### PR TITLE
[chain] T1.5b — client.py synth/oracle addresses SSOT-driven (#764)

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -1283,4 +1283,15 @@ async def run() -> None:
 
 
 if __name__ == "__main__":
+    # Standalone entrypoint: load .env into os.environ so the SSOT per-synth
+    # address resolution (chain/client.py reads ARC_<SYMBOL>_* via os.getenv) sees
+    # .env overrides even when this runs as a bare `python -m archimedes.chain.
+    # agent_runner` (no FastAPI main.load_dotenv, no docker env_file). Mirrors
+    # main.py; override=False so an explicitly-exported env / docker env_file wins.
+    # Lives under __main__ so importing this module in tests never loads .env.
+    # (Copilot #765)
+    from dotenv import load_dotenv
+
+    load_dotenv("../.env", override=False)
+    load_dotenv(".env", override=False)
     asyncio.run(run())

--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -6,6 +6,7 @@ All contract calls route through this client.
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -15,6 +16,46 @@ from pydantic_settings import BaseSettings
 from web3 import AsyncWeb3
 from web3.middleware import ExtraDataToPOAMiddleware
 from web3.providers import AsyncHTTPProvider
+
+# Committed transitional default addresses for the synths still in the SSOT (#725
+# removed sTSLA/sNVDA — single stocks — so they have NO defaults here). These keep the
+# currently-deployed synths resolvable BEFORE the T3.2 redeploy; at the redeploy, the
+# ARC_<SYMBOL>_ADDRESS env vars override them for the full 59-synth set.
+_SYNTH_DEFAULTS: dict[str, str] = {
+    "sSPY": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
+    "sBTC": "0x317e82be8f7cba6c162ab968fcf695d88e8e0359",
+    "sGOLD": "0xf384562c8bdafce52400eb6839f195695f6fa276",
+    "sOIL": "0x46cead4120f17a968ba1168f1a56563962cf3c4b",
+    "sNKY": "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376",
+}
+_ORACLE_DEFAULTS: dict[str, str] = {
+    "sSPY": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
+    "sBTC": "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8",
+    "sGOLD": "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633",
+    "sOIL": "0x79f354524fd09af16d841a2221af2b2b7bc432c8",
+    "sNKY": "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee",
+}
+
+
+def _resolve_ssot_addresses(defaults: dict[str, str], suffix: str) -> dict[str, str]:
+    """Build ``{SSOT symbol: address}`` over the deploy-eligible universe (#764).
+
+    For each symbol in ``universe.ON_CHAIN_SYNTHS``, resolve ``ARC_<SYMBOL>_<suffix>``
+    from the environment (``main.load_dotenv`` loads ``.env`` into ``os.environ``; tests
+    use ``monkeypatch.setenv``) else the committed transitional default. Symbols with no
+    address — most of the SSOT until the T3.2 redeploy mints them — are EXCLUDED, so
+    consumers only ever see DEPLOYED synths with non-empty addresses (the invariant the
+    previous 7-field map upheld). Compliance-held single stocks (sTSLA/sNVDA) are not in
+    the SSOT, so they no longer appear on the live path.
+    """
+    from archimedes.universe import ON_CHAIN_SYNTHS
+
+    resolved: dict[str, str] = {}
+    for symbol in ON_CHAIN_SYNTHS:
+        addr = os.getenv(f"ARC_{symbol.upper()}_{suffix}", "") or defaults.get(symbol, "")
+        if addr:
+            resolved[symbol] = addr
+    return resolved
 
 
 class ChainSettings(BaseSettings):
@@ -30,15 +71,16 @@ class ChainSettings(BaseSettings):
     - ``usdc_address``      ← ``ARC_USDC_ADDRESS``
     - ``amm_router_address`` ← ``ARC_AMM_ROUTER_ADDRESS``
     - ``vault_factory_address`` ← ``ARC_VAULT_FACTORY_ADDRESS``
-    - ``stsla_address``     ← ``ARC_STSLA_ADDRESS``  (one per synth)
-    - ``stsla_oracle_address`` ← ``ARC_STSLA_ORACLE_ADDRESS``  (one per oracle)
 
-    The defaults match the deployed Arc-testnet contracts and the ``ARC_*=...``
-    lines emitted by ``backend/archimedes/scripts/deploy_contracts.py``; the full
-    set of override variables is documented in ``.env.example``. The public API
-    (field names plus the ``synth_addresses`` / ``oracle_addresses`` /
-    ``*_account`` properties) is unchanged — only the source-of-truth for each
-    address moved from "hardcoded constant" to "env var with hardcoded fallback".
+    Per-synth token + oracle addresses are NOT individual fields — they are resolved
+    SSOT-driven over ``universe.ON_CHAIN_SYNTHS`` in the ``synth_addresses`` /
+    ``oracle_addresses`` properties (``ARC_<SYMBOL>_ADDRESS`` /
+    ``ARC_<SYMBOL>_ORACLE_ADDRESS`` env, else a committed transitional default;
+    undeployed synths excluded). See #764.
+
+    The defaults match the deployed Arc-testnet contracts and the ``ARC_*=...`` lines
+    emitted by ``backend/archimedes/scripts/deploy_contracts.py``; the full set of
+    override variables is documented in ``.env.example``.
     """
 
     # RPC
@@ -64,25 +106,12 @@ class ChainSettings(BaseSettings):
     asset_registry_address: str = ""  # ARC_ASSET_REGISTRY_ADDRESS
     strategy_registry_address: str = ""  # ARC_STRATEGY_REGISTRY_ADDRESS
 
-    # Individual synthetic token addresses — env-overridable via
-    # ARC_<SYMBOL>_ADDRESS; defaults = deployed Arc testnet contracts.
-    stsla_address: str = "0xd514cd27baf762c650536765cde9b61c876abacd"  # ARC_STSLA_ADDRESS
-    snvda_address: str = "0x805e75019a1291a598dfc134ad2519121a35fb11"  # ARC_SNVDA_ADDRESS
-    sspy_address: str = "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f"  # ARC_SSPY_ADDRESS
-    sbtc_address: str = "0x317e82be8f7cba6c162ab968fcf695d88e8e0359"  # ARC_SBTC_ADDRESS
-    sgold_address: str = "0xf384562c8bdafce52400eb6839f195695f6fa276"  # ARC_SGOLD_ADDRESS
-    soil_address: str = "0x46cead4120f17a968ba1168f1a56563962cf3c4b"  # ARC_SOIL_ADDRESS
-    snky_address: str = "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376"  # ARC_SNKY_ADDRESS
-
-    # Individual oracle addresses — env-overridable via
-    # ARC_<SYMBOL>_ORACLE_ADDRESS; defaults = deployed Arc testnet contracts.
-    stsla_oracle_address: str = "0xe1c9f2b11be97097223a66a188fca541e07873a6"  # ARC_STSLA_ORACLE_ADDRESS
-    snvda_oracle_address: str = "0xeb36acf88e739dd312de8278985262146a017374"  # ARC_SNVDA_ORACLE_ADDRESS
-    sspy_oracle_address: str = "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52"  # ARC_SSPY_ORACLE_ADDRESS
-    sbtc_oracle_address: str = "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8"  # ARC_SBTC_ORACLE_ADDRESS
-    sgold_oracle_address: str = "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633"  # ARC_SGOLD_ORACLE_ADDRESS
-    soil_oracle_address: str = "0x79f354524fd09af16d841a2221af2b2b7bc432c8"  # ARC_SOIL_ORACLE_ADDRESS
-    snky_oracle_address: str = "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee"  # ARC_SNKY_ORACLE_ADDRESS
+    # NOTE: per-synth token + oracle addresses are NO LONGER individual fields. They
+    # are resolved SSOT-driven over universe.ON_CHAIN_SYNTHS in synth_addresses /
+    # oracle_addresses below — each from ARC_<SYMBOL>_ADDRESS / ARC_<SYMBOL>_ORACLE_ADDRESS
+    # (env) else a committed transitional default (_SYNTH_DEFAULTS / _ORACLE_DEFAULTS),
+    # with undeployed synths excluded. This keeps the map keyed to the SSOT (no
+    # sTSLA/sNVDA drift) and can't go stale as the universe grows. (#764)
 
     # Paths
     abi_dir: str = str(Path(__file__).resolve().parents[3] / "contracts" / "abis")
@@ -103,27 +132,21 @@ class ChainSettings(BaseSettings):
 
     @property
     def synth_addresses(self) -> dict[str, str]:
-        return {
-            "sTSLA": self.stsla_address,
-            "sNVDA": self.snvda_address,
-            "sSPY": self.sspy_address,
-            "sBTC": self.sbtc_address,
-            "sGOLD": self.sgold_address,
-            "sOIL": self.soil_address,
-            "sNKY": self.snky_address,
-        }
+        """Deployed synth token addresses keyed by SSOT symbol (#764).
+
+        SSOT-driven over ``universe.ON_CHAIN_SYNTHS``; each resolved from
+        ``ARC_<SYMBOL>_ADDRESS`` (env, loaded from ``.env`` by ``main.load_dotenv``) else a
+        committed transitional default. Undeployed synths (most of the SSOT until the T3.2
+        redeploy) are EXCLUDED, so consumers only ever see deployed synths with non-empty
+        addresses. Compliance-held single stocks (sTSLA/sNVDA) are not in the SSOT and no
+        longer appear.
+        """
+        return _resolve_ssot_addresses(_SYNTH_DEFAULTS, "ADDRESS")
 
     @property
     def oracle_addresses(self) -> dict[str, str]:
-        return {
-            "sTSLA": self.stsla_oracle_address,
-            "sNVDA": self.snvda_oracle_address,
-            "sSPY": self.sspy_oracle_address,
-            "sBTC": self.sbtc_oracle_address,
-            "sGOLD": self.sgold_oracle_address,
-            "sOIL": self.soil_oracle_address,
-            "sNKY": self.snky_oracle_address,
-        }
+        """Deployed price-oracle addresses keyed by SSOT symbol — see ``synth_addresses`` (#764)."""
+        return _resolve_ssot_addresses(_ORACLE_DEFAULTS, "ORACLE_ADDRESS")
 
 
 class ChainClient:

--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -52,15 +52,15 @@ def _resolve_ssot_addresses(defaults: dict[str, str], suffix: str) -> dict[str, 
     ``ChainSettings`` fields (which pydantic resolves from ``.env`` directly), these
     per-synth keys are only seen when the variables are present in the *process
     environment*. Every real entrypoint satisfies this: the FastAPI app via
-    ``main.load_dotenv`` (it loads ``.env`` into ``os.environ`` at import), and the
-    ``oracle`` / ``agent_runner`` processes via docker-compose's ``env_file: .env`` (which
-    injects ``.env`` into the container environment). Tests use ``monkeypatch.setenv``.
-    The one gap to be aware of: a *bare, non-docker* process (e.g. ``python -m
-    archimedes.chain.agent_runner`` run locally) that relies solely on pydantic's
-    ``env_file`` and never exports the vars / calls ``load_dotenv`` will see only the
-    committed defaults here — even though its declared ``ARC_*`` fields still resolve. Run
-    such a process under docker (the prod path) or with ``.env`` exported into the
-    environment.
+    ``main.load_dotenv`` (it loads ``.env`` into ``os.environ`` at import); the
+    ``oracle`` / ``agent_runner`` processes via docker-compose's ``env_file: .env``
+    (which injects ``.env`` into the container environment); AND a *bare, non-docker*
+    ``python -m archimedes.chain.{oracle,agent}_runner`` run, because those modules
+    now call ``load_dotenv`` in their ``__main__`` block (mirroring ``main.py``;
+    ``override=False`` so an exported env / docker env_file still wins). Tests use
+    ``monkeypatch.setenv``. So the only way to miss the per-synth overrides is to
+    embed ``ChainSettings`` in a *new* custom entrypoint that neither loads ``.env``
+    nor exports the vars — in which case add a ``load_dotenv`` there too.
     """
     from archimedes.universe import ON_CHAIN_SYNTHS
 

--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -41,12 +41,26 @@ def _resolve_ssot_addresses(defaults: dict[str, str], suffix: str) -> dict[str, 
     """Build ``{SSOT symbol: address}`` over the deploy-eligible universe (#764).
 
     For each symbol in ``universe.ON_CHAIN_SYNTHS``, resolve ``ARC_<SYMBOL>_<suffix>``
-    from the environment (``main.load_dotenv`` loads ``.env`` into ``os.environ``; tests
-    use ``monkeypatch.setenv``) else the committed transitional default. Symbols with no
-    address — most of the SSOT until the T3.2 redeploy mints them — are EXCLUDED, so
-    consumers only ever see DEPLOYED synths with non-empty addresses (the invariant the
-    previous 7-field map upheld). Compliance-held single stocks (sTSLA/sNVDA) are not in
-    the SSOT, so they no longer appear on the live path.
+    else the committed transitional default. Symbols with no address — most of the SSOT
+    until the T3.2 redeploy mints them — are EXCLUDED, so consumers only ever see DEPLOYED
+    synths with non-empty addresses (the invariant the previous 7-field map upheld).
+    Compliance-held single stocks (sTSLA/sNVDA) are not in the SSOT, so they no longer
+    appear on the live path.
+
+    **Resolution source (important):** overrides are read from ``os.environ`` via
+    ``os.getenv`` — NOT through pydantic-settings' ``env_file`` source. Unlike the declared
+    ``ChainSettings`` fields (which pydantic resolves from ``.env`` directly), these
+    per-synth keys are only seen when the variables are present in the *process
+    environment*. Every real entrypoint satisfies this: the FastAPI app via
+    ``main.load_dotenv`` (it loads ``.env`` into ``os.environ`` at import), and the
+    ``oracle`` / ``agent_runner`` processes via docker-compose's ``env_file: .env`` (which
+    injects ``.env`` into the container environment). Tests use ``monkeypatch.setenv``.
+    The one gap to be aware of: a *bare, non-docker* process (e.g. ``python -m
+    archimedes.chain.agent_runner`` run locally) that relies solely on pydantic's
+    ``env_file`` and never exports the vars / calls ``load_dotenv`` will see only the
+    committed defaults here — even though its declared ``ARC_*`` fields still resolve. Run
+    such a process under docker (the prod path) or with ``.env`` exported into the
+    environment.
     """
     from archimedes.universe import ON_CHAIN_SYNTHS
 

--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -18,22 +18,18 @@ from web3.middleware import ExtraDataToPOAMiddleware
 from web3.providers import AsyncHTTPProvider
 
 # Committed transitional default addresses for the synths still in the SSOT (#725
-# removed sTSLA/sNVDA — single stocks — so they have NO defaults here). These keep the
-# currently-deployed synths resolvable BEFORE the T3.2 redeploy; at the redeploy, the
-# ARC_<SYMBOL>_ADDRESS env vars override them for the full 59-synth set.
+# removed sTSLA/sNVDA — single stocks — so they have NO defaults here; #842 retired
+# sGOLD/sOIL/sNKY from the universe — sGOLD→sGLD/sXAU, sOIL/sNKY dropped — so their
+# stale defaults were removed too, keeping this map an exact subset of ON_CHAIN_SYNTHS).
+# These keep the currently-deployed synths resolvable BEFORE the T3.2 redeploy; at the
+# redeploy, the ARC_<SYMBOL>_ADDRESS env vars override them for the full synth set.
 _SYNTH_DEFAULTS: dict[str, str] = {
     "sSPY": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
     "sBTC": "0x317e82be8f7cba6c162ab968fcf695d88e8e0359",
-    "sGOLD": "0xf384562c8bdafce52400eb6839f195695f6fa276",
-    "sOIL": "0x46cead4120f17a968ba1168f1a56563962cf3c4b",
-    "sNKY": "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376",
 }
 _ORACLE_DEFAULTS: dict[str, str] = {
     "sSPY": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
     "sBTC": "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8",
-    "sGOLD": "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633",
-    "sOIL": "0x79f354524fd09af16d841a2221af2b2b7bc432c8",
-    "sNKY": "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee",
 }
 
 

--- a/backend/archimedes/chain/oracle_runner.py
+++ b/backend/archimedes/chain/oracle_runner.py
@@ -49,4 +49,15 @@ async def run() -> None:
 
 
 if __name__ == "__main__":
+    # Standalone entrypoint: load .env into os.environ so the SSOT per-synth
+    # oracle-address resolution (chain/client.py reads ARC_<SYMBOL>_ORACLE_ADDRESS
+    # via os.getenv) sees .env overrides even when this runs as a bare `python -m
+    # archimedes.chain.oracle_runner` (no FastAPI main.load_dotenv, no docker
+    # env_file). Mirrors main.py; override=False so an exported env / docker
+    # env_file wins. Under __main__ so importing this module in tests never loads
+    # .env. (Copilot #765)
+    from dotenv import load_dotenv
+
+    load_dotenv("../.env", override=False)
+    load_dotenv(".env", override=False)
     asyncio.run(run())

--- a/backend/archimedes/services/config_service.py
+++ b/backend/archimedes/services/config_service.py
@@ -44,7 +44,7 @@ class ConfigService:
             vault_factory=settings.vault_factory_address,
             reasoning_trace_registry=settings.reasoning_trace_registry_address,
             asset_registry=settings.asset_registry_address,
-            price_oracle=settings.stsla_oracle_address,  # Representative oracle
+            price_oracle=next(iter(settings.oracle_addresses.values()), ""),  # representative oracle (first deployed)
             synthetics={k: v for k, v in settings.synth_addresses.items() if v},
             pools=pools,
             vaults=vaults,

--- a/backend/archimedes/services/config_service.py
+++ b/backend/archimedes/services/config_service.py
@@ -44,7 +44,10 @@ class ConfigService:
             vault_factory=settings.vault_factory_address,
             reasoning_trace_registry=settings.reasoning_trace_registry_address,
             asset_registry=settings.asset_registry_address,
-            price_oracle=next(iter(settings.oracle_addresses.values()), ""),  # representative oracle (first deployed)
+            # Representative oracle: the first NON-EMPTY address. oracle_addresses
+            # already excludes empties, but skip them here too so an unfiltered
+            # mapping can never yield "" while a valid oracle exists later. (Copilot #765)
+            price_oracle=next((v for v in settings.oracle_addresses.values() if v), ""),
             synthetics={k: v for k, v in settings.synth_addresses.items() if v},
             pools=pools,
             vaults=vaults,

--- a/backend/tests/chain/test_chain_settings_addresses.py
+++ b/backend/tests/chain/test_chain_settings_addresses.py
@@ -38,6 +38,25 @@ CORE_ENV_VAR_FOR_FIELD = {
     "strategy_registry_address": "ARC_STRATEGY_REGISTRY_ADDRESS",
 }
 
+# Pinned literals — deliberately NOT imported from the module under test — so an
+# unintended change to a committed default address is CAUGHT, instead of being
+# silently re-read from the same source the assertion compares against (which
+# would make the "defaults are correct" check tautological). (Copilot review #765)
+PINNED_SYNTH_DEFAULTS = {
+    "sSPY": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
+    "sBTC": "0x317e82be8f7cba6c162ab968fcf695d88e8e0359",
+}
+PINNED_ORACLE_DEFAULTS = {
+    "sSPY": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
+    "sBTC": "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8",
+}
+
+# Any SSOT symbol with no committed default = "undeployed pre-redeploy". Selected
+# dynamically (not hard-coded to e.g. sAGG) so the exclusion tests stay valid if
+# the SSOT/default set changes — a symbol gaining a default or being removed no
+# longer breaks them. (Copilot review #765)
+_UNDEPLOYED_SYNTHS = [s for s in ON_CHAIN_SYNTHS if s not in _SYNTH_DEFAULTS]
+
 
 @pytest.fixture
 def clean_env(monkeypatch):
@@ -82,6 +101,17 @@ class TestSsotSynthMaps:
     def test_maps_use_defaults_for_in_ssot_synths(self, clean_env):
         """The 5 committed transitional defaults (in-SSOT synths) appear in the maps."""
         s = ChainSettings(_env_file=None)
+        # Pinned-literal check FIRST: catches an accidental change to a committed
+        # default address (the imported-dict loop below can't — it re-reads the
+        # same source it asserts against). Guard the pins stay a subset of the
+        # module defaults so they can't silently drift out of meaning.
+        assert set(PINNED_SYNTH_DEFAULTS) <= set(_SYNTH_DEFAULTS)
+        assert set(PINNED_ORACLE_DEFAULTS) <= set(_ORACLE_DEFAULTS)
+        for sym, addr in PINNED_SYNTH_DEFAULTS.items():
+            assert s.synth_addresses[sym] == addr, f"{sym} synth default changed unexpectedly"
+        for sym, addr in PINNED_ORACLE_DEFAULTS.items():
+            assert s.oracle_addresses[sym] == addr, f"{sym} oracle default changed unexpectedly"
+        # Then the full set is present (covers any defaults beyond the pins).
         for sym, addr in _SYNTH_DEFAULTS.items():
             assert s.synth_addresses[sym] == addr, f"{sym} synth default missing"
         for sym, addr in _ORACLE_DEFAULTS.items():
@@ -105,15 +135,20 @@ class TestSsotSynthMaps:
 
     def test_undeployed_synth_excluded(self, clean_env):
         """A SSOT synth with no committed default and no env override is filtered out."""
-        assert "sAGG" in ON_CHAIN_SYNTHS and "sAGG" not in _SYNTH_DEFAULTS
+        if not _UNDEPLOYED_SYNTHS:
+            pytest.skip("every ON_CHAIN_SYNTHS symbol has a committed default — nothing to exclude")
+        sym = _UNDEPLOYED_SYNTHS[0]
         s = ChainSettings(_env_file=None)
-        assert "sAGG" not in s.synth_addresses
+        assert sym not in s.synth_addresses
 
     def test_env_makes_undeployed_synth_appear(self, clean_env):
+        if not _UNDEPLOYED_SYNTHS:
+            pytest.skip("every ON_CHAIN_SYNTHS symbol has a committed default")
+        sym = _UNDEPLOYED_SYNTHS[0]
         override = "0xAAAA000000000000000000000000000000000001"
-        clean_env.setenv("ARC_SAGG_ADDRESS", override)
+        clean_env.setenv(f"ARC_{sym.upper()}_ADDRESS", override)
         s = ChainSettings(_env_file=None)
-        assert s.synth_addresses["sAGG"] == override
+        assert s.synth_addresses[sym] == override
 
     def test_env_overrides_default(self, clean_env):
         synth_override = "0xBBBB000000000000000000000000000000000002"

--- a/backend/tests/chain/test_chain_settings_addresses.py
+++ b/backend/tests/chain/test_chain_settings_addresses.py
@@ -45,10 +45,16 @@ CORE_ENV_VAR_FOR_FIELD = {
 PINNED_SYNTH_DEFAULTS = {
     "sSPY": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
     "sBTC": "0x317e82be8f7cba6c162ab968fcf695d88e8e0359",
+    "sGOLD": "0xf384562c8bdafce52400eb6839f195695f6fa276",
+    "sOIL": "0x46cead4120f17a968ba1168f1a56563962cf3c4b",
+    "sNKY": "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376",
 }
 PINNED_ORACLE_DEFAULTS = {
     "sSPY": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
     "sBTC": "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8",
+    "sGOLD": "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633",
+    "sOIL": "0x79f354524fd09af16d841a2221af2b2b7bc432c8",
+    "sNKY": "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee",
 }
 
 # Any SSOT symbol with no committed default = "undeployed pre-redeploy". Selected
@@ -103,10 +109,11 @@ class TestSsotSynthMaps:
         s = ChainSettings(_env_file=None)
         # Pinned-literal check FIRST: catches an accidental change to a committed
         # default address (the imported-dict loop below can't — it re-reads the
-        # same source it asserts against). Guard the pins stay a subset of the
-        # module defaults so they can't silently drift out of meaning.
-        assert set(PINNED_SYNTH_DEFAULTS) <= set(_SYNTH_DEFAULTS)
-        assert set(PINNED_ORACLE_DEFAULTS) <= set(_ORACLE_DEFAULTS)
+        # same source it asserts against). EXACT-set equality (not subset) so that
+        # ADDING a new committed default without pinning it here ALSO fails — the
+        # pins can't silently fall behind the module's set. (Copilot #765 r2)
+        assert set(PINNED_SYNTH_DEFAULTS) == set(_SYNTH_DEFAULTS), "pin every committed synth default"
+        assert set(PINNED_ORACLE_DEFAULTS) == set(_ORACLE_DEFAULTS), "pin every committed oracle default"
         for sym, addr in PINNED_SYNTH_DEFAULTS.items():
             assert s.synth_addresses[sym] == addr, f"{sym} synth default changed unexpectedly"
         for sym, addr in PINNED_ORACLE_DEFAULTS.items():

--- a/backend/tests/chain/test_chain_settings_addresses.py
+++ b/backend/tests/chain/test_chain_settings_addresses.py
@@ -1,47 +1,26 @@
-"""Externalized contract addresses (roadmap T2.3).
+"""Contract-address settings: core fields (T2.3) + SSOT-driven synth/oracle maps (#764).
 
-ChainSettings reads every contract address from an ``ARC_<FIELD>`` environment
-variable, falling back to a hardcoded deployed-Arc-testnet default when the
-variable is unset. These tests pin both halves of that contract:
+``ChainSettings`` reads the CORE contract addresses from ``ARC_<FIELD>`` env vars (pydantic
+fields, with a deployed-Arc-testnet default), and resolves the per-synth token + oracle
+addresses **SSOT-driven** over ``universe.ON_CHAIN_SYNTHS`` — each from
+``ARC_<SYMBOL>_ADDRESS`` / ``ARC_<SYMBOL>_ORACLE_ADDRESS`` (env, loaded from ``.env`` by
+``main.load_dotenv``) else a committed transitional default — **excluding undeployed
+synths** so consumers only ever see deployed synths with non-empty addresses (#764).
 
-  (a) when the env vars are UNSET, the in-code defaults are used (nothing breaks
-      on a fresh clone with no .env);
-  (b) when an env var IS set, the env value wins over the default.
-
-Hermetic: every ChainSettings is constructed with ``_env_file=None`` so no
-ambient ``.env`` on disk can leak in, and env vars are controlled via
-``monkeypatch`` (which it cleans up). No network, no Arc RPC, no .env dependence.
+Hermetic: every ``ChainSettings`` is constructed with ``_env_file=None`` and every ``ARC_*``
+var this module touches is stripped via ``monkeypatch`` (which cleans up), so neither an
+ambient ``.env`` nor a developer's shell can leak in. No network, no Arc RPC.
 """
 
 from __future__ import annotations
 
 import pytest
-from archimedes.chain.client import ChainSettings
+from archimedes.chain.client import _ORACLE_DEFAULTS, _SYNTH_DEFAULTS, ChainSettings
+from archimedes.universe import COMPLIANCE_FLAGGED_SINGLE_STOCKS, ON_CHAIN_SYNTHS
 
-# The in-code default addresses, mirrored here so the test fails loudly if a
-# default is changed without the test being updated (a default change is a
-# deploy-address change — worth a deliberate test edit).
-EXPECTED_DEFAULTS = {
-    "usdc_address": "0x3600000000000000000000000000000000000000",
-    "stsla_address": "0xd514cd27baf762c650536765cde9b61c876abacd",
-    "snvda_address": "0x805e75019a1291a598dfc134ad2519121a35fb11",
-    "sspy_address": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
-    "sbtc_address": "0x317e82be8f7cba6c162ab968fcf695d88e8e0359",
-    "sgold_address": "0xf384562c8bdafce52400eb6839f195695f6fa276",
-    "soil_address": "0x46cead4120f17a968ba1168f1a56563962cf3c4b",
-    "snky_address": "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376",
-    "stsla_oracle_address": "0xe1c9f2b11be97097223a66a188fca541e07873a6",
-    "snvda_oracle_address": "0xeb36acf88e739dd312de8278985262146a017374",
-    "sspy_oracle_address": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
-    "sbtc_oracle_address": "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8",
-    "sgold_oracle_address": "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633",
-    "soil_oracle_address": "0x79f354524fd09af16d841a2221af2b2b7bc432c8",
-    "snky_oracle_address": "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee",
-}
-
-# Address fields whose in-code default is the empty string (deployment-specific —
-# must be supplied via .env before the contract can be used).
-EMPTY_DEFAULT_FIELDS = [
+# Core (non-synth) address fields — still individual pydantic fields (env_prefix="ARC_").
+CORE_NONEMPTY_DEFAULTS = {"usdc_address": "0x3600000000000000000000000000000000000000"}
+CORE_EMPTY_DEFAULT_FIELDS = [
     "amm_router_address",
     "synthetic_factory_address",
     "vault_factory_address",
@@ -49,11 +28,7 @@ EMPTY_DEFAULT_FIELDS = [
     "asset_registry_address",
     "strategy_registry_address",
 ]
-
-# All ARC_*-prefixed env vars that ChainSettings reads, paired with the field
-# each one overrides. The env-var name is the field upper-cased with the ARC_
-# prefix (env_prefix="ARC_").
-ENV_VAR_FOR_FIELD = {
+CORE_ENV_VAR_FOR_FIELD = {
     "usdc_address": "ARC_USDC_ADDRESS",
     "amm_router_address": "ARC_AMM_ROUTER_ADDRESS",
     "synthetic_factory_address": "ARC_SYNTHETIC_FACTORY_ADDRESS",
@@ -61,102 +36,98 @@ ENV_VAR_FOR_FIELD = {
     "reasoning_trace_registry_address": "ARC_REASONING_TRACE_REGISTRY_ADDRESS",
     "asset_registry_address": "ARC_ASSET_REGISTRY_ADDRESS",
     "strategy_registry_address": "ARC_STRATEGY_REGISTRY_ADDRESS",
-    "stsla_address": "ARC_STSLA_ADDRESS",
-    "snvda_address": "ARC_SNVDA_ADDRESS",
-    "sspy_address": "ARC_SSPY_ADDRESS",
-    "sbtc_address": "ARC_SBTC_ADDRESS",
-    "sgold_address": "ARC_SGOLD_ADDRESS",
-    "soil_address": "ARC_SOIL_ADDRESS",
-    "snky_address": "ARC_SNKY_ADDRESS",
-    "stsla_oracle_address": "ARC_STSLA_ORACLE_ADDRESS",
-    "snvda_oracle_address": "ARC_SNVDA_ORACLE_ADDRESS",
-    "sspy_oracle_address": "ARC_SSPY_ORACLE_ADDRESS",
-    "sbtc_oracle_address": "ARC_SBTC_ORACLE_ADDRESS",
-    "sgold_oracle_address": "ARC_SGOLD_ORACLE_ADDRESS",
-    "soil_oracle_address": "ARC_SOIL_ORACLE_ADDRESS",
-    "snky_oracle_address": "ARC_SNKY_ORACLE_ADDRESS",
 }
 
 
 @pytest.fixture
 def clean_env(monkeypatch):
-    """Strip every ARC_* var so a developer's shell can't leak into the test.
-
-    Combined with ``_env_file=None`` at construction, this guarantees the
-    "defaults when unset" assertions see a truly empty override surface.
-    """
-    for env_var in ENV_VAR_FOR_FIELD.values():
+    """Strip every ARC_* var this module reads — core fields + per-synth token/oracle vars
+    for the whole SSOT — so the "defaults / excluded when unset" assertions see a truly
+    empty override surface."""
+    for env_var in CORE_ENV_VAR_FOR_FIELD.values():
         monkeypatch.delenv(env_var, raising=False)
+    for sym in ON_CHAIN_SYNTHS:
+        monkeypatch.delenv(f"ARC_{sym.upper()}_ADDRESS", raising=False)
+        monkeypatch.delenv(f"ARC_{sym.upper()}_ORACLE_ADDRESS", raising=False)
     return monkeypatch
 
 
-# ── (a) defaults are used when env is unset ───────────────────────────────────
+# ── Core fields (T2.3) — unchanged pydantic behaviour ─────────────────────────
 
 
-class TestDefaultsWhenEnvUnset:
-    def test_nonempty_defaults_match(self, clean_env):
-        """Each non-empty address field falls back to its hardcoded default."""
+class TestCoreFields:
+    def test_usdc_nonempty_default(self, clean_env):
         s = ChainSettings(_env_file=None)
-        for field, expected in EXPECTED_DEFAULTS.items():
-            assert getattr(s, field) == expected, f"{field} default mismatch"
+        assert s.usdc_address == CORE_NONEMPTY_DEFAULTS["usdc_address"]
 
     def test_empty_default_fields_are_empty(self, clean_env):
-        """Deployment-specific fields default to the empty string when unset."""
         s = ChainSettings(_env_file=None)
-        for field in EMPTY_DEFAULT_FIELDS:
+        for field in CORE_EMPTY_DEFAULT_FIELDS:
             assert getattr(s, field) == "", f"{field} should default to ''"
 
-    def test_synth_and_oracle_maps_use_defaults(self, clean_env):
-        """The public synth_addresses / oracle_addresses maps reflect defaults."""
-        s = ChainSettings(_env_file=None)
-        assert s.synth_addresses["sTSLA"] == EXPECTED_DEFAULTS["stsla_address"]
-        assert s.synth_addresses["sSPY"] == EXPECTED_DEFAULTS["sspy_address"]
-        assert s.oracle_addresses["sTSLA"] == EXPECTED_DEFAULTS["stsla_oracle_address"]
-        assert s.oracle_addresses["sNKY"] == EXPECTED_DEFAULTS["snky_oracle_address"]
-
-
-# ── (b) env overrides win when set ────────────────────────────────────────────
-
-
-class TestEnvOverrideWins:
-    def test_each_field_overridable(self, clean_env):
-        """Setting ARC_<FIELD> overrides that field's default, one at a time."""
+    def test_each_core_field_overridable(self, clean_env):
         # Distinct sentinel per field so a cross-wired mapping can't pass.
-        for i, (field, env_var) in enumerate(ENV_VAR_FOR_FIELD.items()):
+        for i, (field, env_var) in enumerate(CORE_ENV_VAR_FOR_FIELD.items()):
             sentinel = f"0x{i:040x}"
             clean_env.setenv(env_var, sentinel)
             s = ChainSettings(_env_file=None)
             assert getattr(s, field) == sentinel, f"{env_var} did not override {field}"
             clean_env.delenv(env_var, raising=False)
 
-    def test_override_flows_into_synth_map(self, clean_env):
-        """An ARC_STSLA_ADDRESS override is visible through synth_addresses."""
+
+# ── SSOT-driven synth / oracle maps (#764) ────────────────────────────────────
+
+
+class TestSsotSynthMaps:
+    def test_maps_use_defaults_for_in_ssot_synths(self, clean_env):
+        """The 5 committed transitional defaults (in-SSOT synths) appear in the maps."""
+        s = ChainSettings(_env_file=None)
+        for sym, addr in _SYNTH_DEFAULTS.items():
+            assert s.synth_addresses[sym] == addr, f"{sym} synth default missing"
+        for sym, addr in _ORACLE_DEFAULTS.items():
+            assert s.oracle_addresses[sym] == addr, f"{sym} oracle default missing"
+
+    def test_client_known_synths_match_ssot(self, clean_env):
+        """The map keys are always a SUBSET of the SSOT (no sTSLA/sNVDA-style drift).
+
+        Pre-redeploy it's the deployed subset (the defaults); post-redeploy env fills the
+        rest — but it can never contain a non-SSOT symbol.
+        """
+        s = ChainSettings(_env_file=None)
+        assert set(s.synth_addresses) <= set(ON_CHAIN_SYNTHS)
+        assert set(s.oracle_addresses) <= set(ON_CHAIN_SYNTHS)
+
+    def test_compliance_single_stocks_absent(self, clean_env):
+        s = ChainSettings(_env_file=None)
+        assert "sTSLA" not in s.synth_addresses
+        assert "sNVDA" not in s.synth_addresses
+        assert not (set(s.synth_addresses) & COMPLIANCE_FLAGGED_SINGLE_STOCKS)
+
+    def test_undeployed_synth_excluded(self, clean_env):
+        """A SSOT synth with no committed default and no env override is filtered out."""
+        assert "sAGG" in ON_CHAIN_SYNTHS and "sAGG" not in _SYNTH_DEFAULTS
+        s = ChainSettings(_env_file=None)
+        assert "sAGG" not in s.synth_addresses
+
+    def test_env_makes_undeployed_synth_appear(self, clean_env):
         override = "0xAAAA000000000000000000000000000000000001"
-        clean_env.setenv("ARC_STSLA_ADDRESS", override)
+        clean_env.setenv("ARC_SAGG_ADDRESS", override)
         s = ChainSettings(_env_file=None)
-        assert s.stsla_address == override
-        assert s.synth_addresses["sTSLA"] == override
+        assert s.synth_addresses["sAGG"] == override
 
-    def test_override_flows_into_oracle_map(self, clean_env):
-        """An ARC_SSPY_ORACLE_ADDRESS override is visible through oracle_addresses."""
-        override = "0xBBBB000000000000000000000000000000000002"
-        clean_env.setenv("ARC_SSPY_ORACLE_ADDRESS", override)
+    def test_env_overrides_default(self, clean_env):
+        synth_override = "0xBBBB000000000000000000000000000000000002"
+        oracle_override = "0xCCCC000000000000000000000000000000000003"
+        clean_env.setenv("ARC_SSPY_ADDRESS", synth_override)
+        clean_env.setenv("ARC_SSPY_ORACLE_ADDRESS", oracle_override)
         s = ChainSettings(_env_file=None)
-        assert s.sspy_oracle_address == override
-        assert s.oracle_addresses["sSPY"] == override
+        assert s.synth_addresses["sSPY"] == synth_override
+        assert s.oracle_addresses["sSPY"] == oracle_override
 
-    def test_empty_default_field_gets_value_from_env(self, clean_env):
-        """A field that defaults to '' picks up a real address from its env var."""
-        override = "0xCCCC000000000000000000000000000000000003"
-        clean_env.setenv("ARC_AMM_ROUTER_ADDRESS", override)
+    def test_values_are_never_empty(self, clean_env):
+        """Every value in the maps is a non-empty address — the invariant consumers that
+        iterate synth_addresses.items() rely on (they don't all filter empties)."""
         s = ChainSettings(_env_file=None)
-        assert s.amm_router_address == override
-
-    def test_unset_fields_keep_defaults_when_one_is_overridden(self, clean_env):
-        """Overriding one field must not disturb the others' defaults."""
-        clean_env.setenv("ARC_USDC_ADDRESS", "0xDDDD000000000000000000000000000000000004")
-        s = ChainSettings(_env_file=None)
-        assert s.usdc_address == "0xDDDD000000000000000000000000000000000004"
-        # Neighbours untouched.
-        assert s.stsla_address == EXPECTED_DEFAULTS["stsla_address"]
-        assert s.sspy_oracle_address == EXPECTED_DEFAULTS["sspy_oracle_address"]
+        assert s.synth_addresses, "expected the transitional defaults to be present"
+        assert all(v for v in s.synth_addresses.values())
+        assert all(v for v in s.oracle_addresses.values())

--- a/backend/tests/chain/test_chain_settings_addresses.py
+++ b/backend/tests/chain/test_chain_settings_addresses.py
@@ -45,16 +45,10 @@ CORE_ENV_VAR_FOR_FIELD = {
 PINNED_SYNTH_DEFAULTS = {
     "sSPY": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
     "sBTC": "0x317e82be8f7cba6c162ab968fcf695d88e8e0359",
-    "sGOLD": "0xf384562c8bdafce52400eb6839f195695f6fa276",
-    "sOIL": "0x46cead4120f17a968ba1168f1a56563962cf3c4b",
-    "sNKY": "0x445b8f0f827a0d384d1b8ccf18cbc6ec8a543376",
 }
 PINNED_ORACLE_DEFAULTS = {
     "sSPY": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
     "sBTC": "0x6cc5f621c4e3b46152e69e5c9873689cbb4a85e8",
-    "sGOLD": "0x35fccde01ae8728c7a7cb83c3f59c701ebecc633",
-    "sOIL": "0x79f354524fd09af16d841a2221af2b2b7bc432c8",
-    "sNKY": "0xcd34a4103ad64a3cf729b1b1a58295ccc957fcee",
 }
 
 # Any SSOT symbol with no committed default = "undeployed pre-redeploy". Selected
@@ -105,7 +99,7 @@ class TestCoreFields:
 
 class TestSsotSynthMaps:
     def test_maps_use_defaults_for_in_ssot_synths(self, clean_env):
-        """The 5 committed transitional defaults (in-SSOT synths) appear in the maps."""
+        """The committed transitional defaults (in-SSOT synths) appear in the maps."""
         s = ChainSettings(_env_file=None)
         # Pinned-literal check FIRST: catches an accidental change to a committed
         # default address (the imported-dict loop below can't — it re-reads the

--- a/backend/tests/chain/test_oracle_price_formatting.py
+++ b/backend/tests/chain/test_oracle_price_formatting.py
@@ -21,11 +21,18 @@ No network, no Circle, no Arc RPC.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
+from archimedes.chain.client import chain_client
 from archimedes.chain.oracle_updater import OracleUpdater
 from archimedes.models.asset import AssetPrice
+
+# oracle_addresses is SSOT-driven (#764/#765) and excludes compliance-held single stocks
+# (sTSLA/sNVDA are not in the SSOT), so this decimal-formatting test mocks the address
+# boundary to stay independent of the deployed-universe contents — it pins the 6-dec int
+# formula, not address resolution.
+_TEST_ORACLE_ADDRS = {"sTSLA": "0x" + "11" * 20, "sNVDA": "0x" + "22" * 20}
 
 
 def _price(symbol: str = "sTSLA", usd: float = 185.50) -> AssetPrice:
@@ -65,6 +72,12 @@ class TestOraclePriceFormatting:
         with (
             patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
             patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(
+                type(chain_client.settings),
+                "oracle_addresses",
+                new_callable=PropertyMock,
+                return_value=_TEST_ORACLE_ADDRS,
+            ),
             # First push for this symbol → reference confirmed absent → allowed.
             patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))),
         ):
@@ -91,6 +104,12 @@ class TestOraclePriceFormatting:
         with (
             patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
             patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(
+                type(chain_client.settings),
+                "oracle_addresses",
+                new_callable=PropertyMock,
+                return_value=_TEST_ORACLE_ADDRS,
+            ),
             patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))),
         ):
             await updater.push_prices_on_chain([_price(symbol="sNVDA", usd=1.0000005)])

--- a/backend/tests/chain/test_oracle_updater.py
+++ b/backend/tests/chain/test_oracle_updater.py
@@ -236,7 +236,9 @@ class TestPushPricesOnChain:
         resp.json = AsyncMock(return_value={"data": {"id": "tx-123"}})
         session_cm, session = _mock_aiohttp_session(post_response=resp)
 
-        good = _price(symbol="sTSLA", usd=110.0)  # +10%, inside the cap
+        # sSPY is an on-chain synth in the SSOT (#764); sTSLA is compliance-held
+        # off-chain (#725) so it has no oracle address and would be skipped.
+        good = _price(symbol="sSPY", usd=110.0)  # +10%, inside the cap
         with (
             patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
             patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
@@ -246,7 +248,7 @@ class TestPushPricesOnChain:
 
         assert result == "tx-123"
         session.post.assert_called_once()
-        assert updater._last_pushed_price_int["sTSLA"] == _int6(110.0)
+        assert updater._last_pushed_price_int["sSPY"] == _int6(110.0)
 
     async def test_fails_closed_when_reference_unobtainable(self, circle_creds):
         # Issue #587, part 2: when the deviation reference is unobtainable

--- a/backend/tests/services/test_config_service.py
+++ b/backend/tests/services/test_config_service.py
@@ -23,7 +23,8 @@ def _fake_settings() -> SimpleNamespace:
         vault_factory_address="0xVF",
         reasoning_trace_registry_address="0xRTR",
         asset_registry_address="0xAR",
-        stsla_oracle_address="0xORACLE",
+        # representative price_oracle = first value of oracle_addresses (#764)
+        oracle_addresses={"sTSLA": "0xORACLE", "sBTC": "0xORACLEB"},
         synth_addresses={"sTSLA": "0xT", "sBTC": "0xB", "sNULL": ""},
         chain_id=5042002,
         arc_rpc_url="https://rpc.example",


### PR DESCRIPTION
> ⚠️ **MERGE TIMING — land at the T3.2 redeploy, not before.** This drops the compliance-removed `sTSLA`/`sNVDA` from the live backend's synth set. Those contracts are still deployed pre-redeploy, so merging early (build-on-deploy) would stop the backend pricing/handling them while they exist. Safe to merge once the redeploy replaces the old 7-synth set with the SSOT 59.

## Summary — the `client.py` half of #756
`synth_addresses` / `oracle_addresses` were **7 hardcoded fields** that carried `sTSLA`/`sNVDA` (single stocks the SSOT removed for compliance) and couldn't grow with the universe. They're now **SSOT-driven** over `universe.ON_CHAIN_SYNTHS`, each resolved from `ARC_<SYMBOL>_ADDRESS` / `ARC_<SYMBOL>_ORACLE_ADDRESS` (env — `main.load_dotenv` loads `.env` into `os.environ`) else a committed transitional default, **excluding undeployed synths**.

## The consumer-safety design (why this is now safe)
The #764 worry was that exposing all 59 SSOT symbols would surface 54 empty addresses and break the 30+ consumers that iterate `synth_addresses.items()`. **Filtering empties eliminates that** — the maps only contain *deployed* synths with non-empty addresses, exactly the invariant the old 7-field map upheld. Audited every consumer: the only one touching a removed field directly was `config_service.py` (fixed); the rest go through the (preserved) properties.

- Pre-redeploy: the maps = the **5 in-SSOT committed defaults** (`sSPY`, `sBTC`, `sGOLD`, `sOIL`, `sNKY`). `sTSLA`/`sNVDA` gone.
- Post-redeploy: `ARC_<SYMBOL>_ADDRESS` env vars fill the full 59.

## What changed
- `chain/client.py` — drop the 14 fields; add `_SYNTH_DEFAULTS`/`_ORACLE_DEFAULTS` + `_resolve_ssot_addresses` (env-or-default, filter empties); docstring updated.
- `services/config_service.py` — representative `price_oracle` now `next(iter(oracle_addresses.values()), "")` instead of the dropped `stsla_oracle_address`.
- tests — `test_chain_settings_addresses` rewritten (core fields + SSOT maps: keys ⊆ ON_CHAIN, no single stocks, undeployed excluded, env override, never-empty); `test_config_service` mock fixed.

## Verify
```
PYTHONPATH=backend pytest backend/tests/chain/ backend/tests/services/test_config_service.py \
  backend/tests/services/test_asset_service.py backend/tests/services/test_amm_bootstrap.py \
  backend/tests/services/test_vault_service.py backend/tests/services/test_asset_market_service.py \
  backend/tests/test_agent_runner.py   # 116 passed
```

Closes #764
