### PR TITLE
[docs] T3.2 contract redeploy runbook (Arc testnet)

### DIFF
--- a/docs/runbooks/t3.2-contract-redeploy.md
+++ b/docs/runbooks/t3.2-contract-redeploy.md
@@ -1,0 +1,418 @@
+# T3.2 — Contract Redeploy Runbook (Arc Testnet)
+
+**Owner:** Dan Browne (taking over from Chuan)
+**Scope:** Redeploying the Archimedes smart contracts to Arc testnet (Chain ID `5042002`, hex `0x4cef52`) and re-wiring the backend + UI to the new addresses.
+**Repo root used throughout:** `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes`
+
+> Steps marked **[DAN ACTION]** require a real funded deployer key and/or broadcast an irreversible on-chain transaction. Everything else is read-only / local and safe to dry-run.
+
+---
+
+## 0. Goal + when to run this
+
+**Goal:** Replace the live Arc-testnet contract set with freshly-deployed instances, then point the backend (`docker compose` services) and the UI at the new addresses, and confirm end-to-end.
+
+**Run this when:**
+- A merged Solidity fix needs to go live on-chain (the audit-fix bytecode in umbrella issue **#588**: PRs #582/#583/#584/#585/#586 are merged to `main` but the live instances still run pre-fix bytecode).
+- You are activating a redeploy-dependent feature: ReasoningTraceRegistry commit/reveal v1.5 (backend PR #728), or PriceOracle Chainlink read path (PR #724). See §7.
+- An address set has drifted and you are doing a clean re-cut.
+
+**Do NOT run this when:**
+- You only changed **backend Python** (e.g. PR #728 alone) — that ships zero contracts and is gated behind `supports_commit_reveal()` / `PINATA_JWT`; merge and `docker compose restart`, no redeploy.
+- You only changed an **address in config** — that is a §5 re-wire, not a redeploy.
+- You changed **contract source but not the bytecode the backend calls** — if no function/event signature the backend uses changed, you may not need an ABI refresh (§4).
+
+> **Reality check on deploy paths.** Three deploy implementations coexist and **diverge**:
+> 1. **Foundry** (`contracts/script/Deploy.s.sol`) — the cleanest authoritative spec for order/constructor args; ERC-4626 `Vault`/`VaultFactory` tier model.
+> 2. **Python + Circle** (`backend/archimedes/scripts/deploy_contracts.py`) — same vault model, raw-tx via `circle_signer`; writes `deploy_output.json`.
+> 3. **Node + Circle** (`wallet-setup/deploy.mjs` + `deploy-new.mjs`, via `make deploy` / `make deploy-new`) — deploys per-asset standalone `SyntheticVault(usdc, token, oracle, owner)`, a **different vault model**.
+>
+> **The currently-live 11 contracts were deployed via the Node+Circle (`make deploy`) path, NOT forge.** This runbook uses the **Foundry path as primary** (it is the documented source-of-truth for order and constructor args and produces a clean broadcast record). If you must reproduce the live vault model exactly, use the `make deploy` path instead and note the SyntheticVault divergence.
+>
+> **Note:** the task's assumed `scripts/deploy_contracts.py` does **not** exist. The Python deployer lives at `backend/archimedes/scripts/deploy_contracts.py`. Repo-root `scripts/` holds only `set-contract-env.sh`, `check-parity.sh`, `bulk_ingest_arxiv.py`, `fit_gmm_regime.py`, `setup-branch-protection.sh`.
+
+---
+
+## 1. One-time prerequisites
+
+### 1.1 Install Foundry (NOT currently installed on this machine)
+
+`which forge cast anvil` returns not-found. Install once:
+
+```bash
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+source ~/.zshenv 2>/dev/null   # or restart the shell so ~/.foundry/bin is on PATH
+forge --version                # confirm forge/cast/anvil resolve
+```
+
+### 1.2 Create a DEDICATED Arc-testnet deployer wallet — **NEVER a real-asset key**
+
+**[DAN ACTION]** Generate a throwaway key used only for Arc testnet:
+
+```bash
+cast wallet new
+# prints: Address: 0x...   Private key: 0x...
+```
+
+For a real (non-throwaway-local) deploy, **prefer an encrypted keystore over a plaintext flag** (per the use-arc / use-smart-contract-platform skills and CLAUDE.md):
+
+```bash
+cast wallet import deployer --interactive   # paste the private key once; stored encrypted
+# then deploy with:  forge script ... --account deployer   (instead of --private-key)
+```
+
+> **Never** pass `--private-key $KEY` on the CLI for anything but throwaway local testing. **Never** commit `DEPLOYER_KEY` / `DEV_WALLET_PRIVATE_KEY`. `.env` is gitignored — keep it that way.
+
+### 1.3 Fund the deployer with testnet gas — **USDC IS the gas token on Arc**
+
+There is **no ETH** on Arc; USDC pays gas. **Dual-decimals trap:** native gas = **18 decimals**, ERC-20 USDC = **6 decimals** — never mix them.
+
+**[DAN ACTION]** Fund via the web faucet (canonical, ~20 USDC / 2h rate limit):
+
+```bash
+open https://faucet.circle.com   # paste the deployer address, request USDC on "Arc Testnet"
+# fallback: make fund   (opens the Circle dev-wallets console)
+```
+
+### 1.4 RPC setup — two valid endpoints
+
+```bash
+# (a) Public Arc RPC — what foundry.toml's named endpoint "arc-testnet" points to:
+#     https://rpc.testnet.arc.network   (no secret; does NOT feed the 30% traction telemetry)
+
+# (b) arc-canteen proxy RPC — already present at ~/.arc-canteen/env on this box.
+#     Routes deploy txs through the telemetry surface. Export it:
+eval "$(arc-canteen rpc-url --export)"    # sets $RPC=https://rpc.testnet.arc-node.thecanteenapp.com/v1/swrm_<TOKEN>
+```
+
+> **SECRET:** the `swrm_` token is embedded in the `$RPC` path. Anyone with that URL can send txs as you. Never echo `$RPC` into logs, PRs, or commits. Rotate with `arc-canteen rotate-rpc-key` if exposed. **VERIFY:** confirm `arc-canteen rpc-url --export` is the exact subcommand on your installed version (`arc-canteen --help`) — if not, source `~/.arc-canteen/env` directly.
+
+Smoke-test the chain (expect `5042002` / `0x4cef52`):
+
+```bash
+cast chain-id --rpc-url "$RPC"     # expect 5042002
+arc-canteen rpc eth_chainId        # expect 0x4cef52
+```
+
+### 1.5 Env vars the Foundry deploy needs
+
+`Deploy.s.sol` reads these (note the **name mismatch** vs `.env.example`, which exposes `DEV_WALLET_*` — you must set these explicitly):
+
+```bash
+export DEPLOYER_KEY=0x<deployer-private-key>   # or use --account deployer keystore (preferred)
+export OWNER_ADDRESS=0x<owner-addr>            # address that will OWN the contracts
+export AGENT_ADDRESS=0x<agent-addr>            # platform agent; if == deployer, Phase-4 Tier-1 vault auto-creates
+# optional:
+export SEED_LIQUIDITY=true                     # WARNING: Deploy.s.sol Phase 5 only console.log's seeding — it NEVER adds liquidity. Pools are created EMPTY.
+```
+
+> **Circle path alternative env** (only if you use `make deploy`/`deploy-new` or the Python deployer): `CIRCLE_API_KEY`, `CIRCLE_ENTITY_SECRET`, `WALLET_ID`, `WALLET_ADDRESS` (and `WALLET_SET_ID`). `make wallet` creates the SCA wallet, auto-faucets USDC, and writes those back to `.env`.
+
+---
+
+## 2. Pre-deploy checklist
+
+Run all of these from the repo and confirm green **before** any broadcast.
+
+```bash
+# Confirm you're on the intended commit (the one carrying the merged fixes):
+git -C /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes status
+git -C /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes log --oneline -5
+
+# Clean build — REQUIRED. contracts/out/ is gitignored and currently ABSENT;
+# BOTH the .mjs and Python deploy paths FileNotFoundError without it, and the ABI
+# refresh in §4 reads from out/. forge build regenerates it.
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts && forge build   # == make compile
+
+# Tests green:
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts && forge test -vv  # == make test
+```
+
+Confirm:
+- [ ] On the right commit (carries #582/#583/#584/#585/#586; plus #724 / #589 source if cutting those — see §7).
+- [ ] `forge build` succeeded; `contracts/out/<Name>.sol/<Name>.json` now exists.
+- [ ] `forge test -vv` all green.
+- [ ] Deployer wallet funded (`cast balance 0x<deployer-addr> --rpc-url "$RPC"` is non-zero).
+- [ ] You have a record of the **current live addresses** for rollback (§8) — capture them now from `backend/archimedes/chain/client.py` and `ui/src/config.js`.
+
+---
+
+## 3. Deploy — correct contract order, capturing addresses
+
+### Deploy order + cross-dependencies (from `Deploy.s.sol`, the authoritative spec)
+
+`Deploy.s.sol` already encodes the correct order, so following the script preserves all dependencies:
+
+- **Phase 1 — Core infra (independent except VaultFactory):**
+  `AMMRouter(owner)` → `SyntheticFactory(USDC, owner)` → `ReasoningTraceRegistry(owner)` → `AssetRegistry(owner)` → `VaultFactory(agentAddr, ammRouter, USDC, owner, owner)`. The only Phase-1 cross-dep: **VaultFactory needs ammRouter's address** in its constructor.
+- **Phase 2 — Synthetics (loop per asset):** deploy `PriceOracle(symbol, initialPrice, owner)` **FIRST** (the factory needs the oracle address) → `synthFactory.createSynthetic(name, symbol, oracle)` (returns token addr) → `assetRegistry.registerSynthetic(...)`.
+- **Phase 3 — AMM pools:** `ammRouter.createPool(USDC, synthToken)` per asset (deploys an `AMMPool` internally; **empty** — see SEED_LIQUIDITY note).
+- **Phase 4 — Tier-1 vault (only if deployer == AGENT_ADDRESS):** `vaultFactory.createVault('Archimedes Momentum Alpha','vMOM',150,2000,true)` then `registerVault(...)` then `setTargetAllocations([USDC,sTSLA,sBTC],[4000,3500,2500])`. If `deployer != AGENT_ADDRESS`, the script logs `!!! create Tier 1 vault manually !!!` and skips it.
+
+> **Constructor arg orders (load-bearing):** `VaultFactory(_agentAddress, _ammRouter, _usdc, _platformFeeRecipient, _owner)` — `Deploy.s.sol` passes `(agentAddr, ammRouter, USDC, owner, owner)`. `PriceOracle(_symbol, _initialPrice, _owner)`. `SyntheticVault(_usdc, _synthToken, _oracle, _owner)`. `Vault` is **never deployed directly** — `VaultFactory.createVault` deploys it internally (tier auto-set: `msg.sender == agentAddress → 1`, else `2`).
+
+### 3.1 Deploy (Foundry path) — **[DAN ACTION]** (broadcasts real txs)
+
+```bash
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts
+
+# Preferred (encrypted keystore from §1.2):
+forge script script/Deploy.s.sol --rpc-url "$RPC" --account deployer --broadcast
+
+# OR named public endpoint (no canteen telemetry):
+# forge script script/Deploy.s.sol --rpc-url arc-testnet --account deployer --broadcast
+
+# OR (throwaway-local only, NOT for shared deploys):
+# forge script script/Deploy.s.sol --rpc-url "$RPC" --private-key "$DEPLOYER_KEY" --broadcast
+```
+
+### 3.2 Capture the deployed addresses
+
+forge writes the per-deploy record to:
+
+```
+contracts/broadcast/Deploy.s.sol/5042002/run-latest.json
+```
+
+Each `CREATE` tx records `contractName` + `contractAddress`. Extract them:
+
+```bash
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts
+jq -r '.transactions[] | select(.transactionType=="CREATE") | "\(.contractName)\t\(.contractAddress)"' \
+  broadcast/Deploy.s.sol/5042002/run-latest.json
+```
+
+Record every address: `AMMRouter`, `SyntheticFactory`, `ReasoningTraceRegistry`, `AssetRegistry`, `VaultFactory`, the 7 `PriceOracle`s, the 7 synth tokens, and (if Phase 4 ran) the Tier-1 vault. You will paste these into §5.
+
+> **Do NOT treat `broadcast/.../run-latest.json` as the live registry** — historically the broadcast addresses (forge path) **differ** from the live `client.py`/`config.js` set (live = Circle path). After this redeploy, the run-latest you just wrote **is** the new live set — but only once §5 wires it in.
+
+### 3.3 (Alternative) Circle paths — for reference
+
+```bash
+# Python + Circle (writes deploy_output.json + prints ARC_* env lines):
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/backend && uv run python -m archimedes.scripts.deploy_contracts
+
+# Node + Circle — the path the LIVE deploy used (per-asset SyntheticVault model):
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes && make deploy && make deploy-new
+```
+
+> The Python path is fragile — it hand-builds raw creation txs (`to='0x'`, chainId hardcoded `5042002`) and relies on `circle_signer.sign_and_broadcast`; the file itself notes Circle "doesn't support deployment natively." The `.mjs` path uses Circle's native `/v1/w3s/contracts/deploy`. If you go Circle, prefer `.mjs`.
+
+---
+
+## 4. `deploy_output.json` + refresh `contracts/abis/`
+
+### 4.1 `deploy_output.json` — produced ONLY by the Python path, and it is **STALE/deprecated**
+
+- Written **only** by `backend/archimedes/scripts/deploy_contracts.py` `main()` to repo-root `deploy_output.json` (`Path(__file__).parents[3] / "deploy_output.json"`). Shape: `{contracts:{ammRouter,…,tier1Vault}, synthTokens:{sTSLA:addr,…}, synthOracles:{sTSLA:addr,…}}`.
+- **It is NOT a source of truth.** It's gitignored, untracked, per-operator output. **Nothing reads it at runtime.** Audit 2026-06-14 finding I3 confirmed a previously-tracked copy had drifted from the live deploy.
+- The forge path does **not** produce it (use `run-latest.json` from §3.2). The `.mjs` path and `set-contract-env.sh` write **directly into `.env`**, not this file.
+
+**Action:** Do **not** build your workflow around `deploy_output.json`. The authoritative address surfaces are `backend/archimedes/chain/client.py` (backend) and `ui/src/config.js` (UI), both hand-edited in §5.
+
+### 4.2 Refresh `contracts/abis/` — MANUAL, no automated regen
+
+`contracts/abis/*.json` are **pure ABI arrays** (the `.abi` field), **not** full Foundry artifacts. There is **no Makefile target, CI step, or script** that regenerates them. `forge build` emits full artifacts to `contracts/out/<Name>.sol/<Name>.json`; you extract `.abi` by hand into `contracts/abis/<Name>.json`.
+
+**You only need this if a function/event SIGNATURE the backend or UI calls changed.** A pure address redeploy (same bytecode/ABI) needs no ABI change.
+
+```bash
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts
+forge build   # ensure out/ is fresh
+
+# Per changed contract, extract .abi from out/ into abis/. Example for ReasoningTraceRegistry:
+jq '.abi' out/ReasoningTraceRegistry.sol/ReasoningTraceRegistry.json > abis/ReasoningTraceRegistry.json
+# Repeat for each contract whose signatures changed (PriceOracle, Vault, VaultFactory, SyntheticVault, …).
+```
+
+Confirm the new surface is present, e.g. for the registry v1.5 flip (§7):
+
+```bash
+grep -oE '"name": *"(commit|reveal|getCommitment|publishTrace)"' contracts/abis/ReasoningTraceRegistry.json | sort -u
+```
+
+> **VERIFY** which ABIs actually changed signatures this cut by diffing `git diff -- contracts/src/<Name>.sol` against the deployed ABI's function/event names. Stale ABIs **silently break** the backend `ContractLoader` and `.mjs` `loadArtifact`.
+
+> The 21 committed ABIs include the interface variants (`IVault.json`, `IPriceOracle.json`, etc.) consumed by services like `asset_market_service.py` — refresh those too if their source interface changed.
+
+---
+
+## 5. Backend re-wire — point everything at the new addresses
+
+### How addresses reach the backend
+
+Every backend address is a field on `ChainSettings(BaseSettings)` in `backend/archimedes/chain/client.py` with `model_config = {"env_prefix": "ARC_", "env_file": ".env"}`. So field `vault_factory_address` ← env `ARC_VAULT_FACTORY_ADDRESS` (prefix + UPPERCASED field). Pydantic reads OS env, then `.env`. **Nothing reads `deploy_output.json`. There is no codegen.**
+
+> **#1 FOOTGUN — two naming conventions.** Root `.env` / `.env.example` define **UN-prefixed** keys (`VAULT_FACTORY_ADDRESS`, `AMM_ROUTER_ADDRESS`, …) — confirmed present and populated in `.env.example` lines 125–131. **Pydantic IGNORES these** (wrong prefix); only `verify_arc_e2e.py` reads them. Filling in the un-prefixed keys does **nothing** to the running backend. You must set the **`ARC_`-prefixed** vars.
+
+### 5.1 Core contract addresses (the common case)
+
+**[DAN ACTION]** (changes what the live stack executes against). On the docker host, edit the root `.env` with **ARC_-prefixed** vars:
+
+```bash
+ARC_VAULT_FACTORY_ADDRESS=0x<new>
+ARC_AMM_ROUTER_ADDRESS=0x<new>
+ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x<new>
+ARC_ASSET_REGISTRY_ADDRESS=0x<new>
+ARC_STRATEGY_REGISTRY_ADDRESS=0x<new>
+ARC_SYNTHETIC_FACTORY_ADDRESS=0x<new>
+# ARC_USDC_ADDRESS — leave as 0x3600...0000 (Arc USDC precompile; does NOT change on redeploy)
+```
+
+These root-`.env` values override the `:-0x...` defaults baked into `docker-compose.yml` (confirmed at lines 67/91–93/122–125) and `docker-compose.production.yml`.
+
+> EC2 helper: `scripts/set-contract-env.sh` appends/replaces the **four core** ARC_ vars — but it **hardcodes the CURRENT live addresses** (`ARC_AMM_ROUTER_ADDRESS=0xd5b829…`, `ARC_VAULT_FACTORY_ADDRESS=0xca8734…`, `ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a2…`, `ARC_ASSET_REGISTRY_ADDRESS=0x2d4455…`). **Edit it for the new addresses or just edit `.env` directly.** It does not cover AMM_ROUTER's absence in one block, nor synth/oracle vars.
+
+### 5.2 Per-asset synth tokens + oracles (if those were redeployed)
+
+**The 7 synth + 7 oracle addresses are HARDCODED defaults in `client.py` (lines 44–59) and are NOT wired through docker-compose.** `grep STSLA_ADDRESS docker-compose*.yml` returns nothing. If you only set core vars, the hardcoded `client.py` defaults **silently win** and the backend prices/trades the OLD synth+oracle contracts.
+
+Confirmed current hardcoded defaults you'd be replacing (examples): `stsla_address = 0xd514cd27…`, `stsla_oracle_address = 0xe1c9f2b1…`, … through `snky_*`.
+
+Do **ONE** of:
+
+**(a)** Edit the `client.py` defaults directly (`stsla_address`…`snky_address`, `stsla_oracle_address`…`snky_oracle_address`) and rebuild the backend image (de-facto path, since the live values already live in code), **or**
+
+**(b)** Add all **14** vars to `.env`:
+
+```bash
+ARC_STSLA_ADDRESS=0x...  ARC_SNVDA_ADDRESS=0x...  ARC_SSPY_ADDRESS=0x...  ARC_SBTC_ADDRESS=0x...
+ARC_SGOLD_ADDRESS=0x...  ARC_SOIL_ADDRESS=0x...   ARC_SNKY_ADDRESS=0x...
+ARC_STSLA_ORACLE_ADDRESS=0x...  ARC_SNVDA_ORACLE_ADDRESS=0x...  ARC_SSPY_ORACLE_ADDRESS=0x...
+ARC_SBTC_ORACLE_ADDRESS=0x...   ARC_SGOLD_ORACLE_ADDRESS=0x...  ARC_SOIL_ORACLE_ADDRESS=0x...
+ARC_SNKY_ORACLE_ADDRESS=0x...
+```
+
+> Without this, the **oracle runner** pushes prices to OLD oracle contracts and the **executor** prices SELLs/NAV against OLD oracles — even though core vaults point at the new factory.
+
+### 5.3 Clear stale per-process pins
+
+- `AGENT_VAULT_ADDRESSES` (agent_runner's `EXPLICIT_VAULTS`): if the redeploy created a brand-new `VaultFactory`, any old pin is **stale** — clear or update it, else the agent manages vaults that no longer exist under the new factory.
+- `ARC_CHAIN_ID`: leave unset (code default `5042002` is correct) **or** set `=5042002`. **Do NOT** copy `backend/.env.example` which wrongly says `ARC_CHAIN_ID=13068200` — a raw-key signing path with that value produces txs rejected for wrong chainId. (Circle path is unaffected.)
+
+### 5.4 Restart so import-time singletons re-read env — **REQUIRED**
+
+`chain_client` (`@lru_cache`), the contract loader, `chain_executor`, `trace_publisher`, `strategy_publisher`, `circle_signer`, and agent_runner's cached `_synth_addrs` all read env **once at import**. Env changes have **zero effect** on a running process.
+
+```bash
+# On the docker host. Addresses-only change:
+docker compose restart backend oracle agent
+
+# Code/ABI/client.py-default change (needs rebuild; abis bind-mount is :ro, picked up at container start):
+docker compose up -d --build backend oracle agent
+```
+
+> **Routing notes per service:** `oracle` and `agent` resolve per-asset oracle/synth addrs from `client.py` defaults — they need §5.2 done. Individual VAULT and AMM POOL addresses are **not** env vars; the executor reads them live from `VaultFactory.getVaults()` / `AMMRouter.getPool()`, so they self-heal once the factory/router addresses are correct.
+
+### 5.5 UI — separate surface, currently DISAGREES with backend
+
+`ui/src/config.js` hardcodes its own addresses in the `ASSETS` array (per-asset oracle/vault/token) and `NEW_CONTRACTS` (lines 627–632: `ammRouter`/`vaultFactory`/`traceRegistry`/`assetRegistry`). These are **NOT env-driven** and already diverge from the backend (e.g. UI `vaultFactory = 0x32A3e0D0…` vs backend `0xca873414…`; UI `traceRegistry = 0x44bD55c0…` vs backend `0x42d8a23e…`).
+
+**[DAN ACTION]** After a redeploy, edit `ui/src/config.js` (`ASSETS` + `NEW_CONTRACTS`) to the new addresses and **rebuild the nginx image** — Vite bakes config at build time. This is entirely separate from the backend env change.
+
+### 5.6 Make new addresses survive a clean CI redeploy
+
+`deploy.yml` redeploys on push to `main` but uses **whatever `.env` is on the EC2 box**. The only tracked address source is the docker-compose `:-0x...` defaults. To make new addresses survive a clean redeploy you must update **either** the compose `:-` defaults (tracked file) **or** the EC2 `.env` out-of-band. A git push alone won't carry new addresses unless the compose defaults change.
+
+---
+
+## 6. Smoke-test + verify
+
+### 6.1 On-chain (cast)
+
+```bash
+cast chain-id --rpc-url "$RPC"   # 5042002
+
+# Each new contract has code (non-"0x"):
+cast code 0x<new-vaultFactory> --rpc-url "$RPC" | head -c 12
+cast code 0x<new-reasoningTraceRegistry> --rpc-url "$RPC" | head -c 12
+
+# Sanity-call a read:
+cast call 0x<new-vaultFactory> "getVaultCount()(uint256)" --rpc-url "$RPC"
+```
+
+### 6.2 Backend end-to-end harness
+
+```bash
+cd /Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/backend && uv run python -m archimedes.scripts.verify_arc_e2e
+```
+
+`verify_arc_e2e.py` reads `VAULT_FACTORY_ADDRESS` / `REASONING_TRACE_REGISTRY_ADDRESS` (falling back to the `ARC_`-prefixed forms), warns if unset, and exercises create-vault / trace-publish. It is also the canonical place documenting the dual naming convention.
+
+### 6.3 Via the live app
+
+```bash
+curl -fsS https://<app-host>/health    # VERIFY: confirm the live host (archimedes-arc.com / archimedes-arc per AWS migration); expect 200 / healthy
+```
+
+Then in the UI (rebuilt per §5.5): connect a wallet, do a deposit/withdraw round-trip on a vault, and confirm the address in the UI matches the new `VaultFactory`-derived vault. Watch `docker compose logs backend oracle agent` for `Contract address not configured` (empty env) or revert errors.
+
+---
+
+## 7. Activate the redeploy-dependent PRs
+
+A change "activates on redeploy" only when Solidity **source/ABI** is ahead of **live bytecode**. `contracts/abis/` deliberately mirrors LIVE, so the backend keeps using OLD ABIs until you redeploy **and** refresh the ABI (§4).
+
+### Hard ordering constraint
+
+**ReasoningTraceRegistry must be redeployed BEFORE the Vault**, because PR **#589** wires the registry address into the Vault constructor (or VaultFactory) so `rebalance()` can enforce commit-before-trade. `Deploy.s.sol` already orders Registry before VaultFactory, so following the script preserves this.
+
+> Two **different** registries — don't confuse them: `Vault.rebalance()` today consults only `IAssetRegistry` (the asset/oracle allowlist), **not** `ReasoningTraceRegistry`. #589's whole point is to add the `ReasoningTraceRegistry` consult; it does not exist on-chain today, so commit-before-trade is currently off-chain-evidencable only, not enforced.
+
+### Activation order (the answer)
+
+- **STEP 0 (merge, optional in same cut):** merge #724 (Chainlink read path) and/or #589 source so the new bytecode exists. The already-merged audit fixes (#582/#583/#585/#586) and #584 commit/reveal need no merge.
+- **STEP 1:** Deploy **ReasoningTraceRegistry FIRST** (no upstream dep; its address is an input to the Vault). Capture the address.
+- **STEP 2:** Deploy the **7 PriceOracle** instances (incl. #586 deviation-bound fix and, if #724 merged, the Chainlink read path). Capture addresses.
+- **STEP 3:** Deploy **SyntheticVault(s) and Vault (via VaultFactory)**, passing the NEW registry + oracle addresses.
+- **STEP 4:** Refresh `contracts/abis/` (§4) — **this is the moment** the registry ABI flips v1→v1.5 (exposes `commit`/`reveal`/`getCommitment`) and PriceOracle gains `setPriceFeed`/`priceFeed`. Update the address config (§5).
+- **STEP 5 — #728 (commit/reveal v1.5), AUTOMATIC:** with the refreshed ABI, `supports_commit_reveal()` (`hasattr(registry.functions,'commit'/'reveal')`) now returns **True**, so `agent_runner` switches from the `publishTrace` fallback to the real commit→trade→reveal + Pinata CID anchor — **with no code change**. Confirm: registry ABI now contains `commit`/`reveal`; agent logs show commit/reveal (not publishTrace fallback). Pinata pinning is gated on `PINATA_JWT` (degrades loudly if unset, never raises).
+- **STEP 6 — #724 (Chainlink), MANUAL per asset:** **[DAN ACTION]** owner calls `setPriceFeed(feed)` per asset to flip `getPrice()` onto Chainlink. Until then behavior is identical to today (admin fallback). `getPrice()/setPrice()/price()` signatures are byte-for-byte preserved — #724 does **not** block the backend; it only **activates** the optional feed path once `setPriceFeed` exists in deployed bytecode.
+
+   ```bash
+   cast send 0x<new-priceOracle> "setPriceFeed(address)" 0x<chainlink-feed> --rpc-url "$RPC" --account deployer
+   ```
+- **STEP 7:** Smoke-test on testnet (one end-to-end commit→rebalance→reveal against the new registry; UI deposit/withdraw round-trip) **before** cutting the live stack over (per #588 acceptance + CLAUDE.md smoke rule).
+
+> **#588-now vs full-#589:** if you redeploy the registry for #728 **without** #589 merged, you get fetchable commit/reveal but **no on-chain enforcement** in `rebalance()`. The full enforcement requires #589's two source changes (registry `commit()` gains a `tradeId`/allocation-hash; `Vault.rebalance()` requires a fresh unrevealed commitment) riding the **same** redeploy.
+
+> **Anti-goal preserved:** deposits/withdrawals stay registry-independent, so a registry outage never locks user funds. Don't add a registry dependency to deposit/withdraw paths.
+
+---
+
+## 8. Rollback / safety
+
+On-chain deploys are **irreversible** — you cannot un-deploy. Rollback = **re-pointing config back to the previous live addresses**, which you captured in §2.
+
+1. **Revert backend addresses:** restore the previous `ARC_*` values in `.env` (and/or `client.py` defaults if you edited them in §5.2), then `docker compose restart backend oracle agent` (or `up -d --build` if you rebuilt). Because the backend resolves addresses purely from env/defaults, this fully reverts the backend to the prior contracts.
+2. **Revert ABIs:** `git checkout -- contracts/abis/` to restore the prior committed ABI arrays, then restart/rebuild so the bind-mount (`:ro`) re-reads them. The old ABI re-pins `supports_commit_reveal()` to False → agent falls back to `publishTrace` cleanly.
+3. **Revert UI:** `git checkout -- ui/src/config.js` and rebuild the nginx image.
+4. **Clear stale pins:** if you set `AGENT_VAULT_ADDRESSES`, revert it to the old vaults (or unset).
+5. **Leave `ARC_USDC_ADDRESS` alone** — `0x3600…0000` is the Arc USDC precompile and is invariant across deploys.
+
+**Safety guardrails to re-read before any [DAN ACTION]:**
+- Deployer key is a **dedicated throwaway**, funded only with testnet USDC, never committed.
+- Never echo `$RPC` (canteen `swrm_` secret) anywhere persistent.
+- `SEED_LIQUIDITY=true` does **not** seed — pools are empty; do not assume liquidity exists post-deploy.
+- An ABI refresh that misses a signature change **silently** breaks the backend — verify the ABI surface (§4) before declaring done.
+- The un-prefixed `.env` keys are inert — always wire the **`ARC_`-prefixed** vars.
+
+---
+
+### Quick-reference: files this runbook touches
+
+| Purpose | Path |
+|---|---|
+| Foundry deploy script (order/args spec) | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts/script/Deploy.s.sol` |
+| Foundry config / RPC alias | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts/foundry.toml` |
+| forge deploy record (new live set) | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts/broadcast/Deploy.s.sol/5042002/run-latest.json` |
+| ABI cache (manual refresh) | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/contracts/abis/` |
+| Backend address source-of-truth | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/backend/archimedes/chain/client.py` |
+| Contract loader (ABI by name) | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/backend/archimedes/chain/contracts.py` |
+| Python+Circle deployer | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/backend/archimedes/scripts/deploy_contracts.py` |
+| E2E verify harness | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/backend/archimedes/scripts/verify_arc_e2e.py` |
+| Node+Circle deploy (live-path) | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/wallet-setup/deploy.mjs`, `deploy-new.mjs` |
+| EC2 core-env helper (edit before use) | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/scripts/set-contract-env.sh` |
+| docker-compose `:-` address defaults | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/docker-compose.yml`, `docker-compose.production.yml` |
+| UI hardcoded addresses | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/ui/src/config.js` |
+| Make targets (`compile`/`test`/`deploy`) | `/Users/dbrowne/Desktop/Programming/GitHub/Agora/archimedes/Makefile` |


### PR DESCRIPTION
## Summary
Adds **`docs/runbooks/t3.2-contract-redeploy.md`** — a complete, copy-pasteable runbook for redeploying the Arc-testnet contract suite **from Dan's own keys** and re-wiring the backend + UI. This is the keystone for Dan's full-stack control as Chuan steps back (roadmap **T3.2**), and the unlock for the redeploy-dependent contract work (#724 Chainlink read path, #728 commit/reveal v1.5).

Researched via a 4-agent sweep of the actual deploy machinery, so it documents the **real** state, not the assumed one:
- **Three diverging deploy paths** exist (Foundry `contracts/script/Deploy.s.sol`, Python+Circle `backend/archimedes/scripts/deploy_contracts.py`, Node+Circle `make deploy`) — and the **currently-live 11 contracts were deployed via the Node+Circle path, not forge**. The runbook uses Foundry as the authoritative primary and flags the SyntheticVault model divergence.
- **USDC-as-gas** dual-decimals trap (18-dec native vs 6-dec ERC-20); Foundry not installed; `contracts/out/` gitignored+absent so `forge build` is mandatory; the arc-canteen `swrm_` RPC token is a secret; `deploy_output.json` is stale/deprecated and the ABI refresh is **manual**; the UI address set currently disagrees with the backend; import-time singletons require a container restart.
- Every irreversible / funded-key step is marked **[DAN ACTION]**.

Sections: 0 goal/when-not-to · 1 prereqs (Foundry, deployer wallet, funding, RPC, env) · 2 pre-deploy checklist · 3 deploy + capture addresses · 4 deploy_output.json + ABI refresh · 5 backend re-wire · 6 smoke-test · 7 activate #724/#728 (hard ordering) · 8 rollback.

## Note
Docs-only; safe to merge. But it guides **real on-chain deploys** — Dan (and ideally Bogdan) should read it end-to-end before the first redeploy, and we should tighten any `VERIFY:` markers against the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
