### PR TITLE
[deps] Remediate CVEs: urllib3/pypdf/tornado/starlette

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,8 +5,10 @@
 fastapi>=0.115
 # Pinned directly to close PYSEC-2026-161 (Host-header validation bypass);
 # FastAPI's transitive range can resolve to vulnerable starlette 1.0.0
-# without this floor.
-starlette>=1.0.1
+# without this floor. Floor raised to 1.3.1 to close CVE-2026-54282 /
+# CVE-2026-54283 (CVE bump 2026-06-25). FastAPI's requires-dist is
+# starlette>=0.46.0 with no upper bound, so this floor resolves cleanly.
+starlette>=1.3.1
 uvicorn[standard]>=0.49.0
 sqlalchemy>=2.0.51
 psycopg2-binary>=2.9.12
@@ -35,6 +37,10 @@ aiohttp>=3.14.1
 # services/llm_backend.py (OpenAI-compatible + Ollama backends). Pinned directly
 # so we don't rely on it arriving transitively via anthropic/fastapi.
 httpx>=0.28.1
+# urllib3 is transitive (requests / boto3 / arxiv). Pinned directly to close
+# PYSEC-2026-141 / PYSEC-2026-142 so a fresh resolve can't regress to a
+# vulnerable version (CVE bump 2026-06-25).
+urllib3>=2.7.0
 
 # Backtesting
 backtrader>=1.9.78.123
@@ -53,7 +59,8 @@ slowapi>=0.1.10
 
 # Paper ingestion
 arxiv>=2.1
-pypdf>=6.13.2
+# Floor raised to 6.13.3 to close 8 CVEs incl GHSA-jm82-fx9c-mx94 (CVE bump 2026-06-25).
+pypdf>=6.13.3
 
 # Semantic retrieval (optional — TF-IDF fallback when absent)
 # paper-qa>=0.70  # Apache 2.0, sentence-transformer embeddings

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - pip:
       # --- Web backend ---
       - fastapi>=0.115
-      - "starlette>=1.0.1"            # Pinned directly to close PYSEC-2026-161 (Host-header validation bypass); FastAPI's range can resolve to vulnerable 1.0.0 without this floor.
+      - "starlette>=1.3.1"            # Pinned directly to close PYSEC-2026-161 (Host-header validation bypass); FastAPI's range can resolve to vulnerable 1.0.0 without this floor. Floor raised to 1.3.1 to close CVE-2026-54282 / CVE-2026-54283 (CVE bump 2026-06-25); FastAPI's requires-dist is starlette>=0.46.0 with no upper bound, so this resolves cleanly.
       - "uvicorn[standard]>=0.49.0"
       - sqlalchemy>=2.0
       - psycopg2-binary>=2.9.12       # PostgreSQL driver (binary wheel; no system pq needed). Floor aligned with backend/requirements.txt via dependabot PR #247.
@@ -49,6 +49,7 @@ dependencies:
       - requests>=2.32,<2.34          # arxiv pins requests<2.34; keep aligned with backend/requirements.txt (Dependabot #702 broke the deploy 2026-06-25)
       - aiohttp>=3.14.1                # Bumped from 3.13.5 to close CVE-2026-34993 / CVE-2026-47265 (HTTP parser DoS/smuggling). Floor aligned with backend/requirements.txt.
       - httpx>=0.27                   # Directly imported by services/corpus_service.py (arXiv intake) and services/llm_backend.py (OpenAI-compatible + Ollama). Pinned so we don't rely on transitive resolution.
+      - urllib3>=2.7.0                # Transitive (requests / boto3 / arxiv). Pinned directly to close PYSEC-2026-141 / PYSEC-2026-142 so a fresh resolve can't regress (CVE bump 2026-06-25). Aligned with backend/requirements.txt.
 
       # --- Backtesting (per backtrader-vs-vectorbt decision memo) ---
       - backtrader>=1.9.78.123        # Decision: v1 default. See docs/specs/backtrader-vs-vectorbt-decision-memo.md. Floor aligned with backend/requirements.txt via dependabot PR #249.
@@ -71,7 +72,7 @@ dependencies:
 
       # --- Paper ingestion (Q-fin corpus) ---
       - arxiv>=2.1                    # arxiv API client
-      - pypdf>=6.13.2                 # PDF text extraction
+      - pypdf>=6.13.3                 # PDF text extraction. Floor raised to 6.13.3 to close 8 CVEs incl GHSA-jm82-fx9c-mx94 (CVE bump 2026-06-25). Aligned with backend/requirements.txt.
 
       # --- Quality + tests ---
       - ruff>=0.6                     # Linter + formatter; configured at line length 120
@@ -84,4 +85,4 @@ dependencies:
       # --- Dev convenience ---
       - ipython>=8.27
       - jupyter>=1.1                  # For exploratory strategy work
-      - tornado>=6.5.6                # Pinned directly to close CVE-2026-49854 (WebSocket frame-length overflow) in jupyter's transitive tornado dep. environment.yml-only: tornado is a dev/notebook dependency, not imported by backend runtime code (not in backend/requirements.txt).
+      - tornado>=6.5.7                # Pinned directly to close CVE-2026-49854 (WebSocket frame-length overflow) in jupyter's transitive tornado dep; floor raised to 6.5.7 (CVE bump 2026-06-25). environment.yml-only: tornado is a dev/notebook dependency, not imported by backend runtime code (not in backend/requirements.txt).


### PR DESCRIPTION
## Summary

Remediate four known CVEs by raising pinned dependency floors in **both**
`backend/requirements.txt` and `environment.yml` (kept aligned per the
hard repo rule). Existing explanatory comments are preserved; each bumped
line gets a `(CVE bump 2026-06-25)` note.

| Dep | Old floor | New floor | CVE(s) closed | File(s) |
| --- | --- | --- | --- | --- |
| `urllib3` | *(unpinned / transitive)* | `>=2.7.0` | PYSEC-2026-141 / PYSEC-2026-142 | both (new direct pin) |
| `pypdf` | `>=6.13.2` | `>=6.13.3` | 8 CVEs incl GHSA-jm82-fx9c-mx94 | both |
| `tornado` | `>=6.5.6` | `>=6.5.7` | CVE-2026-49854 (WebSocket frame-length overflow) | `environment.yml` only |
| `starlette` | `>=1.0.1` | `>=1.3.1` | CVE-2026-54282 / CVE-2026-54283 | both |

### Notes on the two judgment calls

**`urllib3` — added as a new direct pin.** It was not previously declared in
either file (purely transitive via `requests` / `boto3` / `arxiv`). Per the
repo's dependency-hygiene rule ("Pin transitively-vulnerable deps directly
when CVEs warrant it"), it's now pinned directly in both files so a fresh
resolve can't regress to a vulnerable version.

**`tornado` — `environment.yml` only, by design.** Tornado is a dev/notebook
(jupyter) transitive dep, not imported by backend runtime code, so it is
correctly **absent from `backend/requirements.txt`** — the bump applies only
to the existing direct pin in `environment.yml`. No new requirements.txt line.

**`starlette` — the FastAPI-coupled / risky bump. APPLIED, fully validated.**
The concern was whether FastAPI caps starlette below 1.3.1. It does **not**:
the latest FastAPI (0.138.1, which the `fastapi>=0.115` floor resolves to)
declares `starlette>=0.46.0` with **no upper bound**. So `starlette>=1.3.1`
co-resolves cleanly with FastAPI — no `ResolutionImpossible`, no coordinated
FastAPI bump required. Confirmed both by inspecting FastAPI's `requires_dist`
on PyPI and by an actual pip resolve (below).

## Validation (throwaway venv — shared `archimedes` conda env untouched)

A throwaway venv was created with the conda env's Python 3.12 interpreter
(creating a venv does not mutate the conda env); all installs went into
`/tmp/cve_venv`, never the shared env.

```text
# 1. Dry-run resolve of bumped backend/requirements.txt
$ /tmp/cve_venv/bin/pip install --dry-run -r backend/requirements.txt
exit 0 — "Would install ... starlette-1.3.1 ... fastapi-0.138.1 ...
          urllib3-2.7.0 ... pypdf-6.14.2 ..."
grep -iE 'ResolutionImpossible|conflict|incompatible|ERROR' → NO conflicts/errors

# 2. Real install into the isolated venv
$ /tmp/cve_venv/bin/pip install -r backend/requirements.txt   → exit 0
   starlette 1.3.1 · fastapi 0.138.1 · urllib3 2.7.0 · pypdf 6.14.2

# 3. Backend unit suite against the venv
$ PYTHONPATH=backend /tmp/cve_venv/bin/python -m pytest backend/tests \
      -m "not integration" -q
   ===== 1697 passed, 2 skipped, 63 warnings in 146.22s =====
   (the 2 skips are pre-existing load-bearing skips —
    "Requires chain_client.settings module-level init mocking" —
    not related to the bumps; warnings are pre-existing numeric edge-cases)

# 4. pip-audit on the resolved tree
$ /tmp/cve_venv/bin/pip-audit   → "No known vulnerabilities found"
   (none of urllib3 / pypdf / starlette / tornado flagged)
```

**Resolve result: clean (exit 0, no ResolutionImpossible / conflict).**
The full CI suite will additionally run on this PR.

## Anti-goals / scope

- Only the four CVE-driven floors changed; no other pins touched.
- `tornado` deliberately NOT added to `requirements.txt` (dev-only dep).
- No code changes — dependency manifests only.

---

Reviewer note: this is `[infra]`/deps-only and non-contract, so one approving
review suffices per repo convention. Flagging for **Dan** since `starlette`
is FastAPI-coupled — the validation above shows FastAPI imposes no upper
bound, so no coordinated FastAPI bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
