### PR TITLE
[docs] Day-9 sweep: user-stories rewrite + UI simplification proposal + design-prompts refresh + new corpus-architecture doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@
 > - [`docs/specs/strategy-passport-spec.md`](docs/specs/strategy-passport-spec.md) +
 >   [`docs/specs/selection-bias-corrections-spec.md`](docs/specs/selection-bias-corrections-spec.md)
 >   — the four-primitive admission gate for Tier 1 strategies
+> - [`docs/corpus-architecture.md`](docs/corpus-architecture.md) — Day-9 reference
+>   for how the 10k q-fin corpus is built, stored, and fused into strategies
+>   (seed/intake/artifact + the fusion path)
 > - [`docs/agora_project_analysis.md`](docs/agora_project_analysis.md) — red-team synthesis
 >   driving the Day-3 rigor-as-wedge framing
 

--- a/docs/claude-design-prompts.md
+++ b/docs/claude-design-prompts.md
@@ -1,14 +1,21 @@
 # Claude Design — Prompts for Archimedes
 
-> **Audience:** Dan (using Claude Design at [claude.ai/design](https://claude.ai/design))
-> **Purpose:** Concrete prompts to paste into Claude Design for slides, UI prototypes,
-> and logo variants. Each prompt is self-contained so the design session has the context
-> it needs without you re-explaining the project.
-> **Status:** Day-4 revision (2026-05-14). Prompts updated to match what the team has
-> actually shipped — a live React/Vite UI at [`http://18.171.230.205/`](http://18.171.230.205/),
-> 10 contracts deployed on Arc testnet, and the
-> [`architecture-diagram.html`](architecture-diagram.html) reference. The UI prompts now
-> work as **refinement** prompts against the live UI rather than greenfield design.
+> **Audience:** Dan (and anyone on the team) using Claude Design at
+> [claude.ai/design](https://claude.ai/design).
+> **Purpose:** Concrete, paste-ready prompts for slides, UI prototypes, logos, and
+> explanatory visualizations. Each prompt is self-contained so the design session has
+> the context it needs without you re-explaining the project.
+> **Status:** Day-9 revision (2026-05-20). Significant cleanup against Day-4 content
+> that had drifted out of sync with shipped reality. Current snapshot the prompts
+> reflect: live React/Vite UI at [`http://18.171.230.205/`](http://18.171.230.205/);
+> 10 Arc-testnet contracts; engine v2 (`POST /api/strategies/generate` with 3-input
+> fusion); the full rigor wedge live (DSR/PBO/Kelly/MVO, 2 Tier-1 strategies — Faber
+> 2007 + Moreira-Muir 2017 — with real 22-year SPY backtest numbers); a DB-backed
+> 10,000-paper q-fin corpus with the Corpus Explorer UI shipped; "Linus for
+> quantitative finance" as the locked product framing per
+> [`docs/user-stories.md`](user-stories.md); 265 backend tests + 16 analytics-engine
+> tests green; 5 days to submission. UI prompts work as **refinement** prompts
+> against the live UI, not greenfield.
 
 ## Quick notes on using Claude Design
 
@@ -184,316 +191,440 @@ that looks like it could be a generic crypto logo.
 
 ---
 
-## Prompt 2 — Slide deck (full 9 slides)
+## Prompt 2 — Slide deck (full 10 slides, Day-9 framing)
 
 **Setup notes:** Use Claude Design's **Slide deck** mode. Make sure the design system is
-set (or pass colors inline). The deck structure mirrors
-[`demo-script-pitch-deck-outline.md`](demo-script-pitch-deck-outline.md).
+set (or paste the palette/typography block inline). The deck structure mirrors
+[`demo-script-pitch-deck-outline.md`](demo-script-pitch-deck-outline.md). The
+substantive Day-9 shifts vs the Day-4 deck: the product is now framed as **"Linus for
+quantitative finance"** (a strategy-generation *instrument*, not a static menu); the
+3-input fusion engine (engine v2) is live; the rigor wedge is real with 22 years of
+SPY data; 2 Tier-1 strategies actually pass the gate. The deck should sound like the
+product, not aspire to it.
 
 ```
 Project: Archimedes — pitch deck for the Agora Agents Hackathon (Canteen × Circle ×
 Arc), submission deadline May 25, 2026. 3-minute pitch + live demo + Q&A.
 
-The deck has 9 slides. Visual style: clean, professional, financial-grade. Think a
-crossover between Wealthfront's marketing site and a serious crypto-native product
-like Circle's own site or Arc.network. Color palette: dark mode primary
-(near-black background, off-white text), with a single brand color accent — use deep
-blue (#2A4DD1 or similar) or violet (#7B2CBF). Typography: a clean serif for
-headlines (the academic-rigor cue), a modern sans-serif for body. No clip art, no
-emojis, no busy decoration.
+The deck is 10 slides. Visual style: clean, professional, financial-grade. Think a
+crossover between Wealthfront's marketing and Arc.network / Stripe / Linear. Dark-mode
+primary (#0E1116 background, #F3F4F6 text), single brand accent (#2A4DD1 deep blue
+OR #7B2CBF violet — pick one and commit). Serif for headlines (Crimson Pro or Source
+Serif Pro — the academic cue); sans for body (Inter or Geist Sans); monospace for
+hashes, addresses, paper IDs. No clip art, no emojis in the artifact, no busy
+decoration, no Greek-temple imagery.
 
-Use this slide-by-slide content:
+Slide-by-slide content:
 
 SLIDE 1 — Title
 Header: Archimedes
-Tagline: Peer-reviewed AI portfolios, settled on Arc.
-Subtitle: The original empiricist meets autonomous on-chain finance.
+Tagline: Linus for quantitative finance.
+Subtitle: A research-grounded strategy-generation instrument — fusion + rigor +
+on-chain provenance, on Arc.
 Attribution: Agora Agents Hackathon — Canteen × Circle × Arc, May 11–25, 2026
 
-SLIDE 2 — The problem
-Title: Today's portfolio products force a tradeoff.
-Three columns:
-- TradFi robo-advisors (Wealthfront, Betterment): rule-based, opaque,
-  no on-chain settlement.
-- DeFi yield aggregators (Yearn, Yield Seeker): chase current yields,
-  no academic rigor, stablecoin-only.
-- AI-flavored crypto agents (Virtuals, SingularityDAO, Theoriq):
-  token-mediated speculation, reasoning opaque.
-Empty fourth column with a "?" — implying Archimedes goes here.
+SLIDE 2 — The problem (one paragraph, centered, no bullets)
+Title: AI portfolio tools today are unfalsifiable.
+Body: "Robo-advisors are rule-based black boxes. AI-flavored crypto agents are
+token-mediated speculation with opaque reasoning. Both ask you to trust. Neither
+surfaces the research their claims rest on — and neither gates against the failure
+mode that breaks most quant strategies in production: in-sample overfitting that
+doesn't survive contact with reality."
+Small footer line: "Curation crisis Nov 2025: $400M+ in DeFi vault losses driven by
+exactly this gap."
 
-SLIDE 3 — What we built
-Title: Archimedes — Peer-reviewed AI portfolios on Arc
-Five bullets with icons:
-- Paper-grounded strategy passport — paper citation + methodology hash + paper-claim
-  delta surfaced honestly (3 strategies seeded: Faber 2007, Moreira-Muir 2017,
-  Moskowitz-Ooi-Pedersen 2012 + buy-and-hold baseline).
-- Selection-bias gate (DSR + PBO + walk-forward OOS + look-ahead audit) at admission.
-- Autonomous agent: regime detection → strategy rotation → rebalancing, with every
-  decision producing a reasoning trace.
-- 10 contracts on Arc testnet today — Vault, AMM, Synthetic Factory, Reasoning Trace
-  Registry — with multi-wallet UX (MetaMask / Coinbase / generic).
-- Commit-reveal trace anchoring: "trace existed *before* the trade," verifiable
-  on-chain.
-Background: stylized version of the architecture diagram from
-docs/architecture-diagram.html (Strategy Engine + Passport → Selection-Bias Gate →
-Autonomous Portfolio Agent → ReasoningTraceRegistry on Arc).
+SLIDE 3 — The product (the spine)
+Title: Describe → Generate → Rigor-gate → Execute → Monitor → Explore
+A horizontal 6-step subway map (see Prompt 9 below for the standalone version). Each
+stop has an icon + one-line caption. Two of the stops are tagged "User" (Describe,
+Monitor+Explore); the others are tagged "System." Below the track, a thin banner:
+"Every step's reasoning is hashed and anchored on Arc — anyone can verify."
 
-SLIDE 4 — DEMO
-Full-bleed slide: just the word "DEMO" in large type, with a small URL underneath —
-either archimedes.hackagora.com (if locked) or 18.171.230.205 (the EC2 IP fallback,
-which works today). This slide gets minimum 90 seconds of live demo time.
+SLIDE 4 — What's actually built (status as of submission)
+Title: Shipped, not planned.
+Two columns:
 
-SLIDE 5 — Competitive landscape
-Title: We fill the gap.
-A two-column "what others do vs. what we do" layout. Reuse the content from the
-competitive slide in demo-script-pitch-deck-outline.md (paste in if Claude Design
-needs it).
-Bottom tagline: "Rule-based, opaque, or token-mediated → AI-driven, paper-
-provenanced, USDC-native"
+LEFT — Generation + intelligence
+- 3-input fusion engine live: user brief × live market regime × 10,000-paper q-fin
+  corpus → grounded strategy
+- 10,000 q-fin papers in a Postgres-canonical corpus with the Corpus Explorer UI
+- 5 reference strategies (Faber 2007 SMA200, Moreira-Muir 2017 vol-managed,
+  Moskowitz-Ooi-Pedersen 2012 TSMOM, George-Hwang 2004 52-week high, buy-and-hold)
+  + a Fixed Income tier for capital-preservation
+- 22 years of real SPY backtest data — no placeholder numbers anywhere
 
-SLIDE 6 — Why we'll score well
-Title: How Archimedes maps to the judging criteria
+RIGHT — Rigor + on-chain
+- Selection-bias gate live: Deflated Sharpe (Bailey & López de Prado 2014) +
+  Probability of Backtest Overfitting (CSCV) + walk-forward OOS + look-ahead audit
+- 2 Tier-1 strategies passing all four gates today (Faber, Moreira-Muir) —
+  the failures are visible, not hidden
+- 10 Arc-testnet contracts deployed: Vault, VaultFactory, SyntheticVault,
+  SyntheticFactory, SyntheticToken, AMMPool, AMMRouter, AssetRegistry,
+  PriceOracle, ReasoningTraceRegistry
+- Multi-wallet UX (MetaMask / Coinbase / generic). 265 backend tests + 16
+  analytics-engine tests green.
+
+SLIDE 5 — DEMO
+Full-bleed slide: the word "DEMO" in large serif type, brand accent, with the live
+URL below in monospace: "http://18.171.230.205" (or the locked domain once announced).
+This slide is the demo timer — minimum 90 seconds of live click-through, ending on
+a strategy passport showing the DSR p-value + PBO + OOS Sharpe + the source-paper
+citations.
+
+SLIDE 6 — The wedge (why "research-grounded" is real)
+Title: We fill the gap others can't.
+A 3-column comparison:
+- TradFi robos (Wealthfront, Betterment): rule-based · opaque · no on-chain
+  settlement · no research provenance
+- DeFi yield (Yearn, Morpho's curated vaults): chase live yield · curation
+  without proof · documented losses in Nov-2025 curation crisis
+- AI crypto agents (Virtuals, SingularityDAO, Theoriq): token-mediated
+  speculation · opaque reasoning · no rigor gate
+- ARCHIMEDES (highlighted column): research-grounded generation · selection-bias
+  rigor gate · on-chain reasoning trace · non-custodial settlement on Arc
+Bottom callout: "Curation-without-proof is the industry default. Curation-with-proof
+is the wedge."
+
+SLIDE 7 — Why we'll score well (judging criteria)
+Title: How Archimedes maps to the rubric.
 Four columns (one per criterion):
-- Agentic Sophistication (30%): regime detection, autonomous rebalancing,
-  strategy rotation, on-chain reasoning traces.
-- Traction (30%): pre-curated strategies, day-1 portfolios, strategy
-  leaderboard, target 50+ users.
-- Circle Tool Usage (20%): Wallets, USYC, CCTP, Gateway, Paymaster,
-  Contracts — full stack.
-- Innovation (20%): paper-grounded provenance, on-chain reasoning traces,
-  academic accountability for autonomous trading.
-RFB tagline at bottom: "RFB 04 primary. RFB 02 math primitive. RFB 06 adjacent."
+- Agentic Sophistication (30%): 3-input fusion, autonomous rebalancing on regime
+  change, on-chain reasoning traces, agentic-issue pipeline self-iterating the
+  codebase.
+- Traction (30%): live testnet deploy, arc-canteen telemetry surface wired,
+  coordinated launch within submission window.
+- Circle Tool Usage (20%): Wallets, USYC, CCTP, Gateway, Paymaster, full
+  Contracts stack on Arc.
+- Innovation (20%): paper-grounded provenance, externally-verifiable rigor gate
+  (DSR/PBO), commit-reveal trace anchoring (provable causal ordering).
+RFB tagline: "RFB 04 primary. RFB 02 math primitive. RFB 06 adjacent."
 
-SLIDE 7 — Why now
-Title: The agent economy is real.
+SLIDE 8 — Why now (one slide, 3 numbers)
+Title: The agent economy is real, but unaccountable.
 Three big-number callouts:
 - $222M — Circle Arc presale at $3B FDV, May 11, 2026 (BlackRock among investors)
-- 700K tx/month — Olas Pearl, 30% MoM growth
-- $470M aGDP — Virtuals Protocol, 18K+ agents
-Sub-tagline: "But nobody is building paper-grounded, verifiably auditable
-portfolio agents. That's the gap."
+- $400M+ — DeFi curated-vault losses in the Nov 2025 curation crisis
+- 18,000+ — AI agents deployed via Virtuals Protocol ($470M aGDP)
+Sub-tagline: "Capital is flowing into agentic finance faster than accountability is
+being built. Archimedes is the accountability layer."
 
-SLIDE 8 — Roadmap
-Title: What we ship next.
-A horizontal timeline with four milestones:
-- Now: Hackathon submission, curated v1 library, autonomous rebalancing on Arc.
-- 30 days: Productize the arxiv ingest pipeline.
-- 90 days: Strategy marketplace, EURC support, DAO-governed curation.
-- 180 days: v2 verticals (prediction markets, perp-aware portfolios).
+SLIDE 9 — Honest framing (the "anti-claims" slide)
+Title: What we're NOT promising.
+Three bullets, plain text, no decoration:
+- We don't promise alpha. We promise *evidence-grounded generation with externally
+  verifiable rigor*. Past performance, even of validated strategies, doesn't
+  guarantee future returns.
+- Arc is testnet — by design. Putting real funds on a chain that's <6 months from
+  mainnet would be reckless. The contracts are real; the settlement is real
+  testnet USDC.
+- The corpus is generated-from, not retrieved-from. The LLM reads cited papers
+  and produces a strategy spec; it does not lift strategies verbatim from any
+  single paper.
+Sub-tagline: "Honest framing is the wedge. Anyone can promise 100x. We can
+*prove* what our agent reasoned about and why."
 
-SLIDE 9 — Team + ask
+SLIDE 10 — Team + ask
 Title: The team.
-5 photos + one-line credentials:
-- Dan Browne — PhD biochemistry, LanzaTech.
-- Marten Windler — Systems Engineering, U. Bremen.
-- Daniel Reis dos Santos — Backend engineer, distributed systems.
-- Chuan Bai — CTO @ Gyld Finance; ex-CoinShares trading platform.
-- Önder Akkaya — ASA Statistical Insight World Champion; trainee actuary.
+5 names + one-line credentials each:
+- Dan Browne — Senior Scientist @ LanzaTech, PhD biochemistry. Strategy engine, pitch.
+- Marten Windler — Systems Engineering, U. Bremen. Off-chain ↔ on-chain integration.
+- Daniel Reis dos Santos — Backend engineer, distributed systems. Frontend lead.
+- Chuan Bai — CTO @ Gyld Finance; ex-CoinShares trading platform. Contracts + infra.
+- Önder Akkaya — ASA Statistical Insight World Champion. Portfolio math + rigor.
+5 timezones, 5 days, a day-job constraint on two of us, and we shipped it.
 
-Ask: "We're asking for: feedback on the strategy passport as a candidate open
-standard; introductions to quant researchers who'd contribute strategies;
-partnerships with RWA-token issuers."
+Ask: "Feedback on the strategy passport as a candidate open standard. Introductions
+to quant researchers who'd contribute strategies. Partnerships with RWA-token
+issuers who want their assets in research-grounded portfolios."
 
 End-of-deck tagline: "The lever is academic research. The fulcrum is autonomous AI.
 The world is your portfolio."
 
-Generate all 9 slides. Maintain visual consistency throughout — same color palette,
-same typography, same density of information.
+Generate all 10 slides with consistent palette / typography / information density.
+Where I've called out a comparison diagram (Slides 3, 6) or a status grid (Slide 4),
+preserve the layout — those visual structures are load-bearing for the pitch.
 ```
 
 **What to do with the output:**
 
-- Review each slide; iterate on the ones that don't land.
-- Export to a deck format (Keynote, PowerPoint, PDF) for the actual pitch.
-- Print one as a one-page handout (Slide 1 + Slide 3 + Slide 5 condensed) if Canteen
-  allows handouts.
+- Review each slide; iterate the ones that don't land. Slides 4 (status) and 6 (the
+  wedge) are the two most likely to need refinement — both carry a lot of substance.
+- Export to a deck format (Keynote / PowerPoint / PDF) for the actual pitch.
+- Pull the wedge diagram from Slide 6 as a standalone image for the launch tweet and
+  the Discord pin.
 
 ---
 
-## Prompt 3 — High-fidelity UI refinement (onboarding + dashboard)
+## Prompt 3 — UI refinement toward the simplified page tree (Day-9 generator-first)
 
 **Setup notes:** Use Claude Design's **Prototype** mode with **High fidelity** selected.
-**Updated framing (Day 4):** the team has shipped a live React/Vite UI at
-[`http://18.171.230.205/`](http://18.171.230.205/) with `Layout`, `WalletConnect`, and
-`Trade` components. This prompt now serves as **visual refinement** — give Claude Design
-the live URL as a starting reference and ask it to propose evolutions, rather than
-generating from scratch.
+This is a refinement prompt against the live UI at
+[`http://18.171.230.205/`](http://18.171.230.205/), targeting the proposed
+simplification in [`docs/ui-simplification-proposal.md`](ui-simplification-proposal.md).
+**The Day-4 risk-tier-cards onboarding flow is retired** — the product is now
+generator-first: users describe what they want, fusion produces a candidate strategy,
+the rigor gate admits or rejects, and the user inspects + deposits. Risk tolerance is
+*an input to the brief*, not a top-level page.
 
 ```
-Project: Archimedes — frontend visual refinement.
+Project: Archimedes — frontend visual refinement toward a simplified page tree.
 
 Live reference URL (please fetch + study before generating): http://18.171.230.205/
-This is our current shipped UI — React 19 + Vite 8 + viem 2.48. The wallet-connect
-modal is already wired (MetaMask / Coinbase / generic browser wallet) and the Trade
-tab is live against deployed AMM contracts on Arc testnet (chain ID 5042002).
+This is the shipped UI — React 19 + Vite 8 + viem 2.48 + plain CSS (no Tailwind,
+no Next.js). Wallet connect (MetaMask / Coinbase / generic), Marketplace, Trade,
+Vaults, Intelligence (Corpus Explorer + Risk Analysis) all live.
 
-Tech stack target: React 19 + Vite 8 + plain CSS (we are not using a CSS framework;
-no Tailwind, no Next.js). The refined screens should be implementable in that stack —
-don't generate UI that requires custom canvas/WebGL or anything exotic.
+Goal: refine the live UI toward a tighter top-level navigation:
+- LANDING (current, lightly polished)
+- GENERATE (NEW top-level page — promotes the strategy generator from buried to
+  primary call-to-action)
+- MY PORTFOLIO (consolidates current Trade + Vaults + the personalized Risk view)
+- LIBRARY (consolidates current Marketplace + Strategies + Corpus Explorer)
+- LEARNINGS (NEW page — surfaces winning AND losing strategies with reasoning
+  traces fully readable; "what worked, what didn't, why")
 
-I need three connected screens that walk a user through the core flow:
+Generate four connected screens that walk a non-expert user through the spine.
+Information density should feel like a serious financial product — like Wealthfront
+crossed with Linear — not like a crypto degen app.
 
-SCREEN 1 — Landing / Risk Profile Selection
-The first screen after wallet connect. Header with logo, wallet address in top-right.
-Hero section: short headline ("Peer-reviewed AI portfolios, autonomous on Arc"),
-subhead, primary CTA implied.
-Below the hero: four cards (Conservative / Moderate / Aggressive / Hyper-Risky).
-Each card shows:
-- Profile name + a one-line description
-- Target volatility band
-- Max drawdown
-- USYC floor percentage
-- A small horizontal stacked bar showing approximate asset-class breakdown
-- "Select this profile" button
-The cards should look like the user could comfortably skim them and choose. Use
-distinct accent colors per profile (Conservative = green, Moderate = blue,
-Aggressive = orange, Hyper-Risky = red), but keep them tasteful — no clip art.
+SCREEN 1 — Generate (the new top-level page)
+The page that replaces "where do I start" with "tell us what you want."
+Layout:
+- Header: "Generate a strategy"
+- Subheader: "Describe what you want. We'll fuse your intent with live market data
+  and 10,000 q-fin papers into a candidate strategy, then run it through our
+  rigor gate."
+- Input area: a single large prose textarea — "Tell us about your goal" — with
+  3-4 example chips below it the user can click ("Steady income, low drawdown",
+  "Growth-oriented, OK with volatility", "Capital preservation", "Diversified
+  cross-asset").
+- Three optional structured inputs below (collapsible "Advanced"):
+  - Asset class slider (Fixed Income → Equities → Crypto)
+  - Risk tolerance slider (Conservative → Hyper-Risky)
+  - Time horizon (3 mo / 1 yr / 5 yr / 10 yr)
+- A single "Generate" CTA button
+- Below: a small panel showing what fusion will see — "Your brief" + "Current
+  market regime: VIX 14, equity-bond corr +0.3" + "Corpus: 10,000 papers across
+  9 q-fin categories" — making the 3 inputs visible
 
-SCREEN 2 — Portfolio Preview
-After selecting a profile, the user sees the constructed portfolio before depositing.
-Layout: top section shows a donut chart of asset weights, with a legend.
-Middle section: a list of selected strategies (4–6 cards horizontally scrollable),
-each showing:
-- Strategy name (with paper citation in small text: "Jegadeesh & Titman 1993")
-- Backtest Sharpe (with paper-claimed Sharpe in parentheses for comparison)
-- One-line methodology summary
-- Weight in the portfolio
-- "View paper" link
-Bottom section: a "Deposit USDC" CTA, plus a small "Customize" link for users who
-want to manually adjust strategy weights.
+SCREEN 2 — Generate (live result, after click)
+Shows the candidate strategy as it comes back from the engine.
+Layout:
+- Top: the strategy name + a colored rigor badge (Tier-1 / Tier-2 / Rejected)
+- The strategy spec card (entry/exit rules, sizing, asset universe, 3-4 source
+  papers cited with arXiv IDs in monospace)
+- Backtest results in a strip: Sharpe, Max DD, CAGR, Win Rate, all with the
+  paper-claim deltas visible
+- Rigor gate verdict panel (collapsible — open by default for Tier-1):
+  - DSR p-value (with "what this means" inline tooltip)
+  - PBO score (same)
+  - OOS Sharpe / IS Sharpe ratio
+  - Look-ahead audit check
+  - Trade count
+- Two CTAs: "Deploy to vault" (primary, only for Tier-1) and "Generate another"
+- "Why these papers?" expandable section listing the cited papers with one-line
+  reasoning for each — surfaces fusion's selection logic
 
-SCREEN 3 — Portfolio Dashboard (after deposit)
-The live state. Layout:
-- Top stat row: Total value (USDC), 24h change, 7d change, current regime
-  classification (Risk-On / Risk-Off / Transition / Crisis).
-- Performance chart: line chart of portfolio value over time, with benchmark line
-  (BTC or S&P 500 for comparison).
-- Current positions table: token, weight, current value, % from target, last
-  rebalance.
-- "Decisions" tab (this is the differentiator) — a chronological feed of agent
-  decisions:
-  - Each decision has: timestamp, decision type, trigger, one-sentence summary,
-    "View reasoning trace" link.
-  - The first item in the feed has a "Verify trace hash" button that, when clicked,
-    shows a small modal with the hash recomputation result (green checkmark animation).
-- Sidebar with: deposit/withdraw buttons, portfolio stats, link to the strategy
-  leaderboard.
+SCREEN 3 — My Portfolio (consolidates Trade + Vaults + personalized Risk)
+Layout:
+- Top stat row: Total USDC value · 24h change · 7d change · current portfolio
+  risk profile (computed, not chosen)
+- Performance chart (large) — portfolio equity curve with SPY benchmark line
+- Two-column body:
+  LEFT: "Holdings" — table of vault tokens with weight, value, last rebalance
+  RIGHT: "Active strategies" — cards of the strategies in your portfolio with
+  one-line status and a link to each strategy's detail page (Prompt 4)
+- Bottom: "Agent activity feed" — chronological list of agent decisions
+  (rebalances, risk-off rotations, position adjustments), each with timestamp,
+  one-line summary, and "View reasoning trace" link (opens Prompt 5's modal)
+- Sidebar: deposit / withdraw / rebalance buttons + a small "Risk profile
+  comparison" card (the band visualization currently on the standalone Risk
+  page — consolidated here)
 
-Visual style: Dark mode primary, off-white text, brand accent color (deep blue or
-violet). Typography: clean and modern; small monospace where on-chain hashes /
-addresses appear; serif for big headlines (the academic-rigor cue). Information
-density: high but not crowded — this user is checking on a portfolio, not browsing.
+SCREEN 4 — Library (consolidates Marketplace + Strategies + Corpus Explorer)
+The "browse what exists" surface. Three tabs at the top: All Strategies / Papers /
+Vault Leaderboard. Each shipping today; here we just consolidate them into one
+top-level nav entry.
+Default tab: All Strategies.
+- Left filter rail: Asset class · Risk tier · Rigor verdict (Tier-1 only / All) ·
+  Sort (Sharpe / OOS Sharpe / Recently added)
+- Main: grid of strategy cards, each showing name, rigor badge, key metrics
+  (Sharpe, max DD, CAGR), source paper count, and "View detail" link
+- Empty-state copy that nudges back to Generate: "Don't see one that fits?
+  → Generate a custom strategy"
 
-Make the prototype interactive enough that I can flow from screen 1 → 2 → 3 with
-the navigation working. Don't worry about real data; placeholder values are fine.
+Add ONE new convention across all screens: **in-line term definitions, not a
+glossary page.** Any finance acronym (DSR, PBO, Sharpe, Calmar, OOS, MVO, Kelly,
+CAGR, MDD) on first appearance gets a small dotted-underline link; hover or tap
+opens a 1-2-sentence definition popover. Acronyms expanded inline on first use
+within a section.
+
+Visual style: Dark mode (#0E1116 background, #F3F4F6 text, #2A4DD1 or #7B2CBF
+accent), serif headlines (Crimson Pro / Source Serif Pro), sans body
+(Inter / Geist Sans), monospace for arXiv IDs and hashes. Information density:
+medium-high. Each screen should feel like one coherent picture, not a wall of
+panels.
+
+Make the prototype interactive enough that the user can flow Generate → result →
+Deploy → My Portfolio → strategy detail → reasoning trace. Don't worry about real
+data; placeholder values are fine.
 ```
 
 **What to do with the output:**
 
-- Share with Marten + Daniel R. (current UI contributors). They evolve the live React
-  components using the refined visuals as a reference.
-- Iterate on any screens that don't match the intended feel.
-- Export key screens for the pitch deck (Slide 3 can use Screen 2; Slide 4's demo will
-  use the real implementation at `18.171.230.205`).
+- Share with Marten + Daniel R. as the **refinement target** for the post-MVP UI
+  polish pass (not a from-scratch reimplementation — incremental moves toward this
+  page tree). The page consolidation moves (Trade + Vaults → My Portfolio;
+  Marketplace + Strategies + Corpus Explorer → Library) are the structural lift.
+- The Generate screen (Screen 1) is the biggest user-facing move — feedback on that
+  one is highest-leverage.
+- Use Screen 2 (the generated-strategy result) as the screenshot for the Library /
+  README hero — it visually carries the "research-grounded" claim.
 
 ---
 
-## Prompt 4 — Strategy detail page (single screen, for the deck)
+## Prompt 4 — Strategy passport / detail page (Day-9 refresh, real numbers)
 
-**Setup notes:** Single screen. Use **Prototype / High fidelity**.
+**Setup notes:** Single screen. Use **Prototype / High fidelity**. This is the most
+important content surface in the entire product — judges will land here when they
+click any strategy from the demo. The example uses Moreira-Muir 2017 because it's
+one of the 2 Tier-1 strategies that actually passes the rigor gate today (real
+numbers, not aspirational).
 
 ```
-Single screen: the Archimedes Strategy Detail page.
+Single screen: the Archimedes Strategy Passport.
 
-Context: the user clicked on a strategy in their portfolio. This screen surfaces the
-strategy's "passport" — the verifiable provenance.
+Context: a user clicked on a strategy from the Library or from their portfolio.
+This screen surfaces the strategy's "passport" — the verifiable provenance + the
+full rigor verdict.
 
-Layout:
-- Header: Strategy name + "Paper-grounded" badge.
-- Subheader: paper citation, formatted like an academic reference:
-  "Jegadeesh, N., & Titman, S. (1993). Returns to buying winners and selling losers:
-  Implications for stock market efficiency. Journal of Finance, 48(1), 65–91.
-  [arxiv:... | doi:...]"
-- Three-column metadata strip:
-  - Paper-claimed Sharpe: 1.16
-  - Our backtest Sharpe (10-year, 10bps costs): 0.87
-  - Delta: -25%
-  - All three should be hash-anchored on Arc (small "View on Arc" link)
-- Methodology section: ~3 paragraphs of plain-English explanation, with key terms
-  bolded.
-- Backtest section: equity curve chart with our backtest, plus a comparison line
-  for the paper's claimed equity curve if available.
-- Validation section: list of audit checks passed:
-  ✓ Walk-forward (70/30 split)
-  ✓ No look-ahead bias detected
-  ✓ Out-of-sample Sharpe > 0.5
-  ✓ Curator validated (with curator wallet address)
-- On-chain registration: tx hash + "View on Arc Explorer" link.
+Use Moreira-Muir 2017 as the worked example (it's one of our 2 currently-Tier-1
+strategies). Layout:
 
-Visual style: same dark-mode + deep-blue accent as the rest of the prototype. This
-screen should feel like a research report, not a marketing page — that's the "we're
-serious about academic rigor" cue.
+Header strip:
+- Strategy name: "Moreira-Muir Volatility-Managed"
+- Rigor badge: large pill saying "TIER-1 — Archimedes Verified" with a small
+  checkmark icon, brand-accent fill
+- Sub-header: paper citation, formatted like an academic reference —
+  "Moreira, A., & Muir, T. (2017). Volatility-Managed Portfolios.
+  Journal of Finance, 72(4), 1611–1644. [arxiv: 1604.05601 | doi:10.1111/jofi.12513]"
+
+Three-column metadata strip (each card monospace for the numeric):
+- Backtest Sharpe (2004–2026, real SPY, 10bps costs): 0.769
+- Paper-claimed Sharpe: 0.60
+- Delta vs paper: +28% (small green chip — we BEAT the paper)
+- Sub-line: "Computed against 22 years of SPY data. Backtest code hash: 0x4f7a…2c91
+  on Arc."
+
+Methodology section (~3 paragraphs of plain-English explanation):
+- What the strategy does
+- Why it's expected to work (the economic intuition)
+- The implementation details (vol-targeting window, leverage cap, costs assumed)
+- Key terms bolded with the same dotted-underline inline-definition convention
+  used elsewhere
+
+Rigor gate verdict panel (the headline differentiator — give it visual weight):
+- "Selection-bias gate: PASSED" header
+- A 2-column grid of the four gates with the value + threshold + pass indicator:
+  - DSR (Deflated Sharpe Ratio): p = 0.995 · threshold > 0.95 · ✓
+  - PBO (Probability of Backtest Overfitting): 0.39 · threshold < 0.5 · ✓
+  - Walk-forward OOS Sharpe ratio: 1.26× in-sample · threshold ≥ 0.5× · ✓
+  - Look-ahead audit: passed · ✓
+- Below the grid: "What this means" plain-English explainer (~2 sentences) —
+  "DSR says the observed Sharpe is statistically distinguishable from zero after
+  correcting for non-normal returns and the number of strategies considered. PBO
+  says this strategy is not expected to underperform the median strategy out of
+  sample."
+
+Backtest section:
+- Equity curve chart (large): our backtest vs SPY buy-and-hold benchmark, with
+  the paper's claimed equity curve as a third line (dashed) where available
+- Below the chart: a strip of the 22-year stats — CAGR · Max DD · Calmar · Win
+  Rate · Volatility · Correlation to SPY
+
+Provenance section (the on-chain layer):
+- "Reasoning trace anchored on Arc"
+- Trace hash (monospace, truncated, with copy-icon): 0x4f7a…2c91
+- Block: 12,847,331 · Timestamp: 2026-05-20T14:23Z
+- "View on Arc Explorer" link (opens https://explorer.testnet.arc.network/tx/...)
+- "Verify trace" button — when clicked, animates a recomputation of the hash from
+  the published off-chain trace and shows a green-checkmark "Verified" badge
+
+Source-papers section:
+- 3-4 small cards, each with: arXiv ID (monospace), title (truncated), authors,
+  primary category, and a "Why fusion chose this" one-line annotation
+- Click → opens the paper detail (from Corpus Explorer)
+
+Visual style: dark mode primary, brand accent for the Tier-1 badge + the
+verification button, serif for big headlines, monospace for numerics + hashes +
+arXiv IDs. This screen should feel like a research report, not a marketing page —
+that's the "we're serious about academic rigor" cue.
 ```
 
 ---
 
-## Prompt 5 — Reasoning trace viewer modal
+## Prompt 5 — Reasoning trace viewer modal (Day-9 refresh)
 
-**Setup notes:** Modal / overlay component within the portfolio dashboard. Use
-**Prototype / High fidelity**.
+**Setup notes:** Modal / overlay component opened from the "Agent activity feed"
+on the My Portfolio screen (Prompt 3 Screen 3) or from any strategy passport
+(Prompt 4). Use **Prototype / High fidelity**.
 
 ```
 Component: the Reasoning Trace Viewer modal.
 
-Context: the user clicked "View reasoning trace" on a specific agent decision in the
-Decisions tab. A modal opens showing the full trace.
+Context: the user clicked "View reasoning trace" on a specific agent decision.
+The modal opens showing the full trace — every step the agent considered, every
+tool it called, what it decided, what it did on-chain, and how to verify.
 
-Layout:
-- Header: Decision type + trigger + timestamp
-  ("Autonomous Rebalance — Regime change to Risk-Off — 2026-05-23 14:32 UTC")
-- Market context section: a compact grid showing the metrics the agent saw at
-  decision time (VIX, S&P 50/200 crossover, credit spreads, BTC dominance,
-  cross-asset correlation, USYC yield).
-- Reasoning section: the LLM-generated explanation as plain prose. Should look
-  like writing, not bullet points — this is what a thoughtful analyst would write.
-- Action taken section: a "before vs. after" portfolio weights comparison, plus
-  a list of trades executed with on-chain tx hashes for each.
-- Tool calls section: collapsible — by default shows count ("9 tool calls"), expand
-  to see each tool, input hash, output hash, latency.
-- Verification footer: content hash + storage pointer + "Verify trace" button.
-  When clicked, animates a recomputation of the hash and shows pass/fail with
-  green checkmark or red X.
+Layout (header sticky, body scrolls):
 
-Visual style: dense but organized. The header should be sticky if the modal
-scrolls. Hash strings displayed in small monospace with copy-to-clipboard buttons.
+Header (sticky):
+- Decision type + trigger + UTC timestamp
+  (e.g. "Autonomous Rebalance — Vol-targeting threshold crossed — 2026-05-23 14:32 UTC")
+- Status pill: "Executed" or "Considered, not executed"
+- Close button (X) in the top-right
+
+Market context section:
+- A compact grid showing the metrics the agent saw at decision time —
+  VIX · S&P 50/200 crossover · credit spreads · BTC dominance · cross-asset
+  correlation · USYC yield · realized vs implied vol delta
+- Each value monospace, with a small "↑ / ↓ / ↔" indicator vs the previous decision
+
+Source signals section:
+- Which corpus papers the fusion engine referenced when this decision was
+  considered. 2-3 small cards with arXiv ID + title + the specific claim invoked
+  ("paper claims vol-targeting reduces tail risk in this regime")
+
+Reasoning section:
+- The LLM-generated explanation as plain prose. Should read like a thoughtful
+  analyst wrote it, not a bullet-pointed checklist. 2-4 paragraphs typically.
+- Inline definitions for any acronym on first use (same dotted-underline pattern
+  as Prompts 3 and 4)
+
+Action taken section:
+- "Before vs After" portfolio weights comparison (two stacked horizontal bars)
+- A short list of trades executed, each with: from-asset → to-asset, USDC
+  amount, slippage, on-chain tx hash (monospace, truncated, copyable, link to
+  Arc Explorer)
+
+Tool calls section (collapsible, collapsed by default):
+- Header: "9 tool calls" with expand chevron
+- When expanded: a table of (tool name, input hash, output hash, latency)
+- Useful for technical judges; doesn't clutter the default view
+
+Verification footer (always visible):
+- Trace content hash (monospace) — the hash that was anchored on Arc
+- Storage pointer (where the full off-chain trace lives — could be S3 URL or
+  IPFS CID, monospace)
+- "Verify trace" button — when clicked, animates a recomputation of the hash
+  from the published off-chain JSON and shows pass/fail with a green-checkmark
+  or red-X animation
+- "View on Arc Explorer" link to the on-chain anchor tx
+
+Visual style: dense but organized. Header sticky. Hash strings always monospace
+with copy-to-clipboard buttons. Generous whitespace between sections so the modal
+doesn't feel like a wall of text.
 ```
-
----
-
-## Logo color and typography proposal (use across all prompts)
-
-If you want consistency across the slide deck and the UI prototype, propose this
-design system up front:
-
-**Primary palette:**
-
-- Background: `#0E1116` (near-black)
-- Surface: `#1A1F2E` (slightly lighter for cards)
-- Text primary: `#F3F4F6` (off-white)
-- Text secondary: `#9CA3AF` (muted gray)
-- Brand accent: `#2A4DD1` (deep blue) — or alternative `#7B2CBF` (violet)
-- Success: `#10B981` (green, for "Verify trace" checkmarks)
-- Warning: `#F59E0B` (amber, for "paper-claim delta" if > 30%)
-- Error: `#EF4444` (red, for failed verifications)
-
-**Typography:**
-
-- Headlines: `Crimson Pro` or `Source Serif Pro` (serif — the academic cue)
-- Body: `Inter` or `Geist Sans` (clean modern sans)
-- Monospace (hashes, addresses): `JetBrains Mono` or `Geist Mono`
-
-You can paste this design-system block into any Claude Design prompt to maintain
-consistency.
 
 ---
 
@@ -517,6 +648,349 @@ density.
 
 ---
 
+## Explainer prompts (Day-9 addition, 2026-05-20)
+
+These prompts produce **explanatory visualizations** rather than UI screens or branding.
+The intent: make the corpus-→-fusion-→-strategy chain visually graspable for the team,
+for judges, for non-finance audiences. Suitable for embedding in the deck, the README,
+the live app's "How it works" section, or as standalone images to share in Discord /
+on social during the launch.
+
+All of these reference the design system above. If you've already done the design-system
+setup in your Claude Design workspace, the prompts will inherit it; otherwise paste the
+palette + typography block above into the conversation first.
+
+### Prompt 6 — Corpus substrate diagram (3 layers)
+
+**Mode:** From template / Other → "Diagram" (or "Slide" if you want it deck-ready)
+
+```
+Create a 3-layer architecture diagram showing how the Archimedes q-fin paper corpus is
+built and consumed. Vertical orientation, top-to-bottom data flow with arrows.
+
+LAYER 1 (top) — "Seed (committed, deterministic)"
+- A file labeled "data/corpus/manifest.jsonl"
+- Subtitle: "10,000 curated arXiv papers, 14 MB, ships with the repo"
+- Small icon for "no network required"
+
+LAYER 2 (middle) — "Truth (Postgres, mutable)"
+- A database cylinder labeled "papers + corpus_meta tables"
+- Subtitle: "Persisted in pgdata volume, survives redeploys"
+- Two arrows entering from the top:
+  - Left arrow from Layer 1: "Idempotent seed at every startup"
+  - Right arrow from a small arXiv logo (outside Layer 1): "Live intake (incremental)"
+
+LAYER 3 (bottom) — "Heavy artifact (persistent volume, lazy)"
+- A volume icon labeled "archimedes-corpus-artifact"
+- Subtitle: "Embeddings, clusters, knowledge graph, summaries"
+- Small badge: "Built out-of-band, never on the deploy path"
+- Note in italics: "Empty for now — boots fine if missing (loud degradation)"
+
+Below all three layers, a single arrow pointing down to a box labeled:
+"Consumed by: strategy_fusion.load_corpus() + /api/papers + Corpus Explorer UI"
+
+Visual style: clean technical diagram, dark background per the design system, single
+brand accent for arrows, monospace for table/file names, serif for layer titles. No
+clip art. Should read like an architecture diagram an engineer would draw on a
+whiteboard, not a marketing illustration.
+
+Use case: Slide in the pitch deck explaining "the substrate"; also embedded in
+docs/architectural-principles.md as the canonical reference.
+```
+
+### Prompt 7 — 3-input fusion explainer (the wedge in one image)
+
+**Mode:** From template / Other → "Diagram"
+
+```
+Create a fusion diagram showing how Archimedes generates a research-grounded strategy
+from three inputs. This is the single most important "what makes us different" image
+in the deck — it must read clearly in 5 seconds.
+
+CENTER: A large hexagon or rounded square labeled "FUSION" with subtitle
+"strategy_fusion.py + LLM (GLM)".
+
+THREE INPUTS feeding in from the left, top, and right (or all from the left, stacked
+— pick whichever reads cleaner):
+
+INPUT 1 — "User brief"
+- Icon: person silhouette or speech bubble
+- Caption: "What you want — asset class, risk tolerance, time horizon"
+- Example bubble: "Steady income, low drawdown, 5-year horizon"
+
+INPUT 2 — "Live market regime"
+- Icon: candlestick chart or volatility curve
+- Caption: "Current conditions — volatility, asset correlations, regime indicators"
+- Example bubble: "VIX 14, rates flat, equity-bond corr +0.3"
+
+INPUT 3 — "Research corpus"
+- Icon: stack of papers or a small database cylinder
+- Caption: "10,000 q-fin papers — methods, evidence, paper-claimed Sharpe"
+- Example bubble: "Moreira-Muir 2017, Faber 2007, George-Hwang 2004…"
+
+OUTPUT (arrow leaving the right or bottom of the fusion box):
+- A strategy spec card showing:
+  - Strategy name
+  - Entry/exit rules (1-2 lines)
+  - Citations: 3-4 arXiv IDs in monospace
+  - A small badge: "Reasoning trace → on-chain"
+
+Beneath the output, a thin downward arrow labeled "Rigor gate (next prompt)" so this
+diagram is composable with Prompt 8.
+
+Visual style: dark background, brand-accent arrows, the three inputs sized equally so
+no one input dominates (that's the point — none of them alone gives you the answer).
+Monospace for the arxiv IDs and rule snippets. Serif for the section headings.
+
+Use case: Deck slide titled "How fusion works"; also the hero image for the
+"research-grounded" section of the live app's landing page.
+```
+
+### Prompt 8 — Rigor gate flowchart
+
+**Mode:** From template / Other → "Diagram" (flowchart)
+
+```
+Create a flowchart showing the rigor gate that every Archimedes-generated strategy
+passes through before being admitted to the library. Vertical orientation, top-down.
+
+START at the top with a card labeled "Candidate strategy"
+- Subtitle: "From fusion (Prompt 7)"
+
+Then a series of decision diamonds, each in sequence, each with a green check (pass)
+arrow continuing down and a red X (fail) arrow exiting to the right into a single
+"Reject + preserve trace" terminal box on the right side:
+
+GATE 1: "DSR (Deflated Sharpe Ratio)"
+- Subtitle: "Bailey & López de Prado 2014"
+- Pass criterion: "p-value > 0.95 — Sharpe credibly > 0 after multiple-testing correction"
+
+GATE 2: "PBO (Probability of Backtest Overfitting)"
+- Subtitle: "CSCV framework"
+- Pass criterion: "< 0.5 — not expected to underperform median out-of-sample"
+
+GATE 3: "Walk-forward OOS"
+- Subtitle: "70/30 train/test split"
+- Pass criterion: "OOS Sharpe within 50% of in-sample — no cliff"
+
+GATE 4: "Look-ahead audit"
+- Subtitle: "Static analysis of strategy code"
+- Pass criterion: "No future-data leakage detected"
+
+GATE 5: "Trade count + paper-claim delta"
+- Subtitle: "Sanity checks"
+- Pass criterion: "Trades ≥ 10 (or always-on) AND backtest Sharpe ≥ 0.5 × paper claim"
+
+If all five pass → green terminal box at the bottom: "ADMITTED — Tier-1 (Archimedes
+Verified 🏆)"
+
+To the right of the entire pipeline, a small panel listing "What's surfaced in the
+strategy passport regardless of pass/fail": DSR value, PBO score, OOS/IS Sharpe ratio,
+paper-claim delta, look-ahead audit result, the reasoning trace.
+
+Visual style: clean flowchart, dark background, green = pass, red = fail, brand
+accent for the gates themselves. Serif for gate names, sans for criteria, monospace
+for thresholds (>0.95, <0.5, etc.).
+
+Use case: Deck slide titled "How we gate strategies"; also the canonical reference
+diagram in docs/specs/selection-bias-corrections-spec.md and on the strategy passport
+page in the live app.
+```
+
+### Prompt 9 — End-to-end user journey
+
+**Mode:** Slide deck (single slide, horizontal)
+
+```
+Create a 5-step horizontal user-journey diagram for Archimedes. This is the spine of
+the product — every other prompt feeds into one of these steps. Should read like a
+subway map: clean, sequenced, each stop has a name and a one-line outcome.
+
+LEFT TO RIGHT, FIVE STOPS connected by a single horizontal track:
+
+STOP 1: "Describe"
+- Icon: chat bubble
+- Caption: "Tell Archimedes what you want — asset class, risk, horizon"
+
+STOP 2: "Generate"
+- Icon: small spark / lightbulb on top of the fusion hexagon
+- Caption: "3-input fusion produces a research-grounded strategy"
+- Tiny note below: "See Prompt 7"
+
+STOP 3: "Rigor-gate"
+- Icon: shield with a checkmark
+- Caption: "DSR + PBO + OOS + audit. Pass → admit. Fail → preserve trace."
+- Tiny note below: "See Prompt 8"
+
+STOP 4: "Execute"
+- Icon: vault / safe (the non-custodial ERC-4626 vault)
+- Caption: "Deploy into your non-custodial vault on Arc. USDC settlement."
+
+STOP 5: "Monitor + Explore"
+- Icon: dashboard / line chart
+- Caption: "Watch performance, inspect reasoning traces, explore the library that grew with you"
+
+BELOW THE TRACK, a horizontal banner spanning all 5 stops:
+"Every step's reasoning is hashed and anchored on Arc via ReasoningTraceRegistry —
+anyone can verify."
+
+Visual style: brand accent for the track, dark background, each stop styled like a
+subway-station node (filled circle + label above + caption below). Stops 1 and 5 are
+labeled "User" (the person), stops 2/3/4 are labeled "System" (the agent) — make this
+distinction visible (small subtitle under each station).
+
+Use case: The single most important slide in the deck — appears right after the
+problem framing, before any architecture detail. Also the hero image on the live app's
+landing page and the README. If this image works on its own, the rest of the deck is
+support.
+```
+
+### Prompt 10 — On-chain reasoning trace anchoring
+
+**Mode:** From template / Other → "Diagram"
+
+```
+Create a diagram showing how Archimedes anchors a reasoning trace on Arc — the
+provenance primitive that makes our claims externally verifiable.
+
+LEFT SIDE — "Off-chain (full trace)"
+- A document/scroll icon labeled "Reasoning trace"
+- Bullets inside:
+  - "Fusion brief (your intent + market + papers)"
+  - "Selected source papers (arXiv IDs)"
+  - "LLM reasoning steps"
+  - "Backtest results (DSR, PBO, OOS Sharpe)"
+  - "Rigor-gate verdict"
+- Subtitle: "Stored in Postgres + Redis; full text recoverable"
+
+MIDDLE — a hash function symbol with an arrow leading into it from the left and out
+of it on the right
+- Caption: "SHA-256"
+
+RIGHT SIDE — "On-chain (anchor)"
+- A small smart-contract icon labeled "ReasoningTraceRegistry"
+- Subtitle: "Deployed on Arc testnet"
+- Inside the contract box:
+  - "traceHash: 0x4f7a…2c91"  (monospace, truncated)
+  - "blockNumber: 12,847,331"
+  - "blockTime: 2026-05-20T14:23Z"
+- Bottom annotation: "Atomic. Sub-second finality. USDC for gas."
+
+BELOW THE WHOLE THING, a small verification panel:
+"Anyone can: recompute the hash of the published off-chain trace, compare against the
+on-chain anchor, and prove the trace existed at the recorded block time."
+
+Optional callout (top right corner): "v1.5 upgrade — commit-reveal — proves the trace
+existed BEFORE the trade (causal ordering, not just temporal coexistence)."
+
+Visual style: dark background, monospace for hashes/block numbers, the SHA-256 step is
+the visual centerpiece (slightly larger, brand accent), arrows are subtle.
+
+Use case: Deck slide titled "Verifiable provenance"; also the canonical reference
+in docs/specs/commit-reveal-trace-spec.md.
+```
+
+### Prompt 11 — One-page explainer (launch-ready)
+
+**Mode:** Slide deck (single landscape slide) OR Prototype (single 1200×1600 page)
+
+```
+Create a single-page explainer for Archimedes — the artifact we share in Discord, on
+social, and as a thumbnail for the deck. One page. Should be self-contained: a person
+who knows nothing about us should grasp the product in 30 seconds.
+
+LAYOUT (top to bottom):
+
+HEADER STRIP
+- Logo (left) + "Archimedes" (serif headline) + tagline (right): "Research-grounded
+  strategies, generated on demand, gated by selection-bias rigor, executed on Arc."
+
+PROBLEM (one paragraph, centered)
+- "AI portfolio tools today are either black-box robo-advisors, opaque copy-trade
+  influencer plays, or LLM 'just trust me' strategy generators. None of them surface
+  the research their claims rest on, and none of them gate against the most common
+  failure mode: in-sample overfitting that doesn't survive contact with reality."
+
+WHAT WE DO (the 5-step subway-map from Prompt 9, simplified and compressed)
+- Just the 5 stops with their captions, horizontal strip
+
+THE WEDGE (3 columns, equal weight)
+- Column 1: "Research-grounded"
+  - "Every strategy cites the q-fin papers that informed it. 10,000-paper corpus.
+    Generated, not retrieved."
+- Column 2: "Rigor-gated"
+  - "Every Tier-1 strategy passes DSR + PBO + walk-forward OOS + look-ahead audit
+    before admission. No black box."
+- Column 3: "Provenance-anchored"
+  - "Every reasoning trace is hashed and anchored on Arc. Verifiable history, not
+    marketing copy."
+
+CURRENT STATUS (small footer band, italic)
+- "Built for the Agora Agents Hackathon — Canteen × Circle × Arc, May 11–25, 2026.
+  Currently on Arc testnet (no mainnet — that's the correct posture). Open-source under
+  the Unlicense."
+- Small QR or short URL pointing to the live app and the GitHub repo.
+
+Visual style: dark background, generous white-space, brand accent used sparingly to
+draw the eye to the 3-column wedge section. Serif headlines, sans body. No emojis in
+the artifact itself.
+
+Use case: Discord pin, social-share image, README hero. Generate once, use everywhere.
+```
+
+### Prompt 12 — Page map: current vs proposed UI
+
+**Mode:** From template / Other → "Diagram" (two-column comparison)
+
+```
+Create a two-column visual page-map comparison for the Archimedes web app — current
+state on the left, proposed simplification on the right.
+
+LEFT COLUMN — "Current (as shipped)"
+Show the existing top-level navigation as a tree, listing every primary page:
+- Landing
+- Marketplace (Explore)
+  - Synthetic Assets
+  - Vault Leaderboard
+  - Trending This Week
+  - All Strategies
+  - Agent Activity
+- Strategies
+- Trade
+- Vaults
+- Intelligence
+  - Corpus Explorer
+  - Risk Analysis
+- (any other pages — check ui/src/components/Layout.jsx)
+
+RIGHT COLUMN — "Proposed (simplified)"
+Show a tighter tree with 4-5 top-level sections:
+- Landing
+- Generate (the strategy generator, prominently surfaced)
+- My Portfolio (consolidates Trade + Vaults + Risk Analysis personalized view)
+- Library (consolidates Marketplace + Strategies + Corpus Explorer)
+- Learnings (NEW — what worked, what didn't, why; reasoning traces fully accessible)
+
+BETWEEN THE COLUMNS, a few annotation arrows showing where current pages map into
+proposed sections (e.g., "Trade + Vaults → My Portfolio").
+
+BELOW THE COMPARISON, a 2-sentence rationale:
+"Current navigation reflects what was built; proposed reflects what users do. Generate
+moves from buried to top-level. Performance, allocation, and risk for YOUR positions
+consolidate into one place. Public corpus + strategies become a single 'Library' surface.
+A new 'Learnings' page makes losing strategies first-class learning material, not
+hidden failures."
+
+Visual style: tree diagram, dark background, current side in muted secondary text
+color, proposed side in primary text + brand accent for the "Generate" and "Learnings"
+nodes (the structural moves). Sans throughout.
+
+Use case: PR description for the UI simplification proposal; also a slide in the deck
+showing "we know our own UX, here's how we'd polish it post-hackathon."
+```
+
+---
+
 ## Workflow recap
 
 1. **Set up a design system** in Claude Design with the palette/typography above.
@@ -524,10 +998,13 @@ density.
    as of Day 4: not yet started. Smallest-scope test of Claude Design for the team.)
 3. **Run Prompt 2** (slide deck) — generate, iterate, export. Make sure the bullets
    match what the team has actually shipped per the Day-4 revision above.
-4. **Run Prompt 3, 4, 5** (UI screens) — give Claude Design the live URL
+4. **Run Prompts 3, 4, 5** (UI screens) — give Claude Design the live URL
    (`http://18.171.230.205/`) as starting reference. These prompts are now **refinement**
    prompts against the shipped React UI, not greenfield.
-5. **Iterate** — Claude Design is conversational; refine outputs based on your eye.
+5. **Run Prompts 6–12** (explainer set) when you want explanatory visualizations for
+   the deck, README, Discord pin, or social-share assets. They're independent of each
+   other — pick the one(s) the moment calls for.
+6. **Iterate** — Claude Design is conversational; refine outputs based on your eye.
 
 If you take screenshots of references along the way, drop them in the conversation —
 both Claude Design and this Linus session can ingest them. URLs work too. Either is

--- a/docs/corpus-architecture.md
+++ b/docs/corpus-architecture.md
@@ -1,0 +1,272 @@
+# Corpus architecture — how it's built, stored, and fused
+
+> **Audience:** anyone on the team (or a curious judge) who needs to understand how
+> the q-fin paper corpus actually works end-to-end.
+> **Purpose:** the single page that explains the substrate. Sits alongside
+> [`docs/specs/strategy-passport-spec.md`](specs/strategy-passport-spec.md) and
+> [`docs/specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md);
+> together they describe the three load-bearing intelligence layers of Archimedes.
+> **Status:** Day-9 (2026-05-20). Reflects what's actually shipped on `main` after
+> #95 (engine v2), #97 (10k corpus), #105 + #108 (rigor wedge), #106 (DB-backed
+> corpus), and #93 (Corpus Explorer UI).
+
+## The substrate (3 layers)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  LAYER 1 — SEED (committed, deterministic)                       │
+│  data/corpus/manifest.jsonl                                      │
+│  Curated arXiv metadata snapshot — ships with the repo           │
+│  Boot-time floor. 10,000 papers, 14 MB. No network required.     │
+└──────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ (idempotent upsert at every startup)
+┌──────────────────────────────────────────────────────────────────┐
+│  LAYER 2 — TRUTH (Postgres, mutable)                             │
+│  papers table (PK = arxiv_id) + corpus_meta singleton            │
+│  Lives in pgdata named volume — survives redeploys               │
+│  Grown by: seed re-runs + arxiv intake + bulk ingest script      │
+│  Indexes on primary_category + published                         │
+└──────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ (read by fusion + /api endpoints)
+┌──────────────────────────────────────────────────────────────────┐
+│  LAYER 3 — HEAVY ARTIFACT (persistent volume, lazy)              │
+│  archimedes-corpus-artifact volume → embeddings, clusters,       │
+│  knowledge graph, summaries. Built out-of-band by the #101       │
+│  KB-pipeline port (which is scaffolded but not yet run).         │
+│  Loud-degradation: app boots fine if missing.                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Three layers, three distinct lifetimes:
+
+- **Layer 1 — Seed** is what git remembers. Determinism. Floor.
+- **Layer 2 — Truth** is what Postgres remembers. Mutable. What the app actually queries.
+- **Layer 3 — Artifact** is what a persistent docker volume remembers. Heavy.
+  Built once, served many times.
+
+The seed is the *recipe*; the truth is the *kitchen*; the artifact is the *prep*. You
+can rebuild any layer from the one above it (with the right time investment), but in
+steady state you only touch each at the cadence it deserves.
+
+## Why two write paths (seed vs intake)
+
+Same code touches `papers`; different reasons to run.
+
+| | Seed (manifest) | Intake (arxiv) |
+|---|---|---|
+| **Trigger** | Every startup (`d80fca3` made it always-run, not just empty-DB) | Currently manual; bulk script `scripts/bulk_ingest_arxiv.py` |
+| **Source** | Committed JSONL in repo | Live arXiv Atom API (https since `a080724`) |
+| **Purpose** | Bootstrap + version-bump the corpus deterministically | Keep it growing/fresh |
+| **Net effect** | DB matches what's in git | DB outgrows what's in git |
+| **Idempotent?** | Yes — upsert by `arxiv_id` | Yes — dedup by `arxiv_id` |
+| **Network needed?** | No | Yes |
+| **Throttling?** | N/A | Polite Atom pulls; exponential backoff for 429s |
+
+This is the right shape:
+- **The manifest is the floor.** Anyone cloning gets a working corpus instantly.
+- **The DB is the truth.** What the running system actually queries.
+- **The intake is the growth path.** Operator decides cadence.
+
+A spec gap worth knowing: `intake_from_arxiv()` is callable but **no periodic task
+wires it up automatically**. Today, an operator runs the script when they want
+freshness. The spec called for an in-process periodic task; adding one is ~10 lines.
+Tracked as a fast-follow under #106.
+
+## Why local and deployment differ
+
+**They don't differ much architecturally — the difference is what survives a restart.**
+
+| | Local dev | Production deployment |
+|---|---|---|
+| Postgres | docker-compose `pgdata` volume | Same `pgdata` volume on the EC2 host |
+| Artifact | `archimedes-corpus-artifact` named volume | Same named volume on the host |
+| Manifest | Committed file, always present | Same committed file, baked into image |
+| Seed runs | On `docker compose up`, every boot | On every deploy/restart, every boot |
+| Intake runs | When you manually invoke `python scripts/bulk_ingest_arxiv.py` | Same — operator-triggered until a scheduler is added |
+
+The differences that *do* exist:
+
+1. **Ephemeral by accident locally.** If you run `docker compose down -v`, your
+   `pgdata` and artifact volumes get wiped, and the next boot reseeds from the
+   manifest. In prod the host volumes persist across redeploys — you'd only lose
+   data if you explicitly deleted them. **Same code, different blast radius.**
+2. **Network latency to arXiv.** Negligible — intake is throttled either way.
+3. **The 10,000-row corpus** (post #97) was built by running
+   `scripts/bulk_ingest_arxiv.py` once, with results committed to `manifest.jsonl`.
+   So both environments start at 10,000 on first boot. Subsequent growth requires
+   running intake again.
+
+That's it. There's no "production magic" — same code, same DB, same artifact volume
+contract. Cold-clone parity is `docker compose down -v && docker compose up`; expect
+`/health` to report `corpus_db_count == 10000` once startup completes.
+
+## What a paper actually contains
+
+Schema lives in [`backend/archimedes/models/corpus_store.py`](../backend/archimedes/models/corpus_store.py). Each `PaperRecord` row carries:
+
+- **Identity:** `arxiv_id` (PK), `title`, `authors` (JSON list), `primary_category`,
+  `categories` (JSON list)
+- **Content:** `abstract` (always present — "abstract-first")
+- **Provenance:** `pdf_url`, `pdf_sha256` (nullable, populated when full text is
+  fetched), `full_text_path` (nullable — lazy)
+- **Clustering (for #101 future use):** `cluster_id`, `topic_label` (both
+  nullable — populated by the KB pipeline when it runs)
+- **Timestamps:** `published`, `updated`, `ingested_at`
+- **Bookkeeping:** `source`, `content_hash`
+
+Plus a `CorpusMetaRecord` singleton: `last_intake_at`, `corpus_hash`, `artifact_hash`,
+`artifact_built_at`, `paper_count`, `source` — all exposed via `/health` so operators
+can see corpus state at a glance.
+
+## How a paper becomes part of a strategy (the fusion path)
+
+This is the chain you most need to understand, because **"research-grounded"** is the
+entire marketing wedge.
+
+```
+User describes intent in the UI
+        │
+        ▼
+POST /api/strategies/generate           (engine v2, Chuan #95)
+        │
+        ▼
+FusionBrief built
+   (user intent + asset class + risk tolerance + time horizon)
+        │
+        ▼
+strategy_fusion.load_corpus()
+        │  ├─→ Try Postgres `papers` table (DB-first since #106)
+        │  └─→ Fallback to manifest.jsonl on disk (defensive)
+        │
+        ▼
+3-INPUT FUSION
+   ┌────────────────────────────────────────────────────────────┐
+   │  Input 1: User brief (what they want)                       │
+   │  Input 2: Live market regime (current vol, asset behavior)  │
+   │  Input 3: Corpus papers (research evidence)                 │
+   └────────────────────────────────────────────────────────────┘
+        │
+        ▼
+Paper selection
+   ⚠️ CURRENT: keyword matching against title + abstract
+   🔜 FUTURE (#96): SPECTER2 embeddings + RAG + minimal KG
+        │
+        ▼
+LLM call (GLM, with citations injected into prompt)
+        │
+        ▼
+Candidate strategy spec (entry/exit rules, sizing, asset universe)
+        │
+        ▼
+RIGOR GATE (Önder's work, PR #105 + #108)
+   ├─ DSR (Deflated Sharpe Ratio, Bailey-LdP eq. 8 raw kurtosis)
+   ├─ PBO (Probability of Backtest Overfitting via CSCV)
+   ├─ Kelly criterion (sizing sanity)
+   ├─ MVO (Mean-Variance Optimization, portfolio context)
+   └─ Trade-count rule (post-#108: <2 OR ≥10, exempting always-on)
+        │
+        ▼
+Either PASSES → stored in StrategyStore with is_example=False, surfaced in UI
+   OR BLOCKS → reasoning trace preserved, strategy not promoted
+```
+
+**Crucial framing**: the corpus is **not a fact lookup**. It's *evidence the LLM is
+asked to ground its proposal in*. The provenance is what makes a generated strategy
+distinguishable from "ChatGPT made up a momentum rule." Every generated strategy can
+point at specific papers that informed it. **That's the rigor wedge externalized.**
+
+## What's wired today vs what's not
+
+### Wired and live
+
+- [x] DB-backed `papers` + `corpus_meta` (10,000 rows)
+- [x] Idempotent seed at every startup
+- [x] `intake_from_arxiv()` function (no scheduler — operator-triggered)
+- [x] DB-first read path through `strategy_fusion.load_corpus()`
+- [x] Paginated `/api/papers` + `/api/papers/{id}` + `/api/corpus/overview` +
+      `/api/corpus/graph` + `/api/corpus/kg`
+- [x] `/health` exposes `corpus_papers`, `corpus_db_count`, `corpus_source`,
+      `corpus_last_intake`, `artifact_hash`
+- [x] Corpus Explorer UI (catalog + overview + similarity graph + knowledge graph)
+- [x] Persistent named volume `archimedes-corpus-artifact` mounted in compose
+- [x] Rigor gate (DSR + PBO + Kelly + MVO + look-ahead audit) on every generated
+      strategy
+- [x] 2 Tier-1 strategies passing all four gates (Faber 2007 SMA200,
+      Moreira-Muir 2017 vol-managed)
+
+### Scaffolded but not running yet
+
+- [ ] **Heavy artifact pipeline (#101)** — SPECTER2 embeddings, HDBSCAN +
+      BERTopic + UMAP clustering, REBEL + SciSpacy knowledge graph, per-cluster
+      LLM summaries. Volume is mounted and ready; the build job has not been run.
+      The `cluster_id` and `topic_label` columns on `PaperRecord` are nullable,
+      ready to be populated.
+- [ ] **Paper-QA RAG retrieval (#96)** — current fusion does keyword selection
+      against title + abstract. Spec calls for SPECTER2 embeddings + nearest-
+      neighbour retrieval + a small entity/method KG. The substrate (#106) and
+      the 3-input fusion brief (#95) are both ready; this is now unblocked.
+
+### Deferred (correct scope decisions, not gaps)
+
+- [ ] **Lazy full-text fetch** — `full_text_path` column exists but no fetcher is
+      wired. Abstract-only across the board today. Belongs in a retrieval path
+      (when fusion picks a paper, fetch the full text on demand), not in the
+      substrate.
+- [ ] **Scheduler for `intake_from_arxiv()`** — function exists and is callable;
+      no periodic task. Filed as a fast-follow under #106 (~10 lines to add an
+      `asyncio.create_task` on startup).
+- [ ] **Retention/prune at `CORPUS_MAX`** — when DB hits the cap, intake silently
+      stops; no eviction. Not biting at 10k (cap default is 2000, currently lifted
+      via env to 10k); spec called for recency-prioritized retention if scale
+      pushes us past the cap.
+- [ ] **`make corpus` / `make build-corpus-artifact` targets** — Makefile has
+      no corpus targets. Local↔prod parity (#98) wants these. Trivial follow-on.
+- [ ] **Quality-signal columns** — spec called for peer-review / preprint /
+      citation-age proxies as features for retrieval, never filters. `PaperRecord`
+      has none of these columns. Not blocking the explorer (#93) which renders
+      without them.
+
+## Why this architecture
+
+A few decisions worth being explicit about (and being able to defend on stage):
+
+**Manifest as seed, not as truth.** Committing the canonical corpus to git makes
+cold-clone determinism cheap and offline dev possible, but it would make the corpus
+*static* if we treated it as truth. DB-as-truth + manifest-as-seed lets us grow the
+corpus dynamically without losing reproducibility.
+
+**Heavy artifact on a persistent volume, never in the request path.** Embeddings +
+clustering + KG are minutes-to-hours to build at 10k+ scale. Computing any of that
+on a `/api/corpus/graph` request would be a multi-second hang. Building it once,
+serving it many times, and re-building only when the corpus hash changes is the
+right shape — and it lets the *build* live in a separate cadence (or even a separate
+container) from the *serve*.
+
+**Loud degradation, never silent.** If the artifact volume is empty, the app boots
+cleanly, `/health` reports `artifact_hash: null`, the Corpus Explorer's heavy viz
+panels degrade *visibly* (the user sees "embeddings not yet built"), and fusion
+falls back to keyword retrieval. No silent half-features.
+
+**Abstract-first, full-text lazy.** Abstracts are cheap to store and sufficient for
+both the explorer and the SPECTER2 embedding layer (#101). Full PDF text is only
+fetched when fusion actually needs it for a specific paper. That keeps the corpus
+small enough to commit, fast enough to seed, and rich enough to retrieve.
+
+## See also
+
+- [`backend/archimedes/services/corpus_service.py`](../backend/archimedes/services/corpus_service.py) — the seed + intake implementation
+- [`backend/archimedes/services/strategy_fusion.py`](../backend/archimedes/services/strategy_fusion.py) — `load_corpus()` + fusion prompt build
+- [`backend/archimedes/models/corpus_store.py`](../backend/archimedes/models/corpus_store.py) — `PaperRecord` + `CorpusMetaRecord` schemas
+- [`docs/qfin-paper-corpus-seed.md`](qfin-paper-corpus-seed.md) — the original
+  seed-curation spec (largely historical now that #97 expanded to 10k via bulk ingest)
+- [`docs/specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md) — what the rigor gate enforces
+- [`docs/architectural-principles.md`](architectural-principles.md) — the four
+  load-bearing primitives, with the corpus + fusion + rigor + on-chain provenance
+  forming the spine
+- Issues: [#97 (10k corpus)](https://github.com/hackagora/archimedes-arcadia/issues/97),
+  [#106 (DB-backed substrate)](https://github.com/hackagora/archimedes-arcadia/issues/106),
+  [#93 (Corpus Explorer UI)](https://github.com/hackagora/archimedes-arcadia/issues/93),
+  [#96 (fusion retrieval — open)](https://github.com/hackagora/archimedes-arcadia/issues/96),
+  [#101 (KB pipeline port — open)](https://github.com/hackagora/archimedes-arcadia/issues/101)

--- a/docs/ui-simplification-proposal.md
+++ b/docs/ui-simplification-proposal.md
@@ -1,0 +1,286 @@
+# UI simplification proposal — from 12 pages to 5
+
+> **Status:** Day-9 draft (2026-05-20) for team review. The proposal flows from the
+> Day-9 rewrite of [`user-stories.md`](user-stories.md); read that first if you
+> haven't. Author: Dan; reviewers: Marten, Daniel R., Chuan, Önder.
+> **Scope:** structural navigation + page consolidation. Visual polish (CSS, typography,
+> spacing) is out of scope for this doc — Daniel R. is the lead on visual polish.
+
+## TL;DR
+
+Today the live app surfaces **12 user-facing pages** across 4 nav groups. The user
+story spine (per [`user-stories.md`](user-stories.md)) only needs **5 top-level
+pages plus one modal**. We can consolidate without losing functionality and the
+result is more legible to the capable-non-expert archetype we're actually building
+for. The structural moves are bounded enough to ship pre-launch if we decide to;
+the visual polish phase can follow.
+
+## The problem
+
+The capable-non-expert archetype (per [`user-stories.md` § Primary archetype](user-stories.md#the-primary-archetype--the-capable-non-expert))
+should be able to land on `/`, understand what Archimedes does, generate a strategy,
+and decide whether to deposit — without bouncing between 12 pages or having to
+infer the difference between "Explore" and "Strategies" or between "Mint/Burn" and
+"Liquidity" (both of which are DeFi primitives, not product moves).
+
+The current navigation reflects what was *built* (every implemented capability gets a
+nav entry). The proposed navigation reflects what users actually *do*. Those are
+different shapes.
+
+## Current page inventory
+
+Per [`ui/src/components/Layout.jsx`](../ui/src/components/Layout.jsx):
+
+### Home
+- **Landing** — first-visit framing
+
+### Markets (3)
+- **Explore** (a.k.a. Marketplace) — synthetic assets, vault leaderboard, trending
+  strategies, all strategies, agent activity (one big scrolling page; now has the
+  sticky subnav from #109)
+- **Strategies** — strategy library
+- **Trade** — manual AMM swap interface against deployed contracts
+
+### Portfolio (6)
+- **Dashboard** — user-specific portfolio overview
+- **Mint / Burn** — synthetic asset issuance/redemption (DeFi primitive)
+- **Liquidity** — LP positions (DeFi primitive)
+- **Vaults** — list of available vaults
+- **Create Vault** — vault creation flow
+- **Financial Analysis** — financial metrics surface
+
+### Intelligence (3)
+- **Reasoning** — reasoning trace browser
+- **Risk Analysis** — Kelly calculator + portfolio risk + risk-band visualization
+- **Corpus Explorer** — paper catalog + overview + similarity graph + KG (new,
+  landed today)
+
+**Total: 12 pages, 4 groups.** Multiple cases of overlap (Explore vs Strategies,
+Vaults vs Create Vault) and several pure-plumbing pages (Mint/Burn, Liquidity)
+that are DeFi primitives, not user-facing moves on the product spine.
+
+## Proposed page tree (5 + 1 modal)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  TOP-LEVEL NAV (5 entries)                                       │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  /             Landing                                           │
+│                                                                  │
+│  /generate     Generate         ← NEW PRIMARY ACTION             │
+│                                                                  │
+│  /portfolio    My Portfolio     ← consolidates Dashboard + Trade │
+│                                   + Vaults + Mint/Burn + Liquidity│
+│                                   + personalized Risk view       │
+│                                                                  │
+│  /library      Library          ← consolidates Explore +         │
+│                                   Strategies + Corpus Explorer   │
+│                                   (three tabs)                   │
+│                                                                  │
+│  /learnings    Learnings        ← NEW SURFACE                    │
+│                                   (winners + losers + reasoning) │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+
+PLUS — modal (no nav entry, opens from anywhere):
+
+  Reasoning trace viewer modal
+    — opens from agent-activity feed entries
+    — opens from any strategy passport
+    — opens from any vault rebalance entry
+
+PLUS — leaf pages (deep links, not in top-level nav):
+
+  /strategy/:id    Strategy passport (deep-linked from Library cards
+                                       and from My Portfolio cards)
+  /paper/:arxiv    Paper detail       (deep-linked from passports
+                                       and from Library Papers tab)
+  /vault/:id       Vault detail       (deep-linked from My Portfolio
+                                       cards and from Library)
+```
+
+Five top-level pages instead of twelve. Each one corresponds to a real move the
+user is making on the spine.
+
+## Consolidation rationale (per merge)
+
+### My Portfolio (replaces Dashboard + Trade + Vaults + Mint/Burn + Liquidity + Risk-personalized)
+
+Today these six pages are all *about your money*. The user has to navigate between
+them to answer simple questions ("how much do I own?" → Dashboard; "what's it
+doing?" → Vaults; "how risky is it?" → Risk Analysis; "how do I move it?" → Trade
++ Mint/Burn + Liquidity). That's 5 nav clicks for one mental task: managing my
+portfolio.
+
+**Proposal:** one **My Portfolio** page with:
+- Top stat row: total value, 24h/7d change, current portfolio risk profile (computed,
+  not chosen)
+- Equity-curve chart (vs SPY benchmark)
+- Holdings table (left) + Active strategies cards (right)
+- Agent activity feed at the bottom (each entry → reasoning-trace modal)
+- Sidebar with deposit/withdraw/rebalance buttons + the risk-band visualization
+- "Advanced" disclosure (collapsed by default) containing:
+  - Mint / Burn (synthetic primitives)
+  - Liquidity (LP positions)
+  - Raw Trade (AMM swap)
+
+The "Advanced" disclosure keeps the DeFi-primitive surfaces around for power users
+without putting them in the top-level nav where they confuse the non-expert.
+
+### Library (replaces Explore + Strategies + Corpus Explorer)
+
+Today these three pages are all *about what exists in the system that isn't yours
+yet*. Same browsing intent, different content types.
+
+**Proposal:** one **Library** page with three tabs:
+- **All Strategies** (default) — what's in Strategies + the user-generated strategies
+  from Marketplace's "All Strategies" section
+- **Papers** — the existing Corpus Explorer catalog + graph + KG
+- **Vaults & Activity** — the Vault Leaderboard + Agent Activity feed from current
+  Marketplace
+
+Left filter rail across all three tabs (asset class, risk tier, rigor verdict, sort).
+The current Marketplace's "Synthetic Assets" and "Trending This Week" sections fold
+into the Strategies tab as filter views ("Trending = sort by user growth").
+
+### Generate (NEW — promotes the strategy generator from buried to primary)
+
+The strategy generator (engine v2, `POST /api/strategies/generate`) is the single
+most novel thing the product does. Today it's reachable but not surfaced as the
+primary call-to-action. Promoting it to a top-level page makes the *generative*
+nature of the product visible from the front door.
+
+The Landing page's primary CTA becomes "Generate a strategy" — sending the user
+straight to `/generate`, no wallet required to see a result. The wallet wall only
+appears at Deposit.
+
+### Learnings (NEW — directly endorsed by user feedback)
+
+> "We could even build a kind of 'learnings' page where you can see which strategies
+> have been successful, which have not, and maybe why."
+
+**Proposal:** a top-level **Learnings** page that surfaces:
+- **Winners** (left column) — currently profitable strategies, sorted by realized
+  return, each card with one-line "what went right" generated from reasoning traces
+- **Losers** (right column) — currently underperforming strategies, sorted by
+  drawdown, each card with one-line "what went wrong"
+- Click any card → opens the strategy passport + reasoning traces over the relevant
+  period
+
+This surface is **the proof that we don't hide losses.** Every "AI fund" silently
+rotates away from losing positions; making losses first-class learning material is
+the inverse of that pattern, and the inverse is the trust signal.
+
+## Specific moves (mapping current → proposed)
+
+| Current page | Move | New home |
+|---|---|---|
+| Landing | Stays | `/` Landing |
+| Explore (Marketplace) | Consolidates | `/library` (Strategies tab + Vaults & Activity tab) |
+| Strategies | Consolidates | `/library` Strategies tab (primary) |
+| Trade | Demotes | `/portfolio` Advanced section |
+| Dashboard | Consolidates | `/portfolio` (primary content) |
+| Mint / Burn | Demotes | `/portfolio` Advanced section |
+| Liquidity | Demotes | `/portfolio` Advanced section |
+| Vaults | Consolidates | `/portfolio` (active-strategies cards link to leaf `/vault/:id`); also `/library` Vaults & Activity tab |
+| Create Vault | Demotes | `/portfolio` Advanced section + deep-link from a strategy passport's "Deploy" CTA |
+| Financial Analysis | Folds in | `/portfolio` (the metrics it surfaces) |
+| Reasoning | Becomes modal | Reasoning trace viewer modal (no top-level page) |
+| Risk Analysis | Splits | Kelly calculator → `/library` Strategies tab tools panel; portfolio risk → `/portfolio` sidebar; risk-band visualization → `/portfolio` sidebar |
+| Corpus Explorer | Consolidates | `/library` Papers tab |
+| — | NEW | `/generate` Generate |
+| — | NEW | `/learnings` Learnings |
+
+## Discoverability: in-line tooltips, not a glossary page
+
+Per the user-stories rewrite, the convention is **in-line definitions, not a
+glossary page**. A glossary page loses context — the user is reading about DSR on
+the passport, has to leave the page to look it up, returns having lost their place.
+
+**Convention:** any finance acronym (DSR, PBO, Sharpe, Calmar, OOS, MVO, Kelly,
+CAGR, MDD, vol, IS) on first appearance within a section gets a small
+dotted-underline link; hover or tap opens a 1–2 sentence definition popover with a
+"learn more" link. Acronyms expanded on first use ("Deflated Sharpe Ratio, DSR").
+
+Implementation surface: a single `<Term>` React component that:
+1. Looks up the term from a central definitions registry
+2. Renders the underlined word/phrase with the tooltip wired
+3. Tracks first-occurrence-per-section so the underline only appears once per section
+   (using context or a useEffect-registered ref)
+
+A separate `/explain` route can come later for the user who clicks "learn more" from
+a tooltip — but it's a deeper-explainer surface, not the front door.
+
+## Implementation phasing
+
+### Phase A — Structural moves (can ship pre-launch if we choose)
+
+Low-risk, mostly nav + routing + page-grouping changes; no new business logic.
+
+- [ ] Consolidate nav into 5 top-level entries; demote 7 current pages
+- [ ] Add `/generate` top-level page that hosts the existing engine-v2 generator UI
+- [ ] Add `/learnings` top-level page (initially populated from the existing
+      strategy + backtest data — winners/losers by realized return)
+- [ ] Add the "Advanced" disclosure on `/portfolio` containing demoted DeFi pages
+- [ ] Switch the Landing page's primary CTA to "Generate a strategy" (deep link
+      to `/generate`)
+- [ ] Remove the "Reasoning" top-level page; wire the modal to open from agent-
+      activity feed entries
+- [ ] Update top-level nav labels accordingly
+
+Estimated effort: ~1 day for Marten + Daniel R. pairing. No backend changes
+required (all endpoints already exist).
+
+### Phase B — In-line tooltip system (can ship pre-launch)
+
+- [ ] Build the central definitions registry (a single JSON file or a Python
+      module the backend serves as `/api/glossary`)
+- [ ] Build the `<Term>` React component with the dotted-underline + popover
+- [ ] Wire it into the 10 highest-leverage surfaces (passport, generator result,
+      learnings cards)
+- [ ] Seed the registry with the ~20 most critical acronyms
+
+Estimated effort: ~0.5 day. Önder is the right person to draft the definitions
+(stats background + already drafting the "explain the rigor gate" surface per the
+standup).
+
+### Phase C — Visual polish on the consolidated pages (post-hackathon)
+
+- [ ] Daniel R. and Marten do a polish pass on the new consolidated `/portfolio`
+      and `/library` to make them feel like single coherent pages, not stitches.
+- [ ] Out of scope for the hackathon submission; surface it on a polish list for
+      the post-launch week.
+
+## Open questions / decisions needed
+
+1. **Do we ship Phase A pre-launch, or post-launch?** Pre-launch is more impactful
+   for the demo (judges see the simplified nav) but adds risk in the last 4 days.
+   Post-launch is safer but the demo carries the current 12-page surface. **My
+   read:** ship Phase A pre-launch, with Phase B as a stretch if Phase A lands by
+   Friday.
+2. **Do we keep the existing "Marketplace" terminology anywhere?** Or fully retire
+   it in favor of "Library" + "My Portfolio"? "Marketplace" implies trading; we're
+   not a marketplace today (no inter-user trading; that's the roadmap social
+   vision). I'd retire the term for the MVP.
+3. **The Strategy passport route — `/strategy/:id`?** Currently strategies are
+   reachable from a few places; making this the single canonical deep-link is good
+   hygiene but requires a small URL-routing change. Worth doing as part of Phase A.
+4. **Vault detail — keep as a leaf page or fold into the Strategy passport?** A
+   strategy IS deployed via a vault, and the vault carries on-chain state the
+   strategy alone doesn't. I'd keep `/vault/:id` as a separate leaf for now, with
+   the strategy passport linking to it.
+5. **The Learnings page needs data.** Without enough deployed strategies and
+   time-elapsed performance, "Winners + Losers" is sparse. The demo can use the 5
+   reference strategies + their 22-year backtest results as the data source
+   (rolling 1-year periods → clear winners + losers). Pre-launch decision: is
+   that honest enough, or do we need live deployed-strategy outcomes?
+
+## See also
+
+- [`user-stories.md`](user-stories.md) — the user stories this proposal serves
+- [`claude-design-prompts.md`](claude-design-prompts.md) — Prompts 3 (UI refinement
+  toward this page tree) and 12 (current-vs-proposed page-map diagram)
+- [`corpus-architecture.md`](corpus-architecture.md) — what the Library Papers tab
+  is actually serving
+- [`launch-plan.md`](launch-plan.md) — what needs to be true at launch

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1,99 +1,77 @@
 # Archimedes — User Stories & The One Spine
 
-> **Status:** Draft, 2026-05-19 (testnet-reality reframe). Spine locked by product-lead decision (Dan). Visual
-> items marked 🔍 await Marten/Daniel's UX walkthrough (per issue #39). Read with
-> [`design.md`](design.md) and [`demo-script-pitch-deck-outline.md`](demo-script-pitch-deck-outline.md).
+> **Status:** Day-9 rewrite (2026-05-20). The spine is locked; this rewrite refocuses
+> the doc around **who the user is and what they're trying to do**, with the
+> Linus/KnowledgeBase architectural lineage moved out to
+> [`docs/research/linus-archimedes-comparison.md`](research/linus-archimedes-comparison.md)
+> so it doesn't crowd the user-facing story. Read alongside
+> [`design.md`](design.md), [`corpus-architecture.md`](corpus-architecture.md), and
+> [`demo-script-pitch-deck-outline.md`](demo-script-pitch-deck-outline.md).
 
 ## One-line definition
 
-**Archimedes is Linus, specialized to quantitative finance for user profit.**
-Linus turns a research corpus into a curated, provenance-anchored knowledge
-substrate that compounds over time. Archimedes turns the q-fin literature into a
-curated, provenance-anchored **strategy library** that compounds a user's
-portfolio over time.
+**Archimedes is a research-grounded strategy-generation instrument for non-experts who
+want their idle USDC to compound thoughtfully** — fusing what you want with current
+market conditions and 10,000 q-fin research papers into novel strategies, gating them
+through selection-bias rigor (so you only see what's defensibly real), executing them
+into your non-custodial vault on Arc, and surfacing every reasoning step so you can
+inspect what worked and what didn't.
 
-> **Testnet reality (read this first).** Arc has **no mainnet** — it is
-> testnet-only (Circle's Arc docs list mainnet as "upcoming"; the public testnet
-> "mirrors mainnet behavior, no real assets"). The honest user story is *"try the
-> full flow on the Arc public testnet with faucet USDC"* (<https://faucet.circle.com/>,
-> 20 USDC / 2h, USDC-is-gas) — **no real funds at risk, by design.** This is a
-> strength, not a hedge: it is the correct posture for an Arc-stage project, and
-> it means the "Deposit" step is a *testnet deposit*. Real-funds custody, mainnet,
-> and the regulatory architecture (off-chain redemptions, preset-strategy / RIA
-> posture, exploit alerting) are the **mainnet / business-plan roadmap** — see
-> [`competitor-landscape.md`](competitor-landscape.md) § Regulatory.
+> **Testnet reality (read this first).** Arc has **no mainnet** — it's testnet-only
+> (Circle's docs list mainnet as "upcoming"; the public testnet "mirrors mainnet
+> behavior, no real assets"). The honest user story is *"try the full flow on the Arc
+> public testnet with faucet USDC"* (<https://faucet.circle.com/>, 20 USDC / 2h,
+> USDC-is-gas) — **no real funds at risk, by design.** This is a strength, not a
+> hedge: it's the correct posture for an Arc-stage project. Real-funds custody,
+> mainnet, and the regulatory architecture are the mainnet / business-plan roadmap.
 
-## Lineage — what we port from Linus / KnowledgeBase, and what we don't
+## The primary archetype — the **capable non-expert**
 
-The deep primitive is not "paper notes." It is a **layered-memory + knowledge-graph
-architecture with provenance and a quality/curation gate**.
+The user we are building for, in detail. Almost every product decision should be
+defensible against this archetype.
 
-| Linus / KnowledgeBase primitive | Archimedes port |
-| --- | --- |
-| KnowledgeBase: research corpus → SPECTER2 embeddings → clustering → **similarity graph + knowledge graph** (entity-relation triplets) over curated metadata | The **q-fin research graph**: papers ↔ methods ↔ assets ↔ regimes ↔ strategies. Strategy *fusion* = traversal/synthesis across related papers, not a single-paper port |
-| Memory pillar — 5 layers (DEC-0028): session scratchpad (B), **cross-session episodic** (C), **investigation memory** (D), **semantic knowledge** (E) | The user's **strategy library + portfolio history** = episodic memory (C); a single generate→backtest run = investigation memory (D); the q-fin research graph = semantic memory (E) |
-| Per-paper **quality scorecard** as a retrieval-time signal (peer-review, preprint, data/code, retraction, citation/age) | The **selection-bias rigor gate (DSR/PBO/walk-forward) + strategy passport** — the q-fin quality scorecard. *This is the curation protocol that makes the library trustworthy.* |
-| Provenance/integrity: claim typing, content hashing, append-only audit | **On-chain reasoning traces + content-hashed methodology** — already our differentiator; same primitive |
-| Garrison's four obligations: addressability, disambiguation, temporal order, integrity | The properties the library/portfolio memory must satisfy: find a strategy, distinguish near-duplicates, ordered decision history, tamper-evident traces (on-chain) |
-| Maestro/Worker discipline | Hosted Claude/GLM plans; the agent executes; humans review |
+**Who they are:**
 
-**Deliberately NOT ported** (explicit product-lead decision): Apple-Silicon /
-local-first execution; fine-tuning, LoRA/QLoRA, pmetal; offline data sovereignty
-(Kiwix/PMTiles); the electricity-budget framing. **Inference is the GLM API key**
-(z.ai Anthropic-compatible). Archimedes is a hosted, single-user web product.
+- Has idle USDC (or wants to). Salary income, side-business income, crypto-native
+  savings — any source. Not pre-allocated to anything urgent.
+- Curious about quantitative finance but not a quant. May know what "Sharpe ratio"
+  means but probably can't define DSR or PBO without help. Comfortable enough with
+  numbers to read a chart.
+- Has tried robo-advisors and found them opaque ("why these allocations?").
+- Has watched crypto influencers shill strategies and noped out (correctly).
+- Has been tempted by AI-flavored portfolio agents but doesn't trust them — *what is
+  the agent actually thinking? where does it get its ideas from? is it just a chatbot
+  pretending to be a quant?*
+- Wants the system to work **semi-autonomously**. Doesn't want to babysit it daily.
+  Does want to be able to inspect what it did and why, on demand.
 
-## Additional architectural primitives (beyond the memory pillar)
+**What they want:**
 
-Linus's orchestration layer (`src/linus/`, Phase 2a largely landed) carries
-primitives Archimedes should lift as **patterns** (not local-first machinery):
+> "An app that helps me make money. That works mostly on its own. That I can trust
+> because I can see what it's doing and why it's doing it. That doesn't require a
+> finance PhD to operate or a crypto-degen tolerance for risk."
 
-| Linus primitive (status) | Archimedes port | Value |
-| --- | --- | --- |
-| **RAG gateway** — fuses SPECTER2 + TF-IDF + KG into one context object; cached, query-logged (Phase 2, thin adapter) | The research-grounding engine: hybrid retrieval over the q-fin corpus is what makes a strategy *grounded*, not merely prompted | ★ highest |
-| **Tool registry, MCP-shape** — `@tool` decorator, domain-grouped (`linus.tools`, landed) | `archimedes.research.* / strategy.* / rigor.* / vault.*` as inspectable MCP tools — composable and judge-legible | ★ high |
-| **Anthropic-compatible server** + tool-call routing + model-preference fallback (`linus.server`; `/v1/messages` = DEC-0056, outstanding N3) | Direct reference for Archimedes's GLM gateway (already Anthropic-compat); fallback = resilience if GLM drops | ★ high |
-| **Agent spawner** — N parallel Workers, scoped prompt + scoped tool allowlist + shared SQLite results, merged to parent (Phase 3, deferred) | **The strategy-fusion engine**: one Worker per paper/method → merge into a novel fused strategy. This *is* the novelty differentiator | ★ high |
-| **Sandbox** — allowlist/blocklist per tool call; confirmation-required ops returned for user approval; every call audited (landed) | Safe autonomous USDC moves; "confirm before rebalance" = the human-in-the-loop trust gate | ★ high |
-| **Audit log** — append-only JSONL of every model/tool/policy decision; basis for "autonomy graduation" (landed) | Off-chain provenance richer than trace hashes; *"the agent earns autonomy as its audited record grows"* = a strong pitch arc | ★ high |
-| **Maestro-side output synthesis** (DEC-0023) — Worker outputs → balanced bullets + prose with citation drill-down | How a generated strategy is presented: synthesized rationale that drills down to source papers = the passport | medium-high |
-| **Trust-tier tagging** on every context item | Each strategy input (peer-reviewed vs preprint vs scraped) tagged → feeds the rigor scorecard | medium-high |
-| Router metadata (`memory_mode`/`cot_budget`), Skills (`SKILL.md`) | Cost/quality discipline; templated strategy archetypes | defer |
+**What they explicitly do NOT want:**
 
-## Linus-MVP prioritization for Archimedes (reverse signal)
+- A wall of jargon they have to Google.
+- An "AI" that gives them strategies with no provenance.
+- A robo-advisor that tells them their allocation without explaining why.
+- A chat interface they have to babysit ("ask me for a strategy" is *also* a wall;
+  the system should propose useful defaults).
+- An app that disappears their losses (silently rotating away from losing positions
+  with no explanation is the failure mode of every "AI fund").
+- A wallet that holds their funds for them (non-custodial only).
 
-Ranked by Archimedes value, to steer what the Linus MVP should include:
+**Implication for the product:** every page should be readable by this person on
+first visit. Acronyms get in-line definitions. Numbers have context. Reasoning is
+always available, never hidden. The interface defaults to *propose*, not *prompt*.
 
-- **Tier 1 — make these clean & copyable in the Linus MVP:**
-  1. **RAG gateway interface.** Thin in Linus, but the #1 Archimedes primitive —
-     the entire "research-grounded" claim rests on hybrid retrieval. A clean
-     gateway contract is the single highest-leverage thing to nail.
-  2. **Tool registry (MCP-shape).** Already landed (`linus.tools`); the
-     architectural backbone Archimedes copies wholesale.
-  3. **Anthropic `/v1/messages` + model fallback (N3, outstanding).**
-     De-risks Archimedes's GLM gateway directly — worth finishing in the MVP.
-- **Tier 2 — pull forward if the Archimedes pitch needs it:**
-  4. **Agent spawner.** Deferred to Phase 3 in Linus, but *Phase 1* for
-     Archimedes — it is the fusion/novelty engine.
-  5. **Sandbox + audit log.** Landed; lift directly for autonomous-USDC safety
-     and the provenance / "autonomy graduation" narrative.
-- **Tier 3 — defer for the hackathon:** Skills, router intelligence,
-  training/fine-tuning, data sovereignty.
+## Secondary lens — the **judge-as-operator**
 
-**The two divergences that matter for Linus-MVP scoping:** (1) the **RAG
-gateway** is "thin / Phase 2" in Linus but Tier-1 for Archimedes — make its
-interface a first-class, copyable contract; (2) the **agent spawner** is
-"Phase 3 / deferred" in Linus but the engine of Archimedes's novelty pitch — a
-minimal version in the MVP pays outsized Archimedes dividends.
-
-## Personas
-
-- **Primary — the single user / allocator.** Has idle USDC, wants
-  research-grounded exposure without hand-picking strategies. The product is
-  built for exactly one of them at a time (MVP).
-- **Evaluation lens — judge-as-operator.** A Stellar/Coinbase/Arc-Circle/Protocol
-  Labs judge who reads the repo and clicks the live link like an operator. The
-  judge is the primary persona, on rails. Whatever serves the judge serves the
-  real user.
+A Stellar / Coinbase / Arc / Circle / Protocol Labs judge who reads the repo and
+clicks through the live link like an operator would. The judge isn't the customer,
+but **what serves the judge serves the customer**: a fast, legible path through the
+product that demonstrates the wedge without needing the judge to read the deck first.
 
 ## The one spine (this is the whole product story)
 
@@ -101,70 +79,245 @@ minimal version in the MVP pays outsized Archimedes dividends.
    describe intent
         │
         ▼
-   ① GENERATE      research-grounded strategy from your interests,
-                   fused across the q-fin research graph
+   ① GENERATE      research-grounded strategy from your intent,
+                   fused across user brief × market regime × q-fin corpus
         │
         ▼
    ② RIGOR-GATE    DSR / PBO / walk-forward — the curation protocol;
-                   only what clears it is admitted to your LIVE library
+                   only what clears it is admitted to your library
         │
         ▼
-   ③ EXECUTE       allocate it into a non-custodial vault (USDC on Arc)
+   ③ EXECUTE       allocate it into a non-custodial vault (testnet USDC on Arc)
         │
         ▼
    ④ MONITOR       portfolio, results, and the agent's on-chain reasoning
         │
         ▼
-   ⑤ EXPLORE       your compounding library of strategies + their passports
+   ⑤ EXPLORE       your compounding library + the underlying research,
+                   plus the LEARNINGS surface (wins AND losses, with reasoning)
 ```
 
-Mapped to the existing UI surfaces:
+Each step, expressed as the story the user is living:
 
-| Step | Story | Surface |
-| --- | --- | --- |
-| ① Generate | "As a user, I describe what I want (e.g. *steady growth, low drawdown, trend-following*) and Archimedes generates a strategy grounded in named q-fin papers." | Strategies → *Strategy Architect* |
-| ② Rigor-gate | "I see *why* I should trust it: paper provenance, methodology hash, and the selection-bias scorecard — not a placeholder number." | Strategies passport · Risk Analysis |
-| ③ Execute | "I allocate USDC into a vault running it. This is the only step that needs a wallet." | Vault Detail → Deposit |
-| ④ Monitor | "I watch holdings, results, regime, and the agent's reasoning trace — verifiable on-chain." | Dashboard · Reasoning · Vault Detail |
-| ⑤ Explore | "I browse my growing library of strategies and revisit any passport." | Strategies / library view |
+### ① Generate
 
-DeFi primitives (Mint/Burn, Liquidity, raw Trade) are **plumbing, not the
-product** → group under "Advanced"; they are not on the spine or the demo path.
+> *"I describe what I want — steady growth, low drawdown, maybe a 5-year horizon — in
+> plain English. Archimedes proposes a strategy and shows me which research papers
+> informed it. The first thing I see is a citation, not a confident assertion."*
+
+### ② Rigor-gate
+
+> *"I see whether the proposed strategy *survives* a battery of statistical tests
+> before I'm asked to deploy it. If it doesn't pass — the strategy is preserved in
+> a 'considered but rejected' bucket with the reasoning intact, so I can see what
+> was tried. If it passes, the verdict cards (DSR, PBO, OOS Sharpe, look-ahead
+> audit) are visible with plain-English explanations next to each."*
+
+### ③ Execute
+
+> *"I deposit testnet USDC into a non-custodial vault that runs the strategy. The
+> only step that needs my wallet. The vault tells me, in advance, what authorities
+> the agent has (rebalance, yes; withdraw-to-platform, never). I confirm. Done."*
+
+### ④ Monitor
+
+> *"I check in. I see how my portfolio is performing, what the agent has done
+> recently, and why. Every rebalance has a reasoning trace I can open — what market
+> conditions it saw, what papers it referenced, what it decided. The full trace is
+> hashed and anchored on Arc — I can verify it wasn't rewritten."*
+
+### ⑤ Explore (Library + Learnings)
+
+> *"I browse my growing library of strategies — the ones running, the ones rejected
+> by the rigor gate (and why), the ones I generated and never deployed. I also
+> browse the underlying paper corpus when I want to understand the field. **And I
+> visit the Learnings page** to see which of my (and the system's) strategies have
+> performed well, which haven't, and what the agent's reasoning was in each case —
+> losing trades are first-class learning material, not hidden failures."*
+
+## Stories by page / surface
+
+The pages exist to support the spine. Each one earns its place by enabling specific
+user moves.
+
+### `/` Landing
+
+> *"As a first-time visitor, I want to understand in 30 seconds what this is and why
+> I might trust it, before I'm asked to connect anything."*
+
+**Surfaces:** product framing (Linus-for-q-fin tagline), the 5-step spine
+visualization, the wedge (research-grounded + rigor-gated + provenance-anchored),
+the honest-framing statement (testnet posture, no-alpha-promise). Big CTA: **Generate
+a strategy** (no wallet required).
+
+### `/generate` Generate (the new primary action)
+
+> *"As a user, I want to describe what I want and see a candidate strategy come back
+> — grounded in named papers, with the rigor verdict visible — without first having
+> to pick from a menu of pre-built options."*
+
+**Surfaces:** the natural-language brief input + optional structured inputs (asset
+class, risk, horizon) + the 3-input fusion preview ("what fusion will see") + the
+result card (strategy spec, citations, rigor verdict, deploy CTA). See Prompt 3 in
+[`claude-design-prompts.md`](claude-design-prompts.md) for the screen design.
+
+### `/portfolio` My Portfolio (consolidates current Trade + Vaults + personalized Risk view)
+
+> *"As a depositor, I want one place to see what I own, how it's performing, and what
+> the agent has done — without bouncing between 3 tabs."*
+
+**Surfaces:** total value + 24h/7d change + computed risk profile + portfolio equity
+curve vs SPY + holdings table + active-strategies cards + agent activity feed (each
+entry deep-links to its reasoning trace). Sidebar: deposit / withdraw / rebalance +
+the risk-band visualization (consolidated from the standalone Risk page).
+
+### `/library` Library (consolidates current Marketplace + Strategies + Corpus Explorer)
+
+> *"As a curious user, I want to browse what's been generated, what's been validated,
+> and what research underlies it — in one place, with filters that make sense."*
+
+**Surfaces:** three tabs at top — All Strategies / Papers / Vault Leaderboard. Left
+filter rail (asset class, risk tier, rigor verdict, sort). Empty-state nudge back to
+Generate. Each strategy card links to its passport (see below).
+
+### `/strategy/:id` Strategy passport
+
+> *"As someone considering depositing into a strategy, I want to see the full provenance
+> — the source papers, the methodology in plain English, the backtest results vs the
+> paper's claims, the rigor verdict with each gate explained, and the on-chain
+> verification — so I can decide whether to trust this with my USDC."*
+
+**Surfaces:** the Day-9 passport per Prompt 4 in
+[`claude-design-prompts.md`](claude-design-prompts.md) — strategy name + Tier badge,
+academic-style paper citation, real backtest numbers with paper-claim deltas, the
+4-gate rigor panel (DSR + PBO + OOS Sharpe + look-ahead) with plain-English explainers,
+equity-curve chart, on-chain trace anchor with Verify button, source-papers section.
+
+### `/learnings` Learnings (NEW — strongly endorsed by user feedback)
+
+> *"As a user managing a portfolio over time, I want to see honestly which strategies
+> are working, which aren't, and **why** — with the agent's reasoning available for
+> both winners and losers — so I can develop my own intuition rather than treat the
+> system as a black box."*
+
+**Surfaces:** two-column layout — "Winners" (currently profitable strategies, sorted
+by realized return) and "Losers" (currently underperforming, sorted by drawdown).
+Each card has the realized return + a "What went right/wrong" summary generated from
+the agent's reasoning traces over the relevant period + the reasoning-trace links
+themselves. **This is the surface that proves we don't hide losses.**
+
+### Reasoning trace viewer (modal, opens from anywhere)
+
+> *"When I click 'view reasoning' on any decision, I want to see what the agent saw,
+> what papers it referenced, what it decided, and how to verify the trace wasn't
+> rewritten."*
+
+**Surfaces:** market context, source-signals papers, prose reasoning (with inline
+acronym definitions), action taken (before/after weights + trades + tx hashes), tool
+calls (collapsible), verification footer with hash + Verify button. See Prompt 5 in
+[`claude-design-prompts.md`](claude-design-prompts.md).
+
+## The jargon problem — in-line definitions, not a glossary page
+
+A glossary page loses context (the user is reading about DSR on the passport, has to
+leave the page to look it up, comes back having lost their place).
+
+**Convention adopted:** any finance acronym (DSR, PBO, Sharpe, Calmar, OOS, MVO,
+Kelly, CAGR, MDD, vol, IS) on first appearance within a section gets a small
+dotted-underline link; hover or tap opens a 1-2 sentence definition popover with a
+"learn more" link to a deeper explainer for the user who wants to go further.
+Acronyms expanded on first use within a section ("Deflated Sharpe Ratio, DSR").
+
+If we add an `/explain` route later, it should be a *deeper* explainer for the user
+who clicks "learn more" from a tooltip — not the front door.
+
+## Honesty rules in effect
+
+These constraints are user-story-level, not architecture footnotes. They're load-
+bearing for trust.
+
+- **We don't promise alpha.** We promise evidence-grounded generation with externally
+  verifiable rigor. Past performance, even of validated strategies, doesn't guarantee
+  future returns.
+- **Arc is testnet by design.** Putting real funds on a chain that's pre-mainnet
+  would be reckless. Contracts are real; settlement is real testnet USDC.
+- **The corpus is generated-from, not retrieved-from.** The LLM reads cited papers
+  and produces a strategy spec; it does not lift strategies verbatim.
+- **Losing strategies are visible.** The Learnings page surfaces both winners and
+  losers. Silently rotating away from losses is the failure mode of every "AI fund"
+  — we explicitly don't.
+- **The rigor gate can be wrong.** A strategy that passes DSR/PBO might still
+  underperform out-of-sample; a strategy that fails might have been over-cautiously
+  rejected. The gate is a *bar*, not a guarantee. We surface the verdict and the
+  inputs that produced it.
 
 ## Judge happy-path (the ~3-min demo, read-only until deposit)
 
-1. Landing → **Explore** (no wallet).
-2. **Strategies** — real paper-grounded strategy; open a passport (provenance + hash + rigor scorecard, **no "est." placeholder**).
-3. **Reasoning** — the agent's decisions, traced and on-chain-verifiable.
-4. **A Vault** — strategies → allocations → reasoning, tied together.
-5. **Risk Analysis** — DSR/PBO/Kelly: the curation protocol made visible.
-6. Wallet wall appears **only at Deposit** — the single gated action.
+1. Landing → **Generate** (no wallet). Describe a goal, click Generate.
+2. **Generated result** — see a paper-grounded strategy with the rigor verdict
+   visible. Open the passport. Verify a paper citation. Click "Verify trace."
+3. **Library** — see other strategies (Tier-1 + rejected). Open one of the rejected
+   ones, see why it failed the gate. (This is the honesty proof point.)
+4. **Learnings** — see which strategies have performed well and which haven't, with
+   the agent's reasoning available for each. (The "we don't hide losses" proof.)
+5. **Vault detail** (or "Deploy" CTA on the generated strategy) — show the
+   non-custodial vault structure, the agent's authorities.
+6. **Wallet wall** appears **only at Deposit** — the single gated action.
 
 ## Scope
 
 **In (the MVP we ship & demo):** the single-user spine end-to-end, one user at a
 time, GLM-backed, hosted, **on the Arc public testnet with faucet USDC (no real
-funds)**.
+funds)**. The 5 reference strategies (2 of them currently Tier-1) plus the
+generator-produced strategies. The DB-backed 10,000-paper q-fin corpus + the live
+Corpus Explorer. The rigor gate with real 22-year SPY data. On-chain reasoning
+traces via the deployed `ReasoningTraceRegistry`.
 
-**Out (stated vision / roadmap — narrate, do not build):** multi-user accounts;
-**a social network of shared strategies & vaults** — users publishing strategies
-others can discover, allocate to, and fork. This is the scale story for the
-README and demo video: the same curated-library substrate, made social. A clear,
-enticing expansion path strengthens the pitch; building it does not fit the
-hackathon window.
+**Out (stated vision / roadmap — narrate, do not build):**
 
-## Open items to verify (🔍 — owners: Marten / Daniel, per #39)
+- **Multi-user accounts.** Single-user is the MVP; multi-user is the roadmap.
+- **A social network of shared strategies & vaults.** Users publishing strategies
+  others can discover, allocate to, and fork. The same curated-library substrate,
+  made social. Strengthens the pitch as a clear expansion path; building it doesn't
+  fit the hackathon window.
+- **Mainnet + real-funds custody.** Requires the regulatory architecture (off-chain
+  redemptions, preset-strategy / RIA posture, exploit alerting) — see
+  [`competitor-landscape.md`](competitor-landscape.md) § Regulatory.
+- **The full KB-pipeline artifact (#101).** Substrate is scaffolded (named volume
+  mounted, `cluster_id`/`topic_label` columns ready); the heavy embedding +
+  clustering + KG build is deferred post-hackathon. Lightweight graph/kg endpoints
+  serve the demo from on-the-fly DB queries.
+- **Real fusion retrieval (#96).** Currently keyword matching; SPECTER2 + RAG + KG
+  is now unblocked and may land before submission depending on time budget.
 
-- 🔍 Is the entire hero path (Strategies→Reasoning→Vault→Risk) traversable
-  **read-only with no wallet**, gating only at Deposit?
-- 🔍 Do builder affordances (Strategies' *Architect* box, Reasoning's manual
-  *publish-trace* form) render to an anonymous visitor? Gate/label for the demo.
-- 🔍 No router: do refresh / browser-back / shared deep-links survive mid-journey?
-- 🔍 Two strategy surfaces (Strategies vs Marketplace) — confirm which is canonical
-  for the spine; the other is removed from the demo path.
+## Open items to verify (🔍 — owners: Marten / Daniel R., per #39)
+
+- 🔍 Is the entire hero path (Generate → result → Library → Learnings → Vault)
+  traversable **read-only with no wallet**, gating only at Deposit?
+- 🔍 Do refresh / browser-back / shared deep-links survive mid-journey across the
+  new consolidated page tree?
+- 🔍 Does the in-line acronym tooltip convention render correctly on touch devices
+  (tap-to-open + dismiss-by-tap-outside)?
+- 🔍 Does the Learnings page have enough live data (winners and losers) to be
+  visually populated during the demo? If not, we need to either deploy more strategy
+  variation or seed the page with example outcomes that are clearly labeled.
 
 ## Definition of done
 
-- This spine is the single narrative in README, demo script, and the live app.
-- No placeholder ("est.") metrics on the judge path (ties to the rigor-wedge P0).
+- This spine is the single narrative in the README, the deck, the live app, and any
+  external comms (Discord, Twitter, launch tweet).
+- No placeholder ("est.") metrics anywhere on the judge path (ties to the rigor-wedge
+  P0; verified done as of #105 + #108).
 - 🔍 items resolved by the walkthrough; the canonical strategy surface chosen.
+- Capable-non-expert can land on `/`, click Generate, and produce + understand a
+  strategy without leaving the app for a Google search.
+
+---
+
+## Architectural lineage (one-line pointer)
+
+The Linus / KnowledgeBase primitives Archimedes ports (RAG gateway, tool registry,
+agent spawner, sandbox, audit log, layered-memory model, quality scorecard) are
+documented in [`docs/research/linus-archimedes-comparison.md`](research/linus-archimedes-comparison.md).
+That content used to live in this file but it's architectural history, not user
+stories — it crowds the user-facing narrative and the team can read it on demand.


### PR DESCRIPTION
## Summary

Day-9 docs sweep landing 5 related changes as one PR — they're tightly linked (Prompt 3 of the design doc references the UI proposal's page tree; the user-stories rewrite references the design doc; the corpus doc grounds Prompts 6-12). Reviewable as one unit.

## Changes

### 1. `docs/user-stories.md` — substantial rewrite (Day-9, non-expert archetype)

Strips the Linus-centric architectural-lineage content (which already lives in `docs/research/linus-archimedes-comparison.md`) and refocuses on **who the user is** and **what they're trying to do**.

- New **"Primary archetype — the capable non-expert"** section deeply fleshed out
- The product spine (Generate → Rigor-gate → Execute → Monitor → Explore) gets one user story per step
- New **"Stories by page/surface"** section tying every story to a page
- New **`/learnings`** surface (winners AND losers with reasoning) — directly from your feedback ("which strategies have been successful, which have not, and maybe why")
- New **"Jargon problem"** section: in-line tooltips, not a glossary page
- New **"Honesty rules in effect"** section: we don't promise alpha; Arc is testnet by design; losing strategies are visible; the rigor gate can be wrong
- Judge happy-path updated to the new page tree
- Architectural lineage → one-line pointer to the existing lineage doc

### 2. `docs/ui-simplification-proposal.md` — NEW

Concrete proposal for **12 user-facing pages → 5 top-level + 1 modal**. Flows from the user-stories rewrite — each proposed page corresponds to a real move on the spine.

- **My Portfolio** consolidates Dashboard + Trade + Vaults + Mint/Burn + Liquidity + Risk Analysis (personalized view), with an "Advanced" disclosure for the DeFi primitives
- **Library** consolidates Explore (Marketplace) + Strategies + Corpus Explorer into 3 tabs
- **NEW** top-level `/generate` (promotes the strategy generator from buried to primary)
- **NEW** top-level `/learnings` (winners + losers with reasoning)
- **Reasoning** becomes a modal (no top-level page)
- In-line acronym tooltips via a single `<Term>` component, not a glossary page
- Phased: Phase A (structural moves) can ship pre-launch; Phase B (tooltips) is a stretch; Phase C (visual polish) is post-hackathon
- 5 open questions teed up for the team

### 3. `docs/claude-design-prompts.md` — Day-9 refresh + 7 new explainer prompts

The Day-4 content had drifted out of sync with shipped reality.

- Header status moved Day-4 → Day-9
- **Prompt 2 (slide deck) rewritten** for current framing — "Linus for q-fin", 10 slides, engine v2 live, 2 Tier-1 strategies with real SPY numbers, an honest-framing "what we're NOT promising" slide added
- **Prompt 3 (UI refinement) rewritten** from the obsolete Conservative/Moderate/Aggressive risk-tier-cards flow to the generator-first / proposed simplified page tree
- **Prompt 4 (passport) refreshed** with real Moreira-Muir numbers + the DSR/PBO/OOS gate panel
- **Prompt 5 (reasoning trace modal) lightly refreshed**
- Dropped the redundant logo-color-and-typography section
- **Added Prompts 6-12**: new "Explainer prompts" section — corpus substrate diagram, 3-input fusion explainer, rigor-gate flowchart, end-to-end user journey, on-chain reasoning-trace anchoring, single-page launch explainer, current-vs-proposed UI page-map

### 4. `docs/corpus-architecture.md` — NEW

Persistent team-facing reference doc explaining the corpus end-to-end:

- The 3-layer substrate (seed manifest → Postgres truth → persistent artifact volume)
- Why seed and intake are two distinct write paths
- Why local and deployment differ (and mostly don't)
- What a paper row actually contains (PaperRecord schema walkthrough)
- How a paper becomes part of a strategy (the fusion path, ASCII diagram)
- Wired-vs-not-yet sections so the team can see exactly what's shipped vs scaffolded vs deferred
- Cross-references to code, specs, and GitHub issues

### 5. `CLAUDE.md` — link to corpus-architecture doc

Adds `docs/corpus-architecture.md` to the architecture-lineage list at the top so new sessions surface it alongside `design.md`, the strategy-passport spec, etc.

## Background

This is the docs portion of the Day-9 "landing the product" effort. Two motivations:

1. **The Day-4 design-prompts content described a product we've since pivoted around** — slide-deck bullets referenced "5 bullets for what we built" when we've shipped much more; the UI refinement prompt was still about Conservative/Moderate/Aggressive risk-tier-cards onboarding which is retired.
2. **The corpus and the user model are both genuinely complex** and the substance was scattered across session transcripts, code comments, and a doc whose framing had drifted Linus-centric. Consolidating gives the team (and the deck, and the launch comms) a single source of truth for each.

The structural moves proposed in the UI simplification doc are scoped tightly enough that Phase A could ship pre-launch if the team chooses — see the "Open questions" section for the decisions teed up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
