### PR TITLE
[security] Sanitize user input in log calls (CWE-117 log forging)

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -35,6 +35,7 @@ from archimedes.api.generate_schemas import (
 )
 from archimedes.api.limiter import limiter
 from archimedes.services.job_queue import EVENT_LOG_TTL, get_job_store
+from archimedes.services.log_scrubber import sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +128,7 @@ async def stream_events(job_id: str, request: Request) -> StreamingResponse:
         elapsed = 0.0
         while elapsed < _STREAM_TIMEOUT_SECONDS:
             if await request.is_disconnected():
-                logger.info("sse client disconnected (job=%s, after=%d)", job_id, cursor)
+                logger.info("sse client disconnected (job=%s, after=%d)", sanitize_log_value(job_id), cursor)
                 return
 
             new_events = await store.list_events(job_id, after_id=cursor)
@@ -211,9 +212,9 @@ async def cancel_job(
     task = _RUNNING_TASKS.get(job_id)
     if task is not None and not task.done():
         task.cancel()
-        logger.info("hard-cancelled job %s", job_id)
+        logger.info("hard-cancelled job %s", sanitize_log_value(job_id))
     else:
-        logger.info("cancel for %s: no live task (already finished or restart)", job_id)
+        logger.info("cancel for %s: no live task (already finished or restart)", sanitize_log_value(job_id))
 
     return {"job_id": job_id, "status": "cancelled"}
 

--- a/backend/archimedes/api/swap_routes.py
+++ b/backend/archimedes/api/swap_routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Query, Request, Response
 
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import PoolListResponse, PoolResponse, SwapQuoteResponse
+from archimedes.services.log_scrubber import sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ async def get_swap_quote(
         # internals, contract addresses, and revert reasons (audit 2026-06-14;
         # same leak class fixed in vaults/portfolio routes #605). Log full
         # detail server-side; return a generic message.
-        logger.exception("swap quote failed for %s -> %s", token_in, token_out)
+        logger.exception("swap quote failed for %s -> %s", sanitize_log_value(token_in), sanitize_log_value(token_out))
         raise HTTPException(status_code=400, detail="Quote failed — check the token pair and amount.") from e
 
 

--- a/backend/archimedes/api/user_routes.py
+++ b/backend/archimedes/api/user_routes.py
@@ -27,7 +27,7 @@ from archimedes.api.user_schemas import UserProfileCreate, UserProfileResponse
 from archimedes.db import get_session
 from archimedes.models.user_profile import UserProfile
 from archimedes.services.email_crypto import decrypt_email, encrypt_email
-from archimedes.services.log_scrubber import scrub_profile
+from archimedes.services.log_scrubber import sanitize_log_value, scrub_profile
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ async def get_profile(wallet: str, request: Request):
 
         logger.info(
             "get_profile: wallet=%s owner=%s data=%s",
-            wallet_lower,
+            sanitize_log_value(wallet_lower),
             is_owner,
             scrub_profile(response.model_dump()),
         )
@@ -168,10 +168,10 @@ async def upsert_profile(payload: UserProfileCreate, request: Request, response:
 
         logger.info(
             "upsert_profile: wallet=%s data=%s",
-            wallet,
+            sanitize_log_value(wallet),
             scrub_profile(
                 {
-                    "wallet_address": wallet,
+                    "wallet_address": sanitize_log_value(wallet),
                     "email": payload.email,
                     "display_name": payload.display_name,
                     "marketing_opt_in": payload.marketing_opt_in,
@@ -185,7 +185,7 @@ async def upsert_profile(payload: UserProfileCreate, request: Request, response:
     except Exception as e:
         session.rollback()
         # Do NOT include PII in error messages
-        logger.error("upsert_profile failed for wallet=%s: %s", wallet, type(e).__name__)
+        logger.error("upsert_profile failed for wallet=%s: %s", sanitize_log_value(wallet), type(e).__name__)
         raise HTTPException(status_code=500, detail="Profile update failed") from e
     finally:
         session.close()

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -11,6 +11,7 @@ from archimedes.api._route_helpers import strategy_provider, vault_svc
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
 from archimedes.chain.strategy_publisher import strategy_publisher
+from archimedes.services.log_scrubber import sanitize_log_value
 
 logger = logging.getLogger(__name__)
 from archimedes.api.schemas import (
@@ -43,10 +44,10 @@ async def _anchor_strategies_async(strategy_ids: list[str]) -> None:
         try:
             passport = strategy_provider.get_strategy(sid)
             if passport is None:
-                logger.debug("anchor: strategy %s not found in provider — skipping", sid)
+                logger.debug("anchor: strategy %s not found in provider — skipping", sanitize_log_value(sid))
                 continue
             if not getattr(passport, "methodology_hash", None):
-                logger.info("skipping anchor for %s: no methodology_hash", sid)
+                logger.info("skipping anchor for %s: no methodology_hash", sanitize_log_value(sid))
                 continue
 
             paper_hashes = [p.arxiv_id for p in passport.papers if p.arxiv_id]
@@ -59,9 +60,9 @@ async def _anchor_strategies_async(strategy_ids: list[str]) -> None:
                 regime_tag=regime_tag,
                 metadata_uri="",
             )
-            logger.info("anchored strategy %s on-chain", sid)
+            logger.info("anchored strategy %s on-chain", sanitize_log_value(sid))
         except Exception as exc:
-            logger.warning("anchor failed for strategy %s (non-fatal): %s", sid, exc)
+            logger.warning("anchor failed for strategy %s (non-fatal): %s", sanitize_log_value(sid), exc)
 
 
 @vaults_router.get("/", response_model=VaultListResponse)

--- a/backend/archimedes/services/job_queue.py
+++ b/backend/archimedes/services/job_queue.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import redis.asyncio as aioredis
 
+from archimedes.services.log_scrubber import sanitize_log_value
+
 logger = logging.getLogger(__name__)
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
@@ -101,7 +103,7 @@ class JobStore:
         if error:
             updates["error"] = error
         await r.hset(key, mapping=updates)
-        logger.info("job: %s → %s", job_id, status)
+        logger.info("job: %s → %s", sanitize_log_value(job_id), status)
 
     # ── Event log (for streaming jobs) ────────────────────────────────────
 

--- a/backend/archimedes/services/log_scrubber.py
+++ b/backend/archimedes/services/log_scrubber.py
@@ -19,3 +19,15 @@ def scrub_profile(profile_dict: dict[str, Any]) -> dict[str, Any]:
     can see that a value *was* present without seeing the value itself.
     """
     return {k: ("<REDACTED>" if k in _PII_FIELDS else v) for k, v in profile_dict.items()}
+
+
+def sanitize_log_value(value: Any) -> str:
+    """Neutralize CR/LF in a user-controlled value before it is logged.
+
+    Guards against log forging (CWE-117): an attacker-supplied value containing
+    newline or carriage-return characters could otherwise inject forged log
+    lines (fake entries, spoofed levels). Both characters are replaced with a
+    single space so the original value stays legible. Any value type is
+    accepted and coerced to ``str``.
+    """
+    return str(value).replace("\r", " ").replace("\n", " ")

--- a/backend/archimedes/services/regime_weight_schedule.py
+++ b/backend/archimedes/services/regime_weight_schedule.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import logging
 from typing import TypedDict
 
+from archimedes.services.log_scrubber import sanitize_log_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -84,12 +86,16 @@ def regime_weight_schedule(risk_profile: str, regime: str) -> RegimeMix:
     """
     profile_schedule = _SCHEDULE.get(risk_profile.lower())
     if not profile_schedule:
-        logger.warning("regime_weight_schedule: unknown profile %r, using default", risk_profile)
+        logger.warning("regime_weight_schedule: unknown profile %r, using default", sanitize_log_value(risk_profile))
         return _DEFAULT_MIX
 
     mix = profile_schedule.get(regime.lower())
     if not mix:
-        logger.warning("regime_weight_schedule: unknown regime %r for %s, using transition", regime, risk_profile)
+        logger.warning(
+            "regime_weight_schedule: unknown regime %r for %s, using transition",
+            sanitize_log_value(regime),
+            sanitize_log_value(risk_profile),
+        )
         mix = profile_schedule.get("transition", _DEFAULT_MIX)
 
     return mix

--- a/backend/archimedes/services/stress_engine.py
+++ b/backend/archimedes/services/stress_engine.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from archimedes.services.log_scrubber import sanitize_log_value
 from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
 
 _logger = logging.getLogger(__name__)
@@ -320,15 +321,15 @@ def _shock_for(asset_class: str, symbol: str, scenario_def: dict) -> tuple[float
         fx_shocks = scenario_def.get("fx_per_pair", {})
         if symbol in fx_shocks:
             return float(fx_shocks[symbol]), True
-        _logger.warning("stress: FX pair %r not in %r scenario", symbol, scenario_def.get("label"))
+        _logger.warning("stress: FX pair %r not in %r scenario", sanitize_log_value(symbol), scenario_def.get("label"))
         return 0.0, False
     shocks = scenario_def.get("shocks", {})
     if asset_class in shocks:
         return float(shocks[asset_class]), True
     _logger.warning(
         "stress: asset_class %r (%s) not in %r scenario — defaulting to 0%% shock",
-        asset_class,
-        symbol,
+        sanitize_log_value(asset_class),
+        sanitize_log_value(symbol),
         scenario_def.get("label"),
     )
     return 0.0, False

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -16,6 +16,7 @@ from archimedes.api.schemas import (
 )
 from archimedes.chain.executor import chain_executor
 from archimedes.chain.trace_publisher import trace_publisher
+from archimedes.services.log_scrubber import sanitize_log_value
 
 
 class VaultService:
@@ -196,7 +197,7 @@ class VaultService:
         except Exception:
             import logging
 
-            logging.getLogger(__name__).exception(f"Failed to get vault detail for {address}")
+            logging.getLogger(__name__).exception("Failed to get vault detail for %s", sanitize_log_value(address))
             return None
 
     def _metrics_to_summary(self, metrics: dict, meta=None) -> VaultSummaryResponse:
@@ -311,7 +312,7 @@ class VaultService:
                         "return_inception": round(weighted_return, 4),
                     }
         except Exception as e:
-            logger.debug(f"Redis price snapshot not available for {vault_address}: {e}")
+            logger.debug("Redis price snapshot not available for %s: %s", sanitize_log_value(vault_address), e)
 
         # Fallback: compute simulated returns from allocation weights
         # This gives realistic numbers until real price history accumulates


### PR DESCRIPTION
## Summary

CodeQL's `security-and-quality` suite flags **21 log-injection sinks** (CWE-117) where user-controlled values reach `logger` calls without neutralizing CR/LF. An attacker could inject forged log lines (fake entries, spoofed levels).

This was surfaced during a full CodeQL-finding validation sweep. Note: GitHub's default code-scanning setup runs the *security-only* suite, which does **not** include `py/log-injection` — so these never appeared as GitHub alerts, only in the quality suite.

## Changes

- Add `sanitize_log_value()` to `services/log_scrubber.py` — replaces `\r`/`\n` with a space, coerces any type to `str`.
- Route the flagged user-controlled args through it across 8 files:
  - `api/generate_routes.py` (`job_id` ×3), `api/swap_routes.py` (token symbols), `api/user_routes.py` (`wallet` ×4), `api/vaults_routes.py` (strategy `sid` ×4)
  - `services/job_queue.py` (`job_id`), `services/regime_weight_schedule.py` (`risk_profile`/`regime`), `services/stress_engine.py` (`symbol`/`asset_class`), `services/vault_service.py` (vault `address`)
- Convert two f-string log calls in `vault_service.py` to lazy `%s` form (also fixes the f-string-in-logging anti-pattern).

## Verify

- `ruff check --select E9,F63,F7,F40,F401,F811` + `ruff format --check` — clean
- `pytest backend/tests/test_user_routes.py backend/tests/services/test_regime_tag.py` — **89 passed**
- All 8 touched modules import cleanly (no circular import via `log_scrubber`)

## Anti-goals

- No behavioral change beyond log output. Internal/non-user values (exception objects, enums, ints) are left untouched.