### PR TITLE
[ui] Resurrect PortfolioAdvisor on /generate as preview-before-deploy banner

### DIFF
--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -158,8 +158,13 @@ a strategy** (no wallet required).
 
 **Surfaces:** the natural-language brief input + optional structured inputs (asset
 class, risk, horizon) + the 3-input fusion preview ("what fusion will see") + the
-result card (strategy spec, citations, rigor verdict, deploy CTA). See Prompt 3 in
-[`claude-design-prompts.md`](claude-design-prompts.md) for the screen design.
+result card (strategy spec, citations, rigor verdict, deploy CTA) + the
+**Portfolio Advisor preview banner** (rendered after a candidate completes — shows
+Kelly + risk-parity allocation, DSR/PBO/walk-forward OOS rigor counters, six-scenario
+stress matrix, variance decomposition, correlation pairs, and the keccak reasoning-trace
+hash for the proposed portfolio — all *before* the user commits any funds). See
+Prompt 3 in [`claude-design-prompts.md`](claude-design-prompts.md) for the screen
+design.
 
 ### `/portfolio` My Portfolio (consolidates current Trade + Vaults + personalized Risk view)
 

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -3,6 +3,7 @@ import { StrategyArchitect } from './Strategies'
 import GenerationStream from './GenerationStream'
 import GenerationStatus from './GenerationStatus'
 import FusionResult from './FusionResult'
+import PortfolioAdvisor from './PortfolioAdvisor'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -288,12 +289,28 @@ export default function Generate({ onNavigate }) {
             </div>
           )}
           {!libLoading && !libError && <StrategyArchitect strategies={strategies} />}
+          {/* Preview-before-deploy: same advisor on the architect path so
+              users get the rigor-gate + Kelly sizing + stress + correlation
+              view before any commit. Issue #210. */}
+          {!libLoading && !libError && (
+            <div className="mt-6">
+              <PortfolioAdvisor initialRiskProfile={riskAppetite} />
+            </div>
+          )}
         </div>
       )}
 
       {pipelineFromEvent === 'fusion' && fusionResult && (
         <>
           <FusionResult result={fusionResult} onNavigate={onNavigate} />
+          {/* Preview-before-deploy: show the user what the Portfolio
+              Construction Agent would allocate for the same brief BEFORE
+              they commit funds. Same risk profile they just selected;
+              they can flip profiles in the advisor's own selector if
+              they want to compare. Issue #210. */}
+          <div className="mt-6">
+            <PortfolioAdvisor initialRiskProfile={riskAppetite} />
+          </div>
           <div className="mt-4">
             <button className="btn btn-outline btn-sm" onClick={resetFusion}>
               Fuse another →

--- a/ui/src/components/PortfolioAdvisor.jsx
+++ b/ui/src/components/PortfolioAdvisor.jsx
@@ -79,8 +79,13 @@ function AllocationBar({ label, weight, isUsdc, kelly, rigorPassed, isCandidate 
   )
 }
 
-export default function PortfolioAdvisor() {
-  const [selectedProfile, setSelectedProfile] = useState('moderate')
+export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {}) {
+  // initialRiskProfile lets a parent page (e.g. /generate's preview banner)
+  // pre-select the profile from the brief the user already typed, so the
+  // preview reflects "what would the agent allocate me for the brief I
+  // submitted" without forcing the user to re-pick. The user can still
+  // switch profiles in the existing selector below.
+  const [selectedProfile, setSelectedProfile] = useState(initialRiskProfile)
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')


### PR DESCRIPTION
Closes #210.

## Summary

The PortfolioAdvisor component file (`ui/src/components/PortfolioAdvisor.jsx`) and its backend endpoint (`/api/strategies/advisor`) were both left as dead code on main when PR-2 (#208) removed the render from `/portfolio`. This PR re-wires the component on `/generate`, positioned **after** a strategy candidate lands and **before** the user clicks "Deploy as Vault" — the preview-before-deploy surface that #210 specified.

## Changes

| File | Change |
|---|---|
| `ui/src/components/PortfolioAdvisor.jsx` | Accept optional `initialRiskProfile` prop (defaults to `'moderate'`). Pre-selects the same risk profile the user typed in the `/generate` brief, so the preview is consistent. **No visual change**. |
| `ui/src/components/Generate.jsx` | Import + render `<PortfolioAdvisor initialRiskProfile={riskAppetite} />` on both pipeline paths (fusion + architect) after the result card lands. |
| `docs/user-stories.md` | One-sentence addition to the `/generate` surfaces description per #210's acceptance criterion. |

## The quant-lane voice on why this matters

I think this needs to be shown for transparency and clarity. That's what makes us unique as a team.

The math behind the advisor — Kelly + covariance-aware Markowitz with γ-mapped risk aversion, Magdon-Ismail closed-form expected max-drawdown, six-scenario stress engine with coverage tracking, Euler variance decomposition, top-N correlation pairs, and the deterministic keccak reasoning-trace hash — is precisely the rigor that distinguishes Archimedes from generic AI-portfolio submissions. Surfacing it **before** the deposit flow lets the user inspect exactly what their funds will do, which papers anchor each pick, and which historical stress scenarios their portfolio survives (or doesn't) — all before they sign a single transaction. That visibility is the wedge our pitch is built on; hiding it costs us the credibility we earned by implementing it.

## Acceptance (per #210)

- [x] `PortfolioAdvisor.jsx` imported + rendered on `/generate` (both fusion and architect paths)
- [x] No render on `/portfolio` (untouched here; already removed by #208)
- [x] `/api/strategies/advisor` continues to work; no schema changes
- [x] One short docs sentence in `docs/user-stories.md`

## Anti-goals respected (per #210)

- No visual redesign of PortfolioAdvisor (the `initialRiskProfile` prop is behavior-only).
- No new endpoints.

## Verify locally

```bash
# Run the UI; head to /generate; submit a brief; confirm the advisor
# preview card renders after the result card on both pipeline paths.
cd ui && npm run dev

# Backend endpoint smoke
curl -s 'http://13.40.112.220/api/strategies/advisor?risk_profile=moderate' \
  | jq '{regime, agent_used: .agent.used, picks: (.allocations | length), rigor_passed: .rigor_summary.passes_rigor_gate, stress_count: (.stress_tests | length), trace_hash: .reasoning_trace.trace_hash}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)