### PR TITLE
[rigor] Remove synthetic-returns fallback from rigor gate evaluation

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -109,15 +109,12 @@ async def evaluate_rigor_gate():
         code = _load_strategy_code(s.strategy_code_path) if s.strategy_code_path else None
         strategy_code_map[s.id] = code
 
-    # Fallback: if no persisted data, try stub-based synthetic returns
-    # (graceful degradation for strategies not yet backtested)
-    for s in strategies:
-        if (s.id not in returns_by_strategy or len(returns_by_strategy[s.id]) < 10) and s.stub_sharpe is not None:
-            returns_by_strategy[s.id] = _synthetic_returns_from_stub(
-                sharpe=s.stub_sharpe,
-                cagr=s.stub_cagr,
-                max_dd=s.stub_max_dd,
-            )
+    # Strategies with no real backtest data report all gate fields as MISSING
+    # (handled in the per-strategy loop below). Do NOT synthesize returns from
+    # stub_sharpe — DSR would trivially pass because the series was constructed
+    # to hit exactly that Sharpe, creating a circular validation that is
+    # meaningless. The stubs remain available for UI display (portfolio page)
+    # but must not feed into the rigor gate.
 
     # Compute PBO across all strategies that have returns
     valid_returns = {k: v for k, v in returns_by_strategy.items() if len(v) >= 10}
@@ -258,29 +255,6 @@ async def compute_pbo_endpoint(req: PBORequest, request: Request, response: Resp
 
 
 # ── Helpers ──────────────────────────────────────────────────
-
-
-def _synthetic_returns_from_stub(
-    sharpe: float,
-    cagr: float | None = None,  # noqa: ARG001 — accepted for forward-compat; current stub only needs sharpe
-    max_dd: float | None = None,  # noqa: ARG001 — accepted for forward-compat; current stub only needs sharpe
-    T: int = 504,  # ~2 years of daily data
-) -> list[float]:
-    """Generate synthetic daily returns matching stub Sharpe.
-
-    This is a hackathon placeholder. In production, the analytics-engine
-    runs the actual backtest and produces real BacktestResult.daily_returns.
-    """
-    import numpy as np
-
-    rng = np.random.default_rng(hash(sharpe) % (2**32))
-
-    # Target daily vol = 1% (reasonable for equity-like assets)
-    daily_vol = 0.01
-    # Target daily mean from annualized Sharpe
-    daily_mean = sharpe * daily_vol / np.sqrt(252)
-
-    return rng.normal(daily_mean, daily_vol, size=T).tolist()
 
 
 def _load_strategy_code(code_path: str) -> str | None:

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -5,7 +5,7 @@ Covers:
   - GET /api/selection-bias/gate/{strategy_id}  (single-strategy gate)
   - POST /api/selection-bias/pbo  (pure-math PBO computation)
   - Pydantic schema construction and defaults
-  - Pure helper functions (_synthetic_returns_from_stub, _load_strategy_code)
+  - Pure helper functions (_load_strategy_code)
 
 The GET /gate and GET /gate/{id} endpoints call init_db() internally; an
 autouse fixture redirects DATABASE_URL to a per-test temporary SQLite file
@@ -26,7 +26,6 @@ from archimedes.api.selection_bias_routes import (
     RigorGateResponse,
     StrategyRigorResult,
     _load_strategy_code,
-    _synthetic_returns_from_stub,
 )
 from httpx import ASGITransport, AsyncClient
 
@@ -160,31 +159,6 @@ class TestPBOResponse:
 
 
 # ── Pure helper function tests ──────────────────────────────────────────
-
-
-class TestSyntheticReturnsFromStub:
-    def test_default_length(self):
-        result = _synthetic_returns_from_stub(sharpe=1.0)
-        assert len(result) == 504
-
-    def test_custom_T(self):
-        result = _synthetic_returns_from_stub(sharpe=0.5, T=100)
-        assert len(result) == 100
-
-    def test_returns_list_of_floats(self):
-        result = _synthetic_returns_from_stub(sharpe=1.5, T=50)
-        assert isinstance(result, list)
-        assert all(isinstance(r, float) for r in result)
-
-    def test_deterministic_with_same_sharpe(self):
-        r1 = _synthetic_returns_from_stub(sharpe=1.2, T=100)
-        r2 = _synthetic_returns_from_stub(sharpe=1.2, T=100)
-        assert r1 == r2
-
-    def test_different_sharpe_different_output(self):
-        r1 = _synthetic_returns_from_stub(sharpe=0.5, T=100)
-        r2 = _synthetic_returns_from_stub(sharpe=1.5, T=100)
-        assert r1 != r2
 
 
 class TestLoadStrategyCode:


### PR DESCRIPTION
## Summary

`evaluate_rigor_gate()` in `selection_bias_routes.py` had a fallback that constructed Gaussian daily returns seeded from `stub_sharpe` for strategies with no real backtest data. Those synthetic returns were then passed through DSR, PBO, and OOS Sharpe.

This is a circular validation: the data was generated to match a target Sharpe, so DSR trivially passes at whatever confidence level the seed implies. The gate output is meaningless — it tells you nothing about the strategy's real statistical properties.

## What changed

- **Removed** the fallback loop (lines 112-120) that called `_synthetic_returns_from_stub()`.
- **Removed** `_synthetic_returns_from_stub()` itself — no callers remain.
- Added a comment explaining why: the existing MISSING branch at line 138 is the correct behaviour for strategies without real backtest data.

## Behaviour after this change

| Before | After |
|--------|-------|
| Strategy with `stub_sharpe=1.5` but no real backtest → gate synthesizes returns, DSR trivially passes → `passes_all=True` | Strategy with `stub_sharpe=1.5` but no real backtest → `passes_all=False`, all gate fields `"MISSING (no backtest data)"` |

## Test plan

- [ ] `pytest backend/tests/ -q -k "selection_bias or rigor"` — all pass
- [ ] Verify `/api/selection-bias/gate` returns `passes_all=false` for a strategy that has `stub_sharpe` set but no `BacktestResult` row in the DB

## Notes

`stub_sharpe`, `stub_cagr`, `stub_max_dd` are still on the `Strategy` model for UI display on the portfolio/strategy pages — this PR only removes their misuse in the rigor gate.