### PR TITLE
[contracts] Emit events on Vault admin setters

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -110,6 +110,8 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     // ─── Events (Vault-local) ────────────────────────────────────────
 
     event MaxSlippageBpsSet(uint256 oldBps, uint256 newBps);
+    event AgentSet(address indexed oldAgent, address indexed newAgent);
+    event PlatformFeeRecipientSet(address indexed oldRecipient, address indexed newRecipient);
 
     // ─── Constructor ─────────────────────────────────────────────────
 
@@ -423,10 +425,12 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     // ─── Admin ───────────────────────────────────────────────────────
 
     function setAgent(address _agent) external onlyOwner {
+        emit AgentSet(agent, _agent);
         agent = _agent;
     }
 
     function setPlatformFeeRecipient(address _recipient) external onlyOwner {
+        emit PlatformFeeRecipientSet(platformFeeRecipient, _recipient);
         platformFeeRecipient = _recipient;
     }
 

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -494,6 +494,23 @@ contract VaultTest is Test {
         vault.setMaxSlippageBps(50);
     }
 
+    function test_setAgent_emits_event() public {
+        // `agent` state starts unset (address(0)); creator (agent addr) is the owner.
+        vm.expectEmit(true, true, false, false, address(vault));
+        emit Vault.AgentSet(address(0), bob);
+        vm.prank(agent);
+        vault.setAgent(bob);
+        assertEq(vault.agent(), bob);
+    }
+
+    function test_setPlatformFeeRecipient_emits_event() public {
+        vm.expectEmit(true, true, false, false, address(vault));
+        emit Vault.PlatformFeeRecipientSet(platformRecipient, bob);
+        vm.prank(agent);
+        vault.setPlatformFeeRecipient(bob);
+        assertEq(vault.platformFeeRecipient(), bob);
+    }
+
     /// @dev Decimal scaling, buy direction: USDC(6) in -> synth(18) out.
     ///      10,000 USDC at 2 USDC/sTSLA → fair output 5,000e18; the floor at
     ///      1% tolerance is 4,950e18. The aligned pool fills at ~4,983e18


### PR DESCRIPTION
## Summary
`setAgent` (grants rebalance/manager authority) and `setPlatformFeeRecipient` (redirects the platform fee share) changed critical state silently — neither emitted an event, leaving off-chain monitoring and agent-rotation auditing blind. Every other Vault setter emits. (Audit 2026-06-13 LOW; observability.)

## Change
- Declare `AgentSet(address indexed old, address indexed new)` and `PlatformFeeRecipientSet(...)`.
- Emit old+new before assignment, matching the existing `MaxSlippageBpsSet` pattern.
- Two `vm.expectEmit` regression tests.

## Verify
```
cd contracts && forge test   # 151 passed, 0 failed
```

## Notes
Source-only; takes effect on the next Vault redeploy (same redeploy that ships the #505 allowance fix).