### PR TITLE
[backend] Per-vault strategy scoping in agent_runner (Issue #307) !minor

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -185,13 +185,55 @@ class StrategyRunner:
 
             logger.info("[tick %s] Managing %d vaults", tick_id, len(vaults))
 
-            # 6. Process each vault
+            # 6. Process each vault with per-vault strategy scoping (Issue #307)
             for vault_addr in vaults:
                 try:
+                    # Per-vault scoping: each vault executes only its selected strategies
+                    vault_strategy_ids = self._get_vault_strategy_ids(vault_addr)
+
+                    if vault_strategy_ids is None:
+                        # No metadata — skip. Never apply global consensus to
+                        # a vault the user hasn't configured.
+                        logger.warning(
+                            "[tick %s] Vault %s has no metadata (strategy_ids=None) — "
+                            "skipping rebalance. Deploy via UI to set strategies.",
+                            tick_id,
+                            vault_addr[:10],
+                        )
+                        continue
+
+                    # Filter signals to this vault's strategies
+                    scoped_signals = [ss for ss in all_signals if ss.strategy_id in vault_strategy_ids]
+
+                    if not scoped_signals:
+                        logger.warning(
+                            "[tick %s] Vault %s strategy_ids=%s — none produced signals, skipping",
+                            tick_id,
+                            vault_addr[:10],
+                            vault_strategy_ids,
+                        )
+                        continue
+
+                    # Aggregate scoped signals into per-vault target weights
+                    vault_weights = strategy_evaluator.aggregate_signals(
+                        scoped_signals,
+                        usdc_floor=USDC_FLOOR,
+                    )
+                    vault_targets = self._weights_to_targets(vault_weights, scoped_signals)
+
+                    logger.info(
+                        "[tick %s] Vault %s: scoped to %d/%d strategies → %s",
+                        tick_id,
+                        vault_addr[:10],
+                        len(scoped_signals),
+                        len(all_signals),
+                        " | ".join(f"{k}={v:.0%}" for k, v in vault_weights.items()),
+                    )
+
                     await self._process_vault(
                         vault_addr,
-                        targets,
-                        all_signals,
+                        vault_targets,
+                        scoped_signals,
                         regime,
                         tick_id,
                     )
@@ -207,6 +249,29 @@ class StrategyRunner:
 
         except Exception:
             logger.exception("[tick %s] Strategy tick failed — will retry", tick_id)
+
+    # ─── Per-vault strategy scoping (Issue #307) ─────────────────────
+
+    def _get_vault_strategy_ids(self, vault_address: str) -> list[str] | None:
+        """Load strategy_ids from VaultMetadata for a vault.
+
+        Returns:
+            list[str] — the user's selected strategies for this vault.
+            None — if no metadata exists (vault deployed outside UI).
+        """
+        try:
+            from archimedes.db import get_session
+            from archimedes.models.chat import VaultMetadata
+
+            with get_session() as session:
+                meta = session.query(VaultMetadata).filter(VaultMetadata.vault_address == vault_address).first()
+                if meta is None:
+                    return None
+                ids = meta.get_strategy_ids()
+                return ids if ids else None
+        except Exception as exc:
+            logger.debug("_get_vault_strategy_ids(%s) failed: %s", vault_address[:10], exc)
+            return None
 
     async def _process_vault(
         self,

--- a/backend/tests/test_health_amm.py
+++ b/backend/tests/test_health_amm.py
@@ -1,0 +1,107 @@
+"""Tests for /health/amm endpoint (Issue #309)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_health_amm_returns_200_or_503_never_404():
+    """The endpoint exists and never returns 404."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/health/amm")
+    assert resp.status_code in (200, 503), f"Expected 200 or 503, got {resp.status_code}"
+    data = resp.json()
+    assert "status" in data
+
+
+@pytest.mark.asyncio
+async def test_health_amm_503_when_chain_disconnected():
+    """Returns 503 with explicit status when chain not reachable."""
+    from archimedes.main import app
+
+    with patch("archimedes.chain.client.chain_client.is_connected", new=AsyncMock(return_value=False)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health/amm")
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["status"] in ("amm_pools_not_initialized", "chain_disconnected")
+
+
+@pytest.mark.asyncio
+async def test_health_amm_503_when_no_pools():
+    """Returns 503 when chain is up but no pools exist."""
+    from archimedes.main import app
+
+    mock_router = MagicMock()
+    mock_get_all_pools_call = MagicMock()
+    mock_get_all_pools_call.call = AsyncMock(return_value=[])
+    mock_router.functions.getAllPools.return_value = mock_get_all_pools_call
+
+    mock_loader = MagicMock()
+    mock_loader.amm_router.return_value = mock_router
+
+    with (
+        patch("archimedes.chain.client.chain_client.is_connected", new=AsyncMock(return_value=True)),
+        patch("archimedes.chain.contracts.get_contract_loader", return_value=mock_loader),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health/amm")
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["status"] == "amm_pools_not_initialized"
+
+
+@pytest.mark.asyncio
+async def test_health_amm_200_when_pools_active():
+    """Returns 200 with pool list when pools exist."""
+    from archimedes.main import app
+
+    pool_addr = "0x1234567890123456789012345678901234567890"
+
+    # Mock the pool contract
+    mock_pool = MagicMock()
+    mock_pool.functions.tokenA.return_value.call = AsyncMock(return_value="0xAAA")
+    mock_pool.functions.tokenB.return_value.call = AsyncMock(return_value="0xBBB")
+    mock_pool.functions.reserveA.return_value.call = AsyncMock(return_value=1000000)
+    mock_pool.functions.reserveB.return_value.call = AsyncMock(return_value=2000000)
+
+    # Mock the router
+    mock_router = MagicMock()
+    mock_get_all_pools_call = MagicMock()
+    mock_get_all_pools_call.call = AsyncMock(return_value=[pool_addr])
+    mock_router.functions.getAllPools.return_value = mock_get_all_pools_call
+
+    mock_loader = MagicMock()
+    mock_loader.amm_router.return_value = mock_router
+    mock_loader.amm_pool.return_value = mock_pool
+
+    with (
+        patch("archimedes.chain.client.chain_client.is_connected", new=AsyncMock(return_value=True)),
+        patch("archimedes.chain.contracts.get_contract_loader", return_value=mock_loader),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health/amm")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["pool_count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_health_main_no_regression():
+    """Main /health endpoint still works."""
+    from archimedes.main import app
+
+    with patch("archimedes.chain.client.chain_client.is_connected", new=AsyncMock(return_value=False)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "status" in data
+    assert "service" in data


### PR DESCRIPTION
Closes #307. Wire _get_vault_strategy_ids() into the rebalance loop. Each vault now executes only its selected strategies (skip if no metadata). 859 tests pass.