### PR TITLE
[docs] M.4 Day-12 content refresh — sync test counts + dates + Day-12 ship deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make clean      # nuke __pycache__/.pytest_cache/.ruff_cache
 
 Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`, …) are also there — see `make help`.
 
-## Status (2026-05-22)
+## Status (2026-05-24)
 
 **Live on the Arc public testnet** (chain ID `5042002`): grab faucet USDC at <https://faucet.circle.com/> (20 USDC / 2h — on Arc, USDC *is* gas) and try the full flow with test funds. **No real money at risk, by design.** Arc has no mainnet yet (Circle's docs list mainnet as "upcoming"); mainnet launch, real-funds custody, and the regulatory architecture (off-chain redemptions, preset-strategy / RIA posture) are the **business-plan roadmap**, not hackathon scope — see [`docs/competitor-landscape.md`](docs/competitor-landscape.md).
 
@@ -56,12 +56,14 @@ Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`,
 
 - Live testnet deploy: <http://13.40.112.220> · 10 Solidity contracts on Arc
 - 3-input fusion engine: user brief × live market regime × 10,000-paper q-fin corpus → grounded strategy spec
-- LLM-driven agentic portfolio advisor (`portfolio_agent.py`, 850 lines) — picks individual instruments and anchors each to a strategy passport
-- Four-control selection-bias rigor gate (DSR + PBO + walk-forward OOS + look-ahead audit) — **2 Tier-1 strategies pass today** against 22 years of real SPY data
+- LLM-driven agentic portfolio advisor (`portfolio_agent.py`, 850 lines) surfaced **before deposit** on `/generate` — picks individual instruments and anchors each to a strategy passport
+- Four-control selection-bias rigor gate (DSR + PBO + walk-forward OOS + look-ahead audit) — **2 Tier-1 strategies pass today** against 22.3 years of real SPY data
+- Regime-conditional risk aversion in the Kelly optimizer (Ang & Bekaert 2002, *RFS*) — effective γ scales with the live regime
 - Multi-asset NAV vaults — `Vault.totalAssets()` prices all synthetic holdings via oracles
 - On-chain reasoning trace anchoring via the deployed `ReasoningTraceRegistry`
+- Multi-wallet UX (MetaMask / Coinbase / generic) with profile dropdown + per-wallet display name
 - 6-container docker stack: backend (FastAPI) + postgres + redis + nginx + oracle + agent
-- 302 backend tests + 16 analytics-engine tests green
+- 564 backend tests + 16 analytics-engine tests collected
 
 ## Why Archimedes
 

--- a/docs/claude-design-prompts.md
+++ b/docs/claude-design-prompts.md
@@ -5,7 +5,7 @@
 > **Purpose:** Concrete, paste-ready prompts for slides, UI prototypes, logos, and
 > explanatory visualizations. Each prompt is self-contained so the design session has
 > the context it needs without you re-explaining the project.
-> **Status:** **Day-11 revision (2026-05-23).** Refreshes the Day-10 baseline
+> **Status:** **Day-12 revision (2026-05-24).** Refreshes the Day-11 baseline
 > against spine-plus-v2 (8 commits ahead of `origin/main`: Phases 0–3 + follow-ups
 > + Makefile + the Day-11 docs cleanup) and Chuan's `bd6935b` (Strategy DSL +
 > interpreter + fusion evaluator pipeline). Current snapshot the prompts reflect:
@@ -27,7 +27,7 @@
 > 2007 + Moreira-Muir 2017 — pass all four gates on 22-year SPY); DB-backed
 > 10,000-paper q-fin corpus with the Corpus Explorer UI shipped; "Linus for
 > quantitative finance" framing locked per [`docs/user-stories.md`](user-stories.md);
-> **343 backend tests** + 16 analytics-engine tests green; **2 days to submission**.
+> **564 backend tests** + 16 analytics-engine tests collected; **~30 hours to submission**.
 > UI prompts work as **refinement** prompts against the live UI, not greenfield.
 >
 > **Aligned with [`docs/chuan-architecture-survey.md`](chuan-architecture-survey.md)
@@ -45,9 +45,18 @@
 >     Reasoning lost its Strategies tab (details moved to Library); Generate is
 >     streaming with a mode toggle (Streaming agent vs Architect fast preview);
 >     onboarding tour appears on first visit + via the "?" icon in the topbar.
->   - **Test counts**: 302 → 343 backend tests; 5 t2o2 issues open in the
->     queue ([#129](https://github.com/a-apin/archimedes-arcadia/issues/129)–
->     [#133](https://github.com/a-apin/archimedes-arcadia/issues/133)).
+>   - **Test counts**: 564 backend tests collected (Day-12 truth; prior 302/343
+>     references were stale). All six original t2o2 issues
+>     ([#128](https://github.com/a-apin/archimedes-arcadia/issues/128)–
+>     [#133](https://github.com/a-apin/archimedes-arcadia/issues/133)) closed;
+>     spec files archived under [`docs/archive/`](archive/).
+>   - **Day-12 ships to fold into prompts**: PortfolioAdvisor resurfaced on
+>     `/generate` as preview-before-deploy banner ([#216](https://github.com/a-apin/archimedes-arcadia/pull/216));
+>     regime-conditional γ scaling in `kelly_optimize_from_prices` cites Ang
+>     & Bekaert 2002 *RFS* ([#217](https://github.com/a-apin/archimedes-arcadia/pull/217));
+>     wallet menu dropdown + Profile view/edit
+>     ([#213](https://github.com/a-apin/archimedes-arcadia/pull/213)); ESLint
+>     at 0 errors / 0 warnings + ruff cleanup.
 
 ## Quick notes on using Claude Design
 
@@ -330,8 +339,8 @@ RIGHT — Rigor + on-chain
   PriceOracle, ReasoningTraceRegistry. **Vault.sol is now multi-asset NAV** —
   `totalAssets()` prices every holding via the oracle, so the share price is
   honest under mixed-asset allocations
-- Multi-wallet UX (MetaMask / Coinbase / generic). 302 backend tests + 16
-  analytics-engine tests green.
+- Multi-wallet UX (MetaMask / Coinbase / generic) with profile dropdown.
+  564 backend tests + 16 analytics-engine tests collected.
 
 SLIDE 5 — DEMO
 Full-bleed slide: the word "DEMO" in large serif type, brand accent, with the live

--- a/docs/demo-script-pitch-deck-outline.md
+++ b/docs/demo-script-pitch-deck-outline.md
@@ -1,7 +1,7 @@
 # Demo Script & Pitch Deck Outline
 
 > **Audience:** Archimedes hackathon team (deck owner + demo runner + Q&A primaries).
-> **Status:** Day-10 update (2026-05-22) on top of the 2026-05-19 rewrite to the
+> **Status:** Day-12 date-bump (2026-05-24) on top of the Day-10 update (2026-05-22) atop the 2026-05-19 rewrite to the
 > **locked product spine** ([`user-stories.md`](user-stories.md)) and the
 > **tiered competitive thesis** ([`competitor-landscape.md`](competitor-landscape.md)).
 > Day-10 deltas to fold into the deck on next pass: (a) the LLM-driven agentic
@@ -14,6 +14,7 @@
 > "what does my position actually mean" judge question; (d) Arc OSS Showcase
 > dimension added — see [`../ARC-OSS-SHOWCASE.md`](../ARC-OSS-SHOWCASE.md) and the
 > Day-10 rubric assessment in [`judging-rubric-assessment.md`](judging-rubric-assessment.md).
+> **Day-12 deltas not yet folded into the slide-by-slide bullets below** (Önder owns the rigor-track refresh per the lane split): (a) **[#216](https://github.com/a-apin/archimedes-arcadia/pull/216)** PortfolioAdvisor surfaced on `/generate` as preview-before-deploy banner — judges see Kelly + risk-parity allocation + DSR/PBO/stress matrix BEFORE any signature; (b) **[#217](https://github.com/a-apin/archimedes-arcadia/pull/217)** regime-conditional γ scaling in `kelly_optimize_from_prices` citing Ang & Bekaert 2002 *Review of Financial Studies* — new academic backstop for SLIDE 4's rigor row; (c) doc directory pruned + UX path-leak scrubs ([#215](https://github.com/a-apin/archimedes-arcadia/pull/215)) — cold-clone judges see a clean repo; (d) test count is **564 backend tests collected** (prior 302/343 references stale).
 > Supersedes the Day-4 "connect wallet → pick a risk profile" script entirely.
 > **Length assumption:** ~3-minute pitch + ~2-minute live demo + Q&A. Adjust if Canteen says otherwise.
 >

--- a/docs/judging-rubric-assessment.md
+++ b/docs/judging-rubric-assessment.md
@@ -1,12 +1,18 @@
-# Judging-Rubric Self-Assessment — Day-10 (2026-05-22)
+# Judging-Rubric Self-Assessment — Day-12 (2026-05-24)
 
-> **Status:** Day-10 rewrite (2026-05-22). The Day-3 version of this doc scored us
+> **Status:** Day-12 date-bump on top of the Day-10 rewrite (2026-05-22). The Day-3 version of this doc scored us
 > 13/40 ≈ 33%; almost every line item it called out as "missing" has since shipped.
 > This version re-scores against shipped reality, adds the new **Arc OSS Showcase**
-> dimension, and lays out the remaining gap-closure work for the final 3 days to
+> dimension, and lays out the remaining gap-closure work for the **~30 hours to**
 > submission.
+> **Day-12 ships not yet folded into the scoring rationale below** (Önder owns the rigor-track
+> rewrite): #216 PortfolioAdvisor resurfaced on `/generate` as preview-before-deploy,
+> #217 regime-conditional γ in the Kelly optimizer citing Ang & Bekaert 2002 *RFS*,
+> #213 wallet menu dropdown + Profile, plus the doc-prune + UX leak-scrub (#215) and
+> ESLint 0/0 + ruff cleanup. **Innovation 9/10 score likely strengthens** with the
+> Ang-Bekaert citation as additional academic backstop.
 > **Audience:** Archimedes hackathon team.
-> **Purpose:** Honest assessment of where we stand against the rubric with 3 days
+> **Purpose:** Honest assessment of where we stand against the rubric with ~30 hours
 > to go. Identifies the biggest *remaining* gaps and what's already done. Re-read
 > daily.
 > **Source for rubric weights / categories:** original Canteen rubric (see


### PR DESCRIPTION
## Summary

Mechanical staleness sweep across the four docs the team reads every session. Reconciles them against current main reality without invading content owned by other lanes.

| File | Edits |
|---|---|
| [README.md](README.md) | Status date 2026-05-22 → 2026-05-24; \"Built today\" list updated with PortfolioAdvisor placement + regime-conditional γ + wallet UX dropdown; test count 302 → 564; backtest period \"22 years\" → \"22.3 years\" |
| [docs/claude-design-prompts.md](docs/claude-design-prompts.md) | Header Day-11 → Day-12; three test-count refs (343/302/302) → 564; reframed \"5 t2o2 issues open\" line (all closed + archived); added a Day-12 ships-to-fold section listing #213/#215/#216/#217 |
| [docs/judging-rubric-assessment.md](docs/judging-rubric-assessment.md) | Header Day-10 → Day-12; \"3 days to go\" → \"~30 hours to go\"; Day-12 ships-not-yet-folded pointer for Önder's scoring refresh (Innovation 9/10 likely strengthens with Ang-Bekaert citation as additional academic backstop) |
| [docs/demo-script-pitch-deck-outline.md](docs/demo-script-pitch-deck-outline.md) | Header Day-10 → Day-12; added a Day-12 deltas pointer enumerating #216 + #217 + #215 + test-count delta; **slide-by-slide bullets and rigor sections deliberately untouched** (Önder owns the rigor refresh per Discord handoff) |

## Why test count went 302 → 564

\`pytest backend/tests --collect-only -q\` reports 564 tests collected today. Prior 302 was from an earlier point; the 343 in claude-design-prompts.md was an intermediate snapshot. Truth: 564. Using \"collected\" not \"passing\" because verifying the full suite passes requires the docker stack to be running (per [README.md](README.md) test-suite caveat).

## Day-12 ships referenced (so anyone reading the docs can chase them)

- **#213** [frontend] PR-3: Wallet menu dropdown + Profile view/edit (merged 17:33Z)
- **#215** [docs+frontend] Prune historical artifacts; scrub user-visible doc-path leaks (merged 21:42Z)
- **#216** [ui] Resurrect PortfolioAdvisor on /generate as preview-before-deploy banner (Önder, merged 21:43Z)
- **#217** [quant] Regime-aware γ scaling in kelly_optimize_from_prices, Ang & Bekaert 2002 RFS (Önder, merged 21:43Z)

## Anti-goals (explicit — to keep PRs un-collidable)

- **No touch** to the rigor sections of \`docs/demo-script-pitch-deck-outline.md\` (SLIDE 4 right column / SLIDE 6 wedge column / SLIDE 9 honest framing) — Önder's lane per Discord handoff Option A items 2 + 3.
- **No touch** to [docs/pitch-talking-points-rigor-track.md](docs/pitch-talking-points-rigor-track.md) — Önder's lane.
- **No touch** to [docs/rigor-methods.md](docs/rigor-methods.md) — Önder's lane (he's the author).
- **No rubric scoring changes** in judging-rubric-assessment.md — score deltas need team alignment, not a mechanical sweep.
- **No competitor-landscape numbers refreshed** — those need fresh web research before pitch, not a sync from this branch.
- **No anti-features.md SDK-roadmap edits** — Coinbase/Circle SDK decision is pending (Dan checking other Claude session for in-flight SDK work).

## Test plan

- [x] \`grep -rn '302 backend\\|343 backend' docs/ README.md\` returns no non-archive matches
- [ ] CI green (no test changes; pure doc edits)
- [ ] Visual check after merge — no markdown rendering breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)