### PR TITLE
[docs] Phase 7 — back-fill 8 historical ADRs + index + dead-link fix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,12 +13,6 @@ For repo-level setup + operations, start at the **repo root**:
 - [`../ARC-OSS-SHOWCASE.md`](../ARC-OSS-SHOWCASE.md) — Arc OSS Showcase positioning + forkable primitives
 - [`../CLAUDE.md`](../CLAUDE.md) — project context for Claude Code sessions
 
-## Submission-day status (read FIRST for "where are we right now?")
-
-| Doc | What it is |
-|---|---|
-| [`dead-code-audit-2026-05-24-v2.md`](dead-code-audit-2026-05-24-v2.md) | **Day-13 dead-code audit + Work Remaining Inventory + Submission-day execution plan.** Authoritative "done / unverified / missing" matrix; paste-ready `t2o2` issue specs (appended bottom); Dan submission-day checklist; live-state snapshot. **Start here.** |
-
 ## Product spine (canonical — read these first)
 
 | Doc | What it is |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,9 +1,11 @@
 # Architecture Decision Records
 
-> **Status:** Day-10 (2026-05-22; updated 2026-06-26). Two ADRs currently. The ADR pattern is:
-> capture a non-trivial technical decision once, with the alternatives considered
-> and the reasoning, so future contributors can understand the choice without
-> needing to relitigate it.
+> **Status:** Day-10 (2026-05-22; updated 2026-06-27 — Phase-7 back-fill of historical
+> decisions). Ten ADRs. The ADR pattern is: capture a non-trivial technical decision
+> once, with the alternatives considered and the reasoning, so future contributors can
+> understand the choice without needing to relitigate it. The records below were written
+> as decisions landed; the 2026-06-27 batch back-fills decisions that shipped before the
+> ADR habit was established (each cites the PR/commit/spec it documents).
 
 ## Index
 
@@ -11,6 +13,14 @@
 |---|---|
 | [`backtrader-vs-vectorbt-decision-memo.md`](backtrader-vs-vectorbt-decision-memo.md) | Why we picked **backtrader** over **vectorbt** for the v1 backtest engine |
 | [`chainlink-primary-oracle.md`](chainlink-primary-oracle.md) | Why on-chain prices are **Chainlink-primary** with a thin, bounded admin fallback that **degrades (not reverts)** on feed outage (#724) |
+| [`build-on-deploy-main-only.md`](build-on-deploy-main-only.md) | Why `main` is the only long-lived branch and every merge auto-deploys (no `develop`) |
+| [`aws-account-migration.md`](aws-account-migration.md) | Why prod moved to Dan's own AWS account (`037613907429`/`us-east-1`) post-Agora |
+| [`k1-generation-external-rigor-gate.md`](k1-generation-external-rigor-gate.md) | Why generation emits **K=1** winner + considered-rejects, with the rigor gate run **externally** |
+| [`rigor-gate-unification.md`](rigor-gate-unification.md) | Why the four selection-bias controls run through **one** authoritative gate, surfaced honestly (post-#710) |
+| [`non-custodial-vault-owner-agent.md`](non-custodial-vault-owner-agent.md) | Why vaults separate **owner (withdrawal)** from **agent (rebalance-only)** so a compromised agent key can't drain (#731) |
+| [`fusion-primary-generation.md`](fusion-primary-generation.md) | Why strategy generation is **fusion-primary** (paper-grounded), not free-form LLM (#751) |
+| [`glm-to-bedrock-llm-migration.md`](glm-to-bedrock-llm-migration.md) | Why the live LLM moved from **GLM to AWS Bedrock** (Nova Micro default, Converse backend) (#717) |
+| [`portfolio-constructor-consolidation.md`](portfolio-constructor-consolidation.md) | Why legacy constructors were retired and a **dual-signal** (regime × consensus) sizer activated (#131, #662) |
 
 ## When to add an ADR
 

--- a/docs/adr/aws-account-migration.md
+++ b/docs/adr/aws-account-migration.md
@@ -1,0 +1,41 @@
+# ADR: Migrate production to Dan's own AWS account
+
+> **Audience:** Archimedes team (decision owner: Dan Browne, AWS account holder)
+> **Status:** **Adopted and completed 2026-06-24** (Lepton Sprint, post-Agora).
+> **Question being decided:** After the hackathon, who owns the production AWS infrastructure?
+> **Related:** CLAUDE.md § "Project / Status" (2026-06-24 revision), [`docs/infra-setup.md`](../infra-setup.md), `infra/`.
+
+## TL;DR
+
+**Migrate production off the shared Agora hackathon account onto Dan's own AWS account (`037613907429` / `us-east-1`).** Dan owns the smart contracts and on-chain integration; owning the AWS account that runs the oracle + backend makes the ownership surface congruent and unblocks the Lepton Sprint without waiting on Agora-managed infrastructure. The live app stays at `https://archimedes-arc.com/`; GitHub Actions auto-deploy is re-pointed and ON.
+
+## Context
+
+The hackathon (May 11–25) provided a shared cloud account for the demo. Post-event, continuing on it meant: ambiguous ownership (Chuan, who held admin, is stepping back), shared blast radius with other teams, and dependence on Agora-managed approvals — too slow for the Lepton Sprint's continuous-ship cadence. Dan was already the de facto owner of contracts, the `backend/archimedes/chain/` layer, and deployment. Concentrating AWS ownership with him clarifies responsibility. A related cleanup: the prior `.app`/`.com` domain split caused the Circle passkey rpId bug (now fixed by standardizing on `.com`).
+
+## Decision
+
+**Migrate the full stack to Dan's account in `us-east-1` (complete 2026-06-24):**
+1. **Ownership** — Dan is the human owner of record. Teammates get IAM users on request (`SecurityAudit` + `ViewOnlyAccess`, MFA, keys via a secure channel — never Discord/email). Long-term: migrate to IAM Identity Center (no long-lived keys).
+2. **What moved** — CloudFront → nginx → EC2, Postgres, Redis, deploy credentials, all re-pointed. The docker-compose stack is unchanged; only the hosting account changes.
+3. **CI/CD** — GitHub Actions re-pointed to the new account; auto-redeploy on every merge to `main`.
+4. **Secrets** — in AWS Secrets Manager / SSM (no plaintext in git or Actions), fetched at boot.
+5. **Terraform state** — S3 backend, versioned + encrypted (SSE-S3) + TLS-only bucket policy + S3-native locking; treated as a secrets store with scoped IAM read.
+
+## Consequences
+
+### Positive
+- **Clear ownership + autonomous ops** — Dan approves all infra changes; the sprint ships continuously without external approvals.
+- **Clean audit + cost control** — full CloudTrail; Dan controls the bill + budgets; clean separation from other teams.
+
+### Negative / costs we accept
+- **Bus-factor concentration on Dan** (AWS owner + sole contract deployer + on-chain owner), who is evenings/weekends-only. Mitigated by **Bogdan (`mnemonik-dev`) as contract/on-chain reviewer**, **Marten as ops backup**, `ViewOnlyAccess` IAM for teammates, and documented runbooks.
+- **AWS cost is now Dan's personal bill** for the sprint (his explicit commitment) until a funding event absorbs it.
+
+## Alternatives considered
+- **Keep the shared Agora account — rejected:** ambiguous post-event ownership, shared blast radius, and too slow to iterate.
+- **A new co-owned team account — rejected:** heavyweight (legal entity, billing) and consensus-slow for a fast sprint; Dan is the de facto owner already, and Bogdan/Marten can step in for review.
+
+## Ratification
+
+Adopted and completed 2026-06-24. Reflects the post-hackathon reality (Chuan stepping back, Dan taking full ownership). See [build-on-deploy](build-on-deploy-main-only.md) for the deploy mechanics this account hosts.

--- a/docs/adr/build-on-deploy-main-only.md
+++ b/docs/adr/build-on-deploy-main-only.md
@@ -1,0 +1,43 @@
+# ADR: Build-on-deploy, main-only branch model
+
+> **Audience:** Archimedes team (decision owner: Dan Browne)
+> **Status:** **Adopted.** Codified 2026-05-18; merge-commit-only enforcement added 2026-05-27.
+> **Question being decided:** How does a 5-person async team across 5 timezones integrate work continuously without a queue-prone `develop` branch?
+> **Related:** CLAUDE.md § "Branch model (build-on-deploy, main-only)", `.github/workflows/deploy.yml`, `release-tag.yml`.
+
+## TL;DR
+
+**`main` is the only long-lived branch, and it is the deploy branch.** Every merge to `main` triggers a CI build + deploy to the live EC2 stack. The `develop`/integration branch is retired (2026-05-18, drifted unused). Short-lived per-owner branches (`<handle>/<name>`) → PR → merge to `main`. Merge commits only, so `git log --graph` shows unit-of-work boundaries. The agentic system (`t2o2`) and parallel Claude sessions land work on `main` and iterate on CI there, so `main` moves continuously — branch late, rebase right before merge, merge fast.
+
+## Context
+
+The hackathon started with a classic gitflow `main` + `develop`. Reality diverged: the agentic system and Dan's sessions merged directly to `main` and iterated on CI failures there, so `develop` drifted behind and became a high-touch, error-prone re-merge nobody wanted to do. Gitflow's `develop` is a queue — bearable when colocated and synchronous, invisible-until-you-merge when distributed. In a 5-timezone async team the cost of maintaining the queue (rebase, conflict, re-test) grows faster than the cost of shipping from `main` + hotfixes.
+
+## Decision
+
+1. **`main` is the single live + deploy branch.** Every merge → CI build + deploy via `deploy.yml`. No `develop`.
+2. **Short-lived per-owner branches** (`<discord-handle>/<short-name>`) → PR → merge → delete. Rebase onto `main` right before merging.
+3. **`main` moves continuously** — treat it as a fast-moving deploy queue, not a staging area. Don't wait for it to "settle"; it won't.
+4. **Merge commits only** (squash/rebase-merge disabled in repo settings) so branch topology + the "this was one PR" signal survive for forensics and release tagging.
+5. **Hard rules:** never force-push `main`; never commit secrets/`.env`; one logical change per PR. Force-pushing your own unmerged branch is fine. Contract changes still warrant Dan's review + Bogdan's audit.
+
+## Consequences
+
+### Positive
+- **No queue bottleneck** — one branch, no invisible `develop` backlog.
+- **Continuous delivery by default** — every merge is a deploy; no "merged but not shipped" limbo.
+- **Tight agentic iteration** — `t2o2` can land, observe CI, fix, re-land, all on `main`.
+- **Forensically clear history** — merge commits preserve "this was PR #NNN"; `git log --graph` reads cleanly.
+
+### Negative / costs we accept
+- **`main` is always live** — a broken commit breaks prod immediately. Mitigated by hard CI gates (`quality-gate.yml`), smoke-test discipline, and one-`revert`-away rollback.
+- **Rebase discipline required** — rebase before merge or conflicts pile up. Mitigated by short-lived branches (<24h).
+- **Release tagging is post-hoc** — `release-tag.yml` infers the version bump from the PR title marker (`!minor`, `!version-release`), so titles must be accurate.
+
+## Alternatives considered
+- **Keep gitflow (`develop` → `main`) — rejected:** it drifted in practice; the queue is invisible in a distributed team and the agentic system works better on `main` directly.
+- **Deploy on every push to any branch — rejected:** too expensive (gates per push) and rollback breaks down with concurrent pushers. Single PR → `main` → deploy is the right middle ground.
+
+## Ratification
+
+Adopted 2026-05-18; merge-commit-only enforced 2026-05-27. The decision reflected how the team actually works. Enforced via repo settings + `release-tag.yml`; `main` self-heals formatting via `main-format-guard.yml`.

--- a/docs/adr/fusion-primary-generation.md
+++ b/docs/adr/fusion-primary-generation.md
@@ -1,0 +1,44 @@
+# ADR: Fusion-primary strategy generation — paper-grounded, not vibes-first
+
+> **Audience:** Archimedes team (decision owner: Dan, strategy engine + backend lead)
+> **Status:** **Accepted.** Wired into the live Generate path in [PR #751](https://github.com/a-apin/archimedes/pull/751).
+> **Question being decided:** How does the generation engine route between free-form LLM generation, curated-library selection, and multi-paper fusion? Which is primary?
+> **Related:** [`docs/corpus-architecture.md`](../corpus-architecture.md), `backend/archimedes/agents/generation_pipeline.py`, `backend/archimedes/services/strategy_fusion.py`.
+
+## TL;DR
+
+**Fusion is the primary generation path when it is enabled, an LLM backend is reachable, and the corpus is rich enough.** The engine routes: (1) **Fusion** — synthesize a new strategy by fusing ≥2 user-steered papers from the q-fin corpus; (2) **Architect** (curated-library selection) when fusion is off / corpus sparse; (3) **Agent** (streaming LLM advisor) as the always-available fallback. Fusion is the workhorse because the only durable edge is *combinations the literature has not yet published* — published strategies decay post-publication (McLean & Pontiff 2016). Fusion forces grounding (name the papers), states the novelty rationale, and defers backtest rigor to the external gate.
+
+## Context
+
+"Propose a strategy given what the user wants" has three solutions: free-form LLM (fast, but drifts toward vibes and can hallucinate papers/backtests), curated-library architect (rigorous but slow to onboard, narrow coverage), and fusion (synthesize from ≥2 corpus papers, user-steered, grounded). Before PR #751 the live Generate path computed a `"fusion"` label and **threw it away** — always running the single-agent loop. The dispatch gap meant users never actually got fusion. PR #751 inserts fusion into the dispatch tree as the primary path (checked first), closing the gap.
+
+## Decision
+
+**Fusion-primary dispatch:**
+1. **Feature-flagged** (`ARCHIMEDES_FUSION_ENABLED`, default OFF) so ops can disable it without code change; the live path stays deterministic for tests/offline.
+2. **Requires a reachable LLM + a sufficiently rich corpus** — otherwise decline with an honest sentinel and fall through to architect/agent (never crash).
+3. **User-steered, not free-form** — the `FusionBrief` (asset classes, risk appetite, direction, paper budget) pre-filters the corpus before the model sees it; the model may not introduce papers outside the filtered set.
+4. **Output is explicitly pre-backtest** — a `novelty_rationale` + `fusion_reasoning` (which papers, how they combine, why novel), rendered on the passport so the user knows they're evaluating a hypothesis, not a validated strategy. The rigor gate ([rigor-gate-unification](rigor-gate-unification.md)) validates separately.
+5. **True-model provenance** — `response.model` (the model that actually served the request) is recorded, not the configured string.
+
+## Consequences
+
+### Positive
+- **Targets novelty, the only durable alpha** — searches for unpublished combinations instead of re-implementing already-arbitraged published strategies.
+- **Grounded, no vibes** — every proposal names its source papers; anyone can verify the synthesis is faithful. A structural defense against hallucination the free-form path lacked.
+- **Clean division of labor** — generation invents (hypothesis); the external rigor gate proves. No conflation of "I synthesized it" with "I proved it."
+- **Additive** — architect + agent fallbacks are untouched; with the flag off, behavior is byte-identical to before.
+
+### Negative / costs we accept
+- **Requires a corpus + an LLM** — a bare install can't run fusion; it degrades gracefully to architect/agent.
+- **Output is a hypothesis, not a guarantee** — the passport/UI must be explicit ("Fusion proposal — under rigor review"), which is correct but means users see "candidate," not "ready to deploy."
+
+## Alternatives considered
+- **Architect-primary — rejected** for coverage: the curated library starts at a handful of strategies; fusion can propose from the full corpus.
+- **Free-form LLM only — rejected** for credibility: ungrounded output abandons the paper-grounded, verifiable wedge.
+- **Run architect + fusion in parallel and blend — rejected** for UX + latency: a single primary path with explicit fallbacks is clearer.
+
+## Ratification
+
+Accepted; wired live via PR #751. Reconciles with [k1-generation-external-rigor-gate](k1-generation-external-rigor-gate.md) (fusion is the K=1 generator) and the empty-corpus risk is tracked separately (the embedding/RAG layer is a quality enhancement, not a blocker for basic end-to-end fusion).

--- a/docs/adr/glm-to-bedrock-llm-migration.md
+++ b/docs/adr/glm-to-bedrock-llm-migration.md
@@ -1,0 +1,44 @@
+# ADR: GLM → AWS Bedrock LLM migration
+
+> **Audience:** Archimedes team (decision owner: Dan)
+> **Status:** **Decided.** Initial Bedrock backend in [commit 199132c](https://github.com/a-apin/archimedes/commit/199132c); multi-model + Nova Micro default in [PR #717](https://github.com/a-apin/archimedes/pull/717). Live since 2026-06-24.
+> **Question being decided:** Which LLM provider for the live backend — GLM via z.ai's anthropic-compatible bridge, or AWS Bedrock?
+> **Related:** CLAUDE.md § "LLM", `backend/archimedes/services/llm_backend.py` (`make_llm_backend`, the Converse backend).
+
+## TL;DR
+
+**AWS Bedrock is the live LLM, with Amazon Nova Micro the free-tier default via a multi-provider Converse backend** and a model cost-picker on the Generate page. GLM is removed from the default prod path (still selectable in the free-tier allowlist); BYOK and a local-Ollama single-user path are preserved. `response.model` is the provenance of record across the migration. The two Anthropic-on-Bedrock models (Haiku 4.5 / Sonnet 4.6) are pending AWS use-case activation (roadmap T3.8) before the paid tier has real models behind it.
+
+## Context
+
+The backend's LLM factory supported direct Anthropic (BYOK), GLM via z.ai's `anthropic_compatible` bridge, and local Ollama. Prod ran on GLM for cost/simplicity, but z.ai is a third-party SaaS bridge we don't control. The 2026-06-24 migration to Dan's own AWS account opened a cleaner path: Bedrock via IAM instance-role auth (no API keys in prod), and Bedrock's **Converse API**, which unifies the request/response shape across providers — removing per-provider SDKs. **Amazon Nova Micro** is the cheapest competitive text model and is invokable immediately (unlike Anthropic-on-Bedrock, which needs a one-time account-level use-case attestation).
+
+## Decision
+
+1. **`LLM_PROVIDER=bedrock_converse` is the live default** (EC2 instance-role auth); model resolves from config, defaulting to Amazon Nova Micro.
+2. **A multi-provider Converse abstraction** wraps the bedrock-runtime client so any Bedrock model is selectable via one API; it degrades gracefully when a model doesn't accept a system prompt in the Converse shape.
+3. **Server-side free-tier model allowlist** governs which models a free user can pick (Nova family, open-source models, and GLM preserved as an option). Premium Anthropic-on-Bedrock models are gated behind the paid-tier entitlement (see [paid-tier gating], #723) and pending T3.8 activation.
+4. **Provenance via `response.model`** — every completion records the model that actually answered, the source of truth across the GLM→Bedrock era.
+5. **Backward-compatible dev paths** — `anthropic` (BYOK), `anthropic_compatible`, and `ollama` remain for dev/test; the factory falls back to a canned offline backend when a provider is unavailable.
+
+## Consequences
+
+### Positive
+- **Removes a third-party bridge dependency** — Bedrock is first-party AWS infra under Dan's control.
+- **Rational cost structure** — Nova Micro is cheap and adequate for free-tier synthesis/traces; stronger models are an upsell, not a cost on free traffic.
+- **Model flexibility** — Converse decouples the UI picker from the SDK; adding a model is an allowlist change.
+- **No consumer breakage** — the `LLMBackend` protocol + `make_llm_backend()` signature are unchanged; callers don't know which provider runs.
+
+### Negative / costs we accept
+- **Bedrock requires AWS/IAM** — local dev needs AWS creds (or the Ollama fallback).
+- **Anthropic-on-Bedrock needs a one-time use-case form** (Dan) — until approved, premium tiers default to Nova (roadmap T3.8). The UI marks this "activating soon."
+- **`.env.example` still defaults to `anthropic_compatible`** — stale vs the live `bedrock_converse`/Nova default; tracked as T3.10.
+
+## Alternatives considered
+- **Stay on GLM (status quo) — rejected** for infrastructure control: a third-party bridge is a live dependency we don't own; the AWS-account migration was the right moment to swap.
+- **Anthropic API directly (paid Bedrock credits) — not chosen as default:** Converse enables the multi-model picker that a single-vendor API doesn't; BYOK remains available for dev.
+- **Nova-only, no picker — rejected** for UX: users should see and choose the cost/performance tradeoff.
+
+## Ratification
+
+Decided; deployed 2026-06-24 (commit 199132c + PR #717). GLM stays selectable; Anthropic-on-Bedrock activation is queued (T3.8). See [aws-account-migration](aws-account-migration.md) for the account this runs on.

--- a/docs/adr/k1-generation-external-rigor-gate.md
+++ b/docs/adr/k1-generation-external-rigor-gate.md
@@ -1,0 +1,45 @@
+# ADR: K=1 generation + externalized rigor gate
+
+> **Audience:** Archimedes team (decision owner: Dan, architecture; implementation: Önder + Daniel R.)
+> **Status:** **Adopted.** Codified 2026-05-23 after a Linus-Maestro architecture audit; live in the generation + passport flow.
+> **Question being decided:** How many candidate strategies should the generation agent emit per Generate call — K=1 (one winner + considered alternatives), or K=many (parallel candidates all gated together)?
+> **Related:** [`docs/architectural-principles.md` § 5](../architectural-principles.md), [`docs/user-stories.md`](../user-stories.md), `backend/archimedes/agents/generation_pipeline.py`, `backend/archimedes/services/strategy_fusion.py`.
+
+## TL;DR
+
+**The generation agent emits ONE winner per Generate call (plus a short list of considered-rejects with rationale); the rigor gate runs EXTERNALLY and is what the user reviews on the strategy passport before deploy.** Two reasons: **(1) hosted-LLM budget economics** — K=many multiplies LLM + backtest cost per Generate; K=1 keeps the demo affordable and responsive for the single-user MVP. **(2) Externally-verifiable provenance** — shifting rigor enforcement from runtime types to externally-verifiable hashes (`methodology_hash` + `consulted_paper_hashes` anchored on-chain via `ReasoningTraceRegistry` / `StrategyRegistry`) is a strict upgrade: anyone can recompute and verify; the agent cannot lie about what it consulted.
+
+## Context
+
+The generation pipeline runs inside a hosted LLM with a per-token cost. An earlier design considered **K=many internal generation**: emit N candidates, run the rigor gate (DSR + PBO + walk-forward OOS + look-ahead audit) over all N, rank, and surface the top K. The appeal is *more diversity*, but the economics are punishing — N synthesis rounds + N backtest runs + an N-way PBO matrix per Generate, multiplying both cost and latency. For a demo whose Traction score is computed from `arc-canteen update-product` telemetry, K=many makes every user session several times more expensive and slower.
+
+The provenance argument is the stronger one. K=1 + an external gate means the user sees exactly what the agent generated, then reviews the rigor verdict before deploying. The methodology + paper-corpus hashes anchor on-chain only when rigor passes — they become verifiable facts, not labels claimed before earned.
+
+## Decision
+
+**Emit K=1 (one winner per Generate) plus a considered-alternatives panel.**
+
+1. **One primary winner** — the highest-fitness strategy for the user brief + current regime (papers list, methodology, thesis, asset universe, regime tag).
+2. **Considered-rejects panel** — 2–5 alternatives the agent evaluated but rejected, each with a one-sentence rationale, persisted in the reasoning trace (not asserted on the passport).
+3. **The rigor gate is external** — the user reviews the winner on the strategy passport (methodology, papers, backtest, rigor verdict) before the Deploy button enables.
+
+The user-facing flow: **Generate → winner + alternatives panel → review passport (rigor verdict) → Deploy** (or reject + regenerate). On-chain anchoring is per-winning-strategy only (the `StrategyRegistry` stores only passed-rigor passports); failed-rigor candidates persist in `strategy_proposals` (episodic memory) but are never anchored — keeping the registry meaningful and gas bounded.
+
+## Consequences
+
+### Positive
+- **Predictable cost + latency.** One synthesis round per Generate, not K. The considered-rejects panel preserves the "what else was on the table" signal without paying for parallel deep generation.
+- **Verifiable provenance out of the box.** K=1 + external gate + on-chain anchoring of passed-rigor strategies makes the full decision trail auditable without trusting the platform's internal process.
+- **Budget aligns with the single-user MVP** and scales naturally; K=many batching is a v2 decision that needs no core change.
+
+### Negative / costs we accept
+- **Users can't see rigor verdicts on the alternatives** (rationales only). Mitigation: a post-MVP "run rigor on this alternative" button can evaluate a selected reject on demand.
+- **A single bad winner can look bad** if the user doesn't notice until the passport review. Mitigation: the considered-alternatives panel + cheap regeneration (one synthesis round).
+
+## Alternatives considered
+- **K=many internal gating (rank by Sharpe/PBO) — rejected** for cost (N× LLM + backtest + N-way PBO) and for burying the "we evaluated K, this won" decision inside the agent rather than in verifiable on-chain anchors.
+- **K=1 with asynchronous gating (poll for verdict) — rejected** for UX: the linear "review verdict before Deploy" story is more credible than "wait, then review."
+
+## Ratification
+
+Adopted and live (generation pipeline → rigor evaluator → passport review). This ADR formalizes the rationale after the fact. Episodic compounding builds on top: every fusion proposal + rigor verdict + user-reject is content-hashed into `strategy_proposals` so the library demonstrably compounds rather than restarting per session.

--- a/docs/adr/non-custodial-vault-owner-agent.md
+++ b/docs/adr/non-custodial-vault-owner-agent.md
@@ -1,0 +1,42 @@
+# ADR: Non-custodial vault architecture — owner ≠ agent
+
+> **Audience:** Archimedes team (decision owner: Dan; preferred contract reviewer: Bogdan `mnemonik-dev`)
+> **Status:** **Accepted.** Implemented in [PR #731](https://github.com/a-apin/archimedes/pull/731) (owner≠agent vaults + `transferOwnership`); live on Arc testnet.
+> **Question being decided:** Who holds withdrawal authority in user vaults? Can a compromised agent key drain user funds?
+> **Related:** [`docs/specs/ecosystem-design-spec.md` § 3.2](../specs/ecosystem-design-spec.md), [`docs/architectural-principles.md`](../architectural-principles.md) (primitive #3), `contracts/src/Vault.sol`, `contracts/src/VaultFactory.sol`.
+
+## TL;DR
+
+**Separate the vault `owner` (the user, holds withdrawal authority) from the `agent` (Archimedes AI, holds rebalance authority only).** The agent can call `rebalance()` to move assets internally; it cannot withdraw, transfer, or redirect funds to a platform wallet. Only the owner can `withdraw()` / `redeem()`. This makes "non-custodial" a structural property of the contracts, not a claim backed by key hygiene alone — the same instinct as the Chainlink-primary oracle (remove the lone trusted writer in front of funds), applied to custody.
+
+## Context
+
+The Archimedes vault is an ERC-4626 tokenized vault holding user USDC + synth tokens. Rebalancing is continuous (drift thresholds, regime shifts, strategy rotation) — that is the agent's job. But rebalance authority sits one step from the funds: it moves USDC between assets and can mis-execute, yet must never be able to send user USDC to a platform address. An earlier shape conflated `creator` (deployer) with withdrawal authority, leaving a vector where a compromised agent key could rebalance *and* withdraw on the user's behalf. PR #731 makes the separation explicit and structural.
+
+## Decision
+
+**Distinct, bounded roles on the ERC-4626 vault:**
+- **`owner`** (the user) — withdrawal authority only: `withdraw()` / `redeem()`. Cannot `rebalance()` or `setAgent()`.
+- **`creator`** (deployer) — configuration authority: `setAgent()`, oracle/slippage config. Cannot `rebalance()`.
+- **`agent`** (Archimedes AI, or a Tier-2 community manager) — `rebalance()` / `setTargetAllocations()` only. Cannot `withdraw()`, `redeem()`, `transfer()`, or `setAgent()`.
+
+A rebalance cannot exfiltrate to a platform-held wallet: it operates only over the creator-curated asset allowlist, and only `withdraw()`/`redeem()` (owner-gated) route USDC to a receiver. `transferOwnership` lets the user retain/transfer their authority explicitly.
+
+## Consequences
+
+### Positive
+- **Non-custodial becomes a structural guarantee.** A compromised agent key can mis-rebalance (a *performance* risk) but cannot *steal* (a custody risk). The user's withdrawal signature is still required for any custodial action.
+- **Clear Tier-1 / Tier-2 governance** — Tier-1 vaults are agent-deployed with the user as `owner`; Tier-2 community vaults use the same structure with a real-user creator.
+- **Consistent with the oracle work** ([chainlink-primary-oracle](chainlink-primary-oracle.md)) — both remove a single trusted authority in front of funds. Together, "non-custodial" is a property, not a slogan.
+
+### Negative / costs we accept
+- **More roles + guards = more contract surface + test surface.** Mitigated by dedicated Foundry tests covering the role boundaries.
+- **Operational care** — setting the agent to a wrong address blocks rebalancing until corrected (`setAgent()` is owner-only and deliberate). This is the correct fail-safe default.
+
+## Alternatives considered
+- **Single-role vault (creator == agent) — rejected** for security: it gives a compromised agent key full control over user funds — the exact vector PR #731 closes.
+- **Time-lock / multi-sig on agent rotation — rejected as incomplete:** it slows key swaps but doesn't narrow the agent's authority *now*. The real defense is narrow authority, not slow rotation.
+
+## Ratification
+
+Accepted; implemented via PR #731 (live on Arc testnet). Commit-before-trade ([commit-reveal] enforcement, #589/#755) layers on top so a rebalance also requires a fresh, causally-prior reasoning-trace commitment.

--- a/docs/adr/portfolio-constructor-consolidation.md
+++ b/docs/adr/portfolio-constructor-consolidation.md
@@ -1,0 +1,45 @@
+# ADR: Portfolio-constructor consolidation — retire legacy paths, activate dual-signal sizing
+
+> **Audience:** Archimedes team (decision owner: Önder, portfolio math; Dan, agent integration)
+> **Status:** **Decided.** Legacy retired in Phase 7 ([#131](https://github.com/a-apin/archimedes/issues/131), [commit a4a09fb](https://github.com/a-apin/archimedes/commit/a4a09fb)); dual-signal path wired in [commit c74e825](https://github.com/a-apin/archimedes/commit/c74e825) for [#662](https://github.com/a-apin/archimedes/issues/662).
+> **Question being decided:** Which portfolio-construction path is canonical — the legacy `kelly_portfolio` + old generic `portfolio_constructor`, or a new dual-signal implementation that throttles by market regime × ensemble consensus?
+> **Related:** [#659](https://github.com/a-apin/archimedes/issues/659) (consensus rename), [#660](https://github.com/a-apin/archimedes/issues/660) (regime detector), `backend/archimedes/services/portfolio_constructor.py`, `backend/archimedes/chain/agent_runner.py`.
+
+## TL;DR
+
+**Retire the legacy portfolio constructors (no production callers) to `services/_deprecated/`, and activate a NEW `PortfolioConstructor` that implements dual-signal position sizing.** Note the nuance: `portfolio_constructor.py` still exists and is used today — what was retired is the *legacy* generic constructor + `kelly_portfolio`; what's live is the new dual-signal one. It throttles risk-asset exposure by `position_scale = regime_mult × consensus_mult ∈ [0, 1]`, moving freed mass into USDC — unifying two orthogonal risk signals (macro environment vs strategy conviction) into one conservative, non-circular sizer.
+
+## Context
+
+Two earlier refactors collide here, so precision matters:
+1. **Phase 7 (issue #131, commit a4a09fb)** moved the *legacy* generic `portfolio_constructor.py` + `kelly_portfolio.py` to `services/_deprecated/`. Both had **zero production call sites** (only test imports) — dead code from an earlier design phase. The `IPortfolioConstructor` Protocol in `interfaces/` was kept as a stable seam.
+2. **Dual-signal wiring (issue #662, commit c74e825)** then built a *new*, actually-called `PortfolioConstructor`. The agent runner already computed two independent risk signals every tick — the exogenous **market regime** (#660) and the endogenous **ensemble consensus** (#659) — but neither fed position sizing; raw aggregated weights mapped straight to vault allocations with no throttle.
+
+## Decision
+
+**Retire the legacy constructors and route sizing through the new dual-signal `PortfolioConstructor`:**
+- Computes `regime_mult ∈ [0,1]` (lower in high-risk regimes) and `consensus_mult ∈ [0,1]` (higher with stronger ensemble agreement), then `position_scale = regime_mult × consensus_mult`.
+- Throttles raw weights by `position_scale`, routes freed mass to USDC (the safe asset), renormalizes to sum 1.0.
+- **Degrades gracefully** — if either signal is unavailable, defaults to conservative scaling rather than crashing, so the agent stays live.
+- Preserves a hard USDC safe-asset floor so even 0× signal scaling never de-risks below the floor.
+- Extends `IPortfolioConstructor` with optional keyword-only params so the Protocol stays stable (no existing caller breaks).
+
+## Consequences
+
+### Positive
+- **Removes dead code** and clarifies the canonical path (the `_deprecated/` move answers "which one does the agent use?").
+- **Closes the measure-but-ignore gap** — the agent was computing regime + consensus but not using them to size; now they throttle exposure.
+- **Non-circular, conservative** — multiplying two orthogonal [0,1] signals shrinks exposure if *either* warns; matches regime-conditional Kelly sizing (Lo 2002; López de Prado 2018 §11).
+- **More credible on-chain traces** — each rebalance trace can carry the regime + consensus multipliers as a paper-grounded sizing justification.
+
+### Negative / costs we accept
+- **Two detector dependencies** — needs both the regime detector (#660) and ensemble consensus (#659) live; degrades to conservative scaling if one is down (ops should monitor both).
+- **Multiplicative, not additive** — `0.7× × 0.8× = 0.56×`, not `0.75×`. Correct Kelly behavior, but can feel aggressive to risk managers used to linear blending; the safe-asset floor + drift rebalancing keep the agent from being fully parked.
+
+## Alternatives considered
+- **Keep the legacy paths alive — rejected:** dead code is a liability; one canonical implementation is clearer.
+- **Regime-only (ignore consensus) — rejected:** regime is macro, consensus is the ensemble's own conviction; ignoring consensus defeats the ensemble's purpose.
+
+## Ratification
+
+Decided; legacy retired (Phase 7, #131) and the dual-signal path live (#662). The deprecated modules remain in `services/_deprecated/` for a release cycle and can be hard-deleted once a full test pass confirms no survivors. This is the regime layer's *execution* surface; regime-aware *rigor* (per-regime Sharpe robustness) is surfaced separately in the rigor gate.

--- a/docs/adr/rigor-gate-unification.md
+++ b/docs/adr/rigor-gate-unification.md
@@ -1,0 +1,43 @@
+# ADR: Rigor-gate unification (single source of selection-bias truth)
+
+> **Audience:** Archimedes team (decision owner: Dan; rigor lane: Önder)
+> **Status:** **Adopted.** Driven by the PR #710 audit; the fake-strict badge it found is closed.
+> **Question being decided:** Should every Tier-1 strategy pass the four selection-bias controls via ONE authoritative gate path, or are different gate definitions (a fast one for the library list, a strict one for the passport) acceptable?
+> **Related:** [PR #710](https://github.com/a-apin/archimedes/pull/710) (full-tree technical audit), [`docs/specs/selection-bias-corrections-spec.md`](../specs/selection-bias-corrections-spec.md), `backend/archimedes/services/rigor_evaluator.py` (`run_rigor_gate`).
+
+## TL;DR
+
+**Every Tier-1 strategy passes the SAME four selection-bias controls — Deflated Sharpe Ratio (DSR), Probability of Backtest Overfitting (PBO), walk-forward OOS Sharpe, look-ahead audit — via ONE authoritative rigor gate.** The gate is unified (one code path, one set of thresholds, one verdict per strategy) and surfaced honestly in the passport (each control shown as its own field, not hidden behind an aggregate score). Failed-rigor strategies are visible failures, not silently dropped. The motivation: Bogdan's PR #710 audit found an earlier implementation had a *fake-strict* rigor badge — the passport claimed rigor but the gate was lenient/incomplete, violating the "claims must be true on the live path" rule.
+
+## Context
+
+The selection-bias spec (Bailey & López de Prado 2014; Bailey, Borwein, López de Prado & Zhu 2014) names four orthogonal controls that separate credible published alpha from curve-fit artifacts: DSR (p-value ≥ 0.95), PBO via CSCV (< 0.5), walk-forward OOS Sharpe (no in/out-of-sample cliff), and a look-ahead static audit. The pitch claims Tier-1 strategies survive all four — the Day-3 red-team insight that became the wedge. The risk the audit found: two divergent gate paths (a fast lenient one for the list view, a stricter one for detail) let the "✓ Rigor Gate Passed" badge display for strategies that passed the lenient path but not the strict one.
+
+## Decision
+
+**One unified `run_rigor_gate()` computes all four controls, records each independently, and emits a single boolean verdict** (`passes_all = DSR p≥0.95 AND PBO<0.5 AND OOS/IS≥0.5 AND look-ahead PASS`). Every read — library list, passport detail, on-chain anchor eligibility — consults the same verdict.
+
+- **Honest surfacing:** the passport returns all four results as separate fields (with the actual numbers), not an aggregate. Paper-claim deltas are shown, never hidden.
+- **Failure visibility:** failed strategies persist with `verdict='rigor_fail'` and are queryable, not silently dropped — defeating the "keep generating until one passes by chance" dynamic.
+- **On-chain eligibility:** a strategy is anchored to the `StrategyRegistry` iff `passes_rigor_gate=true`. Fail-closed: a missing/NaN metric fails its criterion rather than silently passing.
+
+## Consequences
+
+### Positive
+- **"Claims must be true on the live path" is load-bearing** — the gate behaves identically whether tested locally, rendered on the site, or audited on-chain.
+- **Complete audit trail** — recompute the four metrics off-chain, read the hashes on-chain, cross-check. The loop is closed and third-party-verifiable.
+- **Falsifiable** — any reader can check `dsr_p_value` against 0.95; no hiding behind aggregate scores.
+
+### Negative / costs we accept
+- **Four fixed thresholds to defend** — if research consensus shifts, they must be re-evaluated in lockstep (no per-strategy exceptions).
+- **PBO is library-wide**, so adding a strategy recomputes the selection-set PBO; the passport records `num_trials` so the computation stays reproducible.
+- **Synchronous gate latency** — the generator waits for the gate; acceptable for the demo (the user reviews the passport anyway).
+
+## Alternatives considered
+- **Two-tier rigor (fast list gate + strict detail gate) — rejected:** this is exactly what produced the fake-strict badge. Two paths = two truths.
+- **Adaptive thresholds (scale with library size N) — rejected** for auditability: a moving target erodes "it passed" credibility.
+- **Lazy PBO (defer to deploy-time) — rejected:** the user should see the full verdict before deciding, not have the gate fail at deploy.
+
+## Ratification
+
+Adopted; the fake-strict bug flagged by the PR #710 audit is closed and the gate is unified. (See also [k1-generation-external-rigor-gate](k1-generation-external-rigor-gate.md) — the gate runs *external* to the K=1 generator.)


### PR DESCRIPTION
## What

The ADR habit started mid-build, so several load-bearing decisions shipped without a record. This back-fills **8 historical ADRs** so a judge / teammate / grant reviewer can understand *why* the architecture is the way it is without relitigating it. No code — docs only.

Each ADR matches the existing format (`backtrader-vs-vectorbt`, `chainlink-primary-oracle`) and **cites the PR/commit/spec it documents — all refs verified against the repo** (gh + `git cat-file`):

| ADR | Documents | Ref (verified) |
|---|---|---|
| build-on-deploy-main-only | main-only, every merge auto-deploys | CLAUDE.md |
| aws-account-migration | prod → Dan's own AWS account | CLAUDE.md (2026-06-24) |
| k1-generation-external-rigor-gate | K=1 winner + considered-rejects, external gate | architectural-principles §5 |
| rigor-gate-unification | one authoritative selection-bias gate | PR #710 |
| non-custodial-vault-owner-agent | owner≠agent vaults | PR #731 ✓ |
| fusion-primary-generation | paper-grounded fusion-primary | PR #751 ✓ |
| glm-to-bedrock-llm-migration | GLM → Bedrock/Nova Micro | PR #717 ✓ + commit 199132c ✓ |
| portfolio-constructor-consolidation | retire legacy + dual-signal sizing | #131/#662 ✓ + commits a4a09fb/c74e825 ✓ |

Also:
- `docs/adr/README.md` index updated (2 → **10 ADRs**).
- Removed the stale **"Submission-day status"** section in `docs/README.md` whose only link — the "Start here" pointer to `dead-code-audit-2026-05-24-v2.md` — pointed at a deleted file (a past-Agora artifact; we're in the Lepton sprint now).

## Reviewer note
These are best-effort back-fills of decisions made earlier; the *narratives* are faithful to CLAUDE.md/specs and the *refs* are verified, but if any nuance is off (esp. the portfolio-constructor one, which has a subtle legacy-vs-new distinction), flag it and I'll correct. The remaining Phase-7 items (promote the external ROADMAP into `docs/ROADMAP.md`) are a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)