### PR TITLE
[ci] Guard quality-gate PR-comment step against direct push to main

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -129,6 +129,7 @@ jobs:
           EOF
 
       - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Problem

Since PR #641 added `push: branches: [main]` to `quality-gate.yml`, the **Lint — report table** job runs on direct pushes too. But its final step — _Post or update PR comment_ — calls `context.issue.number`, which is empty on push events (no PR). The GitHub API receives `GET /repos/a-apin/archimedes/issues//comments` (double slash), returns 404, and the step fails. This causes the whole job to fail and sends a failure email on every direct push to main.

The actual lint checks (ruff, eslint) ran fine — the only broken part was the comment-posting step.

## Fix

Add `if: github.event_name == 'pull_request'` to the _Post or update PR comment_ step.

The ruff + eslint steps still run on both PR and push events (CI history remains useful). Only the comment is conditional — no PR to comment on during a push.

## Verify

Next push to main: Quality Gate should show all jobs green (or skipped), no more failure emails.