### PR TITLE
[backtest] Add run_parallel_backtest strategy×universe runner !minor

### DIFF
--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -874,3 +874,142 @@ def walk_forward_validate(
         "passes_cliff_gate": passes_cliff_gate,
         "n_splits": len(splits),
     }
+
+
+# ─── parallel multi-strategy backtest runner ─────────────────────────
+
+
+# Keys of a job dict that are forwarded verbatim to ``backtest_portfolio``.
+# Everything else (e.g. ``label``) is metadata used only by the runner.
+_JOB_BACKTEST_KEYS = {
+    "strategy_id",
+    "weights",
+    "start_date",
+    "end_date",
+    "rebalance_days",
+    "initial_cash",
+    "tx_cost_bps",
+    "num_trials_for_dsr",
+    "paper_claimed_sharpe",
+    "paper_title",
+}
+
+# Scalar metrics copied out of each BacktestResult into the runner summary.
+_JOB_REPORTED_METRICS = ("sharpe_ratio", "cagr", "max_drawdown", "sortino_ratio", "volatility")
+
+
+def _run_backtest_job(job: dict[str, Any]) -> dict[str, Any]:
+    """Run a single backtest job and reduce it to a picklable summary dict.
+
+    Module-level (not a closure) so it is picklable by ``ProcessPoolExecutor``
+    under the macOS/Windows spawn start-method — the parallel path therefore
+    actually executes rather than failing to pickle a nested function. A failed
+    backtest is captured as ``{"ok": False, "error": ...}`` rather than raised,
+    so one bad job never aborts the whole sweep.
+    """
+    label = job.get("label") or job.get("strategy_id") or "job"
+    kwargs = {k: v for k, v in job.items() if k in _JOB_BACKTEST_KEYS}
+    try:
+        result, _ = backtest_portfolio(**kwargs)
+        metrics = {m: float(getattr(result, m, float("nan")) or float("nan")) for m in _JOB_REPORTED_METRICS}
+        return {"label": label, "ok": True, "error": None, **metrics}
+    except Exception as exc:  # noqa: BLE001 — non-fatal per-job failure, surfaced in the result
+        logger.debug("run_parallel_backtest job %s failed: %s", label, exc)
+        return {
+            "label": label,
+            "ok": False,
+            "error": str(exc),
+            **{m: float("nan") for m in _JOB_REPORTED_METRICS},
+        }
+
+
+def run_parallel_backtest(
+    *,
+    jobs: list[dict[str, Any]],
+    metric: str = "sharpe_ratio",
+    n_workers: int = 1,
+) -> dict[str, Any]:
+    """Backtest many independent strategy/universe combinations and rank them.
+
+    This is the strategy×universe analogue of ``sensitivity_sweep``: where the
+    sweep varies *parameters* of one strategy on one universe, this runs a list
+    of fully-independent backtests (different strategies, different ticker
+    universes, or both) and produces a ranked comparison. It is the runner used
+    when promoting a batch of CANDIDATE strategies, or when comparing one
+    strategy across several candidate universes, in a single call.
+
+    Each job is a dict forwarded to ``backtest_portfolio``; only the keys in
+    ``_JOB_BACKTEST_KEYS`` are passed through (``strategy_id`` and ``weights``
+    are the minimum). An optional ``"label"`` key names the row in the output;
+    it defaults to ``strategy_id``. The "universe" is implicit in each job's
+    ``weights`` (the set of tickers it allocates to) — the backtester has no
+    separate universe object, so we do not invent one.
+
+    Args:
+        jobs: List of job dicts. Each must contain ``strategy_id`` and
+            ``weights``; may additionally set any of ``start_date``,
+            ``end_date``, ``rebalance_days``, ``initial_cash``, ``tx_cost_bps``,
+            ``num_trials_for_dsr``, ``paper_claimed_sharpe``, ``paper_title``,
+            plus an optional ``label``.
+        metric: Scalar metric used for ranking (one of ``_JOB_REPORTED_METRICS``;
+            ``"sharpe_ratio"`` default). ``max_drawdown`` ranks ascending (less
+            negative / smaller magnitude is better); all others rank descending.
+        n_workers: Worker processes (``ProcessPoolExecutor``). Default 1
+            (sequential). >1 parallelises the per-job market-data fetch +
+            simulation; because network I/O dominates a cold run, it mainly
+            helps when the price cache is warm (e.g. a re-rank over the same
+            universes). Result ordering is independent of ``n_workers``.
+
+    Returns:
+        dict with keys:
+            ``"results"`` — per-job dicts ``{label, ok, error, <metrics...>}``,
+                in the **input order** of ``jobs`` (stable regardless of worker
+                completion order)
+            ``"metric"`` — the ranking metric name
+            ``"ranking"`` — list of labels, best→worst on ``metric`` (failed and
+                NaN-metric jobs are excluded)
+            ``"best"`` / ``"worst"`` — best/worst label (None if none succeeded)
+            ``"n_jobs"`` / ``"n_ok"`` / ``"n_failed"`` — job counts
+
+    Raises:
+        ValueError: if ``jobs`` is empty, if ``metric`` is not a reported
+            metric, or if any job is missing ``strategy_id``/``weights``.
+    """
+    from concurrent.futures import ProcessPoolExecutor
+
+    if not jobs:
+        raise ValueError("jobs must contain at least one backtest job")
+    if metric not in _JOB_REPORTED_METRICS:
+        raise ValueError(f"metric must be one of {_JOB_REPORTED_METRICS}, got {metric!r}")
+    for i, job in enumerate(jobs):
+        if "strategy_id" not in job or "weights" not in job:
+            raise ValueError(f"jobs[{i}] must contain 'strategy_id' and 'weights'")
+
+    if n_workers > 1:
+        # Map preserves input order, so ``results`` is deterministic regardless
+        # of which worker finishes first.
+        with ProcessPoolExecutor(max_workers=n_workers) as pool:
+            results = list(pool.map(_run_backtest_job, jobs))
+    else:
+        results = [_run_backtest_job(job) for job in jobs]
+
+    def _valid(r: dict[str, Any]) -> bool:
+        v = r.get(metric, float("nan"))
+        return bool(r["ok"]) and isinstance(v, float) and v == v  # not NaN
+
+    ranked = [r for r in results if _valid(r)]
+    # max_drawdown is negative/zero — the largest (closest to 0) is best.
+    reverse = metric != "max_drawdown"
+    ranked.sort(key=lambda r: r[metric], reverse=reverse)
+
+    n_ok = sum(1 for r in results if r["ok"])
+    return {
+        "results": results,
+        "metric": metric,
+        "ranking": [r["label"] for r in ranked],
+        "best": ranked[0]["label"] if ranked else None,
+        "worst": ranked[-1]["label"] if ranked else None,
+        "n_jobs": len(jobs),
+        "n_ok": n_ok,
+        "n_failed": len(jobs) - n_ok,
+    }

--- a/backend/tests/test_portfolio_backtester_mc.py
+++ b/backend/tests/test_portfolio_backtester_mc.py
@@ -289,3 +289,169 @@ class TestWalkForwardValidate:
                 end_date="2023-03-01",  # only ~60 days
                 n_splits=5,
             )
+
+
+# ─── run_parallel_backtest (mocked, sequential) ──────────────────────
+
+
+class TestRunParallelBacktest:
+    """Tests for run_parallel_backtest.
+
+    All tests use n_workers=1 so they stay hermetic: patching
+    ``backtest_portfolio`` only affects the parent process, and the sequential
+    path runs ``_run_backtest_job`` in-process where the patch is visible. The
+    parallel (n_workers>1) path re-imports the module in spawned children and
+    would bypass the mock + hit the network, so it is not exercised here.
+    """
+
+    def _mock_result(self, sharpe: float, cagr: float = 0.1, max_dd: float = 0.2) -> MagicMock:
+        r = MagicMock()
+        r.sharpe_ratio = sharpe
+        r.cagr = cagr
+        r.max_drawdown = max_dd
+        r.sortino_ratio = sharpe * 1.2
+        r.volatility = 0.15
+        return r
+
+    def test_raises_on_empty_jobs(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        with pytest.raises(ValueError, match="at least one"):
+            run_parallel_backtest(jobs=[])
+
+    def test_raises_on_bad_metric(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        with pytest.raises(ValueError, match="metric must be one of"):
+            run_parallel_backtest(
+                jobs=[{"strategy_id": "s1", "weights": {"SPY": 1.0}}],
+                metric="not_a_metric",
+            )
+
+    def test_raises_on_job_missing_keys(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        with pytest.raises(ValueError, match="must contain 'strategy_id' and 'weights'"):
+            run_parallel_backtest(jobs=[{"strategy_id": "s1"}])  # no weights
+
+    def test_results_preserve_input_order(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        sharpes = {"a": 0.5, "b": 1.5, "c": 0.9}
+
+        def fake_backtest(*, strategy_id, **kw):
+            return (self._mock_result(sharpes[strategy_id]), {})
+
+        jobs = [
+            {"strategy_id": "a", "weights": {"SPY": 1.0}, "label": "a"},
+            {"strategy_id": "b", "weights": {"QQQ": 1.0}, "label": "b"},
+            {"strategy_id": "c", "weights": {"IWM": 1.0}, "label": "c"},
+        ]
+        with patch("archimedes.services.portfolio_backtester.backtest_portfolio", side_effect=fake_backtest):
+            out = run_parallel_backtest(jobs=jobs)
+
+        assert [r["label"] for r in out["results"]] == ["a", "b", "c"]
+
+    def test_ranking_descending_for_sharpe(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        sharpes = {"a": 0.5, "b": 1.5, "c": 0.9}
+
+        def fake_backtest(*, strategy_id, **kw):
+            return (self._mock_result(sharpes[strategy_id]), {})
+
+        jobs = [{"strategy_id": k, "weights": {"SPY": 1.0}} for k in ("a", "b", "c")]
+        with patch("archimedes.services.portfolio_backtester.backtest_portfolio", side_effect=fake_backtest):
+            out = run_parallel_backtest(jobs=jobs, metric="sharpe_ratio")
+
+        assert out["ranking"] == ["b", "c", "a"]
+        assert out["best"] == "b"
+        assert out["worst"] == "a"
+
+    def test_ranking_ascending_for_max_drawdown(self):
+        """max_drawdown is a positive magnitude; smallest drawdown is best."""
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        dds = {"a": 0.40, "b": 0.10, "c": 0.25}
+
+        def fake_backtest(*, strategy_id, **kw):
+            return (self._mock_result(1.0, max_dd=dds[strategy_id]), {})
+
+        jobs = [{"strategy_id": k, "weights": {"SPY": 1.0}} for k in ("a", "b", "c")]
+        with patch("archimedes.services.portfolio_backtester.backtest_portfolio", side_effect=fake_backtest):
+            out = run_parallel_backtest(jobs=jobs, metric="max_drawdown")
+
+        assert out["ranking"] == ["b", "c", "a"]  # 0.10 best, 0.40 worst
+
+    def test_label_defaults_to_strategy_id(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        def fake_backtest(*, strategy_id, **kw):
+            return (self._mock_result(1.0), {})
+
+        with patch("archimedes.services.portfolio_backtester.backtest_portfolio", side_effect=fake_backtest):
+            out = run_parallel_backtest(jobs=[{"strategy_id": "faber", "weights": {"SPY": 1.0}}])
+
+        assert out["results"][0]["label"] == "faber"
+
+    def test_failed_job_is_captured_not_raised(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        def fake_backtest(*, strategy_id, **kw):
+            if strategy_id == "bad":
+                raise ValueError("insufficient overlap")
+            return (self._mock_result(1.2), {})
+
+        jobs = [
+            {"strategy_id": "good", "weights": {"SPY": 1.0}},
+            {"strategy_id": "bad", "weights": {"ZZZZ": 1.0}},
+        ]
+        with patch("archimedes.services.portfolio_backtester.backtest_portfolio", side_effect=fake_backtest):
+            out = run_parallel_backtest(jobs=jobs)
+
+        assert out["n_jobs"] == 2
+        assert out["n_ok"] == 1
+        assert out["n_failed"] == 1
+        bad = next(r for r in out["results"] if r["label"] == "bad")
+        assert bad["ok"] is False
+        assert "insufficient overlap" in bad["error"]
+        # Failed job is excluded from the ranking entirely.
+        assert out["ranking"] == ["good"]
+
+    def test_all_jobs_failed_yields_none_best(self):
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        def fake_backtest(**kw):
+            raise ValueError("boom")
+
+        jobs = [{"strategy_id": "x", "weights": {"SPY": 1.0}}]
+        with patch("archimedes.services.portfolio_backtester.backtest_portfolio", side_effect=fake_backtest):
+            out = run_parallel_backtest(jobs=jobs)
+
+        assert out["best"] is None
+        assert out["worst"] is None
+        assert out["ranking"] == []
+        assert out["n_failed"] == 1
+
+    def test_only_backtest_keys_forwarded(self):
+        """Metadata keys like 'label' must not leak into backtest_portfolio kwargs."""
+        from archimedes.services.portfolio_backtester import run_parallel_backtest
+
+        seen_kwargs = {}
+
+        def fake_backtest(**kw):
+            seen_kwargs.update(kw)
+            return (self._mock_result(1.0), {})
+
+        job = {
+            "strategy_id": "s1",
+            "weights": {"SPY": 1.0},
+            "label": "pretty-name",
+            "tx_cost_bps": 15,
+        }
+        with patch("archimedes.services.portfolio_backtester.backtest_portfolio", side_effect=fake_backtest):
+            run_parallel_backtest(jobs=[job])
+
+        assert "label" not in seen_kwargs
+        assert seen_kwargs["tx_cost_bps"] == 15
+        assert seen_kwargs["strategy_id"] == "s1"


### PR DESCRIPTION
**Stacked on onder/portfolio-backtester-expansion (#556) — merge that first** (sibling of #564). Adds run_parallel_backtest: runs many independent strategy/universe backtests in parallel and ranks them (distinct from sensitivity_sweep, which varies one strategy's params). Module-level picklable worker so the ProcessPoolExecutor path actually executes under spawn; stable input ordering; failed jobs captured not raised. Tests: 12 hermetic passing.