### PR TITLE
[frontend] Library: View-in-nav fix + rigor section + modal contrast (SPEC-1 walkthrough bugs)

### DIFF
--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -378,6 +378,7 @@ export default function Generate({ onNavigate }) {
           onDone={onJobDone}
           onReset={resetJob}
           onPipelineSelected={handlePipelineEvent}
+          onNavigate={onNavigate}
         />
       )}
 

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -72,7 +72,7 @@ function summarizeEvent(name, data) {
   }
 }
 
-export default function GenerationStream({ jobId, onDone, onReset, onPipelineSelected }) {
+export default function GenerationStream({ jobId, onDone, onReset, onPipelineSelected, onNavigate }) {
   const [events, setEvents] = useState([])
   const [terminal, setTerminal] = useState(null)  // 'done' | 'error' | null
   const [strategyId, setStrategyId] = useState(null)
@@ -268,7 +268,17 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
                     style={{ width: '100%', marginTop: 4 }}
                     onClick={() => {
                       localStorage.removeItem('archimedes:currentJobId')
-                      window.location.hash = `#/library?highlight=${c.strategy_id}`
+                      // Use the React-router-aware navigation passed in from
+                      // the parent Generate page so App.jsx's state machine
+                      // (page + highlightStrategyId + activeTab) updates
+                      // properly. The previous window.location.hash assignment
+                      // bypassed React state and left the Library page rendering
+                      // its initial state without the highlight scroll.
+                      if (onNavigate) {
+                        onNavigate('library', { highlight: c.strategy_id, tab: 'generated' })
+                      } else {
+                        window.location.hash = `#/library?highlight=${c.strategy_id}`
+                      }
                     }}
                   >
                     View in Library →

--- a/ui/src/components/RejectedCandidates.jsx
+++ b/ui/src/components/RejectedCandidates.jsx
@@ -25,7 +25,11 @@ export default function RejectedCandidates({ jobId, onClose }) {
     <div
       onClick={onClose}
       style={{
-        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+        // Bumped backdrop opacity 0.6 → 0.85 so the modal body pops; the
+        // inner card also gets a solid background + border + drop-shadow so
+        // the page's glass-blur 'card' class doesn't render translucent
+        // over the dimmed backdrop (which had been leaving text semi-readable).
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.85)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
         zIndex: 1000, padding: 20,
       }}
@@ -33,7 +37,12 @@ export default function RejectedCandidates({ jobId, onClose }) {
       <div
         onClick={e => e.stopPropagation()}
         className="card"
-        style={{ maxWidth: 720, width: '100%', maxHeight: '80vh', overflowY: 'auto', padding: 24 }}
+        style={{
+          maxWidth: 720, width: '100%', maxHeight: '80vh', overflowY: 'auto', padding: 24,
+          background: 'var(--bg-1)',
+          border: '1px solid var(--glass-border)',
+          boxShadow: '0 24px 48px rgba(0,0,0,0.5)',
+        }}
       >
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
           <div>

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -704,30 +704,90 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
         </div>
       )}
 
-      {activeTab === 'generated' && (
-        <>
-          <StrategyTable
-            strategies={generated}
-            highlightStrategyId={highlightStrategyId}
-            onOpenRigorExplainer={openRigorExplainer}
-            onOpenPassport={openPassport}
-            emptyState={
-              <div className="card" style={{ padding: 22 }}>
-                <div className="label mb-2">No generated strategies yet</div>
-                <p className="body" style={{ marginBottom: 10 }}>
-                  Multi-paper fusion strategies you create from the{' '}
-                  <a href="/generate" style={{ color: 'var(--accent)' }}>Generate</a> page will
-                  appear here once they've been backtested + cleared the rigor gate.
-                </p>
-                <p className="caption" style={{ color: 'var(--text-3)' }}>
-                  Generations in flight show in the agent activity feed on Portfolio and
-                  Reasoning. They land in this table once the rigor gate clears.
-                </p>
-              </div>
-            }
-          />
-        </>
-      )}
+      {activeTab === 'generated' && (() => {
+        // Split generated strategies by rigor verdict so the main table only
+        // shows what passed (the wedge: "the Library is a quality filter, not
+        // a junk drawer"). Rejected candidates stay accessible in a collapsed
+        // section below so the user can inspect *why* they failed — honest
+        // rather than hidden, but visually de-prioritised.
+        const passing = generated.filter(s => s.passes_rigor_gate === true)
+        const rejected = generated.filter(s => s.passes_rigor_gate === false)
+        const pending = generated.filter(s => s.passes_rigor_gate == null)
+        const mainTableStrategies = [...passing, ...pending]
+        return (
+          <>
+            <StrategyTable
+              strategies={mainTableStrategies}
+              highlightStrategyId={highlightStrategyId}
+              onOpenRigorExplainer={openRigorExplainer}
+              onOpenPassport={openPassport}
+              emptyState={
+                rejected.length > 0 ? (
+                  <div className="card" style={{ padding: 22 }}>
+                    <div className="label mb-2">No strategies have passed the rigor gate yet</div>
+                    <p className="body" style={{ marginBottom: 10 }}>
+                      You've generated {rejected.length} {rejected.length === 1 ? 'candidate' : 'candidates'}, but
+                      none have cleared the rigor gate yet. Expand the <strong>Rejected</strong> section below
+                      to see the rigor verdicts (most are <code>"return series too short"</code> — a longer
+                      backtest window is needed for DSR / PBO to score them).
+                    </p>
+                    <p className="caption" style={{ color: 'var(--text-3)' }}>
+                      The Library is a quality filter — only strategies that pass DSR + PBO + walk-forward OOS
+                      + look-ahead audit are surfaced here. That's the wedge.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="card" style={{ padding: 22 }}>
+                    <div className="label mb-2">No generated strategies yet</div>
+                    <p className="body" style={{ marginBottom: 10 }}>
+                      Multi-paper fusion strategies you create from the{' '}
+                      <a href="/generate" style={{ color: 'var(--accent)' }}>Generate</a> page will
+                      appear here once they've been backtested + cleared the rigor gate.
+                    </p>
+                    <p className="caption" style={{ color: 'var(--text-3)' }}>
+                      Generations in flight show in the agent activity feed on Portfolio and
+                      Reasoning. They land in this table once the rigor gate clears.
+                    </p>
+                  </div>
+                )
+              }
+            />
+            {rejected.length > 0 && (
+              <details className="mt-5">
+                <summary
+                  className="caption cursor-pointer select-none"
+                  style={{
+                    color: 'var(--text-3)',
+                    padding: '10px 14px',
+                    background: 'var(--bg-2)',
+                    border: '1px solid var(--glass-border)',
+                    borderRadius: 6,
+                    listStyle: 'none',
+                  }}
+                >
+                  Rejected ({rejected.length}) — did not pass the rigor gate. Click to inspect.
+                </summary>
+                <div style={{ marginTop: 12 }}>
+                  <p className="caption mb-3" style={{ color: 'var(--text-3)', fontSize: '0.82rem' }}>
+                    These candidates were generated but failed at least one rigor check (DSR, PBO,
+                    walk-forward OOS, or look-ahead audit). Most rejections at this stage are
+                    "return series too short" — the agent generated a strategy but there isn't
+                    enough backtest history yet to compute DSR / PBO with statistical confidence.
+                    A longer backtest window typically unlocks them.
+                  </p>
+                  <StrategyTable
+                    strategies={rejected}
+                    highlightStrategyId={highlightStrategyId}
+                    onOpenRigorExplainer={openRigorExplainer}
+                    onOpenPassport={openPassport}
+                    emptyState={<p className="caption">No rejected strategies.</p>}
+                  />
+                </div>
+              </details>
+            )}
+          </>
+        )
+      })()}
 
       {activeTab === 'examples' && (
         <>


### PR DESCRIPTION
## Summary

Three small frontend bugs surfaced during Dan's live SPEC-1 walkthrough. All fixed in one PR — pure display-layer changes, no API contract changes, no backend touched.

## Bug 1: "View in Library" button bypassed React Router

In `GenerationStream.jsx`, the per-card `View in Library →` button assigned `window.location.hash = '#/library?highlight=…'` directly. That doesn't trigger `App.jsx`'s state machine — so the Library page would render its initial state without the highlight, and the user would land somewhere generic instead of on their just-generated strategy.

**Fix:** thread the `onNavigate` prop through `Generate.jsx → GenerationStream.jsx` and call `onNavigate('library', { highlight: c.strategy_id, tab: 'generated' })` instead. This properly updates `page`, `highlightStrategyId`, AND `defaultTab` via React state so the Library page renders on the right tab with the right scroll target.

The `window.location.hash` assignment is kept as a fallback if `onNavigate` isn't passed (defensive — shouldn't trigger in practice).

## Bug 2: Library mixed passing + rigor-failed strategies in the same table

The wedge story is *"the Library is a quality filter, not a junk drawer."* But every strategy a fresh user generates today fails rigor (the candidate's return series is too short for DSR/PBO to score, so `passes_rigor_gate = false`). The Library's Generated tab was showing all of them mixed together, which made the rigor-gate story look broken.

**Fix:** in `Strategies.jsx`, split `generated` into:

1. **Main table** — strategies with `passes_rigor_gate === true` OR `passes_rigor_gate == null` (pending). These are the ones aligned with the wedge story.
2. **Collapsed `<details>` section** — strategies with `passes_rigor_gate === false`. Labeled clearly as `"Rejected (N) — did not pass the rigor gate. Click to inspect."` with an explanation of why (short return series is the common case at generation time) and how (longer backtest unlocks them). This stays honest — rejected candidates are inspectable — but doesn't pollute the main view.

Updated the empty state to handle the "all strategies failed rigor" case explicitly, with a direct pointer to the Rejected section.

## Bug 3: RejectedCandidates modal was semi-transparent

The modal backdrop was `rgba(0, 0, 0, 0.6)` and the inner `card` class uses a glass-blur style that rendered translucent over the dimmed page. Combined, text was hard to read.

**Fix in `RejectedCandidates.jsx`:**
- Backdrop opacity 0.6 → 0.85
- Inner card gets explicit `background: var(--bg-1)` (solid), `border: 1px solid var(--glass-border)`, and `boxShadow: 0 24px 48px rgba(0,0,0,0.5)` to lift it cleanly off the dimmed page

## Anti-goals

- ❌ DO NOT change `/api/strategies/generated` response shape — the server returns the same data; this PR is pure frontend display logic
- ❌ DO NOT filter rigor-failed strategies on the server side — they need to be inspectable; the filter is presentational
- ❌ DO NOT touch the Examples tab — only the Generated tab gets the rigor split

## Verification

- `npm run lint` clean in `ui/`
- `npm run build` clean
- Manual after deploy: (1) Generate a strategy → click "View in Library" on a card → lands on `/library` with that strategy highlighted in the Generated tab. (2) The Generated tab shows passing + pending in the main table; if any are rejected, they appear in a collapsible section below. (3) Open the "Considered candidates" modal — backdrop is dark, card has solid bg, text is readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
