### PR TITLE
[frontend+backend] Fusion mode UI on Generate page (#290)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -63,6 +63,7 @@ def _llm_available() -> bool:
 
 def _pick_pipeline(
     brief: GenerateBrief,  # noqa: ARG001 — accepted for forward-compat brief-aware routing; current heuristic uses env/corpus only
+    mode_override: str | None = None,
 ) -> tuple[str, str]:
     """Decide which generation pipeline to use based on runtime conditions.
 
@@ -77,6 +78,10 @@ def _pick_pipeline(
        brief's inferred asset classes.
     3. **agent** (SSE streaming portfolio-advisor path) as the fallback.
     """
+    # ── User-selected mode override (#290) ──
+    if mode_override and mode_override in ("fusion", "architect", "agent"):
+        return mode_override, f"user selected {mode_override} mode"
+
     # ── Fusion check ──
     try:
         from archimedes.agents.strategy_fusion import fusion_enabled, load_corpus
@@ -512,6 +517,7 @@ async def run_generation(
     brief: GenerateBrief,
     n_candidates: int = 1,
     store: JobStore | None = None,
+    mode: str | None = None,
 ) -> None:
     """Run the full streaming generation pipeline for one job.
 
@@ -567,7 +573,7 @@ async def run_generation(
         )
 
         # ── Auto-route to the best pipeline ──
-        pipeline_name, pipeline_reason = _pick_pipeline(brief)
+        pipeline_name, pipeline_reason = _pick_pipeline(brief, mode_override=mode)
         await emit.emit(
             "pipeline_selected",
             pipeline=pipeline_name,

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -66,7 +66,7 @@ async def start_generation(req: GenerateStartRequest, request: Request, response
 
     # Fire-and-forget the pipeline. The route doesn't await it; the SSE stream
     # below tails the event log written by the pipeline as it runs.
-    task = asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates))
+    task = asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates, req.mode))
     _register_task(job_id, task)
 
     return GenerateStartResponse(
@@ -76,9 +76,9 @@ async def start_generation(req: GenerateStartRequest, request: Request, response
     )
 
 
-async def _run_with_cleanup(job_id: str, brief: GenerateBrief, n_candidates: int) -> None:
+async def _run_with_cleanup(job_id: str, brief: GenerateBrief, n_candidates: int, mode: str | None = None) -> None:
     try:
-        await run_generation(job_id=job_id, brief=brief, n_candidates=n_candidates)
+        await run_generation(job_id=job_id, brief=brief, n_candidates=n_candidates, mode=mode)
     except asyncio.CancelledError:
         raise
     except Exception:  # safety net — run_generation already emits error events

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -29,7 +29,7 @@ class GenerateBrief(BaseModel):
 class GenerateStartRequest(BaseModel):
     brief: GenerateBrief
     n_candidates: int = Field(default=1, ge=1, le=5, description="How many candidates to consider internally")
-    mode: str | None = Field(default=None, description="Legacy — ignored. Backend auto-routes via _pick_pipeline().")
+    mode: str | None = Field(default=None, description="Optional pipeline override: 'fusion', 'architect', or 'agent'. When set, bypasses auto-routing.")
 
 
 class GenerateStartResponse(BaseModel):

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -23,8 +23,15 @@ const RISK_PROFILES = [
 ]
 const ASSET_CLASSES = ['equities', 'bonds', 'commodities', 'crypto', 'fx']
 
+const MODES = [
+  { id: 'agent', label: '🤖 Agent', desc: 'LLM portfolio agent with real-time market signals' },
+  { id: 'fusion', label: '🧪 Fusion (novel)', desc: 'Synthesize new strategies from multiple papers' },
+  { id: 'architect', label: '🏗️ Architect', desc: 'Select + weight from curated library' },
+]
+
 export default function Generate({ onNavigate }) {
   // ── Unified form state ──
+  const [mode, setMode] = useState('agent')
   const [intent, setIntent] = useState('')
   const [riskAppetite, setRiskAppetite] = useState('moderate')
   const [selectedAssets, setSelectedAssets] = useState([])
@@ -83,6 +90,7 @@ export default function Generate({ onNavigate }) {
             asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
             max_papers: depth,
           },
+          mode: mode !== 'agent' ? mode : undefined,
         }),
       })
       if (!res.ok) throw new Error(await res.text())
@@ -202,6 +210,24 @@ export default function Generate({ onNavigate }) {
       {/* ── SINGLE UNIFIED FORM ── */}
       {!jobId && !fusionJobId && !fusionResult && (
         <div className="card p-5 mb-4">
+          {/* Mode toggle strip */}
+          <div className="flex gap-2 flex-wrap mb-4">
+            {MODES.map(m => (
+              <button
+                key={m.id}
+                className={`tag cursor-pointer ${mode === m.id ? 'tag-accent' : 'tag-muted'}`}
+                onClick={() => setMode(m.id)}
+                title={m.desc}
+                style={{ border: 'none', padding: '6px 14px', fontSize: '0.85rem' }}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+          <p className="caption mb-3 text-[var(--text-3)]">
+            {MODES.find(m => m.id === mode)?.desc}
+          </p>
+
           <div className="label mb-2">What would you like?</div>
           <textarea
             value={intent}


### PR DESCRIPTION
Adds mode toggle (Agent/Fusion/Architect) to Generate page. User can explicitly select fusion to invoke the novel synthesis engine. Backend respects mode override. 848 tests pass.

Closes #290