### PR TITLE
[brand] index.html: align <title>, og:title, og:description, og:url with #357 brand refresh

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Archimedes — Paper-Grounded Portfolio Agent on Arc</title>
-    <meta name="description" content="Autonomous portfolio agent turning published quant research into investable strategies on Arc with USDC settlement. Every decision hashed and verifiable on-chain." />
-    <meta property="og:title" content="Archimedes — Paper-Grounded Portfolio Agent" />
-    <meta property="og:description" content="Autonomous portfolio agent on Arc. Paper-grounded strategies, on-chain provenance, non-custodial vaults." />
+    <title>Archimedes — Agentic trading, grounded in research</title>
+    <meta name="description" content="Tell Archimedes what you want in plain English. It fuses your intent with the quant-finance literature, live market data, and statistical rigor — into an autonomous trading strategy that runs in a non-custodial vault on Arc, with every decision hashed and verifiable on-chain." />
+    <meta property="og:title" content="Archimedes — Your Intent. Our Rigor." />
+    <meta property="og:description" content="Agentic trading, grounded in research. An autonomous portfolio agent that fuses your intent with the quant-finance literature and statistical rigor, then runs in a non-custodial vault on Arc." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="http://18.171.230.205/" />
+    <meta property="og:url" content="https://archimedes-arc.app/" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

PR #357 dropped *"Linus for quantitative finance"* and shipped the new *"Your Intent. Our Rigor. / Agentic trading, grounded in research."* voice across the Landing + README + FastAPI tagline, but missed the static `ui/index.html` metadata. Result:

- Browser tabs still read **"Archimedes — Paper-Grounded Portfolio Agent on Arc"**.
- Social-share previews (X, Slack, Discord) render the old brand from the `og:*` tags.
- `og:url` still points at the legacy EC2 IP `http://18.171.230.205/` instead of `https://archimedes-arc.app/`.

This PR aligns all four:

- `<title>` → "Archimedes — Agentic trading, grounded in research"
- `<meta name="description">` → matches the Landing body copy
- `<meta property="og:title">` → "Archimedes — Your Intent. Our Rigor."
- `<meta property="og:description">` → matches the brand voice
- `<meta property="og:url">` → `https://archimedes-arc.app/`

## Test plan

- [x] `npm run build` passes.
- [ ] Manual after deploy: browser tab title reads the new brand. View-source confirms the og:* tags.
- [ ] Optional: paste `https://archimedes-arc.app/` into a Slack / X drafting box to confirm the social card pulls the right title/description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)