### PR TITLE
[spine] Phase 8: Landing polish + Corpus Catalog table + RegimePanel dedup

### DIFF
--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -45,6 +45,7 @@ async def list_papers(
             {
                 "arxiv_id": r.arxiv_id,
                 "title": r.title,
+                "authors": json.loads(r.authors) if r.authors else [],
                 "primary_category": r.primary_category,
                 "category_label": _category_label(r.primary_category),
                 "categories": json.loads(r.categories) if r.categories else [],
@@ -61,6 +62,7 @@ async def list_papers(
             {
                 "arxiv_id": p.arxiv_id,
                 "title": p.title,
+                "authors": list(getattr(p, "authors", []) or []),
                 "primary_category": p.primary_category,
                 "category_label": _category_label(p.primary_category),
                 "categories": list(p.categories),

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -135,7 +135,6 @@ export default function App() {
 
   const renderPage = () => {
     switch (page) {
-      case 'landing':      return <Landing onNavigate={navigateToPage} onConnect={() => {/* topbar handles modal */}} walletAddr={walletAddr} />
       case 'explore':      return <Explore onNavigate={navigateToPage} />
       case 'generate':     return <Generate onNavigate={navigateToPage} />
       case 'library':      return <Strategies highlightStrategyId={highlightStrategyId} />
@@ -144,14 +143,19 @@ export default function App() {
       case 'reasoning':    return <Reasoning onNavigate={navigateToPage} />
       case 'learnings':    return <Learnings onNavigate={navigateToPage} />
       case 'vault-detail': return <VaultDetail address={selectedVault} onBack={backToPortfolio} />
-      default:             return <Landing onNavigate={navigateToPage} onConnect={() => {}} walletAddr={walletAddr} />
+      default:             return <NotFound page={page} onNavigate={navigateToPage} />
     }
   }
 
   if (page === 'landing') {
     return (
       <>
-        <Landing onNavigate={navigateToPage} onConnect={handleConnect} walletAddr={walletAddr} />
+        <Landing
+          onNavigate={navigateToPage}
+          onConnect={handleConnect}
+          onDisconnect={handleDisconnect}
+          walletAddr={walletAddr}
+        />
         <OnboardingTour open={tourOpen} onClose={() => setTourOpen(false)} setPage={navigateToPage} />
       </>
     )
@@ -171,5 +175,22 @@ export default function App() {
       </Layout>
       <OnboardingTour open={tourOpen} onClose={() => setTourOpen(false)} setPage={navigateToPage} />
     </>
+  )
+}
+
+function NotFound({ page, onNavigate }) {
+  return (
+    <div className="max-w-[640px]">
+      <h2 className="font-serif text-[2rem] mb-3">Page not found</h2>
+      <p className="body mb-4">
+        We don't have a page at <code>{String(page)}</code>. The spine has six destinations:
+        Explore, Generate, Library, Corpus, Portfolio, and Reasoning. Use the sidebar
+        on the left, or jump back to the landing page.
+      </p>
+      <div className="flex gap-3">
+        <button className="btn-primary" onClick={() => onNavigate('landing')}>← Home</button>
+        <button className="btn-secondary" onClick={() => onNavigate('generate')}>Generate a Strategy</button>
+      </div>
+    </div>
   )
 }

--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -267,6 +267,18 @@ function OverviewTab({ overview }) {
   )
 }
 
+function formatAuthors(authors) {
+  if (!Array.isArray(authors) || authors.length === 0) return '—'
+  if (authors.length === 1) return authors[0]
+  if (authors.length === 2) return `${authors[0]} & ${authors[1]}`
+  return `${authors[0]}, ${authors[1]} et al.`
+}
+
+function truncate(s, n) {
+  if (!s) return ''
+  return s.length > n ? `${s.slice(0, n)}…` : s
+}
+
 function CatalogTab({ papers, total, page, loading, search, setSearch, categoryFilter, setCategoryFilter, setPage, openPaper, categories }) {
   const totalPages = Math.ceil(total / 20)
   return (
@@ -288,31 +300,51 @@ function CatalogTab({ papers, total, page, loading, search, setSearch, categoryF
       {loading ? <div className="corpus-loading">Loading...</div> : (
         <>
           <div className="catalog-results-info">{total.toLocaleString()} papers found</div>
-          <div className="paper-list">
-            {papers.map(p => (
-              <div key={p.arxiv_id} className="paper-card" onClick={() => openPaper(p.arxiv_id)}>
-                <div className="paper-title">{p.title || p.arxiv_id}</div>
-                <div className="paper-meta">
-                  <span className="paper-id">{p.arxiv_id}</span>
-                  {p.primary_category && (
-                    <span
-                      className="paper-cat"
-                      title={p.category_label ? `${p.primary_category} — ${p.category_label}` : p.primary_category}
-                    >
-                      {p.category_label || p.primary_category}
-                    </span>
-                  )}
-                  {p.published && <span className="paper-year">{p.published?.slice(0, 4)}</span>}
-                  {p.cluster_id && <span className="paper-cluster">Cluster: {p.cluster_id}</span>}
-                </div>
-                <div className="paper-abstract">{(p.abstract || '').slice(0, 200)}{(p.abstract || '').length > 200 ? '...' : ''}</div>
-                {p.citing_strategies?.length > 0 && (
-                  <div className="paper-strategies">
-                    Used by {p.citing_strategies.length} strateg{p.citing_strategies.length === 1 ? 'y' : 'ies'}
-                  </div>
-                )}
-              </div>
-            ))}
+          <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
+            <table className="lib-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+              <thead>
+                <tr style={{ background: 'rgba(255,255,255,0.03)', textAlign: 'left', borderBottom: '1px solid var(--glass-border)' }}>
+                  <th style={{ padding: '10px 14px', whiteSpace: 'nowrap' }}>arxiv ID</th>
+                  <th style={{ padding: '10px 14px' }}>Authors</th>
+                  <th style={{ padding: '10px 14px', textAlign: 'right', whiteSpace: 'nowrap' }}>Year</th>
+                  <th style={{ padding: '10px 14px' }}>Title</th>
+                  <th style={{ padding: '10px 14px', whiteSpace: 'nowrap' }}>Category</th>
+                </tr>
+              </thead>
+              <tbody>
+                {papers.map(p => (
+                  <tr
+                    key={p.arxiv_id}
+                    onClick={() => openPaper(p.arxiv_id)}
+                    style={{ borderBottom: '1px solid var(--glass-border)', cursor: 'pointer' }}
+                    className="hover:bg-[rgba(255,255,255,0.03)]"
+                  >
+                    <td style={{ padding: '8px 14px', fontFamily: 'var(--mono, monospace)', color: 'var(--text-3)', whiteSpace: 'nowrap' }}>
+                      {p.arxiv_id}
+                    </td>
+                    <td style={{ padding: '8px 14px', color: 'var(--text-2)' }} title={Array.isArray(p.authors) ? p.authors.join(', ') : ''}>
+                      {formatAuthors(p.authors)}
+                    </td>
+                    <td style={{ padding: '8px 14px', textAlign: 'right', fontFamily: 'var(--mono, monospace)', color: 'var(--text-3)', whiteSpace: 'nowrap' }}>
+                      {p.published ? p.published.slice(0, 4) : '—'}
+                    </td>
+                    <td style={{ padding: '8px 14px', color: 'var(--text-1)' }} title={p.title || p.arxiv_id}>
+                      {truncate(p.title || p.arxiv_id, 80)}
+                    </td>
+                    <td style={{ padding: '8px 14px', whiteSpace: 'nowrap' }}>
+                      {p.primary_category && (
+                        <span
+                          className="tag tag-muted"
+                          title={p.category_label ? `${p.primary_category} — ${p.category_label}` : p.primary_category}
+                        >
+                          {p.category_label || p.primary_category}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
           {totalPages > 1 && (
             <div className="catalog-pagination">

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { StrategyArchitect } from './Strategies'
-import RegimePanel from './RegimePanel'
 import GenerationStream from './GenerationStream'
 import GenerationStatus from './GenerationStatus'
 
@@ -96,11 +95,6 @@ export default function Generate({ onNavigate }) {
         <p className="body text-[var(--text-3)]">
           No wallet required to generate. Wallet is only needed to deposit into a vault.
         </p>
-      </div>
-
-      {/* Compact regime strip */}
-      <div className="mb-4 fade-up fade-up-2" style={{ fontSize: '0.88rem' }}>
-        <RegimePanel />
       </div>
 
       {/* Mode toggle */}

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import WalletConnect from './WalletConnect'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -10,7 +11,7 @@ async function apiGet(path) {
   } catch { return null }
 }
 
-export default function Landing({ onNavigate, onConnect, walletAddr }) {
+export default function Landing({ onNavigate, onConnect, onDisconnect, walletAddr }) {
   const [stats, setStats]           = useState(null)
   const [agentStatus, setAgentStatus] = useState(null)
   const [regime, setRegime]         = useState(null)
@@ -48,60 +49,63 @@ export default function Landing({ onNavigate, onConnect, walletAddr }) {
         <div className="flex items-center gap-3">
           <button
             className="btn-secondary !py-2 !px-4 !text-sm"
-            onClick={() => onNavigate('strategies')}
+            onClick={() => onNavigate('library')}
           >
             Strategies
           </button>
           {walletAddr ? (
-            <button className="btn-primary !py-2 !px-4 !text-sm" onClick={() => onNavigate('dashboard')}>
+            <button className="btn-primary !py-2 !px-4 !text-sm" onClick={() => onNavigate('portfolio')}>
               Dashboard →
             </button>
           ) : (
-            <button className="btn-primary !py-2 !px-4 !text-sm" onClick={onConnect}>
-              Connect Wallet
-            </button>
+            <WalletConnect address={walletAddr} onConnect={onConnect} onDisconnect={onDisconnect} />
           )}
         </div>
       </header>
 
       {/* ── Hero ─────────────────────────────────────────────────── */}
-      <section className="pt-28 pb-16 px-4 text-center border-b border-[var(--glass-border)] bg-[var(--canvas)] sm:px-6 sm:pt-32 sm:pb-20 lg:px-12 lg:pt-36 lg:pb-24">
+      <section className="pt-28 pb-16 px-4 text-center border-b border-[var(--glass-border)] bg-[var(--canvas)] sm:px-6 sm:pt-32 sm:pb-20 lg:px-12 lg:pt-40 lg:pb-28">
         <div className="max-w-[760px] mx-auto">
           <span style={{
             display: 'inline-block',
             fontSize: '0.7rem',
             fontWeight: 600,
             textTransform: 'uppercase',
-            letterSpacing: '0.1em',
-            color: '#D4A853',
-            border: '1px solid #D4A853',
+            letterSpacing: '0.12em',
+            color: 'var(--accent)',
+            border: '1px solid var(--accent)',
             borderRadius: '9999px',
             padding: '4px 16px',
-            marginBottom: '24px',
-            opacity: 0.9,
+            marginBottom: '28px',
+            opacity: 0.85,
           }}>
             Agora Agents Hackathon 2026
           </span>
-          <h1 className="font-serif text-[2rem] font-normal leading-[1.15] mb-5 text-[var(--text-1)] sm:text-[2.6rem] lg:text-[3.2rem]">
+          <p className="font-serif italic text-[1rem] text-[var(--text-3)] mb-4 md:text-[1.1rem]">
+            Linus for quantitative finance.
+          </p>
+          <h1 className="font-serif text-[2.1rem] font-normal leading-[1.1] mb-6 text-[var(--text-1)] sm:text-[2.8rem] lg:text-[3.4rem]">
             <span className="text-[var(--accent)]">Paper-Grounded.</span><br />
             On-Chain Verifiable.<br />
             <span className="text-[var(--text-3)]">Autonomously Managed.</span>
           </h1>
-          <p className="text-[0.95rem] leading-[1.7] text-[var(--text-2)] max-w-[600px] mx-auto mb-8 md:text-[1.05rem]">
-            Archimedes turns published quant research into investable strategies.
-            It constructs personalized portfolios of synthetic RWA tokens on Arc
-            — with every decision hashed and verifiable on-chain.
+          <p className="text-[0.98rem] leading-[1.75] text-[var(--text-2)] max-w-[620px] mx-auto mb-10 md:text-[1.08rem]">
+            Archimedes turns peer-reviewed quant research into rigor-gated, investable
+            strategies — generated for your brief, executed in non-custodial vaults
+            on Arc, with every decision hashed and verifiable on-chain.
           </p>
           <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:justify-center sm:items-center">
-     <button className="btn-primary" onClick={() => onNavigate('generate')}>
+            <button className="btn-primary" onClick={() => onNavigate('generate')}>
               Generate a Strategy →
             </button>
             <button className="btn-secondary" onClick={() => onNavigate('library')}>
               Browse Example Library
             </button>
           </div>
+          <p className="caption mt-5 text-[var(--text-4)]">
+            No wallet needed to generate. Wallet only required to deposit into a vault.
+          </p>
         </div>
-      <div/>
       </section>
 
       {/* ── Live status bar ──────────────────────────────────────── */}
@@ -248,16 +252,17 @@ export default function Landing({ onNavigate, onConnect, walletAddr }) {
           The fulcrum is autonomous AI.<br />
           The world is your portfolio.
         </p>
-        <div className="hero-actions">
+        <div className="hero-actions flex justify-center items-center gap-3">
           {walletAddr ? (
-            <button className="btn-primary" onClick={() => onNavigate('trade')}>
-              Start Trading →
+            <button className="btn-primary" onClick={() => onNavigate('portfolio')}>
+              Open Portfolio →
             </button>
           ) : (
-            <button className="btn-primary" onClick={onConnect}>
-              Connect Wallet
-            </button>
+            <WalletConnect address={walletAddr} onConnect={onConnect} onDisconnect={onDisconnect} />
           )}
+          <button className="btn-secondary" onClick={() => onNavigate('generate')}>
+            Generate a Strategy →
+          </button>
         </div>
         <p className="text-xs text-[var(--text-4)]">
           Powered by{' '}

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -214,11 +214,16 @@ export default function OnboardingTour({ open, onClose, setPage }) {
   const handleCta = useCallback(() => {
     if (card.cta.target) {
       setPage(card.cta.target)
-      finish()
+      // Advance the tour rather than closing it — the user can see the destination
+      // page behind the modal and still finish the walkthrough. Closing on CTA
+      // strands users (especially on Landing, where there's no topbar "?" to
+      // reopen the tour).
+      if (isLast) finish()
+      else setCardIndex(i => i + 1)
     } else {
       handleContinue()
     }
-  }, [card, setPage, finish, handleContinue])
+  }, [card, setPage, isLast, finish, handleContinue])
 
   // Keyboard support — Esc closes, ArrowRight advances, ArrowLeft goes back.
   useEffect(() => {
@@ -237,7 +242,7 @@ export default function OnboardingTour({ open, onClose, setPage }) {
   return createPortal(
     <div
       className="fixed inset-0 flex items-center justify-center z-[1000]"
-      style={{ background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(2px)' }}
+      style={{ background: 'rgba(0,0,0,0.82)', backdropFilter: 'blur(8px)' }}
       onClick={finish}
       role="dialog"
       aria-modal="true"
@@ -246,6 +251,7 @@ export default function OnboardingTour({ open, onClose, setPage }) {
       <div
         className="card-elevated p-6 max-w-[460px] w-[90vw]"
         onClick={e => e.stopPropagation()}
+        style={{ background: 'var(--surface-1)', opacity: 1 }}
       >
         <div className="caption mb-2 text-[var(--text-4)] uppercase tracking-wider">
           Welcome · {cardIndex + 1} of {CARDS.length}

--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -30,7 +30,6 @@ function shortAddr(a) {
 export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) {
   const [userVaults, setUserVaults] = useState([])
   const [agentStatus, setAgentStatus] = useState(null)
-  const [regime, setRegime] = useState(null)
   const [recentTraces, setRecentTraces] = useState([])
   const [tracesLoading, setTracesLoading] = useState(false)
   const [vaultsLoading, setVaultsLoading] = useState(false)
@@ -67,10 +66,7 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
       const r = await fetch(`${API_BASE}/api/agent/status`)
       if (r.ok) setAgentStatus(await r.json())
     } catch {}
-    try {
-      const r = await fetch(`${API_BASE}/api/regime/current`)
-      if (r.ok) setRegime(await r.json())
-    } catch {}
+    // Regime is loaded + rendered by <RegimePanel /> above, not duplicated here.
   }, [])
 
   const loadTraces = useCallback(async () => {
@@ -115,8 +111,9 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
       {/* Regime sidebar — top of portfolio page */}
       <RegimePanel />
 
-      {/* Status strip — agent + regime are real (Redis-backed) regardless of wallet */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      {/* Status strip — agent state is Redis-backed (regardless of wallet); regime
+          lives in the RegimePanel block above to avoid duplication. */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
         <div className="card-flat p-4">
           <div className="label mb-2">Your Vaults</div>
           <div className="text-[1.8rem] font-bold">{walletAddr ? userVaults.length : '—'}</div>
@@ -139,15 +136,6 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
           </div>
           <div className="caption mt-1.5">
             Last heartbeat: {agentStatus?.last_heartbeat ? timeAgo(agentStatus.last_heartbeat) : '—'}
-          </div>
-        </div>
-        <div className="card-flat p-4">
-          <div className="label mb-2">Market Regime</div>
-          <div className="text-[1.4rem] font-bold capitalize">
-            {regime?.regime?.replace('_', ' ') || '—'}
-          </div>
-          <div className="caption mt-1.5">
-            {regime?.confidence != null ? `${(regime.confidence * 100).toFixed(0)}% confidence` : 'no data'}
           </div>
         </div>
       </div>
@@ -236,8 +224,10 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
                   {t.vault_address && <span>vault {shortAddr(t.vault_address)}</span>}
                   {t.trace_hash && <span className="mono">{t.trace_hash.slice(0, 10)}…</span>}
                   {t.is_verified
-                    ? <span className="flex items-center gap-1 text-[var(--positive)]"><span className="i-lucide-check-circle w-3.5 h-3.5" /> anchored</span>
-                    : <span>off-chain only</span>
+                    ? <span className="flex items-center gap-1 text-[var(--positive)]"><span className="i-lucide-check-circle w-3.5 h-3.5" /> anchored on Arc</span>
+                    : <span className="flex items-center gap-1 text-[var(--text-3)]" title="Trace hashed + persisted off-chain; on-chain anchor pending (registry write didn't complete yet — usually transient).">
+                        <span className="i-lucide-clock w-3.5 h-3.5" /> anchor pending
+                      </span>
                   }
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Demo-blocking UX fixes + polish per [`docs/specs/phase8-9-landing-and-fusion-spec.md`](docs/specs/phase8-9-landing-and-fusion-spec.md). Generated overnight via scheduled CronCreate while Dan slept.

## Scope

**Landing.jsx + App.jsx — bug fixes:**
- CTA page IDs corrected: `'strategies'` → `'library'`, `'dashboard'` → `'portfolio'`, `'trade'` → `'portfolio'` (previously fell through to App.jsx's `renderPage` default which re-rendered Landing inside Layout — the "side panel opens unexpectedly" bug).
- Connect Wallet buttons on Landing replaced with embedded `<WalletConnect />` so the modal-open flow actually fires (previously the buttons called the state setter `onConnect` with no args, which did nothing visible).
- `App.jsx` `renderPage` default no longer renders Landing-inside-Layout for unknown page IDs — small honest 404 component now, with recovery CTAs back home / to Generate.
- `onDisconnect` threaded from App.jsx to Landing so the wallet chip's disconnect-on-click works from the Landing header.

**Landing polish:**
- Tightened hero copy with the [`docs/user-stories.md`](docs/user-stories.md) "Linus for quantitative finance" framing as a serif italic subtitle.
- Single accent color on the badge (was hardcoded gold, now uses `var(--accent)`).
- Honest caption below the hero CTA strip clarifying wallet-only-for-deposit.

**Generate.jsx + Portfolio.jsx — RegimePanel dedup (3× → 1×):**
- Dropped from Generate (page-roles-spec: Generate owns intent→result, not market context).
- Dropped the bare Market Regime stat-card from Portfolio's 4-card status strip — the rich `<RegimePanel />` above already shows regime/confidence/narrative/signals. 4-card → 3-card grid.
- Cleaned up the now-unused `regime` state + fetch in Portfolio.

**OnboardingTour.jsx:**
- Overlay opacity 0.55 → 0.82, blur 2px → 8px, solid card background. Cards readable over animating content.
- CTA ("Open Corpus", "Open Generate", etc.) **advances** the card index instead of closing the tour. User sees the destination page behind the modal and still finishes the walkthrough. Skip/Esc/Done close as before.

**CorpusExplorer.jsx — Catalog cards → table:**
- Converted from chunky `paper-card` list to dense `<table>` using the `StrategyTable` precedent (lib-table class, same framing).
- Columns: arxiv ID · Authors · Year · Title · Category (with hover tooltips for full author list, full title, raw arxiv code).
- Click row → existing `PaperDetail` view (unchanged).
- ~8× density gain (~40 rows visible per screen vs ~5 cards).

**papers_routes.py — small backend tweak:**
- `/api/papers/` list response now includes `authors` field (both DB and file-fallback paths). Required for the new Catalog table column.

**Phase 1 carve-out closed (side note):**
- Replaced the cosmetic `<span>off-chain only</span>` failure label at Portfolio.jsx:240 with `anchor pending` + tooltip explaining the registry-write transient state (was tracked in `spine-plus-v2-plan.md` as the only residual Phase 1 carve-out).

## Verify locally

```bash
# Backend tests
source /opt/homebrew/Caskroom/mambaforge/base/etc/profile.d/conda.sh && conda activate archimedes
pytest -q

# Frontend (docker — node/npm not required locally)
docker compose up -d --build nginx
# Then http://localhost — check:
#   1. Landing "Strategies" CTA → /library
#   2. Landing "Dashboard →" CTA (after wallet connect) → /portfolio
#   3. Landing "Connect Wallet" button → modal opens
#   4. Unknown URL (e.g. /foo) → 404 card, not Landing-in-Layout
#   5. Generate page has no regime strip
#   6. Portfolio page has 3 stat cards (Your Vaults / Total AUM / Agent), regime in rich panel above
#   7. /corpus Catalog tab renders a dense table, click row → detail
#   8. Onboarding card backgrounds opaque; "Open Corpus" CTA advances card index
```

Backend test snapshot from this branch:
- `pytest -q` → 361 passed, 2 skipped, 2 test-isolation flakes (Redis-related, same shape as the flakes documented in standup comment on issue #34; both pass in isolation).

## Open questions for review

- **Önder** — RegimePanel ended up at Portfolio only. If you'd rather it live elsewhere on the spine, easy revert.
- **Daniel R.** — the new Catalog table uses the StrategyTable pattern + lib-table class; happy to switch to a UnoCSS-native shape if you prefer.
- **All** — the 404 component is intentionally small + functional, not styled to match Landing's hero. Worth polishing if it becomes user-visible in the demo.

## Anti-goals respected

- No backend touched beyond the 2-line `authors` field add.
- No new pages, no new navigation entries.
- No refactor of `WalletConnect.jsx` internals.
- Phase 9 (Fusion UI surface) explicitly NOT bundled here — separate PR follows.

🤖 Generated overnight via scheduled CronCreate while Dan slept.