### PR TITLE
[deps] Drop unused alembic (closes #353)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,6 @@ starlette>=1.0.1
 uvicorn[standard]>=0.32
 sqlalchemy>=2.0
 psycopg2-binary>=2.9.12
-alembic>=1.13
 redis>=7.4.0
 pydantic>=2.9
 pydantic-settings>=2.14.1

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,6 @@ dependencies:
       - "uvicorn[standard]>=0.32"
       - sqlalchemy>=2.0
       - psycopg2-binary>=2.9.12       # PostgreSQL driver (binary wheel; no system pq needed). Floor aligned with backend/requirements.txt via dependabot PR #247.
-      - alembic>=1.13                 # DB migrations
       - redis>=7.4.0                  # Redis client for live regime/state cache (aligned with backend/requirements.txt)
       - pydantic>=2.9
       - pydantic-settings>=2.14.1     # Floor aligned with backend/requirements.txt via dependabot PR #248.


### PR DESCRIPTION
## Summary

Remove `alembic>=1.13` from both `backend/requirements.txt` and `environment.yml`. It was declared but never imported anywhere — the project uses raw SQL migrations under `backend/migrations/*.sql` plus SQLAlchemy `create_all()` + hand-rolled `ADD COLUMN IF NOT EXISTS` blocks. `backend/archimedes/db.py:40` even says so explicitly.

Closes #353.

## Why now

- ~1.2 MB Docker image weight for a never-imported package
- Mako transitive surface that we'd otherwise have to keep CVE-clean
- No call sites to break (verified with `grep -rn alembic --include='*.py' .` → 0 hits)

## Test plan

- [ ] CI green (`pip install -r backend/requirements.txt` in a fresh venv)
- [ ] Existing tests pass — there are zero alembic imports to break