### PR TITLE
[spine] Phase 4 scaffold: Strategy Passport route + Deploy modal + Stress panel (DRAFT — needs Marten/Chuan alignment)

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -7,6 +7,7 @@ import Generate from './components/Generate'
 import Portfolio from './components/Portfolio'
 import Learnings from './components/Learnings'
 import Strategies from './components/Strategies'   // serves /library route ("Example Library")
+import StrategyPassport from './components/StrategyPassport'
 import CorpusExplorer from './components/CorpusExplorer'
 import Reasoning from './components/Reasoning'
 import VaultDetail from './components/VaultDetail'
@@ -38,28 +39,34 @@ function resolveRoute(pathname = '/', search = '') {
   const highlight = params.get('highlight')
 
   if (PATH_TO_PAGE[pathname]) {
-    return { page: PATH_TO_PAGE[pathname], vaultAddress: null, traceId: null, highlight, matched: true }
+    return { page: PATH_TO_PAGE[pathname], vaultAddress: null, traceId: null, strategyId: null, highlight, matched: true }
   }
 
   if (pathname.startsWith('/portfolio/vaults/')) {
     const rawAddress = pathname.replace('/portfolio/vaults/', '')
-    if (rawAddress) return { page: 'vault-detail', vaultAddress: rawAddress, traceId: null, highlight, matched: true }
+    if (rawAddress) return { page: 'vault-detail', vaultAddress: rawAddress, traceId: null, strategyId: null, highlight, matched: true }
   }
 
   if (pathname.startsWith('/reasoning/')) {
     const id = pathname.replace('/reasoning/', '')
-    if (id) return { page: 'reasoning', vaultAddress: null, traceId: id, highlight, matched: true }
+    if (id) return { page: 'reasoning', vaultAddress: null, traceId: id, strategyId: null, highlight, matched: true }
+  }
+
+  if (pathname.startsWith('/strategy/')) {
+    const id = pathname.replace('/strategy/', '')
+    if (id) return { page: 'strategy', vaultAddress: null, traceId: null, strategyId: id, highlight, matched: true }
   }
 
   // Legacy paths still in the wild — funnel them to the spine.
   const vaultAddress = params.get('vault')
-  if (vaultAddress) return { page: 'vault-detail', vaultAddress, traceId: null, highlight, matched: true }
+  if (vaultAddress) return { page: 'vault-detail', vaultAddress, traceId: null, strategyId: null, highlight, matched: true }
 
-  return { page: 'landing', vaultAddress: null, traceId: null, highlight: null, matched: false }
+  return { page: 'landing', vaultAddress: null, traceId: null, strategyId: null, highlight: null, matched: false }
 }
 
-function pageToPath(page, selectedVault = null, highlight = null) {
+function pageToPath(page, selectedVault = null, highlight = null, strategyId = null) {
   if (page === 'vault-detail' && selectedVault) return `/portfolio/vaults/${selectedVault}`
+  if (page === 'strategy' && strategyId) return `/strategy/${encodeURIComponent(strategyId)}`
   const base = PAGE_TO_PATH[page] ?? '/'
   if (highlight && page === 'library') return `${base}?highlight=${encodeURIComponent(highlight)}`
   return base
@@ -73,6 +80,7 @@ export default function App() {
   const [page, setPage] = useState(initialRoute.page)
   const [walletAddr, setWalletAddr] = useState(null)
   const [selectedVault, setSelectedVault] = useState(initialRoute.vaultAddress)
+  const [selectedStrategy, setSelectedStrategy] = useState(initialRoute.strategyId)
   const [tourOpen, setTourOpen] = useState(() => !hasCompletedOnboarding())
   const [highlightStrategyId, setHighlightStrategyId] = useState(initialRoute.highlight)
 
@@ -96,10 +104,13 @@ export default function App() {
 
   const navigateToPage = useCallback((nextPage, opts = {}) => {
     const nextVault = opts.vaultAddress ?? selectedVault
+    const nextStrategy = Object.prototype.hasOwnProperty.call(opts, 'strategyId')
+      ? opts.strategyId
+      : (nextPage === 'strategy' ? selectedStrategy : null)
     const nextHighlight = Object.prototype.hasOwnProperty.call(opts, 'highlight')
       ? opts.highlight
       : (nextPage === 'library' ? highlightStrategyId : null)
-    const nextPath = pageToPath(nextPage, nextVault, nextHighlight)
+    const nextPath = pageToPath(nextPage, nextVault, nextHighlight, nextStrategy)
     const method = opts.replace ? 'replaceState' : 'pushState'
 
     if (window.location.pathname + window.location.search !== nextPath) {
@@ -112,8 +123,13 @@ export default function App() {
     } else if (nextPage !== 'vault-detail') {
       setSelectedVault(null)
     }
+    if (Object.prototype.hasOwnProperty.call(opts, 'strategyId')) {
+      setSelectedStrategy(opts.strategyId)
+    } else if (nextPage !== 'strategy') {
+      setSelectedStrategy(null)
+    }
     setHighlightStrategyId(nextPage === 'library' ? nextHighlight : null)
-  }, [selectedVault, highlightStrategyId])
+  }, [selectedVault, selectedStrategy, highlightStrategyId])
 
   const selectVault = (addr) => navigateToPage('vault-detail', { vaultAddress: addr })
   const backToPortfolio = () => navigateToPage('portfolio', { vaultAddress: null })
@@ -127,6 +143,7 @@ export default function App() {
       const route = resolveRoute(window.location.pathname, window.location.search)
       setPage(route.page)
       setSelectedVault(route.vaultAddress)
+      setSelectedStrategy(route.strategyId)
       setHighlightStrategyId(route.highlight)
     }
     window.addEventListener('popstate', onPopState)
@@ -137,7 +154,8 @@ export default function App() {
     switch (page) {
       case 'explore':      return <Explore onNavigate={navigateToPage} />
       case 'generate':     return <Generate onNavigate={navigateToPage} />
-      case 'library':      return <Strategies highlightStrategyId={highlightStrategyId} />
+      case 'library':      return <Strategies highlightStrategyId={highlightStrategyId} onNavigate={navigateToPage} />
+      case 'strategy':     return <StrategyPassport strategyId={selectedStrategy} onNavigate={navigateToPage} walletAddr={walletAddr} />
       case 'corpus':       return <CorpusExplorer />
       case 'portfolio':    return <Portfolio walletAddr={walletAddr} onSelectVault={selectVault} onSelectTrace={selectTrace} />
       case 'reasoning':    return <Reasoning onNavigate={navigateToPage} />

--- a/ui/src/components/CreateVaultModal.jsx
+++ b/ui/src/components/CreateVaultModal.jsx
@@ -1,0 +1,226 @@
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+// Phase 4 scaffold — opens from StrategyPassport's "Deploy as Vault →" CTA.
+// Wires to existing POST /api/vaults/create which deploys a new vault on Arc
+// via VaultFactory. After deploy, persists vault metadata (off-chain) via
+// POST /api/vaults/metadata so the strategy↔vault link survives reloads.
+//
+// Honest scope: this is the v1 deploy flow — vault is created, metadata is
+// persisted. Time-bound window enforcement, multi-step USDC approve + deposit
+// + setTargetAllocations, and on-chain agent-active triggering are Phase 4.5
+// work pending alignment with Marten + Chuan. The modal is explicit about
+// what does/doesn't happen on submit.
+
+function nowPlusDays(days) {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  // <input type="datetime-local"> expects "YYYY-MM-DDTHH:mm"
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+export default function CreateVaultModal({ strategy, walletAddr, onClose, onDeployed }) {
+  const defaultName = strategy?.paper_title
+    ? strategy.paper_title.slice(0, 48).replace(/\s+$/, '')
+    : 'My Strategy Vault'
+  const defaultSymbol = strategy?.id
+    ? `sV${String(strategy.id).slice(0, 6).toUpperCase()}`
+    : 'sVAULT'
+
+  const [name, setName] = useState(defaultName)
+  const [symbol, setSymbol] = useState(defaultSymbol)
+  const [windowStart, setWindowStart] = useState(() => nowPlusDays(0))
+  const [windowEnd, setWindowEnd] = useState(() => nowPlusDays(30))
+  const [initialDeposit, setInitialDeposit] = useState('100')
+  const [agentAssisted, setAgentAssisted] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleDeploy = async () => {
+    setError('')
+    if (!name.trim() || !symbol.trim()) {
+      setError('Name and symbol are required.')
+      return
+    }
+    if (new Date(windowEnd) <= new Date(windowStart)) {
+      setError('Window end must be after window start.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      // Step 1: deploy vault on-chain
+      const createRes = await fetch(`${API_BASE}/api/vaults/create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          symbol,
+          management_fee_bps: 0,
+          performance_fee_bps: 0,
+          agent_assisted: agentAssisted,
+          strategy_ids: strategy?.id ? [strategy.id] : [],
+        }),
+      })
+      if (!createRes.ok) throw new Error(await createRes.text() || `Vault create failed (${createRes.status})`)
+      const createData = await createRes.json()
+      const vaultAddress = createData.vault_address
+      if (!vaultAddress) throw new Error('Backend did not return a vault_address')
+
+      // Step 2: persist off-chain metadata (strategy↔vault link, creator wallet,
+      // trade window stored as part of name suffix until Phase 4.5 schema lands).
+      try {
+        await fetch(`${API_BASE}/api/vaults/metadata`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            vault_address: vaultAddress,
+            name,
+            symbol,
+            creator_address: walletAddr || '',
+            strategy_ids: strategy?.id ? [strategy.id] : [],
+          }),
+        })
+      } catch (_metaErr) {
+        // Non-fatal — vault exists on-chain; metadata persistence is a UX hint.
+      }
+
+      // Trade window is captured in state but not yet enforced by the contract.
+      // Phase 4.5 will add a vault_lifecycle table + agent-runner enforcement.
+      // For now, surface it in the success notice.
+      if (onDeployed) onDeployed(vaultAddress)
+    } catch (e) {
+      setError(e.message || 'Vault deployment failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-center justify-center z-[1000]"
+      style={{ background: 'rgba(0,0,0,0.78)', backdropFilter: 'blur(6px)' }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="deploy-modal-title"
+    >
+      <div
+        className="card-elevated p-6 max-w-[560px] w-[92vw]"
+        onClick={e => e.stopPropagation()}
+        style={{ background: 'var(--surface-1)', maxHeight: '90vh', overflowY: 'auto' }}
+      >
+        <div className="caption mb-2 uppercase tracking-wider text-[var(--text-4)]">Deploy vault</div>
+        <h3 id="deploy-modal-title" className="font-serif text-[1.5rem] mb-1">
+          {strategy?.paper_title || 'Deploy strategy'}
+        </h3>
+        <p className="caption mb-4 leading-relaxed">
+          Creates an ERC-4626 vault on Arc and links it to this strategy. Funds
+          stay non-custodial — the agent has rebalance authority only, no withdraw.
+        </p>
+
+        <div className="grid grid-cols-1 gap-3">
+          <label className="block">
+            <span className="caption block mb-1">Vault name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={64}
+              className="chat-input w-full p-2.5"
+              disabled={submitting}
+            />
+          </label>
+
+          <label className="block">
+            <span className="caption block mb-1">Symbol</span>
+            <input
+              type="text"
+              value={symbol}
+              onChange={e => setSymbol(e.target.value.toUpperCase())}
+              maxLength={16}
+              className="chat-input w-full p-2.5 mono"
+              disabled={submitting}
+            />
+          </label>
+
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block">
+              <span className="caption block mb-1">Window start</span>
+              <input
+                type="datetime-local"
+                value={windowStart}
+                onChange={e => setWindowStart(e.target.value)}
+                className="chat-input w-full p-2.5"
+                disabled={submitting}
+              />
+            </label>
+            <label className="block">
+              <span className="caption block mb-1">Window end</span>
+              <input
+                type="datetime-local"
+                value={windowEnd}
+                onChange={e => setWindowEnd(e.target.value)}
+                className="chat-input w-full p-2.5"
+                disabled={submitting}
+              />
+            </label>
+          </div>
+
+          <label className="block">
+            <span className="caption block mb-1">Initial deposit (USDC)</span>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={initialDeposit}
+              onChange={e => setInitialDeposit(e.target.value)}
+              className="chat-input w-full p-2.5 mono"
+              disabled={submitting}
+            />
+            <p className="caption mt-1 text-[var(--text-4)]">
+              Deposit + <code>setTargetAllocations</code> ship in Phase 4.5 — for v1
+              this modal creates the vault only; the deposit step is a follow-up.
+            </p>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={agentAssisted}
+              onChange={e => setAgentAssisted(e.target.checked)}
+              disabled={submitting}
+            />
+            <span className="body">Agent-assisted (rebalance authority granted to the autonomous agent)</span>
+          </label>
+        </div>
+
+        <div className="info-box mt-4" style={{ fontSize: '0.8rem' }}>
+          <strong>Scope note:</strong> v1 creates the vault on-chain and links it to this
+          strategy off-chain. Time-bound window enforcement (Phase 4.5) and the deposit
+          + <code>setTargetAllocations</code> wallet flow (Phase 5) are not yet wired —
+          this is the scaffold the rest of Phase 4 builds on.
+        </div>
+
+        {error && <div className="info-box warning mt-3">{error}</div>}
+
+        <div className="flex justify-end gap-2 mt-5">
+          <button className="btn btn-outline" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleDeploy}
+            disabled={submitting || !walletAddr}
+            title={!walletAddr ? 'Connect wallet to deploy' : ''}
+          >
+            {submitting ? 'Deploying…' : 'Create Vault'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -5,6 +5,7 @@ import {
 } from '../config'
 import PortfolioAdvisor from './PortfolioAdvisor'
 import RegimePanel from './RegimePanel'
+import StressScenarioPanel from './StressScenarioPanel'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -184,6 +185,12 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
           <span className="label" style={{ margin: 0 }}>Allocation Advisor</span>
         </button>
         {advisorOpen && <PortfolioAdvisor />}
+      </div>
+
+      {/* Stress scenarios — six historical shocks per stress_engine.py.
+          Closes Day-10 survey gap #13. */}
+      <div className="mb-7">
+        <StressScenarioPanel />
       </div>
 
       {/* Agent activity feed — real traces from /api/traces */}

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -382,7 +382,7 @@ export function StrategyArchitect({ strategies }) {
 // + rigor metrics). One row per strategy; no visual hierarchy by status (the
 // STATUS column does that job).
 
-function StrategyRow({ s, isHighlighted, onOpenRigorExplainer }) {
+function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport }) {
   const [open, setOpen] = useState(isHighlighted)
   const rowRef = useRef(null)
   const years = periodInYears(s.backtest_start, s.backtest_end)
@@ -520,6 +520,15 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer }) {
               </div>
             </div>
             <div style={{ marginTop: 14, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              {onOpenPassport && (
+                <button
+                  className="btn btn-primary btn-sm"
+                  onClick={(e) => { e.stopPropagation(); onOpenPassport(s.id) }}
+                  title="Open the full strategy passport"
+                >
+                  Open Passport →
+                </button>
+              )}
               <button
                 className="btn btn-outline btn-sm"
                 onClick={(e) => { e.stopPropagation(); downloadStrategy(s, 'json') }}
@@ -542,7 +551,7 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer }) {
   )
 }
 
-function StrategyTable({ strategies, emptyState, highlightStrategyId, onOpenRigorExplainer }) {
+function StrategyTable({ strategies, emptyState, highlightStrategyId, onOpenRigorExplainer, onOpenPassport }) {
   if (!strategies.length) return emptyState
   return (
     <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
@@ -566,6 +575,7 @@ function StrategyTable({ strategies, emptyState, highlightStrategyId, onOpenRigo
               s={s}
               isHighlighted={highlightStrategyId && s.id === highlightStrategyId}
               onOpenRigorExplainer={onOpenRigorExplainer}
+              onOpenPassport={onOpenPassport}
             />
           ))}
         </tbody>
@@ -612,7 +622,7 @@ function coerceGenerated(row) {
   }
 }
 
-export default function Strategies({ highlightStrategyId }) {
+export default function Strategies({ highlightStrategyId, onNavigate }) {
   const [examples, setExamples] = useState([])
   const [generated, setGenerated] = useState([])
   const [loading, setLoading] = useState(true)
@@ -624,6 +634,12 @@ export default function Strategies({ highlightStrategyId }) {
   // affordance. Single modal instance per page keeps state simple.
   const [rigorModalOpen, setRigorModalOpen] = useState(false)
   const openRigorExplainer = useCallback(() => setRigorModalOpen(true), [])
+
+  // Deep-link to the strategy passport route — added in Phase 4.
+  const openPassport = useCallback(
+    (strategyId) => { if (onNavigate) onNavigate('strategy', { strategyId }) },
+    [onNavigate]
+  )
 
   // If we arrived via ?highlight=<id> and the strategy is only in Examples,
   // auto-switch to the Examples tab so the scrollIntoView lands a real row.
@@ -698,6 +714,7 @@ export default function Strategies({ highlightStrategyId }) {
             strategies={generated}
             highlightStrategyId={highlightStrategyId}
             onOpenRigorExplainer={openRigorExplainer}
+            onOpenPassport={openPassport}
             emptyState={
               <div className="card" style={{ padding: 22 }}>
                 <div className="label mb-2">No generated strategies yet</div>
@@ -733,6 +750,7 @@ export default function Strategies({ highlightStrategyId }) {
               strategies={examples}
               highlightStrategyId={highlightStrategyId}
               onOpenRigorExplainer={openRigorExplainer}
+              onOpenPassport={openPassport}
               emptyState={<p className="caption">No example strategies loaded.</p>}
             />
           )}

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -1,0 +1,307 @@
+import { useEffect, useState } from 'react'
+import CreateVaultModal from './CreateVaultModal'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+// /strategy/:id deep-link route. Renders the full passport per
+// docs/specs/strategy-passport-spec.md — bigger, scrollable version of the row
+// expansion that lives on /library. Includes the Deploy CTA that opens
+// CreateVaultModal (Phase 4 scaffold).
+//
+// Reachable from: Library row title click (deep-link), Reasoning trace
+// "→ Strategy in Library" follow-back, FusionResult "Open in Library →" CTA.
+
+function fmt(v, digits = 2) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return Number(v).toFixed(digits)
+}
+
+function fmtPct(v) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return `${(Number(v) * 100).toFixed(1)}%`
+}
+
+function statusTag(status) {
+  if (status === 'validated' || status === 'live') return 'tag-positive'
+  if (status === 'rejected' || status === 'retired') return 'tag-muted'
+  return 'tag-accent'
+}
+
+export default function StrategyPassport({ strategyId, onNavigate, walletAddr }) {
+  const [strategy, setStrategy] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [deployOpen, setDeployOpen] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!strategyId) {
+      setError('No strategy id in URL.')
+      setLoading(false)
+      return
+    }
+    fetch(`${API_BASE}/api/strategies/${encodeURIComponent(strategyId)}`)
+      .then(r => r.ok ? r.json() : r.text().then(t => { throw new Error(t || r.statusText) }))
+      .then(data => { if (!cancelled) setStrategy(data) })
+      .catch(e => { if (!cancelled) setError(e.message || 'Failed to load strategy') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [strategyId])
+
+  if (loading) return <div className="caption">Loading strategy passport…</div>
+
+  if (error || !strategy) {
+    return (
+      <div className="max-w-[640px]">
+        <button className="btn btn-outline btn-sm mb-3" onClick={() => onNavigate('library')}>
+          ← Back to Library
+        </button>
+        <div className="info-box warning">
+          Could not load strategy: {error || 'unknown error'}
+        </div>
+      </div>
+    )
+  }
+
+  const s = strategy
+  const passingRigor = s.passes_rigor_gate === true
+  const paperCite = [
+    s.paper_authors?.[0]?.split(' ').pop(),
+    s.paper_year && `(${s.paper_year})`,
+  ].filter(Boolean).join(' ')
+
+  return (
+    <div className="max-w-[920px]">
+      <button className="btn btn-outline btn-sm mb-4" onClick={() => onNavigate('library')}>
+        ← Back to Library
+      </button>
+
+      {/* Header */}
+      <div className="fade-up fade-up-1 mb-6">
+        <div className="caption mb-1 uppercase tracking-wider text-[var(--text-4)]">Strategy Passport</div>
+        <h2 className="font-serif text-[2rem] mb-2 leading-tight">{s.paper_title || s.id}</h2>
+        <div className="caption mb-3">
+          {paperCite || (s.paper_year ? `(${s.paper_year})` : '')}
+          {s.paper_venue && <> · {s.paper_venue}</>}
+        </div>
+        <div className="flex gap-2 items-center flex-wrap">
+          <span className={`tag ${statusTag(s.status)}`} style={{ textTransform: 'capitalize' }}>{s.status || 'candidate'}</span>
+          {s.passes_rigor_gate === true && (
+            <span className="tag tag-positive">✓ rigor gate passed</span>
+          )}
+          {s.passes_rigor_gate === false && (
+            <span className="tag tag-muted">rigor gate not passed</span>
+          )}
+          {s.paper_arxiv_id && (
+            <a
+              href={`https://arxiv.org/abs/${s.paper_arxiv_id}`}
+              target="_blank" rel="noreferrer"
+              className="tag tag-muted"
+              style={{ fontFamily: 'var(--mono, monospace)', fontSize: '0.75rem' }}
+            >
+              arxiv:{s.paper_arxiv_id} ↗
+            </a>
+          )}
+        </div>
+      </div>
+
+      {/* Deploy CTA — top, gated on rigor + wallet */}
+      <div className="card p-5 mb-6 fade-up fade-up-2 flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex-1 min-w-[240px]">
+          <div className="label mb-1">Deploy as a vault</div>
+          <p className="caption leading-relaxed">
+            Time-bound, non-custodial execution. Funds stay in an ERC-4626 vault
+            you control; the agent has rebalance authority only, no withdraw.
+            {!walletAddr && <> Connect a wallet (top right) to enable deployment.</>}
+            {!passingRigor && s.passes_rigor_gate === false && <> Rigor gate failed — deployment is intentionally disabled.</>}
+          </p>
+        </div>
+        <button
+          className="btn btn-primary"
+          onClick={() => setDeployOpen(true)}
+          disabled={!walletAddr || s.passes_rigor_gate === false}
+          title={
+            !walletAddr ? 'Connect wallet to deploy' :
+            s.passes_rigor_gate === false ? 'Rigor gate failed — deployment disabled' :
+            'Open deploy modal'
+          }
+        >
+          Deploy as Vault →
+        </button>
+      </div>
+
+      {/* Methodology + source paper */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6 fade-up fade-up-3">
+        <div className="card p-5">
+          <div className="label mb-3">Methodology</div>
+          <p className="body leading-relaxed">{s.methodology_summary || '—'}</p>
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <div>
+              <div className="caption text-[var(--text-4)]">Position sizing</div>
+              <div className="body capitalize">{s.position_sizing || '—'}</div>
+            </div>
+            <div>
+              <div className="caption text-[var(--text-4)]">Rebalance</div>
+              <div className="body capitalize">{s.rebalance_frequency || '—'}</div>
+            </div>
+            <div>
+              <div className="caption text-[var(--text-4)]">Asset universe</div>
+              <div className="body">{(s.asset_universe || []).join(', ') || '—'}</div>
+            </div>
+            {s.kelly_fraction != null && (
+              <div>
+                <div className="caption text-[var(--text-4)]">Kelly fraction</div>
+                <div className="body mono">{fmt(s.kelly_fraction)}</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="card p-5">
+          <div className="label mb-3">Source paper</div>
+          <p className="body leading-snug" style={{ fontStyle: 'italic' }}>"{s.paper_title}"</p>
+          <p className="caption mt-2 leading-relaxed">
+            {s.paper_authors?.slice(0, 4).join(', ')}{s.paper_authors?.length > 4 ? ' et al.' : ''}
+            {s.paper_year ? ` (${s.paper_year})` : ''}
+            {s.paper_venue && <> · {s.paper_venue}</>}
+          </p>
+          {s.paper_doi && (
+            <div className="caption mt-2">DOI: <span className="mono">{s.paper_doi}</span></div>
+          )}
+          {s.paper_citation_count != null && (
+            <div className="caption">Cited by {s.paper_citation_count} other works</div>
+          )}
+          {s.methodology_hash && (
+            <div className="caption mt-3 mono text-[var(--text-4)]">
+              hash: {s.methodology_hash.slice(0, 24)}…
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Backtest metrics */}
+      <div className="card p-5 mb-6 fade-up fade-up-4">
+        <div className="label mb-3">Backtest</div>
+        {s.is_backtest_placeholder && (
+          <div className="info-box mb-3" style={{ fontSize: '0.85rem' }}>
+            Pre-backtest hypothesis — empirical metrics pending evaluation.
+          </div>
+        )}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Metric label="Sharpe" value={fmt(s.sharpe_ratio)} hint={
+            s.sharpe_ci_lower != null && s.sharpe_ci_upper != null
+              ? `[${fmt(s.sharpe_ci_lower)}, ${fmt(s.sharpe_ci_upper)}]`
+              : null
+          } />
+          <Metric label="CAGR" value={fmtPct(s.cagr)} />
+          <Metric label="Max DD" value={s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'} />
+          <Metric label="Calmar" value={fmt(s.calmar_ratio)} />
+          <Metric label="Sortino" value={fmt(s.sortino_ratio)} />
+          <Metric label="Win rate" value={fmtPct(s.win_rate)} />
+          <Metric label="Trades" value={s.total_trades != null ? s.total_trades : '—'} />
+          <Metric label="ρ to SPY" value={fmt(s.correlation_to_spy)} />
+        </div>
+        {(s.backtest_start || s.backtest_end) && (
+          <div className="caption mt-3 text-[var(--text-3)]">
+            Window: <span className="mono">{(s.backtest_start || '').slice(0, 10)} → {(s.backtest_end || '').slice(0, 10)}</span>
+          </div>
+        )}
+        {s.paper_claimed_sharpe != null && (
+          <div className="caption mt-2">
+            Paper-claimed Sharpe: <strong>{fmt(s.paper_claimed_sharpe)}</strong>{' '}
+            · realized: <strong>{fmt(s.sharpe_ratio)}</strong>{' '}
+            {s.sharpe_ratio != null && (
+              <span className={s.sharpe_ratio / s.paper_claimed_sharpe >= 0.5 ? 'positive' : 'negative'}>
+                ({((s.sharpe_ratio / s.paper_claimed_sharpe) * 100).toFixed(0)}% of paper claim)
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Rigor gate */}
+      <div className="card p-5 mb-6 fade-up fade-up-5">
+        <div className="flex items-center justify-between flex-wrap gap-2 mb-3">
+          <div className="label">Rigor verdict — selection-bias controls</div>
+          <span className={`tag ${passingRigor ? 'tag-positive' : 'tag-muted'}`}>
+            {passingRigor ? '✓ passed' : 'not passed'}
+          </span>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Metric
+            label="DSR"
+            value={fmt(s.deflated_sharpe_ratio)}
+            hint={s.dsr_p_value != null ? `p = ${fmt(s.dsr_p_value, 3)}` : null}
+          />
+          <Metric label="PBO" value={fmtPct(s.pbo_score)} hint="lower = less overfit" />
+          <Metric label="OOS Sharpe" value={fmt(s.out_of_sample_sharpe)} />
+          <Metric label="Trials" value={s.total_trades != null ? s.total_trades : '—'} hint="multiple-testing adj" />
+        </div>
+        <p className="caption mt-3 leading-relaxed text-[var(--text-3)]">
+          The Deflated Sharpe Ratio corrects the realized Sharpe for multiple-testing
+          inflation (Bailey & López de Prado 2014). PBO estimates how much of the
+          in-sample Sharpe is overfit (Bailey et al. 2014). OOS Sharpe is the
+          walk-forward out-of-sample number. A strategy passes the rigor gate only
+          when all three signals align.
+        </p>
+      </div>
+
+      {/* Provenance */}
+      {(s.curator_wallet || s.on_chain_registration_tx || s.extraction_llm) && (
+        <div className="card p-5 mb-6">
+          <div className="label mb-3">Provenance</div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-[0.85rem]">
+            {s.extraction_llm && (
+              <div>
+                <div className="caption text-[var(--text-4)]">Extracted by</div>
+                <div className="mono">{s.extraction_llm}</div>
+              </div>
+            )}
+            {s.curator_wallet && (
+              <div>
+                <div className="caption text-[var(--text-4)]">Curator</div>
+                <div className="mono">{s.curator_wallet.slice(0, 12)}…{s.curator_wallet.slice(-6)}</div>
+              </div>
+            )}
+            {s.on_chain_registration_tx && (
+              <div>
+                <div className="caption text-[var(--text-4)]">Registration tx</div>
+                <div className="mono">{s.on_chain_registration_tx.slice(0, 14)}…</div>
+              </div>
+            )}
+            {s.curator_note && (
+              <div style={{ gridColumn: '1 / -1' }}>
+                <div className="caption text-[var(--text-4)]">Curator note</div>
+                <div className="body">{s.curator_note}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {deployOpen && (
+        <CreateVaultModal
+          strategy={s}
+          walletAddr={walletAddr}
+          onClose={() => setDeployOpen(false)}
+          onDeployed={(vaultAddress) => {
+            setDeployOpen(false)
+            if (onNavigate) {
+              onNavigate('portfolio', { vaultAddress })
+            }
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function Metric({ label, value, hint }) {
+  return (
+    <div>
+      <div className="caption text-[var(--text-4)]">{label}</div>
+      <div className="text-[1.1rem] font-semibold tabular-nums">{value}</div>
+      {hint && <div className="caption text-[var(--text-4)]">{hint}</div>}
+    </div>
+  )
+}

--- a/ui/src/components/StressScenarioPanel.jsx
+++ b/ui/src/components/StressScenarioPanel.jsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+// Renders the stress_engine.py output for a portfolio. Six canonical historical
+// shocks per backend (equity crash 2008, COVID 2020, rate shock 2022, EM crisis
+// 2018, etc.). Per [`docs/chuan-architecture-survey.md`](../../docs/chuan-architecture-survey.md)
+// gap #13 — the engine exists but had no UI surface.
+//
+// Phase 4 scaffold: surfaces scenarios + portfolio-PnL view against a
+// caller-supplied allocations array. Drop into Portfolio.jsx (next to or under
+// the Allocation Advisor) for the demo path.
+
+function fmtPct(v) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  const sign = v > 0 ? '+' : ''
+  return `${sign}${(Number(v) * 100).toFixed(2)}%`
+}
+
+function fmtUsd(v) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return `$${Number(v).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+}
+
+// Default demo allocation — diversified placeholder so the panel renders
+// something useful when no user portfolio is plugged in. The caller can pass
+// `allocations` + `usdcWeight` to override.
+const DEFAULT_ALLOCATIONS = [
+  { symbol: 'sSPY', token_address: '', weight_bps: 4000 },
+  { symbol: 'sQQQ', token_address: '', weight_bps: 2000 },
+  { symbol: 'sBTC', token_address: '', weight_bps: 1500 },
+  { symbol: 'sGOLD', token_address: '', weight_bps: 500 },
+]
+const DEFAULT_USDC_WEIGHT = 0.20
+
+export default function StressScenarioPanel({ allocations, usdcWeight, portfolioValue = 10000 }) {
+  const [results, setResults] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const allocs = (allocations && allocations.length > 0) ? allocations : DEFAULT_ALLOCATIONS
+  const usdc = usdcWeight != null ? usdcWeight : DEFAULT_USDC_WEIGHT
+  const isPlaceholder = !allocations || allocations.length === 0
+
+  useEffect(() => {
+    let cancelled = false
+    async function run() {
+      setLoading(true)
+      setError('')
+      try {
+        const res = await fetch(`${API_BASE}/api/strategies/stress/run`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            allocations: allocs,
+            scenario: 'all',
+            usdc_weight: usdc,
+          }),
+        })
+        if (!res.ok) throw new Error(await res.text())
+        const data = await res.json()
+        if (!cancelled) setResults(data.results || [])
+      } catch (e) {
+        if (!cancelled) setError(e.message || 'Failed to run stress test')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    run()
+    return () => { cancelled = true }
+  }, [JSON.stringify(allocs), usdc])
+
+  return (
+    <div className="card p-5">
+      <div className="flex items-center justify-between flex-wrap gap-2 mb-3">
+        <div>
+          <div className="label">Stress scenarios</div>
+          <p className="caption mt-1 leading-relaxed">
+            Six historical shocks applied to your allocation per
+            <code style={{ marginLeft: 4 }}>stress_engine.py</code>. Each scenario
+            shocks asset classes by historically-calibrated amounts;
+            portfolio P&amp;L is the weighted sum.
+          </p>
+        </div>
+      </div>
+
+      {isPlaceholder && (
+        <div className="info-box mb-3" style={{ fontSize: '0.8rem' }}>
+          Showing default demo allocation (40% SPY / 20% QQQ / 15% BTC / 5% GOLD / 20% USDC).
+          Pass real <code>allocations</code> from a vault to see your own portfolio's shock surface.
+        </div>
+      )}
+
+      {loading && <div className="caption">Computing scenarios…</div>}
+      {error && <div className="info-box warning">{error}</div>}
+
+      {results && results.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
+          <table className="lib-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+            <thead>
+              <tr style={{ background: 'rgba(255,255,255,0.03)', textAlign: 'left', borderBottom: '1px solid var(--glass-border)' }}>
+                <th style={{ padding: '10px 14px' }}>Scenario</th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}>P&amp;L %</th>
+                <th style={{ padding: '10px 14px', textAlign: 'right' }}>Value after</th>
+                <th style={{ padding: '10px 14px' }}>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map(r => {
+                const pnl = r.portfolio_pnl
+                const negativeClass = pnl < 0 ? 'negative' : pnl > 0 ? 'positive' : ''
+                return (
+                  <tr key={r.scenario} style={{ borderBottom: '1px solid var(--glass-border)' }}>
+                    <td style={{ padding: '8px 14px', fontWeight: 600 }}>{r.label}</td>
+                    <td className={`mono ${negativeClass}`} style={{ padding: '8px 14px', textAlign: 'right' }}>
+                      {fmtPct(pnl)}
+                    </td>
+                    <td className="mono" style={{ padding: '8px 14px', textAlign: 'right' }}>
+                      {fmtUsd(portfolioValue * (1 + (pnl || 0)))}
+                    </td>
+                    <td className="caption" style={{ padding: '8px 14px', maxWidth: 320 }}>
+                      {r.description}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="caption mt-3 text-[var(--text-4)] leading-relaxed">
+        Beta-1 per-asset-class shock model — coarse on purpose so the assumptions
+        are inspectable. Factor models + Monte Carlo tail-risk are a v2 problem.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Frontend scaffold for Phase 4 — adds the `/strategy/:id` strategy passport route, a `CreateVaultModal` wired to the existing `POST /api/vaults/create` endpoint, and a `StressScenarioPanel` on Portfolio that surfaces the six historical shocks from `stress_engine.py` (Day-10 survey gap #13). **Marked DRAFT** because the time-bound vault-lifecycle architecture this scaffold sits on top of needs Marten + Chuan alignment before it leaves draft.

Generated overnight via scheduled CronCreate while Dan slept.

## What this PR ships

**`ui/src/components/StrategyPassport.jsx` (NEW)** — new `/strategy/:id` deep-link route. Header + status + rigor verdict pill; methodology card; source paper card; backtest metrics (Sharpe / CAGR / Max DD / Calmar / Sortino / Win rate / Trades / ρ to SPY); rigor verdict block with DSR / PBO / OOS Sharpe / Look-ahead-clean; provenance block (curator wallet, extraction LLM, on-chain registration tx). Deploy CTA opens `CreateVaultModal` — gated on wallet + `passes_rigor_gate !== false`.

**`ui/src/components/CreateVaultModal.jsx` (NEW)** — modal collects name, symbol, trade window (datetime-local), initial deposit, agent-assisted toggle. Submit calls existing `POST /api/vaults/create` (deploys on Arc via `VaultFactory` through `chain_executor`) and persists strategy↔vault link via `POST /api/vaults/metadata`. Explicit scope note: time-bound window enforcement (Phase 4.5) and the USDC approve + deposit + `setTargetAllocations` wallet flow (Phase 5) are NOT wired yet — modal honestly says so in the body.

**`ui/src/components/StressScenarioPanel.jsx` (NEW)** — calls existing `/api/strategies/stress/scenarios` + `/api/strategies/stress/run`. Renders a dense table of the six historical shocks with portfolio P&L + value-after. Default demo allocation when caller passes none. Closes Day-10 survey gap #13.

**`ui/src/App.jsx`** — add `strategy` route. `resolveRoute` matches `/strategy/:id`; `pageToPath` emits `/strategy/<encoded_id>`. New `selectedStrategy` state, persisted through `navigateToPage` + `popstate`. `renderPage` routes `'strategy'` → `<StrategyPassport>`.

**`ui/src/components/Portfolio.jsx`** — drop `<StressScenarioPanel />` below Allocation Advisor.

**`ui/src/components/Strategies.jsx`** — thread `onNavigate` → `StrategyTable` → `StrategyRow`. Adds an "Open Passport →" button inside each row's expansion that navigates to `/strategy/<id>`. Existing Export JSON/CSV buttons unchanged.

## What this PR does NOT ship (Phase 4.5 / Phase 5 — pending alignment)

- **`backend/archimedes/services/vault_lifecycle.py`** — state machine for Generated → Validated → Deployed → Active → Completed/Expired/Rejected. Open question: who owns the transition trigger? (Agent runner polls vs on-chain events vs dedicated lifecycle worker.)
- **Time-bound trade-window enforcement on the vault contract** — open question on whether this is contract-native or off-chain-enforced. CLAUDE.md says "do not edit contracts overnight without Chuan", so the contract is untouched. Window is collected in the modal as off-chain metadata only.
- **USDC approve + deposit + `setTargetAllocations` multi-step wallet flow** — out of scope per spec; the modal stops after `POST /api/vaults/create` + metadata persist.
- **`StrategyRecord.status` remap to the strategy-lifecycle-spec enum** — interacts with the agent-runner ticking; needs paired backend change.

## Default choices (need review — Marten + Chuan)

The five open questions from `docs/specs/spine-plus-v2-plan.md` § Phase 4, with the defaults this PR took:

| # | Question | Default taken | Where to override |
|---|---|---|---|
| 1 | Trade window: contract-native vs off-chain enforced? | **Off-chain enforced** (agent runner refuses outside window) | Captured in `CreateVaultModal` state; enforcement is Phase 4.5 |
| 2 | `VaultFactory.createVault` args: include `strategy_id` + `trade_window`? | **Metadata-only** — no contract change | Modal submits to existing `/api/vaults/create` + `/api/vaults/metadata` |
| 3 | State transitions: who triggers? | **Agent runner polls** (option a — simplest) | Phase 4.5 work; not in this PR |
| 4 | Withdrawal at completion: manual or automatic? | **Manual user withdraw** (standard ERC-4626) | Existing vault contracts support this; no UI built |
| 5 | Agent "Active" role: where does the trade plan come from? | **`strategy_spec` DSL from #133/#138/#139** | Agent-side read-and-execute is Phase 5 |

## Verify locally

```bash
# Backend (no changes; spot-check that frontend changes haven't broken anything)
source /opt/homebrew/Caskroom/mambaforge/base/etc/profile.d/conda.sh && conda activate archimedes
pytest -q backend/tests/test_api_routes.py -k "not Advisor and not Redis"
# → 28 passed, 2 skipped (pre-existing chain_client mocking skips).

# Frontend (docker)
docker compose up -d --build nginx
# Then http://localhost — check:
#   1. /library → expand any row → "Open Passport →" button → lands on /strategy/<id>
#   2. Passport renders methodology + backtest + rigor verdict + provenance
#   3. Deploy CTA disabled without wallet; enabled when connected + rigor passes
#   4. Click Deploy → modal opens with name/symbol/window/deposit fields
#   5. Submit (with wallet) → POST /api/vaults/create + /metadata succeed; modal closes
#   6. /portfolio → Stress scenarios table renders 6 historical shocks
```

## Open questions for review

- **Marten** — vault-lifecycle ownership: poll vs on-chain-event-driven vs dedicated worker. The default (agent-runner polls) is the lowest-risk; happy to switch.
- **Chuan** — `VaultFactory.createVault` is being called with the existing signature (no `strategy_id` arg). If we want strategy_id at the contract level, that's a Solidity change I deliberately did NOT make overnight.
- **Önder** — the rigor verdict block on the passport mirrors the row-expansion. Same field names from `StrategyResponse`. Any concern with the framing?
- **Daniel R.** — passport uses inline styles + UnoCSS mix matching the existing pattern. Happy to switch to a UnoCSS-only shape if you prefer.

## Anti-goals respected

- **No Solidity edits** — contracts/ untouched.
- **No `environment.yml` / `docker-compose*` / `.env*` changes.**
- **No `routes.py` monolith additions** — uses existing `strategies_router` + `vaults_router` endpoints only.
- **No new backend service** — `vault_lifecycle.py` deliberately deferred until ownership question (#3 above) is answered.

## Marked DRAFT

Frontend scaffold is review-ready. The "what happens after vault create" flow is not — that's the Phase 4.5 / Phase 5 work pending team alignment. Removing draft when the open questions above are answered.

🤖 Generated overnight via scheduled CronCreate while Dan slept.