### PR TITLE
[backend] explore: route handler must use HistoryRange too, not stale inline Literal

### DIFF
--- a/backend/archimedes/api/explore_routes.py
+++ b/backend/archimedes/api/explore_routes.py
@@ -9,11 +9,13 @@ in routes.py).
 
 from __future__ import annotations
 
-from typing import Literal
-
 from fastapi import APIRouter, HTTPException, Query
 
-from archimedes.api.explore_schemas import ExploreAssetsResponse, ExploreHistoryResponse
+from archimedes.api.explore_schemas import (
+    ExploreAssetsResponse,
+    ExploreHistoryResponse,
+    HistoryRange,
+)
 from archimedes.services.asset_market_service import asset_market_service
 
 explore_router = APIRouter(prefix="/api/explore", tags=["explore"])
@@ -28,7 +30,7 @@ async def list_explore_assets() -> ExploreAssetsResponse:
 @explore_router.get("/assets/{symbol}/history", response_model=ExploreHistoryResponse)
 async def get_explore_history(
     symbol: str,
-    range: Literal["1D", "1W", "1M", "1Y"] = Query("1M", description="History lookback range"),
+    range: HistoryRange = Query("1M", description="History lookback range"),
 ) -> ExploreHistoryResponse:
     """Price history for one asset, used by detail-chart range toggles.
 


### PR DESCRIPTION
## Summary

PR #314 added 5Y / 10Y / MAX to the `HistoryRange` Literal in `explore_schemas.py` and the new frontend buttons in `AssetModal` expected those values to route through. **But the route handler in `explore_routes.py` declared its own inline `Literal["1D", "1W", "1M", "1Y"]` that shadowed the schema**, so every 5Y / 10Y / MAX request returned a Pydantic 422 with the raw error JSON rendered as visible text in the chart panel.

Live reproduction (before this PR):
```sh
$ curl -s 'https://archimedes-arc.app/api/explore/assets/sSPY/history?range=5Y'
{"detail":[{"type":"literal_error","loc":["query","range"],
 "msg":"Input should be '1D', '1W', '1M' or '1Y'",
 "input":"5Y","ctx":{"expected":"'1D', '1W', '1M' or '1Y'"}}]}
```

Fix: import `HistoryRange` from `explore_schemas` and use it as the `Query` annotation, so the route param tracks the schema definition rather than duplicating it.

## Test plan

- [x] `ruff format --check` passes, `ruff check` clean.
- [ ] After merge + deploy: `curl -sw "\n%{http_code}" 'https://archimedes-arc.app/api/explore/assets/sSPY/history?range=5Y'` returns 200 with a `points` array (or 404 if no upstream data, but never 422).
- [ ] Manual: Explore → sSPY → click 5Y / 10Y / MAX — chart renders or shows empty-state, never raw JSON error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)