### PR TITLE
[contracts] Guard Vault against first-depositor share inflation

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -25,6 +25,28 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     uint256 public constant SECONDS_PER_YEAR = 365 days;
     uint256 public constant PLATFORM_FEE_BPS = 1000; // 10% platform cut
 
+    /// @notice First-depositor share-inflation guard (audit 2026-06-10 finding #4, issue #507).
+    ///
+    ///         Chosen mitigation: **Option B — dead shares.** On the first deposit a fixed
+    ///         MIN_LIQUIDITY of shares is minted to an unrecoverable sink and subtracted from
+    ///         the receiver. An attacker can no longer own ~100% of a dust supply and then
+    ///         donate USDC to inflate NAV: the sink permanently holds MIN_LIQUIDITY shares,
+    ///         so the attacker's share of any donation is at most 1/(MIN_LIQUIDITY+1) — the
+    ///         donation is overwhelmingly burned, making the attack strictly unprofitable,
+    ///         and later depositors' shares no longer round to zero.
+    ///
+    ///         Why not Option A (OZ-style virtual decimals offset): a decimals offset of
+    ///         d > 0 rescales shares-per-asset by 10**d, which silently breaks this vault's
+    ///         performance-fee math — `highWaterMark` is initialized to 1e18 assuming a 1:1
+    ///         share:asset scale, so nav-per-share would start at 1e18/10**d and the
+    ///         performance fee would never (or wrongly) accrue. Dead shares preserve the
+    ///         1:1 scale and leave the fee logic untouched. Cost: the first depositor
+    ///         forfeits MIN_LIQUIDITY share-wei (1e3 = 0.001 USDC at 6 decimals) — negligible.
+    uint256 public constant MIN_LIQUIDITY = 1e3;
+
+    /// @notice Sink for dead shares (OZ ERC20 forbids minting to address(0)).
+    address public constant DEAD_SHARES_SINK = address(0xdEaD);
+
     // ─── Immutables ──────────────────────────────────────────────────
 
     address public immutable override asset;
@@ -119,6 +141,13 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
 
         shares = previewDeposit(assets);
         if (shares == 0) revert ZeroShares();
+
+        // Inflation-attack guard: lock MIN_LIQUIDITY dead shares on the first deposit.
+        // previewDeposit already subtracted MIN_LIQUIDITY from the receiver's shares,
+        // so total minted == assets and the 1:1 share:asset scale is preserved.
+        if (totalSupply() == 0) {
+            _mint(DEAD_SHARES_SINK, MIN_LIQUIDITY);
+        }
 
         // Mint shares to receiver
         _mint(receiver, shares);
@@ -217,8 +246,14 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         uint256 _totalSupply = totalSupply();
         uint256 _totalAssets = totalAssets();
 
-        if (_totalSupply == 0 || _totalAssets == 0) {
-            // 1:1 initial rate
+        if (_totalSupply == 0) {
+            // First deposit: 1:1 rate minus the MIN_LIQUIDITY dead shares locked in
+            // deposit() (inflation-attack guard — see MIN_LIQUIDITY doc above).
+            // Deposits of <= MIN_LIQUIDITY return 0 and deposit() reverts ZeroShares,
+            // so a 1-wei first deposit (the classic attack setup) is impossible.
+            shares = assets > MIN_LIQUIDITY ? assets - MIN_LIQUIDITY : 0;
+        } else if (_totalAssets == 0) {
+            // Degenerate: supply exists but NAV is zero — keep legacy 1:1 fallback.
             shares = assets;
         } else {
             shares = (assets * _totalSupply) / _totalAssets;
@@ -483,13 +518,16 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         lastFeeTimestamp = block.timestamp;
     }
 
+    /// @dev Shares to burn for an exact-assets withdraw. Rounds UP (against the
+    ///      withdrawer), per ERC-4626 previewWithdraw semantics — audit finding #4
+    ///      flagged the old round-down as a depositor-favored rounding leak.
     function _convertToShares(uint256 assets) internal view returns (uint256 shares) {
         uint256 _totalSupply = totalSupply();
         uint256 _totalAssets = totalAssets();
         if (_totalSupply == 0 || _totalAssets == 0) {
             shares = assets;
         } else {
-            shares = (assets * _totalSupply) / _totalAssets;
+            shares = (assets * _totalSupply + _totalAssets - 1) / _totalAssets;
         }
     }
 

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -104,9 +104,11 @@ contract VaultTest is Test {
         uint256 shares = vault.deposit(amount, alice);
         vm.stopPrank();
 
-        // First deposit: 1:1 rate
-        assertEq(shares, amount);
+        // First deposit: 1:1 rate minus MIN_LIQUIDITY dead shares (inflation guard, #507)
+        assertEq(shares, amount - vault.MIN_LIQUIDITY());
         assertEq(vault.balanceOf(alice), shares);
+        assertEq(vault.balanceOf(vault.DEAD_SHARES_SINK()), vault.MIN_LIQUIDITY());
+        assertEq(vault.totalSupply(), amount); // 1:1 share:asset scale preserved
         assertEq(usdc.balanceOf(address(vault)), amount);
     }
 
@@ -145,11 +147,14 @@ contract VaultTest is Test {
         usdc.approve(address(vault), amount);
         vault.deposit(amount, alice);
 
+        // First depositor's max withdraw is amount - MIN_LIQUIDITY: the dead shares
+        // (inflation guard, #507) keep their pro-rata sliver of assets locked.
+        uint256 withdrawable = amount - vault.MIN_LIQUIDITY();
         uint256 aliceUsdcBefore = usdc.balanceOf(alice);
-        vault.withdraw(amount, alice, alice);
+        vault.withdraw(withdrawable, alice, alice);
         vm.stopPrank();
 
-        assertEq(usdc.balanceOf(alice) - aliceUsdcBefore, amount);
+        assertEq(usdc.balanceOf(alice) - aliceUsdcBefore, withdrawable);
         assertEq(vault.balanceOf(alice), 0);
     }
 
@@ -164,7 +169,9 @@ contract VaultTest is Test {
         vault.redeem(shares, alice, alice);
         vm.stopPrank();
 
-        assertEq(usdc.balanceOf(alice) - aliceUsdcBefore, amount);
+        // shares = amount - MIN_LIQUIDITY (dead shares, #507); redeeming them all
+        // returns the matching pro-rata assets at the unchanged 1:1 rate.
+        assertEq(usdc.balanceOf(alice) - aliceUsdcBefore, amount - vault.MIN_LIQUIDITY());
         assertEq(vault.balanceOf(alice), 0);
     }
 
@@ -200,6 +207,82 @@ contract VaultTest is Test {
         vm.stopPrank();
 
         assertEq(preview, actual);
+    }
+
+    // ─── Inflation-Attack Tests (audit 2026-06-10 #4 / issue #507) ───
+
+    /// @dev Classic first-depositor inflation attack: deposit 1 wei, donate USDC
+    ///      directly to the vault to inflate NAV, and let the victim's deposit
+    ///      round to zero shares. With MIN_LIQUIDITY dead shares the 1-wei seed
+    ///      deposit is impossible and the donation is absorbed by the dead shares,
+    ///      so the victim keeps ~full value and the attacker takes a massive loss.
+    function test_inflation_attack_fails() public {
+        uint256 minLiq = vault.MIN_LIQUIDITY();
+
+        // Step 1: the canonical 1-wei first deposit now reverts —
+        // previewDeposit(1) == 0 because MIN_LIQUIDITY is subtracted.
+        vm.startPrank(bob); // bob = attacker
+        usdc.approve(address(vault), type(uint256).max);
+        vm.expectRevert(Vault.ZeroShares.selector);
+        vault.deposit(1, bob);
+
+        // Step 2: attacker falls back to the smallest viable first deposit
+        // (MIN_LIQUIDITY + 1 wei → exactly 1 share; dead sink holds MIN_LIQUIDITY).
+        uint256 attackerCost = minLiq + 1;
+        uint256 attackerShares = vault.deposit(attackerCost, bob);
+        assertEq(attackerShares, 1);
+
+        // Step 3: attacker donates USDC directly to the vault to inflate NAV
+        uint256 donation = 10_000 * 10**6;
+        usdc.transfer(address(vault), donation);
+        attackerCost += donation;
+        vm.stopPrank();
+
+        // Step 4: victim deposits
+        uint256 victimDeposit = 10_000 * 10**6;
+        vm.startPrank(alice); // alice = victim
+        usdc.approve(address(vault), victimDeposit);
+        uint256 victimShares = vault.deposit(victimDeposit, alice);
+        vm.stopPrank();
+
+        // Victim's shares MUST NOT round to zero
+        assertGt(victimShares, 0);
+
+        // Victim's redeemable value ≈ deposit (within 0.1% rounding tolerance)
+        uint256 victimValue = vault.previewRedeem(victimShares);
+        assertApproxEqRel(victimValue, victimDeposit, 0.001e18);
+
+        // Attack is strictly unprofitable: the dead shares absorb
+        // MIN_LIQUIDITY/(MIN_LIQUIDITY+1) of the donation, so the attacker
+        // recovers only a dust fraction of what they spent.
+        uint256 attackerValue = vault.previewRedeem(attackerShares);
+        assertLt(attackerValue, attackerCost / 100); // lost > 99% of outlay
+    }
+
+    /// @dev Donation alone (no zero-share rounding) must not let any depositor
+    ///      capture more than their pro-rata claim from a later depositor.
+    function test_donation_does_not_dilute_later_depositor() public {
+        uint256 amount = 10_000 * 10**6;
+
+        // Honest first depositor
+        vm.startPrank(alice);
+        usdc.approve(address(vault), amount);
+        vault.deposit(amount, alice);
+        vm.stopPrank();
+
+        // Third party donates to the vault
+        usdc.mint(address(this), amount);
+        usdc.transfer(address(vault), amount);
+
+        // Bob deposits after the donation: his shares price in the doubled NAV,
+        // and his redeemable value still ≈ his deposit.
+        vm.startPrank(bob);
+        usdc.approve(address(vault), amount);
+        uint256 bobShares = vault.deposit(amount, bob);
+        vm.stopPrank();
+
+        assertGt(bobShares, 0);
+        assertApproxEqRel(vault.previewRedeem(bobShares), amount, 0.001e18);
     }
 
     // ─── Rebalance Tests ─────────────────────────────────────────────
@@ -438,11 +521,12 @@ contract VaultTest is Test {
         vm.startPrank(alice);
         usdc.approve(address(vault), amount);
         vault.deposit(amount, alice);
-        vault.withdraw(amount, alice, alice);
+        vault.withdraw(amount - vault.MIN_LIQUIDITY(), alice, alice);
         vm.stopPrank();
 
-        // Alice should have her USDC back (no fees accrued since time didn't pass)
-        assertEq(usdc.balanceOf(alice), aliceUsdcBefore);
+        // Alice gets her USDC back minus the one-time MIN_LIQUIDITY dead-share cost
+        // (1e3 share-wei = 0.001 USDC, inflation guard #507; no fees — no time passed)
+        assertEq(usdc.balanceOf(alice), aliceUsdcBefore - vault.MIN_LIQUIDITY());
     }
 
     function test_multiple_deposits_withdraws() public {
@@ -459,11 +543,13 @@ contract VaultTest is Test {
         usdc.approve(address(vault), amount2);
         vault.deposit(amount2, bob);
 
-        // Alice withdraws
+        // Alice withdraws her full entitlement: amount1 minus the MIN_LIQUIDITY
+        // dead shares locked by her first deposit (inflation guard, #507)
         vm.startPrank(alice);
-        vault.withdraw(amount1, alice, alice);
+        vault.withdraw(amount1 - vault.MIN_LIQUIDITY(), alice, alice);
 
-        assertEq(vault.totalAssets(), amount2);
+        // Vault retains amount2 plus the dead shares' pro-rata assets
+        assertEq(vault.totalAssets(), amount2 + vault.MIN_LIQUIDITY());
         assertEq(vault.balanceOf(alice), 0);
         assertEq(vault.balanceOf(bob), amount2);
     }


### PR DESCRIPTION
## Summary

Fixes the ERC-4626 first-depositor share-inflation attack on `contracts/src/Vault.sol` (AUDIT_2026-06-10.md finding #4, Critical). Previously an attacker could deposit 1 wei (minting 1 share at the 1:1 bootstrap rate), donate USDC directly to the vault to inflate `totalAssets()` (live `balanceOf` read), and cause subsequent depositors' shares to round to zero — classic inflation theft.

Closes #507

## Chosen mitigation: Option B — dead shares

On the first deposit, a fixed `MIN_LIQUIDITY = 1e3` shares are minted to `DEAD_SHARES_SINK` (`0xdEaD`; OZ ERC20 forbids minting to `address(0)`) and subtracted from the receiver, so total minted == assets deposited.

**Why not Option A (OZ virtual-decimals offset):** an offset `d > 0` rescales shares-per-asset by `10**d`, which silently breaks this vault's performance-fee math — `highWaterMark` is initialized to `1e18` assuming a 1:1 share:asset scale, so NAV-per-share would start at `1e18 / 10**d` and the performance fee would never (or wrongly) accrue. Dead shares preserve the 1:1 scale and leave the fee logic untouched. Cost: the first depositor forfeits 1e3 share-wei (= 0.001 USDC at 6 decimals) — negligible. Rationale is documented in a code comment on `MIN_LIQUIDITY`.

Effect: a 1-wei seed deposit now reverts (`ZeroShares`), and any NAV-inflating donation is absorbed `MIN_LIQUIDITY/(MIN_LIQUIDITY+1)` by the dead shares — the attack is strictly unprofitable and later depositors no longer round to zero.

Defense-in-depth from the same finding's "missing defenses" list: `_convertToShares` (withdraw path) now rounds **up** per ERC-4626 `previewWithdraw` semantics, closing the depositor-favored rounding leak.

## Verification

Baseline on `main`: 97 passed, 2 pre-existing failures in `test/SyntheticVault.t.sol` (`test_isFresh`, `test_revert_stale_price` — known test/contract drift, untouched).

```
forge test --match-contract VaultTest
  Suite result: ok. 32 passed; 0 failed; 0 skipped

forge test   (full suite)
  99 tests passed, 2 failed (101 total)
  Failing: SyntheticVault test_isFresh + test_revert_stale_price — same 2 as baseline, no NEW failures
```

New tests:
- `test_inflation_attack_fails` — full attack reproduction: 1-wei first deposit reverts; attacker falls back to minimum-viable seed (1001 wei → 1 share) + 10,000 USDC donation; victim deposits 10,000 USDC → shares > 0, redeemable value within 0.1% of deposit; attacker recovers < 1% of outlay.
- `test_donation_does_not_dilute_later_depositor` — donation to an honestly-seeded vault doesn't dilute a later depositor.

## Existing tests updated (intentionally, all for the MIN_LIQUIDITY accounting)

- `test_deposit_first` — first depositor receives `amount − 1e3` shares; asserts dead sink holds `MIN_LIQUIDITY` and `totalSupply == amount` (scale preserved).
- `test_withdraw` — first depositor's max withdraw is `amount − 1e3` (dead shares keep their pro-rata sliver).
- `test_redeem` — redeeming all of the first depositor's shares returns `amount − 1e3`.
- `test_deposit_withdraw_round_trip` — round trip nets `−1e3` wei (= 0.001 USDC one-time guard cost).
- `test_multiple_deposits_withdraws` — alice withdraws `amount1 − 1e3`; vault retains `amount2 + 1e3`.

All other deposit/preview tests (`test_deposit_second_user`, `test_previewDeposit`, `test_previewRedeem`, fee tests) pass unchanged — second-depositor and preview semantics are unaffected.

## Follow-up required before this protects the live vault

- **Redeploy + ABI refresh required.** `contracts/abis/` is deliberately untouched — the cached ABIs mirror the LIVE deployed contracts and regenerating them now would break the running backend. The deployed `Vault`/`VaultFactory` on Arc testnet remain vulnerable until redeployed; after redeploy, refresh `contracts/abis/` (the ABI surface gains the `MIN_LIQUIDITY` and `DEAD_SHARES_SINK` constant getters).
- Contract change — requires Chuan's review per repo convention (2 reviews for contract changes).