### PR TITLE
[quant] Revert un-PR'd direct-to-main rigor/backtester burst

### DIFF
--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -42,7 +42,6 @@ import numpy as np
 import pandas as pd
 
 from archimedes.models.backtest import BacktestResult
-from archimedes.services.rigor_evaluator import compute_dsr, compute_oos_sharpe
 
 logger = logging.getLogger(__name__)
 
@@ -70,166 +69,85 @@ def _ensure_analytics_import() -> None:
         sys.path.insert(0, str(analytics_src))
 
 
-def _fetch_price_panel(symbols: list[str], start: str, end: str) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Fetch close prices and volumes for ``symbols`` and inner-join on the date index.
+def _fetch_price_panel(symbols: list[str], start: str, end: str) -> pd.DataFrame:
+    """Fetch close prices for ``symbols`` and inner-join on the date index.
 
-    Missing data is a critical lookahead vector. If a symbol halted or wasn't
-    public yet, forward-filling prices leaks the "survival" fact to the
-    simulator. We strictly inner-join: the panel only contains days where
-    EVERY requested symbol traded.
+    Drops rows where any symbol is missing data — strict alignment so we never
+    invent a return where one of the legs wasn't trading.
     """
     _ensure_analytics_import()
-    from archimedes_analytics_engine.data import fetch_ohlcv
+    from archimedes_analytics_engine.data import fetch_ohlcv  # noqa: PLC0415
 
     closes: dict[str, pd.Series] = {}
-    volumes: dict[str, pd.Series] = {}
     for sym in symbols:
-        try:
-            df = fetch_ohlcv(sym, start, end)
-            if not df.empty and "Close" in df.columns and "Volume" in df.columns:
-                closes[sym] = df["Close"]
-                volumes[sym] = df["Volume"]
-        except Exception:
-            pass
-
-    close_panel = pd.DataFrame(closes).dropna()
-    volume_panel = pd.DataFrame(volumes).dropna()
-
-    if close_panel.empty or volume_panel.empty:
-        raise ValueError(f"Insufficient overlapping history for {symbols}")
-
-    common_idx = close_panel.index.intersection(volume_panel.index)
-    if common_idx.empty:
-        raise ValueError(f"Insufficient overlapping history for {symbols}")
-
-    panel = close_panel.loc[common_idx]
+        df = fetch_ohlcv(sym, start, end)
+        closes[sym] = df["Close"]
+    panel = pd.DataFrame(closes).dropna()
     if len(panel) < MIN_BARS_FOR_BACKTEST:
         raise ValueError(
             f"Insufficient overlapping history: only {len(panel)} bars across {symbols} (min {MIN_BARS_FOR_BACKTEST})"
         )
-
-    return close_panel.loc[common_idx], volume_panel.loc[common_idx]
+    return panel
 
 
 def _simulate_portfolio(
     panel: pd.DataFrame,
-    volume_panel: pd.DataFrame,
-    target_weights: dict[str, float] | pd.DataFrame,
+    target_weights: dict[str, float],
     *,
     rebalance_days: int,
     initial_cash: float,
-    tx_cost_bps: int = 10,
-    gamma: float = 0.1,  # Almgren square-root coefficient
+    tx_cost_bps: int,
 ) -> tuple[list[float], list[float]]:
     """Run a periodic-rebalance simulation; returns ``(daily_returns, equity_curve)``.
 
     Implementation notes:
       - Held weights drift between rebalance bars with realized returns.
-      - Uses the Almgren square-root market impact function:
-        Impact = gamma * sigma * Q * sqrt(Q / ADV)
-      - Proportional transaction costs (tx_cost_bps) are additive to Almgren impact.
+      - On rebalance bars, the L1 turnover ``|held - target|`` is charged as a
+        proportional cost in bps; this is a conservative model (no slippage,
+        no spread — those are tx_cost_bps's job to encode).
       - No leverage. Negative weights are clamped to zero at normalization
         (long-only enforcement matches the agent's actual output contract).
     """
     syms = list(panel.columns)
     n_bars = len(panel)
 
-    returns_df = panel.pct_change().fillna(0.0)
+    # Build canonical target weights aligned to the panel (zero-fill for any
+    # symbol that fell out of the inner-join, then long-only normalize).
+    raw = pd.Series({s: max(target_weights.get(s, 0.0), 0.0) for s in syms})
+    total = float(raw.sum())
+    if total <= 0:
+        raise ValueError("All weights non-positive after symbol alignment")
+    target = raw / total
 
-    # Pre-compute rolling metrics for Almgren impact (must be shift(1) to avoid look-ahead bias)
-    rolling_window = 21
-    sigma_df = returns_df.rolling(window=rolling_window, min_periods=1).std().shift(1).fillna(0.0)
-    dollar_volume_df = (volume_panel * panel).fillna(0.0)
-    adv_df = dollar_volume_df.rolling(window=rolling_window, min_periods=1).mean().shift(1).fillna(0.0)
-
-    # ── Temporal (t-1) data alignment execution layer guard ──
-    if isinstance(target_weights, pd.DataFrame):
-        dynamic_targets = target_weights.reindex(index=panel.index, columns=syms).clip(lower=0.0).fillna(0.0)
-
-        if dynamic_targets.empty:
-            raise ValueError("Dynamic target weights DataFrame cannot be empty.")
-
-        # The loop inherently provides a T-1 execution guard: 'held' state
-        # from the end of i-1 is applied to the return of bar i.
-        # Thus, signals computed at close(t) are executed at close(t),
-        # earning returns over t+1. No double-shift is needed.
-
-        # Row-wise L1 normalization
-        row_sums = dynamic_targets.sum(axis=1)
-        dynamic_targets = dynamic_targets.div(row_sums.where(row_sums > 0, 1.0), axis=0)
-        is_dynamic = True
-        dynamic_targets_arr = dynamic_targets.to_numpy()
-    else:
-        # Build canonical static target weights
-        raw = pd.Series({s: max(target_weights.get(s, 0.0), 0.0) for s in syms})
-        total = float(raw.sum())
-        if total <= 0:
-            raise ValueError("All weights non-positive after symbol alignment")
-        static_target = raw / total
-        is_dynamic = False
-        static_target_arr = static_target.to_numpy()
-
-    # Extract NumPy arrays for high-performance iteration
-    returns_arr = returns_df.to_numpy()
-    sigma_arr = sigma_df.to_numpy()
-    adv_arr = adv_df.to_numpy()
-
-    held = dynamic_targets_arr[0].copy() if is_dynamic else static_target_arr.copy()
-
+    returns = panel.pct_change().fillna(0.0)
+    held = target.copy()
     portfolio_returns: list[float] = []
     equity = float(initial_cash)
     equity_curve: list[float] = []
 
     for i in range(n_bars):
-        # The portfolio return for day i is generated by the weights held at
-        # the end of day i-1, perfectly aligned with the t-1 execution guard.
-        r_t = float(np.sum(returns_arr[i] * held))
+        r_t = float((returns.iloc[i] * held).sum())
 
-        # Calculate pre-cost equity at end of day
-        post_r_t_equity = max(0.0, equity * (1.0 + r_t))
-
-        # Rebalance drift
-        drifted = held * (1.0 + returns_arr[i])
-        drifted_sum = np.sum(drifted)
-        if drifted_sum > 0:
-            drifted /= drifted_sum
+        # Apply the realized return to held weights first; THEN, if this is a
+        # rebalance bar, charge turnover cost and snap back to target.
+        new_value = held * (1.0 + returns.iloc[i])
+        new_total = float(new_value.sum())
+        if new_total > 0:
+            drifted = new_value / new_total
         else:
-            drifted = np.zeros_like(held)
+            drifted = held
 
-        target = dynamic_targets_arr[i].copy() if is_dynamic else static_target_arr.copy()
-
-        # If dynamic, we must rebalance every bar to track the signals.
-        should_rebalance = (i > 0) if is_dynamic else (i > 0 and i % rebalance_days == 0)
-
-        if post_r_t_equity <= 0.0:
-            # Bankruptcy!
-            r_t = -1.0  # 100% loss
-            held = np.zeros_like(held)
-            post_r_t_equity = 0.0
-        elif should_rebalance:
-            delta_w = np.abs(drifted - target)
-            q_j = delta_w * post_r_t_equity
-
-            # Avoid division by zero in ADV, penalize illiquidity heavily
-            safe_adv = np.where(adv_arr[i] > 0, adv_arr[i], 1.0)
-
-            # Impact Cost = sum(gamma * sigma_j * Q_j * sqrt(Q_j / ADV_j))
-            # + linear bps cost
-            impact_dollars = np.sum(gamma * sigma_arr[i] * q_j * np.sqrt(q_j / safe_adv))
-            linear_cost_dollars = np.sum(delta_w) * post_r_t_equity * (tx_cost_bps / 10_000.0)
-
-            total_cost_dollars = impact_dollars + linear_cost_dollars
-
-            cost_fraction = total_cost_dollars / equity if equity > 0 else 0.0
-            r_t -= cost_fraction
-            post_r_t_equity = max(0.0, equity * (1.0 + r_t))
+        if i > 0 and i % rebalance_days == 0:
+            turnover = float((drifted - target).abs().sum())
+            cost = turnover * (tx_cost_bps / 10_000.0)
+            r_t -= cost
             held = target.copy()
         else:
             held = drifted
 
         portfolio_returns.append(r_t)
-        equity_curve.append(post_r_t_equity)
-        equity = post_r_t_equity
+        equity *= 1.0 + r_t
+        equity_curve.append(equity)
 
     return portfolio_returns, equity_curve
 
@@ -256,7 +174,10 @@ def _annualized_metrics(daily_returns: list[float], equity_curve: list[float]) -
     sortino = (mu / down_sigma) * np.sqrt(ANNUALIZATION) if down_sigma > 0 else 0.0
 
     eq = np.asarray(equity_curve, dtype=float)
-    cagr = float((eq[-1] / eq[0]) ** (ANNUALIZATION / T) - 1.0) if eq[0] > 0 and T >= 2 else 0.0
+    if eq[0] > 0 and T >= 2:
+        cagr = float((eq[-1] / eq[0]) ** (ANNUALIZATION / T) - 1.0)
+    else:
+        cagr = 0.0
 
     drawdown = (eq / np.maximum.accumulate(eq)) - 1.0
     max_dd = float(-drawdown.min()) if T > 0 else 0.0
@@ -301,9 +222,9 @@ def _panel_hash(panel: pd.DataFrame) -> str:
 def backtest_portfolio(
     *,
     strategy_id: str,
-    weights: dict[str, float] | pd.DataFrame,
-    start_date: str | None = None,
-    end_date: str | None = None,
+    weights: dict[str, float],
+    start: str | None = None,
+    end: str | None = None,
     rebalance_days: int = DEFAULT_REBALANCE_DAYS,
     initial_cash: float = DEFAULT_INITIAL_CASH,
     tx_cost_bps: int = DEFAULT_TX_COST_BPS,
@@ -315,9 +236,9 @@ def backtest_portfolio(
 
     Args:
         strategy_id: FK back to the StrategyPassport row.
-        weights: ``{ticker: weight}`` or DataFrame for dynamic rebalancing.
-        start_date: ISO date for backtest start. Defaults to ``end - DEFAULT_LOOKBACK_YEARS``.
-        end_date: ISO date for backtest end. Defaults to today (UTC).
+        weights: ``{ticker: weight}`` — non-positive entries are dropped.
+        start: ISO date for backtest start. Defaults to ``end - DEFAULT_LOOKBACK_YEARS``.
+        end: ISO date for backtest end. Defaults to today (UTC).
         rebalance_days: Periodic rebalance interval in trading days.
         initial_cash: Starting equity.
         tx_cost_bps: Round-trip cost in basis points (10 = 0.10%, matches default).
@@ -336,28 +257,22 @@ def backtest_portfolio(
             zero after symbol alignment. Callers should treat these as
             non-fatal: a failed backtest leaves the placeholder in place.
     """
-    end_iso = end_date or datetime.now(UTC).date().isoformat()
-    if start_date is None:
+    end_iso = end or datetime.now(UTC).date().isoformat()
+    if start is None:
         start_dt = datetime.fromisoformat(end_iso) - timedelta(days=365 * DEFAULT_LOOKBACK_YEARS)
         start_iso = start_dt.date().isoformat()
     else:
-        start_iso = start_date
+        start_iso = start
 
-    if isinstance(weights, pd.DataFrame):
-        active_weights = weights
-        symbols = list(weights.columns)
-    else:
-        active_weights = {sym: float(w) for sym, w in (weights or {}).items() if w and w > 0 and sym}
-        symbols = list(active_weights.keys())
-
-    if not symbols:
+    active_weights = {sym: float(w) for sym, w in (weights or {}).items() if w and w > 0 and sym}
+    if not active_weights:
         raise ValueError(f"No positive weights for strategy {strategy_id}")
 
-    panel, volume_panel = _fetch_price_panel(symbols, start_iso, end_iso)
+    symbols = list(active_weights.keys())
+    panel = _fetch_price_panel(symbols, start_iso, end_iso)
     daily_returns, equity_curve = _simulate_portfolio(
-        panel=panel,
-        volume_panel=volume_panel,
-        target_weights=active_weights,
+        panel,
+        active_weights,
         rebalance_days=rebalance_days,
         initial_cash=initial_cash,
         tx_cost_bps=tx_cost_bps,
@@ -365,25 +280,9 @@ def backtest_portfolio(
 
     core = _annualized_metrics(daily_returns, equity_curve)
 
-    # ── Capacity Decay Simulation ──
-    # Run the backtest at logarithmic AUM scales to chart capacity limits.
-    capacity_decay: dict[str, dict[str, float]] = {}
-    for aum_tier in [1_000_000.0, 10_000_000.0, 100_000_000.0, 1_000_000_000.0, 10_000_000_000.0]:
-        tier_rets, tier_eq = _simulate_portfolio(
-            panel=panel,
-            volume_panel=volume_panel,
-            target_weights=active_weights,
-            rebalance_days=rebalance_days,
-            initial_cash=aum_tier,
-            tx_cost_bps=tx_cost_bps,
-        )
-        tier_metrics = _annualized_metrics(tier_rets, tier_eq)
-        capacity_decay[f"${int(aum_tier):,}"] = {
-            "cagr": tier_metrics["cagr"],
-            "sharpe": tier_metrics["sharpe_ratio"],
-        }
-
     # ── Rigor primitives — same evaluator the curated strategies use ──
+    from archimedes.services.rigor_evaluator import compute_dsr, compute_oos_sharpe  # noqa: PLC0415
+
     deflated_sharpe, dsr_p_value = compute_dsr(daily_returns, num_trials_for_dsr)
     oos_sharpe = compute_oos_sharpe(daily_returns)
     # Static rebalance with t-1 prices generating t returns is structurally
@@ -395,7 +294,7 @@ def backtest_portfolio(
     # ── SPY correlation (diversification signal) ──
     correlation_to_spy = 0.0
     try:
-        spy_panel, _ = _fetch_price_panel(["SPY"], start_iso, end_iso)
+        spy_panel = _fetch_price_panel(["SPY"], start_iso, end_iso)
         spy_full = spy_panel["SPY"].pct_change().fillna(0.0)
         # Align to the portfolio's panel index (inner-join already applied)
         common = panel.index.intersection(spy_panel.index)
@@ -485,7 +384,6 @@ def backtest_portfolio(
                     "correlation_to_spy": correlation_to_spy,
                     "num_bars": n_obs_daily,
                     "rebalance_events": rebalance_events,
-                    "capacity_decay": capacity_decay,
                 },
             }
         ],

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -38,9 +38,8 @@ _ANNUALIZATION = 252
 
 
 def compute_dsr(
-    daily_returns: list[float] | np.ndarray,
+    daily_returns: list[float],
     num_trials: int,
-    average_correlation: float = 0.0,
 ) -> tuple[float | None, float | None]:
     """Deflated Sharpe Ratio (Bailey & López de Prado 2014).
 
@@ -53,9 +52,6 @@ def compute_dsr(
             if this is the only strategy ever evaluated — no correction
             will be applied. The orchestrator should pass
             len(strategy_library) so the correction is meaningful.
-        average_correlation: The average pairwise correlation between the
-            trials. Used to compute the effective number of independent
-            trials (Bailey-López de Prado variance-of-trials correlation model).
 
     Returns:
         (deflated_sharpe_ratio, dsr_p_value)
@@ -66,9 +62,6 @@ def compute_dsr(
             Gate threshold is 0.95 per passes_rigor_gate.
         Both are None if data is insufficient (T < 4) or degenerate.
     """
-    if num_trials < 1:
-        raise ValueError("num_trials must be >= 1")
-
     arr = np.asarray(daily_returns, dtype=float)
     T = len(arr)
     if T < 4:
@@ -91,11 +84,7 @@ def compute_dsr(
     # shift the denominator by a constant (3/4)·ŜR² and bias every DSR.
     gamma_4 = float(sp_kurtosis(arr, fisher=False))  # raw (Pearson) kurtosis
 
-    if math.isnan(average_correlation):
-        average_correlation = 0.0
-    average_correlation = max(0.0, min(1.0, average_correlation))
-
-    dsr, p_val = _dsr_from_stats(SR_hat, T, gamma_3, gamma_4, num_trials, average_correlation)
+    dsr, p_val = _dsr_from_stats(SR_hat, T, gamma_3, gamma_4, num_trials)
     return dsr, p_val
 
 
@@ -105,7 +94,6 @@ def _dsr_from_stats(
     gamma_3: float,
     gamma_4: float,
     N: int,
-    average_correlation: float = 0.0,
 ) -> tuple[float | None, float | None]:
     """Core DSR formula — exposed for direct unit-testing against spec cases.
 
@@ -117,7 +105,6 @@ def _dsr_from_stats(
             for normal returns. This matches Bailey-LdP (2014) eq. 8 directly;
             do NOT pass Fisher excess kurtosis here (it would bias the denom).
         N: Number of trials in the selection set.
-        average_correlation: Correlation scalar for variance of trials.
 
     Returns:
         (deflated_sharpe_annualized, dsr_p_value) or (None, None).
@@ -135,11 +122,6 @@ def _dsr_from_stats(
         phi_inv_1 = float(norm.ppf(1.0 - 1.0 / N))
         phi_inv_2 = float(norm.ppf(1.0 - 1.0 / (N * math.e)))
         E_max_N = (1.0 - _EULER_MASCHERONI) * phi_inv_1 + _EULER_MASCHERONI * phi_inv_2
-
-        # Apply Bailey-López de Prado correlation adjustment:
-        # E[max] of correlated variables scales by sqrt(1 - rho)
-        if average_correlation > 0.0:
-            E_max_N *= math.sqrt(max(0.0, 1.0 - average_correlation))
 
     # SR_zero: expected best-of-N under the null, scaled to per-bar variance
     # (under iid normal returns, per-bar SR has variance 1/(T-1))
@@ -273,110 +255,6 @@ def compute_oos_sharpe(
     return round(float((oos.mean() / sigma) * math.sqrt(_ANNUALIZATION)), 6)
 
 
-def _annualized_sharpe_arr(arr: np.ndarray) -> float | None:
-    """Annualized Sharpe of a 1-D return array, or None if degenerate."""
-    if len(arr) < 2:
-        return None
-    if float(np.ptp(arr)) == 0.0:
-        return None
-    sigma = float(arr.std(ddof=1))
-    if sigma <= 0.0:
-        return None
-    return float((arr.mean() / sigma) * math.sqrt(_ANNUALIZATION))
-
-
-# ─── 3b. Combinatorial Purged Cross-Validation OOS Sharpe ────────────
-
-
-def compute_cpcv_oos_sharpe(
-    cv_returns_matrix: np.ndarray | list[list[float]] | None = None,
-    n_groups: int = 6,
-    test_groups: int = 2,
-    test_bounds: list[np.ndarray] | list[list[int]] | None = None,
-    cv_splits: list[tuple[int, ...]] | None = None,
-) -> dict[str, float] | None:
-    """Combinatorial Purged Cross-Validation OOS Sharpe (López de Prado, AFML ch. 12).
-
-    Unlike naive block subsampling on a static returns array, true CPCV requires
-    a matrix of out-of-sample predictions from models trained on C(N, k) splits.
-    This function assembles C(N-1, k-1) continuous backtest paths from those
-    splits, preventing artificial variance and evaluating path-to-path stability.
-
-    Note on embargo: Embargoing (dropping bars after test sets) must be applied
-    upstream during the generation of `cv_returns_matrix` to prevent serial
-    correlation leakage into the training sets. Path assembly only combines
-    the resulting OOS test blocks.
-
-    Args:
-        cv_returns_matrix: Shape (S, T) where S = C(n_groups, test_groups).
-            If a 1D array of static returns is passed (e.g. from a single backtest),
-            this correctly rejects the calculation, as static CPCV is mathematically
-            invalid (it generates identical paths).
-        n_groups: Number of contiguous partitions (N). Must be >= 2.
-        test_groups: Blocks held out per split (k), 1 <= k < N.
-        test_bounds: Explicit list of N arrays containing the exact time indices for
-            each block to prevent look-ahead bias from misaligned uniform splits.
-        cv_splits: Explicit list of S tuples mapping each matrix row to the test
-            blocks it held out, preventing lexicographical misalignment.
-
-    Returns:
-        Dict with metrics, or None if invalid matrix or static returns provided.
-    """
-    if cv_returns_matrix is None or len(cv_returns_matrix) == 0:
-        return None
-
-    arr = np.asarray(cv_returns_matrix, dtype=float)
-    if arr.ndim != 2:
-        return None
-
-    S, T = arr.shape
-    if n_groups < 2 or not (1 <= test_groups < n_groups):
-        return None
-    if n_groups * 5 > T:  # need >= ~5 bars per block to form a Sharpe
-        return None
-
-    splits = cv_splits if cv_splits is not None else list(combinations(range(n_groups), test_groups))
-
-    if len(splits) != S:
-        return None
-
-    if test_bounds is not None:
-        bounds = [np.asarray(b, dtype=int) for b in test_bounds]
-        if len(bounds) != n_groups:
-            return None
-    else:
-        bounds = np.array_split(np.arange(T), n_groups)
-
-    n_paths = math.comb(n_groups - 1, test_groups - 1)
-
-    paths = np.zeros((n_paths, T))
-
-    for i in range(n_groups):
-        splits_with_i = [s_idx for s_idx, combo in enumerate(splits) if i in combo]
-        paths[:, bounds[i]] = arr[np.ix_(splits_with_i, bounds[i])]
-
-    oos_sharpes: list[float] = []
-    for p in range(n_paths):
-        s = _annualized_sharpe_arr(paths[p])
-        if s is not None and math.isfinite(s):
-            oos_sharpes.append(s)
-
-    if not oos_sharpes:
-        return None
-
-    mean_oos = float(np.mean(oos_sharpes))
-    positive_fraction = float(sum(s > 0.0 for s in oos_sharpes) / len(oos_sharpes))
-
-    return {
-        "mean_oos_sharpe": round(mean_oos, 6),
-        "std_oos_sharpe": round(float(np.std(oos_sharpes, ddof=1)) if len(oos_sharpes) > 1 else 0.0, 6),
-        "positive_fraction": round(positive_fraction, 6),
-        "mean_is_sharpe": 0.0,
-        "oos_is_ratio": 0.0,
-        "n_paths": len(oos_sharpes),
-    }
-
-
 # ─── 4. Kelly Criterion position sizing ─────────────────────────────
 
 
@@ -492,7 +370,6 @@ def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
     1. Forward data access patterns (e.g., self.data.close[+N])
     2. Calls to functions with look-ahead-suggestive names
     3. Direct indexing into data feeds beyond current bar
-    4. Negative shifts (e.g., pandas df.shift(-1)) which leak future data.
 
     Args:
         strategy_code: Python source code of the strategy.
@@ -512,35 +389,6 @@ def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
             func_name = _get_func_name(node.func)
             if func_name and func_name.lower() in _LOOK_AHEAD_FUNCTIONS:
                 warnings.append(f"Line {node.lineno}: call to '{func_name}' may indicate look-ahead bias")
-
-            # Check for pandas negative shifts, e.g., shift(-1)
-            if func_name == "shift":
-
-                def _is_negative(val_node: ast.AST) -> bool | int | float:
-                    if isinstance(val_node, ast.UnaryOp) and isinstance(val_node.op, ast.USub):
-                        if isinstance(val_node.operand, ast.Constant) and isinstance(
-                            val_node.operand.value, (int, float)
-                        ):
-                            return val_node.operand.value
-                    elif (
-                        isinstance(val_node, ast.Constant)
-                        and isinstance(val_node.value, (int, float))
-                        and val_node.value < 0
-                    ):
-                        return abs(val_node.value)
-                    return False
-
-                # The first positional argument is 'periods'
-                if len(node.args) > 0:
-                    val = _is_negative(node.args[0])
-                    if val is not False:
-                        warnings.append(f"Line {node.lineno}: negative shift(-{val}) references future data")
-                # Alternatively, check keyword arguments for 'periods'
-                for kw in node.keywords:
-                    if kw.arg == "periods":
-                        val = _is_negative(kw.value)
-                        if val is not False:
-                            warnings.append(f"Line {node.lineno}: negative shift(-{val}) references future data")
 
         if isinstance(node, ast.Subscript):
             slice_val = node.slice
@@ -579,8 +427,6 @@ class RigorGateResult:
         look_ahead_passed: bool = False,
         in_sample_sharpe: float | None = None,
         paper_claimed_sharpe: float | None = None,
-        cpcv_mean_oos_sharpe: float | None = None,
-        cpcv_positive_fraction: float | None = None,
     ) -> None:
         self.strategy_id = strategy_id
         self.deflated_sharpe = deflated_sharpe
@@ -591,11 +437,6 @@ class RigorGateResult:
         self.look_ahead_passed = look_ahead_passed
         self.in_sample_sharpe = in_sample_sharpe
         self.paper_claimed_sharpe = paper_claimed_sharpe
-        # Combinatorial Purged CV results (None when the series is too short to
-        # partition). When present, the gate additionally requires that the
-        # strategy's edge holds OOS across a majority of CPCV paths.
-        self.cpcv_mean_oos_sharpe = cpcv_mean_oos_sharpe
-        self.cpcv_positive_fraction = cpcv_positive_fraction
 
     @property
     def passes_all(self) -> bool:
@@ -610,10 +451,6 @@ class RigorGateResult:
         if self.oos_sharpe is None:
             return False
         if self.in_sample_sharpe and self.in_sample_sharpe > 0 and self.oos_sharpe / self.in_sample_sharpe < 0.5:
-            return False
-        # Combinatorial Purged CV: when computed, the edge must hold OOS across a
-        # majority of held-out paths (not just the single 70/30 tail above).
-        if self.cpcv_positive_fraction is not None and self.cpcv_positive_fraction < 0.5:
             return False
         return self.look_ahead_passed
 
@@ -646,17 +483,6 @@ class RigorGateResult:
         else:
             details["oos_sharpe"] = "MISSING"
 
-        if self.cpcv_positive_fraction is not None:
-            if self.cpcv_positive_fraction >= 0.5:
-                details["cpcv"] = (
-                    f"PASS (OOS+ {self.cpcv_positive_fraction:.0%} of paths, "
-                    f"mean OOS SR={self.cpcv_mean_oos_sharpe:.2f})"
-                )
-            else:
-                details["cpcv"] = f"FAIL (OOS+ only {self.cpcv_positive_fraction:.0%} of paths, need ≥ 50%)"
-        else:
-            details["cpcv"] = "MISSING"
-
         details["look_ahead"] = "PASS" if self.look_ahead_passed else "FAIL"
 
         return details
@@ -682,9 +508,8 @@ def run_rigor_gate(
     # 2. PBO — use pre-computed library-level score
     pbo_score = pbo_scores.get(strategy_id) if pbo_scores else None
 
-    # 3. Walk-forward OOS Sharpe (single holdout) + Combinatorial Purged CV
+    # 3. Walk-forward OOS Sharpe
     oos_sharpe = compute_oos_sharpe(daily_returns)
-    cpcv = compute_cpcv_oos_sharpe(daily_returns)
 
     # 4. Look-ahead audit
     if strategy_code is not None:
@@ -715,18 +540,15 @@ def run_rigor_gate(
         look_ahead_passed=la_passed,
         in_sample_sharpe=in_sample_sharpe,
         paper_claimed_sharpe=paper_claimed_sharpe,
-        cpcv_mean_oos_sharpe=cpcv["mean_oos_sharpe"] if cpcv else None,
-        cpcv_positive_fraction=cpcv["positive_fraction"] if cpcv else None,
     )
 
     logger.info(
-        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s, OOS=%s, CPCV+=%s, LA=%s)",
+        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s, OOS=%s, LA=%s)",
         strategy_id,
         "PASS" if result.passes_all else "FAIL",
         dsr_p_value,
         pbo_score,
         oos_sharpe,
-        cpcv["positive_fraction"] if cpcv else None,
         la_passed,
     )
 

--- a/backend/tests/services/test_portfolio_backtester.py
+++ b/backend/tests/services/test_portfolio_backtester.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
+
 from archimedes.services.portfolio_backtester import (
     ANNUALIZATION,
     DEFAULT_REBALANCE_DAYS,
@@ -24,31 +25,26 @@ from archimedes.services.portfolio_backtester import (
 )
 
 
-def _flat_panel(symbols: list[str], n_bars: int, daily_drift: float = 0.0005) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Build a deterministic price and volume panel with mild upward drift."""
+def _flat_panel(symbols: list[str], n_bars: int, daily_drift: float = 0.0005) -> pd.DataFrame:
+    """Build a deterministic two-symbol price panel with mild upward drift."""
     idx = pd.bdate_range("2018-01-02", periods=n_bars)
     data = {}
-    vols = {}
     for i, s in enumerate(symbols):
-        # Distinct drifts and deterministic noise so variance > 0 for Almgren impact
-        noise = (i + 1) * 0.005 * np.sin(np.arange(n_bars))
-        prices = 100.0 * np.cumprod(1.0 + (daily_drift + i * 0.0001) + noise)
+        # Distinct drifts per symbol so the simulator isn't degenerate.
+        prices = 100.0 * np.cumprod(1.0 + (daily_drift + i * 0.0001) * np.ones(n_bars))
         data[s] = pd.Series(prices, index=idx)
-        # Constant volume
-        vols[s] = pd.Series(1_000_000.0 * np.ones(n_bars), index=idx)
-    return pd.DataFrame(data), pd.DataFrame(vols)
+    return pd.DataFrame(data)
 
 
 class TestSimulate:
     def test_two_asset_rebalance_produces_dense_return_series(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=500)
+        panel = _flat_panel(["SPY", "TLT"], n_bars=500)
         rets, eq = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": 0.6, "TLT": 0.4},
+            panel,
+            {"SPY": 0.6, "TLT": 0.4},
             rebalance_days=21,
             initial_cash=100_000.0,
-            gamma=0.1,
+            tx_cost_bps=10,
         )
         assert len(rets) == 500
         assert len(eq) == 500
@@ -58,104 +54,54 @@ class TestSimulate:
         assert abs(rets[0]) < 1e-6
 
     def test_negative_weights_clamped_to_zero(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
+        panel = _flat_panel(["SPY", "TLT"], n_bars=120)
         # SPY has negative weight; should be treated as 0 → 100% TLT
         rets_neg, _ = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": -0.5, "TLT": 1.0},
+            panel,
+            {"SPY": -0.5, "TLT": 1.0},
             rebalance_days=21,
             initial_cash=100_000.0,
-            gamma=0.1,
+            tx_cost_bps=10,
         )
         rets_pure_tlt, _ = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": 0.0, "TLT": 1.0},
+            panel,
+            {"SPY": 0.0, "TLT": 1.0},
             rebalance_days=21,
             initial_cash=100_000.0,
-            gamma=0.1,
+            tx_cost_bps=10,
         )
         # Long-only enforcement: -0.5 SPY is dropped, TLT renormalizes to 1.0
         np.testing.assert_allclose(rets_neg, rets_pure_tlt, atol=1e-12)
 
     def test_rebalance_charges_turnover_cost(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120, daily_drift=0.001)
-        _, eq_with_cost = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": 0.5, "TLT": 0.5},
+        panel = _flat_panel(["SPY", "TLT"], n_bars=120, daily_drift=0.001)
+        rets_with_cost, eq_with_cost = _simulate_portfolio(
+            panel,
+            {"SPY": 0.5, "TLT": 0.5},
             rebalance_days=21,
             initial_cash=100_000.0,
-            gamma=0.1,  # Market impact cost
+            tx_cost_bps=100,  # 1% turnover cost — exaggerated to make signal clear
         )
-        _, eq_no_cost = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": 0.5, "TLT": 0.5},
+        rets_no_cost, eq_no_cost = _simulate_portfolio(
+            panel,
+            {"SPY": 0.5, "TLT": 0.5},
             rebalance_days=21,
             initial_cash=100_000.0,
-            gamma=0.0,  # Zero impact
+            tx_cost_bps=0,
         )
         # Cost must drag terminal equity strictly below the zero-cost run.
         assert eq_with_cost[-1] < eq_no_cost[-1]
 
     def test_all_zero_weights_raises(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
+        panel = _flat_panel(["SPY", "TLT"], n_bars=120)
         with pytest.raises(ValueError, match="non-positive"):
             _simulate_portfolio(
-                panel=panel,
-                volume_panel=vols,
-                target_weights={"SPY": 0.0, "TLT": 0.0},
+                panel,
+                {"SPY": 0.0, "TLT": 0.0},
                 rebalance_days=21,
                 initial_cash=100_000.0,
-                gamma=0.1,
+                tx_cost_bps=10,
             )
-
-    def test_negative_equity_stops_trading(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
-        rets, eq = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": 0.5, "TLT": 0.5},
-            rebalance_days=21,
-            initial_cash=10.0,  # Tiny starting cash
-            tx_cost_bps=10_000_000,  # Massive transaction costs to trigger bankruptcy on first rebalance
-            gamma=1.0,
-        )
-        assert min(eq) == 0.0
-        assert -1.0 in rets
-
-    def test_zero_volume_fallback(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
-        vols["SPY"] = 0.0
-        vols["TLT"] = 0.0
-        _rets, eq = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": 0.5, "TLT": 0.5},
-            rebalance_days=21,
-            initial_cash=100_000.0,
-            tx_cost_bps=0,
-            gamma=0.1,
-        )
-        assert len(eq) == 120
-
-    def test_zero_volatility_fallback(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120, daily_drift=0.0)
-        panel["SPY"] = 100.0
-        panel["TLT"] = 100.0
-        _rets, eq = _simulate_portfolio(
-            panel=panel,
-            volume_panel=vols,
-            target_weights={"SPY": 0.5, "TLT": 0.5},
-            rebalance_days=21,
-            initial_cash=100_000.0,
-            tx_cost_bps=0,
-            gamma=0.1,
-        )
-        assert len(eq) == 120
-        assert eq[-1] == 100_000.0
 
 
 class TestAnnualizedMetrics:
@@ -207,18 +153,19 @@ class TestBacktestPortfolioIntegration:
     """Integration-style test that stubs the fetcher to avoid yfinance hits."""
 
     def test_end_to_end_with_stubbed_panel(self) -> None:
-        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=2520)  # ~10y of daily bars
+        panel = _flat_panel(["SPY", "TLT"], n_bars=2520)  # ~10y of daily bars
 
         with patch(
             "archimedes.services.portfolio_backtester._fetch_price_panel",
-            return_value=(panel, vols),
+            return_value=panel,
         ):
             result, artifact = backtest_portfolio(
                 strategy_id="test-strategy-1",
                 weights={"SPY": 0.6, "TLT": 0.4},
-                start_date="2016-01-04",
-                end_date="2026-01-02",
+                start="2016-01-04",
+                end="2026-01-02",
                 num_trials_for_dsr=6,
+                paper_title="Test 60/40",
             )
 
         # Hard contract checks the strategies_routes wiring depends on
@@ -256,20 +203,6 @@ class TestBacktestPortfolioIntegration:
         with pytest.raises(ValueError, match="No positive weights"):
             backtest_portfolio(strategy_id="x", weights={"SPY": 0.0, "TLT": 0.0})
 
-    def test_empty_dataframe_vector(self) -> None:
-        import sys
-        from unittest.mock import MagicMock
-        from archimedes.services.portfolio_backtester import _fetch_price_panel
-
-        mock_data = MagicMock()
-        mock_data.fetch_ohlcv.return_value = pd.DataFrame()
-
-        sys.modules["archimedes_analytics_engine"] = MagicMock()
-        sys.modules["archimedes_analytics_engine.data"] = mock_data
-
-        with pytest.raises(ValueError, match="Insufficient overlapping history"):
-            _fetch_price_panel(["SPY", "TLT"], "2020-01-01", "2021-01-01")
-
     def test_rigor_metrics_match_evaluator(self) -> None:
         """DSR/OOS values returned by the backtester must come from the
         canonical rigor_evaluator — same functions the curated strategies'
@@ -277,17 +210,17 @@ class TestBacktestPortfolioIntegration:
         curated strategies are graded on the same scale."""
         from archimedes.services.rigor_evaluator import compute_dsr, compute_oos_sharpe
 
-        panel, vols = _flat_panel(["SPY"], n_bars=1500)
+        panel = _flat_panel(["SPY"], n_bars=1500)
 
         with patch(
             "archimedes.services.portfolio_backtester._fetch_price_panel",
-            return_value=(panel, vols),
+            return_value=panel,
         ):
             result, artifact = backtest_portfolio(
                 strategy_id="rigor-test",
                 weights={"SPY": 1.0},
-                start_date="2018-01-02",
-                end_date="2024-01-02",
+                start="2018-01-02",
+                end="2024-01-02",
                 num_trials_for_dsr=1,
             )
 

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -788,7 +788,7 @@ class TestGateDetailsBranches:
         """gate_details must always contain all four gate keys."""
         r = RigorGateResult("s")
         keys = set(r.gate_details.keys())
-        assert keys == {"dsr", "pbo", "oos_sharpe", "look_ahead", "cpcv"}
+        assert keys == {"dsr", "pbo", "oos_sharpe", "look_ahead"}
 
 
 # ─── run_rigor_gate — all branches in lines 509-555 ──────────────────
@@ -874,32 +874,9 @@ class TestRunRigorGatePaths:
     def test_gate_details_populated_by_run_rigor_gate(self):
         """gate_details on the returned result must have all four keys."""
         result = run_rigor_gate("s", _RETURNS_80)
-        assert set(result.gate_details.keys()) == {"dsr", "pbo", "oos_sharpe", "look_ahead", "cpcv"}
+        assert set(result.gate_details.keys()) == {"dsr", "pbo", "oos_sharpe", "look_ahead"}
 
     def test_num_trials_stored_on_result(self):
         """num_trials argument must be stored on the result."""
         result = run_rigor_gate("s", _RETURNS_80, num_trials=7)
         assert result.num_trials == 7
-
-
-# ─── CPCV Edge Cases ──────────────────────────────────────────────────
-
-from archimedes.services.rigor_evaluator import compute_cpcv_oos_sharpe
-
-
-def test_cpcv_returns_none_for_empty_array():
-    assert compute_cpcv_oos_sharpe([]) is None
-
-
-def test_cpcv_returns_none_for_single_asset_zero_variance():
-    assert compute_cpcv_oos_sharpe([[0.01] * 100] * 15) is None
-
-
-def test_cpcv_returns_none_for_infinite_values():
-    # Numpy calculations on inf cause warnings and usually return nan/inf std
-    res = compute_cpcv_oos_sharpe([[0.01] * 50 + [np.inf] * 50] * 15)
-    assert res is None or res["mean_oos_sharpe"] is None or math.isnan(res["mean_oos_sharpe"])
-
-
-def test_cpcv_returns_none_for_insufficient_splits():
-    assert compute_cpcv_oos_sharpe([[0.01, -0.01] * 2] * 15, n_groups=6, test_groups=2) is None


### PR DESCRIPTION
## Summary

Four files carried logic pushed **straight to `main` without a reviewable PR** during an external-agent session (DSR Effective-N, CPCV rewrite, Almgren market impact, look-ahead guard). This restores them to their pre-burst state (`335a7dc`) so each piece can be re-landed through a proper, reviewable PR — easier for the team to read and review.

Safe revert (new commit, **no force-push**). `#476`/`#477` (Ledoit-Wolf, data provenance) and harmless ruff auto-formatting on other files are untouched.

## Why revert then re-land?

Two reverted changes were **silently inert on `main`** — present in code/tests but never executing:
- **DSR Effective-N**: `average_correlation` was never passed by any caller → always defaulted to `0.0`.
- **CPCV**: `run_rigor_gate` passed a 1-D series to a 2-D-only function → always returned `None`; the CPCV gate check never fired.

Both are fixed in the re-land PRs that follow.

## Files restored to `335a7dc`
- `services/rigor_evaluator.py`
- `services/portfolio_backtester.py`
- `tests/test_rigor_evaluator.py`
- `tests/services/test_portfolio_backtester.py`

## Verify
`PYTHONPATH=backend python -m pytest backend/tests -q` → 1174 passed, 2 skipped

## Follow-up PRs
1. `backtester-execution-realism` — look-ahead guard + Almgren market impact + capacity decay
2. `rigor-gate-hardening` — shift(-1) audit + DSR Effective-N + CPCV, both wired and working