### PR TITLE
[frontend] PR-1: Landing junk purge — kill status ribbon + Two-Tier Marketplace

### DIFF
--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -1,38 +1,4 @@
-import { useState, useEffect } from 'react'
-
-const API_BASE = import.meta.env.VITE_API_BASE ?? ''
-
-async function apiGet(path) {
-  try {
-    const res = await fetch(`${API_BASE}${path}`)
-    if (!res.ok) return null
-    return res.json()
-  } catch { return null }
-}
-
 export default function Landing({ onNavigate }) {
-  const [stats, setStats]           = useState(null)
-  const [agentStatus, setAgentStatus] = useState(null)
-  const [regime, setRegime]         = useState(null)
-
-  useEffect(() => {
-    async function load() {
-      const [contracts, agent, reg, strategies] = await Promise.all([
-        apiGet('/api/config/contracts'),
-        apiGet('/api/agent/status'),
-        apiGet('/api/regime/current'),
-        apiGet('/api/strategies/'),
-      ])
-      setStats({
-        strategyCount: strategies?.strategies?.length || 0,
-        contracts: contracts?.vault_factory ? 10 : 0,
-      })
-      setAgentStatus(agent)
-      setRegime(reg)
-    }
-    load()
-  }, [])
-
   return (
     <div className="min-h-screen bg-[var(--canvas)] overflow-x-hidden font-[var(--sans)]">
 
@@ -81,15 +47,6 @@ export default function Landing({ onNavigate }) {
         </div>
       </section>
 
-      {/* ── Live status bar ──────────────────────────────────────── */}
-      <div className="flex flex-wrap justify-center gap-x-8 gap-y-2 px-5 py-3.5 overflow-hidden bg-[var(--surface-1)] border-b border-[var(--glass-border)]">
-        <StatusItem dot="live"   label="Agent"      value={agentStatus?.alive ? 'LIVE' : '…'} />
-        <StatusItem dot="regime" label="Regime"     value={regime?.regime || '…'} />
-        <StatusItem              label="Confidence" value={regime?.confidence ? `${(regime.confidence * 100).toFixed(0)}%` : '…'} />
-        <StatusItem              label="Strategies" value={stats?.strategyCount ?? '…'} />
-        <StatusItem              label="Contracts"  value={stats?.contracts ?? '…'} />
-      </div>
-
       {/* ── Why Archimedes ───────────────────────────────────────── */}
       <LSection>
         <SectionTitle>Why Archimedes?</SectionTitle>
@@ -110,32 +67,6 @@ export default function Landing({ onNavigate }) {
             Your funds never pass through platform custody. ERC-4626 vault contracts
             hold your USDC and synth tokens — agent has rebalance authority only.
           </FeatureCard>
-        </div>
-      </LSection>
-
-      {/* ── Two-Tier Marketplace ─────────────────────────────────── */}
-      <LSection>
-        <SectionTitle>Two-Tier Strategy Marketplace</SectionTitle>
-        <div className="lg-grid-2">
-          <TierCard tier={1} title="Archimedes Verified" items={[
-            'Paper-grounded provenance',
-            'Selection-bias corrected (DSR + PBO + walk-forward + look-ahead audit)',
-            'Full agent autonomy',
-            'Reasoning trace on-chain',
-            'Paper-claim deltas surfaced honestly',
-          ]} />
-          <TierCard tier={2} title="Community" items={[
-            'Permissionless strategy submission',
-            'Opt-in agent features',
-            'Community curation',
-            'Transparent performance history',
-            'Open to all strategies',
-          ]} />
-        </div>
-        <div className="mt-4 text-center">
-          <button className="btn-secondary" onClick={() => onNavigate('library', { tab: 'examples' })}>
-            Browse {stats?.strategyCount || 6} Strategies →
-          </button>
         </div>
       </LSection>
 
@@ -249,21 +180,6 @@ export default function Landing({ onNavigate }) {
 
 /* ── Sub-components ──────────────────────────────────────────── */
 
-function StatusItem({ dot, label, value }) {
-  const dotCls =
-    dot === 'live'   ? 'bg-[var(--positive)] shadow-[0_0_6px_var(--positive)]' :
-    dot === 'regime' ? 'bg-[var(--accent)]' : null
-  return (
-    <div className="flex items-center gap-1.5 text-[0.82rem]">
-      {dotCls && (
-        <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${dotCls}`} />
-      )}
-      <span className="text-[var(--text-3)]">{label}</span>
-      <span className="text-[var(--text-1)] font-semibold tabular-nums">{value}</span>
-    </div>
-  )
-}
-
 function LSection({ children }) {
   return (
     <section className="l-section">
@@ -293,25 +209,3 @@ function FeatureCard({ icon, title, tag, children }) {
   )
 }
 
-function TierCard({ tier, title, items }) {
-  const borderCls = tier === 1 ? 'border-[var(--accent)]' : 'border-[var(--text-3)]'
-  const colorCls  = tier === 1 ? 'text-[var(--accent)]'   : 'text-[var(--text-3)]'
-  const iconName  = tier === 1 ? 'i-lucide-trophy'        : 'i-lucide-users'
-  return (
-    <div className={`bg-[var(--surface-1)] border-2 ${borderCls} rounded-2xl p-8 flex flex-col items-center text-center`}>
-      <span className={`${iconName} w-8 h-8 mb-3 ${colorCls}`} />
-      <div className={`text-xs font-bold uppercase tracking-[0.08em] ${colorCls} mb-2`}>
-        Tier {tier}
-      </div>
-      <h3 className="font-serif text-[1.15rem] font-normal mb-5 text-[var(--text-1)]">{title}</h3>
-      <ul className="space-y-2 text-left w-full">
-        {items.map(item => (
-          <li key={item} className="flex items-start gap-2 text-[0.85rem] text-[var(--text-2)]">
-            <span className="i-lucide-check w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--positive)]" />
-            {item}
-          </li>
-        ))}
-      </ul>
-    </div>
-  )
-}


### PR DESCRIPTION
## Summary

Two surgical cuts to the Landing page in response to Dan's morning feedback:

> "Confidence 92% on the home page? It's meaningless!!!"
> "I kinda hate the landing page and think it really needs to be cleaned up and purged of junk."

## What's removed (106 lines)

1. **Live status bar** — "Agent LIVE / Regime risk_on / Confidence 92% / Strategies 6 / Contracts 10". Meaningless numbers above the fold for a first-time visitor; Strategies count duplicates a Library-page concern.
2. **"Two-Tier Strategy Marketplace" section** — Tier 2 ("Community") doesn't exist on the live site. Permissionless submission, community curation, etc. are all aspirational. The Tier 1 rigor pillars are already on the page in the "Rigor is the Wedge" section below.

## What's preserved

Every load-bearing pitch surface stays untouched:
- **Hero** — Linus-for-q-fin tagline + paper-grounded/on-chain/autonomous headline + Generate + Browse CTAs
- **Why Archimedes** — 4 feature cards, all real and shipped
- **Built On** — 6 logos, all real
- **Rigor is the Wedge** — 4 selection-bias gates, the actual wedge
- **Circle Ecosystem Integration** — 6 cards (some aspirational; left for a separate Dan-led review pass)
- **"Give me a lever long enough"** final CTA

## Mechanical fallout (clean rewire)

After removing the two sections, the following became orphans and were deleted:
- `useState` + `useEffect` hooks (Landing no longer fetches anything; purely presentational)
- `apiGet` helper, `API_BASE` constant
- `StatusItem` sub-component (was only used by the status bar)
- `TierCard` sub-component (was only used by the marketplace section)
- React import trimmed (no hooks in use)

## Acceptance

- [ ] Browser `/`: no Agent/Regime/Confidence/Strategies/Contracts ribbon
- [ ] Browser `/`: no Two-Tier Marketplace section
- [ ] Hero + Why + Built On + Rigor + Circle + final CTA all render correctly
- [ ] Sidebar + topbar still present (Layout wraps at App.jsx:186 — unchanged)
- [ ] No console errors; lint clean
- [ ] CI ruff + import-guard + complexity gates pass

## Diff

`ui/src/components/Landing.jsx`: -106 lines (318 → 212). Zero behavior changes outside the two removed sections. Same component contract `<Landing onNavigate={...} />`; App.jsx routing unchanged.

## Next in the surface-cleanup series

- **PR-2**: Portfolio simplification (shrink+explain RISK ON banner; honest empty state for vaults)
- **PR-3**: Wallet menu (Profile + Disconnect dropdown) + Profile view/edit
- **PR-4**: Generate `list_strategies` bug fix (the function-vs-object provider error)
- **PR-5**: Library Examples surface + T2.2 mode-picker frontend removal

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>