### PR TITLE
[backend] strategies_by_paper: DB prefilter instead of full-table scan (#9)

### DIFF
--- a/backend/archimedes/models/strategy_store.py
+++ b/backend/archimedes/models/strategy_store.py
@@ -203,7 +203,20 @@ def resolve_source_papers(session: Session, strategy_id: str) -> list[dict]:
 
 
 def strategies_by_paper(session: Session, arxiv_id: str) -> list[StrategyRecord]:
-    """Find all strategies citing a given arXiv paper (bidirectional link)."""
-    # JSON array contains query — works for SQLite and Postgres
-    records = session.query(StrategyRecord).all()
-    return [r for r in records if arxiv_id in {p.get("arxiv_id", "") for p in json.loads(r.source_papers)}]
+    """Find all strategies citing a given arXiv paper (bidirectional link).
+
+    Pushes a substring prefilter into the DB so we don't load the entire
+    StrategyRecord table and JSON-parse every row on each call. The LIKE
+    matches any row whose serialized ``source_papers`` text contains the
+    arxiv_id; the exact JSON check below then removes substring false
+    positives (e.g. ``2401.001`` matching ``2401.0012``). Portable across
+    SQLite and Postgres.
+    """
+    if not arxiv_id:
+        return []
+    # Escape LIKE wildcards in the id so they're matched literally.
+    needle = arxiv_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    candidates = (
+        session.query(StrategyRecord).filter(StrategyRecord.source_papers.like(f"%{needle}%", escape="\\")).all()
+    )
+    return [r for r in candidates if arxiv_id in {p.get("arxiv_id", "") for p in json.loads(r.source_papers)}]

--- a/backend/tests/test_strategy_store.py
+++ b/backend/tests/test_strategy_store.py
@@ -201,6 +201,26 @@ class TestStrategiesByPaper:
     def test_no_match(self, session):
         assert strategies_by_paper(session, "nonexistent") == []
 
+    def test_empty_arxiv_id_returns_empty(self, session):
+        # Guard: an empty id must not LIKE-match every row.
+        assert strategies_by_paper(session, "") == []
+
+    def test_substring_false_positive_excluded(self, session):
+        # The DB LIKE prefilter matches substrings; the exact JSON check must
+        # then exclude an id that is only a *substring* of a cited id.
+        upsert_strategy(
+            session,
+            generation_method="fusion",
+            strategy_name="LongId",
+            thesis="X",
+            source_papers=[{"arxiv_id": "2401.00120", "sha256": "z"}],
+            asset_universe=["SPY"],
+        )
+        # "2401.0012" is a substring of "2401.00120" but not an exact citation.
+        assert strategies_by_paper(session, "2401.0012") == []
+        # The exact id still matches.
+        assert len(strategies_by_paper(session, "2401.00120")) == 1
+
 
 class TestToDict:
     def test_roundtrip(self, session):


### PR DESCRIPTION
## Summary

`strategies_by_paper` loaded the **entire** `StrategyRecord` table with `.all()` and JSON-parsed `source_papers` for every row on each call — O(N strategies × M papers). It's called per-paper from `papers_routes`, so the cost compounds.

## Fix

Push a `LIKE '%<arxiv_id>%'` substring prefilter into the DB (portable across SQLite + Postgres) so only candidate rows are loaded, then keep the exact JSON membership check to drop substring false positives (`2401.0012` must not match `2401.00120`). LIKE wildcards in the id are escaped so they match literally.

## Tests (added to `test_strategy_store.py`)

- empty id → `[]` (must not LIKE-match everything)
- substring false positive (`2401.0012` vs cited `2401.00120`) → excluded; exact id still matches
- existing correctness/no-match tests still pass (16/16 green)

## Notes

Behavior is identical to before for all real inputs; this is purely a performance fix (fewer rows loaded + parsed) with an added escaping/empty-id guard. A JSON-native index (Postgres `jsonb` containment) would be faster still but isn't portable to the SQLite path used in tests/local — left for a future migration if the table grows large.