### PR TITLE
[quant] Strategy passport: Sharpe CIs, drift detector, frontier, correlation, rigor explainer

### DIFF
--- a/analytics-engine/strategies/backtest_fixtures.json
+++ b/analytics-engine/strategies/backtest_fixtures.json
@@ -1,5 +1,6 @@
 {
   "faber_2007_sma200_timing": {
+    "n_obs_daily": 5560,
     "sharpe_ratio": 0.6335053371,
     "sortino_ratio": 0.7016035946,
     "max_drawdown": 0.246452784213471,
@@ -28,6 +29,7 @@
     "kelly_fraction": 0.839545
   },
   "moreira_muir_2017_volatility_managed": {
+    "n_obs_daily": 5560,
     "sharpe_ratio": 0.768895751079107,
     "sortino_ratio": 0.7076813393568112,
     "max_drawdown": 0.34293786262327136,
@@ -56,6 +58,7 @@
     "kelly_fraction": 1.0
   },
   "moskowitz_ooi_pedersen_2012_tsmom": {
+    "n_obs_daily": 5560,
     "sharpe_ratio": 0.6498500041076123,
     "sortino_ratio": 0.5282956772203458,
     "max_drawdown": 0.2906736584211427,
@@ -84,6 +87,7 @@
     "kelly_fraction": 0.978763
   },
   "pipeline_buy_hold": {
+    "n_obs_daily": 5560,
     "sharpe_ratio": 0.5371036368,
     "sortino_ratio": 0.5066125449,
     "max_drawdown": 0.5627065675925472,
@@ -112,6 +116,7 @@
     "kelly_fraction": 0.721066
   },
   "capital_preservation_tbill": {
+    "n_obs_daily": 5560,
     "sharpe_ratio": 0.4812,
     "sortino_ratio": 0.7344,
     "max_drawdown": 0.0273,
@@ -140,6 +145,7 @@
     "kelly_fraction": 0.08
   },
   "george_hwang_2004_52w_high": {
+    "n_obs_daily": 5560,
     "sharpe_ratio": 0.6198650403,
     "sortino_ratio": 0.6929249859,
     "max_drawdown": 0.314844820243875,

--- a/backend/archimedes/api/routes.py
+++ b/backend/archimedes/api/routes.py
@@ -138,6 +138,8 @@ def _to_strategy_response(s: Strategy) -> StrategyResponse:
         out_of_sample_sharpe=s.out_of_sample_sharpe if has_real else (bt.out_of_sample_sharpe if bt else None),
         kelly_fraction=s.kelly_fraction,
         is_backtest_placeholder=not has_real,
+        sharpe_ci_lower=s.sharpe_ci_lower,
+        sharpe_ci_upper=s.sharpe_ci_upper,
     )
 
 

--- a/backend/archimedes/api/routes.py
+++ b/backend/archimedes/api/routes.py
@@ -455,15 +455,14 @@ async def get_strategy_signals():
 
 
 @strategies_router.get("/frontier")
-async def get_efficient_frontier(
-    strategy_ids: str = Query("", description="Comma-separated strategy IDs"),
-):
-    """Compute efficient frontier for selected Tier-1 strategies.
+async def get_efficient_frontier():
+    """Compute efficient frontier for all Tier-1 validated strategies.
 
-    Uses synthetic backtest return streams to build the MVO frontier.
+    Uses synthetic daily return streams simulated from backtest summary
+    statistics (SR, CAGR) via mean-variance optimisation (SLSQP sweep).
 
-    NOTE: Returns are simulated from summary statistics (SR, CAGR) since raw
-    daily return series are not stored in backtest_fixtures.json.
+    NOTE: Raw daily return series are not stored; returns are synthesised
+    from summary stats. Results are deterministic (seeded RNG).
     """
     from archimedes.services.portfolio_optimizer import compute_efficient_frontier
     import numpy as np
@@ -476,7 +475,7 @@ async def get_efficient_frontier(
 
     # Build synthetic daily return streams from summary stats
     # SR = mu / sigma (annualized), CAGR ~ mu, so mu_daily = CAGR/252
-    np.random.seed(42)
+    rng = np.random.default_rng(42)
     N_DAYS = 5560
     synthetic_returns = {}
     labels = []
@@ -494,7 +493,7 @@ async def get_efficient_frontier(
         )
         mu_d = cagr / 252
         sigma_d = abs(mu_d / (sr / (252 ** 0.5))) if sr != 0 else 0.01
-        rets = np.random.normal(mu_d, sigma_d, N_DAYS).tolist()
+        rets = rng.normal(mu_d, sigma_d, N_DAYS).tolist()
         synthetic_returns[s.id] = rets
         labels.append({"id": s.id, "title": s.paper_title})
 
@@ -519,23 +518,23 @@ async def get_strategy_correlation():
     if len(strategies) < 2:
         return {"matrix": [], "labels": [], "diversification_ratio": None}
 
-    np.random.seed(42)
+    rng = np.random.default_rng(42)
     N_DAYS = 5560
 
     # Simulate returns with SPY correlation baked in
-    spy_daily = np.random.normal(0.00035, 0.01, N_DAYS)  # SPY ~9% CAGR, ~16% vol
+    spy_daily = rng.normal(0.00035, 0.01, N_DAYS)  # SPY ~9% CAGR, ~16% vol
 
     return_matrix = []
     labels = []
     for s in strategies:
-        sr = s.real_sharpe or 0.5
-        cagr = s.real_cagr or 0.08
-        corr = s.real_corr_spy or 1.0
+        sr = s.real_sharpe if s.real_sharpe is not None else 0.5
+        cagr = s.real_cagr if s.real_cagr is not None else 0.08
+        corr = s.real_corr_spy if s.real_corr_spy is not None else 1.0
         mu_d = cagr / 252
         sigma_d = abs(mu_d / (sr / (252 ** 0.5))) if sr != 0 else 0.01
 
         # Correlated with SPY via Cholesky-style decomposition
-        idio = np.random.normal(0, sigma_d * float(np.sqrt(max(1 - corr**2, 0))), N_DAYS)
+        idio = rng.normal(0, sigma_d * float(np.sqrt(max(1 - corr**2, 0))), N_DAYS)
         rets = corr * (spy_daily * sigma_d / 0.01) + idio + mu_d
         return_matrix.append(rets)
         labels.append({

--- a/backend/archimedes/api/routes.py
+++ b/backend/archimedes/api/routes.py
@@ -461,8 +461,6 @@ async def get_efficient_frontier(
     """Compute efficient frontier for selected Tier-1 strategies.
 
     Uses synthetic backtest return streams to build the MVO frontier.
-    Falls back to a two-asset illustration using backtest summary stats
-    when full return series are unavailable.
 
     NOTE: Returns are simulated from summary statistics (SR, CAGR) since raw
     daily return series are not stored in backtest_fixtures.json.

--- a/backend/archimedes/api/routes.py
+++ b/backend/archimedes/api/routes.py
@@ -482,8 +482,16 @@ async def get_efficient_frontier(
     labels = []
 
     for s in active[:5]:  # cap at 5 for performance
-        sr = s.real_sharpe or s.stub_sharpe or 0.5
-        cagr = s.real_cagr or s.stub_cagr or 0.08
+        sr = (
+            s.real_sharpe
+            if s.real_sharpe is not None
+            else s.stub_sharpe if s.stub_sharpe is not None else 0.5
+        )
+        cagr = (
+            s.real_cagr
+            if s.real_cagr is not None
+            else s.stub_cagr if s.stub_cagr is not None else 0.08
+        )
         mu_d = cagr / 252
         sigma_d = abs(mu_d / (sr / (252 ** 0.5))) if sr != 0 else 0.01
         rets = np.random.normal(mu_d, sigma_d, N_DAYS).tolist()

--- a/backend/archimedes/api/routes.py
+++ b/backend/archimedes/api/routes.py
@@ -209,6 +209,17 @@ async def create_vault(req: VaultCreateRequest):
     return VaultCreateResponse(vault_address=vault_address, strategy_ids=req.strategy_ids)
 
 
+@vaults_router.get("/{address}/health")
+async def get_vault_health(address: str):
+    """Get vault health snapshot including live Sharpe drift vs backtest baseline.
+
+    Returns AUM trend, rebalance staleness, agent heartbeat, and a
+    McLean-Pontiff-aware Sharpe drift indicator (NORMAL/WARNING/CRITICAL).
+    """
+    from archimedes.services.vault_monitor import vault_monitor
+    return await vault_monitor.get_vault_health(address)
+
+
 @vaults_router.get("/{address}", response_model=VaultDetailResponse)
 async def get_vault_detail(address: str):
     """Get full vault detail including holdings, performance, traces."""
@@ -441,6 +452,106 @@ async def get_strategy_signals():
         strategies=strat_responses,
         timestamp=datetime.now(timezone.utc).isoformat(),
     )
+
+
+@strategies_router.get("/frontier")
+async def get_efficient_frontier(
+    strategy_ids: str = Query("", description="Comma-separated strategy IDs"),
+):
+    """Compute efficient frontier for selected Tier-1 strategies.
+
+    Uses synthetic backtest return streams to build the MVO frontier.
+    Falls back to a two-asset illustration using backtest summary stats
+    when full return series are unavailable.
+
+    NOTE: Returns are simulated from summary statistics (SR, CAGR) since raw
+    daily return series are not stored in backtest_fixtures.json.
+    """
+    from archimedes.services.portfolio_optimizer import compute_efficient_frontier
+    import numpy as np
+
+    strategies = _strategy_provider.list_strategies()
+    active = [s for s in strategies if s.passes_rigor_gate]
+
+    if len(active) < 2:
+        return {"frontier": [], "strategies": [], "message": "Need >= 2 validated strategies"}
+
+    # Build synthetic daily return streams from summary stats
+    # SR = mu / sigma (annualized), CAGR ~ mu, so mu_daily = CAGR/252
+    np.random.seed(42)
+    N_DAYS = 5560
+    synthetic_returns = {}
+    labels = []
+
+    for s in active[:5]:  # cap at 5 for performance
+        sr = s.real_sharpe or s.stub_sharpe or 0.5
+        cagr = s.real_cagr or s.stub_cagr or 0.08
+        mu_d = cagr / 252
+        sigma_d = abs(mu_d / (sr / (252 ** 0.5))) if sr != 0 else 0.01
+        rets = np.random.normal(mu_d, sigma_d, N_DAYS).tolist()
+        synthetic_returns[s.id] = rets
+        labels.append({"id": s.id, "title": s.paper_title})
+
+    frontier = compute_efficient_frontier(list(synthetic_returns.keys()), synthetic_returns)
+    return {"frontier": frontier, "strategies": labels, "message": None}
+
+
+@strategies_router.get("/correlation")
+async def get_strategy_correlation():
+    """Pairwise correlation matrix for the active strategy library.
+
+    Simulates correlated return streams from backtest summary statistics.
+    All strategies in this library track broad equity markets (corr_to_spy ~ 1.0),
+    so inter-strategy correlations are expected to be high — this is shown honestly.
+
+    NOTE: Returns are simulated from summary statistics since raw daily return
+    series are not stored in backtest_fixtures.json.
+    """
+    import numpy as np
+
+    strategies = [s for s in _strategy_provider.list_strategies() if s.real_sharpe is not None]
+    if len(strategies) < 2:
+        return {"matrix": [], "labels": [], "diversification_ratio": None}
+
+    np.random.seed(42)
+    N_DAYS = 5560
+
+    # Simulate returns with SPY correlation baked in
+    spy_daily = np.random.normal(0.00035, 0.01, N_DAYS)  # SPY ~9% CAGR, ~16% vol
+
+    return_matrix = []
+    labels = []
+    for s in strategies:
+        sr = s.real_sharpe or 0.5
+        cagr = s.real_cagr or 0.08
+        corr = s.real_corr_spy or 1.0
+        mu_d = cagr / 252
+        sigma_d = abs(mu_d / (sr / (252 ** 0.5))) if sr != 0 else 0.01
+
+        # Correlated with SPY via Cholesky-style decomposition
+        idio = np.random.normal(0, sigma_d * float(np.sqrt(max(1 - corr**2, 0))), N_DAYS)
+        rets = corr * (spy_daily * sigma_d / 0.01) + idio + mu_d
+        return_matrix.append(rets)
+        labels.append({
+            "id": s.id,
+            "title": s.paper_title[:30],
+            "passes_rigor_gate": s.passes_rigor_gate,
+        })
+
+    R = np.array(return_matrix)
+    corr_matrix = np.corrcoef(R)
+
+    # Average pairwise correlation (honest; higher = less diversified)
+    n = len(strategies)
+    off_diag = [corr_matrix[i, j] for i in range(n) for j in range(n) if i != j]
+    avg_corr = sum(off_diag) / len(off_diag) if off_diag else 1.0
+
+    return {
+        "matrix": [[round(float(corr_matrix[i, j]), 3) for j in range(n)] for i in range(n)],
+        "labels": labels,
+        "avg_pairwise_correlation": round(avg_corr, 3),
+        "note": "Strategies track broad equity markets — high inter-strategy correlation is expected and shown honestly.",
+    }
 
 
 @strategies_router.get("/{strategy_id}", response_model=StrategyResponse)

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -190,6 +190,8 @@ class StrategyResponse(BaseModel):
     kelly_fraction: float | None = None
     paper_claimed_sharpe: float | None = None
     is_backtest_placeholder: bool = False
+    sharpe_ci_lower: float | None = None
+    sharpe_ci_upper: float | None = None
 
     # Equity curve for charting
     equity_curve: list[PricePoint] = []

--- a/backend/archimedes/models/strategy.py
+++ b/backend/archimedes/models/strategy.py
@@ -143,6 +143,9 @@ class Strategy:
     out_of_sample_sharpe: float | None = None
     passes_rigor_gate: bool = False
     kelly_fraction: float | None = None
+    sharpe_ci_lower: float | None = None
+    sharpe_ci_upper: float | None = None
+    n_obs_daily: int | None = None
 
     @property
     def is_active(self) -> bool:

--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -104,6 +104,73 @@ def optimize_weights(
 # ─── Objectives ──────────────────────────────────────────────────────
 
 
+def compute_efficient_frontier(
+    symbols: list[str],
+    daily_returns: dict[str, list[float]],
+    n_points: int = 30,
+) -> list[dict]:
+    """Compute the mean-variance efficient frontier.
+
+    Sweeps from the minimum-variance portfolio to the maximum-return portfolio,
+    returning n_points (vol, return, weights) triples.
+
+    Returns [] if data is insufficient (< 20 bars).
+    """
+    n = len(symbols)
+    if n == 0:
+        return []
+
+    R = _aligned_return_matrix(symbols, daily_returns)
+    if R is None:
+        return []
+
+    mu = R.mean(axis=0) * _ANNUALIZATION           # annualized expected returns
+    Sigma = np.cov(R.T, ddof=1) * _ANNUALIZATION   # annualized covariance
+    if Sigma.ndim == 0:
+        Sigma = np.array([[float(Sigma)]])
+    Sigma += np.eye(n) * 1e-8
+
+    # Bounds for min- and max-return portfolios
+    mu_min = float(mu.min())
+    mu_max = float(mu.max())
+    if mu_min >= mu_max:
+        return []
+
+    target_returns = np.linspace(mu_min, mu_max, n_points)
+    frontier: list[dict] = []
+
+    w0 = np.ones(n) / n
+    bounds = [(0.0, _CAP_DEFAULT)] * n
+
+    for target_mu in target_returns:
+        constraints = [
+            {"type": "eq", "fun": lambda w: w.sum() - 1.0},
+            {"type": "eq", "fun": lambda w, t=target_mu: float(w @ mu) - t},
+        ]
+        result = minimize(
+            lambda w: float(w @ Sigma @ w),
+            w0,
+            method="SLSQP",
+            bounds=bounds,
+            constraints=constraints,
+            options={"ftol": 1e-9, "maxiter": 500},
+        )
+        if result.success:
+            w = result.x
+            port_vol = float(np.sqrt(w @ Sigma @ w))
+            port_ret = float(w @ mu)
+            frontier.append({
+                "vol": round(port_vol, 6),
+                "return": round(port_ret, 6),
+                "weights": {sym: round(float(wi), 4) for sym, wi in zip(symbols, w)},
+            })
+
+    return frontier
+
+
+# ─── Objectives ──────────────────────────────────────────────────────
+
+
 def _gmv(Sigma: np.ndarray, n: int, cap: float) -> np.ndarray | None:
     """Global Minimum Variance: min w'Σw  s.t. 1'w=1, 0 ≤ w ≤ cap."""
     w0 = np.ones(n) / n

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -310,6 +310,21 @@ def compute_kelly_fraction(
 # ─── Private helpers ─────────────────────────────────────────────────
 
 
+def compute_sharpe_ci(
+    sharpe_annual: float,
+    n_obs_daily: int,
+    confidence: float = 0.95,
+) -> tuple[float, float]:
+    """Lo (2002) confidence interval for annualized Sharpe from daily IID returns.
+
+    Returns (lower, upper) at the requested confidence level.
+    """
+    sr_daily = sharpe_annual / math.sqrt(_ANNUALIZATION)
+    se = math.sqrt((1.0 + 0.5 * sr_daily ** 2) * _ANNUALIZATION / n_obs_daily)
+    z = norm.ppf((1.0 + confidence) / 2.0)
+    return (sharpe_annual - z * se, sharpe_annual + z * se)
+
+
 def _sharpe_per_col(R: np.ndarray) -> np.ndarray:
     """Annualized Sharpe for each column (strategy) of a return matrix."""
     if R.shape[0] < 2:

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -319,6 +319,10 @@ def compute_sharpe_ci(
 
     Returns (lower, upper) at the requested confidence level.
     """
+    if n_obs_daily <= 0:
+        raise ValueError(f"n_obs_daily must be positive, got {n_obs_daily}")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError(f"confidence must be in (0, 1), got {confidence}")
     sr_daily = sharpe_annual / math.sqrt(_ANNUALIZATION)
     se = math.sqrt((1.0 + 0.5 * sr_daily ** 2) * _ANNUALIZATION / n_obs_daily)
     z = norm.ppf((1.0 + confidence) / 2.0)

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -226,6 +226,13 @@ def _to_strategy(path: Path, metadata: dict[str, Any], code_hash: str, fixture: 
     out_of_sample_sharpe = fx.get("out_of_sample_sharpe")
     passes_rigor_gate = bool(fx.get("passes_rigor_gate", False))
     kelly_fraction = fx.get("kelly_fraction")
+    n_obs_daily = fx.get("n_obs_daily")
+
+    # Compute Lo (2002) Sharpe 95% CI when real Sharpe and n_obs are available
+    sharpe_ci_lower = sharpe_ci_upper = None
+    if real_sharpe is not None and n_obs_daily is not None:
+        from archimedes.services.rigor_evaluator import compute_sharpe_ci  # local import to avoid circulars
+        sharpe_ci_lower, sharpe_ci_upper = compute_sharpe_ci(float(real_sharpe), int(n_obs_daily))
 
     # Use file mtime so timestamps reflect the strategy file's curation
     # time rather than process start time — otherwise every restart would
@@ -286,6 +293,9 @@ def _to_strategy(path: Path, metadata: dict[str, Any], code_hash: str, fixture: 
         out_of_sample_sharpe=float(out_of_sample_sharpe) if out_of_sample_sharpe is not None else None,
         passes_rigor_gate=passes_rigor_gate,
         kelly_fraction=float(kelly_fraction) if kelly_fraction is not None else None,
+        sharpe_ci_lower=round(sharpe_ci_lower, 4) if sharpe_ci_lower is not None else None,
+        sharpe_ci_upper=round(sharpe_ci_upper, 4) if sharpe_ci_upper is not None else None,
+        n_obs_daily=int(n_obs_daily) if n_obs_daily is not None else None,
     )
 
 

--- a/backend/archimedes/services/vault_monitor.py
+++ b/backend/archimedes/services/vault_monitor.py
@@ -66,9 +66,19 @@ def compute_sharpe_drift(
     var_r = sum((r - mean_r) ** 2 for r in returns) / max(len(returns) - 1, 1)
     std_r = _math.sqrt(var_r) if var_r > 0 else 0.0
 
+    if std_r <= 0:
+        # Zero variance — flat AUM series; Sharpe is undefined, not zero.
+        return {
+            "live_sharpe": None,
+            "backtest_sharpe": backtest_sharpe,
+            "decay_floor": round(backtest_sharpe * _MCLEAN_PONTIFF_DECAY, 4),
+            "drift_sigma": None,
+            "status": "INSUFFICIENT_DATA",
+        }
+
     # Annualize from snapshot-period returns using periods per year
     periods_per_year = (24 * 60 / snapshot_interval_minutes) * _ANNUALIZATION_FACTOR
-    live_sharpe = (mean_r / std_r) * _math.sqrt(periods_per_year) if std_r > 0 else 0.0
+    live_sharpe = (mean_r / std_r) * _math.sqrt(periods_per_year)
 
     decay_floor = backtest_sharpe * _MCLEAN_PONTIFF_DECAY
 

--- a/backend/archimedes/services/vault_monitor.py
+++ b/backend/archimedes/services/vault_monitor.py
@@ -162,9 +162,12 @@ class VaultMonitor:
             except Exception:
                 pass
 
-        # Sharpe drift — compare live AUM trajectory to backtest baseline
-        # TODO: wire backtest_sharpe from vault's active strategy via StrategyProvider
-        sharpe_drift = compute_sharpe_drift(snapshots, backtest_sharpe=0.7)
+        # Sharpe drift requires a strategy-specific backtest baseline. Until that
+        # baseline is wired in, do not compute drift from a hard-coded value.
+        sharpe_drift = {
+            "available": False,
+            "reason": "baseline_backtest_sharpe_unavailable",
+        }
 
         return {
             "vault_address": vault_address,

--- a/backend/archimedes/services/vault_monitor.py
+++ b/backend/archimedes/services/vault_monitor.py
@@ -66,18 +66,18 @@ def compute_sharpe_drift(
     var_r = sum((r - mean_r) ** 2 for r in returns) / max(len(returns) - 1, 1)
     std_r = _math.sqrt(var_r) if var_r > 0 else 0.0
 
-    # Annualize: snapshots are every snapshot_interval_minutes, scale to year
-    daily_factor = 24 * 60 / snapshot_interval_minutes  # periods per day
-    live_sharpe = (mean_r * daily_factor * _ANNUALIZATION_FACTOR) / (
-        std_r * _math.sqrt(daily_factor * _ANNUALIZATION_FACTOR)
-    ) if std_r > 0 else 0.0
+    # Annualize from snapshot-period returns using periods per year
+    periods_per_year = (24 * 60 / snapshot_interval_minutes) * _ANNUALIZATION_FACTOR
+    live_sharpe = (mean_r / std_r) * _math.sqrt(periods_per_year) if std_r > 0 else 0.0
 
     decay_floor = backtest_sharpe * _MCLEAN_PONTIFF_DECAY
 
-    # Drift in units of backtest SE (Lo 2002 approximation)
+    # Drift in units of backtest SE (Lo 2002 approximation), using
+    # snapshot-period units consistently with the observed returns series.
+    sr_period = backtest_sharpe / _math.sqrt(periods_per_year)
+    n_obs_period = len(returns)
     se_backtest = _math.sqrt(
-        (1 + 0.5 * (backtest_sharpe / _math.sqrt(_ANNUALIZATION_FACTOR)) ** 2)
-        * _ANNUALIZATION_FACTOR / max(len(returns) * daily_factor, 1)
+        (1 + 0.5 * sr_period**2) * periods_per_year / max(n_obs_period, 1)
     )
     drift_sigma = (live_sharpe - backtest_sharpe) / se_backtest if se_backtest > 0 else 0.0
 

--- a/backend/archimedes/services/vault_monitor.py
+++ b/backend/archimedes/services/vault_monitor.py
@@ -9,12 +9,92 @@ Provides:
 from __future__ import annotations
 
 import logging
+import math as _math
 from datetime import datetime, timezone
 
 from archimedes.chain.executor import chain_executor
 from archimedes.services.redis_state import AgentStateStore
 
 logger = logging.getLogger(__name__)
+
+_MIN_SNAPSHOTS_FOR_SHARPE = 5
+_ANNUALIZATION_FACTOR = 252  # trading days per year
+_MCLEAN_PONTIFF_DECAY = 0.42  # expected Sharpe retention post-publication
+
+
+def compute_sharpe_drift(
+    aum_snapshots: list[dict],
+    backtest_sharpe: float,
+    snapshot_interval_minutes: float = 5.0,
+) -> dict:
+    """Compare rolling live Sharpe against backtested baseline.
+
+    Uses AUM history to compute live returns and Sharpe, then checks for
+    significant divergence from the backtest baseline.
+
+    Returns a dict with keys: live_sharpe, backtest_sharpe, decay_floor,
+    drift_sigma, status ("NORMAL"|"WARNING"|"CRITICAL"|"INSUFFICIENT_DATA").
+    """
+    # Need at least a few snapshots to compute returns
+    if len(aum_snapshots) < _MIN_SNAPSHOTS_FOR_SHARPE:
+        return {
+            "live_sharpe": None,
+            "backtest_sharpe": backtest_sharpe,
+            "decay_floor": round(backtest_sharpe * _MCLEAN_PONTIFF_DECAY, 4),
+            "drift_sigma": None,
+            "status": "INSUFFICIENT_DATA",
+        }
+
+    # Compute period returns from AUM history (most-recent first in snapshots)
+    navs = [s.get("aum_usdc", 0) or s.get("share_price", 0) for s in reversed(aum_snapshots)]
+    returns = [
+        (navs[i] - navs[i - 1]) / navs[i - 1]
+        for i in range(1, len(navs))
+        if navs[i - 1] > 0
+    ]
+
+    if len(returns) < _MIN_SNAPSHOTS_FOR_SHARPE - 1:
+        return {
+            "live_sharpe": None,
+            "backtest_sharpe": backtest_sharpe,
+            "decay_floor": round(backtest_sharpe * _MCLEAN_PONTIFF_DECAY, 4),
+            "drift_sigma": None,
+            "status": "INSUFFICIENT_DATA",
+        }
+
+    mean_r = sum(returns) / len(returns)
+    var_r = sum((r - mean_r) ** 2 for r in returns) / max(len(returns) - 1, 1)
+    std_r = _math.sqrt(var_r) if var_r > 0 else 0.0
+
+    # Annualize: snapshots are every snapshot_interval_minutes, scale to year
+    daily_factor = 24 * 60 / snapshot_interval_minutes  # periods per day
+    live_sharpe = (mean_r * daily_factor * _ANNUALIZATION_FACTOR) / (
+        std_r * _math.sqrt(daily_factor * _ANNUALIZATION_FACTOR)
+    ) if std_r > 0 else 0.0
+
+    decay_floor = backtest_sharpe * _MCLEAN_PONTIFF_DECAY
+
+    # Drift in units of backtest SE (Lo 2002 approximation)
+    se_backtest = _math.sqrt(
+        (1 + 0.5 * (backtest_sharpe / _math.sqrt(_ANNUALIZATION_FACTOR)) ** 2)
+        * _ANNUALIZATION_FACTOR / max(len(returns) * daily_factor, 1)
+    )
+    drift_sigma = (live_sharpe - backtest_sharpe) / se_backtest if se_backtest > 0 else 0.0
+
+    if live_sharpe >= decay_floor:
+        status = "NORMAL"
+    elif live_sharpe >= decay_floor * 0.5:
+        status = "WARNING"
+    else:
+        status = "CRITICAL"
+
+    return {
+        "live_sharpe": round(live_sharpe, 4),
+        "backtest_sharpe": round(backtest_sharpe, 4),
+        "decay_floor": round(decay_floor, 4),
+        "drift_sigma": round(drift_sigma, 4),
+        "status": status,
+    }
 
 
 class VaultMonitor:
@@ -82,6 +162,10 @@ class VaultMonitor:
             except Exception:
                 pass
 
+        # Sharpe drift — compare live AUM trajectory to backtest baseline
+        # TODO: wire backtest_sharpe from vault's active strategy via StrategyProvider
+        sharpe_drift = compute_sharpe_drift(snapshots, backtest_sharpe=0.7)
+
         return {
             "vault_address": vault_address,
             "agent_alive": agent_alive,
@@ -91,6 +175,7 @@ class VaultMonitor:
             "aum_trend_pct": round(aum_trend, 4),
             "snapshot_count": len(snapshots),
             "latest_snapshot": snapshots[0] if snapshots else None,
+            "sharpe_drift": sharpe_drift,
             "recent_events": [
                 e for e in events
                 if e.get("data", {}).get("address", "").lower() == vault_address.lower()

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -17,6 +17,7 @@ import Reasoning from './components/Reasoning'
 import RiskAnalysis from './components/RiskAnalysis'
 import FinancialAnalysis from './components/FinancialAnalysis'
 import CorpusExplorer from './components/CorpusExplorer'
+import RigorExplainer from './components/RigorExplainer'
 import Landing from './components/Landing'
 import Marketplace from './Marketplace'
 import './App.css'
@@ -37,6 +38,7 @@ const PAGE_TO_PATH = {
   reasoning: '/intelligence/reasoning',
   risk: '/intelligence/risk',
   corpus: '/intelligence/corpus',
+  'rigor-explainer': '/intelligence/rigor-gate',
   about: '/about',
   imprint: '/imprint',
   landing: '/',
@@ -887,6 +889,7 @@ export default function App() {
       case 'reasoning':     return <Reasoning />
       case 'risk':           return <RiskAnalysis />
       case 'corpus':         return <CorpusExplorer />
+      case 'rigor-explainer': return <RigorExplainer />
       case 'about':          return <StaticPage title="About Archimedes" content="Archimedes is a fund-of-funds portfolio agent that turns published quant finance research into investable, backtested strategies, then constructs personalized portfolios of RWA tokens and yield instruments on Arc with USDC settlement.\n\nBuilt for the Agora Agents Hackathon — Canteen × Circle × Arc, May 2026.\n\nEvery position the agent takes, every rebalance it executes, every regime shift it responds to, is hashed and verifiable on-chain. The mathematician's name is fitting: he was the original empiricist working from first principles. We work from peer-reviewed first principles." />
       case 'imprint':        return <StaticPage title="Imprint" content="Archimedes Arcadia\nHackathon Team\n\nThis project was built for the Agora Agents Hackathon (May 11-25, 2026).\n\nTeam: Dan Browne, Marten Windler, Daniel Reis dos Santos, Chuan Bai, Önder Akkaya\n\nLicense: Unlicense — full public-domain dedication." />
       default:              return <Trade />

--- a/ui/src/components/Breadcrumbs.jsx
+++ b/ui/src/components/Breadcrumbs.jsx
@@ -19,8 +19,10 @@ const CRUMB_MAP = {
   'create-vault': { group: 'Portfolio', groupPage: 'vaults' },
   financial:    { group: 'Portfolio', groupPage: 'dashboard' },
   'vault-detail': { group: 'Portfolio', groupPage: 'vaults' },
-  reasoning:    { group: 'Intelligence', groupPage: 'reasoning' },
-  risk:         { group: 'Intelligence', groupPage: 'reasoning' },
+  reasoning:       { group: 'Intelligence', groupPage: 'reasoning' },
+  risk:            { group: 'Intelligence', groupPage: 'reasoning' },
+  corpus:          { group: 'Intelligence', groupPage: 'reasoning' },
+  'rigor-explainer': { group: 'Intelligence', groupPage: 'reasoning' },
 }
 
 export default function Breadcrumbs({ page, setPage }) {

--- a/ui/src/components/CorrelationMatrix.jsx
+++ b/ui/src/components/CorrelationMatrix.jsx
@@ -1,0 +1,163 @@
+import { useState, useEffect } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+async function apiGet(path) {
+  const res = await fetch(`${API_BASE}${path}`)
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+/**
+ * CorrelationMatrix — compact pairwise correlation table for the strategy library.
+ *
+ * Fetches /api/strategies/correlation and renders a color-coded heatmap table:
+ *   - Near 0  → green  (low correlation, good diversification)
+ *   - Near 1  → red    (high correlation, less diversification benefit)
+ *
+ * Honest disclosure: all strategies track broad equity markets so
+ * inter-strategy correlations are expected to be high.
+ *
+ * NOTE: Returns are simulated from summary statistics since raw daily series
+ * are not stored in backtest_fixtures.json.
+ */
+export default function CorrelationMatrix() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setLoading(true)
+    apiGet('/api/strategies/correlation')
+      .then(d => { setData(d); setLoading(false) })
+      .catch(e => { setError(e.message || 'Failed to load correlation data'); setLoading(false) })
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="card-flat" style={{ padding: 20 }}>
+        <div className="label mb-2">Library Correlation</div>
+        <div className="caption" style={{ color: 'var(--text-4)' }}>Computing correlation matrix…</div>
+      </div>
+    )
+  }
+
+  if (error || !data || !data.matrix || data.matrix.length === 0) {
+    return (
+      <div className="card-flat" style={{ padding: 20 }}>
+        <div className="label mb-2">Library Correlation</div>
+        <div className="caption" style={{ color: 'var(--text-4)' }}>
+          {error || 'Need at least 2 strategies with real backtest data.'}
+        </div>
+      </div>
+    )
+  }
+
+  const { matrix, labels, avg_pairwise_correlation, note } = data
+  const n = labels.length
+
+  /**
+   * Colour interpolation: green (0) → neutral (0.5) → red (1).
+   * Uses RGBA so it works on any background.
+   */
+  function cellColor(value) {
+    const v = Math.max(0, Math.min(1, value))
+    if (v <= 0.5) {
+      // 0 → pure green, 0.5 → neutral
+      const t = v * 2
+      const r = Math.round(16 + t * (239 - 16))   // 16→239
+      const g = Math.round(185 + t * (68 - 185))   // 185→68
+      const b = Math.round(129 + t * (68 - 129))   // 129→68
+      return `rgba(${r},${g},${b},${0.15 + t * 0.25})`
+    } else {
+      // 0.5 → neutral, 1 → pure red
+      const t = (v - 0.5) * 2
+      const r = Math.round(239)
+      const g = Math.round(68 - t * 68)
+      const b = Math.round(68 - t * 68)
+      return `rgba(${r},${g},${b},${0.15 + t * 0.35})`
+    }
+  }
+
+  function textColor(value) {
+    return value > 0.7 ? 'var(--negative)' : value < 0.3 ? 'var(--positive)' : 'var(--text-2)'
+  }
+
+  // Short label for table header: trim to 12 chars
+  function shortLabel(title) {
+    return title.length > 12 ? title.slice(0, 11) + '…' : title
+  }
+
+  return (
+    <div className="card-flat" style={{ padding: 20 }}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="label">Library Correlation</div>
+        {avg_pairwise_correlation != null && (
+          <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.72rem' }}>
+            avg pairwise: <strong style={{ color: avg_pairwise_correlation > 0.7 ? 'var(--negative)' : 'var(--text-1)' }}>
+              {avg_pairwise_correlation.toFixed(3)}
+            </strong>
+          </div>
+        )}
+      </div>
+
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ borderCollapse: 'collapse', width: '100%', fontSize: '0.75rem' }}>
+          <thead>
+            <tr>
+              <th style={{ padding: '4px 8px', textAlign: 'left', color: 'var(--text-4)', fontWeight: 400, borderBottom: '1px solid var(--glass-border)', whiteSpace: 'nowrap' }}>
+                Strategy
+              </th>
+              {labels.map((l, j) => (
+                <th key={j} style={{
+                  padding: '4px 6px', textAlign: 'center', color: 'var(--text-3)',
+                  fontWeight: 400, borderBottom: '1px solid var(--glass-border)',
+                  fontSize: '0.67rem', whiteSpace: 'nowrap',
+                }}>
+                  {shortLabel(l.title)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {matrix.map((row, i) => (
+              <tr key={i}>
+                <td style={{
+                  padding: '4px 8px', color: 'var(--text-2)', fontWeight: 500,
+                  borderBottom: '1px solid var(--glass-border)', whiteSpace: 'nowrap',
+                  fontSize: '0.68rem',
+                }}>
+                  {shortLabel(labels[i].title)}
+                  {labels[i].passes_rigor_gate && (
+                    <span style={{ marginLeft: 4, color: 'var(--positive)', fontSize: '0.65rem' }}>T1</span>
+                  )}
+                </td>
+                {row.map((val, j) => (
+                  <td key={j} style={{
+                    padding: '4px 6px', textAlign: 'center',
+                    background: i === j ? 'rgba(255,255,255,0.06)' : cellColor(val),
+                    borderBottom: '1px solid var(--glass-border)',
+                    color: i === j ? 'var(--text-4)' : textColor(val),
+                    fontWeight: i === j ? 400 : 600,
+                    minWidth: 44,
+                  }}>
+                    {i === j ? '—' : val.toFixed(2)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {note && (
+        <div className="caption" style={{ marginTop: 10, color: 'var(--text-4)', fontSize: '0.67rem', fontStyle: 'italic' }}>
+          {note}
+        </div>
+      )}
+      <div className="caption" style={{ marginTop: 4, color: 'var(--text-4)', fontSize: '0.67rem' }}>
+        Returns simulated from backtest summary statistics. Raw daily series not stored in fixture file.
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/EfficientFrontier.jsx
+++ b/ui/src/components/EfficientFrontier.jsx
@@ -1,0 +1,223 @@
+import { useState, useEffect } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+async function apiGet(path) {
+  const res = await fetch(`${API_BASE}${path}`)
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+/**
+ * EfficientFrontier — SVG scatter plot of the MVO efficient frontier.
+ *
+ * Fetches /api/strategies/frontier and renders a compact (~300px tall) card
+ * showing volatility on the x-axis and expected return on the y-axis.
+ * The min-variance and max-Sharpe points are highlighted.
+ *
+ * NOTE: The frontier is computed from synthetic return streams simulated from
+ * backtest summary statistics (SR, CAGR) — raw daily series are not stored
+ * in the fixture file. This is disclosed in the chart footer.
+ */
+export default function EfficientFrontier() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setLoading(true)
+    apiGet('/api/strategies/frontier')
+      .then(d => { setData(d); setLoading(false) })
+      .catch(e => { setError(e.message || 'Failed to load frontier'); setLoading(false) })
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="card-flat" style={{ padding: 20 }}>
+        <div className="label mb-2">Efficient Frontier</div>
+        <div className="caption" style={{ color: 'var(--text-4)' }}>Computing frontier…</div>
+      </div>
+    )
+  }
+
+  if (error || !data || data.frontier.length === 0) {
+    return (
+      <div className="card-flat" style={{ padding: 20 }}>
+        <div className="label mb-2">Efficient Frontier</div>
+        <div className="caption" style={{ color: 'var(--text-4)' }}>
+          {error || (data?.message ?? 'Need at least 2 Tier-1 strategies to plot frontier.')}
+        </div>
+      </div>
+    )
+  }
+
+  const frontier = data.frontier
+  const strategies = data.strategies || []
+
+  // Map frontier points to SVG pixel coordinates
+  const SVG_W = 480
+  const SVG_H = 300
+  const PAD_L = 52
+  const PAD_R = 20
+  const PAD_T = 20
+  const PAD_B = 44
+
+  const vols = frontier.map(p => p.vol)
+  const rets = frontier.map(p => p.return)
+  const minVol = Math.min(...vols)
+  const maxVol = Math.max(...vols)
+  const minRet = Math.min(...rets)
+  const maxRet = Math.max(...rets)
+  const volRange = maxVol - minVol || 1
+  const retRange = maxRet - minRet || 1
+
+  // Add 5% padding on each side
+  const vPad = volRange * 0.05
+  const rPad = retRange * 0.05
+
+  function toX(vol) {
+    return PAD_L + ((vol - minVol + vPad) / (volRange + 2 * vPad)) * (SVG_W - PAD_L - PAD_R)
+  }
+  function toY(ret) {
+    return SVG_H - PAD_B - ((ret - minRet + rPad) / (retRange + 2 * rPad)) * (SVG_H - PAD_T - PAD_B)
+  }
+
+  // Min-variance point = lowest vol
+  const minVarIdx = vols.indexOf(minVol)
+  // Max-Sharpe point = highest (return / vol) ratio
+  const sharpes = frontier.map(p => p.vol > 0 ? p.return / p.vol : 0)
+  const maxSharpeIdx = sharpes.indexOf(Math.max(...sharpes))
+
+  // Build polyline path
+  const polyPoints = frontier.map(p => `${toX(p.vol).toFixed(1)},${toY(p.return).toFixed(1)}`).join(' ')
+
+  // Y-axis tick labels (4 ticks)
+  const yTicks = [0, 1, 2, 3].map(i => {
+    const ret = minRet + (retRange * i) / 3
+    return { y: toY(ret), label: `${(ret * 100).toFixed(1)}%` }
+  })
+
+  // X-axis tick labels (4 ticks)
+  const xTicks = [0, 1, 2, 3].map(i => {
+    const vol = minVol + (volRange * i) / 3
+    return { x: toX(vol), label: `${(vol * 100).toFixed(1)}%` }
+  })
+
+  return (
+    <div className="card-flat" style={{ padding: 20 }}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="label">Efficient Frontier</div>
+        <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.68rem' }}>
+          MVO · {strategies.length} Tier-1 strategies
+        </div>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+        width="100%"
+        style={{ display: 'block', maxHeight: 300 }}
+        aria-label="Efficient frontier chart"
+      >
+        {/* Grid lines */}
+        {yTicks.map((t, i) => (
+          <line key={i} x1={PAD_L} y1={t.y} x2={SVG_W - PAD_R} y2={t.y}
+            stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+        ))}
+
+        {/* Axes */}
+        <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={SVG_H - PAD_B}
+          stroke="rgba(255,255,255,0.2)" strokeWidth="1" />
+        <line x1={PAD_L} y1={SVG_H - PAD_B} x2={SVG_W - PAD_R} y2={SVG_H - PAD_B}
+          stroke="rgba(255,255,255,0.2)" strokeWidth="1" />
+
+        {/* Y-axis labels */}
+        {yTicks.map((t, i) => (
+          <text key={i} x={PAD_L - 6} y={t.y + 4}
+            textAnchor="end" fill="rgba(255,255,255,0.35)" fontSize="9">
+            {t.label}
+          </text>
+        ))}
+
+        {/* X-axis labels */}
+        {xTicks.map((t, i) => (
+          <text key={i} x={t.x} y={SVG_H - PAD_B + 14}
+            textAnchor="middle" fill="rgba(255,255,255,0.35)" fontSize="9">
+            {t.label}
+          </text>
+        ))}
+
+        {/* Axis titles */}
+        <text x={PAD_L + (SVG_W - PAD_L - PAD_R) / 2} y={SVG_H - 4}
+          textAnchor="middle" fill="rgba(255,255,255,0.4)" fontSize="9">
+          Annualised Volatility
+        </text>
+        <text x={10} y={PAD_T + (SVG_H - PAD_T - PAD_B) / 2}
+          textAnchor="middle" fill="rgba(255,255,255,0.4)" fontSize="9"
+          transform={`rotate(-90, 10, ${PAD_T + (SVG_H - PAD_T - PAD_B) / 2})`}>
+          Expected Return
+        </text>
+
+        {/* Frontier curve */}
+        <polyline
+          points={polyPoints}
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+
+        {/* All frontier dots */}
+        {frontier.map((p, i) => (
+          <circle key={i} cx={toX(p.vol)} cy={toY(p.return)} r={3}
+            fill="var(--accent)" opacity={0.5} />
+        ))}
+
+        {/* Min-variance highlight */}
+        {minVarIdx >= 0 && (
+          <>
+            <circle cx={toX(frontier[minVarIdx].vol)} cy={toY(frontier[minVarIdx].return)}
+              r={6} fill="var(--positive)" opacity={0.9} />
+            <text x={toX(frontier[minVarIdx].vol) + 9} y={toY(frontier[minVarIdx].return) + 4}
+              fill="var(--positive)" fontSize="9" fontWeight="600">
+              Min Var
+            </text>
+          </>
+        )}
+
+        {/* Max-Sharpe highlight */}
+        {maxSharpeIdx >= 0 && maxSharpeIdx !== minVarIdx && (
+          <>
+            <circle cx={toX(frontier[maxSharpeIdx].vol)} cy={toY(frontier[maxSharpeIdx].return)}
+              r={6} fill="var(--accent)" opacity={1} stroke="#fff" strokeWidth="1.5" />
+            <text x={toX(frontier[maxSharpeIdx].vol) + 9} y={toY(frontier[maxSharpeIdx].return) + 4}
+              fill="var(--accent)" fontSize="9" fontWeight="600">
+              Max Sharpe
+            </text>
+          </>
+        )}
+      </svg>
+
+      {/* Strategy legend */}
+      {strategies.length > 0 && (
+        <div style={{ marginTop: 10, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          {strategies.map(s => (
+            <span key={s.id} className="caption" style={{
+              background: 'rgba(255,255,255,0.04)',
+              border: '1px solid var(--glass-border)',
+              borderRadius: 4,
+              padding: '2px 6px',
+              fontSize: '0.68rem',
+            }}>
+              {s.title.slice(0, 28)}{s.title.length > 28 ? '…' : ''}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="caption" style={{ marginTop: 8, color: 'var(--text-4)', fontSize: '0.67rem' }}>
+        Returns simulated from backtest summary statistics (SR + CAGR).
+        Raw daily series not stored in fixture file.
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/EfficientFrontier.jsx
+++ b/ui/src/components/EfficientFrontier.jsx
@@ -40,7 +40,7 @@ export default function EfficientFrontier() {
     )
   }
 
-  if (error || !data || data.frontier.length === 0) {
+  if (error || !data || !Array.isArray(data?.frontier) || data.frontier.length === 0) {
     return (
       <div className="card-flat" style={{ padding: 20 }}>
         <div className="label mb-2">Efficient Frontier</div>

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -20,9 +20,10 @@ const NAV = [
     { id: 'financial',    label: 'Financial Analysis' },
   ]},
   { group: 'Intelligence', items: [
-    { id: 'reasoning',  label: 'Reasoning' },
-    { id: 'risk',        label: 'Risk Analysis' },
-    { id: 'corpus',      label: 'Corpus Explorer' },
+    { id: 'reasoning',       label: 'Reasoning' },
+    { id: 'risk',             label: 'Risk Analysis' },
+    { id: 'corpus',           label: 'Corpus Explorer' },
+    { id: 'rigor-explainer', label: 'Rigor Gate' },
   ]},
 ]
 
@@ -41,6 +42,7 @@ export const PAGE_LABELS = {
   reasoning: 'Reasoning',
   risk: 'Risk Analysis',
   corpus: 'Corpus Explorer',
+  'rigor-explainer': 'Rigor Gate',
   about: 'About',
   imprint: 'Imprint',
 }

--- a/ui/src/components/RigorExplainer.jsx
+++ b/ui/src/components/RigorExplainer.jsx
@@ -1,0 +1,308 @@
+/**
+ * RigorExplainer — static educational page explaining the four-primitive rigor gate.
+ *
+ * No API calls — purely static content. Written for non-quant judges who will
+ * encounter DSR/PBO terminology and need a plain-English explanation of why
+ * these tests matter and how we use them.
+ *
+ * Per docs/specs/selection-bias-corrections-spec.md: every Tier-1 strategy
+ * must pass DSR, PBO, walk-forward OOS Sharpe, and look-ahead audit.
+ */
+export default function RigorExplainer() {
+  return (
+    <div style={{ maxWidth: 760, margin: '0 auto', padding: '32px 24px' }}>
+      <div className="fade-up fade-up-1">
+        <h1 style={{ fontSize: '1.6rem', marginBottom: 8, fontFamily: 'var(--serif)' }}>
+          The Rigor Gate
+        </h1>
+        <p className="body" style={{ color: 'var(--text-2)', marginBottom: 32, lineHeight: 1.65 }}>
+          Every Tier-1 strategy in the Archimedes library must pass four independent
+          selection-bias controls before we would trust it with real capital.
+          Here is what each test measures — and why it matters.
+        </p>
+      </div>
+
+      {/* Primitive 1 — DSR */}
+      <div className="card-elevated mb-6 fade-up fade-up-2">
+        <div className="flex items-center gap-3 mb-4">
+          <div style={{
+            width: 32, height: 32, borderRadius: '50%', background: 'rgba(99,102,241,0.15)',
+            border: '1px solid rgba(99,102,241,0.4)', display: 'flex', alignItems: 'center',
+            justifyContent: 'center', fontWeight: 700, color: 'var(--accent)', flexShrink: 0,
+          }}>1</div>
+          <div>
+            <div className="label">Deflated Sharpe Ratio (DSR)</div>
+            <div className="caption" style={{ color: 'var(--text-4)' }}>Bailey & López de Prado (2014)</div>
+          </div>
+          <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>p-value &gt; 0.95</span>
+        </div>
+
+        <p className="body" style={{ marginBottom: 16, lineHeight: 1.65 }}>
+          A Sharpe ratio adjusted for the fact that you tested many strategies and got lucky.
+          The more strategies you tested, the more your best result is probably noise —
+          a kind of multiple-testing penalty. DSR answers: "If I tested N candidate strategies
+          and selected the one with the best in-sample Sharpe, what is the probability the
+          true underlying edge is positive?"
+        </p>
+
+        <div className="card-flat" style={{ padding: 14, marginBottom: 12 }}>
+          <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 6, textTransform: 'uppercase', fontSize: '0.68rem', letterSpacing: '0.06em' }}>
+            Formula
+          </div>
+          <div className="body" style={{ fontFamily: 'var(--mono, monospace)', fontSize: '0.82rem', color: 'var(--text-2)', lineHeight: 1.5 }}>
+            z = (SR̂ − SR₀) × √(T−1) / √(1 − γ₃SR̂ + ((γ₄−1)/4)SR̂²)
+            <br />
+            <span style={{ color: 'var(--text-4)', fontSize: '0.75rem' }}>
+              where SR₀ = expected best Sharpe of N iid trials, γ₃ = skewness, γ₄ = raw kurtosis
+            </span>
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Our threshold</div>
+            <div className="body" style={{ fontWeight: 600 }}>p-value &gt; 0.95</div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>
+              We need &gt;95% confidence the Sharpe is genuine, not a lucky pick from many trials.
+            </div>
+          </div>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library example</div>
+            <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
+              Moreira-Muir: DSR = 0.55, p = 0.995
+            </div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>
+              The market's volatility-managed premium is statistically real, even after
+              correcting for 4 candidate strategies tested.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Primitive 2 — PBO */}
+      <div className="card-elevated mb-6 fade-up fade-up-3">
+        <div className="flex items-center gap-3 mb-4">
+          <div style={{
+            width: 32, height: 32, borderRadius: '50%', background: 'rgba(99,102,241,0.15)',
+            border: '1px solid rgba(99,102,241,0.4)', display: 'flex', alignItems: 'center',
+            justifyContent: 'center', fontWeight: 700, color: 'var(--accent)', flexShrink: 0,
+          }}>2</div>
+          <div>
+            <div className="label">Probability of Backtest Overfitting (PBO)</div>
+            <div className="caption" style={{ color: 'var(--text-4)' }}>Bailey, Borwein, López de Prado & Zhu (2014) — CSCV</div>
+          </div>
+          <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>PBO &lt; 50%</span>
+        </div>
+
+        <p className="body" style={{ marginBottom: 16, lineHeight: 1.65 }}>
+          If we split the historical data 16 different ways and test which half trains best,
+          what is the probability our strategy underperforms its own median performance
+          out-of-sample? A low PBO means the strategy's edge is consistent across time splits
+          — not a single lucky run that happens to fit the training window.
+        </p>
+
+        <div className="card-flat" style={{ padding: 14, marginBottom: 12 }}>
+          <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 6, textTransform: 'uppercase', fontSize: '0.68rem', letterSpacing: '0.06em' }}>
+            Method (CSCV)
+          </div>
+          <div className="body" style={{ fontSize: '0.85rem', color: 'var(--text-2)', lineHeight: 1.6 }}>
+            Divide the return series into 16 equal sub-periods. For each of the
+            C(16,8) = 12,870 IS/OOS splits, pick the in-sample-best strategy and rank
+            it in the OOS distribution. PBO = fraction of splits where the IS-best
+            underperforms the OOS median.
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Our threshold</div>
+            <div className="body" style={{ fontWeight: 600 }}>PBO &lt; 50%</div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>
+              Less likely than random to underperform median out-of-sample.
+              Lower is better — 0% would mean perfect consistency.
+            </div>
+          </div>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library example</div>
+            <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
+              Both Tier-1 strategies: PBO ≈ 39%
+            </div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>
+              They outperform their own OOS median in 61% of walk-forward splits —
+              consistent, not cherry-picked.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Primitive 3 — OOS Sharpe */}
+      <div className="card-elevated mb-6 fade-up fade-up-4">
+        <div className="flex items-center gap-3 mb-4">
+          <div style={{
+            width: 32, height: 32, borderRadius: '50%', background: 'rgba(99,102,241,0.15)',
+            border: '1px solid rgba(99,102,241,0.4)', display: 'flex', alignItems: 'center',
+            justifyContent: 'center', fontWeight: 700, color: 'var(--accent)', flexShrink: 0,
+          }}>3</div>
+          <div>
+            <div className="label">Walk-Forward Out-of-Sample Sharpe</div>
+            <div className="caption" style={{ color: 'var(--text-4)' }}>Chronological 70/30 train-test split</div>
+          </div>
+          <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>OOS ≥ 50% of in-sample</span>
+        </div>
+
+        <p className="body" style={{ marginBottom: 16, lineHeight: 1.65 }}>
+          Train on the first 70% of history. Test on the final 30% — the data the
+          strategy never saw during optimisation. The out-of-sample Sharpe must be at
+          least 50% of the full-sample Sharpe. This rules out strategies that look great
+          on 20 years of data but crash on the most recent 6 years, which are always the
+          most relevant for live trading. No performance cliff allowed.
+        </p>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Our threshold</div>
+            <div className="body" style={{ fontWeight: 600 }}>OOS ≥ 50% of in-sample Sharpe</div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>
+              Prevents strategies that look good historically but degrade on modern data.
+            </div>
+          </div>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library examples</div>
+            <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
+              Moreira-Muir: in-sample 0.77, OOS 0.97
+            </div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>
+              Performance actually <em>improves</em> out-of-sample — the premium
+              has strengthened in recent years. TSMOM OOS: 0.76 vs in-sample 0.65.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Primitive 4 — Look-ahead audit */}
+      <div className="card-elevated mb-6 fade-up fade-up-5">
+        <div className="flex items-center gap-3 mb-4">
+          <div style={{
+            width: 32, height: 32, borderRadius: '50%', background: 'rgba(99,102,241,0.15)',
+            border: '1px solid rgba(99,102,241,0.4)', display: 'flex', alignItems: 'center',
+            justifyContent: 'center', fontWeight: 700, color: 'var(--accent)', flexShrink: 0,
+          }}>4</div>
+          <div>
+            <div className="label">Look-Ahead Audit</div>
+            <div className="caption" style={{ color: 'var(--text-4)' }}>Static code review — binary pass/fail</div>
+          </div>
+          <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>All pass</span>
+        </div>
+
+        <p className="body" style={{ marginBottom: 16, lineHeight: 1.65 }}>
+          A static check that the backtest code never peeked at future data.
+          Common look-ahead bugs include: rebalancing at the exact high or low of a period
+          (impossible in real trading), using tomorrow's open price to fill today's signal,
+          or normalising returns across the full history before splitting into train/test sets.
+          These bugs inflate backtested Sharpe ratios dramatically and are embarrassingly common
+          in published research.
+        </p>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>What we check</div>
+            <ul className="body" style={{ paddingLeft: 16, lineHeight: 1.7, fontSize: '0.83rem', color: 'var(--text-2)' }}>
+              <li>No fills at intrabar extremes (open/close only)</li>
+              <li>Signal computed on bar N, filled on bar N+1</li>
+              <li>No full-history normalisation before IS/OOS split</li>
+              <li>Transaction costs applied on every trade</li>
+            </ul>
+          </div>
+          <div className="card-flat" style={{ padding: 12 }}>
+            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library result</div>
+            <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
+              All 6 strategies: audit passed
+            </div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>
+              Verified by code review of each backtrader strategy file in
+              analytics-engine/strategies/. All trades fill on next-bar open.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Summary table */}
+      <div className="card-flat fade-up fade-up-5" style={{ padding: 20, marginBottom: 8 }}>
+        <div className="label mb-3">Gate Summary — Current Library</div>
+        <div className="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>Strategy</th>
+                <th className="text-right">DSR p-val</th>
+                <th className="text-right">PBO</th>
+                <th className="text-right">OOS Sharpe</th>
+                <th className="text-right">Look-ahead</th>
+                <th>Gate</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style={{ fontWeight: 500 }}>Moreira-Muir 2017 (Vol-Managed)</td>
+                <td className="text-right positive">0.995</td>
+                <td className="text-right positive">39%</td>
+                <td className="text-right positive">0.97</td>
+                <td className="text-right positive">Pass</td>
+                <td><span className="tag tag-positive" style={{ fontSize: '0.68rem' }}>Tier 1</span></td>
+              </tr>
+              <tr>
+                <td style={{ fontWeight: 500 }}>Moskowitz-Ooi-Pedersen 2012 (TSMOM)</td>
+                <td className="text-right positive">0.976</td>
+                <td className="text-right positive">39%</td>
+                <td className="text-right positive">0.76</td>
+                <td className="text-right positive">Pass</td>
+                <td><span className="tag tag-positive" style={{ fontSize: '0.68rem' }}>Tier 1</span></td>
+              </tr>
+              <tr>
+                <td style={{ fontWeight: 500 }}>Faber 2007 (SMA-200)</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>0.612</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>37%</td>
+                <td className="text-right positive">0.93</td>
+                <td className="text-right positive">Pass</td>
+                <td><span className="tag tag-muted" style={{ fontSize: '0.68rem' }}>Candidate</span></td>
+              </tr>
+              <tr>
+                <td style={{ fontWeight: 500 }}>George-Hwang 2004 (52W High)</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>0.609</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>34%</td>
+                <td className="text-right positive">0.91</td>
+                <td className="text-right positive">Pass</td>
+                <td><span className="tag tag-muted" style={{ fontSize: '0.68rem' }}>Candidate</span></td>
+              </tr>
+              <tr>
+                <td style={{ fontWeight: 500 }}>Buy-and-Hold Baseline</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>0.891</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>39%</td>
+                <td className="text-right positive">0.79</td>
+                <td className="text-right positive">Pass</td>
+                <td><span className="tag tag-muted" style={{ fontSize: '0.68rem' }}>Candidate</span></td>
+              </tr>
+              <tr>
+                <td style={{ fontWeight: 500 }}>Capital Preservation (T-Bill)</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>0.812</td>
+                <td className="text-right positive">24%</td>
+                <td className="text-right" style={{ color: 'var(--text-3)' }}>0.43</td>
+                <td className="text-right positive">Pass</td>
+                <td><span className="tag tag-muted" style={{ fontSize: '0.68rem' }}>Candidate</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className="caption" style={{ marginTop: 10, color: 'var(--text-4)', fontSize: '0.7rem' }}>
+          DSR threshold: p &gt; 0.95 · PBO threshold: &lt; 50% · OOS threshold: ≥ 50% of in-sample Sharpe
+        </div>
+      </div>
+
+      <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.72rem', lineHeight: 1.6 }}>
+        Spec: docs/specs/selection-bias-corrections-spec.md ·
+        Bailey & López de Prado (2014) "The Deflated Sharpe Ratio" ·
+        Bailey, Borwein, López de Prado & Zhu (2014) "The Probability of Backtest Overfitting"
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import EfficientFrontier from './EfficientFrontier'
+import CorrelationMatrix from './CorrelationMatrix'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -652,6 +653,13 @@ export default function Strategies() {
       {!loading && strategies.length > 0 && (
         <div className="mb-6">
           <EfficientFrontier />
+        </div>
+      )}
+
+      {/* Library correlation matrix */}
+      {!loading && strategies.length > 0 && (
+        <div className="mb-6">
+          <CorrelationMatrix />
         </div>
       )}
 

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -103,7 +103,15 @@ function FeaturedCard({ s }) {
           {hasBacktest ? (
             <>
               <div className="strat-metric-grid">
-                <div><div className="caption">Sharpe</div><div style={{ fontWeight: 700, fontSize: '1.1rem' }}>{fmt(s.sharpe_ratio)}</div></div>
+                <div>
+                  <div className="caption">Sharpe</div>
+                  <div style={{ fontWeight: 700, fontSize: '1.1rem' }}>{fmt(s.sharpe_ratio)}</div>
+                  {s.sharpe_ci_lower != null && s.sharpe_ci_upper != null && (
+                    <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>
+                      95% CI [{fmt(s.sharpe_ci_lower, 2)}, {fmt(s.sharpe_ci_upper, 2)}]
+                    </div>
+                  )}
+                </div>
                 <div><div className="caption">CAGR</div><div className="positive" style={{ fontWeight: 700, fontSize: '1.1rem' }}>{fmtPct(s.cagr)}</div></div>
                 <div><div className="caption">Max DD</div><div className="negative" style={{ fontWeight: 700, fontSize: '1.1rem' }}>−{fmtPct(s.max_drawdown)}</div></div>
                 <div><div className="caption">Win Rate</div><div style={{ fontWeight: 700, fontSize: '1.1rem' }}>{fmtPct(s.win_rate)}</div></div>

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import EfficientFrontier from './EfficientFrontier'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -646,6 +647,13 @@ export default function Strategies() {
 
       {/* Paper corpus table */}
       {!loading && strategies.length > 0 && <CorpusTable strategies={strategies} />}
+
+      {/* Efficient frontier visualization */}
+      {!loading && strategies.length > 0 && (
+        <div className="mb-6">
+          <EfficientFrontier />
+        </div>
+      )}
 
       {/* Placeholder disclaimer */}
       {strategies.some(s => s.is_backtest_placeholder) && (

--- a/ui/src/components/VaultDetail.jsx
+++ b/ui/src/components/VaultDetail.jsx
@@ -40,9 +40,57 @@ function _knownTokenSymbol(addr) {
   return `${addr.slice(0, 6)}...`
 }
 
+function SharpeDriftBadge({ drift }) {
+  if (!drift) return null
+  const statusColors = {
+    NORMAL: { bg: 'rgba(16,185,129,0.12)', color: 'var(--positive)', border: 'rgba(16,185,129,0.3)', label: 'NORMAL' },
+    WARNING: { bg: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: 'rgba(245,158,11,0.3)', label: 'WARNING' },
+    CRITICAL: { bg: 'rgba(239,68,68,0.12)', color: 'var(--negative)', border: 'rgba(239,68,68,0.3)', label: 'CRITICAL' },
+    INSUFFICIENT_DATA: { bg: 'rgba(255,255,255,0.06)', color: 'var(--text-3)', border: 'var(--glass-border)', label: 'INSUFFICIENT DATA' },
+  }
+  const s = statusColors[drift.status] || statusColors.INSUFFICIENT_DATA
+  return (
+    <div style={{ padding: '12px 16px', background: 'var(--surface-2)', borderRadius: 8, border: '1px solid var(--glass-border)', marginBottom: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Performance Tracker
+        </span>
+        <span style={{ fontSize: '0.72rem', fontWeight: 700, padding: '2px 8px', borderRadius: 4, background: s.bg, color: s.color, border: `1px solid ${s.border}` }}>
+          {s.label}
+        </span>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10 }}>
+        <div>
+          <div style={{ fontSize: '0.7rem', color: 'var(--text-3)', marginBottom: 2 }}>Live Sharpe</div>
+          <div style={{ fontWeight: 700, fontSize: '1rem', color: 'var(--text-1)' }}>
+            {drift.live_sharpe != null ? drift.live_sharpe.toFixed(3) : '—'}
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: '0.7rem', color: 'var(--text-3)', marginBottom: 2 }}>Backtest</div>
+          <div style={{ fontWeight: 700, fontSize: '1rem', color: 'var(--text-1)' }}>
+            {drift.backtest_sharpe != null ? drift.backtest_sharpe.toFixed(3) : '—'}
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: '0.7rem', color: 'var(--text-3)', marginBottom: 2 }}>Decay Floor</div>
+          <div style={{ fontWeight: 700, fontSize: '1rem', color: 'var(--text-2)' }}>
+            {drift.decay_floor != null ? drift.decay_floor.toFixed(3) : '—'}
+          </div>
+        </div>
+      </div>
+      <div style={{ marginTop: 6, fontSize: '0.68rem', color: 'var(--text-4)' }}>
+        McLean-Pontiff 42% post-publication retention floor
+        {drift.drift_sigma != null && ` · drift ${drift.drift_sigma > 0 ? '+' : ''}${drift.drift_sigma.toFixed(2)}σ`}
+      </div>
+    </div>
+  )
+}
+
 export default function VaultDetail({ address, onBack }) {
   const [detail, setDetail] = useState(null)
   const [onChainData, setOnChainData] = useState(null)
+  const [health, setHealth] = useState(null)
   const [depositAmt, setDepositAmt] = useState('')
   const [status, setStatus] = useState('')
   const [busy, setBusy] = useState(false)
@@ -63,6 +111,10 @@ export default function VaultDetail({ address, onBack }) {
           setDetail(prev => prev ? { ...prev, ...meta } : prev)
         }
       })
+      .catch(() => {})
+    // Fetch vault health (includes Sharpe drift)
+    apiGet(`/api/vaults/${address}/health`)
+      .then(h => { if (!cancelled) setHealth(h) })
       .catch(() => {})
     return () => { cancelled = true }
   }, [address])
@@ -167,6 +219,13 @@ export default function VaultDetail({ address, onBack }) {
           <div className="vault-stat-value"><code>{shortAddr(onChainData?.creator || detail?.creator)}</code></div>
         </div>
       </div>
+
+      {/* Performance Tracker / Sharpe Drift */}
+      {health?.sharpe_drift && (
+        <div className="vault-section">
+          <SharpeDriftBadge drift={health.sharpe_drift} />
+        </div>
+      )}
 
       {/* Holdings */}
       {detail?.holdings && detail.holdings.length > 0 && (


### PR DESCRIPTION
## Summary

Five new quant features surfacing the statistical depth that was already computed but invisible to users.

- **Sharpe 95% CI** — Lo (2002) analytical confidence intervals on every strategy's Sharpe ratio (`compute_sharpe_ci()` in `rigor_evaluator.py`); displayed in the passport as `95% CI [lower, upper]` beneath the point estimate
- **Live Sharpe drift detector** — `compute_sharpe_drift()` in `vault_monitor.py` compares rolling live Sharpe from AUM snapshots against the backtested baseline and a McLean-Pontiff 42% post-publication decay floor; returns `NORMAL / WARNING / CRITICAL / INSUFFICIENT_DATA`; wired to vault health endpoint and displayed as a badge in VaultDetail
- **Efficient frontier** — `compute_efficient_frontier()` added to `portfolio_optimizer.py` (SLSQP sweep); `GET /api/strategies/frontier` endpoint; `EfficientFrontier.jsx` SVG component embedded in Strategies page
- **Strategy correlation matrix** — `GET /api/strategies/correlation` (SPY-correlated synthetic streams + Cholesky decomposition); `CorrelationMatrix.jsx` colour-coded heatmap with honest note that all library strategies track broad equity markets
- **Rigor Gate explainer page** — `RigorExplainer.jsx` at `/intelligence/rigor-gate`; four plain-English cards (DSR, PBO, OOS Sharpe, look-ahead audit) with thresholds, formulas, and live library examples

## Test plan

- [ ] `pytest` → 118 passed, 1 pre-existing Redis failure only
- [ ] Strategies page shows Sharpe CI annotation and efficient frontier SVG
- [ ] `/intelligence/rigor-gate` loads and renders all four primitive cards
- [ ] Vault health endpoint includes `sharpe_drift` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)