### PR TITLE
[contracts] Fix CEI violation in Vault.withdraw/redeem (AUDIT_2026-06-14 B6)

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -234,20 +234,21 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         assets = previewRedeem(shares);
         if (assets == 0) revert ZeroAssets();
 
-        // Ensure we have enough USDC — liquidate positions if needed
+        // ERC-4626 allowance enforcement — CEI: check BEFORE any external call (audit B6).
+        // A caller may only burn `owner_`'s shares when it IS the owner, or when the owner
+        // has granted it a share allowance. `_spendAllowance` is a no-op for an infinite
+        // (type(uint256).max) allowance, matching the canonical pattern.
+        if (msg.sender != owner_) {
+            _spendAllowance(owner_, msg.sender, shares);
+        }
+
+        // Ensure we have enough USDC — liquidate positions if needed (external AMM calls
+        // after the allowance check, satisfying the Check-Effects-Interactions pattern).
         uint256 usdcOnHand = IERC20(asset).balanceOf(address(this));
         if (usdcOnHand < assets) {
             _liquidateToUsdc(assets - usdcOnHand);
         }
 
-        // ERC-4626 allowance enforcement (audit 2026-06-13 CRITICAL): a caller may only
-        // burn `owner_`'s shares when it IS the owner, or when the owner has granted it a
-        // share allowance. Without this, anyone could pass a victim as `owner_` and a
-        // chosen `receiver` to drain the victim's deposit. `_spendAllowance` is a no-op
-        // for an infinite (type(uint256).max) allowance, matching the canonical pattern.
-        if (msg.sender != owner_) {
-            _spendAllowance(owner_, msg.sender, shares);
-        }
         _burn(owner_, shares);
 
         IERC20(asset).safeTransfer(receiver, assets);

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -196,20 +196,21 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         shares = _convertToShares(assets);
         if (shares == 0) revert ZeroShares();
 
-        // Ensure we have enough USDC — liquidate positions if needed
+        // ERC-4626 allowance enforcement — CEI: check BEFORE any external call (audit B6).
+        // A caller may only burn `owner_`'s shares when it IS the owner, or when the owner
+        // has granted it a share allowance. `_spendAllowance` is a no-op for an infinite
+        // (type(uint256).max) allowance, matching the canonical pattern.
+        if (msg.sender != owner_) {
+            _spendAllowance(owner_, msg.sender, shares);
+        }
+
+        // Ensure we have enough USDC — liquidate positions if needed (external AMM calls
+        // after the allowance check, satisfying the Check-Effects-Interactions pattern).
         uint256 usdcOnHand = IERC20(asset).balanceOf(address(this));
         if (usdcOnHand < assets) {
             _liquidateToUsdc(assets - usdcOnHand);
         }
 
-        // ERC-4626 allowance enforcement (audit 2026-06-13 CRITICAL): a caller may only
-        // burn `owner_`'s shares when it IS the owner, or when the owner has granted it a
-        // share allowance. Without this, anyone could pass a victim as `owner_` and a
-        // chosen `receiver` to drain the victim's deposit. `_spendAllowance` is a no-op
-        // for an infinite (type(uint256).max) allowance, matching the canonical pattern.
-        if (msg.sender != owner_) {
-            _spendAllowance(owner_, msg.sender, shares);
-        }
         _burn(owner_, shares);
 
         IERC20(asset).safeTransfer(receiver, assets);


### PR DESCRIPTION
## Summary
`withdraw()` and `redeem()` ran `_liquidateToUsdc` (AMM swaps) before checking the caller's share allowance. This is a CEI violation — the allowance check should precede all external calls. No drain is possible (reverts roll back), but gas-griefing by triggering AMM swaps on unauthorized withdrawals was possible.

Fix: move `_spendAllowance` above `_liquidateToUsdc` in both functions. No logic change — same final state.

## Findings addressed
- AUDIT_2026-06-14 B6 (LOW): CEI violation in Vault withdraw/redeem

## Verify
cd contracts && forge test --match-contract Vault -v 2>&1 | grep -E "PASS|FAIL|test_"