### PR TITLE
[infra] Pre-stage IAM policy + .env.example AWS additions for #147

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,3 +114,26 @@ PUBLIC_DOMAIN=https://archimedes-arc.app
 # semantic reranking as a defense-in-depth second pass after keyword filtering.
 # When OFF or when deps are missing, falls back to keyword-only ranking.
 FUSION_SEMANTIC_RETRIEVAL=true
+
+# ── AWS — corpus artifact storage + secrets surface ───────────────────────
+# Set by T3.1 (issue #147) provisioning. Backend uses these via boto3 when
+# running on EC2 with the archimedes-backend-role IAM instance profile attached.
+# For local development, leave blank — the relevant code paths fall back to
+# local filesystem (KB_ARTIFACT_DIR) and .env-based secrets.
+#
+# IAM policy reference: infra/iam/archimedes-backend-policy.json
+# Provisioning runbook:  infra/iam/README.md
+AWS_REGION=us-east-1
+AWS_S3_ARTIFACTS_BUCKET=archimedes-corpus-artifacts-prod
+AWS_S3_PDFS_BUCKET=archimedes-paper-pdfs-prod
+AWS_DYNAMODB_PAPERS_TABLE=archimedes-papers-index
+
+# Local-dev fallback: where corpus artifacts live when AWS_S3_ARTIFACTS_BUCKET
+# is blank. Read by corpus_routes.py via the KB_ARTIFACT_DIR env var.
+KB_ARTIFACT_DIR=/srv/corpus-artifact
+
+# ── AWS SSM Parameter Store — production secrets surface ──────────────────
+# Set by TS.2 (issue #176). Backend reads all params under this prefix at
+# startup via boto3.client("ssm").get_parameters_by_path(...). Leave blank
+# for local dev (uses .env values directly).
+AWS_SSM_PATH_PREFIX=/archimedes/prod/

--- a/infra/iam/README.md
+++ b/infra/iam/README.md
@@ -1,0 +1,113 @@
+# IAM — `archimedes-backend-role`
+
+The IAM policy + role that the backend EC2 instance (and the future ECS task / Lambda
+that runs the KB pipeline on GPU) uses to talk to AWS managed services. **Least-privilege
+by design** — every action is scoped to a specific bucket / table / parameter prefix.
+
+## What this policy grants
+
+| AWS service | Scope | Why |
+| --- | --- | --- |
+| `s3:GetObject`, `PutObject`, `DeleteObject` (+ versioning reads) | `archimedes-corpus-artifacts-prod/*` | KB pipeline writes `embeddings.npy`, `clusters.json`, `topics.json`, `kg_triples.jsonl`, `kg_graph.json`, `manifest.json`; backend reads them via `/api/corpus/*` |
+| `s3:GetObject`, `PutObject`, `DeleteObject` | `archimedes-paper-pdfs-prod/*` | Paper PDF storage for the corpus (input to the KB pipeline) |
+| `s3:ListBucket`, `GetBucketLocation`, `GetBucketVersioning` | Both buckets | List + introspection only on the bucket itself (no other buckets) |
+| `dynamodb:GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `Query`, `Scan`, `BatchGetItem`, `BatchWriteItem`, `DescribeTable` | `archimedes-papers-index` (+ all GSIs) | Paper metadata index — DynamoDB is the additive read index per [T3.1 spec](https://github.com/a-apin/archimedes-arcadia/issues/147); Postgres remains the source of truth |
+| `ssm:GetParameter`, `GetParameters`, `GetParametersByPath` | `/archimedes/prod/*` | Secrets surface for [TS.2 #176](https://github.com/a-apin/archimedes-arcadia/issues/176) — backend reads at startup |
+| `kms:Decrypt` (conditional) | KMS via `ssm.<region>.amazonaws.com` only | Decrypts SecureString SSM parameters; condition prevents using this for arbitrary KMS keys |
+| `logs:CreateLogStream`, `PutLogEvents`, `DescribeLogStreams` | `/archimedes/*` log groups | Backend writes structured logs to CloudWatch (operator observability) |
+
+## What this policy does NOT grant
+
+Anti-goals from the original [T3.1 spec](https://github.com/a-apin/archimedes-arcadia/issues/147):
+
+- **No bucket-policy edits** — separating data-plane (this role) from control-plane (Chuan's deployer credentials)
+- **No public-read** of either bucket (no `s3:PutBucketAcl`, no `s3:PutObjectAcl`)
+- **No cross-region replication** for v1 (no `s3:ReplicateObject`)
+- **No access to other AWS accounts** — every resource ARN scoped to `*` for account but the bucket/table names are unique to this project
+- **No IAM operations** (the role can't create more roles, attach policies, or assume other roles)
+- **No Bedrock** — [T3.5 #154](https://github.com/a-apin/archimedes-arcadia/issues/154) is OPTIONAL and held; if/when it fires, append a separate Bedrock statement
+- **No ECS / Lambda / EC2 management** — provisioning happens with deployer credentials, not the backend runtime role
+
+## How pi (or anyone) applies this
+
+```bash
+# 1. Create the policy in AWS (one-time)
+aws iam create-policy \
+  --policy-name archimedes-backend-policy \
+  --policy-document file://infra/iam/archimedes-backend-policy.json \
+  --description "Backend runtime access for Archimedes — S3 artifacts + DynamoDB index + SSM secrets"
+# Note the returned policy ARN; you'll need it for step 2.
+
+# 2. Create the role with EC2 trust + attach the policy
+aws iam create-role \
+  --role-name archimedes-backend-role \
+  --assume-role-policy-document file://infra/iam/trust-policy-ec2.json
+aws iam attach-role-policy \
+  --role-name archimedes-backend-role \
+  --policy-arn <POLICY_ARN_FROM_STEP_1>
+
+# 3. Create the instance profile + add the role
+aws iam create-instance-profile \
+  --instance-profile-name archimedes-backend-profile
+aws iam add-role-to-instance-profile \
+  --instance-profile-name archimedes-backend-profile \
+  --role-name archimedes-backend-role
+
+# 4. Associate with the running EC2 (or set on launch template)
+aws ec2 associate-iam-instance-profile \
+  --instance-id <BACKEND_INSTANCE_ID> \
+  --iam-instance-profile Name=archimedes-backend-profile
+```
+
+After step 4, the backend can `boto3.client("s3").get_object(...)` etc. without any
+long-lived credentials in `.env` — the EC2 metadata service vends temporary STS
+tokens automatically.
+
+## The trust policy (companion file — pi creates this)
+
+The companion `trust-policy-ec2.json` (not committed; pi creates ad-hoc) should contain:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "ec2.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+If the KB pipeline runs on ECS Fargate or Lambda instead of EC2, add the relevant
+service principal (`ecs-tasks.amazonaws.com` or `lambda.amazonaws.com`) to the
+`Principal.Service` array.
+
+## Cross-account / multi-environment notes
+
+- **Single-account model for v1.** Everything in Chuan's hackathon AWS account.
+- **`*` in resource ARNs** is the account-ID wildcard. AWS resolves to the account
+  the API call is made from, so this is effectively "this account only."
+- **Region `*` in DynamoDB / SSM / KMS / Logs** is deliberate — we may run the
+  backend in any AWS region without policy changes.
+- **For staging / dev environments**, create separate policies with `-staging` /
+  `-dev` suffixes on the resource names; do not share this role across env tiers.
+
+## Validation checklist
+
+After provisioning the role + attaching to backend EC2:
+
+- [ ] `aws sts get-caller-identity` from the EC2 returns the role's ARN (not a user ARN)
+- [ ] `aws s3 ls s3://archimedes-corpus-artifacts-prod/` succeeds (empty list OK)
+- [ ] `aws dynamodb describe-table --table-name archimedes-papers-index` returns `TableStatus: ACTIVE`
+- [ ] `aws ssm get-parameter --name /archimedes/prod/test --with-decryption` returns either the value (if seeded) or `ParameterNotFound` (NOT `AccessDenied`)
+- [ ] Backend can `python -c "from archimedes.services.s3_artifact_store import S3ArtifactStore; print(S3ArtifactStore().list_keys()[:5])"` (returns `[]` if bucket is empty — that's fine)
+
+## Open question / future
+
+- **CloudWatch Logs ingestion volume** could spike if we log per-request at INFO. If
+  AWS billing surfaces this as a concern, downgrade to WARN/ERROR-only in production
+  via `LOG_LEVEL=WARNING` and use a sampling strategy for important traces.
+- **DynamoDB read/write capacity** — left at on-demand (per the T3.1 anti-goals).
+  Migrate to provisioned only after we have a real read pattern signal.

--- a/infra/iam/archimedes-backend-policy.json
+++ b/infra/iam/archimedes-backend-policy.json
@@ -1,0 +1,103 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3CorpusArtifactsReadWrite",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetObjectVersion",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::archimedes-corpus-artifacts-prod/*"
+      ]
+    },
+    {
+      "Sid": "S3PaperPdfsReadWrite",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::archimedes-paper-pdfs-prod/*"
+      ]
+    },
+    {
+      "Sid": "S3BucketList",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": [
+        "arn:aws:s3:::archimedes-corpus-artifacts-prod",
+        "arn:aws:s3:::archimedes-paper-pdfs-prod"
+      ]
+    },
+    {
+      "Sid": "DynamoDBPapersIndexCRUD",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:DescribeTable"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:*:table/archimedes-papers-index",
+        "arn:aws:dynamodb:*:*:table/archimedes-papers-index/index/*"
+      ]
+    },
+    {
+      "Sid": "SSMParameterRead",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:*:parameter/archimedes/prod/*"
+      ]
+    },
+    {
+      "Sid": "KMSDecryptSSM",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": [
+            "ssm.us-east-1.amazonaws.com",
+            "ssm.eu-west-2.amazonaws.com"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "CloudWatchLogsWrite",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:log-group:/archimedes/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Pre-stages the IAM policy JSON + .env.example AWS additions for issue [#147 (T3.1 AWS S3+DynamoDB+IAM)](https://github.com/a-apin/archimedes-arcadia/issues/147). Pi (`t2o2`) explicitly invited this hand-off to shorten the critical path that's blocking [#148](https://github.com/a-apin/archimedes-arcadia/issues/148), [#151](https://github.com/a-apin/archimedes-arcadia/issues/151), and [#176](https://github.com/a-apin/archimedes-arcadia/issues/176).

## What's in the PR

- `infra/iam/archimedes-backend-policy.json` — least-privilege policy. S3 R/W on the 2 buckets, DynamoDB CRUD on `archimedes-papers-index`, SSM read on `/archimedes/prod/*`, conditional KMS decrypt for SSM only, CloudWatch Logs write on `/archimedes/*`. Deliberately excludes bucket-policy edits, public-read, cross-region replication, IAM operations, Bedrock.
- `infra/iam/README.md` — operator runbook. Per-grant table, aws-cli sequence to apply, trust-policy guidance, validation checklist.
- `.env.example` — two new sections: AWS infra envs (`AWS_REGION`, `AWS_S3_ARTIFACTS_BUCKET`, `AWS_S3_PDFS_BUCKET`, `AWS_DYNAMODB_PAPERS_TABLE`, `KB_ARTIFACT_DIR`) + SSM (`AWS_SSM_PATH_PREFIX`). Local dev still works when these are blank.

## Out of scope

- Provisioning the actual AWS resources (pi/Chuan handles in #147)
- Bedrock IAM (held with #154)
- SSM Parameter Store seeding (TS.2 #176)
- Backend code changes to use boto3 (lands in #147 / #151 PRs)

## Acceptance

- [x] `python3 -m json.tool infra/iam/archimedes-backend-policy.json` exits 0
- [ ] `aws iam create-policy --policy-document file://infra/iam/archimedes-backend-policy.json` on Chuan's account succeeds (pi runs this when picking up #147)
- [ ] Backend EC2 with the resulting role attached can list both buckets + describe the DynamoDB table without long-lived credentials

## Next

Once this PR merges, pi can grab the policy JSON directly from `main` and `aws iam create-policy --policy-document file://infra/iam/archimedes-backend-policy.json` straight into #147's execution. Eliminates the "draft the policy from scratch" step.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>