### PR TITLE
[docs] M.4 Day-13 content refresh — sync test counts + dates + Day-12/13 ship deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make clean      # nuke __pycache__/.pytest_cache/.ruff_cache
 
 Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`, …) are also there — see `make help`.
 
-## Status (2026-05-24)
+## Status (2026-05-25 — submission day)
 
 **Live on the Arc public testnet** (chain ID `5042002`): grab faucet USDC at <https://faucet.circle.com/> (20 USDC / 2h — on Arc, USDC *is* gas) and try the full flow with test funds. **No real money at risk, by design.** Arc has no mainnet yet (Circle's docs list mainnet as "upcoming"); mainnet launch, real-funds custody, and the regulatory architecture (off-chain redemptions, preset-strategy / RIA posture) are the **business-plan roadmap**, not hackathon scope — see [`docs/competitor-landscape.md`](docs/competitor-landscape.md).
 
@@ -65,7 +65,8 @@ Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`,
 - On-chain reasoning trace anchoring via the deployed `ReasoningTraceRegistry`
 - 6-container docker stack: backend (FastAPI) + postgres + redis + nginx + oracle + agent
 - Multi-wallet UX (MetaMask + Coinbase + Circle passkey via EIP-6963 wallet discovery) with profile dropdown
-- 576 backend tests + 16 analytics-engine tests green
+- 806 backend tests + 16 analytics-engine tests collected
+- Server-side ruff format guard (`main-format-guard.yml`) — main self-heals if a direct-to-main commit lands unformatted; CI run stays red so the violation is visible
 
 ## Why Archimedes
 

--- a/docs/claude-design-prompts.md
+++ b/docs/claude-design-prompts.md
@@ -5,7 +5,7 @@
 > **Purpose:** Concrete, paste-ready prompts for slides, UI prototypes, logos, and
 > explanatory visualizations. Each prompt is self-contained so the design session has
 > the context it needs without you re-explaining the project.
-> **Status:** **Day-11 revision (2026-05-23).** Refreshes the Day-10 baseline
+> **Status:** **Day-13 revision (2026-05-25, submission day).** Refreshes the Day-10 baseline
 > against spine-plus-v2 (8 commits ahead of `origin/main`: Phases 0–3 + follow-ups
 > + Makefile + the Day-11 docs cleanup) and Chuan's `bd6935b` (Strategy DSL +
 > interpreter + fusion evaluator pipeline). Current snapshot the prompts reflect:
@@ -27,7 +27,7 @@
 > 2007 + Moreira-Muir 2017 — pass all four gates on 22-year SPY); DB-backed
 > 10,000-paper q-fin corpus with the Corpus Explorer UI shipped; "Linus for
 > quantitative finance" framing locked per [`docs/user-stories.md`](user-stories.md);
-> **576 backend tests** + 16 analytics-engine tests green; **submission day**.
+> **806 backend tests** + 16 analytics-engine tests collected; **submission day**.
 > UI prompts work as **refinement** prompts against the live UI, not greenfield.
 >
 > **Aligned with [`docs/chuan-architecture-survey.md`](chuan-architecture-survey.md)
@@ -45,7 +45,7 @@
 >     Reasoning lost its Strategies tab (details moved to Library); Generate is
 >     streaming with a mode toggle (Streaming agent vs Architect fast preview);
 >     onboarding tour appears on first visit + via the "?" icon in the topbar.
->   - **Test counts**: 576 backend tests (as of 2026-05-25); t2o2 issues
+>   - **Test counts**: 806 backend tests (as of 2026-05-25, submission day); t2o2 issues
 >     [#129](https://github.com/a-apin/archimedes-arcadia/issues/129)–
 >     [#133](https://github.com/a-apin/archimedes-arcadia/issues/133) resolved.
 
@@ -330,8 +330,8 @@ RIGHT — Rigor + on-chain
   PriceOracle, ReasoningTraceRegistry. **Vault.sol is now multi-asset NAV** —
   `totalAssets()` prices every holding via the oracle, so the share price is
   honest under mixed-asset allocations
-- Multi-wallet UX (MetaMask / Coinbase / generic). 576 backend tests + 16
-  analytics-engine tests green.
+- Multi-wallet UX (MetaMask / Coinbase / generic) with profile dropdown.
+  806 backend tests + 16 analytics-engine tests collected.
 
 SLIDE 5 — DEMO
 Full-bleed slide: the word "DEMO" in large serif type, brand accent, with the live

--- a/docs/demo-script-pitch-deck-outline.md
+++ b/docs/demo-script-pitch-deck-outline.md
@@ -1,20 +1,26 @@
 # Demo Script & Pitch Deck Outline
 
 > **Audience:** Archimedes hackathon team (deck owner + demo runner + Q&A primaries).
-> **Status:** Day-10 update (2026-05-22) on top of the 2026-05-19 rewrite to the
-> **locked product spine** ([`user-stories.md`](user-stories.md)) and the
-> **tiered competitive thesis** ([`competitor-landscape.md`](competitor-landscape.md)).
-> Day-10 deltas to fold into the deck on next pass: (a) the LLM-driven agentic
+> **Status:** Day-13 date-bump (2026-05-25 — submission day) on top of the Day-10
+> update (2026-05-22) atop the 2026-05-19 rewrite to the **locked product spine**
+> ([`user-stories.md`](user-stories.md)) and the **tiered competitive thesis**
+> ([`competitor-landscape.md`](competitor-landscape.md)). The Day-10 deltas — agentic
 > portfolio advisor ([`portfolio_agent.py`](../backend/archimedes/services/portfolio_agent.py))
-> now picks individual instruments + anchors each to a strategy passport — that's
-> a new demo beat; (b) the stress engine ([`stress_engine.py`](../backend/archimedes/services/stress_engine.py))
-> ships 6 canonical scenario shocks for any portfolio — judges-will-recognize-this
-> standard-at-every-shop tooling; (c) the multi-asset NAV vault upgrade means
-> `Vault.totalAssets()` now prices all synthetic holdings via oracles — fixes the
-> "what does my position actually mean" judge question; (d) Arc OSS Showcase
-> dimension added — see [`../ARC-OSS-SHOWCASE.md`](../ARC-OSS-SHOWCASE.md) and the
-> Day-10 rubric assessment in [`judging-rubric-assessment.md`](judging-rubric-assessment.md).
-> Supersedes the Day-4 "connect wallet → pick a risk profile" script entirely.
+> picking individual instruments anchored to passports, the stress engine
+> ([`stress_engine.py`](../backend/archimedes/services/stress_engine.py)) with 6
+> canonical shocks, the multi-asset NAV vault (`Vault.totalAssets()` oracle-priced),
+> and the Arc OSS Showcase dimension — are now baseline. **Day-12 → Day-13 deltas
+> folded as baseline:** PortfolioAdvisor preview-before-deploy banner on `/generate`
+> (#216), regime-conditional γ scaling citing Ang & Bekaert 2002 *RFS* (#217),
+> multi-wallet UX with profile dropdown (#213, #270 CSP for Circle modular-sdk
+> passkey discovery via EIP-6963), internal-agent auth guard with HMAC header (#255),
+> SSM-backed secret loading on backend startup (#260, #265), self-healing ruff format
+> enforcement on push to main (#267, #272), onboarding tour + landing-page honesty
+> pass (#262, #263), corpus pipeline rate-limit + retry (#268), Explore staleness
+> fix (#269), corpus catalog trailing-slash bug (#259). See the **Day-10 rubric
+> assessment** in [`judging-rubric-assessment.md`](judging-rubric-assessment.md) for
+> the running scoreboard. Supersedes the Day-4 "connect wallet → pick a risk profile"
+> script entirely.
 > **Length assumption:** ~3-minute pitch + ~2-minute live demo + Q&A. Adjust if Canteen says otherwise.
 >
 > **Honesty rules baked into this script (non-negotiable — they are our credibility):**

--- a/docs/judging-rubric-assessment.md
+++ b/docs/judging-rubric-assessment.md
@@ -1,14 +1,27 @@
-# Judging-Rubric Self-Assessment — Day-10 (2026-05-22)
+# Judging-Rubric Self-Assessment — Day-13 (2026-05-25 — submission day)
 
-> **Status:** Day-10 rewrite (2026-05-22). The Day-3 version of this doc scored us
-> 13/40 ≈ 33%; almost every line item it called out as "missing" has since shipped.
-> This version re-scores against shipped reality, adds the new **Arc OSS Showcase**
-> dimension, and lays out the remaining gap-closure work for the final 3 days to
-> submission.
+> **Status:** Day-13 date-bump on top of the Day-10 rewrite (2026-05-22). The Day-3
+> version of this doc scored us 13/40 ≈ 33%; almost every line item it called out as
+> "missing" has since shipped. This version re-scores against shipped reality, adds
+> the new **Arc OSS Showcase** dimension, and tracks the final-hours gap-closure work
+> against the Monday-evening submission deadline.
+> **Day-12 → Day-13 ships now folded into baseline (not deltas anymore):** #216
+> PortfolioAdvisor surfaced on `/generate` as preview-before-deploy banner; #217
+> regime-conditional γ scaling in `kelly_optimize_from_prices` citing Ang & Bekaert
+> 2002 *RFS*; #213 wallet menu dropdown + Profile view/edit; #215 doc-prune + UX
+> leak-scrub; ESLint 0/0 + ruff cleanup. **Day-13 hardening:** #255 internal-agent
+> auth guard (`X-Internal-Agent-Key` HMAC); #260 + #265 SSM-backed secret loading on
+> backend startup; #267 + #272 server-side ruff-format enforcement on push to main
+> (self-healing); #261 environment.yml ↔ Dependabot floor alignment; #268 corpus
+> pipeline rate-limiting + retry; #269 Explore-page staleness fix; #270 CSP allow
+> for Circle modular-sdk passkey; #259 corpus catalog trailing-slash bug; #262/#263
+> onboarding-tour + landing-page honesty pass.
+> **Innovation 9/10 score stands**, with the Ang-Bekaert + Xia-2026 + StockBench
+> citations as named academic backstops.
 > **Audience:** Archimedes hackathon team.
-> **Purpose:** Honest assessment of where we stand against the rubric with 3 days
-> to go. Identifies the biggest *remaining* gaps and what's already done. Re-read
-> daily.
+> **Purpose:** Honest assessment of where we stand against the rubric with hours
+> to go before submission. Identifies the biggest *remaining* gaps and what's
+> already done.
 > **Source for rubric weights / categories:** original Canteen rubric (see
 > [`archive/agora_project_analysis.md`](archive/agora_project_analysis.md) § 1
 > for historical detail).


### PR DESCRIPTION
## Summary

Refresh of the four most-read docs against current main reality on the morning of **submission day** (Mon 2026-05-25). Same intent as the original m4-content-refresh draft from Day-12, expanded to cover everything that shipped between the Day-12 baseline and the submission window.

## What changes

- **Test counts**: 576 → **806** backend tests collected (verified locally via `pytest --collect-only`).
- **Status-line dates** in the 4 most-read docs:
  - README → `Status (2026-05-25 — submission day)`
  - claude-design-prompts → Day-11 → **Day-13** (2026-05-25, submission day)
  - judging-rubric-assessment → Day-10 → **Day-13** (submission day)
  - demo-script-pitch-deck-outline → Day-10 → **Day-13** (submission day)
- **Day-12 → Day-13 ship deltas folded as baseline** (no longer flagged as "not yet folded"):
  - #216 PortfolioAdvisor preview-before-deploy banner on `/generate`
  - #217 regime-conditional γ in `kelly_optimize_from_prices` citing Ang & Bekaert 2002 *RFS*
  - #213 wallet menu dropdown + Profile view/edit
  - #215 doc-prune + UX leak-scrub
  - ESLint 0/0 + ruff cleanup
- **Day-13 hardening ships added to baseline narrative**: #255 internal-agent auth guard, #260+#265 SSM-backed secrets, #267+#272 server-side ruff format enforcement, #261 env-yml alignment, #259/#268/#269/#270/#262/#263 fixes.

## Out of scope

- Does NOT touch `docs/pitch-talking-points-rigor-track.md` — that belongs to Önder per the lane split.
- Does NOT modify scoring rationale tables — just refreshes the framing around them. Önder's rigor-track refresh is separate.

## Test plan

- [ ] Manual read of all 4 files to confirm narrative consistency
- [ ] `grep -n '576\|2026-05-24' docs/judging-rubric-assessment.md docs/demo-script-pitch-deck-outline.md docs/claude-design-prompts.md README.md` → no matches
- [ ] Ruff format check passes (docs-only PR; no Python touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)