### PR TITLE
[tests] Add real monotonicity check to BH adjusted p-value test

### DIFF
--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -1213,9 +1213,13 @@ class TestBenjaminiHochbergFDR:
         pvalues = list(rng.uniform(0, 1, 20))
         result = benjamini_hochberg_fdr(pvalues, fdr_level=0.05)
         adj = result["adjusted_pvalues"]
-        sorted_adj = sorted(adj)
         # All adjusted p-values must be in [0,1]
         assert all(0.0 <= p <= 1.0 for p in adj)
+        # adjusted_pvalues is returned in original input order; re-order by
+        # ascending p-value (BH's natural rank order) and check the
+        # running-minimum step enforced non-decreasing values.
+        sorted_adj = [a for _, a in sorted(zip(pvalues, adj, strict=True))]
+        assert all(sorted_adj[i] <= sorted_adj[i + 1] for i in range(len(sorted_adj) - 1))
 
 
 class TestBonferroniCorrection:


### PR DESCRIPTION
## Summary

- `TestBenjaminiHochbergFDR::test_adjusted_pvalues_monotone` claimed (via docstring/name) that BH adjusted p-values are monotone non-decreasing in sorted order, but the body only asserted `0.0 <= p <= 1.0` — a bounds check, not a monotonicity check.
- `benjamini_hochberg_fdr` (`backend/archimedes/services/_rigor_helpers.py`) returns `adjusted_pvalues` in the *original input order*, with monotonicity enforced internally in ascending-p-value (rank) order via a running-minimum step.
- Added an assertion that re-orders `(pvalue, adjusted_pvalue)` pairs by ascending `pvalue` and checks the corresponding adjusted values are non-decreasing in that order, matching the BH step-down adjustment (Benjamini & Hochberg 1995).

## Test plan

- [x] `pytest backend/tests/test_rigor_evaluator.py -q` → 135 passed
- [x] `ruff check backend/tests/test_rigor_evaluator.py` → All checks passed
- [x] `ruff format --check backend/tests/test_rigor_evaluator.py` → 1 file already formatted