### PR TITLE
[chore] Clear 14 informational ruff findings (no behavior change)

### DIFF
--- a/analytics-engine/tests/test_costs_coverage.py
+++ b/analytics-engine/tests/test_costs_coverage.py
@@ -188,7 +188,7 @@ def test_position_weight_zero_equity_returns_zero() -> None:
         pass
 
     class _FakeBroker:
-        def getvalue(self, datas=None):  # noqa: ANN001, ANN201
+        def getvalue(self, datas=None):
             return 0.0
 
     class _FakeStrategy:

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1563,8 +1563,8 @@ async def _run_fusion_job(job_id: str) -> None:
 @limiter.limit("20/minute")
 async def construct_strategy(
     req: StrategyConstructionRequest,
-    request: Request,
-    response: Response,
+    request: Request,  # noqa: ARG001 — required by the slowapi limiter / FastAPI
+    response: Response,  # noqa: ARG001 — kept for FastAPI handler symmetry
     _wallet: str | None = Depends(gate_generation),
 ):
     """Interactive strategy architect -- the 'design me a portfolio' path."""

--- a/backend/archimedes/services/_fusion_helpers.py
+++ b/backend/archimedes/services/_fusion_helpers.py
@@ -337,10 +337,7 @@ def _as_returns_matrix(
     usable (length >= 2) series survive — the caller treats ``None`` as
     "not scoreable".
     """
-    if isinstance(returns_matrix, dict):
-        series = list(returns_matrix.values())
-    else:
-        series = list(returns_matrix)
+    series = list(returns_matrix.values()) if isinstance(returns_matrix, dict) else list(returns_matrix)
 
     arrs = [_np.asarray(s, dtype=float).ravel() for s in series]
     arrs = [a for a in arrs if a.size >= 2]

--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -814,12 +814,9 @@ def regime_robustness_score(
     max_sharpe = float(max(sharpes))
     dispersion = round(max_sharpe - min_sharpe, 6) if len(sharpes) >= 2 else None
 
-    if max_sharpe > 0.0:
-        consistency = min(1.0, max(0.0, min_sharpe / max_sharpe))
-    else:
-        # Non-positive in every regime: there is no regime in which the edge
-        # works, so there is no consistency to credit.
-        consistency = 0.0
+    # Non-positive in every regime → no regime in which the edge works, so there
+    # is no consistency to credit (0.0).
+    consistency = min(1.0, max(0.0, min_sharpe / max_sharpe)) if max_sharpe > 0.0 else 0.0
 
     return {
         "per_regime": per_regime,
@@ -1099,10 +1096,8 @@ def benjamini_hochberg_fdr(
 
     # Largest k where sorted_p[k-1] <= bh_crit[k-1]
     below_threshold = sorted_p <= bh_crit
-    if np.any(below_threshold):
-        k_star = int(np.where(below_threshold)[0][-1])  # 0-based index of last True
-    else:
-        k_star = -1  # nothing rejected
+    # 0-based index of the last True (largest rejected k); -1 if nothing rejected.
+    k_star = int(np.where(below_threshold)[0][-1]) if np.any(below_threshold) else -1
 
     reject_sorted = np.zeros(m, dtype=bool)
     if k_star >= 0:

--- a/backend/archimedes/services/llm_backend.py
+++ b/backend/archimedes/services/llm_backend.py
@@ -393,7 +393,7 @@ class CannedBackend:
     def available(self) -> bool:
         return False
 
-    def complete(self, system: str, user: str) -> str:
+    def complete(self, system: str, user: str) -> str:  # noqa: ARG002 — LLM backend interface contract
         return json.dumps(
             {
                 "fallback": True,

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -551,7 +551,7 @@ def monte_carlo_portfolio(
     """
     arr = np.asarray(daily_returns, dtype=float)
     T = len(arr)
-    if T < block_size * 2:
+    if block_size * 2 > T:
         raise ValueError(f"Need ≥ {block_size * 2} returns for block bootstrap; got {T}")
 
     rng = np.random.default_rng(seed)
@@ -685,7 +685,7 @@ def sensitivity_sweep(
         )
 
     def _run_one(combo: tuple) -> dict[str, Any]:
-        kw: dict[str, Any] = dict(zip(param_names, combo))
+        kw: dict[str, Any] = dict(zip(param_names, combo, strict=True))
         base = {
             "strategy_id": strategy_id,
             "weights": weights,
@@ -1048,7 +1048,7 @@ def _run_backtest_job(job: dict[str, Any]) -> dict[str, Any]:
         result, _ = backtest_portfolio(**kwargs)
         metrics = {m: float(getattr(result, m, float("nan")) or float("nan")) for m in _JOB_REPORTED_METRICS}
         return {"label": label, "ok": True, "error": None, **metrics}
-    except Exception as exc:  # noqa: BLE001 — non-fatal per-job failure, surfaced in the result
+    except Exception as exc:  # non-fatal per-job failure, surfaced in the result
         logger.debug("run_parallel_backtest job %s failed: %s", label, exc)
         return {
             "label": label,

--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -187,7 +187,7 @@ def optimize_weights(
     Sigma += np.eye(n) * 1e-8  # numerical regularization
 
     if optimizer == "hrp":
-        raw = _hrp_weights(Sigma, symbols)
+        raw = _hrp_weights(Sigma)
     elif optimizer == "black_litterman":
         raw = _black_litterman_weights(mu, Sigma, n, cap=_CAP_DEFAULT)
     elif optimizer == "robust":
@@ -452,7 +452,7 @@ def _hrp_recurse(cov: np.ndarray, order: list[int]) -> np.ndarray:
     return np.concatenate([w_left, w_right])
 
 
-def _hrp_weights(Sigma: np.ndarray, symbols: list[str]) -> np.ndarray | None:
+def _hrp_weights(Sigma: np.ndarray) -> np.ndarray | None:
     """Hierarchical Risk Parity weights (López de Prado 2016).
 
     Steps:
@@ -820,10 +820,7 @@ def compare_optimizers(
         vol_daily = float(port.std(ddof=1)) if port.shape[0] > 1 else 0.0
         annual_return = mean_daily * _ANNUALIZATION
         annual_vol = vol_daily * math.sqrt(_ANNUALIZATION)
-        if annual_vol > 1e-12:
-            sharpe = (mean_daily - _RF_DAILY) / vol_daily * math.sqrt(_ANNUALIZATION)
-        else:
-            sharpe = 0.0
+        sharpe = (mean_daily - _RF_DAILY) / vol_daily * math.sqrt(_ANNUALIZATION) if annual_vol > 1e-12 else 0.0
 
         # Max drawdown of the cumulative-return path.
         cum = np.cumprod(1.0 + port)

--- a/backend/tests/services/test_gmm_regime_detector.py
+++ b/backend/tests/services/test_gmm_regime_detector.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 
 import numpy as np
 from archimedes.models.asset import MarketSnapshot
@@ -283,7 +284,7 @@ class TestCrisisTailLabelling:
             covs[i, _IDX_VIX, _IDX_VIX] = (vs / scaler.scale_[_IDX_VIX]) ** 2
         return SimpleNamespace(means_=means, covariances_=covs)
 
-    _SCALER_ARGS = {"mean": [18.0, 0.0, 0.18, 0.0], "scale": [8.0, 0.3, 0.1, 0.05]}
+    _SCALER_ARGS: ClassVar[dict[str, list[float]]] = {"mean": [18.0, 0.0, 0.18, 0.0], "scale": [8.0, 0.3, 0.1, 0.05]}
 
     def test_subthreshold_mean_with_crash_tail_is_crisis(self) -> None:
         scaler = self._scaler(**self._SCALER_ARGS)


### PR DESCRIPTION
## Summary
Clears the **14 informational `ruff check .` findings** surfaced while reviewing merged PRs #728/#725/#726. **None were introduced by those PRs** — they're standing repo debt (the same count showed on every PR). The blocking ruff subset (`E9,F63,F7,F40`) already passed; this takes the informational broader-ruleset count to **0**.

## Context — the orphan-function angle
The bot also flagged 15–34 "orphan functions" per PR. I verified every one (whole-repo caller search + an adversarial re-check): **zero are genuinely dead** — each is framework-invoked (pytest/FastAPI/React), called elsewhere (e.g. `deploy_contracts.main()`, `Generate.jsx`), or **wired-but-pending the T3.2 redeploy** (#728 commit-reveal gated by `supports_commit_reveal()`, `chainlink_covered_synths()` staged for #724). So there's **nothing to delete** — this PR is ruff-only.

## Changes (all behavior-preserving)
| Rule | Where | Fix |
|---|---|---|
| SIM108 ×4 | `_fusion_helpers`, `_rigor_helpers` ×2, `portfolio_optimizer` | if/else → ternary (comments preserved) |
| SIM300 | `portfolio_backtester` | un-Yoda the comparison |
| B905 | `portfolio_backtester` | `zip(..., strict=True)` |
| ARG001 | `portfolio_optimizer._hrp_weights` | drop unused `symbols` param + its caller |
| ARG001/ARG002 ×4 | `strategies_routes`, `llm_backend` | `# noqa` + reason (FastAPI / interface contract) |
| RUF100 ×2 | `test_costs_coverage`, `portfolio_backtester` | remove dead `noqa`, keep the comment |
| RUF012 | `test_gmm_regime_detector` | annotate `_SCALER_ARGS: ClassVar[...]` |

## Verify
- `ruff check .` → **All checks passed!**
- `ruff format --check .` → 324 files already formatted
- `pytest` across the touched modules + GMM suite → **296 + 22 passed**

Pure hygiene, fully green + tested — safe to merge whenever you're ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
