### PR TITLE
[tests] Mark empty aspirational flow 7-11 tests as skipped (#444)

### DIFF
--- a/tests/flows/test_flow_7_11_aspirational.py
+++ b/tests/flows/test_flow_7_11_aspirational.py
@@ -13,6 +13,15 @@ Flow 10: LP dashboard (add/remove liquidity UI)
 Flow 11: Strategy explorer with paper citations
 """
 
+import pytest
+
+# These flows are aspirational specs beyond the hard commit line. Most of the
+# test bodies are intentionally empty (docstring-only), so without this marker
+# they would report as *passing* — false-green coverage. Skip the whole module
+# so they surface honestly as "not yet implemented" until someone picks them up
+# and drops the marker (or converts an individual test to a real implementation).
+pytestmark = pytest.mark.skip(reason="Aspirational flows 7–11 — specs only, not yet implemented (#444)")
+
 
 # ═══════════════════════════════════════════════════════════════
 # FLOW 7: Community Vault Creation [ASPIRATIONAL]


### PR DESCRIPTION
Closes #444 ("APIN - /tests/whatever complete empty tests").

## Problem
`tests/flows/test_flow_7_11_aspirational.py` contains 29 test functions, most of which are **docstring-only** (no body, no assertions). In Python a docstring-only function is a valid no-op, so these tests **silently pass** — false-green coverage for features that don't exist yet (community vaults, AMM vault-token trading, per-vault chat, LP dashboard).

## Fix
Add a module-level `pytestmark = pytest.mark.skip(...)`. The file's own header already declares it *"[OPTIONAL — written but skippable]"*, so this just makes the intent real: the 29 tests now report as **skipped** ("specs only, not yet implemented") instead of passing empty. Whoever implements a flow drops the marker or converts the individual test.

## Verify
```
python -m pytest tests/flows/test_flow_7_11_aspirational.py -q
# → 29 skipped
```

## Anti-goals
- Doesn't delete the specs (they're a useful implementation checklist) or touch the hard-commit-line tests in `backend/tests/` (which is what `pytest.ini` `testpaths` actually collects).