### PR TITLE
[strategy] T2.5 — return-source classification on the passport

### DIFF
--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -215,6 +215,12 @@ class StrategyResponse(BaseModel):
     # Regime suitability
     regime_tag: str = "regime_neutral"  # "bull" | "bear" | "regime_neutral"
 
+    # Return-source classification (T2.5) — the dominant economic source of the
+    # strategy's return, plus a one-sentence durability note. Computed by the
+    # deterministic heuristic in services/return_source_classifier.py.
+    return_source: str = "noise"  # "risk_premium" | "mispricing" | "productive_growth" | "noise"
+    return_source_note: str = ""
+
 
 class StrategyListResponse(BaseModel):
     strategies: list[StrategyResponse]

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -47,9 +47,11 @@ strategies_router = APIRouter(prefix="/api/strategies", tags=["strategies"])
 def _to_strategy_response(s: Strategy) -> StrategyResponse:
     """Map StrategyPassport + persisted BacktestResult to API schema."""
     from archimedes.api.schemas import PaperRefResponse
+    from archimedes.services.return_source_classifier import classify_strategy
 
     bt = strategy_provider.get_backtest_result(s.id)
     has_real = s.real_sharpe is not None
+    return_source, return_source_note = classify_strategy(s)
 
     # Build papers list from passport
     papers_list = [
@@ -117,6 +119,8 @@ def _to_strategy_response(s: Strategy) -> StrategyResponse:
             else (bt.backtest_end.isoformat() if bt and bt.backtest_end else None)
         ),
         regime_tag=s.regime_tag,
+        return_source=return_source,
+        return_source_note=return_source_note,
     )
 
 
@@ -1090,6 +1094,10 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
     strategies still flow through LocalStrategyProvider above; this is the
     fallback that makes generated strategies clickable from Library."""
     from archimedes.api.schemas import PaperRefResponse
+    from archimedes.services.return_source_classifier import (
+        StrategyView,
+        classify_return_source,
+    )
 
     refs = list(record.paper_refs or [])
     first = refs[0] if refs else None
@@ -1109,6 +1117,17 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
     ]
 
     asset_universe = json.loads(record.asset_universe) if record.asset_universe else []
+
+    return_source_enum, return_source_note = classify_return_source(
+        StrategyView(
+            paper_title=(first.title if first else "") or "",
+            methodology_summary=record.methodology_summary or "",
+            asset_universe=tuple(asset_universe),
+            deflated_sharpe_ratio=record.deflated_sharpe_ratio,
+            dsr_p_value=record.dsr_p_value,
+            passes_rigor_gate=bool(record.passes_rigor_gate),
+        )
+    )
 
     return StrategyResponse(
         id=record.id,
@@ -1152,6 +1171,8 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
         backtest_start=record.backtest_start,
         backtest_end=record.backtest_end,
         regime_tag=record.regime_tag,
+        return_source=return_source_enum.value,
+        return_source_note=return_source_note,
     )
 
 

--- a/backend/archimedes/services/return_source_classifier.py
+++ b/backend/archimedes/services/return_source_classifier.py
@@ -1,0 +1,284 @@
+"""Return-source classification — label each strategy by its dominant
+economic return source (T2.5).
+
+The rigor gate (DSR/PBO/OOS) tells you *whether* a strategy's edge survives
+multiple-testing correction. It does **not** tell you *why* the edge exists.
+This module answers the "why" with an honest, deterministic heuristic: every
+validated strategy is tagged with one of four return sources, plus a short
+durability note the passport renders next to the rigor metrics.
+
+The four return sources (most-durable to least):
+
+- ``risk_premium``     — compensated, persistent exposure to a priced risk factor
+                         (time-series/cross-sectional momentum, carry, value,
+                         volatility-managed). Survives because bearing the risk is
+                         unpleasant; the premium is the payment for holding it.
+- ``mispricing``       — a relative-value / arbitrage edge that exists because a
+                         price relationship is temporarily wrong (pairs, stat-arb,
+                         cointegration, single-name relative-value). Durable only
+                         while the inefficiency and the capital to exploit it persist.
+- ``productive_growth``— broad-market / index beta: the return of owning productive
+                         enterprise (buy-and-hold, SPY/index, tactical asset
+                         allocation across broad sleeves). The most fundamental and
+                         durable source — it is the economy compounding.
+- ``noise``            — no identifiable economic source; the backtest edge is most
+                         likely overfit / data-mined. Assigned when the rigor gate
+                         is failed with a weak/insignificant Deflated Sharpe, OR when
+                         nothing in the methodology maps to a real source.
+
+Design rules (kept honest + simple, per T2.5):
+
+1. **Deterministic.** Pure function of fields already on the passport
+   (paper title, methodology summary, asset universe, DSR / rigor signals).
+   No LLM call, no randomness, no network.
+2. **Rigor overrides taxonomy.** A strategy that failed the rigor gate with a
+   statistically *insignificant* DSR is labelled ``noise`` regardless of how its
+   methodology reads — an uncompensated, overfit edge has no durable source even
+   if it is "momentum-shaped." Strategies that simply have *no backtest yet*
+   (DSR unknown) keep their taxonomy label; we don't punish "not yet measured."
+3. **Keyword mapping is explicit and auditable.** The mapping below is the
+   contract; it lives in ``_SOURCE_KEYWORDS`` so a reviewer can read it in one place.
+
+The classifier reads a small structural view of a strategy rather than the
+``StrategyPassport`` dataclass directly, so it can be exercised hermetically in
+unit tests without constructing a full passport.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = [
+    "ReturnSource",
+    "StrategyView",
+    "classify_return_source",
+    "classify_strategy",
+]
+
+
+class ReturnSource(str, Enum):
+    """Dominant economic source of a strategy's return."""
+
+    RISK_PREMIUM = "risk_premium"
+    MISPRICING = "mispricing"
+    PRODUCTIVE_GROWTH = "productive_growth"
+    NOISE = "noise"
+
+
+@dataclass(frozen=True)
+class StrategyView:
+    """Minimal structural view of a strategy for classification.
+
+    Built from the fields already present on every ``StrategyPassport`` /
+    ``StrategyPassportRecord`` so the classifier never needs the full object.
+    """
+
+    paper_title: str = ""
+    methodology_summary: str = ""
+    asset_universe: tuple[str, ...] = ()
+    deflated_sharpe_ratio: float | None = None
+    dsr_p_value: float | None = None
+    passes_rigor_gate: bool = False
+
+
+# ── Keyword → return source mapping (the auditable contract) ──────────────
+#
+# Each (source, keywords) pair below is matched against the lowercased
+# concatenation of paper title + methodology summary. Order matters: the
+# first source whose keyword set hits wins, so the list is ordered from the
+# most specific / strongest signal (single-name arbitrage) to the broadest
+# (productive growth). The economic rationale for each mapping:
+#
+#   risk_premium      — momentum (TSMOM / cross-sectional), carry, value,
+#                       volatility-managed, trend, seasonality-as-risk: all are
+#                       compensated factor exposures documented in the asset-
+#                       pricing literature.
+#   mispricing        — pairs / stat-arb / cointegration / mean-reversion /
+#                       relative-value: a temporary price error, not a premium.
+#   productive_growth — buy-and-hold, index, tactical asset allocation, broad
+#                       equity beta: owning the productive economy.
+#
+# A strategy with no keyword hit and no rigor evidence falls through to noise.
+_SOURCE_KEYWORDS: tuple[tuple[ReturnSource, tuple[str, ...]], ...] = (
+    (
+        ReturnSource.MISPRICING,
+        (
+            "pairs",
+            "stat-arb",
+            "statistical arbitrage",
+            "arbitrage",
+            "cointegration",
+            "co-integration",
+            "relative-value",
+            "relative value",
+            "mean-reversion",
+            "mean reversion",
+            "kalman",
+            "rsi-2",
+            "bollinger",
+            # NOTE: "spread" is deliberately NOT a keyword — long/short *factor*
+            # portfolios also "earn a spread" (e.g. Betting Against Beta), so it
+            # produced false-positive mispricing labels on risk-premium factors.
+        ),
+    ),
+    (
+        ReturnSource.RISK_PREMIUM,
+        (
+            "momentum",
+            "tsmom",
+            "time series momentum",
+            "time-series momentum",
+            "carry",
+            "value",
+            "volatility-managed",
+            "volatility managed",
+            "vol-managed",
+            "trend",
+            "trend-following",
+            "trend following",
+            "seasonal",
+            "monthly effect",
+            "risk premi",  # "risk premium" / "risk premia"
+            # Established cross-sectional factor premia — each is a documented,
+            # compensated risk exposure in the asset-pricing literature.
+            "quality",  # Quality-minus-Junk (Asness et al.)
+            "dividend",  # dividend-yield tilt (matches "dividend yield")
+            "betting against beta",
+            "low-beta",
+            "low beta",
+            "factor",
+        ),
+    ),
+    (
+        ReturnSource.PRODUCTIVE_GROWTH,
+        (
+            "buy-and-hold",
+            "buy and hold",
+            "buy & hold",
+            "index",
+            "tactical asset allocation",
+            "asset allocation",
+            "moving average",
+            "200-day",
+            "sma200",
+            "broad market",
+        ),
+    ),
+)
+
+# Broad-market tickers — when the entire universe is broad index/treasury
+# exposure and nothing more specific matched, the source is productive growth.
+_BROAD_MARKET_TICKERS = frozenset({"SPY", "VOO", "VTI", "QQQ", "IWM", "DIA", "NIKKEI", "TREASURY", "BIL", "AGG", "TLT"})
+
+
+# Durability notes — one honest sentence per source. Rendered on the passport.
+_DURABILITY_NOTES: dict[ReturnSource, str] = {
+    ReturnSource.RISK_PREMIUM: (
+        "Compensated exposure to a priced risk factor — durable while the factor "
+        "stays unpleasant enough that the premium persists."
+    ),
+    ReturnSource.MISPRICING: (
+        "Relative-value edge from a temporary price error — durable only while the "
+        "inefficiency and the capital to arbitrage it persist; decays as it crowds."
+    ),
+    ReturnSource.PRODUCTIVE_GROWTH: (
+        "Broad-market beta — the return of owning the productive economy. The most "
+        "fundamental and durable source, but undifferentiated from passive holding."
+    ),
+    ReturnSource.NOISE: (
+        "No identifiable economic source; the backtest edge is most likely overfit "
+        "or data-mined. Treat any apparent alpha as fragile."
+    ),
+}
+
+# Stronger note when the rigor evidence *confirms* the no-source verdict: the
+# strategy both lacks an economic explanation AND failed the rigor gate with an
+# insignificant Deflated Sharpe. This is the clearest "data-mined" case.
+_NOISE_NOTE_RIGOR_CONFIRMED = (
+    "No identifiable economic source, and the edge failed the rigor gate with a "
+    "statistically insignificant Deflated Sharpe — the backtest result is most "
+    "likely data-mined. Do not deploy on the strength of the backtest alone."
+)
+
+
+def _rigor_says_noise(view: StrategyView) -> bool:
+    """True when the rigor evidence affirmatively marks the edge as noise.
+
+    A failed rigor gate *with a statistically insignificant* Deflated Sharpe is
+    the honest signal of an uncompensated / overfit edge. We require BOTH a
+    failed gate AND an insignificant DSR (p >= 0.05) so that a strategy which is
+    simply unevaluated (DSR unknown) is never mislabelled noise.
+
+    NOTE: this is applied only as a *tie-breaker* for strategies whose
+    methodology maps to no known economic source (see ``classify_return_source``).
+    A momentum strategy that fails the gate keeps its ``risk_premium`` source —
+    its return source is still a risk premium; that it doesn't survive rigor is
+    communicated separately by the rigor verdict. We don't double-punish an
+    explained edge by also stripping its (honest) source label.
+    """
+    if view.passes_rigor_gate:
+        return False
+    if view.dsr_p_value is None:
+        return False
+    return view.dsr_p_value >= 0.05
+
+
+def _taxonomy_source(view: StrategyView) -> ReturnSource | None:
+    """Return the keyword/universe-derived source, or None if nothing matched."""
+    haystack = f"{view.paper_title} {view.methodology_summary}".lower()
+    for source, keywords in _SOURCE_KEYWORDS:
+        if any(kw in haystack for kw in keywords):
+            return source
+
+    # Universe fallback: a purely broad-market universe with no specific
+    # methodology keyword is productive-growth beta (e.g. an index baseline).
+    universe = {t.upper() for t in view.asset_universe}
+    if universe and universe <= _BROAD_MARKET_TICKERS:
+        return ReturnSource.PRODUCTIVE_GROWTH
+
+    return None
+
+
+def classify_return_source(view: StrategyView) -> tuple[ReturnSource, str]:
+    """Classify a strategy's dominant return source.
+
+    Returns ``(ReturnSource, durability_note)``. Deterministic and side-effect
+    free — pure function of the fields on ``view``.
+
+    Precedence:
+      1. Methodology taxonomy (keyword mapping, then broad-market universe).
+         An explained edge keeps its source label regardless of rigor.
+      2. If taxonomy found NO source, fall back: a failed gate with an
+         insignificant DSR is affirmatively ``noise`` (overfit, no source);
+         anything else is ``noise`` too (nothing mapped to a real source).
+    """
+    source = _taxonomy_source(view)
+    if source is not None:
+        return source, _DURABILITY_NOTES[source]
+
+    # No economic source in the methodology → noise. The rigor signal doesn't
+    # change the label (both branches are noise) but it strengthens the note:
+    # an unmapped edge that *also* failed the gate on an insignificant DSR is the
+    # clearest data-mined case.
+    note = _NOISE_NOTE_RIGOR_CONFIRMED if _rigor_says_noise(view) else _DURABILITY_NOTES[ReturnSource.NOISE]
+    return ReturnSource.NOISE, note
+
+
+def classify_strategy(strategy) -> tuple[str, str]:
+    """Convenience adapter: classify a ``StrategyPassport`` / passport-like object.
+
+    Accepts anything exposing ``paper_title``, ``methodology_summary``,
+    ``asset_universe`` and the rigor fields. Returns ``(return_source_value,
+    durability_note)`` as plain strings for direct assignment onto API schemas.
+    """
+    view = StrategyView(
+        paper_title=getattr(strategy, "paper_title", "") or "",
+        methodology_summary=getattr(strategy, "methodology_summary", "") or "",
+        asset_universe=tuple(getattr(strategy, "asset_universe", ()) or ()),
+        deflated_sharpe_ratio=getattr(strategy, "deflated_sharpe_ratio", None),
+        dsr_p_value=getattr(strategy, "dsr_p_value", None),
+        passes_rigor_gate=bool(getattr(strategy, "passes_rigor_gate", False)),
+    )
+    source, note = classify_return_source(view)
+    return source.value, note

--- a/backend/tests/services/test_return_source_classifier.py
+++ b/backend/tests/services/test_return_source_classifier.py
@@ -1,0 +1,214 @@
+"""Hermetic unit tests for return_source_classifier (T2.5).
+
+No network, no Redis, no DB — pure function of strategy fields. Covers the
+keyword mapping for each return source, the rigor-override → noise rule, the
+broad-market universe fallback, and that the classification serializes onto the
+StrategyResponse passport schema.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.api.schemas import StrategyResponse
+from archimedes.services.return_source_classifier import (
+    ReturnSource,
+    StrategyView,
+    classify_return_source,
+    classify_strategy,
+)
+
+# ── Keyword mapping: risk_premium ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "title,methodology",
+    [
+        ("Time Series Momentum", ""),
+        ("Value and Momentum Everywhere", ""),
+        ("Volatility-Managed Portfolios", ""),
+        ("Carry", ""),
+        ("A Monthly Effect in Stock Returns", ""),
+        # An opaque title whose risk-premium nature lives in the methodology
+        # (a trend-following signal). The classifier reads title + methodology.
+        ("Simple Technical Trading Rules", "Trend-following filter on cross-sectional return."),
+    ],
+)
+def test_risk_premium_strategies(title, methodology):
+    src, note = classify_return_source(StrategyView(paper_title=title, methodology_summary=methodology))
+    assert src is ReturnSource.RISK_PREMIUM, f"{title!r} should map to risk_premium"
+    assert note  # durability note is non-empty
+
+
+def test_opaque_title_with_no_keyword_is_noise_not_guessed():
+    # The classifier must NOT hallucinate a source from an opaque title that
+    # carries no economic keyword — honest "noise" beats a fabricated label.
+    src, _ = classify_return_source(
+        StrategyView(paper_title="Simple Technical Trading Rules and the Stochastic Properties of Stock Returns")
+    )
+    assert src is ReturnSource.NOISE
+
+
+# ── Keyword mapping: mispricing ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Pairs Trading: Performance of a Relative-Value Arbitrage Rule",
+        "Co-integration and Error Correction",
+        "Statistical Arbitrage in the US Equities Market",
+        "Pairs Trading",  # Elliott Kalman
+        "RSI-2 Mean-Reversion",
+        "Bollinger Band Reversal",
+    ],
+)
+def test_mispricing_strategies(title):
+    src, _ = classify_return_source(StrategyView(paper_title=title))
+    assert src is ReturnSource.MISPRICING, f"{title!r} should map to mispricing"
+
+
+def test_mispricing_wins_over_risk_premium_on_overlap():
+    # "Time Series Momentum" pairs strategy → arbitrage keyword is more specific
+    # and is checked first, so mispricing wins.
+    src, _ = classify_return_source(
+        StrategyView(
+            paper_title="Momentum pairs arbitrage",
+            methodology_summary="A statistical arbitrage spread on a momentum pair.",
+        )
+    )
+    assert src is ReturnSource.MISPRICING
+
+
+# ── Keyword mapping: productive_growth ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "title,methodology",
+    [
+        ("A Quantitative Approach to Tactical Asset Allocation", "200-day moving average on broad index"),
+        ("Buy-and-Hold Baseline", "Buy and hold the index."),
+        ("Index Tracking", "Hold a broad market index."),
+    ],
+)
+def test_productive_growth_strategies(title, methodology):
+    src, _ = classify_return_source(StrategyView(paper_title=title, methodology_summary=methodology))
+    assert src is ReturnSource.PRODUCTIVE_GROWTH
+
+
+def test_broad_market_universe_fallback():
+    # No methodology keyword hit, but a purely broad-market universe → growth.
+    src, _ = classify_return_source(
+        StrategyView(
+            paper_title="Untitled baseline",
+            methodology_summary="Hold these tickers.",
+            asset_universe=("SPY", "BIL"),
+        )
+    )
+    assert src is ReturnSource.PRODUCTIVE_GROWTH
+
+
+# ── noise: no economic source ─────────────────────────────────────────
+
+
+def test_no_keyword_no_universe_is_noise():
+    src, note = classify_return_source(StrategyView(paper_title="???", methodology_summary="some opaque rule"))
+    assert src is ReturnSource.NOISE
+    assert "overfit" in note.lower() or "data-mined" in note.lower()
+
+
+def test_explained_edge_keeps_source_despite_failed_gate():
+    # A momentum strategy that FAILED the rigor gate is still risk_premium —
+    # its return source is unchanged; the rigor verdict communicates the failure
+    # separately. We don't double-punish an explained edge by stripping its label.
+    src, _ = classify_return_source(
+        StrategyView(
+            paper_title="Time Series Momentum",
+            passes_rigor_gate=False,
+            dsr_p_value=0.42,  # insignificant
+        )
+    )
+    assert src is ReturnSource.RISK_PREMIUM
+
+
+def test_unexplained_edge_failing_rigor_gets_stronger_noise_note():
+    # No economic keyword AND failed the gate on an insignificant DSR → noise,
+    # with the stronger "data-mined" note that names the rigor failure.
+    src, note = classify_return_source(
+        StrategyView(
+            paper_title="Proprietary signal",
+            methodology_summary="opaque rule with no documented source",
+            passes_rigor_gate=False,
+            dsr_p_value=0.42,
+        )
+    )
+    assert src is ReturnSource.NOISE
+    assert "rigor gate" in note.lower()
+
+
+def test_unevaluated_strategy_keeps_taxonomy():
+    # No backtest yet (dsr_p_value is None) → keep the taxonomy label.
+    src, _ = classify_return_source(
+        StrategyView(paper_title="Pairs Trading", passes_rigor_gate=False, dsr_p_value=None)
+    )
+    assert src is ReturnSource.MISPRICING
+
+
+def test_passing_strategy_keeps_taxonomy():
+    src, _ = classify_return_source(
+        StrategyView(paper_title="Volatility-Managed Portfolios", passes_rigor_gate=True, dsr_p_value=0.01)
+    )
+    assert src is ReturnSource.RISK_PREMIUM
+
+
+# ── Adapter + determinism ─────────────────────────────────────────────
+
+
+def test_classify_strategy_adapter_returns_strings():
+    class _Stub:
+        paper_title = "Time Series Momentum"
+        methodology_summary = ""
+        asset_universe = ("SPY",)
+        deflated_sharpe_ratio = 1.0
+        dsr_p_value = 0.01
+        passes_rigor_gate = True
+
+    source, note = classify_strategy(_Stub())
+    assert source == "risk_premium"
+    assert isinstance(note, str) and note
+
+
+def test_classifier_is_deterministic():
+    view = StrategyView(paper_title="Pairs Trading", methodology_summary="cointegration spread")
+    assert classify_return_source(view) == classify_return_source(view)
+
+
+# ── Passport serialization ────────────────────────────────────────────
+
+
+def test_return_source_serializes_on_passport_schema():
+    resp = StrategyResponse(
+        id="s1",
+        methodology_summary="m",
+        asset_universe=["SPY"],
+        position_sizing="equal_weight",
+        rebalance_frequency="weekly",
+        status="validated",
+        return_source="risk_premium",
+        return_source_note="Compensated exposure to a priced risk factor.",
+    )
+    dumped = resp.model_dump()
+    assert dumped["return_source"] == "risk_premium"
+    assert dumped["return_source_note"].startswith("Compensated")
+
+
+def test_return_source_defaults_to_noise_on_schema():
+    resp = StrategyResponse(
+        id="s2",
+        methodology_summary="m",
+        asset_universe=[],
+        position_sizing="equal_weight",
+        rebalance_frequency="weekly",
+        status="candidate",
+    )
+    assert resp.return_source == "noise"
+    assert resp.return_source_note == ""

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -65,6 +65,21 @@ function regimeChip(tag) {
   return null
 }
 
+// Return-source classification (T2.5) — the dominant economic source of the
+// strategy's return. Maps the backend enum to a human label + tag colour. A
+// durable, compensated source (risk_premium / productive_growth) reads neutral;
+// mispricing reads accent (decays as it crowds); noise reads muted (no source).
+const RETURN_SOURCE_META = {
+  risk_premium: { label: 'Risk premium', cls: 'tag-accent' },
+  mispricing: { label: 'Mispricing', cls: 'tag-accent' },
+  productive_growth: { label: 'Productive growth', cls: 'tag-positive' },
+  noise: { label: 'Noise', cls: 'tag-muted' },
+}
+
+function returnSourceChip(src) {
+  return RETURN_SOURCE_META[src] || RETURN_SOURCE_META.noise
+}
+
 export default function StrategyPassport({ strategyId, onNavigate, walletAddr }) {
   const [strategy, setStrategy] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -312,6 +327,22 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
           chronological out-of-sample number. A strategy passes the rigor gate only
           when all three signals align.
         </p>
+
+        {/* Return source (T2.5) — the rigor gate says whether the edge survives;
+            this says WHY it exists, and how durable that source is. */}
+        {s.return_source && (
+          <div className="mt-4 pt-4 border-t border-[var(--border,rgba(255,255,255,0.08))]">
+            <div className="flex items-center gap-2 flex-wrap mb-1">
+              <span className="caption text-[var(--text-4)]">Dominant return source</span>
+              <span className={`tag ${returnSourceChip(s.return_source).cls}`}>
+                {returnSourceChip(s.return_source).label}
+              </span>
+            </div>
+            {s.return_source_note && (
+              <p className="caption leading-relaxed text-[var(--text-3)]">{s.return_source_note}</p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Provenance */}


### PR DESCRIPTION
## Summary

Labels every strategy by its **dominant economic return source** — `risk_premium` | `mispricing` | `productive_growth` | `noise` — with a one-sentence durability note, and surfaces it on the strategy passport next to the rigor metrics.

The rigor gate (DSR/PBO/OOS) answers *whether* an edge survives multiple-testing correction; it does not answer *why* the edge exists. This adds the "why" — the missing economic-source dimension of the passport.

## What changed

- **Backend classifier** — new `backend/archimedes/services/return_source_classifier.py`: a deterministic, hermetic heuristic. Pure function of fields already on the passport (paper title, methodology summary, asset universe, DSR/rigor signals) — no LLM, no randomness, no network. The keyword → source mapping is the auditable contract, documented inline.
  - momentum / value / vol-managed / carry / trend / quality / dividend / low-beta factors → `risk_premium`
  - pairs / stat-arb / cointegration / mean-reversion / Kalman → `mispricing`
  - buy-and-hold / index / tactical asset allocation, or a purely broad-market universe → `productive_growth`
  - no economic keyword match → `noise` (with a stronger note when a failed rigor gate + insignificant DSR confirms it's data-mined)
  - **Honest rule:** an *explained* edge keeps its source label even if it fails the rigor gate — the rigor verdict communicates the failure separately, so we don't double-punish by stripping the source label.
- **Schema** — `StrategyResponse` gains `return_source` + `return_source_note` (defaults `noise` / `""`), wired through both `_to_strategy_response` (curated) and `_passport_to_strategy_response` (fusion/architect).
- **UI** — `StrategyPassport.jsx` renders a small tagged "Dominant return source" row inside the rigor card, with the durability note.
- **Tests** — 27 hermetic unit tests in `backend/tests/services/test_return_source_classifier.py`: each mapping, the failed-gate semantics, the broad-market universe fallback, the adapter, determinism, and that the field serializes on the passport API schema.

## Verify

```bash
# hermetic classifier + passport serialization tests
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/services/test_return_source_classifier.py \
  backend/tests/test_strategy_endpoints.py backend/tests/test_passport_loader.py -q   # 93 passed

ruff format --check .                              # clean
ruff check --select E9,F63,F7,F40,F82 .            # clean
cd ui && ./node_modules/.bin/eslint src/components/StrategyPassport.jsx   # clean
```

Against the real curated library the distribution is sensible: `risk_premium` 17, `mispricing` 10, `productive_growth` 2 (buy-and-hold + T-bill), `noise` 2 (genuinely-ambiguous papers).

## Anti-goals

- No new dependencies; no changes to the rigor gate, backtest math, or contracts.
- No LLM call in the classifier — kept honest, deterministic, and offline.

## Review notes

Backend `api/`+`services/`+`models/` is Daniel R.'s lane; UI is Marten/Daniel R. — cross-lane review welcome. Strategy-engine taxonomy is Dan's lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M