### PR TITLE
[infra+frontend] Wire VITE_ build args + expand Coinbase detection !minor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,13 @@ services:
     build:
       context: .
       dockerfile: nginx/Dockerfile
+      args:
+        # VITE_* vars embed into the JS bundle at build time (Vite reads
+        # them during `npm run build`). Sourced from the host .env file;
+        # empty defaults so the build still succeeds when unconfigured.
+        VITE_CIRCLE_CLIENT_KEY: ${VITE_CIRCLE_CLIENT_KEY:-}
+        VITE_CIRCLE_CLIENT_URL: ${VITE_CIRCLE_CLIENT_URL:-https://modular-sdk.circle.com/v1/rpc/w3s/buidl}
+        VITE_API_BASE: ${VITE_API_BASE:-}
     restart: unless-stopped
     ports:
       - "80:8080"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,19 @@
 # Stage 1: build the React app
 FROM node:22-alpine AS ui-build
 WORKDIR /app
+
+# Vite embeds VITE_* env vars into the bundle at build time. The values
+# need to be available BEFORE `npm run build` runs — hence build-args
+# (passed via docker-compose `args:`) rather than runtime env. Empty
+# defaults so the build still succeeds when a key is unset (the app
+# gracefully hides features that require missing config).
+ARG VITE_CIRCLE_CLIENT_KEY=""
+ARG VITE_CIRCLE_CLIENT_URL=""
+ARG VITE_API_BASE=""
+ENV VITE_CIRCLE_CLIENT_KEY=${VITE_CIRCLE_CLIENT_KEY}
+ENV VITE_CIRCLE_CLIENT_URL=${VITE_CIRCLE_CLIENT_URL}
+ENV VITE_API_BASE=${VITE_API_BASE}
+
 COPY ui/package.json ui/package-lock.json ./
 RUN npm ci
 COPY ui/ .

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -42,16 +42,40 @@ if (typeof window !== 'undefined') {
 
 // Known wallets we ship icons + curated names for. Any EIP-6963 wallet not in
 // this list still surfaces via discoverEip6963Wallets() with the wallet's own
-// self-declared name + icon.
+// self-declared name + icon. rdns lists are intentionally permissive —
+// wallets sometimes ship multiple identifiers across versions / variants.
 const KNOWN_WALLET_RDNS = {
-  metamask: ['io.metamask', 'io.metamask.flask'],
-  coinbase: ['com.coinbase.wallet'],
+  metamask: ['io.metamask', 'io.metamask.flask', 'io.metamask.mobile'],
+  coinbase: [
+    'com.coinbase.wallet',     // legacy extension rdns
+    'com.coinbase.smartwallet', // Smart Wallet (popup auth)
+    'com.coinbase.cbwallet',    // older variant
+    'org.coinbase.wallet',      // some forks
+    'com.coinbase',             // shortened
+  ],
 }
 
-function findEip6963Provider(rdnsList) {
+// Heuristic name-based fallback for wallets whose rdns drifts between versions.
+// EIP-6963's `info.name` is human-readable but reasonably stable; case-insensitive
+// substring match catches "Coinbase Wallet", "Coinbase Smart Wallet", etc.
+const KNOWN_WALLET_NAME_PATTERNS = {
+  metamask: /\bmetamask\b/i,
+  coinbase: /\bcoinbase\b/i,
+}
+
+function findEip6963Provider(rdnsList, namePattern = null) {
+  // 1. Exact rdns match (preferred — most specific).
   for (const rdns of rdnsList) {
     const entry = eip6963Providers.get(rdns)
     if (entry) return entry.provider
+  }
+  // 2. Name-based fallback for rdns drift. Last resort because it's fuzzy.
+  if (namePattern) {
+    for (const entry of eip6963Providers.values()) {
+      if (entry.info?.name && namePattern.test(entry.info.name)) {
+        return entry.provider
+      }
+    }
   }
   return null
 }
@@ -62,8 +86,12 @@ export const WALLET_PROVIDERS = [
     name: 'MetaMask',
     icon: 'i-token-branded-metamask',
     detect: () => {
-      // EIP-6963 first (modern MetaMask)
-      const announced = findEip6963Provider(KNOWN_WALLET_RDNS.metamask)
+      // EIP-6963 first (modern MetaMask) — try known rdns, then fall back
+      // to a name-based match in case the rdns drifted between versions.
+      const announced = findEip6963Provider(
+        KNOWN_WALLET_RDNS.metamask,
+        KNOWN_WALLET_NAME_PATTERNS.metamask,
+      )
       if (announced) return announced
       // Legacy: window.ethereum.isMetaMask
       if (!window.ethereum) return null
@@ -80,8 +108,14 @@ export const WALLET_PROVIDERS = [
     name: 'Coinbase Wallet',
     icon: 'i-simple-icons-coinbase',
     detect: () => {
-      // EIP-6963 first (modern Coinbase Wallet extension)
-      const announced = findEip6963Provider(KNOWN_WALLET_RDNS.coinbase)
+      // EIP-6963 first (modern Coinbase Wallet extension). Coinbase has
+      // shipped multiple rdns variants — try the known list, then fall
+      // back to matching `info.name` for any future variant we haven't
+      // hardcoded.
+      const announced = findEip6963Provider(
+        KNOWN_WALLET_RDNS.coinbase,
+        KNOWN_WALLET_NAME_PATTERNS.coinbase,
+      )
       if (announced) return announced
       // Legacy patterns (older versions)
       if (window.ethereum?.isCoinbaseWallet) return window.ethereum
@@ -106,11 +140,18 @@ export const WALLET_PROVIDERS = [
 // Returns EIP-6963 wallets that aren't in our curated WALLET_PROVIDERS list —
 // e.g. Rabby, Brave, Phantom EVM. Each entry shape matches WALLET_PROVIDERS so
 // the modal can render them with the wallet's self-declared name + icon.
+// Excludes wallets matched by the curated rdns list AND by the curated name
+// patterns — otherwise a Coinbase variant with a novel rdns would show up
+// twice (once curated via the name-pattern fallback, once dynamic here).
 export function discoverEip6963Wallets() {
   const knownRdns = new Set(Object.values(KNOWN_WALLET_RDNS).flat())
+  const namePatterns = Object.values(KNOWN_WALLET_NAME_PATTERNS)
+  const matchesKnownName = (name) =>
+    typeof name === 'string' && namePatterns.some(p => p.test(name))
   const wallets = []
   for (const [rdns, entry] of eip6963Providers) {
     if (knownRdns.has(rdns)) continue
+    if (matchesKnownName(entry.info?.name)) continue
     wallets.push({
       id: `eip6963:${rdns}`,
       name: entry.info.name || rdns,


### PR DESCRIPTION
## Summary

Two coupled bugs blocking wallet connection on the deployed site:

### Bug 1 — Safari/passkey path: \`VITE_CIRCLE_CLIENT_KEY\` never reached the build

\`nginx/Dockerfile\` runs \`npm run build\` with no env vars, so Vite
embeds \`undefined\` into the bundle → \`circlePasskeyEnabled()\`
returns false → passkey option hidden in the modal → Safari users
have no way to connect.

**Fix**: Dockerfile accepts \`ARG VITE_CIRCLE_CLIENT_KEY\` (+ URL +
API_BASE), exposes as ENV before \`npm run build\`. \`docker-compose.yml\`
passes them as build args sourced from host \`.env\`.

### Bug 2 — Coinbase Wallet Chrome extension undetected

Confirmed via screenshot: Coinbase Wallet v3.140.0 installed, enabled,
"on all sites." Our \`getAvailableProviders()\` still returned empty
because we hardcoded \`com.coinbase.wallet\` as the only Coinbase rdns
and modern Coinbase ships under multiple variants.

**Fix**:
- \`KNOWN_WALLET_RDNS.coinbase\` expanded with 5 known variants
  (\`com.coinbase.wallet\`, \`.smartwallet\`, \`.cbwallet\`, \`org.coinbase.wallet\`,
  \`com.coinbase\`).
- Same treatment for MetaMask (\`io.metamask\`, \`.flask\`, \`.mobile\`).
- New \`KNOWN_WALLET_NAME_PATTERNS\` with case-insensitive substring match
  (\`/\\bcoinbase\\b/i\` etc.) — \`findEip6963Provider()\` now falls back to
  matching \`info.name\` if no rdns matches, catching future variants.
- \`discoverEip6963Wallets()\` excludes wallets caught by the
  name-pattern fallback so we don't double-list.

## Required follow-up (operator action, not code)

After merge + deploy, add to the EC2 host's \`.env\`:

\`\`\`
VITE_CIRCLE_CLIENT_KEY=<your testnet client key from Circle Console>
# Optional override (defaults to standard Circle URL):
# VITE_CIRCLE_CLIENT_URL=https://modular-sdk.circle.com/v1/rpc/w3s/buidl
\`\`\`

Then either re-trigger the deploy workflow OR \`docker compose up -d --build nginx\` on the host.

## Test plan

- [ ] Operator (Dan) adds VITE_CIRCLE_CLIENT_KEY to EC2 .env
- [ ] Re-build nginx container
- [ ] Maestro (Safari MCP): Connect Wallet modal shows "Sign in with Passkey" as first option
- [ ] Dan (Chrome): Coinbase Wallet extension appears + connects successfully
- [ ] Dan (Firefox): MetaMask still works (no regression)
- [ ] Wallet dropdown / profile / disconnect all unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)