### PR TITLE
[contracts] Separate vault owner from agent/creator in VaultFactory (AUDIT_2026-06-14 B1/B3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,14 @@ RPC=
 DEV_WALLET_ADDRESS=
 DEV_WALLET_PRIVATE_KEY=
 
+# ── Vault governance wallet ────────────────────────────────────────────────
+# Optional: governance wallet that owns vaults (onlyOwner admin functions:
+# setTokenOracles, setMaxSlippageBps, pause). Separate from the hot agent
+# signer so a compromised agent key cannot redefine oracles or pause the vault.
+# If unset, the agent address is used (current behaviour — identical to before).
+# Use a cold key in production. Generate with: cast wallet new
+VAULT_GOVERNANCE_ADDRESS=
+
 # ── Circle Developer Controlled Wallets ───────────────────────────────────
 # Used by the oracle runner to push prices on-chain via the Circle wallet
 # that owns the PriceOracle contracts (address 0xc221dC...9aC9).

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -7,6 +7,7 @@ Handles reading portfolio state, executing rebalance trades, and vault creation.
 from __future__ import annotations
 
 import logging
+import os
 
 from web3.contract import AsyncContract
 
@@ -279,19 +280,30 @@ class ChainExecutor:
         management_fee_bps: int,
         performance_fee_bps: int,
         agent_assisted: bool,
+        vault_governance_address: str | None = None,
     ) -> str:
         """Deploy a new vault via VaultFactory.
 
         Uses Circle dev-controlled wallet if configured, falls back to raw private key.
+
+        Args:
+            vault_governance_address: Optional cold governance key that will own the vault
+                (onlyOwner admin: setTokenOracles, setMaxSlippageBps, pause).
+                If None, falls back to VAULT_GOVERNANCE_ADDRESS env var, then to "" which
+                causes the contract to default to msg.sender — preserving the old behaviour.
         """
         factory = self.loader.vault_factory
+
+        # Governance address: separate cold key from the hot agent signer.
+        # If not set, falls back to the agent address (current behaviour — identical to before).
+        governance_addr = vault_governance_address or os.getenv("VAULT_GOVERNANCE_ADDRESS") or ""
 
         # Circle path
         if circle_signer.is_configured:
             tx_hash = await circle_signer.execute_contract(
                 contract_address=chain_client.settings.vault_factory_address,
-                abi_function="createVault(string,string,uint16,uint16,bool)",
-                abi_params=[name, symbol, management_fee_bps, performance_fee_bps, agent_assisted],
+                abi_function="createVault(string,string,uint16,uint16,bool,address)",
+                abi_params=[name, symbol, management_fee_bps, performance_fee_bps, agent_assisted, governance_addr],
             )
             logger.info(f"Vault created via Circle, tx: {tx_hash}")
 
@@ -316,7 +328,7 @@ class ChainExecutor:
         nonce = await chain_client.w3.eth.get_transaction_count(account.address)
 
         tx = await factory.functions.createVault(
-            name, symbol, management_fee_bps, performance_fee_bps, agent_assisted
+            name, symbol, management_fee_bps, performance_fee_bps, agent_assisted, governance_addr
         ).build_transaction(
             {
                 "from": account.address,

--- a/contracts/abis/Vault.json
+++ b/contracts/abis/Vault.json
@@ -51,6 +51,11 @@
         "name": "_symbol",
         "type": "string",
         "internalType": "string"
+      },
+      {
+        "name": "_owner",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "stateMutability": "nonpayable"
@@ -58,6 +63,45 @@
   {
     "type": "function",
     "name": "BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "DEAD_SHARES_SINK",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_SLIPPAGE_CAP_BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MIN_LIQUIDITY",
     "inputs": [],
     "outputs": [
       {
@@ -391,6 +435,19 @@
   },
   {
     "type": "function",
+    "name": "maxSlippageBps",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "name",
     "inputs": [],
     "outputs": [
@@ -571,6 +628,19 @@
         "name": "_agent",
         "type": "address",
         "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMaxSlippageBps",
+    "inputs": [
+      {
+        "name": "_maxSlippageBps",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "outputs": [],
@@ -838,6 +908,25 @@
   },
   {
     "type": "event",
+    "name": "AgentSet",
+    "inputs": [
+      {
+        "name": "oldAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "Approval",
     "inputs": [
       {
@@ -913,6 +1002,25 @@
   },
   {
     "type": "event",
+    "name": "MaxSlippageBpsSet",
+    "inputs": [
+      {
+        "name": "oldBps",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newBps",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "OwnershipTransferred",
     "inputs": [
       {
@@ -938,6 +1046,25 @@
         "name": "account",
         "type": "address",
         "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PlatformFeeRecipientSet",
+    "inputs": [
+      {
+        "name": "oldRecipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newRecipient",
+        "type": "address",
+        "indexed": true,
         "internalType": "address"
       }
     ],
@@ -1188,6 +1315,16 @@
   },
   {
     "type": "error",
+    "name": "InvalidOraclePrice",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OracleNotSet",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "OwnableInvalidOwner",
     "inputs": [
       {
@@ -1223,6 +1360,11 @@
         "internalType": "address"
       }
     ]
+  },
+  {
+    "type": "error",
+    "name": "SlippageBpsTooHigh",
+    "inputs": []
   },
   {
     "type": "error",

--- a/contracts/abis/VaultFactory.json
+++ b/contracts/abis/VaultFactory.json
@@ -84,6 +84,11 @@
         "name": "agentAssisted",
         "type": "bool",
         "internalType": "bool"
+      },
+      {
+        "name": "_vaultOwner",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "outputs": [

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -130,7 +130,8 @@ contract DeployScript is Script {
                 "vMOM",
                 150,   // 1.5% management fee
                 2000,  // 20% performance fee
-                true
+                true,
+                address(0) // _vaultOwner: defaults to deployer/agent (set VAULT_GOVERNANCE_ADDRESS in env for prod)
             );
             console.log("Tier 1 vault:", tier1Vault);
 

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -125,8 +125,9 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         bool _agentAssisted,
         address _platformFeeRecipient,
         string memory _name,
-        string memory _symbol
-    ) ERC20(_name, _symbol) Ownable(_creator) {
+        string memory _symbol,
+        address _owner // NEW: explicit Ownable owner; may differ from creator
+    ) ERC20(_name, _symbol) Ownable(_owner) {
         asset = _usdc;
         ammRouter = IAMMRouter(_ammRouter);
         creator = _creator;

--- a/contracts/src/VaultFactory.sol
+++ b/contracts/src/VaultFactory.sol
@@ -47,22 +47,29 @@ contract VaultFactory is IVaultFactory, Ownable {
         string calldata symbol,
         uint16 managementFeeBps,
         uint16 performanceFeeBps,
-        bool agentAssisted
+        bool agentAssisted,
+        address _vaultOwner // explicit owner; address(0) defaults to msg.sender
     ) external override returns (address vault) {
         // Tier determination: agent address creates Tier 1, anyone else creates Tier 2
         uint8 vaultTier = msg.sender == agentAddress ? uint8(1) : uint8(2);
 
+        // Resolve owner: explicit governance key preferred; fall back to msg.sender.
+        // This separates Ownable admin rights (setTokenOracles, setMaxSlippageBps, pause)
+        // from the creator role (Tier 1 detection, fee accrual, rebalance authority).
+        address resolvedOwner = _vaultOwner != address(0) ? _vaultOwner : msg.sender;
+
         Vault newVault = new Vault(
             usdc,
             ammRouter,
-            msg.sender,
+            msg.sender, // creator (unchanged — determines tier, receives fees)
             vaultTier,
             managementFeeBps,
             performanceFeeBps,
             agentAssisted,
             platformFeeRecipient,
             name,
-            symbol
+            symbol,
+            resolvedOwner // owner separate from creator (AUDIT B1)
         );
 
         vault = address(newVault);

--- a/contracts/src/interfaces/IVaultFactory.sol
+++ b/contracts/src/interfaces/IVaultFactory.sol
@@ -24,13 +24,17 @@ interface IVaultFactory {
     /// @param managementFeeBps Annual management fee in bps (e.g. 150 = 1.50%)
     /// @param performanceFeeBps Performance fee in bps above HWM (e.g. 2000 = 20%)
     /// @param agentAssisted Whether to opt into AI rebalancing
+    /// @param _vaultOwner Explicit owner of the Vault contract (onlyOwner admin functions).
+    ///                    Pass address(0) to default to msg.sender (backwards-compatible).
+    ///                    Pass a cold governance key to separate admin rights from the creator/agent.
     /// @return vault Address of the newly created Vault contract
     function createVault(
         string calldata name,
         string calldata symbol,
         uint16 managementFeeBps,
         uint16 performanceFeeBps,
-        bool agentAssisted
+        bool agentAssisted,
+        address _vaultOwner
     ) external returns (address vault);
 
     // ── Views ────────────────────────────────────────────────

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -75,14 +75,17 @@ contract VaultTest is Test {
         // Create AMM pool for USDC/sTSLA
         router.createPool(address(usdc), address(sTSLA));
 
-        // Create a vault as agent (Tier 1)
+        // Create a vault as agent (Tier 1).
+        // Pass address(0) for _vaultOwner so the contract defaults to msg.sender
+        // (agent), preserving pre-B1 behaviour for the shared setUp vault.
         vm.prank(agent);
         address vaultAddr = factory.createVault(
             "Momentum Alpha",
             "vMOM",
             150,   // 1.5% management fee
             2000,  // 20% performance fee
-            true   // agent assisted
+            true,  // agent assisted
+            address(0) // _vaultOwner: default to msg.sender (agent)
         );
         vault = Vault(payable(vaultAddr));
 
@@ -501,10 +504,10 @@ contract VaultTest is Test {
         address distinctAgent = address(0xA9E27);
 
         vm.prank(creator);
-        address vaultAddr = factory.createVault("T", "T", 0, 0, true);
+        address vaultAddr = factory.createVault("T", "T", 0, 0, true, address(0));
         Vault v = Vault(payable(vaultAddr));
 
-        vm.prank(creator); // creator == Ownable owner
+        vm.prank(creator); // creator == Ownable owner (address(0) defaults to msg.sender)
         v.setAgent(distinctAgent);
 
         address[] memory tokens = new address[](1);
@@ -907,7 +910,7 @@ contract VaultTest is Test {
 
     function test_factory_create_tier1() public {
         vm.prank(agent);
-        address v = factory.createVault("Tier1 Vault", "vT1", 100, 1000, true);
+        address v = factory.createVault("Tier1 Vault", "vT1", 100, 1000, true, address(0));
 
         assertEq(Vault(payable(v)).tier(), 1);
         assertEq(Vault(payable(v)).creator(), agent);
@@ -915,7 +918,7 @@ contract VaultTest is Test {
 
     function test_factory_create_tier2() public {
         vm.prank(alice);
-        address v = factory.createVault("Community Vault", "vCOM", 200, 1500, false);
+        address v = factory.createVault("Community Vault", "vCOM", 200, 1500, false, address(0));
 
         assertEq(Vault(payable(v)).tier(), 2);
         assertEq(Vault(payable(v)).creator(), alice);
@@ -923,10 +926,10 @@ contract VaultTest is Test {
 
     function test_factory_getVaults() public {
         vm.prank(agent);
-        factory.createVault("V1", "v1", 100, 1000, true);
+        factory.createVault("V1", "v1", 100, 1000, true, address(0));
 
         vm.prank(alice);
-        factory.createVault("V2", "v2", 200, 1500, false);
+        factory.createVault("V2", "v2", 200, 1500, false, address(0));
 
         address[] memory vaults = factory.getVaults();
         assertEq(vaults.length, 3); // 1 from setUp + 2 new
@@ -934,7 +937,7 @@ contract VaultTest is Test {
 
     function test_factory_getVaultsByCreator() public {
         vm.prank(alice);
-        factory.createVault("Alice Vault", "vAL", 200, 1500, false);
+        factory.createVault("Alice Vault", "vAL", 200, 1500, false, address(0));
 
         address[] memory aliceVaults = factory.getVaultsByCreator(alice);
         assertEq(aliceVaults.length, 1);
@@ -947,8 +950,27 @@ contract VaultTest is Test {
         assertEq(factory.vaultCount(), 1); // from setUp
 
         vm.prank(alice);
-        factory.createVault("V2", "v2", 200, 1500, false);
+        factory.createVault("V2", "v2", 200, 1500, false, address(0));
         assertEq(factory.vaultCount(), 2);
+    }
+
+    /// @dev B1 (AUDIT 2026-06-14): when an explicit governance address is passed,
+    ///      it becomes the vault owner — not the creator/msg.sender. The
+    ///      onlyOwner guards (setTokenOracles, setMaxSlippageBps, pause) are now
+    ///      exercisable by the cold governance key and NOT by the agent/creator.
+    function test_vault_owner_separate_from_creator() public {
+        address governance = address(0xABCD);
+
+        vm.prank(agent);
+        address vaultAddr = factory.createVault("Gov Vault", "vGOV", 0, 0, true, governance);
+        Vault v = Vault(payable(vaultAddr));
+
+        // Governance key is the Ownable owner
+        assertEq(v.owner(), governance);
+        // Creator is still the agent (for Tier 1 detection and fee accrual)
+        assertEq(v.creator(), agent);
+        // owner != creator — this is the B1 invariant
+        assertNotEq(v.owner(), v.creator());
     }
 
     function test_factory_agentAddress() public view {


### PR DESCRIPTION
## Summary
Previously every vault's Ownable owner was the backend agent signer (creator == owner == agent), making onlyOwner guards on setTokenOracles, setMaxSlippageBps, and pause ineffective against a compromised agent key.

Fix: add explicit `_vaultOwner` parameter to `createVault`. Pass a separate cold governance key via `VAULT_GOVERNANCE_ADDRESS` env var. The agent remains the `creator` (Tier 1 detection + fee accrual) but loses onlyOwner authority. Backwards-compatible: `address(0)` defaults to `msg.sender`.

The ReasoningTraceRegistry's `isAuthorizedForVault` checks `agent() | creator() | owner()`, so trace publishing works via the `creator()` check — no wiring change needed (B3 resolved implicitly).

## Findings addressed
- AUDIT_2026-06-14 B1 (HIGH): agent == vault owner
- AUDIT_2026-06-14 B3 (MEDIUM): trace registry auth still works via creator() introspection

## Changes
- `contracts/src/Vault.sol`: add `address _owner` constructor param; pass to `Ownable(_owner)` instead of `Ownable(_creator)`
- `contracts/src/interfaces/IVaultFactory.sol`: add `address _vaultOwner` param + docstring
- `contracts/src/VaultFactory.sol`: resolve owner from param (fallback to msg.sender if zero) and pass to Vault constructor
- `backend/archimedes/chain/executor.py`: pass `governance_addr` (from `VAULT_GOVERNANCE_ADDRESS` env) to both Circle and raw-key createVault calls
- `.env.example`: document new optional `VAULT_GOVERNANCE_ADDRESS` var
- `contracts/abis/Vault.json` + `contracts/abis/VaultFactory.json`: regenerated after Solidity changes
- `contracts/test/Vault.t.sol`: update all createVault call sites (add `address(0)` 6th arg) + new `test_vault_owner_separate_from_creator` test
- `contracts/script/Deploy.s.sol`: update createVault call to pass `address(0)`

## Verify
```
cd contracts && forge test --match-contract "Vault" -v 2>&1 | grep -E "PASS|FAIL|test_"
grep "VAULT_GOVERNANCE_ADDRESS" backend/archimedes/chain/executor.py .env.example
```