### PR TITLE
[security] SSM secrets migration (Issue #176)

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -18,6 +18,12 @@ from slowapi.errors import RateLimitExceeded
 load_dotenv("../.env", override=True)  # Project root .env first (has real secrets)
 load_dotenv(".env", override=False)  # Backend-local .env fills in any missing (no override)
 
+# Load secrets from AWS SSM Parameter Store (production).
+# No-op when AWS_SSM_PATH_PREFIX is unset (local dev). Must run BEFORE
+# any service imports that read os.environ for API keys / secrets.
+from archimedes.services.secrets_service import load_ssm_secrets  # noqa: E402
+load_ssm_secrets()
+
 # Shared rate limiter (Redis-backed, falls back to in-memory).
 # Defined in a separate module to avoid circular imports with route modules.
 from archimedes.api.chat_routes import chat_router

--- a/backend/tests/services/test_secrets_service.py
+++ b/backend/tests/services/test_secrets_service.py
@@ -1,0 +1,233 @@
+"""Tests for archimedes.services.secrets_service (SSM Parameter Store loader).
+
+All tests mock boto3 — no real AWS calls.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure test secrets don't leak into the real environment."""
+    # Remove any SSM-related env vars that might interfere
+    for key in ("AWS_SSM_PATH_PREFIX", "AWS_REGION", "TEST_SECRET_1", "TEST_SECRET_2", "DATABASE_URL_FROM_SSM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestExtractEnvName:
+    """Unit tests for the _extract_env_name helper."""
+
+    def test_simple_uppercase(self):
+        from archimedes.services.secrets_service import _extract_env_name
+
+        assert _extract_env_name("/archimedes/prod/LLM_AUTH_TOKEN", "/archimedes/prod/") == "LLM_AUTH_TOKEN"
+
+    def test_nested_path(self):
+        from archimedes.services.secrets_service import _extract_env_name
+
+        assert _extract_env_name("/archimedes/prod/circle/api-key", "/archimedes/prod/") == "CIRCLE_API_KEY"
+
+    def test_hyphen_to_underscore(self):
+        from archimedes.services.secrets_service import _extract_env_name
+
+        assert _extract_env_name("/archimedes/prod/dev-wallet-private-key", "/archimedes/prod/") == "DEV_WALLET_PRIVATE_KEY"
+
+    def test_already_uppercase(self):
+        from archimedes.services.secrets_service import _extract_env_name
+
+        assert _extract_env_name("/archimedes/prod/DATABASE_URL", "/archimedes/prod/") == "DATABASE_URL"
+
+
+class TestLoadSsmSecrets:
+    """Integration-style tests for load_ssm_secrets with mocked boto3."""
+
+    def _mock_ssm_response(self, parameters: list[dict]) -> MagicMock:
+        """Create a mock SSM client that returns the given parameters."""
+        mock_client = MagicMock()
+        mock_client.get_parameters_by_path.return_value = {
+            "Parameters": parameters,
+        }
+        return mock_client
+
+    @patch("boto3.client")
+    def test_loads_parameters_into_env(self, mock_boto3, monkeypatch):
+        """SSM parameters are injected into os.environ."""
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
+        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+
+        mock_client = self._mock_ssm_response([
+            {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "secret-value-1"},
+            {"Name": "/archimedes/prod/TEST_SECRET_2", "Value": "secret-value-2"},
+        ])
+        mock_boto3.return_value = mock_client
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets()
+
+        assert count == 2
+        assert os.environ.get("TEST_SECRET_1") == "secret-value-1"
+        assert os.environ.get("TEST_SECRET_2") == "secret-value-2"
+
+    @patch("boto3.client")
+    def test_does_not_override_existing_by_default(self, mock_boto3, monkeypatch):
+        """Existing env vars are NOT overwritten when override_existing=False."""
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
+        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        monkeypatch.setenv("TEST_SECRET_1", "original-value")
+
+        mock_client = self._mock_ssm_response([
+            {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "ssm-value"},
+        ])
+        mock_boto3.return_value = mock_client
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets()
+
+        assert count == 0  # Nothing loaded (already set)
+        assert os.environ.get("TEST_SECRET_1") == "original-value"
+
+    @patch("boto3.client")
+    def test_override_existing_when_flag_set(self, mock_boto3, monkeypatch):
+        """With override_existing=True, SSM values replace existing env vars."""
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
+        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        monkeypatch.setenv("TEST_SECRET_1", "original-value")
+
+        mock_client = self._mock_ssm_response([
+            {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "ssm-override"},
+        ])
+        mock_boto3.return_value = mock_client
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets(override_existing=True)
+
+        assert count == 1
+        assert os.environ.get("TEST_SECRET_1") == "ssm-override"
+
+    def test_noop_when_prefix_not_set(self, monkeypatch):
+        """No AWS calls when AWS_SSM_PATH_PREFIX is unset."""
+        monkeypatch.delenv("AWS_SSM_PATH_PREFIX", raising=False)
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets()
+        assert count == 0
+
+    @patch("boto3.client")
+    def test_handles_no_credentials_gracefully(self, mock_boto3, monkeypatch):
+        """NoCredentialsError → returns 0, does not crash."""
+        from botocore.exceptions import NoCredentialsError
+
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
+
+        mock_boto3.return_value.get_parameters_by_path.side_effect = NoCredentialsError()
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets()
+        assert count == 0
+
+    @patch("boto3.client")
+    def test_handles_client_error_gracefully(self, mock_boto3, monkeypatch):
+        """ClientError → returns 0, does not crash."""
+        from botocore.exceptions import ClientError
+
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
+
+        mock_boto3.return_value.get_parameters_by_path.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+            "GetParametersByPath",
+        )
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets()
+        assert count == 0
+
+    @patch("boto3.client")
+    def test_pagination(self, mock_boto3, monkeypatch):
+        """Handles paginated SSM responses correctly."""
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
+        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+
+        mock_client = MagicMock()
+        # First page returns a NextToken
+        mock_client.get_parameters_by_path.side_effect = [
+            {
+                "Parameters": [{"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "val1"}],
+                "NextToken": "token-abc",
+            },
+            {
+                "Parameters": [{"Name": "/archimedes/prod/TEST_SECRET_2", "Value": "val2"}],
+            },
+        ]
+        mock_boto3.return_value = mock_client
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets()
+
+        assert count == 2
+        assert os.environ.get("TEST_SECRET_1") == "val1"
+        assert os.environ.get("TEST_SECRET_2") == "val2"
+        # Verify pagination was followed
+        assert mock_client.get_parameters_by_path.call_count == 2
+
+    @patch("boto3.client")
+    def test_explicit_prefix_and_region(self, mock_boto3, monkeypatch):
+        """Explicit prefix/region args override env vars."""
+        # Don't set env vars — use explicit args
+        mock_client = self._mock_ssm_response([
+            {"Name": "/custom/path/MY_KEY", "Value": "my-val"},
+        ])
+        mock_boto3.return_value = mock_client
+
+        from archimedes.services.secrets_service import load_ssm_secrets
+
+        count = load_ssm_secrets(prefix="/custom/path/", region="us-east-1")
+
+        assert count == 1
+        assert os.environ.get("MY_KEY") == "my-val"
+        mock_boto3.assert_called_with("ssm", region_name="us-east-1")
+
+
+class TestListSsmParameters:
+    """Tests for the diagnostic list_ssm_parameters helper."""
+
+    @patch("boto3.client")
+    def test_returns_param_names(self, mock_boto3):
+        from archimedes.services.secrets_service import list_ssm_parameters
+
+        mock_client = MagicMock()
+        mock_client.get_parameters_by_path.return_value = {
+            "Parameters": [
+                {"Name": "/archimedes/prod/SECRET_A", "Value": "a"},
+                {"Name": "/archimedes/prod/SECRET_B", "Value": "b"},
+            ],
+        }
+        mock_boto3.return_value = mock_client
+
+        names = list_ssm_parameters()
+        assert names == ["/archimedes/prod/SECRET_A", "/archimedes/prod/SECRET_B"]
+
+    @patch("boto3.client")
+    def test_returns_empty_on_error(self, mock_boto3):
+        from botocore.exceptions import ClientError
+
+        from archimedes.services.secrets_service import list_ssm_parameters
+
+        mock_boto3.return_value.get_parameters_by_path.side_effect = ClientError(
+            {"Error": {"Code": "InternalError", "Message": "oops"}},
+            "GetParametersByPath",
+        )
+
+        names = list_ssm_parameters()
+        assert names == []

--- a/infra/scripts/seed-ssm-secrets.sh
+++ b/infra/scripts/seed-ssm-secrets.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Seed SSM secrets from a local env file.
+# Usage: ./infra/scripts/seed-ssm-secrets.sh /path/to/secrets.env
+#
+# The secrets file is NOT committed — it's a one-time operator artifact.
+# Format: KEY=VALUE (one per line, same as .env)
+set -euo pipefail
+
+SECRETS_FILE="${1:?Usage: $0 /path/to/secrets.env}"
+REGION="${AWS_REGION:-eu-west-2}"
+PREFIX="${AWS_SSM_PATH_PREFIX:-/archimedes/prod}"
+
+if [ ! -f "$SECRETS_FILE" ]; then
+  echo "Error: $SECRETS_FILE not found" >&2
+  exit 1
+fi
+
+echo "Seeding SSM parameters from $SECRETS_FILE → ${PREFIX}/* (region: $REGION)"
+
+count=0
+while IFS='=' read -r key value; do
+  # Skip empty lines and comments
+  [[ -z "$key" || "$key" =~ ^# ]] && continue
+  # Strip quotes from value
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+
+  if [ -z "$value" ]; then
+    echo "  SKIP: $key (empty value)"
+    continue
+  fi
+
+  aws ssm put-parameter \
+    --name "${PREFIX}/${key}" \
+    --value "$value" \
+    --type SecureString \
+    --overwrite \
+    --region "$REGION" \
+    --query "Version" --output text 2>&1 | xargs -I{} echo "  OK: $key (v{})"
+  count=$((count + 1))
+done < "$SECRETS_FILE"
+
+echo "Done. Seeded $count parameters under ${PREFIX}/"
+echo "Verify: aws ssm get-parameters-by-path --path ${PREFIX}/ --recursive --query 'Parameters[*].Name' --region $REGION"

--- a/infra/terraform/iam_archimedes_backend.tf
+++ b/infra/terraform/iam_archimedes_backend.tf
@@ -29,6 +29,27 @@ resource "aws_iam_role_policy" "backend_s3_dynamodb" {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid    = "SSMSecretsAccess"
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParametersByPath",
+          "ssm:GetParameters",
+          "ssm:GetParameter",
+        ]
+        Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/archimedes/prod/*"
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "ssm.${var.aws_region}.amazonaws.com"
+          }
+        }
+      },
+      {
         Sid    = "S3CorpusAccess"
         Effect = "Allow"
         Action = [


### PR DESCRIPTION
Wires SSM Parameter Store into backend startup. 5 secrets seeded as SecureString. IAM policy updated. 14 tests pass.

Closes #176