### PR TITLE
[deps] Bump yfinance >=0.2.40 → >=1.4.1; fix single-ticker Close access

### DIFF
--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -213,7 +213,13 @@ class OracleUpdater:
                     if data.empty:
                         continue
                     if len(symbols) == 1:
-                        price = float(data["Close"].iloc[-1])
+                        close = data["Close"]
+                        # yfinance >=1.0 returns a 1-column DataFrame (MultiIndex
+                        # columns) for single-ticker downloads; squeeze to a Series
+                        # before taking the last value.
+                        if hasattr(close, "columns"):
+                            close = close.iloc[:, 0]
+                        price = float(close.iloc[-1])
                     else:
                         close = data["Close"]
                         if yf_ticker in close.columns:
@@ -270,7 +276,12 @@ class OracleUpdater:
 
             data = await asyncio.to_thread(yf.download, symbol, period="1d", interval="1m", progress=False)
             if not data.empty:
-                return float(data["Close"].iloc[-1])
+                close = data["Close"]
+                # yfinance >=1.0 returns a 1-column DataFrame for single-ticker
+                # downloads; squeeze to a Series before taking the last value.
+                if hasattr(close, "columns"):
+                    close = close.iloc[:, 0]
+                return float(close.iloc[-1])
         except Exception as e:
             logger.warning(f"Failed to fetch {symbol}: {e}")
         return None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,7 +21,7 @@ pandas>=2.2
 scipy>=1.13
 
 # Market data
-yfinance>=0.2.40
+yfinance>=1.4.1
 requests>=2.32
 aiohttp>=3.13.5
 # httpx is directly imported by services/corpus_service.py (arXiv intake) and

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
       - seaborn>=0.13
 
       # --- Market data ---
-      - yfinance>=0.2.40              # Historical + live equity/ETF/crypto data; for backtesting
+      - yfinance>=1.4.1              # Historical + live equity/ETF/crypto data; for backtesting
       - requests>=2.32
       - aiohttp>=3.13.5               # Floor aligned with backend/requirements.txt via dependabot PR #250.
       - httpx>=0.27                   # Directly imported by services/corpus_service.py (arXiv intake) and services/llm_backend.py (OpenAI-compatible + Ollama). Pinned so we don't rely on transitive resolution.


### PR DESCRIPTION
Supersedes #448 (Dependabot) — verifies every yfinance call site against the 0.2→1.x rewrite rather than bumping the pin blind.

## What changed
- Pin bumped `yfinance>=0.2.40 → >=1.4.1` in both `backend/requirements.txt` and `environment.yml` (kept aligned per repo convention).
- Fixed two genuinely-broken single-ticker call sites in `backend/archimedes/chain/oracle_updater.py`.

## Why the code fix was needed
The yfinance 0.2→1.x rewrite changed single-ticker `yf.download(...)` to return a **MultiIndex-column DataFrame** by default, so `data["Close"]` is now a 1-column DataFrame, not a Series. `float(data["Close"].iloc[-1])` therefore raises `TypeError: float() argument must be ... not 'Series'`.

Verified live against yfinance 1.4.1 with a throwaway smoke script (not committed) exercising all 6 call sites:

| Call site | Status |
|-----------|--------|
| `oracle_updater.py:216` single-ticker `float(data["Close"].iloc[-1])` | **fixed** — added `hasattr(close,"columns")` squeeze |
| `oracle_updater.py:273` single-ticker (`_fetch_yfinance_single`) | **fixed** — same squeeze |
| `oracle_updater.py:218` multi-ticker `close[yf_ticker]` | already safe (multi-ticker stays MultiIndex) |
| `oracle_updater.py:289` `Ticker.history` MA path | already safe (flat Series) |
| `asset_market_service.py:165` | already safe (`hasattr(close,"columns")` guard) |
| `strategy_signal_evaluator.py:374 / 448 / 465` | already safe (`isinstance(close, pd.DataFrame)` guards; multi path uses `group_by="ticker"`) |

The fix matches the existing squeeze pattern already used elsewhere in the codebase (`asset_market_service.py`, `strategy_signal_evaluator.py`).

## auto_adjust note
`auto_adjust` default flipped `False→True` in 1.0. No code references `"Adj Close"` (grep clean), and the three sites that depend on adjusted data already pass `auto_adjust=True` explicitly. The oracle intraday spot-price fetches are unaffected (no dividends/splits within a 1-day/1-min window).

## Verification
- `ruff format --check` + `ruff check` clean on the edited file.
- Hermetic suite: `1119 passed` (identical to pre-change baseline; the only failures are a local `boto3`-missing env gap unrelated to this change — those modules import `boto3` which isn't in the local conda env but is present in CI).
- Live smoke test confirmed all 6 patterns return correct float prices on yfinance 1.4.1.

Closes #448