### PR TITLE
Clear 24 informational ruff findings repo-wide

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -554,7 +554,7 @@ async def _run_live_candidate(
     # user-visible risk profile so the agent sees the regime steer.
     regime_suffix = _REGIME_PROMPT_SUFFIX.get(regime, "")
     if regime_suffix:
-        agent._regime_context = regime_suffix  # Consumed by _build_tool_user_prompt if available
+        agent._regime_context = regime_suffix  # noqa: SLF001 — deliberate: consumed by _build_tool_user_prompt if available
 
     portfolio = await asyncio.wait_for(
         asyncio.to_thread(

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -79,7 +79,7 @@ async def list_vaults(
 @limiter.limit("5/minute")
 async def create_vault(
     req: VaultCreateRequest,
-    request: Request,
+    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     response: Response,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     wallet: str = Depends(require_verified_wallet),  # noqa: ARG001 — SIWE gate; raises 401 if unauthenticated
 ):
@@ -131,7 +131,7 @@ async def get_vault_detail(address: str):
 @limiter.limit("10/minute")
 async def store_vault_metadata(
     req: VaultMetadataRequest,
-    request: Request,
+    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     response: Response,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     wallet: str = Depends(require_verified_wallet),
 ):
@@ -166,7 +166,9 @@ async def store_vault_metadata(
 
         # Fire-and-forget on-chain strategy anchoring (best-effort, non-fatal)
         if req.strategy_ids:
-            asyncio.create_task(_anchor_strategies_async(req.strategy_ids))
+            asyncio.create_task(  # noqa: RUF006 — intentional fire-and-forget; anchoring is best-effort and non-fatal
+                _anchor_strategies_async(req.strategy_ids)
+            )
 
         return VaultMetadataResponse(**meta.to_dict())
     except HTTPException:

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -131,10 +131,7 @@ class ChainExecutor:
                 t0 = await pool.functions.token0().call()
 
                 # Identify USDC-side reserve (6 decimals)
-                if chain_client.to_checksum(t0) == usdc_addr:
-                    usdc_reserve = r0 / 1e6
-                else:
-                    usdc_reserve = r1 / 1e6
+                usdc_reserve = r0 / 1e6 if chain_client.to_checksum(t0) == usdc_addr else r1 / 1e6
 
                 if usdc_reserve < MIN_HEALTHY_LIQUIDITY_USDC:
                     raise InsufficientLiquidityError(
@@ -168,7 +165,7 @@ class ChainExecutor:
             norm = hexstr
         else:
             wait_arg = tx_hash
-            norm = tx_hash.hex() if not tx_hash.hex().startswith("0x") else tx_hash.hex()
+            norm = tx_hash.hex()
             norm = norm if norm.startswith("0x") else "0x" + norm
 
         receipt = await chain_client.w3.eth.wait_for_transaction_receipt(wait_arg)

--- a/backend/archimedes/services/amm_bootstrap.py
+++ b/backend/archimedes/services/amm_bootstrap.py
@@ -43,7 +43,7 @@ async def bootstrap_amm_liquidity(usdc_per_pool: float | None = None) -> dict:
             wallet_usdc = balance_raw / 1e6
             # Count empty pools
             empty_count = 0
-            for sym, addr in synth_addresses.items():
+            for _sym, addr in synth_addresses.items():
                 if not addr:
                     continue
                 try:

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -188,10 +188,10 @@ async def test_chat_post_rate_limited():
     # Enable rate limiting for this test
     app.state.limiter.enabled = True
     # Reset limiter storage so prior test state doesn't interfere
-    try:
+    import contextlib
+
+    with contextlib.suppress(Exception):
         app.state.limiter.reset()
-    except Exception:
-        pass
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             hit_429 = False

--- a/ruff.toml
+++ b/ruff.toml
@@ -70,6 +70,13 @@ ignore = [
 "backend/archimedes/scripts/*.py" = ["E402"]
 "analytics-engine/scripts/*.py" = ["E402"]
 "backend/archimedes/api/selection_bias_routes.py" = ["E402"]
+# vaults_routes defines a module logger before its import block; stockbench/adapter
+# orders interleaved stdlib + protocol imports beneath explanatory comments; chat_service
+# reads a Circle wallet env var at import time. All three are intentional load-order
+# patterns, same rationale as the entry-point files above.
+"backend/archimedes/api/vaults_routes.py" = ["E402"]
+"backend/archimedes/evaluation/stockbench/adapter.py" = ["E402"]
+"backend/archimedes/services/chat_service.py" = ["E402"]
 # Tests legitimately have unused fixture args and routinely access private members;
 # scripts often have unused argparse helpers. Tier-1 expansion 2026-05-24.
 "backend/tests/**" = ["ARG", "SLF"]


### PR DESCRIPTION
# Clear the 24 informational ruff findings repo-wide

The quality-gate **lint-report table** (the informational, `continue-on-error` one) has been flagging **24 broad-ruleset ruff errors on `main`** for a while. They don't block merge — but they post a ❌ on every PR's comment table, which triggers the CI-monitor nag and makes real regressions easy to miss. This clears the slate so the table goes green and future findings stand out.

These are all **pre-existing repo debt**, not from any recent PR. Breakdown:

### Real fixes (behavior-preserving)
| Rule | Where | Fix |
|---|---|---|
| `RUF034` useless if-else | `chain/executor.py::_confirm_receipt` | The ternary's two branches were **identical** (`tx_hash.hex()` either way) — collapsed to a plain assignment. The next line still applies the `0x` prefix. |
| `SIM108` if-else → ternary | `chain/executor.py` (USDC-reserve pick) | One-line ternary. |
| `SIM105` try/except/pass | `tests/test_security_hardening.py` | `contextlib.suppress(Exception)`. |
| `B007` unused loop var | `services/amm_bootstrap.py` | `sym` → `_sym`. |

### Intentional patterns — documented with targeted `# noqa` + reason
- `ARG001` ×2 — the `request: Request` param in two `vaults_routes` endpoints (slowapi's `@limiter.limit` inspects the param name; matches the sibling `response` param that was already noqa'd).
- `RUF006` — the fire-and-forget `asyncio.create_task(_anchor_strategies_async(...))` in `vaults_routes` (best-effort, non-fatal by design).
- `SLF001` — the deliberate private-attr set in `generation_pipeline` (regime context consumed downstream).

### 16× E402 (import-not-at-top)
Added per-file-ignores in `ruff.toml` for `vaults_routes.py`, `stockbench/adapter.py`, and `chat_service.py` — all intentional load-order patterns, **same rationale as the existing E402 ignores** (`main.py`, scripts, `selection_bias_routes.py`) already in the config.

## Verification
- `ruff check .` → **All checks passed** (was: 24 errors)
- `ruff format --check .` → clean
- **166 tests** across the touched modules (executor, vaults, security, amm, generation) pass; 0 failed.

## ⚠️ Review note — touches Chuan's lane
This edits `backend/archimedes/chain/executor.py` (on-chain integration layer). The change is behavior-preserving — `RUF034` removed a provably-dead ternary and `SIM108` is a literal if/else→ternary — but per our conventions, **flagging for Chuan's eyes** on the executor diff specifically. Everything else is backend/test/config.

No release marker (cleanup/patch). One approving review per conventions.
