### PR TITLE
Multi-model Bedrock (Converse) + Nova Micro default + Generate cost panel

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -298,6 +298,7 @@ async def health():
         "fusion_enabled": _fusion_on,
         "llm_provider": llm_provider,
         "llm_backend": llm_backend,
+        "llm_model": getattr(backend, "model_id", None),
         "llm_available": is_available,
         "llm_has_api_key": bool(os.getenv("LLM_API_KEY") or os.getenv("ANTHROPIC_API_KEY")),
         "llm_has_auth_token": bool(os.getenv("LLM_AUTH_TOKEN") or os.getenv("ANTHROPIC_AUTH_TOKEN")),

--- a/backend/archimedes/services/llm_backend.py
+++ b/backend/archimedes/services/llm_backend.py
@@ -1,8 +1,8 @@
 """Provider-agnostic LLM backend factory.
 
 Reads ``LLM_PROVIDER`` ∈ {``anthropic``, ``anthropic_compatible``, ``bedrock``,
-``openai``, ``ollama``} and constructs the right backend.  Falls back to
-``CannedBackend`` when no credentials are present — loud degradation, never silent.
+``bedrock_converse``, ``openai``, ``ollama``} and constructs the right backend.
+Falls back to ``CannedBackend`` when no credentials are present — loud degradation.
 
 Back-compat: ``ANTHROPIC_*`` env vars still work this release (deprecated alias
 path, emits a WARN log).
@@ -25,6 +25,11 @@ DEFAULT_MODEL = os.getenv("LLM_MODEL", "claude-sonnet-4-20250514")
 # cheapest option (the free/default tier). Pricier, stronger models (Sonnet/Opus)
 # are available via LLM_BEDROCK_MODEL and are intended to be gated to paying users.
 DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+# Default for the Converse path (provider=bedrock_converse). Amazon Nova Micro is
+# the cheapest competitive text model on Bedrock ($0.035/$0.14 per 1M) and — being
+# AWS-native — is invokable immediately, with NO Anthropic use-case form. Overridable
+# via LLM_BEDROCK_MODEL (e.g. zai.glm-4.7-flash, deepseek.v3.2, us.meta.llama3-3-70b-instruct-v1:0).
+DEFAULT_CONVERSE_MODEL = "amazon.nova-micro-v1:0"
 MAX_TOKENS = 4096
 
 
@@ -176,7 +181,7 @@ class BedrockBackend:
         except ImportError as exc:
             logger.warning("llm: Bedrock unavailable (%s) — needs anthropic[bedrock] + boto3; canned fallback", exc)
             self._client = None
-        except Exception as exc:  # noqa: BLE001 — any client-init failure degrades loudly to canned
+        except Exception as exc:
             logger.warning("llm: Bedrock client init failed (%s); canned fallback", exc)
             self._client = None
 
@@ -204,6 +209,80 @@ class BedrockBackend:
         if served:
             self._served = str(served)
         return resp.content[0].text.strip() if resp.content else ""
+
+
+# ── AWS Bedrock via the Converse API (uniform across ALL providers, IAM auth) ──
+
+
+class BedrockConverseBackend:
+    """Bedrock **Converse** API via boto3 — one request/response shape across every
+    Bedrock provider (Amazon Nova, Meta Llama, Mistral, DeepSeek, Qwen, Z.AI GLM,
+    Moonshot Kimi, Anthropic, ...). IAM auth via the boto3 credential chain (EC2
+    instance role in prod); no API key.
+
+    Unlike the Anthropic-SDK ``BedrockBackend``, this works with the many
+    non-Anthropic models that are invokable WITHOUT the Anthropic use-case form, so
+    it serves real intelligence immediately and cheaply. Default: Amazon Nova Micro.
+    Model id from ``LLM_BEDROCK_MODEL`` (else ``DEFAULT_CONVERSE_MODEL``). This is
+    also the path a future per-user model picker rides on (one API, any model).
+    """
+
+    def __init__(self, model: str | None = None) -> None:
+        self._region = os.getenv("LLM_BEDROCK_REGION", "") or os.getenv("AWS_REGION", "") or "us-east-1"
+        self._model = model or os.getenv("LLM_BEDROCK_MODEL", "") or DEFAULT_CONVERSE_MODEL
+        self._served = self._model
+        self._client = None
+        try:
+            import boto3
+
+            if boto3.Session().get_credentials() is None:
+                logger.warning("llm: Bedrock(Converse) selected but no AWS credentials resolvable; canned fallback")
+                return
+            self._client = boto3.client("bedrock-runtime", region_name=self._region)
+        except ImportError as exc:
+            logger.warning("llm: Bedrock(Converse) unavailable (%s) — needs boto3; canned fallback", exc)
+            self._client = None
+        except Exception as exc:
+            logger.warning("llm: Bedrock(Converse) client init failed (%s); canned fallback", exc)
+            self._client = None
+
+    @property
+    def model_id(self) -> str:
+        return self._model
+
+    @property
+    def served_model(self) -> str:
+        return self._served
+
+    @property
+    def available(self) -> bool:
+        return self._client is not None
+
+    def complete(self, system: str, user: str) -> str:
+        assert self._client is not None
+        kwargs: dict = {
+            "modelId": self._model,
+            "messages": [{"role": "user", "content": [{"text": user}]}],
+            "inferenceConfig": {"maxTokens": MAX_TOKENS},
+        }
+        if system and system.strip():
+            kwargs["system"] = [{"text": system}]
+        try:
+            resp = self._client.converse(**kwargs)
+        except Exception as exc:
+            if system and "system" in str(exc).lower():
+                kwargs.pop("system", None)
+                kwargs["messages"] = [{"role": "user", "content": [{"text": f"{system}\n\n{user}"}]}]
+                resp = self._client.converse(**kwargs)
+            else:
+                raise
+        blocks = resp.get("output", {}).get("message", {}).get("content", []) or []
+        # Reasoning models may emit a reasoningContent block before the text — return
+        # the first block that actually carries text.
+        for b in blocks:
+            if isinstance(b, dict) and b.get("text"):
+                return b["text"].strip()
+        return ""
 
 
 # ── OpenAI-compatible (httpx, no SDK) ────────────────────────────────
@@ -314,7 +393,7 @@ class CannedBackend:
     def available(self) -> bool:
         return False
 
-    def complete(self, system: str, user: str) -> str:  # noqa: ARG002 — Protocol-shaped fallback; signature matches live LLM backends
+    def complete(self, system: str, user: str) -> str:
         return json.dumps(
             {
                 "fallback": True,
@@ -327,7 +406,13 @@ class CannedBackend:
 
 
 def make_llm_backend() -> (
-    AnthropicBackend | AnthropicCompatibleBackend | BedrockBackend | OpenAIBackend | OllamaBackend | CannedBackend
+    AnthropicBackend
+    | AnthropicCompatibleBackend
+    | BedrockBackend
+    | BedrockConverseBackend
+    | OpenAIBackend
+    | OllamaBackend
+    | CannedBackend
 ):
     """Construct the LLM backend from ``LLM_*`` env vars.
 
@@ -335,6 +420,8 @@ def make_llm_backend() -> (
       - ``anthropic``: Anthropic SDK with ``LLM_API_KEY``
       - ``anthropic_compatible``: Anthropic SDK with ``LLM_AUTH_TOKEN`` + ``LLM_BASE_URL``
       - ``bedrock``: Anthropic SDK over AWS Bedrock (IAM auth, no key; ``LLM_BEDROCK_MODEL``)
+      - ``bedrock_converse``: Bedrock Converse API over boto3 — ANY provider (Nova/Llama/
+        Mistral/DeepSeek/GLM/Kimi/…), IAM auth, no key (``LLM_BEDROCK_MODEL``)
       - ``openai``: httpx to OpenAI-compatible endpoint (``LLM_BASE_URL`` + ``LLM_API_KEY``)
       - ``ollama``: httpx to Ollama (``LLM_BASE_URL``, no key)
 
@@ -351,7 +438,8 @@ def make_llm_backend() -> (
     builders = {
         "anthropic": lambda: AnthropicBackend(model=model),
         "anthropic_compatible": lambda: AnthropicCompatibleBackend(model=model),
-        "bedrock": BedrockBackend,  # resolves its own Bedrock model id (not the generic LLM_MODEL default)
+        "bedrock": BedrockBackend,  # Anthropic-SDK path; resolves its own Bedrock model id
+        "bedrock_converse": BedrockConverseBackend,  # Converse API — any provider; resolves its own model id
         "openai": lambda: OpenAIBackend(model=model),
         "ollama": lambda: OllamaBackend(model=model),
     }

--- a/backend/tests/services/test_llm_backend_unification.py
+++ b/backend/tests/services/test_llm_backend_unification.py
@@ -163,6 +163,7 @@ def test_make_llm_backend_returns_a_canonical_subclass():
         AnthropicBackend,
         AnthropicCompatibleBackend,
         BedrockBackend,
+        BedrockConverseBackend,
         CannedBackend,
         OllamaBackend,
         OpenAIBackend,
@@ -181,6 +182,7 @@ def test_make_llm_backend_returns_a_canonical_subclass():
                 AnthropicBackend,
                 AnthropicCompatibleBackend,
                 BedrockBackend,
+                BedrockConverseBackend,
                 OpenAIBackend,
                 OllamaBackend,
                 CannedBackend,
@@ -269,4 +271,77 @@ def test_make_llm_backend_selects_bedrock(monkeypatch):
 
         backend = make_llm_backend()
         assert isinstance(backend, BedrockBackend)
+        assert backend.available is True
+
+
+# ── Bedrock Converse backend (multi-provider, uniform Converse API) ─────────
+
+
+def _fake_boto3_converse(creds, converse_return=None):
+    """Fake boto3 whose client('bedrock-runtime').converse returns a canned response.
+    The created client is exposed as mod._client for call-arg assertions."""
+    mod = types.ModuleType("boto3")
+    session = MagicMock()
+    session.get_credentials.return_value = creds
+    mod.Session = MagicMock(return_value=session)
+    client = MagicMock()
+    client.converse.return_value = converse_return
+    mod.client = MagicMock(return_value=client)
+    mod._client = client
+    return mod
+
+
+def test_bedrock_converse_canned_when_no_credentials():
+    with patch.dict(sys.modules, {"boto3": _fake_boto3_converse(None)}):
+        from archimedes.services.llm_backend import BedrockConverseBackend
+
+        assert BedrockConverseBackend().available is False
+
+
+def test_bedrock_converse_default_model_is_nova_micro(monkeypatch):
+    """Default Converse model is Amazon Nova Micro (cheapest, no Anthropic form)."""
+    monkeypatch.delenv("LLM_BEDROCK_MODEL", raising=False)
+    with patch.dict(sys.modules, {"boto3": _fake_boto3_converse(None)}):
+        from archimedes.services.llm_backend import DEFAULT_CONVERSE_MODEL, BedrockConverseBackend
+
+        backend = BedrockConverseBackend()
+        assert backend.model_id == DEFAULT_CONVERSE_MODEL
+        assert "nova-micro" in backend.model_id
+
+
+def test_bedrock_converse_available_and_completes(monkeypatch):
+    monkeypatch.setenv("LLM_BEDROCK_MODEL", "amazon.nova-micro-v1:0")
+    resp = {"output": {"message": {"content": [{"text": "  HELLO  "}]}}}
+    fake = _fake_boto3_converse(object(), converse_return=resp)
+    with patch.dict(sys.modules, {"boto3": fake}):
+        from archimedes.services.llm_backend import BedrockConverseBackend
+
+        backend = BedrockConverseBackend()
+        assert backend.available is True
+        assert backend.complete("be terse", "hi") == "HELLO"
+        kwargs = fake._client.converse.call_args.kwargs
+        assert kwargs["modelId"] == "amazon.nova-micro-v1:0"
+        assert kwargs["system"] == [{"text": "be terse"}]  # system passed as a Converse system block
+
+
+def test_bedrock_converse_skips_reasoning_block_and_omits_empty_system():
+    """Reasoning models emit a reasoningContent block before text; return the text.
+    And an empty system must NOT be sent as a Converse system block."""
+    resp = {"output": {"message": {"content": [{"reasoningContent": {"x": 1}}, {"text": "ANSWER"}]}}}
+    fake = _fake_boto3_converse(object(), converse_return=resp)
+    with patch.dict(sys.modules, {"boto3": fake}):
+        from archimedes.services.llm_backend import BedrockConverseBackend
+
+        assert BedrockConverseBackend().complete("", "q") == "ANSWER"
+        assert "system" not in fake._client.converse.call_args.kwargs
+
+
+def test_make_llm_backend_selects_bedrock_converse(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "bedrock_converse")
+    resp = {"output": {"message": {"content": [{"text": "ok"}]}}}
+    with patch.dict(sys.modules, {"boto3": _fake_boto3_converse(object(), converse_return=resp)}):
+        from archimedes.services.llm_backend import BedrockConverseBackend, make_llm_backend
+
+        backend = make_llm_backend()
+        assert isinstance(backend, BedrockConverseBackend)
         assert backend.available is True

--- a/docs/bedrock-model-cost-comparison.md
+++ b/docs/bedrock-model-cost-comparison.md
@@ -1,0 +1,133 @@
+# Bedrock Model Cost Comparison — us-east-1, on-demand
+
+**Generated:** 2026-06-24 · account `037613907429` · via the AWS Price List API
+(`pricing get-products --service-code AmazonBedrock`) + live `bedrock-runtime converse`
+availability probes. Prices are **standard us-east-1 on-demand, USD per 1M tokens.**
+
+## TL;DR
+
+- The **cheapest competitive text models on Bedrock are all non-Anthropic**, and — unlike
+  Anthropic models, which 404 until the one-time account **use-case form** is submitted —
+  **they are invokable immediately** (confirmed by live probe under our role).
+- So we can have a **real LLM live right now**, no waiting on the Anthropic form, by pointing
+  the backend at one of these. Anthropic (Haiku 4.5 ≈ $1/$5, Sonnet/Opus pricier) stays the
+  **premium / paid-tier** option once the form clears.
+- For **multi-model support + a user-facing cost picker**, integrate via the **Bedrock
+  Converse API** — one request/response shape across *all* providers. Our current
+  `BedrockBackend` is Anthropic-SDK-specific; a Converse-based backend unlocks model-switching
+  and the live $/1M surface in a single code path. (Roadmap T1.7-adjacent.)
+
+## Recommended "works now" picks (no form, confirmed invokable)
+
+| Model | modelId | Input $/1M | Output $/1M | Why |
+|---|---|---:|---:|---|
+| **Amazon Nova Micro** | `amazon.nova-micro-v1:0` | $0.035 | $0.140 | Cheapest; AWS-native; fast |
+| **Z.AI GLM 4.7 Flash** | `zai.glm-4.7-flash` | $0.035 | $0.200 | Team has GLM experience |
+| **Amazon Nova Lite** | `amazon.nova-lite-v1:0` | $0.060 | $0.240 | Step up from Micro |
+| **Moonshot Kimi K2.5** | `moonshotai.kimi-k2.5` | $0.300 | $1.500 | StockBench top-tier reasoner |
+| **DeepSeek v3.2** | `deepseek.v3.2` | $0.310 | $0.925 | Strong cheap reasoner |
+| **Meta Llama 3.3 70B** | `us.meta.llama3-3-70b-instruct-v1:0` | $0.720 | $0.720 | Open-weight workhorse |
+
+Also confirmed working now: Amazon Nova Pro, Llama 4 Scout, Mistral Small, Qwen3 32B.
+OpenAI `gpt-oss-20b` responds but returns a reasoning-shaped payload (needs different parsing).
+
+> **For comparison — our current default, Anthropic Haiku 4.5**, is ≈ **$1.00 in / $5.00 out**
+> per 1M (from the agreement rate card; batch ≈ $0.50/$2.50). It's ~28× the input cost of Nova
+> Micro — good as a premium tier, overkill as the free default.
+
+## Full on-demand price table (74 text models, cheapest first)
+
+Blended = input×0.75 + output×0.25 (a generation-skewed proxy). Sorted by blended.
+
+| # | Provider | Model | Input $/1M | Output $/1M | Blended |
+|---|----------|-------|-----------:|------------:|--------:|
+| 1 | Mistral | Voxtral Mini 1.0 | $0.020 | $0.020 | $0.020 |
+| 2 | Google | Gemma 3 4B | $0.020 | $0.040 | $0.025 |
+| 3 | Google | google.gemma-4-e2b | $0.020 | $0.040 | $0.025 |
+| 4 | OpenAI | GPT OSS Safeguard 20B | $0.030 | $0.100 | $0.048 |
+| 5 | Mistral | Ministral 3B 3.0 | $0.050 | $0.050 | $0.050 |
+| 6 | Nvidia | Nemotron Nano 3 30B | $0.030 | $0.120 | $0.053 |
+| 7 | Nvidia | NVIDIA Nemotron Nano 2 | $0.030 | $0.120 | $0.053 |
+| 8 | Amazon | Nova Micro | $0.035 | $0.140 | $0.061 |
+| 9 | OpenAI | gpt-oss-20b | $0.035 | $0.150 | $0.064 |
+| 10 | Mistral | Ministral 8B 3.0 | $0.070 | $0.070 | $0.070 |
+| 11 | Mistral | Voxtral Small 1.0 | $0.050 | $0.150 | $0.075 |
+| 12 | Google | Gemma 3 12B | $0.050 | $0.150 | $0.075 |
+| 13 | Z.AI | GLM 4.7 Flash | $0.035 | $0.200 | $0.076 |
+| 14 | Google | google.gemma-4-26b-a4b | $0.065 | $0.200 | $0.099 |
+| 15 | Mistral | Ministral 14B 3.0 | $0.100 | $0.100 | $0.100 |
+| 16 | Meta | Llama 3.2 1B | $0.100 | $0.100 | $0.100 |
+| 17 | Google | google.gemma-4-31b | $0.070 | $0.200 | $0.102 |
+| 18 | Amazon | Nova Lite | $0.060 | $0.240 | $0.105 |
+| 19 | Amazon | Nova Sonic | $0.060 | $0.240 | $0.105 |
+| 20 | OpenAI | GPT OSS Safeguard 120B | $0.070 | $0.300 | $0.128 |
+| 21 | OpenAI | gpt-oss-120b | $0.075 | $0.300 | $0.131 |
+| 22 | Qwen | Qwen3 Coder 30B A3B | $0.075 | $0.300 | $0.131 |
+| 23 | Qwen | Qwen3 32B | $0.075 | $0.300 | $0.131 |
+| 24 | Writer | Writer Palmyra Vision 7B | $0.075 | $0.300 | $0.131 |
+| 25 | Nvidia | NVIDIA Nemotron 3 Super 120B A12B | $0.075 | $0.325 | $0.138 |
+| 26 | Google | Gemma 3 27B | $0.120 | $0.190 | $0.138 |
+| 27 | Meta | Llama 3.2 3B | $0.150 | $0.150 | $0.150 |
+| 28 | Nvidia | NVIDIA Nemotron Nano 2 VL | $0.100 | $0.300 | $0.150 |
+| 29 | Meta | Llama 3.2 11B | $0.160 | $0.160 | $0.160 |
+| 30 | Mistral | Mistral 7B | $0.150 | $0.200 | $0.162 |
+| 31 | Qwen | Qwen3 235B A22B 2507 | $0.110 | $0.440 | $0.193 |
+| 32 | Qwen | Qwen3 Next 80B A3B | $0.070 | $0.600 | $0.202 |
+| 33 | Meta | Llama 3.1 8B | $0.220 | $0.220 | $0.220 |
+| 34 | Anthropic | Claude 3 Haiku | $0.250 | $1.250 | $0.250* |
+| 35 | Minimax AI | Minimax M2.1 | $0.150 | $0.600 | $0.262 |
+| 36 | Minimax AI | Minimax M2 | $0.150 | $0.600 | $0.262 |
+| 37 | Minimax AI | MiniMax M2.5 | $0.150 | $0.600 | $0.262 |
+| 38 | Meta | Llama 4 Scout 17B | $0.170 | $0.660 | $0.292 |
+| 39 | Qwen | Qwen3 Coder Next | $0.250 | $0.600 | $0.338 |
+| 40 | Mistral | Magistral Small 1.2 | $0.250 | $0.750 | $0.375 |
+| 41 | Mistral | Mistral Large 3 | $0.250 | $0.750 | $0.375 |
+| 42 | Meta | Llama 3 8B | $0.300 | $0.600 | $0.375 |
+| 43 | Qwen | Qwen3 Coder 480B A35B | $0.225 | $0.900 | $0.394 |
+| 44 | Mistral AI | Devstral | $0.200 | $1.000 | $0.400 |
+| 45 | Meta | Llama 4 Maverick 17B | $0.240 | $0.970 | $0.423 |
+| 46 | DeepSeek | DeepSeek V3.1 | $0.290 | $0.840 | $0.427 |
+| 47 | DeepSeek | DeepSeek v3.2 | $0.310 | $0.925 | $0.464 |
+| 48 | Amazon | Nova 2.0 Lite | $0.165 | $1.375 | $0.468 |
+| 49 | Z.AI | GLM 4.7 | $0.300 | $1.100 | $0.500 |
+| 50 | Amazon | Nova 2.0 Omni | $0.200 | $1.400 | $0.500 |
+| 51 | Mistral | Mixtral 8x7B | $0.450 | $0.700 | $0.512 |
+| 52 | Qwen | Qwen3 VL 235B A22B | $0.260 | $1.330 | $0.527 |
+| 53 | Moonshot AI | Kimi K2 Thinking | $0.300 | $1.250 | $0.537 |
+| 54 | Kimi AI | Kimi K2 Thinking | $0.300 | $1.250 | $0.537 |
+| 55 | Moonshot AI | Kimi K2.5 | $0.300 | $1.500 | $0.600 |
+| 56 | Amazon | Nova Pro | $0.400 | $1.600 | $0.700 |
+| 57 | Meta | Llama 3.2 90B | $0.720 | $0.720 | $0.720 |
+| 58 | Meta | Llama 3.1 70B | $0.720 | $0.720 | $0.720 |
+| 59 | Meta | Llama 3.3 70B | $0.720 | $0.720 | $0.720 |
+| 60 | Z.AI | GLM 5 | $0.500 | $1.600 | $0.775 |
+| 61 | Anthropic | Claude Instant | $0.800 | $2.400 | $0.800* |
+| 62 | Meta | Llama 3.1 70B Latency Optimized | $0.900 | $0.900 | $0.900 |
+| 63 | Amazon | Nova Sonic 2.0 | $0.330 | $2.750 | $0.935 |
+| 64 | Mistral | Mistral Small | $1.000 | $3.000 | $1.500 |
+| 65 | Amazon | Nova Pro Latency Optimized | $1.000 | $4.000 | $1.750 |
+| 66 | Amazon | Nova 2.0 Pro | $0.688 | $5.500 | $1.891 |
+| 67 | DeepSeek | R1 | $1.350 | $5.400 | $2.363 |
+| 68 | Amazon | Nova Premier | $1.250 | $6.250 | $2.500 |
+| 69 | Meta | Llama 3 70B | $2.650 | $3.500 | $2.862 |
+| 70 | Mistral | Pixtral Large 25.02 | $2.000 | $6.000 | $3.000 |
+| 71 | Anthropic | Claude 3 Sonnet | $3.000 | $15.000 | $3.000* |
+| 72 | Mistral | Mistral Large | $4.000 | $12.000 | $6.000 |
+| 73 | Anthropic | Claude 2.0 | $8.000 | $24.000 | $8.000* |
+| 74 | Anthropic | Claude 2.1 | $8.000 | $24.000 | $8.000* |
+
+\* Anthropic output rates and the **newest** Anthropic models (Haiku 4.5 ≈ $1/$5, Sonnet 4.6,
+Opus 4.8) are INFERENCE_PROFILE-only and priced via the agreement rate card, not this
+on-demand list — so they're under-represented above. They're the premium tier regardless.
+
+## Notes / caveats
+
+- **Batch** inference is ~50% of on-demand for most models. **Cross-region/"Global"** inference-
+  profile rates can differ slightly from the base us-east-1 rate shown.
+- Some entries are duplicated by AWS under multiple provider labels (e.g. Kimi under "Moonshot AI"
+  and "Kimi AI"); both are the same model.
+- "Works now" = returned a valid `converse` response under our role with no agreement/form.
+  Anthropic models return `404 — use case details not submitted` until the form clears.
+- **Product angle:** this is exactly the data to power a **per-model cost/quality picker** for
+  users (pick by budget; show live $/1M). Pair the model list (`bedrock list-foundation-models`)
+  with the Price List API and a periodic refresh.

--- a/infra/ec2_iam.tf
+++ b/infra/ec2_iam.tf
@@ -60,12 +60,16 @@ resource "aws_iam_role_policy" "ec2_ssm_params" {
   })
 }
 
-# Invoke Anthropic models on Bedrock (IAM auth — no API key). The LLM backend
-# (services/llm_backend.BedrockBackend) calls this via the instance role. Scoped
-# to Anthropic foundation models in ALL regions (cross-region inference profiles
-# like `us.anthropic.*` route the call to us-east-1/2 + us-west-2, so InvokeModel
-# is checked against both the inference-profile ARN and the destination
-# foundation-model ARNs) plus this account's inference profiles.
+# Invoke Bedrock foundation models (IAM auth — no API key). The LLM backends call
+# this via the instance role: services/llm_backend.BedrockBackend (Anthropic SDK)
+# and BedrockConverseBackend (the Converse API, for ANY provider — Amazon Nova,
+# Meta Llama, Mistral, DeepSeek, Qwen, Z.AI GLM, Moonshot Kimi, Anthropic, ...).
+# Scoped to foundation models in ALL regions (cross-region inference profiles like
+# `us.*` route the call to us-east-1/2 + us-west-2, so InvokeModel is checked
+# against both the inference-profile ARN and the destination foundation-model
+# ARNs) plus this account's inference profiles. Broad across providers because the
+# multi-model cost picker can target any of them; spend is bounded by the backstop
+# below, not by this resource scope.
 #
 # COST BACKSTOP: the budget guardrail (infra/scripts/setup-budgets.sh) attaches a
 # Bedrock-DENY policy to THIS role when the cost budget trips. An explicit Deny
@@ -77,11 +81,11 @@ resource "aws_iam_role_policy" "ec2_bedrock_invoke" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "InvokeAnthropicOnBedrock"
+        Sid    = "InvokeBedrockFoundationModels"
         Effect = "Allow"
         Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"]
         Resource = [
-          "arn:aws:bedrock:*::foundation-model/anthropic.*",
+          "arn:aws:bedrock:*::foundation-model/*",
           "arn:aws:bedrock:*:037613907429:inference-profile/*"
         ]
       }

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -4,7 +4,6 @@ import Layout from './components/Layout'
 import Landing from './components/Landing'
 import Explore from './components/Explore'
 import Generate from './components/Generate'
-import ModelCostPanel from './components/ModelCostPanel'
 import Portfolio from './components/Portfolio'
 import Learnings from './components/Learnings'
 import Strategies from './components/Strategies'   // serves /library route ("Example Library")
@@ -206,20 +205,14 @@ export default function App() {
       case 'landing':     return <Landing onNavigate={navigateToPage} />
       case 'explore':      return <Explore />
       case 'generate':     return (
-        <>
-          {/* Model & cost transparency — above the wallet gate so a prospective
-              user sees which LLM is running + the cost landscape before
-              connecting. Collapsed by default (a thin bar). */}
-          <ModelCostPanel />
-          <WalletGate
-            walletAddr={walletAddr}
-            pageName="Generate"
-            description="Generate uses an LLM-powered multi-agent pipeline against a 1,014-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
-            onConnect={openConnectModal}
-          >
-            <Generate onNavigate={navigateToPage} />
-          </WalletGate>
-        </>
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Generate"
+          description="Generate uses an LLM-powered multi-agent pipeline against a 1,014-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
+          onConnect={openConnectModal}
+        >
+          <Generate onNavigate={navigateToPage} />
+        </WalletGate>
       )
       case 'architecture': return <Architecture onNavigate={navigateToPage} />
       case 'library':      return (

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -4,6 +4,7 @@ import Layout from './components/Layout'
 import Landing from './components/Landing'
 import Explore from './components/Explore'
 import Generate from './components/Generate'
+import ModelCostPanel from './components/ModelCostPanel'
 import Portfolio from './components/Portfolio'
 import Learnings from './components/Learnings'
 import Strategies from './components/Strategies'   // serves /library route ("Example Library")
@@ -205,14 +206,20 @@ export default function App() {
       case 'landing':     return <Landing onNavigate={navigateToPage} />
       case 'explore':      return <Explore />
       case 'generate':     return (
-        <WalletGate
-          walletAddr={walletAddr}
-          pageName="Generate"
-          description="Generate uses an LLM-powered multi-agent pipeline against a 1,014-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
-          onConnect={openConnectModal}
-        >
-          <Generate onNavigate={navigateToPage} />
-        </WalletGate>
+        <>
+          {/* Model & cost transparency — above the wallet gate so a prospective
+              user sees which LLM is running + the cost landscape before
+              connecting. Collapsed by default (a thin bar). */}
+          <ModelCostPanel />
+          <WalletGate
+            walletAddr={walletAddr}
+            pageName="Generate"
+            description="Generate uses an LLM-powered multi-agent pipeline against a 1,014-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
+            onConnect={openConnectModal}
+          >
+            <Generate onNavigate={navigateToPage} />
+          </WalletGate>
+        </>
       )
       case 'architecture': return <Architecture onNavigate={navigateToPage} />
       case 'library':      return (

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -4,6 +4,7 @@ import GenerationStream from './GenerationStream'
 import GenerationStatus from './GenerationStatus'
 import FusionResult from './FusionResult'
 import PortfolioAdvisor from './PortfolioAdvisor'
+import ModelCostPanel from './ModelCostPanel'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -397,6 +398,12 @@ export default function Generate({ onNavigate }) {
             <div className="info-box warning mt-3">{startError}</div>
           )}
         </div>
+      )}
+
+      {/* ── Model & cost transparency (which LLM is running + the cost landscape).
+          Inside the wallet gate — only shown to connected users. ── */}
+      {!jobId && !fusionJobId && !fusionResult && (
+        <ModelCostPanel />
       )}
 
       {/* ── SSE STREAM (agent + architect paths) ── */}

--- a/ui/src/components/ModelCostPanel.jsx
+++ b/ui/src/components/ModelCostPanel.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from 'react'
+import { apiGet } from '../api'
+import pricing from '../data/modelPricing.json'
+
+// Cost-comparison panel for the Generate page. Surfaces the Bedrock model cost
+// landscape (us-east-1 on-demand, $/1M tokens) and highlights the model the
+// backend is actually using right now (from /health → llm_model). Collapsible so
+// it stays out of the way until a user wants to compare costs. The data is a
+// snapshot (ui/src/data/modelPricing.json); the active row is live.
+
+const blended = (m) => m.input * 0.75 + m.output * 0.25
+const fmt = (x) => (x == null ? '—' : `$${x.toFixed(x < 1 ? 3 : 2)}`)
+
+export default function ModelCostPanel() {
+  const [open, setOpen] = useState(false)
+  const [activeModel, setActiveModel] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    apiGet('/health')
+      .then((d) => { if (!cancelled) setActiveModel(d?.llm_model || null) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
+  const rows = useMemo(() => [...pricing.models].sort((a, b) => blended(a) - blended(b)), [])
+  const active = rows.find((m) => m.model_id && m.model_id === activeModel)
+
+  return (
+    <div className="card mb-4" style={{ padding: 0, overflow: 'hidden' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        style={{
+          display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between',
+          gap: 12, padding: '12px 18px', background: 'transparent', border: 'none',
+          cursor: 'pointer', textAlign: 'left', color: 'inherit',
+        }}
+      >
+        <div>
+          <div className="label" style={{ marginBottom: 2 }}>Model &amp; cost</div>
+          <div className="caption" style={{ color: 'var(--text-3)' }}>
+            {active ? (
+              <>Running <strong style={{ color: 'var(--text-1)' }}>{active.provider} {active.name}</strong>
+                {' · '}{fmt(active.input)} in / {fmt(active.output)} out per 1M tokens</>
+            ) : activeModel ? (
+              <>Running <strong style={{ color: 'var(--text-1)' }}>{activeModel}</strong></>
+            ) : (
+              <>Compare model costs across {rows.length} options on Bedrock</>
+            )}
+          </div>
+        </div>
+        <span
+          className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-4 h-4`}
+          style={{ color: 'var(--text-3)', flexShrink: 0 }}
+        />
+      </button>
+
+      {open && (
+        <div style={{ padding: '6px 18px 18px', borderTop: '1px solid var(--glass-border)' }}>
+          <p className="caption mb-3" style={{ color: 'var(--text-3)' }}>
+            {pricing.unit} · {pricing.region} · snapshot {pricing.generated}. Cheaper is usually
+            less capable — pick for your budget. <strong style={{ color: '#3fb950' }}>✓</strong> = invokable
+            now; <strong>premium</strong> models need a one-time account activation.
+          </p>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+              <thead>
+                <tr style={{ color: 'var(--text-3)', textAlign: 'left' }}>
+                  <th style={{ padding: '6px 8px', fontWeight: 500 }}>Model</th>
+                  <th style={{ padding: '6px 8px', fontWeight: 500, textAlign: 'right' }}>In $/1M</th>
+                  <th style={{ padding: '6px 8px', fontWeight: 500, textAlign: 'right' }}>Out $/1M</th>
+                  <th style={{ padding: '6px 8px', fontWeight: 500 }} />
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((m) => {
+                  const isActive = m.model_id && m.model_id === activeModel
+                  return (
+                    <tr
+                      key={m.model_id || m.name}
+                      style={{
+                        borderTop: '1px solid var(--glass-border)',
+                        background: isActive ? 'color-mix(in srgb, var(--accent) 12%, transparent)' : 'transparent',
+                      }}
+                    >
+                      <td style={{ padding: '7px 8px', color: 'var(--text-1)' }}>
+                        <span style={{ fontWeight: isActive ? 600 : 400 }}>{m.name}</span>
+                        <span className="caption" style={{ color: 'var(--text-3)', marginLeft: 6 }}>{m.provider}</span>
+                      </td>
+                      <td style={{ padding: '7px 8px', textAlign: 'right', color: 'var(--text-1)', fontVariantNumeric: 'tabular-nums' }}>{fmt(m.input)}</td>
+                      <td style={{ padding: '7px 8px', textAlign: 'right', color: 'var(--text-1)', fontVariantNumeric: 'tabular-nums' }}>{fmt(m.output)}</td>
+                      <td style={{ padding: '7px 8px', whiteSpace: 'nowrap' }}>
+                        {isActive && <span className="tag tag-accent" style={{ marginRight: 4 }}>active</span>}
+                        {m.recommended && !isActive && (
+                          <span style={{ color: 'var(--accent)', marginRight: 4 }} title="Recommended cheap pick">★</span>
+                        )}
+                        {m.works_now ? (
+                          <span style={{ color: '#3fb950' }} title="Invokable now">✓</span>
+                        ) : (
+                          <span className="caption" style={{ color: 'var(--text-3)' }}>premium</span>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          <p className="caption mt-3" style={{ color: 'var(--text-3)' }}>{pricing.note}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/data/modelPricing.json
+++ b/ui/src/data/modelPricing.json
@@ -1,0 +1,23 @@
+{
+  "generated": "2026-06-24",
+  "region": "us-east-1",
+  "unit": "USD per 1M tokens · standard on-demand",
+  "source": "AWS Price List API + agreement rate cards; live Converse availability probes",
+  "note": "Snapshot. Batch inference is ~50% cheaper. Anthropic models require a one-time account use-case form before they invoke; everything marked ✓ works immediately.",
+  "models": [
+    { "provider": "Amazon", "name": "Nova Micro", "model_id": "amazon.nova-micro-v1:0", "input": 0.035, "output": 0.14, "works_now": true, "recommended": true },
+    { "provider": "OpenAI", "name": "gpt-oss-20b", "model_id": "openai.gpt-oss-20b-1:0", "input": 0.035, "output": 0.15, "works_now": true },
+    { "provider": "Z.AI", "name": "GLM 4.7 Flash", "model_id": "zai.glm-4.7-flash", "input": 0.035, "output": 0.20, "works_now": true, "recommended": true },
+    { "provider": "Amazon", "name": "Nova Lite", "model_id": "amazon.nova-lite-v1:0", "input": 0.06, "output": 0.24, "works_now": true, "recommended": true },
+    { "provider": "Qwen", "name": "Qwen3 32B", "model_id": "qwen.qwen3-32b-v1:0", "input": 0.075, "output": 0.30, "works_now": true },
+    { "provider": "Meta", "name": "Llama 4 Scout 17B", "model_id": "us.meta.llama4-scout-17b-instruct-v1:0", "input": 0.17, "output": 0.66, "works_now": true },
+    { "provider": "DeepSeek", "name": "DeepSeek v3.2", "model_id": "deepseek.v3.2", "input": 0.31, "output": 0.925, "works_now": true, "recommended": true },
+    { "provider": "Z.AI", "name": "GLM 4.7", "model_id": "zai.glm-4.7", "input": 0.30, "output": 1.10, "works_now": true },
+    { "provider": "Moonshot", "name": "Kimi K2.5", "model_id": "moonshotai.kimi-k2.5", "input": 0.30, "output": 1.50, "works_now": true, "recommended": true },
+    { "provider": "Amazon", "name": "Nova Pro", "model_id": "amazon.nova-pro-v1:0", "input": 0.40, "output": 1.60, "works_now": true },
+    { "provider": "Meta", "name": "Llama 3.3 70B", "model_id": "us.meta.llama3-3-70b-instruct-v1:0", "input": 0.72, "output": 0.72, "works_now": true },
+    { "provider": "Mistral", "name": "Mistral Small", "model_id": "mistral.mistral-small-2402-v1:0", "input": 1.0, "output": 3.0, "works_now": true },
+    { "provider": "Anthropic", "name": "Claude Haiku 4.5", "model_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0", "input": 1.0, "output": 5.0, "works_now": false, "premium": true },
+    { "provider": "Anthropic", "name": "Claude Sonnet 4.6", "model_id": "us.anthropic.claude-sonnet-4-6", "input": 3.0, "output": 15.0, "works_now": false, "premium": true }
+  ]
+}


### PR DESCRIPTION
## Summary

Gives Archimedes **real, cheap LLM intelligence today** (no waiting on the Anthropic use-case form) and **surfaces the model cost landscape to users** on the Generate page.

- **`BedrockConverseBackend`** (`LLM_PROVIDER=bedrock_converse`) — boto3 `converse`, one request/response shape across **every** Bedrock provider (Amazon Nova, Meta Llama, Mistral, DeepSeek, Qwen, Z.AI GLM, Moonshot Kimi, Anthropic, …). IAM auth via the EC2 instance role; no API key.
- **Live default = Amazon Nova Micro** (`amazon.nova-micro-v1:0`, $0.035/$0.14 per 1M) — invokable immediately. Non-Anthropic models skip the Anthropic account use-case form; Anthropic stays the premium tier once that form clears.
- **`ModelCostPanel`** on the Generate page (behind the wallet gate) — a collapsible "Model & cost" card showing the **live active model** (from `/health`) + a cost-sorted table of 14 models, with ✓ = invokable-now, ★ = recommended, `premium` = form-gated Anthropic.

## What changed

**Backend**
- `services/llm_backend.py`: `BedrockConverseBackend` + factory wiring (`bedrock_converse`); `DEFAULT_CONVERSE_MODEL=amazon.nova-micro-v1:0`. Handles reasoning-model content blocks; folds a rejected `system` block into the user turn on retry; loud canned fallback when creds/SDK absent.
- `main.py`: `/health` now reports `llm_model` (active model id) for the UI.
- `tests/services/test_llm_backend_unification.py`: 5 hermetic tests (fake boto3 — no SDK/creds/network). **16 passed.**

**Infra**
- `infra/ec2_iam.tf`: broaden the EC2 role's Bedrock invoke policy from `anthropic.*` to all foundation models (the multi-model picker can target any provider). Spend stays bounded by the budget **Bedrock-DENY** backstop. Applied live (`put-role-policy`) + in Terraform.

**UI**
- `components/ModelCostPanel.jsx` + `data/modelPricing.json` (snapshot from the AWS Price List API + agreement rate cards + live Converse probes). Rendered inside `Generate.jsx` (gated).
- `docs/bedrock-model-cost-comparison.md`: full 74-model survey.

## Verified live (archimedes-arc.com)
- `/health` → `llm_provider=bedrock_converse`, `llm_model=amazon.nova-micro-v1:0`, `llm_available=true`.
- End-to-end completion via the instance role returns real output (`LIVE_OK`).
- Cost panel renders for connected users; **hidden** on the pre-connect "Connect to view Generate" screen.
- Local `eslint` + `vite build` clean.

## Notes
- **Stacks on PR #716** (AWS migration) — depends on its `BedrockBackend` + new account/IAM. Base is `aws-architecture-revival`; GitHub will retarget to `main` once #716 merges.
- Per-user model selection (let users pick from this table, tier-gate premium models) is the natural T1.7-adjacent follow-up the Converse path enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)