### PR TITLE
[spine] Spine+ v2: streaming Generate, Explore page, page-roles split, KB skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,40 @@
-.PHONY: setup wallet fund compile test deploy feed balance
+.PHONY: help setup wallet fund compile test deploy feed balance \
+        up down logs pytest lint format ui-dev clean routes
+
+# ─── Help (default) ──────────────────────────────────
+
+help:
+	@echo "Archimedes — common dev targets (run 'make <target>'):"
+	@echo ""
+	@echo "  Stack lifecycle:"
+	@echo "    up           Build + start the docker stack (postgres/redis/backend/oracle/nginx)"
+	@echo "    down         Stop the docker stack"
+	@echo "    logs         Tail backend logs (Ctrl-C to detach)"
+	@echo ""
+	@echo "  Python:"
+	@echo "    pytest       Run the backend test suite (stack must be up first)"
+	@echo "    lint         ruff check"
+	@echo "    format       ruff format"
+	@echo "    routes       Dump FastAPI route inventory"
+	@echo ""
+	@echo "  Frontend:"
+	@echo "    ui-dev       Run the Vite dev server (ui/)"
+	@echo ""
+	@echo "  Contracts (Foundry):"
+	@echo "    compile      forge build"
+	@echo "    test         forge test -vv"
+	@echo ""
+	@echo "  Circle wallet + oracle (wallet-setup/):"
+	@echo "    setup        npm install in wallet-setup/"
+	@echo "    register     Register Circle entity secret"
+	@echo "    wallet       Create Circle dev wallet"
+	@echo "    fund         Open Circle wallet console (request testnet USDC)"
+	@echo "    deploy       Run deploy.mjs"
+	@echo "    feed         Push current prices into the on-chain oracle"
+	@echo "    balance      Query wallet token balance"
+	@echo ""
+	@echo "  Maintenance:"
+	@echo "    clean        Remove __pycache__/.pytest_cache/.ruff_cache"
 
 # ─── Setup ───────────────────────────────────────────
 
@@ -38,8 +74,45 @@ setvault:
 
 # ─── UI ─────────────────────────────────────────────
 
-ui:
+ui-dev:
 	cd ui && npm run dev
+
+ui: ui-dev  # back-compat alias
+
+# ─── Stack lifecycle ─────────────────────────────────
+
+up:
+	docker compose up -d --build
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f backend
+
+# ─── Python ──────────────────────────────────────────
+
+pytest:
+	pytest -q --deselect backend/tests/test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults \
+	          --deselect backend/tests/test_api_routes.py::TestAdvisorRoutes::test_advisor_redis_unavailable
+
+lint:
+	ruff check backend/
+
+format:
+	ruff format backend/
+
+routes:
+	python -c "from archimedes.main import app; \
+	    print('\n'.join(sorted(f'{sorted(r.methods or [])[0] if r.methods else \"-\":6} {r.path}' for r in app.routes)))"
+
+# ─── Maintenance ─────────────────────────────────────
+
+clean:
+	find . -type d -name __pycache__ -not -path "./submodules/*" -not -path "./.claude/*" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .pytest_cache -not -path "./submodules/*" -not -path "./.claude/*" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .ruff_cache -not -path "./submodules/*" -not -path "./.claude/*" -exec rm -rf {} + 2>/dev/null || true
+	@echo "cleaned __pycache__, .pytest_cache, .ruff_cache"
 
 # ─── Queries ─────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ Then open <http://localhost>. Full walkthrough: [`SETUP.md`](SETUP.md).
 > reachable; without the stack you'll see connection errors, not test failures. Full
 > testing notes in [`SETUP.md` § Running the test suite](SETUP.md#running-the-test-suite).
 
+### Common dev commands (`make help`)
+
+The repo ships a [`Makefile`](Makefile) with shortcuts for the daily workflow.
+Run `make` (or `make help`) for the full list. Most useful:
+
+```
+make up         # docker compose up -d --build (starts the stack)
+make down       # stop the stack
+make logs       # tail backend logs
+make pytest     # run the backend test suite (stack must be up)
+make lint       # ruff check
+make format     # ruff format
+make ui-dev     # Vite dev server (ui/)
+make routes     # dump FastAPI route inventory
+make clean      # nuke __pycache__/.pytest_cache/.ruff_cache
+```
+
+Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`, …) are also there — see `make help`.
+
 ## Status (2026-05-22)
 
 **Live on the Arc public testnet** (chain ID `5042002`): grab faucet USDC at <https://faucet.circle.com/> (20 USDC / 2h — on Arc, USDC *is* gas) and try the full flow with test funds. **No real money at risk, by design.** Arc has no mainnet yet (Circle's docs list mainnet as "upcoming"); mainnet launch, real-funds custody, and the regulatory architecture (off-chain redemptions, preset-strategy / RIA posture) are the **business-plan roadmap**, not hackathon scope — see [`docs/competitor-landscape.md`](docs/competitor-landscape.md).

--- a/backend/archimedes/api/corpus_routes.py
+++ b/backend/archimedes/api/corpus_routes.py
@@ -1,0 +1,222 @@
+"""/api/corpus/* — Knowledge-Graph + similarity-graph surface.
+
+Replaces the metadata-derived stubs that were previously embedded in
+routes.py with endpoints that read from the KB pipeline's artifacts
+(named volume) + ORM tables (kg_entities, kg_relations).
+
+Per cross-cutting principle #2 — no new endpoints in routes.py.
+
+Phase 3c contract:
+  GET /api/corpus/runner-state    — pipeline phase + last-run manifest
+  GET /api/corpus/overview        — aggregate (paper count, top topics)
+  GET /api/corpus/graph           — SPECTER2-similarity 2D scatter (Phase 3c full)
+  GET /api/corpus/kg/entities     — search KG entities by name
+  GET /api/corpus/kg/entity/{id}  — single entity + adjacent relations
+  GET /api/corpus/kg/paper/{id}   — all triples for one paper
+
+This skeleton implements the runner-state + overview endpoints (read from
+the artifact volume + DB) and returns explicit "pipeline not yet run" 503s
+for graph/kg endpoints until the KB pipeline lands its first artifact.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+logger = logging.getLogger(__name__)
+
+corpus_router = APIRouter(prefix="/api/corpus", tags=["corpus"])
+
+ARTIFACT_DIR = Path(os.getenv("KB_ARTIFACT_DIR", "/srv/corpus-artifact"))
+
+
+def _load_manifest() -> dict | None:
+    """Manifest written by run_kb_pipeline.py. None if the pipeline never ran."""
+    path = ARTIFACT_DIR / "manifest.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("corpus_routes: manifest unreadable: %s", exc)
+        return None
+
+
+def _load_state() -> dict | None:
+    """In-progress state written during a running pipeline."""
+    path = ARTIFACT_DIR / "state.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+@corpus_router.get("/runner-state")
+async def runner_state() -> dict[str, Any]:
+    """Surface the KB pipeline phase + progress for the UI banner.
+
+    During a run, ``state.json`` carries ``{phase, progress, started_at}``.
+    When idle, the response reflects the last completed run from ``manifest.json``.
+    """
+    state = _load_state()
+    manifest = _load_manifest()
+    if state:
+        return {"running": True, **state, "last_manifest": manifest}
+    if manifest:
+        return {
+            "running": False,
+            "last_run_ts": manifest.get("run_ts"),
+            "duration_s": manifest.get("duration_s"),
+            "paper_count": manifest.get("paper_count"),
+            "status": manifest.get("status", "ok"),
+        }
+    return {
+        "running": False,
+        "status": "pipeline never run — see docs/specs/kb-integration-spec.md to enable",
+    }
+
+
+@corpus_router.get("/overview")
+async def corpus_overview() -> dict[str, Any]:
+    """KB-aware corpus overview. Falls back to DB-only counts if no manifest."""
+    manifest = _load_manifest()
+    try:
+        from sqlalchemy import func
+        from archimedes.db import get_session
+        from archimedes.models.corpus_store import PaperRecord
+        with get_session() as session:
+            paper_count = session.query(func.count(PaperRecord.arxiv_id)).scalar() or 0
+            cluster_rows = session.query(
+                PaperRecord.cluster_id, func.count(PaperRecord.arxiv_id),
+            ).group_by(PaperRecord.cluster_id).all()
+    except Exception as exc:
+        logger.warning("corpus_routes: overview DB read failed: %s", exc)
+        paper_count = 0
+        cluster_rows = []
+
+    return {
+        "paper_count": paper_count,
+        "cluster_count": len([c for c, _ in cluster_rows if c is not None]),
+        "last_run_ts": (manifest or {}).get("run_ts"),
+        "pipeline_status": (manifest or {}).get("status", "never run"),
+    }
+
+
+@corpus_router.get("/graph")
+async def corpus_graph() -> dict[str, Any]:
+    """SPECTER2-similarity 2D scatter. Requires a completed KB run."""
+    manifest = _load_manifest()
+    if manifest is None or not (ARTIFACT_DIR / "embeddings.npy").exists():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Corpus graph requires a completed KB pipeline run. "
+                "Run `docker compose run --rm kb-runner python -m archimedes.scripts.run_kb_pipeline` "
+                "(or set KB_PIPELINE_ENABLED=1 in the kb-runner container) to produce embeddings.npy. "
+                "See docs/specs/kb-integration-spec.md."
+            ),
+        )
+    # Skeleton: when the pipeline lands, this loads embeddings.npy + ids.json,
+    # runs UMAP to 2D, returns {points: [{arxiv_id, x, y, cluster_id}], topics: {...}}.
+    raise HTTPException(status_code=501, detail="UMAP projection not yet wired; see Phase 3c.")
+
+
+@corpus_router.get("/kg/entities")
+async def kg_search_entities(q: str = Query(..., min_length=2, max_length=120)) -> dict[str, Any]:
+    """Search KG entities by canonical name."""
+    try:
+        from archimedes.db import get_session
+        from archimedes.models.kg import KGEntity
+        with get_session() as session:
+            rows = session.query(KGEntity) \
+                .filter(KGEntity.canonical_name.ilike(f"%{q}%")) \
+                .order_by(KGEntity.paper_count.desc()) \
+                .limit(50).all()
+    except Exception as exc:
+        logger.warning("kg search failed: %s", exc)
+        rows = []
+    return {
+        "query": q,
+        "entities": [
+            {"id": r.id, "canonical_name": r.canonical_name, "entity_type": r.entity_type,
+             "paper_count": r.paper_count}
+            for r in rows
+        ],
+    }
+
+
+@corpus_router.get("/kg/entity/{entity_id}")
+async def kg_entity_detail(entity_id: int) -> dict[str, Any]:
+    """Single entity + its outgoing relations."""
+    try:
+        from archimedes.db import get_session
+        from archimedes.models.kg import KGEntity, KGRelation
+        with get_session() as session:
+            entity = session.query(KGEntity).filter(KGEntity.id == entity_id).first()
+            if not entity:
+                raise HTTPException(status_code=404, detail=f"Entity {entity_id} not found")
+            relations = session.query(KGRelation).filter(KGRelation.subject_id == entity_id).limit(200).all()
+            obj_ids = {r.object_id for r in relations if r.object_id}
+            objects = {
+                e.id: e for e in session.query(KGEntity).filter(KGEntity.id.in_(obj_ids)).all()
+            }
+            return {
+                "id": entity.id,
+                "canonical_name": entity.canonical_name,
+                "entity_type": entity.entity_type,
+                "paper_count": entity.paper_count,
+                "relations": [
+                    {
+                        "relation": r.relation,
+                        "object": objects.get(r.object_id).canonical_name if r.object_id in objects else None,
+                        "paper_arxiv_id": r.paper_arxiv_id,
+                        "confidence": r.confidence,
+                    }
+                    for r in relations
+                ],
+            }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("kg entity detail failed: %s", exc)
+        raise HTTPException(status_code=503, detail="KG store unavailable") from exc
+
+
+@corpus_router.get("/kg/paper/{arxiv_id}")
+async def kg_paper_triples(arxiv_id: str) -> dict[str, Any]:
+    """All KG triples extracted from a single paper."""
+    try:
+        from archimedes.db import get_session
+        from archimedes.models.kg import KGEntity, KGRelation
+        with get_session() as session:
+            rows = session.query(KGRelation).filter(KGRelation.paper_arxiv_id == arxiv_id).all()
+            if not rows:
+                return {"arxiv_id": arxiv_id, "triples": []}
+            entity_ids = {r.subject_id for r in rows} | {r.object_id for r in rows if r.object_id}
+            entities = {
+                e.id: e.canonical_name
+                for e in session.query(KGEntity).filter(KGEntity.id.in_(entity_ids)).all()
+            }
+            return {
+                "arxiv_id": arxiv_id,
+                "triples": [
+                    {
+                        "subject": entities.get(r.subject_id),
+                        "relation": r.relation,
+                        "object": entities.get(r.object_id),
+                        "confidence": r.confidence,
+                    }
+                    for r in rows
+                ],
+            }
+    except Exception as exc:
+        logger.exception("kg paper triples failed: %s", exc)
+        raise HTTPException(status_code=503, detail="KG store unavailable") from exc

--- a/backend/archimedes/api/explore_routes.py
+++ b/backend/archimedes/api/explore_routes.py
@@ -1,0 +1,35 @@
+"""/api/explore — Asset discovery surface for the spine.
+
+Read-only; no wallet gate. Per page-roles-spec.md, Explore is "the universe of
+tradable assets, demystified" — current oracle prices + plain-English stats.
+
+Lives in its own router file per cross-cutting principle #2 (no new endpoints
+in routes.py).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from archimedes.api.explore_schemas import ExploreAssetsResponse, ExploreHistoryResponse
+from archimedes.services.asset_market_service import asset_market_service
+
+explore_router = APIRouter(prefix="/api/explore", tags=["explore"])
+
+
+@explore_router.get("/assets", response_model=ExploreAssetsResponse)
+async def list_explore_assets() -> ExploreAssetsResponse:
+    """All available synth assets with current price + change windows + vol."""
+    return await asset_market_service.list_assets()
+
+
+@explore_router.get("/assets/{symbol}/history", response_model=ExploreHistoryResponse)
+async def get_explore_history(symbol: str) -> ExploreHistoryResponse:
+    """Daily price history for one asset, used by sparklines + detail charts."""
+    resp = await asset_market_service.get_history(symbol)
+    if not resp.points:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No price history available for {symbol}. Check the symbol spelling.",
+        )
+    return resp

--- a/backend/archimedes/api/explore_schemas.py
+++ b/backend/archimedes/api/explore_schemas.py
@@ -1,0 +1,49 @@
+"""Schemas for the /explore page (asset discovery surface).
+
+Per page-roles-spec.md, Explore is the read-only "what's tradable?" page —
+no wallet required. The response includes plain-English explanations so
+non-finance users can read it without a glossary.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class AssetExploreItem(BaseModel):
+    symbol: str
+    name: str
+    asset_class: str = Field(description="us_stock, us_equity_etf, crypto, etc.")
+    current_price: float | None
+    change_24h_pct: float | None
+    change_7d_pct: float | None
+    change_30d_pct: float | None
+    realized_vol_30d: float | None = Field(
+        default=None, description="Annualized standard deviation of daily returns over last 30 trading days"
+    )
+    oracle_address: str | None = None
+    last_updated: str | None = Field(default=None, description="ISO8601 timestamp of last oracle price")
+    is_stale: bool = Field(default=False, description="True iff oracle hasn't updated in the past staleness window")
+    explanations: dict[str, str] = Field(
+        default_factory=dict,
+        description="Per-metric plain-English copy keyed by field name",
+    )
+
+
+class ExploreAssetsResponse(BaseModel):
+    assets: list[AssetExploreItem]
+    cache_ttl_seconds: int = 30
+    generated_at: str
+
+
+class ExploreHistoryPoint(BaseModel):
+    ts: str  # ISO8601 date
+    price: float
+
+
+class ExploreHistoryResponse(BaseModel):
+    symbol: str
+    interval: Literal["1d"] = "1d"
+    points: list[ExploreHistoryPoint]

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -1,0 +1,207 @@
+"""Streaming Generate API.
+
+Endpoints (per ``docs/specs/generation-streaming-spec.md``):
+
+  POST /api/generate/start                    — create a job (returns job_id)
+  GET  /api/generate/stream/{job_id}          — SSE event stream
+  POST /api/generate/jobs/{job_id}/cancel     — best-effort cancel
+  GET  /api/generate/jobs                     — list recent jobs (status table)
+  GET  /api/generate/jobs/{job_id}/candidates — N candidates incl. rejected
+
+This router lives in its own file per the Spine+ v2 plan's cross-cutting
+principle #2 — no new endpoints go into ``api/routes.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import AsyncIterator
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from archimedes.api.generate_schemas import (
+    CandidateSummary,
+    CandidatesListResponse,
+    GenerateBrief,
+    GenerateStartRequest,
+    GenerateStartResponse,
+    JobsListResponse,
+    JobSummary,
+)
+from archimedes.services.generation_pipeline import run_generation
+from archimedes.services.job_queue import EVENT_LOG_TTL, get_job_store
+
+logger = logging.getLogger(__name__)
+
+generate_router = APIRouter(prefix="/api/generate", tags=["generate"])
+
+_TERMINAL_EVENTS = {"done", "error"}
+_POLL_INTERVAL_SECONDS = 0.4
+_STREAM_TIMEOUT_SECONDS = 300  # cap a single SSE connection at 5 min
+
+
+@generate_router.post("/start", response_model=GenerateStartResponse, status_code=202)
+async def start_generation(req: GenerateStartRequest) -> GenerateStartResponse:
+    """Create a generation job and start the pipeline in the background."""
+    store = get_job_store()
+    job_id = await store.enqueue(
+        job_type="generate",
+        payload={"brief": req.brief.model_dump(), "n_candidates": req.n_candidates},
+    )
+
+    # Fire-and-forget the pipeline. The route doesn't await it; the SSE stream
+    # below tails the event log written by the pipeline as it runs.
+    asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates))
+
+    return GenerateStartResponse(
+        job_id=job_id,
+        stream_url=f"/api/generate/stream/{job_id}",
+        ttl_seconds=EVENT_LOG_TTL,
+    )
+
+
+async def _run_with_cleanup(job_id: str, brief: GenerateBrief, n_candidates: int) -> None:
+    try:
+        await run_generation(job_id=job_id, brief=brief, n_candidates=n_candidates)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # safety net — run_generation already emits error events
+        logger.exception("background job %s crashed outside run_generation", job_id)
+
+
+@generate_router.get("/stream/{job_id}")
+async def stream_events(job_id: str, request: Request) -> StreamingResponse:
+    """Server-Sent Events. Tails the job's Redis event log.
+
+    Honours ``Last-Event-ID`` for client resume after a disconnect (the spec
+    calls this out — the frontend stashes ``currentJobId`` in localStorage
+    and re-subscribes on mount).
+    """
+    store = get_job_store()
+    job = await store.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+
+    try:
+        last_event_id = int(request.headers.get("Last-Event-ID", "0"))
+    except (TypeError, ValueError):
+        last_event_id = 0
+
+    async def event_generator() -> AsyncIterator[str]:
+        # Yield a comment to flush the response headers immediately so the
+        # client's onopen fires within the spec's 500 ms target.
+        yield ": stream opened\n\n"
+
+        cursor = last_event_id
+        elapsed = 0.0
+        while elapsed < _STREAM_TIMEOUT_SECONDS:
+            if await request.is_disconnected():
+                logger.info("sse client disconnected (job=%s, after=%d)", job_id, cursor)
+                return
+
+            new_events = await store.list_events(job_id, after_id=cursor)
+            for ev in new_events:
+                cursor = ev["id"]
+                yield _format_sse(ev)
+                if ev.get("event") in _TERMINAL_EVENTS:
+                    return
+
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            elapsed += _POLL_INTERVAL_SECONDS
+
+        # Heartbeat-timeout exit — client can reconnect with Last-Event-ID.
+        yield ": stream timeout\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+def _format_sse(ev: dict) -> str:
+    """Encode one event log entry as an SSE frame."""
+    event_id = ev["id"]
+    event_name = ev.get("event", "message")
+    data = ev.get("data", {})
+    return (
+        f"id: {event_id}\n"
+        f"event: {event_name}\n"
+        f"data: {json.dumps(data, default=str)}\n\n"
+    )
+
+
+@generate_router.post("/jobs/{job_id}/cancel")
+async def cancel_job(job_id: str) -> dict[str, str]:
+    """Mark a job cancelled. Idempotent.
+
+    The background task itself can't currently be hard-cancelled — best-effort
+    only: the next event the pipeline tries to emit will be the ``error``
+    cancellation event (since the status flips to ``cancelled``).
+    """
+    store = get_job_store()
+    job = await store.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+    if job["status"] in ("done", "error", "cancelled"):
+        return {"job_id": job_id, "status": job["status"]}
+    await store.update_status(job_id, "cancelled", error="cancelled by user")
+    await store.push_event(job_id, {
+        "event": "error",
+        "data": {"job_id": job_id, "message": "cancelled by user",
+                 "recoverable": False, "code": "CANCELLED"},
+    })
+    return {"job_id": job_id, "status": "cancelled"}
+
+
+@generate_router.get("/jobs", response_model=JobsListResponse)
+async def list_jobs(limit: int = 20) -> JobsListResponse:
+    """Recent jobs for the GenerationStatus UI."""
+    store = get_job_store()
+    raw = await store.list_recent_jobs(limit=max(1, min(limit, 100)))
+    summaries: list[JobSummary] = []
+    for j in raw:
+        if j.get("type") != "generate":
+            continue
+        payload = j.get("payload") or {}
+        brief = payload.get("brief") or {}
+        result = j.get("result") or {}
+        summaries.append(JobSummary(
+            job_id=j["id"],
+            state=_normalize_state(j.get("status") or "queued"),
+            brief_intent=brief.get("intent", ""),
+            created_at=j.get("created_at", ""),
+            updated_at=j.get("updated_at", ""),
+            n_candidates=int(payload.get("n_candidates") or 1),
+            best_strategy_id=result.get("best_strategy_id"),
+        ))
+    return JobsListResponse(jobs=summaries)
+
+
+def _normalize_state(s: str) -> str:
+    if s in ("queued", "running", "done", "error", "cancelled"):
+        return s
+    return "queued"
+
+
+@generate_router.get("/jobs/{job_id}/candidates", response_model=CandidatesListResponse)
+async def list_candidates(job_id: str) -> CandidatesListResponse:
+    """Rejected-candidate viewer. Empty list until ``done``."""
+    store = get_job_store()
+    job = await store.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+    result = job.get("result") or {}
+    cands = result.get("candidates", []) or []
+    return CandidatesListResponse(
+        job_id=job_id,
+        best_candidate_id=result.get("best_candidate_id"),
+        candidates=[CandidateSummary(**c) for c in cands],
+    )

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -42,6 +42,16 @@ _TERMINAL_EVENTS = {"done", "error"}
 _POLL_INTERVAL_SECONDS = 0.4
 _STREAM_TIMEOUT_SECONDS = 300  # cap a single SSE connection at 5 min
 
+# Live registry of in-flight asyncio tasks per job. Lets cancel_job actually
+# stop the work — without this, /cancel only flips Redis status while the
+# agent keeps burning LLM tokens to completion.
+_RUNNING_TASKS: dict[str, asyncio.Task] = {}
+
+
+def _register_task(job_id: str, task: asyncio.Task) -> None:
+    _RUNNING_TASKS[job_id] = task
+    task.add_done_callback(lambda _t, jid=job_id: _RUNNING_TASKS.pop(jid, None))
+
 
 @generate_router.post("/start", response_model=GenerateStartResponse, status_code=202)
 async def start_generation(req: GenerateStartRequest) -> GenerateStartResponse:
@@ -54,7 +64,8 @@ async def start_generation(req: GenerateStartRequest) -> GenerateStartResponse:
 
     # Fire-and-forget the pipeline. The route doesn't await it; the SSE stream
     # below tails the event log written by the pipeline as it runs.
-    asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates))
+    task = asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates))
+    _register_task(job_id, task)
 
     return GenerateStartResponse(
         job_id=job_id,
@@ -140,11 +151,17 @@ def _format_sse(ev: dict) -> str:
 
 @generate_router.post("/jobs/{job_id}/cancel")
 async def cancel_job(job_id: str) -> dict[str, str]:
-    """Mark a job cancelled. Idempotent.
+    """Cancel a running job. Idempotent.
 
-    The background task itself can't currently be hard-cancelled — best-effort
-    only: the next event the pipeline tries to emit will be the ``error``
-    cancellation event (since the status flips to ``cancelled``).
+    Hard cancellation: looks up the asyncio.Task driving the job and calls
+    ``task.cancel()`` on it. The pipeline's ``except CancelledError`` branch
+    emits the synthetic error event + flips Redis status to ``cancelled``.
+
+    Caveat: if the agent is mid-``asyncio.to_thread(llm_call)``, the OS
+    thread itself isn't cancellable (Python doesn't expose that). The
+    awaiter unblocks immediately, the in-flight LLM call burns to
+    completion but its result is discarded — no events emitted after the
+    cancellation, no strategy persisted.
     """
     store = get_job_store()
     job = await store.get(job_id)
@@ -152,12 +169,24 @@ async def cancel_job(job_id: str) -> dict[str, str]:
         raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
     if job["status"] in ("done", "error", "cancelled"):
         return {"job_id": job_id, "status": job["status"]}
+
+    # Flip status first so observers see "cancelled" even if the cancel
+    # callback hasn't fully propagated yet.
     await store.update_status(job_id, "cancelled", error="cancelled by user")
     await store.push_event(job_id, {
         "event": "error",
         "data": {"job_id": job_id, "message": "cancelled by user",
                  "recoverable": False, "code": "CANCELLED"},
     })
+
+    # Hard-cancel the task itself if we're still holding a reference.
+    task = _RUNNING_TASKS.get(job_id)
+    if task is not None and not task.done():
+        task.cancel()
+        logger.info("hard-cancelled job %s", job_id)
+    else:
+        logger.info("cancel for %s: no live task (already finished or restart)", job_id)
+
     return {"job_id": job_id, "status": "cancelled"}
 
 

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -1,0 +1,111 @@
+"""Pydantic models for the streaming Generate pipeline.
+
+Implements the event protocol in docs/specs/generation-streaming-spec.md.
+Each event is shipped as a single SSE `data:` payload — these models exist
+so route handlers, the pipeline orchestrator, and the test suite all share
+one definition of what an event looks like on the wire.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+# ── Request side ──────────────────────────────────────────────────────────
+
+
+class GenerateBrief(BaseModel):
+    """User-supplied generation brief."""
+
+    intent: str = Field(..., description="Free-text strategy request")
+    risk_appetite: Literal["fixed_income", "conservative", "moderate", "aggressive", "hyper_risky"] = "moderate"
+    asset_classes: list[str] | None = None
+    capital_usdc: float | None = None
+    max_papers: int = Field(default=5, ge=1, le=20)
+
+
+class GenerateStartRequest(BaseModel):
+    brief: GenerateBrief
+    n_candidates: int = Field(default=1, ge=1, le=5, description="How many candidates to consider internally")
+
+
+class GenerateStartResponse(BaseModel):
+    job_id: str
+    stream_url: str
+    ttl_seconds: int
+
+
+# ── Event payloads ────────────────────────────────────────────────────────
+
+
+EventName = Literal[
+    "job_queued",
+    "brief_validated",
+    "candidates_selected",
+    "agent_iteration",
+    "tool_called",
+    "tool_result",
+    "candidate_drafted",
+    "candidate_evaluated",
+    "best_selected",
+    "trace_hashed",
+    "persisted",
+    "done",
+    "error",
+]
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class GenerateEvent(BaseModel):
+    """Generic envelope for any event shipped on the SSE stream.
+
+    `event` is the SSE event name; `data` is the JSON payload that the
+    frontend's `addEventListener(event, …)` callback receives.
+    """
+
+    id: int
+    event: EventName
+    data: dict[str, Any]
+
+    @classmethod
+    def make(cls, *, event_id: int, event: EventName, **payload: Any) -> "GenerateEvent":
+        payload.setdefault("ts", _ts())
+        return cls(id=event_id, event=event, data=payload)
+
+
+# ── Job listing + candidates list ─────────────────────────────────────────
+
+
+class JobSummary(BaseModel):
+    job_id: str
+    state: Literal["queued", "running", "done", "error", "cancelled"]
+    brief_intent: str
+    created_at: str
+    updated_at: str
+    n_candidates: int
+    best_strategy_id: str | None = None
+
+
+class JobsListResponse(BaseModel):
+    jobs: list[JobSummary]
+
+
+class CandidateSummary(BaseModel):
+    candidate_id: str
+    strategy_id: str | None
+    strategy_name: str
+    rigor_verdict: dict[str, Any] | None = None
+    passes_rigor: bool
+    selected: bool
+
+
+class CandidatesListResponse(BaseModel):
+    job_id: str
+    best_candidate_id: str | None
+    candidates: list[CandidateSummary]

--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -7,6 +7,7 @@ import json
 from fastapi import APIRouter, Query
 
 from archimedes.db import get_session
+from archimedes.services.corpus_categories import label_for as _category_label
 
 papers_router = APIRouter(prefix="/api/papers", tags=["papers"])
 
@@ -45,6 +46,7 @@ async def list_papers(
                 "arxiv_id": r.arxiv_id,
                 "title": r.title,
                 "primary_category": r.primary_category,
+                "category_label": _category_label(r.primary_category),
                 "categories": json.loads(r.categories) if r.categories else [],
                 "published": r.published,
                 "abstract": r.abstract[:200] + "..." if len(r.abstract) > 200 else r.abstract,
@@ -60,6 +62,7 @@ async def list_papers(
                 "arxiv_id": p.arxiv_id,
                 "title": p.title,
                 "primary_category": p.primary_category,
+                "category_label": _category_label(p.primary_category),
                 "categories": list(p.categories),
                 "published": p.published,
                 "abstract": p.abstract[:200] + "..." if len(p.abstract) > 200 else p.abstract,
@@ -100,6 +103,7 @@ async def get_paper(arxiv_id: str):
             "title": record.title,
             "authors": json.loads(record.authors) if record.authors else [],
             "primary_category": record.primary_category,
+            "category_label": _category_label(record.primary_category),
             "categories": json.loads(record.categories) if record.categories else [],
             "published": record.published,
             "abstract": record.abstract,
@@ -129,6 +133,7 @@ async def get_paper(arxiv_id: str):
         "arxiv_id": paper.arxiv_id,
         "title": paper.title,
         "primary_category": paper.primary_category,
+        "category_label": _category_label(paper.primary_category),
         "categories": list(paper.categories),
         "published": paper.published,
         "abstract": paper.abstract,
@@ -175,7 +180,10 @@ async def get_corpus_overview():
             return {
                 "total_papers": total,
                 "source": "database",
-                "categories": [{"name": cat, "count": cnt} for cat, cnt in category_counts.most_common(20)],
+                "categories": [
+                    {"name": cat, "label": _category_label(cat), "count": cnt}
+                    for cat, cnt in category_counts.most_common(20)
+                ],
                 "year_distribution": [{"year": yr, "count": cnt} for yr, cnt in year_dist],
             }
 
@@ -199,7 +207,10 @@ async def get_corpus_overview():
     return {
         "total_papers": len(corpus),
         "source": "file",
-        "categories": [{"name": cat, "count": cnt} for cat, cnt in top_categories],
+        "categories": [
+            {"name": cat, "label": _category_label(cat), "count": cnt}
+            for cat, cnt in top_categories
+        ],
         "year_distribution": [{"year": yr, "count": cnt} for yr, cnt in year_dist],
     }
 

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -44,6 +44,11 @@ def init_db() -> None:
     where the papers table predates these model additions (i.e. our running
     docker volume).
     """
+    # Side-effect imports: ensure all ORM models register their tables with
+    # Base.metadata before create_all runs. Otherwise the kg_* tables only
+    # appear if some other code path imports archimedes.models.kg first.
+    from archimedes.models import kg  # noqa: F401
+
     Base.metadata.create_all(bind=engine)
     logger.info(f"Database tables created at {DATABASE_URL}")
 

--- a/backend/archimedes/interfaces/agent.py
+++ b/backend/archimedes/interfaces/agent.py
@@ -1,9 +1,12 @@
-"""Agent orchestrator interface — Chuan implements this.
+"""Agent orchestrator interface.
 
 This is the brain of the system. It polls on a schedule, reads market state,
-runs Önder's math, decides whether to act, and dispatches to Marten's executor.
+runs the math primitives, decides whether to act, and dispatches to the chain
+executor. All other interfaces plug into this one.
 
-All other interfaces plug into this one.
+Reviewer: Chuan (architecture + on-chain).
+Coverage: full team — per CLAUDE.md § "Lead + coverage", lanes are guidance
+for review, not gates for who may author.
 """
 
 from __future__ import annotations
@@ -18,14 +21,14 @@ from archimedes.models.trace import ReasoningTrace
 class IAgentOrchestrator(Protocol):
     """The autonomous portfolio agent — the main polling loop.
 
-    Owner: Chuan
+    Reviewer: Chuan.
     Dependencies:
-      - IRegimeDetector (Önder)
-      - IPortfolioConstructor (Önder)
-      - IStrategyProvider (Dan)
-      - IOracleUpdater (Marten)
-      - IChainExecutor (Marten)
-      - ITracePublisher (Marten)
+      - IRegimeDetector
+      - IPortfolioConstructor
+      - IStrategyProvider
+      - IOracleUpdater
+      - IChainExecutor
+      - ITracePublisher
 
     Design reference: design.md § 4.3
     """
@@ -35,25 +38,25 @@ class IAgentOrchestrator(Protocol):
 
         The full pipeline per tick:
 
-          1. Marten's IOracleUpdater.fetch_market_snapshot()
-          2. Marten's IOracleUpdater.push_prices_on_chain()
-          3. Önder's IRegimeDetector.classify(snapshot)
+          1. IOracleUpdater.fetch_market_snapshot()
+          2. IOracleUpdater.push_prices_on_chain()
+          3. IRegimeDetector.classify(snapshot)
           4. For each managed vault:
-             a. Marten's IChainExecutor.read_portfolio(vault)
+             a. IChainExecutor.read_portfolio(vault)
              b. Check rebalance triggers:
                 - Drift > 5% from target
                 - Regime changed
                 - Strategy rolling 30d Sharpe < 0.5 for 7 days
                 - Calendar (weekly)
              c. If triggered:
-                - Dan's IStrategyProvider.list_strategies()
-                - Önder's IPortfolioConstructor.construct(...)
+                - IStrategyProvider.list_strategies()
+                - IPortfolioConstructor.construct(...)
                 - Compute trades = diff(current, target)
                 - Cost-benefit: only rebalance if benefit > 2 * cost
              d. If rebalancing:
-                - Marten's IChainExecutor.execute_trades(vault, trades)
+                - IChainExecutor.execute_trades(vault, trades)
                 - Generate ReasoningTrace
-                - Marten's ITracePublisher.publish(trace)
+                - ITracePublisher.publish(trace)
              e. If skipping:
                 - Generate skip trace (DecisionType.SKIP)
                 - Optionally publish skip trace

--- a/backend/archimedes/interfaces/chain.py
+++ b/backend/archimedes/interfaces/chain.py
@@ -1,8 +1,11 @@
-"""On-chain backend interfaces — Marten implements these.
+"""On-chain backend interfaces.
 
 These wrap all interactions with Arc contracts and Circle SDK.
-The agent orchestrator calls these; Marten implements the actual
-web3 calls, Circle API calls, and transaction management.
+The agent orchestrator calls these.
+
+Reviewer: Chuan (on-chain integration layer — `chain/` subpackage).
+Coverage: Marten — per CLAUDE.md § "Lead + coverage", lanes are guidance
+for review, not gates for who may author.
 """
 
 from __future__ import annotations
@@ -17,7 +20,7 @@ from archimedes.models.trace import ReasoningTrace
 class IOracleUpdater(Protocol):
     """Fetches real-world prices and pushes them to the on-chain PriceOracle.
 
-    Owner: Marten
+    Reviewer: Chuan (on-chain integration); coverage: Marten.
     Runs on a polling loop (every ~60 seconds for hackathon).
 
     Design reference: ecosystem-design-spec.md § 3.6
@@ -55,7 +58,7 @@ class IOracleUpdater(Protocol):
           - BTC dominance
           - USYC yield
 
-        This is the input to Önder's regime detector.
+        This is the input to IRegimeDetector.
         """
         ...
 
@@ -63,7 +66,7 @@ class IOracleUpdater(Protocol):
 class IChainExecutor(Protocol):
     """Executes on-chain transactions for the agent.
 
-    Owner: Marten
+    Reviewer: Chuan (on-chain integration); coverage: Marten.
     Handles Circle SDK wallet management, transaction signing,
     and confirmation tracking.
 
@@ -122,7 +125,7 @@ class IChainExecutor(Protocol):
 class ITracePublisher(Protocol):
     """Publishes reasoning trace hashes to the on-chain ReasoningTraceRegistry.
 
-    Owner: Marten
+    Reviewer: Chuan (on-chain integration); coverage: Marten.
     Called by the agent orchestrator after every decision.
 
     Design reference: design.md § 4.4, ecosystem-design-spec.md § 3.4

--- a/backend/archimedes/interfaces/math.py
+++ b/backend/archimedes/interfaces/math.py
@@ -1,8 +1,12 @@
-"""Math interfaces — Önder implements these.
+"""Math interfaces.
 
 These are pure computation modules with NO web framework, NO database,
 and NO on-chain dependencies. They take typed inputs and return typed outputs.
-Chuan's backend orchestrator calls them.
+The backend orchestrator calls them.
+
+Reviewer: Önder (portfolio math + risk pricing); coverage: Dan.
+Per CLAUDE.md § "Lead + coverage", lanes are guidance for review, not gates
+for who may author.
 """
 
 from __future__ import annotations
@@ -23,7 +27,7 @@ from archimedes.models.strategy import Strategy
 class IRegimeDetector(Protocol):
     """Classifies the current market regime from a snapshot.
 
-    Owner: Önder
+    Reviewer: Önder; coverage: Dan.
     Input: MarketSnapshot (prices + VIX + MA + credit spreads)
     Output: RegimeClassification (regime + confidence + signals)
 
@@ -51,7 +55,7 @@ class IRegimeDetector(Protocol):
 class IPortfolioConstructor(Protocol):
     """Constructs a target portfolio from strategies + regime + risk profile.
 
-    Owner: Önder
+    Reviewer: Önder; coverage: Dan.
     Input: risk profile, available strategies with backtest results, current regime
     Output: list of TargetAllocation (symbol + weight)
 
@@ -99,7 +103,7 @@ class IPortfolioConstructor(Protocol):
 class IBacktestEvaluator(Protocol):
     """Evaluates a strategy against historical data.
 
-    Owner: Önder
+    Reviewer: Önder; coverage: Dan.
     Input: Strategy definition + historical price data
     Output: BacktestResult with all standard metrics
 

--- a/backend/archimedes/interfaces/strategy.py
+++ b/backend/archimedes/interfaces/strategy.py
@@ -1,9 +1,13 @@
-"""Strategy provider interface — Dan implements this.
+"""Strategy provider interface.
 
-Dan curates the v1 strategy library (5-10 hand-curated strategies)
-and builds the arxiv extraction pipeline as a demo feature.
+Curates the v1 strategy library (5-10 hand-curated strategies)
+and the arxiv extraction pipeline as a demo feature.
 This interface abstracts both: the backend doesn't care whether a
 strategy was hand-curated or LLM-extracted.
+
+Reviewer: Dan (strategy engine + corpus curation); coverage: Önder.
+Per CLAUDE.md § "Lead + coverage", lanes are guidance for review, not gates
+for who may author.
 """
 
 from __future__ import annotations
@@ -16,8 +20,8 @@ from archimedes.models.strategy import Strategy, StrategyStatus
 class IStrategyProvider(Protocol):
     """Provides strategies to the portfolio agent.
 
-    Owner: Dan
-    Consumers: Chuan (agent orchestrator), Önder (backtest evaluator)
+    Reviewer: Dan; coverage: Önder.
+    Consumers: agent orchestrator, backtest evaluator.
 
     Design reference: design.md § 4.1
     """

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -25,6 +25,8 @@ from archimedes.api.routes import (
     papers_router,
 )
 from archimedes.api.chat_routes import chat_router
+from archimedes.api.corpus_routes import corpus_router
+from archimedes.api.explore_routes import explore_router
 from archimedes.api.generate_routes import generate_router
 from archimedes.api.marketplace_routes import marketplace_router
 from archimedes.api.risk_routes import risk_router
@@ -123,6 +125,8 @@ app.include_router(swap_router)
 app.include_router(config_router)
 app.include_router(agent_router)
 app.include_router(chat_router)
+app.include_router(corpus_router)
+app.include_router(explore_router)
 app.include_router(generate_router)
 app.include_router(marketplace_router)
 app.include_router(risk_router)

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -25,6 +25,7 @@ from archimedes.api.routes import (
     papers_router,
 )
 from archimedes.api.chat_routes import chat_router
+from archimedes.api.generate_routes import generate_router
 from archimedes.api.marketplace_routes import marketplace_router
 from archimedes.api.risk_routes import risk_router
 from archimedes.api.selection_bias_routes import selection_bias_router
@@ -122,6 +123,7 @@ app.include_router(swap_router)
 app.include_router(config_router)
 app.include_router(agent_router)
 app.include_router(chat_router)
+app.include_router(generate_router)
 app.include_router(marketplace_router)
 app.include_router(risk_router)
 app.include_router(selection_bias_router)

--- a/backend/archimedes/models/kg.py
+++ b/backend/archimedes/models/kg.py
@@ -1,0 +1,52 @@
+"""Knowledge Graph ORM models.
+
+Backing store for the SPECTER2 + REBEL/SciSpacy pipeline output that
+`scripts/run_kb_pipeline.py` writes once the KB integration is live.
+
+Per docs/specs/kb-integration-spec.md: heavy binaries (embeddings,
+KG_triples.jsonl) live on the named volume; these tables hold the
+DB-only fast paths.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column, DateTime, ForeignKey, Integer, REAL, String, UniqueConstraint,
+)
+
+from archimedes.models.chat import Base
+
+
+class KGEntity(Base):
+    __tablename__ = "kg_entities"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    canonical_name = Column(String, nullable=False, index=True)
+    entity_type = Column(String, nullable=False)
+    paper_count = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint("canonical_name", "entity_type", name="uq_kg_entity"),
+    )
+
+
+class KGRelation(Base):
+    __tablename__ = "kg_relations"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    subject_id = Column(Integer, ForeignKey("kg_entities.id"), index=True)
+    relation = Column(String, nullable=False)
+    object_id = Column(Integer, ForeignKey("kg_entities.id"))
+    paper_arxiv_id = Column(String, ForeignKey("papers.arxiv_id", ondelete="CASCADE"), index=True)
+    confidence = Column(REAL)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint(
+            "subject_id", "relation", "object_id", "paper_arxiv_id",
+            name="uq_kg_relation",
+        ),
+    )

--- a/backend/archimedes/scripts/run_kb_pipeline.py
+++ b/backend/archimedes/scripts/run_kb_pipeline.py
@@ -1,0 +1,115 @@
+"""Operator-triggered KnowledgeBase pipeline runner.
+
+Wraps the existing ``submodules/KnowledgeBase/papers_analysis/`` pipeline
+(SPECTER2 embeddings + HDBSCAN/BERTopic clustering + REBEL/SciSpacy KG)
+and writes outputs to:
+
+  /srv/corpus-artifact/embeddings.npy + ids.json
+  /srv/corpus-artifact/clusters.json
+  /srv/corpus-artifact/topics.json
+  /srv/corpus-artifact/kg_triples.jsonl
+  /srv/corpus-artifact/kg_graph.json
+  /srv/corpus-artifact/manifest.json
+  Postgres papers.cluster_id + topic_label (denormalized)
+  Postgres kg_entities + kg_relations
+
+Per docs/specs/kb-integration-spec.md:
+  - No re-implementation: invokes the submodule's existing code.
+  - Atomic-swap: writes to a tmpdir, then symlinks on success.
+
+This skeleton wires the entry point and persistence schema; the actual
+pipeline invocation is gated behind a feature flag while the docker
+container with the SPECTER2 / REBEL / SciSpacy deps is built out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ARTIFACT_DIR = Path(os.getenv("KB_ARTIFACT_DIR", "/srv/corpus-artifact"))
+DEFAULT_CORPUS_DIR = Path(os.getenv("KB_CORPUS_DIR", "/srv/corpus-text"))
+
+
+def _kb_submodule_path() -> Path:
+    """Locate submodules/KnowledgeBase/ relative to this file."""
+    here = Path(__file__).resolve()
+    # backend/archimedes/scripts/run_kb_pipeline.py → repo root → submodules/KB/
+    return here.parents[3] / "submodules" / "KnowledgeBase"
+
+
+def run_pipeline(*, corpus_dir: Path | None = None, artifact_dir: Path | None = None) -> dict:
+    """Run the full KB pipeline. Returns a manifest dict.
+
+    The actual model-call code is gated behind ``KB_PIPELINE_ENABLED`` until
+    the dedicated container with SPECTER2/REBEL/SciSpacy weights is built
+    out. Without the flag we still write an empty manifest so the runner's
+    "have we ever run?" check has a stable target.
+    """
+    corpus_dir = corpus_dir or DEFAULT_CORPUS_DIR
+    artifact_dir = artifact_dir or DEFAULT_ARTIFACT_DIR
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    started = time.time()
+    started_iso = datetime.now(timezone.utc).isoformat()
+    logger.info("kb_pipeline: starting (corpus=%s, artifact=%s)", corpus_dir, artifact_dir)
+
+    if not os.getenv("KB_PIPELINE_ENABLED"):
+        manifest = {
+            "run_ts": started_iso,
+            "duration_s": 0.0,
+            "paper_count": 0,
+            "cluster_count": 0,
+            "kg_node_count": 0,
+            "kg_edge_count": 0,
+            "status": "skipped — set KB_PIPELINE_ENABLED=1 to invoke the full pipeline",
+        }
+        (artifact_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+        logger.info("kb_pipeline: skipped (KB_PIPELINE_ENABLED not set)")
+        return manifest
+
+    # Real pipeline path — gated by feature flag. Invocation pattern lives in
+    # kb-integration-spec.md § "Pipeline invocation". Adding to sys.path so
+    # the submodule's `papers_analysis` package is importable.
+    kb_root = _kb_submodule_path()
+    if str(kb_root) not in sys.path:
+        sys.path.insert(0, str(kb_root))
+
+    # The actual functions live in:
+    #   papers_analysis.vectorize.embed_corpus(text_dir) → (np.ndarray, ids)
+    #   papers_analysis.cluster.cluster_embeddings(...) → dict[id, cluster]
+    #   papers_analysis.cluster.bertopic_labels(...)     → dict[cluster, label]
+    #   papers_analysis.knowledge_graph.extract_triples(text_dir) → list
+    #   papers_analysis.graph.aggregate(triples) → {nodes, edges}
+    #
+    # See spec for the canonical wiring. Left as TODO under flag because the
+    # full implementation pulls in ~6 GB of model weights and only runs
+    # meaningfully inside the dedicated docker service.
+    raise NotImplementedError(
+        "KB_PIPELINE_ENABLED set, but the full pipeline invocation is not yet wired. "
+        "See docs/specs/kb-integration-spec.md § Pipeline invocation for the canonical shape. "
+        "Until the dedicated docker container with SPECTER2/REBEL/SciSpacy weights ships, "
+        "leave KB_PIPELINE_ENABLED unset and rely on the skip path."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS_DIR)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT_DIR)
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+    manifest = run_pipeline(corpus_dir=args.corpus, artifact_dir=args.artifact)
+    print(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -1,0 +1,195 @@
+"""Composes oracle + history data into the /api/explore/assets response.
+
+Wraps the existing yfinance-backed history fetch in a 30-second TTL cache
+(per the Phase 3a spec — page must load <1s without synchronous on-chain
+reads). The plain-English explanations live in this module so the route
+handler stays a thin facade.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from archimedes.api.explore_schemas import (
+    AssetExploreItem,
+    ExploreAssetsResponse,
+    ExploreHistoryPoint,
+    ExploreHistoryResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_CACHE_TTL_SECONDS = 30
+_HISTORY_LOOKBACK = "3mo"  # enough for 30d realized vol + change windows
+_STALE_WINDOW_SECONDS = 24 * 3600  # >24h since last bar → "stale"
+
+
+# ── Plain-English explanations ────────────────────────────────────────────
+
+
+_EXPLANATIONS_TEMPLATES = {
+    "current_price": "Latest price the on-chain oracle quoted. Settlement on Arc uses this.",
+    "change_24h_pct": (
+        "Percentage move in the last trading day. Positive = up. "
+        "Daily moves bigger than {vol_daily_pct:.1f}% are unusual for this asset."
+    ),
+    "change_7d_pct": "Percentage move over the past week (5 trading days).",
+    "change_30d_pct": "Percentage move over the past month (≈21 trading days).",
+    "realized_vol_30d": (
+        "How much the price wobbles. Higher = bigger swings. {vol:.2f} annualized "
+        "means daily moves of ~{vol_daily_pct:.1f}% are typical."
+    ),
+}
+
+
+def _explanations_for(item: dict[str, Any]) -> dict[str, str]:
+    vol = item.get("realized_vol_30d") or 0.0
+    vol_daily_pct = (vol / math.sqrt(252)) * 100.0 if vol else 0.0
+    fields = {}
+    for key, template in _EXPLANATIONS_TEMPLATES.items():
+        if item.get(key) is None:
+            continue
+        try:
+            fields[key] = template.format(vol=vol, vol_daily_pct=vol_daily_pct)
+        except (KeyError, IndexError):
+            fields[key] = template
+    return fields
+
+
+# ── Stat math ─────────────────────────────────────────────────────────────
+
+
+def _pct_change(prices: list[float], n: int) -> float | None:
+    """Pct change between prices[-1] and prices[-1-n]. None if not enough data."""
+    if not prices or len(prices) < n + 1:
+        return None
+    end, start = prices[-1], prices[-1 - n]
+    if not start:
+        return None
+    return (end - start) / start * 100.0
+
+
+def _realized_vol_annual(prices: list[float], window: int = 30) -> float | None:
+    """Annualized realized vol over the most recent ``window`` trading days."""
+    if not prices or len(prices) < window + 1:
+        return None
+    tail = prices[-(window + 1):]
+    rets = []
+    for i in range(1, len(tail)):
+        prev = tail[i - 1]
+        if not prev:
+            continue
+        rets.append((tail[i] - prev) / prev)
+    if len(rets) < 2:
+        return None
+    mean = sum(rets) / len(rets)
+    var = sum((r - mean) ** 2 for r in rets) / (len(rets) - 1)
+    return math.sqrt(var) * math.sqrt(252)
+
+
+# ── Service ───────────────────────────────────────────────────────────────
+
+
+class AssetMarketService:
+    """Composes per-synth market stats from histories. 30s TTL cache."""
+
+    def __init__(self) -> None:
+        self._cache: ExploreAssetsResponse | None = None
+        self._cache_ts: float = 0.0
+        self._cache_history: dict[str, ExploreHistoryResponse] = {}
+
+    async def list_assets(self) -> ExploreAssetsResponse:
+        now = time.time()
+        if self._cache and (now - self._cache_ts) < _CACHE_TTL_SECONDS:
+            return self._cache
+
+        # Fetch in a thread — yfinance is blocking and slow.
+        try:
+            from archimedes.services.strategy_signal_evaluator import (
+                DEFAULT_SCAN_UNIVERSE, GLOBAL_ASSETS, _fetch_price_histories,
+            )
+            histories = await asyncio.wait_for(
+                asyncio.to_thread(_fetch_price_histories, DEFAULT_SCAN_UNIVERSE, _HISTORY_LOOKBACK),
+                timeout=20.0,
+            )
+        except Exception as exc:
+            logger.warning("explore: history fetch failed: %s", exc)
+            histories = {}
+
+        try:
+            from archimedes.chain.client import chain_client
+            oracle_addrs = chain_client.settings.oracle_addresses or {}
+            synth_addrs = chain_client.settings.synth_addresses or {}
+        except Exception:
+            oracle_addrs, synth_addrs = {}, {}
+
+        items: list[AssetExploreItem] = []
+        nowstamp = datetime.now(timezone.utc).isoformat()
+        for synth, hist in histories.items():
+            prices = hist.get("close") if isinstance(hist, dict) else None
+            if not prices:
+                continue
+            current = prices[-1]
+            stat_dict: dict[str, Any] = {
+                "current_price": current,
+                "change_24h_pct": _pct_change(prices, 1),
+                "change_7d_pct": _pct_change(prices, 5),
+                "change_30d_pct": _pct_change(prices, 21),
+                "realized_vol_30d": _realized_vol_annual(prices, 30),
+            }
+            entry = GLOBAL_ASSETS.get(synth)
+            asset_class = entry[2] if entry else "unknown"
+            real_ticker = entry[0] if entry else synth.lstrip("s")
+            last_ts = hist.get("last_ts") if isinstance(hist, dict) else None
+            is_stale = bool(last_ts and (time.time() - float(last_ts)) > _STALE_WINDOW_SECONDS)
+            items.append(AssetExploreItem(
+                symbol=synth,
+                name=f"Synthetic {real_ticker}",
+                asset_class=asset_class,
+                oracle_address=oracle_addrs.get(synth) or synth_addrs.get(synth),
+                last_updated=nowstamp,
+                is_stale=is_stale,
+                explanations=_explanations_for(stat_dict),
+                **stat_dict,
+            ))
+
+        # Stable ordering — equities first, then crypto, then everything else.
+        items.sort(key=lambda a: (
+            0 if "equity" in a.asset_class else 1 if "crypto" in a.asset_class else 2,
+            a.symbol,
+        ))
+
+        self._cache = ExploreAssetsResponse(
+            assets=items, cache_ttl_seconds=_CACHE_TTL_SECONDS, generated_at=nowstamp,
+        )
+        self._cache_ts = now
+        return self._cache
+
+    async def get_history(self, symbol: str) -> ExploreHistoryResponse:
+        if symbol in self._cache_history:
+            return self._cache_history[symbol]
+        try:
+            from archimedes.services.strategy_signal_evaluator import _fetch_price_histories
+            histories = await asyncio.to_thread(_fetch_price_histories, [symbol], _HISTORY_LOOKBACK)
+        except Exception as exc:
+            logger.warning("explore: history for %s failed: %s", symbol, exc)
+            histories = {}
+        hist = histories.get(symbol) or {}
+        prices = hist.get("close") or []
+        dates = hist.get("dates") or []
+        points = [
+            ExploreHistoryPoint(ts=str(dates[i]) if i < len(dates) else "", price=prices[i])
+            for i in range(len(prices))
+        ]
+        resp = ExploreHistoryResponse(symbol=symbol, points=points)
+        self._cache_history[symbol] = resp
+        return resp
+
+
+asset_market_service = AssetMarketService()

--- a/backend/archimedes/services/corpus_categories.py
+++ b/backend/archimedes/services/corpus_categories.py
@@ -1,0 +1,51 @@
+"""Static map of arxiv category codes → plain-English labels.
+
+Applied at API serialization for the corpus catalog so non-finance users
+can read the page without a glossary. Per Phase 3b of the Spine+ v2 plan.
+"""
+
+from __future__ import annotations
+
+CATEGORY_LABELS: dict[str, str] = {
+    # q-fin
+    "q-fin.ST":      "Statistical Finance",
+    "q-fin.MF":      "Mathematical Finance",
+    "q-fin.CP":      "Computational Finance",
+    "q-fin.RM":      "Risk Management",
+    "q-fin.PM":      "Portfolio Management",
+    "q-fin.TR":      "Trading & Market Microstructure",
+    "q-fin.GN":      "General Finance",
+    "q-fin.PR":      "Pricing of Securities",
+    "q-fin.EC":      "Economics (within q-fin)",
+    # cs
+    "cs.LG":         "Machine Learning",
+    "cs.CL":         "Natural Language Processing",
+    "cs.CE":         "Computational Engineering / Finance",
+    "cs.AI":         "Artificial Intelligence",
+    "cs.NE":         "Neural & Evolutionary Computing",
+    # stat
+    "stat.ME":       "Statistical Methodology",
+    "stat.ML":       "Machine Learning (statistics)",
+    "stat.AP":       "Applied Statistics",
+    "stat.TH":       "Statistical Theory",
+    # math
+    "math.OC":       "Optimization & Control",
+    "math.PR":       "Probability",
+    "math.ST":       "Mathematical Statistics",
+    # econ
+    "econ.GN":       "General Economics",
+    "econ.EM":       "Econometrics",
+    "econ.TH":       "Economic Theory",
+    # physics adjacents
+    "physics.soc-ph": "Social Physics (econophysics)",
+    "physics.data-an": "Data Analysis & Statistics (physics)",
+    # quant-ph
+    "quant-ph":      "Quantum Methods",
+}
+
+
+def label_for(code: str | None) -> str | None:
+    """Return the plain-English label for an arxiv code, or None if unknown."""
+    if not code:
+        return None
+    return CATEGORY_LABELS.get(code)

--- a/backend/archimedes/services/generation_pipeline.py
+++ b/backend/archimedes/services/generation_pipeline.py
@@ -1,0 +1,402 @@
+"""Streaming strategy generation orchestrator.
+
+Wraps ``portfolio_agent.PortfolioAgent.propose_portfolio_with_tools`` with an
+event-emitting pipeline that powers the Generate page's SSE stream
+(see ``docs/specs/generation-streaming-spec.md``).
+
+The pipeline lifecycle:
+
+  job_queued
+    → brief_validated
+    → candidates_selected (which existing strategies the agent will reason over)
+    → for each candidate: agent_iteration / tool_called / tool_result …
+    → candidate_drafted
+    → candidate_evaluated (rigor verdict — synthesized from agent stress-tests)
+    → best_selected
+    → trace_hashed → persisted → done
+
+Multi-candidate mechanic: ``n_candidates`` ≥ 1 (default 1). Each candidate is
+a full agent run with a different seed prompt suffix. The best by rigor is
+surfaced; the rest persist in the job's event log so the frontend can show
+them under "considered N candidates".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Awaitable
+
+from archimedes.api.generate_schemas import GenerateBrief
+from archimedes.services.job_queue import JobStore, get_job_store
+
+logger = logging.getLogger(__name__)
+
+
+# ── Mock backend for tests / no-LLM environments ──────────────────────────
+
+
+def _llm_available() -> bool:
+    """True iff the portfolio agent can actually call an LLM.
+
+    Used to decide between live-agent path and the deterministic fixture
+    path. Tests can force the fixture path via the env var.
+    """
+    if os.getenv("GENERATION_PIPELINE_FIXTURE", "").lower() in ("1", "true"):
+        return False
+    try:
+        from archimedes.services.portfolio_agent import get_portfolio_agent
+        return get_portfolio_agent().available
+    except Exception:
+        return False
+
+
+@dataclass
+class _CandidateResult:
+    """Internal candidate carrier — converted to events + persisted at the end."""
+
+    candidate_id: str
+    strategy_name: str
+    thesis: str
+    asset_universe: list[str]
+    source_papers: list[dict[str, Any]]
+    weights: dict[str, float]
+    reasoning: str
+    rigor_verdict: dict[str, Any]
+    passes_rigor: bool
+
+
+# ── Event emitter ─────────────────────────────────────────────────────────
+
+
+class _Emitter:
+    """Push events to the job's Redis event log + maintain a monotonic ID.
+
+    Decoupled from the agent loop so the pipeline can also emit synthetic
+    events (e.g. ``brief_validated``) that the agent itself doesn't know about.
+    """
+
+    def __init__(self, job_id: str, store: JobStore) -> None:
+        self.job_id = job_id
+        self.store = store
+
+    async def emit(self, event: str, **payload: Any) -> int:
+        ts = datetime.now(timezone.utc).isoformat()
+        body = {"event": event, "data": {"ts": ts, "job_id": self.job_id, **payload}}
+        return await self.store.push_event(self.job_id, body)
+
+
+# ── Fixture path (deterministic; used in tests + when LLM unavailable) ────
+
+
+async def _run_fixture_candidate(
+    *, candidate_id: str, brief: GenerateBrief, emit: _Emitter
+) -> _CandidateResult:
+    """Synthetic generation that exercises every event the live agent emits.
+
+    Useful for: tests, demo on a laptop without an API key, smoke-tests.
+    Each step has a short sleep so the SSE stream actually streams rather
+    than dumping everything at once on connect.
+    """
+    await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=1, max_iterations=3)
+    await asyncio.sleep(0.1)
+
+    await emit.emit("tool_called", candidate_id=candidate_id, tool_name="get_asset_stats",
+                    args_summary="symbols=sBTC,sSPY,sGLD")
+    await asyncio.sleep(0.1)
+    await emit.emit("tool_result", candidate_id=candidate_id, tool_name="get_asset_stats",
+                    result_summary="3-asset stats fetched; sGLD lowest vol")
+
+    await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=3)
+    await emit.emit("tool_called", candidate_id=candidate_id, tool_name="stress_test_portfolio",
+                    args_summary="scenarios=6")
+    await emit.emit("tool_result", candidate_id=candidate_id, tool_name="stress_test_portfolio",
+                    result_summary="max drawdown −12.4% (2022_inflation)")
+
+    name = f"Synthetic {brief.risk_appetite.title()} Blend"
+    weights = {"sSPY": 0.5, "sGLD": 0.3, "sBTC": 0.2}
+    return _CandidateResult(
+        candidate_id=candidate_id,
+        strategy_name=name,
+        thesis=f"Fixture-mode generation for brief: {brief.intent[:120]}",
+        asset_universe=list(weights.keys()),
+        source_papers=[],
+        weights=weights,
+        reasoning="Fixture path — no LLM call. Weights chosen by deterministic stub.",
+        rigor_verdict={
+            "dsr": 0.71, "pbo": 0.18, "oos_sharpe": 0.94,
+            "lookahead_audit_passed": True, "passing": True,
+        },
+        passes_rigor=True,
+    )
+
+
+# ── Live agent path ───────────────────────────────────────────────────────
+
+
+async def _run_live_candidate(
+    *, candidate_id: str, brief: GenerateBrief, emit: _Emitter
+) -> _CandidateResult:
+    """Drive the real ``portfolio_agent`` with per-iteration event emission.
+
+    The agent's iteration loop is sync and runs in a thread. The thread uses
+    a sync emit shim that schedules the async ``Emitter.emit`` back onto the
+    main event loop — this keeps the agent unchanged while still streaming.
+    """
+    from archimedes.services.portfolio_agent import get_portfolio_agent
+    from archimedes.services.strategy_provider import default_provider
+    from archimedes.services.strategy_signal_evaluator import (
+        DEFAULT_SCAN_UNIVERSE, _fetch_price_histories, strategy_evaluator,
+    )
+
+    loop = asyncio.get_running_loop()
+
+    def _sync_emit(event: str, **payload: Any) -> None:
+        # Bridge from the agent's sync thread into the async event log.
+        fut = asyncio.run_coroutine_threadsafe(
+            emit.emit(event, candidate_id=candidate_id, **payload), loop,
+        )
+        try:
+            fut.result(timeout=2.0)
+        except Exception:
+            pass  # event emission is best-effort
+
+    price_histories = await asyncio.wait_for(
+        asyncio.to_thread(_fetch_price_histories, DEFAULT_SCAN_UNIVERSE, "1y"),
+        timeout=30.0,
+    )
+    market_ranking = strategy_evaluator.rank_market(price_histories, lookback_days=90, top_n=20)
+    strategies = default_provider.list_strategies()
+
+    agent = get_portfolio_agent()
+    portfolio = await asyncio.wait_for(
+        asyncio.to_thread(
+            agent.propose_portfolio_with_tools,
+            "transition",  # regime; pipeline uses neutral default for v1
+            0.65,           # regime_confidence
+            brief.risk_appetite,
+            0.30,           # usdc_floor (moderate default)
+            0.70,           # synth_budget
+            market_ranking,
+            strategies,
+            set(DEFAULT_SCAN_UNIVERSE),
+            price_histories,
+        ),
+        timeout=120.0,
+    )
+
+    if portfolio is None:
+        raise RuntimeError("agent returned no portfolio")
+
+    weights = {pick.symbol: pick.weight for pick in (portfolio.picks or [])}
+    referenced = {pick.strategy_id for pick in (portfolio.picks or []) if pick.strategy_id}
+    source_papers = []
+    for sid in referenced:
+        s = next((s for s in strategies if s.id == sid), None)
+        if s and getattr(s, "paper_arxiv_id", None):
+            source_papers.append({
+                "arxiv_id": s.paper_arxiv_id,
+                "title": s.paper_title,
+            })
+
+    return _CandidateResult(
+        candidate_id=candidate_id,
+        strategy_name=f"{brief.risk_appetite.title()} Agent Blend",
+        thesis=getattr(portfolio, "reasoning_text", "") or "Agent-constructed allocation",
+        asset_universe=list(weights.keys()),
+        source_papers=source_papers,
+        weights=weights,
+        reasoning=getattr(portfolio, "reasoning_text", "") or "",
+        # Rigor for agent output is light-touch: the agent's stress-test tool is the
+        # gate. Phase 3+ wires Önder's full DSR/PBO/OOS Sharpe here.
+        rigor_verdict={
+            "dsr": None, "pbo": None, "oos_sharpe": None,
+            "lookahead_audit_passed": True, "passing": True,
+        },
+        passes_rigor=True,
+    )
+
+
+# ── Pipeline entry point ──────────────────────────────────────────────────
+
+
+async def run_generation(
+    *,
+    job_id: str,
+    brief: GenerateBrief,
+    n_candidates: int = 1,
+    store: JobStore | None = None,
+) -> None:
+    """Run the full streaming generation pipeline for one job.
+
+    Designed to be called as a fire-and-forget asyncio task from the route
+    handler. Exceptions are caught + emitted as ``error`` events so the SSE
+    client always sees a terminal state.
+    """
+    store = store or get_job_store()
+    emit = _Emitter(job_id, store)
+
+    await store.update_status(job_id, "running")
+    await emit.emit("job_queued", brief=brief.model_dump())
+
+    try:
+        await emit.emit(
+            "brief_validated",
+            asset_classes=brief.asset_classes or [],
+            risk_appetite=brief.risk_appetite,
+        )
+
+        # Decide path: live agent vs fixture
+        use_live = _llm_available()
+        runner: Callable[..., Awaitable[_CandidateResult]] = (
+            _run_live_candidate if use_live else _run_fixture_candidate
+        )
+
+        # Library is the candidate pool the agent reasons over; surface it so
+        # the UI can show "agent is considering N papers".
+        try:
+            from archimedes.services.strategy_provider import default_provider
+            lib = default_provider.list_strategies()
+            arxiv_ids = [s.paper_arxiv_id for s in lib if getattr(s, "paper_arxiv_id", None)]
+        except Exception:
+            arxiv_ids = []
+        await emit.emit(
+            "candidates_selected",
+            candidate_count=n_candidates,
+            source_arxiv_ids=arxiv_ids[: brief.max_papers],
+        )
+
+        candidates: list[_CandidateResult] = []
+        for i in range(n_candidates):
+            candidate_id = f"cand_{i + 1}"
+            try:
+                cand = await runner(candidate_id=candidate_id, brief=brief, emit=emit)
+            except Exception as exc:
+                logger.exception("candidate %s failed: %s", candidate_id, exc)
+                await emit.emit(
+                    "error",
+                    message=f"candidate {candidate_id} failed: {exc}",
+                    recoverable=(i < n_candidates - 1),
+                    code="CANDIDATE_FAILED",
+                )
+                continue
+
+            await emit.emit(
+                "candidate_drafted",
+                candidate_id=cand.candidate_id,
+                strategy_name=cand.strategy_name,
+                weights_preview=cand.weights,
+            )
+            await emit.emit(
+                "candidate_evaluated",
+                candidate_id=cand.candidate_id,
+                rigor_verdict=cand.rigor_verdict,
+            )
+            candidates.append(cand)
+
+        if not candidates:
+            await emit.emit(
+                "error", message="no candidates passed rigor", recoverable=True, code="RIGOR_FAIL",
+            )
+            await store.update_status(job_id, "error", error="no candidates passed rigor")
+            return
+
+        # Pick the best by passing-rigor first, then by a simple score.
+        passing = [c for c in candidates if c.passes_rigor] or candidates
+        best = max(
+            passing,
+            key=lambda c: c.rigor_verdict.get("dsr") or 0.0,
+        )
+        await emit.emit(
+            "best_selected",
+            best_candidate_id=best.candidate_id,
+            considered_count=len(candidates),
+        )
+
+        # Persist as a StrategyRecord and emit trace_hashed + persisted.
+        strategy_id, trace_hash = await _persist_candidate(best, brief)
+        await emit.emit("trace_hashed", trace_hash=trace_hash)
+        await emit.emit(
+            "persisted",
+            strategy_id=strategy_id,
+            redirect_url=f"/library?highlight={strategy_id}",
+        )
+
+        # Stash the full candidate list on the job for /candidates retrieval.
+        await store.update_status(
+            job_id,
+            "done",
+            result={
+                "best_candidate_id": best.candidate_id,
+                "best_strategy_id": strategy_id,
+                "candidates": [
+                    {
+                        "candidate_id": c.candidate_id,
+                        "strategy_id": strategy_id if c is best else None,
+                        "strategy_name": c.strategy_name,
+                        "rigor_verdict": c.rigor_verdict,
+                        "passes_rigor": c.passes_rigor,
+                        "selected": c is best,
+                    }
+                    for c in candidates
+                ],
+            },
+        )
+        await emit.emit("done", strategy_id=strategy_id)
+
+    except asyncio.CancelledError:
+        await emit.emit("error", message="job cancelled", recoverable=False, code="CANCELLED")
+        await store.update_status(job_id, "cancelled", error="cancelled by client")
+        raise
+    except Exception as exc:
+        logger.exception("generation pipeline crashed: %s", exc)
+        await emit.emit("error", message=str(exc), recoverable=False, code="PIPELINE_CRASH")
+        await store.update_status(job_id, "error", error=str(exc))
+
+
+async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple[str, str]:
+    """Upsert the candidate as a Strategy + return (strategy_id, trace_hash).
+
+    Trace hash is the keccak of the canonical (brief, candidate) tuple — gives
+    every generation a deterministic identifier mirrored on-chain in v1.5.
+    """
+    from web3 import Web3
+    from archimedes.db import get_session
+    from archimedes.models.strategy_store import upsert_strategy
+
+    canonical = json.dumps(
+        {
+            "brief": brief.model_dump(),
+            "candidate_id": c.candidate_id,
+            "strategy_name": c.strategy_name,
+            "weights": c.weights,
+            "rigor_verdict": c.rigor_verdict,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    trace_hash = Web3.keccak(text=canonical).hex()
+
+    def _do_persist() -> str:
+        with get_session() as session:
+            record = upsert_strategy(
+                session,
+                generation_method="portfolio_agent_streaming",
+                strategy_name=c.strategy_name,
+                thesis=c.thesis,
+                source_papers=c.source_papers,
+                asset_universe=c.asset_universe,
+                risk_profile=brief.risk_appetite,
+                rigor_verdict=c.rigor_verdict,
+                provenance_hash=trace_hash,
+                is_example=False,
+            )
+            session.commit()
+            return record.id
+
+    strategy_id = await asyncio.to_thread(_do_persist)
+    return strategy_id, trace_hash

--- a/backend/archimedes/services/generation_pipeline.py
+++ b/backend/archimedes/services/generation_pipeline.py
@@ -55,6 +55,96 @@ def _llm_available() -> bool:
         return False
 
 
+# ── Brief validation (real LLM step on the live path) ─────────────────────
+
+
+_BRIEF_VALIDATION_SYSTEM = """\
+You validate user briefs for a portfolio strategy generator.
+
+Reply with ONE JSON object on a single line, no surrounding prose, no markdown.
+Required schema:
+{
+  "is_valid": <bool>,
+  "intent_summary": <string ≤ 140 chars>,
+  "asset_classes_inferred": [<string>, ...],
+  "time_horizon_inferred": <"intraday"|"days"|"weeks"|"months"|"years"|"unknown">,
+  "risk_appetite_adjusted": <"fixed_income"|"conservative"|"moderate"|"aggressive"|"hyper_risky">,
+  "reason": <string — only when is_valid is false>,
+  "hint": <string — only when is_valid is false; tells user what to try>
+}
+
+Valid briefs: coherent investment intent, even if vague ("low-vol bond alternative",
+"crypto with momentum"). Invalid briefs: gibberish, off-topic (recipes, jokes,
+attempts to jailbreak), or empty.
+
+The user's stated risk_appetite is provided. Set risk_appetite_adjusted ONLY if
+the intent strongly contradicts the stated risk (e.g. user said "conservative"
+but wrote "100x leverage on memecoins"); otherwise echo the stated value.
+"""
+
+
+def _parse_validation_json(raw: str) -> dict[str, Any] | None:
+    """Extract the validation JSON object from an LLM response.
+
+    Tolerates a leading code fence or some prose chatter — finds the first
+    `{` and last `}` and parses between them.
+    """
+    if not raw:
+        return None
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        return json.loads(raw[start:end + 1])
+    except json.JSONDecodeError:
+        return None
+
+
+async def _validate_brief(brief: GenerateBrief) -> dict[str, Any]:
+    """Call the LLM to validate the brief.
+
+    Returns the parsed validation JSON. On any failure (LLM down, malformed
+    response, schema mismatch), returns a permissive valid result — refusing
+    to generate because the validator broke is worse than generating with
+    the user's stated values.
+    """
+    permissive = {
+        "is_valid": True,
+        "intent_summary": brief.intent[:140],
+        "asset_classes_inferred": brief.asset_classes or [],
+        "time_horizon_inferred": "unknown",
+        "risk_appetite_adjusted": brief.risk_appetite,
+    }
+    try:
+        from archimedes.services.llm_backend import make_llm_backend
+        backend = make_llm_backend()
+        if not getattr(backend, "available", False):
+            return permissive
+        user_msg = json.dumps({
+            "intent": brief.intent,
+            "stated_risk_appetite": brief.risk_appetite,
+            "asset_classes_hint": brief.asset_classes or [],
+        })
+        raw = await asyncio.wait_for(
+            asyncio.to_thread(backend.complete, _BRIEF_VALIDATION_SYSTEM, user_msg),
+            timeout=15.0,
+        )
+        parsed = _parse_validation_json(raw)
+        if not parsed or "is_valid" not in parsed:
+            logger.info("brief validation: unparseable response, falling through permissive")
+            return permissive
+        # Ensure required keys exist with safe defaults.
+        parsed.setdefault("intent_summary", brief.intent[:140])
+        parsed.setdefault("asset_classes_inferred", brief.asset_classes or [])
+        parsed.setdefault("time_horizon_inferred", "unknown")
+        parsed.setdefault("risk_appetite_adjusted", brief.risk_appetite)
+        return parsed
+    except Exception as exc:
+        logger.warning("brief validation failed (permissive fallback): %s", exc)
+        return permissive
+
+
 @dataclass
 class _CandidateResult:
     """Internal candidate carrier — converted to events + persisted at the end."""
@@ -68,6 +158,114 @@ class _CandidateResult:
     reasoning: str
     rigor_verdict: dict[str, Any]
     passes_rigor: bool
+    # Daily portfolio return series, used by the rigor gate. Populated in the
+    # live path from the agent's price_histories; the fixture path leaves it
+    # empty and supplies a hardcoded verdict.
+    return_series: list[float] = None  # type: ignore[assignment]
+
+
+# ── Rigor adapter (Önder's rigor_evaluator on agent output) ───────────────
+
+
+def _portfolio_return_series(
+    weights: dict[str, float], price_histories: dict[str, Any]
+) -> list[float]:
+    """Compute daily returns of a buy-and-hold weighted portfolio.
+
+    Sources the per-asset close series from ``price_histories`` (the same dict
+    the agent saw), aligns to the shortest series, and returns ``Σ wᵢ · rᵢ,t``
+    bar by bar. Buy-and-hold is the simplest faithful read of an agent
+    allocation that doesn't specify rebalancing logic — for v1 it's the
+    right baseline. When fusion-to-backtest lands a real DSL interpreter,
+    that path will produce a real return series under the strategy's own
+    rebalance rule.
+    """
+    closes_by_symbol: dict[str, list[float]] = {}
+    for sym, weight in weights.items():
+        if not weight:
+            continue
+        hist = price_histories.get(sym) if isinstance(price_histories, dict) else None
+        if not isinstance(hist, dict):
+            continue
+        closes = hist.get("close")
+        if closes and len(closes) > 1:
+            closes_by_symbol[sym] = list(closes)
+    if not closes_by_symbol:
+        return []
+
+    T = min(len(c) for c in closes_by_symbol.values())
+    if T < 5:
+        return []
+
+    out: list[float] = []
+    for t in range(1, T):
+        bar_ret = 0.0
+        for sym, closes in closes_by_symbol.items():
+            prev = closes[t - 1]
+            if not prev:
+                continue
+            r = (closes[t] - prev) / prev
+            bar_ret += weights.get(sym, 0.0) * r
+        out.append(bar_ret)
+    return out
+
+
+def _rigor_verdict_for(
+    return_series: list[float], num_trials: int
+) -> dict[str, Any]:
+    """Run Önder's rigor primitives on a portfolio return series.
+
+    Returns the same shape the fixture path uses so the consumer (event
+    emitter + frontend) doesn't care which path produced the verdict.
+    """
+    if not return_series or len(return_series) < 10:
+        return {
+            "dsr": None, "pbo": None, "oos_sharpe": None,
+            "lookahead_audit_passed": True, "passing": False,
+            "reason": "return series too short for rigor evaluation",
+        }
+    from archimedes.services.rigor_evaluator import (
+        compute_dsr, compute_oos_sharpe,
+    )
+    dsr, dsr_p = compute_dsr(return_series, num_trials=max(1, num_trials))
+    oos = compute_oos_sharpe(return_series)
+    # PBO is library-level (needs ≥2 candidate return series); the caller
+    # computes it once over all candidates and patches the verdict below.
+    passing = bool(
+        dsr_p is not None and dsr_p >= 0.95
+        and oos is not None and oos > 0.0
+    )
+    return {
+        "dsr": round(float(dsr), 4) if dsr is not None else None,
+        "dsr_p_value": round(float(dsr_p), 4) if dsr_p is not None else None,
+        "pbo": None,  # patched later by _patch_pbo
+        "oos_sharpe": round(float(oos), 4) if oos is not None else None,
+        "lookahead_audit_passed": True,  # agent output is buy-and-hold; no leak
+        "passing": passing,
+    }
+
+
+def _patch_pbo(candidates: list["_CandidateResult"]) -> None:
+    """Compute library-level PBO across the candidate set; patch each verdict."""
+    series_map: dict[str, list[float]] = {
+        c.candidate_id: c.return_series for c in candidates
+        if c.return_series
+    }
+    if len(series_map) < 2:
+        for c in candidates:
+            c.rigor_verdict["pbo"] = 0.0  # PBO undefined for N<2
+        return
+    from archimedes.services.rigor_evaluator import compute_pbo
+    pbo_by_id = compute_pbo(series_map)
+    for c in candidates:
+        pbo = pbo_by_id.get(c.candidate_id, 0.0)
+        c.rigor_verdict["pbo"] = round(float(pbo), 4)
+        # PBO ≥ 0.5 means the library overfits the in-sample winner; tighten
+        # `passing` to require both the per-strategy DSR test AND library-PBO
+        # under the 0.5 threshold.
+        c.rigor_verdict["passing"] = bool(
+            c.rigor_verdict.get("passing") and pbo < 0.5
+        )
 
 
 # ── Event emitter ─────────────────────────────────────────────────────────
@@ -203,6 +401,11 @@ async def _run_live_candidate(
                 "title": s.paper_title,
             })
 
+    # Real rigor verdict via Önder's compute_dsr + compute_oos_sharpe on the
+    # buy-and-hold return series of the agent's allocation. PBO is patched
+    # later (after all candidates are in) since it's a library-level metric.
+    return_series = _portfolio_return_series(weights, price_histories)
+    verdict = _rigor_verdict_for(return_series, num_trials=1)
     return _CandidateResult(
         candidate_id=candidate_id,
         strategy_name=f"{brief.risk_appetite.title()} Agent Blend",
@@ -211,13 +414,9 @@ async def _run_live_candidate(
         source_papers=source_papers,
         weights=weights,
         reasoning=getattr(portfolio, "reasoning_text", "") or "",
-        # Rigor for agent output is light-touch: the agent's stress-test tool is the
-        # gate. Phase 3+ wires Önder's full DSR/PBO/OOS Sharpe here.
-        rigor_verdict={
-            "dsr": None, "pbo": None, "oos_sharpe": None,
-            "lookahead_audit_passed": True, "passing": True,
-        },
-        passes_rigor=True,
+        rigor_verdict=verdict,
+        passes_rigor=verdict.get("passing", False),
+        return_series=return_series,
     )
 
 
@@ -244,10 +443,44 @@ async def run_generation(
     await emit.emit("job_queued", brief=brief.model_dump())
 
     try:
+        # Real LLM validation step (live path only). The fixture path skips
+        # the validator so tests stay hermetic.
+        if _llm_available():
+            validated = await _validate_brief(brief)
+        else:
+            validated = {
+                "is_valid": True,
+                "intent_summary": brief.intent[:140],
+                "asset_classes_inferred": brief.asset_classes or [],
+                "time_horizon_inferred": "unknown",
+                "risk_appetite_adjusted": brief.risk_appetite,
+            }
+
+        if not validated.get("is_valid", True):
+            # Brief failed validation — emit a recoverable error and stop.
+            # Frontend already handles `error` with recoverable=true by
+            # offering a "regenerate" CTA with the reason inline.
+            await emit.emit(
+                "error",
+                message=validated.get("reason", "brief did not pass validation"),
+                hint=validated.get("hint", "Try mentioning an asset class or risk appetite."),
+                recoverable=True,
+                code="BRIEF_INVALID",
+            )
+            await store.update_status(job_id, "error", error="brief invalid")
+            return
+
+        # Honor any risk_appetite_adjusted from the validator (e.g. the user
+        # said "conservative" but described 100x leverage on memecoins).
+        if validated.get("risk_appetite_adjusted") and validated["risk_appetite_adjusted"] != brief.risk_appetite:
+            brief = brief.model_copy(update={"risk_appetite": validated["risk_appetite_adjusted"]})
+
         await emit.emit(
             "brief_validated",
-            asset_classes=brief.asset_classes or [],
+            asset_classes=validated.get("asset_classes_inferred", []),
             risk_appetite=brief.risk_appetite,
+            intent_summary=validated.get("intent_summary", ""),
+            time_horizon_inferred=validated.get("time_horizon_inferred", "unknown"),
         )
 
         # Decide path: live agent vs fixture
@@ -304,6 +537,14 @@ async def run_generation(
             )
             await store.update_status(job_id, "error", error="no candidates passed rigor")
             return
+
+        # Patch PBO across the candidate set (library-level metric — Bailey
+        # et al. CSCV needs N≥2 to be meaningful; the helper handles N<2
+        # gracefully by setting PBO=0.0). After this, every candidate's
+        # rigor_verdict has all four fields (DSR, PBO, OOS Sharpe, lookahead).
+        _patch_pbo(candidates)
+        for c in candidates:
+            c.passes_rigor = c.rigor_verdict.get("passing", False)
 
         # Pick the best by passing-rigor first, then by a simple score.
         passing = [c for c in candidates if c.passes_rigor] or candidates

--- a/backend/archimedes/services/job_queue.py
+++ b/backend/archimedes/services/job_queue.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 KEY_PREFIX = "archimedes:job:"
+EVENT_LOG_SUFFIX = ":events"
 JOB_TTL = 3600  # 1 hour
+EVENT_LOG_TTL = 900  # 15 minutes after terminal state — spec 0.5 § Reconnection
 
 
 class JobStore:
@@ -101,7 +103,94 @@ class JobStore:
         await r.hset(key, mapping=updates)
         logger.info("job: %s → %s", job_id, status)
 
+    # ── Event log (for streaming jobs) ────────────────────────────────────
+
+    async def push_event(self, job_id: str, event_payload: dict[str, Any]) -> int:
+        """Append an event to the job's event log and return its monotonic ID.
+
+        Events are stored as JSON strings in a Redis list keyed
+        ``archimedes:job:{id}:events``. The returned ID is the 1-based list
+        index used as the SSE ``id:`` header — the client sends it back as
+        ``Last-Event-ID`` to resume from a known point.
+        """
+        r = await self._get_redis()
+        key = f"{KEY_PREFIX}{job_id}{EVENT_LOG_SUFFIX}"
+        new_length = await r.rpush(key, json.dumps(event_payload, default=str))
+        await r.expire(key, EVENT_LOG_TTL)
+        return new_length
+
+    async def list_events(self, job_id: str, *, after_id: int = 0) -> list[dict[str, Any]]:
+        """Return events with ID > ``after_id`` in order.
+
+        The returned dicts each have ``id`` (the monotonic event ID) plus
+        whatever keys ``push_event`` was given.
+        """
+        r = await self._get_redis()
+        key = f"{KEY_PREFIX}{job_id}{EVENT_LOG_SUFFIX}"
+        if after_id < 0:
+            after_id = 0
+        raw = await r.lrange(key, after_id, -1)
+        out: list[dict[str, Any]] = []
+        for i, blob in enumerate(raw, start=after_id + 1):
+            try:
+                payload = json.loads(blob)
+            except (TypeError, ValueError):
+                continue
+            payload["id"] = i
+            out.append(payload)
+        return out
+
+    async def event_count(self, job_id: str) -> int:
+        """Length of the event log."""
+        r = await self._get_redis()
+        key = f"{KEY_PREFIX}{job_id}{EVENT_LOG_SUFFIX}"
+        return await r.llen(key)
+
+    async def list_recent_jobs(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        """Scan recent jobs for the GenerationStatus UI.
+
+        SCAN-based; bounded by ``limit`` so the call stays cheap. Sorted by
+        ``updated_at`` desc.
+        """
+        r = await self._get_redis()
+        pattern = f"{KEY_PREFIX}*"
+        keys: list[str] = []
+        async for key in r.scan_iter(match=pattern, count=200):
+            if key.endswith(EVENT_LOG_SUFFIX):
+                continue
+            keys.append(key)
+            if len(keys) >= limit * 4:
+                break
+        jobs: list[dict[str, Any]] = []
+        for key in keys:
+            raw = await r.hgetall(key)
+            if not raw:
+                continue
+            jobs.append({
+                "id": raw.get("id", key.removeprefix(KEY_PREFIX)),
+                "type": raw.get("type", ""),
+                "status": raw.get("status", "unknown"),
+                "payload": json.loads(raw["payload"]) if raw.get("payload") else {},
+                "result": json.loads(raw["result"]) if raw.get("result") else None,
+                "error": raw.get("error", ""),
+                "created_at": raw.get("created_at", ""),
+                "updated_at": raw.get("updated_at", ""),
+            })
+        jobs.sort(key=lambda j: j.get("updated_at", ""), reverse=True)
+        return jobs[:limit]
+
     async def close(self) -> None:
         if self._redis:
             await self._redis.aclose()
             self._redis = None
+
+
+_default_store: JobStore | None = None
+
+
+def get_job_store() -> JobStore:
+    """Singleton accessor used by routes + the pipeline."""
+    global _default_store
+    if _default_store is None:
+        _default_store = JobStore()
+    return _default_store

--- a/backend/archimedes/services/kb_runner.py
+++ b/backend/archimedes/services/kb_runner.py
@@ -1,0 +1,111 @@
+"""Periodic KnowledgeBase pipeline runner.
+
+Mirrors ``chain/oracle_runner.py`` — a standalone ``python -m`` loop that
+polls corpus state and triggers ``scripts.run_kb_pipeline`` when conditions
+are met. Runs in its own docker-compose service (``kb-runner``) so the API
+container stays small.
+
+Re-run trigger:
+  (new papers since last run ≥ KB_NEW_PAPER_THRESHOLD)
+  OR (days elapsed since last run ≥ KB_MAX_DAYS_SINCE_LAST)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+INTERVAL_SECONDS = int(os.getenv("KB_RUNNER_INTERVAL_SECONDS", "21600"))  # 6 h
+NEW_PAPER_THRESHOLD = int(os.getenv("KB_NEW_PAPER_THRESHOLD", "100"))
+MAX_DAYS_SINCE_LAST = int(os.getenv("KB_MAX_DAYS_SINCE_LAST", "7"))
+ARTIFACT_DIR = Path(os.getenv("KB_ARTIFACT_DIR", "/srv/corpus-artifact"))
+
+
+def _load_manifest() -> dict | None:
+    """Read the last-run manifest from the artifact volume."""
+    manifest_path = ARTIFACT_DIR / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        return json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("kb_runner: manifest unreadable: %s", exc)
+        return None
+
+
+def _count_new_papers_since(iso_ts: str | None) -> int:
+    """Count papers ingested after a given ISO timestamp.
+
+    Soft import — if the DB isn't reachable yet (container boot ordering),
+    return 0 so the runner just waits another tick.
+    """
+    if not iso_ts:
+        return 0
+    try:
+        from sqlalchemy import func
+        from archimedes.db import get_session
+        from archimedes.models.corpus_store import PaperRecord
+        with get_session() as session:
+            return session.query(func.count(PaperRecord.arxiv_id)) \
+                .filter(PaperRecord.created_at > iso_ts) \
+                .scalar() or 0
+    except Exception as exc:
+        logger.debug("kb_runner: paper count failed: %s", exc)
+        return 0
+
+
+def needs_rerun() -> bool:
+    manifest = _load_manifest()
+    if manifest is None:
+        logger.info("kb_runner: no prior run — eligible to run")
+        return True
+
+    last_run = manifest.get("run_ts")
+    new_papers = _count_new_papers_since(last_run)
+    if new_papers >= NEW_PAPER_THRESHOLD:
+        logger.info("kb_runner: %d new papers ≥ %d threshold", new_papers, NEW_PAPER_THRESHOLD)
+        return True
+
+    if last_run:
+        try:
+            last_dt = datetime.fromisoformat(last_run)
+            days = (datetime.now(timezone.utc) - last_dt).days
+            if days >= MAX_DAYS_SINCE_LAST:
+                logger.info("kb_runner: %d days since last run ≥ %d threshold", days, MAX_DAYS_SINCE_LAST)
+                return True
+        except ValueError:
+            return True
+
+    return False
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s kb_runner %(message)s")
+    logger.info(
+        "kb_runner: starting (interval=%ds, new_paper=%d, max_days=%d, artifact=%s)",
+        INTERVAL_SECONDS, NEW_PAPER_THRESHOLD, MAX_DAYS_SINCE_LAST, ARTIFACT_DIR,
+    )
+
+    while True:
+        try:
+            if needs_rerun():
+                logger.info("kb_runner: triggering pipeline")
+                from archimedes.scripts.run_kb_pipeline import run_pipeline
+                run_pipeline()
+            else:
+                logger.info("kb_runner: needs_rerun=False, sleeping")
+        except NotImplementedError as exc:
+            logger.warning("kb_runner: pipeline not yet wired: %s", exc)
+        except Exception as exc:
+            logger.exception("kb_runner: tick failed: %s", exc)
+        time.sleep(INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -1,0 +1,102 @@
+"""Tests for the streaming Generate pipeline.
+
+Forces the fixture path (no LLM credentials needed) and asserts that the
+event sequence matches the spec ordering and that a strategy is persisted
+at the end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from archimedes.api.generate_schemas import GenerateBrief
+from archimedes.services.generation_pipeline import run_generation
+
+
+@pytest.fixture(autouse=True)
+def force_fixture_path(monkeypatch):
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+
+class _FakeStore:
+    """In-memory JobStore stand-in. Captures the event sequence."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.status: list[tuple[str, dict | None, str]] = []
+
+    async def push_event(self, job_id, payload):
+        self.events.append(payload)
+        return len(self.events)
+
+    async def update_status(self, job_id, status, *, result=None, error=""):
+        self.status.append((status, result, error))
+
+
+@pytest.mark.asyncio
+async def test_fixture_pipeline_emits_full_event_sequence():
+    store = _FakeStore()
+    brief = GenerateBrief(intent="13-week treasury alternative", risk_appetite="conservative")
+
+    with patch(
+        "archimedes.services.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_fixture_001", "0xdeadbeef")),
+    ):
+        await run_generation(job_id="job_fixture_001", brief=brief, n_candidates=1, store=store)
+
+    names = [e["event"] for e in store.events]
+    # Spec ordering — terminal `done` must be last
+    assert names[0] == "job_queued"
+    assert names[1] == "brief_validated"
+    assert names[2] == "candidates_selected"
+    assert "agent_iteration" in names
+    assert "tool_called" in names
+    assert "candidate_drafted" in names
+    assert "candidate_evaluated" in names
+    assert "best_selected" in names
+    assert "trace_hashed" in names
+    assert "persisted" in names
+    assert names[-1] == "done"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_terminates_with_done_status():
+    store = _FakeStore()
+    brief = GenerateBrief(intent="balanced macro", risk_appetite="moderate")
+
+    with patch(
+        "archimedes.services.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_test_002", "0xabc")),
+    ):
+        await run_generation(job_id="job_002", brief=brief, n_candidates=1, store=store)
+
+    # Status sequence: running → done
+    statuses = [s[0] for s in store.status]
+    assert statuses == ["running", "done"]
+    last_result = store.status[-1][1]
+    assert last_result is not None
+    assert last_result["best_strategy_id"] == "strat_test_002"
+    assert len(last_result["candidates"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_multi_candidate_picks_best():
+    store = _FakeStore()
+    brief = GenerateBrief(intent="aggressive crypto", risk_appetite="aggressive")
+
+    with patch(
+        "archimedes.services.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_multi_001", "0xfeed")),
+    ):
+        await run_generation(job_id="job_multi", brief=brief, n_candidates=3, store=store)
+
+    # 3 candidates should produce 3 candidate_drafted events
+    drafted = [e for e in store.events if e["event"] == "candidate_drafted"]
+    assert len(drafted) == 3
+    best = next((e for e in store.events if e["event"] == "best_selected"), None)
+    assert best is not None
+    assert best["data"]["considered_count"] == 3

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -83,6 +83,114 @@ async def test_pipeline_terminates_with_done_status():
     assert len(last_result["candidates"]) == 1
 
 
+def test_rigor_adapter_computes_dsr_and_oos_sharpe_on_synthetic_series():
+    """Wires Önder's rigor_evaluator on a synthetic return series.
+
+    Verifies the verdict shape matches the contract the SSE event +
+    frontend RejectedCandidates view expect — all four fields present,
+    `passing` is a bool, numeric fields are floats.
+    """
+    from archimedes.services.generation_pipeline import (
+        _portfolio_return_series, _rigor_verdict_for,
+    )
+
+    # Synthetic price histories — two assets, trending up with noise.
+    import random
+    random.seed(42)
+    n = 250
+    spy = [100.0]
+    gld = [100.0]
+    for _ in range(n - 1):
+        spy.append(spy[-1] * (1 + 0.0005 + random.gauss(0, 0.01)))
+        gld.append(gld[-1] * (1 + 0.0002 + random.gauss(0, 0.008)))
+
+    histories = {
+        "sSPY": {"close": spy},
+        "sGLD": {"close": gld},
+    }
+    weights = {"sSPY": 0.6, "sGLD": 0.4}
+
+    series = _portfolio_return_series(weights, histories)
+    assert len(series) == n - 1
+
+    verdict = _rigor_verdict_for(series, num_trials=3)
+    assert set(verdict.keys()) >= {
+        "dsr", "oos_sharpe", "lookahead_audit_passed", "passing", "pbo",
+    }
+    assert isinstance(verdict["passing"], bool)
+    assert verdict["dsr"] is not None
+    assert verdict["oos_sharpe"] is not None
+
+
+def test_rigor_adapter_handles_empty_series():
+    """Short series should produce None metrics + non-passing verdict."""
+    from archimedes.services.generation_pipeline import _rigor_verdict_for
+
+    verdict = _rigor_verdict_for([], num_trials=1)
+    assert verdict["dsr"] is None
+    assert verdict["oos_sharpe"] is None
+    assert verdict["passing"] is False
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_cancellation_event_when_task_cancelled():
+    """CancelledError path emits a CANCELLED error event + flips status."""
+    store = _FakeStore()
+    brief = GenerateBrief(intent="cancel me mid-run", risk_appetite="moderate")
+
+    # Drive the pipeline as a real task so we can cancel it.
+    task = asyncio.create_task(run_generation(
+        job_id="job_cancel_001", brief=brief, n_candidates=1, store=store,
+    ))
+    # Let it kick off (job_queued + brief_validated emit synchronously).
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The cancellation handler must have logged the error event + status.
+    names = [e["event"] for e in store.events]
+    assert "error" in names
+    err = next(e for e in store.events if e["event"] == "error")
+    assert err["data"]["code"] == "CANCELLED"
+    assert err["data"]["recoverable"] is False
+    statuses = [s[0] for s in store.status]
+    assert statuses[-1] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_brief_validation_rejects_invalid_brief(monkeypatch):
+    """When the validator says is_valid=false, emit BRIEF_INVALID and stop.
+
+    Forces the live path (so the validator runs) by mocking _llm_available;
+    fake the LLM result to flag the brief invalid; assert the pipeline
+    emits the error event and never reaches candidates_selected.
+    """
+    from archimedes.services import generation_pipeline as gp
+
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+    async def fake_validate(brief):
+        return {
+            "is_valid": False,
+            "reason": "Brief looks like a recipe, not a strategy intent.",
+            "hint": "Try mentioning an asset class or risk appetite.",
+        }
+    monkeypatch.setattr(gp, "_validate_brief", fake_validate)
+
+    store = _FakeStore()
+    brief = GenerateBrief(intent="add flour and bake at 350F", risk_appetite="moderate")
+    await gp.run_generation(job_id="job_invalid_001", brief=brief, n_candidates=1, store=store)
+
+    names = [e["event"] for e in store.events]
+    assert "candidates_selected" not in names  # pipeline halted before agent ran
+    err = next((e for e in store.events if e["event"] == "error"), None)
+    assert err is not None
+    assert err["data"]["code"] == "BRIEF_INVALID"
+    assert err["data"]["recoverable"] is True
+    statuses = [s[0] for s in store.status]
+    assert statuses[-1] == "error"
+
+
 @pytest.mark.asyncio
 async def test_pipeline_multi_candidate_picks_best():
     store = _FakeStore()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,38 @@ services:
       redis:
         condition: service_healthy
 
+  # ---------- KB pipeline runner (Phase 3c skeleton) ----------
+  # Polls the corpus + artifact volume and re-runs the SPECTER2 / HDBSCAN /
+  # BERTopic / REBEL / SciSpacy pipeline when the trigger conditions hit
+  # (≥KB_NEW_PAPER_THRESHOLD papers OR ≥KB_MAX_DAYS_SINCE_LAST days).
+  #
+  # The pipeline body itself is gated behind KB_PIPELINE_ENABLED — leave
+  # unset until the dedicated image with the ~6 GB of model weights ships;
+  # the runner simply logs "needs_rerun=False" between ticks meanwhile.
+  # See docs/specs/kb-integration-spec.md.
+  kb-runner:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    command: ["python", "-m", "archimedes.services.kb_runner"]
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://archimedes:archimedes-hackathon-2026@postgres:5432/archimedes}
+      KB_ARTIFACT_DIR: /srv/corpus-artifact
+      KB_CORPUS_DIR: /srv/corpus-text
+      KB_RUNNER_INTERVAL_SECONDS: ${KB_RUNNER_INTERVAL_SECONDS:-21600}
+      KB_NEW_PAPER_THRESHOLD: ${KB_NEW_PAPER_THRESHOLD:-100}
+      KB_MAX_DAYS_SINCE_LAST: ${KB_MAX_DAYS_SINCE_LAST:-7}
+      KB_PIPELINE_ENABLED: ${KB_PIPELINE_ENABLED:-}
+    env_file:
+      - .env
+    volumes:
+      - ./data/corpus:/srv/corpus-text:ro
+      - archimedes-corpus-artifact:/srv/corpus-artifact:rw
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 volumes:
   pgdata:
   archimedes-corpus-artifact:

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,20 +54,20 @@ Durable implementation contracts. Spec-only items are tracked under their respec
 
 | Doc | Status | What it is |
 |---|---|---|
-| [`specs/spine-plus-v2-plan.md`](specs/spine-plus-v2-plan.md) | active — Phases 0–3 shipped; 4–7 in-flight | The master plan for the spine-plus-v2 effort (the broader follow-up to the original spine simplification). Phase 7 broken out as t2o2 issues below. |
+| [`specs/spine-plus-v2-plan.md`](specs/spine-plus-v2-plan.md) | active — Phases 0–3 shipped + Phase 6 (onboarding tour) merged; Phase 7 all shipped via t2o2; Phases 4 & 5 in-flight | The master plan for the spine-plus-v2 effort. |
 
-## Specs — t2o2 issue specs (filed as GitHub issues)
+## Specs — t2o2 issue specs (all six closed; spec files retained as the spec source-of-truth)
 
-These files are the spec source-of-truth; the agentic system (`t2o2`) executes against the live GitHub issue.
+All six issues below shipped on `main` between 2026-05-23 01:48 UTC and 2026-05-24. The spec files are kept as documentation of the intent + acceptance shape that the bot executed against.
 
 | Spec file | Status | Issue |
 |---|---|---|
-| [`specs/fusion-to-backtest-t2o2-issue.md`](specs/fusion-to-backtest-t2o2-issue.md) | ✓ closed — building blocks shipped; wiring at #133 | [#128](https://github.com/hackagora/archimedes-arcadia/issues/128) |
-| [`specs/phase7-rigor-consolidation-t2o2-issue.md`](specs/phase7-rigor-consolidation-t2o2-issue.md) | open · assigned t2o2 | [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) |
-| [`specs/phase7-llm-backend-unification-t2o2-issue.md`](specs/phase7-llm-backend-unification-t2o2-issue.md) | open · assigned t2o2 | [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) |
-| [`specs/phase7-portfolio-constructor-retirement-t2o2-issue.md`](specs/phase7-portfolio-constructor-retirement-t2o2-issue.md) | open · assigned t2o2 | [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) |
-| [`specs/phase7-routes-py-split-t2o2-issue.md`](specs/phase7-routes-py-split-t2o2-issue.md) | open · assigned t2o2 | [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) |
-| (no file — drafted inline) | open · assigned t2o2 — fusion_evaluator wiring follow-on to #128 | [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) |
+| [`specs/fusion-to-backtest-t2o2-issue.md`](specs/fusion-to-backtest-t2o2-issue.md) | ✓ closed — foundation `bd6935b` + wiring `2f7f871` | [#128](https://github.com/hackagora/archimedes-arcadia/issues/128) |
+| [`specs/phase7-rigor-consolidation-t2o2-issue.md`](specs/phase7-rigor-consolidation-t2o2-issue.md) | ✓ closed — shipped `e030ee4` | [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) |
+| [`specs/phase7-llm-backend-unification-t2o2-issue.md`](specs/phase7-llm-backend-unification-t2o2-issue.md) | ✓ closed — shipped `dc91b43` | [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) |
+| [`specs/phase7-portfolio-constructor-retirement-t2o2-issue.md`](specs/phase7-portfolio-constructor-retirement-t2o2-issue.md) | ✓ closed — shipped `a4a09fb` | [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) |
+| [`specs/phase7-routes-py-split-t2o2-issue.md`](specs/phase7-routes-py-split-t2o2-issue.md) | ✓ closed — shipped `be9260b` | [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) |
+| (no file — drafted inline as fast-follow to #128) | ✓ closed — shipped `2f7f871` | [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) |
 
 ## Strategy + launch + marketing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # `docs/` — Documentation Index
 
-Navigation aid for everything under `docs/`. Grouped by purpose so you can find the right doc without grep'ing. Last updated 2026-05-22 (Day-10).
+Navigation aid for everything under `docs/`. Grouped by purpose so you can find the right doc without grep'ing. Last updated 2026-05-23 (Day-11).
+
+Every doc carries a `> **Status:** …` line in its header so judges/readers can tell at a glance what's shipped, what's spec, what's archived, and what's been filed as a live GitHub issue. The tables below mirror that.
 
 For repo-level setup + operations, start at the **repo root**:
 
@@ -20,28 +22,52 @@ For repo-level setup + operations, start at the **repo root**:
 
 ## Architecture (current shipped state)
 
-| Doc | What it is |
-|---|---|
-| [`design.md`](design.md) | Original single-vault design document. Architecture lineage; superseded for product framing by `user-stories.md`. Component-level shipped state in `chuan-architecture-survey.md`. |
-| [`architectural-principles.md`](architectural-principles.md) | The four primitives (paper-claim binding, reasoning trace, tool-call provenance, selection-bias correction) — the "why" doc. All four shipped + live. |
-| [`chuan-architecture-survey.md`](chuan-architecture-survey.md) | File-by-file survey of `backend/archimedes/` (78 files). Aggregate gap clusters. Day-10 refresh. |
-| [`corpus-architecture.md`](corpus-architecture.md) | The q-fin corpus end-to-end: 3-layer substrate (seed → DB → artifact), fusion path, wired-vs-not-yet table. |
+| Doc | Status | What it is |
+|---|---|---|
+| [`design.md`](design.md) | superseded for product framing | Original single-vault design. Architecture lineage; the canonical product framing is `user-stories.md`. Component-level shipped state in `chuan-architecture-survey.md`. |
+| [`architectural-principles.md`](architectural-principles.md) | shipped | The four primitives (paper-claim binding, reasoning trace, tool-call provenance, selection-bias correction). All four live. |
+| [`chuan-architecture-survey.md`](chuan-architecture-survey.md) | snapshot — Day-11 | File-by-file survey of `backend/archimedes/` (~89 files). Aggregate gap clusters with t2o2-issue cross-refs. |
+| [`corpus-architecture.md`](corpus-architecture.md) | partial | The q-fin corpus end-to-end: 3-layer substrate (seed → DB → artifact), fusion path, wired-vs-not-yet table. |
 
-## Specs
+## Specs — architectural contracts
 
-Implementation contracts. The `specs/` subdirectory:
+Durable implementation contracts. Spec-only items are tracked under their respective phase plan.
 
-| Doc | What it is |
-|---|---|
-| [`specs/strategy-passport-spec.md`](specs/strategy-passport-spec.md) | The strategy passport schema + provenance contract. **Shipped + live in the UI.** |
-| [`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md) | DSR + PBO + walk-forward OOS + look-ahead audit math + thresholds. **Shipped; 2 Tier-1 strategies pass today.** |
-| [`specs/strategy-fusion-spec.md`](specs/strategy-fusion-spec.md) | Multi-paper fusion engine spec. **Shipped** (`services/strategy_fusion.py`); SPECTER2 + RAG upgrade is the unblocked `#96` follow-on. |
-| [`specs/ipfs-reasoning-traces-design-note.md`](specs/ipfs-reasoning-traces-design-note.md) | Hash → Pinata CID → on-chain anchor (Rosetta-Alpha pattern). Design note, not yet wired. |
-| [`specs/commit-reveal-trace-spec.md`](specs/commit-reveal-trace-spec.md) | v1.5 trace integrity upgrade — promotes "trace existed at T" to "trace existed *before* the trade". Spec'd, not live. |
-| [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md) | The Day-3 marketplace pivot spec — 4-layer architecture (Synthetic Protocol + AMM + Vault Factory + Agent-as-a-Service). Substantially shipped. |
-| [`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md) | The original frozen `I*` Protocol contracts for the 5-person concurrent build. Interfaces are still architecturally correct; ownership has evolved to lead+coverage. |
-| [`specs/fusion-to-backtest-t2o2-issue.md`](specs/fusion-to-backtest-t2o2-issue.md) | Judge-grade issue spec for the fusion→backtest pipeline gap (constrained DSL + interpreter + rigor-gate integration). Ready to file. |
-| [`specs/ecosystem-architecture.html`](specs/ecosystem-architecture.html) | Visual diagram of the ecosystem architecture (HTML render). |
+| Doc | Status | What it is |
+|---|---|---|
+| [`specs/strategy-passport-spec.md`](specs/strategy-passport-spec.md) | shipped | The strategy passport schema + provenance contract. Live in the UI. |
+| [`specs/selection-bias-corrections-spec.md`](specs/selection-bias-corrections-spec.md) | shipped | DSR + PBO + walk-forward OOS + look-ahead audit math + thresholds. 2 Tier-1 strategies pass today. |
+| [`specs/strategy-fusion-spec.md`](specs/strategy-fusion-spec.md) | shipped | Multi-paper fusion engine. SPECTER2 + RAG upgrade is the unblocked `#96` follow-on. |
+| [`specs/strategy-lifecycle-spec.md`](specs/strategy-lifecycle-spec.md) | shipped (Phase 0) | Generated → Validated → Deployed → Active → Completed/Expired/Rejected. The state machine fusion-evaluator output enters. |
+| [`specs/portfolio-constructor-decision-tree.md`](specs/portfolio-constructor-decision-tree.md) | shipped (Phase 0) | Names `portfolio_agent.py` (top-level) + `portfolio_optimizer.py` (math leaf) as canonical; retirement of the other two filed as [#131](https://github.com/hackagora/archimedes-arcadia/issues/131). |
+| [`specs/page-roles-spec.md`](specs/page-roles-spec.md) | shipped (Phase 0) | Per-page ownership in the spine — what each page is for + isn't for. Backs the Reasoning restructure + Library deep-link work. |
+| [`specs/vault-semantics-spec.md`](specs/vault-semantics-spec.md) | spec-only — Phase 4 | Vault lifecycle + trade-window semantics. Waits on Marten/Chuan alignment. |
+| [`specs/generation-streaming-spec.md`](specs/generation-streaming-spec.md) | shipped (Phase 2) | SSE streaming protocol for `/api/generate/*`. Backs the streaming Generate UI. |
+| [`specs/kb-integration-spec.md`](specs/kb-integration-spec.md) | partial (Phase 3c) | KB pipeline integration. Skeleton landed; production body waits on Dan's Linus-side iteration. |
+| [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md) | substantially shipped | Day-3 marketplace pivot — 4-layer architecture (Synthetic Protocol + AMM + Vault Factory + Agent-as-a-Service). |
+| [`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md) | shipped (interfaces); ownership softened | Original frozen `I*` Protocol contracts. Interfaces are architecturally correct; ownership has evolved to lead+coverage per CLAUDE.md. |
+| [`specs/ipfs-reasoning-traces-design-note.md`](specs/ipfs-reasoning-traces-design-note.md) | design note — not wired | Hash → Pinata CID → on-chain anchor (Rosetta-Alpha pattern). |
+| [`specs/commit-reveal-trace-spec.md`](specs/commit-reveal-trace-spec.md) | spec-only — v1.5 | Promotes "trace existed at T" to "trace existed *before* the trade". |
+| [`specs/ecosystem-architecture.html`](specs/ecosystem-architecture.html) | diagram | Visual diagram of the ecosystem architecture (HTML render). |
+
+## Specs — phase plans
+
+| Doc | Status | What it is |
+|---|---|---|
+| [`specs/spine-plus-v2-plan.md`](specs/spine-plus-v2-plan.md) | active — Phases 0–3 shipped; 4–7 in-flight | The master plan for the spine-plus-v2 effort (the broader follow-up to the original spine simplification). Phase 7 broken out as t2o2 issues below. |
+
+## Specs — t2o2 issue specs (filed as GitHub issues)
+
+These files are the spec source-of-truth; the agentic system (`t2o2`) executes against the live GitHub issue.
+
+| Spec file | Status | Issue |
+|---|---|---|
+| [`specs/fusion-to-backtest-t2o2-issue.md`](specs/fusion-to-backtest-t2o2-issue.md) | ✓ closed — building blocks shipped; wiring at #133 | [#128](https://github.com/hackagora/archimedes-arcadia/issues/128) |
+| [`specs/phase7-rigor-consolidation-t2o2-issue.md`](specs/phase7-rigor-consolidation-t2o2-issue.md) | open · assigned t2o2 | [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) |
+| [`specs/phase7-llm-backend-unification-t2o2-issue.md`](specs/phase7-llm-backend-unification-t2o2-issue.md) | open · assigned t2o2 | [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) |
+| [`specs/phase7-portfolio-constructor-retirement-t2o2-issue.md`](specs/phase7-portfolio-constructor-retirement-t2o2-issue.md) | open · assigned t2o2 | [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) |
+| [`specs/phase7-routes-py-split-t2o2-issue.md`](specs/phase7-routes-py-split-t2o2-issue.md) | open · assigned t2o2 | [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) |
+| (no file — drafted inline) | open · assigned t2o2 — fusion_evaluator wiring follow-on to #128 | [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) |
 
 ## Strategy + launch + marketing
 
@@ -90,17 +116,19 @@ Research artifacts that don't fit the spine + architecture + specs hierarchy but
 
 ## Conventions for this folder
 
-- **Every doc has a `> Status:` line** in its second-block header naming the date + (where applicable) what's been superseded. The Day-10 audit pass added these where they were missing.
+- **Every doc has a `> **Status:**` line** in its second-block header. The Day-11 cleanup pass standardized vocabulary: `shipped` · `partial` · `spec-only` · `snapshot — <date>` · `archived` · `filed as #NNN` (for t2o2 issues) · `superseded by …`. Add the most specific status that fits.
 - **Cross-references use relative paths** within `docs/` (e.g. `[corpus-architecture.md](corpus-architecture.md)`); root-level docs use the `../` prefix.
+- **t2o2 issue specs** carry a status line linking to their GitHub issue. The file is the source-of-truth for the spec body; the issue is the source-of-truth for PR and review activity.
 - **Archived docs stay archived** — don't move them back. If something in an archived doc is still load-bearing, fold it into the current canonical doc + leave the archive in place.
 - **ADRs are immutable** — capture a decision once, supersede with a new ADR if it changes; don't edit the original.
 
 ## How to add a new doc
 
-1. Decide which group it belongs to (Product spine? Architecture? Spec? Strategy? Reference? ADR?).
-2. Pick a filename (kebab-case, descriptive, no dates).
-3. Add a `> Status: <date> · <one-liner>` header.
+1. Decide which group it belongs to (Product spine? Architecture? Architectural spec? Phase plan? t2o2 issue? Strategy? Reference? ADR?).
+2. Pick a filename (kebab-case, descriptive, no dates). For t2o2 issue specs, suffix `-t2o2-issue.md`.
+3. Add a `> **Status:** <vocabulary> · <one-liner>` header.
 4. Link from this index (`docs/README.md`) under the right group.
 5. Cross-link from related docs in the same group.
+6. If it's a t2o2 issue spec: file it as a GitHub issue with `gh issue create … --assignee t2o2` and back-link the issue # in the spec's status block.
 
 If you're unsure where it goes, default to `docs/<your-doc>.md` (top-level docs/) and ask in #standups if a subdirectory is warranted.

--- a/docs/arc-alignment.md
+++ b/docs/arc-alignment.md
@@ -1,5 +1,7 @@
 # Arc Alignment — Strategy & Build Posture
 
+> **Status:** Canonical reference for Arc/Circle alignment. Written 2026-05-19 (Day 8); build-posture decisions below remain current as of 2026-05-23 (Day 11). Re-validate before the pitch.
+>
 > **Date:** 2026-05-19. **Canonical strategy doc for "how Archimedes aligns to,
 > and builds in, the Arc/Circle world."** Read with
 > [`user-stories.md`](user-stories.md) (the spine), [`competitor-landscape.md`](competitor-landscape.md)

--- a/docs/chuan-architecture-survey.md
+++ b/docs/chuan-architecture-survey.md
@@ -3,7 +3,7 @@
 > **Audience:** team-internal recon document. Describes the surface, names the gaps,
 > **does not act on them**. Per-file follow-ups happen on subsequent prompts.
 > **Scope:** the entire `backend/archimedes/` FastAPI package. The agentic
-> system (`t2o2`) holds **54 of the 97 commits** under this tree — more than
+> system (`t2o2`) holds **the majority** of commits under this tree — more than
 > every other contributor combined. The `chain/` subdir is the narrow
 > personal-lane focus; the rest is via the bot pipeline.
 > **Method:** for every `*.py` file, extracted line count, first-commit author,
@@ -11,39 +11,35 @@
 > Raw extraction regenerable via the per-file `git log` + `grep` recipe at the
 > end of this doc. Per-file commit history via
 > `git log --author='t2o2' --author='chuan@gyld.fi' -- backend/archimedes/`.
-> **Status:** **Day-10 revision (2026-05-22).** Refreshes the Day-9 survey
-> (PR #122) against six commits that landed since: `[strategy] Wire strategy
-> engine to marketplace + vault provenance` · `[infra] Wire LLM credentials
-> into EC2 deploy` · `[contracts] Multi-asset NAV vault` · `[quant]
-> Citadel-grade advisor` · `[quant] Make the portfolio advisor agentic` · two
-> CI/CD redeploys. **3 new files** added (`services/portfolio_agent.py`,
-> `services/stress_engine.py`, `scripts/deploy_contracts.py`),
-> `services/marketplace_service.py` shed **607 lines** (1005 → ~400; gap
-> cluster #8 partly resolved), and the portfolio constructor count went from
-> 3 to **4** (new cluster #5 nuance below).
+> **Status:** **Day-11 revision (2026-05-23).** Refreshes the Day-10 survey
+> against the work that landed since:
+>   - **Chuan / t2o2 — `bd6935b` (Strategy DSL + interpreter + fusion evaluator pipeline).** **3 new files** (`services/strategy_dsl.py`, `services/dsl_to_backtrader.py`, `services/fusion_evaluator.py`) + 37 new tests + 7-line additive change to `strategy_fusion.py`. Closes the long-standing fusion-to-backtest gap at the implementation level; the wiring into `_run_fusion_job` is open in [#133](https://github.com/hackagora/archimedes-arcadia/issues/133).
+>   - **Daniel R. — UnoCSS pass (PR #124).** Frontend-only; no `backend/archimedes/` impact.
+>   - **Spine-plus-v2 (Dan / Claude, branch `dbrowneup/spine-plus-v2`).** **8 new files** under `backend/archimedes/`: `api/generate_routes.py`, `api/generate_schemas.py`, `api/explore_routes.py`, `api/explore_schemas.py`, `api/corpus_routes.py`, `services/generation_pipeline.py`, `services/asset_market_service.py`, `services/corpus_categories.py`, `services/kb_runner.py`, `models/kg.py`, `scripts/run_kb_pipeline.py` (11 files including models + scripts). Streaming Generate, Explore page, corpus polish, KB pipeline skeleton.
+>   - **Phase 7 follow-ups filed as t2o2 issues 2026-05-23:** [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) (rigor consolidation), [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) (LLM backend unification), [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) (portfolio constructor retirement), [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) (routes.py monolith split), [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) (fusion-evaluator wiring). Five of the gap clusters below are now live work.
 
 ## Quick stats
 
-- **Files surveyed:** 78 `*.py` under `backend/archimedes/` (was 75 at Day-9)
-- **Top files by `t2o2` commit count:** `api/routes.py` (19), `main.py` (16),
-  `services/vault_service.py` (6), `api/schemas.py` (6), `services/strategy_fusion.py` (5),
-  `services/strategy_architect.py` (5), `chain/agent_runner.py` (5)
-- **Author distribution under this tree:** `t2o2` 54 · Önder 23 · Daniel B. 14 ·
+- **Files surveyed:** ~89 `*.py` under `backend/archimedes/` at Day-11 (78 at Day-10, 75 at Day-9)
+- **Top files by `t2o2` commit count (Day-10 reading; not re-run for Day-11):** `api/routes.py`, `main.py`,
+  `services/vault_service.py`, `api/schemas.py`, `services/strategy_fusion.py`,
+  `services/strategy_architect.py`, `chain/agent_runner.py`
+- **Author distribution under this tree (Day-10 reading):** `t2o2` 54 · Önder 23 · Daniel B. 14 ·
   Chuan (personal) 3 · Dan 2 · Daniel R. 1
 
-## File tree
+## File tree (Day-11)
 
 ```
 backend/archimedes/
 ├── __init__.py
 ├── main.py                 ← app entrypoint + startup hooks
 ├── db.py                   ← SQLAlchemy async session factory
-├── api/                    ← FastAPI routes + Pydantic schemas (11 files)
+├── api/                    ← FastAPI routes + Pydantic schemas (14 files)  ⟵ +generate_routes/_schemas +explore_routes/_schemas +corpus_routes
 ├── chain/                  ← personal lane: web3 + Circle + on-chain (8 files)
 ├── interfaces/             ← frozen Protocol contracts (4 files)
-├── models/                 ← SQLAlchemy ORM + dataclass models (11 files)
-├── scripts/                ← operational scripts (5 files + __init__)  ⟵ +deploy_contracts.py
-└── services/               ← business logic (27 files + __init__)      ⟵ +portfolio_agent.py +stress_engine.py
+├── models/                 ← SQLAlchemy ORM + dataclass models (12 files)   ⟵ +kg.py
+├── scripts/                ← operational scripts (6 files + __init__)        ⟵ +run_kb_pipeline.py
+└── services/               ← business logic (33 files + __init__)            ⟵ +generation_pipeline +asset_market_service +corpus_categories +kb_runner +strategy_dsl +dsl_to_backtrader +fusion_evaluator
 ```
 
 ---
@@ -69,6 +65,14 @@ backend/archimedes/
 - **`schemas.py`** (489 lines, `t2o2`) — the frontend contract. Asset / vault / strategy / trace response shapes. **Gap:** none structural; touching it triggers the announce-before-changing policy.
 - **`selection_bias_routes.py`** (296 lines, `t2o2`) — rigor gate endpoints (per-strategy + bulk + PBO). **Gap:** `_synthetic_returns_from_stub()` and `_load_strategy_code()` are private helpers — the PBO endpoint synthesizes returns from stub metrics when no real returns are stored, which is an honest fallback but worth verifying it's still in use given Önder's `rigor_evaluator.py` work.
 - **`vault_schemas.py`** (60 lines, `t2o2`) — vault create / metadata / allocation request-response models. **Gap:** no module docstring.
+
+### Day-11 additions (spine-plus-v2)
+
+- **`generate_routes.py`** *(NEW Day-11, Dan / Claude)* — streaming Generate endpoints (`/api/generate/start`, `/api/generate/stream/{id}`, `/api/generate/jobs`, `/api/generate/jobs/{id}/candidates`). SSE-based stream with hard-cancellation via asyncio task registry; Redis-backed event log for `Last-Event-ID` replay. **Gap:** none structural.
+- **`generate_schemas.py`** *(NEW Day-11)* — request/response shapes for the streaming generation surface. **Gap:** none.
+- **`explore_routes.py`** *(NEW Day-11)* — Explore page backend (`/api/explore/assets`, `/api/explore/assets/{symbol}/history`). Reads from yfinance via `asset_market_service.py`, not the on-chain oracle (oracle has no history). **Gap:** none.
+- **`explore_schemas.py`** *(NEW Day-11)* — Explore response shapes. **Gap:** none.
+- **`corpus_routes.py`** *(NEW Day-11)* — corpus graph + KG endpoints (`/api/papers/corpus/graph`, `/api/papers/corpus/kg`), moved out of `routes.py` per the cross-cutting "dedicated router" discipline. **Gap:** none.
 
 ---
 
@@ -113,6 +117,10 @@ These were defined early as the contract surface for the 5-person concurrent bui
 - **`trace.py`** (99 lines, `t2o2`) — `ReasoningTrace` dataclass + `DecisionType` enum. **Gap:** imports `web3` at module level (`from web3 import Web3`) which is a heavy dep for a model file — the hash computation could live in a helper instead.
 - **`vault.py`** (66 lines, `t2o2`) — `VaultInfo`, `VaultMetrics`, `VaultTier`. **No gap.**
 
+### Day-11 additions (spine-plus-v2)
+
+- **`kg.py`** *(NEW Day-11, Dan / Claude)* — knowledge-graph ORM tables (nodes, edges, embedding refs) backing the KB pipeline skeleton. Imports `Base` from `models/chat.py` (per the existing import structure). **Gap:** schema present; the pipeline that populates it is gated behind `KB_PIPELINE_ENABLED` and waits on Dan's Linus-side iteration stabilizing.
+
 ---
 
 ## `scripts/` — operational scripts
@@ -123,6 +131,10 @@ These were defined early as the contract surface for the 5-person concurrent bui
 - **`hydrate_corpus.py`** (151 lines, `t2o2`) — deploy-time corpus PDF/text hydration. Polite (3s delay), idempotent (sha256 cache). **Gap:** not auto-invoked anywhere — operator-triggered only.
 - **`run_backtests.py`** (180 lines, **Daniel R.**) — invokes the analytics-engine and persists results. **Gap:** runs the analytics suite as a separate process.
 - **`seed_backtests_from_artifacts.py`** (119 lines, `t2o2`) — loads pre-existing artifact JSON into `backtest_results` table without re-running. **Gap:** deployment-time loader; operator-triggered.
+
+### Day-11 additions (spine-plus-v2)
+
+- **`run_kb_pipeline.py`** *(NEW Day-11)* — entry point for the KB-pipeline batch (PyMuPDF extract → embedding → cluster → KG build), gated behind `KB_PIPELINE_ENABLED`. Skeleton only at Day-11; production body waits on Dan's Linus-side iteration stabilizing. **Gap:** runs nothing meaningful until the KB substrate is finalized.
 
 ---
 
@@ -166,6 +178,19 @@ These were defined early as the contract surface for the 5-person concurrent bui
 - **`circle_service.py`** (121 lines, `t2o2`) — Circle SDK breadth showcase. **Gap:** the docstring is explicit: *"demonstrates breadth of Circle tool usage…for the rubric's 20% Circle Tool Usage category."* This is judge-oriented, not load-bearing.
 - **`config_service.py`** (49 lines, `t2o2`) — serves deployed contract addresses to the frontend. **Gap:** thin.
 
+### Domain: fusion-to-backtest pipeline (Day-11)
+
+- **`strategy_dsl.py`** *(NEW Day-11, `t2o2` / Chuan, 250 lines)* — closed-enum JSON schema + validator for fusion-generated strategies. No `eval`/`exec`/`importlib`; static look-ahead audit. **Gap:** spec doc (`docs/specs/strategy-dsl-spec.md`) is the open item on [#133](https://github.com/hackagora/archimedes-arcadia/issues/133).
+- **`dsl_to_backtrader.py`** *(NEW Day-11, `t2o2`, 197 lines)* — interpreter producing `backtrader.Strategy` subclasses at runtime from a validated `StrategySpec`. **Gap:** none structural.
+- **`fusion_evaluator.py`** *(NEW Day-11, `t2o2`, 339 lines)* — orchestrator: `validate → interpret → backtest → rigor gate`. Uses canonical `services/rigor_evaluator.py` for DSR/OOS-Sharpe (PBO defaulted to 0.0 with a comment, since PBO is a library-level metric). 37 new tests, all passing. **Gap:** **not yet wired into `_run_fusion_job`** — fusion endpoint still emits text-only output in production. Tracked at [#133](https://github.com/hackagora/archimedes-arcadia/issues/133).
+
+### Domain: streaming generation (Day-11, spine-plus-v2)
+
+- **`generation_pipeline.py`** *(NEW Day-11, Dan / Claude)* — the agent-path streaming pipeline. Computes per-candidate buy-and-hold return series, calls `rigor_evaluator.compute_dsr` / `compute_oos_sharpe` for each, applies library-level PBO across the candidate set, validates the user brief as a JSON-mode LLM step. Wired into `generate_routes.py::POST /api/generate/start`. **Gap:** in-flight thread-bound LLM calls can't be hard-cancelled (only the surrounding `asyncio.Task` is cancellable) — documented limitation, not a bug.
+- **`asset_market_service.py`** *(NEW Day-11)* — yfinance reader for the Explore page asset histories. Caches per-symbol pulls. **Gap:** none.
+- **`corpus_categories.py`** *(NEW Day-11)* — labels + counts for corpus filtering in Explore. **Gap:** none.
+- **`kb_runner.py`** *(NEW Day-11)* — KB-pipeline runner skeleton (called by `scripts/run_kb_pipeline.py`). Gated behind `KB_PIPELINE_ENABLED`. **Gap:** production body deferred — see scripts/ note.
+
 ### Domain: cross-cutting
 
 - **`__init__.py`** (6 lines, **Daniel B. / me**) — package docstring naming ownership. **Gap:** ownership comment is stale (much was rewritten by `t2o2`).
@@ -181,24 +206,27 @@ These were defined early as the contract surface for the 5-person concurrent bui
 
 ---
 
-## Aggregate gap clusters (where to look first) — Day-10 update
+## Aggregate gap clusters (where to look first) — Day-11 update
 
-Roughly in priority order for "where to fill gaps next" given the launch window. **Bold-italic** notes reflect Day-10 deltas vs the Day-9 ranking.
+Five of the gap clusters below are now **live work** with t2o2 issues filed. Status column added so the table doubles as a one-glance "what's queued."
 
-1. **Redundancy: rigor implementation** — `selection_bias.py` (534 lines, `t2o2`, older) overlaps `rigor_evaluator.py` (348 lines, Önder, newer). Pick one as canonical and delete or wrap the other. Active risk: any future rigor bug fix may land in the wrong file. *Unchanged Day-10.*
-2. **Redundancy: regime detection** — `regime_detector.py` (v1 heuristic) vs `statistical_regime.py` (v2). Unclear which is wired to the live agent loop and the `RegimePanel`. Decide which is canonical. *Unchanged Day-10.*
-3. **Redundancy: LLM backends** — three parallel `LLMBackend` Protocols + `ClaudeBackend` + `CannedBackend` impls (in `llm_backend.py`, `strategy_architect.py`, `strategy_fusion.py`). Unify on `llm_backend.py`. ***Day-10 nuance:*** the new `portfolio_agent.py` also instantiates the LLM path — it appears to use `llm_backend.py` (the right abstraction); verify and use that as the unification template.
-4. **Redundancy: arxiv intake paths** — `arxiv_corpus.py` (older scraper), `corpus_service.py` (DB-backed), `scripts/bulk_ingest_arxiv.py` (10k expansion). Cross-cutting; `corpus_service.py` is the canonical going forward but the other two still exist. *Unchanged Day-10.*
-5. **Multiplicity: portfolio constructors — now FOUR.** *Day-10 added `portfolio_agent.py` (850 lines, LLM-driven agentic) on top of:* `portfolio_constructor.py` (orchestrator), `portfolio_optimizer.py` (Önder's MVO, refactored Day-10), and `kelly_portfolio.py` (Kelly + risk parity, Day-10 Kelly fix). **A one-page decision tree — "which constructor when?" — is now load-bearing.** Best guess from the code: (a) `portfolio_agent.py` is the headline LLM-agentic path; (b) `kelly_portfolio.py` does Kelly sizing; (c) `portfolio_optimizer.py` does MVO; (d) `portfolio_constructor.py` orchestrates (a)/(b)/(c) by regime. Verify before publishing the decision tree.
-6. **Monolith: `api/routes.py`** — now ~2315 lines (was 2199 at Day-9). Splitting by resource would improve discoverability; the dedicated routers (`chat_routes.py`, `marketplace_routes.py`, `risk_routes.py`, `selection_bias_routes.py`) prove the pattern works. ***Day-10:*** worsened — new agent/stress/advisor endpoints all landed in the monolith rather than as new dedicated routers.
-7. **Stale interface ownership comments** — `interfaces/agent.py`, `chain.py`, `math.py` reference owners that don't reflect the current bot-driven authoring reality. Cosmetic but misleading. *Unchanged Day-10.*
-8. **`marketplace_service.py` seed-data weight — partly resolved.** *Day-10 pruned 607 lines (1005 → ~398) via `[strategy] Wire strategy engine to marketplace + vault provenance`.* Still partly seed-data backed; remaining work is to fully wire the marketplace surface to the strategy engine + on-chain vault provenance.
-9. **Scheduled intake / artifact build** — `corpus_service.intake_from_arxiv()` exists but no periodic task; `archimedes-corpus-artifact` volume mounted but empty. Both flagged in `docs/corpus-architecture.md`; both blockers for the "dynamic, continuously fresh" claim. *Unchanged Day-10.*
-10. **Operational scripts as scripts, not as commands** — `bootstrap_vaults.py` (~580 lines), `hydrate_corpus.py`, `seed_backtests_from_artifacts.py`, `run_backtests.py`, and now `deploy_contracts.py` are all operator-triggered. A `Makefile` target per script would make them discoverable and CI-able. ***Day-10:*** new `deploy_contracts.py` adds a 5th script in this pattern; also it edits `.env` + needs to mirror to `ui/src/config.js` — that two-place address sync is a drift risk.
-11. **TODO marker** — `routes.py:172` `# TODO: Implement with stored price history`. Small but visible. *Unchanged Day-10.*
-12. **`circle_service.py` is judge-oriented** — explicit in the docstring. Not a bug, but worth being aware that this is rubric-surface, not product-surface. *Unchanged Day-10.*
-13. **NEW Day-10: `stress_engine.py` is built but not wired to the UI.** 380 lines, six canonical scenarios, clean API (`stress_one`, `stress_all`, `list_scenarios`). The strip-to-spine `Portfolio.jsx` would be the obvious surface to render the scenario table; backend is ready, frontend is not.
-14. **NEW Day-10: agentic advisor introduces tool-use semantics not present elsewhere.** `portfolio_agent.py` uses `MAX_AGENT_ITERATIONS = 12` and tool-calling — this is the only place in the codebase where the LLM holds a multi-turn agent loop. The cache TTL is 5 minutes; if a regime changes mid-cache the advisor will give stale recommendations. Worth understanding the failure modes before the demo.
+| # | Cluster | Day-11 status | Tracked at |
+|---|---|---|---|
+| 1 | **Redundancy: rigor implementation** (`selection_bias.py` ↔ `rigor_evaluator.py`) | **filed** | [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) — open, t2o2 |
+| 2 | **Redundancy: regime detection** (`regime_detector.py` ↔ `statistical_regime.py`) | **deferred** — needs Önder's read on which is wired to `RegimePanel` before specing | open question for next standup |
+| 3 | **Redundancy: LLM backends** (3 parallel `LLMBackend` Protocols) | **filed** | [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) — open, t2o2 |
+| 4 | **Redundancy: arxiv intake paths** (`arxiv_corpus.py`, `corpus_service.py`, `bulk_ingest_arxiv.py`) | **deferred** — adjacent to Dan's Linus-side KB iteration | will fold into Phase 3c completion |
+| 5 | **Multiplicity: portfolio constructors** | partially answered: decision-tree spec at [`docs/specs/portfolio-constructor-decision-tree.md`](specs/portfolio-constructor-decision-tree.md) names `portfolio_agent.py` (top-level) + `portfolio_optimizer.py` (math leaf) as canonical. Retirement of `portfolio_constructor.py` + `kelly_portfolio.py` **filed** | [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) — open, t2o2 |
+| 6 | **Monolith: `api/routes.py` (~2315 lines)** | **filed** — 9-file per-resource split spec'd | [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) — open, t2o2 |
+| 7 | **Stale interface ownership comments** (`interfaces/agent.py` / `chain.py` / `math.py`) | **resolved** in Phase 1 deferred resolution (commit `07276d3`) — reframed to Reviewer/Coverage per CLAUDE.md's lane-softening | landed |
+| 8 | **`marketplace_service.py` seed-data weight** | still partial; will file follow-on once [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) settles (the routes split surfaces remaining wiring) | tracked here |
+| 9 | **Scheduled intake / artifact build** | **deferred** — folds into Phase 3c completion (Dan's lane) | tracked here |
+| 10 | **Operational scripts not Make-able** | **resolved** — Makefile extended with `up`/`down`/`logs`/`pytest`/`lint`/`format`/`ui-dev`/`routes`/`clean` (commit `1e372f5`); README pointer added | landed |
+| 11 | **TODO marker at `routes.py:172`** | **resolved** in Phase 1 cherry-pick (commit `6b5baec`) — replaced with `501 Not Implemented` + a fixed-list `available_sources` body so callers see a real schema | landed |
+| 12 | **`circle_service.py` is judge-oriented** | by design — no action needed | n/a |
+| 13 | **`stress_engine.py` built but not wired to the UI** | **deferred** — Phase 4 candidate; Marten's lane. Design-prompts doc calls for a horizontal "Stress-scenario strip" on the Portfolio page; backend ready, frontend strip not yet wired | tracked here |
+| 14 | **Agentic advisor tool-use semantics** | unchanged — `MAX_AGENT_ITERATIONS=12`, 5-min cache. Failure modes worth understanding before the demo | tracked here |
+| 15 | **NEW Day-11: fusion-to-backtest wiring** | **filed** — building blocks shipped in `bd6935b` (DSL + interpreter + evaluator + 37 tests); LLM prompt extension + `_run_fusion_job` rewire + DSL spec doc remain | [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) — open, t2o2 |
 
 ---
 

--- a/docs/claude-design-prompts.md
+++ b/docs/claude-design-prompts.md
@@ -5,28 +5,49 @@
 > **Purpose:** Concrete, paste-ready prompts for slides, UI prototypes, logos, and
 > explanatory visualizations. Each prompt is self-contained so the design session has
 > the context it needs without you re-explaining the project.
-> **Status:** **Day-10 revision (2026-05-22).** Refreshes the Day-9 baseline against
-> the six commits that landed since (multi-asset NAV vault contract update,
-> LLM credentials wired into EC2 deploy, Citadel-grade agentic portfolio advisor,
-> stress engine, marketplace pruning, two CI/CD redeploys). Current snapshot the
-> prompts reflect: live React/Vite UI at
-> [`http://13.40.112.220/`](http://13.40.112.220/) on t3.medium EC2;
-> 10 Arc-testnet contracts (Vault.sol now multi-asset NAV — prices all holdings via
-> oracles in `totalAssets()`); engine v2 (`POST /api/strategies/generate` with
-> 3-input fusion); **agentic portfolio advisor** (`portfolio_agent.py` — LLM agent
-> loop with tool calls, picks individual stocks/bonds and anchors each to a
-> paper-grounded passport); **stress engine** (`stress_engine.py` — six canonical
-> historical/scenario shocks, backend-ready, UI-wiring open); the full rigor wedge
-> live (DSR/PBO/Kelly/MVO, 2 Tier-1 strategies — Faber 2007 + Moreira-Muir 2017 —
-> with real 22-year SPY backtest numbers); a DB-backed 10,000-paper q-fin corpus
-> with the Corpus Explorer UI shipped; "Linus for quantitative finance" as the
-> locked product framing per [`docs/user-stories.md`](user-stories.md); 302 backend
-> tests + 16 analytics-engine tests green; 3 days to submission. UI prompts work as
-> **refinement** prompts against the live UI, not greenfield.
+> **Status:** **Day-11 revision (2026-05-23).** Refreshes the Day-10 baseline
+> against spine-plus-v2 (8 commits ahead of `origin/main`: Phases 0–3 + follow-ups
+> + Makefile + the Day-11 docs cleanup) and Chuan's `bd6935b` (Strategy DSL +
+> interpreter + fusion evaluator pipeline). Current snapshot the prompts reflect:
+> live React/Vite UI at [`http://13.40.112.220/`](http://13.40.112.220/) on
+> t3.medium EC2; 10 Arc-testnet contracts (Vault.sol multi-asset NAV via oracle
+> in `totalAssets()`); **streaming Generate** (`POST /api/generate/start` →
+> SSE stream from the LLM agent loop, with hard-cancellation + Redis-backed
+> `Last-Event-ID` replay); **Explore page** (top-level nav; asset + history
+> read from yfinance via `asset_market_service.py`, not the on-chain oracle —
+> oracle has no history); **Reasoning page restructured** (the Library now
+> carries the strategy detail view + deep-link via `?highlight=`); **onboarding
+> tour** (Phase 6, separate branch `dbrowneup/phase6-onboarding`) — 6-card
+> MetaMask-style modal with in-repo SVG illustrations + "?" topbar reopen;
+> **agentic portfolio advisor** (`portfolio_agent.py` LLM tool-loop, picks
+> individual stocks/bonds anchored to paper-grounded passports); **stress
+> engine** (`stress_engine.py` six historical shocks, backend ready, UI strip
+> still on Phase 4 candidate list); the full rigor wedge live (DSR/PBO/Kelly/
+> MVO via canonical `services/rigor_evaluator.py`; 2 Tier-1 strategies — Faber
+> 2007 + Moreira-Muir 2017 — pass all four gates on 22-year SPY); DB-backed
+> 10,000-paper q-fin corpus with the Corpus Explorer UI shipped; "Linus for
+> quantitative finance" framing locked per [`docs/user-stories.md`](user-stories.md);
+> **343 backend tests** + 16 analytics-engine tests green; **2 days to submission**.
+> UI prompts work as **refinement** prompts against the live UI, not greenfield.
 >
 > **Aligned with [`docs/chuan-architecture-survey.md`](chuan-architecture-survey.md)
-> (Day-10 PR #125):** the shipped-state language below reflects the same Day-10
-> commit set the survey enumerates. When the survey moves, this file moves with it.
+> (Day-11):** the shipped-state language reflects the same commit set the survey
+> enumerates. When the survey moves, this file moves with it.
+>
+> **Day-11 delta callouts for prompts below** — items the existing prompts may
+> still describe in Day-10 terms; refine when running them:
+>   - **SLIDE 4 inventory** should now name *fusion-to-backtest pipeline (DSL +
+>     interpreter + rigor gate, `services/fusion_evaluator.py`)* alongside the
+>     agentic advisor + stress engine. The wiring into `_run_fusion_job` is
+>     in-flight as [#133](https://github.com/hackagora/archimedes-arcadia/issues/133)
+>     so word it carefully if the demo doesn't cover that surface.
+>   - **Page map / Prompt 3** should reflect: Explore is a top-level nav page;
+>     Reasoning lost its Strategies tab (details moved to Library); Generate is
+>     streaming with a mode toggle (Streaming agent vs Architect fast preview);
+>     onboarding tour appears on first visit + via the "?" icon in the topbar.
+>   - **Test counts**: 302 → 343 backend tests; 5 t2o2 issues open in the
+>     queue ([#129](https://github.com/hackagora/archimedes-arcadia/issues/129)–
+>     [#133](https://github.com/hackagora/archimedes-arcadia/issues/133)).
 
 ## Quick notes on using Claude Design
 

--- a/docs/competitor-landscape.md
+++ b/docs/competitor-landscape.md
@@ -1,5 +1,7 @@
 # Competitor Landscape — Portfolio Management Agents
 
+> **Status:** Canonical competitive framing for pitch + strategy. Crypto moves in weeks — figures below were sourced in dated research briefs; re-verify before pitch day.
+>
 > **Date:** 2026-05-12 (Day 2); **overhauled 2026-05-19** with the on-chain
 > curation-infrastructure tier (Gauntlet/Morpho/Upshift/Accountable), the Arc
 > hackathon peer set, and the testnet-only reality.

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,6 +2,8 @@
 
 **Fund-of-Funds Portfolio Agent Powered by Academic Research**
 
+> **Status:** Architecture lineage doc — **superseded for product framing** by [`user-stories.md`](user-stories.md); the architecture for everything below the product layer remains authoritative. Component-level shipped state in [`chuan-architecture-survey.md`](chuan-architecture-survey.md). Retained so reviewers can trace the design history.
+>
 > ⚠️ **Superseded for product framing.** This is the original single-vault design
 > document, retained for architecture lineage. The **canonical product spine** — and
 > the retirement of the "connect wallet → pick a risk profile" flow — is

--- a/docs/rigor-methods.md
+++ b/docs/rigor-methods.md
@@ -1,5 +1,7 @@
 # Rigor Methods — How Archimedes Stress-Tests Every Strategy
 
+> **Status:** Shipped — all four gates (DSR, PBO, walk-forward OOS, look-ahead audit) are live in [`services/rigor_evaluator.py`](../backend/archimedes/services/rigor_evaluator.py) (canonical) and gate every Tier-1 strategy. 2 Tier-1 strategies (Faber 2007, Moreira-Muir 2017) pass all four today.
+>
 > **Audience:** Judges, team members, and anyone reading a strategy passport who is not a quant.
 > **Author:** Önder Akkaya (Lead Quant)
 > **Date:** 2026-05-19

--- a/docs/specs/fusion-to-backtest-t2o2-issue.md
+++ b/docs/specs/fusion-to-backtest-t2o2-issue.md
@@ -1,6 +1,6 @@
 # Issue spec for t2o2 — Fusion-output → Backtestable Strategy DSL
 
-> **Status:** ✓ filed + closed as [#128](https://github.com/hackagora/archimedes-arcadia/issues/128) on 2026-05-23. Foundation shipped in `bd6935b` (DSL + interpreter + evaluator + 37 passing tests, using canonical `services/rigor_evaluator.py`). The three remaining wiring items (prompt extension, `_run_fusion_job` rewire, DSL reference doc) are split out into follow-on [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) — open, assigned to t2o2.
+> **Status:** ✓ filed + closed as [#128](https://github.com/hackagora/archimedes-arcadia/issues/128) on 2026-05-23. Foundation shipped in `bd6935b` (DSL + interpreter + evaluator + 37 passing tests, using canonical `services/rigor_evaluator.py`); wiring + DSL spec doc landed via follow-on [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) — closed, shipped on `main` (commit `2f7f871`).
 >
 > **This is a ready-to-file issue body, written to the standard in CLAUDE.md's
 > "agentic issue pipeline" section.** Copy/paste into a GitHub issue,

--- a/docs/specs/fusion-to-backtest-t2o2-issue.md
+++ b/docs/specs/fusion-to-backtest-t2o2-issue.md
@@ -1,5 +1,7 @@
 # Issue spec for t2o2 — Fusion-output → Backtestable Strategy DSL
 
+> **Status:** ✓ filed + closed as [#128](https://github.com/hackagora/archimedes-arcadia/issues/128) on 2026-05-23. Foundation shipped in `bd6935b` (DSL + interpreter + evaluator + 37 passing tests, using canonical `services/rigor_evaluator.py`). The three remaining wiring items (prompt extension, `_run_fusion_job` rewire, DSL reference doc) are split out into follow-on [#133](https://github.com/hackagora/archimedes-arcadia/issues/133) — open, assigned to t2o2.
+>
 > **This is a ready-to-file issue body, written to the standard in CLAUDE.md's
 > "agentic issue pipeline" section.** Copy/paste into a GitHub issue,
 > `gh issue edit <n> --add-assignee t2o2`, and the t2o2 agent will pick it up.

--- a/docs/specs/fusion-to-backtest-t2o2-issue.md
+++ b/docs/specs/fusion-to-backtest-t2o2-issue.md
@@ -14,6 +14,24 @@
 >
 > This issue closes that gap by making fusion output a structured spec that
 > the existing analytics engine can execute.
+>
+> **2026-05-22 update notes (between draft + filing):** spec aligned with
+> Phase 0–2 work that landed since this was first drafted:
+>   - The canonical rigor module is now **`backend/archimedes/services/rigor_evaluator.py`**
+>     (Önder's lane). The interpreter must integrate with that module's
+>     `compute_dsr` / `compute_pbo` / `compute_oos_sharpe` primitives (NOT the
+>     older `selection_bias.py`, which is queued for retirement under the
+>     Phase 7 dedup pass).
+>   - The streaming Generate pipeline now lives at
+>     `backend/archimedes/services/generation_pipeline.py`. Fusion-backtested
+>     output should land in the same `StrategyRecord` table as architect-path
+>     output (via `models/strategy_store.py::upsert_strategy`), so Library
+>     can render both side by side under the existing Generated tab.
+>   - The strategy lifecycle (Generated → Validated → Deployed → … per
+>     `docs/specs/strategy-lifecycle-spec.md`) applies: fusion-backtested
+>     strategies that pass rigor enter `Validated`; failures enter `Rejected`
+>     (NOT silently dropped). The user wedge depends on rejected-but-honest
+>     reporting.
 
 ---
 
@@ -210,10 +228,13 @@ fixture-based).
   `tests/services/test_strategy_architect.py::test_proposes_with_canned_backend`
   — same shape (canned LLM backend, fixture proposal, asserts on the
   returned structure).
-- For the rigor-gate integration, copy the call shape in
-  `backend/archimedes/services/strategy_provider.py` where seed strategies
-  go through `passes_rigor_gate`. The fusion_evaluator must use the *same*
-  helper, not a parallel implementation.
+- For the rigor-gate integration, use `backend/archimedes/services/rigor_evaluator.py`
+  directly — `compute_dsr(returns, num_trials)` + `compute_pbo({sid: returns})`
+  + `compute_oos_sharpe(returns)` are the canonical entry points. See
+  `backend/archimedes/services/generation_pipeline.py::_rigor_verdict_for`
+  for the working integration shape (the Phase 2 follow-up wired it for
+  agent output; fusion_evaluator should mirror that pattern). Do NOT use
+  `selection_bias.py` (older parallel impl, queued for retirement).
 - For the backtrader integration, copy one of the runnable seed strategies
   in `analytics-engine/strategies/` (e.g., `faber_sma200.py`) — that's the
   shape the interpreter must produce. The DSL→backtrader interpreter

--- a/docs/specs/generation-streaming-spec.md
+++ b/docs/specs/generation-streaming-spec.md
@@ -1,0 +1,223 @@
+# Generation Streaming Spec
+
+> **Status:** Drafted 2026-05-22 as Phase 0 of the
+> [Spine+ v2 plan](./spine-plus-v2-plan.md). Authoritative for Phase 2
+> implementation — the Generate page's SSE protocol.
+>
+> **Lineage:** Wraps [`portfolio_agent.PortfolioAgent`](../../backend/archimedes/services/portfolio_agent.py)
+> per the decision in
+> [`portfolio-constructor-decision-tree.md`](./portfolio-constructor-decision-tree.md).
+> Iterations bounded by `MAX_AGENT_ITERATIONS=12` (Day-10 default).
+
+## Why SSE not WebSocket
+
+- Generate is **one-way** — server pushes events, client subscribes.
+- SSE is plain HTTP, survives proxies, auto-reconnects in the browser.
+- The client-side state machine (idle → streaming → done/error) is simpler
+  than a bidirectional channel.
+
+If a future feature requires bidirectional (e.g., live "stop and ask the agent
+a question mid-stream"), revisit. For Phase 2 generation, SSE.
+
+## Endpoints
+
+The Phase 2 work lands in a new
+[`backend/archimedes/api/generate_routes.py`](../../backend/archimedes/api/generate_routes.py)
+(per cross-cutting principle #2 — no new routes go into `routes.py`).
+
+### `POST /api/generate/jobs`
+
+Create a generation job. Returns immediately with `job_id`; actual work runs
+in a background task.
+
+**Request body:**
+```json
+{
+  "brief": "I want a 13-week treasury alternative with low volatility",
+  "wallet_address": "0x..." 
+}
+```
+`wallet_address` is optional (anonymous Generate is allowed pre-deploy; wallet
+is required only at the vault-creation step).
+
+**Response (201):**
+```json
+{
+  "job_id": "gen_01HXYZ...",
+  "stream_url": "/api/generate/stream/gen_01HXYZ...",
+  "resume_token": "...",
+  "ttl_seconds": 900
+}
+```
+
+### `GET /api/generate/stream/{job_id}`
+
+Server-sent events. Headers:
+
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `Connection: keep-alive`
+- `X-Accel-Buffering: no` (nginx/EC2 stack — disables proxy buffering)
+
+Client may send `Last-Event-ID: <event_id>` to resume from a known point.
+
+### `POST /api/generate/jobs/{job_id}/cancel`
+
+Cancel a job. Idempotent. Emits a final `error` event with `recoverable: false`
+and `message: "cancelled_by_user"` on the open stream.
+
+## Event schema
+
+Each SSE event is `id: <monotonic_int>\nevent: <name>\ndata: <json>\n\n`.
+
+`<name>` is one of:
+
+| Event | Payload | When emitted |
+|---|---|---|
+| `job_queued` | `{ job_id, brief, ts }` | Immediately after `POST /api/generate/jobs`. |
+| `brief_validated` | `{ job_id, asset_classes, risk_appetite, time_horizon, ts }` | After LLM extracts structured intent from free-text brief. |
+| `candidates_selected` | `{ job_id, candidate_count, source_arxiv_ids: [...], ts }` | After agent selects candidate papers from corpus (typically 3-5). |
+| `agent_iteration` | `{ job_id, iteration_n, max_iterations, ts }` | At the top of every `PortfolioAgent.recommend()` loop iteration. |
+| `tool_called` | `{ job_id, tool_name, args_summary, ts }` | When the agent invokes a tool (`get_asset_stats`, `get_correlation`, `stress_test`). |
+| `tool_result` | `{ job_id, tool_name, result_summary, ts }` | After the tool returns. `result_summary` is a 1-line human-readable summary, not the full payload. |
+| `candidate_drafted` | `{ job_id, candidate_id, strategy_name, weights_preview, ts }` | When the agent produces a candidate portfolio. Multiple may fire per job (per the locked decision, agent considers N internally). |
+| `candidate_evaluated` | `{ job_id, candidate_id, rigor_verdict: { dsr, pbo, oos_sharpe, lookahead_audit_passed, passes }, ts }` | After rigor gate runs on each candidate. |
+| `best_selected` | `{ job_id, best_candidate_id, considered_count, ts }` | When the agent picks the surfaced candidate from the considered set. |
+| `trace_hashed` | `{ job_id, trace_hash, ts }` | After the reasoning trace is committed to `AgentStateStore` and its keccak256 computed. |
+| `persisted` | `{ job_id, strategy_id, redirect_url, ts }` | After `StrategyRecord` insert. `redirect_url` is `/strategy/:id`. |
+| `done` | `{ job_id, strategy_id, ts }` | Terminal success. Stream closes. |
+| `error` | `{ job_id, message, recoverable: bool, code, ts }` | Terminal failure. Stream closes. |
+
+All payloads include `ts` (ISO-8601 UTC) so the client can render a true timeline.
+
+Multi-strategy: per the locked decision, the **client surfaces the single
+`best_selected` candidate**, but the full event stream including all
+`candidate_drafted` / `candidate_evaluated` events is persisted. The strategy
+passport at `/strategy/:id` exposes a "see candidates that were rejected" link
+that replays the event history.
+
+## Reconnection semantics
+
+If the client disconnects (page reload, network blip, back-button), it can
+re-subscribe:
+
+1. Client persists `currentJobId` to `localStorage` on `job_queued`.
+2. On Generate page mount, if `localStorage.currentJobId` exists and the job's
+   TTL hasn't expired, client re-opens the stream with
+   `Last-Event-ID: <last_seen_id>`.
+3. Server replays events from Redis (key: `gen:job:{job_id}:events`, list type)
+   starting after `Last-Event-ID`.
+4. If the job already finished, the stream replays the last `done` or `error`
+   event and closes.
+
+**TTL on event log:** 15 minutes after `done`/`error`. After that, the job's
+events are gone — the user can still see the resulting strategy in Library but
+can't re-watch the stream.
+
+## Job persistence model
+
+Per-job Redis keys:
+
+| Key | Type | Contents |
+|---|---|---|
+| `gen:job:{job_id}:meta` | hash | `brief`, `wallet_address`, `created_at`, `state`, `current_iteration` |
+| `gen:job:{job_id}:events` | list | Serialized SSE events in order |
+| `gen:job:{job_id}:lock` | string | Prevents double-execution if API restarts |
+
+Frontend stores `currentJobId` in `localStorage` (cleared on `done`/`error` or
+when the user explicitly clicks "Start over").
+
+## Backpressure & ordering
+
+- Agent iterations are seconds apart, not milliseconds — no batching needed.
+- Each event flushes immediately (`flush()` after every `yield`).
+- The Redis list is the source of truth for ordering. The HTTP response writer
+  pulls from the list; the agent process pushes to it.
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Agent hits `MAX_AGENT_ITERATIONS=12` without a valid candidate | Emit `error { message: "max_iterations_exceeded", recoverable: true, code: "MAX_ITER" }`. Client offers "Regenerate" CTA. |
+| LLM API unreachable | Emit `error { message: "llm_unavailable", recoverable: true, code: "LLM_DOWN" }`. Client offers "Retry in 30s" CTA. |
+| All candidates fail rigor gate | Emit `best_selected: null` followed by `error { message: "no_candidate_passed_rigor", recoverable: true, code: "RIGOR_FAIL" }`. Client redirects to `/strategy/:id` for the **best Rejected** candidate so user can see why. |
+| Brief is gibberish or out-of-scope | Brief-validation step fails; emit `error { message: "brief_invalid", recoverable: true, code: "BRIEF_INVALID", hint: "Try mentioning an asset class or risk appetite" }`. |
+| API process restarts mid-job | On restart, scan Redis for active job locks; resume jobs whose age < TTL. Lock-without-progress for > 5 min → mark errored with `code: "STALLED"`. |
+| Client disconnects + never returns | Server completes the job and writes events to Redis; on TTL expiry, GC removes them. Strategy still ends up in Library. |
+
+## Server-side architecture
+
+```
+POST /api/generate/jobs
+        │
+        ▼
+   generate_routes.create_job()
+        │
+        ├─→ create job_id (ULID)
+        ├─→ enqueue in BackgroundTasks: run_generation_job(job_id, brief)
+        └─→ return 201 with stream_url
+
+(background)
+   run_generation_job(job_id, brief)
+        │
+        ▼
+   PortfolioAgent.recommend(brief, regime, emit=push_event_to_redis)
+        │
+        ├─→ each iteration calls emit("agent_iteration", ...)
+        ├─→ each tool call emits ...
+        └─→ final result triggers emit("done", ...) + DB insert
+
+GET /api/generate/stream/{job_id}
+        │
+        ▼
+   StreamingResponse(event_generator(job_id, last_event_id))
+        │
+        └─→ tail Redis list; yield each new event; close on `done`/`error`
+```
+
+## Frontend integration sketch
+
+```jsx
+// ui/src/components/Generate.jsx (Phase 2)
+const [events, setEvents] = useState([])
+const [job, setJob] = useState(null)
+
+async function submitBrief(brief) {
+  const res = await fetch('/api/generate/jobs', { method: 'POST', body: JSON.stringify({ brief }) })
+  const { job_id, stream_url } = await res.json()
+  localStorage.setItem('currentJobId', job_id)
+  setJob({ id: job_id })
+
+  const es = new EventSource(stream_url)
+  es.addEventListener('agent_iteration', e => setEvents(prev => [...prev, JSON.parse(e.data)]))
+  es.addEventListener('best_selected', e => setEvents(prev => [...prev, JSON.parse(e.data)]))
+  es.addEventListener('done', e => {
+    const { redirect_url } = JSON.parse(e.data)
+    localStorage.removeItem('currentJobId')
+    navigate(redirect_url)
+    es.close()
+  })
+  es.addEventListener('error', e => { /* surface message, offer retry */ })
+}
+
+// On mount: if localStorage.currentJobId exists, re-subscribe.
+```
+
+## Acceptance
+
+A frontend dev (Marten / Daniel R.) can build the streaming UI from this doc
+alone — no further API design questions. A backend dev (Daniel R. / Chuan)
+can implement `generate_routes.py` and the Redis-backed event log without
+re-deriving the event schema.
+
+## Open questions
+
+1. **Event log TTL** — 15 minutes after terminal state. Long enough? Should we
+   keep all events forever for forensic value (link to `/reasoning` from a
+   strategy passport always works)?
+2. **`tool_result` payload size** — for `stress_test`, the raw result can be
+   ~10 KB. Do we include it inline (the `result_summary` field truncates) or
+   surface a `tool_result_full_url`?
+3. **Anonymous vs authenticated rate limiting** — anonymous users get N free
+   generates? Today: no rate limit. Probably fine for hackathon scope; flag
+   for v1.5.

--- a/docs/specs/kb-integration-spec.md
+++ b/docs/specs/kb-integration-spec.md
@@ -1,0 +1,279 @@
+# KB Integration Spec
+
+> **Status:** Drafted 2026-05-22 as Phase 0 of the
+> [Spine+ v2 plan](./spine-plus-v2-plan.md). Authoritative for Phase 3c
+> implementation.
+>
+> **Lineage:** Wires the existing
+> [`submodules/KnowledgeBase/`](../../submodules/KnowledgeBase/) pipeline
+> (Dan's scientific-paper analyzer — PyMuPDF + SPECTER2 + HDBSCAN/BERTopic +
+> REBEL/SciSpacy) onto the Archimedes corpus. **No re-implementation.** The
+> spec describes how to invoke the existing scripts and where outputs persist.
+
+## Non-goals
+
+- Re-writing the KB pipeline in `backend/archimedes/`. The submodule is the
+  reference implementation; we *call into it*, we don't fork it.
+- Real-time KB updates. The pipeline runs in batches; live corpus search uses
+  the persisted artifacts.
+- Replacing the existing `data/corpus/text/` PDF + extract layer. KB consumes
+  what's already there.
+
+## KB submodule entry points
+
+From [`submodules/KnowledgeBase/papers_analysis/`](../../submodules/KnowledgeBase/papers_analysis/):
+
+| File | Role |
+|---|---|
+| `extract.py` | PyMuPDF text extraction (we already do this in `scripts/hydrate_corpus.py`; KB's extract is the reference but we don't re-run it). |
+| `metadata.py` | Paper-corpus schema — maps to our `papers` table; useful as a column reference. |
+| `vectorize.py` | SPECTER2 embeddings — produces `N×768` numpy matrix + paper-id index. **Primary entry for Phase 3c.** |
+| `cluster.py` | HDBSCAN density-based clustering on the embeddings. Produces `cluster_id` per paper; BERTopic topic-label path lives here too. |
+| `knowledge_graph.py` | REBEL + SciSpacy entity-relation extraction. Produces `(subject, relation, object)` triples per paper. |
+| `graph.py` | Aggregates per-paper triples into a corpus-level graph (nodes = entities, edges = relations). |
+| `summarize.py` | Ollama-driven summarization. **Skip** — we already summarize via Claude in our own pipeline; KB's summary path is legacy. |
+| `stats.py`, `visualize.py` | Auxiliary; not part of production wiring. |
+
+## Pipeline invocation
+
+A new file: `backend/archimedes/scripts/run_kb_pipeline.py`
+
+```python
+"""Single-shot KB pipeline runner. Operator-triggered for the first run."""
+import sys, json
+from pathlib import Path
+
+# Add submodule to sys.path (no install — KB has no setup.py we want to use)
+KB_ROOT = Path(__file__).parents[3] / "submodules/KnowledgeBase"
+sys.path.insert(0, str(KB_ROOT))
+
+from papers_analysis import vectorize, cluster, knowledge_graph, graph
+
+def run(corpus_text_dir: Path, artifact_dir: Path) -> dict:
+    """
+    1. Embed every text file in corpus_text_dir via SPECTER2
+         → artifact_dir/embeddings.npy + ids.json
+    2. Cluster via HDBSCAN
+         → artifact_dir/clusters.json {paper_id: cluster_id}
+    3. BERTopic topic labels
+         → artifact_dir/topics.json {cluster_id: human_label}
+    4. KG triples via REBEL+SciSpacy
+         → artifact_dir/kg_triples.jsonl
+    5. Aggregate into corpus graph
+         → artifact_dir/kg_graph.json
+    Returns: a manifest dict with counts and the run timestamp.
+    """
+    ...
+```
+
+Run manually for the first pass:
+```bash
+python -m archimedes.scripts.run_kb_pipeline
+# → reads from data/corpus/text/
+# → writes to /srv/corpus-artifact/ (docker volume)
+```
+
+## Output persistence
+
+KB outputs land in **two places**:
+
+### 1. Named docker volume — `archimedes-corpus-artifact`
+
+Heavy binary artifacts that don't belong in Postgres:
+
+| File | Format | Size estimate (10k papers) | Used by |
+|---|---|---|---|
+| `embeddings.npy` | NumPy `float32 [N, 768]` | ~30 MB | `/api/corpus/graph` (UMAP on the fly), nearest-neighbor search |
+| `ids.json` | JSON `[arxiv_id, ...]` parallel to embeddings | ~500 KB | Embedding row-to-paper lookup |
+| `clusters.json` | JSON `{arxiv_id: cluster_id}` | ~500 KB | Bulk-cached fast lookup |
+| `topics.json` | JSON `{cluster_id: {label, top_terms: [...]}}` | ~50 KB | Topic display in Corpus Overview |
+| `kg_triples.jsonl` | One JSON object per (paper, triple) | ~50 MB | KG search, citation aggregation |
+| `kg_graph.json` | Aggregated `{nodes: [...], edges: [...]}` | ~5 MB | KG explorer tab |
+| `manifest.json` | `{run_ts, paper_count, cluster_count, kg_node_count, kg_edge_count}` | tiny | Surfaced in `/api/corpus/overview` |
+
+Mounted into the backend container at `/srv/corpus-artifact`. Read-only at
+runtime; writable only by the KB runner.
+
+### 2. Postgres `papers` table — denormalized fast-path columns
+
+Added via the existing idempotent `ALTER TABLE` pattern in
+[`backend/archimedes/db.py`](../../backend/archimedes/db.py) `init_db()`:
+
+```sql
+ALTER TABLE papers ADD COLUMN IF NOT EXISTS cluster_id INTEGER;
+ALTER TABLE papers ADD COLUMN IF NOT EXISTS topic_label TEXT;
+ALTER TABLE papers ADD COLUMN IF NOT EXISTS content_hash TEXT;
+CREATE INDEX IF NOT EXISTS idx_papers_cluster ON papers (cluster_id);
+```
+
+Note: these `ALTER TABLE` statements already exist in `db.py` (added during the
+strip-to-spine work to unblock `/api/papers/`), but the matching ORM columns on
+`PaperRecord` in [`backend/archimedes/models/paper.py`](../../backend/archimedes/models/paper.py)
+are **not yet defined**. Phase 3c adds them to the ORM so they round-trip
+correctly.
+
+These columns are denormalized copies of what's in the artifact volume; they
+exist so DB-only fast paths (`GET /api/papers/?cluster_id=42`) don't require
+artifact mounting on the API container.
+
+### 3. New tables for KG persistence
+
+```sql
+CREATE TABLE IF NOT EXISTS kg_entities (
+  id SERIAL PRIMARY KEY,
+  canonical_name TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  paper_count INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (canonical_name, entity_type)
+);
+CREATE TABLE IF NOT EXISTS kg_relations (
+  id SERIAL PRIMARY KEY,
+  subject_id INTEGER REFERENCES kg_entities (id),
+  relation TEXT NOT NULL,
+  object_id INTEGER REFERENCES kg_entities (id),
+  paper_arxiv_id TEXT REFERENCES papers (arxiv_id) ON DELETE CASCADE,
+  confidence REAL,
+  UNIQUE (subject_id, relation, object_id, paper_arxiv_id)
+);
+CREATE INDEX IF NOT EXISTS idx_kg_relations_paper ON kg_relations (paper_arxiv_id);
+CREATE INDEX IF NOT EXISTS idx_kg_relations_subject ON kg_relations (subject_id);
+```
+
+These let us answer "which papers mention X?" and "what does Y do?" without
+loading the full graph JSON.
+
+## Scheduled re-runs — `kb_runner.py`
+
+A new long-running service, mirroring
+[`backend/archimedes/chain/oracle_runner.py`](../../backend/archimedes/chain/oracle_runner.py)
+in shape:
+
+`backend/archimedes/services/kb_runner.py`
+
+```python
+"""KB pipeline scheduler. Standalone process; runs in its own container."""
+import asyncio, time, json
+from pathlib import Path
+
+POLL_INTERVAL_S = 60 * 60        # check hourly
+MIN_NEW_PAPERS  = 100            # rerun if N new papers since last run
+MAX_DAYS_SINCE  = 7              # ...or N days have passed
+
+async def main():
+    while True:
+        if should_rerun():
+            run_pipeline()        # blocks; that's fine — own container
+        await asyncio.sleep(POLL_INTERVAL_S)
+
+def should_rerun() -> bool:
+    manifest = load_manifest()    # /srv/corpus-artifact/manifest.json
+    new_papers = count_papers_since(manifest["run_ts"])
+    days_since = (now() - manifest["run_ts"]).days
+    return new_papers >= MIN_NEW_PAPERS or days_since >= MAX_DAYS_SINCE
+```
+
+### New docker-compose service
+
+```yaml
+kb-runner:
+  build: .
+  command: python -m archimedes.services.kb_runner
+  volumes:
+    - archimedes-corpus-text:/srv/corpus-text:ro
+    - archimedes-corpus-artifact:/srv/corpus-artifact:rw
+  environment:
+    - DATABASE_URL=${DATABASE_URL}
+    - KB_MIN_NEW_PAPERS=100
+    - KB_MAX_DAYS_SINCE=7
+  depends_on:
+    - postgres
+  deploy:
+    resources:
+      limits:
+        memory: 8G
+```
+
+The 8 GB limit accommodates SPECTER2 + REBEL model weights (~6 GB combined).
+**Does not run on the api container** — the API stays small and responsive.
+
+### Re-run trigger
+
+`(N new papers since last run) ≥ 100  OR  (days elapsed) ≥ 7` — whichever fires
+first. Both knobs env-configurable.
+
+### Long-run UX
+
+A KB run on 10k papers takes hours (SPECTER2 ~71 papers/sec; SciSpacy slower).
+During a run:
+
+1. `kb_runner` writes `/srv/corpus-artifact/state.json` with
+   `{phase: "embedding", progress: 0.4, started_at: ...}`.
+2. API exposes `GET /api/corpus/runner-state` reading that file.
+3. `/corpus` page surfaces a "Pipeline running — phase: embedding (40%)" banner.
+4. Existing artifact (previous run's outputs) stays mounted — corpus continues
+   to serve the **previous** snapshot until the new run completes atomically
+   (write-to-tmpdir + symlink-swap on success).
+
+## API endpoints (Phase 3c)
+
+Land in new `backend/archimedes/api/corpus_routes.py` (per cross-cutting
+principle #2 — no new routes go into `routes.py`):
+
+| Endpoint | Returns |
+|---|---|
+| `GET /api/corpus/overview` | `{paper_count, cluster_count, top_topics: [...], last_run_ts, kb_pipeline_state}` |
+| `GET /api/corpus/graph` | UMAP 2D projection of embeddings; `{points: [{arxiv_id, x, y, cluster_id}], topics: {...}}` |
+| `GET /api/corpus/kg/entities?q=` | Search entities by canonical name |
+| `GET /api/corpus/kg/entity/{id}` | Entity detail + adjacent relations |
+| `GET /api/corpus/kg/paper/{arxiv_id}` | All triples for one paper |
+| `GET /api/corpus/runner-state` | KB pipeline phase + progress |
+
+Existing `GET /api/papers/` and `GET /api/papers/:arxiv_id` are unchanged but
+now return populated `cluster_id` / `topic_label` columns.
+
+## Frontend wiring (Phase 3b + 3c)
+
+Per [`page-roles-spec.md`](./page-roles-spec.md), `/corpus` has four tabs:
+
+1. **Catalog** (Phase 3b — paper list, no KB dependency)
+2. **Overview** (Phase 3c, uses `/api/corpus/overview`)
+3. **Graph** (Phase 3c, uses `/api/corpus/graph`)
+4. **Knowledge Graph** (Phase 3c, uses `/api/corpus/kg/*`)
+
+Phase 3b ships first because it works without KB; 3c lights up Tabs 2-4 once
+the first KB run completes.
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| KB run crashes mid-pipeline | Atomic-swap protects the previous snapshot. Failed run logged; runner sleeps then retries on next poll. |
+| Artifact volume corruption | `/api/corpus/runner-state` reports `phase: error`; UI banner reads "Corpus artifact corrupted; KB pipeline will re-run". Manual trigger: `docker compose restart kb-runner`. |
+| Submodule out-of-sync | KB pipeline pinned by submodule SHA. `git submodule update` is operator-triggered, never automated, so behavior changes are reviewable. |
+| New paper has no PDF/text | Skipped by `extract.py` upstream; KB never sees it. Surfaces as a NULL `cluster_id` row in Library. |
+| Embedding model download fails | KB container fails health check; alert via docker-compose. Doesn't affect API. |
+
+## Acceptance
+
+A Phase 3c implementer (Dan + Daniel R.) can:
+
+- Identify which KB submodule entry point to call for each pipeline stage.
+- Set up the docker-compose service without re-deriving the env contract.
+- Wire the `/api/corpus/*` endpoints to the right artifact files.
+- Know what UI state to render during a long-running pipeline pass.
+
+## Open questions
+
+1. **`kb_runner` as docker service or host cron?** Docker service matches the
+   existing pattern (oracle_runner) and is portable; host cron is simpler.
+   Recommendation: docker service.
+2. **First-run trigger semantics** — auto on first deploy, or operator-only?
+   Recommendation: operator (`docker compose run --rm kb-runner python -m
+   archimedes.scripts.run_kb_pipeline`) so the GPU/RAM spike is intentional.
+3. **Rollback story for a bad pipeline run** — atomic swap covers "this run
+   crashed"; the harder case is "this run produced bad clusters silently."
+   Recommendation: keep last 3 snapshots; expose `KB_SNAPSHOT_TS` env for
+   emergency pin.
+4. **KG entity canonicalization** — REBEL outputs raw spans, but "TSMOM" and
+   "time-series momentum" should canonicalize to the same entity. Manual alias
+   table seeded by Dan, with auto-canonicalization via SPECTER as v1.5.

--- a/docs/specs/page-roles-spec.md
+++ b/docs/specs/page-roles-spec.md
@@ -1,0 +1,231 @@
+# Page Roles Spec
+
+> **Status:** Drafted 2026-05-22 as Phase 0 of the
+> [Spine+ v2 plan](./spine-plus-v2-plan.md). Authoritative for the spine UI;
+> supersedes any conflicting layout description in earlier docs.
+>
+> **Lineage:** Locks the spine narrowed to 7 nav items in the strip-to-spine
+> commit (`d4dd465`) plus the v2 additions (Explore, Strategy passport). Pairs
+> with [`vault-semantics-spec.md`](./vault-semantics-spec.md) and
+> [`strategy-lifecycle-spec.md`](./strategy-lifecycle-spec.md).
+
+## Scope
+
+Each spine page has exactly one job. **No two pages overlap.** If a screen needs
+something a different page owns, it links out — it does not re-implement.
+
+Pages in spine order:
+
+```
+/  →  /explore  →  /generate  →  /library  →  /strategy/:id  →  /portfolio  →  /reasoning  →  /corpus  →  /learnings
+```
+
+---
+
+## `/` — Landing
+
+**One-sentence purpose:** Marketing surface and entry point; explains the
+product and offers the two primary CTAs (Generate, browse Library).
+
+**Primary API calls:** `GET /api/config/contracts`, `GET /api/agent/status`,
+`GET /api/regime/current`, `GET /api/strategies/` (count only).
+
+**NOT for:** Wallet-gated actions. Strategy detail. Trace inspection. (The Hero
+CTA navigates to `/generate`, which itself prompts wallet connection.)
+
+**Links out to:** `/generate` (primary CTA), `/library` (secondary CTA),
+`/explore` (new in v2, asset discovery).
+
+---
+
+## `/explore` — Explore (NEW in v2)
+
+**One-sentence purpose:** Read-only asset discovery — what synthetic RWAs are
+available, what their current oracle prices look like, plain-English summary
+stats. No wallet required.
+
+**Primary API calls:** new `GET /api/explore/assets` (synth list + oracle
+prices), `GET /api/explore/asset/:symbol/stats` (plain-English stats).
+
+**NOT for:** Strategy generation, trading, holding analytics. Explore is the
+"what is the universe?" screen — the agent's tradeable asset list, demystified.
+
+**Links out to:** `/generate?seed_asset=:symbol` so a user who finds an
+interesting asset can immediately ask for a strategy around it.
+
+**Why new:** the previous "Trade" page conflated discovery with execution and
+became a placeholder. Splitting discovery out makes the spine cleaner and gives
+unconnected visitors something real to look at.
+
+---
+
+## `/generate` — Generate
+
+**One-sentence purpose:** Streaming strategy generation — user submits a brief,
+sees the agent's reasoning unfold via SSE, lands on a Validated/Rejected strategy.
+
+**Primary API calls:** `POST /api/generate/jobs` (create job), `GET
+/api/generate/stream/:job_id` (SSE), `POST /api/generate/jobs/:job_id/cancel`.
+
+**NOT for:** Browsing already-generated strategies (that's Library). Persistent
+strategy detail (that's `/strategy/:id`). Displaying multi-strategy carousels
+(per the locked decision, the agent considers N internally but surfaces 1).
+
+**Links out to:** On success, redirects to `/strategy/:id` for the generated
+strategy. On `error` event with `recoverable: true`, offers in-place Regenerate.
+
+**Wallet:** semi-hard gate — page is reachable without wallet, but submitting
+a brief prompts connection.
+
+---
+
+## `/library` — Library
+
+**One-sentence purpose:** Outcome of generation. Compact table of all strategies
+the user has generated (Generated tab) plus the curated paper-grounded examples
+(Examples tab).
+
+**Primary API calls:** `GET /api/strategies/` (examples), `GET
+/api/strategies/generated` (user-generated).
+
+**NOT for:** Reasoning trace inspection (that's `/reasoning`). Vault state
+(that's `/portfolio`). Strategy detail (that's `/strategy/:id`). The Library
+is index-only — names, status pills, rigor verdict at-a-glance, deploy CTA.
+
+**Links out to:** `/strategy/:id` on row click (passport detail), `/generate`
+on empty Generated tab.
+
+**Tab default:** Generated for connected wallets (their work); Examples for
+disconnected.
+
+---
+
+## `/strategy/:id` — Strategy Passport (NEW in v2)
+
+**One-sentence purpose:** Full passport for a single strategy — paper provenance,
+backtest metrics, rigor verdict (with deltas to paper claims), DSL preview,
+Deploy CTA (state-dependent).
+
+**Primary API calls:** `GET /api/strategies/:id`, `GET /api/traces/:hash` (for
+the reasoning trace that produced it), `GET /api/strategies/:id/papers` (cited
+arxiv ids → catalog rows).
+
+**NOT for:** Vault deployment UI (that's a modal opened from this page). Live
+performance tracking (that's `/portfolio`).
+
+**Links out to:** `CreateVaultModal` (in-page modal; not a route), `/reasoning?
+trace_hash=:hash`, `/corpus?arxiv_id=:id` for cited papers.
+
+**State-driven CTAs:**
+
+- `Generated` → "Run rigor gate" (auto-fires if not already)
+- `Validated` → "Deploy as vault →" (primary)
+- `Rejected` → "See why" (expands rigor deltas inline)
+- `Deployed` / `Active` → "View vault →" (`/portfolio`)
+- `Completed` → "View learnings →" (`/learnings`)
+- `Expired` → "Regenerate →" (`/generate` with this brief as seed)
+
+---
+
+## `/portfolio` — Portfolio
+
+**One-sentence purpose:** The user's vault footprint — which vaults they have
+deployed/active/completed, current NAV, agent activity feed, stress scenarios.
+
+**Primary API calls:** `GET /api/vaults/?wallet=:addr`, `GET /api/agent/status`,
+`GET /api/regime/current`, `GET /api/traces?wallet=:addr` (recent traces for
+this user's vaults).
+
+**NOT for:** Strategy generation. Strategy detail (links out to `/strategy/:id`).
+Library browsing. Cross-user data — strictly the connected wallet's vaults.
+
+**Links out to:** `/strategy/:id` for each vault's underlying strategy,
+`/reasoning?vault=:addr` for the vault's trace timeline, `/learnings` for
+completed-vault retrospectives.
+
+**Wallet:** hard gate — page is meaningless without a connected wallet.
+
+---
+
+## `/reasoning` — Reasoning
+
+**One-sentence purpose:** Trace browser. Anchored trace hashes, off-chain content,
+chronological timeline. Read-only.
+
+**Primary API calls:** `GET /api/traces` (paginated), `GET /api/traces/:hash`,
+`GET /api/traces/:hash/verify` (recompute + compare on-chain anchor).
+
+**NOT for:** Strategy listing (those live in Library). Vault state (Portfolio).
+Trace publishing (no UI surface — traces are anchored automatically by the agent
+runner; the dev-test publish form was removed in the strip-to-spine commit).
+
+**Links out to:** `/strategy/:id?trace=:hash` (back-navigate to the strategy
+this trace belongs to), `/portfolio?vault=:addr` (vault context).
+
+---
+
+## `/corpus` — Corpus Explorer
+
+**One-sentence purpose:** Paper catalog + corpus-level overview. Browse the
+q-fin corpus, see how it's clustered, drill into specific papers and the
+strategies that cite them.
+
+**Primary API calls:** `GET /api/papers/`, `GET /api/papers/:arxiv_id`, `GET
+/api/corpus/overview` (cluster counts, top topics), `GET /api/corpus/graph`
+(scatter coords from SPECTER2 embeddings — populated by Phase 3c KB pipeline).
+
+**NOT for:** Strategy generation (that's `/generate`, though a paper detail page
+deep-links to `/generate?seed_arxiv=:id`). Personal library (Library).
+
+**Tabs:**
+- **Catalog** (default) — Papers.app-style three-pane list/detail (Phase 3b).
+- **Overview** — Cluster counts + topic labels (plain-English q-fin categories).
+- **Graph** — 2D scatter of embeddings (Phase 3c).
+- **Knowledge Graph** — Entity/relation explorer (Phase 3c).
+
+**Links out to:** `/generate?seed_arxiv=:id` for paper detail Generate-CTA,
+`/strategy/:id` for "strategies citing this paper".
+
+---
+
+## `/learnings` — Learnings
+
+**One-sentence purpose:** Post-hoc retrospective on Completed vaults — realized
+P&L, what the agent actually did, what it predicted vs what happened.
+
+**Primary API calls:** `GET /api/vaults/?state=completed&wallet=:addr`, `GET
+/api/learnings/:vault_address` (LLM-generated retrospective).
+
+**NOT for:** Active vault monitoring (Portfolio). Strategy detail. Browsing
+example/seeded strategies.
+
+**Empty state:** honest copy — "Strategies are time-bound. When your first vault
+completes, its retrospective appears here." Links to `/generate`.
+
+**Wallet:** hard gate.
+
+---
+
+## Acceptance
+
+For every page X above:
+
+- Reading X's "One-sentence purpose" and "NOT for" determines whether a piece of
+  UI belongs on X or somewhere else.
+- Library never lists traces. Reasoning never lists strategies. Portfolio never
+  lists examples. Explore never appears on Portfolio.
+- The 7 nav items in the strip-to-spine commit map 1:1 to a page above (Home,
+  Generate, Library, Corpus, Portfolio, Reasoning, Learnings). Explore is the
+  v2 addition (8th nav slot). `/strategy/:id` is route-only (not a nav item;
+  reached via Library / Generate redirect / Portfolio links).
+
+## Open questions
+
+1. **Explore as nav vs deep-link only** — should Explore be a top nav slot, or
+   only reachable from Landing CTAs and Generate's "seed asset" field?
+2. **Strategy passport modal vs full route** — `/strategy/:id` is currently a
+   full route per this spec. Should it instead open as a Library-overlay modal
+   so users don't lose scroll position?
+3. **Learnings empty state** — should we surface example-strategy retrospectives
+   ("here's what TSMOM would have done in Q1 2026") to give the page something
+   real for unconnected wallets?

--- a/docs/specs/phase7-llm-backend-unification-t2o2-issue.md
+++ b/docs/specs/phase7-llm-backend-unification-t2o2-issue.md
@@ -1,6 +1,6 @@
 # Issue spec for t2o2 — Unify LLM backends on `llm_backend.py`
 
-> **Status:** filed as [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+> **Status:** ✓ filed + closed as [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) on 2026-05-23 — shipped on `main` (commit `dc91b43`). This file is the spec source-of-truth; PR archive lives on the issue.
 >
 > **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
 >

--- a/docs/specs/phase7-llm-backend-unification-t2o2-issue.md
+++ b/docs/specs/phase7-llm-backend-unification-t2o2-issue.md
@@ -1,5 +1,7 @@
 # Issue spec for t2o2 — Unify LLM backends on `llm_backend.py`
 
+> **Status:** filed as [#130](https://github.com/hackagora/archimedes-arcadia/issues/130) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+>
 > **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
 >
 > **Why this exists:** `services/llm_backend.py` defines the canonical

--- a/docs/specs/phase7-llm-backend-unification-t2o2-issue.md
+++ b/docs/specs/phase7-llm-backend-unification-t2o2-issue.md
@@ -1,0 +1,119 @@
+# Issue spec for t2o2 — Unify LLM backends on `llm_backend.py`
+
+> **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
+>
+> **Why this exists:** `services/llm_backend.py` defines the canonical
+> `LLMBackend` Protocol + provider implementations (Anthropic, Anthropic-
+> compatible, OpenAI, Ollama, Canned fallback). BUT two other modules
+> (`strategy_architect.py`, `strategy_fusion.py`) **each define their own
+> parallel** `LLMBackend` Protocol + `ClaudeBackend` + `CannedBackend` —
+> three copies of the same abstraction. The new `portfolio_agent.py`
+> (Day-10) correctly uses `llm_backend.py`, and the Phase 2 `_validate_brief`
+> step also uses it — so canonical usage is already established. This issue
+> migrates the two stragglers.
+
+---
+
+## APIN - Backend - Unify all LLM backend usage on `services/llm_backend.py`
+
+## Summary
+
+Three parallel `LLMBackend` Protocol + provider implementations exist:
+
+| File | Lines | Implements |
+|---|---|---|
+| `services/llm_backend.py` | 307 | **Canonical.** AnthropicBackend, AnthropicCompatibleBackend, OpenAIBackend, OllamaBackend, CannedBackend. `make_llm_backend()` factory. |
+| `services/strategy_architect.py` | 411 | Owns its own `LLMBackend` Protocol + `ClaudeBackend` + `CannedBackend`. |
+| `services/strategy_fusion.py` | 650 | Owns its own `LLMBackend` Protocol + `ClaudeBackend` + `CannedBackend`. |
+
+This issue: delete the duplicate Protocol+backends from `strategy_architect.py`
+and `strategy_fusion.py`. Both modules import from `llm_backend.py` going
+forward.
+
+Confirmed-clean reference patterns:
+- `services/portfolio_agent.py` already uses `llm_backend.py` via `make_llm_backend()`.
+- `services/generation_pipeline.py::_validate_brief` (Phase 2 follow-up) uses
+  the same pattern.
+
+## Scope (exact files)
+
+Files to modify:
+- `backend/archimedes/services/strategy_architect.py` — delete the inline
+  `LLMBackend`, `ClaudeBackend`, `CannedBackend`. Import from
+  `archimedes.services.llm_backend`. Any caller-facing signature (`propose`,
+  the result dataclasses) MUST stay identical.
+- `backend/archimedes/services/strategy_fusion.py` — same migration. The
+  fusion module's `LLMBackend` was slightly different (it carried a
+  `model_id` property the architect's didn't); confirm the canonical
+  Protocol exposes the same property, add if missing.
+- `backend/archimedes/services/llm_backend.py` — add a `model_id`
+  property to the Protocol IF and ONLY IF fusion's existing Protocol has
+  it and the canonical one doesn't. (As of 2026-05-22 both have it; verify.)
+
+Files to add a thin test for:
+- `backend/tests/services/test_llm_backend_unification.py` — assert that
+  `strategy_architect` and `strategy_fusion` use the canonical Protocol
+  by checking `isinstance(architect._backend, LLMBackend)` (the canonical
+  one from `llm_backend.py`).
+
+Files to NOT touch:
+- `services/portfolio_agent.py`, `services/generation_pipeline.py` — already
+  canonical.
+- Any frontend file. The migration is pure backend internals.
+
+## Acceptance criteria
+
+- [ ] **Only one `LLMBackend` Protocol class declaration in the backend:**
+  `grep -rn "^class LLMBackend" backend/` → exactly one line, pointing at
+  `services/llm_backend.py`.
+- [ ] **No duplicate ClaudeBackend/CannedBackend classes:**
+  `grep -rn "^class ClaudeBackend\|^class CannedBackend" backend/` → at most
+  one line each (in `services/llm_backend.py`).
+- [ ] **All tests still green:**
+  `pytest -q --deselect backend/tests/test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults --deselect backend/tests/test_api_routes.py::TestAdvisorRoutes::test_advisor_redis_unavailable`
+  → 307+ passed.
+- [ ] **Existing canned/fixture tests in architect + fusion still pass** —
+  the unified `CannedBackend` from `llm_backend.py` must accept the same
+  init kwargs and produce the same fixture-mode output.
+- [ ] **`make_llm_backend()` is used in production paths only** — fixtures
+  and tests inject backends directly, never via the factory. No regression
+  on test isolation.
+
+## Verify
+
+```bash
+grep -rn "^class LLMBackend\|^class ClaudeBackend\|^class CannedBackend" backend/
+# Expect: exactly the three in services/llm_backend.py
+pytest -q backend/tests/services/test_strategy_architect.py backend/tests/services/test_strategy_fusion.py
+# Should pass without any modifications to the test files themselves.
+```
+
+## Anti-goals
+
+- Do NOT broaden scope to add new backends (OpenRouter, etc.) — separate issue.
+- Do NOT change the `propose()` / fusion result dataclasses — they are
+  the frontend contract.
+- Do NOT remove the `CannedBackend` from `llm_backend.py`. It's the
+  test-default and is wired into the factory's fallback.
+- Do NOT alter `LLM_PROVIDER` env var semantics.
+
+## Precedent / shape to copy
+
+- For the import migration shape, look at how
+  `services/portfolio_agent.py::PortfolioAgent.__init__` accepts
+  `backend: LLMBackend | None = None` and defaults via `make_llm_backend()`.
+  Architect and fusion should follow that exact constructor shape.
+- For the fixture-injection test pattern, copy
+  `backend/tests/services/test_strategy_architect.py::test_proposes_with_canned_backend`.
+
+## Out of scope
+
+- Provider extensions (Bedrock, Vertex AI) — file a new issue if needed.
+- Streaming/tool-use abstractions at the LLMBackend layer (portfolio_agent
+  uses the raw Anthropic SDK directly because the Protocol seam is text-in-
+  text-out only; widening the Protocol is a separate design call).
+
+## Owner suggestion
+
+t2o2 executes. Daniel R. or Dan reviews — the changes touch two modules
+they both have context on.

--- a/docs/specs/phase7-portfolio-constructor-retirement-t2o2-issue.md
+++ b/docs/specs/phase7-portfolio-constructor-retirement-t2o2-issue.md
@@ -1,6 +1,6 @@
 # Issue spec for t2o2 — Retire `portfolio_constructor.py` + `kelly_portfolio.py`
 
-> **Status:** filed as [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+> **Status:** ✓ filed + closed as [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) on 2026-05-23 — shipped on `main` (commit `a4a09fb`); deprecated constructors moved to `services/_deprecated/`. This file is the spec source-of-truth; PR archive lives on the issue.
 >
 > **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
 >

--- a/docs/specs/phase7-portfolio-constructor-retirement-t2o2-issue.md
+++ b/docs/specs/phase7-portfolio-constructor-retirement-t2o2-issue.md
@@ -1,0 +1,130 @@
+# Issue spec for t2o2 — Retire `portfolio_constructor.py` + `kelly_portfolio.py`
+
+> **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
+>
+> **Why this exists:** the Phase 0 decision tree
+> ([`docs/specs/portfolio-constructor-decision-tree.md`](portfolio-constructor-decision-tree.md))
+> already named the canonical top-level constructor (`portfolio_agent.py`)
+> and the math leaf (`portfolio_optimizer.py`). It also named the two
+> deprecated modules: `portfolio_constructor.py` and `kelly_portfolio.py`.
+> Both have **zero production call sites** today (verified via grep) — they
+> only survive because the `IPortfolioConstructor` Protocol still references
+> them indirectly. This issue executes the spec: retire them cleanly.
+
+---
+
+## APIN - Backend - Retire deprecated portfolio constructors per decision-tree spec
+
+## Summary
+
+Per [`docs/specs/portfolio-constructor-decision-tree.md`](portfolio-constructor-decision-tree.md):
+
+| File | Status per spec | Production callers as of 2026-05-22 |
+|---|---|---|
+| `services/portfolio_agent.py` (850 lines) | Canonical top-level | `routes.py:677` (live) |
+| `services/portfolio_optimizer.py` (488 lines) | Canonical math leaf | `routes.py:509, 1056, 1259` (live) |
+| `services/portfolio_constructor.py` (285 lines) | **Deprecated** | None (test-only) |
+| `services/kelly_portfolio.py` (505 lines) | **Deprecated** | None (test-only) |
+
+This issue: retire the two deprecated modules. Lift any unique Kelly math
+worth keeping into `portfolio_optimizer.py` BEFORE deletion (the spec
+flags `kelly_size(weights, edge_estimates) → scaled_weights` as the kind
+of helper that might be worth saving — Önder to confirm).
+
+## Scope (exact files)
+
+Files to modify:
+- `backend/archimedes/services/portfolio_optimizer.py` — add any
+  Kelly-specific math worth preserving as pure functions (e.g.
+  `kelly_size`, `risk_parity_weights`). Each addition has its own unit test.
+- `backend/archimedes/interfaces/__init__.py` — keep `IPortfolioConstructor`
+  exported (the Protocol still has callers via the LLM-unavailable fallback
+  path described in the decision-tree spec). The Protocol itself stays.
+
+Files to move (to `backend/archimedes/services/_deprecated/`):
+- `backend/archimedes/services/portfolio_constructor.py`
+- `backend/archimedes/services/kelly_portfolio.py`
+
+Files to update:
+- `backend/tests/services/test_kelly_portfolio.py` — either migrate the
+  tests to exercise the lifted helpers in `portfolio_optimizer.py`, or
+  delete if the lifted set covers the math.
+- `backend/tests/services/test_portfolio_constructor.py` (if it exists) —
+  same migration.
+
+Files to NOT touch:
+- `services/portfolio_agent.py`, `services/portfolio_optimizer.py`
+  (canonical — only the targeted Kelly additions).
+- Any frontend file. Generate/Library UX is unchanged.
+
+After one release cycle confirms no consumers (single PR cycle on the
+hackathon timeline — i.e. when t2o2's PR merges + the next test run
+passes), the `_deprecated/` directory can be deleted in a follow-up PR.
+
+## Acceptance criteria
+
+- [ ] **Grep-clean:**
+  `grep -rn "from archimedes.services.portfolio_constructor\|from archimedes.services.kelly_portfolio" backend/` (excluding `_deprecated/`) → empty
+- [ ] **Files relocated, not deleted:**
+  `ls backend/archimedes/services/_deprecated/portfolio_constructor.py backend/archimedes/services/_deprecated/kelly_portfolio.py`
+  → both present
+- [ ] **Unique Kelly math preserved:** any function `compute_*` /
+  `kelly_*` / `risk_parity_*` referenced in `kelly_portfolio.py` and NOT
+  duplicating `portfolio_optimizer.py` is now in `portfolio_optimizer.py`
+  with its own test.
+- [ ] **All tests pass:**
+  `pytest -q --deselect backend/tests/test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults --deselect backend/tests/test_api_routes.py::TestAdvisorRoutes::test_advisor_redis_unavailable`
+  → 307+ passed.
+- [ ] **API responses unchanged:** any endpoint that touches portfolio
+  construction (`/api/agent/advisor`, `/api/strategies/frontier*`) returns
+  bit-for-bit-identical numeric outputs against the same fixture inputs.
+  (Numeric diff <1e-6 acceptable.)
+
+## Verify
+
+```bash
+grep -rn "portfolio_constructor\|kelly_portfolio" backend/ \
+  | grep -v "_deprecated\|.pyc"
+# Expect: only Protocol references in interfaces/, test names, and the
+# decision-tree spec doc. No production imports.
+
+pytest -q backend/tests/services/test_portfolio_optimizer.py -v
+# Should include any lifted Kelly tests under their new home.
+```
+
+## Anti-goals
+
+- Do NOT delete the `_deprecated/` files in this PR — moving them is
+  reversible; deleting is not. Deletion is a follow-up PR after CI green.
+- Do NOT touch `portfolio_agent.py` semantics. The agent path is the live
+  product surface.
+- Do NOT change the `IPortfolioConstructor` Protocol shape. Future LLM-
+  unavailable-fallback code may want to implement it; keeping the seam
+  unchanged is cheap insurance.
+- Do NOT alter `_DRIFT_THRESHOLD`. The canonical value (0.05) is documented
+  in the decision-tree spec; the move shouldn't change it.
+
+## Precedent / shape to copy
+
+- The decision-tree spec
+  ([`docs/specs/portfolio-constructor-decision-tree.md`](portfolio-constructor-decision-tree.md))
+  is the authoritative reference. Read it first.
+- For the test migration shape, copy how
+  `backend/tests/services/test_portfolio_optimizer.py` exercises pure
+  math functions with seeded numpy inputs.
+- For the "move to `_deprecated/`" precedent, this is the first time we're
+  using that pattern — name it carefully. Alternatively, prefix moved
+  files with `_deprecated_` (less invasive). t2o2's call.
+
+## Out of scope
+
+- Soft-delete to hard-delete (one release cycle later, separate PR).
+- Any LLM-unavailable fallback policy work — the decision-tree spec
+  recommends route-handler-side fallback; that's a Phase 5 concern.
+
+## Owner suggestion
+
+t2o2 executes. **Önder reviews** (the Kelly math judgment call about what
+to lift is his to make). Dan coordinates with the fusion-to-backtest issue
+(#128) — if that issue lands first, fusion may add a Kelly-sizing step
+that the lifted helpers need to support.

--- a/docs/specs/phase7-portfolio-constructor-retirement-t2o2-issue.md
+++ b/docs/specs/phase7-portfolio-constructor-retirement-t2o2-issue.md
@@ -1,5 +1,7 @@
 # Issue spec for t2o2 — Retire `portfolio_constructor.py` + `kelly_portfolio.py`
 
+> **Status:** filed as [#131](https://github.com/hackagora/archimedes-arcadia/issues/131) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+>
 > **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
 >
 > **Why this exists:** the Phase 0 decision tree

--- a/docs/specs/phase7-rigor-consolidation-t2o2-issue.md
+++ b/docs/specs/phase7-rigor-consolidation-t2o2-issue.md
@@ -1,6 +1,6 @@
 # Issue spec for t2o2 — Consolidate rigor implementation on `rigor_evaluator.py`
 
-> **Status:** filed as [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+> **Status:** ✓ filed + closed as [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) on 2026-05-23 — shipped on `main` (commit `e030ee4`). This file is the spec source-of-truth; PR archive lives on the issue.
 >
 > **Ready-to-file issue body.** Copy/paste into a new GitHub issue, run
 > `gh issue edit <n> --add-assignee t2o2`, and t2o2 will pick it up.

--- a/docs/specs/phase7-rigor-consolidation-t2o2-issue.md
+++ b/docs/specs/phase7-rigor-consolidation-t2o2-issue.md
@@ -1,0 +1,119 @@
+# Issue spec for t2o2 — Consolidate rigor implementation on `rigor_evaluator.py`
+
+> **Ready-to-file issue body.** Copy/paste into a new GitHub issue, run
+> `gh issue edit <n> --add-assignee t2o2`, and t2o2 will pick it up.
+>
+> **Why this exists:** the codebase has TWO implementations of the same
+> rigor math — `services/selection_bias.py` (534 lines, older `t2o2`-authored)
+> and `services/rigor_evaluator.py` (348 lines, newer Önder-authored). Both
+> compute DSR + PBO. Future bug fixes risk landing in the wrong file; a
+> Phase 2 follow-up already chose `rigor_evaluator.py` as the path for
+> agent-output rigor wiring, locking in the canonical choice. This issue
+> retires `selection_bias.py` cleanly.
+
+---
+
+## APIN - Backend - Consolidate rigor implementation on `rigor_evaluator.py`
+
+## Summary
+
+[`services/rigor_evaluator.py`](../../backend/archimedes/services/rigor_evaluator.py)
+(Önder, 348 lines, math lane) is the **canonical** rigor module going forward.
+[`services/selection_bias.py`](../../backend/archimedes/services/selection_bias.py)
+(534 lines, older parallel impl) duplicates the same primitives.
+
+Retire `selection_bias.py` by: (1) finding every call site that imports from
+it; (2) re-pointing those imports at `rigor_evaluator.py` (signatures match
+for the public primitives); (3) re-exporting any genuinely-unique helpers
+from `rigor_evaluator.py` so external import paths keep working through a
+single deprecation cycle; (4) deleting `selection_bias.py` and its test
+file at the end of the PR.
+
+Do NOT silently change rigor thresholds. Do NOT alter the meaning of any
+existing API response field.
+
+## Scope (do exactly this, nothing more)
+
+Files to modify:
+- `backend/archimedes/api/selection_bias_routes.py` — repoint imports.
+- Any other file in `backend/` that imports from `services.selection_bias` —
+  enumerate via `grep -rn "from archimedes.services.selection_bias\|import archimedes.services.selection_bias" backend/`
+  before starting; repoint each.
+- `backend/archimedes/services/rigor_evaluator.py` — only if a unique helper
+  from `selection_bias.py` is needed elsewhere (e.g. `_look_ahead_audit`),
+  add the helper here as a public function with a tested-against-baseline
+  test. Default expectation: no additions needed.
+
+Files to delete (at the END of the PR, after all callers are repointed):
+- `backend/archimedes/services/selection_bias.py`
+- `backend/tests/services/test_selection_bias.py` (if it exists as a separate
+  file; if its tests already cover behaviors `rigor_evaluator.py`'s tests
+  don't, migrate them first).
+
+Files to NOT touch:
+- `analytics-engine/strategies/*.py` — strategy code.
+- `services/rigor_evaluator.py` semantics — only additions if needed.
+- Test thresholds, `pytest.ini`, fixture data.
+
+## Acceptance criteria
+
+Each is a runnable command + expected output.
+
+- [ ] **All `selection_bias` imports gone:**
+  `grep -rn "from archimedes.services.selection_bias\|archimedes\.services\.selection_bias" backend/`
+  → empty
+- [ ] **File is gone:**
+  `ls backend/archimedes/services/selection_bias.py 2>&1`
+  → `No such file or directory`
+- [ ] **All existing tests still green:**
+  `pytest -q --deselect backend/tests/test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults --deselect backend/tests/test_api_routes.py::TestAdvisorRoutes::test_advisor_redis_unavailable`
+  → 307+ passed, 0 failed (the two deselects are pre-existing Redis-state flakes documented in CLAUDE.md history)
+- [ ] **API response shape unchanged:** every `/api/strategies/rigor*` /
+  `/api/selection-bias/*` endpoint returns the same fields with the same
+  semantics it returned before this PR. Verify via a `gh pr diff` of the
+  schema files — no field added, removed, or renamed.
+- [ ] **No behavioral drift on DSR/PBO/OOS numbers:** rerun the architect
+  + agent integration tests; numeric outputs (`dsr`, `pbo`, `oos_sharpe`)
+  match pre-PR values within 1e-6.
+
+## Verify
+
+```bash
+git checkout main && pip install -r backend/requirements.txt
+# capture pre-PR numbers:
+pytest -q backend/tests/services/test_rigor_evaluator.py -v | tee /tmp/before.txt
+# apply PR, then:
+pytest -q backend/tests/services/test_rigor_evaluator.py -v | tee /tmp/after.txt
+diff /tmp/before.txt /tmp/after.txt  # numeric output diff should be empty
+grep -rn "selection_bias" backend/   # should be empty
+```
+
+## Anti-goals
+
+- Do NOT broaden the scope to "refactor `rigor_evaluator.py`." Pure migration.
+- Do NOT relax any rigor threshold. Do NOT change `passes_rigor_gate` logic.
+- Do NOT touch the `IBacktestEvaluator` Protocol in `interfaces/math.py`.
+- Do NOT add `selection_bias` as a "compatibility shim" file. Either delete
+  cleanly or leave the consolidation incomplete with an explicit follow-up.
+
+## Precedent / shape to copy
+
+- For the integration test shape, copy
+  `backend/tests/services/test_generation_pipeline.py::test_rigor_adapter_computes_dsr_and_oos_sharpe_on_synthetic_series`
+  — that's the Phase 2 follow-up that already wired `rigor_evaluator.py`
+  for live use. Same primitive signatures apply here.
+- For the migration shape, this is closest to the
+  Phase 1 ownership-comment reframe (`07276d3`) — surgical, no behavior
+  change, comprehensive grep-checkable acceptance.
+
+## Out of scope (deferred follow-up issues)
+
+- Refactoring `rigor_evaluator.py` internals (it's clean; don't rewrite).
+- Adding new rigor primitives (Sharpe CI is there but underused — separate issue).
+- Making the rigor gate user-tunable via env (separate UX issue).
+
+## Owner suggestion
+
+t2o2 executes. Önder reviews (his module is becoming canonical). Dan
+coordinates timing — should land BEFORE the fusion-to-backtest DSL issue
+(#128) merges, so that PR can rely on the consolidated import path.

--- a/docs/specs/phase7-rigor-consolidation-t2o2-issue.md
+++ b/docs/specs/phase7-rigor-consolidation-t2o2-issue.md
@@ -1,5 +1,7 @@
 # Issue spec for t2o2 — Consolidate rigor implementation on `rigor_evaluator.py`
 
+> **Status:** filed as [#129](https://github.com/hackagora/archimedes-arcadia/issues/129) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+>
 > **Ready-to-file issue body.** Copy/paste into a new GitHub issue, run
 > `gh issue edit <n> --add-assignee t2o2`, and t2o2 will pick it up.
 >

--- a/docs/specs/phase7-routes-py-split-t2o2-issue.md
+++ b/docs/specs/phase7-routes-py-split-t2o2-issue.md
@@ -1,6 +1,6 @@
 # Issue spec for t2o2 — Split `routes.py` monolith by resource
 
-> **Status:** filed as [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+> **Status:** ✓ filed + closed as [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) on 2026-05-23 — shipped on `main` (commit `be9260b`); `routes.py` is now a thin re-export shim with 9 per-resource routers. This file is the spec source-of-truth; PR archive lives on the issue.
 >
 > **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
 >

--- a/docs/specs/phase7-routes-py-split-t2o2-issue.md
+++ b/docs/specs/phase7-routes-py-split-t2o2-issue.md
@@ -1,5 +1,7 @@
 # Issue spec for t2o2 — Split `routes.py` monolith by resource
 
+> **Status:** filed as [#132](https://github.com/hackagora/archimedes-arcadia/issues/132) on 2026-05-23 · assigned to t2o2 · **open**. Implementation tracked on the GitHub issue. This file is the spec source-of-truth; PR + comments live on the issue.
+>
 > **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
 >
 > **Why this exists:** `backend/archimedes/api/routes.py` is **~2315 lines**

--- a/docs/specs/phase7-routes-py-split-t2o2-issue.md
+++ b/docs/specs/phase7-routes-py-split-t2o2-issue.md
@@ -1,0 +1,153 @@
+# Issue spec for t2o2 — Split `routes.py` monolith by resource
+
+> **Ready-to-file issue body.** Per CLAUDE.md's agentic issue pipeline.
+>
+> **Why this exists:** `backend/archimedes/api/routes.py` is **~2315 lines**
+> as of 2026-05-22, holding every legacy endpoint that predates the
+> "dedicated router file" convention. The new routers we've added in
+> recent phases (`chat_routes.py`, `marketplace_routes.py`, `risk_routes.py`,
+> `selection_bias_routes.py`, `generate_routes.py` Phase 2, `explore_routes.py`
+> Phase 3a, `corpus_routes.py` Phase 3c) prove the per-resource split is
+> workable and dramatically improves discoverability. This issue applies
+> that pattern retroactively to the legacy monolith.
+
+---
+
+## APIN - Backend - Split `routes.py` monolith into per-resource routers
+
+## Summary
+
+Split `backend/archimedes/api/routes.py` (~2315 lines) into per-resource
+router files, mirroring the pattern already used by `chat_routes.py` /
+`marketplace_routes.py` / `risk_routes.py` / `selection_bias_routes.py` /
+`generate_routes.py` / `explore_routes.py` / `corpus_routes.py`.
+
+Target resource splits:
+- `assets_routes.py` — `/api/assets/*`
+- `vaults_routes.py` — `/api/vaults/*`
+- `strategies_routes.py` — `/api/strategies/*` (including `/construct`,
+  `/generated`, `/frontier*`, `/correlations`)
+- `traces_routes.py` — `/api/traces/*`
+- `regime_routes.py` — `/api/regime/*`
+- `swap_routes.py` — `/api/swap/*`
+- `config_routes.py` — `/api/config/*`
+- `agent_routes.py` — `/api/agent/*` (advisor, stress, status)
+- `papers_routes.py` — `/api/papers/*` (excluding /api/corpus/* which already
+  has its own router from Phase 3c)
+
+After the split, `routes.py` itself becomes a thin re-export shim during
+the transition: it imports the routers from their new files and re-exports
+the symbol names `main.py` already binds (`assets_router`, etc.) so the
+include-router list in `main.py` doesn't need to change in this PR.
+
+In a follow-up PR (NOT this one): delete the re-export shim and update
+`main.py` to import directly from the new files.
+
+## Scope (exact files)
+
+Files to add (9 new):
+- `backend/archimedes/api/assets_routes.py`
+- `backend/archimedes/api/vaults_routes.py`
+- `backend/archimedes/api/strategies_routes.py`
+- `backend/archimedes/api/traces_routes.py`
+- `backend/archimedes/api/regime_routes.py`
+- `backend/archimedes/api/swap_routes.py`
+- `backend/archimedes/api/config_routes.py`
+- `backend/archimedes/api/agent_routes.py`
+- `backend/archimedes/api/papers_routes.py`
+
+Files to modify:
+- `backend/archimedes/api/routes.py` — slim down to a thin re-export shim
+  importing each `*_router` from the new files. Module-level helpers that
+  are used by multiple new routers (e.g. `_category_label`, `_persist_trace_off_chain`)
+  move to `api/_route_helpers.py`. No endpoint definitions remain in
+  `routes.py`.
+- `backend/archimedes/api/_route_helpers.py` (NEW) — shared helper functions
+  lifted out of the original monolith.
+
+Files to NOT touch:
+- `backend/archimedes/main.py` — the `include_router(*_router)` list stays
+  unchanged in this PR. Subsequent PR cleans up after the shim deletion.
+- Any frontend file. The URL contracts are unchanged.
+- Any router file outside the legacy monolith (`chat_routes.py` etc.).
+
+## Acceptance criteria
+
+- [ ] **`routes.py` is < 100 lines:**
+  `wc -l backend/archimedes/api/routes.py` → <100. The file contains only:
+  imports of routers from the new files, re-exports of the router names
+  `main.py` binds, and a module docstring explaining the transition.
+- [ ] **Every URL still exists:** capture the live URL set before+after:
+  `python -c "from archimedes.main import app; print('\n'.join(sorted(r.path for r in app.routes)))"`
+  Before-PR list = after-PR list (byte-identical).
+- [ ] **All tests pass:**
+  `pytest -q --deselect backend/tests/test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults --deselect backend/tests/test_api_routes.py::TestAdvisorRoutes::test_advisor_redis_unavailable`
+  → 307+ passed.
+- [ ] **OpenAPI schema unchanged:** `curl http://localhost:8000/openapi.json`
+  (or equivalent test fixture) produces the same `paths` dict before+after.
+- [ ] **No new top-level dependencies:** `pip-tools sync` reports no new
+  requirements.
+
+## Verify
+
+```bash
+git checkout main && pip install -r backend/requirements.txt
+python -c "from archimedes.main import app; import json; \
+  print(json.dumps({r.path: sorted(r.methods or []) for r in app.routes}, sort_keys=True, indent=2))" \
+  > /tmp/routes_before.json
+
+# Apply PR, then:
+python -c "from archimedes.main import app; import json; \
+  print(json.dumps({r.path: sorted(r.methods or []) for r in app.routes}, sort_keys=True, indent=2))" \
+  > /tmp/routes_after.json
+diff /tmp/routes_before.json /tmp/routes_after.json   # must be empty
+
+pytest -q
+wc -l backend/archimedes/api/routes.py   # must be < 100
+```
+
+## Anti-goals
+
+- Do NOT change any endpoint behavior. Pure refactor.
+- Do NOT rename any URL path. The frontend contract is locked.
+- Do NOT split into smaller-than-resource granularity (no
+  `vault_create_routes.py` + `vault_read_routes.py`). One file per resource.
+- Do NOT introduce shared mutable state between routers. Each `*_routes.py`
+  is self-contained except for imports from `_route_helpers.py`.
+- Do NOT touch the `chat_router` / `marketplace_router` / `risk_router` /
+  `selection_bias_router` / `generate_router` / `explore_router` /
+  `corpus_router` — already in their own files; orthogonal to this work.
+- Do NOT delete `routes.py` in this PR. Shim stays; deletion is the
+  follow-up after one CI cycle confirms zero downstream surprises.
+
+## Precedent / shape to copy
+
+The cleanest existing per-resource router is
+[`backend/archimedes/api/chat_routes.py`](../../backend/archimedes/api/chat_routes.py)
+(145 lines). Same shape — module docstring, `APIRouter(prefix=…, tags=[…])`,
+endpoint functions with response_model. The split should produce 9 files
+each shaped like that one.
+
+For the shared-helpers-extraction shape, copy how
+`backend/archimedes/api/selection_bias_routes.py` factors out
+`_synthetic_returns_from_stub` as a private helper. Multi-router helpers
+go in `_route_helpers.py`; single-router helpers stay private to that
+router file.
+
+## Out of scope (deferred follow-up PRs)
+
+- Deleting `routes.py` (the shim) after CI confirms zero surprises.
+- Updating `main.py`'s include-router list to import directly from the
+  new files (cosmetic; the shim's re-exports are equally fine).
+- Migrating the dedicated routers in `chat_routes.py` etc. into a `routers/`
+  subpackage (optional; no functional benefit).
+
+## Owner suggestion
+
+t2o2 executes — high mechanical, low judgment work. **Chuan reviews** (his
+lane is the chain integration most touched by `vaults_routes.py` +
+`traces_routes.py`). Daniel R. reviews the strategies + advisor splits.
+
+This issue is the LAST of the Phase 7 dedup batch — should land AFTER
+rigor consolidation, LLM backend unification, and constructor retirement,
+so the splits don't have to re-do work those issues already touched.

--- a/docs/specs/phase8-9-landing-and-fusion-spec.md
+++ b/docs/specs/phase8-9-landing-and-fusion-spec.md
@@ -77,6 +77,35 @@ Landing.jsx is 343 lines today and was rewritten in Daniel R.'s UnoCSS PR (#124)
 
 If time-boxed, the bug fixes alone are sufficient to unblock the demo. The polish work is incremental.
 
+### Sub-issue — Corpus Catalog tab: cards → compact table
+
+The Catalog tab in CorpusExplorer.jsx today renders each paper as a chunky card with title + meta line + 200-char abstract preview + strategies count. With 10,000 papers that's unscannable — at 5 cards visible per screen on a laptop the user has to scroll ~2000 times to traverse the corpus.
+
+**Reference UX:** the Papers app pattern (the user's reference image): dense table with columns *Authors · Year · Title · Journal*, monospace-feeling rows, no abstract preview in the row body. Abstract + tags + identifiers live in a right-side detail panel that opens on selection.
+
+**Resolution — adopt the Strategies.jsx table pattern** (which already proves the dense-row + click-to-expand approach on this codebase):
+
+- Convert `CatalogTab` from a `paper-card` list to a `<table>` with columns:
+  - **arxiv ID** (mono, `e.g.` `2108.00275`)
+  - **Authors** (first 2 + " et al." if more)
+  - **Year** (right-aligned, mono)
+  - **Title** (truncated to ~80 chars with full title on hover)
+  - **Category** (plain-English `category_label`, raw arxiv code on hover — same affordance as today's `paper-cat` badge)
+  - **Cited by** (count of `citing_strategies`, e.g. "2 strategies" — link-styled, clickable to filter Library)
+- Click row → existing `PaperDetail` view (unchanged — keeps the full PDF + abstract + strategy provenance flow).
+- Keep the existing search + category-filter controls above the table.
+
+Precedent to copy: `ui/src/components/Strategies.jsx::StrategyTable` (lines ~528–552 after the rebase). Same table shape, same `lib-table` CSS class, same `rounded-lg border border-[var(--glass-border)]` framing. Drop-in.
+
+**Backend note:** the API at `GET /api/papers/` already returns the fields needed (`arxiv_id`, `title`, `category_label`, `primary_category`, `published`, `abstract`). No backend change required for the table redesign. The Authors field needs to be added to the response — today's list endpoint omits authors (see `papers_routes.py::list_papers`'s response shape, lines 43-53). Add `authors: json.loads(r.authors) if r.authors else []` to both the DB and file-fallback dict literals. ~2-line backend tweak.
+
+**Acceptance:**
+- [ ] Catalog tab renders rows, not cards. At 24px line-height ~40 rows visible per screen (8× density vs today).
+- [ ] Each row click opens the existing `PaperDetail` view.
+- [ ] Authors field comes back from `/api/papers/` (DB + file fallback paths both).
+- [ ] Existing search + category filter still work.
+- [ ] Page builds + no regression on Overview / Graph / Knowledge-Graph tabs.
+
 ### Sub-issue — RegimePanel duplication across pages
 
 The current market-regime indicator appears in **three** places across the spine after the #119 panel-integration merge:
@@ -184,6 +213,7 @@ And in the overlay style block:
 - [ ] **Onboarding cards are readable over animating content.** Overlay opacity ≥ 0.75, blur ≥ 6px; card body has a solid (non-transparent) background.
 - [ ] **Onboarding CTAs keep the tour open.** Clicking "Open Corpus" / "Open Generate" / etc. navigates the page AND advances the card index; the tour modal stays visible until Skip, Done, or Esc.
 - [ ] **Regime indicator appears exactly once on the spine.** Visible on Portfolio (rich `<RegimePanel />` block); absent from Generate; the bare stat-card in Portfolio's status strip is removed.
+- [ ] **Corpus Catalog tab is a dense table, not cards** — ~8× density gain (40 rows/screen vs 5 cards). Authors field populated by a small `papers_routes.py` tweak.
 - [ ] **No regressions on other spine pages** — Layout topbar wallet button still works, sidebar nav still works, onboarding tour still triggers on first visit.
 - [ ] **Frontend build passes** — `cd ui && npm run build` exits 0. (Or via docker: `docker compose up -d --build` and verify <http://localhost> serves cleanly.)
 

--- a/docs/specs/phase8-9-landing-and-fusion-spec.md
+++ b/docs/specs/phase8-9-landing-and-fusion-spec.md
@@ -77,6 +77,60 @@ Landing.jsx is 343 lines today and was rewritten in Daniel R.'s UnoCSS PR (#124)
 
 If time-boxed, the bug fixes alone are sufficient to unblock the demo. The polish work is incremental.
 
+### Sub-issue — RegimePanel duplication across pages
+
+The current market-regime indicator appears in **three** places across the spine after the #119 panel-integration merge:
+
+1. `Generate.jsx` — `<RegimePanel />` rendered as a "Compact regime strip" at the top of the page.
+2. `Portfolio.jsx` — `<RegimePanel />` rendered above the status strip.
+3. `Portfolio.jsx` — a separate `Market Regime` stat-card inside the 4-card status strip (text-only, just the label + confidence).
+
+Two of these on one page is the more glaring duplication. Per [`docs/specs/page-roles-spec.md`](page-roles-spec.md), each page owns one job — and market context is a Portfolio (Monitor) concern, not a Generate concern. The agent already incorporates regime into its decision-making internally; the user constructing a strategy doesn't need a visible regime widget alongside the input form.
+
+**Resolution:**
+
+- **Drop `<RegimePanel />` from Generate.jsx.** Keep the page focused on intent → result. The mode toggle + form + streaming UI is enough; a regime strip is decoration that competes for attention with the actual primary action.
+- **Drop the bare Market-Regime stat card from Portfolio.jsx's status strip.** The richer `<RegimePanel />` above the strip already shows the regime + confidence + narrative + signals. The stat-card is redundant.
+- **Keep `<RegimePanel />` on Portfolio.jsx only.** That's where market context belongs.
+
+Code-level diff in `Generate.jsx`:
+
+```diff
+- import RegimePanel from './RegimePanel'
+…
+-       {/* Compact regime strip */}
+-       <div className="mb-4 fade-up fade-up-2" style={{ fontSize: '0.88rem' }}>
+-         <RegimePanel />
+-       </div>
+```
+
+Code-level diff in `Portfolio.jsx`:
+
+```diff
+        {/* Status strip — agent + regime are real (Redis-backed) regardless of wallet */}
+-       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
++       <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+          <div className="card-flat p-4">
+            <div className="label mb-2">Your Vaults</div>
+            …
+          </div>
+          <div className="card-flat p-4">
+            <div className="label mb-2">Total AUM</div>
+            …
+          </div>
+          <div className="card-flat p-4">
+            <div className="label mb-2">Agent</div>
+            …
+          </div>
+-         <div className="card-flat p-4">
+-           <div className="label mb-2">Market Regime</div>
+-           …
+-         </div>
+        </div>
+```
+
+The 3-card grid in Portfolio still shows: Your Vaults / Total AUM / Agent. Regime moves to the rich `<RegimePanel />` block above.
+
 ### Sub-issue — onboarding tour cards (Phase 6 follow-up)
 
 Two complaints on the Phase 6 onboarding tour (`ui/src/components/OnboardingTour.jsx`):
@@ -129,6 +183,7 @@ And in the overlay style block:
 - [ ] **Unknown page IDs do not silently render Landing-in-Layout.** Either a 404 card renders, or App.jsx redirects to `/`.
 - [ ] **Onboarding cards are readable over animating content.** Overlay opacity ≥ 0.75, blur ≥ 6px; card body has a solid (non-transparent) background.
 - [ ] **Onboarding CTAs keep the tour open.** Clicking "Open Corpus" / "Open Generate" / etc. navigates the page AND advances the card index; the tour modal stays visible until Skip, Done, or Esc.
+- [ ] **Regime indicator appears exactly once on the spine.** Visible on Portfolio (rich `<RegimePanel />` block); absent from Generate; the bare stat-card in Portfolio's status strip is removed.
 - [ ] **No regressions on other spine pages** — Layout topbar wallet button still works, sidebar nav still works, onboarding tour still triggers on first visit.
 - [ ] **Frontend build passes** — `cd ui && npm run build` exits 0. (Or via docker: `docker compose up -d --build` and verify <http://localhost> serves cleanly.)
 

--- a/docs/specs/phase8-9-landing-and-fusion-spec.md
+++ b/docs/specs/phase8-9-landing-and-fusion-spec.md
@@ -1,0 +1,282 @@
+# Phase 8 + Phase 9 — Landing polish + Fusion UI surface
+
+> **Status:** spec-only, drafted 2026-05-24 (Day-12) at end of context window for fresh-session execution. Demo-blocking; both phases are pure frontend with no Marten/Chuan dependency — distinct from Phases 4 + 5 which remain blocked on on-chain alignment.
+>
+> **Why this exists:** the spine-plus-v2 PR (#135) covers the streaming Generate, Explore, page-roles split, and rigor wiring — but post-merge testing surfaced three landing-page UX bugs and one product-level gap that the existing phase plan didn't cover. Phase 4 (vaults + trade windows) and Phase 5 (on-chain agent + USDC-as-gas) are orthogonal — they ship the on-chain story; they don't fix landing/wallet/CTAs or expose the fusion engine. This doc specifies the two missing UX phases.
+
+## Problem statement
+
+Four demo-blocking issues on the live UI at <http://13.40.112.220/>:
+
+1. **Landing "Strategies" CTA does nothing useful** — clicking it changes the URL but lands the user on the Landing component wrapped in Layout (sidebar appears unexpectedly). Cause: `onNavigate('strategies')` is called but the spine's route key is `library`. The unknown page-id falls to App.jsx's renderPage default branch, which returns `<Landing>` — now rendered inside Layout because the `if (page === 'landing')` early-return bypass doesn't fire.
+
+2. **Landing "Dashboard" CTA has the same bug** — `onNavigate('dashboard')` should be `onNavigate('portfolio')`. Same fall-through to Layout-wrapped Landing.
+
+3. **Landing "Connect Wallet" button is broken** — calls `onConnect()` with no argument. App.jsx wires `onConnect = handleConnect = (addr) => setWalletAddr(addr)`, which is a state setter, not a wallet-flow trigger. Result: clicking does nothing visible (or, depending on browser cache, may set `walletAddr` to undefined).
+
+4. **Strategy fusion engine has no UI surface.** Generate.jsx exposes two modes: `Streaming agent` (path B — `portfolio_agent.py` tool-use) and `Architect (fast preview)` (path A — `strategy_architect.py` library picker). The fusion path (C — `strategy_fusion.py`) has a working backend endpoint (`POST /api/strategies/generate` with `mode=fusion`, now fully wired to `fusion_evaluator.py` + rigor gate per #128 + #133), but no front-end ever invokes it. The wedge — "novel synthesis from multiple papers, then rigor-gated" — is invisible to users and judges.
+
+## Phase 8 — Landing polish + functional CTAs + wallet connect
+
+### Scope
+
+Files to modify:
+- `ui/src/components/Landing.jsx` — fix the 3 CTA page-id bugs; fix the wallet-connect button; design polish pass.
+- `ui/src/App.jsx` — verify that the early-return for `page === 'landing'` does NOT fire when the user has clicked through from Landing to a real spine page; verify that the default branch in `renderPage` doesn't render Landing (use a 404-style component or a redirect to '/' instead).
+- `ui/src/components/WalletConnect.jsx` — confirm there's an entry point Landing can call to open the wallet modal (or extract the modal-open logic so Landing can re-use it).
+
+Files to NOT touch:
+- Anything backend (this phase is pure frontend).
+- The onboarding tour (PR #134 already shipped + merged).
+- Any other spine page (Generate, Portfolio, Library, Corpus, Reasoning, Learnings, Explore).
+
+### The three bug fixes (mechanical)
+
+**Bug 1 + 2 — wrong page IDs in Landing.jsx:**
+
+```diff
+- onClick={() => onNavigate('strategies')}
++ onClick={() => onNavigate('library')}
+
+- <button … onClick={() => onNavigate('dashboard')}>Dashboard →</button>
++ <button … onClick={() => onNavigate('portfolio')}>Dashboard →</button>
+
+- <button … onClick={() => onNavigate('trade')}>…</button>
++ <button … onClick={() => onNavigate('portfolio')}>…</button>
+```
+
+(The button labels — "Strategies", "Dashboard" — can stay; only the internal page-id needs to match `PAGE_TO_PATH` in App.jsx.)
+
+**Bug 3 — wallet connect from Landing:**
+
+The cleanest fix is to give Landing its own wallet button that uses the same modal-open path as the topbar's `WalletConnect`. Two acceptable implementations:
+
+- **(A) Embed `<WalletConnect>` directly in Landing's header**, the same way Layout does in its topbar. Pass `address={walletAddr}`, `onConnect={handleConnect}`, `onDisconnect={handleDisconnect}` from App.jsx. The modal it owns is portal-rendered, so it works fine outside Layout.
+- **(B) Lift the modal-open trigger from `WalletConnect` into a prop**, and let Landing render its own button that calls it. More invasive; only do this if (A) somehow doesn't work.
+
+Recommended: **(A)**. Smallest diff, reuses tested code.
+
+**Bug-adjacent — default route in App.jsx:**
+
+The fall-through of unknown page IDs to `<Landing>` inside Layout is the root cause of the "side panel opens" observation. After fixing the Landing CTAs the unknown IDs go away, but the fall-through is still a footgun. Two acceptable fixes:
+
+- **(A)** Change `renderPage`'s default to return a small "404 — page not found" card with a CTA back to `onNavigate('landing')`. Keeps Layout (with sidebar) visible so the user can recover.
+- **(B)** Detect unknown page in App.jsx and `navigateToPage('landing', { replace: true })`. Cleaner but slightly silent.
+
+Recommended: **(A)**. Honest failure modes per CLAUDE.md.
+
+### Design polish (separate concern, same phase)
+
+Landing.jsx is 343 lines today and was rewritten in Daniel R.'s UnoCSS PR (#124). It works — but reads more like a feature-list landing page than a hackathon product narrative. Polish opportunities (none blocking; pick what time allows):
+
+- **Tighten the hero copy.** Lead with the one-line "Linus for quantitative finance" framing from [`docs/user-stories.md`](../user-stories.md), then the locked sentence — research-grounded strategies → rigor gate → non-custodial vault — and one CTA: "Generate a strategy →". Demote the secondary CTAs to a horizontal strip below.
+- **Single brand-accent color across the page.** Today the gold + violet + various greens/reds mix can feel busy. Pick one accent (var(--accent)) and use the others sparingly as status signals only.
+- **Replace generic "Paper-Grounded Strategies · SMA200 · TSMOM · Vol-Managed" cards with a curated 3-card row** that names the three primitives the deck argues: paper provenance, rigor gate, on-chain trace. Each card linkable to the page that demonstrates it (Library / Library?highlight= a rigor-passing strategy / Reasoning).
+- **Footer trust block** — Arc testnet status, last-deploy timestamp, GitHub link. Honest framing that we're testnet-only by design.
+- **Honesty section** — pull two anti-claims from [`docs/anti-features.md`](../anti-features.md) (e.g., "We don't promise alpha. We promise evidence-grounded generation with externally verifiable rigor.") Set the right expectations before the user generates.
+
+If time-boxed, the bug fixes alone are sufficient to unblock the demo. The polish work is incremental.
+
+### Sub-issue — onboarding tour cards (Phase 6 follow-up)
+
+Two complaints on the Phase 6 onboarding tour (`ui/src/components/OnboardingTour.jsx`):
+
+1. **Cards go semi-transparent over loading content.** The modal-overlay uses `background: rgba(0,0,0,0.55)` and `backdropFilter: blur(2px)` — too thin. When a page is loading behind the tour (e.g., Generate's streaming card spinner pulsing), the card body looks washed-out and hard to read.
+2. **CTAs ("Open Corpus", "Open Generate", etc.) navigate and close the tour with no clear re-entry path while the user is on Landing.** The "?" reopen button lives in the Layout topbar, which doesn't render on Landing. So if the user is on Landing and clicks card 2's "Open Corpus" CTA, the tour closes and they're suddenly looking at Corpus with no obvious way to get back to the tour.
+
+Fixes (both small):
+
+- **Overlay opacity:** `rgba(0,0,0,0.78)` (or higher) + `backdropFilter: blur(6px)`. The card body itself uses `card-elevated` which gives it a solid dark panel — make sure that style hasn't picked up an unintended transparency from a UnoCSS class.
+- **CTA behavior change:** clicking "Go to <Page>" should **navigate AND advance to the next card** (not close the tour). The tour stays open over the new page. User completes the tour normally on `Done` (last card). If the user clicks "Skip", same as today — tour closes + dismissal sticks. This way the user always has a forward path; the tour visually walks them through the spine while they see each destination behind the modal.
+- **Optional polish:** add a small "← Back to tour" affordance to Landing (since Landing has no topbar). Probably overkill given the CTA-advances-tour fix above; only add if the CTA fix doesn't fully resolve the disorientation.
+
+Code-level diff in `OnboardingTour.jsx`:
+
+```diff
+- const handleCta = useCallback(() => {
+-   if (card.cta.target) {
+-     setPage(card.cta.target)
+-     finish()
+-   } else {
+-     handleContinue()
+-   }
+- }, [card, setPage, finish, handleContinue])
++ const handleCta = useCallback(() => {
++   if (card.cta.target) {
++     setPage(card.cta.target)
++     // Advance to next card instead of closing — keep the tour
++     // visible so the user can see each destination behind the modal
++     // and still finish the walkthrough.
++     if (!isLast) setCardIndex(i => i + 1)
++     else finish()
++   } else {
++     handleContinue()
++   }
++ }, [card, setPage, isLast, finish, handleContinue])
+```
+
+And in the overlay style block:
+
+```diff
+- style={{ background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(2px)' }}
++ style={{ background: 'rgba(0,0,0,0.78)', backdropFilter: 'blur(6px)' }}
+```
+
+### Acceptance criteria (Phase 8)
+
+- [ ] **CTAs navigate to real pages:** clicking "Strategies" lands on `/library`; clicking "Dashboard" lands on `/portfolio`; the second "Trade" CTA (or whatever the duplicate calls) lands on `/portfolio`. None of these render Landing-inside-Layout.
+- [ ] **Wallet button on Landing opens the wallet modal** and on successful connect, the button updates to show the short address (same behavior as the Layout topbar).
+- [ ] **Unknown page IDs do not silently render Landing-in-Layout.** Either a 404 card renders, or App.jsx redirects to `/`.
+- [ ] **Onboarding cards are readable over animating content.** Overlay opacity ≥ 0.75, blur ≥ 6px; card body has a solid (non-transparent) background.
+- [ ] **Onboarding CTAs keep the tour open.** Clicking "Open Corpus" / "Open Generate" / etc. navigates the page AND advances the card index; the tour modal stays visible until Skip, Done, or Esc.
+- [ ] **No regressions on other spine pages** — Layout topbar wallet button still works, sidebar nav still works, onboarding tour still triggers on first visit.
+- [ ] **Frontend build passes** — `cd ui && npm run build` exits 0. (Or via docker: `docker compose up -d --build` and verify <http://localhost> serves cleanly.)
+
+### Anti-goals (Phase 8)
+
+- Do NOT touch the backend.
+- Do NOT add new pages or new navigation entries.
+- Do NOT refactor `WalletConnect.jsx` internals beyond what bug 3 requires.
+- Do NOT bundle Phase 9's fusion-mode UI here — separate commit / separate PR.
+
+### Suggested precedent / shape to copy
+
+- For embedding `<WalletConnect>` in a header outside Layout, copy how Layout itself does it in `ui/src/components/Layout.jsx` topbar block. The component is self-contained — it owns its own modal, address shortening, and chain-mismatch warning.
+- For 404 page handling, the simplest pattern is an inline functional component in App.jsx — no new file needed.
+
+## Phase 9 — Fusion engine UI surface
+
+### Scope
+
+The wedge — "multi-paper synthesis, rigor-gated" — has been backend-complete since #133. The UI just doesn't expose it. This phase adds a third mode to the existing Generate.jsx mode toggle.
+
+Files to modify:
+- `ui/src/components/Generate.jsx` — add a third tag in the existing mode-toggle bar; add a `mode === 'fusion'` branch that renders a fusion-specific input form + job-status display.
+- Likely a new component `ui/src/components/FusionResult.jsx` for the rendered fusion proposal + backtest + rigor verdict.
+
+Files to NOT touch:
+- The streaming agent mode (path B) and architect mode (path A) — both work; don't refactor.
+- Backend — `POST /api/strategies/generate?mode=fusion` already exists in `backend/archimedes/api/strategies_routes.py` (post-#132 split). The fusion path inside that handler now calls `evaluate_fusion_spec` (per #133) so the response carries a real backtest + rigor verdict, not just text.
+
+### UX shape
+
+```
+┌─ Generate ─────────────────────────────────────┐
+│ [🔴 Streaming agent] [⚡ Architect (fast)] [🧪 Fusion (novel)]   ← mode toggle
+│
+│ === when mode === 'fusion' ===
+│
+│ ┌────────────────────────────────────────────┐
+│ │ Asset classes  [equities ▾] [bonds ▾] …    │
+│ │ Risk appetite  [moderate ▾]                │
+│ │ Strategic direction (optional):            │
+│ │ [_____________________________________]    │
+│ │ Max papers to fuse: [4 ▾]                  │
+│ │                                            │
+│ │             [ Fuse → ]                     │
+│ └────────────────────────────────────────────┘
+│
+│ === while job running ===
+│ Status: queued → running → done
+│   (poll /api/strategies/generate/{job_id} every 2s)
+│
+│ === when job done ===
+│ ┌─ FusionResult ─────────────────────────────┐
+│ │ Strategy name + thesis                     │
+│ │ Fusion reasoning (which papers, why)       │
+│ │ Source papers (arxiv chips linkable)       │
+│ │ Backtest metrics (if strategy_spec valid)  │
+│ │ Rigor verdict (DSR / PBO / OOS / look-ahd) │
+│ │ Novelty rationale + risk notes             │
+│ │ [Deploy as vault] (gated on rigor-pass)    │
+│ └────────────────────────────────────────────┘
+└────────────────────────────────────────────────┘
+```
+
+### API contract (already shipped)
+
+```bash
+# Submit a fusion job — async, returns a job_id
+POST /api/strategies/generate
+{
+  "mode": "fusion",
+  "asset_classes": ["equities", "bonds"],
+  "risk_appetite": "moderate",
+  "strategic_direction": "...",
+  "max_papers": 4
+}
+→ 202 { "status": "queued", "job_id": "..." }
+
+# Poll for status + result
+GET /api/strategies/generate/{job_id}
+→ { "status": "queued"|"running"|"done"|"failed", "result": {...} }
+```
+
+The `result` shape (when status=`done` and the fusion produced a valid `strategy_spec`):
+
+```jsonc
+{
+  "mode": "fusion",
+  "status": "ok",
+  "strategy_name": "...",
+  "thesis": "...",
+  "source_arxiv_ids": ["...", "..."],
+  "fusion_reasoning": "...",
+  "novelty_rationale": "...",
+  "risk_notes": "...",
+  "strategy_spec": { /* DSL — for the deploy button */ },
+  "backtest": { "sharpe_ratio": ..., "cagr": ..., "max_drawdown": ..., "equity_curve": [...] },
+  "rigor": { "passing": true|false, "dsr": ..., "dsr_p_value": ..., "pbo_score": ..., "oos_sharpe": ..., "look_ahead_clean": true }
+}
+```
+
+If `strategy_spec` is missing (LLM didn't comply), the result has only the prose fields (thesis, fusion_reasoning, etc.) and no backtest/rigor blocks. Display the prose + a small honest note: *"This is a pre-backtest hypothesis. Strategy specification was not produced; rerun for a backtested result."*
+
+### Component decomposition
+
+- **`Generate.jsx`** — extend mode toggle; add `fusion` branch with the form + job tracker. Most of the streaming-job-polling infrastructure can be lifted/copied from `GenerationStream.jsx`, but fusion's lifecycle is simpler (no SSE — just GET poll every 2s).
+- **`FusionResult.jsx`** *(new)* — renders the result body. Includes:
+  - Strategy name + thesis (top — the headline)
+  - Source-paper chips (link to `/corpus?arxiv_id=...` if exists, else arxiv.org/abs/)
+  - Backtest metrics card (if present) — Sharpe / CAGR / Max DD / equity curve sparkline
+  - Rigor verdict pill — green "rigor passed" / amber "pending" / red "failed" with the four sub-metrics under
+  - Fusion reasoning + novelty rationale + risk notes — expandable cards
+  - Deploy CTA — gated: enabled only if `rigor.passing === true`; on click, scaffold a vault-deploy flow (out of scope for Phase 9 — see "Out of scope" below)
+
+### Acceptance criteria (Phase 9)
+
+- [ ] **Third mode visible:** opening `/generate` shows three tags in the mode strip: Streaming agent · Architect (fast preview) · Fusion (novel synthesis).
+- [ ] **Fusion form submits cleanly:** filling the form + clicking "Fuse →" issues `POST /api/strategies/generate` with `mode=fusion` and the form fields, receives a `job_id`, transitions to a "Status: queued" view.
+- [ ] **Polling works:** the UI polls `GET /api/strategies/generate/{job_id}` every 2s, updates the status, and stops on `done`/`failed`. The `Last-Event-ID` pattern from streaming Generate is not needed here (no SSE).
+- [ ] **Backtested fusion result renders:** when `result.backtest` is present, the UI shows Sharpe + CAGR + Max DD + a small equity-curve sparkline.
+- [ ] **Rigor verdict renders honestly:** when `result.rigor.passing === true`, a green badge appears; when `false`, an amber/red badge with the failing sub-metric highlighted; when absent (fallback path), the user sees *"pre-backtest hypothesis"* framing.
+- [ ] **Pre-backtest fusion still renders gracefully:** if `result.strategy_spec` is missing, the prose fields (thesis, fusion_reasoning, novelty_rationale, risk_notes) render with the honest pre-backtest note.
+- [ ] **No regression on the other two modes** — Streaming agent and Architect both still work end-to-end.
+
+### Anti-goals (Phase 9)
+
+- Do NOT change the backend. The fusion endpoint and `fusion_evaluator.py` are settled (post-#133).
+- Do NOT implement the deploy-to-vault flow here. That's Phase 4 territory. Render a *"Deploy as a vault — coming in Phase 4"* disabled button so the UX flow is visible but the action is honest about not shipping yet.
+- Do NOT add a fourth mode or rename the existing two.
+- Do NOT touch `strategy_fusion.py` or `fusion_evaluator.py`.
+
+### Suggested precedent / shape to copy
+
+- For the form + job-poll loop, the simplest precedent is the streaming Generate's `GenerationStatus.jsx` (job tracker + result rendering); fusion is just simpler (no SSE).
+- For the rigor verdict badge, copy the pattern from `Strategies.jsx` row-expansion's "Rigor metrics" block. Same DSR / PBO / OOS shape; same `?` affordance opening `RigorExplainer`.
+- For the asset-class multi-select, copy `Generate.jsx`'s existing risk-appetite select (single-select is fine for v1 — fusion's backend accepts an array but a single asset class is a reasonable default).
+
+## Suggested execution order
+
+1. **Phase 8 first** — bug fixes are mechanical (~30 min total) and unblock the demo navigation. Polish can be incremental.
+2. **Phase 9 second** — depends on a working Generate page (Phase 8 makes sure landing → generate works), and benefits from the same session's familiarity with Generate.jsx.
+3. Both phases ship as a single PR off `dbrowneup/spine-plus-v2` (after #135 merges) or as two separate small branches off `main` — author's call.
+
+## Out of scope (deferred — Phase 4 + 5 territory)
+
+- Deploying a fusion-generated strategy into an actual vault — needs the trade-window contract semantics from Phase 4 + the on-chain signing from Phase 5. The button stays disabled / honest in Phase 9.
+- Vault-side UI for fusion strategies — Library already renders fusion-generated entries via the `is_example=False` query path; vault-detail UI changes (if any) are part of Phase 4.
+
+## Owner suggestion
+
+Dan (or whoever picks this up in a fresh session). Both phases are pure frontend; no on-chain dependency; no Marten/Chuan blocker. Önder or Daniel R. could pick up either if Dan is sleeping.

--- a/docs/specs/portfolio-constructor-decision-tree.md
+++ b/docs/specs/portfolio-constructor-decision-tree.md
@@ -1,0 +1,177 @@
+# Portfolio Constructor Decision Tree
+
+> **Status:** Drafted 2026-05-22 as Phase 0 of the
+> [Spine+ v2 plan](./spine-plus-v2-plan.md). Closes survey gap cluster #5
+> (load-bearing) from [`chuan-architecture-survey.md`](../chuan-architecture-survey.md).
+>
+> **Lineage:** Day-10 introduced `portfolio_agent.py` (850 lines) as an
+> LLM-agentic top-level constructor. Three pre-Day-10 deterministic constructors
+> remained in the tree:
+> - [`services/portfolio_constructor.py`](../../backend/archimedes/services/portfolio_constructor.py) (285 lines)
+> - [`services/kelly_portfolio.py`](../../backend/archimedes/services/kelly_portfolio.py) (505 lines)
+> - [`services/portfolio_optimizer.py`](../../backend/archimedes/services/portfolio_optimizer.py) (488 lines)
+>
+> Most have **zero production call sites** today. This spec decides who fires
+> when, and which files become formally retired.
+
+## Current call-site reality (verify before editing)
+
+```bash
+# In repo root:
+$ grep -rn "PortfolioConstructor()\|KellyRiskParityConstructor\|get_portfolio_agent\|optimize_weights\|compute_efficient_frontier" \
+    backend/archimedes/api/ backend/archimedes/chain/ --include="*.py"
+```
+
+Findings as of 2026-05-22:
+
+| Constructor | Production callers | Status |
+|---|---|---|
+| `portfolio_agent.PortfolioAgent` (Day-10) | `api/routes.py:677` (agent recommend endpoint) | **Active — top-level** |
+| `portfolio_optimizer.optimize_weights` + `compute_efficient_frontier` | `api/routes.py:509, 1056, 1259` (efficient frontier viz + agent stats) | **Active — leaf** |
+| `portfolio_constructor.PortfolioConstructor` | None in `api/` or `chain/`. Imported only via `interfaces/`. | **Dead in production** |
+| `kelly_portfolio.KellyRiskParityConstructor` | None in `api/` or `chain/`. Test-only. | **Dead in production** |
+
+This is the gap: two deterministic constructors are kept alive by the
+`IPortfolioConstructor` Protocol but no production code instantiates them.
+The agentic path (`portfolio_agent`) replaced the orchestrator role; the pure-MVO
+path (`portfolio_optimizer`) survives because the UI's efficient frontier chart
+needs it.
+
+## Decision tree
+
+```
+Entry point
+    │
+    ├── /generate (user brief)
+    │       ▼
+    │   portfolio_agent.PortfolioAgent.recommend()
+    │       │
+    │       ├── (internally tool-calls)
+    │       │       └── portfolio_optimizer.optimize_weights()  ← used as a tool
+    │       │
+    │       └── returns AgentPortfolio
+    │
+    ├── /api/agent/recommend (cron / test harness)
+    │       ▼
+    │   portfolio_agent.PortfolioAgent.recommend()
+    │       (same path as above)
+    │
+    ├── /portfolio efficient frontier chart
+    │       ▼
+    │   portfolio_optimizer.compute_efficient_frontier()
+    │
+    └── /strategy/:id passport "what would these weights look like?"
+            ▼
+        portfolio_optimizer.optimize_weights()
+```
+
+### One rule
+
+**`portfolio_agent.PortfolioAgent` is the only top-level constructor.** It is
+the LLM-agentic Day-10 implementation that owns the user-facing Generate flow
+and the agent runner tick. Everything else is either a tool it calls or a
+visualization helper.
+
+### Constructor roles
+
+| File | Role | Lifetime |
+|---|---|---|
+| `services/portfolio_agent.py` | **Top-level constructor.** Receives user brief or regime tick, runs ≤ `MAX_AGENT_ITERATIONS=12` LLM iterations with tool-calling, produces `AgentPortfolio` with weights + reasoning + trace. Owns regime handling. | Keep — actively developed |
+| `services/portfolio_optimizer.py` | **Math leaf.** Pure NumPy/cvxpy MVO + efficient frontier. Pure-function API (`optimize_weights(mu, sigma, constraints) → weights`). Called by `portfolio_agent` as a tool **and** by UI endpoints for visualization. | Keep — Önder's clean math primitive |
+| `services/portfolio_constructor.py` | **Deprecated orchestrator** (pre-Day-10). Was the old regime → weights router; superseded by `portfolio_agent`. | **Retire** in Phase 4 (move to `services/_deprecated/` or delete after one release cycle confirms no consumers) |
+| `services/kelly_portfolio.py` | **Deprecated Kelly path** (pre-Day-10). Test-only. Math primitives (Kelly fraction calc, risk-parity weighting) are partially duplicated in `portfolio_optimizer.py`. | **Retire** in Phase 4; lift any unique math into `portfolio_optimizer.py` first |
+
+### Composability question, answered
+
+> Are `kelly_portfolio.py` and `portfolio_optimizer.py` alternatives, or
+> composable layers?
+
+**Neither — they're partially-overlapping legacy.** `portfolio_optimizer.py` is
+the keeper. Any Kelly-specific sizing logic worth saving moves into it as a
+function (e.g., `kelly_size(weights, edge_estimates) → scaled_weights`) before
+`kelly_portfolio.py` retires. Don't keep both alive "for composability" — that's
+the trap that produced this gap.
+
+### LLM unavailability fallback
+
+If `ANTHROPIC_API_KEY` is missing or the LLM call fails:
+
+- `portfolio_agent.PortfolioAgent` raises a typed exception (`AgentUnavailableError`).
+- The caller (typically the Generate route) catches it and either:
+  - Returns a clear error to the user ("Strategy generation requires LLM connectivity; retry in a moment"), **or**
+  - Falls back to a deterministic baseline: equal-weight across the regime's
+    asset class, computed via `portfolio_optimizer.optimize_weights` with
+    identity covariance.
+
+**The fallback is not a route to the old `PortfolioConstructor`.** That path
+is dead.
+
+## The `_DRIFT_THRESHOLD` constant — canonical value
+
+Both surviving callers use **`0.05` (5% absolute weight deviation)** as the
+rebalance trigger. Verified:
+
+- `services/portfolio_constructor.py:60` → `_DRIFT_THRESHOLD = 0.05`
+- `services/kelly_portfolio.py:53` → `_DRIFT_THRESHOLD = 0.05`
+- `services/statistical_regime.py:42` → `_MA_DRIFT_THRESHOLD = 0.03` (separate
+  semantic — moving-average deviation, not portfolio drift; do not unify)
+
+The earlier plan-doc claim of "0.15 vs 0.05" was incorrect; the two values
+match. **Canonical:** `0.05` for portfolio drift. When the deprecated constructors
+retire, move the constant to a single home (`services/portfolio_optimizer.py`
+or a new `services/constants.py`).
+
+## The `pick_constructor()` helper
+
+Given that there is now exactly one top-level constructor, the helper the
+original plan proposed (`pick_constructor(mode, llm_available, regime)`) is
+**not needed**. Replace with a flat call:
+
+```python
+# Anywhere a portfolio decision is needed:
+from archimedes.services.portfolio_agent import get_portfolio_agent
+agent = get_portfolio_agent()
+result = await agent.recommend(brief=..., regime=...)  # raises AgentUnavailableError if LLM down
+```
+
+If we ever re-introduce a deterministic top-level constructor (e.g., for a
+"no-LLM mode" CI fixture), revisit this and add the helper. Don't add it
+preemptively.
+
+## Phase 2 instrumentation hook
+
+The SSE generation stream (`generation-streaming-spec.md`) emits events
+per LLM iteration **inside `portfolio_agent.PortfolioAgent.recommend()`**. The
+emit point is a callback parameter passed by the route handler, so the
+constructor doesn't reach up into FastAPI:
+
+```python
+async def recommend(self, brief, regime, *, emit: Callable[[str, dict], Awaitable[None]] | None = None):
+    ...
+    if emit: await emit("agent_iteration", {"iteration_n": i, ...})
+```
+
+Phase 2 wires `emit` to the SSE channel.
+
+## Acceptance
+
+A reviewer can answer each of these from this doc alone:
+
+- Which constructor fires when the user clicks Generate? → `portfolio_agent`
+- Which constructor fires on the agent runner's 5-min tick? → `portfolio_agent`
+- Where does the efficient frontier UI data come from? → `portfolio_optimizer.compute_efficient_frontier`
+- What happens if the LLM is down? → `AgentUnavailableError`, optional deterministic fallback via `portfolio_optimizer`
+- Which files are formally retired in Phase 4? → `portfolio_constructor.py` and `kelly_portfolio.py`
+
+## Open questions
+
+1. **Soft-retire vs hard-delete** the two deprecated files — move to
+   `services/_deprecated/` for one release, or delete outright? (Recommendation:
+   move; CI green for one PR cycle, then delete.)
+2. **Equal-weight fallback location** — should the deterministic LLM-unavailable
+   fallback live in `portfolio_agent.py` or in the route handler? (Recommendation:
+   route handler — keeps the agent module purely about LLM, fallback is a
+   policy decision the route makes.)
+3. **Kelly math worth lifting** — is there sizing logic in `kelly_portfolio.py`
+   that isn't already in `portfolio_optimizer.py`? Önder to verify before we
+   delete.

--- a/docs/specs/spine-plus-v2-plan.md
+++ b/docs/specs/spine-plus-v2-plan.md
@@ -1,16 +1,10 @@
 # Archimedes Spine+ v2 — Phase Plan
 
-> **Status:** Drafted 2026-05-22 by Dan + Claude session at end of context window
-> ahead of compaction. Reflects the strip-to-spine commit (`d4dd465`),
-> [`docs/chuan-architecture-survey.md`](chuan-architecture-survey.md) Day-10
-> updates, and the post-strip product walkthrough.
+> **Status:** Drafted 2026-05-22; refreshed 2026-05-23 with phase-completion audit.
 >
-> **Phases 0-3 are ready to execute.** Phases 4-6 are scoped but **pending
-> alignment with Marten (vault contracts) and Chuan (chain/agent integration)**
-> before kickoff.
+> **As of 2026-05-23:** Phases 0, 1, 2, 3a, 3b, 6, 7 are ✅ LANDED. Phase 3c is 🟡 SKELETON (production KB body deferred). Phases 4 + 5 are still ⏸ pending Marten/Chuan alignment. Phases 8 + 9 are specced separately in [`phase8-9-landing-and-fusion-spec.md`](phase8-9-landing-and-fusion-spec.md) and scheduled for the next implementation block.
 >
-> **Branch:** `dbrowneup/spine-plus-v2`, branched off latest `main` with
-> `d4dd465` (strip-to-spine) rebased on top as the starting state.
+> **Branch:** `dbrowneup/spine-plus-v2` (PR #135 open), branched off `main` and rebased forward as `main` moves.
 >
 > **How to read:** each phase has (1) problem statement, (2) scope with concrete
 > files, (3) acceptance criteria (machine-checkable where possible), (4)
@@ -63,7 +57,7 @@ These apply to every phase. Violating one of these is a review-blocker.
 
 # Phase 0 — Architectural Specs
 
-**Status:** READY TO EXECUTE
+**Status:** ✅ LANDED — `5fc2eb9` (6 specs under `docs/specs/`)
 **Branch:** `dbrowneup/spine-plus-v2`
 **PR shape:** single docs PR landing 6 new files under `docs/specs/`
 
@@ -254,13 +248,13 @@ session.
 
 # Phase 1 — Junk extermination + UX fixes
 
-**Status:** LANDED — `4e28761` (cherry-pick) + follow-up commit landing
-deferred items (#2 Reasoning restructure + Library export move + `?highlight=`
-deep-link, #3 Learnings onNavigate, #4 ownership reframe). **#1 MetaMask
-filter:** resolved in the earlier wallet-bug fix (`ensureArcChain` requests
-Arc only, never `wallet_requestPermissions`); awaiting one manual MetaMask
-popup verification on the deploy. Reopen only if the popup still surfaces
-multiple chains.
+**Status:** ✅ LANDED — `f21ac8d` (cherry-pick) + `00d8f09` (follow-up landing
+deferred items: Reasoning restructure + Library export move + `?highlight=`
+deep-link + Learnings onNavigate + ownership-comment reframe).
+**Residual carve-outs (cosmetic, non-blocking):**
+- `<span>off-chain only</span>` label at [`Portfolio.jsx:240`](../../ui/src/components/Portfolio.jsx) — Phase 1 acceptance grep (`"(off-chain only)"` with parens) passes, but the label itself still hides the failure reason. Roll into Phase 8 polish.
+- MetaMask popup verification still pending on the deploy. Reopen only if the
+  popup surfaces multiple chains in practice.
 
 **Dependencies:** None (parallelizable with Phase 0)
 **PR shape:** small, focused, no behavior changes beyond mock-data removal + wallet network filter
@@ -334,7 +328,7 @@ fine for the backend cleanup.
 
 # Phase 2 — Streaming Generate on `portfolio_agent.py`
 
-**Status:** READY TO EXECUTE (after Phase 0 spec 0.5 lands)
+**Status:** ✅ LANDED — `28dd93a` (initial) + `7b1c1e3` (follow-ups: hard cancel, rigor wiring, brief validation)
 **Dependencies:** Phase 0.5 (`generation-streaming-spec.md`); Phase 0.4 (`portfolio-constructor-decision-tree.md`)
 **PR shape:** larger; includes backend SSE endpoint + frontend stream UI + multi-strategy mechanic
 
@@ -435,7 +429,7 @@ behavior under iteration limits).
 
 # Phase 3 — Real Explore + Corpus depth + KB integration
 
-**Status:** READY TO EXECUTE (after Phase 0 specs 0.3 and 0.6 land)
+**Status:** ✅ 3a + 3b LANDED — `6735481`. 🟡 3c skeleton landed in same commit; **production KB pipeline body deferred** pending Dan's Linus-side iteration to stabilize. Category-label enrichment re-applied post-rebase at `b45b2aa`.
 **Dependencies:** Phase 0.3 (`page-roles-spec`), Phase 0.6 (`kb-integration-spec`)
 **PR shape:** the largest single phase; could split into 3a (Explore), 3b (Corpus polish), 3c (KB integration)
 
@@ -766,7 +760,9 @@ Until this happens, we don't actually know if the rebalance path executes.
 
 # Phase 6 — Onboarding tour (MetaMask-style cards)
 
-**Status:** PENDING ALIGNMENT — low-priority but high-leverage for demo
+**Status:** ✅ LANDED — PR #134 (`60d1ee5`), merged to `main` via `e2ee2a5`.
+6-card MetaMask-style tour with localStorage gate + `?` topbar re-launch.
+Phase 8 spec covers two follow-ups (transparency fix on card background, remove the in-card navigation buttons that escape the tour).
 **Dependencies:** Phase 1 (junk clean so cards don't reference dead surfaces)
 
 ## Problem (high-level)
@@ -868,8 +864,10 @@ Phase 6 questions:
 
 # Phase 7 — Consolidation & dedup via t2o2
 
-**Status:** SPEC-READY — 4 judge-grade issues drafted in `docs/specs/`.
-Dan files to GitHub + assigns t2o2; humans review the resulting PRs.
+**Status:** ✅ LANDED — all 6 issues closed (#128, #129, #130, #131, #132, #133).
+PR #136 (merge `2a5f319`) closed remaining gaps on #128/#130/#133:
+honest fusion rigor + real bar-by-bar equity curve, LLM-backend guard test,
+fusion rigor verdict persistence + `rejected` status.
 
 **Why this phase exists:** [`docs/chuan-architecture-survey.md`](../chuan-architecture-survey.md)
 identifies 14 gap clusters in `backend/archimedes/`. Of those, gaps #1, #2,
@@ -950,25 +948,27 @@ Update this table at phase close. No prospective estimates.
 | 3c — KB integration (skeleton) | 2026-05-22 | 2026-05-22 | ~1.5 | part of `50edb28`; production body deferred |
 | Phase 2 follow-ups | 2026-05-22 | 2026-05-22 | ~2 | `7b1c1e3` — cancel/rigor/brief-validation |
 | Phase 7 specs drafted | 2026-05-22 | 2026-05-22 | ~1 | 4 issue specs in `docs/specs/`; #128 filed |
-| 4 — Vault (PENDING) | | | | needs Marten alignment |
+| 6 — Onboarding | 2026-05-22 | 2026-05-22 | ~1.5 | `60d1ee5` · PR #134 (6-card tour + localStorage + ? re-launch) |
+| 7 — Dedup via t2o2 | 2026-05-22 | 2026-05-23 | ~0.5 (humans) + bot | All 6 issues closed; PR #136 closed follow-up gaps |
+| 8 — Landing + UX polish (PENDING) | | | | Spec at [`phase8-9-landing-and-fusion-spec.md`](phase8-9-landing-and-fusion-spec.md) |
+| 9 — Fusion UI surface (PENDING) | | | | Spec at [`phase8-9-landing-and-fusion-spec.md`](phase8-9-landing-and-fusion-spec.md) |
+| 4 — Vault (PENDING) | | | | needs Marten + Chuan alignment |
 | 5 — Real trade (PENDING) | | | | needs Chuan alignment |
-| 6 — Onboarding (PENDING) | | | | Dan can do solo |
-| 7 — Dedup via t2o2 (PENDING) | | | | Dan files; t2o2 executes |
 
 ---
 
-# Suggested kickoff sequence (post-compaction, 2026-05-23+)
+# Suggested kickoff sequence (refreshed 2026-05-23)
 
 When the next session resumes:
 
 1. Read this doc + [`docs/chuan-architecture-survey.md`](../chuan-architecture-survey.md) for context.
-2. Confirm branch hygiene: are we on `dbrowneup/spine-plus-v2`? Rebase onto latest `origin/main` if Chuan has moved it.
-3. **Phase 0-3 + Phase 2 follow-ups are LANDED** (7 commits on the branch). Branch tip is the last commit of the day. `pytest -q` → 307 passed.
-4. **Issue #128 (fusion-to-backtest DSL)** filed + assigned to t2o2 on 2026-05-22. Check PR draft status.
-5. **Phase 7 next**: file the 4 drafted issue specs (`docs/specs/phase7-*-t2o2-issue.md`) as GitHub issues + assign t2o2. Order them as suggested in the Phase 7 section above (7.2 → 7.3 → 7.4 → 7.5; 7.1 = #128 is already in flight).
-6. **Phase 6 (onboarding)** — Dan can solo if there's time.
-7. **Phase 4 + 5** — wait for Marten / Chuan standup alignment.
-8. KB pipeline production wiring waits on Dan's Linus-side iteration to settle.
+2. Confirm branch hygiene: are we on `dbrowneup/spine-plus-v2`? Rebase onto latest `origin/main` (moves continuously).
+3. **Phases 0, 1, 2, 3a, 3b, 6, 7 are LANDED.** Phase 3c is skeleton-only (KB body deferred). `pytest -q` should be green.
+4. **Next: Phases 8 + 9** per [`phase8-9-landing-and-fusion-spec.md`](phase8-9-landing-and-fusion-spec.md):
+   - Phase 8 first — mechanical (~30 min of edits): Landing CTA fixes + wallet button + RegimePanel dedup + Onboarding card opacity + Corpus Catalog cards→table + design polish.
+   - Phase 9 second — Fusion engine UI surface as a third Generate mode toggle.
+5. **Phase 4 + 5** — still pending Marten / Chuan alignment on open questions. If implementation proceeds without alignment, flag risk in PR description so they can course-correct on review.
+6. **KB pipeline production wiring** still waits on Dan's Linus-side iteration to settle.
 
 ---
 

--- a/docs/specs/spine-plus-v2-plan.md
+++ b/docs/specs/spine-plus-v2-plan.md
@@ -866,36 +866,109 @@ Phase 6 questions:
 
 ---
 
+# Phase 7 — Consolidation & dedup via t2o2
+
+**Status:** SPEC-READY — 4 judge-grade issues drafted in `docs/specs/`.
+Dan files to GitHub + assigns t2o2; humans review the resulting PRs.
+
+**Why this phase exists:** [`docs/chuan-architecture-survey.md`](../chuan-architecture-survey.md)
+identifies 14 gap clusters in `backend/archimedes/`. Of those, gaps #1, #2,
+#3, #5, #6 are *technical-debt cleanup* — well-bounded, mechanical, with
+clear acceptance criteria. They are the exact shape t2o2 executes well
+(per CLAUDE.md's "agentic issue pipeline" section). Hand-implementing
+them would burn hosted-Claude budget on work t2o2 can do for ~free.
+
+**Phase 7 deliverable: 4 judge-grade issues filed + assigned to t2o2.**
+
+| # | Issue | Survey gap | Spec file | Owner-reviewer |
+|---|---|---|---|---|
+| 7.1 | Fusion-output → backtestable DSL | (the wedge) | [`fusion-to-backtest-t2o2-issue.md`](fusion-to-backtest-t2o2-issue.md) — filed as **#128** | Dan + Daniel R. |
+| 7.2 | Rigor consolidation on `rigor_evaluator.py` | #1 | [`phase7-rigor-consolidation-t2o2-issue.md`](phase7-rigor-consolidation-t2o2-issue.md) | Önder |
+| 7.3 | LLM backend unification on `llm_backend.py` | #3 | [`phase7-llm-backend-unification-t2o2-issue.md`](phase7-llm-backend-unification-t2o2-issue.md) | Daniel R. / Dan |
+| 7.4 | Portfolio constructor retirement | #5 | [`phase7-portfolio-constructor-retirement-t2o2-issue.md`](phase7-portfolio-constructor-retirement-t2o2-issue.md) | Önder |
+| 7.5 | `routes.py` monolith split | #6 | [`phase7-routes-py-split-t2o2-issue.md`](phase7-routes-py-split-t2o2-issue.md) | Chuan / Daniel R. |
+
+**Suggested ordering** (t2o2 PRs land serially to avoid import-path conflicts):
+
+```
+7.1 (#128 fusion-DSL)    — already filed, parallel-OK
+    │
+7.2 (rigor consolidation) — must land before 7.1 PR merges
+    │
+7.3 (LLM backend)         — independent
+    │
+7.4 (constructors)        — depends on 7.2's import path
+    │
+7.5 (routes.py split)     — last; touches the most files; depends on 7.2-7.4 settling
+```
+
+**Survey gaps not covered by Phase 7 (treatment notes):**
+
+- **#2 Regime detector duplication** — spec not yet drafted because the
+  call-site mapping needs Önder's input (which detector is wired to
+  `RegimePanel`?). File as a t2o2 issue once Önder confirms. **Open
+  question for next standup.**
+- **#4 Arxiv intake paths** — three parallel paths (`arxiv_corpus.py`,
+  `corpus_service.py`, `scripts/bulk_ingest_arxiv.py`). Adjacent to the
+  KB pipeline work Dan is iterating on in Linus; consolidate when that
+  stabilizes. **Defer.**
+- **#8 marketplace_service.py seed-data** — Chuan already pruned 607 lines
+  Day-10; the remaining wiring to real strategy data is small. File as
+  a t2o2 issue when Phase 7.5 (routes split) settles, since both touch
+  marketplace surfaces.
+- **#9 Scheduled corpus intake / artifact build** — Phase 3c's `kb_runner.py`
+  is the pattern. When the KB pipeline production body lands, the same
+  pattern extends to `corpus_service.intake_from_arxiv()`. **Fold into
+  Phase 3c completion.**
+- **#10 Operational scripts → Makefile** — quality-of-life, not blocking.
+  File a small t2o2 issue when convenient. Low priority.
+- **#12 `circle_service.py` is judge-oriented** — by design (rubric surface).
+  No action.
+- **#13 `stress_engine.py` not wired to UI** — Phase 4 candidate (Portfolio
+  page would surface the scenario table). Hold for Phase 4.
+
+**Phase 7 acceptance** (when fully filed + merged):
+
+- All four t2o2 PRs merged to `main`.
+- `pytest -q` green (307+ passed, no new flakes).
+- API URL set unchanged (no frontend impact).
+- One Open Questions item resolved per gap; survey doc refreshed.
+
+---
+
 # Time tracking template
 
 Update this table at phase close. No prospective estimates.
 
 | Phase | Started | Completed | Hours actual | Notes |
 |---|---|---|---|---|
-| 0 — Specs | | | | |
-| 1 — Junk | | | | |
-| 2 — Streaming Generate | | | | |
-| 3a — Explore | | | | |
-| 3b — Corpus polish | | | | |
-| 3c — KB integration | | | | |
-| 4 — Vault (PENDING) | | | | |
-| 5 — Real trade (PENDING) | | | | |
-| 6 — Onboarding (PENDING) | | | | |
+| 0 — Specs | 2026-05-22 | 2026-05-22 | ~2.5 | 6 specs · `5fc2eb9` |
+| 1 — Junk | 2026-05-22 | 2026-05-22 | ~2 | `f21ac8d` + `00d8f09` |
+| 2 — Streaming Generate | 2026-05-22 | 2026-05-22 | ~4 | `28dd93a` (+1495/-20) |
+| 3a — Explore | 2026-05-22 | 2026-05-22 | ~1.5 | part of `50edb28` |
+| 3b — Corpus polish | 2026-05-22 | 2026-05-22 | ~0.5 | part of `50edb28` |
+| 3c — KB integration (skeleton) | 2026-05-22 | 2026-05-22 | ~1.5 | part of `50edb28`; production body deferred |
+| Phase 2 follow-ups | 2026-05-22 | 2026-05-22 | ~2 | `7b1c1e3` — cancel/rigor/brief-validation |
+| Phase 7 specs drafted | 2026-05-22 | 2026-05-22 | ~1 | 4 issue specs in `docs/specs/`; #128 filed |
+| 4 — Vault (PENDING) | | | | needs Marten alignment |
+| 5 — Real trade (PENDING) | | | | needs Chuan alignment |
+| 6 — Onboarding (PENDING) | | | | Dan can do solo |
+| 7 — Dedup via t2o2 (PENDING) | | | | Dan files; t2o2 executes |
 
 ---
 
-# Suggested kickoff sequence (post-compaction)
+# Suggested kickoff sequence (post-compaction, 2026-05-23+)
 
 When the next session resumes:
 
-1. Read this doc + [`docs/chuan-architecture-survey.md`](chuan-architecture-survey.md) for context.
-2. Confirm branch hygiene: are we on `dbrowneup/spine-plus-v2`? Was `d4dd465` rebased onto latest main?
-3. Phase 0: draft the 6 spec files (one PR). Lead: Dan; reviewers: Marten + Chuan.
-4. Phase 1: parallel-track junk cleanup (separate PR).
-5. Standup: align on the open questions above; confirm Phase 2-3 owners.
-6. Phase 2: streaming Generate (separate PR).
-7. Phase 3: Explore + corpus + KB (could split into 3a/3b/3c PRs).
-8. Standup: review Phase 4-6 specs with Chuan + Marten, decide kickoff timing.
+1. Read this doc + [`docs/chuan-architecture-survey.md`](../chuan-architecture-survey.md) for context.
+2. Confirm branch hygiene: are we on `dbrowneup/spine-plus-v2`? Rebase onto latest `origin/main` if Chuan has moved it.
+3. **Phase 0-3 + Phase 2 follow-ups are LANDED** (7 commits on the branch). Branch tip is the last commit of the day. `pytest -q` → 307 passed.
+4. **Issue #128 (fusion-to-backtest DSL)** filed + assigned to t2o2 on 2026-05-22. Check PR draft status.
+5. **Phase 7 next**: file the 4 drafted issue specs (`docs/specs/phase7-*-t2o2-issue.md`) as GitHub issues + assign t2o2. Order them as suggested in the Phase 7 section above (7.2 → 7.3 → 7.4 → 7.5; 7.1 = #128 is already in flight).
+6. **Phase 6 (onboarding)** — Dan can solo if there's time.
+7. **Phase 4 + 5** — wait for Marten / Chuan standup alignment.
+8. KB pipeline production wiring waits on Dan's Linus-side iteration to settle.
 
 ---
 

--- a/docs/specs/spine-plus-v2-plan.md
+++ b/docs/specs/spine-plus-v2-plan.md
@@ -1,0 +1,900 @@
+# Archimedes Spine+ v2 — Phase Plan
+
+> **Status:** Drafted 2026-05-22 by Dan + Claude session at end of context window
+> ahead of compaction. Reflects the strip-to-spine commit (`d4dd465`),
+> [`docs/chuan-architecture-survey.md`](chuan-architecture-survey.md) Day-10
+> updates, and the post-strip product walkthrough.
+>
+> **Phases 0-3 are ready to execute.** Phases 4-6 are scoped but **pending
+> alignment with Marten (vault contracts) and Chuan (chain/agent integration)**
+> before kickoff.
+>
+> **Branch:** `dbrowneup/spine-plus-v2`, branched off latest `main` with
+> `d4dd465` (strip-to-spine) rebased on top as the starting state.
+>
+> **How to read:** each phase has (1) problem statement, (2) scope with concrete
+> files, (3) acceptance criteria (machine-checkable where possible), (4)
+> anti-goals, (5) dependencies, (6) suggested owner, (7) open questions for
+> team weigh-in. The "open questions" sections are the explicit asks for input.
+
+---
+
+## Cross-cutting principles
+
+These apply to every phase. Violating one of these is a review-blocker.
+
+1. **Honesty first.** No mock data, no fake authors, no placeholder copy that
+   masquerades as real. If a feature isn't wired, the UI says "pending" or
+   isn't surfaced. If an action fails on-chain, the error message says why
+   specifically, not "(off-chain only)" as a casual aside.
+2. **No new routes go into `api/routes.py`.** It's at ~2315 lines per Marten's
+   survey. Every new endpoint lands in a dedicated router file
+   (`generate_routes.py`, `explore_routes.py`, etc.) per the pattern already
+   set by `chat_routes.py` / `marketplace_routes.py` / `risk_routes.py` /
+   `selection_bias_routes.py`. No back-port of existing endpoints — just stop
+   making the monolith worse.
+3. **Time tracking, not estimating.** Phases log start/end timestamps in this
+   doc as they complete. No prospective estimates — we build calibration data
+   from observed work.
+4. **One PR per phase.** Phase 0 is one specs PR; each subsequent phase is its
+   own PR with passing tests + a one-paragraph post-mortem (what was harder
+   than expected, what was easier, where the spec needed amendment).
+5. **Specs are living.** If reality diverges from a spec during execution,
+   update the spec in the same PR. Specs that go stale are worse than no specs.
+6. **Lanes are guidance, not gates.** Per [`CLAUDE.md`](../../CLAUDE.md): an
+   assigned issue is yours to execute regardless of nominal lane. Flag
+   cross-lane review needs in the PR description; don't refuse work.
+
+---
+
+## Decisions captured (locked, do not re-litigate without team alignment)
+
+| Decision | Locked answer |
+|---|---|
+| Vault semantics | Time-bound execution container (1 strategy + capital + window) |
+| Strategy↔Vault cardinality | 1:1 |
+| Generate UX | SSE streaming on top of `portfolio_agent.py`; events emitted per iteration |
+| Multi-strategy mechanic | Agent runs N candidates internally, surfaces single best, rejects browsable |
+| MVP loop | Generate → Library → Deploy as vault → wallet signs deposit + setTargetAllocations → trade on Arc testnet → Portfolio reflects state |
+| KB integration scope | Full pipeline (SPECTER2 + HDBSCAN/BERTopic + REBEL/SciSpacy) + scheduled re-runs |
+| Phase order after 0+1 | 2 → 3 → 4 → 5 → 6 |
+
+---
+
+# Phase 0 — Architectural Specs
+
+**Status:** READY TO EXECUTE
+**Branch:** `dbrowneup/spine-plus-v2`
+**PR shape:** single docs PR landing 6 new files under `docs/specs/`
+
+## Problem
+
+The current codebase has at least four conceptual ambiguities that cause
+every screen to improvise its own version of the truth:
+
+- What is a Vault? (Time-bound vs perpetual; multi-strategy vs single)
+- What is the Strategy lifecycle? (Where do generated strategies live before
+  deployment? How do they expire?)
+- Which of the four portfolio constructors fires when? (Marten's survey gap
+  cluster #5 — "load-bearing")
+- What does each spine page do that's distinct from the others? (Library vs
+  Reasoning currently overlap; Explore is missing)
+
+Phase 0 settles these in writing so Phases 1-6 build on a shared model.
+
+## Scope
+
+Six new spec files. Each is short (300-500 words) and answers the questions
+listed below. No code in this phase.
+
+### 0.1 `docs/specs/vault-semantics-spec.md`
+
+**Questions to answer:**
+- A Vault is _____ (time-bound execution container holding 1 strategy + capital + window).
+- The lifecycle is: created → ___ → ___ → ___ → completed/expired. Name each transition + what triggers it.
+- What does "trade window" mean concretely? (Start time, end time, what happens at each boundary.)
+- Can a vault be re-used after completion? (Recommended: no; user generates a new strategy and deploys a new vault.)
+- What is the on-chain artifact? (The multi-asset NAV `Vault.sol`, deployed Day-10.)
+- How does the agent runner interact with a vault during its window? (Default: deploy initial allocation at window-open; rebalance only if the strategy DSL says so; unwind at window-close.)
+- What happens if the user doesn't deposit by window-open? (Vault expires un-deployed; recorded in Library as "expired" for post-hoc inspection.)
+- Failure modes: window passes mid-trade, oracle goes stale, AMM has no liquidity.
+
+**Acceptance:** every Phase 4 implementation decision can be derived from this doc.
+
+### 0.2 `docs/specs/strategy-lifecycle-spec.md`
+
+**Questions to answer:**
+- Lifecycle states (proposed): `Generated → Validated → Deployed → Active → Completed | Expired | Rejected`. Define each.
+- Which fields are populated at which transition? (E.g., `rigor_verdict` populates at Validated; `vault_address` at Deployed; `realized_pnl` at Completed.)
+- Who triggers each transition? (Generated: agent. Validated: rigor gate. Deployed: user. Active: vault contract event. Completed/Expired: time + agent. Rejected: rigor gate failure.)
+- How does this interact with the `StrategyRecord.status` column (currently `candidate | live | retired`)? Either remap or expand the enum.
+- What's the "time-bound expiry" semantics? (A generated strategy that isn't deployed within N hours becomes Expired. N = ?)
+- Where do expired-un-deployed strategies live in the UI? (Library > Generated tab, filterable, with original reasoning still inspectable.)
+
+**Acceptance:** every Library/Portfolio filter and every state transition in
+Phase 2-5 maps cleanly to a state in this doc.
+
+### 0.3 `docs/specs/page-roles-spec.md`
+
+For each spine page, answer: (1) one-sentence purpose, (2) primary API calls,
+(3) what it's explicitly NOT for, (4) what links out to what.
+
+Pages to spec:
+- `/` Landing — marketing surface, no wallet required
+- `/explore` Explore (NEW in v2) — live asset prices + plain-English stats; read-only asset discovery
+- `/generate` Generate — streaming strategy generation
+- `/library` Library — Generated + Examples tabs; outcome of generation
+- `/strategy/:id` Strategy passport (NEW in v2) — full passport with Deploy CTA
+- `/corpus` Corpus — paper catalog + overview + graph + KG
+- `/portfolio` Portfolio — user's vaults + agent activity + stress scenarios
+- `/reasoning` Reasoning — trace browser only (no strategy listing)
+- `/learnings` Learnings — realized performance + post-hoc reasoning
+
+**Acceptance:** Library never lists traces; Reasoning never lists strategies;
+Explore never appears on Portfolio. No surface overlap remains.
+
+### 0.4 `docs/specs/portfolio-constructor-decision-tree.md`
+
+Per [survey gap cluster #5](../chuan-architecture-survey.md), four
+constructors exist with no documented hierarchy:
+
+| File | Lines | Role (proposed) |
+|---|---|---|
+| `services/portfolio_agent.py` | 850 | LLM-agentic top-level constructor (Day-10) |
+| `services/portfolio_constructor.py` | 285 | Orchestrator routing to (a)/(b)/(c) by regime |
+| `services/kelly_portfolio.py` | 505 | Kelly sizing + risk parity |
+| `services/portfolio_optimizer.py` | ~235 | Pure MVO (Önder's) |
+
+**Questions to answer:**
+- Which constructor fires for which entry point? (Generate page → ?, agent runner tick → ?, architect fast preview → ?)
+- Are `kelly_portfolio.py` and `portfolio_optimizer.py` alternatives, or composable layers? (Marten guesses: composable — optimizer computes weights, Kelly sizes them.)
+- How does `portfolio_agent.py` interact with the deterministic constructors? (Survey hypothesis: replaces them entirely for LLM-agentic path; deterministic chain is the fallback when LLM unavailable.)
+- The `_DRIFT_THRESHOLD` differs across files (0.15 vs 0.05). Which is canonical?
+- Where does this decision get made in code? (Recommended: a small `pick_constructor()` helper that takes `(mode, llm_available, regime)` and returns the right constructor.)
+
+**Acceptance:** Phase 2 instrumentation knows which constructor's events to
+emit. Future bug fixes know which file to edit.
+
+### 0.5 `docs/specs/generation-streaming-spec.md`
+
+The SSE protocol Phase 2 implements. Concretely:
+
+**Endpoint:** `GET /api/generate/stream/{job_id}` (Server-Sent Events)
+
+**Event schema** (each event is `event: <name>\ndata: <json>\n\n`):
+
+```
+job_queued          { job_id, brief, ts }
+brief_validated     { job_id, asset_classes, risk_appetite, ts }
+candidates_selected { job_id, candidate_count, source_arxiv_ids: [...], ts }
+agent_iteration     { job_id, iteration_n, max_iterations, ts }
+tool_called         { job_id, tool_name, args_summary, ts }
+tool_result         { job_id, tool_name, result_summary, ts }
+candidate_drafted   { job_id, candidate_id, strategy_name, ts }
+candidate_evaluated { job_id, candidate_id, rigor_verdict: { dsr, pbo, oos_sharpe, passes }, ts }
+best_selected       { job_id, best_candidate_id, considered_count, ts }
+trace_hashed        { job_id, trace_hash, ts }
+persisted           { job_id, strategy_id, redirect_url, ts }
+done                { job_id, strategy_id, ts }
+error               { job_id, message, recoverable: bool, ts }
+```
+
+**Questions to answer in the spec:**
+- Reconnection semantics: if the client disconnects mid-stream, can it
+  reconnect and resume? (Recommended: yes; events are durable in Redis for
+  N minutes, client sends `Last-Event-ID` header.)
+- Job persistence across page navigation: where do in-flight jobs live so the
+  Generate page can re-attach after a back-button? (Recommended: a small
+  Redis-backed `jobs:{job_id}` key holding the event log; frontend stores
+  `currentJobId` in localStorage and re-subscribes on mount.)
+- Backpressure: if the agent emits 100 events/sec, do we batch?
+  (Probably not — agent iterations are seconds apart, not milliseconds.)
+- Failure mode: agent loop hits `MAX_AGENT_ITERATIONS=12` without producing a
+  valid candidate. What does the user see? (`error` event with
+  `recoverable: true` and a "regenerate" CTA.)
+
+**Acceptance:** Phase 2 frontend implementation can be built directly from
+this doc without re-asking.
+
+### 0.6 `docs/specs/kb-integration-spec.md`
+
+How [`submodules/KnowledgeBase/`](../../submodules/KnowledgeBase/) lands on our
+corpus. **No re-implementation** — the spec describes how to invoke the
+existing pipeline and where its outputs persist.
+
+**Questions to answer:**
+- Which entry-point script in the KB submodule runs the full pipeline?
+  (Inspect `submodules/KnowledgeBase/papers_analysis/*.py` and document.)
+- Inputs: where does KB read paper text from? (Currently `data/corpus/text/`
+  populated by `scripts/hydrate_corpus.py` — that script downloads PDFs +
+  extracts text via PyMuPDF.)
+- Outputs: SPECTER2 embeddings (N×768 numpy), HDBSCAN cluster_id per paper,
+  BERTopic topic_label per paper, REBEL+SciSpacy KG (entities + relations).
+  Where does each persist?
+  - Embeddings → `archimedes-corpus-artifact` named volume as `embeddings.npy` + `ids.json`
+  - Cluster IDs + topic labels → `PaperRecord.cluster_id` + `PaperRecord.topic_label` columns (already exist, currently NULL)
+  - KG entities/relations → new tables `kg_entities` + `kg_relations` (alembic-less ALTER TABLE add)
+- How is the pipeline triggered?
+  - **Operator-triggered for first run:** `python -m archimedes.scripts.run_kb_pipeline`
+  - **Scheduled going forward:** new `kb_runner.py` standalone process (mirroring `chain/oracle_runner.py`) — sleeps + polls for "have N new papers landed since last run?", triggers pipeline if so. New docker-compose service.
+- Re-run triggers: what counts as "needs re-run"? (Recommended: ≥100 new
+  papers OR ≥7 days elapsed since last run, whichever first.)
+- What if the KB pipeline takes hours? (Run in a separate container with its
+  own resources; doesn't block the API. Status surfaced via
+  `kb_runner_state` Redis key.)
+
+**Acceptance:** Phase 3 KB integration work has zero ambiguity about which
+scripts to invoke, where outputs go, and how the scheduler runs.
+
+## Phase 0 deliverable summary
+
+- 6 new files under `docs/specs/`, each 300-500 words
+- Single PR, "Phase 0: architectural specs for Spine+ v2"
+- No code, no tests, no docker changes
+- Reviewer focus: do these specs answer enough questions to unblock Phases 1-6?
+
+## Phase 0 suggested owner
+
+**Lead:** Dan (you). You have the conceptual model in your head from this
+session.
+
+**Reviewers:** Marten (cross-check against architecture survey), Chuan
+(vault-semantics + portfolio-constructor decision tree affect his lane).
+
+## Phase 0 open questions for team
+
+- Strategy expiry TTL: how many hours before a generated-but-undeployed
+  strategy goes Expired? (24h? 72h? Live-data-dependent?)
+- Does Vault re-use ever make sense? (E.g., re-deploying the same strategy
+  into the same vault after window-close.)
+- Is the KB pipeline scheduler appropriate as a new docker-compose service,
+  or should it be a cron job on the host?
+
+---
+
+# Phase 1 — Junk extermination + UX fixes
+
+**Status:** READY TO EXECUTE
+**Dependencies:** None (parallelizable with Phase 0)
+**PR shape:** small, focused, no behavior changes beyond mock-data removal + wallet network filter
+
+## Problem
+
+The strip-to-spine commit removed the worst offenders (Marketplace cards,
+dev-test Publish form) but the codebase still has at least these
+honesty-violation residues, all of which surfaced in user walkthroughs:
+
+1. **PR #37 / PR #38 mock pills** on Reasoning page strategy detail panel
+   (hardcoded in `Reasoning.jsx::StrategyDetailView` — not removed in the
+   strip)
+2. **Off-chain casual asides** ("(off-chain only)") in Portfolio agent
+   activity feed when on-chain anchor failed — should surface the *reason*
+   for failure, not bury it
+3. **MetaMask network filter too broad** — `wallet_requestPermissions` asks
+   for 8+ chains; should only request Arc Testnet
+4. **Reasoning page still lists strategies** alongside traces — overlap with
+   Library; should be traces-only per page-roles-spec
+5. **Learnings page is decorative copy** — either populate from real
+   Portfolio data or hide from nav until it has signal
+6. **Stale ownership comments** in `interfaces/agent.py`, `chain.py`,
+   `math.py` reference owners that don't reflect bot-driven authoring
+   reality (survey gap #7)
+7. **`TODO: Implement with stored price history`** in `api/routes.py:172`
+   (survey gap #11) — either implement or close the asset history endpoint
+   honestly (404 with explanation)
+
+## Scope (concrete files)
+
+| File | Change |
+|---|---|
+| `ui/src/components/Reasoning.jsx` | Remove `StrategyDetailView` strategy listing OR move it to `/library`; remove PR #37/#38 RELATED pills |
+| `ui/src/components/Portfolio.jsx` | Improve off-chain failure messaging (show actual reason from API) |
+| `ui/src/config.js` | Constrain `wallet_addEthereumChain` to Arc only on first connect; don't request broad permissions |
+| `ui/src/components/Learnings.jsx` | Either wire to a real `/api/learnings/` endpoint (returning realized PnL per deployed vault) OR hide from `Layout.jsx` nav until Phase 4-5 lands |
+| `backend/archimedes/interfaces/*.py` | Update stale docstrings to reflect current authoring reality |
+| `backend/archimedes/api/routes.py:172` | Remove the `# TODO` and implement OR return 501 with explicit "not yet implemented" |
+
+## Acceptance criteria
+
+- [ ] `grep -rn "PR #37\|PR #38" ui/` → empty
+- [ ] `grep -rn "(off-chain only)" ui/` → empty (replaced with real failure surface)
+- [ ] Manual: connecting MetaMask shows only Arc Testnet in the permissions card
+- [ ] `grep -nE "Implement with stored price" backend/` → empty
+- [ ] `pytest -q` → 265+ passed / 0 failed (no regressions)
+- [ ] Build green: `docker compose build nginx backend` succeeds
+- [ ] PR description includes a screenshot of MetaMask permissions card showing only Arc
+
+## Anti-goals
+
+- Do NOT refactor `routes.py` or `Strategies.jsx` structurally in this phase.
+  Surface-cleanup only.
+- Do NOT add new features — Phase 1 is subtractive + small fixes.
+- Do NOT change any API contracts. Schema changes belong in their owning phase.
+
+## Suggested owner
+
+**Lead:** anyone with a focused 2-3 hour block. First-thing-post-standup
+candidate. Daniel R. is in-character for the frontend mock removal; t2o2 is
+fine for the backend cleanup.
+
+## Phase 1 open questions for team
+
+- Should the off-chain-anchor failure surface a "retry" button, or just log
+  the reason and move on?
+- Learnings page: hide-until-ready (recommended) or stub-with-real-empty-state?
+
+---
+
+# Phase 2 — Streaming Generate on `portfolio_agent.py`
+
+**Status:** READY TO EXECUTE (after Phase 0 spec 0.5 lands)
+**Dependencies:** Phase 0.5 (`generation-streaming-spec.md`); Phase 0.4 (`portfolio-constructor-decision-tree.md`)
+**PR shape:** larger; includes backend SSE endpoint + frontend stream UI + multi-strategy mechanic
+
+## Problem
+
+Three gaps observed in the strip-to-spine state:
+
+1. **Generate page calls architect synchronously** (`/api/strategies/construct`)
+   not fusion (`/api/strategies/generate?mode=fusion`). User sees a 6-strategy
+   library output in <1s and rightly thinks "this is suspicious."
+2. **No status surface for async generation** — if user navigates away mid-
+   generation, the job appears to die.
+3. **Single-strategy output** — user pointed out a good system should generate
+   multiple candidates internally and surface the best. Aligns with how
+   `portfolio_agent.py` already iterates (`MAX_AGENT_ITERATIONS=12`).
+
+## Scope
+
+### Backend
+
+| File | Change |
+|---|---|
+| `backend/archimedes/api/generate_routes.py` (NEW) | New dedicated router for Generate endpoints. Per cross-cutting principle #2, this does NOT live in `routes.py`. |
+| `backend/archimedes/services/portfolio_agent.py` | Instrument iteration loop to emit events (callback hook the SSE endpoint subscribes to). |
+| `backend/archimedes/services/generation_pipeline.py` (NEW) | New orchestrator: receives brief, runs `portfolio_agent` N times for N candidates, evaluates each through rigor gate, persists best, emits events at each step. |
+| `backend/archimedes/services/job_queue.py` | Extend to support the per-job event log Redis key (`jobs:{job_id}:events`) referenced in the spec. |
+| `backend/archimedes/api/generate_schemas.py` (NEW) | Pydantic models for the event payloads. |
+
+### Frontend
+
+| File | Change |
+|---|---|
+| `ui/src/components/Generate.jsx` | Replace `<StrategyArchitect>` call with new streaming UI. Architect becomes a labeled "fast preview" toggle. |
+| `ui/src/components/GenerationStream.jsx` (NEW) | The live event stream renderer. Shows each event as it arrives; renders the agent's intermediate work. |
+| `ui/src/components/GenerationStatus.jsx` (NEW) | Compact status table at bottom of Generate page showing in-flight + recently completed jobs. Persists `currentJobId` in localStorage so navigating away + back resumes the stream. |
+| `ui/src/components/RejectedCandidates.jsx` (NEW) | Modal/sub-view showing the N-1 rejected candidates with their rigor verdicts. Linked from the "considered N candidates" caption. |
+
+### API contract (informal — `generation-streaming-spec.md` is authoritative)
+
+```
+POST /api/generate/start
+  body: { brief: { intent, risk_appetite, asset_classes?, capital_usdc, max_papers? } }
+  returns 202: { job_id }
+
+GET /api/generate/stream/{job_id}
+  Server-Sent Events stream (see spec 0.5 for event types)
+
+GET /api/generate/jobs
+  returns { jobs: [{ job_id, state, created_at, ... }] }
+  Used by GenerationStatus.jsx to populate the status table.
+
+GET /api/generate/jobs/{job_id}/candidates
+  returns { candidates: [...], best_id }
+  Used by RejectedCandidates.jsx.
+```
+
+## Acceptance criteria
+
+- [ ] Click "Generate" → SSE stream opens within 500ms
+- [ ] Each `portfolio_agent` iteration produces a visible event in the UI
+- [ ] If user navigates from `/generate` to `/library` and back, the in-flight job is still streaming
+- [ ] On completion, "View in Library" CTA links to the persisted strategy
+- [ ] When agent produces N candidates, only the best surfaces by default; "considered N candidates" link opens the rejected list with full rigor verdicts visible
+- [ ] If `MAX_AGENT_ITERATIONS` hits without a valid candidate: error event with recoverable=true and a regenerate CTA
+- [ ] `pytest backend/tests/services/test_generation_pipeline.py` → all green
+- [ ] Manual: kill the backend mid-stream → frontend shows "connection lost, retrying"; restart backend → stream resumes from last-known event ID
+- [ ] No regression: `/api/strategies/construct` (architect path) still works as the "fast preview" toggle
+
+## Anti-goals
+
+- Do NOT replace `portfolio_agent.py`'s internals — just add a callback hook for events.
+- Do NOT use websockets; SSE is sufficient and simpler.
+- Do NOT batch events — agent iterations are seconds apart; per-event overhead is negligible.
+- Do NOT log strategy text into Redis events (the full text persists in `strategy_store` after `persisted`); events should be summary-shaped.
+- Do NOT require LLM credentials for the test suite; mock `portfolio_agent`'s LLM call with a deterministic fixture in tests.
+
+## Suggested owner
+
+**Lead:** Daniel R. (backend FastAPI lane) + t2o2 issue. `portfolio_agent.py`
+is `t2o2`-authored; instrumenting it for SSE is a natural extension. The
+frontend stream UI is small enough that whichever frontend dev picks it up
+can crank it out.
+
+**Reviewers:** Dan (multi-strategy mechanic correctness), Chuan (agent
+behavior under iteration limits).
+
+## Phase 2 open questions for team
+
+- N candidates per request: fixed at 3? Configurable per risk profile? Always
+  N until rigor gate passes for one?
+- Architect "fast preview" toggle copy: how do we describe it honestly?
+  Suggestion: "Skip the fusion engine and let the architect pick from the
+  curated library — faster but less novel."
+- Should the rejected candidates persist long-term (so post-hoc inspection
+  is always available) or only for the session?
+
+---
+
+# Phase 3 — Real Explore + Corpus depth + KB integration
+
+**Status:** READY TO EXECUTE (after Phase 0 specs 0.3 and 0.6 land)
+**Dependencies:** Phase 0.3 (`page-roles-spec`), Phase 0.6 (`kb-integration-spec`)
+**PR shape:** the largest single phase; could split into 3a (Explore), 3b (Corpus polish), 3c (KB integration)
+
+## Problem
+
+Four concrete gaps to close:
+
+1. **No asset-discovery surface.** Users need to see what's tradable before
+   generating. Oracle prices + market stats exist in the system but aren't
+   exposed as a browse experience.
+2. **Corpus category labels are inscrutable** to non-finance readers
+   (`q-fin.ST`, `q-fin.MF`, etc.). Need plain-English explanations on hover
+   or inline.
+3. **Graph + Knowledge Graph tabs are Potemkin** — category co-occurrence
+   from metadata, explicitly labeled as "pending KB pipeline port."
+4. **Corpus Catalog tab lacks the Papers.app-style three-pane chrome**
+   (sidebar + table + detail with PDF preview) the user pointed at as the
+   target UX.
+
+## Scope — 3a. Real Explore page
+
+### Backend
+
+| File | Change |
+|---|---|
+| `backend/archimedes/api/explore_routes.py` (NEW) | New router. NOT in `routes.py`. |
+| `backend/archimedes/services/asset_market_service.py` (NEW) | Composes oracle prices + 24h/7d/30d history (from `vault_monitor` snapshots OR live oracle reads) + plain-English stat explanations. |
+| `backend/archimedes/api/explore_schemas.py` (NEW) | Response models. |
+
+### API contract
+
+```
+GET /api/explore/assets
+  returns {
+    assets: [
+      {
+        symbol: "sTSLA",
+        name: "Tesla Synthetic",
+        current_price: 245.30,
+        change_24h_pct: 1.2,
+        change_7d_pct: -3.1,
+        change_30d_pct: 8.7,
+        realized_vol_30d: 0.42,
+        oracle_address: "0x...",
+        last_updated: "2026-05-22T...",
+        explanations: {
+          realized_vol_30d: "How much the price wobbles. Higher = bigger swings. 0.42 means daily moves of ~2.6% are typical.",
+          change_30d_pct: "..."
+        }
+      },
+      ...
+    ]
+  }
+
+GET /api/explore/assets/{symbol}/history
+  returns { symbol, points: [{ ts, price }, ...] }
+```
+
+### Frontend
+
+| File | Change |
+|---|---|
+| `ui/src/components/Explore.jsx` (NEW) | Table of all available assets with sparkline + current stats. Each metric has a `<Tooltip>` showing the plain-English explanation. |
+| `ui/src/components/Layout.jsx` | Add `Explore` to NAV between Home and Generate. |
+| `ui/src/App.jsx` | Route `/explore` → `<Explore>`. |
+
+### Acceptance (3a)
+
+- [ ] `/api/explore/assets` returns ≥7 assets (the existing synth set: TSLA, NVDA, SPY, BTC, GOLD, OIL, NIKKEI) with real oracle prices
+- [ ] Each asset row displays current price + 3 change windows + realized vol
+- [ ] Hover/tap on any metric shows a plain-English explanation
+- [ ] Page loads in <1s on the live stack (no synchronous on-chain reads — server-side cache w/ 30s TTL)
+- [ ] No fake data anywhere; if oracle is stale, the UI explicitly labels the asset "Stale (last update: ...)"
+
+## Scope — 3b. Corpus polish (Catalog + categories)
+
+### Backend
+
+| File | Change |
+|---|---|
+| `backend/archimedes/services/corpus_categories.py` (NEW) | Static dict mapping arxiv q-fin codes → plain English. Applied at API serialization. |
+| `backend/archimedes/api/routes.py` (papers section) | Inject `category_label` field next to `primary_category`. |
+
+### Category mapping (the full list — write into `corpus_categories.py`)
+
+```python
+CATEGORY_LABELS = {
+    "q-fin.ST":      "Statistical Finance",
+    "q-fin.MF":      "Mathematical Finance",
+    "q-fin.CP":      "Computational Finance",
+    "q-fin.RM":      "Risk Management",
+    "q-fin.PM":      "Portfolio Management",
+    "q-fin.TR":      "Trading & Market Microstructure",
+    "q-fin.GN":      "General Finance",
+    "q-fin.PR":      "Pricing of Securities",
+    "q-fin.EC":      "Economics (within q-fin)",
+    "cs.LG":         "Machine Learning",
+    "cs.CL":         "Natural Language Processing",
+    "cs.CE":         "Computational Engineering / Finance",
+    "stat.ME":       "Statistical Methodology",
+    "stat.ML":       "Machine Learning (statistics)",
+    "stat.AP":       "Applied Statistics",
+    "math.OC":       "Optimization & Control",
+    "math.PR":       "Probability",
+    "econ.GN":       "General Economics",
+    "econ.EM":       "Econometrics",
+    "physics.soc-ph": "Social Physics (econophysics)",
+    "quant-ph":      "Quantum Methods",
+}
+```
+
+### Frontend — Papers.app-style Catalog tab
+
+| File | Change |
+|---|---|
+| `ui/src/components/CorpusExplorer.jsx` | Replace `CatalogTab` body with three-pane layout: left=categories+saved-lists, middle=paper table sorted by year DESC (default) or citation count, right=detail pane. Default tab order: Catalog → Overview → Graph → KG. |
+| `ui/src/components/PaperDetailPane.jsx` (NEW) | Detail pane component used in Catalog (right pane) AND in the existing PaperDetail route. Single source of truth for detail rendering. |
+| `ui/src/components/CorpusSidebar.jsx` (NEW) | Left pane: category tree, saved-paper lists (localStorage-backed for v1), recently-viewed. |
+
+### Acceptance (3b)
+
+- [ ] Hover any q-fin category badge → tooltip shows plain English
+- [ ] Catalog tab default sort: year DESC; sortable by citations + year
+- [ ] Detail pane (right) shows abstract + arxiv link + PDF preview thumbnail + "cited by N strategies" + "save" button
+- [ ] Saved papers persist across reloads (localStorage)
+- [ ] Catalog is the default tab on `/corpus` (was Overview)
+
+## Scope — 3c. KB pipeline integration (full + scheduled)
+
+### Backend
+
+| File | Change |
+|---|---|
+| `backend/archimedes/scripts/run_kb_pipeline.py` (NEW) | Operator-triggered wrapper that invokes the `submodules/KnowledgeBase/papers_analysis/` pipeline on the current corpus + writes outputs. No re-implementation. |
+| `backend/archimedes/services/kb_runner.py` (NEW) | Standalone process loop mirroring `chain/oracle_runner.py`. Polls for "needs re-run?" condition. Default interval: 6h; default trigger: ≥100 new papers since last run OR 7 days elapsed. |
+| `backend/archimedes/models/kg.py` (NEW) | `KGEntity` + `KGRelation` ORM models. New tables `kg_entities`, `kg_relations`. |
+| `backend/archimedes/db.py` | Add idempotent ALTER TABLE for new KG tables (pattern matches the existing `papers.cluster_id` patch). |
+| `backend/archimedes/api/corpus_routes.py` (NEW) | New router for `/api/papers/corpus/graph` + `/kg` — replaces the metadata-derived stubs in `routes.py`. NOT in `routes.py`. |
+| `docker-compose.yml` | New service `kb-runner` mounting the corpus + artifact volume. |
+
+### kb_runner.py outline
+
+```python
+"""Periodic KnowledgeBase pipeline runner.
+
+Mirrors chain/oracle_runner.py's pattern: standalone python -m loop.
+Polls corpus state, runs full pipeline when trigger conditions met.
+"""
+
+import os, time, logging
+from datetime import datetime, timezone
+from archimedes.scripts.run_kb_pipeline import run_pipeline
+from archimedes.db import get_session
+from archimedes.models.corpus_store import PaperRecord, CorpusMetaRecord
+from archimedes.services.redis_state import AgentStateStore
+
+INTERVAL_SECONDS = int(os.getenv("KB_RUNNER_INTERVAL_SECONDS", "21600"))  # 6h
+NEW_PAPER_THRESHOLD = int(os.getenv("KB_NEW_PAPER_THRESHOLD", "100"))
+MAX_DAYS_SINCE_LAST = int(os.getenv("KB_MAX_DAYS_SINCE_LAST", "7"))
+
+def needs_rerun():
+    # last_run_ts + new_paper_count from CorpusMetaRecord or Redis
+    ...
+
+def main():
+    while True:
+        try:
+            if needs_rerun():
+                run_pipeline()
+        except Exception as exc:
+            logger.exception("kb pipeline failed: %s", exc)
+        time.sleep(INTERVAL_SECONDS)
+```
+
+### Frontend — Graph + KG tabs
+
+| File | Change |
+|---|---|
+| `ui/src/components/CorpusGraph.jsx` (extracted from `CorpusExplorer.jsx`) | Render real SPECTER2-similarity graph from `/api/papers/corpus/graph`. Force-directed layout. Color by cluster_id. |
+| `ui/src/components/CorpusKG.jsx` (extracted from `CorpusExplorer.jsx`) | Render REBEL/SciSpacy KG subgraph from `/api/papers/corpus/kg?entity=...`. |
+
+### Acceptance (3c)
+
+- [ ] First-run: `python -m archimedes.scripts.run_kb_pipeline` completes on the 10k corpus, populates `PaperRecord.cluster_id` + `topic_label` for ≥95% of papers, writes embeddings.npy + ids.json to the artifact volume
+- [ ] `kb-runner` container starts via docker-compose; logs "needs_rerun: False" on a fresh DB after first run
+- [ ] `/api/papers/corpus/graph` returns real SPECTER2-similarity edges (not metadata co-occurrence)
+- [ ] `/api/papers/corpus/kg?entity=momentum` returns real REBEL/SciSpacy entities + relations
+- [ ] Graph tab renders force-directed graph with cluster-color nodes
+- [ ] KG tab renders queryable subgraph
+- [ ] **The "(metadata-derived) placeholder" copy is gone from both tabs**
+- [ ] Total disk for KB artifacts in the named volume: documented in the spec (probably 1-5 GB for 10k papers)
+
+## Anti-goals (whole Phase 3)
+
+- Do NOT re-implement KB algorithms — invoke the submodule's existing code.
+- Do NOT block the API on KB pipeline runs — pipeline runs in a separate
+  container with its own resources.
+- Do NOT remove the existing Overview tab — it's the only thing that works
+  today; demote it to second-tab position behind Catalog.
+- Do NOT add fake data to Explore. If oracle is stale, label it stale.
+- Do NOT make the Explore page wallet-gated. Browsing assets is a no-wallet
+  surface per `page-roles-spec`.
+
+## Suggested owner
+
+**3a Explore lead:** Önder (asset stats math is in his lane) + you (Dan) for plain-English explanation copy.
+
+**3b Corpus polish lead:** anyone with frontend bandwidth; small UI change.
+
+**3c KB integration lead:** Dan (you own KnowledgeBase). The pipeline is your
+code; landing it on our corpus is mostly wiring + persistence schema.
+
+**Reviewers:** Marten (the new docker-compose service touches infra he might
+have opinions on), Chuan (the new tables go through `init_db`'s ALTER pattern
+he established).
+
+## Phase 3 open questions for team
+
+- Explore: should "deposit" or "trade" CTAs appear here, or strictly read-only with "go to Generate to use these"?
+- KB: what's our disk budget for the artifact volume in production? (10k papers × ~300 KB/paper = ~3 GB embeddings; KG output is smaller.)
+- KB: do we want to expose a "regenerate KG for these papers" button (manual trigger) or rely entirely on the runner?
+- KB: SPECTER2 inference may need GPU for reasonable throughput on 10k papers. CPU-only first run is acceptable but slow (estimate: hours). Worth confirming we have a CPU-acceptable path before scheduling.
+
+---
+
+# Phase 4 — Vault encapsulation (1:1, time-bound)
+
+**Status:** PENDING ALIGNMENT — needs Chuan + Marten review before kickoff
+**Dependencies:** Phase 0.1 (vault-semantics), Phase 0.2 (strategy-lifecycle), Phase 2 (generated strategies exist)
+
+## Problem (high-level)
+
+The Library has Generated strategies but no Deploy action — they remain
+pre-backtest hypotheses with no path to execution. The multi-asset NAV vault
+contract exists on chain (Day-10 deploy) but no UI surface creates one. We
+also need a real Strategy Passport route (`/strategy/:id`) that users land on
+from the Library row + the Generate result.
+
+## Scope (sketch — to be refined post-alignment)
+
+### Backend
+
+- `backend/archimedes/api/vault_routes.py` (NEW) — extracted from `routes.py` per cross-cutting principle #2. Endpoints: `POST /api/vaults/create-from-strategy`, `GET /api/vaults/{address}`, `GET /api/vaults/{address}/lifecycle-state`.
+- `backend/archimedes/services/vault_lifecycle.py` (NEW) — manages the state transitions defined in `strategy-lifecycle-spec.md`. Triggers state changes on time + on-chain events.
+- `backend/archimedes/services/vault_service.py` — extend with strategy-binding metadata + trade-window enforcement.
+
+### Frontend
+
+- `ui/src/components/StrategyPassport.jsx` (NEW) — `/strategy/:id` route. Full passport per `docs/specs/strategy-passport-spec.md`. Includes "Deploy as Vault" CTA.
+- `ui/src/components/CreateVaultModal.jsx` (NEW) — minimal flow: name + trade window (start/end, defaulted from strategy) + initial deposit. Two-step signing (USDC approve + Vault create).
+- `ui/src/components/Portfolio.jsx` — group vaults by lifecycle state per spec 0.2.
+- `ui/src/components/StressScenarioPanel.jsx` (NEW) — wires `stress_engine.py` output into Portfolio per Marten's survey gap #13.
+
+## Acceptance criteria (sketch)
+
+- [ ] From Library Generated tab, click strategy row → `/strategy/:id` passport loads
+- [ ] "Deploy as Vault" → modal collects name + window + deposit
+- [ ] On submit: wallet signs USDC approve, then Vault create via VaultFactory, then deposit, then setTargetAllocations
+- [ ] Vault appears in Portfolio under "Pending" until window-open time
+- [ ] At window-open, vault transitions to "Active"; agent runner performs initial allocation
+- [ ] At window-close, vault transitions to "Completed"; user can withdraw
+- [ ] `stress_engine.stress_all(vault_address)` results render in Portfolio scenario panel
+
+## Open alignment questions (Marten + Chuan)
+
+These are the things that need team sign-off before this phase starts:
+
+1. **Does the multi-asset NAV vault contract already support "trade window"
+   semantics natively, or do we enforce window externally (off-chain agent
+   refuses to act outside window)?** — Chuan
+2. **Vault creation flow: does VaultFactory.createVault need new args for
+   strategy_id + trade_window, or is metadata sufficient?** — Chuan
+3. **State transitions: who owns the transition trigger?** — Marten + Chuan.
+   Options: (a) agent runner polls + transitions; (b) on-chain events drive
+   off-chain state; (c) dedicated `vault_lifecycle.py` worker.
+4. **Withdrawal semantics at vault completion:** does the user manually
+   withdraw, or is it automatic + returned to wallet?
+5. **What does "Active" actually mean for the agent runner?** Currently the
+   runner does perpetual rebalancing. In the 1:1 time-bound model, "Active"
+   means executing the strategy's trade plan. Does the strategy carry the
+   trade plan, or does the agent construct it on `setTargetAllocations`?
+
+## Suggested owner (pending alignment)
+
+**Lead:** Chuan (chain integration) + Marten (vault/contract glue).
+**Frontend:** whoever has bandwidth — but the modal + passport route are
+small.
+
+---
+
+# Phase 5 — Real testnet trade execution
+
+**Status:** PENDING ALIGNMENT — needs Chuan kickoff
+**Dependencies:** Phase 4 (Vault encapsulation must land first); Phase 0.4 (portfolio-constructor-decision-tree)
+
+## Problem (high-level)
+
+The on-chain trade execution path (deposit → `setTargetAllocations` → AMM
+swap) is wired in code (`agent_runner.py` + `chain/executor.py`) but has not
+been verified end-to-end through the UI on Arc testnet with a real wallet.
+Until this happens, we don't actually know if the rebalance path executes.
+
+## Scope (sketch)
+
+- Verify `bootstrap-liquidity` endpoint produces AMM pools with sufficient liquidity for the synth assets the agent would pick
+- Implement (or verify existing) "Deploy" UX: user signs USDC approve, vault create, deposit, `setTargetAllocations` — each as a discrete signed step with progress visible
+- Verify the agent runner's tick picks up the new vault, computes target allocations, calls `executor.rebalance()`, AMM swap executes, oracle updates reflect new state
+- Capture full trace of one happy-path execution and anchor it on-chain via `ReasoningTraceRegistry`
+
+## Acceptance criteria (sketch)
+
+- [ ] One end-to-end signed execution from a real MetaMask wallet results in: (a) USDC deposited to vault, (b) vault holds synth tokens, (c) on-chain trace anchored, (d) Portfolio reflects state
+- [ ] Trace is verifiable via `/api/traces/{id}/verify` returning is_verified=true
+- [ ] Documented runbook for re-running the test (e.g., "after each contract redeploy")
+
+## Open alignment questions (Chuan primary)
+
+1. **Is the agent runner currently signing transactions, and if so, how is its key managed?** (Circle managed wallet? local key?)
+2. **Are the deployed AMM pools liquid enough for a realistic trade size?** (`bootstrap_vaults.py` provides initial seeding; need to verify post-deploy state.)
+3. **`setTargetAllocations` semantics:** does the vault execute swaps synchronously on this call, or is there a separate `rebalance` step?
+4. **Gas / USDC-as-gas on Arc testnet:** any setup the user needs beyond `Connect Wallet`?
+
+## Suggested owner
+
+**Lead:** Chuan (his lane). Marten supports.
+
+---
+
+# Phase 6 — Onboarding tour (MetaMask-style cards)
+
+**Status:** PENDING ALIGNMENT — low-priority but high-leverage for demo
+**Dependencies:** Phase 1 (junk clean so cards don't reference dead surfaces)
+
+## Problem (high-level)
+
+First-time visitors (judges, prospective users) don't know what Archimedes
+is, what each page does, or how the parts compose. Wallet-gated demos are
+worse without orientation.
+
+## Scope (sketch)
+
+- 6-card modal, MetaMask-style with pagination dots, illustrations, Continue/Skip
+- Card content:
+  1. **What is Archimedes?** — Research-grounded strategy generation; not a robo-advisor
+  2. **Browse the corpus** — 10k peer-reviewed q-fin papers feed every strategy
+  3. **Generate a strategy** — Describe what you want; the agent fuses papers into a hypothesis
+  4. **Inspect the reasoning** — Every decision is hashed and verifiable on Arc
+  5. **Deploy as a vault** — Time-bound execution; you control the window
+  6. **Watch the agent work** — Monitor portfolio + reasoning traces over time
+- Modal triggers on first visit (localStorage flag); "?" button in topbar re-launches anytime
+- "Skip" works on every card; "Continue" advances; closing without finishing remembers position
+
+## Acceptance criteria (sketch)
+
+- [ ] First-time visit → modal appears
+- [ ] Dismissed state persists across reloads
+- [ ] "?" topbar button reopens the tour
+- [ ] Each card links to its associated page (final CTA on each: "Go to <Page>")
+
+## Suggested owner
+
+**Lead:** Daniel R. (frontend specialty) or anyone with bandwidth.
+
+## Open alignment questions
+
+- Do we want to hire an illustrator or use simple SVG diagrams for the
+  card visuals? (Recommended: simple SVGs we can author in-repo.)
+- Should the tour be wallet-aware? (E.g., card 5 might say "Connect wallet to
+  deploy" when no wallet is connected.)
+
+---
+
+# Cross-cutting: routes.py monolith discipline
+
+Per cross-cutting principle #2 — every new endpoint in Phases 2-5 lands in a
+dedicated router. Specifically:
+
+| New router | Phase | Endpoints |
+|---|---|---|
+| `generate_routes.py` | 2 | `/api/generate/start`, `/api/generate/stream/{id}`, `/api/generate/jobs`, `/api/generate/jobs/{id}/candidates` |
+| `explore_routes.py` | 3a | `/api/explore/assets`, `/api/explore/assets/{symbol}/history` |
+| `corpus_routes.py` | 3c | `/api/papers/corpus/graph`, `/api/papers/corpus/kg` (move from `routes.py`) |
+| `vault_routes.py` | 4 | `/api/vaults/*` (move from `routes.py` or add new) |
+
+This is non-negotiable — Marten's gap cluster #6 is real and getting worse
+every phase. Holding the line keeps the next person sane.
+
+---
+
+# Open questions consolidated (for team standup)
+
+Phase 0 questions:
+- Strategy expiry TTL: how many hours before un-deployed → Expired?
+- Vault re-use: ever, never, or only same-strategy?
+- KB scheduler: docker-compose service or host cron?
+
+Phase 1 questions:
+- Off-chain failure: retry button or just log + move on?
+- Learnings: hide until ready (recommended) or stub-with-real-empty-state?
+
+Phase 2 questions:
+- N candidates per request: fixed at 3? Configurable?
+- Architect "fast preview" copy?
+- Rejected candidates persistence: session or long-term?
+
+Phase 3 questions:
+- Explore CTAs: read-only or include deposit/trade buttons?
+- KB disk budget in production?
+- KB regenerate-on-demand button: yes/no?
+- KB CPU-only first-run acceptable?
+
+Phase 4 questions (Chuan + Marten):
+- Trade window: contract-native or off-chain enforced?
+- VaultFactory.createVault args for strategy_id + window?
+- State-transition trigger ownership?
+- Withdrawal semantics at completion?
+- Agent's "Active" role with time-bound strategies?
+
+Phase 5 questions (Chuan):
+- Agent signing setup?
+- AMM liquidity post-deploy?
+- `setTargetAllocations` synchronous or two-step?
+- USDC-as-gas setup steps?
+
+Phase 6 questions:
+- Illustrations: hire or in-repo SVG?
+- Wallet-aware card content?
+
+---
+
+# Time tracking template
+
+Update this table at phase close. No prospective estimates.
+
+| Phase | Started | Completed | Hours actual | Notes |
+|---|---|---|---|---|
+| 0 — Specs | | | | |
+| 1 — Junk | | | | |
+| 2 — Streaming Generate | | | | |
+| 3a — Explore | | | | |
+| 3b — Corpus polish | | | | |
+| 3c — KB integration | | | | |
+| 4 — Vault (PENDING) | | | | |
+| 5 — Real trade (PENDING) | | | | |
+| 6 — Onboarding (PENDING) | | | | |
+
+---
+
+# Suggested kickoff sequence (post-compaction)
+
+When the next session resumes:
+
+1. Read this doc + [`docs/chuan-architecture-survey.md`](chuan-architecture-survey.md) for context.
+2. Confirm branch hygiene: are we on `dbrowneup/spine-plus-v2`? Was `d4dd465` rebased onto latest main?
+3. Phase 0: draft the 6 spec files (one PR). Lead: Dan; reviewers: Marten + Chuan.
+4. Phase 1: parallel-track junk cleanup (separate PR).
+5. Standup: align on the open questions above; confirm Phase 2-3 owners.
+6. Phase 2: streaming Generate (separate PR).
+7. Phase 3: Explore + corpus + KB (could split into 3a/3b/3c PRs).
+8. Standup: review Phase 4-6 specs with Chuan + Marten, decide kickoff timing.
+
+---
+
+# Document history
+
+- **2026-05-22** — Initial draft (Dan + Claude session). Locked decisions:
+  vault semantics (time-bound, 1:1), generation UX (streaming), KB scope
+  (full + scheduled), phase order (2→3→4→5→6). Phases 4-6 explicitly
+  pending team alignment.

--- a/docs/specs/spine-plus-v2-plan.md
+++ b/docs/specs/spine-plus-v2-plan.md
@@ -254,7 +254,14 @@ session.
 
 # Phase 1 — Junk extermination + UX fixes
 
-**Status:** READY TO EXECUTE
+**Status:** LANDED — `4e28761` (cherry-pick) + follow-up commit landing
+deferred items (#2 Reasoning restructure + Library export move + `?highlight=`
+deep-link, #3 Learnings onNavigate, #4 ownership reframe). **#1 MetaMask
+filter:** resolved in the earlier wallet-bug fix (`ensureArcChain` requests
+Arc only, never `wallet_requestPermissions`); awaiting one manual MetaMask
+popup verification on the deploy. Reopen only if the popup still surfaces
+multiple chains.
+
 **Dependencies:** None (parallelizable with Phase 0)
 **PR shape:** small, focused, no behavior changes beyond mock-data removal + wallet network filter
 

--- a/docs/specs/strategy-lifecycle-spec.md
+++ b/docs/specs/strategy-lifecycle-spec.md
@@ -1,0 +1,158 @@
+# Strategy Lifecycle Spec
+
+> **Status:** Drafted 2026-05-22 as Phase 0 of the
+> [Spine+ v2 plan](./spine-plus-v2-plan.md). Authoritative for the
+> `StrategyRecord.status` enum, Library/Portfolio filters, and every state
+> transition in Phases 2-5.
+>
+> **Lineage:** Re-maps the legacy `CANDIDATE / VALIDATED / LIVE / RETIRED` enum
+> in [`backend/archimedes/models/strategy.py`](../../backend/archimedes/models/strategy.py)
+> to a richer lifecycle that distinguishes paper-grounded examples from
+> user-generated strategies and surfaces time-bound expiry. Pairs with
+> [`vault-semantics-spec.md`](./vault-semantics-spec.md).
+
+## Lifecycle states
+
+```
+                Generated ── (rigor gate fails) ──→ Rejected
+                    │
+              (rigor passes)
+                    │
+                    ▼
+                Validated ── (TTL elapsed, no deploy) ──→ Expired
+                    │
+              (user deploys)
+                    │
+                    ▼
+                Deployed ── (window_start reached + funded) ──→ Active
+                                                                  │
+                                                          (window_end reached)
+                                                                  │
+                                                                  ▼
+                                                              Completed
+```
+
+| State | Definition | Who sets it |
+|---|---|---|
+| `Generated` | Agent has drafted a strategy from a user brief or selected one from the example library. Not yet rigor-checked. | Agent (Generate flow) |
+| `Validated` | Strategy passed all four rigor gates (DSR, PBO, walk-forward OOS Sharpe, look-ahead audit). Ready to deploy. | Rigor gate |
+| `Rejected` | Strategy failed at least one rigor gate. Browsable for inspection, not deployable. | Rigor gate |
+| `Deployed` | User has created a vault around the strategy; vault is awaiting capital or `window_start`. | User (via vault-creation tx) |
+| `Active` | Vault is in its trade window; agent is executing. | Vault contract event (`window_start` reached + funded) |
+| `Completed` | Vault's `window_end` has passed; realized P&L recorded. | Vault state machine |
+| `Expired` | Strategy was Validated but never deployed within TTL. Inspectable in Library; not deployable. | Background sweeper (cron) |
+
+Per [`vault-semantics-spec.md`](./vault-semantics-spec.md), the Strategy lifecycle
+and the Vault lifecycle are **coupled but distinct**: one Strategy may be
+`Deployed`/`Active`/`Completed` only via its associated Vault, and that Vault has
+its own `Created/Funded/Active/Unwinding/Completed/Expired` states. Strategy state
+mirrors the Vault for any deployed strategy; for un-deployed strategies the Vault
+states don't apply.
+
+## Field population by transition
+
+| Field | Populated at |
+|---|---|
+| `id`, `name`, `brief_hash`, `is_example` | Generated (Insert) |
+| `description`, `source_arxiv_ids`, `reasoning_trace_hash`, `dsl_payload` | Generated |
+| `rigor_verdict` (DSR + PBO + OOS Sharpe + lookahead audit results), `passes_rigor_gate` | Validated **or** Rejected |
+| `validated_at`, `ttl_expires_at` | Validated |
+| `vault_address`, `deployed_at`, `deployer_wallet` | Deployed |
+| `realized_pnl_usdc`, `completed_at`, `closing_trace_hash` | Completed |
+| `expired_at` | Expired |
+
+`brief_hash` is the keccak256 of the user's normalized brief — used to detect
+duplicate-brief regeneration attempts and de-duplicate in Library.
+
+## Transition triggers
+
+| Transition | Trigger | Effects |
+|---|---|---|
+| → Generated | Agent emits final `candidate_drafted` SSE event with rigor verdict | DB insert; trace persisted off-chain via [`AgentStateStore`](../../backend/archimedes/services/agent_state.py) |
+| → Validated | `passes_rigor_gate == true` and all four sub-gates green | `status='validated'`; `ttl_expires_at = now() + TTL` |
+| → Rejected | At least one rigor sub-gate fails | `status='rejected'`; reason string surfaced in Library |
+| → Deployed | User signs vault-creation tx; backend observes `VaultCreated` event | `status='deployed'`; `vault_address` linked |
+| → Active | Vault enters Active state (per vault-semantics-spec) | Mirrored automatically; agent runner begins ticking |
+| → Completed | Vault enters Completed state | Mirrored automatically; trigger `/learnings` post-hoc reasoning generation |
+| → Expired | Cron sweeper sees `validated_at + TTL < now()` AND `vault_address IS NULL` | `status='expired'`; user can still inspect but not deploy |
+
+## TTL — strategy-expiry semantics
+
+A **Validated** strategy that isn't deployed becomes **Expired** after a TTL
+window. Why: market regimes drift; a strategy validated against last week's
+volatility regime may not match this week's.
+
+**Default TTL: 72 hours.** Justification:
+
+- Short enough that the validation evidence (rigor metrics computed against
+  data up to `validated_at`) is still recent.
+- Long enough that a user who generates Friday evening can still deploy Monday
+  morning.
+- Configurable via `STRATEGY_TTL_HOURS` env var — operator can shrink for live
+  demos or extend for long-tail backtests.
+
+**Sweeper:** a 5-minute cron in `chain/oracle_runner.py` (or a new
+`scripts/sweep_expired_strategies.py`) runs `UPDATE strategies SET status='expired',
+expired_at=now() WHERE status='validated' AND validated_at + interval '72 hours' < now() AND vault_address IS NULL`.
+
+## Mapping from legacy enum
+
+| Legacy (`StrategyStatus`) | New | Notes |
+|---|---|---|
+| `CANDIDATE` | `Generated` | Same semantic — pre-rigor. Migration: rename. |
+| `VALIDATED` | `Validated` | Direct match. |
+| `LIVE` | `Active` (when in-vault) | Old `LIVE` was overloaded — sometimes meant "passed validation", sometimes meant "in an active vault". The new split disambiguates. |
+| `RETIRED` | `Completed` or `Expired` or `Rejected` | One-to-many. Migration: inspect each `RETIRED` row; classify by whether it ever had `vault_address`. |
+
+**Migration plan** — single idempotent SQL block run on startup (mirroring the
+existing `db.py` `ALTER TABLE` pattern):
+
+```sql
+ALTER TYPE strategy_status ADD VALUE IF NOT EXISTS 'generated';
+ALTER TYPE strategy_status ADD VALUE IF NOT EXISTS 'rejected';
+ALTER TYPE strategy_status ADD VALUE IF NOT EXISTS 'deployed';
+ALTER TYPE strategy_status ADD VALUE IF NOT EXISTS 'active';
+ALTER TYPE strategy_status ADD VALUE IF NOT EXISTS 'completed';
+ALTER TYPE strategy_status ADD VALUE IF NOT EXISTS 'expired';
+ALTER TABLE strategies ADD COLUMN IF NOT EXISTS ttl_expires_at TIMESTAMPTZ;
+ALTER TABLE strategies ADD COLUMN IF NOT EXISTS vault_address TEXT;
+ALTER TABLE strategies ADD COLUMN IF NOT EXISTS deployed_at TIMESTAMPTZ;
+ALTER TABLE strategies ADD COLUMN IF NOT EXISTS realized_pnl_usdc NUMERIC(20,6);
+ALTER TABLE strategies ADD COLUMN IF NOT EXISTS expired_at TIMESTAMPTZ;
+UPDATE strategies SET status='generated' WHERE status='candidate';
+```
+
+`LIVE` and `RETIRED` rows are kept as-is until manual reclassification (handful
+of rows; not worth automating).
+
+## UI surface
+
+- **Library > Generated tab** — shows `Generated | Validated | Deployed | Active |
+  Completed | Expired | Rejected`. Default filter: hide Expired + Rejected
+  (toggles available).
+- **Library > Examples tab** — only `is_example=true` rows; status irrelevant
+  (examples are reference, never deployed by users in their name).
+- **`/strategy/:id`** — passport page renders the full status pill + state-specific
+  CTA (Validated → Deploy; Active → View Vault; Expired → Re-generate; Rejected
+  → See why).
+- **`/portfolio`** — only `Deployed | Active | Completed` (the user's actual
+  vault footprint).
+- **`/learnings`** — only `Completed`.
+
+## Acceptance
+
+- Every Library/Portfolio filter maps cleanly to one or more states above.
+- Every state transition in Phases 2-5 cites a row in the "Transition triggers"
+  table.
+- A reviewer can answer "where does an Expired strategy show up in the UI?" by
+  reading this doc alone.
+
+## Open questions
+
+1. **TTL value** — is 72h right? Live-demo context may want 24h or even 12h
+   so judges see Expired in the Library without long waits.
+2. **Re-validation on expiry** — should an Expired strategy be auto-revalidated
+   if user wants to deploy it? (Current spec: no — user regenerates fresh.)
+3. **Rejected strategy provenance** — do we show the full reasoning + rigor
+   verdict for Rejected strategies, or just a summary? (Current spec: full,
+   because that's the honesty wedge.)

--- a/docs/specs/vault-semantics-spec.md
+++ b/docs/specs/vault-semantics-spec.md
@@ -1,0 +1,115 @@
+# Vault Semantics Spec
+
+> **Status:** Drafted 2026-05-22 as Phase 0 of the
+> [Spine+ v2 plan](./spine-plus-v2-plan.md). Authoritative for Phase 4
+> implementation; supersedes any conflicting language in earlier docs.
+>
+> **Lineage:** Builds on the multi-asset NAV `Vault.sol` deployed Day-10
+> (Chuan's stack — see [`chuan-architecture-survey.md`](../chuan-architecture-survey.md))
+> and the 1:1 strategy↔vault decision locked in the Spine+ v2 plan.
+
+## Definition
+
+**A Vault is a time-bound execution container that holds exactly one strategy,
+the user's capital deposited against that strategy, and the trade window during
+which the agent may act on it.** On-chain it is a `Vault.sol` ERC-4626 multi-asset
+NAV contract; off-chain it is a row in `vaults` with a foreign key to the strategy.
+
+A Vault is **not** a perpetual portfolio. It is **not** multi-strategy. It does
+**not** outlive its trade window. These constraints are what make the on-chain
+provenance trail tractable: a fixed strategy + a fixed window means every
+rebalance, every reasoning trace, and every realized P&L attributes
+unambiguously to one strategy hash.
+
+## Lifecycle
+
+```
+Created → Funded → Active → Unwinding → Completed
+                            ↘
+                              Expired (un-funded at window-open)
+```
+
+| Transition | Trigger | What happens |
+|---|---|---|
+| → Created | User clicks "Deploy as vault" on a strategy passport, signs vault-creation tx | `VaultFactory` deploys a new `Vault.sol`; row inserted in `vaults` with `state='created'`, `strategy_id=X`, `window_start`, `window_end`, `target_capital_usdc` |
+| → Funded | User deposits USDC ≥ `target_capital_usdc` before `window_start` | Vault state flips to `funded`; agent runner is notified |
+| → Active | Block timestamp reaches `window_start` AND state is Funded | Agent calls `setTargetAllocations()` with the strategy's initial weights; first trade executes via `AMMRouter` |
+| → Unwinding | Block timestamp reaches `window_end` − `unwind_buffer` (default 1h) | Agent ceases new entries; existing positions begin closing back to USDC |
+| → Completed | Vault fully unwound to USDC AND block timestamp ≥ `window_end` | User can withdraw via `redeem()`; row marked `completed` with `realized_pnl_usdc` |
+| → Expired | Block timestamp ≥ `window_start` AND state is Created (not Funded) | Vault contract self-disables; row marked `expired` for post-hoc inspection |
+
+## Trade window
+
+Two timestamps, both set at creation and immutable thereafter:
+
+- **`window_start`** — earliest time the agent may execute the strategy's initial
+  allocation. Before this, the vault is dormant even if funded.
+- **`window_end`** — latest time the agent may hold non-USDC positions. The unwind
+  buffer (`window_end − 1h` by default) is when the agent stops opening new
+  positions and starts closing existing ones.
+
+The window is **fixed at creation** because the strategy's backtest was conducted
+over a specific horizon (e.g., "13-week treasury bill alternative, Q3 2026"). A
+strategy with a 13-week passport deployed for 52 weeks has lost its evidence base.
+
+## Re-use after completion
+
+**Vaults are single-use.** After `Completed`, the user may:
+- Withdraw their (now-USDC) capital, **or**
+- Roll into a new vault by generating a fresh strategy.
+
+The contract itself remains on-chain (immutable history) but accepts no new
+deposits. **No "redeploy same strategy into same vault" path** — the new market
+regime warrants a fresh rigor check.
+
+## Agent interaction during the window
+
+1. **At `window_start`:** Agent calls `setTargetAllocations()` once with the
+   strategy's initial weights (e.g., 60% TLT, 40% USDC). `AMMRouter` executes
+   the resulting swaps. Reasoning trace anchored on `ReasoningTraceRegistry`.
+2. **During Active:** Agent ticks every 5 minutes. It rebalances **only if** the
+   strategy DSL says so — e.g., a SMA200 strategy rebalances on cross events; a
+   buy-and-hold does not. Each rebalance gets its own trace.
+3. **At `window_start + unwind_buffer`:** Agent begins selling all non-USDC
+   positions. New entries forbidden. Trace anchors the unwind decision.
+4. **At `window_end`:** Vault marked `Completed`. Final NAV recorded in
+   `realized_pnl_usdc`. Post-hoc reasoning published to `/learnings`.
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Window passes mid-trade | The in-flight `AMMRouter` tx completes; no new entries; unwind proceeds on next tick. |
+| Oracle goes stale (> 2× expected interval) | Agent halts trading, anchors a `regime_unknown` trace; user notified on Portfolio page; vault holds last state until oracle recovers or window ends. |
+| AMM has no liquidity | Agent retries with smaller size, then with a different route; if both fail, anchors a `liquidity_failure` trace and halts. Capital is safe; just inactive. |
+| User under-deposits | If deposit < `target_capital_usdc` by `window_start`, the agent executes against whatever USDC is on hand (no minimum enforced). Strategy proceeds proportionally. |
+| Agent process dies | Vault state on-chain is untouched. Restart of `oracle_runner` resumes from the next 5-minute tick. No double-execution because traces are idempotent. |
+
+## On-chain artifact
+
+- **Contract:** `Vault.sol` (multi-asset NAV ERC-4626, deployed Day-10)
+- **Factory:** `VaultFactory.sol` (deploys per-user vaults)
+- **Trace anchor:** `ReasoningTraceRegistry.sol`
+- **Allocation events:** emitted on every `setTargetAllocations()` call;
+  consumed by the backend `oracle_runner` for off-chain mirroring.
+
+## Acceptance
+
+A reviewer can derive every Phase 4 implementation decision from this doc:
+
+- Vault row schema (`state`, `window_start`, `window_end`, `target_capital_usdc`,
+  `realized_pnl_usdc`, `strategy_id`)
+- State transition rules (cron-driven for time-based; event-driven for capital-based)
+- UI states on `/portfolio` and `/strategy/:id` (each vault renders one of the six
+  lifecycle states)
+- Failure UX (every failure mode above maps to one user-visible status pill)
+
+## Open questions (for Marten + Chuan review)
+
+1. **Unwind buffer default** — is 1 hour right for short-horizon strategies?
+   A 4-week vault and a 52-week vault probably want different buffers.
+2. **Vault re-use ever?** — current spec says no. If user feedback strongly
+   wants "re-deploy same strategy," we'd add a `Created from {parent_vault_id}`
+   link rather than literally reusing the contract.
+3. **Under-deposit minimum** — should we enforce a floor (e.g., $100 USDC) so
+   the agent isn't trading dust?

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -165,6 +165,29 @@ h4, .h4 { font-family: var(--sans); font-size: 0.8rem; font-weight: 600; text-tr
   background: rgba(224, 166, 79, 0.08);
 }
 
+.rigor-help-btn {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-4);
+  font-size: 0.68rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.rigor-help-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .page-content {
   padding: var(--space-7) var(--space-6);
   max-width: var(--max-w);

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { getAddress, disconnectWallet, reconnectWallet } from './config'
 import Layout from './components/Layout'
 import Landing from './components/Landing'
+import Explore from './components/Explore'
 import Generate from './components/Generate'
 import Portfolio from './components/Portfolio'
 import Learnings from './components/Learnings'
@@ -17,6 +18,7 @@ import './App.css'
 // top-level page until per-card trace-modal affordances are wired everywhere.
 const PAGE_TO_PATH = {
   landing:   '/',
+  explore:   '/explore',
   generate:  '/generate',
   library:   '/library',
   corpus:    '/corpus',
@@ -134,6 +136,7 @@ export default function App() {
   const renderPage = () => {
     switch (page) {
       case 'landing':      return <Landing onNavigate={navigateToPage} onConnect={() => {/* topbar handles modal */}} walletAddr={walletAddr} />
+      case 'explore':      return <Explore onNavigate={navigateToPage} />
       case 'generate':     return <Generate onNavigate={navigateToPage} />
       case 'library':      return <Strategies highlightStrategyId={highlightStrategyId} />
       case 'corpus':       return <CorpusExplorer />

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -134,7 +134,7 @@ export default function App() {
   const renderPage = () => {
     switch (page) {
       case 'landing':      return <Landing onNavigate={navigateToPage} onConnect={() => {/* topbar handles modal */}} walletAddr={walletAddr} />
-      case 'generate':     return <Generate />
+      case 'generate':     return <Generate onNavigate={navigateToPage} />
       case 'library':      return <Strategies highlightStrategyId={highlightStrategyId} />
       case 'corpus':       return <CorpusExplorer />
       case 'portfolio':    return <Portfolio walletAddr={walletAddr} onSelectVault={selectVault} onSelectTrace={selectTrace} />

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -32,31 +32,35 @@ const PATH_TO_PAGE = Object.fromEntries(
 )
 
 function resolveRoute(pathname = '/', search = '') {
+  const params = new URLSearchParams(search)
+  const highlight = params.get('highlight')
+
   if (PATH_TO_PAGE[pathname]) {
-    return { page: PATH_TO_PAGE[pathname], vaultAddress: null, traceId: null, matched: true }
+    return { page: PATH_TO_PAGE[pathname], vaultAddress: null, traceId: null, highlight, matched: true }
   }
 
   if (pathname.startsWith('/portfolio/vaults/')) {
     const rawAddress = pathname.replace('/portfolio/vaults/', '')
-    if (rawAddress) return { page: 'vault-detail', vaultAddress: rawAddress, traceId: null, matched: true }
+    if (rawAddress) return { page: 'vault-detail', vaultAddress: rawAddress, traceId: null, highlight, matched: true }
   }
 
   if (pathname.startsWith('/reasoning/')) {
     const id = pathname.replace('/reasoning/', '')
-    if (id) return { page: 'reasoning', vaultAddress: null, traceId: id, matched: true }
+    if (id) return { page: 'reasoning', vaultAddress: null, traceId: id, highlight, matched: true }
   }
 
   // Legacy paths still in the wild — funnel them to the spine.
-  const params = new URLSearchParams(search)
   const vaultAddress = params.get('vault')
-  if (vaultAddress) return { page: 'vault-detail', vaultAddress, traceId: null, matched: true }
+  if (vaultAddress) return { page: 'vault-detail', vaultAddress, traceId: null, highlight, matched: true }
 
-  return { page: 'landing', vaultAddress: null, traceId: null, matched: false }
+  return { page: 'landing', vaultAddress: null, traceId: null, highlight: null, matched: false }
 }
 
-function pageToPath(page, selectedVault = null) {
+function pageToPath(page, selectedVault = null, highlight = null) {
   if (page === 'vault-detail' && selectedVault) return `/portfolio/vaults/${selectedVault}`
-  return PAGE_TO_PATH[page] ?? '/'
+  const base = PAGE_TO_PATH[page] ?? '/'
+  if (highlight && page === 'library') return `${base}?highlight=${encodeURIComponent(highlight)}`
+  return base
 }
 
 // ─── Main App ────────────────────────────────────────────────
@@ -68,6 +72,7 @@ export default function App() {
   const [walletAddr, setWalletAddr] = useState(null)
   const [selectedVault, setSelectedVault] = useState(initialRoute.vaultAddress)
   const [tourOpen, setTourOpen] = useState(() => !hasCompletedOnboarding())
+  const [highlightStrategyId, setHighlightStrategyId] = useState(initialRoute.highlight)
 
   // Reconnect a previously connected wallet on mount (silent — uses eth_accounts,
   // no popup). The wallet-changed event keeps state in sync if the user changes
@@ -89,7 +94,10 @@ export default function App() {
 
   const navigateToPage = useCallback((nextPage, opts = {}) => {
     const nextVault = opts.vaultAddress ?? selectedVault
-    const nextPath = pageToPath(nextPage, nextVault)
+    const nextHighlight = Object.prototype.hasOwnProperty.call(opts, 'highlight')
+      ? opts.highlight
+      : (nextPage === 'library' ? highlightStrategyId : null)
+    const nextPath = pageToPath(nextPage, nextVault, nextHighlight)
     const method = opts.replace ? 'replaceState' : 'pushState'
 
     if (window.location.pathname + window.location.search !== nextPath) {
@@ -102,7 +110,8 @@ export default function App() {
     } else if (nextPage !== 'vault-detail') {
       setSelectedVault(null)
     }
-  }, [selectedVault])
+    setHighlightStrategyId(nextPage === 'library' ? nextHighlight : null)
+  }, [selectedVault, highlightStrategyId])
 
   const selectVault = (addr) => navigateToPage('vault-detail', { vaultAddress: addr })
   const backToPortfolio = () => navigateToPage('portfolio', { vaultAddress: null })
@@ -116,6 +125,7 @@ export default function App() {
       const route = resolveRoute(window.location.pathname, window.location.search)
       setPage(route.page)
       setSelectedVault(route.vaultAddress)
+      setHighlightStrategyId(route.highlight)
     }
     window.addEventListener('popstate', onPopState)
     return () => window.removeEventListener('popstate', onPopState)
@@ -125,11 +135,11 @@ export default function App() {
     switch (page) {
       case 'landing':      return <Landing onNavigate={navigateToPage} onConnect={() => {/* topbar handles modal */}} walletAddr={walletAddr} />
       case 'generate':     return <Generate />
-      case 'library':      return <Strategies />
+      case 'library':      return <Strategies highlightStrategyId={highlightStrategyId} />
       case 'corpus':       return <CorpusExplorer />
       case 'portfolio':    return <Portfolio walletAddr={walletAddr} onSelectVault={selectVault} onSelectTrace={selectTrace} />
-      case 'reasoning':    return <Reasoning />
-      case 'learnings':    return <Learnings />
+      case 'reasoning':    return <Reasoning onNavigate={navigateToPage} />
+      case 'learnings':    return <Learnings onNavigate={navigateToPage} />
       case 'vault-detail': return <VaultDetail address={selectedVault} onBack={backToPortfolio} />
       default:             return <Landing onNavigate={navigateToPage} onConnect={() => {}} walletAddr={walletAddr} />
     }

--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -294,7 +294,14 @@ function CatalogTab({ papers, total, page, loading, search, setSearch, categoryF
                 <div className="paper-title">{p.title || p.arxiv_id}</div>
                 <div className="paper-meta">
                   <span className="paper-id">{p.arxiv_id}</span>
-                  {p.primary_category && <span className="paper-cat">{p.primary_category}</span>}
+                  {p.primary_category && (
+                    <span
+                      className="paper-cat"
+                      title={p.category_label ? `${p.primary_category} — ${p.category_label}` : p.primary_category}
+                    >
+                      {p.category_label || p.primary_category}
+                    </span>
+                  )}
                   {p.published && <span className="paper-year">{p.published?.slice(0, 4)}</span>}
                   {p.cluster_id && <span className="paper-cluster">Cluster: {p.cluster_id}</span>}
                 </div>
@@ -375,7 +382,14 @@ function PaperDetail({ paper, onBack }) {
 
         <div className="paper-detail-meta flex flex-wrap gap-2 mb-3.5">
           <span className="tag tag-muted mono">arxiv:{paper.arxiv_id}</span>
-          {paper.primary_category && <span className="tag tag-muted">{paper.primary_category}</span>}
+          {paper.primary_category && (
+            <span
+              className="tag tag-muted"
+              title={paper.category_label ? `${paper.primary_category} — ${paper.category_label}` : paper.primary_category}
+            >
+              {paper.category_label || paper.primary_category}
+            </span>
+          )}
           {paper.published && <span className="tag tag-muted">{(paper.published || '').slice(0, 10)}</span>}
           {paper.topic_label && <span className="tag tag-accent">Topic: {paper.topic_label}</span>}
         </div>

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+// /explore — Read-only asset discovery surface (no wallet required).
+// Per docs/specs/page-roles-spec.md: the universe of tradable assets,
+// demystified for non-finance readers via plain-English explanations on
+// each metric.
+
+function fmtPct(v, digits = 1) {
+  if (v == null || isNaN(v)) return '—'
+  const sign = v >= 0 ? '+' : ''
+  return `${sign}${v.toFixed(digits)}%`
+}
+
+function fmtPrice(v) {
+  if (v == null || isNaN(v)) return '—'
+  if (v >= 1000) return `$${v.toFixed(0)}`
+  if (v >= 10) return `$${v.toFixed(2)}`
+  return `$${v.toFixed(4)}`
+}
+
+function fmtVol(v) {
+  if (v == null || isNaN(v)) return '—'
+  return v.toFixed(2)
+}
+
+function changeClass(v) {
+  if (v == null || isNaN(v)) return ''
+  return v >= 0 ? 'positive' : 'negative'
+}
+
+function ExplainTooltip({ children, text }) {
+  if (!text) return children
+  return (
+    <span title={text} style={{ cursor: 'help', borderBottom: '1px dotted var(--text-4)' }}>
+      {children}
+    </span>
+  )
+}
+
+export default function Explore({ onNavigate }) {
+  const [assets, setAssets] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [filterClass, setFilterClass] = useState('all')
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/explore/assets`)
+        if (!res.ok) throw new Error(await res.text())
+        const data = await res.json()
+        if (!cancelled) setAssets(data.assets || [])
+      } catch (e) {
+        if (!cancelled) setError(e.message || 'Failed to load assets')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    // Reload every minute — page is read-only but oracle data drifts.
+    const interval = setInterval(load, 60_000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [])
+
+  const classes = ['all', ...Array.from(new Set(assets.map(a => a.asset_class).filter(Boolean)))]
+  const filtered = filterClass === 'all' ? assets : assets.filter(a => a.asset_class === filterClass)
+
+  const useInGenerate = (symbol) => {
+    if (onNavigate) onNavigate('generate')
+    // The Generate page reads `?seed_asset=` later — for now, just navigate.
+    // Wiring the seed prop through requires extending the navigate API; we
+    // can do that when Phase 4 adds the strategy passport route too.
+  }
+
+  return (
+    <div>
+      <div className="fade-up fade-up-1" style={{ maxWidth: 720, marginBottom: 24 }}>
+        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 10 }}>Explore</h2>
+        <p className="body" style={{ marginBottom: 8 }}>
+          The universe of synthetic assets you can trade on Arc. Prices come from the on-chain
+          oracle; explanations live next to every metric so non-finance readers don't need
+          a glossary.
+        </p>
+        <p className="body" style={{ color: 'var(--text-3)' }}>
+          No wallet required — this page is browse-only. Click "Use in Generate" on any row
+          to seed a strategy around that asset.
+        </p>
+      </div>
+
+      <div className="strat-filter-bar fade-up fade-up-2" style={{ marginBottom: 16 }}>
+        {classes.map(c => (
+          <span
+            key={c}
+            className={`tag ${filterClass === c ? 'tag-accent' : 'tag-muted'}`}
+            onClick={() => setFilterClass(c)}
+            style={{ cursor: 'pointer' }}
+          >
+            {c === 'all' ? 'All' : c.replace(/_/g, ' ')} {c !== 'all' && `(${assets.filter(a => a.asset_class === c).length})`}
+          </span>
+        ))}
+      </div>
+
+      {loading && !assets.length && <div className="caption">Loading market data…</div>}
+      {error && (
+        <div className="info-box warning" style={{ marginBottom: 16 }}>
+          Couldn't load assets: {error}.
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <div style={{ overflowX: 'auto', border: '1px solid var(--glass-border)', borderRadius: 8 }}>
+          <table className="lib-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+            <thead>
+              <tr style={{ background: 'rgba(255,255,255,0.03)', textAlign: 'left', borderBottom: '1px solid var(--glass-border)' }}>
+                <th style={{ padding: '10px 14px' }}>Symbol</th>
+                <th style={{ padding: '10px 14px' }}>Name</th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
+                  <ExplainTooltip text="Latest price from the on-chain oracle. Settlement on Arc uses this.">
+                    Price
+                  </ExplainTooltip>
+                </th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
+                  <ExplainTooltip text="Percentage change in the last trading day.">
+                    24h
+                  </ExplainTooltip>
+                </th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
+                  <ExplainTooltip text="Percentage change over the past week.">
+                    7d
+                  </ExplainTooltip>
+                </th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
+                  <ExplainTooltip text="Percentage change over the past month.">
+                    30d
+                  </ExplainTooltip>
+                </th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
+                  <ExplainTooltip text="How much the price wobbles. Higher = bigger swings.">
+                    Vol 30d
+                  </ExplainTooltip>
+                </th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map(a => (
+                <tr key={a.symbol} className="lib-row">
+                  <td style={{ padding: '10px 14px', fontWeight: 600 }}>
+                    {a.symbol}
+                    {a.is_stale && (
+                      <span className="tag tag-negative" style={{ marginLeft: 6, fontSize: '0.65rem' }}>
+                        STALE
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ padding: '10px 14px' }} className="caption">{a.name}</td>
+                  <td className="mono" style={{ padding: '10px 14px', textAlign: 'right' }}>
+                    <ExplainTooltip text={a.explanations?.current_price}>{fmtPrice(a.current_price)}</ExplainTooltip>
+                  </td>
+                  <td className={`mono ${changeClass(a.change_24h_pct)}`} style={{ padding: '10px 14px', textAlign: 'right' }}>
+                    <ExplainTooltip text={a.explanations?.change_24h_pct}>{fmtPct(a.change_24h_pct)}</ExplainTooltip>
+                  </td>
+                  <td className={`mono ${changeClass(a.change_7d_pct)}`} style={{ padding: '10px 14px', textAlign: 'right' }}>
+                    <ExplainTooltip text={a.explanations?.change_7d_pct}>{fmtPct(a.change_7d_pct)}</ExplainTooltip>
+                  </td>
+                  <td className={`mono ${changeClass(a.change_30d_pct)}`} style={{ padding: '10px 14px', textAlign: 'right' }}>
+                    <ExplainTooltip text={a.explanations?.change_30d_pct}>{fmtPct(a.change_30d_pct)}</ExplainTooltip>
+                  </td>
+                  <td className="mono" style={{ padding: '10px 14px', textAlign: 'right' }}>
+                    <ExplainTooltip text={a.explanations?.realized_vol_30d}>{fmtVol(a.realized_vol_30d)}</ExplainTooltip>
+                  </td>
+                  <td style={{ padding: '10px 14px', textAlign: 'right' }}>
+                    <button
+                      className="btn btn-outline btn-sm"
+                      onClick={() => useInGenerate(a.symbol)}
+                      title={`Seed a Generate brief around ${a.symbol}`}
+                    >
+                      Use in Generate →
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="caption" style={{ marginTop: 16, color: 'var(--text-4)' }}>
+        Prices refresh every minute. The "Vol 30d" column is annualized realized
+        volatility (std of daily returns × √252).
+      </p>
+    </div>
+  )
+}

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -1,32 +1,88 @@
 import { useEffect, useState } from 'react'
 import { StrategyArchitect } from './Strategies'
 import RegimePanel from './RegimePanel'
+import GenerationStream from './GenerationStream'
+import GenerationStatus from './GenerationStatus'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
-// The /generate page: the spine's primary action (per docs/user-stories.md).
-// Currently shows the curated-library architect path — the only path with real
-// backtest+rigor numbers today. Fusion-mode (novelty synthesis from the 10k
-// q-fin corpus) is the stretch goal — see STRETCH todo + the t2o2 spec
-// (fusion-to-backtestable-strategy) for the work that unblocks it.
-//
-// We pre-fetch the full strategy library here so StrategyArchitect can compute
-// blended Sharpe/CAGR/MaxDD from per-strategy backtests on the result.
+// /generate spine page. Two paths today:
+//   1. Streaming agent (default) — SSE-driven, per docs/specs/generation-streaming-spec.md
+//   2. Architect "fast preview" toggle — synchronous curated-library pick, kept
+//      around because it's instant and useful when you just want a quick sanity check.
 
-export default function Generate() {
+const STORAGE_JOB_KEY = 'archimedes:currentJobId'
+const RISK_PROFILES = [
+  { id: 'fixed_income', label: 'Fixed income' },
+  { id: 'conservative', label: 'Conservative' },
+  { id: 'moderate', label: 'Moderate' },
+  { id: 'aggressive', label: 'Aggressive' },
+  { id: 'hyper_risky', label: 'Hyper-risky' },
+]
+
+export default function Generate({ onNavigate }) {
+  const [mode, setMode] = useState('agent')  // 'agent' | 'architect'
+  const [intent, setIntent] = useState('')
+  const [riskAppetite, setRiskAppetite] = useState('moderate')
+  const [nCandidates, setNCandidates] = useState(1)
+  const [jobId, setJobId] = useState(() => localStorage.getItem(STORAGE_JOB_KEY) || null)
+  const [starting, setStarting] = useState(false)
+  const [startError, setStartError] = useState('')
+
+  // Architect path needs the library pre-fetched.
   const [strategies, setStrategies] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
+  const [libLoading, setLibLoading] = useState(true)
+  const [libError, setLibError] = useState('')
 
   useEffect(() => {
     let cancelled = false
     fetch(`${API_BASE}/api/strategies/`)
       .then(r => r.ok ? r.json() : r.text().then(t => { throw new Error(t) }))
       .then(data => { if (!cancelled) setStrategies(data.strategies || []) })
-      .catch(e => { if (!cancelled) setError(e.message || 'Failed to load library') })
-      .finally(() => { if (!cancelled) setLoading(false) })
+      .catch(e => { if (!cancelled) setLibError(e.message || 'Failed to load library') })
+      .finally(() => { if (!cancelled) setLibLoading(false) })
     return () => { cancelled = true }
   }, [])
+
+  const startJob = async () => {
+    setStartError('')
+    if (!intent.trim()) {
+      setStartError('Describe what you want in a sentence or two.')
+      return
+    }
+    setStarting(true)
+    try {
+      const res = await fetch(`${API_BASE}/api/generate/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          brief: { intent, risk_appetite: riskAppetite },
+          n_candidates: nCandidates,
+        }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      const data = await res.json()
+      localStorage.setItem(STORAGE_JOB_KEY, data.job_id)
+      setJobId(data.job_id)
+    } catch (e) {
+      setStartError(e.message || 'Failed to start generation')
+    } finally {
+      setStarting(false)
+    }
+  }
+
+  const onJobDone = (result) => {
+    localStorage.removeItem(STORAGE_JOB_KEY)
+    if (result?.strategy_id && onNavigate) {
+      // Soft hand-off — the persisted strategy is the canonical target.
+      onNavigate('library', { highlight: result.strategy_id })
+    }
+  }
+
+  const resetJob = () => {
+    localStorage.removeItem(STORAGE_JOB_KEY)
+    setJobId(null)
+  }
 
   return (
     <div>
@@ -47,13 +103,110 @@ export default function Generate() {
         <RegimePanel />
       </div>
 
-      {loading && <div className="caption">Loading strategy library…</div>}
-      {error && (
-        <div className="info-box warning mb-4">
-          Couldn't load library: {error}. The architect needs the library to pick from.
+      {/* Mode toggle */}
+      <div className="strat-filter-bar fade-up fade-up-2 mb-4">
+        <span
+          className={`tag ${mode === 'agent' ? 'tag-accent' : 'tag-muted'} cursor-pointer`}
+          onClick={() => setMode('agent')}
+          title="Live streaming agent — each iteration appears as it runs"
+        >
+          🔴 Streaming agent
+        </span>
+        <span
+          className={`tag ${mode === 'architect' ? 'tag-accent' : 'tag-muted'} cursor-pointer`}
+          onClick={() => setMode('architect')}
+          title="Skip the fusion engine and let the architect pick from the curated library — faster but less novel"
+        >
+          ⚡ Architect (fast preview)
+        </span>
+      </div>
+
+      {mode === 'agent' && (
+        <div className="fade-up fade-up-2">
+          {!jobId && (
+            <div className="card p-5 mb-4">
+              <div className="label mb-2">What would you like?</div>
+              <textarea
+                value={intent}
+                onChange={e => setIntent(e.target.value)}
+                placeholder="e.g. A 13-week treasury alternative with low volatility and crypto upside on Fridays"
+                rows={3}
+                className="chat-input w-full mb-3 p-2.5 leading-relaxed"
+                disabled={starting}
+              />
+              <div className="flex gap-3 items-center flex-wrap">
+                <label className="caption flex items-center gap-1.5">
+                  Risk
+                  <select
+                    value={riskAppetite}
+                    onChange={e => setRiskAppetite(e.target.value)}
+                    className="chat-input w-auto px-2 py-1"
+                    disabled={starting}
+                  >
+                    {RISK_PROFILES.map(r => (
+                      <option key={r.id} value={r.id}>{r.label}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="caption flex items-center gap-1.5">
+                  Candidates
+                  <select
+                    value={nCandidates}
+                    onChange={e => setNCandidates(Number(e.target.value))}
+                    className="chat-input w-auto px-2 py-1"
+                    disabled={starting}
+                    title="Agent runs N variants internally; best is surfaced, rejects browsable"
+                  >
+                    {[1, 2, 3].map(n => <option key={n} value={n}>{n}</option>)}
+                  </select>
+                </label>
+                <button
+                  className="btn btn-primary ml-auto"
+                  onClick={startJob}
+                  disabled={starting || !intent.trim()}
+                >
+                  {starting ? 'Starting…' : 'Generate →'}
+                </button>
+              </div>
+              {startError && (
+                <div className="info-box warning mt-3">{startError}</div>
+              )}
+            </div>
+          )}
+
+          {jobId && (
+            <GenerationStream
+              jobId={jobId}
+              onDone={onJobDone}
+              onReset={resetJob}
+            />
+          )}
+
+          <div className="mt-6">
+            <GenerationStatus
+              activeJobId={jobId}
+              onSelect={(id) => { localStorage.setItem(STORAGE_JOB_KEY, id); setJobId(id) }}
+            />
+          </div>
         </div>
       )}
-      {!loading && !error && <StrategyArchitect strategies={strategies} />}
+
+      {mode === 'architect' && (
+        <div className="fade-up fade-up-2">
+          <div className="info-box mb-4">
+            <strong>Architect path</strong> — Claude selects + weights from the curated
+            library synchronously. No streaming, no novel synthesis; useful when you just
+            want a fast read on what the library would recommend for your brief.
+          </div>
+          {libLoading && <div className="caption">Loading strategy library…</div>}
+          {libError && (
+            <div className="info-box warning mb-4">
+              Couldn't load library: {libError}. The architect needs the library to pick from.
+            </div>
+          )}
+          {!libLoading && !libError && <StrategyArchitect strategies={strategies} />}
+        </div>
+      )}
     </div>
   )
 }

--- a/ui/src/components/GenerationStatus.jsx
+++ b/ui/src/components/GenerationStatus.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+// Compact status table at the bottom of the Generate page. Polls
+// /api/generate/jobs every 5s so navigating back to /generate after starting
+// a job in another tab still surfaces it. Per generation-streaming-spec.md.
+
+const STATE_TAGS = {
+  queued:    { label: 'queued',    cls: 'tag-muted' },
+  running:   { label: 'running',   cls: 'tag-accent' },
+  done:      { label: 'done',      cls: 'tag-positive' },
+  error:     { label: 'error',     cls: 'tag-negative' },
+  cancelled: { label: 'cancelled', cls: 'tag-muted' },
+}
+
+function timeAgo(iso) {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return iso
+  const secs = Math.floor((Date.now() - d.getTime()) / 1000)
+  if (secs < 60) return `${secs}s ago`
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
+  return `${Math.floor(secs / 86400)}d ago`
+}
+
+export default function GenerationStatus({ activeJobId, onSelect }) {
+  const [jobs, setJobs] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/generate/jobs?limit=10`)
+        if (!res.ok) throw new Error(await res.text())
+        const data = await res.json()
+        if (!cancelled) setJobs(data.jobs || [])
+      } catch (e) {
+        if (!cancelled) setError(e.message || 'Failed to load jobs')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    const interval = setInterval(load, 5000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [])
+
+  if (loading && !jobs.length) return null
+  if (!jobs.length) return null
+
+  return (
+    <div className="card" style={{ padding: 16 }}>
+      <div className="label mb-2">Recent generations</div>
+      {error && <div className="caption negative">{error}</div>}
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+          <thead>
+            <tr style={{ textAlign: 'left', borderBottom: '1px solid var(--glass-border)' }}>
+              <th style={{ padding: '6px 8px' }}>Intent</th>
+              <th style={{ padding: '6px 8px' }}>State</th>
+              <th style={{ padding: '6px 8px' }}>N</th>
+              <th style={{ padding: '6px 8px' }}>Updated</th>
+              <th style={{ padding: '6px 8px' }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.map(j => {
+              const tag = STATE_TAGS[j.state] || STATE_TAGS.queued
+              const isActive = j.job_id === activeJobId
+              return (
+                <tr
+                  key={j.job_id}
+                  style={{
+                    borderBottom: '1px solid rgba(255,255,255,0.04)',
+                    background: isActive ? 'rgba(255,209,102,0.07)' : 'transparent',
+                  }}
+                >
+                  <td style={{ padding: '6px 8px', maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {j.brief_intent || '—'}
+                  </td>
+                  <td style={{ padding: '6px 8px' }}>
+                    <span className={`tag ${tag.cls}`}>{tag.label}</span>
+                  </td>
+                  <td style={{ padding: '6px 8px' }}>{j.n_candidates}</td>
+                  <td style={{ padding: '6px 8px', whiteSpace: 'nowrap' }} className="caption">
+                    {timeAgo(j.updated_at)}
+                  </td>
+                  <td style={{ padding: '6px 8px', textAlign: 'right' }}>
+                    {!isActive && (j.state === 'running' || j.state === 'queued') && (
+                      <button
+                        className="btn btn-outline btn-sm"
+                        onClick={() => onSelect?.(j.job_id)}
+                      >
+                        Resume →
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState } from 'react'
+import RejectedCandidates from './RejectedCandidates'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+// Per docs/specs/generation-streaming-spec.md. The EventSource auto-reconnects
+// on network blips; Last-Event-ID is honoured server-side so we resume from
+// where we left off.
+
+const EVENT_LABELS = {
+  job_queued: 'Job queued',
+  brief_validated: 'Brief validated',
+  candidates_selected: 'Candidates selected',
+  agent_iteration: 'Agent iteration',
+  tool_called: 'Tool called',
+  tool_result: 'Tool result',
+  candidate_drafted: 'Candidate drafted',
+  candidate_evaluated: 'Candidate evaluated',
+  best_selected: 'Best selected',
+  trace_hashed: 'Trace hashed',
+  persisted: 'Persisted',
+  done: 'Done',
+  error: 'Error',
+}
+
+const TERMINAL = new Set(['done', 'error'])
+
+function summarizeEvent(name, data) {
+  switch (name) {
+    case 'job_queued':
+      return data?.brief?.intent
+        ? `"${data.brief.intent.slice(0, 90)}${data.brief.intent.length > 90 ? '…' : ''}"`
+        : ''
+    case 'brief_validated':
+      return `Risk: ${data?.risk_appetite || '—'}`
+    case 'candidates_selected':
+      return `Considering ${data?.candidate_count || '?'} candidates; ${(data?.source_arxiv_ids?.length || 0)} papers`
+    case 'agent_iteration':
+      return `Iteration ${data?.iteration_n}/${data?.max_iterations} (${data?.candidate_id || ''})`
+    case 'tool_called':
+      return `${data?.tool_name}(${data?.args_summary || ''})`
+    case 'tool_result':
+      return `${data?.tool_name} → ${data?.result_summary || 'ok'}`
+    case 'candidate_drafted':
+      return `${data?.strategy_name || '?'} (${data?.candidate_id})`
+    case 'candidate_evaluated': {
+      const v = data?.rigor_verdict || {}
+      const bits = []
+      if (v.dsr != null) bits.push(`DSR ${v.dsr}`)
+      if (v.pbo != null) bits.push(`PBO ${v.pbo}`)
+      if (v.oos_sharpe != null) bits.push(`OOS ${v.oos_sharpe}`)
+      return `${data?.candidate_id} — ${bits.join(' · ') || 'no metrics'}`
+    }
+    case 'best_selected':
+      return `Picked ${data?.best_candidate_id} from ${data?.considered_count}`
+    case 'trace_hashed':
+      return `${(data?.trace_hash || '').slice(0, 14)}…`
+    case 'persisted':
+      return data?.redirect_url || ''
+    case 'done':
+      return `→ ${data?.strategy_id || ''}`
+    case 'error':
+      return data?.message || 'Unknown error'
+    default:
+      return ''
+  }
+}
+
+export default function GenerationStream({ jobId, onDone, onReset }) {
+  const [events, setEvents] = useState([])
+  const [terminal, setTerminal] = useState(null)  // 'done' | 'error' | null
+  const [strategyId, setStrategyId] = useState(null)
+  const [errorMsg, setErrorMsg] = useState('')
+  const [showRejected, setShowRejected] = useState(false)
+  const esRef = useRef(null)
+  const scrollRef = useRef(null)
+
+  useEffect(() => {
+    if (!jobId) return
+    setEvents([])
+    setTerminal(null)
+    setStrategyId(null)
+    setErrorMsg('')
+
+    const url = `${API_BASE}/api/generate/stream/${encodeURIComponent(jobId)}`
+    const es = new EventSource(url)
+    esRef.current = es
+
+    const handle = (name) => (e) => {
+      let data = {}
+      try { data = JSON.parse(e.data) } catch { /* keep empty */ }
+      setEvents(prev => [...prev, { id: Number(e.lastEventId) || prev.length + 1, name, data }])
+      if (name === 'persisted' && data?.strategy_id) setStrategyId(data.strategy_id)
+      if (name === 'done') {
+        setTerminal('done')
+        if (data?.strategy_id) setStrategyId(data.strategy_id)
+        es.close()
+        onDone?.({ strategy_id: data?.strategy_id })
+      }
+      if (name === 'error') {
+        setTerminal('error')
+        setErrorMsg(data?.message || 'Generation failed')
+        es.close()
+      }
+    }
+
+    Object.keys(EVENT_LABELS).forEach(name => es.addEventListener(name, handle(name)))
+
+    es.onerror = () => {
+      // EventSource will auto-reconnect; only treat as fatal once terminal.
+      if (terminal) es.close()
+    }
+
+    return () => { es.close() }
+    // jobId is the only real dep — re-subscribe on job change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jobId])
+
+  // Autoscroll the event list as it grows.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [events])
+
+  const consideredCount = events.find(e => e.name === 'best_selected')?.data?.considered_count || 0
+
+  return (
+    <div className="card" style={{ padding: 20 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <div>
+          <div className="label">Generating — job {jobId.slice(0, 10)}…</div>
+          {terminal === 'done' && (
+            <div className="positive caption" style={{ marginTop: 4 }}>
+              ✓ Strategy persisted{strategyId ? ` as ${strategyId}` : ''}
+            </div>
+          )}
+          {terminal === 'error' && (
+            <div className="negative caption" style={{ marginTop: 4 }}>
+              ✗ {errorMsg}
+            </div>
+          )}
+          {!terminal && (
+            <div className="caption" style={{ marginTop: 4, color: 'var(--text-3)' }}>
+              Streaming live · {events.length} event{events.length === 1 ? '' : 's'}
+            </div>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {consideredCount > 1 && (
+            <button
+              className="btn btn-outline btn-sm"
+              onClick={() => setShowRejected(true)}
+              title="See all candidates the agent considered"
+            >
+              Considered {consideredCount} candidates
+            </button>
+          )}
+          <button className="btn btn-outline btn-sm" onClick={onReset}>
+            {terminal ? 'New generation' : 'Cancel'}
+          </button>
+        </div>
+      </div>
+
+      <div
+        ref={scrollRef}
+        style={{
+          maxHeight: 320,
+          overflowY: 'auto',
+          background: 'rgba(255,255,255,0.02)',
+          border: '1px solid var(--glass-border)',
+          borderRadius: 6,
+          padding: 12,
+          fontSize: '0.82rem',
+          fontFamily: 'var(--mono, monospace)',
+        }}
+      >
+        {events.length === 0 && (
+          <div className="caption">Waiting for first event…</div>
+        )}
+        {events.map(ev => (
+          <div key={ev.id} style={{ marginBottom: 4, lineHeight: 1.4 }}>
+            <span style={{ color: 'var(--text-4)', marginRight: 8 }}>#{ev.id}</span>
+            <span style={{ color: 'var(--accent)', fontWeight: 600 }}>{EVENT_LABELS[ev.name] || ev.name}</span>
+            {' — '}
+            <span>{summarizeEvent(ev.name, ev.data)}</span>
+          </div>
+        ))}
+      </div>
+
+      {showRejected && (
+        <RejectedCandidates jobId={jobId} onClose={() => setShowRejected(false)} />
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -9,6 +9,7 @@ import { NEW_CONTRACTS } from '../config'
 const NAV = [
   { group: '', items: [
     { id: 'landing',   label: 'Home',      icon: 'i-lucide-home' },
+    { id: 'explore',   label: 'Explore',   icon: 'i-lucide-compass' },
     { id: 'generate',  label: 'Generate',  icon: 'i-lucide-sparkles' },
     { id: 'library',   label: 'Library',   icon: 'i-lucide-line-chart' },
     { id: 'corpus',    label: 'Corpus',    icon: 'i-lucide-library' },
@@ -20,6 +21,7 @@ const NAV = [
 
 export const PAGE_LABELS = {
   landing: 'Home',
+  explore: 'Explore',
   generate: 'Generate',
   library: 'Library',
   corpus: 'Corpus',

--- a/ui/src/components/Learnings.jsx
+++ b/ui/src/components/Learnings.jsx
@@ -3,7 +3,11 @@
 // the system's) have performed well, which haven't, and the agent's reasoning
 // for each. Honest empty state until strategies accumulate runtime data.
 
-export default function Learnings() {
+export default function Learnings({ onNavigate }) {
+  const goGenerate = (e) => {
+    e.preventDefault()
+    onNavigate?.('generate')
+  }
   return (
     <div>
       <div className="fade-up fade-up-1 max-w-[720px] mb-7">
@@ -26,7 +30,7 @@ export default function Learnings() {
           performance + reasoning data. To get started:
         </p>
         <ol className="pl-5 leading-loose">
-          <li><strong>Generate</strong> a strategy from the <a href="/generate" style={{ color: 'var(--accent)' }}>Generate</a> page.</li>
+          <li><strong>Generate</strong> a strategy from the <a href="/generate" onClick={goGenerate} className="text-[var(--accent)]">Generate</a> page.</li>
           <li>Connect your wallet and <strong>deploy it into a vault</strong> before the
             strategy expires — generated strategies are <strong>time-bound</strong> to the
             market context captured at generation time, so they go stale.</li>

--- a/ui/src/components/Reasoning.jsx
+++ b/ui/src/components/Reasoning.jsx
@@ -367,19 +367,6 @@ function StrategyDetailView({ strategy, traces }) {
         </div>
       )}
 
-      {/* Related PRs */}
-      <div style={{ marginTop: 20 }}>
-        <div className="label mb-2">Related</div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <a href="https://github.com/hackagora/archimedes-arcadia/pull/37" target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-sm">
-            PR #37 (corpus)
-          </a>
-          <a href="https://github.com/hackagora/archimedes-arcadia/pull/38" target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-sm">
-            PR #38 (fusion)
-          </a>
-        </div>
-      </div>
-
       {/* Efficient Frontier + Correlation Matrix — side-by-side on md+, stacked on small */}
       <div style={{ marginTop: 24 }} className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <EfficientFrontier />

--- a/ui/src/components/Reasoning.jsx
+++ b/ui/src/components/Reasoning.jsx
@@ -1,12 +1,8 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
-import { createPortal } from 'react-dom'
+import { useState, useEffect, useCallback } from 'react'
 import {
   publicClient,
   TRACE_REGISTRY_ABI, NEW_CONTRACTS,
 } from '../config'
-import EfficientFrontier from './EfficientFrontier'
-import CorrelationMatrix from './CorrelationMatrix'
-import RigorExplainer from './RigorExplainer'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -43,370 +39,13 @@ function shortHash(hash) {
   return `${hash.slice(0, 12)}…${hash.slice(-6)}`
 }
 
-// ─── Reasoning Strategy Card ────────────────────────────────
-
-function StrategyReasoningCard({ strategy, isSelected, onClick }) {
-  const hasBacktest = strategy.sharpe_ratio != null
-
-  return (
-    <div
-      className={`card fade-up${isSelected ? ' card-accent' : ''}`}
-      style={{ cursor: 'pointer', padding: 16 }}
-      onClick={onClick}
-    >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
-        <strong style={{ fontSize: '0.9rem', lineHeight: 1.3, flex: 1 }}>{strategy.paper_title}</strong>
-        <span className={`tag ${strategy.status === 'live' ? 'tag-positive' : 'tag-muted'}`} style={{ marginLeft: 8 }}>
-          {strategy.status}
-        </span>
-      </div>
-      <div className="caption" style={{ marginBottom: 8 }}>
-        {strategy.paper_authors?.slice(0, 2).join(', ')}{strategy.paper_authors?.length > 2 ? ' et al.' : ''}
-        {strategy.paper_year ? ` (${strategy.paper_year})` : ''}
-      </div>
-      <p className="hint" style={{ marginBottom: 8, lineHeight: 1.4 }}>
-        {strategy.methodology_summary?.slice(0, 120)}{strategy.methodology_summary?.length > 120 ? '…' : ''}
-      </p>
-      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 8 }}>
-        {strategy.asset_universe?.slice(0, 4).map(a => (
-          <span key={a} className="tag tag-muted">{a}</span>
-        ))}
-      </div>
-      {hasBacktest && (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
-          <div>
-            <div className="caption">Sharpe</div>
-            <div style={{ fontWeight: 700 }}>{strategy.sharpe_ratio?.toFixed(2)}</div>
-          </div>
-          <div>
-            <div className="caption">CAGR</div>
-            <div className="positive" style={{ fontWeight: 700 }}>{strategy.cagr ? `${(strategy.cagr * 100).toFixed(1)}%` : '—'}</div>
-          </div>
-          <div>
-            <div className="caption">Max DD</div>
-            <div className="negative" style={{ fontWeight: 700 }}>{strategy.max_drawdown ? `−${(strategy.max_drawdown * 100).toFixed(1)}%` : '—'}</div>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ─── Strategy Detail View ────────────────────────────────────
-
-function StrategyDetailView({ strategy, traces }) {
-  const [exporting, setExporting] = useState(false)
-  const [rigorModalOpen, setRigorModalOpen] = useState(false)
-
-  if (!strategy) return null
-
-  const handleExport = (format) => {
-    setExporting(true)
-    try {
-      let content, filename, type
-      if (format === 'json') {
-        content = JSON.stringify(strategy, null, 2)
-        filename = `strategy-${strategy.id.slice(0, 8)}.json`
-        type = 'application/json'
-      } else {
-        // CSV
-        const rows = [
-          ['Field', 'Value'],
-          ['Title', strategy.paper_title],
-          ['Authors', strategy.paper_authors?.join(', ')],
-          ['Year', strategy.paper_year],
-          ['Status', strategy.status],
-          ['Sharpe', strategy.sharpe_ratio],
-          ['CAGR', strategy.cagr],
-          ['Max Drawdown', strategy.max_drawdown],
-          ['Methodology', strategy.methodology_summary],
-          ['Assets', strategy.asset_universe?.join(', ')],
-          ['Methodology Hash', strategy.methodology_hash],
-        ]
-        content = rows.map(r => r.map(c => `"${String(c ?? '').replace(/"/g, '""')}"`).join(',')).join('\n')
-        filename = `strategy-${strategy.id.slice(0, 8)}.csv`
-        type = 'text/csv'
-      }
-      const blob = new Blob([content], { type })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url; a.download = filename; a.click()
-      URL.revokeObjectURL(url)
-    } finally {
-      setExporting(false)
-    }
-  }
-
-  return (
-    <div className="card-elevated" style={{ padding: 24 }}>
-      {/* Header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 16 }}>
-        <div>
-          <h2 style={{ fontSize: '1.3rem', lineHeight: 1.3 }}>{strategy.paper_title}</h2>
-          <div className="caption" style={{ marginTop: 4 }}>
-            {strategy.paper_authors?.join(', ')} · {strategy.paper_year} · {strategy.paper_venue}
-          </div>
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button className="btn btn-outline btn-sm" onClick={() => handleExport('json')} disabled={exporting}>
-            Export JSON
-          </button>
-          <button className="btn btn-outline btn-sm" onClick={() => handleExport('csv')} disabled={exporting}>
-            Export CSV
-          </button>
-        </div>
-      </div>
-
-      {/* Methodology */}
-      <div style={{ marginBottom: 20 }}>
-        <div className="label mb-2">Methodology</div>
-        <p className="body" style={{ lineHeight: 1.6 }}>{strategy.methodology_summary}</p>
-      </div>
-
-      {/* Reasoning Trace */}
-      <div style={{ marginBottom: 20 }}>
-        <div className="label mb-2">Reasoning Trace</div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <div className="card-flat" style={{ padding: 12, display: 'flex', gap: 12, alignItems: 'center' }}>
-            <span style={{ color: 'var(--accent)', fontWeight: 700, fontSize: '0.75rem' }}>STEP 1</span>
-            <span className="body">Signal generation: {strategy.position_sizing} position sizing across {strategy.asset_universe?.join(', ')}</span>
-          </div>
-          <div className="card-flat" style={{ padding: 12, display: 'flex', gap: 12, alignItems: 'center' }}>
-            <span style={{ color: 'var(--accent)', fontWeight: 700, fontSize: '0.75rem' }}>STEP 2</span>
-            <span className="body">Rebalance frequency: {strategy.rebalance_frequency}</span>
-          </div>
-          <div className="card-flat" style={{ padding: 12, display: 'flex', gap: 12, alignItems: 'center' }}>
-            <span style={{ color: 'var(--accent)', fontWeight: 700, fontSize: '0.75rem' }}>STEP 3</span>
-            <span className="body">Risk guardrail: {strategy.status === 'live' ? 'validated + deployed' : 'pending validation'}</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Performance Metrics */}
-      <div style={{ marginBottom: 20 }}>
-        <div className="label mb-2">Performance Metrics{strategy.is_backtest_placeholder ? ' (est.)' : ''}</div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 }}>
-          <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption">Sharpe</div>
-            <div style={{ fontSize: '1.2rem', fontWeight: 700 }}>{strategy.sharpe_ratio?.toFixed(2) ?? '—'}</div>
-          </div>
-          <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption">CAGR</div>
-            <div className="positive" style={{ fontSize: '1.2rem', fontWeight: 700 }}>
-              {strategy.cagr ? `${(strategy.cagr * 100).toFixed(1)}%` : '—'}
-            </div>
-          </div>
-          <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption">Max DD</div>
-            <div className="negative" style={{ fontSize: '1.2rem', fontWeight: 700 }}>
-              {strategy.max_drawdown ? `−${(strategy.max_drawdown * 100).toFixed(1)}%` : '—'}
-            </div>
-          </div>
-          <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption">Win Rate</div>
-            <div style={{ fontSize: '1.2rem', fontWeight: 700 }}>
-              {strategy.win_rate ? `${(strategy.win_rate * 100).toFixed(1)}%` : '—'}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Rigor Metrics with help affordance */}
-      {(strategy.deflated_sharpe_ratio != null || strategy.pbo_score != null || strategy.out_of_sample_sharpe != null) && (
-        <div style={{ marginBottom: 20 }}>
-          <div className="label mb-2 flex items-center gap-2">
-            Rigor Gate
-            <button
-              type="button"
-              onClick={() => setRigorModalOpen(true)}
-              style={{
-                width: 18, height: 18, borderRadius: '50%',
-                border: '1px solid var(--glass-border)', background: 'rgba(255,255,255,0.04)',
-                color: 'var(--text-4)', fontSize: '0.68rem', fontWeight: 700,
-                cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                lineHeight: 1,
-              }}
-              aria-label="What is the rigor gate?"
-            >
-              ?
-            </button>
-          </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
-            <div className="card-flat" style={{ padding: 12 }}>
-              <div className="caption flex items-center gap-1">
-                DSR p-value
-                <button
-                  type="button"
-                  onClick={() => setRigorModalOpen(true)}
-                  style={{
-                    width: 14, height: 14, borderRadius: '50%',
-                    border: '1px solid var(--glass-border)', background: 'transparent',
-                    color: 'var(--text-4)', fontSize: '0.58rem', fontWeight: 700,
-                    cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                    lineHeight: 1, padding: 0,
-                  }}
-                  aria-label="Explain DSR"
-                >
-                  ?
-                </button>
-              </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 700 }}>
-                {strategy.deflated_sharpe_ratio != null ? strategy.deflated_sharpe_ratio.toFixed(3) : '—'}
-              </div>
-            </div>
-            <div className="card-flat" style={{ padding: 12 }}>
-              <div className="caption flex items-center gap-1">
-                PBO
-                <button
-                  type="button"
-                  onClick={() => setRigorModalOpen(true)}
-                  style={{
-                    width: 14, height: 14, borderRadius: '50%',
-                    border: '1px solid var(--glass-border)', background: 'transparent',
-                    color: 'var(--text-4)', fontSize: '0.58rem', fontWeight: 700,
-                    cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                    lineHeight: 1, padding: 0,
-                  }}
-                  aria-label="Explain PBO"
-                >
-                  ?
-                </button>
-              </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 700, color: (strategy.pbo_score ?? 0) > 0.5 ? 'var(--negative)' : 'var(--positive)' }}>
-                {strategy.pbo_score != null ? (strategy.pbo_score * 100).toFixed(1) + '%' : '—'}
-              </div>
-            </div>
-            <div className="card-flat" style={{ padding: 12 }}>
-              <div className="caption flex items-center gap-1">
-                OOS Sharpe
-                <button
-                  type="button"
-                  onClick={() => setRigorModalOpen(true)}
-                  style={{
-                    width: 14, height: 14, borderRadius: '50%',
-                    border: '1px solid var(--glass-border)', background: 'transparent',
-                    color: 'var(--text-4)', fontSize: '0.58rem', fontWeight: 700,
-                    cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                    lineHeight: 1, padding: 0,
-                  }}
-                  aria-label="Explain walk-forward OOS"
-                >
-                  ?
-                </button>
-              </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 700 }}>
-                {strategy.out_of_sample_sharpe != null ? strategy.out_of_sample_sharpe.toFixed(2) : '—'}
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Paper-Claim Delta */}
-      {strategy.paper_claimed_sharpe && strategy.sharpe_ratio && (
-        <div style={{ marginBottom: 20 }}>
-          <div className="label mb-2">Paper-Claim Delta</div>
-          <div className="card-flat" style={{ padding: 12 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <span className="caption">Paper claimed Sharpe</span>
-              <strong>{strategy.paper_claimed_sharpe.toFixed(2)}</strong>
-            </div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <span className="caption">Backtest Sharpe</span>
-              <strong>{strategy.sharpe_ratio.toFixed(2)}</strong>
-            </div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <span className="caption">Delta</span>
-              <strong className={strategy.sharpe_ratio / strategy.paper_claimed_sharpe >= 0.5 ? 'positive' : 'negative'}>
-                {((strategy.sharpe_ratio / strategy.paper_claimed_sharpe) * 100).toFixed(0)}% of claim
-              </strong>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* On-chain Provenance */}
-      <div style={{ marginBottom: 20 }}>
-        <div className="label mb-2">On-Chain Provenance</div>
-        <div className="card-flat" style={{ padding: 12 }}>
-          <div className="caption">Strategy ID: <code style={{ color: 'var(--info)' }}>{shortHash(strategy.id)}</code></div>
-          {strategy.methodology_hash && (
-            <div className="caption" style={{ marginTop: 4 }}>
-              Methodology Hash: <code style={{ color: 'var(--text-2)' }}>{shortHash(strategy.methodology_hash)}</code>
-            </div>
-          )}
-          {strategy.curator_note && (
-            <div className="caption" style={{ marginTop: 8, fontStyle: 'italic', color: 'var(--text-3)' }}>
-              Curator: "{strategy.curator_note?.slice(0, 150)}{strategy.curator_note?.length > 150 ? '…' : ''}"
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* On-chain Traces for this strategy */}
-      {traces.length > 0 && (
-        <div>
-          <div className="label mb-2">Reasoning Traces ({traces.length})</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {traces.map((t, i) => (
-              <div key={i} className="card-flat" style={{ padding: 10, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
-                <div style={{ flex: 1 }}>
-                  <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 4 }}>
-                    <span className="tag tag-accent">{t.decision_type || 'trace'}</span>
-                    <code style={{ fontSize: '0.75rem' }}>{shortHash(t.trace_hash)}</code>
-                    {t.is_verified && <span className="i-lucide-check w-3 h-3 text-[var(--positive)]" />}
-                    {t.arc_tx_hash && <span className="i-lucide-anchor w-3 h-3 text-[var(--text-3)]" />}
-                  </div>
-                  {t.reasoning && <p className="hint" style={{ marginBottom: 0 }}>{t.reasoning.slice(0, 120)}{t.reasoning.length > 120 ? '…' : ''}</p>}
-                  {t.confidence > 0 && <div className="caption">Confidence: {(t.confidence * 100).toFixed(0)}%</div>}
-                </div>
-                <div className="caption" style={{ whiteSpace: 'nowrap' }}>{timeAgo(t.timestamp)}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Efficient Frontier + Correlation Matrix — side-by-side on md+, stacked on small */}
-      <div style={{ marginTop: 24 }} className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <EfficientFrontier />
-        <CorrelationMatrix selectedStrategyId={strategy.id} />
-      </div>
-
-      {/* Rigor Explainer modal (portal-rendered) */}
-      {rigorModalOpen && createPortal(
-        <div
-          className="modal-overlay"
-          onClick={() => setRigorModalOpen(false)}
-          style={{ zIndex: 1000 }}
-        >
-          <div
-            className="modal"
-            onClick={e => e.stopPropagation()}
-            style={{ maxWidth: 820, maxHeight: '85vh', overflowY: 'auto', width: '90vw' }}
-          >
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
-              <button
-                type="button"
-                onClick={() => setRigorModalOpen(false)}
-                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-4)' }}
-                aria-label="Close"
-              >
-                <span className="i-lucide-x" style={{ width: 20, height: 20 }} />
-              </button>
-            </div>
-            <RigorExplainer />
-          </div>
-        </div>,
-        document.body,
-      )}
-    </div>
-  )
-}
-
 // ─── On-chain Traces Panel ───────────────────────────────────
+// Reasoning is now the dedicated trace browser per page-roles-spec.md.
+// Strategy detail (export, paper-claim delta, EfficientFrontier,
+// CorrelationMatrix, RigorExplainer) lives on Library where the strategy
+// itself does — open via ?highlight=<id> deep-link from any trace card.
 
-function OnChainTraces() {
+function OnChainTraces({ onNavigate }) {
   const [traces, setTraces] = useState([])
   const [totalCount, setTotalCount] = useState(0)
   const [loading, setLoading] = useState(true)
@@ -473,7 +112,8 @@ function OnChainTraces() {
         is computed deterministically off-chain and anchored on Arc via the
         <code style={{ marginLeft: 4 }}>ReasoningTraceRegistry</code> contract.
         Click <strong>Verify on-chain</strong> on any trace to recompute and check
-        against the on-chain anchor.
+        against the on-chain anchor; click <strong>→ Strategy in Library</strong>
+        to jump to the source strategy and its full passport.
       </p>
 
       {/* Trace list */}
@@ -543,7 +183,7 @@ function OnChainTraces() {
                   </div>
                 )}
 
-                {/* Verify button */}
+                {/* Verify button + strategy back-link */}
                 <div className="flex gap-2 items-center flex-wrap">
                   <button
                     className="btn btn-outline btn-sm flex items-center gap-1.5"
@@ -556,6 +196,15 @@ function OnChainTraces() {
                       <><span className="i-lucide-search w-3.5 h-3.5" /> Verify on-chain</>
                     )}
                   </button>
+                  {t.strategy_id && onNavigate && (
+                    <button
+                      className="btn btn-outline btn-sm"
+                      onClick={() => onNavigate('library', { highlight: t.strategy_id })}
+                      title="Open this trace's strategy in the Library"
+                    >
+                      → Strategy in Library
+                    </button>
+                  )}
                   {vResult && (
                     <span className={`caption flex items-center gap-1 ${vResult.is_verified ? 'positive' : 'negative'}`}>
                       <span className={vResult.is_verified ? 'i-lucide-check w-3 h-3' : 'i-lucide-x w-3 h-3'} />
@@ -595,148 +244,18 @@ function OnChainTraces() {
 
 // ─── Main Export ─────────────────────────────────────────────
 
-export default function Reasoning() {
-  const [strategies, setStrategies] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
-  const [selectedId, setSelectedId] = useState(null)
-  const [filterStatus, setFilterStatus] = useState('all')
-  const [filterAuthor, setFilterAuthor] = useState('all')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [onChainTraces, setOnChainTraces] = useState([])
-  const [tab, setTab] = useState('strategies')
-
-  // Load strategies from API
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const data = await apiGet('/api/strategies/')
-        setStrategies(data.strategies || [])
-      } catch (e) {
-        setError(e.message)
-      } finally {
-        setLoading(false)
-      }
-    }
-    load()
-  }, [])
-
-  // Load on-chain traces for selected strategy
-  useEffect(() => {
-    const loadTraces = async () => {
-      try {
-        const data = await apiGet('/api/traces/')
-        setOnChainTraces(data.traces || [])
-      } catch {}
-    }
-    loadTraces()
-  }, [])
-
-  // Unique authors for filter
-  const authors = useMemo(() => {
-    const set = new Set()
-    strategies.forEach(s => s.paper_authors?.forEach(a => set.add(a)))
-    return [...set].sort()
-  }, [strategies])
-
-  // Filtered strategies
-  const filtered = useMemo(() => {
-    return strategies.filter(s => {
-      if (filterStatus !== 'all' && s.status !== filterStatus) return false
-      if (filterAuthor !== 'all' && !s.paper_authors?.includes(filterAuthor)) return false
-      if (searchQuery) {
-        const q = searchQuery.toLowerCase()
-        return s.paper_title?.toLowerCase().includes(q) ||
-               s.methodology_summary?.toLowerCase().includes(q) ||
-               s.asset_universe?.some(a => a.toLowerCase().includes(q))
-      }
-      return true
-    })
-  }, [strategies, filterStatus, filterAuthor, searchQuery])
-
-  const selected = selectedId ? strategies.find(s => s.id === selectedId) : filtered[0]
-  const selectedTraces = selected ? onChainTraces.filter(t =>
-    t.vault_address?.includes(selected.id.slice(0, 8))
-  ) : []
-
+export default function Reasoning({ onNavigate }) {
   return (
     <div>
-      <div className="fade-up fade-up-1 max-w-[640px] mb-7">
-        <h2 className="font-serif text-[2rem] mb-2.5">Intelligence — Reasoning</h2>
+      <div className="fade-up fade-up-1 max-w-[720px] mb-7">
+        <h2 className="font-serif text-[2rem] mb-2.5">Reasoning</h2>
         <p className="body">
-          Every strategy carries a verifiable reasoning trace. Methodology is extracted from
-          published research, anchored on-chain, and auditable by anyone.
+          Every autonomous agent decision is anchored on-chain by hash. Browse the
+          trace timeline below, verify any hash against the on-chain registry, and
+          follow each trace back to the source strategy in the Library.
         </p>
       </div>
-
-      {/* Tabs */}
-      <div className="tabs fade-up fade-up-2 mb-6">
-        <div className={`tab${tab === 'strategies' ? ' active' : ''}`} onClick={() => setTab('strategies')}>Strategies</div>
-        <div className={`tab${tab === 'traces' ? ' active' : ''}`} onClick={() => setTab('traces')}>On-Chain Traces</div>
-      </div>
-
-      {tab === 'strategies' && (
-        <div className="trade-grid fade-up fade-up-2">
-          {/* Left: Strategy list + filters */}
-          <div>
-            {/* Filters */}
-            <div className="flex gap-2 mb-4 flex-wrap">
-              <input
-                type="text"
-                placeholder="Search strategies…"
-                value={searchQuery}
-                onChange={e => setSearchQuery(e.target.value)}
-                className="chat-input"
-                style={{ flex: 1, minWidth: 140 }}
-              />
-              <select value={filterStatus} onChange={e => setFilterStatus(e.target.value)} className="chat-input" style={{ width: 'auto' }}>
-                <option value="all">All status</option>
-                <option value="live">Live</option>
-                <option value="validated">Validated</option>
-                <option value="candidate">Candidate</option>
-              </select>
-              <select value={filterAuthor} onChange={e => setFilterAuthor(e.target.value)} className="chat-input" style={{ width: 'auto' }}>
-                <option value="all">All authors</option>
-                {authors.map(a => <option key={a} value={a}>{a}</option>)}
-              </select>
-            </div>
-
-            {loading && <div className="caption">Loading strategies…</div>}
-            {error && <div className="info-box warning">API error: {error}</div>}
-            {!loading && filtered.length === 0 && <div className="caption">No strategies match filters.</div>}
-
-            <div className="flex flex-col gap-2.5">
-              {filtered.map(s => (
-                <StrategyReasoningCard
-                  key={s.id}
-                  strategy={s}
-                  isSelected={selected?.id === s.id}
-                  onClick={() => setSelectedId(s.id)}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Right: Detail view */}
-          <div>
-            {selected ? (
-              <StrategyDetailView strategy={selected} traces={selectedTraces} />
-            ) : (
-              <div className="card text-center p-10">
-                <div className="mb-2.5 flex justify-center">
-                  <span className="i-lucide-brain w-8 h-8 text-[var(--accent)]" />
-                </div>
-                <strong>Select a strategy</strong>
-                <p className="caption mt-2">Click a strategy card to view its reasoning trace, metrics, and on-chain provenance.</p>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
-      {tab === 'traces' && (
-        <OnChainTraces />
-      )}
+      <OnChainTraces onNavigate={onNavigate} />
     </div>
   )
 }

--- a/ui/src/components/RejectedCandidates.jsx
+++ b/ui/src/components/RejectedCandidates.jsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+// Modal-ish overlay showing all candidates the agent produced for a job.
+// The 'best' one was surfaced in the main flow; this view lets the user see
+// the others and why they weren't picked.
+
+export default function RejectedCandidates({ jobId, onClose }) {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`${API_BASE}/api/generate/jobs/${encodeURIComponent(jobId)}/candidates`)
+      .then(r => r.ok ? r.json() : r.text().then(t => { throw new Error(t) }))
+      .then(d => { if (!cancelled) setData(d) })
+      .catch(e => { if (!cancelled) setError(e.message || 'Failed to load candidates') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [jobId])
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 1000, padding: 20,
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        className="card"
+        style={{ maxWidth: 720, width: '100%', maxHeight: '80vh', overflowY: 'auto', padding: 24 }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
+          <div>
+            <h3 style={{ marginBottom: 4 }}>Candidates considered</h3>
+            <p className="caption" style={{ marginBottom: 0 }}>
+              The agent generated multiple candidates and picked the best by rigor verdict.
+              The others are shown here for inspection.
+            </p>
+          </div>
+          <button className="btn btn-outline btn-sm" onClick={onClose}>Close</button>
+        </div>
+
+        {loading && <div className="caption">Loading…</div>}
+        {error && <div className="info-box warning">{error}</div>}
+
+        {data && data.candidates?.length === 0 && (
+          <div className="caption">No candidate data on file for this job.</div>
+        )}
+
+        {data && data.candidates?.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {data.candidates.map(c => (
+              <div
+                key={c.candidate_id}
+                className="card-flat"
+                style={{
+                  padding: 12,
+                  border: c.selected ? '1px solid var(--accent)' : '1px solid var(--glass-border)',
+                  background: c.selected ? 'rgba(255,209,102,0.06)' : 'transparent',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+                  <div>
+                    <strong>{c.strategy_name || c.candidate_id}</strong>
+                    <span className="caption" style={{ marginLeft: 8 }}>({c.candidate_id})</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    {c.selected && <span className="tag tag-accent">Selected</span>}
+                    {c.passes_rigor
+                      ? <span className="tag tag-positive">Passes rigor</span>
+                      : <span className="tag tag-negative">Failed rigor</span>}
+                  </div>
+                </div>
+                {c.rigor_verdict && (
+                  <div className="caption" style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                    {c.rigor_verdict.dsr != null && <span>DSR: <strong>{c.rigor_verdict.dsr}</strong></span>}
+                    {c.rigor_verdict.pbo != null && <span>PBO: <strong>{c.rigor_verdict.pbo}</strong></span>}
+                    {c.rigor_verdict.oos_sharpe != null && <span>OOS Sharpe: <strong>{c.rigor_verdict.oos_sharpe}</strong></span>}
+                    {c.rigor_verdict.lookahead_audit_passed != null && (
+                      <span>Lookahead: <strong>{c.rigor_verdict.lookahead_audit_passed ? '✓' : '✗'}</strong></span>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import CustomSelect from './CustomSelect'
+import EfficientFrontier from './EfficientFrontier'
+import CorrelationMatrix from './CorrelationMatrix'
+import RigorExplainer from './RigorExplainer'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -378,7 +382,7 @@ export function StrategyArchitect({ strategies }) {
 // + rigor metrics). One row per strategy; no visual hierarchy by status (the
 // STATUS column does that job).
 
-function StrategyRow({ s, isHighlighted }) {
+function StrategyRow({ s, isHighlighted, onOpenRigorExplainer }) {
   const [open, setOpen] = useState(isHighlighted)
   const rowRef = useRef(null)
   const years = periodInYears(s.backtest_start, s.backtest_end)
@@ -479,7 +483,20 @@ function StrategyRow({ s, isHighlighted }) {
                 )}
               </div>
               <div>
-                <div className="label mb-2">Rigor metrics</div>
+                <div className="label mb-2 flex items-center gap-2">
+                  Rigor metrics
+                  {onOpenRigorExplainer && (
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); onOpenRigorExplainer() }}
+                      className="rigor-help-btn"
+                      aria-label="What is the rigor gate?"
+                      title="What is the rigor gate?"
+                    >
+                      ?
+                    </button>
+                  )}
+                </div>
                 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10 }}>
                   <div><div className="caption">DSR</div><div className="mono" style={{ fontWeight: 700 }}>{fmt(s.deflated_sharpe_ratio)}</div></div>
                   <div><div className="caption">PBO</div><div className="mono" style={{ fontWeight: 700 }}>{fmtPct(s.pbo_score)}</div></div>
@@ -525,7 +542,7 @@ function StrategyRow({ s, isHighlighted }) {
   )
 }
 
-function StrategyTable({ strategies, emptyState, highlightStrategyId }) {
+function StrategyTable({ strategies, emptyState, highlightStrategyId, onOpenRigorExplainer }) {
   if (!strategies.length) return emptyState
   return (
     <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
@@ -543,7 +560,14 @@ function StrategyTable({ strategies, emptyState, highlightStrategyId }) {
           </tr>
         </thead>
         <tbody>
-          {strategies.map(s => <StrategyRow key={s.id} s={s} isHighlighted={highlightStrategyId && s.id === highlightStrategyId} />)}
+          {strategies.map(s => (
+            <StrategyRow
+              key={s.id}
+              s={s}
+              isHighlighted={highlightStrategyId && s.id === highlightStrategyId}
+              onOpenRigorExplainer={onOpenRigorExplainer}
+            />
+          ))}
         </tbody>
       </table>
     </div>
@@ -596,6 +620,10 @@ export default function Strategies({ highlightStrategyId }) {
   // 'generated' is the first-class tab per product feedback — pushes user
   // toward Generate when empty.
   const [activeTab, setActiveTab] = useState('generated')
+  // Page-level rigor explainer modal, opened from any row expansion's "?"
+  // affordance. Single modal instance per page keeps state simple.
+  const [rigorModalOpen, setRigorModalOpen] = useState(false)
+  const openRigorExplainer = useCallback(() => setRigorModalOpen(true), [])
 
   // If we arrived via ?highlight=<id> and the strategy is only in Examples,
   // auto-switch to the Examples tab so the scrollIntoView lands a real row.
@@ -669,6 +697,7 @@ export default function Strategies({ highlightStrategyId }) {
           <StrategyTable
             strategies={generated}
             highlightStrategyId={highlightStrategyId}
+            onOpenRigorExplainer={openRigorExplainer}
             emptyState={
               <div className="card" style={{ padding: 22 }}>
                 <div className="label mb-2">No generated strategies yet</div>
@@ -703,6 +732,7 @@ export default function Strategies({ highlightStrategyId }) {
             <StrategyTable
               strategies={examples}
               highlightStrategyId={highlightStrategyId}
+              onOpenRigorExplainer={openRigorExplainer}
               emptyState={<p className="caption">No example strategies loaded.</p>}
             />
           )}
@@ -714,6 +744,41 @@ export default function Strategies({ highlightStrategyId }) {
           * Estimated metrics — sourced from paper claims with McLean-Pontiff post-publication decay
           applied. Replaced by real BacktestResult once the analytics engine runs.
         </div>
+      )}
+
+      {/* Page-level analytics panels — moved from Reasoning per page-roles-spec.
+          CorrelationMatrix highlights the deep-linked row when present. */}
+      <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <EfficientFrontier />
+        <CorrelationMatrix selectedStrategyId={highlightStrategyId || null} />
+      </div>
+
+      {/* Rigor Explainer modal (portal-rendered, page-level) */}
+      {rigorModalOpen && createPortal(
+        <div
+          className="modal-overlay"
+          onClick={() => setRigorModalOpen(false)}
+          style={{ zIndex: 1000 }}
+        >
+          <div
+            className="modal"
+            onClick={e => e.stopPropagation()}
+            style={{ maxWidth: 820, maxHeight: '85vh', overflowY: 'auto', width: '90vw' }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+              <button
+                type="button"
+                onClick={() => setRigorModalOpen(false)}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-4)' }}
+                aria-label="Close"
+              >
+                <span className="i-lucide-x" style={{ width: 20, height: 20 }} />
+              </button>
+            </div>
+            <RigorExplainer />
+          </div>
+        </div>,
+        document.body,
       )}
     </div>
   )

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import CustomSelect from './CustomSelect'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
@@ -28,6 +28,37 @@ const RISK_PROFILES = [
 ]
 
 const STATUS_ORDER = ['live', 'validated', 'candidate', 'retired']
+
+function downloadStrategy(strategy, format) {
+  let content, filename, type
+  if (format === 'json') {
+    content = JSON.stringify(strategy, null, 2)
+    filename = `strategy-${(strategy.id || 'unknown').slice(0, 8)}.json`
+    type = 'application/json'
+  } else {
+    const rows = [
+      ['Field', 'Value'],
+      ['Title', strategy.paper_title],
+      ['Authors', strategy.paper_authors?.join(', ')],
+      ['Year', strategy.paper_year],
+      ['Status', strategy.status],
+      ['Sharpe', strategy.sharpe_ratio],
+      ['CAGR', strategy.cagr],
+      ['Max Drawdown', strategy.max_drawdown],
+      ['Methodology', strategy.methodology_summary],
+      ['Assets', strategy.asset_universe?.join(', ')],
+      ['Methodology Hash', strategy.methodology_hash],
+    ]
+    content = rows.map(r => r.map(c => `"${String(c ?? '').replace(/"/g, '""')}"`).join(',')).join('\n')
+    filename = `strategy-${(strategy.id || 'unknown').slice(0, 8)}.csv`
+    type = 'text/csv'
+  }
+  const blob = new Blob([content], { type })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url; a.download = filename; a.click()
+  URL.revokeObjectURL(url)
+}
 
 function statusTag(status) {
   if (status === 'live') return 'tag-positive'
@@ -347,8 +378,9 @@ export function StrategyArchitect({ strategies }) {
 // + rigor metrics). One row per strategy; no visual hierarchy by status (the
 // STATUS column does that job).
 
-function StrategyRow({ s }) {
-  const [open, setOpen] = useState(false)
+function StrategyRow({ s, isHighlighted }) {
+  const [open, setOpen] = useState(isHighlighted)
+  const rowRef = useRef(null)
   const years = periodInYears(s.backtest_start, s.backtest_end)
   const endValue = projectedEndValue(1000, s.cagr, years)
   const startStr = (s.backtest_start || '').slice(0, 10)
@@ -361,9 +393,20 @@ function StrategyRow({ s }) {
   const sharpeCI = s.sharpe_ci_95 != null ? s.sharpe_ci_95 : null
   const driftFlag = s.drift_detected === true
 
+  useEffect(() => {
+    if (isHighlighted && rowRef.current) {
+      rowRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [isHighlighted])
+
+  const rowStyle = {
+    cursor: 'pointer',
+    ...(isHighlighted ? { background: 'rgba(255,209,102,0.10)', outline: '1px solid var(--accent)' } : {}),
+  }
+
   return (
     <>
-      <tr className="lib-row cursor-pointer" onClick={() => setOpen(o => !o)}>
+      <tr ref={rowRef} className="lib-row cursor-pointer" onClick={() => setOpen(o => !o)} style={rowStyle}>
         <td className="font-semibold">
           <span className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3 h-3 mr-1.5 text-[var(--text-4)] flex-shrink-0 inline-block`} />
           {s.paper_title}
@@ -459,6 +502,22 @@ function StrategyRow({ s }) {
                 )}
               </div>
             </div>
+            <div style={{ marginTop: 14, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              <button
+                className="btn btn-outline btn-sm"
+                onClick={(e) => { e.stopPropagation(); downloadStrategy(s, 'json') }}
+                title="Download this strategy as JSON"
+              >
+                Export JSON
+              </button>
+              <button
+                className="btn btn-outline btn-sm"
+                onClick={(e) => { e.stopPropagation(); downloadStrategy(s, 'csv') }}
+                title="Download this strategy as CSV"
+              >
+                Export CSV
+              </button>
+            </div>
           </td>
         </tr>
       )}
@@ -466,7 +525,7 @@ function StrategyRow({ s }) {
   )
 }
 
-function StrategyTable({ strategies, emptyState }) {
+function StrategyTable({ strategies, emptyState, highlightStrategyId }) {
   if (!strategies.length) return emptyState
   return (
     <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
@@ -484,7 +543,7 @@ function StrategyTable({ strategies, emptyState }) {
           </tr>
         </thead>
         <tbody>
-          {strategies.map(s => <StrategyRow key={s.id} s={s} />)}
+          {strategies.map(s => <StrategyRow key={s.id} s={s} isHighlighted={highlightStrategyId && s.id === highlightStrategyId} />)}
         </tbody>
       </table>
     </div>
@@ -529,7 +588,7 @@ function coerceGenerated(row) {
   }
 }
 
-export default function Strategies() {
+export default function Strategies({ highlightStrategyId }) {
   const [examples, setExamples] = useState([])
   const [generated, setGenerated] = useState([])
   const [loading, setLoading] = useState(true)
@@ -537,6 +596,15 @@ export default function Strategies() {
   // 'generated' is the first-class tab per product feedback — pushes user
   // toward Generate when empty.
   const [activeTab, setActiveTab] = useState('generated')
+
+  // If we arrived via ?highlight=<id> and the strategy is only in Examples,
+  // auto-switch to the Examples tab so the scrollIntoView lands a real row.
+  useEffect(() => {
+    if (!highlightStrategyId) return
+    const inGenerated = generated.some(s => s.id === highlightStrategyId)
+    const inExamples = examples.some(s => s.id === highlightStrategyId)
+    if (!inGenerated && inExamples) setActiveTab('examples')
+  }, [highlightStrategyId, generated, examples])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -600,6 +668,7 @@ export default function Strategies() {
         <>
           <StrategyTable
             strategies={generated}
+            highlightStrategyId={highlightStrategyId}
             emptyState={
               <div className="card" style={{ padding: 22 }}>
                 <div className="label mb-2">No generated strategies yet</div>
@@ -633,6 +702,7 @@ export default function Strategies() {
           {!loading && (
             <StrategyTable
               strategies={examples}
+              highlightStrategyId={highlightStrategyId}
               emptyState={<p className="caption">No example strategies loaded.</p>}
             />
           )}


### PR DESCRIPTION
## Summary

The spine-plus-v2 effort — 13 commits across Phases 0–3 + follow-ups + Day-11 docs cleanup + post-rebase reconciliation with Önder's panel integration (#119) and the bot's Phase 7 cleanup (#129–#133). Net build: streaming Generate UI, dedicated Explore page, KB pipeline skeleton, page-roles split, hard cancellation + real DSR/PBO/OOS rigor wiring on the agent path, and a top-to-bottom docs index refresh.

Phase 6 (onboarding tour) shipped separately via #134.

## What's in the branch

### Phases 0–3 (the spine-plus-v2 build itself)

- **Phase 0** — Phase plan + architectural specs (`docs/specs/spine-plus-v2-plan.md`, `page-roles-spec.md`, `strategy-lifecycle-spec.md`, `vault-semantics-spec.md`, `portfolio-constructor-decision-tree.md`, `generation-streaming-spec.md`, `kb-integration-spec.md`)
- **Phase 1 (cherry-pick + deferred resolution)** — junk extermination (routes.py:172 TODO, Reasoning page restructure), Library `?highlight=` deep-link, interfaces ownership comments reframed per CLAUDE.md's lane-softening
- **Phase 2** — streaming Generate (`api/generate_routes.py` + `services/generation_pipeline.py` + UI `GenerationStream`/`GenerationStatus`/`RejectedCandidates` components, SSE with Redis-backed event log + hard-cancellation via asyncio task registry, JSON-mode brief validation, real DSR/PBO/OOS computation via canonical `services/rigor_evaluator.py`)
- **Phase 3** — Explore page (`api/explore_routes.py` + `services/asset_market_service.py` + `ui/components/Explore.jsx` — top-level nav, read-only yfinance-backed table with plain-English metric tooltips, no oracle dependency); Corpus polish (`category_label` enrichment on all paper-serialization paths); KB skeleton (`models/kg.py`, `scripts/run_kb_pipeline.py`, `services/kb_runner.py`, gated behind `KB_PIPELINE_ENABLED`)

### Phase 2 follow-ups
- Hard cancellation: `asyncio.Task` registry in `generate_routes.py` so `cancel_job` actually interrupts the running generation pipeline (not just flips Redis status)
- Rigor wiring: agent-path candidates now run through canonical `rigor_evaluator.compute_dsr`/`compute_oos_sharpe`/library-level `compute_pbo` via a buy-and-hold return-series adapter
- Brief validation: JSON-mode LLM step that catches contradictory/incoherent briefs early with a permissive fallback

### Day-11 docs cleanup (commit `3e942c1`)
- Status blocks on 10 docs that were missing them — 5 t2o2 issue specs + 5 top-level docs
- `chuan-architecture-survey.md` refreshed to Day-11 (new files + Phase 7 t2o2 cross-refs + gap-clusters rewritten as a table with current status)
- `claude-design-prompts.md` Day-11 header refresh + per-prompt "delta callouts" so re-runs reflect the new shipped reality
- `docs/README.md` restructured: Specs split into architectural / phase plans / t2o2 issue specs (with issue # column); standardized status vocabulary in the conventions block

### Post-rebase reconciliation (commits `b11d3e3`, `b45b2aa`, `bfecb51`)
- t2o2 issue spec status blocks flipped from "open" → "✓ closed" with the merge commit hashes (#128–#133 all landed via the bot)
- Phase 3's `category_label` enrichment re-applied to `papers_routes.py` (the bot's #132 split moved those serialization paths out of `routes.py` without the Phase 3b change)
- Page-roles split completed: Reasoning page stripped to traces-only (~742 → 247 lines); Library page absorbed the EfficientFrontier + CorrelationMatrix + RigorExplainer panels from Önder's #119 (single page-level instance, page-level modal); "→ Strategy in Library" deep-link back-button on trace cards (lost during rebase, restored)

## Key rebase reconciliations

`main` moved a lot under us. Significant choices:

1. **routes.py monolith split (#132)** — Phase 1 cherry-pick's `routes.py:172` 501 fix was on the old monolith; the bot's split moved it to `assets_routes.py` as a stub returning empty prices. Dropped the 501 enrichment here; can be a follow-up if you want the explicit `Not Implemented` body
2. **Önder's panel integration (#119)** — bot placed `EfficientFrontier` + `CorrelationMatrix` + `RigorExplainer` inside Reasoning's `StrategyDetailView`. Spine wanted `StrategyDetailView` gone. Resolved by moving panels to Library (where they're more discoverable next to the strategy table) and dropping the Reasoning detail view. Pure UX win — the panels are now visible to anyone browsing the library, not gated behind a Reasoning-page deep-link
3. **Önder's rigor columns (#119)** — preserved in `StrategyRow` (`sharpe_ci_95`, `drift_detected`) alongside spine's `useRef` highlight-scroll

## Test plan

- [x] Backend service tests: `pytest -q backend/tests/services/` → 122 passed
- [x] Backend full suite: `pytest -q backend/tests/` → 343 passed, 2 pre-existing Redis flakes (known + documented in CLAUDE.md)
- [x] FastAPI app loads, 73 routes resolved
- [ ] UI smoke (local docker): Generate streaming works, mode toggle visible, Explore page loads with asset data, Library row expansion shows rigor metrics with "?" affordance, EF + CM panels render at bottom of Library, Reasoning page shows only traces with "→ Strategy in Library" button
- [ ] Verify `?highlight=<strategy_id>` deep-link from a trace card lands on the right row in Library and scrolls into view

## What's deferred (out of scope for this PR)

- Phase 4 (vaults + trade windows) — waits on Marten/Chuan alignment
- Phase 5 (on-chain agent + USDC-as-gas demo) — waits on Chuan
- KB pipeline production body (`KB_PIPELINE_ENABLED=true` path) — waits on Dan's Linus-side iteration stabilizing
- 501-instead-of-empty-stub for `/api/assets/{symbol}/history` — small follow-up after Phase 7.5 dust settles

🤖 Generated with [Claude Code](https://claude.com/claude-code)