### PR TITLE
[ci/infra] Quality-gate on push + tighten nginx real_ip trust (AUDIT_2026-06-14 I5/I7)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,4 +1,4 @@
-# Quality gate — runs on every PR to main.
+# Quality gate — runs on every PR to main and on direct pushes to main.
 #
 # Hard block:
 #   backend-tests  — pytest unit suite (no DB/Redis required)
@@ -14,6 +14,11 @@ name: Quality Gate
 
 on:
   pull_request:
+    branches: [main]
+  # Also runs on direct pushes to main so test results are visible in CI history
+  # (the agentic CI system pushes directly to main; this surfaces test status
+  # without blocking deployment — deploy.yml is a separate workflow).
+  push:
     branches: [main]
 
 permissions:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,11 +1,10 @@
 # ── Real client IP behind the ALB ──────────────────────────────────────
-# The ALB terminates TLS and proxies to nginx, so $remote_addr is the ALB
-# node's private IP. Without these directives every client would share one
-# rate-limit bucket (rate limiting effectively disabled). Trust the private
-# VPC ranges the ALB lives in and read the real client IP from X-Forwarded-For.
-set_real_ip_from 10.0.0.0/8;
-set_real_ip_from 172.16.0.0/12;
-set_real_ip_from 192.168.0.0/16;
+# Trust X-Forwarded-For only from the ALB VPC (10.0.0.0/16) — restricts
+# real-IP trust to the known ALB subnet after the EC2 SG was locked to this
+# CIDR. Previously trusted all three RFC1918 ranges including 172.16.0.0/12
+# (which covers 172.31.0.0/16, the EC2's own default VPC), allowing the EC2
+# itself to spoof client IPs and bypass rate-limit buckets. (AUDIT I7)
+set_real_ip_from 10.0.0.0/16;
 real_ip_header X-Forwarded-For;
 real_ip_recursive on;
 


### PR DESCRIPTION
## Summary
- **I5**: quality-gate.yml now also triggers on direct pushes to `main`, giving test-result visibility for the agentic CI system's direct commits. Deploy workflow is unchanged.
- **I7**: nginx real_ip trust restricted from three RFC1918 ranges (including 172.16.0.0/12 which covers the EC2's own VPC) to just the ALB VPC CIDR (10.0.0.0/16). Prevents EC2-local IP spoofing of rate-limit buckets.

## Findings addressed
- AUDIT_2026-06-14 I5 (MEDIUM): quality-gate only on PRs
- AUDIT_2026-06-14 I7 (LOW): nginx trusts all RFC1918 for X-Forwarded-For

## Verify
grep -A3 'on:' .github/workflows/quality-gate.yml | head -10
# Should show both pull_request and push triggers
grep 'set_real_ip_from' nginx/nginx.conf
# Should show exactly one line: set_real_ip_from 10.0.0.0/16;