### PR TITLE
[backend] Fix corpus pipeline rate limiting + retry/backoff

### DIFF
--- a/backend/archimedes/scripts/hydrate_corpus.py
+++ b/backend/archimedes/scripts/hydrate_corpus.py
@@ -32,6 +32,8 @@ DEFAULT_TEXT_DIR = Path("data/corpus/text")
 DEFAULT_PDF_DIR = Path("data/corpus/pdfs")
 # Polite delay between arXiv downloads (seconds).
 _DOWNLOAD_DELAY = 3.0
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 10  # seconds; exponential: 10, 20, 40
 
 
 def _resolve_manifest() -> Path | None:
@@ -96,14 +98,29 @@ def hydrate(
             try:
                 import requests
 
-                resp = requests.get(
-                    pdf_url,
-                    timeout=30,
-                    headers={"User-Agent": "archimedes-corpus-hydration/1.0"},
-                )
-                resp.raise_for_status()
-                pdf_path.write_bytes(resp.content)
-                logger.info("hydrate: downloaded PDF for %s", arxiv_id)
+                downloaded = False
+                for attempt in range(_MAX_RETRIES):
+                    resp = requests.get(
+                        pdf_url,
+                        timeout=30,
+                        headers={"User-Agent": "archimedes-corpus-hydration/1.0"},
+                    )
+                    if resp.status_code in (429, 503) and attempt < _MAX_RETRIES - 1:
+                        wait = _BACKOFF_BASE * (2 ** attempt)
+                        logger.warning(
+                            "hydrate: %d from arXiv for %s — backing off %ds (attempt %d/%d)",
+                            resp.status_code, arxiv_id, wait, attempt + 1, _MAX_RETRIES,
+                        )
+                        time.sleep(wait)
+                        continue
+                    resp.raise_for_status()
+                    pdf_path.write_bytes(resp.content)
+                    downloaded = True
+                    logger.info("hydrate: downloaded PDF for %s", arxiv_id)
+                    break
+                if not downloaded:
+                    logger.warning("hydrate: gave up on %s after %d retries", arxiv_id, _MAX_RETRIES)
+                    continue
                 time.sleep(_DOWNLOAD_DELAY)
             except Exception as exc:
                 logger.warning("hydrate: PDF download failed for %s: %s", arxiv_id, exc)

--- a/backend/archimedes/services/arxiv_corpus.py
+++ b/backend/archimedes/services/arxiv_corpus.py
@@ -83,8 +83,11 @@ _TEXT_REL = "data/corpus/text"
 
 # Polite to the arXiv API: their guidance is a single request every ~3s.
 _API_DELAY_SECONDS = 3.0
+_PDF_DOWNLOAD_DELAY = 3.0  # same polite delay between PDF downloads
 _API_PAGE_SIZE = 100
 _PDF_TIMEOUT_SECONDS = 30
+_PDF_MAX_RETRIES = 3
+_PDF_BACKOFF_BASE = 10  # seconds; exponential: 10, 20, 40
 
 
 # ── Records ─────────────────────────────────────────────────────
@@ -256,15 +259,26 @@ def _dedupe_and_trim(papers: Iterable[CorpusPaper], max_papers: int) -> list[Cor
 
 
 def _default_pdf_downloader(pdf_url: str) -> bytes:
+    """Download a PDF with retry + exponential backoff on 429/503."""
     import requests  # lazy
 
-    resp = requests.get(
-        pdf_url,
-        timeout=_PDF_TIMEOUT_SECONDS,
-        headers={"User-Agent": "archimedes-arxiv-corpus/1.0 (+hackathon)"},
-    )
-    resp.raise_for_status()
-    return resp.content
+    for attempt in range(_PDF_MAX_RETRIES):
+        resp = requests.get(
+            pdf_url,
+            timeout=_PDF_TIMEOUT_SECONDS,
+            headers={"User-Agent": "archimedes-arxiv-corpus/1.0 (+hackathon)"},
+        )
+        if resp.status_code in (429, 503) and attempt < _PDF_MAX_RETRIES - 1:
+            wait = _PDF_BACKOFF_BASE * (2 ** attempt)
+            logger.warning("arxiv returned %d — backing off %ds (attempt %d/%d)",
+                          resp.status_code, wait, attempt + 1, _PDF_MAX_RETRIES)
+            import time
+            time.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.content
+    # Should not reach here, but satisfy type checker
+    raise RuntimeError(f"PDF download failed after {_PDF_MAX_RETRIES} retries")
 
 
 def _cache_pdf(
@@ -391,6 +405,9 @@ def build_corpus(
                 pdf_ok += 1
                 if _extract_text(paper, pdf_dir, text_dir):
                     text_ok += 1
+                # Polite delay between PDF downloads — respect arXiv rate limits
+                import time
+                time.sleep(_PDF_DOWNLOAD_DELAY)
         rows.append(paper.manifest_row(pdf_sha256=sha, fetched_at=fetched_at))
         if idx % 25 == 0:
             logger.info("processed %d/%d papers", idx, len(papers))


### PR DESCRIPTION
**Problem:** `arxiv_corpus.py` had zero delay between PDF downloads — hammered arXiv's PDF server, causing mass 429s and only 669/10k papers downloading successfully.

**Fix:**
- `arxiv_corpus.py`: 3s delay between PDF downloads + retry with exponential backoff (10/20/40s) on 429/503
- `hydrate_corpus.py`: retry with exponential backoff on 429/503 (existing 3s delay preserved)

45 corpus/arxiv tests pass.