### PR TITLE
[backend] Wire IPortfolioConstructor with dual-signal position sizing !minor

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -32,12 +32,14 @@ from archimedes.chain.trace_publisher import trace_publisher
 from archimedes.chain.v_check import VCheck
 from archimedes.models.portfolio import (
     Portfolio,
+    RiskProfile,
     TargetAllocation,
     TradeDirection,
     TradeOrder,
 )
 from archimedes.models.regime import EnsembleConsensus, RegimeClassification
 from archimedes.models.trace import DecisionType, ReasoningTrace
+from archimedes.services.portfolio_constructor import PortfolioConstructor
 from archimedes.services.redis_state import AgentStateStore
 from archimedes.services.source_tracker import build_consulted_hashes
 from archimedes.services.strategy_provider import default_provider
@@ -148,6 +150,9 @@ class StrategyRunner:
         # hermetic, no fitted artifact. Kept SEPARATE from the endogenous
         # EnsembleConsensus signal (issue #659): the two are complementary.
         self.regime_detector: VixRegimeDetector = VixRegimeDetector()
+        # Position sizer (issue #662): throttles aggregated target weights by
+        # the exogenous market regime AND the endogenous ensemble consensus.
+        self.portfolio_constructor: PortfolioConstructor = PortfolioConstructor()
         self._synth_addrs = chain_client.settings.synth_addresses
         self._usdc_addr = chain_client.settings.usdc_address
         self._known_vaults: set[str] = set()  # Vaults we've already seen
@@ -236,8 +241,18 @@ class StrategyRunner:
             # not shadow the market regime.
             await self.state.save_ensemble_consensus(consensus, all_signals)
 
-            # 4. Build target allocations
-            targets = self._weights_to_targets(target_weights, all_signals)
+            # 4. Build target allocations — throttle raw weights by the
+            # exogenous market regime AND the endogenous ensemble consensus
+            # (issue #662), then resolve symbols → token addresses.
+            allocations = self.portfolio_constructor.construct(
+                risk_profile=RiskProfile.MODERATE,
+                strategies=strategies,
+                backtest_results={},
+                regime=regime_classification,
+                ensemble_consensus=consensus,
+                base_weights=target_weights,
+            )
+            targets = self._weights_to_targets({a.symbol: a.weight for a in allocations}, all_signals)
 
             # 5. Get managed vaults (polling VaultFactory discovers new vaults)
             vaults = await self._get_managed_vaults()
@@ -299,12 +314,23 @@ class StrategyRunner:
                         )
                         continue
 
-                    # Aggregate scoped signals into per-vault target weights
+                    # Aggregate scoped signals into per-vault target weights,
+                    # then throttle by regime + ensemble consensus (issue #662).
                     vault_weights = strategy_evaluator.aggregate_signals(
                         scoped_signals,
                         usdc_floor=USDC_FLOOR,
                     )
-                    vault_targets = self._weights_to_targets(vault_weights, scoped_signals)
+                    vault_allocations = self.portfolio_constructor.construct(
+                        risk_profile=RiskProfile.MODERATE,
+                        strategies=strategies,
+                        backtest_results={},
+                        regime=regime_classification,
+                        ensemble_consensus=consensus,
+                        base_weights=vault_weights,
+                    )
+                    vault_targets = self._weights_to_targets(
+                        {a.symbol: a.weight for a in vault_allocations}, scoped_signals
+                    )
 
                     logger.info(
                         "[tick %s] Vault %s: scoped to %d/%d strategies → %s",

--- a/backend/archimedes/interfaces/math.py
+++ b/backend/archimedes/interfaces/math.py
@@ -20,7 +20,7 @@ from archimedes.models.portfolio import (
     RiskProfile,
     TargetAllocation,
 )
-from archimedes.models.regime import RegimeClassification
+from archimedes.models.regime import EnsembleConsensus, RegimeClassification
 from archimedes.models.strategy import Strategy
 
 
@@ -67,8 +67,11 @@ class IPortfolioConstructor(Protocol):
         risk_profile: RiskProfile,
         strategies: list[Strategy],
         backtest_results: dict[str, BacktestResult],  # strategy_id → result
-        regime: RegimeClassification,
+        regime: RegimeClassification | None,
         current_portfolio: Portfolio | None = None,
+        ensemble_consensus: EnsembleConsensus | None = None,
+        *,
+        base_weights: dict[str, float] | None = None,
     ) -> list[TargetAllocation]:
         """Construct target allocations for a vault.
 
@@ -82,6 +85,16 @@ class IPortfolioConstructor(Protocol):
              - USYC floor per risk profile
              - Max sector/asset concentration
           5. Map strategy weights to token allocations
+
+        ``regime`` (exogenous market regime) and ``ensemble_consensus``
+        (endogenous strategy-ensemble decisiveness) are two orthogonal
+        throttles on position sizing — both Optional, both degrade to a
+        conservative default when unavailable.
+
+        ``base_weights`` are pre-aggregated raw target weights (symbol→weight)
+        from the runner's signal aggregation. When provided, construct scales
+        these directly rather than re-deriving weights — this is the production
+        path. token_address resolution is the caller's responsibility.
 
         Returns list of TargetAllocation with weights summing to 1.0.
         """

--- a/backend/archimedes/services/portfolio_constructor.py
+++ b/backend/archimedes/services/portfolio_constructor.py
@@ -1,0 +1,200 @@
+"""Regime- and consensus-throttled portfolio construction.
+
+Implements ``IPortfolioConstructor``. The job of this module is to take the
+runner's raw aggregated target weights and *throttle* exposure by two
+orthogonal signals:
+
+1. The exogenous market regime (``RegimeClassification``) — what the *market*
+   is doing (VIX / momentum / spreads).
+2. The endogenous ensemble consensus (``EnsembleConsensus``) — how decisive the
+   *strategy ensemble* itself is (the fraction of flat signals).
+
+Both shrink risk-asset exposure and move the freed mass into the USDC safe
+asset. The two are kept distinct on purpose (issue #659): one is exogenous, the
+other endogenous; multiplying them gives a single position scale in [0, 1].
+
+Sizing basis — regime-conditional Kelly sizing:
+  - Lo (2002), "The Statistics of Sharpe Ratios", Financial Analysts Journal.
+  - López de Prado (2018), *Advances in Financial Machine Learning*, §11
+    (Dangers of Backtesting / bet sizing). Risk is scaled down, not levered up,
+    when conviction (regime confidence, ensemble agreement) is weak.
+"""
+
+from __future__ import annotations
+
+from archimedes.interfaces.math import IPortfolioConstructor
+from archimedes.models.backtest import BacktestResult
+from archimedes.models.portfolio import (
+    Portfolio,
+    RiskProfile,
+    TargetAllocation,
+)
+from archimedes.models.regime import EnsembleConsensus, Regime, RegimeClassification
+from archimedes.models.strategy import Strategy
+
+# ── Named constants (NO magic numbers) ──────────────────────────────
+# Sizing basis: regime-conditional Kelly sizing — Lo (2002),
+# López de Prado (2018) §11. Risk exposure is throttled down when the
+# market regime or the ensemble's conviction is weak.
+
+SAFE_ASSET = "USDC"
+
+# Per-regime exposure multiplier on risk assets. RISK_ON = full sizing;
+# CRISIS = near-flat (flight to safety).
+REGIME_MULTIPLIER: dict[Regime, float] = {
+    Regime.RISK_ON: 1.0,
+    Regime.TRANSITION: 0.7,
+    Regime.RISK_OFF: 0.4,
+    Regime.CRISIS: 0.1,
+}
+# Conservative default when no regime classification is available (snapshot
+# fetch failed or lacked VIX/MA signals — see agent_runner._classify_market_regime).
+REGIME_MULTIPLIER_NONE = 0.7
+
+# Confidence floor: even at confidence 0 the regime multiplier is not fully
+# erased — low confidence halves the regime's effect rather than zeroing it.
+# scale_within_regime = _CONF_BASE + _CONF_SLOPE * confidence.
+_CONF_BASE = 0.5
+_CONF_SLOPE = 0.5
+
+# Ensemble-consensus throttle, driven by flat_pct (fraction of flat signals):
+#   flat_pct < _FLAT_LOW            → 1.0  (decisive ensemble, no penalty)
+#   _FLAT_LOW ≤ flat_pct ≤ _FLAT_HIGH → linear 1.0 → _CONSENSUS_FLOOR
+#   flat_pct > _FLAT_HIGH           → _CONSENSUS_FLOOR (uncertain ensemble)
+_FLAT_LOW = 0.30
+_FLAT_HIGH = 0.60
+_CONSENSUS_FLOOR = 0.6
+_FLAT_SPAN = _FLAT_HIGH - _FLAT_LOW  # 0.30
+_CONSENSUS_DROP = 1.0 - _CONSENSUS_FLOOR  # 0.4
+
+
+class PortfolioConstructor(IPortfolioConstructor):
+    """Throttles aggregated target weights by market regime + ensemble consensus."""
+
+    def compute_position_scale(
+        self,
+        regime: RegimeClassification | None,
+        ensemble_consensus: EnsembleConsensus | None,
+    ) -> float:
+        """Combine regime + ensemble consensus into a single risk-asset scale.
+
+        PURE. Returns a multiplier in [0.0, 1.0] applied to every non-USDC
+        weight; the freed mass moves to USDC.
+
+        regime_mult:
+          - regime is None → ``REGIME_MULTIPLIER_NONE`` (conservative default).
+          - else ``REGIME_MULTIPLIER[regime] * (0.5 + 0.5 * confidence)`` — low
+            confidence reduces sizing *within* a regime.
+        consensus_mult (from flat_pct):
+          - None → 1.0 (no penalty).
+          - < 0.30 → 1.0; 0.30–0.60 → linear 1.0→0.6; > 0.60 → 0.6.
+        """
+        if regime is None:
+            regime_mult = REGIME_MULTIPLIER_NONE
+        else:
+            confidence_factor = _CONF_BASE + _CONF_SLOPE * regime.confidence
+            regime_mult = REGIME_MULTIPLIER[regime.regime] * confidence_factor
+
+        if ensemble_consensus is None:
+            consensus_mult = 1.0
+        else:
+            flat_pct = ensemble_consensus.flat_pct
+            if flat_pct < _FLAT_LOW:
+                consensus_mult = 1.0
+            elif flat_pct > _FLAT_HIGH:
+                consensus_mult = _CONSENSUS_FLOOR
+            else:
+                consensus_mult = 1.0 - (flat_pct - _FLAT_LOW) / _FLAT_SPAN * _CONSENSUS_DROP
+
+        return max(0.0, min(1.0, regime_mult * consensus_mult))
+
+    def construct(
+        self,
+        risk_profile: RiskProfile,  # noqa: ARG002 — IPortfolioConstructor signature; base_weights path doesn't re-derive by profile
+        strategies: list[Strategy],
+        backtest_results: dict[str, BacktestResult],
+        regime: RegimeClassification | None,
+        current_portfolio: Portfolio | None = None,  # noqa: ARG002 — Protocol signature; sizing is stateless wrt current holdings
+        ensemble_consensus: EnsembleConsensus | None = None,
+        *,
+        base_weights: dict[str, float] | None = None,
+    ) -> list[TargetAllocation]:
+        """Scale raw target weights by the regime/consensus position scale.
+
+        The returned weights are authoritative; the on-chain ``token_address``
+        for each symbol is resolved by the caller (the runner attaches
+        addresses via ``_weights_to_targets``), so allocations are emitted with
+        ``token_address=""`` and ``strategy_ids=[]``.
+        """
+        raw_weights = base_weights if base_weights is not None else self._fallback_weights(strategies, backtest_results)
+
+        scale = self.compute_position_scale(regime, ensemble_consensus)
+
+        # Shrink every non-USDC weight by `scale`; the freed mass moves to USDC.
+        scaled: dict[str, float] = {}
+        freed_mass = 0.0
+        usdc_weight = 0.0
+        for symbol, weight in raw_weights.items():
+            if symbol == SAFE_ASSET:
+                usdc_weight += weight
+                continue
+            new_weight = weight * scale
+            scaled[symbol] = new_weight
+            freed_mass += weight - new_weight
+
+        scaled[SAFE_ASSET] = usdc_weight + freed_mass
+
+        # Renormalize so weights sum to 1.0 (guard divide-by-zero).
+        total = sum(scaled.values())
+        if total > 0:
+            scaled = {sym: w / total for sym, w in scaled.items()}
+
+        return [
+            TargetAllocation(symbol=symbol, token_address="", weight=weight, strategy_ids=[])
+            for symbol, weight in scaled.items()
+        ]
+
+    def score_strategy(
+        self,
+        strategy: Strategy,  # noqa: ARG002 — IPortfolioConstructor signature; score derives from the backtest result
+        result: BacktestResult,
+        risk_profile: RiskProfile,  # noqa: ARG002 — Protocol signature; DSR/Sharpe scoring is profile-agnostic
+    ) -> float:
+        """Score a strategy for ranking. Higher = better fit.
+
+        Prefers the Deflated Sharpe Ratio (selection-bias-corrected) when the
+        backtest carries it; otherwise falls back to the raw Sharpe.
+        """
+        if result.deflated_sharpe_ratio is not None:
+            return result.deflated_sharpe_ratio
+        return result.sharpe_ratio
+
+    # ── Fallback weight derivation (no production caller uses this path) ──
+
+    def _fallback_weights(
+        self,
+        strategies: list[Strategy],
+        backtest_results: dict[str, BacktestResult],
+    ) -> dict[str, float]:
+        """Minimal score-ranked, normalized weights when ``base_weights`` is absent.
+
+        Deliberately simple: rank strategies by ``score_strategy`` over their
+        backtest result and normalize the positive scores into per-strategy
+        weights keyed by ``strategy.id``. No production call site exercises this
+        — it exists so ``construct`` never crashes when called without
+        ``base_weights``.
+        """
+        scores: dict[str, float] = {}
+        for strat in strategies:
+            result = backtest_results.get(strat.id)
+            if result is None:
+                continue
+            score = self.score_strategy(strat, result, RiskProfile.MODERATE)
+            if score > 0:
+                scores[strat.id] = score
+
+        total = sum(scores.values())
+        if total <= 0:
+            # Nothing rankable → park everything in the safe asset.
+            return {SAFE_ASSET: 1.0}
+        return {sid: score / total for sid, score in scores.items()}

--- a/backend/tests/services/test_portfolio_constructor.py
+++ b/backend/tests/services/test_portfolio_constructor.py
@@ -1,0 +1,193 @@
+"""Tests for the regime/consensus-throttled PortfolioConstructor (issue #662).
+
+Hermetic: no env, no network, no DB. These are pure sync computations.
+The formula under test is implemented faithfully and its *actual* output is
+asserted — constants are not tweaked to hit round numbers.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from archimedes.models.regime import (
+    ConsensusLabel,
+    EnsembleConsensus,
+    Regime,
+    RegimeClassification,
+    RegimeSignals,
+)
+from archimedes.services.portfolio_constructor import (
+    REGIME_MULTIPLIER,
+    REGIME_MULTIPLIER_NONE,
+    SAFE_ASSET,
+    PortfolioConstructor,
+)
+
+
+def _signals() -> RegimeSignals:
+    """A minimal-but-valid RegimeSignals (only VIX + MA flags are required)."""
+    return RegimeSignals(
+        vix_level=18.0,
+        vix_rate_of_change=0.0,
+        sp500_above_ma50=True,
+        sp500_above_ma200=True,
+    )
+
+
+def _regime(regime: Regime, confidence: float) -> RegimeClassification:
+    return RegimeClassification(
+        regime=regime,
+        confidence=confidence,
+        signals=_signals(),
+        timestamp=datetime.now(UTC),
+    )
+
+
+def _consensus(flat_pct: float) -> EnsembleConsensus:
+    return EnsembleConsensus(
+        flat_pct=flat_pct,
+        signal_count=10,
+        label=EnsembleConsensus.label_for(flat_pct),
+    )
+
+
+@pytest.fixture
+def pc() -> PortfolioConstructor:
+    return PortfolioConstructor()
+
+
+# ── compute_position_scale (the heart of the feature) ────────────────
+
+
+def test_risk_on_full_confidence_decisive_ensemble_scale_one(pc: PortfolioConstructor) -> None:
+    # RISK_ON mult=1.0, confidence=1.0 → (0.5 + 0.5*1.0)=1.0; flat_pct=0.1 → consensus 1.0.
+    scale = pc.compute_position_scale(_regime(Regime.RISK_ON, 1.0), _consensus(0.1))
+    assert scale == pytest.approx(1.0)
+
+
+def test_crisis_high_flat_scale_small_but_positive(pc: PortfolioConstructor) -> None:
+    # CRISIS mult=0.1, confidence=1.0 → 0.1; flat_pct=0.7 → consensus 0.6 → 0.06.
+    scale = pc.compute_position_scale(_regime(Regime.CRISIS, 1.0), _consensus(0.7))
+    assert 0.0 < scale <= 0.1
+    assert scale == pytest.approx(0.06)
+
+
+def test_risk_off_low_flat_no_consensus_penalty(pc: PortfolioConstructor) -> None:
+    # Low flat = confident ensemble must NOT add a penalty → consensus_mult == 1.0.
+    # RISK_OFF mult=0.4, confidence=1.0 → regime_mult=0.4; scale == regime_mult.
+    regime = _regime(Regime.RISK_OFF, 1.0)
+    scale = pc.compute_position_scale(regime, _consensus(0.1))
+    regime_mult = REGIME_MULTIPLIER[Regime.RISK_OFF] * (0.5 + 0.5 * 1.0)
+    assert scale == pytest.approx(regime_mult)
+    assert scale == pytest.approx(0.4)
+
+
+def test_regime_none_uses_conservative_default(pc: PortfolioConstructor) -> None:
+    # regime None → regime_mult == REGIME_MULTIPLIER_NONE (0.7); decisive ensemble → x1.0.
+    scale = pc.compute_position_scale(None, _consensus(0.1))
+    assert REGIME_MULTIPLIER_NONE == pytest.approx(0.7)  # noqa: SIM300 — assert actual == expected reads naturally here
+    assert scale == pytest.approx(0.7)
+
+
+def test_consensus_none_no_penalty(pc: PortfolioConstructor) -> None:
+    # ensemble_consensus None → consensus_mult == 1.0; RISK_ON full conf → 1.0.
+    scale = pc.compute_position_scale(_regime(Regime.RISK_ON, 1.0), None)
+    assert scale == pytest.approx(1.0)
+
+
+def test_both_none_no_crash(pc: PortfolioConstructor) -> None:
+    scale = pc.compute_position_scale(None, None)
+    assert scale == pytest.approx(REGIME_MULTIPLIER_NONE)
+
+
+def test_lower_confidence_gives_lower_scale(pc: PortfolioConstructor) -> None:
+    # Same regime + same (no) consensus penalty; confidence 0.5 < 1.0 → lower scale.
+    high = pc.compute_position_scale(_regime(Regime.RISK_ON, 1.0), None)
+    low = pc.compute_position_scale(_regime(Regime.RISK_ON, 0.5), None)
+    assert low < high
+    # RISK_ON mult=1.0, confidence=0.5 → 0.5 + 0.5*0.5 = 0.75.
+    assert low == pytest.approx(0.75)
+
+
+def test_consensus_linear_interpolation_midpoint(pc: PortfolioConstructor) -> None:
+    # flat_pct=0.45 is the midpoint of [0.30, 0.60] → consensus 1.0 - 0.5*0.4 = 0.8.
+    # RISK_ON full confidence → regime_mult 1.0, so scale == 0.8.
+    scale = pc.compute_position_scale(_regime(Regime.RISK_ON, 1.0), _consensus(0.45))
+    assert scale == pytest.approx(0.8)
+
+
+def test_scale_clamped_to_unit_interval(pc: PortfolioConstructor) -> None:
+    # RISK_ON full confidence + decisive ensemble is the max case → must not exceed 1.0.
+    scale = pc.compute_position_scale(_regime(Regime.RISK_ON, 1.0), _consensus(0.0))
+    assert 0.0 <= scale <= 1.0
+
+
+# ── construct() integration ──────────────────────────────────────────
+
+
+def test_construct_crisis_shrinks_risk_assets_into_usdc(pc: PortfolioConstructor) -> None:
+    base = {"sTSLA": 0.6, "sBTC": 0.4}
+    allocs = pc.construct(
+        risk_profile=None,  # type: ignore[arg-type]  # unused on the base_weights path
+        strategies=[],
+        backtest_results={},
+        regime=_regime(Regime.CRISIS, 1.0),
+        ensemble_consensus=_consensus(0.7),
+        base_weights=base,
+    )
+    by_symbol = {a.symbol: a.weight for a in allocs}
+
+    # Weights sum to 1.0.
+    assert sum(by_symbol.values()) == pytest.approx(1.0)
+    # USDC is now the dominant weight (risk assets throttled near-flat in crisis).
+    assert by_symbol[SAFE_ASSET] > 0.9
+    # Both risk assets shrunk vs their input weight.
+    assert by_symbol["sTSLA"] < base["sTSLA"]
+    assert by_symbol["sBTC"] < base["sBTC"]
+    # Allocations carry empty token_address — the runner resolves addresses.
+    assert all(a.token_address == "" for a in allocs)
+    assert all(a.strategy_ids == [] for a in allocs)
+
+
+def test_construct_risk_on_full_size_preserves_weights(pc: PortfolioConstructor) -> None:
+    # scale == 1.0 → no throttle; weights pass through (with USDC entry created at 0).
+    base = {"sTSLA": 0.6, "sBTC": 0.4}
+    allocs = pc.construct(
+        risk_profile=None,  # type: ignore[arg-type]
+        strategies=[],
+        backtest_results={},
+        regime=_regime(Regime.RISK_ON, 1.0),
+        ensemble_consensus=_consensus(0.1),
+        base_weights=base,
+    )
+    by_symbol = {a.symbol: a.weight for a in allocs}
+    assert sum(by_symbol.values()) == pytest.approx(1.0)
+    assert by_symbol["sTSLA"] == pytest.approx(0.6)
+    assert by_symbol["sBTC"] == pytest.approx(0.4)
+    assert by_symbol[SAFE_ASSET] == pytest.approx(0.0)
+
+
+def test_construct_existing_usdc_weight_preserved(pc: PortfolioConstructor) -> None:
+    # An existing USDC weight is kept and accrues the freed mass.
+    base = {"sTSLA": 0.5, SAFE_ASSET: 0.5}
+    allocs = pc.construct(
+        risk_profile=None,  # type: ignore[arg-type]
+        strategies=[],
+        backtest_results={},
+        regime=_regime(Regime.RISK_OFF, 1.0),
+        ensemble_consensus=None,
+        base_weights=base,
+    )
+    by_symbol = {a.symbol: a.weight for a in allocs}
+    assert sum(by_symbol.values()) == pytest.approx(1.0)
+    # RISK_OFF full conf scale=0.4 → sTSLA 0.5*0.4=0.2, USDC 0.5+0.3=0.8.
+    assert by_symbol["sTSLA"] == pytest.approx(0.2)
+    assert by_symbol[SAFE_ASSET] == pytest.approx(0.8)
+
+
+def test_construct_consensus_label_sanity() -> None:
+    # Guard the bucket mapping the test fixtures rely on.
+    assert EnsembleConsensus.label_for(0.1) == ConsensusLabel.RISK_ON
+    assert EnsembleConsensus.label_for(0.45) == ConsensusLabel.TRANSITION
+    assert EnsembleConsensus.label_for(0.7) == ConsensusLabel.RISK_OFF


### PR DESCRIPTION
Closes #662.

## Summary
The runner computed the exogenous **market regime** (`RegimeClassification`, #660) and the endogenous **ensemble consensus** (`EnsembleConsensus`, #659) every tick, but **neither fed position sizing** — `_weights_to_targets` mapped raw aggregated weights straight to allocations. This wires a `PortfolioConstructor` that throttles exposure by both.

## Dual-signal sizing
`position_scale = regime_mult × consensus_mult` ∈ [0,1], applied to every non-USDC weight; freed mass → USDC, then renormalize to 1.0. The two axes are orthogonal (macro risk vs. strategy conviction) and multiplied so exposure shrinks when **either** warns — a non-circular, conservative dual-approval throttle (regime-conditional Kelly sizing: Lo 2002, López de Prado 2018 §11).

| Regime (×conf factor `0.5+0.5·confidence`) | mult | | flat_pct | mult |
|---|---|---|---|---|
| RISK_ON | 1.0 | | <0.30 | 1.0 |
| TRANSITION | 0.7 | | 0.30–0.60 | lin 1.0→0.6 |
| RISK_OFF | 0.4 | | >0.60 | 0.6 |
| CRISIS | 0.1 | | None | 1.0 |
| None | 0.7 | | | |

e.g. RISK_ON+decisive → 1.0 (full sizing); CRISIS+uncertain → ~0.06 (near-flat).

## Interface change (`IPortfolioConstructor.construct`)
`regime` → `RegimeClassification | None`; added `ensemble_consensus: EnsembleConsensus | None = None` and keyword-only `base_weights: dict[str,float] | None = None` (the runner's pre-aggregated weights — the production path). **Both new params optional → no existing caller breaks**, and `regime`/`ensemble_consensus = None` degrade to conservative defaults rather than crash. `_weights_to_targets` is **retained** as the symbol→token-address mapper run after `construct()`.

> Note: `IPortfolioConstructor` is a component-interface Protocol — the signature change is additive/optional and there were no other implementers or callers (the concrete class is new in this PR). Flagging for **Önder/Dan** quant-lane eyes per the lead/coverage table.

## Verify
```
PYTHONPATH=backend python3 -m pytest backend/tests/services/test_portfolio_constructor.py -q   # 13 passed
PYTHONPATH=backend python3 -m pytest backend/tests/chain/ backend/tests/services/ -q            # 766 passed, 0 regressions
grep -n ensemble_consensus backend/archimedes/interfaces/math.py        # present
grep -n portfolio_constructor.construct backend/archimedes/chain/agent_runner.py   # both call sites
```
13 new hermetic tests cover all 4 regimes, the confidence-scaling, both `None` paths, and a `construct` integration test asserting allocations sum to 1.0 with risk weight shrunk into USDC.

## Anti-goals respected
`_weights_to_targets` kept; no magic numbers (named constants + literature comment); no `None` hard-fails; no other interface touched; only 4 files changed.

Hermetic — no infra needed to validate.