### PR TITLE
[frontend] PR-TRUST-TITLES: trust copy on Connect Wallet + per-page titles + breadcrumb rename

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -149,6 +149,24 @@ export default function App() {
   const backToPortfolio = () => navigateToPage('portfolio', { vaultAddress: null })
   const selectTrace = (id) => navigateToPage('reasoning', { replace: false, traceId: id })
 
+  // Per-route document.title so browser tabs are distinguishable when users
+  // have multiple Archimedes tabs open.
+  useEffect(() => {
+    const titles = {
+      landing:        'Archimedes',
+      explore:        'Explore · Archimedes',
+      generate:       'Generate · Archimedes',
+      library:        'Library · Archimedes',
+      corpus:         'Corpus · Archimedes',
+      portfolio:      'Portfolio · Archimedes',
+      reasoning:      'Reasoning · Archimedes',
+      learnings:      'Learnings · Archimedes',
+      'vault-detail': 'Vault · Archimedes',
+      strategy:       'Strategy · Archimedes',
+    }
+    document.title = titles[page] ?? 'Archimedes'
+  }, [page])
+
   useEffect(() => {
     if (!initialRoute.matched) {
       window.history.replaceState({}, '', '/')

--- a/ui/src/components/Breadcrumbs.jsx
+++ b/ui/src/components/Breadcrumbs.jsx
@@ -8,6 +8,9 @@
 
 import { PAGE_LABELS } from './Layout'
 
+// `group: null` means "no intermediate label" — breadcrumb reads "Home / <page>".
+// Dropped the "Intelligence" grouping (M5): users don't know what the internal
+// grouping means, so the corpus/reasoning/risk pages now render a flat trail.
 const CRUMB_MAP = {
   explore:      { group: 'Markets', groupPage: 'explore' },
   strategies:   { group: 'Markets', groupPage: 'explore' },
@@ -19,10 +22,10 @@ const CRUMB_MAP = {
   'create-vault': { group: 'Portfolio', groupPage: 'vaults' },
   financial:    { group: 'Portfolio', groupPage: 'dashboard' },
   'vault-detail': { group: 'Portfolio', groupPage: 'vaults' },
-  reasoning:       { group: 'Intelligence', groupPage: 'reasoning' },
-  risk:            { group: 'Intelligence', groupPage: 'reasoning' },
-  corpus:          { group: 'Intelligence', groupPage: 'reasoning' },
-  'rigor-explainer': { group: 'Intelligence', groupPage: 'reasoning' },
+  reasoning:       { group: null, groupPage: null },
+  risk:            { group: null, groupPage: null },
+  corpus:          { group: null, groupPage: null },
+  'rigor-explainer': { group: null, groupPage: null },
 }
 
 export default function Breadcrumbs({ page, setPage }) {
@@ -31,7 +34,7 @@ export default function Breadcrumbs({ page, setPage }) {
 
   const crumbs = [
     { label: 'Home', page: 'explore' },
-    { label: info.group, page: info.groupPage },
+    ...(info.group ? [{ label: info.group, page: info.groupPage }] : []),
     { label: PAGE_LABELS[page] ?? page, page: null },
   ]
 

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -133,6 +133,31 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
             <h3>Connect Wallet</h3>
             <p className="caption">Select a wallet to interact with Arc Testnet contracts.</p>
 
+            <div
+              className="caption"
+              style={{
+                marginTop: 8,
+                marginBottom: 12,
+                padding: '10px 12px',
+                background: 'var(--surface-1)',
+                border: '1px solid var(--glass-border)',
+                borderRadius: 8,
+                lineHeight: 1.5,
+              }}
+            >
+              Archimedes only reads your wallet address — it never custodies your USDC.
+              Deposits live in your non-custodial vault contract; the agent has rebalance
+              authority only, not withdraw-to-platform. Source open at{' '}
+              <a
+                href="https://github.com/a-apin/archimedes-arcadia"
+                target="_blank"
+                rel="noreferrer"
+              >
+                github.com/a-apin/archimedes-arcadia
+              </a>
+              . Testnet only — fake USDC, no value at risk.
+            </div>
+
             {available.length === 0 ? (
               <div className="info-box warning mt-3">
                 No wallets detected. Install <a href="https://metamask.io" target="_blank" rel="noreferrer">MetaMask</a> or{' '}


### PR DESCRIPTION
## Summary

Three small UI fixes from the 2026-05-24 PM red-team report.

- **M6 — Connect Wallet trust signals.** The wallet modal previously had one bare caption line. It now leads with a small trust block: non-custodial posture (Archimedes only reads your wallet address, deposits live in your non-custodial vault contract, agent has rebalance authority only — not withdraw-to-platform), a source link to `github.com/a-apin/archimedes-arcadia`, and the testnet-only disclaimer. Trust is the load-bearing moment in a wallet-connect flow; this gives users something to verify before they click.

- **M7 — Per-route document.title.** Every page had the same browser tab title ("Archimedes — Paper-Grounded Portfolio Agent on Arc"). `App.jsx` now sets `document.title` per route on every page change via a small `useEffect`: `Explore · Archimedes`, `Generate · Archimedes`, `Library · Archimedes`, `Corpus · Archimedes`, `Portfolio · Archimedes`, `Reasoning · Archimedes`, `Learnings · Archimedes`, `Vault · Archimedes`, `Strategy · Archimedes`. Landing stays plain `Archimedes`.

- **M5 — Drop the "Intelligence" breadcrumb group.** The breadcrumb on Corpus/Reasoning/Risk pages read `Home / Intelligence / Corpus` — "Intelligence" is an internal grouping label users don't recognize. Removed it entirely: the trail now reads `Home / Corpus` (and `Home / Reasoning`, `Home / Risk`). Implemented via `group: null` in `CRUMB_MAP` so the intermediate crumb is skipped via a spread; the same code path still serves the `Markets` and `Portfolio` groups unchanged.

## Test plan

- [x] `npm run lint` in `ui/` → 0 errors / 0 warnings
- [ ] Manual: open `/corpus`, confirm breadcrumb reads `Home / Corpus`
- [ ] Manual: click Connect Wallet, confirm trust block is visible above wallet options
- [ ] Manual: navigate between routes, confirm browser tab title updates per page

## Anti-goals

- No changes to wallet detection logic (Circle SDK is a separate PR)
- No backend changes
- No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)