### PR TITLE
[deps] Bump aiohttp floor and pin tornado to close 3 CVEs

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,9 @@ scipy>=1.13
 # Market data
 yfinance>=1.4.1
 requests>=2.32
-aiohttp>=3.13.5
+# Bumped from 3.13.5 to close CVE-2026-34993 / CVE-2026-47265 (HTTP parser
+# DoS/smuggling).
+aiohttp>=3.14.0
 # httpx is directly imported by services/corpus_service.py (arXiv intake) and
 # services/llm_backend.py (OpenAI-compatible + Ollama backends). Pinned directly
 # so we don't rely on it arriving transitively via anthropic/fastapi.

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
       # --- Market data ---
       - yfinance>=1.4.1              # Historical + live equity/ETF/crypto data; for backtesting
       - requests>=2.32
-      - aiohttp>=3.13.5               # Floor aligned with backend/requirements.txt via dependabot PR #250.
+      - aiohttp>=3.14.0                # Bumped from 3.13.5 to close CVE-2026-34993 / CVE-2026-47265 (HTTP parser DoS/smuggling). Floor aligned with backend/requirements.txt.
       - httpx>=0.27                   # Directly imported by services/corpus_service.py (arXiv intake) and services/llm_backend.py (OpenAI-compatible + Ollama). Pinned so we don't rely on transitive resolution.
 
       # --- Backtesting (per backtrader-vs-vectorbt decision memo) ---
@@ -73,3 +73,4 @@ dependencies:
       # --- Dev convenience ---
       - ipython>=8.27
       - jupyter>=1.1                  # For exploratory strategy work
+      - tornado>=6.5.6                # Pinned directly to close CVE-2026-49854 (WebSocket frame-length overflow) in jupyter's transitive tornado dep. environment.yml-only: tornado is a dev/notebook dependency, not imported by backend runtime code (not in backend/requirements.txt).


### PR DESCRIPTION
## Summary

- **aiohttp**: the current floor `>=3.13.5` is itself vulnerable. `3.13.5` carries **CVE-2026-34993** and **CVE-2026-47265** (HTTP parser issues — possible request smuggling / DoS). Bump the floor to `>=3.14.0` in both `environment.yml` and `backend/requirements.txt`, with a comment citing both CVE IDs (mirroring the existing `starlette>=1.0.1` pin's comment style).
- **tornado**: a transitive dependency via `jupyter`/`ipython`, not currently pinned anywhere. `6.5.5` carries **CVE-2026-49854** (WebSocket frame-length overflow), fixed in `6.5.6`. Add a direct `tornado>=6.5.6` pin to `environment.yml` only, near the `jupyter`/`ipython` dev dependencies.
  - `environment.yml`-only is intentional: tornado is a dev/notebook dependency (transitive via jupyter), not imported by backend runtime code. Confirmed with `grep -rn "^import tornado\|^from tornado" backend/` → no matches, and `grep -rn tornado backend/requirements.txt` → no matches.

This follows the existing `starlette>=1.0.1` precedent documented in `CLAUDE.md`: "Pin transitively-vulnerable deps directly when CVEs warrant it" and "keep `environment.yml` and `backend/requirements.txt` aligned."

## Test plan

Pure dependency-floor edit — no code changes, no test suite changes. Verified via:

- `git diff` — minimal, surgical line edits to `environment.yml` and `backend/requirements.txt` (5 insertions, 2 deletions across both files), matching existing comment style and indentation.
- `grep -rn "^import tornado\|^from tornado" backend/` → empty (confirms tornado is dev-only, justifying the `environment.yml`-only scope).
- `grep -rn tornado environment.yml backend/requirements.txt` → only the new `environment.yml` line (confirms tornado was previously unpinned).
- PyPI index check (`pip3 index versions aiohttp` / `pip3 index versions tornado`) confirms `3.14.0` and `6.5.6` are real published versions (newer `3.14.1` / `6.5.7` also exist now, but the floors per this issue's spec are `3.14.0` / `6.5.6`). The CVE database remains the source of truth regardless of PyPI-index reachability.