### PR TITLE
[frontend] Don't render upstream HTML in Recent Generations error banner

### DIFF
--- a/ui/src/components/GenerationStatus.jsx
+++ b/ui/src/components/GenerationStatus.jsx
@@ -35,11 +35,17 @@ export default function GenerationStatus({ activeJobId, onSelect }) {
     const load = async () => {
       try {
         const res = await fetch(`${API_BASE}/api/generate/jobs?limit=10`)
-        if (!res.ok) throw new Error(await res.text())
+        if (!res.ok) throw new Error(`Backend returned ${res.status}`)
         const data = await res.json()
-        if (!cancelled) setJobs(data.jobs || [])
+        if (!cancelled) {
+          setJobs(data.jobs || [])
+          setError('')
+        }
       } catch (e) {
-        if (!cancelled) setError(e.message || 'Failed to load jobs')
+        // Network failures bubble up as TypeError with no useful message; nginx
+        // upstream errors return HTML bodies we never want to render raw.
+        const msg = e?.message && e.message.length < 120 ? e.message : 'Failed to load jobs'
+        if (!cancelled) setError(msg)
       } finally {
         if (!cancelled) setLoading(false)
       }


### PR DESCRIPTION
## Summary

- When the backend was briefly unreachable, `GenerationStatus` threw the raw response body as the error message. A 502 from nginx returned the full HTML page (`<html><head><title>502 Bad Gateway</title>...`) and React rendered the markup as text inside the Recent Generations panel.
- Replace the body with a clean `Backend returned <status>` message.
- Length-cap any error string before rendering (120 chars) so a future raw-body throw can't splat across the page.
- Clear the error on the next successful poll so transient blips don't stick around.

## Test plan

- [x] `npm run build` in `ui/` passes.
- [x] Manual: trigger a 502 (backend down) → banner reads "Backend returned 502", not raw HTML.
- [x] Manual: 502 then success → banner clears on the next 5s poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)