### PR TITLE
[frontend] Explore: don't render upstream HTML in 'Couldn't load assets' error

### DIFF
--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -38,11 +38,18 @@ export default function Explore() {
     const load = async () => {
       try {
         const res = await fetch(`${API_BASE}/api/explore/assets`)
-        if (!res.ok) throw new Error(await res.text())
+        if (!res.ok) throw new Error(`Backend returned ${res.status}`)
         const data = await res.json()
-        if (!cancelled) setAssets(data.assets || [])
+        if (!cancelled) {
+          setAssets(data.assets || [])
+          setError('')
+        }
       } catch (e) {
-        if (!cancelled) setError(e.message || 'Failed to load assets')
+        // Never render the response body as the error message — nginx 502s
+        // come back as multi-line HTML and would splat across the page.
+        // Same anti-pattern fixed in GenerationStatus.jsx (#323).
+        const msg = e?.message && e.message.length < 120 ? e.message : 'Failed to load assets'
+        if (!cancelled) setError(msg)
       } finally {
         if (!cancelled) setLoading(false)
       }


### PR DESCRIPTION
## Summary

Same anti-pattern as the GenerationStatus 502 fix (#323), different file. When the backend is mid-deploy and nginx returns its 502 HTML page, the old code did \`throw new Error(await res.text())\` and rendered the full multi-line HTML body inline — \`<html><head><title>502 Bad Gateway\` etc. appeared as visible text inside the assets-failed-to-load error box. Hit during a mobile sweep just now (backend was mid-deploy).

Three things:
1. Throw a clean \`Backend returned <status>\` message instead of the body.
2. Length-cap any error string at 120 chars before rendering, so a future raw-body throw can't splat across the page either.
3. Clear the error on the next successful poll so transient blips don't stick around.

## Test plan

- [x] \`npm run build\` passes.
- [x] \`npm run lint\` clean.
- [ ] After merge + deploy: trigger a 502 (back-end restart) and verify the Explore error box reads "Backend returned 502" not raw HTML.

## Future hardening idea (out of scope here)

Audit every other \`throw new Error(await res.text())\` in the UI for the same risk. \`grep -rn "throw new Error(await res.text" ui/src/\` would surface them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)