### PR TITLE
[universe] T1.5 — backtest==on-chain parity invariant + Chainlink-covered expansion

### DIFF
--- a/backend/archimedes/data/synthetic_universe.json
+++ b/backend/archimedes/data/synthetic_universe.json
@@ -1,0 +1,88 @@
+{
+  "_comment": "Single source of truth (SSOT) for the on-chain synthetic universe. T1.5 — backtest==on-chain parity invariant. Each entry under `synthetics` is one tradable synth that lives on BOTH the on-chain path (deploy_contracts.py SYNTHETICS is derived from here) AND the backtest path (every symbol here is present in strategy_signal_evaluator.GLOBAL_ASSETS and so is backtestable). The parity invariant in backend/tests/test_universe_parity.py fails CI if the two ever diverge. Add-only by convention; do not rename or repurpose existing symbols. Single-stock synths are NOT live here — see `_compliance_review` below.",
+  "_chainlink_note": "`chainlink_covered: true` means the underlying has a Chainlink data feed (Data Feeds / Data Streams) on a major network suitable for backing an on-chain oracle. Expansion priority order: major crypto > FX majors > broad index/sector ETFs > commodities > broad fixed income. We deliberately exclude individual single-name equities from the live on-chain set (compliance).",
+  "_compliance_review": {
+    "status": "FLAGGED — DO NOT add to the live on-chain path without compliance sign-off",
+    "reason": "Single-stock synthetics (sTSLA, sNVDA, sAAPL, sMSFT, ... and the EU/Asian/Turkish single names in GLOBAL_ASSETS) reference individual securities. Minting an on-chain synthetic that tracks a single registered security raises securities-law / derivatives-registration questions that broad-index, FX, crypto, and commodity synths do not. These remain backtest-only (present in GLOBAL_ASSETS) until legal review. The two single-stock names that were on the legacy live list (sTSLA, sNVDA) are intentionally REMOVED from the live on-chain universe by this SSOT.",
+    "single_stock_synths_backtest_only": [
+      "sTSLA", "sNVDA", "sAAPL", "sMSFT", "sGOOGL", "sAMZN", "sMETA", "sAMD",
+      "sAVGO", "sORCL", "sCRM", "sNFLX", "sJPM", "sBAC", "sGS", "sV", "sMA",
+      "sBRK-B", "sLLY", "sUNH", "sJNJ", "sMRK", "sPFE", "sXOM", "sCVX", "sCOP",
+      "sWMT", "sCOST", "sHD", "sPG", "sCOIN", "sMSTR", "sPLTR",
+      "sASML", "sSAP", "sNESN", "sNOVO", "sAZN", "sSHEL", "sBP", "sHSBC",
+      "sTTE", "sRHM", "sLVMH", "sSIE",
+      "sTSM", "sBABA", "sTM", "sSONY", "sSE", "sTCEHY",
+      "sTHYAO", "sKCHOL", "sGARAN", "sASELS", "sAKBNK", "sSAHOL", "sBIMAS", "sEREGL"
+    ]
+  },
+  "synthetics": {
+    "sBTC":    {"name": "Synthetic BTC",            "price_usd": 104500.00, "decimals": 6, "asset_class": "crypto",        "chainlink_covered": true},
+    "sETH":    {"name": "Synthetic ETH",            "price_usd": 3850.00,   "decimals": 6, "asset_class": "crypto",        "chainlink_covered": true},
+    "sSOL":    {"name": "Synthetic SOL",            "price_usd": 215.00,    "decimals": 6, "asset_class": "crypto",        "chainlink_covered": true},
+
+    "sEURUSD": {"name": "Synthetic EUR/USD",        "price_usd": 1.0850,    "decimals": 6, "asset_class": "fx",            "chainlink_covered": true},
+    "sGBPUSD": {"name": "Synthetic GBP/USD",        "price_usd": 1.2700,    "decimals": 6, "asset_class": "fx",            "chainlink_covered": true},
+    "sUSDJPY": {"name": "Synthetic USD/JPY",        "price_usd": 157.20,    "decimals": 6, "asset_class": "fx",            "chainlink_covered": true},
+    "sUSDTRY": {"name": "Synthetic USD/TRY",        "price_usd": 39.10,     "decimals": 6, "asset_class": "fx",            "chainlink_covered": true},
+
+    "sSPY":    {"name": "Synthetic SPY",            "price_usd": 592.40,    "decimals": 6, "asset_class": "us_equity_etf", "chainlink_covered": true},
+    "sQQQ":    {"name": "Synthetic QQQ",            "price_usd": 512.30,    "decimals": 6, "asset_class": "us_equity_etf", "chainlink_covered": true},
+    "sIWM":    {"name": "Synthetic IWM",            "price_usd": 228.70,    "decimals": 6, "asset_class": "us_equity_etf", "chainlink_covered": true},
+    "sDIA":    {"name": "Synthetic DIA",            "price_usd": 437.10,    "decimals": 6, "asset_class": "us_equity_etf", "chainlink_covered": true},
+
+    "sXLE":    {"name": "Synthetic XLE",            "price_usd": 91.80,     "decimals": 6, "asset_class": "us_sector_etf", "chainlink_covered": true},
+    "sXLF":    {"name": "Synthetic XLF",            "price_usd": 49.60,     "decimals": 6, "asset_class": "us_sector_etf", "chainlink_covered": true},
+    "sXLK":    {"name": "Synthetic XLK",            "price_usd": 235.40,    "decimals": 6, "asset_class": "us_sector_etf", "chainlink_covered": true},
+    "sXLV":    {"name": "Synthetic XLV",            "price_usd": 146.20,    "decimals": 6, "asset_class": "us_sector_etf", "chainlink_covered": true},
+    "sXLI":    {"name": "Synthetic XLI",            "price_usd": 138.90,    "decimals": 6, "asset_class": "us_sector_etf", "chainlink_covered": true},
+    "sXLU":    {"name": "Synthetic XLU",            "price_usd": 78.40,     "decimals": 6, "asset_class": "us_sector_etf", "chainlink_covered": true},
+
+    "sEEM":    {"name": "Synthetic EEM",            "price_usd": 44.10,     "decimals": 6, "asset_class": "em_equity_etf", "chainlink_covered": true},
+    "sEZU":    {"name": "Synthetic EZU",            "price_usd": 53.70,     "decimals": 6, "asset_class": "eu_equity_etf", "chainlink_covered": false},
+    "sEWG":    {"name": "Synthetic EWG (Germany)",  "price_usd": 35.40,     "decimals": 6, "asset_class": "eu_equity_etf", "chainlink_covered": false},
+    "sEWU":    {"name": "Synthetic EWU (UK)",       "price_usd": 38.20,     "decimals": 6, "asset_class": "eu_equity_etf", "chainlink_covered": false},
+    "sEWQ":    {"name": "Synthetic EWQ (France)",   "price_usd": 43.90,     "decimals": 6, "asset_class": "eu_equity_etf", "chainlink_covered": false},
+    "sEWJ":    {"name": "Synthetic EWJ",            "price_usd": 73.20,     "decimals": 6, "asset_class": "asia_equity_etf","chainlink_covered": false},
+    "sMCHI":   {"name": "Synthetic MCHI",           "price_usd": 51.40,     "decimals": 6, "asset_class": "asia_equity_etf","chainlink_covered": false},
+    "sINDA":   {"name": "Synthetic INDA",           "price_usd": 55.80,     "decimals": 6, "asset_class": "asia_equity_etf","chainlink_covered": false},
+    "sEWY":    {"name": "Synthetic EWY (Korea)",    "price_usd": 58.30,     "decimals": 6, "asset_class": "asia_equity_etf","chainlink_covered": false},
+    "sTUR":    {"name": "Synthetic TUR (Turkey)",   "price_usd": 28.70,     "decimals": 6, "asset_class": "tr_equity_etf", "chainlink_covered": false},
+
+    "sNKY":    {"name": "Synthetic NKY",            "price_usd": 38500.00,  "decimals": 6, "asset_class": "asia_index",    "chainlink_covered": true},
+    "sFTSE":   {"name": "Synthetic FTSE 100",       "price_usd": 8200.00,   "decimals": 6, "asset_class": "eu_index",      "chainlink_covered": true},
+    "sDAX":    {"name": "Synthetic DAX 40",         "price_usd": 18400.00,  "decimals": 6, "asset_class": "eu_index",      "chainlink_covered": true},
+    "sCAC":    {"name": "Synthetic CAC 40",         "price_usd": 7600.00,   "decimals": 6, "asset_class": "eu_index",      "chainlink_covered": true},
+    "sBIST":   {"name": "Synthetic BIST 100",       "price_usd": 10300.00,  "decimals": 6, "asset_class": "tr_index",      "chainlink_covered": false},
+
+    "sGOLD":   {"name": "Synthetic GOLD",           "price_usd": 3250.00,   "decimals": 6, "asset_class": "metal_fut",     "chainlink_covered": true},
+    "sGLD":    {"name": "Synthetic GLD",            "price_usd": 300.50,    "decimals": 6, "asset_class": "metal_etf",     "chainlink_covered": true},
+    "sSLV":    {"name": "Synthetic SLV",            "price_usd": 30.20,     "decimals": 6, "asset_class": "metal_etf",     "chainlink_covered": true},
+    "sSI":     {"name": "Synthetic Silver",         "price_usd": 32.40,     "decimals": 6, "asset_class": "metal_fut",     "chainlink_covered": true},
+    "sPPLT":   {"name": "Synthetic Platinum",       "price_usd": 96.30,     "decimals": 6, "asset_class": "metal_etf",     "chainlink_covered": true},
+    "sPALL":   {"name": "Synthetic Palladium",      "price_usd": 92.10,     "decimals": 6, "asset_class": "metal_etf",     "chainlink_covered": true},
+    "sHG":     {"name": "Synthetic Copper",         "price_usd": 4.30,      "decimals": 6, "asset_class": "metal_fut",     "chainlink_covered": false},
+    "sGDX":    {"name": "Synthetic GDX",            "price_usd": 40.80,     "decimals": 6, "asset_class": "metal_eq_etf",  "chainlink_covered": false},
+    "sGDXJ":   {"name": "Synthetic GDXJ",           "price_usd": 51.60,     "decimals": 6, "asset_class": "metal_eq_etf",  "chainlink_covered": false},
+
+    "sOIL":    {"name": "Synthetic OIL",            "price_usd": 62.80,     "decimals": 6, "asset_class": "energy_fut",    "chainlink_covered": true},
+    "sBRENT":  {"name": "Synthetic Brent",          "price_usd": 66.40,     "decimals": 6, "asset_class": "energy_fut",    "chainlink_covered": false},
+    "sUSO":    {"name": "Synthetic USO",            "price_usd": 78.50,     "decimals": 6, "asset_class": "energy_etf",    "chainlink_covered": false},
+    "sUNG":    {"name": "Synthetic UNG",            "price_usd": 14.20,     "decimals": 6, "asset_class": "energy_etf",    "chainlink_covered": false},
+    "sNG":     {"name": "Synthetic Natural Gas",    "price_usd": 3.10,      "decimals": 6, "asset_class": "energy_fut",    "chainlink_covered": false},
+
+    "sCORN":   {"name": "Synthetic Corn",           "price_usd": 4.45,      "decimals": 6, "asset_class": "agri_fut",      "chainlink_covered": false},
+    "sWHEAT":  {"name": "Synthetic Wheat",          "price_usd": 5.70,      "decimals": 6, "asset_class": "agri_fut",      "chainlink_covered": false},
+    "sSOY":    {"name": "Synthetic Soybeans",       "price_usd": 10.40,     "decimals": 6, "asset_class": "agri_fut",      "chainlink_covered": false},
+
+    "sTLT":    {"name": "Synthetic TLT (20+yr)",    "price_usd": 92.30,     "decimals": 6, "asset_class": "us_bond_long",  "chainlink_covered": true},
+    "sIEF":    {"name": "Synthetic IEF (7-10yr)",   "price_usd": 95.10,     "decimals": 6, "asset_class": "us_bond_mid",   "chainlink_covered": true},
+    "sSHY":    {"name": "Synthetic SHY (1-3yr)",    "price_usd": 82.40,     "decimals": 6, "asset_class": "us_bond_short", "chainlink_covered": false},
+    "sBIL":    {"name": "Synthetic BIL (T-Bills)",  "price_usd": 91.60,     "decimals": 6, "asset_class": "us_bond_tbill", "chainlink_covered": false},
+    "sTIP":    {"name": "Synthetic TIP (TIPS)",     "price_usd": 108.70,    "decimals": 6, "asset_class": "us_bond_tips",  "chainlink_covered": false},
+    "sAGG":    {"name": "Synthetic AGG (Aggregate)","price_usd": 98.20,     "decimals": 6, "asset_class": "us_bond_agg",   "chainlink_covered": true},
+    "sHYG":    {"name": "Synthetic HYG (HY credit)","price_usd": 79.40,     "decimals": 6, "asset_class": "credit_hy",     "chainlink_covered": false},
+    "sLQD":    {"name": "Synthetic LQD (IG credit)","price_usd": 110.30,    "decimals": 6, "asset_class": "credit_ig",     "chainlink_covered": false},
+    "sEMB":    {"name": "Synthetic EMB (EM bond)",  "price_usd": 91.80,     "decimals": 6, "asset_class": "em_bond",       "chainlink_covered": false},
+    "sMUB":    {"name": "Synthetic MUB (US muni)",  "price_usd": 106.50,    "decimals": 6, "asset_class": "us_muni",       "chainlink_covered": false}
+  }
+}

--- a/backend/archimedes/scripts/deploy_contracts.py
+++ b/backend/archimedes/scripts/deploy_contracts.py
@@ -30,20 +30,22 @@ from web3.middleware import ExtraDataToPOAMiddleware
 
 from archimedes.chain.circle_signer import circle_signer
 
+# The on-chain synthetic universe is derived from the SSOT
+# (backend/archimedes/data/synthetic_universe.json). Do NOT hardcode the list
+# here — the parity invariant in backend/tests/test_universe_parity.py asserts
+# this set equals the backtestable universe (GLOBAL_ASSETS) so the two can never
+# silently diverge (T1.5).
+from archimedes.universe import synthetics_for_deploy
+
 # ─── Config ──────────────────────────────────────────────────
 
 WALLET = os.getenv("WALLET_ADDRESS", "")
 USDC_ARC = "0x3600000000000000000000000000000000000000"
 
-SYNTHETICS = [
-    ("Synthetic TSLA", "sTSLA", 285_500_000),  # $285.50
-    ("Synthetic NVDA", "sNVDA", 135_200_000),  # $135.20
-    ("Synthetic SPY", "sSPY", 592_400_000),  # $592.40
-    ("Synthetic BTC", "sBTC", 104_500_000_000),  # $104,500
-    ("Synthetic GOLD", "sGOLD", 3_250_000_000),  # $3,250.00
-    ("Synthetic OIL", "sOIL", 62_800_000),  # $62.80
-    ("Synthetic NKY", "sNKY", 38_500_000_000),  # $38,500.00
-]
+# (name, symbol, price_int_6dp) tuples — same shape as the old literal, now
+# sourced from the SSOT. Single-stock synths (sTSLA, sNVDA, ...) are
+# intentionally absent: they are backtest-only pending compliance review.
+SYNTHETICS = synthetics_for_deploy()
 
 ABI_DIR = Path(__file__).resolve().parents[3] / "contracts" / "abis"
 ARTIFACTS_DIR = Path(__file__).resolve().parents[3] / "contracts" / "out"

--- a/backend/archimedes/universe.py
+++ b/backend/archimedes/universe.py
@@ -1,0 +1,121 @@
+"""Synthetic-universe SSOT loader (T1.5 — backtest==on-chain parity).
+
+This module is the single source of truth for the **on-chain synthetic
+universe**. The on-chain deploy path (``scripts/deploy_contracts.py``
+``SYNTHETICS``) is derived from here, and the parity invariant in
+``backend/tests/test_universe_parity.py`` asserts that this set equals the
+**backtestable** universe (``services.strategy_signal_evaluator.GLOBAL_ASSETS``)
+so the two can never silently diverge.
+
+Why a JSON SSOT rather than a hardcoded literal: the on-chain universe was
+previously a tuple literal in ``deploy_contracts.py`` while the backtest
+universe lived in ``GLOBAL_ASSETS`` — nothing kept them in sync, so a synth
+could be deployable but not backtestable (or vice-versa). Issue #682 introduced
+the JSON-SSOT pattern for the analytics-engine instruments; this mirrors it for
+the synthetic universe.
+
+Public API:
+  * ``SYNTHETIC_UNIVERSE`` — dict[str, SyntheticSpec] keyed by synth symbol.
+  * ``ON_CHAIN_SYNTHS`` — sorted list of synth symbols on the live on-chain path.
+  * ``synthetics_for_deploy()`` — ``[(name, symbol, price_6dp_int), ...]`` ready
+    to drop into ``deploy_contracts.SYNTHETICS``.
+  * ``COMPLIANCE_FLAGGED_SINGLE_STOCKS`` — single-name equity synths that are
+    backtest-only and must NOT be added to the live on-chain path without a
+    compliance sign-off.
+
+Loading is ``Path(__file__)``-relative (the backend runs with
+``PYTHONPATH=backend``, not as a pip-installed package), and falls back to an
+empty mapping with a logged error only if the SSOT file is unreadable so an
+import never hard-crashes the app — the parity test would catch an empty set.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SSOT_PATH = Path(__file__).resolve().parent / "data" / "synthetic_universe.json"
+
+
+@dataclass(frozen=True)
+class SyntheticSpec:
+    """One synth's on-chain + backtest metadata, loaded from the SSOT."""
+
+    symbol: str
+    name: str
+    price_usd: float
+    decimals: int
+    asset_class: str
+    chainlink_covered: bool
+
+    @property
+    def price_int(self) -> int:
+        """Oracle initial price as an integer in `decimals` fixed-point units.
+
+        ``deploy_contracts`` and ``bootstrap_vaults`` push 6-decimal prices
+        on-chain (e.g. $592.40 → 592_400_000). Derive that from the SSOT so the
+        human-readable USD price stays the single editable value.
+        """
+        return int(round(self.price_usd * (10**self.decimals)))
+
+
+def _load_universe() -> dict[str, SyntheticSpec]:
+    try:
+        payload = json.loads(_SSOT_PATH.read_text(encoding="utf-8"))
+        raw = payload["synthetics"]
+    except (FileNotFoundError, KeyError, ValueError, OSError) as exc:
+        logger.error("could not load synthetic-universe SSOT %s (%s)", _SSOT_PATH, exc)
+        return {}
+    universe: dict[str, SyntheticSpec] = {}
+    for symbol, spec in raw.items():
+        universe[symbol] = SyntheticSpec(
+            symbol=symbol,
+            name=spec["name"],
+            price_usd=float(spec["price_usd"]),
+            decimals=int(spec.get("decimals", 6)),
+            asset_class=str(spec["asset_class"]),
+            chainlink_covered=bool(spec["chainlink_covered"]),
+        )
+    return universe
+
+
+def _load_compliance_flagged() -> list[str]:
+    try:
+        payload = json.loads(_SSOT_PATH.read_text(encoding="utf-8"))
+        return list(payload["_compliance_review"]["single_stock_synths_backtest_only"])
+    except (FileNotFoundError, KeyError, ValueError, OSError) as exc:
+        logger.error("could not load compliance-flagged single-stock list (%s)", exc)
+        return []
+
+
+# ─── Public surface ──────────────────────────────────────────────────
+SYNTHETIC_UNIVERSE: dict[str, SyntheticSpec] = _load_universe()
+
+ON_CHAIN_SYNTHS: list[str] = sorted(SYNTHETIC_UNIVERSE.keys())
+
+# Single-name equity synths that are intentionally NOT on the live on-chain
+# path. They remain backtest-only (present in GLOBAL_ASSETS) pending a
+# securities/derivatives compliance review — see synthetic_universe.json
+# `_compliance_review`. Do not add any of these to the live universe without
+# sign-off.
+COMPLIANCE_FLAGGED_SINGLE_STOCKS: frozenset[str] = frozenset(_load_compliance_flagged())
+
+
+def synthetics_for_deploy() -> list[tuple[str, str, int]]:
+    """Return ``(name, symbol, price_int)`` tuples for the on-chain deploy path.
+
+    Drop-in replacement for the old ``deploy_contracts.SYNTHETICS`` literal.
+    Sorted by symbol for deterministic deploy ordering.
+    """
+    return [
+        (spec.name, spec.symbol, spec.price_int) for spec in sorted(SYNTHETIC_UNIVERSE.values(), key=lambda s: s.symbol)
+    ]
+
+
+def chainlink_covered_synths() -> list[str]:
+    """Synth symbols whose underlying has a Chainlink data feed."""
+    return sorted(s for s, spec in SYNTHETIC_UNIVERSE.items() if spec.chainlink_covered)

--- a/backend/tests/test_universe_parity.py
+++ b/backend/tests/test_universe_parity.py
@@ -1,0 +1,130 @@
+"""Backtest == on-chain universe parity invariant (T1.5).
+
+The on-chain synthetic universe and the backtestable universe MUST stay in
+lock-step. Historically they drifted: the on-chain ``SYNTHETICS`` list was a
+tuple literal in ``scripts/deploy_contracts.py`` (7 names) while the
+backtestable universe lived in ``services.strategy_signal_evaluator.GLOBAL_ASSETS``
+(>100 names), with nothing keeping them consistent — a synth could be
+deployable but not backtestable, or backtestable but never deployed, and no
+test caught it.
+
+This module makes the invariant CI-enforced. Both sides now derive from the
+JSON SSOT (``backend/archimedes/data/synthetic_universe.json``); these tests
+assert the SSOT-driven on-chain set is consistent with the backtest universe in
+both directions, with the single documented exception that single-name equity
+synths are intentionally backtest-only pending compliance review.
+
+The invariants:
+
+1. Every on-chain synth is backtestable (on-chain ⊆ GLOBAL_ASSETS).
+2. No compliance-flagged single-stock synth is on the live on-chain path.
+3. Every backtestable-but-not-on-chain synth is an explained
+   compliance-flagged single-stock (the "vice-versa" direction, with its
+   audited exception) — so a newly added backtest symbol cannot silently fail
+   to reach on-chain unless it was deliberately flagged.
+4. The live ``deploy_contracts.SYNTHETICS`` list is exactly the SSOT-derived
+   set — i.e. the on-chain deploy path has no hand-edited drift from the SSOT.
+
+These are pure in-memory set comparisons: hermetic, no DB / Redis / RPC / .env.
+"""
+
+from __future__ import annotations
+
+from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
+from archimedes.universe import (
+    COMPLIANCE_FLAGGED_SINGLE_STOCKS,
+    ON_CHAIN_SYNTHS,
+    SYNTHETIC_UNIVERSE,
+    synthetics_for_deploy,
+)
+
+# The backtestable universe = the synths the strategy/portfolio agents can rank
+# and allocate over. GLOBAL_ASSETS is the canonical backtest universe.
+BACKTEST_SYNTHS: frozenset[str] = frozenset(GLOBAL_ASSETS.keys())
+ON_CHAIN: frozenset[str] = frozenset(ON_CHAIN_SYNTHS)
+
+
+def test_ssot_loaded_non_empty() -> None:
+    # A silent SSOT-load failure (missing/garbled JSON) would make every other
+    # parity check pass vacuously on an empty set — guard against it.
+    assert len(SYNTHETIC_UNIVERSE) >= 50, (
+        f"SSOT loaded only {len(SYNTHETIC_UNIVERSE)} synths — expected the expanded "
+        "universe (~59). Did synthetic_universe.json fail to load?"
+    )
+    assert frozenset(SYNTHETIC_UNIVERSE.keys()) == ON_CHAIN
+
+
+def test_every_on_chain_synth_is_backtestable() -> None:
+    # Invariant 1: on-chain ⊆ backtest. Anything we can deploy, we can backtest.
+    not_backtestable = ON_CHAIN - BACKTEST_SYNTHS
+    assert not not_backtestable, (
+        "On-chain synths are not present in the backtest universe (GLOBAL_ASSETS): "
+        f"{sorted(not_backtestable)}. Add them to GLOBAL_ASSETS or remove from the SSOT."
+    )
+
+
+def test_no_compliance_flagged_single_stock_on_live_path() -> None:
+    # Invariant 2: single-name equity synths are backtest-only pending review.
+    flagged_on_live = ON_CHAIN & COMPLIANCE_FLAGGED_SINGLE_STOCKS
+    assert not flagged_on_live, (
+        "Compliance-flagged single-stock synths are on the live on-chain path: "
+        f"{sorted(flagged_on_live)}. These need compliance sign-off before going live."
+    )
+
+
+def test_backtest_only_synths_are_all_compliance_flagged() -> None:
+    # Invariant 3 (the "vice-versa"): every backtestable symbol that is NOT
+    # on-chain must be explained by the compliance flag. An unexplained gap
+    # means a backtest symbol was added without either deploying it on-chain or
+    # flagging it — exactly the silent divergence this invariant exists to stop.
+    backtest_only = BACKTEST_SYNTHS - ON_CHAIN
+    unexplained = backtest_only - COMPLIANCE_FLAGGED_SINGLE_STOCKS
+    assert not unexplained, (
+        "Backtestable synths are neither on-chain nor compliance-flagged: "
+        f"{sorted(unexplained)}. Either add them to the SSOT (live on-chain) or "
+        "flag them in synthetic_universe.json `_compliance_review`."
+    )
+
+
+def test_compliance_flags_are_not_stale() -> None:
+    # Every flagged single-stock should actually exist in the backtest universe;
+    # a flag for a symbol no longer in GLOBAL_ASSETS is dead config.
+    stale = COMPLIANCE_FLAGGED_SINGLE_STOCKS - BACKTEST_SYNTHS
+    assert not stale, (
+        f"Compliance-flag entries reference symbols absent from GLOBAL_ASSETS: {sorted(stale)}. Remove the stale flags."
+    )
+
+
+def test_deploy_synthetics_match_ssot_exactly() -> None:
+    # Invariant 4: the live on-chain deploy list is exactly the SSOT-derived set,
+    # with no hand-edited drift. Import the actual production module so a future
+    # edit that re-hardcodes SYNTHETICS would fail here.
+    from archimedes.scripts import deploy_contracts
+
+    deploy_symbols = {sym for (_name, sym, _price) in deploy_contracts.SYNTHETICS}
+    assert deploy_symbols == ON_CHAIN, (
+        "deploy_contracts.SYNTHETICS drifted from the SSOT. "
+        f"only-in-deploy={sorted(deploy_symbols - ON_CHAIN)} "
+        f"only-in-ssot={sorted(ON_CHAIN - deploy_symbols)}"
+    )
+    # Also verify the deploy tuples carry positive integer prices (the contract
+    # constructor takes a uint256 oracle price).
+    for name, sym, price in deploy_contracts.SYNTHETICS:
+        assert isinstance(price, int) and price > 0, f"{sym} has a non-positive integer price: {price!r}"
+        assert name and sym.startswith("s"), f"malformed deploy entry: {(name, sym, price)}"
+
+
+def test_synthetics_for_deploy_is_deterministic_and_sorted() -> None:
+    # Deterministic deploy ordering avoids spurious diffs / nonce churn.
+    tuples = synthetics_for_deploy()
+    symbols = [sym for (_n, sym, _p) in tuples]
+    assert symbols == sorted(symbols)
+    assert len(symbols) == len(set(symbols)), "duplicate symbol in deploy list"
+
+
+def test_universe_expanded_at_least_5x() -> None:
+    # The T1.5 goal: expand the on-chain universe 5–10X from the legacy 7 synths.
+    legacy_size = 7
+    assert len(ON_CHAIN) >= 5 * legacy_size, (
+        f"On-chain universe is {len(ON_CHAIN)}; expected at least {5 * legacy_size} (5X the legacy 7-synth universe)."
+    )


### PR DESCRIPTION
## Summary

Makes **backtest universe == on-chain universe** a hard, CI-enforced invariant and expands the on-chain synthetic universe **~8X (7 → 59)**, prioritizing Chainlink-covered, liquid assets. Both universes now derive from a single instrument SSOT so they can't silently diverge.

### The gap this closes
Before this PR the two universes drifted with nothing keeping them in sync:
- **On-chain** `SYNTHETICS` was a 7-name tuple literal in `scripts/deploy_contracts.py` (`sTSLA, sNVDA, sSPY, sBTC, sGOLD, sOIL, sNKY`).
- **Backtestable** universe lived in `services.strategy_signal_evaluator.GLOBAL_ASSETS` (>100 names).

A synth could be deployable-but-not-backtestable (or backtestable-but-never-deployed) and no test caught it.

## What changed

- **SSOT** `backend/archimedes/data/synthetic_universe.json` — one entry per synth (name, USD price, decimals, asset_class, `chainlink_covered`) plus a `_compliance_review` block listing single-stock synths held back from the live path. Mirrors the issue #682 JSON-SSOT pattern used for analytics-engine instruments.
- **Loader** `backend/archimedes/universe.py` — exposes `SYNTHETIC_UNIVERSE`, `ON_CHAIN_SYNTHS`, `synthetics_for_deploy()`, `chainlink_covered_synths()`, `COMPLIANCE_FLAGGED_SINGLE_STOCKS`. USD price → 6-dp integer oracle price is derived (single editable value).
- **`deploy_contracts.SYNTHETICS`** now sourced from the SSOT (`synthetics_for_deploy()`) — no more hardcoded literal, same tuple shape.
- **Parity test** `backend/tests/test_universe_parity.py` — the CI-enforced invariant (8 tests).

## The new universe (7 → 59)

| Class | Synths |
| --- | --- |
| Crypto | sBTC, sETH, sSOL |
| FX majors | sEURUSD, sGBPUSD, sUSDJPY, sUSDTRY |
| Broad US equity ETFs | sSPY, sQQQ, sIWM, sDIA |
| US sector ETFs | sXLE, sXLF, sXLK, sXLV, sXLI, sXLU |
| Intl/EM equity ETFs | sEEM, sEZU, sEWG, sEWU, sEWQ, sEWJ, sMCHI, sINDA, sEWY, sTUR |
| EU/Asia indices | sNKY, sFTSE, sDAX, sCAC, sBIST |
| Metals | sGOLD, sGLD, sSLV, sSI, sPPLT, sPALL, sHG, sGDX, sGDXJ |
| Energy | sOIL, sBRENT, sUSO, sUNG, sNG |
| Agriculture | sCORN, sWHEAT, sSOY |
| Fixed income | sTLT, sIEF, sSHY, sBIL, sTIP, sAGG, sHYG, sLQD, sEMB, sMUB |

**32 of 59 are Chainlink-covered.** The two legacy single-stock synths (`sTSLA`, `sNVDA`) are **removed from the live on-chain set** and flagged backtest-only.

### Compliance
All single-name equity synths (the 33 US single stocks + EU/Asian/Turkish names in `GLOBAL_ASSETS`) are flagged in the SSOT `_compliance_review` block as **backtest-only pending securities/derivatives review** — they remain backtestable but are kept off the live on-chain path. **Cross-lane note:** the deploy-path change touches Chuan's on-chain integration lane; flagging here for review. No contracts are deployed by this PR.

## How the parity invariant works

`backend/tests/test_universe_parity.py` (8 hermetic, in-memory tests):
1. **on-chain ⊆ backtestable** — every deployable synth is in `GLOBAL_ASSETS`.
2. **No flagged single-stock on the live path.**
3. **vice-versa (with audited exception)** — every backtestable-but-not-on-chain synth must be an explained compliance-flagged single-stock, so a newly added backtest symbol can't silently fail to reach on-chain unless deliberately flagged.
4. **`deploy_contracts.SYNTHETICS` == SSOT** — no hand-edited drift on the deploy path; re-hardcoding the literal would fail here.
5. SSOT-loaded-non-empty guard, no stale flags, deterministic sorted deploy order, ≥5X expansion.

## Test evidence (hermetic)

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend conda run -n archimedes \
    python -m pytest backend/tests/test_universe_parity.py -q
8 passed in 0.06s
```

`ruff format --check` clean and `ruff check --select E9,F63,F7,F40` (CI hard-block subset) passes on all changed Python.

## Scope / anti-goals
Universe config + SSOT + parity test only. **No contract deploys, no infra changes, no `docker-compose`/CI wiring touched.** `deploy_contracts.py` change is a drop-in re-source of the same-shaped list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)