### PR TITLE
[observability] CloudWatch dashboards + alarms (#418 Layer 1)

### DIFF
--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -242,6 +242,672 @@ resource "aws_cloudwatch_dashboard" "ops" {
   })
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #418 — Layer 1 (AWS infrastructure metrics).
+#
+# Adds versioned per-subsystem CloudWatch dashboards (Aurora, ElastiCache,
+# VPC/NAT, EC2 backend, ALB, WAF) plus the additional alarms named in the issue
+# (NAT transfer anomaly, ALB 5xx > 1% over 5 min, Aurora connections > 80%,
+# Aurora ACU pinned at max, ElastiCache evictions, WAF blocked-request spike).
+#
+# Layer 2 (Prometheus app metrics) and Layer 3 (self-hosted Grafana) are
+# SEPARATE PRs — explicitly out of scope here.
+#
+# All resources reference the real infra resources defined in the sibling
+# infra/*.tf files (aurora.tf, elasticache.tf, alb.tf, waf.tf, vpc.tf, main.tf)
+# so every widget and alarm points at a live target. The alarms reuse the
+# existing aws_sns_topic.alerts topic above (no new SNS topic is created — a
+# second topic would collide and split alarm routing).
+#
+# ⚠️  Same offline-authoring caveat as the top of this file: run `terraform plan`
+#     from infra/ before applying. These are additive CloudWatch objects only.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ElastiCache CloudWatch metrics are emitted per cache node, keyed by
+# CacheClusterId. For a single-node replication group the node id is
+# "<replication_group_id>-001". Computed once here so widgets/alarms stay in sync
+# with elasticache.tf if the node count changes.
+locals {
+  redis_node_id = "${aws_elasticache_replication_group.main.replication_group_id}-001"
+
+  # WAF emits metrics in AWS/WAFV2 keyed by WebACL + Region + (per-rule) Rule.
+  # Region dimension is the human region label for REGIONAL scope ACLs.
+  waf_metric_name = aws_wafv2_web_acl.main.name
+}
+
+# ── Additional alarms (issue #418) ───────────────────────────────────────────
+
+# NAT data-transfer anomaly — sustained high outbound bytes from a NAT instance
+# catches both surprise bills and suspicious egress/exfiltration. fck-nat
+# instances are plain EC2, so NetworkOut is the AWS/EC2 metric. Threshold is a
+# conservative first cut (~5 GB / 5-min datapoint ≈ 1.1 GB/min sustained); tune
+# against a baseline. One alarm per NAT instance (one per AZ).
+resource "aws_cloudwatch_metric_alarm" "nat_egress_anomaly" {
+  count               = length(aws_instance.nat)
+  alarm_name          = "${var.project_name}-nat-egress-anomaly-${count.index}"
+  alarm_description   = "NAT instance ${count.index} NetworkOut > 5 GB per 5-min datapoint for 15 min — surprise-bill / exfiltration signal."
+  namespace           = "AWS/EC2"
+  metric_name         = "NetworkOut"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 5368709120 # 5 GiB in bytes, per 5-min period
+  period              = 300
+  evaluation_periods  = 3
+  dimensions          = { InstanceId = aws_instance.nat[count.index].id }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"
+  tags                = { Project = var.project_name }
+}
+
+# ALB 5xx error RATE > 1% sustained 5 min. Uses a metric-math expression:
+# 100 * target-5xx / request-count. This is distinct from the existing
+# absolute-count alarm (alb_5xx_high) — a rate alarm catches degradation that
+# scales with traffic, where a fixed count would either flap or miss it.
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_rate_high" {
+  alarm_name          = "${var.project_name}-alb-5xx-rate-high"
+  alarm_description   = "Backend 5xx rate > 1% of requests for 5 min."
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 1
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "error_rate"
+    expression  = "100 * (m5xx / IF(reqs > 0, reqs, 1))"
+    label       = "5xx error rate (%)"
+    return_data = true
+  }
+
+  metric_query {
+    id = "m5xx"
+    metric {
+      namespace   = "AWS/ApplicationELB"
+      metric_name = "HTTPCode_Target_5XX_Count"
+      stat        = "Sum"
+      period      = 300
+      dimensions = {
+        LoadBalancer = aws_lb.main.arn_suffix
+        TargetGroup  = aws_lb_target_group.backend.arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id = "reqs"
+    metric {
+      namespace   = "AWS/ApplicationELB"
+      metric_name = "RequestCount"
+      stat        = "Sum"
+      period      = 300
+      dimensions = {
+        LoadBalancer = aws_lb.main.arn_suffix
+        TargetGroup  = aws_lb_target_group.backend.arn_suffix
+      }
+    }
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+  tags          = { Project = var.project_name }
+}
+
+# Aurora connections > 80% of a ~100-connection working ceiling for a
+# Serverless-v2 instance at our ACU range. Distinct from the existing
+# aurora_connections_high (absolute > 80) — kept as the issue names an
+# 80%-utilization line; at our ceiling the two coincide today but this one
+# documents the percentage intent for when the ceiling is tuned.
+resource "aws_cloudwatch_metric_alarm" "aurora_connections_pct_high" {
+  alarm_name          = "${var.project_name}-aurora-connections-pct-high"
+  alarm_description   = "Aurora DB connections > 80% of working ceiling (~80 of ~100) for 10 min."
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 80
+  period              = 300
+  evaluation_periods  = 2
+  dimensions          = { DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "missing"
+  tags                = { Project = var.project_name }
+}
+
+# Aurora Serverless v2 capacity pinned at the configured max (16 ACU) for
+# > 10 min — the cluster cannot scale further and is a paging-grade saturation
+# signal (and a cost signal). ServerlessDatabaseCapacity reports current ACUs.
+resource "aws_cloudwatch_metric_alarm" "aurora_acu_max" {
+  alarm_name          = "${var.project_name}-aurora-acu-at-max"
+  alarm_description   = "Aurora Serverless v2 capacity pinned at max (>= 15.5 of 16 ACU) for 10 min — out of headroom."
+  namespace           = "AWS/RDS"
+  metric_name         = "ServerlessDatabaseCapacity"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 15.5
+  period              = 300
+  evaluation_periods  = 2
+  dimensions          = { DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "missing"
+  tags                = { Project = var.project_name }
+}
+
+# ElastiCache evictions sustained — keys evicted under memory pressure means the
+# cache is too small for the working set (regime state / job queue churn).
+resource "aws_cloudwatch_metric_alarm" "redis_evictions" {
+  alarm_name          = "${var.project_name}-redis-evictions"
+  alarm_description   = "ElastiCache Redis evicting keys (> 100 / 5 min) for 10 min — under memory pressure."
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "Evictions"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 100
+  period              = 300
+  evaluation_periods  = 2
+  dimensions          = { CacheClusterId = local.redis_node_id }
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"
+  tags                = { Project = var.project_name }
+}
+
+# WAF blocked-request spike > 100/min (> 6000 per 5-min datapoint) — a burst of
+# blocks signals an active attack/abuse wave worth eyes-on, even though the WAF
+# is already mitigating it.
+resource "aws_cloudwatch_metric_alarm" "waf_blocked_spike" {
+  alarm_name          = "${var.project_name}-waf-blocked-spike"
+  alarm_description   = "WAF blocked > 6000 requests in 5 min (> 100/min) — active attack/abuse wave."
+  namespace           = "AWS/WAFV2"
+  metric_name         = "BlockedRequests"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 6000
+  period              = 300
+  evaluation_periods  = 1
+  dimensions = {
+    WebACL = local.waf_metric_name
+    Region = var.aws_region
+    Rule   = "ALL"
+  }
+  alarm_actions      = [aws_sns_topic.alerts.arn]
+  ok_actions         = [aws_sns_topic.alerts.arn]
+  treat_missing_data = "notBreaching"
+  tags               = { Project = var.project_name }
+}
+
+# ── Aurora dashboard ─────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_dashboard" "aurora" {
+  dashboard_name = "${var.project_name}-aurora"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric", x = 0, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Serverless capacity (ACU)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "ServerlessDatabaseCapacity", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Connections",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "DatabaseConnections", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "CPU utilization (%)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "CPUUtilization", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Read/write latency p95 / p99",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "ReadLatency", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier, { stat = "p95", label = "ReadLatency p95" }],
+            ["AWS/RDS", "ReadLatency", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier, { stat = "p99", label = "ReadLatency p99" }],
+            ["AWS/RDS", "WriteLatency", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier, { stat = "p95", label = "WriteLatency p95" }],
+            ["AWS/RDS", "WriteLatency", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier, { stat = "p99", label = "WriteLatency p99" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "IOPS (read / write)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "ReadIOPS", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier],
+            ["AWS/RDS", "WriteIOPS", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "Storage / freeable memory",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "VolumeBytesUsed", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier, { label = "VolumeBytesUsed" }],
+            ["AWS/RDS", "FreeableMemory", "DBInstanceIdentifier", aws_rds_cluster_instance.main.identifier, { label = "FreeableMemory" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 18, width = 12, height = 6,
+        properties = {
+          title  = "Deadlocks / slow-query proxy (login failures, deadlocks)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/RDS", "Deadlocks", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier, { label = "Deadlocks" }],
+            ["AWS/RDS", "LoginFailures", "DBClusterIdentifier", aws_rds_cluster.main.cluster_identifier, { label = "LoginFailures" }]
+          ]
+        }
+      }
+    ]
+  })
+}
+
+# ── ElastiCache dashboard ────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_dashboard" "elasticache" {
+  dashboard_name = "${var.project_name}-elasticache"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric", x = 0, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Cache hits / misses",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/ElastiCache", "CacheHits", "CacheClusterId", local.redis_node_id],
+            ["AWS/ElastiCache", "CacheMisses", "CacheClusterId", local.redis_node_id]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Hit-rate (%)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            [{ expression = "100 * hits / IF((hits + misses) > 0, (hits + misses), 1)", label = "Hit-rate %", id = "hr" }],
+            ["AWS/ElastiCache", "CacheHits", "CacheClusterId", local.redis_node_id, { id = "hits", visible = false }],
+            ["AWS/ElastiCache", "CacheMisses", "CacheClusterId", local.redis_node_id, { id = "misses", visible = false }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Memory usage (%) / bytes used",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/ElastiCache", "DatabaseMemoryUsagePercentage", "CacheClusterId", local.redis_node_id, { label = "Memory usage %" }],
+            ["AWS/ElastiCache", "BytesUsedForCache", "CacheClusterId", local.redis_node_id, { label = "BytesUsedForCache" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Evictions",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/ElastiCache", "Evictions", "CacheClusterId", local.redis_node_id]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "Current connections",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/ElastiCache", "CurrConnections", "CacheClusterId", local.redis_node_id]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "Slow-log entries / engine CPU (%)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/ElastiCache", "SlowlogLength", "CacheClusterId", local.redis_node_id, { label = "Slowlog length" }],
+            ["AWS/ElastiCache", "EngineCPUUtilization", "CacheClusterId", local.redis_node_id, { label = "Engine CPU %" }]
+          ]
+        }
+      }
+    ]
+  })
+}
+
+# ── VPC / NAT dashboard ──────────────────────────────────────────────────────
+# NAT instances are plain EC2, so their network + CPU metrics live in AWS/EC2.
+# "GB/day" is read off the NetworkOut/NetworkIn time series (Sum stat); the
+# alarm above pages on the per-datapoint anomaly.
+
+resource "aws_cloudwatch_dashboard" "vpc_nat" {
+  dashboard_name = "${var.project_name}-vpc-nat"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric", x = 0, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "NAT data transfer out (bytes / 5 min — multiply for GB/day)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            for i, nat in aws_instance.nat :
+            ["AWS/EC2", "NetworkOut", "InstanceId", nat.id, { label = "NAT-${i} NetworkOut" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "NAT data transfer in (bytes / 5 min)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            for i, nat in aws_instance.nat :
+            ["AWS/EC2", "NetworkIn", "InstanceId", nat.id, { label = "NAT-${i} NetworkIn" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "NAT CPU utilization (%)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            for i, nat in aws_instance.nat :
+            ["AWS/EC2", "CPUUtilization", "InstanceId", nat.id, { label = "NAT-${i} CPU" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "NAT network packets (out / in)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = concat(
+            [for i, nat in aws_instance.nat : ["AWS/EC2", "NetworkPacketsOut", "InstanceId", nat.id, { label = "NAT-${i} pkts out" }]],
+            [for i, nat in aws_instance.nat : ["AWS/EC2", "NetworkPacketsIn", "InstanceId", nat.id, { label = "NAT-${i} pkts in" }]]
+          )
+        }
+      }
+    ]
+  })
+}
+
+# ── EC2 backend dashboard ────────────────────────────────────────────────────
+# Memory/disk are NOT default EC2 metrics — they require the CloudWatch agent on
+# the host emitting to the CWAgent namespace. The widgets reference CWAgent so
+# they light up once the agent is installed (separate infra task); until then
+# they render empty, which is the honest state.
+
+resource "aws_cloudwatch_dashboard" "ec2_backend" {
+  dashboard_name = "${var.project_name}-ec2-backend"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric", x = 0, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "CPU utilization (%)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.archimedes.id]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Network in / out (bytes / 5 min)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/EC2", "NetworkIn", "InstanceId", aws_instance.archimedes.id],
+            ["AWS/EC2", "NetworkOut", "InstanceId", aws_instance.archimedes.id]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Memory used (%) — requires CloudWatch agent (CWAgent)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["CWAgent", "mem_used_percent", "InstanceId", aws_instance.archimedes.id]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Disk used (%) root volume — requires CloudWatch agent (CWAgent)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["CWAgent", "disk_used_percent", "InstanceId", aws_instance.archimedes.id, "path", "/"]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "EBS read/write bytes (container/Docker IO proxy)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/EC2", "EBSReadBytes", "InstanceId", aws_instance.archimedes.id],
+            ["AWS/EC2", "EBSWriteBytes", "InstanceId", aws_instance.archimedes.id]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "Status check failed (host health — container-restart proxy)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Maximum",
+          metrics = [
+            ["AWS/EC2", "StatusCheckFailed", "InstanceId", aws_instance.archimedes.id],
+            ["AWS/EC2", "StatusCheckFailed_Instance", "InstanceId", aws_instance.archimedes.id],
+            ["AWS/EC2", "StatusCheckFailed_System", "InstanceId", aws_instance.archimedes.id]
+          ]
+        }
+      }
+    ]
+  })
+}
+
+# ── ALB dashboard ────────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_dashboard" "alb" {
+  dashboard_name = "${var.project_name}-alb"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric", x = 0, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Request count",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", aws_lb.main.arn_suffix]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "HTTP status breakdown (2xx / 4xx / 5xx)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/ApplicationELB", "HTTPCode_Target_2XX_Count", "LoadBalancer", aws_lb.main.arn_suffix, { label = "2xx" }],
+            ["AWS/ApplicationELB", "HTTPCode_Target_4XX_Count", "LoadBalancer", aws_lb.main.arn_suffix, { label = "4xx" }],
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", aws_lb.main.arn_suffix, { label = "5xx" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Target response time (p50 / p95 / p99)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          metrics = [
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.main.arn_suffix, "TargetGroup", aws_lb_target_group.backend.arn_suffix, { stat = "p50", label = "p50" }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.main.arn_suffix, "TargetGroup", aws_lb_target_group.backend.arn_suffix, { stat = "p95", label = "p95" }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.main.arn_suffix, "TargetGroup", aws_lb_target_group.backend.arn_suffix, { stat = "p99", label = "p99" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Healthy / unhealthy target count",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Maximum",
+          metrics = [
+            ["AWS/ApplicationELB", "HealthyHostCount", "LoadBalancer", aws_lb.main.arn_suffix, "TargetGroup", aws_lb_target_group.backend.arn_suffix, { label = "Healthy" }],
+            ["AWS/ApplicationELB", "UnHealthyHostCount", "LoadBalancer", aws_lb.main.arn_suffix, "TargetGroup", aws_lb_target_group.backend.arn_suffix, { label = "Unhealthy" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "Active connection count",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/ApplicationELB", "ActiveConnectionCount", "LoadBalancer", aws_lb.main.arn_suffix]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 12, width = 12, height = 6,
+        properties = {
+          title  = "ELB-side 5xx (load balancer errors)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/ApplicationELB", "HTTPCode_ELB_5XX_Count", "LoadBalancer", aws_lb.main.arn_suffix]
+          ]
+        }
+      }
+    ]
+  })
+}
+
+# ── WAF dashboard ────────────────────────────────────────────────────────────
+# Per-rule blocked counts use the metric_name set on each rule's
+# visibility_config in waf.tf. Top blocked source IPs / geo distribution are not
+# CloudWatch metrics — they live in the WAF sampled-requests / logs surface and
+# are linked from the dashboard via a text widget rather than synthesized here.
+
+resource "aws_cloudwatch_dashboard" "waf" {
+  dashboard_name = "${var.project_name}-waf"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric", x = 0, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Allowed vs blocked (Web ACL total)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/WAFV2", "AllowedRequests", "WebACL", local.waf_metric_name, "Region", var.aws_region, "Rule", "ALL", { label = "Allowed" }],
+            ["AWS/WAFV2", "BlockedRequests", "WebACL", local.waf_metric_name, "Region", var.aws_region, "Rule", "ALL", { label = "Blocked" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
+        properties = {
+          title  = "Blocked requests per rule",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/WAFV2", "BlockedRequests", "WebACL", local.waf_metric_name, "Region", var.aws_region, "Rule", "rate-limit", { label = "rate-limit" }],
+            ["AWS/WAFV2", "BlockedRequests", "WebACL", local.waf_metric_name, "Region", var.aws_region, "Rule", "aws-core-rules", { label = "core-rules" }],
+            ["AWS/WAFV2", "BlockedRequests", "WebACL", local.waf_metric_name, "Region", var.aws_region, "Rule", "aws-known-bad-inputs", { label = "known-bad-inputs" }],
+            ["AWS/WAFV2", "BlockedRequests", "WebACL", local.waf_metric_name, "Region", var.aws_region, "Rule", "aws-ip-reputation", { label = "ip-reputation" }]
+          ]
+        }
+      },
+      {
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        properties = {
+          title  = "Counted requests per rule (COUNT-mode SQLi)",
+          region = var.aws_region,
+          view   = "timeSeries",
+          stat   = "Sum",
+          metrics = [
+            ["AWS/WAFV2", "CountedRequests", "WebACL", local.waf_metric_name, "Region", var.aws_region, "Rule", "aws-sqli", { label = "sqli (count mode)" }]
+          ]
+        }
+      },
+      {
+        type = "text", x = 12, y = 6, width = 12, height = 6,
+        properties = {
+          markdown = "### Top blocked source IPs & geo distribution\n\nThese are **not** CloudWatch metrics. Open the WAF console for the `${aws_wafv2_web_acl.main.name}` Web ACL → **Sampled requests** for top source IPs and country breakdown, or query the WAF logs.\n\nThe `${var.project_name}-waf-blocked-spike` alarm pages when blocked requests exceed 100/min."
+        }
+      }
+    ]
+  })
+}
+
 # ── Log group retention (AUDIT I8) ──────────────────────────────────────────
 # Without explicit log group resources, CloudWatch retains logs indefinitely
 # (never expires) — unbounded cost and unnecessary data retention. 90 days is
@@ -269,4 +935,20 @@ output "alerts_topic_arn" {
 output "ops_dashboard_name" {
   description = "CloudWatch dashboard name."
   value       = aws_cloudwatch_dashboard.ops.dashboard_name
+}
+
+# All CloudWatch dashboard names (issue #418 acceptance — `terraform output
+# cloudwatch_dashboard_names`). Includes the pre-existing ops dashboard plus the
+# six per-subsystem dashboards added for Layer 1.
+output "cloudwatch_dashboard_names" {
+  description = "Names of every CloudWatch dashboard managed by Terraform."
+  value = [
+    aws_cloudwatch_dashboard.ops.dashboard_name,
+    aws_cloudwatch_dashboard.aurora.dashboard_name,
+    aws_cloudwatch_dashboard.elasticache.dashboard_name,
+    aws_cloudwatch_dashboard.vpc_nat.dashboard_name,
+    aws_cloudwatch_dashboard.ec2_backend.dashboard_name,
+    aws_cloudwatch_dashboard.alb.dashboard_name,
+    aws_cloudwatch_dashboard.waf.dashboard_name,
+  ]
 }


### PR DESCRIPTION
## Summary

Closes #418 **Layer 1 only** (AWS infrastructure metrics). Layer 2 (Prometheus app metrics) and Layer 3 (self-hosted Grafana) are separate PRs per the issue's "3 PRs, one per layer" anti-goal — not implemented here.

Extends the existing `infra/cloudwatch.tf` (does not create a new file) with:

**Versioned per-subsystem dashboards** (`aws_cloudwatch_dashboard`), every widget pointing at the real resources defined in the sibling `infra/*.tf` files:
- `archimedes-aurora` — ACU, connections, CPU, read/write latency p95/p99, IOPS, storage/freeable memory, deadlocks + login failures (slow-query proxy). Refs `aws_rds_cluster.main` / `aws_rds_cluster_instance.main`.
- `archimedes-elasticache` — hits/misses, hit-rate %, memory %, evictions, connections, slow-log + engine CPU. Refs the single-node cache id `${replication_group_id}-001`.
- `archimedes-vpc-nat` — NAT data transfer in/out (bytes per datapoint; GB/day read off the Sum series), CPU, packets. Refs `aws_instance.nat[*]`.
- `archimedes-ec2-backend` — CPU, network, EBS IO, status-check (container-restart proxy), plus memory %/disk % widgets via the `CWAgent` namespace (light up once the CloudWatch agent is installed — a separate infra task; render empty until then, which is the honest state). Refs `aws_instance.archimedes`.
- `archimedes-alb` — request count, 2xx/4xx/5xx, latency p50/p95/p99, healthy/unhealthy targets, active connections, ELB-side 5xx. Refs `aws_lb.main` / `aws_lb_target_group.backend`.
- `archimedes-waf` — allowed vs blocked, blocked-per-rule, COUNT-mode SQLi, plus a text widget pointing at the WAF sampled-requests console for top blocked IPs + geo (these are not CloudWatch metrics). Refs `aws_wafv2_web_acl.main` rule metric names.

This is 6 new dashboards on top of the pre-existing `archimedes-ops` dashboard (7 total), satisfying the issue's "≥6 `aws_cloudwatch_dashboard`" criterion.

**Alarms** (`aws_cloudwatch_metric_alarm`), all routed to the **existing** `aws_sns_topic.alerts` topic already defined in this file — no new SNS topic was created (a second topic would collide and split alarm routing, so I did not add `infra/sns.tf`):
- NAT egress anomaly (one per AZ) — `NetworkOut > 5 GiB` per 5-min datapoint for 15 min.
- ALB 5xx **rate** > 1% over 5 min — metric-math `100 * 5xx / requests` (complements the pre-existing absolute-count alarm).
- Aurora connections > 80% of working ceiling for 10 min.
- Aurora Serverless v2 capacity pinned at max (≥ 15.5 / 16 ACU) for 10 min.
- ElastiCache evictions > 100 / 5 min for 10 min.
- WAF blocked-request spike > 6000 / 5 min (> 100/min).

Adds a `cloudwatch_dashboard_names` output for the issue's verify step.

> **SNS subscription:** the topic supports an optional email subscriber via `var.alarm_email` (already defined in this file). To route to Discord, add an `https` subscription on `aws_sns_topic.alerts` (or an SNS→Lambda→webhook shim) at apply time — left to the operator since the webhook URL is a secret and not committed.

## Verify

terraform not on PATH in the authoring env; validated with OpenTofu 1.12.1 (drop-in for `terraform fmt`/`validate`), offline, no AWS creds:

```
$ tofu fmt -check infra/cloudwatch.tf      # clean (no output)
$ tofu init -backend=false -input=false     # OpenTofu has been successfully initialized!
$ tofu validate                             # Success! The configuration is valid.
```

`grep` confirms 7 `aws_cloudwatch_dashboard` resources and all 6 new alarms wired to `aws_sns_topic.alerts.arn`.

## Anti-goals (honored)

- Layer 1 only — no Prometheus/instrumentator (L2), no Grafana EC2 (L3).
- Touched **only** `infra/cloudwatch.tf`. No new `infra/sns.tf` (existing topic reused). Reverted incidental `tofu fmt -recursive` reformatting of unrelated files (`alb.tf`, `vpc.tf`, `terraform/*.tf`) so the diff stays scoped.
- No Datadog/NewRelic. No Grafana Cloud. Additive CloudWatch objects only — no change to existing EC2/ALB/Aurora/WAF resources.

## Operational note: requires `terraform apply` with AWS creds to take effect — not auto-applied by CI

CI does not run `terraform apply`. These dashboards and alarms become live only when a human runs `terraform plan` + `terraform apply` from `infra/` with AWS credentials. The change is additive (new CloudWatch dashboards, alarms, and one output), so apply blast radius is limited to new CloudWatch objects.