### PR TITLE
[frontend] Fix invisible marketing opt-in checkbox in profile modal

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -811,6 +811,17 @@ textarea {
   appearance: none;
 }
 
+/* Restore native checkbox / radio appearance */
+input[type="checkbox"],
+input[type="radio"] {
+  width: auto;
+  padding: 0;
+  -webkit-appearance: checkbox;
+  appearance: checkbox;
+  cursor: pointer;
+  accent-color: var(--accent);
+}
+
 input:hover,
 select:hover,
 textarea:hover {


### PR DESCRIPTION
**Bug:** 'Keep me updated on new strategies and features' checkbox was invisible in the profile modal.

**Root cause:** Global CSS `input { appearance: none; width: 100%; }` applied to all inputs including checkboxes — nukes the native checkbox rendering.

**Fix:** Added CSS override for `input[type=checkbox], input[type=radio]` restoring native appearance, auto width, and `accent-color: var(--accent)`.

**Backend was fine:** `marketing_opt_in` boolean is stored in Postgres, encrypted email + interests + attribution all captured correctly. This was purely a CSS visibility bug.