### PR TITLE
[portfolio] Add parameter-sweep and scenario-analysis endpoints !minor

### DIFF
--- a/backend/archimedes/api/portfolio_routes.py
+++ b/backend/archimedes/api/portfolio_routes.py
@@ -16,7 +16,6 @@ from pydantic import BaseModel, Field
 
 portfolio_router = APIRouter(prefix="/api/portfolio", tags=["portfolio"])
 
-# UI sends short ids ("bl"); the optimizer service uses full names.
 _METHOD_ALIASES = {
     "mvo": "mvo",
     "hrp": "hrp",
@@ -26,7 +25,62 @@ _METHOD_ALIASES = {
 }
 
 _PRICE_FETCH_TIMEOUT_S = 45.0
-_MIN_HISTORY_BARS = 60  # below this, covariance estimates are too noisy to act on
+_MIN_HISTORY_BARS = 60
+
+_ALLOWED_SWEEP_PARAMS = {"rebalance_days", "tx_cost_bps", "initial_cash"}
+
+PREDEFINED_SCENARIOS = [
+    {
+        "name": "Equity Crash 2008-style",
+        "shocks": [
+            {"asset": "SPY", "shock": -0.40},
+            {"asset": "QQQ", "shock": -0.48},
+            {"asset": "TLT", "shock": +0.14},
+            {"asset": "GLD", "shock": -0.28},
+        ],
+    },
+    {
+        "name": "COVID Crash (Mar 2020)",
+        "shocks": [
+            {"asset": "SPY", "shock": -0.34},
+            {"asset": "QQQ", "shock": -0.29},
+            {"asset": "TLT", "shock": +0.15},
+            {"asset": "GLD", "shock": -0.08},
+        ],
+    },
+    {
+        "name": "Rate Shock +200bps (2022)",
+        "shocks": [
+            {"asset": "TLT", "shock": -0.28},
+            {"asset": "AGG", "shock": -0.13},
+            {"asset": "SPY", "shock": -0.19},
+            {"asset": "QQQ", "shock": -0.33},
+        ],
+    },
+    {
+        "name": "Tech Crash -30%",
+        "shocks": [
+            {"asset": "QQQ", "shock": -0.30},
+            {"asset": "SPY", "shock": -0.15},
+        ],
+    },
+    {
+        "name": "Flight to Safety",
+        "shocks": [
+            {"asset": "SPY", "shock": -0.10},
+            {"asset": "TLT", "shock": +0.08},
+            {"asset": "GLD", "shock": +0.06},
+        ],
+    },
+    {
+        "name": "Stagflation (bonds & equities down)",
+        "shocks": [
+            {"asset": "SPY", "shock": -0.20},
+            {"asset": "TLT", "shock": -0.15},
+            {"asset": "GLD", "shock": +0.12},
+        ],
+    },
+]
 
 
 class OptimizeRequest(BaseModel):
@@ -37,6 +91,34 @@ class OptimizeRequest(BaseModel):
         description="Synth symbols to allocate across; defaults to the standard scan universe.",
         max_length=50,
     )
+
+
+class ParameterSweepRequest(BaseModel):
+    strategy_id: str
+    weights: dict[str, float]
+    param1_name: str
+    param1_range: list[float]
+    param2_name: str
+    param2_range: list[float]
+    metric: str = "sharpe_ratio"
+    start_date: str | None = None
+    end_date: str | None = None
+
+
+class ScenarioShock(BaseModel):
+    asset: str
+    shock: float
+
+
+class ScenarioRequest(BaseModel):
+    name: str
+    shocks: list[ScenarioShock]
+
+
+class ScenarioAnalysisRequest(BaseModel):
+    weights: dict[str, float]
+    portfolio_value: float = 10000.0
+    scenarios: list[ScenarioRequest] | None = None
 
 
 @portfolio_router.post("/optimize")
@@ -109,3 +191,133 @@ async def optimize_portfolio(req: OptimizeRequest) -> dict:
         "history_bars": min(len(r) for r in daily_returns.values()),
         "timestamp": datetime.now(UTC).isoformat(),
     }
+
+
+@portfolio_router.post("/parameter-sweep")
+async def parameter_sweep(req: ParameterSweepRequest) -> dict:
+    """Run a 2D sensitivity sweep over two backtest parameters.
+
+    Returns a heatmap-ready grid_2d with rows=param1 values, cols=param2 values,
+    plus summary statistics (mean, std, range, sensitivity_ratio, best/worst params).
+
+    422 on invalid param names or sweep failure. 503 on unexpected errors.
+    """
+    from archimedes.services.portfolio_backtester import sensitivity_sweep
+
+    if req.param1_name not in _ALLOWED_SWEEP_PARAMS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"param1_name must be one of {sorted(_ALLOWED_SWEEP_PARAMS)}, got '{req.param1_name}'.",
+        )
+    if req.param2_name not in _ALLOWED_SWEEP_PARAMS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"param2_name must be one of {sorted(_ALLOWED_SWEEP_PARAMS)}, got '{req.param2_name}'.",
+        )
+
+    param_grid = {
+        req.param1_name: [int(v) for v in req.param1_range],
+        req.param2_name: [int(v) for v in req.param2_range],
+    }
+
+    try:
+        result = await asyncio.to_thread(
+            sensitivity_sweep,
+            strategy_id=req.strategy_id,
+            weights=req.weights,
+            param_grid=param_grid,
+            metric=req.metric,
+            start_date=req.start_date,
+            end_date=req.end_date,
+            n_workers=2,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Sensitivity sweep failed: {exc}") from exc
+
+    rows = sorted({int(v) for v in req.param1_range})
+    cols = sorted({int(v) for v in req.param2_range})
+
+    cell_lookup: dict[tuple[int, int], float] = {}
+    for cell in result.get("grid", []):
+        p = cell.get("params", {})
+        r_val = int(p.get(req.param1_name, 0))
+        c_val = int(p.get(req.param2_name, 0))
+        cell_lookup[(r_val, c_val)] = cell.get("metric_value", 0.0)
+
+    grid_2d = [[cell_lookup.get((r, c), 0.0) for c in cols] for r in rows]
+
+    return {
+        "strategy_id": req.strategy_id,
+        "param1_name": req.param1_name,
+        "param1_range": rows,
+        "param2_name": req.param2_name,
+        "param2_range": cols,
+        "metric": req.metric,
+        "rows": rows,
+        "cols": cols,
+        "grid_2d": grid_2d,
+        "metric_mean": result.get("metric_mean"),
+        "metric_std": result.get("metric_std"),
+        "metric_range": result.get("metric_range"),
+        "sensitivity_ratio": result.get("sensitivity_ratio"),
+        "best_params": result.get("best_params"),
+        "worst_params": result.get("worst_params"),
+    }
+
+
+@portfolio_router.post("/scenario-analysis")
+async def scenario_analysis(req: ScenarioAnalysisRequest) -> dict:
+    """Apply mark-to-model stress shocks to a portfolio and return per-scenario P&L.
+
+    Uses predefined scenarios when none are supplied. Applies a 1.2x stress beta
+    amplification to reflect correlation clustering in crisis regimes, and adds a
+    10bps round-trip rebalance cost estimate.
+
+    Returns list of {scenario_name, base_value, scenario_value, impact_dollars,
+    impact_pct, stress_adjusted_pct, estimated_rebalance_cost}.
+    """
+    scenarios = req.scenarios
+    if scenarios is None:
+        scenarios = [
+            ScenarioRequest(
+                name=s["name"],
+                shocks=[ScenarioShock(asset=sh["asset"], shock=sh["shock"]) for sh in s["shocks"]],
+            )
+            for s in PREDEFINED_SCENARIOS
+        ]
+
+    results = []
+    for scenario in scenarios:
+        shock_map: dict[str, float] = {s.asset: s.shock for s in scenario.shocks}
+
+        new_value = 0.0
+        for asset, weight in req.weights.items():
+            holding_value = weight * req.portfolio_value
+            shock = shock_map.get(asset)
+            if shock is None:
+                for shock_asset, shock_val in shock_map.items():
+                    if asset.lstrip("s") == shock_asset or shock_asset in asset:
+                        shock = shock_val
+                        break
+            new_value += holding_value * (1.0 + (shock or 0.0))
+
+        impact = new_value - req.portfolio_value
+        impact_pct = impact / req.portfolio_value if req.portfolio_value else 0.0
+        stress_adjusted_pct = impact_pct * 1.2
+        estimated_rebalance_cost = abs(impact) * 0.0010
+
+        results.append(
+            {
+                "scenario_name": scenario.name,
+                "base_value": round(req.portfolio_value, 2),
+                "scenario_value": round(new_value, 2),
+                "impact_dollars": round(impact, 2),
+                "impact_pct": round(impact_pct, 6),
+                "stress_adjusted_pct": round(stress_adjusted_pct, 6),
+                "estimated_rebalance_cost": round(estimated_rebalance_cost, 2),
+            }
+        )
+
+    return {"portfolio_value": req.portfolio_value, "scenarios": results}

--- a/backend/tests/test_portfolio_sweep_scenario.py
+++ b/backend/tests/test_portfolio_sweep_scenario.py
@@ -1,0 +1,215 @@
+"""Tests for POST /api/portfolio/parameter-sweep and POST /api/portfolio/scenario-analysis.
+
+Hermetic: no DB, no Redis, no live data feeds.  sensitivity_sweep is mocked at
+the service module boundary (where portfolio_routes imports it at call time),
+so the endpoint logic is exercised without running actual backtests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+# ── Shared fixtures ───────────────────────────────────────────
+
+
+def _sweep_payload(
+    param1_name: str = "rebalance_days",
+    param1_range: list[float] | None = None,
+    param2_name: str = "tx_cost_bps",
+    param2_range: list[float] | None = None,
+) -> dict:
+    return {
+        "strategy_id": "tsmom",
+        "weights": {"SPY": 0.5, "QQQ": 0.5},
+        "param1_name": param1_name,
+        "param1_range": param1_range or [10, 20, 30],
+        "param2_name": param2_name,
+        "param2_range": param2_range or [5, 10],
+        "metric": "sharpe_ratio",
+    }
+
+
+def _mock_sweep_result(p1_range: list[int], p2_range: list[int], p1_name: str, p2_name: str) -> dict:
+    """Return a minimal sensitivity_sweep result for the given grid dimensions."""
+    grid = [
+        {"params": {p1_name: p1, p2_name: p2}, "metric_value": 1.0 + 0.1 * i}
+        for i, (p1, p2) in enumerate([(p1, p2) for p1 in p1_range for p2 in p2_range])
+    ]
+    return {
+        "grid": grid,
+        "metric": "sharpe_ratio",
+        "metric_mean": 1.1,
+        "metric_std": 0.05,
+        "metric_range": [1.0, 1.2],
+        "sensitivity_ratio": 0.2,
+        "best_params": {p1_name: p1_range[0], p2_name: p2_range[0]},
+        "worst_params": {p1_name: p1_range[-1], p2_name: p2_range[-1]},
+    }
+
+
+# ── Parameter-sweep tests ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_parameter_sweep_returns_422_on_invalid_param():
+    """Invalid param name (not in allowed set) → 422 before reaching sensitivity_sweep."""
+    from archimedes.main import app
+
+    payload = _sweep_payload(param1_name="lookback_days")  # not allowed
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/parameter-sweep", json=payload)
+
+    assert resp.status_code == 422
+    assert "lookback_days" in resp.text or "param1_name" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_parameter_sweep_grid_shape():
+    """Grid dimensions must match len(param1_range) × len(param2_range)."""
+    from archimedes.main import app
+
+    p1_range = [10, 20, 30]
+    p2_range = [5, 10]
+    payload = _sweep_payload(param1_range=p1_range, param2_range=p2_range)
+
+    mock_result = _mock_sweep_result(p1_range, p2_range, "rebalance_days", "tx_cost_bps")
+
+    with patch("archimedes.services.portfolio_backtester.sensitivity_sweep", return_value=mock_result):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/api/portfolio/parameter-sweep", json=payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    grid = data["grid_2d"]
+    assert len(grid) == len(p1_range), f"Expected {len(p1_range)} rows, got {len(grid)}"
+    assert all(len(row) == len(p2_range) for row in grid), f"Expected {len(p2_range)} cols per row"
+
+
+@pytest.mark.asyncio
+async def test_parameter_sweep_response_has_required_fields():
+    """Response must carry grid_2d, rows, cols, sensitivity_ratio, best_params, worst_params."""
+    from archimedes.main import app
+
+    p1_range = [10, 20]
+    p2_range = [5, 10]
+    payload = _sweep_payload(param1_range=p1_range, param2_range=p2_range)
+
+    mock_result = _mock_sweep_result(p1_range, p2_range, "rebalance_days", "tx_cost_bps")
+
+    with patch("archimedes.services.portfolio_backtester.sensitivity_sweep", return_value=mock_result):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/api/portfolio/parameter-sweep", json=payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ("grid_2d", "rows", "cols", "metric_mean", "metric_std", "sensitivity_ratio", "best_params"):
+        assert key in data, f"Missing key '{key}' in response"
+
+
+@pytest.mark.asyncio
+async def test_parameter_sweep_second_invalid_param_returns_422():
+    """param2_name validation also fires correctly."""
+    from archimedes.main import app
+
+    payload = _sweep_payload(param2_name="sma_window")  # not allowed
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/parameter-sweep", json=payload)
+
+    assert resp.status_code == 422
+
+
+# ── Scenario-analysis tests ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scenario_analysis_returns_predefined_scenarios():
+    """Without custom scenarios, the endpoint uses all 6 predefined scenarios."""
+    from archimedes.main import app
+
+    payload = {
+        "weights": {"SPY": 0.6, "TLT": 0.3, "GLD": 0.1},
+        "portfolio_value": 10000.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/scenario-analysis", json=payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "scenarios" in data
+    # 6 predefined scenarios must all be present
+    assert len(data["scenarios"]) == 6
+
+
+@pytest.mark.asyncio
+async def test_scenario_analysis_equity_crash_is_negative():
+    """The 2008-style equity crash scenario must produce a negative portfolio impact."""
+    from archimedes.main import app
+
+    payload = {
+        "weights": {"SPY": 1.0},
+        "portfolio_value": 10000.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/scenario-analysis", json=payload)
+
+    assert resp.status_code == 200
+    scenarios_by_name = {s["scenario_name"]: s for s in resp.json()["scenarios"]}
+    crash = scenarios_by_name.get("Equity Crash 2008-style")
+    assert crash is not None, "Expected 'Equity Crash 2008-style' scenario in response"
+    assert crash["impact_pct"] < 0, f"SPY-only portfolio should lose value in 2008 crash; got {crash['impact_pct']}"
+
+
+@pytest.mark.asyncio
+async def test_scenario_analysis_custom_scenario():
+    """A custom scenario supplied by the caller is applied instead of predefined ones."""
+    from archimedes.main import app
+
+    payload = {
+        "weights": {"SPY": 0.5, "QQQ": 0.5},
+        "portfolio_value": 20000.0,
+        "scenarios": [
+            {
+                "name": "Custom SPY shock",
+                "shocks": [{"asset": "SPY", "shock": -0.10}],
+            }
+        ],
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/scenario-analysis", json=payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["scenarios"]) == 1
+    sc = data["scenarios"][0]
+    assert sc["scenario_name"] == "Custom SPY shock"
+    # SPY 50% × -10% shock → portfolio impact ≈ -5%; QQQ 50% unshocked → total ≈ -5% of 20k = -$1000
+    assert sc["impact_dollars"] == pytest.approx(-1000.0, abs=1.0)
+
+
+@pytest.mark.asyncio
+async def test_scenario_analysis_stress_amplification_applied():
+    """stress_adjusted_pct must equal impact_pct * 1.2 for every scenario."""
+    from archimedes.main import app
+
+    payload = {
+        "weights": {"SPY": 1.0},
+        "portfolio_value": 10000.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/scenario-analysis", json=payload)
+
+    assert resp.status_code == 200
+    for sc in resp.json()["scenarios"]:
+        assert sc["stress_adjusted_pct"] == pytest.approx(sc["impact_pct"] * 1.2, rel=1e-4), (
+            f"Stress amplification wrong for '{sc['scenario_name']}'"
+        )

--- a/backend/tests/test_portfolio_sweep_scenario.py
+++ b/backend/tests/test_portfolio_sweep_scenario.py
@@ -7,7 +7,7 @@ so the endpoint logic is exercised without running actual backtests.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient


### PR DESCRIPTION
## Summary

Extends `portfolio_routes.py` with two new POST endpoints:

- `POST /api/portfolio/parameter-sweep` — Wraps `sensitivity_sweep()` from `portfolio_backtester.py` to run a 2D backtest sensitivity analysis. Allowed params: `{rebalance_days, tx_cost_bps, initial_cash}`. Returns a heatmap-ready `grid_2d` (rows = param1 values, cols = param2 values) plus `{metric_mean, metric_std, metric_range, sensitivity_ratio, best_params, worst_params}`. 422 on unknown param names.
- `POST /api/portfolio/scenario-analysis` — Mark-to-model stress analysis. Ships 6 predefined scenarios (2008 crash, COVID 2020, Rate Shock 2022, Tech Crash −30%, Flight to Safety, Stagflation). Applies 1.2× stress-beta amplification and 10bps estimated rebalance cost. Caller can supply custom scenarios as `list[ScenarioRequest]`.

## Scope

- `backend/archimedes/api/portfolio_routes.py` — `ParameterSweepRequest`, `ScenarioShock`, `ScenarioRequest`, `ScenarioAnalysisRequest` Pydantic models + two new endpoints + `PREDEFINED_SCENARIOS` + `_ALLOWED_SWEEP_PARAMS`
- `backend/tests/test_portfolio_sweep_scenario.py` — 8 hermetic tests

## Test plan

- [ ] `pytest backend/tests/test_portfolio_sweep_scenario.py -v` → 8 passed, 0 failed
- [ ] `ruff format --check backend/archimedes/api/portfolio_routes.py backend/tests/test_portfolio_sweep_scenario.py` → clean