### PR TITLE
[backend] Junk hunt bundle 1: Corpus overview categories/years + Library frontier n<3 fix

### DIFF
--- a/backend/archimedes/api/corpus_routes.py
+++ b/backend/archimedes/api/corpus_routes.py
@@ -86,8 +86,21 @@ async def runner_state() -> dict[str, Any]:
 
 @corpus_router.get("/overview")
 async def corpus_overview() -> dict[str, Any]:
-    """KB-aware corpus overview. Falls back to DB-only counts if no manifest."""
+    """KB-aware corpus overview. Falls back to DB-only counts if no manifest.
+
+    Returns both the legacy KB-pipeline fields (paper_count, cluster_count,
+    last_run_ts, pipeline_status) AND the fields the CorpusExplorer UI
+    needs to render Category Distribution + Year Distribution charts and
+    the stat chips at the top of the page (total_papers, categories,
+    year_distribution, source). Without those, the Overview tab + the
+    header chips render empty (observed live 2026-05-25 — Catalog tab
+    showed 10K papers, Overview tab showed only section titles).
+    """
     manifest = _load_manifest()
+    paper_count = 0
+    cluster_rows: list[tuple] = []
+    categories: list[dict[str, Any]] = []
+    year_distribution: list[dict[str, Any]] = []
     try:
         from sqlalchemy import func
 
@@ -104,17 +117,83 @@ async def corpus_overview() -> dict[str, Any]:
                 .group_by(PaperRecord.cluster_id)
                 .all()
             )
+            cat_rows = (
+                session.query(
+                    PaperRecord.primary_category,
+                    func.count(PaperRecord.arxiv_id),
+                )
+                .filter(PaperRecord.primary_category != "")
+                .group_by(PaperRecord.primary_category)
+                .order_by(func.count(PaperRecord.arxiv_id).desc())
+                .all()
+            )
+            # `primary_category` is the arxiv subject code (e.g. "q-fin.PM").
+            # `label` is what the UI displays in the chart row + filter chip;
+            # for now reuse the raw code — friendly mapping can be a follow-up.
+            categories = [
+                {"name": name, "label": _pretty_category(name), "count": int(count)} for name, count in cat_rows
+            ]
+            # `published` is stored as an ISO date string (YYYY-MM-DD…).
+            # Bucket by year via leftmost 4 chars; cheap GROUP BY without
+            # an extra index.
+            year_rows = (
+                session.query(
+                    func.substr(PaperRecord.published, 1, 4).label("yr"),
+                    func.count(PaperRecord.arxiv_id),
+                )
+                .filter(PaperRecord.published != "")
+                .group_by("yr")
+                .order_by("yr")
+                .all()
+            )
+            year_distribution = [
+                {"year": int(yr), "count": int(count)}
+                for yr, count in year_rows
+                if yr and yr.isdigit() and 1990 <= int(yr) <= 2030
+            ]
     except Exception as exc:
         logger.warning("corpus_routes: overview DB read failed: %s", exc)
-        paper_count = 0
-        cluster_rows = []
 
     return {
+        # Legacy KB-pipeline shape — kept for backward compatibility
         "paper_count": paper_count,
         "cluster_count": len([c for c, _ in cluster_rows if c is not None]),
         "last_run_ts": (manifest or {}).get("run_ts"),
         "pipeline_status": (manifest or {}).get("status", "never run"),
+        # UI shape — read by CorpusExplorer.jsx for header chips + Overview tab
+        "total_papers": paper_count,
+        "categories": categories,
+        "year_distribution": year_distribution,
+        "source": "arxiv q-fin + adjacent",
     }
+
+
+_CATEGORY_LABELS = {
+    "q-fin.PM": "Portfolio Mgmt",
+    "q-fin.RM": "Risk Mgmt",
+    "q-fin.TR": "Trading & Microstructure",
+    "q-fin.PR": "Pricing of Securities",
+    "q-fin.ST": "Statistical Finance",
+    "q-fin.CP": "Computational Finance",
+    "q-fin.MF": "Mathematical Finance",
+    "q-fin.GN": "General Finance",
+    "q-fin.EC": "Economics",
+    "cs.LG": "Machine Learning",
+    "stat.ML": "Machine Learning (statistics)",
+    "stat.AP": "Statistics — Applications",
+    "cs.AI": "AI",
+    "cs.CL": "NLP",
+    "math.OC": "Optimization & Control",
+    "math.PR": "Probability",
+    "math.ST": "Statistics Theory",
+    "econ.EM": "Econometrics",
+    "econ.GN": "General Economics",
+}
+
+
+def _pretty_category(arxiv_code: str) -> str:
+    """Friendly name for an arxiv subject code; falls back to the code."""
+    return _CATEGORY_LABELS.get(arxiv_code, arxiv_code)
 
 
 @corpus_router.get("/graph")

--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -238,7 +238,17 @@ def compute_efficient_frontier(
     frontier: list[dict] = []
 
     w0 = np.ones(n) / n
-    bounds = [(0.0, _CAP_DEFAULT)] * n
+    # Per-asset cap. The default 0.40 cap exists to bound concentration
+    # risk when there are 3+ strategies to diversify across. With only
+    # 1–2 strategies the cap makes the frontier infeasible:
+    #   n=2, cap=0.4 → max sum = 0.8 < 1.0  (frontier empty)
+    #   n=2, cap=0.5 → only equal-weight (0.5, 0.5) is feasible (single point)
+    # When n < 3 there's no meaningful diversification cap to apply, so
+    # remove it entirely; SLSQP then sweeps the full corner-to-corner
+    # frontier. Live symptom: Library "Efficient Frontier" panel said
+    # "Need at least 2 Tier-1 strategies" even though there were 2.
+    per_asset_cap = 1.0 if n < 3 else _CAP_DEFAULT
+    bounds = [(0.0, per_asset_cap)] * n
 
     for target_mu in target_returns:
         constraints = [

--- a/backend/tests/test_vault_metadata_anchor.py
+++ b/backend/tests/test_vault_metadata_anchor.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from archimedes.main import app


### PR DESCRIPTION
## Summary

Two live-site fixes from this morning's Safari MCP browse:

### 1. Corpus Overview tab — section headers but no data

`/api/corpus/overview` returned `{paper_count, cluster_count, last_run_ts, pipeline_status}` but the UI expects `{total_papers, categories[], year_distribution[], source}`. Net effect: Overview tab rendered the layout (Category Distribution, Year Distribution, Library Summary) but no numbers, and the header chips (papers / categories / source) rendered empty. Catalog tab was fine (showed 10K papers) because it uses a different endpoint.

**Fix:** extend backend overview to return both shapes. Added GROUP BY queries for category histogram + year histogram + `_CATEGORY_LABELS` mapping so chart labels are readable (`q-fin.PM → "Portfolio Mgmt"`, etc.) instead of raw arxiv codes.

### 2. Library — Efficient Frontier said "Need at least 2 Tier-1 strategies" when there ARE 2

Root cause: per-asset cap of 0.40 makes the sum-to-1 constraint infeasible for n<3 (n=2: max sum = 0.8 < 1.0 → SLSQP fails on every target return → frontier returns []).

**Fix:** when n < 3 drop the cap entirely (1.0). The cap exists to bound concentration when there are 3+ strategies to diversify across; with 1-2 it has nothing meaningful to do.

Verified locally:
- n=2: 0/30 points → **30/30 points**
- n=4: 12/30 points → 12/30 points (unchanged, cap still 0.40 in effect)

## Out of scope

- The frontend "Examples (0)" tab-count loading flicker (low priority UX nit; deferred)
- CorpusGraph empty-state check (the bot's PR #284 shipped that fix concurrently — dropped my version)

## Bonus

Also cleared one inherited F401 (`pytest` unused import) in `test_vault_metadata_anchor.py` from PR #285 so this PR's CI ruff-gate passes.

## Test plan

- [x] Verified `/api/corpus/overview` returns the new fields locally
- [x] Verified `compute_efficient_frontier(n=2)` returns 30 points (was 0)
- [x] Verified `compute_efficient_frontier(n=4)` still respects 0.40 cap
- [x] ruff format + ruff check (E9/F63/F7/F40/F82) clean
- [ ] After merge + deploy: Corpus Overview tab shows real charts; Library frontier renders curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)