### PR TITLE
[contracts] Add first-depositor dead-share lock + k-invariant to AMMPool

### DIFF
--- a/contracts/src/AMMPool.sol
+++ b/contracts/src/AMMPool.sol
@@ -27,6 +27,17 @@ contract AMMPool is IAMMPool, ERC20, Ownable, ReentrancyGuard {
 
     uint256 private _totalSupply;
 
+    /// @notice First-depositor LP-inflation guard (same Option-B mitigation as
+    ///         Vault.sol). On the first deposit MIN_LIQUIDITY LP tokens are
+    ///         minted to an unrecoverable sink, so an attacker can no longer own
+    ///         ~100% of a dust LP supply and donate tokens to inflate NAV per
+    ///         share and round later mints to zero. Cost: the first LP forfeits
+    ///         MIN_LIQUIDITY LP-wei — negligible.
+    uint256 public constant MIN_LIQUIDITY = 1e3;
+
+    /// @notice Sink for the locked dead shares (OZ ERC20 forbids minting to address(0)).
+    address public constant DEAD_SHARES_SINK = address(0xdEaD);
+
     // ─── Errors ──────────────────────────────────────────────────────
 
     error SameToken();
@@ -80,6 +91,8 @@ contract AMMPool is IAMMPool, ERC20, Ownable, ReentrancyGuard {
         if (amountOut == 0) revert InsufficientOutput();
         if (amountOut >= rOut) revert InsufficientLiquidity();
 
+        uint256 kBefore = rIn * rOut;
+
         // Update reserves
         if (isToken0) {
             reserve0 += amountIn;
@@ -88,6 +101,10 @@ contract AMMPool is IAMMPool, ERC20, Ownable, ReentrancyGuard {
             reserve1 += amountIn;
             reserve0 -= amountOut;
         }
+
+        // Constant-product invariant: fees mean k must never shrink across a
+        // swap. Guards against any future fee-math change silently leaking value.
+        if (reserve0 * reserve1 < kBefore) revert InsufficientOutput();
 
         // Transfer tokens
         address tokenOut = isToken0 ? token1 : token0;
@@ -110,8 +127,12 @@ contract AMMPool is IAMMPool, ERC20, Ownable, ReentrancyGuard {
         uint256 _total = totalSupply();
 
         if (_total == 0) {
-            // First deposit: geometric mean
-            lpTokens = _sqrt(amount0 * amount1);
+            // First deposit: geometric mean, minus a permanently-locked
+            // MIN_LIQUIDITY minted to the dead sink (inflation-attack guard).
+            uint256 minted = _sqrt(amount0 * amount1);
+            if (minted <= MIN_LIQUIDITY) revert InsufficientLiquidity();
+            _mint(DEAD_SHARES_SINK, MIN_LIQUIDITY);
+            lpTokens = minted - MIN_LIQUIDITY;
         } else {
             // Subsequent deposits: min of the two ratios
             uint256 lp0 = (amount0 * _total) / reserve0;

--- a/contracts/test/AMM.t.sol
+++ b/contracts/test/AMM.t.sol
@@ -138,8 +138,41 @@ contract AMMTest is Test {
 
         // Bob should get roughly the same LP tokens as Alice
         assertGt(lp2, 0);
-        // They should be approximately equal (same deposit amounts)
-        assertApproxEqAbs(lp1, lp2, 100);
+        // Equal deposits → equal LP, except the first depositor (Alice) forfeited
+        // MIN_LIQUIDITY to the dead-share inflation guard.
+        assertApproxEqAbs(lp1 + AMMPool(pool).MIN_LIQUIDITY(), lp2, 100);
+    }
+
+    function test_addLiquidity_first_deposit_locks_dead_shares() public {
+        address pool = router.createPool(address(tokenA), address(tokenB));
+        uint256 amountA = 10_000 * 1e18;
+        uint256 amountB = 20_000 * 1e18;
+
+        vm.startPrank(alice);
+        tokenA.approve(address(router), amountA);
+        tokenB.approve(address(router), amountB);
+        uint256 lpTokens = router.addLiquidity(address(tokenA), address(tokenB), amountA, amountB, 0);
+        vm.stopPrank();
+
+        uint256 minLiq = AMMPool(pool).MIN_LIQUIDITY();
+        // MIN_LIQUIDITY is permanently locked in the dead sink and excluded
+        // from the depositor's balance — the canonical Uniswap-V2 guard.
+        assertEq(IERC20(pool).balanceOf(AMMPool(pool).DEAD_SHARES_SINK()), minLiq);
+        assertEq(IERC20(pool).balanceOf(alice), lpTokens);
+        assertEq(AMMPool(pool).totalSupply(), lpTokens + minLiq);
+    }
+
+    function test_revert_addLiquidity_first_deposit_below_min_liquidity() public {
+        router.createPool(address(tokenA), address(tokenB));
+
+        // sqrt(1 * 1) = 1 <= MIN_LIQUIDITY → first deposit must revert rather
+        // than mint a dust LP supply an attacker could inflate.
+        vm.startPrank(alice);
+        tokenA.approve(address(router), 1);
+        tokenB.approve(address(router), 1);
+        vm.expectRevert();
+        router.addLiquidity(address(tokenA), address(tokenB), 1, 1, 0);
+        vm.stopPrank();
     }
 
     function test_revert_addLiquidity_zero() public {


### PR DESCRIPTION
## Summary
Audit (findings.md, 2026-06-13) remediation. `AMMPool.addLiquidity` minted `sqrt(a0*a1)` LP to the first depositor with **no minimum-liquidity lock** — the canonical Uniswap-V2 inflation attack (own ~100% of a dust LP supply, donate tokens to inflate NAV-per-share, round later mints to zero). `Vault.sol` already mitigates this (Option-B dead shares, #507); this brings `AMMPool` in line.

- Lock `MIN_LIQUIDITY` (1e3) LP to `0xdEaD` on first deposit; revert if `sqrt(a0*a1) <= MIN_LIQUIDITY`.
- Assert the constant-product `k` never shrinks across a swap (defence against future fee-math regressions).
- Tests: dead-shares locked + below-min revert; updated the second-deposit assertion for the MIN_LIQUIDITY offset.

## Verify
- `cd contracts && forge test --match-contract AMM` → 24 passed (incl. 2 new)

## Anti-goals / review notes
- Swap CEI ordering left as-is (`nonReentrant` + full revert-on-failure already make it safe); fee-overflow is Solidity-0.8 auto-revert (non-issue).
- ⚠️ **AMMPool is already deployed on Arc testnet — this source fix takes effect only on redeploy**, which is a separate, contract-review-gated action (cf. open PR #505). Merging this updates source + tests only; it does not touch the live contract or auto-redeploy it.