### PR TITLE
[quant] Relabel flat_pct-derived value as EnsembleConsensus, not market regime (#659)

### DIFF
--- a/backend/archimedes/api/agent_routes.py
+++ b/backend/archimedes/api/agent_routes.py
@@ -27,10 +27,12 @@ async def get_agent_status():
     try:
         heartbeat = await state.get_heartbeat()
         regime_data = await state.load_regime()
+        consensus_data = await state.load_ensemble_consensus()
         events = await state.get_events(count=10)
     except Exception:
         heartbeat = None
         regime_data = None
+        consensus_data = None
         events = []
     finally:
         await state.close()
@@ -44,10 +46,24 @@ async def get_agent_status():
         except Exception:
             pass
 
-    regime = regime_data.get("regime") if regime_data else None
-    confidence = regime_data.get("confidence") if regime_data else None
-    source = regime_data.get("source") if regime_data else None
-    strat_count = regime_data.get("strategy_count", 0) if regime_data else 0
+    # Market regime is exogenous (None/"unknown" until a detector is wired).
+    # The "regime"-shaped value the agent actually produces is the endogenous
+    # ensemble consensus (#659) — surface that, labelled as such via `source`.
+    if regime_data:
+        regime = regime_data.get("regime")
+        confidence = regime_data.get("confidence")
+        source = regime_data.get("source")
+        strat_count = regime_data.get("strategy_count", 0)
+    elif consensus_data:
+        regime = consensus_data.get("label")
+        confidence = consensus_data.get("confidence")
+        source = consensus_data.get("source")  # "strategy_consensus"
+        strat_count = consensus_data.get("strategy_count", 0)
+    else:
+        regime = None
+        confidence = None
+        source = None
+        strat_count = 0
 
     vault_count = 0
     try:

--- a/backend/archimedes/api/regime_routes.py
+++ b/backend/archimedes/api/regime_routes.py
@@ -18,6 +18,14 @@ async def get_current_regime():
     state = AgentStateStore()
     try:
         data = await state.load_regime()
+        if not data:
+            # No exogenous market regime yet (no detector wired). Fall back to
+            # the endogenous ensemble consensus so the surface still shows the
+            # agent's directional state — labelled `source=strategy_consensus`
+            # so callers know it is consensus, not a market regime (#659).
+            consensus = await state.load_ensemble_consensus()
+            if consensus:
+                data = {**consensus, "regime": consensus.get("label", "unknown")}
     except Exception:
         data = None
     finally:

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -493,7 +493,12 @@ class StrategySignalResponse(BaseModel):
 
 class StrategySignalsResponse(BaseModel):
     strategy_count: int
+    # `regime` is retained for backward compatibility with existing frontend
+    # reads. It is the flat_pct-derived ENSEMBLE CONSENSUS bucket, not a market
+    # regime (#659) — `ensemble_consensus` carries the same value under the
+    # correct name. A true market regime would come from a detector.
     regime: str
+    ensemble_consensus: str | None = None
     confidence: float
     target_weights: dict[str, float]
     strategies: list[StrategySignalResponse]

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -183,16 +183,16 @@ async def get_strategy_signals():
 
     target_weights = strategy_evaluator.aggregate_signals(all_signals, usdc_floor=0.20)
 
+    # flat_pct → ensemble-consensus bucket (#659). This is the agent's
+    # directional consensus, NOT a market regime; the model owns the thresholds.
+    from archimedes.models.regime import EnsembleConsensus
+
     flat_count = sum(1 for ss in all_signals for s in ss.signals if s.signal.value == "flat")
     total_count = sum(len(ss.signals) for ss in all_signals)
-    flat_pct = flat_count / total_count if total_count > 0 else 0
-
-    if flat_pct > 0.6:
-        regime = "risk_off"
-    elif flat_pct > 0.3:
-        regime = "transition"
-    else:
-        regime = "risk_on"
+    consensus = EnsembleConsensus.from_signal_counts(flat_count, total_count)
+    flat_pct = consensus.flat_pct
+    # `regime` kept for backward-compat; it carries the consensus bucket value.
+    regime = consensus.label.value
 
     strat_responses = []
     for ss in all_signals:
@@ -216,6 +216,7 @@ async def get_strategy_signals():
     return StrategySignalsResponse(
         strategy_count=len(all_signals),
         regime=regime,
+        ensemble_consensus=consensus.label.value,
         confidence=round(1.0 - flat_pct, 2),
         target_weights=target_weights,
         strategies=strat_responses,
@@ -244,6 +245,14 @@ async def get_portfolio_advisor(
     state = AgentStateStore()
     try:
         regime_data = await state.load_regime()
+        if not regime_data:
+            # No market detector wired — fall back to the ensemble-consensus
+            # bucket so the advisor still has a directional prior (#659). The
+            # bucket names line up with Regime values, so the deleverage map
+            # below still resolves; it is consensus-driven, not market-driven.
+            consensus = await state.load_ensemble_consensus()
+            if consensus:
+                regime_data = {"regime": consensus.get("label"), "confidence": consensus.get("confidence")}
     except Exception:
         regime_data = None
     finally:
@@ -1236,13 +1245,17 @@ async def generate_strategy(
         state = AgentStateStore()
         try:
             regime_data = await state.load_regime()
-            if regime_data:
+            consensus_data = await state.load_ensemble_consensus()
+            # Surface market regime (exogenous, may be absent) and ensemble
+            # consensus (endogenous, from flat_pct) as DISTINCT context (#659).
+            if regime_data or consensus_data:
                 market_context = {
-                    "regime": regime_data.get("regime", "unknown"),
-                    "confidence": regime_data.get("confidence", 0.0),
-                    "source": regime_data.get("source", ""),
-                    "strategy_count": regime_data.get("strategy_count", 0),
-                    "signals": regime_data.get("signals", {}),
+                    "regime": (regime_data or {}).get("regime", "unknown"),
+                    "ensemble_consensus": (consensus_data or {}).get("label", "unknown"),
+                    "confidence": (consensus_data or regime_data or {}).get("confidence", 0.0),
+                    "source": (consensus_data or regime_data or {}).get("source", ""),
+                    "strategy_count": (consensus_data or regime_data or {}).get("strategy_count", 0),
+                    "signals": (consensus_data or regime_data or {}).get("signals", {}),
                 }
         finally:
             await state.close()
@@ -1547,7 +1560,7 @@ async def construct_strategy(
     request: Request,
     response: Response,
     _wallet: str | None = Depends(gate_generation),
-):  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+):
     """Interactive strategy architect -- the 'design me a portfolio' path."""
     from fastapi import HTTPException
 

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -35,6 +35,7 @@ from archimedes.models.portfolio import (
     TradeDirection,
     TradeOrder,
 )
+from archimedes.models.regime import EnsembleConsensus
 from archimedes.models.trace import DecisionType, ReasoningTrace
 from archimedes.services.redis_state import AgentStateStore
 from archimedes.services.source_tracker import build_consulted_hashes
@@ -58,6 +59,12 @@ USDC_FLOOR = float(os.getenv("AGENT_USDC_FLOOR", "0.20"))
 
 # Drift threshold for rebalance trigger
 _DRIFT_THRESHOLD = 0.15
+
+# Exogenous market regime is not detected here — an IRegimeDetector (separate
+# issue) would write KEY_REGIME. Until then the market regime is honestly
+# "unknown", and the only regime-shaped signal we have is the *endogenous*
+# ensemble consensus (issue #659). Traces carry both, clearly distinguished.
+_MARKET_REGIME_UNKNOWN = "unknown"
 
 
 def _compute_confidence(all_signals: list[StrategySignals]) -> float:
@@ -192,20 +199,22 @@ class StrategyRunner:
                 " | ".join(f"{k}={v:.0%}" for k, v in target_weights.items()),
             )
 
-            # Derive regime from strategy consensus (how many say flat)
+            # Compute the ensemble consensus (how decisive the ensemble is).
+            # NOTE: flat_pct is an *endogenous* ensemble-uncertainty signal — it
+            # is NOT a market regime. We keep the flat_pct computation (it is a
+            # useful consensus signal) but label it honestly as agent consensus
+            # rather than overloading it onto the exogenous market regime (#659).
             flat_count = sum(1 for ss in all_signals for s in ss.signals if s.signal.value == "flat")
             total_count = sum(len(ss.signals) for ss in all_signals)
-            flat_pct = flat_count / total_count if total_count > 0 else 0
+            consensus = EnsembleConsensus.from_signal_counts(flat_count, total_count)
 
-            if flat_pct > 0.6:
-                regime = "risk_off"
-            elif flat_pct > 0.3:
-                regime = "transition"
-            else:
-                regime = "risk_on"
+            # Market regime is exogenous and not detected here — stays "unknown"
+            # until an IRegimeDetector is wired (separate issue).
+            market_regime = _MARKET_REGIME_UNKNOWN
 
-            # Save regime to Redis
-            await self.state.save_regime_from_values(regime, flat_pct, all_signals)
+            # Persist the ensemble consensus under its OWN Redis key so it does
+            # not shadow the market regime.
+            await self.state.save_ensemble_consensus(consensus, all_signals)
 
             # 4. Build target allocations
             targets = self._weights_to_targets(target_weights, all_signals)
@@ -252,7 +261,8 @@ class StrategyRunner:
                             vault_addr,
                             targets,
                             all_signals,
-                            regime,
+                            market_regime,
+                            consensus,
                             tick_id,
                         )
                         continue
@@ -289,7 +299,8 @@ class StrategyRunner:
                         vault_addr,
                         vault_targets,
                         scoped_signals,
-                        regime,
+                        market_regime,
+                        consensus,
                         tick_id,
                     )
                 except Exception:
@@ -333,10 +344,15 @@ class StrategyRunner:
         vault_address: str,
         targets: list[TargetAllocation],
         all_signals: list[StrategySignals],
-        regime: str,
+        market_regime: str,
+        consensus: EnsembleConsensus,
         tick_id: str,
     ) -> None:
-        """Process a single vault: read portfolio → diff → maybe trade → publish trace."""
+        """Process a single vault: read portfolio → diff → maybe trade → publish trace.
+
+        ``market_regime`` is the exogenous regime (``"unknown"`` until a detector
+        is wired); ``consensus`` is the endogenous ensemble consensus (#659).
+        """
         logger.info("[tick %s] Processing vault %s", tick_id, vault_address[:10])
 
         # Read current portfolio
@@ -372,7 +388,8 @@ class StrategyRunner:
                     portfolio,
                     [],
                     all_signals,
-                    regime,
+                    market_regime,
+                    consensus,
                     tick_id,
                     "Vault is empty — awaiting initial deposit.",
                 )
@@ -462,7 +479,8 @@ class StrategyRunner:
                 portfolio,
                 [],
                 all_signals,
-                regime,
+                market_regime,
+                consensus,
                 tick_id,
                 "Portfolio aligned with strategy signals. No rebalance needed.",
             )
@@ -470,11 +488,12 @@ class StrategyRunner:
 
         # Log the trade plan
         logger.info(
-            "[tick %s] REBALANCE vault %s: %d trades (regime=%s)",
+            "[tick %s] REBALANCE vault %s: %d trades (market_regime=%s, consensus=%s)",
             tick_id,
             vault_address[:10],
             len(trades),
-            regime,
+            market_regime,
+            consensus.label.value,
         )
         for t in trades:
             logger.info(
@@ -516,7 +535,8 @@ class StrategyRunner:
                 portfolio,
                 [],
                 all_signals,
-                regime,
+                market_regime,
+                consensus,
                 tick_id,
                 f"V_check rejected: {'; '.join(v_result.failures)}",
             )
@@ -524,7 +544,7 @@ class StrategyRunner:
 
         # ── Commit-Reveal Flow ────────────────────────────────────
         # Phase 1: COMMIT — compute hash and anchor on-chain BEFORE trade
-        reasoning = self._build_reasoning(all_signals, regime, trades, portfolio)
+        reasoning = self._build_reasoning(all_signals, market_regime, consensus, trades, portfolio)
 
         # Deduplicate: skip identical decisions to avoid trace spam.
         # When the same strategy signals produce the same reasoning, anchoring
@@ -552,7 +572,8 @@ class StrategyRunner:
                 vault_address,
                 trades,
                 all_signals,
-                regime,
+                market_regime,
+                consensus,
                 tick_id,
                 reasoning,
                 portfolio,
@@ -597,7 +618,8 @@ class StrategyRunner:
                     portfolio,
                     [],
                     all_signals,
-                    regime,
+                    market_regime,
+                    consensus,
                     tick_id,
                     f"Swap skipped — thin pool: {e}",
                     commit_tx=commit_tx,
@@ -618,7 +640,8 @@ class StrategyRunner:
                     portfolio,
                     [],
                     all_signals,
-                    regime,
+                    market_regime,
+                    consensus,
                     tick_id,
                     f"Execution failed: {e}",
                     commit_tx=commit_tx,
@@ -635,7 +658,8 @@ class StrategyRunner:
             portfolio,
             trades,
             all_signals,
-            regime,
+            market_regime,
+            consensus,
             tick_id,
             reasoning,
             tx_hashes,
@@ -717,7 +741,8 @@ class StrategyRunner:
         vault_address: str,
         trades: list[TradeOrder],
         all_signals: list[StrategySignals],
-        regime: str,
+        market_regime: str,
+        consensus: EnsembleConsensus,
         tick_id: str,
         reasoning: str,
         portfolio: Portfolio,
@@ -733,7 +758,9 @@ class StrategyRunner:
             trigger="commit_phase",
             timestamp=datetime.now(UTC),
             market_context={
-                "regime": regime,
+                "regime": market_regime,
+                "ensemble_consensus": consensus.label.value,
+                "ensemble_flat_pct": round(consensus.flat_pct, 4),
                 "strategy_count": len(all_signals),
                 "phase": "commit",
             },
@@ -789,7 +816,8 @@ class StrategyRunner:
         portfolio: Portfolio,
         trades: list[TradeOrder],
         all_signals: list[StrategySignals],
-        regime: str,
+        market_regime: str,
+        consensus: EnsembleConsensus,
         tick_id: str,
         reasoning: str,
         tx_hashes: list[str] | None = None,
@@ -808,7 +836,9 @@ class StrategyRunner:
             trigger=trigger,
             timestamp=datetime.now(UTC),
             market_context={
-                "regime": regime,
+                "regime": market_regime,
+                "ensemble_consensus": consensus.label.value,
+                "ensemble_flat_pct": round(consensus.flat_pct, 4),
                 "strategy_count": len(all_signals),
                 "signal_summary": {
                     ss.paper_title[:30]: {s.asset: f"{s.signal.value}({s.weight:.0%})" for s in ss.signals[:5]}
@@ -905,7 +935,8 @@ class StrategyRunner:
         portfolio: Portfolio,
         trades: list[TradeOrder],
         all_signals: list[StrategySignals],
-        regime: str,
+        market_regime: str,
+        consensus: EnsembleConsensus,
         tick_id: str,
         reasoning: str,
         tx_hashes: list[str] | None = None,
@@ -921,7 +952,9 @@ class StrategyRunner:
             trigger=trigger,
             timestamp=datetime.now(UTC),
             market_context={
-                "regime": regime,
+                "regime": market_regime,
+                "ensemble_consensus": consensus.label.value,
+                "ensemble_flat_pct": round(consensus.flat_pct, 4),
                 "strategy_count": len(all_signals),
                 "signal_summary": {
                     ss.paper_title[:30]: {s.asset: f"{s.signal.value}({s.weight:.0%})" for s in ss.signals[:5]}
@@ -988,7 +1021,8 @@ class StrategyRunner:
     def _build_reasoning(
         self,
         all_signals: list[StrategySignals],
-        regime: str,
+        market_regime: str,
+        consensus: EnsembleConsensus,
         trades: list[TradeOrder],
         portfolio: Portfolio | None = None,
     ) -> str:
@@ -997,8 +1031,16 @@ class StrategyRunner:
         Includes portfolio context + trade specifics so each tick's reasoning
         is distinguishable even when the underlying strategy consensus is
         identical (addresses issue #334).
+
+        Market regime (exogenous) and ensemble consensus (endogenous) are
+        surfaced as distinct lines — the consensus is derived from strategy
+        signals; the market regime is not (issue #659).
         """
-        parts = [f"Regime: {regime} (derived from strategy consensus)"]
+        parts = [
+            f"Market regime: {market_regime}",
+            f"Ensemble consensus: {consensus.label.value} "
+            f"(flat_pct={consensus.flat_pct:.0%}, derived from strategy signals)",
+        ]
         for ss in all_signals:
             signal_strs = [f"{s.asset}={s.signal.value}" for s in ss.signals[:4]]
             parts.append(f"{ss.paper_title[:35]}: {', '.join(signal_strs)}")

--- a/backend/archimedes/models/regime.py
+++ b/backend/archimedes/models/regime.py
@@ -54,3 +54,67 @@ class RegimeClassification:
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence <= 1.0:
             raise ValueError(f"Confidence must be 0-1, got {self.confidence}")
+
+
+class ConsensusLabel(str, Enum):
+    """Three-bucket label for the strategy ensemble's directional consensus.
+
+    Deliberately NOT a `Regime`. This describes how directional the *strategy
+    ensemble* is right now (endogenous: derived from the very strategies that
+    would be conditioned on the regime), not what the *market* is doing
+    (exogenous: VIX / momentum / spreads, measured by a regime detector).
+    The bucket names rhyme with the regime names by convention, but the
+    semantics are distinct — see issue #659.
+    """
+
+    RISK_ON = "risk_on"  # Mostly directional signals — ensemble is confident
+    TRANSITION = "transition"  # Mixed — a meaningful fraction of signals are flat
+    RISK_OFF = "risk_off"  # Mostly flat signals — ensemble is uncertain/defensive
+
+
+@dataclass(frozen=True)
+class EnsembleConsensus:
+    """How decisive the strategy ensemble is — agent consensus, not market regime.
+
+    Built from `flat_pct` (the fraction of strategy signals that are flat). This
+    is an *ensemble-uncertainty* signal: a high flat fraction means most
+    strategies abstain, so the agent is collectively uncertain. It is endogenous
+    — derived from the strategies themselves — and must never be persisted or
+    surfaced as a market `Regime` (issue #659).
+
+    Produced by: the strategy runner (agent_runner) once per tick.
+    Consumed by: reasoning traces, rebalance logs, and the API as an explicitly
+                 labelled "ensemble consensus" signal — kept distinct from the
+                 exogenous market regime (which stays `None`/"unknown" until an
+                 `IRegimeDetector` is wired, a separate issue).
+    """
+
+    flat_pct: float  # Fraction of signals that are flat, 0.0–1.0
+    signal_count: int  # Total number of strategy signals considered
+    label: ConsensusLabel  # Three-bucket directional consensus
+
+    # Bucket thresholds — kept here so the one true mapping lives in the model,
+    # not duplicated across agent_runner / strategies_routes.
+    _FLAT_RISK_OFF = 0.6  # > 60% flat → defensive consensus
+    _FLAT_TRANSITION = 0.3  # > 30% flat → mixed consensus
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.flat_pct <= 1.0:
+            raise ValueError(f"flat_pct must be 0-1, got {self.flat_pct}")
+        if self.signal_count < 0:
+            raise ValueError(f"signal_count must be >= 0, got {self.signal_count}")
+
+    @classmethod
+    def label_for(cls, flat_pct: float) -> ConsensusLabel:
+        """Map a flat fraction to its three-bucket consensus label."""
+        if flat_pct > cls._FLAT_RISK_OFF:
+            return ConsensusLabel.RISK_OFF
+        if flat_pct > cls._FLAT_TRANSITION:
+            return ConsensusLabel.TRANSITION
+        return ConsensusLabel.RISK_ON
+
+    @classmethod
+    def from_signal_counts(cls, flat_count: int, total_count: int) -> EnsembleConsensus:
+        """Build from raw flat/total signal counts (the agent_runner call site)."""
+        flat_pct = flat_count / total_count if total_count > 0 else 0.0
+        return cls(flat_pct=flat_pct, signal_count=total_count, label=cls.label_for(flat_pct))

--- a/backend/archimedes/services/redis_state.py
+++ b/backend/archimedes/services/redis_state.py
@@ -2,6 +2,14 @@
 
 Stores the latest regime classification and agent heartbeat in Redis
 so the API layer and frontend can read live agent state.
+
+Two distinct signals live here, under two distinct keys (issue #659):
+  - ``KEY_REGIME`` — the *exogenous* market regime from a regime detector
+    (VIX / momentum / spreads). May be absent until a detector is wired.
+  - ``KEY_ENSEMBLE_CONSENSUS`` — the *endogenous* strategy-ensemble consensus
+    derived from ``flat_pct``. Always available once the agent ticks. This is
+    "how decisive is the ensemble", NOT a market regime, and must not shadow
+    the market-regime key.
 """
 
 from __future__ import annotations
@@ -13,7 +21,7 @@ from datetime import UTC, datetime
 
 import redis.asyncio as aioredis
 
-from archimedes.models.regime import RegimeClassification
+from archimedes.models.regime import EnsembleConsensus, RegimeClassification
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +29,7 @@ REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
 # Keys
 KEY_REGIME = "archimedes:regime:current"
+KEY_ENSEMBLE_CONSENSUS = "archimedes:ensemble_consensus"
 KEY_HEARTBEAT = "archimedes:agent:heartbeat"
 KEY_LAST_REBALANCE_PREFIX = "archimedes:agent:last_rebalance:"
 KEY_TRACE_PREFIX = "archimedes:trace:"
@@ -56,13 +65,17 @@ class AgentStateStore:
         await r.set(KEY_REGIME, json.dumps(data))
         logger.debug("Saved regime to Redis: %s", classification.regime.value)
 
-    async def save_regime_from_values(
+    async def save_ensemble_consensus(
         self,
-        regime: str,
-        flat_pct: float,
+        consensus: EnsembleConsensus,
         all_signals: list,
     ) -> None:
-        """Save regime derived from strategy signal consensus."""
+        """Persist the strategy-ensemble consensus under its own Redis key.
+
+        This is the endogenous "how decisive is the ensemble" signal — derived
+        from ``flat_pct`` — and is stored under ``KEY_ENSEMBLE_CONSENSUS`` so it
+        does NOT shadow the exogenous market regime at ``KEY_REGIME`` (#659).
+        """
         r = await self._get_redis()
         signal_summary = {}
         for ss in all_signals:
@@ -75,6 +88,8 @@ class AgentStateStore:
                 }
         # Dynamic confidence from signal weights + dispersion (matches
         # _compute_confidence in agent_runner — same formula, different caller).
+        # This is the ensemble's *decisiveness*, not a market-regime confidence.
+        flat_pct = consensus.flat_pct
         if all_signals:
             directional = [s for ss in all_signals for s in ss.signals if s.signal.value != "flat"]
             vote_ratio = 1.0 - flat_pct
@@ -91,20 +106,29 @@ class AgentStateStore:
         else:
             dyn_confidence = 0.5
         data = {
-            "regime": regime,
+            "label": consensus.label.value,
             "confidence": round(dyn_confidence, 4),
             "flat_pct": round(flat_pct, 2),
-            "strategy_count": len(all_signals),
+            "strategy_count": consensus.signal_count or len(all_signals),
             "signals": signal_summary,
             "timestamp": datetime.now(UTC).isoformat(),
             "source": "strategy_consensus",
         }
-        await r.set(KEY_REGIME, json.dumps(data))
-        logger.debug("Saved strategy-derived regime to Redis: %s", regime)
+        await r.set(KEY_ENSEMBLE_CONSENSUS, json.dumps(data))
+        logger.debug("Saved ensemble consensus to Redis: %s", consensus.label.value)
 
     async def load_regime(self) -> dict | None:
+        """Load the exogenous market regime (may be None until a detector writes it)."""
         r = await self._get_redis()
         raw = await r.get(KEY_REGIME)
+        if raw:
+            return json.loads(raw)
+        return None
+
+    async def load_ensemble_consensus(self) -> dict | None:
+        """Load the endogenous strategy-ensemble consensus (#659)."""
+        r = await self._get_redis()
+        raw = await r.get(KEY_ENSEMBLE_CONSENSUS)
         if raw:
             return json.loads(raw)
         return None

--- a/backend/tests/models/test_regime_model.py
+++ b/backend/tests/models/test_regime_model.py
@@ -1,0 +1,69 @@
+"""Unit coverage for the regime data models — focused on EnsembleConsensus (#659).
+
+EnsembleConsensus is the endogenous strategy-ensemble consensus derived from
+`flat_pct`. It is deliberately NOT a `Regime`: it measures how decisive the
+strategy ensemble is, not what the market is doing. These tests pin the bucket
+thresholds, the validation, and the distinctness from `Regime`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.models.regime import (
+    ConsensusLabel,
+    EnsembleConsensus,
+    Regime,
+)
+
+
+class TestConsensusLabel:
+    def test_is_not_the_regime_enum(self) -> None:
+        # Same string values by convention, but distinct types/semantics.
+        assert ConsensusLabel is not Regime
+        assert ConsensusLabel.RISK_ON.value == "risk_on"
+        assert not isinstance(ConsensusLabel.RISK_ON, Regime)
+
+
+class TestEnsembleConsensusBuckets:
+    @pytest.mark.parametrize(
+        ("flat_pct", "expected"),
+        [
+            (0.0, ConsensusLabel.RISK_ON),
+            (0.30, ConsensusLabel.RISK_ON),  # boundary: not > 0.3
+            (0.301, ConsensusLabel.TRANSITION),
+            (0.50, ConsensusLabel.TRANSITION),
+            (0.60, ConsensusLabel.TRANSITION),  # boundary: not > 0.6
+            (0.601, ConsensusLabel.RISK_OFF),
+            (1.0, ConsensusLabel.RISK_OFF),
+        ],
+    )
+    def test_label_for_thresholds(self, flat_pct: float, expected: ConsensusLabel) -> None:
+        assert EnsembleConsensus.label_for(flat_pct) is expected
+
+    def test_from_signal_counts(self) -> None:
+        c = EnsembleConsensus.from_signal_counts(flat_count=3, total_count=4)
+        assert c.flat_pct == 0.75
+        assert c.signal_count == 4
+        assert c.label is ConsensusLabel.RISK_OFF
+
+    def test_from_signal_counts_zero_total_is_risk_on(self) -> None:
+        # No signals → flat_pct defaults to 0.0 → RISK_ON (fully directional prior).
+        c = EnsembleConsensus.from_signal_counts(flat_count=0, total_count=0)
+        assert c.flat_pct == 0.0
+        assert c.signal_count == 0
+        assert c.label is ConsensusLabel.RISK_ON
+
+    def test_is_frozen(self) -> None:
+        c = EnsembleConsensus.from_signal_counts(flat_count=1, total_count=2)
+        with pytest.raises((AttributeError, TypeError)):
+            c.flat_pct = 0.9  # type: ignore[misc]
+
+
+class TestEnsembleConsensusValidation:
+    def test_rejects_out_of_range_flat_pct(self) -> None:
+        with pytest.raises(ValueError, match="flat_pct"):
+            EnsembleConsensus(flat_pct=1.5, signal_count=3, label=ConsensusLabel.RISK_OFF)
+
+    def test_rejects_negative_signal_count(self) -> None:
+        with pytest.raises(ValueError, match="signal_count"):
+            EnsembleConsensus(flat_pct=0.5, signal_count=-1, label=ConsensusLabel.TRANSITION)

--- a/backend/tests/services/test_redis_state.py
+++ b/backend/tests/services/test_redis_state.py
@@ -14,11 +14,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from archimedes.models.regime import (
+    ConsensusLabel,
+    EnsembleConsensus,
     Regime,
     RegimeClassification,
     RegimeSignals,
 )
 from archimedes.services.redis_state import (
+    KEY_ENSEMBLE_CONSENSUS,
     KEY_HEARTBEAT,
     KEY_LAST_REBALANCE_PREFIX,
     KEY_REGIME,
@@ -80,27 +83,29 @@ class TestRegime:
         assert payload["confidence"] == 0.8
 
     @pytest.mark.asyncio
-    async def test_save_regime_from_values(self) -> None:
+    async def test_save_ensemble_consensus_writes_to_distinct_key(self) -> None:
+        """Ensemble consensus is persisted under its OWN key, not KEY_REGIME (#659)."""
         store, fake = await _store_with_fake_redis()
         signal_summary = MagicMock()
         signal_summary.signals = []
         signal_summary.paper_title = "Faber 2007"
-        await store.save_regime_from_values("transition", 0.4, [signal_summary])
+        consensus = EnsembleConsensus.from_signal_counts(flat_count=2, total_count=5)
+        await store.save_ensemble_consensus(consensus, [signal_summary])
         fake.set.assert_awaited_once()
-        payload = json.loads(fake.set.await_args.args[1])
-        assert payload["regime"] == "transition"
-        # Dynamic confidence formula (introduced in commit fabc57f, "Bug sweep:
-        # dynamic regime confidence + cleanup junk constants"): replaces the
-        # earlier `1 - flat_pct` simple form with a dispersion-aware
-        # consensus signal. With flat_pct=0.4 and the empty-signals fixture:
-        #   vote_ratio = 1.0 - 0.4 = 0.6
-        #   directional = []          (signals list empty)
-        #   avg_strength = 0.0        (no directional signals)
-        #   dispersion_penalty = 0.0  (< 2 weights)
+        key, value = fake.set.await_args.args
+        # Critical: must NOT shadow the market-regime key.
+        assert key == KEY_ENSEMBLE_CONSENSUS
+        assert key != KEY_REGIME
+        payload = json.loads(value)
+        # The persisted payload carries a "label" (consensus bucket), not a
+        # "regime" — the consensus is not a market regime.
+        assert payload["label"] == ConsensusLabel.TRANSITION.value
+        assert "regime" not in payload
+        assert payload["flat_pct"] == 0.4
+        assert payload["strategy_count"] == 5
+        # Dynamic confidence: with flat_pct=0.4 and the empty-signals fixture:
+        #   vote_ratio = 1.0 - 0.4 = 0.6 ; avg_strength = 0.0 ; dispersion = 0.0
         #   dyn = clamp(0.6 * (0.5 + 0.5 * 0.0) - 0.0, 0.05, 0.99) = 0.3
-        # Keeping this expectation explicit + commented so a future change to
-        # the formula is caught here (rather than silently producing a wrong
-        # confidence on every agent tick).
         assert payload["confidence"] == 0.3
         assert payload["source"] == "strategy_consensus"
 
@@ -115,6 +120,19 @@ class TestRegime:
         fake.get.return_value = json.dumps({"regime": "risk_on", "confidence": 0.9})
         loaded = await store.load_regime()
         assert loaded["regime"] == "risk_on"
+
+    @pytest.mark.asyncio
+    async def test_load_ensemble_consensus_returns_none_when_missing(self) -> None:
+        store, _ = await _store_with_fake_redis()
+        assert await store.load_ensemble_consensus() is None
+
+    @pytest.mark.asyncio
+    async def test_load_ensemble_consensus_parses_json(self) -> None:
+        store, fake = await _store_with_fake_redis()
+        fake.get.return_value = json.dumps({"label": "risk_off", "confidence": 0.2, "flat_pct": 0.8})
+        loaded = await store.load_ensemble_consensus()
+        assert loaded["label"] == "risk_off"
+        assert loaded["flat_pct"] == 0.8
 
 
 class TestHeartbeat:


### PR DESCRIPTION
## Summary

Closes #659.

`agent_runner.py` derived a market-regime label (`risk_on` / `transition` /
`risk_off`) from `flat_pct` — the fraction of flat strategy signals — and
persisted it under the market-regime Redis key. That is semantically wrong:
`flat_pct` is an **endogenous** ensemble-uncertainty signal (how decisive the
strategy ensemble is), not an **exogenous** market regime (VIX / momentum /
spreads). Using it as the regime created a feedback loop and misleading
provenance.

This relabels the value as **agent / ensemble consensus** and keeps it
distinct from the (not-yet-detected) market regime.

- **`models/regime.py`** — adds `ConsensusLabel` (three-bucket enum) and an
  `EnsembleConsensus` frozen dataclass holding `flat_pct`, `signal_count`, and
  the bucket label. The bucket thresholds live in the model
  (`label_for` / `from_signal_counts`). It is explicitly *not* a `Regime`.
- **`chain/agent_runner.py`** — the `flat_pct` block builds an
  `EnsembleConsensus` instead of assigning a market-regime string. The
  `flat_pct` computation is **kept**. Market regime stays `"unknown"` until an
  `IRegimeDetector` is wired (separate issue). Reasoning traces, the commit /
  reveal traces, and the rebalance log now carry market regime and ensemble
  consensus as **distinct** fields.
- **`services/redis_state.py`** — persists consensus under a **distinct** key
  `archimedes:ensemble_consensus` via `save_ensemble_consensus`
  (`save_regime_from_values` removed). `KEY_REGIME` is reserved for a real
  market detector; `load_ensemble_consensus` added.
- **API readers** (`agent_routes`, `regime_routes`, `strategies_routes`) fall
  back to the consensus key and label it `source=strategy_consensus` so the
  existing frontend surfaces keep working (anti-goal: don't break readers).
  `StrategySignalsResponse` gains an additive optional `ensemble_consensus`
  field; `regime` is retained for backward compatibility.
- Unit tests for the new model and for distinct-key persistence.

Cross-lane note: `chain/agent_runner.py` is in the on-chain integration lane
(Chuan lead) — flagging for that review. No contract changes.

## Verify

```bash
# AC: EnsembleConsensus exists in the model
grep -n "EnsembleConsensus" backend/archimedes/models/regime.py
#   76:class EnsembleConsensus:
#  117:    def from_signal_counts(...)

# AC: no line assigns a market regime from flat_pct in agent_runner
grep -n 'regime = "risk_off"\|regime = "risk_on"\|regime = "transition"' \
  backend/archimedes/chain/agent_runner.py
#   (no output — good)

# AC: flat_pct computation is kept (anti-goal)
grep -n "flat_pct" backend/archimedes/chain/agent_runner.py
#   (still present — consumed via EnsembleConsensus)

# AC: old shadowing persist method removed
grep -rn "save_regime_from_values" backend/archimedes/
#   (no output — good)

# Unit suite (the CI gate)
python -m pytest backend/tests/ -q -m "not integration"
#   1578 passed, 2 skipped

# ruff gates (hard CI block)
ruff format --check .                      # 315 files already formatted
ruff check --select E9,F63,F7,F40 .        # All checks passed!
```

Results on this branch: all of the above pass — `1578 passed, 2 skipped`
(the 2 skips are the pre-existing `chain_client.settings` module-init skips);
ruff format + critical-lint gate clean.

## Anti-goals

- **flat_pct computation kept** — not removed; it is a useful ensemble-
  uncertainty signal, now labelled correctly. Verified by
  `grep -n "flat_pct" backend/archimedes/chain/agent_runner.py`.
- **`IRegimeDetector` NOT wired here** — market regime stays `"unknown"`; the
  detector is a separate issue. Only referenced in comments/docstrings.
- **Existing Redis readers not broken** — consensus lives under a new key and
  readers fall back to it with an honest `source` label; `KEY_REGIME` untouched
  for the future detector.
