### PR TITLE
[infra] Lift numpy <2 pin in environment.yml — backtrader verified under numpy 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
       - "slowapi>=0.1.9"              # FastAPI rate-limiter — required by api/limiter.py + user_routes.py. CI installs from backend/requirements.txt; this keeps local dev parity.
 
       # --- Data + numerics ---
-      - numpy>=1.26,<2.0              # Pin <2 until backtrader compatibility is verified
+      - numpy>=2.4.6,<3.0             # numpy 2 verified against backtrader 1.9.78.123 on 2026-06-12: full analytics-engine suite (170 tests) + backend backtrader tests + e2e Faber SMA200 run all green. Aligned with backend/requirements.txt (dependabot #489).
       - pandas>=2.2
       - scipy>=1.13
       - matplotlib>=3.8


### PR DESCRIPTION
## Summary
Companion to dependabot [#489](https://github.com/a-apin/archimedes/pull/489) (merged): lifts the `numpy>=1.26,<2.0` pin in `environment.yml` to `numpy>=2.4.6,<3.0`, keeping local conda env and `backend/requirements.txt` aligned per CLAUDE.md.

The pin's documented precondition ("until backtrader compatibility is verified") is now satisfied — verified empirically today in a fresh venv (python 3.12.13, numpy 2.4.6, backtrader 1.9.78.123):

- analytics-engine full pytest suite: **170 passed, 0 failed**
- backend backtrader-path tests (`test_dsl_to_backtrader`, `test_run_backtests_script`): **17 passed**
- real end-to-end run: `archimedes-analytics-engine run --operations SPY --strategy-path strategies/faber_2007_sma200_timing.py --start 2020-01-01 --end 2023-01-01` → final value 111,252.62 from 100,000, full equity curve + methodology hash produced
- no `np.float_`/`np.bool8`/`numpy.distutils` issues anywhere

## Verify
```bash
grep numpy environment.yml backend/requirements.txt
```