### PR TITLE
[infra] Encrypt EC2 root EBS, pin DynamoDB IAM ARN, align eth-utils/web3 floors

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,9 +46,13 @@ dependencies:
       - anthropic>=0.104.1            # Claude / GLM-compatible client for strategy extraction + reasoning trace generation + chat. Floor aligned with backend/requirements.txt via dependabot PR #251; locally smoke-tested at 0.104.1 against llm_backend.py + chat_service.py (full 784-test backend suite green).
 
       # --- On-chain / Web3 ---
-      - web3>=7.0                     # Python EVM client; works with Arc (EVM-compatible)
+      # Floors kept in lockstep with backend/requirements.txt (audit 2026-06-14):
+      # the two had drifted (web3 7.0 vs 7.16.0, eth-utils 5.0 vs 6.0.0), which is
+      # the documented #1 cause of "works locally, breaks in CI". eth-utils 5→6
+      # was an API-breaking bump, so the floors must agree.
+      - web3>=7.16.0                  # Python EVM client; works with Arc (EVM-compatible)
       - eth-account>=0.13.7           # Local key management for testnet wallets
-      - eth-utils>=5.0
+      - eth-utils>=6.0.0
       - cryptography>=42.0            # RSA sign/serialize for the oracle signer (backend/archimedes/chain/oracle_updater.py); mirrors backend/requirements.txt
 
       # --- AWS / S3 ---

--- a/infra/iam/archimedes-backend-policy.json
+++ b/infra/iam/archimedes-backend-policy.json
@@ -55,8 +55,8 @@
         "dynamodb:DescribeTable"
       ],
       "Resource": [
-        "arn:aws:dynamodb:*:*:table/archimedes-papers-index",
-        "arn:aws:dynamodb:*:*:table/archimedes-papers-index/index/*"
+        "arn:aws:dynamodb:eu-west-2:159903201072:table/archimedes-papers-index",
+        "arn:aws:dynamodb:eu-west-2:159903201072:table/archimedes-papers-index/index/*"
       ]
     },
     {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -5,11 +5,11 @@ terraform {
   # Bootstrap: S3 bucket created out-of-band via AWS CLI.
   # See infra/README.md for the bootstrap commands.
   backend "s3" {
-    bucket         = "archimedes-tfstate-159903201072"
-    key            = "infra/terraform.tfstate"
-    region         = "eu-west-2"
-    encrypt        = true
-    use_lockfile   = true  # S3-native locking (Terraform 1.10+), no DynamoDB needed
+    bucket       = "archimedes-tfstate-159903201072"
+    key          = "infra/terraform.tfstate"
+    region       = "eu-west-2"
+    encrypt      = true
+    use_lockfile = true # S3-native locking (Terraform 1.10+), no DynamoDB needed
   }
 
   required_providers {
@@ -153,6 +153,14 @@ resource "aws_instance" "archimedes" {
     volume_size           = 20
     volume_type           = "gp3"
     delete_on_termination = true
+    # Encrypt at rest (audit 2026-06-14): the root volume holds /opt/archimedes/.env
+    # (Postgres password, DATABASE_URL), SSM-pulled secrets in process/tmp, and
+    # Docker layers. Aurora + ElastiCache were already encrypted; this closes the
+    # last unencrypted store on the funds-hosting box.
+    # NOTE: applying this forces EC2 instance REPLACEMENT — coordinate with a
+    # human-credentialed `terraform plan` (or set account-level EBS default
+    # encryption to avoid replacement). Merge alone changes nothing (no CI apply).
+    encrypted = true
   }
 
   user_data = templatefile("${path.module}/user-data.sh", {


### PR DESCRIPTION
## Summary

Three LOW infra/hygiene findings from the 2026-06-14 audit pass. Source-only — no `terraform apply` runs in CI (per the [#569](https://github.com/a-apin/archimedes/pull/569) precedent), so **merge creates zero AWS changes**.

### 1. EC2 root EBS volume unencrypted at rest
`infra/main.tf` — `aws_instance.archimedes` `root_block_device` omitted `encrypted = true`. That volume holds `/opt/archimedes/.env` (Postgres password, `DATABASE_URL`), SSM-pulled secrets in process/tmp, and Docker layers. Aurora + ElastiCache were already encrypted; this was the last unencrypted store on the funds-hosting box. Added `encrypted = true`.

> ⚠️ **Applying forces EC2 instance REPLACEMENT.** Coordinate with a human-credentialed `terraform plan` at apply time, or instead enable account-level EBS default encryption (no replacement). This PR only declares the intent in source.

### 2. DynamoDB IAM reference policy wildcarded region + account
`infra/iam/archimedes-backend-policy.json` used `arn:aws:dynamodb:*:*:table/archimedes-papers-index`. Pinned to `eu-west-2:159903201072` to match the Terraform-rendered ARN (`iam_archimedes_backend.tf`) — least-privilege, and the two policy sources now agree. The account id is already committed throughout infra (tfstate / ALB-logs bucket names), so nothing new is disclosed.

### 3. `eth-utils` / `web3` floor drift
`backend/requirements.txt` (`>=6.0.0` / `>=7.16.0`) vs `environment.yml` (`>=5.0` / `>=7.0`). `eth-utils` 5→6 was API-breaking; floor drift is the documented #1 cause of "works locally, breaks in CI". Bumped `environment.yml` to match.

## Verify
```
cd infra && tofu init -backend=false && tofu validate     # Success
tofu fmt -check main.tf                                    # clean
python -c "import json,yaml; json.load(open('infra/iam/archimedes-backend-policy.json')); yaml.safe_load(open('environment.yml'))"
grep -E 'eth-utils|web3' backend/requirements.txt environment.yml   # floors now agree
```

## Anti-goals
- No `terraform apply`; no new AWS resources or recurring spend. Apply (esp. the EC2-replacing EBS encryption) remains a human-credentialed step.
- Did not reformat pre-existing fmt drift in `alb.tf`/`vpc.tf` (untouched).