### PR TITLE
[mixed] Pick up 4 polish fixes left uncommitted in the primary worktree

### DIFF
--- a/backend/archimedes/services/chat_service.py
+++ b/backend/archimedes/services/chat_service.py
@@ -244,12 +244,22 @@ class ChatService:
         """
         parts = []
         try:
+            from sqlalchemy import func
+
             from archimedes.db import get_session
             from archimedes.models.chat import VaultMetadata
 
             session = get_session()
             try:
-                meta = session.query(VaultMetadata).filter(VaultMetadata.vault_address == vault_address).first()
+                # VaultMetadata rows can be inserted in checksum-case (see
+                # vaults_routes.py — no normalization at write). MetaMask hands
+                # checksum addresses to the chat route too. Compare lowercase
+                # to lowercase so the lookup actually finds the row.
+                meta = (
+                    session.query(VaultMetadata)
+                    .filter(func.lower(VaultMetadata.vault_address) == vault_address.lower())
+                    .first()
+                )
                 if meta:
                     parts.append(f"Vault name: {meta.name or vault_address[:10]}")
                     strategy_ids = meta.get_strategy_ids() if meta else []

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -265,7 +265,7 @@ export default function App() {
       >
         {renderPage()}
       </Layout>
-      <OnboardingTour open={tourOpen} onClose={() => { setTourOpen(false); try { localStorage.setItem('archimedes.onboarding.v1', 'completed') } catch {} }} setPage={navigateToPage} />
+      <OnboardingTour open={tourOpen} onClose={() => { setTourOpen(false); try { localStorage.setItem('archimedes.onboarding.v1', 'completed') } catch { /* private mode / SSR — non-fatal */ } }} setPage={navigateToPage} />
     </>
   )
 }

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -21,10 +21,20 @@ function fmtPct(v) {
   return `${(Number(v) * 100).toFixed(1)}%`
 }
 
-function statusTag(status) {
+function statusTag(status, passesRigor) {
+  // A "live" admin status combined with a failed rigor verdict shouldn't
+  // render green — the rigor verdict is the truthful signal. Match the
+  // Strategies.jsx pill rule (Issue #387) so the passport doesn't
+  // contradict the library page.
+  if (status === 'live' && passesRigor === false) return 'tag-muted'
   if (status === 'validated' || status === 'live') return 'tag-positive'
   if (status === 'rejected' || status === 'retired') return 'tag-muted'
   return 'tag-accent'
+}
+
+function statusLabel(status, passesRigor) {
+  if (status === 'live' && passesRigor === false) return 'Live (rigor failed)'
+  return (status || 'candidate').charAt(0).toUpperCase() + (status || 'candidate').slice(1)
 }
 
 // Derive a brief-specific display title. The unified passport table doesn't
@@ -125,7 +135,7 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
         </div>
         <div className="flex gap-2 items-center flex-wrap">
           {regime && <span className={`tag ${regime.cls}`}>{regime.label}</span>}
-          <span className={`tag ${statusTag(s.status)}`} style={{ textTransform: 'capitalize' }}>{s.status || 'candidate'}</span>
+          <span className={`tag ${statusTag(s.status, s.passes_rigor_gate)}`}>{statusLabel(s.status, s.passes_rigor_gate)}</span>
           {s.passes_rigor_gate === true && (
             <span className="tag tag-positive inline-flex items-center gap-1">
               <span className="i-lucide-check w-3.5 h-3.5" /> rigor gate passed

--- a/ui/src/components/VaultDetail.jsx
+++ b/ui/src/components/VaultDetail.jsx
@@ -192,7 +192,23 @@ export default function VaultDetail({ address, onBack }) {
       await w.writeContract({ address: USDC, abi: TOKEN_ABI, functionName: 'approve', args: [address, amount] })
       setStatus('Depositing…')
       const hash = await w.writeContract({ address, abi: VAULT_ABI, functionName: 'deposit', args: [amount, getAddress()] })
-      setStatus(`Deposited! TX: ${hash}`)
+      // Render TX hash as a clickable arcscan link (Issue #389 follow-up — Pi
+      // missed this in the original bundle). status is a ReactNode so we can
+      // mix string + <a>; the renderer at line 376 already passes through.
+      setStatus(
+        <span>
+          Deposited! TX:{' '}
+          <a
+            href={`https://testnet.arcscan.app/tx/${hash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mono"
+            style={{ color: 'var(--accent)' }}
+          >
+            {hash.slice(0, 10)}…{hash.slice(-6)} ↗
+          </a>
+        </span>
+      )
       setDepositAmt('')
       loadOnChain()
     } catch (err) { setStatus(err.shortMessage || err.message) }
@@ -243,7 +259,7 @@ export default function VaultDetail({ address, onBack }) {
             try {
               const connected = getAddress()
               if (connected && creator.toLowerCase() === connected.toLowerCase()) return 'Created by you'
-            } catch {}
+            } catch { /* getAddress() may throw if wallet hook isn't ready — fall through to hex */ }
             return shortAddr(creator)
           })()}</code></div>
         </div>


### PR DESCRIPTION
## Summary

A parallel session landed these four real fixes but never committed them. Found uncommitted in the primary worktree during cleanup; recovering before the worktree gets pruned. Each references a known issue and stays small + surgical.

## The four fixes

### `backend/archimedes/services/chat_service.py` — case-insensitive vault address lookup

\`VaultMetadata\` rows are written checksum-case (see \`vaults_routes.py\` — no normalization at write), MetaMask passes checksum addresses, but the existing chat-service query did a case-sensitive \`==\` compare. Every lookup silently missed the row. Now uses \`func.lower(VaultMetadata.vault_address) == vault_address.lower()\`.

### `ui/src/App.jsx` — annotate the empty `catch {}`

One-line lint-quiet on the empty catch around \`localStorage.setItem\` in OnboardingTour onClose. Comment carries the rationale (\"private mode / SSR — non-fatal\") so future readers know the swallow is intentional.

### `ui/src/components/StrategyPassport.jsx` — Issue #387 honest-rigor follow-through

A vault with \`status='live'\` AND \`passes_rigor_gate=false\` should NOT render a green pill; that would contradict what \`Strategies.jsx\` shows on the library page. New \`statusTag\` / \`statusLabel\` helpers render \"Live (rigor failed)\" muted in that case, matching the library rule.

### `ui/src/components/VaultDetail.jsx` — Issue #389 follow-up

Deposit TX hash now renders as a clickable arcscan link (\`https://testnet.arcscan.app/tx/...\`) instead of a raw string. \`status\` is already a ReactNode in the render path; this stops hiding the on-chain receipt one click deeper than it needs to be. Same diff annotates an empty \`catch\` on \`getAddress()\` with the swallow rationale.

## Out of scope

\`SUBMISSION-PACKET.md\` (untracked, 380 lines, dated May 25 22:29) is Dan's own submission notes — left alone.

## Test plan

- [x] \`ruff format --check\` clean (single-line lint changes only)
- [x] No backend behavior change beyond the case-insensitive query fix
- [ ] Live: deposit to a vault → status panel shows clickable arcscan link
- [ ] Live: a rigor-failed live vault on the passport renders \"Live (rigor failed)\" muted (#387 surface-follow-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)