### PR TITLE
Make model selection functional + fix chat premium-model cost leak !minor

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -422,7 +422,12 @@ class _Emitter:
 
 
 async def _run_fixture_candidate(
-    *, candidate_id: str, brief: GenerateBrief, emit: _Emitter, regime: str = "neutral"
+    *,
+    candidate_id: str,
+    brief: GenerateBrief,
+    emit: _Emitter,
+    regime: str = "neutral",
+    agent: Any = None,  # noqa: ARG001 — signature parity with _run_live_candidate; fixture path ignores it
 ) -> _CandidateResult:
     """Synthetic generation that exercises every event the live agent emits.
 
@@ -526,13 +531,17 @@ _REGIME_PROMPT_SUFFIX = {
 
 
 async def _run_live_candidate(
-    *, candidate_id: str, brief: GenerateBrief, emit: _Emitter, regime: str = "neutral"
+    *, candidate_id: str, brief: GenerateBrief, emit: _Emitter, regime: str = "neutral", agent: Any = None
 ) -> _CandidateResult:
     """Drive the real ``portfolio_agent`` with per-iteration event emission.
 
     The agent's iteration loop is sync and runs in a thread. The thread uses
     a sync emit shim that schedules the async ``Emitter.emit`` back onto the
     main event loop — this keeps the agent unchanged while still streaming.
+
+    ``agent`` is an optional pre-built ``PortfolioAgent`` (e.g. bound to the
+    user's free-tier model pick). When ``None`` the shared process singleton is
+    used — the default, unchanged behavior.
     """
     from archimedes.agents.portfolio_agent import get_portfolio_agent
     from archimedes.services.strategy_provider import default_provider
@@ -565,7 +574,7 @@ async def _run_live_candidate(
     agent_regime = {"bull": "expansion", "bear": "contraction"}.get(regime, "transition")
     agent_confidence = 0.80 if regime in ("bull", "bear") else 0.65
 
-    agent = get_portfolio_agent()
+    agent = agent or get_portfolio_agent()
     # Inject regime suffix into the agent's system prompt via the risk_appetite
     # string (the agent reads it as context). The suffix is appended to the
     # user-visible risk profile so the agent sees the regime steer.
@@ -674,6 +683,29 @@ async def _run_live_candidate(
 # ── Pipeline entry point ──────────────────────────────────────────────────
 
 
+def _served_model_for(job_agent: Any, use_live: bool) -> str:
+    """Resolve the model id that actually served this job, for provenance.
+
+    Prefers the per-job agent's backend (when the user picked a model), else the
+    shared singleton. Reads ``served_model`` (post-call truth, e.g. response.model)
+    when present, falling back to ``model_id``. Returns the fixture marker on the
+    non-live path so the UI never claims a real model ran when it didn't.
+    """
+    if not use_live:
+        return "fixture"
+    try:
+        from archimedes.agents.portfolio_agent import get_portfolio_agent
+
+        agent = job_agent or get_portfolio_agent()
+        backend = getattr(agent, "_backend", None)
+        served = getattr(backend, "served_model", None) or getattr(backend, "model_id", None)
+        if served:
+            return str(served)
+        return getattr(agent, "model_id", "unknown")
+    except Exception:
+        return "unknown"
+
+
 async def run_generation(
     *,
     job_id: str,
@@ -681,6 +713,7 @@ async def run_generation(
     n_candidates: int = 1,
     store: JobStore | None = None,
     mode: str | None = None,
+    model: str | None = None,
     dual_regime: bool = True,
 ) -> None:
     """Run the full streaming generation pipeline for one job.
@@ -689,6 +722,11 @@ async def run_generation(
     generates BOTH a bull-tilted AND a bear-tilted candidate. Each regime
     run uses biased paper retrieval + regime-specific reasoning. The user
     sees both candidates with regime tags and can deploy one, both, or neither.
+
+    ``model`` is the user's optional free-tier model pick (already allowlisted
+    by the route). When set, the live path constructs a per-job LLM backend on
+    that model; when ``None`` it uses the shared singleton on the env default —
+    behavior UNCHANGED.
 
     Designed to be called as a fire-and-forget asyncio task from the route
     handler. Exceptions are caught + emitted as ``error`` events so the SSE
@@ -760,6 +798,21 @@ async def run_generation(
         use_live = _llm_available()
         runner: Callable[..., Awaitable[_CandidateResult]] = _run_live_candidate if use_live else _run_fixture_candidate
 
+        # If the user picked an allowlisted free-tier model, build a per-job
+        # portfolio agent bound to that model; otherwise reuse the shared
+        # singleton on the env default (behavior unchanged). Constructed once and
+        # shared across both regime candidates so we don't rebuild a client twice.
+        job_agent = None
+        if use_live and model:
+            try:
+                from archimedes.agents.portfolio_agent import PortfolioAgent
+                from archimedes.services.llm_backend import make_llm_backend
+
+                job_agent = PortfolioAgent(backend=make_llm_backend(model=model))
+            except Exception as exc:
+                logger.warning("could not build per-job agent for model %r (%s); using default", model, exc)
+                job_agent = None
+
         # Library is the candidate pool the agent reasons over; surface it so
         # the UI can show "agent is considering N papers". Its size also feeds
         # the DSR multiple-testing correction below (selection-bias-corrections-
@@ -790,6 +843,7 @@ async def run_generation(
                     brief=brief,
                     emit=emit,
                     regime=regime,
+                    agent=job_agent,
                 )
             except Exception as exc:
                 logger.exception("candidate %s (%s) failed: %s", candidate_id, regime, exc)
@@ -923,7 +977,17 @@ async def run_generation(
                 ],
             },
         )
-        await emit.emit("done", strategy_id=strategy_id, all_strategy_ids=strategy_ids)
+        # Provenance: surface the model that actually served this job so the UI
+        # can show what really ran (vs. what was requested). `served_model` is
+        # the post-call value when available (e.g. response.model), else the
+        # configured id; falls back to the fixture marker on the non-live path.
+        served_model = _served_model_for(job_agent, use_live)
+        await emit.emit(
+            "done",
+            strategy_id=strategy_id,
+            all_strategy_ids=strategy_ids,
+            served_model=served_model,
+        )
 
     except asyncio.CancelledError:
         await emit.emit("error", message="job cancelled", recoverable=False, code="CANCELLED")

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -35,6 +35,7 @@ from archimedes.api.generate_schemas import (
 )
 from archimedes.api.limiter import limiter
 from archimedes.services.job_queue import EVENT_LOG_TTL, get_job_store
+from archimedes.services.llm_backend import is_allowed_model
 from archimedes.services.log_scrubber import sanitize_log_value
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,15 @@ async def start_generation(
 ) -> GenerateStartResponse:
     """Create a generation job and start the pipeline in the background."""
     store = get_job_store()
+    # Server-side model gate (defense in depth — the UI also restricts this).
+    # Only an allowlisted free-tier model id is honored; anything else (premium
+    # ids, junk, None) is dropped and the pipeline falls back to the env default,
+    # so behavior is UNCHANGED when no valid model is selected. This enforces the
+    # free-tier restriction on the server even if the UI is bypassed, and keeps
+    # premium models gated until the #723 HTTP-402 entitlement lands.
+    selected_model = req.model if is_allowed_model(req.model) else None
+    if req.model and selected_model is None:
+        logger.info("generate: ignoring non-allowlisted model %r; using env default", sanitize_log_value(req.model))
     # Tag the job with its creator (audit 2026-06-14) so cancel can be scoped to
     # the owner. When no SIWE session exists (flag off / anonymous), owner_wallet
     # is None and the job stays cancellable by anyone — preserving today's open
@@ -77,12 +87,13 @@ async def start_generation(
             "brief": req.brief.model_dump(),
             "n_candidates": req.n_candidates,
             "owner_wallet": _wallet,
+            "model": selected_model,
         },
     )
 
     # Fire-and-forget the pipeline. The route doesn't await it; the SSE stream
     # below tails the event log written by the pipeline as it runs.
-    task = asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates, req.mode))
+    task = asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates, req.mode, selected_model))
     _register_task(job_id, task)
 
     return GenerateStartResponse(
@@ -92,9 +103,15 @@ async def start_generation(
     )
 
 
-async def _run_with_cleanup(job_id: str, brief: GenerateBrief, n_candidates: int, mode: str | None = None) -> None:
+async def _run_with_cleanup(
+    job_id: str,
+    brief: GenerateBrief,
+    n_candidates: int,
+    mode: str | None = None,
+    model: str | None = None,
+) -> None:
     try:
-        await run_generation(job_id=job_id, brief=brief, n_candidates=n_candidates, mode=mode)
+        await run_generation(job_id=job_id, brief=brief, n_candidates=n_candidates, mode=mode, model=model)
     except asyncio.CancelledError:
         raise
     except Exception:  # safety net — run_generation already emits error events

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -33,6 +33,14 @@ class GenerateStartRequest(BaseModel):
         default=None,
         description="Optional pipeline override: 'fusion', 'architect', or 'agent'. When set, bypasses auto-routing.",
     )
+    model: str | None = Field(
+        default=None,
+        description=(
+            "Optional free-tier LLM model id chosen on the Generate page. Validated server-side "
+            "against a free-tier allowlist; ignored (falls back to the env default) if absent or "
+            "not allowlisted. Premium models are NOT selectable until the paid-tier 402 gate (#723)."
+        ),
+    )
 
 
 class GenerateStartResponse(BaseModel):

--- a/backend/archimedes/services/chat_service.py
+++ b/backend/archimedes/services/chat_service.py
@@ -33,11 +33,16 @@ Never promise returns. Always frame in terms of process and rigor."""
 
 # Use the Circle dev-controlled wallet as the AI's identity in chat.
 # Falls back to a labelled placeholder if the wallet address isn't configured.
-import os as _os
-
-AI_WALLET_ADDRESS = _os.getenv(
+AI_WALLET_ADDRESS = os.getenv(
     "WALLET_ADDRESS", "0xc221dcd6fe7d81ff741f94c08e61f52bea1f9ac9"
 )  # Circle agent walleter for AI identity
+
+# Optional per-surface model override for vault chat. When unset (the default),
+# chat rides the same cheap env-resolved model as the rest of the app via
+# make_llm_backend() — NO hardcoded premium literal. Set CHAT_MODEL only if the
+# chat persona genuinely needs a stronger (paid-tier) model than the generate
+# default; it must be a model id the configured provider can serve.
+CHAT_MODEL = os.getenv("CHAT_MODEL", "").strip() or None
 
 
 class ChatService:
@@ -184,20 +189,18 @@ class ChatService:
         user_message: str,
         wallet_address: str,  # noqa: ARG002 — accepted for future per-wallet personalization; current body uses vault_address + user_message only
     ) -> dict | None:
-        """Generate an AI response using Claude or GLM API."""
-        import anthropic
+        """Generate an AI response via the provider-agnostic LLM backend.
 
-        api_key = os.getenv("ANTHROPIC_API_KEY", "")
-        auth_token = os.getenv("ANTHROPIC_AUTH_TOKEN", "")
-        base_url = os.getenv("ANTHROPIC_BASE_URL", "")
-        if api_key:
-            client: anthropic.Anthropic | None = anthropic.Anthropic(api_key=api_key)
-        elif auth_token and base_url:
-            client = anthropic.Anthropic(auth_token=auth_token, base_url=base_url)
-        else:
-            client = None
-        if client is None:
-            logger.warning("No LLM credentials set — returning canned AI response")
+        Routes through ``make_llm_backend(model=CHAT_MODEL)`` instead of a
+        hardcoded premium Claude literal, so the cheap env default applies and
+        the model is configurable (cost leak fixed). ``CHAT_MODEL`` is an
+        opt-in named override for callers that want a stronger model for chat.
+        """
+        from archimedes.services.llm_backend import make_llm_backend
+
+        backend = make_llm_backend(model=CHAT_MODEL)
+        if not getattr(backend, "available", False):
+            logger.warning("No LLM backend available — returning canned AI response")
             return self._canned_response(vault_address, user_message)
 
         try:
@@ -214,32 +217,20 @@ class ChatService:
             # Inject vault-specific context to prevent hallucination (#386)
             vault_context = self._build_vault_context(vault_address)
 
-            response = client.messages.create(
-                model="claude-sonnet-4-20250514",
-                max_tokens=300,
-                system=AI_SYSTEM_PROMPT,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": (
-                            f"Vault: {vault_address}\n"
-                            f"{vault_context}\n"
-                            f"<chat_history>\n{context}\n</chat_history>\n\n"
-                            f"<user_message>{user_message}</user_message>"
-                        ),
-                    }
-                ],
+            user_prompt = (
+                f"Vault: {vault_address}\n"
+                f"{vault_context}\n"
+                f"<chat_history>\n{context}\n</chat_history>\n\n"
+                f"<user_message>{user_message}</user_message>"
             )
 
-            ai_text = (
-                response.content[0].text.strip()
-                if response.content
-                else "I'm analyzing the portfolio. Give me a moment."
-            )
+            ai_text = (backend.complete(AI_SYSTEM_PROMPT, user_prompt) or "").strip()
+            if not ai_text:
+                ai_text = "I'm analyzing the portfolio. Give me a moment."
             return self.post_ai_message(vault_address, ai_text, trigger="mention")
 
         except Exception:
-            logger.exception("Claude API call failed — falling back to canned response")
+            logger.exception("LLM call failed — falling back to canned response")
             return self._canned_response(vault_address, user_message)
 
     def _build_vault_context(self, vault_address: str) -> str:

--- a/backend/archimedes/services/llm_backend.py
+++ b/backend/archimedes/services/llm_backend.py
@@ -32,6 +32,42 @@ DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 DEFAULT_CONVERSE_MODEL = "amazon.nova-micro-v1:0"
 MAX_TOKENS = 4096
 
+# ── Free-tier model allowlist (server-side defense-in-depth) ─────────────
+# The Generate page exposes a model picker, but only FREE/default-tier models
+# may actually be selected. This set is the server-side enforcement of that
+# UI restriction: a user-supplied ``model`` is honored ONLY if it appears here.
+# Anything else (premium Anthropic-on-Bedrock ids, junk, etc.) is ignored and
+# the request falls back to the env default — so the picker can never route a
+# free user onto a premium model before the #723 HTTP-402 entitlement gate
+# lands. Mirrors the ``works_now: true`` rows in ui/src/data/modelPricing.json;
+# keep the two in sync. Premium ids (Claude Haiku/Sonnet on Bedrock) are
+# deliberately ABSENT.
+FREE_TIER_MODELS: frozenset[str] = frozenset(
+    {
+        "amazon.nova-micro-v1:0",
+        "amazon.nova-lite-v1:0",
+        "amazon.nova-pro-v1:0",
+        "openai.gpt-oss-20b-1:0",
+        "zai.glm-4.7-flash",
+        "zai.glm-4.7",
+        "qwen.qwen3-32b-v1:0",
+        "us.meta.llama4-scout-17b-instruct-v1:0",
+        "us.meta.llama3-3-70b-instruct-v1:0",
+        "deepseek.v3.2",
+        "moonshotai.kimi-k2.5",
+        "mistral.mistral-small-2402-v1:0",
+    }
+)
+
+
+def is_allowed_model(model: str | None) -> bool:
+    """True iff ``model`` is a non-empty, allowlisted free-tier model id.
+
+    Defense-in-depth: the UI already disables premium rows, but the server
+    re-checks so a hand-crafted request can't bypass the gate.
+    """
+    return bool(model) and model in FREE_TIER_MODELS
+
 
 class LLMBackend(Protocol):
     """Minimal text-completion seam consumed by architect + fusion."""
@@ -405,7 +441,9 @@ class CannedBackend:
 # ── Factory ──────────────────────────────────────────────────────────
 
 
-def make_llm_backend() -> (
+def make_llm_backend(
+    model: str | None = None,
+) -> (
     AnthropicBackend
     | AnthropicCompatibleBackend
     | BedrockBackend
@@ -425,23 +463,36 @@ def make_llm_backend() -> (
       - ``openai``: httpx to OpenAI-compatible endpoint (``LLM_BASE_URL`` + ``LLM_API_KEY``)
       - ``ollama``: httpx to Ollama (``LLM_BASE_URL``, no key)
 
+    ``model`` is an optional per-call override (e.g. a user's pick from the
+    Generate page's model picker). When ``None`` (the default), the model is
+    resolved from env exactly as before — behavior is UNCHANGED. When supplied,
+    it overrides the resolved model for this backend instance only. Callers are
+    responsible for allowlisting untrusted input via :func:`is_allowed_model`
+    BEFORE passing it here; this factory does not re-validate the string.
+
     Back-compat: if ``LLM_PROVIDER`` is unset, falls back to ``ANTHROPIC_*``
     env vars (deprecated, emits WARN).
     """
-    model = os.getenv("LLM_MODEL", DEFAULT_MODEL)
+    resolved_model = model or os.getenv("LLM_MODEL", DEFAULT_MODEL)
     provider = os.getenv("LLM_PROVIDER", "").strip().lower()
 
     # Back-compat: auto-detect from ANTHROPIC_* if LLM_PROVIDER not set
     if not provider:
-        return _legacy_backend(model)
+        return _legacy_backend(resolved_model)
 
+    # The Bedrock paths resolve their own (Bedrock-specific) model id from
+    # LLM_BEDROCK_MODEL and ignore the generic LLM_MODEL. A caller-supplied
+    # override IS a Bedrock model id (the picker lists Bedrock ids), so thread
+    # it through to those ctors too — otherwise the picker would be inert on the
+    # live bedrock_converse path. When `model` is None, ctor(None) preserves the
+    # exact env-resolution behavior.
     builders = {
-        "anthropic": lambda: AnthropicBackend(model=model),
-        "anthropic_compatible": lambda: AnthropicCompatibleBackend(model=model),
-        "bedrock": BedrockBackend,  # Anthropic-SDK path; resolves its own Bedrock model id
-        "bedrock_converse": BedrockConverseBackend,  # Converse API — any provider; resolves its own model id
-        "openai": lambda: OpenAIBackend(model=model),
-        "ollama": lambda: OllamaBackend(model=model),
+        "anthropic": lambda: AnthropicBackend(model=resolved_model),
+        "anthropic_compatible": lambda: AnthropicCompatibleBackend(model=resolved_model),
+        "bedrock": lambda: BedrockBackend(model=model),  # Anthropic-SDK path; else resolves its own id
+        "bedrock_converse": lambda: BedrockConverseBackend(model=model),  # Converse API — any provider
+        "openai": lambda: OpenAIBackend(model=resolved_model),
+        "ollama": lambda: OllamaBackend(model=resolved_model),
     }
     builder = builders.get(provider)
     if builder is None:
@@ -455,7 +506,7 @@ def make_llm_backend() -> (
             provider,
         )
         return CannedBackend()
-    logger.info("llm: using provider=%s model=%s", provider, model)
+    logger.info("llm: using provider=%s model=%s", provider, getattr(backend, "model_id", resolved_model))
     return backend
 
 

--- a/backend/tests/services/test_chat_service.py
+++ b/backend/tests/services/test_chat_service.py
@@ -220,3 +220,78 @@ class TestGetMessageCount:
             count = ChatService().get_message_count("0xv")
         assert count == 3
         session.close.assert_called_once()
+
+
+class TestGenerateAiResponse:
+    """P0 — the chat AI response must route through make_llm_backend(), not a
+    hardcoded premium Claude literal (silent cost-leak fix).
+    """
+
+    def test_no_hardcoded_model_literal_in_source(self) -> None:
+        """Anti-goal guard: the old hardcoded Sonnet id must be gone."""
+        import inspect
+
+        from archimedes.services import chat_service as mod
+
+        src = inspect.getsource(mod)
+        assert "claude-sonnet-4-20250514" not in src
+        # And the route is the provider-agnostic factory.
+        assert "make_llm_backend" in src
+
+    def test_routes_through_make_llm_backend(self) -> None:
+        """A real LLM response is produced via backend.complete(), and posted."""
+        svc = ChatService()
+        fake_backend = MagicMock()
+        fake_backend.available = True
+        fake_backend.complete.return_value = "  Backend-served reply.  "
+        with (
+            patch("archimedes.services.llm_backend.make_llm_backend", return_value=fake_backend),
+            patch.object(svc, "get_messages", return_value=[]),
+            patch.object(svc, "_build_vault_context", return_value="<vault_context/>"),
+            patch.object(svc, "post_ai_message", return_value={"id": 1, "message": "Backend-served reply."}) as post,
+        ):
+            result = svc._generate_ai_response("0xv", "@archimedes hi", "0xw")
+        # complete() is called with (system_prompt, user_prompt) — the seam, no model literal.
+        fake_backend.complete.assert_called_once()
+        assert result is not None
+        # Posted text is stripped backend output.
+        assert post.call_args.args[1] == "Backend-served reply."
+
+    def test_falls_back_to_canned_when_backend_unavailable(self) -> None:
+        """No credentials → canned response, not a crash."""
+        svc = ChatService()
+        fake_backend = MagicMock()
+        fake_backend.available = False
+        with (
+            patch("archimedes.services.llm_backend.make_llm_backend", return_value=fake_backend),
+            patch.object(svc, "_canned_response", return_value={"id": 9, "message": "canned"}) as canned,
+        ):
+            result = svc._generate_ai_response("0xv", "how is performance?", "0xw")
+        canned.assert_called_once()
+        assert result["message"] == "canned"
+
+    def test_chat_model_override_threaded_to_factory(self, monkeypatch) -> None:
+        """CHAT_MODEL (when set) is the named override passed to make_llm_backend()."""
+        import importlib
+
+        monkeypatch.setenv("CHAT_MODEL", "amazon.nova-lite-v1:0")
+        # Re-import so the module-level CHAT_MODEL picks up the env var.
+        from archimedes.services import chat_service as mod
+
+        importlib.reload(mod)
+        try:
+            svc = mod.ChatService()
+            fake_backend = MagicMock()
+            fake_backend.available = True
+            fake_backend.complete.return_value = "ok"
+            with (
+                patch("archimedes.services.llm_backend.make_llm_backend", return_value=fake_backend) as factory,
+                patch.object(svc, "get_messages", return_value=[]),
+                patch.object(svc, "_build_vault_context", return_value=""),
+                patch.object(svc, "post_ai_message", return_value={"id": 1}),
+            ):
+                svc._generate_ai_response("0xv", "hi", "0xw")
+            factory.assert_called_once_with(model="amazon.nova-lite-v1:0")
+        finally:
+            monkeypatch.delenv("CHAT_MODEL", raising=False)
+            importlib.reload(mod)

--- a/backend/tests/services/test_llm_backend_model_select.py
+++ b/backend/tests/services/test_llm_backend_model_select.py
@@ -1,0 +1,66 @@
+"""Coverage for the free-tier model allowlist + optional model override on
+``make_llm_backend()`` (P1 — functional model selection).
+
+Hermetic: no network, no AWS. The Converse/Anthropic backends are constructed
+without credentials so they degrade to the canned fallback; we assert on the
+model id resolution and the allowlist gate, not on live calls.
+"""
+
+from __future__ import annotations
+
+from archimedes.services.llm_backend import (
+    DEFAULT_CONVERSE_MODEL,
+    FREE_TIER_MODELS,
+    BedrockConverseBackend,
+    is_allowed_model,
+    make_llm_backend,
+)
+
+
+class TestAllowlist:
+    def test_free_tier_models_are_allowed(self) -> None:
+        # A representative sample of the free-tier ids.
+        for mid in ("amazon.nova-micro-v1:0", "zai.glm-4.7-flash", "amazon.nova-lite-v1:0"):
+            assert is_allowed_model(mid), mid
+
+    def test_premium_anthropic_models_are_rejected(self) -> None:
+        # The two premium (works_now:false) ids must NOT be selectable server-side.
+        assert not is_allowed_model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
+        assert not is_allowed_model("us.anthropic.claude-sonnet-4-6")
+        # Premium ids are absent from the allowlist set itself.
+        assert "us.anthropic.claude-haiku-4-5-20251001-v1:0" not in FREE_TIER_MODELS
+        assert "us.anthropic.claude-sonnet-4-6" not in FREE_TIER_MODELS
+
+    def test_none_and_junk_are_rejected(self) -> None:
+        assert not is_allowed_model(None)
+        assert not is_allowed_model("")
+        assert not is_allowed_model("totally-made-up-model")
+
+
+class TestModelOverride:
+    def test_override_threads_to_converse_ctor(self) -> None:
+        """A supplied model id wins over the env default on the Converse backend."""
+        backend = BedrockConverseBackend(model="zai.glm-4.7-flash")
+        assert backend.model_id == "zai.glm-4.7-flash"
+
+    def test_none_preserves_env_default(self) -> None:
+        """model=None (the default) → the env/default resolution, unchanged."""
+        backend = BedrockConverseBackend(model=None)
+        assert backend.model_id == DEFAULT_CONVERSE_MODEL
+
+    def test_factory_override_on_converse(self, monkeypatch) -> None:
+        """make_llm_backend(model=...) overrides for the bedrock_converse provider."""
+        monkeypatch.setenv("LLM_PROVIDER", "bedrock_converse")
+        backend = make_llm_backend(model="amazon.nova-lite-v1:0")
+        # No AWS creds in the hermetic env → canned fallback, but the override
+        # path must not raise. When creds ARE present the id would be Nova Lite.
+        assert backend is not None
+
+    def test_factory_default_unchanged_when_no_model(self, monkeypatch) -> None:
+        """No model arg → identical behavior to the pre-change factory."""
+        monkeypatch.setenv("LLM_PROVIDER", "bedrock_converse")
+        monkeypatch.setenv("LLM_BEDROCK_MODEL", "amazon.nova-micro-v1:0")
+        # Construct the backend directly to read the resolved id deterministically
+        # (the factory may return canned without creds).
+        backend = BedrockConverseBackend(model=None)
+        assert backend.model_id == "amazon.nova-micro-v1:0"

--- a/backend/tests/test_generate_model_gating.py
+++ b/backend/tests/test_generate_model_gating.py
@@ -1,0 +1,73 @@
+"""Server-side model allowlist gate on POST /api/generate/start (P1).
+
+The Generate page may send an optional ``model``. The server honors it ONLY
+when it is an allowlisted free-tier id (defense in depth — the UI also disables
+premium rows). A non-allowlisted or absent model is dropped and the pipeline
+falls back to the env default → behavior UNCHANGED.
+
+Hermetic: the Redis-backed job store is mocked at the boundary, and the
+fire-and-forget pipeline task is patched out so no LLM/network call happens.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _mock_store() -> MagicMock:
+    store = MagicMock()
+    store.enqueue = AsyncMock(return_value="job-abc")
+    return store
+
+
+def _start(model_value):
+    """POST /start with the given model field; return (status, captured_payload)."""
+    store = _mock_store()
+    body = {
+        "brief": {"intent": "low-vol treasury alternative with crypto upside", "risk_appetite": "moderate"},
+    }
+    if model_value is not None:
+        body["model"] = model_value
+
+    with (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        # Patch the background task factory so the pipeline never actually runs.
+        patch("archimedes.api.generate_routes.asyncio.create_task", return_value=MagicMock()),
+    ):
+        resp = _client().post("/api/generate/start", json=body)
+    captured = store.enqueue.call_args.kwargs["payload"] if store.enqueue.call_args else {}
+    return resp, captured
+
+
+def test_allowlisted_model_is_honored() -> None:
+    resp, payload = _start("zai.glm-4.7-flash")
+    assert resp.status_code == 202, resp.text
+    assert payload.get("model") == "zai.glm-4.7-flash"
+
+
+def test_premium_model_is_dropped() -> None:
+    """A premium (gated) id must be ignored → model None → env default."""
+    resp, payload = _start("us.anthropic.claude-sonnet-4-6")
+    assert resp.status_code == 202, resp.text
+    assert payload.get("model") is None
+
+
+def test_junk_model_is_dropped() -> None:
+    resp, payload = _start("not-a-real-model")
+    assert resp.status_code == 202, resp.text
+    assert payload.get("model") is None
+
+
+def test_absent_model_unchanged_behavior() -> None:
+    """No model field → model None in payload → pipeline uses env default."""
+    resp, payload = _start(None)
+    assert resp.status_code == 202, resp.text
+    assert payload.get("model") is None

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -38,6 +38,10 @@ export default function Generate({ onNavigate }) {
   const [depth, setDepth] = useState(5)       // replaces max_papers UI
   const [starting, setStarting] = useState(false)
   const [startError, setStartError] = useState('')
+  // Optional free-tier model pick from ModelCostPanel. null → backend env
+  // default (unchanged behavior). Premium models are never selectable here; the
+  // server also allowlists, so a non-free id can't ride this field through.
+  const [selectedModel, setSelectedModel] = useState(null)
 
   // ── Agent / SSE path ──
   const [jobId, setJobId] = useState(() => localStorage.getItem(STORAGE_JOB_KEY) || null)
@@ -93,6 +97,9 @@ export default function Generate({ onNavigate }) {
     setStarting(true)
     // Mode is intentionally omitted — the backend's _pick_pipeline() auto-routes
     // between Fusion / Architect / Agent; the choice is surfaced in the SSE stream.
+    // `model` is sent only when the user picked a free-tier model; the server
+    // re-validates it against a free-tier allowlist and falls back to the env
+    // default otherwise, so omitting it keeps the current behavior.
     const payload = {
       brief: {
         intent,
@@ -100,6 +107,7 @@ export default function Generate({ onNavigate }) {
         asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
         max_papers: depth,
       },
+      ...(selectedModel ? { model: selectedModel } : {}),
     }
     const postStart = () =>
       fetch(`${API_BASE}/api/generate/start`, {
@@ -462,7 +470,7 @@ export default function Generate({ onNavigate }) {
       {/* ── Model & cost transparency (which LLM is running + the cost landscape).
           Inside the wallet gate — only shown to connected users. ── */}
       {!jobId && !fusionJobId && !fusionResult && (
-        <ModelCostPanel />
+        <ModelCostPanel selectedModel={selectedModel} onSelectModel={setSelectedModel} />
       )}
 
       {/* ── SSE STREAM (agent + architect paths) ── */}

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -99,6 +99,7 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
   const [events, setEvents] = useState([])
   const [terminal, setTerminal] = useState(null)  // 'done' | 'error' | null
   const [strategyId, setStrategyId] = useState(null)
+  const [servedModel, setServedModel] = useState(null)  // provenance: model that actually ran
   const [errorMsg, setErrorMsg] = useState('')
   const [showRejected, setShowRejected] = useState(false)
   const [draftedCandidates, setDraftedCandidates] = useState([])  // {candidate_id, strategy_name, regime, strategy_id}
@@ -111,6 +112,7 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
     setEvents([])
     setTerminal(null)
     setStrategyId(null)
+    setServedModel(null)
     setErrorMsg('')
 
     const url = `${API_BASE}/api/generate/stream/${encodeURIComponent(jobId)}`
@@ -148,10 +150,12 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
       if (name === 'done') {
         setTerminal('done')
         if (data?.strategy_id) setStrategyId(data.strategy_id)
+        if (data?.served_model) setServedModel(data.served_model)
         es.close()
         onDone?.({
           strategy_id: data?.strategy_id,
           all_strategy_ids: data?.all_strategy_ids,
+          served_model: data?.served_model,
         })
       }
       if (name === 'error') {
@@ -190,6 +194,9 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
           {terminal === 'done' && (
             <div className="positive caption" style={{ marginTop: 4 }}>
               <span className="i-lucide-check w-3.5 h-3.5 mr-1" /> Strategy persisted{strategyId ? ` as ${strategyId}` : ''}
+              {servedModel && servedModel !== 'fixture' && (
+                <span style={{ color: 'var(--text-3)' }}> · served by <strong>{servedModel}</strong></span>
+              )}
             </div>
           )}
           {terminal === 'error' && (

--- a/ui/src/components/ModelCostPanel.jsx
+++ b/ui/src/components/ModelCostPanel.jsx
@@ -2,16 +2,24 @@ import { useEffect, useMemo, useState } from 'react'
 import { apiGet } from '../api'
 import pricing from '../data/modelPricing.json'
 
-// Cost-comparison panel for the Generate page. Surfaces the Bedrock model cost
-// landscape (us-east-1 on-demand, $/1M tokens) and highlights the model the
-// backend is actually using right now (from /health → llm_model). Collapsible so
-// it stays out of the way until a user wants to compare costs. The data is a
-// snapshot (ui/src/data/modelPricing.json); the active row is live.
+// Cost-comparison + model picker for the Generate page. Surfaces the Bedrock
+// model cost landscape (us-east-1 on-demand, $/1M tokens), highlights the model
+// the backend is actually using right now (from /health → llm_model), and lets
+// the user PICK a model for the next generation.
+//
+// SAFETY (critical): only FREE/default-tier models (works_now:true) are
+// selectable. Premium rows (Claude Haiku/Sonnet — works_now:false) stay
+// display-only with a "Paid tier — unlock coming soon" affordance; selecting
+// them is a no-op until the paid-tier 402 entitlement (#723) lands. The server
+// re-enforces this allowlist, so the UI restriction is defense-in-depth.
+//
+// `selectedModel` / `onSelectModel` lift the choice into the Generate flow. The
+// data is a snapshot (ui/src/data/modelPricing.json); the active row is live.
 
 const blended = (m) => m.input * 0.75 + m.output * 0.25
 const fmt = (x) => (x == null ? '—' : `$${x.toFixed(x < 1 ? 3 : 2)}`)
 
-export default function ModelCostPanel() {
+export default function ModelCostPanel({ selectedModel = null, onSelectModel }) {
   const [open, setOpen] = useState(false)
   const [activeModel, setActiveModel] = useState(null)
 
@@ -25,6 +33,16 @@ export default function ModelCostPanel() {
 
   const rows = useMemo(() => [...pricing.models].sort((a, b) => blended(a) - blended(b)), [])
   const active = rows.find((m) => m.model_id && m.model_id === activeModel)
+  // The chosen model row (for the collapsed-header summary), if any.
+  const chosen = rows.find((m) => m.model_id && m.model_id === selectedModel)
+
+  // Free-tier-only selection. Premium rows are never selectable here.
+  const selectable = (m) => Boolean(m.works_now && m.model_id && onSelectModel)
+  const handleSelect = (m) => {
+    if (!selectable(m)) return
+    // Toggle: re-clicking the chosen row clears the override (back to default).
+    onSelectModel(m.model_id === selectedModel ? null : m.model_id)
+  }
 
   return (
     <div className="card mb-4" style={{ padding: 0, overflow: 'hidden' }}>
@@ -41,7 +59,10 @@ export default function ModelCostPanel() {
         <div>
           <div className="label" style={{ marginBottom: 2 }}>Model &amp; cost</div>
           <div className="caption" style={{ color: 'var(--text-3)' }}>
-            {active ? (
+            {chosen ? (
+              <>Will run <strong style={{ color: 'var(--text-1)' }}>{chosen.provider} {chosen.name}</strong>
+                {' · '}{fmt(chosen.input)} in / {fmt(chosen.output)} out per 1M tokens</>
+            ) : active ? (
               <>Running <strong style={{ color: 'var(--text-1)' }}>{active.provider} {active.name}</strong>
                 {' · '}{fmt(active.input)} in / {fmt(active.output)} out per 1M tokens</>
             ) : activeModel ? (
@@ -62,7 +83,7 @@ export default function ModelCostPanel() {
           <p className="caption mb-3" style={{ color: 'var(--text-3)' }}>
             {pricing.unit} · {pricing.region} · snapshot {pricing.generated}. Cheaper is usually
             less capable — pick for your budget. <strong style={{ color: '#3fb950' }}>✓</strong> = invokable
-            now; <strong>premium</strong> models need a one-time account activation.
+            now and selectable; <strong>premium</strong> models are <em>Paid tier — unlock coming soon</em>.
           </p>
           <div style={{ overflowX: 'auto' }}>
             <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
@@ -77,29 +98,49 @@ export default function ModelCostPanel() {
               <tbody>
                 {rows.map((m) => {
                   const isActive = m.model_id && m.model_id === activeModel
+                  const isChosen = m.model_id && m.model_id === selectedModel
+                  const canSelect = selectable(m)
                   return (
                     <tr
                       key={m.model_id || m.name}
+                      onClick={() => handleSelect(m)}
+                      role={canSelect ? 'button' : undefined}
+                      aria-disabled={canSelect ? undefined : true}
+                      aria-pressed={canSelect ? isChosen : undefined}
+                      title={
+                        canSelect
+                          ? 'Use this model for the next generation'
+                          : 'Paid tier — unlock coming soon'
+                      }
                       style={{
                         borderTop: '1px solid var(--glass-border)',
-                        background: isActive ? 'color-mix(in srgb, var(--accent) 12%, transparent)' : 'transparent',
+                        cursor: canSelect ? 'pointer' : 'not-allowed',
+                        opacity: m.works_now ? 1 : 0.55,
+                        background: isChosen
+                          ? 'color-mix(in srgb, var(--accent) 18%, transparent)'
+                          : isActive
+                            ? 'color-mix(in srgb, var(--accent) 12%, transparent)'
+                            : 'transparent',
                       }}
                     >
                       <td style={{ padding: '7px 8px', color: 'var(--text-1)' }}>
-                        <span style={{ fontWeight: isActive ? 600 : 400 }}>{m.name}</span>
+                        <span style={{ fontWeight: (isActive || isChosen) ? 600 : 400 }}>{m.name}</span>
                         <span className="caption" style={{ color: 'var(--text-3)', marginLeft: 6 }}>{m.provider}</span>
                       </td>
                       <td style={{ padding: '7px 8px', textAlign: 'right', color: 'var(--text-1)', fontVariantNumeric: 'tabular-nums' }}>{fmt(m.input)}</td>
                       <td style={{ padding: '7px 8px', textAlign: 'right', color: 'var(--text-1)', fontVariantNumeric: 'tabular-nums' }}>{fmt(m.output)}</td>
                       <td style={{ padding: '7px 8px', whiteSpace: 'nowrap' }}>
-                        {isActive && <span className="tag tag-accent" style={{ marginRight: 4 }}>active</span>}
-                        {m.recommended && !isActive && (
+                        {isChosen && <span className="tag tag-accent" style={{ marginRight: 4 }}>selected</span>}
+                        {isActive && !isChosen && <span className="tag tag-accent" style={{ marginRight: 4 }}>active</span>}
+                        {m.recommended && !isActive && !isChosen && (
                           <span style={{ color: 'var(--accent)', marginRight: 4 }} title="Recommended cheap pick">★</span>
                         )}
                         {m.works_now ? (
                           <span style={{ color: '#3fb950' }} title="Invokable now">✓</span>
                         ) : (
-                          <span className="caption" style={{ color: 'var(--text-3)' }}>premium</span>
+                          <span className="caption" style={{ color: 'var(--text-3)' }} title="Paid tier — unlock coming soon">
+                            Paid tier — soon
+                          </span>
                         )}
                       </td>
                     </tr>
@@ -108,6 +149,18 @@ export default function ModelCostPanel() {
               </tbody>
             </table>
           </div>
+          {chosen && (
+            <p className="caption mt-3" style={{ color: 'var(--accent)' }}>
+              Selected <strong>{chosen.provider} {chosen.name}</strong> for your next generation.{' '}
+              <button
+                type="button"
+                onClick={() => onSelectModel?.(null)}
+                style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', textDecoration: 'underline', padding: 0 }}
+              >
+                Use default
+              </button>
+            </p>
+          )}
           <p className="caption mt-3" style={{ color: 'var(--text-3)' }}>{pricing.note}</p>
         </div>
       )}

--- a/ui/src/components/ModelCostPanel.jsx
+++ b/ui/src/components/ModelCostPanel.jsx
@@ -9,7 +9,7 @@ import pricing from '../data/modelPricing.json'
 //
 // SAFETY (critical): only FREE/default-tier models (works_now:true) are
 // selectable. Premium rows (Claude Haiku/Sonnet — works_now:false) stay
-// display-only with a "Paid tier — unlock coming soon" affordance; selecting
+// display-only with a "Premium model — activating soon (pending Bedrock approval)" affordance; selecting
 // them is a no-op until the paid-tier 402 entitlement (#723) lands. The server
 // re-enforces this allowlist, so the UI restriction is defense-in-depth.
 //
@@ -83,7 +83,7 @@ export default function ModelCostPanel({ selectedModel = null, onSelectModel }) 
           <p className="caption mb-3" style={{ color: 'var(--text-3)' }}>
             {pricing.unit} · {pricing.region} · snapshot {pricing.generated}. Cheaper is usually
             less capable — pick for your budget. <strong style={{ color: '#3fb950' }}>✓</strong> = invokable
-            now and selectable; <strong>premium</strong> models are <em>Paid tier — unlock coming soon</em>.
+            now and selectable; <strong>premium</strong> models (Claude) are <em>activating soon — pending AWS Bedrock approval</em>.
           </p>
           <div style={{ overflowX: 'auto' }}>
             <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
@@ -110,7 +110,7 @@ export default function ModelCostPanel({ selectedModel = null, onSelectModel }) 
                       title={
                         canSelect
                           ? 'Use this model for the next generation'
-                          : 'Paid tier — unlock coming soon'
+                          : 'Premium model — activating soon (pending Bedrock approval)'
                       }
                       style={{
                         borderTop: '1px solid var(--glass-border)',
@@ -138,8 +138,8 @@ export default function ModelCostPanel({ selectedModel = null, onSelectModel }) 
                         {m.works_now ? (
                           <span style={{ color: '#3fb950' }} title="Invokable now">✓</span>
                         ) : (
-                          <span className="caption" style={{ color: 'var(--text-3)' }} title="Paid tier — unlock coming soon">
-                            Paid tier — soon
+                          <span className="caption" style={{ color: 'var(--text-3)' }} title="Premium model — activating soon (pending Bedrock approval)">
+                            Premium · soon
                           </span>
                         )}
                       </td>


### PR DESCRIPTION
## Summary

One PR delivering **P0 + P1** from the payment-cost strategy brief: make the Generate-page model picker actually functional (it was a cosmetic table) and close a silent premium-model cost leak in vault chat. **No contracts touched. No secrets.**

## P0 — fix the silent premium cost leak

`chat_service._generate_ai_response()` hardcoded `model="claude-sonnet-4-20250514"` and called the raw Anthropic SDK directly, bypassing `make_llm_backend()` entirely — so every `@archimedes` chat mention silently billed a premium Sonnet call instead of the cheap Bedrock/Nova default the rest of the app uses.

**Fix:** route chat through `make_llm_backend(model=CHAT_MODEL)` (the provider-agnostic factory + `complete()` seam). `CHAT_MODEL` is an **opt-in named env override** defaulting to `None` → the cheap env-resolved model applies. No hardcoded model literal remains (guarded by a source-grep test). Canned fallback preserved when no backend is available.

## P1 — functional, safe-by-default model selection

| Layer | Change |
|---|---|
| `llm_backend.py` | `make_llm_backend(model=...)` optional override threaded into the backend ctors (incl. the Bedrock Converse seam). New `FREE_TIER_MODELS` allowlist + `is_allowed_model()`. |
| `generate_schemas.py` / `generate_routes.py` | Optional `model` field on the start request; **validated server-side against the free-tier allowlist** (defense in depth). Non-allowlisted / absent → falls back to env default. Propagated into the live generation path via a per-job `PortfolioAgent` bound to the picked model. |
| Provenance | `served_model` surfaced on the `done` SSE event; `GenerationStream.jsx` shows "served by &lt;model&gt;". |
| `ModelCostPanel.jsx` | Rows are now **selectable — but only FREE/default-tier (`works_now:true`) models.** Premium rows (Claude Haiku/Sonnet) stay display-only, dimmed, with a **"Paid tier — unlock coming soon"** affordance; clicking them is a no-op. Selection lifts into `Generate.jsx`, which sends it as `model`. |

### Safety design (free-tier-only + server-side allowlist)

- **UI restriction:** premium rows are never selectable (`selectable()` requires `works_now`).
- **Server allowlist (defense in depth):** even a hand-crafted request can't route a free user onto a premium model — the route drops any non-allowlisted `model` and uses the env default. `FREE_TIER_MODELS` mirrors the `works_now:true` rows in `modelPricing.json`; the two premium Anthropic ids are deliberately absent.
- **Default behavior UNCHANGED:** when no model is selected (or a junk/premium id is sent), `model` resolves to `None` → the exact pre-change env-default path.

This is intentionally orthogonal to **#723** (paid-tier HTTP-402 entitlement), which stacks on top to unlock premium models behind the 402 gate.

## Validation (conda env: `archimedes`)

- **ruff** (changed Python): blocking subset `E9,F63,F7,F40,F82` → **All checks passed**; general `ruff check` → **All checks passed**; `ruff format --check` → **8 files already formatted**.
- **eslint** (changed JSX) + full `npm run lint` → **clean, exit 0**.
- **vite build** → **✓ built in 4.06s** (only pre-existing chunk-size / dynamic-import warnings).
- **pytest** (hermetic, `env -i … PYTHONPATH=backend`): focused + regression suites across chat / llm_backend / generation pipeline / generate routes → **85 passed, 0 failed**. Includes new tests:
  - `test_chat_service.py` — no hardcoded literal, routes through factory, `CHAT_MODEL` override, canned fallback.
  - `test_llm_backend_model_select.py` — allowlist accepts free / rejects premium+junk+None; override threads to ctor; `model=None` preserves env default.
  - `test_generate_model_gating.py` — allowlisted honored; premium / junk / absent dropped → env default.
- **Default-unchanged proof:** `make_llm_backend()` with no provider/model returns `CannedBackend` exactly as before; `BedrockConverseBackend(model=None).model_id == DEFAULT_CONVERSE_MODEL`.

## Follow-ups

- `FREE_TIER_MODELS` (backend) and `modelPricing.json` (UI) are two hand-maintained lists of the same free-tier set — worth unifying into one SSOT later.
- Premium models become selectable only once **#723**'s 402 entitlement lands.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M