### PR TITLE
[frontend] Purge misleading McLean-Pontiff footnote on Library Examples

### DIFF
--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -753,8 +753,8 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
 
       {examples.some(s => s.is_backtest_placeholder) && (
         <div className="caption mt-4 text-[var(--text-4)]">
-          * Estimated metrics — sourced from paper claims with McLean-Pontiff post-publication decay
-          applied. Replaced by real BacktestResult once the analytics engine runs.
+          * Pre-backtest hypothesis — empirical metrics pending evaluation. Real
+          numbers replace the placeholder once the analytics engine runs.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

The Library Examples table footnote claimed numbers existed (with a decay model) that don't actually render. Per Dan's directive: no fake numbers, no pretend functions.

## What was misleading

\`Strategies.jsx:605-619\` builds placeholder strategy records with every numeric metric (\`max_drawdown\`, \`sharpe_ratio\`, \`pbo_score\`, \`dsr_p_value\`, etc.) set to \`null\`. The \`fmt\` helper renders \`null\` as \`\"—\"\` — so the table shows no estimated numbers because no estimated numbers exist.

But the footnote at line 754-759 said:

> _\"Estimated metrics — sourced from paper claims with McLean-Pontiff post-publication decay applied. Replaced by real BacktestResult once the analytics engine runs.\"_

The McLean-Pontiff post-publication decay is a real academic concept (McLean & Pontiff 2016) but we **do not implement it anywhere in the codebase**. The footnote was describing a non-existent decay model that produced non-existent numbers.

## Fix

Replaced with the same honest copy \`StrategyPassport.jsx:186\` already uses for the same condition:

> _\"Pre-backtest hypothesis — empirical metrics pending evaluation. Real numbers replace the placeholder once the analytics engine runs.\"_

## Test plan

- [x] git diff is 2 insertions / 2 deletions in one file
- [x] Backend unchanged
- [ ] CI green
- [ ] Visual: Library Examples table footnote (when any placeholder exists) reads honest

## Anti-goals

- Did NOT implement McLean-Pontiff decay — that would be a multi-day backend project, not a hackathon-window item. Honest framing wins.
- Did NOT touch the placeholder records themselves — null-renders-as-\"—\" is already correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)