### PR TITLE
[backend] Offload blocking chat post_message off the event loop (audit #24)

### DIFF
--- a/backend/archimedes/api/chat_routes.py
+++ b/backend/archimedes/api/chat_routes.py
@@ -13,6 +13,7 @@ Design (per ecosystem-design-spec.md § 16–17):
 
 from __future__ import annotations
 
+import asyncio
 import re
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -80,7 +81,12 @@ async def post_chat_message(
     if len(body.message) > 2000:
         raise HTTPException(status_code=400, detail="Message too long (max 2000 chars)")
 
-    result = chat_service.post_message(
+    # post_message is fully synchronous and, when @archimedes is mentioned, makes
+    # a blocking Anthropic call plus sync DB writes. Calling it directly inside
+    # this async route would block the event loop and serialize concurrent
+    # requests. Offload the whole sync chain to a worker thread.
+    result = await asyncio.to_thread(
+        chat_service.post_message,
         vault_address=address,
         wallet_address=body.wallet_address,
         message=body.message.strip(),


### PR DESCRIPTION
## Summary

Fixes **Medium finding #24** from `AUDIT_2026-06-10.md` (the chat path).

`chat_service.post_message` is fully synchronous and, when `@archimedes` is mentioned, makes a **blocking** `client.messages.create` (Anthropic) call plus sync SQLAlchemy writes. It was invoked directly inside the **async** `post_chat_message` route, so the blocking work ran on the event loop — concurrent chat posts serialized instead of interleaving.

## Fix

Wrap the call in `await asyncio.to_thread(chat_service.post_message, ...)` so the whole sync chain runs on a worker thread and the event loop stays responsive. `post_message` creates its own DB session per call, so running it in a thread is safe.

## Verify

```bash
PYTHONPATH=backend pytest backend/tests -k chat -q   # 23 passed
```

## Scope note

This addresses the chat route (the audit's primary `chat_service.py:210` / `chat_routes.py:83` citation). The audit also mentions a sync `session.query` in `vaults_routes.py`; that file is being changed in the SIWE-gate PR (#511), so a broader async-DB sweep there is best done as a follow-up to avoid overlapping diffs.

Lane: backend (Daniel R.).