### PR TITLE
[backend] Fix Generate persistence: ALTER strategy_store for is_example + 3 cols missing on EC2 Postgres

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -354,7 +354,7 @@ async def get_portfolio_advisor(
     all_strategies = [s for s in strategy_provider.list_strategies() if s.real_sharpe is not None]
 
     # Apply regime-aware tilt to strategy ordering
-    from archimedes.services.regime_weight_schedule import apply_regime_tilt, regime_weight_schedule
+    from archimedes.services.regime_weight_schedule import apply_regime_tilt
 
     strategies, regime_mix = apply_regime_tilt(all_strategies, regime_value, risk_profile)
 

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -62,6 +62,14 @@ def init_db() -> None:
             "ALTER TABLE papers ADD COLUMN IF NOT EXISTS cluster_id TEXT",
             "ALTER TABLE papers ADD COLUMN IF NOT EXISTS topic_label TEXT",
             "ALTER TABLE papers ADD COLUMN IF NOT EXISTS content_hash TEXT",
+            # strategy_store columns added after the table was first created.
+            # Without these, Generate persistence dies with UndefinedColumn
+            # (observed live 2026-05-25 on every Generate attempt — the agent
+            # completes but the post-evaluation upsert crashes).
+            "ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS is_example BOOLEAN NOT NULL DEFAULT FALSE",
+            "ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS on_chain_registration_tx VARCHAR(66)",
+            "ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS on_chain_registration_block VARCHAR(32)",
+            "ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS parent_id VARCHAR(64)",
         ]
         try:
             with engine.begin() as conn:

--- a/backend/archimedes/models/strategy_passport_record.py
+++ b/backend/archimedes/models/strategy_passport_record.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     Boolean,
@@ -28,10 +28,17 @@ from sqlalchemy import (
     String,
     Text,
 )
-from sqlalchemy.orm import Session, relationship
+from sqlalchemy.orm import relationship
 
 from archimedes.models.chat import Base
 from archimedes.models.paper_ref import PaperRef
+
+if TYPE_CHECKING:
+    # Import only for the forward-reference type annotation on
+    # to_strategy_passport(). Avoids a circular import at runtime
+    # (StrategyPassport lives in archimedes.models.strategy which imports
+    # back from this module in some paths).
+    from archimedes.models.strategy import StrategyPassport
 
 
 class StrategyPassportRecord(Base):

--- a/backend/archimedes/scripts/migrate_to_unified_passport_store.py
+++ b/backend/archimedes/scripts/migrate_to_unified_passport_store.py
@@ -19,7 +19,6 @@ import argparse
 import json
 import logging
 import sys
-from datetime import UTC, datetime
 
 logging.basicConfig(
     level=logging.INFO,
@@ -32,7 +31,6 @@ def migrate(dry_run: bool = False) -> dict[str, int]:
     """Run the migration. Returns counts."""
     from archimedes.db import get_session, init_db
     from archimedes.models.strategy_passport_record import (
-        PassportPaperRef,
         StrategyPassportRecord,
     )
     from archimedes.services.passport_loader import ingest_passport

--- a/backend/tests/test_passport_loader.py
+++ b/backend/tests/test_passport_loader.py
@@ -6,7 +6,6 @@ All tests use an in-memory SQLite DB — no real Postgres needed.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import create_engine
@@ -21,7 +20,6 @@ from archimedes.models.strategy import (
     StrategyStatus,
 )
 from archimedes.models.strategy_passport_record import (
-    PassportPaperRef,
     StrategyPassportRecord,
 )
 from archimedes.services.passport_loader import (


### PR DESCRIPTION
## Summary

🔴 **Demo-blocker found via live Safari MCP browse.** Every Generate attempt on the live site dies at persist time with:

\`\`\`
(psycopg2.errors.UndefinedColumn) column strategy_store.is_example does not exist
\`\`\`

The agent itself succeeds (job_queued → brief_validated → pipeline_selected → candidates_selected → candidate_drafted → candidate_evaluated → best_selected) — only the final DB upsert fails.

## Root cause

PR #279 (#160 unified-passport-store, t2o2) added \`is_example\` + 3 other columns to the StrategyRecord ORM. \`Base.metadata.create_all()\` only creates new TABLES, not new columns on existing ones. Postgres on EC2 predates #279, so the columns never landed.

## Fix

Extend the hand-rolled "ADD COLUMN IF NOT EXISTS" block in \`init_db()\` — same pattern as the existing \`papers.cluster_id/topic_label/content_hash\` migrations from prior similar incidents. Idempotent; safe on every boot.

\`\`\`sql
ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS is_example BOOLEAN NOT NULL DEFAULT FALSE
ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS on_chain_registration_tx VARCHAR(66)
ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS on_chain_registration_block VARCHAR(32)
ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS parent_id VARCHAR(64)
\`\`\`

## Test plan

- [ ] After merge + EC2 redeploy: try a Generate from the live UI; verify it completes (no "error" state in Recent Generations)
- [ ] Verify the strategy appears in Library afterward
- [ ] Hit \`/api/strategies\` and confirm it returns rows (it currently returns empty / 500)

## Anti-goals

- Did NOT add Alembic. Long-term fix; for the 12-hour-to-submission window the idempotent ALTER pattern stays.
- Did NOT touch the model — model is correct; only the runtime migration was missing.
- Did NOT delete existing rows — \`ALTER ADD COLUMN\` with default is non-destructive.

This is the third time this pattern has bitten us (papers had the same shape twice). Tracking real Alembic migrations as post-hackathon work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)