### PR TITLE
[frontend] Fix passkey signup: default username had a space

### DIFF
--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -81,7 +81,10 @@ export function hasStoredPasskey() {
 // Throws standard WebAuthn DOMException errors on user cancellation
 // (NotAllowedError) or domain mismatch (SecurityError) — caller should
 // catch and surface a friendly message.
-export async function connectCirclePasskey({ mode = 'auto', username = 'Archimedes user' } = {}) {
+// Username constraint per Circle API: 5-50 chars, [a-zA-Z0-9_@.:+-]+ only.
+// Spaces are rejected; 'Archimedes user' (the old default) failed every
+// first-time signup with "The username is invalid."
+export async function connectCirclePasskey({ mode = 'auto', username = 'archimedes' } = {}) {
   if (!circlePasskeyEnabled()) {
     throw new Error('Circle passkey wallet is not configured (missing VITE_CIRCLE_CLIENT_KEY).')
   }


### PR DESCRIPTION
## Summary
- \`connectCirclePasskey()\` defaulted \`username = 'Archimedes user'\`. Circle's API rejects that with *"The username is invalid. It should be 5 to 50 characters and contain only alphanumeric and \_@.:+- characters."* — spaces fail the regex, so every first-time passkey signup on the live site failed before reaching WebAuthn.
- Default changed to \`'archimedes'\` (10 chars, all alphanumeric, matches the brand).
- Surfaced when Dan clicked "Sign in with Passkey" for the first time after HTTPS landed.

## Test plan
- [ ] On deploy, click Connect Wallet → Sign in with Passkey on https://archimedes-arc.app — WebAuthn biometric prompt should now appear (instead of the username-invalid error).
- [ ] Complete passkey register; smart account address renders in topbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)