### PR TITLE
[frontend] /corpus: cut Topic Clusters tab (frontend↔backend contract mismatch)

### DIFF
--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import CustomSelect from './CustomSelect'
 import CorpusGraph from './CorpusGraph'
-import CorpusKG from './CorpusKG'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -11,21 +10,20 @@ async function apiGet(path) {
   return res.json()
 }
 
-const TABS = ['catalog', 'overview', 'graph', 'knowledge-graph']
+const TABS = ['catalog', 'overview', 'graph']
 
-// Friendly tab labels. The "knowledge-graph" slug stays for routing /
-// state stability, but the displayed label is "Topic Clusters" because
-// — until REBEL + SciSpacy actually run on the corpus (Issue #293) —
-// the only triples in the KG tables are BERTopic cluster memberships
-// (one predicate, `belongs_to_cluster`). Calling that a Knowledge
-// Graph would be misleading. BERTopic clusters across 1014 papers are
-// real and valuable; this is the honest framing of what they are.
-// When #293 lands with multi-predicate REBEL output, revert this map.
+// Friendly tab labels. The "knowledge-graph" tab (rendered by CorpusKG) was
+// cut on 2026-05-25: REBEL #293 produced real multi-predicate triples in the
+// kg_relations table, but the /api/corpus/kg/entities endpoint returns only
+// entities (no relations), and the CorpusKG component reads `e.type` /
+// `r.predicate` while the backend persists `entity_type` / `relation` — so
+// the surface displayed "N entities, 0 relations" even when REBEL had run.
+// CorpusKG.jsx is kept in the tree for whoever wires up a proper KG viewer
+// once the endpoint round-trip is fixed. See follow-up issue.
 const TAB_LABELS = {
   catalog: 'Catalog',
   overview: 'Overview',
   graph: 'Graph',
-  'knowledge-graph': 'Topic Clusters',
 }
 
 export default function CorpusExplorer() {
@@ -111,11 +109,6 @@ export default function CorpusExplorer() {
       {tab === 'graph' && (
         <div className="corpus-graph-container" style={{ padding: '8px 0' }}>
           <CorpusGraph />
-        </div>
-      )}
-      {tab === 'knowledge-graph' && (
-        <div className="corpus-kg-container" style={{ padding: '8px 0' }}>
-          <CorpusKG onOpenPaper={openPaper} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

The Topic Clusters tab on `/corpus` (rendered by `CorpusKG`) was showing **"49 entities, 0 relations"** even after Pi's REBEL #293 produced **1,873 multi-predicate triples and 922 distinct predicates** in `kg_relations`. Two independent bugs:

1. **Missing relations in API response.** [backend/archimedes/api/corpus_routes.py:295-301](backend/archimedes/api/corpus_routes.py#L295-L301) — `GET /api/corpus/kg/entities` returns only `entities` (no `relations` array), so the visualization has nothing to draw edges from.
2. **Frontend↔backend field-name mismatch.** [ui/src/components/CorpusKG.jsx](ui/src/components/CorpusKG.jsx) reads `e.type` and `r.predicate`, but the backend persists `entity_type` and `relation` — so even the entity labels render as `?`.

PR #306's "Knowledge Graph" label revert is moot until both bugs are fixed. Cutting the tab today so the surface doesn't read as faux-KG; `CorpusKG.jsx` stays in the tree for whoever wires up the proper viewer once the endpoint round-trip is fixed.

## Follow-ups

- PR #306 (KG-label revert) is now redundant — recommend closing rather than merging.
- Pi could rebuild the KG tab cleanly: fix the endpoint to include relations for matched entities + align field names. Filing a follow-up issue separately.

## Test plan

- [x] `npm run build` passes.
- [x] `npm run lint` clean.
- [ ] After merge + deploy: `/corpus` shows 3 tabs (Catalog, Overview, Graph), no Topic Clusters / Knowledge Graph.

## Anti-goals

- DO NOT delete `CorpusKG.jsx` from the tree — keep it as the starting point for the proper KG viewer.
- DO NOT touch the `/api/corpus/kg/*` backend endpoints — they're still consumed by the `/api/corpus/kg/paper/{arxiv_id}` per-paper triples API on the paper detail page, which works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)