### PR TITLE
[telemetry] #428 — human vs agent traction counter (app-layer MVP) !minor

### DIFF
--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -1,0 +1,43 @@
+"""Metrics routes — public human-vs-agent traction counter (issue #428).
+
+Exposes ``GET /api/metrics`` with the live cumulative human/agent request
+counts maintained by the telemetry middleware. This is the read side of the
+hackathon win-condition instrument; the write side is
+``api/telemetry_middleware.py`` + ``services/telemetry_store.py``.
+
+# TODO(T-observability): Phase 2 — Prometheus ``/metrics`` exposition endpoint
+# and an arc-canteen async task that mirrors these counts onto the traction
+# dashboard. Intentionally out of scope for this app-layer MVP to keep it tight.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter
+
+from archimedes.models.telemetry import MetricsResponse
+from archimedes.services.telemetry_store import TelemetryStore
+
+metrics_router = APIRouter(prefix="/api", tags=["metrics"])
+
+
+@metrics_router.get("/metrics", response_model=MetricsResponse)
+async def get_metrics() -> MetricsResponse:
+    """Return the live human-vs-agent traction counts.
+
+    Fail-safe: ``TelemetryStore.get_counts`` returns ``(0, 0)`` when Redis is
+    unreachable, so this endpoint always responds 200 with a well-formed shape.
+    """
+    store = TelemetryStore()
+    try:
+        human_count, agent_count = await store.get_counts()
+    finally:
+        await store.close()
+
+    return MetricsResponse(
+        human_count=human_count,
+        agent_count=agent_count,
+        total_requests=human_count + agent_count,
+        timestamp=datetime.now(UTC).isoformat(),
+    )

--- a/backend/archimedes/api/telemetry_middleware.py
+++ b/backend/archimedes/api/telemetry_middleware.py
@@ -1,0 +1,141 @@
+"""Telemetry middleware — human-vs-agent request classifier (issue #428).
+
+Classifies every inbound request as HUMAN or AGENT and increments the matching
+Redis counter (see ``services/telemetry_store.py``). This is the app-layer MVP
+of the hackathon win-condition instrument: a real, live "agents vs humans"
+traction number backed by the live request path rather than a claim.
+
+Classifier (deterministic — identity model as of today):
+  - HUMAN  = a valid SIWE wallet session cookie (``archimedes_session``),
+             verified with the same ``_verify_session`` the auth layer uses.
+  - AGENT (internal) = a valid ``X-Internal-Agent-Key`` header (HMAC-compared
+             against ``INTERNAL_AGENT_API_KEY``), agent_type="internal".
+  - AGENT (external) = no session AND a non-browser User-Agent (no "Mozilla";
+             matches curl / python-requests / boto / axios / *bot*),
+             agent_type="external".
+  - Default (browser UA, no session) = HUMAN — the demo is open, so an
+    un-signed-in browser visitor still counts as a human.
+
+This module only READS the existing auth primitives; it never changes auth.
+
+Graceful degradation is a hard requirement: any classification or Redis error
+is logged at ``debug`` and swallowed. The counter is observability, never a
+gate — a telemetry fault must never turn a request into a 5xx.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+import re
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# Non-browser User-Agent markers. A request with no SIWE session whose UA
+# matches one of these (or carries no "Mozilla" token at all) is treated as an
+# external agent. Browsers always send a "Mozilla/5.0 ..." UA, so its absence
+# is a strong external-client signal.
+_AGENT_UA_PATTERN = re.compile(
+    r"curl|python-requests|httpx|aiohttp|go-http-client|boto|botocore|axios|"
+    r"node-fetch|okhttp|java/|wget|libwww|scrapy|bot|spider|crawler",
+    re.IGNORECASE,
+)
+
+
+def _is_browser_ua(user_agent: str) -> bool:
+    """A real browser sends a ``Mozilla/...`` UA. Empty/non-Mozilla → not a browser."""
+    return "mozilla" in user_agent.lower()
+
+
+def _has_valid_internal_key(request: Request) -> bool:
+    """True iff a valid ``X-Internal-Agent-Key`` is present (constant-time compare).
+
+    Mirrors ``auth_guard.require_internal_agent_key`` semantics: fail-closed when
+    the env key is unset (no key configured → no request can be "internal").
+    """
+    expected = os.getenv("INTERNAL_AGENT_API_KEY", "")
+    provided = request.headers.get("X-Internal-Agent-Key", "")
+    return bool(expected) and hmac.compare_digest(provided, expected)
+
+
+def _has_valid_session(request: Request) -> bool:
+    """True iff the request carries a valid SIWE session cookie.
+
+    Reuses the auth layer's ``_verify_session`` so the human classification
+    matches exactly what the app treats as an authenticated wallet.
+    """
+    from archimedes.api.auth_siwe import _COOKIE_NAME, _verify_session
+
+    token = request.cookies.get(_COOKIE_NAME)
+    if not token:
+        return False
+    return _verify_session(token) is not None
+
+
+def classify_request(request: Request) -> tuple[bool, str]:
+    """Classify a request. Returns ``(is_agent, agent_type)``.
+
+    ``agent_type`` is one of ``"internal"``, ``"external"``, or ``"human"``.
+    Deterministic and side-effect-free so it is trivially testable.
+    """
+    # 1. Internal agent — explicit, strongest signal.
+    if _has_valid_internal_key(request):
+        return True, "internal"
+
+    # 2. Human — a valid SIWE session.
+    if _has_valid_session(request):
+        return False, "human"
+
+    # 3. No session: a non-browser UA is an external agent/script.
+    user_agent = request.headers.get("user-agent", "")
+    if not _is_browser_ua(user_agent) or _AGENT_UA_PATTERN.search(user_agent):
+        return True, "external"
+
+    # 4. Default — browser UA, no session: an open-demo human.
+    return False, "human"
+
+
+async def telemetry_middleware(request: Request, call_next):
+    """ASGI HTTP middleware: classify, count, tag the response.
+
+    Sets ``request.state.is_agent`` / ``request.state.agent_type`` for any
+    downstream consumer, increments the right Redis counter, and adds an
+    ``X-Telemetry-Agent: true|false`` response header. Any error in
+    classification or counting is swallowed (logged at debug) so telemetry can
+    never break the request it is measuring.
+    """
+    is_agent = False
+    agent_type = "human"
+    try:
+        is_agent, agent_type = classify_request(request)
+        request.state.is_agent = is_agent
+        request.state.agent_type = agent_type
+
+        # Lazy import keeps the store off the import-time critical path and
+        # makes the boundary (the Redis client) easy to mock in tests.
+        from archimedes.services.telemetry_store import TelemetryStore
+
+        store = TelemetryStore()
+        try:
+            if is_agent:
+                await store.increment_agent()
+            else:
+                await store.increment_human()
+        finally:
+            await store.close()
+    except Exception as exc:
+        # Fail-safe: never let telemetry raise into the request path.
+        logger.debug("telemetry middleware classify/count failed: %s", exc)
+
+    response: Response = await call_next(request)
+
+    try:
+        response.headers["X-Telemetry-Agent"] = "true" if is_agent else "false"
+    except Exception as exc:
+        logger.debug("telemetry middleware header set failed: %s", exc)
+
+    return response

--- a/backend/archimedes/api/telemetry_middleware.py
+++ b/backend/archimedes/api/telemetry_middleware.py
@@ -109,7 +109,6 @@ async def telemetry_middleware(request: Request, call_next):
     never break the request it is measuring.
     """
     is_agent = False
-    agent_type = "human"
     try:
         is_agent, agent_type = classify_request(request)
         request.state.is_agent = is_agent

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -36,6 +36,7 @@ from archimedes.api.generate_routes import generate_router
 from archimedes.api.limiter import limiter
 
 # marketplace_router removed — hardcoded fees + invented math (Issue #381)
+from archimedes.api.metrics_routes import metrics_router
 from archimedes.api.portfolio_routes import portfolio_router
 from archimedes.api.proposals_routes import proposals_router
 from archimedes.api.risk_routes import risk_router
@@ -147,6 +148,16 @@ async def _limit_request_body(request: Request, call_next):
     return await call_next(request)
 
 
+# ── Telemetry middleware: human-vs-agent traction counter (issue #428) ──
+# Registered AFTER _limit_request_body and BEFORE include_router. It classifies
+# each request (SIWE session → human; internal-key / bot-UA → agent), increments
+# the matching Redis counter, and tags the response with X-Telemetry-Agent.
+# Graceful-degrades on any error — telemetry never turns a request into a 5xx.
+from archimedes.api.telemetry_middleware import telemetry_middleware
+
+app.middleware("http")(telemetry_middleware)
+
+
 # Initialize database (creates chat tables if needed)
 init_db()
 
@@ -235,6 +246,7 @@ app.include_router(papers_router)
 app.include_router(user_router)
 app.include_router(auth_router)
 app.include_router(proposals_router)
+app.include_router(metrics_router)
 
 
 @app.get("/health")
@@ -314,10 +326,27 @@ async def health():
     except Exception:
         risk_data_reason = "import failed"
 
+    # Human-vs-agent traction counts (issue #428). Fail-safe: get_counts
+    # returns (0, 0) when Redis is unreachable, so /health never degrades on it.
+    human_count = 0
+    agent_count = 0
+    try:
+        from archimedes.services.telemetry_store import TelemetryStore
+
+        _store = TelemetryStore()
+        try:
+            human_count, agent_count = await _store.get_counts()
+        finally:
+            await _store.close()
+    except Exception:
+        logger.debug("telemetry counts read failed", exc_info=True)
+
     return {
         "status": "ok" if connected else "degraded",
         "service": "archimedes-backend",
         "chain_connected": connected,
+        "human_count": human_count,
+        "agent_count": agent_count,
         "corpus_papers": len(corpus),
         "corpus_db_count": db_count,
         "corpus_source": corpus_source,

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -1,0 +1,34 @@
+"""Telemetry data models — human-vs-agent traction counter (issue #428).
+
+The traction counter is the hackathon win-condition instrument: it measures
+how much of the live traffic is *humans* (browser sessions) vs *agents*
+(internal agent runner + external bots/scripts) so the "agents make markets"
+narrative is backed by a real, live number rather than a claim.
+
+Identity model (today, single-user MVP):
+  - HUMAN  = a valid SIWE wallet session cookie (``archimedes_session``).
+  - AGENT  = a valid ``X-Internal-Agent-Key`` header (internal), OR no session
+             plus a non-browser User-Agent (external bot/script).
+  - Default (browser UA, no session) = HUMAN — the demo is open, so an
+    un-signed-in browser visitor still counts as a human.
+
+Only response *shapes* live here; classification logic lives in the telemetry
+middleware and the counter persistence lives in ``services/telemetry_store.py``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class MetricsResponse(BaseModel):
+    """Public traction counter — humans vs agents over the live deployment.
+
+    Served by ``GET /api/metrics``. Counts are monotonic cumulative totals
+    since the Redis counters were last reset (deploy / flush).
+    """
+
+    human_count: int = Field(..., description="Requests classified as human (SIWE session / browser).")
+    agent_count: int = Field(..., description="Requests classified as agent (internal key / bot UA).")
+    total_requests: int = Field(..., description="human_count + agent_count.")
+    timestamp: str = Field(..., description="ISO-8601 UTC timestamp this snapshot was read.")

--- a/backend/archimedes/services/telemetry_store.py
+++ b/backend/archimedes/services/telemetry_store.py
@@ -1,0 +1,88 @@
+"""Telemetry store — atomic human/agent request counters in Redis (issue #428).
+
+Backs the human-vs-agent traction counter. Uses Redis ``INCR`` (atomic across
+Uvicorn workers) on two cumulative keys so the count is correct under
+concurrent traffic without a read-modify-write race.
+
+Design notes:
+  - Reuses the same Redis client/config pattern as ``services/redis_state.py``
+    (``redis.asyncio.from_url`` with ``decode_responses=True`` and the
+    ``REDIS_URL`` env default) so there is one connection convention in the
+    codebase.
+  - **Fail-safe by construction.** Every method swallows Redis errors and logs
+    at ``debug``; a Redis outage must never turn a request into a 5xx. The
+    increment path returns silently; the read path returns zeros.
+  - ``total`` is derived (humans + agents) on read rather than stored, so a
+    crash between two INCRs can never desync a stored total from its parts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import redis.asyncio as aioredis
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+# Keys — namespaced under archimedes:telemetry: to match the redis_state.py
+# key convention (archimedes:<domain>:<name>).
+KEY_HUMANS = "archimedes:telemetry:humans"
+KEY_AGENTS = "archimedes:telemetry:agents"
+
+
+class TelemetryStore:
+    """Thin, fail-safe Redis wrapper for the human/agent traction counters."""
+
+    def __init__(self, url: str | None = None) -> None:
+        self._url = url or REDIS_URL
+        self._redis: aioredis.Redis | None = None
+
+    async def _get_redis(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = aioredis.from_url(self._url, decode_responses=True)
+        return self._redis
+
+    # ─── Increment (write path — request middleware) ─────────────
+
+    async def increment_human(self) -> None:
+        """Atomically increment the human counter. Never raises."""
+        await self._incr(KEY_HUMANS)
+
+    async def increment_agent(self) -> None:
+        """Atomically increment the agent counter. Never raises."""
+        await self._incr(KEY_AGENTS)
+
+    async def _incr(self, key: str) -> None:
+        try:
+            r = await self._get_redis()
+            await r.incr(key)
+        except Exception as exc:
+            # Fail-safe: a Redis outage must never break the request it is
+            # measuring. Log at debug so it isn't noisy in normal operation.
+            logger.debug("telemetry incr failed for %s: %s", key, exc)
+
+    # ─── Read (exposure path — /api/metrics, /health) ────────────
+
+    async def get_counts(self) -> tuple[int, int]:
+        """Return ``(human_count, agent_count)``. Returns ``(0, 0)`` on error."""
+        try:
+            r = await self._get_redis()
+            humans = await r.get(KEY_HUMANS)
+            agents = await r.get(KEY_AGENTS)
+            return int(humans or 0), int(agents or 0)
+        except Exception as exc:
+            logger.debug("telemetry read failed: %s", exc)
+            return 0, 0
+
+    # ─── Lifecycle ────────────────────────────────────────────────
+
+    async def close(self) -> None:
+        if self._redis:
+            try:
+                await self._redis.aclose()
+            except Exception as exc:
+                logger.debug("telemetry store close failed: %s", exc)
+            self._redis = None

--- a/backend/tests/test_metrics_routes.py
+++ b/backend/tests/test_metrics_routes.py
@@ -1,0 +1,72 @@
+"""HTTP-layer tests for the /api/metrics traction endpoint (issue #428).
+
+Mocks the Redis boundary (``TelemetryStore.get_counts``) so the test is
+hermetic — no live Redis. Asserts the response shape and the derived total.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_returns_counts_and_total():
+    from archimedes.main import app
+
+    with patch(
+        "archimedes.services.telemetry_store.TelemetryStore.get_counts",
+        new=AsyncMock(return_value=(7, 3)),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/metrics")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["human_count"] == 7
+    assert data["agent_count"] == 3
+    assert data["total_requests"] == 10
+    assert isinstance(data["timestamp"], str) and data["timestamp"]
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_shape_keys_present():
+    from archimedes.main import app
+
+    with patch(
+        "archimedes.services.telemetry_store.TelemetryStore.get_counts",
+        new=AsyncMock(return_value=(0, 0)),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/metrics")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ("human_count", "agent_count", "total_requests", "timestamp"):
+        assert key in data, f"missing {key} in {list(data.keys())}"
+    # Zero state is well-formed, not an error.
+    assert data["total_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_degrades_to_zero_when_redis_down():
+    """When Redis is unreachable, get_counts returns (0, 0) and the endpoint still 200s."""
+    from archimedes.main import app
+    from archimedes.services.telemetry_store import TelemetryStore
+
+    # Patch the underlying client accessor to fail; get_counts swallows → (0, 0).
+    with patch.object(
+        TelemetryStore,
+        "_get_redis",
+        new=AsyncMock(side_effect=ConnectionError("redis down")),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/metrics")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["human_count"] == 0
+    assert data["agent_count"] == 0
+    assert data["total_requests"] == 0

--- a/backend/tests/test_telemetry_classifier.py
+++ b/backend/tests/test_telemetry_classifier.py
@@ -1,0 +1,189 @@
+"""Hermetic tests for the telemetry request classifier + middleware (issue #428).
+
+Covers the deterministic human-vs-agent classification and the middleware's
+fail-safe behaviour:
+
+  - valid SIWE session            → human
+  - valid X-Internal-Agent-Key    → agent (internal)
+  - bot/script User-Agent         → agent (external)
+  - browser UA, no session        → human (open demo default)
+  - Redis-down                    → middleware never raises (no 5xx)
+
+No live Redis / Postgres / Anthropic / Arc RPC. The SIWE session is built with
+the real ``_sign_session`` (the auth layer's own signer) so the human path is
+exercised through production ``_verify_session`` rather than a mock. The Redis
+boundary is mocked via ``patch.object`` on the store's client accessor.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from archimedes.api.telemetry_middleware import classify_request, telemetry_middleware
+from starlette.requests import Request
+
+_WALLET = "0x1111111111111111111111111111111111111111"
+
+
+def _make_request(headers: dict[str, str] | None = None, cookies: dict[str, str] | None = None) -> Request:
+    """Build a minimal ASGI ``Request`` with given headers/cookies (hermetic)."""
+    raw_headers: list[tuple[bytes, bytes]] = []
+    for k, v in (headers or {}).items():
+        raw_headers.append((k.lower().encode(), v.encode()))
+    if cookies:
+        cookie_str = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        raw_headers.append((b"cookie", cookie_str.encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/anything",
+        "headers": raw_headers,
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+# ── classify_request ─────────────────────────────────────────────
+
+
+def test_siwe_session_classifies_as_human():
+    token = _sign_session(_WALLET, time.time())
+    request = _make_request(headers={"user-agent": "curl/8.0"}, cookies={_COOKIE_NAME: token})
+    # Even with a bot UA, a valid session wins → human.
+    is_agent, agent_type = classify_request(request)
+    assert is_agent is False
+    assert agent_type == "human"
+
+
+def test_internal_key_classifies_as_agent():
+    with patch.dict("os.environ", {"INTERNAL_AGENT_API_KEY": "secret-key-123"}):
+        request = _make_request(
+            headers={"user-agent": "Mozilla/5.0", "x-internal-agent-key": "secret-key-123"},
+        )
+        is_agent, agent_type = classify_request(request)
+    assert is_agent is True
+    assert agent_type == "internal"
+
+
+def test_wrong_internal_key_is_not_agent_internal():
+    with patch.dict("os.environ", {"INTERNAL_AGENT_API_KEY": "secret-key-123"}):
+        # Wrong key + browser UA + no session → falls through to human default.
+        request = _make_request(
+            headers={"user-agent": "Mozilla/5.0", "x-internal-agent-key": "wrong-key"},
+        )
+        is_agent, agent_type = classify_request(request)
+    assert is_agent is False
+    assert agent_type == "human"
+
+
+def test_unset_internal_key_fails_closed():
+    # No INTERNAL_AGENT_API_KEY configured → no request can be "internal".
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("INTERNAL_AGENT_API_KEY", None)
+        request = _make_request(headers={"user-agent": "Mozilla/5.0", "x-internal-agent-key": ""})
+        is_agent, agent_type = classify_request(request)
+    assert agent_type == "human"
+    assert is_agent is False
+
+
+@pytest.mark.parametrize(
+    "ua",
+    ["curl/8.0", "python-requests/2.31", "boto3/1.34", "axios/1.6", "Googlebot/2.1", ""],
+)
+def test_bot_user_agent_classifies_as_agent_external(ua):
+    request = _make_request(headers={"user-agent": ua})
+    is_agent, agent_type = classify_request(request)
+    assert is_agent is True
+    assert agent_type == "external"
+
+
+def test_browser_no_session_classifies_as_human():
+    request = _make_request(
+        headers={"user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"},
+    )
+    is_agent, agent_type = classify_request(request)
+    assert is_agent is False
+    assert agent_type == "human"
+
+
+def test_expired_session_is_not_human_session():
+    # An expired session token fails _verify_session; with a bot UA it's external.
+    expired = _sign_session(_WALLET, time.time() - 10**9)
+    request = _make_request(headers={"user-agent": "curl/8.0"}, cookies={_COOKIE_NAME: expired})
+    is_agent, agent_type = classify_request(request)
+    assert is_agent is True
+    assert agent_type == "external"
+
+
+# ── middleware fail-safe ─────────────────────────────────────────
+
+
+async def _passthrough(_request):
+    from starlette.responses import JSONResponse
+
+    return JSONResponse({"ok": True})
+
+
+@pytest.mark.asyncio
+async def test_middleware_sets_state_and_header_for_agent():
+    request = _make_request(headers={"user-agent": "curl/8.0"})
+    # Mock the Redis boundary so no real Redis is touched.
+    with patch(
+        "archimedes.services.telemetry_store.TelemetryStore._get_redis",
+        new=AsyncMock(return_value=AsyncMock()),
+    ):
+        response = await telemetry_middleware(request, _passthrough)
+    assert request.state.is_agent is True
+    assert request.state.agent_type == "external"
+    assert response.headers["X-Telemetry-Agent"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_middleware_sets_header_false_for_human():
+    request = _make_request(headers={"user-agent": "Mozilla/5.0"})
+    with patch(
+        "archimedes.services.telemetry_store.TelemetryStore._get_redis",
+        new=AsyncMock(return_value=AsyncMock()),
+    ):
+        response = await telemetry_middleware(request, _passthrough)
+    assert request.state.is_agent is False
+    assert response.headers["X-Telemetry-Agent"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_middleware_does_not_raise_when_redis_down():
+    """A Redis outage must never turn a request into a 5xx — middleware swallows it."""
+    request = _make_request(headers={"user-agent": "curl/8.0"})
+    with patch(
+        "archimedes.services.telemetry_store.TelemetryStore._get_redis",
+        new=AsyncMock(side_effect=ConnectionError("redis down")),
+    ):
+        response = await telemetry_middleware(request, _passthrough)
+    # The request still completes; the header is still set.
+    assert response.headers["X-Telemetry-Agent"] == "true"
+    assert request.state.is_agent is True
+
+
+@pytest.mark.asyncio
+async def test_store_increment_swallows_redis_error():
+    """TelemetryStore.increment_* must never raise even when Redis is unreachable."""
+    from archimedes.services.telemetry_store import TelemetryStore
+
+    store = TelemetryStore()
+    with patch.object(
+        TelemetryStore,
+        "_get_redis",
+        new=AsyncMock(side_effect=ConnectionError("redis down")),
+    ):
+        # Should not raise.
+        await store.increment_human()
+        await store.increment_agent()
+        humans, agents = await store.get_counts()
+    # Read also fails safe → zeros.
+    assert humans == 0
+    assert agents == 0


### PR DESCRIPTION
## Summary

Closes the **app-layer MVP** of issue #428 — the human-vs-agent traction counter, the hackathon win-condition instrument. Every inbound request is classified as **HUMAN** or **AGENT**, an atomic Redis counter is incremented, and the live counts are exposed at `GET /api/metrics` and on `/health`. This makes the "agents make markets" narrative backed by a real, live number on the request path rather than a claim.

## Identity model (today)

Auth is **read-only** here — this PR reuses the existing primitives and changes nothing about auth:
- **HUMAN** = a valid SIWE wallet session cookie (`archimedes_session`), verified with the auth layer's own `_verify_session`.
- **AGENT (internal)** = a valid `X-Internal-Agent-Key` (HMAC `compare_digest` against `INTERNAL_AGENT_API_KEY`, fail-closed when unset — same semantics as `auth_guard`).
- **AGENT (external)** = no session **and** a non-browser User-Agent (no `Mozilla`; matches curl / python-requests / boto / axios / *bot*).
- **Default** (browser UA, no session) = **HUMAN** — the demo is open, so an un-signed-in browser visitor still counts as a human.

## Scope (files)

- `backend/archimedes/api/telemetry_middleware.py` — deterministic `classify_request` + ASGI middleware. Registered in `main.py` **after** `_limit_request_body` and **before** `include_router`; sets `request.state.is_agent` / `agent_type`, increments the right counter, adds `X-Telemetry-Agent: true|false`. **Graceful-degrades** on any classify/Redis error (logs at debug, never raises → no 5xx).
- `backend/archimedes/services/telemetry_store.py` — `TelemetryStore` with atomic `INCR` on `archimedes:telemetry:{humans,agents}`. Reuses the `redis_state.py` client/config pattern; fail-safe (increment swallows errors, read returns zeros). `total` is derived on read so it can never desync from its parts.
- `backend/archimedes/api/metrics_routes.py` + `backend/archimedes/models/telemetry.py` — `GET /api/metrics` → `MetricsResponse {human_count, agent_count, total_requests, timestamp}`. `/health` extended with `human_count` + `agent_count`.

## Verify

```bash
export PATH=/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin:$PATH
ruff format --check backend/archimedes/api/telemetry_middleware.py backend/archimedes/api/metrics_routes.py \
  backend/archimedes/services/telemetry_store.py backend/archimedes/models/telemetry.py backend/archimedes/main.py \
  backend/tests/test_telemetry_classifier.py backend/tests/test_metrics_routes.py
ruff check --select E9,F63,F7,F40,F82 .
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_telemetry_classifier.py backend/tests/test_metrics_routes.py -q   # 19 passed
PYTHONPATH=backend python -c "import archimedes.main"                                   # import OK
```

All green: ruff format clean, critical-rule lint clean, **19 passed**, `main.py` imports and `/api/metrics` is registered.

## Tests (hermetic — no real Redis)

- `test_telemetry_classifier.py`: SIWE-session→human, internal-key→agent (+ wrong-key / unset-key fail-closed), bot-UA→agent (parametrized: curl/python-requests/boto/axios/Googlebot/empty), browser-no-session→human, expired-session→external, and **Redis-down → middleware/store never raise**. SIWE path uses the real `_sign_session`; the Redis boundary is mocked.
- `test_metrics_routes.py`: mocked `get_counts` → `/api/metrics` shape + derived total + Redis-down degrades-to-zero (still 200).

## Anti-goals / out of scope (intentional, follow-up)

- **No auth changes** — `_verify_session` and the internal-key guard are read-only here.
- **Phase 2 is deferred and intentionally out of scope** (left as a `# TODO(T-observability)` in `metrics_routes.py`): Plausible/funnel analytics, a Prometheus `/metrics` exposition endpoint, and an arc-canteen async task mirroring these counts onto the traction dashboard. Kept tight for the MVP.

## Review note

Touches the backend `api/` + `services/` + `models/` layer (Daniel R.'s lead area) — no contract / chain / infra surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M