### PR TITLE
[frontend] PR-3: Wallet menu dropdown + Profile view/edit !minor

### DIFF
--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -39,6 +39,7 @@ export default function Layout({ page, setPage, walletAddr, onConnect, onDisconn
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [userProfile, setUserProfile] = useState(null)
   const [showWelcomeModal, setShowWelcomeModal] = useState(false)
+  const [showEditProfile, setShowEditProfile] = useState(false)
   const blockLabel = Object.keys(NEW_CONTRACTS).length ? 'Arc · Testnet live' : 'Arc · Connecting'
 
   const API_BASE = import.meta.env.VITE_API_BASE ?? ''
@@ -70,6 +71,11 @@ export default function Layout({ page, setPage, walletAddr, onConnect, onDisconn
 
   const handleWelcomeDone = (profile) => {
     setShowWelcomeModal(false)
+    if (profile) setUserProfile(profile)
+  }
+
+  const handleEditProfileDone = (profile) => {
+    setShowEditProfile(false)
     if (profile) setUserProfile(profile)
   }
 
@@ -169,12 +175,9 @@ export default function Layout({ page, setPage, walletAddr, onConnect, onDisconn
             <Breadcrumbs page={page} setPage={setPage} />
           </div>
           <div className="flex items-center gap-2">
-            {/* Personalized greeting when profile set */}
-            {walletAddr && displayName && (
-              <span className="caption text-[var(--text-3)]" style={{ whiteSpace: 'nowrap' }}>
-                Welcome, <strong className="text-[var(--text-1)]">{displayName}</strong>
-              </span>
-            )}
+            {/* Personalized greeting moved into the WalletConnect dropdown
+                header so the topbar stays compact + the greeting lives next
+                to the wallet identity it belongs to. */}
             {onOpenTour && (
               <button
                 type="button"
@@ -186,7 +189,13 @@ export default function Layout({ page, setPage, walletAddr, onConnect, onDisconn
                 <span className="i-lucide-help-circle" style={{width:18,height:18}} />
               </button>
             )}
-            <WalletConnect address={walletAddr} onConnect={onConnect} onDisconnect={onDisconnect} />
+            <WalletConnect
+              address={walletAddr}
+              displayName={displayName}
+              onConnect={onConnect}
+              onDisconnect={onDisconnect}
+              onEditProfile={() => setShowEditProfile(true)}
+            />
           </div>
         </div>
         <main className={`page-content page-${page}`}>{children}</main>
@@ -197,6 +206,16 @@ export default function Layout({ page, setPage, walletAddr, onConnect, onDisconn
         <WelcomeProfileModal
           walletAddr={walletAddr}
           onDone={handleWelcomeDone}
+        />
+      )}
+
+      {/* Edit profile modal — triggered from the wallet menu dropdown */}
+      {showEditProfile && walletAddr && (
+        <WelcomeProfileModal
+          walletAddr={walletAddr}
+          onDone={handleEditProfileDone}
+          mode="edit"
+          existingProfile={userProfile}
         />
       )}
     </div>

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -1,13 +1,30 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { connectWallet, getAvailableProviders } from '../config'
 
-export default function WalletConnect({ address, onConnect, onDisconnect }) {
+export default function WalletConnect({ address, displayName, onConnect, onDisconnect, onEditProfile }) {
   const [showModal, setShowModal] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef(null)
 
   const available = getAvailableProviders()
+
+  // Close the connected-wallet dropdown on outside click or Escape.
+  useEffect(() => {
+    if (!menuOpen) return undefined
+    const onDocClick = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false)
+    }
+    const onKey = (e) => { if (e.key === 'Escape') setMenuOpen(false) }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [menuOpen])
 
   const handleConnect = async (providerId) => {
     setBusy(true)
@@ -23,10 +40,83 @@ export default function WalletConnect({ address, onConnect, onDisconnect }) {
   }
 
   if (address) {
+    const shortAddr = `${address.slice(0, 6)}…${address.slice(-4)}`
     return (
-      <div className="wallet-chip" onClick={onDisconnect} title="Click to disconnect">
-        <span className="dot" />
-        <span>{address.slice(0, 6)}…{address.slice(-4)}</span>
+      <div className="wallet-menu" ref={menuRef} style={{ position: 'relative' }}>
+        <button
+          type="button"
+          className="wallet-chip"
+          onClick={() => setMenuOpen(v => !v)}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          title={displayName ? `${displayName} · ${shortAddr}` : shortAddr}
+        >
+          <span className="dot" />
+          <span>{displayName || shortAddr}</span>
+          <span
+            className={`i-lucide-chevron-${menuOpen ? 'up' : 'down'}`}
+            style={{ width: 14, height: 14, marginLeft: 4 }}
+            aria-hidden="true"
+          />
+        </button>
+        {menuOpen && (
+          <div
+            className="wallet-dropdown"
+            role="menu"
+            style={{
+              position: 'absolute',
+              right: 0,
+              top: 'calc(100% + 6px)',
+              minWidth: 220,
+              background: 'var(--surface-1)',
+              border: '1px solid var(--glass-border)',
+              borderRadius: 10,
+              boxShadow: '0 10px 30px rgba(0,0,0,0.45)',
+              padding: 6,
+              zIndex: 50,
+            }}
+          >
+            <div
+              className="caption"
+              style={{ padding: '6px 10px', color: 'var(--text-4)', borderBottom: '1px solid var(--glass-border)', marginBottom: 4 }}
+            >
+              <div style={{ color: 'var(--text-2)', fontWeight: 600, fontSize: '0.85rem' }}>
+                {displayName || 'Wallet'}
+              </div>
+              <div className="mono" style={{ fontSize: '0.72rem' }}>{shortAddr}</div>
+            </div>
+            <button
+              type="button"
+              role="menuitem"
+              className="wallet-menu-item"
+              onClick={() => { setMenuOpen(false); onEditProfile?.() }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                width: '100%', padding: '8px 10px', textAlign: 'left',
+                background: 'transparent', border: 'none', color: 'var(--text-1)',
+                fontSize: '0.85rem', cursor: 'pointer', borderRadius: 6,
+              }}
+            >
+              <span className="i-lucide-user-pen" style={{ width: 16, height: 16 }} />
+              <span>Profile</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="wallet-menu-item"
+              onClick={() => { setMenuOpen(false); onDisconnect?.() }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                width: '100%', padding: '8px 10px', textAlign: 'left',
+                background: 'transparent', border: 'none', color: 'var(--text-1)',
+                fontSize: '0.85rem', cursor: 'pointer', borderRadius: 6,
+              }}
+            >
+              <span className="i-lucide-log-out" style={{ width: 16, height: 16 }} />
+              <span>Disconnect</span>
+            </button>
+          </div>
+        )}
       </div>
     )
   }

--- a/ui/src/components/WelcomeProfileModal.jsx
+++ b/ui/src/components/WelcomeProfileModal.jsx
@@ -6,15 +6,22 @@ const STORAGE_PREFIX = 'archimedes.welcomeProfileSeen.'
 
 const INTEREST_OPTIONS = ['Equities', 'Bonds', 'Commodities', 'Crypto', 'FX']
 
-// WelcomeProfileModal — appears once on first wallet connect.
-// All fields optional. User can Skip to dismiss without saving.
-// After Submit or Skip, localStorage gate prevents re-showing.
-export default function WelcomeProfileModal({ walletAddr, onDone }) {
-  const [displayName, setDisplayName] = useState('')
-  const [email, setEmail] = useState('')
-  const [selectedInterests, setSelectedInterests] = useState([])
-  const [attribution, setAttribution] = useState('')
-  const [marketingOptIn, setMarketingOptIn] = useState(false)
+// WelcomeProfileModal — two modes:
+//   `mode="welcome"` (default): first wallet-connect prompt. Has a "Skip"
+//     button; on submit OR skip, sets the localStorage gate so it never
+//     re-shows for this wallet.
+//   `mode="edit"`: invoked from the wallet menu dropdown to view + edit
+//     an existing profile. Pre-fills from `existingProfile`. Has Cancel
+//     instead of Skip; never touches the localStorage gate.
+//
+// All fields remain optional in both modes.
+export default function WelcomeProfileModal({ walletAddr, onDone, mode = 'welcome', existingProfile = null }) {
+  const isEdit = mode === 'edit'
+  const [displayName, setDisplayName] = useState(existingProfile?.display_name || '')
+  const [email, setEmail] = useState(existingProfile?.email || '')
+  const [selectedInterests, setSelectedInterests] = useState(existingProfile?.interests || [])
+  const [attribution, setAttribution] = useState(existingProfile?.attribution || '')
+  const [marketingOptIn, setMarketingOptIn] = useState(existingProfile?.marketing_opt_in || false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
 
@@ -27,12 +34,16 @@ export default function WelcomeProfileModal({ walletAddr, onDone }) {
   }
 
   const markSeen = () => {
+    // Edit mode never touches the gate — only the welcome flow sets it.
+    if (isEdit) return
     if (walletAddr) {
       localStorage.setItem(STORAGE_PREFIX + walletAddr.toLowerCase(), '1')
     }
   }
 
-  const handleSkip = () => {
+  const handleCancel = () => {
+    // Welcome mode: cancel = skip, sets the gate.
+    // Edit mode: cancel = dismiss, no gate change.
     markSeen()
     onDone?.()
   }
@@ -80,14 +91,15 @@ export default function WelcomeProfileModal({ walletAddr, onDone }) {
         style={{ background: 'var(--surface-1)', maxHeight: '90vh', overflowY: 'auto' }}
       >
         <div className="caption mb-2 uppercase tracking-wider text-[var(--text-4)]">
-          Welcome to Archimedes
+          {isEdit ? 'Your Profile' : 'Welcome to Archimedes'}
         </div>
         <h3 id="welcome-modal-title" className="font-serif text-[1.5rem] mb-1">
-          Personalize your experience
+          {isEdit ? 'Edit your profile' : 'Personalize your experience'}
         </h3>
         <p className="caption mb-4 leading-relaxed">
-          All fields are optional. Your wallet is your identity — this just helps
-          us show a friendly name and tailor the experience. You can skip this entirely.
+          {isEdit
+            ? 'Update what we show alongside your wallet. All fields remain optional; leave any blank to clear it.'
+            : 'All fields are optional. Your wallet is your identity — this just helps us show a friendly name and tailor the experience. You can skip this entirely.'}
         </p>
 
         <div className="grid grid-cols-1 gap-3">
@@ -164,17 +176,17 @@ export default function WelcomeProfileModal({ walletAddr, onDone }) {
         <div className="flex justify-between gap-3 mt-5">
           <button
             className="btn btn-outline"
-            onClick={handleSkip}
+            onClick={handleCancel}
             disabled={submitting}
           >
-            Skip for now
+            {isEdit ? 'Cancel' : 'Skip for now'}
           </button>
           <button
             className="btn btn-primary"
             onClick={handleSubmit}
             disabled={submitting}
           >
-            {submitting ? 'Saving…' : 'Save Profile'}
+            {submitting ? 'Saving…' : (isEdit ? 'Save Changes' : 'Save Profile')}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Clicking the wallet button no longer disconnects you outright. Instead it opens a small dropdown menu with two items — **Profile** (opens WelcomeProfileModal in edit mode, pre-filled with current values) and **Disconnect**. Fixes the \"I clicked the address by accident and lost my session\" usability gap, and gives users a way to review + change the profile they entered on first connect.

## Changes

- **WalletConnect.jsx** — connected-state chip is now a button with a dropdown menu (outside-click + Escape close it). New props: `displayName`, `onEditProfile`.
- **WelcomeProfileModal.jsx** — new `mode='edit'` variant pre-fills from `existingProfile` prop, shows \"Save Changes\" / \"Cancel\" instead of welcome-flow copy, and never touches the localStorage seen-gate.
- **Layout.jsx** — new `showEditProfile` state; renders a second `<WelcomeProfileModal mode=\"edit\">` when triggered from the menu. Standalone topbar \"Welcome, <name>\" greeting removed (now in the dropdown header next to the wallet identity).

## Why `!minor`

New user-facing capability (wallet menu surface + profile-edit flow), per the CLAUDE.md release-tag convention.

## Test plan

- [x] `npm run lint` → 0 errors, 0 warnings
- [ ] Browser walkthrough on http://localhost:
  - Connect wallet (cold profile) → first-time WelcomeProfileModal still pops; Submit Alice → modal closes; dropdown shows \"Alice\" in chip
  - Click the wallet chip → dropdown opens with Alice + 0x… header and Profile + Disconnect items
  - Click anywhere outside the dropdown → closes
  - Press Escape with dropdown open → closes
  - Click Profile → edit modal pops pre-filled with Alice/etc; change name to Bob → Save Changes → chip updates to Bob
  - Click Profile → edit modal pops with Bob; Cancel → no change persisted
  - Click Disconnect → returns to disconnected state, Connect Wallet button visible
- [ ] Confirm welcome-flow seen-gate still works (reload after first save → welcome modal does NOT re-open)
- [ ] Confirm edit-modal NEVER sets the seen-gate (`localStorage.getItem('archimedes.welcomeProfileSeen.<addr>')` is unchanged after edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)