### PR TITLE
[backend] Hygiene fixes: SIWE key separation, OOS Sharpe ddof note, dead code markers (AUDIT_2026-06-14 B10/Q8/Q9/Q10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,13 @@ WALLET_SET_ID=
 # For local dev, a default key is used (see services/email_crypto.py).
 EMAIL_ENCRYPTION_KEY=
 
+# ── SIWE session signing key ──────────────────────────────────────────────
+# Dedicated HMAC key for signing SIWE session cookies. Preferred over
+# EMAIL_ENCRYPTION_KEY so session signing is decoupled from email encryption.
+# Falls back to EMAIL_ENCRYPTION_KEY if unset (backwards compat).
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+SIWE_SESSION_KEY=
+
 # ── Internal agent authentication ─────────────────────────────────────────
 # Required by internal endpoints (traces/publish, agent/bootstrap-liquidity,
 # vault chat/rebalance + chat/regime-change). Generate with `openssl rand -hex 32`.

--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -35,14 +35,15 @@ logger = logging.getLogger(__name__)
 
 auth_router = APIRouter(prefix="/api/auth", tags=["auth"])
 
-# Session signing key — derived from EMAIL_ENCRYPTION_KEY or a random per-boot key.
-# In production, EMAIL_ENCRYPTION_KEY is required (fail-closed in main.py), so
-# sessions persist across restarts. In dev, a random key means sessions reset on restart.
+# Session signing key — prefer SIWE_SESSION_KEY (dedicated session-signing secret);
+# falls back to EMAIL_ENCRYPTION_KEY for backwards compatibility. Production enforces
+# EMAIL_ENCRYPTION_KEY at boot (main.py RuntimeError), so the secrets.token_hex(32)
+# path is local-dev only.
 # Multi-worker note: main.py:~127 raises RuntimeError at boot if PUBLIC_DOMAIN is set
 # (production) and EMAIL_ENCRYPTION_KEY is unset, so the secrets.token_hex(32) fallback
 # is only reachable in single-worker local dev -- per-worker secret divergence (which
 # would break cross-worker session-cookie verification) can't occur there.
-_SESSION_SECRET = os.getenv("EMAIL_ENCRYPTION_KEY", secrets.token_hex(32))
+_SESSION_SECRET = os.getenv("SIWE_SESSION_KEY") or os.getenv("EMAIL_ENCRYPTION_KEY", secrets.token_hex(32))
 _SESSION_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 _NONCE_TTL_SECONDS = 300  # 5 minutes
 _CLOCK_SKEW_SECONDS = 120  # tolerate small client/server clock drift on Issued At

--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -708,6 +708,7 @@ def classify_regimes(
     return labels
 
 
+# DEAD CODE — unwired from run_rigor_gate; see issue #621
 def regime_conditional_sharpe(
     strategy_returns: list[float] | np.ndarray,
     regime_labels: list[int] | np.ndarray,
@@ -830,6 +831,7 @@ def regime_robustness_score(
     }
 
 
+# DEAD CODE — unwired from run_rigor_gate; see issue #621
 def regime_conditional_dsr(
     strategy_returns: list[float] | np.ndarray,
     regime_labels: list[int] | np.ndarray,

--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -293,6 +293,9 @@ def compute_oos_sharpe(
 ) -> float | None:
     """Annualized Sharpe on the held-out OOS slice (no shuffling).
 
+    Note: uses ddof=1 (sample stddev); analytics-engine uses ddof=0 — the two OOS Sharpe
+    numbers differ by sqrt(N/(N-1)) and are not directly comparable.
+
     Splits the return series chronologically: the first train_fraction of
     bars are in-sample; the remainder are the OOS test set. The OOS Sharpe
     must clear the absolute floor (> 0) and the cliff check (OOS/IS ≥ 0.5)

--- a/backend/archimedes/services/return_diagnostics.py
+++ b/backend/archimedes/services/return_diagnostics.py
@@ -349,6 +349,7 @@ def runs_test(returns: object) -> dict:
 
 
 def diagnose(returns: object, lags: int = 10, vr_q: int = 2) -> dict:
+    # TODO(issue #621): wire into run_rigor_gate to enforce IID assumption check
     """Run all three IID / random-walk diagnostics and aggregate.
 
     Parameters


### PR DESCRIPTION
## Summary
Four low/info severity backend fixes from the 2026-06-14 audit:

- **B10**: SIWE session key now prefers dedicated `SIWE_SESSION_KEY` env var (falls back to `EMAIL_ENCRYPTION_KEY` for backwards compat). Decouples session signing from email encryption.
- **Q8**: Add comment noting ddof=1 vs ddof=0 OOS Sharpe convention split between backend and analytics-engine.
- **Q9**: Mark `return_diagnostics.py` functions with TODO to wire into rigor gate (IID check unwired).
- **Q10**: Mark `regime_conditional_sharpe` / `regime_conditional_dsr` as dead code (confirmed unwired per issue #621).

## Findings addressed
- AUDIT_2026-06-14 B10 (LOW), Q8 (LOW), Q9 (INFO), Q10 (INFO)

## Verify
grep 'SIWE_SESSION_KEY' backend/archimedes/api/auth_siwe.py .env.example
grep 'ddof' backend/archimedes/services/_rigor_helpers.py | head -5
grep 'DEAD CODE\|issue.*621' backend/archimedes/services/_rigor_helpers.py