### PR TITLE
[frontend] Explore rebuild: cards + modal + price-history chart + better text

### DIFF
--- a/backend/archimedes/api/explore_routes.py
+++ b/backend/archimedes/api/explore_routes.py
@@ -9,7 +9,9 @@ in routes.py).
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
 
 from archimedes.api.explore_schemas import ExploreAssetsResponse, ExploreHistoryResponse
 from archimedes.services.asset_market_service import asset_market_service
@@ -24,12 +26,20 @@ async def list_explore_assets() -> ExploreAssetsResponse:
 
 
 @explore_router.get("/assets/{symbol}/history", response_model=ExploreHistoryResponse)
-async def get_explore_history(symbol: str) -> ExploreHistoryResponse:
-    """Daily price history for one asset, used by sparklines + detail charts."""
-    resp = await asset_market_service.get_history(symbol)
+async def get_explore_history(
+    symbol: str,
+    range: Literal["1D", "1W", "1M", "1Y"] = Query("1M", description="History lookback range"),
+) -> ExploreHistoryResponse:
+    """Price history for one asset, used by detail-chart range toggles.
+
+    The ``range`` query controls both the lookback period and the bar interval.
+    The endpoint returns ``[]`` and ``404`` when no series is available for the
+    requested range — the frontend renders an explicit empty state in that case.
+    """
+    resp = await asset_market_service.get_history(symbol, range_=range)
     if not resp.points:
         raise HTTPException(
             status_code=404,
-            detail=f"No price history available for {symbol}. Check the symbol spelling.",
+            detail=f"No price history available for {symbol} ({range}). The upstream feed returned no data.",
         )
     return resp

--- a/backend/archimedes/api/explore_schemas.py
+++ b/backend/archimedes/api/explore_schemas.py
@@ -20,12 +20,23 @@ class AssetExploreItem(BaseModel):
     change_24h_pct: float | None
     change_7d_pct: float | None
     change_30d_pct: float | None
+    high_24h: float | None = Field(default=None, description="High over the last available bar; null if not available")
+    low_24h: float | None = Field(default=None, description="Low over the last available bar; null if not available")
     realized_vol_30d: float | None = Field(
         default=None, description="Annualized standard deviation of daily returns over last 30 trading days"
     )
     oracle_address: str | None = None
-    last_updated: str | None = Field(default=None, description="ISO8601 timestamp of last oracle price")
-    is_stale: bool = Field(default=False, description="True iff oracle hasn't updated in the past staleness window")
+    last_updated: str | None = Field(default=None, description="ISO8601 timestamp of last price update")
+    price_source: Literal["oracle", "yfinance", "none"] = Field(
+        default="none",
+        description="Where the displayed current_price came from: 'oracle' = on-chain PriceOracle, "
+        "'yfinance' = upstream market data fallback, 'none' = no data",
+    )
+    is_stale: bool = Field(
+        default=False,
+        description="True iff the displayed price is itself unusably old. A missing on-chain oracle "
+        "is NOT stale on its own — only the source actually being shown can be stale.",
+    )
     explanations: dict[str, str] = Field(
         default_factory=dict,
         description="Per-metric plain-English copy keyed by field name",
@@ -43,7 +54,11 @@ class ExploreHistoryPoint(BaseModel):
     price: float
 
 
+HistoryRange = Literal["1D", "1W", "1M", "1Y"]
+
+
 class ExploreHistoryResponse(BaseModel):
     symbol: str
-    interval: Literal["1d"] = "1d"
+    range: HistoryRange = "1M"
+    interval: Literal["1m", "5m", "1h", "1d"] = "1d"
     points: list[ExploreHistoryPoint]

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -6,6 +6,16 @@ fallback when the oracle is stale or unavailable.  30-second TTL cache
 (per the Phase 3a spec — page must load <1s without synchronous on-chain
 reads on cache hit). The plain-English explanations live in this module so
 the route handler stays a thin facade.
+
+Staleness semantics (rebuilt 2026-05-25 — see Explore page rebuild):
+The on-chain ``PriceOracle`` is only actively pushed for a small subset of
+synths (those in ``OracleUpdater.YFINANCE_MAP`` / ``CRYPTO_MAP`` — currently
+~9 symbols). The rest of the ``DEFAULT_SCAN_UNIVERSE`` (~70 names) has an
+oracle slot allocated but no one calls ``setPrice()`` for it. Flagging those
+assets as "STALE" when in fact the displayed price comes from yfinance is
+misleading — the *displayed* price isn't stale; an unused oracle slot is. So
+``is_stale`` now reflects the actual displayed price source, not the oracle
+slot. ``price_source`` discloses where the displayed price came from.
 """
 
 from __future__ import annotations
@@ -15,7 +25,7 @@ import logging
 import math
 import time
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 from archimedes.api.explore_schemas import (
     AssetExploreItem,
@@ -30,7 +40,17 @@ logger = logging.getLogger(__name__)
 _CACHE_TTL_SECONDS = 30
 _HISTORY_LOOKBACK = "3mo"  # enough for 30d realized vol + change windows
 _STALE_WINDOW_SECONDS = 5 * 60  # >5 min since oracle push → "stale" (per issue #168)
+_YF_STALE_WINDOW_SECONDS = 4 * 24 * 60 * 60  # yfinance daily-close → stale if >4 days old
 _ORACLE_READ_TIMEOUT = 5  # seconds per individual chain read
+
+# Range param → (yfinance period, yfinance interval). Daily intervals work
+# for week / month / year ranges; the 1D button uses 5-minute intraday data.
+_HISTORY_RANGE_MAP: dict[str, tuple[str, str]] = {
+    "1D": ("2d", "5m"),
+    "1W": ("1mo", "1d"),
+    "1M": ("3mo", "1d"),
+    "1Y": ("1y", "1d"),
+}
 
 
 # ── Plain-English explanations ────────────────────────────────────────────
@@ -96,6 +116,67 @@ def _realized_vol_annual(prices: list[float], window: int = 30) -> float | None:
     return math.sqrt(var) * math.sqrt(252)
 
 
+# ── Direct yfinance fetch (used by /assets/{symbol}/history) ─────────────
+
+
+def _fetch_yfinance_series(symbol: str, period: str, interval: str) -> list[ExploreHistoryPoint]:
+    """Fetch a single-asset time series at the requested period+interval.
+
+    Returns an empty list when the symbol is unknown, yfinance is unavailable,
+    or the upstream feed returned no data. The caller (route handler) turns
+    an empty list into a 404 so the frontend can render an honest empty state
+    instead of a faked flat line.
+    """
+    try:
+        from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
+
+        entry = GLOBAL_ASSETS.get(symbol)
+        if not entry:
+            return []
+        yf_ticker = entry[0]
+    except Exception as exc:
+        logger.warning("explore: history symbol resolve for %s failed: %s", symbol, exc)
+        return []
+
+    try:
+        import yfinance as yf
+
+        data = yf.download(
+            yf_ticker,
+            period=period,
+            interval=interval,
+            progress=False,
+            auto_adjust=True,
+            threads=False,
+        )
+    except Exception as exc:
+        logger.warning("explore: yfinance history fetch failed for %s (%s/%s): %s", symbol, period, interval, exc)
+        return []
+
+    if data is None or len(data) == 0:
+        return []
+
+    try:
+        close = data["Close"]
+        # When yfinance is called with a single ticker it sometimes still returns
+        # a DataFrame (one column). Squeeze to a Series for uniform handling.
+        if hasattr(close, "columns"):
+            close = close.iloc[:, 0]
+        close = close.dropna()
+    except Exception as exc:
+        logger.warning("explore: yfinance close extract failed for %s: %s", symbol, exc)
+        return []
+
+    points: list[ExploreHistoryPoint] = []
+    for ts, price in close.items():
+        try:
+            # pandas Timestamps render as ISO when stringified.
+            points.append(ExploreHistoryPoint(ts=str(ts), price=float(price)))
+        except Exception:
+            continue
+    return points
+
+
 # ── Service ───────────────────────────────────────────────────────────────
 
 
@@ -105,7 +186,9 @@ class AssetMarketService:
     def __init__(self) -> None:
         self._cache: ExploreAssetsResponse | None = None
         self._cache_ts: float = 0.0
-        self._cache_history: dict[str, ExploreHistoryResponse] = {}
+        # Keyed by (symbol, range) — different ranges have different lookbacks.
+        self._cache_history: dict[tuple[str, str], tuple[float, ExploreHistoryResponse]] = {}
+        self._history_cache_ttl = 60.0  # seconds
 
     # ── On-chain oracle reads ────────────────────────────────────────────
 
@@ -228,30 +311,73 @@ class AssetMarketService:
             else:
                 hist_prices = []
 
-            # Current price: oracle primary, yfinance fallback
-            current_price: float | None = oracle.get("price")
-            if current_price is None and hist_prices:
-                current_price = hist_prices[-1]
-
-            # Staleness + last_updated from oracle
-            oracle_stale = oracle.get("stale", True)
+            # Pick the displayed price source. Oracle wins iff its last push
+            # is within the oracle freshness window. Otherwise fall back to
+            # the most recent yfinance daily close. Track which one we used
+            # so the UI can label it ("Source: on-chain oracle" vs. yfinance).
+            oracle_price = oracle.get("price")
             oracle_updated_at = oracle.get("updated_at")
-            if oracle_updated_at:
+            oracle_fresh = (
+                oracle_price is not None
+                and oracle_updated_at
+                and oracle_updated_at > 0
+                and (now - oracle_updated_at) <= _STALE_WINDOW_SECONDS
+            )
+
+            current_price: float | None
+            price_source: Literal["oracle", "yfinance", "none"]
+            last_updated: str | None
+            displayed_is_stale: bool
+
+            if oracle_fresh:
+                current_price = oracle_price
+                price_source = "oracle"
                 last_updated = datetime.fromtimestamp(oracle_updated_at, tz=UTC).isoformat()
-            elif raw_hist is not None and hasattr(raw_hist, "index") and len(raw_hist) > 0:
-                last_updated = str(raw_hist.index[-1])
+                displayed_is_stale = False
+            elif hist_prices:
+                current_price = hist_prices[-1]
+                price_source = "yfinance"
+                if raw_hist is not None and hasattr(raw_hist, "index") and len(raw_hist) > 0:
+                    last_bar = raw_hist.index[-1]
+                    last_updated = str(last_bar)
+                    try:
+                        # pandas Timestamp supports .timestamp(); fall back to
+                        # parse if last_bar is already a str.
+                        bar_ts = float(last_bar.timestamp()) if hasattr(last_bar, "timestamp") else 0.0
+                    except Exception:
+                        bar_ts = 0.0
+                    # yfinance daily close: stale if last bar is more than a few
+                    # trading days old (weekends + bank holidays count as
+                    # legitimate gaps, but more than ~4 days means the feed is
+                    # broken for this name).
+                    displayed_is_stale = bool(bar_ts > 0 and (now - bar_ts) > _YF_STALE_WINDOW_SECONDS)
+                else:
+                    last_updated = nowstamp
+                    displayed_is_stale = False
             else:
-                last_updated = nowstamp
+                # No source at all — honestly stale + null price.
+                current_price = None
+                price_source = "none"
+                last_updated = None
+                displayed_is_stale = True
 
-            # If no oracle data at all, mark stale
-            is_stale = oracle_stale if oracle else True
+            # 24h high / low — only computable for intraday data, which we
+            # don't fetch in the listing endpoint. The detail-modal endpoint
+            # (get_history with range="1D") returns intraday bars and the UI
+            # can compute these client-side from that series. Leave them
+            # ``None`` here so the card / modal show "—" honestly.
+            high_24h = None
+            low_24h = None
 
-            # Change/vol from yfinance history
+            # Change / vol from yfinance daily history (independent of where
+            # the spot came from — both source paths benefit from these).
             stat_dict: dict[str, Any] = {
                 "current_price": current_price,
                 "change_24h_pct": _pct_change(hist_prices, 1) if hist_prices else None,
                 "change_7d_pct": _pct_change(hist_prices, 5) if hist_prices else None,
                 "change_30d_pct": _pct_change(hist_prices, 21) if hist_prices else None,
+                "high_24h": high_24h,
+                "low_24h": low_24h,
                 "realized_vol_30d": _realized_vol_annual(hist_prices, 30) if hist_prices else None,
             }
 
@@ -266,7 +392,8 @@ class AssetMarketService:
                     asset_class=asset_class,
                     oracle_address=oracle.get("oracle_address"),
                     last_updated=last_updated,
-                    is_stale=is_stale,
+                    is_stale=displayed_is_stale,
+                    price_source=price_source,
                     explanations=_explanations_for(stat_dict),
                     **stat_dict,
                 )
@@ -288,26 +415,30 @@ class AssetMarketService:
         self._cache_ts = now
         return self._cache
 
-    async def get_history(self, symbol: str) -> ExploreHistoryResponse:
-        if symbol in self._cache_history:
-            return self._cache_history[symbol]
-        histories: dict[str, Any] = {}
-        try:
-            from archimedes.services.strategy_signal_evaluator import (
-                _fetch_price_histories,
-            )
+    async def get_history(self, symbol: str, range_: str = "1M") -> ExploreHistoryResponse:
+        """Return time-series points for ``symbol`` over ``range_``.
 
-            histories = await asyncio.to_thread(_fetch_price_histories, [symbol], _HISTORY_LOOKBACK)
-        except Exception as exc:
-            logger.warning("explore: history for %s failed: %s", symbol, exc)
-        hist = histories.get(symbol) or {}
-        prices = hist.get("close") or []
-        dates = hist.get("dates") or []
-        points = [
-            ExploreHistoryPoint(ts=str(dates[i]) if i < len(dates) else "", price=prices[i]) for i in range(len(prices))
-        ]
-        resp = ExploreHistoryResponse(symbol=symbol, points=points)
-        self._cache_history[symbol] = resp
+        Ranges: 1D (intraday 5m bars), 1W / 1M / 1Y (daily close).
+        """
+        if range_ not in _HISTORY_RANGE_MAP:
+            range_ = "1M"
+
+        cache_key = (symbol, range_)
+        now = time.time()
+        cached = self._cache_history.get(cache_key)
+        if cached is not None and (now - cached[0]) < self._history_cache_ttl:
+            return cached[1]
+
+        period, interval = _HISTORY_RANGE_MAP[range_]
+        points = await asyncio.to_thread(_fetch_yfinance_series, symbol, period, interval)
+
+        resp = ExploreHistoryResponse(
+            symbol=symbol,
+            range=range_,  # type: ignore[arg-type]
+            interval=interval,  # type: ignore[arg-type]
+            points=points,
+        )
+        self._cache_history[cache_key] = (now, resp)
         return resp
 
 

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -180,13 +180,23 @@ class TestListAssets:
         assert spy.is_stale is False
 
     @pytest.mark.asyncio
-    async def test_no_oracle_marks_stale(self):
-        """When oracle data is completely missing, asset is marked stale."""
+    async def test_no_oracle_falls_back_to_yfinance_not_stale(self):
+        """When the on-chain oracle has no price, the service should fall back
+        to yfinance and surface ``price_source="yfinance"``. The displayed
+        price isn't stale just because the unused oracle slot has no value —
+        ``is_stale`` reflects the *displayed* price's freshness, not the oracle
+        slot. (Semantics changed during the 2026-05-25 Explore-page rebuild —
+        see ``asset_market_service.py`` module docstring for full rationale.)"""
         service = AssetMarketService()
+        # Use the current UTC date as the latest bar so the staleness check
+        # (yfinance window of 4 days) doesn't drift the test as time passes.
+        from datetime import UTC, datetime, timedelta
+
+        today = datetime.now(UTC).date()
         mock_histories = {
             "sSPY": {
                 "close": [540.0, 545.0],
-                "dates": ["2026-05-22", "2026-05-23"],
+                "dates": [(today - timedelta(days=1)).isoformat(), today.isoformat()],
             }
         }
 
@@ -203,8 +213,9 @@ class TestListAssets:
 
         spy = next((a for a in resp.assets if a.symbol == "sSPY"), None)
         assert spy is not None
-        assert spy.is_stale is True
         assert spy.current_price == pytest.approx(545.0)  # yfinance fallback
+        assert spy.price_source == "yfinance"
+        assert spy.is_stale is False  # displayed price is fresh; only the unused oracle slot is empty
 
     @pytest.mark.asyncio
     async def test_cache_ttl(self):

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -189,7 +189,7 @@ export default function App() {
   const renderPage = () => {
     switch (page) {
       case 'landing':     return <Landing onNavigate={navigateToPage} />
-      case 'explore':      return <Explore onNavigate={navigateToPage} />
+      case 'explore':      return <Explore />
       case 'generate':     return <Generate onNavigate={navigateToPage} />
       case 'library':      return (
         <WalletGate

--- a/ui/src/components/AssetModal.jsx
+++ b/ui/src/components/AssetModal.jsx
@@ -1,0 +1,388 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+const RANGES = ['1D', '1W', '1M', '1Y']
+
+function fmtPrice(v) {
+  if (v == null || Number.isNaN(v)) return '—'
+  if (v >= 1000) return `$${v.toFixed(0)}`
+  if (v >= 10) return `$${v.toFixed(2)}`
+  return `$${v.toFixed(4)}`
+}
+
+function fmtPct(v) {
+  if (v == null || Number.isNaN(v)) return '—'
+  const sign = v >= 0 ? '+' : ''
+  return `${sign}${v.toFixed(2)}%`
+}
+
+function changeClass(v) {
+  if (v == null || Number.isNaN(v)) return ''
+  return v >= 0 ? 'positive' : 'negative'
+}
+
+function sourceLabel(price_source) {
+  if (price_source === 'oracle') return 'On-chain PriceOracle (Arc)'
+  if (price_source === 'yfinance') return 'yfinance (off-chain fallback)'
+  return 'No source available'
+}
+
+/**
+ * PriceHistoryChart — SVG line chart of one symbol's price series.
+ *
+ * Honest fallback: when `points` is empty (range unsupported or upstream
+ * feed returned nothing) we render an explicit empty state. We never
+ * synthesize a flat line.
+ */
+function PriceHistoryChart({ points, loading, error }) {
+  const SVG_W = 720
+  const SVG_H = 260
+  const PAD_L = 56
+  const PAD_R = 18
+  const PAD_T = 16
+  const PAD_B = 36
+
+  if (loading) {
+    return (
+      <div style={{ height: SVG_H, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div className="caption" style={{ color: 'var(--text-4)' }}>Loading price history…</div>
+      </div>
+    )
+  }
+  if (error || !points || points.length === 0) {
+    return (
+      <div
+        style={{
+          height: SVG_H,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'rgba(255,255,255,0.02)',
+          border: '1px dashed var(--glass-border)',
+          borderRadius: 6,
+        }}
+      >
+        <div className="caption" style={{ color: 'var(--text-4)', textAlign: 'center', maxWidth: 380 }}>
+          Historical chart unavailable on this asset for the selected range.
+          {error ? <><br /><span style={{ fontSize: '0.7rem', opacity: 0.7 }}>{error}</span></> : null}
+        </div>
+      </div>
+    )
+  }
+
+  const prices = points.map(p => p.price)
+  const minP = Math.min(...prices)
+  const maxP = Math.max(...prices)
+  const range = maxP - minP || Math.max(1e-6, Math.abs(maxP) * 0.01)
+  // Light vertical padding so the line never touches the top/bottom border.
+  const yPad = range * 0.08
+
+  const toX = i => PAD_L + (i / Math.max(1, points.length - 1)) * (SVG_W - PAD_L - PAD_R)
+  const toY = p => SVG_H - PAD_B - ((p - minP + yPad) / (range + 2 * yPad)) * (SVG_H - PAD_T - PAD_B)
+
+  const linePath = points
+    .map((pt, i) => `${i === 0 ? 'M' : 'L'} ${toX(i).toFixed(1)} ${toY(pt.price).toFixed(1)}`)
+    .join(' ')
+  const areaPath =
+    `M ${toX(0).toFixed(1)} ${(SVG_H - PAD_B).toFixed(1)} ` +
+    points.map((pt, i) => `L ${toX(i).toFixed(1)} ${toY(pt.price).toFixed(1)}`).join(' ') +
+    ` L ${toX(points.length - 1).toFixed(1)} ${(SVG_H - PAD_B).toFixed(1)} Z`
+
+  // y-axis labels (5 ticks)
+  const yTicks = [0, 1, 2, 3, 4].map(i => {
+    const p = minP + (range * i) / 4
+    return { y: toY(p), label: fmtPrice(p) }
+  })
+
+  // x-axis labels (4 ticks at first/quarter/half/three-quarter/last)
+  const xTickIdx = [0, Math.floor((points.length - 1) / 3), Math.floor((2 * (points.length - 1)) / 3), points.length - 1]
+  // Heuristic: if the first two timestamps differ by less than a day, this
+  // is intraday data and we want HH:MM labels. Otherwise show MM-DD.
+  const isIntraday = (() => {
+    if (points.length < 2) return false
+    const a = Date.parse(points[0].ts.replace(' ', 'T'))
+    const b = Date.parse(points[1].ts.replace(' ', 'T'))
+    if (Number.isNaN(a) || Number.isNaN(b)) return false
+    return Math.abs(b - a) < 12 * 60 * 60 * 1000
+  })()
+  const xTicks = xTickIdx
+    .filter((idx, i, arr) => i === 0 || idx !== arr[i - 1])  // dedupe at edges
+    .map(idx => {
+      const tsStr = points[idx]?.ts || ''
+      // pandas Timestamps stringify as "2026-05-25 00:00:00+00:00" or
+      // "2026-05-25". Normalize and format based on intraday / daily.
+      const parsed = Date.parse(tsStr.replace(' ', 'T'))
+      let label = tsStr.slice(0, 10)
+      if (!Number.isNaN(parsed)) {
+        const d = new Date(parsed)
+        if (isIntraday) {
+          label = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+        } else {
+          label = `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+        }
+      }
+      return { x: toX(idx), label }
+    })
+
+  // Coloring: green if last > first, red otherwise — matches the 24h
+  // change badge convention.
+  const first = points[0].price
+  const last = points[points.length - 1].price
+  const stroke = last >= first ? 'var(--positive)' : 'var(--negative)'
+  const fill = last >= first ? 'rgba(34,197,94,0.10)' : 'rgba(239,68,68,0.10)'
+
+  return (
+    <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} width="100%" style={{ display: 'block', maxHeight: 320 }}>
+      {/* horizontal grid */}
+      {yTicks.map((t, i) => (
+        <line key={i} x1={PAD_L} y1={t.y} x2={SVG_W - PAD_R} y2={t.y}
+          stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+      ))}
+      {/* axes */}
+      <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={SVG_H - PAD_B}
+        stroke="rgba(255,255,255,0.2)" strokeWidth="1" />
+      <line x1={PAD_L} y1={SVG_H - PAD_B} x2={SVG_W - PAD_R} y2={SVG_H - PAD_B}
+        stroke="rgba(255,255,255,0.2)" strokeWidth="1" />
+
+      {/* y-axis labels */}
+      {yTicks.map((t, i) => (
+        <text key={i} x={PAD_L - 6} y={t.y + 4} textAnchor="end"
+          fill="rgba(255,255,255,0.42)" fontSize="9" className="mono">
+          {t.label}
+        </text>
+      ))}
+      {/* x-axis labels */}
+      {xTicks.map((t, i) => (
+        <text key={i} x={t.x} y={SVG_H - PAD_B + 14} textAnchor="middle"
+          fill="rgba(255,255,255,0.42)" fontSize="9">
+          {t.label}
+        </text>
+      ))}
+
+      {/* area under the line */}
+      <path d={areaPath} fill={fill} stroke="none" />
+      {/* main line */}
+      <path d={linePath} fill="none" stroke={stroke} strokeWidth="1.8" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export default function AssetModal({ asset, onClose }) {
+  const [range, setRange] = useState('1M')
+  const [history, setHistory] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  // Esc closes
+  useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Lock body scroll while modal is open
+  useEffect(() => {
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = prev }
+  }, [])
+
+  // Fetch on range change. We do NOT silently swallow errors — if the
+  // upstream feed returns nothing, the chart renders an explicit empty
+  // state instead of a faked flat line.
+  useEffect(() => {
+    if (!asset?.symbol) return
+    let cancelled = false
+    setLoading(true)
+    setError('')
+    fetch(`${API_BASE}/api/explore/assets/${asset.symbol}/history?range=${range}`)
+      .then(async res => {
+        if (!res.ok) {
+          // 404 just means "no series for this range"; fall through with empty data.
+          if (res.status === 404) {
+            if (!cancelled) { setHistory([]); setError('') }
+            return null
+          }
+          throw new Error(await res.text() || `History fetch failed (${res.status})`)
+        }
+        return res.json()
+      })
+      .then(data => {
+        if (cancelled || data == null) return
+        setHistory(Array.isArray(data.points) ? data.points : [])
+      })
+      .catch(e => {
+        if (!cancelled) {
+          setError(e?.message || 'Failed to load price history')
+          setHistory([])
+        }
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [asset?.symbol, range])
+
+  // 24h high/low: try to compute from the 1D intraday series when available.
+  // This is the honest computation — falls back to "—" if we don't have data.
+  const intradayStats = useMemo(() => {
+    if (range !== '1D' || history.length === 0) return { high: null, low: null }
+    const prices = history.map(p => p.price).filter(p => p != null && !Number.isNaN(p))
+    if (prices.length === 0) return { high: null, low: null }
+    return { high: Math.max(...prices), low: Math.min(...prices) }
+  }, [history, range])
+
+  if (!asset) return null
+
+  const high24 = asset.high_24h ?? intradayStats.high
+  const low24 = asset.low_24h ?? intradayStats.low
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-center justify-center z-[1000]"
+      style={{ background: 'rgba(0,0,0,0.78)', backdropFilter: 'blur(6px)' }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="asset-modal-title"
+    >
+      <div
+        className="card-elevated p-6"
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: 'var(--surface-1)',
+          maxHeight: '90vh', overflowY: 'auto',
+          width: 'min(820px, 94vw)',
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16 }}>
+          <div>
+            <h3 id="asset-modal-title" className="serif" style={{ fontSize: '1.6rem', margin: 0 }}>
+              {asset.symbol}
+            </h3>
+            <div className="caption" style={{ color: 'var(--text-3)', marginTop: 2 }}>
+              {asset.name || '—'}
+              {asset.asset_class && (
+                <span className="tag tag-muted" style={{ marginLeft: 8, fontSize: '0.65rem' }}>
+                  {asset.asset_class.replace(/_/g, ' ')}
+                </span>
+              )}
+            </div>
+          </div>
+          <button
+            className="btn btn-outline btn-sm"
+            onClick={onClose}
+            aria-label="Close asset details"
+          >
+            Close (Esc)
+          </button>
+        </div>
+
+        {/* Price block */}
+        <div style={{ display: 'flex', gap: 24, alignItems: 'baseline', marginTop: 18, flexWrap: 'wrap' }}>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Current price</div>
+            <div className="mono" style={{ fontSize: '2rem', fontWeight: 600 }}>
+              {fmtPrice(asset.current_price)}
+            </div>
+          </div>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>24h change</div>
+            <div className={`mono ${changeClass(asset.change_24h_pct)}`} style={{ fontSize: '1.1rem', fontWeight: 600 }}>
+              {fmtPct(asset.change_24h_pct)}
+            </div>
+          </div>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>24h high</div>
+            <div className="mono" style={{ fontSize: '1.1rem' }}>{fmtPrice(high24)}</div>
+          </div>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>24h low</div>
+            <div className="mono" style={{ fontSize: '1.1rem' }}>{fmtPrice(low24)}</div>
+          </div>
+        </div>
+
+        {/* Range toggle */}
+        <div style={{ marginTop: 18, display: 'flex', gap: 6, alignItems: 'center' }}>
+          {RANGES.map(r => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`btn btn-sm ${range === r ? '' : 'btn-outline'}`}
+              style={{
+                minWidth: 48,
+                background: range === r ? 'var(--accent-muted)' : undefined,
+                color: range === r ? 'var(--accent)' : undefined,
+                borderColor: range === r ? 'var(--accent)' : undefined,
+              }}
+              aria-pressed={range === r}
+            >
+              {r}
+            </button>
+          ))}
+          <span className="caption" style={{ marginLeft: 'auto', color: 'var(--text-4)', fontSize: '0.7rem' }}>
+            {range === '1D' ? 'Intraday 5-minute bars' : 'Daily close'}
+          </span>
+        </div>
+
+        {/* Chart */}
+        <div style={{ marginTop: 10 }}>
+          <PriceHistoryChart points={history} loading={loading} error={error} />
+        </div>
+
+        {/* Meta grid: source, last updated, longer-window changes, vol */}
+        <div
+          style={{
+            marginTop: 18,
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+            gap: 14,
+            paddingTop: 14,
+            borderTop: '1px solid var(--glass-border)',
+          }}
+        >
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Source</div>
+            <div className="body" style={{ fontSize: '0.9rem' }}>{sourceLabel(asset.price_source)}</div>
+          </div>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Last updated</div>
+            <div className="mono" style={{ fontSize: '0.82rem' }}>
+              {asset.last_updated ? new Date(asset.last_updated).toLocaleString() : '—'}
+            </div>
+          </div>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>7d change</div>
+            <div className={`mono ${changeClass(asset.change_7d_pct)}`}>{fmtPct(asset.change_7d_pct)}</div>
+          </div>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>30d change</div>
+            <div className={`mono ${changeClass(asset.change_30d_pct)}`}>{fmtPct(asset.change_30d_pct)}</div>
+          </div>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
+              Realized vol (30d, annualized)
+            </div>
+            <div className="mono">
+              {asset.realized_vol_30d != null ? asset.realized_vol_30d.toFixed(2) : '—'}
+            </div>
+          </div>
+          {asset.oracle_address && (
+            <div>
+              <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Oracle address</div>
+              <div className="mono" style={{ fontSize: '0.72rem', wordBreak: 'break-all' }}>
+                {asset.oracle_address}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {asset.is_stale && (
+          <div className="info-box warning" style={{ marginTop: 14, fontSize: '0.8rem' }}>
+            The displayed price for this asset is older than the freshness threshold.
+            The upstream feed ({sourceLabel(asset.price_source)}) has not updated recently.
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -1,49 +1,37 @@
 import { useEffect, useState } from 'react'
+import AssetModal from './AssetModal'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
-// /explore — Read-only asset discovery surface (no wallet required).
-// Per docs/specs/page-roles-spec.md: the universe of tradable assets,
-// demystified for non-finance readers via plain-English explanations on
-// each metric.
-
-function fmtPct(v, digits = 1) {
-  if (v == null || isNaN(v)) return '—'
-  const sign = v >= 0 ? '+' : ''
-  return `${sign}${v.toFixed(digits)}%`
-}
+// /explore — Read-only viewer for the market data the strategy engine sees.
+// No wallet required, no trade affordance. Per docs/specs/page-roles-spec.md,
+// this is the discovery surface that helps a user form an opinion about what
+// to ask Generate to build around.
 
 function fmtPrice(v) {
-  if (v == null || isNaN(v)) return '—'
+  if (v == null || Number.isNaN(v)) return '—'
   if (v >= 1000) return `$${v.toFixed(0)}`
   if (v >= 10) return `$${v.toFixed(2)}`
   return `$${v.toFixed(4)}`
 }
 
-function fmtVol(v) {
-  if (v == null || isNaN(v)) return '—'
-  return v.toFixed(2)
+function fmtPct(v, digits = 2) {
+  if (v == null || Number.isNaN(v)) return '—'
+  const sign = v >= 0 ? '+' : ''
+  return `${sign}${v.toFixed(digits)}%`
 }
 
 function changeClass(v) {
-  if (v == null || isNaN(v)) return ''
+  if (v == null || Number.isNaN(v)) return ''
   return v >= 0 ? 'positive' : 'negative'
 }
 
-function ExplainTooltip({ children, text }) {
-  if (!text) return children
-  return (
-    <span title={text} style={{ cursor: 'help', borderBottom: '1px dotted var(--text-4)' }}>
-      {children}
-    </span>
-  )
-}
-
-export default function Explore({ onNavigate }) {
+export default function Explore() {
   const [assets, setAssets] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [filterClass, setFilterClass] = useState('all')
+  const [openAsset, setOpenAsset] = useState(null)
 
   useEffect(() => {
     let cancelled = false
@@ -68,31 +56,37 @@ export default function Explore({ onNavigate }) {
   const classes = ['all', ...Array.from(new Set(assets.map(a => a.asset_class).filter(Boolean)))]
   const filtered = filterClass === 'all' ? assets : assets.filter(a => a.asset_class === filterClass)
 
-  // Renamed from `useInGenerate` so it doesn't trip the rules-of-hooks
-  // detector that flags any `use*`-prefixed call inside a callback.
-  const handleUseInGenerate = (_symbol) => {
-    if (onNavigate) onNavigate('generate')
-    // The Generate page reads `?seed_asset=` later — for now, just navigate.
-    // Wiring the seed prop through requires extending the navigate API; we
-    // can do that when Phase 4 adds the strategy passport route too.
-  }
+  // Banner only fires when *every* asset's displayed price is itself stale.
+  // The backend now treats a missing on-chain oracle as "not stale" when
+  // yfinance is the actual price source, so this banner is honest: it means
+  // the feed pipeline is genuinely broken, not just "the oracle slot is
+  // unused for this asset". See asset_market_service.py docstring.
+  const allStale = assets.length > 0 && assets.every(a => a.is_stale)
+  const someStale = !allStale && assets.some(a => a.is_stale)
 
   return (
     <div>
-      <div style={{ maxWidth: 720, marginBottom: 24 }}>
+      {/* Top-of-page header & explanation */}
+      <div style={{ maxWidth: 760, marginBottom: 28 }}>
         <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 10 }}>Explore</h2>
-        <p className="body" style={{ marginBottom: 8 }}>
-          The universe of synthetic assets you can trade on Arc. Prices come from the on-chain
-          oracle; explanations live next to every metric so non-finance readers don't need
-          a glossary.
+        <p className="body" style={{ marginBottom: 8, fontWeight: 500 }}>
+          Explore is a read-only viewer for the market data the strategy engine sees.
         </p>
         <p className="body" style={{ color: 'var(--text-3)' }}>
-          No wallet required — this page is browse-only. Click "Use in Generate" on any row
-          to seed a strategy around that asset.
+          Browse the universe of synthetic assets that Archimedes can allocate into,
+          look at current spot prices, recent moves, and 30-day volatility, then form
+          an opinion about what looks over- or under-valued. When you're ready,
+          head to Generate and describe a strategy around the names that caught your eye —
+          nothing on this page places a trade or moves a position.
+        </p>
+        <p className="caption" style={{ color: 'var(--text-4)', marginTop: 8 }}>
+          Click any card for full detail, price-history chart, and the upstream source the
+          price came from (on-chain oracle vs. off-chain fallback).
         </p>
       </div>
 
-      <div className="strat-filter-bar" style={{ marginBottom: 16 }}>
+      {/* Filter pills */}
+      <div className="strat-filter-bar" style={{ marginBottom: 18 }}>
         {classes.map(c => (
           <span
             key={c}
@@ -100,126 +94,135 @@ export default function Explore({ onNavigate }) {
             onClick={() => setFilterClass(c)}
             style={{ cursor: 'pointer' }}
           >
-            {c === 'all' ? 'All' : c.replace(/_/g, ' ')} {c !== 'all' && `(${assets.filter(a => a.asset_class === c).length})`}
+            {c === 'all' ? 'All' : c.replace(/_/g, ' ')}
+            {c !== 'all' && ` (${assets.filter(a => a.asset_class === c).length})`}
           </span>
         ))}
       </div>
 
+      {/* Loading / error / empty states */}
       {loading && !assets.length && <div className="caption">Loading market data…</div>}
       {error && !assets.length && (
         <div className="info-box warning" style={{ marginBottom: 16 }}>
           Couldn't load assets: {error}.
         </div>
       )}
-
       {!loading && !error && assets.length === 0 && (
         <div className="info-box" style={{ marginBottom: 16 }}>
-          Oracle feed paused — no price data available. This page refreshes automatically when the oracle resumes.
+          No market data available right now. This page refreshes automatically.
         </div>
       )}
 
-      {!loading && !error && assets.length > 0 && assets.every(a => a.is_stale) && (
+      {/* Banner — only when something is actually wrong with the feed. */}
+      {allStale && (
         <div className="info-box warning" style={{ marginBottom: 16 }}>
-          Oracle feed paused — last update{' '}
-          <span className="mono" style={{ fontSize: '0.85rem' }}>
-            {assets[0]?.last_updated ? new Date(assets[0].last_updated).toLocaleString() : 'unknown'}
-          </span>.
-          Prices shown may be outdated.
+          Every asset's price feed is older than the freshness threshold.
+          The upstream market-data pipeline appears to be paused; values shown may be outdated.
+        </div>
+      )}
+      {someStale && (
+        <div className="info-box" style={{ marginBottom: 16, fontSize: '0.82rem' }}>
+          Some assets have stale price feeds (marked with a STALE badge on the card).
+          Most assets are current.
         </div>
       )}
 
+      {/* Asset card grid */}
       {filtered.length > 0 && (
-        <div style={{ overflowX: 'auto', border: '1px solid var(--glass-border)', borderRadius: 8 }}>
-          <table className="lib-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
-            <thead>
-              <tr style={{ background: 'rgba(255,255,255,0.03)', textAlign: 'left', borderBottom: '1px solid var(--glass-border)' }}>
-                <th style={{ padding: '10px 14px' }}>Symbol</th>
-                <th style={{ padding: '10px 14px' }}>Name</th>
-                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
-                  <ExplainTooltip text="Latest price from the on-chain oracle. Settlement on Arc uses this.">
-                    Price
-                  </ExplainTooltip>
-                </th>
-                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
-                  <ExplainTooltip text="Percentage change in the last trading day.">
-                    24h
-                  </ExplainTooltip>
-                </th>
-                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
-                  <ExplainTooltip text="Percentage change over the past week.">
-                    7d
-                  </ExplainTooltip>
-                </th>
-                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
-                  <ExplainTooltip text="Percentage change over the past month.">
-                    30d
-                  </ExplainTooltip>
-                </th>
-                <th style={{ padding: '10px 14px', textAlign: 'right' }}>
-                  <ExplainTooltip text="How much the price wobbles. Higher = bigger swings.">
-                    Vol 30d
-                  </ExplainTooltip>
-                </th>
-                <th style={{ padding: '10px 14px', textAlign: 'right' }}></th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map(a => (
-                <tr key={a.symbol} className="lib-row">
-                  <td style={{ padding: '10px 14px', fontWeight: 600 }}>
-                    {a.symbol}
-                    {a.is_stale && (
-                      <span
-                        className="tag"
-                        style={{
-                          marginLeft: 6,
-                          fontSize: '0.65rem',
-                          background: 'var(--warning-bg, #fef3c7)',
-                          color: 'var(--warning-text, #92400e)',
-                          borderRadius: 4,
-                          padding: '1px 5px',
-                        }}
-                      >
-                        STALE
-                      </span>
-                    )}
-                  </td>
-                  <td style={{ padding: '10px 14px' }} className="caption">{a.name}</td>
-                  <td className="mono" style={{ padding: '10px 14px', textAlign: 'right' }}>
-                    <ExplainTooltip text={a.explanations?.current_price}>{fmtPrice(a.current_price)}</ExplainTooltip>
-                  </td>
-                  <td className={`mono ${changeClass(a.change_24h_pct)}`} style={{ padding: '10px 14px', textAlign: 'right' }}>
-                    <ExplainTooltip text={a.explanations?.change_24h_pct}>{fmtPct(a.change_24h_pct)}</ExplainTooltip>
-                  </td>
-                  <td className={`mono ${changeClass(a.change_7d_pct)}`} style={{ padding: '10px 14px', textAlign: 'right' }}>
-                    <ExplainTooltip text={a.explanations?.change_7d_pct}>{fmtPct(a.change_7d_pct)}</ExplainTooltip>
-                  </td>
-                  <td className={`mono ${changeClass(a.change_30d_pct)}`} style={{ padding: '10px 14px', textAlign: 'right' }}>
-                    <ExplainTooltip text={a.explanations?.change_30d_pct}>{fmtPct(a.change_30d_pct)}</ExplainTooltip>
-                  </td>
-                  <td className="mono" style={{ padding: '10px 14px', textAlign: 'right' }}>
-                    <ExplainTooltip text={a.explanations?.realized_vol_30d}>{fmtVol(a.realized_vol_30d)}</ExplainTooltip>
-                  </td>
-                  <td style={{ padding: '10px 14px', textAlign: 'right' }}>
-                    <button
-                      className="btn btn-outline btn-sm"
-                      onClick={() => handleUseInGenerate(a.symbol)}
-                      title={`Seed a Generate brief around ${a.symbol}`}
-                    >
-                      Use in Generate →
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+            gap: 14,
+          }}
+        >
+          {filtered.map(a => (
+            <button
+              key={a.symbol}
+              type="button"
+              onClick={() => setOpenAsset(a)}
+              className="card-flat"
+              style={{
+                textAlign: 'left',
+                padding: 16,
+                background: 'rgba(255,255,255,0.02)',
+                border: '1px solid var(--glass-border)',
+                borderRadius: 8,
+                cursor: 'pointer',
+                color: 'inherit',
+                font: 'inherit',
+                transition: 'background 0.15s, border-color 0.15s',
+              }}
+              onMouseEnter={e => {
+                e.currentTarget.style.background = 'rgba(255,255,255,0.05)'
+                e.currentTarget.style.borderColor = 'var(--text-4)'
+              }}
+              onMouseLeave={e => {
+                e.currentTarget.style.background = 'rgba(255,255,255,0.02)'
+                e.currentTarget.style.borderColor = 'var(--glass-border)'
+              }}
+              aria-label={`Open details for ${a.symbol}`}
+            >
+              <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 6 }}>
+                <div>
+                  <div style={{ fontSize: '1.15rem', fontWeight: 700, lineHeight: 1.1 }}>{a.symbol}</div>
+                  <div className="caption" style={{
+                    color: 'var(--text-4)',
+                    fontSize: '0.7rem',
+                    marginTop: 2,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    maxWidth: 180,
+                  }}>
+                    {a.name || '—'}
+                  </div>
+                </div>
+                {a.is_stale && (
+                  <span
+                    className="tag"
+                    style={{
+                      fontSize: '0.6rem',
+                      background: 'rgba(239,68,68,0.10)',
+                      color: 'var(--negative)',
+                      borderRadius: 4,
+                      padding: '1px 5px',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title="The displayed price is older than the freshness window"
+                  >
+                    STALE
+                  </span>
+                )}
+              </div>
+
+              <div className="mono" style={{ fontSize: '1.4rem', fontWeight: 600, marginTop: 12 }}>
+                {fmtPrice(a.current_price)}
+              </div>
+
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginTop: 6 }}>
+                <span className={`mono ${changeClass(a.change_24h_pct)}`} style={{ fontSize: '0.85rem' }}>
+                  {fmtPct(a.change_24h_pct)}
+                </span>
+                <span className="caption" style={{ color: 'var(--text-4)', fontSize: '0.65rem' }}>
+                  24h
+                </span>
+              </div>
+            </button>
+          ))}
         </div>
       )}
 
-      <p className="caption" style={{ marginTop: 16, color: 'var(--text-4)' }}>
-        Prices from on-chain PriceOracle with yfinance fallback. Stale = oracle hasn't updated in &gt;5 minutes.
-        The "Vol 30d" column is annualized realized volatility (std of daily returns × √252).
+      {/* Footer disclosure */}
+      <p className="caption" style={{ marginTop: 22, color: 'var(--text-4)' }}>
+        Prices come from the on-chain PriceOracle when available, with yfinance as the
+        off-chain fallback. "STALE" means the displayed price is itself older than the
+        freshness window (5 minutes for the oracle, ~4 days for daily-close fallback).
+        The "Vol 30d" metric in the detail modal is annualized realized volatility
+        (std of daily returns × √252).
       </p>
+
+      {openAsset && <AssetModal asset={openAsset} onClose={() => setOpenAsset(null)} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Dan asked for a full rebuild of the Explore page (sub day deadline). The old page was a wide table where every row showed "STALE", the "Use in Generate" button navigated nowhere useful, and the top-of-page copy didn't explain what the page is for. This PR replaces all of that:

- **Responsive card grid** instead of a table — one card per asset, click to open a detail modal.
- **Asset detail modal** with a price-history chart, togglable `1D / 1W / 1M / 1Y` ranges, full meta (24h change/high/low, oracle source, last-updated, oracle address, 7d/30d change, realized vol), and Escape-to-close.
- **STALE root-cause fix** on the backend — see below.
- **Rewrite of top-of-page copy** that lead with "Explore is a read-only viewer for the market data the strategy engine sees."
- **"Use in Generate" button removed** — handler, JSX, and the `onNavigate` prop are all gone (`App.jsx` updated).
- **New backend history endpoint behaviour:** `/api/explore/assets/{symbol}/history` now accepts `?range=1D|1W|1M|1Y` and returns intraday 5-minute bars for 1D, daily close for the rest. Returns 404 with an empty series when the upstream feed has nothing — the frontend renders an explicit empty state instead of a faked flat line.

## STALE root cause + fix

`OracleUpdater` only knows about ~9 symbols (`YFINANCE_MAP` ∪ `CRYPTO_MAP`). But `DEFAULT_SCAN_UNIVERSE` has ~70 symbols, and `chain_client.settings.oracle_addresses` allocates an on-chain `PriceOracle` for many of them. For the ~60 symbols nobody pushes `setPrice()` for, `getPrice()` returns `(0, 0)` → `now_ts - 0 > 5min` → `stale = True`. The displayed price was actually coming from the yfinance fallback path (which works fine for those names), but the old code propagated the *unused oracle slot's* staleness into `is_stale`, so the UI banner fired on every asset.

Fix in `asset_market_service.list_assets()`:
- New `price_source: "oracle" | "yfinance" | "none"` field discloses where `current_price` came from.
- `is_stale` now reflects whether the **actually-displayed price** is past its freshness window — 5 minutes for on-chain oracle, ~4 days for yfinance daily-close.
- If neither source has data, `current_price` is `null` and `is_stale` is `true`. No more "stale" labels on prices that are in fact current via yfinance.

Detail in the docstring at the top of `asset_market_service.py`.

## Acceptance criteria

- [x] **Backend: history endpoint accepts `range` param.** `backend/archimedes/api/explore_routes.py` adds `?range=1D|1W|1M|1Y` (Literal-typed via `fastapi.Query`); routes through to `AssetMarketService.get_history(symbol, range_=range)`. 404 on empty series.
- [x] **Backend: STALE root cause fixed at the source.** `backend/archimedes/services/asset_market_service.py` now derives `is_stale` from the displayed-price source (oracle freshness window OR yfinance daily-close freshness OR null). New `price_source` field discloses the source. Module docstring explains the semantics shift.
- [x] **Frontend: responsive card grid.** `Explore.jsx` renders `repeat(auto-fill, minmax(220px, 1fr))` cards. Each card shows symbol (large), name (small ellipsis-truncated), spot price (large, mono), 24h change % (red/green class), STALE badge only when `is_stale === true`.
- [x] **Frontend: click card → modal.** `AssetModal.jsx` (new file). Header shows symbol + name + asset_class tag. Price block: spot, 24h change %, 24h high, 24h low. Range toggle: `1D / 1W / 1M / 1Y` button group with pressed-state styling. Chart: SVG line chart (same idiom as `EfficientFrontier.jsx` — no new chart deps). Meta grid: source label, last updated, 7d/30d change, realized vol, oracle address. Close button **and Escape key**.
- [x] **Frontend: top-of-page copy rewritten.** Leading sentence is the verbatim user-supplied "Explore is a read-only viewer for the market data the strategy engine sees." Follow-up paragraph explains the over/undervalued → Generate workflow without marketing fluff.
- [x] **"Use in Generate" button removed.** No reference to `handleUseInGenerate`, `useInGenerate`, or the prop `onNavigate` remains in `Explore.jsx`; `App.jsx` no longer passes `onNavigate` to `<Explore />`.
- [x] **Honest fallbacks.** `fmtPrice` / `fmtPct` return `"—"` on null/NaN — never `"0"` or `"N/A"`. `PriceHistoryChart` renders an explicit empty-state card when the series is empty, never a flat line.
- [x] **No new top-level dependencies.** Chart is hand-rolled SVG (same pattern as `EfficientFrontier.jsx`). `ui/package.json` not modified.

## Test plan

- [ ] `cd ui && npm run build` — verify locally before merge (could not run in sandbox).
- [ ] `cd ui && npm run lint` — verify locally before merge (could not run in sandbox).
- [ ] Open `/explore` on the live deploy. Cards render in a grid; no STALE banner unless the feed is actually paused.
- [ ] Click a card. Modal opens. Toggle 1D / 1W / 1M / 1Y. The chart redraws each time and shows an empty-state card for any range that returns no data.
- [ ] Press Escape. Modal closes.
- [ ] Inspect a card for a symbol the oracle pusher knows about (e.g. `sSPY`, `sTSLA`, `sBTC`). Modal should show `Source: On-chain PriceOracle (Arc)`. For other symbols (e.g. `sASML`, `sFTSE`) the source is `yfinance (off-chain fallback)`.

## Files changed

- `backend/archimedes/api/explore_routes.py` — `?range` query param + 404 on empty
- `backend/archimedes/api/explore_schemas.py` — `price_source`, `high_24h`, `low_24h`, `HistoryRange`, `interval` literal expanded
- `backend/archimedes/services/asset_market_service.py` — STALE fix, source disclosure, new `_fetch_yfinance_series`, range-keyed history cache
- `ui/src/components/Explore.jsx` — full rewrite (table → cards, "Use in Generate" removed, new copy)
- `ui/src/components/AssetModal.jsx` — new file (modal, SVG `PriceHistoryChart`, range toggle, Escape handler, body-scroll lock)
- `ui/src/App.jsx` — drop `onNavigate` prop on `<Explore />`

## Out of scope / known limitations

- 24h high/low for the listing endpoint is null — the listing path only fetches daily close. The modal computes intraday high/low client-side when the 1D range is selected (honest computation from real data; otherwise "—").
- The oracle-pusher coverage gap (only 9 of ~70 scan-universe symbols get `setPrice()` pushed) is a separate problem worth a follow-up issue. This PR doesn't expand pusher coverage — that's a smart-contract-adjacent change that needs Chuan's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)