### PR TITLE
[frontend][strategy] Gate Deploy button on passing rigor !minor

### DIFF
--- a/backend/tests/test_rigor_deploy_gate_contract.py
+++ b/backend/tests/test_rigor_deploy_gate_contract.py
@@ -1,0 +1,189 @@
+"""Regression: lock the API contract the UI rigor-Deploy gate depends on.
+
+LEG C made the StrategyPassport Deploy button refuse to deploy a
+rigor-failing strategy: the button is `disabled` whenever
+`passes_rigor_gate === false` on the strategy fetched from
+`GET /api/strategies/{id}`. There is no JS test runner in `ui/`
+(`ui/package.json` exposes only dev/build/lint/preview), so the
+enforceable guard for that UI behaviour is this backend invariant —
+it pins the two facts the gate reads:
+
+  1. A strategy that fails the rigor gate serializes to the API with
+     `passes_rigor_gate=False` (the exact boolean the button checks).
+  2. The candidate viewer (`GET /api/generate/jobs/{job_id}/candidates`)
+     returns exactly one `selected=True` candidate, and every rejected
+     candidate carries its own `passes_rigor` flag — so the UI can
+     render "Considered N candidates" + the per-candidate rigor verdict
+     and never silently promote a reject.
+
+Hermetic by construction: no DB, no Redis, no LLM, no network. The
+schema objects (`StrategyResponse`, `CandidatesListResponse`) are the
+literal wire shapes the two endpoints emit, plus a fixture-path
+`run_generation` round-trip that proves the live result dict matches.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.agents.generation_pipeline import run_generation
+from archimedes.api.generate_schemas import (
+    CandidatesListResponse,
+    CandidateSummary,
+    GenerateBrief,
+)
+from archimedes.api.schemas import StrategyResponse
+
+
+@pytest.fixture(autouse=True)
+def force_fixture_path(monkeypatch):
+    """No LLM / network — drive the deterministic fixture pipeline."""
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+
+class _FakeStore:
+    """In-memory JobStore stand-in (mirrors test_generation_pipeline.py)."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.status: list[tuple[str, dict | None, str]] = []
+
+    async def push_event(self, job_id, payload):
+        self.events.append(payload)
+        return len(self.events)
+
+    async def update_status(self, job_id, status, *, result=None, error=""):
+        self.status.append((status, result, error))
+
+
+# ── Invariant 1: rigor-fail serializes to the API as passes_rigor_gate=False ──
+
+
+def _minimal_response(**overrides) -> StrategyResponse:
+    base = {
+        "id": "strat_under_test",
+        "methodology_summary": "brief test strategy",
+        "asset_universe": ["SPY"],
+        "position_sizing": "equal_weight",
+        "rebalance_frequency": "weekly",
+        "status": "candidate",
+    }
+    base.update(overrides)
+    return StrategyResponse(**base)
+
+
+def test_rigor_fail_serializes_passes_rigor_gate_false():
+    """A failing-rigor strategy carries passes_rigor_gate=False on the wire.
+
+    This is the exact field the Deploy button reads
+    (`s.passes_rigor_gate === false`) to disable itself.
+    """
+    resp = _minimal_response(passes_rigor_gate=False)
+    payload = resp.model_dump()
+    assert "passes_rigor_gate" in payload
+    assert payload["passes_rigor_gate"] is False
+    # JSON mode (what the HTTP client actually receives) keeps it a bool False,
+    # never null/omitted — `=== false` in the UI must remain a real comparison.
+    assert resp.model_dump(mode="json")["passes_rigor_gate"] is False
+
+
+def test_rigor_pass_serializes_passes_rigor_gate_true():
+    """Symmetry: a passing strategy serializes True, so the gate opens."""
+    resp = _minimal_response(passes_rigor_gate=True)
+    assert resp.model_dump()["passes_rigor_gate"] is True
+
+
+def test_passes_rigor_gate_defaults_false():
+    """Absent rigor data must default to False (closed), not True (open).
+
+    Fail-closed is the claim-integrity stance: an un-evaluated strategy is
+    not deployable until it demonstrably clears the gate.
+    """
+    assert _minimal_response().model_dump()["passes_rigor_gate"] is False
+
+
+# ── Invariant 2: candidates viewer — exactly one selected + reject flags ──────
+
+
+def test_candidates_response_has_exactly_one_selected_with_reject_flags():
+    """Build the wire shape the /candidates endpoint emits and assert the
+    contract the RejectedCandidates UI + 'Considered N' counter rely on."""
+    candidates = [
+        CandidateSummary(
+            candidate_id="cand_bull",
+            strategy_id="strat_bull",
+            strategy_name="Bull Regime Strategy",
+            rigor_verdict={"passing": True, "dsr": 0.4},
+            passes_rigor=True,
+            selected=True,
+            regime="bull",
+        ),
+        CandidateSummary(
+            candidate_id="cand_bear",
+            strategy_id="strat_bear",
+            strategy_name="Bear Regime Strategy",
+            rigor_verdict={"passing": False, "dsr": -0.1},
+            passes_rigor=False,
+            selected=False,
+            regime="bear",
+        ),
+    ]
+    resp = CandidatesListResponse(
+        job_id="job_under_test",
+        best_candidate_id="cand_bull",
+        candidates=candidates,
+    )
+
+    selected = [c for c in resp.candidates if c.selected]
+    assert len(selected) == 1, "exactly one candidate may be marked selected"
+    assert resp.best_candidate_id == selected[0].candidate_id
+
+    rejects = [c for c in resp.candidates if not c.selected]
+    assert len(rejects) == len(resp.candidates) - 1
+    # Each reject exposes its own rigor verdict so the UI can render WHY it lost.
+    for r in rejects:
+        assert isinstance(r.passes_rigor, bool)
+        assert r.passes_rigor is False
+
+
+@pytest.mark.asyncio
+async def test_live_pipeline_result_matches_candidates_contract(monkeypatch):
+    """End-to-end (fixture path): the dict run_generation stashes on the job
+    is exactly the shape /candidates rebuilds — one selected, rejects flagged.
+
+    This locks the producer (pipeline) and the consumer (schema) together so a
+    future refactor can't drift one without the test catching it.
+    """
+
+    async def _fake_persist(c, _brief):  # signature mirrors _persist_candidate(c, brief)
+        return (f"strat_{c.candidate_id}", f"0x{c.candidate_id}")
+
+    monkeypatch.setattr(
+        "archimedes.agents.generation_pipeline._persist_candidate",
+        _fake_persist,
+    )
+
+    store = _FakeStore()
+    brief = GenerateBrief(intent="dual regime trend following", risk_appetite="moderate")
+    # Default dual_regime=True → bull + bear candidates persisted.
+    await run_generation(job_id="job_contract", brief=brief, store=store)
+
+    result = store.status[-1][1]
+    assert result is not None
+    cands = result["candidates"]
+    assert len(cands) == 2
+
+    # Rebuild the exact endpoint payload from the stashed result (this is what
+    # list_candidates() does) — it must validate against the wire schema.
+    resp = CandidatesListResponse(
+        job_id="job_contract",
+        best_candidate_id=result["best_candidate_id"],
+        candidates=[CandidateSummary(**c) for c in cands],
+    )
+
+    selected = [c for c in resp.candidates if c.selected]
+    assert len(selected) == 1, "pipeline must mark exactly one candidate selected"
+    assert resp.best_candidate_id == selected[0].candidate_id
+
+    # Every candidate (selected or reject) exposes a bool passes_rigor flag.
+    for c in resp.candidates:
+        assert isinstance(c.passes_rigor, bool)

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -180,20 +180,24 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
             Time-bound, non-custodial execution. Funds stay in an ERC-4626 vault
             you control; the agent has rebalance authority only, no withdraw.
             {!walletAddr && <> Connect a wallet (top right) to enable deployment.</>}
-            {s.passes_rigor_gate === false && <> This strategy did not pass the rigor gate — deploy at your own risk.</>}
+            {s.passes_rigor_gate === false && (
+              <> This strategy did not pass the rigor gate — deployment is disabled.
+              Generate a strategy that passes DSR / PBO / OOS / look-ahead to deploy.</>
+            )}
           </p>
         </div>
         <button
           className="btn btn-primary"
           onClick={() => setDeployOpen(true)}
-          disabled={!walletAddr}
+          disabled={!walletAddr || s.passes_rigor_gate === false}
           style={
-            !walletAddr
+            !walletAddr || s.passes_rigor_gate === false
               ? { opacity: 0.45, cursor: 'not-allowed', filter: 'grayscale(0.6)' }
               : undefined
           }
           title={
             !walletAddr ? 'Connect wallet to deploy' :
+            s.passes_rigor_gate === false ? 'Strategy did not pass the rigor gate — cannot deploy' :
             'Open deploy modal'
           }
         >


### PR DESCRIPTION
## Claim-integrity win: Deploy is now gated on passing rigor

The strategy passport's **Deploy** button was gated only on wallet connection. A
strategy that **failed** the rigor gate (DSR / PBO / OOS / look-ahead) could still
be deployed — which made the rigor verdict a *cosmetic* claim rather than an
*enforced* one. This was the one remaining false claim in the LEG C
society demo slice: ~90% of the pipeline was already honest (it drafts 2
candidates, backtests + rigor-gates **all** of them in the request path, picks
the best, persists all, and the UI shows "Considered N candidates" + a
`RejectedCandidates` modal + a rigor verdict tag) — but the Deploy button itself
did not honor the verdict.

This PR makes the UI honor what the backend already computes.

### Frontend — `ui/src/components/StrategyPassport.jsx`
- **Disable Deploy** when `s.passes_rigor_gate === false` (in addition to the
  existing `!walletAddr` check).
- **Grayscale/opacity disabled style** on rigor failure, mirroring the
  wallet-not-connected branch.
- **Tooltip** for the rigor-fail case: *"Strategy did not pass the rigor gate —
  cannot deploy"*.
- **Reworded the warning copy** so it matches enforcement. It previously read
  *"deploy at your own risk"* — which now contradicts a disabled button. It now
  reads: *"This strategy did not pass the rigor gate — deployment is disabled.
  Generate a strategy that passes DSR / PBO / OOS / look-ahead to deploy."*

No data plumbing was needed — `passes_rigor_gate` already arrives from
`GET /api/strategies/{id}`.

### Backend regression test — `backend/tests/test_rigor_deploy_gate_contract.py`
There is **no JS test runner** in `ui/` (`package.json` exposes only
`dev`/`build`/`lint`/`preview`), so the enforceable guard for the UI behaviour is
a hermetic pytest invariant that locks the two API facts the gate reads:

1. A rigor-failing strategy serializes to `/api/strategies/{id}` with
   `passes_rigor_gate=False` — and **defaults to `False` (fail-closed)** when
   rigor data is absent, so an un-evaluated strategy is not deployable.
2. The candidate viewer (`GET /api/generate/jobs/{job_id}/candidates`) returns
   **exactly one `selected=True`** candidate plus rejects that **each carry their
   own `passes_rigor` flag** — proven against both the wire schema
   (`CandidatesListResponse` / `CandidateSummary`) and a fixture-path
   `run_generation` round-trip, so the producer (pipeline) and consumer (schema)
   are locked together.

### What was verified
- `cd ui && npm run lint` → **0 errors** (exit 0).
- Hermetic backend run of the rigor / generation / strategy-endpoint suites +
  the new test:
  `env -i HOME=$HOME PATH=... PYTHONPATH=backend python -m pytest backend/tests/test_rigor_deploy_gate_contract.py backend/tests/services/test_generation_pipeline.py backend/tests/test_strategy_endpoints.py backend/tests/test_rigor_evaluator.py backend/tests/test_generation_gating.py backend/tests/test_rigor_regime.py -q`
  → **243 passed, 0 failed**.
- `ruff format --check` + `ruff check` clean on the new test file.

**Honest about verification scope:** I verified the API contract **by unit test**,
not against a live booted stack. The worktree has no Postgres/Redis/LLM
credentials, so a full `docker compose up` end-to-end was not run here; the
fixture-path `run_generation` round-trip exercises the real pipeline result
assembly without those services. The UI change is a pure render/disabled-state
diff over a field that already flows from the live endpoint.

### Out of scope (intentional)
The full **delete-old-paths refactor (#766)** — unifying/removing the legacy
strategy-response paths — is **not** part of this PR. This change is the minimal,
surgical fix to close the false claim: gate the button + lock the contract with a
regression test. The broader refactor remains tracked separately.

### Review routing
Frontend + backend-test change (no Solidity, no infra, no contract surface). One
approving review suffices per the team's non-contract-change policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
