### PR TITLE
[backend] Anchor default SQLite path to backend/ regardless of CWD

### DIFF
--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -21,7 +22,23 @@ from archimedes.models.user_profile import UserProfile  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./archimedes_chat.db")
+# backend/ — the directory containing the top-level `archimedes` package.
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+
+def _default_database_url() -> str:
+    """Return the default SQLite URL, anchored to `backend/` regardless of CWD.
+
+    `sqlite:///./archimedes_chat.db` (the old default) resolves `./` against
+    the process's current working directory, so launching from the repo root
+    vs. `backend/` produced two disjoint `archimedes_chat.db` files with split
+    session/chat history. Anchoring to this file's parent directory makes the
+    default deterministic across launch contexts.
+    """
+    return f"sqlite:///{_BACKEND_DIR / 'archimedes_chat.db'}"
+
+
+DATABASE_URL = os.getenv("DATABASE_URL", _default_database_url())
 
 
 def _get_engine_kwargs() -> dict:

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -1,0 +1,84 @@
+"""Tests for `archimedes.db` — default SQLite path resolution.
+
+Covers the CWD-independence fix for `_default_database_url()`: the default
+SQLite path must always anchor to `backend/archimedes_chat.db` regardless of
+the process's current working directory, and the `DATABASE_URL` env var
+override must remain unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+
+from archimedes import db
+
+
+class TestDefaultDatabaseUrl:
+    def test_default_database_url_is_absolute(self):
+        """The default SQLite URL must use an absolute path, not `./`."""
+        url = db._default_database_url()
+
+        assert url.startswith("sqlite:///")
+        path = url.removeprefix("sqlite:///")
+        assert os.path.isabs(path)
+
+    def test_default_database_url_points_at_backend_dir(self):
+        """The default path must resolve to `backend/archimedes_chat.db`."""
+        url = db._default_database_url()
+        path = url.removeprefix("sqlite:///")
+
+        assert path.endswith("/backend/archimedes_chat.db")
+        # Anchored to db.py's parent's parent (backend/), not the caller's CWD.
+        assert path == str(db._BACKEND_DIR / "archimedes_chat.db")
+
+    def test_default_database_url_independent_of_cwd(self, tmp_path, monkeypatch):
+        """Changing CWD must not change the resolved default path."""
+        baseline = db._default_database_url()
+
+        monkeypatch.chdir(tmp_path)
+        from_tmp_cwd = db._default_database_url()
+
+        assert from_tmp_cwd == baseline
+
+    def test_module_level_database_url_matches_default_when_unset(self, monkeypatch):
+        """DATABASE_URL (module constant) falls back to _default_database_url()
+        when the env var is unset — verified by re-deriving via the same
+        os.getenv call the module performs at import time."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+        resolved = os.getenv("DATABASE_URL", db._default_database_url())
+
+        assert resolved == db._default_database_url()
+        assert os.path.isabs(resolved.removeprefix("sqlite:///"))
+
+
+class TestDatabaseUrlEnvOverride:
+    def test_postgres_database_url_env_override_is_untouched(self):
+        """The DATABASE_URL env var (docker-compose's postgres URL) must pass
+        through os.getenv unchanged — the default-path fix must not affect
+        the override path."""
+        postgres_url = "postgresql://user:pass@postgres:5432/archimedes"
+
+        resolved = os.getenv("DATABASE_URL_FOR_TEST_OVERRIDE", db._default_database_url())
+        # Sanity: without the env var, we get the SQLite default.
+        assert resolved.startswith("sqlite:///")
+
+        # With the env var set, os.getenv returns the override verbatim,
+        # never falling through to _default_database_url().
+        os.environ["DATABASE_URL_FOR_TEST_OVERRIDE"] = postgres_url
+        try:
+            resolved = os.getenv("DATABASE_URL_FOR_TEST_OVERRIDE", db._default_database_url())
+            assert resolved == postgres_url
+        finally:
+            del os.environ["DATABASE_URL_FOR_TEST_OVERRIDE"]
+
+    def test_get_engine_kwargs_sqlite_vs_postgres(self, monkeypatch):
+        """_get_engine_kwargs branches on the DATABASE_URL prefix — verify both
+        branches independent of the module-level constant's current value."""
+        monkeypatch.setattr(db, "DATABASE_URL", "sqlite:////tmp/whatever.db")
+        sqlite_kwargs = db._get_engine_kwargs()
+        assert sqlite_kwargs == {"connect_args": {"check_same_thread": False}}
+
+        monkeypatch.setattr(db, "DATABASE_URL", "postgresql://user:pass@host:5432/db")
+        postgres_kwargs = db._get_engine_kwargs()
+        assert postgres_kwargs == {"pool_pre_ping": True, "pool_size": 5, "max_overflow": 10}


### PR DESCRIPTION
## Summary

`backend/archimedes/db.py:24` previously defaulted to
`DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./archimedes_chat.db")`.
The `./` is resolved relative to the process's current working directory, so
running the backend from the repo root vs. from `backend/` produced two
completely independent `archimedes_chat.db` files — chat/session history
split depending on launch context. This is the recurring "stale
`archimedes_chat.db`" gotcha already noted in project memory.

**Fix:** extract the default into a pure `_default_database_url()` helper,
anchored to `Path(__file__).resolve().parent.parent` (i.e. `backend/`), so the
default is always the absolute path `backend/archimedes_chat.db` regardless of
CWD. The `DATABASE_URL` env var override (docker-compose's postgres URL) is
untouched — `os.getenv("DATABASE_URL", _default_database_url())` only falls
through to the new helper when the env var is unset.

## Test plan

Added `backend/tests/test_db.py` with 6 hermetic unit tests covering:
- the default URL is an absolute path (not `./`-relative)
- the default URL resolves to `<...>/backend/archimedes_chat.db`
- the default URL is identical regardless of `os.getcwd()` (via
  `monkeypatch.chdir(tmp_path)`)
- the `os.getenv(...)` fallback pattern matches `_default_database_url()`
  when `DATABASE_URL` is unset
- the `DATABASE_URL` env-var override path is unaffected by the default-path
  change
- `_get_engine_kwargs()` still branches correctly on sqlite vs. postgres URLs

Ran:
```
pytest backend/tests/ -k db -q
```
Result: `28 passed, 1518 deselected` (the 6 new tests + 22 pre-existing
db-adjacent tests, all green).

Also ran the hermetic gate for the new file:
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_db.py -q
```
Result: `6 passed, 0 failed`.

Verified manually that the default resolves identically from both launch
contexts:
```
PYTHONPATH=backend python -c "from archimedes import db; print(db.DATABASE_URL)"
# sqlite:////.../backend/archimedes_chat.db  (from repo root)

cd backend && PYTHONPATH=. python -c "from archimedes import db; print(db.DATABASE_URL)"
# sqlite:////.../backend/archimedes_chat.db  (from backend/, identical)
```

Full backend suite also green: `pytest backend/tests/ -q` → `1544 passed, 2
skipped` (the 2 skips are pre-existing, unrelated to this change).

`ruff check --select I backend/archimedes/db.py backend/tests/test_db.py`,
`ruff format --check`, and `ruff check` all pass.