### PR TITLE
[backend] Harden email-key fallback, volatility guard, and list limit

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -19,7 +19,7 @@ import json
 import logging
 from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 
 from archimedes.agents.generation_pipeline import run_generation
@@ -191,10 +191,10 @@ async def cancel_job(job_id: str) -> dict[str, str]:
 
 
 @generate_router.get("/jobs", response_model=JobsListResponse)
-async def list_jobs(limit: int = 20) -> JobsListResponse:
+async def list_jobs(limit: int = Query(default=20, ge=1, le=100)) -> JobsListResponse:
     """Recent jobs for the GenerationStatus UI."""
     store = get_job_store()
-    raw = await store.list_recent_jobs(limit=max(1, min(limit, 100)))
+    raw = await store.list_recent_jobs(limit=limit)
     summaries: list[JobSummary] = []
     for j in raw:
         if j.get("type") != "generate":

--- a/backend/archimedes/api/risk_routes.py
+++ b/backend/archimedes/api/risk_routes.py
@@ -148,10 +148,14 @@ async def get_portfolio_risk():
         corr = bt.correlation_to_spy if bt else None
 
         # Derive annualized volatility: σ ≈ |CAGR| / Sharpe
-        # (rough approximation from Sharpe = (r - rf) / σ, assuming rf ≈ 0)
+        # (rough approximation from Sharpe = (r - rf) / σ, assuming rf ≈ 0).
+        # Floor the Sharpe denominator: a sub-normal-but-positive value (e.g.
+        # 1e-300) passes `> 0` yet yields a non-finite ratio that serializes to
+        # `null` and breaks the UI. Drop any non-finite result.
         volatility = None
-        if sharpe and sharpe > 0 and cagr is not None:
-            volatility = abs(cagr) / sharpe
+        if sharpe is not None and cagr is not None and sharpe > 1e-4:
+            raw_vol = abs(cagr) / sharpe
+            volatility = raw_vol if math.isfinite(raw_vol) else None
 
         if sharpe is not None:
             sharpe_vals.append(sharpe)
@@ -364,8 +368,10 @@ async def get_portfolio_greeks():
         cagr = bt.cagr if bt else None
 
         implied_vol = _FALLBACK_VOL
-        if sharpe is not None and sharpe > 0 and cagr is not None:
-            implied_vol = abs(cagr) / sharpe
+        if sharpe is not None and cagr is not None and sharpe > 1e-4:
+            raw_vol = abs(cagr) / sharpe
+            if math.isfinite(raw_vol) and raw_vol > 0:
+                implied_vol = raw_vol
 
         g = _bs_atm_greeks(implied_vol, _TAU, _R, _Q)
         strategy_greeks.append(

--- a/backend/archimedes/services/email_crypto.py
+++ b/backend/archimedes/services/email_crypto.py
@@ -1,36 +1,50 @@
 """Email encryption at rest using Fernet (symmetric encryption).
 
 Uses a key derived from the ``EMAIL_ENCRYPTION_KEY`` env var. If the env var
-is not set, a deterministic key is generated from a fixed secret — this is
-acceptable for the hackathon MVP (no real user data in production).
+is not set, a *random per-process* key is generated at startup — emails
+encrypted in one dev session cannot be decrypted in another. This is
+intentional: dev data is disposable, and it means there is no fixed fallback
+secret that could decrypt a deployment that merely forgot to set the env var.
 
 The Fernet key must be a URL-safe base64-encoded 32-byte value.
-```
 
 Security model:
   - Email is encrypted before storage and decrypted on read.
   - The DB column stores the Fernet token as a string.
   - If the key is rotated, existing tokens become unreadable — a migration
-    script would need to re-encrypt. For v1, the key is fixed.
+    script would need to re-encrypt. For v1, the key is fixed (per deployment).
+  - Production startup rejects a missing EMAIL_ENCRYPTION_KEY (fail-closed in
+    main.py when PUBLIC_DOMAIN is set), so the random fallback only ever runs
+    in local dev / CI where no real user data is at risk.
 """
 
 from __future__ import annotations
 
 import base64
 import hashlib
+import logging
 import os
 
 from cryptography.fernet import Fernet
 
-# Local-dev fallback — production startup rejects missing EMAIL_ENCRYPTION_KEY
-# (fail-closed in main.py when PUBLIC_DOMAIN is set). This fallback only runs
-# in local dev / CI where no real user data is at risk.
-_LOCAL_DEV_FALLBACK = "archimedes-local-dev-only-not-for-production"
+logger = logging.getLogger(__name__)
 
 
 def _derive_key() -> bytes:
-    """Derive a Fernet key from env var or local-dev fallback."""
-    secret = os.getenv("EMAIL_ENCRYPTION_KEY", _LOCAL_DEV_FALLBACK)
+    """Derive a Fernet key from env var, or a random per-process key in dev.
+
+    With ``EMAIL_ENCRYPTION_KEY`` set the key is deterministic (so tokens
+    survive restarts). Unset, we generate a fresh random key — there is no
+    fixed, publicly-known fallback secret.
+    """
+    secret = os.getenv("EMAIL_ENCRYPTION_KEY", "").strip()
+    if not secret:
+        logger.warning(
+            "EMAIL_ENCRYPTION_KEY is not set — using a random per-process key. "
+            "Encrypted emails will NOT survive a process restart. Set "
+            "EMAIL_ENCRYPTION_KEY for any persistent deployment."
+        )
+        return Fernet.generate_key()
     # Fernet requires a URL-safe base64-encoded 32-byte key
     digest = hashlib.sha256(secret.encode("utf-8")).digest()
     return base64.urlsafe_b64encode(digest)

--- a/backend/tests/services/test_email_crypto.py
+++ b/backend/tests/services/test_email_crypto.py
@@ -19,15 +19,21 @@ def _reset_fernet_singleton():
     email_crypto._fernet = None
 
 
-def test_derive_key_returns_url_safe_base64() -> None:
+def test_derive_key_returns_url_safe_base64(monkeypatch) -> None:
     key = _derive_key()
     # Fernet keys are 44 bytes when base64-encoded
     assert isinstance(key, bytes)
     assert len(key) == 44
 
-    # Deterministic when the env is identical
-    key2 = _derive_key()
-    assert key == key2
+    # Deterministic when EMAIL_ENCRYPTION_KEY is set
+    monkeypatch.setenv("EMAIL_ENCRYPTION_KEY", "stable-secret")
+    assert _derive_key() == _derive_key()
+
+
+def test_derive_key_random_when_env_unset(monkeypatch) -> None:
+    # No fixed fallback secret: each derivation is a fresh random key.
+    monkeypatch.delenv("EMAIL_ENCRYPTION_KEY", raising=False)
+    assert _derive_key() != _derive_key()
 
 
 def test_encrypt_decrypt_roundtrip() -> None:


### PR DESCRIPTION
## Summary
Audit (findings.md, 2026-06-13) remediation — three backend hardening fixes, each verified against current code.

- **email_crypto**: replace the public fixed-string Fernet fallback (`archimedes-local-dev-only-not-for-production`) with a random per-process key when `EMAIL_ENCRYPTION_KEY` is unset. No fixed, repo-readable secret can decrypt a deployment that forgot the env var. Production still fails closed via main.py.
- **risk_routes**: floor the Sharpe denominator (`> 1e-4`) and drop non-finite results so a sub-normal-positive Sharpe can't emit `Inf` that serializes to `null` and breaks the UI (summary + Greeks paths).
- **generate_routes**: validate `list_jobs` limit at the boundary with `Query(ge=1, le=100)`.

## Verify
- `pytest backend/tests/services/test_email_crypto.py backend/tests/test_risk_routes.py` → pass
- ruff format + `--select E9,F63,F7,F40` → pass

## Anti-goals
No DB/session changes; no behavioural change in production (EMAIL_ENCRYPTION_KEY is set there).