### PR TITLE
[contracts] Enforce ERC-4626 share allowance on withdraw/redeem (CRITICAL)

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -200,6 +200,14 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             _liquidateToUsdc(assets - usdcOnHand);
         }
 
+        // ERC-4626 allowance enforcement (audit 2026-06-13 CRITICAL): a caller may only
+        // burn `owner_`'s shares when it IS the owner, or when the owner has granted it a
+        // share allowance. Without this, anyone could pass a victim as `owner_` and a
+        // chosen `receiver` to drain the victim's deposit. `_spendAllowance` is a no-op
+        // for an infinite (type(uint256).max) allowance, matching the canonical pattern.
+        if (msg.sender != owner_) {
+            _spendAllowance(owner_, msg.sender, shares);
+        }
         _burn(owner_, shares);
 
         IERC20(asset).safeTransfer(receiver, assets);
@@ -229,6 +237,14 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             _liquidateToUsdc(assets - usdcOnHand);
         }
 
+        // ERC-4626 allowance enforcement (audit 2026-06-13 CRITICAL): a caller may only
+        // burn `owner_`'s shares when it IS the owner, or when the owner has granted it a
+        // share allowance. Without this, anyone could pass a victim as `owner_` and a
+        // chosen `receiver` to drain the victim's deposit. `_spendAllowance` is a no-op
+        // for an infinite (type(uint256).max) allowance, matching the canonical pattern.
+        if (msg.sender != owner_) {
+            _spendAllowance(owner_, msg.sender, shares);
+        }
         _burn(owner_, shares);
 
         IERC20(asset).safeTransfer(receiver, assets);

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -233,6 +233,65 @@ contract VaultTest is Test {
         vault.withdraw(0, alice, alice);
     }
 
+    // ─── Allowance Enforcement (audit 2026-06-13 CRITICAL: share theft) ──
+
+    /// @dev An attacker must NOT be able to burn a victim's shares by passing the
+    ///      victim as `owner_` and itself as `receiver`. Without the allowance check
+    ///      this drains the victim's deposit; with it, the call reverts.
+    function test_revert_redeem_steal_without_allowance() public {
+        uint256 amount = 10_000 * 10**6;
+
+        vm.startPrank(alice);
+        usdc.approve(address(vault), amount);
+        uint256 shares = vault.deposit(amount, alice);
+        vm.stopPrank();
+
+        // Bob (attacker) tries to redeem Alice's shares into his own wallet.
+        vm.prank(bob);
+        vm.expectRevert(); // ERC20InsufficientAllowance — Bob has no allowance from Alice
+        vault.redeem(shares, bob, alice);
+
+        // Alice's shares and the vault's USDC are untouched.
+        assertEq(vault.balanceOf(alice), shares);
+        assertEq(usdc.balanceOf(address(vault)), amount);
+    }
+
+    function test_revert_withdraw_steal_without_allowance() public {
+        uint256 amount = 10_000 * 10**6;
+
+        vm.startPrank(alice);
+        usdc.approve(address(vault), amount);
+        vault.deposit(amount, alice);
+        vm.stopPrank();
+
+        uint256 withdrawable = amount - vault.MIN_LIQUIDITY();
+        vm.prank(bob);
+        vm.expectRevert(); // no allowance from Alice
+        vault.withdraw(withdrawable, bob, alice);
+
+        assertEq(usdc.balanceOf(address(vault)), amount);
+    }
+
+    /// @dev With an explicit share allowance, a delegate CAN redeem on the owner's
+    ///      behalf, and the allowance is decremented (canonical ERC-4626 path).
+    function test_redeem_with_allowance_succeeds() public {
+        uint256 amount = 10_000 * 10**6;
+
+        vm.startPrank(alice);
+        usdc.approve(address(vault), amount);
+        uint256 shares = vault.deposit(amount, alice);
+        vault.approve(bob, shares); // Alice grants Bob a share allowance
+        vm.stopPrank();
+
+        uint256 aliceUsdcBefore = usdc.balanceOf(alice);
+        vm.prank(bob);
+        vault.redeem(shares, alice, alice); // receiver = owner (Alice)
+
+        assertEq(usdc.balanceOf(alice) - aliceUsdcBefore, amount - vault.MIN_LIQUIDITY());
+        assertEq(vault.balanceOf(alice), 0);
+        assertEq(vault.allowance(alice, bob), 0); // allowance consumed
+    }
+
     // ─── Preview Functions ───────────────────────────────────────────
 
     function test_previewDeposit() public {


### PR DESCRIPTION
## Summary
`withdraw()` and `redeem()` called `_burn(owner_, shares)` on a caller-supplied `owner_` with **no `msg.sender == owner_` check and no allowance accounting**. Any address could call `vault.redeem(victimShares, attacker, victimAddr)` to burn a victim's shares and send their USDC to an attacker-chosen receiver — direct theft, contradicting the non-custodial guarantee. (Audit 2026-06-10 finding #1; re-confirmed present 2026-06-13.)

## Fix
Canonical ERC-4626 guard before both `_burn` calls:
```solidity
if (msg.sender != owner_) { _spendAllowance(owner_, msg.sender, shares); }
```
`_spendAllowance` (OZ ERC20 internal) is a no-op for an infinite allowance and reverts on insufficient allowance.

## Tests
3 regression tests added — the prior suite only ever used `(alice, alice)`, which is why the green suite hid this:
- `test_revert_redeem_steal_without_allowance` — theft reverts, victim untouched
- `test_revert_withdraw_steal_without_allowance` — theft reverts, vault USDC untouched
- `test_redeem_with_allowance_succeeds` — delegated path works and consumes allowance

## Verify
```
cd contracts && forge test --match-path test/Vault.t.sol   # 48 passed
cd contracts && forge test                                  # 149 passed, 0 failed
```

## Notes
- **Rebased onto current main** (post dead-shares / slippage-floor / oracle-staleness hardening). The original 06-09 branch predated all of that; force-updated to avoid a stale-merge regression.
- **Source-only fix.** The deployed on-chain Vault is unchanged until a Foundry redeploy + address propagation (`deploy_output.json`, backend, UI) — tracked as the follow-up.