### PR TITLE
[backend] Train GMM regime model over 10y so it learns a CRISIS regime

### DIFF
--- a/scripts/fit_gmm_regime.py
+++ b/scripts/fit_gmm_regime.py
@@ -44,9 +44,14 @@ from archimedes.services.gmm_regime_detector import (
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("fit_gmm_regime")
 
-# ~2 years of trading days clears the ≥504-row bar with margin for the
-# _FEATURE_WINDOW warm-up that the rolling features consume.
-_LOOKBACK_PERIOD = "3y"
+# 10 years of daily bars. A shorter window (empirically 3y and 5y) contains no
+# sustained VIX>35 stretch, so no GMM component's mean VIX clears the crisis
+# threshold and the model becomes CRISIS-blind — it would label a real crash as
+# RISK_OFF and the dual-signal sizer (#662) would under-de-risk (0.4x vs 0.1x).
+# 10y spans the 2020 COVID spike (VIX 82.7) and the 2022 drawdown, which lets a
+# genuine crisis component form (mean VIX ~39) and yields a clean 1:1
+# component→regime mapping across all four regimes. Comfortably clears ≥504 rows.
+_LOOKBACK_PERIOD = "10y"
 _MIN_FIT_ROWS = 504
 
 


### PR DESCRIPTION
## Problem
While training the #661 model from real data, the trainer's default 3-year lookback produced a **CRISIS-blind model**. Empirically (confirmed live):

| lookback | rows | component VIX-means | regimes covered |
|---|---|---|---|
| 3y | 732 | 14.8 / 18.2 / 19.1 / **29.2** | risk_on, transition, risk_off — **no crisis** |
| 5y | 1234 | 15.4 / 19.8 / 23.5 / **30.0** | **no crisis** |
| **10y** | 2493 | 13.4 / 18.6 / 24.9 / **39.3** | **all four ✓** |
| max | 8383 | 14.3 / 22.1 / 23.2 / **38.8** | all four ✓ |

3y/5y never sustain VIX>35, so no component's mean clears the crisis threshold → the model maps **zero** components to CRISIS and would label a real crash as RISK_OFF. The dual-signal sizer (#662) then under-de-risks: RISK_OFF scales exposure to 0.4× where CRISIS would clamp to 0.1×.

## Fix
Default lookback 3y → **10y** (spans 2020 COVID, VIX 82.7, and the 2022 drawdown). Picked 10y over `max` to stay relevant to current market microstructure rather than reaching back to 1990.

## Verified (refit + live classify)
```
mapping: {0: crisis, 1: risk_on, 2: risk_off, 3: transition}   # clean 1:1, all 4
crisis-like buffer (VIX~46, falling SPY) -> crisis @ 0.95 (GMM path, not fallback)
calm buffer                              -> risk_on
```
The fitted `gmm_model.pkl` remains git-ignored (data-derived; produced by this offline script). Only `scripts/fit_gmm_regime.py` changes — one line + rationale comment. No runtime/import change, so no test impact.

Follows up #661 / #696.
