### PR TITLE
[rigor] Enforce OOS Sharpe + use real trial count in fusion rigor gate

### DIFF
--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -395,10 +395,18 @@ def apply_rigor_gate(
                 (curve[i] - curve[i - 1]) / curve[i - 1] for i in range(1, len(curve)) if curve[i - 1] > 0
             ]
 
+    # num_trials = actual size of the multiple-testing selection set. A fixed
+    # default (10) under-deflates a large variant grid (e.g. a 50-variant sweep
+    # gets only a 10-trial penalty) and over-deflates a small one. When the
+    # variant matrix is known, use its real cardinality as the trial count.
+    effective_trials = num_trials
+    if variants_metrics is not None and len(variants_metrics) >= 2:
+        effective_trials = len(variants_metrics)
+
     # Correlated variants carry fewer independent trials than their nominal
     # count, so the multiple-testing penalty in the DSR is relaxed accordingly.
     avg_correlation = compute_average_pairwise_correlation(variant_returns) if len(variant_returns) >= 2 else 0.0
-    dsr, dsr_p = compute_dsr(daily_returns, num_trials, avg_correlation)
+    dsr, dsr_p = compute_dsr(daily_returns, effective_trials, avg_correlation)
     oos_sharpe = compute_oos_sharpe(daily_returns)
 
     # PBO: compute real CSCV PBO when >= 2 variant backtests are available.
@@ -422,7 +430,14 @@ def apply_rigor_gate(
     # through the fusion path.
     dsr_pass = dsr_p is not None and dsr_p >= 0.95
 
-    passing = dsr_pass and look_ahead_clean and (pbo_score is None or pbo_score < 0.5)
+    # Walk-forward OOS Sharpe is the fourth admission primitive (DSL look-ahead
+    # safety, DSR, PBO, walk-forward OOS). It was computed above but never
+    # enforced — the gate silently dropped it. Mirror the curated path's
+    # absolute floor (run_rigor_gate / RigorGateResult.passes_all): a strategy
+    # with a non-positive out-of-sample Sharpe cannot pass.
+    oos_pass = oos_sharpe is not None and oos_sharpe > 0.0
+
+    passing = dsr_pass and oos_pass and look_ahead_clean and (pbo_score is None or pbo_score < 0.5)
 
     # Provenance gate: a strategy is only admissible for Tier-1 if it passes
     # the statistics AND those statistics were computed on real market data.
@@ -443,7 +458,7 @@ def apply_rigor_gate(
         pbo_score=pbo_score,
         oos_sharpe=oos_sharpe,
         look_ahead_clean=look_ahead_clean,
-        num_trials=num_trials,
+        num_trials=effective_trials,
         data_source=source,
         admissible=admissible,
     )

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -390,3 +390,75 @@ class TestDataProvenanceGate:
         verdict = apply_rigor_gate(metrics)
         assert verdict.passing is False
         assert verdict.admissible is False
+
+
+def _metrics_from_curve(curve: list[float], data_source: str = "csv:test.csv") -> BacktestMetrics:
+    return BacktestMetrics(
+        sharpe_ratio=1.0,
+        sortino_ratio=1.0,
+        max_drawdown=0.2,
+        cagr=0.1,
+        calmar_ratio=0.5,
+        win_rate=0.55,
+        total_trades=50,
+        avg_holding_period_days=10.0,
+        equity_curve=curve,
+        monthly_returns=[],
+        backtest_start=None,
+        backtest_end=None,
+        data_source=data_source,
+    )
+
+
+class TestFusionGateEnforcesOosSharpe:
+    """Regression for the audit finding that the fusion gate computed the OOS
+    Sharpe but never enforced it in the `passing` condition."""
+
+    def test_negative_oos_fails_even_when_dsr_passes(self):
+        # In-sample (first half): strong, low-vol uptrend → very high full-sample
+        # DSR (p ≈ 1). Out-of-sample (second half): noisy but net-negative drift
+        # → OOS Sharpe < 0. Pre-fix this passed on DSR alone; it must now fail.
+        curve = [100_000.0]
+        for _ in range(400):
+            curve.append(curve[-1] * 1.005)  # IS: steady +0.5%/bar
+        for i in range(400):
+            curve.append(curve[-1] * (0.9990 if i % 2 == 0 else 0.9996))  # OOS: net down
+
+        verdict = apply_rigor_gate(_metrics_from_curve(curve))
+        assert verdict.dsr_p_value is not None and verdict.dsr_p_value >= 0.95, (
+            "test setup invalid: IS drift should make DSR pass"
+        )
+        assert verdict.oos_sharpe is not None and verdict.oos_sharpe <= 0.0
+        assert verdict.passing is False  # OOS gate is the deciding factor
+
+    def test_positive_oos_can_pass(self):
+        # Steady uptrend across the whole window → OOS Sharpe > 0 and DSR passes.
+        curve = [100_000.0]
+        for i in range(800):
+            curve.append(curve[-1] * (1.003 if i % 2 == 0 else 1.001))
+        verdict = apply_rigor_gate(_metrics_from_curve(curve))
+        assert verdict.oos_sharpe is not None and verdict.oos_sharpe > 0.0
+        assert verdict.passing is True
+
+
+class TestFusionGateUsesRealTrialCount:
+    """Regression for the audit finding that num_trials was hardcoded to 10
+    regardless of the actual variant-selection set size."""
+
+    def test_num_trials_tracks_variant_count(self):
+        base = [100_000.0]
+        for i in range(800):
+            base.append(base[-1] * (1.003 if i % 2 == 0 else 1.001))
+        base_metrics = _metrics_from_curve(base)
+
+        # 30 correlated variants → trial count must reflect 30, not the default 10.
+        variants = {f"v{i}": _metrics_from_curve(base) for i in range(30)}
+        verdict = apply_rigor_gate(base_metrics, num_trials=10, variants_metrics=variants)
+        assert verdict.num_trials == 30
+
+    def test_falls_back_to_passed_count_without_variants(self):
+        base = [100_000.0]
+        for i in range(800):
+            base.append(base[-1] * (1.003 if i % 2 == 0 else 1.001))
+        verdict = apply_rigor_gate(_metrics_from_curve(base), num_trials=7)
+        assert verdict.num_trials == 7


### PR DESCRIPTION
## Summary

Fixes **High finding #5** and **Medium finding #15** from `AUDIT_2026-06-10.md`. Both are corrections to the same function, `fusion_evaluator.apply_rigor_gate`, on adjacent lines — they form one logical unit (making the fusion gate enforce the four-primitive admission spec), so they ship together rather than as two PRs that would conflict on the same function.

### #5 — OOS Sharpe was computed but never enforced
`oos_sharpe` was computed and stored on the verdict, but the `passing` condition was:
```python
passing = dsr_pass and look_ahead_clean and (pbo_score is None or pbo_score < 0.5)
```
Only three of the four advertised primitives gated admission. A strategy with a non-positive out-of-sample Sharpe could be certified Tier-1 through the fusion path. Added an absolute OOS floor (`oos_sharpe > 0`), mirroring the curated path's [`RigorGateResult.passes_all`](backend/archimedes/services/rigor_evaluator.py).

### #15 — num_trials hardcoded to 10
The DSR was deflated with `num_trials=10` regardless of the real variant-grid size — a 50-variant sweep got only a 10-trial penalty (5× undercount); a tiny grid was over-penalized. Now `effective_trials = len(variants_metrics)` when the variant matrix is known (≥2), falling back to the passed count otherwise, and the verdict reports it.

## Verify

```bash
PYTHONPATH=backend pytest backend/tests/services/test_fusion_evaluator.py -q   # 21 passed
```

New tests: `TestFusionGateEnforcesOosSharpe` (negative OOS fails even when DSR passes; positive OOS passes), `TestFusionGateUsesRealTrialCount` (num_trials tracks variant count and falls back correctly).

## Anti-goals

- No change to the DSR / PBO / correlation math.
- No change to the curated `run_rigor_gate` path.

Lane: quant rigor (Önder).