### PR TITLE
[backend] Kill 'Vault T1' fake data in marketplace listing

### DIFF
--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -52,12 +52,33 @@ class VaultService:
             logging.getLogger(__name__).error(f"Failed to get vault addresses: {e}")
             return VaultListResponse(vaults=[], total=0)
 
+        # Batch-read off-chain metadata so the marketplace shows real names,
+        # symbols, creators, and created_at instead of the "Vault T1"/now()
+        # placeholders that _metrics_to_summary defaults to. One query for all
+        # addresses, not one per vault.
+        metadata_by_address: dict[str, "VaultMetadata"] = {}
+        if vault_addresses:
+            try:
+                from archimedes.db import get_session
+                from archimedes.models.chat import VaultMetadata
+
+                session = get_session()
+                try:
+                    rows = session.query(VaultMetadata).filter(VaultMetadata.vault_address.in_(vault_addresses)).all()
+                    metadata_by_address = {m.vault_address: m for m in rows}
+                finally:
+                    session.close()
+            except Exception as exc:
+                import logging
+
+                logging.getLogger(__name__).warning("vault metadata batch read failed (non-fatal): %s", exc)
+
         summaries: list[VaultSummaryResponse] = []
 
         for addr in vault_addresses:
             try:
                 metrics = await chain_executor.get_vault_metrics(addr)
-                summary = self._metrics_to_summary(metrics)
+                summary = self._metrics_to_summary(metrics, meta=metadata_by_address.get(addr))
                 if tier is not None and summary.tier != tier:
                     continue
                 summaries.append(summary)
@@ -157,14 +178,34 @@ class VaultService:
             logging.getLogger(__name__).exception(f"Failed to get vault detail for {address}")
             return None
 
-    def _metrics_to_summary(self, metrics: dict) -> VaultSummaryResponse:
-        """Convert chain executor metrics to a summary response."""
+    def _metrics_to_summary(self, metrics: dict, meta=None) -> VaultSummaryResponse:
+        """Convert chain executor metrics + (optional) off-chain VaultMetadata
+        into a summary response. ``meta`` is the VaultMetadata row for this
+        vault if one exists; when missing, fields fall back to honest
+        placeholders (short-address slug for name) instead of the misleading
+        "Vault T1" / now() defaults the marketplace used to render."""
+        address = metrics["vault_address"]
+        short_address = f"{address[:6]}…{address[-4:]}" if len(address) > 14 else address
+
+        # Real off-chain metadata if the vault was deployed through the UI;
+        # otherwise honest fallbacks that don't pretend the vault has a name.
+        if meta is not None:
+            name = meta.name or f"Vault {short_address}"
+            symbol = meta.symbol or f"v{address[2:6]}"
+            creator = meta.creator_address or metrics["creator"]
+            created_at = meta.created_at.isoformat() if meta.created_at else ""
+        else:
+            name = f"Vault {short_address}"
+            symbol = f"v{address[2:6]}"
+            creator = metrics["creator"]
+            created_at = ""  # unknown — don't lie about it
+
         return VaultSummaryResponse(
-            address=metrics["vault_address"],
-            name=f"Vault T{metrics['tier']}",
-            symbol=f"v{metrics['vault_address'][:6]}",
+            address=address,
+            name=name,
+            symbol=symbol,
             tier=metrics["tier"],
-            creator=metrics["creator"],
+            creator=creator,
             aum_usdc=metrics["total_aum_usdc"],
             share_price=metrics["share_price_usdc"],
             return_24h=0.0,
@@ -175,7 +216,7 @@ class VaultService:
             performance_fee_pct=metrics["performance_fee_bps"] / 100,
             is_agent_assisted=metrics["is_agent_assisted"],
             depositors=0,
-            created_at=datetime.now(UTC).isoformat(),
+            created_at=created_at,
         )
 
     async def _compute_returns(self, vault_address: str, allocations: list[VaultHolding]) -> dict:

--- a/backend/tests/services/test_vault_service.py
+++ b/backend/tests/services/test_vault_service.py
@@ -52,13 +52,38 @@ class TestMetricsToSummary:
         assert summary.management_fee_pct == 1.5
         assert summary.performance_fee_pct == 20.0
 
-    def test_name_uses_tier_template(self) -> None:
-        summary = VaultService()._metrics_to_summary(_metrics(tier=2))
-        assert summary.name == "Vault T2"
+    def test_name_falls_back_to_short_address_when_no_metadata(self) -> None:
+        """Without VaultMetadata, name shows the address slug — honest fallback
+        instead of the misleading 'Vault T2' shared by every tier-2 vault."""
+        summary = VaultService()._metrics_to_summary(_metrics(address="0xdeadbeef1234567890abcdef", tier=2))
+        assert summary.name == "Vault 0xdead…cdef"
 
-    def test_symbol_is_address_prefix(self) -> None:
+    def test_symbol_falls_back_to_address_prefix(self) -> None:
+        """Symbol fallback uses the 0x-stripped 4-char address slug."""
         summary = VaultService()._metrics_to_summary(_metrics(address="0xdeadbeef1234"))
-        assert summary.symbol == "v0xdead"
+        assert summary.symbol == "vdead"
+
+    def test_metadata_overrides_fallbacks(self) -> None:
+        """When VaultMetadata is provided, real name/symbol/creator/created_at
+        flow through — replacing the address-slug placeholders."""
+        from datetime import UTC, datetime
+
+        meta = SimpleNamespace(
+            name="Momentum Alpha",
+            symbol="vMOM",
+            creator_address="0xb0bb1e",
+            created_at=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        )
+        summary = VaultService()._metrics_to_summary(_metrics(), meta=meta)
+        assert summary.name == "Momentum Alpha"
+        assert summary.symbol == "vMOM"
+        assert summary.creator == "0xb0bb1e"
+        assert summary.created_at == "2026-05-01T12:00:00+00:00"
+
+    def test_created_at_empty_when_no_metadata(self) -> None:
+        """No metadata → no fake `now()` timestamp; surface emptiness honestly."""
+        summary = VaultService()._metrics_to_summary(_metrics())
+        assert summary.created_at == ""
 
     def test_returns_default_to_zero(self) -> None:
         summary = VaultService()._metrics_to_summary(_metrics())


### PR DESCRIPTION
## Summary

`/api/vaults/` returned every vault on the marketplace as identical "Vault T1" with hard-coded zero returns, zero depositors, and a `created_at = datetime.now()` timestamp that lies about when the vault was actually deployed. Discovered today (2026-05-25) while Dan audited the live marketplace and flagged "VAULTS ARE SUPER MESSED UP! There is a ton of fake stuff there!"

Live evidence (pre-fix):

```sh
$ curl -s https://archimedes-arc.app/api/vaults/ | jq -r '.vaults[] | "\(.address[:14])  \(.name)  \(.created_at)"'
0xF3eA08015B2d  Vault T1  2026-05-25T15:32:37.329532+00:00
0x827a2584317c  Vault T1  2026-05-25T15:32:38.614008+00:00
0xA492Fb80F0AF  Vault T1  2026-05-25T15:32:39.897954+00:00
... (all 6 identical name, all created_at = list-call time)
```

`_metrics_to_summary` ignored the `VaultMetadata` table even though `get_vault_detail` reads it correctly. The detail page worked; the listing page lied.

## Changes

**1. Batch-read `VaultMetadata`** in `list_vaults` — single query with `WHERE vault_address IN (...)` against all returned addresses, not N queries.

**2. Plumb `meta` through `_metrics_to_summary`** as an optional argument. When metadata exists for a vault (i.e., it was created through the UI, which posts to `/api/vaults/metadata` after deploy), the real `name`, `symbol`, `creator_address`, and `created_at` flow through.

**3. Honest fallbacks** when no metadata exists (vault deployed outside the UI):
   - `name = "Vault 0xabc1…f9d2"` (address slug, not the misleading shared "Vault T1")
   - `symbol = "v<4-char-slug>"`
   - `creator` = on-chain creator (unchanged)
   - `created_at = ""` — empty string, not a fake `now()` timestamp

Returns and depositors stay at the existing `0.0` / `0` for the listing endpoint — computing real returns per vault requires the Redis price-snapshot path that `get_vault_detail` already does, and pushing it through the listing hot path is a separate change. The detail page renders the rich data.

## Tests

- 22/22 vault service tests pass.
- 2 new tests:
  - `test_metadata_overrides_fallbacks` — verifies real `name`/`symbol`/`creator`/`created_at` flow through when metadata exists.
  - `test_created_at_empty_when_no_metadata` — pins that the fake `now()` is gone.
- 2 existing tests updated:
  - `test_name_falls_back_to_short_address_when_no_metadata` (was `test_name_uses_tier_template`) — asserts honest address-slug fallback.
  - `test_symbol_falls_back_to_address_prefix` (was `test_symbol_is_address_prefix`) — adjusts to new `v<4-char>` slug format.

## Acceptance after deploy

```sh
# Pre-fix: every vault named "Vault T1", created_at = now()
# Post-fix:
curl -s https://archimedes-arc.app/api/vaults/ | jq -r '.vaults[] | "\(.address[:14])  \(.name)  \(.created_at | tostring | .[0:19])"'
# Expected: distinct names (real names if VaultMetadata exists, else "Vault 0xF3eA…d2c4");
# created_at = empty string for the 6 existing vaults (no fake now()), real timestamp for any new UI-created vaults.
```

## Depends on

- PR #295 (deploy timeout fix) — without it, this PR's deploy may also report `cancelled`, though the code itself will still land.

## Anti-goals

- NOT changing the schema (`created_at: str` already permits empty string).
- NOT touching `get_vault_detail` — it already does this correctly.
- NOT computing real returns/depositors in the listing endpoint — separate concern.
- NOT backfilling `VaultMetadata` for the 6 existing fake vaults — those were deployed outside the UI; the right answer is to let users create fresh ones through `CreateVaultModal` (which already posts to both `/create` and `/metadata`).

## Bigger structural concern (separate issue)

Even after this PR, the agent_runner ([agent_runner.py:489-512](backend/archimedes/chain/agent_runner.py#L489)) applies the SAME aggregate strategy consensus to ALL managed vaults — it doesn't read each vault's `VaultMetadata.strategy_ids` to derive per-vault allocations. So "vault executes trades informed by ITS selected strategy" — the user-facing pitch — isn't actually wired end-to-end. Filing as a separate issue if Dan wants it tracked for tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)