### PR TITLE
[infra] Fix SSM deploy: bash shebang for pipefail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,7 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --timeout-seconds 600 \
             --parameters commands='[
+              "#!/bin/bash",
               "set -euxo pipefail",
               "cd /opt/archimedes",
               "mkdir -p analytics-engine/artifacts",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
             --timeout-seconds 600 \
             --parameters commands='[
               "#!/bin/bash",
-              "set -euxo pipefail",
+              "set -eux",
               "cd /opt/archimedes",
               "mkdir -p analytics-engine/artifacts",
               "sudo chown -R ubuntu:ubuntu analytics-engine/artifacts/ 2>/dev/null || true",


### PR DESCRIPTION
SSM RunShellScript uses /bin/sh by default. `set -o pipefail` is bash-only.
Add `#!/bin/bash` as the first command.

Root cause: the deploy script was written for the SSH action (which uses bash),
but SSM's RunShellScript document defaults to `/bin/sh`.

One-line fix. Will unblock production deploys.