### PR TITLE
[infra] CSP: allow modular-sdk.circle.com for passkey wallet calls

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,7 +33,12 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "same-origin" always;
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://rpc.testnet.arc.network https://testnet.arcscan.app https://*.coingecko.com https://*.alchemyapi.io https://api.z.ai https://api.anthropic.com wss://*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;" always;
+    # Circle Modular Wallets SDK calls https://modular-sdk.circle.com for passkey
+    # register/login + bundler RPC. Chrome strictly enforces connect-src; without
+    # this entry, the SDK fails with "An unknown RPC error occurred. Details:
+    # Failed to fetch" on every passkey signup. Safari is more lenient and worked
+    # before this entry was added, which is why the regression was Chrome-only.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://rpc.testnet.arc.network https://testnet.arcscan.app https://*.coingecko.com https://*.alchemyapi.io https://api.z.ai https://api.anthropic.com https://modular-sdk.circle.com wss://*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;" always;
 
     # SPA fallback — serve index.html for client-side routes
     location / {


### PR DESCRIPTION
## Summary
- Chrome strictly enforces CSP \`connect-src\`. Our policy omitted \`https://modular-sdk.circle.com\`, so the Circle Modular Wallets SDK failed with *"An unknown RPC error occurred. Details: Failed to fetch"* on every passkey register/login in Chrome.
- Safari is more lenient about \`connect-src\` enforcement, which is why Safari passkey signup worked after the Circle Console domain config was completed but Chrome still failed.
- Adds \`https://modular-sdk.circle.com\` to \`connect-src\`. Nothing else changed.

## Test plan
- [ ] After deploy: \`curl -sI https://archimedes-arc.app/ | grep -i content-security\` should show \`modular-sdk.circle.com\` in connect-src
- [ ] In Chrome: Connect Wallet → Sign in with Passkey → biometric prompt fires + smart account created
- [ ] In Safari: still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)