### PR TITLE
[contracts] Registry-allowlisted onlyManager oracle setter for Tier-2 vaults

### DIFF
--- a/contracts/src/AssetRegistry.sol
+++ b/contracts/src/AssetRegistry.sol
@@ -44,9 +44,25 @@ contract AssetRegistry is IAssetRegistry, Ownable {
     mapping(address => VaultInfo) private _vaults;
     address[] private _vaultList;
 
+    /// @notice Owner-curated token → oracle allowlist. A vault manager can wire
+    ///         only oracles registered here (Vault.setTokenOraclesFromRegistry),
+    ///         so it can never point a token at an arbitrary attacker contract.
+    ///         The public getter satisfies IAssetRegistry.registeredOracle.
+    mapping(address => address) public override registeredOracle;
+
     // ─── Constructor ─────────────────────────────────────────────────
 
     constructor(address _owner) Ownable(_owner) {}
+
+    // ─── Oracle Allowlist ────────────────────────────────────────────
+
+    /// @notice Register or de-register the canonical oracle for a token.
+    /// @dev    address(0) de-registers; consumers treat an unregistered token
+    ///         as "no known-good oracle" and reject manager-driven wiring.
+    function setRegisteredOracle(address token, address oracle) external override onlyOwner {
+        registeredOracle[token] = oracle;
+        emit OracleRegistered(token, oracle);
+    }
 
     // ─── Synthetic Assets ────────────────────────────────────────────
 

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/utils/Pausable.sol";
 
 import "./interfaces/IVault.sol";
 import "./interfaces/IAMMRouter.sol";
+import "./interfaces/IAssetRegistry.sol";
 import "./PriceOracle.sol";
 
 /// @title Vault
@@ -94,6 +95,11 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         covers the 30 bps AMM fee plus bounded price impact.
     uint256 public maxSlippageBps = 100;
 
+    /// @notice Owner-curated registry consulted by setTokenOraclesFromRegistry.
+    ///         The manager may wire oracles only from this allowlist, never an
+    ///         arbitrary address — see setTokenOraclesFromRegistry.
+    IAssetRegistry public assetRegistry;
+
     // ─── Errors ──────────────────────────────────────────────────────
 
     error ZeroAmount();
@@ -106,12 +112,16 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     error SlippageBpsTooHigh();
     error OracleNotSet();
     error InvalidOraclePrice();
+    error OracleNotRegistered(address token);
+    error AssetRegistryNotSet();
 
     // ─── Events (Vault-local) ────────────────────────────────────────
 
     event MaxSlippageBpsSet(uint256 oldBps, uint256 newBps);
     event AgentSet(address indexed oldAgent, address indexed newAgent);
     event PlatformFeeRecipientSet(address indexed oldRecipient, address indexed newRecipient);
+    event AssetRegistrySet(address indexed registry);
+    event TokenOraclesSetFromRegistry(uint256 count);
 
     // ─── Constructor ─────────────────────────────────────────────────
 
@@ -405,6 +415,28 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         emit TokenOraclesSet(tokens.length);
     }
 
+    /// @notice Wire NAV-pricing oracles for new tokens from the owner-curated
+    ///         AssetRegistry allowlist. Lets the manager (agent) price new
+    ///         synths autonomously WITHOUT being able to point a token at an
+    ///         arbitrary oracle: every oracle written here must already be
+    ///         registered by the owner via AssetRegistry.setRegisteredOracle.
+    /// @dev    onlyManager — the bounded counterpart to the owner-only
+    ///         setTokenOracles (which remains the arbitrary-override path).
+    ///         The allowlist closes the same hole an unrestricted onlyManager
+    ///         setter would open: a compromised manager can only select among
+    ///         owner-approved oracles, never inject a self-serving one.
+    ///         Reverts if the registry is unset, or if any token has no
+    ///         registered (allowlisted) oracle.
+    function setTokenOraclesFromRegistry(address[] calldata tokens) external onlyManager {
+        if (address(assetRegistry) == address(0)) revert AssetRegistryNotSet();
+        for (uint256 i = 0; i < tokens.length; i++) {
+            address oracle = assetRegistry.registeredOracle(tokens[i]);
+            if (oracle == address(0)) revert OracleNotRegistered(tokens[i]);
+            tokenOracle[tokens[i]] = oracle;
+        }
+        emit TokenOraclesSetFromRegistry(tokens.length);
+    }
+
     function getHoldings()
         external
         view
@@ -441,6 +473,14 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     function setPlatformFeeRecipient(address _recipient) external onlyOwner {
         emit PlatformFeeRecipientSet(platformFeeRecipient, _recipient);
         platformFeeRecipient = _recipient;
+    }
+
+    /// @notice Point the vault at the owner-curated oracle allowlist used by
+    ///         setTokenOraclesFromRegistry. Owner-only: it defines which
+    ///         oracles the manager is allowed to wire.
+    function setAssetRegistry(address _registry) external onlyOwner {
+        assetRegistry = IAssetRegistry(_registry);
+        emit AssetRegistrySet(_registry);
     }
 
     /// @notice Set the max slippage tolerance applied to all AMM swaps.

--- a/contracts/src/interfaces/IAssetRegistry.sol
+++ b/contracts/src/interfaces/IAssetRegistry.sol
@@ -12,6 +12,7 @@ interface IAssetRegistry {
     event BridgedRegistered(address indexed token, uint256 sourceChainId);
     event VaultRegistered(address indexed vault, uint8 tier, address creator);
     event VaultMetricsUpdated(address indexed vault, uint256 aum, uint256 timestamp);
+    event OracleRegistered(address indexed token, address indexed oracle);
 
     // ── Synthetic Assets ─────────────────────────────────────
     /// @notice Register a synthetic asset.
@@ -29,6 +30,17 @@ interface IAssetRegistry {
 
     /// @notice List all registered synthetic token addresses.
     function getAllSynthetics() external view returns (address[] memory);
+
+    // ── Oracle Allowlist ─────────────────────────────────────
+    /// @notice Register (or de-register) the canonical oracle for a token.
+    ///         Owner-curated allowlist consumed by Vault.setTokenOraclesFromRegistry,
+    ///         so a manager can wire only known-good oracles for new assets.
+    /// @param token Token whose NAV-pricing oracle is being set
+    /// @param oracle Oracle address; address(0) de-registers the token
+    function setRegisteredOracle(address token, address oracle) external;
+
+    /// @notice Get the registered oracle for a token (address(0) if unregistered).
+    function registeredOracle(address token) external view returns (address);
 
     // ── Bridged Assets ───────────────────────────────────────
     /// @notice Register a bridged asset from another chain.

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -6,6 +6,7 @@ import "../src/Vault.sol";
 import "../src/VaultFactory.sol";
 import "../src/AMMRouter.sol";
 import "../src/AMMPool.sol";
+import "../src/AssetRegistry.sol";
 
 /// @dev Mock ERC-20 USDC for testing
 contract MockUSDC is ERC20 {
@@ -520,6 +521,117 @@ contract VaultTest is Test {
 
         // The creator/owner can still set oracles.
         vm.prank(creator);
+        v.setTokenOracles(tokens, oracles);
+    }
+
+    // ─── Registry-allowlisted oracle wiring (issue #620) ─────────────
+    //
+    // The agent (onlyManager, not onlyOwner) must be able to wire oracles for a
+    // new synth, but ONLY from an owner-curated allowlist — so it can price new
+    // assets autonomously yet can never point a token at an arbitrary attacker
+    // oracle. These tests build a vault whose agent is DISTINCT from the
+    // creator/owner so onlyManager and onlyOwner are actually distinguishable
+    // (in the shared setUp, agent == creator == owner).
+
+    address internal constant REG_CREATOR = address(0xC0FFEE);
+    address internal constant REG_AGENT = address(0xA9E27);
+
+    /// @dev Deploy a vault with a distinct creator/owner and agent, returning it.
+    function _distinctAgentVault() internal returns (Vault v) {
+        vm.prank(REG_CREATOR);
+        address vaultAddr = factory.createVault("Reg", "REG", 0, 0, true);
+        v = Vault(payable(vaultAddr));
+        vm.prank(REG_CREATOR); // creator == Ownable owner
+        v.setAgent(REG_AGENT);
+    }
+
+    function _singleton(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
+    }
+
+    /// @dev Owner registers an oracle in AssetRegistry and points the vault at
+    ///      the registry; the AGENT (onlyManager) wires it via the allowlist and
+    ///      the vault's tokenOracle now equals the registered oracle.
+    function test_setTokenOraclesFromRegistry_agent_wires_allowlisted() public {
+        Vault v = _distinctAgentVault();
+
+        AssetRegistry registry = new AssetRegistry(REG_CREATOR);
+        vm.prank(REG_CREATOR);
+        registry.setRegisteredOracle(address(sTSLA), address(tslaOracle));
+
+        vm.prank(REG_CREATOR);
+        v.setAssetRegistry(address(registry));
+
+        // The agent — which is NOT the owner — wires the allowlisted oracle.
+        vm.prank(REG_AGENT);
+        v.setTokenOraclesFromRegistry(_singleton(address(sTSLA)));
+
+        assertEq(v.tokenOracle(address(sTSLA)), address(tslaOracle));
+    }
+
+    /// @dev A token with no entry in the allowlist reverts OracleNotRegistered —
+    ///      the agent cannot wire an oracle the owner never approved.
+    function test_revert_setTokenOraclesFromRegistry_unregistered_token() public {
+        Vault v = _distinctAgentVault();
+
+        AssetRegistry registry = new AssetRegistry(REG_CREATOR);
+        vm.prank(REG_CREATOR);
+        v.setAssetRegistry(address(registry));
+
+        vm.prank(REG_AGENT);
+        vm.expectRevert(abi.encodeWithSelector(Vault.OracleNotRegistered.selector, address(sTSLA)));
+        v.setTokenOraclesFromRegistry(_singleton(address(sTSLA)));
+    }
+
+    /// @dev With no registry set, the allowlist path reverts AssetRegistryNotSet.
+    function test_revert_setTokenOraclesFromRegistry_registry_unset() public {
+        Vault v = _distinctAgentVault();
+
+        vm.prank(REG_AGENT);
+        vm.expectRevert(Vault.AssetRegistryNotSet.selector);
+        v.setTokenOraclesFromRegistry(_singleton(address(sTSLA)));
+    }
+
+    /// @dev A caller that is neither manager nor owner cannot use the allowlist
+    ///      path — reverts Unauthorized (onlyManager).
+    function test_revert_setTokenOraclesFromRegistry_non_manager() public {
+        Vault v = _distinctAgentVault();
+
+        AssetRegistry registry = new AssetRegistry(REG_CREATOR);
+        vm.prank(REG_CREATOR);
+        registry.setRegisteredOracle(address(sTSLA), address(tslaOracle));
+        vm.prank(REG_CREATOR);
+        v.setAssetRegistry(address(registry));
+
+        // bob is neither the creator (owner) nor the agent.
+        vm.prank(bob);
+        vm.expectRevert(Vault.Unauthorized.selector);
+        v.setTokenOraclesFromRegistry(_singleton(address(sTSLA)));
+    }
+
+    /// @dev setAssetRegistry is owner-only: a non-owner call reverts Ownable.
+    function test_revert_setAssetRegistry_non_owner() public {
+        Vault v = _distinctAgentVault();
+
+        AssetRegistry registry = new AssetRegistry(REG_CREATOR);
+        vm.prank(REG_AGENT); // agent is not the owner
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, REG_AGENT));
+        v.setAssetRegistry(address(registry));
+    }
+
+    /// @dev #609 property preserved: the agent calling the ARBITRARY-override
+    ///      setTokenOracles still reverts (onlyOwner). Combined with the
+    ///      allowlist tests above, the agent's ONLY oracle path is the
+    ///      owner-curated registry — it can never inject an unregistered oracle.
+    function test_revert_setTokenOracles_agent_still_owner_only() public {
+        Vault v = _distinctAgentVault();
+
+        address[] memory tokens = _singleton(address(sTSLA));
+        address[] memory oracles = _singleton(address(tslaOracle));
+
+        vm.prank(REG_AGENT);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, REG_AGENT));
         v.setTokenOracles(tokens, oracles);
     }
 


### PR DESCRIPTION
Closes #620.

## Problem
#609 moved `Vault.setTokenOracles` to `onlyOwner` so a compromised/prompt-injected agent could not repoint a synthetic's price oracle at an attacker contract and drain the vault via mispriced swaps. Correct fix — but it left the `onlyManager` agent unable to wire oracles for a **new** synthetic in a Tier-2 vault, so the agent can't price or rebalance into new assets autonomously.

## Solution — option 1 (registry-allowlisted `onlyManager` setter)
Let the agent set oracles **only from an owner-curated allowlist**, so it can wire known-good oracles for new synths but can never point at an arbitrary contract.

- `AssetRegistry` (+ `IAssetRegistry`): owner-curated allowlist — `setRegisteredOracle(token, oracle)` (`onlyOwner`) + `registeredOracle(token)` view + `OracleRegistered` event.
- `Vault`: `setAssetRegistry(address)` (`onlyOwner`) and `setTokenOraclesFromRegistry(address[])` (`onlyManager`) that copies each token's oracle **only** from `assetRegistry.registeredOracle(token)`, reverting `OracleNotRegistered` for anything the owner hasn't approved (and `AssetRegistryNotSet` if unconfigured).
- The arbitrary-override `setTokenOracles` stays `onlyOwner` — the #609 hole stays closed, now via an allowlist instead of an owner-only gate.

## Why the agent still can't inject an arbitrary oracle
Its only oracle path is `setTokenOraclesFromRegistry`, which reads straight from the owner's allowlist and reverts for unapproved tokens; it cannot write a self-chosen address into `tokenOracle`. The owner-only override path is unchanged and tested.

## Constructor unchanged (no deploy ripple)
Wiring is **setter-based** — the `Vault` constructor signature is byte-for-byte unchanged, so `VaultFactory`, the backend executor, and the cached ABIs are unaffected (this deliberately avoids the `createVault` selector-mismatch class of problem). Source-only; takes effect on the next contract redeploy (#588).

## Verify
```
cd contracts && forge build            # compiles clean
cd contracts && forge test             # 181 passed, 0 failed (Vault suite +6)
```
New tests cover: the agent wiring an allowlisted oracle; the unregistered-token and registry-unset reverts; the `onlyManager` and `onlyOwner` gates; and the preserved #609 property (agent still cannot call `setTokenOracles`).

Scope: 4 files (`Vault.sol`, `AssetRegistry.sol`, `IAssetRegistry.sol`, `Vault.t.sol`). No `VaultFactory`/backend/ABI/deploy-script changes.
