### PR TITLE
[test] Add analytics-engine core coverage tests

### DIFF
--- a/analytics-engine/tests/test_costs_coverage.py
+++ b/analytics-engine/tests/test_costs_coverage.py
@@ -1,0 +1,265 @@
+"""Coverage tests for costs.py — the transaction-cost + turnover model.
+
+Hermetic: synthetic in-memory frames, no network. Complements test_costs.py by
+exercising branches it does not: CostModel.apply_to_broker per-feed/slippage
+paths, position_weight flat/zero-equity branches, no_trade_band exact boundary,
+TurnoverAnalyzer accumulation invariants, and zero-cost models.
+"""
+
+from __future__ import annotations
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.costs import (
+    CostModel,
+    TurnoverAnalyzer,
+    no_trade_band,
+    position_weight,
+)
+from archimedes_analytics_engine.engine import run_backtest, run_multi_backtest
+
+
+def _flat_prices(periods: int, price: float = 100.0, start: str = "2020-01-01") -> pd.DataFrame:
+    idx = pd.date_range(start, periods=periods, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": [price] * periods,
+            "High": [price] * periods,
+            "Low": [price] * periods,
+            "Close": [price] * periods,
+            "Volume": [1_000] * periods,
+        },
+        index=idx,
+    )
+
+
+class _OneRoundTrip(bt.Strategy):
+    """Buy 50 on bar 2, sell on bar 10 — two known executions at flat prices."""
+
+    def next(self) -> None:
+        if len(self) == 2:
+            self.buy(size=50)
+        elif len(self) == 10:
+            self.sell(size=50)
+
+
+class _LongOnce(bt.Strategy):
+    def next(self) -> None:
+        if len(self) == 2 and not self.position:
+            self.order_target_percent(target=0.9)
+
+
+# ── CostModel construction + per_side_bps ─────────────────────────────────────
+
+
+def test_cost_model_defaults() -> None:
+    model = CostModel()
+    assert model.default_bps == 10.0
+    assert model.slippage_bps == 0.0
+    assert model.per_symbol == {}
+    assert model.per_side_bps() == 10.0
+    assert model.per_side_bps("ANYTHING") == 10.0
+
+
+def test_cost_model_per_side_bps_none_symbol() -> None:
+    model = CostModel(default_bps=7.0, per_symbol={"SPY": 3.0})
+    assert model.per_side_bps(None) == 7.0
+    assert model.per_side_bps("SPY") == 3.0
+    assert model.per_side_bps("UNKNOWN") == 7.0
+
+
+def test_cost_model_is_frozen() -> None:
+    model = CostModel(default_bps=10.0)
+    with pytest.raises((AttributeError, Exception)):
+        model.default_bps = 20.0  # type: ignore[misc]
+
+
+def test_cost_model_zero_bps_is_allowed() -> None:
+    # Zero is the boundary of the >= 0 validation — must NOT raise.
+    model = CostModel(default_bps=0.0, slippage_bps=0.0, per_symbol={"SPY": 0.0})
+    assert model.per_side_bps("SPY") == 0.0
+
+
+# ── apply_to_broker branches ──────────────────────────────────────────────────
+
+
+def test_apply_to_broker_sets_default_commission() -> None:
+    cerebro = bt.Cerebro(stdstats=False)
+    cerebro.broker.setcash(100_000.0)
+    CostModel(default_bps=20.0).apply_to_broker(cerebro, ["SPY"])
+    # 20 bps == 0.0020 commission in percent mode. The default (feed-agnostic)
+    # commission is stored under the None key in broker.comminfo.
+    assert cerebro.broker.comminfo[None].p.commission == pytest.approx(0.0020)
+
+
+def test_apply_to_broker_per_symbol_override_ignores_inactive_names() -> None:
+    # per_symbol carries a name NOT in feed_names → must be silently ignored
+    # (no crash), exercising the "name in per_symbol" false branch per feed.
+    cerebro = bt.Cerebro(stdstats=False)
+    cerebro.broker.setcash(100_000.0)
+    model = CostModel(default_bps=10.0, per_symbol={"INACTIVE": 99.0})
+    model.apply_to_broker(cerebro, ["SPY", "GLD"])
+    # Default commission still applies; no exception from the inactive override.
+    assert cerebro.broker.comminfo[None].p.commission == pytest.approx(0.0010)
+
+
+def test_zero_cost_model_charges_no_commission() -> None:
+    result = run_backtest(
+        _flat_prices(20),
+        strategy_cls=_OneRoundTrip,
+        initial_cash=100_000.0,
+        cost_model=CostModel(default_bps=0.0),
+    )
+    assert result.traded_notional == pytest.approx(10_000.0)
+    assert result.total_commission_paid == pytest.approx(0.0)
+    # default_bps recorded on the result rounds to 0.
+    assert result.transaction_cost_bps == 0
+
+
+def test_cost_model_slippage_recorded_on_result() -> None:
+    result = run_backtest(
+        _flat_prices(20),
+        strategy_cls=_LongOnce,
+        initial_cash=100_000.0,
+        cost_model=CostModel(default_bps=10.0, slippage_bps=15.0),
+    )
+    assert result.slippage_bps == 15
+
+
+def test_higher_default_bps_costs_more() -> None:
+    cheap = run_backtest(
+        _flat_prices(20), strategy_cls=_OneRoundTrip, initial_cash=100_000.0, cost_model=CostModel(default_bps=10.0)
+    )
+    pricey = run_backtest(
+        _flat_prices(20), strategy_cls=_OneRoundTrip, initial_cash=100_000.0, cost_model=CostModel(default_bps=100.0)
+    )
+    assert pricey.total_commission_paid > cheap.total_commission_paid
+    # Cost scales ~10x with bps on identical executions.
+    assert pricey.total_commission_paid == pytest.approx(cheap.total_commission_paid * 10.0, rel=1e-6)
+
+
+# ── no_trade_band boundary ────────────────────────────────────────────────────
+
+
+def test_no_trade_band_exact_boundary_trades() -> None:
+    # |target - current| == band → the >= comparison fires → trade.
+    # NOTE: use integer-representable deltas; 0.25-0.20 is 0.04999.. < 0.05 in
+    # binary float and would (correctly) hold, so we pick 1.0 - 0.5 == 0.5.
+    assert no_trade_band(0.5, 1.0, band=0.5) == 1.0
+
+
+def test_no_trade_band_just_inside_holds() -> None:
+    assert no_trade_band(0.20, 0.2499, band=0.05) == 0.20
+
+
+def test_no_trade_band_zero_band_always_trades_even_tiny_move() -> None:
+    assert no_trade_band(0.20, 0.2001, band=0.0) == 0.2001
+    # No move at all with zero band: abs(0) >= 0 is True → returns target==current.
+    assert no_trade_band(0.20, 0.20, band=0.0) == 0.20
+
+
+# ── position_weight branches ──────────────────────────────────────────────────
+
+
+class _AssertFlatWeight(bt.Strategy):
+    """Records position_weight on an early bar while still flat (weight == 0)."""
+
+    def __init__(self) -> None:
+        self.observed: list[float] = []
+
+    def next(self) -> None:
+        if len(self) == 2:
+            self.observed.append(position_weight(self, self.data))
+
+
+def test_position_weight_zero_when_flat() -> None:
+    cerebro = bt.Cerebro(stdstats=False)
+    cerebro.broker.setcash(100_000.0)
+    cerebro.adddata(bt.feeds.PandasData(dataname=_flat_prices(10)))
+    cerebro.addstrategy(_AssertFlatWeight)
+    strat = cerebro.run()[0]
+    assert strat.observed == [0.0]
+
+
+def test_position_weight_zero_equity_returns_zero() -> None:
+    # When broker equity is non-positive, position_weight short-circuits to 0.0.
+    class _FakeData:
+        pass
+
+    class _FakeBroker:
+        def getvalue(self, datas=None):  # noqa: ANN001, ANN201
+            return 0.0
+
+    class _FakeStrategy:
+        broker = _FakeBroker()
+
+    assert position_weight(_FakeStrategy(), _FakeData()) == 0.0  # type: ignore[arg-type]
+
+
+# ── TurnoverAnalyzer accumulation invariants ──────────────────────────────────
+
+
+def test_turnover_analyzer_get_analysis_shape() -> None:
+    result = run_backtest(
+        _flat_prices(20),
+        strategy_cls=_OneRoundTrip,
+        initial_cash=100_000.0,
+        transaction_cost_bps=10,
+    )
+    # Two-way notional == 50 * 100 * 2 == 10_000; commission == 10 bps/side.
+    assert result.traded_notional == pytest.approx(10_000.0)
+    assert result.total_commission_paid == pytest.approx(10.0)
+
+
+def test_turnover_analyzer_bar_commissions_sum_matches_total() -> None:
+    # The per-bar commission series, exposed through the cost metrics, must be
+    # internally consistent: gross_sharpe is computed from it, so it must exist
+    # and the run must not crash. We verify the aggregate invariant indirectly:
+    # total commission equals notional * bps/10000 for the round trip.
+    result = run_backtest(
+        _flat_prices(20),
+        strategy_cls=_OneRoundTrip,
+        initial_cash=100_000.0,
+        transaction_cost_bps=25,
+    )
+    assert result.total_commission_paid == pytest.approx(10_000.0 * 25 / 10_000.0)
+
+
+def test_turnover_analyzer_direct_lifecycle() -> None:
+    # Drive the analyzer's start/next/stop directly with no executions.
+    analyzer = TurnoverAnalyzer.__new__(TurnoverAnalyzer)
+    analyzer.start()
+    assert analyzer.traded_notional == 0.0
+    assert analyzer.commission_paid == 0.0
+    analyzer.next()
+    analyzer.next()
+    analyzer.stop()
+    out = analyzer.get_analysis()
+    assert out["traded_notional"] == 0.0
+    assert out["commission_paid"] == 0.0
+    assert out["bar_commissions"] == [0.0, 0.0]
+
+
+# ── multi-feed default cost model path ────────────────────────────────────────
+
+
+def test_cost_model_multi_feed_zero_cost() -> None:
+    frames = [_flat_prices(30, price=100.0), _flat_prices(30, price=50.0)]
+
+    class _EqualWeight(bt.Strategy):
+        def next(self) -> None:
+            if len(self) != 3:
+                return
+            for d in self.datas:
+                self.order_target_percent(data=d, target=0.45)
+
+    result = run_multi_backtest(
+        frames,
+        strategy_cls=_EqualWeight,
+        initial_cash=100_000.0,
+        names=["A", "B"],
+        cost_model=CostModel(default_bps=0.0),
+    )
+    assert result.total_commission_paid == pytest.approx(0.0)
+    assert result.traded_notional > 0.0

--- a/analytics-engine/tests/test_engine_coverage.py
+++ b/analytics-engine/tests/test_engine_coverage.py
@@ -1,0 +1,277 @@
+"""Coverage tests for engine.py metric-helper functions and edge cases.
+
+Hermetic: all data is synthetic in-memory pandas frames, no network, no
+yfinance. These exercise the pure helper functions directly (the existing
+test_engine.py only drives the full run_buy_and_hold path) plus a few
+edge-case engine runs (always-flat strategy, single-bar feed).
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.engine import (
+    ANNUALIZATION,
+    RF_ANNUAL,
+    RF_DAILY,
+    BacktestResult,
+    _build_equity_curve,
+    _compute_cagr,
+    _compute_sortino,
+    _safe_get,
+    _sharpe_bt_convention,
+    _trade_stats,
+    run_backtest,
+    run_buy_and_hold,
+)
+
+
+def _flat_prices(periods: int, price: float = 100.0, start: str = "2021-01-01") -> pd.DataFrame:
+    idx = pd.date_range(start, periods=periods, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": [price] * periods,
+            "High": [price] * periods,
+            "Low": [price] * periods,
+            "Close": [price] * periods,
+            "Volume": [1_000] * periods,
+        },
+        index=idx,
+    )
+
+
+# ── _compute_sortino ──────────────────────────────────────────────────────────
+
+
+def test_sortino_empty_list_returns_none() -> None:
+    assert _compute_sortino([]) is None
+
+
+def test_sortino_all_positive_returns_none() -> None:
+    # No downside returns at all → denominator undefined → None.
+    assert _compute_sortino([0.01, 0.02, 0.005, 0.03]) is None
+
+
+def test_sortino_all_negative_is_finite_and_negative() -> None:
+    returns = [-0.01, -0.02, -0.015]
+    result = _compute_sortino(returns)
+    assert result is not None
+    # mean is below the daily risk-free rate, so the ratio is negative.
+    assert result < 0
+
+
+def test_sortino_rms_of_negatives_convention() -> None:
+    # Verify the RMS-of-negatives denominator convention explicitly.
+    returns = [0.05, -0.02, 0.03, -0.04]
+    downside = [r for r in returns if r < 0]
+    dd_rms = math.sqrt(sum(r * r for r in downside) / len(downside))
+    mean = statistics.fmean(returns)
+    expected = ((mean - RF_DAILY) / dd_rms) * math.sqrt(ANNUALIZATION)
+    assert _compute_sortino(returns) == pytest.approx(expected)
+
+
+def test_sortino_single_negative_observation() -> None:
+    # One downside observation: dd_rms == |that return|; not None, not zero.
+    result = _compute_sortino([0.10, -0.05])
+    assert result is not None
+
+
+# ── _compute_cagr ─────────────────────────────────────────────────────────────
+
+
+def test_cagr_zero_or_negative_initial_returns_none() -> None:
+    assert _compute_cagr(0.0, 100.0, 252) is None
+    assert _compute_cagr(-10.0, 100.0, 252) is None
+
+
+def test_cagr_nonpositive_final_returns_none() -> None:
+    assert _compute_cagr(100.0, 0.0, 252) is None
+    assert _compute_cagr(100.0, -5.0, 252) is None
+
+
+def test_cagr_zero_bars_returns_none() -> None:
+    assert _compute_cagr(100.0, 200.0, 0) is None
+
+
+def test_cagr_one_year_doubling() -> None:
+    # Exactly one year (252 bars), doubling → CAGR == 1.0 (100%).
+    assert _compute_cagr(100.0, 200.0, ANNUALIZATION) == pytest.approx(1.0)
+
+
+def test_cagr_multi_year_annualization() -> None:
+    # 2 years, 4x growth → annualized rate is 2x - 1 = 1.0.
+    result = _compute_cagr(100.0, 400.0, 2 * ANNUALIZATION)
+    assert result == pytest.approx(1.0)
+
+
+# ── _sharpe_bt_convention ─────────────────────────────────────────────────────
+
+
+def test_sharpe_bt_convention_too_short_returns_none() -> None:
+    assert _sharpe_bt_convention([]) is None
+    assert _sharpe_bt_convention([0.01]) is None
+
+
+def test_sharpe_bt_convention_constant_returns_none() -> None:
+    # Constant series → zero population stddev → None.
+    assert _sharpe_bt_convention([0.01, 0.01, 0.01, 0.01]) is None
+
+
+def test_sharpe_bt_convention_normal_series_matches_formula() -> None:
+    returns = [0.01, -0.005, 0.02, 0.0, 0.015, -0.01]
+    rf_daily_geo = (1.0 + RF_ANNUAL) ** (1.0 / ANNUALIZATION) - 1.0
+    excess = [r - rf_daily_geo for r in returns]
+    expected = (statistics.fmean(excess) / statistics.pstdev(excess)) * math.sqrt(ANNUALIZATION)
+    assert _sharpe_bt_convention(returns) == pytest.approx(expected)
+
+
+# ── _build_equity_curve ───────────────────────────────────────────────────────
+
+
+def test_build_equity_curve_empty_pairs_is_just_initial() -> None:
+    assert _build_equity_curve(10_000.0, []) == [10_000.0]
+
+
+def test_build_equity_curve_compounds_daily_pairs() -> None:
+    # (date, return) pairs — dates are ignored by the builder.
+    pairs = [("2021-01-01", 0.10), ("2021-01-02", -0.05), ("2021-01-03", 0.20)]
+    curve = _build_equity_curve(1_000.0, pairs)
+    assert curve[0] == pytest.approx(1_000.0)
+    assert curve[1] == pytest.approx(1_100.0)
+    assert curve[2] == pytest.approx(1_100.0 * 0.95)
+    assert curve[3] == pytest.approx(1_100.0 * 0.95 * 1.20)
+    assert len(curve) == 4
+
+
+# ── _safe_get ─────────────────────────────────────────────────────────────────
+
+
+def test_safe_get_nested_hit_and_misses() -> None:
+    d = {"a": {"b": {"c": 42}}}
+    assert _safe_get(d, "a", "b", "c") == 42
+    assert _safe_get(d, "a", "x", default="fallback") == "fallback"
+    # Traversal hits a non-dict before exhausting keys → default.
+    assert _safe_get(d, "a", "b", "c", "d", default=None) is None
+    assert _safe_get("not-a-dict", "a", default=7) == 7
+
+
+# ── _trade_stats ──────────────────────────────────────────────────────────────
+
+
+def test_trade_stats_no_closed_trades() -> None:
+    assert _trade_stats({}) == (0, None, None, None)
+    assert _trade_stats({"total": {"closed": 0}}) == (0, None, None, None)
+
+
+def test_trade_stats_computes_win_rate_and_profit_factor() -> None:
+    trade = {
+        "total": {"closed": 4},
+        "won": {"total": 3, "pnl": {"total": 300.0}},
+        "lost": {"pnl": {"total": -100.0}},
+        "len": {"average": 5.5},
+    }
+    total, win_rate, profit_factor, avg_len = _trade_stats(trade)
+    assert total == 4
+    assert win_rate == pytest.approx(0.75)
+    assert profit_factor == pytest.approx(3.0)
+    assert avg_len == pytest.approx(5.5)
+
+
+def test_trade_stats_profit_factor_none_when_no_losses() -> None:
+    # lost_pnl == 0 → profit_factor undefined → None (avoids div-by-zero).
+    trade = {
+        "total": {"closed": 2},
+        "won": {"total": 2, "pnl": {"total": 50.0}},
+        "lost": {"pnl": {"total": 0.0}},
+    }
+    total, win_rate, profit_factor, avg_len = _trade_stats(trade)
+    assert total == 2
+    assert win_rate == pytest.approx(1.0)
+    assert profit_factor is None
+    assert avg_len is None
+
+
+# ── BacktestResult dataclass ──────────────────────────────────────────────────
+
+
+def test_backtest_result_defaults_and_construction() -> None:
+    result = BacktestResult(
+        final_value=12_000.0,
+        total_return_pct=20.0,
+        equity_curve=[10_000.0, 12_000.0],
+    )
+    # Defaulted fields.
+    assert result.sharpe_ratio is None
+    assert result.total_trades == 0
+    assert result.transaction_cost_bps == 10
+    assert result.slippage_bps == 0
+    assert result.look_ahead_audit_passed is False
+    assert result.backtest_engine == "backtrader"
+    assert result.monthly_returns == []
+    assert result.daily_returns == []
+    assert result.daily_return_dates == []
+    # Mutable defaults are independent instances, not shared.
+    other = BacktestResult(final_value=1.0, total_return_pct=0.0, equity_curve=[])
+    result.daily_returns.append(0.01)
+    assert other.daily_returns == []
+
+
+# ── Engine edge cases ─────────────────────────────────────────────────────────
+
+
+class _NeverTrades(bt.Strategy):
+    """An always-flat strategy: never opens a position."""
+
+    def next(self) -> None:
+        pass
+
+
+def test_always_flat_strategy_preserves_capital() -> None:
+    result = run_backtest(
+        _flat_prices(30),
+        strategy_cls=_NeverTrades,
+        initial_cash=10_000.0,
+    )
+    assert result.look_ahead_audit_passed is True
+    assert result.final_value == pytest.approx(10_000.0)
+    assert result.total_trades == 0
+    assert result.traded_notional == 0.0
+    assert result.total_commission_paid == 0.0
+
+
+def test_single_bar_buy_and_hold_runs() -> None:
+    # A single-bar feed: buy-and-hold cannot complete a trade but must still
+    # return a well-formed BacktestResult with sane scalar fields.
+    result = run_buy_and_hold(_flat_prices(1), initial_cash=5_000.0)
+    assert isinstance(result, BacktestResult)
+    assert result.bars == 1
+    assert result.final_value > 0
+    assert result.backtest_start is not None
+    assert result.backtest_end is not None
+
+
+def test_buy_and_hold_deploys_capital_on_rising_feed() -> None:
+    idx = pd.date_range("2021-01-01", periods=12, freq="D")
+    closes = [100.0 + 3.0 * i for i in range(12)]
+    # Open below Close so the next-bar entry fits in cash net of commission
+    # (the BuyAndHold sizing uses close[0] but fills at the next bar's open).
+    prices = pd.DataFrame(
+        {
+            "Open": [c - 2 for c in closes],
+            "High": [c + 1 for c in closes],
+            "Low": [c - 3 for c in closes],
+            "Close": closes,
+            "Volume": [1_000] * 12,
+        },
+        index=idx,
+    )
+    result = run_buy_and_hold(prices, initial_cash=10_000.0)
+    # A rising buy-and-hold should grow capital and record the entry notional.
+    assert result.final_value > 10_000.0
+    assert result.total_return_pct > 0
+    assert result.traded_notional > 0.0
+    assert len(result.equity_curve) == result.bars + 1

--- a/analytics-engine/tests/test_walk_forward_coverage.py
+++ b/analytics-engine/tests/test_walk_forward_coverage.py
@@ -1,0 +1,248 @@
+"""Coverage tests for walk_forward.py — the walk-forward selection harness.
+
+Hermetic: synthetic in-memory frames, no network. Complements
+test_walk_forward.py by exercising the helper functions (_expand_grid,
+_align), the train_bars/test_bars validation branches, the no-common-dates
+alignment error, single-fold layout, multi-parameter grid expansion, and the
+WalkForwardFold/WalkForwardResult dataclass fields.
+"""
+
+from __future__ import annotations
+
+import math
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.walk_forward import (
+    WalkForwardFold,
+    WalkForwardResult,
+    _align,
+    _expand_grid,
+    walk_forward_select,
+)
+
+
+def _frame(closes: list[float], start: str = "2018-01-01") -> pd.DataFrame:
+    idx = pd.date_range(start, periods=len(closes), freq="D")
+    return pd.DataFrame(
+        {
+            "Open": closes,
+            "High": [c * 1.004 for c in closes],
+            "Low": [c * 0.996 for c in closes],
+            "Close": closes,
+            "Volume": [1_000] * len(closes),
+        },
+        index=idx,
+    )
+
+
+def _uptrend(n: int, base: float = 100.0, slope: float = 0.3) -> list[float]:
+    return [base + slope * i + 1.5 * math.sin(i / 6.0) for i in range(n)]
+
+
+class _ExposureStrategy(bt.Strategy):
+    params = (("invested", 0.0),)
+
+    def next(self) -> None:
+        target = float(self.params.invested)
+        if len(self) == 2 and target > 0 and not self.position:
+            self.order_target_percent(target=target)
+
+
+# ── _expand_grid ──────────────────────────────────────────────────────────────
+
+
+def test_expand_grid_single_param() -> None:
+    combos = _expand_grid({"a": [1, 2, 3]})
+    assert combos == [{"a": 1}, {"a": 2}, {"a": 3}]
+
+
+def test_expand_grid_cartesian_product_order() -> None:
+    combos = _expand_grid({"a": [1, 2], "b": [10, 20]})
+    # itertools.product is row-major over the key order.
+    assert combos == [
+        {"a": 1, "b": 10},
+        {"a": 1, "b": 20},
+        {"a": 2, "b": 10},
+        {"a": 2, "b": 20},
+    ]
+
+
+def test_expand_grid_single_value_each() -> None:
+    assert _expand_grid({"x": [5], "y": [7]}) == [{"x": 5, "y": 7}]
+
+
+# ── _align ────────────────────────────────────────────────────────────────────
+
+
+def test_align_single_frame_identity() -> None:
+    f = _frame(_uptrend(50))
+    aligned = _align([f])
+    assert len(aligned) == 1
+    assert len(aligned[0]) == 50
+    pd.testing.assert_index_equal(aligned[0].index, f.index)
+
+
+def test_align_intersects_indices() -> None:
+    a = _frame(_uptrend(60), start="2018-01-01")  # 2018-01-01 .. +60d
+    b = _frame(_uptrend(60), start="2018-01-15")  # overlaps a from 01-15
+    aligned = _align([a, b])
+    # Both frames trimmed to the common index, same length, sorted.
+    assert len(aligned[0]) == len(aligned[1])
+    assert len(aligned[0]) > 0
+    pd.testing.assert_index_equal(aligned[0].index, aligned[1].index)
+    assert aligned[0].index.is_monotonic_increasing
+
+
+def test_align_no_common_dates_raises() -> None:
+    a = _frame(_uptrend(30), start="2018-01-01")
+    b = _frame(_uptrend(30), start="2025-01-01")
+    with pytest.raises(ValueError, match="no common dates"):
+        _align([a, b])
+
+
+# ── walk_forward_select input validation ──────────────────────────────────────
+
+
+def test_rejects_train_bars_too_small() -> None:
+    with pytest.raises(ValueError, match="train_bars >= 2"):
+        walk_forward_select(
+            _frame(_uptrend(200)),
+            strategy_cls=_ExposureStrategy,
+            param_grid={"invested": [0.9]},
+            initial_cash=100_000.0,
+            train_bars=1,
+            test_bars=50,
+        )
+
+
+def test_rejects_test_bars_too_small() -> None:
+    with pytest.raises(ValueError, match="test_bars >= 1"):
+        walk_forward_select(
+            _frame(_uptrend(200)),
+            strategy_cls=_ExposureStrategy,
+            param_grid={"invested": [0.9]},
+            initial_cash=100_000.0,
+            train_bars=100,
+            test_bars=0,
+        )
+
+
+def test_rejects_list_input_with_no_common_dates() -> None:
+    a = _frame(_uptrend(200), start="2018-01-01")
+    b = _frame(_uptrend(200), start="2030-01-01")
+    with pytest.raises(ValueError, match="no common dates"):
+        walk_forward_select(
+            [a, b],
+            strategy_cls=_ExposureStrategy,
+            param_grid={"invested": [0.9]},
+            initial_cash=100_000.0,
+            train_bars=100,
+            test_bars=50,
+        )
+
+
+# ── single-fold layout + dataclass fields ─────────────────────────────────────
+
+
+def test_single_fold_layout() -> None:
+    # Exactly train_bars + test_bars → exactly one fold.
+    result = walk_forward_select(
+        _frame(_uptrend(150)),
+        strategy_cls=_ExposureStrategy,
+        param_grid={"invested": [0.0, 0.9]},
+        initial_cash=100_000.0,
+        train_bars=100,
+        test_bars=50,
+    )
+    assert isinstance(result, WalkForwardResult)
+    assert len(result.folds) == 1
+    fold = result.folds[0]
+    assert isinstance(fold, WalkForwardFold)
+    assert fold.fold == 0
+    assert len(fold.test_returns) == 50
+    assert len(result.oos_daily_returns) == 50
+    # Dataclass string fields are ISO timestamps and chronologically ordered.
+    assert fold.train_start < fold.train_end < fold.test_start < fold.test_end
+
+
+def test_param_grid_echoed_in_result() -> None:
+    grid = {"invested": [0.0, 0.5, 0.9]}
+    result = walk_forward_select(
+        _frame(_uptrend(200)),
+        strategy_cls=_ExposureStrategy,
+        param_grid=grid,
+        initial_cash=100_000.0,
+        train_bars=100,
+        test_bars=50,
+    )
+    assert result.n_param_combos == 3
+    assert result.param_grid == {"invested": [0.0, 0.5, 0.9]}
+    # param_grid is copied (lists rebuilt), not the same object.
+    assert result.param_grid is not grid
+
+
+def test_multi_param_grid_combos_count() -> None:
+    result = walk_forward_select(
+        _frame(_uptrend(220)),
+        strategy_cls=_ExposureStrategy,
+        param_grid={"invested": [0.0, 0.9]},
+        initial_cash=100_000.0,
+        train_bars=100,
+        test_bars=40,
+    )
+    # (220 - 100) // 40 == 3 folds.
+    assert len(result.folds) == 3
+    assert result.n_param_combos == 2
+    assert len(result.oos_daily_returns) == 3 * 40
+
+
+def test_oos_sharpe_uses_engine_convention() -> None:
+    # When at least one combo invests, selection succeeds and the stitched OOS
+    # series feeds _sharpe_bt_convention. On a steady uptrend the OOS Sharpe is
+    # a finite float computed under the engine's net-Sharpe convention.
+    from archimedes_analytics_engine.walk_forward import _sharpe_bt_convention
+
+    result = walk_forward_select(
+        _frame(_uptrend(200)),
+        strategy_cls=_ExposureStrategy,
+        param_grid={"invested": [0.0, 0.9]},
+        initial_cash=100_000.0,
+        train_bars=100,
+        test_bars=50,
+    )
+    assert result.oos_sharpe == _sharpe_bt_convention(result.oos_daily_returns)
+
+
+def test_single_none_sharpe_combo_raises_assertion() -> None:
+    # NOTE: discovered behavior — a single-combo grid whose only combo yields a
+    # None train Sharpe (an always-flat strategy never deploys, so the engine
+    # reports sharpe_ratio=None) leaves best_sharpe at -inf; the `> -inf` guard
+    # never fires and the `assert best_params is not None` trips. We assert the
+    # ACTUAL behavior rather than treating it as a bug to fix in the source.
+    with pytest.raises(AssertionError):
+        walk_forward_select(
+            _frame(_uptrend(200)),
+            strategy_cls=_ExposureStrategy,
+            param_grid={"invested": [0.0]},
+            initial_cash=100_000.0,
+            train_bars=100,
+            test_bars=50,
+        )
+
+
+def test_walk_forward_fold_dataclass_defaults() -> None:
+    fold = WalkForwardFold(
+        fold=0,
+        train_start="2018-01-01",
+        train_end="2018-04-10",
+        test_start="2018-04-11",
+        test_end="2018-05-30",
+        chosen_params={"invested": 0.9},
+        train_sharpe=1.5,
+    )
+    # test_returns defaults to an empty list (field(default_factory=list)).
+    assert fold.test_returns == []
+    assert fold.chosen_params == {"invested": 0.9}
+    assert fold.train_sharpe == 1.5


### PR DESCRIPTION
Coverage tests for analytics-engine engine.py / costs.py / walk_forward.py (56 tests). Documents 3 real behavioral edges as # NOTE (float-rounding no_trade_band, single-None-Sharpe grid assertion, buy-and-hold next-open fill) for triage; no behavior changed.