### PR TITLE
[infra] Fix KB artifact path in backend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
       ARCHIMEDES_STRATEGIES_DIR: /app/analytics-engine/strategies
       ARCHIMEDES_CORPUS_MANIFEST: /app/data/corpus/manifest.jsonl
       ARCHIMEDES_FUSION_ENABLED: ${ARCHIMEDES_FUSION_ENABLED:-true}
+      KB_ARTIFACT_DIR: /app/data/corpus-artifact
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Backend couldn't find KB artifacts because `KB_ARTIFACT_DIR` wasn't set — defaulted to `/srv/corpus-artifact` but volume is mounted at `/app/data/corpus-artifact`.