### PR TITLE
[frontend] PR-2: Portfolio simplification — compact regime + delete advisor + honest stress

### DIFF
--- a/ui/src/components/Learnings.jsx
+++ b/ui/src/components/Learnings.jsx
@@ -3,6 +3,8 @@
 // the system's) have performed well, which haven't, and the agent's reasoning
 // for each. Honest empty state until strategies accumulate runtime data.
 
+import RegimePanel from './RegimePanel'
+
 export default function Learnings({ onNavigate }) {
   const goGenerate = (e) => {
     e.preventDefault()
@@ -21,6 +23,22 @@ export default function Learnings({ onNavigate }) {
           Losing trades are not hidden. Silently rotating away from losses is the failure
           mode of every "AI fund" — we explicitly don't.
         </p>
+      </div>
+
+      {/* Market regime — full breakdown. The agent's lens on current
+          conditions: VIX + MA cross signals, transition probabilities,
+          and which library strategies it leans into. /portfolio shows
+          only the compact pill so users can stay focused on their funds;
+          the educational view lives here. */}
+      <div className="max-w-[860px] mb-7">
+        <h3 className="serif text-[1.4rem] mb-2.5">Current market regime</h3>
+        <p className="body mb-4 text-[var(--text-3)]">
+          The regime is the agent's read of market conditions, derived from VIX +
+          SPX moving-average cross signals. It biases strategy selection —
+          <em>risk_on</em> leans into momentum + TSMOM,
+          <em> crisis</em> leans into t-bill alternatives + capital preservation.
+        </p>
+        <RegimePanel />
       </div>
 
       <div className="card p-6">

--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -3,9 +3,7 @@ import {
   publicClient,
   VAULT_ABI, VAULT_FACTORY_ABI, NEW_CONTRACTS,
 } from '../config'
-import PortfolioAdvisor from './PortfolioAdvisor'
 import RegimePanel from './RegimePanel'
-import StressScenarioPanel from './StressScenarioPanel'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -30,7 +28,6 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
   const [recentTraces, setRecentTraces] = useState([])
   const [tracesLoading, setTracesLoading] = useState(false)
   const [vaultsLoading, setVaultsLoading] = useState(false)
-  const [advisorOpen, setAdvisorOpen] = useState(false)
 
   // Load user's own vaults (wallet-gated, from on-chain)
   const loadVaults = useCallback(async () => {
@@ -97,38 +94,41 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
     return () => clearInterval(t)
   }, [loadAllVaults, loadAgentAndRegime, loadTraces])
 
-  const totalAum = userVaults.reduce((s, v) => s + v.aum, 0)
-  const allAum = allVaults.reduce((s, v) => s + (v.aum_usdc || 0), 0)
+  // YOUR AUM — sum across vaults the connected wallet created.
+  // Wallet-disconnected users see 0; wallet-connected users see real $ at risk.
+  const yourAum = userVaults.reduce((s, v) => s + v.aum, 0)
 
   return (
     <div>
-      <div className="max-w-[720px] mb-6">
-        <h2 className="serif text-[2rem] mb-2.5">Portfolio</h2>
-        <p className="body">
-          Browse vaults, monitor the agent, and inspect every rebalance decision.
-          Every action has a reasoning trace anchored on Arc — click to inspect.
-        </p>
+      <div className="max-w-[720px] mb-6 flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="serif text-[2rem] mb-2.5">Portfolio</h2>
+          <p className="body">
+            Browse vaults, monitor the agent, and inspect every rebalance decision.
+            Every action has a reasoning trace anchored on Arc — click to inspect.
+          </p>
+        </div>
+        {/* Regime context — small pill; full breakdown lives on /learnings. */}
+        <RegimePanel compact />
       </div>
 
-      {/* Regime sidebar */}
-      <RegimePanel />
-
-      {/* Status strip — agent state is Redis-backed (regardless of wallet); regime
-          lives in the RegimePanel block above to avoid duplication. */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      {/* Status strip — Your AUM (wallet-scoped) + marketplace vault count + agent. */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
         <div className="card-flat p-4">
-          <div className="label mb-2">Vaults</div>
+          <div className="label mb-2">Your AUM</div>
+          <div className="text-[1.8rem] font-bold">
+            ${yourAum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+          </div>
+          <div className="caption mt-1.5">
+            Across {userVaults.length} {userVaults.length === 1 ? 'vault' : 'vaults'} you created
+          </div>
+        </div>
+        <div className="card-flat p-4">
+          <div className="label mb-2">Marketplace</div>
           <div className="text-[1.8rem] font-bold">{allVaults.length}</div>
           <div className="caption mt-1.5">
             {allVaults.filter(v => v.tier === 1).length} Tier 1 · {allVaults.filter(v => v.tier === 2).length} Tier 2
           </div>
-        </div>
-        <div className="card-flat p-4">
-          <div className="label mb-2">Total AUM</div>
-          <div className="text-[1.8rem] font-bold">
-            ${allAum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-          </div>
-          <div className="caption positive mt-1.5">Arc Testnet</div>
         </div>
         <div className="card-flat p-4">
           <div className="label mb-2">Agent</div>
@@ -142,9 +142,9 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
         </div>
       </div>
 
-      {/* Browse all vaults */}
+      {/* Vault marketplace — every deployed vault (yours and others). */}
       <div className="mb-7">
-        <div className="label mb-3">Your Vaults</div>
+        <div className="label mb-3">Vault Marketplace</div>
         {allVaults.length === 0 && (
           <div className="card" style={{ padding: 18 }}>
             <p className="body">No vaults deployed yet.</p>
@@ -203,26 +203,6 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace }) 
           </div>
         </div>
       )}
-
-      {/* Allocation Advisor — collapsible section */}
-      <div className="mb-7">
-        <button
-          type="button"
-          className="flex items-center gap-2 w-full text-left mb-3"
-          onClick={() => setAdvisorOpen(v => !v)}
-          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
-        >
-          <span className={`i-lucide-chevron-${advisorOpen ? 'down' : 'right'} w-4 h-4 text-[var(--text-4)]`} />
-          <span className="label" style={{ margin: 0 }}>Allocation Advisor</span>
-        </button>
-        {advisorOpen && <PortfolioAdvisor />}
-      </div>
-
-      {/* Stress scenarios — six historical shocks per stress_engine.py.
-          Closes Day-10 survey gap #13. */}
-      <div className="mb-7">
-        <StressScenarioPanel />
-      </div>
 
       {/* Agent activity feed — real traces from /api/traces */}
       <div>

--- a/ui/src/components/RegimePanel.jsx
+++ b/ui/src/components/RegimePanel.jsx
@@ -44,6 +44,45 @@ function MiniBar({ value, max, color }) {
   )
 }
 
+// Compact pill — page-header context, not a full panel. Used on /portfolio
+// where the user cares about their funds; the full educational view lives
+// on /learnings.
+function CompactRegimePill({ regime }) {
+  const r = regime.regime
+  const rColor = regimeColor(r)
+  const rLabel = r.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+  const conf = regime.confidence ?? 0
+  return (
+    <span
+      title={
+        `The agent's current read of market conditions. Drives which library ` +
+        `strategies it leans into for new generates + rebalances. ` +
+        `risk_on → momentum/TSMOM. transition → vol-managed. ` +
+        `risk_off → t-bill alternatives. crisis → capital preservation.`
+      }
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '4px 10px',
+        borderRadius: 999,
+        background: regimeBg(r),
+        border: `1px solid ${regimeBorder(r)}`,
+        fontSize: '0.78rem',
+        cursor: 'help',
+      }}
+    >
+      <span style={{ width: 8, height: 8, borderRadius: '50%', background: rColor, display: 'inline-block' }} />
+      <span style={{ fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.04em', color: rColor }}>
+        {rLabel}
+      </span>
+      <span className="caption" style={{ color: 'var(--text-3)' }}>
+        {fmtPct(conf)} conf
+      </span>
+    </span>
+  )
+}
+
 function TransitionRow({ from, to, prob }) {
   const arrow = from === to ? 'stay' : `→ ${to.replace(/_/g, ' ')}`
   return (
@@ -59,7 +98,7 @@ function TransitionRow({ from, to, prob }) {
   )
 }
 
-export default function RegimePanel({ regime: regimeProp = null }) {
+export default function RegimePanel({ regime: regimeProp = null, compact = false }) {
   const [fetchedRegime, setFetchedRegime] = useState(null)
   const [loading, setLoading] = useState(regimeProp == null)
 
@@ -74,6 +113,7 @@ export default function RegimePanel({ regime: regimeProp = null }) {
   const regime = regimeProp ?? fetchedRegime
 
   if (loading) {
+    if (compact) return <span className="caption" style={{ color: 'var(--text-4)' }}>Loading regime…</span>
     return (
       <div className="card-flat" style={{ padding: 20, marginBottom: 24 }}>
         <div className="caption">Loading regime data…</div>
@@ -82,6 +122,17 @@ export default function RegimePanel({ regime: regimeProp = null }) {
   }
 
   if (!regime || regime.regime === 'unknown') {
+    if (compact) {
+      return (
+        <span
+          className="caption"
+          title="Agent not running or Redis not connected — the regime classifier writes state to Redis on each agent tick."
+          style={{ color: 'var(--text-4)' }}
+        >
+          Regime: unavailable
+        </span>
+      )
+    }
     return (
       <div className="card-flat" style={{ padding: 20, marginBottom: 24 }}>
         <div className="label mb-2">Current Market Regime</div>
@@ -90,6 +141,10 @@ export default function RegimePanel({ regime: regimeProp = null }) {
         </div>
       </div>
     )
+  }
+
+  if (compact) {
+    return <CompactRegimePill regime={regime} />
   }
 
   const r = regime.regime

--- a/ui/src/components/StressScenarioPanel.jsx
+++ b/ui/src/components/StressScenarioPanel.jsx
@@ -22,27 +22,16 @@ function fmtUsd(v) {
   return `$${Number(v).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
 }
 
-// Default demo allocation — diversified placeholder so the panel renders
-// something useful when no user portfolio is plugged in. The caller can pass
-// `allocations` + `usdcWeight` to override.
-const DEFAULT_ALLOCATIONS = [
-  { symbol: 'sSPY', token_address: '', weight_bps: 4000 },
-  { symbol: 'sQQQ', token_address: '', weight_bps: 2000 },
-  { symbol: 'sBTC', token_address: '', weight_bps: 1500 },
-  { symbol: 'sGOLD', token_address: '', weight_bps: 500 },
-]
-const DEFAULT_USDC_WEIGHT = 0.20
-
 export default function StressScenarioPanel({ allocations, usdcWeight, portfolioValue = 10000 }) {
   const [results, setResults] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  const allocs = (allocations && allocations.length > 0) ? allocations : DEFAULT_ALLOCATIONS
-  const usdc = usdcWeight != null ? usdcWeight : DEFAULT_USDC_WEIGHT
-  const isPlaceholder = !allocations || allocations.length === 0
+  const hasAllocations = allocations && allocations.length > 0
+  const usdc = usdcWeight != null ? usdcWeight : 0
 
   useEffect(() => {
+    if (!hasAllocations) return undefined
     let cancelled = false
     async function run() {
       setLoading(true)
@@ -52,7 +41,7 @@ export default function StressScenarioPanel({ allocations, usdcWeight, portfolio
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            allocations: allocs,
+            allocations,
             scenario: 'all',
             usdc_weight: usdc,
           }),
@@ -68,7 +57,7 @@ export default function StressScenarioPanel({ allocations, usdcWeight, portfolio
     }
     run()
     return () => { cancelled = true }
-  }, [JSON.stringify(allocs), usdc])
+  }, [JSON.stringify(allocations), usdc, hasAllocations])
 
   return (
     <div className="card p-5">
@@ -84,17 +73,16 @@ export default function StressScenarioPanel({ allocations, usdcWeight, portfolio
         </div>
       </div>
 
-      {isPlaceholder && (
-        <div className="info-box mb-3" style={{ fontSize: '0.8rem' }}>
-          Showing default demo allocation (40% SPY / 20% QQQ / 15% BTC / 5% GOLD / 20% USDC).
-          Pass real <code>allocations</code> from a vault to see your own portfolio's shock surface.
+      {!hasAllocations && (
+        <div className="info-box" style={{ fontSize: '0.85rem' }}>
+          Deploy a vault to see how its allocation survives historical shocks.
         </div>
       )}
 
       {loading && <div className="caption">Computing scenarios…</div>}
       {error && <div className="info-box warning">{error}</div>}
 
-      {results && results.length > 0 && (
+      {hasAllocations && results && results.length > 0 && (
         <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
           <table className="lib-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
             <thead>


### PR DESCRIPTION
## Summary

After research with Dan (see [docs/specs/afternoon-execution-plan-2026-05-24.md §PR-2](docs/specs/afternoon-execution-plan-2026-05-24.md)), /portfolio collapses to the wallet-scoped view of your funds. Forward-looking + educational surfaces move to where they belong.

- **RegimePanel** gets a `compact` prop. /portfolio shows the small pill in the page header; /learnings keeps the full educational breakdown (VIX + MA cross + transition probabilities).
- **PortfolioAdvisor** render removed from /portfolio (forward-looking; belongs on /generate). Component file + backend endpoint untouched — follow-up issue tracks relocation.
- **StressScenarioPanel** render removed from /portfolio (vault-allocation plumbing isn't wired yet; rendering the demo allocation as if it were the user's was the source of the phantom \"6 vaults / \$10.11 AUM\" Dan flagged). Component file ships an honest empty-state improvement for whoever re-wires it in DepositFlow.
- Status strip: \"Total AUM\" (system-wide, meaningless on a personal page) → **\"Your AUM\"** (wallet-scoped from `getVaultsByCreator`). 4 cards → 3.
- \"Your Vaults\" → **\"Vault Marketplace\"** (it was always rendering all vaults from `/api/vaults/`, not just the user's). \"Your Vault Positions\" below keeps its accurate label.

Less is more. The page now does one thing: \"these are your funds and their current state.\"

## Test plan

- [x] `npm run lint` → no new errors in changed files (pre-existing empty-catch warnings + exhaustive-deps stale dep list belong to the upcoming ESLint cleanup PR)
- [ ] Local dev server walkthrough at http://localhost (wallet connected vs disconnected; with vs without vaults)
- [ ] Compact regime pill renders correctly on /portfolio header
- [ ] Full RegimePanel renders on /learnings with explainer copy
- [ ] /portfolio with no wallet → still shows Vault Marketplace + Agent status (no \"Your Vault Positions\" section)
- [ ] Confirm no console errors during 30s polling cycle

## Follow-ups (out of scope here)

- Tech-debt issue: move PortfolioAdvisor to /generate as a preview-before-deploy surface
- StressScenarioPanel re-wiring: plumb real vault allocations from DepositFlow → render real stress matrix per vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)