### PR TITLE
[frontend] Surface arcscan links on Portfolio/Passport/VaultDetail (Issue #303)

### DIFF
--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -259,7 +259,19 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace, on
                 )}
                 <div className="caption mt-1.5 flex gap-3 text-[var(--text-3)]">
                   {t.vault_address && <span>vault {shortAddr(t.vault_address)}</span>}
-                  {t.trace_hash && <span className="mono">{t.trace_hash.slice(0, 10)}…</span>}
+                  {t.arc_tx_hash ? (
+                    <a
+                      href={`https://testnet.arcscan.app/tx/${t.arc_tx_hash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mono underline decoration-dotted underline-offset-2 hover:text-[var(--accent)] transition-colors"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {t.arc_tx_hash.slice(0, 10)}… ↗
+                    </a>
+                  ) : t.trace_hash ? (
+                    <span className="mono">{t.trace_hash.slice(0, 10)}…</span>
+                  ) : null}
                   {t.is_verified
                     ? <span className="flex items-center gap-1 text-[var(--positive)]"><span className="i-lucide-check-circle w-3.5 h-3.5" /> anchored on Arc</span>
                     : <span className="flex items-center gap-1 text-[var(--text-3)]" title="Trace hashed + persisted off-chain; on-chain anchor pending (registry write didn't complete yet — usually transient).">

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -266,7 +266,14 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
             {s.on_chain_registration_tx && (
               <div>
                 <div className="caption text-[var(--text-4)]">Registration tx</div>
-                <div className="mono">{s.on_chain_registration_tx.slice(0, 14)}…</div>
+                <a
+                  href={`https://testnet.arcscan.app/tx/${s.on_chain_registration_tx}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mono underline decoration-dotted underline-offset-2 hover:text-[var(--accent)] transition-colors"
+                >
+                  {s.on_chain_registration_tx.slice(0, 14)}… ↗
+                </a>
               </div>
             )}
             {s.curator_note && (

--- a/ui/src/components/VaultDetail.jsx
+++ b/ui/src/components/VaultDetail.jsx
@@ -329,7 +329,18 @@ export default function VaultDetail({ address, onBack }) {
             {detail.recent_traces.map((t, i) => (
               <div key={i} className="vault-trace-row">
                 <span className="vault-trace-type">{t.decision_type}</span>
-                <code className="vault-trace-hash">{t.trace_hash?.slice(0, 16)}…</code>
+                {t.arc_tx_hash ? (
+                  <a
+                    href={`https://testnet.arcscan.app/tx/${t.arc_tx_hash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="vault-trace-hash mono underline decoration-dotted underline-offset-2 hover:text-[var(--accent)] transition-colors"
+                  >
+                    {t.arc_tx_hash.slice(0, 16)}… ↗
+                  </a>
+                ) : (
+                  <code className="vault-trace-hash">{t.trace_hash?.slice(0, 16)}…</code>
+                )}
                 <span className="vault-trace-time">{timeAgo(t.timestamp)}</span>
                 {t.is_verified && <span className="vault-trace-verified i-lucide-check" style={{width:12,height:12}} />}
               </div>


### PR DESCRIPTION
## Summary

Surface clickable arcscan links on the three remaining UI surfaces that display on-chain transaction hashes as monospace text.

Closes #303

## Changes

| File | Before | After |
|------|--------|-------|
| `Portfolio.jsx` | `trace_hash.slice(0,10)…` as `<span>` | Clickable `arc_tx_hash` → arcscan link; falls back to monospace when absent |
| `StrategyPassport.jsx` | `on_chain_registration_tx.slice(0,14)…` as `<div>` | Clickable arcscan link |
| `VaultDetail.jsx` | `trace_hash.slice(0,16)…` as `<code>` | Clickable `arc_tx_hash` → arcscan link; falls back to code when absent |

Pattern copied from existing `Reasoning.jsx:240` implementation.

Arcscan URL: `https://testnet.arcscan.app/tx/{hash}`

## Verify
```bash
cd ui && node_modules/.bin/eslint src/components/Portfolio.jsx src/components/StrategyPassport.jsx src/components/VaultDetail.jsx
# Exit 0, no errors
```