### PR TITLE
[strategy] #465 — dynamic backtest-fixture loading with bundled fallback

### DIFF
--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -142,16 +142,115 @@ def _infer_risk_profiles(methodology_summary: str) -> list[str]:
     return matched or ["moderate"]
 
 
-def _load_fixtures(strategies_dir: Path) -> dict[str, Any]:
-    """Load backtest_fixtures.json from the strategies directory, if present."""
+# Env vars selecting a dynamic fixture source (issue #465). When neither is
+# set, the loader reads the bundled ``backtest_fixtures.json`` exactly as
+# before — the bundled file IS the fallback, so served (gate-sensitive)
+# values are unchanged when nothing is configured.
+_FIXTURES_PATH_ENV = "ARCHIMEDES_FIXTURES_PATH"  # filesystem override
+_FIXTURES_URL_ENV = "ARCHIMEDES_FIXTURES_URL"  # http(s) source
+
+
+def _parse_fixtures_payload(text: str, source: str) -> dict[str, Any]:
+    """Parse fixture JSON text into the keyed dict shape, validating type.
+
+    Returns ``{}`` (so the caller can fall back) when the payload is empty.
+    Raises on malformed JSON or a non-object top level so the caller treats it
+    as a failed source. ``source`` is for log/error context only.
+    """
+    if not text.strip():
+        return {}
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"{source}: expected a JSON object, got {type(data).__name__}")
+    return data
+
+
+def _load_fixtures_from_path(path: Path) -> dict[str, Any]:
+    """Load + parse a fixtures JSON file. Raises on missing/invalid file."""
+    return _parse_fixtures_payload(path.read_text(encoding="utf-8"), str(path))
+
+
+def _load_fixtures_from_url(url: str) -> dict[str, Any]:
+    """Fetch + parse fixtures JSON over HTTP. Raises on any failure.
+
+    ``httpx`` is the established HTTP client in this package (corpus_service,
+    llm_backend); imported lazily so the API process doesn't pay for it unless
+    a URL source is actually configured.
+    """
+    import httpx  # lazy — only when a URL source is configured
+
+    resp = httpx.get(url, timeout=10.0)
+    resp.raise_for_status()
+    return _parse_fixtures_payload(resp.text, url)
+
+
+def _load_dynamic_fixtures() -> dict[str, Any] | None:
+    """Try the env-configured dynamic source (path, then URL).
+
+    Returns the loaded dict on success, or ``None`` when no dynamic source is
+    configured OR the configured source fails / yields nothing — signalling the
+    caller to fall back to the bundled file. A configured-but-failing source is
+    deliberately non-fatal: a transient remote outage must never take down the
+    served strategy library, it just reverts to the bundled fallback.
+    """
+    path_override = os.getenv(_FIXTURES_PATH_ENV)
+    if path_override:
+        try:
+            loaded = _load_fixtures_from_path(Path(path_override))
+            if loaded:
+                logger.info("loaded backtest fixtures from %s=%s", _FIXTURES_PATH_ENV, path_override)
+                return loaded
+            logger.warning("%s=%s yielded no fixtures; falling back to bundled", _FIXTURES_PATH_ENV, path_override)
+        except Exception as exc:
+            logger.warning("dynamic fixtures path %s failed (%s); falling back to bundled", path_override, exc)
+
+    url_override = os.getenv(_FIXTURES_URL_ENV)
+    if url_override:
+        try:
+            loaded = _load_fixtures_from_url(url_override)
+            if loaded:
+                logger.info("loaded backtest fixtures from %s=%s", _FIXTURES_URL_ENV, url_override)
+                return loaded
+            logger.warning("%s=%s yielded no fixtures; falling back to bundled", _FIXTURES_URL_ENV, url_override)
+        except Exception as exc:
+            logger.warning("dynamic fixtures url %s failed (%s); falling back to bundled", url_override, exc)
+
+    return None
+
+
+def _load_bundled_fixtures(strategies_dir: Path) -> dict[str, Any]:
+    """Load the bundled backtest_fixtures.json from the strategies directory.
+
+    This is the fallback (and the historical default). Identical behavior to
+    the original loader: missing/invalid file → ``{}``.
+    """
     fixture_path = strategies_dir / "backtest_fixtures.json"
     if not fixture_path.exists():
         return {}
     try:
-        return json.loads(fixture_path.read_text(encoding="utf-8"))
+        return _load_fixtures_from_path(fixture_path)
     except Exception as exc:
         logger.warning("could not load backtest_fixtures.json: %s", exc)
         return {}
+
+
+def _load_fixtures(strategies_dir: Path) -> dict[str, Any]:
+    """Load backtest fixtures, preferring a dynamic source over the bundle.
+
+    Resolution order (issue #465):
+      1. ``ARCHIMEDES_FIXTURES_PATH`` — a filesystem path override.
+      2. ``ARCHIMEDES_FIXTURES_URL`` — an http(s) source.
+      3. The bundled ``backtest_fixtures.json`` in ``strategies_dir``.
+
+    The dynamic source is *preferred* only when configured and it loads
+    successfully with non-empty content; otherwise the bundled file is used.
+    When neither env var is set the behavior is byte-identical to the original
+    loader, so served gate-sensitive metrics do not move.
+    """
+    dynamic = _load_dynamic_fixtures()
+    if dynamic is not None:
+        return dynamic
+    return _load_bundled_fixtures(strategies_dir)
 
 
 def _to_strategy(

--- a/backend/tests/services/test_strategy_provider.py
+++ b/backend/tests/services/test_strategy_provider.py
@@ -338,6 +338,134 @@ class TestLoadFixtures:
         assert result["test_strategy"]["sharpe_ratio"] == 0.85
 
 
+# ── _load_fixtures: dynamic source vs bundled fallback (issue #465) ──
+
+
+class TestDynamicFixtureLoading:
+    """Hermetic coverage of the env-configured dynamic fixture source.
+
+    No network: the URL branch is mocked at the ``httpx.get`` boundary per the
+    testing conventions (mock at boundaries, not internals).
+    """
+
+    def _bundled(self, tmp_path):
+        """Write a bundled fixture file marked so we can tell it apart."""
+        import json
+
+        (tmp_path / "backtest_fixtures.json").write_text(json.dumps({"bundled_strategy": {"sharpe_ratio": 0.1}}))
+
+    # (a) fallback used when no dynamic source is configured
+
+    def test_falls_back_to_bundled_when_nothing_configured(self, tmp_path, monkeypatch):
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_PATH", raising=False)
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_URL", raising=False)
+        self._bundled(tmp_path)
+
+        result = _load_fixtures(tmp_path)
+        assert result == {"bundled_strategy": {"sharpe_ratio": 0.1}}
+
+    def test_empty_when_nothing_configured_and_no_bundle(self, tmp_path, monkeypatch):
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_PATH", raising=False)
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_URL", raising=False)
+
+        assert _load_fixtures(tmp_path) == {}
+
+    # (b) dynamic source preferred when present — filesystem path override
+
+    def test_dynamic_path_preferred_over_bundle(self, tmp_path, monkeypatch):
+        import json
+
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        self._bundled(tmp_path)
+        dynamic_file = tmp_path / "dynamic_fixtures.json"
+        dynamic_file.write_text(json.dumps({"dynamic_strategy": {"sharpe_ratio": 0.99}}))
+        monkeypatch.setenv("ARCHIMEDES_FIXTURES_PATH", str(dynamic_file))
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_URL", raising=False)
+
+        result = _load_fixtures(tmp_path)
+        assert result == {"dynamic_strategy": {"sharpe_ratio": 0.99}}
+        assert "bundled_strategy" not in result
+
+    # (b) dynamic source preferred when present — URL override (mocked httpx)
+
+    def test_dynamic_url_preferred_over_bundle(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        self._bundled(tmp_path)
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_PATH", raising=False)
+        monkeypatch.setenv("ARCHIMEDES_FIXTURES_URL", "https://fixtures.example/backtest.json")
+
+        fake_resp = MagicMock()
+        fake_resp.text = '{"url_strategy": {"sharpe_ratio": 1.23}}'
+        fake_resp.raise_for_status = MagicMock()
+        with patch("httpx.get", return_value=fake_resp) as mock_get:
+            result = _load_fixtures(tmp_path)
+
+        mock_get.assert_called_once()
+        assert result == {"url_strategy": {"sharpe_ratio": 1.23}}
+        assert "bundled_strategy" not in result
+
+    # Resilience: a configured-but-failing dynamic source reverts to bundled
+
+    def test_dynamic_path_failure_falls_back_to_bundle(self, tmp_path, monkeypatch):
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        self._bundled(tmp_path)
+        monkeypatch.setenv("ARCHIMEDES_FIXTURES_PATH", str(tmp_path / "does_not_exist.json"))
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_URL", raising=False)
+
+        result = _load_fixtures(tmp_path)
+        assert result == {"bundled_strategy": {"sharpe_ratio": 0.1}}
+
+    def test_dynamic_url_failure_falls_back_to_bundle(self, tmp_path, monkeypatch):
+        from unittest.mock import patch
+
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        self._bundled(tmp_path)
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_PATH", raising=False)
+        monkeypatch.setenv("ARCHIMEDES_FIXTURES_URL", "https://fixtures.example/backtest.json")
+
+        with patch("httpx.get", side_effect=ConnectionError("network down")):
+            result = _load_fixtures(tmp_path)
+        assert result == {"bundled_strategy": {"sharpe_ratio": 0.1}}
+
+    def test_path_takes_precedence_over_url(self, tmp_path, monkeypatch):
+        import json
+        from unittest.mock import patch
+
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        dynamic_file = tmp_path / "dynamic_fixtures.json"
+        dynamic_file.write_text(json.dumps({"path_strategy": {"sharpe_ratio": 0.5}}))
+        monkeypatch.setenv("ARCHIMEDES_FIXTURES_PATH", str(dynamic_file))
+        monkeypatch.setenv("ARCHIMEDES_FIXTURES_URL", "https://fixtures.example/backtest.json")
+
+        # URL must never be consulted when the path source succeeds.
+        with patch("httpx.get", side_effect=AssertionError("URL should not be fetched")):
+            result = _load_fixtures(tmp_path)
+        assert result == {"path_strategy": {"sharpe_ratio": 0.5}}
+
+    def test_empty_dynamic_payload_falls_back_to_bundle(self, tmp_path, monkeypatch):
+        from archimedes.services.strategy_provider import _load_fixtures
+
+        self._bundled(tmp_path)
+        empty_file = tmp_path / "empty.json"
+        empty_file.write_text("   ")  # whitespace-only → no fixtures
+        monkeypatch.setenv("ARCHIMEDES_FIXTURES_PATH", str(empty_file))
+        monkeypatch.delenv("ARCHIMEDES_FIXTURES_URL", raising=False)
+
+        result = _load_fixtures(tmp_path)
+        assert result == {"bundled_strategy": {"sharpe_ratio": 0.1}}
+
+
 # ── default_provider resolution ─────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #465. `analytics-engine/strategies/backtest_fixtures.json` was loaded only from a single hardcoded path in the strategies directory (the source of the served DSR/PBO/passport metrics that feed rigor-gate criterion 4). This makes the loader resolve a **dynamic source first**, falling back to the bundled file — exactly the "dynamically loaded, with backup alternative" the issue asks for.

Resolution order in `_load_fixtures()` (`backend/archimedes/services/strategy_provider.py`):

1. **`ARCHIMEDES_FIXTURES_PATH`** — a filesystem path override.
2. **`ARCHIMEDES_FIXTURES_URL`** — an http(s) source. Uses a **lazy `httpx`** import, matching the existing `corpus_service` / `llm_backend` HTTP precedent (no new dependency, no import cost in the API process unless a URL source is configured).
3. **The bundled `backtest_fixtures.json`** in the strategies dir — the hardcoded fallback (and the historical default).

The dynamic source is *preferred* only when it is configured **and** loads non-empty content. Any failure (missing file, malformed JSON, non-object payload, network error) or an empty payload is non-fatal and reverts to the bundle — a transient remote outage must never take down the served strategy library.

## Gate-safety (the load-bearing property)

The scoping comment on #465 flagged this as gate-sensitive: a loader change that shifts served values could move gate verdicts. **When neither env var is set, behavior is byte-identical to the original loader** — it reads the same bundled `backtest_fixtures.json` with the same missing/invalid → `{}` semantics. Served gate-sensitive metrics do not move in the default (prod-today) configuration; the dynamic path only activates on explicit opt-in. The add-only law on the fixture corpus is untouched (this is a loader change only — no fixture content edited, no Generate/Library strategy-loading path changed).

## Tests

Hermetic `TestDynamicFixtureLoading` added to `backend/tests/services/test_strategy_provider.py` (8 cases, no network — the URL branch is mocked at the `httpx.get` boundary per the testing conventions):

- **(a) fallback when no dynamic source** — bundled used when unconfigured; `{}` when unconfigured and no bundle.
- **(b) dynamic source preferred when present** — path override preferred over bundle; URL override preferred over bundle (mocked `httpx.get`).
- Resilience — path failure → bundle, URL failure → bundle, empty payload → bundle, and path-takes-precedence-over-url.

## Verify

```bash
export PATH=/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin:$PATH
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_strategy_provider.py -q   # 41 passed
ruff format --check backend/archimedes/services/strategy_provider.py backend/tests/services/test_strategy_provider.py
ruff check --select E9,F63,F7,F40,F82 backend/archimedes/services/strategy_provider.py backend/tests/services/test_strategy_provider.py   # All checks passed
```

## Anti-goals

- No fixture content edited; no Generate/Library strategy-loading path changed.
- No new dependency (`httpx` already vendored and used in `services/`).
- No `.env.example` / `environment.yml` change required — the two new env vars are optional and default-absent.

> DO NOT MERGE — opening for review per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M