### PR TITLE
[rigor] Warn on negative subscripts in look-ahead audit instead of silently passing

### DIFF
--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -593,7 +593,14 @@ def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
         if isinstance(node, ast.Subscript):
             slice_val = node.slice
             if isinstance(slice_val, ast.UnaryOp) and isinstance(slice_val.op, ast.USub):
-                pass
+                # Negative indices are safe in backtrader ([-N] = N bars ago) but
+                # would reference the last row of future data in a pandas DataFrame
+                # (df.iloc[-1], df["col"][-1]).  Flag so reviewers can verify the
+                # calling context before promotion to Tier-1.
+                warnings.append(
+                    f"Line {node.lineno}: negative index — verify this is backtrader "
+                    f"(bars-ago) not pandas (last-row) access."
+                )
             elif isinstance(slice_val, ast.Constant) and isinstance(slice_val.value, int) and slice_val.value > 0:
                 warnings.append(
                     f"Line {node.lineno}: positive data index [{slice_val.value}] may reference future bars"

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -357,6 +357,20 @@ def test_sharpe_ci_rejects_invalid_confidence():
 
 class TestLookAheadAudit:
     def test_clean_code(self) -> None:
+        # Only index [0] (current bar) — no negative indices, no positive indices.
+        code = """
+class MyStrategy(bt.Strategy):
+    def next(self):
+        if self.data.close[0] > 100:
+            self.buy()
+"""
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert len(warnings) == 0
+
+    def test_negative_index_emits_warning(self) -> None:
+        # Negative indices are safe in backtrader (bars-ago) but would be
+        # last-row future data in pandas.  The audit flags them for human review.
         code = """
 class MyStrategy(bt.Strategy):
     def next(self):
@@ -364,8 +378,8 @@ class MyStrategy(bt.Strategy):
             self.buy()
 """
         passed, warnings = look_ahead_audit(code)
-        assert passed
-        assert len(warnings) == 0
+        assert not passed
+        assert any("negative index" in w.lower() for w in warnings)
 
     def test_positive_index(self) -> None:
         code = """


### PR DESCRIPTION
## Summary

`look_ahead_audit()` in `rigor_evaluator.py` handled `ast.USub` (negative index) with a bare `pass` — meaning any of the following patterns in strategy code would be silently accepted:

```python
data[-1]           # last bar in backtrader → safe
df.iloc[-1]        # last row in pandas → future data!
df["close"][-1]    # same
```

In backtrader, `[-N]` correctly means "N bars ago" and carries no look-ahead. But the same syntax in pandas-based strategy code fetches the *last* row of the DataFrame, which is future data. The audit cannot statically distinguish the two cases.

## What changed (`rigor_evaluator.py:595`)

Replaced `pass` with a warning that surfaces in the audit result:

```
Line N: negative index — verify this is backtrader (bars-ago) not pandas (last-row) access.
```

This makes `look_ahead_clean = False` for any strategy code that uses negative indexing, which prevents silent Tier-1 admission. A human reviewer can confirm the backtrader context and override via `look_ahead_audit_passed=True` when calling `run_rigor_gate()` directly.

## Behaviour change

| Code | Before | After |
|------|--------|-------|
| `self.data.close[-1]` (backtrader) | `look_ahead_clean=True` (silent) | `look_ahead_clean=False` + warning emitted |
| `df.iloc[-1]` (pandas) | `look_ahead_clean=True` (silent) | `look_ahead_clean=False` + warning emitted |

## Impact on existing seed strategies

The seed strategies (`analytics-engine/strategies/`) are backtrader-based and use `[-N]` correctly. After this change they will fail the automated look-ahead audit. Two options to restore them:
1. Pass `look_ahead_audit_passed=True` in `run_rigor_gate()` for known-safe strategies after human review.
2. Add an explicit allowlist of confirmed-backtrader patterns in the audit.

This is intentional: the audit should be conservative. A false positive that requires a human check is preferable to a false negative that silently admits future-data leakage.

## Test plan

- [ ] `pytest backend/tests/ -q -k "look_ahead or rigor"` — existing tests pass
- [ ] New: strategy code containing `data[-1]` now produces a warning in `look_ahead_audit()` output