### PR TITLE
[DO NOT MERGE] #537 prototype: provenance-based num_trials resolver

### DIFF
--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -331,6 +331,35 @@ def _annualized_sharpe_arr(arr: np.ndarray) -> float | None:
     return float(((arr.mean() - _RF_DAILY) / sigma) * math.sqrt(_ANNUALIZATION))
 
 
+def resolve_num_trials(
+    provenance: str,
+    n_variants_tried: int | None,
+    library_size: int,
+) -> int:
+    """#537 PROTOTYPE — DO NOT MERGE without team sign-off (Dan).
+
+    Provenance-based ``num_trials`` for the DSR multiple-testing penalty
+    (issue #537, option 3 — see also #547, which the convention question
+    gates on):
+
+    - ``"paper_grounded"``: N = the parameter variants *actually tried* for
+      this strategy — auditable via the walk-forward harness's
+      ``n_param_combos`` and the fixture spec catalog, not asserted. Falls
+      back to ``library_size`` when no trial count was recorded: unrecorded
+      search history is treated as mined (conservative default).
+    - anything else (``"fusion"``, ``"library_selected"``, …): N = full
+      library size — the winner was selected from the shelf, so it competes
+      against the shelf.
+
+    The DSR p ≥ 0.95 bar itself is untouched (anti-goal in #537); this only
+    changes the N input, and the passport must surface which N was used and
+    why.
+    """
+    if provenance == "paper_grounded" and n_variants_tried is not None and n_variants_tried >= 1:
+        return n_variants_tried
+    return max(1, library_size)
+
+
 def compute_average_pairwise_correlation(
     returns: dict[str, list[float]] | np.ndarray | list[list[float]],
 ) -> float:

--- a/backend/tests/test_resolve_num_trials.py
+++ b/backend/tests/test_resolve_num_trials.py
@@ -1,0 +1,33 @@
+"""Tests for the #537 PROTOTYPE resolve_num_trials — DO NOT MERGE without Dan's sign-off.
+
+Hermetic; documents the intended provenance-split semantics so the prototype
+diff is reviewable as executable spec.
+"""
+
+from __future__ import annotations
+
+from archimedes.services.rigor_evaluator import resolve_num_trials
+
+
+def test_paper_grounded_uses_recorded_variant_count() -> None:
+    # risk parity: 3 lookback combos actually tried (third-wave walk-forward run)
+    assert resolve_num_trials("paper_grounded", n_variants_tried=3, library_size=23) == 3
+
+
+def test_paper_grounded_single_faithful_implementation() -> None:
+    assert resolve_num_trials("paper_grounded", n_variants_tried=1, library_size=23) == 1
+
+
+def test_paper_grounded_without_recorded_trials_falls_back_to_library() -> None:
+    # Unrecorded search history is treated as mined — conservative default.
+    assert resolve_num_trials("paper_grounded", n_variants_tried=None, library_size=23) == 23
+    assert resolve_num_trials("paper_grounded", n_variants_tried=0, library_size=23) == 23
+
+
+def test_fusion_and_library_selected_use_full_library() -> None:
+    assert resolve_num_trials("fusion", n_variants_tried=2, library_size=23) == 23
+    assert resolve_num_trials("library_selected", n_variants_tried=1, library_size=23) == 23
+
+
+def test_library_size_floor_is_one() -> None:
+    assert resolve_num_trials("fusion", n_variants_tried=None, library_size=0) == 1


### PR DESCRIPTION
**DO NOT MERGE.** Draft on purpose; gate change requiring @dbrowneup's sign-off per the #537 anti-goals.

Executable spec for [#537](https://github.com/a-apin/archimedes/issues/537) option 3 (provenance-based split), showing the diff is small: one pure function in `rigor_evaluator.py` + 5 hermetic tests documenting the semantics. No call site is wired; no threshold moves; the p ≥ 0.95 bar is untouched.

Also blocked on the DSR convention decision in [#547](https://github.com/a-apin/archimedes/issues/547) — under the backend (excess-Sharpe) convention the N input alone does not recover risk parity, so #547 should be decided first. Full decision package: see the comment on #537.

Verify: `PYTHONPATH=backend /tmp/abe/bin/python -m pytest backend/tests/test_resolve_num_trials.py backend/tests/test_rigor_evaluator.py -q` → 118 passed.