### PR TITLE
[backtest] Engine→passport bridge — kill stub_* placeholders (Daniel's work, consolidated)

### DIFF
--- a/backend/archimedes/api/risk_routes.py
+++ b/backend/archimedes/api/risk_routes.py
@@ -1,6 +1,6 @@
 """Risk analysis API endpoints.
 
-Dedicated risk router that aggregates strategy backtest stubs and
+Dedicated risk router that aggregates persisted strategy backtests and
 on-chain vault holdings into portfolio-level risk summaries.
 """
 
@@ -105,7 +105,7 @@ async def get_risk_profiles():
 
 @risk_router.get("/portfolio", response_model=PortfolioRiskResponse)
 async def get_portfolio_risk():
-    """Aggregate portfolio-level risk metrics from strategy backtest stubs.
+    """Aggregate portfolio-level risk metrics from persisted backtests.
 
     Computes:
       - Avg Sharpe, worst max drawdown, avg correlation to SPY, best Calmar
@@ -124,11 +124,13 @@ async def get_portfolio_risk():
     vol_vals: list[float] = []
 
     for s in strategies:
-        sharpe = s.stub_sharpe
-        max_dd = s.stub_max_dd
-        cagr = s.stub_cagr
-        calmar = s.stub_calmar
-        corr = s.stub_corr_spy
+        bt = _strategy_provider.get_backtest_result(s.id)
+
+        sharpe = bt.sharpe_ratio if bt else None
+        max_dd = bt.max_drawdown if bt else None
+        cagr = bt.cagr if bt else None
+        calmar = bt.calmar_ratio if bt else None
+        corr = bt.correlation_to_spy if bt else None
 
         # Derive annualized volatility: σ ≈ |CAGR| / Sharpe
         # (rough approximation from Sharpe = (r - rf) / σ, assuming rf ≈ 0)
@@ -156,7 +158,7 @@ async def get_portfolio_risk():
                 volatility=volatility,
                 max_drawdown=max_dd,
                 cagr=cagr,
-                win_rate=s.stub_win_rate,
+                win_rate=bt.win_rate if bt else None,
                 calmar_ratio=calmar,
                 correlation_to_spy=corr,
                 risk_level=_derive_risk_level(sharpe),

--- a/backend/archimedes/api/routes.py
+++ b/backend/archimedes/api/routes.py
@@ -81,14 +81,12 @@ _architect = default_architect()
 
 
 def _to_strategy_response(s: Strategy) -> StrategyResponse:
-    """Map the shared Strategy dataclass to the frontend response shape.
+    """Map Strategy + persisted BacktestResult to API schema.
 
-    Backtest fields sourced from BACKTEST_* stub constants in strategy files
-    (is_backtest_placeholder=True) until Önder's IBacktestEvaluator runs and
-    populates a real BacktestResult. Stub values are clearly labelled so the UI
-    can render them with an honest "estimate" disclaimer.
+    Source of truth for backtest metrics is DB table `backtest_results`.
+    If no row exists yet for a strategy, metrics surface as None.
     """
-    has_stubs = s.stub_sharpe is not None
+    bt = _strategy_provider.get_backtest_result(s.id)
     return StrategyResponse(
         id=s.id,
         paper_arxiv_id=s.paper_arxiv_id,
@@ -111,15 +109,20 @@ def _to_strategy_response(s: Strategy) -> StrategyResponse:
         curator_note=s.curator_note,
         on_chain_registration_tx=s.on_chain_registration_tx,
         # Paper claims (for delta display)
-        paper_claimed_sharpe=s.paper_claimed_sharpe,
-        # Backtest (stubs from strategy file; None when IBacktestEvaluator has not run)
-        sharpe_ratio=s.stub_sharpe,
-        cagr=s.stub_cagr,
-        max_drawdown=s.stub_max_dd,
-        win_rate=s.stub_win_rate,
-        calmar_ratio=s.stub_calmar,
-        correlation_to_spy=s.stub_corr_spy,
-        is_backtest_placeholder=has_stubs,
+        paper_claimed_sharpe=bt.paper_claimed_sharpe if bt else s.paper_claimed_sharpe,
+        # Backtest (real DB row or None fallback)
+        sharpe_ratio=bt.sharpe_ratio if bt else None,
+        sortino_ratio=bt.sortino_ratio if bt else None,
+        cagr=bt.cagr if bt else None,
+        max_drawdown=bt.max_drawdown if bt else None,
+        win_rate=bt.win_rate if bt else None,
+        total_trades=bt.total_trades if bt else None,
+        calmar_ratio=bt.calmar_ratio if bt else None,
+        correlation_to_spy=bt.correlation_to_spy if bt else None,
+        deflated_sharpe_ratio=bt.deflated_sharpe_ratio if bt else None,
+        pbo_score=bt.pbo_score if bt else None,
+        out_of_sample_sharpe=bt.out_of_sample_sharpe if bt else None,
+        is_backtest_placeholder=False,
     )
 
 

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -175,8 +175,7 @@ class StrategyResponse(BaseModel):
     on_chain_registration_tx: str | None = None
 
     # Backtest results (if evaluated; None = not yet run)
-    # is_backtest_placeholder=True means values come from BACKTEST_* stubs in strategy files,
-    # not from a real BacktestResult — surfaced so the UI can label them honestly.
+    # Values come from persisted backtest_results rows (analytics-engine output).
     sharpe_ratio: float | None = None
     sortino_ratio: float | None = None
     max_drawdown: float | None = None

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -87,30 +87,36 @@ async def evaluate_rigor_gate():
     if not strategies:
         return RigorGateResponse(strategies=[], total=0, passing=0, failing=0)
 
-    # Collect daily returns from strategy backtest stubs
-    # In production, these come from the analytics-engine BacktestResult.
-    # For the hackathon demo, we generate synthetic returns from the stub metrics.
-    returns_by_strategy: dict[str, list[float]] = {}
+    # ── Collect real daily returns from persisted backtest results ──
+    from archimedes.db import get_session, init_db
+    from archimedes.services.backtest_repository import (
+        get_all_daily_returns,
+        update_rigor_gate_fields,
+    )
+
+    init_db()
+
+    strategy_ids = [s.id for s in strategies]
     strategy_code_map: dict[str, str | None] = {}
 
-    for s in strategies:
-        # Generate synthetic daily returns from stub metrics
-        # This is a placeholder until the full analytics-engine integration
-        if s.stub_sharpe is not None and s.strategy_code_path:
-            returns = _synthetic_returns_from_stub(
-                sharpe=s.stub_sharpe,
-                cagr=s.stub_cagr,
-                max_dd=s.stub_max_dd,
-            )
-            returns_by_strategy[s.id] = returns
+    # Load real returns from DB
+    with get_session() as session:
+        returns_by_strategy = get_all_daily_returns(session, strategy_ids)
 
-            # Load strategy source code for look-ahead audit
-            code = _load_strategy_code(s.strategy_code_path)
-            strategy_code_map[s.id] = code
-        else:
-            # No stub data — can't evaluate
-            returns_by_strategy[s.id] = []
-            strategy_code_map[s.id] = None
+    for s in strategies:
+        code = _load_strategy_code(s.strategy_code_path) if s.strategy_code_path else None
+        strategy_code_map[s.id] = code
+
+    # Fallback: if no persisted data, try stub-based synthetic returns
+    # (graceful degradation for strategies not yet backtested)
+    for s in strategies:
+        if s.id not in returns_by_strategy or len(returns_by_strategy[s.id]) < 10:
+            if s.stub_sharpe is not None:
+                returns_by_strategy[s.id] = _synthetic_returns_from_stub(
+                    sharpe=s.stub_sharpe,
+                    cagr=s.stub_cagr,
+                    max_dd=s.stub_max_dd,
+                )
 
     # Compute PBO across all strategies that have returns
     valid_returns = {k: v for k, v in returns_by_strategy.items() if len(v) >= 10}
@@ -137,15 +143,39 @@ async def evaluate_rigor_gate():
             ))
             continue
 
+        # Use real in-sample Sharpe from persisted data when available
+        in_sample_sharpe = s.stub_sharpe
+        with get_session() as session:
+            from archimedes.services.backtest_repository import (
+                latest_backtests_by_strategy,
+            )
+            bt_map = latest_backtests_by_strategy(session, [s.id])
+            if s.id in bt_map:
+                in_sample_sharpe = bt_map[s.id].sharpe_ratio
+
         gate_result = run_rigor_gate(
             strategy_id=s.id,
             daily_returns=daily_returns,
             num_trials=num_trials,
             pbo_scores=pbo_scores,
             strategy_code=strategy_code_map.get(s.id),
-            in_sample_sharpe=s.stub_sharpe,
+            in_sample_sharpe=in_sample_sharpe,
             paper_claimed_sharpe=s.paper_claimed_sharpe,
         )
+
+        # Persist rigor gate results to DB
+        with get_session() as session:
+            update_rigor_gate_fields(
+                session,
+                s.id,
+                deflated_sharpe_ratio=gate_result.deflated_sharpe,
+                dsr_p_value=gate_result.dsr_p_value,
+                num_trials_in_selection=num_trials,
+                pbo_score=gate_result.pbo_score,
+                out_of_sample_sharpe=gate_result.oos_sharpe,
+                look_ahead_audit_passed=gate_result.look_ahead_passed,
+            )
+            session.commit()
 
         details = gate_result.gate_details
         results.append(StrategyRigorResult(
@@ -182,13 +212,14 @@ async def evaluate_strategy_rigor(strategy_id: str):
         from fastapi import HTTPException
         raise HTTPException(status_code=404, detail="Strategy not found")
 
-    # Reuse the full gate endpoint with single strategy
-    # (the per-strategy computation is the same)
+    # Run the full gate and extract the matching strategy result
+    full_response = await evaluate_rigor_gate()
+    for result in full_response.strategies:
+        if result.strategy_id == strategy_id:
+            return result
+
     from fastapi import HTTPException
-    raise HTTPException(
-        status_code=501,
-        detail="Use GET /api/selection-bias/gate for full library evaluation",
-    )
+    raise HTTPException(status_code=404, detail="Strategy not found in gate results")
 
 
 @selection_bias_router.post("/pbo", response_model=PBOResponse)

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -13,6 +13,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from archimedes.models.chat import Base
+from archimedes.models.backtest_store import BacktestResultRecord  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -47,6 +47,51 @@ app.add_middleware(
 # Initialize database (creates chat tables if needed)
 init_db()
 
+
+@app.on_event("startup")
+async def _startup_populate_rigor_gate():
+    """On first startup, compute and persist selection-bias rigor gate fields.
+
+    Idempotent: only populates strategies that don't yet have DSR/PBO values.
+    Skips entirely if the backtest_results table is empty.
+    """
+    import logging
+    _logger = logging.getLogger("archimedes.startup")
+    try:
+        from archimedes.services.strategy_provider import default_provider
+        from archimedes.db import get_session
+        from archimedes.models.backtest_store import BacktestResultRecord
+
+        provider = default_provider()
+        strategies = provider.list_strategies()
+        if not strategies:
+            return
+
+        strategy_ids = [s.id for s in strategies]
+        with get_session() as session:
+            rows = session.query(BacktestResultRecord).filter(
+                BacktestResultRecord.strategy_id.in_(strategy_ids)
+            ).all()
+
+            # Check if any need rigor gate computation
+            needs_rigor = [r for r in rows if r.deflated_sharpe_ratio is None]
+            if not needs_rigor:
+                _logger.info("startup: all %d backtest rows have rigor gate fields", len(rows))
+                return
+
+        _logger.info("startup: computing rigor gate for %d strategies...", len(needs_rigor))
+
+        # Call the rigor gate endpoint logic (triggers full computation + persist)
+        from archimedes.api.selection_bias_routes import evaluate_rigor_gate
+        import asyncio
+        result = await evaluate_rigor_gate()
+        _logger.info(
+            "startup: rigor gate computed — %d/%d passing",
+            result.passing, result.total,
+        )
+    except Exception as exc:
+        _logger.warning("startup: rigor gate population failed (non-fatal): %s", exc)
+
 # Wire all routers
 app.include_router(assets_router)
 app.include_router(vaults_router)

--- a/backend/archimedes/models/backtest_store.py
+++ b/backend/archimedes/models/backtest_store.py
@@ -1,0 +1,165 @@
+"""Persistent storage for engine-produced backtest results."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from archimedes.models.backtest import BacktestResult
+from archimedes.models.chat import Base
+
+
+class BacktestResultRecord(Base):
+    """DB row for a strategy backtest snapshot."""
+
+    __tablename__ = "backtest_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    strategy_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    run_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    operation: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+    sharpe_ratio: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    sortino_ratio: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    max_drawdown: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    cagr: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    calmar_ratio: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    win_rate: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    profit_factor: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    total_trades: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    avg_holding_period_days: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    correlation_to_spy: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    correlation_to_btc: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    equity_curve_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    monthly_returns_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+
+    backtest_start: Mapped[date | None] = mapped_column(Date, nullable=True)
+    backtest_end: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    paper_claimed_sharpe: Mapped[float | None] = mapped_column(Float, nullable=True)
+    paper_claimed_cagr: Mapped[float | None] = mapped_column(Float, nullable=True)
+    paper_claimed_max_dd: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    deflated_sharpe_ratio: Mapped[float | None] = mapped_column(Float, nullable=True)
+    dsr_p_value: Mapped[float | None] = mapped_column(Float, nullable=True)
+    num_trials_in_selection: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    pbo_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    out_of_sample_sharpe: Mapped[float | None] = mapped_column(Float, nullable=True)
+    walk_forward_train_fraction: Mapped[float] = mapped_column(Float, nullable=False, default=0.70)
+    look_ahead_audit_passed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    backtest_engine: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    backtest_code_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    transaction_cost_bps: Mapped[int] = mapped_column(Integer, nullable=False, default=10)
+
+    artifact_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("strategy_id", "content_hash", name="uq_backtest_strategy_content"),
+        Index("ix_backtest_strategy_created", "strategy_id", "created_at"),
+    )
+
+    def to_backtest_result(self) -> BacktestResult:
+        return BacktestResult(
+            strategy_id=self.strategy_id,
+            sharpe_ratio=self.sharpe_ratio,
+            sortino_ratio=self.sortino_ratio,
+            max_drawdown=self.max_drawdown,
+            cagr=self.cagr,
+            calmar_ratio=self.calmar_ratio,
+            win_rate=self.win_rate,
+            profit_factor=self.profit_factor,
+            total_trades=self.total_trades,
+            avg_holding_period_days=self.avg_holding_period_days,
+            correlation_to_spy=self.correlation_to_spy,
+            correlation_to_btc=self.correlation_to_btc,
+            equity_curve=json.loads(self.equity_curve_json or "[]"),
+            monthly_returns=json.loads(self.monthly_returns_json or "[]"),
+            backtest_start=self.backtest_start,
+            backtest_end=self.backtest_end,
+            paper_claimed_sharpe=self.paper_claimed_sharpe,
+            paper_claimed_cagr=self.paper_claimed_cagr,
+            paper_claimed_max_dd=self.paper_claimed_max_dd,
+            deflated_sharpe_ratio=self.deflated_sharpe_ratio,
+            dsr_p_value=self.dsr_p_value,
+            num_trials_in_selection=self.num_trials_in_selection,
+            pbo_score=self.pbo_score,
+            out_of_sample_sharpe=self.out_of_sample_sharpe,
+            walk_forward_train_fraction=self.walk_forward_train_fraction,
+            look_ahead_audit_passed=self.look_ahead_audit_passed,
+            backtest_engine=self.backtest_engine,
+            backtest_code_hash=self.backtest_code_hash,
+            transaction_cost_bps=self.transaction_cost_bps,
+        )
+
+    @classmethod
+    def from_backtest_result(
+        cls,
+        *,
+        strategy_id: str,
+        content_hash: str,
+        result: BacktestResult,
+        run_id: str | None = None,
+        operation: str | None = None,
+        artifact_json: str | None = None,
+    ) -> "BacktestResultRecord":
+        return cls(
+            strategy_id=strategy_id,
+            content_hash=content_hash,
+            run_id=run_id,
+            operation=operation,
+            sharpe_ratio=result.sharpe_ratio,
+            sortino_ratio=result.sortino_ratio,
+            max_drawdown=result.max_drawdown,
+            cagr=result.cagr,
+            calmar_ratio=result.calmar_ratio,
+            win_rate=result.win_rate,
+            profit_factor=result.profit_factor,
+            total_trades=result.total_trades,
+            avg_holding_period_days=result.avg_holding_period_days,
+            correlation_to_spy=result.correlation_to_spy,
+            correlation_to_btc=result.correlation_to_btc,
+            equity_curve_json=json.dumps(result.equity_curve),
+            monthly_returns_json=json.dumps(result.monthly_returns),
+            backtest_start=result.backtest_start,
+            backtest_end=result.backtest_end,
+            paper_claimed_sharpe=result.paper_claimed_sharpe,
+            paper_claimed_cagr=result.paper_claimed_cagr,
+            paper_claimed_max_dd=result.paper_claimed_max_dd,
+            deflated_sharpe_ratio=result.deflated_sharpe_ratio,
+            dsr_p_value=result.dsr_p_value,
+            num_trials_in_selection=result.num_trials_in_selection,
+            pbo_score=result.pbo_score,
+            out_of_sample_sharpe=result.out_of_sample_sharpe,
+            walk_forward_train_fraction=result.walk_forward_train_fraction,
+            look_ahead_audit_passed=result.look_ahead_audit_passed,
+            backtest_engine=result.backtest_engine,
+            backtest_code_hash=result.backtest_code_hash,
+            transaction_cost_bps=result.transaction_cost_bps,
+            artifact_json=artifact_json,
+        )

--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -1,0 +1,180 @@
+"""Run analytics-engine backtests and persist latest metrics.
+
+Usage:
+  cd backend
+  python -m archimedes.scripts.run_backtests
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from archimedes.db import get_session, init_db
+from archimedes.services.backtest_mapper import (
+    AnalyticsArtifactModel,
+    canonical_artifact_hash,
+    map_artifact_to_backtest_result,
+)
+from archimedes.services.backtest_repository import insert_backtest_if_missing
+from archimedes.services.strategy_provider import default_provider
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    operations: list[str]
+    start: str
+    end: str
+    initial_cash: float
+    tx_cost_bps: int
+    slippage_bps: int
+
+
+def _repo_root() -> Path:
+    # .../backend/archimedes/scripts/run_backtests.py -> repo root
+    return Path(__file__).resolve().parents[3]
+
+
+def _analytics_strategy_dir(repo_root: Path) -> Path:
+    return repo_root / "analytics-engine" / "strategies"
+
+
+def _artifact_dir(repo_root: Path) -> Path:
+    return repo_root / "analytics-engine" / "artifacts"
+
+
+def _ensure_analytics_import(repo_root: Path) -> None:
+    analytics_src = repo_root / "analytics-engine" / "src"
+    src_text = str(analytics_src)
+    if src_text not in sys.path:
+        sys.path.insert(0, src_text)
+
+
+def _load_run_command(repo_root: Path):
+    _ensure_analytics_import(repo_root)
+    from archimedes_analytics_engine.cli import run_command
+
+    return run_command
+
+
+def _read_config() -> RunConfig:
+    operations = [
+        op.strip().upper()
+        for op in os.getenv("BACKTEST_OPERATIONS", "SPY").split(",")
+        if op.strip()
+    ]
+    start = os.getenv("BACKTEST_START", "2018-01-01")
+    end = os.getenv("BACKTEST_END", datetime.now(UTC).date().isoformat())
+    initial_cash = float(os.getenv("BACKTEST_INITIAL_CASH", "100000"))
+    tx_cost_bps = int(os.getenv("BACKTEST_TX_COST_BPS", "10"))
+    slippage_bps = int(os.getenv("BACKTEST_SLIPPAGE_BPS", "5"))
+    return RunConfig(
+        operations=operations,
+        start=start,
+        end=end,
+        initial_cash=initial_cash,
+        tx_cost_bps=tx_cost_bps,
+        slippage_bps=slippage_bps,
+    )
+
+
+def run_backtests() -> dict[str, int]:
+    repo_root = _repo_root()
+    strategy_dir = _analytics_strategy_dir(repo_root)
+    artifact_dir = _artifact_dir(repo_root)
+    cfg = _read_config()
+
+    run_command = _load_run_command(repo_root)
+
+    provider = default_provider(repo_root=repo_root)
+    strategy_by_path = {
+        Path(s.strategy_code_path).resolve(): s
+        for s in provider.list_strategies()
+        if s.strategy_code_path
+    }
+
+    init_db()
+
+    inserted = 0
+    skipped = 0
+    failed = 0
+
+    for strategy_file in sorted(strategy_dir.glob("*.py")):
+        if strategy_file.name.startswith("_"):
+            continue
+
+        strategy = strategy_by_path.get(strategy_file.resolve())
+        if strategy is None:
+            logger.warning("skip %s: no strategy_id from provider", strategy_file)
+            failed += 1
+            continue
+
+        try:
+            out = run_command(
+                operations=cfg.operations,
+                start=cfg.start,
+                end=cfg.end,
+                initial_cash=cfg.initial_cash,
+                tx_cost_bps=cfg.tx_cost_bps,
+                slippage_bps=cfg.slippage_bps,
+                artifact_dir=artifact_dir,
+                strategy_path=strategy_file,
+            )
+
+            artifact_path = Path(str(out["artifact_path"]))
+            artifact_json = artifact_path.read_text(encoding="utf-8")
+            artifact_payload = json.loads(artifact_json)
+            artifact = AnalyticsArtifactModel.model_validate(artifact_payload)
+            mapped, selected_operation = map_artifact_to_backtest_result(
+                artifact,
+                strategy_id=strategy.id,
+            )
+            content_hash = canonical_artifact_hash(artifact_payload)
+
+            with get_session() as session:
+                _, was_inserted = insert_backtest_if_missing(
+                    session,
+                    strategy_id=strategy.id,
+                    content_hash=content_hash,
+                    result=mapped,
+                    run_id=artifact.run_id,
+                    operation=selected_operation,
+                    artifact_json=artifact_json,
+                )
+                session.commit()
+
+            if was_inserted:
+                inserted += 1
+                logger.info("inserted backtest row: %s (%s)", strategy.paper_title, strategy.id)
+            else:
+                skipped += 1
+                logger.info("skip duplicate content hash: %s (%s)", strategy.paper_title, strategy.id)
+
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            logger.exception("backtest failed for %s: %s", strategy_file, exc)
+
+    summary = {
+        "inserted": inserted,
+        "skipped": skipped,
+        "failed": failed,
+    }
+    logger.info("backtest run summary: %s", summary)
+    return summary
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    summary = run_backtests()
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/archimedes/services/backtest_mapper.py
+++ b/backend/archimedes/services/backtest_mapper.py
@@ -1,0 +1,188 @@
+"""Map analytics-engine artifacts into backend BacktestResult models."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from archimedes.models.backtest import BacktestResult
+
+
+def _safe_iso_to_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    text = value.strip()
+    try:
+        if "T" in text:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).date()
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _f(value: float | int | None, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
+class EngineMetricsModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    sharpe_ratio: float | None = None
+    sortino_ratio: float | None = None
+    calmar_ratio: float | None = None
+    max_drawdown_pct: float | None = None
+    cagr: float | None = None
+
+    win_rate: float | None = None
+    profit_factor: float | None = None
+    total_trades: int = 0
+    avg_holding_period_days: float | None = None
+
+    correlation_to_spy: float | None = None
+    correlation_to_btc: float | None = None
+
+    equity_curve: list[float] = Field(default_factory=list)
+    monthly_returns: list[float] = Field(default_factory=list)
+
+    backtest_start: str | None = None
+    backtest_end: str | None = None
+
+    out_of_sample_sharpe: float | None = None
+    look_ahead_audit_passed: bool = False
+
+    backtest_engine: str | None = None
+    transaction_cost_bps: int | None = None
+
+
+class OperationResultModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    operation: str
+    symbol: str
+    metrics: EngineMetricsModel
+
+
+class StrategyBlockModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    backtest_code_hash: str | None = None
+    paper_claimed_sharpe: float | None = None
+    paper_claimed_cagr: float | None = None
+    paper_claimed_max_dd: float | None = None
+
+
+class AssumptionsBlockModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    transaction_cost_bps: int = 10
+    walk_forward_split: float | None = None
+    backtest_engine: str | None = None
+
+
+class IntegrityFlagsModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    lookahead_audit_passed: bool = False
+
+
+class AnalyticsArtifactModel(BaseModel):
+    """Pydantic schema for analytics-engine JSON artifact."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    run_id: str
+    strategy: StrategyBlockModel
+    assumptions: AssumptionsBlockModel
+    integrity_flags: IntegrityFlagsModel
+    results: list[OperationResultModel]
+
+
+def canonical_artifact_hash(payload: dict[str, Any]) -> str:
+    """Deterministic SHA-256 for artifact payload."""
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def select_operation_result(
+    artifact: AnalyticsArtifactModel,
+    *,
+    operation: str | None = None,
+) -> OperationResultModel:
+    if not artifact.results:
+        raise ValueError("artifact has no results")
+
+    if operation:
+        wanted = operation.upper()
+        for row in artifact.results:
+            if row.operation.upper() == wanted:
+                return row
+
+    for row in artifact.results:
+        if row.operation.upper() == "SPY":
+            return row
+
+    return artifact.results[0]
+
+
+def map_artifact_to_backtest_result(
+    artifact: AnalyticsArtifactModel,
+    *,
+    strategy_id: str,
+    operation: str | None = None,
+) -> tuple[BacktestResult, str | None]:
+    """Map artifact to backend BacktestResult + chosen operation."""
+    chosen = select_operation_result(artifact, operation=operation)
+    m = chosen.metrics
+
+    max_dd_fraction = _f(m.max_drawdown_pct) / 100.0 if m.max_drawdown_pct is not None else 0.0
+
+    lookahead = m.look_ahead_audit_passed
+    if not lookahead:
+        lookahead = artifact.integrity_flags.lookahead_audit_passed
+
+    result = BacktestResult(
+        strategy_id=strategy_id,
+        sharpe_ratio=_f(m.sharpe_ratio),
+        sortino_ratio=_f(m.sortino_ratio),
+        max_drawdown=max_dd_fraction,
+        cagr=_f(m.cagr),
+        calmar_ratio=_f(m.calmar_ratio),
+        win_rate=_f(m.win_rate),
+        profit_factor=_f(m.profit_factor),
+        total_trades=int(m.total_trades or 0),
+        avg_holding_period_days=_f(m.avg_holding_period_days),
+        correlation_to_spy=_f(m.correlation_to_spy),
+        correlation_to_btc=_f(m.correlation_to_btc),
+        equity_curve=list(m.equity_curve),
+        monthly_returns=list(m.monthly_returns),
+        backtest_start=_safe_iso_to_date(m.backtest_start),
+        backtest_end=_safe_iso_to_date(m.backtest_end),
+        paper_claimed_sharpe=artifact.strategy.paper_claimed_sharpe,
+        paper_claimed_cagr=artifact.strategy.paper_claimed_cagr,
+        paper_claimed_max_dd=artifact.strategy.paper_claimed_max_dd,
+        out_of_sample_sharpe=m.out_of_sample_sharpe,
+        walk_forward_train_fraction=artifact.assumptions.walk_forward_split or 0.70,
+        look_ahead_audit_passed=lookahead,
+        backtest_engine=m.backtest_engine or artifact.assumptions.backtest_engine,
+        backtest_code_hash=artifact.strategy.backtest_code_hash,
+        transaction_cost_bps=m.transaction_cost_bps
+        if m.transaction_cost_bps is not None
+        else artifact.assumptions.transaction_cost_bps,
+    )
+    return result, chosen.operation
+
+
+def load_artifact(path: Path) -> AnalyticsArtifactModel:
+    return AnalyticsArtifactModel.model_validate_json(path.read_text(encoding="utf-8"))

--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -1,4 +1,8 @@
-"""Persistence helpers for backtest_results table."""
+"""Persistence helpers for backtest_results table.
+
+Provides read/write access to persisted backtest results, including
+daily returns for the selection-bias rigor gate.
+"""
 
 from __future__ import annotations
 
@@ -43,6 +47,102 @@ def insert_backtest_if_missing(
     session.add(row)
     session.flush()
     return row, True
+
+
+def get_daily_returns(session: Session, strategy_id: str) -> list[float]:
+    """Fetch daily returns from the latest backtest for a strategy.
+
+    Daily returns are stored in the artifact_json blob (not as a separate column).
+    Falls back to deriving from equity_curve if artifact is unavailable.
+    Returns an empty list if no persisted result exists.
+    """
+    row = (
+        session.query(BacktestResultRecord)
+        .filter(BacktestResultRecord.strategy_id == strategy_id)
+        .order_by(BacktestResultRecord.created_at.desc(), BacktestResultRecord.id.desc())
+        .first()
+    )
+    if row is None:
+        return []
+
+    # Try artifact_json first (has raw daily_returns from analytics-engine)
+    import json as _json
+    if row.artifact_json:
+        try:
+            artifact = _json.loads(row.artifact_json)
+            for r in artifact.get("results", []):
+                daily = r.get("metrics", {}).get("daily_returns", [])
+                if daily:
+                    return daily
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    # Fallback: derive from equity_curve
+    result = row.to_backtest_result()
+    if result.equity_curve and len(result.equity_curve) > 1:
+        import numpy as np
+        ec = np.array(result.equity_curve)
+        returns = ((ec[1:] - ec[:-1]) / ec[:-1]).tolist()
+        return returns
+
+    return []
+
+
+def get_all_daily_returns(
+    session: Session,
+    strategy_ids: list[str],
+) -> dict[str, list[float]]:
+    """Fetch daily returns for multiple strategies.
+
+    Returns {strategy_id: [daily_returns]} for strategies with persisted data.
+    """
+    out: dict[str, list[float]] = {}
+    for sid in strategy_ids:
+        returns = get_daily_returns(session, sid)
+        if returns:
+            out[sid] = returns
+    return out
+
+
+def update_rigor_gate_fields(
+    session: Session,
+    strategy_id: str,
+    *,
+    deflated_sharpe_ratio: float | None = None,
+    dsr_p_value: float | None = None,
+    num_trials_in_selection: int | None = None,
+    pbo_score: float | None = None,
+    out_of_sample_sharpe: float | None = None,
+    look_ahead_audit_passed: bool | None = None,
+) -> BacktestResultRecord | None:
+    """Update rigor-gate fields on the latest backtest row for a strategy.
+
+    Returns the updated row, or None if no persisted result exists.
+    """
+    row = (
+        session.query(BacktestResultRecord)
+        .filter(BacktestResultRecord.strategy_id == strategy_id)
+        .order_by(BacktestResultRecord.created_at.desc(), BacktestResultRecord.id.desc())
+        .first()
+    )
+    if row is None:
+        return None
+
+    if deflated_sharpe_ratio is not None:
+        row.deflated_sharpe_ratio = deflated_sharpe_ratio
+    if dsr_p_value is not None:
+        row.dsr_p_value = dsr_p_value
+    if num_trials_in_selection is not None:
+        row.num_trials_in_selection = num_trials_in_selection
+    if pbo_score is not None:
+        row.pbo_score = pbo_score
+    if out_of_sample_sharpe is not None:
+        row.out_of_sample_sharpe = out_of_sample_sharpe
+    if look_ahead_audit_passed is not None:
+        row.look_ahead_audit_passed = look_ahead_audit_passed
+
+    session.flush()
+    return row
 
 
 def latest_backtests_by_strategy(

--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -1,0 +1,72 @@
+"""Persistence helpers for backtest_results table."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from sqlalchemy.orm import Session
+
+from archimedes.models.backtest import BacktestResult
+from archimedes.models.backtest_store import BacktestResultRecord
+
+
+def insert_backtest_if_missing(
+    session: Session,
+    *,
+    strategy_id: str,
+    content_hash: str,
+    result: BacktestResult,
+    run_id: str | None = None,
+    operation: str | None = None,
+    artifact_json: str | None = None,
+) -> tuple[BacktestResultRecord, bool]:
+    """Insert row if strategy_id+content_hash missing. Returns (row, inserted)."""
+    existing = (
+        session.query(BacktestResultRecord)
+        .filter(
+            BacktestResultRecord.strategy_id == strategy_id,
+            BacktestResultRecord.content_hash == content_hash,
+        )
+        .one_or_none()
+    )
+    if existing is not None:
+        return existing, False
+
+    row = BacktestResultRecord.from_backtest_result(
+        strategy_id=strategy_id,
+        content_hash=content_hash,
+        result=result,
+        run_id=run_id,
+        operation=operation,
+        artifact_json=artifact_json,
+    )
+    session.add(row)
+    session.flush()
+    return row, True
+
+
+def latest_backtests_by_strategy(
+    session: Session,
+    strategy_ids: Iterable[str],
+) -> dict[str, BacktestResultRecord]:
+    """Fetch latest row per strategy_id."""
+    ids = [sid for sid in strategy_ids]
+    if not ids:
+        return {}
+
+    rows = (
+        session.query(BacktestResultRecord)
+        .filter(BacktestResultRecord.strategy_id.in_(ids))
+        .order_by(
+            BacktestResultRecord.strategy_id.asc(),
+            BacktestResultRecord.created_at.desc(),
+            BacktestResultRecord.id.desc(),
+        )
+        .all()
+    )
+
+    latest: dict[str, BacktestResultRecord] = {}
+    for row in rows:
+        if row.strategy_id not in latest:
+            latest[row.strategy_id] = row
+    return latest

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -24,14 +24,19 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
+from collections.abc import Iterable
 from typing import Any
 
+from archimedes.db import get_session
+from archimedes.models.backtest import BacktestResult
 from archimedes.models.strategy import (
     PositionSizing,
     RebalanceFrequency,
     Strategy,
     StrategyStatus,
 )
+
+from archimedes.services.backtest_repository import latest_backtests_by_strategy
 
 logger = logging.getLogger(__name__)
 
@@ -63,14 +68,6 @@ _METADATA_KEYS: tuple[str, ...] = (
     "EXTRACTION_LLM",
     # Lifecycle status
     "STATUS",
-    # Placeholder backtest stubs — sourced from BACKTEST_* constants in strategy files.
-    # Replaced by real BacktestResult when IBacktestEvaluator runs.
-    "BACKTEST_SHARPE",
-    "BACKTEST_CAGR",
-    "BACKTEST_MAX_DD",
-    "BACKTEST_WIN_RATE",
-    "BACKTEST_CALMAR",
-    "BACKTEST_CORR_SPY",
 )
 
 
@@ -185,14 +182,6 @@ def _to_strategy(path: Path, metadata: dict[str, Any], code_hash: str) -> Strate
     paper_claimed_cagr = metadata.get("PAPER_CLAIMED_CAGR")
     paper_claimed_max_dd = metadata.get("PAPER_CLAIMED_MAX_DD")
 
-    # Stub backtest values from BACKTEST_* constants (PLACEHOLDER until IBacktestEvaluator runs)
-    stub_sharpe = metadata.get("BACKTEST_SHARPE")
-    stub_cagr = metadata.get("BACKTEST_CAGR")
-    stub_max_dd = metadata.get("BACKTEST_MAX_DD")
-    stub_win_rate = metadata.get("BACKTEST_WIN_RATE")
-    stub_calmar = metadata.get("BACKTEST_CALMAR")
-    stub_corr_spy = metadata.get("BACKTEST_CORR_SPY")
-
     # Use file mtime so timestamps reflect the strategy file's curation
     # time rather than process start time — otherwise every restart would
     # bump created_at/updated_at for unchanged strategies.
@@ -231,12 +220,6 @@ def _to_strategy(path: Path, metadata: dict[str, Any], code_hash: str) -> Strate
         strategy_code_path=str(path),
         strategy_code_hash=code_hash,
         on_chain_registration_tx=None,
-        stub_sharpe=float(stub_sharpe) if stub_sharpe is not None else None,
-        stub_cagr=float(stub_cagr) if stub_cagr is not None else None,
-        stub_max_dd=float(stub_max_dd) if stub_max_dd is not None else None,
-        stub_win_rate=float(stub_win_rate) if stub_win_rate is not None else None,
-        stub_calmar=float(stub_calmar) if stub_calmar is not None else None,
-        stub_corr_spy=float(stub_corr_spy) if stub_corr_spy is not None else None,
     )
 
 
@@ -254,6 +237,7 @@ class LocalStrategyProvider:
     def __init__(self, strategies_dir: Path) -> None:
         self._strategies_dir = strategies_dir
         self._strategies: dict[str, Strategy] = {}
+        self._backtests: dict[str, BacktestResult] = {}
         self.refresh()
 
     def refresh(self) -> int:
@@ -278,8 +262,40 @@ class LocalStrategyProvider:
             except Exception as exc:  # noqa: BLE001 — defensive on startup
                 logger.exception("failed to load strategy %s: %s", path, exc)
         self._strategies = loaded
-        logger.info("loaded %d strategies from %s", len(loaded), self._strategies_dir)
+        self._backtests = self._load_backtests(loaded.keys())
+        for sid, strategy in self._strategies.items():
+            bt = self._backtests.get(sid)
+            if bt is None:
+                continue
+            strategy.stub_sharpe = bt.sharpe_ratio
+            strategy.stub_cagr = bt.cagr
+            strategy.stub_max_dd = bt.max_drawdown
+            strategy.stub_win_rate = bt.win_rate
+            strategy.stub_calmar = bt.calmar_ratio
+            strategy.stub_corr_spy = bt.correlation_to_spy
+
+        logger.info(
+            "loaded %d strategies from %s (%d with backtests)",
+            len(loaded),
+            self._strategies_dir,
+            len(self._backtests),
+        )
         return len(loaded)
+
+    def _load_backtests(self, strategy_ids: Iterable[str]) -> dict[str, BacktestResult]:
+        ids = list(strategy_ids)
+        if not ids:
+            return {}
+        try:
+            with get_session() as session:
+                rows = latest_backtests_by_strategy(session, ids)
+            return {
+                strategy_id: row.to_backtest_result()
+                for strategy_id, row in rows.items()
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("backtest load failed (using None fallback): %s", exc)
+            return {}
 
     # ── IStrategyProvider ───────────────────────────────────
 
@@ -298,6 +314,24 @@ class LocalStrategyProvider:
 
     def get_strategy(self, strategy_id: str) -> Strategy | None:
         return self._strategies.get(strategy_id)
+
+    def get_backtest_result(self, strategy_id: str) -> BacktestResult | None:
+        """Return latest persisted backtest for a strategy, if present."""
+        cached = self._backtests.get(strategy_id)
+        if cached is not None:
+            return cached
+        latest = self._load_backtests([strategy_id]).get(strategy_id)
+        if latest is not None:
+            self._backtests[strategy_id] = latest
+            strategy = self._strategies.get(strategy_id)
+            if strategy is not None:
+                strategy.stub_sharpe = latest.sharpe_ratio
+                strategy.stub_cagr = latest.cagr
+                strategy.stub_max_dd = latest.max_drawdown
+                strategy.stub_win_rate = latest.win_rate
+                strategy.stub_calmar = latest.calmar_ratio
+                strategy.stub_corr_spy = latest.correlation_to_spy
+        return latest
 
     def get_strategies_for_risk_profile(self, risk_profile_name: str) -> list[Strategy]:
         wanted = risk_profile_name.lower()

--- a/backend/migrations/20260518_add_backtest_results.sql
+++ b/backend/migrations/20260518_add_backtest_results.sql
@@ -1,0 +1,56 @@
+-- Add persistent backtest results table.
+-- Idempotent migration keyed by strategy_id + content_hash.
+
+CREATE TABLE IF NOT EXISTS backtest_results (
+    id INTEGER PRIMARY KEY,
+    strategy_id VARCHAR(64) NOT NULL,
+    content_hash VARCHAR(64) NOT NULL,
+    run_id VARCHAR(32),
+    operation VARCHAR(32),
+
+    sharpe_ratio DOUBLE PRECISION NOT NULL DEFAULT 0,
+    sortino_ratio DOUBLE PRECISION NOT NULL DEFAULT 0,
+    max_drawdown DOUBLE PRECISION NOT NULL DEFAULT 0,
+    cagr DOUBLE PRECISION NOT NULL DEFAULT 0,
+    calmar_ratio DOUBLE PRECISION NOT NULL DEFAULT 0,
+
+    win_rate DOUBLE PRECISION NOT NULL DEFAULT 0,
+    profit_factor DOUBLE PRECISION NOT NULL DEFAULT 0,
+    total_trades INTEGER NOT NULL DEFAULT 0,
+    avg_holding_period_days DOUBLE PRECISION NOT NULL DEFAULT 0,
+
+    correlation_to_spy DOUBLE PRECISION NOT NULL DEFAULT 0,
+    correlation_to_btc DOUBLE PRECISION NOT NULL DEFAULT 0,
+
+    equity_curve_json TEXT NOT NULL DEFAULT '[]',
+    monthly_returns_json TEXT NOT NULL DEFAULT '[]',
+
+    backtest_start DATE,
+    backtest_end DATE,
+
+    paper_claimed_sharpe DOUBLE PRECISION,
+    paper_claimed_cagr DOUBLE PRECISION,
+    paper_claimed_max_dd DOUBLE PRECISION,
+
+    deflated_sharpe_ratio DOUBLE PRECISION,
+    dsr_p_value DOUBLE PRECISION,
+    num_trials_in_selection INTEGER,
+    pbo_score DOUBLE PRECISION,
+
+    out_of_sample_sharpe DOUBLE PRECISION,
+    walk_forward_train_fraction DOUBLE PRECISION NOT NULL DEFAULT 0.70,
+    look_ahead_audit_passed BOOLEAN NOT NULL DEFAULT FALSE,
+
+    backtest_engine VARCHAR(32),
+    backtest_code_hash VARCHAR(64),
+    transaction_cost_bps INTEGER NOT NULL DEFAULT 10,
+
+    artifact_json TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_backtest_strategy_content
+    ON backtest_results(strategy_id, content_hash);
+
+CREATE INDEX IF NOT EXISTS ix_backtest_strategy_created
+    ON backtest_results(strategy_id, created_at);

--- a/backend/tests/fixtures/analytics_artifact_buy_hold.json
+++ b/backend/tests/fixtures/analytics_artifact_buy_hold.json
@@ -1,0 +1,44 @@
+{
+  "run_id": "20260516T151551Z",
+  "strategy": {
+    "backtest_code_hash": "sha256:buyhold-fixture-0f1e2d3c4b5a69788796a5b4c3d2e1f0",
+    "paper_claimed_sharpe": null,
+    "paper_claimed_cagr": null,
+    "paper_claimed_max_dd": null
+  },
+  "assumptions": {
+    "transaction_cost_bps": 10,
+    "walk_forward_split": 0.7,
+    "backtest_engine": "backtrader"
+  },
+  "integrity_flags": {
+    "lookahead_audit_passed": true
+  },
+  "results": [
+    {
+      "operation": "SPY",
+      "symbol": "SPY",
+      "metrics": {
+        "sharpe_ratio": 0.7135863248834242,
+        "sortino_ratio": 0.91,
+        "calmar_ratio": 0.42,
+        "max_drawdown_pct": 34.07931346227104,
+        "cagr": 0.142,
+        "win_rate": 0.58,
+        "profit_factor": 1.31,
+        "total_trades": 12,
+        "avg_holding_period_days": 21.0,
+        "correlation_to_spy": 1.0,
+        "correlation_to_btc": 0.34,
+        "equity_curve": [100000.0, 104200.0, 110318.0],
+        "monthly_returns": [0.012, -0.018, 0.024],
+        "backtest_start": "2018-01-01",
+        "backtest_end": "2026-01-01",
+        "out_of_sample_sharpe": 0.61,
+        "look_ahead_audit_passed": true,
+        "backtest_engine": "backtrader",
+        "transaction_cost_bps": 10
+      }
+    }
+  ]
+}

--- a/backend/tests/test_backtest_mapper.py
+++ b/backend/tests/test_backtest_mapper.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from archimedes.services.backtest_mapper import (
+    AnalyticsArtifactModel,
+    map_artifact_to_backtest_result,
+)
+
+
+def test_artifact_schema_round_trip() -> None:
+    artifact_path = Path(__file__).resolve().parents[2] / "analytics-engine" / "artifacts" / "20260516T151551Z.json"
+    payload = artifact_path.read_text(encoding="utf-8")
+
+    parsed = AnalyticsArtifactModel.model_validate_json(payload)
+    dumped = parsed.model_dump_json()
+    reparsed = AnalyticsArtifactModel.model_validate_json(dumped)
+
+    assert reparsed.run_id == parsed.run_id
+    assert reparsed.strategy.backtest_code_hash == parsed.strategy.backtest_code_hash
+    assert len(reparsed.results) == len(parsed.results)
+
+
+def test_mapper_preserves_buy_hold_sharpe() -> None:
+    artifact_path = Path(__file__).resolve().parents[2] / "analytics-engine" / "artifacts" / "20260516T151551Z.json"
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    artifact = AnalyticsArtifactModel.model_validate(payload)
+
+    result, operation = map_artifact_to_backtest_result(
+        artifact,
+        strategy_id="test_strategy",
+        operation="SPY",
+    )
+
+    assert operation == "SPY"
+    assert result.sharpe_ratio == pytest.approx(0.7135863248834242)
+    assert result.max_drawdown == pytest.approx(0.3407931346227104)
+    assert result.backtest_code_hash == artifact.strategy.backtest_code_hash

--- a/backend/tests/test_backtest_mapper.py
+++ b/backend/tests/test_backtest_mapper.py
@@ -12,7 +12,7 @@ from archimedes.services.backtest_mapper import (
 
 
 def test_artifact_schema_round_trip() -> None:
-    artifact_path = Path(__file__).resolve().parents[2] / "analytics-engine" / "artifacts" / "20260516T151551Z.json"
+    artifact_path = Path(__file__).resolve().parent / "fixtures" / "analytics_artifact_buy_hold.json"
     payload = artifact_path.read_text(encoding="utf-8")
 
     parsed = AnalyticsArtifactModel.model_validate_json(payload)
@@ -25,7 +25,7 @@ def test_artifact_schema_round_trip() -> None:
 
 
 def test_mapper_preserves_buy_hold_sharpe() -> None:
-    artifact_path = Path(__file__).resolve().parents[2] / "analytics-engine" / "artifacts" / "20260516T151551Z.json"
+    artifact_path = Path(__file__).resolve().parent / "fixtures" / "analytics_artifact_buy_hold.json"
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
     artifact = AnalyticsArtifactModel.model_validate(payload)
 

--- a/backend/tests/test_backtest_pipeline_integration.py
+++ b/backend/tests/test_backtest_pipeline_integration.py
@@ -1,0 +1,62 @@
+"""Integration test: analytics-engine → DB → passport → risk end-to-end.
+
+Verifies that the full backtest pipeline produces real (non-placeholder)
+metrics including selection-bias rigor gate fields.
+"""
+
+from __future__ import annotations
+
+from archimedes.db import get_session, init_db
+from archimedes.models.backtest_store import BacktestResultRecord
+from archimedes.services.strategy_provider import default_provider
+
+
+def test_backtest_pipeline_e2e():
+    """Exercise the full pipeline: strategies have persisted backtest results
+    with rigor gate fields populated."""
+    init_db()
+    provider = default_provider()
+    strategies = provider.list_strategies()
+
+    assert len(strategies) >= 4, f"Expected >= 4 strategies, got {len(strategies)}"
+
+    strategy_ids = [s.id for s in strategies]
+
+    with get_session() as session:
+        rows = (
+            session.query(BacktestResultRecord)
+            .filter(BacktestResultRecord.strategy_id.in_(strategy_ids))
+            .all()
+        )
+
+    # Every strategy should have a persisted backtest row
+    rows_by_id = {r.strategy_id: r for r in rows}
+    for s in strategies:
+        assert s.id in rows_by_id, f"No backtest row for {s.paper_title}"
+
+    # Every row should have real metrics (not zero/None defaults)
+    for s in strategies:
+        row = rows_by_id[s.id]
+        assert row.sharpe_ratio > 0, f"{s.paper_title}: Sharpe should be > 0, got {row.sharpe_ratio}"
+        assert row.cagr > 0, f"{s.paper_title}: CAGR should be > 0"
+        assert row.max_drawdown > 0, f"{s.paper_title}: MaxDD should be > 0"
+
+    # At least some rows should have rigor gate fields populated
+    with_rigor = [r for r in rows if r.deflated_sharpe_ratio is not None]
+    assert len(with_rigor) >= 2, f"Expected >= 2 rows with DSR, got {len(with_rigor)}"
+
+    # Verify DSR p-value is in valid range
+    for r in with_rigor:
+        assert 0 <= r.dsr_p_value <= 1, f"DSR p-value out of range: {r.dsr_p_value}"
+
+    # Verify PBO score is in valid range
+    with_pbo = [r for r in rows if r.pbo_score is not None]
+    for r in with_pbo:
+        assert 0 <= r.pbo_score <= 1, f"PBO score out of range: {r.pbo_score}"
+
+    # Verify the provider returns real backtest results
+    for s in strategies:
+        bt = provider.get_backtest_result(s.id)
+        assert bt is not None, f"No BacktestResult for {s.paper_title}"
+        assert bt.sharpe_ratio > 0, f"BacktestResult Sharpe should be > 0"
+        assert bt.deflated_sharpe_ratio is not None, f"DSR not populated for {s.paper_title}"

--- a/backend/tests/test_backtest_repository.py
+++ b/backend/tests/test_backtest_repository.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from archimedes.models.backtest import BacktestResult
+from archimedes.models.chat import Base
+from archimedes.models.backtest_store import BacktestResultRecord
+from archimedes.services.backtest_repository import (
+    insert_backtest_if_missing,
+    latest_backtests_by_strategy,
+)
+
+
+def _sample_result(strategy_id: str, sharpe: float) -> BacktestResult:
+    return BacktestResult(
+        strategy_id=strategy_id,
+        sharpe_ratio=sharpe,
+        sortino_ratio=0.5,
+        max_drawdown=0.2,
+        cagr=0.1,
+        calmar_ratio=0.5,
+        win_rate=0.5,
+        profit_factor=1.2,
+        total_trades=10,
+        avg_holding_period_days=5.0,
+        correlation_to_spy=0.3,
+        correlation_to_btc=0.1,
+        equity_curve=[100000, 101000],
+        monthly_returns=[0.01],
+        backtest_start=date(2020, 1, 1),
+        backtest_end=date(2020, 12, 31),
+    )
+
+
+def test_insert_backtest_is_idempotent_on_content_hash() -> None:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    with SessionLocal() as session:
+        row1, inserted1 = insert_backtest_if_missing(
+            session,
+            strategy_id="s1",
+            content_hash="abc123",
+            result=_sample_result("s1", sharpe=0.7),
+            run_id="run1",
+        )
+        row1_id = row1.id
+        session.commit()
+
+    with SessionLocal() as session:
+        row2, inserted2 = insert_backtest_if_missing(
+            session,
+            strategy_id="s1",
+            content_hash="abc123",
+            result=_sample_result("s1", sharpe=0.9),
+            run_id="run2",
+        )
+        session.commit()
+
+        rows = session.query(BacktestResultRecord).all()
+        assert inserted1 is True
+        assert inserted2 is False
+        assert row1_id == row2.id
+        assert len(rows) == 1
+
+
+def test_latest_backtests_by_strategy_picks_newest_row() -> None:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    with SessionLocal() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id="s1",
+            content_hash="h1",
+            result=_sample_result("s1", sharpe=0.5),
+            run_id="run1",
+        )
+        insert_backtest_if_missing(
+            session,
+            strategy_id="s1",
+            content_hash="h2",
+            result=_sample_result("s1", sharpe=0.8),
+            run_id="run2",
+        )
+        insert_backtest_if_missing(
+            session,
+            strategy_id="s2",
+            content_hash="h3",
+            result=_sample_result("s2", sharpe=1.1),
+            run_id="run3",
+        )
+        session.commit()
+
+        latest = latest_backtests_by_strategy(session, ["s1", "s2"])
+
+    assert latest["s1"].sharpe_ratio == 0.8
+    assert latest["s2"].sharpe_ratio == 1.1

--- a/backend/tests/test_run_backtests_script.py
+++ b/backend/tests/test_run_backtests_script.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from archimedes.models.chat import Base
+from archimedes.scripts import run_backtests as run_backtests_mod
+
+
+def _write_strategy(path: Path) -> None:
+    path.write_text(
+        "import backtrader as bt\n\n"
+        "PAPER_TITLE = 'Test Strategy'\n"
+        "PAPER_AUTHORS = ['Test']\n"
+        "METHODOLOGY_SUMMARY = 'Test summary'\n"
+        "ASSET_UNIVERSE = ['SPY']\n"
+        "STATUS = 'candidate'\n\n"
+        "class TestStrategy(bt.Strategy):\n"
+        "    def next(self):\n"
+        "        if not self.position:\n"
+        "            self.buy(size=1)\n"
+    )
+
+
+def _artifact_payload() -> dict:
+    return {
+        "run_id": "20260518T000000Z",
+        "strategy": {
+            "backtest_code_hash": "a" * 64,
+            "paper_claimed_sharpe": None,
+            "paper_claimed_cagr": None,
+            "paper_claimed_max_dd": None,
+        },
+        "assumptions": {
+            "transaction_cost_bps": 10,
+            "walk_forward_split": None,
+            "backtest_engine": "backtrader",
+        },
+        "integrity_flags": {
+            "lookahead_audit_passed": True,
+        },
+        "results": [
+            {
+                "operation": "SPY",
+                "symbol": "SPY",
+                "metrics": {
+                    "sharpe_ratio": 0.7135863248834242,
+                    "sortino_ratio": 0.66,
+                    "calmar_ratio": 0.37,
+                    "max_drawdown_pct": 34.07931346227104,
+                    "cagr": 0.12,
+                    "total_trades": 0,
+                    "win_rate": None,
+                    "profit_factor": None,
+                    "avg_holding_period_days": None,
+                    "correlation_to_spy": None,
+                    "correlation_to_btc": None,
+                    "equity_curve": [100000.0, 101000.0],
+                    "monthly_returns": [0.01],
+                    "transaction_cost_bps": 10,
+                    "slippage_bps": 5,
+                    "look_ahead_audit_passed": True,
+                    "backtest_engine": "backtrader",
+                    "backtest_start": "2018-01-02T00:00:00",
+                    "backtest_end": "2026-05-15T00:00:00",
+                },
+            }
+        ],
+    }
+
+
+def test_run_backtests_is_idempotent(monkeypatch, tmp_path) -> None:
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    _write_strategy(strategies_dir / "test_strategy.py")
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def fake_init_db() -> None:
+        Base.metadata.create_all(bind=engine)
+
+    def fake_get_session():
+        return SessionLocal()
+
+    def fake_run_command(**kwargs):
+        artifact_path = kwargs["artifact_dir"] / "20260518T000000Z.json"
+        artifact_path.write_text(json.dumps(_artifact_payload()), encoding="utf-8")
+        return {"run_id": "20260518T000000Z", "artifact_path": str(artifact_path)}
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+    monkeypatch.setattr(run_backtests_mod, "init_db", fake_init_db)
+    monkeypatch.setattr(run_backtests_mod, "get_session", fake_get_session)
+
+    first = run_backtests_mod.run_backtests()
+    second = run_backtests_mod.run_backtests()
+
+    assert first["inserted"] == 1
+    assert first["failed"] == 0
+    assert second["inserted"] == 0
+    assert second["skipped"] == 1

--- a/backend/tests/test_strategy_endpoints.py
+++ b/backend/tests/test_strategy_endpoints.py
@@ -51,10 +51,17 @@ def test_tsmom_status_is_live(provider):
     assert tsmom.status == StrategyStatus.LIVE
 
 
-def test_buy_hold_status_is_candidate(provider):
+def test_buy_hold_status_is_live(provider):
+    # NOTE (consolidation 2026-05-18): analytics-engine/strategies/pipeline_buy_hold.py
+    # declares STATUS = "live" on current main, like the other seeded strategies, so
+    # the provider yields LIVE. Daniel's original commit (22 commits behind) asserted
+    # CANDIDATE. Aligned to current reality. OPEN DESIGN QUESTION for the team: a
+    # buy-and-hold baseline arguably should stay CANDIDATE until it clears the
+    # selection-bias rigor gate (#53) — but that is a product/strategy-file decision,
+    # not a test fix. Flagged in the PR; not silently changed here.
     baseline = next((s for s in provider.list_strategies() if s.paper_title == "Buy-and-Hold Baseline"), None)
     if baseline is not None:
-        assert baseline.status == StrategyStatus.CANDIDATE
+        assert baseline.status == StrategyStatus.LIVE
 
 
 # ── Paper claim fields ────────────────────────────────────────

--- a/backend/tests/test_strategy_endpoints.py
+++ b/backend/tests/test_strategy_endpoints.py
@@ -1,15 +1,10 @@
 """Tests for strategy provider and response schema.
 
 Covers:
-- LocalStrategyProvider loading the seed strategy files
-- STATUS constant parsed correctly (live / candidate)
-- BACKTEST_* stub constants parsed and exposed on Strategy
-- Paper claim fields parsed
-- StrategyResponse schema — field presence and value mapping
-
-Note: does NOT import archimedes.api.routes (which transitively imports chain/
-web3 services requiring eth_account/web3). The mapping logic is tested via
-schema construction directly.
+- LocalStrategyProvider loading seed strategy files
+- STATUS constant parsing
+- Paper/passport fields parsing
+- Backtest read path from DB table (result or None fallback)
 """
 
 from __future__ import annotations
@@ -62,27 +57,6 @@ def test_buy_hold_status_is_candidate(provider):
         assert baseline.status == StrategyStatus.CANDIDATE
 
 
-# ── BACKTEST_* stub constants ─────────────────────────────────
-
-
-def test_faber_has_stub_sharpe(provider):
-    faber = next(s for s in provider.list_strategies() if "Tactical Asset Allocation" in s.paper_title)
-    assert faber.stub_sharpe is not None
-    assert isinstance(faber.stub_sharpe, float)
-    assert 0 < faber.stub_sharpe < 3.0
-
-
-def test_tsmom_has_stub_calmar(provider):
-    tsmom = next(s for s in provider.list_strategies() if s.paper_title == "Time Series Momentum")
-    assert tsmom.stub_calmar is not None
-
-
-def test_vol_managed_has_stub_corr_spy(provider):
-    vol = next(s for s in provider.list_strategies() if s.paper_title == "Volatility-Managed Portfolios")
-    assert vol.stub_corr_spy is not None
-    assert 0 <= vol.stub_corr_spy <= 1.0
-
-
 # ── Paper claim fields ────────────────────────────────────────
 
 
@@ -115,12 +89,20 @@ def test_strategy_id_is_deterministic(provider):
     assert ids1 == ids2, "Strategy IDs must be deterministic across loads"
 
 
-# ── StrategyResponse schema mapping (no routes import) ───────
+# ── Backtest read path ────────────────────────────────────────
 
 
-def _map_to_response(s: Strategy) -> StrategyResponse:
-    """Inline mapping logic matching _to_strategy_response in routes.py."""
-    has_stubs = s.stub_sharpe is not None
+def test_provider_backtest_lookup_returns_row_or_none(provider):
+    for s in provider.list_strategies():
+        bt = provider.get_backtest_result(s.id)
+        assert bt is None or bt.strategy_id == s.id
+
+
+# ── StrategyResponse mapping (no routes import) ───────────────
+
+
+def _map_to_response(s: Strategy, provider) -> StrategyResponse:
+    bt = provider.get_backtest_result(s.id)
     return StrategyResponse(
         id=s.id,
         paper_arxiv_id=s.paper_arxiv_id,
@@ -140,20 +122,20 @@ def _map_to_response(s: Strategy) -> StrategyResponse:
         curator_wallet=s.curator_wallet,
         curator_note=s.curator_note,
         on_chain_registration_tx=s.on_chain_registration_tx,
-        paper_claimed_sharpe=s.paper_claimed_sharpe,
-        sharpe_ratio=s.stub_sharpe,
-        cagr=s.stub_cagr,
-        max_drawdown=s.stub_max_dd,
-        win_rate=s.stub_win_rate,
-        calmar_ratio=s.stub_calmar,
-        correlation_to_spy=s.stub_corr_spy,
-        is_backtest_placeholder=has_stubs,
+        paper_claimed_sharpe=bt.paper_claimed_sharpe if bt else s.paper_claimed_sharpe,
+        sharpe_ratio=bt.sharpe_ratio if bt else None,
+        cagr=bt.cagr if bt else None,
+        max_drawdown=bt.max_drawdown if bt else None,
+        win_rate=bt.win_rate if bt else None,
+        calmar_ratio=bt.calmar_ratio if bt else None,
+        correlation_to_spy=bt.correlation_to_spy if bt else None,
+        is_backtest_placeholder=False,
     )
 
 
 def test_response_includes_passport_fields(provider):
     faber = next(s for s in provider.list_strategies() if "Tactical Asset Allocation" in s.paper_title)
-    resp = _map_to_response(faber)
+    resp = _map_to_response(faber, provider)
     assert resp.paper_venue == "The Journal of Wealth Management"
     assert resp.paper_year == 2007
     assert resp.paper_citation_count == 850
@@ -161,37 +143,25 @@ def test_response_includes_passport_fields(provider):
     assert resp.curator_note is not None
 
 
-def test_response_backtest_stubs_populated(provider):
-    faber = next(s for s in provider.list_strategies() if "Tactical Asset Allocation" in s.paper_title)
-    resp = _map_to_response(faber)
-    assert resp.sharpe_ratio is not None
-    assert resp.cagr is not None
-    assert resp.max_drawdown is not None
-    assert resp.calmar_ratio is not None
-    assert resp.correlation_to_spy is not None
-    assert resp.is_backtest_placeholder is True
-
-
-def test_response_paper_claimed_sharpe(provider):
-    faber = next(s for s in provider.list_strategies() if "Tactical Asset Allocation" in s.paper_title)
-    resp = _map_to_response(faber)
-    assert resp.paper_claimed_sharpe == pytest.approx(0.78)
+def test_response_backtest_none_when_no_row(provider):
+    # At minimum ensure mapping tolerates no backtest row.
+    strat = next(iter(provider.list_strategies()))
+    resp = _map_to_response(strat, provider)
+    bt = provider.get_backtest_result(strat.id)
+    if bt is None:
+        assert resp.sharpe_ratio is None
+        assert resp.max_drawdown is None
+    else:
+        assert resp.sharpe_ratio == bt.sharpe_ratio
+        assert resp.max_drawdown == bt.max_drawdown
 
 
 def test_response_status_live(provider):
     live = [s for s in provider.list_strategies() if s.status == StrategyStatus.LIVE]
     assert len(live) >= 2, "Expected at least 2 live strategies"
     for s in live:
-        resp = _map_to_response(s)
+        resp = _map_to_response(s, provider)
         assert resp.status == "live"
-
-
-def test_response_buy_hold_no_stubs(provider):
-    baseline = next((s for s in provider.list_strategies() if s.paper_title == "Buy-and-Hold Baseline"), None)
-    if baseline is None:
-        pytest.skip("Buy-and-Hold baseline not loaded")
-    resp = _map_to_response(baseline)
-    assert resp.is_backtest_placeholder is False
 
 
 # ── Filtering ─────────────────────────────────────────────────


### PR DESCRIPTION
## What this is

**Daniel's** engine→passport bridge work (`origin/danielscoffee/backtest-result`, commit `50657e9`), consolidated onto current `main` and pushed forward so the team can review now without waiting. **Authorship preserved** — `c72d71c` is Daniel's commit verbatim (cherry-picked with `-x`); `42f33d7` is a drift-fix on his behalf.

## Why it matters

This closes the **#1 integration gap** from our step-back evaluation: the strategy passport was serving hardcoded `stub_*` placeholders (`is_backtest_placeholder=True`) because nothing connected the analytics-engine to the backend. Daniel built exactly the missing seam:

- `services/backtest_mapper.py` — `map_artifact_to_backtest_result()` + Pydantic artifact schema + `canonical_artifact_hash()` (provenance)
- `services/backtest_repository.py` + `models/backtest_store.py` + `migrations/20260518_add_backtest_results.sql` — persistence
- `scripts/run_backtests.py` — the batch invocation seam (`python -m archimedes.scripts.run_backtests`)
- `routes.py` / `strategy_provider.py` / `risk_routes.py` — rewired to serve **real** persisted `BacktestResult` (`is_backtest_placeholder=False`), with graceful None-fallback when the table is empty

## Consolidation work (commit `42f33d7`, drift from 22 commits)

3 tests broke purely from integration drift (his commit predated Önder's selection-bias merge etc.); all fixed without touching his mapper logic:
1. `test_backtest_mapper` depended on a gitignored runtime artifact → added a committed hermetic fixture.
2. `test_buy_hold_status` asserted `CANDIDATE`; `pipeline_buy_hold.py` on main is `STATUS="live"` → aligned to reality.

**Validation:** full backend suite **119 passed, 0 failed**, ruff clean (archimedes env).

## Open items for review / discussion

- 🔵 **Design Q (team):** should the buy-and-hold baseline stay `CANDIDATE` until it clears the selection-bias rigor gate (#53)? Flagged, not unilaterally changed.
- 🔵 **Next wiring step:** this lands the *pipeline*; connecting Önder's `selection_bias.py` to populate DSR/PBO on the persisted `BacktestResult` (instead of `_synthetic_returns_from_stub`) is the natural follow-up — feeds the rigor wedge.
- ℹ️ Based on `main` (not `develop`) to keep the diff focused on the bridge; `develop` is a separate 22-commit FF-lag, unrelated to this PR.

🤖 Consolidated with [Claude Code](https://claude.com/claude-code)