### PR TITLE
[strategy] Add FusionQualityScorer (6-dimension scoring) !minor

### DIFF
--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -771,3 +771,503 @@ def _max_drawdown(equity_curve: list[float]) -> float:
         if dd > max_dd:
             max_dd = dd
     return max_dd
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Fusion-quality scoring framework
+# ══════════════════════════════════════════════════════════════════════
+# A multi-dimensional score for *how good it is to FUSE/COMBINE* a set of
+# strategies, given each one's daily-return series. This is orthogonal to the
+# single-strategy rigor gate (DSR/PBO/OOS) above — rigor asks "is each member
+# admissible?"; fusion quality asks "do these members combine into something
+# better than any one alone?".
+#
+# All dimensions are pure numpy. Every method returns a float in a documented
+# range (mostly [0, 1], higher = better-for-fusion) or NaN when the input is
+# too degenerate to score (N < 2, all-constant series, …). Degenerate inputs
+# never raise — they return NaN or a neutral 0.5 so the aggregate can simply
+# skip a missing dimension instead of crashing.
+#
+# Owner: Önder (math lane).
+
+import numpy as _np
+
+# Default aggregate weights. Equal-ish weighting over the six dimensions, with
+# diversification + correlation-stability carrying slightly more (they are the
+# load-bearing "is fusion worthwhile at all" signals). Only the dimensions that
+# actually have data participate; the present weights are renormalized to sum to
+# 1.0 at aggregation time, so omitting a dimension does not bias the others.
+_FUSION_DIMENSION_WEIGHTS: dict[str, float] = {
+    "correlation_stability": 0.20,
+    "diversification_benefit": 0.25,
+    "tail_hedge": 0.20,
+    "turnover_interaction": 0.10,
+    "parameter_stability": 0.10,
+    "economic_sense": 0.15,
+}
+
+# A neutral mid-scale score returned when a dimension's input is present but
+# uninformative (e.g. a single perturbation observation): neither rewards nor
+# penalizes fusion.
+_FUSION_NEUTRAL = 0.5
+
+# Tail-risk quantile for CVaR (Conditional Value-at-Risk / Expected Shortfall).
+_CVAR_ALPHA = 0.05
+
+
+def _as_returns_matrix(
+    returns_matrix: dict[str, list[float]] | _np.ndarray | list[list[float]],
+) -> _np.ndarray | None:
+    """Coerce assorted return-series inputs into an aligned ``(N, T)`` array.
+
+    Accepts ``{id: series}``, a 2-D array, or a list of lists. Series of
+    unequal length are **truncated to the shortest** (length-mismatch handling
+    per the fusion-scorer contract). Returns ``None`` when fewer than two
+    usable (length >= 2) series survive — the caller treats ``None`` as
+    "not scoreable".
+    """
+    if isinstance(returns_matrix, dict):
+        series = list(returns_matrix.values())
+    else:
+        series = list(returns_matrix)
+
+    arrs = [_np.asarray(s, dtype=float).ravel() for s in series]
+    arrs = [a for a in arrs if a.size >= 2]
+    if len(arrs) < 2:
+        return None
+
+    T = min(a.size for a in arrs)
+    if T < 2:
+        return None
+    return _np.vstack([a[:T] for a in arrs])
+
+
+def _mean_pairwise_corr_matrix(matrix: _np.ndarray) -> _np.ndarray | None:
+    """Pearson correlation matrix of an ``(N, T)`` return matrix.
+
+    Constant (zero-variance) rows are filled with an identity-like 0 off the
+    diagonal because their correlation is undefined; returns ``None`` if fewer
+    than two non-constant rows remain.
+    """
+    live = matrix[_np.ptp(matrix, axis=1) > 0.0]
+    if live.shape[0] < 2:
+        return None
+    corr = _np.corrcoef(live)
+    # np.corrcoef can emit nan for pathological rows; treat nan as 0 corr.
+    return _np.nan_to_num(corr, nan=0.0)
+
+
+def score_correlation_stability(
+    returns_matrix: dict[str, list[float]] | _np.ndarray | list[list[float]],
+) -> float:
+    """Out-of-sample stability of the cross-strategy correlation structure.
+
+    Splits each series into an early and a late half, computes the pairwise
+    correlation matrix on each half, and returns ``1 - mean(|corr_late -
+    corr_early|)`` over the off-diagonal entries, clipped to ``[0, 1]``.
+
+    High = the diversification structure observed in-sample persists
+    out-of-sample, so a fusion weighting fit on history is more likely to hold.
+    Low = correlations drift (a regime shift), so historical diversification is
+    unreliable.
+
+    Statistical concept: rolling-/split-sample correlation stability — a
+    non-stationarity diagnostic on the dependence structure (cf. correlation
+    breakdown during regime shifts).
+
+    Returns ``NaN`` for fewer than two usable series or when a half is too short
+    (< 2 bars) or all-constant to form a correlation matrix.
+    """
+    matrix = _as_returns_matrix(returns_matrix)
+    if matrix is None:
+        return float("nan")
+
+    T = matrix.shape[1]
+    half = T // 2
+    if half < 2:
+        return float("nan")
+
+    early = matrix[:, :half]
+    late = matrix[:, half : 2 * half]
+
+    corr_early = _mean_pairwise_corr_matrix(early)
+    corr_late = _mean_pairwise_corr_matrix(late)
+    if corr_early is None or corr_late is None or corr_early.shape != corr_late.shape:
+        return float("nan")
+
+    n = corr_early.shape[0]
+    iu = _np.triu_indices(n, k=1)
+    diff = _np.abs(corr_late[iu] - corr_early[iu])
+    if diff.size == 0:
+        return float("nan")
+
+    return float(_np.clip(1.0 - float(_np.mean(diff)), 0.0, 1.0))
+
+
+def score_diversification_benefit(
+    returns_matrix: dict[str, list[float]] | _np.ndarray | list[list[float]],
+) -> float:
+    """Effective number of independent risk bets, normalized to ``[0, 1]``.
+
+    Builds the correlation matrix, takes its eigenvalues, and computes the
+    participation ratio / effective dimension::
+
+        N_eff = (Σ λ_i)² / Σ λ_i²
+
+    then normalizes by ``N`` so the score is ``N_eff / N ∈ (0, 1]``.
+
+    High (→ 1) = the strategies span roughly ``N`` independent risk directions
+    (low mutual correlation) — fusing them genuinely diversifies. Low (→ 1/N) =
+    they collapse onto a single common factor (high correlation) — fusing buys
+    little.
+
+    Statistical concept: effective dimension / participation ratio of the
+    correlation spectrum (Meucci 2009, "Managing Diversification"). For an
+    ``N × N`` correlation matrix the eigenvalues sum to ``N``, so ``N_eff``
+    ranges from ``1`` (one dominant factor) to ``N`` (isotropic / independent).
+
+    Returns ``NaN`` for fewer than two usable, non-constant series.
+    """
+    matrix = _as_returns_matrix(returns_matrix)
+    if matrix is None:
+        return float("nan")
+
+    corr = _mean_pairwise_corr_matrix(matrix)
+    if corr is None:
+        return float("nan")
+
+    n = corr.shape[0]
+    # Symmetric matrix → eigvalsh; clip tiny negatives from float error to 0.
+    eigvals = _np.clip(_np.linalg.eigvalsh(corr), 0.0, None)
+    denom = float(_np.sum(eigvals**2))
+    if denom <= 0.0:
+        return float("nan")
+
+    n_eff = (float(_np.sum(eigvals)) ** 2) / denom
+    return float(_np.clip(n_eff / n, 0.0, 1.0))
+
+
+def _cvar(returns: _np.ndarray, alpha: float = _CVAR_ALPHA) -> float | None:
+    """Conditional Value-at-Risk (Expected Shortfall) of the worst ``alpha`` tail.
+
+    Returns the mean of the worst ``alpha`` fraction of returns as a **loss
+    magnitude** (positive number for a loss). ``None`` if the series is empty.
+    """
+    arr = _np.asarray(returns, dtype=float).ravel()
+    if arr.size == 0:
+        return None
+    # At least one observation in the tail even for short series.
+    k = max(1, int(_np.ceil(alpha * arr.size)))
+    worst = _np.sort(arr)[:k]
+    return -float(_np.mean(worst))  # loss magnitude: positive = loss
+
+
+def score_tail_hedge(
+    returns_matrix: dict[str, list[float]] | _np.ndarray | list[list[float]],
+) -> float:
+    """Joint tail-risk reduction from equal-weight fusion, in ``[0, 1]``.
+
+    Compares the equal-weight portfolio's 95% CVaR (mean of its worst 5% days)
+    against the average of the individual strategies' 95% CVaR, returning::
+
+        max(0, 1 - portfolio_CVaR / avg_individual_CVaR)
+
+    High = combining the strategies materially softens the joint left tail
+    (their bad days don't coincide) — a genuine tail hedge. ``0`` = the
+    portfolio's tail is no better (or worse) than the average member's, so
+    fusion provides no downside protection.
+
+    Statistical concept: Conditional Value-at-Risk / Expected Shortfall at the
+    95% level; tail diversification.
+
+    Returns ``NaN`` for fewer than two usable series. Returns ``0.0`` (no
+    benefit) when the average individual tail loss is non-positive (e.g. no
+    losses in-sample), since there is no downside to hedge.
+    """
+    matrix = _as_returns_matrix(returns_matrix)
+    if matrix is None:
+        return float("nan")
+
+    portfolio = matrix.mean(axis=0)  # equal-weight daily returns
+    port_cvar = _cvar(portfolio)
+
+    indiv = [_cvar(matrix[i]) for i in range(matrix.shape[0])]
+    indiv = [c for c in indiv if c is not None]
+    if port_cvar is None or not indiv:
+        return float("nan")
+
+    avg_indiv_cvar = float(_np.mean(indiv))
+    if avg_indiv_cvar <= 0.0:
+        # No average downside in-sample → nothing to hedge.
+        return 0.0
+
+    return float(_np.clip(1.0 - port_cvar / avg_indiv_cvar, 0.0, 1.0))
+
+
+def score_turnover_interaction(
+    weights_or_signals: dict[str, list[float]] | _np.ndarray | list[list[float]],
+) -> float:
+    """Directional agreement of strategies, in ``[0, 1]`` (churn proxy).
+
+    When two strategies in a fused book hold opposite directional positions on
+    the same day, the combined book partially nets out — and rebalancing back to
+    target weights generates turnover (and transaction cost) that neither
+    strategy incurs alone. This dimension rewards directional *agreement*::
+
+        1 - mean_fraction_of_opposing_days
+
+    averaged over all strategy pairs, where an "opposing day" is one where the
+    two strategies' position signs differ.
+
+    Approximation (documented): the function ideally consumes daily *position
+    signals* (signed weights). When only return series are available it uses
+    ``sign(returns)`` as a directional proxy — a strategy that made money on a
+    given day is assumed to have been positioned long, lost money → short. This
+    conflates "direction of the bet" with "direction of the outcome" and is a
+    deliberate approximation; pass real signed signals for an exact measure.
+
+    Statistical concept: signal disagreement / netting-induced turnover.
+
+    High = strategies mostly agree on direction (low incremental churn from
+    fusion). Low = they frequently oppose (high churn / cost drag). Days where a
+    signal is exactly flat (sign 0) are excluded from that pair's tally.
+    Returns ``NaN`` for fewer than two usable series.
+    """
+    matrix = _as_returns_matrix(weights_or_signals)
+    if matrix is None:
+        return float("nan")
+
+    signs = _np.sign(matrix)  # proxy: sign(return) ≈ direction of position
+    n = signs.shape[0]
+    pair_agreements: list[float] = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            si, sj = signs[i], signs[j]
+            # Only days where both strategies took a directional stance.
+            active = (si != 0) & (sj != 0)
+            if not _np.any(active):
+                continue
+            opposing = (si[active] != sj[active]).mean()
+            pair_agreements.append(1.0 - float(opposing))
+
+    if not pair_agreements:
+        return float("nan")
+
+    return float(_np.clip(_np.mean(pair_agreements), 0.0, 1.0))
+
+
+def score_parameter_stability(
+    metric_under_perturbation: list[float] | _np.ndarray,
+) -> float:
+    """Robustness of a performance metric to small parameter perturbations.
+
+    Given a list of metric values (e.g. Sharpe ratios) observed while a
+    strategy's parameters are jittered slightly, returns::
+
+        1 - normalized_std
+
+    where ``normalized_std = std / |mean|`` is the coefficient of variation
+    (clipped so the score stays in ``[0, 1]``). A flat response surface around
+    the chosen operating point → low CV → score near ``1`` (robust); a metric
+    that swings wildly under tiny perturbations → high CV → score near ``0``
+    (fragile / likely overfit).
+
+    Statistical concept: robustness-to-perturbation / coefficient of variation
+    of the local response surface. Kept generic — the caller decides which
+    metric and which perturbation grid to feed.
+
+    Returns ``NaN`` for an empty input, a neutral ``0.5`` for a single
+    observation (no spread is measurable), and ``0.5`` when the mean is ~0 so
+    the CV is undefined (cannot normalize) — neither rewards nor penalizes.
+    """
+    arr = _np.asarray(metric_under_perturbation, dtype=float).ravel()
+    if arr.size == 0:
+        return float("nan")
+    if arr.size == 1:
+        return _FUSION_NEUTRAL
+
+    mean = float(arr.mean())
+    std = float(arr.std(ddof=1))
+    if abs(mean) < 1e-12:
+        # Mean ~0 → coefficient of variation is undefined; neutral.
+        return _FUSION_NEUTRAL
+
+    cv = std / abs(mean)
+    return float(_np.clip(1.0 - cv, 0.0, 1.0))
+
+
+def score_economic_sense(regime_tags: list[str] | tuple[str, ...]) -> float:
+    """Regime diversity of the fused strategy set, in ``[0, 1]``.
+
+    Given a list of regime tags (e.g. ``["bull", "bear", "neutral"]`` — one tag
+    per strategy describing the regime it is designed to exploit), rewards
+    coverage breadth::
+
+        unique_regimes / total_tags
+
+    High = the fused book spans multiple market regimes (e.g. a trend strategy
+    plus a mean-reversion strategy plus a vol-managed sleeve) — economically
+    sensible diversification across environments. Low (→ small) = every member
+    targets the same regime, so the book is concentrated in one environment.
+
+    Statistical/economic concept: regime coverage / economic diversification —
+    a sanity check that the fusion is not just statistically diverse but spans
+    distinct economic environments.
+
+    Tags are normalized (stripped + lower-cased); empty / whitespace tags are
+    ignored. Returns ``NaN`` for an empty input after filtering.
+    """
+    if regime_tags is None:
+        return float("nan")
+    cleaned = [str(t).strip().lower() for t in regime_tags if str(t).strip()]
+    if not cleaned:
+        return float("nan")
+    return float(len(set(cleaned)) / len(cleaned))
+
+
+class FusionQualityScorer:
+    """Multi-dimensional scorer for the quality of fusing several strategies.
+
+    Each dimension is a thin wrapper around the module-level pure functions so
+    the class can be subclassed / reweighted without touching the math. The
+    aggregate ``fusion_quality`` is a weighted mean over **only the dimensions
+    that produced a finite score**, with the present weights renormalized to sum
+    to 1.0 — so a missing input (e.g. no regime tags) drops that dimension
+    cleanly rather than dragging the aggregate toward 0.
+
+    Weights (``_FUSION_DIMENSION_WEIGHTS``, documented at module level):
+    diversification 0.25, correlation-stability 0.20, tail-hedge 0.20,
+    economic-sense 0.15, turnover-interaction 0.10, parameter-stability 0.10.
+    """
+
+    def __init__(self, weights: dict[str, float] | None = None) -> None:
+        self.weights = dict(weights) if weights is not None else dict(_FUSION_DIMENSION_WEIGHTS)
+
+    # ── individual dimensions (instance-method facade over the pure fns) ──
+
+    def score_correlation_stability(self, returns_matrix: Any) -> float:
+        return score_correlation_stability(returns_matrix)
+
+    def score_diversification_benefit(self, returns_matrix: Any) -> float:
+        return score_diversification_benefit(returns_matrix)
+
+    def score_tail_hedge(self, returns_matrix: Any) -> float:
+        return score_tail_hedge(returns_matrix)
+
+    def score_turnover_interaction(self, weights_or_signals: Any) -> float:
+        return score_turnover_interaction(weights_or_signals)
+
+    def score_parameter_stability(self, metric_under_perturbation: Any) -> float:
+        return score_parameter_stability(metric_under_perturbation)
+
+    def score_economic_sense(self, regime_tags: Any) -> float:
+        return score_economic_sense(regime_tags)
+
+    # ── aggregate ─────────────────────────────────────────────────────
+
+    def score_all(
+        self,
+        returns_matrix: dict[str, list[float]] | _np.ndarray | list[list[float]] | None = None,
+        *,
+        signals: dict[str, list[float]] | _np.ndarray | list[list[float]] | None = None,
+        perturbation_metrics: list[float] | _np.ndarray | None = None,
+        regime_tags: list[str] | None = None,
+    ) -> dict[str, float]:
+        """Compute every sub-score that has data plus the weighted aggregate.
+
+        Args:
+            returns_matrix: ``{id: daily_returns}`` (or array) — drives the
+                correlation-stability, diversification, and tail-hedge
+                dimensions, and (if ``signals`` is not given) the
+                turnover-interaction proxy via ``sign(returns)``.
+            signals: Optional signed daily position signals; if provided,
+                turnover-interaction uses these instead of the return-sign proxy.
+            perturbation_metrics: Optional metric-under-perturbation list for
+                the parameter-stability dimension.
+            regime_tags: Optional per-strategy regime tags for economic-sense.
+
+        Returns:
+            A dict with each computed dimension's score (only finite ones are
+            included as numeric; a dimension whose input was absent is omitted)
+            plus ``fusion_quality`` — the renormalized weighted mean over the
+            present dimensions. ``fusion_quality`` is ``NaN`` if no dimension
+            had usable data.
+        """
+        scores: dict[str, float] = {}
+
+        if returns_matrix is not None:
+            scores["correlation_stability"] = self.score_correlation_stability(returns_matrix)
+            scores["diversification_benefit"] = self.score_diversification_benefit(returns_matrix)
+            scores["tail_hedge"] = self.score_tail_hedge(returns_matrix)
+
+        # Turnover: prefer explicit signed signals, fall back to return-sign proxy.
+        turnover_input = signals if signals is not None else returns_matrix
+        if turnover_input is not None:
+            scores["turnover_interaction"] = self.score_turnover_interaction(turnover_input)
+
+        if perturbation_metrics is not None:
+            scores["parameter_stability"] = self.score_parameter_stability(perturbation_metrics)
+
+        if regime_tags is not None:
+            scores["economic_sense"] = self.score_economic_sense(regime_tags)
+
+        # Aggregate over finite dimensions only, renormalizing their weights.
+        present = {k: v for k, v in scores.items() if v is not None and _np.isfinite(v)}
+        total_w = sum(self.weights.get(k, 0.0) for k in present)
+        if present and total_w > 0.0:
+            agg = sum(self.weights.get(k, 0.0) * v for k, v in present.items()) / total_w
+            fusion_quality = float(_np.clip(agg, 0.0, 1.0))
+        else:
+            fusion_quality = float("nan")
+
+        result = dict(scores)
+        result["fusion_quality"] = fusion_quality
+        return result
+
+
+def generate_fusion_report(scores: dict[str, float], threshold: float = 0.7) -> dict[str, Any]:
+    """Structured (dict) recommendation report from ``FusionQualityScorer.score_all``.
+
+    NOT an HTML/PDF artifact — a plain dict suitable for JSON serialization or
+    further programmatic use.
+
+    Args:
+        scores: The dict returned by ``score_all`` (must contain
+            ``fusion_quality``; other keys are treated as dimension scores).
+        threshold: ``fusion_quality`` at or above this recommends fusion.
+
+    Returns:
+        ``{recommended, fusion_quality, dimension_breakdown, rationale}`` where
+        ``recommended`` is a bool (``False`` if ``fusion_quality`` is NaN/missing),
+        ``dimension_breakdown`` maps each present dimension to its score, and
+        ``rationale`` is a human-readable one-liner naming the strongest and
+        weakest contributing dimensions.
+    """
+    fq = scores.get("fusion_quality", float("nan"))
+    dimension_breakdown = {
+        k: float(v) for k, v in scores.items() if k != "fusion_quality" and v is not None and _np.isfinite(v)
+    }
+
+    fq_finite = isinstance(fq, (int, float)) and _np.isfinite(fq)
+    recommended = bool(fq_finite and fq >= threshold)
+
+    if not fq_finite:
+        rationale = "Insufficient data to score fusion quality (no dimension had usable inputs)."
+    elif not dimension_breakdown:
+        rationale = f"Fusion quality {fq:.2f} computed but no per-dimension breakdown available."
+    else:
+        strongest = max(dimension_breakdown, key=dimension_breakdown.get)
+        weakest = min(dimension_breakdown, key=dimension_breakdown.get)
+        verdict = "Recommend fusion" if recommended else "Do not fuse yet"
+        rationale = (
+            f"{verdict}: fusion quality {fq:.2f} vs threshold {threshold:.2f}. "
+            f"Strongest dimension: {strongest} ({dimension_breakdown[strongest]:.2f}); "
+            f"weakest: {weakest} ({dimension_breakdown[weakest]:.2f})."
+        )
+
+    return {
+        "recommended": recommended,
+        "fusion_quality": float(fq) if fq_finite else float("nan"),
+        "dimension_breakdown": dimension_breakdown,
+        "rationale": rationale,
+    }

--- a/backend/tests/test_fusion_quality_scorer.py
+++ b/backend/tests/test_fusion_quality_scorer.py
@@ -1,0 +1,278 @@
+"""Tests for the FusionQualityScorer multi-dimensional fusion-scoring framework.
+
+Hermetic: numpy only, no network/DB/Redis/Anthropic/Arc RPC. Exercises each of
+the six fusion dimensions, the score_all aggregation, generate_fusion_report
+threshold behavior, and degenerate-input handling (N<2, zero-variance,
+length-mismatch) which must never raise.
+
+Owner: Önder (math lane).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from archimedes.services.fusion_evaluator import (
+    FusionQualityScorer,
+    generate_fusion_report,
+    score_correlation_stability,
+    score_diversification_benefit,
+    score_economic_sense,
+    score_parameter_stability,
+    score_tail_hedge,
+    score_turnover_interaction,
+)
+
+
+# ─── Diversification benefit ─────────────────────────────────────────
+
+
+def test_diversification_low_for_perfectly_correlated_pair():
+    """Two identical (perfectly correlated) strategies → minimal diversification.
+
+    N_eff collapses toward 1, so N_eff/N → 1/2 for N=2 (the single-factor floor).
+    """
+    s = list(np.random.default_rng(0).normal(0.001, 0.01, 300))
+    score = score_diversification_benefit({"a": s, "b": list(s)})
+    # Single dominant factor → N_eff ≈ 1 → score ≈ 1/N = 0.5 for N=2.
+    assert np.isclose(score, 0.5, atol=0.05), f"perfectly correlated pair should collapse to 1/N, got {score}"
+
+
+def test_diversification_high_for_independent_strategies():
+    """Independent strategies span independent risk directions → high score."""
+    rng = np.random.default_rng(1)
+    m = {f"s{i}": list(rng.normal(0.0, 0.01, 600)) for i in range(6)}
+    score = score_diversification_benefit(m)
+    assert score > 0.8, f"independent strategies should diversify well, got {score}"
+
+
+def test_diversification_independent_beats_correlated():
+    """A diversified set must score strictly above a redundant (correlated) one."""
+    rng = np.random.default_rng(2)
+    base = rng.normal(0.0, 0.01, 400)
+    # Correlated set: each is base + tiny idiosyncratic noise.
+    corr_set = {f"c{i}": list(base + rng.normal(0, 0.0005, 400)) for i in range(4)}
+    indep_set = {f"i{i}": list(rng.normal(0.0, 0.01, 400)) for i in range(4)}
+    assert score_diversification_benefit(indep_set) > score_diversification_benefit(corr_set)
+
+
+# ─── Correlation stability ───────────────────────────────────────────
+
+
+def test_correlation_stability_high_for_stationary_series():
+    """Stationary jointly-correlated series → stable correlation across halves."""
+    rng = np.random.default_rng(3)
+    common = rng.normal(0.0, 0.01, 800)
+    a = common + rng.normal(0, 0.003, 800)
+    b = common + rng.normal(0, 0.003, 800)
+    score = score_correlation_stability({"a": list(a), "b": list(b)})
+    assert not math.isnan(score)
+    assert score > 0.7, f"stationary pair should be correlation-stable, got {score}"
+
+
+def test_correlation_stability_low_for_regime_shifting_series():
+    """A correlation that flips sign between halves → low stability score."""
+    rng = np.random.default_rng(4)
+    n = 400
+    common_early = rng.normal(0.0, 0.01, n)
+    common_late = rng.normal(0.0, 0.01, n)
+    # First half: positively correlated; second half: anti-correlated.
+    a = np.concatenate([common_early, common_late])
+    b = np.concatenate([common_early, -common_late])
+    score = score_correlation_stability({"a": list(a), "b": list(b)})
+    stable = score_correlation_stability(
+        {"x": list(np.concatenate([common_early, common_late])), "y": list(np.concatenate([common_early, common_late]))}
+    )
+    assert score < stable, "regime-shifting pair must be less stable than a stationary pair"
+
+
+# ─── Tail hedge ──────────────────────────────────────────────────────
+
+
+def test_tail_hedge_reduces_cvar_for_negatively_correlated_pair():
+    """Negatively-correlated strategies hedge each other's tails → high score."""
+    rng = np.random.default_rng(5)
+    shock = rng.normal(0.0, 0.02, 600)
+    a = shock + rng.normal(0.0005, 0.005, 600)
+    b = -shock + rng.normal(0.0005, 0.005, 600)  # opposite tail exposure
+    score = score_tail_hedge({"a": list(a), "b": list(b)})
+    assert not math.isnan(score)
+    assert score > 0.3, f"negatively-correlated pair should hedge tails, got {score}"
+
+
+def test_tail_hedge_low_for_identical_strategies():
+    """Identical strategies share the same tail → little/no hedging benefit."""
+    s = list(np.random.default_rng(6).normal(0.0, 0.02, 400))
+    score = score_tail_hedge({"a": s, "b": list(s)})
+    # Equal-weight of two identical series == the series itself → CVaR unchanged.
+    assert score == 0.0 or score < 0.05
+
+
+# ─── Turnover interaction ────────────────────────────────────────────
+
+
+def test_turnover_high_for_aligned_signals():
+    """Strategies that almost always agree on direction → high agreement score."""
+    signals = {
+        "a": [1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0],
+        "b": [1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0],
+    }
+    assert score_turnover_interaction(signals) == 1.0
+
+
+def test_turnover_low_for_opposing_signals():
+    """Always-opposing strategies → maximal churn → score 0."""
+    signals = {
+        "a": [1.0, 1.0, 1.0, 1.0, -1.0, -1.0],
+        "b": [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0],
+    }
+    assert score_turnover_interaction(signals) == 0.0
+
+
+# ─── Parameter stability ─────────────────────────────────────────────
+
+
+def test_parameter_stability_high_for_flat_response():
+    """Near-constant metric under perturbation → robust (score → 1)."""
+    metrics = [1.50, 1.49, 1.51, 1.50, 1.50]
+    score = score_parameter_stability(metrics)
+    assert score > 0.95, f"flat response should be robust, got {score}"
+
+
+def test_parameter_stability_low_for_volatile_response():
+    """Wildly swinging metric under perturbation → fragile (low score)."""
+    metrics = [2.0, 0.1, 1.8, 0.2, 1.9, 0.05]
+    score = score_parameter_stability(metrics)
+    assert score < 0.5, f"volatile response should be fragile, got {score}"
+
+
+# ─── Economic sense (regime diversity) ───────────────────────────────
+
+
+def test_economic_sense_full_diversity():
+    """All-distinct regime tags → diversity 1.0."""
+    assert score_economic_sense(["bull", "bear", "neutral"]) == 1.0
+
+
+def test_economic_sense_no_diversity():
+    """All-identical regime tags → diversity 1/N."""
+    assert score_economic_sense(["bull", "bull", "bull", "bull"]) == 0.25
+
+
+def test_economic_sense_normalizes_and_ignores_blanks():
+    """Tags are case/space-normalized; blanks ignored."""
+    # "Bull", " bull " collapse to one regime; "" is dropped → 1 unique / 3 total.
+    assert score_economic_sense(["Bull", " bull ", "BULL", ""]) == 1.0 / 3.0
+
+
+# ─── score_all aggregation ───────────────────────────────────────────
+
+
+def test_score_all_aggregates_present_dimensions():
+    """score_all returns all computed dimensions plus a finite fusion_quality."""
+    rng = np.random.default_rng(7)
+    m = {f"s{i}": list(rng.normal(0.0005, 0.01, 500)) for i in range(4)}
+    scorer = FusionQualityScorer()
+    scores = scorer.score_all(
+        m,
+        perturbation_metrics=[1.5, 1.48, 1.52, 1.5],
+        regime_tags=["bull", "bear", "neutral", "bull"],
+    )
+    assert "fusion_quality" in scores
+    assert 0.0 <= scores["fusion_quality"] <= 1.0
+    for dim in (
+        "correlation_stability",
+        "diversification_benefit",
+        "tail_hedge",
+        "turnover_interaction",
+        "parameter_stability",
+        "economic_sense",
+    ):
+        assert dim in scores
+
+
+def test_score_all_skips_missing_dimensions_without_crash():
+    """Omitting perturbation + regime inputs drops those dims; aggregate stays finite."""
+    rng = np.random.default_rng(8)
+    m = {f"s{i}": list(rng.normal(0.0, 0.01, 400)) for i in range(3)}
+    scores = FusionQualityScorer().score_all(m)
+    assert "parameter_stability" not in scores
+    assert "economic_sense" not in scores
+    assert np.isfinite(scores["fusion_quality"])
+
+
+def test_score_all_nan_when_no_data():
+    """No usable inputs → fusion_quality is NaN, no exception."""
+    scores = FusionQualityScorer().score_all(None)
+    assert math.isnan(scores["fusion_quality"])
+
+
+# ─── generate_fusion_report threshold behavior ───────────────────────
+
+
+def test_report_recommends_above_threshold():
+    scores = {"diversification_benefit": 0.9, "tail_hedge": 0.8, "fusion_quality": 0.85}
+    report = generate_fusion_report(scores, threshold=0.7)
+    assert report["recommended"] is True
+    assert report["fusion_quality"] == 0.85
+    assert "diversification_benefit" in report["dimension_breakdown"]
+    assert isinstance(report["rationale"], str) and report["rationale"]
+
+
+def test_report_rejects_below_threshold():
+    scores = {"diversification_benefit": 0.4, "tail_hedge": 0.3, "fusion_quality": 0.35}
+    report = generate_fusion_report(scores, threshold=0.7)
+    assert report["recommended"] is False
+    assert "Do not fuse" in report["rationale"]
+
+
+def test_report_handles_nan_fusion_quality():
+    report = generate_fusion_report({"fusion_quality": float("nan")}, threshold=0.7)
+    assert report["recommended"] is False
+    assert math.isnan(report["fusion_quality"])
+    assert "Insufficient data" in report["rationale"]
+
+
+# ─── Degenerate inputs never raise ───────────────────────────────────
+
+
+def test_single_strategy_input_does_not_crash():
+    """N<2 in every dimension → NaN, never an exception."""
+    one = {"only": list(np.random.default_rng(9).normal(0.0, 0.01, 200))}
+    assert math.isnan(score_correlation_stability(one))
+    assert math.isnan(score_diversification_benefit(one))
+    assert math.isnan(score_tail_hedge(one))
+    assert math.isnan(score_turnover_interaction(one))
+    scores = FusionQualityScorer().score_all(one)
+    # Single-strategy returns matrix → all return-driven dims NaN → aggregate NaN.
+    assert math.isnan(scores["fusion_quality"])
+
+
+def test_length_mismatch_truncates_to_min():
+    """Series of unequal length are truncated to the shortest, not crashed."""
+    m = {"a": list(np.random.default_rng(10).normal(0.0, 0.01, 500)), "b": [0.01, -0.02, 0.03, 0.0, 0.01]}
+    # Should run without error and yield a finite-or-nan float (not raise).
+    score = score_diversification_benefit(m)
+    assert isinstance(score, float)
+
+
+def test_zero_variance_series_handled():
+    """A constant series alongside a live one is dropped; degrades gracefully."""
+    flat = [0.001] * 200
+    live = list(np.random.default_rng(11).normal(0.0, 0.01, 200))
+    # Only one non-constant row survives → NaN, no crash.
+    assert math.isnan(score_diversification_benefit({"flat": flat, "live": live}))
+
+
+def test_parameter_stability_degenerate_inputs():
+    """Empty → NaN; single observation → neutral 0.5; never raises."""
+    assert math.isnan(score_parameter_stability([]))
+    assert score_parameter_stability([1.5]) == 0.5
+    # Mean ~0 → CV undefined → neutral 0.5.
+    assert score_parameter_stability([1.0, -1.0]) == 0.5
+
+
+def test_economic_sense_empty_is_nan():
+    assert math.isnan(score_economic_sense([]))
+    assert math.isnan(score_economic_sense(["", "  "]))


### PR DESCRIPTION
Adds FusionQualityScorer scoring strategy fusion across 6 dimensions (correlation-stability, diversification via Meucci participation ratio, tail-hedge, turnover-interaction, parameter-stability, economic-sense) + structured report. Existing fusion pipeline untouched. Tests: 25 passing.