### PR TITLE
[auth] Wire SIWE in the UI + bind domain/chain-id/expiry in verify

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -27,6 +27,7 @@ import logging
 import os
 import secrets
 import time
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, HTTPException, Request, Response
 
@@ -40,12 +41,24 @@ auth_router = APIRouter(prefix="/api/auth", tags=["auth"])
 _SESSION_SECRET = os.getenv("EMAIL_ENCRYPTION_KEY", secrets.token_hex(32))
 _SESSION_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 _NONCE_TTL_SECONDS = 300  # 5 minutes
+_CLOCK_SKEW_SECONDS = 120  # tolerate small client/server clock drift on Issued At
+
+# SIWE message binding — a valid signature must be for THIS site and chain, not
+# merely carry a live nonce. Must match what GET /api/auth/nonce advertises and
+# what the UI puts in the message (see ui/src/siwe.js).
+_EXPECTED_DOMAIN = os.getenv("PUBLIC_DOMAIN", "https://archimedes-arc.app")
+_EXPECTED_CHAIN_ID = int(os.getenv("ARC_CHAIN_ID", "5042002"))
 
 # In-memory nonce store. Production would use Redis, but for the hackathon
 # this is sufficient — nonces are short-lived (5 min TTL) and single-use.
 _pending_nonces: dict[str, float] = {}  # nonce → expiry timestamp
 
 _COOKIE_NAME = "archimedes_session"
+
+
+def _normalize_domain(domain: str) -> str:
+    """Bare authority for domain comparison — drop scheme and trailing slash."""
+    return domain.strip().removeprefix("https://").removeprefix("http://").rstrip("/").lower()
 
 
 def _sign_session(wallet: str, issued_at: float) -> str:
@@ -132,18 +145,59 @@ async def verify_signature(request: Request, response: Response):
     if not message or not signature:
         raise HTTPException(status_code=400, detail="message and signature are required")
 
-    # Extract nonce from the message (SIWE format: "Nonce: <value>")
+    # Parse the SIWE message fields (EIP-4361). The first line is
+    # "<domain> wants you to sign in with your Ethereum account:".
     nonce = None
     wallet_from_message = None
-    for line in message.split("\n"):
+    domain_from_message = None
+    chain_id_from_message = None
+    issued_at_from_message = None
+    lines = message.split("\n")
+    if lines and " wants you to sign in" in lines[0]:
+        domain_from_message = lines[0].split(" wants you to sign in")[0].strip()
+    for line in lines:
         line = line.strip()
         if line.startswith("Nonce: "):
             nonce = line[7:].strip()
-        if line.startswith("0x") and len(line) == 42:
+        elif line.startswith("Chain ID: "):
+            chain_id_from_message = line[len("Chain ID: ") :].strip()
+        elif line.startswith("Issued At: "):
+            issued_at_from_message = line[len("Issued At: ") :].strip()
+        elif line.startswith("0x") and len(line) == 42:
             wallet_from_message = line.lower()
 
     if not nonce:
         raise HTTPException(status_code=400, detail="Nonce not found in message")
+
+    # The three EIP-4361 bindings below are REQUIRED, not best-effort: a message
+    # that simply omits the domain / chain-id / issued-at lines must not slip
+    # through unbound. The UI always emits all three (see ui/src/siwe.js).
+
+    # Domain binding — a signature for another dApp's domain must not authenticate
+    # here, even if it happens to carry a live Archimedes nonce. Compare on the
+    # bare authority (scheme/trailing-slash stripped) so "archimedes-arc.app" and
+    # "https://archimedes-arc.app/" are treated as the same site.
+    if domain_from_message is None:
+        raise HTTPException(status_code=400, detail="SIWE message is missing the domain line")
+    if _normalize_domain(domain_from_message) != _normalize_domain(_EXPECTED_DOMAIN):
+        raise HTTPException(status_code=401, detail="SIWE message domain does not match this site")
+
+    # Chain-id binding — reject messages signed for the wrong chain (or with none).
+    if chain_id_from_message is None:
+        raise HTTPException(status_code=400, detail="SIWE message is missing the Chain ID")
+    if chain_id_from_message != str(_EXPECTED_CHAIN_ID):
+        raise HTTPException(status_code=401, detail="SIWE message chain-id mismatch")
+
+    # Expiry — require a fresh "Issued At"; a message without one is not bound in time.
+    if not issued_at_from_message:
+        raise HTTPException(status_code=400, detail="SIWE message is missing Issued At")
+    try:
+        issued_dt = datetime.fromisoformat(issued_at_from_message.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid Issued At timestamp") from exc
+    age = datetime.now(issued_dt.tzinfo) - issued_dt
+    if age > timedelta(seconds=_NONCE_TTL_SECONDS) or age < timedelta(seconds=-_CLOCK_SKEW_SECONDS):
+        raise HTTPException(status_code=401, detail="SIWE message issued-at outside the valid window")
 
     # Verify nonce is pending and not expired
     expiry = _pending_nonces.pop(nonce, None)

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,6 +25,13 @@ from archimedes.api.auth_siwe import (
     require_verified_wallet,
 )
 from httpx import ASGITransport, AsyncClient
+
+
+def _now_iso() -> str:
+    """Current UTC time as an EIP-4361 'Issued At' string (must be fresh: the
+    verifier now rejects stale issued-at timestamps)."""
+    return datetime.now(UTC).isoformat()
+
 
 # ── Unit tests for session token functions ─────────────────────
 
@@ -195,7 +203,12 @@ async def test_verify_rejects_missing_fields():
 async def test_verify_rejects_unknown_nonce():
     from archimedes.main import app
 
-    message = "archimedes-arc.app wants you to sign in\n0xabcdef1234567890abcdef1234567890abcdef12\nNonce: nonexistentnonce12345678"
+    # Full bindings (domain/chain/issued-at) present so we reach the nonce check.
+    message = (
+        "archimedes-arc.app wants you to sign in\n"
+        "0xabcdef1234567890abcdef1234567890abcdef12\n"
+        f"Chain ID: 5042002\nNonce: nonexistentnonce12345678\nIssued At: {_now_iso()}"
+    )
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
     assert resp.status_code == 401
@@ -210,7 +223,11 @@ async def test_verify_rejects_expired_nonce():
     nonce = "expired_nonce_123456"
     _pending_nonces[nonce] = time.time() - 1  # already expired
 
-    message = f"archimedes-arc.app wants you to sign in\n0xabcdef1234567890abcdef1234567890abcdef12\nNonce: {nonce}"
+    message = (
+        "archimedes-arc.app wants you to sign in\n"
+        "0xabcdef1234567890abcdef1234567890abcdef12\n"
+        f"Chain ID: 5042002\nNonce: {nonce}\nIssued At: {_now_iso()}"
+    )
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
     assert resp.status_code == 401
@@ -243,7 +260,7 @@ async def test_verify_with_valid_signature():
             f"Version: 1\n"
             f"Chain ID: 5042002\n"
             f"Nonce: {nonce_data['nonce']}\n"
-            f"Issued At: 2026-05-26T00:00:00Z"
+            f"Issued At: {_now_iso()}"
         )
         signable = encode_defunct(text=message)
         signed = acct.sign_message(signable)
@@ -284,8 +301,9 @@ async def test_verify_rejects_wrong_signer():
         message = (
             f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
             f"{acct_fake}\n\n"
+            f"Chain ID: 5042002\n"
             f"Nonce: {nonce_data['nonce']}\n"
-            f"Issued At: 2026-05-26T00:00:00Z"
+            f"Issued At: {_now_iso()}"
         )
         signable = encode_defunct(text=message)
         signed = acct_real.sign_message(signable)
@@ -314,8 +332,9 @@ async def test_nonce_is_single_use():
         message = (
             f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
             f"{acct.address.lower()}\n\n"
+            f"Chain ID: 5042002\n"
             f"Nonce: {nonce_data['nonce']}\n"
-            f"Issued At: 2026-05-26T00:00:00Z"
+            f"Issued At: {_now_iso()}"
         )
         signable = encode_defunct(text=message)
         signed = acct.sign_message(signable)
@@ -329,3 +348,72 @@ async def test_nonce_is_single_use():
         resp2 = await client.post("/api/auth/verify", json=payload)
         assert resp2.status_code == 401
         assert "Nonce" in resp2.json()["detail"]
+
+
+# ── SIWE message binding: domain / chain-id / expiry (audit #9) ─────
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_wrong_domain():
+    """A message signed for another dApp's domain must not authenticate here."""
+    from archimedes.main import app
+
+    message = (
+        "evil-phish.example wants you to sign in with your Ethereum account:\n"
+        "0xabcdef1234567890abcdef1234567890abcdef12\n\n"
+        "Chain ID: 5042002\n"
+        f"Nonce: somenonce123456\nIssued At: {_now_iso()}"
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
+    assert resp.status_code == 401
+    assert "domain" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_wrong_chain_id():
+    from archimedes.main import app
+
+    message = (
+        "archimedes-arc.app wants you to sign in with your Ethereum account:\n"
+        "0xabcdef1234567890abcdef1234567890abcdef12\n\n"
+        "Chain ID: 1\n"  # Ethereum mainnet, not Arc testnet
+        f"Nonce: somenonce123456\nIssued At: {_now_iso()}"
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
+    assert resp.status_code == 401
+    assert "chain" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_stale_issued_at():
+    from archimedes.main import app
+
+    message = (
+        "archimedes-arc.app wants you to sign in with your Ethereum account:\n"
+        "0xabcdef1234567890abcdef1234567890abcdef12\n\n"
+        "Chain ID: 5042002\n"
+        "Nonce: somenonce123456\nIssued At: 2020-01-01T00:00:00+00:00"  # ancient
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
+    assert resp.status_code == 401
+    assert "issued-at" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_message_missing_chain_id():
+    """A message that omits Chain ID is rejected (400) — bindings are required,
+    not skip-if-absent (self-audit hardening of finding #9)."""
+    from archimedes.main import app
+
+    message = (
+        "archimedes-arc.app wants you to sign in\n"
+        "0xabcdef1234567890abcdef1234567890abcdef12\n"
+        f"Nonce: somenonce123456\nIssued At: {_now_iso()}"
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
+    assert resp.status_code == 400
+    assert "Chain ID" in resp.json()["detail"]

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -5,6 +5,7 @@ import {
   getAvailableProviders,
   getConnectedProvider,
   getUsdcBalance,
+  getWalletClient,
   CIRCLE_PROVIDER_ID,
 } from '../config'
 


### PR DESCRIPTION
## Summary

Fixes **High finding #9** from `AUDIT_2026-06-10.md` — SIWE was dead code in the UI and under-validated on the server.

### UI: SIWE never ran
`WalletConnect.jsx:102` called `getWalletClient()` **without importing it**. That threw `ReferenceError`, was swallowed by the surrounding `try/catch` (`console.warn('SIWE auth failed (non-fatal)')`), and returned early — so no session cookie was ever established and the entire PII/auth-gated layer was unreachable from the UI. `getWalletClient` is already exported from `../config`; the fix is to import it.

(This is why the SIWE gates in #511 matter — without this, no UI user could ever authenticate.)

### Server: verify only checked the nonce
`verify_signature` validated the nonce but not the message itself, so a signature from any dApp on the same address — if it happened to carry a current Archimedes nonce — would verify. Added EIP-4361 binding:

- **domain** — normalized (scheme/trailing-slash-insensitive) compare against `PUBLIC_DOMAIN`.
- **chain-id** — must equal `ARC_CHAIN_ID` (default 5042002).
- **issued-at freshness** — within the nonce TTL, with a small clock-skew tolerance.

## Verify

```bash
PYTHONPATH=backend pytest backend/tests/test_auth_siwe.py -q   # 28 passed
grep -n "getWalletClient" ui/src/components/WalletConnect.jsx    # now imported
```

New tests: wrong-domain / wrong-chain / stale-issued-at each 401. The existing full-flow tests hardcoded `Issued At: 2026-05-26` (now stale under the freshness check) and were updated to use a current timestamp.

## Lanes

UI import → Marten; backend validation → Daniel R. Filed together because they are one finding (the UI fix is meaningless without the round-trip working, and vice-versa).