### PR TITLE
[infra] Add branch-protection-as-code script for main (audit #10)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -70,6 +70,29 @@ aws ssm start-session \
   --parameters host=<aurora-endpoint>,portNumber=5432,localPortNumber=5432
 ```
 
+## Branch Protection (`main`)
+
+`main` is build-on-deploy: every push auto-deploys to the live EC2 host. The protection
+ruleset is codified in [`scripts/setup-branch-protection.sh`](../scripts/setup-branch-protection.sh)
+so an admin can apply or audit it declaratively (audit #10 / issues #519, #526).
+
+```bash
+./scripts/setup-branch-protection.sh            # dry-run: print the payload, apply nothing
+./scripts/setup-branch-protection.sh --apply    # apply (needs repo admin)
+./scripts/setup-branch-protection.sh --verify    # print the currently-applied protection
+# or, raw:  gh api repos/hackagora/archimedes-arcadia/branches/main/protection
+```
+
+What it enforces: the two hard-block CI checks (`Backend — unit tests`, `Ruff — format +
+critical lint rules`), 1 approving review, no force-push, no branch deletion, and
+`required_linear_history: false` (we are **merge-commits-only** — linear history would
+force squash/rebase). The informational checks (lint-report, complexity) stay non-required.
+
+**Build-on-deploy tradeoff:** the script ships with `enforce_admins=false` so repo admins
+(including the `t2o2` agentic user) keep their direct-push path while non-admins are gated.
+Flipping `ENFORCE_ADMINS=true` gates everyone but forces the agentic system onto PRs — that
+is a team decision (Chuan, as repo admin, owns it).
+
 ## Security Notes
 
 - **No `.pem` files in git.** `infra/*.pem` is in `.gitignore`.

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# setup-branch-protection.sh — codify branch protection for `main` (audit #10 / issues #519, #526).
+#
+# WHY THIS EXISTS
+#   `main` is currently unprotected, so every push auto-deploys to the live EC2 host
+#   (build-on-deploy) with no human or status-check gate. This script declares the agreed
+#   protection ruleset as code so a repo admin can apply it in one command — and re-apply
+#   or audit it later. The PUT payload is declarative, so the script is idempotent:
+#   re-running converges to the same state.
+#
+# THE t2o2 / build-on-deploy TRADEOFF  (the team-decision knob — read before applying)
+#   The `t2o2` agentic user pushes directly to `main` (build-on-deploy is the accepted
+#   workflow per CLAUDE.md). Branch protection would normally block that. We preserve it
+#   with `enforce_admins=false`: repo *admins* (which includes t2o2) keep their direct-push
+#   path, while every non-admin contributor is gated behind a passing CI + 1 approval.
+#   If the team would rather gate t2o2 too, flip ENFORCE_ADMINS=true below — but then the
+#   agentic system must switch to PR-based merges. This is Chuan's call as repo admin.
+#
+# USAGE
+#   ./scripts/setup-branch-protection.sh            # dry-run: print the payload + commands, apply nothing
+#   ./scripts/setup-branch-protection.sh --apply    # apply the protection (needs admin on the repo)
+#   ./scripts/setup-branch-protection.sh --verify   # print the currently-applied protection
+#
+# REQUIREMENTS: gh (authenticated, with admin scope for --apply), python3 (for pretty JSON).
+set -euo pipefail
+
+REPO="${REPO:-hackagora/archimedes-arcadia}"
+BRANCH="${BRANCH:-main}"
+
+# enforce_admins=false → admins (incl. the t2o2 build-on-deploy user) bypass the gate.
+# Set to "true" to gate everyone, including t2o2 (forces the agentic system onto PRs).
+ENFORCE_ADMINS="${ENFORCE_ADMINS:-false}"
+
+# Hard-block CI contexts from quality-gate.yml. The informational checks
+# ("Lint — report table", "Complexity analysis", coverage) are deliberately NOT required.
+read -r -d '' PAYLOAD <<JSON || true
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": [
+      "Backend — unit tests",
+      "Ruff — format + critical lint rules"
+    ]
+  },
+  "enforce_admins": ${ENFORCE_ADMINS},
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": false,
+  "required_conversation_resolution": true
+}
+JSON
+
+apply() {
+  echo "Applying branch protection to ${REPO}@${BRANCH} (enforce_admins=${ENFORCE_ADMINS}) ..."
+  printf '%s' "$PAYLOAD" | gh api -X PUT \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${REPO}/branches/${BRANCH}/protection" --input - >/dev/null
+  echo "Applied. Verify with: $0 --verify"
+}
+
+verify() {
+  gh api "repos/${REPO}/branches/${BRANCH}/protection" \
+    --jq '{required_status_checks: .required_status_checks.contexts, enforce_admins: .enforce_admins.enabled, required_approving_review_count: .required_pull_request_reviews.required_approving_review_count, allow_force_pushes: .allow_force_pushes.enabled, allow_deletions: .allow_deletions.enabled, required_linear_history: .required_linear_history.enabled}'
+}
+
+case "${1:-}" in
+  --apply)  apply ;;
+  --verify) verify ;;
+  ""|--dry-run)
+    echo "DRY RUN — nothing applied. Target: ${REPO}@${BRANCH}"
+    echo "Payload that --apply would PUT:"
+    printf '%s\n' "$PAYLOAD" | python3 -m json.tool
+    echo
+    echo "To apply (needs repo admin):   $0 --apply"
+    echo "To inspect current state:      $0 --verify"
+    ;;
+  *)
+    echo "Unknown arg: $1" >&2
+    echo "Usage: $0 [--apply | --verify | --dry-run]" >&2
+    exit 2 ;;
+esac


### PR DESCRIPTION
## What

Codifies branch protection for `main` as a reviewable, idempotent script —
**implements #526; decision tracked in #519 (audit #10).**

`main` is unprotected today (`gh api .../branches/main/protection` → 404), so every push
auto-deploys to the live EC2 host (build-on-deploy) with no human/status-check gate.

- `scripts/setup-branch-protection.sh` — dry-run by default; `--apply` PUTs the ruleset
  (admin only); `--verify` prints current state. Declarative payload → idempotent.
- `infra/README.md` — apply/verify commands + the t2o2 tradeoff.

## The ruleset it declares

- Required CI: `Backend — unit tests` + `Ruff — format + critical lint rules` (the two
  hard-block contexts; informational lint/complexity stay non-required).
- 1 approving review; no force-push; no branch deletion.
- `required_linear_history: false` — we are **merge-commits-only**.
- `enforce_admins: false` — admins (incl. `t2o2`) keep their direct-push build-on-deploy
  path; non-admins are gated.

## ⚠️ Not applied in this PR — needs review + an admin

Merging this does **not** enable protection. An admin runs `--apply` afterward. The
real decision is the **t2o2 bypass policy**, which is why I'm requesting:

- **@t2o2 (Chuan)** — repo admin: confirm the `enforce_admins=false` bypass is the right
  call (keeps build-on-deploy intact) vs. gating t2o2 too (`ENFORCE_ADMINS=true`, forces
  the agentic system onto PRs), then `--apply` on the repo. This is your call as admin.
- **@dbrowneup (Dan)** — sanity-check that the required-check set matches the CI-gate
  convention in CLAUDE.md.

## Verify

```bash
bash -n scripts/setup-branch-protection.sh
./scripts/setup-branch-protection.sh            # dry-run, applies nothing
grep -n required_linear_history scripts/setup-branch-protection.sh   # false (merge-commits-only)
```

Closes #526.