### PR TITLE
[backtest] Record tx_cost_bps as slippage_bps in backtest artifact

### DIFF
--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -471,7 +471,7 @@ def backtest_portfolio(
             "start": start_iso,
             "end": end_iso,
             "transaction_cost_bps": tx_cost_bps,
-            "slippage_bps": 0,
+            "slippage_bps": tx_cost_bps,
             "lookahead_guard": "static_rebalance_no_signal_shift",
             "walk_forward_split": 0.70,
             "data_source": "yfinance",


### PR DESCRIPTION
## Summary

`portfolio_backtester.py:476` was writing `"slippage_bps": 0` into the artifact's `assumptions` block unconditionally. The simulation itself already deducts `tx_cost_bps` (a proportional commission on every trade, intended to cover bid-ask spread and market impact). So the backtest was applying real costs but the artifact was claiming zero slippage — a discrepancy that breaks external verification and makes the strategy passport assumptions untrustworthy.

## Change

```python
# Before
"slippage_bps": 0,

# After
"slippage_bps": tx_cost_bps,
```

The `tx_cost_bps` variable is already in scope at that point (it's the same value passed to the backtest engine). The artifact now honestly reflects what was deducted.

## Why this matters

- The strategy passport's `assumptions` block is hashed and anchored on-chain via `ReasoningTraceRegistry`. Understating slippage in the artifact creates a verifiable discrepancy between what the hash commits to and what actually ran.
- `slippage_bps: 0` with `transaction_cost_bps: 10` is internally contradictory (both fields are in the same block); any external reader would correctly flag this as a data quality issue.

## Test plan

- [ ] `pytest backend/tests/ -q -k "backtester or portfolio"` — all pass
- [ ] Confirm artifact output has `"slippage_bps": 10` when `tx_cost_bps=10` is passed