### PR TITLE
[infra] PR-ENV: complete archimedes env + close starlette CVE PYSEC-2026-161

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,27 @@ ruff format .                      # apply formatting (line-length 120)
 The `--unsafe-fixes` flag should be reviewed line-by-line — those fixes need
 human judgment and are not auto-applied in CI or pre-commit.
 
+### Supply-chain scrutiny — dependency hygiene
+
+We don't bring on new dependencies casually, and we re-check the ones we have. Three
+practices:
+
+| Tool | Command | When to run |
+| --- | --- | --- |
+| `pip-audit` | `pip-audit` (whole env) or `pip-audit -r backend/requirements.txt` (declared only) | Before every PR that bumps or adds a Python dep. Once a week as background hygiene. |
+| `npm audit` | `cd ui && npm audit --omit=dev` (prod only) or `npm audit` (full) | Before every PR that bumps a Node dep. Dependabot also alerts asynchronously. |
+| Dependabot | Auto — see open dependabot PRs in the repo | Always-on. Triage promptly; don't let CVE PRs sit. |
+
+Three rules:
+
+- **Pin transitively-vulnerable deps directly when CVEs warrant it.** Example: `starlette>=1.0.1` is in `environment.yml` + `backend/requirements.txt` to close PYSEC-2026-161 (Host-header bypass) even though it would otherwise come transitively from FastAPI. When `pip-audit` flags a CVE in a transitive dep, add a direct pin to the closest `Fix Versions` so a fresh resolution can't regress.
+- **Keep `environment.yml` (local dev) and `backend/requirements.txt` (Docker / CI) aligned.** Drift is the most common source of "works on my machine" + "breaks in CI" — see the `slowapi` and `redis` misalignment that caused 62 user_routes test errors locally on 2026-05-24. Any new pip dep goes in BOTH files in the same PR.
+- **No new dep without a sentence on what it does + why we picked it.** Comments in the requirements / env files are how future readers (us in a week) understand the trust surface. "added by tooling" is not a sentence.
+
+**Frontend**: `npm ci` (used by both `quality-gate.yml` lint-report and local `ui/` setup) verifies `package-lock.json` integrity — that's the lockfile hash check we rely on for transitive integrity. Don't `npm install` (which can mutate the lockfile); always `npm ci`.
+
+**Pre-commit + detect-secrets** are tracked as separate hardening (issue TS.7 / #176-adjacent) — not implemented today.
+
 ### Smoke-test before deploy
 
 Don't push to shared infrastructure without smoke-testing locally first. If the deploy is a

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,10 @@
 
 # Web backend
 fastapi>=0.115
+# Pinned directly to close PYSEC-2026-161 (Host-header validation bypass);
+# FastAPI's transitive range can resolve to vulnerable starlette 1.0.0
+# without this floor.
+starlette>=1.0.1
 uvicorn[standard]>=0.32
 sqlalchemy>=2.0
 psycopg2-binary>=2.9

--- a/environment.yml
+++ b/environment.yml
@@ -7,19 +7,25 @@ dependencies:
   - pip
   - uv          # Modern, fast Python package + tool installer (used for arc-canteen and dev tooling)
   - git
+  - nodejs>=22  # Frontend toolchain (npm, npx). Required for `npm run lint`,
+                # `npm run dev`, `npm run build` in ui/. Without this, devs
+                # have to install Node separately and CI-vs-local parity
+                # breaks (the ESLint gate runs in CI only).
 
   # Python deps installed via pip — pinned loosely; tighten in pyproject.toml as the project firms up.
   - pip:
       # --- Web backend ---
       - fastapi>=0.115
+      - "starlette>=1.0.1"            # Pinned directly to close PYSEC-2026-161 (Host-header validation bypass); FastAPI's range can resolve to vulnerable 1.0.0 without this floor.
       - "uvicorn[standard]>=0.32"
       - sqlalchemy>=2.0
       - psycopg2-binary>=2.9          # PostgreSQL driver (binary wheel; no system pq needed)
       - alembic>=1.13                 # DB migrations
-      - redis>=5.0                    # Redis client for live regime/state cache
+      - redis>=7.4.0                  # Redis client for live regime/state cache (aligned with backend/requirements.txt)
       - pydantic>=2.9
       - pydantic-settings>=2.5
       - python-dotenv>=1.0
+      - "slowapi>=0.1.9"              # FastAPI rate-limiter — required by api/limiter.py + user_routes.py. CI installs from backend/requirements.txt; this keeps local dev parity.
 
       # --- Data + numerics ---
       - numpy>=1.26,<2.0              # Pin <2 until backtrader compatibility is verified
@@ -58,6 +64,7 @@ dependencies:
       - pytest-asyncio>=0.24
       - pytest-cov>=5.0
       - mypy>=1.11
+      - "pip-audit>=2.7"              # Supply-chain CVE scanner — run `pip-audit` to check installed deps against the PyPI vulnerability DB. Not yet a CI gate; advisory only.
 
       # --- Dev convenience ---
       - ipython>=8.27


### PR DESCRIPTION
## Summary

Two coupled hygiene improvements driven by Dan's afternoon ask (\"absolutely everything we need\" + \"rigorously scrutinize our deps to mitigate supply-chain attacks\").

### environment.yml additions
- **`nodejs>=22`** (conda) — the frontend toolchain. Without it, `npm run lint`, `npm run dev`, `npm run build` all fail locally, devs install Node separately, and CI-vs-local parity breaks (the ESLint gate runs in CI only). Surfaced today when my pre-commit local lint attempt failed.
- **`slowapi>=0.1.9`** (pip) — required by `api/limiter.py` + `user_routes.py`. CI installs from `backend/requirements.txt` where this already lives; the conda env was missing it, causing 62 user_routes test errors locally today.
- **`pip-audit>=2.7`** — supply-chain CVE scanner against PyPI's vulnerability DB. Advisory only; not a CI gate yet.

### Version alignment
- `redis` bumped `>=5.0` → `>=7.4.0` to match `backend/requirements.txt`.

### Supply-chain fix (real CVE)
- **`starlette>=1.0.1`** pinned directly in BOTH `environment.yml` and `backend/requirements.txt` to close **PYSEC-2026-161** (\"Missing Host header validation poisons request.url.path, bypassing path-based security checks\"). FastAPI's transitive range was resolving to vulnerable starlette 1.0.0 without this floor.
- After this pin: `pip-audit` → **No known vulnerabilities found**. `npm audit --omit=dev` → already clean.

### Docs
- New CLAUDE.md \"Supply-chain scrutiny\" section: pip-audit + npm audit + Dependabot triage cadence; rule on pinning transitively-vulnerable deps directly; rule on keeping `environment.yml` + `backend/requirements.txt` aligned; rule on documenting *why* a new dep was picked.

## Test plan

- [x] `pip-audit --requirement backend/requirements.txt` → No known vulnerabilities found
- [x] `pip-audit` (full env, after starlette 1.0.0 → 1.0.1) → No known vulnerabilities found
- [x] `cd ui && npm audit --omit=dev` → found 0 vulnerabilities
- [x] `ruff format --check .` + `ruff check --select E9,F63,F7,F40,F82 .` → all green (no Python changes)
- [ ] Cold-clone reproduction: `mamba env create -f environment.yml && conda activate archimedes && which node && python -c \"import slowapi; print(slowapi.__version__)\"` — verify on a fresh shell after merge

## Out of scope (tracked separately)

- Pre-commit + `detect-secrets` hardening (issue TS.7 / #176-adjacent)
- Promoting `pip-audit` from advisory → blocking CI gate
- SBOM generation + signing
- Frontend dev-deps audit (currently `--omit=dev` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)