### PR TITLE
[contracts] Add minAmountOut slippage guard to AMMPool.swap (AUDIT_2026-06-14 B9)

### DIFF
--- a/contracts/abis/AMMPool.json
+++ b/contracts/abis/AMMPool.json
@@ -27,6 +27,32 @@
   },
   {
     "type": "function",
+    "name": "DEAD_SHARES_SINK",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MIN_LIQUIDITY",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "addLiquidity",
     "inputs": [
       {
@@ -288,6 +314,11 @@
         "name": "to",
         "type": "address",
         "internalType": "address"
+      },
+      {
+        "name": "minAmountOut",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "outputs": [

--- a/contracts/src/AMMPool.sol
+++ b/contracts/src/AMMPool.sol
@@ -70,7 +70,14 @@ contract AMMPool is IAMMPool, ERC20, Ownable, ReentrancyGuard {
     // ─── Swap ────────────────────────────────────────────────────────
 
     /// @notice Swap one token for another. Caller must have approved this contract.
-    function swap(address tokenIn, uint256 amountIn, address to)
+    /// @param tokenIn      Token being sold.
+    /// @param amountIn     Exact amount of tokenIn to sell.
+    /// @param to           Recipient of the output tokens.
+    /// @param minAmountOut Minimum acceptable output; reverts with SlippageProtection
+    ///                     if the computed amountOut is below this threshold.
+    ///                     Pass 0 to skip the check (e.g. when the caller already
+    ///                     enforces slippage at a higher layer, as AMMRouter does).
+    function swap(address tokenIn, uint256 amountIn, address to, uint256 minAmountOut)
         external
         nonReentrant
         returns (uint256 amountOut)
@@ -90,6 +97,7 @@ contract AMMPool is IAMMPool, ERC20, Ownable, ReentrancyGuard {
 
         if (amountOut == 0) revert InsufficientOutput();
         if (amountOut >= rOut) revert InsufficientLiquidity();
+        if (amountOut < minAmountOut) revert SlippageProtection();
 
         uint256 kBefore = rIn * rOut;
 

--- a/contracts/src/AMMRouter.sol
+++ b/contracts/src/AMMRouter.sol
@@ -158,8 +158,10 @@ contract AMMRouter is IAMMRouter, Ownable, ReentrancyGuard {
         // Approve pool to pull tokenIn
         IERC20(tokenIn).safeIncreaseAllowance(pool, amountIn);
 
-        // Execute swap — tokenOut comes to this contract
-        amountOut = AMMPool(pool).swap(tokenIn, amountIn, address(this));
+        // Execute swap — tokenOut comes to this contract.
+        // Pass 0 as minAmountOut: the router already enforces slippage above via
+        // the SlippageExceeded check on the returned amountOut.
+        amountOut = AMMPool(pool).swap(tokenIn, amountIn, address(this), 0);
 
         if (amountOut < minAmountOut) revert SlippageExceeded();
 

--- a/contracts/test/AMM.t.sol
+++ b/contracts/test/AMM.t.sol
@@ -277,6 +277,41 @@ contract AMMTest is Test {
         vm.stopPrank();
     }
 
+    // ─── Direct pool swap (AUDIT B9 — minAmountOut guard) ───────────
+
+    /// @notice Direct pool.swap with minAmountOut=0 succeeds (backward-compatible).
+    function test_pool_swap_direct_zero_min() public {
+        address pool = router.createPool(address(tokenA), address(tokenB));
+        _seedLiquidity(alice, address(tokenA), address(tokenB), 10_000e18, 20_000e18);
+
+        uint256 swapAmount = 100e18;
+
+        vm.startPrank(bob);
+        tokenA.approve(pool, swapAmount);
+        uint256 amountOut = AMMPool(pool).swap(address(tokenA), swapAmount, bob, 0);
+        vm.stopPrank();
+
+        assertGt(amountOut, 0);
+    }
+
+    /// @notice Direct pool.swap reverts with SlippageProtection when minAmountOut
+    ///         exceeds the computed output (AUDIT B9).
+    function test_revert_pool_swap_slippage_protection() public {
+        address pool = router.createPool(address(tokenA), address(tokenB));
+        _seedLiquidity(alice, address(tokenA), address(tokenB), 10_000e18, 20_000e18);
+
+        uint256 swapAmount = 100e18;
+        // Preview what we'd get, then require one more wei than that.
+        uint256 preview = AMMPool(pool).getAmountOut(address(tokenA), swapAmount);
+        assertGt(preview, 0);
+
+        vm.startPrank(bob);
+        tokenA.approve(pool, swapAmount);
+        vm.expectRevert(AMMPool.SlippageProtection.selector);
+        AMMPool(pool).swap(address(tokenA), swapAmount, bob, preview + 1);
+        vm.stopPrank();
+    }
+
     // ─── Remove Liquidity ────────────────────────────────────────────
 
     function test_removeLiquidity_basic() public {


### PR DESCRIPTION
## Summary
Direct calls to `AMMPool.swap()` previously had no slippage protection — any output ≥ 1 wei would succeed. Add a `uint256 minAmountOut` 4th parameter with a `SlippageProtection` revert. Vault funds remain safe (vault routes via `AMMRouter` which enforces its own slippage floor; the router passes `0` to the pool since slippage is already checked at the router layer).

## Findings addressed
- AUDIT_2026-06-14 B9 (LOW): AMMPool.swap no minAmountOut guard

## Changes
- `contracts/src/AMMPool.sol` — new `minAmountOut` 4th parameter + `if (amountOut < minAmountOut) revert SlippageProtection()` check (after the existing InsufficientLiquidity guard, before reserve update)
- `contracts/src/AMMRouter.sol` — updated `AMMPool(pool).swap(...)` call to pass `0` (router already enforces slippage via its own `SlippageExceeded` check)
- `contracts/abis/AMMPool.json` — regenerated from `forge build` output to reflect 4-arg signature
- `contracts/test/AMM.t.sol` — two new tests: `test_pool_swap_direct_zero_min` (zero minAmountOut succeeds) and `test_revert_pool_swap_slippage_protection` (preview+1 triggers SlippageProtection revert)

## Verify
```
cd contracts && forge test --match-contract AMM -v 2>&1 | grep -E "PASS|FAIL|test_"
grep "minAmountOut" contracts/src/AMMPool.sol contracts/src/AMMRouter.sol
```
Expected: 26 tests pass, grep shows minAmountOut in both files.