### PR TITLE
Fix Circle wallet: sign into a specific existing wallet (discoverable passkey picker)

### DIFF
--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -73,10 +73,16 @@ function saveCredential(credential) {
 // [a-zA-Z0-9_@.:+-] constraints. Not persisted: discoverable login needs no
 // username, so there is nothing to remember between sessions.
 function newUniqueUsername() {
-  const suffix = (crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`)
-    .replace(/-/g, '')
-    .slice(0, 12)
-  return `archimedes-${suffix}`
+  // Cryptographically secure 12-hex-char suffix. `crypto` is always present in
+  // the secure contexts where WebAuthn works, so randomUUID is the happy path;
+  // getRandomValues is the fallback for engines lacking randomUUID. No
+  // Math.random fallback — it is not cryptographically secure and CodeQL
+  // (js/insecure-randomness) rightly flags it in this credential-creation path.
+  const uuid = crypto.randomUUID?.()
+  if (uuid) return `archimedes-${uuid.replace(/-/g, '').slice(0, 12)}`
+  const bytes = crypto.getRandomValues(new Uint8Array(6))
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `archimedes-${hex}`
 }
 
 export function clearCircleSession() {

--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -42,9 +42,10 @@ const arcTestnet = {
 // Demo-grade persistence. Per Circle docs, production should use httpOnly
 // cookies to mitigate XSS credential theft — out of scope for hackathon demo.
 const CREDENTIAL_STORAGE_KEY = 'archimedes_circle_credential'
-// Per-device username so Circle's server-side uniqueness check doesn't lock
-// out everyone after the first registrant (see issue #367). Generated on
-// first use; same key reused across sessions so MSCA address stays stable.
+// Legacy: older builds persisted a per-device username here. Registration now
+// generates a fresh unique username per wallet (newUniqueUsername) and login is
+// discoverable (no username), so nothing is written here anymore — the key is
+// retained only so clearCircleSession() can purge values left by old builds.
 const USERNAME_STORAGE_KEY = 'archimedes_circle_username'
 
 // True if a CLIENT_KEY was supplied at build time. The modal hides the
@@ -66,23 +67,16 @@ function saveCredential(credential) {
   } catch { /* storage unavailable */ }
 }
 
-// Returns the per-device username, generating + persisting one on first use.
-// Format: `archimedes-<8 hex chars>` — within Circle's 5-50 char and
-// [a-zA-Z0-9_@.:+-] constraints; 8 hex = 4 billion namespaces, collision-free
-// in practice across a hackathon team and any number of judges.
-function getOrCreateUsername() {
-  try {
-    const existing = localStorage.getItem(USERNAME_STORAGE_KEY)
-    if (existing) return existing
-    const suffix = (crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`)
-      .replace(/-/g, '')
-      .slice(0, 8)
-    const fresh = `archimedes-${suffix}`
-    localStorage.setItem(USERNAME_STORAGE_KEY, fresh)
-    return fresh
-  } catch {
-    return `archimedes-${Date.now()}`
-  }
+// A fresh, UNIQUE username for each Register (new wallet). Circle's server
+// rejects duplicate usernames, so reusing one would block creating a second
+// wallet. Format: `archimedes-<12 hex chars>` — within Circle's 5-50 char and
+// [a-zA-Z0-9_@.:+-] constraints. Not persisted: discoverable login needs no
+// username, so there is nothing to remember between sessions.
+function newUniqueUsername() {
+  const suffix = (crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`)
+    .replace(/-/g, '')
+    .slice(0, 12)
+  return `archimedes-${suffix}`
 }
 
 export function clearCircleSession() {
@@ -120,71 +114,48 @@ function friendlyPasskeyError(err) {
   return msg || 'Passkey sign-in failed.'
 }
 
-// Single entry point for both flows. The caller passes `mode = 'register'`
-// for a new user; we default to 'login' if we already have a stored
-// credential. Returns the smart account + its address + the credential
-// (also persisted to localStorage for next-session re-login).
+// Connect a Circle Modular Wallet via passkey. Two EXPLICIT flows — the caller
+// chooses; we never auto-decide (auto-deciding is what minted a brand-new
+// wallet on every fresh browser, since "no cached credential" fell through to
+// Register):
 //
-// Throws standard WebAuthn DOMException errors on user cancellation
-// (NotAllowedError) or domain mismatch (SecurityError) — caller should
-// catch and surface a friendly message.
-// Username constraint per Circle API: 5-50 chars, [a-zA-Z0-9_@.:+-]+ only.
-// Spaces are rejected; 'Archimedes user' (the old default) failed every
-// first-time signup with "The username is invalid."
-// Username is per-device (see getOrCreateUsername) so Circle's server-side
-// uniqueness check doesn't collide across teammates / judges — issue #367.
-export async function connectCirclePasskey({ mode = 'auto', username } = {}) {
+//   - mode 'login'    → DISCOVERABLE login. Omit both username and credentialId
+//     so the browser shows its native passkey picker listing EVERY passkey
+//     registered for this origin. The user picks one; its public key
+//     deterministically derives that wallet's MSCA address. This is how a user
+//     signs back into a SPECIFIC existing wallet (and recovers it on a fresh
+//     browser / device).
+//   - mode 'register' → CREATE a new wallet: register a fresh passkey under a
+//     unique username (Circle rejects duplicate usernames). New credential →
+//     new MSCA address.
+//
+// Returns the smart account + address + credential (persisted to localStorage
+// for silent next-session rehydrate — see rehydrateSmartAccount). Throws a
+// friendly message on WebAuthn cancellation / domain mismatch.
+export async function connectCirclePasskey({ mode = 'login' } = {}) {
   if (!circlePasskeyEnabled()) {
     throw new Error('Circle passkey wallet is not configured (missing VITE_CIRCLE_CLIENT_KEY).')
   }
 
-  const resolvedUsername = username ?? getOrCreateUsername()
-  const stored = loadStoredCredential()
-  let resolvedMode = mode === 'auto'
-    ? (stored ? WebAuthnMode.Login : WebAuthnMode.Register)
-    : (mode === 'login' ? WebAuthnMode.Login : WebAuthnMode.Register)
-
   // Passkey transport handles WebAuthn challenge issuance + verification.
   const passkeyTransport = toPasskeyTransport(CLIENT_URL, CLIENT_KEY)
 
-  // Either issue a new P256 credential (Register) OR re-authenticate an
-  // existing one (Login). Browser prompts the user for biometrics here.
+  // Browser prompts the user for biometrics here. Register issues a new P256
+  // credential under a unique username; Login is discoverable (no username, no
+  // credentialId) so the browser surfaces all passkeys for this origin to pick.
   let credential
   try {
-    credential = await toWebAuthnCredential({
-      transport: passkeyTransport,
-      mode: resolvedMode,
-      username: resolvedUsername,
-      credentialId: resolvedMode === WebAuthnMode.Login ? stored?.id : undefined,
-    })
+    credential = await toWebAuthnCredential(
+      mode === 'register'
+        ? { transport: passkeyTransport, mode: WebAuthnMode.Register, username: newUniqueUsername() }
+        : { transport: passkeyTransport, mode: WebAuthnMode.Login },
+    )
   } catch (err) {
-    // "Username is duplicated" — Circle server already has a credential for
-    // this username, but our localStorage is empty (typical: Safari ITP
-    // purged it, or user switched browsers). Retry as Login WITHOUT a
-    // credentialId — WebAuthn surfaces the user's existing passkeys for
-    // this origin via discoverable credentials, and the user re-auths.
-    // Only auto-retry when the caller didn't pin a specific mode.
-    const msg = String(err?.message ?? err ?? '')
-    const isDuplicate = /username is duplicated/i.test(msg)
-    if (mode === 'auto' && resolvedMode === WebAuthnMode.Register && isDuplicate) {
-      resolvedMode = WebAuthnMode.Login
-      try {
-        credential = await toWebAuthnCredential({
-          transport: passkeyTransport,
-          mode: WebAuthnMode.Login,
-          username: resolvedUsername,
-        })
-      } catch (retryErr) {
-        throw new Error(friendlyPasskeyError(retryErr), { cause: retryErr })
-      }
-    } else {
-      throw new Error(friendlyPasskeyError(err), { cause: err })
-    }
+    throw new Error(friendlyPasskeyError(err), { cause: err })
   }
 
-  // Persist for next-session login. Stores the credential ID + public key,
-  // NOT the private key (the private key lives in the device's secure
-  // enclave and never leaves it).
+  // Persist the credential (id + public key, NOT the private key — that stays
+  // in the device's secure enclave) so we can silently rehydrate next session.
   saveCredential(credential)
 
   // Modular transport handles bundler RPC + chain-specific calls for the
@@ -192,9 +163,9 @@ export async function connectCirclePasskey({ mode = 'auto', username } = {}) {
   const modularTransport = toModularTransport(`${CLIENT_URL}/arcTestnet`, CLIENT_KEY)
   const client = createPublicClient({ chain: arcTestnet, transport: modularTransport })
 
-  // Derive a WebAuthnAccount viem account from the credential, then turn
-  // it into a Circle smart account. The MSCA address is deterministic
-  // from the credential's public key — same passkey → same address.
+  // Derive a WebAuthnAccount viem account from the credential, then turn it
+  // into a Circle smart account. The MSCA address is deterministic from the
+  // credential's public key — same passkey → same wallet address.
   const owner = toWebAuthnAccount({ credential })
   const smartAccount = await toCircleSmartAccount({ client, owner })
 
@@ -203,7 +174,7 @@ export async function connectCirclePasskey({ mode = 'auto', username } = {}) {
     smartAccount,
     client,
     credential,
-    mode: resolvedMode,
+    mode,
   }
 }
 

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -91,11 +91,11 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
     }
   }
 
-  const handleConnect = async (providerId) => {
+  const handleConnect = async (providerId, opts) => {
     setBusy(true)
     setError('')
     try {
-      const result = await connectWallet(providerId)
+      const result = await connectWallet(providerId, opts)
 
       // SIWE: prove wallet ownership via signature (EIP-4361)
       try {
@@ -354,34 +354,68 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
                           <span style={{ flex: 1, height: 1, background: 'var(--glass-border)' }} />
                         </div>
                       )}
-                      <button className="wallet-option" onClick={() => handleConnect(p.id)} disabled={busy}>
-                        {p.iconDataUri ? (
-                          <img
-                            src={p.iconDataUri}
-                            alt=""
-                            width={20}
-                            height={20}
-                            style={{ borderRadius: 4 }}
-                          />
-                        ) : (
-                          <span className={`wallet-icon ${p.icon} w-5 h-5`} />
-                        )}
-                        {p.id === CIRCLE_PROVIDER_ID ? (
-                          <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2, flex: 1 }}>
-                            <span style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
-                              <span>{p.name}</span>
-
+                      {p.id === CIRCLE_PROVIDER_ID ? (
+                        // Circle Modular Wallets — lead with the Circle ecosystem,
+                        // then two EXPLICIT choices so users can pick a specific
+                        // existing wallet (discoverable passkey picker) instead of
+                        // always minting a new one.
+                        <div
+                          style={{
+                            border: '1px solid var(--glass-border)',
+                            borderRadius: 10,
+                            padding: 12,
+                            background: 'var(--surface-2)',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 10,
+                          }}
+                        >
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                            {p.iconDataUri ? (
+                              <img src={p.iconDataUri} alt="" width={20} height={20} style={{ borderRadius: 4 }} />
+                            ) : (
+                              <span className={`wallet-icon ${p.icon} w-5 h-5`} />
+                            )}
+                            <span style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                              <span style={{ fontWeight: 600, color: 'var(--text-1)' }}>Circle Modular Wallets</span>
+                              <span style={{ fontSize: '0.78rem', color: 'var(--text-3)', lineHeight: 1.4 }}>
+                                Face ID / Touch ID · smart-contract account on Arc · no extension, no seed phrase
+                              </span>
                             </span>
-                            <span
-                              style={{ fontSize: '0.8rem', color: 'var(--text-3)', lineHeight: 1.45, textAlign: 'left' }}
+                          </div>
+                          <div style={{ display: 'flex', gap: 8 }}>
+                            <button
+                              className="btn btn-primary"
+                              style={{ flex: 1 }}
+                              onClick={() => handleConnect(p.id, { mode: 'login' })}
+                              disabled={busy}
                             >
-                              Powered by <strong style={{ color: 'var(--text-2)' }}>Circle Modular Wallets</strong> · Face ID / Touch ID · Smart-contract account on Arc · No extension, no seed phrase
-                            </span>
+                              Sign in to existing
+                            </button>
+                            <button
+                              className="btn btn-outline"
+                              style={{ flex: 1 }}
+                              onClick={() => handleConnect(p.id, { mode: 'register' })}
+                              disabled={busy}
+                            >
+                              Create new wallet
+                            </button>
+                          </div>
+                          <span style={{ fontSize: '0.72rem', color: 'var(--text-4)', lineHeight: 1.4 }}>
+                            <strong style={{ color: 'var(--text-3)' }}>Sign in to existing</strong> opens your passkey
+                            picker — choose the wallet you want. <strong style={{ color: 'var(--text-3)' }}>Create new</strong> mints a fresh wallet.
                           </span>
-                        ) : (
+                        </div>
+                      ) : (
+                        <button className="wallet-option" onClick={() => handleConnect(p.id)} disabled={busy}>
+                          {p.iconDataUri ? (
+                            <img src={p.iconDataUri} alt="" width={20} height={20} style={{ borderRadius: 4 }} />
+                          ) : (
+                            <span className={`wallet-icon ${p.icon} w-5 h-5`} />
+                          )}
                           <span>{p.name}</span>
-                        )}
-                      </button>
+                        </button>
+                      )}
                     </Fragment>
                   )
                 })}

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -335,11 +335,11 @@ function findWalletProvider(providerId) {
 // connectWallet() so the WalletConnect onConnect callback works
 // uniformly. Triggers a WebAuthn prompt (biometric / hardware key) for
 // the user — caller should debounce + show a "Authenticating..." state.
-export async function connectCircleWallet() {
+export async function connectCircleWallet({ mode = 'login' } = {}) {
   if (!circlePasskeyEnabled()) {
     throw new Error('Circle passkey wallet is not configured.')
   }
-  const result = await connectCirclePasskey({ mode: 'auto' })
+  const result = await connectCirclePasskey({ mode })
   _address = result.address
   _providerId = CIRCLE_PROVIDER_ID
   _provider = null
@@ -350,8 +350,8 @@ export async function connectCircleWallet() {
   return { address: _address, provider: CIRCLE_PROVIDER_ID }
 }
 
-export async function connectWallet(providerId) {
-  if (providerId === CIRCLE_PROVIDER_ID) return connectCircleWallet()
+export async function connectWallet(providerId, opts) {
+  if (providerId === CIRCLE_PROVIDER_ID) return connectCircleWallet(opts)
 
   const provider = findWalletProvider(providerId)
   if (!provider) throw new Error(`Unknown provider: ${providerId}`)


### PR DESCRIPTION
## The bug (roadmap → T1.2)
Connecting with a passkey **always minted a new wallet** — you could never select or get back into a *specific* existing wallet.

**Root cause:** `connectCirclePasskey` auto-decided register-vs-login based on a **browser-local cached credential**, and registration used a **per-device random username**. On any fresh browser / cleared storage / different device there's no cached credential, so `mode:'auto'` fell straight through to **Register → a brand-new wallet**. There was no discoverable-login path, so the user's existing passkeys were never offered.

## The fix — two explicit flows
- **`circle-wallet.js`** — `connectCirclePasskey({ mode })`:
  - `'login'` → **discoverable login**: `toWebAuthnCredential({ mode: Login })` with **no username and no credentialId**, so the browser shows its native passkey picker listing **every** passkey for `archimedes-arc.com`. The chosen credential's public key deterministically derives that wallet's MSCA → the user lands in **that specific wallet** (and can recover it on a fresh browser/device).
  - `'register'` → **create new**: register under a fresh unique username (Circle rejects duplicate usernames).
  - Removes `getOrCreateUsername` — the stable per-device username didn't affect the address and was exactly what blocked creating a second wallet.
- **`config.js`** — `connectCircleWallet({ mode })` + `connectWallet(id, opts)` plumb the mode through.
- **`WalletConnect.jsx`** — the Circle option is now a **"Circle Modular Wallets"** box leading with the Circle ecosystem, containing two buttons: **"Sign in to existing"** (picker) and **"Create new wallet"**.

## Verification
- `eslint` + `vite build` clean.
- The WebAuthn biometric prompt can't be automated — **verify on the live site**: open Connect → "Sign in to existing" should show the browser passkey picker; choosing a passkey returns the same wallet address every time.

UX of the box can be refined after we confirm the flow works. The SDK also exposes `getAddressMapping`/`createAddressMapping` for explicit cross-device recovery if the discoverable picker proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)