### PR TITLE
[backend] Fix Generate 500: AgentPick has no .symbol or .strategy_id attrs

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -446,8 +446,8 @@ async def _run_live_candidate(*, candidate_id: str, brief: GenerateBrief, emit: 
     if portfolio is None:
         raise RuntimeError("agent returned no portfolio")
 
-    weights = {pick.symbol: pick.weight for pick in (portfolio.picks or [])}
-    referenced = {pick.strategy_id for pick in (portfolio.picks or []) if pick.strategy_id}
+    weights = {pick.ticker: pick.weight for pick in (portfolio.picks or [])}
+    referenced = {pick.paper_anchor for pick in (portfolio.picks or []) if pick.paper_anchor}
     source_papers = []
     for sid in referenced:
         s = next((s for s in strategies if s.id == sid), None)


### PR DESCRIPTION
## Summary

Fixes the **Generate "Internal Server Error" Dan hit this morning** (screenshot in chat). Reproduced live:

\`\`\`
POST /api/generate/start  {"brief":{"intent":"...","risk_appetite":"aggressive"}}
→ stream event 5:  {"message": "candidate cand_1 failed: 'AgentPick' object has no attribute 'symbol'"}
\`\`\`

Two attribute typos in [generation_pipeline.py:449-450](backend/archimedes/agents/generation_pipeline.py#L449-L450):

| Bug | Fix |
|---|---|
| \`pick.symbol\` | \`pick.ticker\` |
| \`pick.strategy_id\` | \`pick.paper_anchor\` |

\`AgentPick\` (defined in \`portfolio_agent.py:34\`) has fields: \`ticker, synth, asset_class, exchange, weight, paper_anchor, reasoning\`. No \`symbol\`, no \`strategy_id\`.

## Why no test caught it

The integration path \`run_generation\` → agent loop → \`AgentPick\` → rigor weights wasn't covered by an integration test that actually runs the agent. The crash only surfaces when the agent makes it past \`candidates_selected\` and hands real picks to the rigor evaluator. Follow-up: add an integration test that exercises this path with a deterministic stubbed agent.

## Impact

Every Generate call from the live UI was crashing the candidate loop after ~40s (\`brief_validated\` → \`pipeline_selected\` → \`candidates_selected\` → \`error\`). This is **demo-blocking** — Generate is the headline feature on the site.

## Test plan

- [x] Verified \`AgentPick\` field names via direct read of \`portfolio_agent.py:34\`
- [ ] **After merge + EC2 redeploy:** \`curl POST /api/generate/start\` produces a job that runs to completion (no \`error\` event) — or at least dies on a different error that's not this typo
- [ ] Dan tries Generate from the live UI; sees a strategy come back

## Anti-goals

- Did not refactor the agent dataclass — keep \`ticker\` (the agent's natural name for "display symbol") rather than rename to \`symbol\`
- Did not add the missing integration test in this PR; tracking as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)