### PR TITLE
[quant] Add library-level CSCV PBO as criterion-4 input with provenance label (#546)

### DIFF
--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -36,7 +36,7 @@ from archimedes.services._rigor_helpers import (
     compute_dsr,
     compute_in_sample_sharpe,  # noqa: F401 - re-exported for fusion_evaluator
     compute_oos_sharpe,
-    compute_pbo,  # noqa: F401 - re-exported for fusion_evaluator/generation_pipeline/test_pbo_parity
+    compute_pbo,  # used by compute_library_pbo below + re-exported (fusion/generation/test_pbo_parity)
     compute_sharpe_ci,  # noqa: F401 - re-exported for strategy_provider
     monte_carlo_dsr_pvalue,  # noqa: F401 - re-exported for test_rigor_evaluator
     regime_conditional_dsr,  # noqa: F401 - re-exported for test_rigor_regime
@@ -143,6 +143,113 @@ def _get_func_name(node: ast.expr) -> str | None:
     return None
 
 
+# ─── Library-level PBO (criterion-4 input, #546) ──────────────────────
+
+
+def align_returns_store(
+    returns_store: dict[str, dict[str, list]],
+) -> dict[str, list[float]]:
+    """Inner-join dated return series on ISO dates → an aligned PBO matrix.
+
+    Mirrors ``analytics-engine/scripts/compute_library_pbo.py::build_aligned_matrix``
+    so the backend gate and the offline diagnostic compute the library PBO from
+    the *same* alignment. The library's strategies trade different calendars
+    (^N225 vs SPY vs joined pair windows); CSCV requires that row *i* of the
+    returns matrix means the same trading day for every strategy, so we keep
+    only the dates present in *every* series before handing off to
+    ``compute_pbo`` (which itself only truncates to the shortest length).
+
+    Args:
+        returns_store: ``{strategy_stem: {"dates": [...], "daily_returns": [...]}}``
+            — one entry per library strategy, each carrying a 1:1 dated series
+            (the shape of ``analytics-engine/strategies/daily_returns/<stem>.json``).
+            The caller loads it; this module stays I/O-free.
+
+    Returns:
+        ``{strategy_stem: returns_on_joint_dates}`` — date-aligned, ready for
+        ``compute_pbo``. Returns ``{}`` when fewer than two usable series are
+        supplied or the dated intersection is empty (the caller fail-closes on
+        the empty matrix — see ``compute_library_pbo``).
+    """
+    series = {stem: rec for stem, rec in returns_store.items() if rec.get("dates") and rec.get("daily_returns")}
+    if len(series) < 2:
+        return {}
+
+    date_sets = [set(rec["dates"]) for rec in series.values()]
+    joint = sorted(set.intersection(*date_sets))
+    if not joint:
+        return {}
+
+    matrix: dict[str, list[float]] = {}
+    for stem, rec in series.items():
+        # strict=True (matching the offline build_aligned_matrix) fails loud on a
+        # malformed record whose dates/daily_returns lengths disagree, rather than
+        # silently truncating and risking a misaligned row / KeyError on join.
+        by_date = dict(zip(rec["dates"], rec["daily_returns"], strict=True))
+        matrix[stem] = [float(by_date[d]) for d in joint]
+    return matrix
+
+
+def compute_library_pbo(
+    returns_store: dict[str, dict[str, list]],
+    s_partitions: int = 16,
+) -> float | None:
+    """Single library-level CSCV PBO over the whole selection set (#546).
+
+    This is the criterion-4 input for ``run_rigor_gate``: PBO is a property of
+    the *selection set*, not of an individual strategy (Bailey et al. 2014), so
+    the principled gate input is one library-wide value, not a per-cohort score.
+    Date-aligns the store via ``align_returns_store`` then runs the same
+    parity-tested ``compute_pbo`` the cohort path uses.
+
+    **Refresh policy (gate-affecting — documented in docs/specs/library-pbo.md).**
+    CSCV PBO is a property of the selection set: adding, removing, or re-running
+    any library strategy changes it. The caller MUST recompute (call this
+    function afresh) whenever the selection set changes — i.e. on every library
+    add, removal, or daily-returns-store regeneration — and MUST NOT freeze the
+    value into a per-strategy fixture. The store is add-only + idempotent
+    (``gen_daily_returns_store.py``), so "selection set changed" reduces to "a
+    new ``daily_returns/<stem>.json`` exists"; recomputing on store growth is
+    the cadence.
+
+    Args:
+        returns_store: ``{strategy_stem: {"dates": [...], "daily_returns": [...]}}``.
+        s_partitions: Number of equal time-partitions S (even ≥ 2; default 16,
+            the paper's recommended value).
+
+    Returns:
+        The single library PBO ∈ [0, 1], or ``None`` when it cannot be computed
+        (fewer than two aligned series, empty date intersection, a joint window
+        shorter than ``s_partitions``, or a degenerate ``compute_pbo`` result).
+        ``None`` is the fail-closed signal: the gate treats a missing/non-finite
+        library PBO as criterion-4 FAIL rather than silently passing. A
+        non-finite value (should never arise from the rounded ``compute_pbo``
+        output, but guarded for safety) also returns ``None``.
+    """
+    matrix = align_returns_store(returns_store)
+    if len(matrix) < 2:
+        return None
+
+    # Fail closed on a too-short joint window. compute_pbo returns an all-0.0
+    # sentinel (a spurious criterion-4 PASS, PBO < 0.5) when rows_per_block =
+    # T // s_partitions < 1 — i.e. fewer joint dates than partitions. That 0.0
+    # is non-finite-clean but meaningless, so guard it here: an under-length
+    # window is non-computable, which must FAIL criterion 4, not pass it.
+    shortest = min(len(r) for r in matrix.values())
+    if shortest // s_partitions < 1:
+        return None
+
+    scores = compute_pbo(matrix, s_partitions=s_partitions)
+    if not scores:
+        return None
+
+    # compute_pbo attaches the same library-level value to every member; take any.
+    pbo = next(iter(scores.values()))
+    if pbo is None or not math.isfinite(pbo):
+        return None
+    return float(pbo)
+
+
 # ─── 6. Rigor Gate — composite check ─────────────────────────────────
 
 
@@ -162,12 +269,18 @@ class RigorGateResult:
         paper_claimed_sharpe: float | None = None,
         cpcv_mean_oos_sharpe: float | None = None,
         cpcv_positive_fraction: float | None = None,
+        pbo_source: str = "cohort",
     ) -> None:
         self.strategy_id = strategy_id
         self.deflated_sharpe = deflated_sharpe
         self.dsr_p_value = dsr_p_value
         self.num_trials = num_trials
         self.pbo_score = pbo_score
+        # Which selection set produced the criterion-4 PBO: "library" when the
+        # full-library CSCV PBO was supplied (the principled Bailey et al. input,
+        # #546), "cohort" when it fell back to the per-cohort dict score. Surfaced
+        # in gate_details so the verdict is honest about its provenance.
+        self.pbo_source = pbo_source
         self.oos_sharpe = oos_sharpe
         self.look_ahead_passed = look_ahead_passed
         self.in_sample_sharpe = in_sample_sharpe
@@ -183,8 +296,9 @@ class RigorGateResult:
         # NaN-hardening: every IEEE-754 comparison against NaN is False, so a NaN
         # metric (not None — None is guarded) would silently skip its fail branch
         # and let an under-credentialed strategy pass. Treat any non-finite metric
-        # as an automatic fail. pbo_score is sourced from an external dict; oos/IS
-        # Sharpe can carry NaN if upstream returns contain NaN.
+        # as an automatic fail. pbo_score is sourced either from the full-library
+        # CSCV PBO (#546, the principled input) or — fallback — an external cohort
+        # dict; oos/IS Sharpe can carry NaN if upstream returns contain NaN.
         if self.dsr_p_value is None or not math.isfinite(self.dsr_p_value):
             return False
         if self.dsr_p_value < 0.95:
@@ -227,12 +341,15 @@ class RigorGateResult:
         # per-entry "dsr_convention" ("raw" for frozen legacy, "excess" for new).
         details["dsr_convention"] = "excess"
 
-        if self.pbo_score is not None and self.pbo_score < 0.5:
-            details["pbo"] = f"PASS (PBO={self.pbo_score:.4f})"
-        elif self.pbo_score is not None:
-            details["pbo"] = f"FAIL (PBO={self.pbo_score:.4f}, need < 0.5)"
+        # Criterion 4 input provenance (#546): "library" = full-library CSCV PBO
+        # (the principled Bailey et al. selection-set input), "cohort" = the
+        # per-cohort dict score. Disclosed so the verdict states which set fed it.
+        if self.pbo_score is not None and math.isfinite(self.pbo_score) and self.pbo_score < 0.5:
+            details["pbo"] = f"PASS (PBO={self.pbo_score:.4f}, source={self.pbo_source})"
+        elif self.pbo_score is not None and math.isfinite(self.pbo_score):
+            details["pbo"] = f"FAIL (PBO={self.pbo_score:.4f}, need < 0.5, source={self.pbo_source})"
         else:
-            details["pbo"] = "MISSING"
+            details["pbo"] = f"MISSING (source={self.pbo_source})"
 
         if self.oos_sharpe is not None and self.in_sample_sharpe and self.in_sample_sharpe > 0:
             ratio = self.oos_sharpe / self.in_sample_sharpe
@@ -272,12 +389,24 @@ def run_rigor_gate(
     look_ahead_audit_passed: bool | None = None,
     average_correlation: float = 0.0,
     cv_returns_matrix: np.ndarray | list[list[float]] | None = None,
+    library_pbo: float | None = None,
 ) -> RigorGateResult:
     """Run all four selection-bias checks on a strategy.
 
     Main entry point called by the orchestrator and API routes.
 
     Args:
+        library_pbo: The single full-library CSCV PBO (Bailey et al. 2014) for
+            the *current selection set* — the principled criterion-4 input
+            (#546). PBO is a property of the whole library, not of one strategy,
+            so when this is supplied it is used for criterion 4 in preference to
+            the per-cohort ``pbo_scores`` lookup. Compute it from the
+            daily-returns store via ``compute_library_pbo`` and recompute on
+            every selection-set change (see that function's refresh-policy note).
+            Fail-closed: ``None`` (or a non-finite value) makes criterion 4 FAIL
+            rather than silently pass — exactly as a missing cohort score does.
+            When ``None``, the gate falls back to ``pbo_scores.get(strategy_id)``
+            and the verdict is labelled ``source=cohort``.
         average_correlation: Mean pairwise correlation among the ``num_trials``
             trials in the selection set, used by the DSR effective-N correction.
             The caller holds the library/variant returns and computes it via
@@ -301,8 +430,18 @@ def run_rigor_gate(
     #    the trials are correlated (fewer independent bets than the nominal N).
     deflated_sharpe, dsr_p_value = compute_dsr(daily_returns, num_trials, average_correlation)
 
-    # 2. PBO — use pre-computed library-level score
-    pbo_score = pbo_scores.get(strategy_id) if pbo_scores else None
+    # 2. PBO (criterion 4 in the gate ordering) — prefer the full-library CSCV
+    #    PBO when supplied (#546). PBO is a property of the selection set, not of
+    #    one strategy (Bailey et al. 2014), so the library-wide value is the
+    #    principled input; the per-cohort dict is the fallback when no library
+    #    PBO is passed. Fail-closed semantics live in RigorGateResult.passes_all:
+    #    a None/NaN pbo_score fails criterion 4 regardless of source.
+    if library_pbo is not None:
+        pbo_score = library_pbo
+        pbo_source = "library"
+    else:
+        pbo_score = pbo_scores.get(strategy_id) if pbo_scores else None
+        pbo_source = "cohort"
 
     # 3. Walk-forward OOS Sharpe (single holdout) + Combinatorial Purged CV.
     #    CPCV runs only when a real 2-D combinatorial OOS matrix is supplied.
@@ -344,14 +483,16 @@ def run_rigor_gate(
         paper_claimed_sharpe=paper_claimed_sharpe,
         cpcv_mean_oos_sharpe=cpcv["mean_oos_sharpe"] if cpcv else None,
         cpcv_positive_fraction=cpcv["positive_fraction"] if cpcv else None,
+        pbo_source=pbo_source,
     )
 
     logger.info(
-        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s, OOS=%s, CPCV+=%s, LA=%s)",
+        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s [%s], OOS=%s, CPCV+=%s, LA=%s)",
         strategy_id,
         "PASS" if result.passes_all else "FAIL",
         dsr_p_value,
         pbo_score,
+        pbo_source,
         oos_sharpe,
         cpcv["positive_fraction"] if cpcv else None,
         la_passed,

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -39,6 +39,8 @@ from archimedes.services._rigor_helpers import (
 from archimedes.services.rigor_evaluator import (
     RigorGateResult,
     _get_func_name,
+    align_returns_store,
+    compute_library_pbo,
     look_ahead_audit,
     run_rigor_gate,
 )
@@ -450,7 +452,7 @@ class TestRigorGate:
         )
 
         assert not result.passes_all
-        assert result.gate_details["pbo"] == "MISSING"
+        assert result.gate_details["pbo"] == "MISSING (source=cohort)"
 
     def test_fails_with_high_pbo(self) -> None:
         result = RigorGateResult(
@@ -772,19 +774,24 @@ class TestGateDetailsBranches:
         assert r.gate_details["dsr"] == "MISSING"
 
     def test_pbo_pass_branch(self):
-        """pbo_score < 0.5 renders 'PASS (PBO=...)'."""
+        """pbo_score < 0.5 renders 'PASS (PBO=..., source=...)' (#546)."""
         r = RigorGateResult("s", pbo_score=0.3000)
-        assert r.gate_details["pbo"] == "PASS (PBO=0.3000)"
+        assert r.gate_details["pbo"] == "PASS (PBO=0.3000, source=cohort)"
 
     def test_pbo_fail_branch(self):
-        """pbo_score >= 0.5 but not None renders 'FAIL (PBO=..., need < 0.5)'."""
+        """pbo_score >= 0.5 but not None renders 'FAIL (..., source=...)' (#546)."""
         r = RigorGateResult("s", pbo_score=0.6000)
-        assert r.gate_details["pbo"] == "FAIL (PBO=0.6000, need < 0.5)"
+        assert r.gate_details["pbo"] == "FAIL (PBO=0.6000, need < 0.5, source=cohort)"
 
     def test_pbo_missing_branch(self):
-        """pbo_score is None renders 'MISSING'."""
+        """pbo_score is None renders 'MISSING (source=...)' (#546)."""
         r = RigorGateResult("s", pbo_score=None)
-        assert r.gate_details["pbo"] == "MISSING"
+        assert r.gate_details["pbo"] == "MISSING (source=cohort)"
+
+    def test_pbo_source_library_label(self):
+        """A library-level PBO labels the detail source=library (#546)."""
+        r = RigorGateResult("s", pbo_score=0.3000, pbo_source="library")
+        assert r.gate_details["pbo"] == "PASS (PBO=0.3000, source=library)"
 
     def test_oos_sharpe_pass_ratio(self):
         """oos_sharpe set, in_sample_sharpe > 0, ratio >= 0.5 renders 'PASS (OOS/IS=...)'."""
@@ -1268,3 +1275,146 @@ class TestBonferroniCorrection:
         bonf_result = bonferroni_correction(pvalues, alpha=0.05)
         # Bonferroni is always at least as conservative as BH
         assert bonf_result["n_rejected"] <= bh_result["n_rejected"]
+
+
+# ─── Library-level PBO (criterion-4 input, #546) ─────────────────────
+
+
+class TestAlignReturnsStore:
+    """Date-aligned inner-join of the daily-returns store (parity with the
+    offline analytics-engine/scripts/compute_library_pbo.py::build_aligned_matrix)."""
+
+    def test_aligns_on_joint_dates_in_order(self) -> None:
+        store = {
+            "a": {"dates": ["2020-01-01", "2020-01-02", "2020-01-03"], "daily_returns": [0.1, 0.2, 0.3]},
+            "b": {"dates": ["2020-01-02", "2020-01-03", "2020-01-04"], "daily_returns": [0.5, 0.6, 0.7]},
+        }
+        matrix = align_returns_store(store)
+        # Joint dates are {01-02, 01-03}, sorted; each row maps to the right value.
+        assert matrix == {"a": [0.2, 0.3], "b": [0.5, 0.6]}
+
+    def test_fewer_than_two_series_returns_empty(self) -> None:
+        store = {"a": {"dates": ["2020-01-01"], "daily_returns": [0.1]}}
+        assert align_returns_store(store) == {}
+
+    def test_empty_date_intersection_returns_empty(self) -> None:
+        store = {
+            "a": {"dates": ["2020-01-01", "2020-01-02"], "daily_returns": [0.1, 0.2]},
+            "b": {"dates": ["2021-06-01", "2021-06-02"], "daily_returns": [0.5, 0.6]},
+        }
+        assert align_returns_store(store) == {}
+
+    def test_drops_series_missing_dates_or_returns(self) -> None:
+        store = {
+            "a": {"dates": ["2020-01-01", "2020-01-02"], "daily_returns": [0.1, 0.2]},
+            "b": {"dates": [], "daily_returns": []},  # unusable → dropped
+            "c": {"dates": ["2020-01-02", "2020-01-03"], "daily_returns": [0.5, 0.6]},
+        }
+        matrix = align_returns_store(store)
+        assert set(matrix.keys()) == {"a", "c"}
+        assert matrix == {"a": [0.2], "c": [0.5]}
+
+    def test_malformed_record_length_mismatch_raises(self) -> None:
+        # strict=True (parity with the offline build_aligned_matrix): a record
+        # whose dates and daily_returns lengths disagree fails loud rather than
+        # silently producing a misaligned row.
+        store = {
+            "a": {"dates": ["2020-01-01", "2020-01-02"], "daily_returns": [0.1, 0.2]},
+            "b": {"dates": ["2020-01-01", "2020-01-02", "2020-01-03"], "daily_returns": [0.5, 0.6]},
+        }
+        with pytest.raises(ValueError):
+            align_returns_store(store)
+
+
+class TestComputeLibraryPbo:
+    """Single library-wide CSCV PBO over the whole selection set (#546)."""
+
+    @staticmethod
+    def _series(seed: int, n: int = 256) -> dict[str, list]:
+        rng = np.random.default_rng(seed)
+        dates = [f"2020-{1 + i // 28:02d}-{1 + i % 28:02d}" for i in range(n)]
+        return {"dates": dates, "daily_returns": rng.normal(0.0005, 0.01, n).tolist()}
+
+    def test_returns_float_in_unit_interval(self) -> None:
+        store = {f"s{i}": self._series(i) for i in range(4)}
+        pbo = compute_library_pbo(store, s_partitions=8)
+        assert pbo is not None
+        assert 0.0 <= pbo <= 1.0
+
+    def test_fewer_than_two_series_returns_none(self) -> None:
+        store = {"a": self._series(1)}
+        assert compute_library_pbo(store) is None
+
+    def test_empty_store_returns_none(self) -> None:
+        assert compute_library_pbo({}) is None
+
+    def test_short_joint_window_fails_closed(self) -> None:
+        # A joint window shorter than s_partitions is non-computable: must fail
+        # closed to None, NOT return compute_pbo's all-0.0 PASS sentinel (#546).
+        dates = [f"2020-01-{d:02d}" for d in range(1, 6)]  # 5 dates < default S=16
+        store = {
+            "a": {"dates": dates, "daily_returns": [0.01] * 5},
+            "b": {"dates": dates, "daily_returns": [0.02] * 5},
+        }
+        assert compute_library_pbo(store) is None
+
+    def test_empty_pbo_scores_fail_closed(self, monkeypatch) -> None:
+        # If compute_pbo yields no scores, fail closed to None (not silent pass).
+        store = {f"s{i}": self._series(i) for i in range(2)}
+        monkeypatch.setattr("archimedes.services.rigor_evaluator.compute_pbo", lambda *a, **k: {})
+        assert compute_library_pbo(store) is None
+
+    def test_non_finite_pbo_fails_closed(self, monkeypatch) -> None:
+        # A NaN/inf library PBO must not pass criterion 4 — fail closed to None.
+        store = {f"s{i}": self._series(i) for i in range(2)}
+        monkeypatch.setattr(
+            "archimedes.services.rigor_evaluator.compute_pbo",
+            lambda *a, **k: dict.fromkeys(store, float("nan")),
+        )
+        assert compute_library_pbo(store) is None
+
+
+class TestRigorGateLibraryPbo:
+    """run_rigor_gate prefers the library PBO and labels its provenance (#546)."""
+
+    @staticmethod
+    def _returns() -> list[float]:
+        rng = np.random.default_rng(42)
+        return rng.normal(0.001, 0.008, size=500).tolist()
+
+    def test_library_pbo_takes_precedence_and_labels_source(self) -> None:
+        result = run_rigor_gate(
+            strategy_id="s",
+            daily_returns=self._returns(),
+            num_trials=5,
+            pbo_scores={"s": 0.9},  # cohort score would FAIL...
+            library_pbo=0.2,  # ...but the library PBO (0.2) is the real input
+            strategy_code="class S: def next(self): self.buy()",
+        )
+        assert result.pbo_source == "library"
+        assert result.pbo_score == 0.2
+        assert "source=library" in result.gate_details["pbo"]
+
+    def test_falls_back_to_cohort_when_no_library_pbo(self) -> None:
+        result = run_rigor_gate(
+            strategy_id="s",
+            daily_returns=self._returns(),
+            num_trials=5,
+            pbo_scores={"s": 0.2},
+            strategy_code="class S: def next(self): self.buy()",
+        )
+        assert result.pbo_source == "cohort"
+        assert result.pbo_score == 0.2
+        assert "source=cohort" in result.gate_details["pbo"]
+
+    def test_none_library_pbo_with_no_cohort_fails_closed(self) -> None:
+        result = run_rigor_gate(
+            strategy_id="s",
+            daily_returns=self._returns(),
+            num_trials=5,
+            pbo_scores=None,
+            library_pbo=None,
+            strategy_code="class S: def next(self): self.buy()",
+        )
+        assert not result.passes_all
+        assert result.gate_details["pbo"] == "MISSING (source=cohort)"


### PR DESCRIPTION
Completes the unfinished #546 mechanism: library-level CSCV PBO as the principled criterion-4 input.

- `compute_library_pbo` + `align_returns_store` (date-aligned inner-join, parity with the offline `compute_library_pbo.py`).
- `run_rigor_gate(library_pbo=...)` takes precedence over the per-cohort dict; the verdict labels its PBO `source` ("library"/"cohort") in `gate_details`.
- **Fail-closed throughout:** missing, non-finite, OR under-length-window PBO FAILs criterion 4 (never silent-pass). `strict=True` alignment fails loud on malformed store records.

The two hardenings (short-window fail-open guard + strict alignment) were added after adversarial review flagged a fail-OPEN edge.

**Mechanism only** — the `selection_bias_routes.py` call site still uses the cohort fallback (safe no-op default). Wiring the live route is the remaining step, gated on the #546 refresh-cadence decision.

**Tests:** align/compute units + gate precedence/provenance cases; existing `gate_details` assertions updated for the new `source=` suffix. 150 passed.
