### PR TITLE
[contracts] T0.3 — commit-before-trade enforcement + tradeId binding (#589) !minor

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -67,6 +67,7 @@ contract DeployScript is Script {
             agentAddr,
             address(ammRouter),
             USDC_ARC_TESTNET,
+            address(traceRegistry),
             owner,
             owner
         );

--- a/contracts/script/DeployInfra.s.sol
+++ b/contracts/script/DeployInfra.s.sol
@@ -40,6 +40,7 @@ contract DeployInfra is Script {
             agentAddr,
             address(ammRouter),
             USDC_ARC_TESTNET,
+            address(traceRegistry),
             owner,
             owner
         );

--- a/contracts/src/ReasoningTraceRegistry.sol
+++ b/contracts/src/ReasoningTraceRegistry.sol
@@ -123,7 +123,16 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
         require(tradeId != bytes32(0), "Empty trade id");
         // One outstanding commitment per (vault, trade) at a time — a second commit
         // must not clobber an unexecuted one. (#589)
-        require(_pendingTrade[vault][tradeId] == 0, "Pending commitment exists");
+        uint256 pending = _pendingTrade[vault][tradeId];
+        if (pending != 0) {
+            Commitment storage p = _commitments[pending];
+            if (p.executeBlock != 0 || p.revealBlock != 0) {
+                // Stale pointer (already executed/revealed) — clear so this tradeId can be reused.
+                delete _pendingTrade[vault][tradeId];
+            } else {
+                revert("Pending commitment exists");
+            }
+        }
         // Time-lock: the covered execution must be claimed strictly after this
         // block's timestamp — i.e. it lands at least one block after the commit.
         require(claimedExecutionTime > block.timestamp, "Time-lock: execution must follow commit");

--- a/contracts/src/ReasoningTraceRegistry.sol
+++ b/contracts/src/ReasoningTraceRegistry.sol
@@ -36,6 +36,8 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
         uint64 commitBlock;
         uint64 claimedExecutionTime;
         uint64 revealBlock; // 0 until revealed
+        bytes32 tradeId; // #589: binds this commitment to a specific rebalance
+        uint64 executeBlock; // #589: 0 until the covered trade executes (single-use guard)
         string storagePointer; // empty until revealed
     }
 
@@ -55,6 +57,10 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
 
     /// @notice vault => agent => explicitly granted anchoring authority
     mapping(address => mapping(address => bool)) private _vaultAgents;
+
+    /// @notice vault => tradeId => trace ID of the fresh (unexecuted) commitment that
+    ///         binds that trade. Set by commit(), cleared by executeTrade(). (#589)
+    mapping(address => mapping(bytes32 => uint256)) private _pendingTrade;
 
     // ─── Constructor ─────────────────────────────────────────────────
 
@@ -109,10 +115,15 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
         address vault,
         bytes32 contentHash,
         uint64 claimedExecutionTime,
+        bytes32 tradeId,
         bytes calldata tradeIntentSummary
     ) external override returns (uint256 traceId) {
         require(isAuthorizedForVault(vault, msg.sender), "Not authorized for vault");
         require(contentHash != bytes32(0), "Empty content hash");
+        require(tradeId != bytes32(0), "Empty trade id");
+        // One outstanding commitment per (vault, trade) at a time — a second commit
+        // must not clobber an unexecuted one. (#589)
+        require(_pendingTrade[vault][tradeId] == 0, "Pending commitment exists");
         // Time-lock: the covered execution must be claimed strictly after this
         // block's timestamp — i.e. it lands at least one block after the commit.
         require(claimedExecutionTime > block.timestamp, "Time-lock: execution must follow commit");
@@ -125,10 +136,45 @@ contract ReasoningTraceRegistry is IReasoningTraceRegistry, Ownable {
             commitBlock: uint64(block.number),
             claimedExecutionTime: claimedExecutionTime,
             revealBlock: 0,
+            tradeId: tradeId,
+            executeBlock: 0,
             storagePointer: ""
         });
+        _pendingTrade[vault][tradeId] = traceId;
 
         emit TraceCommitted(traceId, contentHash, msg.sender, vault, block.number, claimedExecutionTime);
+    }
+
+    /// @inheritdoc IReasoningTraceRegistry
+    /// @dev The on-chain commit-before-trade enforcement point. The Vault calls this
+    ///      from rebalance() (so msg.sender IS the vault), consuming the fresh
+    ///      commitment that binds the exact trade being executed. No matching, in-time,
+    ///      unconsumed commitment => revert => the trade cannot settle.
+    function executeTrade(bytes32 tradeId) external override returns (uint256 traceId) {
+        traceId = _pendingTrade[msg.sender][tradeId];
+        require(traceId != 0, "No matching commitment");
+
+        Commitment storage c = _commitments[traceId];
+        // Commit must strictly precede the trade block — a same-block commit+trade is
+        // atomically forgeable and would defeat the "trace existed before the trade" proof.
+        require(block.number > c.commitBlock, "Time-lock: execute in commit block");
+        require(c.executeBlock == 0, "Already executed");
+        require(c.revealBlock == 0, "Already revealed");
+
+        c.executeBlock = uint64(block.number);
+        delete _pendingTrade[msg.sender][tradeId];
+
+        emit TradeExecuted(traceId, msg.sender, tradeId, block.number);
+    }
+
+    /// @inheritdoc IReasoningTraceRegistry
+    function pendingTradeCommitment(address vault, bytes32 tradeId)
+        external
+        view
+        override
+        returns (uint256 traceId)
+    {
+        return _pendingTrade[vault][tradeId];
     }
 
     /// @inheritdoc IReasoningTraceRegistry

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/utils/Pausable.sol";
 import "./interfaces/IVault.sol";
 import "./interfaces/IAMMRouter.sol";
 import "./interfaces/IAssetRegistry.sol";
+import "./interfaces/IReasoningTraceRegistry.sol";
 import "./PriceOracle.sol";
 
 /// @title Vault
@@ -100,6 +101,12 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         arbitrary address — see setTokenOraclesFromRegistry.
     IAssetRegistry public assetRegistry;
 
+    /// @notice On-chain reasoning-trace registry that enforces commit-before-trade.
+    ///         Wired immutably at construction (the factory passes the deployed
+    ///         registry). rebalance() consumes a matching fresh commitment here
+    ///         before any swap, so a trade cannot settle without a prior commit (#589).
+    IReasoningTraceRegistry public immutable traceRegistry;
+
     // ─── Errors ──────────────────────────────────────────────────────
 
     error ZeroAmount();
@@ -114,6 +121,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     error InvalidOraclePrice();
     error OracleNotRegistered(address token);
     error AssetRegistryNotSet();
+    error TraceRegistryNotSet();
 
     // ─── Events (Vault-local) ────────────────────────────────────────
 
@@ -122,12 +130,16 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     event PlatformFeeRecipientSet(address indexed oldRecipient, address indexed newRecipient);
     event AssetRegistrySet(address indexed registry);
     event TokenOraclesSetFromRegistry(uint256 count);
+    /// @notice Emitted by rebalance() with the tradeId it enforced and the trace ID of
+    ///         the commitment it consumed in the trace registry (#589).
+    event RebalanceTrace(bytes32 indexed tradeId, uint256 indexed traceId);
 
     // ─── Constructor ─────────────────────────────────────────────────
 
     constructor(
         address _usdc,
         address _ammRouter,
+        address _traceRegistry,
         address _creator,
         uint8 _tier,
         uint16 _managementFeeBps,
@@ -137,8 +149,12 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         string memory _name,
         string memory _symbol
     ) ERC20(_name, _symbol) Ownable(_creator) {
+        // Strict commit-before-trade: the trace registry is required and immutable, so
+        // a vault can never exist in a state where rebalance() skips the commit check (#589).
+        if (_traceRegistry == address(0)) revert TraceRegistryNotSet();
         asset = _usdc;
         ammRouter = IAMMRouter(_ammRouter);
+        traceRegistry = IReasoningTraceRegistry(_traceRegistry);
         creator = _creator;
         tier = _tier;
         managementFeeBps = _managementFeeBps;
@@ -321,6 +337,16 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         address[] calldata tokensOut,
         uint256[] calldata amountsOut
     ) external override onlyManager nonReentrant whenNotPaused {
+        // Commit-before-trade enforcement (#589): the agent must have committed a
+        // matching reasoning trace in an EARLIER block. Recompute the trade identifier
+        // from the exact swap parameters and consume the fresh commitment — reverts if
+        // none binds this (vault, trade), so a trade cannot settle without a prior commit.
+        // (Deposits/withdrawals never touch the registry — funds paths stay registry-
+        // independent so a registry issue can never lock user funds.)
+        bytes32 tradeId = keccak256(abi.encode(tokensIn, amountsIn, tokensOut, amountsOut));
+        uint256 traceId = traceRegistry.executeTrade(tradeId);
+        emit RebalanceTrace(tradeId, traceId);
+
         _accrueFees();
 
         // Sell tokens (swap tokenOut -> USDC via AMM)

--- a/contracts/src/VaultFactory.sol
+++ b/contracts/src/VaultFactory.sol
@@ -16,6 +16,10 @@ contract VaultFactory is IVaultFactory, Ownable {
     address public immutable override ammRouter;
     address public immutable override usdc;
 
+    /// @notice Trace registry passed to every vault this factory creates, so each vault
+    ///         enforces commit-before-trade in rebalance() (#589).
+    address public immutable traceRegistry;
+
     address public platformFeeRecipient;
 
     address[] private _vaults;
@@ -31,12 +35,15 @@ contract VaultFactory is IVaultFactory, Ownable {
         address _agentAddress,
         address _ammRouter,
         address _usdc,
+        address _traceRegistry,
         address _platformFeeRecipient,
         address _owner
     ) Ownable(_owner) {
+        require(_traceRegistry != address(0), "Trace registry required");
         agentAddress = _agentAddress;
         ammRouter = _ammRouter;
         usdc = _usdc;
+        traceRegistry = _traceRegistry;
         platformFeeRecipient = _platformFeeRecipient;
     }
 
@@ -55,6 +62,7 @@ contract VaultFactory is IVaultFactory, Ownable {
         Vault newVault = new Vault(
             usdc,
             ammRouter,
+            traceRegistry,
             msg.sender,
             vaultTier,
             managementFeeBps,

--- a/contracts/src/interfaces/IReasoningTraceRegistry.sol
+++ b/contracts/src/interfaces/IReasoningTraceRegistry.sol
@@ -35,6 +35,15 @@ interface IReasoningTraceRegistry {
         uint256 revealBlock
     );
 
+    /// @notice Emitted when a vault consumes a matching commitment as it executes
+    ///         the covered trade (the on-chain commit-before-trade enforcement point).
+    event TradeExecuted(
+        uint256 indexed traceId,
+        address indexed vault,
+        bytes32 indexed tradeId,
+        uint256 executeBlock
+    );
+
     event VaultAgentSet(address indexed vault, address indexed agent, bool authorized);
 
     // ── Write ────────────────────────────────────────────────
@@ -59,14 +68,37 @@ interface IReasoningTraceRegistry {
     /// @param vault The vault the upcoming trade applies to
     /// @param contentHash keccak256 of the canonical trace JSON
     /// @param claimedExecutionTime Unix time the covered trade is claimed to execute at
+    /// @param tradeId Identifier binding this commitment to a specific trade —
+    ///        keccak256(abi.encode(tokensIn, amountsIn, tokensOut, amountsOut)) of the
+    ///        rebalance the commitment authorizes (#589). The Vault recomputes this in
+    ///        rebalance() and calls executeTrade(tradeId); a mismatch means no matching
+    ///        commitment exists and the trade reverts.
     /// @param tradeIntentSummary ABI-encoded: decisionType, numTrades, totalNotionalUsdc
     /// @return traceId Auto-incrementing trace ID (shared ID space with publishTrace)
     function commit(
         address vault,
         bytes32 contentHash,
         uint64 claimedExecutionTime,
+        bytes32 tradeId,
         bytes calldata tradeIntentSummary
     ) external returns (uint256 traceId);
+
+    /// @notice Consume the fresh commitment that authorizes `tradeId` for the calling
+    ///         vault, at the moment the vault executes that trade. MUST be called by the
+    ///         vault itself (msg.sender == vault). Reverts if no fresh (committed in an
+    ///         earlier block, unrevealed, not-yet-executed) commitment binds this
+    ///         (vault, tradeId) — this is the on-chain "a trade cannot settle without a
+    ///         prior matching commit" guarantee (#589 / #510 acceptance criterion 1).
+    /// @param tradeId keccak256(abi.encode(tokensIn, amountsIn, tokensOut, amountsOut))
+    /// @return traceId The trace ID of the consumed commitment
+    function executeTrade(bytes32 tradeId) external returns (uint256 traceId);
+
+    /// @notice The trace ID of the fresh, unconsumed commitment binding (vault, tradeId),
+    ///         or 0 if none exists. View counterpart to executeTrade for off-chain checks.
+    function pendingTradeCommitment(address vault, bytes32 tradeId)
+        external
+        view
+        returns (uint256 traceId);
 
     /// @notice Reveal the full trace content AFTER the trade settles.
     ///         Verifies keccak256(fullTraceContent) matches the committed hash,

--- a/contracts/test/Registry.t.sol
+++ b/contracts/test/Registry.t.sol
@@ -239,7 +239,7 @@ contract ReasoningTraceRegistryTest is Test {
     function test_revert_commit_unauthorized() public {
         vm.prank(attacker);
         vm.expectRevert("Not authorized for vault");
-        registry.commit(vault1, keccak256("forged"), uint64(block.timestamp + 60), "");
+        registry.commit(vault1, keccak256("forged"), uint64(block.timestamp + 60), keccak256("trade"), "");
     }
 
     function test_revert_setVaultAgent_non_owner() public {
@@ -270,7 +270,7 @@ contract ReasoningTraceRegistryTest is Test {
 
         vm.prank(vaultAgent);
         uint256 traceId = registry.commit(
-            address(vault), keccak256("trace"), uint64(block.timestamp + 60), ""
+            address(vault), keccak256("trace"), uint64(block.timestamp + 60), keccak256("trade"), ""
         );
         assertEq(traceId, 1);
     }
@@ -289,7 +289,7 @@ contract ReasoningTraceRegistryTest is Test {
             1, contentHash, agent1, vault1, block.number, executionTime
         );
         vm.prank(agent1);
-        uint256 traceId = registry.commit(vault1, contentHash, executionTime, intent);
+        uint256 traceId = registry.commit(vault1, contentHash, executionTime, keccak256("trade"), intent);
         assertEq(traceId, 1);
 
         // T-3: next block — the trade executes (simulated by advancing the chain)
@@ -347,7 +347,7 @@ contract ReasoningTraceRegistryTest is Test {
     function test_revert_reveal_hash_mismatch() public {
         vm.prank(agent1);
         uint256 traceId = registry.commit(
-            vault1, keccak256("the real trace"), uint64(block.timestamp + 10), ""
+            vault1, keccak256("the real trace"), uint64(block.timestamp + 10), keccak256("trade"), ""
         );
 
         vm.roll(block.number + 1);
@@ -363,20 +363,20 @@ contract ReasoningTraceRegistryTest is Test {
         // the covered trade has to land at least one block after the commit.
         vm.prank(agent1);
         vm.expectRevert("Time-lock: execution must follow commit");
-        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp), "");
+        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp), keccak256("trade"), "");
 
         // Claimed execution in the past fails too
         vm.warp(block.timestamp + 100);
         vm.prank(agent1);
         vm.expectRevert("Time-lock: execution must follow commit");
-        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp - 1), "");
+        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp - 1), keccak256("trade"), "");
     }
 
     function test_revert_reveal_in_commit_block() public {
         bytes memory content = "trace";
         vm.prank(agent1);
         uint256 traceId = registry.commit(
-            vault1, keccak256(content), uint64(block.timestamp + 1), ""
+            vault1, keccak256(content), uint64(block.timestamp + 1), keccak256("trade"), ""
         );
 
         // Same block as the commit — temporal binding cannot hold
@@ -390,7 +390,7 @@ contract ReasoningTraceRegistryTest is Test {
         bytes memory content = "trace";
         uint64 executionTime = uint64(block.timestamp + 100);
         vm.prank(agent1);
-        uint256 traceId = registry.commit(vault1, keccak256(content), executionTime, "");
+        uint256 traceId = registry.commit(vault1, keccak256(content), executionTime, keccak256("trade"), "");
 
         vm.roll(block.number + 1); // later block, but execution time not reached
         vm.prank(agent1);
@@ -402,7 +402,7 @@ contract ReasoningTraceRegistryTest is Test {
         bytes memory content = "trace";
         vm.prank(agent1);
         uint256 traceId = registry.commit(
-            vault1, keccak256(content), uint64(block.timestamp + 1), ""
+            vault1, keccak256(content), uint64(block.timestamp + 1), keccak256("trade"), ""
         );
 
         vm.roll(block.number + 1);
@@ -416,7 +416,7 @@ contract ReasoningTraceRegistryTest is Test {
         bytes memory content = "trace";
         vm.prank(agent1);
         uint256 traceId = registry.commit(
-            vault1, keccak256(content), uint64(block.timestamp + 1), ""
+            vault1, keccak256(content), uint64(block.timestamp + 1), keccak256("trade"), ""
         );
 
         vm.roll(block.number + 1);
@@ -432,7 +432,7 @@ contract ReasoningTraceRegistryTest is Test {
     function test_revert_commit_empty_hash() public {
         vm.prank(agent1);
         vm.expectRevert("Empty content hash");
-        registry.commit(vault1, bytes32(0), uint64(block.timestamp + 1), "");
+        registry.commit(vault1, bytes32(0), uint64(block.timestamp + 1), keccak256("trade"), "");
     }
 
     function test_revert_getCommitment_nonexistent() public {
@@ -446,7 +446,7 @@ contract ReasoningTraceRegistryTest is Test {
 
         vm.prank(agent1);
         uint256 id2 = registry.commit(
-            vault1, keccak256("committed"), uint64(block.timestamp + 1), ""
+            vault1, keccak256("committed"), uint64(block.timestamp + 1), keccak256("trade"), ""
         );
 
         assertEq(id1, 1);
@@ -455,6 +455,73 @@ contract ReasoningTraceRegistryTest is Test {
 
         uint256[] memory vaultIds = registry.getTracesByVault(vault1);
         assertEq(vaultIds.length, 2);
+    }
+
+    // ─── Commit-before-trade binding (#589) ──────────────────────────
+
+    function test_revert_commit_empty_tradeId() public {
+        vm.prank(agent1);
+        vm.expectRevert("Empty trade id");
+        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp + 1), bytes32(0), "");
+    }
+
+    function test_revert_commit_duplicate_pending() public {
+        bytes32 tradeId = keccak256("trade-A");
+        vm.prank(agent1);
+        registry.commit(vault1, keccak256("t1"), uint64(block.timestamp + 1), tradeId, "");
+        // A second commit for the SAME (vault, tradeId) before it executes must revert.
+        vm.prank(agent1);
+        vm.expectRevert("Pending commitment exists");
+        registry.commit(vault1, keccak256("t2"), uint64(block.timestamp + 1), tradeId, "");
+    }
+
+    function test_revert_executeTrade_no_commitment() public {
+        // The vault marks its own trade (msg.sender == vault); no prior commit => revert.
+        vm.prank(vault1);
+        vm.expectRevert("No matching commitment");
+        registry.executeTrade(keccak256("trade-A"));
+    }
+
+    function test_executeTrade_consumes_and_is_single_use() public {
+        bytes32 tradeId = keccak256("trade-A");
+        vm.prank(agent1);
+        uint256 traceId = registry.commit(vault1, keccak256("trace"), uint64(block.timestamp + 1), tradeId, "");
+        assertEq(registry.pendingTradeCommitment(vault1, tradeId), traceId);
+
+        // Strictly later block, then the vault consumes the commitment.
+        vm.roll(block.number + 1);
+        vm.expectEmit(true, true, true, true);
+        emit IReasoningTraceRegistry.TradeExecuted(traceId, vault1, tradeId, block.number);
+        vm.prank(vault1);
+        uint256 consumed = registry.executeTrade(tradeId);
+        assertEq(consumed, traceId);
+        assertEq(registry.pendingTradeCommitment(vault1, tradeId), 0); // cleared
+
+        // Single-use: a second execute for the same trade reverts.
+        vm.prank(vault1);
+        vm.expectRevert("No matching commitment");
+        registry.executeTrade(tradeId);
+    }
+
+    function test_revert_executeTrade_same_block_as_commit() public {
+        bytes32 tradeId = keccak256("trade-A");
+        vm.prank(agent1);
+        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp + 1), tradeId, "");
+        // Same block as the commit — the trade cannot prove the commit preceded it.
+        vm.prank(vault1);
+        vm.expectRevert("Time-lock: execute in commit block");
+        registry.executeTrade(tradeId);
+    }
+
+    function test_executeTrade_only_consumes_own_vault_commitment() public {
+        // A commitment for vault1 cannot be consumed by a different vault address.
+        bytes32 tradeId = keccak256("trade-A");
+        vm.prank(agent1);
+        registry.commit(vault1, keccak256("trace"), uint64(block.timestamp + 1), tradeId, "");
+        vm.roll(block.number + 1);
+        vm.prank(vault2);
+        vm.expectRevert("No matching commitment");
+        registry.executeTrade(tradeId);
     }
 }
 

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -7,6 +7,7 @@ import "../src/VaultFactory.sol";
 import "../src/AMMRouter.sol";
 import "../src/AMMPool.sol";
 import "../src/AssetRegistry.sol";
+import "../src/ReasoningTraceRegistry.sol";
 
 /// @dev Mock ERC-20 USDC for testing
 contract MockUSDC is ERC20 {
@@ -38,6 +39,7 @@ contract VaultTest is Test {
     AMMRouter public router;
     VaultFactory public factory;
     Vault public vault;
+    ReasoningTraceRegistry public traceRegistry;
 
     MockToken public sTSLA;
     PriceOracle public tslaOracle;
@@ -58,10 +60,14 @@ contract VaultTest is Test {
         router = new AMMRouter(owner);
 
         vm.prank(owner);
+        traceRegistry = new ReasoningTraceRegistry(owner);
+
+        vm.prank(owner);
         factory = new VaultFactory(
             agent,
             address(router),
             address(usdc),
+            address(traceRegistry),
             platformRecipient,
             owner
         );
@@ -122,6 +128,7 @@ contract VaultTest is Test {
         address[] memory tokensOut = new address[](0);
         uint256[] memory amountsOut = new uint256[](0);
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
     }
@@ -135,8 +142,24 @@ contract VaultTest is Test {
         uint256[] memory amountsOut = new uint256[](1);
         amountsOut[0] = amount;
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    /// @dev #589: commit a matching reasoning trace one block before a rebalance, so the
+    ///      vault's commit-before-trade enforcement is satisfied. tradeId MUST equal what
+    ///      Vault.rebalance() recomputes from the same swap arrays.
+    function _commitFor(
+        address[] memory tokensIn,
+        uint256[] memory amountsIn,
+        address[] memory tokensOut,
+        uint256[] memory amountsOut
+    ) internal {
+        bytes32 tradeId = keccak256(abi.encode(tokensIn, amountsIn, tokensOut, amountsOut));
+        vm.prank(agent);
+        traceRegistry.commit(address(vault), keccak256("trace"), uint64(block.timestamp + 1), tradeId, "");
+        vm.roll(block.number + 1); // commit must strictly precede the trade block
     }
 
     /// @dev Deposit USDC into the vault as alice.
@@ -417,6 +440,7 @@ contract VaultTest is Test {
         address[] memory tokensOut = new address[](0);
         uint256[] memory amountsOut = new uint256[](0);
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
 
@@ -459,6 +483,7 @@ contract VaultTest is Test {
         uint256[] memory amountsOut = new uint256[](0);
 
         // Creator (agent in this case) can rebalance
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
         // No tokens swapped, but no revert — success
@@ -703,6 +728,7 @@ contract VaultTest is Test {
         address[] memory tokensOut = new address[](0);
         uint256[] memory amountsOut = new uint256[](0);
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vm.expectRevert(AMMRouter.SlippageExceeded.selector);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
@@ -729,6 +755,7 @@ contract VaultTest is Test {
         address[] memory tokensOut = new address[](0);
         uint256[] memory amountsOut = new uint256[](0);
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vm.expectRevert(AMMRouter.SlippageExceeded.selector);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
@@ -755,6 +782,7 @@ contract VaultTest is Test {
         uint256[] memory amountsOut = new uint256[](1);
         amountsOut[0] = 1_000 * 1e18;
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vm.expectRevert(AMMRouter.SlippageExceeded.selector);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
@@ -783,6 +811,7 @@ contract VaultTest is Test {
         address[] memory tokensOut = new address[](0);
         uint256[] memory amountsOut = new uint256[](0);
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vm.expectRevert(Vault.OracleNotSet.selector);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
@@ -854,6 +883,7 @@ contract VaultTest is Test {
         amountsIn[0] = 1 * 10**6;
         address[] memory tokensOut = new address[](0);
         uint256[] memory amountsOut = new uint256[](0);
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
 
@@ -910,6 +940,7 @@ contract VaultTest is Test {
         address[] memory tokensOut = new address[](0);
         uint256[] memory amountsOut = new uint256[](0);
 
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
         vm.prank(agent);
         vm.expectRevert(PriceOracle.StalePrice.selector);
         vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
@@ -1272,6 +1303,12 @@ contract VaultTest is Test {
         uint256[] memory aIn = _singletonUint(10_000 * 10**6);
         address[] memory tOut = new address[](0);
         uint256[] memory aOut = new uint256[](0);
+        // #589: even the compromised agent must commit-before-trade — but this does NOT
+        // help it drain, the swap stays bounded by the owner's oracle floor.
+        bytes32 drainTradeId = keccak256(abi.encode(tIn, aIn, tOut, aOut));
+        vm.prank(attacker);
+        traceRegistry.commit(address(v), keccak256("trace"), uint64(block.timestamp + 1), drainTradeId, "");
+        vm.roll(block.number + 1);
         vm.prank(attacker);
         v.rebalance(tIn, aIn, tOut, aOut); // buys sTSLA within the oracle floor
 
@@ -1302,6 +1339,60 @@ contract VaultTest is Test {
         uint256 recovered = usdc.balanceOf(user) - userUsdcBefore;
         // 90% of a ~50k deposit, minus bounded slippage → comfortably > 44k.
         assertGt(recovered, (deposit * 88) / 100, "user recovers their funds; attacker got nothing");
+    }
+
+    // ─── Commit-before-trade enforcement (#589) ──────────────────────
+
+    function test_revert_rebalance_without_commit() public {
+        _depositAsAlice(50_000 * 10**6);
+
+        address[] memory tokensIn = _singleton(address(sTSLA));
+        uint256[] memory amountsIn = _singletonUint(10_000 * 10**6);
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+
+        // No prior commit — a trade cannot settle without a matching commitment.
+        vm.prank(agent);
+        vm.expectRevert("No matching commitment");
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    function test_rebalance_commit_is_single_use() public {
+        _depositAsAlice(50_000 * 10**6);
+
+        address[] memory tokensIn = _singleton(address(sTSLA));
+        uint256[] memory amountsIn = _singletonUint(10_000 * 10**6);
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+
+        // Commit, then trade — succeeds.
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
+        vm.prank(agent);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+
+        // The commitment is consumed — repeating the identical trade without a fresh
+        // commit reverts, so one trace cannot authorize many trades.
+        vm.prank(agent);
+        vm.expectRevert("No matching commitment");
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+    }
+
+    function test_revert_rebalance_commit_for_different_trade() public {
+        _depositAsAlice(50_000 * 10**6);
+
+        // The agent commits a SMALL trade (1,000 USDC) ...
+        address[] memory tIn = _singleton(address(sTSLA));
+        uint256[] memory aInCommitted = _singletonUint(1_000 * 10**6);
+        address[] memory tOut = new address[](0);
+        uint256[] memory aOut = new uint256[](0);
+        _commitFor(tIn, aInCommitted, tOut, aOut);
+
+        // ... but tries to execute a LARGER trade (10,000 USDC). Different tradeId =>
+        // no matching commitment => the trade is blocked. (No bait-and-switch.)
+        uint256[] memory aInActual = _singletonUint(10_000 * 10**6);
+        vm.prank(agent);
+        vm.expectRevert("No matching commitment");
+        vault.rebalance(tIn, aInActual, tOut, aOut);
     }
 
     function _singletonUint(uint256 x) internal pure returns (uint256[] memory arr) {


### PR DESCRIPTION
## Summary — `owner != agent` was step one; this is "no trade without a prior trace"

Today commit-before-trade is only **evidencable off-chain** (you can compare the commit block to the trade block) — nothing on-chain *stops* the agent from rebalancing without a matching commit. This PR makes it **enforced**: `Vault.rebalance()` consumes a fresh commitment in the `ReasoningTraceRegistry` before any swap, and the commitment **binds a `tradeId`** so a reveal can only match the trade that actually executed. This is issue #510's first acceptance criterion ("a trade cannot settle without a prior matching commit") and the R3 "enforced, not advisory" provenance claim from the Xia framing.

```
agent → registry.commit(vault, hash, execTime, tradeId, summary)     tradeId = keccak256(trade)
      → Vault.rebalance(...) ──requires──▶ registry.executeTrade(tradeId)   (reverts if none)
            └─ emits RebalanceTrace(tradeId, traceId)
      → registry.reveal(traceId, ptr, fullTrace)                     (already hash-bound to the commit)
```

## What changed
- **`IReasoningTraceRegistry` / `ReasoningTraceRegistry`** — `commit()` gains a `bytes32 tradeId`; new `executeTrade(bytes32 tradeId)` (callable only by the vault itself, `msg.sender == vault`; single-use; requires the commit in a **strictly earlier** block) and a `pendingTradeCommitment(vault, tradeId)` view; `Commitment` struct gains `tradeId` + `executeBlock`. `getCommitment()`'s 8-tuple is unchanged (backend-compatible).
- **`Vault`** — an **immutable** `traceRegistry` wired at construction (**strict**: the constructor reverts if it's zero, so a vault can never skip the check). `rebalance()` computes `tradeId = keccak256(abi.encode(tokensIn, amountsIn, tokensOut, amountsOut))` and calls `executeTrade` **before** any swap; emits `RebalanceTrace`. **Deposits/withdrawals never touch the registry** — funds paths stay registry-independent so a registry issue can never lock user funds.
- **`VaultFactory`** — takes the registry and passes it to every vault it creates (`createVault`'s external signature is unchanged → backend-safe).
- **`Deploy.s.sol` / `DeployInfra.s.sol`** — pass the already-deployed `ReasoningTraceRegistry` into the factory (the deploy order already creates the registry before the factory).

## Tests — `forge test → 192 passed, 0 failed`
- Migrated every existing `commit()` / `rebalance()` call site to the new shape (incl. #731's `test_drain_vector_compromised_agent_cannot_drain`, which still passes — the compromised agent must now commit, but still cannot drain).
- **+9 new tests** proving the enforcement: `rebalance` reverts with no commit; the commitment is **single-use**; a commit bound to a *different* trade does **not** authorize this trade; `executeTrade` reverts with no commitment / in the commit block / from a different vault; `commit` rejects an empty `tradeId` and a duplicate pending commitment.

## Anti-goals (preserved)
- ❌ No change to `createVault`'s external selector or the `Vault` constructor's *external* call shape from the backend's perspective beyond the redeploy.
- ❌ Deposits/withdrawals stay registry-independent (a registry outage must never lock user funds).
- ❌ Legacy `publishTrace` v1 surface untouched.
- ❌ `contracts/abis/` **intentionally not refreshed** — they mirror LIVE bytecode; refreshing here would break the running backend against the old live registry.

## ⚠️ Activation checklist (rides the T3.2 redeploy — tracked in #588)
This PR only lands the source + forge tests; the enforcement goes **live** at the redeploy:
1. Redeploy `ReasoningTraceRegistry` → `VaultFactory` (registry wired) → vaults.
2. Refresh `contracts/abis/` for `ReasoningTraceRegistry` + `Vault`.
3. Update `agent_runner` to **commit(tradeId) → rebalance → reveal** (extends #728's flow).
4. Smoke-test one commit → rebalance → reveal on testnet before cutting over.

## Review
**Funds-path Solidity → two-eyes.** Held for **@mnemonik-dev (Bogdan)** + Dan as contract owner. Draft until reviewed. Design pre-approved by Dan.

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
