### PR TITLE
[brand] Drop 'Linus' headline + fix arXiv ≠ peer-reviewed misclaim

### DIFF
--- a/ARC-OSS-SHOWCASE.md
+++ b/ARC-OSS-SHOWCASE.md
@@ -180,7 +180,7 @@ Implements the five protocols Xia et al. 2026 formalize as the prerequisites for
 | [`backend/archimedes/services/source_tracker.py`](backend/archimedes/services/source_tracker.py) | Source Tracking — every trace records `consulted_paper_hashes` (sorted `arxiv_id:content_hash` list), which is part of the canonical trace hash anchored on-chain. |
 | [`docs/specs/xia-2026-protocols.md`](docs/specs/xia-2026-protocols.md) | Full reference — maps each protocol to the section of the Xia paper it implements. |
 
-**How to fork:** drop the four modules into any retrieval-augmented agent that consumes time-stamped sources. The Hierarchy of Truth is enforced structurally (peer-reviewed > narrative > social), so adopt the curation rule too.
+**How to fork:** drop the four modules into any retrieval-augmented agent that consumes time-stamped sources. The Hierarchy of Truth is enforced structurally (curated academic literature > narrative > social), so adopt the curation rule too.
 
 **Who benefits:** any LLM-agent product that retrieves from a corpus and emits actions audited against a benchmark. The protocols close the "Oracle Fallacy" and "Provenance Loss" failure modes Xia identifies in 15/19 surveyed studies.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Archimedes
 
-> **Linus for quantitative finance — research-grounded AI portfolios, settled on Arc.**
+> # Agentic trading, grounded in research.
+>
+> Tell Archimedes what you want from a portfolio in plain English. It fuses your intent with the quant-finance literature, live market data, and statistical rigor — into an autonomous on-chain strategy that runs in a non-custodial vault on Arc, with every decision hashed and verifiable on-chain.
 >
 > *The lever is academic research. The fulcrum is autonomous AI. The world is your portfolio.*
 

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -64,7 +64,7 @@ else:
 
 app = FastAPI(
     title="Archimedes",
-    description="Peer-reviewed AI portfolios, settled on Arc.",
+    description="Agentic trading, grounded in research — settled on Arc.",
     version="0.1.0",
     docs_url=_docs_url,
     openapi_url=_openapi_url,
@@ -399,6 +399,6 @@ async def health_amm():
 async def root():
     return {
         "name": "Archimedes",
-        "tagline": "Peer-reviewed AI portfolios, settled on Arc.",
+        "tagline": "Agentic trading, grounded in research — settled on Arc.",
         "docs": _docs_url or "disabled (production)",
     }

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -93,7 +93,7 @@ const MEMORY_LAYERS = [
 const PROTOCOLS = [
   { name: 'Outcome Embargo', what: 'Papers retrieved at decision time are filtered to those published before the decision; on-chain anchor proves the filter held.' },
   { name: 'Time-Aware Retrieval', what: 'SPECTER2 similarity decays by paper age; higher decay in volatile regimes.' },
-  { name: 'Hierarchy of Truth', what: 'Chain state outranks LLM narrative; peer-reviewed papers outrank uncurated sources.' },
+  { name: 'Hierarchy of Truth', what: 'Chain state outranks LLM narrative; curated academic literature outranks uncurated sources.' },
   { name: 'Source Tracking', what: 'Every cited paper carries (arxiv_id, version, content_hash). Anchored on Arc; anyone can recompute.' },
 ]
 
@@ -258,10 +258,11 @@ function CorpusPanel() {
     <div className="card p-5 mb-7">
       <div className="label mb-3">The q-fin corpus — Layer E in detail</div>
       <p className="body mb-4">
-        9,873 peer-reviewed papers ingested via PyMuPDF, embedded with SPECTER2, clustered
-        with HDBSCAN, and linked with REBEL + SciSpacy into a knowledge graph. The
-        Strategy Generation Agent's <strong>Paper Retrieval</strong> sub-agent uses this
-        substrate every time you submit a brief.
+        9,873 academic papers (arXiv preprints across q-fin, ML, math, and agentic AI)
+        ingested via PyMuPDF, embedded with SPECTER2, clustered with HDBSCAN, and linked
+        with REBEL + SciSpacy into a knowledge graph. The Strategy Generation Agent's
+        <strong>Paper Retrieval</strong> sub-agent uses this substrate every time you submit
+        a brief.
       </p>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         {[

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -21,16 +21,17 @@ export default function Landing({ onNavigate }) {
             Agora Agents Hackathon 2026
           </span>
           <p className="font-serif italic text-[1rem] text-[var(--text-3)] mb-3 md:text-[1.1rem]">
-            Linus for quantitative finance.
+            Agentic trading, grounded in research.
           </p>
           <h1 className="font-serif text-[2.1rem] font-normal leading-[1.15] mb-5 text-[var(--text-1)] sm:text-[2.6rem] lg:text-[3.1rem]">
-            <span className="text-[var(--accent)]">Paper-Grounded.</span>{' '}
-            <span className="text-[var(--text-3)]">Autonomously Managed.</span>
+            <span className="text-[var(--accent)]">Your Intent.</span>{' '}
+            <span className="text-[var(--text-3)]">Our Rigor.</span>
           </h1>
           <p className="text-[0.98rem] leading-[1.65] text-[var(--text-2)] max-w-[620px] mx-auto mb-8 md:text-[1.08rem]">
-            Archimedes turns bleeding-edge academic research into rigor-gated,
-            investable strategies — generated for your brief, executed in
-            non-custodial vaults on Arc, with every decision hashed and
+            Tell Archimedes what you want in plain English. It fuses your intent
+            with the quant-finance literature, live market data, and statistical
+            rigor — into an autonomous trading strategy that runs in a
+            non-custodial vault on Arc, with every decision hashed and
             verifiable on-chain.
           </p>
           <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:justify-center sm:items-center">


### PR DESCRIPTION
## Summary

Two external-facing corrections per Dan's call:

### 1. Drop "Linus for quantitative finance" headline

The Linus reference is opaque outside the software-insider audience and frames the project as a person rather than the product. **New headline: "Agentic trading, grounded in research."** Supporting copy carries the four pillars Dan articulated: **user intent + academic research + market data + statistical rigor**, and emphasizes accessibility (anyone can wield these tools by writing a brief in plain English).

Updated user-facing surfaces:
- `README.md` tagline block (the H2-style blockquote at the top)
- `ui/src/components/Landing.jsx` hero — italic subtitle + H1 + body copy
- `backend/archimedes/main.py` FastAPI description + root endpoint JSON tagline

Left alone (internal / historical):
- `CLAUDE.md` — internal team context doc; Linus framing here is intra-team, not user-facing
- `docs/user-stories.md` — historical product-framing reference documenting lineage
- `submodules/Linus/` — legitimate source-code dependency

### 2. Fix "arXiv ≠ peer-reviewed"

Multiple user-facing places claimed the corpus was "peer-reviewed papers." **arXiv is a preprint server** — many of those papers are subsequently peer-reviewed in journals, but we ingest the arXiv version, not the published version. Calling the corpus "peer-reviewed" overclaims; honesty matters more than the rhetorical bump.

Updated:
- `ui/src/components/Architecture.jsx` CorpusPanel — "9,873 peer-reviewed papers" → "9,873 academic papers (arXiv preprints across q-fin, ML, math, and agentic AI)"
- `ui/src/components/Architecture.jsx` ProtocolsPanel (Hierarchy of Truth) — "peer-reviewed papers outrank uncurated sources" → "curated academic literature outranks uncurated sources"
- `ARC-OSS-SHOWCASE.md` primitive #8 — same correction to the curation rule

## Acceptance

- `grep -rn "Linus for" README.md ui/src/components/Landing.jsx ARC-OSS-SHOWCASE.md backend/archimedes/main.py` returns empty
- `grep -rn "peer-reviewed\|Peer-reviewed" README.md ui/src/components/Architecture.jsx ARC-OSS-SHOWCASE.md backend/archimedes/main.py` returns empty
- After deploy: `curl -s https://archimedes-arc.app/api/health` shows the new tagline indirectly via `/` root (loads with new copy); Landing page hero reads "Agentic trading, grounded in research" / "Your Intent. Our Rigor."

## Anti-goals

- DO NOT remove the "lever / fulcrum / world" Archimedes quote in README — it's about the historical Archimedes (the mathematician), not the Linus reference
- DO NOT touch CLAUDE.md or docs/user-stories.md (internal historical context)
- DO NOT touch submodules/Linus/ (real source-code dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
