### PR TITLE
Relabel Temporal Binding UI badge to avoid overclaiming on-chain enforcement (AUDIT_2026-06-14 B2)

### DIFF
--- a/ui/src/components/Reasoning.jsx
+++ b/ui/src/components/Reasoning.jsx
@@ -345,13 +345,16 @@ function OnChainTraces({ onNavigate, highlightTraceId }) {
                 </div>
                 )}
 
-                {/* Temporal binding verification */}
+                {/* Block-order check (off-chain) — NOT an on-chain commit-reveal
+                    guarantee. temporal_binding_valid is a Python/Redis-computed
+                    boolean (commit_block < trade_block); the time-locked
+                    commit()/reveal() contract calls are not yet wired into the
+                    live path. See docs/specs/commit-reveal-trace-spec.md (v1.5). */}
                 {!isSkip && t.temporal_binding_valid != null && (
                   <div className="mt-2 rounded-md px-3 py-2" style={{ background: t.temporal_binding_valid ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)' }}>
                     <div className="flex items-center gap-1.5 mb-1">
                       <span className={`w-4 h-4 flex-shrink-0 ${t.temporal_binding_valid ? 'i-lucide-check-circle text-[var(--positive)]' : 'i-lucide-x-circle text-[var(--negative)]'}`} />
-                      <strong className="text-[0.85rem]">Temporal Binding</strong>
-                      {t.temporal_binding_valid && <span className="tag tag-positive text-[0.7rem]">VERIFIED</span>}
+                      <strong className="text-[0.85rem]">Block Order Check (off-chain)</strong>
                     </div>
                     <div className="text-xs text-[var(--text-3)] leading-relaxed">
                       {t.commit_block_number != null && <div>Commit block: <strong>#{t.commit_block_number}</strong></div>}
@@ -359,7 +362,7 @@ function OnChainTraces({ onNavigate, highlightTraceId }) {
                       {t.reveal_block_number != null && <div>Reveal block: <strong>#{t.reveal_block_number}</strong></div>}
                       {t.temporal_binding_valid && (
                         <div style={{ marginTop: 4, fontStyle: 'italic' }}>
-                          Trace committed before trade executed (commit &lt; trade &lt; reveal)
+                          Off-chain record: commit was logged before the trade block (not yet enforced on-chain — commit-reveal wiring is on the roadmap).
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

**B2** (HIGH) from `AUDIT_2026-06-14.md`: the `ReasoningTraceRegistry` v1.5
`commit()`/`reveal()` functions exist in contract source but are **never
called** from the backend (`agent_runner.py` / `trace_publisher.py` only call
the legacy `publishTrace`). The only "temporal binding" check that actually
runs today is a Python/Redis-computed
`temporal_binding_valid = commit_block < trade_block` boolean — yet the UI
rendered this behind a green **"VERIFIED"** badge labeled "Temporal Binding",
implying on-chain commit-reveal enforcement that doesn't exist.

This PR only relabels the UI to stop overclaiming; wiring real on-chain
commit-reveal is tracked separately as a Phase-2 item (depends on vault-owner
topology, B1/B3).

## Change (`ui/src/components/Reasoning.jsx`)

- Heading: `Temporal Binding` (+ green `VERIFIED` tag) → `Block Order Check
  (off-chain)` — tag dropped; the existing check/x icon + green/red background
  still conveys pass/fail.
- Explainer sentence (shown only when `temporal_binding_valid` is true):
  `Trace committed before trade executed (commit < trade < reveal)` →
  `Off-chain record: commit was logged before the trade block (not yet
  enforced on-chain — commit-reveal wiring is on the roadmap).`
- Added a 5-line code comment explaining what `temporal_binding_valid`
  actually is (Python/Redis-computed) and pointing to
  `docs/specs/commit-reveal-trace-spec.md` (v1.5) for the real fix.

**Untouched:** the adjacent "Why does this matter?" hash-anchoring disclosure
(the `ReasoningTraceRegistry` / hash-recompute explanation) and the factual
`Commit block: #...` / `Trade block: #...` / `Reveal block: #...` display
lines — confirmed via `git diff`.

## Test plan

- [x] `npx eslint src/components/Reasoning.jsx` — clean, 0 errors/warnings.
- [x] Grepped `ui/` for "Temporal Binding", "VERIFIED", `temporal_binding_valid`
      in test files — none found, no test updates needed (`ui/package.json`
      has no `test` script, only `lint`).

Part of the AUDIT_2026-06-14.md remediation tracked alongside three sibling
PRs (rigor-gate cliff fix, B4 fail-closed, hygiene/docs corrections).