### PR TITLE
[frontend] DepositFlow address guard + CorpusExplorer pdf_url scheme check

### DIFF
--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -274,7 +274,12 @@ function PaperDetail({ paper, onBack }) {
   // Always derive an arxiv URL from the id — backend doesn't always populate
   // pdf_url, but arxiv.org/abs/{id} is canonical and always works.
   const arxivAbsUrl = paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : null
-  const arxivPdfUrl = paper.pdf_url || (paper.arxiv_id ? `https://arxiv.org/pdf/${paper.arxiv_id}` : null)
+  // Only trust a server-supplied pdf_url if it's an https:// URL — a polluted
+  // corpus record could otherwise inject a javascript:/phishing href into this
+  // button. Fall back to the canonical arxiv template. (audit 2026-06-14)
+  const safePdfUrl =
+    typeof paper.pdf_url === 'string' && /^https:\/\//i.test(paper.pdf_url) ? paper.pdf_url : null
+  const arxivPdfUrl = safePdfUrl || (paper.arxiv_id ? `https://arxiv.org/pdf/${paper.arxiv_id}` : null)
 
   return (
     <div className="corpus-explorer">

--- a/ui/src/components/DepositFlow.jsx
+++ b/ui/src/components/DepositFlow.jsx
@@ -14,7 +14,7 @@ import {
   CIRCLE_PROVIDER_ID,
   USDC_DECIMALS,
 } from '../config'
-import { parseUnits } from 'viem'
+import { isAddress, parseUnits } from 'viem'
 import { executeUserOp, encodeCall } from '../circle-tx-executor'
 
 const ARCSCAN_TX = 'https://testnet.arcscan.app/tx'
@@ -122,6 +122,11 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
     updateStep(0, 'status', WAITING)
     updateStep(0, 'error', null)
     try {
+      // Defense-in-depth (audit 2026-06-14): never route a USDC approve to an
+      // unvalidated spender. Mirrors the VaultDetail.jsx guard — DepositFlow is
+      // the primary funding modal and must not grant allowance to a malformed
+      // address if a future caller passes one.
+      if (!isAddress(vaultAddress)) throw new Error('Invalid vault address — refusing to send funds.')
       const walletClient = await getWalletClient()
       const parsedAmount = parseUnits(amount, USDC_DECIMALS)
       if (parsedAmount <= 0n) throw new Error('Amount must be greater than 0')
@@ -150,6 +155,7 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
     updateStep(1, 'status', WAITING)
     updateStep(1, 'error', null)
     try {
+      if (!isAddress(vaultAddress)) throw new Error('Invalid vault address — refusing to send funds.')
       const walletClient = await getWalletClient()
       const userAddr = getAddress()
       if (!userAddr) throw new Error('Wallet address not available')
@@ -179,6 +185,7 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
     updateStep(2, 'status', WAITING)
     updateStep(2, 'error', null)
     try {
+      if (!isAddress(vaultAddress)) throw new Error('Invalid vault address — refusing to send funds.')
       const walletClient = await getWalletClient()
       const { tokens, weights } = defaultAllocations()
 
@@ -407,6 +414,7 @@ function PasskeyDepositFlow({ vaultAddress, depositAmount = '100', strategy, onC
     setResult(null)
     setState('SIGNING')
     try {
+      if (!isAddress(vaultAddress)) throw new Error('Invalid vault address — refusing to send funds.')
       const smartAccount = getSmartAccount()
       const client = getSmartAccountClient()
       const userAddr = getAddress()


### PR DESCRIPTION
## Summary

Two LOW defense-in-depth gaps from the 2026-06-14 audit pass. No live exploit today (sources are trusted), but both close a documented invariant before a future caller can trip it.

### 1. DepositFlow.jsx missing the `isAddress` guard VaultDetail already enforces
`VaultDetail.jsx:191` validates the vault address before its inline `deposit()` ("never route a USDC approve/deposit to an unvalidated address"). `DepositFlow` — the **primary** funding modal — had no equivalent, so a future caller passing a URL/API-derived `vaultAddress` would silently grant a USDC allowance to a malformed/attacker address. Added `isAddress(vaultAddress)` to all three EOA steps (approve, deposit, allocate) and the passkey batch deposit, mirroring the VaultDetail wording.

### 2. CorpusExplorer.jsx binds server-supplied `pdf_url` to `href` unvalidated
This is the one external link not pinned to a constant `https://arxiv.org/...` template — it trusted `paper.pdf_url` from the corpus API. A polluted corpus record could inject a `javascript:`/phishing href. Now only an `https://` `pdf_url` is trusted; otherwise it falls back to the canonical `arxiv_id` template.

## Verify
```
cd ui
npx eslint src/components/DepositFlow.jsx src/components/CorpusExplorer.jsx   # clean
npm run build                                                                # ok
```
(Note: a pre-existing, unrelated `npm run lint` error in `BacktestVisualizer.jsx` — `ParameterSweepHeatmap` unused — exists on main and is untouched here; `ui/` lint is informational in `quality-gate.yml`.)

## Anti-goals
- No behavior change for valid addresses; no new deps; XSS/approval-scope surfaces were already clean per the audit.