### PR TITLE
[infra] Deploy: disk cleanup + extend SSM timeout (30 min) — fix both #434 and #435 deploy failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 35  # SSM 30min + AWS API overhead + buffer
 
     steps:
       - name: Configure AWS credentials (OIDC)
@@ -80,7 +80,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$EC2_INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --timeout-seconds 600 \
+            --timeout-seconds 1800 \
             --parameters commands='[
               "#!/bin/bash",
               "set -eux",
@@ -91,6 +91,10 @@ jobs:
               "sudo chown -R ubuntu:ubuntu analytics-engine/artifacts/ 2>/dev/null || true",
               "git fetch origin main",
               "git reset --hard origin/main",
+              "df -h / | tail -1 | awk '"'"'{print \"DISK_BEFORE: \"$0}'"'"'",
+              "docker container prune -f 2>/dev/null || true",
+              "docker image prune -af 2>/dev/null || true",
+              "df -h / | tail -1 | awk '"'"'{print \"DISK_AFTER_PRUNE: \"$0}'"'"'",
               "sed -i '"'"'/^LLM_PROVIDER=/d; /^LLM_AUTH_TOKEN=/d; /^LLM_BASE_URL=/d'"'"' .env",
               "echo \"LLM_PROVIDER=${{ secrets.LLM_PROVIDER }}\" >> .env",
               "echo \"LLM_AUTH_TOKEN=${{ secrets.LLM_AUTH_TOKEN }}\" >> .env",
@@ -117,8 +121,8 @@ jobs:
 
           echo "SSM Command ID: $COMMAND_ID"
 
-          # Poll for completion
-          for i in $(seq 1 60); do
+          # Poll for completion (180 × 10s = 30 min, matches SSM --timeout-seconds 1800)
+          for i in $(seq 1 180); do
             STATUS=$(aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
               --instance-id "$EC2_INSTANCE_ID" \


### PR DESCRIPTION
## Summary

Two consecutive merge-to-main deploys (#434 and #435) failed in different ways. This PR addresses both root causes in deploy.yml.

## Failure analysis

### #434 (merged at 11:37Z) — Timeout
SSM command status was `InProgress` for the full 10 minutes (60 polling attempts × 10s), then the polling loop gave up with "❌ Deploy timed out waiting for SSM command." The SSM agent kept the command running but it didn't finish.

**Probable cause**: `docker compose build --no-cache` of the full stack (5 services including the heavy kb-runner with apt-get install of binutils + gcc + etc.) can legitimately exceed 10 minutes on a t3.small. Earlier deploys may have benefited from layer cache that's been invalidated.

### #435 (merged at 12:09Z) — Instant failure with empty output
SSM Command ID returned at 12:09:17, polling loop got Status=`Failed` on first iteration at 12:09:18 (1 second later), stdout AND stderr both empty.

**Probable cause**: disk full on the instance. The script begins with `set -eux`, which would print every command including failures. Empty stderr means **bash never started** — the SSM agent failed BEFORE invoking the script. The most common cause of this pattern is `/tmp` or root filesystem full preventing the agent from writing the temp script. Each failed deploy leaves ~2-3 GB of new docker images (since `docker compose build --no-cache` always rebuilds and `docker image prune -f` only runs AFTER a successful `up`); after several failures, the disk fills.

## Fix

```diff
- timeout-minutes: 15
+ timeout-minutes: 35  # SSM 30min + AWS API overhead + buffer
  ...
- --timeout-seconds 600 \
+ --timeout-seconds 1800 \
  ...
  "git reset --hard origin/main",
+ "df -h / | tail -1 | awk '{print \"DISK_BEFORE: \"$0}'",
+ "docker container prune -f 2>/dev/null || true",
+ "docker image prune -af 2>/dev/null || true",
+ "df -h / | tail -1 | awk '{print \"DISK_AFTER_PRUNE: \"$0}'",
  "sed -i '/^LLM_PROVIDER=/d; ...' .env",
  ...
- # Poll for completion
- for i in $(seq 1 60); do
+ # Poll for completion (180 × 10s = 30 min, matches SSM --timeout-seconds 1800)
+ for i in $(seq 1 180); do
```

**Disk cleanup before build** — addresses the suspected #435 cause AND prevents recurrence. Runs *after* `git reset --hard` (so script knows we have latest code) but *before* `docker compose build --no-cache` (so the build has free disk).

**df -h / before and after the prune** — surfaces disk state in the SSM stdout so future debugging can confirm or rule out disk pressure without needing instance access.

**Timeout extension** — addresses the suspected #434 cause. 30 minutes is generous for our build profile; fast builds still finish in seconds.

## Safety

Both changes are safe-by-default:
- `docker container prune -f` only removes stopped containers (running containers untouched)
- `docker image prune -af` removes all images not referenced by a container — `docker compose up` after the build will pull/build everything it needs again
- The `2>/dev/null || true` makes the prune steps fault-tolerant
- Timeout extension only matters when builds are slow; doesn't affect fast deploys

## Verify

After merge, the next deploy should:
- Print `DISK_BEFORE: /dev/...` then `DISK_AFTER_PRUNE: /dev/...` in the SSM stdout — confirms disk visibility
- Complete in the new 30-minute window (or finish faster with healthy cache)
- Exit `Success` rather than `Failed` or `TimedOut`

If #435's instant-failure recurs after this PR, the cause was NOT disk-full — likely SSM agent state on the instance. Pi or Chuan would need hands-on (SSM Session Manager) to investigate.

## Out of scope

- Staging deploy target (#425) remains the durable fix for this class of "can't validate deploy.yml against actual instance state until prod merge" bugs.
- The `docker compose build --no-cache` flag itself is the source of the slow builds + disk pressure. Dropping it would dramatically speed up builds but risks shipping stale images for changed source files; that's a separate trade-off worth its own issue if we ever want to re-evaluate.