### PR TITLE
[rigor] Document CPCV as not-yet-wired; honest gate description

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -81,8 +81,16 @@ class PBOResponse(BaseModel):
 async def evaluate_rigor_gate():
     """Evaluate the rigor gate for all strategies in the library.
 
-    Runs DSR, PBO, walk-forward OOS, and look-ahead audit for each
-    strategy. Returns pass/fail per strategy with detailed breakdown.
+    Runs three statistical primitives (DSR, PBO, walk-forward OOS Sharpe)
+    plus the look-ahead static audit for each strategy.
+
+    CPCV (Combinatorial Purged Cross-Validation) is implemented in
+    rigor_evaluator.run_rigor_gate() but requires a 2-D (S, T) matrix of
+    per-split OOS returns that comes from re-running the full backtest engine
+    across combinatorial window splits.  That rolling re-backtest pipeline is
+    not yet wired here, so run_rigor_gate() is called without cv_returns_matrix
+    and CPCV is honestly reported as MISSING on every strategy.  Wire it once
+    the analytics-engine supports combinatorial window output.
     """
     strategies = _provider.list_strategies()
 
@@ -162,6 +170,9 @@ async def evaluate_rigor_gate():
             if s.id in bt_map:
                 in_sample_sharpe = bt_map[s.id].sharpe_ratio
 
+        # cv_returns_matrix intentionally omitted — CPCV requires a 2-D array
+        # of per-combinatorial-split OOS returns that the analytics-engine does
+        # not yet produce.  run_rigor_gate() will report cpcv as MISSING.
         gate_result = run_rigor_gate(
             strategy_id=s.id,
             daily_returns=daily_returns,


### PR DESCRIPTION
## Summary

`run_rigor_gate()` in `rigor_evaluator.py` has full CPCV plumbing (`compute_cpcv_oos_sharpe`), but `cv_returns_matrix` is never passed at the call site in `evaluate_rigor_gate()`. The reason is that CPCV requires a 2-D `(S, T)` matrix of per-combinatorial-split OOS returns, which the analytics-engine does not yet produce (it would require running the full backtest engine across many overlapping windows).

As a result, CPCV silently shows as MISSING for every strategy in the internal `gate_details`, but the endpoint docstring claimed the gate "runs DSR, PBO, walk-forward OOS, and look-ahead audit" — making it sound like four checks were operating when three statistical primitives + look-ahead = four checks run and CPCV does not.

## Changes

- **`evaluate_rigor_gate()` docstring**: updated to say "three statistical primitives (DSR, PBO, OOS Sharpe) plus look-ahead audit" and explicitly notes CPCV is not wired yet.
- **`run_rigor_gate()` call site**: added a comment explaining why `cv_returns_matrix` is absent — not an oversight, but a known gap pending the analytics-engine combinatorial window pipeline.

## No logic changes

Behaviour is unchanged — CPCV was already MISSING before this commit. This is a documentation-in-code honesty fix.

## What wiring CPCV properly requires

1. The analytics-engine needs to support running a strategy backtest across `C(n_groups, test_groups)` combinatorial time-window splits and returning a 2-D returns matrix.
2. That matrix gets passed as `cv_returns_matrix` to `run_rigor_gate()`.
3. `compute_cpcv_oos_sharpe()` computes `cpcv_positive_fraction` and `cpcv_mean_oos_sharpe` from the matrix.
4. The result gets added to `RigorGateDetail` and surfaced in the API response.

Until then, the honest description is: three statistical primitives (DSR, PBO, OOS Sharpe) + look-ahead audit.