### PR TITLE
[contracts] Make SyntheticVault redemption solvent under stress

### DIFF
--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -83,14 +83,53 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     }
 
     /// @notice Burn synth tokens and receive USDC back.
+    ///
+    /// @dev SOLVENCY MECHANISM — pro-rata redemption under stress (audit 2026-06-10
+    ///      finding #14, issue #509).
+    ///
+    ///      Mint collateralizes against the *mint-time* price (a user deposits
+    ///      `collateralRatio` (120%) of the mint-price value of the synth issued), but
+    ///      burn pays the *current-price* value. If the asset appreciates more than the
+    ///      collateral buffer (>20% at the default ratio), total redemption liability
+    ///      exceeds vault collateral. Pre-fix behavior was first-come-first-served:
+    ///      early redeemers extracted full current-price value and late redeemers
+    ///      reverted with `InsufficientCollateral` against an empty vault.
+    ///
+    ///      Design decision — option (b) pro-rata haircut, NOT option (a) raising the
+    ///      collateral ratio:
+    ///      * No finite ratio fixes the mechanism: because collateral is keyed to the
+    ///        mint-time price, raising 120% → 150% only moves the insolvency cliff from
+    ///        +20% to +50% appreciation; beyond it the FCFS drain is unchanged. (a) also
+    ///        worsens capital efficiency for every healthy-state user.
+    ///      * Pro-rata is order-independent in this exact code shape. When available
+    ///        collateral C < total liability L (= totalSupply × price), each redemption
+    ///        is scaled by C/L, i.e. a redeemer burning s of supply S receives gross
+    ///        s·C/S. Collateral then falls to C·(1 − s/S) and supply to S − s, so the
+    ///        per-synth payout C/S is invariant across sequential redemptions: early
+    ///        redeemers cannot extract more than their pro-rata share, and the last
+    ///        redeemer is paid the same rate instead of reverting. Integer division
+    ///        rounds the haircut payout down, so dust errs in the vault's favor.
+    ///      * When the vault is healthy (C ≥ L) the scale factor is 1 and behavior is
+    ///        identical to the pre-fix path: full current-price value, minus burn fee.
     function burn(uint256 synthAmount) external nonReentrant returns (uint256) {
         if (synthAmount == 0) revert ZeroAmount();
 
         uint256 assetPrice = oracle.getPrice();
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
+
+        // Pro-rata solvency cap: under stress, scale the claim by C/L so redemption
+        // order cannot redistribute value between holders (see @dev above).
+        uint256 available = usdc.balanceOf(address(this)) - protocolFees;
+        uint256 totalLiability = (synthToken.totalSupply() * assetPrice) / (10 ** SYNTH_DECIMALS);
+        if (totalLiability > available) {
+            usdcValue = (usdcValue * available) / totalLiability;
+        }
+
         uint256 fee = (usdcValue * burnFeeBps) / BPS;
         uint256 usdcOut = usdcValue - fee;
 
+        // Defense-in-depth only: with the pro-rata cap above, usdcOut <= available
+        // always holds (s <= S implies s·C/S <= C), so this cannot revert in practice.
         if (usdc.balanceOf(address(this)) < usdcOut + protocolFees) {
             revert InsufficientCollateral();
         }
@@ -115,6 +154,14 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     function previewBurn(uint256 synthAmount) external view returns (uint256) {
         uint256 assetPrice = oracle.getPrice();
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
+
+        // Mirror burn()'s pro-rata solvency cap so preview == actual under stress.
+        uint256 available = usdc.balanceOf(address(this)) - protocolFees;
+        uint256 totalLiability = (synthToken.totalSupply() * assetPrice) / (10 ** SYNTH_DECIMALS);
+        if (totalLiability > available) {
+            usdcValue = (usdcValue * available) / totalLiability;
+        }
+
         uint256 fee = (usdcValue * burnFeeBps) / BPS;
         return usdcValue - fee;
     }

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -182,6 +182,136 @@ contract SyntheticVaultTest is Test {
         assertGt(vault.protocolFees(), 0);
     }
 
+    // ─── Solvency / Pro-Rata Redemption Tests (issue #509, audit #14) ──
+
+    /// @dev Total issued synth is redeemed across multiple holders after an adverse
+    ///      (upward) price move that makes the vault under-collateralized. Pre-fix:
+    ///      alice (first) extracted full current-price value and bob's burn reverted
+    ///      with InsufficientCollateral. Post-fix: both succeed and, holding equal
+    ///      synth, receive equal pro-rata payouts regardless of redemption order.
+    function test_burn_total_supply_pro_rata_after_price_spike() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+
+        // Alice and bob mint identical amounts at the initial price.
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 aliceSynth = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 bobSynth = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        // Price spikes +50% — beyond the 20% mint-side buffer, so total liability
+        // (totalSupply * price) now exceeds vault collateral.
+        vm.prank(owner);
+        oracle.setPrice((INITIAL_PRICE * 150) / 100);
+
+        uint256 collateralBefore = usdc.balanceOf(address(vault)) - vault.protocolFees();
+        uint256 liability = (sTSLA.totalSupply() * oracle.getPrice()) / 1e18;
+        assertGt(liability, collateralBefore, "scenario must be under-collateralized");
+
+        // Alice redeems everything first...
+        vm.prank(alice);
+        uint256 alicePayout = vault.burn(aliceSynth);
+
+        // ...and bob redeems the entire remaining supply. Pre-fix this reverted.
+        vm.prank(bob);
+        uint256 bobPayout = vault.burn(bobSynth);
+
+        assertEq(sTSLA.totalSupply(), 0, "all issued synth redeemed");
+
+        // Equal holders get equal value: redemption order must not redistribute.
+        // (1 wei tolerance for integer-division dust; dust favors the vault.)
+        assertApproxEqAbs(alicePayout, bobPayout, 1, "order-independent pro-rata payout");
+
+        // Early redeemer capped at her pro-rata share of available collateral
+        // (alice held half the supply -> at most half the collateral, gross of fee).
+        assertLe(alicePayout, collateralBefore / 2, "no more than pro-rata share");
+
+        // Vault stays solvent: balance still covers accrued protocol fees.
+        assertGe(usdc.balanceOf(address(vault)), vault.protocolFees());
+    }
+
+    /// @dev Unequal holders, full-supply redemption under stress: per-synth payout
+    ///      rate is the same for both, and total payouts never exceed collateral.
+    function test_burn_pro_rata_unequal_holders() public {
+        vm.startPrank(alice);
+        usdc.approve(address(vault), 30_000 * 10**6);
+        uint256 aliceSynth = vault.mint(30_000 * 10**6); // 3x bob's position
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        usdc.approve(address(vault), 10_000 * 10**6);
+        uint256 bobSynth = vault.mint(10_000 * 10**6);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        oracle.setPrice(INITIAL_PRICE * 2); // +100%
+
+        uint256 collateralBefore = usdc.balanceOf(address(vault)) - vault.protocolFees();
+
+        // Bob (small holder) redeems first this time.
+        vm.prank(bob);
+        uint256 bobPayout = vault.burn(bobSynth);
+
+        vm.prank(alice);
+        uint256 alicePayout = vault.burn(aliceSynth);
+
+        assertEq(sTSLA.totalSupply(), 0);
+
+        // Same per-synth rate (scaled to 1e18 synth units; tolerate division dust).
+        uint256 bobRate = (bobPayout * 1e18) / bobSynth;
+        uint256 aliceRate = (alicePayout * 1e18) / aliceSynth;
+        assertApproxEqRel(bobRate, aliceRate, 1e12, "equal per-synth payout rate"); // 0.0001%
+
+        // Vault never pays out more than it had.
+        assertLe(alicePayout + bobPayout, collateralBefore, "payouts bounded by collateral");
+        assertGe(usdc.balanceOf(address(vault)), vault.protocolFees());
+    }
+
+    /// @dev When the vault is healthy (collateral >= liability), the pro-rata cap is
+    ///      inactive and burn pays full current-price value minus fee, as before.
+    function test_burn_no_haircut_when_healthy() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synthOut = vault.mint(usdcAmount);
+
+        // Price unchanged: 120% mint collateral comfortably covers 100% redemption.
+        uint256 usdcValue = (synthOut * oracle.getPrice()) / 1e18;
+        uint256 expected = usdcValue - (usdcValue * 50) / 10000; // minus 0.5% burn fee
+
+        uint256 payout = vault.burn(synthOut);
+        vm.stopPrank();
+
+        assertEq(payout, expected, "full price value when solvent");
+    }
+
+    /// @dev previewBurn must mirror burn exactly while the haircut is active.
+    function test_preview_burn_matches_under_stress() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synthOut = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        usdc.approve(address(vault), usdcAmount);
+        vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        oracle.setPrice((INITIAL_PRICE * 150) / 100);
+
+        uint256 preview = vault.previewBurn(synthOut);
+        vm.prank(alice);
+        uint256 actual = vault.burn(synthOut);
+
+        assertEq(preview, actual, "preview == actual under haircut");
+    }
+
     // ─── View Tests ───────────────────────────────────────────────
 
     function test_preview_mint() public {


### PR DESCRIPTION
## Summary

Closes #509 — audit 2026-06-10 finding #14 (High): `SyntheticVault` is structurally under-collateralized. Mint collateralizes at `collateralRatio` (120%) of the **mint-time** price, but `burn` pays full **current-price** value. Once the asset appreciates past the buffer (>20% at the default ratio), total redemption liability exceeds vault collateral: first redeemers extracted full value, later redeemers reverted with `InsufficientCollateral` against an emptied vault.

## Mechanism chosen: (b) pro-rata redemption haircut

Of the two options in the issue:

- **(a) Raise the collateral ratio — rejected.** Because collateral is keyed to the mint-time price, no finite ratio fixes the mechanism: 120% → 150% only moves the insolvency cliff from +20% to +50% appreciation, and beyond it the first-come-first-served drain is unchanged. It also worsens capital efficiency for every healthy-state user.
- **(b) Pro-rata haircut — chosen.** When available collateral `C` < total liability `L = totalSupply × price`, each redemption claim is scaled by `C/L`. This is **order-independent** in this exact code shape: a redeemer burning `s` of supply `S` receives gross `s·C/S`; collateral then falls to `C·(1 − s/S)` and supply to `S − s`, so the per-synth payout `C/S` is invariant across sequential redemptions. Early redeemers cannot extract more than their pro-rata share; the last redeemer is paid at the same rate instead of reverting. Integer division rounds the haircut down, so dust favors the vault. When the vault is healthy (`C ≥ L`) the scale factor is 1 and behavior is byte-identical to before. `previewBurn` mirrors the cap so `preview == actual` under stress. The old `InsufficientCollateral` check is kept as defense-in-depth (now unreachable: `s ≤ S ⇒ s·C/S ≤ C`).

Full rationale is also documented in the `@dev` comment on `burn()`.

## Changes

- `contracts/src/SyntheticVault.sol` — pro-rata cap in `burn()` + `previewBurn()`, mechanism doc comment. No signature/event/ABI shape changes.
- `contracts/test/SyntheticVault.t.sol` — 4 new tests:
  - `test_burn_total_supply_pro_rata_after_price_spike` — two equal holders, +50% price spike, **total issued synth redeemed**: no revert for the late redeemer, equal payouts regardless of order, early redeemer capped at her pro-rata share, vault stays solvent.
  - `test_burn_pro_rata_unequal_holders` — 3:1 holders, +100% spike, full-supply redemption: identical per-synth payout rate, total payouts bounded by collateral.
  - `test_burn_no_haircut_when_healthy` — healthy-path regression: full price value minus fee, unchanged.
  - `test_preview_burn_matches_under_stress` — preview parity while the haircut is active.

## Verification

```
forge test --match-contract SyntheticVaultTest
→ 20 passed; 2 failed (test_isFresh, test_revert_stale_price — pre-existing
  PriceOracle staleness-constant drift, owned by the parallel #508 PR)

forge test   (full suite)
→ 101 passed, 2 failed (same 2 known drift tests)
Baseline before this change: 97 passed, 2 failed → +4 new tests, no new failures.
```

Negative control: with the contract fix stashed, both stress tests fail against the pre-fix code with `InsufficientCollateral()` — reproducing the audited drain/strand behavior exactly.

## Redeploy required

`contracts/abis/` is deliberately **not** touched — it mirrors the live Arc testnet deployment. The deployed `SyntheticVault` instances still carry the FCFS bug; this fix requires a redeploy of `SyntheticVault` (and re-pointing `SyntheticFactory`/backend addresses). Note: the external ABI is unchanged (no signature/event changes), so consumers need only new addresses, not new ABI files.

## Review

Contract change — needs Chuan's review (live-funds surface, two approvals per convention). Cross-lane note: authored from Önder's risk-math lane; the solvency-invariant argument is in the `burn()` doc comment for review.