### PR TITLE
[security] Gate paid LLM-generation endpoints behind opt-in SIWE session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,15 @@ EMAIL_ENCRYPTION_KEY=
 # If unset, all guarded endpoints return 403 (fail-closed).
 INTERNAL_AGENT_API_KEY=
 
+# Gate the expensive LLM-generation endpoints (/api/generate/start,
+# /api/strategies/generate, /api/strategies/construct) behind a SIWE session.
+# Default OFF — anonymous callers pass through (today's open behavior) so a
+# verbatim `cp .env.example .env` never silently breaks the live Generate flow.
+# Flip to true ONCE the UI SIWE round-trip is confirmed end-to-end; then these
+# paid Claude/GLM endpoints return 401 without a verified-wallet session,
+# closing the IP-rotation budget-drain vector (audit 2026-06-13).
+REQUIRE_SIWE_FOR_GENERATION=false
+
 # How often the oracle runner pushes prices (seconds, default 60).
 ORACLE_INTERVAL_SECONDS=60
 

--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -104,6 +104,31 @@ def require_verified_wallet(request: Request) -> str:
     return wallet
 
 
+def _generation_auth_required() -> bool:
+    """Whether expensive LLM-generation endpoints require a SIWE session.
+
+    Off by default so enabling is an explicit, post-verification flip — gating
+    paid endpoints can never *silently* break the live Generate flow on deploy.
+    Set REQUIRE_SIWE_FOR_GENERATION=true once the UI SIWE round-trip is confirmed
+    working end-to-end (a session cookie is established before Generate is called).
+    """
+    return os.getenv("REQUIRE_SIWE_FOR_GENERATION", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def gate_generation(request: Request) -> str | None:
+    """FastAPI dependency for paid LLM-generation endpoints.
+
+    When REQUIRE_SIWE_FOR_GENERATION is enabled, behaves like
+    ``require_verified_wallet`` (401 without a session). When disabled (default),
+    returns the best-effort wallet for attribution without enforcing — preserving
+    today's open behavior. This mitigates the unauthenticated-LLM budget-drain
+    vector (audit 2026-06-13) without a flag-day risk to the live demo.
+    """
+    if _generation_auth_required():
+        return require_verified_wallet(request)
+    return get_verified_wallet(request)
+
+
 # ── Endpoints ─────────────────────────────────────────────────
 
 

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -19,10 +19,11 @@ import json
 import logging
 from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 
 from archimedes.agents.generation_pipeline import run_generation
+from archimedes.api.auth_siwe import gate_generation
 from archimedes.api.generate_schemas import (
     CandidatesListResponse,
     CandidateSummary,
@@ -56,7 +57,12 @@ def _register_task(job_id: str, task: asyncio.Task) -> None:
 
 @generate_router.post("/start", response_model=GenerateStartResponse, status_code=202)
 @limiter.limit("5/minute")
-async def start_generation(req: GenerateStartRequest, request: Request, response: Response) -> GenerateStartResponse:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def start_generation(
+    req: GenerateStartRequest,
+    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    response: Response,  # noqa: ARG001
+    _wallet: str | None = Depends(gate_generation),  # 401 when REQUIRE_SIWE_FOR_GENERATION is on
+) -> GenerateStartResponse:
     """Create a generation job and start the pipeline in the background."""
     store = get_job_store()
     job_id = await store.enqueue(

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -12,7 +12,7 @@ import json
 import math
 from datetime import UTC
 
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from archimedes.api._route_helpers import (
     architect,
@@ -25,6 +25,7 @@ from archimedes.api.architect_schemas import (
     StrategyConstructionRequest,
     StrategyConstructionResponse,
 )
+from archimedes.api.auth_siwe import gate_generation
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import (
     SignalResponse,
@@ -1174,6 +1175,7 @@ async def generate_strategy(
     strategic_direction: str = "",
     max_papers: int = 4,
     mode: str = "fusion",
+    _wallet: str | None = Depends(gate_generation),  # 401 when REQUIRE_SIWE_FOR_GENERATION is on
 ):
     """Queue a strategy generation job. Returns 202 + job_id immediately."""
     from fastapi import HTTPException
@@ -1531,7 +1533,12 @@ async def _run_fusion_job(job_id: str) -> None:
 
 @strategies_router.post("/construct", response_model=StrategyConstructionResponse)
 @limiter.limit("20/minute")
-async def construct_strategy(req: StrategyConstructionRequest, request: Request, response: Response):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def construct_strategy(
+    req: StrategyConstructionRequest,
+    request: Request,
+    response: Response,
+    _wallet: str | None = Depends(gate_generation),
+):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Interactive strategy architect -- the 'design me a portfolio' path."""
     from fastapi import HTTPException
 

--- a/backend/tests/test_generation_gating.py
+++ b/backend/tests/test_generation_gating.py
@@ -1,0 +1,71 @@
+"""Tests for the SIWE gate on expensive LLM-generation endpoints.
+
+The gate (``gate_generation``) is controlled by REQUIRE_SIWE_FOR_GENERATION and
+defaults OFF so enabling it is an explicit, post-verification flip — it can never
+silently break the live Generate flow on deploy. These tests exercise the
+dependency in isolation against a minimal app (no Redis / job store needed),
+minting a session cookie with the same in-process HMAC key the verifier uses.
+"""
+
+import time
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session, gate_generation
+
+
+def _make_client() -> TestClient:
+    app = FastAPI()
+
+    @app.post("/g")
+    async def _g(wallet: str | None = Depends(gate_generation)):
+        return {"wallet": wallet}
+
+    return TestClient(app)
+
+
+def test_gate_off_allows_anonymous(monkeypatch):
+    """Default (flag unset): anonymous callers pass through, wallet is None."""
+    monkeypatch.delenv("REQUIRE_SIWE_FOR_GENERATION", raising=False)
+    resp = _make_client().post("/g")
+    assert resp.status_code == 200
+    assert resp.json()["wallet"] is None
+
+
+def test_gate_off_attributes_session_when_present(monkeypatch):
+    """Flag off but a valid session present: best-effort attribution, still 200."""
+    monkeypatch.delenv("REQUIRE_SIWE_FOR_GENERATION", raising=False)
+    wallet = "0x" + "ab" * 20
+    client = _make_client()
+    client.cookies.set(_COOKIE_NAME, _sign_session(wallet, time.time()))
+    resp = client.post("/g")
+    assert resp.status_code == 200
+    assert resp.json()["wallet"] == wallet.lower()
+
+
+def test_gate_on_blocks_anonymous(monkeypatch):
+    """Flag on: anonymous callers are rejected with 401."""
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "true")
+    resp = _make_client().post("/g")
+    assert resp.status_code == 401
+
+
+def test_gate_on_allows_valid_session(monkeypatch):
+    """Flag on: a valid SIWE session cookie is accepted and returns the wallet."""
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "1")
+    wallet = "0x" + "cd" * 20
+    client = _make_client()
+    client.cookies.set(_COOKIE_NAME, _sign_session(wallet, time.time()))
+    resp = client.post("/g")
+    assert resp.status_code == 200
+    assert resp.json()["wallet"] == wallet.lower()
+
+
+def test_gate_on_rejects_tampered_session(monkeypatch):
+    """Flag on: a cookie with a bad signature is rejected (401)."""
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "yes")
+    client = _make_client()
+    client.cookies.set(_COOKIE_NAME, '{"wallet":"0xdeadbeef","iat":9999999999}|deadbeef')
+    resp = client.post("/g")
+    assert resp.status_code == 401

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -15,7 +15,9 @@ const API_BASE = import.meta.env.VITE_API_BASE ?? ''
  * @returns {Promise<any>} parsed JSON
  */
 export async function apiGet(path) {
-  const res = await fetch(`${API_BASE}${path}`)
+  // credentials:'include' sends the SIWE session cookie so authenticated
+  // endpoints work whether or not the API is same-origin.
+  const res = await fetch(`${API_BASE}${path}`, { credentials: 'include' })
   if (!res.ok) {
     throw new Error(`Backend returned ${res.status}`)
   }
@@ -32,6 +34,7 @@ export async function apiPost(path, body) {
   const res = await fetch(`${API_BASE}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    credentials: 'include', // send SIWE session cookie
     body: JSON.stringify(body),
   })
   if (!res.ok) {

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -75,6 +75,18 @@ export default function Generate({ onNavigate }) {
   }, [])
 
   // ── Start unified generation job ──
+  // Establish a SIWE session on demand. Generation is gated server-side only
+  // when REQUIRE_SIWE_FOR_GENERATION is enabled; until then this is invoked
+  // lazily on a 401 so the flow keeps working the moment the flag flips.
+  const ensureSiweSession = async () => {
+    const { getWalletClient, getAddress } = await import('../config')
+    const { authenticateWithSIWE } = await import('../siwe')
+    const address = getAddress()
+    if (!address) throw new Error('Connect your wallet, then sign in to generate.')
+    const walletClient = await getWalletClient()
+    await authenticateWithSIWE(walletClient, address)
+  }
+
   const startJob = async () => {
     setStartError('')
     setPipelineFromEvent(null)
@@ -83,25 +95,34 @@ export default function Generate({ onNavigate }) {
       return
     }
     setStarting(true)
-    try {
-      const res = await fetch(`${API_BASE}/api/generate/start`, {
+    // Mode is intentionally omitted — the backend's _pick_pipeline() auto-routes
+    // between Fusion / Architect / Agent; the choice is surfaced in the SSE stream.
+    const payload = {
+      brief: {
+        intent,
+        risk_appetite: riskAppetite,
+        asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
+        max_papers: depth,
+      },
+    }
+    const postStart = () =>
+      fetch(`${API_BASE}/api/generate/start`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          brief: {
-            intent,
-            risk_appetite: riskAppetite,
-            asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
-            max_papers: depth,
-          },
-          // Mode is intentionally omitted — the backend's _pick_pipeline()
-          // auto-routes between Fusion / Architect / Agent based on corpus
-          // state and LLM availability. The selected route is surfaced in
-          // the SSE stream's "Pipeline selected" event so the user can see
-          // it transparently without us forcing a tab choice.
-        }),
+        credentials: 'include', // send SIWE session cookie
+        body: JSON.stringify(payload),
       })
-      if (!res.ok) throw new Error(`Generation start failed (${res.status})`)
+    try {
+      let res = await postStart()
+      // If generation is auth-gated and we have no session yet, sign in and retry once.
+      if (res.status === 401) {
+        await ensureSiweSession()
+        res = await postStart()
+      }
+      if (!res.ok) {
+        if (res.status === 401) throw new Error('Sign in with your wallet to generate.')
+        throw new Error(`Generation start failed (${res.status})`)
+      }
       const data = await res.json()
       localStorage.setItem(STORAGE_JOB_KEY, data.job_id)
       setJobId(data.job_id)


### PR DESCRIPTION
## Summary

The expensive LLM-generation endpoints — `/api/generate/start`,
`/api/strategies/generate`, `/api/strategies/construct` — trigger paid
Claude/GLM calls behind **only an IP rate limit**. That's an IP-rotation
budget-drain DoS vector flagged in the 2026-06-13 full-repo audit (HIGH #3).
It's the same auth class the team already enforces on the vault and metadata
routes; it was simply never extended to generation.

## What this does

Adds a `gate_generation` FastAPI dependency in `auth_siwe.py`, controlled by a
new env flag `REQUIRE_SIWE_FOR_GENERATION`:

- **default OFF** — best-effort wallet attribution only; today's open behavior
  is preserved exactly, so a verbatim deploy can never silently break the live
  Generate flow (flag-day-safe);
- **ON** — behaves like `require_verified_wallet` (401 without a verified SIWE
  session), closing the budget-drain vector.

UI side: `apiGet`/`apiPost` now send the SIWE session cookie
(`credentials:'include'`), and `Generate.jsx` signs in lazily on a `401` then
retries once — so the flow keeps working the instant the flag is flipped, with
no other code change. CORS already uses an explicit origin allowlist with
`allow_credentials=True`, so credentialed fetch is safe both same-origin (live)
and cross-origin (dev).

## How to enable (post-merge, after confirming the UI SIWE round-trip e2e)

```
REQUIRE_SIWE_FOR_GENERATION=true
```

## Acceptance criteria

- [x] `pytest backend/tests/test_generation_gating.py` → 5 passed (off-anon,
      off-attributed, on-blocks-anon, on-allows-valid, on-rejects-tampered)
- [x] `pytest backend/tests/test_auth_siwe.py` → still green (34 passed combined)
- [x] generate/strategy/architect route suites → 407 passed, 0 failed
- [x] `ruff format --check` + `ruff check --select E9,F63,F7,F40` → clean
- [x] app boots with the new dependency wired (83 routes)

## Anti-goals

- Does **not** change default behavior — gate is inert until the flag is set.
- Does **not** touch the rate limiter, the SIWE verify/nonce flow, or contracts.

🤖 Reviewed and shipped via Claude Code on Önder's behalf.