### PR TITLE
Fix stale repo-name reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ monitors them in non-custodial vaults on Arc with USDC settlement. The product s
 Built for the [**Agora Agents Hackathon**](https://luma.com/7i50p2r9) — Canteen × Circle × Arc,
 May 11–25, 2026.
 
-- Repository: [`github.com/a-apin/archimedes-arcadia`](https://github.com/a-apin/archimedes-arcadia)
+- Repository: [`github.com/a-apin/archimedes`](https://github.com/a-apin/archimedes)
 - Discord: **Archimedes Arcadia** server
 - Branch model: **`main` is the single live branch — build-on-deploy.** Every merge to
   `main` triggers a CI build + deploy to the live EC2 stack. No `develop`/integration


### PR DESCRIPTION
## Summary
- `CLAUDE.md`'s "Repository:" line pointed at `a-apin/archimedes-arcadia`, the pre-rename name. The org/repo was renamed to `a-apin/archimedes` (GitHub auto-redirects old URLs, which is how `gh api repos/a-apin/archimedes-arcadia/...` calls were still succeeding but returning `url` fields under the new name).
- Updates the canonical declaration line to the live name.

Flagged as a low-priority footnote in `15jun-audit.md`. Note: there's broader drift (~60 references to `archimedes-arcadia` across `docs/archive/`, hackathon submission packets, and git submodules) — intentionally NOT touched here since those are historical/external artifacts and GitHub's redirect makes the links still work.

## Verify
```bash
gh repo view --json nameWithOwner -q '.nameWithOwner'   # a-apin/archimedes
grep -n "Repository:" CLAUDE.md
```

## Test plan
- [x] Docs-only change; no code/test impact.