### PR TITLE
[quant] Fusion gate: enforce IS/OOS cliff + NaN-harden the rigor gate

### DIFF
--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -11,6 +11,7 @@ Orchestrates the full pipeline for fusion-generated strategies:
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -20,6 +21,7 @@ from archimedes.services.dsl_to_backtrader import interpret_spec, interpret_vari
 from archimedes.services.rigor_evaluator import (
     compute_average_pairwise_correlation,
     compute_dsr,
+    compute_in_sample_sharpe,
     compute_oos_sharpe,
     compute_pbo,
 )
@@ -67,6 +69,9 @@ class RigorVerdict:
     oos_sharpe: float | None
     look_ahead_clean: bool
     num_trials: int
+    # In-sample (training-slice) Sharpe, surfaced so the OOS/IS cliff that the
+    # gate enforces is visible on the passport, not just used internally.
+    in_sample_sharpe: float | None = None
     # Provenance carried through from the backtest. ``admissible`` is the
     # honest gate: a strategy can only be certified Tier-1 if it both passes
     # the statistics AND those statistics were computed on real market data.
@@ -424,6 +429,7 @@ def apply_rigor_gate(
     avg_correlation = compute_average_pairwise_correlation(variant_returns) if len(variant_returns) >= 2 else 0.0
     dsr, dsr_p = compute_dsr(daily_returns, effective_trials, avg_correlation)
     oos_sharpe = compute_oos_sharpe(daily_returns)
+    in_sample_sharpe = compute_in_sample_sharpe(daily_returns)
 
     # PBO: compute real CSCV PBO when >= 2 variant backtests are available.
     pbo_score: float | None = None
@@ -444,16 +450,29 @@ def apply_rigor_gate(
     # 0.5 (p ≈ 0.69) would pass here while the same strategy fails the API gate,
     # creating an inconsistency that could admit under-credentialed Tier-1 strategies
     # through the fusion path.
-    dsr_pass = dsr_p is not None and dsr_p >= 0.95
+    # NaN-harden every numeric comparison: a NaN metric makes `>=`/`<` False,
+    # which would silently skip a fail branch. Treat non-finite as fail.
+    dsr_pass = dsr_p is not None and math.isfinite(dsr_p) and dsr_p >= 0.95
 
     # Walk-forward OOS Sharpe is the fourth admission primitive (DSL look-ahead
-    # safety, DSR, PBO, walk-forward OOS). It was computed above but never
-    # enforced — the gate silently dropped it. Mirror the curated path's
-    # absolute floor (run_rigor_gate / RigorGateResult.passes_all): a strategy
-    # with a non-positive out-of-sample Sharpe cannot pass.
-    oos_pass = oos_sharpe is not None and oos_sharpe > 0.0
+    # safety, DSR, PBO, walk-forward OOS). Mirror the curated path's
+    # RigorGateResult.passes_all in full: an absolute floor (OOS > 0) AND the
+    # in-/out-of-sample cliff (OOS/IS >= 0.5). Before this, the fusion path
+    # enforced only the floor, so a strategy grossly overfit in-sample (e.g. IS
+    # Sharpe 5.0, OOS Sharpe +0.05) passed the fusion gate and was certified
+    # Tier-1 while the identical strategy failed the curated API gate.
+    oos_pass = oos_sharpe is not None and math.isfinite(oos_sharpe) and oos_sharpe > 0.0
+    if (
+        oos_pass
+        and in_sample_sharpe is not None
+        and math.isfinite(in_sample_sharpe)
+        and in_sample_sharpe > 0
+        and oos_sharpe / in_sample_sharpe < 0.5
+    ):
+        oos_pass = False
 
-    passing = dsr_pass and oos_pass and look_ahead_clean and (pbo_score is None or pbo_score < 0.5)
+    pbo_pass = pbo_score is None or (math.isfinite(pbo_score) and pbo_score < 0.5)
+    passing = dsr_pass and oos_pass and look_ahead_clean and pbo_pass
 
     # Provenance gate: a strategy is only admissible for Tier-1 if it passes
     # the statistics AND those statistics were computed on real market data.
@@ -473,6 +492,7 @@ def apply_rigor_gate(
         dsr_p_value=dsr_p,
         pbo_score=pbo_score,
         oos_sharpe=oos_sharpe,
+        in_sample_sharpe=in_sample_sharpe,
         look_ahead_clean=look_ahead_clean,
         num_trials=effective_trials,
         data_source=source,

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -340,6 +340,32 @@ def compute_oos_sharpe(
     return round(float(((oos.mean() - _RF_DAILY) / sigma) * math.sqrt(_ANNUALIZATION)), 6)
 
 
+def compute_in_sample_sharpe(
+    daily_returns: list[float],
+    train_fraction: float = 0.70,
+) -> float | None:
+    """Annualized Sharpe on the in-sample (training) slice.
+
+    The chronological complement of ``compute_oos_sharpe``: the first
+    ``train_fraction`` of bars. Uses the same excess-return convention
+    (rf=5%/252, sqrt(252) annualization) and the same length thresholds, so the
+    OOS/IS cliff ratio enforced in ``RigorGateResult.passes_all`` (and mirrored
+    by the fusion gate) compares like with like. Returns None when the series is
+    too short to split meaningfully (mirrors ``compute_oos_sharpe`` so the IS
+    Sharpe is available exactly when the OOS Sharpe is).
+    """
+    arr = np.asarray(daily_returns, dtype=float)
+    T = len(arr)
+    if T < 10:
+        return None
+    split = int(T * train_fraction)
+    is_arr = arr[:split]
+    if len(is_arr) < 21:  # 1 trading month minimum — mirrors compute_oos_sharpe's OOS floor
+        return None
+    s = _annualized_sharpe_arr(is_arr)
+    return round(s, 6) if s is not None else None
+
+
 def _annualized_sharpe_arr(arr: np.ndarray) -> float | None:
     """Annualized Sharpe of a 1-D return array, or None if degenerate."""
     if len(arr) < 2:
@@ -724,23 +750,35 @@ class RigorGateResult:
 
     @property
     def passes_all(self) -> bool:
-        if self.dsr_p_value is None:
+        # NaN-hardening: every IEEE-754 comparison against NaN is False, so a NaN
+        # metric (not None — None is guarded) would silently skip its fail branch
+        # and let an under-credentialed strategy pass. Treat any non-finite metric
+        # as an automatic fail. pbo_score is sourced from an external dict; oos/IS
+        # Sharpe can carry NaN if upstream returns contain NaN.
+        if self.dsr_p_value is None or not math.isfinite(self.dsr_p_value):
             return False
         if self.dsr_p_value < 0.95:
             return False
-        if self.pbo_score is None:
+        if self.pbo_score is None or not math.isfinite(self.pbo_score):
             return False
         if self.pbo_score >= 0.5:
             return False
-        if self.oos_sharpe is None:
+        if self.oos_sharpe is None or not math.isfinite(self.oos_sharpe):
             return False
         if self.oos_sharpe <= 0.0:  # absolute OOS floor: negative OOS cannot pass
             return False
-        if self.in_sample_sharpe and self.in_sample_sharpe > 0 and self.oos_sharpe / self.in_sample_sharpe < 0.5:
+        if (
+            self.in_sample_sharpe is not None
+            and math.isfinite(self.in_sample_sharpe)
+            and self.in_sample_sharpe > 0
+            and self.oos_sharpe / self.in_sample_sharpe < 0.5
+        ):
             return False
         # Combinatorial Purged CV: when computed, the edge must hold OOS across a
         # majority of held-out paths (not just the single 70/30 tail above).
-        if self.cpcv_positive_fraction is not None and self.cpcv_positive_fraction < 0.5:
+        if self.cpcv_positive_fraction is not None and (
+            not math.isfinite(self.cpcv_positive_fraction) or self.cpcv_positive_fraction < 0.5
+        ):
             return False
         return self.look_ahead_passed
 

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -441,6 +441,42 @@ class TestFusionGateEnforcesOosSharpe:
         assert verdict.passing is True
 
 
+class TestFusionGateEnforcesIsOosCliff:
+    """Regression for the audit finding that the fusion gate enforced only the
+    absolute OOS floor (OOS > 0) and omitted the in-/out-of-sample cliff
+    (OOS/IS >= 0.5) that the curated RigorGateResult.passes_all enforces. An
+    overfit strategy with a huge in-sample Sharpe but a collapsed (yet still
+    positive) OOS Sharpe used to pass the fusion gate while failing the curated
+    one."""
+
+    @staticmethod
+    def _overfit_curve() -> list[float]:
+        # IS slice (first 70% = 560 bars): very strong, low-vol uptrend → huge IS
+        # Sharpe and a high full-sample DSR. OOS slice (last 30% = 240 bars):
+        # weakly positive, higher relative vol → OOS Sharpe > 0 (clears the floor)
+        # but OOS/IS << 0.5 (fails the cliff).
+        curve = [100_000.0]
+        for i in range(560):
+            curve.append(curve[-1] * (1.010 if i % 2 == 0 else 1.006))  # IS: ~+0.8%/bar
+        for i in range(240):
+            curve.append(curve[-1] * (1.004 if i % 2 == 0 else 0.998))  # OOS: weakly +, noisy
+        return curve
+
+    def test_overfit_is_high_oos_collapsed_fails_on_cliff(self):
+        verdict = apply_rigor_gate(_metrics_from_curve(self._overfit_curve()))
+        # Test-setup invariants: DSR passes, OOS clears the absolute floor, and IS
+        # Sharpe is strongly positive — so ONLY the cliff can be the deciding gate.
+        assert verdict.dsr_p_value is not None and verdict.dsr_p_value >= 0.95, "setup: DSR should pass"
+        assert verdict.oos_sharpe is not None and verdict.oos_sharpe > 0.0, "setup: OOS must clear the floor"
+        assert verdict.in_sample_sharpe is not None and verdict.in_sample_sharpe > 0.0, "setup: IS Sharpe positive"
+        assert verdict.oos_sharpe / verdict.in_sample_sharpe < 0.5, "setup: ratio must trip the cliff"
+        assert verdict.passing is False, "cliff must reject an overfit strategy with a collapsed OOS Sharpe"
+
+    def test_in_sample_sharpe_surfaced_on_verdict(self):
+        verdict = apply_rigor_gate(_metrics_from_curve(self._overfit_curve()))
+        assert verdict.in_sample_sharpe is not None
+
+
 class TestFusionGateUsesRealTrialCount:
     """Regression for the audit finding that num_trials was hardcoded to 10
     regardless of the actual variant-selection set size."""

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -721,6 +721,33 @@ class TestPassesAllBranches:
         )
         assert r.passes_all is True
 
+    # NaN-hardening: every IEEE-754 comparison against NaN is False, so a NaN
+    # metric (not None) used to skip its fail branch and let the gate continue
+    # toward PASS. Each numeric metric must now fail on a non-finite value.
+    def test_nan_dsr_p_value_fails(self):
+        r = RigorGateResult("s", dsr_p_value=float("nan"), pbo_score=0.2, oos_sharpe=1.0, look_ahead_passed=True)
+        assert r.passes_all is False
+
+    def test_nan_pbo_score_fails(self):
+        r = RigorGateResult("s", dsr_p_value=0.97, pbo_score=float("nan"), oos_sharpe=1.0, look_ahead_passed=True)
+        assert r.passes_all is False
+
+    def test_nan_oos_sharpe_fails(self):
+        r = RigorGateResult("s", dsr_p_value=0.97, pbo_score=0.2, oos_sharpe=float("nan"), look_ahead_passed=True)
+        assert r.passes_all is False
+
+    def test_nan_cpcv_positive_fraction_fails(self):
+        r = RigorGateResult(
+            "s",
+            dsr_p_value=0.97,
+            pbo_score=0.2,
+            oos_sharpe=1.0,
+            look_ahead_passed=True,
+            in_sample_sharpe=2.0,
+            cpcv_positive_fraction=float("nan"),
+        )
+        assert r.passes_all is False
+
 
 # ─── RigorGateResult.gate_details — every branch ─────────────────────
 


### PR DESCRIPTION
## Summary

Two gate-integrity gaps surfaced by the 2026-06-14 full-repo audit pass. Both let an under-credentialed strategy clear the rigor gate — the product's entire wedge.

### 1. Fusion path was missing the IS/OOS cliff primitive (HIGH)
The curated gate (`RigorGateResult.passes_all`) enforces **both** the absolute OOS floor (`oos_sharpe > 0`) **and** the in-/out-of-sample cliff (`oos_sharpe / in_sample_sharpe >= 0.5`) — primitive 4 of the selection-bias spec. `fusion_evaluator.apply_rigor_gate` enforced only the floor and never computed `in_sample_sharpe`, so a strategy grossly overfit in-sample (e.g. IS Sharpe 5.0, OOS Sharpe +0.05) **passed the fusion gate and was marked admissible for Tier-1** while the identical strategy failed the curated API gate. This is a live admission path.

- Added `compute_in_sample_sharpe` (chronological complement of `compute_oos_sharpe`; identical excess-return convention rf=5%/252, `sqrt(252)`, and length thresholds so the ratio compares like-with-like).
- Wired the cliff into `apply_rigor_gate`; surfaced `in_sample_sharpe` on `RigorVerdict` so the passport can show it.

### 2. NaN-hardened both gates (MEDIUM)
Every IEEE-754 comparison against NaN is `False`, so a NaN metric (not `None` — `None` was already guarded) silently skipped its fail branch and let the gate continue toward PASS. `pbo_score` is sourced from an external dict; OOS/IS Sharpe can carry NaN from upstream NaN returns. `passes_all` and `apply_rigor_gate` now treat any non-finite metric as a fail.

## Verify
```
conda activate archimedes
python -m pytest backend/tests/test_rigor_evaluator.py backend/tests/services/test_fusion_evaluator.py -q   # 158 passed
python -m pytest backend/tests/test_selection_bias_routes.py backend/tests/test_backtest_pipeline_integration.py backend/tests/test_strategy_fusion.py -q   # 67 passed
ruff format --check backend/archimedes/services/fusion_evaluator.py backend/archimedes/services/rigor_evaluator.py
```

New tests: `TestFusionGateEnforcesIsOosCliff` (overfit IS, collapsed-but-positive OOS → must fail) and NaN-fail cases for dsr_p / pbo / oos / cpcv.

## Anti-goals
- Did **not** touch the 0.95 DSR / 0.5 PBO / 0.5 cliff thresholds.
- Did **not** change the curated `run_rigor_gate` IS-slice computation (left as-is to avoid behavior drift on short series); the new helper mirrors it.