### PR TITLE
[frontend] Revert #294: restore 'Knowledge Graph' label (hold for Pi's #293)

### DIFF
--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -13,21 +13,6 @@ async function apiGet(path) {
 
 const TABS = ['catalog', 'overview', 'graph', 'knowledge-graph']
 
-// Friendly tab labels. The "knowledge-graph" slug stays for routing /
-// state stability, but the displayed label is "Topic Clusters" because
-// — until REBEL + SciSpacy actually run on the corpus (Issue #293) —
-// the only triples in the KG tables are BERTopic cluster memberships
-// (one predicate, `belongs_to_cluster`). Calling that a Knowledge
-// Graph would be misleading. BERTopic clusters across 1014 papers are
-// real and valuable; this is the honest framing of what they are.
-// When #293 lands with multi-predicate REBEL output, revert this map.
-const TAB_LABELS = {
-  catalog: 'Catalog',
-  overview: 'Overview',
-  graph: 'Graph',
-  'knowledge-graph': 'Topic Clusters',
-}
-
 export default function CorpusExplorer() {
   const [tab, setTab] = useState('catalog')
   const [overview, setOverview] = useState(null)
@@ -93,7 +78,7 @@ export default function CorpusExplorer() {
       <div className="corpus-tabs">
         {TABS.map(t => (
           <button key={t} className={`corpus-tab${tab === t ? ' active' : ''}`} onClick={() => setTab(t)}>
-            {TAB_LABELS[t] ?? t.replace('-', ' ').replace(/\b\w/g, c => c.toUpperCase())}
+            {t.replace('-', ' ').replace(/\b\w/g, c => c.toUpperCase())}
           </button>
         ))}
       </div>

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -20,9 +20,7 @@ const TYPE_ICONS = {
 }
 
 /**
- * Topic Clusters viewer. (Currently renders BERTopic-derived topic clusters
- * across the KB-processed paper subset. Promoted to a real Knowledge Graph
- * once REBEL + SciSpacy land — Issue #293.)
+ * Knowledge Graph viewer.
  *
  * Fetches from ``/api/corpus/kg/entities?q=<q>`` and renders entities
  * + relations as an SVG graph. Entity search filters the KG. Falls back
@@ -46,7 +44,7 @@ export default function CorpusKG({ onOpenPaper }) {
       if (!res.ok) throw new Error(res.statusText)
       setData(await res.json())
     } catch (e) {
-      setError(e.message || 'Failed to load topic clusters')
+      setError(e.message || 'Failed to load knowledge graph')
     } finally {
       setLoading(false)
     }
@@ -103,7 +101,7 @@ export default function CorpusKG({ onOpenPaper }) {
         </form>
         <div className="info-box warning">
           {error.includes('503') || error.includes('KB pipeline')
-            ? 'KB pipeline still running — first artifact pending. The topic clusters will populate once the KG is built.'
+            ? 'KB pipeline still running — first artifact pending. The knowledge graph will populate once the KG is built.'
             : `Knowledge graph unavailable: ${error}`}
         </div>
       </div>
@@ -157,7 +155,7 @@ export default function CorpusKG({ onOpenPaper }) {
       </div>
 
       {loading ? (
-        <div style={{ padding: 40, textAlign: 'center' }} className="caption">Loading topic clusters…</div>
+        <div style={{ padding: 40, textAlign: 'center' }} className="caption">Loading knowledge graph…</div>
       ) : entities.length === 0 ? (
         <div style={{ padding: 40, textAlign: 'center' }} className="caption">No entities found.</div>
       ) : (


### PR DESCRIPTION
## Summary

DRAFT — DO NOT MERGE until Pi ships [Issue #293](https://github.com/a-apin/archimedes/issues/293) (real REBEL + SciSpacy KG triples).

PR #294 (the "Topic Clusters" relabel) was the explicit fallback for #293 missing the deadline. It got merged at 16:03:07Z, 2 seconds after PR #295 (deploy fix) — accidental dual-merge. Today, with the KG endpoint still returning fake single-predicate `belongs_to_cluster` data, the "Topic Clusters" framing is honest and there's no fire. But the moment #293 lands and the backend returns real multi-predicate triples, the UI would under-sell the real KG as "topic clusters."

This PR is the pre-staged restoration. We merge it the instant we've eyeballed #293's output and confirmed the backend returns multi-predicate triples.

## Changes

Pure revert of [fd49addc](https://github.com/a-apin/archimedes/commit/fd49addc056f84144aa232c908309caf8581e8bb):
- `ui/src/components/CorpusExplorer.jsx` — restore "Knowledge Graph" tab label
- `ui/src/components/CorpusKG.jsx` — restore user-facing copy

## Merge gate (hard requirement)

Before un-drafting and merging this, verify:

```sh
# Backend returns multi-predicate KG triples (not just belongs_to_cluster)
curl -s 'https://archimedes-arc.app/api/corpus/kg/paper/<arxiv_id>' | jq '.relations | map(.predicate) | unique | length'
# Expected: ≥ 2 (multiple distinct predicates from REBEL)
```

If that returns 1 (or only `belongs_to_cluster`), Pi has not yet shipped #293 — do not merge.

## Anti-goals

- Do not touch backend / KG endpoint logic.
- Do not delete or re-rename anything beyond reversing #294's UI label changes.
- Do not undraft this PR until the merge-gate check above passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)