### PR TITLE
[rigor] Wire computed-but-dropped diagnostics (IID #621 + regime-robustness) into the gate as advisories

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -47,6 +47,7 @@ class RigorGateDetail(BaseModel):
     cpcv: str = "MISSING"
     dsr_convention: str = "MISSING"
     iid: str = "MISSING"
+    regime_robustness: str = "MISSING"
 
 
 class LibraryPbo(BaseModel):
@@ -254,6 +255,7 @@ async def evaluate_rigor_gate():
                     cpcv=details.get("cpcv", "MISSING"),
                     dsr_convention=details.get("dsr_convention", "MISSING"),
                     iid=details.get("iid", "MISSING"),
+                    regime_robustness=details.get("regime_robustness", "MISSING"),
                 ),
                 deflated_sharpe=gate_result.deflated_sharpe,
                 dsr_p_value=gate_result.dsr_p_value,

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -31,12 +31,22 @@ from pydantic import BaseModel
 
 
 class RigorGateDetail(BaseModel):
-    """Per-check pass/fail detail."""
+    """Per-check pass/fail detail.
+
+    Mirrors every key of ``RigorGateResult.gate_details`` so the passport surfaces
+    the gate honestly — including ``cpcv`` (a real pass/fail criterion when a
+    combinatorial OOS matrix exists), the ``dsr_convention`` disclosure (#547), and
+    the advisory ``iid`` diagnostic (#621). Dropping a computed criterion here would
+    show ``passes_all=False`` with no rendered reason.
+    """
 
     dsr: str = "MISSING"
     pbo: str = "MISSING"
     oos_sharpe: str = "MISSING"
     look_ahead: str = "MISSING"
+    cpcv: str = "MISSING"
+    dsr_convention: str = "MISSING"
+    iid: str = "MISSING"
 
 
 class LibraryPbo(BaseModel):
@@ -241,6 +251,9 @@ async def evaluate_rigor_gate():
                     pbo=details.get("pbo", "MISSING"),
                     oos_sharpe=details.get("oos_sharpe", "MISSING"),
                     look_ahead=details.get("look_ahead", "MISSING"),
+                    cpcv=details.get("cpcv", "MISSING"),
+                    dsr_convention=details.get("dsr_convention", "MISSING"),
+                    iid=details.get("iid", "MISSING"),
                 ),
                 deflated_sharpe=gate_result.deflated_sharpe,
                 dsr_p_value=gate_result.dsr_p_value,

--- a/backend/archimedes/services/return_diagnostics.py
+++ b/backend/archimedes/services/return_diagnostics.py
@@ -349,8 +349,12 @@ def runs_test(returns: object) -> dict:
 
 
 def diagnose(returns: object, lags: int = 10, vr_q: int = 2) -> dict:
-    # TODO(issue #621): wire into run_rigor_gate to enforce IID assumption check
     """Run all three IID / random-walk diagnostics and aggregate.
+
+    Wired into ``rigor_evaluator.run_rigor_gate`` (#621) as an **advisory**
+    diagnostic surfaced in ``RigorGateResult.gate_details['iid']`` — it is
+    deliberately NOT a pass/fail criterion, because autocorrelated returns are
+    the edge for trend/momentum strategies and must not fail the gate.
 
     Parameters
     ----------

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -32,7 +32,7 @@ from archimedes.services._rigor_helpers import (
     _RF_DAILY,
     benjamini_hochberg_fdr,  # noqa: F401 - re-exported for test_rigor_evaluator
     bonferroni_correction,  # noqa: F401 - re-exported for test_rigor_evaluator
-    classify_regimes,  # noqa: F401 - re-exported for test_rigor_regime
+    classify_regimes,  # used by run_rigor_gate (regime-robustness) + re-exported for test_rigor_regime
     compute_average_pairwise_correlation,  # noqa: F401 - re-exported for fusion_evaluator/selection_bias_routes
     compute_cpcv_oos_sharpe,
     compute_dsr,
@@ -43,7 +43,7 @@ from archimedes.services._rigor_helpers import (
     monte_carlo_dsr_pvalue,  # noqa: F401 - re-exported for test_rigor_evaluator
     regime_conditional_dsr,  # noqa: F401 - re-exported for test_rigor_regime
     regime_conditional_sharpe,  # noqa: F401 - re-exported for test_rigor_regime
-    regime_robustness_score,  # noqa: F401 - re-exported for test_rigor_regime
+    regime_robustness_score,  # used by run_rigor_gate (regime-robustness) + re-exported for test_rigor_regime
 )
 from archimedes.services.return_diagnostics import diagnose
 
@@ -355,6 +355,7 @@ class RigorGateResult:
         pbo_source: str = "cohort",
         iid_assumption_violated: bool | None = None,
         iid_diagnostics: dict | None = None,
+        regime_robustness: dict | None = None,
     ) -> None:
         self.strategy_id = strategy_id
         self.deflated_sharpe = deflated_sharpe
@@ -384,6 +385,11 @@ class RigorGateResult:
         # iid_diagnostics carries the full Ljung-Box / variance-ratio / runs detail.
         self.iid_assumption_violated = iid_assumption_violated
         self.iid_diagnostics = iid_diagnostics
+        # Regime-robustness (per-volatility-regime Sharpe consistency). ADVISORY for
+        # the same reason: a single-regime edge can be a legitimate, disclosed strategy.
+        # Carries per_regime / min_regime_sharpe / consistency / robust (see
+        # _rigor_helpers.regime_robustness_score). None when the series is too short.
+        self.regime_robustness = regime_robustness
 
     @property
     def passes_all(self) -> bool:
@@ -418,8 +424,8 @@ class RigorGateResult:
             not math.isfinite(self.cpcv_positive_fraction) or self.cpcv_positive_fraction < 0.5
         ):
             return False
-        # NOTE: the IID diagnostic (#621) is deliberately NOT a pass/fail criterion.
-        # It is surfaced via gate_details["iid"] as an advisory only — see __init__.
+        # NOTE: the IID (#621) and regime-robustness diagnostics are deliberately NOT
+        # pass/fail criteria. They are surfaced via gate_details as advisories — see __init__.
         return self.look_ahead_passed
 
     @property
@@ -483,6 +489,22 @@ class RigorGateResult:
             )
         else:
             details["iid"] = "ADVISORY: returns consistent with IID / random-walk"
+
+        # Regime-robustness — ADVISORY, never gates pass/fail. Shows whether the edge
+        # survives across volatility regimes or is fragile (earned in only one).
+        rr = self.regime_robustness
+        if not rr or rr.get("min_regime_sharpe") is None:
+            details["regime_robustness"] = "MISSING"
+        elif rr.get("robust"):
+            details["regime_robustness"] = (
+                f"ADVISORY: edge holds across regimes (min regime SR={rr['min_regime_sharpe']:.2f}, "
+                f"consistency={rr.get('consistency', 0.0):.2f})"
+            )
+        else:
+            details["regime_robustness"] = (
+                f"ADVISORY: regime-fragile (min regime SR={rr['min_regime_sharpe']:.2f} ≤ 0 in ≥1 regime, "
+                f"consistency={rr.get('consistency', 0.0):.2f})"
+            )
 
         return details
 
@@ -563,6 +585,21 @@ def run_rigor_gate(
     # must not reject it. See RigorGateResult.passes_all / gate_details["iid"].
     iid = diagnose(daily_returns)
 
+    # Regime-robustness diagnostic — does the edge survive across volatility regimes,
+    # or is it earned only in calm/only-in-one regime (fragile)? Uses vol-based regime
+    # labels derived from the series itself (classify_regimes). ADVISORY like IID — it is
+    # surfaced, never gates pass/fail: a single-regime edge can still be a legitimate,
+    # honestly-disclosed strategy, and promoting this to a hard gate is an admission-policy
+    # call for the rigor lane (Dan/Önder). Computed only when the series is long enough to
+    # label more than one regime; never allowed to break the gate.
+    regime_robustness: dict | None = None
+    if len(daily_returns) >= 63:  # ~3 vol windows (vol_window=21) — enough to label >1 regime
+        try:
+            regime_labels = classify_regimes(daily_returns)
+            regime_robustness = regime_robustness_score(daily_returns, regime_labels)
+        except Exception as exc:  # an advisory diagnostic must never break the gate
+            logger.debug("Regime-robustness diagnostic skipped [%s]: %s", strategy_id, exc)
+
     # 4. Look-ahead audit
     if strategy_code is not None:
         la_passed, la_warnings = look_ahead_audit(strategy_code)
@@ -601,10 +638,11 @@ def run_rigor_gate(
         pbo_source=pbo_source,
         iid_assumption_violated=iid.get("iid_assumption_violated"),
         iid_diagnostics=iid,
+        regime_robustness=regime_robustness,
     )
 
     logger.info(
-        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s [%s], OOS=%s, CPCV+=%s, LA=%s, IID_violated=%s [advisory])",
+        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s [%s], OOS=%s, CPCV+=%s, LA=%s, IID_violated=%s, regime_robust=%s [advisories])",
         strategy_id,
         "PASS" if result.passes_all else "FAIL",
         dsr_p_value,
@@ -614,6 +652,7 @@ def run_rigor_gate(
         cpcv["positive_fraction"] if cpcv else None,
         la_passed,
         iid.get("iid_assumption_violated"),
+        regime_robustness.get("robust") if regime_robustness else None,
     )
 
     return result

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -45,6 +45,7 @@ from archimedes.services._rigor_helpers import (
     regime_conditional_sharpe,  # noqa: F401 - re-exported for test_rigor_regime
     regime_robustness_score,  # noqa: F401 - re-exported for test_rigor_regime
 )
+from archimedes.services.return_diagnostics import diagnose
 
 logger = logging.getLogger(__name__)
 
@@ -352,6 +353,8 @@ class RigorGateResult:
         cpcv_mean_oos_sharpe: float | None = None,
         cpcv_positive_fraction: float | None = None,
         pbo_source: str = "cohort",
+        iid_assumption_violated: bool | None = None,
+        iid_diagnostics: dict | None = None,
     ) -> None:
         self.strategy_id = strategy_id
         self.deflated_sharpe = deflated_sharpe
@@ -372,6 +375,15 @@ class RigorGateResult:
         # strategy's edge holds OOS across a majority of CPCV paths.
         self.cpcv_mean_oos_sharpe = cpcv_mean_oos_sharpe
         self.cpcv_positive_fraction = cpcv_positive_fraction
+        # IID / random-walk return diagnostics (#621). ADVISORY, not a pass/fail
+        # criterion: autocorrelated returns are the *signal* for trend/momentum
+        # strategies (Faber SMA200, TSMOM), so an IID violation must NOT fail the
+        # gate — it would wrongly reject legitimate strategies. We surface it so
+        # the diagnostic is honest (computed AND reported, not computed-and-dropped)
+        # and the passport can flag "interpret the Sharpe SE with caution here".
+        # iid_diagnostics carries the full Ljung-Box / variance-ratio / runs detail.
+        self.iid_assumption_violated = iid_assumption_violated
+        self.iid_diagnostics = iid_diagnostics
 
     @property
     def passes_all(self) -> bool:
@@ -406,6 +418,8 @@ class RigorGateResult:
             not math.isfinite(self.cpcv_positive_fraction) or self.cpcv_positive_fraction < 0.5
         ):
             return False
+        # NOTE: the IID diagnostic (#621) is deliberately NOT a pass/fail criterion.
+        # It is surfaced via gate_details["iid"] as an advisory only — see __init__.
         return self.look_ahead_passed
 
     @property
@@ -456,6 +470,19 @@ class RigorGateResult:
             details["cpcv"] = "MISSING"
 
         details["look_ahead"] = "PASS" if self.look_ahead_passed else "FAIL"
+
+        # IID / random-walk diagnostic (#621) — ADVISORY, never gates pass/fail.
+        # Surfaced so a reader knows whether the Sharpe SE rests on an IID
+        # assumption that the return series actually violates (common + expected
+        # for trend/momentum strategies, where the autocorrelation IS the edge).
+        if self.iid_assumption_violated is None:
+            details["iid"] = "MISSING"
+        elif self.iid_assumption_violated:
+            details["iid"] = (
+                "ADVISORY: autocorrelation detected (Sharpe SE may understate risk; expected for trend/momentum)"
+            )
+        else:
+            details["iid"] = "ADVISORY: returns consistent with IID / random-walk"
 
         return details
 
@@ -530,6 +557,12 @@ def run_rigor_gate(
     oos_sharpe = compute_oos_sharpe(daily_returns)
     cpcv = compute_cpcv_oos_sharpe(cv_returns_matrix)
 
+    # IID / random-walk diagnostics (#621) — computed AND surfaced (previously
+    # computed-and-dropped). ADVISORY only: it never gates pass/fail because a
+    # trend/momentum strategy's autocorrelation is its edge, so an IID violation
+    # must not reject it. See RigorGateResult.passes_all / gate_details["iid"].
+    iid = diagnose(daily_returns)
+
     # 4. Look-ahead audit
     if strategy_code is not None:
         la_passed, la_warnings = look_ahead_audit(strategy_code)
@@ -566,10 +599,12 @@ def run_rigor_gate(
         cpcv_mean_oos_sharpe=cpcv["mean_oos_sharpe"] if cpcv else None,
         cpcv_positive_fraction=cpcv["positive_fraction"] if cpcv else None,
         pbo_source=pbo_source,
+        iid_assumption_violated=iid.get("iid_assumption_violated"),
+        iid_diagnostics=iid,
     )
 
     logger.info(
-        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s [%s], OOS=%s, CPCV+=%s, LA=%s)",
+        "Rigor gate [%s]: %s (DSR p=%s, PBO=%s [%s], OOS=%s, CPCV+=%s, LA=%s, IID_violated=%s [advisory])",
         strategy_id,
         "PASS" if result.passes_all else "FAIL",
         dsr_p_value,
@@ -578,6 +613,7 @@ def run_rigor_gate(
         oos_sharpe,
         cpcv["positive_fraction"] if cpcv else None,
         la_passed,
+        iid.get("iid_assumption_violated"),
     )
 
     return result

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -842,10 +842,20 @@ class TestGateDetailsBranches:
         """gate_details must contain the four gate keys + DSR convention (#547) + the IID advisory (#621)."""
         r = RigorGateResult("s")
         keys = set(r.gate_details.keys())
-        assert keys == {"dsr", "dsr_convention", "pbo", "oos_sharpe", "look_ahead", "cpcv", "iid"}
+        assert keys == {
+            "dsr",
+            "dsr_convention",
+            "pbo",
+            "oos_sharpe",
+            "look_ahead",
+            "cpcv",
+            "iid",
+            "regime_robustness",
+        }
         assert r.gate_details["dsr_convention"] == "excess"
-        # IID is advisory and unset by default (no return series) -> MISSING.
+        # Advisories are unset by default (no return series) -> MISSING.
         assert r.gate_details["iid"] == "MISSING"
+        assert r.gate_details["regime_robustness"] == "MISSING"
 
 
 # ─── run_rigor_gate — all branches in lines 509-555 ──────────────────
@@ -939,7 +949,22 @@ class TestRunRigorGatePaths:
             "look_ahead",
             "cpcv",
             "iid",
+            "regime_robustness",
         }
+
+    def test_regime_robustness_surfaced_but_advisory(self):
+        """Regime-robustness is computed for a long-enough series, surfaced, and never gates."""
+        # 80 bars >= 63 → regime classification runs and robustness is populated.
+        result = run_rigor_gate("s", _RETURNS_80, num_trials=1, pbo_scores={"s": 0.1}, look_ahead_audit_passed=True)
+        assert result.regime_robustness is not None
+        assert result.gate_details["regime_robustness"].startswith("ADVISORY")
+        # toggling the advisory does not move passes_all
+        before = result.passes_all
+        result.regime_robustness = {"min_regime_sharpe": -9.0, "consistency": 0.0, "robust": False}
+        assert result.passes_all == before
+        # a short series simply reports MISSING (no crash)
+        short = run_rigor_gate("s2", [0.01, -0.01, 0.02, 0.0, 0.01])
+        assert short.gate_details["regime_robustness"] == "MISSING"
 
     def test_iid_diagnostic_surfaced_but_advisory(self):
         """#621: run_rigor_gate computes + surfaces the IID diagnostic, but it never gates pass/fail.

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -839,11 +839,13 @@ class TestGateDetailsBranches:
         assert r.gate_details["look_ahead"] == "FAIL"
 
     def test_gate_details_returns_all_four_keys(self):
-        """gate_details must always contain the four gate keys + the DSR convention disclosure (#547)."""
+        """gate_details must contain the four gate keys + DSR convention (#547) + the IID advisory (#621)."""
         r = RigorGateResult("s")
         keys = set(r.gate_details.keys())
-        assert keys == {"dsr", "dsr_convention", "pbo", "oos_sharpe", "look_ahead", "cpcv"}
+        assert keys == {"dsr", "dsr_convention", "pbo", "oos_sharpe", "look_ahead", "cpcv", "iid"}
         assert r.gate_details["dsr_convention"] == "excess"
+        # IID is advisory and unset by default (no return series) -> MISSING.
+        assert r.gate_details["iid"] == "MISSING"
 
 
 # ─── run_rigor_gate — all branches in lines 509-555 ──────────────────
@@ -927,9 +929,37 @@ class TestRunRigorGatePaths:
         assert isinstance(result, RigorGateResult)
 
     def test_gate_details_populated_by_run_rigor_gate(self):
-        """gate_details on the returned result must have the four gate keys + DSR convention (#547)."""
+        """gate_details on the returned result must have the four gate keys + DSR convention (#547) + IID (#621)."""
         result = run_rigor_gate("s", _RETURNS_80)
-        assert set(result.gate_details.keys()) == {"dsr", "dsr_convention", "pbo", "oos_sharpe", "look_ahead", "cpcv"}
+        assert set(result.gate_details.keys()) == {
+            "dsr",
+            "dsr_convention",
+            "pbo",
+            "oos_sharpe",
+            "look_ahead",
+            "cpcv",
+            "iid",
+        }
+
+    def test_iid_diagnostic_surfaced_but_advisory(self):
+        """#621: run_rigor_gate computes + surfaces the IID diagnostic, but it never gates pass/fail.
+
+        Autocorrelated returns are the edge for trend/momentum strategies, so an IID
+        violation must be advisory only.
+        """
+        result = run_rigor_gate("s", _RETURNS_80)
+        # computed + surfaced (not None / not dropped)
+        assert result.iid_diagnostics is not None
+        assert "iid_assumption_violated" in result.iid_diagnostics
+        assert result.gate_details["iid"].startswith("ADVISORY")
+        # A clearly autocorrelated series (strong trend) must NOT, by itself, fail the gate.
+        trending = [0.01 * (1 + 0.5 * (i % 3 == 0)) for i in range(80)]
+        r2 = run_rigor_gate("s2", trending, num_trials=1, pbo_scores={"s2": 0.1}, look_ahead_audit_passed=True)
+        # whatever passes_all decides, it is decided WITHOUT reference to the IID flag:
+        # toggling the advisory flag on the result does not change passes_all.
+        before = r2.passes_all
+        r2.iid_assumption_violated = not r2.iid_assumption_violated
+        assert r2.passes_all == before
 
     def test_num_trials_stored_on_result(self):
         """num_trials argument must be stored on the result."""


### PR DESCRIPTION
## What

The rigor gate **computed several diagnostics and threw them away**, and the passport API dropped several computed criteria before they reached the user. This wires them all in as honest, surfaced advisories — strengthening the "rigor is the wedge" claim.

Two lanes, one coherent change (same files, same pattern):
- **IID / random-walk (claim-integrity, Closes #621):** `return_diagnostics.diagnose()` (Ljung-Box, variance-ratio, runs) was computed but never wired into `run_rigor_gate`.
- **Regime-robustness (GMM-regime rigor):** `classify_regimes` + `regime_robustness_score` existed but were re-exported for tests only — never wired live. This is the safe, vol-based "regime-aware backtest" half of the GMM residual (no dependency on the live GMM execution path → no overlap with the #766 T1.1 spec under review).

## Changes
- `run_rigor_gate` now computes **both** diagnostics and surfaces them on `RigorGateResult` (`iid_diagnostics`, `regime_robustness`) + `gate_details["iid"|"regime_robustness"]`.
- **Both are ADVISORY — never gate pass/fail.** Autocorrelated returns are the *edge* for trend/momentum (so IID violation must not reject Faber SMA200 / TSMOM); a single-regime edge can be a legitimate, disclosed strategy. Tests pin that toggling either advisory never moves `passes_all`. Regime-robustness is wrapped (try/except + length guard) so an advisory can never break the gate.
- Surface `cpcv`, `dsr_convention`, `iid`, **and** `regime_robustness` through `RigorGateDetail` → passport API (cpcv + dsr_convention were *also* being dropped, so a `passes_all=False` could render with no reason).
- Removed the stale `TODO(#621)`.

## Verify
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_rigor_evaluator.py backend/tests/test_selection_bias_routes.py backend/tests/test_return_diagnostics.py backend/tests/test_rigor_regime.py -q
```
→ **226 passed.** ruff clean.

## ⚠️ Open question for the rigor lane (Dan / Önder)
Should either advisory ever be promoted to a hard gate? Candidates: IID for *mean-reversion* strategies (violation is a red flag), or regime-robustness as a Tier-1 floor (`min_regime_sharpe > 0`). Left advisory for now — it's an admission-criteria change, your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)