### PR TITLE
[security] Backend hardening: LLM budget-drain, sweep DoS, error leak, job scoping

### DIFF
--- a/backend/archimedes/api/chat_routes.py
+++ b/backend/archimedes/api/chat_routes.py
@@ -22,7 +22,7 @@ import re
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 
 from archimedes.api.auth_guard import require_internal_agent_key
-from archimedes.api.auth_siwe import get_verified_wallet
+from archimedes.api.auth_siwe import _generation_auth_required, get_verified_wallet
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import (
     ChatMessageListResponse,
@@ -90,6 +90,21 @@ async def post_chat_message(
         raise HTTPException(status_code=400, detail="Message cannot be empty")
     if len(body.message) > 2000:
         raise HTTPException(status_code=400, detail="Message too long (max 2000 chars)")
+
+    # Budget-drain guard (audit 2026-06-14): an @archimedes mention triggers a
+    # paid Claude completion inside chat_service.post_message. This is the same
+    # class of unauthenticated paid-LLM vector that the generation endpoints
+    # close via gate_generation, but on a separate code path. Gate the
+    # AI-triggering branch behind the same REQUIRE_SIWE_FOR_GENERATION flag:
+    # default OFF preserves today's open chat (no flag-day risk); when ON, an
+    # anonymous caller can still chat but cannot spend tokens without a session.
+    # The mention test mirrors chat_service.post_message ("@archimedes" in lower).
+    triggers_ai = "@archimedes" in body.message.lower()
+    if triggers_ai and _generation_auth_required() and session_wallet is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Sign in with your wallet to mention @archimedes (AI responses require a verified session).",
+        )
 
     if session_wallet is not None:
         # SIWE-verified caller — session is the identity, not the body.

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 
 from archimedes.agents.generation_pipeline import run_generation
-from archimedes.api.auth_siwe import gate_generation
+from archimedes.api.auth_siwe import gate_generation, get_verified_wallet
 from archimedes.api.generate_schemas import (
     CandidatesListResponse,
     CandidateSummary,
@@ -65,9 +65,18 @@ async def start_generation(
 ) -> GenerateStartResponse:
     """Create a generation job and start the pipeline in the background."""
     store = get_job_store()
+    # Tag the job with its creator (audit 2026-06-14) so cancel can be scoped to
+    # the owner. When no SIWE session exists (flag off / anonymous), owner_wallet
+    # is None and the job stays cancellable by anyone — preserving today's open
+    # behavior with no flag-day risk. owner_wallet is inert to the pipeline
+    # (run_generation reads brief/n_candidates from the task args, not payload).
     job_id = await store.enqueue(
         job_type="generate",
-        payload={"brief": req.brief.model_dump(), "n_candidates": req.n_candidates},
+        payload={
+            "brief": req.brief.model_dump(),
+            "n_candidates": req.n_candidates,
+            "owner_wallet": _wallet,
+        },
     )
 
     # Fire-and-forget the pipeline. The route doesn't await it; the SSE stream
@@ -154,7 +163,10 @@ def _format_sse(ev: dict) -> str:
 
 
 @generate_router.post("/jobs/{job_id}/cancel")
-async def cancel_job(job_id: str) -> dict[str, str]:
+async def cancel_job(
+    job_id: str,
+    caller_wallet: str | None = Depends(get_verified_wallet),
+) -> dict[str, str]:
     """Cancel a running job. Idempotent.
 
     Hard cancellation: looks up the asyncio.Task driving the job and calls
@@ -171,6 +183,16 @@ async def cancel_job(job_id: str) -> dict[str, str]:
     job = await store.get(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+
+    # Owner scoping (audit 2026-06-14): if the job was created by a verified
+    # wallet, only that wallet may cancel it. Jobs created anonymously
+    # (owner_wallet is None) stay cancellable by anyone — preserving the open
+    # behavior when SIWE-for-generation is off. Prevents a third party who
+    # learns a job_id from killing another user's in-flight generation.
+    owner_wallet = (job.get("payload") or {}).get("owner_wallet")
+    if owner_wallet and owner_wallet.lower() != (caller_wallet or "").lower():
+        raise HTTPException(status_code=403, detail="This job belongs to a different wallet.")
+
     if job["status"] in ("done", "error", "cancelled"):
         return {"job_id": job_id, "status": job["status"]}
 

--- a/backend/archimedes/api/portfolio_routes.py
+++ b/backend/archimedes/api/portfolio_routes.py
@@ -100,9 +100,15 @@ class ParameterSweepRequest(BaseModel):
     strategy_id: str
     weights: dict[str, float]
     param1_name: str
-    param1_range: list[float]
+    # Compute-amplification guard (audit 2026-06-14): the sweep runs one full
+    # backtest per cell of the param1 × param2 Cartesian product. Without a
+    # bound, a single unauthenticated request with two large ranges schedules
+    # millions of backtests and pins the worker (DoS). 25 × 25 = 625 cells is a
+    # generous heatmap ceiling; the request is rejected at validation, before
+    # any compute. min_length=1 keeps an empty range from yielding zero cells.
+    param1_range: list[float] = Field(..., min_length=1, max_length=25)
     param2_name: str
-    param2_range: list[float]
+    param2_range: list[float] = Field(..., min_length=1, max_length=25)
     metric: str = "sharpe_ratio"
     start_date: str | None = None
     end_date: str | None = None

--- a/backend/archimedes/api/swap_routes.py
+++ b/backend/archimedes/api/swap_routes.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import PoolListResponse, PoolResponse, SwapQuoteResponse
+
+logger = logging.getLogger(__name__)
 
 swap_router = APIRouter(prefix="/api/swap", tags=["swap"])
 
@@ -86,9 +89,12 @@ async def get_swap_quote(
             min_amount_out=amount_out * 0.995,
         )
     except Exception as e:
-        from fastapi import HTTPException
-
-        raise HTTPException(status_code=400, detail=f"Quote failed: {e!s}") from e
+        # Don't echo the raw chain/web3 exception to the client — it leaks RPC
+        # internals, contract addresses, and revert reasons (audit 2026-06-14;
+        # same leak class fixed in vaults/portfolio routes #605). Log full
+        # detail server-side; return a generic message.
+        logger.exception("swap quote failed for %s -> %s", token_in, token_out)
+        raise HTTPException(status_code=400, detail="Quote failed — check the token pair and amount.") from e
 
 
 @swap_router.get("/pools", response_model=PoolListResponse)

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -673,6 +673,17 @@ def sensitivity_sweep(
     if not combinations:
         raise ValueError("param_grid produced zero combinations")
 
+    # Defense-in-depth compute cap (audit 2026-06-14). The HTTP schema bounds
+    # each range to 25, but this service is callable directly — refuse a grid
+    # whose Cartesian product would schedule an unreasonable number of
+    # backtests rather than pinning the worker pool.
+    _MAX_COMBINATIONS = 625
+    if len(combinations) > _MAX_COMBINATIONS:
+        raise ValueError(
+            f"param_grid yields {len(combinations)} combinations, exceeding the "
+            f"{_MAX_COMBINATIONS}-cell sweep limit; reduce the parameter ranges."
+        )
+
     def _run_one(combo: tuple) -> dict[str, Any]:
         kw: dict[str, Any] = dict(zip(param_names, combo))
         base = {

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -151,3 +151,57 @@ class TestReadEndpointsRegression:
         count = client.get(f"/api/vaults/{_VAULT_READ}/chat/count")
         assert count.status_code == 200
         assert count.json()["message_count"] == before + 2
+
+
+_VAULT_AI = "0x00000000000000000000000000000000000005ae"
+
+
+class TestArchimedesMentionBudgetGate:
+    """Audit 2026-06-14: an @archimedes mention triggers a paid Claude
+    completion. That AI-triggering branch is gated behind the same
+    REQUIRE_SIWE_FOR_GENERATION flag as the generation endpoints — default OFF
+    keeps chat open; ON requires a verified session to spend tokens.
+
+    The AI generator is stubbed so the "allowed" paths stay hermetic (no real
+    Anthropic call); the 401 path fires before post_message is even reached.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_ai(self, monkeypatch):
+        from archimedes.services.chat_service import chat_service
+
+        monkeypatch.setattr(chat_service, "_generate_ai_response", lambda *a, **k: None)
+
+    def test_mention_blocked_without_session_when_flag_on(self, client, monkeypatch):
+        monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "true")
+        res = client.post(
+            f"/api/vaults/{_VAULT_AI}/chat",
+            json={"wallet_address": _W_BODY, "message": "hey @archimedes rebalance me"},
+        )
+        assert res.status_code == 401, res.text
+        assert "sign in" in res.json()["detail"].lower()
+
+    def test_mention_allowed_with_session_when_flag_on(self, client, monkeypatch):
+        monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "true")
+        res = client.post(
+            f"/api/vaults/{_VAULT_AI}/chat",
+            json={"message": "@archimedes status please"},
+            cookies=_siwe_cookies(_W_SESSION),
+        )
+        assert res.status_code == 200, res.text
+
+    def test_mention_open_when_flag_off(self, client, monkeypatch):
+        monkeypatch.delenv("REQUIRE_SIWE_FOR_GENERATION", raising=False)
+        res = client.post(
+            f"/api/vaults/{_VAULT_AI}/chat",
+            json={"wallet_address": _W_BODY, "message": "@archimedes hello (open mode)"},
+        )
+        assert res.status_code == 200, res.text
+
+    def test_non_mention_never_gated_even_when_flag_on(self, client, monkeypatch):
+        monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "true")
+        res = client.post(
+            f"/api/vaults/{_VAULT_AI}/chat",
+            json={"wallet_address": _W_BODY, "message": "just chatting, no mention"},
+        )
+        assert res.status_code == 200, res.text

--- a/backend/tests/test_generate_cancel_scoping.py
+++ b/backend/tests/test_generate_cancel_scoping.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
 from fastapi.testclient import TestClient
 

--- a/backend/tests/test_generate_cancel_scoping.py
+++ b/backend/tests/test_generate_cancel_scoping.py
@@ -1,0 +1,77 @@
+"""Regression for cross-user job cancellation (audit 2026-06-14).
+
+POST /api/generate/jobs/{job_id}/cancel had no caller scoping — anyone who
+learned a job_id could cancel another user's in-flight generation. Jobs are now
+tagged with the creating wallet (``payload.owner_wallet``); a job created by a
+verified wallet may only be cancelled by that same wallet. Anonymous jobs
+(owner_wallet None) stay cancellable by anyone, preserving the open behavior
+when SIWE-for-generation is off.
+
+Hermetic: the Redis-backed job store is mocked at the boundary; SIWE sessions
+are real signed cookies (test_chat_routes / test_user_routes precedent).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from fastapi.testclient import TestClient
+
+_OWNER = "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+_ATTACKER = "0x9999999999999999999999999999999999999999"
+
+
+def _cookies(wallet: str) -> dict[str, str]:
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _mock_store(owner_wallet: str | None):
+    """A job store whose .get returns a queued job owned by owner_wallet."""
+    store = MagicMock()
+    store.get = AsyncMock(
+        return_value={
+            "id": "job123",
+            "status": "queued",
+            "payload": {"owner_wallet": owner_wallet},
+        }
+    )
+    store.update_status = AsyncMock()
+    store.push_event = AsyncMock()
+    return store
+
+
+def test_owner_can_cancel_own_job():
+    with patch("archimedes.api.generate_routes.get_job_store", return_value=_mock_store(_OWNER.lower())):
+        resp = _client().post("/api/generate/jobs/job123/cancel", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "cancelled"
+
+
+def test_other_wallet_cannot_cancel_owned_job():
+    with patch("archimedes.api.generate_routes.get_job_store", return_value=_mock_store(_OWNER.lower())):
+        resp = _client().post("/api/generate/jobs/job123/cancel", cookies=_cookies(_ATTACKER))
+    assert resp.status_code == 403, resp.text
+
+
+def test_anonymous_cannot_cancel_owned_job():
+    """No session at all → cannot cancel a job owned by a verified wallet."""
+    with patch("archimedes.api.generate_routes.get_job_store", return_value=_mock_store(_OWNER.lower())):
+        resp = _client().post("/api/generate/jobs/job123/cancel")
+    assert resp.status_code == 403, resp.text
+
+
+def test_anonymous_job_still_cancellable_by_anyone():
+    """owner_wallet None (anonymous create) → open cancel preserved."""
+    with patch("archimedes.api.generate_routes.get_job_store", return_value=_mock_store(None)):
+        resp = _client().post("/api/generate/jobs/job123/cancel")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "cancelled"

--- a/backend/tests/test_portfolio_sweep_scenario.py
+++ b/backend/tests/test_portfolio_sweep_scenario.py
@@ -69,6 +69,44 @@ async def test_parameter_sweep_returns_422_on_invalid_param():
 
 
 @pytest.mark.asyncio
+async def test_parameter_sweep_rejects_oversized_range():
+    """Audit 2026-06-14: an unbounded range schedules one backtest per Cartesian
+    cell → compute-amplification DoS. Each range is capped at 25 at the schema
+    layer, so an oversized range is rejected (422) before any backtest runs."""
+    from archimedes.main import app
+
+    payload = _sweep_payload(param1_range=[float(i) for i in range(200)])  # 200 > 25
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/parameter-sweep", json=payload)
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_parameter_sweep_rejects_empty_range():
+    """min_length=1 keeps an empty range from yielding zero cells / odd grids."""
+    from archimedes.main import app
+
+    # Build the payload directly — _sweep_payload coalesces a falsy [] to its
+    # default, which would defeat the empty-range check.
+    payload = {
+        "strategy_id": "tsmom",
+        "weights": {"SPY": 0.5, "QQQ": 0.5},
+        "param1_name": "rebalance_days",
+        "param1_range": [10, 20, 30],
+        "param2_name": "tx_cost_bps",
+        "param2_range": [],  # empty → must be rejected by min_length=1
+        "metric": "sharpe_ratio",
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/parameter-sweep", json=payload)
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
 async def test_parameter_sweep_grid_shape():
     """Grid dimensions must match len(param1_range) × len(param2_range)."""
     from archimedes.main import app

--- a/backend/tests/test_swap_routes_error_leak.py
+++ b/backend/tests/test_swap_routes_error_leak.py
@@ -1,0 +1,45 @@
+"""Regression for the swap-quote raw-exception leak (audit 2026-06-14).
+
+GET /api/swap/quote used to return ``detail=f"Quote failed: {e!s}"`` — echoing
+the raw chain/web3 exception (RPC internals, contract addresses, revert reasons)
+to the client. The same leak class was fixed in vaults/portfolio routes (#605);
+this file pins the swap path to a generic message + server-side logging.
+
+Hermetic: the contract loader is patched at the boundary to raise a
+secret-bearing exception; no chain, no RPC.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+_LEAK_MARKER = "RPC node 10.0.3.7 reverted: insufficient-reserve at 0xDEADBEEF"
+
+
+@pytest.mark.asyncio
+async def test_quote_failure_returns_generic_message_not_raw_exception():
+    from archimedes.main import app
+
+    with patch(
+        "archimedes.chain.contracts.get_contract_loader",
+        side_effect=RuntimeError(_LEAK_MARKER),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get(
+                "/api/swap/quote",
+                params={
+                    "token_in": "0x1111111111111111111111111111111111111111",
+                    "token_out": "0x2222222222222222222222222222222222222222",
+                    "amount_in": 100,
+                },
+            )
+
+    assert resp.status_code == 400, resp.text
+    # The raw exception text (addresses, revert reason, internal IPs) must NOT
+    # appear in the response body.
+    assert _LEAK_MARKER not in resp.text
+    assert "0xDEADBEEF" not in resp.text
+    assert resp.json()["detail"] == "Quote failed — check the token pair and amount."


### PR DESCRIPTION
## Summary

Four net-new findings from the 2026-06-14 full-repo audit pass — the budget-drain and DoS items survive even with the SIWE generation gate enabled because they live on separate code paths.

### 1. (MEDIUM) Unauthenticated paid-LLM budget drain via vault chat
`POST /api/vaults/{address}/chat` triggers a paid Claude completion whenever a message contains `@archimedes`, but used only the non-enforcing `get_verified_wallet` — a separate path from the generation endpoints gated in [#601](https://github.com/a-apin/archimedes/pull/601). An attacker could burn tokens at 20 completions/min/IP unauthenticated. **Fix:** gate the AI-triggering branch behind the same `REQUIRE_SIWE_FOR_GENERATION` flag (default OFF preserves open chat; ON requires a session before spending tokens).

### 2. (MEDIUM) Compute-amplification DoS on `/api/portfolio/parameter-sweep`
`param1_range`/`param2_range` were unbounded `list[float]`; the sweep runs one full backtest per Cartesian cell, so two 1000-element ranges schedule 1,000,000 backtests and pin the single worker. **Fix:** bound each range to `max_length=25, min_length=1` at the schema layer (rejected at validation, before any compute) + a defense-in-depth 625-cell cap in `sensitivity_sweep` for direct callers.

### 3. (LOW) Raw-exception leak in `/api/swap/quote`
Returned `detail=f"Quote failed: {exc}"`, echoing chain/web3 internals (addresses, revert reasons, RPC errors). Same class fixed in vaults/portfolio routes ([#605](https://github.com/a-apin/archimedes/pull/605)). **Fix:** log server-side, return a generic message.

### 4. (LOW) Cross-user job cancellation
`/api/generate/jobs/{id}/cancel` had no caller scoping — anyone with a `job_id` could cancel another user's generation. **Fix:** tag jobs with the creating wallet (`payload.owner_wallet`); only that wallet may cancel. Anonymous jobs stay open-cancellable (no flag-day change).

## Verify
```
conda activate archimedes
# (clear any stale local sqlite first: find . -name archimedes_chat.db -delete)
python -m pytest backend/tests/test_chat_routes.py backend/tests/test_portfolio_sweep_scenario.py \
  backend/tests/test_swap_routes_error_leak.py backend/tests/test_generate_cancel_scoping.py \
  backend/tests/test_portfolio_routes.py backend/tests/test_security_hardening.py -q
ruff format --check backend/archimedes/api/ backend/archimedes/services/portfolio_backtester.py
```

## Anti-goals
- No change to the default open behavior (chat & cancel) when `REQUIRE_SIWE_FOR_GENERATION` is off — zero flag-day risk on deploy.
- Did not add new dependencies or touch the SIWE/session machinery.