### PR TITLE
[backend] Oracle deviation gate fails closed when reference price is unobtainable

### DIFF
--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -223,8 +223,10 @@ class OracleUpdater:
         3. Deviation cap — the move vs the last known good price (on-chain
            read, falling back to the last successfully pushed value) must be
            within ``ORACLE_MAX_DEVIATION_BPS`` (default 2000 = 20%, mirroring
-           PriceOracle.sol's maxDeviationBps). First-ever pushes with no
-           reference are allowed.
+           PriceOracle.sol's maxDeviationBps). A *confirmed-absent* reference
+           (genuine first push) is allowed; an *unobtainable* reference (the
+           on-chain read failed and there is no cached fallback) fails CLOSED —
+           we refuse the push rather than send it unchecked (issue #587).
 
         Single-source design (deferred multi-source to v2 per issue #508):
         Each symbol currently has exactly one upstream source (yfinance for
@@ -244,8 +246,15 @@ class OracleUpdater:
         if age_s > self._max_upstream_staleness_s:
             return f"stale upstream data ({age_s:.0f}s old > {self._max_upstream_staleness_s}s cap)"
 
-        reference_int = await self._get_reference_price_int(price.symbol)
-        if reference_int is not None:
+        reference_int, reference_known = await self._get_reference_price_int(price.symbol)
+        if reference_int is None:
+            if not reference_known:
+                return (
+                    "reference price unobtainable (on-chain read failed, no cached "
+                    "fallback) — failing closed to avoid unchecked push"
+                )
+            # reference confirmed absent (genuine first push) → allow
+        else:
             deviation_bps = abs(price_int - reference_int) * 10_000 / reference_int
             if deviation_bps > self._max_deviation_bps:
                 return (
@@ -255,20 +264,46 @@ class OracleUpdater:
 
         return None
 
-    async def _get_reference_price_int(self, symbol: str) -> int | None:
-        """Last known good price (6-dec int): on-chain first, then last pushed.
+    async def _get_reference_price_int(self, symbol: str) -> tuple[int | None, bool]:
+        """Resolve the deviation reference price (6-dec int) for a symbol.
 
-        Returns None when no reference exists (first-ever push for a symbol).
+        Returns a ``(reference_int, reference_known)`` tuple so the caller can
+        distinguish a *confirmed-absent* reference (genuine first push, safe to
+        allow) from an *unobtainable* one (on-chain read failed and no cached
+        fallback — must fail closed to avoid an unchecked push). The two cases
+        both used to surface as a bare ``None``, which let an RPC outage bypass
+        the only deviation protection (issue #587, part 2).
+
+        Cases:
+
+        - on-chain read succeeds, price > 0 → ``(price_int, True)``
+        - on-chain read succeeds but 0/empty, last-pushed cached → ``(last_pushed, True)``
+        - on-chain read succeeds but 0/empty, no cache → ``(None, True)``
+          (reference *confirmed absent* — genuine first push)
+        - on-chain read throws, last-pushed cached → ``(last_pushed, True)``
+          (RPC down, but we still hold a fallback reference)
+        - on-chain read throws, no cache → ``(None, False)``
+          (reference *unobtainable* — caller must fail closed)
         """
         try:
             from archimedes.chain.contracts import get_contract_loader
 
             onchain = await get_contract_loader().oracle_for(symbol).functions.price().call()
             if onchain and int(onchain) > 0:
-                return int(onchain)
+                return int(onchain), True
+            # On-chain read succeeded but reports no price yet.
+            cached = self._last_pushed_price_int.get(symbol)
+            if cached is not None:
+                return cached, True
+            # Confirmed absent: the read worked and there is genuinely no price.
+            return None, True
         except Exception as e:
             logger.warning(f"Could not read on-chain reference price for {symbol}: {e}")
-        return self._last_pushed_price_int.get(symbol)
+            cached = self._last_pushed_price_int.get(symbol)
+            if cached is not None:
+                return cached, True
+            # Unobtainable: read threw and we have no cached fallback.
+            return None, False
 
     async def _get_circle_public_key(self, session: aiohttp.ClientSession) -> str | None:
         """Fetch Circle's RSA public key (cached per instance)."""

--- a/backend/tests/chain/test_oracle_updater.py
+++ b/backend/tests/chain/test_oracle_updater.py
@@ -51,13 +51,13 @@ class TestValidateForPush:
     async def test_accepts_fresh_price_within_deviation_cap(self, updater):
         # +10% vs reference — inside the 20% default cap
         price = _price(usd=110.0)
-        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))):
             assert await updater._validate_for_push(price, _int6(110.0)) is None
 
     async def test_rejects_deviation_beyond_cap(self, updater):
         # +30% vs reference — beyond the 2000 bps default cap
         price = _price(usd=130.0)
-        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))):
             reason = await updater._validate_for_push(price, _int6(130.0))
         assert reason is not None
         assert "deviation" in reason
@@ -65,7 +65,7 @@ class TestValidateForPush:
     async def test_rejects_downward_deviation_beyond_cap(self, updater):
         # -30% is equally out of bounds
         price = _price(usd=70.0)
-        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))):
             reason = await updater._validate_for_push(price, _int6(70.0))
         assert reason is not None
         assert "deviation" in reason
@@ -75,7 +75,7 @@ class TestValidateForPush:
         # Reference mock would pass the deviation check, proving staleness
         # alone is sufficient to refuse the push.
         price = _price(usd=100.0, age_seconds=3600)
-        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))):
             reason = await updater._validate_for_push(price, _int6(100.0))
         assert reason is not None
         assert "stale" in reason
@@ -89,16 +89,25 @@ class TestValidateForPush:
         assert "non-positive" in reason
 
     async def test_accepts_first_push_without_reference(self, updater):
-        # No on-chain price and nothing pushed yet → bootstrap is allowed
+        # Reference confirmed absent (None, known=True) → bootstrap is allowed
         price = _price(usd=100.0)
-        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=None)):
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))):
             assert await updater._validate_for_push(price, _int6(100.0)) is None
+
+    async def test_rejects_when_reference_unobtainable(self, updater):
+        # Reference unobtainable (None, known=False) → fail closed: a non-None
+        # rejection that names the fail-closed reason (issue #587, part 2).
+        price = _price(usd=100.0)
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, False))):
+            reason = await updater._validate_for_push(price, _int6(100.0))
+        assert reason is not None
+        assert "failing closed" in reason
 
     async def test_naive_timestamp_treated_as_utc(self, updater):
         # A tz-naive timestamp must not crash the age computation
         naive_now = datetime.now(UTC).replace(tzinfo=None)
         price = AssetPrice(symbol="sTSLA", price_usd=100.0, timestamp=naive_now, source="yfinance")
-        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=None)):
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))):
             assert await updater._validate_for_push(price, _int6(100.0)) is None
 
     async def test_env_overrides_respected(self, monkeypatch):
@@ -109,7 +118,7 @@ class TestValidateForPush:
         assert updater._max_upstream_staleness_s == 7200
         # +30% now passes under the widened 50% cap; 1h-old data passes 2h cap
         price = _price(usd=130.0, age_seconds=3600)
-        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))):
+        with patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))):
             assert await updater._validate_for_push(price, _int6(130.0)) is None
 
     async def test_defaults_match_contract_bound(self, updater):
@@ -123,28 +132,43 @@ class TestValidateForPush:
 
 class TestReferencePrice:
     async def test_prefers_onchain_price(self, updater):
+        # On-chain read succeeds with a positive price → (price, known=True).
         oracle_contract = MagicMock()
         oracle_contract.functions.price.return_value.call = AsyncMock(return_value=_int6(123.45))
         loader = MagicMock()
         loader.oracle_for.return_value = oracle_contract
         updater._last_pushed_price_int["sTSLA"] = _int6(999.0)
         with patch("archimedes.chain.contracts.get_contract_loader", return_value=loader):
-            assert await updater._get_reference_price_int("sTSLA") == _int6(123.45)
+            assert await updater._get_reference_price_int("sTSLA") == (_int6(123.45), True)
 
     async def test_falls_back_to_last_pushed_when_chain_read_fails(self, updater):
+        # On-chain read throws but a cached last-pushed value exists →
+        # (last_pushed, known=True): we still have a usable reference.
         updater._last_pushed_price_int["sTSLA"] = _int6(101.0)
         with patch(
             "archimedes.chain.contracts.get_contract_loader",
             side_effect=ConnectionError("RPC down"),
         ):
-            assert await updater._get_reference_price_int("sTSLA") == _int6(101.0)
+            assert await updater._get_reference_price_int("sTSLA") == (_int6(101.0), True)
 
-    async def test_returns_none_when_no_reference_exists(self, updater):
+    async def test_confirmed_absent_when_chain_read_succeeds_with_no_price(self, updater):
+        # On-chain read SUCCEEDS but reports 0 and nothing is cached →
+        # (None, known=True): reference confirmed absent (genuine first push).
+        oracle_contract = MagicMock()
+        oracle_contract.functions.price.return_value.call = AsyncMock(return_value=0)
+        loader = MagicMock()
+        loader.oracle_for.return_value = oracle_contract
+        with patch("archimedes.chain.contracts.get_contract_loader", return_value=loader):
+            assert await updater._get_reference_price_int("sTSLA") == (None, True)
+
+    async def test_unobtainable_when_chain_read_fails_and_no_cache(self, updater):
+        # On-chain read THROWS and there is no cached fallback →
+        # (None, known=False): reference unobtainable, caller must fail closed.
         with patch(
             "archimedes.chain.contracts.get_contract_loader",
             side_effect=ConnectionError("RPC down"),
         ):
-            assert await updater._get_reference_price_int("sTSLA") is None
+            assert await updater._get_reference_price_int("sTSLA") == (None, False)
 
 
 # ── push_prices_on_chain refuses bad prices ──────────────────
@@ -180,7 +204,7 @@ class TestPushPricesOnChain:
         bad = _price(symbol="sTSLA", usd=130.0)  # +30% vs reference → rejected
         with (
             patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
-            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
         ):
             result = await updater.push_prices_on_chain([bad])
 
@@ -195,7 +219,7 @@ class TestPushPricesOnChain:
         stale = _price(symbol="sTSLA", usd=100.0, age_seconds=3600)
         with (
             patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
-            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
         ):
             result = await updater.push_prices_on_chain([stale])
 
@@ -216,10 +240,51 @@ class TestPushPricesOnChain:
         with (
             patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
             patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
-            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=_int6(100.0))),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
         ):
             result = await updater.push_prices_on_chain([good])
 
         assert result == "tx-123"
         session.post.assert_called_once()
         assert updater._last_pushed_price_int["sTSLA"] == _int6(110.0)
+
+    async def test_fails_closed_when_reference_unobtainable(self, circle_creds):
+        # Issue #587, part 2: when the deviation reference is unobtainable
+        # (on-chain read failed AND no cached fallback), the symbol must NOT be
+        # pushed — fail closed, no tx, rather than send it unchecked.
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        session_cm, session = _mock_aiohttp_session()
+
+        price = _price(symbol="sTSLA", usd=100.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, False))),
+        ):
+            result = await updater.push_prices_on_chain([price])
+
+        assert result is None
+        session.post.assert_not_called()
+
+    async def test_fails_closed_on_rpc_outage_after_restart(self, circle_creds):
+        # End-to-end variant: simulate the real failure mode — the contract
+        # loader throws (RPC outage) and _last_pushed_price_int is empty (fresh
+        # process restart). No mock of _get_reference_price_int — it must resolve
+        # to (None, False) itself and the push must be skipped (no tx).
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        assert updater._last_pushed_price_int == {}  # fresh restart, no fallback
+        session_cm, session = _mock_aiohttp_session()
+
+        price = _price(symbol="sTSLA", usd=100.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch(
+                "archimedes.chain.contracts.get_contract_loader",
+                side_effect=ConnectionError("RPC down"),
+            ),
+        ):
+            result = await updater.push_prices_on_chain([price])
+
+        assert result is None
+        session.post.assert_not_called()


### PR DESCRIPTION
## Summary
Closes the fail-OPEN gap in the on-chain price-push deviation gate (issue #587, part 2). `_validate_for_push` previously skipped its deviation check whenever `_get_reference_price_int` returned `None` — which conflated two very different situations:

- **Genuine first push** — on-chain read *succeeded*, no price yet, no cache → legitimately allowed.
- **Reference unobtainable** — on-chain read *threw* (RPC outage) and `_last_pushed_price_int` is empty (fresh process restart) → was pushed **unchecked**.

Until the on-chain deviation bound is redeployed (#588), this backend gate is the only deviation protection, so an RPC outage bypassing it is a real hole.

## Change
`_get_reference_price_int` now returns a `(reference_int, reference_known)` tuple so the caller can tell *confirmed-absent* from *unobtainable*:

| on-chain read | cache | result |
|---|---|---|
| ok, price > 0 | — | `(price, True)` |
| ok, no price | hit | `(cached, True)` |
| ok, no price | miss | `(None, True)` → first push allowed |
| threw | hit | `(cached, True)` → fallback reference |
| threw | miss | `(None, False)` → **fail closed** |

`_validate_for_push` returns a rejection on `(None, False)`; the existing `if rejection is not None: continue` in `push_prices_on_chain` skips the symbol's tx. It never raises — skip-and-retry preserved (the runner does not crash-loop on RPC outage).

## Verify
```
PYTHONPATH=backend python3 -m pytest backend/tests/chain/test_oracle_updater.py -q   # 19 passed (was 15)
PYTHONPATH=backend python3 -m pytest backend/tests/chain/ -q                          # 59 passed, no regressions
```
Added `test_fails_closed_on_rpc_outage_after_restart` — end-to-end: contract loader raises `ConnectionError`, empty cache, asserts `session.post` is never called (no tx). Plus unit tests for the tuple contract and the fail-closed rejection.

## Scope / anti-goals
- Only `oracle_updater.py` + its test file touched.
- Did **not** weaken the deviation cap or defaults, touch `pytest.ini`, or make the runner raise.
- Issue #587 **part 1** (on-chain per-block ratchet rate-limit) is a contract change and stays open — gated on the #588 redeploy + Chuan's contract review.

Reviewer: Chuan (oracle/chain lane). Hermetic; no infra needed to validate.