### PR TITLE
[chore] ruff Tier 1 expansion (ARG, C4, PIE, RET, SLF)

### DIFF
--- a/backend/archimedes/chain/circle_signer.py
+++ b/backend/archimedes/chain/circle_signer.py
@@ -224,8 +224,7 @@ class CircleSigner:
                                         tx_hash,
                                     )
                                     return tx_hash
-                                else:
-                                    raise RuntimeError(f"Circle tx {circle_tx_id} ended in {state}: {tx}")
+                                raise RuntimeError(f"Circle tx {circle_tx_id} ended in {state}: {tx}")
                             # Still processing
                             break
                 await asyncio.sleep(_POLL_INTERVAL)

--- a/backend/archimedes/models/chat.py
+++ b/backend/archimedes/models/chat.py
@@ -18,8 +18,6 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 class Base(DeclarativeBase):
     """SQLAlchemy declarative base for all Archimedes models."""
 
-    pass
-
 
 class VaultMetadata(Base):
     """Off-chain vault metadata — strategy associations, display name, etc.

--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -379,7 +379,7 @@ def _equal_weight(symbols: list[str], budget: float) -> dict[str, float]:
     if n == 0:
         return {}
     w = round(budget / n, 6)
-    return {s: w for s in symbols}
+    return dict.fromkeys(symbols, w)
 
 
 # ─── Kelly mean-variance from price-history dict ──────────────────

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -168,7 +168,7 @@ def compute_pbo(
         Returns 0.0 for every strategy if N < 2 or data is insufficient.
     """
     if len(returns_matrix) < 2:
-        return {sid: 0.0 for sid in returns_matrix}
+        return dict.fromkeys(returns_matrix, 0.0)
 
     sorted_ids = sorted(returns_matrix.keys())
     N = len(sorted_ids)
@@ -181,7 +181,7 @@ def compute_pbo(
     S = s_partitions if (s_partitions % 2 == 0 and s_partitions >= 2) else 16
     rows_per_block = T // S
     if rows_per_block < 1:
-        return {sid: 0.0 for sid in sorted_ids}
+        return dict.fromkeys(sorted_ids, 0.0)
 
     blocks = [R[i * rows_per_block : (i + 1) * rows_per_block, :] for i in range(S)]
     half = S // 2
@@ -208,10 +208,10 @@ def compute_pbo(
         lambdas.append(lam)
 
     if not lambdas:
-        return {sid: 0.0 for sid in sorted_ids}
+        return dict.fromkeys(sorted_ids, 0.0)
 
     pbo = round(sum(1 for lam in lambdas if lam <= 0.0) / len(lambdas), 6)
-    return {sid: pbo for sid in sorted_ids}
+    return dict.fromkeys(sorted_ids, pbo)
 
 
 # ─── 3. Walk-forward OOS Sharpe ──────────────────────────────────────

--- a/backend/archimedes/services/statistical_regime.py
+++ b/backend/archimedes/services/statistical_regime.py
@@ -314,12 +314,11 @@ class StatisticalRegimeDetector:
         #   0.75 - 1.0: CRISIS
         if blended < 0.30:
             return Regime.RISK_ON
-        elif blended < 0.50:
+        if blended < 0.50:
             return Regime.TRANSITION
-        elif blended < 0.75:
+        if blended < 0.75:
             return Regime.RISK_OFF
-        else:
-            return Regime.CRISIS
+        return Regime.CRISIS
 
     def _compute_confidence(self, composite: float, vix: float) -> float:
         """Compute confidence from the distance to regime boundaries.

--- a/backend/archimedes/services/strategy_signal_evaluator.py
+++ b/backend/archimedes/services/strategy_signal_evaluator.py
@@ -521,15 +521,14 @@ def _faber_sma200_signal(
             weight=1.0,
             reason=f"Price {current_price:.2f} > SMA200 {current_sma:.2f} → long",
         )
-    else:
-        return AssetSignal(
-            strategy_id=strategy_id,
-            strategy_name="Faber SMA200",
-            asset=asset,
-            signal=Signal.FLAT,
-            weight=0.0,
-            reason=f"Price {current_price:.2f} ≤ SMA200 {current_sma:.2f} → flat",
-        )
+    return AssetSignal(
+        strategy_id=strategy_id,
+        strategy_name="Faber SMA200",
+        asset=asset,
+        signal=Signal.FLAT,
+        weight=0.0,
+        reason=f"Price {current_price:.2f} ≤ SMA200 {current_sma:.2f} → flat",
+    )
 
 
 def _vol_managed_signal(
@@ -628,15 +627,14 @@ def _tsmom_signal(
             weight=1.0,
             reason=f"12m return {trailing_return:+.1%} ({past_price:.2f} → {current_price:.2f}) → long",
         )
-    else:
-        return AssetSignal(
-            strategy_id=strategy_id,
-            strategy_name="TSMOM",
-            asset=asset,
-            signal=Signal.FLAT,
-            weight=0.0,
-            reason=f"12m return {trailing_return:+.1%} ({past_price:.2f} → {current_price:.2f}) → flat",
-        )
+    return AssetSignal(
+        strategy_id=strategy_id,
+        strategy_name="TSMOM",
+        asset=asset,
+        signal=Signal.FLAT,
+        weight=0.0,
+        reason=f"12m return {trailing_return:+.1%} ({past_price:.2f} → {current_price:.2f}) → flat",
+    )
 
 
 def _52w_high_signal(
@@ -673,15 +671,14 @@ def _52w_high_signal(
             weight=proximity,
             reason=f"Price {current:.2f} is {proximity:.0%} of 52w high {high_52w:.2f} → long",
         )
-    else:
-        return AssetSignal(
-            strategy_id=strategy_id,
-            strategy_name="52W High",
-            asset=asset,
-            signal=Signal.FLAT,
-            weight=0.0,
-            reason=f"Price {current:.2f} is only {proximity:.0%} of 52w high {high_52w:.2f} → flat",
-        )
+    return AssetSignal(
+        strategy_id=strategy_id,
+        strategy_name="52W High",
+        asset=asset,
+        signal=Signal.FLAT,
+        weight=0.0,
+        reason=f"Price {current:.2f} is only {proximity:.0%} of 52w high {high_52w:.2f} → flat",
+    )
 
 
 def _buy_hold_signal(

--- a/backend/tests/test_corpus_service.py
+++ b/backend/tests/test_corpus_service.py
@@ -355,7 +355,7 @@ class TestLoadCorpusDBFallback:
         )
 
         # Make DB return empty (by having load_papers_from_db raise)
-        monkeypatch.setattr(corpus_service, "load_papers_from_db", lambda: [])
+        monkeypatch.setattr(corpus_service, "load_papers_from_db", list)
 
         corpus = load_corpus(path=manifest)
         assert len(corpus) == 1

--- a/ruff.toml
+++ b/ruff.toml
@@ -35,6 +35,11 @@ extend-select = [
     "B",     # flake8-bugbear (likely bugs)
     "SIM",   # flake8-simplify (cleaner code)
     "RUF",   # ruff-specific rules
+    "ARG",   # flake8-unused-arguments (Tier 1 expansion 2026-05-24)
+    "C4",    # flake8-comprehensions
+    "PIE",   # flake8-pie (small correctness rules)
+    "RET",   # flake8-return (cleaner return idioms)
+    "SLF",   # flake8-self (private-member access)
 ]
 
 ignore = [
@@ -65,3 +70,10 @@ ignore = [
 "backend/archimedes/scripts/*.py" = ["E402"]
 "analytics-engine/scripts/*.py" = ["E402"]
 "backend/archimedes/api/selection_bias_routes.py" = ["E402"]
+# Tests legitimately have unused fixture args and routinely access private members;
+# scripts often have unused argparse helpers. Tier-1 expansion 2026-05-24.
+"backend/tests/**" = ["ARG", "SLF"]
+"analytics-engine/tests/**" = ["ARG", "SLF"]
+"tests/**" = ["ARG", "SLF"]
+"backend/archimedes/scripts/**" = ["ARG"]
+"backend/archimedes/evaluation/stockbench/__main__.py" = ["ARG"]

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -402,11 +402,10 @@ def client(vault_address):
                     status_code=200,
                     json=MagicMock(return_value={"traces": [sample_trace], "total": 1}),
                 )
-            else:
-                return MagicMock(
-                    status_code=200,
-                    json=MagicMock(return_value=sample_trace),
-                )
+            return MagicMock(
+                status_code=200,
+                json=MagicMock(return_value=sample_trace),
+            )
 
         return MagicMock(
             status_code=200,

--- a/tests/flows/test_flow_1_synthetic_mint_redeem.py
+++ b/tests/flows/test_flow_1_synthetic_mint_redeem.py
@@ -91,24 +91,19 @@ class TestSyntheticMint:
     def test_mint_zero_amount_reverts(self):
         """Minting with 0 USDC should revert."""
         # Contract test: ISyntheticFactory.mint(sTSLA, 0) → revert ZeroAmount()
-        pass
 
     def test_mint_without_approval_reverts(self):
         """Minting without USDC approval should revert."""
         # Contract test: call mint without approve → revert
-        pass
 
     def test_mint_emits_event(self):
         """Minting emits Minted(user, token, usdcIn, synthOut)."""
-        pass
 
     def test_mint_increases_total_collateral(self):
         """After minting, totalCollateral() increases by the USDC deposited."""
-        pass
 
     def test_health_ratio_stays_at_100pct(self):
         """With 100% collateral ratio, healthRatio should stay at 1e18."""
-        pass
 
 
 # ─────────────────────────────────────────────────────────────
@@ -121,27 +116,21 @@ class TestSyntheticRedeem:
 
     def test_redeem_returns_correct_usdc(self):
         """Redeeming 5.405 sTSLA at $185/sTSLA → ~1000 USDC."""
-        pass
 
     def test_redeem_zero_amount_reverts(self):
         """Redeeming 0 tokens should revert."""
-        pass
 
     def test_redeem_more_than_balance_reverts(self):
         """Redeeming more than you hold should revert."""
-        pass
 
     def test_redeem_emits_event(self):
         """Redeeming emits Redeemed(user, token, synthIn, usdcOut)."""
-        pass
 
     def test_redeem_decreases_total_collateral(self):
         """After redeeming, totalCollateral() decreases."""
-        pass
 
     def test_round_trip_mint_redeem_no_loss(self):
         """Mint then immediately redeem → get back same USDC (minus any fees)."""
-        pass
 
 
 # ─────────────────────────────────────────────────────────────
@@ -159,7 +148,6 @@ class TestSyntheticEndToEnd:
         3. Marten pushes TSLA price = $200
         4. User redeems ~5.405 sTSLA → receives ~$1081 USDC (profit from price increase)
         """
-        pass
 
     async def test_factory_tracks_multiple_synthetics(self):
         """
@@ -167,11 +155,9 @@ class TestSyntheticEndToEnd:
         Each has independent price and collateral tracking.
         getSynthetics() returns both addresses.
         """
-        pass
 
     async def test_stale_price_behavior(self, oracle_updater):
         """
         If oracle hasn't been updated in >5 minutes, mint/redeem should
         either revert or use the stale price (design decision — document behavior).
         """
-        pass

--- a/tests/flows/test_flow_2_amm_swap.py
+++ b/tests/flows/test_flow_2_amm_swap.py
@@ -28,19 +28,15 @@ class TestPoolCreation:
 
     def test_create_pool_returns_address(self):
         """IAMMRouter.createPool(USDC, sTSLA) returns a valid pool address."""
-        pass
 
     def test_create_duplicate_pool_reverts(self):
         """Creating a pool for an existing pair should revert."""
-        pass
 
     def test_get_pool_returns_correct_address(self):
         """getPool(USDC, sTSLA) returns the pool created earlier."""
-        pass
 
     def test_get_all_pools_lists_created_pools(self):
         """After creating 5 pools, getAllPools() returns 5 addresses."""
-        pass
 
 
 class TestLiquidity:
@@ -48,23 +44,18 @@ class TestLiquidity:
 
     def test_add_liquidity_mints_lp_tokens(self):
         """Adding 10000 USDC + 54 sTSLA → receives LP tokens > 0."""
-        pass
 
     def test_add_liquidity_updates_reserves(self):
         """After adding, pool.reserve0() and pool.reserve1() increase."""
-        pass
 
     def test_remove_liquidity_returns_both_tokens(self):
         """Burning LP tokens returns proportional amounts of both tokens."""
-        pass
 
     def test_remove_all_liquidity_empties_pool(self):
         """Removing all LP tokens → reserves go to 0."""
-        pass
 
     def test_add_liquidity_respects_ratio(self):
         """Adding liquidity to an existing pool must respect the current price ratio."""
-        pass
 
 
 # ─────────────────────────────────────────────────────────────
@@ -79,40 +70,31 @@ class TestSwap:
         """Swap 100 USDC → sTSLA via IAMMRouter.swap().
         User receives sTSLA, pool reserves update.
         """
-        pass
 
     def test_swap_synth_for_usdc(self):
         """Swap sTSLA → USDC (sell direction)."""
-        pass
 
     def test_swap_respects_min_amount_out(self):
         """If output would be below minAmountOut, revert (slippage protection)."""
-        pass
 
     def test_swap_charges_fee(self):
         """0.3% fee: swapping 1000 USDC yields less than constant-product formula
         would give without fees."""
-        pass
 
     def test_swap_updates_reserves(self):
         """After swap, reserve of input token increases, output token decreases."""
-        pass
 
     def test_swap_emits_event(self):
         """Swap emits Swap(sender, tokenIn, amountIn, tokenOut, amountOut)."""
-        pass
 
     def test_swap_zero_amount_reverts(self):
         """Swapping 0 tokens should revert."""
-        pass
 
     def test_getAmountOut_matches_actual_swap(self):
         """getAmountOut() preview matches the actual swap output."""
-        pass
 
     def test_large_swap_has_significant_price_impact(self):
         """Swapping 50% of pool reserves → large price impact (constant product curve)."""
-        pass
 
 
 # ─────────────────────────────────────────────────────────────
@@ -170,15 +152,12 @@ class TestSwapEndToEnd:
         4. User's sTSLA balance increases, USDC balance decreases
         5. Pool reserves reflect the trade
         """
-        pass
 
     async def test_multiple_swaps_move_price(self):
         """
         Successive buys of sTSLA increase the price (fewer sTSLA per USDC).
         This is the AMM price discovery mechanism.
         """
-        pass
 
     async def test_spot_price_reflects_reserves(self):
         """IAMMPool.getSpotPrice() matches reserve0/reserve1 ratio."""
-        pass

--- a/tests/flows/test_flow_3_vault_lifecycle.py
+++ b/tests/flows/test_flow_3_vault_lifecycle.py
@@ -30,27 +30,21 @@ class TestVaultCreation:
 
     def test_create_tier1_vault(self):
         """Agent address creates vault → tier = 1 (Archimedes Verified)."""
-        pass
 
     def test_create_tier2_vault(self):
         """Random wallet creates vault → tier = 2 (Community)."""
-        pass
 
     def test_vault_has_correct_fees(self):
         """Created vault has the specified management and performance fees."""
-        pass
 
     def test_vault_is_agent_assisted(self):
         """Vault created with agentAssisted=true → isAgentAssisted() returns true."""
-        pass
 
     def test_factory_tracks_vaults(self):
         """getVaults() and getVaultsByCreator() return the created vaults."""
-        pass
 
     def test_vault_token_is_erc20(self):
         """Vault token is a standard ERC-20 (for AMM trading — aspirational #8)."""
-        pass
 
 
 # ─────────────────────────────────────────────────────────────
@@ -63,23 +57,18 @@ class TestVaultDeposit:
 
     def test_deposit_mints_shares(self):
         """Depositing 1000 USDC → receives vault shares > 0."""
-        pass
 
     def test_first_deposit_1_to_1(self):
         """First deposit: 1000 USDC → 1000 shares (1:1 ratio on empty vault)."""
-        pass
 
     def test_second_deposit_at_current_price(self):
         """After NAV changes, new deposits mint shares at current price."""
-        pass
 
     def test_deposit_zero_reverts(self):
         """Depositing 0 USDC should revert."""
-        pass
 
     def test_preview_deposit_matches_actual(self):
         """previewDeposit(1000) matches the actual shares from deposit(1000)."""
-        pass
 
 
 class TestVaultWithdraw:
@@ -87,27 +76,21 @@ class TestVaultWithdraw:
 
     def test_redeem_returns_usdc(self):
         """Redeeming shares → receive USDC proportional to NAV."""
-        pass
 
     def test_redeem_all_empties_position(self):
         """Redeeming all shares → user has 0 shares, receives full NAV share."""
-        pass
 
     def test_withdraw_more_than_balance_reverts(self):
         """Withdrawing more shares than held should revert."""
-        pass
 
     def test_preview_redeem_matches_actual(self):
         """previewRedeem(shares) matches the actual USDC from redeem(shares)."""
-        pass
 
     def test_withdraw_after_profit(self):
         """If vault NAV increased, withdrawing returns more than deposited."""
-        pass
 
     def test_withdraw_after_loss(self):
         """If vault NAV decreased, withdrawing returns less than deposited."""
-        pass
 
 
 # ─────────────────────────────────────────────────────────────
@@ -120,19 +103,15 @@ class TestTargetAllocations:
 
     def test_set_allocations_sums_to_100pct(self):
         """setTargetAllocations with weights summing to 10000 bps succeeds."""
-        pass
 
     def test_set_allocations_not_summing_reverts(self):
         """Weights not summing to 10000 bps should revert."""
-        pass
 
     def test_get_target_allocations_returns_set_values(self):
         """getTargetAllocations() returns what was set."""
-        pass
 
     def test_only_creator_can_set_allocations(self):
         """Non-creator address calling setTargetAllocations should revert."""
-        pass
 
 
 class TestPortfolioConstructionIntegration:
@@ -197,22 +176,18 @@ class TestRebalance:
 
     def test_rebalance_restricted_to_creator_or_agent(self):
         """Random address calling rebalance() should revert."""
-        pass
 
     def test_rebalance_changes_holdings(self):
         """After rebalance, getHoldings() reflects the new positions."""
-        pass
 
     def test_rebalance_emits_event(self):
         """Rebalance emits Rebalanced(caller, tradesCount, timestamp)."""
-        pass
 
     async def test_rebalance_executes_via_amm(self, chain_executor):
         """
         IChainExecutor.execute_trades() submits swap txs to AMM.
         Each trade returns a tx hash.
         """
-        pass
 
     async def test_rebalance_cost_benefit_gate(self, agent_orchestrator):
         """

--- a/tests/flows/test_flow_4_reasoning_traces.py
+++ b/tests/flows/test_flow_4_reasoning_traces.py
@@ -169,27 +169,21 @@ class TestReasoningTraceRegistry:
 
     def test_publish_increments_trace_count(self):
         """Each publishTrace() call increments traceCount()."""
-        pass
 
     def test_publish_emits_event(self):
         """publishTrace emits TracePublished(traceId, agent, vault, hash, timestamp)."""
-        pass
 
     def test_get_trace_by_id(self):
         """getTraceById(1) returns the correct agent, vault, hash, timestamp."""
-        pass
 
     def test_get_traces_by_vault(self):
         """getTracesByVault(vaultAddr) returns all trace IDs for that vault."""
-        pass
 
     def test_verify_trace_returns_true_for_matching_hash(self):
         """verifyTrace(id, data) returns true when SHA-256(data) matches stored hash."""
-        pass
 
     def test_verify_trace_returns_false_for_wrong_data(self):
         """verifyTrace(id, wrongData) returns false."""
-        pass
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/flows/test_flow_7_11_aspirational.py
+++ b/tests/flows/test_flow_7_11_aspirational.py
@@ -24,27 +24,21 @@ class TestCommunityVaultCreation:
 
     async def test_any_wallet_can_create_vault(self, client):
         """POST or on-chain tx: non-agent wallet creates vault → tier = 2."""
-        pass
 
     async def test_community_vault_appears_on_leaderboard(self, client):
         """After creation, vault is visible in GET /api/vaults/?tier=2."""
-        pass
 
     async def test_community_vault_custom_fees(self):
         """Creator sets their own management and performance fees."""
-        pass
 
     async def test_community_vault_opt_in_agent(self):
         """Creator can opt into agent-assisted rebalancing at creation."""
-        pass
 
     async def test_community_vault_custom_allocations(self):
         """Creator sets target allocations: e.g. 40% sTSLA, 30% sSPY, 30% USYC."""
-        pass
 
     async def test_community_vault_deposit_and_share_price(self):
         """Other users can deposit into a community vault and receive shares."""
-        pass
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -57,24 +51,19 @@ class TestVaultTokenTrading:
 
     async def test_vault_token_pool_creation(self):
         """USDC/vaultToken pool is created when vault AUM exceeds threshold."""
-        pass
 
     async def test_buy_vault_token_on_amm(self):
         """User swaps USDC for vault tokens on AMM (without depositing to vault)."""
-        pass
 
     async def test_vault_token_price_tracks_nav(self):
         """AMM price approximates NAV per share (arbitrage mechanism)."""
-        pass
 
     async def test_vault_token_premium_discount(self):
         """Vault token can trade at premium or discount to NAV.
         Direct mint/redeem at NAV provides the arbitrage mechanism."""
-        pass
 
     async def test_sell_vault_token_on_amm(self):
         """User can sell vault tokens on AMM (instant exit without redeem delay)."""
-        pass
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -87,35 +76,27 @@ class TestVaultChat:
 
     async def test_connect_to_vault_chat(self):
         """WebSocket connection to /chat/{vault_address} succeeds."""
-        pass
 
     async def test_send_and_receive_message(self):
         """User sends message, other connected users receive it."""
-        pass
 
     async def test_message_persistence(self):
         """GET /chat/{vault_address} returns message history."""
-        pass
 
     async def test_wallet_address_as_identity(self):
         """Messages show sender's wallet address."""
-        pass
 
     async def test_ai_auto_post_on_rebalance(self):
         """After agent rebalance, AI posts a summary in Tier 1 vault chat."""
-        pass
 
     async def test_ai_responds_to_mention(self):
         """Message containing '@archimedes' triggers AI response via Claude API."""
-        pass
 
     async def test_ai_response_references_traces(self):
         """AI responses reference specific reasoning trace IDs for verifiability."""
-        pass
 
     async def test_chat_open_access(self):
         """Any connected wallet can read and write in any vault's chat."""
-        pass
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -128,23 +109,18 @@ class TestLPDashboard:
 
     async def test_add_liquidity_via_frontend(self):
         """User adds liquidity to USDC/sTSLA pool via AMM router."""
-        pass
 
     async def test_remove_liquidity_via_frontend(self):
         """User removes liquidity and receives both tokens."""
-        pass
 
     async def test_lp_position_display(self):
         """Dashboard shows: LP tokens held, share of pool, fees earned."""
-        pass
 
     async def test_fees_earned_calculation(self):
         """After swaps occur in pool, LP's fee share increases."""
-        pass
 
     async def test_impermanent_loss_display(self):
         """Dashboard shows IL estimate vs holding tokens."""
-        pass
 
 
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Expands `ruff.toml`'s `extend-select` with five Tier 1 low-noise rule families and applies the resulting safe auto-fixes. Per the audit, these are the next-mechanical step after the existing `I, UP, B, SIM, RUF` baseline.

## Rules added

| Code | Family | Purpose |
| --- | --- | --- |
| `ARG`  | flake8-unused-arguments | Unused function/method arguments |
| `C4`   | flake8-comprehensions   | Comprehension cleanup |
| `PIE`  | flake8-pie              | Small correctness antipatterns |
| `RET`  | flake8-return           | Cleaner return idioms |
| `SLF`  | flake8-self             | Private-member access from outside the class |

Plus a `[lint.per-file-ignores]` section for tests (`ARG`, `SLF` — fixtures legitimately have unused args; tests routinely poke private members) and scripts (`ARG` — argparse helpers).

## Auto-fixes applied

**105 safe auto-fixes applied** across 13 files. No `--unsafe-fixes` were used. Touched:

- `backend/archimedes/chain/circle_signer.py`
- `backend/archimedes/models/chat.py`
- `backend/archimedes/services/portfolio_optimizer.py`
- `backend/archimedes/services/rigor_evaluator.py`
- `backend/archimedes/services/statistical_regime.py`
- `backend/archimedes/services/strategy_signal_evaluator.py`
- `backend/tests/test_corpus_service.py`
- `tests/flows/*` (5 files — `RET505/RET506` mostly)

## Remaining violations (deferred, **42 total**)

Not addressed in this PR because the safe rename strategy (`x` → `_x`) is unsafe when the arg name is part of an interface contract or framework signature used as a keyword elsewhere:

**ARG001/ARG002 on FastAPI/Protocol contracts (28):** `system`/`user` on `LLMBackend.complete()` implementations (called as `complete(system=..., user=...)` in `portfolio_agent.py`); `request`/`response` on FastAPI route handlers (framework-injected, signature is inspected by FastAPI/slowapi). Files: `backend/archimedes/services/llm_backend.py`, `backend/archimedes/agents/{strategy_architect,strategy_fusion}.py`, `backend/archimedes/api/{agent,assets,generate,papers,selection_bias,strategies,traces,user,vaults}_routes.py`, `backend/archimedes/main.py`, plus a few service-layer helpers.

**C4 hidden fixes (9):** `C408` (`dict(...)` → `{...}`), `C416`, `C401` — ruff classifies these as `--unsafe-fixes` because they can change ordering/typing semantics in edge cases. Wants per-call review. Files: `backend/archimedes/agents/strategy_fusion.py`, `backend/archimedes/chain/{agent_runner,executor}.py`, `backend/archimedes/scripts/deploy_contracts.py`, `backend/archimedes/services/backtest_repository.py`, `backend/tests/{services/test_paper_rag.py,test_arxiv_corpus.py,test_trace_publisher.py}`.

**RET504 (5):** `unnecessary-assign` cases where the intermediate binding aids readability. Files: `backend/archimedes/api/selection_bias_routes.py`, `backend/archimedes/chain/circle_signer.py`, `backend/archimedes/scripts/deploy_contracts.py`, `backend/archimedes/services/{backtest_repository,redis_state}.py`.

Follow-up PR will batch the safe Protocol-arg renames and review the C4 hidden fixes individually.

## Test plan

- [ ] `ruff format --check .` → exits 0 (verified locally: `196 files already formatted`)
- [ ] `ruff check --select E9,F63,F7,F40 .` → exits 0 (verified locally: `All checks passed!`)
- [ ] `pytest -m "not integration"` → 560 passed, 2 skipped, **2 failed (pre-existing on `main`)** — `TestAgentRoutes::test_agent_status_redis_down_defaults` and `TestAdvisorRoutes::test_advisor_redis_unavailable` both fail on the unmodified `main` baseline (verified)
- [ ] Quality gate CI green (ruff-gate hard block + informational ruff report comment)
- [ ] Complexity gate CI green (informational only)

## Anti-goals respected

- No Tier 2 / Tier 3 rules enabled (`PTH`, `G`, `LOG`, `PERF`, `S`, `N`, `T20`, `TID`, `PL`, `D`, `ANN` all untouched)
- `line-length`, `target-version`, `extend-exclude`, existing `ignore`, and existing `per-file-ignores` all preserved
- No `--unsafe-fixes` applied
- Branch off `main`; **PR is DRAFT** so the build-on-deploy pipeline does not auto-deploy