### PR TITLE
[frontend] Remove dead ParameterSweepHeatmap component

### DIFF
--- a/ui/src/components/BacktestVisualizer.jsx
+++ b/ui/src/components/BacktestVisualizer.jsx
@@ -150,57 +150,6 @@ function WalkForwardBands({ folds }) {
   )
 }
 
-// ─── Parameter sweep heatmap ────────────────────────────────
-function ParameterSweepHeatmap({ sweep }) {
-  const { rows, cols, grid, max, min, param1Name, param2Name, metric } = sweep
-  const range = max - min || 1
-
-  function cellColor(v) {
-    const t = (v - min) / range // 0..1
-    // low Sharpe -> dark; high -> accent purple
-    return `rgba(192,132,252,${(0.08 + 0.82 * t).toFixed(3)})`
-  }
-
-  const headerLabel = `${param1Name ?? 'param1'} ↓ / ${param2Name ?? 'param2'} →`
-  const metricLabel = metric ?? 'metric'
-
-  return (
-    <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
-      <div className="label mb-3">Parameter Sweep ({metricLabel} by parameter pair)</div>
-      <div className="bv-sweep" style={{ gridTemplateColumns: `auto repeat(${cols.length}, 1fr)` }}>
-        <div className="bv-sweep-corner caption">{headerLabel}</div>
-        {cols.map((c) => (
-          <div key={`c${c}`} className="bv-sweep-head mono">{c}</div>
-        ))}
-        {rows.map((r, i) => (
-          <div key={`r${r}`} style={{ display: 'contents' }}>
-            <div className="bv-sweep-head mono" style={{ textAlign: 'right', paddingRight: 8 }}>{r}</div>
-            {cols.map((c, j) => {
-              const v = grid[i][j]
-              return (
-                <div
-                  key={`${r}-${c}`}
-                  className="bv-sweep-cell mono"
-                  style={{ background: cellColor(v) }}
-                  title={`${param1Name ?? 'param1'}=${r}, ${param2Name ?? 'param2'}=${c} → ${metricLabel} ${v.toFixed(2)}`}
-                >
-                  {v.toFixed(2)}
-                </div>
-              )
-            })}
-          </div>
-        ))}
-      </div>
-      <p className="caption" style={{ marginTop: 10, color: 'var(--text-4)', lineHeight: 1.5 }}>
-        {metricLabel} across a 2D parameter grid. A single bright island surrounded by dark cells is a fragile
-        peak (likely overfit); a broad bright plateau means the edge is robust to parameter choice. We
-        report the full grid rather than only the best cell — that&apos;s what the deflated-Sharpe
-        multiple-testing correction accounts for.
-      </p>
-    </div>
-  )
-}
-
 // ─── Trade / rebalance log with date filter ─────────────────
 function TradeLog({ trades }) {
   const [from, setFrom] = useState('')


### PR DESCRIPTION
## Summary

`ui/src/components/BacktestVisualizer.jsx` defined a `ParameterSweepHeatmap` component that was never used, tripping eslint `no-unused-vars` (`'ParameterSweepHeatmap' is defined but never used`) and failing `cd ui && npm run lint` (informational in CI, but noise).

**Investigated whether this was an unwired feature or dead code.** The parameter-sweep feature is already fully wired and displayed — but via an *inline* reimplementation in the main `BacktestVisualizer` component, not via this standalone component. The inline version is strictly richer:

- fetches the live `/api/portfolio/parameter-sweep` endpoint (`fetchSweep`)
- maps the `grid_2d` response shape (`sweepForHeatmap`)
- adds the metric selector + "Run Parameter Sweep" controls
- renders the `sensitivity_ratio` in the caption

The standalone `ParameterSweepHeatmap` only rendered a static grid from a `sweep` prop, was referenced nowhere, and was superseded by that inline block. So the feature is already displayed — the **component** is the dead artifact.

**Fix:** remove the dead component. Re-wiring it would nest a second `card-flat` with a duplicate label/caption, which is worse than the current single-card layout. The rendered output is unchanged.

This is pre-existing on `main`, unrelated to the 2026-06-14 audit PRs.

## Verify

- `cd ui && npm run lint` → clean (no errors)
- `cd ui && npm run build` → builds successfully (pre-existing chunk-size + dynamic-import warnings are unrelated)

## Anti-goals

- No change to rendered output or the parameter-sweep behavior
- No backend / endpoint changes