### PR TITLE
[backend] #160 Phase 2: Cutover to unified strategy_passports table

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -728,6 +728,35 @@ async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple
                 is_example=False,
             )
             session.commit()
+
+            # Also write to the unified strategy_passports table (Issue #160)
+            try:
+                from archimedes.models.paper_ref import PaperRef
+                from archimedes.models.strategy import StrategyPassport, StrategyStatus
+                from archimedes.services.passport_loader import ingest_passport
+
+                papers = [
+                    PaperRef(arxiv_id=p.get("arxiv_id"), title=p.get("title", ""))
+                    for p in (c.source_papers or [])
+                ]
+                passport = StrategyPassport(
+                    id=record.id,
+                    papers=papers,
+                    methodology_summary=c.thesis or "",
+                    asset_universe=c.asset_universe or [],
+                    status=StrategyStatus(record.status) if record.status else StrategyStatus.CANDIDATE,
+                    regime_tag="regime_neutral",
+                    passes_rigor_gate=bool(c.rigor_verdict.get("passing", False)) if c.rigor_verdict else False,
+                    deflated_sharpe_ratio=c.rigor_verdict.get("dsr") if c.rigor_verdict else None,
+                    pbo_score=c.rigor_verdict.get("pbo") if c.rigor_verdict else None,
+                    out_of_sample_sharpe=c.rigor_verdict.get("oos_sharpe") if c.rigor_verdict else None,
+                )
+                with get_session() as sess2:
+                    ingest_passport(sess2, passport, generation_method="fusion", force_update=True)
+                    sess2.commit()
+            except Exception as exc:
+                logger.warning("unified passport persist failed (non-blocking): %s", exc)
+
             return record.id
 
     strategy_id = await asyncio.to_thread(_do_persist)

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1559,3 +1559,35 @@ async def construct_strategy(req: StrategyConstructionRequest):
             is_anchored=trace.is_anchored,
         ),
     )
+
+
+# ── Unified Passport Store (Issue #160 Phase 2) ───────────────────────────
+
+
+@strategies_router.get("/passports")
+async def list_strategy_passports(
+    status: str | None = Query(None),
+    regime_tag: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+):
+    """List strategies from the unified strategy_passports table.
+
+    This is the Phase 2 read path for the unified store — all strategies
+    (curated + generated) are accessible from a single table.
+    """
+    from archimedes.db import get_session
+    from archimedes.services.passport_loader import list_passports
+
+    with get_session() as session:
+        records = list_passports(
+            session,
+            status=status,
+            regime_tag=regime_tag,
+        )
+        passports = [r.to_dict() for r in records[:limit]]
+
+    return {
+        "passports": passports,
+        "total": len(passports),
+        "source": "strategy_passports",
+    }

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -378,7 +378,36 @@ class LocalStrategyProvider:
             self._strategies_dir,
             len(self._backtests),
         )
+
+        # Sync to unified strategy_passports table (Phase 2, Issue #160).
+        # This keeps the Postgres table always in sync with the file-based
+        # strategies + their backtest results. Non-blocking: failures are
+        # logged but don't prevent the provider from serving.
+        self._sync_to_unified_table(loaded)
+
         return len(loaded)
+
+    def _sync_to_unified_table(self, strategies: dict[str, Strategy]) -> None:
+        """Sync loaded strategies to the unified strategy_passports table."""
+        try:
+            from archimedes.services.passport_loader import ingest_passport
+
+            with get_session() as session:
+                synced = 0
+                for strategy in strategies.values():
+                    try:
+                        ingest_passport(
+                            session, strategy,
+                            generation_method="curated",
+                            force_update=True,
+                        )
+                        synced += 1
+                    except Exception as exc:
+                        logger.debug("passport sync failed for %s: %s", strategy.id, exc)
+                session.commit()
+            logger.info("synced %d strategies to strategy_passports table", synced)
+        except Exception as exc:
+            logger.warning("unified table sync failed (non-blocking): %s", exc)
 
     def _load_backtests(self, strategy_ids: Iterable[str]) -> dict[str, BacktestResult]:
         ids = list(strategy_ids)


### PR DESCRIPTION
Completes Issue #160. Write-through to unified table on every refresh() + generation. New /api/strategies/passports read endpoint. 844 tests pass.

Closes #160