### PR TITLE
[backtest] Add walk-forward parameter-selection harness !minor

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/__init__.py
+++ b/analytics-engine/src/archimedes_analytics_engine/__init__.py
@@ -3,4 +3,5 @@ __all__ = [
     "costs",
     "engine",
     "instruments",
+    "walk_forward",
 ]

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -241,6 +241,7 @@ def run_backtest(
     transaction_cost_bps: int = 10,
     slippage_bps: int = 0,
     cost_model: CostModel | None = None,
+    strategy_params: dict | None = None,
 ) -> BacktestResult:
     cerebro = bt.Cerebro(stdstats=False)
     transaction_cost_bps, slippage_bps = _configure_broker(
@@ -254,7 +255,7 @@ def run_backtest(
 
     feed = bt.feeds.PandasData(dataname=prices)
     cerebro.adddata(feed)
-    cerebro.addstrategy(strategy_cls)
+    cerebro.addstrategy(strategy_cls, **(strategy_params or {}))
     _add_analyzers(cerebro)
 
     strategy = cerebro.run()[0]
@@ -381,6 +382,7 @@ def run_pairs_backtest(
     transaction_cost_bps: int = 10,
     slippage_bps: int = 0,
     cost_model: CostModel | None = None,
+    strategy_params: dict | None = None,
 ) -> BacktestResult:
     """Run a two-asset (pairs / relative-value) strategy in a single cerebro.
 
@@ -407,7 +409,7 @@ def run_pairs_backtest(
 
     cerebro.adddata(bt.feeds.PandasData(dataname=aligned_a), name=name_a)
     cerebro.adddata(bt.feeds.PandasData(dataname=aligned_b), name=name_b)
-    cerebro.addstrategy(strategy_cls)
+    cerebro.addstrategy(strategy_cls, **(strategy_params or {}))
     _add_analyzers(cerebro)
 
     strategy = cerebro.run()[0]
@@ -434,6 +436,7 @@ def run_multi_backtest(
     transaction_cost_bps: int = 10,
     slippage_bps: int = 0,
     cost_model: CostModel | None = None,
+    strategy_params: dict | None = None,
 ) -> BacktestResult:
     """Run an N-asset (cross-sectional / portfolio) strategy in a single cerebro.
 
@@ -472,7 +475,7 @@ def run_multi_backtest(
     for prices, name in zip(prices_list, feed_names, strict=True):
         aligned = prices.loc[common_index].sort_index()
         cerebro.adddata(bt.feeds.PandasData(dataname=aligned), name=name)
-    cerebro.addstrategy(strategy_cls)
+    cerebro.addstrategy(strategy_cls, **(strategy_params or {}))
     _add_analyzers(cerebro)
 
     strategy = cerebro.run()[0]

--- a/analytics-engine/src/archimedes_analytics_engine/walk_forward.py
+++ b/analytics-engine/src/archimedes_analytics_engine/walk_forward.py
@@ -1,0 +1,186 @@
+"""Walk-forward parameter selection (third-wave item 3, roadmap Priority 2.3).
+
+Parameters chosen in-sample and reported in-sample are the canonical source of
+backtest overfitting. This harness makes any parameterized result credible:
+parameters are selected on a trailing train window only, then evaluated on the
+*next* window the selector never saw, rolling forward through the data. The
+stitched out-of-sample return series is the honest performance estimate, and
+``n_param_combos`` records exactly how many variants were tried — the right
+``num_trials`` input for the DSR penalty (issue #537's "variants actually
+tried" reading) rather than an unstated, unauditable search.
+
+Anti-look-ahead mechanics, in order:
+
+1. Fold k trains on bars ``[k*test_bars, k*test_bars + train_bars)`` and tests
+   on the following ``test_bars`` bars — train always strictly precedes test.
+2. Every grid combination is backtested on the train slice only; the best
+   train Sharpe wins (ties: first in grid order, deterministic).
+3. The winner is then run once over train+test, and only the final
+   ``test_bars`` per-bar returns are kept as out-of-sample. Running over
+   train+test lets indicator warm-up draw on *train* bars (data already
+   available at the test start) instead of forcing a cold start — no future
+   information is involved.
+4. OOS fold returns are stitched chronologically; the summary Sharpe uses the
+   same convention as the engine's net Sharpe so numbers are comparable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import product
+from typing import Any
+
+import backtrader as bt
+import pandas as pd
+
+from archimedes_analytics_engine.costs import CostModel
+from archimedes_analytics_engine.engine import (
+    BacktestResult,
+    _sharpe_bt_convention,
+    run_backtest,
+    run_multi_backtest,
+)
+
+
+@dataclass
+class WalkForwardFold:
+    fold: int
+    train_start: str
+    train_end: str
+    test_start: str
+    test_end: str
+    chosen_params: dict[str, Any]
+    train_sharpe: float | None
+    test_returns: list[float] = field(default_factory=list)
+
+
+@dataclass
+class WalkForwardResult:
+    folds: list[WalkForwardFold]
+    oos_daily_returns: list[float]  # all fold test returns, stitched chronologically
+    oos_sharpe: float | None  # engine net-Sharpe convention on the stitched series
+    n_param_combos: int  # honest num_trials input for the DSR penalty
+    param_grid: dict[str, list[Any]]
+
+
+def _expand_grid(param_grid: dict[str, list[Any]]) -> list[dict[str, Any]]:
+    keys = list(param_grid.keys())
+    return [dict(zip(keys, values, strict=True)) for values in product(*(param_grid[k] for k in keys))]
+
+
+def _align(prices_list: list[pd.DataFrame]) -> list[pd.DataFrame]:
+    common = prices_list[0].index
+    for prices in prices_list[1:]:
+        common = common.intersection(prices.index)
+    if len(common) == 0:
+        raise ValueError("price frames share no common dates; cannot align feeds")
+    return [p.loc[common].sort_index() for p in prices_list]
+
+
+def walk_forward_select(
+    prices: pd.DataFrame | list[pd.DataFrame],
+    *,
+    strategy_cls: type[bt.Strategy],
+    param_grid: dict[str, list[Any]],
+    initial_cash: float,
+    train_bars: int,
+    test_bars: int,
+    names: list[str] | None = None,
+    transaction_cost_bps: int = 10,
+    slippage_bps: int = 0,
+    cost_model: CostModel | None = None,
+) -> WalkForwardResult:
+    """Roll a train/select/test cycle through the data; see module docstring.
+
+    ``prices`` is a single OHLCV frame or a list of frames (multi-feed
+    strategies run via ``run_multi_backtest`` with ``names`` passthrough).
+    Raises if the grid is empty or the data is too short for one full fold.
+    """
+    if not param_grid or any(not v for v in param_grid.values()):
+        raise ValueError("param_grid must have at least one parameter with at least one value")
+    if train_bars < 2 or test_bars < 1:
+        raise ValueError(f"need train_bars >= 2 and test_bars >= 1, got {train_bars}/{test_bars}")
+
+    frames = _align([prices] if isinstance(prices, pd.DataFrame) else list(prices))
+    n_bars = len(frames[0])
+    if n_bars < train_bars + test_bars:
+        raise ValueError(f"{n_bars} aligned bars < one fold of train_bars+test_bars = {train_bars + test_bars}")
+
+    combos = _expand_grid(param_grid)
+
+    def _run(start: int, stop: int, params: dict[str, Any]) -> BacktestResult:
+        window = [f.iloc[start:stop] for f in frames]
+        if len(window) == 1:
+            return run_backtest(
+                window[0],
+                strategy_cls=strategy_cls,
+                initial_cash=initial_cash,
+                transaction_cost_bps=transaction_cost_bps,
+                slippage_bps=slippage_bps,
+                cost_model=cost_model,
+                strategy_params=params,
+            )
+        return run_multi_backtest(
+            window,
+            strategy_cls=strategy_cls,
+            initial_cash=initial_cash,
+            names=names,
+            transaction_cost_bps=transaction_cost_bps,
+            slippage_bps=slippage_bps,
+            cost_model=cost_model,
+            strategy_params=params,
+        )
+
+    folds: list[WalkForwardFold] = []
+    stitched: list[float] = []
+    index = frames[0].index
+    fold_no = 0
+    while fold_no * test_bars + train_bars + test_bars <= n_bars:
+        train_lo = fold_no * test_bars
+        train_hi = train_lo + train_bars  # exclusive
+        test_hi = train_hi + test_bars  # exclusive
+
+        best_params: dict[str, Any] | None = None
+        best_sharpe = -float("inf")
+        for params in combos:
+            train_result = _run(train_lo, train_hi, params)
+            sharpe = train_result.sharpe_ratio if train_result.sharpe_ratio is not None else -float("inf")
+            if sharpe > best_sharpe:
+                best_sharpe = sharpe
+                best_params = params
+
+        assert best_params is not None  # combos is non-empty by construction
+        eval_result = _run(train_lo, test_hi, best_params)
+        # Per-bar returns over train+test; keep only the test tail as OOS. The
+        # engine emits exactly one return per bar — verify rather than assume,
+        # since a silent misalignment would leak train bars into the OOS series.
+        expected_bars = test_hi - train_lo
+        if len(eval_result.daily_returns) != expected_bars:
+            raise RuntimeError(
+                f"fold {fold_no}: engine returned {len(eval_result.daily_returns)} per-bar returns "
+                f"for a {expected_bars}-bar window; cannot slice the OOS tail safely"
+            )
+        test_returns = eval_result.daily_returns[-test_bars:]
+
+        folds.append(
+            WalkForwardFold(
+                fold=fold_no,
+                train_start=index[train_lo].isoformat(),
+                train_end=index[train_hi - 1].isoformat(),
+                test_start=index[train_hi].isoformat(),
+                test_end=index[test_hi - 1].isoformat(),
+                chosen_params=best_params,
+                train_sharpe=None if best_sharpe == -float("inf") else best_sharpe,
+                test_returns=test_returns,
+            )
+        )
+        stitched.extend(test_returns)
+        fold_no += 1
+
+    return WalkForwardResult(
+        folds=folds,
+        oos_daily_returns=stitched,
+        oos_sharpe=_sharpe_bt_convention(stitched),
+        n_param_combos=len(combos),
+        param_grid={k: list(v) for k, v in param_grid.items()},
+    )

--- a/analytics-engine/tests/test_walk_forward.py
+++ b/analytics-engine/tests/test_walk_forward.py
@@ -1,0 +1,220 @@
+"""Tests for the walk-forward parameter-selection harness.
+
+Hermetic: synthetic data, no network. The load-bearing test is the
+look-ahead proof: when the regime flips exactly at a fold's train/test
+boundary, the harness must pick the train-optimal parameter and lose
+out-of-sample — picking the test-optimal one would mean it peeked.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.engine import run_backtest
+from archimedes_analytics_engine.walk_forward import WalkForwardResult, walk_forward_select
+
+
+def _frame(closes: list[float], start: str = "2018-01-01") -> pd.DataFrame:
+    idx = pd.date_range(start, periods=len(closes), freq="D")
+    return pd.DataFrame(
+        {
+            "Open": closes,
+            "High": [c * 1.004 for c in closes],
+            "Low": [c * 0.996 for c in closes],
+            "Close": closes,
+            "Volume": [1_000] * len(closes),
+        },
+        index=idx,
+    )
+
+
+def _uptrend(n: int, base: float = 100.0, slope: float = 0.3) -> list[float]:
+    return [base + slope * i + 1.5 * math.sin(i / 6.0) for i in range(n)]
+
+
+def _up_then_down(n_up: int, n_down: int) -> list[float]:
+    up = _uptrend(n_up)
+    peak = up[-1]
+    down = [peak - 0.4 * i + 1.5 * math.sin(i / 6.0) for i in range(1, n_down + 1)]
+    return up + down
+
+
+class _ExposureStrategy(bt.Strategy):
+    """Holds a constant target exposure — the simplest selectable parameter."""
+
+    params = (("invested", 0.0),)
+
+    def next(self) -> None:
+        target = float(self.params.invested)
+        if len(self) == 2 and target > 0 and not self.position:
+            self.order_target_percent(target=target)
+
+
+class _SmaTrender(bt.Strategy):
+    """Long above its SMA — has a real warm-up period (param-selectable)."""
+
+    params = (("period", 20),)
+
+    def __init__(self) -> None:
+        self.sma = bt.indicators.SMA(self.data.close, period=int(self.params.period))
+
+    def next(self) -> None:
+        if self.data.close[0] > self.sma[0] and not self.position:
+            self.order_target_percent(target=0.95)
+        elif self.data.close[0] < self.sma[0] and self.position:
+            self.order_target_percent(target=0.0)
+
+
+# ── Engine passthrough prerequisite ───────────────────────────────────────────
+
+
+def test_strategy_params_flow_through_runner() -> None:
+    prices = _frame(_uptrend(60))
+    flat = run_backtest(
+        prices, strategy_cls=_ExposureStrategy, initial_cash=100_000.0, strategy_params={"invested": 0.0}
+    )
+    longed = run_backtest(
+        prices, strategy_cls=_ExposureStrategy, initial_cash=100_000.0, strategy_params={"invested": 0.9}
+    )
+    assert flat.traded_notional == 0.0
+    assert longed.traded_notional > 0.0
+    assert longed.final_value != flat.final_value
+
+
+# ── Fold mechanics ────────────────────────────────────────────────────────────
+
+
+def test_fold_layout_and_stitching() -> None:
+    result = walk_forward_select(
+        _frame(_uptrend(300)),
+        strategy_cls=_ExposureStrategy,
+        param_grid={"invested": [0.0, 0.9]},
+        initial_cash=100_000.0,
+        train_bars=100,
+        test_bars=50,
+    )
+    assert isinstance(result, WalkForwardResult)
+    assert len(result.folds) == 4  # (300 - 100) // 50
+    assert result.n_param_combos == 2
+    assert len(result.oos_daily_returns) == 4 * 50
+    for k, fold in enumerate(result.folds):
+        assert fold.fold == k
+        assert len(fold.test_returns) == 50
+        assert fold.train_end < fold.test_start  # train strictly precedes test
+
+
+def test_uptrend_selects_invested_every_fold() -> None:
+    result = walk_forward_select(
+        _frame(_uptrend(300)),
+        strategy_cls=_ExposureStrategy,
+        param_grid={"invested": [0.0, 0.9]},
+        initial_cash=100_000.0,
+        train_bars=100,
+        test_bars=50,
+    )
+    assert all(f.chosen_params == {"invested": 0.9} for f in result.folds)
+    assert result.oos_sharpe is not None and result.oos_sharpe > 0
+
+
+def test_look_ahead_proof_regime_flip_at_boundary() -> None:
+    # Up for 200 bars, then straight down. With train=100/test=50, fold 2
+    # trains on bars 100-199 (all uptrend) and tests on 200-249 (all downtrend).
+    # A peeking selector would choose invested=0.0 for that fold; an honest one
+    # must choose the train-optimal invested=0.9 and lose out-of-sample.
+    result = walk_forward_select(
+        _frame(_up_then_down(200, 100)),
+        strategy_cls=_ExposureStrategy,
+        param_grid={"invested": [0.0, 0.9]},
+        initial_cash=100_000.0,
+        train_bars=100,
+        test_bars=50,
+    )
+    boundary_fold = result.folds[2]
+    assert boundary_fold.chosen_params == {"invested": 0.9}  # train-optimal, NOT test-optimal
+    assert sum(boundary_fold.test_returns) < 0  # and it pays for it out-of-sample
+
+
+def test_warm_up_draws_on_train_bars_not_cold_start() -> None:
+    # The chosen strategy has a 20-bar SMA. Because evaluation runs over
+    # train+test (slicing only the test tail), the position carries into the
+    # test window — early test bars must show market exposure, not a cold start.
+    result = walk_forward_select(
+        _frame(_uptrend(220)),
+        strategy_cls=_SmaTrender,
+        param_grid={"period": [10, 20]},
+        initial_cash=100_000.0,
+        train_bars=150,
+        test_bars=70,
+    )
+    first_fold = result.folds[0]
+    assert any(r != 0.0 for r in first_fold.test_returns[:5])
+
+
+# ── Input validation ──────────────────────────────────────────────────────────
+
+
+def test_rejects_empty_grid() -> None:
+    with pytest.raises(ValueError, match="param_grid"):
+        walk_forward_select(
+            _frame(_uptrend(200)),
+            strategy_cls=_ExposureStrategy,
+            param_grid={},
+            initial_cash=100_000.0,
+            train_bars=100,
+            test_bars=50,
+        )
+    with pytest.raises(ValueError, match="param_grid"):
+        walk_forward_select(
+            _frame(_uptrend(200)),
+            strategy_cls=_ExposureStrategy,
+            param_grid={"invested": []},
+            initial_cash=100_000.0,
+            train_bars=100,
+            test_bars=50,
+        )
+
+
+def test_rejects_data_shorter_than_one_fold() -> None:
+    with pytest.raises(ValueError, match="aligned bars"):
+        walk_forward_select(
+            _frame(_uptrend(120)),
+            strategy_cls=_ExposureStrategy,
+            param_grid={"invested": [1.0]},
+            initial_cash=100_000.0,
+            train_bars=100,
+            test_bars=50,
+        )
+
+
+# ── Multi-feed support ────────────────────────────────────────────────────────
+
+
+class _PickALeg(bt.Strategy):
+    """Goes long one feed chosen by parameter — selectable across feeds."""
+
+    params = (("leg", 0),)
+
+    def next(self) -> None:
+        if len(self) == 2 and not self.getposition(self.datas[int(self.params.leg)]).size:
+            self.order_target_percent(data=self.datas[int(self.params.leg)], target=0.95)
+
+
+def test_multi_feed_walk_forward_selects_winning_leg() -> None:
+    n = 240
+    up = _frame(_uptrend(n))
+    down = _frame([200.0 - 0.3 * i + 1.5 * math.sin(i / 6.0) for i in range(n)])
+    result = walk_forward_select(
+        [up, down],
+        strategy_cls=_PickALeg,
+        param_grid={"leg": [0, 1]},
+        initial_cash=100_000.0,
+        train_bars=120,
+        test_bars=60,
+        names=["UP", "DOWN"],
+    )
+    assert len(result.folds) == 2
+    assert all(f.chosen_params == {"leg": 0} for f in result.folds)
+    assert result.oos_sharpe is not None and result.oos_sharpe > 0


### PR DESCRIPTION
## Summary

Third-wave item 3 (handover §2 / quant-roadmap Priority 2.3): the walk-forward parameter-selection harness. Parameters chosen and reported in-sample are the canonical source of backtest overfitting; this harness makes any parameterized result credible — parameters are selected on a trailing train window only, evaluated on the next unseen window, rolling through the data. The stitched out-of-sample series is the honest performance estimate, and it directly feeds the PBO/DSR story: `n_param_combos` records exactly how many variants were tried, which is the right `num_trials` input under the "variants actually tried" reading of [#537](https://github.com/a-apin/archimedes/issues/537) (recorded here, **not** decided here — the gate is untouched).

## What's in it

**New module `walk_forward.py`** — `walk_forward_select(prices, strategy_cls, param_grid, train_bars, test_bars, ...)` → `WalkForwardResult` with per-fold provenance (`WalkForwardFold`: train/test date ranges, chosen params, train Sharpe, test returns), the stitched `oos_daily_returns`, `oos_sharpe` (engine net-Sharpe convention, so comparable), and `n_param_combos`. Works on single frames and multi-feed lists (with `names` passthrough), and accepts the item-1 `cost_model`.

**Anti-look-ahead mechanics:**
1. Fold k trains on bars `[k·test, k·test + train)`, tests on the following `test` bars — train strictly precedes test, always.
2. Grid combos are backtested on the train slice only; best train Sharpe wins (ties deterministic by grid order).
3. The winner is evaluated over train+test with only the test tail kept as OOS — indicator warm-up draws on *train* bars (already available at test start) instead of a cold start. No future data is involved.
4. A runtime guard raises if the engine's per-bar return series ever misaligns with the window, rather than silently leaking train bars into the OOS series.

**Engine prerequisite:** all three runners now accept `strategy_params: dict | None` and forward to `addstrategy` (backward compatible).

## Verify

```bash
cd analytics-engine && uv run pytest          # 74 passed (8 new in tests/test_walk_forward.py)
uv run --with ruff ruff format --check . && uv run --with ruff ruff check --select E9,F63,F7,F40 .
PYTHONPATH=backend python -m pytest backend/tests/test_strategy_endpoints.py backend/tests/services/test_strategy_provider.py -q   # 71 passed
```

The load-bearing test is the **look-ahead proof**: synthetic data with a regime flip planted exactly at a fold's train/test boundary. The harness must pick the train-optimal parameter (long) and lose out-of-sample — a selector that picks the test-optimal parameter (flat) has peeked. Also covered: fold layout/stitching math, warm-up continuity into the test window, multi-feed selection, input validation.

## Anti-goals honored

- Rigor gate untouched; #537 gets an honest input recorded, not a unilateral decision.
- No fixtures touched; no strategies modified (re-tests are item 4, next PR).
- No new dependencies.

Quant lane (Önder) — team offline, shipped solo per handover §9.
