### PR TITLE
[docs] Fix stale get_profile docstring (B11)

### DIFF
--- a/backend/archimedes/api/user_routes.py
+++ b/backend/archimedes/api/user_routes.py
@@ -91,8 +91,9 @@ async def get_profile(wallet: str, request: Request):
     """Retrieve a wallet's profile. Returns 404 if not set.
 
     PII fields (email, display_name, marketing_opt_in) are only included
-    when the caller's wallet (from X-Wallet-Address header) matches the
-    requested profile wallet.
+    when the caller holds a verified SIWE session for the requested
+    profile wallet. The X-Wallet-Address header is not used for this
+    check — it is forgeable (see Issue #402).
     """
     session: Session = get_session()
     try:


### PR DESCRIPTION
## Summary

B11 from `AUDIT_2026-06-14.md`: `get_profile`'s docstring claimed PII
fields are gated by "the caller's wallet (from X-Wallet-Address
header)". The actual check (line 109,
`_extract_caller_wallet_siwe(request) == wallet_lower`) uses a verified
SIWE session — the header is intentionally NOT used here, per the
accurate inline comment on line 104 ("PII requires SIWE session — header
spoofing cannot access email/name") and per Issue #402.

## Change

Docstring-only fix in `backend/archimedes/api/user_routes.py`. No
behavior change. The `X-Wallet-Address` CORS allow-header itself is
intentionally left untouched — `ui/src/components/Layout.jsx:74` still
sends it for other purposes, and `upsert_profile`'s docstring (already
accurate) documents why it was dropped for writes.

## Test plan

- [x] `ruff format --check` / `ruff check --select E9,F63,F7,F40` — clean
- Docstring-only change; no test behavior affected.

Part of the solo audit-remediation pass on
[AUDIT_2026-06-14.md](https://github.com/a-apin/archimedes/blob/main/AUDIT_2026-06-14.md).
Sibling PRs: #633-637.