### PR TITLE
[frontend] Honest copy: align wallet-gate messaging + corpus count with what the API returns

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -198,7 +198,7 @@ export default function App() {
         <WalletGate
           walletAddr={walletAddr}
           pageName="Generate"
-          description="Generate uses an LLM-powered multi-agent pipeline against a 9,873-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
+          description="Generate uses an LLM-powered multi-agent pipeline against a 1,014-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
           onConnect={openConnectModal}
         >
           <Generate onNavigate={navigateToPage} />

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -7,7 +7,7 @@ const AGENTS = [
   {
     name: 'Strategy Generation Agent',
     role: 'What should be done?',
-    desc: 'Retrieves relevant papers from a 9,873-paper q-fin corpus, reads current market context, and synthesizes a candidate strategy that passes the rigor gate.',
+    desc: 'Retrieves relevant papers from a 1,014-paper q-fin corpus, reads current market context, and synthesizes a candidate strategy that passes the rigor gate.',
     subagents: [
       { name: 'Paper Retrieval', detail: 'SPECTER2 nearest-neighbour + KG entity walk' },
       { name: 'Market Context', detail: 'Regime classifier + on-chain oracle + price history' },
@@ -84,7 +84,7 @@ const MEMORY_LAYERS = [
   {
     tag: 'E',
     name: 'Semantic knowledge',
-    substrate: 'q-fin corpus (9,873 papers, SPECTER2 + clusters + KG)',
+    substrate: 'q-fin corpus (1,014 papers, SPECTER2 + clusters + KG)',
     lifetime: 'Persistent',
     why: 'The substrate the Strategy Generation Agent retrieves from.',
   },
@@ -106,7 +106,7 @@ function PageHeader() {
         paper-anchored, rigor-gated, and auditable end to end.
       </p>
       <p className="body" style={{ color: 'var(--text-3)' }}>
-        Three top-level agents, six memory layers, a 9,873-paper q-fin corpus, and the{' '}
+        Three top-level agents, six memory layers, a 1,014-paper q-fin corpus, and the{' '}
         <code>ReasoningTraceRegistry</code> on Arc anchoring every decision.
       </p>
     </div>
@@ -117,7 +117,7 @@ function HeroStrip() {
   const stats = [
     { n: '3', l: 'Top-level agents', s: 'Generation · Construction · Execution' },
     { n: '6', l: 'Memory layers', s: 'KV cache → on-chain ground truth' },
-    { n: '9,873', l: 'q-fin papers', s: 'SPECTER2 + clusters + KG' },
+    { n: '1,014', l: 'q-fin papers', s: 'SPECTER2 + clusters + KG' },
     { n: '10', l: 'Smart contracts', s: 'Deployed on Arc testnet' },
   ]
   return (
@@ -258,18 +258,18 @@ function CorpusPanel() {
     <div className="card p-5 mb-7">
       <div className="label mb-3">The q-fin corpus — Layer E in detail</div>
       <p className="body mb-4">
-        9,873 academic papers (arXiv preprints across q-fin, ML, math, and agentic AI)
+        1,014 academic papers (arXiv preprints across q-fin, ML, math, and agentic AI),
         ingested via PyMuPDF, embedded with SPECTER2, clustered with HDBSCAN, and linked
-        with REBEL + SciSpacy into a knowledge graph. The Strategy Generation Agent's
+        with REBEL + SciSpacy into a knowledge graph. The Strategy Generation Agent's{' '}
         <strong>Paper Retrieval</strong> sub-agent uses this substrate every time you submit
         a brief.
       </p>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         {[
-          { n: '5,000', l: 'q-fin foundations', s: 'arxiv q-fin.*' },
-          { n: '2,000', l: 'ML for finance', s: 'cs.LG + stat.ML' },
-          { n: '500', l: 'Agentic AI', s: 'TradingAgents, Xia, StockBench, …' },
-          { n: '1,500', l: 'Mathematics', s: 'optimization · probability · stats' },
+          { n: '120', l: 'Mathematical Finance', s: 'arxiv q-fin.MF' },
+          { n: '119', l: 'Risk Management', s: 'arxiv q-fin.RM' },
+          { n: '107', l: 'Computational Finance', s: 'arxiv q-fin.CP' },
+          { n: '104', l: 'Statistical Finance', s: 'arxiv q-fin.ST' },
         ].map(b => (
           <div key={b.l} className="card-flat p-3">
             <div className="font-bold" style={{ fontSize: '1.1rem' }}>{b.n}</div>
@@ -279,8 +279,9 @@ function CorpusPanel() {
         ))}
       </div>
       <p className="caption mt-3" style={{ color: 'var(--text-3)' }}>
-        Seed target: ~10,000 papers. Currently ingested: 9,873 — REBEL knowledge-graph extraction
-        on the full set runs as we expand the corpus.
+        1,014 papers ingested across 41 categories (top four shown above). Manifest seed
+        target is ~10,000 — the remainder hydrate into Postgres incrementally as we expand
+        the corpus.
       </p>
     </div>
   )
@@ -342,8 +343,8 @@ function CallToAction({ onNavigate }) {
     <div className="card p-5 text-center">
       <h3 className="serif mb-2" style={{ fontSize: '1.4rem' }}>Ready to try it?</h3>
       <p className="body mb-4" style={{ color: 'var(--text-3)', maxWidth: 520, margin: '0 auto 16px' }}>
-        Describe a strategy in plain English. The pipeline above runs on your brief — no
-        wallet required to generate; wallet only needed to deploy a vault.
+        Describe a strategy in plain English. Sign in with a passkey to generate — no
+        browser extension needed; deploying into a vault uses free testnet USDC.
       </p>
       <div className="flex justify-center gap-3 flex-wrap">
         <button className="btn btn-primary" onClick={() => onNavigate?.('generate')}>

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -252,7 +252,7 @@ export default function Generate({ onNavigate }) {
               <div className="label mb-2 mt-3">Architecture</div>
               <p className="body mb-3">
                 <strong>Strategy Generation Agent</strong> retrieves relevant papers from a
-                9,873-paper q-fin corpus (SPECTER2 embeddings + clusters), reads current market
+                1,014-paper q-fin corpus (SPECTER2 embeddings + clusters), reads current market
                 context, and synthesizes a candidate strategy. <strong>Portfolio Construction
                 Agent</strong> picks assets, sizes them with Kelly + risk parity, and stress-tests
                 across six scenarios. After you sign to deploy, the <strong>Live Execution

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -43,7 +43,8 @@ export default function Landing({ onNavigate }) {
             </button>
           </div>
           <p className="caption mt-4 text-[var(--text-4)]">
-            No wallet needed to generate. Wallet only required to deposit into a vault.
+            Sign in with a passkey to generate — no browser extension needed.
+            Deploying into a vault is free testnet USDC from the Circle faucet.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
Two stale facts surfaced during the dress-rehearsal walkthrough:

1. **Landing + Architecture said \"no wallet required to generate\"** — true pre-#365, but the WalletGate around Generate makes it false now. Replaced with: *\"Sign in with a passkey to generate — no browser extension needed. Deploying into a vault is free testnet USDC from the Circle faucet.\"*

2. **Corpus count mismatch** — Architecture hardcoded **9,873** (manifest seed count); \`/api/corpus/overview\` returns **\`total_papers: 1014\`** (papers actually ingested into Postgres with abstract + metadata); Corpus Explorer header already shows 1,014. Architecture now matches. Closing footnote still mentions the 10K manifest target so the gap is visible, not hidden — *\"1,014 papers ingested across 41 categories (top four shown above). Manifest seed target is ~10,000 — the remainder hydrate into Postgres incrementally as we expand the corpus.\"*

Also replaced the aspirational 5K / 2K / 500 / 1.5K corpus breakdown with the **real top-4 categories** from \`/api/corpus/overview\`:
- Mathematical Finance (q-fin.MF) — 120
- Risk Management (q-fin.RM) — 119
- Computational Finance (q-fin.CP) — 107
- Statistical Finance (q-fin.ST) — 104

## Why
A judge will read Landing → Architecture → Corpus and notice within seconds that \"9,873 papers\" doesn't square with \"1,014 papers found\" on the Catalog page. Same for the wallet copy. Both are 5-minute fixes; both make the demo more credible.

## Files touched
- \`ui/src/components/Landing.jsx\` — bottom-of-hero caption
- \`ui/src/components/Architecture.jsx\` — 5 sites for 9,873, 1 site for the stale CTA, 1 corpus breakdown card grid
- \`ui/src/components/Generate.jsx\` — collapsible architecture footnote
- \`ui/src/App.jsx\` — Generate WalletGate description

## Test plan
- [ ] Lint + build green (verified locally)
- [ ] Live: Landing CTA caption reads new copy
- [ ] Live: Architecture / Generate / WalletGate descriptions all say 1,014, not 9,873
- [ ] Live: Architecture corpus card grid shows real category names (Math Finance, Risk Mgmt, etc.) with real counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)