### PR TITLE
[backend] Surface additive library-level PBO on the rigor gate (#546, option 2)

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -12,7 +12,9 @@ from fastapi import APIRouter, Request, Response
 from archimedes.api.limiter import limiter
 from archimedes.services.rigor_evaluator import (
     compute_average_pairwise_correlation,
+    compute_library_pbo,
     compute_pbo,
+    load_daily_returns_store,
     run_rigor_gate,
 )
 from archimedes.services.strategy_provider import default_provider
@@ -37,8 +39,33 @@ class RigorGateDetail(BaseModel):
     look_ahead: str = "MISSING"
 
 
+class LibraryPbo(BaseModel):
+    """Library-level CSCV PBO (Bailey et al. 2014) over the whole selection set.
+
+    Display-only (#546, option 2): this is a *selection-set property*, identical
+    across every strategy, surfaced ALONGSIDE the per-strategy cohort
+    ``pbo_score`` — it is strictly additive and does NOT feed any gate verdict.
+    The same value is attached to ``RigorGateResponse`` and to every
+    ``StrategyRigorResult`` (the passport endpoint renders from the per-strategy
+    result, so the field must be present there too even though it is library-wide,
+    not strategy-specific). ``value is None`` is the fail-closed / store-absent
+    signal, in which case ``source == "unavailable"``.
+    """
+
+    value: float | None = None  # the single library CSCV PBO, or None (fail-closed / store absent)
+    data_vintage: str | None = None  # store vintage, e.g. "2026-06-11"
+    selection_set_size: int = 0  # number of strategies in the selection set
+    source: str = "library_cscv"  # provenance label; "unavailable" when value is None
+
+
 class StrategyRigorResult(BaseModel):
-    """Rigor gate result for a single strategy."""
+    """Rigor gate result for a single strategy.
+
+    ``library_pbo`` is a *selection-set property* (identical across strategies),
+    not a per-strategy metric; it is included here only so the passport endpoint
+    (which renders from this per-strategy result) can surface it. It is
+    display-only and never affects ``passes_all`` or ``pbo_score`` (#546).
+    """
 
     strategy_id: str
     strategy_name: str
@@ -49,6 +76,7 @@ class StrategyRigorResult(BaseModel):
     pbo_score: float | None = None
     oos_sharpe: float | None = None
     in_sample_sharpe: float | None = None
+    library_pbo: LibraryPbo = LibraryPbo()
 
 
 class RigorGateResponse(BaseModel):
@@ -58,6 +86,7 @@ class RigorGateResponse(BaseModel):
     total: int
     passing: int
     failing: int
+    library_pbo: LibraryPbo = LibraryPbo()
 
 
 class PBORequest(BaseModel):
@@ -94,8 +123,14 @@ async def evaluate_rigor_gate():
     """
     strategies = _provider.list_strategies()
 
+    # Library-level CSCV PBO (#546, option 2): a display-only selection-set
+    # property attached to the response and to each per-strategy result. It is
+    # strictly additive — it never feeds run_rigor_gate or any gate verdict.
+    # Computed once (cached on the store file signature) and reused everywhere.
+    library_pbo = _library_pbo_payload()
+
     if not strategies:
-        return RigorGateResponse(strategies=[], total=0, passing=0, failing=0)
+        return RigorGateResponse(strategies=[], total=0, passing=0, failing=0, library_pbo=library_pbo)
 
     # ── Collect real daily returns from persisted backtest results ──
     from archimedes.db import get_session, init_db
@@ -152,6 +187,7 @@ async def evaluate_rigor_gate():
                         oos_sharpe="MISSING (no backtest data)",
                         look_ahead="MISSING (no code)",
                     ),
+                    library_pbo=library_pbo,
                 )
             )
             continue
@@ -211,6 +247,7 @@ async def evaluate_rigor_gate():
                 pbo_score=gate_result.pbo_score,
                 oos_sharpe=gate_result.oos_sharpe,
                 in_sample_sharpe=gate_result.in_sample_sharpe,
+                library_pbo=library_pbo,
             )
         )
 
@@ -220,6 +257,7 @@ async def evaluate_rigor_gate():
         total=len(results),
         passing=passing,
         failing=len(results) - passing,
+        library_pbo=library_pbo,
     )
 
 
@@ -265,6 +303,84 @@ async def compute_pbo_endpoint(req: PBORequest, request: Request, response: Resp
 
 
 # ── Helpers ──────────────────────────────────────────────────
+
+
+# Cache the (expensive) library CSCV PBO keyed on the store's file signature so
+# the C(16, 8) = 12,870-combination CSCV runs only when the daily-returns store
+# actually changes — matching compute_library_pbo's documented "recompute on
+# store growth" refresh cadence. The store is add-only + idempotent, so a change
+# in the (filename, st_mtime_ns) signature is the "selection set changed" signal.
+_LIBRARY_PBO_CACHE: dict[tuple[tuple[str, int], ...], tuple[float | None, str | None, int]] = {}
+
+
+def _store_signature(store_dir) -> tuple[tuple[str, int], ...] | None:
+    """Sorted ``(filename, st_mtime_ns)`` over the store's ``*.json`` files.
+
+    Returns ``None`` when the directory is absent (degrades gracefully). Used as
+    the cache key: a new/changed/removed file flips the signature and forces a
+    recompute; an unchanged store reuses the cached value.
+    """
+    from pathlib import Path
+
+    if store_dir is None or not Path(store_dir).is_dir():
+        return None
+    try:
+        return tuple(sorted((p.name, p.stat().st_mtime_ns) for p in Path(store_dir).glob("*.json")))
+    except OSError:
+        return None
+
+
+def _cached_library_pbo() -> tuple[float | None, str | None, int]:
+    """Load the daily-returns store and compute the single library CSCV PBO.
+
+    Returns ``(value, data_vintage, selection_set_size)`` where ``value`` is the
+    library PBO (``None`` fail-closed / store absent), ``data_vintage`` is the
+    store's max vintage, and ``selection_set_size`` is the number of aligned
+    series actually used by the CSCV. Cached on the store file signature so the
+    expensive CSCV does not re-run on every request.
+
+    Never raises: an absent/empty/malformed store yields ``(None, None, 0)``.
+    """
+    from archimedes.services.rigor_evaluator import (
+        _resolve_daily_returns_store_dir,
+        align_returns_store,
+    )
+
+    store_dir = _resolve_daily_returns_store_dir()
+    signature = _store_signature(store_dir)
+    if signature is None:
+        return None, None, 0
+    if signature in _LIBRARY_PBO_CACHE:
+        return _LIBRARY_PBO_CACHE[signature]
+
+    store, data_vintage = load_daily_returns_store(store_dir)
+    # selection_set_size = number of series that actually survive date-alignment
+    # (the count CSCV runs over), not the raw file count.
+    selection_set_size = len(align_returns_store(store))
+    value = compute_library_pbo(store)
+    result = (value, data_vintage, selection_set_size)
+    _LIBRARY_PBO_CACHE[signature] = result
+    return result
+
+
+def _library_pbo_payload() -> LibraryPbo:
+    """Build the display-only ``LibraryPbo`` for attachment to gate responses.
+
+    Display-only (#546): never feeds the gate verdict. When the store is
+    unavailable or the PBO fails closed, returns ``LibraryPbo(value=None,
+    source="unavailable")`` and never crashes.
+    """
+    value, data_vintage, selection_set_size = _cached_library_pbo()
+    if value is None:
+        return LibraryPbo(
+            value=None, data_vintage=data_vintage, selection_set_size=selection_set_size, source="unavailable"
+        )
+    return LibraryPbo(
+        value=value,
+        data_vintage=data_vintage,
+        selection_set_size=selection_set_size,
+        source="library_cscv",
+    )
 
 
 def _load_strategy_code(code_path: str) -> str | None:

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -20,8 +20,10 @@ Spec:  docs/specs/selection-bias-corrections-spec.md
 from __future__ import annotations
 
 import ast
+import json
 import logging
 import math
+from pathlib import Path
 
 import numpy as np
 
@@ -248,6 +250,86 @@ def compute_library_pbo(
     if pbo is None or not math.isfinite(pbo):
         return None
     return float(pbo)
+
+
+def _resolve_daily_returns_store_dir() -> Path | None:
+    """Locate ``analytics-engine/strategies/daily_returns/`` from the repo root.
+
+    Walks up from this module's location (``backend/archimedes/services/``)
+    looking for the first ancestor that contains the store directory. Avoids a
+    hardcoded absolute path and avoids depending on ``os.getcwd()`` (which is
+    not the repo root under the test harness). Returns ``None`` when no ancestor
+    carries the tree — a backend deployed without the analytics-engine present
+    degrades gracefully rather than raising.
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "analytics-engine" / "strategies" / "daily_returns"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def load_daily_returns_store(
+    store_dir: Path | None = None,
+) -> tuple[dict[str, dict[str, list]], str | None]:
+    """Load the daily-returns store into the shape ``compute_library_pbo`` wants.
+
+    Reads every ``*.json`` record under ``store_dir`` (default: the repo's
+    ``analytics-engine/strategies/daily_returns/``, resolved by walking up from
+    ``__file__``) and projects each onto the minimal
+    ``{stem: {"dates": [...], "daily_returns": [...]}}`` shape that
+    ``align_returns_store`` / ``compute_library_pbo`` consume.
+
+    Also returns the data vintage: the MAX ``data_vintage`` string seen across
+    the loaded records, so the caller can surface "as of <vintage>" provenance.
+
+    **Never raises.** A missing/absent directory, an empty directory, or a
+    malformed/unreadable file all degrade gracefully: a malformed file is
+    skipped, and an absent or empty store returns ``({}, None)``. This mirrors
+    the fail-closed contract of ``compute_library_pbo`` — a backend without the
+    analytics-engine tree present must still serve.
+
+    Args:
+        store_dir: Directory of ``<stem>.json`` records. When ``None``, resolved
+            to the repo's ``analytics-engine/strategies/daily_returns/``.
+
+    Returns:
+        ``(store, data_vintage)`` where ``store`` is
+        ``{stem: {"dates": [...], "daily_returns": [...]}}`` (empty when the dir
+        is absent/empty or every file was malformed) and ``data_vintage`` is the
+        max ISO vintage string across records (``None`` when no usable record
+        carried one).
+    """
+    if store_dir is None:
+        store_dir = _resolve_daily_returns_store_dir()
+    if store_dir is None or not Path(store_dir).is_dir():
+        return {}, None
+
+    store: dict[str, dict[str, list]] = {}
+    vintages: list[str] = []
+    for path in sorted(Path(store_dir).glob("*.json")):
+        try:
+            rec = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            # Malformed / unreadable file — skip it; never let one bad file
+            # take down the whole load.
+            logger.warning("load_daily_returns_store: skipping unreadable store file %s", path.name)
+            continue
+        if not isinstance(rec, dict):
+            continue
+        dates = rec.get("dates")
+        daily_returns = rec.get("daily_returns")
+        if not isinstance(dates, list) or not isinstance(daily_returns, list):
+            continue
+        stem = rec.get("stem") or path.stem
+        store[stem] = {"dates": dates, "daily_returns": daily_returns}
+        vintage = rec.get("data_vintage")
+        if isinstance(vintage, str) and vintage:
+            vintages.append(vintage)
+
+    data_vintage = max(vintages) if vintages else None
+    return store, data_vintage
 
 
 # ─── 6. Rigor Gate — composite check ─────────────────────────────────

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -21,6 +21,7 @@ No network, no database, no on-chain dependencies.
 from __future__ import annotations
 
 import ast
+import json
 import math
 
 import numpy as np
@@ -41,6 +42,7 @@ from archimedes.services.rigor_evaluator import (
     _get_func_name,
     align_returns_store,
     compute_library_pbo,
+    load_daily_returns_store,
     look_ahead_audit,
     run_rigor_gate,
 )
@@ -1418,3 +1420,83 @@ class TestRigorGateLibraryPbo:
         )
         assert not result.passes_all
         assert result.gate_details["pbo"] == "MISSING (source=cohort)"
+
+
+# ─── Daily-returns store loader (#546) ───────────────────────────────
+
+
+class TestLoadDailyReturnsStore:
+    """load_daily_returns_store: read the store into compute_library_pbo's shape,
+    surface the max data_vintage, and degrade gracefully (never raise)."""
+
+    @staticmethod
+    def _write_record(directory, name: str, *, vintage: str, n: int = 4) -> None:
+        dates = [f"2020-01-{1 + i:02d}" for i in range(n)]
+        rec = {
+            "stem": name,
+            "data_vintage": vintage,
+            "n_obs": n,
+            "dates": dates,
+            "daily_returns": [0.001 * (i + 1) for i in range(n)],
+        }
+        (directory / f"{name}.json").write_text(json.dumps(rec), encoding="utf-8")
+
+    def test_loads_shape_and_max_vintage(self, tmp_path) -> None:
+        self._write_record(tmp_path, "alpha", vintage="2026-06-10")
+        self._write_record(tmp_path, "beta", vintage="2026-06-11")
+        self._write_record(tmp_path, "gamma", vintage="2026-06-09")
+
+        store, vintage = load_daily_returns_store(tmp_path)
+
+        assert set(store.keys()) == {"alpha", "beta", "gamma"}
+        # Each entry projected onto exactly {dates, daily_returns}.
+        for rec in store.values():
+            assert set(rec.keys()) == {"dates", "daily_returns"}
+            assert len(rec["dates"]) == len(rec["daily_returns"]) == 4
+        # Max ISO vintage across files.
+        assert vintage == "2026-06-11"
+
+    def test_missing_directory_returns_empty_no_raise(self, tmp_path) -> None:
+        absent = tmp_path / "does-not-exist"
+        store, vintage = load_daily_returns_store(absent)
+        assert store == {}
+        assert vintage is None
+
+    def test_empty_directory_returns_empty(self, tmp_path) -> None:
+        store, vintage = load_daily_returns_store(tmp_path)
+        assert store == {}
+        assert vintage is None
+
+    def test_malformed_file_is_skipped(self, tmp_path) -> None:
+        self._write_record(tmp_path, "good", vintage="2026-06-11")
+        (tmp_path / "broken.json").write_text("{ this is not json", encoding="utf-8")
+
+        store, vintage = load_daily_returns_store(tmp_path)
+
+        # The bad file is skipped; the good one survives.
+        assert set(store.keys()) == {"good"}
+        assert vintage == "2026-06-11"
+
+    def test_record_without_vintage_yields_none_vintage(self, tmp_path) -> None:
+        rec = {"stem": "novintage", "dates": ["2020-01-01", "2020-01-02"], "daily_returns": [0.01, 0.02]}
+        (tmp_path / "novintage.json").write_text(json.dumps(rec), encoding="utf-8")
+
+        store, vintage = load_daily_returns_store(tmp_path)
+        assert set(store.keys()) == {"novintage"}
+        assert vintage is None
+
+    def test_record_missing_returns_field_is_skipped(self, tmp_path) -> None:
+        # dates present but daily_returns absent → not loadable, skip.
+        bad = {"stem": "halfrec", "dates": ["2020-01-01"]}
+        (tmp_path / "halfrec.json").write_text(json.dumps(bad), encoding="utf-8")
+        self._write_record(tmp_path, "good", vintage="2026-06-11")
+
+        store, _ = load_daily_returns_store(tmp_path)
+        assert set(store.keys()) == {"good"}
+
+    def test_default_store_dir_loads_repo_store(self) -> None:
+        # No explicit dir → resolve the repo's analytics-engine store. The repo
+        # ships 22 records, so the live store loads non-empty with a vintage.
+        store, vintage = load_daily_returns_store()
+        assert len(store) >= 2
+        assert isinstance(vintage, str) and vintage

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from archimedes.api.selection_bias_routes import (
+    LibraryPbo,
     PBORequest,
     PBOResponse,
     RigorGateDetail,
@@ -516,3 +517,241 @@ class TestOosCliffDenominator:
         )
         # Same series, only the denominator differs → the bug let it pass.
         assert "PASS" in gate.gate_details["oos_sharpe"]
+
+
+# ── Library PBO: schema + cached helper (#546, display-only) ────────────
+
+
+class TestLibraryPboSchema:
+    def test_defaults_are_unavailable_shape(self):
+        lp = LibraryPbo()
+        assert lp.value is None
+        assert lp.data_vintage is None
+        assert lp.selection_set_size == 0
+        assert lp.source == "library_cscv"
+
+    def test_custom_values_stored(self):
+        lp = LibraryPbo(value=0.31, data_vintage="2026-06-11", selection_set_size=22, source="library_cscv")
+        assert lp.value == pytest.approx(0.31)
+        assert lp.data_vintage == "2026-06-11"
+        assert lp.selection_set_size == 22
+
+    def test_present_on_response_models_by_default(self):
+        resp = RigorGateResponse(strategies=[], total=0, passing=0, failing=0)
+        assert isinstance(resp.library_pbo, LibraryPbo)
+        result = StrategyRigorResult(
+            strategy_id="x",
+            strategy_name="X",
+            passes_all=False,
+            gate_details=RigorGateDetail(),
+        )
+        assert isinstance(result.library_pbo, LibraryPbo)
+
+
+class TestCachedLibraryPbo:
+    """The module-level cached helper computes a value for a valid tmp store and
+    fails closed gracefully for an absent one — without re-running CSCV per call."""
+
+    def _write_store(self, directory, n_series: int = 4, n_obs: int = 256, vintage: str = "2026-06-11"):
+        import json
+
+        import numpy as np
+
+        rng = np.random.default_rng(7)
+        dates = [f"2020-{1 + i // 28:02d}-{1 + i % 28:02d}" for i in range(n_obs)]
+        for k in range(n_series):
+            rec = {
+                "stem": f"strat_{k}",
+                "data_vintage": vintage,
+                "n_obs": n_obs,
+                "dates": dates,
+                "daily_returns": rng.normal(0.0005, 0.01, n_obs).tolist(),
+            }
+            (directory / f"strat_{k}.json").write_text(json.dumps(rec), encoding="utf-8")
+
+    def test_returns_value_for_valid_store(self, tmp_path, monkeypatch):
+        from archimedes.api import selection_bias_routes as routes
+
+        self._write_store(tmp_path)
+        # Point the resolver at the tmp store and clear any cached value.
+        monkeypatch.setattr(routes, "_LIBRARY_PBO_CACHE", {})
+        monkeypatch.setattr(
+            "archimedes.services.rigor_evaluator._resolve_daily_returns_store_dir",
+            lambda: tmp_path,
+        )
+        value, vintage, size = routes._cached_library_pbo()
+        assert value is not None
+        assert 0.0 <= value <= 1.0
+        assert vintage == "2026-06-11"
+        assert size == 4
+
+    def test_absent_store_fails_closed(self, monkeypatch):
+        from archimedes.api import selection_bias_routes as routes
+
+        monkeypatch.setattr(routes, "_LIBRARY_PBO_CACHE", {})
+        monkeypatch.setattr(
+            "archimedes.services.rigor_evaluator._resolve_daily_returns_store_dir",
+            lambda: None,
+        )
+        value, vintage, size = routes._cached_library_pbo()
+        assert value is None
+        assert vintage is None
+        assert size == 0
+
+    def test_payload_unavailable_when_value_none(self, monkeypatch):
+        from archimedes.api import selection_bias_routes as routes
+
+        monkeypatch.setattr(routes, "_cached_library_pbo", lambda: (None, None, 0))
+        payload = routes._library_pbo_payload()
+        assert payload.value is None
+        assert payload.source == "unavailable"
+
+    def test_cache_avoids_recompute_on_unchanged_store(self, tmp_path, monkeypatch):
+        """Second call with an unchanged store does NOT re-run compute_library_pbo."""
+        from archimedes.api import selection_bias_routes as routes
+
+        self._write_store(tmp_path)
+        monkeypatch.setattr(routes, "_LIBRARY_PBO_CACHE", {})
+        monkeypatch.setattr(
+            "archimedes.services.rigor_evaluator._resolve_daily_returns_store_dir",
+            lambda: tmp_path,
+        )
+
+        calls = {"n": 0}
+        real = routes.compute_library_pbo
+
+        def _counting(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+
+        monkeypatch.setattr(routes, "compute_library_pbo", _counting)
+
+        routes._cached_library_pbo()
+        routes._cached_library_pbo()
+        assert calls["n"] == 1  # cached on the unchanged file signature
+
+
+# ── Library PBO: endpoint wiring + additivity guarantee (#546) ──────────
+
+
+@pytest.mark.asyncio
+async def test_gate_response_includes_library_pbo_object():
+    """GET /api/selection-bias/gate carries a library_pbo object on the response
+    AND on every per-strategy result (selection-set property)."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/selection-bias/gate")
+    data = resp.json()
+    assert "library_pbo" in data
+    lp = data["library_pbo"]
+    for key in ("value", "data_vintage", "selection_set_size", "source"):
+        assert key in lp, f"missing '{key}' in library_pbo: {list(lp.keys())}"
+    for strat in data["strategies"]:
+        assert "library_pbo" in strat
+
+
+@pytest.mark.asyncio
+async def test_single_strategy_result_includes_library_pbo():
+    """GET /gate/{id} renders the selection-set library_pbo on the passport result."""
+    from archimedes.api import selection_bias_routes
+    from archimedes.main import app
+
+    # Pick a real strategy id from the provider so the route resolves it.
+    strategies = selection_bias_routes._provider.list_strategies()
+    if not strategies:
+        pytest.skip("no strategies in provider")
+    sid = strategies[0].id
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/selection-bias/gate/{sid}")
+    assert resp.status_code == 200
+    assert "library_pbo" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_library_pbo_does_not_change_verdict_or_pbo_score(monkeypatch):
+    """ADDITIVITY GUARANTEE: injecting vs removing the library PBO must NOT change
+    any strategy's passes_all or pbo_score. We run the gate twice — once with the
+    library PBO forced to a concrete value, once forced unavailable — and assert
+    the per-strategy verdict + cohort pbo_score are byte-for-byte identical."""
+    from archimedes.api import selection_bias_routes as routes
+    from archimedes.main import app
+
+    async def _run_once():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            return (await client.get("/api/selection-bias/gate")).json()
+
+    # Run A: library PBO present with a concrete value.
+    monkeypatch.setattr(
+        routes,
+        "_library_pbo_payload",
+        lambda: routes.LibraryPbo(value=0.42, data_vintage="2026-06-11", selection_set_size=22),
+    )
+    data_with = await _run_once()
+
+    # Run B: library PBO unavailable (None).
+    monkeypatch.setattr(
+        routes,
+        "_library_pbo_payload",
+        lambda: routes.LibraryPbo(value=None, source="unavailable"),
+    )
+    data_without = await _run_once()
+
+    by_id_with = {s["strategy_id"]: s for s in data_with["strategies"]}
+    by_id_without = {s["strategy_id"]: s for s in data_without["strategies"]}
+    assert by_id_with.keys() == by_id_without.keys()
+    for sid, a in by_id_with.items():
+        b = by_id_without[sid]
+        assert a["passes_all"] == b["passes_all"], f"passes_all changed for {sid}"
+        assert a["pbo_score"] == b["pbo_score"], f"pbo_score changed for {sid}"
+    # Sanity: the only thing that differs is the additive library_pbo field.
+    assert data_with["passing"] == data_without["passing"]
+    assert data_with["library_pbo"]["value"] == pytest.approx(0.42)
+    assert data_without["library_pbo"]["value"] is None
+
+
+@pytest.mark.asyncio
+async def test_run_rigor_gate_called_without_library_pbo_kwarg(monkeypatch):
+    """The gate verdict path must be provably unchanged: run_rigor_gate is called
+    WITHOUT a library_pbo= argument (passing it would alter criterion 4 = option 3,
+    which is out of scope). Patch run_rigor_gate, force the DB to yield a usable
+    return series so the full branch executes, and assert library_pbo is absent
+    from every call's kwargs."""
+    from archimedes.api import selection_bias_routes as routes
+    from archimedes.main import app
+    from archimedes.services.rigor_evaluator import run_rigor_gate as real_run_rigor_gate
+
+    strategies = routes._provider.list_strategies()
+    if not strategies:
+        pytest.skip("no strategies in provider")
+
+    # Force the DB read to return a usable series for at least one strategy so the
+    # full (non-MISSING) branch — the one that calls run_rigor_gate — executes.
+    import numpy as np
+
+    rng = np.random.default_rng(3)
+    series = rng.normal(0.001, 0.01, 400).tolist()
+    target_id = strategies[0].id
+    # The route imports get_all_daily_returns inside the function body
+    # (`from archimedes.services.backtest_repository import get_all_daily_returns`),
+    # so the effective patch point is the definition module, not the route module.
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: {target_id: series},
+    )
+
+    captured_kwargs = []
+
+    def _spy(*args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return real_run_rigor_gate(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "run_rigor_gate", _spy)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/selection-bias/gate")
+    assert resp.status_code == 200
+    assert captured_kwargs, "run_rigor_gate was never called — the full branch did not execute"
+    for kwargs in captured_kwargs:
+        assert "library_pbo" not in kwargs, "run_rigor_gate must NOT receive library_pbo (option-3 guard)"


### PR DESCRIPTION
Closes #546.

## Decision
Implements **option 2** of the #546 team decision: surface the full-library CSCV PBO (Bailey et al. 2014) as a **display-only** diagnostic alongside the existing per-strategy cohort `pbo_score`. Never frozen into fixtures; computed from the daily-returns store at evaluation time. (No team currently — Önder's call; option 2 is the recommended honest middle.)

## Strictly additive — the gate verdict is provably unchanged
This is **not** option 3 (feeding library PBO into the gate), which would change criterion 4 and need Dan's sign-off. Here:
- `run_rigor_gate(...)` is still called **without** a `library_pbo` kwarg.
- Per-strategy `pbo_score` still comes only from `gate_result`; `passes_all` is untouched.

Two guard tests lock this in:
- `test_run_rigor_gate_called_without_library_pbo_kwarg` — patches `run_rigor_gate`, asserts `library_pbo` is never in its kwargs.
- `test_library_pbo_does_not_change_verdict_or_pbo_score` — forces library PBO to `0.42` vs `None`, asserts every strategy's `passes_all` and `pbo_score` are identical.

## What's new
- `load_daily_returns_store()` in `rigor_evaluator.py` (+82/-0, existing funcs untouched): repo-root-relative path resolution, never raises, returns `({}, None)` on a missing analytics-engine tree.
- A request-time cache keyed on the store's `(filename, mtime)` signature, so the expensive CSCV (12,870 combinations) reruns **only when the store changes** — the documented recompute-on-store-growth cadence.
- A `LibraryPbo` model (`value` + `data_vintage` + `selection_set_size` + `source`) on both the library gate response and the per-strategy passport result. Store absent → `value=None, source="unavailable"` (never crashes, never blocks the gate).

## Verify
```
PYTHONPATH=backend python3 -m pytest backend/tests/test_selection_bias_routes.py backend/tests/test_rigor_evaluator.py -q   # 204 passed
PYTHONPATH=backend python3 -m pytest backend/tests/ -q                                                                      # 1645 passed, 2 skipped (pre-existing)
```

Reviewer: quant lane (Önder). Additive/display-only — does not alter any gate verdict. Hermetic; no infra needed.
