### PR TITLE
[cleanup] Remove dead code + clarify NaN/redundant idioms (CodeQL)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -592,7 +592,7 @@ async def get_portfolio_advisor(
             if sr < 0.3:
                 continue
             mu_ann = s.real_cagr if s.real_cagr is not None else 0.08
-            vol_ann = abs(mu_ann / sr) if sr != 0 else 0.20
+            vol_ann = abs(mu_ann / sr)
             full_kelly = mu_ann / max(vol_ann**2, 1e-6)
             # Shrink full Kelly by the ratio OOS/IS Sharpe so the fraction
             # reflects walk-forward edge rather than inflated in-sample edge.
@@ -639,7 +639,7 @@ async def get_portfolio_advisor(
             if sr < 0.3:
                 continue
             mu_ann = s.real_cagr if s.real_cagr is not None else 0.08
-            vol_ann = abs(mu_ann / sr) if sr != 0 else 0.20
+            vol_ann = abs(mu_ann / sr)
             kelly = min(0.5 * (mu_ann / max(vol_ann**2, 1e-6)), 0.5)
             universe = s.asset_universe if s.asset_universe else ["SPY"]
             per_asset_kelly = round(kelly / len(universe), 4)

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -70,11 +70,6 @@ class ChainExecutor:
         token_addresses = holdings_data[0]
         amounts = holdings_data[1]
 
-        # Read target allocations
-        target_data = await vault.functions.getTargetAllocations().call()
-        target_data[0]
-        target_data[1]
-
         # Read total assets — fall back to off-chain NAV if stale price
         total_assets = await self._safe_total_assets(vault, token_addresses, amounts)
 
@@ -652,8 +647,6 @@ class ChainExecutor:
             return await vault.functions.totalAssets().call()
         except Exception:
             # Fallback: compute off-chain using raw prices
-            import logging
-
             logging.getLogger(__name__).warning("totalAssets() reverted — computing NAV off-chain with raw prices")
             usdc_address = chain_client.settings.usdc_address
             nav = 0

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -310,7 +310,7 @@ class AssetMarketService:
             # Convert Series to a plain list for downstream math.
             raw_hist = histories.get(synth)
             if raw_hist is not None and hasattr(raw_hist, "tolist"):
-                hist_prices = [float(v) for v in raw_hist.tolist() if v == v]  # v==v filters NaN
+                hist_prices = [float(v) for v in raw_hist.tolist() if not math.isnan(v)]
             elif isinstance(raw_hist, dict):
                 hist_prices = raw_hist.get("close") or []
             else:

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -269,10 +269,10 @@ def _annualized_metrics(daily_returns: list[float], equity_curve: list[float]) -
     sortino = ((mu - RF_DAILY) / down_rms) * np.sqrt(ANNUALIZATION) if down_rms > 0 else 0.0
 
     eq = np.asarray(equity_curve, dtype=float)
-    cagr = float((eq[-1] / eq[0]) ** (ANNUALIZATION / T) - 1.0) if eq[0] > 0 and T >= 2 else 0.0
+    cagr = float((eq[-1] / eq[0]) ** (ANNUALIZATION / T) - 1.0) if eq[0] > 0 else 0.0
 
     drawdown = (eq / np.maximum.accumulate(eq)) - 1.0
-    max_dd = float(-drawdown.min()) if T > 0 else 0.0
+    max_dd = float(-drawdown.min())
 
     calmar = float(cagr / max_dd) if max_dd > 0 else 0.0
 
@@ -852,7 +852,7 @@ def walk_forward_validate(
             logger.debug("WF split %d OOS failed: %s", i, exc)
 
         cliff = float("nan")
-        if is_sharpe == is_sharpe and oos_sharpe == oos_sharpe and abs(is_sharpe) > 1e-10:
+        if not np.isnan(is_sharpe) and not np.isnan(oos_sharpe) and abs(is_sharpe) > 1e-10:
             cliff = (is_sharpe - oos_sharpe) / abs(is_sharpe)
 
         splits.append(
@@ -876,7 +876,7 @@ def walk_forward_validate(
     mean_oos = float(np.mean(valid_oos)) if valid_oos else float("nan")
     mean_cliff = float(np.mean(valid_cliffs)) if valid_cliffs else float("nan")
     max_cliff = float(max(valid_cliffs)) if valid_cliffs else float("nan")
-    passes_cliff_gate = (mean_cliff == mean_cliff) and (mean_cliff <= 0.30)
+    passes_cliff_gate = (not np.isnan(mean_cliff)) and (mean_cliff <= 0.30)
 
     return {
         "splits": splits,
@@ -1130,7 +1130,7 @@ def run_parallel_backtest(
 
     def _valid(r: dict[str, Any]) -> bool:
         v = r.get(metric, float("nan"))
-        return bool(r["ok"]) and isinstance(v, float) and v == v  # not NaN
+        return bool(r["ok"]) and isinstance(v, float) and not np.isnan(v)
 
     ranked = [r for r in results if _valid(r)]
     # max_drawdown is negative/zero — the largest (closest to 0) is best.

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -322,14 +322,9 @@ class VaultService:
         if not allocations:
             return {"return_24h": 0.0, "return_7d": 0.0, "return_30d": 0.0, "return_inception": 0.0}
 
-        from archimedes.chain.contracts import get_contract_loader
-
-        loader = get_contract_loader()
-
         weighted_annual = 0.0
         total_weight = 0
         for alloc in allocations:
-            token = alloc.token_address
             weight = int(alloc.weight_pct * 100)  # BPS
             if weight == 0:
                 continue

--- a/backend/tests/services/test_vault_monitor_class.py
+++ b/backend/tests/services/test_vault_monitor_class.py
@@ -56,7 +56,7 @@ class TestSnapshotAllVaults:
         mon = _build_monitor()
         with patch("archimedes.services.vault_monitor.chain_executor") as ce:
             ce.get_all_vaults = AsyncMock(return_value=["0xA", "0xB"])
-            ce.get_vault_metrics = AsyncMock(side_effect=lambda addr: _vault_metrics(addr))
+            ce.get_vault_metrics = AsyncMock(side_effect=_vault_metrics)
             snaps = await mon.snapshot_all_vaults()
         assert len(snaps) == 2
         assert {s["vault_address"] for s in snaps} == {"0xA", "0xB"}

--- a/backend/tests/test_vault_metadata_anchor.py
+++ b/backend/tests/test_vault_metadata_anchor.py
@@ -41,7 +41,7 @@ class TestVaultMetadataAnchor:
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
     def test_metadata_post_calls_anchor_once_per_strategy_id(self, mock_provider, mock_publisher):
-        mock_provider.get_strategy.side_effect = lambda sid: _make_passport(sid)
+        mock_provider.get_strategy.side_effect = _make_passport
         mock_publisher.anchor = AsyncMock()
 
         resp = client.post(
@@ -91,7 +91,7 @@ class TestVaultMetadataAnchor:
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
     def test_metadata_post_succeeds_when_anchor_raises(self, mock_provider, mock_publisher):
-        mock_provider.get_strategy.side_effect = lambda sid: _make_passport(sid)
+        mock_provider.get_strategy.side_effect = _make_passport
         mock_publisher.anchor = AsyncMock(side_effect=RuntimeError("simulated chain failure"))
 
         resp = client.post(


### PR DESCRIPTION
## Summary

Maintainability findings from the CodeQL sweep — all behavior-preserving.

| CodeQL rule | Fix |
|---|---|
| Statement has no effect ×2 | `executor.read_portfolio` — removed `target_data[0]`/`[1]` (dead; holdings come from `getHoldings()`) |
| Module imported more than once ×1 | `executor` — removed redundant local `import logging` (module-level import exists) |
| Unused local variable ×2 | `vault_service._compute_returns` — removed unused `loader`/`token` (+ the now-dead local import) |
| Comparison of identical values ×5 | `x == x` NaN-filter idiom → explicit `not isnan(x)` (asset_market_service ×1, portfolio_backtester ×4) |
| Redundant comparison ×4 | always-true guards simplified: `T >= 2`/`T > 0` (upstream `if T<2: return`), `sr != 0` (upstream `if sr<0.3: continue`) |
| Unnecessary lambda ×3 | test `side_effect=lambda x: f(x)` → `side_effect=f` |

## Not changed (intentional / false positive)

- **Unused local ×3** (`_max_test_label_end`, `_synth`, `_sync_emit`): `_`-prefix is the intentional-unused convention; `_synth` is a tuple-unpack target. CodeQL over-flags the convention.
- **Unused import ×10**, **`...` Protocol stubs (30 of the "statement has no effect" 33)**, **Unhashable ×1**, **uninitialized `dynamic_targets_arr` ×2**: validated false positives (re-exports/`# noqa` registration imports, idiomatic Protocol bodies, all-string `_safe_get` keys, flags set together). Documented, no code change.

## Verify

- `pytest backend/tests -m "not integration"` → **1602 passed, 2 skipped**
- metrics/backtest/cliff subset → **90 passed**
- `ruff check --select E9,F63,F7,F40,F401,F811,F841,PLR0124,PLW0108` + `ruff format --check` — clean

## Anti-goals

- No behavior change. NaN conversions preserve semantics for the float domain (all sites guarded by `float(...)`/`isinstance(v, float)`). Always-true guard removals are provably dead branches.