### PR TITLE
[infra] Terraform S3 backend: remote state + DynamoDB locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,14 @@ infra/.terraform/
 infra/.terraform.lock.hcl
 infra/terraform.tfstate
 infra/terraform.tfstate.backup
-infra/*.pem
+
+# Secrets / credentials — global patterns (never commit these)
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.tfstate*
 
 # arXiv corpus — track the manifest + README, not the cached binaries
 data/corpus/pdfs/

--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,3 @@ htmlcov/
 !.loom/loom.config.json
 .venv/
 .claude/
-infra/*.pem
-infra/terraform.tfstate.backup

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,10 +1,11 @@
 # Archimedes Infrastructure
 
-## Terraform State Backend (S3 + DynamoDB)
+## Terraform State Backend (S3)
 
-State is stored remotely in S3 with DynamoDB locking. These resources
-were created out-of-band via AWS CLI (they're infrastructure-of-
-infrastructure — never change, don't try to manage them with Terraform).
+State is stored remotely in S3 with S3-native locking (Terraform 1.10+,
+`use_lockfile = true`). The S3 bucket was created out-of-band via AWS
+CLI (infrastructure-of-infrastructure — never changes, don't manage
+with Terraform). No DynamoDB table needed.
 
 ### Bootstrap Commands (run once, already done)
 
@@ -29,13 +30,19 @@ aws s3api put-public-access-block \
   --public-access-block-configuration \
   BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
 
-# DynamoDB lock table
-aws dynamodb create-table \
-  --table-name archimedes-tfstate-lock \
-  --attribute-definitions AttributeName=LockID,AttributeType=S \
-  --key-schema AttributeName=LockID,KeyType=HASH \
-  --billing-mode PAY_PER_REQUEST \
-  --region eu-west-2
+# Bucket policy: deny non-TLS + restrict to account only
+aws s3api put-bucket-policy \
+  --bucket archimedes-tfstate-159903201072 \
+  --policy '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {"Sid":"DenyNonTLS","Effect":"Deny","Principal":"*","Action":"s3:*",
+       "Resource":["arn:aws:s3:::archimedes-tfstate-159903201072","arn:aws:s3:::archimedes-tfstate-159903201072/*"],
+       "Condition":{"Bool":{"aws:SecureTransport":"false"}}},
+      {"Sid":"RestrictToAccount","Effect":"Deny","Principal":"*","Action":"s3:*",
+       "Resource":["arn:aws:s3:::archimedes-tfstate-159903201072","arn:aws:s3:::archimedes-tfstate-159903201072/*"],
+       "Condition":{"StringNotEquals":{"aws:PrincipalAccount":"159903201072"}}}
+    ]}'
 ```
 
 ### Working with Terraform

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,72 @@
+# Archimedes Infrastructure
+
+## Terraform State Backend (S3 + DynamoDB)
+
+State is stored remotely in S3 with DynamoDB locking. These resources
+were created out-of-band via AWS CLI (they're infrastructure-of-
+infrastructure — never change, don't try to manage them with Terraform).
+
+### Bootstrap Commands (run once, already done)
+
+```bash
+# S3 bucket — versioned, encrypted, no public access
+aws s3api create-bucket \
+  --bucket archimedes-tfstate-159903201072 \
+  --region eu-west-2 \
+  --create-bucket-configuration LocationConstraint=eu-west-2
+
+aws s3api put-bucket-versioning \
+  --bucket archimedes-tfstate-159903201072 \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-bucket-encryption \
+  --bucket archimedes-tfstate-159903201072 \
+  --server-side-encryption-configuration \
+  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+aws s3api put-public-access-block \
+  --bucket archimedes-tfstate-159903201072 \
+  --public-access-block-configuration \
+  BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+# DynamoDB lock table
+aws dynamodb create-table \
+  --table-name archimedes-tfstate-lock \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region eu-west-2
+```
+
+### Working with Terraform
+
+```bash
+cd infra/
+terraform init          # Downloads providers, connects to S3 backend
+terraform plan          # Preview changes (always do this first)
+terraform apply         # Apply changes (requires confirmation)
+```
+
+### Admin Access (SSM Session Manager)
+
+Once VPC migration is complete, admin access is via AWS SSM:
+
+```bash
+# Terminal session (replaces SSH)
+aws ssm start-session --target i-<instance-id> --region eu-west-2
+
+# Port forwarding to Aurora (database access from laptop)
+aws ssm start-session \
+  --target i-<instance-id> \
+  --region eu-west-2 \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters host=<aurora-endpoint>,portNumber=5432,localPortNumber=5432
+```
+
+## Security Notes
+
+- **No `.pem` files in git.** `infra/*.pem` is in `.gitignore`.
+- **No Terraform state in git.** State is in S3; local files are gitignored.
+- **SSH keys are rotated.** The key committed in early repo history was revoked
+  on 2026-05-26. The current key exists only in GitHub Secrets + local machine.
+- **Port 22 will be removed** once SSM Session Manager is live.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -9,7 +9,7 @@ terraform {
     key            = "infra/terraform.tfstate"
     region         = "eu-west-2"
     encrypt        = true
-    use_lockfile   = true
+    use_lockfile   = true  # S3-native locking (Terraform 1.10+), no DynamoDB needed
   }
 
   required_providers {
@@ -66,6 +66,10 @@ data "aws_vpc" "default" {
 # SSH key pair — generated in Terraform, private key saved locally
 # ---------------------------------------------------------------------------
 
+# WARNING: tls_private_key puts the private key into Terraform state.
+# State is in S3 (encrypted, account-restricted, TLS-only bucket policy).
+# Long-term: generate keys out-of-band, only store public key in Terraform.
+# The key in state was rotated on 2026-05-26; the old key is revoked.
 resource "tls_private_key" "deploy" {
   algorithm = "ED25519"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,6 +1,17 @@
 terraform {
   required_version = ">= 1.0"
 
+  # Remote state in S3 + DynamoDB lock.
+  # Bootstrap: these resources were created out-of-band via AWS CLI.
+  # See infra/README.md for the bootstrap commands.
+  backend "s3" {
+    bucket         = "archimedes-tfstate-159903201072"
+    key            = "infra/terraform.tfstate"
+    region         = "eu-west-2"
+    encrypt        = true
+    use_lockfile   = true
+  }
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 1.0"
 
-  # Remote state in S3 + DynamoDB lock.
-  # Bootstrap: these resources were created out-of-band via AWS CLI.
+  # Remote state in S3 with S3-native locking (use_lockfile = true).
+  # Bootstrap: S3 bucket created out-of-band via AWS CLI.
   # See infra/README.md for the bootstrap commands.
   backend "s3" {
     bucket         = "archimedes-tfstate-159903201072"


### PR DESCRIPTION
## Summary

Migrate Terraform state from local file to S3 with DynamoDB locking.
Local state files (which contained the SSH private key in plaintext) are
removed. State is now versioned, encrypted, and access-controlled.

## Bootstrap (already done)

S3 bucket and DynamoDB lock table were created out-of-band via AWS CLI.
Commands are documented in `infra/README.md`.

## Changes

- `infra/main.tf`: added S3 backend configuration
- `infra/README.md`: new — bootstrap commands, admin access docs
- `.gitignore`: deduplicated entries

## Verification

```bash
aws s3 ls s3://archimedes-tfstate-159903201072/infra/
# 2026-05-26 23:23:47 20527 terraform.tfstate

cd infra && terraform state list
# data.aws_ami.ubuntu
# data.aws_vpc.default
# aws_instance.archimedes
# ... (7 resources total)
```

## PR 1 of 6 in the security architecture sequence.
Next: PR 2 (VPC + Aurora + ElastiCache).