### PR TITLE
[docs] CLAUDE.md: refresh test count + contract list (closes #355)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,9 @@ Then <http://localhost> for the UI mockups and <http://localhost:8000/docs> for 
 backend API. See README § "Run Archimedes locally" for the full walkthrough.
 
 **Tests:** from the repo root in the `archimedes` conda env, just `pytest` —
-`pytest.ini` sets `pythonpath`/`testpaths` and a verbose default (119 tests,
-green). Coverage: `pytest --cov=archimedes --cov-report=term-missing`. The
+`pytest.ini` sets `pythonpath`/`testpaths` and a verbose default (~860 tests
+on `main` as of 2026-05-26; suite is still growing). Coverage:
+`pytest --cov=archimedes --cov-report=term-missing`. The
 analytics-engine runs its own suite: `cd analytics-engine && uv run pytest`. See
 README § "Running the test suite" for the honest coverage picture and the
 build-on-deploy integration-test caveat.
@@ -269,11 +270,15 @@ they actually shipped (Day 4):
   Supersedes `docs/design.md` § 6 ("vectorbt / custom numpy engine") on this one
   line; design.md remains the architecture spec for everything else. Migration to
   vectorbt is a v2 problem if parameter-sweep speed becomes a constraint.
-- **Smart contracts:** Solidity + Foundry, targeting Arc (EVM-compatible). **10 contracts
-  deployed on Arc testnet as of Day 4**: `AMMPool`, `AMMRouter`, `AssetRegistry`,
-  `PriceOracle`, `ReasoningTraceRegistry`, `SyntheticFactory`, `SyntheticToken`,
-  `SyntheticVault`, `Vault`, `VaultFactory`. ABIs cached in
-  [`contracts/abis/`](contracts/abis/) for backend + UI consumption
+- **Smart contracts:** Solidity + Foundry, targeting Arc (EVM-compatible). **11 contracts
+  deployed on Arc testnet** (Day 4 baseline + `StrategyRegistry` added later):
+  `AMMPool`, `AMMRouter`, `AssetRegistry`, `PriceOracle`, `ReasoningTraceRegistry`,
+  `StrategyRegistry`, `SyntheticFactory`, `SyntheticToken`, `SyntheticVault`,
+  `Vault`, `VaultFactory`. ABIs cached in
+  [`contracts/abis/`](contracts/abis/) for backend + UI consumption. (Note:
+  `ecosystem-design-spec.md` described `StrategyRegistry → AssetRegistry` as a
+  replacement, but in practice both coexist today — the spec-vs-state delta
+  is intentional and the registries serve different lookups.)
 - **On-chain integration:** Circle SDK — Wallets (Circle-managed wallet for the oracle
   signer), USYC, Gateway, CCTP, Paymaster; viem on the UI side
 - **Deployment:** Docker compose stack (5 services: postgres / redis / nginx / oracle /


### PR DESCRIPTION
## Summary

Two drift fixes to `CLAUDE.md`. Both surfaces are loaded into every Claude Code session by default, so the staleness propagates into every parallel agent.

1. **Test count**: `"119 tests, green"` was written Day 2 (2026-05-12). Suite is now ~860 on `main` (`pytest --collect-only` says 858 today and is still growing). Replaced the exact integer with a dated approximation so future PRs don't have to bump it every time.

2. **Contract count**: list said `"10 contracts deployed"` but `StrategyRegistry.sol` is also on disk and has ABIs cached at `contracts/abis/StrategyRegistry.json` + `IStrategyRegistry.json`. Surfaced it honestly + added a one-line note that the `ecosystem-design-spec.md` "`StrategyRegistry → AssetRegistry` replacement" never actually happened (both coexist today).

Closes #355.

## Test plan

- [ ] `grep '119 tests' CLAUDE.md` → no matches
- [ ] `grep '10 contracts deployed' CLAUDE.md` → no matches
- [ ] `StrategyRegistry` appears in the contract list