### PR TITLE
[deps] Bump form-data 4.0.5 → 4.0.6 in wallet-setup (closes Dependabot #4)

### DIFF
--- a/wallet-setup/package-lock.json
+++ b/wallet-setup/package-lock.json
@@ -157,16 +157,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"


### PR DESCRIPTION
## Summary
Bumps the transitive `form-data` (pulled via `@circle-fin/developer-controlled-wallets` → `axios`) from **4.0.5 → 4.0.6** in `wallet-setup/package-lock.json`, closing **Dependabot alert #4** (GHSA, **high**: CRLF injection via unescaped multipart field names/filenames; vulnerable `>=4.0.0 <4.0.6`).

## Scope / safety
- **Dev/e2e only.** `wallet-setup/` is the Circle wallet-provisioning helper (`register-entity-secret`, `create-wallet`) — **not** part of the live `ui/` bundle served to users, so production blast radius was nil. Closing it anyway (security ships with the product).
- `package.json` **unchanged** — the SDK's `^4` range already allowed `4.0.6`, so this is purely a lockfile regen (8 lines).
- Verified: `npm ls form-data` → `form-data@4.0.6`; `npm audit` → **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
