### PR TITLE
[infra] Clear hash-prefixed orphan containers before docker compose up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,6 +101,7 @@ jobs:
               "sed -i '"'"'/^VITE_CIRCLE_CLIENT_KEY=/d'"'"' .env",
               "echo \"VITE_CIRCLE_CLIENT_KEY=${{ secrets.VITE_CIRCLE_CLIENT_KEY }}\" >> .env",
               "docker compose build --no-cache",
+              "docker ps -aq --filter '"'"'name=^[0-9a-f]\\{12\\}_archimedes-'"'"' | xargs -r docker rm -f 2>/dev/null || true",
               "docker compose up -d --force-recreate --remove-orphans",
               "docker image prune -f",
               "docker compose exec -T backend python -m archimedes.scripts.seed_backtests_from_artifacts || echo WARN_SEED_SKIP",


### PR DESCRIPTION
## Summary

Unblocks the deploy pipeline after PR #430's failure. Adds one line that pre-emptively removes hash-prefixed orphan containers before `docker compose up --force-recreate`.

## Diagnosis

PR #430's deploy failed with:

```
Container archimedes-redis-1 Error response from daemon: Conflict.
The container name "/8e4ed551c6dd_archimedes-redis-1" is already in use
by container "d4cbf2154d9c..."
```

Sequence of events that produced the orphan:
1. PR #429 merged at 02:04:38Z → deploy run started
2. PR #430 merged 17 seconds later (02:04:55Z)
3. Concurrency rule `cancel-in-progress: true` cancelled PR #429's deploy at 02:05:08Z while `docker compose up --force-recreate` was mid-rename (had just renamed the existing redis container to `8e4ed551c6dd_archimedes-redis-1` as the prelude to deletion + recreation)
4. PR #430's deploy ran the same `up --force-recreate` and tried to rename redis again → conflict on the still-present orphan from step 3

## Fix

Before `docker compose up`, scan for containers matching docker's hash-prefix rename pattern (`^[0-9a-f]{12}_archimedes-`) and force-remove them:

```diff
  "docker compose build --no-cache",
+ "docker ps -aq --filter 'name=^[0-9a-f]\{12\}_archimedes-' | xargs -r docker rm -f 2>/dev/null || true",
  "docker compose up -d --force-recreate --remove-orphans",
```

Pattern specificity matters: `^[0-9a-f]{12}_archimedes-` only matches orphans from interrupted recreations. It will NOT match normally-named containers (`archimedes-redis-1`, `archimedes-backend-1`, etc.), so this is safe to run on every deploy as a defensive no-op when there are no orphans.

The existing `--remove-orphans` flag on `up` handles *service* orphans (services removed from compose.yml) but not *container* orphans from interrupted recreates — different problem class.

## Why this happened now (and won't again with this fix)

The deploy.yml's concurrency rule `cancel-in-progress: true` is correct — we don't want stacked deploys racing. But it creates the failure window: any merge-during-deploy combination can interrupt the rename dance. Without explicit orphan cleanup, the next deploy fails.

This fix neutralizes the failure mode regardless of whether `cancel-in-progress` fires, an EC2 reboot during deploy, or any other interruption mid-rename.

## Out of scope (follows in other issues)

- **Zero-downtime deploys** — blue/green or rolling restart strategies. Out of scope at our scale; the docker compose recreate dance creates ~30-60s of downtime per deploy, which is acceptable for the hackathon/demo project.
- **Staging deploy target (#425)** — the durable answer to "we can't validate deploy.yml changes against production runtime." This PR is a tactical fix; #425 is the structural one.

## Verify

```bash
gh pr checkout 431  # or whatever this becomes
# Inspect the change:
grep -n "name=^" .github/workflows/deploy.yml
# Should show the new line at the correct position
```

After merge: the next deploy should land cleanly. If it fails for an unrelated reason, the orphan-cleanup will still have run as a no-op (`|| true`).