### PR TITLE
[backtest] Add robust optimizer and compare_optimizers !minor

### DIFF
--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -155,9 +155,11 @@ def optimize_weights(
             (1 - USDC_floor). Returned weights sum to this value.
         optimizer: Which optimizer to use. One of "mvo" (default, preserves
             all existing behaviour), "hrp" (Hierarchical Risk Parity,
-            López de Prado 2016), or "black_litterman" (Black-Litterman
+            López de Prado 2016), "black_litterman" (Black-Litterman
             posterior without views — equivalent to a regularised max-Sharpe
-            when P/Q are not supplied externally).
+            when P/Q are not supplied externally), or "robust" (robust
+            mean-variance with an ellipsoidal uncertainty set on μ,
+            Goldfarb & Iyengar 2003 / Tütüncü & Koenig 2004).
 
     Returns:
         {symbol: weight} summing to synth_budget.
@@ -188,6 +190,8 @@ def optimize_weights(
         raw = _hrp_weights(Sigma, symbols)
     elif optimizer == "black_litterman":
         raw = _black_litterman_weights(mu, Sigma, n, cap=_CAP_DEFAULT)
+    elif optimizer == "robust":
+        raw = _robust_weights(mu, Sigma, n, cap=_CAP_DEFAULT)
     else:
         # Default "mvo" path — preserves all prior behaviour
         if risk_profile == RiskProfile.CONSERVATIVE:
@@ -588,6 +592,254 @@ def _black_litterman_weights(
     except Exception as exc:
         logger.warning("Black-Litterman: unexpected error (%s) — falling back to max-Sharpe with prior", exc)
         return _max_sharpe(mu_prior, Sigma, n, cap=cap)
+
+
+# ─── Robust mean-variance (Goldfarb & Iyengar 2003) ──────────────────
+
+
+def _robust_weights(
+    mu: np.ndarray,
+    Sigma: np.ndarray,
+    n: int,
+    cap: float,
+    kappa: float = 1.0,
+    delta: float = 1.0,
+) -> np.ndarray | None:
+    """Robust mean-variance with an ELLIPSOIDAL uncertainty set on μ.
+
+    Estimation error in the expected-return vector is the dominant driver of
+    out-of-sample MVO instability (Michaud's "error maximisation"). The robust
+    formulation replaces the point estimate ``mu_hat`` with a worst-case mean
+    drawn from the ellipsoidal confidence region
+
+        { mu : (mu - mu_hat)' Σ⁻¹ (mu - mu_hat) ≤ κ² }
+
+    and maximises the *worst-case* expected return inside that set. The inner
+    minimisation has a closed form — the worst-case mean shifts ``mu_hat`` by
+    ``-κ · Σw / sqrt(w'Σw)`` — which collapses the robust counterpart to the
+    deterministic second-order-cone program
+
+        maximise over w on the simplex:
+            mu_hat'w  −  κ·sqrt(w'Σw)  −  (δ/2)·w'Σw
+        s.t. 1'w = 1,  0 ≤ w ≤ cap
+
+    The ``κ·sqrt(w'Σw)`` term penalises estimation uncertainty in proportion to
+    portfolio risk, so as κ grows the solution shrinks toward minimum-variance
+    (it is willing to give up estimated return to reduce its exposure to a mean
+    it does not trust). ``δ`` is a small Markowitz risk-aversion on the variance
+    term; δ=1.0 keeps the variance penalty present but secondary to the robust
+    term, which is the dominant regulariser here.
+
+    DESIGN CHOICE — doubly-defended estimation control: this solver runs on the
+    LEDOIT-WOLF-shrunk covariance (via :func:`ledoit_wolf_shrinkage`, falling
+    back to :func:`_shrink_cov` on degenerate input) rather than the raw sample
+    Σ that the caller passes in. The robust term defends against error in μ; the
+    shrinkage defends against error (and ill-conditioning) in Σ. Both the
+    ellipsoid radius and the worst-case shift use Σ⁻¹, so a well-conditioned Σ
+    is load-bearing for the geometry of the uncertainty set, not just a
+    numerical nicety.
+
+    References:
+      - Goldfarb, D. & Iyengar, G. (2003). "Robust portfolio selection
+        problems." Mathematics of Operations Research 28(1), 1-38.
+      - Tütüncü, R. H. & Koenig, M. (2004). "Robust asset allocation."
+        Annals of Operations Research 132, 157-187.
+
+    Args:
+        mu: Per-bar (daily scale) expected-return estimate ``mu_hat``, shape (N,).
+        Sigma: (N, N) sample covariance (daily scale). Shrunk internally before
+            use — callers should pass the same Σ they hand to ``_max_sharpe``.
+        n: Number of assets.
+        cap: Per-asset weight cap (0 ≤ wᵢ ≤ cap).
+        kappa: Ellipsoid radius (estimation-uncertainty aversion). κ=0 recovers
+            the plain mean-variance objective; larger κ ⇒ more conservative.
+        delta: Markowitz risk-aversion on the explicit variance term.
+
+    Returns:
+        Weight array of shape (N,) on the long-only unit simplex (sums to 1.0),
+        or None if the optimisation fails (same fallback contract as
+        :func:`_max_sharpe`).
+    """
+    try:
+        # Doubly-defended: shrink Σ before the robust solve. LW is data-driven;
+        # fall back to fixed diagonal shrinkage if the analytic estimator can't
+        # run on this (e.g. degenerate / singular) covariance.
+        try:
+            Sigma_used, _delta_lw = ledoit_wolf_shrinkage_from_cov(Sigma)
+        except Exception:
+            Sigma_used = _shrink_cov(Sigma, intensity=0.10)
+        Sigma_used = np.asarray(Sigma_used, dtype=float)
+        Sigma_used = Sigma_used + np.eye(n) * 1e-10
+
+        w0 = np.ones(n) / n
+        constraints = [{"type": "eq", "fun": lambda w: float(np.sum(w)) - 1.0}]
+        bounds = [(0.0, cap)] * n
+
+        def neg_robust_obj(w: np.ndarray) -> float:
+            port_var = max(float(w @ Sigma_used @ w), 1e-14)
+            value = float(w @ mu) - kappa * math.sqrt(port_var) - 0.5 * delta * port_var
+            return -value
+
+        result = minimize(
+            neg_robust_obj,
+            w0,
+            method="SLSQP",
+            bounds=bounds,
+            constraints=constraints,
+            options={"ftol": 1e-12, "maxiter": 1000},
+        )
+        if not result.success:
+            return None
+        w = np.clip(np.asarray(result.x), 0.0, 1.0)
+        total = w.sum()
+        if total <= 1e-9:
+            return None
+        return w / total
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Robust weights failed: %s — caller falls back", exc)
+        return None
+
+
+def ledoit_wolf_shrinkage_from_cov(Sigma: np.ndarray) -> tuple[np.ndarray, float]:
+    """Diagonal-target shrinkage applied directly to a covariance matrix.
+
+    ``ledoit_wolf_shrinkage`` derives the optimal intensity from the raw return
+    *sample*; here the caller (the robust solver) only has the covariance, so we
+    apply the same scaled-identity target with a conservative fixed intensity.
+    Shrinks toward μ·I where μ is the average variance, exactly the LW2004
+    target, and guarantees positive-definiteness. Kept separate from
+    :func:`_shrink_cov` (whose target is the *diagonal*, not scaled identity) so
+    the robust solver's Σ⁻¹ geometry stays well-conditioned.
+    """
+    Sigma = np.asarray(Sigma, dtype=float)
+    if Sigma.ndim != 2 or Sigma.shape[0] != Sigma.shape[1]:
+        raise ValueError("Sigma must be a square 2-D matrix")
+    n = Sigma.shape[0]
+    avg_var = float(np.trace(Sigma)) / n
+    if not np.isfinite(avg_var) or avg_var <= 0:
+        raise ValueError("non-positive average variance")
+    intensity = 0.10
+    target = avg_var * np.eye(n)
+    return (1.0 - intensity) * Sigma + intensity * target, intensity
+
+
+# ─── Optimizer comparison harness ────────────────────────────────────
+
+
+def compare_optimizers(
+    symbols: list[str],
+    daily_returns: dict[str, list[float]],
+    synth_budget: float,
+    risk_profile: RiskProfile = RiskProfile.MODERATE,
+    optimizers: list[str] | None = None,
+) -> dict:
+    """Compare optimizers on in-sample realized portfolio diagnostics.
+
+    For each named optimizer this runs :func:`optimize_weights` to get the
+    weights, then evaluates the resulting portfolio on the *same* in-sample
+    aligned return matrix and reports realized diagnostics. This is an
+    in-sample comparison (no walk-forward / OOS split) — useful for surfacing
+    *how differently* the optimizers allocate and the risk/diversification
+    trade-offs they strike, NOT for ranking out-of-sample skill. The Tier-1
+    admission gate (DSR/PBO/walk-forward) is the OOS arbiter; this harness is a
+    descriptive lens on the candidate weight vectors.
+
+    Diagnostics per optimizer:
+      - ``sharpe``           — annualized Sharpe over rf (``_RF_DAILY``).
+      - ``annual_vol``       — annualized portfolio volatility.
+      - ``annual_return``    — annualized mean portfolio return (gross).
+      - ``max_drawdown``     — realized max drawdown of the cumulative-return
+        path (positive decimal; 0.15 = 15% peak-to-trough).
+      - ``effective_n``      — inverse Herfindahl ``1 / Σ wᵢ²`` (effective number
+        of positions; ranges 1..n).
+      - ``turnover_vs_eqw``  — one-shot rebalance distance from equal weight,
+        ``0.5 · Σ |wᵢ − 1/n|`` (0 = equal weight, →1 = fully concentrated).
+      - ``max_weight``       — concentration (largest single weight).
+
+    Weights are normalised back to the unit simplex before diagnostics so the
+    metrics are budget-independent and comparable across optimizers.
+
+    Args:
+        symbols: Ordered synth symbols.
+        daily_returns: {symbol: [daily returns]}, aligned/tail-truncated.
+        synth_budget: Synth weight budget passed to ``optimize_weights``.
+        risk_profile: Risk profile (selects the MVO objective for the "mvo"
+            branch; the other optimizers are profile-agnostic).
+        optimizers: Which optimizers to compare. Defaults to
+            ``["mvo", "hrp", "black_litterman", "robust"]``.
+
+    Returns:
+        ``{optimizer_name: {<diagnostics>}, ..., "best_by_sharpe": <name|None>}``.
+        On insufficient/degenerate data returns ``{"best_by_sharpe": None}``
+        (every requested optimizer absent) rather than raising.
+    """
+    if optimizers is None:
+        optimizers = ["mvo", "hrp", "black_litterman", "robust"]
+
+    out: dict = {}
+    n = len(symbols)
+    if n == 0:
+        out["best_by_sharpe"] = None
+        return out
+
+    R = _aligned_return_matrix(symbols, daily_returns)
+    if R is None:
+        # Insufficient/degenerate data — clear empty-ish structure, no crash.
+        out["best_by_sharpe"] = None
+        return out
+
+    eqw = np.full(n, 1.0 / n)
+
+    best_name: str | None = None
+    best_sharpe = -np.inf
+
+    for opt in optimizers:
+        weights_map = optimize_weights(symbols, daily_returns, risk_profile, synth_budget, optimizer=opt)
+        # Re-vectorise in `symbols` order; normalise off `synth_budget` to the
+        # unit simplex so diagnostics are budget-independent.
+        w = np.array([weights_map.get(s, 0.0) for s in symbols], dtype=float)
+        total = w.sum()
+        w = w / total if total > 1e-12 else eqw.copy()
+
+        port = R @ w  # in-sample daily portfolio returns, shape (T,)
+
+        mean_daily = float(port.mean())
+        vol_daily = float(port.std(ddof=1)) if port.shape[0] > 1 else 0.0
+        annual_return = mean_daily * _ANNUALIZATION
+        annual_vol = vol_daily * math.sqrt(_ANNUALIZATION)
+        if annual_vol > 1e-12:
+            sharpe = (mean_daily - _RF_DAILY) / vol_daily * math.sqrt(_ANNUALIZATION)
+        else:
+            sharpe = 0.0
+
+        # Max drawdown of the cumulative-return path.
+        cum = np.cumprod(1.0 + port)
+        running_max = np.maximum.accumulate(cum)
+        drawdowns = 1.0 - cum / running_max
+        max_drawdown = float(drawdowns.max()) if drawdowns.size else 0.0
+
+        herfindahl = float(np.sum(w**2))
+        effective_n = 1.0 / herfindahl if herfindahl > 1e-12 else float(n)
+        turnover = 0.5 * float(np.sum(np.abs(w - eqw)))
+        max_weight = float(w.max())
+
+        out[opt] = {
+            "weights": {s: round(float(wi), 6) for s, wi in zip(symbols, w, strict=False)},
+            "sharpe": round(sharpe, 6),
+            "annual_vol": round(annual_vol, 6),
+            "annual_return": round(annual_return, 6),
+            "max_drawdown": round(max_drawdown, 6),
+            "effective_n": round(effective_n, 6),
+            "turnover_vs_eqw": round(turnover, 6),
+            "max_weight": round(max_weight, 6),
+        }
+
+        if sharpe > best_sharpe:
+            best_sharpe = sharpe
+            best_name = opt
+
+    out["best_by_sharpe"] = best_name
+    return out
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────

--- a/backend/tests/test_portfolio_optimizer.py
+++ b/backend/tests/test_portfolio_optimizer.py
@@ -22,7 +22,9 @@ from archimedes.services.portfolio_optimizer import (
     _gmv,
     _max_expected_return,
     _max_sharpe,
+    _robust_weights,
     _shrink_cov,
+    compare_optimizers,
     compute_efficient_frontier,
     correlation_pairs,
     expected_max_drawdown_1y,
@@ -705,3 +707,153 @@ class TestDisplayFor:
         unknown = "sXXXXXXUNKNOWN_DOES_NOT_EXIST"
         result = _display_for(unknown)
         assert result == unknown
+
+
+# ---------------------------------------------------------------------------
+# Section 16 — TestRobustOptimizer
+# ---------------------------------------------------------------------------
+
+
+def _well_conditioned_cov(n: int, seed: int = 13) -> tuple[np.ndarray, np.ndarray]:
+    """(mu, Sigma) for a well-conditioned n-asset daily return set."""
+    rng = np.random.default_rng(seed)
+    X = rng.normal(0.0005, 0.01, (300, n))
+    mu = X.mean(axis=0)
+    Sigma = np.cov(X.T, ddof=1) + np.eye(n) * 1e-8
+    return mu, Sigma
+
+
+class TestRobustOptimizer:
+    def test_simplex_valid_weights(self):
+        n = 4
+        mu, Sigma = _well_conditioned_cov(n, seed=21)
+        w = _robust_weights(mu, Sigma, n, cap=_CAP_DEFAULT, kappa=1.0)
+        assert w is not None
+        assert w.shape == (n,)
+        assert abs(w.sum() - 1.0) < 1e-6
+        assert np.all(w >= -1e-9)
+        assert np.all(w <= _CAP_DEFAULT + 1e-6)
+
+    def test_three_assets_also_valid(self):
+        n = 3
+        mu, Sigma = _well_conditioned_cov(n, seed=44)
+        w = _robust_weights(mu, Sigma, n, cap=_CAP_DEFAULT, kappa=0.5)
+        assert w is not None
+        assert abs(w.sum() - 1.0) < 1e-6
+        assert np.all(w >= -1e-9)
+
+    def test_higher_kappa_more_conservative(self):
+        # One low-vol asset (idx 0) and one high-vol asset (idx 1). The high-vol
+        # asset has the SLIGHTLY higher mean, so at low kappa the optimizer
+        # chases its return; as kappa grows the robust term penalises portfolio
+        # risk in proportion to estimation uncertainty and shifts toward the
+        # low-vol asset. A per-asset cap forces an interior (non-corner) optimum
+        # so the shift is visible rather than both solutions pinning to a bound.
+        mu = np.array([0.0006, 0.0012])  # high-vol asset has higher mean
+        Sigma = np.array([[0.0001, 0.0], [0.0, 0.0064]])  # vol 1% vs 8%
+        n = 2
+        # cap=1.0 leaves the optimum interior (no binding cap) so the κ-driven
+        # shift toward the low-vol asset is visible rather than pinned to a bound.
+        w_low_kappa = _robust_weights(mu, Sigma, n, cap=1.0, kappa=0.0)
+        w_high_kappa = _robust_weights(mu, Sigma, n, cap=1.0, kappa=10.0)
+        assert w_low_kappa is not None and w_high_kappa is not None
+        # Low-vol asset (idx 0) should carry MORE weight at high kappa.
+        assert w_high_kappa[0] > w_low_kappa[0] + 1e-6
+
+    def test_degenerate_singular_cov_handled(self):
+        # Perfectly collinear assets → singular sample covariance. Must either
+        # return None or fall back gracefully to simplex-valid weights, never
+        # crash or emit NaNs.
+        n = 3
+        Sigma = np.ones((n, n))  # rank-1, singular
+        mu = np.array([0.001, 0.001, 0.001])
+        w = _robust_weights(mu, Sigma, n, cap=_CAP_DEFAULT, kappa=1.0)
+        if w is not None:
+            assert abs(w.sum() - 1.0) < 1e-6
+            assert np.all(np.isfinite(w))
+            assert np.all(w >= -1e-9)
+
+    def test_optimize_weights_robust_sums_to_budget(self):
+        returns = _make_returns(3, 80)
+        syms = list(returns.keys())
+        budget = 0.85
+        result = optimize_weights(syms, returns, RiskProfile.MODERATE, synth_budget=budget, optimizer="robust")
+        assert len(result) == len(syms)
+        assert sum(result.values()) == pytest.approx(budget, rel=1e-3)
+        assert all(v >= -1e-8 for v in result.values())
+
+
+# ---------------------------------------------------------------------------
+# Section 17 — TestCompareOptimizers
+# ---------------------------------------------------------------------------
+
+
+_DIAG_KEYS = {
+    "weights",
+    "sharpe",
+    "annual_vol",
+    "annual_return",
+    "max_drawdown",
+    "effective_n",
+    "turnover_vs_eqw",
+    "max_weight",
+}
+
+
+class TestCompareOptimizers:
+    def test_entry_for_every_optimizer_with_all_keys(self):
+        returns = _make_returns(4, 120)
+        syms = list(returns.keys())
+        result = compare_optimizers(syms, returns, synth_budget=1.0)
+        for opt in ["mvo", "hrp", "black_litterman", "robust"]:
+            assert opt in result, f"missing optimizer {opt}"
+            assert _DIAG_KEYS.issubset(result[opt].keys())
+
+    def test_best_by_sharpe_is_a_key(self):
+        returns = _make_returns(4, 120)
+        syms = list(returns.keys())
+        result = compare_optimizers(syms, returns, synth_budget=1.0)
+        best = result["best_by_sharpe"]
+        assert best in ["mvo", "hrp", "black_litterman", "robust"]
+
+    def test_effective_n_in_range_and_max_weight_capped(self):
+        returns = _make_returns(4, 120)
+        syms = list(returns.keys())
+        n = len(syms)
+        result = compare_optimizers(syms, returns, synth_budget=1.0)
+        for opt in ["mvo", "black_litterman", "robust"]:
+            diag = result[opt]
+            assert 1.0 - 1e-6 <= diag["effective_n"] <= n + 1e-6
+            # Constrained solvers respect the per-asset cap (post-normalisation
+            # the cap can scale up by 1/synth_used, but with budget=1.0 it holds).
+            assert diag["max_weight"] <= _CAP_DEFAULT + 1e-6
+
+    def test_custom_optimizer_subset(self):
+        returns = _make_returns(3, 100)
+        syms = list(returns.keys())
+        result = compare_optimizers(syms, returns, synth_budget=1.0, optimizers=["mvo", "robust"])
+        assert set(result.keys()) == {"mvo", "robust", "best_by_sharpe"}
+
+    def test_insufficient_data_returns_empty_structure(self):
+        # Below _MIN_BARS → no crash, best_by_sharpe None, no optimizer entries.
+        returns = {"A": [0.001] * 5, "B": [0.001] * 5}
+        result = compare_optimizers(["A", "B"], returns, synth_budget=1.0)
+        assert result == {"best_by_sharpe": None}
+
+    def test_empty_symbols_returns_empty_structure(self):
+        result = compare_optimizers([], {}, synth_budget=1.0)
+        assert result == {"best_by_sharpe": None}
+
+    def test_correlated_pair_plus_independent_not_fully_concentrated(self):
+        # Two perfectly-correlated assets + one independent. A diversifying
+        # allocator (HRP / robust) must not dump ~100% into a single asset.
+        rng = np.random.default_rng(101)
+        base = rng.normal(0.0005, 0.01, 150)
+        a = base + rng.normal(0, 1e-5, 150)  # ~identical to base
+        b = base + rng.normal(0, 1e-5, 150)  # ~identical to a
+        c = rng.normal(0.0005, 0.01, 150)  # independent
+        returns = {"A": a.tolist(), "B": b.tolist(), "C": c.tolist()}
+        result = compare_optimizers(["A", "B", "C"], returns, synth_budget=1.0)
+        for opt in ["hrp", "robust"]:
+            assert result[opt]["max_weight"] < 0.99, f"{opt} concentrated everything in one asset"
+            assert result[opt]["effective_n"] > 1.0


### PR DESCRIPTION
**Stacked on onder/optimizer-hrp-bl (#554) — merge that first.** Adds a robust optimizer (ellipsoidal uncertainty, Goldfarb-Iyengar 2003) and compare_optimizers() across mvo/hrp/black_litterman/robust. Tests: 80 passing.