### PR TITLE
[backend] T0.5 — loud fallback telemetry (GMM-unfit + risk-mock /health flags)

### DIFF
--- a/backend/archimedes/api/risk_routes.py
+++ b/backend/archimedes/api/risk_routes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import math
+from dataclasses import dataclass
 
 import numpy as np
 import scipy.stats
@@ -30,6 +31,68 @@ logger = logging.getLogger(__name__)
 risk_router = APIRouter(prefix="/api/risk", tags=["risk"])
 
 _strategy_provider = default_provider()
+
+
+# ── Loud-fallback telemetry (T0.5) ───────────────────────────
+# The Risk Analysis UI renders correlation, drawdown and rolling-Sharpe panels
+# from client-side ``mockReturns`` whenever no live source backs them, and the
+# CVaR/Greeks endpoints return empty/zero levels when no persisted backtest has
+# an equity curve. That mock data must NOT be silently presented as real. This
+# probe reports whether the risk surface is backed by live persisted backtests
+# or is falling back to mock/placeholder data, so ``/health`` can surface it.
+
+
+@dataclass(frozen=True)
+class RiskDataHealth:
+    """Health diagnostic for the risk-analysis data surface (T0.5)."""
+
+    status: str  # live | mock
+    reason: str = ""
+
+
+def risk_data_health() -> RiskDataHealth:
+    """Report whether the risk surface is backed by live data or mock fallback.
+
+    - ``live``: at least one persisted backtest carries an equity curve, so the
+      CVaR/series surface is derived from real strategy history.
+    - ``mock``: no persisted equity data exists, so the risk UI renders from
+      client-side ``mockReturns`` placeholders. Visible-not-silent: the product
+      would otherwise present placeholder tail-risk numbers as if they were real.
+
+    Never raises — a provider/DB hiccup degrades to ``mock`` (the honest
+    conservative default) with the exception surfaced in the reason.
+    """
+    try:
+        strategies = _strategy_provider.list_strategies()
+        live_curves = sum(
+            1
+            for s in strategies
+            if (bt := _strategy_provider.get_backtest_result(s.id)) is not None and len(bt.equity_curve) >= 2
+        )
+    except Exception as exc:  # provider/DB unavailable → honest mock fallback
+        logger.warning(
+            "Risk data probe failed — assuming mock surface: %s",
+            exc,
+            extra={"event": "risk_data_mock", "reason": "probe_failed", "surface": "risk_analysis"},
+        )
+        return RiskDataHealth(status="mock", reason=f"risk data probe failed ({exc})")
+
+    if live_curves > 0:
+        return RiskDataHealth(
+            status="live",
+            reason=f"{live_curves} persisted backtest(s) with equity curves",
+        )
+
+    logger.warning(
+        "Risk surface degraded to mock data — no persisted backtest equity curves; "
+        "UI correlation/drawdown/rolling-Sharpe panels render placeholder mockReturns",
+        extra={"event": "risk_data_mock", "reason": "no_equity_curves", "surface": "risk_analysis"},
+    )
+    return RiskDataHealth(
+        status="mock",
+        reason="no persisted backtest equity curves — risk UI renders placeholder mock data",
+    )
+
 
 # ── Risk Profile Bands ───────────────────────────────────────
 # Thresholds used to classify a portfolio into one of five tiers.

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -286,6 +286,34 @@ async def health():
     except Exception:
         paper_rag_reason = "import failed"
 
+    # GMM regime-detector health (T0.5 — loud fallback telemetry).
+    # "degraded" => no fitted artifact, rule-based VixRegimeDetector fallback
+    # active. Surfaced so rule-based regime calls aren't presented as data-driven.
+    regime_detector_status = "unknown"
+    regime_detector_reason = ""
+    try:
+        from archimedes.services.gmm_regime_detector import gmm_regime_health
+
+        _gmm_diag = gmm_regime_health()
+        regime_detector_status = _gmm_diag.status
+        regime_detector_reason = _gmm_diag.reason
+    except Exception:
+        regime_detector_reason = "import failed"
+
+    # Risk-analysis data health (T0.5 — loud fallback telemetry).
+    # "mock" => no persisted backtest equity curves, so the Risk UI renders
+    # placeholder mockReturns. Surfaced so mock tail-risk isn't presented as real.
+    risk_data_status = "unknown"
+    risk_data_reason = ""
+    try:
+        from archimedes.api.risk_routes import risk_data_health
+
+        _risk_diag = risk_data_health()
+        risk_data_status = _risk_diag.status
+        risk_data_reason = _risk_diag.reason
+    except Exception:
+        risk_data_reason = "import failed"
+
     return {
         "status": "ok" if connected else "degraded",
         "service": "archimedes-backend",
@@ -305,6 +333,10 @@ async def health():
         "llm_has_base_url": bool(os.getenv("LLM_BASE_URL") or os.getenv("ANTHROPIC_BASE_URL")),
         "paper_rag": paper_rag_status,
         "paper_rag_reason": paper_rag_reason,
+        "regime_detector": regime_detector_status,
+        "regime_detector_reason": regime_detector_reason,
+        "risk_data": risk_data_status,
+        "risk_data_reason": risk_data_reason,
     }
 
 

--- a/backend/archimedes/services/gmm_regime_detector.py
+++ b/backend/archimedes/services/gmm_regime_detector.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import logging
 import pickle
+import weakref
 from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -119,6 +120,56 @@ class FittedGmm:
     scaler: StandardScaler
     gmm: GaussianMixture
     component_to_regime: dict[int, Regime]
+
+
+@dataclass(frozen=True)
+class GmmRegimeHealth:
+    """Health diagnostic for the GMM regime detector subsystem (T0.5).
+
+    Mirrors ``PaperRAGHealth`` so ``/health`` can surface GMM degradation the
+    same way it surfaces the paper-RAG TF-IDF fallback.
+    """
+
+    status: str  # live | degraded
+    reason: str = ""
+
+
+# Weak reference to the most-recently-constructed detector, so the module-level
+# ``gmm_regime_health()`` probe used by ``/health`` can report the live
+# instance's state without the request handler needing a handle on the agent
+# runner. A weakref avoids pinning a detector alive past its natural lifetime.
+_LAST_DETECTOR: weakref.ReferenceType[GmmRegimeDetector] | None = None
+
+
+def _register_detector(detector: GmmRegimeDetector) -> None:
+    """Record the newest detector instance for the health probe."""
+    global _LAST_DETECTOR
+    _LAST_DETECTOR = weakref.ref(detector)
+
+
+def gmm_regime_health() -> GmmRegimeHealth:
+    """Report GMM regime-detector health for ``/health`` (T0.5).
+
+    - ``live``: a fitted GMM artifact is loaded → data-driven regime calls.
+    - ``degraded``: no fitted artifact → every classify delegates to the
+      rule-based ``VixRegimeDetector`` fallback. This is the expected steady
+      state until ``scripts/fit_gmm_regime.py`` produces an artifact, but it
+      MUST be visible rather than silent: rule-based calls would otherwise be
+      presented as if the data-driven model were live.
+
+    Probes the most-recently-constructed detector if one exists; otherwise
+    checks the default artifact path directly so the flag is meaningful even
+    before any detector is instantiated (e.g. a cold ``/health`` hit).
+    """
+    detector = _LAST_DETECTOR() if _LAST_DETECTOR is not None else None
+    if detector is not None:
+        return detector.health()
+    if DEFAULT_GMM_MODEL_PATH.exists():
+        return GmmRegimeHealth(status="live", reason="data-driven GMM regime model present")
+    return GmmRegimeHealth(
+        status="degraded",
+        reason=f"no fitted GMM model at {DEFAULT_GMM_MODEL_PATH} — rule-based fallback active",
+    )
 
 
 def _label_components(scaler: StandardScaler, gmm: GaussianMixture) -> dict[int, Regime]:
@@ -243,6 +294,7 @@ class GmmRegimeDetector:
         seed_history: list[tuple[float, float]] | None = None,
     ) -> None:
         self._model: FittedGmm | None = load_gmm_model(model_path)
+        self._model_path = Path(model_path)
         self._fallback: IRegimeDetector = fallback or VixRegimeDetector()
         # Rolling (vix, spy_price) buffer, optionally pre-seeded for tests / warm
         # starts. maxlen caps memory; we only ever read the trailing window.
@@ -254,6 +306,62 @@ class GmmRegimeDetector:
         self._pending_regime: Regime | None = None
         self._pending_count: int = 0
         self._last: RegimeClassification | None = None
+        # ── Loud-fallback telemetry (T0.5) ───────────────────────────
+        # The detector silently delegating to the rule-based fallback is a
+        # claim-integrity issue: the product would present rule-based regime
+        # calls as if the data-driven GMM were live. We track the degradation
+        # explicitly so /health can surface it, and we WARN once-per-reason so
+        # the log carries the structured signal without spamming on every tick.
+        self._fallback_warned: set[str] = set()
+        if self._model is None:
+            self._warn_fallback(
+                "no_fitted_model",
+                f"GMM regime model artifact absent at {self._model_path} — "
+                "delegating to rule-based VixRegimeDetector fallback",
+            )
+        # Register as the most-recently-constructed detector so the module-level
+        # gmm_regime_health() probe (used by /health) can report live state.
+        _register_detector(self)
+
+    def _warn_fallback(self, reason: str, detail: str) -> None:
+        """Emit a structured WARN for a fallback/degradation, once per reason.
+
+        ``reason`` is a stable machine key (logged as ``fallback_reason``) so
+        downstream log search can pivot on it; ``detail`` is the human message.
+        Deduped per detector instance so a per-tick fallback path warns once,
+        not on every ``classify`` call.
+        """
+        if reason in self._fallback_warned:
+            return
+        self._fallback_warned.add(reason)
+        logger.warning(
+            "GMM regime detector degraded — silent fallback averted: %s",
+            detail,
+            extra={
+                "event": "gmm_regime_fallback",
+                "fallback_reason": reason,
+                "detector": "GmmRegimeDetector",
+            },
+        )
+
+    @property
+    def is_degraded(self) -> bool:
+        """True when no fitted GMM model is loaded (rule-based fallback active).
+
+        This is the steady-state degradation signal: with no offline-fitted
+        artifact present, *every* ``classify`` call delegates to the rule-based
+        fallback, so the data-driven detector is not actually live.
+        """
+        return self._model is None
+
+    def health(self) -> GmmRegimeHealth:
+        """Per-instance health diagnostic (live | degraded)."""
+        if self._model is None:
+            return GmmRegimeHealth(
+                status="degraded",
+                reason=f"no fitted GMM model at {self._model_path} — rule-based fallback active",
+            )
+        return GmmRegimeHealth(status="live", reason="data-driven GMM regime model loaded")
 
     # ─── IRegimeDetector ─────────────────────────────────────────────
 
@@ -275,6 +383,12 @@ class GmmRegimeDetector:
 
         # ── Fallback conditions ──────────────────────────────────────
         if self._model is None or vix is None or spy_price is None or len(self._buffer) < _MIN_HISTORY:
+            self._warn_fallback(
+                self._fallback_reason(vix, spy_price),
+                "classify() delegated to rule-based VixRegimeDetector "
+                f"(model_loaded={self._model is not None}, vix={vix is not None}, "
+                f"spy_price={spy_price is not None}, history={len(self._buffer)}/{_MIN_HISTORY})",
+            )
             result = self._fallback.classify(snapshot)
             self._last = result
             return result
@@ -350,6 +464,14 @@ class GmmRegimeDetector:
         realized_vol_21d = float(np.std(daily_returns) * np.sqrt(_TRADING_DAYS_PER_YEAR))
 
         return np.array([vix_now, vix_21d_chg, realized_vol_21d, return_21d], dtype=float)
+
+    def _fallback_reason(self, vix: float | None, spy_price: float | None) -> str:
+        """Stable machine key naming WHY the GMM path was skipped this tick."""
+        if self._model is None:
+            return "no_fitted_model"
+        if vix is None or spy_price is None:
+            return "missing_market_data"
+        return "insufficient_history"
 
     @staticmethod
     def _spy_price(snapshot: MarketSnapshot) -> float | None:

--- a/backend/tests/test_loud_fallback_telemetry.py
+++ b/backend/tests/test_loud_fallback_telemetry.py
@@ -1,0 +1,190 @@
+"""Hermetic coverage for T0.5 loud-fallback telemetry.
+
+Two silent-degradation gaps closed here, each asserted to (a) flip a ``/health``
+flag and (b) emit a structured WARN at the fallback site:
+
+1. GMM-unfit — ``GmmRegimeDetector`` with no fitted artifact delegates to the
+   rule-based ``VixRegimeDetector``. The detector must report ``degraded`` and
+   warn, and ``gmm_regime_health()`` (the ``/health`` probe) must agree.
+2. Risk-mock — the Risk Analysis surface renders client-side ``mockReturns``
+   when no persisted backtest carries an equity curve. ``risk_data_health()``
+   must report ``mock`` and warn; ``live`` when real equity data exists.
+
+No DB / Redis / network / .env — boundaries are mocked (``load_gmm_model`` and
+the strategy provider), so the file runs under the hermetic gate:
+
+    env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \\
+        python -m pytest backend/tests/test_loud_fallback_telemetry.py -q
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import archimedes.api.risk_routes as risk_routes
+import archimedes.services.gmm_regime_detector as gmm_mod
+import numpy as np
+import pytest
+from archimedes.models.asset import MarketSnapshot
+from archimedes.services.gmm_regime_detector import (
+    GmmRegimeDetector,
+    fit_gmm_model,
+    gmm_regime_health,
+)
+from httpx import ASGITransport, AsyncClient
+
+# A path guaranteed not to exist, so the detector's load returns None and the
+# fallback path is taken (no real artifact is ever committed — see module docs).
+_ABSENT_MODEL = Path("/nonexistent/gmm_model_does_not_exist.pkl")
+
+
+def _snapshot(*, vix: float | None = 20.0, spy: float | None = 5000.0) -> MarketSnapshot:
+    prices: dict[str, float] = {}
+    if spy is not None:
+        prices["sSPY"] = spy
+    return MarketSnapshot(timestamp=datetime.now(UTC), prices=prices, vix=vix)
+
+
+def _fitted_model() -> object:
+    """A real ``FittedGmm`` from synthetic features — pure, no I/O."""
+    rng = np.random.default_rng(0)
+    # Four loose clusters in the 4-feature space so labelling has something to do.
+    feats = np.vstack(
+        [
+            rng.normal([15, 0.0, 0.10, 0.05], 1.0, size=(60, 4)),
+            rng.normal([22, 0.2, 0.18, -0.02], 1.0, size=(60, 4)),
+            rng.normal([30, 0.4, 0.30, -0.08], 1.0, size=(60, 4)),
+            rng.normal([45, 0.8, 0.50, -0.20], 1.0, size=(60, 4)),
+        ]
+    )
+    return fit_gmm_model(feats, random_state=42)
+
+
+# ── Gap 1: GMM-unfit telemetry ───────────────────────────────────────
+
+
+class TestGmmUnfitTelemetry:
+    def test_unfit_detector_reports_degraded(self) -> None:
+        det = GmmRegimeDetector(model_path=_ABSENT_MODEL)
+        assert det.is_degraded is True
+        assert det.health().status == "degraded"
+        assert "fallback" in det.health().reason.lower()
+
+    def test_unfit_construction_emits_structured_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=gmm_mod.__name__):
+            GmmRegimeDetector(model_path=_ABSENT_MODEL)
+        recs = [r for r in caplog.records if getattr(r, "event", None) == "gmm_regime_fallback"]
+        assert recs, "expected a structured gmm_regime_fallback WARN at construction"
+        assert recs[0].levelno == logging.WARNING
+        assert recs[0].fallback_reason == "no_fitted_model"
+
+    def test_classify_fallback_warns_once_not_per_tick(self, caplog: pytest.LogCaptureFixture) -> None:
+        det = GmmRegimeDetector(model_path=_ABSENT_MODEL)
+        with caplog.at_level(logging.WARNING, logger=gmm_mod.__name__):
+            for _ in range(5):
+                det.classify(_snapshot())
+        # Construction already consumed "no_fitted_model"; the classify path
+        # dedupes on the same reason, so no *additional* duplicate WARNs spam.
+        reasons = [getattr(r, "fallback_reason", None) for r in caplog.records]
+        assert reasons.count("no_fitted_model") <= 1
+
+    def test_module_health_probe_reports_degraded_when_unfit(self) -> None:
+        # Construct an unfit detector → it registers itself as the live instance.
+        GmmRegimeDetector(model_path=_ABSENT_MODEL)
+        diag = gmm_regime_health()
+        assert diag.status == "degraded"
+
+    def test_fitted_detector_reports_live(self) -> None:
+        with patch.object(gmm_mod, "load_gmm_model", return_value=_fitted_model()):
+            det = GmmRegimeDetector(model_path=_ABSENT_MODEL)
+        assert det.is_degraded is False
+        assert det.health().status == "live"
+        assert gmm_regime_health().status == "live"
+
+
+# ── Gap 2: risk-mock telemetry ───────────────────────────────────────
+
+
+def _provider_with(curves: list[list[float]]) -> MagicMock:
+    """A fake strategy provider whose backtests carry the given equity curves."""
+    provider = MagicMock()
+    strategies = []
+    by_id: dict[str, MagicMock] = {}
+    for i, curve in enumerate(curves):
+        sid = f"s{i}"
+        strat = MagicMock()
+        strat.id = sid
+        strategies.append(strat)
+        bt = MagicMock()
+        bt.equity_curve = curve
+        by_id[sid] = bt
+    provider.list_strategies.return_value = strategies
+    provider.get_backtest_result.side_effect = lambda sid: by_id.get(sid)
+    return provider
+
+
+class TestRiskMockTelemetry:
+    def test_no_equity_curves_reports_mock(self, caplog: pytest.LogCaptureFixture) -> None:
+        provider = _provider_with([[], [1.0]])  # both too short (< 2 points)
+        with (
+            patch.object(risk_routes, "_strategy_provider", provider),
+            caplog.at_level(logging.WARNING, logger=risk_routes.__name__),
+        ):
+            diag = risk_routes.risk_data_health()
+        assert diag.status == "mock"
+        recs = [r for r in caplog.records if getattr(r, "event", None) == "risk_data_mock"]
+        assert recs, "expected a structured risk_data_mock WARN"
+        assert recs[0].reason == "no_equity_curves"
+
+    def test_live_equity_curves_report_live_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        provider = _provider_with([[1.0, 1.1, 1.2]])  # a real curve (>= 2 points)
+        with (
+            patch.object(risk_routes, "_strategy_provider", provider),
+            caplog.at_level(logging.WARNING, logger=risk_routes.__name__),
+        ):
+            diag = risk_routes.risk_data_health()
+        assert diag.status == "live"
+        assert not [r for r in caplog.records if getattr(r, "event", None) == "risk_data_mock"]
+
+    def test_provider_failure_degrades_to_mock(self, caplog: pytest.LogCaptureFixture) -> None:
+        provider = MagicMock()
+        provider.list_strategies.side_effect = RuntimeError("db down")
+        with (
+            patch.object(risk_routes, "_strategy_provider", provider),
+            caplog.at_level(logging.WARNING, logger=risk_routes.__name__),
+        ):
+            diag = risk_routes.risk_data_health()
+        assert diag.status == "mock"
+        recs = [r for r in caplog.records if getattr(r, "event", None) == "risk_data_mock"]
+        assert recs and recs[0].reason == "probe_failed"
+
+
+# ── /health surfaces both flags ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_surfaces_regime_and_risk_flags() -> None:
+    """/health exposes regime_detector + risk_data flags alongside paper_rag."""
+    from archimedes.main import app
+
+    # Force both subsystems into their degraded states at the boundary.
+    degraded_risk = risk_routes.RiskDataHealth(status="mock", reason="test mock")
+    with (
+        patch.object(gmm_mod, "load_gmm_model", return_value=None),
+        patch.object(risk_routes, "risk_data_health", return_value=degraded_risk),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Existing flags stay intact.
+    assert "paper_rag" in body
+    # New T0.5 flags present and degraded.
+    assert body["regime_detector"] == "degraded"
+    assert "regime_detector_reason" in body
+    assert body["risk_data"] == "mock"
+    assert body["risk_data_reason"] == "test mock"


### PR DESCRIPTION
## Summary

**T0.5 — Loud fallback telemetry.** Funds-adjacent claim-integrity work: **no silent degradation.** Emit a structured WARN **and** surface a `/health` flag whenever the product silently degrades to a fallback. Closes the two known gaps; keeps the existing `paper_rag` / `llm_*` flags intact.

## What changed

**1. GMM-unfit (`services/gmm_regime_detector.py`)**
- The detector used to delegate to the rule-based `VixRegimeDetector` *silently* — rule-based regime calls were presented as if the data-driven GMM were live.
- Now tracks degradation explicitly: `is_degraded`, `health()`, and a module-level `gmm_regime_health()` probe mirroring `paper_rag_health()`.
- Emits a structured WARN once at construction when no fitted artifact loads (`event=gmm_regime_fallback`, `fallback_reason=no_fitted_model`) and dedupes the per-`classify` fallback WARN so it never spams per-tick.

**2. Risk-mock (`api/risk_routes.py`)**
- The Risk Analysis UI renders client-side `mockReturns` for the correlation / drawdown / rolling-Sharpe panels whenever no live source backs them — silently presented as real.
- New `risk_data_health()` reports `mock` when no persisted backtest carries an equity curve (and WARNs, `event=risk_data_mock`), `live` when real equity data backs the surface. A provider/DB failure degrades to the honest `mock` default.

**3. `/health` (`main.py`)**
- New flags `regime_detector` + `risk_data` (each with a `*_reason`), built the same way as `paper_rag`. Existing flags unchanged.

**Out of scope / anti-collision:** does **not** touch `strategy_fusion.py` asset-universe/SPY logic (parallel agent owns that).

## Test evidence

New hermetic test `backend/tests/test_loud_fallback_telemetry.py` (boundary-mocked `load_gmm_model` + strategy provider; no DB/Redis/network/.env) asserts each flag flips and each WARN fires:

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend conda run -n archimedes \
  python -m pytest backend/tests/test_loud_fallback_telemetry.py -q
=> 9 passed
```

No regressions in related suites:
```
pytest test_risk_routes.py test_risk_cvar_greeks.py test_health_amm.py \
       services/test_vix_regime_detector.py test_rigor_regime.py -q
=> 69 passed
```

End-to-end `/health` (degraded states forced):
```
status_code: 200
  paper_rag           = 'degraded'   # unchanged
  regime_detector     = 'degraded'   # NEW
  risk_data           = 'mock'       # NEW
```

ruff: `ruff format --check` clean + full `ruff check` clean on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)