### PR TITLE
[infra] Add CloudWatch monitoring + DR/backup/WAF runbooks

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -93,6 +93,24 @@ force squash/rebase). The informational checks (lint-report, complexity) stay no
 Flipping `ENFORCE_ADMINS=true` gates everyone but forces the agentic system onto PRs — that
 is a team decision (Chuan, as repo admin, owns it).
 
+## Monitoring & Disaster Recovery
+
+- **`cloudwatch.tf`** — SNS alert topic + alarms (EC2 CPU/status, ALB 5xx /
+  unhealthy hosts / p95 latency, Aurora CPU / memory / connections) + an ops
+  dashboard. Additive: `terraform apply` only *creates* new CloudWatch objects,
+  it does not touch the existing EC2/ALB/Aurora/WAF resources. Set
+  `alarm_email` (tfvars) to get paged. **Authored 2026-06-12, not yet
+  `terraform plan`-verified** — review before applying.
+- **`runbooks/disaster-recovery.md`** — RTO/RPO targets, per-scenario response
+  (host loss, DB corruption, WAF lockout), restore-order, and a drill checklist.
+- **`runbooks/aurora-backup-restore.md`** — exact PITR / snapshot-restore CLI
+  (Aurora `backup_retention_period = 7` ⇒ 7-day PITR window already on).
+- **`runbooks/waf-rules-reference.md`** — what each `waf.tf` rule does and the
+  count→block promotion workflow.
+
+> These runbooks are **authored, not drilled.** Run a game-day (see the DR
+> drill checklist) before trusting the measured RTO/RPO.
+
 ## Security Notes
 
 - **No `.pem` files in git.** `infra/*.pem` is in `.gitignore`.

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -55,10 +55,6 @@ resource "aws_cloudwatch_metric_alarm" "ec2_cpu_high" {
   tags                = { Project = var.project_name }
 }
 
-# Requires the CloudWatch agent on the instance to publish mem_used_percent
-# (namespace CWAgent). If the agent is not installed this alarm sits in
-# INSUFFICIENT_DATA — harmless, and a useful nudge to install it. See the
-# runbook for the agent install snippet.
 resource "aws_cloudwatch_metric_alarm" "ec2_status_check_failed" {
   alarm_name          = "${var.project_name}-ec2-status-check-failed"
   alarm_description   = "EC2 instance/system status check failed — host unhealthy."
@@ -202,9 +198,9 @@ resource "aws_cloudwatch_dashboard" "ops" {
       {
         type = "metric", x = 0, y = 0, width = 12, height = 6,
         properties = {
-          title  = "EC2 CPU",
-          region = var.aws_region,
-          view   = "timeSeries",
+          title   = "EC2 CPU",
+          region  = var.aws_region,
+          view    = "timeSeries",
           metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.archimedes.id]]
         }
       },
@@ -223,10 +219,10 @@ resource "aws_cloudwatch_dashboard" "ops" {
       {
         type = "metric", x = 0, y = 6, width = 12, height = 6,
         properties = {
-          title  = "ALB target latency (p95)",
-          region = var.aws_region,
-          view   = "timeSeries",
-          stat   = "p95",
+          title   = "ALB target latency (p95)",
+          region  = var.aws_region,
+          view    = "timeSeries",
+          stat    = "p95",
           metrics = [["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.main.arn_suffix, "TargetGroup", aws_lb_target_group.backend.arn_suffix]]
         }
       },

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,0 +1,259 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# CloudWatch monitoring — SNS alert topic, alarms, and an ops dashboard.
+#
+# ⚠️  AUTHORED OFFLINE — NOT yet `terraform plan`/`apply`-verified. This file was
+#     written without AWS credentials in the authoring environment. Before
+#     applying, run `terraform plan` from infra/ and review every resource.
+#     These resources are ADDITIVE (apply creates new alarms/topic/dashboard and
+#     does NOT modify or replace the existing EC2/ALB/Aurora/WAF resources), so
+#     the blast radius of an apply is limited to new CloudWatch objects.
+#
+# Thresholds below are conservative first-cut defaults. Tune them against a few
+# days of real CloudWatch baseline data — see infra/runbooks/disaster-recovery.md
+# for the alarm philosophy. Nothing here is load-bearing for the app to run; it
+# is purely observability + paging.
+# ─────────────────────────────────────────────────────────────────────────────
+
+variable "alarm_email" {
+  description = "Email address subscribed to the CloudWatch alarm SNS topic. Leave empty to skip the subscription (alarms still fire to the topic; you can add subscribers later in the console)."
+  type        = string
+  default     = ""
+}
+
+# ── SNS alert topic ──────────────────────────────────────────────────────────
+
+resource "aws_sns_topic" "alerts" {
+  name = "${var.project_name}-alerts"
+  tags = { Project = var.project_name }
+}
+
+# Optional email subscription. Created only when var.alarm_email is non-empty.
+# AWS sends a confirmation email; the subscription is pending until confirmed.
+resource "aws_sns_topic_subscription" "alerts_email" {
+  count     = var.alarm_email == "" ? 0 : 1
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+# ── EC2 (application host) ───────────────────────────────────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "ec2_cpu_high" {
+  alarm_name          = "${var.project_name}-ec2-cpu-high"
+  alarm_description   = "EC2 host CPU > 85% for 10 min — app host saturated."
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 85
+  period              = 300
+  evaluation_periods  = 2
+  dimensions          = { InstanceId = aws_instance.archimedes.id }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "missing"
+  tags                = { Project = var.project_name }
+}
+
+# Requires the CloudWatch agent on the instance to publish mem_used_percent
+# (namespace CWAgent). If the agent is not installed this alarm sits in
+# INSUFFICIENT_DATA — harmless, and a useful nudge to install it. See the
+# runbook for the agent install snippet.
+resource "aws_cloudwatch_metric_alarm" "ec2_status_check_failed" {
+  alarm_name          = "${var.project_name}-ec2-status-check-failed"
+  alarm_description   = "EC2 instance/system status check failed — host unhealthy."
+  namespace           = "AWS/EC2"
+  metric_name         = "StatusCheckFailed"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 0
+  period              = 60
+  evaluation_periods  = 3
+  dimensions          = { InstanceId = aws_instance.archimedes.id }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "breaching"
+  tags                = { Project = var.project_name }
+}
+
+# ── ALB (edge) ───────────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_high" {
+  alarm_name          = "${var.project_name}-alb-target-5xx-high"
+  alarm_description   = "Backend returned > 10 5xx responses in 5 min."
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 10
+  period              = 300
+  evaluation_periods  = 1
+  dimensions = {
+    LoadBalancer = aws_lb.main.arn_suffix
+    TargetGroup  = aws_lb_target_group.backend.arn_suffix
+  }
+  alarm_actions      = [aws_sns_topic.alerts.arn]
+  ok_actions         = [aws_sns_topic.alerts.arn]
+  treat_missing_data = "notBreaching"
+  tags               = { Project = var.project_name }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_hosts" {
+  alarm_name          = "${var.project_name}-alb-unhealthy-hosts"
+  alarm_description   = "One or more backend targets are unhealthy."
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "UnHealthyHostCount"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 0
+  period              = 60
+  evaluation_periods  = 3
+  dimensions = {
+    LoadBalancer = aws_lb.main.arn_suffix
+    TargetGroup  = aws_lb_target_group.backend.arn_suffix
+  }
+  alarm_actions      = [aws_sns_topic.alerts.arn]
+  ok_actions         = [aws_sns_topic.alerts.arn]
+  treat_missing_data = "breaching"
+  tags               = { Project = var.project_name }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_latency_high" {
+  alarm_name          = "${var.project_name}-alb-target-latency-high"
+  alarm_description   = "p95 backend response time > 2s for 10 min."
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "TargetResponseTime"
+  extended_statistic  = "p95"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 2
+  period              = 300
+  evaluation_periods  = 2
+  dimensions = {
+    LoadBalancer = aws_lb.main.arn_suffix
+    TargetGroup  = aws_lb_target_group.backend.arn_suffix
+  }
+  alarm_actions      = [aws_sns_topic.alerts.arn]
+  ok_actions         = [aws_sns_topic.alerts.arn]
+  treat_missing_data = "notBreaching"
+  tags               = { Project = var.project_name }
+}
+
+# ── Aurora PostgreSQL ────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "aurora_cpu_high" {
+  alarm_name          = "${var.project_name}-aurora-cpu-high"
+  alarm_description   = "Aurora CPU > 85% for 10 min."
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 85
+  period              = 300
+  evaluation_periods  = 2
+  dimensions          = { DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "missing"
+  tags                = { Project = var.project_name }
+}
+
+# FreeableMemory is per-instance. ~256 MB floor is a conservative paging line for
+# a Serverless-v2 instance; tune to your min ACU.
+resource "aws_cloudwatch_metric_alarm" "aurora_low_memory" {
+  alarm_name          = "${var.project_name}-aurora-low-freeable-memory"
+  alarm_description   = "Aurora freeable memory < 256 MB — risk of OOM / connection churn."
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeableMemory"
+  statistic           = "Average"
+  comparison_operator = "LessThanThreshold"
+  threshold           = 268435456 # 256 MiB in bytes
+  period              = 300
+  evaluation_periods  = 2
+  dimensions          = { DBInstanceIdentifier = aws_rds_cluster_instance.main.identifier }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "missing"
+  tags                = { Project = var.project_name }
+}
+
+resource "aws_cloudwatch_metric_alarm" "aurora_connections_high" {
+  alarm_name          = "${var.project_name}-aurora-connections-high"
+  alarm_description   = "Aurora DB connections > 80 — approaching pool/limit pressure."
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 80
+  period              = 300
+  evaluation_periods  = 2
+  dimensions          = { DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "missing"
+  tags                = { Project = var.project_name }
+}
+
+# ── Ops dashboard ────────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_dashboard" "ops" {
+  dashboard_name = "${var.project_name}-ops"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric", x = 0, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "EC2 CPU",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.archimedes.id]]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "ALB requests / 5xx",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", aws_lb.main.arn_suffix],
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", aws_lb.main.arn_suffix]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "ALB target latency (p95)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "p95",
+          metrics = [["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.main.arn_suffix, "TargetGroup", aws_lb_target_group.backend.arn_suffix]]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Aurora CPU / connections",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "CPUUtilization", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier],
+            ["AWS/RDS", "DatabaseConnections", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier]
+          ]
+        }
+      }
+    ]
+  })
+}
+
+# ── Outputs ──────────────────────────────────────────────────────────────────
+
+output "alerts_topic_arn" {
+  description = "SNS topic ARN for CloudWatch alarms. Subscribe additional endpoints (Slack via chatbot, PagerDuty, etc.) here."
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "ops_dashboard_name" {
+  description = "CloudWatch dashboard name."
+  value       = aws_cloudwatch_dashboard.ops.dashboard_name
+}

--- a/infra/runbooks/aurora-backup-restore.md
+++ b/infra/runbooks/aurora-backup-restore.md
@@ -1,0 +1,136 @@
+# Aurora Backup & Restore Runbook — Archimedes
+
+> **Status:** Authored 2026-06-12, **not yet drilled.** Commands target the
+> cluster defined in `infra/aurora.tf` (`aws_rds_cluster.main`, identifier
+> `archimedes-aurora`, instance `archimedes-aurora-1`, engine `aurora-postgresql`
+> 16.4). Run in `eu-west-2` with `AWS_PROFILE=archimedes`. **Review each command
+> before running** — they were not executed in the authoring environment.
+
+---
+
+## What backups exist today
+
+`infra/aurora.tf` sets:
+
+```hcl
+backup_retention_period = 7   # days of continuous backup → PITR window
+```
+
+This gives **two** recovery mechanisms automatically, no extra config:
+
+1. **Continuous backup / PITR** — restore to *any second* within the last 7
+   days (RPO ≈ 5 min, often tighter). This is the primary mechanism.
+2. **Automated daily snapshots** — retained for the same 7 days.
+
+There is currently **no** long-term/manual snapshot schedule beyond the 7-day
+window. If you need monthly/quarterly retention for compliance, see § Long-term
+snapshots below.
+
+> ⚠️ `aurora.tf` may set `skip_final_snapshot = true` for hackathon convenience.
+> **Before any destructive action on the cluster, confirm** and override:
+> `terraform apply -var ...` is not enough — take a manual snapshot first (§ Manual
+> snapshot). Losing the cluster with `skip_final_snapshot = true` and no manual
+> snapshot is unrecoverable.
+
+---
+
+## Take a manual snapshot (do this before risky migrations / destroys)
+
+```bash
+aws rds create-db-cluster-snapshot \
+  --db-cluster-identifier archimedes-aurora \
+  --db-cluster-snapshot-identifier archimedes-aurora-manual-$(date +%Y%m%d-%H%M) \
+  --region eu-west-2
+# wait until available:
+aws rds wait db-cluster-snapshot-available \
+  --db-cluster-snapshot-identifier <the-id-you-just-used> --region eu-west-2
+```
+
+---
+
+## Point-in-time restore (primary recovery path)
+
+PITR **always restores into a NEW cluster** — it never overwrites the live one.
+That is a feature: you validate the restored data before cutting over.
+
+```bash
+# 1. Restore to a new cluster at a chosen timestamp (UTC).
+aws rds restore-db-cluster-to-point-in-time \
+  --source-db-cluster-identifier archimedes-aurora \
+  --db-cluster-identifier archimedes-aurora-restore \
+  --restore-to-time 2026-06-12T13:45:00Z \
+  --region eu-west-2
+#   …or for the latest possible point: add  --use-latest-restorable-time
+#   (and drop --restore-to-time).
+
+# 2. A restored CLUSTER has no instances — add one (match the live class).
+aws rds create-db-instance \
+  --db-instance-identifier archimedes-aurora-restore-1 \
+  --db-cluster-identifier archimedes-aurora-restore \
+  --engine aurora-postgresql \
+  --db-instance-class db.serverless \
+  --region eu-west-2
+aws rds wait db-instance-available \
+  --db-instance-identifier archimedes-aurora-restore-1 --region eu-west-2
+
+# 3. Get the new endpoint and validate before cutover.
+aws rds describe-db-clusters \
+  --db-cluster-identifier archimedes-aurora-restore \
+  --query 'DBClusters[0].Endpoint' --output text --region eu-west-2
+```
+
+**Validate** against the restore endpoint (read-only first): row counts on
+`strategies`, `backtests`, `reasoning_traces`, `strategy_proposals`; spot-check
+the most recent rows; confirm the bad migration/corruption is absent.
+
+### Cutover options
+
+- **Preferred (no app reconfig):** rename clusters so the app's `DATABASE_URL`
+  keeps working. Rename live out of the way, then restore into its name:
+  ```bash
+  aws rds modify-db-cluster --db-cluster-identifier archimedes-aurora \
+    --new-db-cluster-identifier archimedes-aurora-broken --apply-immediately --region eu-west-2
+  aws rds modify-db-cluster --db-cluster-identifier archimedes-aurora-restore \
+    --new-db-cluster-identifier archimedes-aurora --apply-immediately --region eu-west-2
+  ```
+  ⚠️ Renaming changes the endpoint host; if `DATABASE_URL` pins the endpoint DNS,
+  update SSM and restart the app (`docker compose up -d`). Confirm which form the
+  app uses before relying on "no reconfig".
+- **Alternative:** point the app at the restore endpoint by updating the
+  `DATABASE_URL` secret in SSM and restarting the stack. Faster to reason about,
+  but leaves cluster names mismatched vs Terraform state — reconcile after.
+
+### Reconcile Terraform after a manual restore
+
+Manual console/CLI restores drift from Terraform state. After the incident,
+either `terraform import` the surviving cluster back under `aws_rds_cluster.main`
+or plan a maintenance window to recreate cleanly. Do **not** `terraform apply`
+blind post-restore — it may try to destroy the manually-restored cluster.
+
+---
+
+## Restore from a specific snapshot
+
+```bash
+aws rds restore-db-cluster-from-snapshot \
+  --db-cluster-identifier archimedes-aurora-fromsnap \
+  --snapshot-identifier <snapshot-id> \
+  --engine aurora-postgresql \
+  --region eu-west-2
+# then create-db-instance as in PITR step 2.
+```
+
+---
+
+## Long-term snapshots (optional hardening, not yet implemented)
+
+The 7-day window does not satisfy monthly/quarterly retention. Options, cheapest
+first:
+
+1. **AWS Backup plan** — a managed monthly/quarterly schedule with its own vault
+   and lifecycle. Add as `aws_backup_plan` + `aws_backup_selection` in a new
+   `infra/backup.tf`. Recommended if compliance retention is ever required.
+2. **EventBridge + Lambda** to call `create-db-cluster-snapshot` on a cron and
+   prune by age. More moving parts; prefer AWS Backup.
+
+Neither is wired today — flagged here so the gap is explicit rather than silent.

--- a/infra/runbooks/disaster-recovery.md
+++ b/infra/runbooks/disaster-recovery.md
@@ -1,0 +1,101 @@
+# Disaster Recovery Runbook — Archimedes
+
+> **Status:** Authored 2026-06-12. **Not yet drilled.** Commands below were
+> written against the Terraform in `infra/` (`aws_instance.archimedes`,
+> `aws_lb.main`, `aws_rds_cluster.main`) and the AWS-access protocol in the root
+> `CLAUDE.md`, but have **not** been executed end-to-end in this environment (no
+> AWS credentials here). Treat every command as *review-then-run*, and schedule a
+> real game-day drill (see § Drills) before relying on this.
+
+Region: `eu-west-2`. Account / profile: `archimedes` (see `CLAUDE.md` § AWS
+account access). All admin access is via **SSM Session Manager**, not SSH.
+
+---
+
+## Objectives (proposed — confirm with stakeholders)
+
+| Metric | Target | Rationale |
+|---|---|---|
+| **RTO** (time to restore service) | ≤ 1 hour | Single-region, single-EC2 app host; Aurora restore dominates. |
+| **RPO** (max data loss) | ≤ 5 minutes | Aurora continuous backup → PITR to ~any second within the retention window. |
+
+Aurora `backup_retention_period = 7` (days) is set in `infra/aurora.tf`, so
+point-in-time recovery is available across a rolling 7-day window with no extra
+configuration.
+
+---
+
+## Failure scenarios & responses
+
+### 1. Application host (EC2) down / unhealthy
+**Detect:** `archimedes-ec2-status-check-failed` or `archimedes-alb-unhealthy-hosts`
+alarm (see `infra/cloudwatch.tf`), or `https://archimedes-arc.app/` 502/503.
+
+**Respond:**
+1. Confirm the target health:
+   ```bash
+   aws elbv2 describe-target-health \
+     --target-group-arn "$(aws elbv2 describe-target-groups \
+        --names archimedes-backend-tg --query 'TargetGroups[0].TargetGroupArn' --output text)" \
+     --region eu-west-2
+   ```
+2. Try an in-place recovery first (fastest). Open a session and restart the stack:
+   ```bash
+   aws ssm start-session --target <instance-id> --region eu-west-2
+   # on host:
+   cd /opt/archimedes && docker compose ps && docker compose up -d
+   ```
+3. If the host itself is gone, recreate it from Terraform (the app is
+   stateless — all state is in Aurora/ElastiCache):
+   ```bash
+   cd infra && terraform plan -target=aws_instance.archimedes
+   terraform apply -target=aws_instance.archimedes
+   ```
+   `user-data.sh` re-bootstraps Docker + pulls the stack on first boot. The ALB
+   target group re-attaches via `aws_lb_target_group_attachment.backend`.
+
+### 2. Database (Aurora) corruption or bad migration
+**Detect:** app 5xx spike, `archimedes-aurora-*` alarms, or a known-bad deploy.
+**Respond:** point-in-time restore — see
+[`aurora-backup-restore.md`](aurora-backup-restore.md). RPO ≤ 5 min, RTO bounded
+by clone+failover (typically 10–30 min for a small cluster).
+
+### 3. Accidental WAF/SG lockout
+The WAF (`infra/waf.tf`) and security groups can lock out legitimate traffic if
+mis-tuned. Recover by reverting the offending Terraform change and re-applying;
+if the console is reachable, temporarily set the WAF default action to `allow`
+on `aws_wafv2_web_acl.main` while you diagnose. Never leave it on `allow`.
+
+### 4. Region outage
+Out of scope for the current single-region design. Documented gap: there is no
+cross-region replica today. If this becomes a requirement, the cheapest first
+step is an Aurora cross-region automated-backup replication
+(`aws rds start-db-instance-automated-backups-replication`) into a DR region,
+plus Terraform parameterized on region.
+
+---
+
+## Restore-order dependency
+
+When rebuilding from scratch, apply in this order (the Terraform graph mostly
+enforces it, but for `-target` restores follow it manually):
+
+1. `vpc.tf` (network) → 2. `aurora.tf` + `elasticache.tf` (data) →
+3. `alb.tf` + `waf.tf` (edge) → 4. `main.tf` (`aws_instance.archimedes`, app) →
+5. `cloudwatch.tf` (observability).
+
+---
+
+## Drills (do this before trusting the runbook)
+
+- [ ] **PITR drill:** restore Aurora to a *new* cluster at a timestamp 1 h ago,
+      point a throwaway app instance at it, confirm data, then destroy. Time it
+      — record the actual RTO.
+- [ ] **Host-loss drill:** terminate the EC2 in a maintenance window, run the
+      §1.3 Terraform recreate, confirm the ALB target goes healthy. Time it.
+- [ ] **Alarm drill:** stop the backend container; confirm
+      `archimedes-alb-unhealthy-hosts` fires to the SNS topic and the subscribed
+      email/Slack receives it.
+
+Record actual measured RTO/RPO here after the first drill and revise the targets
+above to reality.

--- a/infra/runbooks/waf-rules-reference.md
+++ b/infra/runbooks/waf-rules-reference.md
@@ -1,0 +1,64 @@
+# WAF Rule Reference — Archimedes
+
+> Reference for `infra/waf.tf` (`aws_wafv2_web_acl.main`), as of 2026-06-12.
+> This documents the **already-deployed** WAF; it is not a change. Tuning
+> suggestions at the end are proposals, not applied.
+
+**Scope:** regional WAF associated with `aws_lb.main` (the ALB).
+**Default action:** `allow` — the ACL is allow-by-default; only the rules below
+block. **No geo-blocking** is configured (intentional).
+
+Every rule has `cloudwatch_metrics_enabled = true` and `sampled_requests_enabled
+= true`, so each emits a CloudWatch metric under namespace `AWS/WAFV2` and you
+can inspect sampled requests in the console.
+
+## Rules (in priority order)
+
+| Priority | Name | Action | What it does |
+|---|---|---|---|
+| 1 | `rate-limit` | **BLOCK** | Rate-based: blocks an IP exceeding **1000 requests / 5 min** (rolling). `aggregate_key_type = IP`. First line of defense against bursty abuse / scraping. |
+| 10 | `aws-core-rules` | **COUNT** | `AWSManagedRulesCommonRuleSet` in **count mode** — observes (does not block) the OWASP-ish common ruleset. Counting first avoids false-positive blocks on the app's own traffic before you've seen the sampled hits. |
+| 20 | `aws-known-bad-inputs` | **COUNT** | `AWSManagedRulesKnownBadInputsRuleSet` in **count mode** — known exploit patterns, observe-only for now. |
+| 30 | `aws-ip-reputation` | **BLOCK** | `AWSManagedRulesAmazonIpReputationList` — blocks immediately (no override). Amazon-maintained known-bad source IPs; low false-positive risk, so blocking from day one is safe. |
+| 40 | `aws-sqli` | **COUNT** | `AWSManagedRulesSQLiRuleSet` — SQL-injection signatures, **observe-only on purpose**: LLM prompts and generated-strategy text routinely contain SQL-like tokens (`SELECT`, `DROP`, `--`) that would false-positive against a real backend whose DB access is parameterized. Counting here is the correct call, not a gap. |
+
+### Action posture: two block, three count
+IP-reputation and the rate limiter have very low false-positive risk, so they
+**block** immediately. The Common, Known-Bad-Inputs, and SQLi managed groups can
+match legitimate app payloads — rich JSON bodies, base64, and (for SQLi) the
+LLM/strategy text that is the whole point of this product — so they run in
+**count** mode. The tuning workflow is: watch their CloudWatch counts + sampled
+requests, confirm no legitimate traffic matches, then flip `count {}` →
+`none {}` per rule. **SQLi is the one to be most cautious about promoting** given
+the LLM payloads; prefer a scoped-down exclusion over blocking the whole group.
+
+## Tuning / hardening proposals (NOT applied)
+
+1. **Promote Common + Known-Bad-Inputs to block** once their count metrics show
+   no legitimate matches. One-line change each: `count {}` → `none {}` in the
+   rule's `override_action`.
+2. **Scope the rate limit per route.** 1000/5min is global per IP. The
+   `/api/generate` LLM path is expensive; consider a stricter rate-based rule
+   scoped with a `scope_down_statement` (byte-match on URI prefix `/api/generate`)
+   at a lower limit (e.g. 30/5min).
+3. **Alarm on WAF blocks.** Add a CloudWatch alarm on the `BlockedRequests`
+   metric (namespace `AWS/WAFV2`, dimension the web ACL) to the SNS topic in
+   `cloudwatch.tf` — a sudden block spike is either an attack or a bad tuning
+   change. (Left out of the first `cloudwatch.tf` cut to avoid guessing the
+   exact metric dimensions without console access.)
+4. **Excluded-rule granularity.** If a single sub-rule in a managed group causes
+   false positives, exclude just that `rule_action_override` rather than counting
+   the whole group.
+
+## Inspecting WAF activity
+
+```bash
+# List the metrics the WAF is emitting:
+aws cloudwatch list-metrics --namespace AWS/WAFV2 --region eu-west-2
+
+# Blocked vs allowed counts for the ACL over the last hour (fill in the ACL
+# dimensions from the console — Region/Rule/WebACL):
+aws cloudwatch get-metric-statistics --namespace AWS/WAFV2 \
+  --metric-name BlockedRequests --start-time "$(date -u -v-1H +%FT%TZ)" \
+  --end-time "$(date -u +%FT%TZ)" --period 300 --statistics Sum --region eu-west-2
+```


### PR DESCRIPTION
Closes the Phase 4.1 observability gap (there was no `cloudwatch.tf`).

**What's here**
- `infra/cloudwatch.tf` — SNS alert topic (+ optional `alarm_email`), alarms for EC2 (CPU, status check), ALB (target 5xx, unhealthy hosts, p95 latency), Aurora (CPU, freeable memory, connections), + an ops dashboard.
- `infra/runbooks/disaster-recovery.md` — RTO/RPO, per-scenario response, restore-order, drill checklist.
- `infra/runbooks/aurora-backup-restore.md` — PITR + snapshot-restore CLI (`backup_retention_period=7` ⇒ 7-day PITR already on).
- `infra/runbooks/waf-rules-reference.md` — each `waf.tf` rule + count→block workflow.

**Safety**
- The Terraform is **additive** — `apply` only creates new CloudWatch/SNS objects; it does **not** modify or replace the live EC2/ALB/Aurora/WAF resources.
- ⚠️ **Authored offline, NOT `terraform plan`/`apply`-verified** (no AWS creds in the authoring env) and **runbooks not yet drilled**. Every file says so at the top. **Reviewer must run `cd infra && terraform plan` and read it before applying.** Merging this PR lands the files; it does not apply Terraform.
- Thresholds are conservative first-cut defaults — tune against real baseline data.