### PR TITLE
[infra] Fix Quality Gate ruff regex (false 196 errors) + document submodule sticky config

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -81,13 +81,21 @@ jobs:
           ruff format --check . > /tmp/ruff_fmt.txt 2>&1 || true
           python3 - <<'EOF'
           import json, os, re
+          # 1) Lint-error count from JSON output (real ruff check . errors).
           try:
               errors = len(json.load(open("/tmp/ruff.json")))
           except Exception:
               errors = 0
+          # 2) Format-error count: WOULD-BE-REFORMATTED files only.
+          #    Earlier version used /(\d+) file/ which matched BOTH "X files
+          #    would be reformatted" AND "X files already formatted". When all
+          #    files are formatted, ruff outputs only the latter line and the
+          #    old regex counted clean files as errors (false 196 on PR #204).
           try:
-              m = re.search(r"(\d+) file", open("/tmp/ruff_fmt.txt").read())
-              errors += int(m.group(1)) if m else 0
+              fmt_text = open("/tmp/ruff_fmt.txt").read()
+              m = re.search(r"(\d+) files? would be reformatted", fmt_text)
+              if m:
+                  errors += int(m.group(1))
           except Exception:
               pass
           out = open(os.environ["GITHUB_OUTPUT"], "a")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,19 @@ The repo carries three git submodules at [`submodules/`](submodules/):
     - `samples/arc-p2p-payments/` — Paymaster + USDC patterns
   Refresh upstream with `git submodule update --remote submodules/context-arc` or
   `arc-canteen context sync` (drops into `~/.arc-canteen/context/`).
+
+  **Sticky submodule config — one-time, per clone:** after `git clone`, run this
+  to make git auto-recurse into submodules on every checkout/pull/rebase. Without
+  this, working trees drift out of sync with main's recorded pins (we hit this
+  several times during the hackathon — every session had to manually re-sync):
+  ```bash
+  git config submodule.recurse true   # auto-recurse on git ops
+  git config diff.submodule log       # nicer diff display
+  git submodule update --init --recursive  # one-shot sync to recorded pins
+  ```
+  Linus has its OWN nested submodule (`submodules/Linus/modules/KnowledgeBase`)
+  which is the most common source of "modified content" noise in `git status`.
+  The `--recursive` flag handles it.
 - **[`submodules/KnowledgeBase/`](submodules/KnowledgeBase/)** — Dan's scientific-
   paper analysis pipeline (PyMuPDF extract + SPECTER2 embeddings + HDBSCAN/BERTopic
   clustering + REBEL/SciSpacy knowledge graph). For Archimedes, **don't port wholesale**


### PR DESCRIPTION
Two infra cleanups bundled. Patch bump expected (no marker).

## (1) Quality Gate ruff count regex

PR #204 showed `ruff linter (python): 196 errors` in the Quality Gate comment table — false. Local ruff returns 0 errors; the bug is in the lint-report regex `r"(\d+) file"` which matches both "would be reformatted" AND "already formatted" lines. When all files are clean, ruff outputs only `196 files already formatted` and the old regex counted those clean files as errors.

Fix: tightened to `r"(\d+) files? would be reformatted"` — only matches the actual error case.

## (2) CLAUDE.md submodule sticky-config note

Recurring annoyance: working-tree submodules drift out of sync with main's pins every session. Root cause: Linus has a NESTED submodule (`Linus/modules/KnowledgeBase`) not initialized by default. Added sticky-config block to CLAUDE.md so future clones run it once:

```bash
git config submodule.recurse true
git config diff.submodule log
git submodule update --init --recursive
```

After this lands + clones apply it, the `m submodules/KnowledgeBase` / `m submodules/Linus` noise in `git status` should stop.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>