### PR TITLE
[infra] gitignore the local SQLite fallback db (archimedes_chat.db)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,14 @@ infra/*.pem
 data/corpus/pdfs/
 data/corpus/text/
 
+# Local SQLite fallback — backend/archimedes/db.py defaults to
+# sqlite:///./archimedes_chat.db when DATABASE_URL is unset (e.g. pytest or
+# the backend run outside docker-compose). Never commit it: an out-of-container
+# run with live per-vault chat would otherwise leak local data into the repo.
+archimedes_chat.db
+*.sqlite
+*.sqlite3
+
 # Misc
 *.log
 .pytest_cache/


### PR DESCRIPTION
## What

Adds `archimedes_chat.db` + `*.sqlite` / `*.sqlite3` to `.gitignore`.

## Why

`backend/archimedes/db.py` defaults `DATABASE_URL` to `sqlite:///./archimedes_chat.db`. Inside docker-compose it's Postgres, but **any out-of-container DB touch** (running `pytest`, or the backend locally without the env var) silently creates an untracked `archimedes_chat.db` in the repo root. It was **not** gitignored, so:

- a routine `git add .` could commit a stray empty SQLite file, and
- if someone runs the per-vault chat locally, that file contains **real chat data** that would get committed into a public repo the judges read hands-on.

This is the exact git-safety class codified in PR #67. Found while cleaning up an empty `archimedes_chat.db` I generated running the test suites this session (deleted; regenerates harmlessly, just now ignored).

One-line hygiene; no code change. Separate small PR per the one-logical-change discipline.

🤖 Drafted with [Claude Code](https://claude.com/claude-code)
