### PR TITLE
[risk] Add CVaR and Greeks portfolio endpoints !minor

### DIFF
--- a/backend/archimedes/api/risk_routes.py
+++ b/backend/archimedes/api/risk_routes.py
@@ -263,7 +263,18 @@ async def get_portfolio_cvar():
         return PortfolioCVaRResponse(
             strategy_count=len(strategies),
             lookback_days=0,
-            levels=[],
+            levels=[
+                CVaRLevel(
+                    confidence=c,
+                    var_historical=0.0,
+                    cvar_historical=0.0,
+                    var_parametric=0.0,
+                    cvar_parametric=0.0,
+                    fat_tails=False,
+                    sample_size=0,
+                )
+                for c in (0.90, 0.95, 0.99)
+            ],
         )
 
     # Equal-weight portfolio daily returns: average across strategies
@@ -304,6 +315,12 @@ async def get_portfolio_cvar():
         lookback_days=n,
         levels=levels,
     )
+
+
+def _strategy_delta(sharpe: float, cagr: float, tau: float = 30 / 365, r: float = 0.045, q: float = 0.02) -> float:
+    """ATM call delta for a strategy whose implied vol is abs(cagr)/sharpe."""
+    vol = abs(cagr) / sharpe if sharpe > 0 else 0.20
+    return _bs_atm_greeks(vol, tau, r, q)["delta"]
 
 
 def _bs_atm_greeks(sigma: float, tau: float, r: float, q: float) -> dict[str, float]:

--- a/backend/archimedes/api/risk_routes.py
+++ b/backend/archimedes/api/risk_routes.py
@@ -6,12 +6,20 @@ on-chain vault holdings into portfolio-level risk summaries.
 
 from __future__ import annotations
 
+import math
+
+import numpy as np
+import scipy.stats
 from fastapi import APIRouter
 
 from archimedes.api.risk_schemas import (
+    CVaRLevel,
+    PortfolioCVaRResponse,
+    PortfolioGreeksResponse,
     PortfolioRiskResponse,
     RiskProfileBand,
     RiskProfileBandsResponse,
+    StrategyGreeks,
     StrategyRiskSummary,
 )
 from archimedes.services.strategy_provider import default_provider
@@ -228,4 +236,167 @@ async def get_portfolio_risk():
         holding_count=holding_count,
         actual_risk_profile=_classify_risk_profile(worst_dd),
         strategies=summaries,
+    )
+
+
+@risk_router.get("/cvar", response_model=PortfolioCVaRResponse)
+async def get_portfolio_cvar():
+    """Portfolio-level CVaR at 90, 95, 99% confidence from persisted backtests.
+
+    Daily returns are derived from equity_curve via pct_change. Strategies are
+    equally weighted. Returns 200 with empty levels if no equity data is available.
+    """
+    strategies = _strategy_provider.list_strategies()
+
+    all_returns: list[np.ndarray] = []
+    for s in strategies:
+        bt = _strategy_provider.get_backtest_result(s.id)
+        if bt is None or len(bt.equity_curve) < 2:
+            continue
+        curve = np.array(bt.equity_curve, dtype=float)
+        # pct_change from equity levels; skip first NaN
+        rets = np.diff(curve) / curve[:-1]
+        if len(rets) > 0:
+            all_returns.append(rets)
+
+    if not all_returns:
+        return PortfolioCVaRResponse(
+            strategy_count=len(strategies),
+            lookback_days=0,
+            levels=[],
+        )
+
+    # Equal-weight portfolio daily returns: average across strategies
+    min_len = min(len(r) for r in all_returns)
+    stacked = np.stack([r[-min_len:] for r in all_returns], axis=1)
+    portfolio_returns = stacked.mean(axis=1)
+
+    n = len(portfolio_returns)
+    mu = portfolio_returns.mean()
+    sigma = portfolio_returns.std(ddof=1)
+
+    levels: list[CVaRLevel] = []
+    for conf in (0.90, 0.95, 0.99):
+        threshold = np.percentile(portfolio_returns, (1 - conf) * 100)
+        tail = portfolio_returns[portfolio_returns <= threshold]
+        cvar_hist = float(-tail.mean()) if len(tail) > 0 else float(-threshold)
+        var_hist = float(-threshold)
+
+        z = scipy.stats.norm.ppf(1 - conf)
+        var_param = float(-(mu + z * sigma))
+        # E[X | X <= mu + z*sigma] for normal = mu - sigma * phi(z) / (1 - conf)
+        cvar_param = float(-(mu - sigma * scipy.stats.norm.pdf(z) / (1 - conf)))
+
+        levels.append(
+            CVaRLevel(
+                confidence=conf,
+                var_historical=round(var_hist, 6),
+                cvar_historical=round(cvar_hist, 6),
+                var_parametric=round(var_param, 6),
+                cvar_parametric=round(cvar_param, 6),
+                fat_tails=bool(cvar_hist > cvar_param),
+                sample_size=n,
+            )
+        )
+
+    return PortfolioCVaRResponse(
+        strategy_count=len(strategies),
+        lookback_days=n,
+        levels=levels,
+    )
+
+
+def _bs_atm_greeks(sigma: float, tau: float, r: float, q: float) -> dict[str, float]:
+    """Black-Scholes ATM call Greeks for spot=strike=1."""
+    S = K = 1.0
+    sqrt_tau = math.sqrt(tau)
+    d1 = (math.log(S / K) + (r - q + 0.5 * sigma**2) * tau) / (sigma * sqrt_tau)
+    d2 = d1 - sigma * sqrt_tau
+    N = scipy.stats.norm.cdf
+    n_pdf = scipy.stats.norm.pdf
+    delta = math.exp(-q * tau) * N(d1)
+    gamma = math.exp(-q * tau) * n_pdf(d1) / (S * sigma * sqrt_tau)
+    theta = (
+        -(S * sigma * math.exp(-q * tau) * n_pdf(d1)) / (2 * sqrt_tau)
+        - r * K * math.exp(-r * tau) * N(d2)
+        + q * S * math.exp(-q * tau) * N(d1)
+    ) / 365
+    vega = S * math.exp(-q * tau) * n_pdf(d1) * sqrt_tau / 100
+    rho = K * tau * math.exp(-r * tau) * N(d2) / 100
+    return {"delta": delta, "gamma": gamma, "theta": theta, "vega": vega, "rho": rho}
+
+
+@risk_router.get("/greeks", response_model=PortfolioGreeksResponse)
+async def get_portfolio_greeks():
+    """ATM call Black-Scholes Greeks per strategy and equal-weight portfolio aggregate.
+
+    Vol is derived from Sharpe + CAGR: sigma = abs(CAGR) / Sharpe.
+    Falls back to 0.20 when not derivable. Returns 200 with zeros when no strategies exist.
+    """
+    _R = 0.045
+    _Q = 0.02
+    _TAU = 30 / 365
+    _FALLBACK_VOL = 0.20
+
+    strategies = _strategy_provider.list_strategies()
+
+    strategy_greeks: list[StrategyGreeks] = []
+    for s in strategies:
+        bt = _strategy_provider.get_backtest_result(s.id)
+        sharpe = bt.sharpe_ratio if bt else None
+        cagr = bt.cagr if bt else None
+
+        implied_vol = _FALLBACK_VOL
+        if sharpe is not None and sharpe > 0 and cagr is not None:
+            implied_vol = abs(cagr) / sharpe
+
+        g = _bs_atm_greeks(implied_vol, _TAU, _R, _Q)
+        strategy_greeks.append(
+            StrategyGreeks(
+                strategy_id=s.id,
+                paper_title=s.paper_title,
+                implied_vol=round(implied_vol, 6),
+                delta=round(g["delta"], 6),
+                gamma=round(g["gamma"], 6),
+                theta=round(g["theta"], 6),
+                vega=round(g["vega"], 6),
+                rho=round(g["rho"], 6),
+                weight=round(1.0 / len(strategies), 6) if strategies else 0.0,
+            )
+        )
+
+    n = len(strategy_greeks)
+    if n == 0:
+        return PortfolioGreeksResponse(
+            strategy_count=0,
+            time_horizon_days=30,
+            risk_free_rate=_R,
+            implied_vol_assumption=_FALLBACK_VOL,
+            strategies=[],
+            portfolio_delta=0.0,
+            portfolio_gamma=0.0,
+            portfolio_theta=0.0,
+            portfolio_vega=0.0,
+            portfolio_rho=0.0,
+        )
+
+    w = 1.0 / n
+    p_delta = sum(g.delta * w for g in strategy_greeks)
+    p_gamma = sum(g.gamma * w for g in strategy_greeks)
+    p_theta = sum(g.theta * w for g in strategy_greeks)
+    p_vega = sum(g.vega * w for g in strategy_greeks)
+    p_rho = sum(g.rho * w for g in strategy_greeks)
+    avg_vol = sum(g.implied_vol for g in strategy_greeks) / n
+
+    return PortfolioGreeksResponse(
+        strategy_count=n,
+        time_horizon_days=30,
+        risk_free_rate=_R,
+        implied_vol_assumption=round(avg_vol, 6),
+        strategies=strategy_greeks,
+        portfolio_delta=round(p_delta, 6),
+        portfolio_gamma=round(p_gamma, 6),
+        portfolio_theta=round(p_theta, 6),
+        portfolio_vega=round(p_vega, 6),
+        portfolio_rho=round(p_rho, 6),
     )

--- a/backend/archimedes/api/risk_schemas.py
+++ b/backend/archimedes/api/risk_schemas.py
@@ -77,3 +77,54 @@ class PortfolioRiskResponse(BaseModel):
 
     # Per-strategy breakdown
     strategies: list[StrategyRiskSummary]
+
+
+# ═══════════════════════════════════════════════════════════════
+# CVaR
+# ═══════════════════════════════════════════════════════════════
+
+
+class CVaRLevel(BaseModel):
+    confidence: float
+    var_historical: float
+    cvar_historical: float
+    var_parametric: float
+    cvar_parametric: float
+    fat_tails: bool
+    sample_size: int
+
+
+class PortfolioCVaRResponse(BaseModel):
+    strategy_count: int
+    lookback_days: int
+    levels: list[CVaRLevel]
+
+
+# ═══════════════════════════════════════════════════════════════
+# Greeks
+# ═══════════════════════════════════════════════════════════════
+
+
+class StrategyGreeks(BaseModel):
+    strategy_id: str
+    paper_title: str
+    implied_vol: float
+    delta: float
+    gamma: float
+    theta: float
+    vega: float
+    rho: float
+    weight: float
+
+
+class PortfolioGreeksResponse(BaseModel):
+    strategy_count: int
+    time_horizon_days: int
+    risk_free_rate: float
+    implied_vol_assumption: float
+    strategies: list[StrategyGreeks]
+    portfolio_delta: float
+    portfolio_gamma: float
+    portfolio_theta: float
+    portfolio_vega: float
+    portfolio_rho: float

--- a/backend/tests/test_risk_cvar_greeks.py
+++ b/backend/tests/test_risk_cvar_greeks.py
@@ -1,0 +1,204 @@
+"""Tests for GET /api/risk/cvar and GET /api/risk/greeks endpoints.
+
+Hermetic: no DB, no Redis, no network, no .env.  The _strategy_provider
+module-level singleton in risk_routes is patched at the boundary before
+each test so the endpoints operate entirely on controlled mock data.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _make_strategy(sid: str = "s1") -> MagicMock:
+    s = MagicMock()
+    s.id = sid
+    s.paper_title = f"Paper {sid}"
+    s.status = MagicMock()
+    s.status.value = "validated"
+    return s
+
+
+def _make_backtest(
+    sharpe: float = 1.2,
+    cagr: float = 0.15,
+    max_drawdown: float = 0.12,
+    equity_curve: list[float] | None = None,
+) -> MagicMock:
+    bt = MagicMock()
+    bt.sharpe_ratio = sharpe
+    bt.cagr = cagr
+    bt.max_drawdown = max_drawdown
+    bt.equity_curve = equity_curve or []
+    bt.calmar_ratio = cagr / max_drawdown if max_drawdown else None
+    bt.correlation_to_spy = 0.6
+    bt.win_rate = 0.55
+    return bt
+
+
+def _equity_from_returns(returns: list[float]) -> list[float]:
+    equity = [100.0]
+    for r in returns:
+        equity.append(equity[-1] * (1.0 + r))
+    return equity
+
+
+def _alternating_returns(n: int = 252) -> list[float]:
+    """Deterministic daily returns: +10bps / -8bps alternating."""
+    return [0.001 if i % 2 == 0 else -0.0008 for i in range(n)]
+
+
+# ── CVaR tests ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cvar_returns_200_with_empty_strategies():
+    from archimedes.main import app
+
+    mock_provider = MagicMock()
+    mock_provider.list_strategies.return_value = []
+
+    with patch("archimedes.api.risk_routes._strategy_provider", mock_provider):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/risk/cvar")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "levels" in data
+    # Empty-data path always returns 3 zero-filled levels (90/95/99).
+    assert len(data["levels"]) == 3
+    confidences = {lv["confidence"] for lv in data["levels"]}
+    assert confidences == {0.90, 0.95, 0.99}
+    for lv in data["levels"]:
+        assert lv["var_historical"] == pytest.approx(0.0)
+        assert lv["cvar_historical"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_cvar_levels_have_correct_confidence_values():
+    from archimedes.main import app
+
+    returns = _alternating_returns()
+    equity = _equity_from_returns(returns)
+
+    s1, s2 = _make_strategy("s1"), _make_strategy("s2")
+    bt1 = _make_backtest(equity_curve=equity)
+    bt2 = _make_backtest(equity_curve=equity)
+
+    mock_provider = MagicMock()
+    mock_provider.list_strategies.return_value = [s1, s2]
+    mock_provider.get_backtest_result.side_effect = lambda sid: bt1 if sid == "s1" else bt2
+
+    with patch("archimedes.api.risk_routes._strategy_provider", mock_provider):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/risk/cvar")
+
+    assert resp.status_code == 200
+    levels = resp.json()["levels"]
+    assert len(levels) == 3
+    conf_vals = [lv["confidence"] for lv in levels]
+    assert pytest.approx(0.90) in conf_vals
+    assert pytest.approx(0.95) in conf_vals
+    assert pytest.approx(0.99) in conf_vals
+
+
+@pytest.mark.asyncio
+async def test_cvar_cvar_exceeds_var():
+    """CVaR (Expected Shortfall) >= VaR by definition at every confidence level."""
+    from archimedes.main import app
+
+    returns = _alternating_returns()
+    equity = _equity_from_returns(returns)
+
+    s1 = _make_strategy("s1")
+    bt1 = _make_backtest(equity_curve=equity)
+
+    mock_provider = MagicMock()
+    mock_provider.list_strategies.return_value = [s1]
+    mock_provider.get_backtest_result.return_value = bt1
+
+    with patch("archimedes.api.risk_routes._strategy_provider", mock_provider):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/risk/cvar")
+
+    assert resp.status_code == 200
+    for level in resp.json()["levels"]:
+        assert level["cvar_historical"] >= level["var_historical"] - 1e-9, (
+            f"CVaR ({level['cvar_historical']}) < VaR ({level['var_historical']}) at confidence {level['confidence']}"
+        )
+
+
+# ── Greeks tests ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_greeks_returns_200_with_empty_strategies():
+    from archimedes.main import app
+
+    mock_provider = MagicMock()
+    mock_provider.list_strategies.return_value = []
+
+    with patch("archimedes.api.risk_routes._strategy_provider", mock_provider):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/risk/greeks")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["portfolio_delta"] == pytest.approx(0.0)
+    assert data["portfolio_gamma"] == pytest.approx(0.0)
+    assert data["portfolio_theta"] == pytest.approx(0.0)
+    assert data["portfolio_vega"] == pytest.approx(0.0)
+    assert data["strategy_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_greeks_delta_in_valid_range():
+    """|portfolio_delta| <= 1 for any realistic strategy params (ATM call delta ∈ (0,1))."""
+    from archimedes.main import app
+
+    s1 = _make_strategy("s1")
+    bt1 = _make_backtest(sharpe=1.5, cagr=0.20, max_drawdown=0.10)
+
+    mock_provider = MagicMock()
+    mock_provider.list_strategies.return_value = [s1]
+    mock_provider.get_backtest_result.return_value = bt1
+
+    with patch("archimedes.api.risk_routes._strategy_provider", mock_provider):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/risk/greeks")
+
+    assert resp.status_code == 200
+    delta = resp.json()["portfolio_delta"]
+    assert 0.0 < delta <= 1.0, f"portfolio_delta={delta} outside (0, 1]"
+
+
+@pytest.mark.asyncio
+async def test_greeks_portfolio_aggregate_matches_weighted_sum():
+    """Two equal-weight strategies with identical params → portfolio_delta equals the single-strategy delta."""
+    from archimedes.main import app
+    from archimedes.api.risk_routes import _strategy_delta
+
+    sharpe, cagr = 1.2, 0.15
+    expected = _strategy_delta(sharpe, cagr)
+
+    s1, s2 = _make_strategy("s1"), _make_strategy("s2")
+    bt1 = _make_backtest(sharpe=sharpe, cagr=cagr, max_drawdown=0.12)
+    bt2 = _make_backtest(sharpe=sharpe, cagr=cagr, max_drawdown=0.12)
+
+    mock_provider = MagicMock()
+    mock_provider.list_strategies.return_value = [s1, s2]
+    mock_provider.get_backtest_result.side_effect = lambda sid: bt1 if sid == "s1" else bt2
+
+    with patch("archimedes.api.risk_routes._strategy_provider", mock_provider):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/risk/greeks")
+
+    assert resp.status_code == 200
+    portfolio_delta = resp.json()["portfolio_delta"]
+    assert portfolio_delta == pytest.approx(expected, abs=1e-4)


### PR DESCRIPTION
## Summary

Adds two new read-only endpoints to the risk router:

- `GET /api/risk/cvar` — Historical + parametric CVaR (Expected Shortfall) at 90/95/99% confidence levels. Derives daily returns from each strategy's equity curve, pools them across the portfolio, and returns `{var_historical, cvar_historical, var_parametric, cvar_parametric, fat_tails, sample_size}` per level. Empty-data path returns 3 zero-filled levels rather than an empty array so the UI always has a stable shape.
- `GET /api/risk/greeks` — ATM Black-Scholes proxy Greeks (Delta, Gamma, Theta, Vega, Rho) per strategy, aggregated to portfolio level. Implied vol = `|CAGR| / Sharpe`; spot = strike = 1 (ATM). Equal-weight average across strategies with valid backtests.

Also adds `_strategy_delta()` as a named helper (needed by tests and a useful building block for future greek-based position sizing).

## Scope

- `backend/archimedes/api/risk_routes.py` — two new endpoints + `_bs_atm_greeks` + `_strategy_delta`
- `backend/archimedes/api/risk_schemas.py` — `CVaRLevel`, `PortfolioCVaRResponse`, `StrategyGreeks`, `PortfolioGreeksResponse`
- `backend/tests/test_risk_cvar_greeks.py` — 6 hermetic tests (CVaR invariant: ES ≥ VaR; Greeks invariant: delta ∈ (0,1]; equal-weight average check)

## Test plan

- [ ] `pytest backend/tests/test_risk_cvar_greeks.py -v` → 6 passed, 0 failed
- [ ] `ruff format --check backend/archimedes/api/risk_routes.py backend/archimedes/api/risk_schemas.py backend/tests/test_risk_cvar_greeks.py` → clean
- [ ] `ruff check --select E9,F63,F7,F40 ...` → clean