### PR TITLE
[infra] Fix SSM deploy: git safe.directory for root execution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,7 @@ jobs:
               "#!/bin/bash",
               "set -eux",
               "cd /opt/archimedes",
+              "git config --global --add safe.directory /opt/archimedes",
               "mkdir -p analytics-engine/artifacts",
               "sudo chown -R ubuntu:ubuntu analytics-engine/artifacts/ 2>/dev/null || true",
               "git fetch origin main",


### PR DESCRIPTION
SSM RunShellScript runs as root. `/opt/archimedes` is owned by ubuntu.
Git 2.35.2+ rejects cross-user repo operations with 'dubious ownership'.

One-line fix: `git config --global --add safe.directory /opt/archimedes`

Evidence from deploy log:
```
fatal: detected dubious ownership in repository at '/opt/archimedes'
```

This is the third SSM deploy fix (after IAM document ARN + bash shebang).
The root cause of all three is that SSM's execution environment differs
from SSH's in ways that aren't visible until runtime. Debt item #417.2
(codify IAM + test deploy in staging) would prevent this class of bug.