### PR TITLE
[docs] Correct stale backend test-count in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,8 @@ Then <http://localhost> for the UI mockups and <http://localhost:8000/docs> for 
 backend API. See README § "Run Archimedes locally" for the full walkthrough.
 
 **Tests:** from the repo root in the `archimedes` conda env, just `pytest` —
-`pytest.ini` sets `pythonpath`/`testpaths` and a verbose default (~860 tests
-on `main` as of 2026-05-26; suite is still growing). Coverage:
+`pytest.ini` sets `pythonpath`/`testpaths` and a verbose default (~1400 backend
+`def test_` cases on `main` as of 2026-06-13; suite is still growing). Coverage:
 `pytest --cov=archimedes --cov-report=term-missing`. The
 analytics-engine runs its own suite: `cd analytics-engine && uv run pytest`. See
 README § "Running the test suite" for the honest coverage picture and the


### PR DESCRIPTION
## Summary

CLAUDE.md's Tests section claimed `~860 tests on main as of 2026-05-26`. The
suite has roughly doubled since: `grep -rc 'def test_' backend/tests` totals
**1399**. Flagged as ~2× stale in the 2026-06-13 full-repo audit (LOW). One-line
accuracy fix; no behavior change.

## Verify

```
grep -rc "def test_" backend/tests/ | awk -F: '{s+=$2} END {print s}'   # → 1399
```