### PR TITLE
[spine] Phase 9: Fusion engine UI surface on Generate

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1905,6 +1905,11 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
   to { opacity: 1; }
 }
 
+@keyframes fusion-progress {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}
+
 .strategy-modal {
   background: var(--surface-1);
   border: 1px solid var(--glass-border);

--- a/ui/src/components/FusionResult.jsx
+++ b/ui/src/components/FusionResult.jsx
@@ -1,0 +1,189 @@
+// Renders the result of a fusion-mode generation job per
+// docs/specs/phase8-9-landing-and-fusion-spec.md § Phase 9.
+//
+// Two shapes to handle:
+//   1. Pre-backtest hypothesis — result has prose fields (thesis, fusion_reasoning,
+//      novelty_rationale, risk_notes) but no backtest / rigor. We render the prose
+//      and surface an honest "pre-backtest hypothesis" note.
+//   2. Backtested + rigor-gated — result also has backtest { sharpe_ratio, cagr, ... }
+//      and rigor { passing, dsr, dsr_p_value, pbo_score, oos_sharpe, look_ahead_clean }.
+//      We render metrics + verdict + deploy CTA (gated on rigor.passing).
+
+export default function FusionResult({ result, onNavigate }) {
+  if (!result) return null
+
+  const {
+    strategy_name,
+    thesis,
+    source_arxiv_ids = [],
+    fusion_reasoning,
+    novelty_rationale,
+    risk_notes,
+    backtest,
+    rigor,
+    strategy_id,
+    market_context_used,
+    message,        // present when status !== 'ok' (rejected / failed)
+    status,
+  } = result
+
+  const rejected = status && status !== 'ok' && !strategy_name
+  if (rejected) {
+    return (
+      <div className="card p-5 fade-up fade-up-2">
+        <div className="label mb-2 text-[var(--negative)]">Fusion rejected</div>
+        <p className="body">{message || 'The fusion engine did not produce an actionable strategy for this brief.'}</p>
+        <p className="caption mt-3">Try a different brief, broader asset classes, or a different risk profile.</p>
+      </div>
+    )
+  }
+
+  const hasBacktest = backtest && typeof backtest.sharpe_ratio === 'number'
+  const hasRigor = rigor && typeof rigor.passing === 'boolean'
+  const rigorPassing = hasRigor && rigor.passing === true
+
+  return (
+    <div className="fade-up fade-up-2 flex flex-col gap-4">
+      {/* Headline — strategy name + thesis */}
+      <div className="card p-5">
+        <div className="caption mb-1 uppercase tracking-wider text-[var(--text-4)]">Fusion proposal</div>
+        <h3 className="font-serif text-[1.4rem] mb-2 text-[var(--text-1)]">{strategy_name || '(unnamed)'}</h3>
+        {thesis && (
+          <p className="body leading-relaxed">{thesis}</p>
+        )}
+
+        {source_arxiv_ids.length > 0 && (
+          <div className="mt-4 flex gap-2 flex-wrap">
+            <span className="caption text-[var(--text-4)] mr-1">Source papers:</span>
+            {source_arxiv_ids.map(aid => (
+              <a
+                key={aid}
+                href={`https://arxiv.org/abs/${aid}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="tag tag-muted"
+                style={{ fontFamily: 'var(--mono, monospace)', fontSize: '0.75rem' }}
+                title={`arxiv.org/abs/${aid}`}
+              >
+                {aid}
+              </a>
+            ))}
+          </div>
+        )}
+
+        {market_context_used?.regime && (
+          <div className="caption mt-3 text-[var(--text-3)]">
+            Generated under regime: <strong className="capitalize">{String(market_context_used.regime).replace('_', ' ')}</strong>
+            {market_context_used.confidence != null && (
+              <> ({Math.round(market_context_used.confidence * 100)}% confidence)</>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Backtest metrics (when present) */}
+      {hasBacktest && (
+        <div className="card p-5">
+          <div className="label mb-3">Backtest</div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <Metric label="Sharpe" value={fmtNumber(backtest.sharpe_ratio, 2)} />
+            <Metric label="CAGR" value={fmtPct(backtest.cagr)} />
+            <Metric label="Max DD" value={fmtPct(backtest.max_drawdown)} />
+            <Metric label="Calmar" value={fmtNumber(backtest.calmar_ratio, 2)} />
+            <Metric label="Sortino" value={fmtNumber(backtest.sortino_ratio, 2)} />
+            <Metric label="Win rate" value={fmtPct(backtest.win_rate)} />
+            <Metric label="Trades" value={backtest.total_trades != null ? backtest.total_trades : '—'} />
+          </div>
+        </div>
+      )}
+
+      {/* Rigor verdict (when present) */}
+      {hasRigor && (
+        <div className="card p-5">
+          <div className="flex items-center justify-between flex-wrap gap-2 mb-3">
+            <div className="label">Rigor verdict</div>
+            <span className={`tag ${rigorPassing ? 'tag-positive' : 'tag-muted'}`}>
+              {rigorPassing ? '✓ rigor gate passed' : '✗ rigor gate failed'}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <Metric label="DSR" value={fmtNumber(rigor.dsr, 2)} hint={rigor.dsr_p_value != null ? `p = ${fmtNumber(rigor.dsr_p_value, 3)}` : null} />
+            <Metric label="PBO" value={fmtNumber(rigor.pbo_score, 2)} hint="lower = less overfit" />
+            <Metric label="OOS Sharpe" value={fmtNumber(rigor.oos_sharpe, 2)} />
+            <Metric label="Look-ahead" value={rigor.look_ahead_clean ? 'clean' : 'flagged'} />
+          </div>
+        </div>
+      )}
+
+      {/* Pre-backtest hypothesis honesty note (when no backtest) */}
+      {!hasBacktest && (
+        <div className="info-box">
+          <strong>Pre-backtest hypothesis.</strong>{' '}
+          Strategy specification was not produced or could not be evaluated.
+          Rerun for a backtested result, or inspect the reasoning below.
+        </div>
+      )}
+
+      {/* Fusion reasoning + novelty + risk — expandable cards */}
+      {fusion_reasoning && (
+        <details className="card p-5">
+          <summary className="label cursor-pointer">How it fuses</summary>
+          <p className="body mt-3 leading-relaxed">{fusion_reasoning}</p>
+        </details>
+      )}
+      {novelty_rationale && (
+        <details className="card p-5">
+          <summary className="label cursor-pointer">Why novel</summary>
+          <p className="body mt-3 leading-relaxed">{novelty_rationale}</p>
+        </details>
+      )}
+      {risk_notes && (
+        <details className="card p-5">
+          <summary className="label cursor-pointer">Risk notes</summary>
+          <p className="body mt-3 leading-relaxed">{risk_notes}</p>
+        </details>
+      )}
+
+      {/* CTAs — open in Library / Deploy (Phase 4) */}
+      <div className="flex gap-3 flex-wrap">
+        {strategy_id && onNavigate && (
+          <button
+            className="btn btn-outline"
+            onClick={() => onNavigate('library', { highlight: strategy_id })}
+          >
+            Open in Library →
+          </button>
+        )}
+        <button
+          className="btn btn-primary"
+          disabled
+          title={rigorPassing
+            ? 'Deploy as vault — coming in Phase 4 (time-bound vaults + on-chain agent)'
+            : 'Deploy disabled — strategy did not pass the rigor gate'}
+        >
+          Deploy as Vault — coming in Phase 4
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, hint }) {
+  return (
+    <div>
+      <div className="caption text-[var(--text-4)]">{label}</div>
+      <div className="text-[1.1rem] font-semibold tabular-nums">{value}</div>
+      {hint && <div className="caption text-[var(--text-4)]">{hint}</div>}
+    </div>
+  )
+}
+
+function fmtNumber(v, digits = 2) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return Number(v).toFixed(digits)
+}
+
+function fmtPct(v) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return `${(Number(v) * 100).toFixed(1)}%`
+}

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -1,16 +1,22 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { StrategyArchitect } from './Strategies'
 import GenerationStream from './GenerationStream'
 import GenerationStatus from './GenerationStatus'
+import FusionResult from './FusionResult'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
-// /generate spine page. Two paths today:
+// /generate spine page. Three paths:
 //   1. Streaming agent (default) — SSE-driven, per docs/specs/generation-streaming-spec.md
 //   2. Architect "fast preview" toggle — synchronous curated-library pick, kept
 //      around because it's instant and useful when you just want a quick sanity check.
+//   3. Fusion (novel) — multi-paper synthesis through strategy_fusion.py + the
+//      fusion_evaluator rigor gate. The wedge: paper-grounded novel hypotheses
+//      with externally verifiable DSR/PBO/OOS verdicts. Backend-complete since
+//      #133; Phase 9 adds the UI per docs/specs/phase8-9-landing-and-fusion-spec.md.
 
 const STORAGE_JOB_KEY = 'archimedes:currentJobId'
+const STORAGE_FUSION_JOB_KEY = 'archimedes:currentFusionJobId'
 const RISK_PROFILES = [
   { id: 'fixed_income', label: 'Fixed income' },
   { id: 'conservative', label: 'Conservative' },
@@ -18,9 +24,10 @@ const RISK_PROFILES = [
   { id: 'aggressive', label: 'Aggressive' },
   { id: 'hyper_risky', label: 'Hyper-risky' },
 ]
+const ASSET_CLASSES = ['equities', 'bonds', 'commodities', 'crypto', 'fx']
 
 export default function Generate({ onNavigate }) {
-  const [mode, setMode] = useState('agent')  // 'agent' | 'architect'
+  const [mode, setMode] = useState('agent')  // 'agent' | 'architect' | 'fusion'
   const [intent, setIntent] = useState('')
   const [riskAppetite, setRiskAppetite] = useState('moderate')
   const [nCandidates, setNCandidates] = useState(1)
@@ -32,6 +39,17 @@ export default function Generate({ onNavigate }) {
   const [strategies, setStrategies] = useState([])
   const [libLoading, setLibLoading] = useState(true)
   const [libError, setLibError] = useState('')
+
+  // Fusion path — form fields + job state (no SSE — simple GET poll every 2s).
+  const [fusionAssets, setFusionAssets] = useState(['equities'])
+  const [fusionDirection, setFusionDirection] = useState('')
+  const [fusionMaxPapers, setFusionMaxPapers] = useState(4)
+  const [fusionJobId, setFusionJobId] = useState(() => localStorage.getItem(STORAGE_FUSION_JOB_KEY) || null)
+  const [fusionStatus, setFusionStatus] = useState(null) // 'queued' | 'running' | 'done' | 'failed'
+  const [fusionResult, setFusionResult] = useState(null)
+  const [fusionError, setFusionError] = useState('')
+  const [fusionStarting, setFusionStarting] = useState(false)
+  const fusionPollRef = useRef(null)
 
   useEffect(() => {
     let cancelled = false
@@ -83,6 +101,99 @@ export default function Generate({ onNavigate }) {
     setJobId(null)
   }
 
+  // ── Fusion path ────────────────────────────────────────────────
+  const stopFusionPoll = () => {
+    if (fusionPollRef.current) {
+      clearInterval(fusionPollRef.current)
+      fusionPollRef.current = null
+    }
+  }
+
+  const pollFusion = async (id) => {
+    try {
+      const res = await fetch(`${API_BASE}/api/strategies/generate/${encodeURIComponent(id)}`)
+      if (!res.ok) {
+        // 404 = job lost; clear and surface honestly
+        if (res.status === 404) {
+          setFusionError('Fusion job not found — backend may have restarted.')
+          setFusionStatus('failed')
+          stopFusionPoll()
+          localStorage.removeItem(STORAGE_FUSION_JOB_KEY)
+        }
+        return
+      }
+      const data = await res.json()
+      setFusionStatus(data.status)
+      if (data.status === 'done') {
+        setFusionResult(data.result || null)
+        stopFusionPoll()
+        localStorage.removeItem(STORAGE_FUSION_JOB_KEY)
+      } else if (data.status === 'failed') {
+        setFusionError(data.error || 'Fusion job failed.')
+        stopFusionPoll()
+        localStorage.removeItem(STORAGE_FUSION_JOB_KEY)
+      }
+    } catch (e) {
+      // Network blip — keep polling silently
+    }
+  }
+
+  // Auto-poll while a fusion job is in flight (resumes across reloads via localStorage).
+  useEffect(() => {
+    if (!fusionJobId) {
+      stopFusionPoll()
+      return
+    }
+    pollFusion(fusionJobId)
+    fusionPollRef.current = setInterval(() => pollFusion(fusionJobId), 2000)
+    return stopFusionPoll
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fusionJobId])
+
+  const startFusionJob = async () => {
+    setFusionError('')
+    if (fusionAssets.length === 0) {
+      setFusionError('Pick at least one asset class to fuse.')
+      return
+    }
+    setFusionStarting(true)
+    setFusionResult(null)
+    setFusionStatus(null)
+    try {
+      const params = new URLSearchParams({
+        asset_classes: fusionAssets.join(','),
+        risk_appetite: riskAppetite,
+        strategic_direction: fusionDirection,
+        max_papers: String(fusionMaxPapers),
+        mode: 'fusion',
+      })
+      const res = await fetch(`${API_BASE}/api/strategies/generate?${params}`, { method: 'POST' })
+      if (!res.ok) throw new Error(await res.text())
+      const data = await res.json()
+      if (!data.job_id) throw new Error('Backend did not return a job_id')
+      localStorage.setItem(STORAGE_FUSION_JOB_KEY, data.job_id)
+      setFusionJobId(data.job_id)
+      setFusionStatus(data.status || 'queued')
+    } catch (e) {
+      setFusionError(e.message || 'Failed to start fusion job')
+    } finally {
+      setFusionStarting(false)
+    }
+  }
+
+  const resetFusion = () => {
+    stopFusionPoll()
+    localStorage.removeItem(STORAGE_FUSION_JOB_KEY)
+    setFusionJobId(null)
+    setFusionStatus(null)
+    setFusionResult(null)
+    setFusionError('')
+  }
+
+  const toggleAsset = (a) => {
+    setFusionAssets(prev => prev.includes(a) ? prev.filter(x => x !== a) : [...prev, a])
+  }
+
   return (
     <div>
       <div className="fade-up fade-up-1 max-w-[720px] mb-7">
@@ -112,6 +223,13 @@ export default function Generate({ onNavigate }) {
           title="Skip the fusion engine and let the architect pick from the curated library — faster but less novel"
         >
           ⚡ Architect (fast preview)
+        </span>
+        <span
+          className={`tag ${mode === 'fusion' ? 'tag-accent' : 'tag-muted'} cursor-pointer`}
+          onClick={() => setMode('fusion')}
+          title="Multi-paper synthesis through the fusion engine — novel hypotheses, rigor-gated"
+        >
+          🧪 Fusion (novel)
         </span>
       </div>
 
@@ -199,6 +317,130 @@ export default function Generate({ onNavigate }) {
             </div>
           )}
           {!libLoading && !libError && <StrategyArchitect strategies={strategies} />}
+        </div>
+      )}
+
+      {mode === 'fusion' && (
+        <div className="fade-up fade-up-2">
+          <div className="info-box mb-4">
+            <strong>Fusion path</strong> — multi-paper synthesis through the fusion engine.
+            The agent picks N papers from the corpus, fuses their methodologies into a
+            novel hypothesis, runs a backtest, and gates the result through DSR / PBO /
+            walk-forward OOS / look-ahead audit. Slowest path (~30–90s) but the only
+            one that produces genuinely novel strategies.
+          </div>
+
+          {!fusionJobId && !fusionResult && (
+            <div className="card p-5 mb-4">
+              <div className="label mb-3">Asset classes (pick at least one)</div>
+              <div className="flex gap-2 flex-wrap mb-4">
+                {ASSET_CLASSES.map(a => (
+                  <span
+                    key={a}
+                    className={`tag ${fusionAssets.includes(a) ? 'tag-accent' : 'tag-muted'} cursor-pointer capitalize`}
+                    onClick={() => toggleAsset(a)}
+                  >
+                    {a}
+                  </span>
+                ))}
+              </div>
+
+              <div className="label mb-2">Strategic direction (optional)</div>
+              <textarea
+                value={fusionDirection}
+                onChange={e => setFusionDirection(e.target.value)}
+                placeholder="e.g. Combine momentum signals with vol-of-vol; we want crypto exposure on Fridays"
+                rows={3}
+                className="chat-input w-full mb-3 p-2.5 leading-relaxed"
+                disabled={fusionStarting}
+              />
+
+              <div className="flex gap-3 items-center flex-wrap">
+                <label className="caption flex items-center gap-1.5">
+                  Risk
+                  <select
+                    value={riskAppetite}
+                    onChange={e => setRiskAppetite(e.target.value)}
+                    className="chat-input w-auto px-2 py-1"
+                    disabled={fusionStarting}
+                  >
+                    {RISK_PROFILES.map(r => (
+                      <option key={r.id} value={r.id}>{r.label}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="caption flex items-center gap-1.5">
+                  Max papers
+                  <select
+                    value={fusionMaxPapers}
+                    onChange={e => setFusionMaxPapers(Number(e.target.value))}
+                    className="chat-input w-auto px-2 py-1"
+                    disabled={fusionStarting}
+                    title="Number of papers the fusion engine will combine"
+                  >
+                    {[2, 3, 4, 5, 6].map(n => <option key={n} value={n}>{n}</option>)}
+                  </select>
+                </label>
+                <button
+                  className="btn btn-primary ml-auto"
+                  onClick={startFusionJob}
+                  disabled={fusionStarting || fusionAssets.length === 0}
+                >
+                  {fusionStarting ? 'Starting…' : 'Fuse →'}
+                </button>
+              </div>
+
+              {fusionError && (
+                <div className="info-box warning mt-3">{fusionError}</div>
+              )}
+            </div>
+          )}
+
+          {fusionJobId && !fusionResult && (
+            <div className="card p-5 mb-4">
+              <div className="label mb-2">
+                Status: <span className="capitalize">{fusionStatus || 'queued'}</span>
+              </div>
+              <div className="caption mb-3">
+                Polling <code>/api/strategies/generate/{fusionJobId.slice(0, 8)}…</code> every 2s.
+                Fusion typically takes 30–90 seconds — the engine fetches papers, synthesizes a
+                methodology, runs a backtest, and computes selection-bias-corrected rigor.
+              </div>
+              <div className="flex gap-2">
+                <div
+                  className="h-1 flex-1 rounded"
+                  style={{
+                    background: 'var(--bg-2)',
+                    overflow: 'hidden',
+                    position: 'relative',
+                  }}
+                >
+                  <div
+                    style={{
+                      position: 'absolute',
+                      inset: 0,
+                      width: '30%',
+                      background: 'var(--accent)',
+                      animation: 'fusion-progress 1.6s ease-in-out infinite',
+                    }}
+                  />
+                </div>
+                <button className="btn btn-outline btn-sm" onClick={resetFusion}>Cancel</button>
+              </div>
+              {fusionError && <div className="info-box warning mt-3">{fusionError}</div>}
+            </div>
+          )}
+
+          {fusionResult && (
+            <>
+              <FusionResult result={fusionResult} onNavigate={onNavigate} />
+              <div className="mt-4">
+                <button className="btn btn-outline btn-sm" onClick={resetFusion}>
+                  Fuse another →
+                </button>
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Exposes the fusion engine — the wedge — through the UI as a third Generate mode alongside Streaming agent and Architect (fast preview). Backend has been complete since #133 (fusion_evaluator wired + rigor verdict persisted); this PR just makes it reachable for users and judges. Per [`docs/specs/phase8-9-landing-and-fusion-spec.md` § Phase 9](docs/specs/phase8-9-landing-and-fusion-spec.md).

Generated overnight via scheduled CronCreate while Dan slept.

## Scope

**`ui/src/components/Generate.jsx`** — extend the mode toggle with `🧪 Fusion (novel)`:
- New form: asset class chips (multi-select: equities / bonds / commodities / crypto / fx), free-text strategic direction, risk profile, max-papers (2-6).
- Submit fires `POST /api/strategies/generate?mode=fusion&asset_classes=...&risk_appetite=...&strategic_direction=...&max_papers=...`.
- In-flight tracker: status pill + animated progress bar + cancel.
- Polls `GET /api/strategies/generate/{job_id}` every 2s per spec (no SSE — fusion jobs are seconds-to-minutes, not per-iteration streaming).
- Job ID persists in `localStorage` so reload / navigate-away resumes the poll on remount.

**`ui/src/components/FusionResult.jsx` (NEW)** — renders the result body:
- Strategy name + thesis as the headline.
- Source-paper chips link to `arxiv.org/abs/{id}`.
- Backtest metrics card (Sharpe / CAGR / Max DD / Calmar / Sortino / Win rate / Trades) when `result.backtest` is present.
- Rigor verdict badge: green `tag-positive` when `rigor.passing === true`, muted otherwise; DSR / PBO / OOS Sharpe / Look-ahead-clean metrics below.
- "Pre-backtest hypothesis" honest fallback when `strategy_spec` is missing — surfaces prose fields with no fake metrics.
- Expandable cards for fusion reasoning, novelty rationale, risk notes.
- "Open in Library →" CTA (deep-link to `/library?highlight=strategy_id`).
- "Deploy as Vault — coming in Phase 4" intentionally disabled with honest tooltip (Phase 4/5 territory per spec).

**`ui/src/App.css`** — add `@keyframes fusion-progress` for the in-flight progress bar shimmer (single small keyframes block; no other CSS touched).

## Anti-goals respected

- No backend touched. `POST /api/strategies/generate?mode=fusion` and `fusion_evaluator.py` are already settled (per #128 / #133 / #136 / #138).
- No new mode names — the existing Streaming agent and Architect modes are unchanged.
- No deploy-flow implementation — the "Deploy as Vault" CTA stays disabled with honest "coming in Phase 4" copy.

## Verify locally

```bash
# Backend tests (Phase 9 is frontend-only; pytest should not change)
source /opt/homebrew/Caskroom/mambaforge/base/etc/profile.d/conda.sh && conda activate archimedes
pytest -q

# Frontend (docker)
docker compose up -d --build nginx
# Then http://localhost/generate — check:
#   1. Three tags visible in mode strip: Streaming agent · Architect (fast) · Fusion (novel)
#   2. Click "Fusion" — form appears with asset chips, direction box, risk + max-papers selects
#   3. Pick assets + click Fuse → — receives job_id, transitions to "queued"/"running"
#   4. Backend env must have ARCHIMEDES_FUSION_ENABLED=1; otherwise the POST returns 503 with
#      clear "Fusion is disabled" detail (surfaced honestly in the form's error box)
#   5. When job lands status=done, FusionResult renders:
#      - Headline + thesis + source-paper chips (linked to arxiv)
#      - Backtest card (Sharpe / CAGR / Max DD / etc.) when result.backtest present
#      - Rigor verdict badge + DSR / PBO / OOS Sharpe / Look-ahead-clean metrics
#      - Pre-backtest fallback note when strategy_spec missing
#   6. "Open in Library →" jumps to /library?highlight=<id>
#   7. Streaming agent + Architect modes unchanged (no regression)
```

Backend test snapshot from this branch: `pytest -q` → 361 passed, 2 skipped, same 2 pre-existing Redis-isolation flakes as Phase 8 PR #140 (both pass in isolation).

## Open questions for review

- **Asset-class options** (`['equities', 'bonds', 'commodities', 'crypto', 'fx']`) — picked to match what `strategy_fusion.py` will sanity-check. If you'd prefer a different set, easy swap.
- **Poll interval** is 2s; could tune up (3s) or down (1s). 2s is the spec recommendation.
- **Max-papers default = 4** matches the backend default; range 2-6 covers the reasonable space.
- **Deploy CTA copy**: currently "Deploy as Vault — coming in Phase 4" disabled. If you'd prefer to hide entirely until Phase 4 lands, easy change.

🤖 Generated overnight via scheduled CronCreate while Dan slept.