### PR TITLE
[frontend] Fix Corpus Graph + KG tabs showing empty instead of real data

### DIFF
--- a/ui/src/components/CorpusGraph.jsx
+++ b/ui/src/components/CorpusGraph.jsx
@@ -137,7 +137,7 @@ export default function CorpusGraph() {
     )
   }
 
-  if (!data || data.status === 'empty' || !data.nodes || data.nodes.length === 0) {
+  if (!data || data.status === 'empty' || ((!data.nodes || data.nodes.length === 0) && (!data.points || data.points.length === 0))) {
     return (
       <div className="corpus-graph-empty" style={{ padding: 40, textAlign: 'center' }}>
         <div className="caption">No papers in corpus yet.</div>

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -38,8 +38,8 @@ export default function CorpusKG({ onOpenPaper }) {
     setLoading(true)
     setError('')
     try {
-      if (!q) { setData(null); setLoading(false); return }
-      const res = await fetch(`${API_BASE}/api/corpus/kg/entities?q=${encodeURIComponent(q)}`)
+      const searchTerm = q || 'topic'
+      const res = await fetch(`${API_BASE}/api/corpus/kg/entities?q=${encodeURIComponent(searchTerm)}`)
       if (res.status === 503) throw new Error('KB pipeline still running — first artifact pending')
       if (!res.ok) throw new Error(res.statusText)
       setData(await res.json())


### PR DESCRIPTION
Graph checked `data.nodes` but API returns `data.points`. KG's empty-query guard prevented initial load.