### PR TITLE
[infra] Serve security headers on the live HTTP (:8080) server block (audit #20)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,20 @@ server {
     listen 8080;
     server_name archimedes-arc.app;
 
+    # ── Security headers ──────────────────────────────────────────────────
+    # Production traffic is served from THIS block (ALB terminates TLS and
+    # forwards to :8080), so the headers must live here — they previously
+    # existed only in the unused :8443 block, leaving the live app with none
+    # (clickjacking + no CSP). See AUDIT_2026-06-10.md finding #20. Kept in sync
+    # with the :8443 block below; CSP still allows 'unsafe-inline'/'unsafe-eval'
+    # (tightening that is tracked separately as finding #27).
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "same-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://rpc.testnet.arc.network https://testnet.arcscan.app https://*.coingecko.com https://*.alchemyapi.io https://api.z.ai https://api.anthropic.com https://modular-sdk.circle.com wss://*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;" always;
+
     # ACME challenge passthrough for certbot renewals
     location /.well-known/acme-challenge/ {
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary

Fixes **Medium finding #20** from `AUDIT_2026-06-10.md`.

Production traffic is served from the `listen 8080` block (the ALB terminates TLS and forwards to `:8080` as HTTP with `X-Forwarded-Proto: https`). The security headers (`CSP`, `X-Frame-Options: DENY`, `HSTS`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) existed **only in the unused `:8443` block** — so the live app served none and was clickjackable with no CSP.

## Change

Add the same `add_header ... always` block to the `:8080` server (server-level → inherited by all its locations, none of which define their own `add_header`). Kept identical to the `:8443` block.

CSP content is **unchanged** — it still allows `'unsafe-inline'`/`'unsafe-eval'` (needed today by the Vite bundle + Circle SDK). Tightening that is **finding #27**, filed separately because it needs inline-script mapping + browser testing to avoid breaking passkey signup.

## ⚠️ Needs Chuan to validate + redeploy

Not `nginx -t`'d locally. Verify after deploy:
```bash
curl -sI https://archimedes-arc.app/ | grep -iE "content-security-policy|x-frame-options|strict-transport"
```

Lane: infra (Chuan).