### PR TITLE
[backend] Fix fusion-gate num_trials default + PBO fail-closed (Q4/Q6)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1362,6 +1362,13 @@ async def _run_fusion_job(job_id: str) -> None:
                 "pbo_score": r.pbo_score,
                 "oos_sharpe": r.oos_sharpe,
                 "look_ahead_clean": bool(r.look_ahead_clean),
+                # Honest label distinct from the bare bool above: the DSL's
+                # self-attested look_ahead_safe is enforced as an admission
+                # gate, but it is NOT the independent AST audit that
+                # rigor_evaluator.look_ahead_audit runs against cited curated
+                # source. Surfaced so the passport doesn't read this as that
+                # audit having passed (audit 06-14, Q6).
+                "look_ahead_label": r.look_ahead_label,
                 "num_trials": int(r.num_trials),
                 # Backtest metrics — surface alongside so the passport renders
                 # without the UI having to denormalize from a separate field.
@@ -1492,6 +1499,8 @@ async def _run_fusion_job(job_id: str) -> None:
                     "dsr_p_value": eval_result.rigor.dsr_p_value,
                     "oos_sharpe": eval_result.rigor.oos_sharpe,
                     "look_ahead_clean": eval_result.rigor.look_ahead_clean,
+                    # Honest label — see rigor_verdict_dict above (audit 06-14, Q6).
+                    "look_ahead_label": eval_result.rigor.look_ahead_label,
                 }
             if eval_result.error:
                 job_result["eval_error"] = eval_result.error

--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -67,6 +67,14 @@ class RigorVerdict:
     dsr_p_value: float | None
     pbo_score: float | None
     oos_sharpe: float | None
+    # True for every spec that reaches this evaluator: validate_strategy_spec
+    # rejects look_ahead_safe=False before a backtest ever runs, so this is
+    # always True in practice. It is NOT the result of an independent
+    # AST-based audit (cf. rigor_evaluator.look_ahead_audit, which runs only
+    # against cited curated source) — it is the LLM's own self-declared
+    # look_ahead_safe flag, enforced as a closed-DSL admission gate. Kept as
+    # a bool because it participates in the `passing` computation; see
+    # `look_ahead_label` for the honest user-facing string (audit 06-14, Q6).
     look_ahead_clean: bool
     num_trials: int
     # In-sample (training-slice) Sharpe, surfaced so the OOS/IS cliff that the
@@ -77,6 +85,16 @@ class RigorVerdict:
     # the statistics AND those statistics were computed on real market data.
     data_source: str = "synthetic"
     admissible: bool = False
+    # Honest user-facing label for the look-ahead check (audit 06-14, Q6).
+    # Distinct from `look_ahead_clean` (the gating bool, always True here):
+    # this string makes clear that "clean" means "the closed DSL's
+    # self-attested look_ahead_safe flag was True", NOT "an independent
+    # AST audit of the generated code ran and found no look-ahead bias" —
+    # the latter is what `rigor_evaluator.look_ahead_audit` does for cited
+    # curated source, and it is NOT run against fusion/DSL output. Mirrors
+    # the "MISSING"-style honest labels in
+    # `selection_bias_routes.RigorGateDetail.look_ahead`.
+    look_ahead_label: str = "N/A (closed-DSL, self-attested, not source-audited)"
 
 
 @dataclass(frozen=True)
@@ -382,9 +400,25 @@ def _run_variant_backtest(
 # ── Rigor gate ────────────────────────────────────────────────────────
 
 
+def _default_num_trials() -> int:
+    """Fallback selection-set size: the curated strategy library's count.
+
+    Mirrors the pattern in ``generation_pipeline.run_generation`` — a lazy
+    import (avoids a module-load-time dependency on the DB-backed provider)
+    inside a try/except, with a safe ``1`` fallback if the provider is
+    unavailable (e.g. in a hermetic unit test with no DB).
+    """
+    try:
+        from archimedes.services.strategy_provider import default_provider
+
+        return max(1, len(default_provider().list_strategies()))
+    except Exception:
+        return 1
+
+
 def apply_rigor_gate(
     metrics: BacktestMetrics,
-    num_trials: int = 10,
+    num_trials: int | None = None,
     variants_metrics: dict[str, BacktestMetrics] | None = None,
     data_source: str | None = None,
 ) -> RigorVerdict:
@@ -398,7 +432,14 @@ def apply_rigor_gate(
 
     When ``variants_metrics`` is provided with >= 2 entries, real CSCV PBO
     is computed from the variant returns matrix and attached to the verdict.
+
+    ``num_trials``, when ``None`` (the default), falls back to the curated
+    strategy library's size via ``_default_num_trials()`` — the real
+    multiple-testing selection set a fusion-generated strategy is being
+    compared against, rather than an arbitrary placeholder (audit 06-14, Q4).
     """
+    if num_trials is None:
+        num_trials = _default_num_trials()
     daily_returns = [
         (metrics.equity_curve[i] - metrics.equity_curve[i - 1]) / metrics.equity_curve[i - 1]
         for i in range(1, len(metrics.equity_curve))
@@ -416,10 +457,12 @@ def apply_rigor_gate(
                 (curve[i] - curve[i - 1]) / curve[i - 1] for i in range(1, len(curve)) if curve[i - 1] > 0
             ]
 
-    # num_trials = actual size of the multiple-testing selection set. A fixed
-    # default (10) under-deflates a large variant grid (e.g. a 50-variant sweep
-    # gets only a 10-trial penalty) and over-deflates a small one. When the
-    # variant matrix is known, use its real cardinality as the trial count.
+    # num_trials = actual size of the multiple-testing selection set. The
+    # caller-supplied/default value (curated library size — see
+    # _default_num_trials) under-deflates a large variant grid (e.g. a
+    # 50-variant sweep gets only a library-sized penalty) and over-deflates a
+    # small one. When the variant matrix is known, it is a MORE precise
+    # selection-set size, so it takes priority over the library-size fallback.
     effective_trials = num_trials
     if variants_metrics is not None and len(variants_metrics) >= 2:
         effective_trials = len(variants_metrics)
@@ -440,10 +483,15 @@ def apply_rigor_gate(
         first_key = next(iter(pbo_map))
         pbo_score = pbo_map[first_key]
 
-    # Look-ahead is guaranteed by the DSL design (static check in
-    # validate_strategy_spec — DSL specs with look_ahead_safe=false are
-    # rejected at validation time, long before reaching this evaluator).
+    # Look-ahead admission: validate_strategy_spec rejects any DSL spec with a
+    # self-declared look_ahead_safe=False before this evaluator ever runs, so
+    # `look_ahead_clean` is always True for specs reaching this point. This is
+    # the LLM's OWN self-attestation enforced as a closed-DSL gate — NOT the
+    # independent AST audit (rigor_evaluator.look_ahead_audit) that runs
+    # against cited curated source. `look_ahead_label` carries the honest
+    # framing of that distinction for the passport/UI (audit 06-14, Q6).
     look_ahead_clean = True
+    look_ahead_label = "N/A (closed-DSL, self-attested, not source-audited)"
 
     # DSR gate: require p-value >= 0.95 (same threshold enforced by the curated
     # path in run_rigor_gate). Using dsr > 0.0 was too permissive — a z-score of
@@ -471,7 +519,12 @@ def apply_rigor_gate(
     ):
         oos_pass = False
 
-    pbo_pass = pbo_score is None or (math.isfinite(pbo_score) and pbo_score < 0.5)
+    # Fail-closed when PBO wasn't computed (audit 06-14, Q4): a missing PBO
+    # means CSCV never ran (fewer than 2 variant backtests), NOT that the
+    # strategy passed the overfitting check. Mirrors RigorGateResult.passes_all
+    # (rigor_evaluator.py), where pbo_score is None fails the overall gate
+    # rather than vacuously passing it.
+    pbo_pass = pbo_score is not None and math.isfinite(pbo_score) and pbo_score < 0.5
     passing = dsr_pass and oos_pass and look_ahead_clean and pbo_pass
 
     # Provenance gate: a strategy is only admissible for Tier-1 if it passes
@@ -494,6 +547,7 @@ def apply_rigor_gate(
         oos_sharpe=oos_sharpe,
         in_sample_sharpe=in_sample_sharpe,
         look_ahead_clean=look_ahead_clean,
+        look_ahead_label=look_ahead_label,
         num_trials=effective_trials,
         data_source=source,
         admissible=admissible,
@@ -507,9 +561,13 @@ def evaluate_fusion_spec(
     spec_dict: dict[str, Any],
     *,
     data_feed: Any = None,
-    num_trials: int = 10,
+    num_trials: int | None = None,
 ) -> FusionEvalResult:
-    """Full pipeline: validate → interpret → backtest → rigor gate."""
+    """Full pipeline: validate → interpret → backtest → rigor gate.
+
+    ``num_trials=None`` (the default) defers to ``apply_rigor_gate``'s own
+    fallback (the curated library size) — see ``_default_num_trials``.
+    """
     try:
         spec = validate_strategy_spec(spec_dict)
     except DSLError as e:

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -14,6 +14,7 @@ separate piece of work).
 
 from __future__ import annotations
 
+import random
 from pathlib import Path
 
 from archimedes.services.fusion_evaluator import (
@@ -26,6 +27,41 @@ from archimedes.services.fusion_evaluator import (
 from archimedes.services.strategy_dsl import FABER_2007_SPEC, validate_strategy_spec
 
 _SPY_FIXTURE = Path(__file__).parent.parent / "fixtures" / "spy_ohlcv_2004_2026.csv"
+
+
+def _noisy_variant_curve(curve: list[float], seed: int = 42, noise_sigma: float = 0.002) -> list[float]:
+    """Build a second equity curve from the same per-bar drift as ``curve`` plus
+    independent Gaussian noise, for use as a non-identical CSCV variant.
+
+    Audit 06-14 (Q4) made ``apply_rigor_gate`` fail-closed when ``pbo_score is
+    None`` (no variants supplied). Tests that need a genuinely *passing*
+    verdict for a single high-Sharpe curve now must also supply >= 2 variant
+    backtests so a real CSCV PBO is computed. A perfectly-correlated duplicate
+    of ``curve`` yields PBO == 1.0 (the IS-best is always the OOS-worst on an
+    identical series) — i.e. an automatic fail. Adding independent per-bar
+    noise to the second variant breaks that perfect correlation so PBO lands
+    at 0.0 (the original curve's steady drift dominates every split), letting
+    the test's intended "this is a passing strategy" setup hold honestly.
+    """
+    rng = random.Random(seed)
+    drifts = [curve[i] / curve[i - 1] - 1.0 for i in range(1, len(curve))]
+    noisy = [curve[0]]
+    for drift in drifts:
+        noisy.append(noisy[-1] * (1.0 + drift + rng.gauss(0, noise_sigma)))
+    return noisy
+
+
+def _two_variant_set(curve: list[float], data_source: str = "csv:test.csv") -> dict[str, BacktestMetrics]:
+    """Minimal >= 2-entry ``variants_metrics`` dict so ``apply_rigor_gate``
+    computes a real (non-``None``) CSCV PBO — see ``_noisy_variant_curve``.
+
+    Reuses ``_metrics_from_curve`` (defined below; module-level functions
+    resolve at call time, so the forward reference is safe).
+    """
+    return {
+        "v0": _metrics_from_curve(curve, data_source=data_source),
+        "v1": _metrics_from_curve(_noisy_variant_curve(curve), data_source=data_source),
+    }
 
 
 def _make_high_sharpe_metrics(data_source: str = "csv:test.csv") -> BacktestMetrics:
@@ -355,8 +391,12 @@ class TestDataProvenanceGate:
         # Use a high-Sharpe synthetic equity curve with real data provenance.
         # Faber's 6.7% CAGR barely exceeds the 5% rf, so its DSR p-value falls
         # short of 0.95 — this test is about the provenance gate, not Faber's stats.
+        # A 2-entry variant set is supplied so CSCV PBO is computed (audit
+        # 06-14, Q4: pbo_score=None now fails closed) — see _two_variant_set.
+        curve = _make_high_sharpe_metrics(data_source="csv:spy_ohlcv_2004_2026.csv").equity_curve
         metrics = _make_high_sharpe_metrics(data_source="csv:spy_ohlcv_2004_2026.csv")
-        verdict = apply_rigor_gate(metrics)
+        verdict = apply_rigor_gate(metrics, variants_metrics=_two_variant_set(curve, data_source="csv:spy.csv"))
+        assert verdict.pbo_score is not None and verdict.pbo_score < 0.5
         assert verdict.passing is True
         assert verdict.admissible is True
         assert verdict.data_source.startswith("csv:")
@@ -364,8 +404,11 @@ class TestDataProvenanceGate:
     def test_provenance_override_revokes_admissibility(self):
         # Take a passing real-data run and re-judge it as if the data were
         # synthetic — admissibility must flip off even though passing stays on.
+        # 2-entry variant set per test_real_data_passing_strategy_is_admissible.
+        curve = _make_high_sharpe_metrics(data_source="csv:spy_ohlcv_2004_2026.csv").equity_curve
         metrics = _make_high_sharpe_metrics(data_source="csv:spy_ohlcv_2004_2026.csv")
-        as_synthetic = apply_rigor_gate(metrics, data_source="synthetic")
+        variants = _two_variant_set(curve, data_source="csv:spy.csv")
+        as_synthetic = apply_rigor_gate(metrics, variants_metrics=variants, data_source="synthetic")
         assert as_synthetic.passing is True
         assert as_synthetic.admissible is False
 
@@ -433,10 +476,13 @@ class TestFusionGateEnforcesOosSharpe:
 
     def test_positive_oos_can_pass(self):
         # Steady uptrend across the whole window → OOS Sharpe > 0 and DSR passes.
+        # 2-entry variant set so CSCV PBO is computed (audit 06-14, Q4:
+        # pbo_score=None now fails closed) — see _two_variant_set.
         curve = [100_000.0]
         for i in range(800):
             curve.append(curve[-1] * (1.003 if i % 2 == 0 else 1.001))
-        verdict = apply_rigor_gate(_metrics_from_curve(curve))
+        verdict = apply_rigor_gate(_metrics_from_curve(curve), variants_metrics=_two_variant_set(curve))
+        assert verdict.pbo_score is not None and verdict.pbo_score < 0.5
         assert verdict.oos_sharpe is not None and verdict.oos_sharpe > 0.0
         assert verdict.passing is True
 


### PR DESCRIPTION
## Summary

Two findings from `AUDIT_2026-06-14.md`'s fusion-evaluator review:

- **Q4** — `apply_rigor_gate`/`evaluate_fusion_spec` defaulted
  `num_trials=10`, a placeholder unrelated to the actual selection-set
  size. Now defaults to `_default_num_trials()` =
  `max(1, len(default_provider().list_strategies()))` — the curated
  library size — mirroring the `generation_pipeline.run_generation`
  pattern from PR #633. The existing `variants_metrics >= 2` override
  for `effective_trials` still takes priority when present.

  While fixing this, found and fixed a **fail-open PBO bug**:
  `pbo_pass = pbo_score is None or (...)` let a missing PBO score pass
  the gate. Changed to `pbo_pass = pbo_score is not None and (...)`,
  matching the fail-closed contract in `RigorGateResult.passes_all`.

- **Q6** — `RigorVerdict.look_ahead_clean` is the fusion LLM's
  self-attested flag, with no independent AST audit (unlike
  `generation_pipeline`'s static look-ahead audit). Added
  `look_ahead_label: str = "N/A (closed-DSL, self-attested, not
  source-audited)"` so the passport surfaces this distinction honestly
  instead of implying equivalent rigor to the audited path. Threaded
  through `strategies_routes.py`'s two rigor-verdict dict sites
  (job-result + fusion-job response).

## Change

- `backend/archimedes/services/fusion_evaluator.py`:
  - New `_default_num_trials()` helper (try/except → fallback `1`,
    hermetic-test safe).
  - `apply_rigor_gate(metrics, num_trials: int | None = None, ...)` and
    `evaluate_fusion_spec(..., num_trials: int | None = None)` — `None`
    defers to `_default_num_trials()`.
  - PBO fail-closed fix (see above).
  - New `look_ahead_label` field + comments distinguishing
    self-attestation from independent audit.
- `backend/archimedes/api/strategies_routes.py`: thread
  `look_ahead_label` through both rigor-verdict dict construction sites
  (additive only).
- `backend/tests/services/test_fusion_evaluator.py`: new
  `_noisy_variant_curve` / `_two_variant_set` helpers (PBO=1.0 on
  identical curves auto-fails CSCV under the new fail-closed rule, so
  tests now exercise two distinct variants); updated 3 tests to assert
  `pbo_score is not None and pbo_score < 0.5`.

## Test plan

- [x] `ruff format --check .` — 3 files already formatted
- [x] `ruff check --select E9,F63,F7,F40 .` — All checks passed
- [x] `pytest backend/tests/services/test_fusion_evaluator.py backend/tests/test_api_routes.py -q`
      → **51 passed, 2 skipped** (pre-existing skips, unrelated —
      "Requires chain_client.settings module-level init mocking")

Part of the solo audit-remediation pass on
[AUDIT_2026-06-14.md](https://github.com/a-apin/archimedes/blob/main/AUDIT_2026-06-14.md).
Sibling PRs: #633 (Q1/Q2/Q3/Q7/Q11), #634 (B4), #635 (B2 UI), #636 (hygiene).