### PR TITLE
[corpus] Honest surface: corpus is manifest metadata, not embedded/graphed (#778)

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -341,6 +341,45 @@ async def health():
     except Exception:
         logger.debug("telemetry counts read failed", exc_info=True)
 
+    # Claim-integrity: corpus honesty fields (issue #778).
+    # The `corpus_papers` / `corpus_db_count` counts above are *metadata records*
+    # seeded from the JSONL manifest into the `papers` table — they do NOT imply
+    # the corpus has been embedded, clustered, or graphed. These three fields make
+    # the real state machine-readable so no surface can present manifest metadata
+    # as "embedded / knowledge-graphed". Each is driven from actual state, never a
+    # constant:
+    #   corpus_embedded         — live sentence-transformer embeddings active
+    #                             (paper_rag == "live"; "degraded" => TF-IDF, NOT embedded)
+    #   corpus_kg_built         — at least one KG entity exists (REBEL/SciSpacy output)
+    #   corpus_artifact_present — a real KB-pipeline artifact (S3/local manifest) exists
+    corpus_embedded = paper_rag_status == "live"
+    kg_entity_count = 0
+    kg_relation_count = 0
+    try:
+        from sqlalchemy import func
+
+        from archimedes.db import get_session
+        from archimedes.models.kg import KGEntity, KGRelation
+
+        with get_session() as session:
+            kg_entity_count = session.query(func.count(KGEntity.id)).scalar() or 0
+            kg_relation_count = session.query(func.count(KGRelation.id)).scalar() or 0
+    except Exception:
+        logger.debug("kg counts read failed", exc_info=True)
+    corpus_kg_built = kg_entity_count > 0
+
+    corpus_artifact_present = False
+    try:
+        from archimedes.services.kb_artifacts import ArtifactNotFound, load_manifest
+
+        try:
+            load_manifest()
+            corpus_artifact_present = True
+        except ArtifactNotFound:
+            corpus_artifact_present = False
+    except Exception:
+        logger.debug("kb artifact probe failed", exc_info=True)
+
     return {
         "status": "ok" if connected else "degraded",
         "service": "archimedes-backend",
@@ -352,6 +391,15 @@ async def health():
         "corpus_source": corpus_source,
         "corpus_last_intake": corpus_last_intake,
         "artifact_hash": artifact_hash,
+        # Claim-integrity honesty fields (issue #778). The counts above are
+        # manifest-seeded *metadata records*; these say what has actually been
+        # built on top of them. New keys only — existing keys are unchanged so
+        # current UI/monitoring consumers don't break.
+        "corpus_embedded": corpus_embedded,
+        "corpus_kg_built": corpus_kg_built,
+        "corpus_kg_entities": kg_entity_count,
+        "corpus_kg_relations": kg_relation_count,
+        "corpus_artifact_present": corpus_artifact_present,
         "fusion_enabled": _fusion_on,
         "llm_provider": llm_provider,
         "llm_backend": llm_backend,

--- a/backend/tests/test_loud_fallback_telemetry.py
+++ b/backend/tests/test_loud_fallback_telemetry.py
@@ -197,3 +197,44 @@ async def test_health_surfaces_regime_and_risk_flags() -> None:
     assert "regime_detector_reason" in body
     assert body["risk_data"] == "mock"
     assert body["risk_data_reason"] == "test mock"
+
+
+# ── /health corpus honesty fields (claim-integrity, issue #778) ──────
+
+
+@pytest.mark.asyncio
+async def test_health_surfaces_corpus_honesty_fields() -> None:
+    """/health exposes machine-readable corpus honesty fields (issue #778).
+
+    The ``corpus_papers`` / ``corpus_db_count`` counts are manifest-seeded
+    *metadata records* — they must not be read as "embedded / graphed". These
+    boolean + count fields make the real state explicit. Hermetic: no DB/KG, so
+    every field reflects the un-built default (no embeddings, no KG, no artifact).
+    """
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # The honesty fields are present and machine-readable booleans / ints.
+    for key in ("corpus_embedded", "corpus_kg_built", "corpus_artifact_present"):
+        assert key in body, f"missing honesty field {key!r}"
+        assert isinstance(body[key], bool)
+    for key in ("corpus_kg_entities", "corpus_kg_relations"):
+        assert key in body
+        assert isinstance(body[key], int)
+
+    # With no KB pipeline run / KG store, every honesty field reads "not built".
+    assert body["corpus_kg_built"] is False
+    assert body["corpus_kg_entities"] == 0
+    assert body["corpus_kg_relations"] == 0
+    assert body["corpus_artifact_present"] is False
+    # corpus_embedded tracks paper_rag: "live" => embedded; anything else => not.
+    assert body["corpus_embedded"] == (body.get("paper_rag") == "live")
+
+    # The legacy count keys are untouched (no consumer breakage).
+    assert "corpus_papers" in body
+    assert "corpus_db_count" in body

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -7,9 +7,9 @@ const AGENTS = [
   {
     name: 'Strategy Generation Agent',
     role: 'What should be done?',
-    desc: 'Retrieves relevant papers from a 1,014-paper q-fin corpus, reads current market context, and synthesizes a candidate strategy that passes the rigor gate.',
+    desc: 'Retrieves relevant papers from a 1,014-record q-fin metadata corpus, reads current market context, and synthesizes a candidate strategy that passes the rigor gate.',
     subagents: [
-      { name: 'Paper Retrieval', detail: 'SPECTER2 nearest-neighbour + KG entity walk' },
+      { name: 'Paper Retrieval', detail: 'Keyword + TF-IDF ranking (SPECTER2 / KG walk: build target)' },
       { name: 'Market Context', detail: 'Regime classifier + on-chain oracle + price history' },
       { name: 'Strategy Synthesis', detail: 'LLM fusion: brief × papers × market' },
       { name: 'Rigor Gate', detail: 'DSR + PBO + chronological OOS + look-ahead audit' },
@@ -84,15 +84,15 @@ const MEMORY_LAYERS = [
   {
     tag: 'E',
     name: 'Semantic knowledge',
-    substrate: 'q-fin corpus (1,014 papers, SPECTER2 + clusters + KG)',
+    substrate: 'q-fin corpus (1,014 metadata records; embeddings + clusters + KG pending)',
     lifetime: 'Persistent',
-    why: 'The substrate the Strategy Generation Agent retrieves from.',
+    why: 'The substrate the Strategy Generation Agent retrieves from (keyword/TF-IDF today).',
   },
 ]
 
 const PROTOCOLS = [
   { name: 'Outcome Embargo', what: 'Papers retrieved at decision time are filtered to those published before the decision; on-chain anchor proves the filter held.' },
-  { name: 'Time-Aware Retrieval', what: 'SPECTER2 similarity decays by paper age; higher decay in volatile regimes.' },
+  { name: 'Time-Aware Retrieval', what: 'Retrieval relevance decays by paper age; higher decay in volatile regimes. (Today over keyword/TF-IDF scores; SPECTER2 similarity once the KB pipeline runs.)' },
   { name: 'Hierarchy of Truth', what: 'Chain state outranks LLM narrative; curated academic literature outranks uncurated sources.' },
   { name: 'Source Tracking', what: 'Every cited paper carries (arxiv_id, version, content_hash). Anchored on Arc; anyone can recompute.' },
 ]
@@ -117,7 +117,7 @@ function HeroStrip() {
   const stats = [
     { n: '3', l: 'Top-level agents', s: 'Generation · Construction · Execution' },
     { n: '6', l: 'Memory layers', s: 'KV cache → on-chain ground truth' },
-    { n: '1,014', l: 'q-fin papers', s: 'SPECTER2 + clusters + KG' },
+    { n: '1,014', l: 'q-fin metadata records', s: 'embeddings + clusters + KG: build target' },
     { n: '10', l: 'Smart contracts', s: 'Deployed on Arc testnet' },
   ]
   return (
@@ -317,11 +317,12 @@ function CorpusPanel() {
     <div className="card p-5 mb-7">
       <div className="label mb-3">The q-fin corpus — Layer E in detail</div>
       <p className="body mb-4">
-        1,014 academic papers (arXiv preprints across q-fin, ML, math, and agentic AI),
-        ingested via PyMuPDF, embedded with SPECTER2, clustered with HDBSCAN, and linked
-        with REBEL + SciSpacy into a knowledge graph. The Strategy Generation Agent's{' '}
-        <strong>Paper Retrieval</strong> sub-agent uses this substrate every time you submit
-        a brief.
+        1,014 paper <strong>metadata records</strong> (arXiv preprints across q-fin, ML, math,
+        and agentic AI) seeded from a JSONL manifest into Postgres. The Strategy Generation Agent's{' '}
+        <strong>Paper Retrieval</strong> sub-agent ranks these records by keyword/TF-IDF relevance
+        when you submit a brief. The full KB pipeline — PyMuPDF full-text extraction, SPECTER2
+        embeddings, HDBSCAN clusters, and a REBEL + SciSpacy knowledge graph — is the build target;
+        it has not run yet, so embeddings, clusters, and graph edges are not live.
       </p>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         {[
@@ -338,9 +339,10 @@ function CorpusPanel() {
         ))}
       </div>
       <p className="caption mt-3" style={{ color: 'var(--text-3)' }}>
-        1,014 papers ingested across 41 categories (top four shown above). Manifest seed
+        1,014 metadata records across 41 categories (top four shown above). Manifest seed
         target is ~10,000 — the remainder hydrate into Postgres incrementally as we expand
-        the corpus.
+        the corpus. Counts are metadata only; they do not imply the records have been
+        embedded or graphed.
       </p>
     </div>
   )

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -307,8 +307,9 @@ export default function Generate({ onNavigate }) {
               <div className="label mb-2 mt-3">Architecture</div>
               <p className="body mb-3">
                 <strong>Strategy Generation Agent</strong> retrieves relevant papers from a
-                1,014-paper q-fin corpus (SPECTER2 embeddings + clusters), reads current market
-                context, and synthesizes a candidate strategy. <strong>Portfolio Construction
+                1,014-record q-fin metadata corpus (keyword/TF-IDF ranking today; SPECTER2
+                embeddings + clusters are the build target), reads current market context, and
+                synthesizes a candidate strategy. <strong>Portfolio Construction
                 Agent</strong> picks assets, sizes them with Kelly + risk parity, and stress-tests
                 across six scenarios. After you sign to deploy, the <strong>Live Execution
                 Agent</strong> runs the rebalance loop on-chain — every decision anchored on Arc


### PR DESCRIPTION
## Summary

Part A (honest surface) of #778. The live `/health` reports `corpus_papers: 10000`, `corpus_db_count: 10000` — but `corpus_source: "file"`, `paper_rag: degraded` (TF-IDF fallback, **no embeddings**), and there is no knowledge graph and no KB/S3 artifact. **The 10,000 are metadata rows seeded from a JSONL manifest into the `papers` table.** Presenting them as a "10k-paper corpus / knowledge graph / RAG" in the UI or pitch is a claim-integrity violation (the #1 rule — a judge disproves it by reading `/health`). This PR makes the real state machine-readable and relabels the over-claiming UI copy so every surviving claim is TRUE. It does **not** build embeddings/KG (that's Part B).

## What changed (small + reviewable: 4 files, +107/-15)

### Backend `/health` — additive only, no key renames
Existing keys (`corpus_papers`, `corpus_db_count`, `corpus_source`, `artifact_hash`, …) are **unchanged** so current UI/monitoring consumers don't break. New honesty fields, each driven from **actual state, never a constant**:

| field | source | value today |
| --- | --- | --- |
| `corpus_embedded` | `paper_rag == "live"` (live sentence-transformer embeddings; `degraded` = TF-IDF = NOT embedded) | `false` |
| `corpus_kg_built` | `kg_entities > 0` | `false` |
| `corpus_kg_entities` / `corpus_kg_relations` | `COUNT()` over the KG tables | `0` / `0` |
| `corpus_artifact_present` | `kb_artifacts.load_manifest()` (real KB artifact probe) | `false` |

Every field fails safe to the un-built default when the DB / KG store / artifact is absent (wrapped in try/except, logged at debug).

### UI copy — make existing claims TRUE (no new claims invented)
- **`Architecture.jsx`**: the CorpusPanel prose claimed the 1,014 papers were "ingested via PyMuPDF, embedded with SPECTER2, clustered with HDBSCAN, and linked with REBEL + SciSpacy into a knowledge graph." Relabeled to "metadata records … ranked by keyword/TF-IDF; the KB pipeline (extraction + embeddings + clusters + KG) is the build target and has not run yet." Same honesty fix applied to the Paper-Retrieval sub-agent descriptor, the Layer-E memory substrate, the hero stat chip, and the Time-Aware-Retrieval protocol line.
- **`Generate.jsx`**: the "How this works" panel now says keyword/TF-IDF ranking today, SPECTER2 embeddings + clusters as the build target.

### Test
Hermetic test (`test_loud_fallback_telemetry.py`) asserts the new honesty fields are present, correctly typed, and read "not built" with no DB/KG — mirrors the existing T0.5 loud-fallback-telemetry pattern.

## `/api/corpus/*` 503 verification (no change needed)
Per CLAUDE.md the KB graph must come from real pipeline output. **Verified this already holds:**
- `GET /api/corpus/graph` → **503** `kb_artifact_not_found` when no artifact exists (probed live in this PR).
- `GET /api/corpus/kg/*` → empty `entities`/`relations` lists when the KG store is empty.
- The UI (`CorpusGraph` / `CorpusKG`) renders the explicit "KB pipeline still running — first artifact pending" empty state for both 503 and empty-data responses.
- `GET /api/corpus/overview` returns the **processed** paper count (0 today), not the 10k metadata count, for the prominent stat chips.

So the corpus endpoints are already honest — documented here, **not** re-scoped.

## Anti-goals (kept out of scope)
- Did **not** rename any existing `/health` key (consumer-safe).
- Did **not** build embeddings / clusters / KG / S3 buckets — that is Part B of #778.
- Did **not** touch contracts, infra, or the `/api/corpus/*` route logic.

## Verify
```bash
# new honesty fields present + correct with no DB/KG:
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
  python -m pytest backend/tests/test_loud_fallback_telemetry.py -q   # 10 passed

# /api/corpus/graph honestly 503s with no artifact:
KB_ARTIFACT_DIR=/nonexistent KB_S3_BUCKET= python - <<'PY'
import asyncio; from httpx import ASGITransport, AsyncClient; from archimedes.main import app
async def m():
    async with AsyncClient(transport=ASGITransport(app=app), base_url='http://t') as c:
        print((await c.get('/api/corpus/graph')).status_code)  # 503
asyncio.run(m())
PY
```

Refs #778 (Part A). DO NOT MERGE without Dan's review — relabels a pitch-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)