### PR TITLE
[chore] ruff format aftermath of SSM secrets work — unblock CI gate

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -22,6 +22,7 @@ load_dotenv(".env", override=False)  # Backend-local .env fills in any missing (
 # No-op when AWS_SSM_PATH_PREFIX is unset (local dev). Must run BEFORE
 # any service imports that read os.environ for API keys / secrets.
 from archimedes.services.secrets_service import load_ssm_secrets  # noqa: E402
+
 load_ssm_secrets()
 
 # Shared rate limiter (Redis-backed, falls back to in-memory).

--- a/backend/archimedes/services/secrets_service.py
+++ b/backend/archimedes/services/secrets_service.py
@@ -95,9 +95,7 @@ def load_ssm_secrets(
         client = boto3.client("ssm", region_name=region)
         parameters = _fetch_all_parameters(client, prefix)
     except NoCredentialsError:
-        logger.info(
-            "secrets_service: no AWS credentials available — skipping SSM (expected in local dev)"
-        )
+        logger.info("secrets_service: no AWS credentials available — skipping SSM (expected in local dev)")
         return 0
     except (BotoCoreError, ClientError) as exc:
         logger.warning("secrets_service: SSM fetch failed: %s — falling back to .env", exc)

--- a/backend/tests/services/test_secrets_service.py
+++ b/backend/tests/services/test_secrets_service.py
@@ -35,7 +35,10 @@ class TestExtractEnvName:
     def test_hyphen_to_underscore(self):
         from archimedes.services.secrets_service import _extract_env_name
 
-        assert _extract_env_name("/archimedes/prod/dev-wallet-private-key", "/archimedes/prod/") == "DEV_WALLET_PRIVATE_KEY"
+        assert (
+            _extract_env_name("/archimedes/prod/dev-wallet-private-key", "/archimedes/prod/")
+            == "DEV_WALLET_PRIVATE_KEY"
+        )
 
     def test_already_uppercase(self):
         from archimedes.services.secrets_service import _extract_env_name
@@ -60,10 +63,12 @@ class TestLoadSsmSecrets:
         monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
         monkeypatch.setenv("AWS_REGION", "eu-west-2")
 
-        mock_client = self._mock_ssm_response([
-            {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "secret-value-1"},
-            {"Name": "/archimedes/prod/TEST_SECRET_2", "Value": "secret-value-2"},
-        ])
+        mock_client = self._mock_ssm_response(
+            [
+                {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "secret-value-1"},
+                {"Name": "/archimedes/prod/TEST_SECRET_2", "Value": "secret-value-2"},
+            ]
+        )
         mock_boto3.return_value = mock_client
 
         from archimedes.services.secrets_service import load_ssm_secrets
@@ -81,9 +86,11 @@ class TestLoadSsmSecrets:
         monkeypatch.setenv("AWS_REGION", "eu-west-2")
         monkeypatch.setenv("TEST_SECRET_1", "original-value")
 
-        mock_client = self._mock_ssm_response([
-            {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "ssm-value"},
-        ])
+        mock_client = self._mock_ssm_response(
+            [
+                {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "ssm-value"},
+            ]
+        )
         mock_boto3.return_value = mock_client
 
         from archimedes.services.secrets_service import load_ssm_secrets
@@ -100,9 +107,11 @@ class TestLoadSsmSecrets:
         monkeypatch.setenv("AWS_REGION", "eu-west-2")
         monkeypatch.setenv("TEST_SECRET_1", "original-value")
 
-        mock_client = self._mock_ssm_response([
-            {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "ssm-override"},
-        ])
+        mock_client = self._mock_ssm_response(
+            [
+                {"Name": "/archimedes/prod/TEST_SECRET_1", "Value": "ssm-override"},
+            ]
+        )
         mock_boto3.return_value = mock_client
 
         from archimedes.services.secrets_service import load_ssm_secrets
@@ -185,9 +194,11 @@ class TestLoadSsmSecrets:
     def test_explicit_prefix_and_region(self, mock_boto3, monkeypatch):
         """Explicit prefix/region args override env vars."""
         # Don't set env vars — use explicit args
-        mock_client = self._mock_ssm_response([
-            {"Name": "/custom/path/MY_KEY", "Value": "my-val"},
-        ])
+        mock_client = self._mock_ssm_response(
+            [
+                {"Name": "/custom/path/MY_KEY", "Value": "my-val"},
+            ]
+        )
         mock_boto3.return_value = mock_client
 
         from archimedes.services.secrets_service import load_ssm_secrets

--- a/docs/benchmarks/generate_chart.py
+++ b/docs/benchmarks/generate_chart.py
@@ -5,6 +5,7 @@ Produces docs/benchmarks/stockbench-vs-baselines.png
 """
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
@@ -57,7 +58,15 @@ ax.set_title(
 for i, (v, agent) in enumerate(zip(sortino, agents)):
     offset = 0.08 if v >= 0 else -0.08
     ha = "left" if v >= 0 else "right"
-    ax.text(v + offset, i, f"{v:+.2f}", va="center", ha=ha, fontsize=9, fontweight="bold" if agent.startswith("Archimedes") else "normal")
+    ax.text(
+        v + offset,
+        i,
+        f"{v:+.2f}",
+        va="center",
+        ha=ha,
+        fontsize=9,
+        fontweight="bold" if agent.startswith("Archimedes") else "normal",
+    )
 
 # Zero line
 ax.axvline(x=0, color="#555", linewidth=0.8, linestyle="--", alpha=0.5)


### PR DESCRIPTION
## Summary
- PRs #260 + #265 landed without \`ruff format\`, leaving 4 files unformatted: \`backend/archimedes/main.py\`, \`backend/archimedes/services/secrets_service.py\`, \`backend/tests/services/test_secrets_service.py\`, \`docs/benchmarks/generate_chart.py\`.
- Quality gate \`ruff format --check .\` is now failing on every PR opened against main, blocking otherwise-clean PRs from merging.
- Pure formatting (whitespace/alignment) — no logic changes.

## Test plan
- [x] \`ruff format --check .\` passes locally
- [x] Local \`pytest -m "not integration"\` — 802 pass / 2 unrelated pre-existing failures (Redis-mocking, not introduced by this PR)
- [ ] CI ruff-gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)