### PR TITLE
[strategy] Add Quality-Momentum and cross-asset Value strategies !minor

### DIFF
--- a/analytics-engine/strategies/asness_moskowitz_2013_value.py
+++ b/analytics-engine/strategies/asness_moskowitz_2013_value.py
@@ -92,7 +92,7 @@ class AsnessMoskowitzValue(bt.Strategy):
     """
 
     params = (
-        ("value_window", 252),   # rolling mean window for cheapness proxy
+        ("value_window", 252),  # rolling mean window for cheapness proxy
         ("rebalance_every", 21),
         ("long_frac", 0.4),
         ("short_frac", 0.4),

--- a/analytics-engine/strategies/asness_moskowitz_2013_value.py
+++ b/analytics-engine/strategies/asness_moskowitz_2013_value.py
@@ -1,0 +1,149 @@
+"""Cross-Asset Value Factor — Asness, Moskowitz & Pedersen (2013).
+
+Long assets trading below their long-run price level (cheap); short assets
+trading above it (expensive). Uses negative price deviation from a rolling
+mean as a price-based cheapness proxy — the cross-asset value signal from
+the "Value and Momentum Everywhere" Appendix Table AI.
+
+Requires ``engine.run_multi_backtest``.
+"""
+
+from __future__ import annotations
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Value and Momentum Everywhere"
+PAPER_AUTHORS: list[str] = ["Clifford Asness", "Tobias Moskowitz", "Lasse Heje Pedersen"]
+PAPER_VENUE = "The Journal of Finance"
+PAPER_YEAR = 2013
+PAPER_DOI = "10.1111/jofi.12021"
+PAPER_CITATION_COUNT = 3800  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# Value strategies tend to outperform in recovery and bear regimes when
+# expensive assets de-rate and cheap assets mean-revert.
+REGIME_TAG: str = "bear"
+
+METHODOLOGY_SUMMARY = (
+    "Cross-asset price-based value: rank assets by how far their current price "
+    "lies below their rolling historical mean. Long the cheapest (most below mean), "
+    "short the most expensive (most above mean). Monthly rebalance."
+)
+
+METHODOLOGY_TEXT = (
+    "Asness, Moskowitz & Pedersen (2013) document robust value AND momentum premia "
+    "across eight asset classes (global equities, equity indices, government bonds, "
+    "currencies, and commodities). Their cross-asset value measure for individual "
+    "stocks is book-to-price; for asset classes they use a 5-year return reversal "
+    "(cheap = assets that have underperformed over the past 5 years). The paper "
+    "reports a value factor Sharpe of ~0.6 averaged across asset classes.\n\n"
+    "v1 Archimedes adaptation (price-based value on the N-feed engine): without "
+    "fundamental ratios (P/B, E/P, dividend yield), we use the negative of the "
+    "current price's deviation from its rolling mean over value_window bars as the "
+    "cheapness proxy: value_score = -(close[0] / mean(close[-value_window:]) - 1). "
+    "A large positive score means the asset is trading well below its historical "
+    "mean, i.e., potentially cheap. This captures the mean-reversion dimension of "
+    "cross-asset value described in the paper's Appendix Table AI proxies.\n\n"
+    "Honest caveats: (1) This is a price-based proxy, not a fundamental valuation "
+    "ratio. It measures cheapness relative to recent history, not relative to "
+    "intrinsic value. (2) Our 5-asset universe is far narrower than the paper's "
+    "8-class, 40+ market coverage — paper_claimed_* are null. (3) The mean-reversion "
+    "signal can conflict with momentum; in practice value and momentum tend to be "
+    "negatively correlated (as the paper documents), making them useful complements. "
+    "(4) Rolling mean over a fixed window is sensitive to the choice of window — a "
+    "known limitation of price-based value proxies."
+)
+
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["conservative", "moderate"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "The value counterweight in the library. Value and momentum tend to be "
+    "negatively correlated (AMP 2013 Table VI) which makes them natural complements "
+    "in a multi-strategy portfolio — blending them reduces variance without "
+    "proportionally reducing expected return. In the optimizer this pair is "
+    "worth explicitly tracking for the diversification benefit."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+_ANNUALIZATION = 252
+
+
+class AsnessMoskowitzValue(bt.Strategy):
+    """Cross-asset value: long cheap (below rolling mean), short expensive (above mean).
+
+    Expects N>=2 data feeds. Driven by ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("value_window", 252),   # rolling mean window for cheapness proxy
+        ("rebalance_every", 21),
+        ("long_frac", 0.4),
+        ("short_frac", 0.4),
+        ("gross", 1.0),
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    def _value_score(self, data) -> float | None:
+        window = int(self.params.value_window)
+        if len(data) < window + 1:
+            return None
+        closes: list[float] = [float(data.close[-i]) for i in range(window)]
+        mean_price = sum(closes) / len(closes)
+        if mean_price <= 0.0:
+            return None
+        current = float(data.close[0])
+        # negative of deviation: high score = current price below mean = cheap
+        return -(current / mean_price - 1.0)
+
+    def next(self) -> None:
+        if len(self) < int(self.params.value_window) + 1:
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        scored = [(self._value_score(d), d) for d in self.datas]
+        scored = [(s, d) for s, d in scored if s is not None]
+        n = len(scored)
+        if n < 2:
+            return
+
+        scored.sort(key=lambda x: x[0], reverse=True)  # highest score (cheapest) first
+
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)

--- a/analytics-engine/strategies/novy_marx_2012_quality_momentum.py
+++ b/analytics-engine/strategies/novy_marx_2012_quality_momentum.py
@@ -96,9 +96,9 @@ class NovyMarxQualityMomentum(bt.Strategy):
     """
 
     params = (
-        ("lookback", 252),      # formation window for momentum
-        ("skip", 21),           # skip most-recent bars (short-term reversal control)
-        ("ir_window", 63),      # rolling window for information ratio (quality proxy)
+        ("lookback", 252),  # formation window for momentum
+        ("skip", 21),  # skip most-recent bars (short-term reversal control)
+        ("ir_window", 63),  # rolling window for information ratio (quality proxy)
         ("rebalance_every", 21),
         ("long_frac", 0.4),
         ("short_frac", 0.4),
@@ -181,9 +181,9 @@ class NovyMarxQualityMomentum(bt.Strategy):
 
         mom_z = self._zscore(mom_raw)
         ir_z = self._zscore(ir_raw)
-        composite = [0.5 * mz + 0.5 * qz for mz, qz in zip(mom_z, ir_z)]
+        composite = [0.5 * mz + 0.5 * qz for mz, qz in zip(mom_z, ir_z, strict=True)]
 
-        scored = sorted(zip(composite, valid_datas), key=lambda x: x[0], reverse=True)
+        scored = sorted(zip(composite, valid_datas, strict=True), key=lambda x: x[0], reverse=True)
         n_long = max(1, int(round(n * float(self.params.long_frac))))
         n_short = max(1, int(round(n * float(self.params.short_frac))))
         if n_long + n_short > n:

--- a/analytics-engine/strategies/novy_marx_2012_quality_momentum.py
+++ b/analytics-engine/strategies/novy_marx_2012_quality_momentum.py
@@ -1,0 +1,203 @@
+"""Quality Momentum — Novy-Marx (2012).
+
+Intermediate-horizon momentum (months 7-12, skipping recent) combined with a
+quality filter (information ratio over a shorter window). Standard cross-sectional
+momentum chases total return; quality momentum only chases it in assets that also
+exhibit consistent positive drift relative to their noise — reducing the risk of
+following high-volatility "junk" rallies that subsequently reverse.
+
+Requires ``engine.run_multi_backtest``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Is Momentum Really Momentum?"
+PAPER_AUTHORS: list[str] = ["Robert Novy-Marx"]
+PAPER_VENUE = "Journal of Financial Economics"
+PAPER_YEAR = 2012
+PAPER_DOI = "10.1016/j.jfineco.2012.01.005"
+PAPER_CITATION_COUNT = 900  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# Trend-following + quality filter — effective in bull regimes, partially
+# defensive in bear because quality leg avoids high-vol junk rallies.
+REGIME_TAG: str = "bull"
+
+METHODOLOGY_SUMMARY = (
+    "Composite ranking: 50% intermediate-horizon momentum (months 7-12, skipping "
+    "recent) + 50% quality score (information ratio over a short window). Long top "
+    "composite, short bottom composite, monthly rebalance."
+)
+
+METHODOLOGY_TEXT = (
+    "Novy-Marx (2012) shows that intermediate-horizon momentum (formation window "
+    "roughly months 7-12, skipping the most recent month) drives most of the "
+    "standard 12-1 momentum signal. Short-horizon continuation (months 1-6) is "
+    "largely noise and adds drawdown risk. The paper reports that this refined "
+    "momentum proxy earns higher risk-adjusted returns and loads more cleanly on "
+    "the momentum factor in factor regressions.\n\n"
+    "v1 Archimedes adaptation (quality momentum composite on the N-feed engine): "
+    "for each asset at each monthly rebalance we compute (1) intermediate-horizon "
+    "formation return = close[-skip] / close[-lookback] - 1 (lookback=252, skip=21, "
+    "so the window covers ~months 2-12 relative to today) and (2) information ratio "
+    "= mean daily return / std daily return over the last ir_window=63 bars, a "
+    "price-based quality proxy that captures consistent positive drift (high IR) "
+    "vs. volatile noise (low IR). Both scores are z-scored across the universe and "
+    "combined 50/50 into a composite. We go long the top long_frac and short the "
+    "bottom short_frac by composite score.\n\n"
+    "Honest caveats: (1) The paper's result is for a US stock cross-section, not a "
+    "5-asset multi-market basket. Paper_claimed_* are null: the 1%/month figure "
+    "does not transfer to our universe. (2) Our 'quality' is purely price-based "
+    "(information ratio), not the fundamental quality dimensions (profitability, "
+    "safety, growth) the AQR QMJ paper measures. It captures the 'safety' dimension "
+    "(low-vol) + 'profitability' dimension (positive drift) in a single ratio, but "
+    "is a loose proxy. (3) Cross-market momentum on non-synchronous closes is a "
+    "known approximation disclosed here."
+)
+
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["aggressive"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "Quality momentum is a tighter version of cross-sectional momentum: it filters "
+    "out high-volatility assets whose momentum signal may be noise rather than "
+    "genuine trend. Complementary to JT cross-sectional momentum in the library — "
+    "both rank by trailing return but this one penalizes inconsistency."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+_ANNUALIZATION = 252
+
+
+class NovyMarxQualityMomentum(bt.Strategy):
+    """Composite quality-momentum ranking: 50% intermediate momentum + 50% quality IR.
+
+    Expects N>=2 data feeds. Driven by ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("lookback", 252),      # formation window for momentum
+        ("skip", 21),           # skip most-recent bars (short-term reversal control)
+        ("ir_window", 63),      # rolling window for information ratio (quality proxy)
+        ("rebalance_every", 21),
+        ("long_frac", 0.4),
+        ("short_frac", 0.4),
+        ("gross", 1.0),
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    # ── helpers ────────────────────────────────────────────────────────────────
+
+    def _formation_return(self, data) -> float | None:
+        need = int(self.params.lookback) + 1
+        if len(data) < need:
+            return None
+        old = float(data.close[-int(self.params.lookback)])
+        recent = float(data.close[-int(self.params.skip)])
+        if old <= 0:
+            return None
+        return recent / old - 1.0
+
+    def _information_ratio(self, data) -> float | None:
+        window = int(self.params.ir_window)
+        if len(data) < window + 2:
+            return None
+        rets: list[float] = []
+        for i in range(1, window + 1):
+            prev = float(data.close[-i - 1])
+            curr = float(data.close[-i])
+            if prev > 0:
+                rets.append(curr / prev - 1.0)
+        if len(rets) < 2:
+            return None
+        mean_r = sum(rets) / len(rets)
+        var_r = sum((r - mean_r) ** 2 for r in rets) / (len(rets) - 1)
+        sigma = math.sqrt(var_r)
+        if sigma <= 0.0:
+            return None
+        return mean_r / sigma
+
+    @staticmethod
+    def _zscore(values: list[float]) -> list[float]:
+        n = len(values)
+        if n < 2:
+            return [0.0] * n
+        mean_v = sum(values) / n
+        var_v = sum((v - mean_v) ** 2 for v in values) / (n - 1)
+        sigma_v = math.sqrt(var_v)
+        if sigma_v <= 0.0:
+            return [0.0] * n
+        return [(v - mean_v) / sigma_v for v in values]
+
+    # ── main logic ─────────────────────────────────────────────────────────────
+
+    def next(self) -> None:
+        min_bars = max(int(self.params.lookback), int(self.params.ir_window)) + 2
+        if len(self) < min_bars:
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        mom_raw: list[float] = []
+        ir_raw: list[float] = []
+        valid_datas: list = []
+
+        for d in self.datas:
+            mom = self._formation_return(d)
+            ir = self._information_ratio(d)
+            if mom is None or ir is None:
+                continue
+            mom_raw.append(mom)
+            ir_raw.append(ir)
+            valid_datas.append(d)
+
+        n = len(valid_datas)
+        if n < 2:
+            return
+
+        mom_z = self._zscore(mom_raw)
+        ir_z = self._zscore(ir_raw)
+        composite = [0.5 * mz + 0.5 * qz for mz, qz in zip(mom_z, ir_z)]
+
+        scored = sorted(zip(composite, valid_datas), key=lambda x: x[0], reverse=True)
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)


### PR DESCRIPTION
Adds two candidate strategies: Quality Momentum (Novy-Marx 2012) and cross-asset Value (Asness-Moskowitz-Pedersen 2013). Price-based adaptations; paper-claim caveats in METHODOLOGY_TEXT. Covered by the analytics-engine suite.