### PR TITLE
Wire Kelly-sized allocation into vault construction (fourth wave task 3) !minor

### DIFF
--- a/backend/archimedes/api/vault_schemas.py
+++ b/backend/archimedes/api/vault_schemas.py
@@ -53,6 +53,11 @@ class SetAllocationsRequest(BaseModel):
 
     strategy_ids: list[str] = Field(default_factory=list)
     usdc_floor_pct: float = Field(20.0, ge=0, le=80, description="Min USDC allocation (%)")
+    risk_profile: str = Field(
+        "moderate",
+        pattern="^(fixed_income|conservative|moderate|aggressive|hyper_risky)$",
+        description="Maps to the Kelly γ table (RISK_AVERSION) for strategy-level sizing",
+    )
 
 
 class SetAllocationsResponse(BaseModel):
@@ -61,3 +66,13 @@ class SetAllocationsResponse(BaseModel):
     allocations: list[AllocationTarget]
     total_bps: int = Field(..., description="Should equal 10000")
     strategy_count: int = Field(..., description="Number of strategies used")
+    # Kelly-sizing transparency (additive; defaults keep old consumers working):
+    risk_profile: str = "moderate"
+    sized_strategies: dict[str, float] = Field(
+        default_factory=dict,
+        description="Per-strategy capital fraction = passport half-Kelly × profile multiplier (post budget scaling)",
+    )
+    excluded_strategy_ids: list[str] = Field(
+        default_factory=list,
+        description="Selected strategies sized to zero (rigor-gate CANDIDATE/fail, or no stored kelly_fraction)",
+    )

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -28,6 +28,7 @@ from archimedes.api.vault_schemas import (
 )
 from archimedes.chain.executor import chain_executor
 from archimedes.models.chat import VaultMetadata
+from archimedes.services.strategy_sizer import kelly_weighted_allocations, scale_to_budget, size_strategies
 
 vaults_router = APIRouter(prefix="/api/vaults", tags=["vaults"])
 
@@ -240,7 +241,15 @@ async def derive_vault_allocations(address: str, req: SetAllocationsRequest, req
         synth_assets,
     )
     usdc_floor = req.usdc_floor_pct / 100.0
-    target_weights = strategy_evaluator.aggregate_signals(all_signals, usdc_floor=usdc_floor)
+
+    # Strategy-level Kelly sizing (roadmap Priority 3.1): each gate-passing
+    # strategy receives passport-half-Kelly × risk-profile multiplier of the
+    # capital; CANDIDATEs and gate-failers size to zero (the gate is not
+    # bypassable via deployment); unclaimed budget stays in USDC.
+    sized_fractions = size_strategies(strategies, req.risk_profile)
+    sized_fractions = scale_to_budget(sized_fractions, 1.0 - usdc_floor)
+    excluded = sorted(sid for sid, frac in sized_fractions.items() if frac <= 0.0)
+    target_weights = kelly_weighted_allocations(all_signals, sized_fractions, usdc_floor=usdc_floor)
 
     allocations: list[AllocationTarget] = []
 
@@ -276,4 +285,7 @@ async def derive_vault_allocations(address: str, req: SetAllocationsRequest, req
         allocations=allocations,
         total_bps=sum(a.weight_bps for a in allocations),
         strategy_count=len(strategies),
+        risk_profile=req.risk_profile,
+        sized_strategies={sid: frac for sid, frac in sized_fractions.items() if frac > 0.0},
+        excluded_strategy_ids=excluded,
     )

--- a/backend/archimedes/services/strategy_sizer.py
+++ b/backend/archimedes/services/strategy_sizer.py
@@ -1,0 +1,127 @@
+"""Strategy-level Kelly sizing for vault construction (roadmap Priority 3.1).
+
+Closes the gap where the strategy passport's ``kelly_fraction`` — computed by
+the rigor pipeline and served on every passport — was never consumed by vault
+construction: the derive-allocations path flat-averaged every selected
+strategy's votes regardless of edge or gate verdict.
+
+Sizing model (one source for every constant — do not fork these):
+
+- **The passport ``kelly_fraction`` IS half-Kelly by construction.**
+  ``analytics-engine/scripts/regen_buy_hold_fixture.py::compute_kelly``
+  applies ``fractional=0.5`` before storing. Do NOT multiply by another 0.5
+  here — that would double-discount.
+- **The risk profile maps to a Kelly multiple via the same γ table the
+  portfolio optimizer uses** (``RISK_AVERSION`` in ``portfolio_optimizer.py``).
+  Mean-variance Kelly with risk aversion γ allocates w* = full-Kelly / γ, so
+  the multiplier applied to the stored *half*-Kelly is 2/γ. γ = 2 reproduces
+  half-Kelly exactly (Bell & Cover 1980).
+- **Half-Kelly is the never-exceed ceiling**: the multiplier is capped at 1.0
+  (so ``hyper_risky`` γ = 1.5 still gets at most the stored half-Kelly). Full
+  Kelly on backtest-estimated edges is overbetting by construction — the
+  estimation error in μ/σ² makes the "optimal" fraction an upper bound, not a
+  target.
+- **Only rigor-gate passers are sizeable.** CANDIDATE / gate-failing
+  strategies size to 0.0 — sizing must not become a side-door past the gate.
+- **Never lever up to fill a budget.** If the sized fractions sum below the
+  investable budget, the remainder stays in USDC; if above, all fractions
+  scale down proportionally.
+
+Pure computation: no I/O, no chain, no DB. The deploy path consumes this via
+``derive_vault_allocations`` (the derived targets are returned to the UI; the
+user submits the on-chain transaction from their own wallet).
+
+Owner: Önder (math lane).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from archimedes.services.portfolio_optimizer import RISK_AVERSION
+
+if TYPE_CHECKING:
+    from archimedes.models.strategy import Strategy
+    from archimedes.services.strategy_signal_evaluator import StrategySignals
+
+# γ at which the multiplier is exactly 1× the stored half-Kelly (Bell & Cover).
+_HALF_KELLY_GAMMA = 2.0
+
+
+def kelly_multiplier(risk_profile: str) -> float:
+    """Risk-profile multiplier applied to the passport's half-Kelly fraction.
+
+    2/γ with γ from RISK_AVERSION, capped at 1.0 (half-Kelly ceiling).
+    Unknown profiles fall back to the moderate γ, matching the optimizer's
+    own ``RISK_AVERSION.get(risk_profile, 3.0)`` fallback.
+    """
+    gamma = RISK_AVERSION.get(risk_profile, RISK_AVERSION["moderate"])
+    return min(_HALF_KELLY_GAMMA / gamma, 1.0)
+
+
+def size_strategies(strategies: list[Strategy], risk_profile: str) -> dict[str, float]:
+    """Per-strategy capital fractions: passport half-Kelly × profile multiplier.
+
+    Gate-failing strategies (``passes_rigor_gate`` falsy) and strategies with
+    no stored ``kelly_fraction`` size to 0.0 — no gate pass, no capital; no
+    measured edge, no capital.
+    """
+    mult = kelly_multiplier(risk_profile)
+    sized: dict[str, float] = {}
+    for s in strategies:
+        if not getattr(s, "passes_rigor_gate", False):
+            sized[s.id] = 0.0
+            continue
+        kelly = getattr(s, "kelly_fraction", None)
+        sized[s.id] = round(max(float(kelly), 0.0) * mult, 6) if kelly is not None else 0.0
+    return sized
+
+
+def scale_to_budget(fractions: dict[str, float], budget: float) -> dict[str, float]:
+    """Scale fractions DOWN proportionally if they overflow the budget.
+
+    Never scales up: an under-allocated portfolio keeps the remainder in USDC
+    rather than levering positions to fill the budget.
+    """
+    total = sum(fractions.values())
+    if total <= 0.0 or total <= budget:
+        return dict(fractions)
+    scale = budget / total
+    return {k: round(v * scale, 6) for k, v in fractions.items()}
+
+
+def kelly_weighted_allocations(
+    all_signals: list[StrategySignals],
+    sized_fractions: dict[str, float],
+    usdc_floor: float = 0.20,
+) -> dict[str, float]:
+    """Per-asset target weights from per-strategy sized fractions × votes.
+
+    target(asset) = Σ_s sized_s × vote_{s,asset}, where a strategy's votes are
+    its internal allocation across assets (normalized down if they sum > 1, so
+    a strategy can never deploy more than its sized fraction). USDC receives
+    the floor plus all capital the sized votes did not claim — there is no
+    re-normalization up, by design (see module docstring).
+
+    Returns {symbol: weight} with weights ≥ 0 summing to 1.0 (4-dp rounding).
+    """
+    budget = 1.0 - usdc_floor
+    sized = scale_to_budget(sized_fractions, budget)
+
+    weights: dict[str, float] = {}
+    for strat_signals in all_signals:
+        frac = sized.get(strat_signals.strategy_id, 0.0)
+        if frac <= 0.0:
+            continue
+        positive = [sig for sig in strat_signals.signals if sig.weight > 0.0]
+        total_vote = sum(sig.weight for sig in positive)
+        if total_vote <= 0.0:
+            continue
+        vote_scale = 1.0 / total_vote if total_vote > 1.0 else 1.0
+        for sig in positive:
+            weights[sig.asset] = weights.get(sig.asset, 0.0) + frac * sig.weight * vote_scale
+
+    weights = {k: round(v, 4) for k, v in weights.items()}
+    synth_total = sum(weights.values())
+    weights["USDC"] = round(max(1.0 - synth_total, 0.0), 4)
+    return dict(sorted(weights.items()))

--- a/backend/tests/test_strategy_sizer.py
+++ b/backend/tests/test_strategy_sizer.py
@@ -1,0 +1,205 @@
+"""Hermetic tests for strategy_sizer — Kelly-sized vault allocation (Priority 3.1).
+
+Pure computation tests (no chain, no DB, no network) plus an endpoint test for
+the derive-allocations wiring using the boundary-mock pattern from
+test_api_routes.py (mock chain_client / strategy_evaluator / strategy_provider,
+never internals).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+import pytest
+from archimedes.services.strategy_signal_evaluator import AssetSignal, Signal, StrategySignals
+from archimedes.services.strategy_sizer import (
+    kelly_multiplier,
+    kelly_weighted_allocations,
+    scale_to_budget,
+    size_strategies,
+)
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _Strat:
+    """Minimal stand-in carrying only the fields the sizer reads."""
+
+    id: str
+    passes_rigor_gate: bool = False
+    kelly_fraction: float | None = None
+
+
+def _signals(strategy_id: str, votes: dict[str, float]) -> StrategySignals:
+    return StrategySignals(
+        strategy_id=strategy_id,
+        strategy_name=strategy_id,
+        paper_title=strategy_id,
+        signals=[
+            AssetSignal(
+                strategy_id=strategy_id,
+                strategy_name=strategy_id,
+                asset=asset,
+                signal=Signal.LONG if w > 0 else Signal.FLAT,
+                weight=w,
+                reason="test",
+            )
+            for asset, w in votes.items()
+        ],
+    )
+
+
+# ── kelly_multiplier: 2/γ from the optimizer's RISK_AVERSION, capped at 1 ──────
+
+
+def test_multiplier_tracks_gamma_table() -> None:
+    assert kelly_multiplier("fixed_income") == pytest.approx(2 / 12)
+    assert kelly_multiplier("conservative") == pytest.approx(2 / 6)
+    assert kelly_multiplier("moderate") == pytest.approx(2 / 3)
+    assert kelly_multiplier("aggressive") == pytest.approx(1.0)  # γ=2 = half-Kelly exactly
+
+
+def test_multiplier_capped_at_half_kelly() -> None:
+    # hyper_risky γ=1.5 would give 1.33× the stored half-Kelly — capped.
+    assert kelly_multiplier("hyper_risky") == 1.0
+
+
+def test_unknown_profile_falls_back_to_moderate() -> None:
+    assert kelly_multiplier("yolo") == kelly_multiplier("moderate")
+
+
+# ── size_strategies: gate-passers only, deterministic ─────────────────────────
+
+
+def test_validated_strategy_gets_deterministic_capped_fraction() -> None:
+    # The handover's acceptance case: kelly_fraction=0.3, moderate profile.
+    sized = size_strategies([_Strat("s1", passes_rigor_gate=True, kelly_fraction=0.3)], "moderate")
+    assert sized == {"s1": pytest.approx(0.2)}  # 0.3 × 2/3
+
+
+def test_candidate_gets_zero() -> None:
+    sized = size_strategies([_Strat("cand", passes_rigor_gate=False, kelly_fraction=0.4)], "aggressive")
+    assert sized == {"cand": 0.0}
+
+
+def test_no_kelly_fraction_gets_zero() -> None:
+    sized = size_strategies([_Strat("nokelly", passes_rigor_gate=True, kelly_fraction=None)], "moderate")
+    assert sized == {"nokelly": 0.0}
+
+
+def test_negative_kelly_clamped_to_zero() -> None:
+    sized = size_strategies([_Strat("neg", passes_rigor_gate=True, kelly_fraction=-0.1)], "moderate")
+    assert sized == {"neg": 0.0}
+
+
+# ── scale_to_budget: scale down, never up ──────────────────────────────────────
+
+
+def test_under_budget_is_not_levered_up() -> None:
+    fractions = {"a": 0.1, "b": 0.2}
+    assert scale_to_budget(fractions, budget=0.8) == fractions
+
+
+def test_over_budget_scales_down_proportionally() -> None:
+    scaled = scale_to_budget({"a": 0.6, "b": 0.6}, budget=0.8)
+    assert scaled["a"] == pytest.approx(0.4)
+    assert scaled["b"] == pytest.approx(0.4)
+
+
+# ── kelly_weighted_allocations ────────────────────────────────────────────────
+
+
+def test_unclaimed_budget_stays_in_usdc() -> None:
+    # One strategy sized at 0.2 voting 100% on sSPY: sSPY=0.2, USDC=0.8 —
+    # the synth budget is NOT re-normalized up to fill (1 − floor).
+    weights = kelly_weighted_allocations(
+        [_signals("s1", {"sSPY": 1.0})],
+        {"s1": 0.2},
+        usdc_floor=0.20,
+    )
+    assert weights == {"USDC": pytest.approx(0.8), "sSPY": pytest.approx(0.2)}
+
+
+def test_votes_within_strategy_normalized_to_its_fraction() -> None:
+    # Votes sum to 2.0 → normalized so the strategy deploys exactly its 0.3.
+    weights = kelly_weighted_allocations(
+        [_signals("s1", {"sSPY": 1.0, "sGOLD": 1.0})],
+        {"s1": 0.3},
+        usdc_floor=0.20,
+    )
+    assert weights["sSPY"] == pytest.approx(0.15)
+    assert weights["sGOLD"] == pytest.approx(0.15)
+    assert weights["USDC"] == pytest.approx(0.7)
+
+
+def test_zero_sized_strategy_contributes_nothing() -> None:
+    weights = kelly_weighted_allocations(
+        [_signals("cand", {"sSPY": 1.0})],
+        {"cand": 0.0},
+        usdc_floor=0.20,
+    )
+    assert weights == {"USDC": 1.0}
+
+
+def test_weights_sum_to_one() -> None:
+    weights = kelly_weighted_allocations(
+        [_signals("s1", {"sSPY": 0.5, "sGOLD": 0.3}), _signals("s2", {"sTLT": 1.0})],
+        {"s1": 0.25, "s2": 0.35},
+        usdc_floor=0.10,
+    )
+    assert sum(weights.values()) == pytest.approx(1.0, abs=2e-4)
+
+
+# ── endpoint wiring: derive-allocations consumes the sizer ─────────────────────
+
+
+@dataclass
+class _PassportStrat:
+    id: str
+    passes_rigor_gate: bool
+    kelly_fraction: float | None
+    paper_title: str = "t"
+    asset_universe: list = field(default_factory=list)
+
+
+@pytest.mark.asyncio
+async def test_derive_allocations_sizes_passers_and_excludes_candidates(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/t.db")
+
+    validated = _PassportStrat("val", passes_rigor_gate=True, kelly_fraction=0.3)
+    candidate = _PassportStrat("cand", passes_rigor_gate=False, kelly_fraction=0.4)
+
+    mock_settings = MagicMock()
+    mock_settings.synth_addresses = {"sSPY": "0x" + "1" * 40}
+    mock_settings.usdc_address = "0x" + "2" * 40
+
+    from archimedes.api import vaults_routes
+    from archimedes.api.vault_schemas import SetAllocationsRequest
+    from archimedes.services.strategy_signal_evaluator import strategy_evaluator
+
+    with (
+        patch.object(vaults_routes.strategy_provider, "list_strategies", return_value=[validated, candidate]),
+        patch("archimedes.chain.client.chain_client") as mock_chain,
+        patch.object(
+            strategy_evaluator,
+            "evaluate_strategies",
+            return_value=[
+                _signals("val", {"sSPY": 1.0}),
+                _signals("cand", {"sSPY": 1.0}),
+            ],
+        ),
+    ):
+        mock_chain.settings = mock_settings
+        req = SetAllocationsRequest(strategy_ids=["val", "cand"], usdc_floor_pct=20.0, risk_profile="moderate")
+        resp = await vaults_routes.derive_vault_allocations.__wrapped__("0x" + "3" * 40, req, MagicMock(), MagicMock())
+
+    # val: 0.3 × (2/3) = 0.2 of capital on sSPY; cand contributes nothing.
+    by_symbol = {a.symbol: a.weight_bps for a in resp.allocations}
+    assert by_symbol["sSPY"] == 2000
+    assert by_symbol["USDC"] == 8000
+    assert resp.total_bps == 10000
+    assert resp.sized_strategies == {"val": pytest.approx(0.2)}
+    assert resp.excluded_strategy_ids == ["cand"]
+    assert resp.risk_profile == "moderate"


### PR DESCRIPTION
## Summary

Roadmap Priority 3.1 / [fourth-wave-handover task 3](docs/specs/fourth-wave-handover.md): strategy-level Kelly sizing wired into the vault deploy path. Until now the passport's `kelly_fraction` was computed and served but never consumed — `derive-allocations` flat-averaged every selected strategy's votes regardless of edge or rigor-gate verdict, and nothing prevented a CANDIDATE from receiving the same capital as a VALIDATED strategy.

## Surface map (the handover's mapping hour — what exists, where this fits)

| Surface | State before this PR |
|---|---|
| `services/portfolio_optimizer.py` | **Asset-level** Kelly machinery already substantial: `kelly_optimize_from_prices` (γ-mapped `RISK_AVERSION`, γ=2 ≈ half-Kelly per Bell & Cover), `kelly_risk_decomposition`, Ledoit-Wolf. Owner: Önder. **Untouched.** |
| `api/strategies_routes.py` ~540–700 | Allocation endpoints emit `kelly_fraction`-labelled weights from optimizer output (agent path) or ad-hoc per-asset Kelly math (fallback paths). **Untouched** (consolidating those fallbacks onto the new sizer is a natural follow-up). |
| Passport `kelly_fraction` | Per-strategy **half-Kelly by construction** (`regen_buy_hold_fixture.compute_kelly` bakes `fractional=0.5`), served via `models/strategy.py` → `api/schemas.py`. **This was the unconsumed piece.** |
| `api/vaults_routes.py::derive_vault_allocations` | **The actual deploy path** (UI derives targets here, then the user signs `setTargetAllocations` from their own wallet — the route never sends a tx, per its docstring). Sized strategies by flat vote-averaging via `aggregate_signals`. **This is where the gap closes.** |
| `services/strategy_signal_evaluator.py::aggregate_signals` | Shared with the **oracle** (`chain/agent_runner.py`). **Deliberately untouched** — the sizer-aware aggregation lives in the new service instead, so the oracle path is byte-identical. |

## Design (one source for every constant)

New `services/strategy_sizer.py` (pure computation, no I/O):

- **fraction = passport half-Kelly × min(2/γ, 1.0)**, γ from the optimizer's existing `RISK_AVERSION` table — *not* a second fraction source, and no double-discount (the passport value already carries the 0.5). γ=2 (`aggressive`) reproduces half-Kelly exactly; `hyper_risky` (γ=1.5) is capped at the half-Kelly ceiling — full Kelly on backtest-estimated edges is overbetting by construction.
- **Gate-passers only**: `passes_rigor_gate` falsy or missing `kelly_fraction` → 0.0. Sizing is not a side-door past the gate.
- **Never lever up**: if sized fractions don't fill (1 − USDC floor), the remainder stays in USDC; if they overflow, all scale down proportionally.
- `derive-allocations` gains `risk_profile` (request, default `moderate`) and transparency fields (response): `sized_strategies`, `excluded_strategy_ids`, `risk_profile` — all additive with defaults.

Worked example (= the test acceptance case): VALIDATED strategy with passport kelly 0.3 under `moderate` (γ=3) → 0.3 × 2/3 = **0.20** of vault capital, deterministic; a selected CANDIDATE lands in `excluded_strategy_ids` with zero weight; with a 20% USDC floor the response is sSPY 2000 bps / USDC 8000 bps.

## Solo-boundary note (per handover §task-3)

Pure-python sizing in `services/` + `api/` + tests only. **Nothing in `backend/archimedes/chain/` changed; the oracle runner and `aggregate_signals` are untouched; no contract or transaction behavior changes** — the endpoint returns derived targets and the user's wallet remains the tx signer. Behavior change to flag for review: `derive-allocations` now sizes by Kelly instead of flat vote-averaging by default, so a selection of only CANDIDATEs derives to 100% USDC (honest, but UI-visible). cc @daniel-reis-santos for backend review (lanes-aren't-gates; quant math is Önder's lane, the FastAPI surface is yours).

## Verify

```bash
PYTHONPATH=backend /tmp/abe/bin/python -m pytest backend/tests/test_strategy_sizer.py -q          # 14 passed
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend /tmp/abe/bin/python -m pytest backend/tests/test_strategy_sizer.py -q  # hermetic gate: 14 passed
PYTHONPATH=backend /tmp/abe/bin/python -m pytest backend/tests/ -q -m 'not integration'           # 1286 passed, 2 pre-existing skips
```

Ties into the #537 package: if risk parity is ever promoted, its tempered walk-forward OOS (+0.14 vs +0.35) argues for exactly this kind of conservative fractional sizing.