### PR TITLE
[backtest] Add run_multi_backtest — N-feed engine (Phase 2 prerequisite) !minor

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -293,6 +293,66 @@ def run_pairs_backtest(
     )
 
 
+def run_multi_backtest(
+    prices_list: list[pd.DataFrame],
+    *,
+    strategy_cls: type[bt.Strategy],
+    initial_cash: float,
+    names: list[str] | None = None,
+    transaction_cost_bps: int = 10,
+    slippage_bps: int = 0,
+) -> BacktestResult:
+    """Run an N-asset (cross-sectional / portfolio) strategy in a single cerebro.
+
+    The N-feed generalization of :func:`run_pairs_backtest`. All price frames are
+    inner-joined on their common datetime index first, so every feed advances
+    together bar-for-bar — the strategy can rely on ``self.datas[i]`` for
+    ``i in range(N)`` being aligned and rank/weight across the universe each bar.
+    Metrics are computed on portfolio value, so the existing analyzer +
+    extraction path (:func:`_add_analyzers` / :func:`_extract_result`) is reused
+    unchanged, keeping metric shapes identical across single / pair / N-asset runs.
+    """
+    if not prices_list:
+        raise ValueError("prices_list is empty; need at least one price frame")
+    if names is not None and len(names) != len(prices_list):
+        raise ValueError(f"names has {len(names)} entries but prices_list has {len(prices_list)}")
+
+    feed_names = names if names is not None else [f"leg_{i}" for i in range(len(prices_list))]
+
+    # N-way index intersection: only bars present in every feed are backtested.
+    common_index = prices_list[0].index
+    for prices in prices_list[1:]:
+        common_index = common_index.intersection(prices.index)
+    if len(common_index) == 0:
+        raise ValueError("price frames share no common dates; cannot align feeds")
+
+    cerebro = bt.Cerebro(stdstats=False)
+    cerebro.broker.setcash(initial_cash)
+    cerebro.broker.setcommission(commission=transaction_cost_bps / 10_000)
+    if slippage_bps > 0:
+        cerebro.broker.set_slippage_perc(perc=slippage_bps / 10_000)
+
+    for prices, name in zip(prices_list, feed_names, strict=True):
+        aligned = prices.loc[common_index].sort_index()
+        cerebro.adddata(bt.feeds.PandasData(dataname=aligned), name=name)
+    cerebro.addstrategy(strategy_cls)
+    _add_analyzers(cerebro)
+
+    strategy = cerebro.run()[0]
+
+    bars = len(common_index)
+    return _extract_result(
+        cerebro=cerebro,
+        strategy=strategy,
+        initial_cash=initial_cash,
+        bars=bars,
+        backtest_start=common_index[0].isoformat() if bars else None,
+        backtest_end=common_index[-1].isoformat() if bars else None,
+        transaction_cost_bps=transaction_cost_bps,
+        slippage_bps=slippage_bps,
+    )
+
+
 def run_buy_and_hold(
     prices: pd.DataFrame,
     *,

--- a/analytics-engine/tests/test_multi_engine.py
+++ b/analytics-engine/tests/test_multi_engine.py
@@ -1,0 +1,117 @@
+"""Tests for the N-asset (cross-sectional / portfolio) backtest runner —
+engine.run_multi_backtest.
+
+Hermetic: all data is synthetic, no network. Validates the N-feed plumbing,
+N-way date alignment, and metric extraction shared with the single- and
+two-asset runners. Mirrors test_pairs_engine.py.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.engine import BacktestResult, run_multi_backtest
+
+
+def _synthetic_prices(
+    periods: int, start: str = "2020-01-01", base: float = 100.0, drift: float = 0.1, phase: float = 0.0
+) -> pd.DataFrame:
+    idx = pd.date_range(start, periods=periods, freq="D")
+    closes = [base + drift * i + 5.0 * math.sin(i / 7.0 + phase) for i in range(periods)]
+    return pd.DataFrame(
+        {
+            "Open": [c - 0.5 for c in closes],
+            "High": [c + 1.0 for c in closes],
+            "Low": [c - 1.0 for c in closes],
+            "Close": closes,
+            "Volume": [1_000] * periods,
+        },
+        index=idx,
+    )
+
+
+class _EqualWeightStrategy(bt.Strategy):
+    """Minimal N-feed strategy: equal-weight all feeds on the first eligible bar."""
+
+    def next(self) -> None:
+        if len(self) != 5:
+            return
+        weight = 0.9 / len(self.datas)
+        equity = float(self.broker.getvalue())
+        for data in self.datas:
+            size = int((equity * weight) // float(data.close[0]))
+            if size > 0:
+                self.order_target_size(data=data, target=size)
+
+
+def test_run_multi_backtest_returns_result() -> None:
+    frames = [_synthetic_prices(40, base=b, drift=0.05, phase=i) for i, b in enumerate([100.0, 50.0, 75.0, 120.0])]
+    result = run_multi_backtest(frames, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0)
+
+    assert isinstance(result, BacktestResult)
+    assert result.final_value > 0
+    assert result.bars == 40
+    assert result.look_ahead_audit_passed is True
+    assert isinstance(result.daily_returns, list)
+    assert len(result.daily_returns) > 0
+
+
+def test_run_multi_backtest_aligns_on_common_dates() -> None:
+    # Feeds start on staggered dates → only the fully-overlapping window is backtested.
+    frames = [
+        _synthetic_prices(40, start="2020-01-01", base=100.0),
+        _synthetic_prices(40, start="2020-01-06", base=50.0),
+        _synthetic_prices(40, start="2020-01-11", base=75.0),
+    ]
+    result = run_multi_backtest(frames, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0)
+
+    common = frames[0].index
+    for f in frames[1:]:
+        common = common.intersection(f.index)
+    assert result.bars == len(common)
+    # 40 bars, latest start is +10 days → 30 overlapping bars.
+    assert result.bars == 30
+
+
+def test_run_multi_backtest_raises_on_disjoint_dates() -> None:
+    frames = [
+        _synthetic_prices(20, start="2020-01-01"),
+        _synthetic_prices(20, start="2020-01-01", base=50.0),
+        _synthetic_prices(20, start="2022-01-01", base=75.0),  # disjoint from the others
+    ]
+    with pytest.raises(ValueError, match="no common dates"):
+        run_multi_backtest(frames, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0)
+
+
+def test_run_multi_backtest_raises_on_empty_list() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        run_multi_backtest([], strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0)
+
+
+def test_run_multi_backtest_raises_on_names_length_mismatch() -> None:
+    frames = [_synthetic_prices(20), _synthetic_prices(20, base=50.0)]
+    with pytest.raises(ValueError, match="names has"):
+        run_multi_backtest(frames, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0, names=["only_one"])
+
+
+def test_run_multi_backtest_honors_named_feeds() -> None:
+    frames = [_synthetic_prices(30, base=100.0), _synthetic_prices(30, base=50.0)]
+    # Named feeds must run and produce a valid result (names are passthrough labels).
+    result = run_multi_backtest(frames, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0, names=["SPY", "GLD"])
+    assert isinstance(result, BacktestResult)
+    assert result.bars == 30
+
+
+def test_run_multi_backtest_matches_pairs_for_two_feeds() -> None:
+    """For N=2 the multi runner must agree with run_pairs_backtest (same plumbing)."""
+    from archimedes_analytics_engine.engine import run_pairs_backtest
+
+    a = _synthetic_prices(60, base=100.0, drift=0.1)
+    b = _synthetic_prices(60, base=80.0, drift=0.12, phase=1.0)
+    multi = run_multi_backtest([a, b], strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0)
+    pair = run_pairs_backtest(a, b, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0)
+    assert multi.bars == pair.bars
+    assert multi.final_value == pytest.approx(pair.final_value)


### PR DESCRIPTION
> **Stacked PR.** Base is `onder/second-wave-phase1-coint-kalman` ([#532](https://github.com/hackagora/archimedes-arcadia/pull/532)). Review/merge the earlier phase PRs first; GitHub will retarget this to `main`. The diff here is only the engine work.

## What this adds (in plain terms)

A new engine function, **`run_multi_backtest`**, that can backtest a strategy across **any number of assets at once** (not just one, and not just a pair). Today the engine can run:
- **1 asset** → `run_backtest` (e.g. SMA200 timing)
- **2 assets** → `run_pairs_backtest` (e.g. the pairs strategies)
- **N assets** → `run_multi_backtest` ← **new**

This is the **prerequisite for Phase 2** of the [second-wave roadmap](https://github.com/hackagora/archimedes-arcadia/blob/main/docs/specs/second-wave-multi-asset-strategies.md). Strategies like *cross-sectional momentum* ("rank all 5 assets, buy the winners, short the losers") or *risk parity* ("weight each asset by its volatility") fundamentally need to see the whole universe on each day — which is exactly what this unlocks. **No strategies ship in this PR** — it's pure engine plumbing so the change is small and review-isolated (it touches the shared runner).

## Why it's low-risk
It is a **line-for-line generalization** of the existing two-feed `run_pairs_backtest`. The only differences are: it loops over N price frames instead of exactly 2, and it intersects N date indices instead of 2. Crucially it **reuses the exact same metric-extraction path** (`_add_analyzers` + `_extract_result`) as the single- and two-asset runners, so Sharpe/DSR/drawdown/etc. come out in an identical shape regardless of asset count. There's even a test asserting that for N=2 it produces the *same result* as `run_pairs_backtest`.

## What it does, precisely (for reviewers)
- Inner-joins all N price frames on their common dates (a bar is only backtested if **every** feed has data that day).
- Adds N `PandasData` feeds; the strategy accesses `self.datas[i]` for `i in range(N)`, all bar-aligned.
- Optional per-feed `names` (passthrough labels).
- Raises a clear `ValueError` on: empty input, feeds with no overlapping dates, or a `names`/frames length mismatch.

## Tests — `test_multi_engine.py` (hermetic, mirrors `test_pairs_engine.py`)
- Runs a 4-feed equal-weight strategy end-to-end ✔
- N-way date alignment trims to the overlapping window ✔
- Raises on disjoint dates ✔, empty list ✔, names-length mismatch ✔
- N=2 agrees with `run_pairs_backtest` ✔

## Verification (all green locally)
```
cd analytics-engine && uv run pytest          # 42 passed (7 new)
ruff format --check . && ruff check --select E9,F63,F7,F40 .   # clean
```

## Out of scope / cross-lane note
Quant/backtest-lane (Önder). Touches the shared backtest runner only — no contract, infra, or API changes. Best reviewer: **Dan / Önder** (backtest-math lane).
