### PR TITLE
[backend] executor: skip USDC-denominated legs in rebalance (fixes #399 Bug 1)

### DIFF
--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -104,6 +104,13 @@ class ChainExecutor:
 
         for trade in trades:
             token_addr = chain_client.to_checksum(trade.token_address)
+            # A USDC-denominated leg (e.g. the cash / TREASURY allocation) needs
+            # no swap — it is already in the settlement asset. getPool(USDC, USDC)
+            # has no pool and would otherwise raise InsufficientLiquidityError,
+            # aborting the whole rebalance before any fundable leg is reached
+            # (issue #399). Skip it.
+            if token_addr == usdc_addr:
+                continue
             try:
                 pool_addr = await router.functions.getPool(usdc_addr, token_addr).call()
                 if pool_addr == "0x" + "0" * 40:
@@ -155,6 +162,13 @@ class ChainExecutor:
           - BUY (USDC → synth): amount in USDC raw (6 decimals)
           - SELL (synth → USDC): amount in synth raw (18 decimals)
         """
+        # Drop USDC-denominated legs (cash / TREASURY allocation): holding USDC
+        # is already the settlement asset, so there is no swap to make and no
+        # USDC/USDC pool to find (issue #399). Filter once so both the liquidity
+        # check and the swap construction below see only real swap legs.
+        usdc_addr = chain_client.to_checksum(chain_client.settings.usdc_address)
+        trades = [t for t in trades if chain_client.to_checksum(t.token_address) != usdc_addr]
+
         # Pre-flight liquidity check (raises InsufficientLiquidityError)
         await self._validate_trade_liquidity(trades)
 

--- a/backend/tests/chain/test_executor_usdc_leg.py
+++ b/backend/tests/chain/test_executor_usdc_leg.py
@@ -1,0 +1,81 @@
+"""Executor: USDC-denominated legs must not be treated as swaps (issue #399).
+
+A cash / TREASURY allocation maps to USDC itself. The executor must not call
+getPool(USDC, USDC) for such a leg — there is no self-pool, and doing so raised
+InsufficientLiquidityError, aborting the whole rebalance before any fundable
+leg was reached. These tests pin the skip behavior with a mocked router so no
+chain access is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from archimedes.chain.executor import ChainExecutor, InsufficientLiquidityError
+from archimedes.models.portfolio import TradeDirection, TradeOrder
+
+USDC = "0x3600000000000000000000000000000000000000"
+SYNTH = "0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388"  # sTSLA-style synth
+
+
+def _executor_with_router(get_pool_return: str) -> tuple[ChainExecutor, MagicMock]:
+    """Build a ChainExecutor whose AMM router.getPool returns a fixed address."""
+    loader = MagicMock()
+    router = MagicMock()
+    get_pool_call = MagicMock()
+    get_pool_call.call = AsyncMock(return_value=get_pool_return)
+    router.functions.getPool = MagicMock(return_value=get_pool_call)
+    loader.amm_router = router
+    return ChainExecutor(loader=loader), router
+
+
+@pytest.mark.asyncio
+async def test_usdc_leg_skipped_no_getpool_call():
+    """A USDC-denominated leg must not trigger a getPool lookup."""
+    executor, router = _executor_with_router("0x" + "0" * 40)
+
+    usdc_trade = TradeOrder(
+        symbol="USDC",
+        token_address=USDC,
+        direction=TradeDirection.BUY,
+        amount=5.0,
+        estimated_usdc_value=5.0,
+    )
+
+    # Must not raise — the USDC leg is recognized as "already in cash".
+    await executor._validate_trade_liquidity([usdc_trade])
+    router.functions.getPool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_usdc_leg_does_not_abort_real_leg():
+    """A USDC leg alongside a real synth leg must not block the synth check."""
+    # getPool returns zero for any call here; the synth leg should then raise,
+    # proving the synth leg WAS evaluated (i.e. the USDC leg didn't short-circuit
+    # the whole loop with its own spurious error first).
+    executor, router = _executor_with_router("0x" + "0" * 40)
+
+    usdc_trade = TradeOrder(
+        symbol="USDC",
+        token_address=USDC,
+        direction=TradeDirection.BUY,
+        amount=5.0,
+        estimated_usdc_value=5.0,
+    )
+    synth_trade = TradeOrder(
+        symbol="sTSLA",
+        token_address=SYNTH,
+        direction=TradeDirection.BUY,
+        amount=5.0,
+        estimated_usdc_value=5.0,
+    )
+
+    with pytest.raises(InsufficientLiquidityError) as exc:
+        await executor._validate_trade_liquidity([usdc_trade, synth_trade])
+
+    # The error must be about the synth, never about USDC.
+    assert "sTSLA" in str(exc.value)
+    assert "USDC" not in str(exc.value)
+    # getPool was called exactly once — for the synth, not the USDC leg.
+    router.functions.getPool.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes Bug 1 of #399 — the reason **no vault can rebalance** on the live site. Every reasoning trace records `skip / No AMM pool for USDC: getPool returned zero address`.

The cash / TREASURY allocation leg maps to USDC itself. `_validate_trade_liquidity` was calling `getPool(USDC, USDC)` for it → zero address (there is no self-pool) → `InsufficientLiquidityError` → the **whole rebalance aborts before any fundable leg is reached.**

## Fix

Holding USDC needs no swap — it's already the settlement asset. So:
- `execute_trades` filters out USDC-denominated legs once, up front (so both the liquidity check and the swap construction see only real swap legs).
- `_validate_trade_liquidity` guards the same condition defensively.

## Tests

`backend/tests/chain/test_executor_usdc_leg.py` (mocked router, no chain access):
- USDC leg → no `getPool` call, no error raised.
- USDC leg + real synth leg → the synth leg is still evaluated (error mentions the synth, never USDC); `getPool` called exactly once.

Both green locally. Blocking ruff checks (E9/F63/F7/F40 + format) pass.

## Scope / review

⚠️ **This is on the on-chain rebalance path — requesting @Chuan's review** per repo convention, even though it's backend Python (no contract change).

This fixes Bug 1 only. **Bug 2 of #399** (the funded pool is sTSLA but no deployed strategy targets it; SPY/GOLD/etc. pools are dry/missing) is separate liquidity/bootstrap work and remains open — so a *real* on-chain swap still needs those pools seeded before a trace shows `decision_type != skip`.

## Anti-goals

- Did not weaken `MIN_HEALTHY_LIQUIDITY_USDC` (the guard is correct; the bug was calling it for a non-swap).
- Did not touch the pre-existing SIM108 in the same function (unrelated style, would violate one-change-per-PR).