### PR TITLE
[frontend] Allow vault deploy for strategies that fail rigor gate

### DIFF
--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -143,21 +143,20 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
             Time-bound, non-custodial execution. Funds stay in an ERC-4626 vault
             you control; the agent has rebalance authority only, no withdraw.
             {!walletAddr && <> Connect a wallet (top right) to enable deployment.</>}
-            {!passingRigor && s.passes_rigor_gate === false && <> Rigor gate failed — deployment is intentionally disabled.</>}
+            {s.passes_rigor_gate === false && <> This strategy did not pass the rigor gate — deploy at your own risk.</>}
           </p>
         </div>
         <button
           className="btn btn-primary"
           onClick={() => setDeployOpen(true)}
-          disabled={!walletAddr || s.passes_rigor_gate === false}
+          disabled={!walletAddr}
           style={
-            !walletAddr || s.passes_rigor_gate === false
+            !walletAddr
               ? { opacity: 0.45, cursor: 'not-allowed', filter: 'grayscale(0.6)' }
               : undefined
           }
           title={
             !walletAddr ? 'Connect wallet to deploy' :
-            s.passes_rigor_gate === false ? 'Rigor gate failed — deployment disabled' :
             'Open deploy modal'
           }
         >


### PR DESCRIPTION
## Summary
Ungate the **Deploy as Vault** CTA on the strategy passport so any strategy is deployable once a wallet is connected, regardless of rigor verdict. Previously the button was disabled when `passes_rigor_gate === false`, which (combined with most generated strategies sitting at `null`/failed) left the demo with nothing deployable.

## Changes (`ui/src/components/StrategyPassport.jsx`)
- Deploy `disabled` gate: `!walletAddr || passes_rigor_gate === false` → `!walletAddr`
- Button style/title simplified to the wallet-only condition
- Caption for failed strategies: "deployment is intentionally disabled" → "did not pass the rigor gate — deploy at your own risk"
- Rigor verdict panel + "rigor gate not passed" tag left intact (honest signal preserved)

## Verify
- Passport for a strategy with `passes_rigor_gate === false`: Deploy button enabled (wallet connected), risk caption shown, tag still reads "not passed"
- `npx eslint src/components/StrategyPassport.jsx` → clean

## Anti-goals
- No change to the rigor verdict computation or the tag rendering
- No change to backend / contract deploy path

## ⚠️ Decision note
This **overrides documented principle #5** in `CLAUDE.md` (deploy gated on rigor verdict / "rigor is the wedge"). Intentional per product call to unblock the demo. Flagging for team review — if kept, the CLAUDE.md principle should be updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)