### PR TITLE
[contracts] forceSetPrice bound + SyntheticVault zero/underflow guards (AUDIT_2026-06-14 B5/B7/B8)

### DIFF
--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -35,6 +35,12 @@ contract PriceOracle is Ownable {
     /// @notice Basis-point denominator (100% = 10_000 bps)
     uint256 public constant BPS_DENOMINATOR = 10_000;
 
+    /// @notice Hard cap on single forceSetPrice moves (900% = 10× max change per call).
+    ///         Prevents pathological oracle manipulation; legitimate >10× gaps require
+    ///         two sequential calls. Unlike setPrice's maxDeviationBps this constant is
+    ///         not owner-configurable — it exists precisely to bound a compromised key.
+    uint256 public constant FORCE_MAX_DEVIATION_BPS = 90_000;
+
     event PriceUpdated(uint256 oldPrice, uint256 newPrice, uint256 timestamp);
     event PriceForced(uint256 oldPrice, uint256 newPrice, uint256 timestamp);
     event MaxDeviationBpsChanged(uint256 oldBps, uint256 newBps);
@@ -80,12 +86,19 @@ contract PriceOracle is Ownable {
     }
 
     /// @notice Emergency override — owner-only escape hatch for legitimately
-    ///         gapped markets (e.g. a >maxDeviationBps overnight move). Skips
-    ///         the deviation bound but still rejects zero. Emits a distinct
-    ///         event so forced updates are auditable on-chain.
+    ///         gapped markets (e.g. a >maxDeviationBps overnight move). Bounded
+    ///         by FORCE_MAX_DEVIATION_BPS (900% / 10×) when a prior price exists;
+    ///         a legitimate >10× gap requires two sequential calls. Emits a
+    ///         distinct event so forced updates are auditable on-chain.
     function forceSetPrice(uint256 _newPrice) external onlyOwner {
         if (_newPrice == 0) revert ZeroPrice();
         uint256 oldPrice = price;
+        if (oldPrice != 0) {
+            uint256 diff = _newPrice > oldPrice ? _newPrice - oldPrice : oldPrice - _newPrice;
+            if (diff * BPS_DENOMINATOR > oldPrice * FORCE_MAX_DEVIATION_BPS) {
+                revert PriceDeviationTooLarge(oldPrice, _newPrice, FORCE_MAX_DEVIATION_BPS);
+            }
+        }
         price = _newPrice;
         lastUpdated = block.timestamp;
         emit PriceForced(oldPrice, _newPrice, block.timestamp);

--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -150,11 +150,15 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
 
     // ─── Views ───────────────────────────────────────────────────────
 
-    function previewMint(uint256 amountUsdc) external view returns (uint256) {
+    /// @notice Mirror mint()'s zero-amount guards exactly so callers can rely on
+    ///         previewMint to detect inputs that would revert before submitting a tx.
+    function previewMint(uint256 amountUsdc) external view returns (uint256 synthAmount) {
+        if (amountUsdc == 0) revert ZeroAmount();
         uint256 assetPrice = oracle.getPrice();
         uint256 fee = (amountUsdc * mintFeeBps) / BPS;
         uint256 netUsdc = amountUsdc - fee;
-        return (netUsdc * (10 ** SYNTH_DECIMALS) * BPS) / (assetPrice * collateralRatio);
+        synthAmount = (netUsdc * (10 ** SYNTH_DECIMALS) * BPS) / (assetPrice * collateralRatio);
+        if (synthAmount == 0) revert ZeroAmount();
     }
 
     function previewBurn(uint256 synthAmount) external view returns (uint256) {

--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -125,7 +125,10 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
 
         // Pro-rata solvency cap: under stress, scale the claim by C/L so redemption
         // order cannot redistribute value between holders (see @dev above).
-        uint256 available = usdc.balanceOf(address(this)) - protocolFees;
+        // Safe subtraction: protocolFees should never exceed balance, but fee rounding
+        // over many small operations could cause a transient underflow; clamp to 0.
+        uint256 _burnBal = usdc.balanceOf(address(this));
+        uint256 available = _burnBal > protocolFees ? _burnBal - protocolFees : 0;
         uint256 totalLiability = (synthToken.totalSupply() * assetPrice) / (10 ** SYNTH_DECIMALS);
         if (totalLiability > available) {
             usdcValue = (usdcValue * available) / totalLiability;

--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -169,7 +169,9 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
 
         // Mirror burn()'s pro-rata solvency cap so preview == actual under stress.
-        uint256 available = usdc.balanceOf(address(this)) - protocolFees;
+        // Safe subtraction: clamp to 0 in the contrived case protocolFees > balance.
+        uint256 _previewBal = usdc.balanceOf(address(this));
+        uint256 available = _previewBal > protocolFees ? _previewBal - protocolFees : 0;
         uint256 totalLiability = (synthToken.totalSupply() * assetPrice) / (10 ** SYNTH_DECIMALS);
         if (totalLiability > available) {
             usdcValue = (usdcValue * available) / totalLiability;
@@ -180,7 +182,8 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     }
 
     function totalCollateral() external view returns (uint256) {
-        return usdc.balanceOf(address(this)) - protocolFees;
+        uint256 _bal = usdc.balanceOf(address(this));
+        return _bal > protocolFees ? _bal - protocolFees : 0;
     }
 
     function vaultCollateralization() external view returns (uint256) {
@@ -188,7 +191,8 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         if (totalSynth == 0) return type(uint256).max;
         uint256 assetPrice = oracle.getPrice();
         uint256 totalBacking = (totalSynth * assetPrice) / (10 ** SYNTH_DECIMALS);
-        uint256 collateral = usdc.balanceOf(address(this)) - protocolFees;
+        uint256 _colBal = usdc.balanceOf(address(this));
+        uint256 collateral = _colBal > protocolFees ? _colBal - protocolFees : 0;
         return (collateral * BPS) / totalBacking;
     }
 

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -138,6 +138,42 @@ contract SyntheticVaultTest is Test {
         oracle.forceSetPrice(0);
     }
 
+    /// @dev audit 2026-06-14 B5: forceSetPrice is now bounded by FORCE_MAX_DEVIATION_BPS
+    ///      (900% = 10×). A >10× single-call move reverts PriceDeviationTooLarge even
+    ///      for the owner — a compromised key cannot zero-out or overflow the oracle.
+    function test_revert_forceSetPrice_exceeds_hard_cap() public {
+        // +11× is beyond the 900% (10×) hard cap
+        uint256 elevenX = INITIAL_PRICE * 11;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PriceOracle.PriceDeviationTooLarge.selector,
+                INITIAL_PRICE,
+                elevenX,
+                oracle.FORCE_MAX_DEVIATION_BPS()
+            )
+        );
+        oracle.forceSetPrice(elevenX);
+    }
+
+    /// @dev Exactly 10× is within the 900% cap (diff == 9×old, 9*10000 <= 90000).
+    function test_forceSetPrice_at_hard_cap_boundary() public {
+        uint256 tenX = INITIAL_PRICE * 10;
+        vm.prank(owner);
+        oracle.forceSetPrice(tenX);
+        assertEq(oracle.price(), tenX);
+    }
+
+    /// @dev forceSetPrice with no prior price (price == 0) skips the bound check
+    ///      so the oracle can always be bootstrapped.
+    function test_forceSetPrice_no_prior_price_skips_bound() public {
+        PriceOracle freshOracle = new PriceOracle("FRESH", 0, owner);
+        uint256 anyPrice = 1e30; // extreme — fine when oldPrice == 0
+        vm.prank(owner);
+        freshOracle.forceSetPrice(anyPrice);
+        assertEq(freshOracle.price(), anyPrice);
+    }
+
     function test_revert_forceSetPrice_non_owner() public {
         vm.prank(alice);
         vm.expectRevert();
@@ -432,6 +468,30 @@ contract SyntheticVaultTest is Test {
         vm.stopPrank();
 
         assertEq(preview, actual);
+    }
+
+    /// @dev audit 2026-06-14 B7: previewMint now mirrors mint()'s zero-input guard.
+    function test_revert_preview_mint_zero() public {
+        vm.expectRevert(SyntheticVault.ZeroAmount.selector);
+        vault.previewMint(0);
+    }
+
+    /// @dev audit 2026-06-14 B7: previewMint now mirrors mint()'s dust-rounds-to-zero guard.
+    function test_revert_preview_mint_dust_rounds_to_zero() public {
+        uint256 hugePrice = 1e21;
+        SyntheticToken dustSynth = new SyntheticToken("Dust", "DUST", owner);
+        PriceOracle dustOracle = new PriceOracle("DUST", hugePrice, owner);
+        SyntheticVault dustVault = new SyntheticVault(
+            address(usdc),
+            address(dustSynth),
+            address(dustOracle),
+            owner
+        );
+        vm.prank(owner);
+        dustSynth.setVault(address(dustVault));
+
+        vm.expectRevert(SyntheticVault.ZeroAmount.selector);
+        dustVault.previewMint(1); // 1 unit at extreme price rounds to 0 synth
     }
 
     function test_preview_burn() public {


### PR DESCRIPTION
## Summary
Three targeted safety guards for the Solidity contracts:

- **B5**: PriceOracle.forceSetPrice now enforces FORCE_MAX_DEVIATION_BPS = 90_000 (900% / 10× per call). A compromised owner key cannot zero-out or overflow oracle prices in a single transaction. Legitimate >10× gaps require two sequential calls. The cap is a non-configurable constant so it can't be widened by the same compromised key.
- **B7**: SyntheticVault.previewMint now mirrors mint() behavior exactly — reverts ZeroAmount on 0-input and on dust that rounds to 0 synths. Callers can use previewMint to detect inputs that would revert before submitting a transaction.
- **B8**: Four arithmetic expressions that could underflow when protocolFees > vault balance now use a safe subtraction pattern (`_bal > protocolFees ? _bal - protocolFees : 0`). Affected: burn(), previewBurn(), totalCollateral(), vaultCollateralization().

## Findings addressed
- AUDIT_2026-06-14 B5 (MEDIUM), B7 (LOW), B8 (LOW)

## Commits
1. `[contracts] Bound forceSetPrice to 900% max deviation (AUDIT B5)`
2. `[contracts] Add zero-amount guard to previewMint matching mint() behavior (AUDIT B7)`
3. `[contracts] Guard burn() against protocolFees > balance underflow (AUDIT B8)`
4. `[contracts] Guard previewBurn/totalCollateral/vaultCollateralization against underflow (AUDIT B8)`
5. `[tests] Update SyntheticVault tests for B5/B7/B8 guard behavior`

## New tests added
- `test_revert_forceSetPrice_exceeds_hard_cap` — >10× move reverts PriceDeviationTooLarge
- `test_forceSetPrice_at_hard_cap_boundary` — exactly 10× is accepted
- `test_forceSetPrice_no_prior_price_skips_bound` — bootstrap (oldPrice==0) skips the cap
- `test_revert_preview_mint_zero` — previewMint(0) reverts ZeroAmount
- `test_revert_preview_mint_dust_rounds_to_zero` — previewMint on dust reverts ZeroAmount

## Verify
```
cd contracts && forge build && forge test --match-path test/SyntheticVault.t.sol
```
Note: forge build compiles all files including pre-existing Vault.t.sol arity mismatch (unrelated, exists on main). `forge build` itself succeeds with `Compiler run successful with warnings`.

## Cross-lane note
Smart contract changes — Chuan's lane. PR open for Chuan's review.