### PR TITLE
CodeQL dedup: redundant imports + reachable agent trace-dedup

### DIFF
--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -238,8 +238,6 @@ async def publish_trace(req: TracePublishRequest, _: None = Depends(require_inte
             off_chain_data["arc_tx_hash"] = arc_tx_hash
             off_chain_data["is_verified"] = True
     except Exception as e:
-        import logging
-
         logging.getLogger(__name__).error(f"On-chain publish failed: {e}")
 
     state = AgentStateStore()

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -539,6 +539,23 @@ class StrategyRunner:
 
         if not trades:
             logger.info("[tick %s] No drift — portfolio aligned with strategy signals", tick_id)
+            # Deduplicate identical aligned decisions: when the portfolio stays
+            # within drift thresholds tick after tick with the same reasoning,
+            # re-anchoring the SKIP trace wastes gas and clutters the Reasoning
+            # page. Increment a repeat counter and skip the publish instead.
+            aligned_reasoning = self._build_reasoning(all_signals, market_regime, consensus, trades, portfolio)
+            if self._last_reasoning.get(vault_address) == aligned_reasoning:
+                count = self._last_reasoning_count.get(vault_address, 1) + 1
+                self._last_reasoning_count[vault_address] = count
+                logger.info(
+                    "[tick %s] Vault %s: identical aligned decision (repeat #%d) — skipping trace publish",
+                    tick_id,
+                    vault_address[:10],
+                    count,
+                )
+                return
+            self._last_reasoning[vault_address] = aligned_reasoning
+            self._last_reasoning_count[vault_address] = 1
             await self._publish_trace(
                 vault_address,
                 DecisionType.SKIP,
@@ -613,21 +630,11 @@ class StrategyRunner:
         # Phase 1: COMMIT — compute hash and anchor on-chain BEFORE trade
         reasoning = self._build_reasoning(all_signals, market_regime, consensus, trades, portfolio)
 
-        # Deduplicate: skip identical decisions to avoid trace spam.
-        # When the same strategy signals produce the same reasoning, anchoring
-        # a duplicate trace wastes gas and clutters the Reasoning page.
-        prev_reasoning = self._last_reasoning.get(vault_address)
-        if prev_reasoning == reasoning and not trades:
-            count = self._last_reasoning_count.get(vault_address, 1) + 1
-            self._last_reasoning_count[vault_address] = count
-            logger.info(
-                "[tick %s] Vault %s: identical decision (repeat #%d) — skipping trace publish",
-                tick_id,
-                vault_address[:10],
-                count,
-            )
-            return
-        # Record current reasoning for next-tick comparison
+        # A rebalance always publishes — trades are real actions that must be
+        # anchored, so identical reasoning is never deduplicated here. Record
+        # this decision so the next aligned (no-trade) tick dedups against the
+        # most recently published reasoning (the no-trade branch above is the
+        # only place identical decisions are skipped).
         self._last_reasoning[vault_address] = reasoning
         self._last_reasoning_count[vault_address] = 1
 

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -158,8 +158,6 @@ async def _startup_populate_rigor_gate():
     Idempotent: only populates strategies that don't yet have DSR/PBO values.
     Skips entirely if the backtest_results table is empty.
     """
-    import logging
-
     _logger = logging.getLogger("archimedes.startup")
     try:
         from archimedes.db import get_session
@@ -203,8 +201,6 @@ async def _startup_populate_rigor_gate():
 @app.on_event("startup")
 async def _startup_seed_corpus():
     """Seed papers table from manifest.jsonl (idempotent — adds new papers only)."""
-    import logging
-
     _logger = logging.getLogger("archimedes.startup")
     try:
         from archimedes.services.corpus_service import seed_from_manifest
@@ -393,8 +389,6 @@ async def health_amm():
         }
 
     except Exception:
-        import logging
-
         logging.getLogger(__name__).exception("AMM health check failed")
         return JSONResponse(
             status_code=503,

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -66,8 +66,6 @@ class VaultService:
         try:
             vault_addresses = await chain_executor.get_all_vaults()
         except Exception as e:
-            import logging
-
             logging.getLogger(__name__).error(f"Failed to get vault addresses: {e}")
             return VaultListResponse(vaults=[], total=0)
 
@@ -88,8 +86,6 @@ class VaultService:
                 finally:
                     session.close()
             except Exception as exc:
-                import logging
-
                 logging.getLogger(__name__).warning("vault metadata batch read failed (non-fatal): %s", exc)
 
         summaries: list[VaultSummaryResponse] = []
@@ -102,8 +98,6 @@ class VaultService:
                     continue
                 summaries.append(summary)
             except Exception as e:
-                import logging
-
                 logging.getLogger(__name__).warning(f"Skipping vault {addr}: {e}")
                 continue
 
@@ -198,8 +192,6 @@ class VaultService:
                 current_regime=current_regime,
             )
         except Exception:
-            import logging
-
             logging.getLogger(__name__).exception("Failed to get vault detail for %s", sanitize_log_value(address))
             return None
 
@@ -251,7 +243,6 @@ class VaultService:
         to compute a weighted return. If price snapshots exist in Redis (set by
         the oracle updater), uses real price changes instead.
         """
-        import logging
         import os
 
         import redis as _redis

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -297,3 +297,79 @@ class TestClassifyMarketRegime:
         classification, regime = await runner._classify_market_regime("tick-4")
         assert classification is None
         assert regime == "unknown"
+
+
+class TestAlignedDecisionDedup:
+    """_process_vault deduplicates identical no-trade ("aligned") decisions.
+
+    Regression for the unreachable-dedup bug (CodeQL "Unreachable code"): the
+    dedup guard used to sit in the rebalance branch behind ``and not trades``,
+    which the earlier ``if not trades: return`` made statically unreachable — so
+    identical "aligned" SKIP traces were re-anchored on-chain every tick. The
+    dedup now lives on the no-trade path; a repeated identical decision is
+    skipped (repeat counter incremented), not re-published.
+    """
+
+    @pytest.fixture()
+    def runner(self):
+        with (
+            patch("archimedes.chain.agent_runner.chain_client") as mock_client,
+            patch("archimedes.chain.agent_runner.chain_executor") as mock_executor,
+            patch("archimedes.chain.agent_runner.trace_publisher"),
+            patch("archimedes.chain.agent_runner.default_provider"),
+            patch("archimedes.chain.agent_runner.AgentStateStore"),
+        ):
+            mock_client.settings = MagicMock(
+                synth_addresses={"sSPY": "0xsspy", "sGOLD": "0xsgold"},
+                usdc_address="0xusdc",
+                oracle_addresses={},  # empty → no oracle-setting calls
+            )
+            mock_executor.read_portfolio = AsyncMock(return_value=_make_portfolio())
+            mock_executor.set_token_oracles = AsyncMock()
+            mock_executor.set_target_allocations = AsyncMock()
+            from archimedes.chain.agent_runner import StrategyRunner
+
+            # yield (not return) so the module-level patches stay active while
+            # the test calls _process_vault, which reads chain_executor at call
+            # time.
+            yield StrategyRunner()
+
+    @staticmethod
+    def _consensus():
+        from archimedes.models.regime import ConsensusLabel, EnsembleConsensus
+
+        return EnsembleConsensus(flat_pct=0.2, signal_count=3, label=ConsensusLabel.RISK_ON)
+
+    async def test_identical_aligned_decision_published_once(self, runner):
+        # No drift → no trades → aligned SKIP path on both ticks.
+        runner._compute_trades = MagicMock(return_value=[])
+        runner._publish_trace = AsyncMock()
+        call = {
+            "vault_address": "0xvault123",
+            "targets": _make_targets(USDC=0.30, sSPY=0.40, sGOLD=0.30),
+            "all_signals": [],
+            "market_regime": "unknown",
+            "consensus": self._consensus(),
+        }
+        await runner._process_vault(tick_id="t1", **call)
+        await runner._process_vault(tick_id="t2", **call)
+
+        # First aligned tick publishes; the identical second tick is deduped.
+        assert runner._publish_trace.await_count == 1
+        assert runner._last_reasoning_count["0xvault123"] == 2
+
+    async def test_changed_aligned_decision_republishes(self, runner):
+        runner._compute_trades = MagicMock(return_value=[])
+        runner._publish_trace = AsyncMock()
+        base = {
+            "vault_address": "0xvault123",
+            "targets": _make_targets(USDC=0.30, sSPY=0.40, sGOLD=0.30),
+            "all_signals": [],
+            "consensus": self._consensus(),
+        }
+        await runner._process_vault(tick_id="t1", market_regime="risk_on", **base)
+        # Different market regime → different reasoning string → must re-publish.
+        await runner._process_vault(tick_id="t2", market_regime="risk_off", **base)
+
+        assert runner._publish_trace.await_count == 2
+        assert runner._last_reasoning_count["0xvault123"] == 1


### PR DESCRIPTION
## Summary

Continuation of the CodeQL `security-and-quality` cleanup (after #689 log-injection, #690 info-exposure, #691 reliability, #692 maintainability). This branch covers the **dedup** cluster — and, after validating the full remaining finding set, fixes the two that were genuinely actionable.

**Two commits:**

1. **`[cleanup]` Remove 9 redundant function-local `import logging`** — `vault_service.py` (×5), `main.py` (×3), `traces_routes.py` (×1). Each file already imports `logging` at module top (and defines a module-level `logger`); the local re-imports are pure noise. Behavior-preserving. Resolves CodeQL **"Module is imported more than once"**.

2. **`[fix]` Make the agent trace-dedup reachable** — `StrategyRunner._process_vault`'s dedup guard sat behind `prev_reasoning == reasoning and not trades`, but the earlier `if not trades: return` makes `not trades` statically always-false → the block was **unreachable** (CodeQL "Unreachable code"). So identical "aligned" SKIP traces were re-anchored on-chain *every tick*. Moved the dedup to the no-trade path where the spam actually originates. Adds `TestAlignedDecisionDedup`.

> ⚠️ Commit 2 touches the on-chain oracle (`backend/archimedes/chain/agent_runner.py`) and changes trace-publish behavior (identical aligned decisions now publish once instead of every tick). Flagging for on-chain-lane review.

## Validation — most of the 14 audit findings are false positives

I re-ran CodeQL fresh against HEAD (the audit snapshot predated #691/#692). Of the 14 categories, only these two needed code changes. The rest:

| Finding | Count | Verdict |
|---|---|---|
| Unused **global variable** | 439 | FP — 430 are `analytics-engine/strategies/` passport metadata read via `getattr(module, key)` by `strategy_loader.py`/`strategy_provider.py`; mass-deleting would destroy the strategy passport |
| Statement has no effect | 31 | FP — `...` Protocol method stubs in `interfaces/*.py` |
| Unused **import** | 10 | FP — all `# noqa: F401` intentional re-exports (db.py SQLAlchemy registration; fusion/rigor/gatev test re-exports) |
| Import with `import`+`import from` | 4 | FP — `import X as mod` used for `monkeypatch.setattr(mod, …)` / `mod.__file__` alongside `from X import name` |
| Unused local variable | 3 | FP — `_`-prefixed intentional markers (adjudicated in #692) |
| Unhashable object hashed | 1 (ERROR) | FP — `key` is `*keys: str`, every caller passes string literals; `cur[key]` hashes a str |
| Use of return value of procedure | 1 | Minor test-assertion smell in `test_auth_guard.py`; left as-is (documents the None contract) |
| Empty except / comparison-identical / redundant-comparison / unnecessary-lambda | 27/5/4/3 → 0 | Already fixed by #691/#692 |

## Verify

```bash
# Redundant imports gone, module-top preserved
grep -cE '^[[:space:]]+import logging' backend/archimedes/services/vault_service.py backend/archimedes/main.py backend/archimedes/api/traces_routes.py   # → 0 each
# Unreachable dedup gone
grep -n 'and not trades' backend/archimedes/chain/agent_runner.py   # → no match
# Tests
PYTHONPATH=backend python -m pytest backend/tests/test_agent_runner.py -q   # 16 passed
PYTHONPATH=backend python -m pytest backend/tests -m "not integration" -q   # 1604 passed, 2 skipped
ruff format --check . && ruff check backend/archimedes/chain/agent_runner.py
```

## Anti-goals

- Did **not** touch the 439 unused-globals / 31 statement-no-effect / 10 unused-imports / 4 import-and-import-from — validated as false positives; "fixing" them would break the strategy passport, Protocol interfaces, SQLAlchemy registration, and test monkeypatching.
- Did not weaken any threshold or edit `pytest.ini`.