### PR TITLE
[contracts] Add commit-reveal provenance to ReasoningTraceRegistry !minor

### DIFF
--- a/contracts/src/ReasoningTraceRegistry.sol
+++ b/contracts/src/ReasoningTraceRegistry.sol
@@ -9,6 +9,16 @@ import "./interfaces/IReasoningTraceRegistry.sol";
 /// @notice On-chain provenance anchoring of agent reasoning traces.
 ///         Stores keccak256 hashes — full traces live off-chain in Postgres.
 ///         Anyone can verify a trace by recomputing its hash and comparing.
+///
+///         v1.5 (commit-reveal, per docs/specs/commit-reveal-trace-spec.md +
+///         audit 2026-06-10 finding #18):
+///         - commit() anchors the trace hash BEFORE the covered trade executes,
+///           with a time-lock requiring the claimed execution to land at least
+///           one block after the commit.
+///         - reveal() publishes the content AFTER settlement; the contract
+///           recomputes the hash and verifies the binding on-chain.
+///         - All anchoring (publishTrace AND commit) is scoped to the vault's
+///           agent/owner — arbitrary addresses cannot forge anchors for a vault.
 contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
     // ─── Structs ─────────────────────────────────────────────────────
 
@@ -18,6 +28,15 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
         bytes32 traceHash;
         uint256 timestamp;
         bytes metadata;
+    }
+
+    struct Commitment {
+        bytes32 contentHash;
+        address committer;
+        uint64 commitBlock;
+        uint64 claimedExecutionTime;
+        uint64 revealBlock; // 0 until revealed
+        string storagePointer; // empty until revealed
     }
 
     // ─── State ───────────────────────────────────────────────────────
@@ -31,6 +50,12 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
     /// @notice vault address => trace IDs
     mapping(address => uint256[]) private _vaultTraces;
 
+    /// @notice trace ID => commit-reveal commitment (only set for commit() traces)
+    mapping(uint256 => Commitment) private _commitments;
+
+    /// @notice vault => agent => explicitly granted anchoring authority
+    mapping(address => mapping(address => bool)) private _vaultAgents;
+
     // ─── Constructor ─────────────────────────────────────────────────
 
     constructor(address _owner) Ownable(_owner) {
@@ -38,13 +63,100 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
         _traces.push();
     }
 
+    // ─── Authorization ───────────────────────────────────────────────
+
+    function setVaultAgent(address vault, address agent, bool authorized) external override onlyOwner {
+        _vaultAgents[vault][agent] = authorized;
+        emit VaultAgentSet(vault, agent, authorized);
+    }
+
+    function isAuthorizedForVault(address vault, address account) public view override returns (bool) {
+        if (_vaultAgents[vault][account]) return true;
+        if (vault.code.length == 0) return false;
+        // Live introspection of Vault-shaped contracts: agent(), creator(), owner().
+        return _roleMatches(vault, bytes4(keccak256("agent()")), account)
+            || _roleMatches(vault, bytes4(keccak256("creator()")), account)
+            || _roleMatches(vault, bytes4(keccak256("owner()")), account);
+    }
+
+    /// @dev Non-reverting role probe: staticcall the zero-arg selector and compare
+    ///      the returned address. Any failure (missing function, wrong return shape)
+    ///      reads as "no match" rather than reverting.
+    function _roleMatches(address vault, bytes4 selector, address account) private view returns (bool) {
+        (bool ok, bytes memory data) = vault.staticcall(abi.encodeWithSelector(selector));
+        return ok && data.length == 32 && abi.decode(data, (address)) == account;
+    }
+
     // ─── Write ───────────────────────────────────────────────────────
 
+    /// @inheritdoc IReasoningTraceRegistry
+    /// @dev v1 anchor-after-the-fact, kept for backwards compatibility with the
+    ///      existing backend publisher. As of v1.5 it is gated by vault authority —
+    ///      it no longer accepts anchors from arbitrary addresses. It carries no
+    ///      temporal-binding guarantee; new integrations should use commit()+reveal().
     function publishTrace(
         address vault,
         bytes32 traceHash,
         bytes calldata metadata
     ) external override returns (uint256 traceId) {
+        require(isAuthorizedForVault(vault, msg.sender), "Not authorized for vault");
+        traceId = _pushTrace(vault, traceHash, metadata);
+        emit TracePublished(traceId, msg.sender, vault, traceHash, block.timestamp);
+    }
+
+    /// @inheritdoc IReasoningTraceRegistry
+    function commit(
+        address vault,
+        bytes32 contentHash,
+        uint64 claimedExecutionTime,
+        bytes calldata tradeIntentSummary
+    ) external override returns (uint256 traceId) {
+        require(isAuthorizedForVault(vault, msg.sender), "Not authorized for vault");
+        require(contentHash != bytes32(0), "Empty content hash");
+        // Time-lock: the covered execution must be claimed strictly after this
+        // block's timestamp — i.e. it lands at least one block after the commit.
+        require(claimedExecutionTime > block.timestamp, "Time-lock: execution must follow commit");
+
+        traceId = _pushTrace(vault, contentHash, tradeIntentSummary);
+
+        _commitments[traceId] = Commitment({
+            contentHash: contentHash,
+            committer: msg.sender,
+            commitBlock: uint64(block.number),
+            claimedExecutionTime: claimedExecutionTime,
+            revealBlock: 0,
+            storagePointer: ""
+        });
+
+        emit TraceCommitted(traceId, contentHash, msg.sender, vault, block.number, claimedExecutionTime);
+    }
+
+    /// @inheritdoc IReasoningTraceRegistry
+    function reveal(
+        uint256 traceId,
+        string calldata storagePointer,
+        bytes calldata fullTraceContent
+    ) external override {
+        Commitment storage c = _commitments[traceId];
+        require(c.committer != address(0), "No commitment");
+        require(c.revealBlock == 0, "Already revealed");
+        require(msg.sender == c.committer, "Not committer");
+        // Temporal binding: commit block < execution <= reveal block.
+        require(block.number > c.commitBlock, "Time-lock: reveal in commit block");
+        require(block.timestamp >= c.claimedExecutionTime, "Reveal before claimed execution");
+        // The binding itself: the revealed content must hash to the committed hash.
+        require(keccak256(fullTraceContent) == c.contentHash, "Hash mismatch");
+
+        c.revealBlock = uint64(block.number);
+        c.storagePointer = storagePointer;
+
+        emit TraceRevealed(traceId, storagePointer, block.number);
+    }
+
+    function _pushTrace(address vault, bytes32 traceHash, bytes calldata metadata)
+        private
+        returns (uint256 traceId)
+    {
         traceId = _traces.length;
 
         _traces.push(Trace({
@@ -57,8 +169,6 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
 
         _agentTraces[msg.sender].push(traceId);
         _vaultTraces[vault].push(traceId);
-
-        emit TracePublished(traceId, msg.sender, vault, traceHash, block.timestamp);
     }
 
     // ─── Read ────────────────────────────────────────────────────────
@@ -71,6 +181,35 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
     {
         if (traceId == 0 || traceId >= _traces.length) return false;
         return _traces[traceId].traceHash == keccak256(fullTrace);
+    }
+
+    function getCommitment(uint256 traceId)
+        external
+        view
+        override
+        returns (
+            bytes32 contentHash,
+            address committer,
+            address vault,
+            uint256 commitBlock,
+            uint64 claimedExecutionTime,
+            bool revealed,
+            uint256 revealBlock,
+            string memory storagePointer
+        )
+    {
+        Commitment storage c = _commitments[traceId];
+        require(c.committer != address(0), "No commitment");
+        return (
+            c.contentHash,
+            c.committer,
+            _traces[traceId].vault,
+            c.commitBlock,
+            c.claimedExecutionTime,
+            c.revealBlock != 0,
+            c.revealBlock,
+            c.storagePointer
+        );
     }
 
     function getTraces(address agent, uint256 from, uint256 to)

--- a/contracts/src/interfaces/IReasoningTraceRegistry.sol
+++ b/contracts/src/interfaces/IReasoningTraceRegistry.sol
@@ -5,6 +5,9 @@ pragma solidity ^0.8.24;
 /// @notice On-chain anchoring of agent reasoning traces.
 ///         Stores hashes (not full traces) — full traces live off-chain in Postgres.
 ///         Anyone can verify a trace by recomputing its hash and comparing.
+///         v1.5 adds commit-reveal provenance per docs/specs/commit-reveal-trace-spec.md:
+///         the agent commits the trace hash BEFORE the trade executes and reveals the
+///         content afterwards, proving commit block < execution < reveal block.
 /// @dev Owner: Chuan (implements). Consumer: Marten (publishes trace hashes from agent loop).
 ///      Daniel (frontend reads trace IDs + hashes for verification UI).
 interface IReasoningTraceRegistry {
@@ -17,10 +20,30 @@ interface IReasoningTraceRegistry {
         uint256 timestamp
     );
 
+    event TraceCommitted(
+        uint256 indexed traceId,
+        bytes32 indexed contentHash,
+        address indexed committer,
+        address vault,
+        uint256 commitBlock,
+        uint64 claimedExecutionTime
+    );
+
+    event TraceRevealed(
+        uint256 indexed traceId,
+        string storagePointer,
+        uint256 revealBlock
+    );
+
+    event VaultAgentSet(address indexed vault, address indexed agent, bool authorized);
+
     // ── Write ────────────────────────────────────────────────
-    /// @notice Publish a reasoning trace hash on-chain.
+    /// @notice Publish a reasoning trace hash on-chain (v1 anchor-after-the-fact).
+    ///         Kept for backwards compatibility; as of v1.5 it is GATED — the caller
+    ///         must be authorized for the vault (see isAuthorizedForVault). It carries
+    ///         no temporal-binding guarantee; prefer commit() + reveal().
     /// @param vault The vault this trace applies to
-    /// @param traceHash SHA-256 hash of the full trace content
+    /// @param traceHash keccak256 hash of the full trace content
     /// @param metadata ABI-encoded metadata (decision_type, trigger, etc.)
     /// @return traceId Auto-incrementing trace ID
     function publishTrace(
@@ -28,6 +51,40 @@ interface IReasoningTraceRegistry {
         bytes32 traceHash,
         bytes calldata metadata
     ) external returns (uint256 traceId);
+
+    /// @notice Commit a reasoning trace hash BEFORE the trade it covers executes.
+    ///         Time-lock: claimedExecutionTime must be strictly after the commit
+    ///         block's timestamp, i.e. the covered execution lands >= 1 block later.
+    ///         Caller must be authorized for the vault.
+    /// @param vault The vault the upcoming trade applies to
+    /// @param contentHash keccak256 of the canonical trace JSON
+    /// @param claimedExecutionTime Unix time the covered trade is claimed to execute at
+    /// @param tradeIntentSummary ABI-encoded: decisionType, numTrades, totalNotionalUsdc
+    /// @return traceId Auto-incrementing trace ID (shared ID space with publishTrace)
+    function commit(
+        address vault,
+        bytes32 contentHash,
+        uint64 claimedExecutionTime,
+        bytes calldata tradeIntentSummary
+    ) external returns (uint256 traceId);
+
+    /// @notice Reveal the full trace content AFTER the trade settles.
+    ///         Verifies keccak256(fullTraceContent) matches the committed hash,
+    ///         that the reveal lands in a later block than the commit, and that
+    ///         the claimed execution time has passed. Only the committer may reveal.
+    /// @param traceId The trace ID returned by commit()
+    /// @param storagePointer Off-chain pointer to the canonical trace (URL/IPFS/Arweave)
+    /// @param fullTraceContent Full trace bytes for on-chain hash verification
+    function reveal(
+        uint256 traceId,
+        string calldata storagePointer,
+        bytes calldata fullTraceContent
+    ) external;
+
+    /// @notice Grant or revoke an agent's anchoring authority for a vault.
+    ///         Registry-owner only. Vault contracts exposing agent()/creator()/owner()
+    ///         are also recognized automatically (no explicit grant needed).
+    function setVaultAgent(address vault, address agent, bool authorized) external;
 
     // ── Read ─────────────────────────────────────────────────
     /// @notice Verify a full trace matches the on-chain hash.
@@ -73,4 +130,33 @@ interface IReasoningTraceRegistry {
 
     /// @notice Get all trace IDs for a specific vault.
     function getTracesByVault(address vault) external view returns (uint256[] memory traceIds);
+
+    /// @notice Get a commit-reveal commitment by trace ID.
+    /// @param traceId The trace ID returned by commit()
+    /// @return contentHash The committed keccak256 hash
+    /// @return committer Address that made the commitment
+    /// @return vault The vault the covered trade applies to
+    /// @return commitBlock Block number of the commit transaction
+    /// @return claimedExecutionTime Unix time the covered trade was claimed to execute at
+    /// @return revealed True once reveal() has succeeded
+    /// @return revealBlock Block number of the reveal transaction (0 until revealed)
+    /// @return storagePointer Off-chain pointer to the canonical trace (empty until revealed)
+    function getCommitment(uint256 traceId)
+        external
+        view
+        returns (
+            bytes32 contentHash,
+            address committer,
+            address vault,
+            uint256 commitBlock,
+            uint64 claimedExecutionTime,
+            bool revealed,
+            uint256 revealBlock,
+            string memory storagePointer
+        );
+
+    /// @notice True if `account` may anchor traces for `vault` — either explicitly
+    ///         granted via setVaultAgent, or recognized live as the vault's
+    ///         agent()/creator()/owner().
+    function isAuthorizedForVault(address vault, address account) external view returns (bool);
 }

--- a/contracts/test/Registry.t.sol
+++ b/contracts/test/Registry.t.sol
@@ -5,18 +5,39 @@ import "forge-std/Test.sol";
 import "../src/ReasoningTraceRegistry.sol";
 import "../src/AssetRegistry.sol";
 
+/// @dev Minimal Vault-shaped contract for testing live role introspection.
+contract MockVaultWithAgent {
+    address public agent;
+    address public creator;
+
+    constructor(address _agent, address _creator) {
+        agent = _agent;
+        creator = _creator;
+    }
+}
+
 contract ReasoningTraceRegistryTest is Test {
     ReasoningTraceRegistry public registry;
 
     address public owner = address(0x1);
     address public agent1 = address(0x2);
     address public agent2 = address(0x3);
+    address public attacker = address(0xBAD);
     address public vault1 = address(0x10);
     address public vault2 = address(0x11);
 
     function setUp() public {
         vm.prank(owner);
         registry = new ReasoningTraceRegistry(owner);
+
+        // v1.5: anchoring is gated — grant the test agents authority over the
+        // (codeless) test vault addresses.
+        vm.startPrank(owner);
+        registry.setVaultAgent(vault1, agent1, true);
+        registry.setVaultAgent(vault1, agent2, true);
+        registry.setVaultAgent(vault2, agent1, true);
+        registry.setVaultAgent(vault2, agent2, true);
+        vm.stopPrank();
     }
 
     // ─── Publish Trace ───────────────────────────────────────────────
@@ -184,6 +205,235 @@ contract ReasoningTraceRegistryTest is Test {
         vm.prank(agent2);
         registry.publishTrace(vault2, keccak256("2"), "");
         assertEq(registry.traceCount(), 2);
+    }
+
+    // ─── Authorization (audit #18: no forged anchors) ────────────────
+
+    function test_revert_publishTrace_unauthorized() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not authorized for vault");
+        registry.publishTrace(vault1, keccak256("forged"), "");
+    }
+
+    function test_revert_commit_unauthorized() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not authorized for vault");
+        registry.commit(vault1, keccak256("forged"), uint64(block.timestamp + 60), "");
+    }
+
+    function test_revert_setVaultAgent_non_owner() public {
+        vm.prank(attacker);
+        vm.expectRevert();
+        registry.setVaultAgent(vault1, attacker, true);
+    }
+
+    function test_setVaultAgent_revoke() public {
+        vm.prank(owner);
+        registry.setVaultAgent(vault1, agent1, false);
+
+        vm.prank(agent1);
+        vm.expectRevert("Not authorized for vault");
+        registry.publishTrace(vault1, keccak256("trace"), "");
+    }
+
+    function test_isAuthorizedForVault_via_vault_roles() public {
+        // A Vault-shaped contract exposing agent()/creator() is recognized live,
+        // without an explicit setVaultAgent grant.
+        address vaultAgent = address(0x20);
+        address vaultCreator = address(0x21);
+        MockVaultWithAgent vault = new MockVaultWithAgent(vaultAgent, vaultCreator);
+
+        assertTrue(registry.isAuthorizedForVault(address(vault), vaultAgent));
+        assertTrue(registry.isAuthorizedForVault(address(vault), vaultCreator));
+        assertFalse(registry.isAuthorizedForVault(address(vault), attacker));
+
+        vm.prank(vaultAgent);
+        uint256 traceId = registry.commit(
+            address(vault), keccak256("trace"), uint64(block.timestamp + 60), ""
+        );
+        assertEq(traceId, 1);
+    }
+
+    // ─── Commit-reveal (v1.5 temporal binding) ───────────────────────
+
+    function test_commit_reveal_happy_path() public {
+        bytes memory content = "canonical trace json";
+        bytes32 contentHash = keccak256(content);
+        uint64 executionTime = uint64(block.timestamp + 10);
+        bytes memory intent = abi.encode("rebalance", uint256(3), uint256(50_000e6));
+
+        // T-2: commit BEFORE the trade
+        vm.expectEmit(true, true, true, true);
+        emit IReasoningTraceRegistry.TraceCommitted(
+            1, contentHash, agent1, vault1, block.number, executionTime
+        );
+        vm.prank(agent1);
+        uint256 traceId = registry.commit(vault1, contentHash, executionTime, intent);
+        assertEq(traceId, 1);
+
+        // T-3: next block — the trade executes (simulated by advancing the chain)
+        vm.roll(block.number + 1);
+        vm.warp(executionTime);
+
+        // T-5: reveal AFTER settlement
+        vm.roll(block.number + 1);
+        vm.warp(executionTime + 5);
+        vm.expectEmit(true, false, false, true);
+        emit IReasoningTraceRegistry.TraceRevealed(1, "ipfs://QmTrace", block.number);
+        vm.prank(agent1);
+        registry.reveal(traceId, "ipfs://QmTrace", content);
+
+        // Commitment is promoted to revealed with the temporal binding recorded
+        (
+            bytes32 storedHash,
+            address committer,
+            address vault,
+            uint256 commitBlock,
+            uint64 claimedExecutionTime,
+            bool revealed,
+            uint256 revealBlock,
+            string memory storagePointer
+        ) = registry.getCommitment(traceId);
+
+        assertEq(storedHash, contentHash);
+        assertEq(committer, agent1);
+        assertEq(vault, vault1);
+        assertEq(claimedExecutionTime, executionTime);
+        assertTrue(revealed);
+        assertGt(revealBlock, commitBlock); // commit block strictly precedes reveal block
+        assertEq(storagePointer, "ipfs://QmTrace");
+
+        // The committed trace is also verifiable through the standard v1 read path
+        assertTrue(registry.verifyTrace(traceId, content));
+        assertEq(registry.traceCount(), 1);
+    }
+
+    function test_revert_reveal_without_commitment() public {
+        // No commit at all
+        vm.prank(agent1);
+        vm.expectRevert("No commitment");
+        registry.reveal(999, "ipfs://x", "content");
+
+        // A v1 publishTrace anchor is NOT a commitment — reveal against it reverts
+        vm.prank(agent1);
+        uint256 publishedId = registry.publishTrace(vault1, keccak256("content"), "");
+        vm.roll(block.number + 1);
+        vm.prank(agent1);
+        vm.expectRevert("No commitment");
+        registry.reveal(publishedId, "ipfs://x", "content");
+    }
+
+    function test_revert_reveal_hash_mismatch() public {
+        vm.prank(agent1);
+        uint256 traceId = registry.commit(
+            vault1, keccak256("the real trace"), uint64(block.timestamp + 10), ""
+        );
+
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 10);
+
+        vm.prank(agent1);
+        vm.expectRevert("Hash mismatch");
+        registry.reveal(traceId, "ipfs://x", "a tampered trace");
+    }
+
+    function test_revert_commit_same_block_as_execution() public {
+        // Time-lock: claiming execution in the commit block itself must fail —
+        // the covered trade has to land at least one block after the commit.
+        vm.prank(agent1);
+        vm.expectRevert("Time-lock: execution must follow commit");
+        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp), "");
+
+        // Claimed execution in the past fails too
+        vm.warp(block.timestamp + 100);
+        vm.prank(agent1);
+        vm.expectRevert("Time-lock: execution must follow commit");
+        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp - 1), "");
+    }
+
+    function test_revert_reveal_in_commit_block() public {
+        bytes memory content = "trace";
+        vm.prank(agent1);
+        uint256 traceId = registry.commit(
+            vault1, keccak256(content), uint64(block.timestamp + 1), ""
+        );
+
+        // Same block as the commit — temporal binding cannot hold
+        vm.warp(block.timestamp + 1);
+        vm.prank(agent1);
+        vm.expectRevert("Time-lock: reveal in commit block");
+        registry.reveal(traceId, "ipfs://x", content);
+    }
+
+    function test_revert_reveal_before_claimed_execution() public {
+        bytes memory content = "trace";
+        uint64 executionTime = uint64(block.timestamp + 100);
+        vm.prank(agent1);
+        uint256 traceId = registry.commit(vault1, keccak256(content), executionTime, "");
+
+        vm.roll(block.number + 1); // later block, but execution time not reached
+        vm.prank(agent1);
+        vm.expectRevert("Reveal before claimed execution");
+        registry.reveal(traceId, "ipfs://x", content);
+    }
+
+    function test_revert_reveal_not_committer() public {
+        bytes memory content = "trace";
+        vm.prank(agent1);
+        uint256 traceId = registry.commit(
+            vault1, keccak256(content), uint64(block.timestamp + 1), ""
+        );
+
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 1);
+        vm.prank(agent2);
+        vm.expectRevert("Not committer");
+        registry.reveal(traceId, "ipfs://x", content);
+    }
+
+    function test_revert_reveal_twice() public {
+        bytes memory content = "trace";
+        vm.prank(agent1);
+        uint256 traceId = registry.commit(
+            vault1, keccak256(content), uint64(block.timestamp + 1), ""
+        );
+
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 1);
+        vm.startPrank(agent1);
+        registry.reveal(traceId, "ipfs://x", content);
+
+        vm.expectRevert("Already revealed");
+        registry.reveal(traceId, "ipfs://y", content);
+        vm.stopPrank();
+    }
+
+    function test_revert_commit_empty_hash() public {
+        vm.prank(agent1);
+        vm.expectRevert("Empty content hash");
+        registry.commit(vault1, bytes32(0), uint64(block.timestamp + 1), "");
+    }
+
+    function test_revert_getCommitment_nonexistent() public {
+        vm.expectRevert("No commitment");
+        registry.getCommitment(999);
+    }
+
+    function test_commit_shares_trace_id_space_with_publishTrace() public {
+        vm.prank(agent1);
+        uint256 id1 = registry.publishTrace(vault1, keccak256("v1 anchor"), "");
+
+        vm.prank(agent1);
+        uint256 id2 = registry.commit(
+            vault1, keccak256("committed"), uint64(block.timestamp + 1), ""
+        );
+
+        assertEq(id1, 1);
+        assertEq(id2, 2);
+        assertEq(registry.traceCount(), 2);
+
+        uint256[] memory vaultIds = registry.getTracesByVault(vault1);
+        assertEq(vaultIds.length, 2);
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the v1.5 commit-reveal upgrade to `ReasoningTraceRegistry` per [`docs/specs/commit-reveal-trace-spec.md`](docs/specs/commit-reveal-trace-spec.md), closing audit 2026-06-10 finding #18 ("commit-reveal is not implemented; anchors are permissionless; anyone can forge anchors for arbitrary vaults").

Closes #510

**What changed** (`contracts/src/ReasoningTraceRegistry.sol`, `contracts/src/interfaces/IReasoningTraceRegistry.sol`, `contracts/test/Registry.t.sol`):

- **`commit(vault, contentHash, claimedExecutionTime, tradeIntentSummary)`** — anchors the trace hash *before* the covered trade. Time-lock: `claimedExecutionTime > block.timestamp` at commit, so the covered execution must land at least one block after the commit.
- **`reveal(traceId, storagePointer, fullTraceContent)`** — recomputes `keccak256(fullTraceContent)` on-chain and verifies it against the commitment; requires `block.number > commitBlock` and `block.timestamp >= claimedExecutionTime` (temporal binding: commit block < execution ≤ reveal block); committer-only; records `storagePointer` + `revealBlock`.
- **Authorization** — *all* anchoring (`publishTrace` AND `commit`) is now scoped to the vault's agent/owner: explicit `setVaultAgent` grants (registry-owner only) or non-reverting live introspection of `agent()`/`creator()`/`owner()` on Vault-shaped contracts. Arbitrary addresses can no longer forge anchors.
- **`publishTrace` kept** (the spec retains it as the existing v1 surface) but gated by the same vault authorization and documented as carrying no temporal-binding guarantee — new integrations should use `commit()` + `reveal()`.
- New reads: `getCommitment(traceId)`, `isAuthorizedForVault(vault, account)`.

## Spec-vs-implementation deltas

Where the spec and issue #510 disagreed, I followed the spec and noted the delta here (per task brief):

1. **`claimedExecutionTime` param added to `commit`** — the spec's sketch has `commit(contentHash, tradeIntentSummary)`; the issue/audit #18 explicitly require the claimed execution time + the ≥1-block time-lock, so it's a first-class `uint64` param checked on-chain.
2. **`vault` lifted to a first-class `commit` param** — the spec encodes `vaultAddr` inside the `tradeIntentSummary` bytes; the authorization check and vault index need it without decoding, so it's explicit (mirrors `publishTrace`).
3. **Unified traceId space** — the spec sketches a separate `commitments` mapping + `nextTraceId` counter; here commits share the `_traces` array's ID space so `verifyTrace`/`getTraceById`/`getTracesByVault` work uniformly for committed and published traces. `getCommitment` returns the spec's fields plus `vault` and `claimedExecutionTime`.
4. **Authorization is not in the spec at all** — the spec is silent on who may anchor; audit #18 requires scoping, so both `publishTrace` and `commit` are gated. This is a behavior change for the v1 surface: existing permissionless callers must be granted via `setVaultAgent` or be the vault's `agent()`/`creator()`/`owner()`.
5. The spec's "time-locked reveal windows" out-of-scope note refers to a *minimum commit→reveal delay* (still out of scope); the implemented time-lock is the issue's *commit-before-execution* requirement — a different mechanism.

## Verification

`forge test` (forge 1.7.1): **113 passed, 2 failed** — the 2 failures are the PRE-EXISTING `test/SyntheticVault.t.sol` drift (`test_isFresh`, `test_revert_stale_price`) handled in a parallel PR; baseline before this change was 97 passed / same 2 failures. **No new failures; +16 new tests.**

The four required proofs (all in `contracts/test/Registry.t.sol`, `ReasoningTraceRegistryTest` — 29/29 pass):

1. **Reveal without a prior matching commit reverts** — `test_revert_reveal_without_commitment` (covers both no-commit-at-all and reveal against a v1 `publishTrace` anchor); `test_revert_reveal_hash_mismatch` for a non-matching reveal.
2. **Commit in the same block as execution fails the time-lock** — `test_revert_commit_same_block_as_execution` (also covers past execution times); `test_revert_reveal_in_commit_block` enforces the block-ordering side.
3. **Unauthorized address cannot commit/anchor for a vault it doesn't control** — `test_revert_commit_unauthorized`, `test_revert_publishTrace_unauthorized`, `test_revert_setVaultAgent_non_owner`, `test_setVaultAgent_revoke`.
4. **Happy path commit → (next block) → execute → reveal verifies** — `test_commit_reveal_happy_path` (asserts `revealBlock > commitBlock`, hash binding, event emission, and `verifyTrace` interop).

## Honest scope note (added after adversarial review)

Issue #510's first acceptance criterion reads "a trade cannot settle without a prior matching commit." This PR proves the **registry-side half**: a *reveal* cannot succeed without a prior matching commit, and the commit block provably precedes the reveal. It does **not** make trade *settlement* conditional on a commit — that requires the Vault's `rebalance()` to consult the registry, and commitments are not yet bound to a specific trade identifier. Both are tracked in follow-up #589. Until then, commit-before-trade ordering is externally *evidencable* (commitBlock vs trade tx block), not on-chain *enforced*.

## Redeploy note

`contracts/abis/` is deliberately **untouched** — it mirrors the LIVE deployed registry on Arc testnet. The deployed contract stays as-is until redeploy; this change **requires redeploy + backend wiring (`trace_publisher` commit/reveal sequence) as the v1.5 hop**. Backend wiring is out of scope for this PR per issue #510.

⚠️ Contract change — needs Chuan's review (contract changes get two reviews per CLAUDE.md). Cross-lane note: this sits in Chuan's contracts lane; executed per the assignment-is-authorization convention.
