### PR TITLE
[quant] Fix DSR kurtosis convention and regen script robustness

### DIFF
--- a/analytics-engine/scripts/regen_buy_hold_fixture.py
+++ b/analytics-engine/scripts/regen_buy_hold_fixture.py
@@ -174,15 +174,19 @@ def _compute_passes_rigor_gate(
     pbo_score: float | None,
     look_ahead_passed: bool | None,
 ) -> bool:
-    """Recompute the rigor gate — mirrors BacktestResult.passes_rigor_gate exactly.
+    """Recompute the rigor gate from fresh metrics.
 
-    Criteria (in order):
+    Mirrors BacktestResult.passes_rigor_gate criteria 1–6:
       1. Base validation passes (Sharpe/DD/CAGR/trade-count).
       2. DSR value, p-value, and num_trials all populated.
       3. DSR p-value >= 0.95.
       4. PBO score populated and < 0.5 (strictly; >= 0.5 fails).
       5. Look-ahead audit passed.
       6. OOS Sharpe populated; if full Sharpe > 0, OOS/full >= 0.5.
+
+    Note: omits the sharpe_vs_paper >= 0.5 check (criterion 7) because
+    pipeline_buy_hold has no paper_claimed_sharpe. If this helper is ever
+    reused for a paper-grounded strategy, add that check.
     """
     if not passes_validation:
         return False
@@ -274,7 +278,7 @@ def main(write: bool = False) -> None:
         "passes_rigor_gate": _compute_passes_rigor_gate(
             passes_validation=(
                 result.sharpe_ratio is not None and result.sharpe_ratio > 0.5
-                and max_dd_frac < 0.5
+                and result.max_drawdown_pct is not None and max_dd_frac < 0.5
                 and result.cagr is not None and result.cagr < 10.0
                 and (result.total_trades < 2 or result.total_trades >= 10)
             ),

--- a/analytics-engine/scripts/regen_buy_hold_fixture.py
+++ b/analytics-engine/scripts/regen_buy_hold_fixture.py
@@ -29,7 +29,7 @@ BACKTEST_START = "2004-01-02"
 BACKTEST_END = "2026-05-01"  # yfinance end is exclusive; includes bars through 2026-04-30
 INITIAL_CASH = 100_000.0
 TX_COST_BPS = 10
-NUM_TRIALS = 6  # total strategies in the current library (for DSR correction)
+_FIXTURE_PATH = ROOT / "strategies" / "backtest_fixtures.json"
 _EULER = 0.5772156649
 _ANN = 252
 
@@ -81,12 +81,13 @@ def _skew(arr: np.ndarray) -> float:
     return float(np.mean(m ** 3)) / m2 ** 1.5
 
 
-def _excess_kurtosis(arr: np.ndarray) -> float:
+def _raw_kurtosis(arr: np.ndarray) -> float:
+    """Pearson (raw) kurtosis — normal distribution = 3. DSR formula requires this."""
     m = arr - arr.mean()
     m2 = float(np.mean(m ** 2))
     if m2 == 0:
         return 0.0
-    return float(np.mean(m ** 4)) / m2 ** 2 - 3.0
+    return float(np.mean(m ** 4)) / m2 ** 2
 
 
 # ── Rigor metrics ─────────────────────────────────────────────────────────────
@@ -105,7 +106,7 @@ def compute_dsr(
 
     sr_hat = float(arr.mean()) / sigma
     g3 = _skew(arr)
-    g4 = _excess_kurtosis(arr)
+    g4 = _raw_kurtosis(arr)  # Pearson raw kurtosis; DSR formula uses (γ₄−1)/4
     trials = max(1, num_trials)
 
     if trials == 1:
@@ -164,6 +165,10 @@ def compute_kelly(
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main(write: bool = False) -> None:
+    fixtures = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    num_trials = len(fixtures)
+    existing = fixtures.get("pipeline_buy_hold", {})
+
     print(f"Fetching SPY {BACKTEST_START} → {BACKTEST_END}…")
     prices = fetch_ohlcv("SPY", BACKTEST_START, BACKTEST_END)
     print(f"  {len(prices)} bars  "
@@ -183,7 +188,7 @@ def main(write: bool = False) -> None:
           f"  Final: ${result.final_value:,.0f}")
 
     daily = result.daily_returns
-    dsr, dsr_p = compute_dsr(daily, NUM_TRIALS)
+    dsr, dsr_p = compute_dsr(daily, num_trials)
     oos = compute_oos_sharpe(daily)
     kelly = compute_kelly(daily)
     print(f"  DSR: {dsr}  p={dsr_p}  OOS Sharpe: {oos}  Kelly: {kelly}")
@@ -218,11 +223,10 @@ def main(write: bool = False) -> None:
         "paper_claimed_max_dd": None,
         "deflated_sharpe_ratio": dsr,
         "dsr_p_value": dsr_p,
-        "num_trials_in_selection": NUM_TRIALS,
-        # PBO requires all strategies' daily returns simultaneously.
-        # Reuse existing value; flag for full cross-strategy recompute.
-        "pbo_score": 0.3899,
-        "passes_rigor_gate": False,
+        "num_trials_in_selection": num_trials,
+        # PBO requires all strategies' daily returns simultaneously; carry forward.
+        "pbo_score": existing.get("pbo_score"),
+        "passes_rigor_gate": existing.get("passes_rigor_gate", False),
         "kelly_fraction": kelly,
     }
 

--- a/analytics-engine/scripts/regen_buy_hold_fixture.py
+++ b/analytics-engine/scripts/regen_buy_hold_fixture.py
@@ -162,10 +162,39 @@ def compute_kelly(
     return round(float(np.clip(fractional * excess / sigma_sq_ann, 0.0, 1.0)), 6)
 
 
+# ── Rigor gate ────────────────────────────────────────────────────────────────
+
+def _compute_passes_rigor_gate(
+    dsr_p: float | None,
+    full_sharpe: float | None,
+    oos_sharpe: float | None,
+    pbo_score: float | None,
+    look_ahead_passed: bool | None,
+) -> bool:
+    """Recompute the rigor gate from fresh metrics (mirrors rigor_evaluator thresholds).
+
+    Gate: DSR p-value ≥ 0.95, OOS Sharpe ≥ 50% of full-sample Sharpe,
+    PBO score ≤ 0.5, and look-ahead audit passed.
+    """
+    if dsr_p is None or dsr_p < 0.95:
+        return False
+    if full_sharpe is None or oos_sharpe is None or oos_sharpe < 0.5 * full_sharpe:
+        return False
+    if pbo_score is None or pbo_score > 0.5:
+        return False
+    return bool(look_ahead_passed)
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main(write: bool = False) -> None:
-    fixtures = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    try:
+        fixtures = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            f"Cannot read fixture file {_FIXTURE_PATH}: {exc}\n"
+            "Run from the analytics-engine directory with an existing backtest_fixtures.json."
+        ) from exc
     num_trials = len(fixtures)
     existing = fixtures.get("pipeline_buy_hold", {})
 
@@ -226,7 +255,13 @@ def main(write: bool = False) -> None:
         "num_trials_in_selection": num_trials,
         # PBO requires all strategies' daily returns simultaneously; carry forward.
         "pbo_score": existing.get("pbo_score"),
-        "passes_rigor_gate": existing.get("passes_rigor_gate", False),
+        "passes_rigor_gate": _compute_passes_rigor_gate(
+            dsr_p=dsr_p,
+            full_sharpe=result.sharpe_ratio,
+            oos_sharpe=oos,
+            pbo_score=existing.get("pbo_score"),
+            look_ahead_passed=result.look_ahead_audit_passed,
+        ),
         "kelly_fraction": kelly,
     }
 
@@ -234,13 +269,11 @@ def main(write: bool = False) -> None:
     print(json.dumps({"pipeline_buy_hold": entry}, indent=2))
 
     if write:
-        fixture_path = ROOT / "strategies" / "backtest_fixtures.json"
-        fixtures = json.loads(fixture_path.read_text(encoding="utf-8"))
         fixtures["pipeline_buy_hold"] = entry
-        fixture_path.write_text(
+        _FIXTURE_PATH.write_text(
             json.dumps(fixtures, indent=2) + "\n", encoding="utf-8"
         )
-        print(f"\n✓ Written to {fixture_path}")
+        print(f"\n✓ Written to {_FIXTURE_PATH}")
 
 
 if __name__ == "__main__":

--- a/analytics-engine/scripts/regen_buy_hold_fixture.py
+++ b/analytics-engine/scripts/regen_buy_hold_fixture.py
@@ -165,24 +165,40 @@ def compute_kelly(
 # ── Rigor gate ────────────────────────────────────────────────────────────────
 
 def _compute_passes_rigor_gate(
+    passes_validation: bool,
+    dsr: float | None,
     dsr_p: float | None,
+    num_trials: int | None,
     full_sharpe: float | None,
     oos_sharpe: float | None,
     pbo_score: float | None,
     look_ahead_passed: bool | None,
 ) -> bool:
-    """Recompute the rigor gate from fresh metrics (mirrors rigor_evaluator thresholds).
+    """Recompute the rigor gate — mirrors BacktestResult.passes_rigor_gate exactly.
 
-    Gate: DSR p-value ≥ 0.95, OOS Sharpe ≥ 50% of full-sample Sharpe,
-    PBO score ≤ 0.5, and look-ahead audit passed.
+    Criteria (in order):
+      1. Base validation passes (Sharpe/DD/CAGR/trade-count).
+      2. DSR value, p-value, and num_trials all populated.
+      3. DSR p-value >= 0.95.
+      4. PBO score populated and < 0.5 (strictly; >= 0.5 fails).
+      5. Look-ahead audit passed.
+      6. OOS Sharpe populated; if full Sharpe > 0, OOS/full >= 0.5.
     """
-    if dsr_p is None or dsr_p < 0.95:
+    if not passes_validation:
         return False
-    if full_sharpe is None or oos_sharpe is None or oos_sharpe < 0.5 * full_sharpe:
+    if dsr is None or dsr_p is None or num_trials is None:
         return False
-    if pbo_score is None or pbo_score > 0.5:
+    if dsr_p < 0.95:
         return False
-    return bool(look_ahead_passed)
+    if pbo_score is None or pbo_score >= 0.5:
+        return False
+    if look_ahead_passed is not True:
+        return False
+    if oos_sharpe is None:
+        return False
+    if full_sharpe is not None and full_sharpe > 0 and oos_sharpe / full_sharpe < 0.5:
+        return False
+    return True
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -256,7 +272,15 @@ def main(write: bool = False) -> None:
         # PBO requires all strategies' daily returns simultaneously; carry forward.
         "pbo_score": existing.get("pbo_score"),
         "passes_rigor_gate": _compute_passes_rigor_gate(
+            passes_validation=(
+                result.sharpe_ratio is not None and result.sharpe_ratio > 0.5
+                and max_dd_frac < 0.5
+                and result.cagr is not None and result.cagr < 10.0
+                and (result.total_trades < 2 or result.total_trades >= 10)
+            ),
+            dsr=dsr,
             dsr_p=dsr_p,
+            num_trials=num_trials,
             full_sharpe=result.sharpe_ratio,
             oos_sharpe=oos,
             pbo_score=existing.get("pbo_score"),

--- a/analytics-engine/scripts/regen_buy_hold_fixture.py
+++ b/analytics-engine/scripts/regen_buy_hold_fixture.py
@@ -213,7 +213,7 @@ def main(write: bool = False) -> None:
     except (FileNotFoundError, json.JSONDecodeError) as exc:
         raise SystemExit(
             f"Cannot read fixture file {_FIXTURE_PATH}: {exc}\n"
-            "Run from the analytics-engine directory with an existing backtest_fixtures.json."
+            f"Ensure the fixture file exists at {_FIXTURE_PATH} and contains valid JSON."
         ) from exc
     num_trials = len(fixtures)
     existing = fixtures.get("pipeline_buy_hold", {})
@@ -242,7 +242,9 @@ def main(write: bool = False) -> None:
     kelly = compute_kelly(daily)
     print(f"  DSR: {dsr}  p={dsr_p}  OOS Sharpe: {oos}  Kelly: {kelly}")
 
-    max_dd_frac = (result.max_drawdown_pct or 0.0) / 100.0
+    if result.max_drawdown_pct is None:
+        raise SystemExit("Backtest returned no max_drawdown_pct; cannot write a valid fixture.")
+    max_dd_frac = result.max_drawdown_pct / 100.0
     calmar = None
     if result.cagr is not None and max_dd_frac > 0:
         calmar = round(result.cagr / max_dd_frac, 7)
@@ -278,7 +280,7 @@ def main(write: bool = False) -> None:
         "passes_rigor_gate": _compute_passes_rigor_gate(
             passes_validation=(
                 result.sharpe_ratio is not None and result.sharpe_ratio > 0.5
-                and result.max_drawdown_pct is not None and max_dd_frac < 0.5
+                and max_dd_frac < 0.5
                 and result.cagr is not None and result.cagr < 10.0
                 and (result.total_trades < 2 or result.total_trades >= 10)
             ),

--- a/analytics-engine/strategies/pipeline_buy_hold.py
+++ b/analytics-engine/strategies/pipeline_buy_hold.py
@@ -18,7 +18,7 @@ PAPER_CLAIMED_MAX_DD = None
 
 STATUS = "live"
 
-# Backtest results — REAL (run via scripts/regen_buy_hold_fixture.py, 2004-01-02 → 2026-04-29)
+# Backtest results — REAL (run via scripts/regen_buy_hold_fixture.py, 2004-01-02 → 2026-04-30)
 # SPY buy-and-hold over full available history including 2008-09 crisis and 2022 correction
 BACKTEST_SHARPE = 0.5371
 BACKTEST_CAGR = 0.0864

--- a/backend/archimedes/models/backtest.py
+++ b/backend/archimedes/models/backtest.py
@@ -125,9 +125,6 @@ class BacktestResult:
     def passes_validation(self) -> bool:
         """Quick check against design.md § 4.2 validation criteria.
 
-        Preserves the original behavior for backward compatibility with
-        callers that only look at raw Sharpe/DD/CAGR/trade count.
-
         Trade-count rule: always-on and buy-and-hold strategies produce 0 or 1
         closed trades in backtrader (position never exits). For these, trade
         count is meaningless as a quality signal; the Sharpe/DD/CAGR checks are


### PR DESCRIPTION
## Summary

Follow-up to PR #108 addressing Copilot review comments across three rounds.

### Round 1 — kurtosis, NUM_TRIALS, pbo carryforward, docstring, date
- **DSR kurtosis bug (High):** `regen_buy_hold_fixture.py` was computing Fisher excess kurtosis (normal = 0) and passing it to the DSR formula, which expects Pearson raw kurtosis (normal = 3) per Bailey & López de Prado 2014. Renamed `_excess_kurtosis → _raw_kurtosis` and removed the `−3.0` offset, matching `rigor_evaluator.py` (`fisher=False`).
- **Hard-coded `NUM_TRIALS = 6` (Medium):** Replaced with `len(fixtures)` read live from the fixture file so the DSR multiple-testing correction stays accurate as the library grows.
- **Hard-coded `pbo_score` / `passes_rigor_gate` (Medium):** `pbo_score` is now carried forward from the existing fixture (PBO can't be recomputed without all strategies' returns simultaneously). `passes_rigor_gate` is **recomputed** from the freshly computed metrics via `_compute_passes_rigor_gate()`.
- **Misleading docstring (Medium):** Removed the "backward compatibility" sentence from `passes_validation`.
- **Off-by-one date in comment (Low):** Fixed `2026-04-29` → `2026-04-30`.

### Round 2 — defensive IO, gate recomputation, path deduplication
- **Bare crash on missing fixture (Medium):** Added `try/except (FileNotFoundError, JSONDecodeError)` with a clear `SystemExit` message.
- **`passes_rigor_gate` recomputed (High):** Added `_compute_passes_rigor_gate()` that derives the gate deterministically from fresh metrics instead of carrying the stale value forward. Mirrors `BacktestResult.passes_rigor_gate` logic.
- **`_FIXTURE_PATH` deduplication (Low):** Write block now uses `_FIXTURE_PATH` and the already-loaded `fixtures` dict; dropped the redundant inline path redefinition and second `json.loads()`.

### Round 3 — exact gate parity, null-drawdown guard, docstring
- **`pbo_score >= 0.5` bug (Medium):** Was `> 0.5`; backend rejects at exactly 0.5.
- **Missing `passes_validation` prerequisite (Medium):** Gate now checks Sharpe/DD/CAGR/trade-count before the DSR/PBO/OOS checks.
- **Missing null checks (Medium):** Added `deflated_sharpe_ratio is not None`, `num_trials is not None`, and the `sharpe_ratio > 0` guard on the OOS ratio check.
- **Null drawdown passes validation (Medium):** `max_dd_frac` derived from `(max_drawdown_pct or 0.0)/100` silently treated `None` as `0.0`. Added `max_drawdown_pct is not None` guard.
- **Docstring overpromise (Medium):** Softened "mirrors ... exactly" to document the intentional omission of the `sharpe_vs_paper` check (not applicable to buy-and-hold which has no `paper_claimed_sharpe`).

> Note: the stored `deflated_sharpe_ratio` and `dsr_p_value` in the `pipeline_buy_hold` fixture entry were computed with the old (wrong) kurtosis convention. Run `uv run python scripts/regen_buy_hold_fixture.py --write` from `analytics-engine/` to regenerate with corrected values.