### PR TITLE
[contracts] getTraces underflow guard, owner-only setTokenOracles, mint zero-guard

### DIFF
--- a/contracts/src/ReasoningTraceRegistry.sol
+++ b/contracts/src/ReasoningTraceRegistry.sol
@@ -221,8 +221,10 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
         uint256[] storage ids = _agentTraces[agent];
         if (ids.length == 0 || from > to) return new bytes32[](0);
 
-        // Clamp range
-        if (from >= ids.length) from = ids.length;
+        // An out-of-range start has no results — return empty. (Previously this
+        // clamped `from = ids.length`, which then made `to - from` underflow and
+        // revert with a panic on any query past the end. audit 2026-06-14)
+        if (from >= ids.length) return new bytes32[](0);
         if (to >= ids.length) to = ids.length - 1;
 
         uint256 count = to - from + 1;

--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -74,6 +74,12 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         uint256 synthAmount = (netUsdc * (10 ** SYNTH_DECIMALS) * BPS) /
                               (assetPrice * collateralRatio);
 
+        // Reject dust deposits that round to zero synth: integer division can
+        // make synthAmount == 0 for a tiny amount at a high price, in which case
+        // the user would pay USDC (including the mint fee) and receive nothing.
+        // (audit 2026-06-14)
+        if (synthAmount == 0) revert ZeroAmount();
+
         usdc.safeTransferFrom(msg.sender, address(this), amountUsdc);
         protocolFees += fee;
         synthToken.mint(msg.sender, synthAmount);

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -385,10 +385,17 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
 
     /// @notice Set oracle addresses for held tokens (needed for NAV pricing).
     ///         Must be called before rebalance so totalAssets() is accurate.
+    /// @dev onlyOwner (creator), NOT onlyManager — the agent must not be able to
+    ///      redefine the oracles that feed the rebalance slippage floor
+    ///      (_oracleMinOut). Otherwise a compromised agent could point a token at
+    ///      a self-serving oracle, set minAmountOut ≈ 0, and route swaps that
+    ///      leak vault value — defeating the "agent has rebalance-only authority"
+    ///      invariant. Consistent with setMaxSlippageBps being owner-only.
+    ///      (audit 2026-06-14)
     function setTokenOracles(
         address[] calldata tokens,
         address[] calldata oracles
-    ) external override onlyManager {
+    ) external override onlyOwner {
         if (tokens.length != oracles.length) revert InvalidAllocations();
         for (uint256 i = 0; i < tokens.length; i++) {
             tokenOracle[tokens[i]] = oracles[i];

--- a/contracts/test/Registry.t.sol
+++ b/contracts/test/Registry.t.sol
@@ -137,6 +137,27 @@ contract ReasoningTraceRegistryTest is Test {
         assertEq(hashes.length, 0);
     }
 
+    /// @dev audit 2026-06-14: a `from` past the end used to clamp `from =
+    ///      ids.length` and then underflow `to - from`, reverting with a panic
+    ///      instead of returning an empty array. An out-of-range start must now
+    ///      return empty cleanly so pagination / verifiers don't see a fake revert.
+    function test_getTraces_from_out_of_range_returns_empty() public {
+        vm.prank(agent1);
+        registry.publishTrace(vault1, keccak256("only trace"), "");
+
+        // agent1 has exactly 1 trace (index 0). A start at/after the end is empty.
+        bytes32[] memory past = registry.getTraces(agent1, 5, 10);
+        assertEq(past.length, 0);
+
+        // from == length (1) with to beyond end: previously panicked, now empty.
+        bytes32[] memory atEnd = registry.getTraces(agent1, 1, 3);
+        assertEq(atEnd.length, 0);
+
+        // A valid query still returns the trace (to clamps to the last index).
+        bytes32[] memory valid = registry.getTraces(agent1, 0, 99);
+        assertEq(valid.length, 1);
+    }
+
     // ─── Get Trace by ID ─────────────────────────────────────────────
 
     function test_getTraceById() public {

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -218,6 +218,33 @@ contract SyntheticVaultTest is Test {
         vault.mint(1000 * 10**6);
     }
 
+    /// @dev audit 2026-06-14: integer division can make synthAmount round to 0
+    ///      (dust deposit at a very high price). The user must not pay USDC +
+    ///      mint fee and receive zero synth — mint now reverts ZeroAmount.
+    ///      Reproduce with an extreme-price oracle so 1 USDC-unit yields 0 synth:
+    ///      synthAmount = netUsdc*1e18*BPS / (assetPrice*collateralRatio) == 0.
+    function test_revert_mint_dust_rounds_to_zero_synth() public {
+        // assetPrice * collateralRatio must exceed netUsdc * 1e18 * 1e4 for a
+        // 1-unit deposit. With collateralRatio 12000, price > ~8.3e17 suffices.
+        uint256 hugePrice = 1e21; // 1e21 * 12000 = 1.2e25 > 1*1e22
+        SyntheticToken dustSynth = new SyntheticToken("Dust", "DUST", owner);
+        PriceOracle dustOracle = new PriceOracle("DUST", hugePrice, owner);
+        SyntheticVault dustVault = new SyntheticVault(
+            address(usdc),
+            address(dustSynth),
+            address(dustOracle),
+            owner
+        );
+        vm.prank(owner);
+        dustSynth.setVault(address(dustVault));
+
+        vm.startPrank(alice);
+        usdc.approve(address(dustVault), 1);
+        vm.expectRevert(SyntheticVault.ZeroAmount.selector);
+        dustVault.mint(1); // 1 unit (1e-6 USDC) → rounds to 0 synth → revert
+        vm.stopPrank();
+    }
+
     // ─── Burn Tests ───────────────────────────────────────────────
 
     function test_burn_basic() public {

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -488,6 +488,41 @@ contract VaultTest is Test {
         vault.setMaxSlippageBps(501);
     }
 
+    // ─── setTokenOracles is owner-only (audit 2026-06-14) ────────────
+    /// @dev The agent must not be able to redefine the oracles that feed the
+    ///      rebalance slippage floor (_oracleMinOut); otherwise a compromised
+    ///      agent could point a token at a self-serving oracle and route swaps
+    ///      that leak vault value. This test builds a vault whose agent is
+    ///      DISTINCT from the creator/owner so it actually distinguishes
+    ///      onlyOwner from the old onlyManager (under which the agent could set
+    ///      oracles). In the shared setUp, agent == creator == owner.
+    function test_revert_setTokenOracles_agent_cannot_set() public {
+        address creator = address(0xC0FFEE);
+        address distinctAgent = address(0xA9E27);
+
+        vm.prank(creator);
+        address vaultAddr = factory.createVault("T", "T", 0, 0, true);
+        Vault v = Vault(payable(vaultAddr));
+
+        vm.prank(creator); // creator == Ownable owner
+        v.setAgent(distinctAgent);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(sTSLA);
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(tslaOracle);
+
+        // Under the old onlyManager this SUCCEEDED (agent is a manager); under
+        // onlyOwner it must revert.
+        vm.prank(distinctAgent);
+        vm.expectRevert();
+        v.setTokenOracles(tokens, oracles);
+
+        // The creator/owner can still set oracles.
+        vm.prank(creator);
+        v.setTokenOracles(tokens, oracles);
+    }
+
     function test_revert_setMaxSlippageBps_unauthorized() public {
         vm.prank(bob);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, bob));


### PR DESCRIPTION
## Summary

Three net-new contract findings from the 2026-06-14 full-repo audit pass.

> ⚠️ **Source-only — NOT redeployed.** The live deployed contracts on Arc testnet are unchanged until a separate Foundry redeploy + `deploy_output.json`/backend/UI address+ABI propagation. Per repo convention, a redeploy of the live funds-stack still warrants explicit review before it happens. This PR lands the source fix + regression tests, same pattern as [#505](https://github.com/a-apin/archimedes/pull/505)/[#597](https://github.com/a-apin/archimedes/pull/597).

### 1. (MEDIUM) `ReasoningTraceRegistry.getTraces` panics on out-of-range start
`contracts/src/ReasoningTraceRegistry.sol`. When `from >= ids.length` the code clamped `from = ids.length` and then computed `to - from`, which **underflows (panic 0x11)** instead of returning empty. Any verifier/indexer paginating past the end hit a fake revert — bad for a registry whose whole point is open verification. **Fix:** return an empty array on an out-of-range start.

### 2. (MEDIUM) `Vault.setTokenOracles` was agent-settable → slippage-floor bypass
`contracts/src/Vault.sol`. It was `onlyManager` (creator **or** agent), so the agent could redefine the oracles that feed the rebalance slippage floor (`_oracleMinOut`). A compromised agent could point a token at a self-serving oracle, set `minAmountOut ≈ 0`, and route swaps that leak vault value — defeating the "agent has rebalance-only authority" invariant. **Fix:** `onlyOwner` (creator), consistent with `setMaxSlippageBps`.

### 3. (LOW) `SyntheticVault.mint` charges a fee for zero synth
`contracts/src/SyntheticVault.sol`. Integer division can round `synthAmount` to 0 (dust deposit at a high price); the function still pulled USDC + credited the mint fee and minted nothing. **Fix:** revert `ZeroAmount` when `synthAmount == 0`.

## Verify
```
cd contracts && forge test    # 154 passed (was 151)
forge test --match-test "getTraces_from_out_of_range|setTokenOracles_agent_cannot_set|mint_dust"
```
New regressions: out-of-range `getTraces` returns empty (no panic); a vault with a **distinct** agent (≠ owner) — so the test genuinely distinguishes `onlyOwner` from the old `onlyManager` — proves the agent cannot `setTokenOracles` while the owner can; dust mint reverts `ZeroAmount`.

## Anti-goals
- No redeploy. No ABI/address changes committed.
- Did not reformat pre-existing fmt drift in unrelated functions (no forge-fmt CI gate; edits match surrounding style).