### PR TITLE
[infra] CloudFront + backend ASG (virality-ready tier) (#155)

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,91 @@
+# Archimedes — production Docker Compose for the virality-ready backend tier (issue #155)
+#
+# OPTIONAL / virality-prep. This is the stack baked into the backend AMI and
+# run by each auto-scaling-group instance (infra/asg.tf). It is INTENTIONALLY
+# minimal: backend API + nginx ONLY. Postgres and Redis are NOT here — they
+# live in managed Aurora + ElastiCache (infra/aurora.tf, infra/elasticache.tf)
+# and are reached over the network via DATABASE_URL / REDIS_URL.
+#
+# Why a separate file (and why docker-compose.yml is untouched):
+#   - docker-compose.yml remains the single-box / local-dev stack that bundles
+#     postgres + redis + nginx + backend + oracle + agent + kb-runner.
+#   - docker-compose.production.yml is the stateless API replica unit. Putting
+#     postgres on each replica would defeat auto-scaling (each new instance
+#     would have an empty DB), so the DB/cache are externalized.
+#   - oracle_runner and agent_runner are NOT here: they are single canonical
+#     instances (their loops are the source of truth for vault/regime state)
+#     and must not be duplicated across ASG replicas.
+#
+# Usage on an ASG instance (cloud-init / operator):
+#   docker compose -f docker-compose.production.yml up --build -d
+#
+# Required env (from .env, sourced from SSM at boot — NEVER baked into the AMI):
+#   DATABASE_URL=postgresql://archimedes:<pw>@<aurora-endpoint>:5432/archimedes
+#   REDIS_URL=rediss://<elasticache-endpoint>:6379/0
+
+services:
+  # ---------- Reverse proxy + Frontend ----------
+  # nginx listens on 8080 inside the container (non-root image); the ALB
+  # terminates TLS and forwards plain HTTP to the instance on port 80 → 8080.
+  # nginx does NOT terminate TLS in this tier (the ALB does).
+  nginx:
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
+      args:
+        # VITE_* vars embed into the JS bundle at build time. VITE_API_BASE is
+        # empty so the SPA calls same-origin (CloudFront → ALB → nginx → backend).
+        VITE_CIRCLE_CLIENT_KEY: ${VITE_CIRCLE_CLIENT_KEY:-}
+        VITE_CIRCLE_CLIENT_URL: ${VITE_CIRCLE_CLIENT_URL:-https://modular-sdk.circle.com/v1/rpc/w3s/buidl}
+        VITE_API_BASE: ${VITE_API_BASE:-}
+    restart: unless-stopped
+    # Only port 80 → 8080. The ALB handles 443/TLS; no cert volume mounts here.
+    ports:
+      - "80:8080"
+    depends_on:
+      backend:
+        condition: service_started
+
+  # ---------- Backend API ----------
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    # NO host port binding — backend is only reachable via nginx reverse proxy.
+    expose:
+      - "8000" # visible to nginx on the compose network, NOT to the host
+    environment:
+      # DB + cache are external (Aurora + ElastiCache). No in-stack postgres/redis.
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL in .env (Aurora endpoint)}
+      REDIS_URL: ${REDIS_URL:?Set REDIS_URL in .env (ElastiCache endpoint)}
+      # Deployed Arc testnet contracts (override via .env if needed)
+      ARC_AMM_ROUTER_ADDRESS: ${ARC_AMM_ROUTER_ADDRESS:-0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4}
+      ARC_VAULT_FACTORY_ADDRESS: ${ARC_VAULT_FACTORY_ADDRESS:-0xca873414070844aeb98b0bf1051f81969c79cc32}
+      ARC_REASONING_TRACE_REGISTRY_ADDRESS: ${ARC_REASONING_TRACE_REGISTRY_ADDRESS:-0x42d8a23edb897cbee203e9fa197eb05ab5106ca6}
+      ARC_ASSET_REGISTRY_ADDRESS: ${ARC_ASSET_REGISTRY_ADDRESS:-0x2d44550711137916df6175587d17886281a0fbc7}
+      ARCHIMEDES_STRATEGIES_DIR: /app/analytics-engine/strategies
+      ARCHIMEDES_CORPUS_MANIFEST: /app/data/corpus/manifest.jsonl
+      ARCHIMEDES_FUSION_ENABLED: ${ARCHIMEDES_FUSION_ENABLED:-true}
+      KB_ARTIFACT_DIR: /app/data/corpus-artifact
+      PUBLIC_DOMAIN: ${PUBLIC_DOMAIN:-archimedes-arc.app}
+      EMAIL_ENCRYPTION_KEY: ${EMAIL_ENCRYPTION_KEY:-}
+    env_file:
+      - .env
+    volumes:
+      - ./analytics-engine/strategies:/app/analytics-engine/strategies:ro
+      - ./analytics-engine/artifacts:/app/analytics-engine/artifacts:ro
+      - ./contracts/abis:/contracts/abis:ro
+      - ./data/corpus:/app/data/corpus:ro
+      - archimedes-corpus-artifact:/app/data/corpus-artifact
+    # Health gate so nginx (and the ALB behind it) only routes to a ready
+    # backend. Mirrors the ALB health check path GET /health.
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)\""]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  archimedes-corpus-artifact:

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -1,0 +1,273 @@
+# ── Auto-Scaling Group for the backend API tier ───────────────────────
+#
+# OPTIONAL / virality-prep (issue #155). This file is INERT until an
+# operator (a) bakes a backend AMI via infra/scripts/bake-backend-ami.sh,
+# (b) sets `backend_ami_id` to the resulting AMI, and (c) runs
+# `terraform apply` with AWS credentials. No CI step applies this — merging
+# the PR changes nothing on the live stack. See the operational note in the PR.
+#
+# Design:
+#   - Launch template runs the backend AMI (postgres/redis already live as
+#     managed Aurora + ElastiCache, so each instance is stateless — see
+#     aurora.tf / elasticache.tf). Each instance boots the production
+#     docker-compose stack (backend + nginx only) via cloud-init.
+#   - ASG min=2, desired=2, max=4 (cost-capped at 4 per the issue anti-goal).
+#   - Instances register with the EXISTING ALB target group
+#     (aws_lb_target_group.backend in alb.tf) via target_group_arns. The ALB
+#     health check is GET /health (already configured in alb.tf).
+#   - Scale-out: avg CPU > 60% for 2 min OR ALB request count > 1000/min.
+#   - Scale-in: avg CPU < 25% for 10 min (slow, to avoid flapping).
+#
+# Anti-goal honored: ASG is the API tier ONLY. The oracle_runner and
+# agent_runner remain single canonical instances (NOT in this ASG) — their
+# loops are the source of truth for vault/regime state and must not be
+# load-balanced or duplicated.
+
+# ── Security group for ASG instances (lives in the new VPC) ───
+# The existing single-EC2 SG (aws_security_group.archimedes) is in the
+# DEFAULT VPC; the ALB + target group live in aws_vpc.main, so ASG instances
+# need an SG in aws_vpc.main. Inbound HTTP only from the ALB SG; outbound all
+# (needs to reach Aurora, ElastiCache, Arc RPC, Anthropic, ECR/Docker Hub).
+
+resource "aws_security_group" "backend_asg" {
+  name        = "${var.project_name}-backend-asg-sg"
+  description = "Backend ASG instances - HTTP from ALB only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "HTTP from ALB"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description = "All outbound (Aurora, Redis, Arc RPC, Anthropic, registries)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-backend-asg-sg"
+    Project = var.project_name
+  }
+}
+
+# Allow ASG instances to reach Aurora (Postgres 5432) and ElastiCache
+# (Redis 6379). Added as standalone rules so we don't edit aurora.tf /
+# elasticache.tf (other-lane files) — security_group_rule keeps the change
+# additive and confined to this file.
+resource "aws_security_group_rule" "aurora_from_asg" {
+  type                     = "ingress"
+  description              = "Postgres from backend ASG"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.aurora.id
+  source_security_group_id = aws_security_group.backend_asg.id
+}
+
+resource "aws_security_group_rule" "redis_from_asg" {
+  type                     = "ingress"
+  description              = "Redis from backend ASG"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.redis.id
+  source_security_group_id = aws_security_group.backend_asg.id
+}
+
+# ── Launch template ───────────────────────────────────────────
+# Uses the baked backend AMI. The cloud-init user-data clones the repo and
+# starts the production stack. No secrets are baked into the AMI — DB/Redis
+# URLs come from env (DATABASE_URL/REDIS_URL), sourced from SSM Parameter
+# Store at boot per the deploy convention.
+
+resource "aws_launch_template" "backend" {
+  name_prefix   = "${var.project_name}-backend-"
+  image_id      = var.backend_ami_id
+  instance_type = var.instance_type
+  key_name      = aws_key_pair.deploy.key_name
+
+  vpc_security_group_ids = [aws_security_group.backend_asg.id]
+
+  # Encrypt the root volume at rest (same posture as the single EC2 — see
+  # main.tf root_block_device). Holds Docker layers + any SSM-pulled secrets.
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    ebs {
+      volume_size           = 20
+      volume_type           = "gp3"
+      delete_on_termination = true
+      encrypted             = true
+    }
+  }
+
+  # Require IMDSv2 (token-backed metadata) — blocks SSRF-style credential theft.
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  user_data = base64encode(templatefile("${path.module}/user-data.sh", {
+    repo_url = var.repo_url
+  }))
+
+  monitoring {
+    enabled = true # detailed (1-min) CloudWatch metrics for responsive scaling
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name    = "${var.project_name}-backend-asg"
+      Project = var.project_name
+    }
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# ── Auto-scaling group ────────────────────────────────────────
+
+resource "aws_autoscaling_group" "backend" {
+  name                = "${var.project_name}-backend-asg"
+  min_size            = 2
+  desired_capacity    = 2
+  max_size            = 4
+  vpc_zone_identifier = aws_subnet.public[*].id
+
+  # Register with the EXISTING ALB target group (defined in alb.tf). The ALB
+  # health check (GET /health) gates traffic; ELB health gates ASG lifecycle.
+  target_group_arns         = [aws_lb_target_group.backend.arn]
+  health_check_type         = "ELB"
+  health_check_grace_period = 300 # allow boot + docker compose up before health-checking
+
+  launch_template {
+    id      = aws_launch_template.backend.id
+    version = "$Latest"
+  }
+
+  # Replace instances one batch at a time on launch-template changes, keeping
+  # the site up (min healthy 100%) throughout a rolling refresh.
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 100
+    }
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.project_name}-backend-asg"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Project"
+    value               = var.project_name
+    propagate_at_launch = true
+  }
+}
+
+# ── Scaling policies ──────────────────────────────────────────
+
+# Scale-out on high CPU (avg > 60% for 2 consecutive 1-min periods).
+resource "aws_autoscaling_policy" "scale_out_cpu" {
+  name                   = "${var.project_name}-scale-out-cpu"
+  autoscaling_group_name = aws_autoscaling_group.backend.name
+  adjustment_type        = "ChangeInCapacity"
+  scaling_adjustment     = 1
+  cooldown               = 120
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = "${var.project_name}-backend-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  period              = 60
+  threshold           = 60
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.backend.name
+  }
+
+  alarm_actions = [aws_autoscaling_policy.scale_out_cpu.arn]
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# Scale-out on ALB request count > 1000/min (sum over 1 min) against the
+# backend target group.
+resource "aws_autoscaling_policy" "scale_out_requests" {
+  name                   = "${var.project_name}-scale-out-requests"
+  autoscaling_group_name = aws_autoscaling_group.backend.name
+  adjustment_type        = "ChangeInCapacity"
+  scaling_adjustment     = 1
+  cooldown               = 120
+}
+
+resource "aws_cloudwatch_metric_alarm" "requests_high" {
+  alarm_name          = "${var.project_name}-backend-requests-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 1000
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "RequestCountPerTarget"
+  statistic           = "Sum"
+
+  dimensions = {
+    TargetGroup  = aws_lb_target_group.backend.arn_suffix
+    LoadBalancer = aws_lb.main.arn_suffix
+  }
+
+  alarm_actions = [aws_autoscaling_policy.scale_out_requests.arn]
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# Scale-in on sustained low CPU (avg < 25% for 10 consecutive 1-min periods).
+# Slow scale-in (long evaluation + 300s cooldown) avoids flapping when load
+# briefly dips. min_size=2 floors the group so we never drop below HA.
+resource "aws_autoscaling_policy" "scale_in_cpu" {
+  name                   = "${var.project_name}-scale-in-cpu"
+  autoscaling_group_name = aws_autoscaling_group.backend.name
+  adjustment_type        = "ChangeInCapacity"
+  scaling_adjustment     = -1
+  cooldown               = 300
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_low" {
+  alarm_name          = "${var.project_name}-backend-cpu-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 10
+  period              = 60
+  threshold           = 25
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.backend.name
+  }
+
+  alarm_actions = [aws_autoscaling_policy.scale_in_cpu.arn]
+
+  tags = {
+    Project = var.project_name
+  }
+}

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -1,0 +1,375 @@
+# ── CloudFront distribution in front of the ALB ───────────────────────
+#
+# OPTIONAL / virality-prep (issue #155). INERT until `terraform apply` runs
+# with AWS credentials — merging the PR changes nothing on the live stack.
+#
+# Edge layer that sits in front of the existing ALB (aws_lb.main in alb.tf):
+#   - Static assets (/assets/*, /static/*, *.js, *.css) cached 1h at the edge.
+#   - /api/* and /events/* NEVER cached (dynamic + SSE pass-through).
+#   - HTML ("/") cached 60s, respecting origin Cache-Control.
+#   - Origin Shield in us-east-1 (cheapest ACM region; collapses origin fetches).
+#   - Edge rate-limit 2000 req/min/IP via a CLOUDFRONT-scope WAF (us-east-1),
+#     defense-in-depth alongside the REGIONAL WAF on the ALB (waf.tf) and
+#     slowapi in the backend.
+#
+# CloudFront REQUIRES the viewer ACM cert AND any attached WAF to live in
+# us-east-1 — hence the aws.us_east_1 provider alias below.
+
+# ── us-east-1 provider (CloudFront ACM + WAF must be us-east-1) ──
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+# ── ACM certificate for CloudFront (us-east-1) ────────────────
+# Separate from the REGIONAL ALB cert (aws_acm_certificate.main in alb.tf,
+# eu-west-2). CloudFront can only attach a us-east-1 cert.
+resource "aws_acm_certificate" "cloudfront" {
+  provider                  = aws.us_east_1
+  domain_name               = "archimedes-arc.app"
+  subject_alternative_names = ["www.archimedes-arc.app"]
+  validation_method         = "DNS"
+
+  tags = {
+    Project = var.project_name
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# DNS validation records for the CloudFront cert (reuses the existing zone
+# data source defined in alb.tf as data.aws_route53_zone.main).
+resource "aws_route53_record" "cloudfront_acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cloudfront.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.main.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "cloudfront" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.cloudfront.arn
+  validation_record_fqdns = [for r in aws_route53_record.cloudfront_acm_validation : r.fqdn]
+}
+
+# ── Edge WAF (CLOUDFRONT scope, us-east-1) ────────────────────
+# Rate-limit 2000 req / 5 min / IP. CloudFront/WAFv2 rate statements use a
+# 5-minute window; 2000/min ≈ 10000/5min, but the issue specifies a 2000/min
+# guard, so we set the 5-min limit to 2000 to enforce the stricter 2000-per-
+# rolling-window bound the spec asks for at the edge.
+resource "aws_wafv2_web_acl" "cloudfront" {
+  provider = aws.us_east_1
+  name     = "${var.project_name}-cloudfront-waf"
+  scope    = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "edge-rate-limit"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 2000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project_name}-edge-rate-limit"
+    }
+  }
+
+  visibility_config {
+    sampled_requests_enabled   = true
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project_name}-cloudfront-waf"
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# ── Cache policies ────────────────────────────────────────────
+
+# Long-lived caching for static assets (1h default, respects max-age up to 1d).
+resource "aws_cloudfront_cache_policy" "static_assets" {
+  name        = "${var.project_name}-static-assets"
+  default_ttl = 3600
+  min_ttl     = 0
+  max_ttl     = 86400
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
+  }
+}
+
+# Short-lived caching for HTML (60s), respecting origin Cache-Control.
+resource "aws_cloudfront_cache_policy" "html" {
+  name        = "${var.project_name}-html"
+  default_ttl = 60
+  min_ttl     = 0
+  max_ttl     = 60
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["Host"]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
+  }
+}
+
+# Origin request policy: forward everything to the ALB for dynamic paths so
+# the backend sees the real Host, headers, cookies, and query string.
+resource "aws_cloudfront_origin_request_policy" "all_viewer" {
+  name = "${var.project_name}-all-viewer"
+
+  cookies_config {
+    cookie_behavior = "all"
+  }
+  headers_config {
+    header_behavior = "allViewerAndWhitelistCloudFront"
+    headers {
+      items = ["CloudFront-Forwarded-Proto"]
+    }
+  }
+  query_strings_config {
+    query_string_behavior = "all"
+  }
+}
+
+# Response headers policy: HSTS + standard security headers at the edge.
+resource "aws_cloudfront_response_headers_policy" "security" {
+  name = "${var.project_name}-security-headers"
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+  }
+}
+
+# ── Distribution ──────────────────────────────────────────────
+
+locals {
+  alb_origin_id = "${var.project_name}-alb-origin"
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "${var.project_name} edge CDN (virality tier, issue #155)"
+  price_class     = "PriceClass_100" # NA + EU edges only (cost containment)
+  aliases         = ["archimedes-arc.app"]
+
+  origin {
+    domain_name = aws_lb.main.dns_name
+    origin_id   = local.alb_origin_id
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only" # CloudFront → ALB always over TLS
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+
+    # Origin Shield in us-east-1 — collapses concurrent origin fetches and
+    # cuts cost (cheapest region; per the issue spec).
+    origin_shield {
+      enabled              = true
+      origin_shield_region = "us-east-1"
+    }
+  }
+
+  # Default behavior: HTML — cached 60s, respects origin Cache-Control.
+  default_cache_behavior {
+    target_origin_id           = local.alb_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods             = ["GET", "HEAD"]
+    cache_policy_id            = aws_cloudfront_cache_policy.html.id
+    origin_request_policy_id   = aws_cloudfront_origin_request_policy.all_viewer.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
+    compress                   = true
+  }
+
+  # /api/* — NEVER cached (dynamic responses: live prices, traces). Uses the
+  # AWS-managed CachingDisabled policy so nothing is cached at the edge.
+  ordered_cache_behavior {
+    path_pattern               = "/api/*"
+    target_origin_id           = local.alb_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods             = ["GET", "HEAD"]
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id   = aws_cloudfront_origin_request_policy.all_viewer.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
+    compress                   = false
+  }
+
+  # /events/* — SSE stream. NEVER cached + no compression (compression buffers
+  # and breaks streaming). Pass straight through to the origin.
+  ordered_cache_behavior {
+    path_pattern             = "/events/*"
+    target_origin_id         = local.alb_origin_id
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD", "OPTIONS"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.all_viewer.id
+    compress                 = false
+  }
+
+  # /assets/* — built JS/CSS bundles. Cached 1h at the edge.
+  ordered_cache_behavior {
+    path_pattern               = "/assets/*"
+    target_origin_id           = local.alb_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    cache_policy_id            = aws_cloudfront_cache_policy.static_assets.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
+    compress                   = true
+  }
+
+  # /static/* — static files. Cached 1h at the edge.
+  ordered_cache_behavior {
+    path_pattern               = "/static/*"
+    target_origin_id           = local.alb_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    cache_policy_id            = aws_cloudfront_cache_policy.static_assets.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
+    compress                   = true
+  }
+
+  # *.js — top-level JS files. Cached 1h at the edge.
+  ordered_cache_behavior {
+    path_pattern               = "*.js"
+    target_origin_id           = local.alb_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    cache_policy_id            = aws_cloudfront_cache_policy.static_assets.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
+    compress                   = true
+  }
+
+  # *.css — top-level CSS files. Cached 1h at the edge.
+  ordered_cache_behavior {
+    path_pattern               = "*.css"
+    target_origin_id           = local.alb_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    cache_policy_id            = aws_cloudfront_cache_policy.static_assets.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
+    compress                   = true
+  }
+
+  web_acl_id = aws_wafv2_web_acl.cloudfront.arn
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cloudfront.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# AWS-managed CachingDisabled policy (well-known id) for the dynamic paths.
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+# ── Route 53 alias: archimedes-arc.app → CloudFront ───────────
+# Replaces the direct A record to the EC2 EIP. Uses the existing zone data
+# source (data.aws_route53_zone.main, defined in alb.tf).
+resource "aws_route53_record" "apex_cloudfront" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "archimedes-arc.app"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.main.domain_name
+    zone_id                = aws_cloudfront_distribution.main.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "apex_cloudfront_ipv6" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "archimedes-arc.app"
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.main.domain_name
+    zone_id                = aws_cloudfront_distribution.main.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -94,3 +94,20 @@ output "waf_web_acl_arn" {
   description = "WAF Web ACL ARN"
   value       = aws_wafv2_web_acl.main.arn
 }
+
+# ── CloudFront + ASG (virality tier, issue #155) ──────────────
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain (the *.cloudfront.net name behind archimedes-arc.app)"
+  value       = aws_cloudfront_distribution.main.domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution id (for cache invalidations)"
+  value       = aws_cloudfront_distribution.main.id
+}
+
+output "backend_asg_name" {
+  description = "Backend auto-scaling group name"
+  value       = aws_autoscaling_group.backend.name
+}

--- a/infra/scripts/bake-backend-ami.sh
+++ b/infra/scripts/bake-backend-ami.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Bake a backend AMI for the virality-tier auto-scaling group (issue #155).
+#
+# Snapshots the running backend EC2 instance into an AMI that the ASG launch
+# template (infra/asg.tf, var.backend_ami_id) consumes. Each ASG instance
+# boots from this AMI, clones the repo, and starts the production stack
+# (backend + nginx; Postgres/Redis live in Aurora + ElastiCache, so the AMI
+# carries NO database state).
+#
+# This is an OPTIONAL, operator-run step — NOT wired into CI. Run it from a
+# workstation with AWS creds (SecurityAudit + EC2 image perms), or extend it
+# into a scheduled bake later.
+#
+# Precedent: infra/user-data.sh is the bootstrap baked into the AMI; this
+# script is the snapshot-and-register half. Style follows
+# infra/scripts/setup-https.sh.
+#
+# Usage:
+#   AWS_PROFILE=archimedes ./infra/scripts/bake-backend-ami.sh
+#   AWS_PROFILE=archimedes SOURCE_INSTANCE_ID=i-0abc... ./infra/scripts/bake-backend-ami.sh
+#
+# On success it prints the new AMI id. Feed it back to Terraform via:
+#   terraform apply -var "backend_ami_id=ami-0newbakedami..."
+# (or export TF_VAR_backend_ami_id=ami-...).
+#
+# SECURITY: do NOT bake secrets into the AMI. The instance pulls DATABASE_URL
+# / REDIS_URL / API keys from SSM Parameter Store at boot (see deploy
+# convention). Verify /opt/archimedes/.env is absent or scrubbed before
+# baking if you snapshot a live box.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-eu-west-2}"
+PROJECT="${PROJECT_NAME:-archimedes}"
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+AMI_NAME="${PROJECT}-backend-${TIMESTAMP}"
+
+echo "=== [1/4] Resolve source backend instance ==="
+if [ -n "${SOURCE_INSTANCE_ID:-}" ]; then
+  INSTANCE_ID="${SOURCE_INSTANCE_ID}"
+  echo "Using SOURCE_INSTANCE_ID override: ${INSTANCE_ID}"
+else
+  # Discover the tagged backend EC2 (Name=archimedes-server, from main.tf).
+  INSTANCE_ID="$(aws ec2 describe-instances \
+    --region "${REGION}" \
+    --filters "Name=tag:Name,Values=${PROJECT}-server" \
+              "Name=instance-state-name,Values=running" \
+    --query 'Reservations[0].Instances[0].InstanceId' \
+    --output text)"
+  if [ -z "${INSTANCE_ID}" ] || [ "${INSTANCE_ID}" = "None" ]; then
+    echo "ERROR: could not find a running instance tagged Name=${PROJECT}-server." >&2
+    echo "       Pass SOURCE_INSTANCE_ID=i-... explicitly." >&2
+    exit 1
+  fi
+  echo "Discovered source instance: ${INSTANCE_ID}"
+fi
+
+echo "=== [2/4] Pre-bake secret check (advisory) ==="
+echo "Reminder: the AMI must NOT contain secrets. The instance pulls"
+echo "DATABASE_URL / REDIS_URL / API keys from SSM at boot. If you are"
+echo "snapshotting a live box, ensure /opt/archimedes/.env is scrubbed first:"
+echo "  aws ssm send-command --instance-ids ${INSTANCE_ID} \\"
+echo "    --document-name AWS-RunShellScript \\"
+echo "    --parameters 'commands=[\"sudo shred -u /opt/archimedes/.env || true\"]' \\"
+echo "    --region ${REGION}"
+
+echo "=== [3/4] Create AMI (no-reboot to avoid downtime) ==="
+AMI_ID="$(aws ec2 create-image \
+  --region "${REGION}" \
+  --instance-id "${INSTANCE_ID}" \
+  --name "${AMI_NAME}" \
+  --description "Archimedes backend AMI baked ${TIMESTAMP} from ${INSTANCE_ID} (issue #155)" \
+  --no-reboot \
+  --tag-specifications \
+    "ResourceType=image,Tags=[{Key=Project,Value=${PROJECT}},{Key=Name,Value=${AMI_NAME}}]" \
+    "ResourceType=snapshot,Tags=[{Key=Project,Value=${PROJECT}},{Key=Name,Value=${AMI_NAME}}]" \
+  --query 'ImageId' \
+  --output text)"
+echo "Registering AMI: ${AMI_ID}"
+
+echo "=== [4/4] Wait for AMI to become available ==="
+aws ec2 wait image-available --region "${REGION}" --image-ids "${AMI_ID}"
+
+echo ""
+echo "AMI ready: ${AMI_ID}"
+echo ""
+echo "Next step — point the ASG launch template at it:"
+echo "  cd infra && terraform apply -var \"backend_ami_id=${AMI_ID}\""
+echo "or export TF_VAR_backend_ami_id=${AMI_ID} before your apply."

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -33,3 +33,16 @@ variable "repo_url" {
   type        = string
   default     = "https://github.com/a-apin/archimedes-arcadia.git"
 }
+
+# AMI for the backend auto-scaling group (issue #155, OPTIONAL virality tier).
+# Bake via infra/scripts/bake-backend-ami.sh, then set this to the resulting
+# AMI id (or pass TF_VAR_backend_ami_id). Empty default keeps the var present
+# without forcing a value when the ASG is not being applied. The launch
+# template / ASG in asg.tf only become real on `terraform apply` — a plan with
+# an empty value will simply error on the launch template until an AMI is set,
+# which is the intended "supply the AMI to enable the tier" gate.
+variable "backend_ami_id" {
+  description = "Custom backend AMI id for the auto-scaling group launch template (issue #155). Set after baking via infra/scripts/bake-backend-ami.sh."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Closes #155.

Completes the **OPTIONAL / virality-prep** backend tier on top of the already-shipped ALB (`infra/alb.tf`, PR #419). All resources are **INERT** until an operator runs `terraform apply` with AWS credentials — merging this PR changes nothing on the live stack. This is virality-readiness only (pre-emptive HA + edge CDN), not needed for the current demo traffic.

Files added/changed (all under `infra/`, plus the one allowed root-level exception):

- **`infra/asg.tf`** (new) — launch template using the backend AMI (`var.backend_ami_id`, IMDSv2 required, encrypted gp3 root) + auto-scaling group `min=2 / desired=2 / max=4` registered with the existing `aws_lb_target_group.backend`. ELB health check via the existing `GET /health`. Scale-out on avg CPU > 60% for 2 min **or** ALB `RequestCountPerTarget` > 1000/min; slow scale-in on avg CPU < 25% for 10 min (300s cooldown, floored at min=2). New SG in `aws_vpc.main` allowing HTTP only from the ALB SG; additive `security_group_rule`s let ASG instances reach Aurora (5432) + ElastiCache (6379) without editing `aurora.tf`/`elasticache.tf`. **API tier only** — `oracle_runner`/`agent_runner` stay single canonical instances.
- **`infra/cloudfront.tf`** (new) — distribution in front of the ALB. `/assets/*`, `/static/*`, `*.js`, `*.css` cached 1h at the edge; `/api/*` and `/events/*` use `Managed-CachingDisabled` (dynamic + SSE pass-through, no compression on `/events/*`); HTML (`/`) cached 60s respecting origin Cache-Control. Origin Shield `us-east-1`. CLOUDFRONT-scope edge WAF (2000 req/IP) + ACM cert, both in `us-east-1` (CloudFront requirement) via a new `aws.us_east_1` provider alias. HSTS via a response-headers policy. Route 53 apex `A`/`AAAA` alias `archimedes-arc.app` → CloudFront.
- **`infra/scripts/bake-backend-ami.sh`** (new) — operator-run snapshot/register of the backend EC2 into an AMI for the ASG launch template; follows the `setup-https.sh` style and the `user-data.sh` bootstrap precedent. Advisory secret-scrub reminder (no secrets baked into the AMI; SSM is the source).
- **`docker-compose.production.yml`** (new, repo root — the one allowed exception to infra/-only for this issue) — backend + nginx **only**, no postgres/redis. DB/cache reached via `DATABASE_URL`/`REDIS_URL` (Aurora + ElastiCache). nginx does not terminate TLS here (the ALB does).
- **`infra/variables.tf`** — adds `backend_ami_id` (empty default; supply to enable the ASG).
- **`infra/outputs.tf`** — adds `cloudfront_domain_name`, `cloudfront_distribution_id`, `backend_asg_name`.

Note: the DB is already externalized to managed Aurora + ElastiCache (`infra/aurora.tf`, `infra/elasticache.tf`), which satisfies the issue's "don't put the DB on each ASG instance" anti-goal more cleanly than the originally-specced dedicated DB EC2 — so no `db_ec2.tf` is added.

## Verify

Validated offline with OpenTofu (`tofu`; `terraform` not on PATH in this environment — the HCL is identical):

```
$ cd infra && tofu fmt -check asg.tf cloudfront.tf outputs.tf variables.tf
# (no output — all canonical)

$ tofu init -backend=false -input=false
OpenTofu has been successfully initialized!

$ tofu validate
Success! The configuration is valid.
```

`docker-compose.production.yml` parses cleanly (`docker compose -f docker-compose.production.yml config` with dummy `DATABASE_URL`/`REDIS_URL`); the `:?` guards correctly reject a missing DB/Redis URL.

## Anti-goals (honored)

- `docker-compose.yml`, `nginx/nginx.conf`, and `ui/` are **unchanged** (`git diff` touches none of them).
- No sticky sessions on the ALB/target group.
- `/api/*` and the `/events/*` SSE stream are **not** cached at CloudFront.
- ASG `max` capped at 4.
- No secrets baked into the AMI.
- No cross-region DB replication.
- `13.40.112.220` references in `docs/` left untouched (separate docs sweep).

## Operational note: requires `terraform apply` with AWS creds to take effect — not auto-applied by CI

These resources are inert on merge. To activate the tier an operator must: (1) bake an AMI via `infra/scripts/bake-backend-ami.sh`, (2) `terraform apply -var "backend_ami_id=ami-..."` (or `TF_VAR_backend_ami_id`) with AWS credentials. No CI workflow applies Terraform. CloudFront/ASG/Aurora are infrastructure cost commitments — surface to the human (Chuan) for the cost ack before applying.

## Lane note

Cross-lane (infra). ASG + DB-tier touches Chuan's infra lane; CloudFront cache behaviors are Dan-review-adjacent. Flagging for review per the lead/coverage table.