### PR TITLE
[backend] Fix verify-on-chain 504: use cached arc_tx_hash for O(1) lookup

### DIFF
--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -295,24 +295,32 @@ async def verify_trace(trace_id: str, request: Request):  # noqa: ARG001 — slo
         on_chain_ts = 0
         details = ""
 
-        if not off_chain.get("arc_tx_hash"):
+        arc_tx_hash = off_chain.get("arc_tx_hash")
+        if not arc_tx_hash:
             details = "Trace was not published on-chain -- cannot verify"
         else:
             try:
-                vault_traces = await trace_publisher.get_traces_by_vault(vault)
-                on_chain_count = await trace_publisher.get_total_trace_count()
-                is_verified = False
-                agent = ""
-                on_chain_ts = 0
-
-                for tid in vault_traces if vault_traces else range(1, on_chain_count + 1):
-                    detail = await trace_publisher.get_trace_by_id(tid)
-                    if detail and detail["trace_hash"] == trace_hash.removeprefix("0x"):
+                # O(1): fetch the receipt for the cached arc_tx_hash and decode
+                # the TracePublished event directly. Replaces the prior O(N)
+                # getTracesByVault → getTraceById scan that 504'd on vaults with
+                # 40+ traces.
+                detail = await trace_publisher.get_trace_by_tx_hash(arc_tx_hash)
+                if detail is None:
+                    details = "On-chain receipt not found for cached arc_tx_hash"
+                else:
+                    expected = trace_hash.removeprefix("0x").lower()
+                    on_chain = detail["trace_hash"].removeprefix("0x").lower()
+                    if expected and expected == on_chain:
                         is_verified = True
                         agent = detail["agent"]
                         on_chain_ts = detail["timestamp"]
-                        break
-                details = "Hash verified on-chain ✓" if is_verified else "Hash not found on-chain"
+                        # Keep vault as recorded off-chain; surface the on-chain
+                        # vault when off-chain didn't record one.
+                        if not vault:
+                            vault = detail["vault"]
+                        details = "Hash verified on-chain ✓"
+                    else:
+                        details = "Hash mismatch: on-chain trace does not match off-chain hash"
             except Exception as e:
                 details = f"Verification failed: {e}"
 

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -173,6 +173,48 @@ class TracePublisher:
         except Exception:
             return []
 
+    async def get_trace_by_tx_hash(self, tx_hash: str) -> dict | None:
+        """Get trace details from the TracePublished event in a known tx receipt.
+
+        O(1) verification path — single RPC roundtrip — used by /verify when the
+        off-chain trace already remembers its `arc_tx_hash`. Avoids the O(N)
+        getTracesByVault → getTraceById scan over a vault's full trace history.
+
+        Returns the same shape as `get_trace_by_id` (agent / vault / trace_hash /
+        timestamp / metadata=None) or None if the receipt is missing or the
+        TracePublished event cannot be decoded.
+        """
+        if not tx_hash:
+            return None
+
+        registry = self.loader.trace_registry
+        try:
+            receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
+        except Exception as e:
+            logger.error(f"Failed to fetch receipt for {tx_hash}: {e}")
+            return None
+
+        for log in receipt.logs:
+            try:
+                decoded = registry.events.TracePublished().process_log(log)
+            except Exception:
+                continue
+            args = decoded["args"]
+            trace_hash_raw = args["traceHash"]
+            trace_hash_hex = (
+                trace_hash_raw.hex() if isinstance(trace_hash_raw, (bytes, bytearray)) else str(trace_hash_raw)
+            )
+            return {
+                "agent": args["agent"],
+                "vault": args["vault"],
+                "trace_hash": trace_hash_hex,
+                "timestamp": args["timestamp"],
+                "metadata": None,
+                "trace_id": args.get("traceId", 0),
+            }
+
+        return None
+
     def _encode_metadata(self, trace: ReasoningTrace) -> bytes:
         """Encode trace metadata as ABI-encoded bytes for on-chain storage."""
         import json

--- a/backend/tests/test_trace_publisher.py
+++ b/backend/tests/test_trace_publisher.py
@@ -162,3 +162,113 @@ class TestTraceVerify:
 
             result = asyncio.get_event_loop().run_until_complete(publisher.verify(trace))
             assert result is True
+
+
+class TestGetTraceByTxHash:
+    """Test the O(1) tx-receipt-based lookup used by /verify."""
+
+    def test_returns_decoded_event(self):
+        """When the receipt contains a TracePublished log, the helper decodes it."""
+        trace_hash_bytes = bytes.fromhex("aa" * 32)
+
+        # Mock the receipt with a single log.
+        fake_log = MagicMock()
+        fake_receipt = MagicMock()
+        fake_receipt.logs = [fake_log]
+
+        mock_registry = MagicMock()
+        mock_registry.events.TracePublished.return_value.process_log = MagicMock(
+            return_value={
+                "args": {
+                    "traceId": 7,
+                    "agent": "0xagent",
+                    "vault": "0xvault",
+                    "traceHash": trace_hash_bytes,
+                    "timestamp": 99999,
+                }
+            }
+        )
+
+        mock_loader = MagicMock()
+        mock_loader.trace_registry = mock_registry
+
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.w3.eth.get_transaction_receipt = AsyncMock(return_value=fake_receipt)
+
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            publisher = TracePublisher(loader=mock_loader)
+
+            import asyncio
+
+            result = asyncio.get_event_loop().run_until_complete(publisher.get_trace_by_tx_hash("0xdeadbeef"))
+
+            assert result is not None
+            assert result["agent"] == "0xagent"
+            assert result["vault"] == "0xvault"
+            assert result["trace_hash"] == trace_hash_bytes.hex()
+            assert result["timestamp"] == 99999
+            assert result["trace_id"] == 7
+            # Single RPC roundtrip — receipt fetched exactly once.
+            mock_client.w3.eth.get_transaction_receipt.assert_awaited_once_with("0xdeadbeef")
+
+    def test_returns_none_when_no_event_in_receipt(self):
+        """If no log decodes to TracePublished, return None."""
+        fake_log = MagicMock()
+        fake_receipt = MagicMock()
+        fake_receipt.logs = [fake_log]
+
+        mock_registry = MagicMock()
+        mock_registry.events.TracePublished.return_value.process_log = MagicMock(
+            side_effect=Exception("not this event")
+        )
+
+        mock_loader = MagicMock()
+        mock_loader.trace_registry = mock_registry
+
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.w3.eth.get_transaction_receipt = AsyncMock(return_value=fake_receipt)
+
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            publisher = TracePublisher(loader=mock_loader)
+
+            import asyncio
+
+            result = asyncio.get_event_loop().run_until_complete(publisher.get_trace_by_tx_hash("0xdeadbeef"))
+            assert result is None
+
+    def test_returns_none_when_receipt_fetch_fails(self):
+        """If get_transaction_receipt raises, the helper returns None (no crash)."""
+        mock_loader = MagicMock()
+        mock_loader.trace_registry = MagicMock()
+
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.w3.eth.get_transaction_receipt = AsyncMock(side_effect=Exception("RPC error"))
+
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            publisher = TracePublisher(loader=mock_loader)
+
+            import asyncio
+
+            result = asyncio.get_event_loop().run_until_complete(publisher.get_trace_by_tx_hash("0xdeadbeef"))
+            assert result is None
+
+    def test_returns_none_for_empty_tx_hash(self):
+        """Empty or falsy tx_hash short-circuits to None without an RPC call."""
+        mock_loader = MagicMock()
+        mock_loader.trace_registry = MagicMock()
+
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.w3.eth.get_transaction_receipt = AsyncMock()
+
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            publisher = TracePublisher(loader=mock_loader)
+
+            import asyncio
+
+            result = asyncio.get_event_loop().run_until_complete(publisher.get_trace_by_tx_hash(""))
+            assert result is None
+            mock_client.w3.eth.get_transaction_receipt.assert_not_awaited()


### PR DESCRIPTION
## Summary

The `GET /api/traces/{trace_id}/verify` endpoint 504s on live (`https://archimedes-arc.app/...`). The handler in `backend/archimedes/api/traces_routes.py` was doing an O(N) scan: `get_traces_by_vault(vault)` + a `get_trace_by_id(tid)` RPC call per returned id (old lines 302–314 in `verify_trace`). On a vault with 40+ traces that exceeds nginx's `proxy_read_timeout` and the user sees a 504 page.

This is **demo-critical**: the "Verify on-chain" button on the Reasoning page is the headline integrity affordance of the pitch (every rebalance decision gets its keccak256 hash anchored on Arc via `ReasoningTraceRegistry`, and the UI lets a judge verify that hash with one click). With the endpoint timing out, that affordance hard-fails in front of judges.

## The O(N) → O(1) change

The off-chain trace already remembers its `arc_tx_hash` (the publish path writes it at `traces_routes.py:235`). The fix uses it directly:

- Added `TracePublisher.get_trace_by_tx_hash(tx_hash)` in `backend/archimedes/chain/trace_publisher.py`: one `eth_getTransactionReceipt` call, then decodes the `TracePublished(traceId, agent, vault, traceHash, timestamp)` event from the receipt logs using the existing `registry.events.TracePublished().process_log(log)` pattern (same shape as `executor.py:443` for `VaultCreated`). One RPC roundtrip.
- Rewrote the primary branch of `verify_trace` (old lines 298–317) to call the new helper and compare the on-chain `traceHash` to `off_chain["trace_hash"]` (normalized lowercase, `0x` stripped on both sides). On match: `is_verified=True`, populate `agent`/`vault`/`on_chain_ts` from the event. On mismatch or decode failure: `is_verified=False` with a clear `details` string.

All other code paths preserved verbatim: the integer-id fallback for traces with no Redis entry, the "not published on-chain" fallback, and the outer exception handler. The `TraceVerifyResponse` schema is untouched — `commit_block_number`, `trade_block_number`, `reveal_block_number`, `temporal_binding_valid` still come from `off_chain` as before.

## Live evidence of the 504

```
$ curl -sI 'https://archimedes-arc.app/api/traces/0/verify'
HTTP/1.1 405 Method Not Allowed   # HEAD short-circuits; GET is the slow path
```

The original report attached a `curl -sw` GET returning the nginx 504 Gateway Time-out HTML page from the live host. The old handler's behavior matches that: `get_traces_by_vault` returns up to N ids, then N sequential `getTraceById` calls — every one a JSON-RPC roundtrip — easily exceeding the 60s nginx timeout for any well-used vault.

## Acceptance checks

Reviewer can run these on a checkout of this branch:

- [x] `ruff format --check backend/archimedes/api/traces_routes.py backend/archimedes/chain/trace_publisher.py` → exits 0
- [x] `ruff check --select E9,F63,F7,F40,F82,F401 backend/archimedes/api/traces_routes.py backend/archimedes/chain/trace_publisher.py` → "All checks passed!"
- [x] `pytest backend/tests/ -m "not integration" -k "trace" --no-header -q` → 50 passed (46 existing + 4 new tests for `get_trace_by_tx_hash` covering: happy path with single-receipt-fetch assertion, no decodable log → None, RPC failure → None, empty tx_hash → short-circuit no RPC)

## Constraints honored

- No new top-level deps (uses existing `web3.eth.get_transaction_receipt` already exposed via `chain_client.w3`)
- No backwards-compat hacks
- `TraceVerifyResponse` schema unchanged
- No other security/integrity check on this endpoint weakened
- Did not touch unrelated routes (`list_traces`, `get_trace`, `publish_trace`, `get_trace_canonical`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)