### PR TITLE
[security] Fail-closed PII key + honest chat fallback (claim-integrity) !minor

### DIFF
--- a/backend/archimedes/services/chat_service.py
+++ b/backend/archimedes/services/chat_service.py
@@ -284,24 +284,60 @@ class ChatService:
             return "<vault_context>No metadata available for this vault.</vault_context>"
         return "<vault_context>\n" + "\n".join(parts) + "\n</vault_context>"
 
+    # Prefix that makes every fallback message visibly NON-AUTHORITATIVE, so a
+    # creds-less visitor never mistakes a canned string for a freshly-reasoned
+    # live answer (issue #752 — "claims must be true"). The live assistant did
+    # NOT run; this is static, non-personalized info, and it must read that way.
+    _FALLBACK_PREFIX = "⚠️ _The live assistant is temporarily unavailable — this is a static, non-personalized message (no live AI ran)._\n\n"
+
     def _canned_response(self, vault_address: str, user_message: str) -> dict | None:
-        """Fallback AI responses when Claude API is unavailable."""
+        """Static fallback when the LLM backend is unavailable or errors.
+
+        CRITICAL (issue #752): this path does NOT run the live agent, so it must
+        not assert product guarantees (rigor controls, on-chain anchoring) as
+        freshly-verified live output. Every message is prefixed as a static
+        offline notice, and the body points the user at the real, independently
+        verifiable surfaces (the strategy passport, the Traces tab) instead of
+        restating those guarantees as a fact the agent just established.
+        """
         msg_lower = user_message.lower()
 
         if any(w in msg_lower for w in ["performance", "return", "pnl", "profit"]):
-            text = "Portfolio performance is tracked on-chain via reasoning traces. Every rebalance decision is anchored with a verifiable hash on Arc. Check the Traces tab for the full history."
+            body = (
+                "I can't pull live numbers right now. This vault's performance and every "
+                "rebalance decision are recorded in the Traces tab — open it to read the "
+                "history and verify it yourself."
+            )
         elif any(w in msg_lower for w in ["rebalance", "adjust", "change"]):
-            text = "Rebalances are triggered by regime detection and strategy rotation signals. I execute them with full reasoning traces — the why, not just the what."
+            body = (
+                "I can't analyze the live portfolio right now. Past rebalances and the "
+                "reasoning behind them are listed in the Traces tab when you're ready to review."
+            )
         elif any(w in msg_lower for w in ["risk", "safe", "dangerous"]):
-            text = "Every Tier 1 strategy passes four selection-bias controls (DSR, PBO, walk-forward OOS, look-ahead audit) before admission. Rigor is the wedge."
+            body = (
+                "I can't give a live risk read right now. Each strategy's rigor checks and "
+                "their results are shown on its strategy passport — that's the place to "
+                "confirm what controls it actually passed."
+            )
         elif any(w in msg_lower for w in ["strategy", "paper", "research"]):
-            text = "Our strategies are grounded in peer-reviewed quantitative finance research. Each one carries a strategy passport with backtest results and paper-claim deltas."
+            body = (
+                "I can't look up this vault's strategies live right now. Each one carries a "
+                "strategy passport with its source paper, backtest results, and paper-claim "
+                "deltas — check the passport for the verifiable details."
+            )
         elif any(w in msg_lower for w in ["hello", "hi", "hey", "what"]):
-            text = "Hey! 👋 I'm Archimedes, your AI portfolio manager. Ask me about this vault's strategy, recent rebalances, or the research backing our positions."
+            body = (
+                "Hi — I'm Archimedes, the vault's AI portfolio manager, but I'm offline at "
+                "the moment so I can't answer live. Try again shortly, or browse the strategy "
+                "passport and Traces tab in the meantime."
+            )
         else:
-            text = "Good question. I'm monitoring the portfolio and market conditions. Feel free to ask about specific strategies, performance, or our research-backed approach."
+            body = (
+                "I'm offline right now and can't answer live. Try again shortly, or explore "
+                "this vault's strategy passport and Traces tab for the recorded details."
+            )
 
-        return self.post_ai_message(vault_address, text, trigger="mention")
+        return self.post_ai_message(vault_address, self._FALLBACK_PREFIX + body, trigger="mention")
 
     def get_message_count(self, vault_address: str) -> int:
         """Get total message count for a vault."""

--- a/backend/archimedes/services/email_crypto.py
+++ b/backend/archimedes/services/email_crypto.py
@@ -1,10 +1,10 @@
 """Email encryption at rest using Fernet (symmetric encryption).
 
 Uses a key derived from the ``EMAIL_ENCRYPTION_KEY`` env var. If the env var
-is not set, a *random per-process* key is generated at startup — emails
-encrypted in one dev session cannot be decrypted in another. This is
-intentional: dev data is disposable, and it means there is no fixed fallback
-secret that could decrypt a deployment that merely forgot to set the env var.
+is not set, a *random per-process* key is generated — emails encrypted in one
+dev session cannot be decrypted in another. This is intentional for dev: dev
+data is disposable, and there is no fixed fallback secret that could decrypt a
+deployment that merely forgot to set the env var.
 
 The Fernet key must be a URL-safe base64-encoded 32-byte value.
 
@@ -13,9 +13,16 @@ Security model:
   - The DB column stores the Fernet token as a string.
   - If the key is rotated, existing tokens become unreadable — a migration
     script would need to re-encrypt. For v1, the key is fixed (per deployment).
-  - Production startup rejects a missing EMAIL_ENCRYPTION_KEY (fail-closed in
-    main.py when PUBLIC_DOMAIN is set), so the random fallback only ever runs
-    in local dev / CI where no real user data is at risk.
+  - **Fail-closed in production at the crypto layer (issue #753).** In a
+    production context (``PUBLIC_DOMAIN`` set) with no explicit dev opt-in,
+    a missing ``EMAIL_ENCRYPTION_KEY`` raises rather than silently falling
+    back to a random per-process key. The random-key fallback would otherwise
+    encrypt real PII with a key that does not survive a restart (silent data
+    loss) and is enforced nowhere. ``main.py`` keeps an equivalent boot-time
+    check for an earlier, clearer fatal message — this module-level guard is
+    defense-in-depth so the protection travels with the module to *any* entry
+    point (worker, ops script, direct service import), not just the FastAPI
+    app-boot path.
 """
 
 from __future__ import annotations
@@ -30,15 +37,41 @@ from cryptography.fernet import Fernet
 logger = logging.getLogger(__name__)
 
 
+def _is_dev_context() -> bool:
+    """True when the random-key fallback is acceptable (local dev / CI / tests).
+
+    The fallback is allowed only when this is NOT a production deployment.
+    Production is signalled by ``PUBLIC_DOMAIN`` (the same marker ``main.py``
+    uses). An explicit ``TESTING`` opt-in (the repo convention, see
+    ``api/limiter.py``) keeps the dev/CI path working even if a test sets
+    ``PUBLIC_DOMAIN`` to exercise production wiring.
+    """
+    if os.getenv("TESTING"):
+        return True
+    return not os.getenv("PUBLIC_DOMAIN")
+
+
 def _derive_key() -> bytes:
     """Derive a Fernet key from env var, or a random per-process key in dev.
 
     With ``EMAIL_ENCRYPTION_KEY`` set the key is deterministic (so tokens
-    survive restarts). Unset, we generate a fresh random key — there is no
-    fixed, publicly-known fallback secret.
+    survive restarts). Unset:
+      - in a dev/CI/test context → a fresh random key (data is disposable).
+      - in production (``PUBLIC_DOMAIN`` set, no ``TESTING`` opt-in) → raise.
+        Encrypting real PII with an ephemeral random key would silently lose
+        data on restart and is enforced nowhere; we fail closed instead
+        (issue #753). This guard travels with the module, so it holds for any
+        entry point — not just the FastAPI app-boot check in ``main.py``.
     """
     secret = os.getenv("EMAIL_ENCRYPTION_KEY", "").strip()
     if not secret:
+        if not _is_dev_context():
+            raise RuntimeError(
+                "FATAL: EMAIL_ENCRYPTION_KEY must be set in production "
+                "(PUBLIC_DOMAIN is configured). Refusing to encrypt PII with a "
+                "random per-process key that cannot be decrypted after restart. "
+                'Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"'
+            )
         logger.warning(
             "EMAIL_ENCRYPTION_KEY is not set — using a random per-process key. "
             "Encrypted emails will NOT survive a process restart. Set "

--- a/backend/tests/services/test_chat_service.py
+++ b/backend/tests/services/test_chat_service.py
@@ -9,6 +9,7 @@ Added 2026-05-24 as part of the #147 coverage-gate lift.
 
 from __future__ import annotations
 
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -194,23 +195,61 @@ class TestEventPosters:
 
 
 class TestCannedResponse:
-    @pytest.mark.parametrize(
-        "user_message,expected_marker",
-        [
-            ("How is performance?", "performance"),
-            ("Should we rebalance soon?", "Rebalances"),
-            ("Is this risky?", "selection-bias"),
-            ("What strategy is this?", "research"),
-            ("Hello!", "👋"),
-            ("Just listing without any trigger", "monitoring the portfolio"),
-        ],
-    )
-    def test_keyword_routing(self, user_message: str, expected_marker: str) -> None:
+    """The fallback path (no live AI) must read as static, non-authoritative
+    info — never as a freshly-reasoned live agent answer (issue #752).
+    """
+
+    # Representative user messages spanning every keyword branch + the default.
+    _MESSAGES: ClassVar[list[str]] = [
+        "How is performance?",
+        "Should we rebalance soon?",
+        "Is this risky?",
+        "What strategy is this?",
+        "Hello!",
+        "Just listing without any trigger",
+    ]
+
+    @pytest.mark.parametrize("user_message", _MESSAGES)
+    def test_every_branch_is_marked_non_authoritative(self, user_message: str) -> None:
+        """Every fallback message carries the offline/static prefix."""
         with patch.object(ChatService, "post_ai_message") as poster:
             poster.return_value = {"id": 1}
             ChatService()._canned_response("0xv", user_message)
         text = poster.call_args.args[1]
-        assert expected_marker in text
+        assert text.startswith(ChatService._FALLBACK_PREFIX)
+        lowered = text.lower()
+        # Honest framing words that signal "this is not a live answer".
+        assert ("unavailable" in lowered) or ("offline" in lowered)
+        assert "no live ai ran" in lowered
+
+    @pytest.mark.parametrize("user_message", _MESSAGES)
+    def test_no_authoritative_product_claims_in_fallback(self, user_message: str) -> None:
+        """Anti-goal guard (#752): the fallback must NOT restate product
+        guarantees as freshly-verified live output. The specific marketing
+        sentences that previously leaked through this path are forbidden.
+        """
+        with patch.object(ChatService, "post_ai_message") as poster:
+            poster.return_value = {"id": 1}
+            ChatService()._canned_response("0xv", user_message)
+        text = poster.call_args.args[1]
+        forbidden = [
+            "Every Tier 1 strategy passes four selection-bias controls",
+            "anchored with a verifiable hash on Arc",
+            "Rigor is the wedge",
+            "Portfolio performance is tracked on-chain via reasoning traces",
+        ]
+        for claim in forbidden:
+            assert claim not in text, f"fallback must not assert: {claim!r}"
+
+    def test_fallback_points_to_verifiable_surfaces(self) -> None:
+        """Honest static info may direct the user to the real, independently
+        verifiable surfaces (passport / Traces tab) — that's allowed and good.
+        """
+        with patch.object(ChatService, "post_ai_message") as poster:
+            poster.return_value = {"id": 1}
+            ChatService()._canned_response("0xv", "Is this risky?")
+        text = poster.call_args.args[1]
+        assert ("passport" in text.lower()) or ("traces" in text.lower())
 
 
 class TestGetMessageCount:

--- a/backend/tests/services/test_email_crypto.py
+++ b/backend/tests/services/test_email_crypto.py
@@ -64,3 +64,57 @@ def test_env_var_changes_key(monkeypatch) -> None:
     monkeypatch.delenv("EMAIL_ENCRYPTION_KEY", raising=False)
     default_key = _derive_key()
     assert custom_key != default_key
+
+
+# ── Fail-closed in production (issue #753) ────────────────────────────────
+
+
+def test_derive_key_fails_closed_in_production_without_key(monkeypatch) -> None:
+    """Prod context (PUBLIC_DOMAIN set, no dev opt-in) + no key → raise.
+
+    Refusing the random-key fallback prevents encrypting real PII with an
+    ephemeral key that cannot be decrypted after a restart.
+    """
+    monkeypatch.delenv("EMAIL_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("PUBLIC_DOMAIN", "https://archimedes-arc.com")
+    with pytest.raises(RuntimeError, match="EMAIL_ENCRYPTION_KEY"):
+        _derive_key()
+
+
+def test_encrypt_fails_closed_in_production_without_key(monkeypatch) -> None:
+    """The fail-closed guard also fires through the public encrypt entrypoint."""
+    monkeypatch.delenv("EMAIL_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("PUBLIC_DOMAIN", "https://archimedes-arc.com")
+    with pytest.raises(RuntimeError, match="EMAIL_ENCRYPTION_KEY"):
+        encrypt_email("alice@example.com")
+
+
+def test_derive_key_dev_path_works_without_key_no_public_domain(monkeypatch) -> None:
+    """Local dev (no PUBLIC_DOMAIN, no key) still gets a random key — no raise."""
+    monkeypatch.delenv("EMAIL_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("PUBLIC_DOMAIN", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    key = _derive_key()  # must not raise
+    assert isinstance(key, bytes)
+    assert len(key) == 44
+
+
+def test_derive_key_testing_optin_overrides_production_marker(monkeypatch) -> None:
+    """TESTING=1 keeps the dev path working even if PUBLIC_DOMAIN is set."""
+    monkeypatch.delenv("EMAIL_ENCRYPTION_KEY", raising=False)
+    monkeypatch.setenv("PUBLIC_DOMAIN", "https://archimedes-arc.com")
+    monkeypatch.setenv("TESTING", "1")
+    key = _derive_key()  # must not raise — TESTING is the explicit dev opt-in
+    assert isinstance(key, bytes)
+    assert len(key) == 44
+
+
+def test_production_with_key_still_works(monkeypatch) -> None:
+    """Prod with the key set is the normal, deterministic, non-raising path."""
+    monkeypatch.setenv("PUBLIC_DOMAIN", "https://archimedes-arc.com")
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("EMAIL_ENCRYPTION_KEY", "a-real-prod-secret")
+    token = encrypt_email("alice@example.com")
+    assert decrypt_email(token) == "alice@example.com"


### PR DESCRIPTION
Fixes two verified roadmap-audit findings in one PR. Both are scoped narrowly to the broken path; no live/true claim is weakened and contracts are untouched.

Closes #752 (claim-integrity) and #753 (PII / security).

## #752 — Honest, non-authoritative chat fallback (claim-integrity)

`ChatService._canned_response` (the path used when no LLM backend is available, or after a live LLM call raises) previously returned **hardcoded product claims** styled exactly like a live-AI answer — posted under the agent wallet with `is_ai=True, verified=True`, signaled only by a server `logger.warning`. A creds-less visitor (e.g. a judge) got canned guarantees ("Every Tier 1 strategy passes four selection-bias controls…", "anchored with a verifiable hash on Arc") **indistinguishable from a freshly-reasoned live answer**. That violates the repo's #1 rule — *claims must be true / backed by the live path*.

**Fix (fallback path only):**
- Every fallback message now opens with a visible static/offline notice: *"The live assistant is temporarily unavailable — this is a static, non-personalized message (no live AI ran)."*
- The bodies no longer assert rigor / on-chain guarantees as fresh live output. They point the user at the **real, independently verifiable surfaces** (strategy passport, Traces tab) instead of restating the guarantee as a fact the agent just established. Genuinely-true static pointers are preserved, marked as static.
- The genuine live-LLM path (`_generate_ai_response` happy path) is **unchanged**.

## #753 — Fail-closed PII encryption key at the crypto layer (security)

`email_crypto._derive_key()` falls back to a **random per-process key** when `EMAIL_ENCRYPTION_KEY` is unset. The only fail-closed guard was in `main.py` (app boot). Any entry point that doesn't import `archimedes.main` (worker, ops script, future task, direct service import) could encrypt real PII with an ephemeral key that doesn't survive a restart (silent data loss) and is enforced nowhere.

**Fix:**
- `_derive_key()` now **fails closed in production**: when `PUBLIC_DOMAIN` is set, there is no `TESTING` opt-in, and the key is unset → raise `RuntimeError` instead of returning a random key. The guard now **travels with the module**, holding for any entry point.
- `main.py`'s boot-time check is **retained** as defense-in-depth (earlier, clearer fatal message).
- Dev/CI/test UX preserved: absence of `PUBLIC_DOMAIN` (local dev) or the explicit `TESTING` opt-in keeps the random-key path working; the key-set path stays deterministic (no token-compat break).

## Tests

- `test_email_crypto.py`: prod-no-key raises (via `_derive_key` and `encrypt_email`); dev path (no `PUBLIC_DOMAIN`) works; `TESTING` opt-in overrides the prod marker; key-set prod path round-trips.
- `test_chat_service.py`: every fallback branch is marked non-authoritative (offline prefix + "no live ai ran"); the four forbidden product-claim strings are asserted **absent**; fallback still points to verifiable surfaces.

## Validation

- `pytest` full backend unit suite (`-m "not integration"`): **1783 passed, 2 skipped** (pre-existing chain-client skips).
- Hermetic gate green for `test_email_crypto.py`, `test_chat_service.py`, `test_security_hardening.py`.
- `ruff format --check` + `ruff check` (full ruleset) clean on all four changed files.

## Anti-goals respected

- Did not change the live-LLM happy path message content.
- Did not weaken any claim true on the live path.
- Did not remove `main.py`'s boot check or change the key-derivation algorithm when the key is set.
- Did not touch contracts.

Reviewer note: backend services lane (Daniel R. lead) + security-relevant (PII / claim-integrity), so this warrants the more-careful review CLAUDE.md §6 calls for. Do **not** auto-merge — left open per instructions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M