### PR TITLE
[frontend] Read SIWE chain ID from env, not a hardcoded literal

### DIFF
--- a/ui/src/siwe.js
+++ b/ui/src/siwe.js
@@ -10,6 +10,9 @@
  */
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+// Must match the backend's ARC_CHAIN_ID (auth_siwe.py `_EXPECTED_CHAIN_ID`).
+// Configurable so a chain change is a single env flip, not a silent auth break.
+const CHAIN_ID = import.meta.env.VITE_ARC_CHAIN_ID ?? '5042002'
 
 /**
  * Perform SIWE authentication: request nonce, sign message, verify.
@@ -33,7 +36,7 @@ export async function authenticateWithSIWE(walletClient, address) {
     '',
     `URI: https://${domain}`,
     `Version: 1`,
-    `Chain ID: 5042002`,
+    `Chain ID: ${CHAIN_ID}`,
     `Nonce: ${nonce}`,
     `Issued At: ${new Date(issued_at * 1000).toISOString()}`,
   ].join('\n')


### PR DESCRIPTION
## Summary
Audit (findings.md, 2026-06-13) remediation. The SIWE message hardcoded `Chain ID: 5042002` while the backend reads `ARC_CHAIN_ID`; a chain change updating only the backend would silently break auth with a generic error. Now sourced from `VITE_ARC_CHAIN_ID` (default 5042002), so it's a single env flip.

## Verify
- `node --check ui/src/siwe.js` → ok

## Anti-goals
No change to the signing/verification flow or the `checkSession` fail-closed behaviour.