### PR TITLE
[infra] Capture terraform + awscli in conda env + document local CLI tooling

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,16 @@ dependencies:
                 # have to install Node separately and CI-vs-local parity
                 # breaks (the ESLint gate runs in CI only).
 
+  # Infra / cloud CLI tooling — conda-forge binaries, pinned so the whole team
+  # (and a from-scratch setup) gets one consistent version for IaC + AWS work.
+  - terraform>=1.10   # IaC for the AWS stack (infra/*.tf). >=1.10 required for S3-native
+                      #   state locking (use_lockfile=true; see infra/README.md). Verified 1.15.3.
+  - awscli>=2.15      # AWS CLI v2 (conda-forge ships v2). v2 is REQUIRED for `aws configure sso`
+                      #   / IAM Identity Center — v1's SSO support is insufficient. Verified 2.34.48.
+  # NOTE: aws-sam-cli is intentionally NOT here — it is not packaged on conda-forge.
+  #   Install via Homebrew (`brew install aws-sam-cli`). See infra/README.md
+  #   "Local CLI tooling" for when SAM actually applies (Lambda/serverless only).
+
   # Python deps installed via pip — pinned loosely; tighten in pyproject.toml as the project firms up.
   - pip:
       # --- Web backend ---

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,5 +1,28 @@
 # Archimedes Infrastructure
 
+## Local CLI tooling
+
+The infra workflow needs three command-line tools. Two come from the `archimedes`
+conda env (pinned in [`../environment.yml`](../environment.yml), so `conda env create`
+gives everyone the same versions); the third is a Homebrew install because it is not
+packaged on conda-forge.
+
+| Tool | Version (verified) | How to install | Why |
+| --- | --- | --- | --- |
+| **Terraform** | 1.15.3 | conda env (`terraform>=1.10`) | IaC for the whole AWS stack (`infra/*.tf`). 1.10+ required for S3-native state locking (`use_lockfile=true`). |
+| **AWS CLI v2** | 2.34.48 | conda env (`awscli>=2.15`) | Deploys, SSM sessions, and **`aws configure sso`** for IAM Identity Center. **v2 is required** — v1's SSO support is insufficient for the Identity Center login flow. |
+| **AWS SAM CLI** | 1.162.1 | **Homebrew**: `brew install aws-sam-cli` (not on conda-forge) | Serverless build/deploy + `sam local` testing. Only needed if/when we add Lambda pieces — see note below. |
+
+Run env-scoped tools with `conda run -n archimedes <cmd>` (or `conda activate archimedes`
+first) so you are always on the pinned versions, not whatever is on the system PATH.
+
+**On SAM's role:** the production stack is **ECS-on-EC2 + Aurora + ALB, managed by
+Terraform** — Terraform is the IaC backbone and SAM does not replace it. SAM is
+purpose-built for **Lambda / API Gateway serverless** apps and local Lambda emulation.
+Treat it as *additive*: reach for it only when we introduce a concrete Lambda use-case
+(e.g. an event-driven nanopayment-settlement hook, a scheduled job, or lightweight glue),
+not as a second way to manage the core web tier. Until then it is installed-but-unused.
+
 ## Terraform State Backend (S3)
 
 State is stored remotely in S3 with S3-native locking (Terraform 1.10+,


### PR DESCRIPTION
## What
Capture the infra CLI tooling so a from-scratch setup is reproducible:
- `environment.yml`: add `terraform>=1.10` and `awscli>=2.15` (both ship on conda-forge; verified terraform 1.15.3, awscli 2.34.48).
- `infra/README.md`: new **"Local CLI tooling"** section — the three tools, versions, install path, and `conda run -n archimedes` usage.

## Why
The AWS rebuild needs Terraform (IaC for `infra/*.tf`) and AWS CLI **v2** (required for `aws configure sso` / IAM Identity Center). Pinning them in the conda env keeps the whole team — and a cold setup — on one consistent version.

## Notes
- **AWS SAM CLI stays a Homebrew install** (`brew install aws-sam-cli`) — not packaged on conda-forge. Documented as *additive* (Lambda/serverless only); Terraform remains the IaC backbone.
- **Not added to `backend/requirements.txt`** — that file is the backend's Docker runtime deps; ops CLIs would only bloat the production image.
- Safe to merge after the Dependabot sweep; no code or runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
