### PR TITLE
Fix rigor-gate IS/OOS cliff and DSR num_trials (AUDIT_2026-06-14 Q1/Q2/Q3/Q7/Q11)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -28,6 +28,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import math
 import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -292,27 +293,41 @@ def _rigor_verdict_for(
             "dsr": None,
             "pbo": None,
             "oos_sharpe": None,
+            "in_sample_sharpe": None,
             "lookahead_audit_passed": lookahead_passed,
             "passing": False,
             "reason": "return series too short for rigor evaluation",
         }
     from archimedes.services.rigor_evaluator import (
         compute_dsr,
+        compute_in_sample_sharpe,
         compute_oos_sharpe,
     )
 
     dsr, dsr_p = compute_dsr(return_series, num_trials=max(1, num_trials))
     oos = compute_oos_sharpe(return_series)
+    in_sample_sharpe = compute_in_sample_sharpe(return_series)
     # PBO is library-level (needs ≥2 candidate return series); the caller
     # computes it once over all candidates and patches the verdict below.
     # All four admission primitives gate `passing`: DSR (p ≥ 0.95), OOS Sharpe
-    # (> 0), look-ahead audit (clean), and PBO (< 0.5, patched in _patch_pbo).
-    passing = bool(dsr_p is not None and dsr_p >= 0.95 and oos is not None and oos > 0.0 and lookahead_passed)
+    # (> 0, with no IS/OOS cliff), look-ahead audit (clean), and PBO (< 0.5,
+    # patched in _patch_pbo).
+    oos_pass = oos is not None and oos > 0.0
+    if (
+        oos_pass
+        and in_sample_sharpe is not None
+        and math.isfinite(in_sample_sharpe)
+        and in_sample_sharpe > 0
+        and oos / in_sample_sharpe < 0.5
+    ):
+        oos_pass = False
+    passing = bool(dsr_p is not None and dsr_p >= 0.95 and oos_pass and lookahead_passed)
     return {
         "dsr": round(float(dsr), 4) if dsr is not None else None,
         "dsr_p_value": round(float(dsr_p), 4) if dsr_p is not None else None,
         "pbo": None,  # patched later by _patch_pbo
         "oos_sharpe": round(float(oos), 4) if oos is not None else None,
+        "in_sample_sharpe": round(float(in_sample_sharpe), 4) if in_sample_sharpe is not None else None,
         "lookahead_audit_passed": lookahead_passed,
         "passing": passing,
     }
@@ -475,13 +490,15 @@ async def _run_fixture_candidate(
         weights=weights,
         reasoning=f"Fixture path ({regime} regime) — no LLM call. Weights chosen by deterministic stub.",
         rigor_verdict={
-            "dsr": 0.71,
-            "pbo": 0.18,
-            "oos_sharpe": 0.94,
-            "lookahead_audit_passed": True,
-            "passing": True,
+            "dsr": None,
+            "pbo": None,
+            "oos_sharpe": None,
+            "in_sample_sharpe": None,
+            "lookahead_audit_passed": False,
+            "passing": False,
+            "reason": "fixture mode — no LLM call, rigor gate not run",
         },
-        passes_rigor=True,
+        passes_rigor=False,
         regime=regime,
     )
 
@@ -744,14 +761,19 @@ async def run_generation(
         runner: Callable[..., Awaitable[_CandidateResult]] = _run_live_candidate if use_live else _run_fixture_candidate
 
         # Library is the candidate pool the agent reasons over; surface it so
-        # the UI can show "agent is considering N papers".
+        # the UI can show "agent is considering N papers". Its size also feeds
+        # the DSR multiple-testing correction below (selection-bias-corrections-
+        # spec.md § 1.3) — num_trials must be the size of the selection set the
+        # winner was chosen from, not 1.
         try:
             from archimedes.services.strategy_provider import default_provider
 
             lib = default_provider().list_strategies()
             arxiv_ids = [s.paper_arxiv_id for s in lib if getattr(s, "paper_arxiv_id", None)]
+            library_size = max(1, len(lib))
         except Exception:
             arxiv_ids = []
+            library_size = 1
         await emit.emit(
             "candidates_selected",
             candidate_count=len(regimes),
@@ -854,7 +876,9 @@ async def run_generation(
         # regime variants in parallel (yfinance + numpy is I/O-bound), then
         # upsert the BacktestResult row + updated passport metrics so the
         # next /api/strategies/ read surfaces empirical Sharpe/DSR/PBO/OOS.
-        await asyncio.gather(*[_backtest_and_persist(c, strategy_ids[c.candidate_id], emit) for c in candidates])
+        await asyncio.gather(
+            *[_backtest_and_persist(c, strategy_ids[c.candidate_id], emit, library_size) for c in candidates]
+        )
 
         # ── Persist all candidates to episodic memory (T-PE.8) ──
         try:
@@ -987,7 +1011,7 @@ async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple
     return strategy_id, trace_hash
 
 
-async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Emitter) -> None:
+async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Emitter, num_trials: int = 1) -> None:
     """Backtest the generated strategy on real multi-year data and persist results.
 
     Closes the "Pending Backtest" gap on the Library page. The agent only
@@ -1008,6 +1032,8 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         c: The candidate that was just persisted.
         strategy_id: The DB id returned by :func:`_persist_candidate`.
         emit: The SSE emitter to surface backtest progress to the UI.
+        num_trials: Curated-library size, fed to ``backtest_portfolio`` as
+            ``num_trials_for_dsr`` for the DSR multiple-testing correction.
     """
     # Fixture mode (offline tests, no-LLM environments) — skip the network
     # round-trip. The test suite covers this function's behavior via direct
@@ -1050,10 +1076,14 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         from archimedes.services.portfolio_backtester import backtest_portfolio
 
         # Run the actual backtest. Raises on insufficient data / fetch failure.
+        # num_trials_for_dsr = curated-library size (selection-bias-corrections-
+        # spec.md § 1.3) — the DSR multiple-testing correction for the selection
+        # set this candidate was chosen from, not the default of 1.
         result, artifact = backtest_portfolio(
             strategy_id=strategy_id,
             weights=c.weights,
             paper_title=c.strategy_name,
+            num_trials_for_dsr=max(1, num_trials),
         )
         artifact_json = _json.dumps(artifact, default=str)
         content_hash = hashlib.sha256(artifact_json.encode("utf-8")).hexdigest()

--- a/backend/archimedes/models/backtest.py
+++ b/backend/archimedes/models/backtest.py
@@ -16,6 +16,7 @@ References:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from datetime import date
 
@@ -171,7 +172,31 @@ class BacktestResult:
             return False
         if self.out_of_sample_sharpe is None:
             return False
-        if self.sharpe_ratio > 0 and (self.out_of_sample_sharpe / self.sharpe_ratio < 0.5):
+        in_sample_sharpe = self._in_sample_sharpe()
+        if (
+            in_sample_sharpe is not None
+            and math.isfinite(in_sample_sharpe)
+            and in_sample_sharpe > 0
+            and self.out_of_sample_sharpe / in_sample_sharpe < 0.5
+        ):
             return False
         vs_paper = self.sharpe_vs_paper
         return not (vs_paper is not None and vs_paper < 0.5)
+
+    def _in_sample_sharpe(self) -> float | None:
+        """Annualized Sharpe on the in-sample (training) slice of equity_curve.
+
+        Mirrors RigorGateResult.passes_all's cliff check: the OOS/IS ratio must
+        compare like with like (both slices of the SAME series), not OOS against
+        the full-sample Sharpe (which already blends in the OOS tail and makes
+        the cliff trivially easy to pass). Returns None when equity_curve is too
+        short to split meaningfully (compute_in_sample_sharpe's own threshold).
+        """
+        from archimedes.services._rigor_helpers import compute_in_sample_sharpe
+
+        daily_returns = [
+            (self.equity_curve[i] - self.equity_curve[i - 1]) / self.equity_curve[i - 1]
+            for i in range(1, len(self.equity_curve))
+            if self.equity_curve[i - 1] > 0
+        ]
+        return compute_in_sample_sharpe(daily_returns, train_fraction=self.walk_forward_train_fraction)


### PR DESCRIPTION
## Summary

Four related findings from `AUDIT_2026-06-14.md` (Q1, Q2, Q3, Q7, Q11) — all
concern the rigor gate's selection-bias corrections not measuring what they
claim to measure.

- **Q2** (HIGH): `BacktestResult.passes_rigor_gate`'s OOS/IS cliff check divided
  by the **full-sample** Sharpe, which already blends in the OOS tail — the
  cliff was trivially easy to pass. Added `_in_sample_sharpe()` (mirrors
  `RigorGateResult.passes_all`'s pattern) and compare OOS against the
  in-sample-slice Sharpe instead.
- **Q3** (HIGH): the streaming rigor verdict (`_rigor_verdict_for`, used during
  live generation) omitted the IS/OOS cliff entirely — only DSR/PBO/lookahead
  gated `passing`. Now computes `in_sample_sharpe` via
  `compute_in_sample_sharpe` and folds the cliff into `passing`, surfacing
  `in_sample_sharpe` in the verdict dict.
- **Q1/Q7** (MEDIUM): the persist path called `backtest_portfolio` with
  `num_trials_for_dsr` defaulting to `1`, deflating DSR as if only one
  strategy were ever trialed — wrong displayed `deflated_sharpe_ratio` for
  every persisted backtest. `run_generation` now computes `library_size` from
  the live strategy library (`max(1, len(default_provider().list_strategies()))`,
  falling back to `1` on error) and threads it through
  `_backtest_and_persist -> backtest_portfolio` as `num_trials_for_dsr`.
- **Q11** (MEDIUM): `_run_fixture_candidate` (no-LLM / fixture mode, used on a
  judge's cold clone with no `ANTHROPIC_API_KEY`) hardcoded a **passing** rigor
  verdict (`dsr=0.71, pbo=0.18, oos_sharpe=0.94, passing=True`) even though no
  rigor gate ever ran. Now returns all-`None` metrics with `passes_rigor=False`
  and `"reason": "fixture mode — no LLM call, rigor gate not run"`, matching
  the shape `_rigor_verdict_for` already uses for its short-series early
  return.

## Test plan

- [x] `ruff format` / `ruff check --select E9,F63,F7,F40` clean on both files
- [x] `backend/tests/services/test_generation_pipeline.py` — 16 passed
- [x] `backend/tests/test_backtest_repository.py` — 2 passed
- [x] Broader rigor sweep (`test_dsr_parity`, `test_pbo_parity`,
      `test_rigor_evaluator`, `test_rigor_regime`, `test_selection_bias_routes`,
      `test_passport_loader`, `test_strategy_sizer`, `test_strategy_store`,
      `services/test_portfolio_backtester{,_mc}`, `services/test_stockbench_adapter`,
      `services/test_strategy_memory`) — 348 passed
- [x] `backend/tests/services/test_kelly_portfolio.py`,
      `services/test_strategy_provider.py`,
      `test_backtest_pipeline_integration.py` — 54 passed

All hermetic (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python3 -m pytest ...`).

Part of the AUDIT_2026-06-14.md remediation tracked alongside three sibling
PRs (B4 liquidity fail-closed, B2 UI relabel, hygiene/docs corrections).