### PR TITLE
[infra] Gate deploy job behind DEPLOY_ENABLED flag (offline target)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,12 @@
 # Required GitHub Variables (or hardcoded below):
 #   AWS_ROLE_ARN — arn:aws:iam::159903201072:role/archimedes-github-deploy
 #   EC2_INSTANCE_ID — i-0987f70a131ed3ab1
+#   DEPLOY_ENABLED — gate flag; the deploy job runs ONLY when this repo variable
+#     equals 'true'. Unset/false → the job is skipped (neutral, not failed). The
+#     deploy target was torn down post-hackathon for cost (#436, EC2-only) and the
+#     box is offline, so unguarded runs would fail on every push to main. Set
+#     DEPLOY_ENABLED=true (Settings → Secrets and variables → Actions → Variables)
+#     to re-enable once a deploy target exists again.
 #
 # ─── KNOWN SECURITY DEBT ───
 #
@@ -61,6 +67,13 @@ env:
 jobs:
   deploy:
     name: Deploy
+    # Gated behind an explicit opt-in repo variable. The deploy target (managed
+    # tier + EC2) was torn down post-hackathon for cost (#436, EC2-only) and the
+    # instance is offline / DNS released, so an unguarded run would fail on the
+    # SSM SendCommand to a dead instance on every push to main. With DEPLOY_ENABLED
+    # unset, this job is SKIPPED (neutral, keeps the Actions history green); set the
+    # repo variable DEPLOY_ENABLED=true to re-enable once a deploy target exists.
+    if: ${{ vars.DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 35  # SSM 30min + AWS API overhead + buffer
 


### PR DESCRIPTION
## Summary
The live deploy target (managed tier + EC2) was torn down post-hackathon for cost (#436, EC2-only) and the instance is offline / DNS released. Unguarded, every push to `main` would fail on the SSM `SendCommand` to a dead instance, polluting the Actions history with red runs.

This gates the `deploy` job behind a `DEPLOY_ENABLED` repo variable:
- **unset / not 'true'** → the job is **skipped** (neutral conclusion, not failed) — Actions history stays green.
- **'true'** → deploy runs exactly as before.

Re-enable by setting `DEPLOY_ENABLED=true` under Settings → Secrets and variables → Actions → Variables once a deploy target exists again. No other deploy logic changed.

## Verify
```
python -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy.yml')); print(d['jobs']['deploy']['if'])"
# -> ${{ vars.DEPLOY_ENABLED == 'true' }}
```
After merge, the deploy run for this push shows the `Deploy` job as **skipped** rather than failed.

## Anti-goals
- No change to the deploy script body, OIDC, or SSM logic — purely a gate.
- Reversible via a single repo-variable toggle.