### PR TITLE
[frontend] Fix Corpus Catalog 0-papers-found: trailing slash on /api/papers

### DIFF
--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -38,7 +38,10 @@ export default function CorpusExplorer() {
       const params = new URLSearchParams({ page: String(page), limit: '20' })
       if (search) params.set('search', search)
       if (categoryFilter) params.set('category', categoryFilter)
-      const data = await apiGet(`/api/papers?${params}`)
+      // Trailing slash matters: FastAPI 307-redirects /api/papers → /api/papers/,
+      // and the browser silently drops the query string on the redirect, so the
+      // catalog rendered "0 papers found" despite the backend having 10000.
+      const data = await apiGet(`/api/papers/?${params}`)
       setPapers(data.papers || [])
       setTotalPapers(data.total || 0)
     } catch { setPapers([]) }


### PR DESCRIPTION
## Summary
- \`CorpusExplorer.jsx\` fetched \`/api/papers?...\` (no trailing slash). FastAPI 307-redirects collection routes to add the slash, and the browser silently drops the query string on the redirect, so the catalog rendered "0 papers found" despite the backend having 10,000 papers.
- One-line fix: \`/api/papers/?...\` (trailing slash) lands directly.
- Surfaced during the live-site red-team walk on https://archimedes-arc.app after HTTPS landed.

## Test plan
- [ ] Open https://archimedes-arc.app/corpus → Catalog tab → see populated table with ~10000 papers (not "0 papers found")
- [ ] Search + category filter still work
- [ ] Pagination still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)