### PR TITLE
[frontend] Fix Safari passkey signin: auto-fallback Register → Login on duplicate username

### DIFF
--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -73,6 +73,27 @@ export function hasStoredPasskey() {
   return loadStoredCredential() !== null
 }
 
+// Map raw passkey errors (viem RPC errors, DOMExceptions) to user-readable
+// strings. The default error.message for viem is "An unknown RPC error
+// occurred. Details: …. Version: viem@x.y.z" — informative for debugging,
+// hostile for the user. This converts the common cases.
+function friendlyPasskeyError(err) {
+  const msg = String(err?.message ?? err ?? '')
+  if (/NotAllowedError/i.test(msg) || /not allowed/i.test(msg)) {
+    return 'Sign-in cancelled or no passkey selected.'
+  }
+  if (/SecurityError/i.test(msg)) {
+    return 'Passkey blocked: this site\'s domain doesn\'t match the registered passkey origin.'
+  }
+  if (/username is duplicated/i.test(msg)) {
+    return 'A passkey for this site already exists on Circle\'s server but no passkey matched on your device. Use the device that originally created it, or click "Clear and try again" to register fresh.'
+  }
+  if (/no credentials available/i.test(msg) || /no passkey/i.test(msg)) {
+    return 'No passkey found on this device. Create a new one to continue.'
+  }
+  return msg || 'Passkey sign-in failed.'
+}
+
 // Single entry point for both flows. The caller passes `mode = 'register'`
 // for a new user; we default to 'login' if we already have a stored
 // credential. Returns the smart account + its address + the credential
@@ -90,7 +111,7 @@ export async function connectCirclePasskey({ mode = 'auto', username = 'archimed
   }
 
   const stored = loadStoredCredential()
-  const resolvedMode = mode === 'auto'
+  let resolvedMode = mode === 'auto'
     ? (stored ? WebAuthnMode.Login : WebAuthnMode.Register)
     : (mode === 'login' ? WebAuthnMode.Login : WebAuthnMode.Register)
 
@@ -99,12 +120,38 @@ export async function connectCirclePasskey({ mode = 'auto', username = 'archimed
 
   // Either issue a new P256 credential (Register) OR re-authenticate an
   // existing one (Login). Browser prompts the user for biometrics here.
-  const credential = await toWebAuthnCredential({
-    transport: passkeyTransport,
-    mode: resolvedMode,
-    username,
-    credentialId: resolvedMode === WebAuthnMode.Login ? stored?.id : undefined,
-  })
+  let credential
+  try {
+    credential = await toWebAuthnCredential({
+      transport: passkeyTransport,
+      mode: resolvedMode,
+      username,
+      credentialId: resolvedMode === WebAuthnMode.Login ? stored?.id : undefined,
+    })
+  } catch (err) {
+    // "Username is duplicated" — Circle server already has a credential for
+    // this username, but our localStorage is empty (typical: Safari ITP
+    // purged it, or user switched browsers). Retry as Login WITHOUT a
+    // credentialId — WebAuthn surfaces the user's existing passkeys for
+    // this origin via discoverable credentials, and the user re-auths.
+    // Only auto-retry when the caller didn't pin a specific mode.
+    const msg = String(err?.message ?? err ?? '')
+    const isDuplicate = /username is duplicated/i.test(msg)
+    if (mode === 'auto' && resolvedMode === WebAuthnMode.Register && isDuplicate) {
+      resolvedMode = WebAuthnMode.Login
+      try {
+        credential = await toWebAuthnCredential({
+          transport: passkeyTransport,
+          mode: WebAuthnMode.Login,
+          username,
+        })
+      } catch (retryErr) {
+        throw new Error(friendlyPasskeyError(retryErr), { cause: retryErr })
+      }
+    } else {
+      throw new Error(friendlyPasskeyError(err), { cause: err })
+    }
+  }
 
   // Persist for next-session login. Stores the credential ID + public key,
   // NOT the private key (the private key lives in the device's secure


### PR DESCRIPTION
## Summary

Fixes the **passkey signin breakage Dan hit this morning on Safari** (screenshot in chat): `An unknown RPC error occurred. Details: The username is duplicated. Version: viem@2.50.4`.

## Root cause

- `connectCirclePasskey({ mode: 'auto' })` picks Register vs Login based on whether `loadStoredCredential()` returns something.
- Safari ITP / private-browsing purges `localStorage` → code picks Register.
- Circle's server still has the prior passkey for username `archimedes` → returns "username is duplicated" → raw RPC error surfaces in the modal.

This was working before the localStorage purge — it's an edge case the auto-mode resolution didn't handle.

## Fix

1. **Catch "username is duplicated" on Register attempt; retry as Login without a credentialId.** WebAuthn surfaces the user's existing passkeys for this origin via discoverable credentials — the biometric prompt re-auths the same underlying credential, derives the same MSCA address.
2. **New `friendlyPasskeyError()` helper** maps common viem RPC errors + DOMExceptions to user-readable strings (cancel, security mismatch, duplicate, no-credentials). Surfaces via the existing `setError(err.message)` path in `WalletConnect.jsx` — no UI changes required.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| New user | Register → succeeds | Register → succeeds |
| Returning user, storage intact | Login(credentialId) → succeeds | Login(credentialId) → succeeds |
| **Returning user, storage cleared (Dan's case)** | **Register → raw "duplicate" error** | **Register → auto Login(discoverable) → succeeds** |
| No passkey on device | Register → raw "duplicate" error | Register → Login fails → friendly "no passkey on this device" message |

## Why not "Login first by default"?

It would trigger a biometric prompt on every cold load with no stored cred, including for genuinely new users who'd then see "no passkey" and be confused. Reactive retry on the specific "duplicate" error is the precise fix.

## Test plan

- [x] eslint clean on `ui/src/circle-wallet.js`
- [ ] **After merge + EC2 redeploy:** Dan signs in on Safari with passkey, succeeds without error
- [ ] Verify a fresh-passkey flow still works (clear storage + clear server-side cred, then Register)

## Anti-goals

- Did not change the UI of the connect modal (only error text via the existing surface)
- Did not change credential storage shape (Safari ITP will keep purging; the retry path handles that)
- Did not touch the EOA paths (MetaMask / Coinbase) — those were not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)