### PR TITLE
[strategy] Strategy passport foundation: extended models, IStrategyProvider, 3 seeded strategies, rigor-as-wedge docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,52 @@
+# Archimedes — environment variables template
+#
+# Copy this file to `.env` and fill in the values. The `.env` file is gitignored;
+# never commit it.
+#
+#   cp .env.example .env
+#
+# Required for `docker compose up` to start the local stack. Most defaults work
+# out of the box for local development; only ANTHROPIC_API_KEY and (later) the
+# Arc-specific wallet variables need real values.
+
+# ── PostgreSQL (the local docker compose stack starts a server with these) ──
+POSTGRES_USER=archimedes
+POSTGRES_PASSWORD=archimedes-hackathon-2026
+POSTGRES_DB=archimedes
+DATABASE_URL=postgresql://archimedes:archimedes-hackathon-2026@postgres:5432/archimedes
+
+# ── Redis ──────────────────────────────────────────────────────────────────
+REDIS_URL=redis://redis:6379/0
+
+# ── LLM (required for reasoning-trace generation + arxiv extraction) ───────
+# Get a key at https://console.anthropic.com — free tier works for dev.
+ANTHROPIC_API_KEY=
+
+# ── Arc testnet RPC (per-developer, from `arc-canteen login`) ──────────────
+# Source ~/.arc-canteen/env in your shell to populate $RPC automatically.
+# For docker-compose you can paste the value here, but it's per-user and
+# secret — do NOT commit. Leave blank to skip on-chain features locally.
+RPC=
+
+# ── Wallet (dev only — never put a wallet with real funds here) ────────────
+# Generate a fresh dev wallet for hackathon testing. Cast example:
+#   cast wallet new
+# Then paste the address + private key. NEVER commit a key with real funds.
+DEV_WALLET_ADDRESS=
+DEV_WALLET_PRIVATE_KEY=
+
+# ── Contract addresses (filled in after Chuan's deploy) ────────────────────
+# These will be auto-populated once contracts/ deploys to testnet.
+PRICE_ORACLE_ADDRESS=
+SYNTHETIC_FACTORY_ADDRESS=
+VAULT_FACTORY_ADDRESS=
+REASONING_TRACE_REGISTRY_ADDRESS=
+ASSET_REGISTRY_ADDRESS=
+
+# ── Backend service config ─────────────────────────────────────────────────
+BACKEND_HOST=0.0.0.0
+BACKEND_PORT=8000
+LOG_LEVEL=INFO
+
+# ── CORS (frontend talking to backend in dev) ──────────────────────────────
+CORS_ORIGINS=http://localhost:3000,http://localhost:80

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,20 @@
 # Archimedes — Claude Code Context
 
-> **Status:** Draft proposal, written 2026-05-12 (Day 2). Intent: drop at the root of the
-> `archimedes` repo and read at the start of every Claude Code session. Several sections
-> (license confirmation, demo wow-moment, weekly milestones) reference Chuan's
-> [`docs/design.md`](docs/design.md) — read both together; this file is project context,
-> design.md is the architecture spec.
+> **Status:** Living context doc, written 2026-05-12 (Day 2), revised 2026-05-13 (Day 3)
+> for the marketplace pivot and rigor-as-wedge decision. Intent: drop at the root of the
+> `archimedes` repo and read at the start of every Claude Code session.
+>
+> **Architecture lineage to read together:**
+> - [`docs/design.md`](docs/design.md) — original single-vault architecture
+> - [`docs/specs/ecosystem-design-spec.md`](docs/specs/ecosystem-design-spec.md) — Day-3
+>   two-tier marketplace pivot (synthetic protocol + AMM + VaultFactory + agent-as-a-service)
+> - [`docs/specs/component-interfaces-spec.md`](docs/specs/component-interfaces-spec.md) —
+>   frozen-interface contract for the 5-person concurrent build (Dan owns `IStrategyProvider`)
+> - [`docs/specs/strategy-passport-spec.md`](docs/specs/strategy-passport-spec.md) +
+>   [`docs/specs/selection-bias-corrections-spec.md`](docs/specs/selection-bias-corrections-spec.md)
+>   — the four-primitive admission gate for Tier 1 strategies
+> - [`docs/agora_project_analysis.md`](docs/agora_project_analysis.md) — red-team synthesis
+>   driving the Day-3 rigor-as-wedge framing
 
 ## Project
 
@@ -118,19 +128,26 @@ Refer to [`docs/design.md` § 6](docs/design.md) for the full table. Headline ch
 ## Scope — the headline commitments
 
 Refer to [`docs/mvp-scope-memo.md`](docs/mvp-scope-memo.md) for the full argument. Locked
-decisions:
+decisions (5 of them as of Day 3):
 
-- **Primary RFB:** [RFB 04 — Adaptive Portfolio Manager](https://luma.com/7i50p2r9).
-  Adjacent: RFB 02 (Kelly/+EV math primitive); RFB 06 (strategy leaderboard).
-- **Both on-chain stories:** vault contracts for RWA-token allocation **and** reasoning-
-  trace registry for verifiable provenance. Ambitious; achievable with five committed
-  people.
-- **Curated v1 strategy library:** ship 5–10 hand-curated quant strategies; arxiv ingest
-  pipeline runs as a demo feature on 2–3 papers to show the concept.
+1. **Primary RFB:** [RFB 04 — Adaptive Portfolio Manager](https://luma.com/7i50p2r9).
+   Adjacent: RFB 02 (Kelly/+EV math primitive); RFB 06 (strategy leaderboard).
+2. **Both on-chain stories:** vault contracts for portfolio allocation **and** the
+   ReasoningTraceRegistry for verifiable provenance. Both shipping.
+3. **Curated v1 strategy library:** 5–10 hand-curated quant strategies; arxiv ingest
+   pipeline runs as a demo feature on 2–3 papers, not relied on for live decisions.
+4. **(Day 3) Rigor is the wedge.** Every Tier-1 strategy passes the four selection-bias
+   controls (DSR + PBO + walk-forward OOS + look-ahead audit) before admission to the
+   library. Paper-claim deltas are surfaced honestly, not hidden behind an aggregate
+   score. See [`docs/specs/selection-bias-corrections-spec.md`](docs/specs/selection-bias-corrections-spec.md).
+5. **(Day 3) Two-tier marketplace.** Tier 1 (Archimedes Verified 🏆) = paper-grounded +
+   selection-bias-corrected + full agent autonomy. Tier 2 (Community 👥) = permissionless,
+   opt-in agent features. Per [`docs/specs/ecosystem-design-spec.md`](docs/specs/ecosystem-design-spec.md).
 - **Demo vertical:** portfolio construction + autonomous rebalancing on Arc, NOT trading-
   agent-as-product. Per [`docs/architectural-principles.md`](docs/architectural-principles.md),
-  the wedge is verifiable history + paper-grounded provenance, not predicted performance.
-- **Out of scope:** see [`docs/anti-features.md`](docs/anti-features.md).
+  the wedge is verifiable history + paper-grounded provenance + selection-bias rigor.
+- **Out of scope:** see [`docs/anti-features.md`](docs/anti-features.md), including the
+  Day-3 "pitch-rigor anti-claims" section that constrains the deck framing.
 
 ## Engineering conventions
 
@@ -214,30 +231,41 @@ rules:
 
 ## Architectural primitives we want to get right
 
-These three architectural commitments are load-bearing for the pitch's defensibility. Detail
-in the linked specs; principle here.
+These four architectural commitments are load-bearing for the pitch's defensibility.
+Detail in [`docs/architectural-principles.md`](docs/architectural-principles.md); principle
+here.
 
 ### 1. The strategy passport
 
-Every strategy in the library carries a verifiable record: which paper claims back it, what
-methodology the LLM extracted, what backtest results validated it, what reasoning trace the
-agent left when selecting it for a portfolio. Detail in
-[`docs/specs/strategy-passport-spec.md`](docs/specs/strategy-passport-spec.md) — builds on
-Chuan's `ReasoningTrace` shape in [`docs/design.md` § 4.4](docs/design.md).
+Every Tier-1 strategy in the library carries a verifiable record: which paper backs it,
+the methodology hash, curator wallet signature, backtest results with paper-claim deltas
+surfaced. Detail in [`docs/specs/strategy-passport-spec.md`](docs/specs/strategy-passport-spec.md).
 
 ### 2. On-chain provenance anchoring
 
 Reasoning traces, strategy registrations, and rebalance decisions all get hashed and
-anchored on Arc via a `ReasoningTraceRegistry` contract (Chuan's design). The hash is the
-integrity primitive; off-chain storage holds the full trace; anyone can verify a trace
-matches the on-chain anchor.
+anchored on Arc via the `ReasoningTraceRegistry` contract (interface lives in
+[`contracts/src/interfaces/IReasoningTraceRegistry.sol`](contracts/src/interfaces/IReasoningTraceRegistry.sol);
+implementation is on Chuan's queue). Hash is the integrity primitive; off-chain storage
+holds the full trace; anyone can recompute and verify against the on-chain anchor.
 
 ### 3. Non-custodial vault architecture
 
-User funds NEVER pass through platform custody. The pattern: user deposits USDC to an
-Arc-native `ArchimedesVault` contract; the agent has rebalance authority but not withdraw-
-to-platform authority. See Chuan's smart contract architecture in
-[`docs/design.md` § 5.2](docs/design.md).
+User funds NEVER pass through platform custody. ERC-4626 vault contracts per
+[`docs/specs/ecosystem-design-spec.md` § 3.2](docs/specs/ecosystem-design-spec.md) hold
+user USDC and synth tokens; the agent has rebalance authority only, not withdraw-to-
+platform authority.
+
+### 4. Selection-bias correction (Tier-1 admission gate)
+
+Every Tier-1 strategy passes Deflated Sharpe Ratio (Bailey & López de Prado 2014),
+Probability of Backtest Overfitting (Bailey/Borwein/López de Prado/Zhu 2014), walk-
+forward out-of-sample Sharpe with no in/out-of-sample cliff, and a look-ahead static
+audit before promotion from CANDIDATE → VALIDATED. The numbers and the paper-claim
+deltas are surfaced in the passport — never hidden behind an aggregate score. This is
+the Day-3 addition that distinguishes Archimedes from the 96 other AI-portfolio
+submissions at the last Arc HackMoney. Detail in
+[`docs/specs/selection-bias-corrections-spec.md`](docs/specs/selection-bias-corrections-spec.md).
 
 ## Known risks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Archimedes — Claude Code Context
 
-> **Status:** Living context doc, written 2026-05-12 (Day 2), revised 2026-05-13 (Day 3)
+o> **Status:** Living context doc, written 2026-05-12 (Day 2), revised 2026-05-13 (Day 3)
 > for the marketplace pivot and rigor-as-wedge decision. Intent: drop at the root of the
 > `archimedes` repo and read at the start of every Claude Code session.
 >
@@ -103,8 +103,69 @@ end of Day 3 whether to spread it across the four engineers or hire externally.
 
 Read [`README.md`](README.md) for the full setup walkthrough — Python conda env via
 [`environment.yml`](environment.yml), Node.js frontend, Foundry for contracts, the
-[arc-canteen CLI](https://github.com/the-canteen-dev/ARC-cli) for traction tracking.
+[arc-canteen CLI](https://github.com/the-canteen-dev/ARC-cli) for traction tracking,
+and a Docker-compose-driven local stack that mirrors the production EC2 deployment.
 Platform-specific notes for macOS / Linux / Windows (WSL2 recommended for Marten).
+
+**Spinning up locally is one command** once `.env` is filled in:
+
+```bash
+cp .env.example .env       # fill in ANTHROPIC_API_KEY + RPC at minimum
+docker compose up -d --build
+```
+
+Then <http://localhost> for the UI mockups and <http://localhost:8000/docs> for the
+backend API. See README § "Run Archimedes locally" for the full walkthrough.
+
+## External references — submodules
+
+The repo carries three git submodules at [`submodules/`](submodules/):
+
+- **[`submodules/context-arc/`](submodules/context-arc/)** — Circle's agent-facing
+  developer docs and 5 reference codebases for Arc + Circle. **This is the canonical
+  reference for any Arc/Circle integration question.** Start with
+  [`submodules/context-arc/AGENTS.md`](submodules/context-arc/AGENTS.md) for the
+  task-indexed entry-point table. Highest-leverage files for our build:
+    - `circlefin-skills/use-smart-contract-platform.md` — contract deploy + monitor (Chuan's lane)
+    - `circlefin-skills/bridge-stablecoin.md` — CCTP + Gateway for RWA bridging (Marten's lane)
+    - `circlefin-skills/use-gateway.md` — unified balance + nanopayments
+    - `samples/arc-escrow/` — closest existing pattern to our vault contract
+    - `samples/arc-multichain-wallet/` — CCTP integration patterns
+    - `samples/arc-p2p-payments/` — Paymaster + USDC patterns
+  Refresh upstream with `git submodule update --remote submodules/context-arc` or
+  `arc-canteen context sync` (drops into `~/.arc-canteen/context/`).
+- **[`submodules/KnowledgeBase/`](submodules/KnowledgeBase/)** — Dan's scientific-
+  paper analysis pipeline (PyMuPDF extract + SPECTER2 embeddings + HDBSCAN/BERTopic
+  clustering + REBEL/SciSpacy knowledge graph). For Archimedes, **don't port wholesale**
+  — read it as a reference implementation. The patterns worth lifting for the
+  Tier-1 arxiv extraction pipeline:
+    - `papers_analysis/extract.py` — PyMuPDF caching pattern (~71 files/s)
+    - `papers_analysis/metadata.py` — paper-corpus schema (maps to our `paper_corpus` table)
+    - `papers_analysis/summarize.py` — Ollama-driven methodology synthesis (we'd use Claude)
+- **[`submodules/Linus/`](submodules/Linus/)** — Dan's personal AI orchestration
+  project. Reference only; nothing to port to Archimedes. The
+  [`experiments/archimedes/`](submodules/Linus/experiments/archimedes/) and
+  [`experiments/agora-hackathon/`](submodules/Linus/experiments/agora-hackathon/)
+  directories contain the priors that seeded several of our current `docs/` files.
+
+## arc-canteen CLI — telemetry surface for the 30% Traction weight
+
+Every teammate authenticates individually (`arc-canteen login` → GitHub device flow).
+The CLI is two things in one binary:
+
+1. A **per-developer Arc-testnet RPC proxy.** `arc-canteen rpc <method>` proxies JSON-RPC
+   calls through Canteen's server. The per-user `swrm_*` token in `~/.arc-canteen/env`
+   authenticates. Allowlist: most reads + `eth_sendRawTransaction`. **The full RPC URL
+   is a secret — see README § "Understanding the RPC URL" for the threat model.**
+2. The **traction telemetry surface that the rubric reads.** Every meaningful product
+   ship should be paired with an `arc-canteen update-product` call; every user we
+   onboard or even talk to should be logged via `arc-canteen update-traction`. The
+   30% Traction score is computed from this telemetry, not from anywhere else. **Until
+   we start logging, the rubric reads zero.** See
+   [`docs/judging-rubric-assessment.md`](docs/judging-rubric-assessment.md) for where we
+   currently stand.
+
+`arc-canteen status` shows your current dashboard — what the judges see.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ from archimedes.services.strategy_provider import default_provider
 p = default_provider()
 for s in p.list_strategies():
     print(f'{s.paper_title}  ({s.paper_venue}, {s.paper_year})')
-    print(f'  paper_grounded={s.is_paper_grounded}  profiles={s.risk_constraints.get(\"risk_profiles\")}')
+    print(f'  paper_grounded={s.is_paper_grounded}  profiles={s.risk_profiles}')
 "
 
 # Run a real backtest via the analytics-engine CLI (requires uv in the engine subdir)

--- a/README.md
+++ b/README.md
@@ -39,17 +39,24 @@ on-chain reasoning, settled in pure USDC.** That's the gap.
 | Topic                                          | Document                                                                   |
 | ---------------------------------------------- | -------------------------------------------------------------------------- |
 | 🧭 Project context for Claude Code sessions     | [`CLAUDE.md`](CLAUDE.md)                                                   |
-| 🏗️ System architecture (Chuan)                  | [`docs/design.md`](docs/design.md)                                         |
-| 🎯 MVP scope decisions                          | [`docs/mvp-scope-memo.md`](docs/mvp-scope-memo.md)                         |
+| 🏗️ Original system architecture (Chuan)         | [`docs/design.md`](docs/design.md)                                         |
+| 🌐 Day-3 ecosystem pivot                        | [`docs/specs/ecosystem-design-spec.md`](docs/specs/ecosystem-design-spec.md) |
+| 🤝 Frozen interface contract (5-person concurrent build) | [`docs/specs/component-interfaces-spec.md`](docs/specs/component-interfaces-spec.md) |
+| 🔬 Red-team synthesis + regulatory survey       | [`docs/agora_project_analysis.md`](docs/agora_project_analysis.md)         |
+| 🎯 MVP scope decisions (5 locked)               | [`docs/mvp-scope-memo.md`](docs/mvp-scope-memo.md)                         |
 | 🚫 Anti-features                                | [`docs/anti-features.md`](docs/anti-features.md)                           |
-| 🧱 Architectural principles                     | [`docs/architectural-principles.md`](docs/architectural-principles.md)     |
+| 🧱 Architectural principles (4 primitives)      | [`docs/architectural-principles.md`](docs/architectural-principles.md)     |
 | 📜 Strategy passport spec                       | [`docs/specs/strategy-passport-spec.md`](docs/specs/strategy-passport-spec.md) |
+| 📐 Selection-bias corrections spec (DSR/PBO)    | [`docs/specs/selection-bias-corrections-spec.md`](docs/specs/selection-bias-corrections-spec.md) |
+| 🔒 Commit-reveal trace integrity (v1.5)         | [`docs/specs/commit-reveal-trace-spec.md`](docs/specs/commit-reveal-trace-spec.md) |
 | ⚖️ Backtrader vs vectorbt decision              | [`docs/specs/backtrader-vs-vectorbt-decision-memo.md`](docs/specs/backtrader-vs-vectorbt-decision-memo.md) |
 | 🎓 Q-fin paper corpus seed                      | [`docs/qfin-paper-corpus-seed.md`](docs/qfin-paper-corpus-seed.md)         |
 | 🏛️ Pitch deck + demo script                     | [`docs/demo-script-pitch-deck-outline.md`](docs/demo-script-pitch-deck-outline.md) |
 | 🎨 Claude Design prompts                        | [`docs/claude-design-prompts.md`](docs/claude-design-prompts.md)           |
 | 🔭 RFB alignment                                | [`docs/rfb-alignment.md`](docs/rfb-alignment.md)                           |
 | 🏟️ Competitive landscape                        | [`docs/competitor-landscape.md`](docs/competitor-landscape.md)             |
+| ⚙️ Infra + CI/CD (EC2, Terraform)               | [`docs/infra-setup.md`](docs/infra-setup.md)                              |
+| 📊 Judging-rubric self-assessment               | [`docs/judging-rubric-assessment.md`](docs/judging-rubric-assessment.md)   |
 
 ## Repository Structure
 
@@ -59,23 +66,68 @@ archimedes/
 ├── README.md                        # This file
 ├── LICENSE                          # Unlicense (public domain dedication)
 ├── environment.yml                  # Conda env spec for the Python backend
+├── docker-compose.yml               # Local + production stack: postgres + redis + nginx + backend
+├── .env.example                     # Copy to .env and fill in (gitignored)
+│
 ├── docs/                            # Design + planning + specs
-│   ├── design.md                    # Full architecture (Chuan)
-│   ├── architectural-principles.md
-│   ├── competitor-landscape.md
-│   ├── mvp-scope-memo.md
+│   ├── design.md                    # Original architecture (Chuan)
+│   ├── agora_project_analysis.md    # Red-team + regulatory synthesis
+│   ├── architectural-principles.md  # 4 primitives + Tier 1/2 framing
+│   ├── anti-features.md             # Scope discipline + pitch-rigor anti-claims
+│   ├── mvp-scope-memo.md            # 5 locked scope decisions
 │   ├── rfb-alignment.md
-│   ├── anti-features.md
+│   ├── competitor-landscape.md
 │   ├── qfin-paper-corpus-seed.md
 │   ├── demo-script-pitch-deck-outline.md
 │   ├── claude-design-prompts.md
+│   ├── infra-setup.md               # EC2 + Terraform + CI/CD (Chuan)
 │   └── specs/
+│       ├── ecosystem-design-spec.md           # Day-3 marketplace pivot
+│       ├── component-interfaces-spec.md       # Frozen interfaces for 5-person build
 │       ├── strategy-passport-spec.md
+│       ├── selection-bias-corrections-spec.md # DSR / PBO / OOS / look-ahead audit
+│       ├── commit-reveal-trace-spec.md        # v1.5 trace integrity upgrade
 │       └── backtrader-vs-vectorbt-decision-memo.md
-├── backend/                         # FastAPI + strategy engine (TBD)
-├── frontend/                        # Next.js (TBD)
-├── contracts/                       # Solidity contracts for Arc (TBD)
-└── tests/                           # Test suite (TBD)
+│
+├── backend/                         # FastAPI app (Python 3.12)
+│   ├── Dockerfile
+│   ├── requirements.txt
+│   └── archimedes/
+│       ├── main.py                  # FastAPI entrypoint
+│       ├── api/                     # Routes + Pydantic schemas (Chuan)
+│       ├── models/                  # Shared dataclasses (Strategy, BacktestResult, Trace, Portfolio, …)
+│       ├── interfaces/              # Protocol classes — frozen contracts between teammates
+│       └── services/                # Implementations (strategy_provider lands here)
+│
+├── analytics-engine/                # Backtest engine (Daniel R., uv-managed)
+│   ├── pyproject.toml
+│   ├── src/archimedes_analytics_engine/
+│   │   ├── cli.py                   # `archimedes-analytics-engine` entrypoint
+│   │   ├── engine.py                # backtrader runner + BacktestResult
+│   │   ├── data.py, instruments.py, strategy_loader.py
+│   └── strategies/                  # One .py file per strategy (paper-grounded)
+│       ├── pipeline_buy_hold.py
+│       ├── faber_2007_sma200_timing.py
+│       ├── moreira_muir_2017_volatility_managed.py
+│       └── moskowitz_ooi_pedersen_2012_tsmom.py
+│
+├── contracts/                       # Solidity (Foundry layout)
+│   ├── foundry.toml
+│   ├── src/
+│   │   ├── PriceOracle.sol
+│   │   ├── SyntheticToken.sol
+│   │   ├── SyntheticVault.sol
+│   │   └── interfaces/              # I*.sol — frozen ABIs Marten + Daniel code against
+│   ├── script/Deploy.s.sol
+│   └── test/
+│
+├── ui-mockups/                      # Static HTML mockups (Daniel, served by nginx)
+├── nginx/                           # nginx config for the docker-compose stack
+├── infra/                           # Terraform — EC2 deployment (Chuan)
+└── submodules/                      # External references (git submodules)
+    ├── context-arc/                 # Circle's Arc/Circle docs + 5 sample codebases
+    ├── KnowledgeBase/                # Dan's paper-analysis pipeline (port targets: extract.py, metadata.py)
+    └── Linus/                       # Dan's AI orchestration project (reference only for archimedes)
 ```
 
 ## Tech Stack
@@ -111,12 +163,20 @@ team follows.
 | [Docker Desktop](https://www.docker.com/products/docker-desktop/)                 | Local PostgreSQL + Redis                           |
 | [Foundry](https://book.getfoundry.sh/getting-started/installation)                | Smart contract compilation + testing               |
 
-### 1. Clone the repository
+### 1. Clone the repository (with submodules)
 
 ```bash
-git clone git@github.com:hackagora/archimedes-arcadia.git archimedes
+git clone --recurse-submodules git@github.com:hackagora/archimedes-arcadia.git archimedes
 cd archimedes
 ```
+
+If you already cloned without `--recurse-submodules`, populate them now:
+
+```bash
+git submodule update --init --recursive
+```
+
+The `submodules/` directory carries Circle's [`context-arc`](submodules/context-arc/) (Arc + Circle developer docs and 5 sample codebases) and Dan's [`KnowledgeBase`](submodules/KnowledgeBase/) + [`Linus`](submodules/Linus/) reference projects.
 
 ### 2. Create the Python environment
 
@@ -169,38 +229,277 @@ echo '[ -f ~/.arc-canteen/env ] && . ~/.arc-canteen/env' >> ~/.zshrc
 
 Then `$RPC` is set automatically in new shells.
 
-### 4. Frontend setup
-
-```bash
-cd frontend
-npm install     # or pnpm install
-npm run dev     # → http://localhost:3000
-```
-
-(The `frontend/` directory will land as Daniel's PR.)
-
-### 5. Database (Docker Compose)
-
-```bash
-docker compose up -d postgres redis
-```
-
-(The `docker-compose.yml` will land alongside the backend skeleton.)
-
-### 6. Smart contracts (Foundry)
+### 4. Smart contracts (Foundry)
 
 ```bash
 curl -L https://foundry.paradigm.xyz | bash
 foundryup
 ```
 
-Verify against Arc testnet using your arc-canteen RPC:
+Verify against Arc testnet using your arc-canteen RPC (see § "Run Archimedes locally" below for what `$RPC` means and how to set it):
 
 ```bash
 source ~/.arc-canteen/env       # ensures $RPC is set
 cast block-number --rpc-url $RPC
 cast chain-id --rpc-url $RPC
 ```
+
+The contract sources live in [`contracts/src/`](contracts/src/) and follow the Foundry layout. Build + test:
+
+```bash
+cd contracts
+forge build
+forge test
+```
+
+### 5. Frontend (UI mockups via nginx)
+
+The `frontend/` Next.js app is on Daniel's queue. Until it lands, [`ui-mockups/`](ui-mockups/) carries static HTML mockups for the 8 marketplace screens (marketplace, vault detail, portfolio dashboard, strategy explorer, swap, vault creator, onboarding, reasoning-trace viewer). Docker compose serves them via nginx on port 80 — see § "Run Archimedes locally" below.
+
+---
+
+## Run Archimedes locally
+
+This is the everyone-on-the-team path for spinning up Archimedes on your laptop and poking it. The docker-compose stack reproduces the production EC2 deployment so what you see locally is what runs on the team's shared instance.
+
+### What you get
+
+`docker compose up` brings up four services:
+
+| Service     | Port | URL                              | What it is |
+| ----------- | ---- | -------------------------------- | ---------- |
+| `nginx`     | 80   | <http://localhost>               | Static `ui-mockups/` — Daniel's 8 marketplace screens |
+| `backend`   | 8000 | <http://localhost:8000/docs>     | FastAPI app (Swagger UI auto-generated from `backend/archimedes/api/routes.py`) |
+| `postgres`  | 5432 | `postgres://archimedes@localhost:5432/archimedes` | DB for strategies, backtests, reasoning traces |
+| `redis`     | 6379 | `redis://localhost:6379/0`       | Live regime state cache; agent loop scratch |
+
+### Prerequisites (one-time)
+
+- Docker Desktop running (or any Docker daemon)
+- The conda env from Step 2 above is **only** needed if you also want to run `pytest`, the `analytics-engine` CLI, or any Python tool *outside* the containers. The containers ship their own Python; you don't need conda to use the local stack.
+
+### Step 1 — Create your `.env` file
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` in your editor and fill in the values that are blank. Defaults work for postgres + redis. The variables that need real values for full functionality:
+
+| Variable                     | Where to get it                                       | Required for             |
+| ---------------------------- | ----------------------------------------------------- | ------------------------ |
+| `ANTHROPIC_API_KEY`          | <https://console.anthropic.com>                       | Reasoning-trace + arxiv extraction features |
+| `RPC`                        | `~/.arc-canteen/env` (after `arc-canteen login`)      | On-chain features (contracts, trace anchoring) |
+| `DEV_WALLET_ADDRESS` / `_PRIVATE_KEY` | `cast wallet new` (generate a fresh dev wallet) | Submitting signed transactions to Arc |
+| `*_ADDRESS`                  | Auto-populated after Chuan deploys contracts          | On-chain features        |
+
+You can leave these blank to start — the API will boot, you can hit the routes, and the UI mockups will render. The on-chain features just won't work until you populate them.
+
+### Step 2 — Spin up the stack
+
+```bash
+docker compose up -d --build
+```
+
+On first run this downloads ~150 MB of base images (postgres-alpine, redis-alpine, python:3.12-slim, nginx-alpine) and builds the backend image from `backend/Dockerfile`. Subsequent runs are seconds.
+
+Watch healthchecks succeed:
+
+```bash
+docker compose ps
+# All four services should report "running" and "(healthy)"
+```
+
+### Step 3 — Verify it works
+
+| Open in your browser | Expect to see |
+| -------------------- | ------------- |
+| <http://localhost>           | Daniel's marketplace mockup (`ui-mockups/index.html`) |
+| <http://localhost:8000>      | `{"name":"Archimedes","tagline":"Peer-reviewed AI portfolios, settled on Arc.","docs":"/docs"}` |
+| <http://localhost:8000/health> | `{"status":"ok","service":"archimedes-backend"}` |
+| <http://localhost:8000/docs> | Swagger UI auto-rendered from the API contract |
+
+The Swagger UI right now shows route signatures only — handlers are stubs (the orchestrator wiring is on Chuan's queue per [`docs/specs/component-interfaces-spec.md`](docs/specs/component-interfaces-spec.md)). The contract is real even if the implementations are placeholders.
+
+### Step 4 — Drive the strategy library from the Python side
+
+The analytics-engine and the strategy provider work locally without Docker — handy if you want to debug strategies without rebuilding the container. From a conda-`archimedes` shell:
+
+```bash
+# List the loaded strategy passport metadata (uses the in-process strategy provider)
+python -c "
+import sys; sys.path.insert(0, 'backend')
+from archimedes.services.strategy_provider import default_provider
+p = default_provider()
+for s in p.list_strategies():
+    print(f'{s.paper_title}  ({s.paper_venue}, {s.paper_year})')
+    print(f'  paper_grounded={s.is_paper_grounded}  profiles={s.risk_constraints.get(\"risk_profiles\")}')
+"
+
+# Run a real backtest via the analytics-engine CLI (requires uv in the engine subdir)
+cd analytics-engine
+uv sync
+uv run archimedes-analytics-engine run --operations SPY GOLD TREASURY
+# Artifacts land in analytics-engine/artifacts/
+```
+
+### Step 5 — Tear down
+
+```bash
+docker compose down                 # stop containers; keep data
+docker compose down -v              # stop containers; wipe postgres volume (start fresh)
+docker compose logs -f backend      # tail the backend logs
+docker compose logs postgres        # database logs
+```
+
+### Step 6 — Optional: connect to Arc testnet
+
+If you want to make on-chain calls (read contract state, send signed transactions, etc.) you need `$RPC` set — the per-developer RPC URL from `arc-canteen`. See **§ "Understanding the RPC URL"** below for the full picture.
+
+```bash
+# One-off: source the env then call any Eth RPC method
+source ~/.arc-canteen/env       # exports $RPC
+cast chain-id --rpc-url $RPC    # → 0x4cef52 (Arc testnet)
+cast block-number --rpc-url $RPC
+
+# Or via the canteen CLI directly:
+arc-canteen rpc eth_chainId
+```
+
+To make these calls available inside the docker stack, paste the URL into `.env` as the `RPC` variable and `docker compose up -d` again (compose re-exports the env vars to the backend container).
+
+---
+
+## Understanding the RPC URL
+
+The single most-used piece of infrastructure on this project. Worth a minute of orientation, especially for anyone newer to EVM tooling.
+
+### What you get from `arc-canteen login`
+
+A URL of the form:
+
+```
+https://rpc.testnet.arc-node.thecanteenapp.com/v1/swrm_<64-hex>
+```
+
+Three pieces glued together:
+
+1. **`rpc.testnet.arc-node.thecanteenapp.com`** — Canteen's JSON-RPC **proxy** for the Arc testnet (not the Arc node itself; a proxy in front of it).
+2. **`/v1/`** — proxy API version.
+3. **`swrm_<64-hex>`** — your **per-user server token**, embedded in the URL path. Each teammate has a different one.
+
+### What it does
+
+The Arc chain is EVM-compatible, so it speaks the standard Ethereum JSON-RPC protocol — the same HTTP API that geth, Infura, Alchemy etc. expose. The proxy lets you make calls like:
+
+| Method                       | Effect                                                | Read or write |
+| ---------------------------- | ----------------------------------------------------- | ------------- |
+| `eth_chainId`                | Returns `0x4cef52` for Arc testnet                    | Read          |
+| `eth_blockNumber`            | Current head block number                             | Read          |
+| `eth_getBalance`             | USDC/native-token balance of an address               | Read          |
+| `eth_call`                   | Simulate a contract function call (no state change)   | Read          |
+| `eth_getLogs`                | Query event logs by topic / address / block range     | Read          |
+| `eth_sendRawTransaction`     | Submit a **pre-signed** transaction to be mined       | Write         |
+
+The proxy enforces a **method allowlist** — most reads plus `eth_sendRawTransaction`. Try a non-allowlisted method and you'll see `method '<x>' not allowed by the proxy`.
+
+### What the token is NOT
+
+The `swrm_*` token is **not a wallet private key.** It can't sign transactions on its own. The signing flow is:
+
+1. You hold a wallet private key (a separate 64-hex string, generated by `cast wallet new` or Circle's wallet service — **never** stored in `~/.arc-canteen/`).
+2. Your code uses the private key to sign a transaction *locally* (`web3.py`, `viem`, `forge create`, etc.).
+3. The signed-transaction bytes are submitted to the proxy via `eth_sendRawTransaction`.
+4. The proxy forwards the bytes to an Arc node.
+
+If someone steals your `swrm_` token they can eat your rate limit and attribute spurious activity to your handle; **they can't drain a wallet** with it. Rotate (`arc-canteen rotate-rpc-key`) if leaked, but don't panic.
+
+### How you actually use it
+
+Three patterns. Pick whichever fits the task.
+
+**Pattern A — One-off via the canteen CLI:**
+
+```bash
+arc-canteen rpc eth_chainId
+arc-canteen rpc eth_blockNumber
+arc-canteen rpc eth_getBalance '["0xYOUR_ADDRESS", "latest"]'
+```
+
+**Pattern B — Set `$RPC` once, then any tool that takes `--rpc-url`:**
+
+```bash
+source ~/.arc-canteen/env
+cast block-number --rpc-url $RPC
+cast chain-id --rpc-url $RPC
+forge create --rpc-url $RPC src/MyContract.sol:MyContract
+```
+
+**Pattern C — From Python or TypeScript:**
+
+```python
+import os
+from web3 import Web3
+w3 = Web3(Web3.HTTPProvider(os.environ["RPC"]))
+print(w3.eth.chain_id, w3.eth.block_number)
+```
+
+```typescript
+import { createPublicClient, http } from "viem";
+const client = createPublicClient({ transport: http(process.env.RPC!) });
+const block = await client.getBlockNumber();
+```
+
+### Why the proxy exists
+
+1. **Telemetry attribution.** The proxy logs every call. The 30% Traction score in the hackathon rubric reads from this telemetry. Without per-user auth, Canteen has no way to tell which team's agent generated which on-chain activity.
+2. **Per-team rate limiting.** Without auth, one runaway loop from any team would degrade the testnet for everyone.
+3. **Operational control.** Canteen can spin the testnet up/down and revoke individual tokens without distributing new node URLs.
+
+---
+
+## Reporting traction (the 30% rubric weight)
+
+The `arc-canteen` CLI is not just an RPC proxy — it's also the **traction telemetry surface** that the judging rubric reads. **Until the team starts calling `update-traction` and `update-product` regularly, the rubric scoreboard for Archimedes reads zero, regardless of what's shipped.**
+
+Two commands matter:
+
+```bash
+# Log a product / feature update — call after merging anything meaningful
+arc-canteen update-product "Strategy passport landed: 3 paper-grounded strategies, DSR + PBO spec for Önder"
+
+# Log a traction event — call every time you talk to a potential user or onboard someone
+arc-canteen update-traction "Onboarded user 0x... — deposited 100 USDC into Tier-1 vault, executed first rebalance"
+```
+
+Run `arc-canteen status` to view your current dashboard — what the judges will see when they look at your handle. The judging-rubric assessment in [`docs/judging-rubric-assessment.md`](docs/judging-rubric-assessment.md) breaks down where we currently stand on each of the 4 weighted criteria.
+
+---
+
+## Using the context-arc submodule
+
+[`submodules/context-arc/`](submodules/context-arc/) is Circle's curated bundle of Arc + Circle developer documentation and 5 reference codebases (`arc-commerce`, `arc-escrow`, `arc-fintech`, `arc-multichain-wallet`, `arc-p2p-payments`). It is the single best place to look up anything Arc- or Circle-specific.
+
+Start with [`submodules/context-arc/AGENTS.md`](submodules/context-arc/AGENTS.md) for the entry-point index. Task-routed quick reference:
+
+| Task                                            | Start with                                                            |
+| ----------------------------------------------- | --------------------------------------------------------------------- |
+| Anything Arc-specific (chain config, deploy)    | `circlefin-skills/use-arc.md`                                         |
+| USDC transfers / balances / approvals           | `circlefin-skills/use-usdc.md`                                        |
+| Cross-chain USDC (CCTP, Bridge Kit)             | `circlefin-skills/bridge-stablecoin.md`                               |
+| Custodial / dev-controlled wallets              | `circlefin-skills/use-developer-controlled-wallets.md`                |
+| Unified balance / nanopayments (Gateway)        | `circlefin-skills/use-gateway.md`                                     |
+| Contract templates, deploy, monitor             | `circlefin-skills/use-smart-contract-platform.md`                     |
+| AI agent that holds + spends USDC itself        | `docs/developers.circle.com/agent-stack.md` (Circle CLI + Agent Wallets) |
+| Onchain agent identity / job settlement         | `docs/docs.arc.network/build/agentic-economy.md` (ERC-8004 / ERC-8183) |
+
+Refresh upstream when Circle pushes new docs:
+
+```bash
+git submodule update --remote submodules/context-arc
+```
+
+Or via the canteen CLI: `arc-canteen context sync` (drops a copy into `~/.arc-canteen/context/`).
 
 ---
 

--- a/analytics-engine/strategies/faber_2007_sma200_timing.py
+++ b/analytics-engine/strategies/faber_2007_sma200_timing.py
@@ -1,0 +1,92 @@
+"""SMA200 Tactical Asset Allocation — Faber 2007.
+
+Long the asset when its closing price is above the 200-day simple moving
+average; in cash otherwise. The simplest published trend-filter that
+materially reduces left-tail drawdowns versus buy-and-hold. Single-asset by
+construction — drops cleanly into the analytics-engine per-instrument loop.
+"""
+
+from __future__ import annotations
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "A Quantitative Approach to Tactical Asset Allocation"
+PAPER_AUTHORS: list[str] = ["Mebane T. Faber"]
+PAPER_VENUE = "The Journal of Wealth Management"
+PAPER_YEAR = 2007
+PAPER_DOI = "10.3905/jwm.2007.674809"
+PAPER_CITATION_COUNT = 850  # Snapshot 2026-05; verify via Semantic Scholar.
+
+METHODOLOGY_SUMMARY = (
+    "Hold a long position in the asset when its monthly close is above the "
+    "10-month simple moving average; otherwise hold cash. A simple binary "
+    "trend filter intended to clip drawdowns while preserving most upside."
+)
+
+METHODOLOGY_TEXT = (
+    "Faber's quantitative tactical-asset-allocation model evaluates each "
+    "asset's monthly close against its 10-month simple moving average. If "
+    "the close is above the SMA, the position is fully invested; if below, "
+    "the position is moved to cash (T-bills in the paper). The model is "
+    "applied across five asset classes (US equity, foreign equity, bonds, "
+    "commodities, REITs) in an equal-weighted portfolio, rebalanced "
+    "monthly.\n\n"
+    "v1 Archimedes adaptation: 10 trading months ≈ 210 daily bars; we use "
+    "a 200-day SMA for tractability on daily data. Single-asset "
+    "implementation — portfolio-level weighting across operations is the "
+    "responsibility of upstream allocation logic. Cash leg returns are "
+    "modeled as zero (conservative); the paper assumes 90-day T-bill "
+    "yield."
+)
+
+PAPER_CLAIMED_SHARPE = 0.78
+PAPER_CLAIMED_CAGR = 0.1127
+PAPER_CLAIMED_MAX_DD = 0.095  # For the 5-asset combined portfolio; single-asset is worse.
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["conservative", "moderate"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "Best-in-class drawdown control for a binary trend filter. Mandatory "
+    "inclusion in any tactical-allocation library; the 200-day SMA cross "
+    "is also the regime-detection signal Önder's classifier uses, which "
+    "lets us anchor the strategy and regime narrative to the same line in "
+    "the chart."
+)
+EXTRACTION_LLM: str | None = None
+
+
+class FaberSMA200(bt.Strategy):
+    """Long when close > 200d SMA; flat otherwise."""
+
+    params = (
+        ("sma_period", 200),
+        ("exposure_fraction", 0.99),
+    )
+
+    def __init__(self) -> None:
+        self.sma = bt.indicators.SimpleMovingAverage(
+            self.data.close, period=int(self.params.sma_period)
+        )
+
+    def next(self) -> None:
+        if len(self) <= int(self.params.sma_period):
+            return
+
+        price = float(self.data.close[0])
+        sma_value = float(self.sma[0])
+
+        if price > sma_value:
+            if not self.position:
+                account_value = float(self.broker.getvalue())
+                target_notional = account_value * float(self.params.exposure_fraction)
+                size = int(target_notional // price)
+                if size > 0:
+                    self.buy(size=size)
+        else:
+            if self.position:
+                self.close()

--- a/analytics-engine/strategies/moreira_muir_2017_volatility_managed.py
+++ b/analytics-engine/strategies/moreira_muir_2017_volatility_managed.py
@@ -1,0 +1,116 @@
+"""Volatility-Managed Portfolios — Moreira & Muir 2017.
+
+Scale exposure inversely to recent realized volatility, holding the
+underlying asset always-long. The conservative end of the seed library:
+no on/off binary, just a position size that contracts during turbulent
+regimes and expands during calm ones.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Volatility-Managed Portfolios"
+PAPER_AUTHORS: list[str] = ["Alan Moreira", "Tyler Muir"]
+PAPER_VENUE = "The Journal of Finance"
+PAPER_YEAR = 2017
+PAPER_DOI = "10.1111/jofi.12513"
+PAPER_CITATION_COUNT = 1100  # Snapshot 2026-05; verify via Semantic Scholar.
+
+METHODOLOGY_SUMMARY = (
+    "Stay long the asset; scale exposure inversely to a rolling estimate "
+    "of realized volatility so the portfolio targets a fixed annualized "
+    "volatility level. Reduces drawdowns and improves Sharpe versus a "
+    "constant fully-invested baseline."
+)
+
+METHODOLOGY_TEXT = (
+    "Moreira and Muir construct managed-volatility portfolios by scaling "
+    "the position in a risky asset by c / sigma^2_{t-1}, where sigma_{t-1} "
+    "is a rolling realized-volatility estimate (the paper uses one-month "
+    "realized variance from daily returns) and c is a normalizing constant "
+    "chosen to match the unconditional volatility of the original "
+    "portfolio. The paper applies this to the market factor, FF3, FF5, "
+    "momentum, and value factors over 1926-2015 and reports unconditional "
+    "Sharpe improvements of roughly 50% across factors.\n\n"
+    "v1 Archimedes adaptation: 22-day rolling realized volatility from "
+    "daily simple returns; exposure_t = min(target_vol_annual / "
+    "realized_vol_annual_t, 1.0); rebalance to target each bar. Capping "
+    "at 1.0 (no leverage) preserves the spot/RWA constraint in "
+    "anti-features.md. The leverage cap means we capture the downside "
+    "scaling but only partially the upside boost from levering up during "
+    "low-vol regimes; expect realized Sharpe to land between buy-hold and "
+    "the paper's fully-leveraged version."
+)
+
+PAPER_CLAIMED_SHARPE = 0.60  # Approximate, market-factor 1926-2015 leveraged version.
+PAPER_CLAIMED_CAGR = 0.09
+PAPER_CLAIMED_MAX_DD = 0.30
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "inverse_vol"
+REBALANCE_FREQUENCY = "daily"
+RISK_PROFILES: list[str] = ["conservative", "moderate"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "Conservative sleeve. Always-on long exposure with vol-targeting "
+    "produces a smoother equity curve that fits the conservative risk "
+    "profile's USYC-heavy bias. Useful regime-agnostic counterweight to "
+    "the binary on/off Faber filter."
+)
+EXTRACTION_LLM: str | None = None
+
+_ANNUALIZATION = 252
+
+
+class VolatilityManagedLong(bt.Strategy):
+    """Always-long with exposure scaled inversely to realized volatility."""
+
+    params = (
+        ("vol_window", 22),
+        ("target_vol_annual", 0.15),
+    )
+
+    def _realized_vol_annual(self) -> float | None:
+        window = int(self.params.vol_window)
+        if len(self) <= window + 1:
+            return None
+        returns: list[float] = []
+        for i in range(window):
+            prev = float(self.data.close[-i - 1])
+            curr = float(self.data.close[-i])
+            if prev > 0:
+                returns.append((curr / prev) - 1.0)
+        if len(returns) < 2:
+            return None
+        mean = sum(returns) / len(returns)
+        var = sum((r - mean) ** 2 for r in returns) / (len(returns) - 1)
+        return math.sqrt(var) * math.sqrt(_ANNUALIZATION)
+
+    def next(self) -> None:
+        realized_vol = self._realized_vol_annual()
+        if realized_vol is None or realized_vol <= 0:
+            return
+
+        target_vol = float(self.params.target_vol_annual)
+        exposure_fraction = min(target_vol / realized_vol, 1.0)
+
+        price = float(self.data.close[0])
+        if price <= 0:
+            return
+
+        account_value = float(self.broker.getvalue())
+        target_notional = account_value * exposure_fraction
+        target_size = int(target_notional // price)
+
+        if target_size <= 0:
+            if self.position:
+                self.close()
+            return
+
+        if self.position.size != target_size:
+            self.order_target_size(target=target_size)

--- a/analytics-engine/strategies/moskowitz_ooi_pedersen_2012_tsmom.py
+++ b/analytics-engine/strategies/moskowitz_ooi_pedersen_2012_tsmom.py
@@ -1,0 +1,98 @@
+"""Time Series Momentum (TSMOM) — Moskowitz, Ooi, Pedersen 2012.
+
+Single-asset adaptation: long if the trailing 12-month return is positive,
+flat otherwise. The paper's diversified portfolio combines long *and* short
+sleeves across equities, bonds, commodities, and currencies; v1 Archimedes
+is spot/RWA only (no short selling — see `docs/anti-features.md`) so this
+implementation collapses the short leg to flat. Document the divergence in
+the methodology block so the paper-claimed-vs-actual delta is honest.
+"""
+
+from __future__ import annotations
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Time Series Momentum"
+PAPER_AUTHORS: list[str] = [
+    "Tobias J. Moskowitz",
+    "Yao Hua Ooi",
+    "Lasse Heje Pedersen",
+]
+PAPER_VENUE = "Journal of Financial Economics"
+PAPER_YEAR = 2012
+PAPER_DOI = "10.1016/j.jfineco.2011.11.003"
+PAPER_CITATION_COUNT = 3200  # Snapshot 2026-05; verify via Semantic Scholar.
+
+METHODOLOGY_SUMMARY = (
+    "Trend-following: for each asset, compute the trailing 12-month total "
+    "return; hold a long position when positive, flat when negative; "
+    "rebalance monthly with inverse-volatility position sizing."
+)
+
+METHODOLOGY_TEXT = (
+    "For a given asset, on each rebalance date compute the trailing 12-month "
+    "total return r_{t-12,t}. The paper's diversified portfolio takes a long "
+    "position when r > 0 and a short position when r < 0, scaling each "
+    "position to a 40% ex-ante annualized volatility target using a 60-day "
+    "exponential weighted standard deviation estimate. The portfolio is "
+    "rebalanced monthly across 24 commodity futures, 12 cross-currency "
+    "forwards, 9 equity index futures, and 13 government bond futures.\n\n"
+    "v1 Archimedes adaptation (single-asset, long-only): on each daily bar "
+    "after 252 trading days of history, evaluate the trailing 252-day "
+    "return; if positive, target a long position sized to the full account "
+    "value; if non-positive, close any open position. This loses the long-"
+    "short structure that produces the paper's headline Sharpe of 1.43; "
+    "single-asset TSMOM is documented to deliver per-asset Sharpes in the "
+    "0.4-0.9 range. The backtest result is expected to underperform "
+    "PAPER_CLAIMED_SHARPE substantially; this is by design — the passport "
+    "surfaces the gap so users can audit the divergence."
+)
+
+PAPER_CLAIMED_SHARPE = 1.43  # Diversified 4-asset-class portfolio, 1985-2009.
+PAPER_CLAIMED_CAGR = 0.178
+PAPER_CLAIMED_MAX_DD = 0.14
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"  # Per-asset; portfolio-level weighting is upstream.
+REBALANCE_FREQUENCY = "daily"  # Engine evaluates on each bar; logical horizon is monthly.
+RISK_PROFILES: list[str] = ["moderate", "aggressive"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "Classic per-asset trend-following primitive. Highest single-asset "
+    "Sharpe in our seed set; pairs well with Faber 2007 as a regime-aware "
+    "moderate sleeve. Long-only adaptation introduces a deliberate "
+    "paper-claim gap which is the strategy passport's flagship example."
+)
+EXTRACTION_LLM: str | None = None  # Hand-curated.
+
+
+class TimeSeriesMomentum(bt.Strategy):
+    """Single-asset long-only TSMOM with 12-month lookback."""
+
+    params = (
+        ("lookback_bars", 252),
+        ("exposure_fraction", 0.99),
+    )
+
+    def next(self) -> None:
+        lookback = int(self.params.lookback_bars)
+        if len(self) <= lookback:
+            return
+
+        past_close = float(self.data.close[-lookback])
+        if past_close <= 0:
+            return
+
+        trailing_return = (float(self.data.close[0]) / past_close) - 1.0
+
+        if trailing_return > 0:
+            account_value = float(self.broker.getvalue())
+            target_notional = account_value * float(self.params.exposure_fraction)
+            target_size = int(target_notional // float(self.data.close[0]))
+            if target_size > 0 and self.position.size != target_size:
+                self.order_target_size(target=target_size)
+        else:
+            if self.position:
+                self.close()

--- a/backend/archimedes/models/backtest.py
+++ b/backend/archimedes/models/backtest.py
@@ -144,7 +144,8 @@ class BacktestResult:
 
         Criteria:
           - Base validation passes
-          - DSR populated and p-value > 0.95 (Sharpe credibly > 0)
+          - DSR populated (value, p-value, AND num_trials_in_selection)
+            and p-value > 0.95 (Sharpe credibly > 0)
           - PBO populated and < 0.5 (not expected to underperform median OOS)
           - OOS Sharpe populated and within 50% of in-sample Sharpe (no cliff)
           - Look-ahead audit passed
@@ -153,6 +154,10 @@ class BacktestResult:
         if not self.passes_validation:
             return False
         if self.deflated_sharpe_ratio is None or self.dsr_p_value is None:
+            return False
+        if self.num_trials_in_selection is None:
+            # DSR is meaningless without recording the N used; the spec
+            # requires it for reproducibility.
             return False
         if self.dsr_p_value < 0.95:
             return False

--- a/backend/archimedes/models/backtest.py
+++ b/backend/archimedes/models/backtest.py
@@ -1,4 +1,18 @@
-"""Backtest result data models."""
+"""Backtest result data models.
+
+Carries the selection-bias corrections (Deflated Sharpe Ratio, Probability of
+Backtest Overfitting, OOS Sharpe split) that make a paper-grounded strategy
+credibly distinguishable from a curve-fit artifact. The fields here are the
+contract Önder's `IBacktestEvaluator` populates and the strategy passport
+surfaces in the UI.
+
+References:
+- Bailey & López de Prado (2014). The Deflated Sharpe Ratio. JPM 40(5).
+- Bailey, Borwein, López de Prado, Zhu (2014). The Probability of Backtest
+  Overfitting (PBO / CSCV framework).
+- McLean & Pontiff (2016). Does Academic Research Destroy Stock Return
+  Predictability? JoF 71(1).
+"""
 
 from __future__ import annotations
 
@@ -14,6 +28,8 @@ class BacktestResult:
     Consumed by: Chuan (strategy DB, portfolio agent ranking),
                  Dan (validation gate — compare to paper claims),
                  Daniel (performance charts in UI)
+
+    Selection-bias contract: docs/specs/selection-bias-corrections-spec.md
     """
 
     strategy_id: str  # FK to Strategy.id
@@ -43,8 +59,37 @@ class BacktestResult:
     backtest_start: date | None = None
     backtest_end: date | None = None
 
-    # ── Paper comparison ────────────────────────────────────
+    # ── Paper comparison (claim vs. our re-run) ─────────────
     paper_claimed_sharpe: float | None = None
+    paper_claimed_cagr: float | None = None
+    paper_claimed_max_dd: float | None = None  # As a positive fraction
+
+    # ── Selection-bias controls (rigor gate) ────────────────
+    # Deflated Sharpe Ratio — Sharpe adjusted for non-normality + multiple testing.
+    # Bailey & López de Prado (2014). DSR_p_value is the probability that the
+    # true Sharpe is greater than zero given the observed return distribution
+    # and the number of trials considered in selection.
+    deflated_sharpe_ratio: float | None = None
+    dsr_p_value: float | None = None  # 0-1, higher = more confident Sharpe > 0
+    num_trials_in_selection: int | None = None  # N for DSR multiple-testing correction
+
+    # Probability of Backtest Overfitting — Bailey/Borwein/López de Prado/Zhu
+    # (2014). Computed via Combinatorially Symmetric Cross-Validation (CSCV).
+    # Lower is better; PBO > 0.5 means the in-sample-optimal strategy is
+    # expected to underperform the median out-of-sample.
+    pbo_score: float | None = None  # 0-1
+
+    # Out-of-sample slice held separately from in-sample for honesty.
+    out_of_sample_sharpe: float | None = None
+    walk_forward_train_fraction: float = 0.70  # Train/test split used
+
+    # Static analysis confirmed no look-ahead in strategy code or data slicing.
+    look_ahead_audit_passed: bool = False
+
+    # ── Engine + reproducibility ────────────────────────────
+    backtest_engine: str | None = None  # 'backtrader' | 'vectorbt' | 'custom-numpy'
+    backtest_code_hash: str | None = None  # SHA-256 of executable backtest code
+    transaction_cost_bps: int = 10  # Round-trip cost assumed; spec default
 
     @property
     def sharpe_vs_paper(self) -> float | None:
@@ -57,11 +102,71 @@ class BacktestResult:
         return None
 
     @property
+    def cagr_vs_paper(self) -> float | None:
+        """Ratio of backtest CAGR to paper's claimed CAGR."""
+        if self.paper_claimed_cagr and self.paper_claimed_cagr > 0:
+            return self.cagr / self.paper_claimed_cagr
+        return None
+
+    @property
+    def sharpe_decay_estimate(self) -> float | None:
+        """Naive McLean-Pontiff (2016) post-publication decay correction.
+
+        Published cross-sectional predictors lost ~58% of in-sample Sharpe
+        post-publication on average. If a paper is published and we have a
+        claimed Sharpe, this returns the decayed expectation against which to
+        sanity-check our backtest.
+        """
+        if self.paper_claimed_sharpe is None:
+            return None
+        return self.paper_claimed_sharpe * 0.42
+
+    @property
     def passes_validation(self) -> bool:
-        """Quick check against design.md § 4.2 validation criteria."""
+        """Quick check against design.md § 4.2 validation criteria.
+
+        Preserves the original behavior for backward compatibility with
+        callers that only look at raw Sharpe/DD/CAGR/trade count.
+        """
         return (
             self.sharpe_ratio > 0.5
             and self.max_drawdown < 0.5
             and self.cagr < 10.0  # Reject >1000% annual as unrealistic
             and self.total_trades >= 10
         )
+
+    @property
+    def passes_rigor_gate(self) -> bool:
+        """Stricter check: selection-bias corrections must be present and pass.
+
+        Required for promotion from CANDIDATE → VALIDATED. Tier-1 vaults only
+        admit strategies that pass this gate.
+
+        Criteria:
+          - Base validation passes
+          - DSR populated and p-value > 0.95 (Sharpe credibly > 0)
+          - PBO populated and < 0.5 (not expected to underperform median OOS)
+          - OOS Sharpe populated and within 50% of in-sample Sharpe (no cliff)
+          - Look-ahead audit passed
+          - sharpe_vs_paper >= 0.5 if paper_claimed_sharpe is set
+        """
+        if not self.passes_validation:
+            return False
+        if self.deflated_sharpe_ratio is None or self.dsr_p_value is None:
+            return False
+        if self.dsr_p_value < 0.95:
+            return False
+        if self.pbo_score is None or self.pbo_score >= 0.5:
+            return False
+        if not self.look_ahead_audit_passed:
+            return False
+        if self.out_of_sample_sharpe is None:
+            return False
+        if self.sharpe_ratio > 0 and (
+            self.out_of_sample_sharpe / self.sharpe_ratio < 0.5
+        ):
+            return False
+        vs_paper = self.sharpe_vs_paper
+        if vs_paper is not None and vs_paper < 0.5:
+            return False
+        return True

--- a/backend/archimedes/models/strategy.py
+++ b/backend/archimedes/models/strategy.py
@@ -1,7 +1,14 @@
-"""Strategy data models — shared across all components."""
+"""Strategy data models — shared across all components.
+
+Passport-aware: every strategy carries enough provenance metadata to be
+independently auditable per `docs/specs/strategy-passport-spec.md`. Selection-
+bias controls (DSR, PBO, OOS sharpe split) live on `BacktestResult` rather
+than here — see `models/backtest.py`.
+"""
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -51,10 +58,12 @@ class Strategy:
     Produced by: Dan (curated library + LLM extraction)
     Consumed by: Önder (backtest evaluation, portfolio construction),
                  Chuan (strategy DB, API), Daniel (strategy explorer UI)
+
+    Passport reference: docs/specs/strategy-passport-spec.md
     """
 
     id: str  # Deterministic hash of paper + methodology
-    paper_arxiv_id: str  # e.g. "2509.11420"
+    paper_arxiv_id: str  # e.g. "2509.11420" — may be empty for non-arxiv papers
     paper_title: str
     paper_authors: list[str] = field(default_factory=list)
     methodology_summary: str = ""  # 2-3 sentence plain English
@@ -70,6 +79,49 @@ class Strategy:
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
+    # ── Paper provenance (passport fields) ──────────────────
+    paper_venue: str | None = None  # Journal, conference, or "arxiv only"
+    paper_year: int | None = None
+    paper_doi: str | None = None
+    paper_citation_count: int | None = None  # Snapshot at curation time
+
+    # ── Methodology integrity ───────────────────────────────
+    methodology_hash: str | None = None  # SHA-256 of canonical methodology_summary
+    methodology_text: str | None = None  # Full extracted methodology (longer than summary)
+    extraction_llm: str | None = None  # e.g. "claude-opus-4-7" — null if hand-curated
+    extraction_prompt_hash: str | None = None  # SHA-256 of the extraction prompt
+
+    # ── Curation trail (v1: Dan is the sole curator) ────────
+    curator_wallet: str | None = None  # Wallet of human curator who validated
+    curator_validation_at: datetime | None = None
+    curator_note: str | None = None  # Per-paper rationale
+
+    # ── Backtest engine binding ─────────────────────────────
+    strategy_code_path: str | None = None  # Path to the analytics-engine strategy file
+    strategy_code_hash: str | None = None  # SHA-256 of the strategy file contents
+
+    # ── On-chain anchor ─────────────────────────────────────
+    on_chain_registration_tx: str | None = None  # StrategyRegistry contract tx hash
+
     @property
     def is_active(self) -> bool:
         return self.status in (StrategyStatus.VALIDATED, StrategyStatus.LIVE)
+
+    @property
+    def is_paper_grounded(self) -> bool:
+        """True iff the strategy traces back to a real published paper.
+
+        Tier-1 vaults require paper-grounded strategies per
+        architectural-principles.md. Tier-2 vaults do not.
+        """
+        return bool(self.paper_arxiv_id or self.paper_doi)
+
+    def compute_methodology_hash(self) -> str:
+        """Compute deterministic SHA-256 hash of the methodology.
+
+        Hashes `methodology_text` if present, else `methodology_summary`.
+        UTF-8 with stripped leading/trailing whitespace; the canonical form
+        anyone can recompute from the stored content.
+        """
+        source = (self.methodology_text or self.methodology_summary).strip()
+        return hashlib.sha256(source.encode("utf-8")).hexdigest()

--- a/backend/archimedes/models/strategy.py
+++ b/backend/archimedes/models/strategy.py
@@ -74,6 +74,9 @@ class Strategy:
     risk_constraints: dict[str, float] = field(
         default_factory=dict
     )  # e.g. {"max_drawdown": 0.20, "max_leverage": 1.0}
+    risk_profiles: list[str] = field(
+        default_factory=list
+    )  # Risk-tier tags: "conservative" | "moderate" | "aggressive" | "hyper_risky"
     status: StrategyStatus = StrategyStatus.CANDIDATE
     extraction_reasoning: str = ""  # Full LLM reasoning for extraction
     created_at: datetime | None = None
@@ -86,7 +89,9 @@ class Strategy:
     paper_citation_count: int | None = None  # Snapshot at curation time
 
     # ── Methodology integrity ───────────────────────────────
-    methodology_hash: str | None = None  # SHA-256 of canonical methodology_summary
+    # SHA-256 over the canonical methodology — methodology_text when populated,
+    # otherwise methodology_summary. See compute_methodology_hash() for the rule.
+    methodology_hash: str | None = None
     methodology_text: str | None = None  # Full extracted methodology (longer than summary)
     extraction_llm: str | None = None  # e.g. "claude-opus-4-7" — null if hand-curated
     extraction_prompt_hash: str | None = None  # SHA-256 of the extraction prompt

--- a/backend/archimedes/services/__init__.py
+++ b/backend/archimedes/services/__init__.py
@@ -1,0 +1,6 @@
+"""Service implementations of the interface contracts in `interfaces/`.
+
+Each module here is owned by a single teammate and implements one or more
+Protocols from `archimedes.interfaces.*`. Wired together by Chuan's agent
+orchestrator.
+"""

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -163,6 +163,11 @@ def _to_strategy(path: Path, metadata: dict[str, Any], code_hash: str) -> Strate
     if paper_year is not None:
         paper_year = int(paper_year)
 
+    # Use file mtime so timestamps reflect the strategy file's curation
+    # time rather than process start time — otherwise every restart would
+    # bump created_at/updated_at for unchanged strategies.
+    file_mtime = datetime.fromtimestamp(path.stat().st_mtime)
+
     return Strategy(
         id=_strategy_id(metadata, code_hash),
         paper_arxiv_id=str(metadata.get("PAPER_ARXIV_ID") or ""),
@@ -174,11 +179,12 @@ def _to_strategy(path: Path, metadata: dict[str, Any], code_hash: str) -> Strate
         signals=[],
         position_sizing=position_sizing,
         rebalance_frequency=rebalance_frequency,
-        risk_constraints=dict(metadata.get("RISK_CONSTRAINTS") or {}) | {"risk_profiles": risk_profiles},
+        risk_constraints=dict(metadata.get("RISK_CONSTRAINTS") or {}),
+        risk_profiles=list(risk_profiles),
         status=StrategyStatus.CANDIDATE,
         extraction_reasoning="",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=file_mtime,
+        updated_at=file_mtime,
         paper_venue=metadata.get("PAPER_VENUE"),
         paper_year=paper_year,
         paper_doi=metadata.get("PAPER_DOI"),
@@ -256,11 +262,7 @@ class LocalStrategyProvider:
 
     def get_strategies_for_risk_profile(self, risk_profile_name: str) -> list[Strategy]:
         wanted = risk_profile_name.lower()
-        return [
-            s
-            for s in self._strategies.values()
-            if wanted in (s.risk_constraints.get("risk_profiles") or [])
-        ]
+        return [s for s in self._strategies.values() if wanted in s.risk_profiles]
 
     def extract_from_paper(self, arxiv_id: str) -> Strategy | None:
         """Demo-feature stub. Real implementation arrives in the arxiv pipeline.

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -1,0 +1,286 @@
+"""Strategy provider service — Dan's implementation of `IStrategyProvider`.
+
+Source of truth is the analytics-engine strategy directory
+(`analytics-engine/strategies/*.py`). Each file is a self-describing
+paper-grounded strategy: a `bt.Strategy` subclass plus module-level
+constants that encode the passport metadata.
+
+The provider does not import backtrader. It reads the metadata via AST so
+the backend can list and serve strategies without pulling the backtest
+engine into the API process.
+
+References:
+- `docs/specs/component-interfaces-spec.md` — Dan owns IStrategyProvider
+- `docs/specs/strategy-passport-spec.md` — passport schema
+- `analytics-engine/src/archimedes_analytics_engine/strategy_loader.py` —
+  parallel runtime loader used by the backtest engine
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from archimedes.models.strategy import (
+    PositionSizing,
+    RebalanceFrequency,
+    Strategy,
+    StrategyStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Constants the analytics-engine strategy_loader recognizes plus passport
+# extensions specific to the provider. Anything not present is treated as
+# missing rather than an error — strategies remain valid with partial
+# metadata.
+_METADATA_KEYS: tuple[str, ...] = (
+    "PAPER_ARXIV_ID",
+    "PAPER_TITLE",
+    "PAPER_AUTHORS",
+    "PAPER_VENUE",
+    "PAPER_YEAR",
+    "PAPER_DOI",
+    "PAPER_CITATION_COUNT",
+    "METHODOLOGY_SUMMARY",
+    "METHODOLOGY_TEXT",
+    "PAPER_CLAIMED_SHARPE",
+    "PAPER_CLAIMED_CAGR",
+    "PAPER_CLAIMED_MAX_DD",
+    "ASSET_UNIVERSE",
+    "POSITION_SIZING",
+    "REBALANCE_FREQUENCY",
+    "RISK_PROFILES",
+    "RISK_CONSTRAINTS",
+    "CURATOR_WALLET",
+    "CURATOR_NOTE",
+    "EXTRACTION_LLM",
+)
+
+
+# Keyword heuristic for risk profile inference when a strategy file does
+# not declare RISK_PROFILES explicitly. Lowercased substring match.
+_RISK_PROFILE_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "conservative": ("mean reversion", "low-vol", "bond", "defensive", "yield"),
+    "moderate": ("trend", "balanced", "factor", "value", "carry"),
+    "aggressive": ("momentum", "high-conviction", "concentrated", "growth"),
+    "hyper_risky": ("leveraged", "leverage", "sector concentration", "volatility short"),
+}
+
+
+def _read_module_constants(path: Path) -> dict[str, Any]:
+    """Parse a Python file and return its module-level constant assignments.
+
+    Uses `ast.literal_eval` on right-hand sides so backtrader (or any other
+    import) is never executed. Only literals of the standard JSON-ish shape
+    are recoverable; anything more exotic is silently skipped.
+    """
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    out: dict[str, Any] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets = [t for t in node.targets if isinstance(t, ast.Name)]
+            value_node = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is None:
+                continue  # bare annotation, no value to read
+            targets = [node.target]
+            value_node = node.value
+        else:
+            continue
+        for target in targets:
+            if target.id not in _METADATA_KEYS:
+                continue
+            try:
+                out[target.id] = ast.literal_eval(value_node)
+            except (ValueError, SyntaxError) as exc:
+                logger.debug("skip non-literal %s in %s: %s", target.id, path, exc)
+    return out
+
+
+def _hash_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_methodology(metadata: dict[str, Any]) -> str:
+    text = metadata.get("METHODOLOGY_TEXT") or metadata.get("METHODOLOGY_SUMMARY") or ""
+    return str(text).strip()
+
+
+def _methodology_hash(metadata: dict[str, Any]) -> str:
+    canonical = _canonical_methodology(metadata)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _strategy_id(metadata: dict[str, Any], code_hash: str) -> str:
+    """Deterministic ID: hash of arxiv_id (or DOI, or title) + methodology hash."""
+    paper_key = (
+        metadata.get("PAPER_ARXIV_ID")
+        or metadata.get("PAPER_DOI")
+        or metadata.get("PAPER_TITLE")
+        or code_hash
+    )
+    payload = f"{paper_key}|{_methodology_hash(metadata)}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:32]
+
+
+def _infer_risk_profiles(methodology_summary: str) -> list[str]:
+    text = methodology_summary.lower()
+    matched = [
+        profile
+        for profile, keywords in _RISK_PROFILE_KEYWORDS.items()
+        if any(kw in text for kw in keywords)
+    ]
+    return matched or ["moderate"]
+
+
+def _to_strategy(path: Path, metadata: dict[str, Any], code_hash: str) -> Strategy:
+    methodology_summary = str(metadata.get("METHODOLOGY_SUMMARY") or metadata.get("METHODOLOGY_TEXT") or "")
+    methodology_text = metadata.get("METHODOLOGY_TEXT")
+    risk_profiles = metadata.get("RISK_PROFILES") or _infer_risk_profiles(methodology_summary)
+
+    position_sizing_raw = str(metadata.get("POSITION_SIZING") or "equal_weight").lower()
+    try:
+        position_sizing = PositionSizing(position_sizing_raw)
+    except ValueError:
+        logger.warning("unknown POSITION_SIZING=%s in %s, defaulting", position_sizing_raw, path)
+        position_sizing = PositionSizing.EQUAL_WEIGHT
+
+    rebalance_raw = str(metadata.get("REBALANCE_FREQUENCY") or "weekly").lower()
+    try:
+        rebalance_frequency = RebalanceFrequency(rebalance_raw)
+    except ValueError:
+        logger.warning("unknown REBALANCE_FREQUENCY=%s in %s, defaulting", rebalance_raw, path)
+        rebalance_frequency = RebalanceFrequency.WEEKLY
+
+    paper_year = metadata.get("PAPER_YEAR")
+    if paper_year is not None:
+        paper_year = int(paper_year)
+
+    return Strategy(
+        id=_strategy_id(metadata, code_hash),
+        paper_arxiv_id=str(metadata.get("PAPER_ARXIV_ID") or ""),
+        paper_title=str(metadata.get("PAPER_TITLE") or path.stem),
+        paper_authors=list(metadata.get("PAPER_AUTHORS") or []),
+        methodology_summary=methodology_summary,
+        methodology_text=methodology_text if isinstance(methodology_text, str) else None,
+        asset_universe=list(metadata.get("ASSET_UNIVERSE") or []),
+        signals=[],
+        position_sizing=position_sizing,
+        rebalance_frequency=rebalance_frequency,
+        risk_constraints=dict(metadata.get("RISK_CONSTRAINTS") or {}) | {"risk_profiles": risk_profiles},
+        status=StrategyStatus.CANDIDATE,
+        extraction_reasoning="",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        paper_venue=metadata.get("PAPER_VENUE"),
+        paper_year=paper_year,
+        paper_doi=metadata.get("PAPER_DOI"),
+        paper_citation_count=metadata.get("PAPER_CITATION_COUNT"),
+        methodology_hash=_methodology_hash(metadata),
+        extraction_llm=metadata.get("EXTRACTION_LLM"),  # None for hand-curated
+        extraction_prompt_hash=None,
+        curator_wallet=metadata.get("CURATOR_WALLET"),
+        curator_validation_at=None,
+        curator_note=metadata.get("CURATOR_NOTE"),
+        strategy_code_path=str(path),
+        strategy_code_hash=code_hash,
+        on_chain_registration_tx=None,
+    )
+
+
+class LocalStrategyProvider:
+    """File-system-backed `IStrategyProvider`.
+
+    Owner: Dan. Wired into the agent orchestrator via dependency injection
+    in `archimedes.api.routes`.
+
+    Reload semantics: strategies are loaded eagerly on construction and
+    cached in-memory. Call `refresh()` to re-scan the directory after a
+    new strategy file lands.
+    """
+
+    def __init__(self, strategies_dir: Path) -> None:
+        self._strategies_dir = strategies_dir
+        self._strategies: dict[str, Strategy] = {}
+        self.refresh()
+
+    def refresh(self) -> int:
+        """Re-scan the strategies directory. Returns the loaded count."""
+        if not self._strategies_dir.exists():
+            logger.warning("strategies dir not found: %s", self._strategies_dir)
+            self._strategies = {}
+            return 0
+
+        loaded: dict[str, Strategy] = {}
+        for path in sorted(self._strategies_dir.glob("*.py")):
+            if path.name.startswith("_"):
+                continue
+            try:
+                metadata = _read_module_constants(path)
+                if not metadata.get("PAPER_TITLE"):
+                    logger.debug("no PAPER_TITLE in %s, skipping", path)
+                    continue
+                code_hash = _hash_file(path)
+                strategy = _to_strategy(path, metadata, code_hash)
+                loaded[strategy.id] = strategy
+            except Exception as exc:  # noqa: BLE001 — defensive on startup
+                logger.exception("failed to load strategy %s: %s", path, exc)
+        self._strategies = loaded
+        logger.info("loaded %d strategies from %s", len(loaded), self._strategies_dir)
+        return len(loaded)
+
+    # ── IStrategyProvider ───────────────────────────────────
+
+    def list_strategies(
+        self,
+        status: StrategyStatus | None = None,
+        asset_universe: list[str] | None = None,
+    ) -> list[Strategy]:
+        results = list(self._strategies.values())
+        if status is not None:
+            results = [s for s in results if s.status == status]
+        if asset_universe:
+            wanted = set(asset_universe)
+            results = [s for s in results if wanted.intersection(s.asset_universe)]
+        return results
+
+    def get_strategy(self, strategy_id: str) -> Strategy | None:
+        return self._strategies.get(strategy_id)
+
+    def get_strategies_for_risk_profile(self, risk_profile_name: str) -> list[Strategy]:
+        wanted = risk_profile_name.lower()
+        return [
+            s
+            for s in self._strategies.values()
+            if wanted in (s.risk_constraints.get("risk_profiles") or [])
+        ]
+
+    def extract_from_paper(self, arxiv_id: str) -> Strategy | None:
+        """Demo-feature stub. Real implementation arrives in the arxiv pipeline.
+
+        Returns None for now. The pipeline will live in
+        `archimedes.services.arxiv_pipeline` and use the KnowledgeBase
+        `extract.py` pattern (PyMuPDF cache) plus a Claude API call to
+        synthesize the methodology, then write a new `.py` file into the
+        analytics-engine strategies directory and call `self.refresh()`.
+        """
+        logger.info("extract_from_paper(%s): not yet implemented", arxiv_id)
+        return None
+
+
+def default_provider(repo_root: Path | None = None) -> LocalStrategyProvider:
+    """Construct a provider pointing at `analytics-engine/strategies/`.
+
+    `repo_root` defaults to four levels up from this file (the archimedes
+    repo root). Override for tests.
+    """
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[3]
+    return LocalStrategyProvider(repo_root / "analytics-engine" / "strategies")

--- a/docs/anti-features.md
+++ b/docs/anti-features.md
@@ -4,7 +4,9 @@
 > **Purpose:** Make scope discipline explicit. For every plausible-but-distracting feature
 > someone proposes mid-week-2, this doc says NO with a reason. Use it as the back-pressure
 > document.
-> **Date:** 2026-05-12 (Day 2). Revisit weekly.
+> **Date:** 2026-05-12 (Day 2). **Last revised 2026-05-13 (Day 3)** — reconciled with the
+> ecosystem-design pivot in [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md)
+> and the red-team critique in [`agora_project_analysis.md`](agora_project_analysis.md).
 
 ## Why this doc exists
 
@@ -32,14 +34,21 @@ against. Take-rate on USDC settlement + USYC yield-share is the revenue model.
 v1 portfolio is spot + RWA + USYC. Leverage adds liquidation failure modes, regulatory
 exposure, and demo fragility we can't manage in 12 days.
 
-### NOT building: third-party strategy onboarding for v1
+### NOT building: third-party strategy onboarding into Tier 1
 
-**Why not:** Curated v1 library per [`mvp-scope-memo.md`](mvp-scope-memo.md). Third-party
-onboarding requires moderation, abuse prevention, methodology review at scale, and an
-onboarding flow — none of which advance the v1 demo. The arxiv ingest pipeline runs as a
-demo segment on 2–3 papers; it does not productize for v1.
+**Why not:** Tier 1 vaults carry the "Archimedes Verified" badge precisely because every
+strategy is curator-validated and paper-grounded. Allowing arbitrary third-party
+strategies into Tier 1 dilutes the badge to meaninglessness — moderation, abuse
+prevention, and methodology review at scale are real products on their own.
 
-**v2 conversation, not v1.**
+**Tier 2 is the carve-out.** Per [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md)
+§ 5, community-tier vaults are permissionless and explicitly labeled. They carry reasoning
+traces and tool-call provenance like Tier 1, but they do NOT carry paper-grounding or
+selection-bias-corrected backtests. The two-tier separation is the design — not a
+relaxation of the original scope.
+
+**v2 conversation:** opening a curator-application flow that lets community-tier vault
+authors petition for Tier 1 review.
 
 ### NOT building: a full slashing / dispute resolution mechanic
 
@@ -102,21 +111,27 @@ benefit of demonstrating real on-chain primitives.
 **Why not:** Web-first. Mobile is a different engineering problem and doesn't unlock
 new judging value.
 
-### NOT building: social features (follow users, share portfolios, comments)
+### NOT building: profile pages, DMs, reactions, threads, global feed
 
-**Why not:** Different product. Strategy-leaderboard (per design.md § 9) gives us
-discovery; we don't need social commentary on top.
+**Why not:** [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md) § 4 puts
+per-vault chat in scope (wallet-address identity, message persistence, AI auto-post +
+@mention). Everything beyond that — profiles with PnL, direct messages, emoji reactions,
+threaded replies, a global marketplace feed — is a different product shape and a v2
+conversation.
 
-**v2 conversation.**
+**Hard line for v1:** chat is a post-investment surface inside a single vault, not a
+discovery or onboarding flow.
 
-### NOT building: a chat-bot / conversational portfolio agent
+### NOT building: chat-as-onboarding / conversational portfolio construction
 
-**Why not:** v1 is form-driven onboarding (pick risk profile) + dashboard for live state.
-A conversational interface is a different product and shifts the agent's failure modes
-from "did it construct the right portfolio?" to "did it understand the user?" — a
-harder evaluation problem.
+**Why not:** v1 onboarding is form-driven (pick risk profile, deposit USDC). The vault
+chat is a *post-investment* engagement surface — users talk to the AI about decisions
+that have already been made. Conversational onboarding shifts agent failure modes from
+"did it construct the right portfolio?" to "did it understand the user's prompt?" —
+a harder evaluation problem we don't take on in v1.
 
-**v2 conversation.**
+**v2 conversation:** natural-language risk-profile elicitation, "describe your goals and
+let the agent recommend a vault" flow.
 
 ### NOT building: agent-to-agent (a2a) commerce
 
@@ -143,18 +158,21 @@ bug surfaces, we deploy a new contract and migrate. Upgrade patterns add their o
 surface (the proxy / delegatecall failure mode is non-trivial); we hold the line on
 immutability for v1.
 
-### NOT building: real-time portfolio chat with the agent
+### NOT building: real-time portfolio *coaching* — user-interruptible agent
 
-**Why not:** Reasoning traces are async — the agent decides, hashes, publishes. A
-real-time chat interface where the user can interrupt or coach the agent is a different
-product (and a harder one — agency vs. interruptibility tradeoffs).
+**Why not:** The vault chat per [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md)
+§ 4 is read-mostly: the AI auto-posts on agent actions and answers questions about
+*already-made* decisions. What we are NOT building is a chat where the user can
+interrupt, coach, or reverse the agent's behavior in real time. That is a different
+product (agency vs. interruptibility tradeoffs), and a v2 conversation.
 
-### NOT building: a portfolio NFT or position-tokenization layer
+### NOT building: per-position NFTs or per-user portfolio tokens
 
-**Why not:** Don't tokenize the user's *position*. Tokenize the *underlying assets* (RWA
-tokens) per Chuan's [`design.md` § 5.3](design.md). Adding a layer where the user's
-portfolio itself is a tradeable token is a v2+ conversation and adds complexity without
-clear v1 benefit.
+**Why not:** ERC-4626 vault shares per [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md)
+§ 3.2 are the unit of position — fungible vault-token holdings represent your share of
+the vault's portfolio. We do NOT issue a per-position NFT (one token per user per
+position), a per-user portfolio token, or any other position-individuation layer.
+Vault-token fungibility is what makes the AMM-traded copy-trade primitive work.
 
 ### NOT building: gamified / "rewards" mechanics
 
@@ -167,25 +185,102 @@ ethically dicey territory.)
 **Why not:** Use Chainlink, Pyth, or RedStone for price feeds. Don't roll our own oracle
 network. Off-the-shelf where reliable.
 
+**Hackathon caveat:** the synth layer currently uses a backend-driven mock oracle (per
+[`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md) § 3.6). This is a
+demo simplification; the production path replaces it with Pyth/Chainlink, not a
+home-grown alternative.
+
+## Pitch-rigor anti-claims (Day 3 additions from red-team review)
+
+These are not features we won't build — they are *claims we won't make* in the deck or
+the public-facing copy. Each one survived the red team in
+[`agora_project_analysis.md`](agora_project_analysis.md) as a defensible framing line.
+
+### NOT pitching: "blockchain as memory" as the load-bearing rhetorical claim
+
+**Why not:** Garrison's "memory makes computation universal" is satisfied by Postgres,
+git, Kafka, and S3 versioning — the bar is extraordinarily low and the framing is more
+aesthetic than substantive (analysis doc § 5.1). What blockchain uniquely provides is
+**multi-party tamper-evident commitment** of specific facts, not "memory" in general. The
+defensible pitch line is:
+
+> The ReasoningTraceRegistry is the agent's externalized memory for the specific
+> financial-decision artifacts no party — including Archimedes — can later rewrite.
+
+Use that framing. Do not pitch "blockchain as substrate for universal computation."
+
+### NOT claiming: predicted alpha or future-return guarantees
+
+**Why not:** McLean & Pontiff (2016) — published cross-sectional predictors lose 26%
+out-of-sample and 58% post-publication. Bailey & López de Prado (2014) — backtest-
+optimized strategies often do not exceed the median out-of-sample. Any claim that our
+agent "delivers" a target Sharpe is structurally unsupportable. We claim **auditability
+of past decisions plus statistical rigor of strategy admission** — not future returns.
+
+### NOT claiming: that an on-chain trace hash proves the agent used the trace
+
+**Why not:** A hash anchored at time T proves the trace existed at time T. It does NOT
+prove the agent's trade was caused by that trace's reasoning (analysis doc § 5.2). Until
+[`commit-reveal-trace-spec.md`](specs/commit-reveal-trace-spec.md) is implemented (v1.5),
+do not claim causation. The honest pitch is "verifiable record of the reasoning at the
+moment of the trade" — not "proof that the trade followed from the reasoning."
+
+### NOT claiming: regulatory clarity or production-readiness
+
+**Why not:** Per the regulatory survey in
+[`agora_project_analysis.md`](agora_project_analysis.md) § 6, a managed-portfolio vault
+with curator discretion likely satisfies all four prongs of Howey under current SEC
+interpretation. This is fine for a hackathon prototype with test users; it is **not** a
+production stance. Any pitch should explicitly frame this as a research prototype, not a
+launchable investment product. (The 2026-05 SEC + MiCA + Cayman survey in the analysis
+doc is the reference; cite it if asked.)
+
+### NOT claiming: that selection-bias correction makes our strategies "right"
+
+**Why not:** DSR, PBO, and OOS Sharpe per
+[`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md)
+*reduce* the false-positive rate; they do not eliminate it. The honest claim is that
+we apply the corrections and surface the numbers — not that the corrections make any
+specific strategy a true positive. The wedge is the rigor, not a guarantee.
+
 ## What we ARE building (for explicit contrast)
 
-To make this doc complete: the v1 scope is the inverse of the above. Specifically:
+To make this doc complete: the v1 scope is the inverse of the above. Updated 2026-05-13
+to reflect the two-tier marketplace pivot in
+[`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md). Specifically:
 
-- Portfolio agent that constructs personalized portfolios from a curated library of
-  paper-grounded strategies
-- Live regime detection + autonomous rebalancing + strategy rotation
-- Strategy passport: paper provenance + reasoning trace + tool-call provenance
+**Ecosystem layer (Chuan + Marten):**
+- Synthetic protocol: 5 oracle-priced synthetic assets (sSPY, sNIKKEI, sGLD, sTREASURY,
+  sOIL) backed 1:1 by USDC in a shared collateral pool
+- AMM exchange: Uniswap-V2-style constant-product pools, USDC-paired
+- VaultFactory + ERC-4626 Vault contracts with 2-and-20-style fees and a 10% platform cut
+- Two-tier marketplace:
+  - **Tier 1 (Archimedes Verified):** paper-grounded strategies + full agent autonomy +
+    selection-bias-corrected backtests + reasoning traces
+  - **Tier 2 (Community):** permissionless vault creation + opt-in agent features +
+    reasoning traces (paper-grounding optional)
+- Vault-token AMM pools enable copy-trading (buy vault tokens = invest in the manager)
+- Per-vault chat with wallet-address identity and AI auto-post + @mention (Tier 1)
+
+**Strategy + agent layer (Dan + Önder + Chuan):**
+- Curated v1 library: 5–10 paper-grounded strategies, each with full strategy passport
+  (paper provenance + methodology hash + curator wallet signature)
+- Selection-bias-corrected backtests (DSR, PBO, OOS Sharpe split, look-ahead audit) per
+  [`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md)
+- Arxiv ingest pipeline demo on 2–3 papers (not relied on for live portfolio decisions)
+- Portfolio agent: regime detection, autonomous rebalancing, strategy rotation, reasoning
+  traces, tool-call provenance
 - On-chain anchoring of reasoning traces via ReasoningTraceRegistry on Arc
-- Non-custodial vault: ArchimedesVault holds user USDC, agent has rebalance authority only
-- USYC floor per risk profile for risk-off yield
-- RWA token acquisition via CCTP/Gateway
-- Strategy leaderboard for discovery
-- Curated v1 library: 5–10 paper-grounded strategies
-- Arxiv ingest pipeline demo on 2–3 papers (not relied on for live demo)
-- Web frontend (Next.js) for onboarding + dashboard + reasoning-trace viewer
-- Pitch deck + live demo + Q&A prep
 
-That's it. That's the v1. Everything else is v2.
+**Settlement + UX (Marten + Daniel + Chuan):**
+- USDC settlement on Arc + Paymaster for USDC-denominated gas
+- USYC as the risk-off yield anchor in every portfolio (per risk-profile floor)
+- Next.js frontend: marketplace landing, vault detail, swap UI, vault creator, reasoning
+  trace viewer with "verify trace hash" UI element
+- Pitch deck + live demo + Q&A prep grounded in
+  [`agora_project_analysis.md`](agora_project_analysis.md)
+
+That's the updated v1. Everything else is v2.
 
 ## How to use this doc
 

--- a/docs/architectural-principles.md
+++ b/docs/architectural-principles.md
@@ -48,10 +48,18 @@ Three independent arguments converge:
    problem of every leaderboard. **Verifiable reasoning history bypasses the prediction
    problem**: we don't claim the past predicts the future; we claim the past is auditable.
 
-## The three primitives that make verifiable history work
+## The four primitives that make verifiable history work
 
 These are the architectural commitments. Schema details in
-[`specs/strategy-passport-spec.md`](specs/strategy-passport-spec.md); principle here.
+[`specs/strategy-passport-spec.md`](specs/strategy-passport-spec.md) and
+[`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md);
+principle here.
+
+> **Day 3 update:** The fourth primitive — selection-bias correction — was added on
+> 2026-05-13 after the red-team review documented in
+> [`agora_project_analysis.md`](agora_project_analysis.md) § 5.3. The three original
+> primitives address *auditability*; the fourth addresses *credibility* of admission to
+> the library in the first place.
 
 ### Primitive 1: paper-claim binding (the strategy passport)
 
@@ -104,6 +112,54 @@ outputs. This is what makes the agent's *information surface* auditable.
   agent's tool calls are recorded, we can replay them later with different LLM prompts
   and see how decisions would have differed.
 
+### Primitive 4: selection-bias correction (the admission gate)
+
+Auditability proves that the agent *did what it claims*. Selection-bias correction proves
+that the strategies in the library *deserve to be there* — that they survive the
+statistical tests separating curve-fit artifacts from credible predictors.
+
+For every strategy admitted to the Tier-1 library, the
+[`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md)
+contract requires:
+
+- **Deflated Sharpe Ratio (DSR)** — Sharpe corrected for non-normality and multiple
+  testing (Bailey & López de Prado 2014). `dsr_p_value >= 0.95`.
+- **Probability of Backtest Overfitting (PBO)** — CSCV-framework probability that the
+  in-sample-optimal strategy underperforms the OOS median (Bailey, Borwein, López de
+  Prado, Zhu 2014). `pbo_score < 0.5`.
+- **Walk-forward out-of-sample Sharpe** — held-out slice metric. Must reach at least
+  50% of the in-sample Sharpe (no cliff).
+- **Look-ahead audit** — static checks confirm no future-bar references in strategy
+  code or data slicing.
+- **Paper-claim delta surfaced**, not hidden — `sharpe_vs_paper`, `cagr_vs_paper`, and
+  McLean-Pontiff post-publication decay estimate all visible in the passport.
+
+This addresses the strongest red-team critique of an LLM-driven strategy pipeline:
+*published academic alpha is mostly dead alpha* (McLean & Pontiff 2016 — 58% of
+in-sample Sharpe lost post-publication on average). The four corrections do not make a
+strategy "right"; they reduce the false-positive rate and surface the residual
+uncertainty so the user can audit it.
+
+**Tier-2 community vaults are exempt from primitive 4.** That is by design — see the
+two-tier section below.
+
+## Two-tier marketplace: how the primitives apply to each tier
+
+Per [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md), Archimedes runs a
+two-tier vault marketplace. The primitives are not uniformly required; the tiers are
+*defined* by which primitives they commit to.
+
+| Primitive | Tier 1 (Archimedes Verified 🏆) | Tier 2 (Community 👥) |
+|---|---|---|
+| 1. Paper-claim binding | **Required** — every strategy traces to published research | Optional — community vaults need no paper backing |
+| 2. Reasoning trace | **Required** — every agent decision is hashed and anchored | **Required** if agent-assisted; manual vaults log creator-attributed decisions |
+| 3. Tool-call provenance | **Required** — every tool invocation recorded with input/output hashes | **Required** for agent-assisted actions |
+| 4. Selection-bias correction | **Required** — DSR + PBO + OOS Sharpe + look-ahead audit must all pass | Not required — Tier 2 is freestyle by design |
+
+The Tier 1 badge means "this vault's strategies survive all four primitives." The Tier 2
+flag means "this vault carries reasoning traces but the strategies have not been
+paper-grounded or selection-bias-corrected." Both are useful; neither is misrepresented.
+
 ## The three layers, named explicitly
 
 Borrowing a framing from prediction-market architecture (Canteen's _Unbundling the
@@ -125,24 +181,30 @@ MCP-native + verifiable history" credible as a pitch.
 
 ## Design constraints these primitives imply
 
-Once you commit to the three primitives, several design choices are forced:
+Once you commit to the four primitives, several design choices are forced:
 
 1. **You commit to an on-chain anchoring path.** The verifiability depends on the hash
-   being checkable independent of the platform. Chuan's
-   [`design.md` § 5.2](design.md) specifies this as `ReasoningTraceRegistry.sol`. Don't
-   skip it.
+   being checkable independent of the platform. The
+   [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md) § 3.4 keeps
+   `ReasoningTraceRegistry.sol` from the original design unchanged. Don't skip it.
 2. **You commit to content-hashing as the integrity primitive.** Not signatures, not
    platform attestations. The trace is what it is; any change to it changes the hash;
    anyone with the trace can verify it themselves.
 3. **You commit to "verifiable history, not predictive performance" as the reputation
    thesis.** Don't ship a numeric score that claims to predict future performance. Ship
-   the queryable, auditable history.
-4. **You commit to non-custodial settlement.** Platform never holds user funds. ArchimedesVault
-   contracts hold USDC; agent has rebalance authority only, not withdraw-to-platform
-   authority.
-5. **You commit to paper-grounded curation, not LLM-blind ingestion.** Strategies come
-   from real published research with verifiable methodology. The arxiv pipeline can
+   the queryable, auditable history + the selection-bias-corrected admission record.
+4. **You commit to non-custodial settlement.** Platform never holds user funds. Vault
+   contracts (ERC-4626 per ecosystem-design-spec § 3.2) hold user USDC and synth tokens;
+   the agent has rebalance authority only, not withdraw-to-platform authority.
+5. **You commit to paper-grounded curation for Tier 1, not LLM-blind ingestion.** Tier 1
+   strategies come from real published research with verifiable methodology. The arxiv
+   pipeline can
    *propose* strategies, but a human curator (Dan in v1) validates before listing.
+6. **You commit to selection-bias-corrected admission for Tier 1.** Every Tier-1
+   strategy passes DSR (Bailey & López de Prado 2014), PBO (Bailey/Borwein/López de
+   Prado/Zhu 2014), walk-forward OOS Sharpe, and a look-ahead static audit before
+   promotion from CANDIDATE → VALIDATED. The numbers, including the paper-claim delta,
+   are surfaced in the passport — never hidden behind an aggregate score.
 
 ## What this doesn't commit you to
 
@@ -163,15 +225,19 @@ open, and the team can pick later:
 
 ## How to evaluate proposed features against these principles
 
-When the team is deciding whether to add a feature, run it through this filter:
+When the team is deciding whether to add a feature, run it through this six-question filter:
 
 1. **Does it make any prior decision's record less auditable?** If yes, push back hard.
 2. **Does it tie reputation to predicted performance rather than actual history?** If yes,
    replace with a history-based equivalent.
 3. **Does it move user funds into platform custody?** If yes, redesign.
 4. **Does it lock us into a single framework or LLM provider?** If yes, push back.
-5. **Does it bypass the paper-claim binding?** (E.g., "let users submit untested strategies
-   directly.") If yes, push back — the paper-grounded curation is part of the pitch.
+5. **Does it bypass the Tier 1 paper-claim binding?** (E.g., "let community strategies
+   carry the Verified badge.") If yes, push back — paper-grounded curation is the badge.
+   Tier 2 is the legitimate freestyle path.
+6. **Does it bypass the Tier 1 selection-bias gate?** (E.g., "skip DSR/PBO for strategies
+   we feel good about.") If yes, push back — the four-primitive admission gate is the
+   only thing that distinguishes rigor from hand-waving.
 
 A feature that fails any of these is a feature that erodes the architectural moat.
 Sometimes it's worth the erosion (e.g., a v2 fiat on-ramp may require custodial

--- a/docs/judging-rubric-assessment.md
+++ b/docs/judging-rubric-assessment.md
@@ -1,0 +1,293 @@
+# Judging-Rubric Self-Assessment — Day 3 Snapshot
+
+> **Date:** 2026-05-13 (Day 3, late evening Chicago)
+> **Audience:** Archimedes hackathon team
+> **Purpose:** Honest assessment of where we stand against the four rubric categories with
+> ~11 days to go. Identifies the biggest gaps and a concrete forcing function for closing
+> them. Re-score weekly.
+> **Source:** Rubric weights and category definitions per
+> [`agora_project_analysis.md`](agora_project_analysis.md) § 1.
+
+## The rubric
+
+| Weight | Category                | Reads from                                                  |
+| ------ | ----------------------- | ----------------------------------------------------------- |
+| 30%    | Agentic Sophistication  | How much the AI actually decides vs. just automates         |
+| 30%    | Traction                | Real users, real transactions, real volume *during the event window* (arc-canteen telemetry is the scoreboard) |
+| 20%    | Circle Tool Usage       | Creative use of Wallets, CCTP, Gateway, App Kit, Contracts, USYC, USDC |
+| 20%    | Innovation              | Novel approaches, emergent behavior, research insight       |
+
+## TL;DR — rough running score: ~13 / 40 ≈ 33%
+
+| Weight | Category               | Score / 10 | Trend     | Risk    |
+| ------ | ---------------------- | ---------- | --------- | ------- |
+| 30%    | Agentic Sophistication | **4**      | Improving | Medium  |
+| 30%    | Traction               | **0**      | Flat      | **High — easily fixable** |
+| 20%    | Circle Tool Usage      | **2**      | Improving | **High — gating dependency on Chuan/Marten testnet deploy** |
+| 20%    | Innovation             | **7**      | Improving | Low     |
+
+Innovation is the strongest. Traction is a fixable structural zero. Circle Tool Usage
+requires the testnet deploy to happen. Agentic Sophistication is "promising specs, no
+live agent" — converts when the orchestrator runs end-to-end.
+
+---
+
+## 30% Agentic Sophistication — current: 4 / 10
+
+**What the rubric values:** the agent making non-trivial decisions autonomously after
+deployment, not just at design time. Reasoning visible, regime-adaptive, strategy
+rotation in response to drift / market state.
+
+**What we have:**
+
+- ✅ Architecture for an autonomous portfolio agent with five frozen interfaces
+  (`IAgentOrchestrator`, `IRegimeDetector`, `IPortfolioConstructor`, `IStrategyProvider`,
+  `IBacktestEvaluator`) per [`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md)
+- ✅ Reasoning trace model (`models/trace.py`) with canonical-JSON SHA-256 hashing and
+  on-chain anchor slots
+- ✅ Day-3 commit-reveal trace integrity spec — promotes "trace existed at T" to
+  "trace existed *before* the trade" with proven causal ordering
+  ([`specs/commit-reveal-trace-spec.md`](specs/commit-reveal-trace-spec.md))
+- ✅ Selection-bias gate that prevents the agent from acting on curve-fit artifacts
+  ([`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md))
+- ✅ Strategy provider (`backend/archimedes/services/strategy_provider.py`) implemented
+  and loading 4 strategies (3 paper-grounded + 1 baseline) with risk-profile routing
+
+**What's missing:**
+
+- ❌ No live orchestrator loop running yet (Chuan's queue)
+- ❌ No `regime_detector` / `portfolio_constructor` / `backtest_evaluator` implementations
+  (Önder's queue)
+- ❌ No `oracle_updater` / `chain_executor` / `trace_publisher` implementations (Marten's
+  queue)
+- ❌ Zero reasoning traces have been generated, hashed, or anchored
+- ❌ Zero agent decisions on testnet
+
+**To get to 7 / 10:** ship the orchestrator with one Tier-1 vault running a regime-aware
+strategy, generating at least one reasoning trace that anchors to Arc. Live demo of an
+autonomous rebalance triggered by a regime classification change.
+
+**To get to 9 / 10:** ship the commit-reveal trace pattern in production. Live demo
+shows the user clicking "Verify temporal binding" and seeing
+`commitBlock < tradeBlock < revealBlock`.
+
+---
+
+## 30% Traction — current: 0 / 10
+
+**What the rubric values:** real users, real transactions, real volume during the event
+window. The Canteen team explicitly noted this weight is unusual; per
+[`agora_project_analysis.md`](agora_project_analysis.md) § 1 the framing is "great
+founders ship and get users in two weeks."
+
+**The scoreboard:** `arc-canteen` telemetry. Specifically the `update-traction` and
+`update-product` events that each teammate logs. **`arc-canteen status` is what the
+judges see.**
+
+**What we have:** **zero.** No traction updates logged. No product updates logged. The
+rubric scoreboard reads zero across the team.
+
+**What's missing:**
+
+- Every team member running `arc-canteen update-product` at minimum once per meaningful
+  ship (this PR, the smart-contract merges, the EC2 deployment, the analytics-engine
+  release — none of these are in arc-canteen's log)
+- Every team member running `arc-canteen update-traction` whenever they talk to a
+  potential user, share a screenshot in Discord, get a meaningful conversation on Twitter,
+  etc.
+- A testnet-deployed product to drive users *to* (gates Circle Tool Usage as well)
+- Outbound outreach: Canteen Discord, Arc Builder Discord, crypto Twitter, r/algotrading,
+  QuantConnect forums (per the design.md § 9 channels)
+
+**Backfill TODO (do tonight or first thing Day 4):**
+
+```bash
+# One per meaningful ship — backfill these:
+arc-canteen update-product "Day 1-2: project setup, design docs, MVP scope memo"
+arc-canteen update-product "Day 3: EC2 + Docker + CI/CD live; analytics-engine module shipped; passport-aware models; 3 paper-grounded strategies seeded"
+arc-canteen update-product "Day 3: rigor-as-wedge — DSR + PBO + walk-forward selection-bias spec; commit-reveal trace integrity spec; doc corpus reconciled around ecosystem-design pivot"
+# … one per future merge
+```
+
+**To get to 5 / 10:** consistent daily `update-product` cadence + 5 logged `update-traction`
+events (judges, fellow hackers, Discord conversations).
+
+**To get to 8 / 10:** 30+ portfolios created on testnet by Day 14, with each one
+logged via `update-traction`. Per design.md § 9 targets.
+
+**Risk:** **highest of the four categories.** A team that ships brilliantly and forgets
+to log loses ~half of the 30% rubric weight for nothing. **Make this a daily ritual.**
+
+---
+
+## 20% Circle Tool Usage — current: 2 / 10
+
+**What the rubric values:** depth and creativity across Wallets, CCTP, Gateway,
+App Kit, Contracts, USYC, USDC, Paymaster.
+
+**What we have:**
+
+- ✅ Contracts written: `PriceOracle.sol`, `SyntheticToken.sol`, `SyntheticVault.sol`,
+  plus 8 interface stubs
+- ✅ Ecosystem design references the full Circle toolset
+- ✅ USDC as exclusive settlement currency — no native-token gas to learn
+- ✅ EC2 infrastructure live, ready to deploy
+
+**What's missing:**
+
+- ❌ No contracts deployed to Arc testnet. Zero on-chain footprint as a team.
+- ❌ No CCTP usage (cross-chain USDC movement)
+- ❌ No Gateway integration (unified balance / nanopayments)
+- ❌ No Paymaster integration (USDC-denominated gas)
+- ❌ No USYC integration (the risk-off anchor)
+- ❌ No App Kit usage
+- ❌ No Circle Wallets onboarding flow
+
+**Reference material we have at hand:**
+
+- `submodules/context-arc/circlefin-skills/use-smart-contract-platform.md` for deploy
+- `submodules/context-arc/circlefin-skills/bridge-stablecoin.md` for CCTP + Gateway
+- `submodules/context-arc/circlefin-skills/use-gateway.md` for unified balance
+- `submodules/context-arc/samples/arc-escrow/` — closest existing vault pattern
+- `submodules/context-arc/samples/arc-multichain-wallet/` — CCTP integration
+- `submodules/context-arc/samples/arc-p2p-payments/` — Paymaster + USDC
+
+**To get to 5 / 10:** contracts deployed to Arc testnet (PriceOracle + SyntheticFactory
++ Vault). PaymasterImpl integrated so all transactions are USDC-paid. USYC live as
+risk-off anchor with at least one Tier-1 vault holding it.
+
+**To get to 7 / 10:** add CCTP or Gateway for a meaningful cross-chain action. Circle
+Wallets integrated for user onboarding (no MetaMask popup — direct USDC deposit flow).
+
+**To get to 9 / 10:** add the Agent Stack (Circle CLI + Agent Wallets per
+`developers.circle.com/agent-stack.md`) so the orchestrator runs as a first-class
+on-chain agent with its own wallet identity, settling reasoning-trace publishes through
+its own paymaster account.
+
+---
+
+## 20% Innovation — current: 7 / 10 ⭐
+
+**What the rubric values:** novel approaches, emergent behavior, research insight.
+**Our strongest category.**
+
+**What we have that no other AI-portfolio submission will have:**
+
+- ✅ **Strategy passport** ([`specs/strategy-passport-spec.md`](specs/strategy-passport-spec.md))
+  — every strategy carries paper-arxiv-id, methodology hash, curator signature,
+  on-chain registration tx. Other AI portfolios make "trust me" claims; ours is bound
+  to peer-reviewed research with a verifiable hash chain.
+- ✅ **Selection-bias corrections** ([`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md))
+  — DSR (Bailey & López de Prado 2014) + PBO (Bailey/Borwein/López de Prado/Zhu 2014) +
+  walk-forward OOS + look-ahead static audit. No other AI portfolio submission applies
+  the textbook multiple-testing corrections that quant academics have demanded for a
+  decade.
+- ✅ **Paper-claim deltas surfaced** — `sharpe_vs_paper`, `cagr_vs_paper`, McLean-Pontiff
+  (2016) post-publication-decay estimate. We tell the user where the strategy was
+  expected to live (paper) vs. where it actually lives (our re-run). Hidden by every
+  competitor; surfaced by us as a feature.
+- ✅ **Commit-reveal trace integrity** ([`specs/commit-reveal-trace-spec.md`](specs/commit-reveal-trace-spec.md))
+  — commit-before-trade / reveal-after-trade binds the agent to a single reasoning
+  trace before the outcome is knowable. Closes the "generate 100 traces, pick the one
+  that rationalizes the outcome" attack ([`agora_project_analysis.md`](agora_project_analysis.md)
+  § 5.2). Spec'd for v1.5.
+- ✅ **Two-tier architectural primitive coverage** — Tier 1 = paper-grounded +
+  selection-bias-corrected + full agent; Tier 2 = freestyle + reasoning traces only.
+  The badge means something concrete, not aspirational.
+- ✅ **Tool-call provenance** — every market-data fetch and oracle read recorded with
+  input + output hashes. Lets us *replay* agent behavior with different prompts to study
+  decision sensitivity. Nobody else is doing this.
+- ✅ **Honest pitch framing** — anti-features.md § "pitch-rigor anti-claims" explicitly
+  rules out the "blockchain as memory", "predicted alpha", "trace proves causation",
+  and "regulatory clarity" claims that competitors will reach for. We claim
+  auditability + rigor; we don't claim returns.
+
+**What's missing:**
+
+- ⚠️ All of the above are *spec'd*. The full demo evidence (judges actually clicking
+  "Verify trace hash" and seeing the green checkmark; live DSR + PBO numbers on a
+  strategy detail page; the paper-claim delta line item visible) doesn't exist yet.
+- ⚠️ Arxiv ingest pipeline is not built (KnowledgeBase has the patterns; we haven't
+  ported them yet).
+
+**To get to 9 / 10:** ship the "Verify trace hash" UI element. Have a strategy detail
+page that shows the DSR p-value, PBO score, paper-claim delta, and a green checkmark
+on the trace integrity check. Each of those is a screenshot-worthy demo moment.
+
+**To get to 10 / 10:** add a demo segment where Dan extracts a strategy from a fresh
+arxiv paper live on stage — the KnowledgeBase `extract.py` → Claude API → new strategy
+file in `analytics-engine/strategies/` → backtest gate → reasoning trace anchored
+on-chain in under 5 minutes. "We can turn a paper into an audited strategy on stage,
+right now."
+
+---
+
+## Cross-category forcing function: the smallest possible end-to-end demo
+
+The single highest-leverage thing we can build in the next 11 days is a **vertical slice
+that touches all four rubric categories at once.** Per
+[`agora_project_analysis.md`](agora_project_analysis.md) § 8, recent hackathon winners
+shipped narrow products; none tried to be platforms.
+
+**The minimal viable demo:**
+
+1. **One Tier-1 vault** holding one strategy (TSMOM is the best candidate — simplest
+   to backtest convincingly and pairs naturally with the regime detector).
+2. **Real Arc testnet deployment** of `PriceOracle`, `SyntheticVault`,
+   `ReasoningTraceRegistry`, with USDC and USYC live.
+3. **User wallet flow** via Circle Wallets — judge connects, deposits 10 USDC, sees a
+   portfolio constructed.
+4. **One autonomous rebalance** triggered by a regime classification change (we control
+   the regime trigger for demo timing).
+5. **One published reasoning trace** with a working "Verify trace hash" UI button.
+6. **Strategy detail page** showing the DSR p-value, PBO score, paper-claim delta, and
+   the green look-ahead-audit checkmark.
+
+That single end-to-end loop checks every rubric category:
+
+| Category               | What the demo shows                                                  |
+| ---------------------- | -------------------------------------------------------------------- |
+| Agentic Sophistication | Autonomous rebalance + reasoning trace + regime classification       |
+| Traction               | Real on-chain transaction by a real user; log via `update-traction`  |
+| Circle Tool Usage      | USDC settlement + Paymaster + Wallets + Contracts + USYC (5 of 7)    |
+| Innovation             | Strategy passport + selection-bias gate + paper-claim delta visible  |
+
+**Everything else in the ecosystem spec — Tier 2 community vaults, AMM-traded vault
+tokens, per-vault chat — is decoration on this loop.** They can be in the pitch as
+"what's next"; they don't need to be in the live demo to score well.
+
+## Recommendation for the team
+
+1. **Tonight (Dan, alone):** start the traction-logging habit. Backfill `update-product`
+   for everything that's already shipped.
+2. **Day 4 morning (Chuan):** deploy contracts to Arc testnet. First on-chain
+   transactions belong to us by lunchtime.
+3. **Day 4-5 (Marten):** oracle updater service + chain executor + trace publisher
+   skeleton. Get the agent → testnet pipe working.
+4. **Day 5-7 (Önder):** portfolio constructor + backtest evaluator with the DSR/PBO
+   math from the selection-bias spec. The math is the rigor pitch.
+5. **Day 7-9 (Chuan + Dan):** stitch the orchestrator together; first end-to-end
+   autonomous rebalance with reasoning trace.
+6. **Day 9-12 (Daniel R.):** frontend Next.js app or live data on the ui-mockups —
+   reasoning-trace viewer + Verify-trace button are the demo wow.
+7. **Day 9-14 (Dan + everyone):** active outreach — Canteen Discord, Arc Builder
+   Discord, crypto Twitter. Log every conversation.
+
+Re-score this doc weekly. The traction line in particular should not stay at zero past
+Day 4.
+
+## Open questions
+
+1. **Do we explicitly cut Tier 2 from the v1 demo?** Per
+   [`mvp-scope-memo.md`](mvp-scope-memo.md) § "What gets cut if Day 3 ambition outruns
+   the timeline," Tier 2 is the second-to-cut. With ~11 days remaining and zero on-chain
+   activity, this looks like the time. Surface as "v2 — community can author vaults"
+   in the deck.
+2. **Same question for AMM-traded vault tokens.** Cut last per the memo, but the
+   premium/discount-to-NAV story is at odds with the verifiable-history pitch and adds
+   contract surface. Recommend cut from v1 demo; keep in roadmap.
+3. **Same question for per-vault chat.** Cut for demo; the chat is engagement layer
+   not core trust.
+
+Recommendation: cut all three from the demo MVP, keep them in the roadmap segment of
+the deck. **The wedge is one Tier-1 vault that proves the rigor stack works end-to-end.**

--- a/docs/mvp-scope-memo.md
+++ b/docs/mvp-scope-memo.md
@@ -1,23 +1,31 @@
 # MVP Scope Memo
 
-> **Date:** 2026-05-12 (Day 2)
+> **Date:** 2026-05-12 (Day 2). **Last revised 2026-05-13 (Day 3)** — see § "Day 3
+> updates" below for the marketplace expansion and the rigor-as-wedge decision.
 > **Audience:** Archimedes hackathon team
-> **Purpose:** Formalize three scope decisions that came out of the Day-2 standup and the
-> design-doc review: RFB lock-in, on-chain ambition, and strategy-library breadth. This is
-> the document the team commits to — when scope creep starts, this is the back-pressure
-> reference.
+> **Purpose:** Formalize the locked scope decisions that came out of the Day-2 standup
+> and the Day-3 design pivot. This is the document the team commits to — when scope creep
+> starts, this is the back-pressure reference.
 
 ## TL;DR
 
 1. **Primary RFB: 04 — Adaptive Portfolio Manager.** Adjacent: RFB 02 (Kelly/+EV math
    primitive); RFB 06 (strategy leaderboard).
-2. **Both on-chain stories are in scope:** ArchimedesVault contracts for RWA-token
-   allocation **and** ReasoningTraceRegistry for verifiable provenance. Shoot for the moon.
+2. **Both on-chain stories are in scope:** vault contracts for portfolio allocation
+   **and** ReasoningTraceRegistry for verifiable provenance. Shoot for the moon.
 3. **Strategy library v1 = curated, ~5–10 hand-built strategies.** Arxiv ingest pipeline
    runs as a demo feature on 2–3 papers — shown in the pitch, not relied on for the wow
    moment.
+4. **(Day 3 addition) Rigor is the wedge.** Selection-bias-corrected backtests
+   (DSR + PBO + walk-forward OOS + look-ahead audit) gate every Tier-1 strategy. The
+   passport surfaces paper-claim deltas honestly. This is what distinguishes Archimedes
+   from the 96 other "AI portfolio agent" submissions at the last Arc HackMoney.
+5. **(Day 3 addition) Two-tier marketplace.** Tier 1 = Archimedes-Verified, paper-grounded,
+   full agent autonomy, selection-bias-corrected. Tier 2 = community, permissionless,
+   opt-in agent features. The single-vault original scope is replaced by VaultFactory
+   per [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md).
 
-These three decisions cascade through every other doc in `docs/`. Treat them as locked
+These five decisions cascade through every other doc in `docs/`. Treat them as locked
 unless the team explicitly agrees to change one (and updates this memo).
 
 ## Decision 1 — RFB lock-in
@@ -146,6 +154,69 @@ and the per-paper rationale. Headline criteria for a paper to make the v1 librar
    markets.
 4. **Sharpe ≥ 0.5 in our re-run** at conservative transaction costs (10bps round-trip).
 5. **No look-ahead bias** in our re-run (walk-forward only).
+
+## Day 3 updates (2026-05-13)
+
+Two new commitments were locked on Day 3, prompted by Chuan's ecosystem-design pivot
+([`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md)) and Dan's red-team
+synthesis ([`agora_project_analysis.md`](agora_project_analysis.md)). Both are now
+treated as locked alongside the original three decisions.
+
+### Decision 4 — Rigor is the wedge
+
+**Choice:** Every Tier-1 strategy passes the four selection-bias controls before
+admission to the library: Deflated Sharpe Ratio (Bailey & López de Prado 2014),
+Probability of Backtest Overfitting (Bailey/Borwein/López de Prado/Zhu 2014),
+walk-forward out-of-sample Sharpe with no in-sample/test cliff, and a look-ahead static
+audit. Paper-claim deltas (`sharpe_vs_paper`, `cagr_vs_paper`, McLean-Pontiff
+post-publication decay estimate) are surfaced in the passport — never hidden behind an
+aggregate score.
+
+**Why:** The strongest red-team critique of any LLM-extracted strategy pipeline is the
+multiple-testing inflation problem. McLean & Pontiff (2016) showed published predictors
+lose ~58% of in-sample Sharpe post-publication on average; Bailey, Borwein, López de
+Prado & Zhu (2014) showed in-sample-optimal strategies frequently underperform the OOS
+median under realistic conditions. Either failure mode produces a "validated" library
+full of curve-fit artifacts. Applying the textbook corrections — and surfacing the
+results — is the single change that turns the analysis-doc critique from a *risk* into
+a *differentiator*. See [`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md)
+for Önder's implementation contract.
+
+### Decision 5 — Two-tier marketplace
+
+**Choice:** Replace the single-vault original scope (ArchimedesVault holding pooled USDC
+managed by one agent) with a two-tier vault marketplace per the ecosystem-design-spec:
+
+- **Tier 1 (Archimedes Verified 🏆):** strategies are paper-grounded and selection-bias-
+  corrected; the agent has full autonomy (regime detection, autonomous rebalancing,
+  strategy rotation); every decision produces an anchored reasoning trace.
+- **Tier 2 (Community 👥):** permissionless vault creation by any wallet, any asset
+  combination, opt-in agent features (drift alerts, basic regime response). Tier 2
+  vaults carry reasoning traces if agent-assisted but are not paper-grounded.
+
+**Why:** A two-tier marketplace deepens the Circle SDK surface (VaultFactory + ERC-4626
++ AMM-traded vault tokens = copy-trade primitive), opens an organic traction channel
+(community vault authors), and clarifies the architectural moat (Tier 1 = primitives
+1+2+3+4; Tier 2 = primitives 2+3 only — see `architectural-principles.md`). The single
+vault wasn't the goal; verifiable, paper-grounded, selection-bias-corrected portfolio
+management was. The marketplace just makes the moat legible.
+
+### What gets cut if Day 3 ambition outruns the timeline
+
+If by end of Week 1 the ecosystem layer is at risk, the cut order is (best → worst):
+
+1. **AMM-traded vault tokens** — cut last. Without these, vaults still work; users
+   deposit/withdraw at NAV. The copy-trade UX degrades but the demo holds.
+2. **Tier 2 community vaults** — cut second. Tier 1 + the agent + the passport are the
+   pitch. Tier 2 is the marketplace dressing.
+3. **Per-vault chat** — cut third. Reasoning trace viewer is the verifiability primitive;
+   chat is the engagement layer on top.
+4. **Synthetic protocol** — cut last-resort. If we can't ship synthetics, fall back to
+   the original ArchimedesVault holding USYC + a subset of bridged RWAs. This is a
+   meaningful retreat — flag immediately if it becomes likely.
+
+The four primitives in `architectural-principles.md` are NOT on this cut list. The whole
+pitch dies without them.
 
 ## Cross-decision implications
 

--- a/docs/qfin-paper-corpus-seed.md
+++ b/docs/qfin-paper-corpus-seed.md
@@ -22,7 +22,27 @@ A paper qualifies for the v1 strategy library if and only if:
 
 Papers below are organized by arxiv [q-fin category](https://arxiv.org/list/q-fin/recent).
 **Validation status to be filled by Dan:** ✓ = re-validated; ⚠ = re-implementation in
-progress; ☐ = candidate not yet evaluated.
+progress; ☐ = candidate not yet evaluated; 🌱 = seeded as analytics-engine strategy file
+awaiting backtest run.
+
+## Day 3 seeded strategies (2026-05-13)
+
+Three strategies have been written as runnable backtrader files in
+[`analytics-engine/strategies/`](../analytics-engine/strategies/) and are loadable by
+[`backend/archimedes/services/strategy_provider.py`](../backend/archimedes/services/strategy_provider.py):
+
+- 🌱 **A2** Moskowitz, Ooi & Pedersen 2012 — Time Series Momentum
+  ([`moskowitz_ooi_pedersen_2012_tsmom.py`](../analytics-engine/strategies/moskowitz_ooi_pedersen_2012_tsmom.py))
+- 🌱 **A new — single-asset SMA200 trend filter** — Faber 2007
+  ([`faber_2007_sma200_timing.py`](../analytics-engine/strategies/faber_2007_sma200_timing.py))
+- 🌱 **A new — volatility-managed long** — Moreira & Muir 2017
+  ([`moreira_muir_2017_volatility_managed.py`](../analytics-engine/strategies/moreira_muir_2017_volatility_managed.py))
+
+All three are *single-asset* per the analytics-engine's one-feed-per-backtest constraint.
+Cross-sectional papers like A1 (Jegadeesh-Titman) and A3 (HRP) require multi-feed
+support and stay deferred for v1.5. Per-asset backtests pending Önder's
+`IBacktestEvaluator` implementation; until then the strategies load with `status =
+CANDIDATE` and no `BacktestResult`.
 
 ---
 

--- a/docs/specs/commit-reveal-trace-spec.md
+++ b/docs/specs/commit-reveal-trace-spec.md
@@ -45,14 +45,22 @@ T-2:  ReasoningTraceRegistry.commit(trace_hash, trade_intent_summary)
         - Emits TraceCommitted(traceId, hash, msg.sender, block.number)
         - Stores commitment in a pending-traces table
 T-3:  Vault.rebalance(trades)  [trade executes on Arc]
-T-4:  ReasoningTraceRegistry.reveal(traceId, trace_content_pointer, content_hash)
-        - Verifies keccak256(content_pointer_contents) == committed hash
-        - Emits TraceRevealed(traceId, pointer, block.number)
+T-4:  Upload canonical_trace_json to off-chain storage; obtain storagePointer.
+T-5:  ReasoningTraceRegistry.reveal(traceId, storagePointer, fullTraceContent)
+        - On-chain: verifies keccak256(fullTraceContent) == committed contentHash
+        - Records storagePointer alongside the commitment
+        - Emits TraceRevealed(traceId, storagePointer, block.number)
         - Promotes commitment from pending to revealed
 ```
 
+Note that the reveal call carries both the off-chain `storagePointer` (URL/IPFS/Arweave —
+the canonical place to fetch the content from) and the `fullTraceContent` bytes (so the
+contract itself can recompute the hash and verify the binding without trusting any
+off-chain fetch). The storage pointer is recorded for convenience; the hash verification
+is what enforces the commit.
+
 Between T-2 and T-3, the trace hash is on-chain and **immutable**. The agent cannot
-alter the content without breaking the verification at T-4. The reveal at T-4 publishes
+alter the content without breaking the verification at T-5. The reveal at T-5 publishes
 the content. Anyone can verify post-hoc that the hash committed before the trade matches
 the content revealed after.
 

--- a/docs/specs/commit-reveal-trace-spec.md
+++ b/docs/specs/commit-reveal-trace-spec.md
@@ -1,0 +1,249 @@
+# Commit-Reveal Reasoning Trace — v1.5 Spec
+
+> **Date:** 2026-05-13 (Day 3)
+> **Owner:** Chuan (smart contracts) + Dan (passport / pitch framing)
+> **Status:** Proposal — v1.5, post-hackathon MVP unless trivially droppable into the
+> existing `ReasoningTraceRegistry` work
+> **Prerequisite reading:**
+> [`../agora_project_analysis.md`](../agora_project_analysis.md) § 5.2,
+> [`./strategy-passport-spec.md`](./strategy-passport-spec.md),
+> [`./ecosystem-design-spec.md`](./ecosystem-design-spec.md) § 3.4
+
+## The problem this solves
+
+A reasoning-trace hash anchored on-chain at time T proves the trace **existed** at time
+T. It does NOT prove the agent **used** that trace to decide the trade. An adversarial
+actor (or a buggy agent) can:
+
+1. Make a trade for any reason.
+2. Generate 100 plausible reasoning traces post-hoc.
+3. Pick the one that retroactively rationalizes the trade.
+4. Publish its hash to the registry.
+
+The user sees a hash on-chain and a matching trace off-chain and concludes "the agent
+reasoned this way, then traded." But the audit trail does not actually prove that
+ordering or causation.
+
+The current v1 design from
+[`ecosystem-design-spec.md`](./ecosystem-design-spec.md) § 3.4 is vulnerable to this
+critique. We disclose the limit honestly per the Day-3 addition to `anti-features.md`
+("NOT claiming: that an on-chain trace hash proves the agent used the trace") — but
+disclosure is weaker than mitigation. Commit-reveal is the mitigation.
+
+## The proposal
+
+Anchor the reasoning trace's hash **before** the trade executes; reveal the trace content
+**after** the trade settles. The agent then publicly cannot tailor reasoning to outcomes
+without breaking the hash.
+
+### Sequence
+
+```
+T-0:  Agent decides what trade to make + writes reasoning trace.
+T-1:  Compute trace_hash = keccak256(canonical_trace_json).
+T-2:  ReasoningTraceRegistry.commit(trace_hash, trade_intent_summary)
+        - Emits TraceCommitted(traceId, hash, msg.sender, block.number)
+        - Stores commitment in a pending-traces table
+T-3:  Vault.rebalance(trades)  [trade executes on Arc]
+T-4:  ReasoningTraceRegistry.reveal(traceId, trace_content_pointer, content_hash)
+        - Verifies keccak256(content_pointer_contents) == committed hash
+        - Emits TraceRevealed(traceId, pointer, block.number)
+        - Promotes commitment from pending to revealed
+```
+
+Between T-2 and T-3, the trace hash is on-chain and **immutable**. The agent cannot
+alter the content without breaking the verification at T-4. The reveal at T-4 publishes
+the content. Anyone can verify post-hoc that the hash committed before the trade matches
+the content revealed after.
+
+### What this prevents
+
+| Attack | Without commit-reveal | With commit-reveal |
+|---|---|---|
+| Generate 100 traces, pick best one to publish | Possible | The committed hash binds the agent to a single trace before the trade lands |
+| Edit trace content after seeing trade outcome | Possible (the hash is computed on the edited content) | Hash verification at reveal fails |
+| Backdate a trace to look like it preceded the trade | Possible — the off-chain timestamp is forgeable | Commit transaction's block number is the timestamp; reveal must follow |
+| Claim "the agent reasoned, then traded" causally | Disclaimed in anti-features.md as unverifiable | Provable: commit block < trade block < reveal block |
+
+### What it does not prevent
+
+- The agent **could** still commit a trace it never internally used. But it has to commit
+  to *one* trace per decision, before the outcome is knowable, which is a much stronger
+  bar than "any trace consistent with the outcome." This is the same property that
+  makes commit-reveal valuable in prediction-market resolution and zk-proof submission.
+- A coordinated attacker controlling both the agent and the on-chain registry could
+  game both. We assume the registry is genuinely public and the agent does not control
+  the chain.
+- This does not address the "garbage in, garbage out" reasoning quality problem — only
+  the integrity-over-time problem.
+
+## Contract changes
+
+The existing `IReasoningTraceRegistry` from
+[`../../contracts/src/interfaces/IReasoningTraceRegistry.sol`](../../contracts/src/interfaces/IReasoningTraceRegistry.sol)
+needs three new functions plus state. Sketch:
+
+```solidity
+interface IReasoningTraceRegistry {
+    // ── Existing v1 ─────────────────────────────────────────
+    function publishTrace(bytes32 hash, bytes calldata metadata) external;
+    function verifyTrace(uint256 id, bytes calldata fullTrace) external view returns (bool);
+    function getTraces(address agent, uint256 from, uint256 to) external view returns (bytes32[] memory);
+
+    // ── New for v1.5 ────────────────────────────────────────
+    function commit(
+        bytes32 contentHash,
+        bytes calldata tradeIntentSummary   // ABI-encoded: vaultAddr, decisionType, numTrades, totalNotionalUsdc
+    ) external returns (uint256 traceId);
+
+    function reveal(
+        uint256 traceId,
+        string calldata storagePointer,    // URL/IPFS/Arweave
+        bytes calldata fullTraceContent    // For on-chain verification of the hash
+    ) external;
+
+    function getCommitment(uint256 traceId) external view returns (
+        bytes32 contentHash,
+        address committer,
+        uint256 commitBlock,
+        bool revealed,
+        uint256 revealBlock,
+        string memory storagePointer
+    );
+}
+```
+
+### Storage
+
+```solidity
+struct Commitment {
+    bytes32 contentHash;
+    address committer;
+    uint64 commitBlock;
+    uint64 revealBlock;          // 0 until revealed
+    string storagePointer;        // empty until revealed
+}
+
+mapping(uint256 => Commitment) public commitments;
+uint256 public nextTraceId;
+```
+
+### Events
+
+```solidity
+event TraceCommitted(uint256 indexed traceId, bytes32 indexed contentHash, address indexed committer, uint256 commitBlock);
+event TraceRevealed(uint256 indexed traceId, string storagePointer, uint256 revealBlock);
+```
+
+### Gas + cost estimate
+
+Per ecosystem-design-spec § 3.4, traces anchor for ~$0.01 on Arc via Paymaster. The
+commit-reveal pattern doubles the on-chain footprint per decision: one commit tx + one
+reveal tx. Conservative estimate: **~$0.02 per decision instead of $0.01**. At ~20
+agent decisions across 4 Tier-1 vaults during the demo window, that's $1.60 in
+testnet gas. Negligible.
+
+## Backend changes
+
+`backend/archimedes/services/trace_publisher.py` (Marten's lane per
+[`component-interfaces-spec.md`](./component-interfaces-spec.md)) extends from a single
+`publish(trace)` call to a two-step sequence:
+
+```python
+class ITracePublisher(Protocol):
+    async def commit(self, trace: ReasoningTrace, trade_intent: TradeIntent) -> int:
+        """Commit the trace hash on-chain BEFORE the rebalance executes.
+
+        Returns the on-chain traceId. Stores the commitment locally so the
+        reveal step can complete asynchronously after the vault settles.
+        """
+        ...
+
+    async def reveal(self, trace_id: int, trace: ReasoningTrace) -> str:
+        """Reveal the full trace content AFTER the rebalance settles.
+
+        Uploads the canonical trace JSON to storage, then calls the registry's
+        reveal() with the storage pointer + the full content for hash
+        verification. Returns the tx hash.
+        """
+        ...
+```
+
+The agent orchestrator (`IAgentOrchestrator.tick`) sequence becomes:
+
+1. Decide → trace object built (no hash yet)
+2. `trace.compute_hash()` → 32-byte hash
+3. `trace_publisher.commit(trace, intent)` → on-chain commitment + traceId
+4. `chain_executor.execute_trades(vault, trades)` → vault settles
+5. `trace_publisher.reveal(traceId, trace)` → full trace published
+6. Both `commit_tx_hash` and `reveal_tx_hash` recorded on the `reasoning_traces` row
+
+The `ReasoningTrace` dataclass needs two additions:
+
+```python
+commit_tx_hash: str | None = None       # Tx that committed the hash pre-trade
+reveal_tx_hash: str | None = None       # Tx that revealed the content post-trade
+```
+
+`is_anchored` becomes `is_commit_anchored` + `is_reveal_anchored`.
+
+## UI implications
+
+The passport's "verify trace" element grows by one button:
+
+- **Verify content hash** — recompute keccak256 on the displayed trace, compare to the
+  on-chain commitment. (Already in spec.)
+- **Verify temporal binding** — show the user that `commitBlock < tradeBlock <
+  revealBlock`. A green checkmark with a tooltip explaining what this proves vs. what
+  it does not prove.
+
+The tooltip text matters. Suggested copy:
+
+> "The reasoning trace was hashed and recorded on Arc before this trade executed. The
+> hash committed the agent to a single trace; the reveal published the content
+> afterward. This proves the trace existed at the time of the trade — it does not
+> prove the agent's reasoning was correct or that the trade was profitable."
+
+That's honesty about what the cryptography buys you.
+
+## Acceptance criteria for v1.5
+
+- [ ] `ReasoningTraceRegistry.sol` has working `commit()` and `reveal()` with
+      hash-verification on reveal.
+- [ ] `trace_publisher.commit()` and `reveal()` round-trip cleanly against an Arc
+      testnet deployment.
+- [ ] At least one Tier-1 vault demo decision shows: commit tx → rebalance tx → reveal
+      tx in that block order.
+- [ ] The "Verify temporal binding" UI element renders green for that decision.
+- [ ] The `anti-features.md` "NOT claiming: that an on-chain trace hash proves the agent
+      used the trace" entry is updated to reflect that v1.5 mitigates this — though does
+      not eliminate it.
+
+## Why this is v1.5 not v1
+
+- Doubles the orchestrator's on-chain call sequence — adds latency between decision and
+  trade settlement (commit must confirm before the rebalance can fire).
+- Doubles the contract surface — `ReasoningTraceRegistry` is currently interface-only;
+  adding commit-reveal before there's even a v1 implementation risks scope-creeping
+  Chuan's contract lane in the final hackathon week.
+- The disclosure-not-mitigation stance in `anti-features.md` § "pitch-rigor anti-claims"
+  is a coherent v1 posture. v1.5 turns it into a real mitigation; v2 could go further
+  (zk-proof of LLM execution, threshold-encrypted commit windows).
+
+## Out-of-scope
+
+- ZK-proof of the LLM call itself. The commit-reveal binds the trace content; it does
+  not prove the LLM actually generated that content vs. a human typing it. v2 territory.
+- Time-locked reveal windows that force a minimum delay between commit and reveal.
+  v2 — only useful in adversarial settings we don't expose in v1.5.
+- Compressed batched commitments (Merkle-root over many traces). Useful at scale, not
+  at the ~20-decisions-per-demo scale of the hackathon.
+
+## References
+
+- The commit-reveal pattern in cryptography: Naor (1989), "Bit commitment using
+  pseudorandom generators."
+- The same pattern in prediction-market resolution: Augur, Realitio, and most
+  oracle-based markets use commit-reveal for honest reporting.
+- The "trace existed at T, doesn't prove causation" critique:
+  [`../agora_project_analysis.md`](../agora_project_analysis.md) § 5.2.

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -61,19 +61,32 @@ Non-Normality. *Journal of Portfolio Management* 40(5), 94–107.
 
 ### Formula
 
-Given Sharpe ratio `SR_hat` estimated from `T` daily returns with skewness
-`gamma_3` and excess kurtosis `gamma_4`, and `N` independent trials in the
-selection set, the DSR is the probability that the true Sharpe exceeds zero:
+Convention: `SR_hat` is the **per-bar** Sharpe ratio (un-annualized). If the
+caller carries an annualized Sharpe, divide by `sqrt(annualization_factor)`
+before computing DSR (annualization is purely a display transform). Skewness
+`gamma_3` and excess kurtosis `gamma_4` are likewise computed on the per-bar
+return series.
+
+Given `T` per-bar returns, the per-bar Sharpe `SR_hat`, and `N` independent
+trials in the selection set, the DSR is the probability that the true Sharpe
+exceeds zero:
 
 ```
-SR_zero = sqrt( (1 - gamma_E) + gamma_E^2 ) * (1 / sqrt(N))
-       where gamma_E ≈ 0.5772 (Euler-Mascheroni)
-       (the Bailey-López de Prado approximation for the expected max of
-        N iid normal Sharpe estimates)
+gamma_E = 0.5772156649        # Euler-Mascheroni
+Phi_inv = standard normal inverse CDF (scipy.stats.norm.ppf)
 
-DSR = Z * ( (SR_hat - SR_zero) * sqrt(T - 1) /
-            sqrt( 1 - gamma_3 * SR_hat + ((gamma_4 - 1) / 4) * SR_hat^2 ) )
-       where Z is the standard normal CDF
+# Bailey-López de Prado (2014) approximation for E[max_N] across N iid
+# normal Sharpe estimates with unit variance:
+E_max_N = (1 - gamma_E) * Phi_inv(1 - 1/N)
+        + gamma_E       * Phi_inv(1 - 1/(N * e))
+
+# Per-bar SR_hat has variance 1/(T - 1) under the iid normal null, so the
+# expected best-of-N under the null is scaled by sqrt(1/(T - 1)):
+SR_zero = sqrt(1 / (T - 1)) * E_max_N
+
+# Standard normal CDF of the variance-corrected z statistic:
+DSR = Phi( (SR_hat - SR_zero) * sqrt(T - 1)
+         / sqrt(1 - gamma_3 * SR_hat + ((gamma_4 - 1) / 4) * SR_hat^2) )
 ```
 
 `dsr_p_value` is the resulting probability (0 to 1). Higher = more confident
@@ -114,7 +127,7 @@ This will be wired in T5 (post-hackathon if not reached).
 
 | Field | Source | Notes |
 |---|---|---|
-| `returns_matrix: np.ndarray (T, N)` | orchestrator | Daily returns for all N candidate strategies aligned on the same T dates |
+| `returns_matrix: dict[str, list[float]]` | orchestrator | Map of `strategy_id → daily returns` for all N candidate strategies aligned on the same T dates. The evaluator converts this to an internal `np.ndarray` of shape `(T, N)` (column order pinned by sorted `strategy_id`) before running CSCV — the dict-keyed input is what the orchestrator naturally carries and preserves the strategy-id mapping needed for the `dict[str, float]` return value. |
 | `S: int` | constant `16` | Number of CSCV partitions; 16 is the paper's recommended default |
 | `selection_metric: callable` | default `sharpe_ratio` | The function used to pick the "best" strategy |
 
@@ -218,23 +231,24 @@ def compute_pbo(
 - [ ] Unit tests: a hand-constructed return series with known properties
       reproduces a DSR and PBO matching reference values (within tolerance).
 
-## Numerical sanity-check example (for unit test seed)
+## Numerical sanity-check examples (for unit test seed)
 
-A strategy with:
-- `sharpe_ratio = 1.8` over `T = 2520` days (10 years)
-- `skewness = -0.4`, `excess_kurtosis = 3.2`
-- `num_trials = 10` (a library of 10 strategies)
+All three cases use the per-bar convention: `SR_per_bar = SR_annualized /
+sqrt(252)` for daily bars, and skew/excess-kurtosis computed on the per-bar
+series. Reference values below were computed against `scipy.stats.norm.ppf`
+and `norm.cdf`; pin the unit tests to these to catch implementation drift.
 
-Expected (approximate):
-- `SR_zero ≈ sqrt(1.557) * 1/sqrt(10) ≈ 0.394`
-- `DSR statistic ≈ (1.8 - 0.394) * sqrt(2519) / sqrt(1 - (-0.4)(1.8) + (2.2/4)(3.24))`
-  `≈ 1.406 * 50.19 / sqrt(1 + 0.72 + 1.782) ≈ 70.57 / 1.873 ≈ 37.7`
-- `dsr_p_value ≈ Z(37.7) ≈ ~1.0` (very high confidence Sharpe > 0)
+| Case | `SR_ann` | `T` | `skew` | `ex_kurt` | `N` | `SR_zero` (per-bar) | `z` | `dsr_p_value` |
+|---|---|---|---|---|---|---|---|---|
+| A — strong | 1.8 | 2520 | −0.4 | 3.2  | 10   | 0.0314 |  4.013 | ~1.0000 |
+| B — borderline | 0.9 | 1260 | −0.2 | 2.0  | 20   | 0.0536 |  0.110 | ~0.5439 |
+| C — failure | 0.3 | 504  |  0.0 | 0.0  | 1000 | 0.1451 | −2.831 | ~0.0023 |
 
-A weaker strategy with `sharpe_ratio = 0.9`, same N=10, T=2520, same higher
-moments produces `dsr_p_value ≈ 0.99x` — still likely positive but with
-visibly lower confidence. Use a `sharpe_ratio = 0.3, N=1000` case to
-produce a `dsr_p_value < 0.5` for the failure-case unit test.
+Case A is the slam-dunk: a long, smooth backtest with a small library.
+Case B is the "credibly positive but not at the 95% bar" boundary used to
+exercise the gate threshold. Case C is the multiple-testing failure mode —
+a weak Sharpe pulled out of a thousand-trial selection should *not* clear
+the gate, even with arbitrarily clean residuals.
 
 ## What this spec deliberately does not specify
 

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -1,0 +1,260 @@
+# Selection-Bias Corrections — Implementation Spec
+
+> **Date:** 2026-05-13 (Day 3)
+> **Owner:** Önder (math + statistics)
+> **Consumers:** Dan (strategy validation gate), Daniel R. (analytics-engine
+> output), Daniel S. (passport UI), Chuan (orchestrator's rigor gate)
+> **Status:** Draft — ready for Önder review and implementation
+> **Prerequisite reading:** [`../agora_project_analysis.md`](../agora_project_analysis.md)
+> § 5.3, [`./strategy-passport-spec.md`](./strategy-passport-spec.md),
+> [`../architectural-principles.md`](../architectural-principles.md)
+
+## Why this exists
+
+The strongest red-team critique of an LLM-driven strategy-extraction pipeline
+is **multiple-testing inflation**. If we evaluate N candidate strategies on
+historical data and pick the top K by backtest Sharpe, we are running an
+N-way selection experiment without selection-bias control. McLean & Pontiff
+(2016) showed published cross-sectional predictors lost ~26% of return
+out-of-sample and ~58% post-publication; Bailey, Borwein, López de Prado &
+Zhu (2014) demonstrated that under realistic multiple-testing conditions
+the in-sample-optimal strategy frequently does not even dominate the median
+out-of-sample. Either failure mode produces a "validated" strategy that
+fails in production.
+
+**Archimedes' wedge against the 96 other AI-portfolio submissions at the
+last HackMoney is that we apply the textbook corrections.** This spec
+defines the contract.
+
+## What this spec covers
+
+Three corrections, each populating specific fields on
+[`backend/archimedes/models/backtest.py`](../../backend/archimedes/models/backtest.py)
+`BacktestResult`:
+
+1. **Deflated Sharpe Ratio (DSR)** — Sharpe corrected for non-normality and
+   multiple testing (Bailey & López de Prado 2014).
+2. **Probability of Backtest Overfitting (PBO)** — CSCV-framework probability
+   that the in-sample-optimal strategy underperforms the median out-of-
+   sample (Bailey, Borwein, López de Prado & Zhu 2014).
+3. **Walk-forward OOS Sharpe** — held-out-of-sample slice metric, separate
+   from in-sample. The analytics-engine already exposes `walk_forward_split`
+   and `out_of_sample_sharpe` slots; this spec defines how they're populated.
+
+The fourth column, `look_ahead_audit_passed`, is a static-analysis check
+already wired by Daniel R.'s engine — covered briefly at the end for
+completeness.
+
+## 1. Deflated Sharpe Ratio (DSR)
+
+**Reference:** Bailey, D. H., & López de Prado, M. (2014). The Deflated
+Sharpe Ratio: Correcting for Selection Bias, Backtest Overfitting and
+Non-Normality. *Journal of Portfolio Management* 40(5), 94–107.
+
+### Inputs
+
+| Field | Source | Notes |
+|---|---|---|
+| `daily_returns: list[float]` | analytics-engine `BacktestResult.daily_returns` | Already populated |
+| `num_trials: int` | caller (orchestrator) | See § 1.3 for sourcing rules |
+| `annualization: int` | constant `252` | Daily bars assumption |
+
+### Formula
+
+Given Sharpe ratio `SR_hat` estimated from `T` daily returns with skewness
+`gamma_3` and excess kurtosis `gamma_4`, and `N` independent trials in the
+selection set, the DSR is the probability that the true Sharpe exceeds zero:
+
+```
+SR_zero = sqrt( (1 - gamma_E) + gamma_E^2 ) * (1 / sqrt(N))
+       where gamma_E ≈ 0.5772 (Euler-Mascheroni)
+       (the Bailey-López de Prado approximation for the expected max of
+        N iid normal Sharpe estimates)
+
+DSR = Z * ( (SR_hat - SR_zero) * sqrt(T - 1) /
+            sqrt( 1 - gamma_3 * SR_hat + ((gamma_4 - 1) / 4) * SR_hat^2 ) )
+       where Z is the standard normal CDF
+```
+
+`dsr_p_value` is the resulting probability (0 to 1). Higher = more confident
+the true Sharpe is positive after correcting for the N-way selection.
+
+### Outputs
+
+Populate on `BacktestResult`:
+
+- `deflated_sharpe_ratio: float` — the corrected Sharpe value (Sharpe units,
+  not probability)
+- `dsr_p_value: float` — probability the true Sharpe > 0
+- `num_trials_in_selection: int` — the N value used
+
+### Sourcing N (`num_trials_in_selection`)
+
+For v1, `N` is the number of distinct strategies evaluated by the analytics-
+engine in the same "selection round" — i.e. the size of the curated library
+at evaluation time. The orchestrator passes this in as a single integer.
+
+**Concretely:** when Önder's `evaluate(strategy, ...)` is called by the
+orchestrator, the orchestrator also passes
+`num_trials = len(strategy_provider.list_strategies())`. The default in the
+absence of context is `1` (no correction), but a warning is logged if N=1
+when more than one strategy exists in the library.
+
+For LLM-extracted candidates (the arxiv pipeline demo), `N` should reflect
+the candidate pool size from the most recent extraction pass, not the
+library size — the LLM tried K methodology variants and we picked the best.
+This will be wired in T5 (post-hackathon if not reached).
+
+## 2. Probability of Backtest Overfitting (PBO)
+
+**Reference:** Bailey, D. H., Borwein, J., López de Prado, M., & Zhu, J.
+(2014). The Probability of Backtest Overfitting. SSRN 2326253.
+
+### Inputs
+
+| Field | Source | Notes |
+|---|---|---|
+| `returns_matrix: np.ndarray (T, N)` | orchestrator | Daily returns for all N candidate strategies aligned on the same T dates |
+| `S: int` | constant `16` | Number of CSCV partitions; 16 is the paper's recommended default |
+| `selection_metric: callable` | default `sharpe_ratio` | The function used to pick the "best" strategy |
+
+### Algorithm (CSCV — Combinatorially Symmetric Cross-Validation)
+
+1. Partition the T-day return matrix into `S` equal-size submatrices along
+   the time axis.
+2. Enumerate every combination `C(S, S/2)` of S/2 submatrices forming the
+   in-sample set; the complement is out-of-sample.
+3. For each split, rank all N strategies in-sample by `selection_metric`,
+   identify the strategy with the highest in-sample rank, then look up its
+   out-of-sample rank.
+4. The relative OOS rank `omega = rank_OOS / N` produces the logit
+   `lambda = log( omega / (1 - omega) )`.
+5. `PBO = P(lambda <= 0)` — the fraction of splits in which the in-sample-
+   best strategy underperforms the OOS median.
+
+### Outputs
+
+Populate on `BacktestResult`:
+
+- `pbo_score: float` — probability of backtest overfitting (0 to 1, lower
+  is better)
+
+A `pbo_score >= 0.5` means the in-sample-optimal strategy is expected to
+underperform the median strategy out-of-sample — the strategy fails the
+rigor gate.
+
+### Computation cadence
+
+PBO is a **library-level** metric, not a per-strategy metric. Compute once
+per analytics-engine run across all strategies in the library, then attach
+the same `pbo_score` to each strategy's `BacktestResult` from that run.
+Re-compute when the library changes.
+
+## 3. Walk-forward Out-of-Sample Sharpe
+
+The analytics-engine already declares `walk_forward_split` (train fraction,
+default 0.70) and `out_of_sample_sharpe` on its result dataclass. Önder's
+`IBacktestEvaluator` should:
+
+1. Split `daily_returns` by `walk_forward_train_fraction` along the time
+   axis. No shuffling.
+2. Run the strategy logic over the **train** slice for any
+   parameter-tuning the strategy supports (v1 strategies are
+   non-parameterized so this is a no-op).
+3. Apply the chosen parameters to the **test** slice and compute Sharpe
+   over the test slice alone.
+4. Populate `out_of_sample_sharpe` with the test-slice Sharpe.
+
+The rigor gate requires `out_of_sample_sharpe / sharpe_ratio >= 0.5` —
+i.e. the OOS Sharpe must be at least half the in-sample Sharpe.
+
+## 4. Look-ahead audit
+
+`look_ahead_audit_passed: bool` is already set by Daniel R.'s engine via
+[`analytics-engine/.../engine.py`](../../analytics-engine/src/archimedes_analytics_engine/engine.py)
+`_lookahead_audit_passed()`, which checks that the broker is not configured
+with `coc` (close-on-close) or `coo` (close-on-open). That covers the
+backtrader-level look-ahead vector; if you add additional static checks
+(e.g. AST analysis of the strategy file for forward-bar references) wire
+the result into the same field.
+
+## API surface
+
+Önder's `IBacktestEvaluator.evaluate` signature already takes the strategy
+and price data. Extend it once to accept `num_trials`:
+
+```python
+def evaluate(
+    self,
+    strategy: Strategy,
+    price_data: dict[str, list[float]],
+    start_date: str | None = None,
+    end_date: str | None = None,
+    num_trials: int = 1,  # NEW — for DSR multiple-testing correction
+) -> BacktestResult: ...
+```
+
+A new method for library-level PBO:
+
+```python
+def compute_pbo(
+    self,
+    returns_matrix: dict[str, list[float]],  # strategy_id -> daily returns
+    s_partitions: int = 16,
+) -> dict[str, float]:  # strategy_id -> pbo_score (all identical)
+    """Compute PBO across the full strategy library."""
+```
+
+## Acceptance criteria for v1
+
+- [ ] `BacktestResult.deflated_sharpe_ratio` and `dsr_p_value` populated for
+      every backtest run with `num_trials > 1`.
+- [ ] `num_trials_in_selection` recorded so the correction is reproducible.
+- [ ] `pbo_score` computed once per library run and attached to every
+      strategy's result from that run.
+- [ ] `out_of_sample_sharpe` populated per strategy via walk-forward split.
+- [ ] `BacktestResult.passes_rigor_gate` returns `True` only when all four
+      controls are present and pass their thresholds.
+- [ ] Unit tests: a hand-constructed return series with known properties
+      reproduces a DSR and PBO matching reference values (within tolerance).
+
+## Numerical sanity-check example (for unit test seed)
+
+A strategy with:
+- `sharpe_ratio = 1.8` over `T = 2520` days (10 years)
+- `skewness = -0.4`, `excess_kurtosis = 3.2`
+- `num_trials = 10` (a library of 10 strategies)
+
+Expected (approximate):
+- `SR_zero ≈ sqrt(1.557) * 1/sqrt(10) ≈ 0.394`
+- `DSR statistic ≈ (1.8 - 0.394) * sqrt(2519) / sqrt(1 - (-0.4)(1.8) + (2.2/4)(3.24))`
+  `≈ 1.406 * 50.19 / sqrt(1 + 0.72 + 1.782) ≈ 70.57 / 1.873 ≈ 37.7`
+- `dsr_p_value ≈ Z(37.7) ≈ ~1.0` (very high confidence Sharpe > 0)
+
+A weaker strategy with `sharpe_ratio = 0.9`, same N=10, T=2520, same higher
+moments produces `dsr_p_value ≈ 0.99x` — still likely positive but with
+visibly lower confidence. Use a `sharpe_ratio = 0.3, N=1000` case to
+produce a `dsr_p_value < 0.5` for the failure-case unit test.
+
+## What this spec deliberately does not specify
+
+- Exact numerical-library choice (scipy vs. numpy vs. statsmodels) — Önder
+  picks.
+- Specific test fixtures or property-based test setup — Önder owns.
+- The PBO `S` parameter beyond the default `16` — known-good per the paper.
+- Encryption / privacy of trial counts (a v2 concern; v1 is fully public).
+
+## References
+
+Bailey, D. H., & López de Prado, M. (2014). The Deflated Sharpe Ratio:
+Correcting for Selection Bias, Backtest Overfitting and Non-Normality.
+*Journal of Portfolio Management* 40(5), 94–107.
+<https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2460551>
+
+Bailey, D. H., Borwein, J., López de Prado, M., & Zhu, J. (2014). The
+Probability of Backtest Overfitting. SSRN 2326253.
+<https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2326253>
+
+McLean, R. D., & Pontiff, J. (2016). Does Academic Research Destroy Stock
+Return Predictability? *Journal of Finance* 71(1), 5–32.
+<https://onlinelibrary.wiley.com/doi/abs/10.1111/jofi.12365>


### PR DESCRIPTION
## Summary

Day 3 evening solo work to seed Dan's `IStrategyProvider` lane per
[`docs/specs/component-interfaces-spec.md`](docs/specs/component-interfaces-spec.md)
and reconcile the doc corpus with Chuan's ecosystem pivot
([`docs/specs/ecosystem-design-spec.md`](docs/specs/ecosystem-design-spec.md))
and the red-team synthesis ([`docs/agora_project_analysis.md`](docs/agora_project_analysis.md)).

The wedge: **rigor**. Tier-1 strategies are admitted only after passing Deflated Sharpe
Ratio, Probability of Backtest Overfitting, walk-forward OOS Sharpe, and a look-ahead
audit — and paper-claim deltas are surfaced honestly. That's the differentiator against
the 96 other AI-portfolio submissions Arc HackMoney saw last cycle.

## Commits

- `b537cbc [models]` Extend `Strategy` + `BacktestResult` with passport + selection-bias fields. New `passes_rigor_gate` property. All new fields optional/defaulted; existing callers untouched.
- `ee3acc6 [backend]` Add `LocalStrategyProvider` in `backend/archimedes/services/strategy_provider.py` implementing `IStrategyProvider` via AST-parsing of the analytics-engine strategy files. Handles both `Assign` and `AnnAssign` nodes.
- `cd2a8d3 [strategies]` Seed three single-asset paper-grounded strategies: Moskowitz-Ooi-Pedersen 2012 TSMOM, Faber 2007 SMA200 timing, Moreira-Muir 2017 volatility-managed. Cross-sectional classics deferred to v1.5 (need multi-feed engine support).
- `f88c5d2 [docs]` `docs/specs/selection-bias-corrections-spec.md` — Önder's contract for DSR + PBO + walk-forward OOS + look-ahead. Includes a unit-test seed example.
- `7a2a403 [docs]` Day-3 reconciliation: `CLAUDE.md` + `anti-features.md` + `architectural-principles.md` + `mvp-scope-memo.md` + `qfin-paper-corpus-seed.md` all updated for two-tier marketplace + rigor-as-wedge. Three contradicted anti-features dropped; five new "pitch-rigor anti-claims" added. Architectural primitives go from 3 to 4.

## Test plan

- [x] `Strategy` + `BacktestResult` models import and instantiate cleanly with old + new field combinations
- [x] `LocalStrategyProvider().list_strategies()` returns 4 strategies (3 paper-grounded + the existing buy-hold baseline)
- [x] Risk-profile filter routes: conservative=2, moderate=4, aggressive=1, hyper_risky=0
- [x] All three new strategy files import under backtrader (verified with module-level `exec_module`)
- [x] `Strategy.compute_methodology_hash()` produces deterministic SHA-256 over canonical methodology
- [x] `BacktestResult.passes_rigor_gate` returns False when DSR/PBO/OOS fields are unset (correct — pre-Önder)

## Things to look at in review

- **Shared models changed.** Per [`component-interfaces-spec.md`](docs/specs/component-interfaces-spec.md) the change policy says "announce in Discord before changing." The additions are all backward-compatible optional fields, but Önder + Chuan should sign off on the names and types before merge.
- **The new pitch-rigor anti-claims** in `anti-features.md` constrain the deck framing (no "blockchain as memory", no predicted-alpha, no causation-from-hash claims, no regulatory clarity, no "rigor makes them right"). Dan owns the deck so these are his to keep or revise.
- **Architectural principles grew from 3 to 4.** Primitive 4 is selection-bias correction; the Tier 1/Tier 2 split is now formalized as a primitive-coverage matrix. If anyone wanted the Tier 1 badge to mean something looser, this is the moment to push back.
- **The `extract_from_paper` stub** returns None — the arxiv-pipeline implementation is the next spec to write (see follow-up).

## What this PR does NOT do

- Önder's math (DSR / PBO computation) — that's `services/backtest_evaluator.py` per his lane.
- The arxiv extraction pipeline — referenced as a follow-up spec.
- Smart contract changes — none touched.
- Frontend / Daniel R's analytics-engine internals — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)