### PR TITLE
[security] Update detect-secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,7 +124,14 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "\\.git/|node_modules/|\\.venv/|__pycache__|\\.env$|package-lock\\.json|\\.secrets\\.baseline"
+        "\\.git/.*",
+        "node_modules/.*",
+        "\\.venv/.*",
+        "contracts/lib/.*",
+        "submodules/.*",
+        "ui/dist/.*",
+        "package-lock\\.json",
+        "\\.terraform/.*"
       ]
     }
   ],
@@ -299,22 +306,13 @@
         "line_number": 4381
       }
     ],
-    "backend/archimedes/services/email_crypto.py": [
+    "backend/tests/test_auth_guard.py": [
       {
-        "type": "Secret Keyword",
-        "filename": "backend/archimedes/services/email_crypto.py",
-        "hashed_secret": "a9b8e6c4773c582675f2e45c4b67b7ed831b2f9c",
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/test_auth_guard.py",
+        "hashed_secret": "b82fc37e3681f20491e1bd2240193b9d7e8422fd",
         "is_verified": false,
-        "line_number": 25
-      }
-    ],
-    "docker-compose.yml": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docker-compose.yml",
-        "hashed_secret": "e28f8feb4e287f8868516a59947402f3c9fce8a4",
-        "is_verified": false,
-        "line_number": 54
+        "line_number": 21
       }
     ],
     "infra/user-data.sh": [
@@ -355,9 +353,9 @@
         "filename": "tests/flows/conftest.py",
         "hashed_secret": "c0174d8dfe9687a8f29297449712d6ba12ed2bc3",
         "is_verified": false,
-        "line_number": 383
+        "line_number": 395
       }
     ]
   },
-  "generated_at": "2026-05-24T11:01:17Z"
+  "generated_at": "2026-05-27T00:40:11Z"
 }


### PR DESCRIPTION
## Summary

Refresh `.secrets.baseline` to match current codebase. All 28 detections are
false positives:
- Analytics artifacts: strategy methodology hashes (Hex High Entropy)
- `.env.example`: template credentials (Basic Auth)
- Test files: fixture data

Pre-commit hooks (`.pre-commit-config.yaml`) already configured:
- `detect-secrets`: high-entropy string scanner with baseline
- `detect-private-key`: PEM/key file scanner
- `ruff check/format`: mirrors CI gate

## PR 2 of the security architecture sequence.
Previous: PR #396 (TF S3 backend) — merged.
Next: #405 test coverage PRs, then VPC.