### PR TITLE
[deps] Pin requests<2.34 — fix arxiv conflict that broke the deploy

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,11 @@ scikit-learn>=1.5  # GaussianMixture + StandardScaler for the data-driven GmmReg
 
 # Market data
 yfinance>=1.4.1
-requests>=2.34.2
+# Do NOT bump to >=2.34: arxiv (incl. 4.0.0) pins requests<2.34, so a fresh
+# `pip install -r requirements.txt` resolve fails and the Docker deploy breaks
+# (regression from Dependabot #702, caught on deploy 2026-06-25). Keep <2.34
+# until arxiv relaxes its pin. environment.yml uses the same floor.
+requests>=2.32,<2.34
 # Bumped from 3.13.5 to close CVE-2026-34993 / CVE-2026-47265 (HTTP parser
 # DoS/smuggling).
 aiohttp>=3.14.1

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
 
       # --- Market data ---
       - yfinance>=1.4.1              # Historical + live equity/ETF/crypto data; for backtesting
-      - requests>=2.32
+      - requests>=2.32,<2.34          # arxiv pins requests<2.34; keep aligned with backend/requirements.txt (Dependabot #702 broke the deploy 2026-06-25)
       - aiohttp>=3.14.1                # Bumped from 3.13.5 to close CVE-2026-34993 / CVE-2026-47265 (HTTP parser DoS/smuggling). Floor aligned with backend/requirements.txt.
       - httpx>=0.27                   # Directly imported by services/corpus_service.py (arXiv intake) and services/llm_backend.py (OpenAI-compatible + Ollama). Pinned so we don't rely on transitive resolution.
 


### PR DESCRIPTION
Fixes the deploy break from Dependabot #702: `requests>=2.34.2` conflicts with arxiv (pins `requests<2.34`), making the Docker `pip install -r requirements.txt` resolve impossible. Bounded to `>=2.32,<2.34` in requirements.txt + environment.yml; verified the full fresh resolve succeeds (requests-2.33.1, pandas-3.0.3, cryptography-49). 🤖 Generated with Claude Code