### PR TITLE
[frontend+backend] PR-REGIME-HONEST: hide null signal rows + show strategy names instead of hashes

### DIFF
--- a/backend/archimedes/api/regime_routes.py
+++ b/backend/archimedes/api/regime_routes.py
@@ -45,6 +45,7 @@ async def get_current_regime():
         all_strats = strategy_provider.list_strategies()
         regime_keywords = regime_to_keywords.get(regime_value, [])
         recommended_ids: list[str] = []
+        recommended_titles: list[str] = []
         for keyword in regime_keywords:
             for s in all_strats:
                 title_lower = s.paper_title.lower().replace("_", " ")
@@ -52,7 +53,14 @@ async def get_current_regime():
                     keyword in title_lower or keyword.replace("-", "") in title_lower.replace("-", "")
                 ) and s.id not in recommended_ids:
                     recommended_ids.append(s.id)
+                    recommended_titles.append(s.paper_title)
                     break
+
+        # NOTE: do NOT coerce missing vix/* into 0.0 — see RegimeSignalsResponse
+        # docstring. None means "no data" and the UI hides the row honestly.
+        raw_vix = data.get("vix_level")
+        if raw_vix is None:
+            raw_vix = data.get("vix")
 
         return RegimeResponse(
             regime=regime_value,
@@ -60,7 +68,7 @@ async def get_current_regime():
             timestamp=data.get("timestamp", ""),
             regime_changed=data.get("regime_changed", False),
             signals=RegimeSignalsResponse(
-                vix_level=data.get("vix_level") or data.get("vix", 0.0),
+                vix_level=raw_vix,
                 sp500_above_ma50=data.get("sp500_above_ma50", True),
                 sp500_above_ma200=data.get("sp500_above_ma200", True),
                 vix_rate_of_change=data.get("vix_rate_of_change"),
@@ -74,6 +82,7 @@ async def get_current_regime():
             transition_probabilities=transitions,
             regime_history=history,
             recommended_strategies=recommended_ids[:2],
+            recommended_strategy_titles=recommended_titles[:2],
         )
 
     return RegimeResponse(
@@ -82,13 +91,14 @@ async def get_current_regime():
         timestamp="",
         regime_changed=False,
         signals=RegimeSignalsResponse(
-            vix_level=0.0,
+            vix_level=None,
             sp500_above_ma50=True,
             sp500_above_ma200=True,
         ),
         transition_probabilities=default_transitions,
         regime_history={"total": 0},
         recommended_strategies=[],
+        recommended_strategy_titles=[],
     )
 
 

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -330,10 +330,18 @@ class RegimeResponse(BaseModel):
     transition_probabilities: dict | None = None  # From get_transition_probabilities()
     regime_history: dict | None = None  # From get_regime_history_summary()
     recommended_strategies: list[str] | None = None  # Strategy IDs best for this regime
+    # Paper titles for each recommended_strategies id, in matching order.
+    # Surfaced so the UI can show "Volatility-Managed Portfolios" instead of
+    # a raw strategy hash (red-team report 2026-05-24 H3).
+    recommended_strategy_titles: list[str] | None = None
 
 
 class RegimeSignalsResponse(BaseModel):
-    vix_level: float
+    # vix_level is nullable: the VIX feed can be unavailable (no data) and we
+    # MUST NOT render that as 0.0 — VIX is a price-of-insurance index that
+    # floors around 10, so 0 is dishonest. None means "agent feed not
+    # connected" (red-team report 2026-05-24 H2).
+    vix_level: float | None = None
     sp500_above_ma50: bool
     sp500_above_ma200: bool
     vix_rate_of_change: float | None = None  # VIX momentum

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -375,6 +375,100 @@ class TestRegimeRoutes:
         assert isinstance(data["confidence"], float)
         assert "transition_probabilities" in data
 
+    def test_current_regime_unknown_signals_are_null_not_zero(self, client):
+        """Unknown-regime fallback must NOT report VIX=0 (it would be a lie).
+
+        Red-team report 2026-05-24 H2: VIX is a price-of-insurance index
+        that floors around 10, so 0.0 is not a valid reading -- it means
+        "no data". Surface that honestly as null instead of zero so the UI
+        can hide the row instead of rendering a misleading 0.0 bar.
+        """
+        resp = client.get("/api/regime/current")
+        assert resp.status_code == 200
+        data = resp.json()
+        if data["regime"] == "unknown":
+            # vix_level must be null (not 0.0) when no agent data is present
+            assert data["signals"]["vix_level"] is None
+
+    def test_current_regime_recommended_strategy_titles(self, client, monkeypatch):
+        """When Redis returns a known regime, the response must include
+        recommended_strategy_titles parallel to recommended_strategies so the
+        UI can render paper titles instead of raw strategy hashes.
+
+        Red-team report 2026-05-24 H3.
+        """
+        fake_state = {
+            "regime": "risk_off",
+            "confidence": 0.92,
+            "timestamp": "2026-05-24T12:00:00Z",
+            "regime_changed": False,
+            "vix_level": 28.5,
+            "sp500_above_ma50": False,
+            "sp500_above_ma200": True,
+            "composite_score": 0.65,
+        }
+
+        async def fake_load(self):
+            return fake_state
+
+        async def fake_close(self):
+            return None
+
+        from archimedes.services.redis_state import AgentStateStore
+
+        monkeypatch.setattr(AgentStateStore, "load_regime", fake_load)
+        monkeypatch.setattr(AgentStateStore, "close", fake_close)
+        # __init__ on AgentStateStore may try to connect to Redis; replace it
+        monkeypatch.setattr(AgentStateStore, "__init__", lambda self: None)
+
+        resp = client.get("/api/regime/current")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["regime"] == "risk_off"
+        # Parallel field present and a list
+        assert "recommended_strategy_titles" in data
+        titles = data["recommended_strategy_titles"]
+        ids = data["recommended_strategies"]
+        assert isinstance(titles, list)
+        assert isinstance(ids, list)
+        # Same length so the UI can index in parallel
+        assert len(titles) == len(ids)
+        # If any recommendations exist, titles must not be empty strings and
+        # must not look like raw strategy hashes (which are 32-char hex).
+        for t in titles:
+            assert isinstance(t, str) and len(t) > 0
+            # Strategy hashes are 32 lowercase hex chars; paper titles should
+            # contain spaces or capitals -- at least one non-hex character.
+            assert not (len(t) == 32 and all(c in "0123456789abcdef" for c in t))
+
+    def test_current_regime_vix_null_passthrough(self, client, monkeypatch):
+        """If the agent feed reports vix_level as None, the API must pass it
+        through as null -- never coerce to 0.0 (red-team 2026-05-24 H2)."""
+        from archimedes.services.redis_state import AgentStateStore
+
+        async def fake_load(self):
+            return {
+                "regime": "risk_on",
+                "confidence": 0.88,
+                "timestamp": "2026-05-24T12:00:00Z",
+                "regime_changed": False,
+                "vix_level": None,
+                "sp500_above_ma50": True,
+                "sp500_above_ma200": True,
+            }
+
+        async def fake_close(self):
+            return None
+
+        monkeypatch.setattr(AgentStateStore, "load_regime", fake_load)
+        monkeypatch.setattr(AgentStateStore, "close", fake_close)
+        monkeypatch.setattr(AgentStateStore, "__init__", lambda self: None)
+
+        resp = client.get("/api/regime/current")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["signals"]["vix_level"] is None
+
 
 class TestAgentRoutes:
     def test_agent_status(self, client):

--- a/ui/src/components/RegimePanel.jsx
+++ b/ui/src/components/RegimePanel.jsx
@@ -155,9 +155,23 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
   const transitions = regime.transition_probabilities
   const currentTransitions = transitions?.[r]
   const recommended = regime.recommended_strategies || []
+  const recommendedTitles = regime.recommended_strategy_titles || []
 
-  // VIX score: rough scale — VIX 10=calm, VIX 40=crisis
-  const vixScore = signals.vix_score ?? Math.min((signals.vix_level - 10) / 30, 1)
+  // VIX honesty (red-team 2026-05-24 H2): the agent's VIX feed reports null
+  // when no data is available. VIX is never literally 0 — it's a price-of-
+  // insurance index that floors around 10. So treat 0 (and NaN) as "no data"
+  // and refuse to render a misleading row/bar.
+  const isUsable = v => v != null && Number.isFinite(v)
+  const vixUsable = isUsable(signals.vix_level) && signals.vix_level !== 0
+  const vixRocUsable = isUsable(signals.vix_rate_of_change)
+  const compositeUsable = isUsable(signals.composite_score)
+  const anySignalUsable = vixUsable || vixRocUsable || compositeUsable
+
+  // VIX score: rough scale — VIX 10=calm, VIX 40=crisis. Only meaningful
+  // when vix_level itself is usable.
+  const vixScore = vixUsable
+    ? (signals.vix_score ?? Math.min((signals.vix_level - 10) / 30, 1))
+    : 0
   const vixBarColor = vixScore > 0.7 ? 'var(--negative)' : vixScore > 0.4 ? '#f59e0b' : 'var(--positive)'
 
   return (
@@ -204,7 +218,7 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
         <div>
           <div className="label mb-3" style={{ fontSize: '0.72rem' }}>Signal Breakdown</div>
 
-          {signals.vix_level != null && (
+          {vixUsable && (
             <div style={{ marginBottom: 10 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 3 }}>
                 <span className="caption">VIX Level</span>
@@ -214,7 +228,7 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
             </div>
           )}
 
-          {signals.vix_rate_of_change != null && (
+          {vixRocUsable && (
             <div style={{ marginBottom: 10 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 3 }}>
                 <span className="caption">VIX Momentum</span>
@@ -226,13 +240,22 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
             </div>
           )}
 
-          {signals.composite_score != null && (
+          {compositeUsable && (
             <div style={{ marginBottom: 10 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 3 }}>
                 <span className="caption">Composite Score</span>
                 <span className="mono" style={{ fontSize: '0.8rem' }}>{fmt(signals.composite_score, 2)}</span>
               </div>
               <MiniBar value={signals.composite_score} max={1} color={rColor} />
+            </div>
+          )}
+
+          {!anySignalUsable && (
+            <div
+              className="caption"
+              style={{ color: 'var(--text-4)', marginBottom: 10, fontStyle: 'italic' }}
+            >
+              Signal unavailable — agent feed not connected.
             </div>
           )}
 
@@ -263,20 +286,28 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
         </div>
       </div>
 
-      {/* Recommended strategies */}
+      {/* Recommended strategies — show paper titles, never raw hashes
+          (red-team 2026-05-24 H3). Fall back to an 8-char id prefix only if
+          the backend didn't return a title for that index. */}
       {recommended.length > 0 && (
         <div style={{ marginTop: 16, paddingTop: 14, borderTop: '1px solid rgba(255,255,255,0.08)' }}>
           <span className="caption" style={{ color: 'var(--text-3)', marginRight: 10 }}>Best strategies for this regime:</span>
-          {recommended.map(id => (
-            <span key={id} style={{
-              display: 'inline-block', marginRight: 6, padding: '2px 9px', borderRadius: 4,
-              fontSize: '0.75rem', fontWeight: 600,
-              background: 'rgba(255,255,255,0.07)', color: 'var(--text-2)',
-              border: '1px solid var(--glass-border)',
-            }}>
-              {id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
-            </span>
-          ))}
+          {recommended.map((id, i) => {
+            const title = recommendedTitles[i]
+            const label = title
+              ? title.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+              : id.slice(0, 8)
+            return (
+              <span key={id} title={title || id} style={{
+                display: 'inline-block', marginRight: 6, padding: '2px 9px', borderRadius: 4,
+                fontSize: '0.75rem', fontWeight: 600,
+                background: 'rgba(255,255,255,0.07)', color: 'var(--text-2)',
+                border: '1px solid var(--glass-border)',
+              }}>
+                {label}
+              </span>
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixes two coupled bugs from the 2026-05-24 PM red-team report on RegimePanel honesty:

- **H2** — RegimePanel was rendering "VIX Level: 0.0" while still claiming 92% confidence Risk On. The VIX feed is null in prod; rendering it as 0.0 is dishonest (VIX is a price-of-insurance index that floors around 10, so it is never literally 0). Now: backend passes `vix_level` through as `null` instead of coercing to 0.0, and the UI hides the row when the value is missing/zero/NaN. When NO signals are usable, renders an explicit "Signal unavailable — agent feed not connected" empty state.
- **H3** — RegimePanel was showing "Best strategies for this regime: 3a57a8b5a53965b3f9047e6e057058c6" — the raw strategy hash. Backend now returns a parallel `recommended_strategy_titles` field on `/api/regime/current`, and the UI renders the paper title (e.g. "Volatility-Managed Portfolios"). Falls back to an 8-char id prefix only if the backend omitted a title.

Anti-goals respected: regime classification logic untouched; the compact `CompactRegimePill` (used on `/portfolio`) unchanged — only the full panel rendering changed.

## Files touched

- `backend/archimedes/api/schemas.py` — `vix_level: float | None`; new `recommended_strategy_titles: list[str] | None` on `RegimeResponse`.
- `backend/archimedes/api/regime_routes.py` — `/current` handler populates the titles list parallel to the IDs; stops coercing missing VIX to 0.0; unknown-regime fallback returns `vix_level=None`.
- `ui/src/components/RegimePanel.jsx` — `isUsable()` + `vixUsable`/`vixRocUsable`/`compositeUsable` guards on the three signal rows; new "Signal unavailable" empty state; recommended-strategies chips render titles with id-prefix fallback.
- `backend/tests/test_api_routes.py` — three new `TestRegimeRoutes` tests covering: null-vix in the unknown-regime fallback, parallel-titles shape in a known-regime mock, and null vix passthrough when the agent feed reports `None`.

## Test plan

- [x] `cd ui && npm run lint` → 0 errors
- [x] `pytest -m "not integration" --tb=short -q -k "regime"` → 47 passed (3 new)
- [x] `ruff format --check .` → 196 files already formatted
- [x] `ruff check --select E9,F63,F7,F40,F82 .` → All checks passed
- [ ] Manual: hit a deployed `/learnings` with VIX feed disconnected → no "VIX Level: 0.0" row; recommended chips show paper titles, not hashes

Red-team source: 2026-05-24 PM report, H2 + H3.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>