### PR TITLE
[frontend] Harden deposit path: validate vault address + parseUnits (audit #19, #26)

### DIFF
--- a/ui/src/components/DepositFlow.jsx
+++ b/ui/src/components/DepositFlow.jsx
@@ -12,7 +12,9 @@ import {
   VAULT_ABI,
   ASSETS,
   CIRCLE_PROVIDER_ID,
+  USDC_DECIMALS,
 } from '../config'
+import { parseUnits } from 'viem'
 import { executeUserOp, encodeCall } from '../circle-tx-executor'
 
 const ARCSCAN_TX = 'https://testnet.arcscan.app/tx'
@@ -121,7 +123,7 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
     updateStep(0, 'error', null)
     try {
       const walletClient = await getWalletClient()
-      const parsedAmount = BigInt(Math.round(parseFloat(amount) * 1e6))
+      const parsedAmount = parseUnits(amount, USDC_DECIMALS)
       if (parsedAmount <= 0n) throw new Error('Amount must be greater than 0')
 
       const hash = await walletClient.writeContract({
@@ -151,7 +153,7 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
       const walletClient = await getWalletClient()
       const userAddr = getAddress()
       if (!userAddr) throw new Error('Wallet address not available')
-      const parsedAmount = BigInt(Math.round(parseFloat(amount) * 1e6))
+      const parsedAmount = parseUnits(amount, USDC_DECIMALS)
 
       const hash = await walletClient.writeContract({
         address: vaultAddress,
@@ -411,7 +413,7 @@ function PasskeyDepositFlow({ vaultAddress, depositAmount = '100', strategy, onC
       if (!smartAccount || !client) {
         throw new Error('Passkey wallet not initialized — please reconnect.')
       }
-      const parsedAmount = BigInt(Math.round(parseFloat(amount) * 1e6))
+      const parsedAmount = parseUnits(amount, USDC_DECIMALS)
       if (parsedAmount <= 0n) throw new Error('Amount must be greater than 0')
 
       const { tokens, weights } = defaultAllocations()

--- a/ui/src/components/VaultDetail.jsx
+++ b/ui/src/components/VaultDetail.jsx
@@ -1,9 +1,10 @@
 import { apiGet } from '../api'
 import { useState, useEffect, useCallback } from 'react'
+import { isAddress, parseUnits } from 'viem'
 import {
   publicClient, getWalletClient, getAddress,
   USDC, TOKEN_ABI, VAULT_ABI,
-  ASSETS,
+  ASSETS, USDC_DECIMALS,
 } from '../config'
 import VaultChat from './VaultChat'
 
@@ -184,10 +185,19 @@ export default function VaultDetail({ address, onBack }) {
 
   const deposit = async () => {
     if (!address || !depositAmt) return
+    // The vault address comes from the URL (deep-link); never route a USDC
+    // approve/deposit to an unvalidated address — a phishing link like
+    // /portfolio/vaults/0xATTACKER would otherwise receive the approval.
+    if (!isAddress(address)) {
+      setStatus('Invalid vault address — refusing to send funds.')
+      return
+    }
     setBusy(true); setStatus('')
     try {
       const w = await getWalletClient()
-      const amount = BigInt(Math.round(parseFloat(depositAmt) * 1e6))
+      // parseUnits is exact for decimal strings; float math (parseFloat * 1e6)
+      // is lossy for large/many-decimal inputs.
+      const amount = parseUnits(depositAmt, USDC_DECIMALS)
       setStatus('Approving USDC…')
       await w.writeContract({ address: USDC, abi: TOKEN_ABI, functionName: 'approve', args: [address, amount] })
       setStatus('Depositing…')


### PR DESCRIPTION
## Summary

Fixes **Medium finding #19** and **Low finding #26** from `AUDIT_2026-06-10.md`. Both live in the same deposit code path (`VaultDetail.deposit`), so they ship together rather than as two PRs conflicting on the same lines.

### #19 — unvalidated deep-link vault address → approve target
The vault address comes from the URL (`/portfolio/vaults/<addr>`) and flowed directly into the USDC `approve()` / `deposit()` args. A phishing link like `/portfolio/vaults/0xATTACKER` would route the approval to the attacker. Now `VaultDetail.deposit` calls viem `isAddress(address)` first and refuses to send funds on failure.

### #26 — lossy float amount parsing
Replaced `BigInt(Math.round(parseFloat(x) * 1e6))` with viem `parseUnits(x, USDC_DECIMALS)`:
- `VaultDetail.jsx` (1 site)
- `DepositFlow.jsx` (3 sites — `runApprove`, `runDeposit`, and the passkey path)

`parseUnits` is exact for decimal strings; the float path is lossy for large/many-decimal inputs.

## ⚠️ Not built/linted locally

No frontend toolchain in my environment (`node`/`ui/node_modules` absent). Relies on CI `npm run lint` + **Marten** confirming the deposit flow in the UI. The APIs used (`parseUnits`, `isAddress`) are standard viem exports; `USDC_DECIMALS` already exists in `ui/src/config.js`.

## Verify

```bash
grep -rn "Math.round(parseFloat" ui/src/components/   # none remaining
grep -n "isAddress(address)" ui/src/components/VaultDetail.jsx
```

Lane: frontend (Marten).