### PR TITLE
Back SIWE pending-nonce store with Redis for multi-worker auth

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -38,6 +38,10 @@ auth_router = APIRouter(prefix="/api/auth", tags=["auth"])
 # Session signing key — derived from EMAIL_ENCRYPTION_KEY or a random per-boot key.
 # In production, EMAIL_ENCRYPTION_KEY is required (fail-closed in main.py), so
 # sessions persist across restarts. In dev, a random key means sessions reset on restart.
+# Multi-worker note: main.py:~127 raises RuntimeError at boot if PUBLIC_DOMAIN is set
+# (production) and EMAIL_ENCRYPTION_KEY is unset, so the secrets.token_hex(32) fallback
+# is only reachable in single-worker local dev -- per-worker secret divergence (which
+# would break cross-worker session-cookie verification) can't occur there.
 _SESSION_SECRET = os.getenv("EMAIL_ENCRYPTION_KEY", secrets.token_hex(32))
 _SESSION_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 _NONCE_TTL_SECONDS = 300  # 5 minutes
@@ -49,8 +53,10 @@ _CLOCK_SKEW_SECONDS = 120  # tolerate small client/server clock drift on Issued 
 _EXPECTED_DOMAIN = os.getenv("PUBLIC_DOMAIN", "https://archimedes-arc.app")
 _EXPECTED_CHAIN_ID = int(os.getenv("ARC_CHAIN_ID", "5042002"))
 
-# In-memory nonce store. Production would use Redis, but for the hackathon
-# this is sufficient — nonces are short-lived (5 min TTL) and single-use.
+# Pending-nonce store: Redis-backed (via AgentStateStore) so /nonce and /verify
+# agree across Uvicorn workers, with this in-memory dict as a same-process
+# fallback when Redis is unreachable (single-worker local dev keeps working
+# exactly as before). nonce → expiry timestamp.
 _pending_nonces: dict[str, float] = {}  # nonce → expiry timestamp
 
 _COOKIE_NAME = "archimedes_session"
@@ -134,15 +140,30 @@ def gate_generation(request: Request) -> str | None:
 
 @auth_router.get("/nonce")
 async def get_nonce():
-    """Issue a challenge nonce for SIWE signing."""
-    # Clean expired nonces
-    now = time.time()
-    expired = [n for n, exp in _pending_nonces.items() if exp < now]
-    for n in expired:
-        del _pending_nonces[n]
+    """Issue a challenge nonce for SIWE signing.
 
+    Stored in Redis (via AgentStateStore) with a TTL so /verify on a
+    different worker can find it -- Redis handles expiry via SETEX, so no
+    manual sweep is needed on that path. Falls back to the in-process
+    `_pending_nonces` dict if Redis is unreachable (single-worker local dev).
+    """
+    now = time.time()
     nonce = secrets.token_hex(16)
-    _pending_nonces[nonce] = now + _NONCE_TTL_SECONDS
+
+    from archimedes.services.redis_state import AgentStateStore
+
+    state = AgentStateStore()
+    try:
+        await state.save_nonce(nonce, _NONCE_TTL_SECONDS)
+    except Exception as exc:
+        logger.debug("SIWE nonce store unavailable, using in-process fallback: %s", exc)
+        # Clean expired nonces from the in-memory fallback before adding a new one.
+        expired = [n for n, exp in _pending_nonces.items() if exp < now]
+        for n in expired:
+            del _pending_nonces[n]
+        _pending_nonces[nonce] = now + _NONCE_TTL_SECONDS
+    finally:
+        await state.close()
 
     return {
         "nonce": nonce,
@@ -224,12 +245,33 @@ async def verify_signature(request: Request, response: Response):
     if age > timedelta(seconds=_NONCE_TTL_SECONDS) or age < timedelta(seconds=-_CLOCK_SKEW_SECONDS):
         raise HTTPException(status_code=401, detail="SIWE message issued-at outside the valid window")
 
-    # Verify nonce is pending and not expired
-    expiry = _pending_nonces.pop(nonce, None)
-    if expiry is None:
+    # Verify nonce is pending and not expired. Redis (GETDEL) makes this
+    # read-and-delete atomic and shared across workers; Redis-managed TTL means
+    # a "found" result is by construction unexpired, so no separate expiry
+    # check is needed on that path. Falls back to the in-process dict (with
+    # its own expiry timestamp) if Redis is unreachable.
+    from archimedes.services.redis_state import AgentStateStore
+
+    state = AgentStateStore()
+    try:
+        found = await state.pop_nonce(nonce)
+    except Exception as exc:
+        logger.debug("SIWE nonce store unavailable, using in-process fallback: %s", exc)
+        found = False
+        redis_unreachable = True
+    else:
+        redis_unreachable = False
+    finally:
+        await state.close()
+
+    if not found and redis_unreachable:
+        expiry = _pending_nonces.pop(nonce, None)
+        if expiry is None:
+            raise HTTPException(status_code=401, detail="Nonce not found or already used")
+        if time.time() > expiry:
+            raise HTTPException(status_code=401, detail="Nonce expired")
+    elif not found:
         raise HTTPException(status_code=401, detail="Nonce not found or already used")
-    if time.time() > expiry:
-        raise HTTPException(status_code=401, detail="Nonce expired")
 
     # Recover the signer address from the signature
     try:

--- a/backend/archimedes/services/redis_state.py
+++ b/backend/archimedes/services/redis_state.py
@@ -25,6 +25,7 @@ KEY_HEARTBEAT = "archimedes:agent:heartbeat"
 KEY_LAST_REBALANCE_PREFIX = "archimedes:agent:last_rebalance:"
 KEY_TRACE_PREFIX = "archimedes:trace:"
 KEY_TRACE_INDEX = "archimedes:trace:index"
+KEY_SIWE_NONCE_PREFIX = "archimedes:auth:nonce:"
 
 
 class AgentStateStore:
@@ -272,6 +273,27 @@ class AgentStateStore:
         """Total number of stored off-chain traces."""
         r = await self._get_redis()
         return await r.zcard(KEY_TRACE_INDEX)
+
+    # ─── SIWE Nonces ────────────────────────────────────────────────
+
+    async def save_nonce(self, nonce: str, ttl_seconds: int) -> None:
+        """Store a SIWE challenge nonce with a Redis-managed expiry.
+
+        Using SETEX means Redis itself evicts expired nonces -- no manual
+        sweep needed. Shared across workers so /nonce on one worker and
+        /verify on another see the same pending-nonce set.
+        """
+        r = await self._get_redis()
+        await r.setex(f"{KEY_SIWE_NONCE_PREFIX}{nonce}", ttl_seconds, "1")
+
+    async def pop_nonce(self, nonce: str) -> bool:
+        """Atomically read-and-delete a pending nonce. Returns True if it existed.
+
+        GETDEL makes the nonce single-use: a second pop for the same value
+        returns False, matching the "Nonce not found or already used" check.
+        """
+        r = await self._get_redis()
+        return await r.getdel(f"{KEY_SIWE_NONCE_PREFIX}{nonce}") is not None
 
     # ─── Lifecycle ────────────────────────────────────────────────
 

--- a/backend/tests/services/test_redis_state.py
+++ b/backend/tests/services/test_redis_state.py
@@ -22,6 +22,7 @@ from archimedes.services.redis_state import (
     KEY_HEARTBEAT,
     KEY_LAST_REBALANCE_PREFIX,
     KEY_REGIME,
+    KEY_SIWE_NONCE_PREFIX,
     KEY_TRACE_INDEX,
     AgentStateStore,
 )
@@ -32,6 +33,8 @@ def _fake_redis() -> MagicMock:
     r = MagicMock()
     r.get = AsyncMock(return_value=None)
     r.set = AsyncMock()
+    r.setex = AsyncMock()
+    r.getdel = AsyncMock(return_value=None)
     r.lpush = AsyncMock()
     r.ltrim = AsyncMock()
     r.lrange = AsyncMock(return_value=[])
@@ -151,6 +154,36 @@ class TestLastRebalance:
     async def test_get_returns_none_when_missing(self) -> None:
         store, _ = await _store_with_fake_redis()
         assert await store.get_last_rebalance("0xV") is None
+
+
+class TestSiweNonces:
+    @pytest.mark.asyncio
+    async def test_save_nonce_setex_with_ttl(self) -> None:
+        store, fake = await _store_with_fake_redis()
+        await store.save_nonce("abc123", 300)
+        fake.setex.assert_awaited_once_with(f"{KEY_SIWE_NONCE_PREFIX}abc123", 300, "1")
+
+    @pytest.mark.asyncio
+    async def test_pop_nonce_present_returns_true(self) -> None:
+        store, fake = await _store_with_fake_redis()
+        fake.getdel.return_value = "1"
+        assert await store.pop_nonce("abc123") is True
+        fake.getdel.assert_awaited_once_with(f"{KEY_SIWE_NONCE_PREFIX}abc123")
+
+    @pytest.mark.asyncio
+    async def test_pop_nonce_missing_returns_false(self) -> None:
+        store, fake = await _store_with_fake_redis()
+        fake.getdel.return_value = None
+        assert await store.pop_nonce("abc123") is False
+
+    @pytest.mark.asyncio
+    async def test_pop_nonce_is_single_use(self) -> None:
+        """GETDEL semantics: a second pop for the same key returns False
+        once Redis has deleted it (simulated here via side_effect)."""
+        store, fake = await _store_with_fake_redis()
+        fake.getdel = AsyncMock(side_effect=["1", None])
+        assert await store.pop_nonce("abc123") is True
+        assert await store.pop_nonce("abc123") is False
 
 
 class TestEvents:

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import time
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from archimedes.api.auth_siwe import (
@@ -417,3 +417,196 @@ async def test_verify_rejects_message_missing_chain_id():
         resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
     assert resp.status_code == 400
     assert "Chain ID" in resp.json()["detail"]
+
+
+# ── Redis-backed nonce store (multi-worker support) ─────────────
+
+
+class _FakeRedisNonceStore:
+    """In-memory stand-in for the Redis keyspace AgentStateStore.save_nonce /
+    pop_nonce write to. A single instance shared across two separately
+    constructed AgentStateStore patches simulates "two workers, one Redis" --
+    the scenario the real fix is for."""
+
+    def __init__(self):
+        self._nonces: set[str] = set()
+
+    async def save_nonce(self, nonce: str, ttl_seconds: int) -> None:
+        self._nonces.add(nonce)
+
+    async def pop_nonce(self, nonce: str) -> bool:
+        if nonce in self._nonces:
+            self._nonces.discard(nonce)
+            return True
+        return False
+
+
+@pytest.mark.asyncio
+async def test_nonce_survives_across_separate_store_instances():
+    """A nonce issued through one AgentStateStore instance is verifiable
+    through a *different* instance against the same backing store --
+    the multi-worker scenario. Asserts the in-process `_pending_nonces`
+    fallback dict is untouched, proving the Redis-backed path was used.
+    """
+    from archimedes.main import app
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+
+    fake_store = _FakeRedisNonceStore()
+    acct = Account.create()
+
+    with (
+        patch("archimedes.services.redis_state.AgentStateStore.save_nonce", fake_store.save_nonce),
+        patch("archimedes.services.redis_state.AgentStateStore.pop_nonce", fake_store.pop_nonce),
+        patch("archimedes.services.redis_state.AgentStateStore.close", AsyncMock(return_value=None)),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            nonce_resp = await client.get("/api/auth/nonce")
+            assert nonce_resp.status_code == 200
+            nonce_data = nonce_resp.json()
+
+            # The nonce landed in the shared fake-Redis store, not the
+            # in-process fallback dict.
+            assert nonce_data["nonce"] in fake_store._nonces
+            assert nonce_data["nonce"] not in _pending_nonces
+
+            message = (
+                f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
+                f"{acct.address.lower()}\n\n"
+                f"Chain ID: 5042002\n"
+                f"Nonce: {nonce_data['nonce']}\n"
+                f"Issued At: {_now_iso()}"
+            )
+            signable = encode_defunct(text=message)
+            signed = acct.sign_message(signable)
+
+            verify_resp = await client.post(
+                "/api/auth/verify",
+                json={"message": message, "signature": signed.signature.hex()},
+            )
+
+    assert verify_resp.status_code == 200
+    data = verify_resp.json()
+    assert data["status"] == "authenticated"
+    assert data["wallet"] == acct.address.lower()
+    # Single-use: the nonce was popped from the shared store.
+    assert nonce_data["nonce"] not in fake_store._nonces
+
+
+@pytest.mark.asyncio
+async def test_nonce_reuse_rejected_via_redis_backed_store():
+    """A nonce already popped from the (fake) Redis store cannot be reused,
+    even across separately-constructed AgentStateStore instances."""
+    from archimedes.main import app
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+
+    fake_store = _FakeRedisNonceStore()
+    acct = Account.create()
+
+    with (
+        patch("archimedes.services.redis_state.AgentStateStore.save_nonce", fake_store.save_nonce),
+        patch("archimedes.services.redis_state.AgentStateStore.pop_nonce", fake_store.pop_nonce),
+        patch("archimedes.services.redis_state.AgentStateStore.close", AsyncMock(return_value=None)),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            nonce_resp = await client.get("/api/auth/nonce")
+            nonce_data = nonce_resp.json()
+
+            message = (
+                f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
+                f"{acct.address.lower()}\n\n"
+                f"Chain ID: 5042002\n"
+                f"Nonce: {nonce_data['nonce']}\n"
+                f"Issued At: {_now_iso()}"
+            )
+            signable = encode_defunct(text=message)
+            signed = acct.sign_message(signable)
+            payload = {"message": message, "signature": signed.signature.hex()}
+
+            resp1 = await client.post("/api/auth/verify", json=payload)
+            assert resp1.status_code == 200
+
+            resp2 = await client.post("/api/auth/verify", json=payload)
+
+    assert resp2.status_code == 401
+    assert "Nonce" in resp2.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_nonce_redis_down_falls_back_to_in_process_dict():
+    """When the Redis-backed store raises (Redis unreachable), /nonce and
+    /verify fall back to the in-process `_pending_nonces` dict -- single-worker
+    local dev keeps working exactly as before this change.
+    """
+    from archimedes.main import app
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+
+    acct = Account.create()
+
+    with (
+        patch(
+            "archimedes.services.redis_state.AgentStateStore.save_nonce",
+            AsyncMock(side_effect=ConnectionError("redis down")),
+        ),
+        patch(
+            "archimedes.services.redis_state.AgentStateStore.pop_nonce",
+            AsyncMock(side_effect=ConnectionError("redis down")),
+        ),
+        patch("archimedes.services.redis_state.AgentStateStore.close", AsyncMock(return_value=None)),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            nonce_resp = await client.get("/api/auth/nonce")
+            assert nonce_resp.status_code == 200
+            nonce_data = nonce_resp.json()
+
+            # Fell back to the in-process dict.
+            assert nonce_data["nonce"] in _pending_nonces
+
+            message = (
+                f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
+                f"{acct.address.lower()}\n\n"
+                f"Chain ID: 5042002\n"
+                f"Nonce: {nonce_data['nonce']}\n"
+                f"Issued At: {_now_iso()}"
+            )
+            signable = encode_defunct(text=message)
+            signed = acct.sign_message(signable)
+
+            verify_resp = await client.post(
+                "/api/auth/verify",
+                json={"message": message, "signature": signed.signature.hex()},
+            )
+
+    assert verify_resp.status_code == 200
+    data = verify_resp.json()
+    assert data["status"] == "authenticated"
+    assert data["wallet"] == acct.address.lower()
+    # Single-use: popped from the in-process fallback dict.
+    assert nonce_data["nonce"] not in _pending_nonces
+
+
+@pytest.mark.asyncio
+async def test_verify_redis_down_unknown_nonce_rejected():
+    """With Redis down and no matching nonce in the in-process fallback dict,
+    /verify still returns 401 (not a 500 from the unhandled ConnectionError)."""
+    from archimedes.main import app
+
+    with (
+        patch(
+            "archimedes.services.redis_state.AgentStateStore.pop_nonce",
+            AsyncMock(side_effect=ConnectionError("redis down")),
+        ),
+        patch("archimedes.services.redis_state.AgentStateStore.close", AsyncMock(return_value=None)),
+    ):
+        message = (
+            "archimedes-arc.app wants you to sign in\n"
+            "0xabcdef1234567890abcdef1234567890abcdef12\n"
+            f"Chain ID: 5042002\nNonce: nonexistentnonce_redisdown\nIssued At: {_now_iso()}"
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
+
+    assert resp.status_code == 401
+    assert "Nonce" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

`_pending_nonces` in `backend/archimedes/api/auth_siwe.py:54` was a process-local
`dict[str, float]` used by `GET /api/auth/nonce` (issue + store) and
`POST /api/auth/verify` (pop + expiry check). Because this dict lives in one
Uvicorn worker's memory, any multi-worker deploy breaks SIWE login: `/nonce`
served by worker A is invisible to `/verify` served by worker B, which returns
`401 Nonce not found or already used` -- a flaky, load-balancer-routing-dependent
failure.

This PR (verified finding 3a in
[`docs/audits/2026-06-14-gpt-oss-findings-verified.md`](docs/audits/2026-06-14-gpt-oss-findings-verified.md#3a-siwe-nonces-are-process-local--real))
backs the nonce store with Redis via `AgentStateStore`:

- **`backend/archimedes/services/redis_state.py`**: new `save_nonce(nonce, ttl_seconds)`
  (SETEX -- Redis manages expiry, no manual sweep needed) and
  `pop_nonce(nonce) -> bool` (GETDEL -- atomic read-and-delete, single-use,
  shared across workers). New key prefix `KEY_SIWE_NONCE_PREFIX`.
- **`backend/archimedes/api/auth_siwe.py`**:
  - `GET /api/auth/nonce` writes through `AgentStateStore.save_nonce`.
  - `POST /api/auth/verify` reads-and-deletes via `AgentStateStore.pop_nonce`.
  - **Redis-down fallback**: if `AgentStateStore` raises (Redis unreachable),
    both endpoints fall back to the existing in-process `_pending_nonces` dict
    -- single-worker local dev keeps working exactly as before, unchanged.
    "Redis down AND multi-worker" remains a pre-existing degradation, not a
    regression from this PR.
  - Comment-only addition near `_SESSION_SECRET` (`auth_siwe.py:~41`)
    documenting why the `secrets.token_hex(32)` random fallback is safe:
    `main.py:~127` already fail-closes (`RuntimeError` at boot) if
    `PUBLIC_DOMAIN` is set (production) and `EMAIL_ENCRYPTION_KEY` is unset, so
    the random-per-worker path is only reachable in single-worker local dev
    where per-worker divergence can't occur. No behavior change.

## Test plan

```
pytest backend/tests/test_auth_siwe.py -q
```
Result: **33 passed, 0 failed**.

Also ran with `backend/tests/services/test_redis_state.py` (new
`TestSiweNonces` class covers `save_nonce`/`pop_nonce` directly against a
mocked Redis client): **62 passed, 0 failed**, 92% coverage on
`auth_siwe.py` / 96% on `redis_state.py`.

New/adapted tests:
- `test_nonce_survives_across_separate_store_instances` -- a nonce issued
  through one `AgentStateStore` instance is verified through a *different*
  instance against a shared fake-Redis backing store (the multi-worker
  scenario), and asserts the in-process `_pending_nonces` dict was untouched.
- `test_nonce_reuse_rejected_via_redis_backed_store` -- single-use enforcement
  via the Redis-backed (GETDEL) path.
- `test_nonce_redis_down_falls_back_to_in_process_dict` -- with
  `AgentStateStore.save_nonce`/`pop_nonce` raising `ConnectionError`, the full
  nonce → sign → verify flow still succeeds via `_pending_nonces`.
- `test_verify_redis_down_unknown_nonce_rejected` -- Redis-down + unknown
  nonce still returns 401 (not a 500 from an unhandled `ConnectionError`).
- Existing single-use/expiry tests (`test_nonce_is_single_use`,
  `test_verify_rejects_expired_nonce`, `test_verify_rejects_unknown_nonce`,
  etc.) pass unchanged -- in this hermetic environment Redis is unreachable so
  they exercise the fallback path, which preserves prior behavior exactly.
- `TestSiweNonces` in `test_redis_state.py` -- direct unit coverage of
  `save_nonce` (SETEX with TTL) and `pop_nonce` (GETDEL, present/missing/
  single-use) against a mocked Redis client.

Ruff format + lint clean on all four touched files.