### PR TITLE
[strategy] Multi-paper strategy fusion — spec + flagged module

### DIFF
--- a/backend/archimedes/services/strategy_fusion.py
+++ b/backend/archimedes/services/strategy_fusion.py
@@ -1,0 +1,630 @@
+"""Strategy fusion — multi-paper, user-steered, novelty-seeking synthesis.
+
+A NEW, feature-flagged primitive that sits *beside* `strategy_architect.py`,
+not inside it. The architect selects + weights pre-curated single-paper
+library strategies (the verified-library path that feeds the strategy-passport
+/ reasoning-trace data flow). Fusion does the opposite-direction thing:
+synthesizes a *new* strategy hypothesis by fusing >=2 raw arXiv q-fin papers,
+steered by the user, optimizing for novelty (McLean & Pontiff 2016: published
+alpha decays — the un-decayed edge is combinations not yet in the literature).
+
+Why a separate, flagged module (owner-decided HARD constraint):
+- `strategy_architect.py` and the construction-trace path are
+  contract-review-grade (the live `ReasoningTraceRegistry`). Fusion is
+  additive, behind `ARCHIMEDES_FUSION_ENABLED` (default OFF), and revertible
+  by deleting this file + its spec. Nothing in the audited flow is touched.
+- The LLM-backend seam, lazy `anthropic` import, `extract_json`, frozen
+  artifact and honest-fallback labelling deliberately mirror the architect so
+  a later route-wiring is a small, familiar diff.
+
+True-model honesty: our backend is routed through a GLM-backed,
+Anthropic-compatible endpoint. `messages.create(model=...)` gets the
+*configured* string, but `response.model` is the model that actually served
+the request (e.g. `glm-4.7`). The proposal records `response.model` as the
+provenance field of record and keeps the configured/requested string
+separately. See `docs/specs/strategy-fusion-spec.md`.
+
+References:
+- `docs/specs/strategy-fusion-spec.md` — the design this implements
+- `backend/archimedes/services/strategy_architect.py` — the seam mirrored here
+- `backend/archimedes/services/strategy_provider.py` — env-override precedent
+- `backend/archimedes/models/portfolio.py` — RiskProfile, RISK_PROFILE_PARAMS
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+from archimedes.models.portfolio import RISK_PROFILE_PARAMS, RiskProfile
+from archimedes.services.strategy_architect import extract_json
+
+logger = logging.getLogger(__name__)
+
+# Mirror the architect's configured default; `response.model` is what is
+# actually recorded for provenance (see module docstring / spec).
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+MAX_TOKENS = 4096
+
+# Hard floor: a fusion of one paper is just extraction (the architect's job).
+MIN_PAPERS = 2
+# Hard cap: token + cross-paper-coherence budget. max_papers clamps into here.
+FUSION_MAX_PAPERS = 6
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+# ── Feature flag (mirrors ARCHIMEDES_STRATEGIES_DIR: plain getenv) ──
+
+
+def fusion_enabled() -> bool:
+    """True iff ARCHIMEDES_FUSION_ENABLED is truthy. Default OFF.
+
+    Truthy = {1,true,yes,on} case-insensitive — the env convention shared
+    across the codebase. No central settings module exists; env override is
+    the established pattern (`strategy_provider.default_provider`).
+    """
+    return os.getenv("ARCHIMEDES_FUSION_ENABLED", "").strip().lower() in _TRUTHY
+
+
+# ── Asset-class synonym map (deterministic candidate filtering) ──
+#
+# Lowercased substring match against primary_category + categories + title +
+# abstract. Intentionally simple and reviewable rather than embedding-based;
+# a SPECTER2 ranker is a clean post-hackathon swap behind this same seam.
+_ASSET_SYNONYMS: dict[str, tuple[str, ...]] = {
+    "equities": ("equit", "stock", "share", "q-fin.pm", "cross-section"),
+    "rates": ("rate", "bond", "treasury", "yield curve", "fixed income", "duration"),
+    "credit": ("credit", "default", "cds", "spread", "bankruptcy"),
+    "fx": ("fx", "currency", "exchange rate", "carry trade"),
+    "commodities": ("commodit", "oil", "energy", "metal", "gold", "futures"),
+    "crypto": ("crypto", "bitcoin", "blockchain", "defi", "token"),
+    "vol": ("volatil", "variance", "option", "vix", "implied vol"),
+    "macro": ("macro", "regime", "business cycle", "monetary", "inflation"),
+}
+
+
+# ── LLM backend seam (mirrors the architect's Protocol) ─────────
+
+
+class LLMBackend(Protocol):
+    """Minimal text-completion seam. Identical shape to the architect's.
+
+    `served_model` is the fusion-specific addition: the model that actually
+    answered (`response.model`), distinct from the configured `model_id`.
+    """
+
+    @property
+    def model_id(self) -> str:
+        """The configured/requested model string (reproducibility)."""
+        ...
+
+    @property
+    def served_model(self) -> str:
+        """The model that actually served the last call (provenance)."""
+        ...
+
+    def complete(self, system: str, user: str) -> str:
+        """Return the model's raw text response to a single user turn."""
+        ...
+
+
+class ClaudeBackend:
+    """Hosted Claude via the Anthropic SDK, GLM-routed in this deployment.
+
+    `anthropic` is imported lazily inside `complete` so this module stays
+    importable in dependency-light environments (tests, AST tooling) — the
+    architect's pattern. `served_model` is populated from `response.model`
+    on each call so the proposal records the model that actually answered.
+    """
+
+    def __init__(self, model: str = DEFAULT_MODEL, api_key: str | None = None) -> None:
+        import anthropic
+
+        self._model = model
+        self._served = model  # configured until a real response overrides it
+        self._api_key = api_key or os.getenv("ANTHROPIC_API_KEY", "")
+        self._client = anthropic.Anthropic(api_key=self._api_key) if self._api_key else None
+
+    @property
+    def model_id(self) -> str:
+        return self._model
+
+    @property
+    def served_model(self) -> str:
+        return self._served
+
+    @property
+    def available(self) -> bool:
+        return bool(self._api_key)
+
+    def complete(self, system: str, user: str) -> str:
+        import anthropic
+
+        client = self._client or anthropic.Anthropic(api_key=self._api_key)
+        response = client.messages.create(
+            model=self._model,
+            max_tokens=MAX_TOKENS,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        # The honesty rule: record what actually served the request, not what
+        # we asked for. GLM-routed endpoint returns e.g. "glm-4.7" here.
+        served = getattr(response, "model", None)
+        if served:
+            self._served = str(served)
+        return response.content[0].text.strip() if response.content else ""
+
+
+class CannedBackend:
+    """Deterministic offline fallback. Explicitly NOT model reasoning.
+
+    Mirrors the architect's `CannedBackend`: keeps the path demoable with no
+    API key and gives the parser a stable fixture in tests. The text is
+    emphatic that this is a non-novel placeholder so it can never masquerade
+    as a real cross-paper synthesis in a provenance record.
+    """
+
+    model_id = "canned-fusion-fallback"
+    served_model = "canned-fusion-fallback"
+
+    def complete(self, system: str, user: str) -> str:  # noqa: ARG002
+        ids = re.findall(r'"arxiv_id"\s*:\s*"([^"]+)"', user)
+        ids = ids[:FUSION_MAX_PAPERS] or ["__none__"]
+        return json.dumps(
+            {
+                "strategy_name": "Offline fusion placeholder",
+                "thesis": (
+                    "Offline fallback: no LLM backend available, so no genuine "
+                    "cross-paper synthesis was performed. Connect "
+                    "ANTHROPIC_API_KEY for a real, novelty-seeking fusion."
+                ),
+                "source_arxiv_ids": ids,
+                "fusion_reasoning": (
+                    "Not model reasoning. Papers are echoed back unfused; this "
+                    "is a labelled placeholder, not a novel combination."
+                ),
+                "novelty_rationale": (
+                    "None claimed — a fallback is by definition not novel."
+                ),
+                "risk_notes": (
+                    "Fallback output. Pre-backtest hypothesis only; the "
+                    "selection-bias gate (DSR/PBO/OOS/look-ahead) still applies."
+                ),
+            }
+        )
+
+
+# ── User-steering input ─────────────────────────────────────────
+
+
+@dataclass
+class FusionBrief:
+    """The user's steer. Fusion never free-runs the whole corpus.
+
+    `asset_classes` is a required-overlap filter (empty = no asset filter).
+    `risk_appetite` shapes the synthesis envelope (RISK_PROFILE_PARAMS), it
+    does not hard-filter papers. `strategic_direction` biases ranking and is
+    passed verbatim to the prompt. `max_papers` is clamped to
+    [MIN_PAPERS, FUSION_MAX_PAPERS]; the >=2 floor is non-negotiable.
+    """
+
+    asset_classes: list[str] = field(default_factory=list)
+    risk_appetite: RiskProfile | str = RiskProfile.MODERATE
+    strategic_direction: str = ""
+    max_papers: int = 4
+
+    @property
+    def risk_profile(self) -> RiskProfile:
+        rp = self.risk_appetite
+        return RiskProfile(rp) if isinstance(rp, str) else rp
+
+    @property
+    def paper_budget(self) -> int:
+        """max_papers clamped into the enforced [MIN_PAPERS, cap] range."""
+        return max(MIN_PAPERS, min(FUSION_MAX_PAPERS, int(self.max_papers)))
+
+
+# ── Corpus manifest (read-only, defensive, not a hard dependency) ──
+
+
+@dataclass(frozen=True)
+class CorpusPaper:
+    """One manifest line, reduced to the fields fusion needs."""
+
+    arxiv_id: str
+    title: str
+    abstract: str
+    primary_category: str
+    categories: tuple[str, ...]
+    published: str
+
+    @property
+    def haystack(self) -> str:
+        """Lowercased text used for asset-class + direction matching."""
+        cats = " ".join(self.categories)
+        return f"{self.primary_category} {cats} {self.title} {self.abstract}".lower()
+
+
+def _manifest_path() -> Path | None:
+    """Resolve the corpus manifest. Mirrors default_provider() precedence.
+
+    1. ARCHIMEDES_CORPUS_MANIFEST env override (deployment / tests).
+    2. First existing candidate among host + container-plausible layouts.
+    Returns None if nothing resolvable — caller degrades, never raises.
+    """
+    env = os.getenv("ARCHIMEDES_CORPUS_MANIFEST")
+    if env:
+        p = Path(env)
+        return p if p.exists() else None
+
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parents[3] / "data" / "corpus" / "manifest.jsonl",  # host repo
+        Path("/app/data/corpus/manifest.jsonl"),  # repo-root build context
+        Path("/data/corpus/manifest.jsonl"),  # bind-mount at root
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def load_corpus(path: Path | None = None) -> list[CorpusPaper]:
+    """Defensive line-by-line manifest load. No hard dependency on the file.
+
+    A blank / non-JSON line, or one missing arxiv_id or all of
+    title+abstract, is logged at debug and skipped — one bad line never
+    aborts the load (arxiv_pipeline's per-page tolerance posture). A
+    missing/empty manifest yields an empty list (caller declines honestly).
+    """
+    path = path or _manifest_path()
+    if path is None or not path.exists():
+        logger.info("fusion: no corpus manifest resolvable; empty corpus")
+        return []
+
+    papers: list[CorpusPaper] = []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("fusion: cannot read manifest %s: %s", path, exc)
+        return []
+
+    for lineno, line in enumerate(raw.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj: dict[str, Any] = json.loads(line)
+        except json.JSONDecodeError as exc:
+            logger.debug("fusion: skip manifest line %d (bad JSON): %s", lineno, exc)
+            continue
+        arxiv_id = str(obj.get("arxiv_id", "")).strip()
+        title = str(obj.get("title", "")).strip()
+        abstract = str(obj.get("abstract", "")).strip()
+        if not arxiv_id or not (title or abstract):
+            logger.debug("fusion: skip manifest line %d (missing core fields)", lineno)
+            continue
+        cats = obj.get("categories") or []
+        papers.append(
+            CorpusPaper(
+                arxiv_id=arxiv_id,
+                title=title,
+                abstract=abstract,
+                primary_category=str(obj.get("primary_category", "")).strip(),
+                categories=tuple(str(c) for c in cats if isinstance(c, str)),
+                published=str(obj.get("published", "")).strip(),
+            )
+        )
+    logger.info("fusion: loaded %d corpus papers from %s", len(papers), path)
+    return papers
+
+
+# ── Deterministic pre-LLM candidate selection ───────────────────
+
+
+def _asset_terms(asset_classes: list[str]) -> list[str]:
+    """Expand requested asset classes through the synonym map (+ raw term)."""
+    terms: list[str] = []
+    for ac in asset_classes:
+        key = ac.strip().lower()
+        if not key:
+            continue
+        terms.append(key)
+        terms.extend(_ASSET_SYNONYMS.get(key, ()))
+    return terms
+
+
+def select_candidates(brief: FusionBrief, corpus: list[CorpusPaper]) -> list[CorpusPaper]:
+    """Deterministic, explainable, pre-LLM. The model never widens this set.
+
+    1. Asset-class overlap filter (skipped if no asset_classes given).
+    2. Rank by strategic_direction keyword hits, then recency (newer first
+       — alpha decay favours fresher results), then arxiv_id for total order.
+    3. Take top `paper_budget`.
+    """
+    terms = _asset_terms(brief.asset_classes)
+    if terms:
+        filtered = [p for p in corpus if any(t in p.haystack for t in terms)]
+    else:
+        filtered = list(corpus)
+
+    direction_kws = [
+        w for w in re.findall(r"[a-z]{3,}", brief.strategic_direction.lower())
+    ]
+
+    def score(p: CorpusPaper) -> tuple[int, str, str]:
+        hits = sum(1 for kw in direction_kws if kw in p.haystack)
+        # Negative hits → higher hits sort first; published desc → newer
+        # first; arxiv_id asc as the final deterministic tiebreak.
+        return (-hits, _recency_key(p.published), p.arxiv_id)
+
+    ranked = sorted(filtered, key=score)
+    return ranked[: brief.paper_budget]
+
+
+def _recency_key(published: str) -> str:
+    """Sort key making newer `published` sort first (we sort ascending).
+
+    ISO dates sort lexicographically; invert by complementing digits so a
+    later date yields a smaller key. Non-dates sort last (treated as oldest).
+    """
+    digits = re.sub(r"\D", "", published)[:8]
+    if len(digits) != 8:
+        return "99999999"
+    return "".join(str(9 - int(c)) for c in digits)
+
+
+# ── Output artifact ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FusionProposal:
+    """A novel cross-paper strategy hypothesis. Pre-backtest, pre-curation.
+
+    `status` is explicit so callers never infer failure from emptiness
+    (architect parity). `model` is the TRUE served model (`response.model`)
+    — the provenance field of record; `requested_model` is what we asked
+    for, kept separately.
+    """
+
+    status: str  # ok | disabled | insufficient_corpus | unparseable
+    brief: FusionBrief
+    strategy_name: str
+    thesis: str
+    source_arxiv_ids: list[str]
+    fusion_reasoning: str
+    novelty_rationale: str
+    risk_notes: str
+    model: str
+    requested_model: str
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def is_actionable(self) -> bool:
+        """True only for a real, parseable, >=2-paper fusion."""
+        return self.status == "ok" and len(self.source_arxiv_ids) >= MIN_PAPERS
+
+
+# ── Prompt construction ─────────────────────────────────────────
+
+
+_SYSTEM_PROMPT = """You are Archimedes Fusion, an AI quant-research synthesizer. \
+You design a NOVEL trading-strategy hypothesis by FUSING the mechanisms of \
+MULTIPLE peer-reviewed quantitative-finance papers into one combined approach.
+
+Hard rules:
+- You MUST fuse AT LEAST TWO of the provided papers. A single-paper answer is \
+invalid — that is a different tool's job. You may use a subset of the papers, \
+but never fewer than two and never a paper not in the provided list.
+- Reference papers ONLY by an arxiv_id from the provided candidates. Never \
+invent a paper or an arxiv_id.
+- OPTIMIZE FOR NOVELTY. The edge is the combination the literature has NOT \
+published. Published single-paper alpha decays post-publication (McLean & \
+Pontiff 2016) — your value is the non-obvious synthesis, not re-stating one \
+paper. Explain why the COMBINATION is non-obvious relative to each paper alone.
+- This is a HYPOTHESIS, not validated alpha. Do NOT invent Sharpe ratios, \
+returns, or backtest numbers. Do NOT promise or forecast returns. State \
+plainly that empirical validation (backtest / DSR / PBO) is pending.
+- Respect the user's risk envelope (USYC floor/ceiling, target vol, max DD) \
+as a synthesis constraint, not as a paper filter.
+
+Output STRICT JSON ONLY (no prose, no markdown fences), exactly this schema:
+{
+  "strategy_name": "<short working name for the fused strategy>",
+  "thesis": "<the fused strategy in plain language, honest it is pre-backtest>",
+  "source_arxiv_ids": ["<arxiv_id from candidates>", "<another>", ...],
+  "fusion_reasoning": "<what mechanism EACH cited paper contributes and how \
+they combine>",
+  "novelty_rationale": "<why this specific combination is not already in the \
+literature>",
+  "risk_notes": "<key risks + the pre-backtest / selection-bias caveat>"
+}"""
+
+
+def _build_user_prompt(brief: FusionBrief, candidates: list[CorpusPaper]) -> str:
+    rp = brief.risk_profile
+    payload = {
+        "user_steer": {
+            "asset_classes": brief.asset_classes,
+            "risk_appetite": rp.value,
+            "risk_envelope": RISK_PROFILE_PARAMS[rp],
+            "strategic_direction": brief.strategic_direction
+            or "(none given — optimize for novelty within the asset steer)",
+            "min_papers_to_fuse": MIN_PAPERS,
+            "max_papers_to_fuse": brief.paper_budget,
+        },
+        "candidate_papers": [
+            {
+                "arxiv_id": p.arxiv_id,
+                "title": p.title,
+                "primary_category": p.primary_category,
+                "categories": list(p.categories),
+                "published": p.published,
+                "abstract": p.abstract,
+            }
+            for p in candidates
+        ],
+    }
+    return json.dumps(payload, indent=2)
+
+
+# ── The fusion service ──────────────────────────────────────────
+
+
+def _inert_proposal(brief: FusionBrief, status: str, thesis: str) -> FusionProposal:
+    """A well-formed, self-describing non-fusion (disabled / declined)."""
+    return FusionProposal(
+        status=status,
+        brief=brief,
+        strategy_name="",
+        thesis=thesis,
+        source_arxiv_ids=[],
+        fusion_reasoning="",
+        novelty_rationale="",
+        risk_notes="No fusion performed.",
+        model="",
+        requested_model="",
+    )
+
+
+class StrategyFusion:
+    """User-steered, novelty-seeking, multi-paper strategy synthesizer.
+
+    Pure service — no FastAPI, no on-chain, not wired into the architect or
+    the construction-trace flow. Flag-gated: flag-off is a hard inert path
+    (no anthropic import, no manifest read, sentinel proposal).
+    """
+
+    def __init__(
+        self,
+        backend: LLMBackend | None = None,
+        corpus: list[CorpusPaper] | None = None,
+    ) -> None:
+        # Backend/corpus are injectable for offline tests. They are resolved
+        # lazily in `propose` so constructing the service never triggers an
+        # anthropic import or a manifest read (matters for the flag-off path
+        # and dependency-light import sites).
+        self._backend = backend
+        self._corpus = corpus
+
+    def _resolve_backend(self) -> LLMBackend:
+        if self._backend is not None:
+            return self._backend
+        self._backend = default_backend()
+        return self._backend
+
+    def _resolve_corpus(self) -> list[CorpusPaper]:
+        if self._corpus is not None:
+            return self._corpus
+        self._corpus = load_corpus()
+        return self._corpus
+
+    def propose(self, brief: FusionBrief) -> FusionProposal:
+        if not fusion_enabled():
+            # Hard inert path: no LLM, no manifest read, sentinel out.
+            return _inert_proposal(
+                brief,
+                "disabled",
+                "Strategy fusion is disabled. Set ARCHIMEDES_FUSION_ENABLED=1 "
+                "to enable multi-paper, novelty-seeking synthesis.",
+            )
+
+        corpus = self._resolve_corpus()
+        candidates = select_candidates(brief, corpus)
+        if len(candidates) < MIN_PAPERS:
+            return _inert_proposal(
+                brief,
+                "insufficient_corpus",
+                f"Need at least {MIN_PAPERS} papers matching the steer to "
+                f"fuse; the corpus yielded {len(candidates)}. Broaden "
+                "asset_classes / strategic_direction or grow the corpus. "
+                "(Single-paper output is intentionally not produced — that "
+                "is the strategy architect's job, not fusion's.)",
+            )
+
+        backend = self._resolve_backend()
+        valid_ids = {p.arxiv_id for p in candidates}
+        raw = backend.complete(_SYSTEM_PROMPT, _build_user_prompt(brief, candidates))
+
+        try:
+            parsed = extract_json(raw)
+        except ValueError:
+            logger.warning("fusion: unparseable LLM output; declined proposal")
+            return FusionProposal(
+                status="unparseable",
+                brief=brief,
+                strategy_name="",
+                thesis=(
+                    "Could not parse a valid fusion from the model. No "
+                    "hypothesis proposed — safer than shipping a guess."
+                ),
+                source_arxiv_ids=[],
+                fusion_reasoning="",
+                novelty_rationale="",
+                risk_notes="Model output was not valid JSON.",
+                model=backend.served_model,
+                requested_model=backend.model_id,
+            )
+
+        # Anti-hallucination: drop any arxiv_id not in the deterministically
+        # selected candidate set (architect parity — it drops unknown ids).
+        raw_ids = parsed.get("source_arxiv_ids", [])
+        source_ids = [
+            str(i) for i in raw_ids if isinstance(i, str) and i in valid_ids
+        ]
+        # De-dupe, preserve order.
+        seen: set[str] = set()
+        source_ids = [i for i in source_ids if not (i in seen or seen.add(i))]
+
+        if len(source_ids) < MIN_PAPERS:
+            logger.warning(
+                "fusion: model fused %d valid papers (<%d); declined",
+                len(source_ids),
+                MIN_PAPERS,
+            )
+            return _inert_proposal(
+                brief,
+                "insufficient_corpus",
+                f"Model did not fuse at least {MIN_PAPERS} of the provided "
+                "papers (after dropping any hallucinated ids). No "
+                "single-paper hypothesis is produced.",
+            )
+
+        return FusionProposal(
+            status="ok",
+            brief=brief,
+            strategy_name=str(parsed.get("strategy_name", "")).strip(),
+            thesis=str(parsed.get("thesis", "")).strip(),
+            source_arxiv_ids=source_ids,
+            fusion_reasoning=str(parsed.get("fusion_reasoning", "")).strip(),
+            novelty_rationale=str(parsed.get("novelty_rationale", "")).strip(),
+            risk_notes=str(parsed.get("risk_notes", "")).strip(),
+            model=backend.served_model,  # TRUE served model — field of record
+            requested_model=backend.model_id,  # what we asked for
+        )
+
+
+def default_backend() -> LLMBackend:
+    """Hosted Claude when a key is present; canned fallback otherwise.
+
+    Mirrors `strategy_architect.default_backend()`.
+    """
+    claude = ClaudeBackend()
+    if claude.available:
+        return claude
+    logger.warning(
+        "ANTHROPIC_API_KEY not set — strategy fusion using canned fallback"
+    )
+    return CannedBackend()
+
+
+def default_fusion() -> StrategyFusion:
+    """Factory mirroring `default_architect()`. Not yet route-wired."""
+    return StrategyFusion()

--- a/backend/tests/test_strategy_fusion.py
+++ b/backend/tests/test_strategy_fusion.py
@@ -1,0 +1,388 @@
+"""Tests for the flagged multi-paper strategy-fusion module.
+
+No network: the Anthropic client is never constructed — every test injects
+either a mock `LLMBackend` or the deterministic `CannedBackend`. The corpus
+is a self-contained in-test fixture written to a tmp manifest (no dependency
+on Stream-A's data/corpus/manifest.jsonl).
+
+Covers:
+- feature-flag gating (default OFF → inert; ON → real path)
+- steering filters candidates (asset_classes + strategic_direction + budget)
+- the synthesis prompt contains >=2 candidate papers
+- provenance lists the source arxiv_ids; recorded model == response.model
+- the offline fallback is explicitly labelled (not model reasoning)
+- defensive manifest loader skips bad lines, no hard file dependency
+- the >=2-paper floor: insufficient corpus / single-paper output declined
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from archimedes.models.portfolio import RiskProfile
+from archimedes.services.strategy_fusion import (
+    MIN_PAPERS,
+    CannedBackend,
+    FusionBrief,
+    StrategyFusion,
+    fusion_enabled,
+    load_corpus,
+    select_candidates,
+)
+
+# ── Self-contained fixture corpus (frozen manifest schema) ──────
+
+_FIXTURE_ROWS = [
+    {
+        "arxiv_id": "2401.00001",
+        "title": "Cross-Sectional Equity Momentum with Regime Conditioning",
+        "authors": ["A. One"],
+        "primary_category": "q-fin.PM",
+        "categories": ["q-fin.PM"],
+        "published": "2024-01-05",
+        "updated": "2024-01-06",
+        "abstract": "We study a regime-switching overlay on cross-sectional "
+        "equity momentum across the stock universe.",
+        "pdf_url": "http://x/1",
+        "pdf_sha256": "a" * 64,
+        "pdf_path": "data/corpus/pdfs/2401.00001.pdf",
+        "text_path": "data/corpus/text/2401.00001.txt",
+        "fetched_at": "2026-05-16T00:00:00Z",
+    },
+    {
+        "arxiv_id": "2402.00002",
+        "title": "Treasury Yield Curve Carry and Macro Regimes",
+        "authors": ["B. Two"],
+        "primary_category": "q-fin.PM",
+        "categories": ["q-fin.PM", "econ.EM"],
+        "published": "2024-02-10",
+        "updated": "2024-02-11",
+        "abstract": "A carry strategy on the treasury yield curve conditioned "
+        "on macro regime states.",
+        "pdf_url": "http://x/2",
+        "pdf_sha256": "b" * 64,
+        "pdf_path": "data/corpus/pdfs/2402.00002.pdf",
+        "text_path": "data/corpus/text/2402.00002.txt",
+        "fetched_at": "2026-05-16T00:00:00Z",
+    },
+    {
+        "arxiv_id": "2403.00003",
+        "title": "Implied Volatility Surface Dynamics for Index Options",
+        "authors": ["C. Three"],
+        "primary_category": "q-fin.PR",
+        "categories": ["q-fin.PR"],
+        "published": "2024-03-15",
+        "updated": "2024-03-16",
+        "abstract": "Modelling implied volatility surface dynamics and variance "
+        "risk premia for index options.",
+        "pdf_url": "http://x/3",
+        "pdf_sha256": "c" * 64,
+        "pdf_path": "data/corpus/pdfs/2403.00003.pdf",
+        "text_path": "data/corpus/text/2403.00003.txt",
+        "fetched_at": "2026-05-16T00:00:00Z",
+    },
+    {
+        "arxiv_id": "2404.00004",
+        "title": "Deep Learning for Protein Folding",
+        "authors": ["D. Four"],
+        "primary_category": "q-bio.BM",
+        "categories": ["q-bio.BM"],
+        "published": "2024-04-20",
+        "updated": "2024-04-21",
+        "abstract": "An unrelated biology paper that must never match a "
+        "finance asset-class steer.",
+        "pdf_url": "http://x/4",
+        "pdf_sha256": "d" * 64,
+        "pdf_path": "data/corpus/pdfs/2404.00004.pdf",
+        "text_path": "data/corpus/text/2404.00004.txt",
+        "fetched_at": "2026-05-16T00:00:00Z",
+    },
+]
+
+
+@pytest.fixture
+def manifest(tmp_path):
+    """Write the fixture corpus + a deliberately corrupt + blank line."""
+    p = tmp_path / "manifest.jsonl"
+    lines = [json.dumps(r) for r in _FIXTURE_ROWS]
+    lines.insert(2, "")  # blank line — must be skipped
+    lines.insert(3, "{not valid json")  # corrupt line — must be skipped
+    lines.append('{"title": "no arxiv id"}')  # missing core field — skipped
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def corpus(manifest):
+    return load_corpus(manifest)
+
+
+@pytest.fixture(autouse=True)
+def _flag_off_by_default(monkeypatch):
+    """Every test starts with the flag explicitly cleared (default OFF)."""
+    monkeypatch.delenv("ARCHIMEDES_FUSION_ENABLED", raising=False)
+    monkeypatch.delenv("ARCHIMEDES_CORPUS_MANIFEST", raising=False)
+
+
+# ── A mock backend that records what it was asked ───────────────
+
+
+class _MockBackend:
+    """Records the prompt; returns a canned fusion of the first 2 candidates.
+
+    `served_model` differs from `model_id` to assert the true-model honesty
+    rule (the deployment is GLM-routed: response.model != requested model).
+    """
+
+    model_id = "claude-sonnet-4-20250514"  # what we'd configure/request
+    served_model = "glm-4.7"  # what actually answers (response.model)
+
+    def __init__(self) -> None:
+        self.system: str | None = None
+        self.user: str | None = None
+
+    def complete(self, system: str, user: str) -> str:
+        self.system = system
+        self.user = user
+        payload = json.loads(user)
+        ids = [p["arxiv_id"] for p in payload["candidate_papers"][:2]]
+        return json.dumps(
+            {
+                "strategy_name": "Regime-conditioned carry/momentum fusion",
+                "thesis": "Fuse the two mechanisms. Pre-backtest hypothesis.",
+                "source_arxiv_ids": ids
+                + ["9999.99999"],  # hallucinated id — must be dropped
+                "fusion_reasoning": "Paper A gives momentum; paper B gives carry.",
+                "novelty_rationale": "The joint regime conditioning is unpublished.",
+                "risk_notes": "Pre-backtest; selection-bias gate still applies.",
+            }
+        )
+
+
+# ── Feature-flag gating ─────────────────────────────────────────
+
+
+def test_flag_default_off():
+    assert fusion_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "Yes", "on"])
+def test_flag_truthy_values(monkeypatch, val):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", val)
+    assert fusion_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", "0", "false", "no", "off", "maybe"])
+def test_flag_falsy_values(monkeypatch, val):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", val)
+    assert fusion_enabled() is False
+
+
+def test_flag_off_is_inert_no_backend_no_corpus():
+    """Flag OFF: sentinel out, backend never resolved, corpus never read."""
+
+    class _Boom:
+        model_id = "x"
+        served_model = "x"
+
+        def complete(self, system, user):  # noqa: ARG002
+            raise AssertionError("backend must not be called when flag is OFF")
+
+    def _boom_corpus():
+        raise AssertionError("corpus must not be read when flag is OFF")
+
+    svc = StrategyFusion(backend=_Boom(), corpus=None)
+    svc._resolve_corpus = _boom_corpus  # would raise if touched
+    proposal = svc.propose(FusionBrief(asset_classes=["equities"]))
+
+    assert proposal.status == "disabled"
+    assert proposal.source_arxiv_ids == []
+    assert "ARCHIMEDES_FUSION_ENABLED" in proposal.thesis
+    assert proposal.is_actionable is False
+
+
+# ── Defensive manifest loader ───────────────────────────────────
+
+
+def test_loader_skips_blank_corrupt_and_incomplete_lines(corpus):
+    # 4 good rows; blank + corrupt + missing-core lines all skipped.
+    assert {p.arxiv_id for p in corpus} == {
+        "2401.00001",
+        "2402.00002",
+        "2403.00003",
+        "2404.00004",
+    }
+
+
+def test_loader_no_file_returns_empty(tmp_path):
+    assert load_corpus(tmp_path / "does_not_exist.jsonl") == []
+
+
+def test_loader_env_override(monkeypatch, manifest):
+    monkeypatch.setenv("ARCHIMEDES_CORPUS_MANIFEST", str(manifest))
+    # path=None → resolves via ARCHIMEDES_CORPUS_MANIFEST.
+    assert len(load_corpus()) == 4
+
+
+# ── Deterministic steering / candidate selection ────────────────
+
+
+def test_asset_class_filter_excludes_unrelated(corpus):
+    brief = FusionBrief(asset_classes=["equities"])
+    picked = select_candidates(brief, corpus)
+    ids = {p.arxiv_id for p in picked}
+    assert "2401.00001" in ids  # equity momentum matches
+    assert "2404.00004" not in ids  # biology paper excluded
+
+
+def test_direction_biases_ranking(corpus):
+    """A 'volatility' steer should surface the IV-surface paper first."""
+    brief = FusionBrief(
+        asset_classes=[], strategic_direction="implied volatility variance"
+    )
+    picked = select_candidates(brief, corpus)
+    assert picked[0].arxiv_id == "2403.00003"
+
+
+def test_paper_budget_clamped_and_enforced_floor(corpus):
+    # max_papers below the floor is clamped UP to MIN_PAPERS.
+    brief = FusionBrief(asset_classes=[], max_papers=1)
+    assert brief.paper_budget == MIN_PAPERS
+    picked = select_candidates(brief, corpus)
+    assert len(picked) == MIN_PAPERS
+
+
+def test_selection_is_deterministic(corpus):
+    brief = FusionBrief(asset_classes=["rates", "equities"], max_papers=3)
+    a = [p.arxiv_id for p in select_candidates(brief, corpus)]
+    b = [p.arxiv_id for p in select_candidates(brief, corpus)]
+    assert a == b
+
+
+# ── Fusion happy path (flag ON, mocked backend) ─────────────────
+
+
+def test_propose_fuses_and_records_provenance(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    backend = _MockBackend()
+    svc = StrategyFusion(backend=backend, corpus=corpus)
+    brief = FusionBrief(
+        asset_classes=["equities", "rates"],
+        risk_appetite=RiskProfile.MODERATE,
+        strategic_direction="regime conditioning",
+        max_papers=4,
+    )
+    proposal = svc.propose(brief)
+
+    assert proposal.status == "ok"
+    assert proposal.is_actionable is True
+
+    # Prompt was handed >=2 candidate papers.
+    sent = json.loads(backend.user)
+    assert len(sent["candidate_papers"]) >= MIN_PAPERS
+
+    # Provenance lists the fused source arxiv_ids (>=2) ...
+    assert len(proposal.source_arxiv_ids) >= MIN_PAPERS
+    # ... and the hallucinated id was dropped (anti-hallucination).
+    assert "9999.99999" not in proposal.source_arxiv_ids
+    assert all(
+        sid in {p.arxiv_id for p in corpus} for sid in proposal.source_arxiv_ids
+    )
+
+    # True-model honesty: recorded model == response.model (served), and the
+    # configured/requested model is kept separately.
+    assert proposal.model == "glm-4.7"
+    assert proposal.requested_model == "claude-sonnet-4-20250514"
+
+
+def test_prompt_demands_at_least_two_papers(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    backend = _MockBackend()
+    svc = StrategyFusion(backend=backend, corpus=corpus)
+    svc.propose(FusionBrief(asset_classes=["equities", "rates", "vol"]))
+    assert "AT LEAST TWO" in backend.system
+
+
+# ── Insufficient corpus / >=2 floor declines ────────────────────
+
+
+def test_insufficient_corpus_declines(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    backend = _MockBackend()
+    # Asset class that matches at most one fixture paper → < MIN_PAPERS.
+    svc = StrategyFusion(backend=backend, corpus=corpus)
+    proposal = svc.propose(FusionBrief(asset_classes=["crypto"]))
+    assert proposal.status == "insufficient_corpus"
+    assert proposal.is_actionable is False
+    assert backend.user is None  # LLM never called when corpus too thin
+
+
+def test_empty_corpus_declines_without_llm(monkeypatch):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    backend = _MockBackend()
+    svc = StrategyFusion(backend=backend, corpus=[])
+    proposal = svc.propose(FusionBrief(asset_classes=["equities"]))
+    assert proposal.status == "insufficient_corpus"
+    assert backend.user is None
+
+
+def test_model_fusing_under_two_valid_papers_declines(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+
+    class _SinglePaperBackend:
+        model_id = "claude-sonnet-4-20250514"
+        served_model = "glm-4.7"
+
+        def complete(self, system, user):  # noqa: ARG002
+            ids = [json.loads(user)["candidate_papers"][0]["arxiv_id"]]
+            return json.dumps(
+                {
+                    "strategy_name": "x",
+                    "thesis": "x",
+                    "source_arxiv_ids": ids + ["hallucinated"],
+                    "fusion_reasoning": "x",
+                    "novelty_rationale": "x",
+                    "risk_notes": "x",
+                }
+            )
+
+    svc = StrategyFusion(backend=_SinglePaperBackend(), corpus=corpus)
+    proposal = svc.propose(FusionBrief(asset_classes=["equities", "rates"]))
+    assert proposal.status == "insufficient_corpus"
+    assert proposal.is_actionable is False
+
+
+# ── Offline fallback labelling ──────────────────────────────────
+
+
+def test_canned_fallback_is_labelled_not_model_reasoning(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    svc = StrategyFusion(backend=CannedBackend(), corpus=corpus)
+    proposal = svc.propose(
+        FusionBrief(asset_classes=["equities", "rates"], max_papers=3)
+    )
+    assert proposal.status == "ok"
+    # The model field must out itself as the fallback, never a real model.
+    assert proposal.model == "canned-fusion-fallback"
+    assert proposal.requested_model == "canned-fusion-fallback"
+    blob = (proposal.thesis + proposal.fusion_reasoning).lower()
+    assert "not model reasoning" in blob or "fallback" in blob
+
+
+def test_unparseable_model_output_declines(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+
+    class _Garbage:
+        model_id = "claude-sonnet-4-20250514"
+        served_model = "glm-4.7"
+
+        def complete(self, system, user):  # noqa: ARG002
+            return "this is not json at all"
+
+    svc = StrategyFusion(backend=_Garbage(), corpus=corpus)
+    proposal = svc.propose(FusionBrief(asset_classes=["equities", "rates"]))
+    assert proposal.status == "unparseable"
+    assert proposal.model == "glm-4.7"  # still records the served model
+    assert proposal.requested_model == "claude-sonnet-4-20250514"

--- a/docs/specs/strategy-fusion-spec.md
+++ b/docs/specs/strategy-fusion-spec.md
@@ -1,0 +1,275 @@
+# Strategy Fusion — Implementation Spec
+
+> **Audience:** Strategy engine owner (Dan) + backend engineers + reviewers ahead of standup
+> **Status:** Draft v1 — agent-generated for team review. Additive to, and deliberately
+> decoupled from, [`strategy_architect.py`](../../backend/archimedes/services/strategy_architect.py).
+> Builds on [`strategy-passport-spec.md`](strategy-passport-spec.md) (provenance) and the
+> Stream-A q-fin corpus manifest.
+> **Prerequisite reading:** [`../architectural-principles.md`](../architectural-principles.md)
+> for the verifiability philosophy; [`strategy-passport-spec.md`](strategy-passport-spec.md)
+> for the provenance primitive this extends.
+
+## Goal
+
+Shift strategy generation from **one strategy per paper** to **novel strategies fused across
+multiple papers**, steered by the user, grounded in the arXiv q-fin corpus, and recorded with
+honest provenance.
+
+The existing `StrategyArchitect` selects and weights *pre-curated* library strategies, each
+of which is grounded in a single paper. That is the right primitive for the verified library.
+It is not the right primitive for the thing that is actually the moat: **continuously
+generating cross-paper syntheses that no one has published yet**. This spec defines that
+second primitive — `strategy_fusion` — as a new, feature-flagged module that does not modify
+the architect or anything in the strategy-passport / reasoning-trace data flow.
+
+## Why this is a separate module, not an edit to the architect
+
+`strategy_architect.py` feeds the strategy-passport and reasoning-trace data flow, which is
+contract-review-grade (the `ReasoningTraceRegistry` contract is live — see
+[`../../CLAUDE.md`](../../CLAUDE.md) "When to ask before acting"). Changing it to do
+multi-paper fusion would be a load-bearing change to an audited path under hackathon time
+pressure. Instead:
+
+- **Additive.** A new `backend/archimedes/services/strategy_fusion.py`. Nothing imports it
+  yet; wiring it into a route is a later, separately reviewable step.
+- **Flagged.** `ARCHIMEDES_FUSION_ENABLED` (default OFF). Flag-off is a hard inert path:
+  no LLM call, no corpus read, returns a self-describing sentinel.
+- **Revertible.** Deleting the module and the spec fully reverts the change. The architect,
+  guardrail, construction-trace, and the on-chain flow are byte-for-byte untouched.
+- **Seam-faithful.** It mirrors the architect's `LLMBackend` Protocol seam, lazy `anthropic`
+  import, `extract_json`, frozen-dataclass artifact, and honest fallback labelling, so a
+  later integration is a small, familiar diff rather than a rewrite.
+
+## Per-paper → multi-paper fusion: the conceptual shift
+
+| | Architect (today) | Fusion (this spec) |
+| --- | --- | --- |
+| Input | curated `Strategy` library (1 paper each) | the raw arXiv q-fin corpus manifest |
+| Unit of output | a selection + weighting of existing strategies | a *new* strategy synthesized from ≥2 papers |
+| User input | free-text intent + risk profile | structured steering brief (asset classes, risk appetite, strategic direction, paper budget) |
+| Objective | fit intent + risk profile from validated alpha | **novelty** — a combination not yet in the literature |
+| Provenance | `model_id`, strategy ids referenced | N source `arxiv_id`s + fusion reasoning + the true model recorded honestly |
+| Validation state | library is curated / gated | proposal is a **hypothesis** — explicitly pre-backtest, pre-curation |
+
+The architect answers *"build me a portfolio from what we trust."* Fusion answers *"propose a
+strategy nobody has written down yet, from these papers, for what I want."* They are
+complementary; fusion output is a **candidate hypothesis** that must still pass the same
+selection-bias admission gate before it could ever be trusted.
+
+## User-steering inputs (`FusionBrief`)
+
+Fusion is **user-steered by construction** — it never free-runs over the whole corpus. The
+user (or an upstream agent) supplies a `FusionBrief`:
+
+| Field | Type | Role in candidate gating |
+| --- | --- | --- |
+| `asset_classes` | `list[str]` | Required-overlap filter. A paper is eligible only if its category/title/abstract evidences at least one requested class (substring + a small synonym map: `equities`, `rates`, `credit`, `fx`, `commodities`, `crypto`, `vol`, `macro`). Empty list = no asset filter (corpus-wide, still novelty-ranked). |
+| `risk_appetite` | `str` → `RiskProfile` | Maps to `RISK_PROFILE_PARAMS`. Passed into the prompt as the synthesis constraint envelope (USYC floor/ceiling, target vol, max DD). Does **not** hard-filter papers (a paper is a building block, not a risk-tagged strategy) — it shapes the synthesis, not the candidate set. |
+| `strategic_direction` | `str` | Free-text steer (e.g. *"regime-switching overlays on a carry core"*). Used for keyword-biased ranking of candidates and passed verbatim into the synthesis prompt. |
+| `max_papers` | `int` | Upper bound on fused papers. Clamped to `[2, FUSION_MAX_PAPERS]` (hard cap 6 — token + coherence budget). |
+| `min_papers` | (enforced, not user-settable below 2) | **Hard floor of 2.** A fusion of one paper is just extraction — that is the architect's job. If fewer than 2 eligible candidates survive filtering, fusion declines with a labelled, honest "insufficient corpus coverage" proposal rather than degrading to single-paper output. |
+
+### Deterministic pre-LLM candidate selection
+
+Candidate selection is **deterministic and pre-LLM** so the model never sees, and cannot
+silently widen, the corpus. Order of operations:
+
+1. Load the corpus manifest defensively (see below).
+2. **Asset-class filter.** Keep papers whose `primary_category`/`categories`/`title`/
+   `abstract` match a requested asset class via the synonym map. Skip if `asset_classes`
+   is empty.
+3. **Direction-biased score.** Rank surviving papers by: count of `strategic_direction`
+   keyword hits in title+abstract (primary), then a recency tiebreak on `published`
+   (newer first — alpha decay favours fresher results), then `arxiv_id` for total
+   determinism.
+4. **Take top `max_papers`.** If `< 2` remain → decline (honest sentinel, see below).
+5. Hand exactly that ordered set to the synthesis prompt. The model may fuse all of them
+   or a subset, but **may not introduce any `arxiv_id` not in the candidate set** —
+   anti-hallucination is enforced post-parse exactly as the architect drops unknown
+   `strategy_id`s.
+
+The selection is intentionally simple and explainable rather than embedding-based: for the
+hackathon, a reviewer can read the candidate list and verify the steer was honoured. A
+SPECTER2/embedding ranker (per `submodules/KnowledgeBase`) is a clean post-hackathon swap
+behind the same deterministic seam.
+
+## Novelty objective and the McLean–Pontiff rationale
+
+The optimisation target is **novelty of the cross-paper combination**, not backtested
+performance (which fusion deliberately does not compute — it produces a hypothesis).
+
+**Why novelty is the objective, not historical Sharpe:** McLean & Pontiff (2016, *Journal of
+Finance*, "Does Academic Research Destroy Stock Return Predictability?") show that
+post-publication, predictor returns decay ~58% — roughly 26% from in-sample/statistical bias
+and ~32% from genuine arbitrage as the signal becomes known and traded. The practical
+corollary for an agent whose corpus *is* the published literature: **the alpha in any single
+published strategy is, by construction, the most-decayed alpha available.** The durable edge
+is not re-implementing a known predictor — it is producing *combinations the literature has
+not yet published and therefore the market has not yet arbitraged*. Novelty is not a
+nice-to-have; under the McLean–Pontiff result it is the only part of the objective that has
+not already decayed. This is why fusion's objective function is novelty and its provenance
+records *which papers were combined* — the combination is the claim.
+
+**How novelty is operationalised (v1):** the synthesis prompt instructs the model to (a)
+state the specific mechanism each source paper contributes, (b) articulate why the
+*combination* is non-obvious relative to each paper alone, and (c) self-rate a
+`novelty_rationale` (prose, not a fabricated score — consistent with the project's
+no-invented-numbers rule; a calibrated novelty metric is a backtest/embedding-layer problem,
+explicitly deferred). The deterministic fallback labels itself as non-novel and non-model.
+
+## Fusion provenance
+
+A `FusionProposal` carries provenance designed to be independently checkable:
+
+- `source_arxiv_ids: list[str]` — the N (≥2) papers fused. The verifiable core of the
+  claim: anyone can pull these arXiv papers and judge whether the synthesis is faithful
+  and the combination is genuinely novel.
+- `fusion_reasoning: str` — the model's cross-paper synthesis: what each paper contributes
+  and why the combination is non-obvious. Honest about being pre-backtest.
+- `novelty_rationale: str` — the model's argument for why this combination is not already
+  in the literature. Prose; no fabricated novelty score.
+- `model: str` — **the true model, recorded honestly.** This is the field of record for
+  provenance.
+- `requested_model: str` — the model string we *configured/requested*, kept separately.
+
+### The true-model honesty rule (load-bearing)
+
+Our backend is routed through a GLM-backed, Anthropic-compatible endpoint. The Anthropic
+SDK's `messages.create(model=...)` is given our *configured* model string, but the response
+object's `response.model` returns the **real model that actually served the request** (e.g.
+`glm-4.7`). Recording the configured string as provenance would be a quiet lie in an
+audit trail whose entire selling point is honesty.
+
+Therefore:
+
+- `FusionProposal.model` = `response.model` (the served model). This is what flows into any
+  future provenance/passport field for a fusion-derived strategy. The `ClaudeBackend`
+  exposes a `served_model` populated from the last response; `model_id` continues to return
+  the *configured* string (so the seam stays drop-in compatible with the architect, which
+  reads `model_id`).
+- `FusionProposal.requested_model` = the configured string (`DEFAULT_MODEL` /
+  constructor override). Kept for reproducibility — "what we asked for" vs "what answered".
+- Offline fallback: `model = requested_model = "canned-fusion-fallback"`, and the proposal
+  text states plainly it is not model reasoning. It can never masquerade as a real fusion.
+
+This mirrors, and is stricter than, the architect's `model_id` provenance: the architect
+predates the GLM routing nuance; fusion records the served model because a fused-strategy
+hypothesis is a stronger claim and deserves the more honest field. If/when fusion is wired
+into the passport flow, **`response.model` is the value that must be persisted** — this is
+called out explicitly so the integration does not regress to the configured string.
+
+## Corpus manifest contract (read-only, defensive)
+
+Fusion reads the Stream-A corpus manifest. It is **read-only** and **not a hard runtime
+dependency**: a missing/empty/corrupt file degrades to an honest "no corpus available"
+sentinel, never an exception.
+
+### Frozen schema (one JSON object per line, `data/corpus/manifest.jsonl`)
+
+```json
+{"arxiv_id":"2401.12345","title":"...","authors":["..."],
+ "primary_category":"q-fin.PM","categories":["q-fin.PM"],
+ "published":"2024-01-22","updated":"2024-02-01","abstract":"...",
+ "pdf_url":"...","pdf_sha256":"...","pdf_path":"data/corpus/pdfs/2401.12345.pdf",
+ "text_path":"data/corpus/text/2401.12345.txt","fetched_at":"2026-05-16T...Z"}
+```
+
+### Loader rules
+
+- **Path resolution** (mirrors `strategy_provider.default_provider()` /
+  `ARCHIMEDES_STRATEGIES_DIR`):
+  1. `ARCHIMEDES_CORPUS_MANIFEST` env var — explicit override (deployment / tests).
+  2. First existing candidate among known host + container-plausible layouts
+     (`<repo>/data/corpus/manifest.jsonl`, `/app/data/corpus/manifest.jsonl`,
+     `/data/corpus/manifest.jsonl`).
+- **Defensive line-skipping.** Each line is parsed independently; a line that is blank,
+  not JSON, or missing the only two fields fusion strictly needs (`arxiv_id`, and at least
+  one of `title`/`abstract`) is logged at debug and skipped. One bad line never aborts the
+  load (same posture as `arxiv_pipeline.extract_text`'s per-page tolerance).
+- **No file → empty corpus → honest decline.** Absent/empty manifest yields zero
+  candidates, which (being `< 2`) produces a labelled "insufficient corpus coverage"
+  proposal. No crash, no fabricated papers.
+- Extra/unknown fields are ignored (forward-compatible with manifest schema growth).
+
+## The feature flag
+
+`ARCHIMEDES_FUSION_ENABLED`, default **OFF**. Truthy = `{"1","true","yes","on"}`
+case-insensitively (the parsing convention shared with the rest of the env surface).
+Mechanism mirrors `ARCHIMEDES_STRATEGIES_DIR`: a plain `os.getenv` read, no central
+settings module (there is none in this codebase — env overrides are the established
+pattern). Flag-off behaviour is a **hard inert path**:
+
+- No `anthropic` import, no LLM call.
+- No manifest read.
+- Returns a frozen sentinel `FusionProposal` (`status="disabled"`, empty
+  `source_arxiv_ids`, self-describing reasoning string). Callers can ship it through a UI
+  unchanged and it reads as "feature disabled", never as an empty/failed strategy.
+
+## Output artifact
+
+```text
+FusionProposal (frozen dataclass)
+  status: "ok" | "disabled" | "insufficient_corpus" | "unparseable"
+  brief: FusionBrief                 # echoed back for traceability
+  strategy_name: str                 # model-proposed working name
+  thesis: str                        # the fused strategy thesis, plain language
+  source_arxiv_ids: list[str]        # ≥2 on status="ok"; provenance core
+  fusion_reasoning: str              # per-paper contribution + why non-obvious
+  novelty_rationale: str             # why not already in the literature
+  risk_notes: str                    # incl. the pre-backtest / selection-bias caveat
+  model: str                         # response.model — TRUE served model (field of record)
+  requested_model: str               # configured/requested model
+  created_at: datetime
+```
+
+`status` is explicit so a caller never has to infer failure from emptiness — consistent
+with the architect returning an empty-but-well-formed proposal rather than raising.
+
+## Honesty rules (carried through from the architect / arxiv pipeline)
+
+- Never invent Sharpe/CAGR/returns. Fusion output is a **hypothesis**; the prompt forbids
+  performance numbers and the proposal states empirical validation is pending.
+- The fallback is explicitly labelled as a non-model, non-novel placeholder.
+- The recorded model is the *served* model (`response.model`), never the configured string.
+- Anti-hallucination: any `arxiv_id` the model emits that is not in the deterministically
+  selected candidate set is dropped post-parse (architect parity).
+- A fusion proposal is never auto-promoted: it is a CANDIDATE-grade hypothesis that must
+  still pass the selection-bias gate (DSR / PBO / walk-forward OOS / look-ahead) before it
+  could enter the verified library.
+
+## Forward-looking: on-chain, falsifiable novelty (explicitly future)
+
+This section is **vision, not v1 scope**. v1 is grounded entirely in the corpus and stops
+at an in-memory `FusionProposal`. The eventual shape:
+
+- **Anchor the fusion claim.** Hash the canonical `FusionProposal` (the
+  `strategy-passport-spec.md` canonicalisation rule) and anchor it via the live
+  `ReasoningTraceRegistry`, exactly as construction traces are anchored — *without
+  modifying that flow now*. The anchor would bind *"this novel combination of these N
+  papers was proposed at time T by this served model"*.
+- **IPFS-pin the full reasoning.** The full fusion reasoning + the resolved source paper
+  metadata pinned to IPFS, with the CID in the on-chain anchor — a public, permanent,
+  **falsifiable** novelty claim: anyone can fetch the papers, read the synthesis, and
+  argue the combination was in fact already published. Being falsifiable is the point;
+  it is the on-chain analogue of the McLean–Pontiff discipline.
+- **Novelty decay tracking.** Once anchored, a fusion's novelty is itself a decaying
+  quantity (its own publication is the decay trigger). A future loop re-scores anchored
+  fusions against newer corpus snapshots and rotates capital away from syntheses the
+  literature has caught up to — operationalising "novelty is the moat" as a maintained
+  invariant, not a one-shot.
+
+None of this is built here. It is documented so the v1 dataclass and provenance fields are
+shaped to make the future hop a small, additive, separately-reviewable step — the same
+discipline by which this module is itself additive and flagged.
+
+## Acceptance criteria for v1 (this PR)
+
+- [x] Spec written, prose-first, design rationale explicit.
+- [x] `strategy_fusion.py` — flag-gated; flag-off is fully inert (no LLM, no manifest read).
+- [x] `FusionBrief` + `FusionProposal` dataclasses; `FusionProposal` frozen.
+- [x] Defensive manifest loader; `ARCHIMEDES_CORPUS_MANIFEST` override; no hard file dep.
+- [x] Deterministic pre-LLM candidate selection honouring all steering inputs; ≥2 floor.
+- [x] Backend seam mirrors the architect (lazy `anthropic`, `extract_json`, fallback).
+- [x] Records `response.model` as `model`; keeps `requested_model` separately.
+- [x] Mocked-client tests; no network; self-contained fixture manifest.
+- [ ] (Future, not this PR) Route wiring, on-chain anchor, IPFS pin, novelty-decay loop.


### PR DESCRIPTION
## Summary

Introduces the **strategy-fusion** primitive: a new, feature-flagged module that
synthesizes a *novel* strategy hypothesis by fusing **≥2 arXiv q-fin papers**,
**user-steered** (asset classes, risk appetite, strategic direction, paper budget),
optimizing for **novelty** rather than re-stating single-paper alpha.

Product rationale: per McLean & Pontiff (2016), published single-paper alpha decays
post-publication — the durable edge is cross-paper combinations the literature has
not yet published. The corpus is the grounding (Stream-A's 200-paper q-fin manifest).

### Files

- `docs/specs/strategy-fusion-spec.md` — prose-first design: per-paper → multi-paper
  shift; user-steering inputs and how they gate candidate selection; novelty objective
  + McLean-Pontiff rationale; fusion provenance with the true-served-model honesty
  rule; defensive corpus-manifest contract; forward-looking on-chain/IPFS
  falsifiable-novelty vision (explicitly future).
- `backend/archimedes/services/strategy_fusion.py` — `FusionBrief` + frozen
  `FusionProposal`; defensive manifest loader; deterministic pre-LLM ≥2-paper
  candidate selection; architect-mirrored backend seam; records `response.model`.
- `backend/tests/test_strategy_fusion.py` — 27 tests, mocked client, no network,
  self-contained fixture manifest.

## Why additive / flagged (strategy_architect untouched)

`strategy_architect.py` and the strategy-passport / reasoning-trace data flow are
contract-review-grade (the live `ReasoningTraceRegistry`). Per the owner-decided HARD
constraint, **nothing in that flow is modified**. Fusion is:

- **Additive** — a new module; nothing imports it yet (route-wiring is a later,
  separately reviewable step).
- **Flagged** — `ARCHIMEDES_FUSION_ENABLED`, default **OFF**; truthy `1/true/yes/on`
  case-insensitive (mirrors the `ARCHIMEDES_STRATEGIES_DIR` env mechanism). Flag-off
  is a hard inert path: no `anthropic` import, no manifest read, returns a
  self-describing sentinel `FusionProposal`.
- **Revertible** — deleting the module + spec fully reverts. `git status` confirms
  only 3 new files; `strategy_architect.py` / `construction_trace.py` /
  `models/trace.py` are byte-for-byte unchanged.
- **Seam-faithful** — mirrors the architect's `LLMBackend` Protocol, lazy `anthropic`
  import, `extract_json`, frozen-dataclass artifact, honest-fallback labelling.

### True-model honesty

The deployment is GLM-routed: `messages.create(model=...)` gets the configured
string, but `response.model` returns the model that actually served (e.g.
`glm-4.7`). `FusionProposal.model` records `response.model` (the provenance field of
record); `requested_model` keeps the configured string separately. The spec calls
this out so a future passport integration persists the served model, not the
configured one.

## Test status

- `pytest backend/tests/test_strategy_fusion.py` — **27/27 pass**, no network
  (mocked/canned backend only).
- Full backend suite — **48/48 pass** (21 pre-existing + 27 new), confirming the
  architect/trace flow is undisturbed.
- `ruff check` on both new files — **clean**.
- Sanity-checked the loader against Stream-A's real 200-paper manifest (all 200
  parse; steering selects correctly) — but the module has **no hard runtime
  dependency** on that file and tests use a self-contained fixture.

## Open design questions / deviations

- No backend `pyproject`/ruff config exists in the repo; ran `ruff check` with
  defaults (matches how the existing architect/pipeline files lint clean).
- Candidate selection is a deliberately simple, reviewable substring+synonym ranker
  (not embeddings) for the hackathon — a SPECTER2 swap is noted in the spec behind
  the same deterministic seam.
- Not route-wired by design (the additive/flagged constraint). Wiring fusion into an
  API route + the on-chain anchor/IPFS pin is documented as explicitly future, not
  this PR.

agent-generated for team review ahead of standup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)