### PR TITLE
[infra] Fix SSM deploy #4: export HOME=/root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,7 @@ jobs:
             --parameters commands='[
               "#!/bin/bash",
               "set -eux",
+              "export HOME=/root",
               "cd /opt/archimedes",
               "git config --global --add safe.directory /opt/archimedes",
               "mkdir -p analytics-engine/artifacts",


### PR DESCRIPTION
Bug #4 in the SSH → SSM series: `git config --global` fails with `fatal: $HOME not set`.

SSM runs scripts in a non-login context without HOME. One-line fix sets it at script top.

Long-term: `sudo -u ubuntu -i` wrapping or SSM RunAs (per #425 staging deploy target).