### PR TITLE
[quant] Fix correlation heatmap gradient; add CI, drift, frontier, correlation tests

### DIFF
--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -129,6 +129,107 @@ class TestRootAndHealth:
         assert "status" in data
 
 
+class TestFrontierRoutes:
+    def test_frontier_returns_200(self, client):
+        """Frontier endpoint must return 200 regardless of library state."""
+        resp = client.get("/api/strategies/frontier")
+        assert resp.status_code == 200
+
+    def test_frontier_response_shape(self, client):
+        """Response must include 'frontier' and 'strategies' keys."""
+        resp = client.get("/api/strategies/frontier")
+        data = resp.json()
+        assert "frontier" in data
+        assert "strategies" in data
+
+    def test_frontier_points_have_vol_and_return(self, client):
+        """Every frontier point must have numeric vol and return fields."""
+        resp = client.get("/api/strategies/frontier")
+        data = resp.json()
+        for pt in data.get("frontier", []):
+            assert "vol" in pt, "Frontier point missing 'vol'"
+            assert "return" in pt, "Frontier point missing 'return'"
+            assert isinstance(pt["vol"], (int, float))
+            assert isinstance(pt["return"], (int, float))
+
+    def test_frontier_vol_non_negative(self, client):
+        """Volatility must be ≥ 0 for every frontier point."""
+        resp = client.get("/api/strategies/frontier")
+        data = resp.json()
+        for pt in data.get("frontier", []):
+            assert pt["vol"] >= 0, f"Negative vol {pt['vol']} in frontier"
+
+    def test_frontier_insufficient_strategies_returns_empty(self, client):
+        """With < 2 Tier-1 strategies the endpoint returns an empty frontier, not 500."""
+        resp = client.get("/api/strategies/frontier")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Either a populated frontier or an explicit empty list with a message
+        assert isinstance(data.get("frontier"), list)
+
+
+class TestCorrelationRoutes:
+    def test_correlation_returns_200(self, client):
+        """Correlation endpoint must return 200."""
+        resp = client.get("/api/strategies/correlation")
+        assert resp.status_code == 200
+
+    def test_correlation_response_shape(self, client):
+        """Response must include matrix and labels keys."""
+        resp = client.get("/api/strategies/correlation")
+        data = resp.json()
+        assert "matrix" in data
+        assert "labels" in data
+
+    def test_correlation_matrix_is_square(self, client):
+        """Correlation matrix must be N×N where N = len(labels)."""
+        resp = client.get("/api/strategies/correlation")
+        data = resp.json()
+        n = len(data.get("labels", []))
+        matrix = data.get("matrix", [])
+        if n == 0:
+            return  # no strategies with real data — acceptable
+        assert len(matrix) == n, f"Expected {n} rows, got {len(matrix)}"
+        for row in matrix:
+            assert len(row) == n, f"Expected {n} cols per row, got {len(row)}"
+
+    def test_correlation_diagonal_is_one(self, client):
+        """Diagonal entries must be 1.0 (each strategy perfectly correlated with itself)."""
+        resp = client.get("/api/strategies/correlation")
+        data = resp.json()
+        matrix = data.get("matrix", [])
+        for i, row in enumerate(matrix):
+            assert abs(row[i] - 1.0) < 0.01, f"Diagonal [{i}][{i}] = {row[i]}, expected 1.0"
+
+    def test_correlation_values_in_range(self, client):
+        """All correlation values must be in [-1, 1]."""
+        resp = client.get("/api/strategies/correlation")
+        data = resp.json()
+        for row in data.get("matrix", []):
+            for val in row:
+                assert -1.0 <= val <= 1.0, f"Correlation {val} outside [-1, 1]"
+
+    def test_correlation_matrix_is_symmetric(self, client):
+        """Correlation matrix must be symmetric: M[i][j] == M[j][i]."""
+        resp = client.get("/api/strategies/correlation")
+        data = resp.json()
+        matrix = data.get("matrix", [])
+        for i, row in enumerate(matrix):
+            for j, val in enumerate(row):
+                assert abs(val - matrix[j][i]) < 1e-6, (
+                    f"Matrix not symmetric: [{i}][{j}]={val} vs [{j}][{i}]={matrix[j][i]}"
+                )
+
+    def test_avg_pairwise_correlation_present(self, client):
+        """avg_pairwise_correlation must be present and numeric when matrix is non-empty."""
+        resp = client.get("/api/strategies/correlation")
+        data = resp.json()
+        if data.get("matrix"):
+            avg = data.get("avg_pairwise_correlation")
+            assert avg is not None
+            assert -1.0 <= avg <= 1.0
+
+
 class TestStrategyRoutes:
     def test_list_strategies(self, client, seeded_db):
         resp = client.get("/api/strategies/")

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -31,6 +31,7 @@ from archimedes.services.rigor_evaluator import (
     compute_kelly_fraction,
     compute_oos_sharpe,
     compute_pbo,
+    compute_sharpe_ci,
 )
 
 _ANNUALIZATION = 252
@@ -270,3 +271,75 @@ def test_kelly_is_clipped_to_unit_interval():
     assert f is not None
     assert f <= 1.0, "Kelly fraction must be clipped to ≤ 1.0"
     assert f >= 0.0
+
+
+# ─── Sharpe CI (Lo 2002) ─────────────────────────────────────────────
+
+
+def test_sharpe_ci_symmetric_around_point_estimate():
+    """CI must be symmetric: point estimate is the midpoint of (lower, upper)."""
+    sr = 1.0
+    lower, upper = compute_sharpe_ci(sr, n_obs_daily=252, confidence=0.95)
+    mid = (lower + upper) / 2
+    assert abs(mid - sr) < 1e-9, f"CI midpoint {mid:.6f} must equal SR {sr}"
+
+
+def test_sharpe_ci_wider_with_fewer_obs():
+    """Fewer observations → wider confidence interval."""
+    sr = 0.8
+    lo_wide, hi_wide = compute_sharpe_ci(sr, n_obs_daily=252)
+    lo_narrow, hi_narrow = compute_sharpe_ci(sr, n_obs_daily=2520)
+    assert (hi_wide - lo_wide) > (hi_narrow - lo_narrow), (
+        "CI with 252 obs must be wider than CI with 2520 obs"
+    )
+
+
+def test_sharpe_ci_wider_with_higher_confidence():
+    """Higher confidence level → wider interval."""
+    sr = 0.7
+    lo_95, hi_95 = compute_sharpe_ci(sr, n_obs_daily=500, confidence=0.95)
+    lo_99, hi_99 = compute_sharpe_ci(sr, n_obs_daily=500, confidence=0.99)
+    assert (hi_99 - lo_99) > (hi_95 - lo_95), "99% CI must be wider than 95% CI"
+
+
+def test_sharpe_ci_lo2002_formula_pinned():
+    """Pin Lo (2002) SE against a manually computed reference value.
+
+    SR_annual = 1.0, n = 252, confidence = 0.95.
+    SR_daily = 1/sqrt(252)
+    SE = sqrt((1 + 0.5*(1/252)) * 252 / 252) = sqrt(1 + 0.5/252) ≈ 1.001
+    z_0.975 ≈ 1.96 → half-width ≈ 1.96 * 1.001 ≈ 1.962
+    """
+    import math
+    sr = 1.0
+    n = 252
+    sr_daily = sr / math.sqrt(252)
+    se = math.sqrt((1 + 0.5 * sr_daily ** 2) * 252 / n)
+    from scipy.stats import norm
+    z = norm.ppf(0.975)
+    expected_lower = sr - z * se
+    expected_upper = sr + z * se
+
+    lower, upper = compute_sharpe_ci(sr, n_obs_daily=n, confidence=0.95)
+    assert abs(lower - expected_lower) < 1e-9
+    assert abs(upper - expected_upper) < 1e-9
+
+
+def test_sharpe_ci_rejects_invalid_n():
+    """n_obs_daily ≤ 0 must raise ValueError."""
+    import pytest
+    with pytest.raises(ValueError, match="n_obs_daily"):
+        compute_sharpe_ci(1.0, n_obs_daily=0)
+    with pytest.raises(ValueError, match="n_obs_daily"):
+        compute_sharpe_ci(1.0, n_obs_daily=-5)
+
+
+def test_sharpe_ci_rejects_invalid_confidence():
+    """Confidence outside (0, 1) must raise ValueError."""
+    import pytest
+    with pytest.raises(ValueError, match="confidence"):
+        compute_sharpe_ci(1.0, n_obs_daily=252, confidence=0.0)
+    with pytest.raises(ValueError, match="confidence"):
+        compute_sharpe_ci(1.0, n_obs_daily=252, confidence=1.0)
+    with pytest.raises(ValueError, match="confidence"):
+        compute_sharpe_ci(1.0, n_obs_daily=252, confidence=1.5)

--- a/backend/tests/test_vault_monitor.py
+++ b/backend/tests/test_vault_monitor.py
@@ -1,0 +1,174 @@
+"""Tests for vault_monitor.compute_sharpe_drift.
+
+Pure-computation tests — no chain client, no Redis, no database.
+Covers the McLean-Pontiff decay floor, status thresholds, Lo (2002) SE,
+and edge cases (insufficient data, zero variance).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from archimedes.services.vault_monitor import (
+    _MCLEAN_PONTIFF_DECAY,
+    _MIN_SNAPSHOTS_FOR_SHARPE,
+    compute_sharpe_drift,
+)
+
+
+def _snapshots(navs: list[float]) -> list[dict]:
+    """Build snapshot dicts from a NAV series (oldest-first input).
+
+    compute_sharpe_drift expects most-recent-first order (Redis LRANGE convention)
+    and internally reverses to chronological order before computing returns.
+    """
+    return [{"aum_usdc": n} for n in reversed(navs)]
+
+
+# ─── Insufficient data ────────────────────────────────────────────────
+
+
+def test_insufficient_snapshots_returns_status():
+    """Fewer than _MIN_SNAPSHOTS_FOR_SHARPE snapshots → INSUFFICIENT_DATA."""
+    snaps = _snapshots([100.0] * (_MIN_SNAPSHOTS_FOR_SHARPE - 1))
+    result = compute_sharpe_drift(snaps, backtest_sharpe=1.0)
+    assert result["status"] == "INSUFFICIENT_DATA"
+    assert result["live_sharpe"] is None
+    assert result["drift_sigma"] is None
+
+
+def test_exactly_min_snapshots_computes():
+    """Exactly _MIN_SNAPSHOTS_FOR_SHARPE + 2 snapshots with drift should compute."""
+    navs = [100.0 * (1.001 ** i) for i in range(_MIN_SNAPSHOTS_FOR_SHARPE + 2)]
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=1.0)
+    assert result["status"] != "INSUFFICIENT_DATA"
+    assert result["live_sharpe"] is not None
+
+
+def test_zero_variance_aum_returns_insufficient():
+    """Flat AUM (zero variance) → INSUFFICIENT_DATA, not a crash or 0.0."""
+    navs = [100.0] * 20
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=1.0)
+    assert result["status"] == "INSUFFICIENT_DATA"
+    assert result["live_sharpe"] is None
+
+
+# ─── McLean-Pontiff decay floor ───────────────────────────────────────
+
+
+def test_decay_floor_is_correct_fraction():
+    """decay_floor must equal backtest_sharpe * _MCLEAN_PONTIFF_DECAY (42%)."""
+    bs = 1.2
+    navs = [100.0] * 20  # insufficient data — but decay_floor is always returned
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=bs)
+    assert abs(result["decay_floor"] - round(bs * _MCLEAN_PONTIFF_DECAY, 4)) < 1e-9
+
+
+def test_decay_constant_is_42_percent():
+    """Constant must match McLean & Pontiff (2016): 42% Sharpe retention."""
+    assert abs(_MCLEAN_PONTIFF_DECAY - 0.42) < 1e-9
+
+
+# ─── Status thresholds ───────────────────────────────────────────────
+
+
+def test_normal_status_when_live_sharpe_above_floor():
+    """live_sharpe ≥ decay_floor → NORMAL."""
+    bs = 0.8
+    rng = np.random.default_rng(1)
+    # High drift/vol ratio → annualized Sharpe well above decay_floor (0.336)
+    navs = [100.0]
+    for r in rng.normal(0.002, 0.001, 50):
+        navs.append(navs[-1] * (1 + r))
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=bs)
+    assert result["status"] == "NORMAL", (
+        f"Expected NORMAL, got {result['status']} "
+        f"(live={result['live_sharpe']:.3f}, floor={bs * _MCLEAN_PONTIFF_DECAY:.3f})"
+    )
+
+
+def test_warning_or_critical_when_live_sharpe_below_floor():
+    """live_sharpe below decay_floor → WARNING or CRITICAL (not NORMAL).
+
+    Note: 5-min snapshots annualize with 72,576 periods/year, so even a
+    small positive mean/vol ratio produces a huge live Sharpe. We need a
+    clearly negative mean to guarantee live_sharpe < floor.
+    """
+    bs = 1.5
+    rng = np.random.default_rng(2)
+    # Negative drift → live Sharpe well below decay_floor (0.63)
+    navs = [100.0]
+    for r in rng.normal(-0.001, 0.002, 60):
+        navs.append(navs[-1] * (1 + r))
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=bs)
+    assert result["status"] in ("WARNING", "CRITICAL"), (
+        f"Expected WARNING or CRITICAL for degraded Sharpe, got {result['status']}"
+    )
+
+
+def test_critical_status_when_live_sharpe_far_below_floor():
+    """live_sharpe < decay_floor * 0.5 → CRITICAL."""
+    bs = 2.0
+    rng = np.random.default_rng(3)
+    # Strongly negative returns → live Sharpe << decay_floor * 0.5 (0.42)
+    navs = [100.0]
+    for r in rng.normal(-0.003, 0.001, 60):
+        navs.append(navs[-1] * (1 + r))
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=bs)
+    assert result["status"] == "CRITICAL", (
+        f"Expected CRITICAL for strongly negative live Sharpe, got {result['status']}"
+    )
+
+
+# ─── drift_sigma sign and magnitude ──────────────────────────────────
+
+
+def test_drift_sigma_negative_for_degraded_performance():
+    """Strategies performing far below backtest baseline should have negative drift_sigma."""
+    rng = np.random.default_rng(4)
+    # Negative drift → live Sharpe << backtest_sharpe of 2.0
+    navs = [100.0]
+    for r in rng.normal(-0.001, 0.002, 50):
+        navs.append(navs[-1] * (1 + r))
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=2.0)
+    if result["drift_sigma"] is not None:
+        assert result["drift_sigma"] < 0, (
+            f"Degraded live Sharpe should give negative drift_sigma, got {result['drift_sigma']:.3f}"
+        )
+
+
+def test_drift_sigma_near_zero_for_matching_performance():
+    """live_sharpe ≈ backtest_sharpe → drift_sigma ≈ 0."""
+    rng = np.random.default_rng(5)
+    rets = rng.normal(0.002, 0.005, 100).tolist()
+    navs = [100.0]
+    for r in rets:
+        navs.append(navs[-1] * (1 + r))
+
+    # Compute the same live Sharpe the function will compute, then pass it as backtest
+    mean_r = sum(rets) / len(rets)
+    var_r = sum((r - mean_r) ** 2 for r in rets) / max(len(rets) - 1, 1)
+    std_r = math.sqrt(var_r)
+    periods_per_year = (24 * 60 / 5.0) * 252
+    expected_live_sharpe = (mean_r / std_r) * math.sqrt(periods_per_year)
+
+    result = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=expected_live_sharpe)
+    if result["drift_sigma"] is not None:
+        assert abs(result["drift_sigma"]) < 0.5, (
+            f"When live ≈ backtest, drift_sigma should be near 0, got {result['drift_sigma']:.3f}"
+        )
+
+
+# ─── Output shape ────────────────────────────────────────────────────
+
+
+def test_output_always_has_required_keys():
+    """All result dicts must contain the five required keys regardless of status."""
+    required = {"live_sharpe", "backtest_sharpe", "decay_floor", "drift_sigma", "status"}
+    r1 = compute_sharpe_drift(_snapshots([100.0] * 3), backtest_sharpe=1.0)
+    assert required.issubset(r1.keys())
+    navs = [100.0 * (1.001 ** i) for i in range(30)]
+    r2 = compute_sharpe_drift(_snapshots(navs), backtest_sharpe=1.0)
+    assert required.issubset(r2.keys())

--- a/ui/src/components/CorrelationMatrix.jsx
+++ b/ui/src/components/CorrelationMatrix.jsx
@@ -57,25 +57,26 @@ export default function CorrelationMatrix() {
   const n = labels.length
 
   /**
-   * Colour interpolation: green (0) → neutral (0.5) → red (1).
+   * Colour interpolation: green (0) → neutral grey (0.5) → red (1).
    * Uses RGBA so it works on any background.
+   * green = rgba(16,185,129), neutral = rgba(120,120,120), red = rgba(239,68,68)
    */
   function cellColor(value) {
     const v = Math.max(0, Math.min(1, value))
     if (v <= 0.5) {
-      // 0 → pure green, 0.5 → neutral
+      // green → neutral grey
       const t = v * 2
-      const r = Math.round(16 + t * (239 - 16))   // 16→239
-      const g = Math.round(185 + t * (68 - 185))   // 185→68
-      const b = Math.round(129 + t * (68 - 129))   // 129→68
-      return `rgba(${r},${g},${b},${0.15 + t * 0.25})`
+      const r = Math.round(16  + t * (120 - 16))
+      const g = Math.round(185 + t * (120 - 185))
+      const b = Math.round(129 + t * (120 - 129))
+      return `rgba(${r},${g},${b},${0.15 + t * 0.20})`
     } else {
-      // 0.5 → neutral, 1 → pure red
+      // neutral grey → red
       const t = (v - 0.5) * 2
-      const r = Math.round(239)
-      const g = Math.round(68 - t * 68)
-      const b = Math.round(68 - t * 68)
-      return `rgba(${r},${g},${b},${0.15 + t * 0.35})`
+      const r = Math.round(120 + t * (239 - 120))
+      const g = Math.round(120 + t * (68  - 120))
+      const b = Math.round(120 + t * (68  - 120))
+      return `rgba(${r},${g},${b},${0.35 + t * 0.15})`
     }
   }
 


### PR DESCRIPTION
## Summary

- **Visual fix:** `CorrelationMatrix` colour gradient was broken — both halves of the 0→1 scale converged to red variants at the midpoint, so there was no neutral grey. Now properly interpolates green → grey → red.
- **New tests:** `compute_sharpe_ci`, `compute_sharpe_drift`, `/frontier`, `/correlation` were all untested. Added 29 tests covering them.

## Changes

### `ui/src/components/CorrelationMatrix.jsx`
`cellColor()` now correctly interpolates:
- `v=0`: `rgba(16,185,129)` — green (low correlation, good diversification)
- `v=0.5`: `rgba(120,120,120)` — neutral grey (no jump at the midpoint)
- `v=1`: `rgba(239,68,68)` — red (high correlation, less diversification)

### `backend/tests/test_rigor_evaluator.py`
6 unit tests for `compute_sharpe_ci` (Lo 2002):
- Symmetry around point estimate
- Width increases with fewer observations
- Width increases with higher confidence
- Formula pinned against a manually computed reference
- `ValueError` raised for `n_obs_daily ≤ 0`
- `ValueError` raised for `confidence` outside `(0, 1)`

### `backend/tests/test_vault_monitor.py` *(new file)*
11 unit tests for `compute_sharpe_drift`:
- Insufficient data → `INSUFFICIENT_DATA`
- Zero-variance AUM → `INSUFFICIENT_DATA` (not 0.0 or crash)
- Decay floor = `backtest_sharpe × 0.42`
- `_MCLEAN_PONTIFF_DECAY` constant pinned to 0.42
- Strong positive drift → `NORMAL`
- Negative drift → `WARNING` or `CRITICAL`
- Strongly negative drift → `CRITICAL`
- Degraded live Sharpe → negative `drift_sigma`
- Matching live ≈ backtest → `drift_sigma ≈ 0`
- Output always contains the 5 required keys

### `backend/tests/test_api_routes.py`
12 integration tests across 2 new test classes:
- `TestFrontierRoutes` (5): 200 status, shape, numeric fields, non-negative vol, graceful empty fallback
- `TestCorrelationRoutes` (7): 200 status, shape, N×N matrix, diagonal=1.0, values ∈ [-1,1], symmetry, avg pairwise present

## Test results
```
302 passed, 2 skipped — 0 failures
```

## Anti-goals
- No threshold changes, no rigor gate logic touched
- No new dependencies
- No changes to production code beyond the colour fix