### PR TITLE
[security] Drop X-Wallet-Address fallback for profile writes (#402)

### DIFF
--- a/backend/archimedes/api/user_routes.py
+++ b/backend/archimedes/api/user_routes.py
@@ -76,23 +76,6 @@ def _extract_caller_wallet_siwe(request: Request) -> str | None:
     return get_verified_wallet(request)
 
 
-def _extract_caller_wallet(request: Request) -> str | None:
-    """Extract wallet from SIWE session or X-Wallet-Address header.
-
-    Used for write operations (profile upsert, chat posting) where the
-    caller is modifying their OWN data. The header is acceptable here
-    because the write check enforces caller == payload.wallet_address.
-
-    PII reads use _extract_caller_wallet_siwe() instead.
-    """
-    from archimedes.api.auth_siwe import get_verified_wallet
-
-    verified = get_verified_wallet(request)
-    if verified:
-        return verified
-    return request.headers.get("X-Wallet-Address", "").lower().strip() or None
-
-
 @user_router.get("/profile/{wallet}", response_model=UserProfileResponse)
 async def get_profile(wallet: str, request: Request):
     """Retrieve a wallet's profile. Returns 404 if not set.
@@ -128,14 +111,17 @@ async def get_profile(wallet: str, request: Request):
 async def upsert_profile(payload: UserProfileCreate, request: Request, response: Response):  # noqa: ARG001 — response param threaded for downstream cookie/header setting; not used in current body
     """Create or update a wallet's profile. All fields optional except wallet.
 
-    Email is encrypted at rest before storage. Caller must supply an
-    `X-Wallet-Address` header matching `payload.wallet_address` — prevents one
-    wallet from writing another wallet's profile.
+    Email is encrypted at rest before storage. Caller must hold a valid SIWE
+    session matching `payload.wallet_address` — prevents one wallet from
+    writing another wallet's profile. The X-Wallet-Address header fallback
+    was dropped per Issue #402 because it is forgeable.
     """
-    caller = _extract_caller_wallet(request)
+    caller = _extract_caller_wallet_siwe(request)
+    if caller is None:
+        raise HTTPException(status_code=403, detail="Forbidden: SIWE session required for profile writes")
     wallet = payload.wallet_address.lower()
     if caller != wallet:
-        raise HTTPException(status_code=403, detail="Forbidden: X-Wallet-Address header must match payload wallet")
+        raise HTTPException(status_code=403, detail="Forbidden: SIWE session wallet does not match payload wallet")
 
     session: Session = get_session()
     try:

--- a/backend/tests/test_user_profile_privacy.py
+++ b/backend/tests/test_user_profile_privacy.py
@@ -177,11 +177,14 @@ class TestUpsertEncryption:
             from starlette.responses import Response as StarletteResponse
 
             mock_req = _MagicMock(spec=StarletteRequest)
-            # upsert_profile rejects writes where X-Wallet-Address header doesn't
-            # match payload.wallet_address. Match the payload so the auth check passes.
-            mock_req.headers = {"X-Wallet-Address": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}
             mock_resp = _MagicMock(spec=StarletteResponse)
-            asyncio.run(upsert_profile(payload, request=mock_req, response=mock_resp))
+            # upsert_profile (post Issue #402) requires a SIWE session matching
+            # payload.wallet_address. Patch get_verified_wallet to return the payload wallet.
+            with patch(
+                "archimedes.api.auth_siwe.get_verified_wallet",
+                return_value="0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            ):
+                asyncio.run(upsert_profile(payload, request=mock_req, response=mock_resp))
 
         # The stored email must be encrypted (not plaintext)
         assert added_obj is not None

--- a/backend/tests/test_user_routes.py
+++ b/backend/tests/test_user_routes.py
@@ -1,9 +1,11 @@
 """Tests for user profile API — WelcomeProfileModal backend.
 
-Updated for Issue #181 (user-data minimization):
-  - POST stores email encrypted at rest
-  - GET without owner header strips PII (display_name, email, marketing_opt_in)
-  - GET with X-Wallet-Address header matching the profile wallet returns full data
+Auth model (Issue #181 + Issue #402):
+  - POST requires a SIWE session matching payload.wallet_address.
+    The X-Wallet-Address header fallback was dropped per #402 (forgeable).
+  - GET strips PII when caller lacks SIWE session matching the queried wallet.
+  - GET with a valid SIWE session for the queried wallet returns full data.
+  - Email is encrypted at rest before storage.
 """
 
 from __future__ import annotations
@@ -74,7 +76,7 @@ class TestUserProfileRoutes:
                 "display_name": "Alice",
                 "marketing_opt_in": False,
             },
-            headers={"X-Wallet-Address": _W_ALICE},
+            cookies=_siwe_cookies(_W_ALICE),
         )
         assert res.status_code == 200
         data = res.json()
@@ -89,7 +91,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_BOB,
                 "display_name": "Bob",
             },
-            headers={"X-Wallet-Address": _W_BOB},
+            cookies=_siwe_cookies(_W_BOB),
         )
         # GET with SIWE session cookie → full data including PII
         res = client.get(
@@ -107,7 +109,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_BOB,
                 "display_name": "Bob",
             },
-            headers={"X-Wallet-Address": _W_BOB},
+            cookies=_siwe_cookies(_W_BOB),
         )
         # GET without owner header → PII stripped
         res = client.get(f"/api/user/profile/{_W_BOB}")
@@ -126,7 +128,7 @@ class TestUserProfileRoutes:
                 "attribution": "Twitter",
                 "marketing_opt_in": True,
             },
-            headers={"X-Wallet-Address": _W_CHARLIE},
+            cookies=_siwe_cookies(_W_CHARLIE),
         )
         assert res.status_code == 200
         data = res.json()
@@ -145,7 +147,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CHARLIE,
                 "email": email,
             },
-            headers={"X-Wallet-Address": _W_CHARLIE},
+            cookies=_siwe_cookies(_W_CHARLIE),
         )
         # Read directly from DB
         session = get_session()
@@ -165,7 +167,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_UPDATE,
                 "display_name": "Original",
             },
-            headers={"X-Wallet-Address": _W_UPDATE},
+            cookies=_siwe_cookies(_W_UPDATE),
         )
         res = client.post(
             "/api/user/profile",
@@ -174,7 +176,7 @@ class TestUserProfileRoutes:
                 "display_name": "Updated",
                 "marketing_opt_in": True,
             },
-            headers={"X-Wallet-Address": _W_UPDATE},
+            cookies=_siwe_cookies(_W_UPDATE),
         )
         assert res.status_code == 200
         assert res.json()["display_name"] == "Updated"
@@ -187,7 +189,7 @@ class TestUserProfileRoutes:
             json={
                 "wallet_address": _W_MINIMAL,
             },
-            headers={"X-Wallet-Address": _W_MINIMAL},
+            cookies=_siwe_cookies(_W_MINIMAL),
         )
         assert res.status_code == 200
         data = res.json()
@@ -214,7 +216,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CASE,
                 "display_name": "CaseTest",
             },
-            headers={"X-Wallet-Address": _W_CASE},
+            cookies=_siwe_cookies(_W_CASE),
         )
         # Query with lowercase + SIWE session
         res = client.get(
@@ -239,7 +241,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CHARLIE,
                 "email": "secret@example.com",
             },
-            headers={"X-Wallet-Address": _W_CHARLIE},
+            cookies=_siwe_cookies(_W_CHARLIE),
         )
         res = client.get(f"/api/user/profile/{_W_CHARLIE}")
         assert res.status_code == 200
@@ -253,7 +255,7 @@ class TestUserProfileRoutes:
                 "wallet_address": _W_CHARLIE,
                 "email": "owner@example.com",
             },
-            headers={"X-Wallet-Address": _W_CHARLIE},
+            cookies=_siwe_cookies(_W_CHARLIE),
         )
         res = client.get(
             f"/api/user/profile/{_W_CHARLIE}",
@@ -268,7 +270,7 @@ class TestUserProfileRoutes:
         client.post(
             "/api/user/profile",
             json={"wallet_address": wallet, "email": "private@example.com", "display_name": "Secret"},
-            headers={"X-Wallet-Address": wallet},
+            cookies=_siwe_cookies(wallet),
         )
         # Spoof with header only (no SIWE cookie)
         res = client.get(f"/api/user/profile/{wallet}", headers={"X-Wallet-Address": wallet})
@@ -283,7 +285,7 @@ class TestUserProfileRoutes:
         client.post(
             "/api/user/profile",
             json={"wallet_address": wallet_a, "email": "a@example.com"},
-            headers={"X-Wallet-Address": wallet_a},
+            cookies=_siwe_cookies(wallet_a),
         )
         # Session is for wallet_b, trying to read wallet_a
         res = client.get(f"/api/user/profile/{wallet_a}", cookies=_siwe_cookies(wallet_b))
@@ -291,12 +293,35 @@ class TestUserProfileRoutes:
         assert res.json()["email"] is None, "Wrong wallet session must not reveal PII"
 
     def test_write_without_any_auth_fails(self, client):
-        """POST without X-Wallet-Address or SIWE session returns 403."""
+        """POST without any auth returns 403 (no SIWE session)."""
         res = client.post(
             "/api/user/profile",
             json={"wallet_address": "0x9999999999999999999999999999999999999999"},
         )
         assert res.status_code == 403
+
+    def test_write_with_header_only_fails(self, client):
+        """POST with X-Wallet-Address header but no SIWE session returns 403 (Issue #402)."""
+        wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        res = client.post(
+            "/api/user/profile",
+            json={"wallet_address": wallet, "display_name": "HeaderOnly"},
+            headers={"X-Wallet-Address": wallet},
+        )
+        assert res.status_code == 403, "Header-only auth must be rejected for writes (Issue #402)"
+        assert "SIWE session required" in res.json().get("detail", "")
+
+    def test_write_with_wrong_siwe_session_fails(self, client):
+        """POST with SIWE session for wallet A claiming to write wallet B returns 403."""
+        session_wallet = "0xcccccccccccccccccccccccccccccccccccccccc"
+        payload_wallet = "0xdddddddddddddddddddddddddddddddddddddddd"
+        res = client.post(
+            "/api/user/profile",
+            json={"wallet_address": payload_wallet, "display_name": "Imposter"},
+            cookies=_siwe_cookies(session_wallet),
+        )
+        assert res.status_code == 403, "Session wallet must match payload wallet"
+        assert "does not match" in res.json().get("detail", "")
 
     def test_write_with_siwe_session_succeeds(self, client):
         """POST with a valid SIWE session (no header) should succeed."""

--- a/ui/src/components/WelcomeProfileModal.jsx
+++ b/ui/src/components/WelcomeProfileModal.jsx
@@ -64,8 +64,8 @@ export default function WelcomeProfileModal({ walletAddr, onDone, mode = 'welcom
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-Wallet-Address': walletAddr,
         },
+        credentials: 'include',  // Issue #402: SIWE session cookie required for profile writes
         body: JSON.stringify(payload),
       })
       if (!res.ok) {


### PR DESCRIPTION
## Summary

Closes #402. Profile writes (POST /api/user/profile) no longer accept the
forgeable X-Wallet-Address header as an auth fallback. SIWE session is now
required for the write — the same cryptographic-proof bar that already
gates PII reads. The boundary was the same shape on both sides of the
read/write split before; now it's actually enforced symmetrically.

## What changes

**Backend** (`backend/archimedes/api/user_routes.py`):
- Removed `_extract_caller_wallet` (the function that fell through to the header).
- `upsert_profile` now uses `_extract_caller_wallet_siwe` and returns two distinct 403s — "SIWE session required for profile writes" (no session present) and "SIWE session wallet does not match payload wallet" (session-vs-payload mismatch). Clearer signals for the frontend, simpler test assertions.

**Frontend** (`ui/src/components/WelcomeProfileModal.jsx`):
- Added `credentials: 'include'` to the POST so the SIWE session cookie is actually sent. Previously the welcome flow relied on the X-Wallet-Address header which is no longer trusted.
- Removed the `'X-Wallet-Address'` header from that fetch since the backend ignores it.

**Tests** (`backend/tests/test_user_routes.py`, `backend/tests/test_user_profile_privacy.py`):
- Every profile-write test was switched from `headers={"X-Wallet-Address": …}` to `cookies=_siwe_cookies(…)` via the existing helper.
- Two new tests lock in the #402 behavior:
  - `test_write_with_header_only_fails` — POST with header but no SIWE → 403 with "SIWE session required" in the detail.
  - `test_write_with_wrong_siwe_session_fails` — POST with mismatched-wallet SIWE session → 403 with "does not match" in the detail.
- The `test_upsert_encrypts_email_before_storage` integration test was updated to patch `archimedes.api.auth_siwe.get_verified_wallet` instead of setting a mock header (since the header is no longer the auth source).
- Module docstring updated to describe the new auth model.

## Out of scope (deferred to follow-up cleanup)

- `X-Wallet-Address` is still in the CORS `allow_headers` list (`main.py:113-119`) and still sent by `Layout.jsx:71-74` on the profile GET. Both are dead config now (backend ignores the header on both reads and writes), but removing them is unrelated to the security boundary closure. Worth a small cleanup PR — flagging here so it's not forgotten.

## Test results

```
backend/tests/test_user_routes.py            18 passed
backend/tests/test_user_profile_privacy.py   12 passed
backend/tests/test_security_hardening.py     20 passed
```

Hermetic — runs with `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest` (no .env, no docker, no network).

## Verify

```bash
# Header-only POST is rejected
curl -X POST https://archimedes-arc.app/api/user/profile \
  -H 'Content-Type: application/json' \
  -H 'X-Wallet-Address: 0x...' \
  -d '{"wallet_address": "0x...", "display_name": "spoofed"}'
# → 403 {"detail":"Forbidden: SIWE session required for profile writes"}

# SIWE-session POST succeeds (with valid cookie)
curl -X POST https://archimedes-arc.app/api/user/profile \
  -H 'Content-Type: application/json' \
  --cookie 'archimedes_session=<valid-signed-cookie>' \
  -d '{"wallet_address": "0x<matching-wallet>", "display_name": "ok"}'
# → 200 {"wallet_address": ..., "display_name": "ok", ...}
```