### PR TITLE
[infra] Fix disk-full deploy — remove --no-cache from docker compose build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,7 +104,7 @@ jobs:
               "grep -q '"'"'^PUBLIC_DOMAIN='"'"' .env || echo '"'"'PUBLIC_DOMAIN=https://archimedes-arc.app'"'"' >> .env",
               "sed -i '"'"'/^VITE_CIRCLE_CLIENT_KEY=/d'"'"' .env",
               "echo \"VITE_CIRCLE_CLIENT_KEY=${{ secrets.VITE_CIRCLE_CLIENT_KEY }}\" >> .env",
-              "docker compose build --no-cache",
+              "docker compose build",
               "docker ps -aq --filter '"'"'name=^[0-9a-f]\\{12\\}_archimedes-'"'"' | xargs -r docker rm -f 2>/dev/null || true",
               "docker compose up -d --force-recreate --remove-orphans",
               "docker image prune -f",

--- a/docs/audits/quant-audit-prompt.md
+++ b/docs/audits/quant-audit-prompt.md
@@ -1,0 +1,73 @@
+# Quant Audit Prompt
+<!-- Model: claude-opus-4-8 -->
+
+You are a senior quant researcher (Citadel/AQR frame) auditing whether Archimedes'
+statistical claims are actually backed by the code. Adversarial, not charitable.
+
+## Scope (priority order)
+
+### 1. Selection-bias stack
+`rigor_evaluator.py` · `fusion_evaluator.py` · `selection_bias_routes.py`
+
+- **DSR**: raw Pearson kurtosis (γ₄=3 normal, NOT Fisher); E[max_N] Euler-Mascheroni
+  constants correct; `sqrt(1-ρ̄)` applied to right term; √252 annualization consistent.
+- **PBO**: CSCV combinatorial splits generated correctly; median-OOS threshold defensible.
+- **CPCV**: 1-D input → None (never a number)? `cv_returns_matrix` flows to function?
+- **`compute_average_pairwise_correlation`**: constant rows dropped; NaN/negative clamped
+  to 0.0 (conservative); < 2 series → 0.0.
+- **`run_rigor_gate`**: `average_correlation` + `cv_returns_matrix` reach DSR/CPCV;
+  defaults are conservative, not optimistic.
+
+### 2. Lookahead bias
+`rigor_evaluator.py` (look_ahead_audit) · `analytics-engine/strategies/*.py` ·
+`portfolio_backtester.py`
+
+- `look_ahead_audit` catches `shift(-1)` on signal columns; does `.iloc[-1]`/`.tail(1)`
+  still pass?
+- Signal generated bar T → fill bar T+1 open? Any intrabar fill path?
+- `pd.merge`/`pd.concat` index alignment: future data into past rows possible?
+
+### 3. Market impact & costs
+`portfolio_backtester.py`
+
+- Almgren-Chriss γ: sourced from paper (cite eq.); applied to executions only.
+- Bid-ask spread modeled? If not, acknowledged in passport?
+- Position size cap preventing self-impact?
+
+### 4. Kelly criterion
+`rigor_evaluator.py` (compute_kelly_fraction) + callers
+
+- Full Kelly computed first, then halved?
+- Clamped to [0,1]; negative edge → negative Kelly possible?
+- Edge (μ) from in-sample or OOS returns? (in-sample Kelly on signal data = overfitting)
+
+### 5. Numerical precision
+Across all of the above:
+
+- Division guarded by zero-check (not epsilon fudge)?
+- `np.sqrt` of potentially negative argument?
+- Float `==` instead of `np.isclose`?
+- Silent NaN propagation (NaN in → valid-looking float out)?
+
+## Output format
+
+One block per finding:
+
+```
+[SEVERITY]   CRITICAL | HIGH | MEDIUM | LOW | INFO
+File:        path:line
+Claim vs reality: one sentence
+Exploit:     how this inflates backtest SR (or "correctness only, no alpha impact")
+Fix:         exact change (diff snippet or pseudocode)
+```
+
+End with a **Verdict** paragraph: is the rigor gate defensible as a Tier-1 admission
+barrier, or does it have holes a strategy could slip through?
+
+## Rules
+
+- Read every function fully before filing — no speculation from names alone.
+- Cite paper + equation number for formula findings.
+- Flag conservative-over-spec code as INFO (not just problems).
+- No style, naming, or import findings.
+- Verify recent fixes via `git log`; mark RESOLVED with commit SHA if already fixed.

--- a/docs/audits/rigor-gate-fixes.md
+++ b/docs/audits/rigor-gate-fixes.md
@@ -1,0 +1,100 @@
+# Rigor Gate — Required Fixes
+
+## HIGH: DSR threshold inconsistency (fusion vs curated path)
+
+`backend/archimedes/services/fusion_evaluator.py:423`
+
+Fusion path uses `dsr > 0.0` (p ≈ 0.5); curated path uses `dsr_p_value >= 0.95`.
+A generated strategy with z=0.5 (p=0.69) is admitted Tier-1 by fusion but fails the API gate.
+
+```python
+# fusion_evaluator.py apply_rigor_gate()
+- dsr_pass = dsr is not None and dsr > 0.0
++ dsr_pass = dsr_p_value is not None and dsr_p_value >= 0.95
+```
+
+Also update `passing` to use `dsr_p_value` directly:
+```python
+- passing = metrics.sharpe_ratio > 0.0 and dsr_pass and look_ahead_clean and (pbo_score is None or pbo_score < 0.5)
++ passing = dsr_pass and look_ahead_clean and (pbo_score is None or pbo_score < 0.5)
+```
+
+---
+
+## MEDIUM: Synthetic-returns fallback creates circular DSR validation
+
+`backend/archimedes/api/selection_bias_routes.py:114-121`
+
+When no real backtest data exists, synthetic returns are seeded from `stub_sharpe` then
+passed through DSR. Gate trivially passes because the data was constructed to hit that Sharpe.
+
+```python
+# selection_bias_routes.py evaluate_rigor_gate()
+- for s in strategies:
+-     if (s.id not in returns_by_strategy or len(returns_by_strategy[s.id]) < 10) and s.stub_sharpe is not None:
+-         returns_by_strategy[s.id] = _synthetic_returns_from_stub(sharpe=s.stub_sharpe, ...)
+```
+
+Strategies with no real backtest data should report all gate fields as MISSING, not synthesize a passing series.
+
+---
+
+## MEDIUM: Kelly fraction uses full in-sample returns
+
+`backend/archimedes/api/strategies_routes.py:578-581`
+
+`real_sharpe` and `real_cagr` are full-period IS metrics. Kelly fraction shown to users is inflated vs OOS edge.
+
+```python
+# strategies_routes.py
+- mu_ann = s.real_cagr if s.real_cagr is not None else 0.08
+- vol_ann = abs(mu_ann / sr) if sr != 0 else 0.20
++ sr_oos = s.real_oos_sharpe if s.real_oos_sharpe is not None else sr
++ vol_ann = abs(mu_ann / sr) if sr != 0 else 0.20   # vol unchanged
++ full_kelly = mu_ann / max(vol_ann**2, 1e-6)        # keep; shrink via sr_oos
++ base_kelly = min(0.5 * (sr_oos / max(sr, 1e-6)) * full_kelly, 0.5)
+```
+
+---
+
+## MEDIUM: Look-ahead audit passes pandas `.iloc[-1]` / `.tail(1)`
+
+`backend/archimedes/services/rigor_evaluator.py:593-595`
+
+The `USub` branch hits bare `pass` — all negative subscripts are silently allowed.
+Safe for backtrader (where `[-N]` = N bars ago), but would not catch `df.iloc[-1]` in
+pandas-based strategy code.
+
+```python
+# look_ahead_audit(), ast.Subscript handling
+  if isinstance(slice_val, ast.UnaryOp) and isinstance(slice_val.op, ast.USub):
+-     pass
++     # Safe in backtrader; potentially future data in pandas context.
++     warnings.append(
++         f"Line {node.lineno}: negative index — verify this is backtrader "
++         f"(bars-ago) not pandas (last-row) access."
++     )
+```
+
+---
+
+## LOW: Artifact records `slippage_bps: 0` while 10 bps tx cost covers that role
+
+`backend/archimedes/services/portfolio_backtester.py:476`
+
+```python
+- "slippage_bps": 0,
++ "slippage_bps": tx_cost_bps,   # proportional cost covers spread + commissions
+```
+
+---
+
+## LOW: CPCV always MISSING — never passed to run_rigor_gate
+
+`backend/archimedes/api/selection_bias_routes.py:165-174`
+
+`cv_returns_matrix` is never constructed and never passed to `run_rigor_gate`.
+CPCV shows as MISSING on every strategy in the UI. Either wire it or remove the claim.
+
+Short-term: update pitch/UI copy to say "three statistical primitives" (DSR + PBO + OOS Sharpe)
+until CPCV is wired from real rolling-window re-backtests.


### PR DESCRIPTION
## Problem
Deploy failed with \`no space left on device\` mid-build. The EC2 disk was at 69% (5.8G free) before the build started. \`docker compose build --no-cache\` forces a full re-download of all Python deps for all 5 services simultaneously — scipy, psycopg2, etc. exhaust the remaining space.

The prune step before the build reclaimed \`0B\`, meaning there was nothing stale to clean. The cache wasn't the problem; \`--no-cache\` was.

## Fix
Remove \`--no-cache\`. Docker layer caching means only layers downstream of actual changes rebuild — if only Python code changed, deps layers are reused from cache.

## Verification
Next deploy triggered by merge should complete without disk errors.