### PR TITLE
[backend] executor: confirm rebalance receipt + raise on revert (#6)

### DIFF
--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -33,6 +33,15 @@ class InsufficientLiquidityError(RuntimeError):
     """Raised when an AMM pool's USDC reserve is below MIN_HEALTHY_LIQUIDITY_USDC."""
 
 
+class TradeRevertedError(RuntimeError):
+    """Raised when a submitted rebalance transaction reverts on-chain (status 0).
+
+    Without this, a reverted rebalance is logged as "sent" and returned as a
+    success hash — the agent then records a reasoning trace as if the trade
+    executed when it actually failed.
+    """
+
+
 class ChainExecutor:
     """Executes on-chain vault operations: read portfolio, rebalance, create vault."""
 
@@ -140,6 +149,26 @@ class ChainExecutor:
                     exc,
                 )
 
+    async def _confirm_receipt(self, tx_hash: str | bytes) -> str:
+        """Wait for a tx receipt and raise TradeRevertedError if it reverted.
+
+        Mirrors the receipt-wait already done in create_vault. Returns the
+        normalized 0x-prefixed hex hash on success.
+        """
+        if isinstance(tx_hash, str):
+            hexstr = tx_hash if tx_hash.startswith("0x") else "0x" + tx_hash
+            wait_arg = chain_client.w3.to_bytes(hexstr=hexstr)
+            norm = hexstr
+        else:
+            wait_arg = tx_hash
+            norm = tx_hash.hex() if not tx_hash.hex().startswith("0x") else tx_hash.hex()
+            norm = norm if norm.startswith("0x") else "0x" + norm
+
+        receipt = await chain_client.w3.eth.wait_for_transaction_receipt(wait_arg)
+        if receipt.get("status") == 0:
+            raise TradeRevertedError(f"Rebalance tx reverted on-chain: {norm}")
+        return norm
+
     async def execute_trades(
         self,
         vault_address: str,
@@ -189,8 +218,9 @@ class ChainExecutor:
                 abi_function="rebalance(address[],uint256[],address[],uint256[])",
                 abi_params=[checksummed_in, amounts_in, checksummed_out, amounts_out],
             )
-            logger.info(f"Rebalance tx via Circle: {tx_hash}")
-            return [tx_hash]
+            confirmed = await self._confirm_receipt(tx_hash)
+            logger.info(f"Rebalance tx via Circle confirmed: {confirmed}")
+            return [confirmed]
 
         # Fallback: raw private key
         account = chain_client.settings.agent_account
@@ -198,7 +228,9 @@ class ChainExecutor:
             raise RuntimeError("No agent account configured — set CIRCLE_API_KEY or ARC_AGENT_PRIVATE_KEY")
 
         vault = self.loader.vault(vault_address)
-        nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+        # Use the pending-block nonce so a quick second rebalance doesn't reuse
+        # a nonce that's already in the mempool (reduces nonce-collision drops).
+        nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
 
         tx = await vault.functions.rebalance(tokens_in, amounts_in, tokens_out, amounts_out).build_transaction(
             {
@@ -213,8 +245,11 @@ class ChainExecutor:
         signed = account.sign_transaction(tx)
         tx_hash = await chain_client.w3.eth.send_raw_transaction(signed.raw_transaction)
 
-        logger.info(f"Rebalance tx sent: {tx_hash.hex()}")
-        return [tx_hash.hex()]
+        # Confirm the receipt and raise on revert — don't return a "success"
+        # hash for a transaction that failed on-chain.
+        confirmed = await self._confirm_receipt(tx_hash)
+        logger.info(f"Rebalance tx confirmed: {confirmed}")
+        return [confirmed]
 
     async def create_vault(
         self,

--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -163,6 +163,9 @@ class TestExecuteTrades:
 
         with (
             patch.object(executor, "_validate_trade_liquidity", new=AsyncMock()) as mock_validate,
+            # _confirm_receipt added by #403 — must mock so the Circle path doesn't
+            # try to await the real wait_for_transaction_receipt chain on a MagicMock.
+            patch.object(executor, "_confirm_receipt", new=AsyncMock(return_value="0xtxhash")),
             patch("archimedes.chain.executor.circle_signer") as mock_signer,
         ):
             mock_signer.is_configured = True
@@ -182,11 +185,17 @@ class TestExecuteTrades:
                 asyncio.run(executor.execute_trades("0xvault", [trade]))
 
     def test_circle_signer_path(self, executor, mock_loader):
-        """When Circle signer is configured, uses circle_signer.execute_contract."""
+        """When Circle signer is configured, uses circle_signer.execute_contract.
+
+        After #403, execute_trades also awaits _confirm_receipt on the returned
+        tx_hash. _confirm_receipt is mocked here to return the hash unchanged
+        so we still assert the same end-to-end shape.
+        """
         trade = _make_trade()
 
         with (
             patch.object(executor, "_validate_trade_liquidity", new=AsyncMock()),
+            patch.object(executor, "_confirm_receipt", new=AsyncMock(return_value="0xdeadbeef")) as mock_confirm,
             patch("archimedes.chain.executor.circle_signer") as mock_signer,
         ):
             mock_signer.is_configured = True
@@ -195,6 +204,8 @@ class TestExecuteTrades:
             result = asyncio.run(executor.execute_trades("0xvault", [trade]))
             assert result == ["0xdeadbeef"]
             mock_signer.execute_contract.assert_called_once()
+            # Receipt-confirm must run after Circle submit (regression guard for #403)
+            mock_confirm.assert_called_once_with("0xdeadbeef")
 
     def test_no_signer_raises(self, executor):
         """No Circle signer + no raw key → RuntimeError."""

--- a/backend/tests/chain/test_executor_receipt.py
+++ b/backend/tests/chain/test_executor_receipt.py
@@ -1,0 +1,50 @@
+"""Executor: rebalance must confirm the receipt and raise on revert (#6).
+
+Previously execute_trades sent the tx and returned the hash without waiting,
+so a reverted rebalance was logged as "sent" and recorded as a success — the
+agent then published a REBALANCE trace for a trade that never settled. These
+tests pin _confirm_receipt's behavior with a mocked w3.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.executor import ChainExecutor, TradeRevertedError
+
+
+def _executor_with_receipt(status: int) -> ChainExecutor:
+    """ChainExecutor whose w3.eth.wait_for_transaction_receipt returns `status`."""
+    executor = ChainExecutor(loader=MagicMock())
+    fake_w3 = MagicMock()
+    fake_w3.eth.wait_for_transaction_receipt = AsyncMock(return_value={"status": status})
+    fake_w3.to_bytes = MagicMock(return_value=b"\x00" * 32)
+    return executor, fake_w3
+
+
+@pytest.mark.asyncio
+async def test_confirm_receipt_raises_on_revert():
+    executor, fake_w3 = _executor_with_receipt(status=0)
+    with patch("archimedes.chain.executor.chain_client") as cc:
+        cc.w3 = fake_w3
+        with pytest.raises(TradeRevertedError):
+            await executor._confirm_receipt("0xabc123")
+
+
+@pytest.mark.asyncio
+async def test_confirm_receipt_returns_hash_on_success():
+    executor, fake_w3 = _executor_with_receipt(status=1)
+    with patch("archimedes.chain.executor.chain_client") as cc:
+        cc.w3 = fake_w3
+        result = await executor._confirm_receipt("0xabc123")
+    assert result == "0xabc123"
+
+
+@pytest.mark.asyncio
+async def test_confirm_receipt_normalizes_unprefixed_hash():
+    executor, fake_w3 = _executor_with_receipt(status=1)
+    with patch("archimedes.chain.executor.chain_client") as cc:
+        cc.w3 = fake_w3
+        result = await executor._confirm_receipt("abc123")
+    assert result.startswith("0x")

--- a/backend/tests/chain/test_executor_receipt.py
+++ b/backend/tests/chain/test_executor_receipt.py
@@ -48,3 +48,37 @@ async def test_confirm_receipt_normalizes_unprefixed_hash():
         cc.w3 = fake_w3
         result = await executor._confirm_receipt("abc123")
     assert result.startswith("0x")
+
+
+@pytest.mark.asyncio
+async def test_confirm_receipt_accepts_bytes_input():
+    """Raw-key signer path: tx_hash is HexBytes (subclass of bytes), not str.
+
+    Pins the bytes branch at executor.py:162-165 — the actual production
+    code path for raw-key signing, which the str-only tests above did not
+    cover.
+    """
+    from hexbytes import HexBytes
+
+    executor, fake_w3 = _executor_with_receipt(status=1)
+    tx_hash_bytes = HexBytes("0x" + "ab" * 32)  # 32-byte tx hash
+    with patch("archimedes.chain.executor.chain_client") as cc:
+        cc.w3 = fake_w3
+        result = await executor._confirm_receipt(tx_hash_bytes)
+    # HexBytes input → normalized 0x-prefixed hex string out
+    assert isinstance(result, str)
+    assert result.startswith("0x")
+    assert result == "0x" + "ab" * 32
+
+
+@pytest.mark.asyncio
+async def test_confirm_receipt_raises_on_revert_with_bytes_input():
+    """Revert detection must work on the bytes (raw-key signer) path too."""
+    from hexbytes import HexBytes
+
+    executor, fake_w3 = _executor_with_receipt(status=0)
+    tx_hash_bytes = HexBytes("0x" + "cd" * 32)
+    with patch("archimedes.chain.executor.chain_client") as cc:
+        cc.w3 = fake_w3
+        with pytest.raises(TradeRevertedError, match="0x" + "cd" * 32):
+            await executor._confirm_receipt(tx_hash_bytes)


### PR DESCRIPTION
## Summary

`execute_trades` sent the rebalance tx and returned the hash **without waiting for a receipt** (both the Circle and raw-key paths). A reverted trade was logged as "sent" and returned as a success hash — so the agent then published a **REBALANCE** reasoning trace for a trade that never actually settled. Meanwhile `create_vault` already waits for its receipt; only the rebalance path skipped it.

## Fix

- New `_confirm_receipt(tx_hash)` — waits for the receipt, raises `TradeRevertedError` on `status == 0`, returns the normalized 0x hash on success. Mirrors the existing `create_vault` pattern.
- Wired into both `execute_trades` submission paths (Circle + raw key).
- The `agent_runner` generic handler already catches this and records an honest `execution_failed` SKIP trace instead of a false REBALANCE.
- Raw-key path now uses the **pending-block nonce** to reduce nonce-collision drops on a quick second rebalance.

## Tests

`backend/tests/chain/test_executor_receipt.py` (mocked w3):
- reverts (status 0) → `TradeRevertedError`
- success (status 1) → returns the hash
- unprefixed hash → normalized to `0x…`

All green; blocking ruff checks pass.

## Scope / review

⚠️ **On-chain rebalance path — requesting @Chuan's review.** No contract change; backend-only. The behavior change is: a reverted rebalance now surfaces as a failed trace rather than a false success. This is strictly more honest.

## Note on nonce handling

This addresses the receipt-confirmation half of the audit's "fire-and-forget + nonce race" finding, plus a pending-nonce improvement. A full nonce-manager (serializing concurrent submissions per signer) is a larger change left for a follow-up if concurrency on a single signer becomes real.