### PR TITLE
[infra] SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
         with:
           role-to-assume: arn:aws:iam::159903201072:role/archimedes-github-deploy
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary

Pins every non-first-party GitHub Action in `.github/workflows/` by full commit SHA with a trailing version comment, so a tag move (or compromised tag) in a third-party repo cannot silently change the code our CI executes. An audit of all six workflows found exactly one non-first-party action — `aws-actions/configure-aws-credentials@v6` in `deploy.yml` — now pinned to the commit behind `v6.2.0`. First-party `actions/*` (checkout, setup-python, setup-node, github-script) stay on tags per the issue spec.

Closes #523

## SHA ↔ tag mapping (verified)

| Action | Tag | Commit SHA | Verification |
| --- | --- | --- | --- |
| `aws-actions/configure-aws-credentials` | `v6` → `v6.2.0` | `e7f100cf4c008499ea8adda475de1042d6975c7b` | `git/refs/tags/v6` returned annotated tag `633526d...`; dereferenced via `git/tags/<sha>` → `e7f100cf...`; cross-checked with `commits/v6 --jq .sha` → same; tag list confirms `v6.2.0` and `v6` both point at `e7f100cf...` |

Resolution commands:
```
gh api repos/aws-actions/configure-aws-credentials/git/refs/tags/v6 --jq '.object.type + " " + .object.sha'
# tag 633526dcc9c26211a4282d6d8de3d8b5cb7ad07b   (annotated)
gh api repos/aws-actions/configure-aws-credentials/git/tags/633526dcc9c26211a4282d6d8de3d8b5cb7ad07b --jq .object.sha
# e7f100cf4c008499ea8adda475de1042d6975c7b
gh api repos/aws-actions/configure-aws-credentials/commits/v6 --jq .sha
# e7f100cf4c008499ea8adda475de1042d6975c7b   (matches)
```

## Verification

- `grep -rn "uses: aws-actions" .github/workflows` → single hit, 40-hex SHA pin with `# v6.2.0` comment.
- Reviewed every `uses:` line across all 6 workflows (`grep -rn "uses:" .github/workflows/*.yml`): all remaining lines are first-party `actions/*` on tags; no other third-party actions exist.
- YAML validity: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → exit 0.