### PR TITLE
[backend] Fix test_save_regime_from_values to expect dynamic confidence post-fabc57f

### DIFF
--- a/backend/tests/services/test_redis_state.py
+++ b/backend/tests/services/test_redis_state.py
@@ -86,7 +86,19 @@ class TestRegime:
         fake.set.assert_awaited_once()
         payload = json.loads(fake.set.await_args.args[1])
         assert payload["regime"] == "transition"
-        assert payload["confidence"] == 0.6  # 1 - 0.4
+        # Dynamic confidence formula (introduced in commit fabc57f, "Bug sweep:
+        # dynamic regime confidence + cleanup junk constants"): replaces the
+        # earlier `1 - flat_pct` simple form with a dispersion-aware
+        # consensus signal. With flat_pct=0.4 and the empty-signals fixture:
+        #   vote_ratio = 1.0 - 0.4 = 0.6
+        #   directional = []          (signals list empty)
+        #   avg_strength = 0.0        (no directional signals)
+        #   dispersion_penalty = 0.0  (< 2 weights)
+        #   dyn = clamp(0.6 * (0.5 + 0.5 * 0.0) - 0.0, 0.05, 0.99) = 0.3
+        # Keeping this expectation explicit + commented so a future change to
+        # the formula is caught here (rather than silently producing a wrong
+        # confidence on every agent tick).
+        assert payload["confidence"] == 0.3
         assert payload["source"] == "strategy_consensus"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

One-line test fix to unblock #287 + #378 (and any future PR rebased onto `main` HEAD).

## Root cause

Commit `fabc57f` ("[backend] Bug sweep: dynamic regime confidence + cleanup junk constants") landed directly on `main` and changed the confidence formula in `RedisStateStore.save_regime_from_values`:

| Before | After |
|---|---|
| `confidence = 1 - flat_pct` (simple) | dispersion-aware consensus formula |

The test in `test_redis_state.py::TestRegime::test_save_regime_from_values` was not updated. With the fixture (`flat_pct=0.4`, empty signal list), the new dynamic formula returns **0.3**, not 0.6.

Every PR rebased onto `fabc57f` fails CI:

```
FAILED backend/tests/services/test_redis_state.py::TestRegime::test_save_regime_from_values - assert 0.3 == 0.6
======= 1 failed, 886 passed, 2 skipped =======
```

## Fix

Update the expected value to **0.3** and add an inline derivation comment showing the formula → expected value chain, so the test fails loudly if anyone changes the formula again without updating expectations.

## Anti-goals
- DO NOT loosen the assertion to a range. Hardcoded scalar with a derivation comment is the highest-signal regression detector.
- DO NOT touch the production formula. The dynamic-confidence change is the intended behavior per the originating commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
