### PR TITLE
[backend] Fix create_vaults() createVault revert handling (#655)

### DIFF
--- a/backend/archimedes/scripts/bootstrap_vaults.py
+++ b/backend/archimedes/scripts/bootstrap_vaults.py
@@ -30,6 +30,7 @@ load_dotenv(".env", override=False)
 from archimedes.chain.circle_signer import circle_signer
 from archimedes.chain.client import chain_client
 from archimedes.chain.contracts import get_contract_loader
+from archimedes.chain.executor import VaultCreationRevertedError
 
 # ─── Configuration ──────────────────────────────────────────────
 
@@ -248,6 +249,9 @@ async def create_vaults(minted: dict[str, float]) -> list[dict]:
                 chain_client.w3.to_bytes(hexstr=tx_hash.removeprefix("0x"))
             )
 
+            if receipt.get("status") == 0:
+                raise VaultCreationRevertedError(f"createVault tx reverted on-chain: {tx_hash}")
+
             vault_address = None
             factory = loader.vault_factory
             for log in receipt.logs:
@@ -259,7 +263,13 @@ async def create_vaults(minted: dict[str, float]) -> list[dict]:
                     continue
 
             if not vault_address:
-                # Fallback: get last vault from factory
+                # Tx succeeded but no VaultCreated event was found — fall back
+                # to the most recently created vault, but flag it: this masks
+                # an event-decoding/indexing issue, not a revert (handled above).
+                print(
+                    f"  ⚠️  {profile['name']}: createVault tx succeeded but no VaultCreated "
+                    f"event found; falling back to most recent vault from getVaults()"
+                )
                 all_vaults = await factory.functions.getVaults().call()
                 vault_address = all_vaults[-1]
 

--- a/backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
+++ b/backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
@@ -1,0 +1,112 @@
+"""Tests for create_vaults()'s createVault revert handling (#655).
+
+Mirrors TestCreateVault in backend/tests/chain/test_chain_executor.py (#651):
+create_vaults() submits createVault via Circle's execute_contract and, before
+this fix, fell back to all_vaults[-1] (an existing vault's address) on both a
+revert and a successful-tx-but-no-event case, indistinguishably.
+
+Hermetic: circle_signer, chain_client, and get_contract_loader are mocked.
+No network, no Arc RPC, no Circle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from archimedes.scripts.bootstrap_vaults import create_vaults
+from web3.datastructures import AttributeDict
+
+_TEST_PROFILE = {
+    "name": "Test Vault",
+    "symbol": "vTEST",
+    "management_fee_bps": 100,
+    "performance_fee_bps": 1000,
+    "agent_assisted": True,
+    "allocations": {"USDC": 10000},
+}
+
+
+class TestCreateVaults:
+    """Coverage for create_vaults' createVault revert handling (#655)."""
+
+    def test_happy_path_returns_parsed_vault_address(self):
+        """status=1 + VaultCreated event found → vault appended with the
+        parsed address, without ever calling getVaults()."""
+        factory = MagicMock()
+        factory.events.VaultCreated.return_value.process_log.return_value = {"args": {"vault": "0xNewVault"}}
+        loader = MagicMock()
+        loader.vault_factory = factory
+        receipt = AttributeDict({"status": 1, "logs": [MagicMock()]})
+
+        with (
+            patch("archimedes.scripts.bootstrap_vaults.VAULT_PROFILES", [_TEST_PROFILE]),
+            patch("archimedes.scripts.bootstrap_vaults.get_contract_loader", return_value=loader),
+            patch("archimedes.scripts.bootstrap_vaults.circle_signer") as mock_signer,
+            patch("archimedes.scripts.bootstrap_vaults.chain_client") as mock_cc,
+        ):
+            mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
+            mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value=receipt)
+
+            vaults = asyncio.run(create_vaults({}))
+
+        assert vaults == [
+            {
+                "address": "0xNewVault",
+                "name": "Test Vault",
+                "symbol": "vTEST",
+                "allocations": {"USDC": 10000},
+            }
+        ]
+        factory.functions.getVaults.assert_not_called()
+
+    def test_revert_skips_profile_and_prints_error(self, capsys):
+        """status=0 → VaultCreationRevertedError is raised, caught by the
+        per-profile try/except, and the profile is NOT appended to vaults
+        (the bug #655 guards against: silently returning all_vaults[-1])."""
+        factory = MagicMock()
+        loader = MagicMock()
+        loader.vault_factory = factory
+        receipt = AttributeDict({"status": 0, "logs": []})
+
+        with (
+            patch("archimedes.scripts.bootstrap_vaults.VAULT_PROFILES", [_TEST_PROFILE]),
+            patch("archimedes.scripts.bootstrap_vaults.get_contract_loader", return_value=loader),
+            patch("archimedes.scripts.bootstrap_vaults.circle_signer") as mock_signer,
+            patch("archimedes.scripts.bootstrap_vaults.chain_client") as mock_cc,
+        ):
+            mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
+            mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value=receipt)
+
+            vaults = asyncio.run(create_vaults({}))
+
+        assert vaults == []
+        factory.functions.getVaults.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Test Vault: creation failed" in captured.out
+        assert "reverted on-chain" in captured.out
+
+    def test_no_event_falls_back_with_warning(self, capsys):
+        """status=1 but no VaultCreated event found → falls back to
+        all_vaults[-1] and prints a warning flagging the indexing gap."""
+        factory = MagicMock()
+        factory.events.VaultCreated.return_value.process_log.side_effect = Exception("no match")
+        factory.functions.getVaults.return_value.call = AsyncMock(return_value=["0xOldVault1", "0xOldVault2"])
+        loader = MagicMock()
+        loader.vault_factory = factory
+        receipt = AttributeDict({"status": 1, "logs": [MagicMock()]})
+
+        with (
+            patch("archimedes.scripts.bootstrap_vaults.VAULT_PROFILES", [_TEST_PROFILE]),
+            patch("archimedes.scripts.bootstrap_vaults.get_contract_loader", return_value=loader),
+            patch("archimedes.scripts.bootstrap_vaults.circle_signer") as mock_signer,
+            patch("archimedes.scripts.bootstrap_vaults.chain_client") as mock_cc,
+        ):
+            mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
+            mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value=receipt)
+
+            vaults = asyncio.run(create_vaults({}))
+
+        assert vaults[0]["address"] == "0xOldVault2"
+        captured = capsys.readouterr()
+        assert "no VaultCreated event found" in captured.out


### PR DESCRIPTION
## Summary

Mirrors #651/#653: `create_vaults()` in `backend/archimedes/scripts/bootstrap_vaults.py`
submitted `createVault` via Circle's `execute_contract`, waited for the w3 receipt,
but never checked `receipt.status` before parsing for the `VaultCreated` event —
falling back to `all_vaults[-1]` (an existing vault's address) on both a revert AND
a successful-tx-but-no-event case, indistinguishably.

Closes #655.

## Changes

- `bootstrap_vaults.py`: import `VaultCreationRevertedError` (from #651/#653,
  already on `main`); raise it on `receipt.get("status") == 0`, before the
  `VaultCreated`-parsing loop. The existing per-profile
  `try/except Exception as e: print(f"  ❌ {profile['name']}: creation failed — {e}")`
  catches and reports it — no error-handling restructure needed. Also print a
  `⚠️` warning on the remaining no-event `all_vaults[-1]` fallback (status==1, no
  event found — an indexing gap, not a revert).
- New `backend/tests/scripts/test_bootstrap_vaults_create_vaults.py`: happy path,
  revert (raises, profile skipped, `getVaults` never called), and no-event fallback
  (warns, falls back to `all_vaults[-1]`). Manually verified these two new tests FAIL
  against the pre-fix code (via `git stash` on the production file) and PASS with
  the fix.

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/scripts/ -q
ruff format --check backend/archimedes/scripts/bootstrap_vaults.py backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
ruff check --select E9,F63,F7,F40 backend/archimedes/scripts/bootstrap_vaults.py backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
```