### PR TITLE
[deps] Pin httpx directly (closes #349)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,6 +25,10 @@ scipy>=1.13
 yfinance>=0.2.40
 requests>=2.32
 aiohttp>=3.13.5
+# httpx is directly imported by services/corpus_service.py (arXiv intake) and
+# services/llm_backend.py (OpenAI-compatible + Ollama backends). Pinned directly
+# so we don't rely on it arriving transitively via anthropic/fastapi.
+httpx>=0.27
 
 # Backtesting
 backtrader>=1.9.78.123

--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
       - yfinance>=0.2.40              # Historical + live equity/ETF/crypto data; for backtesting
       - requests>=2.32
       - aiohttp>=3.13.5               # Floor aligned with backend/requirements.txt via dependabot PR #250.
+      - httpx>=0.27                   # Directly imported by services/corpus_service.py (arXiv intake) and services/llm_backend.py (OpenAI-compatible + Ollama). Pinned so we don't rely on transitive resolution.
 
       # --- Backtesting (per backtrader-vs-vectorbt decision memo) ---
       - backtrader>=1.9.78.123        # Decision: v1 default. See docs/specs/backtrader-vs-vectorbt-decision-memo.md. Floor aligned with backend/requirements.txt via dependabot PR #249.


### PR DESCRIPTION
## Summary

Pin `httpx>=0.27` directly in `backend/requirements.txt` and `environment.yml`. It was arriving transitively (via `anthropic`/`fastapi`) but is imported in 3 hot paths — a clean Docker build that doesn't pull it transitively would `ModuleNotFoundError` the first time any of these run.

Closes #349.

## Hot paths that depend on httpx

| File | Line | Usage |
| --- | --- | --- |
| `services/corpus_service.py` | 147 | `intake_from_arxiv()` — arXiv API |
| `services/llm_backend.py` | 163 | `AnthropicCompatibleBackend.complete()` — OpenAI-compatible (`LLM_BACKEND=openai`) |
| `services/llm_backend.py` | 208 | `OllamaBackend.complete()` |

## Test plan

- [ ] CI green
- [ ] `pip install -r backend/requirements.txt` in a fresh venv succeeds with httpx pinned