### PR TITLE
[regime] Fix crisis-blind GMM — label CRISIS by VIX tail, not brittle mean

### DIFF
--- a/backend/archimedes/services/gmm_regime_detector.py
+++ b/backend/archimedes/services/gmm_regime_detector.py
@@ -85,10 +85,17 @@ _CONFIRMATIONS_REQUIRED = 2
 _CONF_MIN = 0.5
 _CONF_MAX = 0.95
 
-# Component-labelling thresholds (in ORIGINAL feature space). A component whose
-# mean VIX exceeds this is full-crisis rather than merely defensive — the GFC
-# 2008 and COVID 2020 peaks both blew through 35.
+# Component-labelling thresholds (in ORIGINAL feature space). The CRISIS test is
+# applied to the top-VIX component's upper TAIL, not its mean: a genuine crisis
+# cluster (the GFC 2008 / COVID 2020 tail) has its mean pulled below the ~35
+# crash level by the surrounding elevated-but-not-crash days — empirically the
+# component capturing those crashes had mean VIX 34.9, missing a `mean > 35` test
+# by 0.1. So a component is CRISIS when its VIX `mean + 1σ` blows through this
+# crash level (and its mean is at least clearly defensive, _CRISIS_MEAN_FLOOR).
 _CRISIS_VIX_THRESHOLD = 35.0
+# A crisis component must also be unambiguously elevated on average, so a calm
+# component with a fat tail can't trip the tail test.
+_CRISIS_MEAN_FLOOR = 25.0
 
 # Rolling buffer of recent (vix, spy_price) observations. 64 > _MIN_HISTORY so a
 # few short ticks at startup still warm up toward the GMM-eligible threshold.
@@ -179,7 +186,8 @@ def _label_components(scaler: StandardScaler, gmm: GaussianMixture) -> dict[int,
     each component's mean in the ORIGINAL feature space (via
     ``scaler.inverse_transform``). The rule (deterministic; covers all four):
 
-      1. Highest VIX-mean component → CRISIS if that VIX-mean > 35, else RISK_OFF.
+      1. Highest VIX-mean component → CRISIS if its VIX upper tail (mean + 1σ)
+         clears the crash level AND its mean is clearly elevated, else RISK_OFF.
       2. Among the remaining components, the lowest VIX-mean one is the calm
          regime: RISK_ON if its 21-day-return mean is positive, else TRANSITION.
       3. Any still-unassigned components are labelled by DESCENDING VIX-mean,
@@ -193,9 +201,14 @@ def _label_components(scaler: StandardScaler, gmm: GaussianMixture) -> dict[int,
     order_by_vix_desc = list(np.argsort(vix_means)[::-1])  # highest VIX first
     mapping: dict[int, Regime] = {}
 
-    # 1. Highest-VIX component → CRISIS (if extreme) else RISK_OFF.
+    # 1. Highest-VIX component → CRISIS when its VIX upper tail reaches crash
+    #    territory (robust to a crisis cluster's mean sitting below its peaks),
+    #    gated on a clearly-elevated mean; else RISK_OFF.
     crisis_idx = order_by_vix_desc[0]
-    mapping[crisis_idx] = Regime.CRISIS if vix_means[crisis_idx] > _CRISIS_VIX_THRESHOLD else Regime.RISK_OFF
+    crisis_vix_std = float(np.sqrt(gmm.covariances_[crisis_idx][_IDX_VIX, _IDX_VIX]) * scaler.scale_[_IDX_VIX])
+    crisis_tail = vix_means[crisis_idx] + crisis_vix_std
+    is_crisis = vix_means[crisis_idx] >= _CRISIS_MEAN_FLOOR and crisis_tail > _CRISIS_VIX_THRESHOLD
+    mapping[crisis_idx] = Regime.CRISIS if is_crisis else Regime.RISK_OFF
 
     # 2. Lowest-VIX remaining component → calm regime (RISK_ON / TRANSITION by
     #    the sign of its mean 21-day return).

--- a/backend/tests/services/test_gmm_regime_detector.py
+++ b/backend/tests/services/test_gmm_regime_detector.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 from archimedes.models.asset import MarketSnapshot
@@ -32,12 +33,16 @@ from archimedes.models.regime import Regime, RegimeClassification, RegimeSignals
 from archimedes.services.gmm_regime_detector import (
     _CONF_MAX,
     _CONF_MIN,
+    _CRISIS_MEAN_FLOOR,
+    _IDX_VIX,
     _MIN_HISTORY,
     FittedGmm,
     GmmRegimeDetector,
+    _label_components,
     fit_gmm_model,
     load_gmm_model,
 )
+from sklearn.preprocessing import StandardScaler
 
 # A path that never exists → load_gmm_model returns None → detector falls back.
 _NONEXISTENT_MODEL = Path("/nonexistent/archimedes-gmm-test-does-not-exist.pkl")
@@ -248,6 +253,61 @@ class TestFallbackDelegation:
 
         det = GmmRegimeDetector(model_path=_NONEXISTENT_MODEL)
         assert isinstance(det._fallback, VixRegimeDetector)
+
+
+class TestCrisisTailLabelling:
+    """CRISIS keys off the top-VIX component's upper TAIL, not its mean — a crisis
+    cluster whose mean sits just below the crash level still labels CRISIS
+    (regression for the brittle ``mean > 35`` test that left the live 10y model
+    crisis-blind by 0.1 VIX: the COVID/2022 cluster had mean VIX 34.9)."""
+
+    @staticmethod
+    def _scaler(mean: list[float], scale: list[float]) -> StandardScaler:
+        s = StandardScaler()
+        s.mean_ = np.asarray(mean, dtype=float)
+        s.scale_ = np.asarray(scale, dtype=float)
+        s.var_ = s.scale_**2
+        s.n_features_in_ = len(mean)
+        return s
+
+    @staticmethod
+    def _gmm(vix_means: list[float], vix_stds: list[float], scaler: StandardScaler) -> SimpleNamespace:
+        # Only the VIX dim varies; other feature dims stay 0 so the calm
+        # component's mean 21d-return is >= 0 → RISK_ON. Full covariances encode
+        # each component's original-space VIX std in the VIX-VIX entry.
+        n = len(vix_means)
+        means = np.zeros((n, 4))
+        covs = np.tile(np.eye(4) * 0.05, (n, 1, 1))
+        for i, (vm, vs) in enumerate(zip(vix_means, vix_stds, strict=True)):
+            means[i, _IDX_VIX] = (vm - scaler.mean_[_IDX_VIX]) / scaler.scale_[_IDX_VIX]
+            covs[i, _IDX_VIX, _IDX_VIX] = (vs / scaler.scale_[_IDX_VIX]) ** 2
+        return SimpleNamespace(means_=means, covariances_=covs)
+
+    _SCALER_ARGS = {"mean": [18.0, 0.0, 0.18, 0.0], "scale": [8.0, 0.3, 0.1, 0.05]}
+
+    def test_subthreshold_mean_with_crash_tail_is_crisis(self) -> None:
+        scaler = self._scaler(**self._SCALER_ARGS)
+        # Top component: mean VIX 34.9 (< 35) but a wide tail (std 12 → mean+1σ ≈ 47).
+        gmm = self._gmm([34.9, 28.0, 22.0, 14.0], [12.0, 3.0, 2.0, 2.0], scaler)
+        mapping = _label_components(scaler, gmm)
+        assert Regime.CRISIS in mapping.values()
+        assert mapping[0] is Regime.CRISIS  # index 0 is the highest-VIX component
+
+    def test_low_mean_thin_tail_is_not_crisis(self) -> None:
+        scaler = self._scaler(**self._SCALER_ARGS)
+        # Elevated but its tail never reaches the crash level → RISK_OFF, no CRISIS.
+        gmm = self._gmm([30.0, 22.0, 16.0, 12.0], [1.0, 2.0, 2.0, 2.0], scaler)
+        mapping = _label_components(scaler, gmm)
+        assert Regime.CRISIS not in mapping.values()
+        assert mapping[0] is Regime.RISK_OFF
+
+    def test_below_mean_floor_is_not_crisis(self) -> None:
+        scaler = self._scaler(**self._SCALER_ARGS)
+        # A calm-but-fat-tailed top component (mean < floor) can't trip CRISIS.
+        assert _CRISIS_MEAN_FLOOR > 22.0
+        gmm = self._gmm([22.0, 16.0, 13.0, 10.0], [20.0, 2.0, 2.0, 2.0], scaler)
+        mapping = _label_components(scaler, gmm)
+        assert Regime.CRISIS not in mapping.values()
 
 
 class TestGetCurrentRegime:


### PR DESCRIPTION
## Summary
Fixes a **crisis-blind** GMM regime model, surfaced by the T0.5 telemetry that just went live (`/health` reported `regime_detector: degraded` — no fitted model in prod). When I fit the model for the first time under current 2026 data, the result had **no CRISIS component**: the highest-VIX cluster (which captures the COVID 2020 / 2022 crashes, 2.3% of days) had a **mean VIX of 34.9 — missing the `mean > 35` crisis threshold by 0.1**.

Root cause is **threshold brittleness**: a crisis cluster's *mean* is always pulled below its peaks (VIX 82 in 2020) by the surrounding elevated-but-not-crash days, so thresholding the mean at 35 is fragile.

## Fix
Label the top-VIX component CRISIS when its VIX **upper tail (`mean + 1σ`) clears the crash level**, gated on a clearly-elevated mean (`_CRISIS_MEAN_FLOOR = 25`). This keeps 35 as the crash level (the original intent — "GFC/COVID peaks blew through 35") but applies it to the tail, not the brittle mean. Only the single highest-VIX component is ever a crisis candidate (unchanged).

- `backend/archimedes/services/gmm_regime_detector.py` — tail-based crisis label + `_CRISIS_MEAN_FLOOR`.
- `backend/tests/services/test_gmm_regime_detector.py` — 3 regression tests (sub-35-mean-with-crash-tail → CRISIS; thin tail → not; below floor → not).

## Verification
- Re-fit on real 10y ^VIX+SPY → clean 1:1 mapping across all four regimes: `{crisis, risk_on, risk_off, transition}` (was `{risk_off, risk_on, risk_off, transition}` — crisis-blind).
- `pytest backend/tests/services/test_gmm_regime_detector.py` → **22 passed**. ruff format + critical-lint clean.

## Why this matters (claim integrity)
A crisis-blind GMM is *worse* than the rule-based fallback (which catches VIX spikes), so I did **not** ship the broken model — and I didn't silently lower a funds-adjacent risk threshold. This is the reviewed fix. **On merge, I'll re-fit and ship `gmm_model.pkl` to prod** (it's gitignored, shipped out-of-band into the backend image), flipping `/health` `regime_detector` to `live` with real CRISIS detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
