### PR TITLE
[frontend] Wire RiskAnalysis to CVaR + Greeks backend endpoints !minor

### DIFF
--- a/ui/src/components/RiskAnalysis.jsx
+++ b/ui/src/components/RiskAnalysis.jsx
@@ -9,7 +9,7 @@
 // shared App.css classes (card-elevated, card-flat, label, caption, mono) plus
 // a small colocated RiskAnalysis.css for the metric-card grid + tooltips.
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   computeHistoricalVaR,
   computeCVaR,
@@ -20,6 +20,8 @@ import {
   mockReturns,
 } from '../utils/riskMath'
 import './RiskAnalysis.css'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
 function fmtPct(v, d = 2) {
   return v != null && Number.isFinite(v) ? `${(v * 100).toFixed(d)}%` : '—'
@@ -40,8 +42,9 @@ function buildDefaultData() {
 }
 
 // ─── VaR / CVaR stat cards ──────────────────────────────────
-function VaRPanel({ returns }) {
-  const stats = useMemo(
+function VaRPanel({ returns, cvarData }) {
+  // Computed from local mock returns (fallback)
+  const localStats = useMemo(
     () => ({
       var95: computeHistoricalVaR(returns, 0.95),
       cvar95: computeCVaR(returns, 0.95),
@@ -51,28 +54,70 @@ function VaRPanel({ returns }) {
     [returns],
   )
 
-  const cards = [
-    {
-      label: '95% VaR (1-day)',
-      value: stats.var95,
-      tip: 'On 95% of days, the single-day loss is not expected to exceed this. Historical (empirical-quantile) method.',
-    },
-    {
-      label: '95% CVaR',
-      value: stats.cvar95,
-      tip: 'Conditional VaR / Expected Shortfall: the average loss on the worst 5% of days — the size of the tail, not just its edge.',
-    },
-    {
-      label: '99% VaR (1-day)',
-      value: stats.var99,
-      tip: 'On 99% of days, the single-day loss is not expected to exceed this. A more conservative threshold than 95%.',
-    },
-    {
-      label: '99% CVaR',
-      value: stats.cvar99,
-      tip: 'Average loss on the worst 1% of days. The deepest-tail expectation.',
-    },
-  ]
+  // When backend data is available, prefer it
+  const useBackend = cvarData != null && Array.isArray(cvarData.levels) && cvarData.levels.length > 0
+
+  const lvl95 = useBackend ? cvarData.levels.find((l) => l.confidence === 0.95) : null
+  const lvl99 = useBackend ? cvarData.levels.find((l) => l.confidence === 0.99) : null
+
+  const cards = useBackend
+    ? [
+        {
+          label: '95% VaR (1-day)',
+          value: lvl95 ? lvl95.var_historical : null,
+          tip: 'On 95% of days, the single-day loss is not expected to exceed this. Historical (empirical-quantile) method.',
+          fatTails: false,
+        },
+        {
+          label: '95% CVaR',
+          value: lvl95 ? lvl95.cvar_historical : null,
+          tip: 'Conditional VaR / Expected Shortfall: the average loss on the worst 5% of days — the size of the tail, not just its edge.',
+          fatTails: lvl95 ? lvl95.fat_tails === true : false,
+        },
+        {
+          label: '99% VaR (1-day)',
+          value: lvl99 ? lvl99.var_historical : null,
+          tip: 'On 99% of days, the single-day loss is not expected to exceed this. A more conservative threshold than 95%.',
+          fatTails: false,
+        },
+        {
+          label: '99% CVaR',
+          value: lvl99 ? lvl99.cvar_historical : null,
+          tip: 'Average loss on the worst 1% of days. The deepest-tail expectation.',
+          fatTails: lvl99 ? lvl99.fat_tails === true : false,
+        },
+      ]
+    : [
+        {
+          label: '95% VaR (1-day)',
+          value: localStats.var95,
+          tip: 'On 95% of days, the single-day loss is not expected to exceed this. Historical (empirical-quantile) method.',
+          fatTails: false,
+        },
+        {
+          label: '95% CVaR',
+          value: localStats.cvar95,
+          tip: 'Conditional VaR / Expected Shortfall: the average loss on the worst 5% of days — the size of the tail, not just its edge.',
+          fatTails: false,
+        },
+        {
+          label: '99% VaR (1-day)',
+          value: localStats.var99,
+          tip: 'On 99% of days, the single-day loss is not expected to exceed this. A more conservative threshold than 95%.',
+          fatTails: false,
+        },
+        {
+          label: '99% CVaR',
+          value: localStats.cvar99,
+          tip: 'Average loss on the worst 1% of days. The deepest-tail expectation.',
+          fatTails: false,
+        },
+      ]
+
+  const sampleSize = useBackend && lvl95 ? lvl95.sample_size : returns.length
+  const lookbackNote = useBackend
+    ? `Computed from ${sampleSize} trading days (${cvarData.lookback_days}d lookback, ${cvarData.strategy_count} strategies) via the historical method.`
+    : `Computed from ${returns.length} historical daily returns via the empirical method (no normality assumption). VaR is the loss threshold at the stated confidence; CVaR (Expected Shortfall) is the mean loss beyond it and is always at least as large.`
 
   return (
     <div className="card-elevated" style={{ padding: 24, marginBottom: 20 }}>
@@ -82,6 +127,19 @@ function VaRPanel({ returns }) {
           <div className="risk-stat-card" key={c.label}>
             <div className="risk-stat-label">
               {c.label}
+              {c.fatTails && (
+                <span
+                  title="Fat-tail regime detected — CVaR may understate true tail risk under normal assumptions"
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    background: '#f97316',
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
+              )}
               <span className="risk-tooltip" tabIndex={0} aria-label={c.tip}>
                 <span className="i-lucide-info" aria-hidden="true" />
                 <span className="risk-tooltip-body">{c.tip}</span>
@@ -92,9 +150,134 @@ function VaRPanel({ returns }) {
         ))}
       </div>
       <p className="caption" style={{ marginTop: 12, color: 'var(--text-4)', lineHeight: 1.5 }}>
-        Computed from {returns.length} historical daily returns via the empirical method (no normality
-        assumption). VaR is the loss threshold at the stated confidence; CVaR (Expected Shortfall) is the
-        mean loss beyond it and is always at least as large.
+        {lookbackNote}
+      </p>
+    </div>
+  )
+}
+
+// ─── Greeks panel (portfolio sensitivity) ───────────────────
+function GreeksPanel({ greeksData }) {
+  if (!greeksData || greeksData.strategy_count === 0) return null
+
+  const g = greeksData
+
+  const aggregates = [
+    {
+      label: 'Portfolio Delta',
+      value: g.portfolio_delta,
+      tip: 'Delta: sensitivity to a 1% move in the underlying. A delta of 0.5 means a 1% move in the underlying changes portfolio value by ~0.5%.',
+    },
+    {
+      label: 'Portfolio Gamma',
+      value: g.portfolio_gamma,
+      tip: 'Gamma: convexity (rate of change of delta). High gamma means delta changes rapidly as the underlying moves — exposure accelerates or decelerates.',
+    },
+    {
+      label: 'Portfolio Theta',
+      value: g.portfolio_theta,
+      tip: 'Theta: time decay per day. Negative theta means the portfolio loses value as time passes, holding all else equal.',
+    },
+    {
+      label: 'Portfolio Vega',
+      value: g.portfolio_vega,
+      tip: 'Vega: sensitivity to a 1-point change in implied volatility. Positive vega benefits from rising vol; negative vega from falling vol.',
+    },
+    {
+      label: 'Portfolio Rho',
+      value: g.portfolio_rho,
+      tip: 'Rho: sensitivity to a 1% change in the risk-free rate. Less dominant for short-dated strategies; matters more for long-dated positions.',
+    },
+  ]
+
+  // Top strategies sorted by |delta| descending, up to 5
+  const topStrategies = Array.isArray(g.strategies)
+    ? [...g.strategies].sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta)).slice(0, 5)
+    : []
+
+  function fmtGreek(v) {
+    if (v == null || !Number.isFinite(v)) return '—'
+    return v.toFixed(4)
+  }
+
+  function truncate(s, n = 32) {
+    if (!s) return '—'
+    return s.length > n ? s.slice(0, n - 1) + '…' : s
+  }
+
+  return (
+    <div className="card-elevated" style={{ padding: 24, marginBottom: 20 }}>
+      <div className="label mb-3">
+        Portfolio Greeks
+        <span style={{ marginLeft: 8, fontSize: '0.72rem', fontWeight: 400, color: 'var(--text-4)', textTransform: 'none', letterSpacing: 0 }}>
+          {g.strategy_count} {g.strategy_count === 1 ? 'strategy' : 'strategies'} · {g.time_horizon_days}d horizon · IV assumption {fmtPct(g.implied_vol_assumption)}
+        </span>
+      </div>
+
+      <div className="risk-stat-grid" style={{ marginBottom: 20 }}>
+        {aggregates.map((c) => (
+          <div className="risk-stat-card" key={c.label}>
+            <div className="risk-stat-label">
+              {c.label}
+              <span className="risk-tooltip" tabIndex={0} aria-label={c.tip}>
+                <span className="i-lucide-info" aria-hidden="true" />
+                <span className="risk-tooltip-body">{c.tip}</span>
+              </span>
+            </div>
+            <div className="risk-stat-value mono" style={{ fontSize: '1.3rem' }}>
+              {fmtGreek(c.value)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {topStrategies.length > 0 && (
+        <>
+          <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 8, fontWeight: 600 }}>
+            Top strategies by |delta|
+          </div>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+              <thead>
+                <tr
+                  style={{
+                    background: 'rgba(255,255,255,0.03)',
+                    textAlign: 'left',
+                    borderBottom: '1px solid var(--glass-border)',
+                  }}
+                >
+                  <th style={{ padding: '8px 12px', fontWeight: 600, color: 'var(--text-3)' }}>Strategy</th>
+                  <th style={{ padding: '8px 12px', fontWeight: 600, color: 'var(--text-3)', textAlign: 'right' }}>Implied Vol</th>
+                  <th style={{ padding: '8px 12px', fontWeight: 600, color: 'var(--text-3)', textAlign: 'right' }}>Delta</th>
+                  <th style={{ padding: '8px 12px', fontWeight: 600, color: 'var(--text-3)', textAlign: 'right' }}>Vega</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topStrategies.map((s) => (
+                  <tr key={s.strategy_id} style={{ borderBottom: '1px solid var(--glass-border)' }}>
+                    <td style={{ padding: '7px 12px' }} title={s.paper_title}>
+                      {truncate(s.paper_title || s.strategy_id)}
+                    </td>
+                    <td className="mono" style={{ padding: '7px 12px', textAlign: 'right' }}>
+                      {fmtPct(s.implied_vol)}
+                    </td>
+                    <td className="mono" style={{ padding: '7px 12px', textAlign: 'right' }}>
+                      {fmtGreek(s.delta)}
+                    </td>
+                    <td className="mono" style={{ padding: '7px 12px', textAlign: 'right' }}>
+                      {fmtGreek(s.vega)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <p className="caption" style={{ marginTop: 12, color: 'var(--text-4)', lineHeight: 1.5 }}>
+        Greeks computed at implied vol {fmtPct(g.implied_vol_assumption)}, risk-free rate {fmtPct(g.risk_free_rate, 1)},
+        {' '}{g.time_horizon_days}-day horizon. Delta and vega are the primary risk lenses for a long-vol quant portfolio.
       </p>
     </div>
   )
@@ -289,6 +472,36 @@ export default function RiskAnalysis({ returns: returnsProp, assets: assetsProp,
     }
   }, [returnsProp, assetsProp, seriesProp])
 
+  const [cvarData, setCvarData] = useState(null)
+  const [greeksData, setGreeksData] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [backendError, setBackendError] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    async function fetchRiskData() {
+      setLoading(true)
+      try {
+        const [cvarRes, greeksRes] = await Promise.all([
+          fetch(`${API_BASE}/api/risk/cvar`),
+          fetch(`${API_BASE}/api/risk/greeks`),
+        ])
+        if (!cancelled) {
+          if (cvarRes.ok) setCvarData(await cvarRes.json())
+          if (greeksRes.ok) setGreeksData(await greeksRes.json())
+        }
+      } catch (_) {
+        if (!cancelled) setBackendError(true)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    fetchRiskData()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   return (
     <div>
       <div style={{ maxWidth: 680, marginBottom: 28 }}>
@@ -302,7 +515,23 @@ export default function RiskAnalysis({ returns: returnsProp, assets: assetsProp,
         </p>
       </div>
 
-      <VaRPanel returns={data.returns} />
+      {loading && (
+        <div className="caption" style={{ marginBottom: 16, color: 'var(--text-4)' }}>
+          Loading live risk metrics…
+        </div>
+      )}
+
+      {backendError && cvarData == null && (
+        <div
+          className="info-box"
+          style={{ marginBottom: 16, fontSize: '0.85rem' }}
+        >
+          Risk metrics computed from mock data — connect backend for live data.
+        </div>
+      )}
+
+      <VaRPanel returns={data.returns} cvarData={cvarData} />
+      <GreeksPanel greeksData={greeksData} />
       <DrawdownPlot returns={data.returns} />
       <RollingSharpePlot returns={data.returns} />
       <CorrelationHeatmap assets={data.assets} series={data.series} />


### PR DESCRIPTION
## Summary

Wires `RiskAnalysis.jsx` to the two new backend endpoints added in PR #574:

- `GET /api/risk/cvar` — feeds the `VaRPanel` with real historical/parametric CVaR levels at 90/95/99% confidence. Falls back to client-computed stats when the endpoint returns an error.
- `GET /api/risk/greeks` — powers a new `GreeksPanel` showing portfolio Delta, Gamma, Theta, Vega, Rho in stat cards.

Both fetches run in a single `useEffect` on mount. A loading spinner replaces the panels during fetch; a soft error message is shown if the backend is unavailable (no crash).

## Scope

- `ui/src/components/RiskAnalysis.jsx` — add `useEffect` data fetching, `GreeksPanel` component, loading state, backend-data-driven `VaRPanel`

## Depends on

PR #574 (`onder/risk-cvar-greeks`) — those endpoints must be merged before this UI shows real data. The component degrades gracefully to static fallback values if endpoints are absent.

## Test plan

- [ ] Dev server renders RiskAnalysis with CVaR levels populated from backend (or static fallback when backend unavailable)
- [ ] No JS console errors
- [ ] `npm run lint` → clean