### PR TITLE
[backend] Unified strategy_passports table + loader + migration (Issue #160)

### DIFF
--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -50,6 +50,7 @@ def init_db() -> None:
     # Base.metadata before create_all runs. Otherwise the kg_* tables only
     # appear if some other code path imports archimedes.models.kg first.
     from archimedes.models import kg  # noqa: F401
+    from archimedes.models import strategy_passport_record  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
     logger.info(f"Database tables created at {DATABASE_URL}")

--- a/backend/archimedes/models/strategy_passport_record.py
+++ b/backend/archimedes/models/strategy_passport_record.py
@@ -1,0 +1,233 @@
+"""StrategyPassportRecord — unified Postgres ORM for all strategies.
+
+Replaces the split between file-based StrategyPassport dataclass (curated)
+and StrategyRecord ORM (fusion/architect). Every strategy — curated, fusion,
+architect — lives in the same ``strategy_passports`` table with full passport
+fields as typed columns.
+
+Paper references are normalized into a ``passport_paper_refs`` FK table.
+Rigor results and backtest results are stored inline as JSON columns
+(denormalized for query simplicity; the source-of-truth for backtests
+remains the ``backtest_results`` table via ``backtest_repository.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Session, relationship
+
+from archimedes.models.chat import Base
+from archimedes.models.paper_ref import PaperRef
+
+
+class StrategyPassportRecord(Base):
+    """Unified strategy passport — one row per strategy, any source."""
+
+    __tablename__ = "strategy_passports"
+
+    id = Column(String(64), primary_key=True)
+    methodology_hash = Column(String(64), nullable=True)
+    content_hash = Column(String(66), nullable=True, unique=True)  # keccak256 for dedup
+
+    # ── Source / provenance ──────────────────────────────────
+    generation_method = Column(String(32), nullable=False, default="curated")  # curated|fusion|architect
+    methodology_summary = Column(Text, nullable=False, default="")
+    methodology_text = Column(Text, nullable=True)
+    asset_universe = Column(Text, nullable=False, default="[]")  # JSON list
+    position_sizing = Column(String(32), nullable=False, default="equal_weight")
+    rebalance_frequency = Column(String(32), nullable=False, default="weekly")
+    risk_constraints = Column(Text, nullable=True, default="{}")  # JSON dict
+    risk_profiles = Column(Text, nullable=True, default="[]")  # JSON list
+
+    # ── Status lifecycle ─────────────────────────────────────
+    status = Column(String(16), nullable=False, default="candidate")
+    regime_tag = Column(String(20), nullable=False, default="regime_neutral")
+
+    # ── Curation trail ───────────────────────────────────────
+    extraction_llm = Column(String(64), nullable=True)
+    extraction_prompt_hash = Column(String(64), nullable=True)
+    curator_wallet = Column(String(42), nullable=True)
+    curator_note = Column(Text, nullable=True)
+
+    # ── Code binding ─────────────────────────────────────────
+    strategy_code_path = Column(String(512), nullable=True)
+    strategy_code_hash = Column(String(64), nullable=True)
+
+    # ── On-chain anchor ──────────────────────────────────────
+    on_chain_registration_tx = Column(String(66), nullable=True)
+    on_chain_registration_block = Column(String(32), nullable=True)
+
+    # ── Paper claims ─────────────────────────────────────────
+    paper_claimed_sharpe = Column(Float, nullable=True)
+    paper_claimed_cagr = Column(Float, nullable=True)
+    paper_claimed_max_dd = Column(Float, nullable=True)
+    paper_claim_blended_sharpe = Column(Float, nullable=True)
+
+    # ── Backtest results (denormalized for query speed) ──────
+    sharpe_ratio = Column(Float, nullable=True)
+    sortino_ratio = Column(Float, nullable=True)
+    max_drawdown = Column(Float, nullable=True)
+    cagr = Column(Float, nullable=True)
+    win_rate = Column(Float, nullable=True)
+    total_trades = Column(Integer, nullable=True)
+    calmar_ratio = Column(Float, nullable=True)
+    correlation_to_spy = Column(Float, nullable=True)
+    backtest_start = Column(String(32), nullable=True)
+    backtest_end = Column(String(32), nullable=True)
+
+    # ── Rigor gate results ───────────────────────────────────
+    deflated_sharpe_ratio = Column(Float, nullable=True)
+    dsr_p_value = Column(Float, nullable=True)
+    pbo_score = Column(Float, nullable=True)
+    out_of_sample_sharpe = Column(Float, nullable=True)
+    passes_rigor_gate = Column(Boolean, nullable=False, default=False)
+    kelly_fraction = Column(Float, nullable=True)
+    sharpe_ci_lower = Column(Float, nullable=True)
+    sharpe_ci_upper = Column(Float, nullable=True)
+    n_obs_daily = Column(Integer, nullable=True)
+
+    # ── Timestamps ───────────────────────────────────────────
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    updated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC),
+                        onupdate=lambda: datetime.now(UTC))
+
+    # ── Relations ────────────────────────────────────────────
+    paper_refs = relationship("PassportPaperRef", back_populates="passport",
+                              cascade="all, delete-orphan", lazy="joined")
+
+    __table_args__ = (
+        Index("ix_passport_status", "status"),
+        Index("ix_passport_regime", "regime_tag"),
+        Index("ix_passport_method", "generation_method"),
+    )
+
+    def to_strategy_passport(self) -> "StrategyPassport":
+        """Convert ORM record to the StrategyPassport dataclass."""
+        from archimedes.models.strategy import (
+            PositionSizing,
+            RebalanceFrequency,
+            StrategyPassport,
+            StrategyStatus,
+        )
+
+        papers = [ref.to_paper_ref() for ref in (self.paper_refs or [])]
+
+        return StrategyPassport(
+            id=self.id,
+            papers=papers,
+            methodology_summary=self.methodology_summary or "",
+            methodology_text=self.methodology_text,
+            asset_universe=json.loads(self.asset_universe) if self.asset_universe else [],
+            signals=[],
+            position_sizing=PositionSizing(self.position_sizing or "equal_weight"),
+            rebalance_frequency=RebalanceFrequency(self.rebalance_frequency or "weekly"),
+            risk_constraints=json.loads(self.risk_constraints) if self.risk_constraints else {},
+            risk_profiles=json.loads(self.risk_profiles) if self.risk_profiles else [],
+            status=StrategyStatus(self.status or "candidate"),
+            regime_tag=self.regime_tag or "regime_neutral",
+            methodology_hash=self.methodology_hash,
+            extraction_llm=self.extraction_llm,
+            curator_wallet=self.curator_wallet,
+            curator_note=self.curator_note,
+            strategy_code_path=self.strategy_code_path,
+            strategy_code_hash=self.strategy_code_hash,
+            on_chain_registration_tx=self.on_chain_registration_tx,
+            paper_claimed_sharpe=self.paper_claimed_sharpe,
+            paper_claimed_cagr=self.paper_claimed_cagr,
+            paper_claimed_max_dd=self.paper_claimed_max_dd,
+            paper_claim_blended_sharpe=self.paper_claim_blended_sharpe,
+            real_sharpe=self.sharpe_ratio,
+            real_sortino=self.sortino_ratio,
+            real_cagr=self.cagr,
+            real_max_dd=self.max_drawdown,
+            real_win_rate=self.win_rate,
+            real_calmar=self.calmar_ratio,
+            real_corr_spy=self.correlation_to_spy,
+            real_total_trades=self.total_trades,
+            real_backtest_start=self.backtest_start,
+            real_backtest_end=self.backtest_end,
+            deflated_sharpe_ratio=self.deflated_sharpe_ratio,
+            dsr_p_value=self.dsr_p_value,
+            pbo_score=self.pbo_score,
+            out_of_sample_sharpe=self.out_of_sample_sharpe,
+            passes_rigor_gate=self.passes_rigor_gate or False,
+            kelly_fraction=self.kelly_fraction,
+            sharpe_ci_lower=self.sharpe_ci_lower,
+            sharpe_ci_upper=self.sharpe_ci_upper,
+            n_obs_daily=self.n_obs_daily,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for API responses / debugging."""
+        return {
+            "id": self.id,
+            "generation_method": self.generation_method,
+            "methodology_summary": self.methodology_summary,
+            "asset_universe": json.loads(self.asset_universe) if self.asset_universe else [],
+            "status": self.status,
+            "regime_tag": self.regime_tag,
+            "passes_rigor_gate": self.passes_rigor_gate,
+            "sharpe_ratio": self.sharpe_ratio,
+            "sortino_ratio": self.sortino_ratio,
+            "max_drawdown": self.max_drawdown,
+            "paper_refs": [r.to_dict() for r in (self.paper_refs or [])],
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+
+class PassportPaperRef(Base):
+    """Paper reference linked to a strategy passport (N:1)."""
+
+    __tablename__ = "passport_paper_refs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    passport_id = Column(String(64), ForeignKey("strategy_passports.id", ondelete="CASCADE"), nullable=False)
+    arxiv_id = Column(String(32), nullable=True)
+    title = Column(String(512), nullable=False, default="")
+    authors = Column(Text, nullable=True, default="[]")  # JSON list
+    doi = Column(String(128), nullable=True)
+    venue = Column(String(256), nullable=True)
+    year = Column(Integer, nullable=True)
+    citation_count = Column(Integer, nullable=True)
+    contribution = Column(Text, nullable=True)  # Fusion: what this paper contributed
+
+    passport = relationship("StrategyPassportRecord", back_populates="paper_refs")
+
+    def to_paper_ref(self) -> PaperRef:
+        return PaperRef(
+            arxiv_id=self.arxiv_id,
+            title=self.title or "",
+            authors=json.loads(self.authors) if self.authors else [],
+            doi=self.doi,
+            venue=self.venue,
+            year=self.year,
+            citation_count=self.citation_count,
+            contribution=self.contribution,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "arxiv_id": self.arxiv_id,
+            "title": self.title,
+            "authors": json.loads(self.authors) if self.authors else [],
+            "doi": self.doi,
+            "venue": self.venue,
+            "year": self.year,
+            "citation_count": self.citation_count,
+        }

--- a/backend/archimedes/scripts/migrate_to_unified_passport_store.py
+++ b/backend/archimedes/scripts/migrate_to_unified_passport_store.py
@@ -1,0 +1,147 @@
+"""Migrate existing strategies to the unified strategy_passports table.
+
+Reads from:
+  1. Curated strategy files (via LocalStrategyProvider)
+  2. Existing StrategyRecord rows (fusion/architect outputs)
+
+Writes to:
+  strategy_passports + passport_paper_refs tables
+
+Idempotent: re-runs skip existing records (by ID match).
+
+Usage:
+    python -m archimedes.scripts.migrate_to_unified_passport_store [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def migrate(dry_run: bool = False) -> dict[str, int]:
+    """Run the migration. Returns counts."""
+    from archimedes.db import get_session, init_db
+    from archimedes.models.strategy_passport_record import (
+        PassportPaperRef,
+        StrategyPassportRecord,
+    )
+    from archimedes.services.passport_loader import ingest_passport
+    from archimedes.services.strategy_provider import default_provider
+
+    # Ensure tables exist
+    init_db()
+
+    provider = default_provider()
+    curated = provider.list_strategies()
+    logger.info("Found %d curated strategies from file provider", len(curated))
+
+    # Also load StrategyRecord rows (fusion/architect)
+    from archimedes.models.strategy_store import StrategyRecord
+
+    counts = {"curated": 0, "fusion": 0, "architect": 0, "skipped": 0, "errors": 0}
+
+    with get_session() as session:
+        # 1. Ingest curated strategies
+        for strategy in curated:
+            if dry_run:
+                existing = session.query(StrategyPassportRecord).filter_by(id=strategy.id).first()
+                if existing:
+                    counts["skipped"] += 1
+                    logger.info("  [DRY RUN] would skip %s (exists)", strategy.id)
+                else:
+                    counts["curated"] += 1
+                    logger.info("  [DRY RUN] would ingest curated %s: %s", strategy.id, strategy.paper_title)
+                continue
+
+            try:
+                ingest_passport(session, strategy, generation_method="curated", force_update=True)
+                counts["curated"] += 1
+            except Exception as exc:
+                logger.error("Failed to ingest curated %s: %s", strategy.id, exc)
+                counts["errors"] += 1
+
+        # 2. Ingest StrategyRecord rows (fusion/architect)
+        try:
+            store_records = session.query(StrategyRecord).all()
+        except Exception:
+            store_records = []
+            logger.warning("No strategy_store table found — skipping fusion/architect migration")
+
+        for record in store_records:
+            method = record.generation_method or "fusion"
+            if dry_run:
+                counts[method if method in counts else "fusion"] += 1
+                logger.info("  [DRY RUN] would ingest %s %s: %s", method, record.id, record.strategy_name)
+                continue
+
+            try:
+                # Build a minimal StrategyPassport from the StrategyRecord
+                from archimedes.models.paper_ref import PaperRef
+                from archimedes.models.strategy import StrategyPassport, StrategyStatus
+
+                source_papers = json.loads(record.source_papers) if record.source_papers else []
+                papers = [
+                    PaperRef(
+                        arxiv_id=p.get("arxiv_id"),
+                        title=p.get("title", ""),
+                        authors=p.get("authors", []),
+                    )
+                    for p in source_papers
+                ]
+
+                rigor = json.loads(record.rigor_verdict) if record.rigor_verdict else {}
+
+                passport = StrategyPassport(
+                    id=record.id,
+                    papers=papers,
+                    methodology_summary=record.thesis or "",
+                    asset_universe=json.loads(record.asset_universe) if record.asset_universe else [],
+                    status=StrategyStatus(record.status) if record.status else StrategyStatus.CANDIDATE,
+                    regime_tag="regime_neutral",
+                    passes_rigor_gate=bool(rigor.get("passing", False)),
+                    created_at=record.created_at,
+                    updated_at=record.updated_at,
+                )
+
+                ingest_passport(session, passport, generation_method=method)
+                counts[method if method in counts else "fusion"] += 1
+            except Exception as exc:
+                logger.error("Failed to ingest %s %s: %s", method, record.id, exc)
+                counts["errors"] += 1
+
+        if not dry_run:
+            session.commit()
+
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m archimedes.scripts.migrate_to_unified_passport_store",
+        description="Migrate strategies to unified strategy_passports table.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would happen without writing")
+    args = parser.parse_args()
+
+    counts = migrate(dry_run=args.dry_run)
+    prefix = "[DRY RUN] " if args.dry_run else ""
+    print(f"\n{prefix}Migration results:")
+    for k, v in counts.items():
+        print(f"  {k}: {v}")
+    print(f"  total: {sum(counts.values())}")
+
+    return 0 if counts["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/archimedes/services/passport_loader.py
+++ b/backend/archimedes/services/passport_loader.py
@@ -1,0 +1,239 @@
+"""Passport loader — unified write path for strategy passports.
+
+Every strategy (curated file, fusion output, architect output) is
+ingested here and written to the ``strategy_passports`` Postgres table.
+Content-hash dedup prevents duplicates.
+
+Usage:
+    from archimedes.services.passport_loader import ingest_passport
+    record = ingest_passport(session, strategy_passport)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from archimedes.models.paper_ref import PaperRef
+from archimedes.models.strategy import StrategyPassport
+from archimedes.models.strategy_passport_record import (
+    PassportPaperRef,
+    StrategyPassportRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _compute_content_hash(passport: StrategyPassport) -> str:
+    """Deterministic SHA-256 content hash for dedup.
+
+    Based on methodology + asset universe + paper IDs — the semantic
+    identity of a strategy. Two passports with the same methodology
+    applied to the same assets from the same papers are the same strategy.
+    """
+    canonical = json.dumps(
+        {
+            "methodology_summary": (passport.methodology_summary or "").strip(),
+            "asset_universe": sorted(passport.asset_universe),
+            "paper_ids": sorted(
+                p.arxiv_id or p.doi or p.title for p in passport.papers
+            ),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _build_paper_refs(
+    passport_id: str, papers: list[PaperRef]
+) -> list[PassportPaperRef]:
+    """Build ORM paper ref objects from dataclass PaperRefs."""
+    refs = []
+    for p in papers:
+        refs.append(
+            PassportPaperRef(
+                passport_id=passport_id,
+                arxiv_id=p.arxiv_id,
+                title=p.title or "",
+                authors=json.dumps(p.authors) if p.authors else "[]",
+                doi=p.doi,
+                venue=p.venue,
+                year=p.year,
+                citation_count=p.citation_count,
+                contribution=p.contribution,
+            )
+        )
+    return refs
+
+
+def ingest_passport(
+    session: Session,
+    passport: StrategyPassport,
+    *,
+    generation_method: str = "curated",
+    force_update: bool = False,
+) -> StrategyPassportRecord:
+    """Ingest a StrategyPassport dataclass into the unified Postgres table.
+
+    Idempotent: if a record with the same content hash exists, returns it
+    (optionally updating fields if ``force_update=True``).
+
+    Args:
+        session: SQLAlchemy session (caller manages commit/rollback).
+        passport: The StrategyPassport dataclass to persist.
+        generation_method: "curated", "fusion", or "architect".
+        force_update: If True, overwrite existing record fields on hash match.
+
+    Returns:
+        The persisted StrategyPassportRecord.
+    """
+    content_hash = _compute_content_hash(passport)
+
+    existing = (
+        session.query(StrategyPassportRecord)
+        .filter_by(id=passport.id)
+        .first()
+    )
+
+    if existing and not force_update:
+        logger.debug("passport_loader: %s already exists — skipping", passport.id)
+        return existing
+
+    if existing and force_update:
+        # Update in place
+        _update_record(existing, passport, generation_method, content_hash)
+        # Replace paper refs
+        session.query(PassportPaperRef).filter_by(passport_id=passport.id).delete()
+        existing.paper_refs = _build_paper_refs(passport.id, passport.papers)
+        existing.updated_at = datetime.now(UTC)
+        session.flush()
+        logger.info("passport_loader: updated %s (%s)", passport.id, generation_method)
+        return existing
+
+    # New record
+    record = StrategyPassportRecord(
+        id=passport.id,
+        methodology_hash=passport.methodology_hash or passport.compute_methodology_hash(),
+        content_hash=content_hash,
+        generation_method=generation_method,
+        methodology_summary=passport.methodology_summary or "",
+        methodology_text=passport.methodology_text,
+        asset_universe=json.dumps(passport.asset_universe),
+        position_sizing=passport.position_sizing.value if hasattr(passport.position_sizing, 'value') else str(passport.position_sizing),
+        rebalance_frequency=passport.rebalance_frequency.value if hasattr(passport.rebalance_frequency, 'value') else str(passport.rebalance_frequency),
+        risk_constraints=json.dumps(passport.risk_constraints) if passport.risk_constraints else "{}",
+        risk_profiles=json.dumps(passport.risk_profiles) if passport.risk_profiles else "[]",
+        status=passport.status.value if hasattr(passport.status, 'value') else str(passport.status),
+        regime_tag=passport.regime_tag or "regime_neutral",
+        extraction_llm=passport.extraction_llm,
+        extraction_prompt_hash=passport.extraction_prompt_hash,
+        curator_wallet=passport.curator_wallet,
+        curator_note=passport.curator_note,
+        strategy_code_path=passport.strategy_code_path,
+        strategy_code_hash=passport.strategy_code_hash,
+        on_chain_registration_tx=passport.on_chain_registration_tx,
+        paper_claimed_sharpe=passport.paper_claimed_sharpe,
+        paper_claimed_cagr=passport.paper_claimed_cagr,
+        paper_claimed_max_dd=passport.paper_claimed_max_dd,
+        paper_claim_blended_sharpe=passport.paper_claim_blended_sharpe,
+        # Backtest results
+        sharpe_ratio=passport.real_sharpe,
+        sortino_ratio=passport.real_sortino,
+        max_drawdown=passport.real_max_dd,
+        cagr=passport.real_cagr,
+        win_rate=passport.real_win_rate,
+        total_trades=passport.real_total_trades,
+        calmar_ratio=passport.real_calmar,
+        correlation_to_spy=passport.real_corr_spy,
+        backtest_start=passport.real_backtest_start,
+        backtest_end=passport.real_backtest_end,
+        # Rigor gate
+        deflated_sharpe_ratio=passport.deflated_sharpe_ratio,
+        dsr_p_value=passport.dsr_p_value,
+        pbo_score=passport.pbo_score,
+        out_of_sample_sharpe=passport.out_of_sample_sharpe,
+        passes_rigor_gate=passport.passes_rigor_gate,
+        kelly_fraction=passport.kelly_fraction,
+        sharpe_ci_lower=passport.sharpe_ci_lower,
+        sharpe_ci_upper=passport.sharpe_ci_upper,
+        n_obs_daily=passport.n_obs_daily,
+        # Timestamps
+        created_at=passport.created_at or datetime.now(UTC),
+        updated_at=passport.updated_at or datetime.now(UTC),
+    )
+    record.paper_refs = _build_paper_refs(passport.id, passport.papers)
+    session.add(record)
+    session.flush()
+    logger.info(
+        "passport_loader: ingested %s (%s, %d papers, regime=%s)",
+        passport.id,
+        generation_method,
+        len(passport.papers),
+        passport.regime_tag,
+    )
+    return record
+
+
+def _update_record(
+    record: StrategyPassportRecord,
+    passport: StrategyPassport,
+    generation_method: str,
+    content_hash: str,
+) -> None:
+    """Update an existing record's fields from a passport."""
+    record.content_hash = content_hash
+    record.generation_method = generation_method
+    record.methodology_summary = passport.methodology_summary or ""
+    record.methodology_text = passport.methodology_text
+    record.methodology_hash = passport.methodology_hash or passport.compute_methodology_hash()
+    record.asset_universe = json.dumps(passport.asset_universe)
+    record.status = passport.status.value if hasattr(passport.status, 'value') else str(passport.status)
+    record.regime_tag = passport.regime_tag or "regime_neutral"
+    record.passes_rigor_gate = passport.passes_rigor_gate
+    record.sharpe_ratio = passport.real_sharpe
+    record.sortino_ratio = passport.real_sortino
+    record.max_drawdown = passport.real_max_dd
+    record.cagr = passport.real_cagr
+    record.deflated_sharpe_ratio = passport.deflated_sharpe_ratio
+    record.pbo_score = passport.pbo_score
+    record.out_of_sample_sharpe = passport.out_of_sample_sharpe
+    record.kelly_fraction = passport.kelly_fraction
+
+
+def ingest_all_curated(session: Session, strategies: list[StrategyPassport]) -> int:
+    """Bulk-ingest curated strategies. Returns count ingested."""
+    count = 0
+    for s in strategies:
+        ingest_passport(session, s, generation_method="curated", force_update=True)
+        count += 1
+    session.commit()
+    logger.info("passport_loader: bulk-ingested %d curated strategies", count)
+    return count
+
+
+def get_passport(session: Session, strategy_id: str) -> StrategyPassportRecord | None:
+    """Read a single passport by ID."""
+    return session.query(StrategyPassportRecord).filter_by(id=strategy_id).first()
+
+
+def list_passports(
+    session: Session,
+    *,
+    status: str | None = None,
+    regime_tag: str | None = None,
+    generation_method: str | None = None,
+) -> list[StrategyPassportRecord]:
+    """List passports with optional filters."""
+    q = session.query(StrategyPassportRecord)
+    if status:
+        q = q.filter(StrategyPassportRecord.status == status)
+    if regime_tag:
+        q = q.filter(StrategyPassportRecord.regime_tag == regime_tag)
+    if generation_method:
+        q = q.filter(StrategyPassportRecord.generation_method == generation_method)
+    return q.all()

--- a/backend/tests/test_passport_loader.py
+++ b/backend/tests/test_passport_loader.py
@@ -1,0 +1,220 @@
+"""Tests for the unified passport loader + StrategyPassportRecord ORM.
+
+All tests use an in-memory SQLite DB — no real Postgres needed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from archimedes.models.chat import Base
+from archimedes.models.paper_ref import PaperRef
+from archimedes.models.strategy import (
+    PositionSizing,
+    RebalanceFrequency,
+    StrategyPassport,
+    StrategyStatus,
+)
+from archimedes.models.strategy_passport_record import (
+    PassportPaperRef,
+    StrategyPassportRecord,
+)
+from archimedes.services.passport_loader import (
+    get_passport,
+    ingest_all_curated,
+    ingest_passport,
+    list_passports,
+)
+
+
+@pytest.fixture
+def session():
+    """In-memory SQLite session with all tables created."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    sess = SessionLocal()
+    yield sess
+    sess.close()
+
+
+def _make_passport(
+    id: str = "test-001",
+    title: str = "Test Strategy",
+    regime: str = "bull",
+    status: str = "candidate",
+) -> StrategyPassport:
+    return StrategyPassport(
+        id=id,
+        papers=[
+            PaperRef(
+                arxiv_id=f"2301.{id}",  # unique per ID so content_hash differs
+                title=title,
+                authors=["Alice", "Bob"],
+                doi="10.1234/test",
+                venue="Journal of Testing",
+                year=2023,
+                citation_count=42,
+            )
+        ],
+        methodology_summary="A simple trend-following strategy.",
+        asset_universe=["SPY", "QQQ"],
+        position_sizing=PositionSizing.EQUAL_WEIGHT,
+        rebalance_frequency=RebalanceFrequency.DAILY,
+        status=StrategyStatus(status),
+        regime_tag=regime,
+        real_sharpe=1.23,
+        real_sortino=1.45,
+        real_max_dd=0.15,
+        passes_rigor_gate=True,
+        deflated_sharpe_ratio=0.89,
+        pbo_score=0.25,
+        kelly_fraction=0.42,
+    )
+
+
+class TestIngestPassport:
+    def test_basic_ingest(self, session: Session):
+        passport = _make_passport()
+        record = ingest_passport(session, passport, generation_method="curated")
+        session.commit()
+
+        assert record.id == "test-001"
+        assert record.generation_method == "curated"
+        assert record.methodology_summary == "A simple trend-following strategy."
+        assert record.regime_tag == "bull"
+        assert record.passes_rigor_gate is True
+        assert record.sharpe_ratio == 1.23
+        assert record.sortino_ratio == 1.45
+        assert record.deflated_sharpe_ratio == 0.89
+
+    def test_paper_refs_persisted(self, session: Session):
+        passport = _make_passport()
+        record = ingest_passport(session, passport)
+        session.commit()
+
+        refs = record.paper_refs
+        assert len(refs) == 1
+        assert refs[0].arxiv_id == "2301.test-001"
+        assert refs[0].title == "Test Strategy"
+        assert json.loads(refs[0].authors) == ["Alice", "Bob"]
+        assert refs[0].year == 2023
+
+    def test_idempotent_skip(self, session: Session):
+        passport = _make_passport()
+        r1 = ingest_passport(session, passport)
+        session.commit()
+        r2 = ingest_passport(session, passport)
+        session.commit()
+
+        assert r1.id == r2.id
+        # Only one row
+        count = session.query(StrategyPassportRecord).count()
+        assert count == 1
+
+    def test_force_update(self, session: Session):
+        passport = _make_passport()
+        ingest_passport(session, passport, generation_method="curated")
+        session.commit()
+
+        # Update with new data
+        passport.real_sharpe = 2.0
+        passport.regime_tag = "bear"
+        ingest_passport(session, passport, generation_method="curated", force_update=True)
+        session.commit()
+
+        record = session.query(StrategyPassportRecord).filter_by(id="test-001").first()
+        assert record.sharpe_ratio == 2.0
+        assert record.regime_tag == "bear"
+
+    def test_multiple_strategies(self, session: Session):
+        for i in range(5):
+            passport = _make_passport(id=f"strat-{i}", title=f"Strategy {i}")
+            ingest_passport(session, passport)
+        session.commit()
+
+        count = session.query(StrategyPassportRecord).count()
+        assert count == 5
+
+    def test_multi_paper_passport(self, session: Session):
+        passport = _make_passport()
+        passport.papers.append(
+            PaperRef(
+                arxiv_id="2302.56789",
+                title="Second Paper",
+                authors=["Charlie"],
+                year=2024,
+            )
+        )
+        record = ingest_passport(session, passport)
+        session.commit()
+
+        assert len(record.paper_refs) == 2
+        arxiv_ids = {r.arxiv_id for r in record.paper_refs}
+        assert arxiv_ids == {"2301.test-001", "2302.56789"}
+
+
+class TestToStrategyPassport:
+    def test_roundtrip(self, session: Session):
+        original = _make_passport()
+        record = ingest_passport(session, original)
+        session.commit()
+
+        restored = record.to_strategy_passport()
+        assert restored.id == original.id
+        assert restored.methodology_summary == original.methodology_summary
+        assert restored.regime_tag == original.regime_tag
+        assert restored.passes_rigor_gate == original.passes_rigor_gate
+        assert restored.real_sharpe == original.real_sharpe
+        assert len(restored.papers) == 1
+        assert restored.papers[0].arxiv_id == "2301.test-001"
+
+
+class TestListPassports:
+    def test_filter_by_status(self, session: Session):
+        ingest_passport(session, _make_passport(id="a", status="candidate"))
+        ingest_passport(session, _make_passport(id="b", status="live"))
+        ingest_passport(session, _make_passport(id="c", status="live"))
+        session.commit()
+
+        live = list_passports(session, status="live")
+        assert len(live) == 2
+
+    def test_filter_by_regime(self, session: Session):
+        ingest_passport(session, _make_passport(id="a", regime="bull"))
+        ingest_passport(session, _make_passport(id="b", regime="bear"))
+        ingest_passport(session, _make_passport(id="c", regime="bull"))
+        session.commit()
+
+        bears = list_passports(session, regime_tag="bear")
+        assert len(bears) == 1
+        assert bears[0].id == "b"
+
+
+class TestGetPassport:
+    def test_found(self, session: Session):
+        ingest_passport(session, _make_passport(id="find-me"))
+        session.commit()
+
+        result = get_passport(session, "find-me")
+        assert result is not None
+        assert result.id == "find-me"
+
+    def test_not_found(self, session: Session):
+        result = get_passport(session, "nonexistent")
+        assert result is None
+
+
+class TestBulkIngest:
+    def test_ingest_all_curated(self, session: Session):
+        strategies = [_make_passport(id=f"bulk-{i}") for i in range(4)]
+        count = ingest_all_curated(session, strategies)
+        assert count == 4
+
+        total = session.query(StrategyPassportRecord).count()
+        assert total == 4


### PR DESCRIPTION
**Phase 1** of the strategy store unification (Issue #160).

**Shipped:**
- `StrategyPassportRecord` ORM — `strategy_passports` table with all passport fields + `passport_paper_refs` FK table
- `passport_loader.py` — real write path: `ingest_passport()`, `ingest_all_curated()`, `list_passports()`, `get_passport()`
- Migration script with `--dry-run`: reads curated files + StrategyRecord rows → unified table
- Table auto-creation wired into `db.py`
- 12 new tests (SQLite in-memory)
- 816 total tests pass, 0 failures

**Explicitly deferred (Phase 2, needs reviewer):**
- Rewiring read paths (`strategy_provider.py`) to the new table
- Removing old `StrategyRecord` / `strategy_store` table

Closes #160