### PR TITLE
[frontend] Strategy Passport: visually disable Deploy on rigor-fail + treat PBO=0 as missing

### DIFF
--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -120,6 +120,11 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
           className="btn btn-primary"
           onClick={() => setDeployOpen(true)}
           disabled={!walletAddr || s.passes_rigor_gate === false}
+          style={
+            !walletAddr || s.passes_rigor_gate === false
+              ? { opacity: 0.45, cursor: 'not-allowed', filter: 'grayscale(0.6)' }
+              : undefined
+          }
           title={
             !walletAddr ? 'Connect wallet to deploy' :
             s.passes_rigor_gate === false ? 'Rigor gate failed — deployment disabled' :
@@ -233,7 +238,19 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
             value={fmt(s.deflated_sharpe_ratio)}
             hint={s.dsr_p_value != null ? `p = ${fmt(s.dsr_p_value, 3)}` : null}
           />
-          <Metric label="PBO" value={fmtPct(s.pbo_score)} hint="lower = less overfit" />
+          {/* PBO of exactly 0 paired with missing DSR/OOS is almost always a
+              placeholder, not a real measurement. Render "—" in that case so
+              we don't show a fake 0.0% next to honest unknowns elsewhere. */}
+          <Metric
+            label="PBO"
+            value={
+              s.pbo_score == null ||
+              (s.pbo_score === 0 && s.deflated_sharpe_ratio == null && s.out_of_sample_sharpe == null)
+                ? '—'
+                : fmtPct(s.pbo_score)
+            }
+            hint="lower = less overfit"
+          />
           <Metric label="OOS Sharpe" value={fmt(s.out_of_sample_sharpe)} />
           <Metric label="Trials" value={s.total_trades != null ? s.total_trades : '—'} hint="multiple-testing adj" />
         </div>


### PR DESCRIPTION
## Summary

Two polish hits flagged in the final-day scan:

1. **Deploy button looked live even when rigor failed.** The `disabled` attribute was set correctly + the title tooltip explained "Rigor gate failed — deployment disabled," but the `.btn-primary` styling didn't visually change. A user would click it and nothing would happen. Now: when disabled (no wallet OR `passes_rigor_gate === false`) the button gets `opacity: 0.45 + grayscale + cursor:not-allowed` so the disabled state reads at a glance.

2. **PBO rendered "0.0%" while DSR / OOS / Trials all rendered "—".** PBO of exactly zero paired with missing DSR + OOS is almost always the default placeholder (no rigor evaluation actually ran), not a real measurement (real PBO is rarely exactly zero). Render `—` in that specific scenario so we don't show a fake precise number next to honest unknowns. If at least one of `deflated_sharpe_ratio` or `out_of_sample_sharpe` is set, PBO=0 is treated as real.

## Test plan

- [x] `npm run build` passes.
- [x] `npm run lint` clean.
- [ ] Manual after merge: generate a strategy that fails rigor → Deploy button visibly greyed out, cursor not-allowed, click does nothing. PBO field reads "—" not "0.0%" if DSR + OOS are also missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)