### PR TITLE
[rigor] Replace undocumented sqrt(1-rho) DSR relief with effective-N

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -132,7 +132,7 @@ async def evaluate_rigor_gate():
 
     # The strategy library is the multiple-testing selection set; correlated
     # strategies (overlapping assets/signals) carry fewer independent trials, so
-    # the DSR effective-N correction relaxes the penalty by sqrt(1 - rho_bar).
+    # the DSR effective-N correction relaxes the penalty via N_eff = N/(1+(N-1)ρ̄).
     avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
 
     # Run rigor gate for each strategy

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -134,14 +134,31 @@ def _dsr_from_stats(
     if N == 1:
         E_max_N = 0.0
     else:
-        phi_inv_1 = float(norm.ppf(1.0 - 1.0 / N))
-        phi_inv_2 = float(norm.ppf(1.0 - 1.0 / (N * math.e)))
-        E_max_N = (1.0 - _EULER_MASCHERONI) * phi_inv_1 + _EULER_MASCHERONI * phi_inv_2
+        # Correlated trials are not independent tests: a parameter sweep whose
+        # variants move together carries fewer effective trials than its nominal
+        # count. Convert N to an effective count under an equicorrelation model
+        # with average pairwise correlation ρ:
+        #     N_eff = N / (1 + (N − 1)·ρ)
+        # the standard "effective number of independent tests" (Cheverud 2001;
+        # Nyholt 2004 — the equicorrelated effective sample size). ρ=0 → N_eff=N
+        # (full multiple-testing penalty); ρ=1 → N_eff=1 (all variants collapse
+        # to a single test, so there is no selection bias to deflate). This
+        # replaces a previous ad-hoc E[max]·sqrt(1 − ρ) factor that had no
+        # published source and let deflation vanish without a principled basis.
+        rho = max(0.0, min(1.0, average_correlation))
+        n_eff = N / (1.0 + (N - 1) * rho) if rho > 0.0 else float(N)
 
-        # Apply Bailey-López de Prado correlation adjustment:
-        # E[max] of correlated variables scales by sqrt(1 - rho)
-        if average_correlation > 0.0:
-            E_max_N *= math.sqrt(max(0.0, 1.0 - average_correlation))
+        # The Bailey-LdP two-quantile E[max] approximation is only well-behaved
+        # for ≥ 2 trials (norm.ppf(1 − 1/N) → −∞ as N → 1). Evaluate it at
+        # max(2, N_eff) and linearly taper the result to 0 across the effective
+        # range [1, 2], so a fully correlated grid (N_eff → 1) carries no penalty
+        # without the ppf blow-up a literal non-integer N_eff < 2 would cause.
+        n_for_emax = max(2.0, n_eff)
+        phi_inv_1 = float(norm.ppf(1.0 - 1.0 / n_for_emax))
+        phi_inv_2 = float(norm.ppf(1.0 - 1.0 / (n_for_emax * math.e)))
+        e_max_full = (1.0 - _EULER_MASCHERONI) * phi_inv_1 + _EULER_MASCHERONI * phi_inv_2
+        taper = min(1.0, max(0.0, n_eff - 1.0))
+        E_max_N = e_max_full * taper
 
     # SR_zero: expected best-of-N under the null, scaled to per-bar variance
     # (under iid normal returns, per-bar SR has variance 1/(T-1))

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -309,9 +309,10 @@ def compute_average_pairwise_correlation(
 ) -> float:
     """Average off-diagonal Pearson correlation across a set of return series.
 
-    Feeds the Deflated Sharpe Ratio's effective-number-of-trials correction
-    (Bailey & López de Prado 2014): the expected best-of-N null Sharpe shrinks
-    by ``sqrt(1 - rho_bar)`` when the N trials are correlated, because correlated
+    Feeds the Deflated Sharpe Ratio's effective-number-of-trials correction:
+    the expected best-of-N null Sharpe is computed at the effective trial count
+    ``N_eff = N / (1 + (N-1)*rho_bar)`` (the equicorrelated effective number of
+    independent tests) when the N trials are correlated, because correlated
     trials carry fewer *independent* bets than their nominal count. The caller
     that holds the selection set (the strategy library, or a parameter-variant
     grid) computes this and passes it into ``compute_dsr`` / ``run_rigor_gate``.

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -974,6 +974,37 @@ class TestDsrCorrelationRelaxesPenalty:
             rets, num_trials=1, average_correlation=0.0
         )
 
+    def test_full_correlation_collapses_to_single_effective_trial(self):
+        # ρ=1 under the effective-N model means N_eff = 1: all trials are the
+        # same test, so there is no selection bias to deflate. The DSR must
+        # equal the N=1 (no-penalty) result — not vanish via an undocumented
+        # sqrt(1−ρ) factor.
+        rng = np.random.default_rng(9)
+        rets = list(rng.normal(0.0012, 0.01, 600))
+        fully_correlated = compute_dsr(rets, num_trials=25, average_correlation=1.0)
+        no_penalty = compute_dsr(rets, num_trials=1, average_correlation=0.0)
+        assert fully_correlated == no_penalty
+
+    def test_intermediate_correlation_lies_between_endpoints(self):
+        # Effective-N is monotonic in ρ: a partially-correlated grid deflates
+        # less than an independent one (ρ=0) and more than a degenerate one (ρ=1).
+        rng = np.random.default_rng(10)
+        rets = list(rng.normal(0.0012, 0.01, 600))
+        dsr_indep = compute_dsr(rets, num_trials=25, average_correlation=0.0)[0]
+        dsr_mid = compute_dsr(rets, num_trials=25, average_correlation=0.5)[0]
+        dsr_full = compute_dsr(rets, num_trials=25, average_correlation=1.0)[0]
+        assert dsr_indep < dsr_mid < dsr_full
+
+    def test_uncorrelated_path_unchanged_from_nominal_n(self):
+        # ρ=0 must deflate by the full nominal N (the change only touches the
+        # correlated relief, leaving independent-trial deflation untouched).
+        rng = np.random.default_rng(12)
+        rets = list(rng.normal(0.001, 0.01, 500))
+        dsr_n10 = compute_dsr(rets, num_trials=10, average_correlation=0.0)[0]
+        dsr_n50 = compute_dsr(rets, num_trials=50, average_correlation=0.0)[0]
+        # More independent trials → larger best-of-N null → lower deflated Sharpe.
+        assert dsr_n50 < dsr_n10
+
 
 # ─── CPCV wiring into run_rigor_gate ─────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes **Medium finding #16** from `AUDIT_2026-06-10.md`.

The DSR's expected best-of-N term applied `E_max_N *= sqrt(1 - average_correlation)`, commented as a "Bailey-López de Prado correlation adjustment" — but that factor is **not** in Bailey-LdP (2014) and not in the spec, and at ρ→1 it drove deflation to zero with no principled basis.

## Fix

Replace it with the standard **effective number of independent tests** under an equicorrelation model:

```
N_eff = N / (1 + (N − 1)·ρ)      (Cheverud 2001 / Nyholt 2004)
```

- ρ=0 → `N_eff = N` (full multiple-testing penalty)
- ρ=1 → `N_eff = 1` (perfectly correlated variants are one test → genuinely no selection bias to deflate)

The Bailey-LdP two-quantile `E[max]` approximation is only well-behaved for ≥2 trials (`norm.ppf(1 − 1/N) → −∞` as N→1), so it is evaluated at `max(2, N_eff)` and linearly tapered to 0 across the effective range `[1, 2]`.

**The ρ=0 path is byte-identical to the previous formula** — independent-trial deflation is unchanged; only the correlated relief is corrected.

## Verify

```bash
PYTHONPATH=backend pytest backend/tests/test_rigor_evaluator.py -q   # 113 passed
```

New tests: ρ=1 collapses to the N=1 no-penalty result; intermediate ρ lies strictly between the ρ=0/ρ=1 endpoints; uncorrelated deflation still scales with nominal N. Existing `TestDsrCorrelationRelaxesPenalty` still passes.

## Notes for review

- This is a substantive quant-math change — flagging for **Dan's** eyes (strategy/rigor coverage). The effective-N formula choice (equicorrelated N_eff + `[1,2]` taper) is the reviewable decision.
- Also updates a stale `sqrt(1 - rho_bar)` **comment** in `selection_bias_routes.py` (lines far from those changed in #501, so no conflict).

Lane: quant rigor (Önder).