### PR TITLE
[contracts] Bound PriceOracle updates and add oracle-runner sanity checks

### DIFF
--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -41,6 +41,16 @@ CRYPTO_MAP = {
 CIRCLE_API_BASE = "https://api.circle.com/v1/w3s"
 CIRCLE_BLOCKCHAIN = "ARC-TESTNET"
 
+# ─── Sanity bounds for on-chain pushes (audit #13 / issue #508) ───
+# Max allowed move vs the last known good price, in basis points.
+# Default mirrors PriceOracle.sol's maxDeviationBps (2000 bps = 20%) so the
+# backend rejects a corrupted upstream price before spending a tx the
+# contract would revert anyway. Override via ORACLE_MAX_DEVIATION_BPS.
+DEFAULT_MAX_DEVIATION_BPS = 2000
+# Max age of the upstream observation before we refuse to push it on-chain.
+# Override via ORACLE_MAX_UPSTREAM_STALENESS_SECONDS.
+DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS = 900  # 15 minutes
+
 
 def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
     """Encrypt entity secret with Circle's RSA public key (OAEP/SHA-256).
@@ -74,6 +84,15 @@ class OracleUpdater:
         self._api_key: str = os.getenv("CIRCLE_API_KEY", "")
         self._entity_secret: str = os.getenv("CIRCLE_ENTITY_SECRET", "")
         self._wallet_id: str = os.getenv("WALLET_ID", "")
+
+        # Sanity bounds (audit #13 / issue #508)
+        self._max_deviation_bps: int = int(os.getenv("ORACLE_MAX_DEVIATION_BPS", str(DEFAULT_MAX_DEVIATION_BPS)))
+        self._max_upstream_staleness_s: int = int(
+            os.getenv("ORACLE_MAX_UPSTREAM_STALENESS_SECONDS", str(DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS))
+        )
+        # Last price (6-dec int) we successfully submitted, per symbol —
+        # fallback deviation reference when the on-chain read fails.
+        self._last_pushed_price_int: dict[str, int] = {}
 
     # ─── Public API ──────────────────────────────────────────────
 
@@ -124,9 +143,18 @@ class OracleUpdater:
                     logger.debug(f"No oracle address for {price.symbol} — skipping")
                     continue
 
+                price_int = int(price.price_usd * 1e6)  # 6 decimals, matches PriceOracle.sol
+
+                # Sanity gate (audit #13 / issue #508): refuse to push prices
+                # that are non-positive, stale upstream, or deviate too far
+                # from the last known good price.
+                rejection = await self._validate_for_push(price, price_int)
+                if rejection is not None:
+                    logger.warning(f"Refusing to push {price.symbol} price {price.price_usd}: {rejection}")
+                    continue
+
                 try:
                     ciphertext = _encrypt_entity_secret(self._entity_secret, public_key)
-                    price_int = int(price.price_usd * 1e6)  # 6 decimals, matches PriceOracle.sol
 
                     payload = {
                         "idempotencyKey": str(uuid.uuid4()),
@@ -151,6 +179,7 @@ class OracleUpdater:
                         if resp.status == 201:
                             tx_id = body["data"]["id"]
                             tx_ids.append(tx_id)
+                            self._last_pushed_price_int[price.symbol] = price_int
                             logger.info(f"Pushed {price.symbol} price {price.price_usd:.2f} → Circle tx {tx_id}")
                         else:
                             logger.error(f"Circle API error for {price.symbol} ({resp.status}): {body}")
@@ -180,6 +209,62 @@ class OracleUpdater:
         return self._price_cache.get(symbol)
 
     # ─── Private helpers ──────────────────────────────────────────
+
+    async def _validate_for_push(self, price: AssetPrice, price_int: int) -> str | None:
+        """Sanity-check a price before pushing on-chain (audit #13 / issue #508).
+
+        Returns a human-readable rejection reason, or None when the price is
+        safe to push. Checks, in order:
+
+        1. Zero/non-positive guard — the 6-decimal int must be > 0 (the
+           contract rejects zero; sub-microdollar floats truncate to 0).
+        2. Upstream staleness — the observation must be younger than
+           ``ORACLE_MAX_UPSTREAM_STALENESS_SECONDS`` (default 15 min).
+        3. Deviation cap — the move vs the last known good price (on-chain
+           read, falling back to the last successfully pushed value) must be
+           within ``ORACLE_MAX_DEVIATION_BPS`` (default 2000 = 20%, mirroring
+           PriceOracle.sol's maxDeviationBps). First-ever pushes with no
+           reference are allowed.
+
+        TODO(#508): multi-source corroboration. Each symbol currently has
+        exactly one upstream source (yfinance for equities/futures, CoinGecko
+        for sBTC), so requiring N corroborating sources cannot be implemented
+        honestly today. When a second independent feed is added, require
+        agreement within the deviation cap across >= 2 sources before pushing.
+        """
+        if price_int <= 0:
+            return f"non-positive on-chain price ({price.price_usd} → {price_int})"
+
+        observed = price.timestamp if price.timestamp.tzinfo else price.timestamp.replace(tzinfo=UTC)
+        age_s = (datetime.now(UTC) - observed).total_seconds()
+        if age_s > self._max_upstream_staleness_s:
+            return f"stale upstream data ({age_s:.0f}s old > {self._max_upstream_staleness_s}s cap)"
+
+        reference_int = await self._get_reference_price_int(price.symbol)
+        if reference_int is not None:
+            deviation_bps = abs(price_int - reference_int) * 10_000 / reference_int
+            if deviation_bps > self._max_deviation_bps:
+                return (
+                    f"deviation {deviation_bps:.0f} bps vs last known price "
+                    f"{reference_int / 1e6:.2f} exceeds {self._max_deviation_bps} bps cap"
+                )
+
+        return None
+
+    async def _get_reference_price_int(self, symbol: str) -> int | None:
+        """Last known good price (6-dec int): on-chain first, then last pushed.
+
+        Returns None when no reference exists (first-ever push for a symbol).
+        """
+        try:
+            from archimedes.chain.contracts import get_contract_loader
+
+            onchain = await get_contract_loader().oracle_for(symbol).functions.price().call()
+            if onchain and int(onchain) > 0:
+                return int(onchain)
+        except Exception as e:
+            logger.warning(f"Could not read on-chain reference price for {symbol}: {e}")
+        return self._last_pushed_price_int.get(symbol)
 
     async def _get_circle_public_key(self, session: aiohttp.ClientSession) -> str | None:
         """Fetch Circle's RSA public key (cached per instance)."""

--- a/backend/tests/chain/test_oracle_updater.py
+++ b/backend/tests/chain/test_oracle_updater.py
@@ -1,0 +1,225 @@
+"""Tests for OracleUpdater sanity bounds — audit #13 / issue #508.
+
+Target: backend/archimedes/chain/oracle_updater.py
+The oracle runner must refuse to push prices that are non-positive, stale
+upstream, or deviate beyond the configured cap vs the last known good price —
+while preserving the legitimate update path (anti-goal: bound it, don't
+remove it).
+
+Hermetic: chain reads and Circle HTTP calls are mocked at the boundary
+(contract loader / aiohttp session). No network, no Arc RPC, no Circle.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.oracle_updater import (
+    DEFAULT_MAX_DEVIATION_BPS,
+    DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS,
+    OracleUpdater,
+)
+from archimedes.models.asset import AssetPrice
+
+# ── Helpers ───────────────────────────────────────────────────
+
+
+def _price(symbol: str = "sTSLA", usd: float = 100.0, age_seconds: float = 0.0) -> AssetPrice:
+    return AssetPrice(
+        symbol=symbol,
+        price_usd=usd,
+        timestamp=datetime.now(UTC) - timedelta(seconds=age_seconds),
+        source="yfinance",
+    )
+
+
+def _int6(usd: float) -> int:
+    return int(usd * 1e6)
+
+
+@pytest.fixture
+def updater() -> OracleUpdater:
+    return OracleUpdater()
+
+
+# ── _validate_for_push ────────────────────────────────────────
+
+
+class TestValidateForPush:
+    async def test_accepts_fresh_price_within_deviation_cap(self, updater):
+        # +10% vs reference — inside the 20% default cap
+        price = _price(usd=110.0)
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+            assert await updater._validate_for_push(price, _int6(110.0)) is None
+
+    async def test_rejects_deviation_beyond_cap(self, updater):
+        # +30% vs reference — beyond the 2000 bps default cap
+        price = _price(usd=130.0)
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+            reason = await updater._validate_for_push(price, _int6(130.0))
+        assert reason is not None
+        assert "deviation" in reason
+
+    async def test_rejects_downward_deviation_beyond_cap(self, updater):
+        # -30% is equally out of bounds
+        price = _price(usd=70.0)
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+            reason = await updater._validate_for_push(price, _int6(70.0))
+        assert reason is not None
+        assert "deviation" in reason
+
+    async def test_rejects_stale_upstream_data(self, updater):
+        # 1 hour old — past the 15-minute default staleness cap.
+        # Reference mock would pass the deviation check, proving staleness
+        # alone is sufficient to refuse the push.
+        price = _price(usd=100.0, age_seconds=3600)
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+            reason = await updater._validate_for_push(price, _int6(100.0))
+        assert reason is not None
+        assert "stale" in reason
+
+    async def test_rejects_zero_int_price(self, updater):
+        # Sub-microdollar float truncates to a 0 on-chain int, which the
+        # contract rejects — the backend must refuse before spending a tx.
+        price = _price(usd=5e-7)
+        reason = await updater._validate_for_push(price, int(5e-7 * 1e6))
+        assert reason is not None
+        assert "non-positive" in reason
+
+    async def test_accepts_first_push_without_reference(self, updater):
+        # No on-chain price and nothing pushed yet → bootstrap is allowed
+        price = _price(usd=100.0)
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=None)):
+            assert await updater._validate_for_push(price, _int6(100.0)) is None
+
+    async def test_naive_timestamp_treated_as_utc(self, updater):
+        # A tz-naive timestamp must not crash the age computation
+        naive_now = datetime.now(UTC).replace(tzinfo=None)
+        price = AssetPrice(symbol="sTSLA", price_usd=100.0, timestamp=naive_now, source="yfinance")
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=None)):
+            assert await updater._validate_for_push(price, _int6(100.0)) is None
+
+    async def test_env_overrides_respected(self, monkeypatch):
+        monkeypatch.setenv("ORACLE_MAX_DEVIATION_BPS", "5000")
+        monkeypatch.setenv("ORACLE_MAX_UPSTREAM_STALENESS_SECONDS", "7200")
+        updater = OracleUpdater()
+        assert updater._max_deviation_bps == 5000
+        assert updater._max_upstream_staleness_s == 7200
+        # +30% now passes under the widened 50% cap; 1h-old data passes 2h cap
+        price = _price(usd=130.0, age_seconds=3600)
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+            assert await updater._validate_for_push(price, _int6(130.0)) is None
+
+    async def test_defaults_match_contract_bound(self, updater):
+        assert DEFAULT_MAX_DEVIATION_BPS == 2000  # mirrors PriceOracle.maxDeviationBps
+        assert updater._max_deviation_bps == DEFAULT_MAX_DEVIATION_BPS
+        assert updater._max_upstream_staleness_s == DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS
+
+
+# ── _get_reference_price_int ─────────────────────────────────
+
+
+class TestReferencePrice:
+    async def test_prefers_onchain_price(self, updater):
+        oracle_contract = MagicMock()
+        oracle_contract.functions.price.return_value.call = AsyncMock(return_value=_int6(123.45))
+        loader = MagicMock()
+        loader.oracle_for.return_value = oracle_contract
+        updater._last_pushed_price_int["sTSLA"] = _int6(999.0)
+        with patch("archimedes.chain.contracts.get_contract_loader", return_value=loader):
+            assert await updater._get_reference_price_int("sTSLA") == _int6(123.45)
+
+    async def test_falls_back_to_last_pushed_when_chain_read_fails(self, updater):
+        updater._last_pushed_price_int["sTSLA"] = _int6(101.0)
+        with patch(
+            "archimedes.chain.contracts.get_contract_loader",
+            side_effect=ConnectionError("RPC down"),
+        ):
+            assert await updater._get_reference_price_int("sTSLA") == _int6(101.0)
+
+    async def test_returns_none_when_no_reference_exists(self, updater):
+        with patch(
+            "archimedes.chain.contracts.get_contract_loader",
+            side_effect=ConnectionError("RPC down"),
+        ):
+            assert await updater._get_reference_price_int("sTSLA") is None
+
+
+# ── push_prices_on_chain refuses bad prices ──────────────────
+
+
+def _mock_aiohttp_session(post_response: MagicMock | None = None) -> tuple[MagicMock, MagicMock]:
+    """Build a mock aiohttp.ClientSession context manager (the HTTP boundary)."""
+    session = MagicMock()
+    if post_response is not None:
+        post_cm = MagicMock()
+        post_cm.__aenter__ = AsyncMock(return_value=post_response)
+        post_cm.__aexit__ = AsyncMock(return_value=False)
+        session.post = MagicMock(return_value=post_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return session_cm, session
+
+
+@pytest.fixture
+def circle_creds(monkeypatch):
+    monkeypatch.setenv("CIRCLE_API_KEY", "test-api-key")
+    monkeypatch.setenv("CIRCLE_ENTITY_SECRET", "ab" * 32)
+    monkeypatch.setenv("WALLET_ID", "test-wallet-id")
+
+
+class TestPushPricesOnChain:
+    async def test_refuses_to_push_price_failing_deviation_check(self, circle_creds):
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"  # skip key fetch
+        session_cm, session = _mock_aiohttp_session()
+
+        bad = _price(symbol="sTSLA", usd=130.0)  # +30% vs reference → rejected
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))),
+        ):
+            result = await updater.push_prices_on_chain([bad])
+
+        assert result is None
+        session.post.assert_not_called()
+
+    async def test_refuses_to_push_stale_price(self, circle_creds):
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        session_cm, session = _mock_aiohttp_session()
+
+        stale = _price(symbol="sTSLA", usd=100.0, age_seconds=3600)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))),
+        ):
+            result = await updater.push_prices_on_chain([stale])
+
+        assert result is None
+        session.post.assert_not_called()
+
+    async def test_legitimate_update_path_preserved(self, circle_creds):
+        # Anti-goal check: a fresh, in-bounds price still pushes through and
+        # is recorded as the new fallback reference.
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+
+        resp = MagicMock(status=201)
+        resp.json = AsyncMock(return_value={"data": {"id": "tx-123"}})
+        session_cm, session = _mock_aiohttp_session(post_response=resp)
+
+        good = _price(symbol="sTSLA", usd=110.0)  # +10%, inside the cap
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))),
+        ):
+            result = await updater.push_prices_on_chain([good])
+
+        assert result == "tx-123"
+        session.post.assert_called_once()
+        assert updater._last_pushed_price_int["sTSLA"] == _int6(110.0)

--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -23,11 +23,28 @@ contract PriceOracle is Ownable {
     /// @notice Address allowed to push price updates (e.g. Circle wallet)
     address public updater;
 
+    /// @notice Max allowed move per setPrice, in basis points vs the prior price.
+    ///         Default 2000 bps (20%) — generous for a daily-update cadence but
+    ///         blocks fat-finger / glitched-feed / compromised-key writes that
+    ///         would otherwise flow straight into Vault.totalAssets().
+    ///         Owner-configurable via setMaxDeviationBps; for a legitimately
+    ///         gapped market the owner can use forceSetPrice (two-step escape
+    ///         hatch) so the oracle can never be bricked permanently.
+    uint256 public maxDeviationBps = 2000;
+
+    /// @notice Basis-point denominator (100% = 10_000 bps)
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
     event PriceUpdated(uint256 oldPrice, uint256 newPrice, uint256 timestamp);
+    event PriceForced(uint256 oldPrice, uint256 newPrice, uint256 timestamp);
+    event MaxDeviationBpsChanged(uint256 oldBps, uint256 newBps);
     event UpdaterChanged(address oldUpdater, address newUpdater);
 
     error StalePrice();
     error UnauthorizedUpdater();
+    error ZeroPrice();
+    error PriceDeviationTooLarge(uint256 oldPrice, uint256 newPrice, uint256 maxBps);
+    error InvalidDeviationBound();
 
     modifier onlyUpdater() {
         if (msg.sender != owner() && msg.sender != updater) revert UnauthorizedUpdater();
@@ -42,11 +59,46 @@ contract PriceOracle is Ownable {
         emit PriceUpdated(0, _initialPrice, block.timestamp);
     }
 
+    /// @notice Push a new price. Bounded: rejects zero and any move larger
+    ///         than maxDeviationBps vs the prior price. If the market truly
+    ///         gapped beyond the bound, the owner uses forceSetPrice (or
+    ///         widens the bound via setMaxDeviationBps).
     function setPrice(uint256 _newPrice) external onlyUpdater {
+        if (_newPrice == 0) revert ZeroPrice();
         uint256 oldPrice = price;
+        // Deviation bound only applies once a prior price exists; a zero
+        // prior price (bootstrap) accepts any positive first price.
+        if (oldPrice != 0) {
+            uint256 diff = _newPrice > oldPrice ? _newPrice - oldPrice : oldPrice - _newPrice;
+            if (diff * BPS_DENOMINATOR > oldPrice * maxDeviationBps) {
+                revert PriceDeviationTooLarge(oldPrice, _newPrice, maxDeviationBps);
+            }
+        }
         price = _newPrice;
         lastUpdated = block.timestamp;
         emit PriceUpdated(oldPrice, _newPrice, block.timestamp);
+    }
+
+    /// @notice Emergency override — owner-only escape hatch for legitimately
+    ///         gapped markets (e.g. a >maxDeviationBps overnight move). Skips
+    ///         the deviation bound but still rejects zero. Emits a distinct
+    ///         event so forced updates are auditable on-chain.
+    function forceSetPrice(uint256 _newPrice) external onlyOwner {
+        if (_newPrice == 0) revert ZeroPrice();
+        uint256 oldPrice = price;
+        price = _newPrice;
+        lastUpdated = block.timestamp;
+        emit PriceForced(oldPrice, _newPrice, block.timestamp);
+    }
+
+    /// @notice Adjust the per-update deviation bound. Must be in (0, 10_000];
+    ///         a zero bound would brick setPrice entirely and >100% is
+    ///         meaningless (use forceSetPrice for gap recovery instead).
+    function setMaxDeviationBps(uint256 _maxDeviationBps) external onlyOwner {
+        if (_maxDeviationBps == 0 || _maxDeviationBps > BPS_DENOMINATOR) revert InvalidDeviationBound();
+        uint256 old = maxDeviationBps;
+        maxDeviationBps = _maxDeviationBps;
+        emit MaxDeviationBpsChanged(old, _maxDeviationBps);
     }
 
     function setUpdater(address _updater) external onlyOwner {

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -287,7 +287,7 @@ contract SyntheticVaultTest is Test {
         // Price spikes +50% — beyond the 20% mint-side buffer, so total liability
         // (totalSupply * price) now exceeds vault collateral.
         vm.prank(owner);
-        oracle.setPrice((INITIAL_PRICE * 150) / 100);
+        oracle.forceSetPrice((INITIAL_PRICE * 150) / 100);
 
         uint256 collateralBefore = usdc.balanceOf(address(vault)) - vault.protocolFees();
         uint256 liability = (sTSLA.totalSupply() * oracle.getPrice()) / 1e18;
@@ -329,7 +329,7 @@ contract SyntheticVaultTest is Test {
         vm.stopPrank();
 
         vm.prank(owner);
-        oracle.setPrice(INITIAL_PRICE * 2); // +100%
+        oracle.forceSetPrice(INITIAL_PRICE * 2); // +100%
 
         uint256 collateralBefore = usdc.balanceOf(address(vault)) - vault.protocolFees();
 
@@ -384,7 +384,7 @@ contract SyntheticVaultTest is Test {
         vm.stopPrank();
 
         vm.prank(owner);
-        oracle.setPrice((INITIAL_PRICE * 150) / 100);
+        oracle.forceSetPrice((INITIAL_PRICE * 150) / 100);
 
         uint256 preview = vault.previewBurn(synthOut);
         vm.prank(alice);

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -79,15 +79,96 @@ contract SyntheticVaultTest is Test {
     }
 
     function test_revert_stale_price() public {
-        vm.warp(block.timestamp + 2 hours); // past MAX_STALENESS
+        vm.warp(block.timestamp + 25 hours); // past MAX_STALENESS (24 hours)
         vm.expectRevert();
         oracle.getPrice();
     }
 
     function test_isFresh() public {
         assertTrue(oracle.isFresh());
-        vm.warp(block.timestamp + 2 hours);
+        vm.warp(block.timestamp + 25 hours); // past MAX_STALENESS (24 hours)
         assertFalse(oracle.isFresh());
+    }
+
+    function test_revert_setPrice_zero() public {
+        vm.prank(owner);
+        vm.expectRevert(PriceOracle.ZeroPrice.selector);
+        oracle.setPrice(0);
+    }
+
+    function test_revert_setPrice_deviation_too_large() public {
+        // +25% jump vs prior price — beyond the 20% (2000 bps) default bound
+        uint256 jumped = (INITIAL_PRICE * 125) / 100;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(PriceOracle.PriceDeviationTooLarge.selector, INITIAL_PRICE, jumped, 2000)
+        );
+        oracle.setPrice(jumped);
+    }
+
+    function test_revert_setPrice_deviation_too_large_downward() public {
+        // -25% drop is equally out of bounds
+        uint256 dropped = (INITIAL_PRICE * 75) / 100;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(PriceOracle.PriceDeviationTooLarge.selector, INITIAL_PRICE, dropped, 2000)
+        );
+        oracle.setPrice(dropped);
+    }
+
+    function test_setPrice_within_deviation_bound() public {
+        // +19% stays inside the 20% default bound
+        uint256 within = (INITIAL_PRICE * 119) / 100;
+        vm.prank(owner);
+        oracle.setPrice(within);
+        assertEq(oracle.price(), within);
+    }
+
+    function test_forceSetPrice_bypasses_deviation_bound() public {
+        // Owner escape hatch for a legitimately gapped market: +50% accepted
+        uint256 gapped = (INITIAL_PRICE * 150) / 100;
+        vm.prank(owner);
+        oracle.forceSetPrice(gapped);
+        assertEq(oracle.price(), gapped);
+    }
+
+    function test_revert_forceSetPrice_zero() public {
+        vm.prank(owner);
+        vm.expectRevert(PriceOracle.ZeroPrice.selector);
+        oracle.forceSetPrice(0);
+    }
+
+    function test_revert_forceSetPrice_non_owner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        oracle.forceSetPrice(INITIAL_PRICE);
+    }
+
+    function test_setMaxDeviationBps() public {
+        vm.prank(owner);
+        oracle.setMaxDeviationBps(5000);
+        assertEq(oracle.maxDeviationBps(), 5000);
+
+        // A +40% move now passes under the widened 50% bound
+        uint256 jumped = (INITIAL_PRICE * 140) / 100;
+        vm.prank(owner);
+        oracle.setPrice(jumped);
+        assertEq(oracle.price(), jumped);
+    }
+
+    function test_revert_setMaxDeviationBps_invalid_bounds() public {
+        vm.startPrank(owner);
+        vm.expectRevert(PriceOracle.InvalidDeviationBound.selector);
+        oracle.setMaxDeviationBps(0);
+        vm.expectRevert(PriceOracle.InvalidDeviationBound.selector);
+        oracle.setMaxDeviationBps(10_001);
+        vm.stopPrank();
+    }
+
+    function test_revert_setMaxDeviationBps_non_owner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        oracle.setMaxDeviationBps(5000);
     }
 
     // ─── Mint Tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #508 (AUDIT_2026-06-10.md, High finding #13). `PriceOracle.setPrice` accepted any value from the single admin key, and the oracle runner pushed upstream prices on-chain with no sanity bounds — any corruption (fat-finger, yfinance glitch, key compromise) flowed straight into `Vault.totalAssets()` and rebalance sizing.

## Contract changes (`contracts/src/PriceOracle.sol`)

- `setPrice` now rejects **zero** (`ZeroPrice`) and any move **> `maxDeviationBps`** vs the prior price (`PriceDeviationTooLarge`). Default bound: **2000 bps (20%)** — generous for a daily-update cadence while blocking glitched/compromised writes.
- **Emergency override path (documented choice):** two complementary escapes so a legitimately gapped market can never brick the oracle:
  - `setMaxDeviationBps(uint256)` — owner adjusts the bound; constrained to `(0, 10_000]` so the bound itself can't brick `setPrice`.
  - `forceSetPrice(uint256)` — owner-only force-update that bypasses the deviation bound (still rejects zero) and emits a distinct `PriceForced` event so forced updates are auditable on-chain.
- Bootstrap: the deviation bound is skipped while the prior price is zero, so a fresh oracle accepts its first positive price.
- Fixed the two drifted staleness tests (`test_isFresh`, `test_revert_stale_price`): they warped +2h with a "past MAX_STALENESS" comment, but `MAX_STALENESS` is 24h — they now warp +25h. The contract was **not** weakened.

## Backend changes (`backend/archimedes/chain/oracle_updater.py`)

Each price now passes `_validate_for_push` before any Circle tx is spent:

1. **Non-positive guard** — the 6-decimal on-chain int must be > 0.
2. **Upstream staleness** — observation younger than `ORACLE_MAX_UPSTREAM_STALENESS_SECONDS` (default 900s).
3. **Deviation cap** — move vs the last known good price (on-chain read, falling back to the last successfully pushed value) within `ORACLE_MAX_DEVIATION_BPS` (default 2000, mirroring the contract). First-ever pushes with no reference are allowed.

**Multi-source corroboration (issue scope item) — documented TODO, not faked:** each symbol has exactly **one** upstream source today (yfinance for equities/futures, CoinGecko for sBTC), so requiring N corroborating sources cannot be implemented honestly yet. The TODO in `_validate_for_push`'s docstring specifies the rule for when a second independent feed lands: agreement within the deviation cap across ≥ 2 sources before pushing.

## Verification

```
forge test                          → 109 passed, 0 failed (baseline was 97 passed, 2 failed — the drifted staleness tests)
pytest backend/tests/chain/ -q      → 50 passed (15 new in test_oracle_updater.py), hermetic (env -i, no RPC/Circle)
pytest backend/tests -m "not integration" -q → 1501 passed, 2 skipped (pre-existing load-bearing skips)
ruff format --check .               → 307 files already formatted
ruff check --select E9,F63,F7,F40 . → All checks passed!
```

New forge tests: zero rejection, ±25% deviation rejection, +19% in-bound update, `forceSetPrice` bypass + zero/non-owner reverts, `setMaxDeviationBps` happy path + invalid-bound + non-owner reverts.

New pytest coverage: staleness rejection, ±30% deviation rejection, zero-int rejection, bootstrap-without-reference acceptance, env overrides, on-chain-reference fallback chain, and full `push_prices_on_chain` paths (refuses deviant/stale prices — `session.post` never called; legitimate in-bound update still pushes and records the fallback reference).

## Redeploy note

⚠️ `contracts/abis/` was deliberately **not** touched — it mirrors the LIVE Arc testnet deployment, and the backend only reads `price()`, which exists on the deployed contract. The new `PriceOracle` (with `maxDeviationBps` / `forceSetPrice` / `setMaxDeviationBps`) requires a **redeploy of the 7 oracle contracts** + ABI refresh + `ChainSettings` address update as a follow-up deploy step. Until redeploy, the backend sanity gates already protect the live oracles.

## Review

Contract change — needs Chuan's eyes per CLAUDE.md (cross-lane: oracle runner is Chuan's lane, contract portion flagged in #508 as requiring Chuan).