### PR TITLE
[chain] T2.3: externalize contract addresses + #506 slippage regression test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,8 +120,13 @@ REQUIRE_SIWE_FOR_GENERATION=false
 ORACLE_INTERVAL_SECONDS=60
 
 # ── Contract addresses (Arc testnet, Chain ID 5042002 / 0x4cef52) ─────────
-# (Chain ID aligned with README/CLAUDE; addresses unchanged — verify via
-# Chuan/contracts before relying on them.)
+# (Chain ID aligned with README/CLAUDE; verify with Dan/contracts before relying
+# on them — Dan owns the contracts + deploys them.)
+#
+# These bare (un-prefixed) names are consumed by the one-off e2e verifier
+# (backend/archimedes/scripts/verify_arc_e2e.py). They are NOT what the running
+# backend reads — the backend's ChainSettings reads the ARC_*-prefixed vars
+# below. Keep them in sync if you set both.
 PRICE_ORACLE_ADDRESS=0xe1c9f2b11be97097223a66a188fca541e07873a6
 SYNTHETIC_FACTORY_ADDRESS=
 AMM_ROUTER_ADDRESS=0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4
@@ -129,6 +134,46 @@ VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32
 REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6
 ASSET_REGISTRY_ADDRESS=0x2d44550711137916df6175587d17886281a0fbc7
 STRATEGY_REGISTRY_ADDRESS=0x728C264d0681b71c4Cc1D26a4fb14Ec29D9a90e4
+
+# ── Contract addresses the BACKEND reads (ChainSettings, env_prefix=ARC_) ──
+# Externalized contract addresses (roadmap T2.3). ChainSettings in
+# backend/archimedes/chain/client.py reads each address field from its
+# ARC_<FIELD> env var, falling back to the deployed Arc-testnet address baked
+# into the code as a default. So these are ALL OPTIONAL: leave them unset to use
+# the in-code defaults (the live Arc-testnet contracts); set one to repoint the
+# backend at a freshly-deployed contract WITHOUT a code change. The values shown
+# below are the current code defaults — uncomment + edit only the ones you need
+# to override. (deploy_contracts.py prints these exact ARC_*=... lines after a
+# deploy, ready to paste here.)
+#
+# Core contracts (note: ARC_AMM_ROUTER_ADDRESS etc. default to EMPTY in code and
+# MUST be supplied for that contract to be usable — the values below are the
+# live Arc-testnet deploys):
+# ARC_USDC_ADDRESS=0x3600000000000000000000000000000000000000
+# ARC_AMM_ROUTER_ADDRESS=0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4
+# ARC_SYNTHETIC_FACTORY_ADDRESS=
+# ARC_VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32
+# ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6
+# ARC_ASSET_REGISTRY_ADDRESS=0x2d44550711137916df6175587d17886281a0fbc7
+# ARC_STRATEGY_REGISTRY_ADDRESS=0x728C264d0681b71c4Cc1D26a4fb14Ec29D9a90e4
+#
+# Synthetic token addresses (defaults = deployed Arc-testnet contracts):
+# ARC_STSLA_ADDRESS=0xd514cd27baf762c650536765cde9b61c876abacd
+# ARC_SNVDA_ADDRESS=0x805e75019a1291a598dfc134ad2519121a35fb11
+# ARC_SSPY_ADDRESS=0x6fea38dedea0c6bb66ce93e5383c34385d8b889f
+# ARC_SBTC_ADDRESS=0x317e82be8f7cba6c162ab968fcf695d88e8e0359
+# ARC_SGOLD_ADDRESS=0xf384562c8bdafce52400eb6839f195695f6fa276
+# ARC_SOIL_ADDRESS=0x46cead4120f17a968ba1168f1a56563962cf3c4b
+# ARC_SNKY_ADDRESS=0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376
+#
+# Per-asset oracle addresses (defaults = deployed Arc-testnet contracts):
+# ARC_STSLA_ORACLE_ADDRESS=0xe1c9f2b11be97097223a66a188fca541e07873a6
+# ARC_SNVDA_ORACLE_ADDRESS=0xeb36acf88e739dd312de8278985262146a017374
+# ARC_SSPY_ORACLE_ADDRESS=0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52
+# ARC_SBTC_ORACLE_ADDRESS=0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8
+# ARC_SGOLD_ORACLE_ADDRESS=0x35fccde01ae8728c7a7cb83c3f59c701ebecc633
+# ARC_SOIL_ORACLE_ADDRESS=0x79f354524fd09af16d841a2221af2b2b7bc432c8
+# ARC_SNKY_ORACLE_ADDRESS=0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee
 
 # ── Backend service config ─────────────────────────────────────────────────
 BACKEND_HOST=0.0.0.0

--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -18,7 +18,28 @@ from web3.providers import AsyncHTTPProvider
 
 
 class ChainSettings(BaseSettings):
-    """On-chain connection settings — loaded from .env or environment variables."""
+    """On-chain connection settings — loaded from .env or environment variables.
+
+    **Contract addresses are externalized (roadmap T2.3).** Every address field
+    below is read from an environment variable, falling back to the value shown as
+    its default when the variable is unset — so nothing breaks if the env is
+    unset, while a redeploy can repoint the backend at new contracts without a
+    code change. Because ``env_prefix = "ARC_"``, the override variable for a
+    field is its name upper-cased with the ``ARC_`` prefix:
+
+    - ``usdc_address``      ← ``ARC_USDC_ADDRESS``
+    - ``amm_router_address`` ← ``ARC_AMM_ROUTER_ADDRESS``
+    - ``vault_factory_address`` ← ``ARC_VAULT_FACTORY_ADDRESS``
+    - ``stsla_address``     ← ``ARC_STSLA_ADDRESS``  (one per synth)
+    - ``stsla_oracle_address`` ← ``ARC_STSLA_ORACLE_ADDRESS``  (one per oracle)
+
+    The defaults match the deployed Arc-testnet contracts and the ``ARC_*=...``
+    lines emitted by ``backend/archimedes/scripts/deploy_contracts.py``; the full
+    set of override variables is documented in ``.env.example``. The public API
+    (field names plus the ``synth_addresses`` / ``oracle_addresses`` /
+    ``*_account`` properties) is unchanged — only the source-of-truth for each
+    address moved from "hardcoded constant" to "env var with hardcoded fallback".
+    """
 
     # RPC
     arc_rpc_url: str = "https://rpc.testnet.arc.network"
@@ -31,32 +52,37 @@ class ChainSettings(BaseSettings):
     # Owner account (for admin operations like oracle price updates)
     owner_private_key: str = ""
 
-    # Contract addresses — set these after deploying via Deploy.s.sol
-    usdc_address: str = "0x3600000000000000000000000000000000000000"
-    amm_router_address: str = ""
-    synthetic_factory_address: str = ""
-    vault_factory_address: str = ""
-    reasoning_trace_registry_address: str = ""
-    asset_registry_address: str = ""
-    strategy_registry_address: str = ""
+    # Contract addresses — env-overridable via ARC_<FIELD>; defaults = deployed
+    # Arc testnet contracts (Deploy.s.sol / deploy_contracts.py emits the
+    # ARC_*=... lines). Empty defaults mark deployment-specific addresses that
+    # must be supplied via .env before that contract can be used.
+    usdc_address: str = "0x3600000000000000000000000000000000000000"  # ARC_USDC_ADDRESS
+    amm_router_address: str = ""  # ARC_AMM_ROUTER_ADDRESS
+    synthetic_factory_address: str = ""  # ARC_SYNTHETIC_FACTORY_ADDRESS
+    vault_factory_address: str = ""  # ARC_VAULT_FACTORY_ADDRESS
+    reasoning_trace_registry_address: str = ""  # ARC_REASONING_TRACE_REGISTRY_ADDRESS
+    asset_registry_address: str = ""  # ARC_ASSET_REGISTRY_ADDRESS
+    strategy_registry_address: str = ""  # ARC_STRATEGY_REGISTRY_ADDRESS
 
-    # Individual synthetic token addresses (defaults = deployed Arc testnet contracts)
-    stsla_address: str = "0xd514cd27baf762c650536765cde9b61c876abacd"
-    snvda_address: str = "0x805e75019a1291a598dfc134ad2519121a35fb11"
-    sspy_address: str = "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f"
-    sbtc_address: str = "0x317e82be8f7cba6c162ab968fcf695d88e8e0359"
-    sgold_address: str = "0xf384562c8bdafce52400eb6839f195695f6fa276"
-    soil_address: str = "0x46cead4120f17a968ba1168f1a56563962cf3c4b"
-    snky_address: str = "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376"
+    # Individual synthetic token addresses — env-overridable via
+    # ARC_<SYMBOL>_ADDRESS; defaults = deployed Arc testnet contracts.
+    stsla_address: str = "0xd514cd27baf762c650536765cde9b61c876abacd"  # ARC_STSLA_ADDRESS
+    snvda_address: str = "0x805e75019a1291a598dfc134ad2519121a35fb11"  # ARC_SNVDA_ADDRESS
+    sspy_address: str = "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f"  # ARC_SSPY_ADDRESS
+    sbtc_address: str = "0x317e82be8f7cba6c162ab968fcf695d88e8e0359"  # ARC_SBTC_ADDRESS
+    sgold_address: str = "0xf384562c8bdafce52400eb6839f195695f6fa276"  # ARC_SGOLD_ADDRESS
+    soil_address: str = "0x46cead4120f17a968ba1168f1a56563962cf3c4b"  # ARC_SOIL_ADDRESS
+    snky_address: str = "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376"  # ARC_SNKY_ADDRESS
 
-    # Individual oracle addresses (defaults = deployed Arc testnet contracts)
-    stsla_oracle_address: str = "0xe1c9f2b11be97097223a66a188fca541e07873a6"
-    snvda_oracle_address: str = "0xeb36acf88e739dd312de8278985262146a017374"
-    sspy_oracle_address: str = "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52"
-    sbtc_oracle_address: str = "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8"
-    sgold_oracle_address: str = "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633"
-    soil_oracle_address: str = "0x79f354524fd09af16d841a2221af2b2b7bc432c8"
-    snky_oracle_address: str = "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee"
+    # Individual oracle addresses — env-overridable via
+    # ARC_<SYMBOL>_ORACLE_ADDRESS; defaults = deployed Arc testnet contracts.
+    stsla_oracle_address: str = "0xe1c9f2b11be97097223a66a188fca541e07873a6"  # ARC_STSLA_ORACLE_ADDRESS
+    snvda_oracle_address: str = "0xeb36acf88e739dd312de8278985262146a017374"  # ARC_SNVDA_ORACLE_ADDRESS
+    sspy_oracle_address: str = "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52"  # ARC_SSPY_ORACLE_ADDRESS
+    sbtc_oracle_address: str = "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8"  # ARC_SBTC_ORACLE_ADDRESS
+    sgold_oracle_address: str = "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633"  # ARC_SGOLD_ORACLE_ADDRESS
+    soil_oracle_address: str = "0x79f354524fd09af16d841a2221af2b2b7bc432c8"  # ARC_SOIL_ORACLE_ADDRESS
+    snky_oracle_address: str = "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee"  # ARC_SNKY_ORACLE_ADDRESS
 
     # Paths
     abi_dir: str = str(Path(__file__).resolve().parents[3] / "contracts" / "abis")

--- a/backend/tests/chain/test_chain_settings_addresses.py
+++ b/backend/tests/chain/test_chain_settings_addresses.py
@@ -1,0 +1,162 @@
+"""Externalized contract addresses (roadmap T2.3).
+
+ChainSettings reads every contract address from an ``ARC_<FIELD>`` environment
+variable, falling back to a hardcoded deployed-Arc-testnet default when the
+variable is unset. These tests pin both halves of that contract:
+
+  (a) when the env vars are UNSET, the in-code defaults are used (nothing breaks
+      on a fresh clone with no .env);
+  (b) when an env var IS set, the env value wins over the default.
+
+Hermetic: every ChainSettings is constructed with ``_env_file=None`` so no
+ambient ``.env`` on disk can leak in, and env vars are controlled via
+``monkeypatch`` (which it cleans up). No network, no Arc RPC, no .env dependence.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.chain.client import ChainSettings
+
+# The in-code default addresses, mirrored here so the test fails loudly if a
+# default is changed without the test being updated (a default change is a
+# deploy-address change — worth a deliberate test edit).
+EXPECTED_DEFAULTS = {
+    "usdc_address": "0x3600000000000000000000000000000000000000",
+    "stsla_address": "0xd514cd27baf762c650536765cde9b61c876abacd",
+    "snvda_address": "0x805e75019a1291a598dfc134ad2519121a35fb11",
+    "sspy_address": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
+    "sbtc_address": "0x317e82be8f7cba6c162ab968fcf695d88e8e0359",
+    "sgold_address": "0xf384562c8bdafce52400eb6839f195695f6fa276",
+    "soil_address": "0x46cead4120f17a968ba1168f1a56563962cf3c4b",
+    "snky_address": "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376",
+    "stsla_oracle_address": "0xe1c9f2b11be97097223a66a188fca541e07873a6",
+    "snvda_oracle_address": "0xeb36acf88e739dd312de8278985262146a017374",
+    "sspy_oracle_address": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
+    "sbtc_oracle_address": "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8",
+    "sgold_oracle_address": "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633",
+    "soil_oracle_address": "0x79f354524fd09af16d841a2221af2b2b7bc432c8",
+    "snky_oracle_address": "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee",
+}
+
+# Address fields whose in-code default is the empty string (deployment-specific —
+# must be supplied via .env before the contract can be used).
+EMPTY_DEFAULT_FIELDS = [
+    "amm_router_address",
+    "synthetic_factory_address",
+    "vault_factory_address",
+    "reasoning_trace_registry_address",
+    "asset_registry_address",
+    "strategy_registry_address",
+]
+
+# All ARC_*-prefixed env vars that ChainSettings reads, paired with the field
+# each one overrides. The env-var name is the field upper-cased with the ARC_
+# prefix (env_prefix="ARC_").
+ENV_VAR_FOR_FIELD = {
+    "usdc_address": "ARC_USDC_ADDRESS",
+    "amm_router_address": "ARC_AMM_ROUTER_ADDRESS",
+    "synthetic_factory_address": "ARC_SYNTHETIC_FACTORY_ADDRESS",
+    "vault_factory_address": "ARC_VAULT_FACTORY_ADDRESS",
+    "reasoning_trace_registry_address": "ARC_REASONING_TRACE_REGISTRY_ADDRESS",
+    "asset_registry_address": "ARC_ASSET_REGISTRY_ADDRESS",
+    "strategy_registry_address": "ARC_STRATEGY_REGISTRY_ADDRESS",
+    "stsla_address": "ARC_STSLA_ADDRESS",
+    "snvda_address": "ARC_SNVDA_ADDRESS",
+    "sspy_address": "ARC_SSPY_ADDRESS",
+    "sbtc_address": "ARC_SBTC_ADDRESS",
+    "sgold_address": "ARC_SGOLD_ADDRESS",
+    "soil_address": "ARC_SOIL_ADDRESS",
+    "snky_address": "ARC_SNKY_ADDRESS",
+    "stsla_oracle_address": "ARC_STSLA_ORACLE_ADDRESS",
+    "snvda_oracle_address": "ARC_SNVDA_ORACLE_ADDRESS",
+    "sspy_oracle_address": "ARC_SSPY_ORACLE_ADDRESS",
+    "sbtc_oracle_address": "ARC_SBTC_ORACLE_ADDRESS",
+    "sgold_oracle_address": "ARC_SGOLD_ORACLE_ADDRESS",
+    "soil_oracle_address": "ARC_SOIL_ORACLE_ADDRESS",
+    "snky_oracle_address": "ARC_SNKY_ORACLE_ADDRESS",
+}
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip every ARC_* var so a developer's shell can't leak into the test.
+
+    Combined with ``_env_file=None`` at construction, this guarantees the
+    "defaults when unset" assertions see a truly empty override surface.
+    """
+    for env_var in ENV_VAR_FOR_FIELD.values():
+        monkeypatch.delenv(env_var, raising=False)
+    return monkeypatch
+
+
+# ── (a) defaults are used when env is unset ───────────────────────────────────
+
+
+class TestDefaultsWhenEnvUnset:
+    def test_nonempty_defaults_match(self, clean_env):
+        """Each non-empty address field falls back to its hardcoded default."""
+        s = ChainSettings(_env_file=None)
+        for field, expected in EXPECTED_DEFAULTS.items():
+            assert getattr(s, field) == expected, f"{field} default mismatch"
+
+    def test_empty_default_fields_are_empty(self, clean_env):
+        """Deployment-specific fields default to the empty string when unset."""
+        s = ChainSettings(_env_file=None)
+        for field in EMPTY_DEFAULT_FIELDS:
+            assert getattr(s, field) == "", f"{field} should default to ''"
+
+    def test_synth_and_oracle_maps_use_defaults(self, clean_env):
+        """The public synth_addresses / oracle_addresses maps reflect defaults."""
+        s = ChainSettings(_env_file=None)
+        assert s.synth_addresses["sTSLA"] == EXPECTED_DEFAULTS["stsla_address"]
+        assert s.synth_addresses["sSPY"] == EXPECTED_DEFAULTS["sspy_address"]
+        assert s.oracle_addresses["sTSLA"] == EXPECTED_DEFAULTS["stsla_oracle_address"]
+        assert s.oracle_addresses["sNKY"] == EXPECTED_DEFAULTS["snky_oracle_address"]
+
+
+# ── (b) env overrides win when set ────────────────────────────────────────────
+
+
+class TestEnvOverrideWins:
+    def test_each_field_overridable(self, clean_env):
+        """Setting ARC_<FIELD> overrides that field's default, one at a time."""
+        # Distinct sentinel per field so a cross-wired mapping can't pass.
+        for i, (field, env_var) in enumerate(ENV_VAR_FOR_FIELD.items()):
+            sentinel = f"0x{i:040x}"
+            clean_env.setenv(env_var, sentinel)
+            s = ChainSettings(_env_file=None)
+            assert getattr(s, field) == sentinel, f"{env_var} did not override {field}"
+            clean_env.delenv(env_var, raising=False)
+
+    def test_override_flows_into_synth_map(self, clean_env):
+        """An ARC_STSLA_ADDRESS override is visible through synth_addresses."""
+        override = "0xAAAA000000000000000000000000000000000001"
+        clean_env.setenv("ARC_STSLA_ADDRESS", override)
+        s = ChainSettings(_env_file=None)
+        assert s.stsla_address == override
+        assert s.synth_addresses["sTSLA"] == override
+
+    def test_override_flows_into_oracle_map(self, clean_env):
+        """An ARC_SSPY_ORACLE_ADDRESS override is visible through oracle_addresses."""
+        override = "0xBBBB000000000000000000000000000000000002"
+        clean_env.setenv("ARC_SSPY_ORACLE_ADDRESS", override)
+        s = ChainSettings(_env_file=None)
+        assert s.sspy_oracle_address == override
+        assert s.oracle_addresses["sSPY"] == override
+
+    def test_empty_default_field_gets_value_from_env(self, clean_env):
+        """A field that defaults to '' picks up a real address from its env var."""
+        override = "0xCCCC000000000000000000000000000000000003"
+        clean_env.setenv("ARC_AMM_ROUTER_ADDRESS", override)
+        s = ChainSettings(_env_file=None)
+        assert s.amm_router_address == override
+
+    def test_unset_fields_keep_defaults_when_one_is_overridden(self, clean_env):
+        """Overriding one field must not disturb the others' defaults."""
+        clean_env.setenv("ARC_USDC_ADDRESS", "0xDDDD000000000000000000000000000000000004")
+        s = ChainSettings(_env_file=None)
+        assert s.usdc_address == "0xDDDD000000000000000000000000000000000004"
+        # Neighbours untouched.
+        assert s.stsla_address == EXPECTED_DEFAULTS["stsla_address"]
+        assert s.sspy_oracle_address == EXPECTED_DEFAULTS["sspy_oracle_address"]

--- a/backend/tests/chain/test_executor_slippage.py
+++ b/backend/tests/chain/test_executor_slippage.py
@@ -1,0 +1,195 @@
+"""Slippage-guard regression for the rebalance call path (issue #506).
+
+WHERE THE SLIPPAGE GUARD LIVES. For Archimedes' vault swaps, the non-zero
+``minAmountOut`` slippage floor is enforced ON-CHAIN, in ``Vault.sol``, not in
+this Python executor. ``Vault.rebalance`` and ``Vault._liquidateToUsdc`` both
+call ``ammRouter.swap(..., _oracleMinOut(...))``, where ``_oracleMinOut`` derives
+a strictly-positive floor from the on-chain oracle price minus the bounded
+``maxSlippageBps`` (default 100 bps, hard-capped at 500 bps), and REVERTS
+(``OracleNotSet`` / ``InvalidOraclePrice``) rather than falling back to
+``minAmountOut = 0`` when it can't price the leg. This placement is deliberate
+(Vault.sol audit note, 2026-06-14): the agent must NOT be able to set the
+slippage floor, or a compromised agent could pass ``minAmountOut ≈ 0`` and leak
+vault value. The Solidity tests for this floor live in
+``contracts/test/Vault.t.sol`` ("Swap Slippage Protection (issue #506)").
+
+WHAT THIS PYTHON TEST GUARDS. The executor's job is therefore to route every
+rebalance through the contract method that applies that on-chain floor — i.e.
+``rebalance(address[],uint256[],address[],uint256[])`` — and to never introduce a
+Python-side swap path that submits a caller-supplied ``minAmountOut`` of 0/None
+(which would bypass the contract's oracle floor). These tests pin that contract:
+
+  - the Circle path submits exactly the no-min ``rebalance(...)`` ABI signature
+    (the contract derives the floor itself); it does not pass a 0 min;
+  - the raw-key path builds the same ``vault.functions.rebalance(...)`` call;
+  - neither path references the AMMRouter.swap(min) primitive directly with a
+    zero/None min — the executor only ever talks to the vault, which owns the
+    floor.
+
+Hermetic: all chain/contract calls mocked. No network, no Arc RPC, no Circle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+from archimedes.chain.executor import ChainExecutor
+from archimedes.models.portfolio import TradeDirection, TradeOrder
+from hexbytes import HexBytes
+
+# The rebalance ABI signature that delegates the slippage floor to the vault's
+# on-chain _oracleMinOut. There is intentionally NO minAmountOut argument here —
+# the vault computes it. A regression that added a Python-supplied min would
+# change this signature.
+REBALANCE_ABI_SIG = "rebalance(address[],uint256[],address[],uint256[])"
+
+USDC = "0x3600000000000000000000000000000000000000"
+SYNTH = "0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388"  # sTSLA-style synth
+
+
+# ── Fixtures (mirror test_chain_executor.py shapes) ───────────────────────────
+
+
+@pytest.fixture
+def mock_loader():
+    loader = MagicMock()
+    mock_router = MagicMock()
+    type(loader).amm_router = PropertyMock(return_value=mock_router)
+    loader.amm_pool.return_value = MagicMock()
+    loader.vault.return_value = MagicMock()
+    loader.oracle_for.return_value = MagicMock()
+    loader.usdc.return_value = MagicMock()
+    return loader
+
+
+@pytest.fixture
+def executor(mock_loader):
+    """ChainExecutor with mocked loader + chain_client."""
+
+    class _Awaitable:
+        def __init__(self, value):
+            self._value = value
+
+        def __await__(self):
+            async def _coro():
+                return self._value
+
+            return _coro().__await__()
+
+    with patch("archimedes.chain.executor.chain_client") as mock_cc:
+        mock_cc.settings = MagicMock()
+        mock_cc.settings.usdc_address = USDC
+        mock_cc.settings.synth_addresses = {"sTSLA": SYNTH}
+        mock_cc.settings.oracle_addresses = {"sTSLA": "0xe1c9f2b11be97097223a66a188fca541e07873a6"}
+        mock_cc.settings.chain_id = 5042002
+        mock_cc.settings.agent_account = None
+        mock_cc.to_checksum = lambda addr: addr
+        mock_cc.w3 = MagicMock()
+        mock_cc.w3.eth = MagicMock()
+        mock_cc.w3.eth.gas_price = _Awaitable(1_000_000_000)
+        mock_cc.w3.eth.get_transaction_count = AsyncMock(return_value=1)
+        mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=HexBytes(b"\x00" * 32))
+        mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value={"status": 1})
+
+        ex = ChainExecutor(loader=mock_loader)
+        ex._mock_cc = mock_cc
+        yield ex
+
+
+def _buy(symbol="sTSLA", token_address=SYNTH, amount=10.0):
+    return TradeOrder(
+        symbol=symbol,
+        direction=TradeDirection.BUY,
+        amount=amount,
+        token_address=token_address,
+        estimated_usdc_value=amount,
+    )
+
+
+# ── #506: Circle path routes through the on-chain-floor rebalance signature ───
+
+
+class TestCircleRebalanceUsesOracleFloorSignature:
+    def test_circle_submits_no_min_rebalance_signature(self, executor):
+        """The Circle path submits the rebalance ABI that delegates the slippage
+        floor to the vault (no Python-supplied minAmountOut)."""
+        trade = _buy()
+        with (
+            patch.object(executor, "_validate_trade_liquidity", new=AsyncMock()),
+            patch.object(executor, "_confirm_receipt", new=AsyncMock(return_value="0xtx")),
+            patch("archimedes.chain.executor.circle_signer") as mock_signer,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xtx")
+
+            asyncio.run(executor.execute_trades("0xvault", [trade]))
+
+            mock_signer.execute_contract.assert_called_once()
+            _, kwargs = mock_signer.execute_contract.call_args
+            # The exact rebalance signature — the vault, not the executor, owns
+            # the slippage floor. If a refactor adds a Python-side min, this
+            # signature (and thus the abi_params arity) changes and the test trips.
+            assert kwargs["abi_function"] == REBALANCE_ABI_SIG
+            # rebalance takes exactly 4 params: tokensIn, amountsIn, tokensOut,
+            # amountsOut. No 5th "minAmountOut" array is smuggled in.
+            assert len(kwargs["abi_params"]) == 4
+
+    def test_circle_does_not_call_router_swap_directly(self, executor, mock_loader):
+        """The executor never invokes AMMRouter.swap(min) itself — that primitive
+        (and its min argument) is only ever reached via the vault's rebalance,
+        which supplies the oracle-derived non-zero floor."""
+        trade = _buy()
+        with (
+            patch.object(executor, "_validate_trade_liquidity", new=AsyncMock()),
+            patch.object(executor, "_confirm_receipt", new=AsyncMock(return_value="0xtx")),
+            patch("archimedes.chain.executor.circle_signer") as mock_signer,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xtx")
+
+            asyncio.run(executor.execute_trades("0xvault", [trade]))
+
+            # No direct router.swap(...) call with a Python-chosen (possibly zero) min.
+            mock_loader.amm_router.functions.swap.assert_not_called()
+
+
+# ── #506: raw-key path routes through the same vault.rebalance(...) ────────────
+
+
+class TestRawKeyRebalanceUsesOracleFloorSignature:
+    def test_raw_key_builds_vault_rebalance(self, executor, mock_loader):
+        """The raw-private-key path builds vault.functions.rebalance(...), the
+        same on-chain-floor entrypoint as the Circle path — no AMMRouter.swap
+        with a zero/None min on the Python side."""
+        trade = _buy()
+
+        # Give the executor a usable raw agent account.
+        account = MagicMock()
+        account.address = "0x000000000000000000000000000000000000dEaD"
+        account.sign_transaction.return_value = MagicMock(raw_transaction=b"\x01" * 32)
+        executor._mock_cc.settings.agent_account = account
+
+        vault = mock_loader.vault.return_value
+        vault.functions.rebalance.return_value.build_transaction = AsyncMock(
+            return_value={"from": account.address, "nonce": 1, "gas": 2_000_000}
+        )
+
+        with (
+            patch.object(executor, "_validate_trade_liquidity", new=AsyncMock()),
+            patch.object(executor, "_confirm_receipt", new=AsyncMock(return_value="0xtx")),
+            patch("archimedes.chain.executor.circle_signer") as mock_signer,
+        ):
+            mock_signer.is_configured = False
+
+            asyncio.run(executor.execute_trades("0xvault", [trade]))
+
+            # rebalance(...) was the entrypoint (positional 4-arg form: tokensIn,
+            # amountsIn, tokensOut, amountsOut). The vault derives the slippage
+            # floor; the executor passes no min.
+            vault.functions.rebalance.assert_called_once()
+            pos_args, _ = vault.functions.rebalance.call_args
+            assert len(pos_args) == 4
+            # And the executor did not bypass the vault by calling router.swap.
+            mock_loader.amm_router.functions.swap.assert_not_called()


### PR DESCRIPTION
## Summary

**T2.3 — externalize contract addresses out of `client.py`** (roadmap mitigation for the single-human contract-ownership bus factor) **+ verify #506 slippage and add a regression test.**

> ⚠️ **Funds-adjacent — needs Dan's review + Bogdan two-eyes.** This touches on-chain config (`backend/archimedes/chain/`) and the `.env.example` env contract. No funds logic was changed.

### Part 1 — Externalize contract addresses

`ChainSettings` (pydantic-settings, `env_prefix="ARC_"`) **already** reads every address field from its `ARC_<FIELD>` env var, with the deployed Arc-testnet address as the fallback default — so the "hardcoded" addresses were really pydantic defaults that env vars override. This PR makes that contract **explicit and documented** rather than implicit, and surfaces the override vars in `.env.example`:

- **`backend/archimedes/chain/client.py`** — documents the env-override-with-hardcoded-fallback model on the `ChainSettings` docstring and per-field `# ARC_*` annotations. **Values and the public API are unchanged**: field names, the `synth_addresses` / `oracle_addresses` / `agent_account` / `owner_account` properties, and the `chain_client` / `get_chain_client()` singleton all behave identically (smoke-tested). Only the source-of-truth framing moved from "hardcoded constant" → "env var with hardcoded fallback."
- **`.env.example`** — adds the full set of `ARC_*`-prefixed contract-address override vars (all commented/optional, with the current defaults shown). Clarifies that the **running backend** reads these `ARC_*` vars, distinct from the bare-named `*_ADDRESS` vars that are consumed only by the one-off `verify_arc_e2e.py` script (left in place, now labelled).

### Part 2 — #506 slippage verification + regression test

**Finding: the non-zero `minAmountOut` slippage guard is already enforced — on-chain, in `Vault.sol`, which is the correct place.** Both swap paths pass a strictly-positive, oracle-derived floor:

- `Vault.rebalance` (`contracts/src/Vault.sol:341,362`) and `Vault._liquidateToUsdc` (`:588`) call `ammRouter.swap(..., _oracleMinOut(...))`.
- `_oracleMinOut` (`:519–536`) computes `minAmountOut = expectedOut * (BPS - maxSlippageBps) / BPS` from the on-chain oracle price (`maxSlippageBps` default 100 bps, hard-capped at `MAX_SLIPPAGE_CAP_BPS = 500`). It **reverts** (`OracleNotSet` / `InvalidOraclePrice`) rather than falling back to `minAmountOut = 0` when it can't price a leg, and `PriceOracle.getPrice()` itself reverts on stale prices.
- This placement is deliberate (Vault.sol audit note, 2026-06-14): **the agent must not be able to set the slippage floor**, or a compromised agent could pass `minAmountOut ≈ 0` and leak vault value. Existing Solidity coverage lives in `contracts/test/Vault.t.sol` ("Swap Slippage Protection (issue #506)").

The Python `ChainExecutor` therefore correctly passes **no** `minAmountOut` — it routes every rebalance through `rebalance(address[],uint256[],address[],uint256[])`, the vault entrypoint that applies the on-chain floor. **No path passes a Python-supplied `0`/`None` min.** New regression test added (per the task's "if a non-zero min is already enforced, add a regression test"):

- **`backend/tests/chain/test_executor_slippage.py`** (new, hermetic) — asserts the executor submits the no-min `rebalance(...)` signature (exactly 4 ABI params) on both the Circle and raw-key paths, and never calls `AMMRouter.swap(min)` directly. This guards against a future refactor that introduces a 0/None-min swap path that would bypass the vault's oracle floor.

### Tests added

- **`backend/tests/chain/test_chain_settings_addresses.py`** (new, hermetic) — pins both halves of the externalization contract: **(a)** defaults are used when env unset; **(b)** `ARC_<FIELD>` overrides win when set, flowing through to the `synth_addresses` / `oracle_addresses` maps. Uses `_env_file=None` + `monkeypatch` so it stays hermetic regardless of any ambient `.env`.

## Verify

```bash
export PATH=/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin:$PATH
ruff format --check .
ruff check --select E9,F63,F7,F40,F82 .
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/chain -q
```

Results on this branch: `ruff format` → 326 files already formatted; `ruff check` (E9,F63,F7,F40,F82) → all checks passed; `pytest backend/tests/chain` → **70 passed, 0 failed** (11 new). Public-API smoke test confirms `chain_client` singleton + settings properties unchanged.

## Anti-goals (held)

- Did **not** change any address values, the public API, or any funds/swap logic.
- Did **not** modify any Solidity contract.
- Did **not** alter `pytest.ini`, CI config, or weaken any threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
