### PR TITLE
[backend] SIWE-gate unauthenticated vault create + metadata endpoints

### DIFF
--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 
 from archimedes.api._route_helpers import strategy_provider, vault_svc
+from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
 from archimedes.chain.strategy_publisher import strategy_publisher
 
@@ -76,10 +77,18 @@ async def list_vaults(
 
 @vaults_router.post("/create", response_model=VaultCreateResponse)
 @limiter.limit("5/minute")
-async def create_vault(req: VaultCreateRequest, request: Request, response: Response):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
-    """Deploy a new vault on Arc via VaultFactory."""
-    from fastapi import HTTPException
+async def create_vault(
+    req: VaultCreateRequest,
+    request: Request,
+    response: Response,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    wallet: str = Depends(require_verified_wallet),  # noqa: ARG001 — SIWE gate; raises 401 if unauthenticated
+):
+    """Deploy a new vault on Arc via VaultFactory.
 
+    SIWE-gated: vault creation spends the backend signer's gas on-chain, so it
+    must require an authenticated wallet (rate-limiting alone left it open to an
+    unauthenticated gas-drain).
+    """
     try:
         vault_address = await chain_executor.create_vault(
             name=req.name,
@@ -120,10 +129,20 @@ async def get_vault_detail(address: str):
 
 @vaults_router.post("/metadata", response_model=VaultMetadataResponse)
 @limiter.limit("10/minute")
-async def store_vault_metadata(req: VaultMetadataRequest, request: Request, response: Response):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
-    """Store off-chain vault metadata (strategy associations, display name)."""
-    from fastapi import HTTPException
+async def store_vault_metadata(
+    req: VaultMetadataRequest,
+    request: Request,
+    response: Response,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    wallet: str = Depends(require_verified_wallet),
+):
+    """Store off-chain vault metadata (strategy associations, display name).
 
+    SIWE-gated and owner-scoped: this write triggers `_anchor_strategies_async`,
+    a backend-signed on-chain transaction. Previously anyone could overwrite any
+    vault's metadata and spend gas. The authenticated wallet now becomes the
+    metadata owner on first write, and subsequent writes require the caller to
+    be that owner.
+    """
     from archimedes.db import get_session
 
     session = get_session()
@@ -132,10 +151,15 @@ async def store_vault_metadata(req: VaultMetadataRequest, request: Request, resp
         if meta is None:
             meta = VaultMetadata(vault_address=req.vault_address)
             session.add(meta)
+        elif meta.creator_address and meta.creator_address.lower() != wallet.lower():
+            # An owner already claimed this vault's metadata; only they may edit it.
+            raise HTTPException(status_code=403, detail="Not authorized to edit this vault's metadata.")
 
         meta.name = req.name
         meta.symbol = req.symbol
-        meta.creator_address = req.creator_address or ""
+        # Bind ownership to the authenticated wallet — never trust a
+        # caller-supplied creator_address (that was the spoofing vector).
+        meta.creator_address = wallet.lower()
         meta.set_strategy_ids(req.strategy_ids)
         session.commit()
         session.refresh(meta)
@@ -145,6 +169,11 @@ async def store_vault_metadata(req: VaultMetadataRequest, request: Request, resp
             asyncio.create_task(_anchor_strategies_async(req.strategy_ids))
 
         return VaultMetadataResponse(**meta.to_dict())
+    except HTTPException:
+        # Auth/ownership failures (401/403) must pass through unchanged, not be
+        # masked as a 500 by the broad handler below.
+        session.rollback()
+        raise
     except Exception as exc:
         session.rollback()
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/tests/test_vault_metadata_anchor.py
+++ b/backend/tests/test_vault_metadata_anchor.py
@@ -8,12 +8,21 @@ survives anchor failures without breaking the DB write.
 from __future__ import annotations
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
 from archimedes.main import app
 from fastapi.testclient import TestClient
 
 client = TestClient(app)
+
+_WALLET = "0x" + "a1" * 20
+
+
+def _siwe_cookies(wallet: str = _WALLET) -> dict[str, str]:
+    """A valid SIWE session cookie for `wallet` (the endpoints are now gated)."""
+    return {_COOKIE_NAME: _sign_session(wallet.lower(), time.time())}
 
 
 def _make_passport(sid: str, methodology_hash: str | None = "abcd1234" * 8):
@@ -43,6 +52,7 @@ class TestVaultMetadataAnchor:
                 "symbol": "tVLT",
                 "strategy_ids": ["s1", "s2", "s3"],
             },
+            cookies=_siwe_cookies(),
         )
         assert resp.status_code == 200
 
@@ -70,6 +80,7 @@ class TestVaultMetadataAnchor:
                 "symbol": "tVL2",
                 "strategy_ids": ["s1", "s2", "s3"],
             },
+            cookies=_siwe_cookies(),
         )
         assert resp.status_code == 200
 
@@ -91,6 +102,7 @@ class TestVaultMetadataAnchor:
                 "symbol": "tVL3",
                 "strategy_ids": ["s1"],
             },
+            cookies=_siwe_cookies(),
         )
         # Handler still returns 200 — anchor failure is non-fatal
         assert resp.status_code == 200
@@ -109,9 +121,72 @@ class TestVaultMetadataAnchor:
                 "symbol": "tVL4",
                 "strategy_ids": ["unknown_id"],
             },
+            cookies=_siwe_cookies(),
         )
         assert resp.status_code == 200
 
         asyncio.run(asyncio.sleep(0.1))
         # anchor should NOT have been called for unknown strategy
         mock_publisher.anchor.assert_not_called()
+
+
+class TestVaultMetadataAuth:
+    """Audit finding #8: /api/vaults/metadata triggers a backend-signed on-chain
+    tx and was unauthenticated. It must require SIWE and be owner-scoped."""
+
+    def test_metadata_post_requires_auth(self):
+        resp = client.post(
+            "/api/vaults/metadata",
+            json={
+                "vault_address": "0x" + "22" * 20,
+                "name": "Unauthed",
+                "symbol": "tUNA",
+                "strategy_ids": [],
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_metadata_post_rejects_non_owner_overwrite(self):
+        vault = "0x" + "33" * 20
+        owner = "0x" + "aa" * 20
+        attacker = "0x" + "bb" * 20
+
+        # Owner claims the vault metadata first.
+        first = client.post(
+            "/api/vaults/metadata",
+            json={"vault_address": vault, "name": "Owned", "symbol": "tOWN", "strategy_ids": []},
+            cookies=_siwe_cookies(owner),
+        )
+        assert first.status_code == 200
+
+        # A different authenticated wallet cannot overwrite it.
+        attack = client.post(
+            "/api/vaults/metadata",
+            json={"vault_address": vault, "name": "Hijacked", "symbol": "tHJK", "strategy_ids": []},
+            cookies=_siwe_cookies(attacker),
+        )
+        assert attack.status_code == 403
+
+        # The owner can still edit their own metadata.
+        again = client.post(
+            "/api/vaults/metadata",
+            json={"vault_address": vault, "name": "Owned v2", "symbol": "tOWN", "strategy_ids": []},
+            cookies=_siwe_cookies(owner),
+        )
+        assert again.status_code == 200
+
+
+def test_create_vault_requires_auth():
+    """Vault creation spends the backend signer's gas → must be SIWE-gated."""
+    resp = client.post(
+        "/api/vaults/create",
+        json={
+            "name": "Unauthed Vault",
+            "symbol": "tUAV",
+            "management_fee_bps": 100,
+            "performance_fee_bps": 1000,
+            "agent_assisted": True,
+            "strategy_ids": [],
+        },
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Fixes **High finding #8** from `AUDIT_2026-06-10.md`.

Two endpoints triggered backend-signed on-chain transactions **without SIWE authentication** (rate-limited per IP only):

- `POST /api/vaults/create` — deploys a vault, charging the backend signer's gas → unauthenticated gas-drain.
- `POST /api/vaults/metadata` — lets anyone overwrite any vault's metadata and fire `_anchor_strategies_async` (backend-signed on-chain tx) → metadata tampering + unauthenticated on-chain spend.

The same signer (`ARC_AGENT_PRIVATE_KEY`) also drives `execute_trades`, so weak auth here is funds-adjacent.

## Changes

- Add `Depends(require_verified_wallet)` (existing SIWE session dependency) to both endpoints — **401 without a valid session**.
- **Owner-scope** metadata writes: the authenticated wallet becomes the metadata owner on first write; `creator_address` is bound to the session wallet (never a caller-supplied value, which was the spoofing vector); later writes require the caller to be that owner (**403** otherwise).
- Let `HTTPException` (401/403) pass through the metadata handler instead of being masked as 500.

## Verify

```bash
PYTHONPATH=backend pytest backend/tests/test_vault_metadata_anchor.py -q   # 7 passed
# unauthenticated create now 401:
curl -X POST .../api/vaults/create -d '{"name":"x",...}'   # 401
```

New tests: 401 unauthenticated (create + metadata); 403 non-owner overwrite (owner can still edit). Existing anchor tests now send a SIWE cookie.

## Note

The audit's `:131` blocking `session.query` (finding #24) is addressed separately. Lane: backend (Daniel R.); funds-adjacent, so flagged for prompt review.