### PR TITLE
[frontend] Add quantitative-visualization components !minor

### DIFF
--- a/backend/archimedes/api/portfolio_routes.py
+++ b/backend/archimedes/api/portfolio_routes.py
@@ -1,0 +1,111 @@
+"""Portfolio optimization endpoints — /api/portfolio/*.
+
+Thin HTTP layer over :func:`archimedes.services.portfolio_optimizer.optimize_weights`.
+The solvers themselves (MVO / HRP / Black-Litterman / robust) landed via #554 +
+#570; this router exposes them to the UI (PortfolioAdvisorPanels' optimizer
+selector POSTs here).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+portfolio_router = APIRouter(prefix="/api/portfolio", tags=["portfolio"])
+
+# UI sends short ids ("bl"); the optimizer service uses full names.
+_METHOD_ALIASES = {
+    "mvo": "mvo",
+    "hrp": "hrp",
+    "bl": "black_litterman",
+    "black_litterman": "black_litterman",
+    "robust": "robust",
+}
+
+_PRICE_FETCH_TIMEOUT_S = 45.0
+_MIN_HISTORY_BARS = 60  # below this, covariance estimates are too noisy to act on
+
+
+class OptimizeRequest(BaseModel):
+    method: str = Field("mvo", description="One of: mvo, hrp, bl, black_litterman, robust")
+    risk_profile: str = Field("moderate", pattern="^(fixed_income|conservative|moderate|aggressive|hyper_risky)$")
+    symbols: list[str] | None = Field(
+        None,
+        description="Synth symbols to allocate across; defaults to the standard scan universe.",
+        max_length=50,
+    )
+
+
+@portfolio_router.post("/optimize")
+async def optimize_portfolio(req: OptimizeRequest) -> dict:
+    """Compute optimal synth-asset weights with the requested optimizer.
+
+    Returns {method, optimizer, risk_profile, usdc_weight, weights, symbols_used,
+    history_bars, timestamp}. Weights sum to (1 - usdc_floor) for the profile;
+    the USDC floor is reported separately as usdc_weight.
+
+    503 when price history is unavailable (e.g. data provider down) — the UI
+    degrades gracefully on that status.
+    """
+    from archimedes.models.portfolio import RISK_PROFILE_PARAMS, RiskProfile
+    from archimedes.services.portfolio_optimizer import optimize_weights
+    from archimedes.services.strategy_signal_evaluator import (
+        DEFAULT_SCAN_UNIVERSE,
+        _fetch_price_histories,
+    )
+
+    optimizer = _METHOD_ALIASES.get(req.method.lower())
+    if optimizer is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown optimizer '{req.method}'. Expected one of {sorted(_METHOD_ALIASES)}.",
+        )
+
+    rp = RiskProfile(req.risk_profile)
+    usdc_floor = RISK_PROFILE_PARAMS[rp]["usyc_floor"]
+    synth_budget = max(0.0, 1.0 - usdc_floor)
+
+    universe = req.symbols or list(DEFAULT_SCAN_UNIVERSE)
+    try:
+        price_histories = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_price_histories, universe, "2y"),
+            timeout=_PRICE_FETCH_TIMEOUT_S,
+        )
+    except Exception:
+        price_histories = {}
+
+    daily_returns: dict[str, list[float]] = {}
+    for sym, series in price_histories.items():
+        rets = series.pct_change().dropna()
+        if len(rets) >= _MIN_HISTORY_BARS:
+            daily_returns[sym] = rets.tolist()
+
+    if len(daily_returns) < 2:
+        raise HTTPException(
+            status_code=503,
+            detail="Price history unavailable — optimizer needs ≥2 assets with ≥60 bars of returns.",
+        )
+
+    symbols = sorted(daily_returns)
+    weights = await asyncio.to_thread(
+        optimize_weights,
+        symbols,
+        daily_returns,
+        rp,
+        synth_budget,
+        optimizer,
+    )
+
+    return {
+        "method": req.method,
+        "optimizer": optimizer,
+        "risk_profile": req.risk_profile,
+        "usdc_weight": round(usdc_floor, 4),
+        "weights": {s: round(w, 6) for s, w in weights.items()},
+        "symbols_used": symbols,
+        "history_bars": min(len(r) for r in daily_returns.values()),
+        "timestamp": datetime.now(UTC).isoformat(),
+    }

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -35,6 +35,7 @@ from archimedes.api.generate_routes import generate_router
 from archimedes.api.limiter import limiter
 
 # marketplace_router removed — hardcoded fees + invented math (Issue #381)
+from archimedes.api.portfolio_routes import portfolio_router
 from archimedes.api.proposals_routes import proposals_router
 from archimedes.api.risk_routes import risk_router
 from archimedes.api.routes import (
@@ -229,6 +230,7 @@ app.include_router(explore_router)
 app.include_router(generate_router)
 # marketplace_router removed (Issue #381)
 app.include_router(risk_router)
+app.include_router(portfolio_router)
 app.include_router(selection_bias_router)
 app.include_router(papers_router)
 app.include_router(user_router)

--- a/backend/tests/test_portfolio_routes.py
+++ b/backend/tests/test_portfolio_routes.py
@@ -1,0 +1,94 @@
+"""HTTP-layer tests for portfolio_routes (POST /api/portfolio/optimize).
+
+Hermetic: the yfinance boundary (_fetch_price_histories) is mocked with
+deterministic synthetic price series — no network, DB, or Redis required.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+_N_BARS = 300
+
+
+def _synthetic_prices() -> dict[str, pd.Series]:
+    """Three deterministic, non-degenerate price series (≥60 return bars)."""
+    out: dict[str, pd.Series] = {}
+    for k, sym in enumerate(["sSPY", "sGOLD", "sBTC"]):
+        prices = [100.0 * (1 + 0.0004 * (k + 1)) ** i * (1 + 0.01 * math.sin(i / (3.0 + k))) for i in range(_N_BARS)]
+        out[sym] = pd.Series(prices)
+    return out
+
+
+def _patch_prices(histories):
+    return patch(
+        "archimedes.services.strategy_signal_evaluator._fetch_price_histories",
+        return_value=histories,
+    )
+
+
+async def _post_optimize(body: dict):
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.post("/api/portfolio/optimize", json=body)
+
+
+@pytest.mark.parametrize("method,expected_optimizer", [("mvo", "mvo"), ("hrp", "hrp"), ("bl", "black_litterman")])
+async def test_optimize_happy_path(method, expected_optimizer):
+    with _patch_prices(_synthetic_prices()):
+        resp = await _post_optimize({"method": method, "risk_profile": "moderate"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["optimizer"] == expected_optimizer
+    assert set(data["weights"]) <= {"sSPY", "sGOLD", "sBTC"}
+    # Weights sum to the synth budget (1 - usdc_floor), which itself is in (0, 1].
+    total = sum(data["weights"].values())
+    assert 0.0 < total <= 1.0
+    assert abs(total + data["usdc_weight"] - 1.0) < 0.01
+    assert all(w >= -1e-9 for w in data["weights"].values())
+
+
+async def test_optimize_default_method_is_mvo():
+    with _patch_prices(_synthetic_prices()):
+        resp = await _post_optimize({})
+    assert resp.status_code == 200
+    assert resp.json()["optimizer"] == "mvo"
+
+
+async def test_optimize_unknown_method_422():
+    resp = await _post_optimize({"method": "alchemy"})
+    assert resp.status_code == 422
+    assert "alchemy" in resp.json()["detail"]
+
+
+async def test_optimize_invalid_risk_profile_422():
+    resp = await _post_optimize({"method": "mvo", "risk_profile": "yolo"})
+    assert resp.status_code == 422
+
+
+async def test_optimize_no_price_data_503():
+    with _patch_prices({}):
+        resp = await _post_optimize({"method": "mvo"})
+    assert resp.status_code == 503
+
+
+async def test_optimize_insufficient_history_503():
+    # Two symbols but only 10 bars each — below the 60-bar floor.
+    short = {sym: series.iloc[:10] for sym, series in _synthetic_prices().items()}
+    with _patch_prices(short):
+        resp = await _post_optimize({"method": "hrp"})
+    assert resp.status_code == 503
+
+
+async def test_optimize_risk_profile_changes_usdc_floor():
+    with _patch_prices(_synthetic_prices()):
+        conservative = await _post_optimize({"method": "mvo", "risk_profile": "conservative"})
+        aggressive = await _post_optimize({"method": "mvo", "risk_profile": "aggressive"})
+    assert conservative.status_code == aggressive.status_code == 200
+    assert conservative.json()["usdc_weight"] > aggressive.json()["usdc_weight"]

--- a/ui/src/components/BacktestVisualizer.css
+++ b/ui/src/components/BacktestVisualizer.css
@@ -1,0 +1,80 @@
+/* BacktestVisualizer.css — colocated styles. Reuses shared App.css classes for
+   cards/labels/tables; this file covers the sweep heatmap and the trade-log
+   date filter. */
+
+/* ─── parameter sweep heatmap ─── */
+.bv-sweep {
+  display: grid;
+  gap: 3px;
+  max-width: 620px;
+}
+.bv-sweep-corner {
+  display: flex;
+  align-items: flex-end;
+  font-size: 0.66rem;
+  color: var(--text-4);
+  padding: 0 6px 4px 0;
+  text-align: right;
+}
+.bv-sweep-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-3);
+  padding: 4px 0;
+}
+.bv-sweep-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--text-1);
+  border-radius: 4px;
+  border: 1px solid var(--glass-border);
+}
+
+/* ─── trade log filter ─── */
+.bv-filter {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.bv-filter input[type='date'] {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  padding: 5px 8px;
+  color: var(--text-1);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  margin-left: 5px;
+  outline: none;
+  color-scheme: dark;
+}
+.bv-filter input[type='date']:focus {
+  border-color: var(--accent-border);
+}
+.bv-clear {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  color: var(--text-2);
+  font-size: 0.76rem;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.bv-clear:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-1);
+}
+
+/* mb-0 helper if not present in App.css */
+.label.mb-0 {
+  margin-bottom: 0;
+}

--- a/ui/src/components/BacktestVisualizer.jsx
+++ b/ui/src/components/BacktestVisualizer.jsx
@@ -1,0 +1,394 @@
+// BacktestVisualizer — equity+drawdown dual chart, walk-forward IS/OOS bands,
+// parameter-sweep heatmap, filterable trade log, and rolling-stat confidence
+// band. Renders standalone with mock defaults; accepts real props.
+//
+// Suggested integration: import into the StrategyPassport / backtest detail
+// surface, e.g.
+//   import BacktestVisualizer from './components/BacktestVisualizer'
+// and render <BacktestVisualizer result={backtestResult} />.
+//
+// All inline SVG (no chart lib). Styling reuses shared App.css classes plus a
+// small colocated BacktestVisualizer.css.
+
+import { useState, useMemo } from 'react'
+import {
+  equityFromReturns,
+  drawdownSeries,
+  rollingSharpe,
+  mockReturns,
+  seededRng,
+} from '../utils/riskMath'
+import './BacktestVisualizer.css'
+
+function fmtPct(v, d = 2) {
+  return v != null && Number.isFinite(v) ? `${(v * 100).toFixed(d)}%` : '—'
+}
+function fmt(v, d = 2) {
+  return v != null && Number.isFinite(v) ? v.toFixed(d) : '—'
+}
+
+// ─── Equity curve + drawdown (dual axis) ────────────────────
+function EquityDrawdownChart({ returns, oosStartFrac }) {
+  const W = 720
+  const H = 300
+  const PAD_L = 52
+  const PAD_R = 52
+  const PAD_T = 16
+  const PAD_B = 26
+
+  const { equityLine, ddArea, eqTicks, ddTicks, oosX } = useMemo(() => {
+    const equity = equityFromReturns(returns)
+    const dd = drawdownSeries(equity)
+    const n = equity.length
+    const eqLo = Math.min(...equity)
+    const eqHi = Math.max(...equity)
+    const ddLo = Math.min(...dd, -0.01)
+    const toX = (i) => PAD_L + (i / Math.max(1, n - 1)) * (W - PAD_L - PAD_R)
+    const toYeq = (v) => PAD_T + (1 - (v - eqLo) / (eqHi - eqLo)) * (H - PAD_T - PAD_B)
+    const toYdd = (v) => PAD_T + (v / ddLo) * (H - PAD_T - PAD_B)
+    const eqPts = equity.map((v, i) => `${toX(i).toFixed(1)},${toYeq(v).toFixed(1)}`)
+    const ddPts = dd.map((v, i) => `${toX(i).toFixed(1)},${toYdd(v).toFixed(1)}`)
+    const ddBase = toYdd(0)
+    return {
+      equityLine: `M ${eqPts.join(' L ')}`,
+      ddArea: `M ${PAD_L},${ddBase} L ${ddPts.join(' L ')} L ${toX(n - 1)},${ddBase} Z`,
+      eqTicks: [eqHi, (eqHi + eqLo) / 2, eqLo].map((v) => ({ y: toYeq(v), label: v.toFixed(2) })),
+      ddTicks: [0, ddLo / 2, ddLo].map((v) => ({ y: toYdd(v), label: `${(v * 100).toFixed(0)}%` })),
+      oosX: toX(Math.floor(oosStartFrac * (n - 1))),
+    }
+  }, [returns, oosStartFrac])
+
+  return (
+    <div className="card-elevated" style={{ padding: 24, marginBottom: 20 }}>
+      <div className="label mb-2">Equity Curve &amp; Drawdown</div>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Equity curve with drawdown overlay" style={{ display: 'block' }}>
+        {eqTicks.map((t, i) => (
+          <line key={i} x1={PAD_L} y1={t.y} x2={W - PAD_R} y2={t.y} stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+        ))}
+        {/* left axis = equity (accent) */}
+        {eqTicks.map((t, i) => (
+          <text key={`eq${i}`} x={PAD_L - 6} y={t.y + 3} textAnchor="end" fill="var(--accent)" fontSize="9" className="mono">
+            {t.label}
+          </text>
+        ))}
+        {/* right axis = drawdown (red) */}
+        {ddTicks.map((t, i) => (
+          <text key={`dd${i}`} x={W - PAD_R + 6} y={t.y + 3} textAnchor="start" fill="var(--negative)" fontSize="9" className="mono">
+            {t.label}
+          </text>
+        ))}
+        {/* OOS divider */}
+        <line x1={oosX} y1={PAD_T} x2={oosX} y2={H - PAD_B} stroke="rgba(255,255,255,0.28)" strokeWidth="1" strokeDasharray="4 3" />
+        <text x={oosX + 4} y={PAD_T + 10} fill="rgba(255,255,255,0.5)" fontSize="9">
+          OOS →
+        </text>
+        <path d={ddArea} fill="rgba(239,68,68,0.14)" stroke="none" />
+        <path d={equityLine} fill="none" stroke="var(--accent)" strokeWidth="1.8" strokeLinejoin="round" />
+      </svg>
+      <p className="caption" style={{ marginTop: 8, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        <span style={{ color: 'var(--accent)' }}>Purple</span> = cumulative equity (left axis);{' '}
+        <span style={{ color: 'var(--negative)' }}>red</span> = drawdown from peak (right axis). The dashed
+        line marks the in-sample / out-of-sample boundary — equity that keeps compounding past it without a
+        drawdown cliff is the signal we want.
+      </p>
+    </div>
+  )
+}
+
+// ─── Walk-forward IS/OOS band visualizer ────────────────────
+function WalkForwardBands({ folds }) {
+  const W = 720
+  const H = 90
+  const PAD_L = 8
+  const PAD_R = 8
+
+  const segW = (W - PAD_L - PAD_R) / folds.length
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-2">Walk-Forward Validation (IS / OOS folds)</div>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Walk-forward in-sample and out-of-sample folds" style={{ display: 'block' }}>
+        {folds.map((f, i) => {
+          const x = PAD_L + i * segW
+          const isW = segW * 0.7
+          const oosW = segW * 0.28
+          const oosColor = f.oosSharpe > 0 ? 'var(--positive)' : 'var(--negative)'
+          return (
+            <g key={i}>
+              <rect x={x} y={20} width={isW} height={40} rx={3} fill="rgba(192,132,252,0.28)" stroke="var(--accent)" strokeWidth="0.8">
+                <title>Fold {i + 1} in-sample: train Sharpe {f.isSharpe.toFixed(2)}</title>
+              </rect>
+              <rect x={x + isW + 2} y={20} width={oosW} height={40} rx={3} fill={oosColor} opacity="0.85">
+                <title>Fold {i + 1} out-of-sample: OOS Sharpe {f.oosSharpe.toFixed(2)}</title>
+              </rect>
+              <text x={x + segW / 2} y={14} textAnchor="middle" fill="rgba(255,255,255,0.45)" fontSize="8">
+                F{i + 1}
+              </text>
+              <text x={x + segW / 2} y={76} textAnchor="middle" fill="rgba(255,255,255,0.55)" fontSize="8" className="mono">
+                {f.oosSharpe.toFixed(2)}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+      <div style={{ display: 'flex', gap: 16, marginTop: 4 }}>
+        <span className="caption" style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+          <span style={{ width: 12, height: 8, background: 'rgba(192,132,252,0.4)', border: '1px solid var(--accent)', borderRadius: 2 }} /> In-sample (train)
+        </span>
+        <span className="caption" style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+          <span style={{ width: 12, height: 8, background: 'var(--positive)', borderRadius: 2 }} /> OOS Sharpe &gt; 0
+        </span>
+        <span className="caption" style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+          <span style={{ width: 12, height: 8, background: 'var(--negative)', borderRadius: 2 }} /> OOS Sharpe ≤ 0
+        </span>
+      </div>
+      <p className="caption" style={{ marginTop: 8, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Each fold trains on its purple in-sample window, then tests on the adjacent out-of-sample slice. A
+        strategy whose OOS bars stay green and close to their IS Sharpe is stable; a sharp IS→OOS drop is
+        the overfitting signature that PBO quantifies.
+      </p>
+    </div>
+  )
+}
+
+// ─── Parameter sweep heatmap ────────────────────────────────
+function ParameterSweepHeatmap({ sweep }) {
+  const { rows, cols, grid, max, min } = sweep
+  const range = max - min || 1
+
+  function cellColor(v) {
+    const t = (v - min) / range // 0..1
+    // low Sharpe -> dark; high -> accent purple
+    return `rgba(192,132,252,${(0.08 + 0.82 * t).toFixed(3)})`
+  }
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-3">Parameter Sweep (Sharpe by parameter pair)</div>
+      <div className="bv-sweep" style={{ gridTemplateColumns: `auto repeat(${cols.length}, 1fr)` }}>
+        <div className="bv-sweep-corner caption">lookback ↓ / thresh →</div>
+        {cols.map((c) => (
+          <div key={`c${c}`} className="bv-sweep-head mono">{c}</div>
+        ))}
+        {rows.map((r, i) => (
+          <div key={`r${r}`} style={{ display: 'contents' }}>
+            <div className="bv-sweep-head mono" style={{ textAlign: 'right', paddingRight: 8 }}>{r}</div>
+            {cols.map((c, j) => {
+              const v = grid[i][j]
+              return (
+                <div
+                  key={`${r}-${c}`}
+                  className="bv-sweep-cell mono"
+                  style={{ background: cellColor(v) }}
+                  title={`lookback=${r}, threshold=${c} → Sharpe ${v.toFixed(2)}`}
+                >
+                  {v.toFixed(2)}
+                </div>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+      <p className="caption" style={{ marginTop: 10, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Sharpe across a 2D parameter grid. A single bright island surrounded by dark cells is a fragile
+        peak (likely overfit); a broad bright plateau means the edge is robust to parameter choice. We
+        report the full grid rather than only the best cell — that&apos;s what the deflated-Sharpe
+        multiple-testing correction accounts for.
+      </p>
+    </div>
+  )
+}
+
+// ─── Trade / rebalance log with date filter ─────────────────
+function TradeLog({ trades }) {
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+
+  const filtered = useMemo(() => {
+    return trades.filter((t) => {
+      if (from && t.date < from) return false
+      if (to && t.date > to) return false
+      return true
+    })
+  }, [trades, from, to])
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 10 }}>
+        <div className="label mb-0">Trade / Rebalance Log</div>
+        <div className="bv-filter">
+          <label className="caption">
+            From <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
+          </label>
+          <label className="caption">
+            To <input type="date" value={to} onChange={(e) => setTo(e.target.value)} />
+          </label>
+          {(from || to) && (
+            <button className="bv-clear" onClick={() => { setFrom(''); setTo('') }}>Clear</button>
+          )}
+        </div>
+      </div>
+      <div className="table-container" style={{ marginTop: 12 }}>
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Action</th>
+              <th>Asset</th>
+              <th className="text-right">Weight Δ</th>
+              <th className="text-right">Price</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((t, i) => (
+              <tr key={i}>
+                <td className="mono" style={{ fontSize: '0.76rem' }}>{t.date}</td>
+                <td>
+                  <span className={t.action === 'BUY' ? 'positive' : t.action === 'SELL' ? 'negative' : ''} style={{ fontWeight: 600, fontSize: '0.8rem' }}>
+                    {t.action}
+                  </span>
+                </td>
+                <td className="mono" style={{ fontSize: '0.78rem' }}>{t.asset}</td>
+                <td className={`text-right mono ${t.weightDelta > 0 ? 'positive' : t.weightDelta < 0 ? 'negative' : ''}`}>
+                  {t.weightDelta > 0 ? '+' : ''}{(t.weightDelta * 100).toFixed(1)}%
+                </td>
+                <td className="text-right mono">{fmt(t.price)}</td>
+              </tr>
+            ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={5} className="caption" style={{ textAlign: 'center', padding: 16, color: 'var(--text-4)' }}>
+                  No trades in the selected date range.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <p className="caption" style={{ marginTop: 8, color: 'var(--text-4)' }}>
+        Showing {filtered.length} of {trades.length} rebalance events. Each row corresponds to an on-chain
+        rebalance whose reasoning trace is anchored on Arc.
+      </p>
+    </div>
+  )
+}
+
+// ─── Rolling statistic with confidence band ─────────────────
+function RollingStatBand({ returns, window }) {
+  const W = 720
+  const H = 220
+  const PAD_L = 44
+  const PAD_R = 12
+  const PAD_T = 14
+  const PAD_B = 22
+
+  const { line, bandPath, yTicks, zeroY } = useMemo(() => {
+    const series = rollingSharpe(returns, window)
+    const valid = series.map((v, i) => ({ v, i })).filter((d) => d.v != null)
+    const ys = valid.map((d) => d.v)
+    // crude ±1 std confidence band around each point's neighborhood
+    const lo = Math.min(-1, ...ys)
+    const hi = Math.max(1, ...ys)
+    const n = returns.length
+    const toX = (i) => PAD_L + (i / Math.max(1, n - 1)) * (W - PAD_L - PAD_R)
+    const toY = (v) => PAD_T + (1 - (v - lo) / (hi - lo)) * (H - PAD_T - PAD_B)
+    // standard error of a Sharpe estimate ~ sqrt((1 + 0.5*S^2)/window)
+    const se = (s) => Math.sqrt((1 + 0.5 * s * s) / window)
+    const upper = valid.map((d) => `${toX(d.i).toFixed(1)},${toY(d.v + se(d.v)).toFixed(1)}`)
+    const lower = valid.map((d) => `${toX(d.i).toFixed(1)},${toY(d.v - se(d.v)).toFixed(1)}`).reverse()
+    const band = valid.length ? `M ${upper.join(' L ')} L ${lower.join(' L ')} Z` : ''
+    const mid = valid.length ? `M ${valid.map((d) => `${toX(d.i).toFixed(1)},${toY(d.v).toFixed(1)}`).join(' L ')}` : ''
+    const ticks = [hi, 0, lo].map((v) => ({ y: toY(v), label: v.toFixed(1) }))
+    return { line: mid, bandPath: band, yTicks: ticks, zeroY: toY(0) }
+  }, [returns, window])
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-2">Rolling Sharpe with Confidence Band ({window}d)</div>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Rolling Sharpe with confidence band" style={{ display: 'block' }}>
+        {yTicks.map((t, i) => (
+          <line key={i} x1={PAD_L} y1={t.y} x2={W - PAD_R} y2={t.y} stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+        ))}
+        {yTicks.map((t, i) => (
+          <text key={`l${i}`} x={PAD_L - 6} y={t.y + 3} textAnchor="end" fill="rgba(255,255,255,0.42)" fontSize="9" className="mono">
+            {t.label}
+          </text>
+        ))}
+        <line x1={PAD_L} y1={zeroY} x2={W - PAD_R} y2={zeroY} stroke="rgba(255,255,255,0.2)" strokeWidth="1" strokeDasharray="3 3" />
+        {bandPath && <path d={bandPath} fill="rgba(192,132,252,0.15)" stroke="none" />}
+        {line && <path d={line} fill="none" stroke="var(--accent)" strokeWidth="1.6" strokeLinejoin="round" />}
+      </svg>
+      <p className="caption" style={{ marginTop: 8, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Shaded band is the ±1 standard-error envelope on the rolling Sharpe estimate (SE ≈ √((1 + ½S²)/n)).
+        When the band straddles 0, the estimated edge is not statistically distinguishable from noise over
+        that window.
+      </p>
+    </div>
+  )
+}
+
+// ─── mock defaults ──────────────────────────────────────────
+function buildMockResult() {
+  const returns = mockReturns(252, { seed: 21, drift: 0.0006 })
+  const rng = seededRng(5)
+  const folds = Array.from({ length: 6 }, (_, i) => ({
+    isSharpe: 1.0 + rng() * 0.8,
+    oosSharpe: 0.6 + rng() * 0.9 - (i === 4 ? 1.1 : 0), // one weak fold for realism
+  }))
+  const rows = [10, 20, 40, 60, 90]
+  const cols = [0.5, 1.0, 1.5, 2.0]
+  const grid = rows.map((r) =>
+    cols.map((c) => {
+      const peak = Math.exp(-(((r - 40) / 40) ** 2) - ((c - 1.5) / 1.2) ** 2)
+      return 0.3 + 1.6 * peak + (rng() - 0.5) * 0.25
+    }),
+  )
+  const flat = grid.flat()
+  const sweep = { rows, cols, grid, max: Math.max(...flat), min: Math.min(...flat) }
+  const actions = ['BUY', 'SELL', 'REBAL']
+  const assets = ['sSPY', 'sBTC', 'sGOLD', 'sNVDA']
+  const trades = Array.from({ length: 14 }, (_, i) => {
+    const d = new Date(2025, 0, 1 + i * 18)
+    return {
+      date: d.toISOString().slice(0, 10),
+      action: actions[Math.floor(rng() * actions.length)],
+      asset: assets[Math.floor(rng() * assets.length)],
+      weightDelta: (rng() - 0.5) * 0.16,
+      price: 50 + rng() * 400,
+    }
+  })
+  return { returns, folds, sweep, trades }
+}
+
+export default function BacktestVisualizer({ result } = {}) {
+  const data = useMemo(() => {
+    const mock = buildMockResult()
+    return {
+      returns: result?.returns ?? mock.returns,
+      folds: result?.folds ?? mock.folds,
+      sweep: result?.sweep ?? mock.sweep,
+      trades: result?.trades ?? mock.trades,
+    }
+  }, [result])
+
+  return (
+    <div>
+      <div style={{ maxWidth: 680, marginBottom: 28 }}>
+        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 10 }}>
+          Backtest Visualizer
+        </h2>
+        <p className="body">
+          The full diagnostic surface behind a strategy passport: equity and drawdown, walk-forward
+          stability, parameter robustness, the rebalance log, and the statistical-significance band on
+          rolling performance.
+        </p>
+      </div>
+
+      <EquityDrawdownChart returns={data.returns} oosStartFrac={0.7} />
+      <WalkForwardBands folds={data.folds} />
+      <ParameterSweepHeatmap sweep={data.sweep} />
+      <TradeLog trades={data.trades} />
+      <RollingStatBand returns={data.returns} window={60} />
+    </div>
+  )
+}

--- a/ui/src/components/BacktestVisualizer.jsx
+++ b/ui/src/components/BacktestVisualizer.jsx
@@ -20,9 +20,6 @@ import {
 } from '../utils/riskMath'
 import './BacktestVisualizer.css'
 
-function fmtPct(v, d = 2) {
-  return v != null && Number.isFinite(v) ? `${(v * 100).toFixed(d)}%` : '—'
-}
 function fmt(v, d = 2) {
   return v != null && Number.isFinite(v) ? v.toFixed(d) : '—'
 }

--- a/ui/src/components/PortfolioAdvisorPanels.css
+++ b/ui/src/components/PortfolioAdvisorPanels.css
@@ -105,3 +105,31 @@
   margin-top: 5px;
   color: var(--text-4);
 }
+
+/* optimizer result weights */
+.pap-weights {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.pap-weight-row {
+  display: grid;
+  grid-template-columns: 64px 1fr 56px;
+  align-items: center;
+  gap: 10px;
+}
+.pap-weight-track {
+  height: 8px;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.pap-weight-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+.pap-weight-row .caption {
+  text-align: right;
+}

--- a/ui/src/components/PortfolioAdvisorPanels.css
+++ b/ui/src/components/PortfolioAdvisorPanels.css
@@ -1,0 +1,107 @@
+/* PortfolioAdvisorPanels.css — colocated styles. Reuses shared App.css classes
+   for cards/labels; this file covers the segmented control, Kelly inputs, and
+   drift bars. */
+
+/* ─── segmented control ─── */
+.pap-segmented {
+  display: inline-flex;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+.pap-seg-btn {
+  border: none;
+  background: transparent;
+  color: var(--text-2);
+  font-size: 0.82rem;
+  font-weight: 500;
+  padding: 7px 18px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.pap-seg-btn:hover {
+  color: var(--text-1);
+}
+.pap-seg-btn.active {
+  background: var(--accent);
+  color: #000;
+  font-weight: 700;
+}
+
+/* ─── Kelly widget ─── */
+.pap-kelly-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+.pap-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.pap-field input {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  padding: 9px 12px;
+  color: var(--text-1);
+  font-family: var(--mono);
+  font-size: 0.92rem;
+  outline: none;
+}
+.pap-field input:focus {
+  border-color: var(--accent-border);
+}
+.pap-kelly-out {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  border: 1px solid var(--glass-border);
+}
+
+/* ─── allocation drift bars ─── */
+.pap-drift-row {
+  margin-bottom: 18px;
+}
+.pap-drift-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.pap-drift-track {
+  position: relative;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  overflow: visible;
+}
+.pap-drift-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+.pap-drift-target {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 2px;
+  background: var(--text-1);
+  transform: translateX(-1px);
+  z-index: 2;
+}
+.pap-drift-legend {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 5px;
+  color: var(--text-4);
+}

--- a/ui/src/components/PortfolioAdvisorPanels.jsx
+++ b/ui/src/components/PortfolioAdvisorPanels.jsx
@@ -1,0 +1,305 @@
+// PortfolioAdvisorPanels — interactive optimizer + Kelly + frontier + drift
+// panels that complement the existing read-only PortfolioAdvisor.jsx (NOT a
+// replacement — drop this alongside it).
+//
+// Suggested integration: import into the /portfolio (or a new /optimizer)
+// surface, e.g.
+//   import PortfolioAdvisorPanels from './components/PortfolioAdvisorPanels'
+// and render <PortfolioAdvisorPanels /> beneath <PortfolioAdvisor />.
+//
+// All inline SVG (no chart lib). Styling reuses shared App.css classes plus a
+// small colocated PortfolioAdvisorPanels.css.
+
+import { useState, useMemo } from 'react'
+import { apiPost } from '../api'
+import { kellyFraction, seededRng } from '../utils/riskMath'
+import './PortfolioAdvisorPanels.css'
+
+// TODO: confirm the exact backend optimizer route. The advisor read path is
+// GET /api/strategies/advisor; the POST optimize endpoint is wired here as a
+// clearly-named constant so a backend owner can point it at the real handler.
+const OPTIMIZE_ENDPOINT = '/api/portfolio/optimize'
+
+const OPTIMIZERS = [
+  { id: 'mvo', label: 'MVO', full: 'Mean-Variance Optimization (Markowitz)' },
+  { id: 'hrp', label: 'HRP', full: 'Hierarchical Risk Parity (López de Prado)' },
+  { id: 'bl', label: 'Black-Litterman', full: 'Black-Litterman equilibrium + views' },
+]
+
+function fmtPct(v, d = 1) {
+  return v != null && Number.isFinite(v) ? `${(v * 100).toFixed(d)}%` : '—'
+}
+
+// ─── Optimizer selector (segmented control + POST) ──────────
+function OptimizerSelector() {
+  const [selected, setSelected] = useState('mvo')
+  const [status, setStatus] = useState('idle') // idle | loading | done | error
+  const [error, setError] = useState('')
+  const [result, setResult] = useState(null)
+
+  async function runOptimizer(id) {
+    setSelected(id)
+    setStatus('loading')
+    setError('')
+    setResult(null)
+    try {
+      const data = await apiPost(OPTIMIZE_ENDPOINT, { method: id })
+      setResult(data)
+      setStatus('done')
+    } catch (e) {
+      // Endpoint may not exist yet — surface gracefully rather than crashing.
+      setError(e.message || 'Optimizer endpoint unavailable')
+      setStatus('error')
+    }
+  }
+
+  const active = OPTIMIZERS.find((o) => o.id === selected)
+
+  return (
+    <div className="card-elevated" style={{ padding: 24, marginBottom: 20 }}>
+      <div className="label mb-3">Optimizer</div>
+      <div className="pap-segmented" role="tablist" aria-label="Portfolio optimizer">
+        {OPTIMIZERS.map((o) => (
+          <button
+            key={o.id}
+            role="tab"
+            aria-selected={selected === o.id}
+            className={`pap-seg-btn${selected === o.id ? ' active' : ''}`}
+            onClick={() => runOptimizer(o.id)}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+      <p className="caption" style={{ marginTop: 10, color: 'var(--text-3)' }}>
+        {active.full}
+      </p>
+      {status === 'loading' && <div className="caption" style={{ marginTop: 8 }}>Optimizing allocation…</div>}
+      {status === 'error' && (
+        <div className="info-box warning" style={{ marginTop: 8 }}>
+          Optimizer unavailable: {error}. (POST {OPTIMIZE_ENDPOINT})
+        </div>
+      )}
+      {status === 'done' && result?.weights && (
+        <div className="caption" style={{ marginTop: 8, color: 'var(--text-2)' }}>
+          Returned {Object.keys(result.weights).length} weights from the {active.label} optimizer.
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Efficient frontier scatter ─────────────────────────────
+function EfficientFrontier({ points }) {
+  const W = 700
+  const H = 280
+  const PAD_L = 48
+  const PAD_R = 16
+  const PAD_T = 16
+  const PAD_B = 36
+
+  const { plot, frontierPath, optimal, xTicks, yTicks } = useMemo(() => {
+    const xs = points.map((p) => p.risk)
+    const ys = points.map((p) => p.ret)
+    const xlo = Math.min(...xs) * 0.9
+    const xhi = Math.max(...xs) * 1.05
+    const ylo = Math.min(...ys) * 0.9
+    const yhi = Math.max(...ys) * 1.05
+    const toX = (v) => PAD_L + ((v - xlo) / (xhi - xlo)) * (W - PAD_L - PAD_R)
+    const toY = (v) => PAD_T + (1 - (v - ylo) / (yhi - ylo)) * (H - PAD_T - PAD_B)
+    const mapped = points.map((p) => ({ ...p, cx: toX(p.risk), cy: toY(p.ret), sharpe: p.ret / p.risk }))
+    // frontier = upper envelope (sort by risk, keep running-max return)
+    const sorted = [...mapped].sort((a, b) => a.risk - b.risk)
+    const env = []
+    let best = -Infinity
+    for (const p of sorted) {
+      if (p.ret >= best) {
+        best = p.ret
+        env.push(p)
+      }
+    }
+    const path = env.length ? `M ${env.map((p) => `${p.cx.toFixed(1)},${p.cy.toFixed(1)}`).join(' L ')}` : ''
+    const opt = mapped.reduce((a, b) => (b.sharpe > a.sharpe ? b : a), mapped[0])
+    const xt = [xlo, (xlo + xhi) / 2, xhi].map((v) => ({ x: toX(v), label: fmtPct(v) }))
+    const yt = [ylo, (ylo + yhi) / 2, yhi].map((v) => ({ y: toY(v), label: fmtPct(v) }))
+    return { plot: mapped, frontierPath: path, optimal: opt, xTicks: xt, yTicks: yt }
+  }, [points])
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-2">Efficient Frontier</div>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Efficient frontier: expected return vs risk" style={{ display: 'block' }}>
+        {yTicks.map((t, i) => (
+          <line key={i} x1={PAD_L} y1={t.y} x2={W - PAD_R} y2={t.y} stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+        ))}
+        {yTicks.map((t, i) => (
+          <text key={`yl${i}`} x={PAD_L - 6} y={t.y + 3} textAnchor="end" fill="rgba(255,255,255,0.42)" fontSize="9" className="mono">
+            {t.label}
+          </text>
+        ))}
+        {xTicks.map((t, i) => (
+          <text key={`xl${i}`} x={t.x} y={H - PAD_B + 16} textAnchor="middle" fill="rgba(255,255,255,0.42)" fontSize="9" className="mono">
+            {t.label}
+          </text>
+        ))}
+        {/* axis titles */}
+        <text x={(W + PAD_L) / 2} y={H - 4} textAnchor="middle" fill="rgba(255,255,255,0.55)" fontSize="10">
+          Risk (annualized σ)
+        </text>
+        {frontierPath && <path d={frontierPath} fill="none" stroke="var(--accent)" strokeWidth="1.6" strokeLinejoin="round" />}
+        {plot.map((p, i) => (
+          <circle key={i} cx={p.cx} cy={p.cy} r={p === optimal ? 5 : 3} fill={p === optimal ? 'var(--positive)' : 'rgba(192,132,252,0.55)'}>
+            <title>
+              {p.label || `Portfolio ${i + 1}`}: return {fmtPct(p.ret)}, risk {fmtPct(p.risk)}, Sharpe {p.sharpe.toFixed(2)}
+            </title>
+          </circle>
+        ))}
+      </svg>
+      <p className="caption" style={{ marginTop: 8, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Each dot is a candidate allocation; the purple curve is the efficient frontier (max return per unit
+        of risk). The green dot is the max-Sharpe (tangency) portfolio at{' '}
+        <span className="mono">{fmtPct(optimal.ret)}</span> return /{' '}
+        <span className="mono">{fmtPct(optimal.risk)}</span> risk.
+      </p>
+    </div>
+  )
+}
+
+// ─── Kelly fraction widget ──────────────────────────────────
+function KellyWidget() {
+  const [p, setP] = useState(0.55)
+  const [b, setB] = useState(1.2)
+
+  const full = kellyFraction(p, b)
+  const half = full / 2
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-3">Kelly Fraction Calculator</div>
+      <div className="pap-kelly-grid">
+        <label className="pap-field">
+          <span className="caption">Win probability (p)</span>
+          <input
+            type="number"
+            min="0"
+            max="1"
+            step="0.01"
+            value={p}
+            onChange={(e) => setP(Math.min(1, Math.max(0, Number(e.target.value))))}
+          />
+        </label>
+        <label className="pap-field">
+          <span className="caption">Net payoff odds (b)</span>
+          <input
+            type="number"
+            min="0"
+            step="0.1"
+            value={b}
+            onChange={(e) => setB(Math.max(0, Number(e.target.value)))}
+          />
+        </label>
+      </div>
+      <div className="pap-kelly-out">
+        <div>
+          <div className="caption">Full Kelly f*</div>
+          <div className="mono" style={{ fontWeight: 700, fontSize: '1.6rem', color: 'var(--accent)' }}>
+            {fmtPct(full)}
+          </div>
+        </div>
+        <div>
+          <div className="caption">Half-Kelly (recommended)</div>
+          <div className="mono positive" style={{ fontWeight: 700, fontSize: '1.6rem' }}>
+            {fmtPct(half)}
+          </div>
+        </div>
+      </div>
+      <p className="caption" style={{ marginTop: 12, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        f* = (b·p − q) / b, where q = 1 − p. Full Kelly maximizes long-run log-growth but is volatile and
+        assumes p and b are known exactly. <strong>Half-Kelly</strong> is the standard safety margin: it
+        captures ~75% of the growth at ~50% of the variance and is far more robust to estimation error in p.
+      </p>
+    </div>
+  )
+}
+
+// ─── Allocation drift bars (current vs target) ──────────────
+function AllocationDrift({ rows }) {
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-3">Allocation Drift (current vs target)</div>
+      {rows.map((r) => {
+        const drift = r.current - r.target
+        const driftColor = Math.abs(drift) < 0.01 ? 'var(--text-3)' : drift > 0 ? '#f59e0b' : '#60a5fa'
+        return (
+          <div key={r.symbol} className="pap-drift-row">
+            <div className="pap-drift-head">
+              <span className="mono" style={{ fontWeight: 600, fontSize: '0.84rem' }}>{r.symbol}</span>
+              <span className="caption" style={{ color: driftColor }}>
+                {drift > 0 ? '+' : ''}{(drift * 100).toFixed(1)}% vs target
+              </span>
+            </div>
+            <div className="pap-drift-track">
+              {/* target marker */}
+              <div className="pap-drift-target" style={{ left: `${(r.target * 100).toFixed(1)}%` }} title={`target ${fmtPct(r.target)}`} />
+              {/* current fill */}
+              <div className="pap-drift-fill" style={{ width: `${(r.current * 100).toFixed(1)}%` }} />
+            </div>
+            <div className="pap-drift-legend caption">
+              <span>current <span className="mono">{fmtPct(r.current)}</span></span>
+              <span>target <span className="mono">{fmtPct(r.target)}</span></span>
+            </div>
+          </div>
+        )
+      })}
+      <p className="caption" style={{ marginTop: 6, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        The vertical tick marks each sleeve&apos;s target weight; the bar shows the current weight. Drift
+        beyond a band triggers the agent&apos;s rebalance — every rebalance decision is hashed and anchored
+        on Arc.
+      </p>
+    </div>
+  )
+}
+
+// ─── default mock data ──────────────────────────────────────
+function buildMockFrontier() {
+  const rng = seededRng(99)
+  const pts = []
+  for (let i = 0; i < 40; i++) {
+    const risk = 0.05 + rng() * 0.22
+    // concave-ish return vs risk with noise
+    const ret = 0.02 + 0.9 * risk - 1.4 * risk * risk + (rng() - 0.5) * 0.03
+    pts.push({ risk, ret: Math.max(0.005, ret) })
+  }
+  return pts
+}
+
+const MOCK_DRIFT = [
+  { symbol: 'sSPY', current: 0.34, target: 0.3 },
+  { symbol: 'sBTC', current: 0.12, target: 0.18 },
+  { symbol: 'sGOLD', current: 0.21, target: 0.2 },
+  { symbol: 'USDC', current: 0.33, target: 0.32 },
+]
+
+export default function PortfolioAdvisorPanels({ frontierPoints, driftRows } = {}) {
+  const points = useMemo(() => frontierPoints ?? buildMockFrontier(), [frontierPoints])
+  const rows = driftRows ?? MOCK_DRIFT
+
+  return (
+    <div>
+      <div style={{ maxWidth: 680, marginBottom: 28 }}>
+        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 10 }}>
+          Optimizer &amp; Sizing
+        </h2>
+        <p className="body">
+          Choose an allocation method, inspect the efficient frontier, size positions with Kelly, and watch
+          how far the live book has drifted from its targets.
+        </p>
+      </div>
+
+      <OptimizerSelector />
+      <EfficientFrontier points={points} />
+      <KellyWidget />
+      <AllocationDrift rows={rows} />
+    </div>
+  )
+}

--- a/ui/src/components/PortfolioAdvisorPanels.jsx
+++ b/ui/src/components/PortfolioAdvisorPanels.jsx
@@ -15,15 +15,16 @@ import { apiPost } from '../api'
 import { kellyFraction, seededRng } from '../utils/riskMath'
 import './PortfolioAdvisorPanels.css'
 
-// TODO: confirm the exact backend optimizer route. The advisor read path is
-// GET /api/strategies/advisor; the POST optimize endpoint is wired here as a
-// clearly-named constant so a backend owner can point it at the real handler.
+// Backed by POST /api/portfolio/optimize (portfolio_routes.py), a thin route
+// over services/portfolio_optimizer.optimize_weights. Returns 503 when price
+// history is unavailable — handled by the error branch below.
 const OPTIMIZE_ENDPOINT = '/api/portfolio/optimize'
 
 const OPTIMIZERS = [
   { id: 'mvo', label: 'MVO', full: 'Mean-Variance Optimization (Markowitz)' },
   { id: 'hrp', label: 'HRP', full: 'Hierarchical Risk Parity (López de Prado)' },
   { id: 'bl', label: 'Black-Litterman', full: 'Black-Litterman equilibrium + views' },
+  { id: 'robust', label: 'Robust', full: 'Robust MVO — ellipsoidal uncertainty on μ (Goldfarb & Iyengar)' },
 ]
 
 function fmtPct(v, d = 1) {
@@ -81,8 +82,25 @@ function OptimizerSelector() {
         </div>
       )}
       {status === 'done' && result?.weights && (
-        <div className="caption" style={{ marginTop: 8, color: 'var(--text-2)' }}>
-          Returned {Object.keys(result.weights).length} weights from the {active.label} optimizer.
+        <div style={{ marginTop: 12 }}>
+          <div className="caption" style={{ color: 'var(--text-2)', marginBottom: 6 }}>
+            {active.label} allocation — USDC floor {fmtPct(result.usdc_weight)}, synth sleeve{' '}
+            {Object.keys(result.weights).length} assets:
+          </div>
+          <div className="pap-weights">
+            {Object.entries(result.weights)
+              .sort((a, b) => b[1] - a[1])
+              .filter(([, w]) => w > 0.0005)
+              .map(([sym, w]) => (
+                <div key={sym} className="pap-weight-row">
+                  <span className="mono" style={{ fontSize: '0.8rem' }}>{sym}</span>
+                  <div className="pap-weight-track">
+                    <div className="pap-weight-fill" style={{ width: `${Math.min(100, w * 100).toFixed(1)}%` }} />
+                  </div>
+                  <span className="mono caption">{fmtPct(w)}</span>
+                </div>
+              ))}
+          </div>
         </div>
       )}
     </div>

--- a/ui/src/components/RiskAnalysis.css
+++ b/ui/src/components/RiskAnalysis.css
@@ -1,0 +1,106 @@
+/* RiskAnalysis.css — colocated styles for the risk dashboard.
+   Only the metric-card grid, tooltip, and heatmap need bespoke CSS; everything
+   else reuses the shared App.css classes (card-elevated, card-flat, etc.). */
+
+.risk-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.risk-stat-card {
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+}
+
+.risk-stat-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-bottom: 8px;
+}
+
+.risk-stat-value {
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 1.1;
+}
+
+/* ─── tooltip ─── */
+.risk-tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: help;
+  color: var(--text-4);
+  outline: none;
+}
+.risk-tooltip:hover,
+.risk-tooltip:focus-visible {
+  color: var(--accent);
+}
+.risk-tooltip .risk-tooltip-body {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 220px;
+  padding: 10px 12px;
+  background: #0d0e12;
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  font-size: 0.74rem;
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--text-2);
+  line-height: 1.45;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.12s ease;
+  z-index: 20;
+  pointer-events: none;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+.risk-tooltip:hover .risk-tooltip-body,
+.risk-tooltip:focus-visible .risk-tooltip-body {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ─── correlation heatmap ─── */
+.risk-heatmap {
+  display: grid;
+  gap: 3px;
+  max-width: 560px;
+}
+.risk-heatmap-corner {
+  /* empty top-left cell */
+}
+.risk-heatmap-head {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 0;
+}
+.risk-heatmap-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-1);
+  border-radius: 4px;
+  border: 1px solid var(--glass-border);
+}

--- a/ui/src/components/RiskAnalysis.jsx
+++ b/ui/src/components/RiskAnalysis.jsx
@@ -1,0 +1,314 @@
+// RiskAnalysis — quantitative risk dashboard (VaR/CVaR, drawdown, rolling
+// Sharpe, correlation heatmap). Renders standalone with mock defaults.
+//
+// Suggested integration: import into a route alongside PortfolioAdvisor, e.g.
+//   import RiskAnalysis from './components/RiskAnalysis'
+// and render <RiskAnalysis /> on the /risk or /portfolio surface.
+//
+// All inline SVG (no chart lib — matches AssetModal.jsx). Styling reuses the
+// shared App.css classes (card-elevated, card-flat, label, caption, mono) plus
+// a small colocated RiskAnalysis.css for the metric-card grid + tooltips.
+
+import { useMemo } from 'react'
+import {
+  computeHistoricalVaR,
+  computeCVaR,
+  rollingSharpe,
+  drawdownSeries,
+  equityFromReturns,
+  correlation,
+  mockReturns,
+} from '../utils/riskMath'
+import './RiskAnalysis.css'
+
+function fmtPct(v, d = 2) {
+  return v != null && Number.isFinite(v) ? `${(v * 100).toFixed(d)}%` : '—'
+}
+function fmt(v, d = 2) {
+  return v != null && Number.isFinite(v) ? v.toFixed(d) : '—'
+}
+
+// ─── default mock data ──────────────────────────────────────
+function buildDefaultData() {
+  const returns = mockReturns(252, { seed: 7 })
+  const assets = ['sSPY', 'sBTC', 'sGOLD', 'sNVDA']
+  const series = assets.map((_, i) => mockReturns(252, { seed: 11 + i * 13, vol: 0.012 + i * 0.004 }))
+  return { returns, assets, series }
+}
+
+// ─── VaR / CVaR stat cards ──────────────────────────────────
+function VaRPanel({ returns }) {
+  const stats = useMemo(
+    () => ({
+      var95: computeHistoricalVaR(returns, 0.95),
+      cvar95: computeCVaR(returns, 0.95),
+      var99: computeHistoricalVaR(returns, 0.99),
+      cvar99: computeCVaR(returns, 0.99),
+    }),
+    [returns],
+  )
+
+  const cards = [
+    {
+      label: '95% VaR (1-day)',
+      value: stats.var95,
+      tip: 'On 95% of days, the single-day loss is not expected to exceed this. Historical (empirical-quantile) method.',
+    },
+    {
+      label: '95% CVaR',
+      value: stats.cvar95,
+      tip: 'Conditional VaR / Expected Shortfall: the average loss on the worst 5% of days — the size of the tail, not just its edge.',
+    },
+    {
+      label: '99% VaR (1-day)',
+      value: stats.var99,
+      tip: 'On 99% of days, the single-day loss is not expected to exceed this. A more conservative threshold than 95%.',
+    },
+    {
+      label: '99% CVaR',
+      value: stats.cvar99,
+      tip: 'Average loss on the worst 1% of days. The deepest-tail expectation.',
+    },
+  ]
+
+  return (
+    <div className="card-elevated" style={{ padding: 24, marginBottom: 20 }}>
+      <div className="label mb-3">Value-at-Risk &amp; Conditional VaR</div>
+      <div className="risk-stat-grid">
+        {cards.map((c) => (
+          <div className="risk-stat-card" key={c.label}>
+            <div className="risk-stat-label">
+              {c.label}
+              <span className="risk-tooltip" tabIndex={0} aria-label={c.tip}>
+                <span className="i-lucide-info" aria-hidden="true" />
+                <span className="risk-tooltip-body">{c.tip}</span>
+              </span>
+            </div>
+            <div className="risk-stat-value negative mono">-{fmtPct(c.value)}</div>
+          </div>
+        ))}
+      </div>
+      <p className="caption" style={{ marginTop: 12, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Computed from {returns.length} historical daily returns via the empirical method (no normality
+        assumption). VaR is the loss threshold at the stated confidence; CVaR (Expected Shortfall) is the
+        mean loss beyond it and is always at least as large.
+      </p>
+    </div>
+  )
+}
+
+// ─── Drawdown / underwater area chart ───────────────────────
+function DrawdownPlot({ returns }) {
+  const W = 700
+  const H = 200
+  const PAD_L = 44
+  const PAD_R = 12
+  const PAD_T = 12
+  const PAD_B = 22
+
+  const { areaPath, linePath, minDD, yTicks } = useMemo(() => {
+    const equity = equityFromReturns(returns)
+    const dd = drawdownSeries(equity) // <= 0
+    const n = dd.length
+    const lo = Math.min(...dd, -0.01)
+    const toX = (i) => PAD_L + (i / Math.max(1, n - 1)) * (W - PAD_L - PAD_R)
+    const toY = (v) => PAD_T + (v / lo) * (H - PAD_T - PAD_B) // v in [lo,0] -> [bottom,top]
+    const pts = dd.map((v, i) => `${toX(i).toFixed(1)},${toY(v).toFixed(1)}`)
+    const baselineY = toY(0)
+    const area = `M ${PAD_L},${baselineY} L ${pts.join(' L ')} L ${toX(n - 1)},${baselineY} Z`
+    const line = `M ${pts.join(' L ')}`
+    const ticks = [0, 0.5, 1].map((f) => {
+      const v = lo * f
+      return { y: toY(v), label: `${(v * 100).toFixed(0)}%` }
+    })
+    return { areaPath: area, linePath: line, minDD: lo, yTicks: ticks }
+  }, [returns])
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-2">Drawdown (Underwater Plot)</div>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Drawdown over time" style={{ display: 'block' }}>
+        {yTicks.map((t, i) => (
+          <line key={i} x1={PAD_L} y1={t.y} x2={W - PAD_R} y2={t.y} stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+        ))}
+        {yTicks.map((t, i) => (
+          <text key={`l${i}`} x={PAD_L - 6} y={t.y + 3} textAnchor="end" fill="rgba(255,255,255,0.42)" fontSize="9" className="mono">
+            {t.label}
+          </text>
+        ))}
+        <path d={areaPath} fill="rgba(239,68,68,0.16)" stroke="none" />
+        <path d={linePath} fill="none" stroke="var(--negative)" strokeWidth="1.5" strokeLinejoin="round" />
+      </svg>
+      <p className="caption" style={{ marginTop: 8, color: 'var(--text-4)' }}>
+        Decline from the running high-water mark. Max drawdown over the window:{' '}
+        <span className="mono negative">{fmtPct(-minDD)}</span>. Shallower and shorter underwater periods
+        indicate a more capital-preserving strategy.
+      </p>
+    </div>
+  )
+}
+
+// ─── Rolling Sharpe line chart (30 / 60 / 90d) ──────────────
+function RollingSharpePlot({ returns }) {
+  const W = 700
+  const H = 220
+  const PAD_L = 44
+  const PAD_R = 12
+  const PAD_T = 12
+  const PAD_B = 22
+
+  const windows = [
+    { w: 30, color: 'var(--accent)', label: '30d' },
+    { w: 60, color: '#60a5fa', label: '60d' },
+    { w: 90, color: 'var(--positive)', label: '90d' },
+  ]
+
+  const { lines, yTicks, zeroY } = useMemo(() => {
+    const computed = windows.map((cfg) => ({ ...cfg, series: rollingSharpe(returns, cfg.w) }))
+    const all = computed.flatMap((c) => c.series.filter((v) => v != null))
+    const lo = Math.min(-1, ...all)
+    const hi = Math.max(1, ...all)
+    const n = returns.length
+    const toX = (i) => PAD_L + (i / Math.max(1, n - 1)) * (W - PAD_L - PAD_R)
+    const toY = (v) => PAD_T + (1 - (v - lo) / (hi - lo)) * (H - PAD_T - PAD_B)
+    const built = computed.map((c) => {
+      const segs = []
+      let cur = []
+      c.series.forEach((v, i) => {
+        if (v == null) {
+          if (cur.length) segs.push(cur)
+          cur = []
+        } else {
+          cur.push(`${toX(i).toFixed(1)},${toY(v).toFixed(1)}`)
+        }
+      })
+      if (cur.length) segs.push(cur)
+      return { ...c, path: segs.map((s) => `M ${s.join(' L ')}`).join(' ') }
+    })
+    const ticks = [hi, (hi + lo) / 2, lo, 0]
+      .filter((v, i, arr) => arr.indexOf(v) === i)
+      .map((v) => ({ y: toY(v), label: v.toFixed(1) }))
+    return { lines: built, yTicks: ticks, zeroY: toY(0) }
+  }, [returns])
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 }}>
+        <div className="label mb-2">Rolling Sharpe Ratio (annualized)</div>
+        <div style={{ display: 'flex', gap: 14 }}>
+          {lines.map((l) => (
+            <span key={l.label} className="caption" style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              <span style={{ width: 14, height: 3, background: l.color, borderRadius: 2, display: 'inline-block' }} />
+              {l.label}
+            </span>
+          ))}
+        </div>
+      </div>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Rolling Sharpe ratio over time" style={{ display: 'block' }}>
+        {yTicks.map((t, i) => (
+          <line key={i} x1={PAD_L} y1={t.y} x2={W - PAD_R} y2={t.y} stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+        ))}
+        {yTicks.map((t, i) => (
+          <text key={`l${i}`} x={PAD_L - 6} y={t.y + 3} textAnchor="end" fill="rgba(255,255,255,0.42)" fontSize="9" className="mono">
+            {t.label}
+          </text>
+        ))}
+        {/* zero reference line */}
+        <line x1={PAD_L} y1={zeroY} x2={W - PAD_R} y2={zeroY} stroke="rgba(255,255,255,0.2)" strokeWidth="1" strokeDasharray="3 3" />
+        {lines.map((l) => (
+          <path key={l.label} d={l.path} fill="none" stroke={l.color} strokeWidth="1.6" strokeLinejoin="round" />
+        ))}
+      </svg>
+      <p className="caption" style={{ marginTop: 8, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Trailing-window Sharpe (mean / std of excess returns, annualized ×√252). A stable line well above
+        0 indicates persistent risk-adjusted edge; a Sharpe that decays toward 0 out-of-sample is a classic
+        overfitting tell — exactly what the DSR/PBO rigor gate is built to catch.
+      </p>
+    </div>
+  )
+}
+
+// ─── Correlation heatmap ────────────────────────────────────
+function CorrelationHeatmap({ assets, series }) {
+  const matrix = useMemo(() => {
+    return assets.map((_, i) => assets.map((__, j) => correlation(series[i], series[j])))
+  }, [assets, series])
+
+  // diverging color: +1 accent-purple, 0 neutral, -1 blue
+  function cellColor(v) {
+    if (v >= 0) {
+      return `rgba(192,132,252,${(0.12 + 0.7 * v).toFixed(3)})`
+    }
+    return `rgba(96,165,250,${(0.12 + 0.7 * -v).toFixed(3)})`
+  }
+
+  return (
+    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+      <div className="label mb-3">Correlation Matrix (daily returns, ρ)</div>
+      <div className="risk-heatmap" style={{ gridTemplateColumns: `auto repeat(${assets.length}, 1fr)` }}>
+        <div className="risk-heatmap-corner" />
+        {assets.map((a) => (
+          <div key={`h${a}`} className="risk-heatmap-head mono">
+            {a}
+          </div>
+        ))}
+        {assets.map((rowA, i) => (
+          <div key={`row${rowA}`} style={{ display: 'contents' }}>
+            <div className="risk-heatmap-head mono" style={{ textAlign: 'right', paddingRight: 8 }}>
+              {rowA}
+            </div>
+            {assets.map((colA, j) => {
+              const v = matrix[i][j]
+              return (
+                <div
+                  key={`${rowA}-${colA}`}
+                  className="risk-heatmap-cell mono"
+                  style={{ background: cellColor(v) }}
+                  title={`ρ(${rowA}, ${colA}) = ${v.toFixed(2)}`}
+                >
+                  {v.toFixed(2)}
+                </div>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+      <p className="caption" style={{ marginTop: 10, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Pairwise Pearson correlation. Diversification benefit comes from low or negative ρ — a portfolio of
+        highly-correlated (ρ near +1, purple) sleeves carries hidden concentration risk that VaR alone can
+        understate.
+      </p>
+    </div>
+  )
+}
+
+export default function RiskAnalysis({ returns: returnsProp, assets: assetsProp, series: seriesProp } = {}) {
+  const data = useMemo(() => {
+    const d = buildDefaultData()
+    return {
+      returns: returnsProp ?? d.returns,
+      assets: assetsProp ?? d.assets,
+      series: seriesProp ?? d.series,
+    }
+  }, [returnsProp, assetsProp, seriesProp])
+
+  return (
+    <div>
+      <div style={{ maxWidth: 680, marginBottom: 28 }}>
+        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 10 }}>
+          Risk Analysis
+        </h2>
+        <p className="body">
+          Tail-risk, drawdown, and correlation diagnostics for the active portfolio. These are the
+          loss-side counterparts to the return-side metrics on the Advisor — rigor means making the
+          downside as legible as the upside.
+        </p>
+      </div>
+
+      <VaRPanel returns={data.returns} />
+      <DrawdownPlot returns={data.returns} />
+      <RollingSharpePlot returns={data.returns} />
+      <CorrelationHeatmap assets={data.assets} series={data.series} />
+    </div>
+  )
+}

--- a/ui/src/components/RiskAnalysis.jsx
+++ b/ui/src/components/RiskAnalysis.jsx
@@ -24,9 +24,12 @@ import './RiskAnalysis.css'
 function fmtPct(v, d = 2) {
   return v != null && Number.isFinite(v) ? `${(v * 100).toFixed(d)}%` : '—'
 }
-function fmt(v, d = 2) {
-  return v != null && Number.isFinite(v) ? v.toFixed(d) : '—'
-}
+
+const SHARPE_WINDOWS = [
+  { w: 30, color: 'var(--accent)', label: '30d' },
+  { w: 60, color: '#60a5fa', label: '60d' },
+  { w: 90, color: 'var(--positive)', label: '90d' },
+]
 
 // ─── default mock data ──────────────────────────────────────
 function buildDefaultData() {
@@ -157,14 +160,8 @@ function RollingSharpePlot({ returns }) {
   const PAD_T = 12
   const PAD_B = 22
 
-  const windows = [
-    { w: 30, color: 'var(--accent)', label: '30d' },
-    { w: 60, color: '#60a5fa', label: '60d' },
-    { w: 90, color: 'var(--positive)', label: '90d' },
-  ]
-
   const { lines, yTicks, zeroY } = useMemo(() => {
-    const computed = windows.map((cfg) => ({ ...cfg, series: rollingSharpe(returns, cfg.w) }))
+    const computed = SHARPE_WINDOWS.map((cfg) => ({ ...cfg, series: rollingSharpe(returns, cfg.w) }))
     const all = computed.flatMap((c) => c.series.filter((v) => v != null))
     const lo = Math.min(-1, ...all)
     const hi = Math.max(1, ...all)

--- a/ui/src/utils/riskMath.js
+++ b/ui/src/utils/riskMath.js
@@ -1,0 +1,210 @@
+/**
+ * riskMath.js — pure, dependency-free quant helpers for the risk + backtest
+ * visualization components (RiskAnalysis, BacktestVisualizer, PortfolioAdvisorPanels).
+ *
+ * Everything here is intentionally small and standalone so the components can
+ * render with mock data offline and so the math is unit-testable without React.
+ * All functions guard against empty / degenerate input and return finite-safe
+ * values (never NaN/Infinity leaking to the page — see fmt helpers in the
+ * components).
+ */
+
+const TRADING_DAYS = 252
+
+/**
+ * Historical Value-at-Risk at a confidence `level` (e.g. 0.95).
+ * Returns a POSITIVE magnitude of the loss (e.g. 0.031 == "you can lose 3.1%").
+ * Uses the empirical quantile of the loss distribution (-returns).
+ * @param {number[]} returns — periodic simple returns (e.g. daily)
+ * @param {number} level — confidence level in (0,1), default 0.95
+ * @returns {number} VaR as a positive fraction; 0 for empty input
+ */
+export function computeHistoricalVaR(returns, level = 0.95) {
+  if (!returns || returns.length === 0) return 0
+  const losses = returns.map((r) => -r).sort((a, b) => a - b)
+  // Index of the (level) quantile of the loss distribution.
+  const idx = Math.min(losses.length - 1, Math.max(0, Math.floor(level * (losses.length - 1))))
+  return Math.max(0, losses[idx])
+}
+
+/**
+ * Conditional VaR (a.k.a. Expected Shortfall): the mean loss in the tail beyond
+ * the VaR threshold. Always >= the VaR at the same level.
+ * @param {number[]} returns — periodic simple returns
+ * @param {number} level — confidence level in (0,1), default 0.95
+ * @returns {number} CVaR as a positive fraction; 0 for empty input
+ */
+export function computeCVaR(returns, level = 0.95) {
+  if (!returns || returns.length === 0) return 0
+  const losses = returns.map((r) => -r).sort((a, b) => a - b)
+  const cutoff = Math.floor(level * (losses.length - 1))
+  const tail = losses.slice(cutoff)
+  if (tail.length === 0) return Math.max(0, losses[losses.length - 1])
+  const mean = tail.reduce((s, v) => s + v, 0) / tail.length
+  return Math.max(0, mean)
+}
+
+/**
+ * Annualized Sharpe ratio over a window of periodic returns.
+ * @param {number[]} window — periodic returns
+ * @param {number} rf — periodic risk-free rate (default 0)
+ * @param {number} periodsPerYear — annualization factor (default 252)
+ * @returns {number} annualized Sharpe; 0 if std is ~0 or input too short
+ */
+export function annualizedSharpe(window, rf = 0, periodsPerYear = TRADING_DAYS) {
+  if (!window || window.length < 2) return 0
+  const excess = window.map((r) => r - rf)
+  const mean = excess.reduce((s, v) => s + v, 0) / excess.length
+  const variance = excess.reduce((s, v) => s + (v - mean) ** 2, 0) / (excess.length - 1)
+  const std = Math.sqrt(variance)
+  if (std < 1e-12) return 0
+  return (mean / std) * Math.sqrt(periodsPerYear)
+}
+
+/**
+ * Rolling annualized Sharpe over a trailing window. Returns one value per
+ * position once enough data exists (null before the window fills, so charts
+ * can skip the warm-up region).
+ * @param {number[]} returns — periodic returns
+ * @param {number} window — lookback length in periods (e.g. 30)
+ * @param {number} rf — periodic risk-free rate (default 0)
+ * @returns {(number|null)[]} array aligned to `returns`
+ */
+export function rollingSharpe(returns, window = 30, rf = 0) {
+  if (!returns || returns.length === 0) return []
+  const out = []
+  for (let i = 0; i < returns.length; i++) {
+    if (i + 1 < window) {
+      out.push(null)
+      continue
+    }
+    const slice = returns.slice(i + 1 - window, i + 1)
+    out.push(annualizedSharpe(slice, rf))
+  }
+  return out
+}
+
+/**
+ * Drawdown series from an equity curve: at each point, the fractional decline
+ * from the running peak (<= 0). 0 means a fresh high-water mark.
+ * @param {number[]} equity — cumulative portfolio value series
+ * @returns {number[]} drawdown fractions (<= 0)
+ */
+export function drawdownSeries(equity) {
+  if (!equity || equity.length === 0) return []
+  let peak = equity[0]
+  return equity.map((v) => {
+    if (v > peak) peak = v
+    return peak > 0 ? v / peak - 1 : 0
+  })
+}
+
+/**
+ * Maximum drawdown magnitude (positive fraction) from an equity curve.
+ * @param {number[]} equity
+ * @returns {number} max drawdown as a positive fraction
+ */
+export function maxDrawdown(equity) {
+  const dd = drawdownSeries(equity)
+  return dd.length ? -Math.min(...dd) : 0
+}
+
+/**
+ * Build an equity curve from periodic returns, starting at `start`.
+ * @param {number[]} returns
+ * @param {number} start — initial value (default 1)
+ * @returns {number[]} equity curve of length returns.length + 1
+ */
+export function equityFromReturns(returns, start = 1) {
+  const out = [start]
+  let v = start
+  for (const r of returns || []) {
+    v *= 1 + r
+    out.push(v)
+  }
+  return out
+}
+
+/**
+ * Kelly fraction for a binary bet: f* = (b·p − q) / b, where q = 1 − p.
+ * `b` is the net odds (payoff per unit staked, e.g. 1.5 means win 1.5x).
+ * Clamped to [0,1] — never recommends leverage or a negative bet.
+ * @param {number} p — win probability in [0,1]
+ * @param {number} b — net payoff multiple (> 0)
+ * @returns {number} optimal fraction of bankroll in [0,1]
+ */
+export function kellyFraction(p, b) {
+  if (!Number.isFinite(p) || !Number.isFinite(b) || b <= 0) return 0
+  const q = 1 - p
+  const f = (b * p - q) / b
+  if (!Number.isFinite(f)) return 0
+  return Math.min(1, Math.max(0, f))
+}
+
+/**
+ * Pearson correlation between two equal-length series. Returns 0 for
+ * degenerate input.
+ */
+export function correlation(a, b) {
+  if (!a || !b || a.length !== b.length || a.length < 2) return 0
+  const n = a.length
+  const ma = a.reduce((s, v) => s + v, 0) / n
+  const mb = b.reduce((s, v) => s + v, 0) / n
+  let cov = 0
+  let va = 0
+  let vb = 0
+  for (let i = 0; i < n; i++) {
+    const da = a[i] - ma
+    const db = b[i] - mb
+    cov += da * db
+    va += da * da
+    vb += db * db
+  }
+  const denom = Math.sqrt(va * vb)
+  if (denom < 1e-12) return 0
+  return cov / denom
+}
+
+/**
+ * Deterministic pseudo-random generator (mulberry32) so mock series are
+ * stable across renders — avoids flicker and makes screenshots reproducible.
+ * @param {number} seed
+ * @returns {() => number} a () => number in [0,1)
+ */
+export function seededRng(seed = 42) {
+  let a = seed >>> 0
+  return function () {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * Box-Muller standard-normal draw from a uniform RNG.
+ * @param {() => number} rng
+ * @returns {number} ~ N(0,1)
+ */
+export function gaussian(rng) {
+  const u = Math.max(1e-12, rng())
+  const v = rng()
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v)
+}
+
+/**
+ * Generate a mock daily-return series with a small positive drift and fat-ish
+ * tails — good enough to make the risk charts look realistic offline.
+ * @param {number} n — number of returns
+ * @param {object} opts — { drift, vol, seed }
+ * @returns {number[]}
+ */
+export function mockReturns(n = 252, { drift = 0.0004, vol = 0.011, seed = 7 } = {}) {
+  const rng = seededRng(seed)
+  const out = []
+  for (let i = 0; i < n; i++) {
+    out.push(drift + vol * gaussian(rng))
+  }
+  return out
+}


### PR DESCRIPTION
Adds RiskAnalysis, PortfolioAdvisorPanels, BacktestVisualizer + riskMath.js (inline SVG, no new deps, mock defaults). Components only — wiring is in onder/frontend-quant-viz-wiring. Run 'cd ui && npm ci && npm run build && npm run lint' before merge (not lintable in authoring env).