### PR TITLE
[explore] Add 5Y / 10Y / MAX range buttons to asset price-history modal

### DIFF
--- a/backend/archimedes/api/explore_schemas.py
+++ b/backend/archimedes/api/explore_schemas.py
@@ -54,11 +54,11 @@ class ExploreHistoryPoint(BaseModel):
     price: float
 
 
-HistoryRange = Literal["1D", "1W", "1M", "1Y"]
+HistoryRange = Literal["1D", "1W", "1M", "1Y", "5Y", "10Y", "MAX"]
 
 
 class ExploreHistoryResponse(BaseModel):
     symbol: str
     range: HistoryRange = "1M"
-    interval: Literal["1m", "5m", "1h", "1d"] = "1d"
+    interval: Literal["1m", "5m", "1h", "1d", "1wk", "1mo"] = "1d"
     points: list[ExploreHistoryPoint]

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -44,12 +44,17 @@ _YF_STALE_WINDOW_SECONDS = 4 * 24 * 60 * 60  # yfinance daily-close → stale if
 _ORACLE_READ_TIMEOUT = 5  # seconds per individual chain read
 
 # Range param → (yfinance period, yfinance interval). Daily intervals work
-# for week / month / year ranges; the 1D button uses 5-minute intraday data.
+# for week / month / year ranges; 1D uses 5-minute intraday data; the longer
+# ranges (5Y / 10Y / MAX) downsample to weekly / monthly bars to keep the
+# point count and the chart legible. "max" pulls the asset's full history.
 _HISTORY_RANGE_MAP: dict[str, tuple[str, str]] = {
     "1D": ("2d", "5m"),
     "1W": ("1mo", "1d"),
     "1M": ("3mo", "1d"),
     "1Y": ("1y", "1d"),
+    "5Y": ("5y", "1wk"),
+    "10Y": ("10y", "1wk"),
+    "MAX": ("max", "1mo"),
 }
 
 

--- a/ui/src/components/AssetModal.jsx
+++ b/ui/src/components/AssetModal.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
-const RANGES = ['1D', '1W', '1M', '1Y']
+const RANGES = ['1D', '1W', '1M', '1Y', '5Y', '10Y', 'MAX']
 
 function fmtPrice(v) {
   if (v == null || Number.isNaN(v)) return '—'


### PR DESCRIPTION
## Summary

Dan asked for longer lookback ranges on the Explore asset modal:
> "Only critique is that I'd like longer range price histories. 1 year as the max is kinda short. We should add 5Y, 10Y, and Max I think."

yfinance happily serves `5y`, `10y`, and `max` periods. The only nuance is downsampling — at multi-year ranges, daily bars are too dense for the chart. Use weekly bars for 5Y/10Y, monthly bars for MAX.

## Changes

- **`ui/src/components/AssetModal.jsx`** — extend `RANGES` to `['1D','1W','1M','1Y','5Y','10Y','MAX']`. Button strip auto-grows.
- **`backend/archimedes/api/explore_schemas.py`** — extend `HistoryRange` Literal + `ExploreHistoryResponse.interval` Literal to include `1wk` and `1mo`.
- **`backend/archimedes/services/asset_market_service.py`** — add to `_HISTORY_RANGE_MAP`:
  - `5Y → ("5y", "1wk")` — ~260 weekly bars
  - `10Y → ("10y", "1wk")` — ~520 weekly bars
  - `MAX → ("max", "1mo")` — monthly bars from the asset's inception

## Honest fallback

Already in place from the original Explore rebuild — if yfinance returns no bars for a given range/asset (e.g. a young synth asked for MAX, or a delisted ticker), the endpoint returns 404 with an empty array and the UI renders *"Historical chart unavailable on this asset for the selected range."* No fake flat lines, no zero-padding.

## Verification

- `ruff format --check` + `ruff check --select E9,F63,F7,F40,F82,F401` clean
- `pytest backend/tests/services/test_asset_market_service.py` — 12/12 pass
- `npm run lint` silent
- `npm run build` clean (1.83s, 1881 modules)

## Acceptance after deploy

```sh
# Each new range should return a non-empty points array for SPY
for r in 5Y 10Y MAX; do
  echo "=== $r ===" && curl -s "https://archimedes-arc.app/api/explore/assets/sSPY/history?range=$r" | jq '{range, interval, point_count: (.points | length)}'
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)