### PR TITLE
T1.2 nanopayment marketplace scaffold (first draft) !minor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,6 +209,19 @@ VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32
 REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6
 ASSET_REGISTRY_ADDRESS=0x2d44550711137916df6175587d17886281a0fbc7
 STRATEGY_REGISTRY_ADDRESS=0x728C264d0681b71c4Cc1D26a4fb14Ec29D9a90e4
+# RevenueSplit (x402 nanopayment marketplace, T1.2) — 90/10 creator/platform
+# splitter that the x402 facilitator settles paid /construct requests into.
+# Leave BLANK until DeployRevenueSplit.s.sol is run; required only when the
+# paywall is armed (ARCHIMEDES_X402_ENABLED=1). Non-secret address.
+REVENUE_SPLIT_ADDRESS=
+
+# ── x402 nanopayment paywall (T1.2) ───────────────────────────────────────
+# Master flag for the optional-publish marketplace paywall. Default OFF — the
+# x402 dependency is a no-op until set to 1. When ON, POST /api/strategies/construct
+# requires a sub-cent USDC payment settled via Circle Gateway.
+ARCHIMEDES_X402_ENABLED=0
+# Per-payer daily spend cap in USDC (testnet default 0.10).
+ARCHIMEDES_X402_MAX_USDC_PER_DAY=0.10
 
 # ── Contract addresses the BACKEND reads (ChainSettings, env_prefix=ARC_) ──
 # Externalized contract addresses (roadmap T2.3). ChainSettings in

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 
 # Buffer files
 *~
-
 # Python
 __pycache__/
 *.py[cod]
@@ -15,13 +14,11 @@ build/
 .venv/
 venv/
 *.egg
-
 # Node
 node_modules/
 .next/
 .vite/
 .vite-temp/
-
 # Foundry
 contracts/cache/
 contracts/out/
@@ -32,43 +29,34 @@ contracts/broadcast/
 contracts/lib/*
 !contracts/lib/forge-std
 !contracts/lib/openzeppelin-contracts
-
 # OS
 .DS_Store
 Thumbs.db
-
 # Local dev helpers (process PIDs from dev-server scripts; per-machine state)
 .dev-pids/
-
 # IDE
 .vscode/
 .idea/
 *.swp
 *.swo
-
 # Wallet / secrets
 wallet-setup/recovery_file.dat
 *.keystore
 *.key
-
 # Terraform
 infra/.terraform/
 infra/.terraform.lock.hcl
 infra/terraform.tfstate
 infra/terraform.tfstate.backup
-
 # Secrets / credentials — global patterns (never commit these)
 *.pem
-*.key
 *.p12
 *.pfx
 *.crt
 *.tfstate*
-
 # arXiv corpus — track the manifest + README, not the cached binaries
 data/corpus/pdfs/
 data/corpus/text/
-
 # Local SQLite fallback — backend/archimedes/db.py defaults to
 # sqlite:///./archimedes_chat.db when DATABASE_URL is unset (e.g. pytest or
 # the backend run outside docker-compose). Never commit it: an out-of-container
@@ -77,31 +65,29 @@ archimedes_chat.db
 *.db
 *.sqlite
 *.sqlite3
-
 # Per-deploy contract-address dump — written by
 # backend/archimedes/scripts/deploy_contracts.py on every redeploy and goes
 # stale the moment a contract is redeployed. NOT a source of truth — see
 # infra/README.md "Per-deploy artifacts"; ui/src/config.js and
 # backend/archimedes/chain/client.py are authoritative (audit 06-14 I3).
 /deploy_output.json
-
 # Fitted GMM regime model — data-derived (yfinance) + stale-prone; produced
 # offline by scripts/fit_gmm_regime.py and loaded at runtime by
 # GmmRegimeDetector. Never commit it (issue #661); the detector falls back to
 # the rule-based VixRegimeDetector when it is absent.
 backend/archimedes/services/gmm_model.pkl
-
 # Misc
 *.log
 .pytest_cache/
 .coverage
 htmlcov/
-
 .loom/
 !.loom/loom.config.json
-.venv/
 .claude/
 
 # Terraform local provider cache / lock in ANY (incl. nested) module dir
 **/.terraform/
 **/.terraform.lock.hcl
+
+# Foundry-installed contract dependencies
+contracts/lib/

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -229,6 +229,11 @@ class StrategyResponse(BaseModel):
     return_source: str = "noise"  # "risk_premium" | "mispricing" | "productive_growth" | "noise"
     return_source_note: str = ""
 
+    # Nanopayment marketplace (T1.2) — true when the x402 paywall is armed for
+    # constructing this strategy. Drives the "Pay per run" disclosure chip in the
+    # Marketplace UI. Single boolean for the first slice (one paywalled route).
+    is_paywalled: bool = False
+
 
 class StrategyListResponse(BaseModel):
     strategies: list[StrategyResponse]

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -35,6 +35,7 @@ from archimedes.api.schemas import (
     StrategySignalResponse,
     StrategySignalsResponse,
 )
+from archimedes.api.x402_middleware import x402_enabled, x402_paywall
 from archimedes.models.strategy import Strategy, StrategyStatus
 from archimedes.services.construction_trace import build_construction_trace
 from archimedes.services.live_rigor_gate import (
@@ -150,6 +151,9 @@ def _to_strategy_response(s: Strategy, verdict: RigorGateVerdict | None = None) 
         regime_tag=s.regime_tag,
         return_source=return_source,
         return_source_note=return_source_note,
+        # T1.2: constructing a strategy is paywalled exactly when the x402
+        # marketplace flag is armed. Single boolean drives the Marketplace chip.
+        is_paywalled=x402_enabled(),
     )
 
 
@@ -1273,6 +1277,8 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
         regime_tag=record.regime_tag,
         return_source=return_source_enum.value,
         return_source_note=return_source_note,
+        # T1.2: see _to_strategy_response — paywalled when the x402 flag is armed.
+        is_paywalled=x402_enabled(),
     )
 
 
@@ -1680,6 +1686,13 @@ async def _run_fusion_job(job_id: str) -> None:
 # ── Construct (architect interactive) ─────────────────────────
 
 
+#: x402 nanopayment paywall for the strategy-construction endpoint (T1.2).
+#: A no-op when ARCHIMEDES_X402_ENABLED is unset; when armed it charges a fixed
+#: sub-cent USDC price into the deployed RevenueSplit (90/10 creator/platform).
+#: This is the ONLY paywalled route in this PR — applied per-route, never global.
+CONSTRUCT_PRICE_USDC = 0.001
+
+
 @strategies_router.post("/construct", response_model=StrategyConstructionResponse)
 @limiter.limit("20/minute")
 async def construct_strategy(
@@ -1687,6 +1700,7 @@ async def construct_strategy(
     request: Request,  # noqa: ARG001 — required by the slowapi limiter / FastAPI
     response: Response,  # noqa: ARG001 — kept for FastAPI handler symmetry
     _wallet: str | None = Depends(gate_generation),
+    _payment: dict | None = Depends(x402_paywall(CONSTRUCT_PRICE_USDC, resource_path="/api/strategies/construct")),
 ):
     """Interactive strategy architect -- the 'design me a portfolio' path."""
     from fastapi import HTTPException

--- a/backend/archimedes/api/x402_middleware.py
+++ b/backend/archimedes/api/x402_middleware.py
@@ -1,0 +1,311 @@
+"""Generic x402 paywall — a reusable FastAPI dependency.
+
+This is the first slice of the optional-publish nanopayment marketplace
+(issue #713 / roadmap T1.2). It implements the seller side of the x402 open
+payment standard (HTTP `402 Payment Required`) backed by Circle's Gateway
+facilitator for gasless, sub-cent USDC settlement on Arc.
+
+Design: GENERIC + opt-in per route. `x402_paywall(price_usdc, recipient)`
+returns a FastAPI dependency you attach to ANY route with a configurable price
+and recipient address. In THIS PR it is wired to exactly one endpoint
+(`POST /api/strategies/construct`), but the factory shape is deliberate — a
+sibling use-case (charging per *generation*, 100% to the platform to cover
+inference cost) will reuse it on the generate route in a follow-up.
+
+Flow (per `submodules/context-arc/docs/.../nanopayments/concepts/x402.md`):
+  1. No `PAYMENT-SIGNATURE` header  → 402 + a `PAYMENT-REQUIRED` header naming
+     Arc testnet, the recipient `RevenueSplit` address, and the USDC price.
+  2. With `PAYMENT-SIGNATURE`       → settle via Circle Gateway
+     (`POST {CIRCLE_GW_BASE}/x402/settle`); gate the handler on `success: true`.
+  3. Per-payer spend cap            → 429 when a payer wallet exceeds the daily
+     USDC cap (24h sliding window in Redis).
+
+Feature flag: `ARCHIMEDES_X402_ENABLED=1` arms the paywall. Default OFF → the
+dependency is a no-op passthrough, so attaching it to a route never changes
+behavior until the flag is set.
+
+The Circle facilitator base URL is imported from `circle_service.CIRCLE_GW_BASE`
+(not redeclared) per the spec's anti-goal on duplicating that constant.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+
+import aiohttp
+from fastapi import HTTPException, Request
+
+from archimedes.services.circle_service import CIRCLE_GW_BASE
+
+logger = logging.getLogger(__name__)
+
+# ── Config (env-driven; all non-secret) ──────────────────────────────────────
+
+#: Master feature flag. When unset/0, every x402 dependency is a no-op.
+FLAG_ENV = "ARCHIMEDES_X402_ENABLED"
+
+#: Deployed RevenueSplit address (the default recipient). Non-secret; lives in
+#: .env.example mirroring STRATEGY_REGISTRY_ADDRESS.
+REVENUE_SPLIT_ADDRESS_ENV = "REVENUE_SPLIT_ADDRESS"
+
+#: Per-payer daily spend cap in USDC (testnet default 0.10).
+MAX_USDC_PER_DAY_ENV = "ARCHIMEDES_X402_MAX_USDC_PER_DAY"
+DEFAULT_MAX_USDC_PER_DAY = 0.10
+
+#: Arc testnet chain id (CAIP-2 `eip155:5042002`); matches chain/client.py.
+ARC_CHAIN_ID = 5042002
+ARC_NETWORK_CAIP2 = f"eip155:{ARC_CHAIN_ID}"
+
+#: USDC token address on Arc (matches chain/client.py default).
+ARC_USDC_ADDRESS = "0x3600000000000000000000000000000000000000"
+
+#: 24h sliding-window length for the spend cap, in seconds.
+SPEND_WINDOW_SECONDS = 24 * 60 * 60
+
+
+def x402_enabled() -> bool:
+    """True when the paywall is armed (`ARCHIMEDES_X402_ENABLED=1`)."""
+    return os.getenv(FLAG_ENV, "").strip() in {"1", "true", "True", "yes"}
+
+
+def _max_usdc_per_day() -> float:
+    raw = os.getenv(MAX_USDC_PER_DAY_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MAX_USDC_PER_DAY
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to %s", MAX_USDC_PER_DAY_ENV, raw, DEFAULT_MAX_USDC_PER_DAY)
+        return DEFAULT_MAX_USDC_PER_DAY
+
+
+# ── Per-payer spend cap (Redis, 24h sliding window) ───────────────────────────
+
+
+class SpendCapStore:
+    """Thin Redis wrapper for the per-payer daily USDC spend cap.
+
+    Keyed on the *payer wallet address* from the verified payment payload (there
+    is no embedded wallet per user yet — that's downstream of Dan's passkey fix).
+    Uses a sorted set per payer scored by unix-ts; entries older than 24h are
+    trimmed on each read. Mirrors the `AgentStateStore` shape in
+    `services/redis_state.py` (lazy `aioredis.from_url`), and is mocked at this
+    boundary in tests so the suite stays hermetic (no live Redis).
+    """
+
+    KEY_PREFIX = "archimedes:x402:spend:"
+
+    def __init__(self, url: str | None = None) -> None:
+        self._url = url or os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        self._redis = None
+
+    async def _get_redis(self):
+        if self._redis is None:
+            import redis.asyncio as aioredis
+
+            self._redis = aioredis.from_url(self._url, decode_responses=True)
+        return self._redis
+
+    async def amount_spent(self, payer: str, *, now: float | None = None) -> float:
+        """Total USDC spent by `payer` inside the trailing 24h window."""
+        r = await self._get_redis()
+        key = f"{self.KEY_PREFIX}{payer.lower()}"
+        now = time.time() if now is None else now
+        cutoff = now - SPEND_WINDOW_SECONDS
+        await r.zremrangebyscore(key, 0, cutoff)
+        members = await r.zrange(key, 0, -1)
+        total = 0.0
+        for m in members:
+            # member format: "<unix_ts>:<amount_usdc>"
+            try:
+                total += float(str(m).split(":", 1)[1])
+            except (IndexError, ValueError):
+                continue
+        return total
+
+    async def record(self, payer: str, amount_usdc: float, *, now: float | None = None) -> None:
+        """Record a `payer` charge of `amount_usdc` at `now`."""
+        r = await self._get_redis()
+        key = f"{self.KEY_PREFIX}{payer.lower()}"
+        now = time.time() if now is None else now
+        member = f"{now}:{amount_usdc}"
+        await r.zadd(key, {member: now})
+        await r.expire(key, SPEND_WINDOW_SECONDS)
+
+
+#: Module-level default store. Tests patch `SpendCapStore` methods at this
+#: boundary (per CLAUDE.md "Testing conventions" §"Mock at boundaries").
+_spend_store = SpendCapStore()
+
+
+# ── Circle Gateway facilitator settlement ─────────────────────────────────────
+
+
+async def _settle_with_facilitator(payment_payload: dict, requirements: dict) -> dict:
+    """Settle an x402 payment via Circle Gateway.
+
+    POSTs to `{CIRCLE_GW_BASE}/x402/settle` (see the Gateway OpenAPI
+    `/v1/x402/settle`). Returns the parsed settlement result
+    (`{success, payer, transaction, network, errorReason?}`). Raises on a
+    non-200 facilitator response so the caller maps it to a 402.
+
+    Mocked at the `aiohttp` boundary in tests — no live Circle call.
+    """
+    url = f"{CIRCLE_GW_BASE}/x402/settle"
+    body = {"paymentPayload": payment_payload, "paymentRequirements": requirements}
+    async with aiohttp.ClientSession() as session, session.post(url, json=body) as resp:
+        if resp.status != 200:
+            text = await resp.text()
+            logger.warning("x402 facilitator non-200 (%s): %s", resp.status, text[:200])
+            raise HTTPException(status_code=402, detail="Payment settlement failed")
+        return await resp.json()
+
+
+# ── Payment requirements / header helpers ─────────────────────────────────────
+
+
+def _recipient_address(explicit: str | None) -> str:
+    return explicit or os.getenv(REVENUE_SPLIT_ADDRESS_ENV, "").strip()
+
+
+def _build_requirements(price_usdc: float, recipient: str, resource_path: str) -> dict:
+    """Build the x402 `paymentRequirements` block (exact scheme, Arc testnet)."""
+    # USDC has 6 decimals; amount is the integer base-unit string.
+    amount_base_units = str(int(round(price_usdc * 1_000_000)))
+    return {
+        "scheme": "exact",
+        "network": ARC_NETWORK_CAIP2,
+        "asset": ARC_USDC_ADDRESS,
+        "amount": amount_base_units,
+        "maxTimeoutSeconds": 604900,
+        "payTo": recipient,
+        "resource": resource_path,
+    }
+
+
+def _payment_required_header(price_usdc: float, recipient: str, resource_path: str) -> str:
+    """Base64-encoded `PAYMENT-REQUIRED` header value (x402 v2)."""
+    payment_required = {
+        "x402Version": 2,
+        "resource": {
+            "url": resource_path,
+            "description": "Archimedes strategy construction",
+            "mimeType": "application/json",
+        },
+        "accepts": [_build_requirements(price_usdc, recipient, resource_path)],
+    }
+    return base64.b64encode(json.dumps(payment_required).encode()).decode()
+
+
+def _decode_payment_signature(raw: str) -> dict:
+    """Decode the base64 `PAYMENT-SIGNATURE` header into the payment payload."""
+    try:
+        return json.loads(base64.b64decode(raw).decode())
+    except Exception as exc:
+        # Any decode failure (bad base64 / non-JSON) → 402, never a 500.
+        raise HTTPException(status_code=402, detail="Malformed PAYMENT-SIGNATURE") from exc
+
+
+def _payer_from_payload(payload: dict, settlement: dict) -> str:
+    """Best-effort payer wallet extraction (settlement result, then payload)."""
+    payer = settlement.get("payer")
+    if payer:
+        return str(payer)
+    # Fall back to the EIP-3009 `from` field in the authorization.
+    auth = (payload.get("payload") or {}).get("authorization") or {}
+    return str(auth.get("from", "")) or "unknown"
+
+
+# ── The reusable dependency factory ───────────────────────────────────────────
+
+
+def x402_paywall(
+    price_usdc: float,
+    *,
+    recipient: str | None = None,
+    resource_path: str = "",
+) -> Callable[[Request], Awaitable[dict | None]]:
+    """Build a FastAPI dependency that paywalls a route via x402.
+
+    Args:
+        price_usdc:   Price per request in USDC (e.g. 0.001 for a sub-cent slice).
+        recipient:    Destination address for settlement. Defaults to the deployed
+                      `RevenueSplit` (env `REVENUE_SPLIT_ADDRESS`). A follow-up
+                      generation paywall passes the platform address here for the
+                      100%-to-platform case.
+        resource_path: The route path, surfaced in the PAYMENT-REQUIRED header.
+
+    Returns:
+        An async dependency. When the flag is OFF it is a no-op (returns None).
+        When ON it enforces 402 / settle / 429 and returns the payment context
+        dict on success (so handlers can read `payer` / `transaction` if needed).
+
+    Usage:
+        @router.post("/construct", ...)
+        async def construct(..., _pay: dict | None = Depends(x402_paywall(0.001))):
+            ...
+    """
+
+    async def _dependency(request: Request) -> dict | None:
+        # Flag OFF → no-op passthrough. Attaching this never changes behavior
+        # until the operator arms the paywall.
+        if not x402_enabled():
+            return None
+
+        to = _recipient_address(recipient)
+        if not to:
+            # Misconfigured (flag on but no recipient) — fail loud, don't silently
+            # let a paid route through for free.
+            raise HTTPException(status_code=503, detail="x402 enabled but REVENUE_SPLIT_ADDRESS is unset")
+
+        path = resource_path or request.url.path
+        sig = request.headers.get("PAYMENT-SIGNATURE")
+
+        # 1. No payment → 402 with the requirements.
+        if not sig:
+            raise HTTPException(
+                status_code=402,
+                detail="Payment required",
+                headers={"PAYMENT-REQUIRED": _payment_required_header(price_usdc, to, path)},
+            )
+
+        # 2. Settle via Circle Gateway facilitator.
+        payload = _decode_payment_signature(sig)
+        requirements = _build_requirements(price_usdc, to, path)
+        settlement = await _settle_with_facilitator(payload, requirements)
+        if not settlement.get("success"):
+            reason = settlement.get("errorReason", "settlement_failed")
+            raise HTTPException(status_code=402, detail=f"Payment not settled: {reason}")
+
+        payer = _payer_from_payload(payload, settlement)
+
+        # 3. Per-payer daily spend cap → 429.
+        cap = _max_usdc_per_day()
+        spent = await _spend_store.amount_spent(payer)
+        if spent + price_usdc > cap:
+            reset_in = SPEND_WINDOW_SECONDS
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": "Daily spend cap exceeded",
+                    "payer": payer,
+                    "spent_usdc": round(spent, 6),
+                    "cap_usdc": cap,
+                    "resets_in_seconds": reset_in,
+                },
+            )
+        await _spend_store.record(payer, price_usdc)
+
+        return {
+            "payer": payer,
+            "amount_usdc": price_usdc,
+            "transaction": settlement.get("transaction", ""),
+            "network": settlement.get("network", ARC_NETWORK_CAIP2),
+        }
+
+    return _dependency

--- a/backend/archimedes/api/x402_middleware.py
+++ b/backend/archimedes/api/x402_middleware.py
@@ -137,6 +137,62 @@ class SpendCapStore:
         await r.zadd(key, {member: now})
         await r.expire(key, SPEND_WINDOW_SECONDS)
 
+    async def try_charge(
+        self, payer: str, amount_usdc: float, cap_usdc: float, *, now: float | None = None
+    ) -> tuple[bool, float]:
+        """Atomically check the 24h spend cap AND record the charge if it fits.
+
+        Returns ``(allowed, spent_before)``. When ``allowed`` is True the charge has
+        already been recorded; when False nothing was written.
+
+        This is the atomic replacement for a separate ``amount_spent()`` read followed
+        by a ``record()`` write. That read-then-write had a TOCTOU window: two concurrent
+        requests for the same payer could both observe ``spent`` below the cap and both
+        record, letting a payer exceed the daily cap. The trim + sum + compare +
+        conditional-add here run as ONE server-side ``EVAL`` so the check and the write
+        can never be interleaved by a concurrent request.
+        """
+        r = await self._get_redis()
+        key = f"{self.KEY_PREFIX}{payer.lower()}"
+        now = time.time() if now is None else now
+        cutoff = now - SPEND_WINDOW_SECONDS
+        member = f"{now}:{amount_usdc}"
+        allowed, spent = await r.eval(
+            _TRY_CHARGE_LUA,
+            1,
+            key,
+            str(now),
+            str(cutoff),
+            str(amount_usdc),
+            str(cap_usdc),
+            str(SPEND_WINDOW_SECONDS),
+            member,
+        )
+        # Redis truncates Lua numbers to integers on return, so the running total is
+        # returned as a string to preserve the fractional USDC value.
+        return bool(allowed), float(spent)
+
+
+# Atomic check-and-record for the per-payer cap, run server-side so the read and the
+# conditional write can't interleave. KEYS[1]=spend key; ARGV: now, cutoff, amount, cap,
+# ttl, member ("<ts>:<amount>"). Trims the 24h window, sums the surviving charges, and
+# only adds the new one (returning allowed=1) when it stays within the cap.
+_TRY_CHARGE_LUA = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[2])
+local members = redis.call('ZRANGE', KEYS[1], 0, -1)
+local spent = 0.0
+for _, m in ipairs(members) do
+    local amt = string.match(m, ':(.*)$')
+    if amt then spent = spent + tonumber(amt) end
+end
+if spent + tonumber(ARGV[3]) > tonumber(ARGV[4]) then
+    return {0, tostring(spent)}
+end
+redis.call('ZADD', KEYS[1], ARGV[1], ARGV[6])
+redis.call('EXPIRE', KEYS[1], ARGV[5])
+return {1, tostring(spent)}
+"""
+
 
 #: Module-level default store. Tests patch `SpendCapStore` methods at this
 #: boundary (per CLAUDE.md "Testing conventions" §"Mock at boundaries").
@@ -211,14 +267,19 @@ def _decode_payment_signature(raw: str) -> dict:
         raise HTTPException(status_code=402, detail="Malformed PAYMENT-SIGNATURE") from exc
 
 
-def _payer_from_payload(payload: dict, settlement: dict) -> str:
-    """Best-effort payer wallet extraction (settlement result, then payload)."""
+def _payer_from_settlement(settlement: dict) -> str:
+    """Spend-cap key — taken ONLY from the facilitator's verified settlement result.
+
+    The payer must come from Circle's settlement response, never from the
+    caller-supplied `PAYMENT-SIGNATURE` payload. Trusting the payload's EIP-3009
+    `from` field would let a caller choose which wallet the daily cap debits — so if
+    a settlement somehow succeeds without a `payer`, we fail closed (402) rather than
+    fall back to an attacker-controlled value.
+    """
     payer = settlement.get("payer")
-    if payer:
-        return str(payer)
-    # Fall back to the EIP-3009 `from` field in the authorization.
-    auth = (payload.get("payload") or {}).get("authorization") or {}
-    return str(auth.get("from", "")) or "unknown"
+    if not payer:
+        raise HTTPException(status_code=402, detail="Settlement missing verified payer")
+    return str(payer)
 
 
 # ── The reusable dependency factory ───────────────────────────────────────────
@@ -282,13 +343,13 @@ def x402_paywall(
             reason = settlement.get("errorReason", "settlement_failed")
             raise HTTPException(status_code=402, detail=f"Payment not settled: {reason}")
 
-        payer = _payer_from_payload(payload, settlement)
+        payer = _payer_from_settlement(settlement)
 
-        # 3. Per-payer daily spend cap → 429.
+        # 3. Per-payer daily spend cap → 429. The check + record is atomic (one
+        #    server-side EVAL) so concurrent requests can't both slip past the cap.
         cap = _max_usdc_per_day()
-        spent = await _spend_store.amount_spent(payer)
-        if spent + price_usdc > cap:
-            reset_in = SPEND_WINDOW_SECONDS
+        allowed, spent = await _spend_store.try_charge(payer, price_usdc, cap)
+        if not allowed:
             raise HTTPException(
                 status_code=429,
                 detail={
@@ -296,10 +357,9 @@ def x402_paywall(
                     "payer": payer,
                     "spent_usdc": round(spent, 6),
                     "cap_usdc": cap,
-                    "resets_in_seconds": reset_in,
+                    "resets_in_seconds": SPEND_WINDOW_SECONDS,
                 },
             )
-        await _spend_store.record(payer, price_usdc)
 
         return {
             "payer": payer,

--- a/backend/tests/test_x402_middleware.py
+++ b/backend/tests/test_x402_middleware.py
@@ -1,0 +1,271 @@
+"""Hermetic tests for the x402 nanopayment paywall (T1.2 / issue #713).
+
+Covers the four states of the generic `x402_paywall` dependency:
+  1. 402 when no PAYMENT-SIGNATURE header.
+  2. 200 passthrough when PAYMENT-SIGNATURE present + facilitator settles (mocked
+     at the aiohttp boundary).
+  3. 429 when the per-payer daily spend cap is exceeded (SpendCapStore mocked).
+  4. Flag off → the dependency is a no-op (route serves normally).
+
+Hermetic per CLAUDE.md "Testing conventions" §1: no live Redis, no live Circle —
+both boundaries are mocked. Mirrors the boundary-mocking precedent in
+`test_api_routes.py` (AgentStateStore / httpx.ASGITransport) but uses a tiny
+purpose-built FastAPI app so the test exercises the dependency in isolation,
+independent of the heavyweight /construct handler (architect/LLM) wiring.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from archimedes.api import x402_middleware
+from archimedes.api.x402_middleware import x402_paywall
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+RECIPIENT = "0x1111111111111111111111111111111111111111"
+PRICE = 0.001
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_app():
+    """Tiny app with one paywalled route, mirroring how /construct wires it."""
+    app = FastAPI()
+
+    @app.post("/paid")
+    async def paid(_payment: dict | None = Depends(x402_paywall(PRICE, resource_path="/paid"))):
+        return {"ok": True, "payment": _payment}
+
+    return app
+
+
+def _sig_header() -> dict[str, str]:
+    """A base64 PAYMENT-SIGNATURE with an EIP-3009 `from` payer."""
+    payload = {"payload": {"authorization": {"from": "0xPAYER000000000000000000000000000000beef"}}}
+    raw = base64.b64encode(json.dumps(payload).encode()).decode()
+    return {"PAYMENT-SIGNATURE": raw}
+
+
+class _FakeResp:
+    """Minimal aiohttp-style response context manager."""
+
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._body
+
+    async def text(self):
+        return json.dumps(self._body)
+
+
+@pytest.fixture(autouse=True)
+def _arm_paywall(monkeypatch):
+    """Arm the paywall + point the recipient at a fixed address for every test
+    except the explicit flag-off case (which clears the flag itself)."""
+    monkeypatch.setenv("ARCHIMEDES_X402_ENABLED", "1")
+    monkeypatch.setenv("REVENUE_SPLIT_ADDRESS", RECIPIENT)
+    monkeypatch.setenv("ARCHIMEDES_X402_MAX_USDC_PER_DAY", "0.10")
+    yield
+
+
+# ── 1. 402 when no payment signature ──────────────────────────────────────────
+
+
+def test_402_when_no_payment_signature():
+    client = TestClient(_make_app())
+    r = client.post("/paid")
+    assert r.status_code == 402
+    # The PAYMENT-REQUIRED header names Arc + the recipient + the price.
+    header = r.headers.get("PAYMENT-REQUIRED")
+    assert header
+    decoded = json.loads(base64.b64decode(header).decode())
+    req = decoded["accepts"][0]
+    assert req["network"] == "eip155:5042002"
+    assert req["payTo"] == RECIPIENT
+    assert req["amount"] == "1000"  # 0.001 USDC * 1e6 base units
+
+
+# ── 2. 200 passthrough on a settled payment ───────────────────────────────────
+
+
+def test_200_passthrough_when_settled():
+    settle_body = {"success": True, "payer": "0xPAYER", "transaction": "tx-uuid", "network": "eip155:5042002"}
+    with (
+        patch(
+            "archimedes.api.x402_middleware.aiohttp.ClientSession",
+            return_value=_FakeSessionCM(settle_body, 200),
+        ),
+        patch.object(x402_middleware._spend_store, "amount_spent", AsyncMock(return_value=0.0)),
+        patch.object(x402_middleware._spend_store, "record", AsyncMock()),
+    ):
+        client = TestClient(_make_app())
+        r = client.post("/paid", headers=_sig_header())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["payment"]["payer"] == "0xPAYER"
+    assert body["payment"]["transaction"] == "tx-uuid"
+
+
+# ── 3. 429 when over the per-payer spend cap ──────────────────────────────────
+
+
+def test_429_when_spend_cap_exceeded():
+    settle_body = {"success": True, "payer": "0xPAYER", "transaction": "tx-uuid", "network": "eip155:5042002"}
+    with (
+        patch(
+            "archimedes.api.x402_middleware.aiohttp.ClientSession",
+            return_value=_FakeSessionCM(settle_body, 200),
+        ),
+        # Already spent 0.10 (== cap); the next 0.001 pushes over → 429.
+        patch.object(x402_middleware._spend_store, "amount_spent", AsyncMock(return_value=0.10)),
+        patch.object(x402_middleware._spend_store, "record", AsyncMock()) as rec,
+    ):
+        client = TestClient(_make_app())
+        r = client.post("/paid", headers=_sig_header())
+    assert r.status_code == 429, r.text
+    detail = r.json()["detail"]
+    assert detail["error"] == "Daily spend cap exceeded"
+    assert detail["cap_usdc"] == 0.10
+    # We must NOT record a charge that was rejected.
+    rec.assert_not_called()
+
+
+# ── 4. Flag off → no-op passthrough ───────────────────────────────────────────
+
+
+def test_flag_off_is_noop(monkeypatch):
+    monkeypatch.setenv("ARCHIMEDES_X402_ENABLED", "0")
+    client = TestClient(_make_app())
+    # No payment header, but the paywall is disarmed → route serves 200.
+    r = client.post("/paid")
+    assert r.status_code == 200
+    assert r.json()["payment"] is None
+
+
+# ── 5. Settlement failure (facilitator success=false) → 402 ───────────────────
+
+
+def test_402_when_settlement_fails():
+    settle_body = {"success": False, "errorReason": "insufficient_balance", "transaction": "", "network": ""}
+    with (
+        patch(
+            "archimedes.api.x402_middleware.aiohttp.ClientSession",
+            return_value=_FakeSessionCM(settle_body, 200),
+        ),
+        patch.object(x402_middleware._spend_store, "amount_spent", AsyncMock(return_value=0.0)),
+        patch.object(x402_middleware._spend_store, "record", AsyncMock()),
+    ):
+        client = TestClient(_make_app())
+        r = client.post("/paid", headers=_sig_header())
+    assert r.status_code == 402
+    assert "insufficient_balance" in r.json()["detail"]
+
+
+# ── 6. Misc edge cases ────────────────────────────────────────────────────────
+
+
+def test_402_on_malformed_signature():
+    """A non-base64 / non-JSON PAYMENT-SIGNATURE → 402, not a 500."""
+    client = TestClient(_make_app())
+    r = client.post("/paid", headers={"PAYMENT-SIGNATURE": "!!!not-base64!!!"})
+    assert r.status_code == 402
+    assert "Malformed" in r.json()["detail"]
+
+
+def test_402_when_facilitator_non_200():
+    """Facilitator HTTP error (e.g. 400) maps to a clean 402."""
+    with (
+        patch(
+            "archimedes.api.x402_middleware.aiohttp.ClientSession",
+            return_value=_FakeSessionCM({"error": "bad request"}, 400),
+        ),
+        patch.object(x402_middleware._spend_store, "amount_spent", AsyncMock(return_value=0.0)),
+    ):
+        client = TestClient(_make_app())
+        r = client.post("/paid", headers=_sig_header())
+    assert r.status_code == 402
+
+
+def test_503_when_armed_but_recipient_unset(monkeypatch):
+    """Flag on but no REVENUE_SPLIT_ADDRESS → fail loud (503), never free passage."""
+    monkeypatch.delenv("REVENUE_SPLIT_ADDRESS", raising=False)
+    client = TestClient(_make_app())
+    r = client.post("/paid")
+    assert r.status_code == 503
+
+
+class _FakeRedis:
+    """Minimal in-memory sorted-set double for the SpendCapStore Redis boundary."""
+
+    def __init__(self):
+        self.store: dict[str, dict[str, float]] = {}
+
+    async def zremrangebyscore(self, key, lo, hi):
+        members = self.store.get(key, {})
+        self.store[key] = {m: s for m, s in members.items() if not (lo <= s <= hi)}
+
+    async def zrange(self, key, start, end):
+        members = sorted(self.store.get(key, {}).items(), key=lambda kv: kv[1])
+        return [m for m, _ in members]
+
+    async def zadd(self, key, mapping):
+        self.store.setdefault(key, {}).update(mapping)
+
+    async def expire(self, key, ttl):
+        return True
+
+
+async def test_spend_cap_store_records_and_reads():
+    """Exercise the real SpendCapStore logic against an in-memory redis double."""
+    store = x402_middleware.SpendCapStore()
+    fake = _FakeRedis()
+    store._redis = fake  # inject the boundary double
+
+    now = 1_000_000.0
+    assert await store.amount_spent("0xABC", now=now) == 0.0
+
+    await store.record("0xABC", 0.03, now=now)
+    await store.record("0xABC", 0.02, now=now + 1)
+    assert abs(await store.amount_spent("0xABC", now=now + 2) - 0.05) < 1e-9
+
+    # An entry older than the 24h window is trimmed on read.
+    await store.record("0xABC", 0.10, now=now - x402_middleware.SPEND_WINDOW_SECONDS - 10)
+    assert abs(await store.amount_spent("0xABC", now=now + 3) - 0.05) < 1e-9
+
+
+# ── aiohttp.ClientSession test double ──────────────────────────────────────────
+
+
+class _FakeSessionCM:
+    """Stand-in for `aiohttp.ClientSession()` used as an async context manager.
+
+    `_settle_with_facilitator` does `async with aiohttp.ClientSession() as s, s.post(...) as resp`.
+    This double yields itself as the session and returns a `_FakeResp` from .post().
+    """
+
+    def __init__(self, body: dict, status: int = 200):
+        self._body = body
+        self._status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, *_a, **_k):
+        return _FakeResp(self._status, self._body)

--- a/backend/tests/test_x402_middleware.py
+++ b/backend/tests/test_x402_middleware.py
@@ -108,8 +108,7 @@ def test_200_passthrough_when_settled():
             "archimedes.api.x402_middleware.aiohttp.ClientSession",
             return_value=_FakeSessionCM(settle_body, 200),
         ),
-        patch.object(x402_middleware._spend_store, "amount_spent", AsyncMock(return_value=0.0)),
-        patch.object(x402_middleware._spend_store, "record", AsyncMock()),
+        patch.object(x402_middleware._spend_store, "try_charge", AsyncMock(return_value=(True, 0.0))),
     ):
         client = TestClient(_make_app())
         r = client.post("/paid", headers=_sig_header())
@@ -130,9 +129,8 @@ def test_429_when_spend_cap_exceeded():
             "archimedes.api.x402_middleware.aiohttp.ClientSession",
             return_value=_FakeSessionCM(settle_body, 200),
         ),
-        # Already spent 0.10 (== cap); the next 0.001 pushes over → 429.
-        patch.object(x402_middleware._spend_store, "amount_spent", AsyncMock(return_value=0.10)),
-        patch.object(x402_middleware._spend_store, "record", AsyncMock()) as rec,
+        # Already at the 0.10 cap; the atomic try_charge rejects and records nothing → 429.
+        patch.object(x402_middleware._spend_store, "try_charge", AsyncMock(return_value=(False, 0.10))) as charge,
     ):
         client = TestClient(_make_app())
         r = client.post("/paid", headers=_sig_header())
@@ -140,8 +138,8 @@ def test_429_when_spend_cap_exceeded():
     detail = r.json()["detail"]
     assert detail["error"] == "Daily spend cap exceeded"
     assert detail["cap_usdc"] == 0.10
-    # We must NOT record a charge that was rejected.
-    rec.assert_not_called()
+    # The atomic check-and-record owns the "don't record a rejected charge" guarantee.
+    charge.assert_called_once()
 
 
 # ── 4. Flag off → no-op passthrough ───────────────────────────────────────────
@@ -228,6 +226,33 @@ class _FakeRedis:
     async def expire(self, key, ttl):
         return True
 
+    async def eval(self, script, numkeys, *args):
+        """Mirror the _TRY_CHARGE_LUA logic in Python so the atomic API is exercisable
+        hermetically. (True atomicity under concurrency is enforced by Redis running the
+        real EVAL server-side; this double validates the trim/sum/compare/record shape.)"""
+        key, now, cutoff, amount, cap, ttl, member = (
+            args[0],
+            float(args[1]),
+            float(args[2]),
+            float(args[3]),
+            float(args[4]),
+            int(args[5]),
+            args[6],
+        )
+        await self.zremrangebyscore(key, 0, cutoff)
+        members = await self.zrange(key, 0, -1)
+        spent = 0.0
+        for m in members:
+            try:
+                spent += float(str(m).split(":", 1)[1])
+            except (IndexError, ValueError):
+                continue
+        if spent + amount > cap:
+            return [0, str(spent)]
+        await self.zadd(key, {member: now})
+        await self.expire(key, ttl)
+        return [1, str(spent)]
+
 
 async def test_spend_cap_store_records_and_reads():
     """Exercise the real SpendCapStore logic against an in-memory redis double."""
@@ -245,6 +270,83 @@ async def test_spend_cap_store_records_and_reads():
     # An entry older than the 24h window is trimmed on read.
     await store.record("0xABC", 0.10, now=now - x402_middleware.SPEND_WINDOW_SECONDS - 10)
     assert abs(await store.amount_spent("0xABC", now=now + 3) - 0.05) < 1e-9
+
+
+async def test_try_charge_atomic_check_and_record():
+    """try_charge records iff the charge stays within cap, in a single operation.
+
+    The race the atomic path closes: with a separate read-then-write, two concurrent
+    requests near the cap could both pass the check and both record. try_charge folds
+    check+record into one server-side EVAL. Here we drive it sequentially against the
+    in-memory double to pin the contract — allowed charges record, a rejected charge
+    leaves the running total untouched.
+    """
+    store = x402_middleware.SpendCapStore()
+    store._redis = _FakeRedis()
+    cap = 0.10
+    now = 2_000_000.0
+
+    allowed, spent = await store.try_charge("0xABC", 0.06, cap, now=now)
+    assert allowed and spent == 0.0
+    allowed, spent = await store.try_charge("0xABC", 0.03, cap, now=now + 1)
+    assert allowed and abs(spent - 0.06) < 1e-9
+    # 0.09 + 0.02 > 0.10 → rejected, and nothing recorded.
+    allowed, spent = await store.try_charge("0xABC", 0.02, cap, now=now + 2)
+    assert not allowed and abs(spent - 0.09) < 1e-9
+    # The rejected charge did not advance the total.
+    allowed, spent = await store.try_charge("0xABC", 0.001, cap, now=now + 3)
+    assert allowed and abs(spent - 0.09) < 1e-9
+
+
+def test_402_when_settlement_missing_payer():
+    """Settlement success but no `payer` → fail closed (402).
+
+    The spend-cap key must come only from Circle's verified settlement result; we never
+    fall back to the caller-supplied payload `from`, so the cap is never consulted
+    without a verified payer.
+    """
+    settle_body = {"success": True, "transaction": "tx", "network": "eip155:5042002"}  # no payer
+    with (
+        patch(
+            "archimedes.api.x402_middleware.aiohttp.ClientSession",
+            return_value=_FakeSessionCM(settle_body, 200),
+        ),
+        patch.object(x402_middleware._spend_store, "try_charge", AsyncMock(return_value=(True, 0.0))) as charge,
+    ):
+        client = TestClient(_make_app())
+        r = client.post("/paid", headers=_sig_header())
+    assert r.status_code == 402
+    assert "verified payer" in r.json()["detail"]
+    charge.assert_not_called()
+
+
+def test_replay_rejected_when_facilitator_rejects_reused_authorization():
+    """A replayed PAYMENT-SIGNATURE is rejected at settlement, not by the middleware.
+
+    The EIP-3009 `transferWithAuthorization` nonce is single-use at the USDC contract, so
+    the facilitator returns success=false on the second presentation of the same signed
+    authorization. This documents that replay protection is correctly delegated to
+    Circle/EIP-3009 — the first request settles (200), the identical replay 402s, and the
+    handler runs exactly once.
+    """
+    first = {"success": True, "payer": "0xPAYER", "transaction": "tx-1", "network": "eip155:5042002"}
+    replay = {"success": False, "errorReason": "authorization_used", "transaction": "", "network": ""}
+    responses = [_FakeSessionCM(first, 200), _FakeSessionCM(replay, 200)]
+
+    with (
+        patch(
+            "archimedes.api.x402_middleware.aiohttp.ClientSession",
+            side_effect=lambda *_a, **_k: responses.pop(0),
+        ),
+        patch.object(x402_middleware._spend_store, "try_charge", AsyncMock(return_value=(True, 0.0))),
+    ):
+        client = TestClient(_make_app())
+        headers = _sig_header()
+        r1 = client.post("/paid", headers=headers)
+        r2 = client.post("/paid", headers=headers)  # identical signature → replay
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 402
+    assert "authorization_used" in r2.json()["detail"]
 
 
 # ── aiohttp.ClientSession test double ──────────────────────────────────────────

--- a/contracts/abis/RevenueSplit.json
+++ b/contracts/abis/RevenueSplit.json
@@ -1,0 +1,77 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      { "name": "_usdc", "type": "address", "internalType": "address" },
+      { "name": "_creator", "type": "address", "internalType": "address" },
+      { "name": "_platform", "type": "address", "internalType": "address" }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "BPS_DENOMINATOR",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "CREATOR_BPS",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PLATFORM_BPS",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "creator",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "platform",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "usdc",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "contract IERC20" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pending",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "release",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Released",
+    "inputs": [
+      { "name": "totalAmount", "type": "uint256", "indexed": false, "internalType": "uint256" },
+      { "name": "creatorAmount", "type": "uint256", "indexed": false, "internalType": "uint256" },
+      { "name": "platformAmount", "type": "uint256", "indexed": false, "internalType": "uint256" }
+    ],
+    "anonymous": false
+  }
+]

--- a/contracts/abis/RevenueSplit.json
+++ b/contracts/abis/RevenueSplit.json
@@ -2,9 +2,21 @@
   {
     "type": "constructor",
     "inputs": [
-      { "name": "_usdc", "type": "address", "internalType": "address" },
-      { "name": "_creator", "type": "address", "internalType": "address" },
-      { "name": "_platform", "type": "address", "internalType": "address" }
+      {
+        "name": "_usdc",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_creator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_platform",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
     "stateMutability": "nonpayable"
   },
@@ -12,49 +24,78 @@
     "type": "function",
     "name": "BPS_DENOMINATOR",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "CREATOR_BPS",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "PLATFORM_BPS",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "creator",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "platform",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "usdc",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "address", "internalType": "contract IERC20" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "pending",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "platform",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "stateMutability": "view"
   },
   {
@@ -65,13 +106,52 @@
     "stateMutability": "nonpayable"
   },
   {
+    "type": "function",
+    "name": "usdc",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IERC20"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
     "type": "event",
     "name": "Released",
     "inputs": [
-      { "name": "totalAmount", "type": "uint256", "indexed": false, "internalType": "uint256" },
-      { "name": "creatorAmount", "type": "uint256", "indexed": false, "internalType": "uint256" },
-      { "name": "platformAmount", "type": "uint256", "indexed": false, "internalType": "uint256" }
+      {
+        "name": "totalAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "creatorAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "platformAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
     ],
     "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
   }
 ]

--- a/contracts/script/DeployRevenueSplit.s.sol
+++ b/contracts/script/DeployRevenueSplit.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/RevenueSplit.sol";
+
+/// @notice Deploy RevenueSplit.sol to Arc testnet.
+///         Usage:
+///           forge script script/DeployRevenueSplit.s.sol --rpc-url arc-testnet --broadcast
+///
+///         Required env vars:
+///           DEPLOYER_KEY      — private key of the deployer
+///           USDC_ADDRESS      — USDC token address on Arc (settlement asset)
+///           CREATOR_ADDRESS   — address that receives the 90% creator share
+///           PLATFORM_ADDRESS  — address that receives the 10% platform share
+///
+///         After deploy, copy the printed address into .env as REVENUE_SPLIT_ADDRESS
+///         so the x402 middleware names it in the PAYMENT-REQUIRED header.
+contract DeployRevenueSplitScript is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("DEPLOYER_KEY");
+        address usdc = vm.envAddress("USDC_ADDRESS");
+        address creator = vm.envAddress("CREATOR_ADDRESS");
+        address platform = vm.envAddress("PLATFORM_ADDRESS");
+
+        vm.startBroadcast(deployerKey);
+
+        RevenueSplit splitter = new RevenueSplit(usdc, creator, platform);
+        console.log("RevenueSplit deployed at:", address(splitter));
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Deployment Summary ===");
+        console.log("RevenueSplit:", address(splitter));
+        console.log("USDC:        ", usdc);
+        console.log("Creator (90%):", creator);
+        console.log("Platform (10%):", platform);
+        console.log("");
+        console.log("Add to .env:");
+        console.log("  REVENUE_SPLIT_ADDRESS=", address(splitter));
+    }
+}

--- a/contracts/src/RevenueSplit.sol
+++ b/contracts/src/RevenueSplit.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title RevenueSplit
+/// @notice Minimal, non-upgradeable creator/platform revenue splitter for the
+///         x402 nanopayment marketplace (T1.2, first slice).
+///
+///         The x402 facilitator settles each paywalled `/construct` request by
+///         moving USDC (via EIP-3009 `transferWithAuthorization`) to THIS
+///         contract's address. Anyone can then call `release()` to forward the
+///         accumulated balance 90% to `creator` and 10% to `platform`. Both
+///         addresses are immutable at construction.
+///
+///         Design constraints for this first slice (see issue #713 / spec
+///         SPEC-1 T1.2):
+///           - No streaming, no per-strategy creator routing (a single splitter
+///             for all paywalled strategies; per-strategy routing is a follow-up).
+///           - No admin / owner function — the split cannot be redirected after
+///             deploy. The contract is intentionally un-ownable so a paid creator
+///             can trust that funds route as advertised.
+///           - `release()` is permissionless: anyone can trigger the forward, but
+///             funds can only ever go to the two immutable recipients.
+///
+///         LOCAL VALIDATION STATUS: `forge` is not installed on the authoring
+///         machine, so this contract is UNVALIDATED locally. Bogdan / Dan must run
+///         `forge build && forge test --match-contract RevenueSplit -vv` after the
+///         Foundry standup before this is deploy-ready.
+contract RevenueSplit {
+    using SafeERC20 for IERC20;
+
+    // ─── Constants ───────────────────────────────────────────────────
+    /// @notice Basis points denominator (100% = 10_000 bps).
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    /// @notice Creator share in basis points (90%).
+    uint256 public constant CREATOR_BPS = 9_000;
+    /// @notice Platform share in basis points (10%).
+    uint256 public constant PLATFORM_BPS = 1_000;
+
+    // ─── Immutable state ─────────────────────────────────────────────
+    /// @notice The USDC token this splitter forwards.
+    IERC20 public immutable usdc;
+    /// @notice Receives 90% of every release. Immutable.
+    address public immutable creator;
+    /// @notice Receives 10% of every release. Immutable.
+    address public immutable platform;
+
+    // ─── Events ──────────────────────────────────────────────────────
+    /// @notice Emitted on every successful `release()`.
+    event Released(uint256 totalAmount, uint256 creatorAmount, uint256 platformAmount);
+
+    // ─── Constructor ─────────────────────────────────────────────────
+    /// @param _usdc     USDC token address on Arc (the settlement asset).
+    /// @param _creator  Address that receives the 90% creator share.
+    /// @param _platform Address that receives the 10% platform share.
+    constructor(address _usdc, address _creator, address _platform) {
+        require(_usdc != address(0), "RevenueSplit: zero USDC");
+        require(_creator != address(0), "RevenueSplit: zero creator");
+        require(_platform != address(0), "RevenueSplit: zero platform");
+
+        usdc = IERC20(_usdc);
+        creator = _creator;
+        platform = _platform;
+    }
+
+    // ─── Write ───────────────────────────────────────────────────────
+    /// @notice Forward the contract's entire USDC balance 90/10 to creator/platform.
+    ///         Permissionless — anyone may trigger, but funds only ever route to
+    ///         the two immutable recipients. The platform share is computed as the
+    ///         remainder after the creator share so no dust is ever stranded.
+    function release() external {
+        uint256 balance = usdc.balanceOf(address(this));
+        require(balance > 0, "RevenueSplit: nothing to release");
+
+        uint256 creatorAmount = (balance * CREATOR_BPS) / BPS_DENOMINATOR;
+        uint256 platformAmount = balance - creatorAmount;
+
+        usdc.safeTransfer(creator, creatorAmount);
+        usdc.safeTransfer(platform, platformAmount);
+
+        emit Released(balance, creatorAmount, platformAmount);
+    }
+
+    // ─── Read ────────────────────────────────────────────────────────
+    /// @notice Current USDC balance held by the splitter awaiting release.
+    function pending() external view returns (uint256) {
+        return usdc.balanceOf(address(this));
+    }
+}

--- a/contracts/test/RevenueSplit.t.sol
+++ b/contracts/test/RevenueSplit.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../src/RevenueSplit.sol";
+
+/// @dev Mock ERC-20 USDC for testing (6 decimals, mirrors the fixture in
+///      SyntheticVault.t.sol).
+contract MockUSDC is ERC20 {
+    constructor() ERC20("Mock USDC", "USDC") {
+        _mint(msg.sender, 1_000_000 * 10 ** 6); // 1M USDC
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+}
+
+contract RevenueSplitTest is Test {
+    MockUSDC public usdc;
+    RevenueSplit public splitter;
+
+    address public creator = address(0xC0FFEE);
+    address public platform = address(0xBEEF);
+
+    function setUp() public {
+        usdc = new MockUSDC();
+        splitter = new RevenueSplit(address(usdc), creator, platform);
+    }
+
+    // ─── Split math ──────────────────────────────────────────────────
+
+    function test_release_splits_90_10() public {
+        // Settle 1.00 USDC into the splitter (the x402 facilitator transfer).
+        uint256 amount = 1_000_000; // 1.00 USDC (6 dec)
+        usdc.mint(address(splitter), amount);
+
+        assertEq(splitter.pending(), amount);
+
+        splitter.release();
+
+        // 90% to creator, 10% to platform.
+        assertEq(usdc.balanceOf(creator), 900_000);
+        assertEq(usdc.balanceOf(platform), 100_000);
+        assertEq(usdc.balanceOf(address(splitter)), 0);
+    }
+
+    function test_release_subcent_no_dust_stranded() public {
+        // A sub-cent x402 payment: 0.001 USDC = 1000 base units.
+        // 90% = 900, 10% = 100 — exact, but the contract computes platform as the
+        // remainder so any rounding dust always lands with the platform, never
+        // stranded in the contract.
+        uint256 amount = 1000;
+        usdc.mint(address(splitter), amount);
+
+        splitter.release();
+
+        assertEq(usdc.balanceOf(creator), 900);
+        assertEq(usdc.balanceOf(platform), 100);
+        assertEq(usdc.balanceOf(address(splitter)), 0);
+    }
+
+    function test_release_rounding_remainder_goes_to_platform() public {
+        // 7 base units: creator = (7 * 9000) / 10000 = 6 (floored),
+        // platform = 7 - 6 = 1. No dust stranded.
+        uint256 amount = 7;
+        usdc.mint(address(splitter), amount);
+
+        splitter.release();
+
+        assertEq(usdc.balanceOf(creator), 6);
+        assertEq(usdc.balanceOf(platform), 1);
+        assertEq(usdc.balanceOf(address(splitter)), 0);
+    }
+
+    function test_release_emits_event() public {
+        uint256 amount = 1_000_000;
+        usdc.mint(address(splitter), amount);
+
+        vm.expectEmit(false, false, false, true);
+        emit RevenueSplit.Released(amount, 900_000, 100_000);
+        splitter.release();
+    }
+
+    function test_release_reverts_when_empty() public {
+        vm.expectRevert(bytes("RevenueSplit: nothing to release"));
+        splitter.release();
+    }
+
+    function test_release_is_permissionless() public {
+        uint256 amount = 1_000_000;
+        usdc.mint(address(splitter), amount);
+
+        // A random caller can trigger the forward, but funds only route to the
+        // two immutable recipients.
+        vm.prank(address(0xD00D));
+        splitter.release();
+
+        assertEq(usdc.balanceOf(creator), 900_000);
+        assertEq(usdc.balanceOf(platform), 100_000);
+    }
+
+    // ─── Construction guards ─────────────────────────────────────────
+
+    function test_constructor_reverts_zero_usdc() public {
+        vm.expectRevert(bytes("RevenueSplit: zero USDC"));
+        new RevenueSplit(address(0), creator, platform);
+    }
+
+    function test_constructor_reverts_zero_creator() public {
+        vm.expectRevert(bytes("RevenueSplit: zero creator"));
+        new RevenueSplit(address(usdc), address(0), platform);
+    }
+
+    function test_constructor_reverts_zero_platform() public {
+        vm.expectRevert(bytes("RevenueSplit: zero platform"));
+        new RevenueSplit(address(usdc), creator, address(0));
+    }
+
+    // ─── No redirect after deploy (no admin function) ────────────────
+
+    function test_recipients_are_immutable() public view {
+        // The contract exposes no setter for creator/platform — the only way to
+        // read them is the immutable getters, and they match construction args.
+        assertEq(splitter.creator(), creator);
+        assertEq(splitter.platform(), platform);
+        assertEq(address(splitter.usdc()), address(usdc));
+        assertEq(splitter.CREATOR_BPS(), 9_000);
+        assertEq(splitter.PLATFORM_BPS(), 1_000);
+        assertEq(splitter.BPS_DENOMINATOR(), 10_000);
+    }
+}

--- a/ui/src/components/Marketplace.jsx
+++ b/ui/src/components/Marketplace.jsx
@@ -38,6 +38,29 @@ export default function Marketplace({ onNavigate }) {
   const [error, setError] = useState('')
   const [tierFilter, setTierFilter] = useState('all') // 'all' | 1 | 2
   const [sortBy, setSortBy] = useState('aum')
+  // T1.2 nanopayment marketplace — true when the backend has the x402 paywall
+  // armed (ARCHIMEDES_X402_ENABLED=1). Read via the single `is_paywalled` boolean
+  // the strategies API plumbs through; drives the "Pay per run" disclosure chip.
+  const [paywallActive, setPaywallActive] = useState(false)
+
+  // Probe the backend once for the marketplace paywall state. A no-op (chip
+  // stays hidden) unless the operator has armed the x402 flag.
+  useEffect(() => {
+    let cancelled = false
+    const probe = async () => {
+      try {
+        const r = await fetch(`${API_BASE}/api/strategies/?limit=1`)
+        if (!r.ok) return
+        const data = await r.json()
+        const first = (data.strategies || [])[0]
+        if (!cancelled && first) setPaywallActive(Boolean(first.is_paywalled))
+      } catch {
+        // Paywall probe is best-effort; the chip simply stays hidden on failure.
+      }
+    }
+    probe()
+    return () => { cancelled = true }
+  }, [])
 
   // Load vaults from the backend marketplace endpoint.
   // We fetch with sort hint, but also re-sort client-side so the dropdown
@@ -193,11 +216,22 @@ export default function Marketplace({ onNavigate }) {
                 <span className="font-semibold text-sm" style={{ color: 'var(--text-1)' }}>
                   {v.name || `Vault ${shortAddr(v.address)}`}
                 </span>
-                <span className={`tag ${v.tier === 1 ? 'tag-accent' : 'tag-muted'}`}>
-                  {v.tier === 1
-                    ? <><span className="i-lucide-trophy w-3.5 h-3.5" /> Verified</>
-                    : <><span className="i-lucide-users w-3.5 h-3.5" /> Community</>}
-                </span>
+                <div className="flex items-center gap-1.5">
+                  {/* T1.2: "Pay per run" disclosure — rendered only when the x402
+                      paywall is armed on the backend and the vault is agent-assisted
+                      (its strategy is the paywalled construct verb). One-line chip
+                      only; the full payment flow is a follow-up issue. */}
+                  {paywallActive && v.is_agent_assisted && (
+                    <span className="tag tag-muted" title="Constructing this strategy charges a sub-cent USDC nanopayment via x402">
+                      <span className="i-lucide-coins w-3.5 h-3.5" /> Pay per run
+                    </span>
+                  )}
+                  <span className={`tag ${v.tier === 1 ? 'tag-accent' : 'tag-muted'}`}>
+                    {v.tier === 1
+                      ? <><span className="i-lucide-trophy w-3.5 h-3.5" /> Verified</>
+                      : <><span className="i-lucide-users w-3.5 h-3.5" /> Community</>}
+                  </span>
+                </div>
               </div>
               <div className="flex items-baseline gap-2 mt-3 mb-1">
                 <span className="text-[1.4rem] font-bold">{fmtUsd(v.aum_usdc)}</span>


### PR DESCRIPTION
**@rcrdoh @mnemonik-dev — first-draft scaffold for review, NOT for merge yet.**

This is a reviewable starting point for **T1.2 (issue #713)** built in parallel with Ricardo's own work (Dan-authorized). It cuts the smallest verifiable slice of the optional-publish nanopayment marketplace: **one paywalled `POST /api/strategies/construct` endpoint** that pays a sub-cent USDC nanopayment via the **x402 protocol + Circle Gateway facilitator** into a **90/10 `RevenueSplit`** on Arc. Everything else is stubbed-but-clean so the follow-ups plug in.

## What's in this PR (per SPEC-1 T1.2)

**Backend (hermetic, no Foundry needed):**
- `backend/archimedes/api/x402_middleware.py` — a **generic, reusable** x402 paywall as a **FastAPI dependency factory**: `x402_paywall(price_usdc, recipient=...)`. Opt-in per-route, **feature-flagged default-OFF** (`ARCHIMEDES_X402_ENABLED`, no-op until armed).
  - No `PAYMENT-SIGNATURE` -> **402** + a base64 `PAYMENT-REQUIRED` header naming Arc testnet (`eip155:5042002`), the `RevenueSplit` recipient, and the USDC price (`0.001`).
  - With `PAYMENT-SIGNATURE` -> **settle** via Circle Gateway (`POST {CIRCLE_GW_BASE}/x402/settle`; reuses `CIRCLE_GW_BASE` from `circle_service.py` — not redeclared), gate the handler on `success: true`.
  - **Per-payer daily spend cap** -> **429** (24h sliding window in Redis via a `SpendCapStore`, keyed on the payer wallet from the verified payload; `ARCHIMEDES_X402_MAX_USDC_PER_DAY` default `0.10`).
- Wired to **exactly one route** — `POST /api/strategies/construct` (the canonical "consume a strategy" verb). **Spec note:** the cited line drifted — the live route is `POST /construct` with **no** `{strategy_id}` path param (strategy selection is internal to the architect), so the paywall attaches to the route as a whole. **No other endpoint touched.**
- `is_paywalled: bool` on the strategy response (`schemas.py`), set from the flag in `strategies_routes.py`.
- `ui/src/components/Marketplace.jsx` — a one-line **"Pay per run" disclosure chip** on agent-assisted vaults, rendered only when the backend paywall is armed (probed via `is_paywalled`). Not the full payment flow (follow-up).
- `.env.example` — only the **non-secret** `REVENUE_SPLIT_ADDRESS` (+ the two non-secret flags). No secrets.

**Contracts (LOCALLY UNVALIDATED — see Foundry status):**
- `contracts/src/RevenueSplit.sol` — minimal, non-upgradeable, **immutable** `creator`/`platform`, **no admin redirect**. `release()` forwards 90% to creator / 10% to platform (platform takes the remainder so no dust is stranded).
- `contracts/test/RevenueSplit.t.sol` — 90/10 split, sub-cent + rounding, zero-address construction reverts, immutability/no-admin, permissionless release, event (11 functions, >= 3 required).
- `contracts/script/DeployRevenueSplit.s.sol` — mirrors `DeployStrategyRegistry.s.sol`; reads `USDC_ADDRESS`/`CREATOR_ADDRESS`/`PLATFORM_ADDRESS`.
- `contracts/abis/RevenueSplit.json` — **hand-authored** ABI cache (forge not installed to regenerate); `forge build` should regenerate it identically.

## Generic-middleware design note

The x402 dependency is deliberately a **factory** (`price` + `recipient` configurable). A sibling use-case — **charging per *generation*, 100% to the platform to cover inference cost** — will reuse it on the generate route in a follow-up. This PR applies it to **only** the construct route, per spec.

## Foundry-validation status

`forge` is **not installed** on the authoring machine and was **not** installed (per instruction). The Solidity is written by copying the cited patterns (`Registry.t.sol`, `DeployStrategyRegistry.s.sol`, the `MockUSDC` fixture in `SyntheticVault.t.sol`) but is **LOCALLY UNVALIDATED**. **Bogdan/Dan: please run `forge build && forge test --match-contract RevenueSplit -vv` after the Foundry standup** before treating the contract as deploy-ready. The **backend half needs no forge and passes hermetically.**

## Validation (in the `archimedes` conda env)

- `pytest backend/tests/test_x402_middleware.py -q` -> **9 passed, 0 failed** (402 / 200-passthrough / 429-cap / flag-off no-op + settlement-fail / malformed-sig / facilitator-non-200 / missing-recipient-503 / SpendCapStore window logic).
- **Hermetic gate**: `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_x402_middleware.py -q` -> **9 passed, 0 failed**. Middleware coverage **91%**.
- `ruff format --check .` + `ruff check --select E9,F63,F7,F40,F82 .` -> both pass. Broader `ruff check` on changed files clean.
- ESLint clean on `Marketplace.jsx`.
- Existing `backend/tests/test_api_routes.py` -> 28 passed (no regressions).
- **Surface coverage** — exactly **one** route carries the x402 dependency (`POST /api/strategies/construct`), verified by enumerating `app.routes`.
- Contract `forge build`/`forge test` — **not run** (forge not installed). Live happy-path `curl` (402/200) needs a deployed `REVENUE_SPLIT_ADDRESS` + the stack up — left for Bogdan/Dan.

## The three named follow-up issues

1. **Gateway batched settlement** + facilitator polling (this slice settles each payment via the EIP-3009 `transferWithAuthorization` path; batching is next).
2. **Per-strategy creator routing** through `RevenueSplit` (ships with a single immutable `creator` for all paywalled strategies; the strategy->creator mapping table is PR #2).
3. **Embedded-Wallet-per-user UI** — downstream of Dan's Circle modular-wallet passkey fix. **That passkey/MSCA per-call-mint bug is now FIXED (commit `bd1c858` / #718), so this follow-up is unblocked.**

## Alignment with Ricardo's #713 + Discord architecture diagrams

This is the minimal slice of Ricardo's fuller vision. His diagrams describe **ephemeral per-subscription wallets**, an **"arc nanopayments agent"** that reserves an upfront amount + performs the split, a **vault-funding threshold gate**, and a **"type-3" docker consumption-tracking agent** — all **follow-up work** (subscription engine / ephemeral wallet / type-3 agent), not this PR. This PR is the one concrete payment-gated request that the rest plugs into.

## Anti-goals respected

Opt-in per-route + feature-flagged default-off; no Gateway batching; no per-strategy creator routing; passkey flow / vault contracts / other routes untouched; only the non-secret `REVENUE_SPLIT_ADDRESS` in `.env.example`; `CIRCLE_GW_BASE` reused not redeclared; `broadcast/` gitignored; no weakened/skip-marked tests. One PR.

---
Contract review needs **@mnemonik-dev** (Bogdan) eyes + **Dan** as contract owner; backend Python review by Daniel R. / Marten.

Generated with Claude Code

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
