### PR TITLE
[docs] .env.example + README: clarify the one secret that unlocks real intelligence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,10 @@
 #   cp .env.example .env
 #
 # Required for `docker compose up` to start the local stack. Most defaults work
-# out of the box for local development; only ANTHROPIC_API_KEY and (later) the
-# Arc-specific wallet variables need real values.
+# out of the box for local development. The ONLY secret that changes the
+# experience is the LLM credential below — without it the app still runs but
+# the strategy intelligence SILENTLY falls back to canned output. The Arc
+# wallet / RPC / Circle variables are optional locally (skip on-chain features).
 
 # ── PostgreSQL (the local docker compose stack starts a server with these) ──
 POSTGRES_USER=archimedes
@@ -18,8 +20,24 @@ DATABASE_URL=postgresql://archimedes:archimedes-hackathon-2026@postgres:5432/arc
 # ── Redis ──────────────────────────────────────────────────────────────────
 REDIS_URL=redis://redis:6379/0
 
-# ── LLM (required for reasoning-trace generation + arxiv extraction) ───────
-# Get a key at https://console.anthropic.com — free tier works for dev.
+# ── LLM — the one credential that unlocks REAL strategy intelligence ──────
+# Powers strategy fusion, the architect, reasoning-trace generation, and
+# arxiv passport extraction. Leave ALL of these blank and the app still
+# boots, but those paths use a CANNED fallback (not real intelligence) —
+# degraded silently. Set EXACTLY ONE of the two paths:
+#
+#  (A) Any Anthropic-compatible endpoint — this project uses GLM via z.ai:
+#        ANTHROPIC_AUTH_TOKEN=<token>
+#        ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+#      JUDGES: the project's token is delivered privately via the Canteen
+#      submission (never in this public repo). Paste it here in your local
+#      .env only — this template stays blank.
+#
+#  (B) Bring your own real Anthropic key (free tier works for dev):
+#        ANTHROPIC_API_KEY=<key from https://console.anthropic.com>
+#
+ANTHROPIC_AUTH_TOKEN=
+ANTHROPIC_BASE_URL=
 ANTHROPIC_API_KEY=
 
 # ── Arc testnet RPC (per-developer, from `arc-canteen login`) ──────────────
@@ -49,7 +67,9 @@ WALLET_SET_ID=
 # How often the oracle runner pushes prices (seconds, default 60).
 ORACLE_INTERVAL_SECONDS=60
 
-# ── Contract addresses (Arc testnet, Chain ID 13068200) ───────────────────
+# ── Contract addresses (Arc testnet, Chain ID 5042002 / 0x4cef52) ─────────
+# (Chain ID aligned with README/CLAUDE; addresses unchanged — verify via
+# Chuan/contracts before relying on them.)
 PRICE_ORACLE_ADDRESS=0xe1c9f2b11be97097223a66a188fca541e07873a6
 SYNTHETIC_FACTORY_ADDRESS=
 AMM_ROUTER_ADDRESS=0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4

--- a/README.md
+++ b/README.md
@@ -357,12 +357,24 @@ Open `.env` in your editor and fill in the values that are blank. Defaults work 
 
 | Variable                     | Where to get it                                       | Required for             |
 | ---------------------------- | ----------------------------------------------------- | ------------------------ |
-| `ANTHROPIC_API_KEY`          | <https://console.anthropic.com>                       | Reasoning-trace + arxiv extraction features |
+| **LLM** — one of: `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`, *or* `ANTHROPIC_API_KEY` | GLM token via the **Canteen submission** (judges), or your own key at <https://console.anthropic.com> | **Real strategy intelligence** — blank = silent canned fallback |
 | `RPC`                        | `~/.arc-canteen/env` (after `arc-canteen login`)      | On-chain features (contracts, trace anchoring) |
 | `DEV_WALLET_ADDRESS` / `_PRIVATE_KEY` | `cast wallet new` (generate a fresh dev wallet) | Submitting signed transactions to Arc |
 | `*_ADDRESS`                  | Auto-populated after Chuan deploys contracts          | On-chain features        |
 
 You can leave these blank to start — the API will boot, you can hit the routes, and the UI mockups will render. The on-chain features just won't work until you populate them.
+
+> **🔑 The one secret that actually matters.** Everything except the LLM
+> credential is optional for the core demo. With **no** LLM credential the
+> stack boots and routes work, but strategy fusion / architect / passport
+> extraction return **canned** output (not real intelligence) — and it does so
+> silently. Set exactly one path in your gitignored `.env`:
+> **(A)** `ANTHROPIC_AUTH_TOKEN=<token>` + `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`
+> — this project runs on GLM; the token is delivered to **judges privately via
+> the Canteen submission** and is **never** committed to this public repo; or
+> **(B)** your own free `ANTHROPIC_API_KEY` from <https://console.anthropic.com>.
+> The exact block (with comments) is in `.env.example`. A `/health` field
+> reporting live-vs-canned so this can't fail silently is tracked in #88.
 
 ### Step 2 — Spin up the stack
 


### PR DESCRIPTION
## What

Makes `.env.example` + the README setup honest about **the one secret that actually matters** — the LLM credential — so judges (and we) don't unknowingly demo canned output. Approved by the product lead (`.env.example` is ask-first per CLAUDE.md). **No key is committed; the template stays blank.**

## Why

The strategy intelligence (fusion / architect / passport extraction) runs on **GLM via z.ai**, which the code reads from `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`. But `.env.example` only listed `ANTHROPIC_API_KEY` and said "get a key at console.anthropic.com" — it never mentioned the two vars the working path actually uses. A judge following the README verbatim gets a **silent `CannedBackend`** and never knows the engine isn't real. This is the highest-impact local-setup gap for judging.

## Changes

- **`.env.example`**: rewrites the LLM block to spell out the two supported paths — (A) Anthropic-compatible (`ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`, GLM/z.ai; **judges get this token privately via the Canteen submission**), (B) bring-your-own `ANTHROPIC_API_KEY`. Adds the two missing vars (blank). States plainly that blank ⇒ silent canned fallback. Header reworded. Stale chain-ID comment `13068200` → `5042002 / 0x4cef52` to match README/CLAUDE (addresses untouched; flagged for contracts/Chuan to verify).
- **README**: corrects the secrets table row and adds a "🔑 The one secret that actually matters" callout — the two paths, the Canteen-for-judges distribution, the public-repo rule, and a forward-ref to the `/health` live-vs-canned surface (#88).

## Key distribution (decided)

GLM token → judges **privately via arc-canteen / the Canteen submission**, never in the repo. README documents BYO-Anthropic as a zero-shared-secret fallback. Loud degradation tracked in #88.

## Verify

`grep -n ANTHROPIC .env.example` → AUTH_TOKEN + BASE_URL + API_KEY present, all blank.
