### PR TITLE
[frontend] Gate Generate + Reasoning, regroup sidebar into Discover/Strategy/Position

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -194,7 +194,16 @@ export default function App() {
     switch (page) {
       case 'landing':     return <Landing onNavigate={navigateToPage} />
       case 'explore':      return <Explore />
-      case 'generate':     return <Generate onNavigate={navigateToPage} />
+      case 'generate':     return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Generate"
+          description="Generate uses an LLM-powered multi-agent pipeline against a 9,873-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
+          onConnect={openConnectModal}
+        >
+          <Generate onNavigate={navigateToPage} />
+        </WalletGate>
+      )
       case 'architecture': return <Architecture onNavigate={navigateToPage} />
       case 'library':      return (
         <WalletGate
@@ -218,7 +227,16 @@ export default function App() {
           <Portfolio walletAddr={walletAddr} onSelectVault={selectVault} onSelectTrace={selectTrace} onNavigate={navigateToPage} />
         </WalletGate>
       )
-      case 'reasoning':    return <Reasoning onNavigate={navigateToPage} />
+      case 'reasoning':    return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Reasoning"
+          description="Reasoning is the audit trail for every autonomous agent decision — hashed off-chain and anchored on Arc via the ReasoningTraceRegistry contract. Connect a wallet to inspect traces and verify hashes against the on-chain registry."
+          onConnect={openConnectModal}
+        >
+          <Reasoning onNavigate={navigateToPage} />
+        </WalletGate>
+      )
       case 'learnings':    return (
         <WalletGate
           walletAddr={walletAddr}

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -209,9 +209,6 @@ export default function Generate({ onNavigate }) {
           relevant q-fin papers, fuses them with live market context, sizes positions
           with Kelly + risk parity, and anchors every decision on Arc.
         </p>
-        <p className="body text-[var(--text-3)]">
-          No wallet required to generate. Wallet is only needed to deposit into a vault.
-        </p>
       </div>
 
       {/* ── COLLAPSIBLE: How this works + Tips + Example briefs ──

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -4,17 +4,23 @@ import Breadcrumbs from './Breadcrumbs'
 import WelcomeProfileModal from './WelcomeProfileModal'
 import { NEW_CONTRACTS } from '../config'
 
-// Spine per docs/user-stories.md. Reasoning is in nav until the per-page modal
-// affordances are fully wired (user-stories.md ideal); for now traces need a
-// browse surface so users can actually inspect them.
+// Sidebar groups split the 9 surfaces along the gating boundary:
+//   DISCOVER — open to anonymous visitors (no wallet needed)
+//   STRATEGY — wallet-gated: generate + your saved strategies
+//   POSITION — wallet-gated: deployed vaults, on-chain audit, post-hoc review
+// The group label renders as a small-caps section header in the sidebar.
 const NAV = [
-  { group: '', items: [
-    { id: 'landing',   label: 'Home',      icon: 'i-lucide-home' },
-    { id: 'explore',   label: 'Explore',   icon: 'i-lucide-compass' },
-    { id: 'generate',  label: 'Generate',  icon: 'i-lucide-sparkles' },
+  { group: 'Discover', items: [
+    { id: 'landing',      label: 'Home',         icon: 'i-lucide-home' },
+    { id: 'explore',      label: 'Explore',      icon: 'i-lucide-compass' },
     { id: 'architecture', label: 'Architecture', icon: 'i-lucide-network' },
-    { id: 'library',   label: 'Library',   icon: 'i-lucide-line-chart' },
-    { id: 'corpus',    label: 'Corpus',    icon: 'i-lucide-library' },
+    { id: 'corpus',       label: 'Corpus',       icon: 'i-lucide-library' },
+  ]},
+  { group: 'Strategy', items: [
+    { id: 'generate', label: 'Generate', icon: 'i-lucide-sparkles' },
+    { id: 'library',  label: 'Library',  icon: 'i-lucide-line-chart' },
+  ]},
+  { group: 'Position', items: [
     { id: 'portfolio', label: 'Portfolio', icon: 'i-lucide-layout-dashboard' },
     { id: 'reasoning', label: 'Reasoning', icon: 'i-lucide-brain' },
     { id: 'learnings', label: 'Learnings', icon: 'i-lucide-graduation-cap' },


### PR DESCRIPTION
## Summary

Two related structural changes Dan asked for during the final-day sweep:

### 1. Stricter gating

Wrap `Generate` and `Reasoning` in `WalletGate`. Discover-cluster pages (Home, Explore, Architecture, Corpus) stay open for anonymous visitors. Strategy + Position clusters now all require a passkey sign-in.

Each new gate has honest, page-specific copy describing what the user gets after connecting. Generate's old *"No wallet required to generate"* subhead is removed — the page isn't reachable without a wallet anymore.

| Page | Status |
|---|---|
| Home | open |
| Explore | open |
| Architecture | open |
| Corpus | open |
| **Generate** | **gated (new)** |
| Library | gated |
| Portfolio | gated |
| **Reasoning** | **gated (new)** |
| Learnings | gated |

### 2. Sidebar reorganization

Split the 9 nav items into 3 named groups that mirror the gating boundary:

```
DISCOVER  →  Home · Explore · Architecture · Corpus    (open)
STRATEGY  →  Generate · Library                        (gated)
POSITION  →  Portfolio · Reasoning · Learnings         (gated)
```

`Layout.jsx` already supported grouped nav via the existing `nav-group-label` class — just populated the group names.

## Test plan

- [x] `npm run build` passes.
- [x] `npm run lint` clean.
- [ ] Manual after deploy: Generate and Reasoning both show the WalletGate when no wallet is connected. Generate's intro paragraph no longer mentions "No wallet required". Sidebar shows three small-caps section headers (Discover / Strategy / Position) with the right items under each.

## Anti-goals

- DO NOT change the WalletGate component itself — only how it's wired into App.jsx.
- DO NOT touch the backend rate-limits / auth — this is a frontend UX gate, not an API auth boundary.
- DO NOT remove Reasoning from the sidebar (it's surfaced under Position).

🤖 Generated with [Claude Code](https://claude.com/claude-code)