### PR TITLE
[rigor] Fix transposed DSR tuple in StockBench adapter

### DIFF
--- a/backend/archimedes/evaluation/stockbench/adapter.py
+++ b/backend/archimedes/evaluation/stockbench/adapter.py
@@ -554,9 +554,12 @@ class ArchimedesStockBenchAdapter:
             # Step 4
             self.execute_decision(decision, prices, day)
 
-        # compute_dsr: Deflated Sharpe Ratio over the full episode (Bailey & Lopez de Prado 2014)
+        # compute_dsr: Deflated Sharpe Ratio over the full episode (Bailey & Lopez de Prado 2014).
+        # It returns (deflated_sharpe, p_value) in that order — unpack accordingly.
+        # The previous `dsr_p, dsr_sr = ...` transposed them, so dsr_p_value carried
+        # the Sharpe and dsr_sharpe_estimate carried the p-value.
         daily_rets = self.portfolio.daily_returns
-        dsr_p, dsr_sr = compute_dsr(daily_returns=daily_rets, num_trials=1) if len(daily_rets) >= 5 else (None, None)
+        dsr_sr, dsr_p = compute_dsr(daily_returns=daily_rets, num_trials=1) if len(daily_rets) >= 5 else (None, None)
 
         return BenchmarkResult(
             seed=self.seed,

--- a/backend/tests/services/test_stockbench_adapter.py
+++ b/backend/tests/services/test_stockbench_adapter.py
@@ -210,6 +210,23 @@ class TestAdapterSingleRun:
         assert "sortino_ratio" in d
         assert d["trading_days"] == 5
 
+    def test_dsr_fields_are_not_transposed(self):
+        """dsr_p_value must be a probability; dsr_sharpe_estimate the Sharpe.
+
+        Regression for the audit finding that the adapter unpacked
+        compute_dsr() as `dsr_p, dsr_sr = ...`, transposing the (deflated_sharpe,
+        p_value) tuple. A p-value lives in [0, 1]; an annualized Sharpe routinely
+        falls outside it — so the swap is detectable by range.
+        """
+        adapter = ArchimedesStockBenchAdapter(seed=0)
+        result = adapter.run(n_days=30)  # ≥5 daily returns → DSR computed
+        assert result.dsr_p_value is not None
+        assert result.dsr_sharpe_estimate is not None
+        assert 0.0 <= result.dsr_p_value <= 1.0, (
+            f"dsr_p_value={result.dsr_p_value} is not a probability — tuple likely transposed"
+        )
+        assert isinstance(result.dsr_sharpe_estimate, float)
+
 
 # ── Multi-seed aggregation ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes **High finding #6** from `AUDIT_2026-06-10.md`.

`compute_dsr` returns `(deflated_sharpe, p_value)` ([rigor_evaluator.py](backend/archimedes/services/rigor_evaluator.py)), but `adapter.py:559` unpacked it as `dsr_p, dsr_sr = compute_dsr(...)`. The result: `BenchmarkResult.dsr_p_value` held the **annualized Sharpe** and `dsr_sharpe_estimate` held the **p-value** — every StockBench DSR figure was transposed.

## Changes

- Unpack as `dsr_sr, dsr_p = compute_dsr(...)`.
- Regression test (`test_dsr_fields_are_not_transposed`) asserts `dsr_p_value ∈ [0, 1]`. A p-value is a probability; an annualized Sharpe routinely exceeds 1 or goes negative, so the transposition is detectable purely by range.

## Note on published benchmarks

The audit suggested regenerating published benchmarks. Verified unnecessary: [`docs/benchmarks/stockbench-results.md`](docs/benchmarks/stockbench-results.md) reports **no concrete DSR/p-value numbers** (only that the rigor gate is "active"). The transposed values lived solely in the `BenchmarkResult` dict / `to_dict()` output, not in any committed figure.

## Verify

```bash
grep -n "dsr_sr, dsr_p = compute_dsr" backend/archimedes/evaluation/stockbench/adapter.py
PYTHONPATH=backend pytest backend/tests/services/test_stockbench_adapter.py -q   # 36 passed
```

Lane: quant rigor (Önder).