### PR TITLE
[infra] Fix terraform apply: ASCII descriptions + cross-VPC routing + IP targets

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -138,7 +138,7 @@ resource "aws_acm_certificate_validation" "main" {
 
 resource "aws_security_group" "alb" {
   name        = "${var.project_name}-alb-sg"
-  description = "ALB — public HTTPS only"
+  description = "ALB - public HTTPS only"
   vpc_id      = aws_vpc.main.id
 
   # HTTPS from internet
@@ -201,10 +201,11 @@ resource "aws_lb" "main" {
 # Points at the EC2 instance. Health check on /health (not /api/generate/stream/).
 
 resource "aws_lb_target_group" "backend" {
-  name     = "${var.project_name}-backend-tg"
-  port     = 80
-  protocol = "HTTP"
-  vpc_id   = data.aws_vpc.default.id # EC2 is still in default VPC
+  name        = "${var.project_name}-backend-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id # ALB and TG must be in same VPC
+  target_type = "ip"           # IP-based targeting for cross-VPC (EC2 in default VPC)
 
   health_check {
     enabled             = true
@@ -224,9 +225,10 @@ resource "aws_lb_target_group" "backend" {
 }
 
 resource "aws_lb_target_group_attachment" "backend" {
-  target_group_arn = aws_lb_target_group.backend.arn
-  target_id        = aws_instance.archimedes.id
-  port             = 80
+  target_group_arn  = aws_lb_target_group.backend.arn
+  target_id         = aws_instance.archimedes.private_ip # IP target, not instance ID
+  port              = 80
+  availability_zone = "all" # Cross-VPC IP target
 }
 
 # ── Listeners ────────────────────────────────────────────────

--- a/infra/aurora.tf
+++ b/infra/aurora.tf
@@ -18,7 +18,7 @@ resource "aws_db_subnet_group" "aurora" {
 
 resource "aws_security_group" "aurora" {
   name        = "${var.project_name}-aurora-sg"
-  description = "Aurora — only reachable from EC2 backend"
+  description = "Aurora - only reachable from EC2 backend"
   vpc_id      = aws_vpc.main.id
 
   # Inbound: Postgres from the EC2 security group (current default VPC)

--- a/infra/elasticache.tf
+++ b/infra/elasticache.tf
@@ -14,7 +14,7 @@ resource "aws_elasticache_subnet_group" "main" {
 
 resource "aws_security_group" "redis" {
   name        = "${var.project_name}-redis-sg"
-  description = "ElastiCache Redis — only reachable from EC2 backend"
+  description = "ElastiCache Redis - only reachable from EC2 backend"
   vpc_id      = aws_vpc.main.id
 
   # Inbound: Redis from private subnets
@@ -50,7 +50,7 @@ resource "aws_security_group" "redis" {
 
 resource "aws_elasticache_replication_group" "main" {
   replication_group_id = "${var.project_name}-redis"
-  description          = "Archimedes Redis — regime state, traces, job queue"
+  description          = "Archimedes Redis - regime state, traces, job queue"
 
   engine         = "redis"
   engine_version = "7.1"

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -62,6 +62,12 @@ resource "aws_route_table" "public" {
     gateway_id = aws_internet_gateway.main.id
   }
 
+  # Route to default VPC via peering (ALB needs to reach EC2)
+  route {
+    cidr_block                = "172.31.0.0/16"
+    vpc_peering_connection_id = aws_vpc_peering_connection.default_to_main.id
+  }
+
   tags = {
     Name    = "${var.project_name}-public-rt"
     Project = var.project_name
@@ -124,7 +130,7 @@ data "aws_ami" "fck_nat" {
 
 resource "aws_security_group" "nat" {
   name        = "${var.project_name}-nat-sg"
-  description = "NAT instance — allows outbound for private subnets"
+  description = "NAT instance - allows outbound for private subnets"
   vpc_id      = aws_vpc.main.id
 
   # Inbound from private subnets (all traffic)


### PR DESCRIPTION
Fixes discovered during `terraform apply`. All infrastructure is now live.

## Fixes
1. Em-dashes → ASCII dashes in SG descriptions (AWS rejects non-ASCII)
2. Target group: instance-based → IP-based for cross-VPC ALB→EC2
3. Public route table: added peering route to 172.31.0.0/16

## Verified live
- Site: `curl https://archimedes-arc.app/api/health` → `ok`
- ALB target: healthy
- ACM cert: ISSUED
- WAF: attached