### PR TITLE
[ui] Rename market regimes to plain language + add findable definitions

### DIFF
--- a/ui/src/components/Learnings.jsx
+++ b/ui/src/components/Learnings.jsx
@@ -64,8 +64,9 @@ export default function Learnings({ onNavigate }) {
         <p className="body mb-4 text-[var(--text-3)]">
           The regime is the agent's read of market conditions, derived from VIX +
           SPX moving-average cross signals. It biases strategy selection —
-          <em>risk_on</em> leans into momentum + TSMOM,
-          <em> crisis</em> leans into t-bill alternatives + capital preservation.
+          <em>Calm</em> leans into momentum + TSMOM,
+          <em> Crisis</em> leans into t-bill alternatives + capital preservation.
+          The four regimes are defined in full below.
         </p>
         <RegimePanel />
       </div>

--- a/ui/src/components/PortfolioAdvisor.jsx
+++ b/ui/src/components/PortfolioAdvisor.jsx
@@ -1,5 +1,6 @@
 import { apiGet } from '../api'
 import { useState, useEffect } from 'react'
+import { regimeMeta } from '../regime'
 
 
 
@@ -19,12 +20,6 @@ function fmtPct(v) {
 
 function fmt(v, d = 2) {
   return (v != null && Number.isFinite(v)) ? v.toFixed(d) : '—'
-}
-
-function regimeColor(regime) {
-  if (regime === 'risk_on') return 'var(--positive)'
-  if (regime === 'crisis' || regime === 'risk_off') return 'var(--negative)'
-  return '#f59e0b'
 }
 
 function AllocationBar({ label, weight, isUsdc, kelly, rigorPassed, isCandidate }) {
@@ -105,8 +100,9 @@ export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {
   }, [selectedProfile])
 
   const regime = data?.regime ?? 'unknown'
-  const regimeLabel = regime.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
-  const rColor = regimeColor(regime)
+  const regimeInfo = regimeMeta(regime)
+  const regimeLabel = regimeInfo.label
+  const rColor = regimeInfo.color
 
   return (
     <div>
@@ -165,12 +161,11 @@ export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {
                 </span>
               </div>
               <span className="caption">confidence {fmtPct(data.regime_confidence)}</span>
+              <span className="caption" style={{ color: 'var(--text-4)' }}>· {regimeInfo.exposure}</span>
             </div>
-            {data.regime_narrative && (
-              <p className="body" style={{ margin: 0, color: 'var(--text-3)', lineHeight: 1.5 }}>
-                {data.regime_narrative}
-              </p>
-            )}
+            <p className="body" style={{ margin: 0, color: 'var(--text-3)', lineHeight: 1.5 }}>
+              {data.regime_narrative || regimeInfo.definition}
+            </p>
           </div>
 
           {/* Allocation breakdown */}

--- a/ui/src/components/Reasoning.jsx
+++ b/ui/src/components/Reasoning.jsx
@@ -4,6 +4,7 @@ import {
   publicClient,
   TRACE_REGISTRY_ABI, NEW_CONTRACTS,
 } from '../config'
+import { regimeMeta } from '../regime'
 
 
 
@@ -242,8 +243,9 @@ function OnChainTraces({ onNavigate, highlightTraceId }) {
                     {t.regime_at_decision && (
                       <div style={{ marginBottom: 8 }}>
                         <span className="caption">Regime: </span>
-                        <span className={`tag ${t.regime_at_decision === 'risk_on' ? 'tag-positive' : t.regime_at_decision === 'risk_off' ? 'tag-muted' : 'tag-accent'}`}>
-                          {t.regime_at_decision}
+                        <span className={`tag ${regimeMeta(t.regime_at_decision).tag}`}
+                          title={regimeMeta(t.regime_at_decision).definition}>
+                          {regimeMeta(t.regime_at_decision).label}
                         </span>
                       </div>
                     )}

--- a/ui/src/components/RegimePanel.jsx
+++ b/ui/src/components/RegimePanel.jsx
@@ -1,5 +1,6 @@
 import { apiGet } from '../api'
 import { useState, useEffect, useCallback } from 'react'
+import { regimeMeta, regimeLabel, REGIME_ORDER } from '../regime'
 
 
 
@@ -11,23 +12,14 @@ function fmt(v, d = 1) {
   return v != null ? v.toFixed(d) : '—'
 }
 
-function regimeColor(regime) {
-  if (regime === 'risk_on') return 'var(--positive)'
-  if (regime === 'crisis') return 'var(--negative)'
-  if (regime === 'risk_off') return 'var(--negative)'
-  return '#f59e0b'
-}
-
+// Presentation pulled from the shared regime map (src/regime.js) so the
+// labels, colors, and definitions stay consistent across every surface.
 function regimeBg(regime) {
-  if (regime === 'risk_on') return 'rgba(16,185,129,0.08)'
-  if (regime === 'crisis' || regime === 'risk_off') return 'rgba(239,68,68,0.08)'
-  return 'rgba(245,158,11,0.08)'
+  return regimeMeta(regime).bg
 }
 
 function regimeBorder(regime) {
-  if (regime === 'risk_on') return 'rgba(16,185,129,0.25)'
-  if (regime === 'crisis' || regime === 'risk_off') return 'rgba(239,68,68,0.25)'
-  return 'rgba(245,158,11,0.25)'
+  return regimeMeta(regime).border
 }
 
 function MiniBar({ value, max, color }) {
@@ -44,16 +36,14 @@ function MiniBar({ value, max, color }) {
 // on /learnings.
 function CompactRegimePill({ regime }) {
   const r = regime.regime
-  const rColor = regimeColor(r)
-  const rLabel = r.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+  const meta = regimeMeta(r)
+  const rColor = meta.color
+  const rLabel = meta.label
   const conf = regime.confidence ?? 0
   return (
     <span
       title={
-        `The agent's current read of market conditions. Drives which library ` +
-        `strategies it leans into for new generates + rebalances. ` +
-        `risk_on → momentum/TSMOM. transition → vol-managed. ` +
-        `risk_off → t-bill alternatives. crisis → capital preservation.`
+        `${meta.label} — ${meta.definition} ${meta.exposure}.`
       }
       style={{
         display: 'inline-flex',
@@ -79,11 +69,10 @@ function CompactRegimePill({ regime }) {
 }
 
 function TransitionRow({ from, to, prob }) {
-  const arrow = from === to ? 'stay' : `→ ${to.replace(/_/g, ' ')}`
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
       <span className="caption" style={{ width: 100, color: 'var(--text-3)', fontSize: '0.75rem' }}>
-        {from === to ? `Stay ${from.replace(/_/g, ' ')}` : arrow}
+        {from === to ? `Stay ${regimeLabel(from)}` : `→ ${regimeLabel(to)}`}
       </span>
       <MiniBar value={prob} max={1} color={from === to ? 'var(--accent)' : 'rgba(255,255,255,0.25)'} />
       <span className="mono" style={{ fontSize: '0.75rem', width: 36, textAlign: 'right' }}>
@@ -155,8 +144,9 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
   }
 
   const r = regime.regime
-  const rColor = regimeColor(r)
-  const rLabel = r.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+  const meta = regimeMeta(r)
+  const rColor = meta.color
+  const rLabel = meta.label
   const confidencePct = regime.confidence ?? 0
   const signals = regime.signals || {}
   const transitions = regime.transition_probabilities
@@ -207,6 +197,12 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
           </span>
         )}
       </div>
+
+      {/* Plain-language meaning of the current regime */}
+      <p className="body" style={{ margin: '0 0 14px', color: 'var(--text-3)', fontSize: '0.86rem', lineHeight: 1.5 }}>
+        {meta.definition}{' '}
+        <span style={{ color: 'var(--text-4)' }}>{meta.exposure}.</span>
+      </p>
 
       {/* Confidence bar */}
       <div style={{ marginBottom: 18 }}>
@@ -322,6 +318,36 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
           })}
         </div>
       )}
+
+      {/* Findable definitions — every regime explained inline, so the labels
+          above are never a black box. The current regime is highlighted. */}
+      <details style={{ marginTop: 16, paddingTop: 14, borderTop: '1px solid rgba(255,255,255,0.08)' }}>
+        <summary className="caption" style={{ cursor: 'pointer', color: 'var(--text-3)' }}>
+          What do these regimes mean?
+        </summary>
+        <div style={{ marginTop: 10, display: 'grid', gap: 10 }}>
+          {REGIME_ORDER.map(key => {
+            const m = regimeMeta(key)
+            const active = key === r
+            return (
+              <div key={key} style={{
+                padding: '8px 10px', borderRadius: 6,
+                background: active ? m.bg : 'rgba(255,255,255,0.02)',
+                border: `1px solid ${active ? m.border : 'var(--glass-border)'}`,
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 3 }}>
+                  <span style={{ width: 8, height: 8, borderRadius: '50%', background: m.color, display: 'inline-block' }} />
+                  <span style={{ fontWeight: 700, fontSize: '0.84rem', color: m.color }}>{m.label}</span>
+                  {active && <span className="caption" style={{ color: 'var(--text-4)' }}>· current</span>}
+                </div>
+                <div className="caption" style={{ color: 'var(--text-3)', lineHeight: 1.45 }}>
+                  {m.definition} <span style={{ color: 'var(--text-4)' }}>{m.exposure}.</span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </details>
     </div>
   )
 }

--- a/ui/src/regime.js
+++ b/ui/src/regime.js
@@ -1,0 +1,91 @@
+// Single source of truth for how market regimes are presented to users.
+//
+// The WIRE VALUES — 'risk_on' | 'transition' | 'risk_off' | 'crisis' — are
+// NEVER renamed: they're persisted to Redis, embedded in the fitted GMM model
+// pickle (backend/archimedes/services/gmm_model.pkl), and sent over
+// /api/regime/*. This module is a DISPLAY layer only: it maps each stable wire
+// value to a plain-language name, a one-line definition, and the agent's actual
+// exposure response, so the UI can stop showing esoteric labels like "risk_on".
+//
+// The exposure multipliers below mirror REGIME_MULTIPLIER in
+// backend/archimedes/services/portfolio_constructor.py (RISK_ON 1.0 /
+// TRANSITION 0.7 / RISK_OFF 0.4 / CRISIS 0.1) — keep them in sync if that
+// table changes.
+
+export const REGIME_META = {
+  risk_on: {
+    label: 'Calm',
+    tagline: 'Low volatility, positive trend',
+    definition:
+      'Low VIX, prices above their moving averages, and tight credit spreads. ' +
+      'Conditions favor taking risk, so the agent sizes positions in full.',
+    exposure: 'Full risk exposure (≈1.0× position sizing)',
+    color: 'var(--positive)',
+    bg: 'rgba(16,185,129,0.08)',
+    border: 'rgba(16,185,129,0.25)',
+    tag: 'tag-positive',
+  },
+  transition: {
+    label: 'Choppy',
+    tagline: 'Mixed signals, rising uncertainty',
+    definition:
+      'Conflicting signals and increasing uncertainty — the market is between ' +
+      'regimes. The agent trims exposure as a precaution while direction resolves.',
+    exposure: 'Reduced exposure (≈0.7× position sizing)',
+    color: '#f59e0b',
+    bg: 'rgba(245,158,11,0.08)',
+    border: 'rgba(245,158,11,0.25)',
+    tag: 'tag-accent',
+  },
+  risk_off: {
+    label: 'Defensive',
+    tagline: 'Elevated volatility, weakening trend',
+    definition:
+      'Rising VIX, prices breaking below moving averages, and widening credit ' +
+      'spreads. The agent cuts risk and rotates the freed weight toward cash-like assets.',
+    exposure: 'Low exposure (≈0.4× position sizing)',
+    color: 'var(--negative)',
+    bg: 'rgba(239,68,68,0.08)',
+    border: 'rgba(239,68,68,0.25)',
+    tag: 'tag-muted',
+  },
+  crisis: {
+    label: 'Crisis',
+    tagline: 'Extreme volatility, flight to safety',
+    definition:
+      'Extreme VIX, cross-asset correlations spiking toward 1, and a broad flight ' +
+      'to safety. The agent moves to near-flat, capital-preservation mode.',
+    exposure: 'Minimal exposure (≈0.1× position sizing)',
+    color: 'var(--negative)',
+    bg: 'rgba(239,68,68,0.12)',
+    border: 'rgba(239,68,68,0.35)',
+    tag: 'tag-muted',
+  },
+}
+
+// Display order from calmest to most defensive — used by the definitions panel.
+export const REGIME_ORDER = ['risk_on', 'transition', 'risk_off', 'crisis']
+
+const UNKNOWN_META = {
+  label: 'Unknown',
+  tagline: 'Regime unavailable',
+  definition:
+    'No market-regime read is available yet — the agent feed is not connected or ' +
+    'has not produced a classification. The agent falls back to a conservative default.',
+  exposure: 'Conservative default until a regime is detected',
+  color: 'var(--text-4)',
+  bg: 'rgba(255,255,255,0.04)',
+  border: 'var(--glass-border)',
+  tag: 'tag-muted',
+}
+
+// Look up presentation metadata for a wire value. Unknown / consensus-only
+// values fall back to a safe "Unknown" descriptor rather than throwing.
+export function regimeMeta(value) {
+  return REGIME_META[value] || UNKNOWN_META
+}
+
+// Plain-language label for a wire value (e.g. 'risk_on' -> 'Calm').
+export function regimeLabel(value) {
+  return regimeMeta(value).label
+}


### PR DESCRIPTION
## Summary
Renames the market-regime labels to plain language and adds findable, inline definitions — addresses the note that `crisis / risk_on / risk_off / transition` are esoteric and need clear, discoverable meanings in the UI.

**Display names (presentation only):**
| Wire value (unchanged) | New label | Meaning | Exposure |
|---|---|---|---|
| `risk_on` | **Calm** | Low vol, positive trend, tight spreads | Full (≈1.0×) |
| `transition` | **Choppy** | Mixed signals, rising uncertainty | Reduced (≈0.7×) |
| `risk_off` | **Defensive** | Elevated vol, weakening trend, widening spreads | Low (≈0.4×) |
| `crisis` | **Crisis** | Extreme vol, flight to safety | Minimal (≈0.1×) |

## Why a display layer (not a raw rename)
The wire values are persisted to Redis, **baked into the fitted `gmm_model.pkl` that just shipped to prod**, and sent over `/api/regime/*`. A raw enum rename would break serialization + the live GMM model. So this keeps wire values stable and adds a presentation layer on top.

## Changes
- **New** `ui/src/regime.js` — single source of truth mapping each wire value → `{label, definition, exposure, colors}`.
- `RegimePanel.jsx` — labels / colors / transition rows now come from the map; current-regime definition shown inline; new **"What do these regimes mean?"** panel lists all four (current highlighted).
- `PortfolioAdvisor.jsx`, `Reasoning.jsx`, `Learnings.jsx` — consistent names + colors from the map.
- Exposure copy cites the real `REGIME_MULTIPLIER` (1.0 / 0.7 / 0.4 / 0.1) from `portfolio_constructor.py`, so the definitions match the agent's actual behavior.

## Scope / safety
- **Frontend-only — no backend, API, Redis, or pickle changes** → zero serialization risk; the just-shipped GMM model keeps working.
- All names live in one file — renaming any label is a one-line edit. **@dbrowneup: easy to tweak the words if you'd prefer different ones (e.g. Calm/Choppy/Defensive/Crisis).**

## Verify
- `/learnings` and `/portfolio` render the new names; the RegimePanel **"What do these regimes mean?"** expandable lists all four definitions + exposure.
- Local eslint could not run this session (no `node` on PATH); relying on the CI eslint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
