### PR TITLE
[backend] PR-4: Fix Generate AttributeError on default_provider.list_strategies

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -36,10 +36,9 @@ jobs:
 
   ruff-gate:
     # Blocking gate for formatting + the critical lint rule families that
-    # catch real bugs (syntax errors, undefined modules). Reads root ruff.toml.
-    # The broader `ruff check` set is still informational in lint-report.
-    # Add more rules to --select as the codebase converges (next add: F82
-    # after the agent_runner consulted_hashes bug is fixed in the PR-4 cluster).
+    # catch real bugs (syntax errors, undefined names/modules). Reads root
+    # ruff.toml. The broader `ruff check` set is still informational in
+    # lint-report. Add more rules to --select as the codebase converges.
     name: Ruff — format + critical lint rules
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +50,7 @@ jobs:
       - name: ruff format --check
         run: ruff format --check .
       - name: ruff check (critical rules only)
-        run: ruff check --select E9,F63,F7,F40 .
+        run: ruff check --select E9,F63,F7,F40,F82 .
 
   lint-report:
     name: Lint — report table

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -93,7 +93,7 @@ def _pick_pipeline(
     try:
         from archimedes.services.strategy_provider import default_provider
 
-        lib = default_provider.list_strategies()
+        lib = default_provider().list_strategies()
         if len(lib) >= 3:
             return "architect", (f"curated library has {len(lib)} strategies; fast preview available")
     except Exception:
@@ -424,7 +424,7 @@ async def _run_live_candidate(*, candidate_id: str, brief: GenerateBrief, emit: 
         timeout=30.0,
     )
     market_ranking = strategy_evaluator.rank_market(price_histories, lookback_days=90, top_n=20)
-    strategies = default_provider.list_strategies()
+    strategies = default_provider().list_strategies()
 
     agent = get_portfolio_agent()
     portfolio = await asyncio.wait_for(
@@ -558,7 +558,7 @@ async def run_generation(
         try:
             from archimedes.services.strategy_provider import default_provider
 
-            lib = default_provider.list_strategies()
+            lib = default_provider().list_strategies()
             arxiv_ids = [s.paper_arxiv_id for s in lib if getattr(s, "paper_arxiv_id", None)]
         except Exception:
             arxiv_ids = []

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -138,6 +138,29 @@ def test_rigor_adapter_handles_empty_series():
     assert verdict["passing"] is False
 
 
+def test_pick_pipeline_architect_branch_calls_provider_factory(monkeypatch):
+    # `default_provider` is a factory function. The architect-check branch
+    # of _pick_pipeline previously called `default_provider.list_strategies()`
+    # without the `()`, raising AttributeError that the broad `except
+    # Exception` swallowed silently — collapsing the pipeline to "agent" on
+    # every call. This test forces the architect path (fusion disabled) and
+    # asserts it actually selects "architect" — which can only happen if
+    # `.list_strategies()` succeeds.
+    from archimedes.agents import generation_pipeline as gp
+    from archimedes.api.generate_schemas import GenerateBrief
+
+    # Force fusion off so we exit the fusion branch and hit architect.
+    monkeypatch.setattr(
+        "archimedes.agents.strategy_fusion.fusion_enabled",
+        lambda: False,
+    )
+
+    brief = GenerateBrief(intent="trend-following", risk_appetite="moderate")
+    pipeline, reason = gp._pick_pipeline(brief)
+    assert pipeline == "architect", f"expected architect, got {pipeline!r} (reason={reason!r})"
+    assert "strategies" in reason
+
+
 @pytest.mark.asyncio
 async def test_pipeline_emits_cancellation_event_when_task_cancelled():
     """CancelledError path emits a CANCELLED error event + flips status."""


### PR DESCRIPTION
## Summary

Three sites in `generation_pipeline.py` called `default_provider.list_strategies()` when `default_provider` is a **factory function** — raising `AttributeError` that the surrounding broad `except Exception` swallowed silently. Net effect: every Generate run that hit the architect branch silently fell through to the streaming-agent fallback even when fusion + the curated library were healthy.

Discovered via Dan's afternoon screenshot showing the error in the fusion candidate ranker; root-cause confirmed by parallel research subagent in [docs/specs/afternoon-execution-plan-2026-05-24.md](docs/specs/afternoon-execution-plan-2026-05-24.md#pr-4).

## Changes

- **3-line fix** in `backend/archimedes/agents/generation_pipeline.py` (lines 96, 427, 561): add the missing `()` to call the factory.
- **New regression test** `test_pick_pipeline_architect_branch_calls_provider_factory` in `backend/tests/services/test_generation_pipeline.py` — disables fusion via monkeypatch and asserts `_pick_pipeline` returns `"architect"`. Verified the test fails on the buggy code (`expected architect, got 'agent'`) and passes after the fix.
- **`ruff-gate` hardening**: add `F82` (undefined-name) to the blocking `--select` list. CLAUDE.md already documented this as the next add after PR-0 fixed the `consulted_hashes` undefined-name bug; this fulfills that promise. Repo-wide `ruff check --select E9,F63,F7,F40,F82` is clean.

## Test plan

- [x] `pytest backend/tests/services/test_generation_pipeline.py -q` → 8/8 pass
- [x] Verified test catches regression by temporarily reverting line 96 → `AssertionError: expected architect, got 'agent'`
- [x] `ruff check --select E9,F63,F7,F40,F82 .` → All checks passed!
- [x] `ruff format --check .` → 2 files already formatted
- [x] Full local unit suite: 560 passed (2 pre-existing Redis-down failures unrelated to PR-4 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)