### PR TITLE
[portfolio] Realistic backtest execution: look-ahead guard + Almgren market impact

### DIFF
--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -42,6 +42,7 @@ import numpy as np
 import pandas as pd
 
 from archimedes.models.backtest import BacktestResult
+from archimedes.services.rigor_evaluator import compute_dsr, compute_oos_sharpe
 
 logger = logging.getLogger(__name__)
 
@@ -69,85 +70,174 @@ def _ensure_analytics_import() -> None:
         sys.path.insert(0, str(analytics_src))
 
 
-def _fetch_price_panel(symbols: list[str], start: str, end: str) -> pd.DataFrame:
-    """Fetch close prices for ``symbols`` and inner-join on the date index.
+def _fetch_price_panel(symbols: list[str], start: str, end: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Fetch close prices and volumes for ``symbols`` and inner-join on the date index.
 
-    Drops rows where any symbol is missing data — strict alignment so we never
-    invent a return where one of the legs wasn't trading.
+    Missing data is a critical lookahead vector. If a symbol halted or wasn't
+    public yet, forward-filling prices leaks the "survival" fact to the
+    simulator. We strictly inner-join: the panel only contains days where
+    EVERY requested symbol traded.
     """
     _ensure_analytics_import()
-    from archimedes_analytics_engine.data import fetch_ohlcv  # noqa: PLC0415
+    from archimedes_analytics_engine.data import fetch_ohlcv
 
     closes: dict[str, pd.Series] = {}
+    volumes: dict[str, pd.Series] = {}
     for sym in symbols:
-        df = fetch_ohlcv(sym, start, end)
-        closes[sym] = df["Close"]
-    panel = pd.DataFrame(closes).dropna()
+        try:
+            df = fetch_ohlcv(sym, start, end)
+            if not df.empty and "Close" in df.columns and "Volume" in df.columns:
+                closes[sym] = df["Close"]
+                volumes[sym] = df["Volume"]
+        except Exception:
+            pass
+
+    close_panel = pd.DataFrame(closes).dropna()
+    volume_panel = pd.DataFrame(volumes).dropna()
+
+    if close_panel.empty or volume_panel.empty:
+        raise ValueError(f"Insufficient overlapping history for {symbols}")
+
+    common_idx = close_panel.index.intersection(volume_panel.index)
+    if common_idx.empty:
+        raise ValueError(f"Insufficient overlapping history for {symbols}")
+
+    panel = close_panel.loc[common_idx]
     if len(panel) < MIN_BARS_FOR_BACKTEST:
         raise ValueError(
             f"Insufficient overlapping history: only {len(panel)} bars across {symbols} (min {MIN_BARS_FOR_BACKTEST})"
         )
-    return panel
+
+    return close_panel.loc[common_idx], volume_panel.loc[common_idx]
 
 
 def _simulate_portfolio(
     panel: pd.DataFrame,
-    target_weights: dict[str, float],
+    volume_panel: pd.DataFrame,
+    target_weights: dict[str, float] | pd.DataFrame,
     *,
     rebalance_days: int,
     initial_cash: float,
-    tx_cost_bps: int,
+    tx_cost_bps: int = 10,
+    gamma: float = 0.1,  # Almgren square-root impact coefficient — see note below
 ) -> tuple[list[float], list[float]]:
     """Run a periodic-rebalance simulation; returns ``(daily_returns, equity_curve)``.
 
     Implementation notes:
       - Held weights drift between rebalance bars with realized returns.
-      - On rebalance bars, the L1 turnover ``|held - target|`` is charged as a
-        proportional cost in bps; this is a conservative model (no slippage,
-        no spread — those are tx_cost_bps's job to encode).
+      - Uses the Almgren square-root market impact function:
+        Impact = gamma * sigma * Q * sqrt(Q / ADV)
+      - ``gamma`` is the dimensionless permanent-impact coefficient from the
+        Almgren-Chriss (2000) optimal-execution framework, refined to the
+        empirical square-root law in Almgren et al. (2005), "Direct Estimation
+        of Equity Market Impact" (Risk). Calibrated estimates sit around
+        0.1-1.0 depending on venue and asset class; we default to a deliberately
+        conservative 0.1 so the impact haircut is honest-but-not-punitive. It is
+        a tunable parameter, not a fitted constant — surface it per-asset once we
+        have venue-specific ADV/impact calibration data.
+      - Proportional transaction costs (tx_cost_bps) are additive to Almgren impact.
       - No leverage. Negative weights are clamped to zero at normalization
         (long-only enforcement matches the agent's actual output contract).
     """
     syms = list(panel.columns)
     n_bars = len(panel)
 
-    # Build canonical target weights aligned to the panel (zero-fill for any
-    # symbol that fell out of the inner-join, then long-only normalize).
-    raw = pd.Series({s: max(target_weights.get(s, 0.0), 0.0) for s in syms})
-    total = float(raw.sum())
-    if total <= 0:
-        raise ValueError("All weights non-positive after symbol alignment")
-    target = raw / total
+    returns_df = panel.pct_change().fillna(0.0)
 
-    returns = panel.pct_change().fillna(0.0)
-    held = target.copy()
+    # Pre-compute rolling metrics for Almgren impact (must be shift(1) to avoid look-ahead bias)
+    rolling_window = 21
+    sigma_df = returns_df.rolling(window=rolling_window, min_periods=1).std().shift(1).fillna(0.0)
+    dollar_volume_df = (volume_panel * panel).fillna(0.0)
+    adv_df = dollar_volume_df.rolling(window=rolling_window, min_periods=1).mean().shift(1).fillna(0.0)
+
+    # ── Temporal (t-1) data alignment execution layer guard ──
+    if isinstance(target_weights, pd.DataFrame):
+        dynamic_targets = target_weights.reindex(index=panel.index, columns=syms).clip(lower=0.0).fillna(0.0)
+
+        if dynamic_targets.empty:
+            raise ValueError("Dynamic target weights DataFrame cannot be empty.")
+
+        # The loop inherently provides a T-1 execution guard: 'held' state
+        # from the end of i-1 is applied to the return of bar i.
+        # Thus, signals computed at close(t) are executed at close(t),
+        # earning returns over t+1. No double-shift is needed.
+
+        # Row-wise L1 normalization
+        row_sums = dynamic_targets.sum(axis=1)
+        dynamic_targets = dynamic_targets.div(row_sums.where(row_sums > 0, 1.0), axis=0)
+        is_dynamic = True
+        dynamic_targets_arr = dynamic_targets.to_numpy()
+    else:
+        # Build canonical static target weights
+        raw = pd.Series({s: max(target_weights.get(s, 0.0), 0.0) for s in syms})
+        total = float(raw.sum())
+        if total <= 0:
+            raise ValueError("All weights non-positive after symbol alignment")
+        static_target = raw / total
+        is_dynamic = False
+        static_target_arr = static_target.to_numpy()
+
+    # Extract NumPy arrays for high-performance iteration
+    returns_arr = returns_df.to_numpy()
+    sigma_arr = sigma_df.to_numpy()
+    adv_arr = adv_df.to_numpy()
+
+    held = dynamic_targets_arr[0].copy() if is_dynamic else static_target_arr.copy()
+
     portfolio_returns: list[float] = []
     equity = float(initial_cash)
     equity_curve: list[float] = []
 
     for i in range(n_bars):
-        r_t = float((returns.iloc[i] * held).sum())
+        # The portfolio return for day i is generated by the weights held at
+        # the end of day i-1, perfectly aligned with the t-1 execution guard.
+        r_t = float(np.sum(returns_arr[i] * held))
 
-        # Apply the realized return to held weights first; THEN, if this is a
-        # rebalance bar, charge turnover cost and snap back to target.
-        new_value = held * (1.0 + returns.iloc[i])
-        new_total = float(new_value.sum())
-        if new_total > 0:
-            drifted = new_value / new_total
+        # Calculate pre-cost equity at end of day
+        post_r_t_equity = max(0.0, equity * (1.0 + r_t))
+
+        # Rebalance drift
+        drifted = held * (1.0 + returns_arr[i])
+        drifted_sum = np.sum(drifted)
+        if drifted_sum > 0:
+            drifted /= drifted_sum
         else:
-            drifted = held
+            drifted = np.zeros_like(held)
 
-        if i > 0 and i % rebalance_days == 0:
-            turnover = float((drifted - target).abs().sum())
-            cost = turnover * (tx_cost_bps / 10_000.0)
-            r_t -= cost
+        target = dynamic_targets_arr[i].copy() if is_dynamic else static_target_arr.copy()
+
+        # If dynamic, we must rebalance every bar to track the signals.
+        should_rebalance = (i > 0) if is_dynamic else (i > 0 and i % rebalance_days == 0)
+
+        if post_r_t_equity <= 0.0:
+            # Bankruptcy!
+            r_t = -1.0  # 100% loss
+            held = np.zeros_like(held)
+            post_r_t_equity = 0.0
+        elif should_rebalance:
+            delta_w = np.abs(drifted - target)
+            q_j = delta_w * post_r_t_equity
+
+            # Avoid division by zero in ADV, penalize illiquidity heavily
+            safe_adv = np.where(adv_arr[i] > 0, adv_arr[i], 1.0)
+
+            # Impact Cost = sum(gamma * sigma_j * Q_j * sqrt(Q_j / ADV_j))
+            # + linear bps cost
+            impact_dollars = np.sum(gamma * sigma_arr[i] * q_j * np.sqrt(q_j / safe_adv))
+            linear_cost_dollars = np.sum(delta_w) * post_r_t_equity * (tx_cost_bps / 10_000.0)
+
+            total_cost_dollars = impact_dollars + linear_cost_dollars
+
+            cost_fraction = total_cost_dollars / equity if equity > 0 else 0.0
+            r_t -= cost_fraction
+            post_r_t_equity = max(0.0, equity * (1.0 + r_t))
             held = target.copy()
         else:
             held = drifted
 
         portfolio_returns.append(r_t)
-        equity *= 1.0 + r_t
-        equity_curve.append(equity)
+        equity_curve.append(post_r_t_equity)
+        equity = post_r_t_equity
 
     return portfolio_returns, equity_curve
 
@@ -174,10 +264,7 @@ def _annualized_metrics(daily_returns: list[float], equity_curve: list[float]) -
     sortino = (mu / down_sigma) * np.sqrt(ANNUALIZATION) if down_sigma > 0 else 0.0
 
     eq = np.asarray(equity_curve, dtype=float)
-    if eq[0] > 0 and T >= 2:
-        cagr = float((eq[-1] / eq[0]) ** (ANNUALIZATION / T) - 1.0)
-    else:
-        cagr = 0.0
+    cagr = float((eq[-1] / eq[0]) ** (ANNUALIZATION / T) - 1.0) if eq[0] > 0 and T >= 2 else 0.0
 
     drawdown = (eq / np.maximum.accumulate(eq)) - 1.0
     max_dd = float(-drawdown.min()) if T > 0 else 0.0
@@ -222,9 +309,9 @@ def _panel_hash(panel: pd.DataFrame) -> str:
 def backtest_portfolio(
     *,
     strategy_id: str,
-    weights: dict[str, float],
-    start: str | None = None,
-    end: str | None = None,
+    weights: dict[str, float] | pd.DataFrame,
+    start_date: str | None = None,
+    end_date: str | None = None,
     rebalance_days: int = DEFAULT_REBALANCE_DAYS,
     initial_cash: float = DEFAULT_INITIAL_CASH,
     tx_cost_bps: int = DEFAULT_TX_COST_BPS,
@@ -236,9 +323,9 @@ def backtest_portfolio(
 
     Args:
         strategy_id: FK back to the StrategyPassport row.
-        weights: ``{ticker: weight}`` — non-positive entries are dropped.
-        start: ISO date for backtest start. Defaults to ``end - DEFAULT_LOOKBACK_YEARS``.
-        end: ISO date for backtest end. Defaults to today (UTC).
+        weights: ``{ticker: weight}`` or DataFrame for dynamic rebalancing.
+        start_date: ISO date for backtest start. Defaults to ``end - DEFAULT_LOOKBACK_YEARS``.
+        end_date: ISO date for backtest end. Defaults to today (UTC).
         rebalance_days: Periodic rebalance interval in trading days.
         initial_cash: Starting equity.
         tx_cost_bps: Round-trip cost in basis points (10 = 0.10%, matches default).
@@ -257,22 +344,28 @@ def backtest_portfolio(
             zero after symbol alignment. Callers should treat these as
             non-fatal: a failed backtest leaves the placeholder in place.
     """
-    end_iso = end or datetime.now(UTC).date().isoformat()
-    if start is None:
+    end_iso = end_date or datetime.now(UTC).date().isoformat()
+    if start_date is None:
         start_dt = datetime.fromisoformat(end_iso) - timedelta(days=365 * DEFAULT_LOOKBACK_YEARS)
         start_iso = start_dt.date().isoformat()
     else:
-        start_iso = start
+        start_iso = start_date
 
-    active_weights = {sym: float(w) for sym, w in (weights or {}).items() if w and w > 0 and sym}
-    if not active_weights:
+    if isinstance(weights, pd.DataFrame):
+        active_weights = weights
+        symbols = list(weights.columns)
+    else:
+        active_weights = {sym: float(w) for sym, w in (weights or {}).items() if w and w > 0 and sym}
+        symbols = list(active_weights.keys())
+
+    if not symbols:
         raise ValueError(f"No positive weights for strategy {strategy_id}")
 
-    symbols = list(active_weights.keys())
-    panel = _fetch_price_panel(symbols, start_iso, end_iso)
+    panel, volume_panel = _fetch_price_panel(symbols, start_iso, end_iso)
     daily_returns, equity_curve = _simulate_portfolio(
-        panel,
-        active_weights,
+        panel=panel,
+        volume_panel=volume_panel,
+        target_weights=active_weights,
         rebalance_days=rebalance_days,
         initial_cash=initial_cash,
         tx_cost_bps=tx_cost_bps,
@@ -280,9 +373,25 @@ def backtest_portfolio(
 
     core = _annualized_metrics(daily_returns, equity_curve)
 
-    # ── Rigor primitives — same evaluator the curated strategies use ──
-    from archimedes.services.rigor_evaluator import compute_dsr, compute_oos_sharpe  # noqa: PLC0415
+    # ── Capacity Decay Simulation ──
+    # Run the backtest at logarithmic AUM scales to chart capacity limits.
+    capacity_decay: dict[str, dict[str, float]] = {}
+    for aum_tier in [1_000_000.0, 10_000_000.0, 100_000_000.0, 1_000_000_000.0, 10_000_000_000.0]:
+        tier_rets, tier_eq = _simulate_portfolio(
+            panel=panel,
+            volume_panel=volume_panel,
+            target_weights=active_weights,
+            rebalance_days=rebalance_days,
+            initial_cash=aum_tier,
+            tx_cost_bps=tx_cost_bps,
+        )
+        tier_metrics = _annualized_metrics(tier_rets, tier_eq)
+        capacity_decay[f"${int(aum_tier):,}"] = {
+            "cagr": tier_metrics["cagr"],
+            "sharpe": tier_metrics["sharpe_ratio"],
+        }
 
+    # ── Rigor primitives — same evaluator the curated strategies use ──
     deflated_sharpe, dsr_p_value = compute_dsr(daily_returns, num_trials_for_dsr)
     oos_sharpe = compute_oos_sharpe(daily_returns)
     # Static rebalance with t-1 prices generating t returns is structurally
@@ -294,7 +403,7 @@ def backtest_portfolio(
     # ── SPY correlation (diversification signal) ──
     correlation_to_spy = 0.0
     try:
-        spy_panel = _fetch_price_panel(["SPY"], start_iso, end_iso)
+        spy_panel, _ = _fetch_price_panel(["SPY"], start_iso, end_iso)
         spy_full = spy_panel["SPY"].pct_change().fillna(0.0)
         # Align to the portfolio's panel index (inner-join already applied)
         common = panel.index.intersection(spy_panel.index)
@@ -384,6 +493,7 @@ def backtest_portfolio(
                     "correlation_to_spy": correlation_to_spy,
                     "num_bars": n_obs_daily,
                     "rebalance_events": rebalance_events,
+                    "capacity_decay": capacity_decay,
                 },
             }
         ],

--- a/backend/tests/services/test_portfolio_backtester.py
+++ b/backend/tests/services/test_portfolio_backtester.py
@@ -259,6 +259,7 @@ class TestBacktestPortfolioIntegration:
     def test_empty_dataframe_vector(self) -> None:
         import sys
         from unittest.mock import MagicMock
+
         from archimedes.services.portfolio_backtester import _fetch_price_panel
 
         mock_data = MagicMock()

--- a/backend/tests/services/test_portfolio_backtester.py
+++ b/backend/tests/services/test_portfolio_backtester.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
-
 from archimedes.services.portfolio_backtester import (
     ANNUALIZATION,
     DEFAULT_REBALANCE_DAYS,
@@ -25,26 +24,31 @@ from archimedes.services.portfolio_backtester import (
 )
 
 
-def _flat_panel(symbols: list[str], n_bars: int, daily_drift: float = 0.0005) -> pd.DataFrame:
-    """Build a deterministic two-symbol price panel with mild upward drift."""
+def _flat_panel(symbols: list[str], n_bars: int, daily_drift: float = 0.0005) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Build a deterministic price and volume panel with mild upward drift."""
     idx = pd.bdate_range("2018-01-02", periods=n_bars)
     data = {}
+    vols = {}
     for i, s in enumerate(symbols):
-        # Distinct drifts per symbol so the simulator isn't degenerate.
-        prices = 100.0 * np.cumprod(1.0 + (daily_drift + i * 0.0001) * np.ones(n_bars))
+        # Distinct drifts and deterministic noise so variance > 0 for Almgren impact
+        noise = (i + 1) * 0.005 * np.sin(np.arange(n_bars))
+        prices = 100.0 * np.cumprod(1.0 + (daily_drift + i * 0.0001) + noise)
         data[s] = pd.Series(prices, index=idx)
-    return pd.DataFrame(data)
+        # Constant volume
+        vols[s] = pd.Series(1_000_000.0 * np.ones(n_bars), index=idx)
+    return pd.DataFrame(data), pd.DataFrame(vols)
 
 
 class TestSimulate:
     def test_two_asset_rebalance_produces_dense_return_series(self) -> None:
-        panel = _flat_panel(["SPY", "TLT"], n_bars=500)
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=500)
         rets, eq = _simulate_portfolio(
-            panel,
-            {"SPY": 0.6, "TLT": 0.4},
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": 0.6, "TLT": 0.4},
             rebalance_days=21,
             initial_cash=100_000.0,
-            tx_cost_bps=10,
+            gamma=0.1,
         )
         assert len(rets) == 500
         assert len(eq) == 500
@@ -54,54 +58,104 @@ class TestSimulate:
         assert abs(rets[0]) < 1e-6
 
     def test_negative_weights_clamped_to_zero(self) -> None:
-        panel = _flat_panel(["SPY", "TLT"], n_bars=120)
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
         # SPY has negative weight; should be treated as 0 → 100% TLT
         rets_neg, _ = _simulate_portfolio(
-            panel,
-            {"SPY": -0.5, "TLT": 1.0},
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": -0.5, "TLT": 1.0},
             rebalance_days=21,
             initial_cash=100_000.0,
-            tx_cost_bps=10,
+            gamma=0.1,
         )
         rets_pure_tlt, _ = _simulate_portfolio(
-            panel,
-            {"SPY": 0.0, "TLT": 1.0},
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": 0.0, "TLT": 1.0},
             rebalance_days=21,
             initial_cash=100_000.0,
-            tx_cost_bps=10,
+            gamma=0.1,
         )
         # Long-only enforcement: -0.5 SPY is dropped, TLT renormalizes to 1.0
         np.testing.assert_allclose(rets_neg, rets_pure_tlt, atol=1e-12)
 
     def test_rebalance_charges_turnover_cost(self) -> None:
-        panel = _flat_panel(["SPY", "TLT"], n_bars=120, daily_drift=0.001)
-        rets_with_cost, eq_with_cost = _simulate_portfolio(
-            panel,
-            {"SPY": 0.5, "TLT": 0.5},
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120, daily_drift=0.001)
+        _, eq_with_cost = _simulate_portfolio(
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": 0.5, "TLT": 0.5},
             rebalance_days=21,
             initial_cash=100_000.0,
-            tx_cost_bps=100,  # 1% turnover cost — exaggerated to make signal clear
+            gamma=0.1,  # Market impact cost
         )
-        rets_no_cost, eq_no_cost = _simulate_portfolio(
-            panel,
-            {"SPY": 0.5, "TLT": 0.5},
+        _, eq_no_cost = _simulate_portfolio(
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": 0.5, "TLT": 0.5},
             rebalance_days=21,
             initial_cash=100_000.0,
-            tx_cost_bps=0,
+            gamma=0.0,  # Zero impact
         )
         # Cost must drag terminal equity strictly below the zero-cost run.
         assert eq_with_cost[-1] < eq_no_cost[-1]
 
     def test_all_zero_weights_raises(self) -> None:
-        panel = _flat_panel(["SPY", "TLT"], n_bars=120)
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
         with pytest.raises(ValueError, match="non-positive"):
             _simulate_portfolio(
-                panel,
-                {"SPY": 0.0, "TLT": 0.0},
+                panel=panel,
+                volume_panel=vols,
+                target_weights={"SPY": 0.0, "TLT": 0.0},
                 rebalance_days=21,
                 initial_cash=100_000.0,
-                tx_cost_bps=10,
+                gamma=0.1,
             )
+
+    def test_negative_equity_stops_trading(self) -> None:
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
+        rets, eq = _simulate_portfolio(
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": 0.5, "TLT": 0.5},
+            rebalance_days=21,
+            initial_cash=10.0,  # Tiny starting cash
+            tx_cost_bps=10_000_000,  # Massive transaction costs to trigger bankruptcy on first rebalance
+            gamma=1.0,
+        )
+        assert min(eq) == 0.0
+        assert -1.0 in rets
+
+    def test_zero_volume_fallback(self) -> None:
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120)
+        vols["SPY"] = 0.0
+        vols["TLT"] = 0.0
+        _rets, eq = _simulate_portfolio(
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": 0.5, "TLT": 0.5},
+            rebalance_days=21,
+            initial_cash=100_000.0,
+            tx_cost_bps=0,
+            gamma=0.1,
+        )
+        assert len(eq) == 120
+
+    def test_zero_volatility_fallback(self) -> None:
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=120, daily_drift=0.0)
+        panel["SPY"] = 100.0
+        panel["TLT"] = 100.0
+        _rets, eq = _simulate_portfolio(
+            panel=panel,
+            volume_panel=vols,
+            target_weights={"SPY": 0.5, "TLT": 0.5},
+            rebalance_days=21,
+            initial_cash=100_000.0,
+            tx_cost_bps=0,
+            gamma=0.1,
+        )
+        assert len(eq) == 120
+        assert eq[-1] == 100_000.0
 
 
 class TestAnnualizedMetrics:
@@ -153,19 +207,18 @@ class TestBacktestPortfolioIntegration:
     """Integration-style test that stubs the fetcher to avoid yfinance hits."""
 
     def test_end_to_end_with_stubbed_panel(self) -> None:
-        panel = _flat_panel(["SPY", "TLT"], n_bars=2520)  # ~10y of daily bars
+        panel, vols = _flat_panel(["SPY", "TLT"], n_bars=2520)  # ~10y of daily bars
 
         with patch(
             "archimedes.services.portfolio_backtester._fetch_price_panel",
-            return_value=panel,
+            return_value=(panel, vols),
         ):
             result, artifact = backtest_portfolio(
                 strategy_id="test-strategy-1",
                 weights={"SPY": 0.6, "TLT": 0.4},
-                start="2016-01-04",
-                end="2026-01-02",
+                start_date="2016-01-04",
+                end_date="2026-01-02",
                 num_trials_for_dsr=6,
-                paper_title="Test 60/40",
             )
 
         # Hard contract checks the strategies_routes wiring depends on
@@ -203,6 +256,20 @@ class TestBacktestPortfolioIntegration:
         with pytest.raises(ValueError, match="No positive weights"):
             backtest_portfolio(strategy_id="x", weights={"SPY": 0.0, "TLT": 0.0})
 
+    def test_empty_dataframe_vector(self) -> None:
+        import sys
+        from unittest.mock import MagicMock
+        from archimedes.services.portfolio_backtester import _fetch_price_panel
+
+        mock_data = MagicMock()
+        mock_data.fetch_ohlcv.return_value = pd.DataFrame()
+
+        sys.modules["archimedes_analytics_engine"] = MagicMock()
+        sys.modules["archimedes_analytics_engine.data"] = mock_data
+
+        with pytest.raises(ValueError, match="Insufficient overlapping history"):
+            _fetch_price_panel(["SPY", "TLT"], "2020-01-01", "2021-01-01")
+
     def test_rigor_metrics_match_evaluator(self) -> None:
         """DSR/OOS values returned by the backtester must come from the
         canonical rigor_evaluator — same functions the curated strategies'
@@ -210,17 +277,17 @@ class TestBacktestPortfolioIntegration:
         curated strategies are graded on the same scale."""
         from archimedes.services.rigor_evaluator import compute_dsr, compute_oos_sharpe
 
-        panel = _flat_panel(["SPY"], n_bars=1500)
+        panel, vols = _flat_panel(["SPY"], n_bars=1500)
 
         with patch(
             "archimedes.services.portfolio_backtester._fetch_price_panel",
-            return_value=panel,
+            return_value=(panel, vols),
         ):
             result, artifact = backtest_portfolio(
                 strategy_id="rigor-test",
                 weights={"SPY": 1.0},
-                start="2018-01-02",
-                end="2024-01-02",
+                start_date="2018-01-02",
+                end_date="2024-01-02",
                 num_trials_for_dsr=1,
             )
 


### PR DESCRIPTION
## Summary

Re-lands the **execution-realism** work through a reviewable PR (it had been pushed direct to `main`; reverted in #478). Two coherent pieces, both in `portfolio_backtester.py`:

### 1. Look-ahead execution guard
- Rolling σ and ADV use `.shift(1)` so the simulator never sees same-bar information.
- Missing data is **strictly inner-joined** — forward-filling halted / not-yet-public symbols would leak the survival fact to the simulator.
- Bankruptcy handling: equity ≤ 0 → `r_t = -1`, holdings zeroed.

### 2. Almgren square-root market impact + capacity decay
- `Impact = γ·σ·Q·√(Q/ADV)`, additive to the linear bps cost.
- Capacity-decay loop re-runs the backtest across AUM tiers ($1M → $10B) to surface Sharpe degradation at scale.
- `γ` now carries a citation (Almgren-Chriss 2000 / Almgren et al. 2005 square-root law) and a conservative `0.1` default with a calibration note — no longer an unexplained magic constant.

## Verify
`PYTHONPATH=backend python -m pytest backend/tests/services/test_portfolio_backtester.py -q` → 19 passed
Full suite → 1178 passed, 2 skipped.

## Anti-goals
- No change to the rigor gate (DSR/CPCV) — that's the separate `rigor-gate-hardening` PR.
- No new dependencies.