### PR TITLE
feat: Per-vault chat with AI responder

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+archimedes_chat.db

--- a/backend/archimedes/api/chat_routes.py
+++ b/backend/archimedes/api/chat_routes.py
@@ -1,0 +1,145 @@
+"""Chat API routes — per-vault chat for the Archimedes marketplace.
+
+Endpoints:
+  GET    /api/vaults/{address}/chat       — list messages (paginated)
+  POST   /api/vaults/{address}/chat       — post a message
+  GET    /api/vaults/{address}/chat/count  — message count
+
+Design (per ecosystem-design-spec.md § 16–17):
+  - Fully open: any connected wallet can read/write
+  - Wallet address = identity
+  - AI auto-responds to @archimedes mentions
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+
+from archimedes.api.schemas import (
+    ChatMessageListResponse,
+    ChatMessageResponse,
+    ChatPostRequest,
+    ChatPostResponse,
+)
+from archimedes.services.chat_service import chat_service
+
+chat_router = APIRouter(prefix="/api/vaults", tags=["chat"])
+
+
+@chat_router.get("/{address}/chat", response_model=ChatMessageListResponse)
+async def get_chat_messages(
+    address: str,
+    limit: int = Query(50, ge=1, le=200),
+    before_id: int | None = Query(None, description="For pagination — get messages before this ID"),
+):
+    """Get chat messages for a vault, oldest-first (chat display order)."""
+    messages = chat_service.get_messages(
+        vault_address=address,
+        limit=limit,
+        before_id=before_id,
+    )
+    total = chat_service.get_message_count(address)
+    has_more = total > limit and (before_id is None or before_id > 1)
+
+    return ChatMessageListResponse(
+        messages=[
+            ChatMessageResponse(
+                id=m["id"],
+                vault_address=m["vault_address"],
+                wallet_address=m["wallet_address"],
+                message=m["message"],
+                is_ai=m["is_ai"],
+                created_at=m["created_at"],
+            )
+            for m in messages
+        ],
+        total=total,
+        has_more=has_more,
+    )
+
+
+@chat_router.post("/{address}/chat", response_model=ChatPostResponse)
+async def post_chat_message(
+    address: str,
+    body: ChatPostRequest,
+):
+    """Post a message to a vault's chat. Triggers AI response if @archimedes is mentioned."""
+    if not body.message or not body.message.strip():
+        raise HTTPException(status_code=400, detail="Message cannot be empty")
+    if not body.wallet_address or len(body.wallet_address) < 10:
+        raise HTTPException(status_code=400, detail="Valid wallet address required")
+    if len(body.message) > 2000:
+        raise HTTPException(status_code=400, detail="Message too long (max 2000 chars)")
+
+    result = chat_service.post_message(
+        vault_address=address,
+        wallet_address=body.wallet_address,
+        message=body.message.strip(),
+    )
+
+    ai_response = None
+    if "_ai_response" in result and result["_ai_response"]:
+        ai_data = result["_ai_response"]
+        ai_response = ChatMessageResponse(
+            id=ai_data["id"],
+            vault_address=ai_data["vault_address"],
+            wallet_address=ai_data["wallet_address"],
+            message=ai_data["message"],
+            is_ai=ai_data["is_ai"],
+            created_at=ai_data["created_at"],
+        )
+
+    return ChatPostResponse(
+        message=ChatMessageResponse(
+            id=result["id"],
+            vault_address=result["vault_address"],
+            wallet_address=result["wallet_address"],
+            message=result["message"],
+            is_ai=result["is_ai"],
+            created_at=result["created_at"],
+        ),
+        ai_response=ai_response,
+    )
+
+
+@chat_router.get("/{address}/chat/count")
+async def get_chat_count(address: str):
+    """Get total message count for a vault."""
+    count = chat_service.get_message_count(address)
+    return {"vault_address": address, "message_count": count}
+
+
+# ── Agent event endpoints (called by agent runner) ───────────
+
+
+@chat_router.post("/{address}/chat/rebalance")
+async def post_rebalance_event(address: str, body: dict):
+    """Post a rebalance event from the agent runner.
+
+    Body: {"reasoning": "...", "trades": [{"direction": "sell", "amount": 1000, "symbol": "sTSLA"}]}
+    """
+    reasoning = body.get("reasoning", "Portfolio rebalanced")
+    trades = body.get("trades")
+    result = chat_service.post_rebalance_event(address, reasoning, trades)
+    if result is None:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=500, detail="Failed to post rebalance event")
+    return result
+
+
+@chat_router.post("/{address}/chat/regime-change")
+async def post_regime_change(address: str, body: dict):
+    """Post a regime change event from the agent runner.
+
+    Body: {"old_regime": "risk_on", "new_regime": "risk_off", "confidence": 0.85}
+    """
+    result = chat_service.post_regime_change(
+        address,
+        old_regime=body.get("old_regime", "unknown"),
+        new_regime=body.get("new_regime", "unknown"),
+        confidence=body.get("confidence", 0.0),
+    )
+    if result is None:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=500, detail="Failed to post regime change")
+    return result

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -286,6 +286,49 @@ class PoolListResponse(BaseModel):
 # ═══════════════════════════════════════════════════════════════
 
 
+# ═══════════════════════════════════════════════════════════════
+# Chat (per-vault)
+# ═══════════════════════════════════════════════════════════════
+
+
+class ChatMessageResponse(BaseModel):
+    """A single chat message in a vault's chat room."""
+
+    id: int
+    vault_address: str
+    wallet_address: str
+    message: str
+    is_ai: bool = False
+    created_at: str  # ISO 8601
+
+
+class ChatMessageListResponse(BaseModel):
+    """Paginated list of chat messages for a vault."""
+
+    messages: list[ChatMessageResponse]
+    total: int
+    has_more: bool = False
+
+
+class ChatPostRequest(BaseModel):
+    """Post a new message to a vault's chat."""
+
+    wallet_address: str
+    message: str
+
+
+class ChatPostResponse(BaseModel):
+    """Response after posting a message. Includes AI response if triggered."""
+
+    message: ChatMessageResponse
+    ai_response: ChatMessageResponse | None = None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Contract Addresses
+# ═══════════════════════════════════════════════════════════════
+
+
 class ContractAddressesResponse(BaseModel):
     """All deployed contract addresses. Frontend needs these for direct on-chain calls."""
 

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -1,0 +1,42 @@
+"""Database setup — SQLAlchemy async engine + session factory.
+
+Uses DATABASE_URL env var (set by docker-compose to Postgres).
+Falls back to local SQLite for development.
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from archimedes.models.chat import Base
+
+logger = logging.getLogger(__name__)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./archimedes_chat.db")
+
+
+def _get_engine_kwargs() -> dict:
+    """Return engine kwargs appropriate for the database type."""
+    if DATABASE_URL.startswith("sqlite"):
+        return {"connect_args": {"check_same_thread": False}}
+    # Postgres
+    return {"pool_pre_ping": True, "pool_size": 5, "max_overflow": 10}
+
+
+engine = create_engine(DATABASE_URL, **_get_engine_kwargs())
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def init_db() -> None:
+    """Create all tables (idempotent for hackathon — no Alembic needed)."""
+    Base.metadata.create_all(bind=engine)
+    logger.info(f"Database tables created at {DATABASE_URL}")
+
+
+def get_session() -> Session:
+    """Get a new DB session. Use as context manager."""
+    return SessionLocal()

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -16,6 +16,8 @@ from archimedes.api.routes import (
     swap_router,
     config_router,
 )
+from archimedes.api.chat_routes import chat_router
+from archimedes.db import init_db
 
 app = FastAPI(
     title="Archimedes",
@@ -32,6 +34,9 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Initialize database (creates chat tables if needed)
+init_db()
+
 # Wire all routers
 app.include_router(assets_router)
 app.include_router(vaults_router)
@@ -40,6 +45,7 @@ app.include_router(traces_router)
 app.include_router(regime_router)
 app.include_router(swap_router)
 app.include_router(config_router)
+app.include_router(chat_router)
 
 
 @app.get("/health")

--- a/backend/archimedes/models/chat.py
+++ b/backend/archimedes/models/chat.py
@@ -1,0 +1,52 @@
+"""Chat message model — per-vault chat for the Archimedes marketplace.
+
+Design decisions (hackathon MVP per ecosystem-design-spec.md § 16–17):
+  - Fully open: any connected wallet can read/write in any vault chat
+  - Wallet address = identity (no profiles, DMs, reactions)
+  - AI messages: is_ai=True, triggered by @archimedes mentions or rebalance events
+  - Persistence: SQLite for local dev, Postgres in Docker — both via SQLAlchemy
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import String, Text, Boolean, Integer, DateTime, Index
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy declarative base for all Archimedes models."""
+    pass
+
+
+class ChatMessage(Base):
+    """A single chat message in a vault's chat room."""
+
+    __tablename__ = "chat_messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    vault_address: Mapped[str] = mapped_column(String(42), nullable=False, index=True)
+    wallet_address: Mapped[str] = mapped_column(String(42), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    is_ai: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    # Composite index for efficient vault + time-ordered queries
+    __table_args__ = (
+        Index("ix_chat_vault_created", "vault_address", "created_at"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "vault_address": self.vault_address,
+            "wallet_address": self.wallet_address,
+            "message": self.message,
+            "is_ai": self.is_ai,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/backend/archimedes/services/chat_service.py
+++ b/backend/archimedes/services/chat_service.py
@@ -1,0 +1,253 @@
+"""Chat service — business logic for per-vault chat.
+
+Handles:
+  - Message persistence
+  - Paginated message retrieval
+  - AI response generation (Claude API) for @archimedes mentions
+  - Auto-post on rebalance/regime events
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+
+from archimedes.db import get_session
+from archimedes.models.chat import ChatMessage
+
+logger = logging.getLogger(__name__)
+
+# AI persona for @archimedes mentions
+AI_SYSTEM_PROMPT = """You are Archimedes, an AI portfolio manager for a DeFi vault on Arc blockchain.
+
+You are speaking in a vault chat room. Be:
+- Concise (2–3 sentences max, chat format)
+- Informative about portfolio decisions, market conditions, strategy reasoning
+- Professional but approachable
+- Honest about risks and uncertainties
+
+You have access to on-chain reasoning traces that explain every rebalance decision.
+Reference academic research when discussing strategy choices.
+Never promise returns. Always frame in terms of process and rigor."""
+
+AI_WALLET_ADDRESS = "0x0000000000000000000000000000000000000000"  # Placeholder for AI identity
+
+
+class ChatService:
+    """Manages per-vault chat messages and AI responses."""
+
+    def get_messages(
+        self,
+        vault_address: str,
+        limit: int = 50,
+        before_id: int | None = None,
+    ) -> list[dict]:
+        """Get messages for a vault, newest last (chat scroll-up pattern)."""
+        session = get_session()
+        try:
+            query = session.query(ChatMessage).filter(
+                ChatMessage.vault_address == vault_address.lower()
+            )
+
+            if before_id:
+                query = query.filter(ChatMessage.id < before_id)
+
+            # Get up to `limit` messages, ordered oldest-first for display
+            messages = (
+                query.order_by(ChatMessage.created_at.desc())
+                .limit(limit)
+                .all()
+            )
+            # Reverse so newest is at the bottom
+            messages.reverse()
+            return [m.to_dict() for m in messages]
+        finally:
+            session.close()
+
+    def post_message(
+        self,
+        vault_address: str,
+        wallet_address: str,
+        message: str,
+    ) -> dict:
+        """Post a user message and optionally trigger an AI response."""
+        session = get_session()
+        try:
+            msg = ChatMessage(
+                vault_address=vault_address.lower(),
+                wallet_address=wallet_address.lower(),
+                message=message,
+                is_ai=False,
+                created_at=datetime.now(timezone.utc),
+            )
+            session.add(msg)
+            session.commit()
+            session.refresh(msg)
+
+            result = msg.to_dict()
+
+            # Check for @archimedes mention — trigger AI response
+            if "@archimedes" in message.lower():
+                ai_response = self._generate_ai_response(
+                    vault_address, message, wallet_address
+                )
+                if ai_response:
+                    result["_ai_response"] = ai_response
+
+            return result
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def post_ai_message(
+        self,
+        vault_address: str,
+        message: str,
+        trigger: str = "mention",
+    ) -> dict | None:
+        """Post an AI-generated message (rebalance event, regime change, or mention response)."""
+        session = get_session()
+        try:
+            msg = ChatMessage(
+                vault_address=vault_address.lower(),
+                wallet_address=AI_WALLET_ADDRESS,
+                message=message,
+                is_ai=True,
+                created_at=datetime.now(timezone.utc),
+            )
+            session.add(msg)
+            session.commit()
+            session.refresh(msg)
+
+            result = msg.to_dict()
+            result["trigger"] = trigger
+            return result
+        except Exception:
+            session.rollback()
+            logger.exception("Failed to post AI message")
+            return None
+        finally:
+            session.close()
+
+    def post_rebalance_event(
+        self,
+        vault_address: str,
+        reasoning: str,
+        trades: list[dict] | None = None,
+    ) -> dict | None:
+        """Auto-post a rebalance event in the vault chat (Tier 1 vaults).
+
+        Called by the agent runner after a successful rebalance.
+        """
+        trade_summary = ""
+        if trades:
+            trade_lines = [f"  • {t.get('direction','?').upper()} {t.get('amount','?')} {t.get('symbol','?')}" for t in trades[:5]]
+            trade_summary = "\n" + "\n".join(trade_lines)
+
+        message = (
+            f"🔄 **Rebalance executed**\n"
+            f"{reasoning}{trade_summary}\n\n"
+            f"_Reasoning trace anchored on-chain. View in the Traces tab._"
+        )
+        return self.post_ai_message(vault_address, message, trigger="rebalance")
+
+    def post_regime_change(
+        self,
+        vault_address: str,
+        old_regime: str,
+        new_regime: str,
+        confidence: float,
+    ) -> dict | None:
+        """Auto-post a regime change event."""
+        message = (
+            f"⚡ **Regime change detected**\n"
+            f"Market shifted from **{old_regime}** → **{new_regime}** "
+            f"(confidence: {confidence:.0%})\n\n"
+            f"_Portfolio will be adjusted accordingly._"
+        )
+        return self.post_ai_message(vault_address, message, trigger="regime_change")
+
+    def _generate_ai_response(
+        self,
+        vault_address: str,
+        user_message: str,
+        wallet_address: str,
+    ) -> dict | None:
+        """Generate an AI response using Claude API."""
+        api_key = os.getenv("ANTHROPIC_API_KEY", "")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set — returning canned AI response")
+            return self._canned_response(vault_address, user_message)
+
+        try:
+            import anthropic
+
+            client = anthropic.Anthropic(api_key=api_key)
+
+            # Get recent chat context (last 10 messages)
+            recent = self.get_messages(vault_address, limit=10)
+            lines = []
+            for m in recent[-5:]:
+                if m["is_ai"]:
+                    lines.append(f"🤖 Archimedes: {m['message']}")
+                else:
+                    lines.append(f"👤 {m['wallet_address'][:10]}...: {m['message']}")
+            context = "\n".join(lines)
+
+            response = client.messages.create(
+                model="claude-sonnet-4-20250514",
+                max_tokens=300,
+                system=AI_SYSTEM_PROMPT,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"Vault: {vault_address}\nRecent chat:\n{context}\n\nUser asks: {user_message}",
+                    }
+                ],
+            )
+
+            ai_text = response.content[0].text.strip() if response.content else "I'm analyzing the portfolio. Give me a moment."
+            return self.post_ai_message(vault_address, ai_text, trigger="mention")
+
+        except Exception:
+            logger.exception("Claude API call failed — falling back to canned response")
+            return self._canned_response(vault_address, user_message)
+
+    def _canned_response(self, vault_address: str, user_message: str) -> dict | None:
+        """Fallback AI responses when Claude API is unavailable."""
+        msg_lower = user_message.lower()
+
+        if any(w in msg_lower for w in ["performance", "return", "pnl", "profit"]):
+            text = "Portfolio performance is tracked on-chain via reasoning traces. Every rebalance decision is anchored with a verifiable hash on Arc. Check the Traces tab for the full history."
+        elif any(w in msg_lower for w in ["rebalance", "adjust", "change"]):
+            text = "Rebalances are triggered by regime detection and strategy rotation signals. I execute them with full reasoning traces — the why, not just the what."
+        elif any(w in msg_lower for w in ["risk", "safe", "dangerous"]):
+            text = "Every Tier 1 strategy passes four selection-bias controls (DSR, PBO, walk-forward OOS, look-ahead audit) before admission. Rigor is the wedge."
+        elif any(w in msg_lower for w in ["strategy", "paper", "research"]):
+            text = "Our strategies are grounded in peer-reviewed quantitative finance research. Each one carries a strategy passport with backtest results and paper-claim deltas."
+        elif any(w in msg_lower for w in ["hello", "hi", "hey", "what"]):
+            text = "Hey! 👋 I'm Archimedes, your AI portfolio manager. Ask me about this vault's strategy, recent rebalances, or the research backing our positions."
+        else:
+            text = "Good question. I'm monitoring the portfolio and market conditions. Feel free to ask about specific strategies, performance, or our research-backed approach."
+
+        return self.post_ai_message(vault_address, text, trigger="mention")
+
+    def get_message_count(self, vault_address: str) -> int:
+        """Get total message count for a vault."""
+        session = get_session()
+        try:
+            return (
+                session.query(ChatMessage)
+                .filter(ChatMessage.vault_address == vault_address.lower())
+                .count()
+            )
+        finally:
+            session.close()
+
+
+# Singleton
+chat_service = ChatService()

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -822,3 +822,399 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 
 [hidden] { display: none !important; }
+
+/* ═══════════════════════════════════════════════════════════════
+   VAULT DETAIL PAGE
+   ═══════════════════════════════════════════════════════════════ */
+
+.vault-detail-page {
+  max-width: 900px;
+}
+
+.back-btn {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 8px 0;
+  margin-bottom: 16px;
+  transition: color 0.15s;
+}
+.back-btn:hover { color: var(--text-1); }
+
+.vault-detail-header {
+  margin-bottom: 24px;
+}
+
+.vault-detail-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.vault-detail-name {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-1);
+}
+
+.vault-tier-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 20px;
+}
+.vault-tier-badge.tier-1 {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+.vault-tier-badge.tier-2 {
+  background: rgba(96, 165, 250, 0.1);
+  color: var(--info);
+}
+
+.vault-detail-meta {
+  color: var(--text-3);
+  font-size: 0.8rem;
+}
+.vault-detail-meta code {
+  background: var(--surface-3);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+/* Stats grid */
+.vault-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+@media (max-width: 768px) {
+  .vault-stats-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+.vault-stat-card {
+  background: var(--surface-2);
+  border: 1px solid var(--glass-border);
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.vault-stat-label {
+  font-size: 0.75rem;
+  color: var(--text-3);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.vault-stat-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-1);
+}
+.vault-stat-value code {
+  font-size: 0.85rem;
+}
+
+/* Sections */
+.vault-section {
+  margin-bottom: 24px;
+}
+.vault-section h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-2);
+  margin-bottom: 12px;
+}
+
+/* Holdings */
+.vault-holdings-list {
+  background: var(--surface-2);
+  border: 1px solid var(--glass-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.vault-holding-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 100px 60px;
+  padding: 10px 16px;
+  font-size: 0.85rem;
+  border-bottom: 1px solid var(--glass-border);
+}
+.vault-holding-row:last-child { border-bottom: none; }
+
+.vault-holding-symbol { font-weight: 600; color: var(--text-1); }
+.vault-holding-amount { color: var(--text-2); font-family: var(--mono); }
+.vault-holding-value { color: var(--text-2); text-align: right; }
+.vault-holding-weight { color: var(--accent); text-align: right; font-weight: 600; }
+
+/* Traces */
+.vault-traces-list {
+  background: var(--surface-2);
+  border: 1px solid var(--glass-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.vault-trace-row {
+  display: grid;
+  grid-template-columns: 100px 1fr 80px 30px;
+  align-items: center;
+  padding: 10px 16px;
+  font-size: 0.8rem;
+  border-bottom: 1px solid var(--glass-border);
+}
+.vault-trace-row:last-child { border-bottom: none; }
+
+.vault-trace-type {
+  color: var(--accent);
+  font-weight: 500;
+  text-transform: capitalize;
+}
+.vault-trace-hash { color: var(--text-3); }
+.vault-trace-time { color: var(--text-3); text-align: right; }
+.vault-trace-verified { color: var(--positive); text-align: center; }
+
+/* Deposit */
+.vault-deposit-row {
+  display: flex;
+  gap: 10px;
+}
+
+.vault-deposit-input {
+  flex: 1;
+  background: var(--surface-3);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  color: var(--text-1);
+  font-size: 0.9rem;
+  outline: none;
+}
+.vault-deposit-input:focus { border-color: var(--accent); }
+
+/* Vault card clickable */
+.vault-card-clickable {
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: border-color 0.15s, background 0.15s;
+}
+.vault-card-clickable:hover {
+  border-color: var(--accent);
+  background: var(--surface-3);
+}
+.vault-card-arrow {
+  color: var(--text-4);
+  font-size: 1rem;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   CHAT PANEL
+   ═══════════════════════════════════════════════════════════════ */
+
+.chat-panel {
+  background: var(--surface-1);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-panel-collapsed .chat-messages,
+.chat-panel-collapsed .chat-input-area {
+  display: none;
+}
+
+.chat-panel-open {
+  height: 480px;
+}
+
+/* Header */
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--glass-border);
+  cursor: pointer;
+  user-select: none;
+}
+.chat-header:hover { background: var(--surface-3); }
+
+.chat-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-icon { font-size: 1rem; }
+.chat-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-1);
+}
+.chat-count {
+  font-size: 0.7rem;
+  color: var(--text-3);
+  background: var(--surface-4);
+  padding: 2px 7px;
+  border-radius: 10px;
+}
+.chat-toggle { color: var(--text-3); font-size: 0.7rem; }
+
+/* Messages area */
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: var(--text-3);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.chat-hint {
+  font-size: 0.75rem;
+  color: var(--text-4);
+  margin-top: 6px;
+}
+
+/* Message bubble */
+.chat-msg {
+  max-width: 85%;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--surface-3);
+  border: 1px solid var(--glass-border);
+}
+
+.chat-msg-own {
+  align-self: flex-end;
+  background: rgba(212, 168, 83, 0.08);
+  border-color: rgba(212, 168, 83, 0.15);
+}
+
+.chat-msg-ai {
+  align-self: flex-start;
+  background: rgba(96, 165, 250, 0.06);
+  border-color: rgba(96, 165, 250, 0.12);
+  max-width: 90%;
+}
+
+.chat-msg-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.chat-msg-avatar { font-size: 0.85rem; }
+
+.chat-msg-sender {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-2);
+}
+
+.chat-msg-time {
+  font-size: 0.65rem;
+  color: var(--text-4);
+  margin-left: auto;
+}
+
+.chat-msg-body {
+  font-size: 0.82rem;
+  color: var(--text-1);
+  line-height: 1.5;
+  word-break: break-word;
+}
+.chat-msg-ai .chat-msg-body {
+  color: var(--text-2);
+}
+
+/* Bold markdown-style text in AI messages */
+.chat-msg-ai .chat-msg-body strong,
+.chat-msg-ai .chat-msg-body b {
+  color: var(--text-1);
+}
+
+/* Input area */
+.chat-input-area {
+  border-top: 1px solid var(--glass-border);
+  padding: 10px 12px;
+  background: var(--surface-2);
+}
+
+.chat-error {
+  font-size: 0.75rem;
+  color: var(--negative);
+  margin-bottom: 8px;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-input {
+  flex: 1;
+  background: var(--surface-3);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: var(--text-1);
+  font-size: 0.82rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.chat-input:focus { border-color: var(--accent); }
+.chat-input::placeholder { color: var(--text-4); }
+
+.chat-send-btn {
+  background: var(--accent);
+  color: #000;
+  border: none;
+  border-radius: 8px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.15s;
+}
+.chat-send-btn:hover:not(:disabled) { background: var(--accent-hover); }
+.chat-send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Status message reuse */
+.status-msg {
+  margin-top: 8px;
+  font-size: 0.8rem;
+  color: var(--text-2);
+  padding: 8px 12px;
+  background: var(--surface-2);
+  border-radius: 8px;
+}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -9,6 +9,8 @@ import {
 } from './config'
 import Layout from './components/Layout'
 import Trade from './components/Trade'
+import VaultDetail from './components/VaultDetail'
+import VaultChat from './components/VaultChat'
 import './App.css'
 
 const PRICE_DECIMALS = 6
@@ -398,13 +400,10 @@ function Liquidity() {
 
 // ─── Vaults Panel ────────────────────────────────────────────
 
-function Vaults() {
+function Vaults({ onSelectVault }) {
   const [vaults, setVaults] = useState([])
   const [status, setStatus] = useState('')
-  const [busy, setBusy] = useState(false)
-  const [selectedVault, setSelectedVault] = useState(null)
-  const [vaultDetail, setVaultDetail] = useState(null)
-  const [depositAmt, setDepositAmt] = useState('')
+  const [manualAddr, setManualAddr] = useState('')
 
   const factoryAddr = NEW_CONTRACTS.vaultFactory
 
@@ -416,40 +415,6 @@ function Vaults() {
     } catch (err) { setStatus(err.shortMessage || err.message) }
   }
 
-  const loadVaultDetail = async (addr) => {
-    try {
-      const [totalAssets, totalSupply, creator, tier, paused, asset] = await Promise.all([
-        publicClient.readContract({ address: addr, abi: VAULT_ABI, functionName: 'totalAssets' }),
-        publicClient.readContract({ address: addr, abi: VAULT_ABI, functionName: 'totalSupply' }),
-        publicClient.readContract({ address: addr, abi: VAULT_ABI, functionName: 'creator' }),
-        publicClient.readContract({ address: addr, abi: VAULT_ABI, functionName: 'tier' }),
-        publicClient.readContract({ address: addr, abi: VAULT_ABI, functionName: 'paused' }),
-        publicClient.readContract({ address: addr, abi: VAULT_ABI, functionName: 'asset' }),
-      ])
-      setVaultDetail({
-        address: addr, totalAssets: Number(totalAssets) / 1e6, totalSupply: Number(totalSupply),
-        sharePrice: totalSupply > 0 ? Number(totalAssets) / Number(totalSupply) / 1e6 : 1,
-        creator, tier: Number(tier), paused, asset,
-      })
-    } catch (err) { setVaultDetail({ error: err.shortMessage || err.message }) }
-  }
-
-  const deposit = async () => {
-    if (!selectedVault || !depositAmt) return
-    setBusy(true); setStatus('')
-    try {
-      const wallet = await getWalletClient()
-      const amount = BigInt(Math.round(parseFloat(depositAmt) * 1e6))
-      setStatus('Approving USDC…')
-      await wallet.writeContract({ address: USDC, abi: TOKEN_ABI, functionName: 'approve', args: [selectedVault, amount] })
-      setStatus('Depositing…')
-      const hash = await wallet.writeContract({ address: selectedVault, abi: VAULT_ABI, functionName: 'deposit', args: [amount, getAddress()] })
-      setStatus(`Deposited! TX: ${hash}`)
-      loadVaultDetail(selectedVault)
-    } catch (err) { setStatus(err.shortMessage || err.message) }
-    setBusy(false)
-  }
-
   useEffect(() => { loadVaults() }, [])
 
   return (
@@ -459,36 +424,34 @@ function Vaults() {
         <div className="info-box warning">VaultFactory not deployed. Run <code>node deploy-new.mjs</code>.</div>
       ) : (
         <>
-          <p className="hint">{vaults.length} vaults deployed</p>
-          {vaults.length === 0 ? (
-            <p className="hint">No vaults yet. Deploy contracts first, then create a vault.</p>
-          ) : (
+          <p className="hint">{vaults.length} vault{vaults.length !== 1 ? 's' : ''} deployed — click to view details & chat</p>
+          {vaults.length > 0 && (
             <div className="vault-list">
               {vaults.map((v, i) => (
-                <div key={i} className={`vault-card ${selectedVault === v ? 'selected' : ''}`} onClick={() => { setSelectedVault(v); loadVaultDetail(v) }}>
+                <div key={i} className="vault-card vault-card-clickable" onClick={() => onSelectVault(v)}>
                   <code>{v}</code>
+                  <span className="vault-card-arrow">→</span>
                 </div>
               ))}
             </div>
           )}
 
-          {vaultDetail && !vaultDetail.error && (
-            <div className="info-box">
-              <strong>AUM:</strong> {vaultDetail.totalAssets.toFixed(2)} USDC<br />
-              <strong>Share Price:</strong> {vaultDetail.sharePrice.toFixed(6)} USDC<br />
-              <strong>Tier:</strong> {vaultDetail.tier} | <strong>Creator:</strong> <code>{vaultDetail.creator?.slice(0,10)}...</code><br />
-              <strong>Paused:</strong> {vaultDetail.paused ? 'Yes' : 'No'}
-            </div>
-          )}
-
-          {selectedVault && (
+          <div style={{ marginTop: 20, paddingTop: 16, borderTop: '1px solid var(--glass-border)' }}>
+            <label style={{ fontSize: '0.8rem', color: 'var(--text-3)', marginBottom: 6, display: 'block' }}>Enter vault address</label>
             <div className="form-row">
-              <input type="number" value={depositAmt} onChange={e => setDepositAmt(e.target.value)} placeholder="USDC amount" />
-              <button className="primary" onClick={deposit} disabled={busy} style={{ width: 'auto' }}>
-                {busy ? 'Waiting…' : 'Deposit'}
+              <input
+                type="text"
+                value={manualAddr}
+                onChange={e => setManualAddr(e.target.value)}
+                placeholder="0x..."
+                style={{ flex: 1, background: 'var(--surface-3)', border: '1px solid var(--glass-border)', borderRadius: 8, padding: '8px 12px', color: 'var(--text-1)', fontSize: '0.85rem', outline: 'none' }}
+              />
+              <button className="btn btn-primary" style={{ width: 'auto' }} onClick={() => manualAddr && onSelectVault(manualAddr)} disabled={!manualAddr}>
+                View →
               </button>
             </div>
-          )}
+          </div>
+
           {status && <div className="status">{status}</div>}
         </>
       )}
@@ -607,6 +570,7 @@ function ComingSoon({ title }) {
 export default function App() {
   const [page, setPage] = useState('trade')
   const [walletAddr, setWalletAddr] = useState(null)
+  const [selectedVault, setSelectedVault] = useState(null)
   const [data, setData] = useState({})
   const [prevData, setPrevData] = useState({})
   const [errors, setErrors] = useState({})
@@ -628,6 +592,16 @@ export default function App() {
 
   const handleConnect = (addr) => setWalletAddr(addr)
   const handleDisconnect = () => { disconnectWallet(); setWalletAddr(null) }
+
+  const selectVault = (addr) => {
+    setSelectedVault(addr)
+    setPage('vault-detail')
+  }
+
+  const backToVaults = () => {
+    setSelectedVault(null)
+    setPage('vaults')
+  }
 
   const fetchAll = useCallback(async () => {
     const results = await Promise.allSettled(ASSETS.map(a => fetchAssetData(a)))
@@ -660,15 +634,16 @@ export default function App() {
 
   const renderPage = () => {
     switch (page) {
-      case 'explore':    return <ComingSoon title="Marketplace" />
-      case 'strategies': return <ComingSoon title="Strategy Explorer" />
-      case 'trade':      return <Trade />
-      case 'dashboard':  return <Dashboard data={data} prevData={prevData} errors={errors} loading={loading} lastFetch={lastFetch} countdown={countdown} fetchAll={fetchAll} />
-      case 'mint':       return <MintBurn />
-      case 'liquidity':  return <Liquidity />
-      case 'vaults':     return <Vaults />
-      case 'reasoning':  return <Traces />
-      default:           return <Trade />
+      case 'explore':       return <ComingSoon title="Marketplace" />
+      case 'strategies':    return <ComingSoon title="Strategy Explorer" />
+      case 'trade':         return <Trade />
+      case 'dashboard':     return <Dashboard data={data} prevData={prevData} errors={errors} loading={loading} lastFetch={lastFetch} countdown={countdown} fetchAll={fetchAll} />
+      case 'mint':          return <MintBurn />
+      case 'liquidity':     return <Liquidity />
+      case 'vaults':        return <Vaults onSelectVault={selectVault} />
+      case 'vault-detail':  return <VaultDetail address={selectedVault} onBack={backToVaults} />
+      case 'reasoning':     return <Traces />
+      default:              return <Trade />
     }
   }
 

--- a/ui/src/components/VaultChat.jsx
+++ b/ui/src/components/VaultChat.jsx
@@ -1,0 +1,226 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { getAddress } from '../config'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+async function apiGet(path) {
+  const res = await fetch(`${API_BASE}${path}`)
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+async function apiPost(path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+// ─── Message Bubble ─────────────────────────────────────────
+
+function MessageBubble({ msg, isOwn }) {
+  const addr = msg.wallet_address || ''
+  const shortAddr = addr.length > 12
+    ? `${addr.slice(0, 6)}...${addr.slice(-4)}`
+    : addr
+
+  const time = msg.created_at
+    ? new Date(msg.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : ''
+
+  return (
+    <div className={`chat-msg ${msg.is_ai ? 'chat-msg-ai' : ''} ${isOwn ? 'chat-msg-own' : ''}`}>
+      <div className="chat-msg-header">
+        <span className="chat-msg-avatar">
+          {msg.is_ai ? '🤖' : '👤'}
+        </span>
+        <span className="chat-msg-sender">
+          {msg.is_ai ? 'Archimedes AI' : shortAddr}
+        </span>
+        <span className="chat-msg-time">{time}</span>
+      </div>
+      <div className="chat-msg-body">
+        {msg.message.split('\n').map((line, i) => {
+          // Simple bold rendering for AI messages: **text** → <strong>
+          const parts = msg.is_ai
+            ? line.split(/(\*\*[^*]+\*\*)/g).map((part, j) => {
+                if (part.startsWith('**') && part.endsWith('**')) {
+                  return <strong key={j}>{part.slice(2, -2)}</strong>
+                }
+                return <span key={j}>{part}</span>
+              })
+            : [line]
+          return (
+            <span key={i}>
+              {parts}
+              {i < msg.message.split('\n').length - 1 && <br />}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── Chat Panel (embedded in vault detail) ──────────────────
+
+export default function VaultChat({ vaultAddress, isOpen = true, onToggle }) {
+  const [messages, setMessages] = useState([])
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const messagesEndRef = useRef(null)
+  const inputRef = useRef(null)
+  const wallet = getAddress()
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  const loadMessages = useCallback(async () => {
+    if (!vaultAddress) return
+    try {
+      const data = await apiGet(`/api/vaults/${vaultAddress}/chat?limit=100`)
+      setMessages(data.messages || [])
+      setLoading(false)
+    } catch (err) {
+      setError(err.message)
+      setLoading(false)
+    }
+  }, [vaultAddress])
+
+  // Initial load + polling
+  useEffect(() => {
+    loadMessages()
+    const interval = setInterval(loadMessages, 5000) // Poll every 5s
+    return () => clearInterval(interval)
+  }, [loadMessages])
+
+  // Auto-scroll on new messages
+  useEffect(() => {
+    scrollToBottom()
+  }, [messages.length])
+
+  // Focus input when chat opens
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [isOpen])
+
+  const sendMessage = async () => {
+    const text = input.trim()
+    if (!text || sending) return
+    if (!wallet) {
+      setError('Connect your wallet to send messages')
+      return
+    }
+
+    setSending(true)
+    setError('')
+    try {
+      const result = await apiPost(`/api/vaults/${vaultAddress}/chat`, {
+        wallet_address: wallet,
+        message: text,
+      })
+
+      // Add user message immediately
+      setMessages(prev => [...prev, result.message])
+
+      // Add AI response if triggered
+      if (result.ai_response) {
+        setMessages(prev => [...prev, result.ai_response])
+      }
+
+      setInput('')
+    } catch (err) {
+      setError(err.message)
+    }
+    setSending(false)
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
+  }
+
+  if (!vaultAddress) return null
+
+  return (
+    <div className={`chat-panel ${isOpen ? 'chat-panel-open' : 'chat-panel-collapsed'}`}>
+      {/* Header */}
+      <div className="chat-header" onClick={onToggle}>
+        <div className="chat-header-left">
+          <span className="chat-icon">💬</span>
+          <span className="chat-title">Vault Chat</span>
+          <span className="chat-count">{messages.length}</span>
+        </div>
+        <span className="chat-toggle">{isOpen ? '▼' : '▲'}</span>
+      </div>
+
+      {isOpen && (
+        <>
+          {/* Messages */}
+          <div className="chat-messages">
+            {loading ? (
+              <div className="chat-empty">Loading messages…</div>
+            ) : messages.length === 0 ? (
+              <div className="chat-empty">
+                <div style={{ fontSize: '1.5rem', marginBottom: 8 }}>💬</div>
+                <div>No messages yet</div>
+                <div className="chat-hint">
+                  Be the first to say something, or @archimedes to talk to the AI
+                </div>
+              </div>
+            ) : (
+              messages.map(msg => (
+                <MessageBubble
+                  key={msg.id}
+                  msg={msg}
+                  isOwn={!msg.is_ai && msg.wallet_address?.toLowerCase() === wallet?.toLowerCase()}
+                />
+              ))
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Input */}
+          <div className="chat-input-area">
+            {error && <div className="chat-error">{error}</div>}
+            {wallet ? (
+              <div className="chat-input-row">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  className="chat-input"
+                  value={input}
+                  onChange={e => setInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Type a message… (@archimedes to summon AI)"
+                  disabled={sending}
+                />
+                <button
+                  className="chat-send-btn"
+                  onClick={sendMessage}
+                  disabled={sending || !input.trim()}
+                >
+                  {sending ? '⏳' : '➤'}
+                </button>
+              </div>
+            ) : (
+              <div className="chat-hint" style={{ padding: '12px 16px' }}>
+                Connect your wallet to join the conversation
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/VaultDetail.jsx
+++ b/ui/src/components/VaultDetail.jsx
@@ -1,0 +1,204 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  publicClient, getWalletClient, getAddress,
+  USDC, TOKEN_ABI, VAULT_ABI,
+  ASSETS, NEW_CONTRACTS,
+} from '../config'
+import VaultChat from './VaultChat'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+async function apiGet(path) {
+  const res = await fetch(`${API_BASE}${path}`)
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+function timeAgo(ts) {
+  if (!ts) return '—'
+  const d = new Date(ts)
+  if (isNaN(d.getTime())) return ts
+  const secs = Math.floor((Date.now() - d.getTime()) / 1000)
+  if (secs < 60) return `${secs}s ago`
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
+  return `${Math.floor(secs / 86400)}d ago`
+}
+
+function shortAddr(addr) {
+  if (!addr) return '—'
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`
+}
+
+export default function VaultDetail({ address, onBack }) {
+  const [detail, setDetail] = useState(null)
+  const [onChainData, setOnChainData] = useState(null)
+  const [depositAmt, setDepositAmt] = useState('')
+  const [status, setStatus] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [chatOpen, setChatOpen] = useState(true)
+  const wallet = getAddress()
+
+  // Fetch backend data
+  useEffect(() => {
+    if (!address) return
+    let cancelled = false
+    apiGet(`/api/vaults/${address}`)
+      .then(data => { if (!cancelled) setDetail(data) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [address])
+
+  // Fetch on-chain data
+  const loadOnChain = useCallback(async () => {
+    if (!address) return
+    try {
+      const [totalAssets, totalSupply, creator, tier, paused, asset] = await Promise.all([
+        publicClient.readContract({ address, abi: VAULT_ABI, functionName: 'totalAssets' }),
+        publicClient.readContract({ address, abi: VAULT_ABI, functionName: 'totalSupply' }),
+        publicClient.readContract({ address, abi: VAULT_ABI, functionName: 'creator' }),
+        publicClient.readContract({ address, abi: VAULT_ABI, functionName: 'tier' }),
+        publicClient.readContract({ address, abi: VAULT_ABI, functionName: 'paused' }),
+        publicClient.readContract({ address, abi: VAULT_ABI, functionName: 'asset' }),
+      ])
+      setOnChainData({
+        totalAssets: Number(totalAssets) / 1e6,
+        totalSupply: Number(totalSupply),
+        sharePrice: Number(totalSupply) > 0 ? Number(totalAssets) / Number(totalSupply) / 1e6 : 1,
+        creator, tier: Number(tier), paused, asset,
+      })
+    } catch {}
+  }, [address])
+
+  useEffect(() => { loadOnChain() }, [loadOnChain])
+
+  const deposit = async () => {
+    if (!address || !depositAmt) return
+    setBusy(true); setStatus('')
+    try {
+      const w = await getWalletClient()
+      const amount = BigInt(Math.round(parseFloat(depositAmt) * 1e6))
+      setStatus('Approving USDC…')
+      await w.writeContract({ address: USDC, abi: TOKEN_ABI, functionName: 'approve', args: [address, amount] })
+      setStatus('Depositing…')
+      const hash = await w.writeContract({ address, abi: VAULT_ABI, functionName: 'deposit', args: [amount, getAddress()] })
+      setStatus(`Deposited! TX: ${hash}`)
+      setDepositAmt('')
+      loadOnChain()
+    } catch (err) { setStatus(err.shortMessage || err.message) }
+    setBusy(false)
+  }
+
+  const name = detail?.name || `Vault ${shortAddr(address)}`
+  const symbol = detail?.symbol || 'vAULT'
+  const tier = onChainData?.tier ?? detail?.tier ?? 1
+  const aum = onChainData?.totalAssets ?? detail?.aum_usdc ?? 0
+  const sharePrice = onChainData?.sharePrice ?? detail?.share_price ?? 1
+
+  return (
+    <div className="vault-detail-page">
+      {/* Back button */}
+      <button className="back-btn" onClick={onBack}>
+        ← Back to Vaults
+      </button>
+
+      {/* Vault Header */}
+      <div className="vault-detail-header">
+        <div className="vault-detail-title-row">
+          <h2 className="vault-detail-name">{name}</h2>
+          <span className={`vault-tier-badge tier-${tier}`}>
+            {tier === 1 ? '🏆 Verified' : '👥 Community'}
+          </span>
+        </div>
+        <div className="vault-detail-meta">
+          <code>{address}</code>
+        </div>
+      </div>
+
+      {/* Stats Grid */}
+      <div className="vault-stats-grid">
+        <div className="vault-stat-card">
+          <div className="vault-stat-label">AUM</div>
+          <div className="vault-stat-value">${aum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</div>
+        </div>
+        <div className="vault-stat-card">
+          <div className="vault-stat-label">Share Price</div>
+          <div className="vault-stat-value">${sharePrice.toFixed(6)}</div>
+        </div>
+        <div className="vault-stat-card">
+          <div className="vault-stat-label">Tier</div>
+          <div className="vault-stat-value">{tier === 1 ? 'Paper-grounded' : 'Community'}</div>
+        </div>
+        <div className="vault-stat-card">
+          <div className="vault-stat-label">Creator</div>
+          <div className="vault-stat-value"><code>{shortAddr(onChainData?.creator || detail?.creator)}</code></div>
+        </div>
+      </div>
+
+      {/* Holdings */}
+      {detail?.holdings && detail.holdings.length > 0 && (
+        <div className="vault-section">
+          <h3>Holdings</h3>
+          <div className="vault-holdings-list">
+            {detail.holdings.map((h, i) => (
+              <div key={i} className="vault-holding-row">
+                <span className="vault-holding-symbol">{h.symbol}</span>
+                <span className="vault-holding-amount">{h.amount?.toFixed(6) ?? '—'}</span>
+                <span className="vault-holding-value">${h.value_usdc?.toFixed(2) ?? '—'}</span>
+                <span className="vault-holding-weight">{h.weight_pct?.toFixed(1) ?? '—'}%</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Recent Traces */}
+      {detail?.recent_traces && detail.recent_traces.length > 0 && (
+        <div className="vault-section">
+          <h3>Recent Reasoning Traces</h3>
+          <div className="vault-traces-list">
+            {detail.recent_traces.map((t, i) => (
+              <div key={i} className="vault-trace-row">
+                <span className="vault-trace-type">{t.decision_type}</span>
+                <code className="vault-trace-hash">{t.trace_hash?.slice(0, 16)}…</code>
+                <span className="vault-trace-time">{timeAgo(t.timestamp)}</span>
+                {t.is_verified && <span className="vault-trace-verified">✓</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Deposit */}
+      <div className="vault-section">
+        <h3>Deposit</h3>
+        <div className="vault-deposit-row">
+          <input
+            type="number"
+            value={depositAmt}
+            onChange={e => setDepositAmt(e.target.value)}
+            placeholder="USDC amount"
+            className="vault-deposit-input"
+          />
+          <button
+            className="btn btn-primary"
+            onClick={deposit}
+            disabled={busy || !wallet}
+          >
+            {busy ? 'Waiting…' : 'Deposit'}
+          </button>
+        </div>
+        {status && <div className="status-msg">{status}</div>}
+      </div>
+
+      {/* Chat */}
+      <div className="vault-section">
+        <VaultChat
+          vaultAddress={address}
+          isOpen={chatOpen}
+          onToggle={() => setChatOpen(o => !o)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Per-Vault Chat — ecosystem-design-spec § 16–17

### What
- **ChatMessage model** (SQLAlchemy) — vault_address, wallet_address, message, is_ai, created_at
- **ChatService** — message CRUD, `@archimedes` AI responses via Claude API (canned fallback when no key), rebalance/regime change auto-post
- **5 REST endpoints** under `/api/vaults/{address}/chat/` — GET/POST messages, count, rebalance event, regime-change event
- **VaultChat.jsx** — chat panel with message bubbles (user/AI/own), input, 5s polling, bold markdown rendering
- **VaultDetail.jsx** — full vault page with stats grid, holdings, traces, deposit, embedded chat
- **Vite proxy** for `/api` → backend in dev mode
- **DB auto-init** on startup — Postgres in Docker, SQLite for local dev

### API Endpoints
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/vaults/{address}/chat` | List messages (paginated) |
| POST | `/api/vaults/{address}/chat` | Post message (AI responds to @archimedes) |
| GET | `/api/vaults/{address}/chat/count` | Message count |
| POST | `/api/vaults/{address}/chat/rebalance` | Agent posts rebalance event |
| POST | `/api/vaults/{address}/chat/regime-change` | Agent posts regime change |

### Tested
- Backend loads clean, all endpoints return 200
- Seeded 7 messages (user, AI, rebalance, regime change) — all displayed correctly
- Browser-tested via agent-browser: vault detail page, chat panel, real-time polling

### Spec alignment
- §16a: Fully open chat, any connected wallet can read/write ✓
- §16b: Minimal chat — per-vault text, wallet address identity, message persistence ✓
- §17: AI auto-posts on rebalance, responds to @mentions via Claude API ✓