### PR TITLE
[backtest] Fix BuyAndHold sizing bias, warn on PBO truncation, robust ingest

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/data.py
+++ b/analytics-engine/src/archimedes_analytics_engine/data.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import logging
+import time
+
 import pandas as pd
 import yfinance as yf
 
+logger = logging.getLogger(__name__)
+
 REQUIRED_COLUMNS = ["Open", "High", "Low", "Close", "Volume"]
+_MAX_RETRIES = 3
+_RETRY_DELAY_S = 2.0
 
 
 def normalize_ohlcv(data: pd.DataFrame, *, symbol: str) -> pd.DataFrame:
@@ -19,12 +26,50 @@ def normalize_ohlcv(data: pd.DataFrame, *, symbol: str) -> pd.DataFrame:
     if missing:
         raise ValueError(f"Missing required columns for {symbol}: {missing}")
 
-    return out[REQUIRED_COLUMNS].dropna()
+    before = len(out)
+    out = out[REQUIRED_COLUMNS].dropna()
+    dropped = before - len(out)
+    if dropped > 0:
+        # A partial/garbled yfinance response can drop many bars here and
+        # silently shorten the series, misaligning cross-strategy PBO splits.
+        logger.warning("normalize_ohlcv(%s): dropped %d row(s) with NaN values", symbol, dropped)
+
+    # yfinance occasionally returns duplicate or out-of-order timestamps (seen
+    # on some corporate-action dates); a non-monotonic index makes backtrader's
+    # PandasData feed advance incorrectly and introduces look-ahead bias.
+    if not out.index.is_monotonic_increasing:
+        dupes = int(out.index.duplicated().sum())
+        if dupes > 0:
+            logger.warning("normalize_ohlcv(%s): %d duplicate timestamp(s) — keeping last", symbol, dupes)
+            out = out[~out.index.duplicated(keep="last")]
+        out = out.sort_index()
+
+    return out
 
 
 def fetch_ohlcv(symbol: str, start: str, end: str) -> pd.DataFrame:
-    data = yf.download(symbol, start=start, end=end, auto_adjust=False, progress=False)
-    if data.empty:
-        raise ValueError(f"No data returned for symbol={symbol} in range {start}..{end}")
+    last_exc: Exception | None = None
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            data = yf.download(symbol, start=start, end=end, auto_adjust=False, progress=False)
+        except Exception as exc:  # transient network/yfinance error — retry with backoff
+            last_exc = exc
+            if attempt == _MAX_RETRIES:
+                break
+            logger.warning("fetch_ohlcv(%s) attempt %d failed: %s — retrying", symbol, attempt, exc)
+            time.sleep(_RETRY_DELAY_S * attempt)
+            continue
 
-    return normalize_ohlcv(data, symbol=symbol)
+        if data.empty:
+            if attempt == _MAX_RETRIES:
+                raise ValueError(f"No data returned for symbol={symbol} in range {start}..{end}")
+            logger.warning("fetch_ohlcv(%s) returned empty — retrying (attempt %d)", symbol, attempt)
+            time.sleep(_RETRY_DELAY_S * attempt)
+            continue
+
+        result = normalize_ohlcv(data, symbol=symbol)
+        if len(result) == 0:
+            raise ValueError(f"All rows dropped after normalization for {symbol} — check date range")
+        return result
+
+    raise RuntimeError(f"yfinance download failed for {symbol} after {_MAX_RETRIES} attempts") from last_exc

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -108,9 +108,13 @@ class BuyAndHoldStrategy(bt.Strategy):
 
     def next(self) -> None:
         if not self.position:
-            size = int(self.broker.getcash() / self.data.close[0])
-            if size > 0:
-                self.buy(size=size)
+            if self.data.close[0] <= 0:
+                return
+            # Target ~100% of equity rather than int(cash / price): the latter
+            # floors share count and strands up to (price - ε) of capital per
+            # trade, biasing this passive benchmark's return downward (and so
+            # flattering every active strategy measured against it).
+            self.order_target_percent(data=self.data, target=1.0)
 
 
 def _safe_get(d: Any, *keys: str, default: Any = None) -> Any:

--- a/analytics-engine/src/archimedes_analytics_engine/pbo.py
+++ b/analytics-engine/src/archimedes_analytics_engine/pbo.py
@@ -18,6 +18,7 @@ identically.
 from __future__ import annotations
 
 import math
+import warnings
 from itertools import combinations
 
 import numpy as np
@@ -58,7 +59,21 @@ def compute_pbo(returns_matrix: dict[str, list[float]], s_partitions: int = 16) 
 
     sorted_ids = sorted(returns_matrix.keys())
     N = len(sorted_ids)
-    T = min(len(v) for v in returns_matrix.values())
+    lengths = {sid: len(returns_matrix[sid]) for sid in sorted_ids}
+    T = min(lengths.values())
+    T_max = max(lengths.values())
+    if T_max != T:
+        # Truncating to the shortest series silently drops the most recent
+        # (most forward-looking) OOS bars from longer series — exactly the bars
+        # that matter most for detecting overfitting. Surface it so the caller
+        # date-aligns rather than getting an optimistic PBO from misaligned data.
+        discarded = {sid: lengths[sid] - T for sid in sorted_ids if lengths[sid] > T}
+        warnings.warn(
+            f"compute_pbo: series length mismatch (min={T}, max={T_max}); "
+            f"trailing bars discarded per id: {discarded}. Pass date-aligned "
+            f"series to suppress this warning.",
+            stacklevel=2,
+        )
     R = np.array([returns_matrix[sid][:T] for sid in sorted_ids], dtype=float).T  # (T, N)
 
     S = s_partitions if (s_partitions % 2 == 0 and s_partitions >= 2) else 16

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import ast
 import logging
 import math
+import warnings
 from itertools import combinations
 from typing import Any
 
@@ -227,7 +228,21 @@ def compute_pbo(
     sorted_ids = sorted(returns_matrix.keys())
     N = len(sorted_ids)
 
-    T = min(len(v) for v in returns_matrix.values())
+    lengths = {sid: len(returns_matrix[sid]) for sid in sorted_ids}
+    T = min(lengths.values())
+    T_max = max(lengths.values())
+    if T_max != T:
+        # Mirror of analytics-engine pbo.py: truncating to the shortest series
+        # silently drops the most recent (most forward-looking) OOS bars from
+        # longer series. Surface it so the caller date-aligns rather than
+        # getting an optimistic PBO from misaligned data.
+        discarded = {sid: lengths[sid] - T for sid in sorted_ids if lengths[sid] > T}
+        warnings.warn(
+            f"compute_pbo: series length mismatch (min={T}, max={T_max}); "
+            f"trailing bars discarded per id: {discarded}. Pass date-aligned "
+            f"series to suppress this warning.",
+            stacklevel=2,
+        )
 
     # Build (T, N) matrix, columns in sorted_ids order
     R = np.array([returns_matrix[sid][:T] for sid in sorted_ids], dtype=float).T  # shape (T, N)


### PR DESCRIPTION
## Summary
Audit (findings.md, 2026-06-13) remediation — backtest correctness + robustness.

- **engine**: BuyAndHold now targets ~100% equity via `order_target_percent` instead of `int(cash/price)`, which floored share count and stranded up to (price − ε) of capital per trade — a **systematic downward bias in the passive benchmark** that flattered every active strategy measured against it.
- **pbo + rigor_evaluator**: `warnings.warn` when series-length mismatch silently truncates trailing (most forward-looking) OOS bars. Both implementations changed in lockstep (the parity test asserts equal outputs and stays green).
- **data**: retry yfinance with backoff, log dropped-NaN counts, dedupe/sort a non-monotonic index (look-ahead guard).

## Verify
- `cd analytics-engine && uv run pytest` → 170 passed
- `pytest backend/tests/test_pbo_parity.py backend/tests/test_rigor_evaluator.py` → pass

## Anti-goals
No change to the PBO algorithm or its numeric output (warning only); equity-curve math left in sequential form (sub-µ$ error, not material).