### PR TITLE
[backend] Make generated strategies clickable: passport fallback + /passports/{id} detail

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1122,15 +1122,112 @@ async def list_strategy_passports(
     return {"passports": passports, "total": len(passports), "source": "strategy_passports"}
 
 
+@strategies_router.get("/passports/{strategy_id}")
+async def get_strategy_passport(strategy_id: str):
+    """Get a single passport in its native dict shape from strategy_passports."""
+    from fastapi import HTTPException
+
+    from archimedes.db import get_session
+    from archimedes.services.passport_loader import get_passport
+
+    with get_session() as session:
+        record = get_passport(session, strategy_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="Passport not found")
+        return record.to_dict()
+
+
+def _passport_to_strategy_response(record) -> StrategyResponse:
+    """Reshape a StrategyPassportRecord (fusion/architect output) into the
+    StrategyResponse schema that StrategyPassport.jsx expects. Curated
+    strategies still flow through LocalStrategyProvider above; this is the
+    fallback that makes generated strategies clickable from Library."""
+    from archimedes.api.schemas import PaperRefResponse
+
+    refs = list(record.paper_refs or [])
+    first = refs[0] if refs else None
+
+    papers_list = [
+        PaperRefResponse(
+            arxiv_id=r.arxiv_id,
+            title=r.title or "",
+            authors=json.loads(r.authors) if r.authors else [],
+            doi=r.doi,
+            venue=r.venue,
+            year=r.year,
+            citation_count=r.citation_count,
+            contribution=r.contribution,
+        )
+        for r in refs
+    ]
+
+    asset_universe = json.loads(record.asset_universe) if record.asset_universe else []
+
+    return StrategyResponse(
+        id=record.id,
+        papers=papers_list,
+        paper_arxiv_id=first.arxiv_id if first else None,
+        paper_title=first.title if first else None,
+        paper_authors=json.loads(first.authors) if first and first.authors else [],
+        paper_venue=first.venue if first else None,
+        paper_year=first.year if first else None,
+        paper_doi=first.doi if first else None,
+        paper_citation_count=first.citation_count if first else None,
+        methodology_summary=record.methodology_summary or "",
+        asset_universe=asset_universe,
+        position_sizing=record.position_sizing or "equal_weight",
+        rebalance_frequency=record.rebalance_frequency or "weekly",
+        status=record.status or "candidate",
+        methodology_hash=record.methodology_hash,
+        extraction_llm=record.extraction_llm,
+        curator_wallet=record.curator_wallet,
+        curator_note=record.curator_note,
+        on_chain_registration_tx=record.on_chain_registration_tx,
+        paper_claimed_sharpe=record.paper_claimed_sharpe,
+        paper_claim_blended_sharpe=record.paper_claim_blended_sharpe,
+        sharpe_ratio=record.sharpe_ratio,
+        sortino_ratio=record.sortino_ratio,
+        cagr=record.cagr,
+        max_drawdown=record.max_drawdown,
+        win_rate=record.win_rate,
+        calmar_ratio=record.calmar_ratio,
+        correlation_to_spy=record.correlation_to_spy,
+        total_trades=record.total_trades,
+        deflated_sharpe_ratio=record.deflated_sharpe_ratio,
+        dsr_p_value=record.dsr_p_value,
+        pbo_score=record.pbo_score,
+        out_of_sample_sharpe=record.out_of_sample_sharpe,
+        kelly_fraction=None,
+        passes_rigor_gate=bool(record.passes_rigor_gate),
+        is_backtest_placeholder=record.sharpe_ratio is None,
+        sharpe_ci_lower=None,
+        sharpe_ci_upper=None,
+        backtest_start=record.backtest_start,
+        backtest_end=record.backtest_end,
+        regime_tag=record.regime_tag,
+    )
+
+
 @strategies_router.get("/{strategy_id}", response_model=StrategyResponse)
 async def get_strategy(strategy_id: str):
-    """Get a single strategy by ID. Backed by LocalStrategyProvider."""
+    """Get a single strategy by ID. Tries LocalStrategyProvider (curated)
+    first; falls through to the strategy_passports table for fusion- and
+    architect-generated strategies so they're clickable from Library."""
     from fastapi import HTTPException
 
     strat = strategy_provider.get_strategy(strategy_id)
-    if strat is None:
-        raise HTTPException(status_code=404, detail="Strategy not found")
-    return _to_strategy_response(strat)
+    if strat is not None:
+        return _to_strategy_response(strat)
+
+    from archimedes.db import get_session
+    from archimedes.services.passport_loader import get_passport
+
+    with get_session() as session:
+        record = get_passport(session, strategy_id)
+        if record is not None:
+            return _passport_to_strategy_response(record)
+
+    raise HTTPException(status_code=404, detail="Strategy not found")
 
 
 # ── Strategy generation (fusion / architect) ──────────────────


### PR DESCRIPTION
## Summary

Generated strategies (fusion / architect output) land in the unified `strategy_passports` table but `GET /api/strategies/{id}` only knows about `LocalStrategyProvider` — which serves curated only. Result: clicking any generated strategy in /library navigates to /strategy/{id}, the StrategyPassport view fetches `/api/strategies/{id}`, gets 404, and renders "Could not load strategy: …". Discovered today via Safari verification of a freshly-generated strategy (`43d08fca16d8ef2b` → 404 even though it appears in `/passports` and `/generated` listings).

## Changes

**`_passport_to_strategy_response(record)`** — new helper that reshapes a `StrategyPassportRecord` into the `StrategyResponse` schema the UI already consumes:
- `papers` (PaperRefResponse list) from `paper_refs`
- Flat `paper_arxiv_id/title/authors/venue/year/doi/citation_count` from `paper_refs[0]`
- All scoring fields (sharpe_ratio, sortino_ratio, max_drawdown, cagr, win_rate, calmar_ratio, dsr, pbo, oos_sharpe, …) lifted from the same columns on the record
- `kelly_fraction`, `sharpe_ci_lower`, `sharpe_ci_upper` → `None` (curated-only fields)
- `is_backtest_placeholder = record.sharpe_ratio is None`

**`get_strategy(strategy_id)`** now tries LocalStrategyProvider first (existing curated path), falls through to `get_passport(session, id)`, and only 404s if neither knows the id. UI unchanged.

**`GET /api/strategies/passports/{strategy_id}`** — new endpoint that returns the passport in its native dict shape (`paper_refs[]` + `methodology_summary` etc.). For any caller that wants the passport-native shape without coercion. Registered before the `/{strategy_id}` catch-all.

## Verification

- `ruff format --check` + `ruff check --select E9,F63,F7,F40,F82,F401` clean.
- `pytest backend/tests/test_strategy_endpoints.py` — 17/17 pass.
- `pytest backend/tests/test_passport_loader.py` — 16/16 pass.
- Live verified the breakage on prod: `curl https://archimedes-arc.app/api/strategies/43d08fca16d8ef2b` → `{"detail":"Strategy not found"}` even though that ID is in `/passports` list and `/generated` list.

## Acceptance after deploy

```sh
# pre-fix: returns 404
curl -s https://archimedes-arc.app/api/strategies/43d08fca16d8ef2b
# post-fix: returns full StrategyResponse with paper_refs=[], status="rejected", passes_rigor_gate=false
```

Live: clicking a generated strategy from /library should render the full passport view (with honest "—" for absent fields like paper_arxiv_id when the fusion agent didn't ground its picks).

## Anti-goals

- Not fixing the upstream "fusion agent doesn't ground picks in papers" integrity issue — that's a separate, deeper architectural concern (LLM prompt-engineering + AgentPick.paper_anchor enforcement). Tracked as a follow-up.
- Not renaming "Moderate Agent Blend" → brief-derived names — same root cause as above.
- Not adding `/passports/{id}` field unification with `/strategies/{id}` — keeping them as distinct shape choices (native vs StrategyResponse-coerced).

## Depends on

- PR #295 ([infra] Fix deploy timeout) — without it, this PR's deploy may also report `cancelled`, though the code itself will still land on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)