### PR TITLE
[quant] Wire VixRegimeDetector into agent_runner + persist regime to Redis (#660)

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -27,6 +27,7 @@ from datetime import UTC, datetime
 
 from archimedes.chain.client import chain_client
 from archimedes.chain.executor import InsufficientLiquidityError, chain_executor
+from archimedes.chain.oracle_updater import OracleUpdater
 from archimedes.chain.trace_publisher import trace_publisher
 from archimedes.chain.v_check import VCheck
 from archimedes.models.portfolio import (
@@ -35,7 +36,7 @@ from archimedes.models.portfolio import (
     TradeDirection,
     TradeOrder,
 )
-from archimedes.models.regime import EnsembleConsensus
+from archimedes.models.regime import EnsembleConsensus, RegimeClassification
 from archimedes.models.trace import DecisionType, ReasoningTrace
 from archimedes.services.redis_state import AgentStateStore
 from archimedes.services.source_tracker import build_consulted_hashes
@@ -44,6 +45,7 @@ from archimedes.services.strategy_signal_evaluator import (
     StrategySignals,
     strategy_evaluator,
 )
+from archimedes.services.vix_regime_detector import VixRegimeDetector
 
 logging.basicConfig(
     level=logging.INFO,
@@ -139,6 +141,12 @@ class StrategyRunner:
     def __init__(self) -> None:
         self.provider = default_provider()
         self.state = AgentStateStore()
+        # Oracle for market snapshots (VIX + S&P MAs) feeding regime detection.
+        self.oracle = OracleUpdater()
+        # Exogenous market-regime classifier (issue #660). Rule-based VIX/MA —
+        # hermetic, no fitted artifact. Kept SEPARATE from the endogenous
+        # EnsembleConsensus signal (issue #659): the two are complementary.
+        self.regime_detector: VixRegimeDetector = VixRegimeDetector()
         self._synth_addrs = chain_client.settings.synth_addresses
         self._usdc_addr = chain_client.settings.usdc_address
         self._known_vaults: set[str] = set()  # Vaults we've already seen
@@ -208,9 +216,20 @@ class StrategyRunner:
             total_count = sum(len(ss.signals) for ss in all_signals)
             consensus = EnsembleConsensus.from_signal_counts(flat_count, total_count)
 
-            # Market regime is exogenous and not detected here — stays "unknown"
-            # until an IRegimeDetector is wired (separate issue).
-            market_regime = _MARKET_REGIME_UNKNOWN
+            # Exogenous market regime (issue #660). Fetch a market snapshot
+            # (VIX + S&P MAs) and classify it with the rule-based detector.
+            # This is INDEPENDENT of the endogenous EnsembleConsensus above —
+            # the regime says what the *market* is doing, the consensus says
+            # how decisive *our strategies* are. Traces carry both.
+            regime_classification, market_regime = await self._classify_market_regime(tick_id)
+
+            # Persist the exogenous market regime under KEY_REGIME so the
+            # /api/regime/current surface returns the *real* detector output
+            # (it falls back to ensemble consensus only while this is absent —
+            # see regime_routes.get_current_regime). Guarded: the classifier
+            # returns None on snapshot-fetch failure or missing regime signals.
+            if regime_classification is not None:
+                await self.state.save_regime(regime_classification)
 
             # Persist the ensemble consensus under its OWN Redis key so it does
             # not shadow the market regime.
@@ -315,6 +334,53 @@ class StrategyRunner:
 
         except Exception:
             logger.exception("[tick %s] Strategy tick failed — will retry", tick_id)
+
+    # ─── Exogenous market-regime classification (Issue #660) ─────────
+
+    async def _classify_market_regime(self, tick_id: str) -> tuple[RegimeClassification | None, str]:
+        """Fetch a market snapshot and classify the exogenous market regime.
+
+        Returns ``(classification, regime_value)``. On any failure — snapshot
+        fetch error, or a snapshot without enough regime signals (VIX / S&P
+        MAs unavailable) — degrades gracefully to ``(None, "unknown")`` and
+        logs a warning rather than crashing the tick.
+        """
+        try:
+            snapshot = await self.oracle.fetch_market_snapshot()
+        except Exception as e:
+            logger.warning(
+                "[tick %s] Market snapshot fetch failed (%s) — regime=unknown",
+                tick_id,
+                e,
+            )
+            return None, _MARKET_REGIME_UNKNOWN
+
+        if not snapshot.has_regime_signals:
+            logger.warning(
+                "[tick %s] Snapshot missing regime signals (VIX/MA unavailable) — regime=unknown",
+                tick_id,
+            )
+            return None, _MARKET_REGIME_UNKNOWN
+
+        try:
+            classification = self.regime_detector.classify(snapshot)
+        except Exception as e:
+            logger.warning(
+                "[tick %s] Regime classification failed (%s) — regime=unknown",
+                tick_id,
+                e,
+            )
+            return None, _MARKET_REGIME_UNKNOWN
+
+        logger.info(
+            "[tick %s] Market regime: %s (confidence=%.2f, VIX=%.1f, changed=%s)",
+            tick_id,
+            classification.regime.value,
+            classification.confidence,
+            classification.signals.vix_level,
+            classification.regime_changed,
+        )
+        return classification, classification.regime.value
 
     # ─── Per-vault strategy scoping (Issue #307) ─────────────────────
 

--- a/backend/archimedes/services/vix_regime_detector.py
+++ b/backend/archimedes/services/vix_regime_detector.py
@@ -1,0 +1,251 @@
+"""VIX/MA rule-based market-regime detector — concrete ``IRegimeDetector``.
+
+This is the exogenous market-regime classifier wired into the agent runner
+(issue #660). It is deliberately rule-based and hermetic: no fitted model
+artifact, no return history, no new pip dependency. The thresholds are
+named constants drawn from practitioner literature (VIX term structure +
+moving-average trend filters), so the classification is interpretable and
+fully unit-testable.
+
+Distinct from ``EnsembleConsensus`` (issue #659): that is an *endogenous*
+signal (how flat the strategy ensemble's own signals are); this is an
+*exogenous* read on what the market is doing (VIX level, S&P 500 trend).
+The agent runner carries both, clearly labelled.
+
+Calibration table (issue #660):
+
+    VIX >= 40  OR  (VIX >= 30 AND not above MA200)        -> CRISIS
+    VIX >= 25  OR  not above MA200                         -> RISK_OFF
+    VIX <= 15  AND above MA50 AND above MA200              -> RISK_ON
+    everything else                                        -> TRANSITION
+
+Confidence is derived from the distance between the current VIX and the
+nearest decision-boundary threshold, clamped to [0.5, 0.95]. A two-tick
+confirmation rule (hysteresis) prevents a single noisy snapshot from
+flipping the regime: the candidate regime must repeat on two consecutive
+``classify`` calls before it is adopted.
+
+Owner: Önder (portfolio math + risk pricing); coverage: Dan.
+Design reference: design.md § 4.3.3; IRegimeDetector docstring (math.py).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from archimedes.models.asset import MarketSnapshot
+from archimedes.models.regime import (
+    Regime,
+    RegimeClassification,
+    RegimeSignals,
+)
+
+logger = logging.getLogger(__name__)
+
+# ─── Calibration thresholds (named, not magic numbers) ───────────────
+# VIX boundaries. Practitioner convention: sub-15 VIX is a calm/complacent
+# tape; the 20s are elevated; 30+ is stress; 40+ is full crisis (the GFC
+# 2008 and COVID-2020 peaks both blew through 40).
+_VIX_CALM = 15.0  # at/below -> eligible for RISK_ON
+_VIX_ELEVATED = 25.0  # at/above -> at least RISK_OFF
+_VIX_STRESS = 30.0  # at/above + trend break -> CRISIS
+_VIX_CRISIS = 40.0  # at/above -> CRISIS outright
+
+# Confidence is clamped to this band — a rule-based classifier should never
+# claim certainty (1.0) nor be a coin-flip (< 0.5).
+_CONF_MIN = 0.5
+_CONF_MAX = 0.95
+# VIX points of distance-to-boundary that map to full _CONF_MAX confidence.
+# 15 points is roughly one regime band wide, so being a full band away from
+# the nearest boundary earns maximum confidence.
+_CONF_VIX_SCALE = 15.0
+
+# Hysteresis: a new candidate regime must be observed on this many consecutive
+# classify() calls before the detector actually switches to it. Matches the
+# IRegimeDetector docstring ("2+ confirming signals before changing regime").
+_CONFIRMATIONS_REQUIRED = 2
+
+# Symbols we try, in order, to find the S&P 500 spot price in a snapshot.
+# The issue spec names "SPY"; the live oracle publishes "sSPY". We accept
+# either so the classifier works against both.
+_SP500_PRICE_KEYS = ("SPY", "sSPY")
+
+
+class VixRegimeDetector:
+    """Rule-based VIX + moving-average market-regime classifier.
+
+    Implements ``IRegimeDetector`` (interfaces/math.py): ``classify`` and
+    ``get_current_regime``. Stateful across calls — it tracks the previous
+    VIX (for rate-of-change), the confirmed regime, and a pending-candidate
+    counter for the two-tick hysteresis rule.
+    """
+
+    def __init__(self, previous_regime: Regime | None = None) -> None:
+        self._confirmed_regime: Regime | None = previous_regime
+        self._last_classification: RegimeClassification | None = None
+        self._last_vix: float | None = None
+        # Hysteresis bookkeeping: the candidate awaiting confirmation and how
+        # many consecutive times it has now been seen.
+        self._pending_regime: Regime | None = None
+        self._pending_count: int = 0
+
+    # ─── IRegimeDetector ─────────────────────────────────────────────
+
+    def classify(self, snapshot: MarketSnapshot) -> RegimeClassification:
+        """Classify the current market regime from a snapshot.
+
+        Applies the calibration table to derive a *candidate* regime, then
+        the two-tick hysteresis rule to decide whether to adopt it. Returns
+        a ``RegimeClassification`` whose ``regime`` is the currently
+        *confirmed* regime (which may lag the candidate by up to one tick).
+        """
+        vix = snapshot.vix if snapshot.vix is not None else 20.0
+
+        above_ma50 = self._above_ma(snapshot, snapshot.sp500_ma50)
+        above_ma200 = self._above_ma(snapshot, snapshot.sp500_ma200)
+
+        candidate = self._raw_regime(vix, above_ma50, above_ma200)
+        confidence = self._confidence(vix)
+
+        # Hysteresis: only switch the confirmed regime once the candidate has
+        # repeated for _CONFIRMATIONS_REQUIRED consecutive calls. The very
+        # first classification adopts its candidate immediately (no prior to
+        # confirm against).
+        previous_confirmed = self._confirmed_regime
+        regime_changed = self._apply_hysteresis(candidate)
+
+        signals = RegimeSignals(
+            vix_level=vix,
+            vix_rate_of_change=self._vix_roc(vix),
+            sp500_above_ma50=above_ma50,
+            sp500_above_ma200=above_ma200,
+            credit_spread_ig=snapshot.credit_spread_ig,
+            credit_spread_hy=snapshot.credit_spread_hy,
+            btc_dominance=snapshot.btc_dominance,
+        )
+
+        classification = RegimeClassification(
+            regime=self._confirmed_regime or candidate,
+            confidence=round(confidence, 2),
+            signals=signals,
+            timestamp=datetime.now(UTC),
+            previous_regime=previous_confirmed,
+            regime_changed=regime_changed,
+        )
+
+        self._last_vix = vix
+        self._last_classification = classification
+        logger.info(
+            "Regime: %s (candidate=%s, confidence=%.2f, changed=%s, VIX=%.1f, above_ma50=%s, above_ma200=%s)",
+            classification.regime.value,
+            candidate.value,
+            confidence,
+            regime_changed,
+            vix,
+            above_ma50,
+            above_ma200,
+        )
+        return classification
+
+    def get_current_regime(self) -> RegimeClassification | None:
+        """Return the most recent classification, or None if never classified."""
+        return self._last_classification
+
+    # ─── Rule table ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _raw_regime(vix: float, above_ma50: bool, above_ma200: bool) -> Regime:
+        """Map (VIX, MA positioning) to a regime via the calibration table.
+
+        Ordering matters — checks run most-defensive-first so CRISIS wins
+        over RISK_OFF when both conditions hold.
+        """
+        if vix >= _VIX_CRISIS or (vix >= _VIX_STRESS and not above_ma200):
+            return Regime.CRISIS
+        if vix >= _VIX_ELEVATED or not above_ma200:
+            return Regime.RISK_OFF
+        if vix <= _VIX_CALM and above_ma50 and above_ma200:
+            return Regime.RISK_ON
+        return Regime.TRANSITION
+
+    @staticmethod
+    def _above_ma(snapshot: MarketSnapshot, ma: float | None) -> bool:
+        """Whether the S&P 500 spot trades above a given moving average.
+
+        Returns False when the MA is unavailable or no S&P spot price is in
+        the snapshot — a conservative default (treats missing trend data as
+        "not confirmed above"), which biases toward the defensive regimes.
+        """
+        if ma is None:
+            return False
+        price = 0.0
+        for key in _SP500_PRICE_KEYS:
+            value = snapshot.prices.get(key)
+            if value:
+                price = value
+                break
+        return price > ma
+
+    # ─── Confidence ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _confidence(vix: float) -> float:
+        """Confidence from the distance between VIX and the nearest boundary.
+
+        The further VIX sits from the closest decision boundary, the more
+        confident the classification (a VIX of 12 is unambiguously calm; a
+        VIX of 24.9 is a hair from flipping to RISK_OFF). Distance is scaled
+        by ``_CONF_VIX_SCALE`` and clamped to [_CONF_MIN, _CONF_MAX].
+        """
+        boundaries = (_VIX_CALM, _VIX_ELEVATED, _VIX_STRESS, _VIX_CRISIS)
+        distance = min(abs(vix - b) for b in boundaries)
+        scaled = distance / _CONF_VIX_SCALE
+        return max(_CONF_MIN, min(_CONF_MAX, _CONF_MIN + scaled * (_CONF_MAX - _CONF_MIN)))
+
+    def _vix_roc(self, vix: float) -> float:
+        """VIX rate of change vs the previously seen VIX (fraction).
+
+        Zero on the first observation (no prior to compare against) or when
+        the previous VIX was non-positive.
+        """
+        if self._last_vix is None or self._last_vix <= 0:
+            return 0.0
+        return round((vix - self._last_vix) / self._last_vix, 4)
+
+    # ─── Hysteresis ──────────────────────────────────────────────────
+
+    def _apply_hysteresis(self, candidate: Regime) -> bool:
+        """Advance the confirmation state machine; return whether regime changed.
+
+        - First-ever classification: adopt the candidate immediately.
+        - Candidate equals the confirmed regime: reset any pending switch.
+        - Candidate differs: require ``_CONFIRMATIONS_REQUIRED`` consecutive
+          observations before adopting it.
+        """
+        if self._confirmed_regime is None:
+            self._confirmed_regime = candidate
+            self._pending_regime = None
+            self._pending_count = 0
+            return False
+
+        if candidate == self._confirmed_regime:
+            # Candidate agrees with the status quo — clear any pending switch.
+            self._pending_regime = None
+            self._pending_count = 0
+            return False
+
+        # Candidate disagrees with the confirmed regime.
+        if candidate == self._pending_regime:
+            self._pending_count += 1
+        else:
+            self._pending_regime = candidate
+            self._pending_count = 1
+
+        if self._pending_count >= _CONFIRMATIONS_REQUIRED:
+            self._confirmed_regime = candidate
+            self._pending_regime = None
+            self._pending_count = 0
+            return True
+
+        return False

--- a/backend/tests/services/test_vix_regime_detector.py
+++ b/backend/tests/services/test_vix_regime_detector.py
@@ -1,0 +1,233 @@
+"""Unit coverage for the VIX/MA rule-based market-regime detector (#660).
+
+Pure-function + small state-machine tests — no I/O, no DB, no network, so the
+file runs under the hermetic gate. Covers the calibration table (all four
+regimes + the CRISIS-over-RISK_OFF ordering), the distance-to-boundary
+confidence band, the MA-positioning helper (missing MA / missing price →
+conservative False), the VIX rate-of-change, and the two-tick hysteresis
+state machine (first-tick immediate adoption, lag-by-one switch, reset on a
+disagreeing candidate, clear on agreement).
+
+Distinct from ``test_regime_detector.py`` (the older 18/25/35 heuristic): this
+exercises the refined 15/25/30/40 detector with hysteresis that issue #660
+actually wires into the agent runner.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from archimedes.models.asset import MarketSnapshot
+from archimedes.models.regime import Regime
+from archimedes.services.vix_regime_detector import (
+    _CONF_MAX,
+    _CONF_MIN,
+    VixRegimeDetector,
+)
+
+
+def _snapshot(
+    *,
+    vix: float | None = 20.0,
+    sp500_price: float | None = 5000.0,
+    ma50: float | None = 4900.0,
+    ma200: float | None = 4800.0,
+    price_key: str = "sSPY",
+) -> MarketSnapshot:
+    """Build a minimal MarketSnapshot exercising the detector's inputs."""
+    prices: dict[str, float] = {}
+    if sp500_price is not None:
+        prices[price_key] = sp500_price
+    return MarketSnapshot(
+        timestamp=datetime.now(UTC),
+        prices=prices,
+        vix=vix,
+        sp500_ma50=ma50,
+        sp500_ma200=ma200,
+    )
+
+
+class TestCalibrationTable:
+    """The (VIX, MA positioning) → Regime mapping, including precedence."""
+
+    def test_extreme_vix_is_crisis_regardless_of_trend(self) -> None:
+        det = VixRegimeDetector()
+        cls = det.classify(_snapshot(vix=45.0))  # >= 40 → CRISIS outright
+        assert cls.regime is Regime.CRISIS
+
+    def test_stress_vix_with_broken_trend_is_crisis(self) -> None:
+        det = VixRegimeDetector()
+        # VIX >= 30 AND below MA200 → CRISIS (price under the 200-day MA).
+        cls = det.classify(_snapshot(vix=32.0, sp500_price=4000.0, ma200=4800.0))
+        assert cls.regime is Regime.CRISIS
+
+    def test_stress_vix_with_intact_trend_is_only_risk_off(self) -> None:
+        det = VixRegimeDetector()
+        # VIX 32 but price ABOVE MA200 → not CRISIS; >= 25 → RISK_OFF.
+        cls = det.classify(_snapshot(vix=32.0, sp500_price=5000.0, ma200=4800.0))
+        assert cls.regime is Regime.RISK_OFF
+
+    def test_elevated_vix_is_risk_off(self) -> None:
+        det = VixRegimeDetector()
+        cls = det.classify(_snapshot(vix=28.0))  # >= 25 → RISK_OFF
+        assert cls.regime is Regime.RISK_OFF
+
+    def test_broken_trend_alone_is_risk_off(self) -> None:
+        det = VixRegimeDetector()
+        # Calm VIX but price below MA200 → RISK_OFF on the trend break.
+        cls = det.classify(_snapshot(vix=20.0, sp500_price=4000.0, ma200=4800.0))
+        assert cls.regime is Regime.RISK_OFF
+
+    def test_calm_vix_with_uptrend_is_risk_on(self) -> None:
+        det = VixRegimeDetector()
+        # VIX <= 15 AND above both MAs → RISK_ON.
+        cls = det.classify(_snapshot(vix=12.0, sp500_price=5000.0, ma50=4900.0, ma200=4800.0))
+        assert cls.regime is Regime.RISK_ON
+
+    def test_calm_vix_below_ma50_is_transition_not_risk_on(self) -> None:
+        det = VixRegimeDetector()
+        # VIX calm and above MA200 (so not RISK_OFF) but below MA50 → not
+        # RISK_ON (needs both MAs) → TRANSITION.
+        cls = det.classify(_snapshot(vix=14.0, sp500_price=4850.0, ma50=4900.0, ma200=4800.0))
+        assert cls.regime is Regime.TRANSITION
+
+    def test_mid_vix_intact_trend_is_transition(self) -> None:
+        det = VixRegimeDetector()
+        # VIX 20 (between calm and elevated), above both MAs → TRANSITION.
+        cls = det.classify(_snapshot(vix=20.0, sp500_price=5000.0, ma50=4900.0, ma200=4800.0))
+        assert cls.regime is Regime.TRANSITION
+
+
+class TestConfidence:
+    """Confidence is clamped to [_CONF_MIN, _CONF_MAX] and grows with distance."""
+
+    def test_confidence_within_band(self) -> None:
+        det = VixRegimeDetector()
+        cls = det.classify(_snapshot(vix=20.0))
+        assert _CONF_MIN <= cls.confidence <= _CONF_MAX
+
+    def test_on_boundary_is_minimum_confidence(self) -> None:
+        det = VixRegimeDetector()
+        # VIX exactly on a boundary (40) → distance 0 → minimum confidence.
+        cls = det.classify(_snapshot(vix=40.0))
+        assert cls.confidence == _CONF_MIN
+
+    def test_midband_confidence_value(self) -> None:
+        det = VixRegimeDetector()
+        # VIX 20 is 5 points from the nearest boundary (15 or 25):
+        # 0.5 + (5/15) * (0.95 - 0.5) = 0.65.
+        cls = det.classify(_snapshot(vix=20.0))
+        assert cls.confidence == 0.65
+
+    def test_far_from_boundary_is_capped(self) -> None:
+        det = VixRegimeDetector()
+        # VIX 70 is 30 points past the 40 boundary → scaled would exceed 1,
+        # so confidence clamps to the max.
+        cls = det.classify(_snapshot(vix=70.0))
+        assert cls.confidence == _CONF_MAX
+
+
+class TestMaPositioning:
+    """The _above_ma helper degrades conservatively to False."""
+
+    def test_missing_ma_is_not_above(self) -> None:
+        det = VixRegimeDetector()
+        # ma200 missing → treated as "not above" → trend break → at least RISK_OFF.
+        cls = det.classify(_snapshot(vix=12.0, ma200=None))
+        assert cls.signals.sp500_above_ma200 is False
+        assert cls.regime is Regime.RISK_OFF
+
+    def test_missing_price_is_not_above(self) -> None:
+        det = VixRegimeDetector()
+        cls = det.classify(_snapshot(vix=12.0, sp500_price=None))
+        assert cls.signals.sp500_above_ma50 is False
+        assert cls.signals.sp500_above_ma200 is False
+
+    def test_accepts_plain_spy_price_key(self) -> None:
+        det = VixRegimeDetector()
+        # The classifier accepts both "sSPY" (live oracle) and "SPY" (spec).
+        cls = det.classify(_snapshot(vix=12.0, sp500_price=5000.0, price_key="SPY"))
+        assert cls.signals.sp500_above_ma50 is True
+        assert cls.regime is Regime.RISK_ON
+
+
+class TestVixRateOfChange:
+    """VIX RoC is zero on the first tick and a fraction thereafter."""
+
+    def test_first_tick_roc_is_zero(self) -> None:
+        det = VixRegimeDetector()
+        cls = det.classify(_snapshot(vix=20.0))
+        assert cls.signals.vix_rate_of_change == 0.0
+
+    def test_subsequent_roc_is_fractional_change(self) -> None:
+        det = VixRegimeDetector()
+        det.classify(_snapshot(vix=20.0))
+        cls = det.classify(_snapshot(vix=22.0))
+        # (22 - 20) / 20 = 0.1
+        assert cls.signals.vix_rate_of_change == 0.1
+
+
+class TestHysteresis:
+    """The two-tick confirmation state machine."""
+
+    def test_first_classification_adopts_immediately(self) -> None:
+        det = VixRegimeDetector()
+        cls = det.classify(_snapshot(vix=12.0))
+        assert cls.regime is Regime.RISK_ON
+        assert cls.previous_regime is None
+        assert cls.regime_changed is False
+
+    def test_regime_lags_one_tick_before_switching(self) -> None:
+        det = VixRegimeDetector()
+        det.classify(_snapshot(vix=12.0))  # confirmed RISK_ON
+        # First disagreeing tick: candidate is CRISIS but confirmed still lags.
+        lagging = det.classify(_snapshot(vix=45.0))
+        assert lagging.regime is Regime.RISK_ON
+        assert lagging.regime_changed is False
+        # Second consecutive CRISIS tick: now it switches.
+        switched = det.classify(_snapshot(vix=45.0))
+        assert switched.regime is Regime.CRISIS
+        assert switched.regime_changed is True
+        assert switched.previous_regime is Regime.RISK_ON
+
+    def test_disagreeing_candidate_resets_pending_count(self) -> None:
+        det = VixRegimeDetector()
+        det.classify(_snapshot(vix=12.0))  # confirmed RISK_ON
+        det.classify(_snapshot(vix=45.0))  # pending CRISIS, count 1
+        # A different candidate (RISK_OFF) resets the pending switch...
+        det.classify(_snapshot(vix=28.0, sp500_price=5000.0))  # pending RISK_OFF, count 1
+        # ...so a single later CRISIS tick is only count 1 again, no switch.
+        still = det.classify(_snapshot(vix=45.0))
+        assert still.regime is Regime.RISK_ON
+        assert still.regime_changed is False
+
+    def test_agreement_clears_pending_switch(self) -> None:
+        det = VixRegimeDetector()
+        det.classify(_snapshot(vix=12.0))  # confirmed RISK_ON
+        det.classify(_snapshot(vix=45.0))  # pending CRISIS, count 1
+        det.classify(_snapshot(vix=12.0))  # candidate == confirmed → clears pending
+        # One CRISIS tick after a clear is only count 1 → still no switch.
+        still = det.classify(_snapshot(vix=45.0))
+        assert still.regime is Regime.RISK_ON
+        assert still.regime_changed is False
+
+
+class TestGetCurrentRegime:
+    """get_current_regime returns the latest classification, or None."""
+
+    def test_none_before_first_classify(self) -> None:
+        det = VixRegimeDetector()
+        assert det.get_current_regime() is None
+
+    def test_returns_latest_after_classify(self) -> None:
+        det = VixRegimeDetector()
+        cls = det.classify(_snapshot(vix=12.0))
+        assert det.get_current_regime() is cls
+
+    def test_seeded_previous_regime_enables_immediate_hysteresis(self) -> None:
+        # Seeding a prior confirmed regime means the first disagreeing tick
+        # does NOT adopt immediately — it must clear the two-tick gate.
+        det = VixRegimeDetector(previous_regime=Regime.RISK_ON)
+        lagging = det.classify(_snapshot(vix=45.0))
+        assert lagging.regime is Regime.RISK_ON
+        assert lagging.regime_changed is False

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -7,7 +7,7 @@ Hermetic: no network, no testnet.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from archimedes.models.portfolio import (
@@ -230,3 +230,70 @@ class TestPerVaultScopingLegacyFallback:
 
             result = runner._get_vault_strategy_ids("0xVaultWithStrategies")
             assert result == ["faber_001", "tsmom_001"]
+
+
+class TestClassifyMarketRegime:
+    """The exogenous-regime helper wired in #660 — degrades to ('unknown')."""
+
+    @pytest.fixture()
+    def runner(self):
+        with (
+            patch("archimedes.chain.agent_runner.chain_client") as mock_client,
+            patch("archimedes.chain.agent_runner.chain_executor"),
+            patch("archimedes.chain.agent_runner.trace_publisher"),
+            patch("archimedes.chain.agent_runner.default_provider"),
+            patch("archimedes.chain.agent_runner.AgentStateStore"),
+        ):
+            mock_client.settings = MagicMock(synth_addresses={}, usdc_address="0xusdc")
+            from archimedes.chain.agent_runner import StrategyRunner
+
+            return StrategyRunner()
+
+    @staticmethod
+    def _snapshot_with_signals():
+        from datetime import UTC, datetime
+
+        from archimedes.models.asset import MarketSnapshot
+
+        # vix + sp500_ma50 present → has_regime_signals is True.
+        return MarketSnapshot(
+            timestamp=datetime.now(UTC),
+            prices={"sSPY": 5000.0},
+            vix=12.0,
+            sp500_ma50=4900.0,
+            sp500_ma200=4800.0,
+        )
+
+    async def test_happy_path_returns_classification_and_regime(self, runner):
+        from archimedes.models.regime import Regime
+
+        runner.oracle.fetch_market_snapshot = AsyncMock(return_value=self._snapshot_with_signals())
+        classification, regime = await runner._classify_market_regime("tick-1")
+        assert classification is not None
+        assert regime == Regime.RISK_ON.value
+        assert classification.regime is Regime.RISK_ON
+
+    async def test_snapshot_fetch_failure_degrades_to_unknown(self, runner):
+        runner.oracle.fetch_market_snapshot = AsyncMock(side_effect=RuntimeError("oracle down"))
+        classification, regime = await runner._classify_market_regime("tick-2")
+        assert classification is None
+        assert regime == "unknown"
+
+    async def test_snapshot_without_regime_signals_degrades_to_unknown(self, runner):
+        from datetime import UTC, datetime
+
+        from archimedes.models.asset import MarketSnapshot
+
+        # No VIX → has_regime_signals is False.
+        bare = MarketSnapshot(timestamp=datetime.now(UTC), prices={"sSPY": 5000.0})
+        runner.oracle.fetch_market_snapshot = AsyncMock(return_value=bare)
+        classification, regime = await runner._classify_market_regime("tick-3")
+        assert classification is None
+        assert regime == "unknown"
+
+    async def test_classifier_exception_degrades_to_unknown(self, runner):
+        runner.oracle.fetch_market_snapshot = AsyncMock(return_value=self._snapshot_with_signals())
+        runner.regime_detector.classify = MagicMock(side_effect=ValueError("bad signals"))
+        classification, regime = await runner._classify_market_regime("tick-4")
+        assert classification is None
+        assert regime == "unknown"


### PR DESCRIPTION
Completes the unfinished #660 work: wires the rule-based VIX/MA market-regime detector into the strategy tick.

- New `services/vix_regime_detector.py` — hermetic VIX/MA classifier (no fitted artifact, no new dep) with two-tick hysteresis + distance-to-boundary confidence.
- `agent_runner` classifies a `MarketSnapshot` each tick **and persists it via `state.save_regime`** — the missing call the previous draft left out, so `/api/regime/current` now returns the real detector output instead of falling back to ensemble consensus.
- Kept strictly separate from the endogenous `EnsembleConsensus` (#659).

**Tests:** 24 detector cases (100% line cov) + 4 agent_runner helper cases (happy path + 3 graceful-degradation branches). Hermetic suite green.

Note: `services/regime_detector.py` (older 18/25/35 heuristic) predates this and is now redundant at the wiring layer — #621 tracks consolidating the two. Adversarial review verdict: SOUND.
