### PR TITLE
[generation] Wire fusion engine into the live Generate path (Stack A) !minor

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -31,7 +31,7 @@ import logging
 import math
 import os
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
@@ -108,6 +108,40 @@ def _pick_pipeline(
 
     # ── Agent (fallback) ──
     return "agent", "streaming agent — general-purpose fallback"
+
+
+def _fusion_can_run(brief: GenerateBrief) -> bool:
+    """No-LLM viability precheck for the fusion path.
+
+    Returns True iff the fusion flag is on AND the deterministic candidate
+    selection yields ≥ ``MIN_PAPERS`` papers for this brief's steer — i.e. the
+    engine would not immediately return ``insufficient_corpus``. Used to keep
+    ``pipeline_selected`` honest: we only announce "fusion" if it can actually
+    produce a ≥2-paper synthesis. Never raises — any failure degrades to False
+    so the caller falls back to the agent path.
+    """
+    try:
+        from archimedes.agents.strategy_fusion import (
+            MIN_PAPERS,
+            FusionBrief,
+            fusion_enabled,
+            load_corpus,
+            select_candidates,
+        )
+
+        if not fusion_enabled():
+            return False
+        fusion_brief = FusionBrief(
+            asset_classes=list(brief.asset_classes or []),
+            risk_appetite=brief.risk_appetite,
+            strategic_direction=brief.intent or "",
+            max_papers=brief.max_papers,
+        )
+        candidates = select_candidates(fusion_brief, load_corpus())
+        return len(candidates) >= MIN_PAPERS
+    except Exception:
+        logger.debug("fusion viability precheck failed; treating as not runnable", exc_info=True)
+        return False
 
 
 # ── Brief validation (real LLM step on the live path) ─────────────────────
@@ -221,6 +255,20 @@ class _CandidateResult:
     # live path from the agent's price_histories; the fixture path leaves it
     # empty and supplies a hardcoded verdict.
     return_series: list[float] = None  # type: ignore[assignment]
+    # Provenance method this candidate was produced by — persisted verbatim into
+    # the StrategyRecord. The agent/fixture path leaves the default; the fusion
+    # runner sets ``"fusion"`` so the library distinguishes multi-paper synthesis
+    # from single-agent allocation. (Fusion dispatch wire, Stack A.)
+    generation_method: str = "portfolio_agent_streaming"
+    # The ≥2 arXiv ids fused into this candidate (fusion path only). Empty on the
+    # agent path; the fusion runner populates it from the FusionProposal so the
+    # passport renders real cross-paper provenance, not a placeholder.
+    source_arxiv_ids: list[str] = field(default_factory=list)
+    # Backtest verdict already carries DSR/PBO/OOS when the fusion evaluator ran;
+    # ``has_real_rigor`` flags that the verdict is a real DSL backtest (so the
+    # downstream buy-and-hold backtest step is skipped — it would clobber the
+    # already-computed fusion metrics with a different, weight-less read).
+    has_real_rigor: bool = False
 
 
 # ── Rigor adapter (Önder's rigor_evaluator on agent output) ───────────────
@@ -380,16 +428,25 @@ def _lookahead_for_candidate(referenced_strategies: list[Any]) -> bool:
 
 
 def _patch_pbo(candidates: list[_CandidateResult]) -> None:
-    """Compute library-level PBO across the candidate set; patch each verdict."""
-    series_map: dict[str, list[float]] = {c.candidate_id: c.return_series for c in candidates if c.return_series}
+    """Compute library-level PBO across the agent/fixture candidate set; patch each verdict.
+
+    Fusion candidates are SKIPPED: they carry a real PBO already computed by the
+    fusion evaluator's CSCV over the strategy's own parameter-variant grid
+    (``has_real_rigor=True``). Overwriting that with a buy-and-hold cross-candidate
+    PBO — or with the 0.0 N<2 default — would clobber the correct value and
+    silently relax the gate. Only the buy-and-hold (agent/fixture) candidates,
+    which have a ``return_series`` and no real rigor, participate here.
+    """
+    agent_cands = [c for c in candidates if not c.has_real_rigor]
+    series_map: dict[str, list[float]] = {c.candidate_id: c.return_series for c in agent_cands if c.return_series}
     if len(series_map) < 2:
-        for c in candidates:
+        for c in agent_cands:
             c.rigor_verdict["pbo"] = 0.0  # PBO undefined for N<2
         return
     from archimedes.services.rigor_evaluator import compute_pbo
 
     pbo_by_id = compute_pbo(series_map)
-    for c in candidates:
+    for c in agent_cands:
         pbo = pbo_by_id.get(c.candidate_id, 0.0)
         c.rigor_verdict["pbo"] = round(float(pbo), 4)
         # PBO ≥ 0.5 means the library overfits the in-sample winner; tighten
@@ -680,6 +737,197 @@ async def _run_live_candidate(
     )
 
 
+# ── Fusion path (multi-paper synthesis folded into the live stream) ───────
+#
+# Stack A previously computed a "fusion" LABEL via _pick_pipeline() and emitted
+# a cosmetic pipeline_selected event, then ALWAYS dispatched to the single-agent
+# portfolio path — the choice was thrown away. This runner makes the choice
+# actually drive dispatch: it REUSES the existing, unit-tested fusion engine
+# (StrategyFusion.propose → evaluate_fusion_spec, the same path Stack B's
+# _run_fusion_job wires) and emits the SAME streaming SSE events the agent path
+# emits, so the UI surfaces fusion transparently with real DSR/PBO/OOS.
+
+
+class FusionUnavailable(Exception):
+    """Fusion was selected but couldn't actually run (disabled / <2 papers /
+    LLM declined). The caller falls back to the agent path and relabels the
+    pipeline honestly rather than silently mislabeling an agent run as fusion."""
+
+
+async def _run_fusion_candidate(
+    *,
+    candidate_id: str,
+    brief: GenerateBrief,
+    emit: _Emitter,
+    regime: str = "neutral",
+    agent: Any = None,  # noqa: ARG001 — signature parity with _run_live_candidate; fusion path builds its own client
+) -> _CandidateResult:
+    """Drive the existing fusion engine with per-step streaming event emission.
+
+    Builds a ``FusionBrief`` from the incoming ``GenerateBrief``, calls the
+    EXISTING engine (``StrategyFusion.propose()`` → ``evaluate_fusion_spec()`` —
+    reuse, no duplication), and returns a ``_CandidateResult`` carrying the real
+    rigor verdict (DSR/PBO/OOS/look-ahead) computed by the DSL backtest.
+
+    Raises ``FusionUnavailable`` when the engine can't produce an actionable,
+    ≥2-paper fusion (disabled, insufficient corpus, unparseable, or fewer than
+    ``MIN_PAPERS`` fused) so the caller can fall back to the agent path and
+    relabel honestly — fusion never silently degrades into a single-paper or
+    mislabeled result.
+    """
+    from archimedes.agents.strategy_fusion import (
+        MIN_PAPERS,
+        FusionBrief,
+        default_fusion,
+    )
+
+    # Surface the same "agent is thinking" cadence the agent path emits so the
+    # SSE stream renders progress rather than dumping the result on connect.
+    await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=1, max_iterations=3)
+    await emit.emit(
+        "tool_called",
+        candidate_id=candidate_id,
+        tool_name="select_candidates",
+        args_summary=f"asset_classes={brief.asset_classes or '(any)'}, regime={regime}",
+    )
+
+    # Map the GenerateBrief → FusionBrief (the engine's steer). asset_classes
+    # carries the user's universe steer; strategic_direction carries the intent.
+    fusion_brief = FusionBrief(
+        asset_classes=list(brief.asset_classes or []),
+        risk_appetite=brief.risk_appetite,
+        strategic_direction=brief.intent or "",
+        max_papers=brief.max_papers,
+    )
+
+    fusion = default_fusion()
+    proposal = await asyncio.wait_for(
+        asyncio.to_thread(fusion.propose, fusion_brief),
+        timeout=120.0,
+    )
+
+    await emit.emit(
+        "tool_result",
+        candidate_id=candidate_id,
+        tool_name="select_candidates",
+        result_summary=(f"fusion status={proposal.status}, papers={len(proposal.source_arxiv_ids)}"),
+    )
+
+    if not proposal.is_actionable:
+        # status in {disabled, insufficient_corpus, unparseable} OR <2 papers.
+        # Don't fabricate a fusion — bubble up so the caller falls back honestly.
+        raise FusionUnavailable(
+            f"fusion not actionable (status={proposal.status}, "
+            f"papers={len(proposal.source_arxiv_ids)}): {proposal.thesis[:160]}"
+        )
+
+    # ── Run the fusion evaluator pipeline (validate → backtest → rigor gate) ──
+    # Same call Stack B's _run_fusion_job makes. Produces the real DSR/PBO/OOS
+    # verdict on a DSL-interpreted backtest. Degrade gracefully (text-only
+    # fusion) if no machine-readable strategy_spec was emitted.
+    rigor_verdict: dict[str, Any]
+    has_real_rigor = False
+    asset_universe: list[str] = []
+    if proposal.strategy_spec is not None:
+        await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=3)
+        await emit.emit(
+            "tool_called",
+            candidate_id=candidate_id,
+            tool_name="evaluate_fusion_spec",
+            args_summary="backtest + DSR/PBO/OOS rigor gate",
+        )
+        from archimedes.services.fusion_evaluator import evaluate_fusion_spec
+
+        eval_result = await asyncio.wait_for(
+            asyncio.to_thread(evaluate_fusion_spec, proposal.strategy_spec),
+            timeout=120.0,
+        )
+        asset_universe = list(proposal.strategy_spec.get("asset_universe", []) or [])
+        if eval_result.success and eval_result.rigor is not None:
+            r = eval_result.rigor
+            bt = eval_result.backtest
+            rigor_verdict = {
+                "dsr": r.dsr,
+                "dsr_p_value": r.dsr_p_value,
+                "pbo": r.pbo_score,
+                "oos_sharpe": r.oos_sharpe,
+                "in_sample_sharpe": r.in_sample_sharpe,
+                "lookahead_audit_passed": bool(r.look_ahead_clean),
+                "look_ahead_label": r.look_ahead_label,
+                "num_trials": int(r.num_trials),
+                "passing": bool(r.passing),
+                "data_source": r.data_source,
+                "admissible": bool(r.admissible),
+                # Backtest headline metrics — surfaced alongside so the passport
+                # renders without denormalizing from a separate field (parity
+                # with Stack B's rigor_verdict_dict).
+                "sharpe_ratio": bt.sharpe_ratio,
+                "sortino_ratio": bt.sortino_ratio,
+                "max_drawdown": bt.max_drawdown,
+                "cagr": bt.cagr,
+                "calmar_ratio": bt.calmar_ratio,
+                "win_rate": bt.win_rate,
+                "total_trades": bt.total_trades,
+            }
+            has_real_rigor = True
+            await emit.emit(
+                "tool_result",
+                candidate_id=candidate_id,
+                tool_name="evaluate_fusion_spec",
+                result_summary=(
+                    f"DSR={r.dsr} p={r.dsr_p_value} PBO={r.pbo_score} OOS={r.oos_sharpe} passing={r.passing}"
+                ),
+            )
+        else:
+            rigor_verdict = {
+                "dsr": None,
+                "pbo": None,
+                "oos_sharpe": None,
+                "in_sample_sharpe": None,
+                "lookahead_audit_passed": False,
+                "passing": False,
+                "reason": (eval_result.error or "fusion backtest produced no metrics"),
+            }
+            await emit.emit(
+                "tool_result",
+                candidate_id=candidate_id,
+                tool_name="evaluate_fusion_spec",
+                result_summary=f"evaluation failed: {(eval_result.error or 'no metrics')[:120]}",
+            )
+    else:
+        # Text-only fusion (no DSL spec) — honest pre-backtest verdict, not a
+        # fabricated pass. The proposal is still actionable (≥2 papers fused).
+        rigor_verdict = {
+            "dsr": None,
+            "pbo": None,
+            "oos_sharpe": None,
+            "in_sample_sharpe": None,
+            "lookahead_audit_passed": False,
+            "passing": False,
+            "reason": "fusion produced no machine-readable strategy_spec — rigor gate not run",
+        }
+
+    source_papers = [{"arxiv_id": aid, "title": ""} for aid in proposal.source_arxiv_ids]
+    # Defensive: the engine already guarantees ≥ MIN_PAPERS via is_actionable.
+    assert len(proposal.source_arxiv_ids) >= MIN_PAPERS  # invariant guard (engine guarantees via is_actionable)
+
+    return _CandidateResult(
+        candidate_id=candidate_id,
+        strategy_name=proposal.strategy_name or f"Fusion — {brief.intent[:50].strip()}",
+        thesis=proposal.thesis,
+        asset_universe=asset_universe,
+        source_papers=source_papers,
+        weights={},  # fusion emits a DSL spec, not a static weight vector
+        reasoning=proposal.fusion_reasoning or proposal.novelty_rationale or "",
+        rigor_verdict=rigor_verdict,
+        passes_rigor=bool(rigor_verdict.get("passing", False)),
+        regime=regime,
+        generation_method="fusion",
+        source_arxiv_ids=list(proposal.source_arxiv_ids),
+        has_real_rigor=has_real_rigor,
+    )
+
+
 # ── Pipeline entry point ──────────────────────────────────────────────────
 
 
@@ -787,6 +1035,36 @@ async def run_generation(
             regimes: list[str] = ["bull", "bear"]
         else:
             regimes = ["neutral"] * n_candidates
+
+        # ── Resolve the ACTUAL runner that will drive dispatch ──
+        # _pick_pipeline computes a label; before this fix that label was thrown
+        # away and the agent path always ran. Now the choice DRIVES dispatch:
+        # when "fusion" is selected, dispatch to the real (unit-tested) fusion
+        # engine via _run_fusion_candidate. A lightweight, no-LLM viability
+        # precheck (fusion flag on + ≥2 candidate papers for the steer) keeps
+        # pipeline_selected honest — we only announce "fusion" if it can run.
+        # The single-agent path remains the FALLBACK (fusion not selected / no
+        # LLM / corpus <2 papers).
+        use_live = _llm_available()
+        agent_runner: Callable[..., Awaitable[_CandidateResult]] = (
+            _run_live_candidate if use_live else _run_fixture_candidate
+        )
+        runner = agent_runner
+        if pipeline_name == "fusion":
+            if use_live and _fusion_can_run(brief):
+                runner = _run_fusion_candidate
+            else:
+                # Selected fusion but it can't actually run (no LLM, or the steer
+                # yields <2 papers). Relabel honestly rather than mislabeling an
+                # agent run as fusion (claim integrity).
+                pipeline_name = "agent"
+                pipeline_reason = (
+                    "fusion selected but not runnable "
+                    f"({'no LLM backend' if not use_live else 'corpus yielded <2 papers for the steer'})"
+                    " — falling back to streaming agent"
+                )
+                runner = agent_runner
+
         await emit.emit(
             "pipeline_selected",
             pipeline=pipeline_name,
@@ -794,14 +1072,16 @@ async def run_generation(
             regimes=regimes,
         )
 
-        # Decide path: live agent vs fixture
-        use_live = _llm_available()
-        runner: Callable[..., Awaitable[_CandidateResult]] = _run_live_candidate if use_live else _run_fixture_candidate
-
         # If the user picked an allowlisted free-tier model, build a per-job
         # portfolio agent bound to that model; otherwise reuse the shared
         # singleton on the env default (behavior unchanged). Constructed once and
         # shared across both regime candidates so we don't rebuild a client twice.
+        #
+        # NOTE: `use_live` and `runner` are already resolved ABOVE, where the
+        # fusion-vs-agent dispatch decision is made. Do NOT redefine `runner`
+        # here — a second `runner = _run_live_candidate ...` would clobber the
+        # fusion runner selected for a "fusion" pipeline and silently revert to
+        # the agent path (the bug this rebase had to reconcile).
         job_agent = None
         if use_live and model:
             try:
@@ -812,7 +1092,6 @@ async def run_generation(
             except Exception as exc:
                 logger.warning("could not build per-job agent for model %r (%s); using default", model, exc)
                 job_agent = None
-
         # Library is the candidate pool the agent reasons over; surface it so
         # the UI can show "agent is considering N papers". Its size also feeds
         # the DSR multiple-testing correction below (selection-bias-corrections-
@@ -845,6 +1124,36 @@ async def run_generation(
                     regime=regime,
                     agent=job_agent,
                 )
+            except FusionUnavailable as exc:
+                # Fusion was selected + precheck passed, but at runtime the
+                # engine declined (e.g. the LLM fused <2 valid papers). Fall
+                # back to the agent path for THIS candidate rather than failing
+                # — and surface the relabel so the stream stays honest.
+                logger.info("fusion declined for %s (%s); falling back to agent: %s", candidate_id, regime, exc)
+                await emit.emit(
+                    "pipeline_selected",
+                    pipeline="agent",
+                    reason=f"fusion declined at runtime ({exc}); using streaming agent",
+                    regimes=regimes,
+                )
+                try:
+                    cand = await agent_runner(
+                        candidate_id=candidate_id,
+                        brief=brief,
+                        emit=emit,
+                        regime=regime,
+                        agent=job_agent,  # preserve the user's free-tier model pick on fallback (#748)
+                    )
+                except Exception as exc2:
+                    logger.exception("agent fallback %s (%s) failed: %s", candidate_id, regime, exc2)
+                    await emit.emit(
+                        "candidate_failed",
+                        candidate_id=candidate_id,
+                        regime=regime,
+                        error=str(exc2),
+                        message=f"No {regime} candidate available — your brief may be structurally one-sided.",
+                    )
+                    continue
             except Exception as exc:
                 logger.exception("candidate %s (%s) failed: %s", candidate_id, regime, exc)
                 await emit.emit(
@@ -930,8 +1239,17 @@ async def run_generation(
         # regime variants in parallel (yfinance + numpy is I/O-bound), then
         # upsert the BacktestResult row + updated passport metrics so the
         # next /api/strategies/ read surfaces empirical Sharpe/DSR/PBO/OOS.
+        # Fusion candidates already carry a real DSL backtest + rigor verdict
+        # (has_real_rigor); they emit no static weight vector, so the buy-and-hold
+        # portfolio_backtester doesn't apply. Skip them here — re-running a
+        # weight-less backtest would only emit backtest_failed and can't improve
+        # on the fusion evaluator's metrics.
         await asyncio.gather(
-            *[_backtest_and_persist(c, strategy_ids[c.candidate_id], emit, library_size) for c in candidates]
+            *[
+                _backtest_and_persist(c, strategy_ids[c.candidate_id], emit, library_size)
+                for c in candidates
+                if not c.has_real_rigor
+            ]
         )
 
         # ── Persist all candidates to episodic memory (T-PE.8) ──
@@ -941,7 +1259,10 @@ async def run_generation(
             for cand in candidates:
                 persist_proposal(
                     generation_id=job_id,
-                    agent="agent",
+                    # "fusion" for fused candidates, "agent" otherwise — the
+                    # episodic record now reflects which engine produced the
+                    # proposal rather than always claiming "agent".
+                    agent="fusion" if cand.generation_method == "fusion" else "agent",
                     intent=brief.intent,
                     strategy_spec={
                         "strategy_name": cand.strategy_name,
@@ -949,7 +1270,7 @@ async def run_generation(
                         "weights": cand.weights,
                         "asset_universe": cand.asset_universe,
                     },
-                    papers=[p.get("arxiv_id", "") for p in cand.source_papers],
+                    papers=[p.get("arxiv_id", "") for p in cand.source_papers] or list(cand.source_arxiv_ids),
                     rigor_verdict=cand.rigor_verdict,
                     extra={"candidate_id": cand.candidate_id, "selected": cand is best},
                 )
@@ -1027,7 +1348,11 @@ async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple
         with get_session() as session:
             record = upsert_strategy(
                 session,
-                generation_method="portfolio_agent_streaming",
+                # Provenance of record — "fusion" for multi-paper synthesis,
+                # "portfolio_agent_streaming" for the single-agent path. Was
+                # hardcoded to the agent method; now reads the candidate's own
+                # method so fusion candidates land in the library as fusion.
+                generation_method=c.generation_method,
                 strategy_name=c.strategy_name,
                 thesis=c.thesis,
                 source_papers=c.source_papers,
@@ -1064,7 +1389,7 @@ async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple
                     out_of_sample_sharpe=c.rigor_verdict.get("oos_sharpe") if c.rigor_verdict else None,
                 )
                 with get_session() as sess2:
-                    ingest_passport(sess2, passport, generation_method="fusion", force_update=True)
+                    ingest_passport(sess2, passport, generation_method=c.generation_method, force_update=True)
                     sess2.commit()
             except Exception as exc:
                 logger.warning("unified passport persist failed (non-blocking): %s", exc)

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -8,6 +8,7 @@ at the end.
 from __future__ import annotations
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -432,3 +433,237 @@ async def test_pipeline_multi_candidate_picks_best():
     best = next((e for e in store.events if e["event"] == "best_selected"), None)
     assert best is not None
     assert best["data"]["considered_count"] == 3
+
+
+# ── Fusion dispatch wire — hermetic end-to-end (Stack A) ───────────────────
+#
+# Proves the #1 fix: the "fusion" pipeline choice ACTUALLY drives dispatch.
+# Drives run_generation with fusion_enabled=true + a ≥20-paper fixture corpus +
+# a MOCKED LLM backend (no network, no real Anthropic/Bedrock), and asserts the
+# persisted strategy is generation_method=="fusion", cites ≥2 source_arxiv_ids,
+# and carries a non-null rigor verdict (real DSR/PBO/OOS from the DSL backtest).
+
+
+def _fixture_corpus(n: int = 24):
+    """A ≥n-paper fixture corpus the deterministic selector can rank.
+
+    Returns CorpusPaper objects (the type load_corpus yields). Titles/abstracts
+    carry equities+momentum+volatility terms so select_candidates matches them
+    for a generic steer.
+    """
+    from archimedes.agents.strategy_fusion import CorpusPaper
+
+    papers = []
+    for i in range(n):
+        papers.append(
+            CorpusPaper(
+                arxiv_id=f"24{i:02d}.{1000 + i}",
+                title=f"Cross-sectional equity momentum and volatility timing #{i}",
+                abstract=(
+                    "We study momentum, trend-following and volatility-managed "
+                    "portfolios across equities, with risk-on and defensive regimes."
+                ),
+                primary_category="q-fin.PM",
+                categories=("q-fin.PM", "q-fin.ST"),
+                published=f"2024-01-{(i % 27) + 1:02d}",
+            )
+        )
+    return papers
+
+
+class _MockFusionBackend:
+    """Deterministic LLM stand-in that returns a REAL, parseable fusion.
+
+    Mirrors the live LLMBackend Protocol (model_id / served_model / available /
+    complete). ``available`` is True so the fusion path treats it as a live
+    model. ``complete`` echoes back ≥2 of the candidate arxiv_ids it sees in the
+    user prompt (so the engine's anti-hallucination filter keeps them) and emits
+    a real Archimedes DSL strategy_spec the evaluator can backtest + rigor-gate.
+    """
+
+    model_id = "mock-fusion-model"
+    served_model = "mock-fusion-model-served"
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    def complete(self, system: str, user: str) -> str:
+        import json as _json
+        import re as _re
+
+        ids = _re.findall(r'"arxiv_id"\s*:\s*"([^"]+)"', user)[:3]
+        return _json.dumps(
+            {
+                "strategy_name": "Mock Fused SMA+Vol Strategy",
+                "thesis": "Fuses SMA-200 trend timing with vol-managed sizing (pre-backtest).",
+                "source_arxiv_ids": ids,
+                "fusion_reasoning": "Paper A contributes trend timing; paper B vol scaling.",
+                "novelty_rationale": "Combination not published together.",
+                "risk_notes": "Pre-backtest hypothesis; rigor gate applies.",
+                "strategy_spec": {
+                    "name": "Mock Fused SMA+Vol Strategy",
+                    "asset_universe": ["SPY"],
+                    "rebalance_frequency": "monthly",
+                    "entry": {"gt": ["close", "sma_200"]},
+                    "exit": {"lt": ["close", "sma_200"]},
+                    "position_sizing": {"type": "full_invested_when_in_market"},
+                    "source_arxiv_ids": ids,
+                    "look_ahead_safe": True,
+                    "indicators": ["sma_200"],
+                    "parameter_variants": {"sma_200": [150, 200, 250]},
+                },
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_fusion_dispatch_end_to_end_persists_fusion_strategy(tmp_path, monkeypatch):
+    """The fusion choice drives dispatch → a fusion strategy is persisted.
+
+    Hermetic: tmp SQLite DB, fixture corpus, mocked LLM backend — no network.
+    """
+    # Real (temp) DB so _persist_candidate's upsert_strategy lands a row. db.py
+    # binds its engine/SessionLocal at IMPORT time, so an env tweak alone won't
+    # rebind them once another test has imported db — rebind the globals here so
+    # get_session() (used by upsert_strategy) writes to OUR isolated sqlite file.
+    import archimedes.db as _db
+    from archimedes.agents import generation_pipeline as gp
+    from archimedes.agents import strategy_fusion as sf
+    from archimedes.models.strategy_store import StrategyRecord
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    test_engine = create_engine(
+        f"sqlite:///{tmp_path / 'fusion_e2e.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    monkeypatch.setattr(_db, "engine", test_engine)
+    monkeypatch.setattr(_db, "SessionLocal", sessionmaker(bind=test_engine, autocommit=False, autoflush=False))
+    # Register all ORM tables, then create them on the isolated engine.
+    from archimedes.models import kg, strategy_passport_record  # noqa: F401
+
+    _db.Base.metadata.create_all(bind=test_engine)
+
+    # Enable fusion + take the LIVE path (override the file's fixture autouse).
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
+    # Skip the buy-and-hold backtest network round-trip for any agent fallback.
+    monkeypatch.setenv("GENERATION_PIPELINE_SKIP_BACKTEST", "1")
+
+    # Live LLM available (validator + fusion gating both read this).
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+
+    async def _permissive_validate(brief):
+        return {
+            "is_valid": True,
+            "intent_summary": brief.intent[:140],
+            "asset_classes_inferred": brief.asset_classes or [],
+            "time_horizon_inferred": "unknown",
+            "risk_appetite_adjusted": brief.risk_appetite,
+        }
+
+    monkeypatch.setattr(gp, "_validate_brief", _permissive_validate)
+
+    # ≥20-paper fixture corpus, injected at the engine's load_corpus seam (both
+    # the no-LLM precheck and StrategyFusion read through this).
+    corpus = _fixture_corpus(24)
+    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: corpus)
+
+    # MOCKED LLM backend — inject via a StrategyFusion built with our backend +
+    # corpus so propose() does no network call. Patch on the agents module
+    # (the canonical home; services.strategy_fusion is the same object via
+    # the services/__init__ re-export).
+    monkeypatch.setattr(
+        sf,
+        "default_fusion",
+        lambda: sf.StrategyFusion(backend=_MockFusionBackend(), corpus=corpus),
+    )
+
+    store = _FakeStore()
+    brief = GenerateBrief(
+        intent="equity momentum with a volatility overlay",
+        risk_appetite="moderate",
+        asset_classes=["equities"],
+    )
+
+    await run_generation(job_id="job_fusion_e2e", brief=brief, store=store, dual_regime=False, n_candidates=1)
+
+    # ── pipeline_selected announced fusion (and it actually ran) ──
+    ps = [e for e in store.events if e["event"] == "pipeline_selected"]
+    assert ps, "no pipeline_selected event emitted"
+    assert ps[0]["data"]["pipeline"] == "fusion", (
+        f"fusion was not dispatched; got {ps[0]['data']['pipeline']!r} (reason={ps[0]['data'].get('reason')!r})"
+    )
+
+    # ── Same streaming events the agent path emits surfaced the fusion run ──
+    names = [e["event"] for e in store.events]
+    for required in ("candidate_drafted", "candidate_evaluated", "persisted", "done"):
+        assert required in names, f"fusion run did not emit {required!r} (events={names})"
+
+    # ── The persisted strategy is a real fusion with provenance + rigor ──
+    # Filter on the mock's exact name (not just generation_method) so a fusion
+    # row left by another test in the same session can't be mistaken for ours.
+    with _db.get_session() as session:
+        record = (
+            session.query(StrategyRecord)
+            .filter(
+                StrategyRecord.generation_method == "fusion",
+                StrategyRecord.strategy_name == "Mock Fused SMA+Vol Strategy",
+            )
+            .first()
+        )
+
+    assert record is not None, "no fusion StrategyRecord was persisted"
+    assert record.generation_method == "fusion"
+
+    source_papers = json.loads(record.source_papers)
+    arxiv_ids = [p.get("arxiv_id") for p in source_papers if p.get("arxiv_id")]
+    assert len(arxiv_ids) >= 2, f"fusion must cite ≥2 source_arxiv_ids; got {arxiv_ids}"
+
+    assert record.rigor_verdict is not None, "fusion strategy persisted without a rigor verdict"
+    verdict = json.loads(record.rigor_verdict)
+    # Real DSL backtest verdict: the four admission primitives + a passing bool.
+    for key in ("dsr", "pbo", "oos_sharpe", "passing"):
+        assert key in verdict, f"rigor verdict missing {key!r}: {verdict}"
+    assert isinstance(verdict["passing"], bool)
+    # A non-null rigor verdict (real DSR/PBO/OOS) — at least one numeric metric
+    # populated, proving evaluate_fusion_spec actually ran a backtest.
+    assert any(verdict.get(k) is not None for k in ("dsr", "pbo", "oos_sharpe")), (
+        f"rigor verdict has no populated numeric metric (backtest didn't run?): {verdict}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fusion_falls_back_to_agent_when_no_llm(monkeypatch):
+    """Fusion selected but no LLM → relabel to agent + run the fixture path.
+
+    Confirms the agent FALLBACK still works when fusion can't run, and that the
+    pipeline_selected event is HONEST (says "agent", not "fusion").
+    """
+    from archimedes.agents import generation_pipeline as gp
+
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    # Fixture path (no LLM) is forced by the file's autouse fixture; _pick_pipeline
+    # may still select fusion via the flag, but use_live=False must relabel.
+    monkeypatch.setattr(gp, "_pick_pipeline", lambda brief, mode_override=None: ("fusion", "forced fusion for test"))
+
+    store = _FakeStore()
+    brief = GenerateBrief(intent="balanced macro", risk_appetite="moderate")
+
+    with patch(
+        "archimedes.agents.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_fallback_001", "0xfb")),
+    ):
+        await run_generation(job_id="job_fusion_fallback", brief=brief, store=store, dual_regime=False, n_candidates=1)
+
+    ps = next(e for e in store.events if e["event"] == "pipeline_selected")
+    # No LLM (fixture path) → fusion is NOT runnable → honest relabel to agent.
+    assert ps["data"]["pipeline"] == "agent", (
+        f"fusion with no LLM must relabel to agent, got {ps['data']['pipeline']!r}"
+    )
+    # And the agent fallback still produced + persisted a candidate.
+    names = [e["event"] for e in store.events]
+    assert "candidate_drafted" in names
+    assert "persisted" in names
+    assert names[-1] == "done"

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -10,10 +10,15 @@ import { ASSET_GROUPS, SUPPORTED_ASSETS } from '../data/assetUniverse'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
-// /generate spine page. Single input — backend _pick_pipeline() auto-routes
-// between Fusion (novel synthesis), Architect (curated-library preview), and
-// the streaming agent. The SSE stream emits a `pipeline_selected` event right
-// after `brief_validated` so the frontend renders the correct result component.
+// /generate spine page. Single input — backend _pick_pipeline() picks a
+// pipeline and that choice now DRIVES dispatch (fusion-dispatch wire): when
+// "fusion" is selected and the corpus + LLM allow it, the streaming pipeline
+// runs the multi-paper fusion engine and surfaces it through the SAME SSE
+// events as the agent path (candidate_drafted / candidate_evaluated /
+// persisted); otherwise it falls back to the streaming agent. The SSE stream
+// emits a `pipeline_selected` event right after `brief_validated` carrying the
+// pipeline that ACTUALLY ran, so the frontend renders the correct result
+// component and the announced pipeline is never a label for a different run.
 
 const STORAGE_JOB_KEY = 'archimedes:currentJobId'
 const STORAGE_FUSION_JOB_KEY = 'archimedes:currentFusionJobId'
@@ -95,8 +100,10 @@ export default function Generate({ onNavigate }) {
       return
     }
     setStarting(true)
-    // Mode is intentionally omitted — the backend's _pick_pipeline() auto-routes
-    // between Fusion / Architect / Agent; the choice is surfaced in the SSE stream.
+    // Mode is intentionally omitted — the backend's _pick_pipeline() chooses the
+    // pipeline and that choice now DRIVES dispatch (fusion actually runs the
+    // fusion engine via the streaming path; otherwise the agent path runs). The
+    // pipeline that actually ran is surfaced in the SSE `pipeline_selected` event.
     // `model` is sent only when the user picked a free-tier model; the server
     // re-validates it against a free-tier allowlist and falls back to the env
     // default otherwise, so omitting it keeps the current behavior.


### PR DESCRIPTION
## The dispatch-gap diagnosis (Stack A vs B)

Two parallel generate stacks existed; only one ran the fusion engine, and the UI used the other:

- **Stack A (what the UI Generate button uses):** `POST /api/generate/start` → `generation_pipeline.run_generation`. It computed a `"fusion"` LABEL via `_pick_pipeline()` and emitted a cosmetic `pipeline_selected="fusion"` SSE event — then **always** dispatched to the single-agent 12-iteration `portfolio_agent` (`use_live = _llm_available()` → `_run_live_candidate`). **The fusion choice was thrown away** — there was no fusion runner branch.
- **Stack B (the real fusion route):** `POST /api/strategies/generate` → `_run_fusion_job` → `StrategyFusion.propose()` → `evaluate_fusion_spec()`, persisting with real DSR/PBO. But **no UI code POSTs to it** (dead GET-poller; `setFusionJobId` only ever called with `null`).

The engine itself (`agents/strategy_fusion.py`, `services/fusion_evaluator.py`) was real and unit-tested — it was simply unreachable from the product.

## What was wired in `run_generation`

Folded fusion **into the streaming pipeline** (the synthesis's preferred approach) so it surfaces through the same SSE events as the agent path:

1. **The `_pick_pipeline()` choice now drives dispatch.** When `"fusion"` is selected AND a real LLM is available AND a no-LLM viability precheck (`_fusion_can_run`: flag on + ≥2 candidate papers for the steer) passes, `run_generation` dispatches to a new `_run_fusion_candidate`. It builds a `FusionBrief` from the incoming `GenerateBrief`, calls the **existing** engine (`StrategyFusion.propose()` → `evaluate_fusion_spec()` — reuse, no duplication), and emits the **same** streaming events (`agent_iteration`/`tool_called`/`tool_result`/`candidate_drafted`/`candidate_evaluated`/`persisted`) so the UI renders it transparently with real DSR/PBO/OOS.
2. **Persists `generation_method="fusion"` with ≥2 `source_arxiv_ids`.** `_CandidateResult` gained `generation_method` / `source_arxiv_ids` / `has_real_rigor`; `_persist_candidate` now persists the candidate's own method (was hardcoded `portfolio_agent_streaming`). The episodic-memory + passport writes follow the same method.
3. **The single-agent path remains the FALLBACK.** Fusion not selected / no LLM / corpus <2 papers → `pipeline_selected` is **honestly relabeled** to `"agent"` (no silent mislabeling) and the agent path runs. A runtime fusion decline (`FusionUnavailable`, e.g. the LLM fused <2 valid papers) falls back per-candidate and re-emits a corrected `pipeline_selected`.
4. **`_patch_pbo` + the buy-and-hold backtest step skip fusion candidates** — they already carry a real CSCV PBO over their own parameter-variant grid and a real DSL backtest verdict; the buy-and-hold (weight-less) path would clobber those.

## Claim-integrity copy fix

`Generate.jsx` claimed the backend "auto-routes between Fusion/Architect/Agent" — false today (fusion never ran). Corrected the two comments to describe the choice **now driving dispatch** through the SSE stream, and that `pipeline_selected` carries the pipeline that **actually ran**. `pipeline_selected="fusion"` now fires only when fusion actually runs.

## The e2e test + the patch-path-bug verdict

- **Hermetic e2e test** (`test_fusion_dispatch_end_to_end_persists_fusion_strategy`): drives `run_generation` with `fusion_enabled=true` + a 24-paper fixture corpus + a MOCKED LLM backend (no network), and asserts the persisted strategy is `generation_method=="fusion"`, cites ≥2 `source_arxiv_ids`, and carries a non-null rigor verdict (real DSR/PBO/OOS from the DSL backtest). Plus `test_fusion_falls_back_to_agent_when_no_llm` proving the agent FALLBACK still runs (honestly relabeled) when fusion can't run.
- **The "patch-path bug" from the diagnosis was NOT real.** The diagnosis suspected `test_api_routes.py` patches `archimedes.services.strategy_fusion.default_fusion` while `_run_fusion_job` imports from `archimedes.agents.strategy_fusion`. But `services/__init__.py` re-exports `from archimedes.agents import strategy_fusion as strategy_fusion` — the two paths are the **same module object**, so the mock binds correctly (verified: `agents.strategy_fusion.default_fusion is <the patch>` → True). Left those tests as-is; they pass.

## Validation

- New e2e + fallback tests pass under the hermetic gate (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest ... -q`).
- Existing modules green: `test_generation_pipeline.py` (18 incl. new), `test_strategy_fusion.py`, `test_fusion_quality_scorer.py`, `test_generation_gating.py`, `test_api_routes.py::TestFusionEvaluatorIntegration`, plus `test_engine_v2 / test_strategy_store / test_strategy_publisher / test_api_routes` (82 + 75 passing across the sweeps; 2 pre-existing skips).
- ruff blocking gate clean (`E9,F63,F7,F40,F82` + `ruff format --check`). Generate.jsx changes are comment-only (no logic change).
- Agent FALLBACK confirmed working when fusion isn't selected.

**Core generate path — Dan review before merge; recommend a live-box smoke after deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M