### PR TITLE
[rigor] Shrink Kelly fraction by OOS/IS Sharpe ratio when OOS data available

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -578,7 +578,11 @@ async def get_portfolio_advisor(
             mu_ann = s.real_cagr if s.real_cagr is not None else 0.08
             vol_ann = abs(mu_ann / sr) if sr != 0 else 0.20
             full_kelly = mu_ann / max(vol_ann**2, 1e-6)
-            base_kelly = min(0.5 * full_kelly, 0.5)
+            # Shrink full Kelly by the ratio OOS/IS Sharpe so the fraction
+            # reflects walk-forward edge rather than inflated in-sample edge.
+            # Falls back to half-Kelly when no OOS Sharpe is stored.
+            sr_oos = s.out_of_sample_sharpe if s.out_of_sample_sharpe is not None else sr
+            base_kelly = min(0.5 * (sr_oos / max(sr, 1e-6)) * full_kelly, 0.5)
 
             active = [sig for sig in strat_signals.signals if sig.signal != _Signal.FLAT and sig.weight > 0]
             active.sort(key=lambda x: x.weight, reverse=True)


### PR DESCRIPTION
## Summary

The Kelly fraction displayed on the portfolio / strategy pages was computed from full in-sample returns:

```python
base_kelly = min(0.5 * full_kelly, 0.5)
```

`full_kelly = mu_ann / vol_ann²` uses `real_cagr` and `real_sharpe`, both of which are full-period in-sample metrics. A strategy that looks good in-sample but degrades badly OOS shows the same Kelly as one whose OOS Sharpe matches its IS Sharpe — which misleads users about how much they should actually allocate.

## What changed (`strategies_routes.py:578-581`)

```python
# Before
base_kelly = min(0.5 * full_kelly, 0.5)

# After
sr_oos = s.out_of_sample_sharpe if s.out_of_sample_sharpe is not None else sr
base_kelly = min(0.5 * (sr_oos / max(sr, 1e-6)) * full_kelly, 0.5)
```

The `sr_oos / sr` ratio scales full Kelly down by however much OOS underperforms IS. If `out_of_sample_sharpe` is NULL (strategy not yet through the rigor gate), the ratio is 1.0 and the result is identical to the old half-Kelly — fully backwards-compatible.

### Numeric example

| IS Sharpe | OOS Sharpe | full_kelly | old base_kelly | new base_kelly |
|-----------|------------|-----------|----------------|----------------|
| 1.8       | 0.6        | 0.45      | 0.225          | **0.075**      |
| 1.0       | 1.0        | 0.25      | 0.125          | 0.125 (no change) |
| 1.2       | NULL       | 0.30      | 0.150          | 0.150 (no change) |

## Test plan

- [ ] `pytest backend/tests/ -q -k "strategies or kelly"` — all pass
- [ ] Manually: strategy with `out_of_sample_sharpe = 0.5` and `real_sharpe = 1.5` → `kelly_fraction` is ~1/3 of the old value
- [ ] Manually: strategy with `out_of_sample_sharpe = NULL` → `kelly_fraction` unchanged

## Field used

`Strategy.out_of_sample_sharpe` (model line 163) — written by `update_rigor_gate_fields()` after each rigor gate run.