### PR TITLE
[URGENT][frontend] Per-device passkey username — unblock teammates + judges (closes #367)

### DIFF
--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -42,6 +42,10 @@ const arcTestnet = {
 // Demo-grade persistence. Per Circle docs, production should use httpOnly
 // cookies to mitigate XSS credential theft — out of scope for hackathon demo.
 const CREDENTIAL_STORAGE_KEY = 'archimedes_circle_credential'
+// Per-device username so Circle's server-side uniqueness check doesn't lock
+// out everyone after the first registrant (see issue #367). Generated on
+// first use; same key reused across sessions so MSCA address stays stable.
+const USERNAME_STORAGE_KEY = 'archimedes_circle_username'
 
 // True if a CLIENT_KEY was supplied at build time. The modal hides the
 // passkey option when this is false so we never show a broken button.
@@ -62,8 +66,30 @@ function saveCredential(credential) {
   } catch { /* storage unavailable */ }
 }
 
+// Returns the per-device username, generating + persisting one on first use.
+// Format: `archimedes-<8 hex chars>` — within Circle's 5-50 char and
+// [a-zA-Z0-9_@.:+-] constraints; 8 hex = 4 billion namespaces, collision-free
+// in practice across a hackathon team and any number of judges.
+function getOrCreateUsername() {
+  try {
+    const existing = localStorage.getItem(USERNAME_STORAGE_KEY)
+    if (existing) return existing
+    const suffix = (crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`)
+      .replace(/-/g, '')
+      .slice(0, 8)
+    const fresh = `archimedes-${suffix}`
+    localStorage.setItem(USERNAME_STORAGE_KEY, fresh)
+    return fresh
+  } catch {
+    return `archimedes-${Date.now()}`
+  }
+}
+
 export function clearCircleSession() {
-  try { localStorage.removeItem(CREDENTIAL_STORAGE_KEY) } catch { /* */ }
+  try {
+    localStorage.removeItem(CREDENTIAL_STORAGE_KEY)
+    localStorage.removeItem(USERNAME_STORAGE_KEY)
+  } catch { /* */ }
 }
 
 // Returns true if a previously-registered passkey is on file for this
@@ -105,11 +131,14 @@ function friendlyPasskeyError(err) {
 // Username constraint per Circle API: 5-50 chars, [a-zA-Z0-9_@.:+-]+ only.
 // Spaces are rejected; 'Archimedes user' (the old default) failed every
 // first-time signup with "The username is invalid."
-export async function connectCirclePasskey({ mode = 'auto', username = 'archimedes' } = {}) {
+// Username is per-device (see getOrCreateUsername) so Circle's server-side
+// uniqueness check doesn't collide across teammates / judges — issue #367.
+export async function connectCirclePasskey({ mode = 'auto', username } = {}) {
   if (!circlePasskeyEnabled()) {
     throw new Error('Circle passkey wallet is not configured (missing VITE_CIRCLE_CLIENT_KEY).')
   }
 
+  const resolvedUsername = username ?? getOrCreateUsername()
   const stored = loadStoredCredential()
   let resolvedMode = mode === 'auto'
     ? (stored ? WebAuthnMode.Login : WebAuthnMode.Register)
@@ -125,7 +154,7 @@ export async function connectCirclePasskey({ mode = 'auto', username = 'archimed
     credential = await toWebAuthnCredential({
       transport: passkeyTransport,
       mode: resolvedMode,
-      username,
+      username: resolvedUsername,
       credentialId: resolvedMode === WebAuthnMode.Login ? stored?.id : undefined,
     })
   } catch (err) {
@@ -143,7 +172,7 @@ export async function connectCirclePasskey({ mode = 'auto', username = 'archimed
         credential = await toWebAuthnCredential({
           transport: passkeyTransport,
           mode: WebAuthnMode.Login,
-          username,
+          username: resolvedUsername,
         })
       } catch (retryErr) {
         throw new Error(friendlyPasskeyError(retryErr), { cause: retryErr })


### PR DESCRIPTION
## Demo-blocker fix

Hardcoded `username = 'archimedes'` at `ui/src/circle-wallet.js:108` locks out **everyone but Dan** (the first registrant). On every subsequent attempt — teammates, judges, anyone — Circle's server returns "username is duplicated"; the auto-fallback then tries Login but there's no local credential, so Safari shows:

> "You don't have any passwords or passkeys saved for this website."

I reproduced this on my own Mac at ~01:58 TR time tonight. With the final demo today, this is the single biggest visible bug.

Closes #367.

## Fix

Generate a per-device username on first use and persist to localStorage:

- New `USERNAME_STORAGE_KEY = 'archimedes_circle_username'`
- New `getOrCreateUsername()` — returns `archimedes-<8 hex>`, stable across sessions
- `connectCirclePasskey()` default changes from `username = 'archimedes'` to `username` (undefined), falling back to `getOrCreateUsername()` when caller doesn't pass one
- `clearCircleSession()` now also removes the username key

## Why this is safe to ship now

- Dan's existing flow is **unchanged**: he has `archimedes_circle_credential` in localStorage → `loadStoredCredential()` returns truthy → Login mode is picked first → he never hits the Register-then-fallback path. Zero regression for the only person who currently has it working.
- Username format `archimedes-<8 hex>` is well within Circle's 5-50 char + `[a-zA-Z0-9_@.:+-]+` constraint (verified against the spec comment at line 105).
- 8 hex chars = 4 billion namespaces — no realistic collision risk across the team + judges.
- Single file, ~30 line diff, no API contract changes.

## Test plan

After deploy:

- [ ] Önder on Safari/Mac: click "Sign in with Passkey" → **Touch ID prompt appears** (Register mode), MSCA address displays in header
- [ ] Reload page → click again → no prompt or quick re-auth, **same MSCA address**
- [ ] Marten on Chrome/Bremen: same — first click Registers, second Logs in
- [ ] Dan on his Mac: still works (existing credential takes Login path)
- [ ] "Disconnect" then click passkey again → fresh Register flow (since `clearCircleSession()` clears both keys)

## Deploy note

This needs the build-on-deploy CI to rebuild the nginx/frontend container. No env var changes; existing `VITE_CIRCLE_CLIENT_KEY` is sufficient.