### PR TITLE
[infra] Stop hardcoding the Postgres password; generate at boot (audit #11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,13 @@
 # wallet / RPC / Circle variables are optional locally (skip on-chain features).
 
 # ── PostgreSQL (the local docker compose stack starts a server with these) ──
+# LOCAL-DEV ONLY. This is a throwaway local password, NOT a production secret —
+# the EC2 bootstrap (infra/user-data.sh) generates a random password at boot.
+# Never reuse this value anywhere real. Keep the two lines in sync if you change it.
 POSTGRES_USER=archimedes
-POSTGRES_PASSWORD=archimedes-hackathon-2026
+POSTGRES_PASSWORD=local-dev-only-change-me
 POSTGRES_DB=archimedes
-DATABASE_URL=postgresql://archimedes:archimedes-hackathon-2026@postgres:5432/archimedes
+DATABASE_URL=postgresql://archimedes:local-dev-only-change-me@postgres:5432/archimedes
 
 # ── Redis ──────────────────────────────────────────────────────────────────
 REDIS_URL=redis://redis:6379/0

--- a/infra/user-data.sh
+++ b/infra/user-data.sh
@@ -40,16 +40,30 @@ chown ubuntu:ubuntu /opt/archimedes
 # Clone the repo
 su - ubuntu -c "git clone ${repo_url} /opt/archimedes"
 
-# Create a placeholder .env on the server (team will populate secrets later)
-cat > /opt/archimedes/.env <<'ENVEOF'
+# Generate a strong DB password at boot — never hardcode a credential in the
+# repo (the previous "archimedes-hackathon-2026" literal was world-readable in
+# git). hex is URL-safe, so it slots into DATABASE_URL without escaping.
+# (Longer-term: pull this from AWS SSM Parameter Store at container start.)
+#
+# NOTE: this file is rendered by Terraform's templatefile() (see main.tf), which
+# parses the WHOLE file (comments included) and treats $${...} as a template
+# directive. Shell variable references are therefore doubled ($$ renders to a
+# single $) so the rendered script keeps the shell expansion at boot. The only
+# real Terraform template variable in this file is repo_url (used above).
+DB_PASS="$(openssl rand -hex 24)"
+
+# Create a placeholder .env on the server (team will populate the rest later).
+# Unquoted heredoc so $${DB_PASS} expands at runtime; no other shell $refs here.
+cat > /opt/archimedes/.env <<ENVEOF
 # Archimedes production environment — populated by the team
 # Do NOT commit this file. See .env.example for the template.
 POSTGRES_USER=archimedes
-POSTGRES_PASSWORD=archimedes-hackathon-2026
+POSTGRES_PASSWORD=$${DB_PASS}
 POSTGRES_DB=archimedes
 REDIS_URL=redis://redis:6379/0
-DATABASE_URL=postgresql://archimedes:archimedes-hackathon-2026@postgres:5432/archimedes
+DATABASE_URL=postgresql://archimedes:$${DB_PASS}@postgres:5432/archimedes
 ENVEOF
+chmod 600 /opt/archimedes/.env
 chown ubuntu:ubuntu /opt/archimedes/.env
 
 # Start services (if docker-compose.yml exists)


### PR DESCRIPTION
## Summary

Fixes **High finding #11** from `AUDIT_2026-06-10.md`.

`POSTGRES_PASSWORD=archimedes-hackathon-2026` was committed verbatim in **both** `.env.example` and `infra/user-data.sh` — the production Postgres credential was world-readable in the repo.

## Changes

- `infra/user-data.sh`: generate a random password at boot (`openssl rand -hex 24`, URL-safe) and reuse it for `POSTGRES_PASSWORD` and `DATABASE_URL`; `chmod 600` the `.env`.
  - **Templatefile escaping:** `user-data.sh` is rendered by Terraform `templatefile()` (main.tf), which treats `${...}` as template syntax. The shell var is written `$${DB_PASS}` so Terraform emits a literal `${DB_PASS}` for the boot-time shell. (Only `${repo_url}` is a real template var.)
- `.env.example`: obviously-local throwaway value (`local-dev-only-change-me`) so local `docker compose up` still works one-command, with a comment that it is not a production secret.

## ⚠️ Rotation does not undo the leak (CLAUDE.md)

The old literal remains in `git log -p` and every clone. **The live DB password must be rotated out-of-band regardless.** An existing deployment whose Postgres volume was initialized with the old literal needs an `ALTER USER ... PASSWORD` (a fresh-boot random password won't match an already-initialized data dir). Chuan should coordinate the rotation + `terraform apply`.

Longer term: pull the password from AWS SSM Parameter Store at container start.

## Verify

```bash
grep -rn "archimedes-hackathon-2026" .env.example infra/user-data.sh   # only in an explanatory comment
```

Lane: infra (Chuan).