### PR TITLE
Raise on createVault revert in Circle path (#651)

### DIFF
--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -42,6 +42,15 @@ class TradeRevertedError(RuntimeError):
     """
 
 
+class VaultCreationRevertedError(RuntimeError):
+    """Raised when a submitted createVault transaction reverts on-chain (status 0).
+
+    Without this, a reverted createVault is logged as "sent" and the Circle
+    path falls through to all_vaults[-1] — returning a pre-existing vault's
+    address as the result of a creation call that never happened.
+    """
+
+
 class ChainExecutor:
     """Executes on-chain vault operations: read portfolio, rebalance, create vault."""
 
@@ -300,9 +309,19 @@ class ChainExecutor:
             receipt = await chain_client.w3.eth.wait_for_transaction_receipt(
                 chain_client.w3.to_bytes(hexstr=tx_hash.removeprefix("0x")) if isinstance(tx_hash, str) else tx_hash
             )
+            if receipt.get("status") == 0:
+                raise VaultCreationRevertedError(f"createVault tx reverted on-chain: {tx_hash}")
             vault_address = self._parse_vault_created(factory, receipt)
             if not vault_address:
-                # Fallback: get last vault from factory
+                # Tx succeeded but no VaultCreated event was found — fall back
+                # to the most recently created vault, but flag it: this masks
+                # an event-decoding/indexing issue, not a revert (that's
+                # already handled above).
+                logger.warning(
+                    "createVault tx %s succeeded but no VaultCreated event found; "
+                    "falling back to most recent vault from getVaults()",
+                    tx_hash,
+                )
                 all_vaults = await factory.functions.getVaults().call()
                 vault_address = all_vaults[-1]
             logger.info(f"Vault created at {vault_address}")

--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -17,6 +17,7 @@ from archimedes.chain.executor import (
     ChainExecutor,
     InsufficientLiquidityError,
     TradeRevertedError,
+    VaultCreationRevertedError,
 )
 from archimedes.models.portfolio import TradeDirection, TradeOrder
 from hexbytes import HexBytes
@@ -517,6 +518,58 @@ class TestExecuteTradesDepth:
             mock_signer.is_configured = False
             with pytest.raises(ConnectionError, match="RPC down"):
                 asyncio.run(executor.execute_trades("0xvault", [trade]))
+
+
+# ── create_vault ─────────────────────────────────────────────
+
+
+class TestCreateVault:
+    """Coverage for create_vault's Circle-signer path (#651).
+
+    Hermetic: _parse_vault_created and factory.functions.getVaults().call()
+    are mocked per-scenario; no network, no Arc RPC, no Circle.
+    """
+
+    def test_circle_path_happy_returns_parsed_vault_address(self, executor, mock_loader):
+        """status=1 + VaultCreated event found → returns the parsed address
+        without ever calling getVaults()."""
+        with (
+            patch.object(executor, "_parse_vault_created", return_value="0xNewVault"),
+            patch("archimedes.chain.executor.circle_signer") as mock_signer,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
+            result = asyncio.run(executor.create_vault("Momentum Alpha", "vMOM", 150, 2000, True))
+            assert result == "0xNewVault"
+            mock_loader.vault_factory.functions.getVaults.assert_not_called()
+
+    def test_circle_path_revert_raises(self, executor, mock_loader):
+        """status=0 → raises VaultCreationRevertedError and never falls back
+        to all_vaults[-1] (the bug #651 guards against)."""
+        executor._mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value={"status": 0})
+        with patch("archimedes.chain.executor.circle_signer") as mock_signer:
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
+            with pytest.raises(VaultCreationRevertedError, match="reverted on-chain"):
+                asyncio.run(executor.create_vault("Momentum Alpha", "vMOM", 150, 2000, True))
+        mock_loader.vault_factory.functions.getVaults.assert_not_called()
+
+    def test_circle_path_no_event_falls_back_with_warning(self, executor, mock_loader, caplog):
+        """status=1 but no VaultCreated event found → falls back to
+        all_vaults[-1] and logs a warning flagging the indexing gap."""
+        mock_loader.vault_factory.functions.getVaults.return_value.call = AsyncMock(
+            return_value=["0xOldVault1", "0xOldVault2"]
+        )
+        with (
+            patch.object(executor, "_parse_vault_created", return_value=None),
+            patch("archimedes.chain.executor.circle_signer") as mock_signer,
+            caplog.at_level("WARNING", logger="archimedes.chain.executor"),
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
+            result = asyncio.run(executor.create_vault("Momentum Alpha", "vMOM", 150, 2000, True))
+        assert result == "0xOldVault2"
+        assert any("no VaultCreated event found" in r.message for r in caplog.records)
 
 
 # ── _usdc_value_to_token_raw ─────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #651. `create_vault()`'s Circle-signer path fetched the tx receipt
(which carries `.status`) but never checked it before falling through to
`all_vaults[-1]`. A reverted `createVault` was therefore reported as
success, returning a pre-existing vault's address as if it were newly
created.

This is the audit's "secondary bug" — independent of the 5-arg/6-arg
selector mismatch fixed in #650, and confirmed real by tracing
`circle_signer._poll_transaction`: Circle's `state == "COMPLETE"` reflects
broadcast/inclusion, not the underlying EVM `status`.

## Changes

- `backend/archimedes/chain/executor.py`:
  - New `VaultCreationRevertedError(RuntimeError)`, alongside the existing
    `TradeRevertedError` (same shape/rationale).
  - After `wait_for_transaction_receipt`, raise `VaultCreationRevertedError`
    if `receipt.get("status") == 0` — mirrors `_confirm_receipt`.
  - The remaining `all_vaults[-1]` fallback (status==1 but no `VaultCreated`
    event decoded) now logs a `warning`, since it masks an
    event-decoding/indexing gap rather than a revert.
- `backend/tests/chain/test_chain_executor.py`: new `TestCreateVault` class
  (3 tests) — `create_vault` had zero prior coverage. Covers the happy path,
  the revert-raises path, and the no-event-fallback-with-warning path.

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/chain/test_chain_executor.py -q
# 31 passed

env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest -m "not integration" -q
# 1558 passed, 2 skipped (pre-existing, documented)

ruff format --check backend/archimedes/chain/executor.py backend/tests/chain/test_chain_executor.py
ruff check --select E9,F63,F7,F40 backend/archimedes/chain/executor.py backend/tests/chain/test_chain_executor.py
```

## Anti-goals

- Does not touch the raw-key fallback path in `create_vault` (already
  raises correctly on missing vault address).
- Does not touch `_confirm_receipt` or `execute_trades`.
- No retry/backoff changes.