### PR TITLE
[hotfix] Fix Generate + Vault 500 error (missing slowapi Response param)

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -19,7 +19,7 @@ import json
 import logging
 from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 
 from archimedes.agents.generation_pipeline import run_generation
@@ -56,7 +56,7 @@ def _register_task(job_id: str, task: asyncio.Task) -> None:
 
 @generate_router.post("/start", response_model=GenerateStartResponse, status_code=202)
 @limiter.limit("5/minute")
-async def start_generation(req: GenerateStartRequest, request: Request) -> GenerateStartResponse:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def start_generation(req: GenerateStartRequest, request: Request, response: Response) -> GenerateStartResponse:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Create a generation job and start the pipeline in the background."""
     store = get_job_store()
     job_id = await store.enqueue(

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Query, Request, Response
 
 from archimedes.api._route_helpers import strategy_provider, vault_svc
 from archimedes.api.limiter import limiter
@@ -41,7 +41,7 @@ async def list_vaults(
 
 @vaults_router.post("/create", response_model=VaultCreateResponse)
 @limiter.limit("5/minute")
-async def create_vault(req: VaultCreateRequest, request: Request):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def create_vault(req: VaultCreateRequest, request: Request, response: Response):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Deploy a new vault on Arc via VaultFactory."""
     from fastapi import HTTPException
 
@@ -85,7 +85,7 @@ async def get_vault_detail(address: str):
 
 @vaults_router.post("/metadata", response_model=VaultMetadataResponse)
 @limiter.limit("10/minute")
-async def store_vault_metadata(req: VaultMetadataRequest, request: Request):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def store_vault_metadata(req: VaultMetadataRequest, request: Request, response: Response):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Store off-chain vault metadata (strategy associations, display name)."""
     from fastapi import HTTPException
 


### PR DESCRIPTION
**Critical:** Generate page and Vault create/metadata returned 500 on every request. slowapi needs `response: Response` in the function signature. 816 tests pass.