### PR TITLE
Guard Max-Sharpe against bearish-market volatility maximization

### DIFF
--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -327,7 +327,20 @@ def _max_sharpe(
     n: int,
     cap: float,
 ) -> np.ndarray | None:
-    """Max Sharpe: maximize (μ-rf)'w / sqrt(w'Σw)  s.t. 1'w=1, 0 ≤ w ≤ cap."""
+    """Max Sharpe: maximize (μ-rf)'w / sqrt(w'Σw)  s.t. 1'w=1, 0 ≤ w ≤ cap.
+
+    Bearish-market guard: when every asset's expected return is at or below
+    the risk-free rate (``max(mu) <= _RF_DAILY``), the numerator ``w·μ - rf``
+    is <= 0 for every feasible w. Minimizing ``-(excess / vol)`` with
+    excess <= 0 then PUSHES vol UP (toward the least-negative ratio) — the
+    solver deliberately picks the highest-volatility corner of the simplex,
+    the opposite of prudent during a downturn. Short-circuit to the Global
+    Minimum Variance portfolio instead, which is the textbook fallback when
+    no asset offers a positive risk premium.
+    """
+    if float(np.max(mu)) <= _RF_DAILY:
+        return _gmv(Sigma, n, cap)
+
     w0 = np.ones(n) / n
     constraints = [{"type": "eq", "fun": lambda w: float(np.sum(w)) - 1.0}]
     bounds = [(0.0, cap)] * n

--- a/backend/tests/test_portfolio_optimizer.py
+++ b/backend/tests/test_portfolio_optimizer.py
@@ -318,6 +318,40 @@ class TestMaxSharpe:
         assert w is not None
         assert np.all(w <= cap + 1e-6)
 
+    def test_bearish_excess_returns_falls_back_to_gmv(self):
+        # Every asset's expected return is at/below the risk-free rate
+        # (mu == 0 << _RF_DAILY). Without the bearish guard, neg_sharpe's
+        # numerator (excess = w·mu - rf) is negative for every feasible w,
+        # so minimizing -(excess/vol) PUSHES VOL UP — the solver would pick
+        # the highest-volatility corner of the simplex. The guard must
+        # short-circuit to _gmv instead.
+        rng = np.random.default_rng(7)
+        X = rng.normal(0, [0.01, 0.01, 0.05], (200, 3))
+        mu = np.zeros(3)  # mu <= _RF_DAILY for every asset
+        Sigma = np.cov(X.T) + np.eye(3) * 1e-8
+
+        w_sharpe = _max_sharpe(mu, Sigma, 3, cap=_CAP_DEFAULT)
+        w_gmv = _gmv(Sigma, 3, cap=_CAP_DEFAULT)
+
+        assert w_sharpe is not None
+        assert w_gmv is not None
+        np.testing.assert_allclose(w_sharpe, w_gmv)
+
+    def test_slightly_negative_mu_also_falls_back_to_gmv(self):
+        # max(mu) strictly below _RF_DAILY (small negative drift across the
+        # board) must also trigger the GMV fallback, not just the mu==0 case.
+        rng = np.random.default_rng(8)
+        X = rng.normal(0, [0.01, 0.02, 0.03], (200, 3))
+        mu = np.array([-0.0005, -0.0003, -0.0001])  # all << _RF_DAILY
+        Sigma = np.cov(X.T) + np.eye(3) * 1e-8
+
+        w_sharpe = _max_sharpe(mu, Sigma, 3, cap=_CAP_DEFAULT)
+        w_gmv = _gmv(Sigma, 3, cap=_CAP_DEFAULT)
+
+        assert w_sharpe is not None
+        assert w_gmv is not None
+        np.testing.assert_allclose(w_sharpe, w_gmv)
+
 
 # ---------------------------------------------------------------------------
 # Section 8 — TestMaxExpectedReturn


### PR DESCRIPTION
## Summary

`_max_sharpe` (`backend/archimedes/services/portfolio_optimizer.py:324-351`)
minimizes `-(w·μ - rf) / sqrt(w'Σw)` (`neg_sharpe`, line 335-338).

When `max(mu) <= _RF_DAILY` (every asset's expected return is at or below the
risk-free rate, `_RF_DAILY = 0.05 / 252` at line 34) — i.e. a bearish
environment where no asset offers a positive risk premium — `excess = w·mu -
rf` is `<= 0` for every feasible `w`. To minimize `neg_sharpe = -(excess /
vol)` with `excess <= 0`, the optimizer wants `excess / vol` as large as
possible (least negative), which means it deliberately **increases** `vol`.
Result: during a downturn the "Max Sharpe" solver picks the
highest-volatility corner of the feasible simplex — the opposite of prudent —
instead of falling back to the textbook Global Minimum Variance (GMV)
portfolio.

`_max_sharpe` now guards `max(mu) <= _RF_DAILY` at the top of the function and
short-circuits to `_gmv(Sigma, n, cap)` (the existing GMV solver, line
304-321) in that case. Since the six call sites (the `optimize_weights`
dispatcher at lines ~199-200, and the Black-Litterman fallback paths at
564/571/587/591/594) all funnel through `_max_sharpe`, the guard covers all
of them transparently — no caller-side changes needed.

## Test plan

Added two regression tests to `TestMaxSharpe` in
`backend/tests/test_portfolio_optimizer.py`:

- `test_bearish_excess_returns_falls_back_to_gmv` — `mu = [0, 0, 0]` (well
  below `_RF_DAILY`), asserts `_max_sharpe(...)` weights are `np.allclose` to
  `_gmv(...)` weights for the same `Sigma`/`n`/`cap`.
- `test_slightly_negative_mu_also_falls_back_to_gmv` — small negative `mu`
  across all assets (still `< _RF_DAILY`), same assertion.

Existing genuinely-positive-excess tests (`test_max_sharpe_converges`,
`test_higher_mu_asset_gets_more_weight`, `test_cap_enforced`) are unchanged
and continue to pass — they all use `mu` from `rng.normal(0.0005 or 0.001,
...)`, which is well above `_RF_DAILY ≈ 0.000198`.

Ran:

```
source /opt/homebrew/Caskroom/miniconda/base/etc/profile.d/conda.sh && conda activate archimedes
pytest backend/tests/test_portfolio_optimizer.py -q
```

Result: `82 passed, 0 failed` (was 80 before this change).

Also ran the hermetic gate (no `.env`, no live services) and the project's
ruff format/lint gates on the two changed files — both clean.