### PR TITLE
[frontend] Wallet faucet menu + clickable Generate cards + sidebar Home + Learnings roadmap badge

### DIFF
--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -231,61 +231,73 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
             gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
             gap: 12,
           }}>
-            {draftedCandidates.map(c => (
-              <div
-                key={c.candidate_id}
-                className="card"
-                style={{
-                  padding: 16,
-                  border: `2px solid ${c.regime === 'bull' ? 'var(--positive, #22c55e)' : c.regime === 'bear' ? 'var(--negative, #ef4444)' : 'var(--glass-border)'}`,
-                }}
-              >
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                  <span style={{
-                    display: 'inline-block',
-                    padding: '2px 10px',
-                    borderRadius: 999,
-                    fontSize: '0.75rem',
-                    fontWeight: 700,
-                    background: c.regime === 'bull' ? 'rgba(34,197,94,0.15)' : c.regime === 'bear' ? 'rgba(239,68,68,0.15)' : 'var(--bg-2)',
-                    color: c.regime === 'bull' ? 'var(--positive, #22c55e)' : c.regime === 'bear' ? 'var(--negative, #ef4444)' : 'var(--text-2)',
-                  }}>
-                    {c.regime === 'bull' ? '🟢 Bull' : c.regime === 'bear' ? '🔴 Bear' : 'Neutral'}
-                  </span>
-                  <span className="label" style={{ fontSize: '0.85rem' }}>{c.strategy_name}</span>
-                </div>
-                {c.weights_preview && (
-                  <div className="caption" style={{ marginBottom: 8 }}>
-                    {Object.entries(c.weights_preview)
-                      .sort(([, a], [, b]) => b - a)
-                      .map(([sym, w]) => `${sym} ${(w * 100).toFixed(0)}%`)
-                      .join(' · ')}
+            {draftedCandidates.map(c => {
+              // Once the candidate has a strategy_id, the entire card becomes
+              // a navigation affordance to its Library passport — the button
+              // below is preserved as a redundant explicit CTA for users who
+              // expect a labelled trigger. The button stops propagation so
+              // its click isn't double-counted.
+              const navigateToLibrary = () => {
+                localStorage.removeItem('archimedes:currentJobId')
+                if (onNavigate) {
+                  onNavigate('library', { highlight: c.strategy_id, tab: 'generated' })
+                } else {
+                  window.location.hash = `#/library?highlight=${c.strategy_id}`
+                }
+              }
+              const clickable = Boolean(c.strategy_id)
+              return (
+                <div
+                  key={c.candidate_id}
+                  className="card"
+                  onClick={clickable ? navigateToLibrary : undefined}
+                  onKeyDown={clickable ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigateToLibrary() } } : undefined}
+                  role={clickable ? 'link' : undefined}
+                  tabIndex={clickable ? 0 : undefined}
+                  aria-label={clickable ? `Open ${c.strategy_name} in Library` : undefined}
+                  style={{
+                    padding: 16,
+                    border: `2px solid ${c.regime === 'bull' ? 'var(--positive, #22c55e)' : c.regime === 'bear' ? 'var(--negative, #ef4444)' : 'var(--glass-border)'}`,
+                    cursor: clickable ? 'pointer' : 'default',
+                    transition: 'transform 0.12s ease-out, border-color 0.12s ease-out',
+                  }}
+                  onMouseEnter={clickable ? (e) => { e.currentTarget.style.transform = 'translateY(-1px)' } : undefined}
+                  onMouseLeave={clickable ? (e) => { e.currentTarget.style.transform = 'translateY(0)' } : undefined}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                    <span style={{
+                      display: 'inline-block',
+                      padding: '2px 10px',
+                      borderRadius: 999,
+                      fontSize: '0.75rem',
+                      fontWeight: 700,
+                      background: c.regime === 'bull' ? 'rgba(34,197,94,0.15)' : c.regime === 'bear' ? 'rgba(239,68,68,0.15)' : 'var(--bg-2)',
+                      color: c.regime === 'bull' ? 'var(--positive, #22c55e)' : c.regime === 'bear' ? 'var(--negative, #ef4444)' : 'var(--text-2)',
+                    }}>
+                      {c.regime === 'bull' ? '🟢 Bull' : c.regime === 'bear' ? '🔴 Bear' : 'Neutral'}
+                    </span>
+                    <span className="label" style={{ fontSize: '0.85rem' }}>{c.strategy_name}</span>
                   </div>
-                )}
-                {c.strategy_id && (
-                  <button
-                    className="btn btn-primary btn-sm"
-                    style={{ width: '100%', marginTop: 4 }}
-                    onClick={() => {
-                      localStorage.removeItem('archimedes:currentJobId')
-                      // Use the React-router-aware navigation passed in from
-                      // the parent Generate page so App.jsx's state machine
-                      // (page + highlightStrategyId + activeTab) updates
-                      // properly. The previous window.location.hash assignment
-                      // bypassed React state and left the Library page rendering
-                      // its initial state without the highlight scroll.
-                      if (onNavigate) {
-                        onNavigate('library', { highlight: c.strategy_id, tab: 'generated' })
-                      } else {
-                        window.location.hash = `#/library?highlight=${c.strategy_id}`
-                      }
-                    }}
-                  >
-                    View in Library →
-                  </button>
-                )}
-              </div>
-            ))}
+                  {c.weights_preview && (
+                    <div className="caption" style={{ marginBottom: 8 }}>
+                      {Object.entries(c.weights_preview)
+                        .sort(([, a], [, b]) => b - a)
+                        .map(([sym, w]) => `${sym} ${(w * 100).toFixed(0)}%`)
+                        .join(' · ')}
+                    </div>
+                  )}
+                  {c.strategy_id && (
+                    <button
+                      className="btn btn-primary btn-sm"
+                      style={{ width: '100%', marginTop: 4 }}
+                      onClick={(e) => { e.stopPropagation(); navigateToLibrary() }}
+                    >
+                      View in Library →
+                    </button>
+                  )}
+                </div>
+              )
+            })}
           </div>
           {failedRegimes.length > 0 && (
             <div className="info-box warning" style={{ marginTop: 12 }}>

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -4,17 +4,25 @@ import Breadcrumbs from './Breadcrumbs'
 import WelcomeProfileModal from './WelcomeProfileModal'
 import { NEW_CONTRACTS } from '../config'
 
-// Sidebar groups split the 9 surfaces along the gating boundary:
+// Sidebar groups separate Home (anchor / landing) from the three product-state
+// bands. Empty group label is intentional for the Home entry — it renders as a
+// header-less section so Home reads as the top-of-shell anchor, not a peer of
+// the other groups. The three labelled groups split the remaining surfaces
+// along the gating boundary:
 //   DISCOVER — open to anonymous visitors (no wallet needed)
 //   STRATEGY — wallet-gated: generate + your saved strategies
 //   POSITION — wallet-gated: deployed vaults, on-chain audit, post-hoc review
-// The group label renders as a small-caps section header in the sidebar.
+// Item order inside DISCOVER (Explore → Corpus → Architecture) follows the
+// natural user-onboarding read: browse the seed strategies first, see the
+// substrate they're drawn from second, see the system that fuses them third.
 const NAV = [
+  { group: null, items: [
+    { id: 'landing', label: 'Home', icon: 'i-lucide-home' },
+  ]},
   { group: 'Discover', items: [
-    { id: 'landing',      label: 'Home',         icon: 'i-lucide-home' },
     { id: 'explore',      label: 'Explore',      icon: 'i-lucide-compass' },
-    { id: 'architecture', label: 'Architecture', icon: 'i-lucide-network' },
     { id: 'corpus',       label: 'Corpus',       icon: 'i-lucide-library' },
+    { id: 'architecture', label: 'Architecture', icon: 'i-lucide-network' },
   ]},
   { group: 'Strategy', items: [
     { id: 'generate', label: 'Generate', icon: 'i-lucide-sparkles' },

--- a/ui/src/components/Learnings.jsx
+++ b/ui/src/components/Learnings.jsx
@@ -13,15 +13,44 @@ export default function Learnings({ onNavigate }) {
   return (
     <div>
       <div className="max-w-[720px] mb-7">
-        <h2 className="serif text-[2rem] mb-2.5">Learnings</h2>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10, flexWrap: 'wrap' }}>
+          <h2 className="serif text-[2rem]" style={{ margin: 0 }}>Learnings</h2>
+          <span
+            className="tag"
+            style={{
+              fontSize: '0.72rem',
+              fontWeight: 700,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              padding: '4px 10px',
+              background: 'rgba(96, 165, 250, 0.12)',
+              border: '1px solid rgba(96, 165, 250, 0.35)',
+              color: 'var(--info, #60A5FA)',
+            }}
+            title="This page is a roadmap surface — the runtime that populates it lands post-hackathon."
+          >
+            Roadmap · post-hackathon
+          </span>
+        </div>
         <p className="body mb-2.5">
-          Strategies you've deployed — winners and losers, both first-class — with the
-          agent's reasoning available for each rebalance. The whole point: develop your
-          own intuition rather than treat the system as a black box.
+          <strong>This page is a roadmap preview, not a shipped feature.</strong>{' '}
+          The intent: surface the strategies you've deployed — winners and losers,
+          both first-class — with the agent's reasoning available for each rebalance.
+          Develop your own intuition rather than treat the system as a black box.
         </p>
         <p className="body text-[var(--text-3)]">
-          Losing trades are not hidden. Silently rotating away from losses is the failure
-          mode of every "AI fund" — we explicitly don't.
+          Why it isn't live yet: the rebalance-trace history needs to accumulate
+          before per-strategy winner/loser splits become meaningful. The data
+          model and reasoning surface are in place (see <a
+            href="/reasoning"
+            onClick={(e) => { e.preventDefault(); onNavigate?.('reasoning') }}
+            style={{ color: 'var(--accent)' }}
+          >Reasoning</a>); the per-strategy aggregation view lands after the
+          hackathon as a thin layer on top.
+        </p>
+        <p className="body text-[var(--text-3)]">
+          Losing trades are not hidden when this lands. Silently rotating away from
+          losses is the failure mode of every "AI fund" — we explicitly don't.
         </p>
       </div>
 

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -218,6 +218,34 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
               <span className="i-lucide-user-pen" style={{ width: 16, height: 16 }} />
               <span>Profile</span>
             </button>
+            {/* Faucet — always visible in the dropdown so the user can top up
+                regardless of current balance. Opens in a new tab so the
+                Archimedes session isn't unloaded. The conditional inline link
+                above (balance < 1) is kept as the urgent-state nudge; this is
+                the durable entry point. */}
+            <a
+              role="menuitem"
+              href="https://faucet.circle.com/"
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => setMenuOpen(false)}
+              title="Get test USDC from Circle's faucet (20 USDC every 2h on Arc testnet)"
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                width: '100%', padding: '8px 10px', textAlign: 'left',
+                background: 'transparent', border: 'none', color: 'var(--text-1)',
+                fontSize: '0.85rem', cursor: 'pointer', borderRadius: 6,
+                textDecoration: 'none',
+              }}
+            >
+              <span className="i-lucide-droplets" style={{ width: 16, height: 16 }} />
+              <span style={{ flex: 1 }}>Faucet</span>
+              <span
+                className="i-lucide-external-link"
+                style={{ width: 12, height: 12, color: 'var(--text-4)' }}
+                aria-hidden="true"
+              />
+            </a>
             <button
               type="button"
               role="menuitem"


### PR DESCRIPTION
## Summary

Four polish items that came up during the demo dress rehearsal — none overlap with PR #375 (Library cleanup) or the other Claude session's submission-polish bundle (color/text/Portfolio/Reasoning compaction).

| # | File | What |
|---|---|---|
| 1 | `WalletConnect.jsx` | Permanent **Faucet** entry in the wallet dropdown |
| 2 | `GenerationStream.jsx` | Dual-regime candidate cards are now **wholly clickable** to Library |
| 3 | `Layout.jsx` | Sidebar regroup: **Home** alone at top, then DISCOVER / STRATEGY / POSITION |
| 4 | `Learnings.jsx` | **Roadmap · post-hackathon** badge + reframed leading copy |

## Details

### 1. Faucet always visible in the wallet menu

Previously the faucet link was a conditional inline link inside the balance row, rendered only when `balance !== null && balance < 1`. Users with funded wallets (the demo path) never saw it. Adds a permanent menu item between Profile and Disconnect with `target="_blank"` + external-link glyph so the Archimedes session is preserved. The existing inline low-balance nudge stays as the urgent-state affordance.

### 2. Whole-card click navigation on Generate

The dual-regime candidate cards previously required clicking the small "View in Library →" button. Now the entire card is clickable (`role=link`, keyboard-accessible via Enter/Space, hover lift via `translateY(-1px)`). The button is preserved as a redundant explicit CTA with `e.stopPropagation()` so its click isn't double-counted. Card is only clickable once `strategy_id` exists (post-persist event).

### 3. Sidebar Home anchor + DISCOVER reorder

Per Dan's request:
- **Home** alone at top, no group header (uses empty `group: null` in `NAV` array; the existing render conditional `group.group && <div className="nav-group-label">…</div>` handles this without CSS changes)
- **DISCOVER** items reordered to Explore → Corpus → Architecture (natural onboarding read: seed strategies → substrate → fusion system)
- STRATEGY and POSITION unchanged

### 4. Learnings roadmap badge

The page already had an honest "Nothing to show yet" empty state, but the heading didn't signal "future feature" strongly enough — a user landing here cold could read it as broken. Adds:
- Info-blue **"Roadmap · post-hackathon"** chip next to the H2
- Leading paragraph that explicitly says this is roadmap, not shipped
- Honest "why isn't it live yet" framing with a cross-link to `/reasoning` (which IS the shipped trace surface)

## Test plan

- [ ] Build passes (CI)
- [ ] Lint clean (CI)
- [ ] Live: open wallet dropdown → Faucet item visible regardless of balance; clicking opens faucet.circle.com in a new tab
- [ ] Live: Generate → submit a brief → wait for dual-regime cards → click anywhere on a card (not just the button) → lands on `/library?highlight=<id>&tab=generated`
- [ ] Live: sidebar shows Home alone at top, then DISCOVER (Explore/Corpus/Architecture), STRATEGY, POSITION
- [ ] Live: Learnings page heading shows "Learnings" + "Roadmap · post-hackathon" chip

## Coordination notes

- **No overlap with PR #375** (Strategies.jsx, Library cleanup) — different files
- **No overlap with the other Claude session's submission-polish bundle** (App.css, Portfolio.jsx, Reasoning.jsx, StrategyPassport.jsx deploy gate) — different files
- Branched off `main` HEAD `79650f8` (post-#373 SPEC-1 evidence merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
