### PR TITLE
[security] Salvage 3 primitives from PR #199 onto current main (chat XML wrap + wallet enforce + auth_guard)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,13 @@ WALLET_ID=
 WALLET_ADDRESS=
 WALLET_SET_ID=
 
+# ── Internal agent authentication ─────────────────────────────────────────
+# Required by internal endpoints (traces/publish, agent/bootstrap-liquidity,
+# vault chat/rebalance + chat/regime-change). Generate with `openssl rand -hex 32`.
+# The agent runner must send this as `X-Internal-Agent-Key` on its requests.
+# If unset, all guarded endpoints return 403 (fail-closed).
+INTERNAL_AGENT_API_KEY=
+
 # How often the oracle runner pushes prices (seconds, default 60).
 ORACLE_INTERVAL_SECONDS=60
 

--- a/backend/archimedes/api/agent_routes.py
+++ b/backend/archimedes/api/agent_routes.py
@@ -6,8 +6,9 @@ import asyncio
 import contextlib
 from datetime import UTC
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
+from archimedes.api.auth_guard import require_internal_agent_key
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import AgentStatusResponse, AMMHealthResponse
 from archimedes.chain.executor import chain_executor
@@ -186,8 +187,11 @@ async def get_amm_health(request: Request):
 
 
 @agent_router.post("/bootstrap-liquidity")
-async def bootstrap_amm_liquidity():
-    """Add AMM pool liquidity so vault rebalances can execute."""
+async def bootstrap_amm_liquidity(_: None = Depends(require_internal_agent_key)):
+    """Add AMM pool liquidity so vault rebalances can execute.
+
+    Internal-only: requires X-Internal-Agent-Key header.
+    """
     from archimedes.services.amm_bootstrap import bootstrap_amm_liquidity as _bootstrap
 
     async def _run():

--- a/backend/archimedes/api/auth_guard.py
+++ b/backend/archimedes/api/auth_guard.py
@@ -1,0 +1,39 @@
+"""Internal agent authentication guard.
+
+Endpoints that trigger backend-signed on-chain actions or inject system events
+must only be callable by the internal agent runner, not by arbitrary public callers.
+
+Usage::
+
+    from archimedes.api.auth_guard import require_internal_agent_key
+    from fastapi import Depends
+
+    @router.post("/protected")
+    async def endpoint(_: None = Depends(require_internal_agent_key)):
+        ...
+
+Set INTERNAL_AGENT_API_KEY in the environment to a random 32-byte hex string
+(generate with `openssl rand -hex 32`).
+
+If the env var is unset, all requests are rejected (fail-closed). This avoids
+a deploy-time misconfiguration silently leaving internal endpoints open.
+
+User-facing endpoints (e.g. POST /api/vaults/create, POST /api/vaults/metadata)
+are deliberately NOT behind this guard — they're signed-by-system on behalf of
+a user who arrived via the UI, and the UI cannot carry the internal key. Use
+slowapi rate limits for DoS protection on those endpoints instead.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+from fastapi import HTTPException, Request
+
+
+def require_internal_agent_key(request: Request) -> None:
+    expected = os.getenv("INTERNAL_AGENT_API_KEY", "")
+    provided = request.headers.get("X-Internal-Agent-Key", "")
+    if not expected or not hmac.compare_digest(provided, expected):
+        raise HTTPException(status_code=403, detail="Forbidden")

--- a/backend/archimedes/api/chat_routes.py
+++ b/backend/archimedes/api/chat_routes.py
@@ -13,8 +13,9 @@ Design (per ecosystem-design-spec.md § 16–17):
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from archimedes.api.auth_guard import require_internal_agent_key
 from archimedes.api.schemas import (
     ChatMessageListResponse,
     ChatMessageResponse,
@@ -113,8 +114,10 @@ async def get_chat_count(address: str):
 
 
 @chat_router.post("/{address}/chat/rebalance")
-async def post_rebalance_event(address: str, body: dict):
+async def post_rebalance_event(address: str, body: dict, _: None = Depends(require_internal_agent_key)):
     """Post a rebalance event from the agent runner.
+
+    Internal-only: requires X-Internal-Agent-Key header.
 
     Body: {"reasoning": "...", "trades": [{"direction": "sell", "amount": 1000, "symbol": "sTSLA"}]}
     """
@@ -129,8 +132,10 @@ async def post_rebalance_event(address: str, body: dict):
 
 
 @chat_router.post("/{address}/chat/regime-change")
-async def post_regime_change(address: str, body: dict):
+async def post_regime_change(address: str, body: dict, _: None = Depends(require_internal_agent_key)):
     """Post a regime change event from the agent runner.
+
+    Internal-only: requires X-Internal-Agent-Key header.
 
     Body: {"old_regime": "risk_on", "new_regime": "risk_off", "confidence": 0.85}
     """

--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import UTC
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 
+from archimedes.api.auth_guard import require_internal_agent_key
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import (
     TraceListResponse,
@@ -170,8 +171,11 @@ async def get_trace(trace_id: str):
 
 
 @traces_router.post("/publish", response_model=TracePublishResponse)
-async def publish_trace(req: TracePublishRequest):
-    """Publish a reasoning trace: compute hash, anchor on Arc, persist off-chain."""
+async def publish_trace(req: TracePublishRequest, _: None = Depends(require_internal_agent_key)):
+    """Publish a reasoning trace: compute hash, anchor on Arc, persist off-chain.
+
+    Internal-only: requires X-Internal-Agent-Key header.
+    """
     import uuid
     from datetime import datetime
 

--- a/backend/archimedes/api/user_routes.py
+++ b/backend/archimedes/api/user_routes.py
@@ -109,11 +109,17 @@ async def get_profile(wallet: str, request: Request):
 async def upsert_profile(payload: UserProfileCreate, request: Request, response: Response):
     """Create or update a wallet's profile. All fields optional except wallet.
 
-    Email is encrypted at rest before storage.
+    Email is encrypted at rest before storage. Caller must supply an
+    `X-Wallet-Address` header matching `payload.wallet_address` — prevents one
+    wallet from writing another wallet's profile.
     """
+    caller = _extract_caller_wallet(request)
+    wallet = payload.wallet_address.lower()
+    if caller != wallet:
+        raise HTTPException(status_code=403, detail="Forbidden: X-Wallet-Address header must match payload wallet")
+
     session: Session = get_session()
     try:
-        wallet = payload.wallet_address.lower()
         profile = session.query(UserProfile).filter(UserProfile.wallet_address == wallet).first()
 
         interests_json = json.dumps(payload.interests) if payload.interests else "[]"

--- a/backend/archimedes/services/chat_service.py
+++ b/backend/archimedes/services/chat_service.py
@@ -205,7 +205,11 @@ class ChatService:
                 messages=[
                     {
                         "role": "user",
-                        "content": f"Vault: {vault_address}\nRecent chat:\n{context}\n\nUser asks: {user_message}",
+                        "content": (
+                            f"Vault: {vault_address}\n"
+                            f"<chat_history>\n{context}\n</chat_history>\n\n"
+                            f"<user_message>{user_message}</user_message>"
+                        ),
                     }
                 ],
             )

--- a/backend/tests/test_auth_guard.py
+++ b/backend/tests/test_auth_guard.py
@@ -1,0 +1,52 @@
+"""Unit tests for the internal agent key guard."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_request(header_value: str | None) -> MagicMock:
+    req = MagicMock()
+    if header_value is None:
+        req.headers = {}
+    else:
+        req.headers = {"X-Internal-Agent-Key": header_value}
+    return req
+
+
+def test_missing_header_is_rejected(monkeypatch):
+    monkeypatch.setenv("INTERNAL_AGENT_API_KEY", "deadbeef01234567")
+    from archimedes.api.auth_guard import require_internal_agent_key
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_internal_agent_key(_make_request(None))
+    assert exc_info.value.status_code == 403
+
+
+def test_wrong_key_is_rejected(monkeypatch):
+    monkeypatch.setenv("INTERNAL_AGENT_API_KEY", "deadbeef01234567")
+    from archimedes.api.auth_guard import require_internal_agent_key
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_internal_agent_key(_make_request("wrongvalue"))
+    assert exc_info.value.status_code == 403
+
+
+def test_correct_key_passes(monkeypatch):
+    monkeypatch.setenv("INTERNAL_AGENT_API_KEY", "deadbeef01234567")
+    from archimedes.api.auth_guard import require_internal_agent_key
+
+    result = require_internal_agent_key(_make_request("deadbeef01234567"))
+    assert result is None
+
+
+def test_unset_env_var_rejects_any_value(monkeypatch):
+    monkeypatch.delenv("INTERNAL_AGENT_API_KEY", raising=False)
+    from archimedes.api.auth_guard import require_internal_agent_key
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_internal_agent_key(_make_request("anyvalue"))
+    assert exc_info.value.status_code == 403

--- a/backend/tests/test_user_profile_privacy.py
+++ b/backend/tests/test_user_profile_privacy.py
@@ -177,6 +177,9 @@ class TestUpsertEncryption:
             from starlette.responses import Response as StarletteResponse
 
             mock_req = _MagicMock(spec=StarletteRequest)
+            # upsert_profile rejects writes where X-Wallet-Address header doesn't
+            # match payload.wallet_address. Match the payload so the auth check passes.
+            mock_req.headers = {"X-Wallet-Address": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}
             mock_resp = _MagicMock(spec=StarletteResponse)
             asyncio.get_event_loop().run_until_complete(upsert_profile(payload, request=mock_req, response=mock_resp))
 

--- a/backend/tests/test_user_routes.py
+++ b/backend/tests/test_user_routes.py
@@ -62,6 +62,7 @@ class TestUserProfileRoutes:
                 "display_name": "Alice",
                 "marketing_opt_in": False,
             },
+            headers={"X-Wallet-Address": _W_ALICE},
         )
         assert res.status_code == 200
         data = res.json()
@@ -76,6 +77,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_BOB,
                 "display_name": "Bob",
             },
+            headers={"X-Wallet-Address": _W_BOB},
         )
         # GET with owner header → full data
         res = client.get(
@@ -93,6 +95,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_BOB,
                 "display_name": "Bob",
             },
+            headers={"X-Wallet-Address": _W_BOB},
         )
         # GET without owner header → PII stripped
         res = client.get(f"/api/user/profile/{_W_BOB}")
@@ -111,6 +114,7 @@ class TestUserProfileRoutes:
                 "attribution": "Twitter",
                 "marketing_opt_in": True,
             },
+            headers={"X-Wallet-Address": _W_CHARLIE},
         )
         assert res.status_code == 200
         data = res.json()
@@ -129,6 +133,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CHARLIE,
                 "email": email,
             },
+            headers={"X-Wallet-Address": _W_CHARLIE},
         )
         # Read directly from DB
         session = get_session()
@@ -148,6 +153,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_UPDATE,
                 "display_name": "Original",
             },
+            headers={"X-Wallet-Address": _W_UPDATE},
         )
         res = client.post(
             "/api/user/profile",
@@ -156,6 +162,7 @@ class TestUserProfileRoutes:
                 "display_name": "Updated",
                 "marketing_opt_in": True,
             },
+            headers={"X-Wallet-Address": _W_UPDATE},
         )
         assert res.status_code == 200
         assert res.json()["display_name"] == "Updated"
@@ -168,6 +175,7 @@ class TestUserProfileRoutes:
             json={
                 "wallet_address": _W_MINIMAL,
             },
+            headers={"X-Wallet-Address": _W_MINIMAL},
         )
         assert res.status_code == 200
         data = res.json()
@@ -194,6 +202,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CASE,
                 "display_name": "CaseTest",
             },
+            headers={"X-Wallet-Address": _W_CASE},
         )
         # Query with lowercase + owner header
         res = client.get(
@@ -218,6 +227,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CHARLIE,
                 "email": "secret@example.com",
             },
+            headers={"X-Wallet-Address": _W_CHARLIE},
         )
         res = client.get(f"/api/user/profile/{_W_CHARLIE}")
         assert res.status_code == 200
@@ -231,6 +241,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CHARLIE,
                 "email": "owner@example.com",
             },
+            headers={"X-Wallet-Address": _W_CHARLIE},
         )
         res = client.get(
             f"/api/user/profile/{_W_CHARLIE}",


### PR DESCRIPTION
## Summary

Salvages the three substantive security primitives from PR #199 (Daniel R., \`security/auth-hardening\`) onto current main. The original branch was 60 commits behind main; merging it cleanly would have silently dropped most of the work (I tried — proved this empirically on a throwaway branch). This PR cherry-picks the still-needed primitives onto a fresh base.

## Three atomic commits

| # | Commit | What it adds |
|---|---|---|
| 1 | \`d95e157\` | **chat_service.py XML wrap.** The AI_SYSTEM_PROMPT (lines 22-38) already had the injection-resistance clause referencing \`<user_message>\` and \`<chat_history>\` tags, but the runtime prompt construction wasn't actually wrapping user content in those tags. Now wired. |
| 2 | \`66092ba\` | **user_routes.py wallet-check enforcement.** Adds the missing \`if caller != wallet: raise 403\` in \`upsert_profile\`. Pairs with the existing UI behavior — WelcomeProfileModal.jsx:67 was already sending \`X-Wallet-Address: walletAddr\` against an endpoint that wasn't yet checking it. Also updates \`test_user_routes.py\` POSTs to include the header (10 places) so the 4 tests that were failing on main today now pass. |
| 3 | (this commit) | **auth_guard.py + apply to 4 truly-internal endpoints.** New \`require_internal_agent_key\` dependency (HMAC + fail-closed) applied to \`/api/traces/publish\`, \`/api/agent/bootstrap-liquidity\`, \`/api/vaults/{addr}/chat/rebalance\`, \`/api/vaults/{addr}/chat/regime-change\`. Includes 4-case test suite and \`.env.example\` entry. |

## Why the original PR couldn't merge cleanly

Daniel R.'s branch added the auth guard to **6** endpoints — including \`/api/vaults/create\` and \`/api/vaults/metadata\` which are called by the UI's CreateVaultModal flow. That was the BLOCKER I flagged earlier (#236) — merging as-is would have 403'd every user-initiated vault deploy.

This salvage PR applies the guard to the **4 truly-internal endpoints only**, skipping the 2 UI-callable ones. \`auth_guard.py\`'s docstring documents this as a deliberate exclusion. DoS protection on the user-facing endpoints continues via the slowapi rate limits already in place.

The original PR's other changes were either already absorbed into main via the #177-#181 security PR series (CORS lockdown, rate limiting, security headers, user-data minimization, Dependabot+secret-scanning) or were targeting the older pre-#132 route file structure (\`routes.py\` before the per-resource split) that no longer exists.

## Test plan

- [x] \`pytest backend/tests/test_auth_guard.py -q\` → 4 passed
- [x] \`pytest backend/tests/test_user_routes.py -q\` → 12 passed (was 4 failed on main before this PR)
- [x] \`pytest backend/tests --collect-only -q\` → 792 tests collected (no import errors)
- [ ] CI green on PR
- [ ] After merge: set \`INTERNAL_AGENT_API_KEY\` on EC2 (\`openssl rand -hex 32\`) BEFORE the deploy completes, else the agent runner's calls to the 4 internal endpoints will 403

## Anti-goals respected

- DO NOT guard \`/api/vaults/create\` or \`/api/vaults/metadata\` — they're UI-callable; would break the demo
- DO NOT rotate Circle credentials in this PR — that's a separate operational concern Daniel R. flagged; not blocking
- DO NOT touch the routes the #177-#181 series already secured (CORS, rate limits, security headers, etc.)
- DO NOT modify \`security/auth-hardening\` branch directly — it's Daniel R.'s authored work; this is a cherry-pick onto a fresh branch with full attribution in commit messages

## Coordination

PR #199 will be **closed as superseded** by this PR (with a comment for Daniel R. explaining the salvage). His authored work is preserved in commit messages crediting the original PR.

The single operational dependency: **set \`INTERNAL_AGENT_API_KEY\` on EC2 before merging this PR** so the agent runner can authenticate immediately on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)