### PR TITLE
[strategy] Add factor strategies: BAB, RMOM, QMJ, Low-IdioVol !minor

### DIFF
--- a/analytics-engine/strategies/ang_hodrick_2006_low_idiovol.py
+++ b/analytics-engine/strategies/ang_hodrick_2006_low_idiovol.py
@@ -1,0 +1,244 @@
+"""Low Idiosyncratic Volatility — Ang, Hodrick, Xing & Zhang 2006.
+
+Ang et al. (2006) document that stocks with high idiosyncratic volatility
+(residual vol relative to the Fama-French model) earn anomalously LOW
+subsequent returns. Going long low-idiovol and short high-idiovol generates
+a significant premium. This is a puzzle for standard risk-return theory and
+has attracted extensive follow-up work.
+
+This adaptation computes each asset's idiosyncratic volatility as the
+standard deviation of its CAPM residuals (asset return minus beta-scaled
+market return) over a rolling window. Assets are ranked by idiosyncratic
+vol; we long the lowest (the 'quality' end) and short the highest.
+
+Requires ``engine.run_multi_backtest``. ``self.datas[0]`` is the market
+benchmark (assumed SPY) used for beta estimation.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "The Cross-Section of Volatility and Expected Returns"
+PAPER_AUTHORS: list[str] = [
+    "Andrew Ang",
+    "Robert J. Hodrick",
+    "Yuhang Xing",
+    "Xiaoyan Zhang",
+]
+PAPER_VENUE = "The Journal of Finance"
+PAPER_YEAR = 2006
+PAPER_DOI = "10.1111/j.1540-6261.2006.00836.x"
+PAPER_CITATION_COUNT = 6500  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# Low-volatility anomaly is strongest in defensive/bear regimes when
+# investors flee to lower-risk assets.
+REGIME_TAG: str = "bear"
+
+METHODOLOGY_SUMMARY = (
+    "Rank assets by CAPM idiosyncratic volatility (std of beta-adjusted "
+    "residual returns). Long the lowest-idiovol assets, short the highest. "
+    "Exploits the low-volatility anomaly: high idiosyncratic vol predicts "
+    "lower subsequent returns, contradicting the risk-return tradeoff."
+)
+
+METHODOLOGY_TEXT = (
+    "Ang, Hodrick, Xing & Zhang (2006) show that stocks with high "
+    "idiosyncratic volatility — measured as the standard deviation of "
+    "Fama-French three-factor model residuals over the prior month — earn "
+    "significantly lower returns over the following month. The effect is "
+    "economically large: the authors report a -1.06%/month premium for a "
+    "value-weighted quintile spread (long low-idiovol, short high-idiovol) "
+    "on US stocks 1963-2000, robust to controlling for size, value, momentum, "
+    "liquidity, and return reversals. The anomaly contradicts the standard "
+    "risk-return intuition: investors appear to overpay for high-idiovol "
+    "'lottery stocks', possibly due to underdiversification, leverage "
+    "constraints, or preference for positive skewness.\n\n"
+    "v1 Archimedes adaptation — CAPM residuals over a cross-asset universe: "
+    "we simplify the three-factor model to a single-factor CAPM where the "
+    "market proxy is self.datas[0] (SPY). For each asset we (1) estimate a "
+    "rolling OLS beta over 'beta_window' bars using the covariance formula "
+    "beta = cov(r_asset, r_mkt) / var(r_mkt), implemented in pure Python; "
+    "(2) compute residual daily returns r_resid = r_asset - beta * r_mkt "
+    "over the most recent 'vol_window' bars; (3) take the standard deviation "
+    "of those residuals as the idiosyncratic volatility score. Assets are "
+    "ranked by idiosyncratic vol ASCENDING (lower is better); the bottom "
+    "long_frac are held long and the top short_frac are held short, each in "
+    "equal weight, with positions rebalanced every ~21 bars.\n\n"
+    "Honest caveats: (1) Ang et al.'s findings apply to a broad individual-"
+    "stock cross-section, not a 5-asset multi-market basket; the -1.06%/month "
+    "figure is context, not a benchmark for this adaptation — PAPER_CLAIMED_* "
+    "are left null. (2) We use a single-factor CAPM rather than the Fama-"
+    "French three-factor model; omitting the size and value factors means our "
+    "residuals are noisier estimates of true idiosyncratic vol. (3) In a "
+    "small cross-asset universe (SPY, NIKKEI, GOLD, TREASURY, OIL) the "
+    "low-idiovol anomaly has a weaker theoretical footing because the assets "
+    "are already diversified proxies rather than individual equities. "
+    "(4) Short-selling costs are not modelled."
+)
+
+# Stock-level monthly-return anomaly — not a like-for-like benchmark for
+# this cross-asset price-data adaptation.
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["conservative"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "Low-volatility sleeve. Long low-idiosyncratic-vol, short high-idiovol. "
+    "One of the most cited anomaly papers in empirical asset pricing (~6500 "
+    "citations). Defensive profile — regime tag 'bear' reflects the anomaly's "
+    "stronger performance during risk-off episodes. Status is 'candidate' "
+    "until backtest metrics are populated."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+
+class AngHodrickLowIdioVol(bt.Strategy):
+    """Long low-idiovol assets, short high-idiovol assets.
+
+    Expects N>=2 data feeds (``self.datas[i]``). ``self.datas[0]`` is the
+    market benchmark used for CAPM beta estimation. Driven by
+    ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("vol_window", 22),  # bars for residual-vol estimation
+        ("beta_window", 63),  # bars for rolling OLS beta estimation (~quarter)
+        ("rebalance_every", 21),  # ~monthly rebalance
+        ("long_frac", 0.4),  # long the lowest 40% by idiovol
+        ("short_frac", 0.4),  # short the highest 40% by idiovol
+        ("gross", 1.0),  # total gross exposure split evenly across legs
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    def _daily_returns(self, data, n: int) -> list[float]:
+        """Return the last *n* daily simple returns for *data* (oldest first).
+
+        Returns an empty list when history is insufficient.
+        """
+        need = n + 1
+        if len(data) < need:
+            return []
+        rets: list[float] = []
+        for i in range(n, 0, -1):  # i = n, n-1, ..., 1  (oldest → newest)
+            prev = float(data.close[-i - 1])
+            curr = float(data.close[-i])
+            if prev > 0:
+                rets.append(curr / prev - 1.0)
+        return rets
+
+    def _rolling_beta(self, data) -> float | None:
+        """Estimate CAPM beta of *data* vs self.datas[0] over beta_window bars.
+
+        beta = cov(r_asset, r_mkt) / var(r_mkt), computed in pure Python.
+        Returns None when history is insufficient or market variance is zero.
+        """
+        n = int(self.params.beta_window)
+        mkt = self.datas[0]
+        r_asset = self._daily_returns(data, n)
+        r_mkt = self._daily_returns(mkt, n)
+        # Align lengths (both should be n but guard against differing history).
+        length = min(len(r_asset), len(r_mkt))
+        if length < 2:
+            return None
+        r_asset = r_asset[-length:]
+        r_mkt = r_mkt[-length:]
+
+        mean_a = sum(r_asset) / length
+        mean_m = sum(r_mkt) / length
+        cov = sum((r_asset[i] - mean_a) * (r_mkt[i] - mean_m) for i in range(length)) / (length - 1)
+        var_m = sum((r_mkt[i] - mean_m) ** 2 for i in range(length)) / (length - 1)
+        if var_m <= 0.0:
+            return None
+        return cov / var_m
+
+    def _idiosyncratic_vol(self, data) -> float | None:
+        """Compute idiosyncratic volatility for *data*.
+
+        Idiosyncratic vol = std(r_asset - beta * r_mkt) over vol_window bars.
+        Returns None when history is insufficient or estimation fails.
+        """
+        beta = self._rolling_beta(data)
+        if beta is None:
+            return None
+
+        n = int(self.params.vol_window)
+        mkt = self.datas[0]
+        r_asset = self._daily_returns(data, n)
+        r_mkt = self._daily_returns(mkt, n)
+        length = min(len(r_asset), len(r_mkt))
+        if length < 2:
+            return None
+        r_asset = r_asset[-length:]
+        r_mkt = r_mkt[-length:]
+
+        residuals = [r_asset[i] - beta * r_mkt[i] for i in range(length)]
+        mean_r = sum(residuals) / length
+        variance = sum((r - mean_r) ** 2 for r in residuals) / (length - 1)
+        if variance < 0.0:
+            return None
+        return math.sqrt(variance)
+
+    def next(self) -> None:
+        # Need at least beta_window bars of history before we can act.
+        need = max(int(self.params.beta_window), int(self.params.vol_window))
+        if len(self) <= need:
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        # Score each asset; skip market benchmark (datas[0]) from the ranking
+        # because including it would always assign beta=1 and residual vol=0.
+        scored: list[tuple[float, object]] = []
+        for d in self.datas[1:]:  # exclude market benchmark
+            iv = self._idiosyncratic_vol(d)
+            if iv is not None:
+                scored.append((iv, d))
+        n = len(scored)
+        if n < 2:
+            return
+        scored.sort(key=lambda x: x[0])  # ascending: lowest idiovol first
+
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        # Never let the long and short buckets overlap.
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        # Always flatten the market benchmark — it is used only as a factor.
+        self.order_target_percent(data=self.datas[0], target=0.0)
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)

--- a/analytics-engine/strategies/blitz_hanauer_2010_rmom.py
+++ b/analytics-engine/strategies/blitz_hanauer_2010_rmom.py
@@ -1,0 +1,261 @@
+"""Residual Momentum — Blitz, Huij & Martens (2011).
+
+Standard cross-sectional momentum conflates an asset's alpha with its
+systematic factor exposure. Residual momentum strips out the market
+component — rank assets by their beta-adjusted formation-window return
+(alpha) rather than total return. Blitz et al. show this earns a higher
+Sharpe and is less correlated with conventional momentum factors.
+
+Requires ``engine.run_multi_backtest`` (ranks assets cross-sectionally).
+``self.datas[0]`` is treated as the market benchmark (assumed SPY).
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Residual Momentum"
+PAPER_AUTHORS: list[str] = ["David Blitz", "Joop Huij", "Martin Martens"]
+PAPER_VENUE = "Journal of Empirical Finance"
+PAPER_YEAR = 2011
+PAPER_DOI = "10.1016/j.jempfin.2011.08.004"
+PAPER_CITATION_COUNT = 350  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# Momentum is a trend / risk-on phenomenon — strongest in bull regimes.
+REGIME_TAG: str = "bull"
+
+METHODOLOGY_SUMMARY = (
+    "Each month, estimate rolling OLS beta for every asset vs the market "
+    "benchmark; subtract the systematic market component from the "
+    "formation-window return to obtain a residual return. Rank by residual "
+    "return, long the top fraction, short the bottom fraction."
+)
+
+METHODOLOGY_TEXT = (
+    "Blitz, Huij & Martens (2011) observe that standard price momentum "
+    "partially reflects systematic exposure to the market factor: an asset "
+    "that simply has high market beta will have a high total return in a "
+    "rising market and would be ranked highly by conventional momentum, even "
+    "if it produced no alpha. Residual momentum corrects for this by "
+    "computing each asset's formation-window return net of its estimated "
+    "market exposure:\n\n"
+    "    residual_return = total_return_{[lookback, skip]} "
+    "- beta * market_return_{[lookback, skip]}\n\n"
+    "where beta is estimated from a rolling daily-returns OLS regression "
+    "over the most recent beta_window bars (shorter than the lookback to "
+    "use fresh data for the factor model). The paper applies this to a broad "
+    "US and international equity cross-section and reports that residual "
+    "momentum has a higher Sharpe ratio than total-return momentum, survives "
+    "standard risk-factor controls, and is less correlated with conventional "
+    "momentum factor portfolios (suggesting it captures a distinct source "
+    "of return predictability).\n\n"
+    "v1 Archimedes adaptation (cross-asset, N-feed engine): with a small "
+    "asset universe rather than a stock cross-section, each rebalance "
+    "(every ~21 bars) we (1) compute the total return from close[-lookback] "
+    "to close[-skip] for each asset and the market, (2) estimate rolling "
+    "beta over the most recent beta_window bars of daily returns, (3) compute "
+    "residual_return = total_return - beta * market_total_return, and "
+    "(4) rank assets by residual return — long the top long_frac, short the "
+    "bottom short_frac in equal weight.\n\n"
+    "Honest caveats: (1) The paper's results are for a broad equity "
+    "cross-section; our 5-asset basket is a conceptual demonstration — "
+    "paper_claimed_* are left null. (2) With only a handful of assets the "
+    "beta adjustment may amplify measurement noise rather than reduce it. "
+    "(3) The residual is only as good as the single-factor market model; "
+    "multi-factor beta adjustment (FF3/FF5) would be a natural extension "
+    "but is out of scope for v1."
+)
+
+# Results are for a broad equity cross-section — not applicable to our basket.
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["aggressive"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "The momentum sleeve's factor-adjusted member. Pairs naturally with "
+    "jegadeesh_titman_1993_cross_sectional_momentum: both rank a universe, "
+    "but this one penalizes assets whose past performance is explained by "
+    "riding the market rather than genuine alpha. In a high-beta-rising-market "
+    "regime the two signals may diverge, which is precisely the informative "
+    "comparison for the strategy library."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+
+class BlitzHanauerRMOM(bt.Strategy):
+    """Rank assets by beta-adjusted formation-window return; long top, short bottom.
+
+    Expects N>=2 data feeds (``self.datas[i]``). ``self.datas[0]`` is the
+    market benchmark (SPY). Driven by ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("lookback", 252),  # formation window start (bars back)
+        ("skip", 21),  # skip most-recent bars (short-term reversal control)
+        ("rebalance_every", 21),  # ~monthly rebalance
+        ("beta_window", 63),  # rolling window for beta estimation (bars)
+        ("long_frac", 0.4),  # long the top 40% by residual return
+        ("short_frac", 0.4),  # short the bottom 40%
+        ("gross", 1.0),  # total gross exposure split equally across legs
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    # ------------------------------------------------------------------
+    # Pure-Python helpers (no numpy)
+    # ------------------------------------------------------------------
+
+    def _formation_return(self, data) -> float | None:
+        """Total return from close[-lookback] to close[-skip]."""
+        lookback = int(self.params.lookback)
+        skip = int(self.params.skip)
+        need = lookback + 1
+        if len(data) < need:
+            return None
+        old = float(data.close[-lookback])
+        recent = float(data.close[-skip])
+        if old <= 0:
+            return None
+        return recent / old - 1.0
+
+    def _daily_returns(self, data, n: int) -> list[float]:
+        """Collect n most-recent daily simple returns (oldest first).
+
+        Uses the n+1 most recent closes: close[-(n)] … close[0].
+        Returns a list of length n; returns [] on any zero-price or
+        insufficient-history condition.
+        """
+        if len(data) < n + 1:
+            return []
+        rets: list[float] = []
+        for i in range(n, 0, -1):
+            prev = float(data.close[-(i + 1)])
+            curr = float(data.close[-i])
+            if prev <= 0:
+                return []
+            rets.append(curr / prev - 1.0)
+        return rets
+
+    @staticmethod
+    def _sample_cov(xs: list[float], ys: list[float]) -> float | None:
+        """Sample covariance of two equal-length lists."""
+        n = len(xs)
+        if n < 2 or len(ys) != n:
+            return None
+        mx = sum(xs) / n
+        my = sum(ys) / n
+        return sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / (n - 1)
+
+    @staticmethod
+    def _sample_var(xs: list[float]) -> float | None:
+        """Sample variance of a list."""
+        n = len(xs)
+        if n < 2:
+            return None
+        mx = sum(xs) / n
+        return sum((x - mx) ** 2 for x in xs) / (n - 1)
+
+    def _rolling_beta(self, data) -> float | None:
+        """OLS beta of data's daily returns vs self.datas[0] daily returns.
+
+        Estimated over the most recent beta_window bars.
+        Returns None if there is insufficient history or market variance is zero.
+        """
+        n = int(self.params.beta_window)
+        if len(data) < n + 1 or len(self.datas[0]) < n + 1:
+            return None
+        asset_rets = self._daily_returns(data, n)
+        mkt_rets = self._daily_returns(self.datas[0], n)
+        if len(asset_rets) != n or len(mkt_rets) != n:
+            return None
+        cov = self._sample_cov(asset_rets, mkt_rets)
+        var = self._sample_var(mkt_rets)
+        if cov is None or var is None or var <= 0:
+            return None
+        return cov / var
+
+    def _residual_return(self, data) -> float | None:
+        """Beta-adjusted formation-window return.
+
+        residual = total_asset_return - beta * total_market_return
+        """
+        asset_ret = self._formation_return(data)
+        mkt_ret = self._formation_return(self.datas[0])
+        if asset_ret is None or mkt_ret is None:
+            return None
+        beta = self._rolling_beta(data)
+        if beta is None:
+            # Fall back to unadjusted total return if beta cannot be estimated.
+            return asset_ret
+        return asset_ret - beta * mkt_ret
+
+    # ------------------------------------------------------------------
+    # backtrader entry point
+    # ------------------------------------------------------------------
+
+    def next(self) -> None:
+        if len(self) <= int(self.params.lookback):
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        # Rank all assets EXCEPT the market benchmark (datas[0]).
+        candidates = self.datas[1:] if len(self.datas) > 1 else []
+        if not candidates:
+            self.order_target_percent(data=self.datas[0], target=0.0)
+            return
+
+        scored: list[tuple[float, object]] = []
+        for d in candidates:
+            rr = self._residual_return(d)
+            if rr is not None:
+                scored.append((rr, d))
+
+        n = len(scored)
+        if n < 2:
+            return
+
+        scored.sort(key=lambda x: x[0], reverse=True)  # best first
+
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        # Prevent overlap.
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        # Market benchmark held flat.
+        self.order_target_percent(data=self.datas[0], target=0.0)
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)

--- a/analytics-engine/strategies/blitz_hanauer_2010_rmom.py
+++ b/analytics-engine/strategies/blitz_hanauer_2010_rmom.py
@@ -12,8 +12,6 @@ Requires ``engine.run_multi_backtest`` (ranks assets cross-sectionally).
 
 from __future__ import annotations
 
-import math
-
 import backtrader as bt
 
 PAPER_ARXIV_ID: str | None = None
@@ -163,7 +161,7 @@ class BlitzHanauerRMOM(bt.Strategy):
             return None
         mx = sum(xs) / n
         my = sum(ys) / n
-        return sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / (n - 1)
+        return sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True)) / (n - 1)
 
     @staticmethod
     def _sample_var(xs: list[float]) -> float | None:

--- a/analytics-engine/strategies/frazzini_pedersen_2014_bab.py
+++ b/analytics-engine/strategies/frazzini_pedersen_2014_bab.py
@@ -1,0 +1,229 @@
+"""Betting Against Beta — Frazzini & Pedersen (2014).
+
+Long leveraged low-beta assets, short deleveraged high-beta assets.
+The low-beta anomaly contradicts CAPM: constrained investors' preference
+for high-beta assets drives a flat or inverted Security Market Line, so
+BAB earns alpha from the other side of that tilt.
+
+Requires ``engine.run_multi_backtest`` (ranks assets cross-sectionally by
+estimated rolling beta). ``self.datas[0]`` is treated as the market benchmark
+(assumed SPY); the remaining feeds are the investable universe.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Betting Against Beta"
+PAPER_AUTHORS: list[str] = ["Andrea Frazzini", "Lasse Heje Pedersen"]
+PAPER_VENUE = "Journal of Financial Economics"
+PAPER_YEAR = 2014
+PAPER_DOI = "10.1016/j.jfineco.2013.10.005"
+PAPER_CITATION_COUNT = 4200  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# Low-beta strategies outperform in down / stressed markets.
+REGIME_TAG: str = "bear"
+
+METHODOLOGY_SUMMARY = (
+    "Estimate rolling OLS beta for each asset versus the market benchmark. "
+    "Long the lowest-beta assets (leveraged to unit beta) and short the "
+    "highest-beta assets (deleveraged to unit beta), earning the spread "
+    "between the Security Market Line's slope and the actual flat/inverted SML."
+)
+
+METHODOLOGY_TEXT = (
+    "Frazzini & Pedersen (2014) document that the Security Market Line is "
+    "empirically flat or even inverted: high-beta assets earn lower "
+    "risk-adjusted returns than CAPM predicts, and low-beta assets earn "
+    "higher ones. The mechanism is leverage constraints: institutional "
+    "investors who cannot lever up buy high-beta equities to increase "
+    "expected returns, bidding up their prices and compressing their "
+    "future returns. BAB exploits this by going long a portfolio of "
+    "low-beta assets leveraged to unit beta and short a portfolio of "
+    "high-beta assets deleveraged to unit beta.\n\n"
+    "v1 Archimedes adaptation (cross-asset, N-feed engine): each rebalance "
+    "(every ~21 bars) we estimate a rolling 63-day OLS beta for each asset "
+    "vs datas[0] (the market benchmark, assumed SPY) using daily close "
+    "returns. Assets are ranked by beta; the bottom long_frac are held long "
+    "and the top short_frac are held short, in equal weight within each leg "
+    "(order_target_percent). No explicit leverage rescaling to unit beta is "
+    "applied — only the sign and equal weight within each leg — because the "
+    "core insight (long low-beta, short high-beta) survives without it.\n\n"
+    "Honest caveats: (1) The paper's results are for a broad US equity "
+    "cross-section (thousands of stocks); our 5-asset basket is a conceptual "
+    "demonstration of the signal, not a replication — paper_claimed_* are "
+    "left null. (2) Beta is estimated from daily price-only data with no "
+    "dividend or factor adjustment; measurement error in beta is higher for "
+    "a small universe. (3) With only a handful of assets the long/short "
+    "buckets may each contain only one or two names, so diversification is "
+    "thin and idiosyncratic risk dominates."
+)
+
+# Results are for a broad US equity cross-section — not applicable to our basket.
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["conservative", "moderate"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "The beta-anomaly sleeve. Complements the momentum strategies: momentum "
+    "is a bull-regime signal, BAB works best in bear/stressed regimes when "
+    "high-beta assets draw down sharply. Low-beta assets (Treasuries, gold) "
+    "in the long leg provide natural flight-to-quality exposure."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+
+class FrazziniPedersenBAB(bt.Strategy):
+    """Rank assets by rolling OLS beta; long low-beta, short high-beta.
+
+    Expects N>=2 data feeds (``self.datas[i]``). ``self.datas[0]`` is the
+    market benchmark (SPY). Driven by ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("lookback", 63),  # rolling window for beta estimation (bars)
+        ("rebalance_every", 21),  # ~monthly rebalance
+        ("min_history", 64),  # minimum bars before any position is taken
+        ("long_frac", 0.4),  # long the bottom 40% (lowest beta) of the universe
+        ("short_frac", 0.4),  # short the top 40% (highest beta)
+        ("gross", 1.0),  # total gross exposure split equally across legs
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    # ------------------------------------------------------------------
+    # Pure-Python helpers (no numpy)
+    # ------------------------------------------------------------------
+
+    def _daily_returns(self, data, n: int) -> list[float]:
+        """Collect n most-recent daily simple returns.
+
+        Returns a list of length n where element 0 is the oldest and element
+        n-1 is the most recent. ``data.close[-i]`` accesses i bars back from
+        the current bar (close[0] is the current close).
+        """
+        rets: list[float] = []
+        # We need n consecutive (prev, curr) close pairs.
+        # Pair i: prev = close[-(i+1)], curr = close[-i]  (i from n down to 1)
+        for i in range(n, 0, -1):
+            prev = float(data.close[-(i + 1)])
+            curr = float(data.close[-i])
+            if prev <= 0:
+                return []
+            rets.append(curr / prev - 1.0)
+        return rets
+
+    @staticmethod
+    def _sample_cov(xs: list[float], ys: list[float]) -> float | None:
+        """Sample covariance of two equal-length lists."""
+        n = len(xs)
+        if n < 2 or len(ys) != n:
+            return None
+        mx = sum(xs) / n
+        my = sum(ys) / n
+        return sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / (n - 1)
+
+    @staticmethod
+    def _sample_var(xs: list[float]) -> float | None:
+        """Sample variance of a list."""
+        n = len(xs)
+        if n < 2:
+            return None
+        mx = sum(xs) / n
+        return sum((x - mx) ** 2 for x in xs) / (n - 1)
+
+    def _rolling_beta(self, data) -> float | None:
+        """OLS beta of data's daily returns vs self.datas[0] daily returns.
+
+        Returns None if there is insufficient history or variance is zero.
+        """
+        n = int(self.params.lookback)
+        # Need n+1 closes to produce n returns.
+        if len(data) < n + 1 or len(self.datas[0]) < n + 1:
+            return None
+        asset_rets = self._daily_returns(data, n)
+        mkt_rets = self._daily_returns(self.datas[0], n)
+        if len(asset_rets) != n or len(mkt_rets) != n:
+            return None
+        cov = self._sample_cov(asset_rets, mkt_rets)
+        var = self._sample_var(mkt_rets)
+        if cov is None or var is None or var <= 0:
+            return None
+        return cov / var
+
+    # ------------------------------------------------------------------
+    # backtrader entry point
+    # ------------------------------------------------------------------
+
+    def next(self) -> None:
+        if len(self) <= int(self.params.min_history):
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        # Compute betas for all assets EXCEPT the market benchmark (datas[0]).
+        # If there are no other assets, nothing to rank.
+        candidates = self.datas[1:] if len(self.datas) > 1 else []
+        if not candidates:
+            # Single-asset universe: flatten to zero.
+            self.order_target_percent(data=self.datas[0], target=0.0)
+            return
+
+        scored: list[tuple[float, object]] = []
+        for d in candidates:
+            beta = self._rolling_beta(d)
+            if beta is not None:
+                scored.append((beta, d))
+
+        n = len(scored)
+        if n < 1:
+            return
+        if n == 1:
+            # Cannot form both legs — flatten.
+            self.order_target_percent(data=scored[0][1], target=0.0)
+            return
+
+        scored.sort(key=lambda x: x[0])  # ascending: lowest beta first
+
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        # Prevent overlap.
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        # Market benchmark is never held directly; set to flat.
+        self.order_target_percent(data=self.datas[0], target=0.0)
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)

--- a/analytics-engine/strategies/frazzini_pedersen_2014_bab.py
+++ b/analytics-engine/strategies/frazzini_pedersen_2014_bab.py
@@ -12,8 +12,6 @@ estimated rolling beta). ``self.datas[0]`` is treated as the market benchmark
 
 from __future__ import annotations
 
-import math
-
 import backtrader as bt
 
 PAPER_ARXIV_ID: str | None = None
@@ -140,7 +138,7 @@ class FrazziniPedersenBAB(bt.Strategy):
             return None
         mx = sum(xs) / n
         my = sum(ys) / n
-        return sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / (n - 1)
+        return sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True)) / (n - 1)
 
     @staticmethod
     def _sample_var(xs: list[float]) -> float | None:

--- a/analytics-engine/strategies/novy_marx_2013_qmj.py
+++ b/analytics-engine/strategies/novy_marx_2013_qmj.py
@@ -1,0 +1,188 @@
+"""Quality Minus Junk — Asness, Frazzini & Pedersen 2019 (price-based proxy).
+
+The paper defines quality along four dimensions (profitability, safety,
+growth, payout) using accounting fundamentals. Because the analytics engine
+has no fundamental data we use the information ratio (mean_return / std_return)
+over a trailing window as a price-based proxy for quality. The proxy captures
+the two most tractable dimensions: a positive drift maps to 'profitable', and
+low daily-return volatility maps to 'safe'. This is an approximation; see
+METHODOLOGY_TEXT for the honest caveats and scope of the adaptation.
+
+Requires ``engine.run_multi_backtest`` (reads every ``self.datas[i]`` each
+rebalance). ``self.datas[0]`` is the market benchmark (assumed SPY) and is
+included in the quality ranking.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Quality Minus Junk"
+PAPER_AUTHORS: list[str] = ["Clifford Asness", "Andrea Frazzini", "Lasse Heje Pedersen"]
+PAPER_VENUE = "Review of Accounting Studies"
+PAPER_YEAR = 2019
+PAPER_DOI = "10.1007/s11142-018-9470-2"
+PAPER_CITATION_COUNT = 1200  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# Quality is defensive — the QMJ premium is persistent across regimes but
+# strongest when junk sells off; the strategy is broadly regime-neutral.
+REGIME_TAG: str = "neutral"
+
+METHODOLOGY_SUMMARY = (
+    "Price-based proxy for the Quality Minus Junk factor. Rank assets by "
+    "information ratio (mean / std of daily returns) over a trailing window. "
+    "Long the high-quality (high IR) assets, short the low-quality (low IR) "
+    "assets. A cross-sectional quality tilt without fundamental data."
+)
+
+METHODOLOGY_TEXT = (
+    "Asness, Frazzini & Pedersen (2019) define quality along four dimensions "
+    "computed from Compustat accounting data: (1) Profitability — ROA, ROE, "
+    "gross margins, and accruals; (2) Safety — leverage, Altman Z-score, and "
+    "idiosyncratic volatility; (3) Growth — five-year growth rates in the "
+    "profitability measures; (4) Payout — equity and debt issuance, buyback "
+    "yield. Each dimension is standardized and equally weighted into a single "
+    "quality score. Going long high-quality and short low-quality ('junk') "
+    "equities earned a Sharpe of approximately 1.0 on US stocks from 1956 to "
+    "2012, largely independent of the market, value, and momentum factors.\n\n"
+    "v1 Archimedes adaptation — price-based proxy: the analytics engine does "
+    "not have balance-sheet or income-statement data, so we replace the four "
+    "accounting dimensions with a single price-derived proxy: the information "
+    "ratio (IR) = mean(daily_return) / std(daily_return) over the trailing "
+    "'lookback' bars. The IR is tractable because it simultaneously captures "
+    "the two most quantifiable quality dimensions — 'profitability' (positive "
+    "drift, high mean return) and 'safety' (low variance). Growth and payout "
+    "have no clean price-based analogue and are omitted. Each rebalance "
+    "(every ~21 bars) assets are ranked by IR, the top long_frac are held "
+    "long, and the bottom short_frac are held short, each in equal weight.\n\n"
+    "Honest caveats: (1) This is a loose approximation of QMJ, not a faithful "
+    "implementation. The paper's Sharpe ~1.0 is for a fundamental-data quality "
+    "score on a broad US equity cross-section 1956-2012; it is provided as "
+    "research context, not a benchmark for this adaptation — PAPER_CLAIMED_* "
+    "are left null. (2) The IR proxy conflates the 'safety' and 'profitability' "
+    "dimensions and captures nothing of 'growth' or 'payout'. (3) In a small "
+    "cross-asset universe (SPY, NIKKEI, GOLD, TREASURY, OIL) the concept of "
+    "cross-sectional quality is economically less clean than in a 500-stock "
+    "universe. (4) Short positions in the analytics engine are executed at "
+    "market via order_target_percent; realistic short-selling costs are not "
+    "modelled."
+)
+
+# Fundamental-data Sharpe on the full US stock cross-section — not a
+# like-for-like benchmark for this price-proxy cross-asset adaptation.
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["conservative", "moderate"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "Quality sleeve. Uses information ratio as a price-based proxy for the "
+    "Asness-Frazzini-Pedersen quality score. Pairs well with the momentum "
+    "strategies (Jegadeesh-Titman, TSMOM) as a defensive complement — quality "
+    "and momentum are historically lowly correlated. Status is 'candidate' "
+    "until backtest metrics are populated."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+
+class NoVyMarxQMJ(bt.Strategy):
+    """Rank assets by information ratio (quality proxy); long top, short bottom.
+
+    Expects N>=2 data feeds (``self.datas[i]``). Driven by
+    ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("lookback", 252),  # window for IR computation (bars)
+        ("rebalance_every", 21),  # ~monthly rebalance
+        ("long_frac", 0.4),  # long the top 40% by IR
+        ("short_frac", 0.4),  # short the bottom 40% by IR
+        ("gross", 1.0),  # total gross exposure split evenly across legs
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    def _daily_returns(self, data, n: int) -> list[float]:
+        """Return the last *n* daily simple returns for *data* (oldest first).
+
+        Uses close prices at negative indices: close[-1] is yesterday,
+        close[-n] is n bars ago.  Returns an empty list when history is
+        insufficient.
+        """
+        need = n + 1  # need n+1 closes to compute n returns
+        if len(data) < need:
+            return []
+        rets: list[float] = []
+        for i in range(n, 0, -1):  # i goes from n down to 1
+            prev = float(data.close[-i - 1])
+            curr = float(data.close[-i])
+            if prev > 0:
+                rets.append(curr / prev - 1.0)
+        return rets
+
+    def _information_ratio(self, data) -> float | None:
+        """Compute the information ratio over the lookback window.
+
+        Returns None when history is insufficient or std is zero.
+        """
+        rets = self._daily_returns(data, int(self.params.lookback))
+        n = len(rets)
+        if n < 2:
+            return None
+        mean = sum(rets) / n
+        variance = sum((r - mean) ** 2 for r in rets) / (n - 1)
+        if variance <= 0.0:
+            return None
+        return mean / math.sqrt(variance)
+
+    def next(self) -> None:
+        if len(self) <= int(self.params.lookback):
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        scored = [(self._information_ratio(d), d) for d in self.datas]
+        scored = [(ir, d) for ir, d in scored if ir is not None]
+        n = len(scored)
+        if n < 2:
+            return
+        scored.sort(key=lambda x: x[0], reverse=True)  # highest IR first
+
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        # Never let the long and short buckets overlap.
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)

--- a/analytics-engine/strategies/novy_marx_2013_qmj.py
+++ b/analytics-engine/strategies/novy_marx_2013_qmj.py
@@ -29,7 +29,7 @@ PAPER_CITATION_COUNT = 1200  # Snapshot 2026-06; verify via Semantic Scholar.
 
 # Quality is defensive — the QMJ premium is persistent across regimes but
 # strongest when junk sells off; the strategy is broadly regime-neutral.
-REGIME_TAG: str = "neutral"
+REGIME_TAG: str = "regime_neutral"
 
 METHODOLOGY_SUMMARY = (
     "Price-based proxy for the Quality Minus Junk factor. Rank assets by "

--- a/analytics-engine/tests/test_factor_strategies.py
+++ b/analytics-engine/tests/test_factor_strategies.py
@@ -1,0 +1,172 @@
+"""Tests for factor-based strategies: BAB, RMOM, QMJ, Low-IdiοVol.
+
+Hermetic: synthetic N-feed data, no network. Each strategy is loaded via
+strategy_loader (validates metadata + single strategy class) and run through
+engine.run_multi_backtest. Verifies plumbing and that capital is deployed.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.engine import BacktestResult, run_multi_backtest
+
+_STRATEGIES_DIR = Path(__file__).parent.parent / "strategies"
+sys.path.insert(0, str(_STRATEGIES_DIR))
+sys.path.insert(0, str(_STRATEGIES_DIR.parent / "src"))
+
+_NAMES = ["SPY", "^N225", "GC=F", "TLT", "CL=F"]
+
+
+def _factor_universe(n: int = 500) -> list[pd.DataFrame]:
+    """Five synthetic feeds with diverse beta/vol/trend profiles.
+
+    Feed 0 (SPY) is the market benchmark used by BAB/RMOM/IdioVol for
+    beta estimation.  Feeds 1-4 have distinct drift and noise levels so
+    ranking by beta, residual return, quality, or idio-vol produces a
+    meaningful spread.
+    """
+    specs = [
+        # (start_price, drift_per_bar, annual_vol_approx, phase)
+        (100.0, 0.08, 0.20, 0.0),   # SPY: moderate drift, moderate vol
+        (80.0,  0.03, 0.30, 1.0),   # high-vol, slow drift → high beta-like
+        (120.0, 0.12, 0.10, 2.0),   # low-vol, high drift → high quality
+        (90.0,  0.00, 0.40, 3.0),   # high-vol, flat → low quality
+        (70.0,  0.06, 0.15, 4.0),   # moderate
+    ]
+    frames = []
+    for base, drift, vol, phase in specs:
+        idx = pd.date_range("2014-01-01", periods=n, freq="D")
+        daily_sigma = vol / math.sqrt(252)
+        closes = []
+        price = base
+        for i in range(n):
+            price = price * (1.0 + drift / 252.0) + daily_sigma * price * math.sin(i / 15.0 + phase)
+            price = max(price, 1.0)
+            closes.append(price)
+        frames.append(
+            pd.DataFrame(
+                {
+                    "Open": [c - 0.2 for c in closes],
+                    "High": [c + 0.5 for c in closes],
+                    "Low":  [c - 0.5 for c in closes],
+                    "Close": closes,
+                    "Volume": [1_000] * n,
+                },
+                index=idx,
+            )
+        )
+    return frames
+
+
+@pytest.mark.parametrize(
+    ("stem", "expected_cls"),
+    [
+        ("frazzini_pedersen_2014_bab", "FrazziniPedersenBAB"),
+        ("blitz_hanauer_2010_rmom", "BlitzHanauerRMOM"),
+        ("novy_marx_2013_qmj", "NoVyMarxQMJ"),
+        ("ang_hodrick_2006_low_idiovol", "AngHodrickLowIdioVol"),
+    ],
+)
+def test_factor_strategy_loads_and_runs(stem: str, expected_cls: str) -> None:
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(_STRATEGIES_DIR / f"{stem}.py")
+    assert bundle.cls.__name__ == expected_cls
+
+    frames = _factor_universe()
+    result = run_multi_backtest(frames, strategy_cls=bundle.cls, initial_cash=100_000.0, names=_NAMES)
+
+    assert isinstance(result, BacktestResult)
+    assert result.bars == 500
+    assert result.look_ahead_audit_passed is True
+    assert isinstance(result.daily_returns, list)
+    assert len(result.daily_returns) > 0
+    assert result.final_value != pytest.approx(100_000.0, rel=1e-3)
+
+
+@pytest.mark.parametrize(
+    "stem",
+    [
+        "frazzini_pedersen_2014_bab",
+        "blitz_hanauer_2010_rmom",
+        "novy_marx_2013_qmj",
+        "ang_hodrick_2006_low_idiovol",
+    ],
+)
+def test_factor_strategy_metadata(stem: str) -> None:
+    """Each strategy file must export the required metadata constants."""
+    import importlib.util
+
+    path = _STRATEGIES_DIR / f"{stem}.py"
+    spec = importlib.util.spec_from_file_location(stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert isinstance(mod.PAPER_TITLE, str) and mod.PAPER_TITLE
+    assert isinstance(mod.PAPER_AUTHORS, list) and len(mod.PAPER_AUTHORS) >= 1
+    assert isinstance(mod.PAPER_YEAR, int) and mod.PAPER_YEAR > 1900
+    assert mod.REGIME_TAG in ("bull", "bear", "neutral", "all")
+    assert isinstance(mod.RISK_PROFILES, list) and len(mod.RISK_PROFILES) >= 1
+    assert mod.STATUS in ("live", "candidate", "deprecated")
+    assert isinstance(mod.METHODOLOGY_SUMMARY, str) and len(mod.METHODOLOGY_SUMMARY) > 20
+    assert isinstance(mod.METHODOLOGY_TEXT, str) and len(mod.METHODOLOGY_TEXT) > 100
+
+
+def test_bab_flattens_when_insufficient_history() -> None:
+    """BAB should not crash and should hold 0% exposure when fewer bars than lookback."""
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(_STRATEGIES_DIR / "frazzini_pedersen_2014_bab.py")
+
+    # Only 30 bars — less than BAB's beta_window=63; strategy must return without trading
+    short_frames = _factor_universe(n=30)
+    result = run_multi_backtest(short_frames, strategy_cls=bundle.cls, initial_cash=100_000.0, names=_NAMES)
+
+    assert isinstance(result, BacktestResult)
+    # With no trades, final_value equals initial cash (no positions taken)
+    assert result.final_value == pytest.approx(100_000.0, rel=1e-4)
+
+
+def test_rmom_degrades_gracefully_without_beta() -> None:
+    """RMOM falls back to unadjusted total return when beta cannot be estimated."""
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(_STRATEGIES_DIR / "blitz_hanauer_2010_rmom.py")
+
+    # 300 bars — enough for formation window (252+21=273) but NOT for beta_window=63
+    # on top of that, so beta fallback path should trigger for the first few rebalances
+    frames = _factor_universe(n=300)
+    result = run_multi_backtest(frames, strategy_cls=bundle.cls, initial_cash=100_000.0, names=_NAMES)
+
+    assert isinstance(result, BacktestResult)
+    assert result.look_ahead_audit_passed is True
+
+
+def test_qmj_scores_spread_across_universe() -> None:
+    """QMJ should assign distinct quality scores to the diverse synthetic universe."""
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(_STRATEGIES_DIR / "novy_marx_2013_qmj.py")
+    frames = _factor_universe(n=400)
+    result = run_multi_backtest(frames, strategy_cls=bundle.cls, initial_cash=100_000.0, names=_NAMES)
+
+    assert isinstance(result, BacktestResult)
+    assert result.bars == 400
+    assert result.look_ahead_audit_passed is True
+
+
+def test_ang_hodrick_excludes_market_benchmark() -> None:
+    """Ang-Hodrick must exclude datas[0] from idio-vol ranking (it has zero residual vol)."""
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(_STRATEGIES_DIR / "ang_hodrick_2006_low_idiovol.py")
+    frames = _factor_universe(n=400)
+    result = run_multi_backtest(frames, strategy_cls=bundle.cls, initial_cash=100_000.0, names=_NAMES)
+
+    assert isinstance(result, BacktestResult)
+    assert result.final_value != pytest.approx(100_000.0, rel=1e-3)

--- a/analytics-engine/tests/test_factor_strategies.py
+++ b/analytics-engine/tests/test_factor_strategies.py
@@ -32,11 +32,11 @@ def _factor_universe(n: int = 500) -> list[pd.DataFrame]:
     """
     specs = [
         # (start_price, drift_per_bar, annual_vol_approx, phase)
-        (100.0, 0.08, 0.20, 0.0),   # SPY: moderate drift, moderate vol
-        (80.0,  0.03, 0.30, 1.0),   # high-vol, slow drift → high beta-like
-        (120.0, 0.12, 0.10, 2.0),   # low-vol, high drift → high quality
-        (90.0,  0.00, 0.40, 3.0),   # high-vol, flat → low quality
-        (70.0,  0.06, 0.15, 4.0),   # moderate
+        (100.0, 0.08, 0.20, 0.0),  # SPY: moderate drift, moderate vol
+        (80.0, 0.03, 0.30, 1.0),  # high-vol, slow drift → high beta-like
+        (120.0, 0.12, 0.10, 2.0),  # low-vol, high drift → high quality
+        (90.0, 0.00, 0.40, 3.0),  # high-vol, flat → low quality
+        (70.0, 0.06, 0.15, 4.0),  # moderate
     ]
     frames = []
     for base, drift, vol, phase in specs:
@@ -53,7 +53,7 @@ def _factor_universe(n: int = 500) -> list[pd.DataFrame]:
                 {
                     "Open": [c - 0.2 for c in closes],
                     "High": [c + 0.5 for c in closes],
-                    "Low":  [c - 0.5 for c in closes],
+                    "Low": [c - 0.5 for c in closes],
                     "Close": closes,
                     "Volume": [1_000] * n,
                 },
@@ -110,7 +110,7 @@ def test_factor_strategy_metadata(stem: str) -> None:
     assert isinstance(mod.PAPER_TITLE, str) and mod.PAPER_TITLE
     assert isinstance(mod.PAPER_AUTHORS, list) and len(mod.PAPER_AUTHORS) >= 1
     assert isinstance(mod.PAPER_YEAR, int) and mod.PAPER_YEAR > 1900
-    assert mod.REGIME_TAG in ("bull", "bear", "neutral", "all")
+    assert mod.REGIME_TAG in ("bull", "bear", "regime_neutral")
     assert isinstance(mod.RISK_PROFILES, list) and len(mod.RISK_PROFILES) >= 1
     assert mod.STATUS in ("live", "candidate", "deprecated")
     assert isinstance(mod.METHODOLOGY_SUMMARY, str) and len(mod.METHODOLOGY_SUMMARY) > 20

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -148,7 +148,12 @@ class TestStrategyRoutes:
         assert "id" in s
         assert "paper_title" in s
         assert "sharpe_ratio" in s
-        assert s["is_backtest_placeholder"] is False
+        # A strategy with a real backtest fixture must surface as non-placeholder.
+        # Don't assume index[0] is fixtured: candidate strategies added without a
+        # backtest fixture can legitimately sort first alphabetically and read as
+        # placeholders, so assert the non-placeholder path is exercised somewhere
+        # in the listing rather than at a brittle fixed position.
+        assert any(st["is_backtest_placeholder"] is False for st in data["strategies"])
 
     def test_get_strategy_signals(self, client):
         resp = client.get("/api/strategies/signals")
@@ -180,8 +185,11 @@ class TestStrategyRoutes:
     def test_rigor_gate_fields_correct_for_tier1(self, client, seeded_db):
         """Moreira-Muir fixture values flow correctly: dsr_p_value ≥ 0.95, passes_rigor_gate=True."""
         strategies = _list_all_strategies(client)
+        # Match Moreira-Muir specifically by its full title. A bare "Volatility"
+        # substring also matches Ang-Hodrick's "The Cross-Section of Volatility
+        # and Expected Returns", which sorts first and would hijack this lookup.
         mm = next(
-            (s for s in strategies if "Volatility" in s.get("paper_title", "")),
+            (s for s in strategies if "Volatility-Managed" in s.get("paper_title", "")),
             None,
         )
         if mm is None:


### PR DESCRIPTION
Adds four price-based cross-asset factor strategies (all STATUS=candidate, pure-Python, honest paper-claim caveats in METHODOLOGY_TEXT):

- **BAB** — Betting Against Beta (Frazzini-Pedersen 2014)
- **RMOM** — Residual Momentum (Blitz-Huij-Martens 2011)
- **QMJ** — Quality Minus Junk proxy (Asness-Frazzini-Pedersen 2019)
- **Low-IdioVol** — Low idiosyncratic volatility (Ang-Hodrick 2006)

Each is a price-based adaptation of a stock-cross-section paper; PAPER_CLAIMED_* left null and disclosed in the methodology text.

Tests: 12 passing (analytics-engine factor suite).