### PR TITLE
[tests] Clean up unused vars and import order in backend/tests/

### DIFF
--- a/backend/tests/quant_factories.py
+++ b/backend/tests/quant_factories.py
@@ -100,7 +100,6 @@ def make_price_panel(
     if symbols is None:
         symbols = ["SPY", "AGG", "GLD", "QQQ"]
     rng = np.random.default_rng(seed)
-    k = len(symbols)
     common = rng.standard_normal(n)
     closes: dict[str, list[float]] = {}
     volumes: dict[str, list[float]] = {}

--- a/backend/tests/test_backtester_profiler.py
+++ b/backend/tests/test_backtester_profiler.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
-
 from archimedes.services.portfolio_backtester import profile_backtest
 
 

--- a/backend/tests/test_dsr_parity.py
+++ b/backend/tests/test_dsr_parity.py
@@ -89,8 +89,8 @@ def test_convention_is_excess_not_raw() -> None:
     parametrised parity above) fail loudly.
     """
     returns = _series(0.0015, 0.008, 1500, 7)  # high mean → rf subtraction is visible
-    f_dsr, f_p = fixture_compute_dsr(returns, 1)
-    b_dsr, b_p = backend_compute_dsr(returns, 1, average_correlation=0.0)
+    _f_dsr, f_p = fixture_compute_dsr(returns, 1)
+    _b_dsr, b_p = backend_compute_dsr(returns, 1, average_correlation=0.0)
 
     # Fixture path tracks the backend's excess convention.
     assert abs(f_p - b_p) <= _TOL

--- a/backend/tests/test_fusion_quality_scorer.py
+++ b/backend/tests/test_fusion_quality_scorer.py
@@ -24,7 +24,6 @@ from archimedes.services.fusion_evaluator import (
     score_turnover_interaction,
 )
 
-
 # ─── Diversification benefit ─────────────────────────────────────────
 
 

--- a/backend/tests/test_generation_gating.py
+++ b/backend/tests/test_generation_gating.py
@@ -9,10 +9,9 @@ minting a session cookie with the same in-process HMAC key the verifier uses.
 
 import time
 
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session, gate_generation
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
-
-from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session, gate_generation
 
 
 def _make_client() -> TestClient:

--- a/backend/tests/test_portfolio_backtester_mc.py
+++ b/backend/tests/test_portfolio_backtester_mc.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-
 # ─── monte_carlo_portfolio ───────────────────────────────────────────
 
 

--- a/backend/tests/test_portfolio_sweep_scenario.py
+++ b/backend/tests/test_portfolio_sweep_scenario.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-
 # ── Shared fixtures ───────────────────────────────────────────
 
 

--- a/backend/tests/test_quant_factories.py
+++ b/backend/tests/test_quant_factories.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+
 from tests import quant_factories as qf
 
 
@@ -86,7 +87,7 @@ class TestFixturesRegistered:
         assert len(rets) == 200
 
     def test_price_panel_fixture(self, price_panel):
-        close, vol = price_panel(["X", "Y"], n=120, seed=2)
+        close, _vol = price_panel(["X", "Y"], n=120, seed=2)
         assert close.shape == (120, 2)
 
     def test_returns_matrix_fixture(self, returns_matrix):

--- a/backend/tests/test_return_diagnostics.py
+++ b/backend/tests/test_return_diagnostics.py
@@ -8,7 +8,6 @@ and non-flaky.
 from __future__ import annotations
 
 import numpy as np
-
 from archimedes.services.return_diagnostics import (
     diagnose,
     ljung_box_test,

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -1213,7 +1213,6 @@ class TestBenjaminiHochbergFDR:
         pvalues = list(rng.uniform(0, 1, 20))
         result = benjamini_hochberg_fdr(pvalues, fdr_level=0.05)
         adj = result["adjusted_pvalues"]
-        sorted_adj = sorted(adj)
         # All adjusted p-values must be in [0,1]
         assert all(0.0 <= p <= 1.0 for p in adj)
 

--- a/backend/tests/test_rigor_regime.py
+++ b/backend/tests/test_rigor_regime.py
@@ -8,7 +8,6 @@ No .env / Redis / DB / network dependence.
 from __future__ import annotations
 
 import numpy as np
-
 from archimedes.services.rigor_evaluator import (
     classify_regimes,
     regime_conditional_dsr,
@@ -99,7 +98,6 @@ def test_classify_regimes_too_short_all_unclassified():
 
 def test_regime_conditional_sharpe_higher_in_strong_regime():
     rng = np.random.default_rng(SEED)
-    n = 200
     labels = np.array([0] * 100 + [1] * 100, dtype=int)
     strat = np.concatenate(
         [

--- a/backend/tests/test_risk_cvar_greeks.py
+++ b/backend/tests/test_risk_cvar_greeks.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-
 # ── Helpers ──────────────────────────────────────────────────
 
 
@@ -181,8 +180,8 @@ async def test_greeks_delta_in_valid_range():
 @pytest.mark.asyncio
 async def test_greeks_portfolio_aggregate_matches_weighted_sum():
     """Two equal-weight strategies with identical params → portfolio_delta equals the single-strategy delta."""
-    from archimedes.main import app
     from archimedes.api.risk_routes import _strategy_delta
+    from archimedes.main import app
 
     sharpe, cagr = 1.2, 0.15
     expected = _strategy_delta(sharpe, cagr)

--- a/backend/tests/test_sharpe_statistics.py
+++ b/backend/tests/test_sharpe_statistics.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import math
 
 import numpy as np
-
 from archimedes.services.sharpe_statistics import (
     autocorr_adjusted_annualized_sharpe,
     iid_sharpe_stderr,


### PR DESCRIPTION
## Summary

Mechanical ruff lint cleanup in `backend/tests/`, no behavior change:

- **F841** (unused local var): remove `k = len(symbols)` in `quant_factories.py`, remove `sorted_adj = sorted(adj)` in `test_rigor_evaluator.py`, remove `n = 200` in `test_rigor_regime.py` — all three were dead assignments with no side effects.
- **RUF059** (unpacked-but-unused tuple element): `test_dsr_parity.py` — `f_dsr`/`b_dsr` from `fixture_compute_dsr`/`backend_compute_dsr` calls now prefixed `_f_dsr`/`_b_dsr` (the calls themselves are load-bearing — `f_p`/`b_p` are used). `test_quant_factories.py` — `vol` from `price_panel(...)` now `_vol` (the call exercises the fixture; `close` is asserted).
- **I001** (import sort): resolved across 10 files (`test_backtester_profiler.py`, `test_fusion_quality_scorer.py`, `test_generation_gating.py`, `test_portfolio_backtester_mc.py`, `test_portfolio_sweep_scenario.py`, `test_quant_factories.py`, `test_return_diagnostics.py`, `test_rigor_regime.py`, `test_risk_cvar_greeks.py`, `test_sharpe_statistics.py`) via `ruff check --select I --fix`.

Scope confined to `backend/tests/`. `ruff check .` repo-wide shows 14 remaining errors, all pre-existing and entirely outside `backend/tests/` (`analytics-engine/tests/`, `backend/archimedes/api/strategies_routes.py`, `backend/archimedes/services/{_fusion_helpers,_rigor_helpers,fusion_evaluator,portfolio_backtester,portfolio_optimizer}.py`) — not touched by this PR.

## Test plan

```
ruff check backend/tests/                         # All checks passed!
ruff format --check backend/tests/                # 92 files already formatted

pytest backend/tests/test_rigor_evaluator.py backend/tests/test_rigor_regime.py \
       backend/tests/test_dsr_parity.py backend/tests/test_quant_factories.py \
       backend/tests/test_backtester_profiler.py backend/tests/test_fusion_quality_scorer.py \
       backend/tests/test_generation_gating.py -q
# → 217 passed, 2 warnings in 1.14s
```