### PR TITLE
[frontend] Generate: 'View in Library' button now actually navigates

### DIFF
--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -378,6 +378,7 @@ export default function Generate({ onNavigate }) {
           onDone={onJobDone}
           onReset={resetJob}
           onPipelineSelected={handlePipelineEvent}
+          onNavigate={onNavigate}
         />
       )}
 

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -72,7 +72,7 @@ function summarizeEvent(name, data) {
   }
 }
 
-export default function GenerationStream({ jobId, onDone, onReset, onPipelineSelected }) {
+export default function GenerationStream({ jobId, onDone, onReset, onPipelineSelected, onNavigate }) {
   const [events, setEvents] = useState([])
   const [terminal, setTerminal] = useState(null)  // 'done' | 'error' | null
   const [strategyId, setStrategyId] = useState(null)
@@ -268,7 +268,14 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
                     style={{ width: '100%', marginTop: 4 }}
                     onClick={() => {
                       localStorage.removeItem('archimedes:currentJobId')
-                      window.location.hash = `#/library?highlight=${c.strategy_id}`
+                      // SPA navigation through the parent router. Falls back to a
+                      // full-page nav if onNavigate isn't wired through, so the
+                      // button never silently does nothing.
+                      if (onNavigate) {
+                        onNavigate('library', { highlight: c.strategy_id })
+                      } else {
+                        window.location.href = `/library?highlight=${encodeURIComponent(c.strategy_id)}`
+                      }
                     }}
                   >
                     View in Library →


### PR DESCRIPTION
## Summary

The post-generation **View in Library** button was setting `window.location.hash = #/library?highlight=...` — that only changes the URL fragment without telling the SPA router, so the user stayed on `/generate` and watched a phantom hash get appended to the address bar. A happy-path clicker hits this and the canonical flow stalls at the most important moment (the just-generated strategy → review surface).

Fix: thread the parent `onNavigate` through `Generate` → `GenerationStream` and call it correctly with the strategy_id as the `highlight` param. Falls back to a full-page nav (`window.location.href = ...`) if the prop isn't wired so the button never silently does nothing.

## Test plan

- [x] `npm run build` passes.
- [x] `npm run lint` clean.
- [ ] Manual after merge: Generate → submit a brief → wait for SSE done → click "View in Library →" on a candidate card → land on `/library?highlight=<strategy_id>` with the row scrolled into view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)