### PR TITLE
[portfolio] Add Ledoit-Wolf analytic covariance shrinkage for MVO

### DIFF
--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -395,18 +395,74 @@ def _equal_weight(symbols: list[str], budget: float) -> dict[str, float]:
 # ─── Kelly mean-variance from price-history dict ──────────────────
 
 
+def ledoit_wolf_shrinkage(returns: np.ndarray) -> tuple[np.ndarray, float]:
+    """Ledoit-Wolf (2004) analytic shrinkage toward a scaled-identity target.
+
+    Reference: Ledoit & Wolf (2004), "A well-conditioned estimator for
+    large-dimensional covariance matrices", J. Multivariate Analysis 88(2),
+    pp. 365-411.
+
+    The sample covariance S is the maximum-likelihood estimate but is badly
+    conditioned — and often singular — when the asset count N is not small
+    relative to the number of observations T.  Mean-variance optimisation has
+    to invert Σ, and inverting an ill-conditioned S amplifies estimation error
+    into wild, unstable corner weights.  LW shrink S toward the structured
+    target F = μ·I (μ = average sample variance), picking the intensity δ* that
+    minimises the expected Frobenius loss E‖Σ* − Σ‖²:
+
+        Σ* = δ·μ·I + (1 − δ)·S,    δ* = b² / d²  ∈ [0, 1]
+
+    where d² = ‖S − μI‖²_F / N is how far S sits from the target and b² is the
+    (clamped) estimation error of S — so a short, noisy sample shrinks hard
+    toward the target while a long, clean one barely shrinks at all.  Unlike a
+    fixed shrinkage intensity, δ* is derived entirely from the data.
+
+    Args:
+        returns: (T, N) array of per-period returns. Demeaning is handled
+            internally. Requires T ≥ 2.
+
+    Returns:
+        (shrunk_cov, delta) — the (N, N) shrunk covariance on the same period
+        as the input returns, and the chosen intensity δ ∈ [0, 1].
+    """
+    X = np.asarray(returns, dtype=float)
+    if X.ndim != 2:
+        raise ValueError("returns must be a 2-D (T, N) array")
+    T, N = X.shape
+    if T < 2:
+        raise ValueError(f"need at least 2 observations, got T={T}")
+
+    X = X - X.mean(axis=0, keepdims=True)
+    S = (X.T @ X) / T  # MLE sample covariance (1/T convention, per LW2004)
+
+    mu = float(np.trace(S)) / N  # ⟨S, I⟩ — average sample variance
+    tr_s2 = float(np.trace(S @ S))
+    d2 = tr_s2 / N - mu**2  # ‖S − μI‖²_F / N — dispersion of S around target
+
+    if d2 <= 0.0:
+        # S is already isotropic (e.g. N == 1): nothing to shrink.
+        return S, 0.0
+
+    # b̄² = (1/T²)·Σ_k‖x_k x_kᵀ − S‖²_F / N, via the closed form
+    #      Σ_k‖x_k‖⁴ − T·tr(S²)  (avoids the per-observation outer-product loop).
+    sq_norms = np.sum(X**2, axis=1)  # ‖x_k‖² for each observation k
+    b_bar2 = (float(np.sum(sq_norms**2)) - T * tr_s2) / (T**2 * N)
+    b2 = max(0.0, min(b_bar2, d2))  # clamp to [0, d²] so δ ∈ [0, 1]
+
+    delta = b2 / d2
+    shrunk = delta * mu * np.eye(N) + (1.0 - delta) * S
+    return shrunk, float(delta)
+
+
 def _shrink_cov(cov: np.ndarray, intensity: float = 0.10) -> np.ndarray:
-    """Fixed-intensity diagonal shrinkage (NOT Ledoit-Wolf).
+    """Fixed-intensity diagonal shrinkage — fallback for ``ledoit_wolf_shrinkage``.
 
-    True Ledoit-Wolf (LW 2003) solves analytically for the optimal
-    intensity from the data; we use a fixed α=0.10 toward the diagonal
-    target (preserve per-asset variances, zero off-diagonals).  Cheaper
-    and deterministic; keeps the matrix positive-definite even on short
-    windows; under-shrinks for short samples and over-shrinks for long.
-
-    TODO: swap in `sklearn.covariance.LedoitWolf().fit(returns)` so
-    intensity is data-derived; tracked separately so the trade-off is
-    explicit instead of hidden in this function name.
+    Used only when the data-driven LW estimator can't run (degenerate input).
+    Shrinks a fixed α=0.10 toward the diagonal target (preserve per-asset
+    variances, zero off-diagonals): cheap, deterministic, and keeps the matrix
+    positive-definite even on short windows, at the cost of a non-optimal,
+    hard-coded intensity. Prefer :func:`ledoit_wolf_shrinkage`, whose intensity
+    is derived from the data.
     """
     diag = np.diag(np.diag(cov))
     return (1 - intensity) * cov + intensity * diag
@@ -440,9 +496,16 @@ def _build_mu_sigma_from_prices(
     returns = returns[keep]
 
     daily_mean = returns.mean().values
-    daily_cov = np.cov(returns.values, rowvar=False)
     mu_annual = daily_mean * _ANNUALIZATION
-    cov_annual = _shrink_cov(daily_cov * _ANNUALIZATION, intensity=0.10)
+    # Data-driven Ledoit-Wolf shrinkage (preferred); fall back to fixed-intensity
+    # diagonal shrinkage only if the analytic estimator can't run.
+    try:
+        daily_cov, lw_delta = ledoit_wolf_shrinkage(returns.values)
+        logger.debug("Ledoit-Wolf shrinkage: δ=%.4f (N=%d, T=%d)", lw_delta, returns.shape[1], len(returns))
+        cov_annual = daily_cov * _ANNUALIZATION
+    except Exception as exc:
+        logger.warning("Ledoit-Wolf shrinkage failed (%s); using fixed diagonal shrinkage", exc)
+        cov_annual = _shrink_cov(np.cov(returns.values, rowvar=False) * _ANNUALIZATION, intensity=0.10)
     sigma_annual = np.sqrt(np.diag(cov_annual))
     sigma_safe = np.where(sigma_annual > 1e-9, sigma_annual, 1e-9)
     corr = cov_annual / np.outer(sigma_safe, sigma_safe)

--- a/backend/tests/test_portfolio_optimizer.py
+++ b/backend/tests/test_portfolio_optimizer.py
@@ -28,6 +28,7 @@ from archimedes.services.portfolio_optimizer import (
     expected_max_drawdown_1y,
     kelly_optimize_from_prices,
     kelly_risk_decomposition,
+    ledoit_wolf_shrinkage,
     optimize_weights,
     value_at_risk_95_1y,
 )
@@ -190,6 +191,67 @@ class TestShrinkCov:
             for j in range(n):
                 if i != j:
                     assert abs(shrunk[i, j]) <= abs(cov[i, j]) + 1e-12
+
+
+class TestLedoitWolfShrinkage:
+    """Ledoit-Wolf (2004) analytic shrinkage toward a scaled-identity target."""
+
+    def _correlated_returns(self, T: int, N: int, seed: int = 7) -> np.ndarray:
+        """T×N returns with a non-trivial correlation structure (single factor)."""
+        rng = np.random.default_rng(seed)
+        factor = rng.normal(0, 1, (T, 1))
+        loadings = rng.uniform(0.5, 1.5, (1, N))
+        idio = rng.normal(0, 0.5, (T, N))
+        return factor @ loadings + idio
+
+    def test_delta_in_unit_interval(self):
+        X = self._correlated_returns(T=60, N=5)
+        _, delta = ledoit_wolf_shrinkage(X)
+        assert 0.0 <= delta <= 1.0
+
+    def test_symmetric_and_positive_definite(self):
+        X = self._correlated_returns(T=40, N=6)
+        shrunk, _ = ledoit_wolf_shrinkage(X)
+        np.testing.assert_allclose(shrunk, shrunk.T, atol=1e-12)
+        eigvals = np.linalg.eigvalsh(shrunk)
+        assert eigvals.min() > 0, f"not PD: min eigenvalue {eigvals.min()}"
+
+    def test_better_conditioned_than_sample_cov(self):
+        # Short sample relative to N: the raw sample covariance is poorly
+        # conditioned; LW shrinkage must reduce the condition number.
+        X = self._correlated_returns(T=30, N=10)
+        sample = np.cov(X, rowvar=False)
+        shrunk, delta = ledoit_wolf_shrinkage(X)
+        cond_sample = np.linalg.cond(sample)
+        cond_shrunk = np.linalg.cond(shrunk)
+        assert delta > 0.0, "expected non-trivial shrinkage on a short sample"
+        assert cond_shrunk < cond_sample, f"LW did not improve conditioning: {cond_shrunk} vs {cond_sample}"
+
+    def test_shrinks_harder_on_shorter_samples(self):
+        # More noise (fewer observations) ⇒ larger optimal shrinkage intensity.
+        _, delta_short = ledoit_wolf_shrinkage(self._correlated_returns(T=20, N=8))
+        _, delta_long = ledoit_wolf_shrinkage(self._correlated_returns(T=2000, N=8))
+        assert delta_short > delta_long
+
+    def test_approaches_sample_cov_on_large_T(self):
+        # With T ≫ N the sample cov is reliable, so δ → 0 and Σ* ≈ S.
+        X = self._correlated_returns(T=5000, N=4)
+        shrunk, delta = ledoit_wolf_shrinkage(X)
+        sample_mle = (lambda x: (x - x.mean(0)).T @ (x - x.mean(0)) / len(x))(X)
+        assert delta < 0.1
+        np.testing.assert_allclose(shrunk, sample_mle, rtol=0.15, atol=1e-3)
+
+    def test_single_asset_returns_variance_no_shrinkage(self):
+        rng = np.random.default_rng(3)
+        X = rng.normal(0, 1, (100, 1))
+        shrunk, delta = ledoit_wolf_shrinkage(X)
+        assert delta == 0.0
+        assert shrunk.shape == (1, 1)
+        assert shrunk[0, 0] > 0
+
+    def test_raises_on_insufficient_observations(self):
+        with pytest.raises(ValueError):
+            ledoit_wolf_shrinkage(np.array([[0.01, 0.02, 0.03]]))  # T=1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
Mean-variance optimisation inverts the covariance matrix Σ. The sample covariance is the MLE but is badly conditioned — often singular — when the asset count N isn't small relative to the number of observations T, and inverting an ill-conditioned matrix amplifies estimation error into wild, unstable corner weights. This is the classic reason naive Markowitz blows up in practice.

The optimizer previously used a **fixed 10% diagonal shrinkage** (`_shrink_cov`) — its own docstring carried a `TODO: swap in Ledoit-Wolf`. A hard-coded intensity under-shrinks short samples and over-shrinks long ones.

## What
Implements **Ledoit-Wolf (2004) analytic shrinkage** toward a scaled-identity target, with the optimal intensity δ* derived from the data:

    Σ* = δ·μ·I + (1 − δ)·S,    δ* = b²/d²  ∈ [0, 1]

where `d² = ‖S − μI‖²_F / N` measures how far the sample sits from the target and `b²` is its (clamped) estimation error — so a short, noisy sample shrinks hard toward the target while a long, clean one barely shrinks. Reference: Ledoit & Wolf (2004), *A well-conditioned estimator for large-dimensional covariance matrices*, J. Multivariate Analysis 88(2).

Implemented in pure numpy (no new dependency — `sklearn` is neither installed nor declared). `_build_mu_sigma_from_prices` now uses it, falling back to the fixed diagonal shrink only if the analytic estimator can't run. The fixed shrink is retained and documented as the fallback.

## Tests
7 new tests in `TestLedoitWolfShrinkage` (hermetic, numpy-only):
- δ ∈ [0, 1]; shrunk matrix symmetric + positive-definite
- **better-conditioned than raw sample cov** on a short sample (lower condition number)
- shrinks harder on shorter samples; δ → 0 (Σ* → S) as T ≫ N
- single-asset returns variance with δ = 0; raises on T < 2

```
python -m pytest backend/tests/test_portfolio_optimizer.py -q   # → 68 passed
```

## Anti-goals
- No new dependency; doesn't touch the MVO objective functions or weight constraints — only the covariance estimate feeding them.