### PR TITLE
[security] Stop leaking exception detail to clients (CWE-209)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -461,8 +461,11 @@ async def get_portfolio_advisor(
                 "decision_type": trace.decision_type.value,
                 "trigger": trace.trigger,
             }
-        except Exception as e:
-            return {"trace_id": None, "trace_hash": None, "error": str(e)}
+        except Exception:
+            import logging as _logging
+
+            _logging.getLogger(__name__).exception("build/anchor reasoning trace failed")
+            return {"trace_id": None, "trace_hash": None, "error": "trace build failed"}
 
     def _run_stress(allocs: list[dict], usdc_w: float) -> list:
         try:

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -389,12 +389,15 @@ async def health_amm():
             "pools": pools,
         }
 
-    except Exception as exc:
+    except Exception:
+        import logging
+
+        logging.getLogger(__name__).exception("AMM health check failed")
         return JSONResponse(
             status_code=503,
             content={
                 "status": "amm_health_check_failed",
-                "reason": str(exc),
+                "reason": "AMM health check failed — see server logs.",
             },
         )
 

--- a/backend/archimedes/services/circle_service.py
+++ b/backend/archimedes/services/circle_service.py
@@ -57,8 +57,9 @@ class CircleService:
                             "custody_type": wallet.get("custodyType", "DEVELOPER"),
                         }
                     return {"error": f"API returned {resp.status}"}
-            except Exception as e:
-                return {"error": str(e)}
+            except Exception:
+                logger.exception("circle wallet status fetch failed")
+                return {"error": "wallet status unavailable"}
 
     async def get_integration_status(self) -> dict:
         """Get comprehensive Circle integration status for the demo."""

--- a/backend/tests/services/test_circle_service.py
+++ b/backend/tests/services/test_circle_service.py
@@ -122,7 +122,10 @@ class TestGetWalletBalance:
         session = _MockSession(RuntimeError("network down"))
         with patch("archimedes.services.circle_service.aiohttp.ClientSession", return_value=session):
             result = await svc.get_wallet_balance()
-        assert "network down" in result["error"]
+        # Failure is signalled, but the raw exception detail must NOT leak to the
+        # caller-facing response (CWE-209 — info exposure). See get_wallet_balance.
+        assert result["error"] == "wallet status unavailable"
+        assert "network down" not in result["error"]
 
 
 class TestGetIntegrationStatus:


### PR DESCRIPTION
## Summary

Fixes the **4 open GitHub code-scanning alerts** (`py/stack-trace-exposure`, CWE-209) — caught exceptions whose `str()` reaches a client-facing response, leaking internals (RPC errors, stack context).

The exact dataflow sources were confirmed by re-running the CodeQL `StackTraceExposure.ql` query and reading its `codeFlows`:

| Sink | Source | Fix |
|---|---|---|
| `main.py:395` (AMM health 503) | `exc` @ 392 | log + generic `reason` |
| `agent_routes.py:92` (circle-status) | `e` @ `circle_service.py:60` | log + `"wallet status unavailable"` |
| `strategies_routes.py:728` & `:948` | `e` @ `strategies_routes.py:464` | log + `"trace build failed"` |

## Changes

- `logger.exception(...)` records the full detail server-side; the caller gets a generic message. `as e`/`as exc` bindings dropped where now unused.
- Updated `test_circle_service.py::test_request_exception_returns_error` to assert the **secure** behavior (generic message + raw detail absent) — it previously asserted the leak.

## Verify

- `pytest test_circle_service.py test_health_amm.py test_strategy_endpoints.py` → **53 passed**
- `ruff check --select E9,F63,F7,F40,F401,F841` + `ruff format --check` — clean
- Once merged, CodeQL on `main` should auto-close alerts #2–#5.

## Anti-goals

- Non-sensitive `reason` fields (e.g. `"no pool"`, validation messages) untouched — only exception-derived detail is genericized.