### PR TITLE
[frontend] UI fixes: sticky subnav, spacing, overflow, responsive layout

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -71,6 +71,7 @@ body {
   line-height: 1.6;
   min-height: 100vh;
   letter-spacing: -0.01em;
+  overflow-x: hidden;
 }
 
 a { color: var(--text-2); text-decoration: none; transition: color 0.15s; }

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -63,7 +63,7 @@
 }
 
 /* --- Base --- */
-html { font-size: 15px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+html { font-size: 15px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; scroll-behavior: smooth; }
 body {
   font-family: var(--sans);
   background: var(--canvas);
@@ -142,6 +142,46 @@ h4, .h4 { font-family: var(--sans); font-size: 0.8rem; font-weight: 600; text-tr
   padding: var(--space-7) var(--space-6);
   max-width: var(--max-w);
   margin: 0 auto;
+}
+
+/* --- Section subnav (Explore) --- */
+.explore-subnav {
+  position: sticky;
+  top: 56px;
+  z-index: 40;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 0;
+  margin-bottom: var(--space-5);
+  background: rgba(9, 9, 11, 0.82);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  border-bottom: 1px solid var(--glass-border);
+}
+.explore-subnav-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--text-3);
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+.explore-subnav-btn:hover {
+  color: var(--text-1);
+  background: var(--glass-hover);
+  border-color: var(--accent-muted);
+}
+.scroll-anchor { scroll-margin-top: 120px; }
+
+@media (max-width: 900px) {
+  .explore-subnav { top: 0; }
+  .scroll-anchor { scroll-margin-top: 16px; }
 }
 
 /* --- Sidebar --- */

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -546,6 +546,8 @@ h4, .h4 { font-family: var(--sans); font-size: 0.8rem; font-weight: 600; text-tr
 .mb-4 { margin-bottom: var(--space-4); }
 .mb-5 { margin-bottom: var(--space-5); }
 .mb-6 { margin-bottom: var(--space-6); }
+.mb-7 { margin-bottom: var(--space-7); }
+.mb-8 { margin-bottom: var(--space-8); }
 .mt-4 { margin-top: var(--space-4); }
 
 /* --- Modal --- */
@@ -628,7 +630,8 @@ h4, .h4 { font-family: var(--sans); font-size: 0.8rem; font-weight: 600; text-tr
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 16px;
   max-width: var(--max-w);
-  margin: 0 auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* Cards for dashboard */

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -63,7 +63,7 @@
 }
 
 /* --- Base --- */
-html { font-size: 15px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; scroll-behavior: smooth; }
+html { font-size: 15px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; scroll-behavior: smooth; overflow-x: hidden; }
 body {
   font-family: var(--sans);
   background: var(--canvas);
@@ -71,7 +71,6 @@ body {
   line-height: 1.6;
   min-height: 100vh;
   letter-spacing: -0.01em;
-  overflow-x: hidden;
 }
 
 a { color: var(--text-2); text-decoration: none; transition: color 0.15s; }
@@ -1357,6 +1356,8 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   overflow: hidden;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 .table-container table {
   width: 100%;
@@ -1999,10 +2000,9 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* Tech logos */
 .tech-logos {
-  display: flex;
-  justify-content: center;
-  gap: 24px;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 16px;
   max-width: var(--max-w);
   margin: 0 auto;
 }
@@ -2012,8 +2012,7 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
   background: var(--surface-1);
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
-  padding: 20px 24px;
-  min-width: 140px;
+  padding: 20px 16px;
 }
 
 .tech-name {
@@ -2195,6 +2194,34 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
   }
 }
 
+/* Tablet: landing section padding reduction */
+@media (max-width: 900px) {
+  .landing-features,
+  .landing-marketplace,
+  .landing-tech,
+  .landing-rigor,
+  .landing-cta {
+    padding: 48px 24px;
+  }
+
+  .landing-hero {
+    padding: 56px 24px 40px;
+  }
+
+  .features-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tier-cards {
+    grid-template-columns: 1fr;
+    max-width: 480px;
+  }
+
+  .rigor-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Phone: compact everything */
 @media (max-width: 600px) {
   :root {
@@ -2220,14 +2247,14 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
     padding: var(--space-3);
   }
 
-  /* Force single column on stat grids */
+  /* Force single column on stat grids — use kebab-case to match React DOM output */
   .grid.g-4,
-  [style*="gridTemplateColumns: repeat(4"] {
+  [style*="grid-template-columns: repeat(4"] {
     grid-template-columns: repeat(2, 1fr) !important;
     gap: 10px !important;
   }
 
-  [style*="gridTemplateColumns: repeat(5"] {
+  [style*="grid-template-columns: repeat(5"] {
     grid-template-columns: repeat(2, 1fr) !important;
   }
 
@@ -2235,12 +2262,6 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
   .form-row {
     flex-direction: column !important;
     gap: 10px !important;
-  }
-
-  /* Table scroll */
-  .table-container {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   table {
@@ -2278,6 +2299,22 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
   .swap-amount {
     font-size: 1.2rem !important;
+  }
+
+  .landing-features,
+  .landing-marketplace,
+  .landing-tech,
+  .landing-rigor,
+  .landing-cta {
+    padding: 36px 16px;
+  }
+
+  .landing-hero {
+    padding: 40px 16px 32px;
+  }
+
+  .features-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/ui/src/Marketplace.jsx
+++ b/ui/src/Marketplace.jsx
@@ -793,6 +793,19 @@ export default function Marketplace() {
         </div>
       </div>
 
+      {/* Section subnav */}
+      <nav className="explore-subnav" aria-label="Explore sections">
+        {[
+          { id: 'synthetic-assets',  label: 'Synthetic Assets' },
+          { id: 'vault-leaderboard', label: 'Vault Leaderboard' },
+          { id: 'trending',          label: 'Trending This Week' },
+          { id: 'all-strategies',    label: 'All Strategies' },
+          { id: 'agent-activity',    label: 'Agent Activity' },
+        ].map(s => (
+          <a key={s.id} href={`#${s.id}`} className="explore-subnav-btn">{s.label}</a>
+        ))}
+      </nav>
+
       {/* Ecosystem Stats */}
       <div className="grid g-4 mb-7" style={{ gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
         {[
@@ -812,7 +825,7 @@ export default function Marketplace() {
       <div className="divider" style={{ marginBottom: 24 }} />
 
       {/* Synthetic Asset Prices */}
-      <div className="mb-7">
+      <div id="synthetic-assets" className="mb-7 scroll-anchor">
         <div className="flex items-center justify-between mb-5">
           <div className="label">Synthetic Assets</div>
           <span className="caption">Live oracle prices</span>
@@ -851,7 +864,7 @@ export default function Marketplace() {
       </div>
 
       {/* Vault Leaderboard */}
-      <div className="mb-7">
+      <div id="vault-leaderboard" className="mb-7 scroll-anchor">
         <div className="flex items-center justify-between mb-5">
           <div className="label">Vault Leaderboard</div>
           <div className="flex gap-2">
@@ -945,7 +958,7 @@ export default function Marketplace() {
 
       {/* Trending Strategies */}
       {trendingStrategies.length > 0 && (
-        <div className="mb-7">
+        <div id="trending" className="mb-7 scroll-anchor">
           <div className="flex items-center justify-between mb-5">
             <div className="label flex items-center gap-2"><span>🔥</span> Trending This Week</div>
             <span className="caption">Highest user growth in the last 7 days</span>
@@ -967,7 +980,7 @@ export default function Marketplace() {
 
       {/* All Strategies */}
       {!loadingStrategies && (
-        <div className="mb-7">
+        <div id="all-strategies" className="mb-7 scroll-anchor">
           <div className="flex items-center justify-between mb-5">
             <div className="label">All Strategies</div>
             <div className="flex gap-2 items-center">
@@ -1048,7 +1061,7 @@ export default function Marketplace() {
       )}
 
       {/* Agent Activity */}
-      <div>
+      <div id="agent-activity" className="scroll-anchor">
         <div className="flex items-center justify-between mb-5">
           <div className="label">Agent Activity</div>
         </div>

--- a/ui/src/Marketplace.jsx
+++ b/ui/src/Marketplace.jsx
@@ -1061,7 +1061,7 @@ export default function Marketplace() {
       )}
 
       {/* Agent Activity */}
-      <div id="agent-activity" className="scroll-anchor">
+      <div id="agent-activity" className="mb-7 scroll-anchor">
         <div className="flex items-center justify-between mb-5">
           <div className="label">Agent Activity</div>
         </div>

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -50,8 +50,8 @@ export default function Landing({ onNavigate, onConnect, walletAddr }) {
             <span className="hero-title-dim">Autonomously Managed.</span>
           </h1>
           <p className="hero-subtitle">
-            Archimedes turns published quant research into investable strategies,
-            then constructs personalized portfolios of synthetic RWA tokens on Arc
+            Archimedes turns published quant research into investable strategies.<br/>
+            It constructs personalized portfolios of synthetic RWA tokens on Arc<br/>
             — with every decision hashed and verifiable on-chain.
           </p>
           <div className="hero-actions">
@@ -300,7 +300,8 @@ export default function Landing({ onNavigate, onConnect, walletAddr }) {
         <h2>Give me a lever long enough<br />and I shall move the world.</h2>
         <p className="cta-quote">— Archimedes (paraphrased)</p>
         <p className="cta-sub">
-          The lever is academic research. The fulcrum is autonomous AI.
+          The lever is academic research.<br/>
+          The fulcrum is autonomous AI.<br/>
           The world is your portfolio.
         </p>
         <div className="hero-actions">

--- a/ui/src/components/Trade.jsx
+++ b/ui/src/components/Trade.jsx
@@ -336,7 +336,7 @@ export default function Trade() {
             <div className="positions-empty fade-up fade-up-1">
               <div style={{ fontSize: '2rem', marginBottom: 10 }}>💧</div>
               <strong>No LP positions detected</strong>
-              <p className="caption" style={{ marginTop: 8, maxWidth: 440 }}>Add liquidity from the Liquidity tab to see pool shares, fees earned, and vault-token premium/discount here.</p>
+              <p className="caption" style={{ margin: '8px auto 0', maxWidth: 440 }}>Add liquidity from the Liquidity tab to see pool shares, fees earned, and vault-token premium/discount here.</p>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

- **Sticky section subnav** on Explore page — anchors to Synthetic Assets, Vault Leaderboard, Agent Activity; stays visible while scrolling
- **Fixed `overflow-x: hidden` placement** — moved from `body` to `html` to restore `position: sticky` behaviour (body as scroll container was breaking it)
- **Added missing `mb-7` / `mb-8` utility classes** — used throughout Marketplace but never defined, causing all section gaps to be 0px
- **Fixed `.grid` margin shorthand** — `margin: 0 auto` was zeroing `margin-bottom` on elements also carrying `mb-*` classes; changed to `margin-left / margin-right: auto`
- **Fixed My Positions empty-state centering** — block element with `max-width` needed `margin: auto` to centre itself, not just `text-align: center` from parent
- **Responsive layout fixes** — CSS attribute selectors corrected to kebab-case (`grid-template-columns`), mobile breakpoints added for landing sections, Built-On row switched to CSS grid `auto-fit`
- **Landing copy** — `<br/>` line breaks added to hero subtitle and CTA text per Marten's feedback