### PR TITLE
[tests] Fix executor fixture gas_price latent bug + simplify raw-key tests (#430 follow-up)

### DIFF
--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -21,6 +21,32 @@ from archimedes.chain.executor import (
 from archimedes.models.portfolio import TradeDirection, TradeOrder
 from hexbytes import HexBytes
 
+# ── Helpers ───────────────────────────────────────────────────
+
+
+class _Awaitable:
+    """Re-awaitable value wrapper for attribute-access await patterns.
+
+    The executor reads `chain_client.w3.eth.gas_price` like a property —
+    that is, `await mock.gas_price` where `gas_price` is accessed by
+    attribute, not called. `AsyncMock` instances satisfy `await mock()`
+    (call pattern) but NOT `await mock` (attribute pattern); the call
+    pattern is what makes a method awaitable, the attribute pattern needs
+    the attribute *itself* to be awaitable. This helper wraps any value
+    so `await _Awaitable(x)` returns `x`, and is safe to await repeatedly
+    (each `__await__` creates a fresh coroutine).
+    """
+
+    def __init__(self, value):
+        self._value = value
+
+    def __await__(self):
+        async def _coro():
+            return self._value
+
+        return _coro().__await__()
+
+
 # ── Fixtures ──────────────────────────────────────────────────
 
 
@@ -56,7 +82,16 @@ def executor(mock_loader):
         mock_cc.to_checksum = lambda addr: addr  # pass-through
         mock_cc.w3 = MagicMock()
         mock_cc.w3.eth = MagicMock()
-        mock_cc.w3.eth.gas_price = AsyncMock(return_value=1000000000)
+        # Property pattern: `await w3.eth.gas_price` (attribute access, then await).
+        # _Awaitable satisfies this; AsyncMock does not (latent bug in prior fixture
+        # versions; surfaced and worked around in PR #430, fixed properly here).
+        mock_cc.w3.eth.gas_price = _Awaitable(1000000000)
+        # Method pattern: `await w3.eth.method(args)` (call, then await). AsyncMock
+        # is the right shape here. Set defaults so raw-key path tests don't have to
+        # re-spell common values; individual tests can override per-scenario.
+        mock_cc.w3.eth.get_transaction_count = AsyncMock(return_value=1)
+        mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=HexBytes(b"\x00" * 32))
+        mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value={"status": 1})
 
         ex = ChainExecutor(loader=mock_loader)
         ex._mock_cc = mock_cc  # expose for test access
@@ -229,67 +264,14 @@ class TestExecuteTrades:
 # ── execute_trades depth coverage (#408) ──────────────────────
 
 
-class _Awaitable:
-    """A re-awaitable value wrapper. Needed because the executor awaits
-    `chain_client.w3.eth.gas_price` like a property, which means the
-    attribute itself must be awaitable. AsyncMock instances are only
-    awaitable when *called*, not on attribute access, so they don't fit
-    this access pattern. This helper wraps any value so `await wrapper`
-    returns it, and is safe to await repeatedly.
-    """
-
-    def __init__(self, value):
-        self._value = value
-
-    def __await__(self):
-        async def _coro():
-            return self._value
-
-        return _coro().__await__()
-
-
-def _install_raw_key_eth(executor, tx_hash):
-    """Replace `executor._mock_cc.w3.eth` with a minimal real namespace that
-    correctly supports the production raw-key path's await pattern.
-
-    Returns the namespace so callers can override individual attrs per-test
-    (e.g. swap send_raw_transaction for a side_effect-raising async fn).
-    """
-    import types
-
-    async def _get_tx_count(addr, when=None):
-        return 1
-
-    async def _send_raw_transaction(raw):
-        return tx_hash
-
-    async def _wait_for_receipt(wait_arg):  # not used by these tests — _confirm_receipt is mocked
-        return {"status": 1}
-
-    ns = types.SimpleNamespace(
-        chain_id=5042002,
-        gas_price=_Awaitable(1_000_000_000),
-        get_transaction_count=_get_tx_count,
-        send_raw_transaction=_send_raw_transaction,
-        wait_for_transaction_receipt=_wait_for_receipt,
-    )
-    executor._mock_cc.w3.eth = ns
-    return ns
-
-
 def _install_raw_key_vault(mock_loader, mock_account):
     """Wire up vault.functions.rebalance(...).build_transaction(...) to
-    return a plausible tx dict via real async functions (not AsyncMock),
-    because the AsyncMock-on-attribute pattern bites the same way
-    gas_price does.
+    return a plausible tx dict. Per-test helper because each test's
+    mock_account.address differs.
     """
-
-    async def _build_transaction(tx_dict):
-        return {"from": mock_account.address, "nonce": 1, "gas": 2_000_000, **tx_dict}
-
-    inner = MagicMock()
-    inner.build_transaction = _build_transaction
-    mock_loader.vault.return_value.functions.rebalance.return_value = inner
+    mock_loader.vault.return_value.functions.rebalance.return_value.build_transaction = AsyncMock(
+        return_value={"from": mock_account.address, "nonce": 1, "gas": 2_000_000}
+    )
 
 
 class TestExecuteTradesDepth:
@@ -441,7 +423,7 @@ class TestExecuteTradesDepth:
         mock_account.sign_transaction.return_value = signed
 
         executor._mock_cc.settings.agent_account = mock_account
-        _install_raw_key_eth(executor, hex_hash)
+        executor._mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=hex_hash)
         _install_raw_key_vault(mock_loader, mock_account)
 
         with (
@@ -469,7 +451,7 @@ class TestExecuteTradesDepth:
         mock_account.sign_transaction.return_value = MagicMock(raw_transaction=b"\x04\x05\x06")
 
         executor._mock_cc.settings.agent_account = mock_account
-        _install_raw_key_eth(executor, hex_hash)
+        executor._mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=hex_hash)
         _install_raw_key_vault(mock_loader, mock_account)
 
         with (
@@ -495,7 +477,7 @@ class TestExecuteTradesDepth:
         mock_account.sign_transaction.return_value = MagicMock(raw_transaction=b"\x07\x08\x09")
 
         executor._mock_cc.settings.agent_account = mock_account
-        _install_raw_key_eth(executor, hex_hash)
+        executor._mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=hex_hash)
         _install_raw_key_vault(mock_loader, mock_account)
 
         with (
@@ -520,14 +502,8 @@ class TestExecuteTradesDepth:
         mock_account.sign_transaction.return_value = MagicMock(raw_transaction=b"\x0a\x0b\x0c")
 
         executor._mock_cc.settings.agent_account = mock_account
-        eth_ns = _install_raw_key_eth(executor, HexBytes("0x" + "ff" * 32))
+        executor._mock_cc.w3.eth.send_raw_transaction = AsyncMock(side_effect=ConnectionError("RPC down"))
         _install_raw_key_vault(mock_loader, mock_account)
-
-        # Override send_raw_transaction to raise instead of returning a hash
-        async def _failing_send(raw):
-            raise ConnectionError("RPC down")
-
-        eth_ns.send_raw_transaction = _failing_send
 
         with (
             patch.object(executor, "_validate_trade_liquidity", new=AsyncMock()),


### PR DESCRIPTION
## Summary

Closes the latent bug Pi flagged in her PR #430 review: the shared executor fixture mocks `chain_client.w3.eth.gas_price` as `AsyncMock(return_value=...)`, but the production code reads it as an awaitable property (`await mock.gas_price`), not as a callable (`await mock.gas_price()`). `AsyncMock` instances satisfy the call-pattern, not the attribute-pattern.

PR #430 worked around this with per-test helpers (`_install_raw_key_eth`). This PR fixes the fixture properly so the helpers can be retired.

## Why the bug was latent until #430

Every test before #430 took the Circle signer path, which never touches `gas_price`. The line `mock_cc.w3.eth.gas_price = AsyncMock(...)` was wrong from the start but invisible. PR #430 introduced the first tests that exercise the raw-key signer path — which immediately hit the wall (`TypeError: object AsyncMock can't be used in 'await' expression`). #430 worked around it with a per-test namespace replacement; this PR fixes the root cause.

## What changes

**1. Promote `_Awaitable` from inside the test class to module scope**

The `_Awaitable` helper from #430 lives just below the `_make_trade` helper now. Trivially reusable.

**2. Fixture uses `_Awaitable` for property-pattern, `AsyncMock` for call-pattern**

```diff
- mock_cc.w3.eth.gas_price = AsyncMock(return_value=1000000000)
+ # Property pattern: `await w3.eth.gas_price` (attribute access, then await).
+ mock_cc.w3.eth.gas_price = _Awaitable(1000000000)
+ # Method pattern: `await w3.eth.method(args)` (call, then await).
+ mock_cc.w3.eth.get_transaction_count = AsyncMock(return_value=1)
+ mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=HexBytes(b"\x00" * 32))
+ mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value={"status": 1})
```

The fixture comment now explicitly notes the two await-shapes so future-reader doesn't repeat the mistake.

**3. Remove `_install_raw_key_eth` — fixture handles it now**

The 25-line helper that #430 introduced is gone. The four raw-key tests previously called `_install_raw_key_eth(executor, hex_hash)` to install a `types.SimpleNamespace` over the fixture's broken eth mock. Now they just override the one attribute they need:

```diff
- _install_raw_key_eth(executor, hex_hash)
- _install_raw_key_vault(mock_loader, mock_account)
+ executor._mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=hex_hash)
+ _install_raw_key_vault(mock_loader, mock_account)
```

For the network-failure test, the override is a `side_effect` instead of `return_value`:

```diff
- eth_ns = _install_raw_key_eth(executor, HexBytes("0x" + "ff" * 32))
- async def _failing_send(raw):
-     raise ConnectionError("RPC down")
- eth_ns.send_raw_transaction = _failing_send
+ executor._mock_cc.w3.eth.send_raw_transaction = AsyncMock(side_effect=ConnectionError("RPC down"))
```

**4. Keep `_install_raw_key_vault`, simplify it to `AsyncMock`**

The `vault.functions.rebalance(args).build_transaction(args)` chain is genuinely per-test (each test's `mock_account.address` differs). The helper stays. But now that `gas_price` works, the inner `build_transaction` can be a plain `AsyncMock(return_value=...)` — no real `async def` needed:

```diff
-     async def _build_transaction(tx_dict):
-         return {"from": mock_account.address, "nonce": 1, "gas": 2_000_000, **tx_dict}
-
-     inner = MagicMock()
-     inner.build_transaction = _build_transaction
-     mock_loader.vault.return_value.functions.rebalance.return_value = inner
+     mock_loader.vault.return_value.functions.rebalance.return_value.build_transaction = AsyncMock(
+         return_value={"from": mock_account.address, "nonce": 1, "gas": 2_000_000}
+     )
```

(The original PR #430 used a real `async def` because the AsyncMock-on-attribute pattern *appeared* broken — but it was actually `gas_price` failing first during arg-dict construction. With gas_price fixed, AsyncMock works fine for build_transaction.)

## Diff stats

```
1 file changed, 45 insertions(+), 69 deletions(-)
```

Net **-24 lines**, same test coverage, same 33 tests passing, cleaner shape, fixture now models reality.

## Test results

```
backend/tests/chain/test_chain_executor.py   28 passed
backend/tests/chain/test_executor_receipt.py  5 passed
Total: 33 passed, 0 failed.
```

Hermetic (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest`).
Ruff lint + format clean.

## Followups still tracked

- #408 sub-tasks 2-5 (`_confirm_receipt`, `create_vault`, `set_token_oracles`, `set_target_allocations`) — separate PRs to follow
- The two await-shapes documented inline in the fixture should keep future test authors out of this trap; no separate doc change needed.