### PR TITLE
[docs] Day-4 curation: CLAUDE.md + README.md + pitch deck + Claude Design prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,11 +35,17 @@ RPC=
 DEV_WALLET_ADDRESS=
 DEV_WALLET_PRIVATE_KEY=
 
-# ── Oracle price pusher ────────────────────────────────────────────────────
-# Private key of the account authorised to call PriceOracle.setPrice().
-# Must match the `owner` set at contract deploy time. Leave blank to run the
-# oracle in fetch-only mode (prices fetched but not pushed on-chain).
-ARC_OWNER_PRIVATE_KEY=
+# ── Circle Developer Controlled Wallets ───────────────────────────────────
+# Used by the oracle runner to push prices on-chain via the Circle wallet
+# that owns the PriceOracle contracts (address 0xc221dC...9aC9).
+# CIRCLE_API_KEY and CIRCLE_ENTITY_SECRET come from the Circle Developer Console.
+# WALLET_ID is the Circle wallet UUID, WALLET_ADDRESS is its EVM address.
+CIRCLE_API_KEY=
+CIRCLE_ENTITY_SECRET=
+WALLET_ID=
+WALLET_ADDRESS=
+WALLET_SET_ID=
+
 # How often the oracle runner pushes prices (seconds, default 60).
 ORACLE_INTERVAL_SECONDS=60
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # Archimedes — Claude Code Context
 
-o> **Status:** Living context doc, written 2026-05-12 (Day 2), revised 2026-05-13 (Day 3)
-> for the marketplace pivot and rigor-as-wedge decision. Intent: drop at the root of the
-> `archimedes` repo and read at the start of every Claude Code session.
+> **Status:** Living context doc. Written 2026-05-12 (Day 2), revised 2026-05-13 (Day 3)
+> for the marketplace pivot and rigor-as-wedge decision, revised 2026-05-14 (Day 4) after
+> the 10-contract Arc-testnet deployment, live UI, and ownership reshuffle. Intent: drop
+> at the root of the `archimedes` repo and read at the start of every Claude Code session.
 >
 > **Architecture lineage to read together:**
 > - [`docs/design.md`](docs/design.md) — original single-vault architecture
@@ -30,7 +31,11 @@ May 11–25, 2026.
 
 - Repository: [`github.com/hackagora/archimedes-arcadia`](https://github.com/hackagora/archimedes-arcadia)
 - Discord: **Archimedes Arcadia** server
-- Primary branch: `main`; active design work on `design`; integration on `develop`
+- Branch model: `develop` is the integration branch; `main` is protected and promoted-to
+  once stable. Per-owner staging branches (e.g. `dbrowneup/<name>`, `moonshot/<name>`,
+  `marten`) are personal scratch space before opening a PR
+- Live testnet deploy: [`http://18.171.230.205/`](http://18.171.230.205/) (EC2,
+  Chain ID `5042002` / `0x4cef52`, Arc testnet)
 - License: [Unlicense](https://unlicense.org) — full public-domain dedication
 
 ## North Star
@@ -89,15 +94,20 @@ Bremen / 16:00 Ankara. Works across the whole team without anyone in unsocial ho
 | -------------------------------------------------- | ---------------- | --------------------- |
 | Strategy engine + Q-fin paper corpus curation       | Dan              | Önder                 |
 | Backtesting / strategy-passport math + risk pricing | Önder            | Dan                   |
-| Backend (FastAPI, strategy DB, portfolio agent)     | (open — TBD)     | Marten                |
-| Frontend (Next.js, portfolio dashboard, traces)     | Daniel           | Dan                   |
-| Smart contracts (Arc, Circle SDK)                   | Chuan            | Marten                |
-| Off-chain ↔ on-chain orchestration                  | Marten           | Chuan                 |
+| Backend Python layer (FastAPI, API, services, models) | Daniel R.      | Marten                |
+| On-chain integration layer (`backend/archimedes/chain/`, oracle runner) | Chuan | Marten          |
+| Frontend (React + Vite + viem, wallet UX, trade tab) | Marten (current) / Daniel R. | Dan       |
+| Smart contracts (Arc, Foundry, 10 deployed)         | Chuan            | Marten                |
+| Infra / EC2 / CI/CD / docker-compose                | Chuan            | Daniel R.             |
 | Architecture + design decisions                     | Chuan (lead)     | full team             |
-| Pitch deck + demo script + judging strategy         | Dan              | Marten                |
+| Pitch deck + demo script + Claude Design + judging  | Dan              | Marten                |
 
-Backend ownership is the one un-filled slot since Shimon left. The team should decide by
-end of Day 3 whether to spread it across the four engineers or hire externally.
+The post-Shimon backend slot resolved as a Daniel R. (Python backend) + Chuan (on-chain
+integration) split — the `chain/` subdirectory under `backend/archimedes/` is Chuan's, and
+`api/` + `services/` + `models/` + `interfaces/` are Daniel R.'s. Both layers share the
+`backend/archimedes/` Python package and the FastAPI app boots them together via
+`main.py`. Marten currently has the most recent commits on the React UI as he comes up to
+speed on what the team has built.
 
 ## Setup
 
@@ -169,10 +179,20 @@ The CLI is two things in one binary:
 
 ## Tech Stack
 
-Refer to [`docs/design.md` § 6](docs/design.md) for the full table. Headline choices:
+Refer to [`docs/design.md` § 6](docs/design.md) for the full table. Headline choices as
+they actually shipped (Day 4):
 
-- **Backend:** Python 3.12 / FastAPI / Uvicorn
-- **Frontend:** Next.js + TailwindCSS (Daniel's call as frontend owner)
+- **Backend:** Python 3.12 / FastAPI / Uvicorn, packaged as `backend/archimedes/` with
+  subpackages `api/` (routes), `chain/` (on-chain integration + oracle runner),
+  `interfaces/` (frozen Protocol classes), `models/` (Strategy, BacktestResult,
+  ReasoningTrace, Portfolio dataclasses), `services/` (LocalStrategyProvider etc.)
+- **Frontend:** React 19 + Vite 8 + viem 2.48 + plain CSS. Lives at [`ui/`](ui/) (the
+  earlier `ui-mockups/` static-HTML directory is now retired but still in-tree).
+  Components shipped: `Layout`, `WalletConnect` (MetaMask / Coinbase / generic browser
+  wallet), `Trade`
+- **Analytics engine:** [`analytics-engine/`](analytics-engine/) — uv-managed Python
+  package with the backtrader runner. Loads strategy files from
+  [`analytics-engine/strategies/`](analytics-engine/strategies/)
 - **DB:** PostgreSQL + Redis (Postgres for strategies + backtests; Redis for live regime
   state)
 - **LLM:** Claude API for strategy extraction, reasoning trace generation, user-facing
@@ -182,9 +202,17 @@ Refer to [`docs/design.md` § 6](docs/design.md) for the full table. Headline ch
   Supersedes `docs/design.md` § 6 ("vectorbt / custom numpy engine") on this one
   line; design.md remains the architecture spec for everything else. Migration to
   vectorbt is a v2 problem if parameter-sweep speed becomes a constraint.
-- **Smart contracts:** Solidity targeting Arc (EVM-compatible)
-- **On-chain integration:** Circle SDK — Wallets, USYC, Gateway, CCTP, Paymaster, App Kit
-- **Deployment:** Docker + Fly.io / Railway
+- **Smart contracts:** Solidity + Foundry, targeting Arc (EVM-compatible). **10 contracts
+  deployed on Arc testnet as of Day 4**: `AMMPool`, `AMMRouter`, `AssetRegistry`,
+  `PriceOracle`, `ReasoningTraceRegistry`, `SyntheticFactory`, `SyntheticToken`,
+  `SyntheticVault`, `Vault`, `VaultFactory`. ABIs cached in
+  [`contracts/abis/`](contracts/abis/) for backend + UI consumption
+- **On-chain integration:** Circle SDK — Wallets (Circle-managed wallet for the oracle
+  signer), USYC, Gateway, CCTP, Paymaster; viem on the UI side
+- **Deployment:** Docker compose stack (5 services: postgres / redis / nginx / oracle /
+  backend) running on an EC2 instance behind nginx. CI/CD wired via GitHub Actions per
+  [`docs/infra-setup.md`](docs/infra-setup.md). Live at
+  [`http://18.171.230.205/`](http://18.171.230.205/)
 
 ## Scope — the headline commitments
 
@@ -214,15 +242,19 @@ decisions (5 of them as of Day 3):
 
 ### Branch model (5-person hackathon team, async-first)
 
-- `main` is protected. Every change goes through a PR.
+- `main` is protected. Every change goes through a PR. (Day-4 reality: small infra fixes
+  have occasionally landed on `main` directly via merge from the contracts owner's branch
+  for hotfix expediency. Keep this rare — `develop` is the integration target.)
 - `develop` is the integration branch — merge feature branches here first; promote to
   `main` once stable.
 - Feature branches: `feat/<short-name>`, e.g. `feat/strategy-passport`,
-  `feat/regime-detection`.
+  `feat/regime-detection`, `feat/ec2-infra-cicd`.
 - Per-owner branches: `<discord-handle>/<short-name>`, e.g. `moonshot/contracts-v0`,
-  `marten/arc-cli-spike`. Personal staging.
-- Smart-contract branches: `contract/<short-name>` — these get **two reviews** (Chuan +
-  one generalist) before merge.
+  `marten/arc-cli-spike`, `dbrowneup/strategy-foundation`,
+  `danielscoffee/backtest`. Personal staging.
+- Smart-contract branches: `smart-contracts` (the live branch Chuan uses) or
+  `contract/<short-name>` for spikes — these get **two reviews** (Chuan + one generalist)
+  before merge.
 - **No force-push to `main` or `develop`. Ever.** Force-push to your own branch before
   opening a PR is fine.
 
@@ -277,8 +309,11 @@ rules:
 - Any smart contract change (needs Chuan's review)
 - Editing `.env.example` (signals an env contract change for everyone)
 - Editing [`environment.yml`](environment.yml) (every team member rebuilds their env on a change)
-- Anything that touches the strategy-passport / reasoning-trace data flow once it lands
-- Anything that touches the on-chain vault contract once it lands
+- Anything that touches the strategy-passport / reasoning-trace data flow (the
+  `ReasoningTraceRegistry` contract is live as of Day 4 — modifications are
+  contract-review-grade work)
+- Anything that touches the on-chain vault contracts (`Vault`, `VaultFactory`,
+  `SyntheticVault` — all deployed as of Day 4)
 - Anything that touches `~/.arc-canteen/` files (those are individual team-member credentials —
   see [`README.md` "Security notes"](README.md#security-notes))
 
@@ -305,10 +340,14 @@ surfaced. Detail in [`docs/specs/strategy-passport-spec.md`](docs/specs/strategy
 ### 2. On-chain provenance anchoring
 
 Reasoning traces, strategy registrations, and rebalance decisions all get hashed and
-anchored on Arc via the `ReasoningTraceRegistry` contract (interface lives in
-[`contracts/src/interfaces/IReasoningTraceRegistry.sol`](contracts/src/interfaces/IReasoningTraceRegistry.sol);
-implementation is on Chuan's queue). Hash is the integrity primitive; off-chain storage
-holds the full trace; anyone can recompute and verify against the on-chain anchor.
+anchored on Arc via the [`ReasoningTraceRegistry`](contracts/src/ReasoningTraceRegistry.sol)
+contract (deployed Day 4; interface at
+[`contracts/src/interfaces/IReasoningTraceRegistry.sol`](contracts/src/interfaces/IReasoningTraceRegistry.sol)).
+Hash is the integrity primitive; off-chain storage holds the full trace; anyone can
+recompute and verify against the on-chain anchor. The Day-3 commit-reveal upgrade
+([`docs/specs/commit-reveal-trace-spec.md`](docs/specs/commit-reveal-trace-spec.md))
+strengthens "trace existed at T" to "trace existed *before* the trade" with proven
+causal ordering — wiring this through the live `ReasoningTraceRegistry` is the v1.5 hop.
 
 ### 3. Non-custodial vault architecture
 
@@ -330,21 +369,31 @@ submissions at the last Arc HackMoney. Detail in
 
 ## Known risks
 
-Refer to [`docs/design.md` § 10](docs/design.md) for the technical risk matrix. Adding
-team / coordination risks:
+Refer to [`docs/design.md` § 10](docs/design.md) for the technical risk matrix and
+[`docs/judging-rubric-assessment.md`](docs/judging-rubric-assessment.md) for the running
+rubric score. Adding team / coordination risks:
 
-- **Backend ownership unfilled.** Shimon left; backend doesn't have a single owner. Decide
-  by end of Day 3.
-- **Chuan as smart-contract bus factor 1.** Mitigated by keeping contracts small + pair-
-  review. See [`docs/architectural-principles.md`](docs/architectural-principles.md) for the
-  general pattern.
+- **Chuan as smart-contract + on-chain-integration bus factor 1.** Day-4 reality: Chuan
+  owns the contracts AND the `backend/archimedes/chain/` layer AND infra. Mitigated by
+  Marten as documented backup and by keeping contracts small with cached ABIs. See
+  [`docs/architectural-principles.md`](docs/architectural-principles.md) for the general
+  pattern.
 - **5-person team across 5 timezones with 3 day-job constraints.** Mitigated by Marten as
   schedule owner + daily sync + async-first defaults.
+- **Traction = 0 on the rubric scoreboard until arc-canteen telemetry starts flowing.**
+  Per [`docs/judging-rubric-assessment.md`](docs/judging-rubric-assessment.md), this is
+  the cheapest +points to recover. Every meaningful product ship should pair with an
+  `arc-canteen update-product` call; every user conversation should be logged via
+  `arc-canteen update-traction`.
 - **Multiple parallel Claude sessions risk artifact drift.** Mitigated by treating `docs/`
-  as single source of truth.
-- **Q-fin paper corpus needs Dan's curation.** Dan is evenings/weekends only; needs to
-  block weekend time to seed the corpus per
-  [`docs/qfin-paper-corpus-seed.md`](docs/qfin-paper-corpus-seed.md).
+  as single source of truth — and by curating those docs (this file is part of that
+  curation rhythm; expect periodic Day-N revisions as reality outpaces specs).
+- **Q-fin paper corpus needs Dan's curation.** Dan is evenings/weekends only. v1 ships
+  with three paper-grounded strategies seeded (Faber 2007 SMA200, Moreira-Muir 2017
+  volatility-managed, Moskowitz-Ooi-Pedersen 2012 TSMOM) plus a buy-and-hold baseline,
+  per [`analytics-engine/strategies/`](analytics-engine/strategies/). Corpus expansion
+  per [`docs/qfin-paper-corpus-seed.md`](docs/qfin-paper-corpus-seed.md) remains a
+  weekend-blocked item.
 
 ## What this file deliberately does not cover
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ reputation is **verifiable history, not predicted performance**.
 Built for the [**Agora Agents Hackathon**](https://luma.com/7i50p2r9) — Canteen × Circle ×
 Arc, May 11–25, 2026.
 
-**Status:** MVP in development. See [`docs/`](docs/) for design + planning artifacts.
+**Status (Day 4, 2026-05-14):** live testnet deploy at
+[`http://18.171.230.205/`](http://18.171.230.205/). 10 Solidity contracts deployed on Arc
+testnet (chain ID `5042002`). React/Vite UI with multi-wallet connect (MetaMask /
+Coinbase / generic). 3 paper-grounded strategies + buy-and-hold baseline seeded in the
+analytics engine. Backend FastAPI app with strategy provider + chain integration layer
+running behind nginx in the EC2 docker-compose stack. The remaining critical-path work
+is the autonomous orchestrator loop and end-to-end reasoning-trace anchoring — see
+[`docs/judging-rubric-assessment.md`](docs/judging-rubric-assessment.md) for the running
+self-score. See [`docs/`](docs/) for design + planning artifacts.
 
 ## Why Archimedes?
 
@@ -94,10 +102,11 @@ archimedes/
 │   ├── requirements.txt
 │   └── archimedes/
 │       ├── main.py                  # FastAPI entrypoint
-│       ├── api/                     # Routes + Pydantic schemas (Chuan)
-│       ├── models/                  # Shared dataclasses (Strategy, BacktestResult, Trace, Portfolio, …)
+│       ├── api/                     # Routes + Pydantic schemas (Daniel R.)
+│       ├── chain/                   # On-chain integration + oracle_runner (Chuan)
 │       ├── interfaces/              # Protocol classes — frozen contracts between teammates
-│       └── services/                # Implementations (strategy_provider lands here)
+│       ├── models/                  # Shared dataclasses (Strategy, BacktestResult, Trace, Portfolio, …)
+│       └── services/                # Implementations (strategy_provider, etc.)
 │
 ├── analytics-engine/                # Backtest engine (Daniel R., uv-managed)
 │   ├── pyproject.toml
@@ -106,27 +115,43 @@ archimedes/
 │   │   ├── engine.py                # backtrader runner + BacktestResult
 │   │   ├── data.py, instruments.py, strategy_loader.py
 │   └── strategies/                  # One .py file per strategy (paper-grounded)
-│       ├── pipeline_buy_hold.py
-│       ├── faber_2007_sma200_timing.py
-│       ├── moreira_muir_2017_volatility_managed.py
-│       └── moskowitz_ooi_pedersen_2012_tsmom.py
+│       ├── pipeline_buy_hold.py                          # Baseline
+│       ├── faber_2007_sma200_timing.py                   # Faber 2007 (Cambria)
+│       ├── moreira_muir_2017_volatility_managed.py       # Moreira & Muir 2017 (J. Finance)
+│       └── moskowitz_ooi_pedersen_2012_tsmom.py          # Moskowitz, Ooi, Pedersen 2012 (J. Fin. Econ.)
 │
-├── contracts/                       # Solidity (Foundry layout)
+├── contracts/                       # Solidity (Foundry layout) — 10 contracts deployed on Arc testnet
 │   ├── foundry.toml
+│   ├── abis/                        # Cached ABIs for backend + UI consumption
 │   ├── src/
-│   │   ├── PriceOracle.sol
-│   │   ├── SyntheticToken.sol
-│   │   ├── SyntheticVault.sol
-│   │   └── interfaces/              # I*.sol — frozen ABIs Marten + Daniel code against
-│   ├── script/Deploy.s.sol
-│   └── test/
+│   │   ├── AMMPool.sol              # x*y=k AMM
+│   │   ├── AMMRouter.sol            # AMM router / swap entry
+│   │   ├── AssetRegistry.sol        # Strategy + asset registry
+│   │   ├── PriceOracle.sol          # Oracle (Circle-Wallets-signed price pushes)
+│   │   ├── ReasoningTraceRegistry.sol  # On-chain anchor for agent reasoning traces
+│   │   ├── SyntheticFactory.sol     # Synthetic asset minting factory
+│   │   ├── SyntheticToken.sol       # ERC-20 synthetic tokens
+│   │   ├── SyntheticVault.sol       # Per-synth collateral vault
+│   │   ├── Vault.sol                # Core user vault (ERC-4626)
+│   │   ├── VaultFactory.sol         # Vault deployer
+│   │   └── interfaces/              # I*.sol — frozen ABIs the backend + UI code against
+│   ├── script/                      # Foundry deploy scripts (Deploy.s.sol, DeployV2.s.sol)
+│   └── test/                        # Forge tests
 │
-├── ui-mockups/                      # Static HTML mockups (Daniel, served by nginx)
-├── nginx/                           # nginx config for the docker-compose stack
+├── ui/                              # React 19 + Vite 8 + viem 2.48 (the live frontend)
+│   ├── src/
+│   │   ├── App.jsx, main.jsx, config.js
+│   │   └── components/              # Layout, WalletConnect, Trade
+│   ├── package.json
+│   └── vite.config.js
+│
+├── ui-mockups/                      # Static HTML mockups (early prototypes; retained for reference)
+├── nginx/                           # nginx config + multi-stage Dockerfile for the docker-compose stack
+├── wallet-setup/                    # Circle Wallets setup scripts (oracle wallet, entity-secret rotation, etc.)
 ├── infra/                           # Terraform — EC2 deployment (Chuan)
 └── submodules/                      # External references (git submodules)
     ├── context-arc/                 # Circle's Arc/Circle docs + 5 sample codebases
-    ├── KnowledgeBase/                # Dan's paper-analysis pipeline (port targets: extract.py, metadata.py)
+    ├── KnowledgeBase/               # Dan's paper-analysis pipeline (port targets: extract.py, metadata.py)
     └── Linus/                       # Dan's AI orchestration project (reference only for archimedes)
 ```
 
@@ -135,14 +160,14 @@ archimedes/
 | Layer             | Technology                                                                                |
 | ----------------- | ----------------------------------------------------------------------------------------- |
 | Backend           | Python 3.12, FastAPI, Uvicorn, SQLAlchemy                                                 |
-| Frontend          | Next.js + TailwindCSS                                                                     |
+| Frontend          | React 19 + Vite 8 + [viem](https://viem.sh/) 2.48 (plain CSS)                             |
 | Database          | PostgreSQL 16 + Redis                                                                     |
 | LLM               | Claude API ([anthropic](https://github.com/anthropics/anthropic-sdk-python))              |
 | Backtesting       | [backtrader](https://github.com/mementum/backtrader) (v1 decision — see specs)            |
 | Smart contracts   | Solidity targeting Arc (EVM-compatible) + [Foundry](https://book.getfoundry.sh/)          |
-| On-chain          | [Circle SDK](https://www.circle.com/) + [web3.py](https://github.com/ethereum/web3.py)    |
+| On-chain          | [Circle SDK](https://www.circle.com/) (Wallets, Gateway, CCTP) + viem on the UI side      |
 | Hackathon CLI     | [arc-canteen](https://github.com/the-canteen-dev/ARC-cli) (traction tracking)             |
-| Deployment        | Docker + Fly.io / Railway                                                                 |
+| Deployment        | Docker compose (5-service stack) on EC2; CI/CD via GitHub Actions                         |
 
 Full architecture in [`docs/design.md`](docs/design.md).
 
@@ -252,9 +277,18 @@ forge build
 forge test
 ```
 
-### 5. Frontend (UI mockups via nginx)
+### 5. Frontend (React + Vite via nginx)
 
-The `frontend/` Next.js app is on Daniel's queue. Until it lands, [`ui-mockups/`](ui-mockups/) carries static HTML mockups for the 8 marketplace screens (marketplace, vault detail, portfolio dashboard, strategy explorer, swap, vault creator, onboarding, reasoning-trace viewer). Docker compose serves them via nginx on port 80 — see § "Run Archimedes locally" below.
+The live UI is at [`ui/`](ui/) — React 19 + Vite 8 + viem 2.48 (plain CSS, no framework
+beyond React). Components: `Layout`, `WalletConnect` (MetaMask / Coinbase / generic
+browser wallet), `Trade`. The docker-compose `nginx` service builds the React app via a
+multi-stage Dockerfile in [`nginx/`](nginx/) and serves the built static bundle on port
+80 with a reverse-proxy to the backend at `/api/`. For frontend hot-reload during
+development, run `npm install && npm run dev` from inside `ui/` to use the Vite dev
+server directly.
+
+[`ui-mockups/`](ui-mockups/) carries the earlier static-HTML prototypes — retained for
+reference, no longer wired into the stack.
 
 ---
 
@@ -264,12 +298,13 @@ This is the everyone-on-the-team path for spinning up Archimedes on your laptop 
 
 ### What you get
 
-`docker compose up` brings up four services:
+`docker compose up` brings up five services:
 
 | Service     | Port | URL                              | What it is |
 | ----------- | ---- | -------------------------------- | ---------- |
-| `nginx`     | 80   | <http://localhost>               | Static `ui-mockups/` — Daniel's 8 marketplace screens |
+| `nginx`     | 80   | <http://localhost>               | React UI build (multi-stage Dockerfile in [`nginx/`](nginx/)) + reverse-proxy to backend |
 | `backend`   | 8000 | <http://localhost:8000/docs>     | FastAPI app (Swagger UI auto-generated from `backend/archimedes/api/routes.py`) |
+| `oracle`    | —    | (no HTTP)                        | Oracle price feeder — pushes prices via Circle Wallets API to `PriceOracle.sol` |
 | `postgres`  | 5432 | `postgres://archimedes@localhost:5432/archimedes` | DB for strategies, backtests, reasoning traces |
 | `redis`     | 6379 | `redis://localhost:6379/0`       | Live regime state cache; agent loop scratch |
 
@@ -314,12 +349,16 @@ docker compose ps
 
 | Open in your browser | Expect to see |
 | -------------------- | ------------- |
-| <http://localhost>           | Daniel's marketplace mockup (`ui-mockups/index.html`) |
+| <http://localhost>           | The live React UI (built from [`ui/`](ui/) — Layout + WalletConnect + Trade components) |
 | <http://localhost:8000>      | `{"name":"Archimedes","tagline":"Peer-reviewed AI portfolios, settled on Arc.","docs":"/docs"}` |
 | <http://localhost:8000/health> | `{"status":"ok","service":"archimedes-backend"}` |
 | <http://localhost:8000/docs> | Swagger UI auto-rendered from the API contract |
 
-The Swagger UI right now shows route signatures only — handlers are stubs (the orchestrator wiring is on Chuan's queue per [`docs/specs/component-interfaces-spec.md`](docs/specs/component-interfaces-spec.md)). The contract is real even if the implementations are placeholders.
+The Swagger UI shows the live routes. As of Day 4, the strategy provider, chain
+integration (read paths), and oracle runner are real implementations; the autonomous
+orchestrator loop, regime detector, portfolio constructor, and backtest evaluator are
+the remaining interface implementations from
+[`docs/specs/component-interfaces-spec.md`](docs/specs/component-interfaces-spec.md).
 
 ### Step 4 — Drive the strategy library from the Python side
 
@@ -466,10 +505,10 @@ Two commands matter:
 
 ```bash
 # Log a product / feature update — call after merging anything meaningful
-arc-canteen update-product "Strategy passport landed: 3 paper-grounded strategies, DSR + PBO spec for Önder"
+arc-canteen update-product "Live testnet deploy at http://18.171.230.205/ — 10 contracts on Arc + wallet-connect UI + 3 paper-grounded strategies"
 
 # Log a traction event — call every time you talk to a potential user or onboard someone
-arc-canteen update-traction "Onboarded user 0x... — deposited 100 USDC into Tier-1 vault, executed first rebalance"
+arc-canteen update-traction "Shared live demo URL with two crypto-native users — first external traffic on the EC2 deploy"
 ```
 
 Run `arc-canteen status` to view your current dashboard — what the judges will see when they look at your handle. The judging-rubric assessment in [`docs/judging-rubric-assessment.md`](docs/judging-rubric-assessment.md) breaks down where we currently stand on each of the 4 weighted criteria.
@@ -561,9 +600,9 @@ See [`CLAUDE.md`](CLAUDE.md) for full conventions. Headline points:
 ### Running tests
 
 ```bash
-pytest                       # backend tests
-cd frontend && npm test      # frontend tests
-forge test                   # contract tests (once contracts/ lands)
+pytest                       # backend tests (under tests/)
+cd ui && npm run lint        # frontend lint (ESLint 10)
+cd contracts && forge test   # contract tests (10 contracts deployed, full Forge suite)
 ```
 
 ### Lint + format

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -134,7 +134,7 @@ class OracleUpdater:
                         "contractAddress": oracle_addr,
                         "abiFunctionSignature": "setPrice(uint256)",
                         "abiParameters": [str(price_int)],
-                        "fee": {"type": "level", "config": {"feeLevel": "MEDIUM"}},
+                        "feeLevel": "MEDIUM",
                         "blockchain": CIRCLE_BLOCKCHAIN,
                         "entitySecretCiphertext": ciphertext,
                     }

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -2,16 +2,21 @@
 
 Implements IOracleUpdater from archimedes/interfaces/chain.py.
 Uses yfinance for equity/ETF prices and CoinGecko for crypto.
+Pushes prices via Circle Developer Controlled Wallets API (the oracle owner
+wallet is a Circle-managed wallet — no raw private key available).
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
+import os
+import uuid
 from datetime import datetime, timezone
 
-from archimedes.chain.client import chain_client
-from archimedes.chain.contracts import ContractLoader, get_contract_loader
+import aiohttp
+
 from archimedes.models.asset import AssetPrice, MarketSnapshot
 
 logger = logging.getLogger(__name__)
@@ -33,13 +38,44 @@ CRYPTO_MAP = {
     "sBTC": "bitcoin",
 }
 
+CIRCLE_API_BASE = "https://api.circle.com/v1/w3s"
+CIRCLE_BLOCKCHAIN = "ARC-TESTNET"
+
+
+def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
+    """Encrypt entity secret with Circle's RSA public key (OAEP/SHA-256).
+
+    Circle requires a fresh ciphertext per request to prevent replay attacks.
+    """
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    public_key = serialization.load_pem_public_key(public_key_pem.encode())
+    plaintext = bytes.fromhex(entity_secret_hex)
+    ciphertext = public_key.encrypt(
+        plaintext,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    return base64.b64encode(ciphertext).decode()
+
 
 class OracleUpdater:
     """Fetches market prices and pushes them to on-chain PriceOracle contracts."""
 
-    def __init__(self, loader: ContractLoader | None = None):
-        self.loader = loader or get_contract_loader()
+    def __init__(self) -> None:
         self._price_cache: dict[str, AssetPrice] = {}
+        self._circle_public_key: str | None = None  # cached per instance lifetime
+
+        # Circle credentials from env
+        self._api_key: str = os.getenv("CIRCLE_API_KEY", "")
+        self._entity_secret: str = os.getenv("CIRCLE_ENTITY_SECRET", "")
+        self._wallet_id: str = os.getenv("WALLET_ID", "")
+
+    # ─── Public API ──────────────────────────────────────────────
 
     async def fetch_prices(self) -> list[AssetPrice]:
         """Fetch current prices for all synthetic assets via yfinance + CoinGecko."""
@@ -55,7 +91,6 @@ class OracleUpdater:
         crypto_prices = await self._fetch_crypto(now)
         prices.extend(crypto_prices)
 
-        # Cache
         for p in prices:
             self._price_cache[p.symbol] = p
 
@@ -63,39 +98,72 @@ class OracleUpdater:
         return prices
 
     async def push_prices_on_chain(self, prices: list[AssetPrice]) -> str | None:
-        """Call PriceOracle.setPrice() for each asset on Arc."""
-        account = chain_client.settings.owner_account
-        if not account:
-            logger.warning("No owner account configured — skipping on-chain price push")
+        """Call PriceOracle.setPrice() for each asset via Circle Wallets API."""
+        if not self._api_key or not self._entity_secret or not self._wallet_id:
+            logger.warning(
+                "Circle credentials not configured "
+                "(CIRCLE_API_KEY / CIRCLE_ENTITY_SECRET / WALLET_ID) — "
+                "skipping on-chain price push"
+            )
             return None
 
-        nonce = await chain_client.w3.eth.get_transaction_count(account.address)
-        tx_hashes: list[str] = []
+        from archimedes.chain.client import chain_client
 
-        for price in prices:
-            try:
-                oracle = self.loader.oracle_for(price.symbol)
-                # Price in USD with 6 decimals (matching PriceOracle.sol convention)
-                price_int = int(price.price_usd * 1e6)
+        oracle_addresses = chain_client.settings.oracle_addresses
+        tx_ids: list[str] = []
 
-                tx = await oracle.functions.setPrice(price_int).build_transaction(
-                    {
-                        "from": account.address,
-                        "nonce": nonce,
-                        "chainId": chain_client.settings.chain_id,
-                        "gas": 100_000,
-                        "gasPrice": await chain_client.w3.eth.gas_price,
+        async with aiohttp.ClientSession() as session:
+            public_key = await self._get_circle_public_key(session)
+            if not public_key:
+                logger.error("Failed to fetch Circle public key — aborting price push")
+                return None
+
+            for price in prices:
+                oracle_addr = oracle_addresses.get(price.symbol)
+                if not oracle_addr:
+                    logger.debug(f"No oracle address for {price.symbol} — skipping")
+                    continue
+
+                try:
+                    ciphertext = _encrypt_entity_secret(self._entity_secret, public_key)
+                    price_int = int(price.price_usd * 1e6)  # 6 decimals, matches PriceOracle.sol
+
+                    payload = {
+                        "idempotencyKey": str(uuid.uuid4()),
+                        "walletId": self._wallet_id,
+                        "contractAddress": oracle_addr,
+                        "abiFunctionSignature": "setPrice(uint256)",
+                        "abiParameters": [str(price_int)],
+                        "fee": {"type": "level", "config": {"feeLevel": "MEDIUM"}},
+                        "blockchain": CIRCLE_BLOCKCHAIN,
+                        "entitySecretCiphertext": ciphertext,
                     }
-                )
-                signed = account.sign_transaction(tx)
-                tx_hash = await chain_client.w3.eth.send_raw_transaction(signed.raw_transaction)
-                tx_hashes.append(tx_hash.hex())
-                nonce += 1
-                logger.info(f"Pushed {price.symbol} price {price.price_usd:.2f} → tx {tx_hash.hex()[:16]}...")
-            except Exception as e:
-                logger.error(f"Failed to push price for {price.symbol}: {e}")
 
-        return tx_hashes[0] if tx_hashes else None
+                    async with session.post(
+                        f"{CIRCLE_API_BASE}/developer/transactions/contractExecution",
+                        json=payload,
+                        headers={
+                            "Authorization": f"Bearer {self._api_key}",
+                            "Content-Type": "application/json",
+                        },
+                    ) as resp:
+                        body = await resp.json()
+                        if resp.status == 201:
+                            tx_id = body["data"]["id"]
+                            tx_ids.append(tx_id)
+                            logger.info(
+                                f"Pushed {price.symbol} "
+                                f"price {price.price_usd:.2f} → Circle tx {tx_id}"
+                            )
+                        else:
+                            logger.error(
+                                f"Circle API error for {price.symbol} "
+                                f"({resp.status}): {body}"
+                            )
+                except Exception:
+                    logger.exception(f"Failed to push price for {price.symbol}")
+
+        return tx_ids[0] if tx_ids else None
 
     async def fetch_market_snapshot(self) -> MarketSnapshot:
         """Fetch a full market snapshot with prices + regime signals."""
@@ -103,7 +171,6 @@ class OracleUpdater:
         price_map = {p.symbol: p.price_usd for p in prices}
         now = datetime.now(timezone.utc)
 
-        # Fetch regime signals
         vix = await self._fetch_yfinance_single("^VIX")
         sp500_data = await asyncio.to_thread(self._fetch_sp500_moving_averages)
 
@@ -120,6 +187,24 @@ class OracleUpdater:
 
     # ─── Private helpers ──────────────────────────────────────────
 
+    async def _get_circle_public_key(self, session: aiohttp.ClientSession) -> str | None:
+        """Fetch Circle's RSA public key (cached per instance)."""
+        if self._circle_public_key:
+            return self._circle_public_key
+        try:
+            async with session.get(
+                f"{CIRCLE_API_BASE}/config/entity/publicKey",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+            ) as resp:
+                if resp.status == 200:
+                    body = await resp.json()
+                    self._circle_public_key = body["data"]["publicKey"]
+                    return self._circle_public_key
+                logger.error(f"Failed to fetch Circle public key: {resp.status}")
+        except Exception:
+            logger.exception("Error fetching Circle public key")
+        return None
+
     def _fetch_yfinance(
         self, symbols: dict[str, str], timestamp: datetime
     ) -> list[AssetPrice]:
@@ -135,7 +220,6 @@ class OracleUpdater:
                 try:
                     if data.empty:
                         continue
-                    # Get the latest close price
                     if len(symbols) == 1:
                         price = float(data["Close"].iloc[-1])
                     else:
@@ -165,8 +249,6 @@ class OracleUpdater:
         """Fetch crypto prices from CoinGecko API."""
         results: list[AssetPrice] = []
         try:
-            import aiohttp
-
             async with aiohttp.ClientSession() as session:
                 for symbol, cg_id in CRYPTO_MAP.items():
                     try:
@@ -185,16 +267,17 @@ class OracleUpdater:
                                 )
                     except Exception as e:
                         logger.warning(f"Failed to fetch {symbol} from CoinGecko: {e}")
-        except ImportError:
-            logger.warning("aiohttp not installed — skipping crypto prices")
+        except Exception as e:
+            logger.warning(f"Crypto fetch error: {e}")
         return results
 
     async def _fetch_yfinance_single(self, symbol: str) -> float | None:
         """Fetch a single yfinance price (e.g. VIX)."""
         try:
             import yfinance as yf
-
-            data = await asyncio.to_thread(yf.download, symbol, period="1d", interval="1m", progress=False)
+            data = await asyncio.to_thread(
+                yf.download, symbol, period="1d", interval="1m", progress=False
+            )
             if not data.empty:
                 return float(data["Close"].iloc[-1])
         except Exception as e:
@@ -205,7 +288,6 @@ class OracleUpdater:
         """Fetch S&P 500 50-day and 200-day moving averages."""
         try:
             import yfinance as yf
-            import pandas as pd
 
             spy = yf.Ticker("^GSPC")
             hist = spy.history(period="1y")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,6 +32,7 @@ anthropic>=0.40
 web3>=7.0
 eth-account>=0.13
 eth-utils>=5.0
+cryptography>=42.0
 
 # Paper ingestion
 arxiv>=2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       ORACLE_INTERVAL_SECONDS: ${ORACLE_INTERVAL_SECONDS:-60}
     env_file:
       - .env
+    healthcheck:
+      disable: true
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/claude-design-prompts.md
+++ b/docs/claude-design-prompts.md
@@ -41,6 +41,76 @@ inaccurate.
 
 ---
 
+## Design system setup — paste-ready field values
+
+The Claude Design **"Set up your design system"** page (the first step before any
+prompts) asks for a company blurb, optional code/Figma/asset uploads, and a free-form
+notes field. The values below are tuned to Archimedes' actual surfaces and constrain
+all downstream prompt outputs without re-explaining the project each time.
+
+**Tips on the upload fields:**
+
+- **Link code on GitHub:** `hackagora/archimedes-arcadia` is sufficient. The repo carries
+  the live `ui/` (React 19 + Vite 8 + viem 2.48), `docs/architecture-diagram.html`, and
+  all the curated design context. No need to configure additional repos.
+- **Link code from your computer:** skip. Requires Chrome/Edge and the GitHub link
+  covers the same ground.
+- **Upload a .fig file:** none — Archimedes doesn't have a Figma source of truth (and
+  doesn't need one for hackathon scope).
+- **Add fonts, logos and assets:** none externally. The logo is what Prompt 1 below
+  generates; fonts are open-source web fonts named in the design system below.
+- **Do NOT upload `ui-mockups/`.** Those are retired static-HTML prototypes from Day
+  1–2 that the team kept only for archival reference. Uploading them would actively
+  steer Claude Design toward stale visuals. The "any other notes" field below tells
+  Claude Design to study `ui/` (the live React app) and ignore `ui-mockups/` — that's
+  the correct mental model.
+
+### Field: Company name and blurb
+
+```
+Archimedes: an autonomous portfolio agent that grounds investment strategies in
+peer-reviewed quant finance research, settled in USDC on Arc (Circle's stablecoin-native
+L1). Surfaces: web app (React + Vite), pitch deck, repo README + GitHub presence. Built
+for the Agora Agents Hackathon (Canteen × Circle × Arc, May 11–25, 2026).
+```
+
+### Field: Any other notes
+
+```
+Tone: serious, financial-grade, academic-rigor cue. Think a crossover between
+Wealthfront's marketing site and a crypto-native product like Arc.network or Circle.
+No clip art, no emojis in product surfaces, no busy decoration, and specifically no
+cliché Greek-temple imagery despite the name — Archimedes is the patron saint of
+empirical reasoning, not a tourism brand.
+
+Palette: dark-mode primary. Near-black background (#0E1116), off-white text (#F3F4F6),
+muted gray (#9CA3AF) for secondary text, single brand accent — pick one of deep blue
+(#2A4DD1) or violet (#7B2CBF) and commit. Success #10B981, warning #F59E0B, error
+#EF4444. Plain CSS in the React app — we are NOT using Tailwind or any CSS framework.
+
+Typography: serif headlines for the academic-rigor cue (Crimson Pro or Source Serif
+Pro), modern sans body (Inter or Geist Sans), monospace for hashes and addresses
+(JetBrains Mono or Geist Mono).
+
+In the linked repo: the live frontend is `ui/` (React 19 + Vite 8 + viem 2.48).
+Ignore `ui-mockups/` — that's a retired set of static-HTML prototypes from Day 1–2,
+kept only for archival reference. Live testnet deploy: http://18.171.230.205/.
+Architecture diagram: `docs/architecture-diagram.html`. Curated per-asset design
+prompts: `docs/claude-design-prompts.md`. Pitch + demo context:
+`docs/demo-script-pitch-deck-outline.md`.
+
+Product narrative: "every claim the agent makes is wrong-able on the record."
+Strategies carry a passport (paper citation + methodology hash + paper-claim delta
+surfaced honestly); reasoning traces are hashed and anchored on Arc. Visual language
+should signal academic rigor + on-chain provenance, not crypto-speculation vibes.
+```
+
+After saving the design system, run **Prompt 1 (logo)** below first — smallest scope,
+fastest feedback on whether the system is steering correctly. If the logo output feels
+right, scale up to the slide deck and UI refinement prompts.
+
+---
+
 ## Prompt 1 — Logo set (multiple variants)
 
 **Setup notes:** Use Claude Design's **Other** mode for graphics generation. If a "logo"

--- a/docs/claude-design-prompts.md
+++ b/docs/claude-design-prompts.md
@@ -4,7 +4,11 @@
 > **Purpose:** Concrete prompts to paste into Claude Design for slides, UI prototypes,
 > and logo variants. Each prompt is self-contained so the design session has the context
 > it needs without you re-explaining the project.
-> **Status:** v1 prompts. Iterate based on what Claude Design produces.
+> **Status:** Day-4 revision (2026-05-14). Prompts updated to match what the team has
+> actually shipped — a live React/Vite UI at [`http://18.171.230.205/`](http://18.171.230.205/),
+> 10 contracts deployed on Arc testnet, and the
+> [`architecture-diagram.html`](architecture-diagram.html) reference. The UI prompts now
+> work as **refinement** prompts against the live UI rather than greenfield design.
 
 ## Quick notes on using Claude Design
 
@@ -139,17 +143,25 @@ Empty fourth column with a "?" — implying Archimedes goes here.
 
 SLIDE 3 — What we built
 Title: Archimedes — Peer-reviewed AI portfolios on Arc
-Four bullets with icons:
-- Strategies from peer-reviewed quant papers (with paper-claim binding).
-- Risk profiles: Conservative / Moderate / Aggressive / Hyper-Risky.
-- Autonomous: regime detection, rebalancing, strategy rotation.
-- Every decision hashed on Arc — verifiable reasoning trace.
-Background: stylized version of the system architecture diagram (strategy engine
-→ backtesting → portfolio agent → on-chain).
+Five bullets with icons:
+- Paper-grounded strategy passport — paper citation + methodology hash + paper-claim
+  delta surfaced honestly (3 strategies seeded: Faber 2007, Moreira-Muir 2017,
+  Moskowitz-Ooi-Pedersen 2012 + buy-and-hold baseline).
+- Selection-bias gate (DSR + PBO + walk-forward OOS + look-ahead audit) at admission.
+- Autonomous agent: regime detection → strategy rotation → rebalancing, with every
+  decision producing a reasoning trace.
+- 10 contracts on Arc testnet today — Vault, AMM, Synthetic Factory, Reasoning Trace
+  Registry — with multi-wallet UX (MetaMask / Coinbase / generic).
+- Commit-reveal trace anchoring: "trace existed *before* the trade," verifiable
+  on-chain.
+Background: stylized version of the architecture diagram from
+docs/architecture-diagram.html (Strategy Engine + Passport → Selection-Bias Gate →
+Autonomous Portfolio Agent → ReasoningTraceRegistry on Arc).
 
 SLIDE 4 — DEMO
-Full-bleed slide: just the word "DEMO" in large type, with a small "archimedes.
-hackagora.com" URL underneath. This slide gets minimum 90 seconds of live demo time.
+Full-bleed slide: just the word "DEMO" in large type, with a small URL underneath —
+either archimedes.hackagora.com (if locked) or 18.171.230.205 (the EC2 IP fallback,
+which works today). This slide gets minimum 90 seconds of live demo time.
 
 SLIDE 5 — Competitive landscape
 Title: We fill the gap.
@@ -218,16 +230,26 @@ same typography, same density of information.
 
 ---
 
-## Prompt 3 — High-fidelity UI prototype (onboarding + dashboard)
+## Prompt 3 — High-fidelity UI refinement (onboarding + dashboard)
 
 **Setup notes:** Use Claude Design's **Prototype** mode with **High fidelity** selected.
-This is what Daniel uses as a visual reference before writing the React code.
+**Updated framing (Day 4):** the team has shipped a live React/Vite UI at
+[`http://18.171.230.205/`](http://18.171.230.205/) with `Layout`, `WalletConnect`, and
+`Trade` components. This prompt now serves as **visual refinement** — give Claude Design
+the live URL as a starting reference and ask it to propose evolutions, rather than
+generating from scratch.
 
 ```
-Project: Archimedes — frontend prototype.
+Project: Archimedes — frontend visual refinement.
 
-Tech stack target: Next.js + TailwindCSS. The prototype should be implementable in
-that stack — don't generate UI that requires custom canvas/WebGL or anything exotic.
+Live reference URL (please fetch + study before generating): http://18.171.230.205/
+This is our current shipped UI — React 19 + Vite 8 + viem 2.48. The wallet-connect
+modal is already wired (MetaMask / Coinbase / generic browser wallet) and the Trade
+tab is live against deployed AMM contracts on Arc testnet (chain ID 5042002).
+
+Tech stack target: React 19 + Vite 8 + plain CSS (we are not using a CSS framework;
+no Tailwind, no Next.js). The refined screens should be implementable in that stack —
+don't generate UI that requires custom canvas/WebGL or anything exotic.
 
 I need three connected screens that walk a user through the core flow:
 
@@ -288,11 +310,11 @@ the navigation working. Don't worry about real data; placeholder values are fine
 
 **What to do with the output:**
 
-- Share with Daniel (frontend owner). He builds the actual React/Next.js implementation
-  using this as a visual reference.
+- Share with Marten + Daniel R. (current UI contributors). They evolve the live React
+  components using the refined visuals as a reference.
 - Iterate on any screens that don't match the intended feel.
 - Export key screens for the pitch deck (Slide 3 can use Screen 2; Slide 4's demo will
-  use the real implementation).
+  use the real implementation at `18.171.230.205`).
 
 ---
 
@@ -418,10 +440,13 @@ density.
 ## Workflow recap
 
 1. **Set up a design system** in Claude Design with the palette/typography above.
-2. **Run Prompt 1** (logo) first — pick a logo, lock it before doing slides/UI.
-3. **Run Prompt 2** (slide deck) — generate, iterate, export.
-4. **Run Prompt 3, 4, 5** (UI screens) — Daniel uses these as reference for the
-   actual frontend build.
+2. **Run Prompt 1** (logo) first — pick a logo, lock it before doing slides/UI. (Status
+   as of Day 4: not yet started. Smallest-scope test of Claude Design for the team.)
+3. **Run Prompt 2** (slide deck) — generate, iterate, export. Make sure the bullets
+   match what the team has actually shipped per the Day-4 revision above.
+4. **Run Prompt 3, 4, 5** (UI screens) — give Claude Design the live URL
+   (`http://18.171.230.205/`) as starting reference. These prompts are now **refinement**
+   prompts against the shipped React UI, not greenfield.
 5. **Iterate** — Claude Design is conversational; refine outputs based on your eye.
 
 If you take screenshots of references along the way, drop them in the conversation —

--- a/docs/demo-script-pitch-deck-outline.md
+++ b/docs/demo-script-pitch-deck-outline.md
@@ -1,9 +1,22 @@
 # Demo Script & Pitch Deck Outline
 
 > **Audience:** Archimedes hackathon team (deck owner + demo runner + Q&A primaries)
-> **Status:** Working outline — tighten in Week 2 once the build converges.
+> **Status:** Day-4 revision (2026-05-14) — tighten in Week 2 as the orchestrator loop
+> and reasoning-trace anchoring come online.
 > **Pitch length assumption:** 3-minute pitch + ~2 minute live demo + Q&A. Adjust if
 > Canteen tells us otherwise.
+> **Shipped reality the demo can lean on (as of Day 4):**
+> - Live deploy at [`http://18.171.230.205/`](http://18.171.230.205/)
+> - 10 Solidity contracts on Arc testnet (chain ID `5042002`): `AMMPool`, `AMMRouter`,
+>   `AssetRegistry`, `PriceOracle`, `ReasoningTraceRegistry`, `SyntheticFactory`,
+>   `SyntheticToken`, `SyntheticVault`, `Vault`, `VaultFactory`
+> - React 19 + Vite + viem UI with three-way wallet connect (MetaMask / Coinbase / generic
+>   browser wallet) and an add-liquidity / trade tab
+> - Oracle service pushing prices via Circle Wallets API on a docker-compose schedule
+> - Backend strategy provider serving 4 strategies (3 paper-grounded + buy-and-hold) with
+>   passport metadata exposed via the API
+> - Selection-bias spec (DSR / PBO / OOS / look-ahead) and commit-reveal trace spec
+>   landed; implementations are on Önder's and Chuan's queues respectively
 
 ## The headline message
 
@@ -44,37 +57,68 @@ name." It's "we built a product whose architecture matches the original empirici
 
 ## The "wow moment" the demo must hit
 
-A user, in front of judges, lives the full Archimedes flow:
+A user, in front of judges, lives the full Archimedes flow on the live testnet deploy
+at [`http://18.171.230.205/`](http://18.171.230.205/). The demo is anchored to what's
+actually clickable on Day 4, with the items still on the orchestrator/regime-detector/
+reasoning-trace queue marked **🚧 Week 2** so we can be honest about what's live vs.
+what's narrated.
 
-1. Lands on the Archimedes site. Sees the marketing page with one of Daniel's hero
-   visuals.
-2. Clicks "Get Started." Connects a wallet (testnet USDC pre-funded).
+1. Lands on the Archimedes site. Sees the marketing page with the Archimedes hero.
+2. Clicks **"Connect Wallet."** Sees the three-way wallet selector (MetaMask / Coinbase
+   Wallet / generic browser wallet). Connects to Arc testnet (chain ID `5042002`).
 3. **Picks a risk profile.** Four cards: Conservative / Moderate / Aggressive /
    Hyper-Risky. Each card shows the target vol band, max drawdown, USYC floor, and a
-   one-line description.
-4. **Sees a constructed portfolio.** Pie chart of weights. Underneath: the strategies
+   one-line description. 🚧 Week 2 — currently a planned screen; the data shape is
+   defined in [`docs/design.md`](design.md) § Risk Profiles.
+4. **Sees a constructed portfolio.** Donut chart of weights. Underneath: the strategies
    selected (with paper citations), the backtest performance for each, the regime
-   classification at construction time.
-5. **Clicks on a strategy card** ("Cross-Asset Value & Momentum — Asness, Moskowitz,
-   Pedersen 2013"). Sees the paper title, arxiv link, methodology summary, our
-   re-validated Sharpe vs. the paper's claimed Sharpe, equity curve.
-6. **Clicks "Deposit USDC."** Approves the transaction. USDC flows into the
-   ArchimedesVault contract on Arc.
+   classification at construction time. 🚧 Week 2 (portfolio constructor is on Önder's
+   queue per [`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md)).
+5. **Clicks on a strategy card** — e.g., *"Time Series Momentum — Moskowitz, Ooi,
+   Pedersen 2012, J. Fin. Econ. 104(2)."* Sees the paper title, arxiv link, methodology
+   summary, our re-validated Sharpe vs. the paper's claimed Sharpe, equity curve. The
+   strategy provider already serves this metadata today via the backend API; the
+   strategy-detail screen is Week 2 UI work.
+6. **Clicks "Deposit USDC."** Approves the transaction. USDC flows into the live
+   `Vault` contract on Arc (deployed Day 4, real testnet tx, real Arc explorer link).
 7. **Watches the agent build the portfolio live.** Progress UI shows: regime check ✓ →
-   strategy selection ✓ → weight optimization ✓ → CCTP bridge for RWA tokens ✓ → portfolio
-   live. Each step has a "View on Arc" link to the on-chain tx.
-8. **The portfolio dashboard appears.** Live positions. Live performance vs. benchmark.
-   A "Decisions" tab.
+   strategy selection ✓ → weight optimization ✓ → on-chain transfers via `AMMRouter` ✓ →
+   portfolio live. Each step has a "View on Arc" link. 🚧 Week 2 — the orchestrator
+   loop is the headline Week-2 deliverable.
+8. **The portfolio dashboard appears.** Live positions sourced from the deployed `Vault`
+   contract. Live performance vs. benchmark.
 9. **Clicks the Decisions tab.** Sees the agent's construction decision with full
    reasoning trace. **Clicks "Verify trace hash."** Browser recomputes the hash in JS;
-   green checkmark appears showing it matches the Arc on-chain anchor.
+   green checkmark appears showing it matches the on-chain anchor in the deployed
+   `ReasoningTraceRegistry` contract. 🚧 Week 2 — the contract is live; the
+   reasoning-trace generator + anchoring writer is the wiring still to ship.
 10. **(Optional advanced demo)** Fast-forward in the demo environment to trigger a
     regime change. Watch the agent autonomously rebalance. New reasoning trace appears;
-    new on-chain anchor; the portfolio shifts toward defensive strategies + USYC.
+    new on-chain anchor in `ReasoningTraceRegistry`; the portfolio shifts toward
+    defensive strategies + USYC. 🚧 Week 2 (regime detector + portfolio constructor).
 
 **Steps 5 (paper citation), 9 (verify trace hash), and 10 (autonomous rebalance) are the
 three differentiators.** Without them, the demo is a robo-advisor on Arc. With them, the
-demo is Archimedes.
+demo is Archimedes. Three of the ten contracts on Arc are load-bearing for these three
+moments: `ReasoningTraceRegistry` (step 9), `Vault` + `AMMRouter` (steps 6–10).
+
+### What we can confidently demo today (Day 4 fallback)
+
+If Week 2 falls behind, the Day-4-and-honest version of the demo still tells a strong
+story:
+
+- Wallet connect on Arc testnet (live).
+- Deposit USDC into the deployed `Vault` (live — real on-chain tx, real Arc explorer link).
+- AMM swap against the deployed `AMMPool` (live).
+- Synthetic-asset mint via `SyntheticFactory` + `SyntheticVault` (live).
+- Backend API call returning the 4 seeded strategies with passport metadata
+  (`paper_grounded=True`, paper citation, risk profiles) — live, demonstrable in the
+  Swagger UI at `/docs`.
+- The selection-bias spec ([`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md))
+  and commit-reveal trace spec ([`specs/commit-reveal-trace-spec.md`](specs/commit-reveal-trace-spec.md))
+  as the *intellectual differentiators* — these are what set Archimedes apart from the 96
+  other AI-portfolio submissions at the last Arc HackMoney even before the full live loop
+  ships.
 
 ## Pitch deck — 9-slide structure
 
@@ -109,23 +153,33 @@ Visual: three-column comparison with an empty fourth column where Archimedes goe
 
 Archimedes — an autonomous portfolio agent where:
 
-- **Strategies come from peer-reviewed quant papers.** Every strategy has a paper ID, a
-  methodology hash, and a backtest validated against the paper's own claimed metrics.
-- **Users pick a risk profile** (Conservative / Moderate / Aggressive / Hyper-Risky).
-  The agent constructs a personalized portfolio of RWA tokens + USYC.
+- **Strategies come from peer-reviewed quant papers.** Every strategy carries a
+  paper-grounded passport (paper ID, citation, methodology hash, paper-claim vs.
+  re-implemented metrics with deltas surfaced honestly). Day 4: 3 paper-grounded
+  strategies seeded (Faber 2007, Moreira & Muir 2017, Moskowitz Ooi Pedersen 2012)
+  plus a buy-and-hold baseline, served live by the strategy provider.
+- **Selection-bias gate at admission.** Every Tier-1 strategy passes Deflated Sharpe,
+  Probability of Backtest Overfitting, walk-forward OOS, and a look-ahead audit. The
+  spec is published; implementation is on Önder's queue.
 - **The agent operates autonomously** post-deployment — regime detection, rebalancing,
   strategy rotation. Every decision produces a reasoning trace.
-- **Every reasoning trace is hashed on Arc** via the ReasoningTraceRegistry. Users can
-  audit any decision the agent has ever made.
+- **Every reasoning trace is hashed on Arc** via the deployed `ReasoningTraceRegistry`
+  contract. Users can audit any decision the agent has ever made — with the v1.5
+  commit-reveal upgrade in spec, "trace existed at T" strengthens to "trace existed
+  *before* the trade."
+- **10 contracts already on Arc testnet** (chain ID `5042002`): Vault / VaultFactory,
+  AMM / Router, Synthetic Factory / Token / Vault, Asset + Price + Trace registries.
+  Live UI with multi-wallet connect at `18.171.230.205`.
 
-Visual: simplified version of Chuan's [`design.md`](design.md) architecture diagram with
-the four key components highlighted (Strategy Engine, Backtesting, Portfolio Agent,
-Reasoning Trace Registry).
+Visual: simplified version of [`architecture-diagram.html`](architecture-diagram.html)
+with the four key components highlighted (Strategy Engine + Passport, Selection-Bias
+Gate, Autonomous Portfolio Agent, ReasoningTraceRegistry on Arc).
 
 ### Slide 4: Live demo (90 seconds)
 
-Just "**DEMO**" in large text. Run the wow-moment script above from
-`archimedes.hackagora.com` (or wherever it deploys).
+Just "**DEMO**" in large text, with `archimedes.hackagora.com` or `18.171.230.205`
+underneath. Run the wow-moment script above. The demo URL should be locked in Week 2;
+the EC2 IP works as the fallback.
 
 ### Slide 5: Competitive landscape (30 seconds)
 
@@ -154,10 +208,13 @@ RFB + judging-criteria coverage. From [`rfb-alignment.md`](rfb-alignment.md):
 
 | Criterion                    | Weight | How we score                                                      |
 | ---------------------------- | ------ | ----------------------------------------------------------------- |
-| Agentic Sophistication       | 30%    | Regime detection, autonomous rebalancing, strategy rotation, on-chain reasoning traces. |
-| Traction                     | 30%    | Pre-curated strategies → day-1 portfolios. Strategy leaderboard, target 50+ users. |
-| Circle Tool Usage            | 20%    | Wallets, USYC, CCTP, Gateway, Paymaster, Contracts — full stack.   |
-| Innovation                   | 20%    | Paper-grounded provenance for every strategy. On-chain reasoning traces. Academic accountability for autonomous trading. |
+| Agentic Sophistication       | 30%    | Regime detection, autonomous rebalancing, strategy rotation, on-chain reasoning traces. Five frozen interfaces, three queues converging on the live loop. |
+| Traction                     | 30%    | Pre-curated strategies → day-1 portfolios. arc-canteen telemetry firing on every product ship + user conversation. Live testnet from Day 4. |
+| Circle Tool Usage            | 20%    | Wallets (Circle-managed oracle signer, live), USDC settlement, USYC risk-off floor, CCTP for RWA bridging, Gateway for nanopayments, 10 contracts on Arc. |
+| Innovation                   | 20%    | Paper-grounded passport with paper-claim deltas. On-chain reasoning traces with commit-reveal temporal binding. Selection-bias gate (DSR + PBO + OOS + look-ahead) at admission. |
+
+See [`judging-rubric-assessment.md`](judging-rubric-assessment.md) for the running
+self-score and the gap analysis driving the Week-2 critical path.
 
 RFB 04 primary; RFB 02 math primitive (Kelly); RFB 06 adjacent (strategy leaderboard).
 
@@ -250,7 +307,10 @@ performance is not predictive** — the reputation primitive is *auditable histo
 A: Four triggers per [Chuan's design](design.md): drift threshold (any position > 5%
 from target), regime change (the regime classifier transitions), strategy decay (rolling
 30-day Sharpe < 0.5), or calendar (weekly check). Every trigger evaluates expected
-benefit vs. transaction cost before executing.
+benefit vs. transaction cost before executing. The trigger logic lives in the
+`IRegimeDetector` + `IAgentOrchestrator` interfaces in
+[`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md); the
+implementations land in Week 2.
 
 **Q: What about taxes?**
 
@@ -322,7 +382,13 @@ Lock these roles by end of Week 1.
   ship next" slide? **Recommendation:** save for the slide. Live demo should be tight on
   the curated path.
 - Should we name specific RWA tokens (tokenized TSLA, NVDA, GLD) in the demo, or use
-  symbolic placeholders? **Recommendation:** use real tokens if available on Arc testnet;
-  symbolic placeholders if not.
+  symbolic placeholders? **Day-4 reality:** the deployed `SyntheticFactory` mints synthetic
+  versions today (e.g. sOIL, sNKY visible in the deploy script defaults). **Recommendation:**
+  demo with the actually-minted synthetics; mention real RWA bridging via CCTP as the
+  v1.5 step.
 - Do we want a written one-pager for the judges to take with them? **Recommendation:** yes,
   if Canteen accepts handouts. One-page version of this deck.
+- Does Week 2 prioritize the **orchestrator loop** (closing Agentic Sophistication gap)
+  or **arc-canteen telemetry density** (closing Traction zero)? Both are required to
+  break ~13/40; the rubric assessment argues telemetry is the cheapest +points and should
+  be parallelized from Day 4 forward regardless of which engineering work lands next.


### PR DESCRIPTION
## Summary

Four core docs were lagging the build state. After Day-4 reality landed (10 contracts on Arc testnet, live React/Vite UI with multi-wallet connect at `18.171.230.205`, EC2 docker-compose with oracle service, post-Shimon ownership reshuffle), several concrete details in our top-of-tree docs had drifted. This pass aligns them to shipped reality. **No code changes — docs only.** Architectural narrative and rigor-as-wedge framing are unchanged.

## Changes

- **`CLAUDE.md`** — Fix stray `o>` typo. Replace stale primary/design/develop note with the actual branch model. Backend ownership reshuffle: Daniel R. owns the Python backend layer (`api/`, `services/`, `models/`, `interfaces/`); Chuan owns the on-chain integration layer (`chain/`, oracle runner); Marten currently most active on the React UI. Tech stack reflects shipped reality (React+Vite+viem, EC2 docker-compose, 10 contracts enumerated). Risks updated: backend-ownership-unfilled retired; traction-zero added per `judging-rubric-assessment.md`; `ReasoningTraceRegistry` marked live (was "on Chuan's queue").

- **`README.md`** — Status moved from "MVP in development" to a concrete Day-4 status paragraph. Repo structure now lists all 10 contracts, the `backend/archimedes/chain/` subpackage, and the live `ui/` (React + Vite). Tech Stack table updated (React/Vite/viem, EC2 + GH Actions). Docker-compose service table updated to 5 services (oracle added). "Run Archimedes locally" verify section refreshed (live UI, real strategy provider). Frontend section rewritten for the React+Vite multi-stage Docker build. Example `arc-canteen` messages refreshed. Test commands updated.

- **`docs/demo-script-pitch-deck-outline.md`** — Header note enumerates Day-4 shipped surface. Wow-moment walkthrough fixes stale "Asness-Moskowitz-Pedersen 2013" citation (we actually seeded Moskowitz-Ooi-Pedersen 2012 TSMOM); every step now marked **live** vs. **🚧 Week 2** honestly. New "What we can confidently demo today (Day 4 fallback)" subsection so the team has a defensible demo even if Week 2 slips. Slide 3 bullets match shipped surface (5 bullets including selection-bias gate and the 10-contract deploy). Slide 4 demo URL adds the EC2 IP fallback. Slide 6 judging-criteria table sharpened with concrete Day-4 evidence. Q&A on rebalance triggers points at `component-interfaces-spec.md`. Open question added about Week-2 prioritization (orchestrator-loop vs. arc-canteen telemetry density).

- **`docs/claude-design-prompts.md`** — Status note that UI prompts are now refinement prompts against the live UI, not greenfield. Slide-3 bullets match shipped surface. Slide-4 URL adds the EC2 IP fallback. Prompt 3 reframed as visual-refinement-against-live-URL, with the actual stack (React 19 + Vite 8 + plain CSS — no Next.js, no Tailwind) called out so Claude Design doesn't propose unbuildable framework choices. Workflow recap notes logo status (not started) and the refinement framing.

## Spec

No external spec — this is regular doc maintenance per the team's source-of-truth-in-`docs/` discipline. PR targets `develop` per the branch model in `CLAUDE.md`.

## Background

Branched off `main` (which is actually 4 commits ahead of `develop` after Chuan's recent oracle fixes) to start from the most current state, with develop merged in for completeness. Diff against `develop` should be just the four file edits.