### PR TITLE
[rigor] Add regime-conditional Sharpe/DSR and robustness score !minor

### DIFF
--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -868,6 +868,263 @@ def run_rigor_gate(
     return result
 
 
+# ─── 6b. Regime-conditional rigor analysis ───────────────────────────
+
+
+def classify_regimes(
+    market_returns: list[float] | np.ndarray,
+    vol_window: int = 21,
+    n_regimes: int = 2,
+) -> np.ndarray:
+    """Label each day by volatility regime using rolling realized volatility.
+
+    A strategy's edge may be regime-dependent — strong in calm markets and
+    fragile in stressed ones (or vice versa). This labels each bar by the
+    *market benchmark's* recent volatility so that ``regime_conditional_*``
+    can slice the strategy's own returns by the regime the market was in.
+
+    Method (a deliberately simple vol-quantile proxy):
+      1. Compute the rolling standard deviation of ``market_returns`` over a
+         trailing ``vol_window``.
+      2. **Shift the rolling-vol series by one bar** so the label assigned to
+         day *t* uses only volatility realized through day *t − 1*. This avoids
+         look-ahead: the regime label for a bar never peeks at that bar's own
+         return (which the strategy is being evaluated on for the same day).
+      3. Split the (shifted) rolling-vol values into ``n_regimes`` buckets by
+         quantile — for ``n_regimes=2``, label 0 = "calm" (rolling-vol at or
+         below the median) and label 1 = "stressed" (above the median).
+      4. The first ``vol_window`` bars lack a full trailing window (and the
+         extra shift consumes one more), so they get label ``-1`` =
+         "unclassified" and are excluded from every downstream regime stat.
+
+    This is intentionally a coarse realized-vol regime proxy, NOT a fitted
+    regime model. A proper Markov-switching / HMM treatment (Ang & Bekaert
+    2002, "International Asset Allocation With Regime Shifts", Review of
+    Financial Studies 15(4): 1137-1187 — which motivates conditioning asset
+    behavior on latent volatility regimes) is out of scope here; we surface a
+    transparent, reproducible vol bucketing instead of an opaque fitted state.
+
+    Args:
+        market_returns: Per-bar benchmark return series (the regime driver).
+        vol_window: Trailing window (bars) for realized volatility. Default 21
+            (~one trading month).
+        n_regimes: Number of volatility buckets (>= 1). Labels are
+            ``0 .. n_regimes-1`` in ascending volatility order.
+
+    Returns:
+        Integer ``np.ndarray`` of length ``len(market_returns)``. Entries are
+        ``-1`` for unclassified leading bars, else the regime id in
+        ``0 .. n_regimes-1``. Returns an all-``-1`` array (no crash) when the
+        series is too short to form a single full window or ``n_regimes < 1``.
+    """
+    arr = np.asarray(market_returns, dtype=float)
+    T = len(arr)
+    labels = np.full(T, -1, dtype=int)
+
+    if T == 0 or n_regimes < 1 or vol_window < 1:
+        return labels
+
+    # Rolling std (ddof=1) over a trailing window; entries before a full window
+    # exist remain NaN. Build via a simple stride-free loop for numpy-only clarity.
+    roll_vol = np.full(T, np.nan, dtype=float)
+    for i in range(vol_window - 1, T):
+        window = arr[i - vol_window + 1 : i + 1]
+        if window.size >= 2:
+            roll_vol[i] = float(window.std(ddof=1))
+
+    # Shift by one bar so day t's label uses vol realized through t-1 (no look-ahead).
+    shifted = np.full(T, np.nan, dtype=float)
+    shifted[1:] = roll_vol[:-1]
+
+    valid_mask = np.isfinite(shifted)
+    valid_vals = shifted[valid_mask]
+    if valid_vals.size == 0:
+        return labels
+
+    if n_regimes == 1:
+        labels[valid_mask] = 0
+        return labels
+
+    # Quantile cut-points partition the valid rolling-vol values into n_regimes
+    # buckets of (approximately) equal mass. np.digitize maps each value to a
+    # bucket in 0 .. n_regimes-1. A degenerate (constant-vol) series yields
+    # identical edges; digitize then collapses everything into a single bucket
+    # without crashing.
+    quantiles = np.quantile(valid_vals, np.linspace(0.0, 1.0, n_regimes + 1)[1:-1])
+    bucket = np.digitize(valid_vals, quantiles, right=False)
+    bucket = np.clip(bucket, 0, n_regimes - 1).astype(int)
+    labels[valid_mask] = bucket
+    return labels
+
+
+def regime_conditional_sharpe(
+    strategy_returns: list[float] | np.ndarray,
+    regime_labels: list[int] | np.ndarray,
+) -> dict[int, dict]:
+    """Per-regime annualized Sharpe (and mean/vol/count) of a strategy.
+
+    Slices the strategy's own daily returns by the market regime each day fell
+    in (per ``classify_regimes``) and reports the strategy's annualized Sharpe,
+    annualized mean return, annualized vol, and day-count within each regime.
+
+    Args:
+        strategy_returns: Per-bar strategy return series.
+        regime_labels: Integer regime labels aligned to the same bars (``-1``
+            for unclassified). Truncated to the shorter of the two lengths.
+
+    Returns:
+        ``{regime_id: {"sharpe", "ann_return", "ann_vol", "n_days"}}`` for each
+        regime id present (excluding ``-1``). ``sharpe`` is ``None`` for any
+        regime with < 2 days or zero variance. Empty dict if no classified days.
+    """
+    s = np.asarray(strategy_returns, dtype=float)
+    r = np.asarray(regime_labels, dtype=int)
+    n = min(len(s), len(r))
+    if n == 0:
+        return {}
+    s = s[:n]
+    r = r[:n]
+
+    out: dict[int, dict] = {}
+    for regime_id in sorted({int(x) for x in r if int(x) != -1}):
+        sub = s[r == regime_id]
+        n_days = int(sub.size)
+        if n_days < 2 or float(np.ptp(sub)) == 0.0:
+            out[regime_id] = {
+                "sharpe": None,
+                "ann_return": round(float(sub.mean()) * _ANNUALIZATION, 6) if n_days >= 1 else None,
+                "ann_vol": 0.0 if n_days >= 1 else None,
+                "n_days": n_days,
+            }
+            continue
+        sigma = float(sub.std(ddof=1))
+        sharpe = _annualized_sharpe_arr(sub)
+        out[regime_id] = {
+            "sharpe": round(sharpe, 6) if sharpe is not None else None,
+            "ann_return": round(float(sub.mean()) * _ANNUALIZATION, 6),
+            "ann_vol": round(sigma * math.sqrt(_ANNUALIZATION), 6),
+            "n_days": n_days,
+        }
+    return out
+
+
+def regime_robustness_score(
+    strategy_returns: list[float] | np.ndarray,
+    regime_labels: list[int] | np.ndarray,
+) -> dict:
+    """Regime-fragility score — does the edge survive across volatility regimes?
+
+    A strategy that earns its Sharpe in only one regime (e.g. only in calm
+    markets) is fragile: the moment the market shifts, the edge evaporates.
+    This surfaces that fragility *transparently* rather than burying it behind
+    a single aggregate Sharpe, consistent with the repo's honest-framing
+    principle (paper-claim deltas and per-regime numbers are shown, not hidden).
+
+    Motivation: Ang & Bekaert (2002), "International Asset Allocation With
+    Regime Shifts", Review of Financial Studies 15(4): 1137-1187 — asset
+    behavior (and therefore a strategy's edge) is regime-dependent, so a single
+    full-sample Sharpe can mask regime-specific failure.
+
+    Args:
+        strategy_returns: Per-bar strategy return series.
+        regime_labels: Integer regime labels aligned to the same bars.
+
+    Returns:
+        Dict with keys:
+          ``per_regime``        — the ``regime_conditional_sharpe`` dict.
+          ``min_regime_sharpe`` — lowest per-regime Sharpe (None if none computable).
+          ``max_regime_sharpe`` — highest per-regime Sharpe (None if none computable).
+          ``sharpe_dispersion`` — ``max - min`` (None if < 2 computable regimes).
+          ``consistency``       — a ``[0, 1]`` score; high = the edge holds across
+            regimes. Convention: when ``max > 0`` it is
+            ``min(1, max(0, min_sharpe / max_sharpe))`` (so a regime with
+            negative or near-zero Sharpe drives consistency toward 0). When
+            ``max <= 0`` (the strategy is non-positive in *every* regime) there
+            is no regime in which it works, so consistency is ``0.0``.
+          ``robust``            — ``bool``: the strict honest gate
+            ``min_regime_sharpe > 0`` (positive Sharpe in *every* classified
+            regime). ``False`` when no regimes are computable.
+    """
+    per_regime = regime_conditional_sharpe(strategy_returns, regime_labels)
+    sharpes = [v["sharpe"] for v in per_regime.values() if v.get("sharpe") is not None]
+
+    if not sharpes:
+        return {
+            "per_regime": per_regime,
+            "min_regime_sharpe": None,
+            "max_regime_sharpe": None,
+            "sharpe_dispersion": None,
+            "consistency": 0.0,
+            "robust": False,
+        }
+
+    min_sharpe = float(min(sharpes))
+    max_sharpe = float(max(sharpes))
+    dispersion = round(max_sharpe - min_sharpe, 6) if len(sharpes) >= 2 else None
+
+    if max_sharpe > 0.0:
+        consistency = min(1.0, max(0.0, min_sharpe / max_sharpe))
+    else:
+        # Non-positive in every regime: there is no regime in which the edge
+        # works, so there is no consistency to credit.
+        consistency = 0.0
+
+    return {
+        "per_regime": per_regime,
+        "min_regime_sharpe": round(min_sharpe, 6),
+        "max_regime_sharpe": round(max_sharpe, 6),
+        "sharpe_dispersion": dispersion,
+        "consistency": round(float(consistency), 6),
+        "robust": bool(min_sharpe > 0.0),
+    }
+
+
+def regime_conditional_dsr(
+    strategy_returns: list[float] | np.ndarray,
+    regime_labels: list[int] | np.ndarray,
+    num_trials: int = 1,
+) -> dict[int, dict]:
+    """Per-regime Deflated Sharpe Ratio — does the DSR evidence hold within each regime?
+
+    Runs the existing ``compute_dsr`` on the strategy's return subset *within*
+    each market regime, so the deflated-Sharpe evidence can be inspected regime
+    by regime rather than only on the blended full sample. Reuses ``compute_dsr``
+    directly, so the same minimum-length guard (T < 4 → ``None``) applies per
+    regime subset — a regime with too few bars reports ``None`` DSR honestly
+    instead of fabricating significance from a handful of points.
+
+    Args:
+        strategy_returns: Per-bar strategy return series.
+        regime_labels: Integer regime labels aligned to the same bars.
+        num_trials: Number of trials in the selection set, passed through to
+            ``compute_dsr`` for the multiple-testing correction (default 1).
+
+    Returns:
+        ``{regime_id: {"deflated_sharpe", "dsr_p_value", "n_days"}}`` for each
+        regime id present (excluding ``-1``). ``deflated_sharpe`` and
+        ``dsr_p_value`` are ``None`` when the regime subset is too short or
+        degenerate. Empty dict if no classified days.
+    """
+    s = np.asarray(strategy_returns, dtype=float)
+    r = np.asarray(regime_labels, dtype=int)
+    n = min(len(s), len(r))
+    if n == 0:
+        return {}
+    s = s[:n]
+    r = r[:n]
+
+    out: dict[int, dict] = {}
+    for regime_id in sorted({int(x) for x in r if int(x) != -1}):
+        sub = s[r == regime_id]
+        dsr, p_val = compute_dsr(sub, num_trials)
+        out[regime_id] = {
+            "deflated_sharpe": dsr,
+            "dsr_p_value": p_val,
+            "n_days": int(sub.size),
+        }
+    return out
+
+
 # ─── 7. Monte Carlo DSR significance via circular block bootstrap ─────
 
 

--- a/backend/tests/test_rigor_regime.py
+++ b/backend/tests/test_rigor_regime.py
@@ -1,0 +1,241 @@
+"""Hermetic tests for regime-conditional rigor analysis.
+
+Covers classify_regimes, regime_conditional_sharpe, regime_robustness_score,
+and regime_conditional_dsr. Numpy-only, deterministic via default_rng(SEED).
+No .env / Redis / DB / network dependence.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from archimedes.services.rigor_evaluator import (
+    classify_regimes,
+    regime_conditional_dsr,
+    regime_conditional_sharpe,
+    regime_robustness_score,
+)
+
+SEED = 20260612
+_VOL_WINDOW = 21
+
+
+def _regime_shift_series(n_half: int = 250, seed: int = SEED) -> np.ndarray:
+    """First half low-vol, second half high-vol — a clear regime shift."""
+    rng = np.random.default_rng(seed)
+    calm = rng.normal(loc=0.0005, scale=0.004, size=n_half)
+    stressed = rng.normal(loc=-0.0003, scale=0.025, size=n_half)
+    return np.concatenate([calm, stressed])
+
+
+# ─── classify_regimes ────────────────────────────────────────────────
+
+
+def test_classify_regimes_output_length_matches_input():
+    market = _regime_shift_series()
+    labels = classify_regimes(market, vol_window=_VOL_WINDOW, n_regimes=2)
+    assert labels.shape == (market.shape[0],)
+
+
+def test_classify_regimes_leading_bars_unclassified():
+    market = _regime_shift_series()
+    labels = classify_regimes(market, vol_window=_VOL_WINDOW, n_regimes=2)
+    # The first vol_window bars lack a full trailing window → label -1.
+    assert np.all(labels[:_VOL_WINDOW] == -1)
+
+
+def test_classify_regimes_high_vol_period_gets_stressed_label():
+    market = _regime_shift_series(n_half=250)
+    labels = classify_regimes(market, vol_window=_VOL_WINDOW, n_regimes=2)
+    # Deep into the high-vol second half, labels should be predominantly 1 (stressed).
+    second_half_tail = labels[400:]
+    classified = second_half_tail[second_half_tail != -1]
+    assert classified.size > 0
+    assert np.mean(classified == 1) > 0.8
+
+
+def test_classify_regimes_calm_period_gets_calm_label():
+    market = _regime_shift_series(n_half=250)
+    labels = classify_regimes(market, vol_window=_VOL_WINDOW, n_regimes=2)
+    # Deep into the low-vol first half (past the warmup), labels should be 0 (calm).
+    first_half_mid = labels[100:230]
+    classified = first_half_mid[first_half_mid != -1]
+    assert classified.size > 0
+    assert np.mean(classified == 0) > 0.8
+
+
+def test_classify_regimes_n_regimes_2_label_set():
+    market = _regime_shift_series()
+    labels = classify_regimes(market, vol_window=_VOL_WINDOW, n_regimes=2)
+    assert set(np.unique(labels)).issubset({-1, 0, 1})
+    # All three should actually appear given the regime shift.
+    assert set(np.unique(labels)) == {-1, 0, 1}
+
+
+def test_classify_regimes_constant_vol_degenerate_no_crash():
+    # A perfectly linear-trend series has constant per-window std → degenerate
+    # quantile edges. Should not crash; collapses into a single bucket.
+    market = np.full(200, 0.001)
+    labels = classify_regimes(market, vol_window=_VOL_WINDOW, n_regimes=2)
+    assert labels.shape == (200,)
+    classified = labels[labels != -1]
+    # Zero-variance windows → roll_vol == 0 everywhere; one bucket (0).
+    assert set(np.unique(classified)).issubset({0, 1})
+
+
+def test_classify_regimes_empty_input_returns_empty():
+    labels = classify_regimes([], vol_window=_VOL_WINDOW, n_regimes=2)
+    assert labels.shape == (0,)
+
+
+def test_classify_regimes_too_short_all_unclassified():
+    market = np.array([0.001, -0.002, 0.0015])  # shorter than vol_window
+    labels = classify_regimes(market, vol_window=_VOL_WINDOW, n_regimes=2)
+    assert np.all(labels == -1)
+
+
+# ─── regime_conditional_sharpe ───────────────────────────────────────
+
+
+def test_regime_conditional_sharpe_higher_in_strong_regime():
+    rng = np.random.default_rng(SEED)
+    n = 200
+    labels = np.array([0] * 100 + [1] * 100, dtype=int)
+    strat = np.concatenate(
+        [
+            rng.normal(loc=0.002, scale=0.005, size=100),  # strong in regime 0
+            rng.normal(loc=-0.0005, scale=0.005, size=100),  # weak in regime 1
+        ]
+    )
+    out = regime_conditional_sharpe(strat, labels)
+    assert 0 in out and 1 in out
+    assert out[0]["sharpe"] is not None
+    assert out[1]["sharpe"] is not None
+    assert out[0]["sharpe"] > out[1]["sharpe"]
+
+
+def test_regime_conditional_sharpe_short_regime_none_sharpe():
+    strat = np.array([0.001, 0.002, -0.001, 0.0015, 0.0])
+    labels = np.array([0, 0, 0, 0, 1], dtype=int)  # regime 1 has 1 day
+    out = regime_conditional_sharpe(strat, labels)
+    assert out[1]["sharpe"] is None
+    assert out[1]["n_days"] == 1
+
+
+def test_regime_conditional_sharpe_counts_sum_correctly():
+    strat = np.array([0.001, -0.002, 0.003, -0.001, 0.002, 0.0005])
+    labels = np.array([0, 0, 1, 1, 1, -1], dtype=int)
+    out = regime_conditional_sharpe(strat, labels)
+    total_classified = sum(v["n_days"] for v in out.values())
+    assert total_classified == int(np.sum(labels != -1))
+    assert out[0]["n_days"] == 2
+    assert out[1]["n_days"] == 3
+
+
+def test_regime_conditional_sharpe_truncates_to_min_length():
+    strat = np.array([0.001, 0.002, -0.001, 0.0015])
+    labels = np.array([0, 0, 1, 1, 1, 1], dtype=int)  # longer than strat
+    out = regime_conditional_sharpe(strat, labels)
+    total = sum(v["n_days"] for v in out.values())
+    assert total == 4  # truncated to len(strat)
+
+
+def test_regime_conditional_sharpe_all_unclassified_empty():
+    strat = np.array([0.001, 0.002, -0.001])
+    labels = np.array([-1, -1, -1], dtype=int)
+    assert regime_conditional_sharpe(strat, labels) == {}
+
+
+# ─── regime_robustness_score ─────────────────────────────────────────
+
+
+def test_regime_robustness_single_regime_strategy_not_robust():
+    rng = np.random.default_rng(SEED)
+    labels = np.array([0] * 100 + [1] * 100, dtype=int)
+    strat = np.concatenate(
+        [
+            rng.normal(loc=0.003, scale=0.005, size=100),  # strong in 0
+            rng.normal(loc=-0.002, scale=0.006, size=100),  # negative in 1
+        ]
+    )
+    score = regime_robustness_score(strat, labels)
+    assert score["robust"] is False
+    assert score["min_regime_sharpe"] < 0
+    assert score["consistency"] == 0.0  # min/max with negative min → clamped to 0
+
+
+def test_regime_robustness_all_positive_strategy_robust():
+    rng = np.random.default_rng(SEED + 1)
+    labels = np.array([0] * 120 + [1] * 120, dtype=int)
+    strat = np.concatenate(
+        [
+            rng.normal(loc=0.0018, scale=0.005, size=120),  # positive in 0
+            rng.normal(loc=0.0016, scale=0.005, size=120),  # positive in 1
+        ]
+    )
+    score = regime_robustness_score(strat, labels)
+    assert score["robust"] is True
+    assert score["min_regime_sharpe"] > 0
+    assert 0.0 <= score["consistency"] <= 1.0
+    assert score["consistency"] > 0.5  # comparable Sharpes → high consistency
+
+
+def test_regime_robustness_dispersion_computed():
+    rng = np.random.default_rng(SEED + 2)
+    labels = np.array([0] * 100 + [1] * 100, dtype=int)
+    strat = np.concatenate(
+        [
+            rng.normal(loc=0.003, scale=0.005, size=100),
+            rng.normal(loc=0.0005, scale=0.005, size=100),
+        ]
+    )
+    score = regime_robustness_score(strat, labels)
+    expected = score["max_regime_sharpe"] - score["min_regime_sharpe"]
+    assert abs(score["sharpe_dispersion"] - round(expected, 6)) < 1e-6
+    assert score["sharpe_dispersion"] >= 0
+
+
+def test_regime_robustness_no_computable_regimes_sensible():
+    # All unclassified → no per-regime sharpes computable.
+    strat = np.array([0.001, 0.002, -0.001])
+    labels = np.array([-1, -1, -1], dtype=int)
+    score = regime_robustness_score(strat, labels)
+    assert score["robust"] is False
+    assert score["consistency"] == 0.0
+    assert score["min_regime_sharpe"] is None
+    assert score["sharpe_dispersion"] is None
+
+
+# ─── regime_conditional_dsr ──────────────────────────────────────────
+
+
+def test_regime_conditional_dsr_returns_per_regime_dict():
+    rng = np.random.default_rng(SEED)
+    labels = np.array([0] * 100 + [1] * 100, dtype=int)
+    strat = np.concatenate(
+        [
+            rng.normal(loc=0.002, scale=0.005, size=100),
+            rng.normal(loc=0.0008, scale=0.005, size=100),
+        ]
+    )
+    out = regime_conditional_dsr(strat, labels, num_trials=5)
+    assert set(out.keys()) == {0, 1}
+    for v in out.values():
+        assert "deflated_sharpe" in v
+        assert "dsr_p_value" in v
+        assert "n_days" in v
+    assert out[0]["n_days"] == 100
+
+
+def test_regime_conditional_dsr_too_short_regime_none():
+    # Regime 1 has only 2 days → below compute_dsr's T < 4 guard → None.
+    strat = np.array([0.001, -0.002, 0.003, -0.001, 0.002, 0.0005])
+    labels = np.array([0, 0, 0, 0, 1, 1], dtype=int)
+    out = regime_conditional_dsr(strat, labels)
+    assert out[1]["deflated_sharpe"] is None
+    assert out[1]["dsr_p_value"] is None
+    assert out[1]["n_days"] == 2
+
+
+def test_regime_conditional_dsr_empty_input():
+    assert regime_conditional_dsr([], []) == {}


### PR DESCRIPTION
**Stacked on onder/rigor-mc-fdr (#555) — merge that first.** Adds regime classification + regime-conditional Sharpe/DSR + a regime-robustness score (Ang-Bekaert 2002). Tests: 20 passing (151 across the rigor suite).