### PR TITLE
[backend] corpus_routes: narrow 4 bare excepts (pattern-setter for #8)

### DIFF
--- a/backend/archimedes/api/corpus_routes.py
+++ b/backend/archimedes/api/corpus_routes.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy.exc import SQLAlchemyError
 
 logger = logging.getLogger(__name__)
 
@@ -162,8 +163,11 @@ async def corpus_overview() -> dict[str, Any]:
                 for yr, count in year_rows
                 if yr and yr.isdigit() and 1990 <= int(yr) <= 2030
             ]
-    except Exception as exc:
-        logger.warning("corpus_routes: overview DB read failed: %s", exc)
+    except (ImportError, SQLAlchemyError):
+        # Expected when the corpus DB/KG models are absent or the query fails;
+        # the endpoint degrades to the manifest-only shape below. logger.exception
+        # captures the traceback so a *real* failure is debuggable, not silent.
+        logger.exception("corpus_routes: overview DB read failed")
 
     return {
         # Legacy KB-pipeline shape — kept for backward compatibility
@@ -316,8 +320,10 @@ async def kg_search_entities(q: str = Query(..., min_length=2, max_length=120)) 
                     }
                     for r in rel_rows
                 ]
-    except Exception as exc:
-        logger.warning("kg search failed: %s", exc)
+    except (ImportError, SQLAlchemyError):
+        # KG models missing or query failed → return the empty entities/relations
+        # shape below. Traceback logged for debuggability.
+        logger.exception("kg search failed")
     return {
         "query": q,
         "entities": [
@@ -359,8 +365,8 @@ async def kg_entity_detail(entity_id: int) -> dict[str, Any]:
             }
     except HTTPException:
         raise
-    except Exception as exc:
-        logger.exception("kg entity detail failed: %s", exc)
+    except (ImportError, SQLAlchemyError) as exc:
+        logger.exception("kg entity detail failed")
         raise HTTPException(status_code=503, detail="KG store unavailable") from exc
 
 
@@ -391,6 +397,6 @@ async def kg_paper_triples(arxiv_id: str) -> dict[str, Any]:
                     for r in rows
                 ],
             }
-    except Exception as exc:
-        logger.exception("kg paper triples failed: %s", exc)
+    except (ImportError, SQLAlchemyError) as exc:
+        logger.exception("kg paper triples failed")
         raise HTTPException(status_code=503, detail="KG store unavailable") from exc


### PR DESCRIPTION
## Summary

The audit flagged ~100 bare `except Exception` blocks across the codebase. Per the agreed approach (per-subsystem, not one mega-PR), this is the **pattern-setter** on the lowest-risk subsystem: the read-only corpus/KG routes.

Narrows 4 bare excepts in `corpus_routes.py` to `(ImportError, SQLAlchemyError)` — the genuine failure modes of "import the KG model + query the DB":

| Endpoint | Before | After |
| --- | --- | --- |
| overview | `except Exception` + `logger.warning(msg)` | `(ImportError, SQLAlchemyError)` + `logger.exception` |
| kg search | `except Exception` + `logger.warning(msg)` | same |
| kg entity detail | `except Exception` + `logger.exception` | narrowed |
| kg paper triples | `except Exception` + `logger.exception` | narrowed |

## Why

- **Graceful degradation preserved** for the expected cases (missing KG artifact, DB unavailable) — the endpoints still return their empty/manifest-only/503 shapes.
- **Real bugs now surface.** Previously an `AttributeError` from a code change was masked as "DB read failed." Now only DB/import errors are swallowed; anything else propagates and is visible.
- **Tracebacks captured.** The two message-only `logger.warning(..., exc)` calls become `logger.exception`, so failures are debuggable.

## Test plan

- [x] `corpus_routes` imports cleanly
- [x] `test_corpus_service.py` 14/14 green
- [x] No bare `except Exception` remain in `corpus_routes.py`
- [x] Blocking ruff checks pass

## Scope

Deliberately one subsystem. The remaining bare-except sites (chain/, services/, other api/ routes) should follow this same pattern in separate per-subsystem PRs — the chain/ ones especially need per-call judgment and Chuan's eyes.