### PR TITLE
[provenance] T0.3+T1.4 — commit/reveal anchoring + Pinata IPFS CID

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -28,6 +28,7 @@ from datetime import UTC, datetime
 from archimedes.chain.client import chain_client
 from archimedes.chain.executor import InsufficientLiquidityError, chain_executor
 from archimedes.chain.oracle_updater import OracleUpdater
+from archimedes.chain.provenance_publisher import pin_public_provenance
 from archimedes.chain.trace_publisher import trace_publisher
 from archimedes.chain.v_check import VCheck
 from archimedes.interfaces.math import IRegimeDetector
@@ -675,18 +676,21 @@ class StrategyRunner:
 
         commit_tx = None
         commit_block = None
+        commit_trace_id: int | None = None
 
-        if not DRY_RUN:
-            commit_tx, commit_block = await self._commit_trace(
-                vault_address,
-                trades,
-                all_signals,
-                market_regime,
-                consensus,
-                tick_id,
-                reasoning,
-                portfolio,
-            )
+        # Build + commit the canonical trace ONCE. The same trace object is revealed
+        # after settlement so the on-chain keccak256 binding holds. In dry-run we still
+        # build it (no on-chain commit) so the reveal/persist path has a trace to use.
+        committed_trace, commit_trace_id, commit_tx, commit_block = await self._commit_trace(
+            vault_address,
+            trades,
+            all_signals,
+            market_regime,
+            consensus,
+            tick_id,
+            reasoning,
+            portfolio,
+        )
 
         # Phase 2: TRADE — execute the rebalance
         if DRY_RUN:
@@ -759,18 +763,11 @@ class StrategyRunner:
                 )
                 return
 
-        # Phase 3: REVEAL — publish full trace with all data AFTER trade settles
+        # Phase 3: REVEAL — pin public provenance + reveal the SAME committed trace
         await self._reveal_trace(
-            vault_address,
-            DecisionType.REBALANCE,
-            "strategy_signal_drift",
-            portfolio,
-            trades,
-            all_signals,
-            market_regime,
-            consensus,
+            committed_trace,
+            commit_trace_id,
             tick_id,
-            reasoning,
             tx_hashes,
             commit_tx=commit_tx,
             commit_block=commit_block,
@@ -845,6 +842,12 @@ class StrategyRunner:
 
     # ─── Commit-Reveal Trace ────────────────────────────────────
 
+    # How far in the future the committed execution is claimed to land. The
+    # contract requires claimedExecutionTime > commit-block timestamp, so the
+    # reveal can only succeed once this lead window has elapsed — proving the
+    # trade landed strictly after the commit (causal ordering).
+    _COMMIT_EXECUTION_LEAD_S = 60
+
     async def _commit_trace(
         self,
         vault_address: str,
@@ -855,23 +858,29 @@ class StrategyRunner:
         tick_id: str,
         reasoning: str,
         portfolio: Portfolio,
-    ) -> tuple[str | None, int | None]:
-        """Commit phase: publish trace hash on-chain BEFORE the trade executes.
+    ) -> tuple[ReasoningTrace, int | None, str | None, int | None]:
+        """Commit phase: anchor the trace hash on-chain BEFORE the trade executes.
 
-        Returns (commit_tx_hash, commit_block_number) or (None, None) on failure.
+        Builds the canonical trace ONCE and commits its keccak256 via the registry's
+        real ``commit()`` (with claimedExecutionTime) so the same bytes can be revealed
+        after settlement and the on-chain hash binding holds. Falls back to the v1
+        ``publishTrace`` anchor when the deployed registry is pre-v1.5 (#588 redeploy).
+
+        Returns (trace, on_chain_trace_id, commit_tx_hash, commit_block_number).
+        The trace is always returned so reveal() can submit the identical content;
+        trace_id is None when commit-reveal is unavailable (publishTrace fallback).
         """
         trace = ReasoningTrace(
             id=str(uuid.uuid4()),
             vault_address=vault_address,
             decision_type=DecisionType.REBALANCE,
-            trigger="commit_phase",
+            trigger="strategy_signal_drift",
             timestamp=datetime.now(UTC),
             market_context={
                 "regime": market_regime,
                 "ensemble_consensus": consensus.label.value,
                 "ensemble_flat_pct": round(consensus.flat_pct, 4),
                 "strategy_count": len(all_signals),
-                "phase": "commit",
             },
             portfolio_before={
                 "vault": vault_address[:10],
@@ -880,12 +889,9 @@ class StrategyRunner:
                     h.symbol: {"weight": f"{h.weight:.1%}", "value_usdc": h.value_usdc} for h in portfolio.holdings
                 },
             },
-            reasoning=f"[COMMIT] {reasoning}",
+            reasoning=reasoning,
             confidence=_compute_confidence(all_signals),
-            trades_executed=[
-                {"symbol": t.symbol, "direction": t.direction.value, "amount": t.amount, "phase": "intended"}
-                for t in trades
-            ],
+            trades_executed=[{"symbol": t.symbol, "direction": t.direction.value, "amount": t.amount} for t in trades],
             strategies_referenced=[ss.strategy_id for ss in all_signals],
             consulted_paper_hashes=_paper_hashes_from_signals(all_signals),
         )
@@ -893,115 +899,122 @@ class StrategyRunner:
         trace.compute_hash()
         logger.info("[tick %s] COMMIT hash: %s", tick_id, trace.trace_hash[:16])
 
+        if DRY_RUN:
+            logger.info("[tick %s] DRY RUN — skipping on-chain commit", tick_id)
+            return trace, None, None, None
+
+        claimed_execution_time = int(datetime.now(UTC).timestamp()) + self._COMMIT_EXECUTION_LEAD_S
+        intent_summary = f"{trace.decision_type.value}:{len(trades)}".encode()
+
         try:
+            if trace_publisher.supports_commit_reveal():
+                trace_id, commit_tx, commit_block = await trace_publisher.commit(
+                    trace, claimed_execution_time, intent_summary
+                )
+                if commit_tx:
+                    logger.info(
+                        "[tick %s] COMMIT anchored (commit-reveal): id=%s tx=%s block=%s",
+                        tick_id,
+                        trace_id,
+                        commit_tx[:16],
+                        commit_block,
+                    )
+                return trace, trace_id, commit_tx, commit_block
+
+            # Fallback: v1 publishTrace anchor (no temporal binding).
             arc_tx = await trace_publisher.publish(trace)
+            commit_block = None
             if arc_tx:
-                # Get block number from commit tx
                 try:
                     receipt = await chain_client.w3.eth.get_transaction_receipt(
                         chain_client.w3.to_bytes(hexstr=arc_tx.removeprefix("0x"))
                     )
-                    block_num = receipt.blockNumber
-                    logger.info(
-                        "[tick %s] COMMIT anchored: tx=%s block=%d",
-                        tick_id,
-                        arc_tx[:16],
-                        block_num,
-                    )
-                    return arc_tx, block_num
+                    commit_block = receipt.blockNumber
                 except Exception as e:
                     logger.warning("[tick %s] Cannot get commit block: %s", tick_id, e)
-                    return arc_tx, None
-            return None, None
+                logger.info(
+                    "[tick %s] COMMIT anchored (publishTrace fallback): tx=%s block=%s",
+                    tick_id,
+                    arc_tx[:16],
+                    commit_block,
+                )
+            return trace, None, arc_tx, commit_block
         except Exception as e:
-            logger.error("[tick %s] COMMIT publish FAILED: %s", tick_id, e)
-            return None, None
+            logger.error("[tick %s] COMMIT FAILED: %s", tick_id, e)
+            return trace, None, None, None
 
     async def _reveal_trace(
         self,
-        vault_address: str,
-        decision_type: DecisionType,
-        trigger: str,
-        portfolio: Portfolio,
-        trades: list[TradeOrder],
-        all_signals: list[StrategySignals],
-        market_regime: str,
-        consensus: EnsembleConsensus,
+        trace: ReasoningTrace,
+        trace_id: int | None,
         tick_id: str,
-        reasoning: str,
         tx_hashes: list[str] | None = None,
         commit_tx: str | None = None,
         commit_block: int | None = None,
         trade_block: int | None = None,
     ) -> None:
-        """Reveal phase: publish full trace AFTER the trade settles.
+        """Reveal phase: pin public provenance to IPFS, then reveal the SAME trace.
 
-        Records commit/reveal/trade block numbers for temporal binding verification.
+        ``trace`` is the exact object committed in the commit phase — we do NOT rebuild
+        it, so the canonical bytes revealed on-chain match the committed hash. Steps:
+          1. Pin the PUBLIC provenance layer (papers/methodology/rigor — not executable
+             params) to IPFS → CID. Degrades loudly to hash-only if PINATA_JWT is unset.
+          2. reveal(trace_id, cid, canonicalBytes) — contract recomputes keccak256 and
+             enforces commit block < execution < reveal block.
+          3. Fall back to publishTrace if the deployed registry is pre-v1.5 (#588).
         """
-        trace = ReasoningTrace(
-            id=str(uuid.uuid4()),
-            vault_address=vault_address,
-            decision_type=decision_type,
-            trigger=trigger,
-            timestamp=datetime.now(UTC),
-            market_context={
-                "regime": market_regime,
-                "ensemble_consensus": consensus.label.value,
-                "ensemble_flat_pct": round(consensus.flat_pct, 4),
-                "strategy_count": len(all_signals),
-                "signal_summary": {
-                    ss.paper_title[:30]: {s.asset: f"{s.signal.value}({s.weight:.0%})" for s in ss.signals[:5]}
-                    for ss in all_signals
-                },
-                "phase": "reveal",
-            },
-            portfolio_before={
-                "vault": vault_address[:10],
-                "aum_usdc": portfolio.total_value_usdc,
-                "holdings": {
-                    h.symbol: {"weight": f"{h.weight:.1%}", "value_usdc": h.value_usdc} for h in portfolio.holdings
-                },
-            },
-            portfolio_after={"tx_hashes": tx_hashes or []},
-            reasoning=f"[REVEAL] {reasoning}",
-            confidence=_compute_confidence(all_signals),
-            trades_executed=[{"symbol": t.symbol, "direction": t.direction.value, "amount": t.amount} for t in trades],
-            strategies_referenced=[ss.strategy_id for ss in all_signals],
-            consulted_paper_hashes=_paper_hashes_from_signals(all_signals),
-            # Commit-reveal temporal binding
-            commit_tx_hash=commit_tx,
-            commit_block_number=commit_block,
-            trade_tx_hash=tx_hashes[0] if tx_hashes else None,
-            trade_block_number=trade_block,
-        )
+        # Annotate the (already-committed) trace with trade settlement data. These
+        # fields are NOT in the hashed canonical set (_HASH_FIELDS), so adding them
+        # does not change trace_hash — the commit binding stays intact.
+        trace.portfolio_after = {"tx_hashes": tx_hashes or []}
+        trace.commit_tx_hash = commit_tx
+        trace.commit_block_number = commit_block
+        trace.trade_tx_hash = tx_hashes[0] if tx_hashes else None
+        trace.trade_block_number = trade_block
 
-        trace.compute_hash()
-        logger.info("[tick %s] REVEAL hash: %s", tick_id, trace.trace_hash[:16])
+        logger.info("[tick %s] REVEAL hash: %s", tick_id, (trace.trace_hash or trace.compute_hash())[:16])
 
-        # Publish reveal trace on-chain
         reveal_tx = None
         reveal_block = None
+        ipfs_cid = None
         if not DRY_RUN:
+            # ── 1. Pin public provenance to IPFS (loud-degrade if unconfigured) ──
             try:
-                reveal_tx = await trace_publisher.publish(trace)
+                ipfs_cid, _payload = await pin_public_provenance(trace)
+                if ipfs_cid:
+                    logger.info("[tick %s] Public provenance pinned: cid=%s", tick_id, ipfs_cid)
+            except Exception as e:
+                logger.error("[tick %s] IPFS pin FAILED (continuing hash-only): %s", tick_id, e)
+
+            # ── 2. Reveal on-chain, anchoring the CID as the storage pointer ──
+            try:
+                if trace_id is not None and trace_publisher.supports_commit_reveal():
+                    reveal_tx, reveal_block = await trace_publisher.reveal(
+                        trace_id, trace, storage_pointer=ipfs_cid or ""
+                    )
+                else:
+                    # Pre-v1.5 registry: anchor the canonical content via publishTrace.
+                    reveal_tx = await trace_publisher.publish(trace)
+                    if reveal_tx:
+                        try:
+                            receipt = await chain_client.w3.eth.get_transaction_receipt(
+                                chain_client.w3.to_bytes(hexstr=reveal_tx.removeprefix("0x"))
+                            )
+                            reveal_block = receipt.blockNumber
+                        except Exception:
+                            logger.debug("reveal receipt block lookup failed", exc_info=True)
                 if reveal_tx:
-                    try:
-                        receipt = await chain_client.w3.eth.get_transaction_receipt(
-                            chain_client.w3.to_bytes(hexstr=reveal_tx.removeprefix("0x"))
-                        )
-                        reveal_block = receipt.blockNumber
-                    except Exception:
-                        logger.debug("reveal receipt block lookup failed", exc_info=True)
                     logger.info(
-                        "[tick %s] REVEAL anchored: tx=%s block=%s",
+                        "[tick %s] REVEAL anchored: tx=%s block=%s cid=%s",
                         tick_id,
                         reveal_tx[:16],
                         reveal_block,
+                        ipfs_cid,
                     )
             except Exception as e:
                 logger.error("[tick %s] REVEAL publish FAILED: %s", tick_id, e)
 
-        # Persist off-chain with full temporal binding data
+        # Persist off-chain with full temporal binding + IPFS pointer
         try:
             off_chain_data = {
                 "id": trace.id,
@@ -1019,6 +1032,8 @@ class StrategyRunner:
                 "trace_hash": trace.trace_hash,
                 "arc_tx_hash": reveal_tx,
                 "is_verified": reveal_tx is not None,
+                # IPFS provenance pointer (T1.4)
+                "ipfs_cid": ipfs_cid,
                 # Temporal binding fields
                 "commit_tx_hash": commit_tx,
                 "commit_block_number": commit_block,

--- a/backend/archimedes/chain/pinata_client.py
+++ b/backend/archimedes/chain/pinata_client.py
@@ -1,0 +1,195 @@
+"""Pinata IPFS client — pins the PUBLIC provenance layer and verifies CIDs.
+
+T1.4: the public provenance trace (papers cited, methodology, rigor / DSR / PBO
+scores, timestamp) is pinned to IPFS via Pinata and the returned CID is anchored
+on-chain (commit-reveal ``storagePointer``). The EXECUTABLE layer — strategy
+weights, position-sizing params, code paths/hashes — is deliberately NOT pinned;
+publishing it would leak the alpha. See ``build_public_provenance`` for the split.
+
+Gating (coordinated with T0.5 no-silent-degradation):
+  PINATA_JWT — Pinata JWT (scoped `pinJSONToIPFS` key). If unset, every pin/fetch
+  degrades LOUDLY: a structured WARN is logged (event=pinata_degraded) and the call
+  returns None rather than raising. Callers MUST treat None as "IPFS unavailable"
+  and fall back to the on-chain hash anchor — never silently pretend it pinned.
+
+Mock at the HTTP boundary (``aiohttp.ClientSession``) in tests — same convention as
+``circle_service`` / ``circle_signer``. No network in unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# Pinata REST + public gateway. Pin via the API; fetch via the gateway.
+PINATA_API_BASE = "https://api.pinata.cloud"
+PINATA_GATEWAY = "https://gateway.pinata.cloud/ipfs"
+_PIN_TIMEOUT_S = 30.0
+
+
+class PinataClient:
+    """Pins JSON to IPFS via Pinata and re-fetches it for verification.
+
+    Stateless apart from the JWT; safe to use as a module singleton. All methods
+    degrade to None (with a loud WARN) when ``PINATA_JWT`` is unset — they never
+    raise on the missing-credential path, so the agent loop keeps running with the
+    on-chain hash as the sole anchor.
+    """
+
+    def __init__(self, jwt: str | None = None) -> None:
+        # Read once at construction so tests can inject; falls back to env.
+        self._jwt: str = jwt if jwt is not None else os.getenv("PINATA_JWT", "")
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._jwt)
+
+    def _warn_degraded(self, op: str) -> None:
+        """Emit the structured no-silent-degradation WARN (T0.5)."""
+        logger.warning(
+            "Pinata IPFS unavailable — degrading to on-chain hash only "
+            "(event=pinata_degraded op=%s reason=missing_PINATA_JWT)",
+            op,
+        )
+
+    async def pin_json(self, payload: dict, *, name: str | None = None) -> str | None:
+        """Pin a JSON object to IPFS; return its CID (IpfsHash) or None.
+
+        Returns None — never raises — when PINATA_JWT is unset (loud WARN) or when
+        the Pinata API errors / is unreachable (error logged). A None return is the
+        signal to fall back to the on-chain hash anchor.
+        """
+        if not self.is_configured:
+            self._warn_degraded("pin_json")
+            return None
+
+        body: dict = {"pinataContent": payload}
+        if name:
+            body["pinataMetadata"] = {"name": name}
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=_PIN_TIMEOUT_S)
+            async with (
+                aiohttp.ClientSession(timeout=timeout) as session,
+                session.post(
+                    f"{PINATA_API_BASE}/pinning/pinJSONToIPFS",
+                    json=body,
+                    headers={
+                        "Authorization": f"Bearer {self._jwt}",
+                        "Content-Type": "application/json",
+                    },
+                ) as resp,
+            ):
+                data = await resp.json()
+                if resp.status != 200:
+                    # Don't leak the JWT or full body; log status + safe detail.
+                    logger.error(
+                        "Pinata pin failed (status=%s detail=%s)",
+                        resp.status,
+                        data.get("error") if isinstance(data, dict) else "unknown",
+                    )
+                    return None
+                cid = data.get("IpfsHash")
+                if not cid:
+                    logger.error("Pinata pin returned no IpfsHash: %s", data)
+                    return None
+                logger.info("Pinned public provenance to IPFS: cid=%s", cid)
+                return cid
+        except Exception as e:  # network / timeout / JSON decode
+            logger.error("Pinata pin error: %s", e)
+            return None
+
+    async def fetch_json(self, cid: str) -> dict | None:
+        """Re-fetch the pinned JSON for a CID from the public gateway.
+
+        Used by ``verify`` to round-trip the anchor. Returns None on any failure
+        (missing CID, gateway error, non-JSON body) — never raises.
+        """
+        if not cid:
+            return None
+        try:
+            timeout = aiohttp.ClientTimeout(total=_PIN_TIMEOUT_S)
+            async with (
+                aiohttp.ClientSession(timeout=timeout) as session,
+                session.get(f"{PINATA_GATEWAY}/{cid}") as resp,
+            ):
+                if resp.status != 200:
+                    logger.error("Pinata gateway fetch failed (status=%s cid=%s)", resp.status, cid)
+                    return None
+                return await resp.json()
+        except Exception as e:
+            logger.error("Pinata gateway fetch error (cid=%s): %s", cid, e)
+            return None
+
+    async def verify(self, cid: str, expected: dict) -> bool:
+        """Re-fetch ``cid`` and check its canonical bytes equal ``expected``.
+
+        This proves the CID anchored on-chain still resolves to exactly the public
+        provenance payload the agent pinned — i.e. IPFS content has not drifted from
+        the on-chain anchor. Canonicalizes both sides (sorted keys, no spaces) so
+        key ordering never causes a false mismatch.
+        """
+        fetched = await self.fetch_json(cid)
+        if fetched is None:
+            return False
+        return canonical_bytes(fetched) == canonical_bytes(expected)
+
+
+def canonical_bytes(payload: dict) -> bytes:
+    """Deterministic JSON encoding — sorted keys, no whitespace, UTF-8 bytes.
+
+    Shared by the pin path and verify so the round-trip is byte-stable.
+    """
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def build_public_provenance(
+    *,
+    trace_id: str,
+    vault_address: str,
+    decision_type: str,
+    timestamp_iso: str,
+    papers_cited: list[dict] | list[str],
+    methodology: str,
+    rigor: dict | None = None,
+    reasoning: str = "",
+    consulted_paper_hashes: list[str] | None = None,
+) -> dict:
+    """Assemble the PUBLIC provenance layer that is safe to pin to IPFS.
+
+    INCLUDES (publishable, verifiable claims):
+      - trace id, vault, decision type, timestamp
+      - papers cited (titles / arxiv ids / dois) and consulted-paper content hashes
+      - methodology summary (the *what*, not the executable *how*)
+      - rigor scores: deflated Sharpe, DSR p-value, PBO, OOS Sharpe, rigor-gate pass
+      - human-readable reasoning
+
+    DELIBERATELY EXCLUDES (the executable / alpha layer — stays off IPFS):
+      - target weights / allocations, position-sizing parameters
+      - strategy code paths or code hashes
+      - raw signal magnitudes per asset
+
+    Keep this function the single source of truth for the split so nothing leaks
+    the executable layer onto a public gateway.
+    """
+    return {
+        "schema": "archimedes.public-provenance/v1",
+        "trace_id": trace_id,
+        "vault_address": vault_address,
+        "decision_type": decision_type,
+        "timestamp": timestamp_iso,
+        "papers_cited": papers_cited,
+        "consulted_paper_hashes": consulted_paper_hashes or [],
+        "methodology": methodology,
+        "rigor": rigor or {},
+        "reasoning": reasoning,
+    }
+
+
+# Module singleton — reads PINATA_JWT from the environment at import time.
+pinata_client = PinataClient()

--- a/backend/archimedes/chain/provenance_publisher.py
+++ b/backend/archimedes/chain/provenance_publisher.py
@@ -1,0 +1,100 @@
+"""Provenance publisher — public IPFS layer + commit-reveal CID anchoring.
+
+Ties T0.3 (commit-reveal anchoring) to T1.4 (IPFS publishing):
+
+  1. Build the PUBLIC provenance layer from a ReasoningTrace (papers cited,
+     methodology, rigor / DSR / PBO scores, timestamp — NOT executable params;
+     see ``build_public_provenance``).
+  2. Pin it to IPFS via Pinata → CID.
+  3. Anchor the CID on-chain as the commit-reveal ``storagePointer``.
+  4. ``verify`` re-fetches the CID and checks it against the on-chain anchor.
+
+PINATA_JWT gating (T0.5 no-silent-degradation): if unset, ``pin_public_provenance``
+returns None with a loud structured WARN. The caller still reveals with an empty
+storage pointer — the on-chain keccak256 hash remains the authoritative anchor — so
+provenance is never silently dropped; it is loudly downgraded to "hash-only".
+"""
+
+from __future__ import annotations
+
+import logging
+
+from archimedes.chain.pinata_client import (
+    PinataClient,
+    build_public_provenance,
+    canonical_bytes,
+    pinata_client,
+)
+from archimedes.models.trace import ReasoningTrace
+
+logger = logging.getLogger(__name__)
+
+
+def public_provenance_for(trace: ReasoningTrace, rigor: dict | None = None) -> dict:
+    """Project a ReasoningTrace onto its PUBLIC provenance layer (IPFS-safe).
+
+    Pulls only publishable fields. ``rigor`` (optional) carries the strategy's
+    DSR / PBO / rigor-gate scores when available — these are claims, safe to publish.
+    The executable layer (weights, sizing params, code hashes) is excluded by
+    ``build_public_provenance``.
+    """
+    return build_public_provenance(
+        trace_id=trace.id,
+        vault_address=trace.vault_address,
+        decision_type=trace.decision_type.value,
+        timestamp_iso=trace.timestamp.isoformat(),
+        papers_cited=trace.strategies_referenced,
+        methodology=trace.reasoning,
+        rigor=rigor,
+        reasoning=trace.reasoning,
+        consulted_paper_hashes=trace.consulted_paper_hashes,
+    )
+
+
+async def pin_public_provenance(
+    trace: ReasoningTrace,
+    rigor: dict | None = None,
+    client: PinataClient | None = None,
+) -> tuple[str | None, dict]:
+    """Pin the trace's public provenance layer to IPFS.
+
+    Returns (cid, payload). ``cid`` is None (loud WARN, never raises) when
+    PINATA_JWT is unset or Pinata errors — the caller falls back to a hash-only
+    anchor. ``payload`` is always returned so it can be persisted off-chain and
+    re-used by ``verify`` regardless of pin success.
+    """
+    client = client or pinata_client
+    payload = public_provenance_for(trace, rigor)
+    cid = await client.pin_json(payload, name=f"archimedes-provenance-{trace.id}")
+    if cid is None:
+        logger.warning(
+            "Public provenance NOT pinned to IPFS — anchoring on-chain hash only "
+            "(event=provenance_ipfs_skipped trace_id=%s)",
+            trace.id,
+        )
+    return cid, payload
+
+
+async def verify_provenance(
+    cid: str,
+    trace: ReasoningTrace,
+    rigor: dict | None = None,
+    client: PinataClient | None = None,
+) -> bool:
+    """Re-fetch ``cid`` from IPFS and check it equals the trace's public provenance.
+
+    Proves the CID anchored on-chain still resolves to exactly the public layer the
+    agent published — content hasn't drifted from the anchor. Returns False if the
+    CID is empty, unfetchable, or its canonical bytes differ.
+    """
+    client = client or pinata_client
+    expected = public_provenance_for(trace, rigor)
+    return await client.verify(cid, expected)
+
+
+__all__ = [
+    "canonical_bytes",
+    "pin_public_provenance",
+    "public_provenance_for",
+    "verify_provenance",
+]

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -17,10 +17,35 @@ logger = logging.getLogger(__name__)
 
 
 class TracePublisher:
-    """Publishes reasoning trace hashes to on-chain ReasoningTraceRegistry."""
+    """Publishes reasoning trace hashes to on-chain ReasoningTraceRegistry.
+
+    Two anchoring paths:
+      - ``publish`` → ``publishTrace`` (v1 anchor-after-the-fact; kept for the
+        legacy SKIP/error path and existing callers).
+      - ``commit`` + ``reveal`` (v1.5 temporal binding): the agent commits the
+        trace hash BEFORE the trade and reveals the canonical content AFTER it
+        settles. The contract recomputes keccak256 on reveal and enforces
+        commit block < execution < reveal block — proving "trace existed before
+        the trade". commit/reveal require the v1.5 registry; ``supports_commit_reveal``
+        detects whether the deployed ABI exposes them (redeploy gated on #588).
+    """
 
     def __init__(self, loader: ContractLoader | None = None):
         self.loader = loader or get_contract_loader()
+
+    def supports_commit_reveal(self) -> bool:
+        """True iff the deployed registry ABI exposes commit() + reveal().
+
+        The v1.5 commit-reveal pair lives in the Solidity source but the deployed
+        ABI may still be v1 (publishTrace only) until the registry is redeployed
+        (#588). Callers use this to fall back to publishTrace gracefully instead
+        of throwing an AttributeError mid-tick.
+        """
+        try:
+            fns = self.loader.trace_registry.functions
+            return hasattr(fns, "commit") and hasattr(fns, "reveal")
+        except Exception:
+            return False
 
     async def publish(self, trace: ReasoningTrace) -> str | None:
         """Publish a reasoning trace hash on-chain.
@@ -97,6 +122,204 @@ class TracePublisher:
         except Exception as e:
             logger.error(f"Failed to publish trace on-chain: {e}")
             return None
+
+    # ── Commit-Reveal (v1.5 temporal binding) ─────────────────────────
+
+    async def commit(
+        self,
+        trace: ReasoningTrace,
+        claimed_execution_time: int,
+        trade_intent_summary: bytes = b"",
+    ) -> tuple[int | None, str | None, int | None]:
+        """Commit the trace hash on-chain BEFORE the covered trade executes.
+
+        Calls ``ReasoningTraceRegistry.commit(vault, contentHash, claimedExecutionTime,
+        tradeIntentSummary)``. The committed ``contentHash`` is keccak256 of the trace's
+        canonical JSON — the SAME bytes ``reveal`` will later submit, so the on-chain
+        hash binding holds.
+
+        Args:
+            trace: the trace being committed (its hash is computed here if absent).
+            claimed_execution_time: unix time the trade is claimed to land at; must be
+                strictly after the commit block's timestamp (the contract enforces this).
+            trade_intent_summary: ABI/opaque bytes summarizing intended trades (metadata).
+
+        Returns:
+            (trace_id, tx_hash, commit_block) — trace_id is the on-chain id needed to
+            reveal; any field is None on failure. Falls back to None if the deployed
+            registry has no commit() (pre-#588 redeploy).
+        """
+        if not self.supports_commit_reveal():
+            logger.warning(
+                "Registry ABI has no commit() — deployed contract is pre-v1.5 "
+                "(redeploy gated on #588). Falling back to publishTrace anchor."
+            )
+            return None, None, None
+
+        content_hash = trace.trace_hash or trace.compute_hash()
+        content_hash_bytes = bytes.fromhex(content_hash.removeprefix("0x"))  # 32 bytes
+        vault_addr = chain_client.to_checksum(trace.vault_address)
+        registry_addr = chain_client.to_checksum(chain_client.settings.reasoning_trace_registry_address)
+
+        # ── Path 1: Circle wallet ──
+        if circle_signer.is_configured:
+            try:
+                content_hash_hex = "0x" + content_hash.removeprefix("0x")
+                intent_hex = "0x" + trade_intent_summary.hex() if trade_intent_summary else "0x"
+                tx_hash = await circle_signer.execute_contract(
+                    contract_address=registry_addr,
+                    abi_function="commit(address,bytes32,uint64,bytes)",
+                    abi_params=[vault_addr, content_hash_hex, str(claimed_execution_time), intent_hex],
+                )
+                logger.info(f"Trace committed via Circle: {tx_hash[:16]}...")
+                return await self._finalize_commit(trace, tx_hash, vault_addr)
+            except Exception as e:
+                logger.error(f"Circle commit failed, falling back: {e}")
+
+        # ── Path 2: Raw private key ──
+        account = chain_client.settings.agent_account
+        if not account:
+            logger.warning("No agent account configured — skipping trace commit")
+            return None, None, None
+
+        registry = self.loader.trace_registry
+        try:
+            nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+            tx = await registry.functions.commit(
+                vault_addr, content_hash_bytes, claimed_execution_time, trade_intent_summary
+            ).build_transaction(
+                {
+                    "from": account.address,
+                    "nonce": nonce,
+                    "chainId": chain_client.settings.chain_id,
+                    "gas": 300_000,
+                    "gasPrice": await chain_client.w3.eth.gas_price,
+                }
+            )
+            signed = account.sign_transaction(tx)
+            tx_hash_bytes = await chain_client.w3.eth.send_raw_transaction(signed.raw_transaction)
+            tx_hash = tx_hash_bytes.hex()
+            logger.info(f"Trace committed on-chain: {tx_hash[:16]}...")
+            return await self._finalize_commit(trace, tx_hash, vault_addr)
+        except Exception as e:
+            logger.error(f"Failed to commit trace on-chain: {e}")
+            return None, None, None
+
+    async def _finalize_commit(
+        self, trace: ReasoningTrace, tx_hash: str, vault_addr: str
+    ) -> tuple[int | None, str | None, int | None]:
+        """Resolve the on-chain trace_id + block from a commit tx receipt.
+
+        Decodes the TraceCommitted event to read the auto-incremented trace_id; falls
+        back to getTracesByVault()[-1] if the event can't be decoded.
+        """
+        trace.commit_tx_hash = tx_hash
+        registry = self.loader.trace_registry
+        block_num = None
+        trace_id = None
+        try:
+            receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
+            block_num = receipt.blockNumber
+            for log in receipt.logs:
+                try:
+                    decoded = registry.events.TraceCommitted().process_log(log)
+                    trace_id = int(decoded["args"]["traceId"])
+                    break
+                except Exception:
+                    continue
+        except Exception as e:
+            logger.warning(f"Cannot read commit receipt: {e}")
+
+        if trace_id is None:
+            # Fallback: newest trace id for the vault.
+            try:
+                ids = await registry.functions.getTracesByVault(vault_addr).call()
+                trace_id = int(ids[-1]) if ids else None
+            except Exception:
+                trace_id = None
+
+        trace.commit_block_number = block_num
+        return trace_id, tx_hash, block_num
+
+    async def reveal(
+        self,
+        trace_id: int,
+        trace: ReasoningTrace,
+        storage_pointer: str = "",
+    ) -> tuple[str | None, int | None]:
+        """Reveal the full canonical trace content AFTER the trade settles.
+
+        Calls ``ReasoningTraceRegistry.reveal(traceId, storagePointer, fullTraceContent)``.
+        ``fullTraceContent`` MUST be the exact canonical bytes whose keccak256 equals the
+        committed hash; we derive them from ``trace.canonical_json()`` (the same source the
+        commit hash was computed from). ``storage_pointer`` is the IPFS CID (or any URL) so
+        verifiers can fetch the off-chain public provenance.
+
+        Returns (reveal_tx_hash, reveal_block) — None on failure or pre-v1.5 registry.
+        """
+        if not self.supports_commit_reveal():
+            logger.warning("Registry ABI has no reveal() — skipping reveal (redeploy gated on #588).")
+            return None, None
+        if trace_id is None:
+            logger.warning("No trace_id to reveal (commit likely failed) — skipping reveal")
+            return None, None
+
+        full_content = trace.canonical_json().encode("utf-8")
+        registry_addr = chain_client.to_checksum(chain_client.settings.reasoning_trace_registry_address)
+
+        # ── Path 1: Circle wallet ──
+        if circle_signer.is_configured:
+            try:
+                content_hex = "0x" + full_content.hex()
+                tx_hash = await circle_signer.execute_contract(
+                    contract_address=registry_addr,
+                    abi_function="reveal(uint256,string,bytes)",
+                    abi_params=[str(trace_id), storage_pointer, content_hex],
+                )
+                logger.info(f"Trace revealed via Circle: {tx_hash[:16]}...")
+                return await self._finalize_reveal(trace, tx_hash)
+            except Exception as e:
+                logger.error(f"Circle reveal failed, falling back: {e}")
+
+        # ── Path 2: Raw private key ──
+        account = chain_client.settings.agent_account
+        if not account:
+            logger.warning("No agent account configured — skipping trace reveal")
+            return None, None
+
+        registry = self.loader.trace_registry
+        try:
+            nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+            tx = await registry.functions.reveal(trace_id, storage_pointer, full_content).build_transaction(
+                {
+                    "from": account.address,
+                    "nonce": nonce,
+                    "chainId": chain_client.settings.chain_id,
+                    "gas": 500_000,
+                    "gasPrice": await chain_client.w3.eth.gas_price,
+                }
+            )
+            signed = account.sign_transaction(tx)
+            tx_hash_bytes = await chain_client.w3.eth.send_raw_transaction(signed.raw_transaction)
+            tx_hash = tx_hash_bytes.hex()
+            logger.info(f"Trace revealed on-chain: {tx_hash[:16]}...")
+            return await self._finalize_reveal(trace, tx_hash)
+        except Exception as e:
+            logger.error(f"Failed to reveal trace on-chain: {e}")
+            return None, None
+
+    async def _finalize_reveal(self, trace: ReasoningTrace, tx_hash: str) -> tuple[str, int | None]:
+        """Record reveal tx + block on the trace and return them."""
+        trace.reveal_tx_hash = tx_hash
+        trace.arc_tx_hash = tx_hash  # reveal is the canonical anchor tx for this trace
+        block_num = None
+        try:
+            receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
+            block_num = receipt.blockNumber
+        except Exception:
+            logger.debug("reveal receipt block lookup failed", exc_info=True)
+        trace.reveal_block_number = block_num
+        return tx_hash, block_num
 
     async def verify(self, trace: ReasoningTrace) -> bool:
         """Verify a trace against its on-chain hash."""

--- a/backend/tests/test_provenance_ipfs.py
+++ b/backend/tests/test_provenance_ipfs.py
@@ -1,0 +1,372 @@
+"""T0.3 + T1.4 — commit/reveal anchoring + Pinata IPFS CID provenance.
+
+Hermetic: the Pinata HTTP boundary (aiohttp.ClientSession) and the contract
+loader are mocked — no network, no Arc RPC, no real Pinata. Mirrors the
+boundary-mock convention in tests/services/test_circle_service.py.
+
+Coverage:
+  - pin → CID → fetch → verify round-trips
+  - missing PINATA_JWT degrades LOUDLY (structured WARN), returns None, never raises
+  - the public provenance layer EXCLUDES the executable layer (weights/code)
+  - TracePublisher.commit/reveal call the real contract fns and bind the same bytes
+  - supports_commit_reveal gates the publishTrace fallback (pre-#588 redeploy)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.pinata_client import (
+    PinataClient,
+    build_public_provenance,
+    canonical_bytes,
+)
+from archimedes.models.trace import DecisionType, ReasoningTrace
+
+# ── aiohttp boundary mocks (same shape as test_circle_service) ──────────────
+
+
+class _MockResp:
+    """aiohttp-like response for `async with session.post(...)` / `.get(...)`."""
+
+    def __init__(self, *, status: int, body: dict) -> None:
+        self.status = status
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _MockSession:
+    """aiohttp-like session; `post`/`get` return the canned response (or raise)."""
+
+    def __init__(self, response: _MockResp | Exception) -> None:
+        self._response = response
+        self.last_url: str | None = None
+
+    def post(self, url, *_args, **_kwargs):
+        self.last_url = url
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+    def get(self, url, *_args, **_kwargs):
+        self.last_url = url
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _patch_session(session: _MockSession):
+    return patch("archimedes.chain.pinata_client.aiohttp.ClientSession", return_value=session)
+
+
+def _make_trace(**overrides) -> ReasoningTrace:
+    defaults = {
+        "id": "trace-prov-001",
+        "vault_address": "0x1234567890abcdef1234567890abcdef12345678",
+        "decision_type": DecisionType.REBALANCE,
+        "trigger": "strategy_signal_drift",
+        "timestamp": datetime(2026, 6, 24, 12, 0, 0, tzinfo=UTC),
+        "reasoning": "Momentum + vol-target ensemble; rotate into sBTC",
+        "confidence": 0.82,
+        "strategies_referenced": ["strat-momentum-12m", "strat-voltarget"],
+        "consulted_paper_hashes": ["2301.00001:abc", "2302.00002:def"],
+    }
+    defaults.update(overrides)
+    return ReasoningTrace(**defaults)
+
+
+# ── Public/executable split ─────────────────────────────────────────────────
+
+
+class TestPublicProvenanceSplit:
+    def test_public_layer_includes_claims_excludes_executable(self):
+        payload = build_public_provenance(
+            trace_id="t1",
+            vault_address="0xvault",
+            decision_type="rebalance",
+            timestamp_iso="2026-06-24T12:00:00+00:00",
+            papers_cited=["arxiv:2301.00001"],
+            methodology="SMA200 cross + vol target",
+            rigor={"deflated_sharpe_ratio": 1.4, "pbo_score": 0.12, "passes_rigor_gate": True},
+            reasoning="rotate into sBTC",
+            consulted_paper_hashes=["2301.00001:abc"],
+        )
+        # Publishable claims present
+        assert payload["papers_cited"] == ["arxiv:2301.00001"]
+        assert payload["rigor"]["deflated_sharpe_ratio"] == 1.4
+        assert payload["rigor"]["pbo_score"] == 0.12
+        assert payload["methodology"] == "SMA200 cross + vol target"
+        # Executable layer must NOT leak — assert no alpha keys anywhere in the JSON.
+        blob = json.dumps(payload).lower()
+        for forbidden in ("weight", "target_alloc", "position_sizing", "code_hash", "code_path", "private"):
+            assert forbidden not in blob, f"executable layer leaked: {forbidden}"
+
+    def test_canonical_bytes_stable_under_key_order(self):
+        a = {"b": 2, "a": 1}
+        b = {"a": 1, "b": 2}
+        assert canonical_bytes(a) == canonical_bytes(b)
+
+
+# ── Pinata pin → CID ─────────────────────────────────────────────────────────
+
+
+class TestPinataPin:
+    @pytest.mark.asyncio
+    async def test_pin_returns_cid(self):
+        client = PinataClient(jwt="test-jwt")
+        session = _MockSession(_MockResp(status=200, body={"IpfsHash": "QmCID123"}))
+        with _patch_session(session):
+            cid = await client.pin_json({"hello": "world"}, name="x")
+        assert cid == "QmCID123"
+        assert session.last_url.endswith("/pinning/pinJSONToIPFS")
+
+    @pytest.mark.asyncio
+    async def test_pin_non_200_returns_none(self):
+        client = PinataClient(jwt="test-jwt")
+        session = _MockSession(_MockResp(status=401, body={"error": "bad jwt"}))
+        with _patch_session(session):
+            cid = await client.pin_json({"hello": "world"})
+        assert cid is None
+
+    @pytest.mark.asyncio
+    async def test_pin_network_error_returns_none(self):
+        client = PinataClient(jwt="test-jwt")
+        session = _MockSession(RuntimeError("network down"))
+        with _patch_session(session):
+            cid = await client.pin_json({"hello": "world"})
+        assert cid is None
+
+
+# ── No-silent-degradation (T0.5) — missing PINATA_JWT ────────────────────────
+
+
+class TestMissingJwtDegradesLoudly:
+    @pytest.mark.asyncio
+    async def test_missing_jwt_returns_none_and_warns(self, caplog):
+        client = PinataClient(jwt="")  # explicitly unconfigured
+        assert client.is_configured is False
+        with caplog.at_level(logging.WARNING, logger="archimedes.chain.pinata_client"):
+            cid = await client.pin_json({"x": 1})
+        assert cid is None
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warns, "missing PINATA_JWT must emit a WARN — no silent degradation"
+        # Structured marker so log-based alerting can fire on it.
+        assert any("event=pinata_degraded" in r.getMessage() for r in warns)
+        assert any("missing_PINATA_JWT" in r.getMessage() for r in warns)
+
+    @pytest.mark.asyncio
+    async def test_missing_jwt_never_raises(self):
+        client = PinataClient(jwt="")
+        # Must not raise even with no network mock in place.
+        assert await client.pin_json({"x": 1}) is None
+
+
+# ── Fetch + verify round-trip ────────────────────────────────────────────────
+
+
+class TestVerifyRoundTrip:
+    @pytest.mark.asyncio
+    async def test_pin_fetch_verify_round_trip(self):
+        client = PinataClient(jwt="test-jwt")
+        payload = {"schema": "v1", "rigor": {"pbo_score": 0.1}}
+
+        # pin
+        with _patch_session(_MockSession(_MockResp(status=200, body={"IpfsHash": "QmABC"}))):
+            cid = await client.pin_json(payload)
+        assert cid == "QmABC"
+
+        # fetch returns the SAME payload → verify True
+        with _patch_session(_MockSession(_MockResp(status=200, body=payload))):
+            assert await client.verify(cid, payload) is True
+
+    @pytest.mark.asyncio
+    async def test_verify_detects_drift(self):
+        client = PinataClient(jwt="test-jwt")
+        expected = {"rigor": {"pbo_score": 0.1}}
+        drifted = {"rigor": {"pbo_score": 0.9}}  # gateway content drifted
+        with _patch_session(_MockSession(_MockResp(status=200, body=drifted))):
+            assert await client.verify("QmABC", expected) is False
+
+    @pytest.mark.asyncio
+    async def test_verify_unfetchable_cid_is_false(self):
+        client = PinataClient(jwt="test-jwt")
+        with _patch_session(_MockSession(_MockResp(status=404, body={}))):
+            assert await client.verify("QmMissing", {"a": 1}) is False
+
+
+# ── provenance_publisher glue: pin → CID → verify ────────────────────────────
+
+
+class TestProvenancePublisher:
+    @pytest.mark.asyncio
+    async def test_pin_public_provenance_returns_cid_and_payload(self):
+        from archimedes.chain.provenance_publisher import pin_public_provenance
+
+        trace = _make_trace()
+        client = PinataClient(jwt="test-jwt")
+        with _patch_session(_MockSession(_MockResp(status=200, body={"IpfsHash": "QmProv"}))):
+            cid, payload = await pin_public_provenance(trace, rigor={"pbo_score": 0.2}, client=client)
+        assert cid == "QmProv"
+        assert payload["trace_id"] == "trace-prov-001"
+        assert payload["rigor"]["pbo_score"] == 0.2
+        # consulted hashes carried through for source-tracking
+        assert payload["consulted_paper_hashes"] == ["2301.00001:abc", "2302.00002:def"]
+
+    @pytest.mark.asyncio
+    async def test_pin_then_verify_round_trips_for_trace(self):
+        from archimedes.chain.provenance_publisher import pin_public_provenance, verify_provenance
+
+        trace = _make_trace()
+        client = PinataClient(jwt="test-jwt")
+        with _patch_session(_MockSession(_MockResp(status=200, body={"IpfsHash": "QmProv"}))):
+            cid, payload = await pin_public_provenance(trace, client=client)
+        # gateway returns the exact pinned payload
+        with _patch_session(_MockSession(_MockResp(status=200, body=payload))):
+            assert await verify_provenance(cid, trace, client=client) is True
+
+    @pytest.mark.asyncio
+    async def test_missing_jwt_glue_returns_none_cid_but_payload(self, caplog):
+        from archimedes.chain.provenance_publisher import pin_public_provenance
+
+        trace = _make_trace()
+        client = PinataClient(jwt="")
+        with caplog.at_level(logging.WARNING):
+            cid, payload = await pin_public_provenance(trace, client=client)
+        assert cid is None  # loudly degraded
+        assert payload["trace_id"] == "trace-prov-001"  # still built for off-chain persist
+        assert any("provenance_ipfs_skipped" in r.getMessage() for r in caplog.records)
+
+
+# ── TracePublisher.commit / reveal (mocked contract) ─────────────────────────
+
+
+class TestCommitReveal:
+    def _publisher_with_v15_abi(self):
+        """A TracePublisher whose mocked registry exposes commit()+reveal()."""
+        from archimedes.chain.trace_publisher import TracePublisher
+
+        registry = MagicMock()
+        # supports_commit_reveal() probes hasattr(functions, 'commit'/'reveal')
+        registry.functions.commit = MagicMock()
+        registry.functions.reveal = MagicMock()
+        loader = MagicMock()
+        loader.trace_registry = registry
+        return TracePublisher(loader=loader), registry
+
+    def test_supports_commit_reveal_true_when_abi_has_fns(self):
+        publisher, _ = self._publisher_with_v15_abi()
+        assert publisher.supports_commit_reveal() is True
+
+    def test_supports_commit_reveal_false_on_v1_abi(self):
+        from archimedes.chain.trace_publisher import TracePublisher
+
+        registry = MagicMock(spec=["functions"])
+        # functions has neither commit nor reveal
+        registry.functions = MagicMock(spec=["publishTrace", "getTracesByVault"])
+        loader = MagicMock()
+        loader.trace_registry = registry
+        publisher = TracePublisher(loader=loader)
+        assert publisher.supports_commit_reveal() is False
+
+    @pytest.mark.asyncio
+    async def test_commit_via_circle_returns_trace_id(self):
+        publisher, registry = self._publisher_with_v15_abi()
+        trace = _make_trace()
+        trace.compute_hash()
+
+        # Receipt with a TraceCommitted log decoding to traceId=42
+        fake_receipt = MagicMock()
+        fake_receipt.blockNumber = 100
+        fake_receipt.logs = [MagicMock()]
+        registry.events.TraceCommitted.return_value.process_log = MagicMock(return_value={"args": {"traceId": 42}})
+
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as client,
+        ):
+            signer.is_configured = True
+            signer.execute_contract = AsyncMock(return_value="0xCOMMIT")
+            client.to_checksum = lambda x: x
+            client.settings = MagicMock(reasoning_trace_registry_address="0xreg")
+            client.w3.eth.get_transaction_receipt = AsyncMock(return_value=fake_receipt)
+
+            trace_id, tx, block = await publisher.commit(trace, claimed_execution_time=9999999999)
+
+        assert tx == "0xCOMMIT"
+        assert trace_id == 42
+        assert block == 100
+        assert trace.commit_tx_hash == "0xCOMMIT"
+        # commit() called with the real signature + claimedExecutionTime
+        call = signer.execute_contract.await_args
+        assert call.kwargs["abi_function"] == "commit(address,bytes32,uint64,bytes)"
+        assert call.kwargs["abi_params"][2] == "9999999999"
+
+    @pytest.mark.asyncio
+    async def test_reveal_submits_same_canonical_bytes_and_cid(self):
+        publisher, _registry = self._publisher_with_v15_abi()
+        trace = _make_trace()
+        trace.compute_hash()
+        committed_hash = trace.trace_hash
+
+        fake_receipt = MagicMock()
+        fake_receipt.blockNumber = 105
+
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as client,
+        ):
+            signer.is_configured = True
+            signer.execute_contract = AsyncMock(return_value="0xREVEAL")
+            client.to_checksum = lambda x: x
+            client.settings = MagicMock(reasoning_trace_registry_address="0xreg")
+            client.w3.eth.get_transaction_receipt = AsyncMock(return_value=fake_receipt)
+
+            tx, block = await publisher.reveal(42, trace, storage_pointer="QmCID")
+
+        assert tx == "0xREVEAL"
+        assert block == 105
+        assert trace.reveal_tx_hash == "0xREVEAL"
+        assert trace.arc_tx_hash == "0xREVEAL"
+        call = signer.execute_contract.await_args
+        assert call.kwargs["abi_function"] == "reveal(uint256,string,bytes)"
+        params = call.kwargs["abi_params"]
+        assert params[0] == "42"
+        assert params[1] == "QmCID"  # IPFS CID anchored as storage pointer
+        # The revealed bytes hash to the committed hash (on-chain binding holds).
+        from web3 import Web3
+
+        revealed_bytes = bytes.fromhex(params[2].removeprefix("0x"))
+        assert Web3.keccak(revealed_bytes).hex().removeprefix("0x") == committed_hash.removeprefix("0x")
+
+    @pytest.mark.asyncio
+    async def test_commit_returns_none_when_abi_lacks_commit(self):
+        from archimedes.chain.trace_publisher import TracePublisher
+
+        registry = MagicMock()
+        registry.functions = MagicMock(spec=["publishTrace"])  # no commit/reveal
+        loader = MagicMock()
+        loader.trace_registry = registry
+        publisher = TracePublisher(loader=loader)
+
+        trace = _make_trace()
+        trace.compute_hash()
+        trace_id, tx, block = await publisher.commit(trace, claimed_execution_time=9999999999)
+        assert (trace_id, tx, block) == (None, None, None)


### PR DESCRIPTION
## What & why

Makes reasoning-trace provenance **chain-provable AND fetchable/verifiable**:
1. **T0.3** — switch the live anchor path from `publishTrace()`-only to the registry's real **`commit()` → trade → `reveal()`** pair, with hash-binding + `claimedExecutionTime` (proves "the trace existed before the trade").
2. **T1.4** — pin the **public provenance trace to IPFS (Pinata)** and anchor the returned **CID** on-chain (as the reveal `storagePointer`). The executable layer (weights/params/code) stays OFF IPFS.

## Design

### Commit-reveal (T0.3)
- `TracePublisher.commit(trace, claimedExecutionTime, intent)` → `ReasoningTraceRegistry.commit(vault, contentHash, claimedExecutionTime, tradeIntentSummary)` **before** the trade. `contentHash = keccak256(trace.canonical_json())`.
- `TracePublisher.reveal(trace_id, trace, storage_pointer=cid)` → `reveal(traceId, storagePointer, fullTraceContent)` **after** settlement. `fullTraceContent` is the **same canonical bytes** the commit hashed, so the contract's `keccak256(fullTraceContent) == contentHash` binding holds, and `commitBlock < execution <= revealBlock` enforces causal ordering.
- `agent_runner` now builds the canonical trace **once**, commits it, executes, then reveals the **same object**. Settlement fields (tx hashes, blocks) live outside `_HASH_FIELDS`, so annotating them post-trade doesn't perturb the committed hash.
- Dual-path signing preserved (Circle wallet → raw key fallback), same as the existing publisher.
- `publishTrace` is **kept** as the fallback anchor and for the SKIP/error paths; no existing callers/tests broken.

### IPFS (T1.4)
- `pinata_client.py` — small Pinata client: `pin_json` → CID, `fetch_json`, `verify(cid, expected)` (re-fetch + canonical-bytes compare against the anchor).
- `provenance_publisher.py` — glue: `build public layer → pin → use CID as reveal storagePointer → verify`.

### Public vs. executable split (the load-bearing decision)
`build_public_provenance` is the **single source of truth** for what's IPFS-safe:
- **Pinned (public claims):** trace id, vault, decision type, timestamp, papers cited, consulted-paper content hashes, methodology, rigor scores (deflated Sharpe / DSR p-value / PBO / OOS Sharpe / rigor-gate pass), reasoning.
- **NOT pinned (executable / alpha layer):** target weights / allocations, position-sizing params, strategy code paths/hashes, raw per-asset signal magnitudes. A test asserts none of these keys appear in the pinned JSON.

## Gated behind `PINATA_JWT` (coordinated with T0.5 no-silent-degradation)
If `PINATA_JWT` is unset (or Pinata errors), pinning returns `None` and logs a **structured WARN** (`event=pinata_degraded` / `provenance_ipfs_skipped`) — never raises, never silently pretends it pinned. The flow falls back to the on-chain keccak256 hash as the authoritative anchor. So provenance is loudly downgraded to "hash-only", not dropped.

## Tests
`backend/tests/test_provenance_ipfs.py` — 18 hermetic tests, Pinata mocked at the **aiohttp HTTP boundary** (same convention as `test_circle_service`). Asserts: pin → CID → fetch → verify round-trips; verify detects content drift; missing `PINATA_JWT` degrades **loudly** (WARN) and never raises; public/executable split; `commit`/`reveal` call the real contract signatures and the revealed bytes hash to the committed hash; `supports_commit_reveal` gates the publishTrace fallback.

```
backend/tests/test_provenance_ipfs.py ... 18 passed
# no regressions across:
test_trace_publisher.py test_agent_runner.py test_strategy_publisher.py tests/chain/ test_circle_service.py
# 134 passed total
```
ruff-format clean, `ruff check` clean on all changed files.

## ⚠️ Contract-redeploy dependency (#588)
The **deployed** `ReasoningTraceRegistry` ABI is still **v1 (`publishTrace` only)** — `commit`/`reveal`/`getCommitment` exist in the Solidity source (v1.5) but are **not in the deployed ABI**. `supports_commit_reveal()` probes the loaded ABI and returns `False` today, so this PR's backend **falls back to `publishTrace` cleanly**. Once the registry is **redeployed (#588)** and the ABI regenerated to expose `commit`/`reveal`, the backend activates the commit-reveal + CID-anchoring path **automatically** — no further code change. No contracts deployed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)