### PR TITLE
[infra] VPC + Aurora Serverless v2 + ElastiCache Redis !minor

### DIFF
--- a/infra/aurora.tf
+++ b/infra/aurora.tf
@@ -1,0 +1,125 @@
+# ── Aurora Serverless v2 (PostgreSQL) ─────────────────────────────────
+#
+# Replaces the Docker Compose Postgres container with a managed,
+# encrypted, auto-scaling database in the private subnet.
+#
+# Budget: min 0.5 ACU ($~27/mo baseline), max 16 ACU (burst to ~$850/mo).
+# Standard pricing (not I/O-Optimized) — our workload is read-heavy.
+
+resource "aws_db_subnet_group" "aurora" {
+  name       = "${var.project_name}-aurora-subnet"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Name    = "${var.project_name}-aurora-subnet"
+    Project = var.project_name
+  }
+}
+
+resource "aws_security_group" "aurora" {
+  name        = "${var.project_name}-aurora-sg"
+  description = "Aurora — only reachable from EC2 backend"
+  vpc_id      = aws_vpc.main.id
+
+  # Inbound: Postgres from the EC2 security group (current default VPC)
+  # AND from the private subnets (for when EC2 moves to private subnet)
+  ingress {
+    description = "Postgres from private subnets"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.10.0/24", "10.0.11.0/24"]
+  }
+
+  ingress {
+    description     = "Postgres from current EC2 (default VPC, transitional)"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.archimedes.id]
+  }
+
+  # No egress needed for a database
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-aurora-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_rds_cluster" "main" {
+  cluster_identifier = "${var.project_name}-aurora"
+  engine             = "aurora-postgresql"
+  engine_mode        = "provisioned" # Serverless v2 uses provisioned mode + serverless_v2_scaling_configuration
+  engine_version     = "16.4"
+
+  database_name   = "archimedes"
+  master_username = "archimedes"
+  master_password = var.aurora_master_password
+
+  db_subnet_group_name   = aws_db_subnet_group.aurora.name
+  vpc_security_group_ids = [aws_security_group.aurora.id]
+
+  storage_encrypted = true
+  # deletion_protection = true  # Enable after migration is verified
+
+  serverlessv2_scaling_configuration {
+    min_capacity = 0.5
+    max_capacity = 16
+  }
+
+  # Skip final snapshot during development (enable for production)
+  skip_final_snapshot = true
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_rds_cluster_instance" "main" {
+  identifier         = "${var.project_name}-aurora-1"
+  cluster_identifier = aws_rds_cluster.main.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.main.engine
+  engine_version     = aws_rds_cluster.main.engine_version
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# ── VPC Peering (default VPC ↔ new VPC) ──────────────────────
+# Needed so the current EC2 in default VPC can reach Aurora in the new VPC.
+# This is transitional — removed when EC2 moves to the private subnet.
+
+resource "aws_vpc_peering_connection" "default_to_main" {
+  vpc_id      = data.aws_vpc.default.id
+  peer_vpc_id = aws_vpc.main.id
+  auto_accept = true
+
+  tags = {
+    Name    = "${var.project_name}-vpc-peer"
+    Project = var.project_name
+  }
+}
+
+# Route from default VPC to new VPC's CIDR
+resource "aws_route" "default_to_main" {
+  route_table_id            = data.aws_vpc.default.main_route_table_id
+  destination_cidr_block    = "10.0.0.0/16"
+  vpc_peering_connection_id = aws_vpc_peering_connection.default_to_main.id
+}
+
+# Route from new VPC private subnets to default VPC's CIDR
+resource "aws_route" "main_to_default" {
+  count                     = 2
+  route_table_id            = aws_route_table.private[count.index].id
+  destination_cidr_block    = "172.31.0.0/16"
+  vpc_peering_connection_id = aws_vpc_peering_connection.default_to_main.id
+}

--- a/infra/aurora.tf
+++ b/infra/aurora.tf
@@ -67,7 +67,12 @@ resource "aws_rds_cluster" "main" {
   vpc_security_group_ids = [aws_security_group.aurora.id]
 
   storage_encrypted = true
-  # deletion_protection = true  # Enable after migration is verified
+  # deletion_protection = true  # Enable after migration is verified — see follow-up note in PR
+  iam_database_authentication_enabled = true # enables IAM-based DB auth as alternative to password (no cost)
+
+  # Aurora automated backups — 7 days is the standard production retention.
+  # Backups are continuous; point-in-time recovery available within the window.
+  backup_retention_period = 7
 
   serverlessv2_scaling_configuration {
     min_capacity = 0.5
@@ -75,6 +80,8 @@ resource "aws_rds_cluster" "main" {
   }
 
   # Skip final snapshot during development (enable for production)
+  # Follow-up: flip skip_final_snapshot=false + deletion_protection=true
+  # BEFORE any real user data lands in the cluster.
   skip_final_snapshot = true
 
   tags = {

--- a/infra/elasticache.tf
+++ b/infra/elasticache.tf
@@ -1,0 +1,73 @@
+# ── ElastiCache Redis ─────────────────────────────────────────────────
+#
+# Replaces the Docker Compose Redis container with a managed, encrypted
+# Redis instance in the private subnet.
+
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.project_name}-redis-subnet"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_security_group" "redis" {
+  name        = "${var.project_name}-redis-sg"
+  description = "ElastiCache Redis — only reachable from EC2 backend"
+  vpc_id      = aws_vpc.main.id
+
+  # Inbound: Redis from private subnets
+  ingress {
+    description = "Redis from private subnets"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.10.0/24", "10.0.11.0/24"]
+  }
+
+  # Inbound: Redis from current EC2 (default VPC, transitional)
+  ingress {
+    description     = "Redis from current EC2 (transitional)"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.archimedes.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-redis-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id = "${var.project_name}-redis"
+  description          = "Archimedes Redis — regime state, traces, job queue"
+
+  engine         = "redis"
+  engine_version = "7.1"
+  node_type      = "cache.t3.micro"
+
+  num_cache_clusters = 1 # Single node (multi-AZ is a cost upgrade)
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = [aws_security_group.redis.id]
+
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  # Auth token for Redis AUTH (optional — adds another layer)
+  # auth_token = var.redis_auth_token
+
+  tags = {
+    Project = var.project_name
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -57,7 +57,15 @@ output "redis_endpoint" {
 }
 
 output "database_url" {
-  description = "Full DATABASE_URL for backend .env"
+  description = <<-DESC
+    Full DATABASE_URL for backend .env. STATE-SENSITIVE: this output stores
+    the master password in Terraform state (which lives in the S3 backend).
+    The bucket policy restricts access to the AWS account principal and TLS-only,
+    but the password is still in the state file. Recommended pattern going forward:
+    backend fetches the password from AWS Secrets Manager / SSM Parameter Store at
+    runtime and constructs the URL from `aurora_endpoint` + password — that way
+    the secret never lands in Terraform state at all. Tracked as a follow-up.
+  DESC
   value       = "postgresql://archimedes:${var.aurora_master_password}@${aws_rds_cluster.main.endpoint}:5432/archimedes"
   sensitive   = true
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -33,3 +33,36 @@ output "ssh_private_key" {
   value       = tls_private_key.deploy.private_key_openssh
   sensitive   = true
 }
+
+# ── New VPC infrastructure outputs ────────────────────────────
+
+output "vpc_id" {
+  description = "New VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "aurora_endpoint" {
+  description = "Aurora cluster endpoint (for DATABASE_URL)"
+  value       = aws_rds_cluster.main.endpoint
+}
+
+output "aurora_reader_endpoint" {
+  description = "Aurora reader endpoint"
+  value       = aws_rds_cluster.main.reader_endpoint
+}
+
+output "redis_endpoint" {
+  description = "ElastiCache Redis endpoint (for REDIS_URL)"
+  value       = aws_elasticache_replication_group.main.primary_endpoint_address
+}
+
+output "database_url" {
+  description = "Full DATABASE_URL for backend .env"
+  value       = "postgresql://archimedes:${var.aurora_master_password}@${aws_rds_cluster.main.endpoint}:5432/archimedes"
+  sensitive   = true
+}
+
+output "redis_url" {
+  description = "Full REDIS_URL for backend .env"
+  value       = "rediss://${aws_elasticache_replication_group.main.primary_endpoint_address}:6379/0"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -16,6 +16,12 @@ variable "key_name" {
   default     = "archimedes-deploy-key"
 }
 
+variable "aurora_master_password" {
+  description = "Master password for Aurora PostgreSQL. Set via TF_VAR_aurora_master_password env var."
+  type        = string
+  sensitive   = true
+}
+
 variable "project_name" {
   description = "Project name for tagging"
   type        = string

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,165 @@
+# ── VPC + Networking for Archimedes Production ─────────────────────────
+#
+# Architecture:
+#   - New VPC with /16 CIDR (10.0.0.0/16)
+#   - 2 public subnets (ALB, NAT instances) in eu-west-2a + eu-west-2b
+#   - 2 private subnets (EC2, Aurora, ElastiCache) in same AZs
+#   - fck-nat t4g.nano instances (one per AZ) for outbound internet
+#   - Internet Gateway for public subnets
+#
+# The EC2 instance stays in the DEFAULT VPC for this PR (env-var cutover
+# only). Moving EC2 to the private subnet is a separate PR after the
+# deploy pipeline is converted to SSM.
+
+locals {
+  azs = ["eu-west-2a", "eu-west-2b"]
+}
+
+# ── VPC ───────────────────────────────────────────────────────
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name    = "${var.project_name}-vpc"
+    Project = var.project_name
+  }
+}
+
+# ── Internet Gateway ─────────────────────────────────────────
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project_name}-igw"
+    Project = var.project_name
+  }
+}
+
+# ── Public Subnets (ALB + NAT instances) ─────────────────────
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.${count.index}.0/24"
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project_name}-public-${local.azs[count.index]}"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name    = "${var.project_name}-public-rt"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# ── Private Subnets (EC2, Aurora, ElastiCache) ───────────────
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index + 10}.0/24"
+  availability_zone = local.azs[count.index]
+
+  tags = {
+    Name    = "${var.project_name}-private-${local.azs[count.index]}"
+    Project = var.project_name
+  }
+}
+
+# Each private subnet routes outbound through its AZ's NAT instance
+resource "aws_route_table" "private" {
+  count  = 2
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block           = "0.0.0.0/0"
+    network_interface_id = aws_instance.nat[count.index].primary_network_interface_id
+  }
+
+  tags = {
+    Name    = "${var.project_name}-private-rt-${local.azs[count.index]}"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+# ── NAT Instances (fck-nat, t4g.nano, one per AZ) ───────────
+
+data "aws_ami" "fck_nat" {
+  most_recent = true
+  owners      = ["568608671756"] # fck-nat project
+
+  filter {
+    name   = "name"
+    values = ["fck-nat-al2023-*-arm64-*"]
+  }
+}
+
+resource "aws_security_group" "nat" {
+  name        = "${var.project_name}-nat-sg"
+  description = "NAT instance — allows outbound for private subnets"
+  vpc_id      = aws_vpc.main.id
+
+  # Inbound from private subnets (all traffic)
+  ingress {
+    description = "Private subnets"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["10.0.10.0/24", "10.0.11.0/24"]
+  }
+
+  # Outbound — all (NAT needs to reach the internet)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-nat-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_instance" "nat" {
+  count                = 2
+  ami                  = data.aws_ami.fck_nat.id
+  instance_type        = "t4g.nano"
+  subnet_id            = aws_subnet.public[count.index].id
+  vpc_security_group_ids = [aws_security_group.nat.id]
+  source_dest_check    = false # Required for NAT
+
+  tags = {
+    Name    = "${var.project_name}-nat-${local.azs[count.index]}"
+    Project = var.project_name
+  }
+}


### PR DESCRIPTION
## Summary — the load-bearing security infrastructure PR

New VPC with private subnets, Aurora Serverless v2 (PostgreSQL), and ElastiCache
Redis. This is the foundation for moving all backend services behind a network
boundary where they cannot be reached from the public internet.

## What gets created (28 resources)

| Resource | Spec | Monthly Cost |
|----------|------|-------------|
| VPC + 4 subnets + IGW + route tables | 10.0.0.0/16 | Free |
| 2× fck-nat t4g.nano | One per AZ | ~$4/mo each |
| Aurora Serverless v2 (PostgreSQL 16.4) | 0.5-16 ACU | ~$27-35/mo |
| ElastiCache Redis 7.1 | cache.t3.micro | ~$12/mo |
| VPC Peering (default ↔ new) | Transitional | Free |
| Security groups (3 new) | Aurora, Redis, NAT | Free |

## What does NOT change

- EC2 stays in default VPC (moves to private subnet in a later PR after SSM)
- No DNS changes, no ALB yet (separate PR)
- No application code changes
- Terraform plan: **28 add, 1 change (EC2 in-place), 0 destroy**

## Terraform plan diff

```
Plan: 28 to add, 1 to change, 0 to destroy.
```

## env-var cutover plan (post-apply)

After `terraform apply` confirms endpoints:
1. Update GitHub Secrets: `DATABASE_URL` and `REDIS_URL` to point at Aurora/ElastiCache
2. Trigger deploy to pick up new endpoints
3. Verify backend connects to managed services
4. Run data migration from Docker Postgres → Aurora

## Sequence

PR 3 of the security architecture. Previous: #396 (S3 backend), #409 (detect-secrets).
Next: deploy pipeline (SSM), ALB + WAF, EC2 → private subnet.

## Review checklist
- [ ] Terraform plan reviewed (28 add, 0 destroy)
- [ ] Aurora SG allows 5432 from private subnets + current EC2 SG
- [ ] Redis SG allows 6379 from private subnets + current EC2 SG
- [ ] VPC peering routes are bidirectional
- [ ] NAT instances have source_dest_check = false
- [ ] No secrets in the Terraform config (password via TF_VAR)