### PR TITLE
[backend] Bind chat identity to SIWE session when present

### DIFF
--- a/backend/archimedes/api/chat_routes.py
+++ b/backend/archimedes/api/chat_routes.py
@@ -5,9 +5,12 @@ Endpoints:
   POST   /api/vaults/{address}/chat       — post a message
   GET    /api/vaults/{address}/chat/count  — message count
 
-Design (per ecosystem-design-spec.md § 16–17):
+Design (per ecosystem-design-spec.md § 16–17, identity hardened per issue #524):
   - Fully open: any connected wallet can read/write
-  - Wallet address = identity
+  - Wallet address = identity. With a SIWE session the identity comes from the
+    session and the message is stored `verified=True`; a mismatched body wallet
+    is rejected with 403. Without a session, posts are accepted but explicitly
+    marked `verified=False` — attribution is never silently trusted.
   - AI auto-responds to @archimedes mentions
 """
 
@@ -19,6 +22,7 @@ import re
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 
 from archimedes.api.auth_guard import require_internal_agent_key
+from archimedes.api.auth_siwe import get_verified_wallet
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import (
     ChatMessageListResponse,
@@ -56,6 +60,7 @@ async def get_chat_messages(
                 wallet_address=m["wallet_address"],
                 message=m["message"],
                 is_ai=m["is_ai"],
+                verified=m.get("verified", False),
                 created_at=m["created_at"],
             )
             for m in messages
@@ -72,14 +77,35 @@ async def post_chat_message(
     body: ChatPostRequest,
     request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     response: Response,  # noqa: ARG001
+    session_wallet: str | None = Depends(get_verified_wallet),
 ):
-    """Post a message to a vault's chat. Triggers AI response if @archimedes is mentioned."""
+    """Post a message to a vault's chat. Triggers AI response if @archimedes is mentioned.
+
+    Identity binding (#524): with a SIWE session, the message is attributed to
+    the session wallet and stored verified; a body wallet that contradicts the
+    session is rejected with 403. Without a session, the body wallet is
+    accepted but the message is explicitly marked unverified.
+    """
     if not body.message or not body.message.strip():
         raise HTTPException(status_code=400, detail="Message cannot be empty")
-    if not body.wallet_address or not _WALLET_RE.match(body.wallet_address):
-        raise HTTPException(status_code=422, detail="wallet_address must match ^0x[a-fA-F0-9]{40}$")
     if len(body.message) > 2000:
         raise HTTPException(status_code=400, detail="Message too long (max 2000 chars)")
+
+    if session_wallet is not None:
+        # SIWE-verified caller — session is the identity, not the body.
+        if body.wallet_address and body.wallet_address.lower() != session_wallet:
+            raise HTTPException(
+                status_code=403,
+                detail="wallet_address does not match the authenticated SIWE session",
+            )
+        wallet_address = session_wallet
+        verified = True
+    else:
+        # No session — open chat stays open, but attribution is unverified.
+        if not body.wallet_address or not _WALLET_RE.match(body.wallet_address):
+            raise HTTPException(status_code=422, detail="wallet_address must match ^0x[a-fA-F0-9]{40}$")
+        wallet_address = body.wallet_address
+        verified = False
 
     # post_message is fully synchronous and, when @archimedes is mentioned, makes
     # a blocking Anthropic call plus sync DB writes. Calling it directly inside
@@ -88,8 +114,9 @@ async def post_chat_message(
     result = await asyncio.to_thread(
         chat_service.post_message,
         vault_address=address,
-        wallet_address=body.wallet_address,
+        wallet_address=wallet_address,
         message=body.message.strip(),
+        verified=verified,
     )
 
     ai_response = None
@@ -101,6 +128,7 @@ async def post_chat_message(
             wallet_address=ai_data["wallet_address"],
             message=ai_data["message"],
             is_ai=ai_data["is_ai"],
+            verified=ai_data.get("verified", False),
             created_at=ai_data["created_at"],
         )
 
@@ -111,6 +139,7 @@ async def post_chat_message(
             wallet_address=result["wallet_address"],
             message=result["message"],
             is_ai=result["is_ai"],
+            verified=result.get("verified", False),
             created_at=result["created_at"],
         ),
         ai_response=ai_response,

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -411,6 +411,7 @@ class ChatMessageResponse(BaseModel):
     wallet_address: str
     message: str
     is_ai: bool = False
+    verified: bool = False  # True when the wallet identity was SIWE-session-proven at post time (#524)
     created_at: str  # ISO 8601
 
 
@@ -423,9 +424,14 @@ class ChatMessageListResponse(BaseModel):
 
 
 class ChatPostRequest(BaseModel):
-    """Post a new message to a vault's chat."""
+    """Post a new message to a vault's chat.
 
-    wallet_address: str
+    wallet_address is optional when the caller has a SIWE session — identity
+    then comes from the session, not the body (#524). Without a session it is
+    required and the message is stored as unverified.
+    """
+
+    wallet_address: str | None = None
     message: str
 
 

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -72,6 +72,9 @@ def init_db() -> None:
             "ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS on_chain_registration_tx VARCHAR(66)",
             "ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS on_chain_registration_block VARCHAR(32)",
             "ALTER TABLE strategy_store ADD COLUMN IF NOT EXISTS parent_id VARCHAR(64)",
+            # chat_messages.verified — SIWE-bound chat identity (issue #524).
+            # Pre-existing rows default to FALSE: they were body-supplied, never verified.
+            "ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS verified BOOLEAN NOT NULL DEFAULT FALSE",
         ]
         try:
             with engine.begin() as conn:

--- a/backend/archimedes/models/chat.py
+++ b/backend/archimedes/models/chat.py
@@ -75,6 +75,10 @@ class ChatMessage(Base):
     wallet_address: Mapped[str] = mapped_column(String(42), nullable=False)
     message: Mapped[str] = mapped_column(Text, nullable=False)
     is_ai: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    # True when the wallet identity was proven by a SIWE session at post time
+    # (issue #524). Default False keeps pre-existing rows honest: they were
+    # body-supplied and never verified.
+    verified: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
@@ -91,5 +95,6 @@ class ChatMessage(Base):
             "wallet_address": self.wallet_address,
             "message": self.message,
             "is_ai": self.is_ai,
+            "verified": self.verified,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }

--- a/backend/archimedes/services/chat_service.py
+++ b/backend/archimedes/services/chat_service.py
@@ -70,8 +70,13 @@ class ChatService:
         vault_address: str,
         wallet_address: str,
         message: str,
+        verified: bool = False,
     ) -> dict:
-        """Post a user message and optionally trigger an AI response."""
+        """Post a user message and optionally trigger an AI response.
+
+        `verified` is True only when the caller proved wallet ownership via a
+        SIWE session (#524); body-supplied identities stay False.
+        """
         session = get_session()
         try:
             msg = ChatMessage(
@@ -79,6 +84,7 @@ class ChatService:
                 wallet_address=wallet_address.lower(),
                 message=message,
                 is_ai=False,
+                verified=verified,
                 created_at=datetime.now(UTC),
             )
             session.add(msg)
@@ -114,6 +120,7 @@ class ChatService:
                 wallet_address=AI_WALLET_ADDRESS,
                 message=message,
                 is_ai=True,
+                verified=True,  # backend-authored — identity is the configured agent wallet
                 created_at=datetime.now(UTC),
             )
             session.add(msg)

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -123,6 +123,12 @@ class TestReadEndpointsRegression:
     """(d) Existing read endpoints keep working and surface the verified flag."""
 
     def test_list_and_count_surface_verified(self, client):
+        # Delta-based, message-specific assertions — the shared sqlite engine
+        # (sqlite:///./archimedes_chat.db) persists rows across runs, so an
+        # absolute `total == 2` is brittle on re-run. Mirror the before/after
+        # pattern used in TestMismatchRejected above.
+        before = client.get(f"/api/vaults/{_VAULT_READ}/chat/count").json()["message_count"]
+
         client.post(
             f"/api/vaults/{_VAULT_READ}/chat",
             json={"message": "verified one"},
@@ -136,12 +142,12 @@ class TestReadEndpointsRegression:
         res = client.get(f"/api/vaults/{_VAULT_READ}/chat")
         assert res.status_code == 200
         data = res.json()
-        assert data["total"] == 2
         by_text = {m["message"]: m for m in data["messages"]}
         assert by_text["verified one"]["verified"] is True
         assert by_text["verified one"]["wallet_address"] == _W_SESSION.lower()
         assert by_text["unverified one"]["verified"] is False
+        assert by_text["unverified one"]["wallet_address"] == _W_BODY.lower()
 
         count = client.get(f"/api/vaults/{_VAULT_READ}/chat/count")
         assert count.status_code == 200
-        assert count.json()["message_count"] == 2
+        assert count.json()["message_count"] == before + 2

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -1,0 +1,147 @@
+"""Route-level tests for chat identity binding — issue #524 (audit #28).
+
+POST /api/vaults/{address}/chat used to trust the body-supplied
+wallet_address outright. The hybrid model under test:
+
+  - Valid SIWE session  → message attributed to the session wallet,
+    stored/returned with verified=True; a contradicting body wallet → 403.
+  - No session          → post still accepted (open chat), but explicitly
+    verified=False so attribution is never silently trusted.
+
+Hermetic: uses the shared SQLAlchemy engine (sqlite fallback, no Postgres /
+Redis / Anthropic). SIWE sessions are real signed cookies via the
+`_siwe_cookies` precedent from test_user_routes.py — no header spoofing.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from fastapi.testclient import TestClient
+
+# Distinct vaults per test so message assertions don't bleed across tests
+# sharing the same sqlite file.
+_VAULT_SESSION = "0x00000000000000000000000000000000000005aa"
+_VAULT_MISMATCH = "0x00000000000000000000000000000000000005ab"
+_VAULT_ANON = "0x00000000000000000000000000000000000005ac"
+_VAULT_READ = "0x00000000000000000000000000000000000005ad"
+
+_W_SESSION = "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"  # checksum-case on purpose
+_W_OTHER = "0x9999999999999999999999999999999999999999"
+_W_BODY = "0x7777777777777777777777777777777777777777"
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Build a valid SIWE session cookie for `wallet` (test_user_routes precedent)."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+@pytest.fixture
+def client():
+    """Test client with tables created on the shared (sqlite) engine."""
+    from archimedes.db import engine
+    from archimedes.models.chat import Base
+
+    Base.metadata.create_all(bind=engine)
+
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+class TestSiweBoundIdentity:
+    """(a) Session present → attribution comes from the session, verified=True."""
+
+    def test_session_wallet_wins_and_marks_verified(self, client):
+        res = client.post(
+            f"/api/vaults/{_VAULT_SESSION}/chat",
+            json={"message": "posting with a session, no body wallet"},
+            cookies=_siwe_cookies(_W_SESSION),
+        )
+        assert res.status_code == 200, res.text
+        msg = res.json()["message"]
+        assert msg["wallet_address"] == _W_SESSION.lower()
+        assert msg["verified"] is True
+
+    def test_matching_body_wallet_is_accepted(self, client):
+        """A body wallet that agrees with the session (any case) is fine."""
+        res = client.post(
+            f"/api/vaults/{_VAULT_SESSION}/chat",
+            json={"wallet_address": _W_SESSION, "message": "body matches session"},
+            cookies=_siwe_cookies(_W_SESSION),
+        )
+        assert res.status_code == 200, res.text
+        msg = res.json()["message"]
+        assert msg["wallet_address"] == _W_SESSION.lower()
+        assert msg["verified"] is True
+
+
+class TestMismatchRejected:
+    """(b) Session present + contradicting body wallet → 403, nothing stored."""
+
+    def test_mismatched_body_wallet_403(self, client):
+        before = client.get(f"/api/vaults/{_VAULT_MISMATCH}/chat/count").json()["message_count"]
+        res = client.post(
+            f"/api/vaults/{_VAULT_MISMATCH}/chat",
+            json={"wallet_address": _W_OTHER, "message": "impersonation attempt"},
+            cookies=_siwe_cookies(_W_SESSION),
+        )
+        assert res.status_code == 403
+        assert "SIWE" in res.json()["detail"]
+        after = client.get(f"/api/vaults/{_VAULT_MISMATCH}/chat/count").json()["message_count"]
+        assert after == before  # rejected post must not be persisted
+
+
+class TestAnonymousUnverified:
+    """(c) No session → accepted (open chat) but explicitly verified=False."""
+
+    def test_no_session_accepted_as_unverified(self, client):
+        res = client.post(
+            f"/api/vaults/{_VAULT_ANON}/chat",
+            json={"wallet_address": _W_BODY, "message": "anonymous post"},
+        )
+        assert res.status_code == 200, res.text
+        msg = res.json()["message"]
+        assert msg["wallet_address"] == _W_BODY.lower()
+        assert msg["verified"] is False
+
+    def test_no_session_no_wallet_still_422(self, client):
+        """Without a session the body wallet remains required + regex-validated."""
+        res = client.post(f"/api/vaults/{_VAULT_ANON}/chat", json={"message": "who am I?"})
+        assert res.status_code == 422
+
+        res = client.post(
+            f"/api/vaults/{_VAULT_ANON}/chat",
+            json={"wallet_address": "garbage", "message": "still no"},
+        )
+        assert res.status_code == 422
+
+
+class TestReadEndpointsRegression:
+    """(d) Existing read endpoints keep working and surface the verified flag."""
+
+    def test_list_and_count_surface_verified(self, client):
+        client.post(
+            f"/api/vaults/{_VAULT_READ}/chat",
+            json={"message": "verified one"},
+            cookies=_siwe_cookies(_W_SESSION),
+        )
+        client.post(
+            f"/api/vaults/{_VAULT_READ}/chat",
+            json={"wallet_address": _W_BODY, "message": "unverified one"},
+        )
+
+        res = client.get(f"/api/vaults/{_VAULT_READ}/chat")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["total"] == 2
+        by_text = {m["message"]: m for m in data["messages"]}
+        assert by_text["verified one"]["verified"] is True
+        assert by_text["verified one"]["wallet_address"] == _W_SESSION.lower()
+        assert by_text["unverified one"]["verified"] is False
+
+        count = client.get(f"/api/vaults/{_VAULT_READ}/chat/count")
+        assert count.status_code == 200
+        assert count.json()["message_count"] == 2


### PR DESCRIPTION
## Summary
Implements the hybrid decided for #524 (audit finding #28): vault chat stays fully open, but wallet attribution becomes trustworthy. With a valid SIWE session the message identity comes from the session (a contradicting body `wallet_address` is rejected with 403 — rejection over silent override); without a session the post is still accepted but explicitly marked `verified: false`, so attribution is never silently trusted.

## What changed
- `backend/archimedes/api/chat_routes.py` — `POST /api/vaults/{address}/chat` now takes the optional SIWE dependency (`Depends(get_verified_wallet)`, reused from `auth_siwe.py` — no new auth mechanism). Session present → attribute to session wallet, `verified=True`, 403 on body/session mismatch. No session → body wallet required + regex-validated as before, `verified=False`. Read endpoints surface the flag.
- `backend/archimedes/api/schemas.py` — `ChatPostRequest.wallet_address` optional (required only without a session); `ChatMessageResponse.verified: bool = False`.
- `backend/archimedes/models/chat.py` — `ChatMessage.verified` column, default `False` so pre-existing rows stay honest (they were body-supplied, never verified); included in `to_dict`.
- `backend/archimedes/db.py` — idempotent `ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS verified` in the existing Postgres patch list (same pattern as the `strategy_store` patches).
- `backend/archimedes/services/chat_service.py` — `post_message(..., verified: bool = False)`; AI/system messages stored `verified=True` (backend-authored identity).
- `backend/tests/test_chat_routes.py` — new route-level tests, hermetic, using the real signed-cookie `_siwe_cookies` precedent from `test_user_routes.py`: (a) session → session-wallet attribution + `verified=True` (incl. case-insensitive body match), (b) mismatched body wallet → 403 and not persisted, (c) no session → accepted with `verified=False`, plus 422 when no session and no/invalid wallet, (d) regression on list/count read endpoints incl. the `verified` flag.

## Verification
```
env -i HOME=$HOME PATH=/usr/bin:/bin PYTHONPATH=backend python -m pytest backend/tests/test_chat_routes.py -q
→ 6 passed

env -i HOME=$HOME PATH=/usr/bin:/bin PYTHONPATH=backend python -m pytest backend/tests -m "not integration" -q
→ 1492 passed, 2 skipped (pre-existing skips)

ruff format --check .   → 307 files already formatted
ruff check --select E9,F63,F7,F40 .   → All checks passed!
```

Cross-lane note: chat routes sit in Daniel R.'s backend lane — flagging for his review eyes.

Closes #524