### PR TITLE
[infra] Tighten CSP script-src: drop unsafe-inline/unsafe-eval

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,14 +18,17 @@ server {
     # forwards to :8080), so the headers must live here — they previously
     # existed only in the unused :8443 block, leaving the live app with none
     # (clickjacking + no CSP). See AUDIT_2026-06-10.md finding #20. Kept in sync
-    # with the :8443 block below; CSP still allows 'unsafe-inline'/'unsafe-eval'
-    # (tightening that is tracked separately as finding #27).
+    # with the :8443 block below. script-src is 'self' only (finding #27): the
+    # Vite prod bundle has no inline scripts and no executed eval — the only
+    # Function() constructor uses are dead fallback paths (lodash-es _root.js
+    # globalThis detection, setImmediate-polyfill string-callback branch).
+    # style-src 'unsafe-inline' is retained deliberately (separate concern).
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "same-origin" always;
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://rpc.testnet.arc.network https://testnet.arcscan.app https://*.coingecko.com https://*.alchemyapi.io https://api.z.ai https://api.anthropic.com https://modular-sdk.circle.com wss://*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; connect-src 'self' https://rpc.testnet.arc.network https://testnet.arcscan.app https://*.coingecko.com https://*.alchemyapi.io https://api.z.ai https://api.anthropic.com https://modular-sdk.circle.com wss://*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;" always;
 
     # ACME challenge passthrough for certbot renewals
     location /.well-known/acme-challenge/ {
@@ -113,7 +116,7 @@ server {
     # this entry, the SDK fails with "An unknown RPC error occurred. Details:
     # Failed to fetch" on every passkey signup. Safari is more lenient and worked
     # before this entry was added, which is why the regression was Chrome-only.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://rpc.testnet.arc.network https://testnet.arcscan.app https://*.coingecko.com https://*.alchemyapi.io https://api.z.ai https://api.anthropic.com https://modular-sdk.circle.com wss://*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; connect-src 'self' https://rpc.testnet.arc.network https://testnet.arcscan.app https://*.coingecko.com https://*.alchemyapi.io https://api.z.ai https://api.anthropic.com https://modular-sdk.circle.com wss://*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;" always;
 
     # SPA fallback — serve index.html for client-side routes
     location / {


### PR DESCRIPTION
## Summary
AUDIT_2026-06-10.md finding #27 / closes #522. The CSP in `nginx/nginx.conf` allowed `script-src 'self' 'unsafe-inline' 'unsafe-eval'`, which neuters CSP as an XSS defense. A production-bundle audit shows neither directive is needed, so `script-src` is now `'self'` only — in **both** the `:8080` and `:8443` server blocks (kept identical).

## Evidence (from `cd ui && npm ci && npm run build`)
- `grep -c "eval(" dist/assets/*.js` → **0** in all three chunks (`index-BRyveAvc.js`, `siwe-B3Bm6BbL.js`, `ccip-DefD1oQo.js`); `new Function(` → 0; `WebAssembly` → 0 (so `'wasm-unsafe-eval'` not needed)
- Two bare `Function(` constructor hits in the main chunk, both **dead fallback paths** that never execute in a browser:
  - lodash-es `_root.js`: `freeGlobal || freeSelf || Function('return this')()` — `self` is always defined in browsers, so the eval branch is unreachable
  - a `setImmediate` polyfill: `typeof e != 'function' && (e = Function('' + e))` — only fires when a *string* callback is passed, and all callers pass functions
- `dist/index.html`: exactly one `<script type="module" crossorigin src="/assets/index-….js">` — no inline `<script>` blocks, no inline event handlers
- `ui/src` + `ui/index.html`: zero `eval(` / `new Function` / `dangerouslySetInnerHTML`

## What changed
- `script-src 'self' 'unsafe-inline' 'unsafe-eval'` → `script-src 'self'` in both server blocks
- Updated the :8080 security-headers comment to record the evidence
- **Untouched on purpose:** `connect-src` (Circle Modular Wallets SDK / Chrome passkey regression history — see the comment above the :8443 CSP) and `style-src 'unsafe-inline'` (some libs inject `<style>` tags; separate concern, out of scope per #522)

## Residual verification needed
- **Live Chrome passkey register/login + deposit flow smoke test after deploy.** Headers can't be exercised locally without the docker stack; the greps above prove the tightened policy cannot block any script the bundle actually loads, but the Circle SDK passkey flow has a history of Chrome-only CSP regressions (connect-src, not script-src — still, verify).
- Safari pass of the same flow.

## Adjacent observation (not changed here)
`ui/index.html` loads Google Fonts from `fonts.googleapis.com`/`fonts.gstatic.com`, but the CSP's `style-src`/`font-src` don't allow those origins — fonts are likely already being blocked on the live stack since finding #20 landed. Separate issue territory.

Closes #522