### PR TITLE
[rigor] Fix OOS/IS cliff check using full-sample denominator

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -156,16 +156,15 @@ async def evaluate_rigor_gate():
             )
             continue
 
-        # Use real in-sample Sharpe from persisted data when available
-        in_sample_sharpe = s.stub_sharpe
-        with get_session() as session:
-            from archimedes.services.backtest_repository import (
-                latest_backtests_by_strategy,
-            )
-
-            bt_map = latest_backtests_by_strategy(session, [s.id])
-            if s.id in bt_map:
-                in_sample_sharpe = bt_map[s.id].sharpe_ratio
+        # in_sample_sharpe is left None on purpose: run_rigor_gate derives it
+        # from the first 70% of `daily_returns`, the same series whose last 30%
+        # produces oos_sharpe. Passing the *full-sample* backtest Sharpe here
+        # (the previous `bt_map[s.id].sharpe_ratio`) made the OOS/IS cliff check
+        # trivially passable — a bad OOS tail drags the full-sample denominator
+        # down, inflating the ratio (see rigor_evaluator.run_rigor_gate's own
+        # warning at the IS-slice fallback). Let the gate compute the honest
+        # first-70% in-sample denominator instead of overriding it.
+        in_sample_sharpe = None
 
         # cv_returns_matrix intentionally omitted — CPCV requires a 2-D array
         # of per-combinatorial-split OOS returns that the analytics-engine does

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -456,3 +456,63 @@ async def test_gate_endpoint_empty_provider_404_for_strategy(monkeypatch):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/api/selection-bias/gate/any-id-at-all")
     assert resp.status_code == 404
+
+
+# ── OOS/IS cliff denominator (audit finding #7) ─────────────────────────
+
+
+class TestOosCliffDenominator:
+    """The /gate route must pass in_sample_sharpe=None so run_rigor_gate derives
+    the IS denominator from the first 70% of the series — NOT the full-sample
+    backtest Sharpe (the previous `bt_map[s.id].sharpe_ratio` override), which
+    blends IS+OOS and makes the OOS/IS cliff trivially passable.
+
+    These deterministic series (no RNG → version-independent) demonstrate the
+    denominator choice flipping the verdict on a strong-IS / weak-positive-OOS
+    strategy: the honest first-70% denominator fails the cliff; the inflated
+    full-sample denominator passes it.
+    """
+
+    @staticmethod
+    def _strong_is_weak_oos() -> list[float]:
+        # IS (first 700 bars): drift 0.003 ± 0.01 → high Sharpe.
+        # OOS (last 300 bars): drift 0.0015 ± 0.01 → ~half the IS edge.
+        amp = 0.01
+        is_part = [0.003 + (amp if i % 2 == 0 else -amp) for i in range(700)]
+        oos_part = [0.0015 + (amp if i % 2 == 0 else -amp) for i in range(300)]
+        return is_part + oos_part
+
+    def test_first70_denominator_fails_cliff(self):
+        from archimedes.services.rigor_evaluator import run_rigor_gate
+
+        series = self._strong_is_weak_oos()
+        gate = run_rigor_gate(
+            "s",
+            series,
+            num_trials=1,
+            pbo_scores=None,
+            strategy_code=None,
+            in_sample_sharpe=None,
+            average_correlation=0.0,
+        )
+        assert "FAIL" in gate.gate_details["oos_sharpe"]
+
+    def test_fullsample_denominator_would_inflate_and_pass(self):
+        import math
+
+        from archimedes.services.rigor_evaluator import run_rigor_gate
+
+        series = self._strong_is_weak_oos()
+        arr = np.asarray(series, dtype=float)
+        full_sample_sharpe = (arr.mean() / arr.std(ddof=1)) * math.sqrt(252)
+        gate = run_rigor_gate(
+            "s",
+            series,
+            num_trials=1,
+            pbo_scores=None,
+            strategy_code=None,
+            in_sample_sharpe=full_sample_sharpe,
+            average_correlation=0.0,
+        )
+        # Same series, only the denominator differs → the bug let it pass.
+        assert "PASS" in gate.gate_details["oos_sharpe"]


### PR DESCRIPTION
## Summary

Fixes **High finding #7** from `AUDIT_2026-06-10.md`.

[`selection_bias_routes.py`](backend/archimedes/api/selection_bias_routes.py) overrode `in_sample_sharpe` with `bt_map[s.id].sharpe_ratio` — the **full-sample** backtest Sharpe — and passed it to `run_rigor_gate`. The walk-forward cliff check then divided the out-of-sample Sharpe by a full-sample denominator. Because the full-sample Sharpe blends IS+OOS, a weak OOS tail drags the denominator down and *inflates* the OOS/IS ratio, making the cliff trivially passable. `run_rigor_gate`'s own IS-slice comment warns against exactly this.

## Fix

Pass `in_sample_sharpe=None` so `run_rigor_gate` computes the honest in-sample denominator on the **first 70%** of the same `daily_returns` whose last 30% produces `oos_sharpe` (the correct fallback at [rigor_evaluator.py:786](backend/archimedes/services/rigor_evaluator.py#L786)). Also drops the now-unused `latest_backtests_by_strategy` lookup at that call site.

## Verify

```bash
PYTHONPATH=backend pytest backend/tests/test_selection_bias_routes.py -q   # 36 passed
```

`TestOosCliffDenominator` uses a deterministic (RNG-free, version-independent) strong-IS / weak-positive-OOS series: it **fails** the cliff under the honest first-70% denominator but **passes** under the inflated full-sample denominator — proving the override flipped the verdict.

## Anti-goals

- No change to the cliff threshold (0.5) or the OOS computation itself.

Lane: quant rigor (Önder).