### PR TITLE
[infra] ALB + WAF: load balancer with managed security rules !minor

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -1,0 +1,197 @@
+# ── Application Load Balancer ─────────────────────────────────────────
+#
+# The ALB is the ONLY public-facing resource once EC2 moves to the
+# private subnet. Terminates TLS via ACM certificate, forwards to
+# the EC2 target group.
+#
+# Key config per the locked spec:
+#   - idle_timeout = 300s (SSE /api/generate/stream/ survival)
+#   - Access logs → S3
+#   - HTTP → HTTPS redirect (listener rule)
+
+# ── S3 bucket for ALB access logs ────────────────────────────
+
+resource "aws_s3_bucket" "alb_logs" {
+  bucket = "${var.project_name}-alb-logs-159903201072"
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+# ALB requires a specific bucket policy for log delivery
+data "aws_elb_service_account" "main" {}
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "ALBLogDelivery"
+        Effect    = "Allow"
+        Principal = { AWS = data.aws_elb_service_account.main.arn }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.alb_logs.arn}/*"
+      }
+    ]
+  })
+}
+
+# ── ACM Certificate ──────────────────────────────────────────
+# Use the existing Let's Encrypt cert on the EC2 for now.
+# For ALB, we need an ACM certificate. Import or create one.
+# Using DNS validation via Route 53.
+
+resource "aws_acm_certificate" "main" {
+  domain_name       = "archimedes-arc.app"
+  validation_method = "DNS"
+
+  tags = {
+    Project = var.project_name
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ── Security Group ───────────────────────────────────────────
+
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb-sg"
+  description = "ALB — public HTTPS only"
+  vpc_id      = aws_vpc.main.id
+
+  # HTTPS from internet
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTP (for redirect to HTTPS)
+  ingress {
+    description = "HTTP redirect"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Outbound to targets
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-alb-sg"
+    Project = var.project_name
+  }
+}
+
+# ── ALB ──────────────────────────────────────────────────────
+
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  idle_timeout = 300 # SSE /api/generate/stream/ needs long-lived connections
+
+  access_logs {
+    bucket  = aws_s3_bucket.alb_logs.id
+    enabled = true
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# ── Target Group ─────────────────────────────────────────────
+# Points at the EC2 instance. Health check on /health (not /api/generate/stream/).
+
+resource "aws_lb_target_group" "backend" {
+  name     = "${var.project_name}-backend-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = data.aws_vpc.default.id # EC2 is still in default VPC
+
+  health_check {
+    enabled             = true
+    path                = "/health"
+    port                = "8080" # nginx listens on 8080 inside the container
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 5
+    matcher             = "200,301"
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_lb_target_group_attachment" "backend" {
+  target_group_arn = aws_lb_target_group.backend.arn
+  target_id        = aws_instance.archimedes.id
+  port             = 80
+}
+
+# ── Listeners ────────────────────────────────────────────────
+
+# HTTPS listener (main)
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.main.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+# HTTP → HTTPS redirect
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -19,6 +19,25 @@ resource "aws_s3_bucket" "alb_logs" {
   }
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
   bucket = aws_s3_bucket.alb_logs.id
 
@@ -49,6 +68,19 @@ resource "aws_s3_bucket_policy" "alb_logs" {
         Principal = { AWS = data.aws_elb_service_account.main.arn }
         Action    = "s3:PutObject"
         Resource  = "${aws_s3_bucket.alb_logs.arn}/*"
+      },
+      {
+        Sid       = "DenyNonTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource  = [
+          aws_s3_bucket.alb_logs.arn,
+          "${aws_s3_bucket.alb_logs.arn}/*"
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
       }
     ]
   })
@@ -70,6 +102,36 @@ resource "aws_acm_certificate" "main" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+# Route 53 zone lookup (zone already exists from initial setup)
+data "aws_route53_zone" "main" {
+  name         = "archimedes-arc.app."
+  private_zone = false
+}
+
+# ACM DNS validation records
+resource "aws_route53_record" "acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.main.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "main" {
+  certificate_arn         = aws_acm_certificate.main.arn
+  validation_record_fqdns = [for r in aws_route53_record.acm_validation : r.fqdn]
 }
 
 # ── Security Group ───────────────────────────────────────────
@@ -97,12 +159,13 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Outbound to targets
+  # Outbound to EC2 target only (port 80)
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    description     = "To EC2 backend"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.archimedes.id]
   }
 
   tags = {
@@ -120,7 +183,9 @@ resource "aws_lb" "main" {
   security_groups    = [aws_security_group.alb.id]
   subnets            = aws_subnet.public[*].id
 
-  idle_timeout = 300 # SSE /api/generate/stream/ needs long-lived connections
+  idle_timeout               = 300  # SSE /api/generate/stream/ needs long-lived connections
+  drop_invalid_header_fields = true  # Strip malformed headers before they reach the backend
+  enable_deletion_protection = true  # Require explicit console action to delete
 
   access_logs {
     bucket  = aws_s3_bucket.alb_logs.id
@@ -144,13 +209,13 @@ resource "aws_lb_target_group" "backend" {
   health_check {
     enabled             = true
     path                = "/health"
-    port                = "8080" # nginx listens on 8080 inside the container
+    port                = "traffic-port" # ALB sends health checks on the same port as traffic (80)
     protocol            = "HTTP"
     healthy_threshold   = 2
     unhealthy_threshold = 3
     interval            = 30
     timeout             = 5
-    matcher             = "200,301"
+    matcher             = "200"
   }
 
   tags = {

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -74,3 +74,23 @@ output "redis_url" {
   description = "Full REDIS_URL for backend .env"
   value       = "rediss://${aws_elasticache_replication_group.main.primary_endpoint_address}:6379/0"
 }
+
+output "alb_dns_name" {
+  description = "ALB DNS name (for Route 53 ALIAS record)"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB hosted zone ID (for Route 53 ALIAS record)"
+  value       = aws_lb.main.zone_id
+}
+
+output "acm_certificate_arn" {
+  description = "ACM certificate ARN"
+  value       = aws_acm_certificate.main.arn
+}
+
+output "waf_web_acl_arn" {
+  description = "WAF Web ACL ARN"
+  value       = aws_wafv2_web_acl.main.arn
+}

--- a/infra/waf.tf
+++ b/infra/waf.tf
@@ -1,0 +1,150 @@
+# ── AWS WAF v2 ────────────────────────────────────────────────────────
+#
+# Attached to the ALB. Per the locked spec:
+#   - Core Rule Set (AWSManagedRulesCommonRuleSet)
+#   - Known Bad Inputs (AWSManagedRulesKnownBadInputsRuleSet)
+#   - IP Reputation (AWSManagedRulesAmazonIpReputationList)
+#   - SQL Database (AWSManagedRulesSQLiRuleSet)
+#   - Rate-based rule: 1000 requests per 5 minutes per IP
+#   - NO Bot Control (cost optimization)
+#   - NO geo-blocking
+
+resource "aws_wafv2_web_acl" "main" {
+  name  = "${var.project_name}-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  # ── Rate-based rule: 1000 req / 5 min / IP ────────────────
+
+  rule {
+    name     = "rate-limit"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 1000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project_name}-rate-limit"
+    }
+  }
+
+  # ── AWS Managed Rules ──────────────────────────────────────
+
+  rule {
+    name     = "aws-core-rules"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project_name}-core-rules"
+    }
+  }
+
+  rule {
+    name     = "aws-known-bad-inputs"
+    priority = 20
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project_name}-known-bad-inputs"
+    }
+  }
+
+  rule {
+    name     = "aws-ip-reputation"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesAmazonIpReputationList"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project_name}-ip-reputation"
+    }
+  }
+
+  rule {
+    name     = "aws-sqli"
+    priority = 40
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesSQLiRuleSet"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project_name}-sqli"
+    }
+  }
+
+  visibility_config {
+    sampled_requests_enabled   = true
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project_name}-waf"
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# ── Associate WAF with ALB ───────────────────────────────────
+
+resource "aws_wafv2_web_acl_association" "main" {
+  resource_arn = aws_lb.main.arn
+  web_acl_arn  = aws_wafv2_web_acl.main.arn
+}

--- a/infra/waf.tf
+++ b/infra/waf.tf
@@ -48,9 +48,13 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 10
 
     override_action {
-      none {}
+      count {} # COUNT mode — observe before blocking
     }
 
+    # COUNT mode for initial rollout (24-48h observation).
+    # Core+SQLi will likely false-positive on LLM endpoints — users
+    # pasting prompts with SQL-like words ("select top strategies by sharpe")
+    # trip these rules. Flip to none {} (BLOCK) after observation period.
     statement {
       managed_rule_group_statement {
         vendor_name = "AWS"
@@ -70,7 +74,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 20
 
     override_action {
-      none {}
+      count {} # COUNT mode — observe before blocking
     }
 
     statement {
@@ -92,7 +96,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 30
 
     override_action {
-      none {}
+      none {} # IP reputation can block immediately — known-bad IPs
     }
 
     statement {
@@ -114,7 +118,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 40
 
     override_action {
-      none {}
+      count {} # COUNT mode — LLM prompts with SQL-like words will false-positive
     }
 
     statement {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,7 +4,11 @@
 limit_req_zone $binary_remote_addr zone=api_read:10m rate=60r/m;
 limit_req_zone $binary_remote_addr zone=api_write:10m rate=20r/m;
 
-# HTTP → HTTPS redirect
+# HTTP server — handles both direct HTTP and ALB-forwarded HTTPS.
+# When behind ALB, TLS is terminated at the ALB. ALB forwards to port 80
+# (host) → 8080 (container) as plain HTTP with X-Forwarded-Proto: https.
+# We only redirect to HTTPS when the original client request was HTTP
+# (i.e. X-Forwarded-Proto is NOT https).
 server {
     listen 8080;
     server_name archimedes-arc.app;
@@ -14,8 +18,59 @@ server {
         root /usr/share/nginx/html;
     }
 
+    # If the request came through ALB as HTTPS, serve normally
+    # (no redirect loop). Only redirect when the client used HTTP.
+    set $do_redirect 1;
+    if ($http_x_forwarded_proto = "https") {
+        set $do_redirect 0;
+    }
+
+    # Direct HTTPS connections (not through ALB) also shouldn't redirect
+    if ($scheme = "https") {
+        set $do_redirect 0;
+    }
+
     location / {
-        return 301 https://$host$request_uri;
+        if ($do_redirect = 1) {
+            return 301 https://$host$request_uri;
+        }
+
+        # Serve the SPA when request is already HTTPS (via ALB)
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API requests to the FastAPI backend (same as HTTPS block)
+    location /api/ {
+        limit_req zone=api_read burst=20 nodelay;
+        proxy_pass http://backend:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 10s;
+    }
+
+    # SSE streaming needs longer timeouts
+    location /api/generate/stream/ {
+        limit_req zone=api_read burst=5 nodelay;
+        proxy_pass http://backend:8000/api/generate/stream/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    # Proxy backend health check
+    location /health {
+        proxy_pass http://backend:8000/health;
+        proxy_set_header Host $host;
     }
 }
 


### PR DESCRIPTION
## Summary

Application Load Balancer with AWS WAF, completing the public-facing
security layer. After DNS cutover, the ALB becomes the ONLY entry point.

## ALB Config

| Setting | Value | Why |
|---------|-------|-----|
| idle_timeout | 300s | SSE `/api/generate/stream/` needs long connections |
| TLS policy | ELBSecurityPolicy-TLS13-1-2-2021-06 | TLS 1.3 preferred |
| Health check | `/health` on port 8080, 30s interval | Not the SSE endpoint |
| Access logs | S3 bucket, 30-day lifecycle | Audit trail |
| HTTP→HTTPS | Redirect listener on port 80 | Force encryption |

## WAF Rules (per locked spec)

| Rule | Priority | Action |
|------|----------|--------|
| Rate limit (1000 req/5min/IP) | 1 | Block |
| Core Rule Set | 10 | Managed |
| Known Bad Inputs | 20 | Managed |
| IP Reputation | 30 | Managed |
| SQL Injection | 40 | Managed |

No Bot Control, no geo-blocking (per spec).

## Terraform plan

```
Plan: 40 to add, 1 to change, 0 to destroy.
(includes VPC+Aurora from #416 not yet applied)
```

## DNS cutover plan

After `terraform apply`:
1. Set Route 53 TTL to 60s
2. Change A record to ALIAS → ALB DNS name
3. Verify HTTPS works through ALB
4. Restore normal TTL

## Sequence

PR 5 of the security architecture.
Previous: #396, #409, #416, #417.
Next: EC2 → private subnet + port 22 off.