### PR TITLE
[backend] Guard decrypt_email InvalidToken in GET /api/user/profile

### DIFF
--- a/backend/archimedes/api/user_routes.py
+++ b/backend/archimedes/api/user_routes.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 
+from cryptography.fernet import InvalidToken
 from fastapi import APIRouter, HTTPException, Request, Response
 from sqlalchemy.orm import Session
 
@@ -55,10 +56,19 @@ def _profile_to_response(p: UserProfile, *, owner: bool = False) -> UserProfileR
             marketing_opt_in=False,  # default-safe
         )
 
+    try:
+        email = decrypt_email(p.email)
+    except InvalidToken:
+        # Ciphertext can't be decrypted with the current EMAIL_ENCRYPTION_KEY
+        # (e.g. a key rotation left old tokens unreadable). Degrade to a null
+        # email rather than 500ing the whole profile for this wallet.
+        logger.warning("decrypt_email failed for wallet=%s: InvalidToken", p.wallet_address)
+        email = None
+
     return UserProfileResponse(
         wallet_address=p.wallet_address,
         display_name=p.display_name,
-        email=decrypt_email(p.email),
+        email=email,
         interests=interests,
         attribution=p.attribution,
         marketing_opt_in=p.marketing_opt_in,

--- a/backend/tests/test_user_routes.py
+++ b/backend/tests/test_user_routes.py
@@ -10,6 +10,7 @@ Auth model (Issue #181 + Issue #402):
 
 from __future__ import annotations
 
+import logging
 import time
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ import pytest
 from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
 from archimedes.db import get_session
 from archimedes.models.user_profile import UserProfile
+from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
 
 # Unique wallets per test to avoid slowapi rate-limit collisions.
@@ -26,6 +28,7 @@ _W_CHARLIE = "0x3333333333333333333333333333333333333333"
 _W_UPDATE = "0x4444444444444444444444444444444444444444"
 _W_MINIMAL = "0x0000000000000000000000000000000000000002"
 _W_CASE = "0x5555555555555555555555555555555555555555"
+_W_ROTATED_KEY = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 
 
 def _siwe_cookies(wallet: str) -> dict[str, str]:
@@ -263,6 +266,59 @@ class TestUserProfileRoutes:
         )
         assert res.status_code == 200
         assert res.json()["email"] == "owner@example.com"
+
+    def test_owner_get_survives_undecryptable_email(self, client, caplog):
+        """GET /api/user/profile must not 500 when stored ciphertext can't be
+        decrypted with the current EMAIL_ENCRYPTION_KEY (e.g. after a key
+        rotation leaves old tokens unreadable).
+
+        Asserts: HTTP 200, email field is null, and a warning is logged
+        (without leaking the ciphertext or any decrypted value).
+        """
+        client.post(
+            "/api/user/profile",
+            json={
+                "wallet_address": _W_ROTATED_KEY,
+                "display_name": "RotatedKeyUser",
+                "email": "rotated@example.com",
+            },
+            cookies=_siwe_cookies(_W_ROTATED_KEY),
+        )
+
+        # Simulate a key rotation: overwrite the stored ciphertext with a
+        # token encrypted under a DIFFERENT Fernet key. This is
+        # well-formed Fernet ciphertext (so it parses) but raises
+        # InvalidToken when decrypted with the app's actual key.
+        other_key_token = Fernet(Fernet.generate_key()).encrypt(b"rotated@example.com").decode("utf-8")
+        session = get_session()
+        try:
+            profile = session.query(UserProfile).filter(UserProfile.wallet_address == _W_ROTATED_KEY.lower()).first()
+            assert profile is not None
+            profile.email = other_key_token
+            session.commit()
+        finally:
+            session.close()
+
+        with caplog.at_level(logging.WARNING, logger="archimedes.api.user_routes"):
+            res = client.get(
+                f"/api/user/profile/{_W_ROTATED_KEY}",
+                cookies=_siwe_cookies(_W_ROTATED_KEY),
+            )
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["email"] is None, "Undecryptable email must degrade to null, not 500"
+        assert data["display_name"] == "RotatedKeyUser", "Non-PII-encrypted fields must still be returned"
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("decrypt_email failed" in r.getMessage() for r in warnings), (
+            "Expected a warning log for the failed decrypt"
+        )
+        for r in warnings:
+            msg = r.getMessage()
+            assert other_key_token not in msg, "Warning must not leak ciphertext"
+            assert "rotated@example.com" not in msg, "Warning must not leak decrypted value"
+            assert _W_ROTATED_KEY.lower() in msg, "Warning should identify the affected wallet"
 
     def test_header_spoof_does_not_reveal_pii(self, client):
         """X-Wallet-Address header alone must NOT reveal PII — SIWE session required."""


### PR DESCRIPTION
## Summary

`backend/archimedes/api/user_routes.py:61` (`_profile_to_response`) called
`decrypt_email(p.email)` with no exception handling. `decrypt_email` (in
`backend/archimedes/services/email_crypto.py`) wraps `cryptography.fernet.Fernet.decrypt`,
which raises `InvalidToken` when the ciphertext can't be decrypted with the
current Fernet key — e.g. after an `EMAIL_ENCRYPTION_KEY` rotation leaves old
ciphertext undecryptable, or if the stored token is simply corrupted.

An `InvalidToken` here bubbled all the way out of `get_profile`, turning
`GET /api/user/profile/{wallet}` into a permanent 500 for that user's owner
view — no recovery short of re-encrypting their email.

**Fix:** wrap the `decrypt_email(p.email)` call in
`try/except cryptography.fernet.InvalidToken`, matching the
`logger.warning("<context> for <id> (non-fatal): %s", ...)` style already used
for non-fatal degradations in `vaults_routes.py:64` and `corpus_routes.py:48`.
On failure: log `logger.warning("decrypt_email failed for wallet=%s: InvalidToken", p.wallet_address)`
(wallet address only — never the ciphertext or any decrypted value, per the
`log_scrubber` PII discipline already enforced in this file) and set the
response's `email` field to `None` instead of propagating the exception.

Ref: `docs/audits/2026-06-14-gpt-oss-findings-verified.md` § 3c.

## Test plan

Added `TestUserProfileRoutes::test_owner_get_survives_undecryptable_email` in
`backend/tests/test_user_routes.py`, using the existing `_siwe_cookies(wallet)`
helper for a real signed owner session. The test creates a profile via the
normal POST flow, then directly overwrites the stored `email` ciphertext with
a token encrypted under a *different* Fernet key (well-formed Fernet
ciphertext that raises `InvalidToken` under the app's actual key — simulating
a key rotation). It then asserts:

- `GET /api/user/profile/{wallet}` (owner session) → HTTP 200 (not 500)
- `email` field is `null`
- other fields (e.g. `display_name`) are still returned normally
- a `WARNING`-level log containing `"decrypt_email failed"` and the wallet
  address was emitted (via `caplog`), and does **not** contain the ciphertext
  or the plaintext email

Command run:
```
pytest backend/tests/test_user_routes.py -q
```
Result: `19 passed, 0 failed`.

Also ran the hermetic gate (no `.env`, stripped env vars):
```
env -i HOME=$HOME PATH=<conda-bin>:/usr/bin:/bin PYTHONPATH=backend python -m pytest backend/tests/test_user_routes.py -q
```
Result: `19 passed, 0 failed`.

And the adjacent privacy suite together:
```
pytest backend/tests/test_user_profile_privacy.py backend/tests/test_user_routes.py -q
```
Result: `31 passed, 0 failed`.

`ruff format --check` and `ruff check` on both changed files: all checks
passed.