### PR TITLE
[backend] llm_backend: defensive .get() chain for OpenAI-style responses (closes #351)

### DIFF
--- a/backend/archimedes/services/llm_backend.py
+++ b/backend/archimedes/services/llm_backend.py
@@ -178,7 +178,12 @@ class OpenAIBackend:
         resp.raise_for_status()
         data = resp.json()
         self._served = data.get("model", self._model)
-        return data["choices"][0]["message"]["content"].strip()
+        # Defensive: OpenAI-style APIs can legitimately return empty `choices`
+        # (content filtering, tool-only responses, etc.). Mirror OllamaBackend's
+        # `.get()`-chain pattern so we never IndexError mid-request.
+        choices = data.get("choices") or []
+        first = choices[0] if choices else {}
+        return (first.get("message") or {}).get("content", "").strip()
 
 
 # ── Ollama (local, no key) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

`OpenAIBackend.complete()` in `services/llm_backend.py:181` was using bare indexing:

```python
return data["choices"][0]["message"]["content"].strip()
```

This crashes the FastAPI worker with `IndexError` when `choices` is empty (legitimate when OpenAI content filtering trips or for tool-only responses) and `KeyError` if `message`/`content` is missing.

Mirror the `OllamaBackend` pattern at line 225 — `.get()` chain with empty-string fallback. Caller already accepts an empty string.

Closes #351.

## Smoke test

```python
empty choices → ''
normal       → 'hello'
missing message → ''
```

All three return cleanly without exception.

## Test plan

- [ ] CI green
- [ ] `pytest backend/tests/services/test_llm_backend_unification.py` passes (verified locally, 7/7 green)