### PR TITLE
[docs] README: sync status date + test count + add Day-12 ship deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make clean      # nuke __pycache__/.pytest_cache/.ruff_cache
 
 Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`, …) are also there — see `make help`.
 
-## Status (2026-05-22)
+## Status (2026-05-24)
 
 **Live on the Arc public testnet** (chain ID `5042002`): grab faucet USDC at <https://faucet.circle.com/> (20 USDC / 2h — on Arc, USDC *is* gas) and try the full flow with test funds. **No real money at risk, by design.** Arc has no mainnet yet (Circle's docs list mainnet as "upcoming"); mainnet launch, real-funds custody, and the regulatory architecture (off-chain redemptions, preset-strategy / RIA posture) are the **business-plan roadmap**, not hackathon scope — see [`docs/competitor-landscape.md`](docs/competitor-landscape.md).
 
@@ -57,11 +57,13 @@ Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`,
 - Live testnet deploy: <http://13.40.112.220> · 10 Solidity contracts on Arc
 - 3-input fusion engine: user brief × live market regime × 10,000-paper q-fin corpus → grounded strategy spec
 - LLM-driven agentic portfolio advisor (`portfolio_agent.py`, 850 lines) — picks individual instruments and anchors each to a strategy passport
-- Four-control selection-bias rigor gate (DSR + PBO + walk-forward OOS + look-ahead audit) — **2 Tier-1 strategies pass today** against 22 years of real SPY data
+- Four-control selection-bias rigor gate (DSR + PBO + walk-forward OOS + look-ahead audit) — **2 Tier-1 strategies pass today** against 22.3 years of real SPY data
+- Regime-conditional risk aversion in the Kelly optimizer (Ang & Bekaert 2002, *Review of Financial Studies*) — effective γ scales with the live regime
 - Multi-asset NAV vaults — `Vault.totalAssets()` prices all synthetic holdings via oracles
 - On-chain reasoning trace anchoring via the deployed `ReasoningTraceRegistry`
 - 6-container docker stack: backend (FastAPI) + postgres + redis + nginx + oracle + agent
-- 302 backend tests + 16 analytics-engine tests green
+- Multi-wallet UX (MetaMask + Coinbase + Circle passkey via EIP-6963 wallet discovery) with profile dropdown
+- 576 backend tests + 16 analytics-engine tests green
 
 ## Why Archimedes
 


### PR DESCRIPTION
## Summary

Five-line README freshness PR. Strips down the broader M.4 sweep in #226 (now superseded by Önder's #228 for the deeper docs work) to just the README edits that are unique and conflict-free.

| Line | Was | Now |
|---|---|---|
| Status header | \`(2026-05-22)\` | \`(2026-05-24)\` |
| Built today: SPY backtest | \`22 years\` | \`22.3 years\` |
| Built today: rigor section | (single bullet) | + bullet for regime-conditional γ (Ang & Bekaert 2002 RFS, via #217) |
| Built today: docker | (existed) | (unchanged) |
| Built today: wallet | (absent) | + bullet for MetaMask + Coinbase + Circle passkey via EIP-6963 (#225 + #227) |
| Built today: tests | \`302 backend tests + 16 analytics-engine tests green\` | \`576 backend tests + 16 analytics-engine tests green\` (matches Önder's #228 measurement) |

## Test plan

- [x] git diff is 5 insertions / 3 deletions, README only
- [ ] CI green
- [ ] Visual: README front-page reads honest as of 2026-05-24

## Anti-goals

- No other files touched. PR #226 (now to be closed) covered the wider docs; this strips to README-only to avoid conflicts with Önder's #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)