### PR TITLE
[frontend] Wallet UX polish: surface Circle SDK, copy button, USDC balance

### DIFF
--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -1,6 +1,12 @@
 import { Fragment, useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { connectWallet, getAvailableProviders, CIRCLE_PROVIDER_ID } from '../config'
+import {
+  connectWallet,
+  getAvailableProviders,
+  getConnectedProvider,
+  getUsdcBalance,
+  CIRCLE_PROVIDER_ID,
+} from '../config'
 
 export default function WalletConnect({ address, displayName, onConnect, onDisconnect, onEditProfile }) {
   const [showModal, setShowModal] = useState(false)
@@ -8,7 +14,11 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
   const [error, setError] = useState('')
   const [menuOpen, setMenuOpen] = useState(false)
   const [discoveryTick, setDiscoveryTick] = useState(0)
+  const [copied, setCopied] = useState(false)
+  const [balance, setBalance] = useState(null)
   const menuRef = useRef(null)
+  const providerId = getConnectedProvider()
+  const isPasskey = providerId === CIRCLE_PROVIDER_ID
 
   // EIP-6963 wallets announce themselves asynchronously. The set can grow
   // after first render — re-derive `available` when a new wallet announces.
@@ -40,6 +50,28 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
       document.removeEventListener('keydown', onKey)
     }
   }, [menuOpen])
+
+  // Fetch the USDC balance on connect + whenever the dropdown opens, so the
+  // number is fresh after the user faucets or deposits without us subscribing
+  // to chain events. Returns null on failure (caller renders placeholder).
+  useEffect(() => {
+    if (!address) { setBalance(null); return undefined }
+    let cancelled = false
+    getUsdcBalance(address).then(b => { if (!cancelled) setBalance(b) })
+    return () => { cancelled = true }
+  }, [address, menuOpen])
+
+  const handleCopy = async () => {
+    if (!address) return
+    try {
+      await navigator.clipboard.writeText(address)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Older browsers / blocked clipboard — silently fail; user can
+      // long-press the address to copy via native selection.
+    }
+  }
 
   const handleConnect = async (providerId) => {
     setBusy(true)
@@ -93,12 +125,66 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
           >
             <div
               className="caption"
-              style={{ padding: '6px 10px', color: 'var(--text-4)', borderBottom: '1px solid var(--glass-border)', marginBottom: 4 }}
+              style={{ padding: '8px 10px', color: 'var(--text-4)', borderBottom: '1px solid var(--glass-border)', marginBottom: 4 }}
             >
-              <div style={{ color: 'var(--text-2)', fontWeight: 600, fontSize: '0.85rem' }}>
+              <div style={{ color: 'var(--text-2)', fontWeight: 600, fontSize: '0.85rem', marginBottom: 2 }}>
                 {displayName || 'Wallet'}
               </div>
-              <div className="mono" style={{ fontSize: '0.72rem' }}>{shortAddr}</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span className="mono" style={{ fontSize: '0.72rem' }} title={address}>{shortAddr}</span>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  title={copied ? 'Copied!' : 'Copy full address'}
+                  aria-label={copied ? 'Copied' : 'Copy full address'}
+                  style={{
+                    background: 'transparent', border: 'none', color: copied ? 'var(--accent)' : 'var(--text-3)',
+                    cursor: 'pointer', padding: 2, display: 'inline-flex', alignItems: 'center',
+                  }}
+                >
+                  <span
+                    className={copied ? 'i-lucide-check' : 'i-lucide-copy'}
+                    style={{ width: 12, height: 12 }}
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 6, fontSize: '0.74rem' }}>
+                <span className="i-lucide-wallet" style={{ width: 12, height: 12, color: 'var(--text-3)' }} aria-hidden="true" />
+                <span style={{ color: 'var(--text-2)' }}>
+                  {balance === null
+                    ? <span style={{ color: 'var(--text-4)' }}>Loading USDC…</span>
+                    : <><strong style={{ color: 'var(--text-1)' }}>{balance.toFixed(2)}</strong> USDC</>}
+                </span>
+                {balance !== null && balance < 1 && (
+                  <a
+                    href="https://faucet.circle.com/"
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{
+                      marginLeft: 'auto', fontSize: '0.7rem', color: 'var(--accent)',
+                      textDecoration: 'none',
+                    }}
+                    title="Get test USDC from Circle's faucet (20 USDC / 2h on Arc)"
+                  >
+                    Faucet →
+                  </a>
+                )}
+              </div>
+              {isPasskey && (
+                <div
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 4, marginTop: 6,
+                    padding: '4px 6px', background: 'rgba(99, 102, 241, 0.08)',
+                    border: '1px solid rgba(99, 102, 241, 0.18)', borderRadius: 6,
+                    fontSize: '0.68rem', color: 'var(--text-3)',
+                  }}
+                  title="Smart-contract wallet on Arc — backed by a passkey on this device. No seed phrase. No browser extension."
+                >
+                  <span className="i-lucide-fingerprint" style={{ width: 11, height: 11 }} aria-hidden="true" />
+                  <span>Circle Modular Wallet</span>
+                </div>
+              )}
             </div>
             <button
               type="button"
@@ -216,14 +302,30 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
                         ) : (
                           <span className={`wallet-icon ${p.icon} w-5 h-5`} />
                         )}
-                        <span>{p.name}</span>
-                        {p.id === CIRCLE_PROVIDER_ID && (
-                          <span
-                            className="caption"
-                            style={{ marginLeft: 'auto', fontSize: '0.7rem', color: 'var(--text-4)' }}
-                          >
-                            Works in any browser
+                        {p.id === CIRCLE_PROVIDER_ID ? (
+                          <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2, flex: 1 }}>
+                            <span style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+                              <span>{p.name}</span>
+                              <span
+                                style={{
+                                  marginLeft: 'auto', fontSize: '0.62rem', letterSpacing: '0.04em',
+                                  textTransform: 'uppercase', padding: '2px 6px',
+                                  background: 'rgba(212, 168, 83, 0.12)', color: 'var(--accent)',
+                                  border: '1px solid rgba(212, 168, 83, 0.3)', borderRadius: 999,
+                                }}
+                              >
+                                Recommended
+                              </span>
+                            </span>
+                            <span
+                              className="caption"
+                              style={{ fontSize: '0.68rem', color: 'var(--text-4)', lineHeight: 1.35, textAlign: 'left' }}
+                            >
+                              Powered by <strong style={{ color: 'var(--text-3)' }}>Circle Modular Wallets</strong> · Face ID / Touch ID · Smart-contract account on Arc · No extension, no seed phrase
+                            </span>
                           </span>
+                        ) : (
+                          <span>{p.name}</span>
                         )}
                       </button>
                     </Fragment>

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -583,6 +583,33 @@ export const VAULT_FACTORY_ABI = [
 
 export const USDC = "0x3600000000000000000000000000000000000000"
 
+// USDC on Arc testnet uses 6 decimals (verified via
+// `eth_call decimals() at 0x3600...`). Used by getUsdcBalance() below.
+export const USDC_DECIMALS = 6
+
+// Read the USDC balance for an arbitrary address (the wallet menu uses
+// this to show the user how many test USDC they have). Returns a Number
+// in USDC units (already divided by 10^USDC_DECIMALS); returns null on
+// any failure so the caller can fall back to a placeholder rather than
+// crash the menu render.
+export async function getUsdcBalance(address) {
+  if (!address) return null
+  try {
+    const raw = await publicClient.readContract({
+      address: USDC,
+      abi: [
+        { name: 'balanceOf', type: 'function', stateMutability: 'view',
+          inputs: [{ type: 'address' }], outputs: [{ type: 'uint256' }] },
+      ],
+      functionName: 'balanceOf',
+      args: [address],
+    })
+    return Number(raw) / 10 ** USDC_DECIMALS
+  } catch {
+    return null
+  }
+}
+
 export const ASSETS = [
   { id: 'TSLA',   name: 'Tesla',      sym: 'sTSLA',   icon: 'i-simple-icons-tesla',          oracle: '0xe1c9f2b11be97097223a66a188fca541e07873a6', vault: '0xf0356600e26c6c403ec4f5b36b0e3380bb0609ab', token: '0xd514cd27baf762c650536765cde9b61c876abacd' },
   { id: 'NVDA',   name: 'Nvidia',     sym: 'sNVDA',   icon: 'i-simple-icons-nvidia',          oracle: '0xeb36acf88e739dd312de8278985262146a017374', vault: '0x4c3cdc2bf44195ad8a4d201c8afbd453949a8781', token: '0x805e75019a1291a598dfc134ad2519121a35fb11' },


### PR DESCRIPTION
## Summary

Three gaps Dan flagged this morning. All addressed:

| Gap | Fix |
|---|---|
| Passkey CTA undersells Circle | Two-line layout with "Powered by Circle Modular Wallets · Face ID / Touch ID · Smart-contract account on Arc · No extension, no seed phrase" + "Recommended" pill |
| No way to copy wallet address | Inline copy button next to short address; 1.5s "Copied!" check-icon confirmation; clipboard write via navigator.clipboard |
| USDC balance invisible | New `getUsdcBalance()` helper reads USDC.balanceOf via existing publicClient; surfaces under the address. "Faucet →" nudge link when balance < 1 |
| Bonus | "Circle Modular Wallet" pill in the connected-wallet dropdown when signed in via passkey |

## Why this matters

- **For judges:** Circle is one of the sponsors. The fact that we use their Modular Wallets SDK to get a passkey-backed smart-contract account on Arc with no extension is a banger. Burying it as "Sign in with Passkey · Works in any browser" was leaving a sponsor-points layup on the table.
- **For the demo flow:** Without a copy button, the user can't get test USDC. The faucet at https://faucet.circle.com/ needs the address pasted in. Today they'd have to right-click → inspect element. The Faucet → link surfaces only when the balance is < 1 USDC (just-in-time nudge for users who need funds).
- **For trust:** Showing a real on-chain balance ("12.34 USDC") on every menu open proves we're talking to the chain, not faking it.

## Implementation notes

- `getUsdcBalance(address)` returns null on any RPC failure — caller renders "Loading USDC…" rather than crash the menu.
- Balance refetches on every menu open (cheap; one eth_call) so it stays fresh after faucet/deposit without subscribing to chain events.
- USDC decimals = 6 on Arc (verified via `eth_call decimals()` at `0x3600…0000` → returns `0x06`). The chain config's `nativeCurrency.decimals = 18` is for the gas accounting layer and is intentionally separate from the ERC20 view.
- Passkey CTA layout: two-line, "Recommended" pill on the right, subtext below. Existing wallet-option button class; no new CSS.
- Copy button uses an inline lucide icon; flips to `i-lucide-check` on success and back after 1.5s.
- Circle pill only renders when `getConnectedProvider() === CIRCLE_PROVIDER_ID` so EOA users don't see it.

## Test plan

- [x] eslint clean
- [ ] After merge + EC2 redeploy: passkey CTA in modal shows new copy
- [ ] After merge: connected dropdown shows balance + copy button
- [ ] Copy button writes the full address to clipboard
- [ ] Balance shows real USDC amount from chain
- [ ] Faucet → link appears when balance < 1, hidden otherwise

## Anti-goals

- Did not touch the EOA wallet options (MetaMask / Coinbase / generic) in the modal — those weren't underselling anything
- Did not add a "Get more USDC" CTA to the dropdown when balance > 1 — would be noise
- Did not subscribe to chain events for live-updating balance — refetch-on-open is sufficient for the demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)