### PR TITLE
[quant] Document the deliberate display-vs-gate rf-convention split

### DIFF
--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -189,6 +189,14 @@ def run_dsl_backtest(
         for i in range(1, len(equity_curve))
         if equity_curve[i - 1] > 0
     ]
+    # rf-convention (deliberate split — do NOT "reconcile" to one rate):
+    #   DISPLAY (here) = raw Sharpe/Sortino with rf=0. This is the passport
+    #   headline and matches how backtrader's analyzer / practitioners quote it.
+    #   GATE = rigor_evaluator._RF_ANNUAL = 0.05: the DSR deflates an *excess*-
+    #   return Sharpe because Bailey-LdP (2014) is defined on excess returns.
+    # The two answer different questions (headline performance vs. selection-bias-
+    # corrected significance); forcing a single rf would corrupt one of them.
+    # See rigor_evaluator.py for the gate side. (audit 2026-06-13, MEDIUM #8)
     sharpe = _annualized_sharpe(daily_returns, rf_annual=0.0)
     sortino = _annualized_sortino(daily_returns, rf_annual=0.0)
     max_dd = _max_drawdown(equity_curve)
@@ -327,6 +335,14 @@ def _run_variant_backtest(
         for i in range(1, len(equity_curve))
         if equity_curve[i - 1] > 0
     ]
+    # rf-convention (deliberate split — do NOT "reconcile" to one rate):
+    #   DISPLAY (here) = raw Sharpe/Sortino with rf=0. This is the passport
+    #   headline and matches how backtrader's analyzer / practitioners quote it.
+    #   GATE = rigor_evaluator._RF_ANNUAL = 0.05: the DSR deflates an *excess*-
+    #   return Sharpe because Bailey-LdP (2014) is defined on excess returns.
+    # The two answer different questions (headline performance vs. selection-bias-
+    # corrected significance); forcing a single rf would corrupt one of them.
+    # See rigor_evaluator.py for the gate side. (audit 2026-06-13, MEDIUM #8)
     sharpe = _annualized_sharpe(daily_returns, rf_annual=0.0)
     sortino = _annualized_sortino(daily_returns, rf_annual=0.0)
     max_dd = _max_drawdown(equity_curve)

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -36,6 +36,11 @@ logger = logging.getLogger(__name__)
 
 _EULER_MASCHERONI = 0.5772156649
 _ANNUALIZATION = 252
+# GATE-side rf convention: the DSR deflates an EXCESS-return Sharpe, because
+# Bailey-LdP (2014) is defined on excess returns. This deliberately differs from
+# the passport DISPLAY Sharpe, which uses rf=0 (raw) — see fusion_evaluator.py's
+# rf_annual=0.0 call sites. The split is intentional (gate=excess, display=raw),
+# not drift; the two metrics answer different questions. (audit 2026-06-13 #8)
 _RF_ANNUAL = 0.05  # 5% annual risk-free rate (Fed funds 2024-2025 environment)
 _RF_DAILY = _RF_ANNUAL / _ANNUALIZATION
 


### PR DESCRIPTION
## Summary

Closes audit 2026-06-13 **MEDIUM #8**. The passport **display** Sharpe
(`fusion_evaluator.py`) uses `rf=0` (raw return/vol); the Tier-1 rigor **gate**'s
DSR (`rigor_evaluator._RF_ANNUAL=0.05`) deflates an *excess*-return Sharpe because
Bailey-LdP (2014) is defined on excess returns. Both conventions are individually
correct, but the divergence was **undocumented** — a reader sees a headline Sharpe
next to a DSR deflated from a different, lower baseline, with no disclosure. That
silent drift is exactly what the "surface deltas honestly" principle forbids and
why it keeps getting re-flagged.

## What I verified first (house rule: verify the audit claim)

- The `fusion_evaluator` display sites (`:192`, `:330`) explicitly pass
  `rf_annual=0.0`; the helper's own default is `0.05` but is overridden here.
- Grepped the passport/publisher assembly: **nothing numerically compares the
  rf=0 display Sharpe against the rf=0.05 DSR as if same-convention.** So this is a
  transparency gap, not a calculation bug — the fix is documentation, not a recompute.

## Change

Cross-referencing comments at all three rf sites (both fusion display call-sites +
the rigor `_RF_ANNUAL` constant) making the split a documented, deliberate decision.
**Comments only — no behavior change.**

## Acceptance

- [x] `ruff format --check` + `ruff check --select E9,F63,F7,F40` → clean
- [x] `pytest -k "fusion or rigor or dsr or sharpe or selection_bias"` → 353 passed

## Out of scope

Surfacing the rf assumption on the passport **UI** is a product call (e.g. show both
raw + excess Sharpe, or label the rf next to each) — intentionally not done here.