### PR TITLE
[ui] Custom wallet name at Circle wallet creation

### DIFF
--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -85,6 +85,22 @@ function newUniqueUsername() {
   return `archimedes-${hex}`
 }
 
+// Turn a user-typed wallet name into a Circle-valid username (5-50 chars from
+// [a-zA-Z0-9_@.:+-]): trim, collapse disallowed runs (incl. spaces) to a single
+// hyphen, strip edge hyphens, cap at 50. Returns null when the input is empty or
+// sanitizes to fewer than Circle's 5-char floor, so the caller falls back to an
+// auto-generated unique name. Circle enforces username uniqueness, so the name
+// doubles as the human-readable label shown in the passkey picker at login.
+export function sanitizeWalletName(name) {
+  if (!name) return null
+  const cleaned = String(name)
+    .trim()
+    .replace(/[^a-zA-Z0-9_@.:+-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50)
+  return cleaned.length >= 5 ? cleaned : null
+}
+
 export function clearCircleSession() {
   try {
     localStorage.removeItem(CREDENTIAL_STORAGE_KEY)
@@ -131,14 +147,15 @@ function friendlyPasskeyError(err) {
 //     deterministically derives that wallet's MSCA address. This is how a user
 //     signs back into a SPECIFIC existing wallet (and recovers it on a fresh
 //     browser / device).
-//   - mode 'register' → CREATE a new wallet: register a fresh passkey under a
-//     unique username (Circle rejects duplicate usernames). New credential →
-//     new MSCA address.
+//   - mode 'register' → CREATE a new wallet: register a fresh passkey under the
+//     user-chosen `walletName` (sanitized to Circle's username rules), or an
+//     auto-generated unique name if none is given. Circle rejects duplicate
+//     usernames. New credential → new MSCA address.
 //
 // Returns the smart account + address + credential (persisted to localStorage
 // for silent next-session rehydrate — see rehydrateSmartAccount). Throws a
-// friendly message on WebAuthn cancellation / domain mismatch.
-export async function connectCirclePasskey({ mode = 'login' } = {}) {
+// friendly message on WebAuthn cancellation / domain mismatch / name collision.
+export async function connectCirclePasskey({ mode = 'login', walletName } = {}) {
   if (!circlePasskeyEnabled()) {
     throw new Error('Circle passkey wallet is not configured (missing VITE_CIRCLE_CLIENT_KEY).')
   }
@@ -146,17 +163,27 @@ export async function connectCirclePasskey({ mode = 'login' } = {}) {
   // Passkey transport handles WebAuthn challenge issuance + verification.
   const passkeyTransport = toPasskeyTransport(CLIENT_URL, CLIENT_KEY)
 
+  // Register uses the user-chosen name (sanitized) so the wallet is recognizable
+  // in the passkey picker at login; falls back to an auto-generated unique name.
+  const registerUsername = sanitizeWalletName(walletName) ?? newUniqueUsername()
+
   // Browser prompts the user for biometrics here. Register issues a new P256
-  // credential under a unique username; Login is discoverable (no username, no
+  // credential under that username; Login is discoverable (no username, no
   // credentialId) so the browser surfaces all passkeys for this origin to pick.
   let credential
   try {
     credential = await toWebAuthnCredential(
       mode === 'register'
-        ? { transport: passkeyTransport, mode: WebAuthnMode.Register, username: newUniqueUsername() }
+        ? { transport: passkeyTransport, mode: WebAuthnMode.Register, username: registerUsername }
         : { transport: passkeyTransport, mode: WebAuthnMode.Login },
     )
   } catch (err) {
+    // A custom name that collides with an existing wallet's name gets a clear,
+    // actionable message instead of the generic duplicate-credential copy.
+    const raw = String(err?.message ?? err ?? '')
+    if (mode === 'register' && sanitizeWalletName(walletName) && /username is duplicated/i.test(raw)) {
+      throw new Error('That wallet name is already taken — choose a different one.', { cause: err })
+    }
     throw new Error(friendlyPasskeyError(err), { cause: err })
   }
 

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -8,6 +8,7 @@ import {
   getWalletClient,
   CIRCLE_PROVIDER_ID,
 } from '../config'
+import { sanitizeWalletName } from '../circle-wallet'
 
 export default function WalletConnect({ address, displayName, onConnect, onDisconnect, onEditProfile }) {
   const [showModal, setShowModal] = useState(false)
@@ -17,6 +18,7 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
   const [discoveryTick, setDiscoveryTick] = useState(0)
   const [copied, setCopied] = useState(false)
   const [balance, setBalance] = useState(null)
+  const [walletName, setWalletName] = useState('')
   const menuRef = useRef(null)
   const providerId = getConnectedProvider()
   const isPasskey = providerId === CIRCLE_PROVIDER_ID
@@ -383,6 +385,27 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
                               </span>
                             </span>
                           </div>
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                            <input
+                              type="text"
+                              value={walletName}
+                              onChange={(e) => setWalletName(e.target.value)}
+                              placeholder="Name a new wallet (optional) — e.g. Trading"
+                              maxLength={50}
+                              disabled={busy}
+                              aria-label="New wallet name (optional)"
+                              style={{
+                                width: '100%', padding: '8px 10px', borderRadius: 8,
+                                background: 'var(--surface-1)', border: '1px solid var(--glass-border)',
+                                color: 'var(--text-1)', fontSize: '0.85rem',
+                              }}
+                            />
+                            {walletName.trim().length > 0 && sanitizeWalletName(walletName) === null && (
+                              <span style={{ fontSize: '0.7rem', color: 'var(--danger, #f87171)' }}>
+                                At least 5 characters — letters, numbers, or _ @ . : + -
+                              </span>
+                            )}
+                          </div>
                           <div style={{ display: 'flex', gap: 8 }}>
                             <button
                               className="btn btn-primary"
@@ -395,15 +418,15 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
                             <button
                               className="btn btn-outline"
                               style={{ flex: 1 }}
-                              onClick={() => handleConnect(p.id, { mode: 'register' })}
-                              disabled={busy}
+                              onClick={() => handleConnect(p.id, { mode: 'register', walletName })}
+                              disabled={busy || (walletName.trim().length > 0 && sanitizeWalletName(walletName) === null)}
                             >
                               Create new wallet
                             </button>
                           </div>
                           <span style={{ fontSize: '0.72rem', color: 'var(--text-4)', lineHeight: 1.4 }}>
                             <strong style={{ color: 'var(--text-3)' }}>Sign in to existing</strong> opens your passkey
-                            picker — choose the wallet you want. <strong style={{ color: 'var(--text-3)' }}>Create new</strong> mints a fresh wallet.
+                            picker — choose the wallet you want. <strong style={{ color: 'var(--text-3)' }}>Create new</strong> mints a fresh wallet under the name above (or an auto-generated one).
                           </span>
                         </div>
                       ) : (

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -335,11 +335,11 @@ function findWalletProvider(providerId) {
 // connectWallet() so the WalletConnect onConnect callback works
 // uniformly. Triggers a WebAuthn prompt (biometric / hardware key) for
 // the user — caller should debounce + show a "Authenticating..." state.
-export async function connectCircleWallet({ mode = 'login' } = {}) {
+export async function connectCircleWallet({ mode = 'login', walletName } = {}) {
   if (!circlePasskeyEnabled()) {
     throw new Error('Circle passkey wallet is not configured.')
   }
-  const result = await connectCirclePasskey({ mode })
+  const result = await connectCirclePasskey({ mode, walletName })
   _address = result.address
   _providerId = CIRCLE_PROVIDER_ID
   _provider = null


### PR DESCRIPTION
## Summary
Lets users **name a Circle wallet when creating it**, so wallets are easy to tell apart in the discoverable-login passkey picker (the previous behavior labeled every wallet with an auto-generated `archimedes-<hex>` username). Closes the **T1.9** custom-wallet-naming gap and supports a real second user in the marketplace flow (#713).

## What changed
- `ui/src/circle-wallet.js` — new exported `sanitizeWalletName()` (trim → collapse disallowed chars to `-` → enforce Circle's 5–50 char `[a-zA-Z0-9_@.:+-]` rule; `null` → fall back to auto-name). `connectCirclePasskey({ mode, walletName })` uses it for the Register username; a name collision throws a clear *"That wallet name is already taken"* instead of the generic duplicate-credential copy.
- `ui/src/config.js` — `connectCircleWallet` plumbs `walletName` through.
- `ui/src/components/WalletConnect.jsx` — optional "Name a new wallet" input in the Circle box; inline 5-char validation; **only** applies to *Create new wallet* (discoverable *Sign in to existing* is unchanged).

## Notes
- The name **is** the Circle username (which is what the browser passkey picker shows at login), so it doubles as a stable per-wallet label. Circle enforces uniqueness → two wallets can't share a name (friendly error on collision).
- Blank input = prior auto-generated behavior, so this is purely additive.

## Verify
- `cd ui && npm run lint && npm run build` → clean (built locally).
- Manual: open Connect → type a name → *Create new wallet* → the passkey registers under that name; leaving it blank still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
