### PR TITLE
[backtest] Add transaction-cost + turnover model to the analytics engine !minor

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/__init__.py
+++ b/analytics-engine/src/archimedes_analytics_engine/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "cli",
+    "costs",
     "engine",
     "instruments",
 ]

--- a/analytics-engine/src/archimedes_analytics_engine/costs.py
+++ b/analytics-engine/src/archimedes_analytics_engine/costs.py
@@ -1,0 +1,155 @@
+"""Transaction-cost + turnover model for the backtest engine.
+
+Motivation (quant-roadmap Priority 2.2): execution realism is decisive — the
+Kalman pairs strategy cost-bled to −1.47 Sharpe on 1174 trades. This module
+provides the three reusable pieces every strategy can share:
+
+1. :class:`CostModel` — per-side cost assumptions in bps, with per-symbol
+   overrides, applied to the backtrader broker per feed.
+2. :class:`TurnoverAnalyzer` — measures what was actually traded (two-way
+   notional, commissions paid, per-bar commission series) so the engine can
+   report turnover, cost drag, gross-vs-net Sharpe, and break-even cost.
+3. :func:`no_trade_band` / :func:`position_weight` — a turnover penalty
+   strategies opt into: suppress rebalances smaller than a weight band.
+
+Conventions (documented once, used everywhere):
+
+- **Costs are per side**: a cost of 10 bps charges 0.10% of traded notional on
+  the buy AND 0.10% on the sell. This matches the legacy flat
+  ``transaction_cost_bps`` behaviour (``broker.setcommission`` percent mode).
+- **Turnover is one-way and annualized**: ``(two_way_notional / 2) /
+  mean(equity) / years``. A strategy that replaces its whole book once a year
+  has turnover 1.0.
+- **"Gross" means commissions added back, slippage NOT added back** —
+  slippage is embedded in the execution price and cannot be recovered from
+  broker accounting. Gross metrics are therefore a *lower bound* on the true
+  frictionless performance when slippage_bps > 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import backtrader as bt
+
+
+@dataclass(frozen=True)
+class CostModel:
+    """Per-side transaction-cost assumptions in basis points.
+
+    ``default_bps`` applies to every feed unless overridden in ``per_symbol``
+    (keyed by the feed name passed to the engine runners, e.g. ``"SPY"``).
+    ``slippage_bps`` is broker-global (backtrader cannot apply per-feed
+    slippage) and is applied to execution prices, not charged as commission.
+    """
+
+    default_bps: float = 10.0
+    slippage_bps: float = 0.0
+    per_symbol: dict[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.default_bps < 0:
+            raise ValueError(f"default_bps must be >= 0, got {self.default_bps}")
+        if self.slippage_bps < 0:
+            raise ValueError(f"slippage_bps must be >= 0, got {self.slippage_bps}")
+        for symbol, bps in self.per_symbol.items():
+            if bps < 0:
+                raise ValueError(f"per_symbol[{symbol!r}] must be >= 0, got {bps}")
+
+    def per_side_bps(self, symbol: str | None = None) -> float:
+        """Effective per-side cost in bps for a feed name (default if unknown)."""
+        if symbol is not None and symbol in self.per_symbol:
+            return self.per_symbol[symbol]
+        return self.default_bps
+
+    def apply_to_broker(self, cerebro: bt.Cerebro, feed_names: list[str]) -> None:
+        """Install this cost model on a cerebro broker.
+
+        Sets the default percent commission for all feeds, then a per-feed
+        override for every name present in ``per_symbol``. Names in
+        ``per_symbol`` that are not in ``feed_names`` are ignored (the model
+        can carry a universe-wide table; only active feeds matter).
+        """
+        cerebro.broker.setcommission(commission=self.default_bps / 10_000)
+        for name in feed_names:
+            if name in self.per_symbol:
+                cerebro.broker.setcommission(commission=self.per_symbol[name] / 10_000, name=name)
+        if self.slippage_bps > 0:
+            cerebro.broker.set_slippage_perc(perc=self.slippage_bps / 10_000)
+
+
+class TurnoverAnalyzer(bt.Analyzer):
+    """Tracks traded notional and commissions actually charged by the broker.
+
+    Output (``get_analysis()``):
+
+    - ``traded_notional``: total two-way traded notional (|size| × price summed
+      over every completed execution).
+    - ``commission_paid``: total commission the broker charged.
+    - ``bar_commissions``: per-bar commission list, positionally aligned with
+      the TimeReturn analyzer's per-bar returns (both fire once per
+      post-warm-up bar), so the engine can reconstruct gross returns.
+    """
+
+    def start(self) -> None:
+        self.traded_notional = 0.0
+        self.commission_paid = 0.0
+        self.bar_commissions: list[float] = []
+        self._current_bar_comm = 0.0
+
+    def notify_order(self, order: bt.Order) -> None:
+        # Executions are notified before the analyzer's next() for the same
+        # bar, so accumulating here and flushing in next() lands each
+        # commission on the bar whose TimeReturn already reflects it.
+        if order.status != order.Completed:
+            return
+        executed = order.executed
+        self.traded_notional += abs(float(executed.size)) * float(executed.price)
+        self.commission_paid += float(executed.comm)
+        self._current_bar_comm += float(executed.comm)
+
+    def next(self) -> None:
+        self.bar_commissions.append(self._current_bar_comm)
+        self._current_bar_comm = 0.0
+
+    def stop(self) -> None:
+        # Executions notified after the last next() (none expected, but be safe).
+        if self._current_bar_comm > 0 and self.bar_commissions:
+            self.bar_commissions[-1] += self._current_bar_comm
+            self._current_bar_comm = 0.0
+
+    def get_analysis(self) -> dict:
+        return {
+            "traded_notional": self.traded_notional,
+            "commission_paid": self.commission_paid,
+            "bar_commissions": list(self.bar_commissions),
+        }
+
+
+def position_weight(strategy: bt.Strategy, data: bt.LineSeries) -> float:
+    """Current portfolio weight of one feed (0.0 when flat or equity is 0)."""
+    total = float(strategy.broker.getvalue())
+    if total <= 0:
+        return 0.0
+    return float(strategy.broker.getvalue(datas=[data])) / total
+
+
+def no_trade_band(current_weight: float, target_weight: float, band: float = 0.005) -> float:
+    """Turnover penalty: suppress rebalances smaller than ``band`` (weight units).
+
+    Returns ``target_weight`` when the adjustment is at least ``band`` wide,
+    otherwise ``current_weight`` (i.e. don't trade). With the default 0.005, a
+    drift from 25.0% to 25.4% is left alone; 25.0% to 26.0% rebalances.
+
+    Strategies use it as a drop-in filter before ``order_target_percent``::
+
+        w_now = position_weight(self, d)
+        w_target = no_trade_band(w_now, w_model, band=0.01)
+        if w_target != w_now:
+            self.order_target_percent(data=d, target=w_target)
+    """
+    if band < 0:
+        raise ValueError(f"band must be >= 0, got {band}")
+    if abs(target_weight - current_weight) >= band:
+        return target_weight
+    return current_weight

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -8,6 +8,8 @@ from typing import Any
 import backtrader as bt
 import pandas as pd
 
+from archimedes_analytics_engine.costs import CostModel, TurnoverAnalyzer
+
 ANNUALIZATION = 252
 RF_ANNUAL = 0.05  # 5% annual risk-free rate
 RF_DAILY = RF_ANNUAL / ANNUALIZATION
@@ -35,6 +37,13 @@ class BacktestResult:
     daily_returns: list[float] = field(default_factory=list)
     transaction_cost_bps: int = 10
     slippage_bps: int = 0
+    # Turnover / cost-realism metrics (see costs.py for conventions).
+    turnover_annualized: float | None = None  # one-way, x/year
+    traded_notional: float = 0.0  # two-way, total over the backtest
+    total_commission_paid: float = 0.0
+    cost_drag_annual_pct: float | None = None  # annualized commission as % of avg equity
+    break_even_cost_bps: float | None = None  # per-side bps at which gross CAGR is consumed
+    gross_sharpe_ratio: float | None = None  # Sharpe with commissions added back (not slippage)
     walk_forward_split: float | None = None
     out_of_sample_sharpe: float | None = None
     look_ahead_audit_passed: bool = False
@@ -119,10 +128,109 @@ def _trade_stats(
     return int(total_closed), float(win_rate), profit_factor, avg_len_f
 
 
+def _sharpe_bt_convention(daily_returns: list[float]) -> float | None:
+    """Sharpe under the same convention as the bt.analyzers.SharpeRatio config in
+    _add_analyzers (annualized, geometric daily risk-free, population stddev), so
+    gross-vs-net Sharpe comparisons are apples-to-apples (zero-cost => equal)."""
+    if len(daily_returns) < 2:
+        return None
+    rf_daily_geo = (1.0 + RF_ANNUAL) ** (1.0 / ANNUALIZATION) - 1.0
+    excess = [r - rf_daily_geo for r in daily_returns]
+    dev = statistics.pstdev(excess)
+    if dev == 0:
+        return None
+    return (statistics.fmean(excess) / dev) * math.sqrt(ANNUALIZATION)
+
+
+def _cost_metrics(
+    *,
+    turnover_analysis: dict,
+    daily_returns: list[float],
+    equity_curve: list[float],
+    bars: int,
+) -> dict[str, float | None]:
+    """Derive turnover / cost-drag / break-even / gross-Sharpe from the
+    TurnoverAnalyzer output. Conventions documented in costs.py."""
+    traded_notional = float(turnover_analysis.get("traded_notional", 0.0))
+    commission_paid = float(turnover_analysis.get("commission_paid", 0.0))
+    bar_commissions = turnover_analysis.get("bar_commissions", [])
+
+    metrics: dict[str, float | None] = {
+        "turnover_annualized": None,
+        "traded_notional": traded_notional,
+        "total_commission_paid": commission_paid,
+        "cost_drag_annual_pct": None,
+        "break_even_cost_bps": None,
+        "gross_sharpe_ratio": None,
+    }
+
+    avg_equity = statistics.fmean(equity_curve) if equity_curve else 0.0
+    years = bars / ANNUALIZATION
+    if avg_equity <= 0 or years <= 0:
+        return metrics
+
+    turnover_annualized = (traded_notional / 2.0) / avg_equity / years
+    metrics["turnover_annualized"] = turnover_annualized
+    metrics["cost_drag_annual_pct"] = (commission_paid / avg_equity / years) * 100.0
+
+    # Gross (commissions-added-back) return series. Positional alignment with
+    # daily_returns holds because both analyzers fire once per bar; if it ever
+    # doesn't, report None rather than misreport.
+    if len(bar_commissions) != len(daily_returns) or not daily_returns:
+        return metrics
+
+    gross_returns: list[float] = []
+    for i, net_r in enumerate(daily_returns):
+        prev_equity = equity_curve[i]  # equity_curve[0] is initial cash
+        if prev_equity <= 0:
+            return metrics
+        gross_returns.append(net_r + float(bar_commissions[i]) / prev_equity)
+
+    metrics["gross_sharpe_ratio"] = _sharpe_bt_convention(gross_returns)
+
+    gross_growth = 1.0
+    for g in gross_returns:
+        gross_growth *= 1.0 + g
+    if gross_growth > 0:
+        gross_cagr = gross_growth ** (1.0 / years) - 1.0
+        if turnover_annualized > 0:
+            # Annual cost at per-side cost c = 2 * one-way turnover * c.
+            metrics["break_even_cost_bps"] = max(gross_cagr / (2.0 * turnover_annualized) * 10_000.0, 0.0)
+
+    return metrics
+
+
 def _lookahead_audit_passed(cerebro: bt.Cerebro) -> bool:
     coc = getattr(cerebro.broker.p, "coc", False)
     coo = getattr(cerebro.broker.p, "coo", False)
     return not coc and not coo
+
+
+def _configure_broker(
+    cerebro: bt.Cerebro,
+    *,
+    initial_cash: float,
+    transaction_cost_bps: int,
+    slippage_bps: int,
+    cost_model: CostModel | None,
+    feed_names: list[str],
+) -> tuple[int, int]:
+    """Install cash + costs on the broker; shared by all runners.
+
+    When ``cost_model`` is given it supersedes the flat ``transaction_cost_bps``
+    / ``slippage_bps`` arguments (per-feed overrides included). Returns the
+    (transaction_cost_bps, slippage_bps) actually recorded on the result —
+    the model's defaults when a model is used; per-symbol detail stays in the
+    model, not the summary fields.
+    """
+    cerebro.broker.setcash(initial_cash)
+    if cost_model is not None:
+        cost_model.apply_to_broker(cerebro, feed_names)
+        return int(round(cost_model.default_bps)), int(round(cost_model.slippage_bps))
+    cerebro.broker.setcommission(commission=transaction_cost_bps / 10_000)
+    if slippage_bps > 0:
+        cerebro.broker.set_slippage_perc(perc=slippage_bps / 10_000)
+    return transaction_cost_bps, slippage_bps
 
 
 def run_backtest(
@@ -132,12 +240,17 @@ def run_backtest(
     initial_cash: float,
     transaction_cost_bps: int = 10,
     slippage_bps: int = 0,
+    cost_model: CostModel | None = None,
 ) -> BacktestResult:
     cerebro = bt.Cerebro(stdstats=False)
-    cerebro.broker.setcash(initial_cash)
-    cerebro.broker.setcommission(commission=transaction_cost_bps / 10_000)
-    if slippage_bps > 0:
-        cerebro.broker.set_slippage_perc(perc=slippage_bps / 10_000)
+    transaction_cost_bps, slippage_bps = _configure_broker(
+        cerebro,
+        initial_cash=initial_cash,
+        transaction_cost_bps=transaction_cost_bps,
+        slippage_bps=slippage_bps,
+        cost_model=cost_model,
+        feed_names=[],
+    )
 
     feed = bt.feeds.PandasData(dataname=prices)
     cerebro.adddata(feed)
@@ -204,6 +317,13 @@ def _extract_result(
 
     look_ahead_passed = _lookahead_audit_passed(cerebro)
 
+    cost_metrics = _cost_metrics(
+        turnover_analysis=strategy.analyzers.turnover.get_analysis(),
+        daily_returns=daily_returns,
+        equity_curve=equity_curve,
+        bars=bars,
+    )
+
     return BacktestResult(
         final_value=final_value,
         total_return_pct=total_return_pct,
@@ -222,6 +342,12 @@ def _extract_result(
         daily_returns=daily_returns,
         transaction_cost_bps=transaction_cost_bps,
         slippage_bps=slippage_bps,
+        turnover_annualized=cost_metrics["turnover_annualized"],
+        traded_notional=cost_metrics["traded_notional"],
+        total_commission_paid=cost_metrics["total_commission_paid"],
+        cost_drag_annual_pct=cost_metrics["cost_drag_annual_pct"],
+        break_even_cost_bps=cost_metrics["break_even_cost_bps"],
+        gross_sharpe_ratio=cost_metrics["gross_sharpe_ratio"],
         look_ahead_audit_passed=look_ahead_passed,
         bars=bars,
         backtest_start=backtest_start,
@@ -241,6 +367,7 @@ def _add_analyzers(cerebro: bt.Cerebro) -> None:
     )
     cerebro.addanalyzer(bt.analyzers.DrawDown, _name="dd")
     cerebro.addanalyzer(bt.analyzers.TradeAnalyzer, _name="trades")
+    cerebro.addanalyzer(TurnoverAnalyzer, _name="turnover")
 
 
 def run_pairs_backtest(
@@ -253,6 +380,7 @@ def run_pairs_backtest(
     name_b: str = "leg_b",
     transaction_cost_bps: int = 10,
     slippage_bps: int = 0,
+    cost_model: CostModel | None = None,
 ) -> BacktestResult:
     """Run a two-asset (pairs / relative-value) strategy in a single cerebro.
 
@@ -268,10 +396,14 @@ def run_pairs_backtest(
     aligned_b = prices_b.loc[common_index].sort_index()
 
     cerebro = bt.Cerebro(stdstats=False)
-    cerebro.broker.setcash(initial_cash)
-    cerebro.broker.setcommission(commission=transaction_cost_bps / 10_000)
-    if slippage_bps > 0:
-        cerebro.broker.set_slippage_perc(perc=slippage_bps / 10_000)
+    transaction_cost_bps, slippage_bps = _configure_broker(
+        cerebro,
+        initial_cash=initial_cash,
+        transaction_cost_bps=transaction_cost_bps,
+        slippage_bps=slippage_bps,
+        cost_model=cost_model,
+        feed_names=[name_a, name_b],
+    )
 
     cerebro.adddata(bt.feeds.PandasData(dataname=aligned_a), name=name_a)
     cerebro.adddata(bt.feeds.PandasData(dataname=aligned_b), name=name_b)
@@ -301,6 +433,7 @@ def run_multi_backtest(
     names: list[str] | None = None,
     transaction_cost_bps: int = 10,
     slippage_bps: int = 0,
+    cost_model: CostModel | None = None,
 ) -> BacktestResult:
     """Run an N-asset (cross-sectional / portfolio) strategy in a single cerebro.
 
@@ -327,10 +460,14 @@ def run_multi_backtest(
         raise ValueError("price frames share no common dates; cannot align feeds")
 
     cerebro = bt.Cerebro(stdstats=False)
-    cerebro.broker.setcash(initial_cash)
-    cerebro.broker.setcommission(commission=transaction_cost_bps / 10_000)
-    if slippage_bps > 0:
-        cerebro.broker.set_slippage_perc(perc=slippage_bps / 10_000)
+    transaction_cost_bps, slippage_bps = _configure_broker(
+        cerebro,
+        initial_cash=initial_cash,
+        transaction_cost_bps=transaction_cost_bps,
+        slippage_bps=slippage_bps,
+        cost_model=cost_model,
+        feed_names=feed_names,
+    )
 
     for prices, name in zip(prices_list, feed_names, strict=True):
         aligned = prices.loc[common_index].sort_index()

--- a/analytics-engine/tests/test_costs.py
+++ b/analytics-engine/tests/test_costs.py
@@ -1,0 +1,270 @@
+"""Tests for the transaction-cost + turnover model (costs.py + engine wiring).
+
+Hermetic: all data is synthetic, no network. Validates the cost accounting
+against hand-computed expectations, the gross-vs-net invariants, per-symbol
+cost overrides, and the no-trade-band turnover penalty.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.costs import CostModel, no_trade_band, position_weight
+from archimedes_analytics_engine.engine import run_backtest, run_multi_backtest
+
+
+def _flat_prices(periods: int, price: float = 100.0, start: str = "2020-01-01") -> pd.DataFrame:
+    idx = pd.date_range(start, periods=periods, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": [price] * periods,
+            "High": [price] * periods,
+            "Low": [price] * periods,
+            "Close": [price] * periods,
+            "Volume": [1_000] * periods,
+        },
+        index=idx,
+    )
+
+
+def _wavy_prices(
+    periods: int, start: str = "2020-01-01", base: float = 100.0, drift: float = 0.1, phase: float = 0.0
+) -> pd.DataFrame:
+    idx = pd.date_range(start, periods=periods, freq="D")
+    closes = [base + drift * i + 5.0 * math.sin(i / 7.0 + phase) for i in range(periods)]
+    return pd.DataFrame(
+        {
+            "Open": closes,  # Open == Close so executions happen at known prices
+            "High": [c + 1.0 for c in closes],
+            "Low": [c - 1.0 for c in closes],
+            "Close": closes,
+            "Volume": [1_000] * periods,
+        },
+        index=idx,
+    )
+
+
+class _OneRoundTrip(bt.Strategy):
+    """Buy 50 shares on bar 2, sell them on bar 10. Two known executions."""
+
+    def next(self) -> None:
+        if len(self) == 2:
+            self.buy(size=50)
+        elif len(self) == 10:
+            self.sell(size=50)
+
+
+class _TradeEveryBar(bt.Strategy):
+    """Alternate between 30% and 70% exposure every bar — deliberately churny."""
+
+    def next(self) -> None:
+        target = 0.3 if len(self) % 2 == 0 else 0.7
+        self.order_target_percent(target=target)
+
+
+class _SmaFlipper(bt.Strategy):
+    """Has a real warm-up period (10-bar SMA) and trades on crossings."""
+
+    def __init__(self) -> None:
+        self.sma = bt.indicators.SMA(self.data.close, period=10)
+
+    def next(self) -> None:
+        if self.data.close[0] > self.sma[0] and not self.position:
+            self.order_target_percent(target=0.9)
+        elif self.data.close[0] < self.sma[0] and self.position:
+            self.order_target_percent(target=0.0)
+
+
+class _BandedRebalancer(bt.Strategy):
+    """Chases a noisy target weight (0.500 <-> 0.504) through no_trade_band."""
+
+    params = (("band", 0.0),)
+
+    def next(self) -> None:
+        target = 0.500 if len(self) % 2 == 0 else 0.504
+        current = position_weight(self, self.data)
+        filtered = no_trade_band(current, target, band=self.params.band)
+        if filtered != current:
+            self.order_target_percent(target=filtered)
+
+
+class _TightBandedRebalancer(_BandedRebalancer):
+    params = (("band", 0.02),)
+
+
+# ── CostModel unit behaviour ──────────────────────────────────────────────────
+
+
+def test_cost_model_per_symbol_resolution() -> None:
+    model = CostModel(default_bps=10.0, per_symbol={"EEM": 25.0})
+    assert model.per_side_bps("EEM") == 25.0
+    assert model.per_side_bps("SPY") == 10.0
+    assert model.per_side_bps() == 10.0
+
+
+def test_cost_model_rejects_negative_bps() -> None:
+    with pytest.raises(ValueError, match="default_bps"):
+        CostModel(default_bps=-1.0)
+    with pytest.raises(ValueError, match="slippage_bps"):
+        CostModel(slippage_bps=-1.0)
+    with pytest.raises(ValueError, match="per_symbol"):
+        CostModel(per_symbol={"SPY": -5.0})
+
+
+def test_no_trade_band_scalar_behaviour() -> None:
+    assert no_trade_band(0.250, 0.254, band=0.005) == 0.250  # inside band: hold
+    assert no_trade_band(0.250, 0.260, band=0.005) == 0.260  # outside band: trade
+    assert no_trade_band(0.250, 0.260, band=0.0) == 0.260  # zero band: always trade
+    with pytest.raises(ValueError, match="band"):
+        no_trade_band(0.25, 0.26, band=-0.1)
+
+
+# ── Turnover accounting (hand-computed expectations) ─────────────────────────
+
+
+def test_turnover_accounting_one_round_trip() -> None:
+    # Flat prices at 100: both executions at exactly 100. Two-way notional =
+    # 50 shares x 100 x 2 sides = 10_000; commission at 10 bps/side = 10.0.
+    result = run_backtest(
+        _flat_prices(20),
+        strategy_cls=_OneRoundTrip,
+        initial_cash=100_000.0,
+        transaction_cost_bps=10,
+    )
+
+    assert result.traded_notional == pytest.approx(10_000.0)
+    assert result.total_commission_paid == pytest.approx(10.0)
+
+    # One-way annualized turnover = (10_000 / 2) / avg_equity / (20/252).
+    years = 20 / 252
+    expected_turnover = (10_000.0 / 2.0) / 100_000.0 / years
+    assert result.turnover_annualized == pytest.approx(expected_turnover, rel=1e-3)
+
+    # Flat prices: the only P&L is commission, so gross return is ~0 and the
+    # break-even cost (the per-side bps a zero-alpha strategy can afford) is ~0.
+    assert result.break_even_cost_bps == pytest.approx(0.0, abs=0.5)
+
+
+def test_no_trades_means_zero_turnover() -> None:
+    class _Sleeper(bt.Strategy):
+        def next(self) -> None:
+            pass
+
+    result = run_backtest(_wavy_prices(30), strategy_cls=_Sleeper, initial_cash=100_000.0)
+    assert result.traded_notional == 0.0
+    assert result.total_commission_paid == 0.0
+    assert result.turnover_annualized == 0.0
+    assert result.cost_drag_annual_pct == 0.0
+    assert result.break_even_cost_bps is None  # no turnover -> undefined
+
+
+# ── Gross-vs-net invariants ───────────────────────────────────────────────────
+
+
+def test_zero_cost_gross_sharpe_matches_net() -> None:
+    result = run_backtest(
+        _wavy_prices(120),
+        strategy_cls=_TradeEveryBar,
+        initial_cash=100_000.0,
+        transaction_cost_bps=0,
+    )
+    assert result.total_commission_paid == 0.0
+    assert result.sharpe_ratio is not None
+    assert result.gross_sharpe_ratio is not None
+    # Zero commissions: gross return series == net return series, and the
+    # gross Sharpe replicates the bt.analyzers.SharpeRatio convention exactly.
+    assert result.gross_sharpe_ratio == pytest.approx(result.sharpe_ratio, rel=1e-6)
+
+
+def test_costs_only_hurt() -> None:
+    free = run_backtest(_wavy_prices(120), strategy_cls=_TradeEveryBar, initial_cash=100_000.0, transaction_cost_bps=0)
+    costly = run_backtest(
+        _wavy_prices(120), strategy_cls=_TradeEveryBar, initial_cash=100_000.0, transaction_cost_bps=50
+    )
+    assert costly.final_value < free.final_value
+    assert costly.total_commission_paid > 0
+    assert costly.cost_drag_annual_pct is not None and costly.cost_drag_annual_pct > 0
+    assert costly.gross_sharpe_ratio is not None and costly.sharpe_ratio is not None
+    assert costly.gross_sharpe_ratio > costly.sharpe_ratio
+
+
+def test_gross_metrics_survive_strategy_warm_up_period() -> None:
+    # _SmaFlipper has a 10-bar minimum period; the per-bar commission series
+    # must stay positionally aligned with the daily-return series regardless.
+    result = run_backtest(
+        _wavy_prices(150),
+        strategy_cls=_SmaFlipper,
+        initial_cash=100_000.0,
+        transaction_cost_bps=10,
+    )
+    assert result.total_trades > 0
+    assert result.total_commission_paid > 0
+    assert result.gross_sharpe_ratio is not None
+    assert result.turnover_annualized is not None and result.turnover_annualized > 0
+
+
+# ── CostModel through the runners ─────────────────────────────────────────────
+
+
+def test_cost_model_flat_default_matches_legacy_bps() -> None:
+    frames = [_wavy_prices(60, base=100.0), _wavy_prices(60, base=80.0, phase=1.0)]
+
+    class _EqualWeight(bt.Strategy):
+        def next(self) -> None:
+            if len(self) != 3:
+                return
+            for d in self.datas:
+                self.order_target_percent(data=d, target=0.45)
+
+    legacy = run_multi_backtest(frames, strategy_cls=_EqualWeight, initial_cash=100_000.0, transaction_cost_bps=10)
+    modeled = run_multi_backtest(
+        frames,
+        strategy_cls=_EqualWeight,
+        initial_cash=100_000.0,
+        names=["SPY", "GLD"],
+        cost_model=CostModel(default_bps=10.0),
+    )
+    assert modeled.final_value == pytest.approx(legacy.final_value)
+    assert modeled.transaction_cost_bps == 10
+
+
+def test_cost_model_per_symbol_override_charges_more() -> None:
+    frames = [_wavy_prices(60, base=100.0), _wavy_prices(60, base=80.0, phase=1.0)]
+
+    class _EqualWeight(bt.Strategy):
+        def next(self) -> None:
+            if len(self) != 3:
+                return
+            for d in self.datas:
+                self.order_target_percent(data=d, target=0.45)
+
+    cheap = run_multi_backtest(
+        frames,
+        strategy_cls=_EqualWeight,
+        initial_cash=100_000.0,
+        names=["SPY", "EEM"],
+        cost_model=CostModel(default_bps=10.0),
+    )
+    expensive = run_multi_backtest(
+        frames,
+        strategy_cls=_EqualWeight,
+        initial_cash=100_000.0,
+        names=["SPY", "EEM"],
+        cost_model=CostModel(default_bps=10.0, per_symbol={"EEM": 200.0}),
+    )
+    assert expensive.total_commission_paid > cheap.total_commission_paid
+    assert expensive.final_value < cheap.final_value
+
+
+# ── Turnover penalty in a live strategy ───────────────────────────────────────
+
+
+def test_no_trade_band_reduces_turnover_in_strategy() -> None:
+    prices = _wavy_prices(80)
+    unbanded = run_backtest(prices, strategy_cls=_BandedRebalancer, initial_cash=100_000.0)
+    banded = run_backtest(prices, strategy_cls=_TightBandedRebalancer, initial_cash=100_000.0)
+    assert banded.traded_notional < unbanded.traded_notional
+    assert banded.total_commission_paid < unbanded.total_commission_paid

--- a/docs/specs/transaction-cost-turnover-model.md
+++ b/docs/specs/transaction-cost-turnover-model.md
@@ -1,0 +1,91 @@
+# Transaction-cost + turnover model (analytics-engine)
+
+> **Status:** Shipped 2026-06-11 (third wave, item 1 of
+> [`third-wave-handover.md`](third-wave-handover.md) §2 / Priority 2.2 of
+> [`quant-roadmap.md`](quant-roadmap.md)). Author: Önder (quant lane).
+> Code: `analytics-engine/src/archimedes_analytics_engine/costs.py` + wiring in
+> `engine.py`. Tests: `analytics-engine/tests/test_costs.py`.
+
+## Why
+
+The Kalman pairs strategy cost-bled to −1.47 Sharpe on 1174 trades — execution
+realism is decisive, and until now the engine reported nothing about *how much*
+of a strategy's edge costs consume. This model makes cost sensitivity a
+first-class, reported quantity so re-tests of the 20 `CANDIDATE`s (and every
+future strategy) are credible.
+
+## What it adds
+
+### 1. `CostModel` — per-side costs in bps, per-symbol overrides
+
+```python
+from archimedes_analytics_engine.costs import CostModel
+
+model = CostModel(default_bps=10.0, slippage_bps=5.0, per_symbol={"EEM": 25.0})
+run_multi_backtest(frames, names=["SPY", "EEM"], cost_model=model, ...)
+```
+
+All three runners (`run_backtest`, `run_pairs_backtest`, `run_multi_backtest`)
+accept an optional `cost_model=`. When given, it supersedes the flat
+`transaction_cost_bps` / `slippage_bps` arguments; per-symbol overrides are
+matched against the feed names. When omitted, behaviour is byte-identical to
+before (flat bps) — fully backward compatible.
+
+### 2. Turnover + cost metrics on every `BacktestResult`
+
+| Field | Definition |
+| --- | --- |
+| `turnover_annualized` | One-way annualized turnover: `(two_way_notional / 2) / mean(equity) / years`. A strategy replacing its whole book once a year scores 1.0. |
+| `traded_notional` | Total two-way traded notional over the backtest (sum of \|size\| × execution price). |
+| `total_commission_paid` | Commission the broker actually charged. |
+| `cost_drag_annual_pct` | Annualized commission as % of average equity — the headline "how much did costs eat" number. |
+| `break_even_cost_bps` | The per-side cost level at which the *gross* CAGR is fully consumed: `gross_cagr / (2 × one-way turnover) × 10⁴`. If a strategy's break-even is below its realistic cost, the alpha is not implementable — the Kalman failure mode, now quantified. Floored at 0; `None` when there is no turnover. |
+| `gross_sharpe_ratio` | Sharpe with commissions added back to the return series, computed under the *same convention* as the net `sharpe_ratio` (bt SharpeRatio: geometric daily risk-free at 5%, population stddev, √252 annualization) so gross-vs-net is apples-to-apples. |
+
+Measurement is done by a `TurnoverAnalyzer` (`bt.Analyzer`) that records every
+completed execution's notional and commission, plus a per-bar commission series
+positionally aligned with the TimeReturn series — gross daily returns are
+reconstructed as `net_r + commission / prior_equity`. If the alignment ever
+breaks, gross metrics are reported as `None` rather than misreported.
+
+### 3. `no_trade_band` — the turnover penalty strategies opt into
+
+```python
+from archimedes_analytics_engine.costs import no_trade_band, position_weight
+
+w_now = position_weight(self, d)
+w_target = no_trade_band(w_now, w_model, band=0.01)  # hold unless |Δw| ≥ 1%
+if w_target != w_now:
+    self.order_target_percent(data=d, target=w_target)
+```
+
+Suppresses rebalances smaller than a weight band — the standard, simple
+turnover-control device. No existing strategy was modified in this PR (re-tests
+through the band are roadmap step 4, a separate change per the add-only /
+one-change-per-PR discipline).
+
+## Conventions and caveats (read before citing the numbers)
+
+- **Costs are per side.** 10 bps means 0.10% on the buy and 0.10% on the
+  sell — identical to the legacy flat `transaction_cost_bps` semantics.
+- **"Gross" adds back commissions only, not slippage.** Slippage is embedded in
+  execution prices by the broker and cannot be recovered from accounting; when
+  `slippage_bps > 0`, gross metrics are a *lower bound* on frictionless
+  performance. Disclosed here so nobody over-reads the gross Sharpe.
+- **`break_even_cost_bps` assumes cost scales linearly with turnover** (no
+  market-impact convexity). It is a screening number, not a capacity model.
+- **No per-symbol default cost table is shipped.** Per the honesty discipline,
+  we don't hand-assert spread estimates; callers supply their own assumptions
+  explicitly via `per_symbol`, and those assumptions are visible at the call
+  site.
+- Fixture schema is unchanged — `backtest_fixtures.json` is untouched (add-only
+  law). Surfacing turnover fields in *future* fixture entries is a follow-up
+  decision for the fixture/backend join, not made unilaterally here.
+
+## Verify
+
+```bash
+cd analytics-engine && uv run pytest                  # 59 passed (11 new in test_costs.py)
+uv run --with ruff ruff format --check . && uv run --with ruff ruff check --select E9,F63,F7,F40 .
+git diff main -- analytics-engine/strategies/backtest_fixtures.json   # empty
+```


### PR DESCRIPTION
## Summary

Third-wave item 1 (handover §2 / quant-roadmap Priority 2.2): the engine now measures and reports execution realism. The Kalman pairs strategy cost-bled to −1.47 Sharpe on 1174 trades; until now the engine couldn't quantify that failure mode. This PR adds a reusable turnover-aware cost model and a turnover penalty usable by every strategy — the prerequisite for credible re-tests of the 20 CANDIDATEs.

## What's in it

**New module `costs.py`:**
- `CostModel` — per-side costs in bps with per-symbol overrides, applied to the broker per feed. No default cost table shipped (per honesty discipline, cost assumptions are explicit at the call site).
- `TurnoverAnalyzer` — records executed notional + commissions per bar.
- `no_trade_band` / `position_weight` — the opt-in turnover penalty (suppress rebalances below a weight band).

**`engine.py` wiring — six new `BacktestResult` fields:**
`turnover_annualized` (one-way, ×/yr), `traded_notional`, `total_commission_paid`, `cost_drag_annual_pct`, `break_even_cost_bps` (per-side bps at which gross CAGR is fully consumed — the implementability screen), `gross_sharpe_ratio` (commissions added back, same convention as the net Sharpe so the comparison is apples-to-apples).

All three runners accept an optional `cost_model=`; omitted ⇒ behaviour identical to before (backward compatible — all 48 pre-existing tests pass unchanged).

**Spec:** `docs/specs/transaction-cost-turnover-model.md` — definitions, conventions, and caveats (gross adds back commissions only, not slippage; break-even assumes linear cost scaling).

## Verify

```bash
cd analytics-engine && uv run pytest          # 59 passed (11 new in tests/test_costs.py)
uv run --with ruff ruff format --check . && uv run --with ruff ruff check --select E9,F63,F7,F40 .
PYTHONPATH=backend python -m pytest backend/tests/test_strategy_endpoints.py backend/tests/services/test_strategy_provider.py -q   # 69 passed
git diff main -- analytics-engine/strategies/backtest_fixtures.json   # empty (add-only law)
```

Key test invariants: hand-computed round-trip accounting (notional/commission exact), zero-cost ⇒ gross Sharpe == net Sharpe to 1e-6 (proves the convention replication), costs-only-hurt monotonicity, per-symbol override charges more, alignment survives strategy warm-up periods, banded rebalancer trades less.

## Anti-goals honored

- No strategy files modified; no fixture regenerated (re-tests through this model are roadmap step 4, separate PRs).
- Rigor gate (`rigor_evaluator.py`, #537) untouched.
- No new dependencies.

Quant lane (Önder) — team offline, shipped solo per handover §9 (pure analytics-engine work).
