### PR TITLE
[infra] Remove SSH port 22 ingress open to 0.0.0.0/0 (audit #12)

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -95,17 +95,12 @@ resource "local_sensitive_file" "private_key" {
 
 resource "aws_security_group" "archimedes" {
   name        = "${var.project_name}-sg"
-  description = "Archimedes EC2 - SSH, HTTP, HTTPS, API"
+  description = "Archimedes EC2 - HTTP, HTTPS (admin access via SSM, no inbound SSH)"
   vpc_id      = data.aws_vpc.default.id
 
-  # SSH
-  ingress {
-    description = "SSH"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # No SSH ingress. Admin access is via AWS SSM Session Manager (see CLAUDE.md /
+  # infra-setup.md), which needs no inbound port. Port 22 open to 0.0.0.0/0 on a
+  # funds-holding host was unused attack surface — removed per audit finding #12.
 
   # HTTP
   ingress {


### PR DESCRIPTION
## Summary

Fixes **High finding #12** from `AUDIT_2026-06-10.md`.

The `archimedes` security group opened port 22 to `0.0.0.0/0` on the funds-holding EC2 host. The deploy posture explicitly uses **SSM Session Manager** (no inbound SSH needed), so port 22 was dead, unused attack surface.

## Change

Delete the SSH `ingress` block (and update the SG description). SSM requires no inbound ports; HTTP/HTTPS ingress is unchanged.

## ⚠️ Needs Chuan to plan + apply

`terraform` isn't available in my environment, so this is not `terraform validate`'d locally. Chuan should `terraform plan` (expect: one ingress rule removed, no replacement) and apply against the live stack.

## Verify (post-apply)

```bash
aws ec2 describe-security-groups --filters Name=group-name,Values=archimedes-sg \
  --query 'SecurityGroups[0].IpPermissions[?FromPort==`22`]'   # should be []
```

Lane: infra (Chuan).