### PR TITLE
[strategy] Add Dividend-yield and Defensive-Quality strategies !minor

### DIFF
--- a/analytics-engine/strategies/arnott_2019_defensive_quality.py
+++ b/analytics-engine/strategies/arnott_2019_defensive_quality.py
@@ -1,0 +1,234 @@
+"""Alice's Adventures in Factorland — Arnott, Harvey, Kalesnik & Linnainmaa 2019.
+
+Arnott et al. (2019) catalogue the blunders that plague naive factor investing
+— overfit backtests, ignored trading costs, and aggressive tilts that do not
+survive out of sample — and argue that defensive, robust exposures (low
+volatility, low beta, steady profitability) hold up better than aggressive
+factor chasing. This strategy builds a price-based defensive-quality composite:
+reward steady, low-risk compounders; penalize high volatility and high beta.
+
+Requires ``engine.run_multi_backtest`` (it reads every ``self.datas[i]`` each
+bar to rank the universe). ``self.datas[0]`` is the market benchmark (SPY) and
+is used as the beta reference.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Alice's Adventures in Factorland: Three Blunders That Plague Factor Investing"
+PAPER_AUTHORS: list[str] = [
+    "Robert D. Arnott",
+    "Campbell R. Harvey",
+    "Vitali Kalesnik",
+    "Juhani T. Linnainmaa",
+]
+PAPER_VENUE = "The Journal of Portfolio Management"
+PAPER_YEAR = 2019
+PAPER_DOI = "10.3905/jpm.2019.45.4.018"
+PAPER_CITATION_COUNT = 400  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# Defensive quality (low-vol, low-beta) tends to outperform in downturns.
+REGIME_TAG: str = "bear"
+
+METHODOLOGY_SUMMARY = (
+    "Defensive-quality composite via price-based proxies. Each rebalance, "
+    "score every asset by z(positive drift) - 0.5*z(volatility) - "
+    "0.5*z(beta vs SPY), go long the highest defensive-quality names and "
+    "short the lowest, hold to the next rebalance. Rewards steady, low-risk "
+    "compounders over aggressive factor tilts."
+)
+
+METHODOLOGY_TEXT = (
+    "Arnott, Harvey, Kalesnik & Linnainmaa (2019) caution that naive factor "
+    "investing is undermined by three blunders: backtest overfitting, "
+    "ignoring real-world trading costs, and crowding into aggressive tilts "
+    "that do not replicate out of sample. They argue that defensive, robust "
+    "exposures — low volatility, low beta, and steady profitability ('quality') "
+    "— are more durable than aggressive factor chasing.\n\n"
+    "v1 Archimedes adaptation (cross-asset, on the N-feed engine): we build a "
+    "price-based defensive-quality composite. For each asset we compute (1) "
+    "realized volatility over vol_window bars, (2) beta vs self.datas[0] (SPY) "
+    "over beta_window bars via a pure-Python OLS cov/var, and (3) the mean "
+    "daily return over vol_window (positive drift). The defensive-quality "
+    "score is z(drift) - 0.5*z(vol) - 0.5*z(beta), where z(.) is the cross-"
+    "sectional z-score across the universe. Each rebalance (~21 bars) we rank "
+    "by this score, go long the highest defensive-quality fraction and short "
+    "the lowest in equal weight (order_target_percent), holding to the next "
+    "rebalance.\n\n"
+    "Honest caveats: (1) these are PRICE-BASED PROXIES, not fundamental "
+    "quality — realized vol and beta stand in for risk, and trailing drift "
+    "stands in for profitability; there is no balance-sheet or earnings data "
+    "here. (2) The paper studies broad equity factor portfolios, not a 5-asset "
+    "multi-market basket, so it is context, not a like-for-like benchmark — "
+    "paper_claimed_* are left null."
+)
+
+# Methodological survey of factor blunders; no clean Sharpe/CAGR for this
+# composite on this basket → null (provenance discipline).
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["conservative"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "The defensive sleeve. Where the momentum members chase trends, this "
+    "rewards steady, low-volatility, low-beta compounders — the robust "
+    "exposures Arnott et al. (2019) argue survive out of sample. Disclosed "
+    "clearly as price-based proxies, not fundamental quality."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+_ANNUALIZATION = 252
+
+
+class ArnottDefensiveQuality(bt.Strategy):
+    """Rank by a defensive-quality composite; long the highest, short the lowest.
+
+    Expects N>=2 data feeds (``self.datas[i]``); ``self.datas[0]`` is the
+    market benchmark (SPY) used as the beta reference. Driven by
+    ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("vol_window", 63),  # realized-vol / drift window (bars)
+        ("beta_window", 63),  # beta-vs-benchmark window (bars)
+        ("rebalance_every", 21),  # ~monthly
+        ("long_frac", 0.4),  # long the top 40% of the universe
+        ("short_frac", 0.4),  # short the bottom 40%
+        ("gross", 1.0),  # total gross exposure (split across long + short legs)
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    @staticmethod
+    def _daily_returns(data, n: int) -> list[float] | None:
+        if len(data) < n + 1:
+            return None
+        returns: list[float] = []
+        for i in range(1, n + 1):
+            prev = float(data.close[-i - 1])
+            curr = float(data.close[-i])
+            if prev > 0:
+                returns.append((curr / prev) - 1.0)
+        if len(returns) < 2:
+            return None
+        return returns
+
+    def _mean_return(self, data, n: int) -> float | None:
+        returns = self._daily_returns(data, n)
+        if returns is None:
+            return None
+        return sum(returns) / len(returns)
+
+    def _realized_vol(self, data, n: int) -> float | None:
+        returns = self._daily_returns(data, n)
+        if returns is None:
+            return None
+        mean = sum(returns) / len(returns)
+        var = sum((r - mean) ** 2 for r in returns) / (len(returns) - 1)
+        return math.sqrt(var) * math.sqrt(_ANNUALIZATION)
+
+    def _rolling_beta(self, data) -> float | None:
+        """Pure-Python OLS beta of ``data`` returns on the benchmark returns."""
+        n = int(self.params.beta_window)
+        market = self.datas[0]
+        asset_rets = self._daily_returns(data, n)
+        market_rets = self._daily_returns(market, n)
+        if asset_rets is None or market_rets is None:
+            return None
+        m = min(len(asset_rets), len(market_rets))
+        if m < 2:
+            return None
+        asset_rets = asset_rets[:m]
+        market_rets = market_rets[:m]
+        mkt_mean = sum(market_rets) / m
+        asset_mean = sum(asset_rets) / m
+        cov = sum((market_rets[i] - mkt_mean) * (asset_rets[i] - asset_mean) for i in range(m)) / (m - 1)
+        var = sum((market_rets[i] - mkt_mean) ** 2 for i in range(m)) / (m - 1)
+        if var <= 0:
+            return None
+        return cov / var
+
+    @staticmethod
+    def _zscore(values: list[float]) -> list[float]:
+        n = len(values)
+        if n == 0:
+            return []
+        mean = sum(values) / n
+        if n < 2:
+            return [0.0 for _ in values]
+        var = sum((v - mean) ** 2 for v in values) / (n - 1)
+        std = math.sqrt(var)
+        if std <= 0:
+            return [0.0 for _ in values]
+        return [(v - mean) / std for v in values]
+
+    def next(self) -> None:
+        warmup = max(int(self.params.vol_window), int(self.params.beta_window))
+        if len(self) <= warmup:
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        vw = int(self.params.vol_window)
+        # Gather raw features for every asset that has full history.
+        feats = []  # (data, drift, vol, beta)
+        for d in self.datas:
+            drift = self._mean_return(d, vw)
+            vol = self._realized_vol(d, vw)
+            beta = self._rolling_beta(d)
+            if drift is None or vol is None or beta is None:
+                continue
+            if not (math.isfinite(drift) and math.isfinite(vol) and math.isfinite(beta)):
+                continue
+            feats.append((d, drift, vol, beta))
+
+        n = len(feats)
+        if n < 2:
+            return
+
+        drifts = self._zscore([f[1] for f in feats])
+        vols = self._zscore([f[2] for f in feats])
+        betas = self._zscore([f[3] for f in feats])
+
+        scored = [(drifts[i] - 0.5 * vols[i] - 0.5 * betas[i], feats[i][0]) for i in range(n)]
+        scored.sort(key=lambda x: x[0], reverse=True)  # most defensive-quality first
+
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)

--- a/analytics-engine/strategies/low_tan_wermers_2004_dividend_yield.py
+++ b/analytics-engine/strategies/low_tan_wermers_2004_dividend_yield.py
@@ -1,0 +1,186 @@
+"""Dividend Yields and Expected Stock Returns — Fama & French 1988.
+
+Fama & French (1988) show that the dividend yield (D/P) of stocks predicts
+their subsequent returns: high-yield names earn higher expected returns,
+especially over longer horizons, and the effect is most useful as a defensive,
+income-like tilt. We have NO fundamental dividend data in the demo universe, so
+this strategy uses a PRICE-BASED PROXY for the "steady income compounding"
+characteristic that high-yield assets tend to exhibit — explicitly a loose
+proxy, not a faithful dividend-yield sort.
+
+Requires ``engine.run_multi_backtest`` (it reads every ``self.datas[i]`` each
+bar to rank the universe). ``self.datas[0]`` is the market benchmark (SPY).
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+
+PAPER_ARXIV_ID: str | None = None
+PAPER_TITLE = "Dividend Yields and Expected Stock Returns"
+PAPER_AUTHORS: list[str] = ["Eugene F. Fama", "Kenneth R. French"]
+PAPER_VENUE = "Journal of Financial Economics"
+PAPER_YEAR = 1988
+PAPER_DOI = "10.1016/0304-405X(88)90020-7"
+PAPER_CITATION_COUNT = 6000  # Snapshot 2026-06; verify via Semantic Scholar.
+
+# High-yield defensive assets tend to outperform in downturns.
+REGIME_TAG: str = "bear"
+
+METHODOLOGY_SUMMARY = (
+    "Dividend-yield tilt via a price-based proxy. Each rebalance, rank the "
+    "universe by a 'yield proxy score' = mean daily return / max drawdown "
+    "(income-like steadiness), go long the steadiest compounders and short "
+    "the least steady, hold to the next rebalance. A loose proxy for the "
+    "high-D/P sort Fama-French (1988) study — NOT a true dividend sort."
+)
+
+METHODOLOGY_TEXT = (
+    "Fama & French (1988) regress future stock returns on the dividend yield "
+    "(D/P) and find that dividend yield predicts subsequent returns: stocks "
+    "with high D/P earn higher expected returns over the following months and "
+    "years, with the explanatory power rising with the return horizon. High-"
+    "yield names also behave defensively, providing an income-like compounding "
+    "profile that holds up better in downturns.\n\n"
+    "v1 Archimedes adaptation (cross-asset, on the N-feed engine): the demo "
+    "universe has NO fundamental dividend data, so we CANNOT compute a real "
+    "D/P. Instead we use a price-based PROXY for the 'steady income "
+    "compounding' characteristic high-yield assets exhibit. For each asset we "
+    "compute a yield proxy score = (mean daily return over the lookback) / "
+    "(max drawdown over the lookback + epsilon). A higher score means steadier "
+    "compounding with shallower drawdowns — the return signature of an income-"
+    "like holding. Each rebalance (~21 bars) we rank the universe by this "
+    "score, go long the top fraction and short the bottom fraction in equal "
+    "weight (order_target_percent), holding to the next rebalance.\n\n"
+    "Honest caveats: (1) this is a LOOSE PROXY and explicitly NOT a faithful "
+    "dividend-yield sort — return-to-drawdown stability only correlates with "
+    "the income-like profile of high-D/P assets; it does not measure dividend "
+    "yield. (2) Fama-French (1988) study a broad single-market stock cross-"
+    "section, not a 5-asset multi-market basket, so it is context, not a like-"
+    "for-like benchmark — paper_claimed_* are left null."
+)
+
+# Predictive-regression anomaly on a stock universe; no clean Sharpe/CAGR for
+# this proxy on this basket → null (provenance discipline).
+PAPER_CLAIMED_SHARPE: float | None = None
+PAPER_CLAIMED_CAGR: float | None = None
+PAPER_CLAIMED_MAX_DD: float | None = None
+
+ASSET_UNIVERSE: list[str] = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+POSITION_SIZING = "equal_weight"
+REBALANCE_FREQUENCY = "monthly"
+RISK_PROFILES: list[str] = ["conservative", "moderate"]
+
+CURATOR_WALLET: str | None = None
+CURATOR_NOTE = (
+    "The income-tilt member of the library, expressed as a price-based proxy "
+    "because the demo universe lacks dividend data. Rewards assets that "
+    "compound steadily with shallow drawdowns — the return signature of a "
+    "high-yield defensive holding. Disclosed clearly as a proxy, not a true "
+    "dividend-yield sort."
+)
+EXTRACTION_LLM: str | None = None
+
+STATUS = "candidate"
+
+BACKTEST_SHARPE: float | None = None
+BACKTEST_CAGR: float | None = None
+BACKTEST_MAX_DD: float | None = None
+BACKTEST_WIN_RATE: float | None = None
+BACKTEST_CALMAR: float | None = None
+BACKTEST_CORR_SPY: float | None = None
+
+_EPSILON = 1e-9
+
+
+class FamaFrenchDividendYield(bt.Strategy):
+    """Rank the universe by a price-based dividend-yield proxy; long top, short bottom.
+
+    Expects N>=2 data feeds (``self.datas[i]``); ``self.datas[0]`` is the
+    market benchmark (SPY). Driven by ``engine.run_multi_backtest``.
+    """
+
+    params = (
+        ("lookback", 252),  # trailing window (bars) for the proxy score
+        ("rebalance_every", 21),  # ~monthly
+        ("long_frac", 0.4),  # long the top 40% of the universe
+        ("short_frac", 0.4),  # short the bottom 40%
+        ("gross", 1.0),  # total gross exposure (split across long + short legs)
+    )
+
+    def __init__(self) -> None:
+        self._bars_since_rebalance = 0
+
+    def _mean_daily_return(self, data, n: int) -> float | None:
+        if len(data) < n + 1:
+            return None
+        returns: list[float] = []
+        for i in range(1, n + 1):
+            prev = float(data.close[-i - 1])
+            curr = float(data.close[-i])
+            if prev > 0:
+                returns.append((curr / prev) - 1.0)
+        if not returns:
+            return None
+        return sum(returns) / len(returns)
+
+    def _max_drawdown(self, data, n: int) -> float | None:
+        if len(data) < n + 1:
+            return None
+        # Oldest -> newest closes over the trailing window (exclude current bar).
+        closes = [float(data.close[-i]) for i in range(n, 0, -1)]
+        if not closes:
+            return None
+        peak = closes[0]
+        max_dd = 0.0
+        for price in closes:
+            if price > peak:
+                peak = price
+            if peak > 0:
+                dd = (peak - price) / peak
+                if dd > max_dd:
+                    max_dd = dd
+        return max_dd
+
+    def _yield_proxy_score(self, data) -> float | None:
+        n = int(self.params.lookback)
+        mean_ret = self._mean_daily_return(data, n)
+        max_dd = self._max_drawdown(data, n)
+        if mean_ret is None or max_dd is None:
+            return None
+        return mean_ret / (max_dd + _EPSILON)
+
+    def next(self) -> None:
+        if len(self) <= int(self.params.lookback):
+            return
+        self._bars_since_rebalance += 1
+        if self._bars_since_rebalance < int(self.params.rebalance_every):
+            return
+        self._bars_since_rebalance = 0
+
+        scored = [(self._yield_proxy_score(d), d) for d in self.datas]
+        scored = [(s, d) for s, d in scored if s is not None and math.isfinite(s)]
+        n = len(scored)
+        if n < 2:
+            return
+        scored.sort(key=lambda x: x[0], reverse=True)  # steadiest first
+
+        n_long = max(1, int(round(n * float(self.params.long_frac))))
+        n_short = max(1, int(round(n * float(self.params.short_frac))))
+        if n_long + n_short > n:
+            n_short = max(1, n - n_long)
+
+        longs = {id(d) for _, d in scored[:n_long]}
+        shorts = {id(d) for _, d in scored[-n_short:]}
+        long_w = (float(self.params.gross) / 2.0) / n_long
+        short_w = (float(self.params.gross) / 2.0) / n_short
+
+        for _, d in scored:
+            if id(d) in longs:
+                self.order_target_percent(data=d, target=long_w)
+            elif id(d) in shorts:
+                self.order_target_percent(data=d, target=-short_w)
+            else:
+                self.order_target_percent(data=d, target=0.0)

--- a/analytics-engine/tests/test_dividend_defensive_strategies.py
+++ b/analytics-engine/tests/test_dividend_defensive_strategies.py
@@ -1,0 +1,111 @@
+"""Tests for the dividend-yield-proxy and defensive-quality strategies.
+
+Hermetic: synthetic N-feed data, no network. Each strategy file is loaded via
+the real strategy_loader (proving its metadata block + single strategy class
+resolve) and run through engine.run_multi_backtest with named feeds. Metadata
+is asserted by loading the module directly via importlib (StrategyBundle has no
+``.module`` attribute). The real performance metrics live elsewhere; these
+tests only guard the plumbing, the trade path, and the metadata block.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.engine import BacktestResult, run_multi_backtest
+
+_STRATEGIES_DIR = Path(__file__).parent.parent / "strategies"
+sys.path.insert(0, str(_STRATEGIES_DIR))
+sys.path.insert(0, str(_STRATEGIES_DIR.parent / "src"))
+
+# Feed names mirror the production universe; datas[0] (SPY) is the benchmark.
+_NAMES = ["SPY", "^N225", "GC=F", "TLT", "CL=F"]
+
+
+def _trending_universe(n: int = 500) -> list[pd.DataFrame]:
+    """Five synthetic feeds with distinct drifts/phases so ranks/vols/betas differ."""
+    specs = [(100.0, 0.06, 0.0), (80.0, 0.03, 1.0), (120.0, 0.01, 2.0), (90.0, 0.02, 3.0), (70.0, 0.05, 4.0)]
+    frames = []
+    for base, drift, phase in specs:
+        idx = pd.date_range("2015-01-01", periods=n, freq="D")
+        closes = [base + drift * i + 8.0 * math.sin(i / 20.0 + phase) for i in range(n)]
+        frames.append(
+            pd.DataFrame(
+                {
+                    "Open": [c - 0.3 for c in closes],
+                    "High": [c + 0.6 for c in closes],
+                    "Low": [c - 0.6 for c in closes],
+                    "Close": closes,
+                    "Volume": [1_000] * n,
+                },
+                index=idx,
+            )
+        )
+    return frames
+
+
+def _load_module(stem: str):
+    path = _STRATEGIES_DIR / f"{stem}.py"
+    spec = importlib.util.spec_from_file_location(f"_meta_{stem}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CASES = [
+    ("low_tan_wermers_2004_dividend_yield", "FamaFrenchDividendYield"),
+    ("arnott_2019_defensive_quality", "ArnottDefensiveQuality"),
+]
+
+
+@pytest.mark.parametrize(("stem", "expected_cls"), _CASES)
+def test_strategy_loads_and_runs(stem: str, expected_cls: str) -> None:
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(_STRATEGIES_DIR / f"{stem}.py")
+    assert bundle.cls.__name__ == expected_cls
+
+    frames = _trending_universe()
+    result = run_multi_backtest(frames, strategy_cls=bundle.cls, initial_cash=100_000.0, names=_NAMES)
+    assert isinstance(result, BacktestResult)
+    assert result.look_ahead_audit_passed is True
+    assert isinstance(result.daily_returns, list)
+    assert len(result.daily_returns) > 0
+    # Strategy must actually deploy capital — final value diverges from initial cash.
+    assert result.final_value != pytest.approx(100_000.0, rel=1e-3)
+
+
+@pytest.mark.parametrize(("stem", "expected_cls"), _CASES)
+def test_strategy_metadata(stem: str, expected_cls: str) -> None:
+    module = _load_module(stem)
+
+    assert isinstance(module.PAPER_TITLE, str) and module.PAPER_TITLE.strip()
+    assert isinstance(module.PAPER_AUTHORS, list) and len(module.PAPER_AUTHORS) >= 1
+    assert all(isinstance(a, str) and a.strip() for a in module.PAPER_AUTHORS)
+    assert isinstance(module.PAPER_YEAR, int) and module.PAPER_YEAR > 1900
+    assert module.REGIME_TAG == "bear"
+    assert isinstance(module.RISK_PROFILES, list) and len(module.RISK_PROFILES) >= 1
+    assert module.STATUS == "candidate"
+    assert isinstance(module.METHODOLOGY_TEXT, str) and len(module.METHODOLOGY_TEXT) > 100
+    # The class the tests reference must exist on the module.
+    assert hasattr(module, expected_cls)
+
+
+@pytest.mark.parametrize(("stem", "expected_cls"), _CASES)
+def test_insufficient_history_holds_flat(stem: str, expected_cls: str) -> None:
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(_STRATEGIES_DIR / f"{stem}.py")
+    assert bundle.cls.__name__ == expected_cls
+
+    # 30 bars is below every warmup window → strategy never deploys capital.
+    frames = _trending_universe(n=30)
+    result = run_multi_backtest(frames, strategy_cls=bundle.cls, initial_cash=100_000.0, names=_NAMES)
+    assert isinstance(result, BacktestResult)
+    assert result.final_value == pytest.approx(100_000.0, rel=1e-6)


### PR DESCRIPTION
Adds Dividend-yield proxy (Fama-French 1988) and Defensive Quality (Arnott 2019), STATUS=candidate, price-based adaptations. Tests: 6 passing.