### PR TITLE
[frontend] Fix Chrome+Coinbase Wallet reload loop on chainChanged

### DIFF
--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -467,8 +467,18 @@ if (typeof window !== 'undefined' && window.ethereum) {
       window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: _address } }))
     }
   })
-  window.ethereum.on?.('chainChanged', () => {
-    window.location.reload()
+  // Coinbase Wallet (Chrome) re-emits chainChanged on internal lifecycle
+  // events — tab sync, popup re-open, multi-tab state sync — even when
+  // the chain hasn't changed. The previous handler reloaded on every
+  // emit, which produced an infinite reload loop on Chrome + Coinbase.
+  // Track the last-seen chain id and only react to actual transitions.
+  // viem clients are pinned to arcTestnet at construction so we don't
+  // need to rebuild them; just notify any consumer that wants to know.
+  let _lastChainId = null
+  window.ethereum.on?.('chainChanged', (newChainId) => {
+    if (newChainId === _lastChainId) return
+    _lastChainId = newChainId
+    window.dispatchEvent(new CustomEvent('wallet-chain-changed', { detail: { chainId: newChainId } }))
   })
 }
 


### PR DESCRIPTION
## Summary
- Coinbase Wallet on Chrome re-emits \`chainChanged\` on internal lifecycle events (tab sync, popup re-open, multi-tab state sync) even when the chain hasn't actually changed. Our handler called \`window.location.reload()\` unconditionally, producing an infinite reload loop on connect.
- Track the last-seen chain id; only react to real transitions. Drop the page reload (viem clients are pinned to \`arcTestnet\` at construction so nothing depends on it). Dispatch a \`wallet-chain-changed\` custom event for any future consumer.
- MetaMask is much quieter about \`chainChanged\` and didn't hit the loop; Chrome + Coinbase is the specifically-affected combination Dan reported.

## Test plan
- [ ] On deploy, open https://archimedes-arc.app in Chrome with Coinbase Wallet extension; click Connect Wallet → Coinbase. Page should NOT reload-thrash.
- [ ] In Console before connecting, run \`['accountsChanged','chainChanged','connect','disconnect'].forEach(ev => window.ethereum?.on?.(ev, (...a) => console.log('[wallet]', ev, a)))\` to confirm chainChanged still fires (Coinbase will emit it) but page stays stable.
- [ ] Disconnect + reconnect a few times — no reload loop.
- [ ] Sanity: MetaMask in Firefox still connects + works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)