### PR TITLE
[backtest] Track price-data provenance; bar synthetic data from Tier-1 admission

### DIFF
--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -49,6 +49,10 @@ class BacktestMetrics:
     monthly_returns: list[float]
     backtest_start: date | None
     backtest_end: date | None
+    # Provenance of the price series the metrics were computed on. "synthetic"
+    # means random.gauss noise (dev/test only); "csv:<name>" / "provided" mean
+    # real OHLCV. Rigor metrics from a "synthetic" run are NOT admissible.
+    data_source: str = "synthetic"
 
 
 @dataclass(frozen=True)
@@ -62,6 +66,11 @@ class RigorVerdict:
     oos_sharpe: float | None
     look_ahead_clean: bool
     num_trials: int
+    # Provenance carried through from the backtest. ``admissible`` is the
+    # honest gate: a strategy can only be certified Tier-1 if it both passes
+    # the statistics AND those statistics were computed on real market data.
+    data_source: str = "synthetic"
+    admissible: bool = False
 
 
 @dataclass(frozen=True)
@@ -77,11 +86,39 @@ class FusionEvalResult:
     def success(self) -> bool:
         return self.error is None and self.backtest is not None
 
+    @property
+    def admissible(self) -> bool:
+        """True only if rigor passed AND on real (non-synthetic) market data."""
+        return self.rigor is not None and self.rigor.admissible
+
 
 # ── Backtest runner ───────────────────────────────────────────────────
 
 _DEFAULT_CASH = 100_000.0
 _DEFAULT_TX_BPS = 10
+
+# The only price-data provenance that is NOT admissible for Tier-1 rigor
+# certification. Everything else (real CSV, an explicitly provided feed) is
+# trusted to be real market data — the caller owns that contract.
+_SYNTHETIC_SOURCE = "synthetic"
+
+
+def _data_source_label(data_feed: Any, data_csv_path: str | Path | None) -> str:
+    """Honest provenance label for the price series a backtest ran on."""
+    if data_feed is not None:
+        return "provided"
+    if data_csv_path is not None:
+        return f"csv:{Path(data_csv_path).name}"
+    return _SYNTHETIC_SOURCE
+
+
+def is_admissible_source(data_source: str) -> bool:
+    """True unless the metrics were computed on synthetic (random) prices.
+
+    Rigor numbers from synthetic data describe noise, not a strategy — they
+    must never be the basis for Tier-1 admission.
+    """
+    return data_source != _SYNTHETIC_SOURCE
 
 
 def run_dsl_backtest(
@@ -104,6 +141,15 @@ def run_dsl_backtest(
     strategy_cls = interpret_spec(spec)
     cerebro = bt.Cerebro(stdstats=False)
     cerebro.addstrategy(strategy_cls)
+
+    data_source = _data_source_label(data_feed, data_csv_path)
+    if data_source == _SYNTHETIC_SOURCE:
+        logger.warning(
+            "run_dsl_backtest[%s] is using SYNTHETIC price data — rigor metrics "
+            "from this run are NOT admissible for Tier-1 certification. Pass "
+            "data_csv_path or data_feed with real OHLCV for an admissible result.",
+            spec.name,
+        )
 
     if data_feed is None:
         data_feed = _csv_data_feed(Path(data_csv_path)) if data_csv_path is not None else _synthetic_data()
@@ -170,6 +216,7 @@ def run_dsl_backtest(
         monthly_returns=[round(m, 4) for m in monthly_returns],
         backtest_start=date(2004, 1, 2) if data_feed is None else None,
         backtest_end=date(2026, 4, 30) if data_feed is None else None,
+        data_source=data_source,
     )
 
 
@@ -241,6 +288,7 @@ def _run_variant_backtest(
     """Run a single variant backtest given an already-interpreted strategy class."""
     import backtrader as bt
 
+    data_source = _data_source_label(data_feed, data_csv_path)
     cerebro = bt.Cerebro(stdstats=False)
     cerebro.addstrategy(strategy_cls)
 
@@ -305,6 +353,7 @@ def _run_variant_backtest(
         monthly_returns=[round(m, 4) for m in monthly_returns],
         backtest_start=date(2004, 1, 2) if data_csv_path is None else None,
         backtest_end=date(2026, 4, 30) if data_csv_path is None else None,
+        data_source=data_source,
     )
 
 
@@ -315,6 +364,7 @@ def apply_rigor_gate(
     metrics: BacktestMetrics,
     num_trials: int = 10,
     variants_metrics: dict[str, BacktestMetrics] | None = None,
+    data_source: str | None = None,
 ) -> RigorVerdict:
     """Apply rigor gate to fusion backtest metrics.
 
@@ -365,6 +415,18 @@ def apply_rigor_gate(
 
     passing = metrics.sharpe_ratio > 0.0 and dsr_pass and look_ahead_clean and (pbo_score is None or pbo_score < 0.5)
 
+    # Provenance gate: a strategy is only admissible for Tier-1 if it passes
+    # the statistics AND those statistics were computed on real market data.
+    # Default to the metrics' own provenance unless the caller overrides it.
+    source = data_source if data_source is not None else metrics.data_source
+    admissible = passing and is_admissible_source(source)
+    if passing and not admissible:
+        logger.warning(
+            "rigor verdict is PASSING but NOT admissible — metrics came from "
+            "non-real data source %r. Refusing Tier-1 certification.",
+            source,
+        )
+
     return RigorVerdict(
         passing=passing,
         dsr=dsr,
@@ -373,6 +435,8 @@ def apply_rigor_gate(
         oos_sharpe=oos_sharpe,
         look_ahead_clean=look_ahead_clean,
         num_trials=num_trials,
+        data_source=source,
+        admissible=admissible,
     )
 
 

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -14,12 +14,18 @@ separate piece of work).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from archimedes.services.fusion_evaluator import (
     BacktestMetrics,
     apply_rigor_gate,
     evaluate_fusion_spec,
+    is_admissible_source,
+    run_dsl_backtest,
 )
-from archimedes.services.strategy_dsl import FABER_2007_SPEC
+from archimedes.services.strategy_dsl import FABER_2007_SPEC, validate_strategy_spec
+
+_SPY_FIXTURE = Path(__file__).parent.parent / "fixtures" / "spy_ohlcv_2004_2026.csv"
 
 
 class TestFixtureFusionToLibrary:
@@ -292,3 +298,68 @@ class TestFusionWithVariantsComputesRealPbo:
             f"Expected high PBO (> 0.5) for IS/OOS reversal pattern, got {verdict.pbo_score}"
         )
         assert verdict.passing is False, f"Rigor gate must fail when PBO > 0.5, but passing={verdict.passing}"
+
+
+class TestDataProvenanceGate:
+    """A strategy can only be admissible if its rigor was computed on real data."""
+
+    def test_is_admissible_source_helper(self):
+        assert is_admissible_source("csv:spy_ohlcv_2004_2026.csv") is True
+        assert is_admissible_source("provided") is True
+        assert is_admissible_source("synthetic") is False
+
+    def test_synthetic_run_is_labeled_and_not_admissible(self):
+        # No data feed → synthetic prices → must never be Tier-1 admissible,
+        # even if the statistics happen to "pass".
+        result = evaluate_fusion_spec(FABER_2007_SPEC)
+        assert result.backtest is not None
+        assert result.backtest.data_source == "synthetic"
+        assert result.rigor is not None
+        assert result.rigor.data_source == "synthetic"
+        assert result.rigor.admissible is False
+        assert result.admissible is False
+
+    def test_real_csv_run_is_labeled_real(self):
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = run_dsl_backtest(spec, data_csv_path=_SPY_FIXTURE)
+        assert metrics.data_source == "csv:spy_ohlcv_2004_2026.csv"
+
+    def test_real_data_passing_strategy_is_admissible(self):
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = run_dsl_backtest(spec, data_csv_path=_SPY_FIXTURE)
+        verdict = apply_rigor_gate(metrics)
+        # Faber on real SPY passes; on real data that makes it admissible.
+        assert verdict.passing is True
+        assert verdict.admissible is True
+        assert verdict.data_source.startswith("csv:")
+
+    def test_provenance_override_revokes_admissibility(self):
+        # Take a passing real-data run and re-judge it as if the data were
+        # synthetic — admissibility must flip off even though passing stays on.
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = run_dsl_backtest(spec, data_csv_path=_SPY_FIXTURE)
+        as_synthetic = apply_rigor_gate(metrics, data_source="synthetic")
+        assert as_synthetic.passing is True
+        assert as_synthetic.admissible is False
+
+    def test_admissibility_requires_passing(self):
+        # Real data but a flat (zero-return) curve → not passing → not admissible.
+        flat = [100_000.0] * 600
+        metrics = BacktestMetrics(
+            sharpe_ratio=0.0,
+            sortino_ratio=0.0,
+            max_drawdown=0.0,
+            cagr=0.0,
+            calmar_ratio=0.0,
+            win_rate=0.0,
+            total_trades=0,
+            avg_holding_period_days=0.0,
+            equity_curve=flat,
+            monthly_returns=[],
+            backtest_start=None,
+            backtest_end=None,
+            data_source="csv:real.csv",
+        )
+        verdict = apply_rigor_gate(metrics)
+        assert verdict.passing is False
+        assert verdict.admissible is False


### PR DESCRIPTION
## Why
The rigor gate (DSR / PBO / OOS Sharpe) is the project's whole credibility wedge — but `evaluate_fusion_spec` calls `run_dsl_backtest(data_feed=None)`, which falls back to `_synthetic_data()`: a `random.gauss` price series. So **the rigor numbers shown on the strategy passport could be computed on synthetic noise**, with nothing stopping a synthetic-derived strategy from being marked "passing." For a system whose entire pitch is "we don't fool ourselves," certifying noise is the one unacceptable failure.

## What
Make data provenance explicit and refuse to certify synthetic-derived results — without requiring production data infra:

- `BacktestMetrics` and `RigorVerdict` now carry a `data_source` label (`"synthetic"`, `"csv:<name>"`, or `"provided"`).
- New `is_admissible_source()` — everything except `"synthetic"` is real market data.
- `RigorVerdict` gains an **`admissible`** flag: a strategy is admissible only if it **both** passes the statistics **and** those statistics came from real data. `FusionEvalResult.admissible` surfaces it.
- `run_dsl_backtest` logs a loud WARNING whenever it falls back to synthetic data, stating the result is not admissible.
- `apply_rigor_gate(..., data_source=...)` lets a caller override provenance (e.g. re-judge a run).

This is additive (new fields default to the safe `"synthetic"` / `admissible=False`), so existing behavior is preserved — but the gate can no longer *claim* Tier-1 admission on noise. The bundled real fixture `backend/tests/fixtures/spy_ohlcv_2004_2026.csv` is the admissible path.

## Tests
New `TestDataProvenanceGate` (6 tests, hermetic — uses the in-tree real SPY fixture, no network):
- synthetic run is labeled `synthetic` and **not admissible even though it passes**
- real-CSV run is labeled `csv:…` and a passing Faber-on-real-SPY run is admissible
- provenance override revokes admissibility (passing stays true, admissible flips false)
- admissibility requires passing (flat real-data curve → not admissible)
- `is_admissible_source` helper

```
python -m pytest backend/tests/services/test_fusion_evaluator.py backend/tests/services/test_fusion_evaluator_real_spy.py -q   # → 19 passed
```

## Anti-goals
- Doesn't add a network data fetch (kept hermetic) or change the DSR/PBO/OOS math. It changes *what the gate is allowed to certify*, not how the statistics are computed. Wiring a production real-data source into `evaluate_fusion_spec`'s default is a sensible follow-up now that provenance is tracked.