### PR TITLE
[backend] Regime-aware portfolio construction (Issue #164)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -351,7 +351,11 @@ async def get_portfolio_advisor(
     usdc_floor = min(usdc_floor_base * deleverage, 0.95)
     synth_budget = max(0.0, 1.0 - usdc_floor)
 
-    strategies = [s for s in strategy_provider.list_strategies() if s.real_sharpe is not None]
+    all_strategies = [s for s in strategy_provider.list_strategies() if s.real_sharpe is not None]
+
+    # Apply regime-aware tilt to strategy ordering
+    from archimedes.services.regime_weight_schedule import apply_regime_tilt, regime_weight_schedule
+    strategies, regime_mix = apply_regime_tilt(all_strategies, regime_value, risk_profile)
 
     from archimedes.agents.portfolio_agent import get_portfolio_agent
     from archimedes.services.strategy_signal_evaluator import (
@@ -796,6 +800,11 @@ async def get_portfolio_advisor(
                 "diversification_ratio": round(opt.diversification_ratio, 4) if opt else None,
                 "risk_aversion_gamma": round(opt.risk_aversion, 2) if opt else None,
                 "optimizer_converged": opt.converged if opt else False,
+            },
+            "regime_breakdown": {
+                "bull_weight": round(regime_mix["bull"], 4),
+                "bear_weight": round(regime_mix["bear"], 4),
+                "neutral_weight": round(regime_mix["neutral"], 4),
             },
             "risk_decomposition": risk_decomp,
             "correlation_pairs": corr_pairs,

--- a/backend/archimedes/services/regime_weight_schedule.py
+++ b/backend/archimedes/services/regime_weight_schedule.py
@@ -1,0 +1,134 @@
+"""Regime-aware weight schedule for portfolio construction.
+
+Maps (risk_profile, regime) → {bull_weight, bear_weight, neutral_weight}
+where the weights represent the target allocation mix between bull-tilted,
+bear-tilted, and regime-neutral strategies.
+
+Usage:
+    from archimedes.services.regime_weight_schedule import regime_weight_schedule
+
+    mix = regime_weight_schedule("moderate", "risk_off")
+    # → {"bull": 0.25, "bear": 0.70, "neutral": 0.05}
+
+The schedule is hardcoded v1 per issue #164 spec. The bull/bear/neutral
+weights sum to 1.0 and determine how the Portfolio Construction Agent
+tilts strategy selection based on the detected market regime.
+
+Owner: Önder (portfolio math lane)
+Spec: docs/specs/launch-execution-plan-2026-05-23.md § T-PE.7
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class RegimeMix(TypedDict):
+    bull: float
+    bear: float
+    neutral: float
+
+
+# Hardcoded v1 weight schedules per the issue #164 spec.
+# Outer key: risk profile. Inner key: regime state.
+_SCHEDULE: dict[str, dict[str, RegimeMix]] = {
+    "fixed_income": {
+        "risk_on":    {"bull": 0.30, "bear": 0.60, "neutral": 0.10},
+        "risk_off":   {"bull": 0.10, "bear": 0.80, "neutral": 0.10},
+        "transition": {"bull": 0.20, "bear": 0.60, "neutral": 0.20},
+        "crisis":     {"bull": 0.05, "bear": 0.85, "neutral": 0.10},
+    },
+    "conservative": {
+        "risk_on":    {"bull": 0.50, "bear": 0.40, "neutral": 0.10},
+        "risk_off":   {"bull": 0.20, "bear": 0.70, "neutral": 0.10},
+        "transition": {"bull": 0.30, "bear": 0.50, "neutral": 0.20},
+        "crisis":     {"bull": 0.10, "bear": 0.80, "neutral": 0.10},
+    },
+    "moderate": {
+        "risk_on":    {"bull": 0.70, "bear": 0.25, "neutral": 0.05},
+        "risk_off":   {"bull": 0.25, "bear": 0.70, "neutral": 0.05},
+        "transition": {"bull": 0.40, "bear": 0.40, "neutral": 0.20},
+        "crisis":     {"bull": 0.15, "bear": 0.75, "neutral": 0.10},
+    },
+    "aggressive": {
+        "risk_on":    {"bull": 0.85, "bear": 0.10, "neutral": 0.05},
+        "risk_off":   {"bull": 0.10, "bear": 0.85, "neutral": 0.05},
+        "transition": {"bull": 0.50, "bear": 0.40, "neutral": 0.10},
+        "crisis":     {"bull": 0.05, "bear": 0.90, "neutral": 0.05},
+    },
+    "hyper_risky": {
+        "risk_on":    {"bull": 0.95, "bear": 0.03, "neutral": 0.02},
+        "risk_off":   {"bull": 0.05, "bear": 0.93, "neutral": 0.02},
+        "transition": {"bull": 0.55, "bear": 0.35, "neutral": 0.10},
+        "crisis":     {"bull": 0.02, "bear": 0.95, "neutral": 0.03},
+    },
+}
+
+# Default for unknown regime or profile
+_DEFAULT_MIX: RegimeMix = {"bull": 0.40, "bear": 0.40, "neutral": 0.20}
+
+
+def regime_weight_schedule(risk_profile: str, regime: str) -> RegimeMix:
+    """Look up the bull/bear/neutral weight mix for a given profile + regime.
+
+    Args:
+        risk_profile: One of "fixed_income", "conservative", "moderate",
+                      "aggressive", "hyper_risky".
+        regime: One of "risk_on", "risk_off", "transition", "crisis".
+
+    Returns:
+        RegimeMix with bull + bear + neutral summing to 1.0.
+    """
+    profile_schedule = _SCHEDULE.get(risk_profile.lower())
+    if not profile_schedule:
+        logger.warning("regime_weight_schedule: unknown profile %r, using default", risk_profile)
+        return _DEFAULT_MIX
+
+    mix = profile_schedule.get(regime.lower())
+    if not mix:
+        logger.warning("regime_weight_schedule: unknown regime %r for %s, using transition", regime, risk_profile)
+        mix = profile_schedule.get("transition", _DEFAULT_MIX)
+
+    return mix
+
+
+def apply_regime_tilt(
+    strategies: list,
+    regime: str,
+    risk_profile: str,
+) -> tuple[list, RegimeMix]:
+    """Filter and weight strategies by regime tilt.
+
+    Partitions strategies by their ``regime_tag`` (bull/bear/regime_neutral)
+    and returns them ordered by the regime weight schedule — strategies
+    matching the dominant regime tilt come first, weighted higher.
+
+    Returns:
+        (sorted_strategies, regime_mix) — strategies sorted by tilt
+        priority, and the mix used for portfolio display.
+    """
+    mix = regime_weight_schedule(risk_profile, regime)
+
+    # Partition by regime_tag
+    buckets: dict[str, list] = {"bull": [], "bear": [], "regime_neutral": []}
+    for s in strategies:
+        tag = getattr(s, "regime_tag", "regime_neutral") or "regime_neutral"
+        if tag in buckets:
+            buckets[tag].append(s)
+        else:
+            buckets["regime_neutral"].append(s)
+
+    # Build priority-sorted list: highest-weighted regime bucket first
+    sorted_pairs = sorted(
+        [("bull", mix["bull"]), ("bear", mix["bear"]), ("regime_neutral", mix["neutral"])],
+        key=lambda x: -x[1],
+    )
+
+    result = []
+    for tag, _weight in sorted_pairs:
+        result.extend(buckets.get(tag, []))
+
+    return result, mix

--- a/backend/tests/services/test_regime_weight_schedule.py
+++ b/backend/tests/services/test_regime_weight_schedule.py
@@ -1,0 +1,81 @@
+"""Tests for regime_weight_schedule — weight mixes sum to 1.0, tilt ordering works."""
+
+import pytest
+
+from archimedes.services.regime_weight_schedule import (
+    apply_regime_tilt,
+    regime_weight_schedule,
+)
+
+
+class TestRegimeWeightSchedule:
+    @pytest.mark.parametrize("profile", ["fixed_income", "conservative", "moderate", "aggressive", "hyper_risky"])
+    @pytest.mark.parametrize("regime", ["risk_on", "risk_off", "transition", "crisis"])
+    def test_weights_sum_to_one(self, profile, regime):
+        mix = regime_weight_schedule(profile, regime)
+        total = mix["bull"] + mix["bear"] + mix["neutral"]
+        assert abs(total - 1.0) < 1e-6, f"{profile}/{regime}: sum={total}"
+
+    def test_moderate_risk_on_bull_heavy(self):
+        mix = regime_weight_schedule("moderate", "risk_on")
+        assert mix["bull"] == 0.70
+        assert mix["bear"] == 0.25
+
+    def test_moderate_risk_off_bear_heavy(self):
+        mix = regime_weight_schedule("moderate", "risk_off")
+        assert mix["bear"] == 0.70
+        assert mix["bull"] == 0.25
+
+    def test_aggressive_risk_on(self):
+        mix = regime_weight_schedule("aggressive", "risk_on")
+        assert mix["bull"] >= 0.80
+
+    def test_conservative_crisis(self):
+        mix = regime_weight_schedule("conservative", "crisis")
+        assert mix["bear"] >= 0.70
+
+    def test_unknown_profile_returns_default(self):
+        mix = regime_weight_schedule("unknown_profile", "risk_on")
+        assert mix["bull"] + mix["bear"] + mix["neutral"] == 1.0
+
+    def test_unknown_regime_falls_back_to_transition(self):
+        mix = regime_weight_schedule("moderate", "unknown_regime")
+        expected = regime_weight_schedule("moderate", "transition")
+        assert mix == expected
+
+
+class TestApplyRegimeTilt:
+    def test_sorts_by_dominant_regime(self):
+        class FakeStrategy:
+            def __init__(self, name, tag):
+                self.name = name
+                self.regime_tag = tag
+
+        strategies = [
+            FakeStrategy("bear1", "bear"),
+            FakeStrategy("bull1", "bull"),
+            FakeStrategy("neutral1", "regime_neutral"),
+            FakeStrategy("bull2", "bull"),
+        ]
+
+        # risk_on/moderate → bull-heavy (0.70)
+        sorted_strats, mix = apply_regime_tilt(strategies, "risk_on", "moderate")
+        assert mix["bull"] > mix["bear"]
+        # Bull strategies should come first
+        assert sorted_strats[0].regime_tag == "bull"
+        assert sorted_strats[1].regime_tag == "bull"
+
+    def test_risk_off_puts_bear_first(self):
+        class FakeStrategy:
+            def __init__(self, name, tag):
+                self.name = name
+                self.regime_tag = tag
+
+        strategies = [
+            FakeStrategy("bull1", "bull"),
+            FakeStrategy("bear1", "bear"),
+        ]
+
+        sorted_strats, mix = apply_regime_tilt(strategies, "risk_off", "moderate")
+        assert mix["bear"] > mix["bull"]
+        assert sorted_strats[0].regime_tag == "bear"


### PR DESCRIPTION
Adds regime weight schedule + wires into advisor endpoint. Strategies prioritized by regime tilt; API returns regime_breakdown with bull/bear/neutral weights. 28 new tests, 844 total pass.

Closes #164