### PR TITLE
[contracts] Derive swap minAmountOut from oracle with bounded slippage

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -47,6 +47,10 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     /// @notice Sink for dead shares (OZ ERC20 forbids minting to address(0)).
     address public constant DEAD_SHARES_SINK = address(0xdEaD);
 
+    /// @notice Hard cap on the owner-configurable slippage tolerance (5%).
+    ///         Prevents the owner from effectively disabling swap protection.
+    uint256 public constant MAX_SLIPPAGE_CAP_BPS = 500;
+
     // ─── Immutables ──────────────────────────────────────────────────
 
     address public immutable override asset;
@@ -84,6 +88,12 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     /// @notice Oracle address for each held token (for NAV pricing)
     mapping(address => address) public override tokenOracle;
 
+    /// @notice Max slippage tolerance (in bps) applied to every AMM swap,
+    ///         relative to the oracle-implied fair output. Owner-configurable,
+    ///         hard-capped at MAX_SLIPPAGE_CAP_BPS. Default 100 bps (1%) —
+    ///         covers the 30 bps AMM fee plus bounded price impact.
+    uint256 public maxSlippageBps = 100;
+
     // ─── Errors ──────────────────────────────────────────────────────
 
     error ZeroAmount();
@@ -93,6 +103,13 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     error InvalidAllocations();
     error InsufficientBalance();
     error InsufficientLiquidity();
+    error SlippageBpsTooHigh();
+    error OracleNotSet();
+    error InvalidOraclePrice();
+
+    // ─── Events (Vault-local) ────────────────────────────────────────
+
+    event MaxSlippageBpsSet(uint256 oldBps, uint256 newBps);
 
     // ─── Constructor ─────────────────────────────────────────────────
 
@@ -289,8 +306,9 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             // Approve router
             IERC20(tokenOut).safeIncreaseAllowance(address(ammRouter), amount);
 
-            // Swap tokenOut -> USDC
-            uint256 usdcReceived = ammRouter.swap(tokenOut, asset, amount, 0);
+            // Swap tokenOut -> USDC with oracle-derived slippage floor
+            uint256 usdcReceived =
+                ammRouter.swap(tokenOut, asset, amount, _oracleMinOut(tokenOut, asset, amount));
 
             _removeHolding(tokenOut, amount);
             _addHolding(address(asset), usdcReceived);
@@ -309,8 +327,9 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             // Approve router
             IERC20(asset).safeIncreaseAllowance(address(ammRouter), amount);
 
-            // Swap USDC -> tokenIn
-            uint256 tokensReceived = ammRouter.swap(asset, tokenIn, amount, 0);
+            // Swap USDC -> tokenIn with oracle-derived slippage floor
+            uint256 tokensReceived =
+                ammRouter.swap(asset, tokenIn, amount, _oracleMinOut(asset, tokenIn, amount));
 
             _removeHolding(asset, amount);
             _addHolding(tokenIn, tokensReceived);
@@ -395,6 +414,15 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         platformFeeRecipient = _recipient;
     }
 
+    /// @notice Set the max slippage tolerance applied to all AMM swaps.
+    ///         Bounded by MAX_SLIPPAGE_CAP_BPS so swap protection can never
+    ///         be effectively disabled.
+    function setMaxSlippageBps(uint256 _maxSlippageBps) external onlyOwner {
+        if (_maxSlippageBps > MAX_SLIPPAGE_CAP_BPS) revert SlippageBpsTooHigh();
+        emit MaxSlippageBpsSet(maxSlippageBps, _maxSlippageBps);
+        maxSlippageBps = _maxSlippageBps;
+    }
+
     function pause() external onlyOwner {
         _pause();
     }
@@ -404,6 +432,39 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     }
 
     // ─── Internal ────────────────────────────────────────────────────
+
+    /// @notice Compute the minimum acceptable output for an AMM swap from the
+    ///         on-chain oracle price, minus the bounded slippage tolerance.
+    /// @dev    Exactly one side of every vault swap is USDC (the vault asset);
+    ///         the other side is a synth token. Decimal conventions (matching
+    ///         totalAssets()): USDC has 6 decimals; synth tokens have 18;
+    ///         oracle prices are USDC (6 decimals) per 1e18 synth units.
+    ///
+    ///         synth -> USDC: expectedOut(6) = amountIn(18) * price(6) / 1e18
+    ///         USDC -> synth: expectedOut(18) = amountIn(6) * 1e18 / price(6)
+    ///
+    ///         Reverts if the non-USDC side has no registered oracle (an
+    ///         unpriced swap would be unprotected) or the oracle price is zero.
+    ///         PriceOracle.getPrice() itself reverts when the price is stale,
+    ///         so stale oracles block swaps rather than mispricing them.
+    function _oracleMinOut(address tokenIn, address tokenOut, uint256 amountIn)
+        internal
+        view
+        returns (uint256 minAmountOut)
+    {
+        address synth = tokenIn == address(asset) ? tokenOut : tokenIn;
+        address oracle = tokenOracle[synth];
+        if (oracle == address(0)) revert OracleNotSet();
+
+        uint256 price = PriceOracle(oracle).getPrice();
+        if (price == 0) revert InvalidOraclePrice();
+
+        uint256 expectedOut = tokenIn == address(asset)
+            ? (amountIn * 1e18) / price // buy: USDC(6) -> synth(18)
+            : (amountIn * price) / 1e18; // sell: synth(18) -> USDC(6)
+
+        minAmountOut = (expectedOut * (BPS - maxSlippageBps)) / BPS;
+    }
 
     /// @notice Liquidate non-USDC positions to cover a USDC shortfall.
     ///         Sells proportionally from each held token via the AMM.
@@ -444,9 +505,11 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             if (tokensToSell == 0) continue;
             if (tokensToSell > balance) tokensToSell = balance;
 
-            // Approve router and swap to USDC
+            // Approve router and swap to USDC with oracle-derived slippage floor
             IERC20(heldTokens[i]).safeIncreaseAllowance(address(ammRouter), tokensToSell);
-            ammRouter.swap(heldTokens[i], asset, tokensToSell, 0);
+            ammRouter.swap(
+                heldTokens[i], asset, tokensToSell, _oracleMinOut(heldTokens[i], asset, tokensToSell)
+            );
         }
 
         // Verify we now have enough USDC

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -39,6 +39,10 @@ contract VaultTest is Test {
     Vault public vault;
 
     MockToken public sTSLA;
+    PriceOracle public tslaOracle;
+
+    /// @dev sTSLA oracle price: 2 USDC per token (6-decimal USDC units per 1e18 synth)
+    uint256 public constant TSLA_PRICE = 2 * 10**6;
 
     address public owner = address(0x1);
     address public alice = address(0x2);
@@ -82,9 +86,11 @@ contract VaultTest is Test {
         );
         vault = Vault(payable(vaultAddr));
 
-        // Seed AMM pool with liquidity
-        uint256 poolUsdc = 100_000 * 10**6;
-        uint256 poolTsla = 50_000 * 1e18;
+        // Seed AMM pool with liquidity at the oracle price (2 USDC per sTSLA).
+        // Deep pool so a 10k USDC rebalance has price impact well below the
+        // vault's default 1% slippage tolerance (impact ~0.1% + 0.3% AMM fee).
+        uint256 poolUsdc = 10_000_000 * 10**6;
+        uint256 poolTsla = 5_000_000 * 1e18;
 
         usdc.mint(address(this), poolUsdc);
         sTSLA.mint(address(this), poolTsla);
@@ -92,6 +98,52 @@ contract VaultTest is Test {
         usdc.approve(address(router), poolUsdc);
         sTSLA.approve(address(router), poolTsla);
         router.addLiquidity(address(usdc), address(sTSLA), poolUsdc, poolTsla, 0);
+
+        // Deploy oracle for sTSLA and register it on the vault — swaps now
+        // require an oracle-derived minAmountOut (issue #506).
+        tslaOracle = new PriceOracle("sTSLA", TSLA_PRICE, owner);
+        address[] memory oracleTokens = new address[](1);
+        oracleTokens[0] = address(sTSLA);
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(tslaOracle);
+        vm.prank(agent);
+        vault.setTokenOracles(oracleTokens, oracles);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────
+
+    /// @dev Rebalance the vault: buy `amount` USDC worth of sTSLA.
+    function _rebalanceBuyTsla(uint256 amount) internal {
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(sTSLA);
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = amount;
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+
+        vm.prank(agent);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    /// @dev Rebalance the vault: sell `amount` sTSLA back to USDC.
+    function _rebalanceSellTsla(uint256 amount) internal {
+        address[] memory tokensIn = new address[](0);
+        uint256[] memory amountsIn = new uint256[](0);
+        address[] memory tokensOut = new address[](1);
+        tokensOut[0] = address(sTSLA);
+        uint256[] memory amountsOut = new uint256[](1);
+        amountsOut[0] = amount;
+
+        vm.prank(agent);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    /// @dev Deposit USDC into the vault as alice.
+    function _depositAsAlice(uint256 amount) internal {
+        vm.startPrank(alice);
+        usdc.approve(address(vault), amount);
+        vault.deposit(amount, alice);
+        vm.stopPrank();
     }
 
     // ─── Deposit Tests ───────────────────────────────────────────────
@@ -350,6 +402,217 @@ contract VaultTest is Test {
         vm.prank(agent);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
         // No tokens swapped, but no revert — success
+    }
+
+    // ─── Swap Slippage Protection (issue #506) ───────────────────────
+
+    function test_maxSlippageBps_default() public view {
+        assertEq(vault.maxSlippageBps(), 100);
+        assertEq(vault.MAX_SLIPPAGE_CAP_BPS(), 500);
+    }
+
+    function test_setMaxSlippageBps() public {
+        // Vault owner is the creator (agent in setUp)
+        vm.prank(agent);
+        vault.setMaxSlippageBps(50);
+        assertEq(vault.maxSlippageBps(), 50);
+
+        // Boundary: exactly the cap is allowed
+        vm.prank(agent);
+        vault.setMaxSlippageBps(500);
+        assertEq(vault.maxSlippageBps(), 500);
+    }
+
+    function test_revert_setMaxSlippageBps_above_cap() public {
+        vm.prank(agent);
+        vm.expectRevert(Vault.SlippageBpsTooHigh.selector);
+        vault.setMaxSlippageBps(501);
+    }
+
+    function test_revert_setMaxSlippageBps_unauthorized() public {
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, bob));
+        vault.setMaxSlippageBps(50);
+    }
+
+    /// @dev Decimal scaling, buy direction: USDC(6) in -> synth(18) out.
+    ///      10,000 USDC at 2 USDC/sTSLA → fair output 5,000e18; the floor at
+    ///      1% tolerance is 4,950e18. The aligned pool fills at ~4,983e18
+    ///      (0.3% fee + ~0.1% impact), which must clear the floor.
+    function test_rebalance_buy_min_out_decimal_scaling() public {
+        _depositAsAlice(50_000 * 10**6);
+        _rebalanceBuyTsla(10_000 * 10**6);
+
+        uint256 received = sTSLA.balanceOf(address(vault));
+        uint256 fairOut = (10_000 * 10**6 * 1e18) / TSLA_PRICE; // 5_000e18
+        assertGe(received, (fairOut * 9900) / 10000); // >= oracle floor
+        assertLe(received, fairOut); // can't beat fair price in an aligned pool
+    }
+
+    /// @dev Decimal scaling, sell direction: synth(18) in -> USDC(6) out.
+    ///      1,000 sTSLA at 2 USDC/sTSLA → fair output 2,000e6; floor 1,980e6.
+    function test_rebalance_sell_min_out_decimal_scaling() public {
+        _depositAsAlice(50_000 * 10**6);
+        _rebalanceBuyTsla(10_000 * 10**6);
+
+        uint256 usdcBefore = usdc.balanceOf(address(vault));
+        _rebalanceSellTsla(1_000 * 1e18);
+        uint256 received = usdc.balanceOf(address(vault)) - usdcBefore;
+
+        uint256 fairOut = (1_000 * 1e18 * TSLA_PRICE) / 1e18; // 2_000e6
+        assertGe(received, (fairOut * 9900) / 10000); // >= oracle floor
+        assertLe(received, fairOut);
+    }
+
+    /// @dev With tolerance 0 the floor equals the oracle-fair output; the
+    ///      30 bps AMM fee alone must trip it — proves maxSlippageBps is
+    ///      actually enforced in the min-out computation.
+    function test_maxSlippageBps_enforced_zero_tolerance() public {
+        _depositAsAlice(50_000 * 10**6);
+
+        vm.prank(agent);
+        vault.setMaxSlippageBps(0);
+
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(sTSLA);
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = 10_000 * 10**6;
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+
+        vm.prank(agent);
+        vm.expectRevert(AMMRouter.SlippageExceeded.selector);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    /// @dev Attack scenario (audit finding #3): attacker skews the pool ahead
+    ///      of a rebalance BUY (front-run buys sTSLA, raising its pool price).
+    ///      The vault must revert instead of buying at the manipulated price.
+    function test_revert_rebalance_buy_manipulated_pool() public {
+        _depositAsAlice(50_000 * 10**6);
+
+        // Attacker front-runs: dumps 5M USDC into the pool, ~halving the
+        // sTSLA reserve and pushing the pool price far above the oracle.
+        usdc.mint(bob, 5_000_000 * 10**6);
+        vm.startPrank(bob);
+        usdc.approve(address(router), 5_000_000 * 10**6);
+        router.swap(address(usdc), address(sTSLA), 5_000_000 * 10**6, 0);
+        vm.stopPrank();
+
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(sTSLA);
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = 10_000 * 10**6;
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+
+        vm.prank(agent);
+        vm.expectRevert(AMMRouter.SlippageExceeded.selector);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    /// @dev Attack scenario, sell direction: attacker dumps sTSLA into the
+    ///      pool (crashing its pool price) before the vault sells. The vault
+    ///      must revert instead of selling at the manipulated price.
+    function test_revert_rebalance_sell_manipulated_pool() public {
+        _depositAsAlice(50_000 * 10**6);
+        _rebalanceBuyTsla(10_000 * 10**6);
+
+        // Attacker front-runs: dumps 5M sTSLA into the pool.
+        sTSLA.mint(bob, 5_000_000 * 1e18);
+        vm.startPrank(bob);
+        sTSLA.approve(address(router), 5_000_000 * 1e18);
+        router.swap(address(sTSLA), address(usdc), 5_000_000 * 1e18, 0);
+        vm.stopPrank();
+
+        address[] memory tokensIn = new address[](0);
+        uint256[] memory amountsIn = new uint256[](0);
+        address[] memory tokensOut = new address[](1);
+        tokensOut[0] = address(sTSLA);
+        uint256[] memory amountsOut = new uint256[](1);
+        amountsOut[0] = 1_000 * 1e18;
+
+        vm.prank(agent);
+        vm.expectRevert(AMMRouter.SlippageExceeded.selector);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    /// @dev A swap on a token with no registered oracle is unprotected and
+    ///      must revert rather than fall back to minAmountOut = 0.
+    function test_revert_rebalance_without_oracle() public {
+        MockToken sNVDA = new MockToken("Synthetic NVDA", "sNVDA");
+        router.createPool(address(usdc), address(sNVDA));
+
+        uint256 poolUsdc = 1_000_000 * 10**6;
+        uint256 poolNvda = 1_000_000 * 1e18;
+        usdc.mint(address(this), poolUsdc);
+        sNVDA.mint(address(this), poolNvda);
+        usdc.approve(address(router), poolUsdc);
+        sNVDA.approve(address(router), poolNvda);
+        router.addLiquidity(address(usdc), address(sNVDA), poolUsdc, poolNvda, 0);
+
+        _depositAsAlice(50_000 * 10**6);
+
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(sNVDA);
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = 10_000 * 10**6;
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+
+        vm.prank(agent);
+        vm.expectRevert(Vault.OracleNotSet.selector);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    /// @dev Withdrawal-driven liquidation (_liquidateToUsdc) succeeds against
+    ///      an oracle-aligned pool — the min-out floor doesn't block honest flow.
+    function test_withdraw_liquidation_with_min_out() public {
+        _depositAsAlice(50_000 * 10**6);
+        _rebalanceBuyTsla(40_000 * 10**6);
+
+        // Vault now holds ~10k USDC; withdrawing 30k forces a synth liquidation.
+        vm.prank(alice);
+        vault.withdraw(30_000 * 10**6, alice, alice);
+
+        assertGe(usdc.balanceOf(alice), 950_000 * 10**6 + 30_000 * 10**6 - 50_000 * 10**6);
+    }
+
+    /// @dev Withdrawal-driven liquidation against a manipulated pool must
+    ///      revert — rebalance/liquidation authority cannot be converted into
+    ///      a bad-price drain.
+    function test_revert_withdraw_liquidation_manipulated_pool() public {
+        _depositAsAlice(50_000 * 10**6);
+        _rebalanceBuyTsla(40_000 * 10**6);
+
+        // Attacker crashes the sTSLA pool price before the liquidation sell.
+        sTSLA.mint(bob, 5_000_000 * 1e18);
+        vm.startPrank(bob);
+        sTSLA.approve(address(router), 5_000_000 * 1e18);
+        router.swap(address(sTSLA), address(usdc), 5_000_000 * 1e18, 0);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert(AMMRouter.SlippageExceeded.selector);
+        vault.withdraw(30_000 * 10**6, alice, alice);
+    }
+
+    /// @dev Stale oracle blocks swaps entirely (PriceOracle.getPrice reverts).
+    function test_revert_rebalance_stale_oracle() public {
+        _depositAsAlice(50_000 * 10**6);
+
+        vm.warp(block.timestamp + 25 hours);
+
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(sTSLA);
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = 10_000 * 10**6;
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+
+        vm.prank(agent);
+        vm.expectRevert(PriceOracle.StalePrice.selector);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
     }
 
     // ─── Target Allocations ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #506 (audit 2026-06-10 finding #3). All three AMM swap sites in `contracts/src/Vault.sol` — rebalance sell (~L276), rebalance buy (~L297), and `_liquidateToUsdc` (~L475) — passed `minAmountOut = 0`, so a sandwich bot or attacker-seeded pool could extract nearly the full trade value, turning rebalance authority into economic withdraw authority.

Every swap now passes an oracle-derived floor:

- New internal `_oracleMinOut(tokenIn, tokenOut, amountIn)` computes the fair output from the registered `PriceOracle` for the synth side of the pair, reduced by `maxSlippageBps`.
- `maxSlippageBps` is owner-configurable via `setMaxSlippageBps` (default **100 bps**), hard-capped at `MAX_SLIPPAGE_CAP_BPS = 500` (5%) so the owner can never disable protection.
- Swaps on tokens with **no registered oracle** revert with `OracleNotSet` (an unpriced swap is an unprotected swap), zero prices revert with `InvalidOraclePrice`, and stale oracles block swaps via `PriceOracle.getPrice()`'s existing `StalePrice` revert.

## Decimal scaling

Conventions match the existing `totalAssets()` NAV math: USDC = 6 decimals, synths = 18 decimals, oracle price = USDC (6dp) per 1e18 synth units.

- **sell, synth → USDC:** `expectedOut(6) = amountIn(18) * price(6) / 1e18`
- **buy, USDC → synth:** `expectedOut(18) = amountIn(6) * 1e18 / price(6)`
- floor: `minAmountOut = expectedOut * (BPS - maxSlippageBps) / BPS`

Both directions are unit-tested against a pool seeded exactly at the oracle price (2 USDC/sTSLA): received amounts must land between the 1%-tolerance floor and the oracle-fair output.

## Tests (13 new in `contracts/test/Vault.t.sol`)

- `test_rebalance_buy_min_out_decimal_scaling` / `test_rebalance_sell_min_out_decimal_scaling` — scaling both directions
- `test_revert_rebalance_buy_manipulated_pool` / `test_revert_rebalance_sell_manipulated_pool` — attacker skews the pool with a 5M front-run; the vault swap **reverts** (`SlippageExceeded`) instead of filling at the bad price
- `test_withdraw_liquidation_with_min_out` / `test_revert_withdraw_liquidation_manipulated_pool` — `_liquidateToUsdc` path: honest liquidation passes, manipulated pool reverts
- `test_maxSlippageBps_enforced_zero_tolerance` — at 0 bps the 30 bps AMM fee alone trips the floor, proving the parameter is live
- `test_maxSlippageBps_default`, `test_setMaxSlippageBps` (incl. boundary 500), `test_revert_setMaxSlippageBps_above_cap`, `test_revert_setMaxSlippageBps_unauthorized`
- `test_revert_rebalance_without_oracle`, `test_revert_rebalance_stale_oracle`

setUp changes: sTSLA `PriceOracle` registered on the vault; pool deepened to 10M USDC / 5M sTSLA so honest 10–40k rebalances clear the 1% tolerance (fee 0.3% + impact ≤0.4%).

## Verification

```
forge test
Ran 5 test suites: 110 tests passed, 2 failed (112 total)
```

The 2 failures are the **pre-existing** `SyntheticVault.t.sol` staleness-drift failures (`test_isFresh`, `test_revert_stale_price`) — identical to the `main` baseline of 97 passed / 2 failed. No new failures; +13 new passing tests. `forge test --match-contract VaultTest`: 43/43 pass.

Anti-goal checks: `grep -n "ammRouter.swap" contracts/src/Vault.sol` shows all three sites use `_oracleMinOut`; `_convertToShares`/`preview*` deposit/withdraw share math untouched (#507's scope); `contracts/abis/` untouched.

## Deploy note

⚠️ **Redeploy + ABI refresh required.** `Vault` (via `VaultFactory`) has new state (`maxSlippageBps`), a new owner function (`setMaxSlippageBps`), and new errors. `contracts/abis/` deliberately not regenerated here — cached ABIs mirror the LIVE deployed contracts; refresh them in the redeploy.

Cross-lane note: contract change in Chuan's lane — needs Chuan's review per contract-review convention.