### PR TITLE
[frontend] Fix profile data not persisting across page refresh

### DIFF
--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -52,7 +52,9 @@ export default function Layout({ page, setPage, walletAddr, onConnect, onDisconn
     }
     // Check localStorage gate — only show welcome modal once per wallet
     const seen = localStorage.getItem('archimedes.welcomeProfileSeen.' + walletAddr.toLowerCase())
-    fetch(`${API_BASE}/api/user/profile/${walletAddr}`)
+    fetch(`${API_BASE}/api/user/profile/${walletAddr}`, {
+        headers: { 'X-Wallet-Address': walletAddr },
+      })
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         setUserProfile(data)

--- a/ui/src/components/WelcomeProfileModal.jsx
+++ b/ui/src/components/WelcomeProfileModal.jsx
@@ -62,7 +62,10 @@ export default function WelcomeProfileModal({ walletAddr, onDone, mode = 'welcom
       }
       const res = await fetch(`${API_BASE}/api/user/profile`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Wallet-Address': walletAddr,
+        },
         body: JSON.stringify(payload),
       })
       if (!res.ok) {


### PR DESCRIPTION
**Bug:** Profile saves to Postgres correctly (3 real profiles in DB), but on refresh the edit modal shows empty fields.

**Root cause:** `GET /api/user/profile/{wallet}` was missing the `X-Wallet-Address` header. The backend's privacy logic treats headerless callers as anonymous and strips PII fields (display_name, email, marketing_opt_in) from the response → edit modal pre-fills with nulls.

**Fix:** Send `X-Wallet-Address` header on both GET (Layout.jsx) and POST (WelcomeProfileModal.jsx).