### PR TITLE
[reliability] Fix uninitialized-name bug + surface swallowed errors (CodeQL)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -479,7 +479,7 @@ async def _run_fixture_candidate(
             if title or arxiv_id:
                 fixture_source_papers.append({"arxiv_id": arxiv_id, "title": title})
     except Exception:
-        pass
+        logger.debug("failed to collect fixture source papers", exc_info=True)
 
     return _CandidateResult(
         candidate_id=candidate_id,

--- a/backend/archimedes/api/agent_routes.py
+++ b/backend/archimedes/api/agent_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from datetime import UTC
 
 from fastapi import APIRouter, Depends, Request
@@ -12,6 +13,8 @@ from archimedes.api.auth_guard import require_internal_agent_key
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import AgentStatusResponse, AMMHealthResponse
 from archimedes.chain.executor import chain_executor
+
+logger = logging.getLogger(__name__)
 
 agent_router = APIRouter(prefix="/api/agent", tags=["agent"])
 
@@ -44,7 +47,7 @@ async def get_agent_status():
             age = (datetime.now(UTC) - hb_time).total_seconds()
             alive = age < 600
         except Exception:
-            pass
+            logger.debug("agent heartbeat parse failed", exc_info=True)
 
     # Market regime is exogenous (None/"unknown" until a detector is wired).
     # The "regime"-shaped value the agent actually produces is the endogenous
@@ -70,7 +73,7 @@ async def get_agent_status():
         vaults = await chain_executor.get_all_vaults()
         vault_count = len(vaults) if vaults else 0
     except Exception:
-        pass
+        logger.debug("vault count lookup failed", exc_info=True)
 
     return AgentStatusResponse(
         alive=alive,
@@ -163,7 +166,7 @@ async def get_amm_health(request: Request):  # noqa: ARG001 — slowapi @limiter
                     price_raw = await oracle.functions.price().call()
                     oracle_price = price_raw / 1e6
                 except Exception:
-                    pass
+                    logger.debug("oracle price read failed", exc_info=True)
 
             # Total liquidity in USDC terms
             # reserve_usdc + (reserve_token * oracle_price)

--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 
 from fastapi import APIRouter, Query
 
 from archimedes.db import get_session
 from archimedes.services.corpus_categories import label_for as _category_label
+
+logger = logging.getLogger(__name__)
 
 papers_router = APIRouter(prefix="/api/papers", tags=["papers"])
 
@@ -112,7 +115,7 @@ async def get_paper(arxiv_id: str):
                     for r in records
                 ]
         except Exception:
-            pass
+            logger.debug("citing-strategies lookup failed", exc_info=True)
 
         return {
             "arxiv_id": record.arxiv_id,
@@ -144,7 +147,7 @@ async def get_paper(arxiv_id: str):
                 for r in records
             ]
     except Exception:
-        pass
+        logger.debug("citing-strategies lookup failed", exc_info=True)
 
     return {
         "arxiv_id": paper.arxiv_id,

--- a/backend/archimedes/api/risk_routes.py
+++ b/backend/archimedes/api/risk_routes.py
@@ -6,6 +6,7 @@ on-chain vault holdings into portfolio-level risk summaries.
 
 from __future__ import annotations
 
+import logging
 import math
 
 import numpy as np
@@ -23,6 +24,8 @@ from archimedes.api.risk_schemas import (
     StrategyRiskSummary,
 )
 from archimedes.services.strategy_provider import default_provider
+
+logger = logging.getLogger(__name__)
 
 risk_router = APIRouter(prefix="/api/risk", tags=["risk"])
 
@@ -221,7 +224,7 @@ async def get_portfolio_risk():
                 weights = [a / total_aum for a in vault_aums]
                 hhi = sum(w * w for w in weights)
     except Exception:
-        pass
+        logger.debug("portfolio concentration calc failed", exc_info=True)
 
     # Fallback: equal weight across strategies
     if hhi == 0.0 and strategies:

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import math
 from datetime import UTC
 
@@ -37,6 +38,8 @@ from archimedes.api.schemas import (
 from archimedes.models.strategy import Strategy, StrategyStatus
 from archimedes.services.construction_trace import build_construction_trace
 from archimedes.services.strategy_guardrail import apply_guardrail
+
+logger = logging.getLogger(__name__)
 
 strategies_router = APIRouter(prefix="/api/strategies", tags=["strategies"])
 
@@ -1263,7 +1266,7 @@ async def generate_strategy(
         finally:
             await state.close()
     except Exception:
-        pass
+        logger.debug("market regime context read failed", exc_info=True)
 
     store = JobStore()
     try:
@@ -1417,7 +1420,7 @@ async def _run_fusion_job(job_id: str) -> None:
                 session.commit()
                 strategy_id = record.id
         except Exception:
-            pass
+            logger.debug("fusion strategy persist failed", exc_info=True)
 
         try:
             import hashlib

--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -16,6 +17,8 @@ from archimedes.api.schemas import (
     TraceVerifyResponse,
 )
 from archimedes.models.trace import DecisionType, ReasoningTrace
+
+logger = logging.getLogger(__name__)
 
 traces_router = APIRouter(prefix="/api/traces", tags=["traces"])
 
@@ -102,7 +105,7 @@ async def list_traces(
                     )
                 )
         except Exception:
-            pass
+            logger.debug("on-chain trace listing failed", exc_info=True)
 
         return TraceListResponse(traces=traces, total=len(traces))
     finally:

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -663,7 +663,7 @@ class StrategyRunner:
                         )
                         trade_block = receipt.blockNumber
                     except Exception:
-                        pass
+                        logger.debug("trade receipt block lookup failed", exc_info=True)
                 logger.info(
                     "[tick %s] Executed %d trades: %s",
                     tick_id,
@@ -949,7 +949,7 @@ class StrategyRunner:
                         )
                         reveal_block = receipt.blockNumber
                     except Exception:
-                        pass
+                        logger.debug("reveal receipt block lookup failed", exc_info=True)
                     logger.info(
                         "[tick %s] REVEAL anchored: tx=%s block=%s",
                         tick_id,

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -4,6 +4,7 @@ Minimal bootstrap for the hackathon MVP. All routes are wired to
 chain services that read/write Arc smart contracts.
 """
 
+import logging
 import os
 
 # Load .env into os.environ at import time for modules that use os.getenv()
@@ -52,6 +53,8 @@ from archimedes.api.routes import (
 from archimedes.api.selection_bias_routes import selection_bias_router
 from archimedes.api.user_routes import user_router
 from archimedes.db import init_db
+
+logger = logging.getLogger(__name__)
 
 # ── Docs gate: disable /docs and /openapi.json in production ──────────
 # Default OFF when PUBLIC_DOMAIN is set (production). Override with
@@ -273,7 +276,7 @@ async def health():
             corpus_last_intake = meta.get("last_intake_at")
             artifact_hash = meta.get("artifact_hash")
     except Exception:
-        pass
+        logger.debug("corpus meta read failed", exc_info=True)
 
     # Paper RAG health (semantic retrieval)
     paper_rag_status = "disabled"

--- a/backend/archimedes/scripts/bootstrap_vaults.py
+++ b/backend/archimedes/scripts/bootstrap_vaults.py
@@ -18,6 +18,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 
@@ -31,6 +32,8 @@ from archimedes.chain.circle_signer import circle_signer
 from archimedes.chain.client import chain_client
 from archimedes.chain.contracts import get_contract_loader
 from archimedes.chain.executor import VaultCreationRevertedError
+
+logger = logging.getLogger(__name__)
 
 # ─── Configuration ──────────────────────────────────────────────
 
@@ -192,7 +195,7 @@ async def mint_synthetic_tokens() -> dict[str, float]:
                 minted[symbol] = existing_float
                 continue
         except Exception:
-            pass
+            logger.debug("existing synth balance check failed", exc_info=True)
 
         try:
             # Approve USDC for the synth vault

--- a/backend/archimedes/scripts/verify_arc_e2e.py
+++ b/backend/archimedes/scripts/verify_arc_e2e.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import os
 import sys
 from datetime import UTC, datetime
@@ -40,6 +41,8 @@ from dotenv import load_dotenv
 
 load_dotenv("../.env", override=True)
 load_dotenv(".env", override=False)
+
+logger = logging.getLogger(__name__)
 
 # ── Constants ─────────────────────────────────────────────────────
 
@@ -538,7 +541,7 @@ async def execute_smoke_test(wallet_key: str | None = None) -> None:
             if trace_id:
                 break
         except Exception:
-            pass
+            logger.debug("trace poll request failed", exc_info=True)
         print(f"  ⏳ Poll {poll + 1}/{MAX_POLLS} — no trace yet...")
         await asyncio.sleep(POLL_INTERVAL)
 

--- a/backend/archimedes/services/_fusion_helpers.py
+++ b/backend/archimedes/services/_fusion_helpers.py
@@ -10,12 +10,15 @@ Contains pure functions for:
 
 from __future__ import annotations
 
+import logging
 import tempfile
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
 import numpy as _np
+
+logger = logging.getLogger(__name__)
 
 # ── Equity curve and return extraction ─────────────────────────────────
 
@@ -66,7 +69,7 @@ def _extract_equity_curve(strat: Any, initial_cash: float) -> list[float]:
             # Approximate by replaying — in practice cerebro.run() doesn't keep history
             pass
     except Exception:
-        pass
+        logger.debug("fusion equity replay failed", exc_info=True)
     # Cerebro doesn't easily expose per-bar equity after run()
     # Return a simplified curve based on initial → final
     final = float(strat.broker.getvalue())

--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -6,12 +6,15 @@ daily returns for the selection-bias rigor gate.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 
 from sqlalchemy.orm import Session
 
 from archimedes.models.backtest import BacktestResult
 from archimedes.models.backtest_store import BacktestResultRecord
+
+logger = logging.getLogger(__name__)
 
 
 def insert_backtest_if_missing(
@@ -76,7 +79,7 @@ def get_daily_returns(session: Session, strategy_id: str) -> list[float]:
                 if daily:
                     return daily
         except (_json.JSONDecodeError, KeyError):
-            pass
+            logger.debug("cached backtest parse failed", exc_info=True)
 
     # Fallback: derive from equity_curve
     result = row.to_backtest_result()

--- a/backend/archimedes/services/config_service.py
+++ b/backend/archimedes/services/config_service.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+
 from archimedes.api.schemas import ContractAddressesResponse
 from archimedes.chain.client import chain_client
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigService:
@@ -22,7 +26,7 @@ class ConfigService:
             for i, addr in enumerate(pool_addresses):
                 pools[f"pool_{i}"] = addr
         except Exception:
-            pass
+            logger.debug("amm pool enumeration failed", exc_info=True)
 
         # Get vaults from factory
         vaults: dict[str, str] = {}
@@ -31,7 +35,7 @@ class ConfigService:
             for i, addr in enumerate(vault_addresses):
                 vaults[f"vault_{i}"] = addr
         except Exception:
-            pass
+            logger.debug("vault enumeration failed", exc_info=True)
 
         return ContractAddressesResponse(
             usdc=settings.usdc_address,

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -93,7 +93,7 @@ def _fetch_price_panel(symbols: list[str], start: str, end: str) -> tuple[pd.Dat
                 closes[sym] = df["Close"]
                 volumes[sym] = df["Volume"]
         except Exception:
-            pass
+            logger.debug("price/volume frame load failed for a symbol", exc_info=True)
 
     close_panel = pd.DataFrame(closes).dropna()
     volume_panel = pd.DataFrame(volumes).dropna()

--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -1155,7 +1155,7 @@ def _display_for(synth: str) -> str:
         if entry is not None:
             return entry[1]
     except Exception:
-        pass
+        logger.debug("optimizer symbol-cache lookup failed", exc_info=True)
     return synth
 
 

--- a/backend/archimedes/services/secrets_service.py
+++ b/backend/archimedes/services/secrets_service.py
@@ -144,10 +144,14 @@ def list_ssm_parameters(prefix: str | None = None, region: str | None = None) ->
     try:
         import boto3
         from botocore.exceptions import BotoCoreError, ClientError
+    except ImportError:
+        logger.warning("secrets_service: boto3 not installed — cannot list SSM parameters")
+        return []
 
+    try:
         client = boto3.client("ssm", region_name=region)
         params = _fetch_all_parameters(client, prefix)
         return [p["Name"] for p in params]
-    except (ImportError, BotoCoreError, ClientError) as exc:
+    except (BotoCoreError, ClientError) as exc:
         logger.warning("secrets_service: list failed: %s", exc)
         return []

--- a/backend/archimedes/services/strategy_memory.py
+++ b/backend/archimedes/services/strategy_memory.py
@@ -166,7 +166,7 @@ def query_proposals(
                     since_dt = datetime.fromisoformat(since)
                     q = q.filter(StrategyProposal.created_at >= since_dt)
                 except (ValueError, TypeError):
-                    pass
+                    logger.debug("invalid 'since' filter %r — ignoring date bound", since, exc_info=True)
 
             total = q.count()
             rows = q.order_by(StrategyProposal.created_at.desc()).offset(offset).limit(limit).all()

--- a/backend/archimedes/services/vault_monitor.py
+++ b/backend/archimedes/services/vault_monitor.py
@@ -162,7 +162,7 @@ class VaultMonitor:
                 age = (datetime.now(UTC) - hb_time).total_seconds()
                 agent_alive = age < 600  # alive if heartbeat < 10min old
             except Exception:
-                pass
+                logger.debug("agent heartbeat parse failed — treating as not-alive", exc_info=True)
 
         # Sharpe drift requires a strategy-specific backtest baseline. Until that
         # baseline is wired in, do not compute drift from a hard-coded value.

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from datetime import UTC, datetime
 from typing import ClassVar
 
@@ -17,6 +18,8 @@ from archimedes.api.schemas import (
 from archimedes.chain.executor import chain_executor
 from archimedes.chain.trace_publisher import trace_publisher
 from archimedes.services.log_scrubber import sanitize_log_value
+
+logger = logging.getLogger(__name__)
 
 
 class VaultService:
@@ -170,7 +173,7 @@ class VaultService:
                     market_ctx = last_trace.get("market_context", {})
                     current_regime = market_ctx.get("regime")
             except Exception:
-                pass
+                logger.debug("vault strategy provenance lookup failed", exc_info=True)
 
             return VaultDetailResponse(
                 address=address,
@@ -426,7 +429,7 @@ class VaultService:
             finally:
                 session.close()
         except Exception:
-            pass
+            logger.debug("vault name resolution failed", exc_info=True)
         return None, None
 
     async def _get_recent_traces(self, vault_address: str, limit: int = 5) -> list[TraceResponse]:
@@ -453,5 +456,5 @@ class VaultService:
                         )
                     )
         except Exception:
-            pass
+            logger.debug("vault recent traces fetch failed", exc_info=True)
         return traces


### PR DESCRIPTION
## Summary

Two reliability findings from the CodeQL sweep:

**1. Uninitialized-name bug (error severity) — `secrets_service.list_ssm_parameters`.**
The function imported `botocore` inside a `try` and caught `(ImportError, BotoCoreError, ClientError)` in the *same* clause. If `boto3` isn't installed, `import boto3` raises `ImportError`, the botocore names never bind, and evaluating the `except` tuple raises `NameError` on the unbound `BotoCoreError` — masking the intended graceful `return []`. Fixed by splitting the import-guard (`except ImportError`) from the usage block (`except (BotoCoreError, ClientError)`), mirroring the already-correct `load_ssm_secrets()`.

**2. Empty except (26 sites).** Replaced bare `except ...: pass` with `logger.debug("<context>", exc_info=True)` so non-fatal swallows are observable. **No control-flow change** — each block still swallows and continues. A module-level `logger` was added to 12 files that lacked one; narrow clauses (`JSONDecodeError`/`KeyError`/`ValueError`/`TypeError`) preserved.

## Verify

- `pytest backend/tests -m "not integration"` → **1602 passed, 2 skipped** (the 2 skips pre-exist)
- `ruff check --select E9,F63,F7,F40,F401,F811,F841` + `ruff format --check` over all 19 files — clean
- No bare `except: pass` remains in the touched files (verified by AST scan)

## Anti-goals

- No change to which exceptions are caught or to control flow. The intentional inner-loop `pass` in `_fusion_helpers` (a replay no-op) is left untouched.