### PR TITLE
[docs] Realign core docs to the locked product spine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,15 @@
 # Archimedes — Claude Code Context
 
-> **Status:** Living context doc. Written 2026-05-12 (Day 2), revised 2026-05-13 (Day 3)
-> for the marketplace pivot and rigor-as-wedge decision, revised 2026-05-14 (Day 4) after
-> the 10-contract Arc-testnet deployment, live UI, and ownership reshuffle. Intent: drop
-> at the root of the `archimedes` repo and read at the start of every Claude Code session.
+> **Status:** Living context doc. Written 2026-05-12 (Day 2); revised 2026-05-13 (Day 3,
+> marketplace pivot + rigor-as-wedge), 2026-05-14 (Day 4, 10-contract Arc deploy + live
+> UI + ownership reshuffle), and 2026-05-19 (build-on-deploy main-only + `develop`
+> retired; GLM intelligence live; product spine locked in `docs/user-stories.md`;
+> agentic-issue pipeline codified). Intent: drop at the root of the `archimedes` repo
+> and read at the start of every Claude Code session.
 >
 > **Architecture lineage to read together:**
+> - [`docs/user-stories.md`](docs/user-stories.md) — **the locked product spine
+>   (canonical); supersedes the older product framing in the docs below**
 > - [`docs/design.md`](docs/design.md) — original single-vault architecture
 > - [`docs/specs/ecosystem-design-spec.md`](docs/specs/ecosystem-design-spec.md) — Day-3
 >   two-tier marketplace pivot (synthetic protocol + AMM + VaultFactory + agent-as-a-service)
@@ -19,9 +23,11 @@
 
 ## Project
 
-**Archimedes** — a fund-of-funds portfolio agent that turns published quant finance research
-into investable, backtested strategies, then constructs personalized portfolios of RWA tokens
-and yield instruments on Arc with USDC settlement.
+**Archimedes** — "Linus for quantitative finance": a single-user agent that turns the
+q-fin research literature into investable, rigor-gated strategies, then executes and
+monitors them in non-custodial vaults on Arc with USDC settlement. The product spine
+(generate → rigor-gate → execute → monitor → explore) is locked in
+[`docs/user-stories.md`](docs/user-stories.md) — the canonical product framing.
 
 > *"Give me a lever long enough and I shall move the world."* The lever here is academic
 > research; the fulcrum is autonomous AI; the world is your portfolio.
@@ -43,10 +49,14 @@ May 11–25, 2026.
 ## North Star
 
 A user with idle USDC who wants thoughtful portfolio management — but is tired of black-box
-robo-advisors, opaque AI funds, and "trust me bro" influencer copy-trading — connects a
-wallet, picks a risk profile, and gets a portfolio constructed from strategies that come
-with a **paper-grounded reasoning trace anchored on-chain**. Every position the agent takes,
-every rebalance it executes, every regime shift it responds to, is hashed and verifiable.
+robo-advisors, opaque AI funds, and "trust me bro" influencer copy-trading — **describes
+what they want**, and Archimedes **generates** a research-grounded strategy, **rigor-gates**
+it (DSR/PBO — the curation protocol that makes the library trustworthy), **executes** it
+into a non-custodial vault, then lets them **monitor** results and **explore** their
+compounding strategy library. Every position, rebalance, and regime shift comes with a
+**paper-grounded reasoning trace anchored on-chain** — hashed and verifiable. Single-user
+is the MVP; a social network of shared strategies is the roadmap vision (canonical detail
+in [`docs/user-stories.md`](docs/user-stories.md)).
 
 The Agora narrative frames this:
 

--- a/docs/demo-script-pitch-deck-outline.md
+++ b/docs/demo-script-pitch-deck-outline.md
@@ -1,8 +1,13 @@
 # Demo Script & Pitch Deck Outline
 
 > **Audience:** Archimedes hackathon team (deck owner + demo runner + Q&A primaries)
-> **Status:** Day-4 revision (2026-05-14) — tighten in Week 2 as the orchestrator loop
-> and reasoning-trace anchoring come online.
+> **Status:** Day-4 revision (2026-05-14); **2026-05-19 realignment pending.** The flow
+> below still narrates the retired "connect wallet → pick a risk profile" path. The
+> submission demo MUST follow the locked spine in [`user-stories.md`](user-stories.md):
+> describe intent → generate → rigor-gate → execute → monitor → explore, read-only until
+> Deposit. Steps 2–4 below are superseded; the **rigor gate is the central pitch** — the
+> curation protocol that makes the strategy library trustworthy. Full rewrite tracked as
+> a docs-realignment follow-up.
 > **Pitch length assumption:** 3-minute pitch + ~2 minute live demo + Q&A. Adjust if
 > Canteen tells us otherwise.
 > **Shipped reality the demo can lean on (as of Day 4):**

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,6 +2,11 @@
 
 **Fund-of-Funds Portfolio Agent Powered by Academic Research**
 
+> ⚠️ **Superseded for product framing.** This is the original single-vault design
+> document, retained for architecture lineage. The **canonical product spine** — and
+> the retirement of the "connect wallet → pick a risk profile" flow — is
+> [`user-stories.md`](user-stories.md). Read that first for what the product *is*.
+
 Agora Agents Hackathon | Canteen x Circle x Arc | May 11–25, 2026
 
 ---


### PR DESCRIPTION
## What

Realigns core docs to the locked product spine (`docs/user-stories.md`, merged #79) and refreshes stale headers. Docs-only, runtime-inert.

## Why

#79 locked the spine but three load-bearing docs still told the retired "connect wallet → pick a risk profile" story — a live contradiction (#79's own definition-of-done says the demo must tell the one spine).

## Changes

- **CLAUDE.md**: status header refreshed to 2026-05-19 (develop retired, GLM live, spine locked, agentic pipeline); Project + North Star rewritten to the spine (generate → rigor-gate → execute → monitor → explore; single-user MVP, social = roadmap); `user-stories.md` added as the **canonical** lineage entry.
- **docs/design.md**: superseded-for-product-framing banner → routes readers to `user-stories.md`.
- **docs/demo-script-pitch-deck-outline.md**: realignment banner — flags steps 2–4 as superseded, points the submission demo at the locked spine, threads the rigor-gate-as-curation-protocol pitch.

## Audit findings (for the record)

- 🔴 P0 contradiction (above) — **fixed here.**
- 🟢 "robo-advisor / fund-of-funds" in `competitor-landscape.md`, `architectural-principles.md`, `claude-design-prompts.md`, `anti-features.md` — correct as competitive *foil*, deliberately left.
- 🟠 Follow-up (not in this PR): full demo-script rewrite to the spine; `docs/mvp-scope-memo.md` pass vs single-user-MVP/social-roadmap. Banners make the current state honest in the meantime.

## Review

Read the diff — surgical edits + three pointer banners. Merge if the spine reads true.
