### PR TITLE
Fail closed on liquidity-probe errors (AUDIT_2026-06-14 B4)

### DIFF
--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -147,11 +147,21 @@ class ChainExecutor:
             except InsufficientLiquidityError:
                 raise
             except Exception as exc:
+                # Fail closed: a probe error (RPC failure, ABI decode error, etc.)
+                # means we could NOT determine whether this pool has healthy
+                # liquidity — treat that the same as "confirmed insufficient"
+                # rather than letting the trade through unguarded. The message
+                # is worded distinctly ("probe failed") so logs/operators can
+                # tell a probe failure apart from a confirmed-thin-pool result,
+                # even though the caller-visible effect (skip this leg) matches.
                 logger.warning(
-                    "liquidity check failed for %s (non-fatal, allowing trade): %s",
+                    "liquidity probe failed for %s — skipping leg (fail-closed): %s",
                     trade.symbol,
                     exc,
                 )
+                raise InsufficientLiquidityError(
+                    f"Liquidity probe failed for {trade.symbol} (treating as insufficient): {exc}"
+                ) from exc
 
     async def _confirm_receipt(self, tx_hash: str | bytes) -> str:
         """Wait for a tx receipt and raise TradeRevertedError if it reverted.

--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -179,13 +179,18 @@ class TestValidateTradeLiquidity:
         # Should pass — USDC (token1) has $10k
         asyncio.run(executor._validate_trade_liquidity([trade]))
 
-    def test_non_fatal_on_unexpected_error(self, executor, mock_loader):
-        """Unexpected errors during pool read are non-fatal (logged, trade allowed)."""
+    def test_fails_closed_on_unexpected_error(self, executor, mock_loader):
+        """Unexpected probe errors (RPC/ABI) fail closed — leg is skipped, not allowed.
+
+        B4 (AUDIT_2026-06-14.md): a probe failure must NOT be treated as "liquidity
+        OK". It raises InsufficientLiquidityError (probe-failure variant) so the
+        caller skips this leg the same way it would for a confirmed thin pool.
+        """
         trade = _make_trade()
         mock_loader.amm_router.functions.getPool.return_value.call = AsyncMock(side_effect=RuntimeError("RPC timeout"))
 
-        # Should NOT raise — non-fatal
-        asyncio.run(executor._validate_trade_liquidity([trade]))
+        with pytest.raises(InsufficientLiquidityError, match="probe failed"):
+            asyncio.run(executor._validate_trade_liquidity([trade]))
 
 
 # ── execute_trades ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**B4** (MEDIUM) from `AUDIT_2026-06-14.md`: `_validate_trade_liquidity` in
`backend/archimedes/chain/executor.py` caught a broad `except Exception`,
logged it as "non-fatal, allowing trade", and fell through — meaning an RPC
error or any unexpected failure during the liquidity probe would silently
**allow** the trade rather than skip it.

## Change

`backend/archimedes/chain/executor.py:147-162` — the broad exception handler
now re-raises as `InsufficientLiquidityError(f"Liquidity probe failed for
{trade.symbol} (treating as insufficient): {exc}") from exc`. The "probe
failed" wording distinguishes this from the "confirmed thin pool" messages
(`"No AMM pool"`, `"below threshold"`) while producing the same
caller-visible skip.

**Caller verification** (`backend/archimedes/chain/agent_runner.py:567-606`):
`_validate_trade_liquidity` is called from `execute_trades`
(`executor.py:199`); `InsufficientLiquidityError` propagates out of
`execute_trades` entirely. The caller catches it at the tick level: logs
"swap skipped — thin pool", publishes a `DecisionType.SKIP` trace with reason
`"insufficient_liquidity"`, and returns (retries next tick). This reuses the
existing, already-tested path for confirmed thin pools — smallest blast
radius, matches the audit's suggested fix ("fail-closed (skip the leg) on
probe error"). Note it skips the whole tick's trade batch rather than a single
leg, but that's pre-existing behavior, unchanged by this fix.

## Test plan

- [x] `backend/tests/chain/test_chain_executor.py` — renamed
      `test_non_fatal_on_unexpected_error` → `test_fails_closed_on_unexpected_error`,
      now asserts `pytest.raises(InsufficientLiquidityError, match="probe failed")`
      when `getPool` raises `RuntimeError("RPC timeout")`.
- [x] `ruff format` / `ruff check --fix` — clean, no changes needed beyond the edit.
- [x] Hermetic `backend/tests/chain/` — **50 passed, 0 failed** (includes
      `test_chain_executor.py` + `test_executor_usdc_leg.py`). No
      `agent_runner` tests reference this exception path, so the caller's
      existing handler coverage is unaffected.

Part of the AUDIT_2026-06-14.md remediation tracked alongside three sibling
PRs (rigor-gate cliff fix, B2 UI relabel, hygiene/docs corrections).