### PR TITLE
[frontend] PR-LIB-CORR: remove fake Library Correlation matrix

### DIFF
--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import CustomSelect from './CustomSelect'
 import EfficientFrontier from './EfficientFrontier'
-import CorrelationMatrix from './CorrelationMatrix'
 import RigorExplainer from './RigorExplainer'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
@@ -759,11 +758,9 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
         </div>
       )}
 
-      {/* Page-level analytics panels — moved from Reasoning per page-roles-spec.
-          CorrelationMatrix highlights the deep-linked row when present. */}
+      {/* Page-level analytics panels — moved from Reasoning per page-roles-spec. */}
       <div className="mt-8 flex flex-col gap-4">
         <EfficientFrontier />
-        <CorrelationMatrix selectedStrategyId={highlightStrategyId || null} />
       </div>
 
       {/* Rigor Explainer modal (portal-rendered, page-level) */}


### PR DESCRIPTION
## Summary

Deletes the `<CorrelationMatrix>` widget render on the Library page (`ui/src/components/Strategies.jsx`). The component rendered a 6x6 table of mostly 1.00 values plus a column of 0.14, with a footnote literally admitting "Returns simulated from backtest summary statistics. Raw daily series not stored in fixture file." Reads as fake data presented as analysis — clear trust-hit risk if a judge inspects the page.

Part of the post-red-team junk hunt: surfaces of the product that look quantitative-but-aren't get removed until they can be backed by real data.

## Scope

- Remove the `import CorrelationMatrix from './CorrelationMatrix'` line.
- Remove the `<CorrelationMatrix selectedStrategyId={...} />` render call from the page-level analytics panel block (EfficientFrontier stays).
- `CorrelationMatrix.jsx` is **not** deleted — kept for potential re-use once we persist real daily series. What replaces it on Library is a separate design decision.

## Test plan

- [ ] `cd ui && npm run lint` exits 0 (verified locally: 0 errors).
- [ ] Library page renders without the correlation table; `EfficientFrontier` still renders below the strategy grid.
- [ ] No console errors / broken imports.
- [ ] `git grep CorrelationMatrix ui/src/components/Strategies.jsx` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)