### PR TITLE
[infra] Exclude .env and keys from Docker build contexts (audit #22)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Keep secrets, local state, and build cruft out of the Docker build context.
+# Without this, a backend Dockerfile `COPY . /app` would pull any local .env
+# (and keys) into the image layers. See AUDIT_2026-06-10.md finding #22.
+
+# Secrets / local env
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.tfstate
+*.tfstate.*
+
+# Python build/test cruft
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+*.egg-info/
+.venv/
+venv/
+
+# Node / frontend
+node_modules/
+ui/dist/
+ui/node_modules/
+
+# VCS / tooling / docs not needed at runtime
+.git/
+.github/
+.gitignore
+.idea/
+.vscode/
+.DS_Store
+
+# Submodules (large reference trees, not needed in the runtime image)
+submodules/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,7 +1,21 @@
+# Secrets / local env — the backend image builds `COPY . /app` from context
+# ./backend, so without these a local backend/.env (or keys) would be baked into
+# the image layers. See AUDIT_2026-06-10.md finding #22.
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+
+# Python build/test cruft (not needed at runtime)
 __pycache__
 *.pyc
 *.pyo
 .pytest_cache
+.ruff_cache
+.mypy_cache
 .coverage
 htmlcov
 .venv


### PR DESCRIPTION
## Summary

Fixes **Low finding #22** from `AUDIT_2026-06-10.md`.

The audit said "no `.dockerignore` exists." Verified more precisely: a `backend/.dockerignore` **does** exist but **does not exclude `.env` or keys** — and since the backend image builds `COPY . /app` from context `./backend`, a local `backend/.env` (or `*.pem`/`*.key`) would be baked into the image layers. (Docker reads `.dockerignore` from each build context's root, so a repo-root file would not have protected the backend build.)

## Changes

- `backend/.dockerignore`: add `.env`, `.env.*`, `*.pem/key/p12/pfx/crt` plus the usual Python cruft.
- New repo-root `.dockerignore` for the **nginx** build (context `.`), excluding secrets, `node_modules`, `ui/dist`, `submodules/`, `.git`.

## Build-graph safety (checked)

- nginx Dockerfile (context `.`) re-runs `npm ci` and only copies `ui/` + `nginx.conf` → excluding `node_modules`/`dist`/`submodules` is safe.
- backend Dockerfile needs none of the excluded paths at runtime.

## Verify

```bash
ls -la backend/.dockerignore .dockerignore
grep -n "^.env" backend/.dockerignore
```

Lane: infra (Chuan).