### PR TITLE
[ui] T1.6 — asset picker + prompt library + drop hardcoded SPY universe

### DIFF
--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -45,6 +45,7 @@ from typing import Any
 from archimedes.agents.strategy_architect import extract_json
 from archimedes.models.portfolio import RISK_PROFILE_PARAMS, RiskProfile
 from archimedes.services.llm_backend import LLMBackend, make_llm_backend
+from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,49 @@ _ASSET_SYNONYMS: dict[str, tuple[str, ...]] = {
     "vol": ("volatil", "variance", "option", "vix", "implied vol"),
     "macro": ("macro", "regime", "business cycle", "monetary", "inflation"),
 }
+
+# ── Investable-universe SSOT (issue #682 derived) ───────────────────────────
+#
+# The fusion strategy_spec's `asset_universe` MUST be steered by the user's
+# selected assets — never a hardcoded `["SPY"]` literal. `GLOBAL_ASSETS`
+# (backend-local, hermetic, importable without the analytics-engine package) is
+# the single source of truth for the supported instruments; its display symbols
+# are the user-facing tickers the UI picker exposes. When the user gives no
+# steer, we fall back to this full SSOT-derived universe rather than to SPY.
+SUPPORTED_UNIVERSE: tuple[str, ...] = tuple(
+    # Display symbol (e.g. "SPY", "QQQ", "GOLD_FUT") — the user-facing label.
+    sorted({display for (_yf, display, _asset_class, _exchange) in GLOBAL_ASSETS.values()})
+)
+# Case-folded membership index: accept either a display symbol ("SPY") or the
+# synth key ("sSPY") the user / UI might send, mapping both to the canonical
+# display symbol used in the strategy_spec.
+_UNIVERSE_LOOKUP: dict[str, str] = {}
+for _synth, (_yf, _display, _ac, _exch) in GLOBAL_ASSETS.items():
+    _UNIVERSE_LOOKUP[_display.casefold()] = _display
+    _UNIVERSE_LOOKUP[_synth.casefold()] = _display
+    _UNIVERSE_LOOKUP[_yf.casefold()] = _display
+
+
+def derive_asset_universe(selected_assets: list[str]) -> list[str]:
+    """Derive the strategy_spec asset_universe from the user's selected assets.
+
+    The universe is the user's chosen instruments (resolved to canonical
+    display symbols via the SSOT), de-duped and order-preserved. Tokens that
+    don't resolve to a supported instrument (e.g. broad-class steers like
+    "equities" the paper filter consumes) are dropped from the *universe* — the
+    universe is a concrete instrument list, not a class filter. When nothing in
+    the steer resolves, fall back to the full supported universe (issue #682) —
+    never a bare `["SPY"]`.
+    """
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for token in selected_assets:
+        canonical = _UNIVERSE_LOOKUP.get(str(token).strip().casefold())
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            resolved.append(canonical)
+    return resolved if resolved else list(SUPPORTED_UNIVERSE)
+
 
 # ── Regime-biased keyword sets for bull/bear paper retrieval (Issue #163) ──
 _REGIME_BIAS_TERMS: dict[str, tuple[str, ...]] = {
@@ -472,7 +516,7 @@ literature>",
   "risk_notes": "<key risks + the pre-backtest / selection-bias caveat>",
   "strategy_spec": {
     "name": "<same as strategy_name>",
-    "asset_universe": ["SPY"],
+    "asset_universe": ["<ticker>", "<ticker>", ...],
     "rebalance_frequency": "monthly",
     "entry": {"gt": ["close", "sma_200"]},
     "exit": {"lt": ["close", "sma_200"]},
@@ -485,7 +529,10 @@ literature>",
 }
 
 The strategy_spec field is REQUIRED. It is a machine-readable strategy definition \
-using the Archimedes DSL (closed-enum vocabulary). Valid rebalance_frequency values: \
+using the Archimedes DSL (closed-enum vocabulary). For asset_universe, list the \
+tickers the mechanism trades from the user's selected assets (in user_steer); the \
+platform overrides this with the user's chosen universe, so do not default to a \
+single broad-market proxy. Valid rebalance_frequency values: \
 daily, weekly, monthly. Valid indicators: sma_N, ema_N, rsi_N, momentum_N (replace \
 N with an integer period). Entry/exit conditions use comparison ops (gt, lt, gte, lte) \
 or logic ops (and, or, not). Position sizing types: full_invested_when_in_market, \
@@ -648,6 +695,12 @@ class StrategyFusion:
         strategy_spec = parsed.get("strategy_spec")
         if not isinstance(strategy_spec, dict):
             strategy_spec = None
+        else:
+            # Steer the asset universe from the user's selected assets (falling
+            # back to the SSOT-derived supported universe), overriding whatever
+            # the model emitted. The universe is the user's lever — never a
+            # hardcoded `["SPY"]` default and never silently the model's guess.
+            strategy_spec["asset_universe"] = derive_asset_universe(brief.asset_classes)
 
         return FusionProposal(
             status="ok",

--- a/backend/tests/test_strategy_fusion.py
+++ b/backend/tests/test_strategy_fusion.py
@@ -22,9 +22,11 @@ import json
 import pytest
 from archimedes.agents.strategy_fusion import (
     MIN_PAPERS,
+    SUPPORTED_UNIVERSE,
     FusionBrief,
     FusionCannedBackend,
     StrategyFusion,
+    derive_asset_universe,
     fusion_enabled,
     load_corpus,
     select_candidates,
@@ -374,3 +376,100 @@ def test_unparseable_model_output_declines(monkeypatch, corpus):
     assert proposal.status == "unparseable"
     assert proposal.model == "glm-4.7"  # still records the served model
     assert proposal.requested_model == "claude-sonnet-4-20250514"
+
+
+# ── Asset-universe derivation (T1.6 — no hardcoded SPY) ──────────
+
+
+class _SpecBackend:
+    """A mock that emits a strategy_spec whose universe defaults to ["SPY"].
+
+    This is the worst case the derivation must defend against: a model that
+    parrots the old single-proxy default. The service must override it with
+    the user's selected assets (or the SSOT fallback) so the universe is the
+    user's lever, never a hardcoded literal.
+    """
+
+    model_id = "claude-sonnet-4-20250514"
+    served_model = "glm-4.7"
+
+    def complete(self, system: str, user: str) -> str:
+        payload = json.loads(user)
+        ids = [p["arxiv_id"] for p in payload["candidate_papers"][:2]]
+        return json.dumps(
+            {
+                "strategy_name": "Universe-steer test fusion",
+                "thesis": "Pre-backtest hypothesis.",
+                "source_arxiv_ids": ids,
+                "fusion_reasoning": "Paper A + paper B.",
+                "novelty_rationale": "Joint combination unpublished.",
+                "risk_notes": "Pre-backtest; rigor gate pending.",
+                "strategy_spec": {
+                    "name": "Universe-steer test fusion",
+                    "asset_universe": ["SPY"],  # the model's stale default
+                    "rebalance_frequency": "monthly",
+                    "entry": {"gt": ["close", "sma_200"]},
+                    "exit": {"lt": ["close", "sma_200"]},
+                    "position_sizing": {"type": "full_invested_when_in_market"},
+                    "source_arxiv_ids": ids,
+                    "look_ahead_safe": True,
+                    "indicators": ["sma_200"],
+                },
+            }
+        )
+
+
+def test_universe_derived_from_user_selected_assets(monkeypatch, corpus):
+    """The user's selected instruments steer the spec universe, overriding the model.
+
+    Realistic steer: a broad class ("equities") drives paper retrieval, while the
+    specific instruments the user picked drive the concrete universe.
+    """
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    svc = StrategyFusion(backend=_SpecBackend(), corpus=corpus)
+    proposal = svc.propose(FusionBrief(asset_classes=["equities", "QQQ", "IWM"]))
+    assert proposal.status == "ok"
+    assert proposal.strategy_spec is not None
+    # The model emitted ["SPY"]; the service replaced it with the user's picks.
+    assert proposal.strategy_spec["asset_universe"] == ["QQQ", "IWM"]
+    assert proposal.strategy_spec["asset_universe"] != ["SPY"]
+
+
+def test_universe_falls_back_to_ssot_when_no_instrument_steer(monkeypatch, corpus):
+    """No concrete instrument in the steer → the full SSOT universe, never ["SPY"]."""
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    svc = StrategyFusion(backend=_SpecBackend(), corpus=corpus)
+    # Broad-class steer ("equities") drives the paper filter but resolves to no
+    # single instrument, so the universe falls back to the SSOT.
+    proposal = svc.propose(FusionBrief(asset_classes=["equities", "rates"]))
+    assert proposal.status == "ok"
+    assert proposal.strategy_spec is not None
+    universe = proposal.strategy_spec["asset_universe"]
+    assert universe != ["SPY"]  # never the bare hardcoded literal
+    assert universe == list(SUPPORTED_UNIVERSE)
+    assert len(universe) > 1  # a real multi-instrument universe
+
+
+def test_derive_asset_universe_resolves_synth_and_yfinance_aliases():
+    """The derivation accepts display symbols, synth keys, and yfinance tickers."""
+    assert derive_asset_universe(["SPY"]) == ["SPY"]
+    assert derive_asset_universe(["sSPY"]) == ["SPY"]  # synth key
+    assert derive_asset_universe(["spy"]) == ["SPY"]  # case-insensitive
+    # De-dupe + order-preserve across alias forms.
+    assert derive_asset_universe(["QQQ", "sQQQ", "QQQ"]) == ["QQQ"]
+
+
+def test_derive_asset_universe_empty_is_full_ssot_not_spy():
+    """Empty steer → the full supported universe, never a bare ["SPY"]."""
+    universe = derive_asset_universe([])
+    assert universe == list(SUPPORTED_UNIVERSE)
+    assert universe != ["SPY"]
+    assert "SPY" in universe  # SPY is *in* the universe, just not the whole of it
+
+
+def test_supported_universe_is_ssot_derived_and_nontrivial():
+    """The supported universe is derived from the GLOBAL_ASSETS SSOT, not a literal."""
+    assert "SPY" in SUPPORTED_UNIVERSE
+    assert "QQQ" in SUPPORTED_UNIVERSE
+    assert len(SUPPORTED_UNIVERSE) > 50  # the expanded multi-asset universe
+    assert tuple(sorted(SUPPORTED_UNIVERSE)) == SUPPORTED_UNIVERSE  # stable order

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { StrategyArchitect } from './Strategies'
 import GenerationStream from './GenerationStream'
 import GenerationStatus from './GenerationStatus'
 import FusionResult from './FusionResult'
 import PortfolioAdvisor from './PortfolioAdvisor'
 import ModelCostPanel from './ModelCostPanel'
+import { PROMPT_LIBRARY } from '../data/promptLibrary'
+import { ASSET_GROUPS, SUPPORTED_ASSETS } from '../data/assetUniverse'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -22,17 +24,9 @@ const RISK_PROFILES = [
   { id: 'aggressive', label: 'Aggressive' },
   { id: 'hyper_risky', label: 'Hyper-risky' },
 ]
-const ASSET_CLASSES = ['equities', 'bonds', 'commodities', 'crypto', 'fx']
-
-// Hand-picked briefs that route cleanly through the auto-router and produce
-// a strategy a user can deploy without further coaching. Click fills the
-// textarea so the user can edit before submitting.
-const EXAMPLE_BRIEFS = [
-  'A 13-week treasury alternative with low volatility and crypto upside on Fridays',
-  'Trend-following momentum on liquid US equity ETFs, rebalanced monthly, regime-aware',
-  'Defensive equity strategy that rotates into bonds when realized volatility spikes',
-  'Long-only large-cap value with a quality screen and a max-drawdown circuit breaker',
-]
+// Asset picker + starter prompt library are sourced from data files so they
+// stay in sync with the backend universe SSOT (assetUniverse.js mirrors
+// GLOBAL_ASSETS / issue #682) and are easy to extend (promptLibrary.js).
 
 export default function Generate({ onNavigate }) {
   // ── Unified form state ──
@@ -40,6 +34,7 @@ export default function Generate({ onNavigate }) {
   const [helpOpen, setHelpOpen] = useState(false)
   const [riskAppetite, setRiskAppetite] = useState('moderate')
   const [selectedAssets, setSelectedAssets] = useState([])
+  const [assetQuery, setAssetQuery] = useState('')
   const [depth, setDepth] = useState(5)       // replaces max_papers UI
   const [starting, setStarting] = useState(false)
   const [startError, setStartError] = useState('')
@@ -207,6 +202,28 @@ export default function Generate({ onNavigate }) {
     setSelectedAssets(prev => prev.includes(a) ? prev.filter(x => x !== a) : [...prev, a])
   }
 
+  const clearAssets = () => setSelectedAssets([])
+
+  // Click a starter prompt: fill the brief and pre-select its suggested assets
+  // (only those still in the supported universe), then collapse the help panel.
+  const applyExample = (example) => {
+    setIntent(example.brief)
+    if (Array.isArray(example.suggestedAssets) && example.suggestedAssets.length) {
+      const valid = example.suggestedAssets.filter(a => SUPPORTED_ASSETS.includes(a))
+      setSelectedAssets(valid)
+    }
+    setHelpOpen(false)
+  }
+
+  // Filter the asset groups by the live search box (matches the display symbol).
+  const filteredAssetGroups = useMemo(() => {
+    const q = assetQuery.trim().toLowerCase()
+    if (!q) return ASSET_GROUPS
+    return ASSET_GROUPS
+      .map(g => ({ ...g, assets: g.assets.filter(a => a.toLowerCase().includes(q)) }))
+      .filter(g => g.assets.length > 0)
+  }, [assetQuery])
+
   // ── Callback: GenerationStream tells us which pipeline was selected ──
   const handlePipelineEvent = (pipelineName) => {
     setPipelineFromEvent(pipelineName)
@@ -304,14 +321,15 @@ export default function Generate({ onNavigate }) {
                 <li>Reference recognizable patterns if it helps — "Kelly-sized momentum", "60/40 with regime overlay".</li>
               </ul>
 
-              <div className="label mb-2">Try an example (click to fill the box)</div>
+              <div className="label mb-2">Prompt library (click to fill the box)</div>
               <div className="flex flex-col gap-2">
-                {EXAMPLE_BRIEFS.map((p) => (
+                {PROMPT_LIBRARY.map((ex) => (
                   <button
-                    key={p}
+                    key={ex.id}
                     type="button"
-                    onClick={() => { setIntent(p); setHelpOpen(false) }}
+                    onClick={() => applyExample(ex)}
                     className="text-left"
+                    title={ex.brief}
                     style={{
                       padding: '8px 12px',
                       background: 'var(--bg-2)',
@@ -324,7 +342,7 @@ export default function Generate({ onNavigate }) {
                     }}
                   >
                     <span style={{ color: 'var(--accent)', marginRight: 8 }}>→</span>
-                    {p}
+                    {ex.label}
                   </button>
                 ))}
               </div>
@@ -346,16 +364,57 @@ export default function Generate({ onNavigate }) {
             disabled={starting}
           />
 
-          <div className="label mb-2">Asset classes (optional)</div>
-          <div className="flex gap-2 flex-wrap mb-4">
-            {ASSET_CLASSES.map(a => (
-              <span
-                key={a}
-                className={`tag ${selectedAssets.includes(a) ? 'tag-accent' : 'tag-muted'} cursor-pointer capitalize`}
-                onClick={() => toggleAsset(a)}
+          <div className="flex items-center justify-between mb-2">
+            <div className="label">
+              Assets (optional){selectedAssets.length > 0 ? ` · ${selectedAssets.length} selected` : ''}
+            </div>
+            {selectedAssets.length > 0 && (
+              <button
+                type="button"
+                onClick={clearAssets}
+                className="caption"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)' }}
               >
-                {a}
-              </span>
+                Clear
+              </button>
+            )}
+          </div>
+          <p className="caption mb-2" style={{ color: 'var(--text-3)' }}>
+            Pick the instruments to steer the strategy toward. Leave empty to let the
+            engine choose from the full supported universe.
+          </p>
+          <input
+            type="text"
+            value={assetQuery}
+            onChange={e => setAssetQuery(e.target.value)}
+            placeholder="Search assets (e.g. SPY, GOLD, BTC)…"
+            className="chat-input w-full mb-2 px-2.5 py-1.5"
+            disabled={starting}
+          />
+          <div
+            className="mb-4"
+            style={{ maxHeight: 220, overflowY: 'auto', paddingRight: 4 }}
+          >
+            {filteredAssetGroups.length === 0 && (
+              <div className="caption" style={{ color: 'var(--text-3)' }}>
+                No assets match “{assetQuery}”.
+              </div>
+            )}
+            {filteredAssetGroups.map(group => (
+              <div key={group.id} className="mb-2.5">
+                <div className="caption mb-1" style={{ color: 'var(--text-3)' }}>{group.label}</div>
+                <div className="flex gap-2 flex-wrap">
+                  {group.assets.map(a => (
+                    <span
+                      key={a}
+                      className={`tag ${selectedAssets.includes(a) ? 'tag-accent' : 'tag-muted'} cursor-pointer`}
+                      onClick={() => toggleAsset(a)}
+                    >
+                      {a}
+                    </span>
+                  ))}
+                </div>
+              </div>
             ))}
           </div>
 

--- a/ui/src/data/assetUniverse.js
+++ b/ui/src/data/assetUniverse.js
@@ -1,0 +1,94 @@
+// Supported-asset universe for the Generate asset picker (T1.6).
+//
+// Mirrors the backend single source of truth — GLOBAL_ASSETS in
+// backend/archimedes/services/strategy_signal_evaluator.py (issue #682). These
+// are the display symbols the strategy_fusion universe-derivation resolves; the
+// picker sends the user's selection as `asset_classes` on the generate request,
+// and the backend's derive_asset_universe() turns them into the strategy's
+// concrete asset_universe (never a hardcoded ["SPY"]).
+//
+// Kept add-only by convention: when GLOBAL_ASSETS grows, add the new display
+// symbol here so the picker exposes it. Grouped into user-facing buckets so the
+// chips stay scannable.
+
+export const ASSET_GROUPS = [
+  {
+    id: 'us_equity',
+    label: 'US equity & sectors',
+    assets: [
+      'SPY', 'QQQ', 'IWM', 'DIA',
+      'XLE', 'XLF', 'XLK', 'XLV', 'XLI', 'XLU',
+    ],
+  },
+  {
+    id: 'us_stocks',
+    label: 'US stocks',
+    assets: [
+      'AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'META', 'TSLA', 'AMD', 'AVGO',
+      'ORCL', 'CRM', 'NFLX', 'JPM', 'BAC', 'GS', 'V', 'MA', 'BRK.B', 'LLY',
+      'UNH', 'JNJ', 'MRK', 'PFE', 'XOM', 'CVX', 'COP', 'WMT', 'COST', 'HD',
+      'PG', 'COIN', 'MSTR', 'PLTR',
+    ],
+  },
+  {
+    id: 'intl_equity',
+    label: 'International equity',
+    assets: [
+      'ASML', 'SAP', 'NESN', 'NVO', 'AZN', 'SHEL', 'BP', 'HSBC', 'TTE', 'RHM',
+      'LVMH', 'SIE', 'EZU', 'DAX_ETF', 'FTSE_ETF', 'CAC_ETF', 'FTSE100',
+      'DAX40', 'CAC40', 'TSM', 'BABA', 'TM', 'SONY', 'SE', 'TCEHY', 'EWJ',
+      'NIKKEI', 'MCHI', 'INDA', 'EWY', 'EEM',
+    ],
+  },
+  {
+    id: 'turkey',
+    label: 'Turkish equity',
+    assets: [
+      'THYAO', 'KCHOL', 'GARAN', 'ASELS', 'AKBNK', 'SAHOL', 'BIMAS', 'EREGL',
+      'TUR_ETF', 'BIST100',
+    ],
+  },
+  {
+    id: 'metals',
+    label: 'Metals',
+    assets: [
+      'GLD', 'GOLD_FUT', 'SLV', 'SILVER_FUT', 'PLATINUM', 'PALLADIUM',
+      'COPPER_FUT', 'GDX', 'GDXJ',
+    ],
+  },
+  {
+    id: 'energy',
+    label: 'Energy',
+    assets: ['USO', 'WTI_FUT', 'BRENT_FUT', 'UNG', 'NATGAS_FUT'],
+  },
+  {
+    id: 'agriculture',
+    label: 'Agriculture',
+    assets: ['CORN_FUT', 'WHEAT_FUT', 'SOY_FUT'],
+  },
+  {
+    id: 'fixed_income',
+    label: 'Fixed income & credit',
+    assets: [
+      'TLT', 'IEF', 'SHY', 'BIL', 'TIP', 'AGG', 'HYG', 'LQD', 'EMB', 'MUB',
+    ],
+  },
+  {
+    id: 'fx',
+    label: 'FX',
+    assets: ['EUR/USD', 'USD/TRY', 'GBP/USD', 'USD/JPY'],
+  },
+  {
+    id: 'crypto',
+    label: 'Crypto',
+    assets: ['BTC', 'ETH', 'SOL'],
+  },
+]
+
+// Flat, de-duped list of every supported display symbol (handy for validation
+// and search). Mirrors the union of ASSET_GROUPS[*].assets.
+export const SUPPORTED_ASSETS = Array.from(
+  new Set(ASSET_GROUPS.flatMap((g) => g.assets)),
+)
+
+export default ASSET_GROUPS

--- a/ui/src/data/promptLibrary.js
+++ b/ui/src/data/promptLibrary.js
@@ -1,0 +1,74 @@
+// Starter prompt library for the Generate flow (T1.6).
+//
+// Hand-picked briefs that route cleanly through the backend auto-router
+// (_pick_pipeline → Fusion / Architect / Agent) and produce a strategy a user
+// can deploy without further coaching. Clicking one fills the brief textarea so
+// the user can edit/vary it before submitting.
+//
+// Each entry pairs a short, clickable `label` (what the chip/card shows) with
+// the full `brief` text that lands in the input. `suggestedAssets` (optional)
+// are display symbols from the supported universe (see assetUniverse.js) the
+// example pairs well with — the UI can pre-select them alongside the brief.
+//
+// Keep this list tight and high-signal: a few good examples beat a long menu.
+
+export const PROMPT_LIBRARY = [
+  {
+    id: 'treasury-alt-crypto-friday',
+    label: 'Treasury alternative with Friday crypto upside',
+    brief:
+      'A 13-week treasury alternative with low volatility and crypto upside on Fridays',
+    suggestedAssets: ['SHY', 'BIL', 'BTC'],
+  },
+  {
+    id: 'trend-momentum-etfs',
+    label: 'Regime-aware trend momentum on US ETFs',
+    brief:
+      'Trend-following momentum on liquid US equity ETFs, rebalanced monthly, regime-aware',
+    suggestedAssets: ['SPY', 'QQQ', 'IWM'],
+  },
+  {
+    id: 'defensive-vol-rotation',
+    label: 'Defensive equity that rotates to bonds in vol spikes',
+    brief:
+      'Defensive equity strategy that rotates into bonds when realized volatility spikes',
+    suggestedAssets: ['SPY', 'TLT', 'IEF'],
+  },
+  {
+    id: 'value-quality-circuit-breaker',
+    label: 'Large-cap value + quality with a drawdown circuit breaker',
+    brief:
+      'Long-only large-cap value with a quality screen and a max-drawdown circuit breaker',
+    suggestedAssets: ['SPY', 'XLF', 'XLV'],
+  },
+  {
+    id: 'gold-miners-pairs',
+    label: 'Gold vs. gold-miners relative-value pair',
+    brief:
+      'A relative-value pair trade between gold and gold miners, mean-reverting on the spread, with a volatility-scaled position size',
+    suggestedAssets: ['GLD', 'GDX'],
+  },
+  {
+    id: 'sector-momentum-rotation',
+    label: 'Monthly sector-momentum rotation',
+    brief:
+      'Rotate monthly into the top-performing US sectors by 6-month momentum, with a defensive cash sleeve when the broad market is below its 200-day average',
+    suggestedAssets: ['XLK', 'XLE', 'XLF', 'XLV', 'XLI'],
+  },
+  {
+    id: 'risk-parity-60-40',
+    label: 'Risk-parity 60/40 with a regime overlay',
+    brief:
+      'A risk-parity take on the classic 60/40 stocks-and-bonds portfolio, with a macro-regime overlay that trims equity exposure in contractions',
+    suggestedAssets: ['SPY', 'TLT', 'GLD'],
+  },
+  {
+    id: 'crypto-momentum-vol-target',
+    label: 'Volatility-targeted crypto momentum',
+    brief:
+      'Trend-following momentum on major crypto with a volatility target so position size shrinks when realized vol rises',
+    suggestedAssets: ['BTC', 'ETH', 'SOL'],
+  },
+]
+
+export default PROMPT_LIBRARY


### PR DESCRIPTION
## What changed

**T1.6 — Generation UX + prompt library.** Let users steer the asset universe from their chosen assets (never a hardcoded literal), and give them a starter prompt library.

### Backend — drop the hardcoded `["SPY"]` universe (`strategy_fusion.py`)
- The fusion `strategy_spec` no longer hardcodes the asset universe. The `_SYSTEM_PROMPT` example schema dropped the `["SPY"]` seed (now a neutral `["<ticker>", ...]` placeholder), and after parsing, a new `derive_asset_universe()` **overrides** whatever the model emitted with the user's selected assets.
- The universe is **derived from the user's selection** (`brief.asset_classes`), resolving display symbols (`SPY`), synth keys (`sSPY`), and yfinance tickers against the **instrument SSOT** — `GLOBAL_ASSETS` in `strategy_signal_evaluator.py` (issue #682). It's backend-local and hermetic (no analytics-engine dependency).
- When the steer resolves to **no concrete instrument** (e.g. a broad-class term the paper filter consumes, like "equities"), it **falls back to the full supported universe** — never a bare `["SPY"]`.
- Added `SUPPORTED_UNIVERSE` (SSOT-derived) and 5 hermetic unit tests: user-pick override, SSOT fallback, alias resolution, the no-`["SPY"]`-literal invariant, and the SSOT-derived universe shape.

### Frontend — asset picker + prompt library (`Generate.jsx` + `ui/src/data/`)
- Replaced the 5 broad-class chips with a **grouped, searchable multi-select picker of the supported instruments** (`assetUniverse.js`, which mirrors the backend `GLOBAL_ASSETS` SSOT). Uses the existing `tag` / `tag-accent` / `tag-muted` chip patterns and CSS vars. The selection rides through on `asset_classes`, steering the derived universe.
- Moved the example briefs out of the component into a data file (`ui/src/data/promptLibrary.js`) and surfaced them as a **clickable starter prompt library** — clicking one fills the brief textarea and pre-selects the example's suggested assets, then the user can edit/vary.

## Verification
- `grep -n "\['SPY'\]" backend/archimedes/agents/strategy_fusion.py` → **no match** (hardcoded literal gone)
- `pytest backend/tests/test_strategy_fusion.py` → **32 passed** (hermetic gate clean: `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest …`)
- `ruff format --check` + `ruff check` on changed Python → **clean**
- `cd ui && npm run build` → **✓ built**
- `cd ui && npm run lint` → **clean**

## Scope notes / cross-lane
- Backend change is tight: universe-derivation fix + passing the user's selected assets through. No change to the paper-retrieval filter semantics (broad-class terms still drive `_asset_terms`).
- Touches the strategy engine (Dan's lane) + frontend (Marten / Daniel R.). Flagging for a frontend + strategy-engine review eye.

🤖 Generated with Claude Code