### PR TITLE
[frontend] Track A fallback (DRAFT): rename Knowledge Graph tab → Topic Clusters

### DIFF
--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -13,6 +13,21 @@ async function apiGet(path) {
 
 const TABS = ['catalog', 'overview', 'graph', 'knowledge-graph']
 
+// Friendly tab labels. The "knowledge-graph" slug stays for routing /
+// state stability, but the displayed label is "Topic Clusters" because
+// — until REBEL + SciSpacy actually run on the corpus (Issue #293) —
+// the only triples in the KG tables are BERTopic cluster memberships
+// (one predicate, `belongs_to_cluster`). Calling that a Knowledge
+// Graph would be misleading. BERTopic clusters across 1014 papers are
+// real and valuable; this is the honest framing of what they are.
+// When #293 lands with multi-predicate REBEL output, revert this map.
+const TAB_LABELS = {
+  catalog: 'Catalog',
+  overview: 'Overview',
+  graph: 'Graph',
+  'knowledge-graph': 'Topic Clusters',
+}
+
 export default function CorpusExplorer() {
   const [tab, setTab] = useState('catalog')
   const [overview, setOverview] = useState(null)
@@ -78,7 +93,7 @@ export default function CorpusExplorer() {
       <div className="corpus-tabs">
         {TABS.map(t => (
           <button key={t} className={`corpus-tab${tab === t ? ' active' : ''}`} onClick={() => setTab(t)}>
-            {t.replace('-', ' ').replace(/\b\w/g, c => c.toUpperCase())}
+            {TAB_LABELS[t] ?? t.replace('-', ' ').replace(/\b\w/g, c => c.toUpperCase())}
           </button>
         ))}
       </div>

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -20,7 +20,9 @@ const TYPE_ICONS = {
 }
 
 /**
- * Knowledge Graph viewer.
+ * Topic Clusters viewer. (Currently renders BERTopic-derived topic clusters
+ * across the KB-processed paper subset. Promoted to a real Knowledge Graph
+ * once REBEL + SciSpacy land — Issue #293.)
  *
  * Fetches from ``/api/corpus/kg/entities?q=<q>`` and renders entities
  * + relations as an SVG graph. Entity search filters the KG. Falls back
@@ -44,7 +46,7 @@ export default function CorpusKG({ onOpenPaper }) {
       if (!res.ok) throw new Error(res.statusText)
       setData(await res.json())
     } catch (e) {
-      setError(e.message || 'Failed to load knowledge graph')
+      setError(e.message || 'Failed to load topic clusters')
     } finally {
       setLoading(false)
     }
@@ -101,7 +103,7 @@ export default function CorpusKG({ onOpenPaper }) {
         </form>
         <div className="info-box warning">
           {error.includes('503') || error.includes('KB pipeline')
-            ? 'KB pipeline still running — first artifact pending. The knowledge graph will populate once the KG is built.'
+            ? 'KB pipeline still running — first artifact pending. The topic clusters will populate once the KG is built.'
             : `Knowledge graph unavailable: ${error}`}
         </div>
       </div>
@@ -155,7 +157,7 @@ export default function CorpusKG({ onOpenPaper }) {
       </div>
 
       {loading ? (
-        <div style={{ padding: 40, textAlign: 'center' }} className="caption">Loading knowledge graph…</div>
+        <div style={{ padding: 40, textAlign: 'center' }} className="caption">Loading topic clusters…</div>
       ) : entities.length === 0 ? (
         <div style={{ padding: 40, textAlign: 'center' }} className="caption">No entities found.</div>
       ) : (


### PR DESCRIPTION
## ⚠️ DRAFT — fallback only

**Do NOT merge unless Track B (Issue #293, real REBEL+SciSpacy run) doesn't land by T-6h to submission.** This PR is the honest framing if real KG triples don't ship in time.

## Context

Pi confirmed in Discord 2026-05-25 ~14:30 UTC that REBEL + SciSpacy were never invoked on the KB-processed 1014-paper corpus. `kg_relations` contains only `belongs_to_cluster` rows (BERTopic cluster memberships reshaped into the KG schema with a single synthesized predicate at confidence=0.9).

Calling that surface a "Knowledge Graph" is misleading. Calling it "Topic Clusters" is honest about what it actually is: BERTopic clusters with SPECTER2-derived membership.

BERTopic clusters across 1014 papers ARE real and impressive (49 clusters with meaningful topic labels). Only the framing is off.

## Changes

- `CorpusExplorer.jsx`: new `TAB_LABELS` map. Route slug `knowledge-graph` unchanged; displayed tab label = "Topic Clusters".
- `CorpusKG.jsx`: user-facing copy in loading/error states ("knowledge graph" → "topic clusters") + module docstring flagging the temporary framing.

API paths untouched. When Issue #293 lands with multi-predicate REBEL output, flip the TAB_LABELS entry back and the framing returns automatically.

## Revert path

If Track B (Issue #293) lands first:
```bash
git revert <this PR's merge commit>
# or edit TAB_LABELS['knowledge-graph'] back to undefined / 'Knowledge Graph'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)