### PR TITLE
[contracts] Enforce PriceOracle setPrice cooldown to cap ratchet (#587)

### DIFF
--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -23,6 +23,13 @@ contract PriceOracle is Ownable {
     /// @notice Address allowed to push price updates (e.g. Circle wallet)
     address public updater;
 
+    /// @notice Timestamp of the last *setPrice* update (0 until the first one).
+    ///         Distinct from lastUpdated (which the constructor seeds) so the
+    ///         updateCooldown applies only between two actual updater pushes —
+    ///         not between deploy and the first push. forceSetPrice does not
+    ///         touch this field; the cooldown only governs the setPrice path.
+    uint256 public lastSetPriceTime;
+
     /// @notice Max allowed move per setPrice, in basis points vs the prior price.
     ///         Default 2000 bps (20%) — generous for a daily-update cadence but
     ///         blocks fat-finger / glitched-feed / compromised-key writes that
@@ -41,16 +48,40 @@ contract PriceOracle is Ownable {
     ///         not owner-configurable — it exists precisely to bound a compromised key.
     uint256 public constant FORCE_MAX_DEVIATION_BPS = 90_000;
 
+    /// @notice Minimum spacing between two consecutive setPrice calls, in seconds.
+    ///         setPrice already bounds a single move to maxDeviationBps, but with no
+    ///         spacing an attacker could chain N max-deviation calls in one block to
+    ///         ratchet the price arbitrarily (issue #587). Requiring a gap of at least
+    ///         updateCooldown seconds between accepted updates blocks that intra-block
+    ///         chaining and limits a compromised key to one bounded move per window,
+    ///         giving the owner time to react (rotate the key / forceSetPrice).
+    ///         Owner-configurable via setUpdateCooldown; forceSetPrice (owner escape
+    ///         hatch) is exempt so the owner can always reprice out-of-band.
+    ///         Default 30s — well above Arc's sub-second block time (so it defeats the
+    ///         same-block ratchet this guards against) yet comfortably below the oracle
+    ///         runner's 60s push cadence (ORACLE_INTERVAL_SECONDS), so legitimate
+    ///         updates never trip it. Operators who slow the on-chain push cadence can
+    ///         raise this toward MAX_UPDATE_COOLDOWN for a stronger rate limit.
+    uint256 public updateCooldown = 30;
+
+    /// @notice Upper bound on the owner-configurable cooldown (1 hour). Prevents the
+    ///         owner from setting a cooldown so long that legitimate daily updates are
+    ///         blocked, while still allowing the bound to be tuned for the deploy cadence.
+    uint256 public constant MAX_UPDATE_COOLDOWN = 1 hours;
+
     event PriceUpdated(uint256 oldPrice, uint256 newPrice, uint256 timestamp);
     event PriceForced(uint256 oldPrice, uint256 newPrice, uint256 timestamp);
     event MaxDeviationBpsChanged(uint256 oldBps, uint256 newBps);
     event UpdaterChanged(address oldUpdater, address newUpdater);
+    event UpdateCooldownChanged(uint256 oldCooldown, uint256 newCooldown);
 
     error StalePrice();
     error UnauthorizedUpdater();
     error ZeroPrice();
     error PriceDeviationTooLarge(uint256 oldPrice, uint256 newPrice, uint256 maxBps);
     error InvalidDeviationBound();
+    error UpdateRateLimited(uint256 lastUpdated, uint256 cooldown, uint256 nowTs);
+    error InvalidCooldown();
 
     modifier onlyUpdater() {
         if (msg.sender != owner() && msg.sender != updater) revert UnauthorizedUpdater();
@@ -71,6 +102,15 @@ contract PriceOracle is Ownable {
     ///         widens the bound via setMaxDeviationBps).
     function setPrice(uint256 _newPrice) external onlyUpdater {
         if (_newPrice == 0) revert ZeroPrice();
+        // Rate-limit: require at least updateCooldown seconds between two
+        // accepted setPrice pushes (issue #587). Skipped on the very first
+        // push (lastSetPriceTime == 0). Combined with the per-call deviation
+        // bound, this caps a compromised updater key to one bounded move per
+        // cooldown window — it cannot chain many max-deviation calls in a block
+        // to ratchet the price. forceSetPrice (owner escape hatch) is exempt.
+        if (lastSetPriceTime != 0 && block.timestamp < lastSetPriceTime + updateCooldown) {
+            revert UpdateRateLimited(lastSetPriceTime, updateCooldown, block.timestamp);
+        }
         uint256 oldPrice = price;
         // Deviation bound only applies once a prior price exists; a zero
         // prior price (bootstrap) accepts any positive first price.
@@ -82,6 +122,7 @@ contract PriceOracle is Ownable {
         }
         price = _newPrice;
         lastUpdated = block.timestamp;
+        lastSetPriceTime = block.timestamp;
         emit PriceUpdated(oldPrice, _newPrice, block.timestamp);
     }
 
@@ -112,6 +153,18 @@ contract PriceOracle is Ownable {
         uint256 old = maxDeviationBps;
         maxDeviationBps = _maxDeviationBps;
         emit MaxDeviationBpsChanged(old, _maxDeviationBps);
+    }
+
+    /// @notice Adjust the minimum spacing between setPrice calls (issue #587).
+    ///         Bounded above by MAX_UPDATE_COOLDOWN so the owner cannot set a
+    ///         cooldown long enough to block legitimate daily updates. A value
+    ///         of 0 disables rate-limiting (the per-call deviation bound still
+    ///         applies) — a deliberate, owner-only choice.
+    function setUpdateCooldown(uint256 _cooldown) external onlyOwner {
+        if (_cooldown > MAX_UPDATE_COOLDOWN) revert InvalidCooldown();
+        uint256 old = updateCooldown;
+        updateCooldown = _cooldown;
+        emit UpdateCooldownChanged(old, _cooldown);
     }
 
     function setUpdater(address _updater) external onlyOwner {

--- a/contracts/test/PriceOracle.t.sol
+++ b/contracts/test/PriceOracle.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/PriceOracle.sol";
+
+/// @dev Rate-limit / ratchet-protection tests for PriceOracle (issue #587).
+///      The deviation bound caps a *single* move; the updateCooldown caps how
+///      *often* a move can land, so a compromised updater key cannot chain
+///      many bounded moves in one block to ratchet the price arbitrarily.
+contract PriceOracleCooldownTest is Test {
+    PriceOracle public oracle;
+
+    address public owner = address(0x1);
+    address public alice = address(0x2);
+
+    uint256 constant INITIAL_PRICE = 392_600_000; // $392.60 (6 dec)
+    uint256 constant WITHIN_BOUND = 400_000_000; // +~1.9%, inside the 20% bound
+
+    function setUp() public {
+        // Pin a non-zero baseline timestamp so lastSetPriceTime is unambiguous.
+        vm.warp(1_000_000);
+        vm.prank(owner);
+        oracle = new PriceOracle("TSLA", INITIAL_PRICE, owner);
+    }
+
+    function test_default_cooldown_is_30s() public view {
+        // 30s: above Arc's sub-second block time (defeats the same-block ratchet)
+        // but below the oracle runner's 60s push cadence so legit pushes never trip.
+        assertEq(oracle.updateCooldown(), 30);
+        assertEq(oracle.MAX_UPDATE_COOLDOWN(), 1 hours);
+    }
+
+    function test_first_setPrice_allowed_regardless_of_cooldown() public {
+        // lastSetPriceTime starts at 0, so the first push is never rate-limited.
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND);
+        assertEq(oracle.price(), WITHIN_BOUND);
+        assertEq(oracle.lastSetPriceTime(), block.timestamp);
+    }
+
+    function test_second_setPrice_within_cooldown_reverts() public {
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND);
+        // Same block → rate-limited.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PriceOracle.UpdateRateLimited.selector, block.timestamp, oracle.updateCooldown(), block.timestamp
+            )
+        );
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND + 1);
+    }
+
+    function test_setPrice_allowed_after_cooldown_elapses() public {
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND);
+        vm.warp(block.timestamp + 300); // exactly one cooldown window later
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND + 1);
+        assertEq(oracle.price(), WITHIN_BOUND + 1);
+    }
+
+    function test_setPrice_still_limited_one_second_before_window() public {
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND);
+        vm.warp(block.timestamp + 29); // one second short of the 30s window
+        vm.expectRevert(); // UpdateRateLimited
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND + 1);
+    }
+
+    /// @dev Core #587 protection: two max-deviation moves in the same block
+    ///      cannot compound — the cooldown blocks the second before its
+    ///      deviation check even runs, so cumulative drift is one move/window.
+    function test_cooldown_blocks_ratchet_within_block() public {
+        uint256 firstMove = INITIAL_PRICE + (INITIAL_PRICE * 2000) / 10_000; // +20% (the cap)
+        vm.prank(owner);
+        oracle.setPrice(firstMove);
+
+        uint256 secondMove = firstMove + (firstMove * 2000) / 10_000; // another +20%
+        vm.expectRevert(); // UpdateRateLimited — not PriceDeviationTooLarge
+        vm.prank(owner);
+        oracle.setPrice(secondMove);
+
+        // Still only one bounded move from the start.
+        assertEq(oracle.price(), firstMove);
+    }
+
+    function test_forceSetPrice_is_exempt_from_cooldown() public {
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND);
+        // Owner escape hatch works in the same block despite the cooldown.
+        vm.prank(owner);
+        oracle.forceSetPrice(WITHIN_BOUND + 1);
+        assertEq(oracle.price(), WITHIN_BOUND + 1);
+    }
+
+    function test_forceSetPrice_does_not_touch_lastSetPriceTime() public {
+        // forceSetPrice must not seed the setPrice cooldown clock.
+        vm.prank(owner);
+        oracle.forceSetPrice(WITHIN_BOUND);
+        assertEq(oracle.lastSetPriceTime(), 0);
+    }
+
+    function test_setUpdateCooldown_changes_window_and_emits() public {
+        vm.expectEmit(false, false, false, true);
+        emit PriceOracle.UpdateCooldownChanged(30, 600);
+        vm.prank(owner);
+        oracle.setUpdateCooldown(600);
+        assertEq(oracle.updateCooldown(), 600);
+    }
+
+    function test_setUpdateCooldown_zero_disables_rate_limit() public {
+        vm.prank(owner);
+        oracle.setUpdateCooldown(0);
+        // Two consecutive same-block pushes now both land.
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND);
+        vm.prank(owner);
+        oracle.setPrice(WITHIN_BOUND + 1);
+        assertEq(oracle.price(), WITHIN_BOUND + 1);
+    }
+
+    function test_setUpdateCooldown_at_max_boundary_allowed() public {
+        vm.prank(owner);
+        oracle.setUpdateCooldown(1 hours);
+        assertEq(oracle.updateCooldown(), 1 hours);
+    }
+
+    function test_revert_setUpdateCooldown_above_max() public {
+        vm.expectRevert(PriceOracle.InvalidCooldown.selector);
+        vm.prank(owner);
+        oracle.setUpdateCooldown(1 hours + 1);
+    }
+
+    function test_revert_setUpdateCooldown_non_owner() public {
+        vm.prank(alice);
+        vm.expectRevert(); // Ownable: OwnableUnauthorizedAccount
+        oracle.setUpdateCooldown(600);
+    }
+}

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -144,15 +144,20 @@ contract SyntheticVaultTest is Test {
     function test_revert_forceSetPrice_exceeds_hard_cap() public {
         // +11× is beyond the 900% (10×) hard cap
         uint256 elevenX = INITIAL_PRICE * 11;
-        vm.prank(owner);
+        // Read the constant BEFORE the prank so vm.prank applies to the
+        // forceSetPrice call itself, not the FORCE_MAX_DEVIATION_BPS() read
+        // (a stray view call would consume the single-shot prank and the
+        // forceSetPrice would then run as this test contract → OwnableUnauthorizedAccount).
+        uint256 hardCap = oracle.FORCE_MAX_DEVIATION_BPS();
         vm.expectRevert(
             abi.encodeWithSelector(
                 PriceOracle.PriceDeviationTooLarge.selector,
                 INITIAL_PRICE,
                 elevenX,
-                oracle.FORCE_MAX_DEVIATION_BPS()
+                hardCap
             )
         );
+        vm.prank(owner);
         oracle.forceSetPrice(elevenX);
     }
 


### PR DESCRIPTION
⚠️ **Contract change — holding for @onderakkaya explicit merge approval (per our agreement).** Do not merge until the cooldown-default decision below is confirmed.

Completes the unfinished #587 oracle hardening. The previous draft declared `lastSetPriceTime` / `updateCooldown` / the errors + event but left the **enforcement and the owner setter unimplemented**. This wires them up:

- `setPrice` reverts `UpdateRateLimited` within `updateCooldown` of the prior accepted push (first push skipped); stamps `lastSetPriceTime` on success. Combined with the per-call deviation bound, a compromised updater key can no longer chain max-deviation calls in one block to ratchet the price. `forceSetPrice` stays exempt and does not touch `lastSetPriceTime`.
- `setUpdateCooldown(uint256)` — owner-tunable, bounded by `MAX_UPDATE_COOLDOWN` (1h) via `InvalidCooldown`; 0 disables.

**Decision needed (adversarial-review finding):** default cooldown is **30s**, deliberately below the live oracle runner's 60s `ORACLE_INTERVAL_SECONDS` push cadence so legit pushes never revert. (An earlier draft used 300s, which would have reverted ~4/5 legit pushes.) If you want a longer security window, also raise `ORACLE_INTERVAL_SECONDS`. **Önder: confirm 30s or pick a value.**

Separate follow-up (out of scope): `push_prices_on_chain` records success on bare Circle-201 without on-chain confirmation — worth a robustness pass.

**Tests:** new `PriceOracle.t.sol`, 13 cases (first-push, in-window revert, post-window, same-block ratchet block, forceSetPrice exemption, setter bounds/zero/owner-only). Full contracts suite **175 passed**; `forge fmt` clean.
