### PR TITLE
[backtest] Seed only latest artifact per strategy with fallback (#462)

### DIFF
--- a/backend/archimedes/scripts/seed_backtests_from_artifacts.py
+++ b/backend/archimedes/scripts/seed_backtests_from_artifacts.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import defaultdict
 from pathlib import Path
 
 from archimedes.db import get_session, init_db
@@ -56,52 +57,79 @@ def seed_from_artifacts(artifact_dir: Path | None = None) -> dict[str, int]:
     for s in strategies:
         strategy_by_title[s.paper_title] = s
 
+    # Group every artifact file by the strategy (paper title) it describes, then
+    # seed only the *current-state* run per strategy: the newest artifact that
+    # parses + maps cleanly. The artifact directory accumulates one JSON per
+    # backtest re-run, so a single strategy can have several timestamped files;
+    # globbing and seeding all of them persisted stale runs alongside the current
+    # one. run_id is a sortable ISO-8601 UTC timestamp (e.g. "20260518T223800Z"),
+    # so a reverse string sort gives newest-first, and if the newest run is broken
+    # we fall back to the next-newest — a single corrupt artifact never silently
+    # drops a strategy's backtest entirely.
+    artifacts_by_title: dict[str, list[tuple[Path, str, dict]]] = defaultdict(list)
+    for artifact_path in artifact_dir.glob("*.json"):
+        try:
+            raw = artifact_path.read_text(encoding="utf-8")
+            payload = json.loads(raw)
+        except Exception as exc:
+            logger.warning("skip unreadable artifact %s: %s", artifact_path.name, exc)
+            continue
+        title = payload.get("strategy", {}).get("paper_title", "")
+        artifacts_by_title[title].append((artifact_path, raw, payload))
+
+    # Newest run first, keyed on run_id (falling back to the filename stem).
+    for candidates in artifacts_by_title.values():
+        candidates.sort(key=lambda c: c[2].get("run_id") or c[0].stem, reverse=True)
+
     inserted = 0
     skipped = 0
     failed = 0
 
-    for artifact_path in sorted(artifact_dir.glob("*.json")):
-        try:
-            raw = artifact_path.read_text(encoding="utf-8")
-            payload = json.loads(raw)
-            artifact = AnalyticsArtifactModel.model_validate(payload)
+    for title, candidates in artifacts_by_title.items():
+        strategy = strategy_by_title.get(title)
+        if strategy is None:
+            logger.warning("skip %d artifact(s): no matching strategy for '%s'", len(candidates), title)
+            failed += 1
+            continue
 
-            # Match artifact to strategy by paper title
-            title = payload.get("strategy", {}).get("paper_title", "")
-            strategy = strategy_by_title.get(title)
+        # Try newest-first; stop at the first run that seeds successfully and
+        # ignore that strategy's older runs.
+        seeded = False
+        for artifact_path, raw, payload in candidates:
+            try:
+                artifact = AnalyticsArtifactModel.model_validate(payload)
+                mapped, selected_operation = map_artifact_to_backtest_result(
+                    artifact,
+                    strategy_id=strategy.id,
+                )
+                content_hash = canonical_artifact_hash(payload)
 
-            if strategy is None:
-                logger.warning("skip %s: no matching strategy for '%s'", artifact_path.name, title)
-                failed += 1
+                with get_session() as session:
+                    _, was_inserted = insert_backtest_if_missing(
+                        session,
+                        strategy_id=strategy.id,
+                        content_hash=content_hash,
+                        result=mapped,
+                        run_id=artifact.run_id,
+                        operation=selected_operation,
+                        artifact_json=raw,
+                    )
+                    session.commit()
+
+                if was_inserted:
+                    inserted += 1
+                    logger.info("seeded: %s (%s) from %s", strategy.paper_title, strategy.id[:12], artifact_path.name)
+                else:
+                    skipped += 1
+                seeded = True
+                break
+            except Exception as exc:
+                logger.warning("artifact %s failed to seed (%s); falling back to older run", artifact_path.name, exc)
                 continue
 
-            mapped, selected_operation = map_artifact_to_backtest_result(
-                artifact,
-                strategy_id=strategy.id,
-            )
-            content_hash = canonical_artifact_hash(payload)
-
-            with get_session() as session:
-                _, was_inserted = insert_backtest_if_missing(
-                    session,
-                    strategy_id=strategy.id,
-                    content_hash=content_hash,
-                    result=mapped,
-                    run_id=artifact.run_id,
-                    operation=selected_operation,
-                    artifact_json=raw,
-                )
-                session.commit()
-
-            if was_inserted:
-                inserted += 1
-                logger.info("seeded: %s (%s)", strategy.paper_title, strategy.id[:12])
-            else:
-                skipped += 1
-
-        except Exception as exc:
+        if not seeded:
             failed += 1
-            logger.exception("failed to seed %s: %s", artifact_path, exc)
+            logger.error("all artifacts failed for strategy '%s'", title)
 
     summary = {"inserted": inserted, "skipped": skipped, "failed": failed}
     logger.info("seed summary: %s", summary)

--- a/backend/tests/scripts/test_seed_backtests_from_artifacts.py
+++ b/backend/tests/scripts/test_seed_backtests_from_artifacts.py
@@ -1,0 +1,165 @@
+"""Tests for seed_backtests_from_artifacts — current-state selection + fallback.
+
+These are hermetic: every DB / provider / mapper boundary is patched, so no
+Postgres, Redis, or analytics-engine import is required. The focus is the
+*selection* logic added for issue #462 — seed only the latest artifact per
+strategy, with fallback to an older run when the newest one is broken.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from archimedes.scripts import seed_backtests_from_artifacts as seed_mod
+
+
+class _FakeStrategy:
+    def __init__(self, sid: str, title: str):
+        self.id = sid
+        self.paper_title = title
+
+
+def _write_artifact(dir_path: Path, run_id: str, title: str) -> Path:
+    p = dir_path / f"{run_id}.json"
+    p.write_text(
+        json.dumps({"run_id": run_id, "strategy": {"paper_title": title}}),
+        encoding="utf-8",
+    )
+    return p
+
+
+@contextmanager
+def _fake_session():
+    yield MagicMock()
+
+
+def _run_seed(tmp_path: Path, strategies: list[_FakeStrategy], *, insert_mock, validate_side_effect):
+    """Invoke seed_from_artifacts with all boundaries patched."""
+    provider = MagicMock()
+    provider.list_strategies.return_value = strategies
+
+    with (
+        patch.object(seed_mod, "init_db"),
+        patch.object(seed_mod, "default_provider", return_value=provider),
+        patch.object(seed_mod, "get_session", _fake_session),
+        patch.object(seed_mod, "AnalyticsArtifactModel") as model_cls,
+        patch.object(seed_mod, "map_artifact_to_backtest_result", return_value=({}, "SPY")),
+        patch.object(seed_mod, "canonical_artifact_hash", return_value="hash"),
+        patch.object(seed_mod, "insert_backtest_if_missing", insert_mock),
+    ):
+        model_cls.model_validate.side_effect = validate_side_effect
+        return seed_mod.seed_from_artifacts(tmp_path)
+
+
+def test_seeds_only_latest_run_per_strategy(tmp_path):
+    # Three timestamped runs for the same strategy — only the newest should seed.
+    _write_artifact(tmp_path, "20260518T062814Z", "Buy-and-Hold Baseline")
+    _write_artifact(tmp_path, "20260518T062844Z", "Buy-and-Hold Baseline")
+    _write_artifact(tmp_path, "20260518T223800Z", "Buy-and-Hold Baseline")  # newest
+
+    strat = _FakeStrategy("strat-bah-id", "Buy-and-Hold Baseline")
+    insert_mock = MagicMock(return_value=(MagicMock(), True))
+
+    summary = _run_seed(
+        tmp_path,
+        [strat],
+        insert_mock=insert_mock,
+        validate_side_effect=lambda payload: MagicMock(run_id=payload["run_id"]),
+    )
+
+    assert summary == {"inserted": 1, "skipped": 0, "failed": 0}
+    assert insert_mock.call_count == 1
+    assert insert_mock.call_args.kwargs["run_id"] == "20260518T223800Z"
+
+
+def test_falls_back_to_older_run_when_newest_broken(tmp_path):
+    _write_artifact(tmp_path, "20260518T090000Z", "Time Series Momentum")  # older, good
+    _write_artifact(tmp_path, "20260518T100000Z", "Time Series Momentum")  # newest, broken
+
+    strat = _FakeStrategy("strat-tsm-id", "Time Series Momentum")
+    insert_mock = MagicMock(return_value=(MagicMock(), True))
+
+    def _validate(payload):
+        if payload["run_id"] == "20260518T100000Z":
+            raise ValueError("corrupt artifact")
+        return MagicMock(run_id=payload["run_id"])
+
+    summary = _run_seed(tmp_path, [strat], insert_mock=insert_mock, validate_side_effect=_validate)
+
+    assert summary == {"inserted": 1, "skipped": 0, "failed": 0}
+    assert insert_mock.call_count == 1
+    # fell back from the broken newest run to the older good one
+    assert insert_mock.call_args.kwargs["run_id"] == "20260518T090000Z"
+
+
+def test_strategy_failed_when_all_runs_broken(tmp_path):
+    _write_artifact(tmp_path, "20260518T090000Z", "Time Series Momentum")
+    _write_artifact(tmp_path, "20260518T100000Z", "Time Series Momentum")
+
+    strat = _FakeStrategy("strat-tsm-id", "Time Series Momentum")
+    insert_mock = MagicMock(return_value=(MagicMock(), True))
+
+    def _always_broken(payload):
+        raise ValueError("corrupt artifact")
+
+    summary = _run_seed(tmp_path, [strat], insert_mock=insert_mock, validate_side_effect=_always_broken)
+
+    assert summary == {"inserted": 0, "skipped": 0, "failed": 1}
+    insert_mock.assert_not_called()
+
+
+def test_unmatched_strategy_counted_failed_once(tmp_path):
+    # No provider strategy matches this title; the whole group is one failure.
+    _write_artifact(tmp_path, "20260518T223800Z", "Unknown Paper")
+    _write_artifact(tmp_path, "20260518T223801Z", "Unknown Paper")
+
+    insert_mock = MagicMock(return_value=(MagicMock(), True))
+
+    summary = _run_seed(
+        tmp_path,
+        [],
+        insert_mock=insert_mock,
+        validate_side_effect=lambda payload: MagicMock(run_id=payload["run_id"]),
+    )
+
+    assert summary == {"inserted": 0, "skipped": 0, "failed": 1}
+    insert_mock.assert_not_called()
+
+
+def test_unreadable_artifact_is_skipped_not_fatal(tmp_path):
+    # A corrupt JSON file must not abort seeding of the valid strategy.
+    (tmp_path / "20260518T120000Z.json").write_text("{ not valid json", encoding="utf-8")
+    _write_artifact(tmp_path, "20260518T223800Z", "Buy-and-Hold Baseline")
+
+    strat = _FakeStrategy("strat-bah-id", "Buy-and-Hold Baseline")
+    insert_mock = MagicMock(return_value=(MagicMock(), True))
+
+    summary = _run_seed(
+        tmp_path,
+        [strat],
+        insert_mock=insert_mock,
+        validate_side_effect=lambda payload: MagicMock(run_id=payload["run_id"]),
+    )
+
+    assert summary == {"inserted": 1, "skipped": 0, "failed": 0}
+    assert insert_mock.call_args.kwargs["run_id"] == "20260518T223800Z"
+
+
+def test_already_present_run_counts_as_skipped(tmp_path):
+    # insert_backtest_if_missing returning was_inserted=False → skipped, not failed.
+    _write_artifact(tmp_path, "20260518T223800Z", "Buy-and-Hold Baseline")
+
+    strat = _FakeStrategy("strat-bah-id", "Buy-and-Hold Baseline")
+    insert_mock = MagicMock(return_value=(MagicMock(), False))
+
+    summary = _run_seed(
+        tmp_path,
+        [strat],
+        insert_mock=insert_mock,
+        validate_side_effect=lambda payload: MagicMock(run_id=payload["run_id"]),
+    )
+
+    assert summary == {"inserted": 0, "skipped": 1, "failed": 0}


### PR DESCRIPTION
Closes #462 ("APIN - Artifacts - ./analytics-engine/artifacts").

## Problem
`analytics-engine/artifacts/` accumulates one timestamped JSON per backtest re-run, so a single strategy can have several files (today: 3 for "Buy-and-Hold Baseline", 2 for "Tactical Asset Allocation"). `seed_from_artifacts` globbed **all** of them and seeded each, persisting stale historical runs alongside the current one — there was no notion of "current state," and a single corrupt file just raised and got logged per-file.

## Fix
Make seeding resolve to a **single current-state run per strategy**, with a backup:
- Group artifact files by `paper_title`.
- `run_id` is a sortable ISO-8601 UTC timestamp (`20260518T223800Z`), so a reverse sort gives newest-first.
- Seed the **newest** artifact that parses + maps cleanly; if the newest is broken, **fall back** to the next-newest. A single corrupt artifact never silently drops a strategy's backtest.
- Unreadable JSON is skipped (not fatal); a strategy whose runs all fail is counted once as `failed`.

This matches the issue's ask: "a dynamic pattern to a single resulting json of the current state and a backup solution if broken."

## Tests
New hermetic suite `backend/tests/scripts/test_seed_backtests_from_artifacts.py` (6 tests, all DB/provider/mapper boundaries mocked — no Postgres/Redis/analytics-engine):
- seeds only the latest run per strategy
- falls back to an older run when the newest is broken
- counts `failed` once when all runs are broken
- unmatched strategy counted once as failed
- unreadable JSON skipped, not fatal
- `was_inserted=False` → `skipped`, not `failed`

```
python -m pytest backend/tests/scripts/test_seed_backtests_from_artifacts.py -q   # → 6 passed
```

## Anti-goals
- Doesn't change the artifact file format or the analytics-engine writer; doesn't touch contracts/infra. Pure seeding-selection logic + tests.