### PR TITLE
[frontend+backend] Wallet-gate Library/Portfolio/Learnings + Corpus catalog honesty (10K→1014)

### DIFF
--- a/backend/archimedes/api/corpus_routes.py
+++ b/backend/archimedes/api/corpus_routes.py
@@ -98,6 +98,7 @@ async def corpus_overview() -> dict[str, Any]:
     """
     manifest = _load_manifest()
     paper_count = 0
+    processed_papers = 0
     cluster_rows: list[tuple] = []
     categories: list[dict[str, Any]] = []
     year_distribution: list[dict[str, Any]] = []
@@ -109,6 +110,9 @@ async def corpus_overview() -> dict[str, Any]:
 
         with get_session() as session:
             paper_count = session.query(func.count(PaperRecord.arxiv_id)).scalar() or 0
+            processed_papers = (
+                session.query(func.count(PaperRecord.arxiv_id)).filter(PaperRecord.cluster_id.isnot(None)).scalar() or 0
+            )
             cluster_rows = (
                 session.query(
                     PaperRecord.cluster_id,
@@ -117,12 +121,18 @@ async def corpus_overview() -> dict[str, Any]:
                 .group_by(PaperRecord.cluster_id)
                 .all()
             )
+            # Category + year histograms restricted to KB-processed papers so
+            # the chart numbers match what the user can actually inspect end
+            # to end (paper detail + topic cluster + similarity neighbors).
+            # Showing histogram over all 10K metadata rows would imply the
+            # KB pipeline ran on rows it hasn't touched yet.
             cat_rows = (
                 session.query(
                     PaperRecord.primary_category,
                     func.count(PaperRecord.arxiv_id),
                 )
                 .filter(PaperRecord.primary_category != "")
+                .filter(PaperRecord.cluster_id.isnot(None))
                 .group_by(PaperRecord.primary_category)
                 .order_by(func.count(PaperRecord.arxiv_id).desc())
                 .all()
@@ -142,6 +152,7 @@ async def corpus_overview() -> dict[str, Any]:
                     func.count(PaperRecord.arxiv_id),
                 )
                 .filter(PaperRecord.published != "")
+                .filter(PaperRecord.cluster_id.isnot(None))
                 .group_by("yr")
                 .order_by("yr")
                 .all()
@@ -157,11 +168,16 @@ async def corpus_overview() -> dict[str, Any]:
     return {
         # Legacy KB-pipeline shape — kept for backward compatibility
         "paper_count": paper_count,
+        "processed_papers": processed_papers,
+        "metadata_only_papers": max(paper_count - processed_papers, 0),
         "cluster_count": len([c for c, _ in cluster_rows if c is not None]),
         "last_run_ts": (manifest or {}).get("run_ts"),
         "pipeline_status": (manifest or {}).get("status", "never run"),
-        # UI shape — read by CorpusExplorer.jsx for header chips + Overview tab
-        "total_papers": paper_count,
+        # UI shape — read by CorpusExplorer.jsx for header chips + Overview tab.
+        # total_papers reflects the *processed* count so the prominent number
+        # users see matches what they can inspect end to end. Catalog tab
+        # defaults to processed_only=true (see papers_routes.py).
+        "total_papers": processed_papers,
         "categories": categories,
         "year_distribution": year_distribution,
         "source": "arxiv q-fin + adjacent",

--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -18,13 +18,32 @@ async def list_papers(
     page_size: int = Query(20, ge=1, le=100),
     category: str | None = None,
     search: str | None = None,
+    processed_only: bool = Query(
+        True,
+        description=(
+            "If true (default), only return papers the KB pipeline has fully "
+            "processed (i.e. have a non-null cluster_id from BERTopic). The "
+            "papers table holds 10K rows of arxiv metadata but the KB pipeline "
+            "has only run on ~1K so far; setting this to false reveals the raw "
+            "metadata-only rows that have no embeddings/topic labels/triples."
+        ),
+    ),
 ):
-    """Paginated corpus catalog. DB-backed with file fallback."""
+    """Paginated corpus catalog. DB-backed with file fallback.
+
+    Defaults to ``processed_only=true`` so the catalog reflects what the
+    user can actually inspect end-to-end (paper detail + topic cluster +
+    similarity neighbors). The raw 10K-row metadata table is preserved
+    as a superset; the runner-state endpoint reports the processed
+    paper_count separately.
+    """
     from archimedes.models.corpus_store import PaperRecord
 
     with get_session() as session:
         query = session.query(PaperRecord)
 
+        if processed_only:
+            query = query.filter(PaperRecord.cluster_id.isnot(None))
         if category:
             query = query.filter(PaperRecord.categories.contains(category))
         if search:

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -12,7 +12,10 @@ import CorpusExplorer from './components/CorpusExplorer'
 import Reasoning from './components/Reasoning'
 import VaultDetail from './components/VaultDetail'
 import OnboardingTour, { hasCompletedOnboarding } from './components/OnboardingTour'
+import WalletGate from './components/WalletGate'
 import './App.css'
+
+const openConnectModal = () => window.dispatchEvent(new Event('open-wallet-modal'))
 
 // Spine routing per docs/user-stories.md. Anything not in this map is gone.
 // vault-detail is a deep-link only (reached from Portfolio); reasoning is a
@@ -188,12 +191,39 @@ export default function App() {
       case 'landing':     return <Landing onNavigate={navigateToPage} />
       case 'explore':      return <Explore onNavigate={navigateToPage} />
       case 'generate':     return <Generate onNavigate={navigateToPage} />
-      case 'library':      return <Strategies highlightStrategyId={highlightStrategyId} defaultTab={defaultTab} onNavigate={navigateToPage} />
+      case 'library':      return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Your Strategies"
+          description="Library shows strategies you've generated, plus a clearly-separated set of paper-grounded example strategies. Connect a wallet — passkey or browser wallet, both work — to see your generations and deploy them as vaults."
+          onConnect={openConnectModal}
+        >
+          <Strategies highlightStrategyId={highlightStrategyId} defaultTab={defaultTab} onNavigate={navigateToPage} />
+        </WalletGate>
+      )
       case 'strategy':     return <StrategyPassport strategyId={selectedStrategy} onNavigate={navigateToPage} walletAddr={walletAddr} />
       case 'corpus':       return <CorpusExplorer />
-      case 'portfolio':    return <Portfolio walletAddr={walletAddr} onSelectVault={selectVault} onSelectTrace={selectTrace} />
+      case 'portfolio':    return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Portfolio"
+          description="Portfolio shows your AUM, your deployed vaults, and the autonomous agent's rebalance decisions. Connect a wallet to deposit USDC and start tracking — this is a non-custodial vault you control, not an account on our platform."
+          onConnect={openConnectModal}
+        >
+          <Portfolio walletAddr={walletAddr} onSelectVault={selectVault} onSelectTrace={selectTrace} />
+        </WalletGate>
+      )
       case 'reasoning':    return <Reasoning onNavigate={navigateToPage} />
-      case 'learnings':    return <Learnings onNavigate={navigateToPage} />
+      case 'learnings':    return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Learnings"
+          description="Learnings reviews the strategies you've deployed — winners and losers, both first-class — with the agent's reasoning available for each rebalance. Connect a wallet to see your deployments."
+          onConnect={openConnectModal}
+        >
+          <Learnings onNavigate={navigateToPage} />
+        </WalletGate>
+      )
       case 'vault-detail': return <VaultDetail address={selectedVault} onBack={backToPortfolio} />
       default:             return <NotFound page={page} onNavigate={navigateToPage} />
     }

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -36,6 +36,15 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
   void discoveryTick
   const available = getAvailableProviders()
 
+  // Allow other components (e.g. WalletGate on logged-out pages) to open
+  // this modal without prop-drilling. Dispatch `open-wallet-modal` to
+  // trigger; WalletGate's "Connect Wallet" button uses this.
+  useEffect(() => {
+    const open = () => setShowModal(true)
+    window.addEventListener('open-wallet-modal', open)
+    return () => window.removeEventListener('open-wallet-modal', open)
+  }, [])
+
   // Close the connected-wallet dropdown on outside click or Escape.
   useEffect(() => {
     if (!menuOpen) return undefined

--- a/ui/src/components/WalletGate.jsx
+++ b/ui/src/components/WalletGate.jsx
@@ -1,0 +1,57 @@
+// Wallet-gate wrapper. Renders a Connect-Wallet CTA card when no wallet
+// is connected; renders children when one is. Used to gate per-user
+// surfaces (Library, Portfolio, Learnings) so the logged-out experience
+// doesn't render "$0.00 across 0 vaults you created", "Your Strategies",
+// or "27 traces (you've deployed)" — all of which imply personalization
+// the user doesn't actually have without a wallet.
+//
+// Public pages (Generate, Corpus, Reasoning, Explore, Landing) deliberately
+// do NOT use this gate — they're either browse-only or paper-grounded
+// and useful without a wallet.
+
+export default function WalletGate({ walletAddr, pageName, description, onConnect, children }) {
+  if (walletAddr) return children
+
+  return (
+    <div className="wallet-gate" style={{
+      maxWidth: 560,
+      margin: '64px auto',
+      padding: 32,
+      background: 'var(--surface-1)',
+      border: '1px solid var(--glass-border)',
+      borderRadius: 14,
+      textAlign: 'center',
+    }}>
+      <div style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 56,
+        height: 56,
+        borderRadius: '50%',
+        background: 'rgba(212, 168, 83, 0.10)',
+        border: '1px solid rgba(212, 168, 83, 0.30)',
+        marginBottom: 18,
+      }}>
+        <span className="i-lucide-lock" style={{ width: 22, height: 22, color: 'var(--accent)' }} aria-hidden="true" />
+      </div>
+      <h2 style={{ margin: 0, marginBottom: 8, fontFamily: 'var(--font-serif)' }}>
+        Connect to view {pageName}
+      </h2>
+      <p className="caption" style={{ color: 'var(--text-3)', maxWidth: 440, margin: '0 auto 20px', lineHeight: 1.55 }}>
+        {description}
+      </p>
+      <button
+        type="button"
+        className="btn btn-primary"
+        onClick={onConnect}
+        style={{ minWidth: 200 }}
+      >
+        Connect Wallet
+      </button>
+      <p className="caption" style={{ marginTop: 20, fontSize: '0.72rem', color: 'var(--text-4)' }}>
+        Testnet only — no real funds at risk. Passkey or browser wallet both work.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Two integrity fixes from this morning's live-site junk hunt with Safari MCP. Both matter because the prior state implied personalization the user didn't have (gated pages without a wallet) **or** KB-pipeline work the bot hadn't actually done (catalog 10K vs processed 1014).

## 1. Wallet-gate Library / Portfolio / Learnings

Logged-out browse on https://archimedes-arc.app/ today found:

| Route | Leak |
|---|---|
| `/library` | "Your Strategies" + "Generated (1)" — implies the strategy you generated is yours, but it's associated to **someone else's** wallet |
| `/portfolio` | "YOUR AUM **$0.00** / Across 0 vaults you created" + "RISK ON **92.0% conf**" — implies an account |
| `/learnings` | Frames as "Strategies you've deployed" with no deployments possible without a wallet |

**Fix:** new `<WalletGate>` wrapper renders a single Connect-Wallet CTA card when `walletAddr` is null; renders children when set. Page-specific descriptive copy. Connect button dispatches `open-wallet-modal` window event; `WalletConnect.jsx` listens for it.

Wrapped: Library, Portfolio, Learnings.
Deliberately NOT gated: Generate, Corpus, Reasoning, Explore, Landing (all public-by-design).

## 2. Corpus catalog honesty (10K → 1014)

`/api/corpus/runner-state` reports `paper_count: 1014` (processed). But:
- Catalog tab listed all 10,000 metadata rows
- Overview chip claimed "10,000 papers"

Clicking into a paper that wasn't in the processed 1014 returned no cluster, no topic — the "papers we processed" claim was 10× reality.

**Fix:**
- `papers_routes.py`: new `processed_only=true` default; filters `cluster_id IS NOT NULL`. Escape hatch `?processed_only=false` for the full metadata superset.
- `corpus_routes.py /overview`: returns `processed_papers` + `metadata_only_papers` distinctly. `total_papers` (prominent UI chip) = processed count. Category + year histograms also filtered to the processed subset.

## Test plan

- [x] `pytest backend/tests -k "corpus or papers"` → 54 passed
- [x] ruff format + ruff check (E9/F63/F7/F40/F82) clean
- [x] eslint clean on touched JSX
- [ ] After merge: logged-out browse — Library/Portfolio/Learnings show CTA card, not personalized data
- [ ] After merge: Corpus chip reads ~1014 papers, Catalog tab lists only the processed subset

## Out of scope — tracked separately

**KB pipeline authenticity question.** `/api/corpus/kg/paper/{id}` returns only one triple per paper with `relation: "belongs_to_cluster"`. That's BERTopic cluster membership masquerading as a REBEL triple. Real REBEL output should have varied predicates (cites, uses, evaluates, anchored_to, etc.). The SPECTER2 embedding endpoint also 404s. Drafting a Discord message to Chuan's bot to triage whether the REBEL + SciSpacy steps of the pipeline actually ran, or got skipped/stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)