### PR TITLE
[backend] Wire StrategyPublisher into vault metadata (Issue #276)

### DIFF
--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from fastapi import APIRouter, Query, Request, Response
 
 from archimedes.api._route_helpers import strategy_provider, vault_svc
 from archimedes.api.limiter import limiter
+from archimedes.chain.strategy_publisher import strategy_publisher
+
+logger = logging.getLogger(__name__)
 from archimedes.api.schemas import (
     VaultDetailResponse,
     VaultListResponse,
@@ -25,6 +29,37 @@ from archimedes.chain.executor import chain_executor
 from archimedes.models.chat import VaultMetadata
 
 vaults_router = APIRouter(prefix="/api/vaults", tags=["vaults"])
+
+
+async def _anchor_strategies_async(strategy_ids: list[str]) -> None:
+    """Best-effort on-chain anchoring of strategy passports via StrategyRegistry.
+
+    Fire-and-forget: failures are logged but never raised. Matches the
+    trace_publisher pattern in agent_runner.py.
+    """
+    for sid in strategy_ids:
+        try:
+            passport = strategy_provider.get_strategy(sid)
+            if passport is None:
+                logger.debug("anchor: strategy %s not found in provider — skipping", sid)
+                continue
+            if not getattr(passport, "methodology_hash", None):
+                logger.info("skipping anchor for %s: no methodology_hash", sid)
+                continue
+
+            paper_hashes = [p.arxiv_id for p in passport.papers if p.arxiv_id]
+            regime_tag = getattr(passport, "regime_tag", None)
+
+            await strategy_publisher.anchor(
+                strategy_id=passport.id,
+                methodology_hash=passport.methodology_hash,
+                paper_hashes=paper_hashes,
+                regime_tag=regime_tag,
+                metadata_uri="",
+            )
+            logger.info("anchored strategy %s on-chain", sid)
+        except Exception as exc:
+            logger.warning("anchor failed for strategy %s (non-fatal): %s", sid, exc)
 
 
 @vaults_router.get("/", response_model=VaultListResponse)
@@ -104,6 +139,11 @@ async def store_vault_metadata(req: VaultMetadataRequest, request: Request, resp
         meta.set_strategy_ids(req.strategy_ids)
         session.commit()
         session.refresh(meta)
+
+        # Fire-and-forget on-chain strategy anchoring (best-effort, non-fatal)
+        if req.strategy_ids:
+            asyncio.create_task(_anchor_strategies_async(req.strategy_ids))
+
         return VaultMetadataResponse(**meta.to_dict())
     except Exception as exc:
         session.rollback()

--- a/backend/tests/test_vault_metadata_anchor.py
+++ b/backend/tests/test_vault_metadata_anchor.py
@@ -1,0 +1,107 @@
+"""Tests for strategy passport on-chain anchoring via POST /api/vaults/metadata.
+
+Validates that store_vault_metadata triggers strategy_publisher.anchor()
+for each strategy_id, handles missing passports/hashes gracefully, and
+survives anchor failures without breaking the DB write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from archimedes.main import app
+
+client = TestClient(app)
+
+
+def _make_passport(sid: str, methodology_hash: str | None = "abcd1234" * 8):
+    """Build a mock passport with the fields anchor() needs."""
+    mock = MagicMock()
+    mock.id = sid
+    mock.methodology_hash = methodology_hash
+    mock.regime_tag = "bull"
+    paper = MagicMock()
+    paper.arxiv_id = f"2301.{sid}"
+    mock.papers = [paper]
+    return mock
+
+
+class TestVaultMetadataAnchor:
+    @patch("archimedes.api.vaults_routes.strategy_publisher")
+    @patch("archimedes.api.vaults_routes.strategy_provider")
+    def test_metadata_post_calls_anchor_once_per_strategy_id(self, mock_provider, mock_publisher):
+        mock_provider.get_strategy.side_effect = lambda sid: _make_passport(sid)
+        mock_publisher.anchor = AsyncMock()
+
+        resp = client.post("/api/vaults/metadata", json={
+            "vault_address": "0x" + "ab" * 20,
+            "name": "Test Vault",
+            "symbol": "tVLT",
+            "strategy_ids": ["s1", "s2", "s3"],
+        })
+        assert resp.status_code == 200
+
+        # Give the fire-and-forget task time to execute
+        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.1))
+
+        assert mock_publisher.anchor.call_count == 3
+
+    @patch("archimedes.api.vaults_routes.strategy_publisher")
+    @patch("archimedes.api.vaults_routes.strategy_provider")
+    def test_metadata_post_skips_passports_without_methodology_hash(self, mock_provider, mock_publisher):
+        def get_strat(sid):
+            if sid == "s2":
+                return _make_passport(sid, methodology_hash=None)
+            return _make_passport(sid)
+
+        mock_provider.get_strategy.side_effect = get_strat
+        mock_publisher.anchor = AsyncMock()
+
+        resp = client.post("/api/vaults/metadata", json={
+            "vault_address": "0x" + "cd" * 20,
+            "name": "Test Vault 2",
+            "symbol": "tVL2",
+            "strategy_ids": ["s1", "s2", "s3"],
+        })
+        assert resp.status_code == 200
+
+        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.1))
+        # s2 skipped due to no methodology_hash
+        assert mock_publisher.anchor.call_count == 2
+
+    @patch("archimedes.api.vaults_routes.strategy_publisher")
+    @patch("archimedes.api.vaults_routes.strategy_provider")
+    def test_metadata_post_succeeds_when_anchor_raises(self, mock_provider, mock_publisher):
+        mock_provider.get_strategy.side_effect = lambda sid: _make_passport(sid)
+        mock_publisher.anchor = AsyncMock(side_effect=RuntimeError("simulated chain failure"))
+
+        resp = client.post("/api/vaults/metadata", json={
+            "vault_address": "0x" + "ef" * 20,
+            "name": "Test Vault 3",
+            "symbol": "tVL3",
+            "strategy_ids": ["s1"],
+        })
+        # Handler still returns 200 — anchor failure is non-fatal
+        assert resp.status_code == 200
+
+    @patch("archimedes.api.vaults_routes.strategy_publisher")
+    @patch("archimedes.api.vaults_routes.strategy_provider")
+    def test_metadata_post_with_unknown_strategy_id_does_not_crash(self, mock_provider, mock_publisher):
+        mock_provider.get_strategy.return_value = None
+        mock_publisher.anchor = AsyncMock()
+
+        resp = client.post("/api/vaults/metadata", json={
+            "vault_address": "0x" + "11" * 20,
+            "name": "Test Vault 4",
+            "symbol": "tVL4",
+            "strategy_ids": ["unknown_id"],
+        })
+        assert resp.status_code == 200
+
+        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.1))
+        # anchor should NOT have been called for unknown strategy
+        mock_publisher.anchor.assert_not_called()


### PR DESCRIPTION
On-chain strategy passport anchoring via StrategyRegistry.sol. Fire-and-forget, non-fatal, 4 new tests. Closes #276