### PR TITLE
[docs] Add docs/quant methodology and admission criteria

### DIFF
--- a/docs/quant/README.md
+++ b/docs/quant/README.md
@@ -1,0 +1,23 @@
+# Quantitative Methodology Docs
+
+> The math layer of Archimedes, written for teammates, judges, and anyone reading a
+> strategy passport. Author: Önder Akkaya (quant / math lane). Written 2026-06-12.
+
+These four docs explain the statistics and portfolio math behind the
+rigor-as-the-wedge story. They are the conceptual companions to the canonical
+operational spec [`../specs/selection-bias-corrections-spec.md`](../specs/selection-bias-corrections-spec.md)
+and the judge-facing summary [`../rigor-methods.md`](../rigor-methods.md); where
+thresholds or formulas overlap, the spec and the code
+([`../../backend/archimedes/services/rigor_evaluator.py`](../../backend/archimedes/services/rigor_evaluator.py),
+[`../../backend/archimedes/services/portfolio_optimizer.py`](../../backend/archimedes/services/portfolio_optimizer.py))
+are authoritative.
+
+| Doc | What it covers |
+|---|---|
+| [`methodology.md`](methodology.md) | The full quantitative methodology — selection-bias corrections (DSR, PBO/CSCV, walk-forward OOS, look-ahead, FDR vs FWER, circular block bootstrap) and portfolio construction (MVO, GMV, Max-Sharpe, Kelly, HRP, Black–Litterman, Ledoit–Wolf shrinkage). |
+| [`backtest-interpretation.md`](backtest-interpretation.md) | How to read a backtest adversarially — the red flags (IS/OOS cliff, parameter sensitivity, smooth curves, concentration, regime turnover, correlation clustering) and green lights, each mapped to the detector in our codebase. |
+| [`admission-criteria.md`](admission-criteria.md) | The four-gate Tier-1 admission contract, the CANDIDATE → VALIDATED flow, principled exceptions, and post-admission monitoring. |
+| [`strategy-library.md`](strategy-library.md) | A per-strategy reference for the 25 files in `analytics-engine/strategies/`, grouped by sleeve, with the honest paper-vs-v1 adaptation caveats. |
+
+**Read in this order** if you are new: `methodology.md` → `backtest-interpretation.md`
+→ `admission-criteria.md` → `strategy-library.md`.

--- a/docs/quant/admission-criteria.md
+++ b/docs/quant/admission-criteria.md
@@ -1,0 +1,247 @@
+# Tier-1 Strategy Admission
+
+> **Status:** Living reference. Written 2026-06-12.
+> **Author:** Önder Akkaya (quant / math lane).
+> **Audience:** Anyone deciding whether a strategy belongs in the
+> Archimedes-Verified (Tier 1) library, and anyone auditing why a given strategy
+> passed or failed.
+> **Canonical sources this doc must stay consistent with:**
+> [`../specs/selection-bias-corrections-spec.md`](../specs/selection-bias-corrections-spec.md)
+> (the frozen control contract) and the live implementation
+> [`../../backend/archimedes/services/rigor_evaluator.py`](../../backend/archimedes/services/rigor_evaluator.py)
+> (`RigorGateResult.passes_all`). Where this doc and those drift, **the spec and the
+> code win** — the thresholds below are transcribed from `passes_all`, not invented.
+
+Tier 1 ("Archimedes Verified 🏆") strategies get full agent autonomy and are
+eligible for live vault deployment. The bar to enter is the **four-primitive
+admission gate**. This doc states each control's threshold, the promotion flow, the
+principled exceptions, and what monitoring continues *after* admission.
+
+---
+
+## The four controls and their thresholds
+
+A strategy is admitted only when **all four** controls pass simultaneously. These
+are exactly the conditions checked in `RigorGateResult.passes_all`:
+
+| # | Control | Function | Threshold (the literal gate) |
+|---|---|---|---|
+| 1 | Deflated Sharpe Ratio | `compute_dsr` | `dsr_p_value ≥ 0.95` (and not `None`) |
+| 2 | Probability of Backtest Overfitting | `compute_pbo` | `pbo_score < 0.5` (and not `None`) |
+| 3a | Walk-forward OOS Sharpe — absolute floor | `compute_oos_sharpe` | `oos_sharpe > 0` (and not `None`) |
+| 3b | Walk-forward OOS Sharpe — the cliff | `compute_oos_sharpe` | `oos_sharpe / in_sample_sharpe ≥ 0.5` |
+| 3c | CPCV path stability (when computed) | `compute_cpcv_oos_sharpe` | `cpcv_positive_fraction ≥ 0.5` |
+| 4 | Look-ahead static audit | `look_ahead_audit` | `look_ahead_passed == True` |
+
+Notes on each threshold, with the *why* behind the number:
+
+### 1. DSR p-value ≥ 0.95
+
+The Deflated Sharpe Ratio (Bailey & López de Prado 2014) returns a probability that
+the true Sharpe is positive *after* deflating for multiple testing and
+non-normality. The `0.95` bar is the conventional 95%-confidence threshold:
+admission requires 95% confidence that the Sharpe is not a selection-and-luck
+artifact. When `num_trials = 1` no deflation is applied (there was no selection);
+the orchestrator passes `N = len(strategy_library)` so the correction is real, and
+the effective-N correction (`average_correlation`) prevents a correlated parameter
+sweep from being over-penalized as `N` independent tests. See
+[`methodology.md`](methodology.md) §1 for the full formula.
+
+### 2. PBO < 0.5
+
+The Probability of Backtest Overfitting (Bailey, Borwein, López de Prado & Zhu
+2014) is the CSCV-estimated fraction of IS/OOS splits in which the in-sample winner
+underperforms the OOS median. **`PBO ≥ 0.5` means the in-sample-optimal strategy is
+expected to underperform the median strategy out-of-sample** — the strategy (more
+precisely, the *library's selection procedure*) fails the gate. This matches the
+spec exactly: "A `pbo_score >= 0.5` means the in-sample-optimal strategy is expected
+to underperform the median strategy out-of-sample — the strategy fails the rigor
+gate." PBO is library-level: one value per analytics-engine run, recomputed when the
+library changes.
+
+### 3. Walk-forward OOS Sharpe — floor + cliff
+
+Two sub-checks. The **absolute floor** (`oos_sharpe > 0`) means a negative
+out-of-sample Sharpe can never pass, no matter how strong the in-sample result. The
+**cliff check** (`oos_sharpe / in_sample_sharpe ≥ 0.5`) requires the out-of-sample
+edge to retain at least half the in-sample edge — equivalently, **the OOS-to-IS
+Sharpe degradation must be no worse than ~50%**. This is consistent with the
+Bailey–López de Prado finding that overfit strategies cliff hard out-of-sample; a
+≥50%-retained edge is the line between "degraded but real" and "memorized." The IS
+Sharpe is computed on the first-70% slice only (see `run_rigor_gate`), so the ratio
+cannot be inflated by leaking OOS data into the denominator. When a real
+combinatorial OOS matrix is available, the CPCV path-stability check
+(`cpcv_positive_fraction ≥ 0.5`) is an additional requirement; until then it is
+honestly reported as `MISSING` and does not silently pass.
+
+### 4. Look-ahead audit PASS
+
+The static AST audit (`look_ahead_audit`) must return `passed = True` (zero
+warnings). Any flagged forward-data access — negative pandas shift, positive feed
+index, forecast-named call, or an ambiguous negative subscript — blocks admission
+until a reviewer resolves it. A strategy that cannot be parsed also fails (a
+`SyntaxError` returns `passed = False`).
+
+> **Cross-reference to `rigor-methods.md`.** The judge-facing summary in
+> [`../rigor-methods.md`](../rigor-methods.md) lists a fourth row "Total trades in
+> backtest ≥ 10 (avoid sparse-trade illusions)." That is an *analytics-engine
+> data-sufficiency* precondition applied upstream of the four statistical gates
+> here — a strategy with too few trades cannot produce a meaningful return series in
+> the first place. The four controls above are the statistical gate enforced in
+> `RigorGateResult.passes_all`; the trade-count minimum is the data-quality
+> prerequisite that must hold before those controls are even computed.
+
+---
+
+## The CANDIDATE → VALIDATED promotion flow
+
+Every strategy carries a status. Promotion is gated; demotion is automatic on
+re-evaluation failure.
+
+```
+                 generate / ingest
+                        │
+                        ▼
+                  ┌───────────┐
+                  │ CANDIDATE │   ← admitted to the library, NOT yet trusted
+                  └─────┬─────┘      for live deployment or full agent autonomy
+                        │
+          run_rigor_gate(strategy_id, daily_returns,
+            num_trials=len(library), pbo_scores=…,
+            strategy_code=…, average_correlation=…)
+                        │
+            ┌───────────┴────────────┐
+            │  RigorGateResult         │
+            │  .passes_all == True?    │
+            └───────────┬────────────┘
+                 yes ▼          ▼ no
+            ┌───────────┐   stays CANDIDATE
+            │ VALIDATED │   (gate_details shows exactly which
+            └───────────┘    control failed: FAIL / MISSING)
+```
+
+Mechanics:
+
+1. **A strategy enters as `CANDIDATE`.** It is in the library, its numbers are
+   visible on its passport, but it is *not* eligible for live deployment or full
+   agent autonomy.
+2. **The gate runs via `run_rigor_gate(...)`**, which orchestrates all four controls
+   and returns a `RigorGateResult`. The caller passes
+   `num_trials = len(strategy_library)`, the pre-computed library-level
+   `pbo_scores`, the strategy source for the look-ahead audit, and the library's
+   `average_correlation` for the DSR effective-N correction.
+3. **Promotion to `VALIDATED` requires `passes_all == True`.** Every gate must pass.
+   If any returns `None` (insufficient/degenerate data) or fails its threshold, the
+   strategy stays `CANDIDATE`.
+4. **Transparency, not a black box.** `RigorGateResult.gate_details` renders each
+   control as `PASS (p=0.97)` / `FAIL (PBO=0.61, need < 0.5)` / `MISSING`. The UI
+   shows this for *candidates and validated strategies alike* — a failing strategy
+   shows exactly which gate it tripped. This is the design intent: rigor as
+   transparency, not as a hidden score. Paper-claim deltas are surfaced alongside,
+   never collapsed into an aggregate.
+5. **Re-evaluation can demote.** Because PBO is library-level, adding or removing a
+   strategy can change every member's PBO; a re-run that pushes a previously-passing
+   strategy's PBO `≥ 0.5` (or any other gate below threshold) returns it to
+   `CANDIDATE`. Validation is a *standing* property, not a one-time stamp.
+
+Today **2 of the library's strategies pass all four gates** (Faber 2007 SMA200
+timing and Moreira–Muir 2017 volatility-managed), per
+[`../rigor-methods.md`](../rigor-methods.md). The rest remain honest CANDIDATEs with
+their failing gate shown openly.
+
+---
+
+## Principled exceptions
+
+The gate is a hard filter by default. But two situations warrant a *documented,
+reviewer-approved* exception — never a silent threshold weakening (weakening
+thresholds is an explicit anti-goal).
+
+### A. Diversification benefit vs. a marginally lower DSR
+
+A strategy that *just* misses the `0.95` DSR bar but is **genuinely
+decorrelated** from the rest of the validated set can be more valuable to the
+portfolio than a higher-DSR strategy that duplicates an existing bet. The portfolio
+math is the justification: adding a low-correlation sleeve lowers portfolio variance
+(its marginal contribution to variance, `kelly_risk_decomposition`, is small) and
+raises the diversification ratio, even at a modestly lower standalone Sharpe.
+
+This ties directly to the **fusion-quality** concept: the library is judged not as a
+bag of independent strategies but as a *constructable portfolio*. A candidate's value
+includes its incremental diversification, measurable via
+`compute_average_pairwise_correlation(...)` against the validated set. When a
+reviewer grants this exception, two things are mandatory: (1) the decorrelation must
+be *real and measured* (low `ρ̄` against the validated set, not asserted), and (2)
+the exception is recorded on the passport so the lower DSR and the diversification
+rationale are both visible. The DSR's own effective-N machinery already encodes part
+of this logic — correlated trials are penalized harder, decorrelated ones less.
+
+> An exception is a documented portfolio-construction decision, not a relaxation of
+> the statistic. The DSR number shown does not change; what changes is the *admission
+> decision*, with the reason attached.
+
+### B. CPCV / data-sufficiency `MISSING` on a short but sound series
+
+When a strategy's series is too short to form a combinatorial OOS matrix, the CPCV
+check reports `MISSING` rather than failing. The four core controls (DSR, PBO,
+single-holdout OOS, look-ahead) can still all pass. Promotion is permissible on the
+core four, with the `MISSING` CPCV explicitly noted — and the strategy is flagged for
+CPCV re-evaluation once more history accrues. This is *not* a weakened threshold; it
+is honest reporting of an uncomputable check, with a follow-up obligation.
+
+Both exceptions share a rule: **the number is never altered, the decision is
+documented, and the caveat is visible on the passport.**
+
+---
+
+## Post-admission monitoring
+
+Admission is the beginning of trust, not the end. A VALIDATED strategy is monitored
+on three axes:
+
+### 1. Live-vs-backtest tracking
+
+The whole point of the OOS gate is to predict live behavior; we then *check that
+prediction*. Live realized returns are compared against the backtest's expected
+distribution. The natural tolerance is the Sharpe confidence band from
+`compute_sharpe_ci(...)` (Lo 2002): if live Sharpe drifts persistently outside the
+backtest's CI, the edge is decaying — consistent with McLean & Pontiff (2016)'s
+finding that published predictors lose ~26% of their return out-of-sample and ~58%
+post-publication. A strategy whose live performance falls materially below its
+backtest band is a re-evaluation (and possible demotion) trigger.
+
+### 2. Regime drift
+
+Each strategy carries a `REGIME_TAG` (`bull` / `bear` / `regime_neutral`). A
+strategy validated largely in one regime is at risk when the regime changes. The
+**regime-conditional γ multiplier** (`REGIME_GAMMA_MULTIPLIER`, Ang & Bekaert 2002)
+is the live defense: in `risk_off`/`crisis` the optimizer's effective risk aversion
+rises (2×/4×), pulling allocations toward minimum-variance so a single-regime
+strategy is not sized as if its favorable regime will persist. Monitoring watches for
+the regime detector flipping and for the strategy's live Sharpe degrading
+specifically when its tagged regime ends.
+
+### 3. Library re-coupling (PBO recompute)
+
+Because PBO is library-level, the validated set must be re-evaluated whenever the
+library changes. Adding a new strategy that is highly correlated with the existing
+set can raise PBO across the board (and lower the DSR effective-N benefit); removing
+a strategy can change every neighbor's verdict. The discipline: **recompute
+`compute_pbo(...)` and `compute_average_pairwise_correlation(...)` on every library
+mutation**, and re-run `run_rigor_gate(...)` for affected members. A strategy that
+no longer passes returns to `CANDIDATE` automatically.
+
+---
+
+## Summary
+
+- Admission = all four controls pass in `RigorGateResult.passes_all`:
+  DSR `p ≥ 0.95`, PBO `< 0.5`, OOS Sharpe `> 0` and OOS/IS `≥ 0.5`
+  (plus CPCV `positive_fraction ≥ 0.5` when computable), look-ahead `PASS`.
+- Promotion is `CANDIDATE → VALIDATED`; failures stay `CANDIDATE` with the failing
+  gate shown openly; re-evaluation can demote.
+- Exceptions are documented portfolio-construction decisions (genuine
+  diversification benefit; `MISSING` uncomputable checks) — never silent threshold
+  weakening.
+- Monitoring continues post-admission: live-vs-backtest tracking against the Sharpe
+  CI, regime drift, and PBO recompute on every library change.

--- a/docs/quant/backtest-interpretation.md
+++ b/docs/quant/backtest-interpretation.md
@@ -1,0 +1,233 @@
+# How to Read a Backtest
+
+> **Status:** Living reference. Written 2026-06-12.
+> **Author:** Önder Akkaya (quant / math lane).
+> **Audience:** Anyone reading a strategy passport who wants to know whether a
+> backtest is *trustworthy*, not just whether the line goes up.
+> **Companions:** [`methodology.md`](methodology.md) (the statistics in depth),
+> [`admission-criteria.md`](admission-criteria.md) (the gate thresholds),
+> [`../rigor-methods.md`](../rigor-methods.md) (the plain-English gate story).
+
+A backtest is a *claim about the future stated in the language of the past*. The
+single most important skill in quantitative finance is reading a backtest
+**adversarially** — assuming it is overfit until it proves otherwise. This doc is a
+field guide: the red flags that say "do not trust this," the green lights that say
+"this might be real," and, for each, the metric or tool in our codebase that
+detects it. Every detector named below is a real function in
+[`../../backend/archimedes/services/rigor_evaluator.py`](../../backend/archimedes/services/rigor_evaluator.py)
+or [`../../backend/archimedes/services/portfolio_optimizer.py`](../../backend/archimedes/services/portfolio_optimizer.py).
+
+---
+
+## The mindset: a backtest is a hypothesis, not a result
+
+When you see a Sharpe of 2.0 on ten years of history, the correct first question is
+**not** "how much money would that have made?" It is: *"How many strategies were
+tried before this one was kept, and would it survive on data it has never seen?"*
+A backtest earns trust by surviving attempts to break it — out-of-sample tests,
+multiple-testing deflation, cost realism, and a check against economic logic. The
+rest of this document is those attempts, organized as red flags and green lights.
+
+---
+
+## Red flags — reasons to distrust a backtest
+
+### 1. The IS/OOS Sharpe gap (the cliff)
+
+**The tell.** The strategy looks great in-sample and falls apart out-of-sample. If
+a Sharpe of 1.8 in-sample collapses to 0.3 out-of-sample, the "edge" was a property
+of the training data, not the market.
+
+**What detects it.** `compute_oos_sharpe(daily_returns, train_fraction=0.70)`
+computes the held-out final-30% Sharpe, and the gate enforces the **cliff check**
+`OOS_Sharpe / IS_Sharpe ≥ 0.5` (with the IS Sharpe measured on the *first 70% only*
+inside `run_rigor_gate`, so the ratio cannot be gamed by blending the slices).
+`RigorGateResult.gate_details["oos_sharpe"]` renders the exact ratio as
+`PASS (OOS/IS=0.71)` or `FAIL (OOS/IS=0.22, need ≥ 0.50)`. A ratio near or below
+zero means the edge evaporated the moment the model stopped seeing the answers.
+
+> **Deeper detector.** The single 70/30 hold-out can still let a lookback window
+> straddle the split. `compute_cpcv_oos_sharpe(...)` runs Combinatorial Purged
+> Cross-Validation over many paths and the gate requires
+> `cpcv_positive_fraction ≥ 0.5` — the edge must hold OOS across a *majority* of
+> held-out paths, not just one tail. It is honestly reported as `MISSING` until the
+> analytics-engine supplies a real combinatorial OOS matrix.
+
+### 2. Parameter sensitivity
+
+**The tell.** Move the lookback from 200 days to 190 or 210 and the Sharpe halves.
+A genuine signal is a *plateau* in parameter space; an overfit one is a needle.
+Sensitive parameters mean the backtest found a coincidence, not a structure.
+
+**What detects it.** This is the question **Probability of Backtest Overfitting**
+answers at the library level. `compute_pbo(returns_matrix)` runs CSCV across
+`C(16,8) = 12,870` symmetric IS/OOS splits and asks how often the in-sample winner
+survives out-of-sample. **`PBO ≥ 0.5`** means the selection procedure systematically
+picks strategies that underperform the OOS median — the hallmark of fitting noise.
+At the single-strategy level, the **Deflated Sharpe Ratio** (`compute_dsr`) deflates
+the Sharpe by the expected best-of-`N` trials, so a Sharpe that only looks good
+because many variants were tried gets pushed below the `p ≥ 0.95` bar.
+
+### 3. The unrealistically smooth equity curve / no slippage
+
+**The tell.** A curve that climbs in a near-straight line with no drawdowns is a
+warning, not a triumph. Either it ignored transaction costs and slippage, or it is
+trading on look-ahead information. Real strategies have *jagged* equity curves and
+real drawdowns.
+
+**What detects it.** Two checks. First, the **look-ahead static audit**
+(`look_ahead_audit(strategy_code)`) parses the strategy source and flags
+forward-data access — negative pandas shifts (`shift(-1)`), positive feed indexing
+(`data[+N]`), and forecast-named calls — any of which can manufacture an
+implausibly smooth curve. Second, the analytics-engine's broker-level check rejects
+`coc`/`coo` (close-on-close / close-on-open) configurations that leak the bar's own
+close into its decision. On the cost side, a strategy whose Sharpe survives only at
+zero cost should be read against the realistic-cost requirement in the green-lights
+section. The closed-form `expected_max_drawdown_1y(μ, σ)` gives the *expected* worst
+drawdown for a given μ/σ — an equity curve with materially smaller realized
+drawdowns than that is suspicious.
+
+### 4. Concentration risk
+
+**The tell.** The whole return comes from one asset, one position, or one lucky
+year. The "diversified" portfolio is diversified in name only — a single name
+drives the variance.
+
+**What detects it.** `kelly_risk_decomposition(...)` computes each asset's
+**marginal contribution to portfolio variance** via the Euler decomposition
+`MCᵢ = wᵢ·(Σw)ᵢ / σ²ₚ` (sums to 1), surfacing lines like "NVDA contributes 61% of
+portfolio variance." The optimizer itself defends against this with **per-asset
+weight caps** (`_CAP_DEFAULT = 0.40`, `_CAP_HYPER = 0.60` in `portfolio_optimizer.py`)
+so no single synth can dominate, and `correlation_pairs(...)` surfaces the
+highest-magnitude pairwise correlations so apparent diversification across
+correlated names is visible.
+
+### 5. Regime-selection turnover
+
+**The tell.** The strategy only "works" because it happened to be long through one
+bull regime, or it flips positions so often that the backtest is really a bet on a
+specific historical sequence of regimes. High turnover that aligns suspiciously well
+with past regime boundaries is curve-fitting to history's particular path.
+
+**What detects it.** Two surfaces. The strategy library tags each strategy with a
+`REGIME_TAG` (`bull` / `bear` / `regime_neutral`) so a strategy that only earns its
+Sharpe in one regime is labeled as such (see [`strategy-library.md`](strategy-library.md)).
+And the **regime-conditional γ multiplier** (`REGIME_GAMMA_MULTIPLIER` in
+`portfolio_optimizer.py`, grounded in Ang & Bekaert 2002) is precisely the mechanism
+that prevents a single-regime strategy from being sized as if its regime will
+persist: in `risk_off`/`crisis` the optimizer's effective risk aversion rises (2×/4×),
+pulling toward minimum-variance rather than chasing a regime-specific edge.
+
+### 6. Correlation clustering
+
+**The tell.** The library's strategies all secretly bet on the same thing. Five
+"different" strategies that are 0.9-correlated are one strategy with five names —
+and the apparent diversification (and apparent multiple-testing breadth) is an
+illusion.
+
+**What detects it.** `compute_average_pairwise_correlation(...)` computes the mean
+off-diagonal correlation across a set of return series, and it feeds the DSR's
+**effective-N** correction (`N_eff = N / (1 + (N−1)·ρ̄)`): if the "trials" are
+highly correlated, the deflation correctly counts them as *fewer independent tests*.
+On the construction side, `correlation_pairs(...)` lists the top correlation pairs,
+and the Ledoit–Wolf shrinkage (`ledoit_wolf_shrinkage(...)`) keeps a
+near-singular correlation matrix from blowing up the optimizer.
+
+---
+
+## Green lights — reasons to trust a backtest
+
+### 1. Consistent rolling Sharpe
+
+**The tell of quality.** The Sharpe is roughly stable across rolling windows and
+across regimes, not concentrated in one lucky stretch. The strategy earns its return
+*repeatedly*, not once.
+
+**What supports it.** The CPCV path stability check
+(`compute_cpcv_oos_sharpe → positive_fraction`) measures exactly this: the fraction
+of out-of-sample paths on which the edge is positive. A `cpcv_positive_fraction`
+well above the 0.5 gate floor is the multi-path version of "consistent across
+windows." `compute_sharpe_ci(...)` (Lo 2002) gives the Sharpe's confidence band, so
+"consistent" can be read against the estimate's actual error bars.
+
+### 2. Low parameter sensitivity
+
+**The tell of quality.** Small changes to lookbacks/thresholds barely move the
+result — the strategy sits on a *plateau*, not a needle. This is the direct opposite
+of red-flag #2.
+
+**What supports it.** A low PBO from `compute_pbo(...)` is the formal version: if the
+strategy keeps winning across `C(16,8)` different IS/OOS partitions, it is not
+sensitive to which slice of history it was tuned on. A high DSR p-value
+(`compute_dsr → dsr_p_value ≥ 0.95`) confirms the Sharpe survives multiple-testing
+deflation.
+
+### 3. Realistic transaction costs
+
+**The tell of quality.** The Sharpe is reported *after* commissions and slippage,
+and the strategy still clears the bar. Costs hit high-turnover strategies hardest,
+so a strategy that survives realistic costs is reporting a real, capturable edge —
+not a paper one.
+
+**What supports it.** The walk-forward OOS Sharpe (`compute_oos_sharpe`) and the
+gate's **absolute floor** (`oos_sharpe > 0`) are computed on the *net* return series
+the analytics-engine produces. The honest framing is reinforced by the
+paper-claim delta: where the live, cost-aware adaptation underperforms the paper's
+gross claim, the passport shows the gap rather than hiding it.
+
+### 4. Documented economic intuition
+
+**The tell of quality.** There is a *reason* the edge should exist — a behavioral
+bias, a risk premium, a structural friction — stated before the backtest, not
+reverse-engineered after. A strategy with a strong backtest and no economic story is
+more likely a data-mining artifact than one with a weak backtest and a sound thesis.
+
+**What supports it.** Every library strategy file carries a methodology docstring
+that states the anomaly and its economic mechanism (momentum as
+under-reaction/herding; pairs as relative-value mean reversion; volatility
+management as the negative vol-risk-premium tilt). The strategy passport renders this
+alongside the numbers — and where the live implementation is a *proxy* for the
+paper's design, the file's header discloses the divergence (see the v1 adaptation
+caveats in [`strategy-library.md`](strategy-library.md)).
+
+### 5. Peer-reviewed backing
+
+**The tell of quality.** The strategy traces to a published, citable paper — ideally
+one whose results have themselves survived replication and post-publication scrutiny.
+
+**What supports it.** Each strategy file records `PAPER_TITLE`, `PAPER_AUTHORS`,
+`PAPER_VENUE`, `PAPER_YEAR`, and `PAPER_DOI`. We are honest about the strength of the
+anchor: a *Journal of Finance* paper (e.g. Jegadeesh & Titman 1993, Moreira & Muir
+2017) is a stronger backing than a practitioner book (e.g. Bollinger 2001, Connors &
+Alvarez 2009), and where the academic anchor is a *related* paper rather than the
+strategy's literal origin (e.g. anchoring a moving-average rule on Brock,
+Lakonishok & LeBaron 1992) the file says so. McLean & Pontiff (2016) is the
+sobering backdrop: published predictors lost ~26% of their return out-of-sample and
+~58% post-publication, which is *why* peer-reviewed backing is necessary but not
+sufficient — it must still clear the four gates on our own data.
+
+---
+
+## Putting it together: the one-screen read
+
+When you open a strategy passport, scan in this order:
+
+1. **`gate_details`** — are all four gates `PASS`? Any `FAIL` tells you *which*
+   failure mode tripped; any `MISSING` tells you a check could not be computed
+   (usually too little data, or CPCV without a combinatorial matrix).
+2. **DSR p-value** — is it `≥ 0.95`? If not, the Sharpe has not cleared
+   multiple-testing deflation; treat the headline Sharpe as unproven.
+3. **PBO** — is it `< 0.5`? If not, the *library's selection* is overfit, and this
+   strategy's apparent edge is suspect by association.
+4. **OOS/IS ratio** — is it `≥ 0.5`, and is the OOS Sharpe positive? This is the
+   economic survival test.
+5. **Paper-claim delta** — how far below the paper's claim is our measured
+   performance, and is the divergence explained (price-proxy, single-name
+   adaptation, cost-aware)?
+6. **Risk decomposition** — is the variance concentrated in one name? Is the library
+   secretly one correlated bet?
+
+A backtest that survives all six reads is not *guaranteed* to work — nothing is —
+but it has survived the attempts that catch the vast majority of false positives.
+That is the most any honest backtest can claim, and stating exactly that is the
+point of the whole protocol.

--- a/docs/quant/methodology.md
+++ b/docs/quant/methodology.md
@@ -1,0 +1,625 @@
+# Quantitative Methodology
+
+> **Status:** Living reference for the math layer. Written 2026-06-12.
+> **Author:** Önder Akkaya (quant / math lane).
+> **Audience:** Teammates, judges, and any technically-literate reader who wants
+> the *why* behind the numbers on a strategy passport.
+> **Scope:** This document explains the statistics and the portfolio math that
+> Archimedes runs. It is the conceptual companion to two operational specs that
+> remain canonical where they overlap:
+> - [`../specs/selection-bias-corrections-spec.md`](../specs/selection-bias-corrections-spec.md)
+>   — the frozen DSR / PBO / walk-forward / look-ahead contract. **Thresholds and
+>   formulas in this doc are consistent with that spec; if they ever drift, the
+>   spec wins.**
+> - [`../rigor-methods.md`](../rigor-methods.md) — the plain-English, judge-facing
+>   version of the four-gate admission story.
+>
+> The implementing code is [`../../backend/archimedes/services/rigor_evaluator.py`](../../backend/archimedes/services/rigor_evaluator.py)
+> (selection-bias controls + Kelly) and
+> [`../../backend/archimedes/services/portfolio_optimizer.py`](../../backend/archimedes/services/portfolio_optimizer.py)
+> (portfolio construction). Function names cited below are real and resolve in
+> those files.
+
+---
+
+## 0. The thesis in one paragraph
+
+A high backtest Sharpe ratio is the *easiest thing in finance to manufacture by
+accident*. Search enough parameter combinations, or pick the best of enough
+candidate strategies, and you will find something that looks brilliant on
+history and is worthless out-of-sample. Archimedes' wedge is that it refuses to
+report a raw Sharpe as if it were evidence. Every Tier-1 strategy is run through
+selection-bias corrections that *deflate* the observed performance by exactly the
+amount of luck the search process injected, and the corrected numbers — plus the
+delta against what the source paper claimed — are surfaced openly, never hidden
+behind an aggregate score. This is "rigor as the wedge": the curation protocol is
+the product.
+
+---
+
+## Part I — Selection-bias corrections
+
+The four-primitive admission gate is: **Deflated Sharpe Ratio**, **Probability of
+Backtest Overfitting**, **walk-forward out-of-sample Sharpe**, and a **look-ahead
+static audit**. A strategy is promoted `CANDIDATE → VALIDATED` only when all four
+pass simultaneously (see [`admission-criteria.md`](admission-criteria.md)).
+
+### 1. Deflated Sharpe Ratio (DSR)
+
+**Reference:** Bailey, D. H., & López de Prado, M. (2014). *The Deflated Sharpe
+Ratio: Correcting for Selection Bias, Backtest Overfitting and Non-Normality.*
+Journal of Portfolio Management 40(5), 94–107.
+
+**Implemented by:** `compute_dsr(daily_returns, num_trials, average_correlation)`
+in `rigor_evaluator.py`, with the core formula factored into
+`_dsr_from_stats(...)` for direct unit-testing against the spec's reference cases.
+
+#### What it corrects
+
+Two distinct biases in the ordinary Sharpe ratio:
+
+1. **Multiple-testing inflation.** If you evaluate `N` candidate strategies and
+   keep the best one, the maximum observed Sharpe is upward-biased *even when
+   every strategy is pure noise*. The expected maximum of `N` independent
+   standard-normal Sharpe estimates grows with `N`; reporting the winner's raw
+   Sharpe without subtracting that expected-maximum baseline is the single most
+   common way honest-looking backtests lie.
+2. **Non-normality.** The textbook Sharpe significance test assumes i.i.d. normal
+   returns. Real return series are skewed and fat-tailed; negative skew and excess
+   kurtosis both *inflate* the apparent significance of a positive Sharpe. DSR
+   widens the variance of the Sharpe estimator to account for both.
+
+#### The formula and its intuition
+
+Work in **per-bar** (un-annualized) Sharpe units; annualization is purely a
+display transform. Given `T` per-bar returns, the per-bar Sharpe `ŜR`, skewness
+`γ₃`, and **raw (Pearson) kurtosis** `γ₄` (γ₄ = 3 for a normal distribution —
+*not* Fisher excess kurtosis), and `N` trials in the selection set:
+
+```
+γ_E   = 0.5772156649                      # Euler–Mascheroni constant
+Φ⁻¹   = standard-normal inverse CDF        # scipy.stats.norm.ppf
+Φ     = standard-normal CDF                # scipy.stats.norm.cdf
+
+# Expected maximum of N i.i.d. standard-normal Sharpe estimates
+# (Bailey–López de Prado two-quantile approximation):
+E[max_N] = (1 − γ_E)·Φ⁻¹(1 − 1/N) + γ_E·Φ⁻¹(1 − 1/(N·e))
+
+# Per-bar SR has variance 1/(T−1) under the i.i.d.-normal null,
+# so the expected best-of-N null Sharpe scales by √(1/(T−1)):
+SR_zero  = √(1/(T−1)) · E[max_N]
+
+# Variance-corrected z-statistic (Bailey–LdP eq. 8):
+z   = (ŜR − SR_zero)·√(T−1) / √(1 − γ₃·ŜR + ((γ₄ − 1)/4)·ŜR²)
+DSR = Φ(z)
+```
+
+Read it left to right:
+
+- `SR_zero` is **the Sharpe you would expect to see by luck alone** after picking
+  the best of `N` trials. The more strategies you searched (`N` ↑), the higher
+  this bar climbs.
+- `ŜR − SR_zero` is the strategy's *excess over the luck baseline*. If your
+  observed Sharpe barely beats what `N`-way search produces from noise, this is
+  near zero and the strategy will not clear the gate.
+- The denominator `√(1 − γ₃·ŜR + ((γ₄−1)/4)·ŜR²)` is the non-normality
+  correction. Negative skew (`γ₃ < 0`) and fat tails (`γ₄ > 3`) both *enlarge* it,
+  shrinking `z` and lowering the DSR — exactly the behavior we want, because
+  fat-tailed strategies hide crash risk.
+- `DSR = Φ(z)` is a **probability in `[0, 1]`** — the model's confidence that the
+  true Sharpe is positive after both corrections. This is what the UI shows as the
+  DSR p-value.
+
+> **Convention warning (load-bearing).** The `(γ₄ − 1)/4` coefficient is derived
+> for the *raw-kurtosis* convention. The code calls
+> `scipy.stats.kurtosis(arr, fisher=False)` deliberately. Passing Fisher *excess*
+> kurtosis would bias the denominator by a constant `(3/4)·ŜR²` and skew every
+> DSR. This is documented inline in `compute_dsr`.
+
+#### When it applies and sample-size requirements
+
+- DSR needs at least **`T ≥ 4` bars** to form skew/kurtosis; `compute_dsr` returns
+  `(None, None)` below that, on a degenerate constant series, or on a non-positive
+  denominator. Statistical power, however, requires far more than the floor — a
+  borderline strategy needs years of daily data before `z` separates from the
+  null. The spec's reference cases use `T` of 504 / 1260 / 2520 bars (2–10 years).
+- `num_trials = 1` applies **no correction** (`E[max_N] = 0`): there was no
+  selection, so there is nothing to deflate. The orchestrator passes
+  `N = len(strategy_library)` so the correction is meaningful, and a warning is
+  logged when `N = 1` while the library holds more than one strategy.
+
+#### Effective-N for correlated trials
+
+A parameter sweep whose variants move together does **not** constitute `N`
+*independent* tests. `compute_dsr` accepts an `average_correlation` argument and
+converts the nominal trial count to an effective count under an equicorrelation
+model:
+
+```
+N_eff = N / (1 + (N − 1)·ρ̄)
+```
+
+This is the standard "effective number of independent tests" (Cheverud 2001;
+Nyholt 2004). At `ρ̄ = 0` we get `N_eff = N` (full multiple-testing penalty); at
+`ρ̄ = 1` all variants collapse to a single test (`N_eff = 1`, no deflation). The
+helper `compute_average_pairwise_correlation(...)` computes `ρ̄` from the library's
+return matrix and clamps negative (diversifying) correlations to `0.0` — a
+conservative "no penalty relief" default. The two-quantile `E[max]` approximation
+diverges as `N → 1`, so the code evaluates it at `max(2, N_eff)` and linearly
+tapers to zero across `N_eff ∈ [1, 2]`.
+
+#### Outputs
+
+`compute_dsr` returns `(deflated_sharpe_ratio, dsr_p_value)`:
+- `deflated_sharpe_ratio` — `(ŜR − SR_zero)·√252`, the *annualized* corrected
+  Sharpe in Sharpe units (positive ⇒ clears the multiple-testing bar).
+- `dsr_p_value` — `Φ(z) ∈ [0, 1]`, the gate quantity. **Gate threshold: ≥ 0.95**
+  (`RigorGateResult.passes_all`).
+
+A companion `compute_sharpe_ci(...)` returns the Lo (2002) confidence interval for
+an annualized Sharpe under i.i.d. daily returns — useful context for how wide the
+Sharpe estimate's error bars actually are.
+
+---
+
+### 2. Probability of Backtest Overfitting (PBO) via CSCV
+
+**Reference:** Bailey, D. H., Borwein, J., López de Prado, M., & Zhu, J. (2014).
+*The Probability of Backtest Overfitting.* SSRN 2326253. See also Bailey et al.
+(2014), *Pseudo-Mathematics and Financial Charlatanism*, Notices of the AMS
+61(5), 458–471, for the accessible exposition.
+
+**Implemented by:** `compute_pbo(returns_matrix, s_partitions=16)` in
+`rigor_evaluator.py`.
+
+#### The question PBO answers
+
+> "If we had picked this strategy on a *different* slice of history, would it still
+> beat its peers on the remainder?"
+
+DSR corrects the *winner's own* Sharpe. PBO instead asks whether the **selection
+procedure** — picking the in-sample best from a library — is itself overfit. It is
+a property of the whole library, not of one strategy.
+
+#### CSCV — Combinatorially Symmetric Cross-Validation
+
+1. Stack the `N` strategies' aligned daily returns into a `(T, N)` matrix.
+2. Partition the `T` rows into `S` equal time-blocks (`S = 16` is the paper's
+   recommended default; must be even).
+3. Enumerate **every** way to choose `S/2` blocks as in-sample (IS); the
+   complementary `S/2` blocks are out-of-sample (OOS). That is `C(16, 8) = 12,870`
+   distinct symmetric splits.
+4. For each split: rank the `N` strategies by Sharpe in-sample, take the
+   **in-sample winner**, and look up *its* rank out-of-sample.
+5. Convert the winner's OOS rank to a relative rank `ω = rank_OOS / N` and form the
+   logit `λ = log(ω / (1 − ω))`.
+6. **`PBO = P(λ ≤ 0)`** — the fraction of splits in which the in-sample winner
+   landed in the *bottom half* out-of-sample.
+
+#### Interpretation
+
+- `PBO = 0` — the IS winner also won OOS in every split: no overfitting detected.
+- `PBO = 0.5` — a coin flip: the IS-best strategy is no better than the median OOS
+  strategy. **This is the failure threshold.**
+- `PBO ≥ 0.5` means the selection procedure systematically picks strategies that
+  underperform the OOS median — the library is overfit. **Gate threshold: PBO < 0.5.**
+
+#### Honest caveats baked into the implementation
+
+`compute_pbo`'s docstring documents three real limitations that matter for a small
+library (today `N ≈ 4–6`):
+
+- **Library-level coupling.** PBO is a property of the *selection set*; the same
+  value is attached to every strategy in the run. A strategy's PBO verdict
+  therefore shifts when you add or remove a *neighbor*. This is inherent to CSCV,
+  not a bug — read PBO as a *library-overfit signal*, not a per-strategy score.
+- **Coarse OOS rank.** With small `N`, `ω = rank_OOS / N` takes only a few discrete
+  values, so `λ` and hence PBO are granular. The estimate sharpens as the library
+  grows.
+- **Trailing-bar truncation.** `rows_per_block = T // S` drops up to `S − 1`
+  trailing bars so every block is equal-length — negligible for multi-year series.
+
+PBO is a **library-level** metric: compute it once per analytics-engine run and
+attach the same score to each strategy's `BacktestResult` from that run; recompute
+when the library changes.
+
+---
+
+### 3. Walk-forward out-of-sample Sharpe and the IS/OOS cliff
+
+**Implemented by:** `compute_oos_sharpe(daily_returns, train_fraction=0.70)` in
+`rigor_evaluator.py`.
+
+DSR and PBO are *statistical* tests. The walk-forward OOS Sharpe is an *economic*
+one: split the return series chronologically (no shuffling), reserve the first
+70% as in-sample, and compute the Sharpe on the held-out final 30% alone. The gate
+applies two checks:
+
+- **Absolute floor:** OOS Sharpe must be `> 0`. A negative OOS Sharpe can never
+  pass, regardless of how strong the in-sample Sharpe was.
+- **The cliff check:** `OOS_Sharpe / IS_Sharpe ≥ 0.5`. The out-of-sample edge must
+  be at least half the in-sample edge. A strategy whose Sharpe *cliffs* the moment
+  it stops seeing training data has memorized the past, not discovered a signal.
+
+The in-sample Sharpe used for the ratio is computed on the **first 70% slice
+only** (`run_rigor_gate` derives this when not supplied) — blending IS+OOS into the
+denominator would make the ratio trivially easy to pass.
+
+#### Honest limitation and the principled upgrade
+
+`compute_oos_sharpe` is a **single chronological hold-out**, not a rolling
+walk-forward re-estimation. There is no per-window refit and no purge/embargo gap
+at the train/test boundary, so a lookback indicator's state (e.g. an SMA-200 or
+TSMOM-252 window) can straddle the split. The principled upgrade is **Combinatorial
+Purged Cross-Validation** (López de Prado, *Advances in Financial Machine
+Learning*, ch. 12), implemented as `compute_cpcv_oos_sharpe(...)`. CPCV assembles
+`C(N−1, k−1)` continuous backtest paths from `C(N, k)` purged splits and measures
+path-to-path stability (mean OOS Sharpe + fraction of paths with positive OOS
+Sharpe). Crucially, **CPCV is mathematically invalid on a single static 1-D return
+series** (it would generate identical paths), so the function returns `None` unless
+the analytics-engine supplies a real 2-D combinatorial OOS matrix — and the gate
+reports the CPCV check as `MISSING` rather than silently passing. When present, the
+gate additionally requires `cpcv_positive_fraction ≥ 0.5`.
+
+---
+
+### 4. Look-ahead static audit
+
+**Implemented by:** `look_ahead_audit(strategy_code)` in `rigor_evaluator.py`.
+
+The cheapest way to fake alpha is to let the strategy peek at data it could not
+have known at decision time. The audit parses the strategy source with Python's
+`ast` module and flags:
+
+1. Calls to functions whose names suggest forecasting/peeking (`future`,
+   `forecast`, `predict`, `peek`, `lookahead`, `look_ahead`).
+2. Negative pandas shifts (`shift(-1)`), which pull future rows backward.
+3. Positive integer indexing into a data feed (`data[+N]`), which references
+   future bars.
+4. Negative subscripts, flagged for manual review because `[-N]` is *safe* in
+   backtrader (N bars ago) but *unsafe* in pandas (last row = future data) — the
+   audit cannot resolve the calling context, so it surfaces the ambiguity rather
+   than guessing.
+
+It returns `(passed, warnings)`; `passed` is `True` only when zero warnings fire.
+This complements the analytics-engine's own broker-level check that rejects
+`coc` (close-on-close) / `coo` (close-on-open) configurations.
+
+---
+
+### 5. Multiple-testing control: FDR vs FWER
+
+When the library grows and we want a *family-wide* significance statement across
+many strategy p-values (rather than the per-strategy DSR), two control regimes
+apply. They answer different questions, and choosing the wrong one is itself a
+methodological error.
+
+#### Bonferroni — Family-Wise Error Rate (FWER)
+
+**Reference:** Bonferroni (1936); see Holm (1979) for the uniformly more powerful
+step-down variant.
+
+Controls `P(at least one false positive) ≤ α` by testing each of `m` hypotheses at
+`α/m`. It is **conservative**: with `m = 100` strategies and `α = 0.05`, each must
+clear `p ≤ 0.0005`. Use FWER when *any* single false admission is costly — e.g.
+deploying real capital where one curve-fit strategy in the live set is unacceptable.
+
+#### Benjamini–Hochberg — False Discovery Rate (FDR)
+
+**Reference:** Benjamini, Y., & Hochberg, Y. (1995). *Controlling the False
+Discovery Rate: A Practical and Powerful Approach to Multiple Testing.* JRSS-B
+57(1), 289–300.
+
+Controls the **expected proportion of false positives among the rejections**.
+Procedure: sort the `m` p-values ascending `p₍₁₎ ≤ … ≤ p₍ₘ₎`; find the largest `k`
+with `p₍ₖ₎ ≤ (k/m)·α`; reject hypotheses `1…k`. FDR is **more powerful** than
+Bonferroni — it tolerates a controlled fraction of false discoveries in exchange
+for finding more true ones.
+
+#### When to prefer FDR over FWER
+
+| Use FWER (Bonferroni) when… | Use FDR (Benjamini–Hochberg) when… |
+|---|---|
+| Any single false admission is expensive (live capital, one bad strategy poisons the vault) | You are *screening* a large candidate pool and a few false leads are acceptable |
+| `m` is small | `m` is large (dozens+ of candidates) |
+| You need a guarantee on *any* error | You can tolerate a known *expected proportion* of errors |
+
+For Archimedes, the **per-strategy DSR is the binding gate** (it already encodes
+multiple-testing via the `N`-trial deflation). FDR/FWER are the right frame for the
+*library-screening* question — "of the candidates we are about to promote, what
+fraction are likely false?" — and FDR is generally preferred at the screening stage
+because the candidate pool is large and a missed true strategy costs more than a
+controlled trickle of false leads that the DSR gate then filters individually.
+
+---
+
+### 6. Monte Carlo significance via the circular block bootstrap
+
+**Reference:** Politis, D. N., & Romano, J. P. (1992). *A Circular Block-Resampling
+Procedure for Stationary Data.* (And the stationary bootstrap, Politis & Romano
+1994.)
+
+A parametric significance test assumes a return distribution. When we want a
+**distribution-free** significance statement for a metric (Sharpe, CAGR, max
+drawdown) on serially-correlated returns, we bootstrap. The naive i.i.d. bootstrap
+is wrong for financial returns because it destroys autocorrelation and volatility
+clustering. The **circular block bootstrap** fixes this:
+
+1. Wrap the return series into a circle (so the last bar's "next" is the first).
+2. Resample contiguous **blocks** of length `b` (preserving short-range serial
+   dependence within each block) until a synthetic series of length `T` is built.
+3. Recompute the metric on each resample to build its null/empirical distribution.
+4. Read significance as the resampled metric's percentile (e.g. one-sided p =
+   fraction of resamples with metric ≤ 0 for a positive-Sharpe test).
+
+Block length `b` should grow with the autocorrelation horizon (rule of thumb
+`b ∝ T^{1/3}`). The circular variant gives every observation equal resampling
+weight (the plain block bootstrap under-weights the tails). This is the right tool
+when we report a Monte-Carlo confidence band on a backtest statistic rather than
+relying on the closed-form Lo (2002) Sharpe standard error.
+
+---
+
+## Part II — Portfolio construction
+
+The optimizer maps each vault **risk profile** to an objective. The five profiles
+are defined in
+[`../../backend/archimedes/models/portfolio.py`](../../backend/archimedes/models/portfolio.py)
+(`RiskProfile`: `FIXED_INCOME`, `CONSERVATIVE`, `MODERATE`, `AGGRESSIVE`,
+`HYPER_RISKY`). Construction lives in `portfolio_optimizer.py`.
+
+### 7. Mean-Variance Optimization (Markowitz)
+
+**Reference:** Markowitz, H. (1952). *Portfolio Selection.* Journal of Finance
+7(1), 77–91.
+
+The foundation: a portfolio is a point in (expected-return, variance) space, and
+for any target return there is a *minimum-variance* weight vector. Sweeping the
+target return traces the **efficient frontier** — implemented by
+`compute_efficient_frontier(...)`, which solves a sequence of
+`min wᵀΣw  s.t. wᵀμ = target, 1ᵀw = 1` problems via SLSQP. All objectives below
+are solved on the **long-only unit simplex** with a per-asset weight cap (default
+0.40, raised to 0.60 for the hyper-risky profile) to prevent degenerate
+corner solutions, falling back to equal weight when SLSQP fails or history is too
+short (`< 20` bars).
+
+| Risk profile | Objective | Function |
+|---|---|---|
+| `CONSERVATIVE` | Global Minimum Variance | `_gmv(...)` |
+| `MODERATE` / `AGGRESSIVE` | Max Sharpe (tangency) | `_max_sharpe(...)` |
+| `HYPER_RISKY` | Max Expected Return (LP) | `_max_expected_return(...)` |
+
+### 8. Global Minimum Variance (GMV)
+
+`min wᵀΣw  s.t.  1ᵀw = 1,  0 ≤ wᵢ ≤ cap`. The single point on the frontier with the
+lowest variance, ignoring expected returns entirely. **Serves the conservative
+profile** because it is the most estimation-robust objective — it depends only on
+the covariance matrix `Σ`, never on the notoriously noisy expected-return vector
+`μ`. When you cannot trust your return forecasts, minimize variance.
+
+### 9. Max-Sharpe (tangency portfolio)
+
+`max (μ − rf)ᵀw / √(wᵀΣw)`. The point where a ray from the risk-free rate is
+tangent to the efficient frontier — the **highest risk-adjusted return**
+portfolio. **Serves the moderate and aggressive profiles** (aggressive applies a
+looser USYC floor upstream). More sensitive to `μ` estimation error than GMV, which
+is why we shrink the covariance (§13) and, in the Kelly path, shrink `μ` too.
+
+### 10. Kelly criterion sizing
+
+**References:** Kelly, J. L. (1956). *A New Interpretation of Information Rate.*
+Bell System Technical Journal 35(4), 917–926. Bell, R., & Cover, T. M. (1980).
+*Competitive Optimality of Logarithmic Investment.* Mathematics of Operations
+Research 5(2), 161–166.
+
+Kelly answers: *what fraction of capital maximizes long-run (log) growth?* For a
+continuous return stream the single-asset full-Kelly fraction is:
+
+```
+f* = (μ_ann − rf_ann) / σ²_ann
+```
+
+implemented in `compute_kelly_fraction(daily_returns, rf_annual=0.05,
+fractional=0.5)`.
+
+- **Full Kelly** (`fractional=1.0`) maximizes growth but is *too aggressive in
+  practice*: it is acutely sensitive to estimation error in `μ`, and over-betting
+  it can be catastrophic. We treat full Kelly as an academic reference only.
+- **Half-Kelly** (`fractional=0.5`, the default) sacrifices a small amount of
+  long-run growth for a large reduction in drawdown volatility — the standard
+  risk-management convention. Kelly is defined on **excess** returns; using gross
+  returns inflates every allocation by `rf/σ²`. The output is clipped to `[0, 1]`
+  (no leverage); a non-positive excess return returns `0.0`.
+
+#### γ-mapped risk aversion (Kelly as mean-variance)
+
+In the portfolio (multi-asset) path, Kelly is expressed as the
+risk-aversion-parameterized mean-variance objective solved by
+`kelly_optimize_from_prices(...)`:
+
+```
+maximize   wᵀ(μ − rf) − ½·γ·wᵀΣw
+subject to 0 ≤ wᵢ ≤ max_weight,   Σ wᵢ ≤ synth_budget
+```
+
+`γ` is mapped from the risk profile via the `RISK_AVERSION` table. **`γ = 2`
+reproduces half-Kelly** (Bell & Cover 1980); `γ → 0` approaches full Kelly;
+`γ → ∞` collapses to minimum-variance:
+
+| Profile | Baseline γ | Reading |
+|---|---|---|
+| `fixed_income` | 12.0 | Extreme preservation; minvar-dominated |
+| `conservative` | 6.0 | Capital preservation first |
+| `moderate` | 3.0 | Balanced |
+| `aggressive` | 2.0 | Half-Kelly; accepts drawdown |
+| `hyper_risky` | 1.5 | Near-full-Kelly |
+
+#### Regime-conditional γ scaling
+
+**Reference:** Ang, A., & Bekaert, G. (2002). *International Asset Allocation With
+Regime Shifts.* Review of Financial Studies 15(4), 1137–1187.
+
+When a live regime is supplied, the effective risk aversion is
+`γ_eff = γ_profile × REGIME_GAMMA_MULTIPLIER[regime]`
+(`risk_on` 1.0× · `transition` 1.0× · `risk_off` 2.0× · `crisis` 4.0×). Ang &
+Bekaert show regime-conditioned weights strictly dominate static weights: risk
+aversion *should* rise in stressed states. So a `moderate` investor in a `crisis`
+regime operates at `γ = 12.0`, equivalent to `fixed_income` in normal times — more
+defensive without the user changing their declared profile. The multipliers are
+deliberately conservative (research papers sometimes use 6–10× in tail regimes) to
+avoid whipsawing allocations on every regime flip; this is documented as an
+engineering judgment, not a claim of optimality.
+
+### 11. Hierarchical Risk Parity (HRP)
+
+**Reference:** López de Prado, M. (2016). *Building Diversified Portfolios that
+Outperform Out of Sample.* Journal of Portfolio Management 42(4), 59–69.
+
+HRP avoids the single worst failure mode of Markowitz: **inverting an
+ill-conditioned covariance matrix.** Quadratic optimizers must invert `Σ`, and when
+assets are highly correlated (so `Σ` is near-singular) the inverse amplifies
+estimation noise into wild, unstable corner weights. HRP never inverts `Σ`.
+Instead it (1) builds a hierarchical *tree* of assets by clustering the correlation
+matrix, (2) reorders `Σ` so similar assets are adjacent (**quasi-diagonalization**),
+and (3) allocates capital top-down by **recursive bisection**, splitting each
+cluster's budget in inverse proportion to its sub-clusters' variance. The result is
+more stable out-of-sample than Markowitz and degrades gracefully as asset count
+grows. **Maps to risk-balanced / diversification-seeking mandates** — the same
+intent the inverse-volatility risk-parity sleeve serves (Maillard, Roncalli &
+Teïletche 2010, implemented as a strategy in the library).
+
+> *Status note:* the production optimizer today routes the five profiles through
+> GMV / Max-Sharpe / Max-Return (above) with Ledoit–Wolf covariance shrinkage;
+> HRP is documented here as the principled diversification objective and the
+> intended path for many-asset, high-correlation baskets.
+
+### 12. Black–Litterman
+
+**Reference:** He, G., & Litterman, R. (1999). *The Intuition Behind
+Black–Litterman Model Portfolios.* Goldman Sachs Investment Management. (Original:
+Black & Litterman 1992.)
+
+Markowitz's Achilles heel is that small changes in the `μ` estimate produce
+enormous swings in weights. Black–Litterman fixes this by **starting from the
+market-implied equilibrium returns** (reverse-optimized from market-cap weights via
+`Π = δ·Σ·w_mkt`) as a Bayesian *prior*, then blending in the investor's explicit
+**views** (with stated confidences) to form a posterior `μ`. The posterior is far
+more stable than raw historical means, so the optimized weights are well-behaved
+and tilt *gently* toward views rather than over-reacting. In Archimedes' frame, the
+**paper-grounded expected returns** (a strategy's claimed edge) are natural
+"views," and the market equilibrium is the prior — a clean mapping onto the
+`mu_override` + `mu_shrinkage` blending already in `kelly_optimize_from_prices`,
+which shrinks paper-extrapolated `μ` toward each asset's own sample mean (default
+0.5 blend) so a single strategy's CAGR does not get promised across every asset it
+voted for.
+
+### 13. Robust optimization and covariance shrinkage
+
+**Reference:** Ledoit, O., & Wolf, M. (2004). *A Well-Conditioned Estimator for
+Large-Dimensional Covariance Matrices.* Journal of Multivariate Analysis 88(2),
+365–411.
+
+Every objective that touches `Σ` is only as good as the `Σ` estimate. The sample
+covariance is the MLE but is badly conditioned — often singular — when the asset
+count is not small relative to the number of observations. `ledoit_wolf_shrinkage(...)`
+shrinks the sample covariance `S` toward a scaled-identity target `F = μ·I`:
+
+```
+Σ* = δ·μ·I + (1 − δ)·S,    δ* = b²/d² ∈ [0, 1]
+```
+
+where `δ*` is derived *analytically from the data* (not hand-tuned): a short, noisy
+sample shrinks hard toward the target; a long, clean one barely shrinks. This is
+the production estimator in `_build_mu_sigma_from_prices(...)`, with a
+fixed-intensity diagonal fallback (`_shrink_cov`, α = 0.10) only when the analytic
+estimator cannot run. Shrinkage is the practical face of **robust optimization**:
+it makes the optimizer's output stable under the estimation error that plagues
+naive MVO.
+
+### 14. Risk attribution and reporting
+
+Two reporting primitives make the optimizer's output legible:
+
+- `kelly_risk_decomposition(...)` — per-asset **marginal contribution to portfolio
+  variance** via the Euler decomposition `MCᵢ = wᵢ·(Σw)ᵢ / σ²ₚ` (sums to 1). Lets
+  the UI say "GLD contributes 22% of portfolio variance."
+- `expected_max_drawdown_1y(μ, σ)` and `value_at_risk_95_1y(μ, σ)` — closed-form
+  risk figures. The drawdown uses the Magdon-Ismail & Atiya (2004) approximation
+  (a real improvement on the naive `2σ` heuristic); the VaR is the parametric
+  normal `−(μ − 1.645σ)`. Both return positive decimals and are explainable to a
+  non-quant ("5% chance you lose at least this much in a year, assuming normal
+  returns").
+
+---
+
+## Part III — Honest framing (non-negotiable)
+
+Rigor that hides its own caveats is theater. Two disclosure rules are
+architectural, not optional:
+
+1. **Paper-claim deltas are surfaced, not hidden.** Every strategy passport shows
+   the source paper's *claimed* Sharpe/CAGR alongside our *measured* post-gate
+   numbers. When our adaptation underperforms the paper (it usually does — see the
+   v1 adaptation caveats in [`strategy-library.md`](strategy-library.md)), the
+   delta is shown openly. We never collapse the four gate numbers into a single
+   marketing score. This is the design intent of `RigorGateResult.gate_details`,
+   which renders each gate as `PASS` / `FAIL` / `MISSING` with the actual value.
+2. **Price-based proxies are disclosed.** Several library strategies are *price-only
+   adaptations* of strategies that originally used cross-sectional or
+   fundamental data (e.g. a single-name 52-week-high proxy for a cross-sectional
+   sort; an SPY-yield proxy for a true dividend-yield sort). Where the live
+   implementation diverges from the paper's universe or data, the strategy file's
+   header says so, the `paper_claimed_*` fields are set to `null` when the paper
+   reports no mechanical Sharpe/CAGR, and the only performance claim we stand
+   behind is the post-gate one measured on our own data.
+
+The risk-free rate is a single shared constant (`_RF_ANNUAL = 0.05`, the
+2024–2025 Fed-funds environment) used consistently across DSR, OOS Sharpe, Kelly,
+and the optimizer, so every excess-return figure is computed on the same basis.
+
+---
+
+## References
+
+- Ang, A., & Bekaert, G. (2002). International Asset Allocation With Regime Shifts.
+  *Review of Financial Studies* 15(4), 1137–1187.
+- Bailey, D. H., Borwein, J., López de Prado, M., & Zhu, J. (2014). The Probability
+  of Backtest Overfitting. *SSRN 2326253*.
+- Bailey, D. H., Borwein, J., López de Prado, M., & Zhu, J. (2014).
+  Pseudo-Mathematics and Financial Charlatanism. *Notices of the AMS* 61(5),
+  458–471.
+- Bailey, D. H., & López de Prado, M. (2014). The Deflated Sharpe Ratio. *Journal
+  of Portfolio Management* 40(5), 94–107.
+- Bell, R., & Cover, T. M. (1980). Competitive Optimality of Logarithmic
+  Investment. *Mathematics of Operations Research* 5(2), 161–166.
+- Benjamini, Y., & Hochberg, Y. (1995). Controlling the False Discovery Rate.
+  *Journal of the Royal Statistical Society B* 57(1), 289–300.
+- Black, F., & Litterman, R. (1992). Global Portfolio Optimization. *Financial
+  Analysts Journal* 48(5), 28–43. (See He & Litterman 1999 for the intuition.)
+- Cheverud, J. M. (2001). A simple correction for multiple comparisons in interval
+  mapping genome scans. *Heredity* 87, 52–58.
+- He, G., & Litterman, R. (1999). The Intuition Behind Black–Litterman Model
+  Portfolios. *Goldman Sachs Investment Management*.
+- Holm, S. (1979). A Simple Sequentially Rejective Multiple Test Procedure.
+  *Scandinavian Journal of Statistics* 6(2), 65–70.
+- Kelly, J. L. (1956). A New Interpretation of Information Rate. *Bell System
+  Technical Journal* 35(4), 917–926.
+- Ledoit, O., & Wolf, M. (2004). A Well-Conditioned Estimator for
+  Large-Dimensional Covariance Matrices. *Journal of Multivariate Analysis* 88(2),
+  365–411.
+- Lo, A. W. (2002). The Statistics of Sharpe Ratios. *Financial Analysts Journal*
+  58(4), 36–52.
+- López de Prado, M. (2016). Building Diversified Portfolios that Outperform Out of
+  Sample. *Journal of Portfolio Management* 42(4), 59–69.
+- López de Prado, M. (2018). *Advances in Financial Machine Learning.* Wiley.
+  (CPCV — ch. 12.)
+- Magdon-Ismail, M., & Atiya, A. (2004). Maximum Drawdown. *Wilmott Magazine*.
+- Markowitz, H. (1952). Portfolio Selection. *Journal of Finance* 7(1), 77–91.
+- McLean, R. D., & Pontiff, J. (2016). Does Academic Research Destroy Stock Return
+  Predictability? *Journal of Finance* 71(1), 5–32.
+- Nyholt, D. R. (2004). A Simple Correction for Multiple Testing for SNPs in
+  Linkage Disequilibrium. *American Journal of Human Genetics* 74(4), 765–769.
+- Politis, D. N., & Romano, J. P. (1992). A Circular Block-Resampling Procedure for
+  Stationary Data. In *Exploring the Limits of Bootstrap*, Wiley.
+- Politis, D. N., & Romano, J. P. (1994). The Stationary Bootstrap. *Journal of the
+  American Statistical Association* 89(428), 1303–1313.

--- a/docs/quant/strategy-library.md
+++ b/docs/quant/strategy-library.md
@@ -1,0 +1,322 @@
+# Strategy Library Reference
+
+> **Status:** Living reference. Written 2026-06-12.
+> **Author:** Önder Akkaya (quant / math lane).
+> **Audience:** Anyone browsing the library who wants to know what each strategy
+> captures, what regime it suits, and — honestly — how the v1 implementation
+> diverges from the source paper.
+> **Source of truth:** the strategy files under
+> [`../../analytics-engine/strategies/`](../../analytics-engine/strategies/). The
+> paper / author / regime fields below are transcribed from each file's
+> `PAPER_*` and `REGIME_TAG` constants. Where a file's header documents a v1
+> adaptation caveat, that caveat is reproduced here. For strategies whose full
+> methodology is non-trivial, see the file header for the complete write-up.
+
+This page documents the **25 strategy files** in the library as of this writing.
+Each carries an academic or practitioner anchor, a `REGIME_TAG`
+(`bull` / `bear` / `regime_neutral`), and the honest paper-vs-implementation
+delta. Admission to Tier 1 still requires passing the four-gate
+[`admission-criteria.md`](admission-criteria.md); a paper anchor is necessary, not
+sufficient. Today **Faber 2007** and **Moreira–Muir 2017** pass all four gates; the
+rest are honest `CANDIDATE`s with their failing gate shown openly.
+
+A recurring honesty theme: many files set `paper_claimed_*` to **null** when the
+source reports win-rate / t-statistic / conditional-mean tables rather than a
+mechanical Sharpe or CAGR (common for the technical-rule and book-sourced
+strategies). In those cases the only performance claim we stand behind is the
+post-gate one measured on our own data.
+
+---
+
+## Sleeve: Momentum / trend-following
+
+Momentum captures under-reaction and herding — winners keep winning over
+intermediate horizons. Trend strategies are **bull-biased** by construction and
+carry crash risk at trend reversals.
+
+### Jegadeesh & Titman (1993) — cross-sectional momentum
+- **File:** `jegadeesh_titman_1993_cross_sectional_momentum.py`
+- **Paper:** *Returns to Buying Winners and Selling Losers: Implications for Stock
+  Market Efficiency*, Journal of Finance, 1993.
+- **Anomaly:** stocks ranked on prior 3–12 month returns continue to outperform/
+  underperform over the next 3–12 months — the canonical academic documentation of
+  the momentum effect.
+- **Regime:** `bull` (momentum is a trend phenomenon).
+- **v1 caveat:** the original is a cross-sectional long–short ranking; verify the
+  live universe and ranking horizon against the paper. *(See file header.)*
+
+### Moskowitz, Ooi & Pedersen (2012) — Time Series Momentum (TSMOM)
+- **File:** `moskowitz_ooi_pedersen_2012_tsmom.py`
+- **Paper:** *Time Series Momentum*, Journal of Financial Economics, 2012.
+- **Anomaly:** an asset's own past 12-month return predicts its next-month return —
+  go long if the trailing return `r_{t-12,t}` is positive, flat/short otherwise.
+- **Regime:** `bull`.
+- **v1 caveat:** the paper's diversified portfolio takes **long *and* short**
+  positions across many assets; the v1 adaptation is long/flat on a narrower
+  universe, so the paper-claimed-vs-actual delta is surfaced in the methodology
+  block. *(See file header.)*
+
+### Antonacci (2014) — Dual Momentum
+- **File:** `antonacci_2014_dual_momentum.py`
+- **Paper:** *Risk Premia Harvesting Through Dual Momentum* (SSRN 2042750; JPM
+  Vol. 42 No. 1), 2014.
+- **Anomaly:** combines **relative** momentum (pick the stronger asset) with
+  **absolute** momentum (defensive switch to cash/bonds when trailing return is
+  negative) — trend-following with a downside switch.
+- **Regime:** `bull` (defends in bear).
+
+### George & Hwang (2004) — 52-Week High proximity momentum
+- **File:** `george_hwang_2004_52w_high.py`
+- **Paper:** *The 52-Week High and Momentum Investing*, Journal of Finance, 2004.
+- **Anomaly:** proximity of price to its 52-week high predicts continued returns —
+  a nearness-to-high signal rather than a raw-return rank.
+- **Regime:** `bull`.
+- **v1 caveat:** the original is **cross-sectional** (rank all stocks by
+  high-proximity); the v1 single-name proxy strips the cross-sectional component, so
+  the directional alpha is **lower than the paper claims** and the divergence is
+  disclosed. *(See file header.)*
+
+### Appel (1979) — MACD signal-line crossover
+- **File:** `appel_1979_macd.py`
+- **Paper:** MACD trading method (Appel 1979); academic MA-rule evidence in **Brock,
+  Lakonishok & LeBaron (1992)**, Journal of Finance 47(5).
+- **Anomaly:** smoothed momentum via the convergence/divergence of two EMAs; trade
+  the signal-line crossover.
+- **Regime:** `regime_neutral`.
+- **v1 caveat:** MACD has no peer-reviewed origin paper, so the academic anchor is
+  Brock et al. (1992)'s MA-rule tests. **Data-snooping caveat** (Sullivan,
+  Timmermann & White 1999) applies. *(See file header.)*
+
+### Brock, Lakonishok & LeBaron (1992) — dual MA crossover (golden cross)
+- **File:** `brock_1992_dual_ma_crossover.py`
+- **Paper:** *Simple Technical Trading Rules and the Stochastic Properties of Stock
+  Returns*, Journal of Finance 47(5):1731–1764, 1992.
+- **Anomaly:** long/short on a fast/slow moving-average crossover; the paper's
+  rigorous test of the MA-rule family on the DJIA 1897–1986 found buy-signals carry
+  predictive content.
+- **Regime:** `bull`.
+- **v1 caveat:** the paper reports **conditional mean returns and t-statistics, not
+  a tradeable Sharpe or CAGR**, so `paper_claimed_*` are null. *(See file header.)*
+
+### Donchian — channel breakout (Four-Week Rule)
+- **File:** `donchian_breakout.py`
+- **Paper:** Donchian's breakout rule; academic anchor again **Brock, Lakonishok &
+  LeBaron (1992)**.
+- **Anomaly:** enter on a breakout above the N-day high (and exit on the symmetric
+  low) — the classic trend-capture mechanism.
+- **Regime:** `bull`.
+- **v1 caveat:** no peer-reviewed origin; anchored on Brock et al. (1992).
+  Data-snooping caveat (Sullivan, Timmermann & White 1999) applies; the performance
+  claim we stand behind is the post-gate one, `paper_claimed_*` null. *(See file
+  header.)*
+
+---
+
+## Sleeve: Mean-reversion / pairs (relative-value, market-neutral)
+
+These strategies bet on convergence — a spread, ratio, or residual that has
+diverged should revert. Built to be **regime-neutral** because the bet is on the
+*relationship*, not market direction.
+
+### Gatev, Goetzmann & Rouwenhorst (2006) — pairs trading (distance method)
+- **Files:** `gatev_2006_pairs_distance.py`, `gatev_2006_pairs_ewa_ewc.py`,
+  `gatev_2006_pairs_gld_slv.py`, `gatev_2006_pairs_ko_pep.py`,
+  `gatev_2006_portfolio_of_pairs.py`
+- **Paper:** *Pairs Trading: Performance of a Relative-Value Arbitrage Rule*, Review
+  of Financial Studies 19, 2006.
+- **Anomaly:** match securities by minimum sum-of-squared normalized-price distance;
+  when a matched pair's normalized prices diverge beyond a threshold, short the
+  winner / long the loser and hold to convergence.
+- **Regime:** `regime_neutral`.
+- **Five implementations:** four are **single specific pairs** (EWA/EWC country
+  ETFs, GLD/SLV gold-silver ratio, KO/PEP consumer staples, plus the generic
+  distance pair) and one is the **portfolio-of-pairs** faithful-scale method.
+- **v1 caveat (important):** the paper's headline ~11% annualized excess return
+  belongs to a **diversified portfolio of many pairs**, *not* a single pair. The
+  `gatev_2006_portfolio_of_pairs.py` file reproduces the paper's actual design at
+  the paper's actual scale (re-form pairs every 6 months); the single-pair files
+  explicitly note that a lone pair is **not comparable** to the paper's diversified
+  ~11%. *(See file headers.)*
+
+### Engle & Granger (1987) — cointegration pairs
+- **File:** `engle_granger_1987_cointegration_pairs.py`
+- **Paper:** *Co-integration and Error Correction: Representation, Estimation, and
+  Testing*, Econometrica, 1987 (with Vidyamurthy 2004 for the pairs application).
+- **Anomaly:** where the distance method trades the *price ratio*, this trades the
+  **cointegration residual** — fit a cointegrating relationship, model the spread's
+  reversion with an Ornstein–Uhlenbeck half-life, and trade deviations.
+- **Regime:** `regime_neutral` (relative-value by design).
+- **v1 caveat:** Engle–Granger is the econometric *framework*, not a trading paper;
+  the trading application follows Vidyamurthy (2004). *(See file header.)*
+
+### Elliott, van der Hoek & Malcolm (2005) — Kalman-filter dynamic-hedge pairs
+- **File:** `elliott_2005_kalman_pairs.py`
+- **Paper:** *Pairs Trading*, Quantitative Finance, 2005.
+- **Anomaly:** model the hedge ratio as a **time-varying state** estimated by a
+  Kalman filter, so the pair's spread adapts as the relationship drifts — more
+  robust than a static OLS hedge.
+- **Regime:** `regime_neutral`.
+
+### Avellaneda & Lee (2010) — PCA / eigenportfolio statistical arbitrage
+- **File:** `avellaneda_lee_2010_pca_statarb.py`
+- **Paper:** *Statistical Arbitrage in the U.S. Equities Market*, Quantitative
+  Finance, 2010.
+- **Anomaly:** decompose returns into principal-component (eigenportfolio) factors;
+  trade the mean-reverting **residual** of each name against its factor exposure —
+  market-neutral residual reversion.
+- **Regime:** `regime_neutral` (market-neutral by construction).
+- **v1 caveat:** the PCA-residual approach reads from every `self.datas[i]` each
+  bar; verify the live universe matches the paper's residual construction. *(See
+  file header.)*
+
+### Bollinger (2001) — lower-band mean reversion
+- **File:** `bollinger_2001_band_reversion.py`
+- **Paper:** *Bollinger on Bollinger Bands* (McGraw-Hill book), 2001.
+- **Anomaly:** buy when price touches the lower band (volatility-scaled distance from
+  a moving average), expecting reversion to the mean.
+- **Regime:** `regime_neutral`.
+- **v1 caveat:** the authoritative reference is a **book, not a peer-reviewed
+  paper**, and it describes the bands qualitatively without a mechanical Sharpe/CAGR;
+  bands widen in volatile regimes and contract in calm ones, so a fixed-distance
+  rule behaves differently across regimes. `paper_claimed_*` null. *(See file
+  header.)*
+
+### Connors & Alvarez (2009) — RSI(2) mean reversion
+- **File:** `connors_alvarez_2009_rsi2.py`
+- **Paper:** *Short Term Trading Strategies That Work* (book), 2009.
+- **Anomaly:** short-term mean reversion using a 2-period RSI, entered only inside a
+  longer-term uptrend filter.
+- **Regime:** `regime_neutral` (mean reversion inside an uptrend filter).
+- **v1 caveat:** book source, not peer-reviewed; reports **win-rate / average-gain
+  tables** rather than a clean Sharpe/CAGR, so `paper_claimed_*` are null. *(See
+  file header.)*
+
+---
+
+## Sleeve: Value / yield
+
+### Fama & French (1988) — dividend-yield predictability
+- **File:** `low_tan_wermers_2004_dividend_yield.py`
+- **Paper:** *Dividend Yields and Expected Stock Returns*, Journal of Financial
+  Economics, 1988.
+- **Anomaly:** the dividend yield (D/P) of stocks predicts subsequent returns — a
+  value/yield tilt.
+- **Regime:** `bear` (value/defensive tilt).
+- **v1 caveat:** the live implementation is a **high-D/P-sort proxy**, *not a true
+  dividend sort*; the file name references Low, Tan & Wermers (2004) but the
+  documented anchor and methodology are the Fama–French (1988) D/P study. Treat as a
+  yield-tilt proxy. *(See file header.)*
+
+---
+
+## Sleeve: Quality / defensive
+
+### Arnott, Harvey, Kalesnik & Linnainmaa (2019) — defensive quality
+- **File:** `arnott_2019_defensive_quality.py`
+- **Paper:** *Alice's Adventures in Factorland: Three Blunders That Plague Factor
+  Investing*, Journal of Portfolio Management, 2019.
+- **Anomaly:** a defensive/quality tilt informed by the paper's catalogue of naive
+  factor-investing blunders (using the market as a beta reference rather than
+  chasing raw factor backtests).
+- **Regime:** `bear` (defensive).
+- **v1 caveat:** the paper is a *critique-and-prescription* on factor investing, not
+  a single mechanical strategy; the implementation operationalizes its defensive
+  prescription. *(See file header.)*
+
+---
+
+## Sleeve: Risk-parity / allocation / volatility management
+
+These are **allocation overlays** — how to size and balance, not what single
+anomaly to chase.
+
+### Maillard, Roncalli & Teïletche (2010) — risk parity / inverse-volatility
+- **File:** `maillard_2010_risk_parity.py`
+- **Paper:** *The Properties of Equally Weighted Risk Contribution Portfolios*,
+  Journal of Portfolio Management, 2010.
+- **Anomaly:** size positions so each contributes **equal risk** (equal-risk
+  contribution / inverse-volatility), rather than equal capital — a diversification
+  overlay designed to hold across regimes.
+- **Regime:** `regime_neutral`.
+- **Relation to the optimizer:** this is the strategy-level cousin of the
+  Hierarchical Risk Parity objective documented in
+  [`methodology.md`](methodology.md) §11.
+
+### Moreira & Muir (2017) — volatility-managed portfolios ✅ *passes the gate*
+- **File:** `moreira_muir_2017_volatility_managed.py`
+- **Paper:** *Volatility-Managed Portfolios*, Journal of Finance, 2017.
+- **Anomaly:** scale exposure **inversely to recent realized volatility** — contract
+  in high-vol regimes, expand in calm ones. Reduces drawdowns and improves Sharpe
+  versus a static-exposure baseline; exploits the weak/negative relationship between
+  current volatility and next-period return.
+- **Regime:** `bear` (outperforms in bear/high-vol regimes).
+- **Status:** one of the two strategies that **passes all four admission gates**
+  today.
+- **v1 note:** the volatility signal is a rolling realized-volatility estimate (the
+  paper uses one-month realized vol). *(See file header.)*
+
+### Faber (2007) — SMA200 tactical asset allocation ✅ *passes the gate*
+- **File:** `faber_2007_sma200_timing.py`
+- **Paper:** *A Quantitative Approach to Tactical Asset Allocation*, Journal of
+  Wealth Management, 2007.
+- **Anomaly:** hold the asset while price is above its 200-day SMA; move to cash
+  (T-bills) when it falls below — a simple trend filter that cuts drawdowns.
+- **Regime:** `bull` (works in trending markets).
+- **Status:** one of the two strategies that **passes all four admission gates**
+  today.
+
+---
+
+## Sleeve: Seasonality
+
+### Ariel (1987) — turn-of-the-month effect
+- **File:** `ariel_1987_turn_of_month.py`
+- **Paper:** *A Monthly Effect in Stock Returns*, Journal of Financial Economics,
+  1987 (corroborated by Lakonishok & Smidt 1988).
+- **Anomaly:** essentially all of the market's cumulative gain over 1963–1981 accrued
+  in the first half of trading months; trade the turn-of-month window.
+- **Regime:** `regime_neutral`.
+- **v1 caveat:** a calendar-window strategy; the file notes `paper_claimed_*` are
+  null (the paper reports the effect, not a tradeable Sharpe). *(See file header.)*
+
+---
+
+## Sleeve: Baseline / capital preservation
+
+These are not alpha bets — they are the references everything else is measured
+against, and the defensive floor.
+
+### Buy-and-Hold baseline
+- **File:** `pipeline_buy_hold.py`
+- **Anchor:** internal baseline (no paper).
+- **Role:** the long-only SPY buy-and-hold benchmark against which paper-grounded
+  strategies are compared. Backtest results are **real**, regenerated via
+  `scripts/regen_buy_hold_fixture.py` over 2004-01-02 → 2026-04-30 (includes the
+  2008–09 crisis and the 2022 correction).
+- **Regime:** `bull` (long-only, bull-biased).
+
+### Capital Preservation — T-Bill / USYC allocation
+- **File:** `capital_preservation_tbill.py`
+- **Anchor:** internal (no paper); a short-duration Treasury / USYC proxy.
+- **Role:** the defensive baseline that works in any regime — the destination the
+  trend filters (Faber, Antonacci's absolute-momentum switch) rotate *into* when
+  risk-off. Maps naturally to the `fixed_income` / `conservative` risk profiles.
+- **Regime:** `regime_neutral` (defensive baseline).
+
+---
+
+## How to read this library
+
+- **Paper anchor strength varies and is disclosed.** Journal-of-Finance/JFE papers
+  (Jegadeesh–Titman, Moreira–Muir, Gatev et al., George–Hwang, Fama–French) are
+  stronger anchors than practitioner books (Bollinger, Connors–Alvarez) or
+  rules anchored on a *related* academic test (MACD/Donchian → Brock et al. 1992).
+- **`paper_claimed_*` null ≠ a weak strategy.** It means the source reported
+  t-stats/win-rates rather than a mechanical Sharpe/CAGR; the number we stand behind
+  is always the post-gate one on our own data.
+- **A paper anchor does not equal Tier-1 admission.** Only Faber 2007 and
+  Moreira–Muir 2017 pass all four gates today; the rest are honest `CANDIDATE`s with
+  their failing gate visible. See [`admission-criteria.md`](admission-criteria.md).
+- **Regime tags drive sizing, not just labeling.** A `bull`-tagged strategy is sized
+  down by the regime-conditional γ multiplier in `risk_off`/`crisis` regimes (see
+  [`methodology.md`](methodology.md) §10).


### PR DESCRIPTION
Adds docs/quant/: methodology, backtest-interpretation, admission-criteria, strategy-library + README. Thresholds transcribed from code/spec; internal links verified.