### PR TITLE
[infra] Optimize nginx.conf: gzip, keepalive, DRY proxy params, SSL session cache (#456)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,14 @@
+# ── nginx server fragment ──────────────────────────────────────────────
+# This file is mounted at /etc/nginx/conf.d/default.conf (see nginx/Dockerfile)
+# and is therefore included INSIDE the stock nginx `http {}` block. That is why
+# the http-context directives below (map / upstream / limit_req_zone / gzip /
+# ssl_session_cache) are valid here — they are not at the true top level, they
+# are inside `http {}` via the conf.d include. Validate with `nginx -t` by
+# mounting this file into conf.d (NOT as the main nginx.conf):
+#   docker run --rm \
+#     -v "$PWD/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+#     nginxinc/nginx-unprivileged:alpine nginx -t
+
 # ── Real client IP behind the ALB ──────────────────────────────────────
 # Trust X-Forwarded-For only from the ALB VPC (10.0.0.0/16) — restricts
 # real-IP trust to the known ALB subnet after the EC2 SG was locked to this
@@ -8,32 +19,111 @@ set_real_ip_from 10.0.0.0/16;
 real_ip_header X-Forwarded-For;
 real_ip_recursive on;
 
+# ── Backend upstream ───────────────────────────────────────────────────
+# Single source of truth for the FastAPI backend address. keepalive reuses
+# upstream connections, cutting per-request TCP/handshake overhead between
+# nginx and the backend.
+upstream backend_api {
+    server backend:8000;
+    keepalive 32;
+}
+
+# ── HTTPS-redirect decision (replaces nested-if logic) ─────────────────
+# $do_redirect is 1 only when the original client request was plain HTTP.
+# When behind the ALB, TLS is terminated at the ALB and forwarded to :8080
+# as HTTP with X-Forwarded-Proto: https — those must NOT be redirected (no
+# redirect loop). Direct HTTPS connections ($scheme=https) also skip the
+# redirect. Default (HTTP, no XFP=https) redirects to HTTPS.
+map $http_x_forwarded_proto $xfp_is_https {
+    default 0;
+    "https" 1;
+}
+map $scheme $scheme_is_https {
+    default 0;
+    "https" 1;
+}
+# do_redirect = NOT (xfp_is_https OR scheme_is_https); expressed as a map on
+# the concatenation so the only "serve, don't redirect" case is when at least
+# one of the two signals indicates HTTPS.
+map "$xfp_is_https$scheme_is_https" $do_redirect {
+    default 1;   # 00 → plain HTTP → redirect
+    "01"    0;   # direct HTTPS
+    "10"    0;   # ALB-forwarded HTTPS
+    "11"    0;   # both signal HTTPS
+}
+
+# ── Compression ────────────────────────────────────────────────────────
+# gzip JSON API responses + text assets to save user bandwidth. SSE is
+# explicitly excluded per-location (gzip off there) so streamed events are
+# not buffered for compression. gzip_proxied any → compress even when the
+# response carries a Via header (i.e. proxied from the backend / behind ALB).
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 5;
+gzip_min_length 1024;
+gzip_types
+    application/json
+    application/javascript
+    application/manifest+json
+    application/xml
+    application/rss+xml
+    image/svg+xml
+    text/css
+    text/javascript
+    text/plain
+    text/xml;
+
 # ── Rate limiting zones (defense-in-depth behind slowapi) ──────────────
 # These fire even if an attacker somehow bypasses the app-layer rate limiter.
 # After the real_ip directives above, $binary_remote_addr is the real client
-# IP, so each client gets its own bucket. 60/min reads, 20/min writes.
+# IP, so each client gets its own bucket. These are a defense-in-depth BACKSTOP
+# above the app-layer slowapi limits — they must stay HIGHER than the per-route
+# app limits so nginx never becomes the binding constraint on legitimate SPA
+# traffic (the UI polls several endpoints on 2-5s intervals; 60r/m leaves ~2x
+# headroom over the app-layer public-GET limit, 30r/m did not — it 503'd normal
+# usage). 60/min reads, 20/min writes.
 limit_req_zone $binary_remote_addr zone=api_read:10m rate=60r/m;
 limit_req_zone $binary_remote_addr zone=api_write:10m rate=20r/m;
 
-# HTTP server — handles both direct HTTP and ALB-forwarded HTTPS.
-# When behind ALB, TLS is terminated at the ALB. ALB forwards to port 80
-# (host) → 8080 (container) as plain HTTP with X-Forwarded-Proto: https.
-# We only redirect to HTTPS when the original client request was HTTP
-# (i.e. X-Forwarded-Proto is NOT https).
+# ── DRY proxy parameters ───────────────────────────────────────────────
+# The repeated proxy headers/timeouts that previously lived in every
+# `location` block are now declared ONCE at the server level in each server
+# below and inherited by all proxy locations. The SSE location overrides only
+# what it must (read timeout + buffering). This is the DRY win: one place to
+# change a header, applied everywhere.
+
 server {
     listen 8080;
     server_name archimedes-arc.app;
+
+    # ── Shared proxy parameters (inherited by every proxy location) ───────
+    # Defining these at server level removes the per-location duplication
+    # (DRY): each `location` that proxy_passes inherits these unless it
+    # overrides them. Timeouts are the read/write defaults; the SSE location
+    # overrides proxy_read_timeout + buffering for streaming.
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    proxy_connect_timeout 5s;
+    proxy_read_timeout 30s;
+    proxy_send_timeout 10s;
 
     # ── Security headers ──────────────────────────────────────────────────
     # Production traffic is served from THIS block (ALB terminates TLS and
     # forwards to :8080), so the headers must live here — they previously
     # existed only in the unused :8443 block, leaving the live app with none
     # (clickjacking + no CSP). See AUDIT_2026-06-10.md finding #20. Kept in sync
-    # with the :8443 block below. script-src is 'self' only (finding #27): the
-    # Vite prod bundle has no inline scripts and no executed eval — the only
-    # Function() constructor uses are dead fallback paths (lodash-es _root.js
-    # globalThis detection, setImmediate-polyfill string-callback branch).
-    # style-src 'unsafe-inline' is retained deliberately (separate concern).
+    # with the :8443 block below. The `always` flag ensures they are emitted on
+    # error responses (4xx/5xx) too, not just 2xx/3xx. script-src is 'self' only
+    # (finding #27): the Vite prod bundle has no inline scripts and no executed
+    # eval — the only Function() constructor uses are dead fallback paths
+    # (lodash-es _root.js globalThis detection, setImmediate-polyfill
+    # string-callback branch). style-src 'unsafe-inline' is retained
+    # deliberately (separate concern).
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -44,18 +134,6 @@ server {
     # ACME challenge passthrough for certbot renewals
     location /.well-known/acme-challenge/ {
         root /usr/share/nginx/html;
-    }
-
-    # If the request came through ALB as HTTPS, serve normally
-    # (no redirect loop). Only redirect when the client used HTTP.
-    set $do_redirect 1;
-    if ($http_x_forwarded_proto = "https") {
-        set $do_redirect 0;
-    }
-
-    # Direct HTTPS connections (not through ALB) also shouldn't redirect
-    if ($scheme = "https") {
-        set $do_redirect 0;
     }
 
     location / {
@@ -69,42 +147,34 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Proxy API requests to the FastAPI backend (same as HTTPS block)
+    # Proxy API requests to the FastAPI backend (proxy headers/timeouts
+    # inherited from server level above — DRY).
     location /api/ {
         limit_req zone=api_read burst=20 nodelay;
-        proxy_pass http://backend:8000/api/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_connect_timeout 5s;
-        proxy_read_timeout 30s;
-        proxy_send_timeout 10s;
+        proxy_pass http://backend_api/api/;
     }
 
-    # SSE streaming needs longer timeouts
+    # SSE streaming needs longer timeouts and must NOT be buffered or gzipped.
     location /api/generate/stream/ {
         limit_req zone=api_read burst=5 nodelay;
-        proxy_pass http://backend:8000/api/generate/stream/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://backend_api/api/generate/stream/;
+        # Override the server-level read timeout for long-lived streams.
         proxy_read_timeout 300s;
         proxy_buffering off;
         proxy_cache off;
+        gzip off;
     }
 
     # Proxy backend health check
     location /health {
-        proxy_pass http://backend:8000/health;
-        proxy_set_header Host $host;
+        proxy_pass http://backend_api/health;
     }
 }
 
-# HTTPS server
+# HTTPS server (direct, non-ALB) — http/2 + SSL session caching
 server {
     listen 8443 ssl;
+    http2 on;
     server_name archimedes-arc.app;
 
     ssl_certificate     /etc/nginx/certs/fullchain.pem;
@@ -113,10 +183,30 @@ server {
     ssl_ciphers         HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 
+    # SSL session caching avoids a full handshake on reconnects within the
+    # timeout window — large latency win for repeat visitors. shared cache so
+    # all workers share sessions; tickets off prevents the well-known
+    # forward-secrecy weakening of stale ticket keys.
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1h;
+    ssl_session_tickets off;
+
     root /usr/share/nginx/html;
     index index.html;
 
+    # ── Shared proxy parameters (inherited by every proxy location) ───────
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    proxy_connect_timeout 5s;
+    proxy_read_timeout 30s;
+    proxy_send_timeout 10s;
+
     # ── Security headers (Issue #177) ─────────────────────────────────────
+    # `always` ensures headers are emitted on error responses too.
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -134,36 +224,26 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Proxy API requests to the FastAPI backend
+    # Proxy API requests to the FastAPI backend (proxy headers/timeouts
+    # inherited from server level above — DRY).
     location /api/ {
         limit_req zone=api_read burst=20 nodelay;
-        proxy_pass http://backend:8000/api/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_connect_timeout 5s;
-        proxy_read_timeout 30s;
-        proxy_send_timeout 10s;
+        proxy_pass http://backend_api/api/;
     }
 
-    # SSE streaming needs longer timeouts + no buffering
+    # SSE streaming needs longer timeouts + no buffering + no gzip.
     location /api/generate/stream/ {
         limit_req zone=api_read burst=5 nodelay;
-        proxy_pass http://backend:8000/api/generate/stream/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://backend_api/api/generate/stream/;
         proxy_read_timeout 300s;
         proxy_buffering off;
         proxy_cache off;
+        gzip off;
     }
 
     # Proxy backend health check
     location /health {
-        proxy_pass http://backend:8000/health;
-        proxy_set_header Host $host;
+        proxy_pass http://backend_api/health;
     }
 
     # /docs and /openapi.json are gated behind ENABLE_API_DOCS (default OFF in


### PR DESCRIPTION
Completes #456: nginx.conf performance + maintainability refactor (no routing-behaviour change).

- `backend_api` upstream with keepalive; gzip for JSON/text/SVG (SSE excluded); proxy params hoisted to server level (DRY); map-based HTTPS-redirect; http/2 + SSL session cache on :8443; `always` on security headers.

Rate-limit zones kept at **60r/m read / 20r/m write** (unchanged from main): an earlier draft tightened reads to 30r/m, but adversarial review showed the UI's 2-5s polling exceeds that — nginx would become the binding constraint (not the app-layer slowapi limiter) and 503 legit traffic. Reverted.

Validated with `nginx -t` (conf.d include context, dummy certs + resolvable backend). Not deploy-verified — EC2 target offline (deploy gated behind DEPLOY_ENABLED, #679).
