### PR TITLE
[hotfix] Fix vaults hang + health 404 + reasoning sort/filter (#288 #289 #291)

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -191,6 +191,7 @@ app.include_router(proposals_router)
 
 
 @app.get("/health")
+@app.get("/api/health")
 @limiter.exempt
 async def health():
     """Health check — used by Docker healthcheck and CI/CD.

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -333,6 +333,7 @@ class LocalStrategyProvider:
         self._strategies: dict[str, Strategy] = {}
         self._backtests: dict[str, BacktestResult] = {}
         self._fixtures: dict[str, Any] = {}
+        self._synced_to_unified = False  # one-time sync flag
         self.refresh()
 
     def refresh(self) -> int:
@@ -380,10 +381,12 @@ class LocalStrategyProvider:
         )
 
         # Sync to unified strategy_passports table (Phase 2, Issue #160).
-        # This keeps the Postgres table always in sync with the file-based
-        # strategies + their backtest results. Non-blocking: failures are
-        # logged but don't prevent the provider from serving.
-        self._sync_to_unified_table(loaded)
+        # One-time at startup only — not on every refresh() call.
+        # PR #283's force_update=True on every request caused 8s latency
+        # on /api/vaults/ (Issue #288).
+        if not self._synced_to_unified:
+            self._sync_to_unified_table(loaded)
+            self._synced_to_unified = True
 
         return len(loaded)
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -52,6 +52,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 10s;
     }
 
     # Proxy backend health check

--- a/ui/src/components/Reasoning.jsx
+++ b/ui/src/components/Reasoning.jsx
@@ -51,6 +51,7 @@ function OnChainTraces({ onNavigate, highlightTraceId }) {
   const [loading, setLoading] = useState(true)
   const [verifying, setVerifying] = useState({})
   const [verifyResults, setVerifyResults] = useState({})
+  const [filter, setFilter] = useState('all') // 'all' | 'rebalance' | 'construction' | 'skip'
 
   const loadTraces = useCallback(async () => {
     setLoading(true)
@@ -135,6 +136,20 @@ function OnChainTraces({ onNavigate, highlightTraceId }) {
         to jump to the source strategy and its full passport.
       </p>
 
+      {/* Filter chips */}
+      <div className="flex gap-2 flex-wrap mb-3">
+        {['all', 'rebalance', 'construction', 'skip'].map(f => (
+          <button
+            key={f}
+            className={`tag cursor-pointer ${filter === f ? 'tag-accent' : 'tag-muted'}`}
+            onClick={() => setFilter(f)}
+            style={{ border: 'none', padding: '4px 12px' }}
+          >
+            {f === 'all' ? 'All' : f === 'rebalance' ? '✅ Rebalances' : f === 'construction' ? '🏛️ Constructions' : '⏭ Skips'}
+          </button>
+        ))}
+      </div>
+
       {/* Trace list */}
       {loading ? (
         <div className="caption">Loading traces…</div>
@@ -150,7 +165,15 @@ function OnChainTraces({ onNavigate, highlightTraceId }) {
         </div>
       ) : (
         <div className="flex flex-col gap-2.5">
-          {traces.map((t, i) => {
+          {traces
+          .sort((a, b) => {
+            // Most recent first
+            const ta = a.timestamp ? new Date(typeof a.timestamp === 'number' && a.timestamp > 1e12 ? a.timestamp : a.timestamp * 1000).getTime() : 0
+            const tb = b.timestamp ? new Date(typeof b.timestamp === 'number' && b.timestamp > 1e12 ? b.timestamp : b.timestamp * 1000).getTime() : 0
+            return tb - ta
+          })
+          .filter(t => filter === 'all' || t.decision_type === filter)
+          .map((t, i) => {
             const vResult = verifyResults[t.id]
             return (
               <div key={i} id={`trace-${t.id}`} className="card" style={{ padding: 14 }}>


### PR DESCRIPTION
Three quick fixes batched:
- #288: sync-to-unified runs once at startup, not per-request (8s → <500ms)
- #289: /api/health alias + nginx proxy timeouts
- #291: Reasoning page sort by most-recent + filter chips

848 tests pass. Closes #288, closes #289, closes #291