### PR TITLE
[ci] Least-privilege permissions for import-guard workflow

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -18,6 +18,13 @@ on:
       - "environment.yml"
       - ".github/workflows/import-guard.yml"
 
+# Least-privilege GITHUB_TOKEN: this workflow only reads the repo to run the
+# guards; it never writes. The explicit block satisfies CodeQL
+# actions/missing-workflow-permissions and bounds blast radius if a third-party
+# action in the job is ever compromised.
+permissions:
+  contents: read
+
 jobs:
   import-guard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds an explicit least-privilege `permissions:` block to `.github/workflows/import-guard.yml`, resolving the open CodeQL alert **actions/missing-workflow-permissions** (medium).

The job only reads the repo to run `ruff` / `compileall` / `deptry`, so `contents: read` is the complete permission set. No behavior change; bounds blast radius if a third-party action in the job is ever compromised.

## Verify
- `gh api repos/a-apin/archimedes/code-scanning/alerts --jq '.[] | select(.rule.id=="actions/missing-workflow-permissions")'` resolves once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M