### PR TITLE
[infra] Deploy pull-model: stop leaking secrets into SSM/CloudTrail history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,29 +3,26 @@
 # Authentication: OIDC federation (GitHub → AWS IAM role assumption).
 # No long-lived AWS access keys in GitHub Secrets.
 #
-# Required GitHub Secrets (Settings → Secrets → Actions):
-#   LLM_PROVIDER, LLM_AUTH_TOKEN, LLM_BASE_URL — LLM credentials
-#   EMAIL_ENCRYPTION_KEY — Fernet key for email encryption at rest
-#   VITE_CIRCLE_CLIENT_KEY — Circle Modular Wallets client key
+# Secrets: PULL-MODEL — this workflow no longer carries any application secret.
+#   App secrets (LLM_PROVIDER/LLM_AUTH_TOKEN/LLM_BASE_URL, EMAIL_ENCRYPTION_KEY,
+#   VITE_CIRCLE_CLIENT_KEY) live in AWS SSM Parameter Store under /archimedes/prod/*
+#   and are read by the EC2 instance role at runtime, never injected from CI.
+#   Population runbook: infra/iam/README.md § "SSM Parameter Store — app secrets".
 #
 # Required GitHub Variables (or hardcoded below):
 #   AWS_ROLE_ARN — arn:aws:iam::159903201072:role/archimedes-github-deploy
 #   EC2_INSTANCE_ID — i-0987f70a131ed3ab1
 #
-# ─── KNOWN SECURITY DEBT (added 2026-05-27, fix in follow-up PR) ───
+# ─── KNOWN SECURITY DEBT ───
 #
-# 1. SECRETS IN SSM COMMAND HISTORY + CLOUDTRAIL.
-#    GitHub Actions interpolates ${{ secrets.X }} into the SSM command body
-#    BEFORE the API call. The literal secret values then land in:
-#      - SSM command history (`aws ssm list-commands` shows parameters)
-#      - CloudTrail SendCommand events (cloudtrail:LookupEvents-visible)
-#      - CloudWatch Logs (if SSM logging is enabled)
-#    Anyone with read access to those AWS audit surfaces can extract the
-#    secrets. Regression vs. SSH (where secrets stayed on the runner only).
-#    Acceptable now because audit surfaces are IAM-gated to the account.
-#    Proper fix: backend reads secrets from AWS Secrets Manager / SSM
-#    Parameter Store via its EC2 IAM role at container start. Deploy
-#    script never touches secrets.
+# 1. SECRETS IN SSM COMMAND HISTORY + CLOUDTRAIL — RESOLVED 2026-06-14 (audit #5).
+#    Previously GitHub Actions interpolated ${{ secrets.X }} into the SSM command
+#    body, leaking the literal values into SSM command history + CloudTrail
+#    SendCommand events. Fixed by removing all CI secret injection: the backend
+#    now reads LLM_*/EMAIL_ENCRYPTION_KEY from SSM Parameter Store via its EC2
+#    instance role at container start (services/secrets_service.load_ssm_secrets,
+#    IAM in infra/iam/archimedes-backend-policy.json). The deploy script no longer
+#    touches secrets, so no secret value enters any AWS audit surface.
 #
 # 2. OUT-OF-BAND IAM RESOURCES NOT TERRAFORMED.
 #    `archimedes-github-deploy`, `AWSSystemsManagerDefaultEC2InstanceManagementRole`,
@@ -95,15 +92,14 @@ jobs:
               "docker container prune -f 2>/dev/null || true",
               "docker image prune -af 2>/dev/null || true",
               "df -h / | tail -1 | awk '"'"'{print \"DISK_AFTER_PRUNE: \"$0}'"'"'",
-              "sed -i '"'"'/^LLM_PROVIDER=/d; /^LLM_AUTH_TOKEN=/d; /^LLM_BASE_URL=/d'"'"' .env",
-              "echo \"LLM_PROVIDER=${{ secrets.LLM_PROVIDER }}\" >> .env",
-              "echo \"LLM_AUTH_TOKEN=${{ secrets.LLM_AUTH_TOKEN }}\" >> .env",
-              "echo \"LLM_BASE_URL=${{ secrets.LLM_BASE_URL }}\" >> .env",
-              "sed -i '"'"'/^EMAIL_ENCRYPTION_KEY=/d'"'"' .env",
-              "echo \"EMAIL_ENCRYPTION_KEY=${{ secrets.EMAIL_ENCRYPTION_KEY }}\" >> .env",
+              "# Pull-model (audit 2026-06-13 #5): secrets are NO LONGER injected from",
+              "# CI, so no secret value enters the SSM command body / CloudTrail. The",
+              "# backend reads LLM_*/EMAIL_ENCRYPTION_KEY from SSM Parameter Store at",
+              "# startup via its instance role (services/secrets_service.load_ssm_secrets);",
+              "# the box-local, gitignored .env (untouched by git reset) carries any",
+              "# values not yet in SSM, incl. the build-time VITE_CIRCLE_CLIENT_KEY. See",
+              "# infra/iam/README.md for the SSM population runbook.",
               "grep -q '"'"'^PUBLIC_DOMAIN='"'"' .env || echo '"'"'PUBLIC_DOMAIN=https://archimedes-arc.app'"'"' >> .env",
-              "sed -i '"'"'/^VITE_CIRCLE_CLIENT_KEY=/d'"'"' .env",
-              "echo \"VITE_CIRCLE_CLIENT_KEY=${{ secrets.VITE_CIRCLE_CLIENT_KEY }}\" >> .env",
               "docker compose build",
               "docker ps -aq --filter '"'"'name=^[0-9a-f]\\{12\\}_archimedes-'"'"' | xargs -r docker rm -f 2>/dev/null || true",
               "docker compose up -d --force-recreate --remove-orphans",

--- a/infra/iam/README.md
+++ b/infra/iam/README.md
@@ -84,6 +84,62 @@ If the KB pipeline runs on ECS Fargate or Lambda instead of EC2, add the relevan
 service principal (`ecs-tasks.amazonaws.com` or `lambda.amazonaws.com`) to the
 `Principal.Service` array.
 
+## SSM Parameter Store — app secrets (deploy pull-model)
+
+Since 2026-06-14 (audit #5), `deploy.yml` no longer injects any application secret —
+the deploy script never touches secret values, so nothing leaks into SSM command
+history or CloudTrail `SendCommand` events. Instead:
+
+- **Runtime secrets** (`LLM_PROVIDER`, `LLM_AUTH_TOKEN`, `LLM_BASE_URL`,
+  `EMAIL_ENCRYPTION_KEY`) are read at backend startup by
+  [`services/secrets_service.load_ssm_secrets()`](../../backend/archimedes/services/secrets_service.py)
+  via the instance role (this policy already grants `ssm:GetParametersByPath` +
+  `kms:Decrypt` on `/archimedes/prod/*`). They are loaded into `os.environ` with
+  `override_existing=False`, so a value already present in the box-local `.env`
+  wins — see the migration note below.
+- **Build-time secret** (`VITE_CIRCLE_CLIENT_KEY`, baked into the UI bundle during
+  `docker compose build`) cannot be read at backend runtime; it is sourced from the
+  box-local, gitignored `.env` (which `git reset --hard` never touches).
+
+### Populate the parameters (one-time, then on rotation)
+
+Store each as a **SecureString** so it is KMS-encrypted at rest:
+
+```bash
+for k in LLM_PROVIDER LLM_AUTH_TOKEN LLM_BASE_URL EMAIL_ENCRYPTION_KEY VITE_CIRCLE_CLIENT_KEY; do
+  read -rsp "$k: " v; echo
+  aws ssm put-parameter --region eu-west-2 --type SecureString \
+    --name "/archimedes/prod/$k" --value "$v" --overwrite
+done
+aws ssm get-parameters-by-path --region eu-west-2 \
+  --path /archimedes/prod --recursive --query 'Parameter[].Name'   # verify (names only)
+```
+
+### Migration note — making SSM authoritative
+
+The current live box already has working values in its `.env` (written by the old
+CI-injection deploys), so removing CI injection is **non-breaking**: the next deploy
+keeps using those `.env` values. To make SSM the single source of truth for the
+*runtime* secrets, after populating SSM:
+
+```bash
+# on the EC2 box, in /opt/archimedes — drop the runtime secrets from .env so
+# load_ssm_secrets() (override_existing=False) fills them from SSM at next restart.
+sed -i '/^LLM_PROVIDER=/d;/^LLM_AUTH_TOKEN=/d;/^LLM_BASE_URL=/d;/^EMAIL_ENCRYPTION_KEY=/d' .env
+docker compose up -d --force-recreate backend
+docker compose exec -T backend python -c "import os; print('LLM set:', bool(os.environ.get('LLM_AUTH_TOKEN')))"
+```
+
+Keep `VITE_CIRCLE_CLIENT_KEY` in `.env` (build-time). **Fresh-box rebuilds** require
+the parameters to exist in SSM *and* `VITE_CIRCLE_CLIENT_KEY` to be seeded into `.env`
+by `user-data.sh` before the first `docker compose build`.
+
+### Rotation
+
+Re-run the `put-parameter ... --overwrite` for the rotated key, then restart the
+backend container (`docker compose up -d --force-recreate backend`). No deploy or
+code change needed; the GitHub repo never sees the value.
+
 ## Cross-account / multi-environment notes
 
 - **Single-account model for v1.** Everything in Chuan's hackathon AWS account.


### PR DESCRIPTION
## Summary

Closes audit 2026-06-13 **MEDIUM #5**. `deploy.yml` interpolated `${{ secrets.X }}`
into the `AWS-RunShellScript` command body, so the literal values for `LLM_*`,
`EMAIL_ENCRYPTION_KEY`, and `VITE_CIRCLE_CLIENT_KEY` landed in **SSM command history**
and **CloudTrail `SendCommand` events** — extractable by anyone with read access to
those audit surfaces. The file's own header already prescribed this exact fix.

## What changed

- **Removed all CI secret injection** from `deploy.yml` (the 8 `sed`/`echo` lines).
- The backend **already** reads runtime secrets from SSM Parameter Store at startup via
  its EC2 instance role — `services/secrets_service.load_ssm_secrets()` (wired in
  `main.py:26`); the IAM policy already grants `ssm:GetParametersByPath` + `kms:Decrypt`
  on `/archimedes/prod/*`. No new code or IAM needed.
- Added an SSM population / migration / rotation **runbook** to `infra/iam/README.md`.

## Why this is non-breaking (safe by design)

`.env` is gitignored and lives on the EC2 box; `git reset --hard origin/main` never
touches it. The live box's `.env` already holds working values (written by the old
CI-injection deploys). Removing the injection means the next deploy simply **keeps
those values** — runtime secrets continue to resolve, and the build-time
`VITE_CIRCLE_CLIENT_KEY` is still present for `docker compose build`. SSM becomes the
authoritative source for runtime secrets only after you populate it and drop them from
`.env` (documented in the runbook); until then, behavior is identical to today.

## Validation done locally (deploy job can't run pre-merge)

- `deploy.yml` parses as YAML.
- The shell-resolved SSM `commands` array is valid JSON: **31 elements (−1)**, with
  **ZERO secret-bearing command lines** (was 5). `PUBLIC_DOMAIN` handling preserved verbatim.
- Confirmed both the pre- and post-edit arrays parse identically under the shell's
  single-quote resolution — the edit introduces no structural regression.

## ⚠️ Merge = live deploy — recommend you merge & watch

The deploy job only runs **after merge to main** (build-on-deploy), so PR CI does not
exercise it. I've left this **unmerged** for you to merge when you can watch the run.

**Success looks like:** the deploy job ends with `✅ Deploy succeeded` and the tail
shows the `/health` line + `DEPLOY_COMPLETE`. Then spot-check the live site can still
generate (LLM key resolved) and that wallet/Circle UI loads (VITE key baked).

**Instant rollback:** `git revert` this merge (re-adds CI injection) and let it redeploy,
or re-run the previous green deploy from the Actions tab.

## Out of scope (still open infra debt, unchanged)

deploy.yml DEBT #2 (IAM not terraformed) and #3 (verify OIDC trust locked to repo).