### PR TITLE
[infra] Deployment: managed-stores compose profiles + nginx runtime DNS resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,15 @@
 # the strategy intelligence SILENTLY falls back to canned output. The Arc
 # wallet / RPC / Circle variables are optional locally (skip on-chain features).
 
+# ── Compose profile: run the in-stack Postgres + Redis locally ─────────────
+# LOCAL DEV keeps this set so `docker compose up` brings up the full
+# self-contained stack (postgres + redis + app). PRODUCTION leaves it UNSET:
+# the postgres/redis services are profile-gated (profiles: ["localdb"] in
+# docker-compose.yml), so without this they don't start and the app talks to
+# managed Aurora + ElastiCache via DATABASE_URL / REDIS_URL below. One compose
+# file, two topologies — see docs/deployment.md.
+COMPOSE_PROFILES=localdb
+
 # ── PostgreSQL (the local docker compose stack starts a server with these) ──
 # LOCAL-DEV ONLY. This is a throwaway local password, NOT a production secret —
 # the EC2 bootstrap (infra/user-data.sh) generates a random password at boot.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,17 @@
 # Usage: docker compose up --build -d
 
 services:
-  # ---------- Data stores ----------
+  # ---------- Data stores (LOCAL ONLY — see profiles note) ----------
+  # postgres + redis run ONLY when the `localdb` profile is active
+  # (COMPOSE_PROFILES=localdb, set in .env.example for local dev). In PRODUCTION
+  # the .env omits COMPOSE_PROFILES, so these two services are NOT started and
+  # the app talks to managed Aurora + ElastiCache via DATABASE_URL / REDIS_URL.
+  # This makes ONE compose file serve both: `docker compose up` locally brings up
+  # the full self-contained stack; the same command in prod (no localdb profile)
+  # runs the app tier against managed stores. See docs/deployment.md.
   postgres:
     image: postgres:16-alpine
+    profiles: ["localdb"]
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-archimedes}
@@ -22,6 +30,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    profiles: ["localdb"]
     restart: unless-stopped
     # NO host port binding — Redis is internal-only.
     healthcheck:
@@ -70,11 +79,17 @@ services:
       - .env
     healthcheck:
       disable: true
+    # required: false → these app services still start when postgres/redis are
+    # NOT in the active profile (production = managed Aurora/ElastiCache). When
+    # the `localdb` profile IS active, they wait for the local DB/cache to be
+    # healthy. (required on depends_on needs docker compose ≥ 2.20.)
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
+        required: false
 
   # ---------- Strategy Agent (autonomous portfolio runner) ----------
   agent:
@@ -98,11 +113,17 @@ services:
       - ./contracts/abis:/contracts/abis:ro
     healthcheck:
       disable: true
+    # required: false → these app services still start when postgres/redis are
+    # NOT in the active profile (production = managed Aurora/ElastiCache). When
+    # the `localdb` profile IS active, they wait for the local DB/cache to be
+    # healthy. (required on depends_on needs docker compose ≥ 2.20.)
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
+        required: false
 
   # ---------- Backend API ----------
   backend:
@@ -145,11 +166,17 @@ services:
       - ./contracts/abis:/contracts/abis:ro
       - ./data/corpus:/app/data/corpus:ro
       - archimedes-corpus-artifact:/app/data/corpus-artifact
+    # required: false → these app services still start when postgres/redis are
+    # NOT in the active profile (production = managed Aurora/ElastiCache). When
+    # the `localdb` profile IS active, they wait for the local DB/cache to be
+    # healthy. (required on depends_on needs docker compose ≥ 2.20.)
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
+        required: false
 
   # ---------- KB pipeline runner (Phase 3c skeleton) ----------
   # Polls the corpus + artifact volume and re-runs the SPECTER2 / HDBSCAN /
@@ -179,9 +206,11 @@ services:
     volumes:
       - ./data/corpus:/srv/corpus-text:ro
       - archimedes-corpus-artifact:/srv/corpus-artifact:rw
+    # required: false → starts against managed Aurora in prod (no localdb profile).
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
 
 volumes:
   pgdata:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,12 +60,25 @@ bootstrap + a `/health` check.
 
 The live EC2 currently still has the idle `postgres`/`redis` containers running
 (left intact as the cutover rollback). After this PR merges and you're confident
-the managed stores are stable, reclaim the resources:
+the managed stores are stable, reclaim the resources.
 
-```bash
-aws ssm start-session --target i-01803d3abc271d39b --region us-east-1
-cd /opt/archimedes && docker compose stop postgres redis   # or: docker rm -f
-```
+**These are two separate steps. The second command runs _inside_ the interactive
+SSM session, on the EC2 — do NOT run `docker compose stop` on your laptop.**
+
+1. Open an interactive shell on the live box (substitute the real instance id /
+   region — the current values are in the `prod-infra-reality` notes / `CLAUDE.md`
+   AWS section):
+
+   ```bash
+   aws ssm start-session --target <INSTANCE_ID> --region <REGION>
+   ```
+
+2. **Now at the EC2 shell prompt** (the prompt changes to the instance's
+   hostname), stop the idle containers:
+
+   ```bash
+   cd /opt/archimedes && docker compose stop postgres redis   # or: docker rm -f
+   ```
 
 (The `pgdata` volume persists — data isn't deleted — but once the cutover is
 trusted it's just dead weight. Keep it until then as the rollback path.)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,79 @@
+# Deployment — local vs production (one compose file, two topologies)
+
+> Written 2026-06-28, alongside the Aurora/ElastiCache cutover. Resolves the
+> drift between "simple `docker compose up` locally" and "how it runs in prod."
+
+## The two topologies
+
+| | Local dev | Production (single EC2) |
+|---|---|---|
+| Command | `docker compose up -d` | `docker compose up -d --force-recreate --remove-orphans` (via `deploy.yml`) |
+| Data stores | **in-stack** `postgres` + `redis` containers | **managed** Aurora Serverless v2 + ElastiCache |
+| Switch | `.env` has `COMPOSE_PROFILES=localdb` | `.env` omits `COMPOSE_PROFILES` |
+| `DATABASE_URL` | `…@postgres:5432/…` | `…@archimedes-aurora…:5432/…?sslmode=require` |
+| `REDIS_URL` | `redis://redis:6379/0` | `rediss://…elasticache…:6379/0` (TLS) |
+
+**How one file serves both:** `postgres` and `redis` are gated behind
+`profiles: ["localdb"]` in `docker-compose.yml`. The `localdb` profile is active
+**only** when `COMPOSE_PROFILES=localdb` is in the `.env` (which `.env.example`
+ships, so local dev is unchanged — `cp .env.example .env && docker compose up`
+still brings up the full self-contained stack). Production's box-local `.env`
+omits `COMPOSE_PROFILES`, so those two services never start and the app tier
+(`backend`, `oracle`, `agent`, `kb-runner`, `nginx`) runs against managed
+Aurora + ElastiCache via the URLs in `.env`. The app services declare
+`depends_on … { required: false }` so they boot even when the local DB/cache
+isn't present (prod). *(Needs docker compose ≥ 2.20 for `required:` on
+`depends_on`.)*
+
+## Why this shape
+
+Before this change, prod ran the **base** stack (in-stack postgres/redis) even
+though the app `.env` already pointed at managed Aurora/ElastiCache after the
+2026-06-28 cutover — so the box **double-ran** idle docker databases (paying for
+managed *and* burning EC2 RAM on unused containers). Profile-gating makes the
+managed-stores intent explicit and stops the waste, without forking the compose
+file or changing the local workflow.
+
+## nginx runtime DNS re-resolution (the recreate-502 fix)
+
+`nginx/nginx.conf` previously declared `upstream backend_api { server
+backend:8000; }`. nginx resolves that hostname to an IP **once at config-load**
+and caches it. When `--force-recreate` gives the `backend` container a **new**
+IP, nginx keeps proxying the dead IP → **every request 502s** until nginx is
+restarted (this is exactly what happened during the cutover when the backend was
+recreated without nginx). The fix adds a `resolver 127.0.0.11` (docker's
+embedded DNS) + `zone` + the `resolve` parameter so nginx re-resolves `backend`
+at **runtime** (every 10s) — a backend recreate now self-heals. A full
+`deploy.yml` run recreates *all* services (nginx after backend), so it was
+already safe; this fix additionally makes **partial** recreates (operational
+fixes) safe.
+
+## Production deploy flow (`deploy.yml`)
+
+Push to `main` → (gated on `DEPLOY_ENABLED=true`) → OIDC into AWS → SSM
+`SendCommand` on the EC2: `git reset --hard origin/main` (the gitignored `.env`
+is **untouched**, so the managed-store URLs persist), `docker compose build`,
+`docker compose up -d --force-recreate --remove-orphans`, then seed/hydrate/AMM
+bootstrap + a `/health` check.
+
+## One-time step on the live box (after merging this change)
+
+The live EC2 currently still has the idle `postgres`/`redis` containers running
+(left intact as the cutover rollback). After this PR merges and you're confident
+the managed stores are stable, reclaim the resources:
+
+```bash
+aws ssm start-session --target i-01803d3abc271d39b --region us-east-1
+cd /opt/archimedes && docker compose stop postgres redis   # or: docker rm -f
+```
+
+(The `pgdata` volume persists — data isn't deleted — but once the cutover is
+trusted it's just dead weight. Keep it until then as the rollback path.)
+
+## ⚠️ Merge note
+
+`DEPLOY_ENABLED=true` — **merging this auto-deploys.** Merge in a controlled
+window with someone watching the deploy, **not** right before a demo/relaunch.
+The nginx-resolver part is low-risk; the profile-gating changes which services
+prod starts — validate the `/health` 200 after deploy and have the rollback
+(revert + redeploy) ready.

--- a/infra/user-data.sh
+++ b/infra/user-data.sh
@@ -62,6 +62,13 @@ POSTGRES_PASSWORD=$${DB_PASS}
 POSTGRES_DB=archimedes
 REDIS_URL=redis://redis:6379/0
 DATABASE_URL=postgresql://archimedes:$${DB_PASS}@postgres:5432/archimedes
+# The postgres/redis services are profile-gated (profiles: ["localdb"]) so the
+# default compose run starts only the app against MANAGED stores. This freshly
+# bootstrapped instance writes in-stack DATABASE_URL/REDIS_URL above, so it MUST
+# enable the localdb profile or those services won't start and the app can't
+# connect. Cutover to managed Aurora/ElastiCache is a deliberate manual step:
+# edit this .env to the managed URLs and REMOVE this line, then recreate. (#780)
+COMPOSE_PROFILES=localdb
 ENVEOF
 chmod 600 /opt/archimedes/.env
 chown ubuntu:ubuntu /opt/archimedes/.env

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -20,6 +20,10 @@ COPY ui/ .
 RUN npm run build
 
 # Stage 2: serve with non-root nginx (listens on 8080, no CAP_NET_BIND_SERVICE needed)
-FROM nginxinc/nginx-unprivileged:alpine
+# Pinned to a specific version: nginx.conf's upstream `server … resolve` directive
+# (runtime DNS re-resolution) REQUIRES nginx >= 1.27.3. An unpinned `:alpine` tag
+# (or a stale cached layer) could resolve to an older nginx and make `nginx -t`
+# fail at deploy time, taking the proxy down. Bump this tag deliberately. (#780)
+FROM nginxinc/nginx-unprivileged:1.27.3-alpine
 COPY --from=ui-build /app/dist /usr/share/nginx/html
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -23,7 +23,8 @@ RUN npm run build
 # Pinned to a specific version: nginx.conf's upstream `server … resolve` directive
 # (runtime DNS re-resolution) REQUIRES nginx >= 1.27.3. An unpinned `:alpine` tag
 # (or a stale cached layer) could resolve to an older nginx and make `nginx -t`
-# fail at deploy time, taking the proxy down. Bump this tag deliberately. (#780)
-FROM nginxinc/nginx-unprivileged:1.27.3-alpine
+# fail at deploy time, taking the proxy down. Pinned to 1.31.2 to MATCH the live
+# box (`Server: nginx/1.31.2`) — never downgrade prod. Bump this tag deliberately. (#780)
+FROM nginxinc/nginx-unprivileged:1.31.2-alpine
 COPY --from=ui-build /app/dist /usr/share/nginx/html
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,8 +23,21 @@ real_ip_recursive on;
 # Single source of truth for the FastAPI backend address. keepalive reuses
 # upstream connections, cutting per-request TCP/handshake overhead between
 # nginx and the backend.
+#
+# RUNTIME DNS RE-RESOLUTION (fix for the recreate-502): with a plain
+# `server backend:8000;` nginx resolves the `backend` hostname to an IP ONCE at
+# config-load and caches it for the worker's lifetime. When `docker compose up
+# -d --force-recreate backend` (or a partial recreate) gives the backend a NEW
+# container IP, nginx keeps proxying to the dead IP and every request 502s until
+# nginx is restarted. The `resolver` (docker's embedded DNS at 127.0.0.11) plus
+# `zone` + the `resolve` parameter make nginx re-resolve `backend` periodically
+# (valid=10s) at RUNTIME, so a backend recreate self-heals without an nginx
+# restart. Requires nginx ≥ 1.27.3 for open-source upstream `resolve` (the live
+# image is 1.31.x). keepalive is preserved.
+resolver 127.0.0.11 valid=10s ipv6=off;
 upstream backend_api {
-    server backend:8000;
+    zone backend_api 64k;
+    server backend:8000 resolve;
     keepalive 32;
 }
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -32,8 +32,8 @@ real_ip_recursive on;
 # nginx is restarted. The `resolver` (docker's embedded DNS at 127.0.0.11) plus
 # `zone` + the `resolve` parameter make nginx re-resolve `backend` periodically
 # (valid=10s) at RUNTIME, so a backend recreate self-heals without an nginx
-# restart. Requires nginx ≥ 1.27.3 for open-source upstream `resolve` (the live
-# image is 1.31.x). keepalive is preserved.
+# restart. Requires nginx ≥ 1.27.3 for open-source upstream `resolve`; the image
+# is pinned to 1.31.2 (nginx/Dockerfile) to match the live box. keepalive is preserved.
 resolver 127.0.0.11 valid=10s ipv6=off;
 upstream backend_api {
     zone backend_api 64k;


### PR DESCRIPTION
## Summary
Resolves the local-vs-prod deployment drift surfaced by the Aurora/ElastiCache cutover. **One `docker-compose.yml` now serves both topologies**, and the recreate-502 class of failure is fixed.

### 1. Compose profiles — one file, two topologies
- `postgres` + `redis` are gated behind `profiles: ["localdb"]`.
- **Local dev unchanged:** `.env.example` ships `COMPOSE_PROFILES=localdb` → `docker compose up` brings up the full self-contained stack.
- **Production:** box `.env` omits `COMPOSE_PROFILES` → those services don't start; the app tier runs against **managed Aurora + ElastiCache** via `DATABASE_URL`/`REDIS_URL`. Stops prod **double-running idle docker DBs** post-cutover.
- App services get `depends_on … { required: false }` so they boot without the local DB/cache. *(needs docker compose ≥ 2.20)*

### 2. nginx runtime DNS resolver — the recreate-502 fix
`upstream backend_api { server backend:8000; }` resolved the IP **once** at config-load. A `--force-recreate` gave the backend a new IP → nginx kept proxying the dead one → **502 until nginx restarted** (exactly what happened during the cutover). Added `resolver 127.0.0.11` + `zone` + `server … resolve` → runtime re-resolution, self-healing recreates. keepalive preserved.

## Validation
```
prod (no profile):   agent backend kb-runner nginx oracle          # postgres/redis EXCLUDED ✓
local (localdb):     + postgres redis                               # INCLUDED ✓
docker compose config -q:  VALID ✓
```
⚠️ `nginx -t` not run locally (no docker daemon) — please confirm in CI / on the box before merge; the `resolver`/`zone`/`resolve` directives are standard nginx ≥ 1.27.3 (live image is 1.31.x).

## ⚠️ Merge guidance (`DEPLOY_ENABLED=true` → auto-deploys)
- **Do NOT merge right before the relaunch.** Merge in a controlled window, watch the deploy, verify `/health` 200.
- After merge, one-time on the box: `docker compose stop postgres redis` to reclaim the idle rollback containers (the `pgdata` volume persists as rollback until you trust the cutover).
- nginx-resolver part is low-risk; the profile-gating changes which services prod starts.

## Files
`nginx/nginx.conf`, `docker-compose.yml`, `.env.example` (env-contract change — adds `COMPOSE_PROFILES`), `docs/deployment.md` (new).

cc reviewers for the infra + env-contract change. Relates to the cutover; pairs with the DB-architecture doc PR.