### PR TITLE
[infra] T3.10: default .env.example LLM to bedrock_converse / Nova Micro

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,15 @@ REDIS_URL=redis://redis:6379/0
 # degraded loudly via /health.
 #
 # Provider-agnostic: set LLM_PROVIDER + provider-specific vars.
-# Supported: anthropic, anthropic_compatible, openai, ollama
+# Supported: bedrock_converse (PROD DEFAULT), anthropic, anthropic_compatible, bedrock, openai, ollama
+#
+#  (E) AWS Bedrock Converse — the PRODUCTION default (Amazon Nova Micro). IAM
+#      auth via the EC2 instance role (no key); ANY Bedrock provider works
+#      (Nova / Llama / Mistral / DeepSeek / GLM / Kimi / …) via LLM_BEDROCK_MODEL.
+#      Local dev needs AWS creds to invoke; without them the app degrades to
+#      canned output (loud via /health) — same as leaving every provider blank.
+#        LLM_PROVIDER=bedrock_converse
+#        LLM_BEDROCK_MODEL=amazon.nova-micro-v1:0
 #
 #  (A) Anthropic-compatible endpoint (e.g. GLM via z.ai):
 #        LLM_PROVIDER=anthropic_compatible
@@ -51,11 +59,15 @@ REDIS_URL=redis://redis:6379/0
 #        LLM_PROVIDER=ollama
 #        LLM_BASE_URL=http://localhost:11434
 #
-LLM_PROVIDER=anthropic_compatible
+# Default matches production: AWS Bedrock Converse + Amazon Nova Micro.
+LLM_PROVIDER=bedrock_converse
+LLM_BEDROCK_MODEL=amazon.nova-micro-v1:0
+# (anthropic / anthropic_compatible / openai paths use these instead — leave
+# blank on the bedrock_converse path):
 LLM_API_KEY=
 LLM_AUTH_TOKEN=
 LLM_BASE_URL=
-LLM_MODEL=claude-sonnet-4-20250514
+LLM_MODEL=
 #
 # Back-compat (deprecated — migrate to LLM_* above):
 ANTHROPIC_AUTH_TOKEN=


### PR DESCRIPTION
## Summary
`.env.example` defaulted `LLM_PROVIDER=anthropic_compatible` (GLM via z.ai) + `LLM_MODEL=claude-sonnet-4-20250514` — **stale vs prod**, which runs `bedrock_converse` + **Amazon Nova Micro** (the live `/health` provider). It also never documented the `bedrock_converse` provider at all.

- Default `LLM_PROVIDER=bedrock_converse` + `LLM_BEDROCK_MODEL=amazon.nova-micro-v1:0`.
- Document the **(E) Bedrock Converse** path (IAM via instance role; any Bedrock provider — Nova/Llama/Mistral/DeepSeek/GLM/Kimi — via `LLM_BEDROCK_MODEL`; local dev degrades to canned without AWS creds).
- Clear the stale anthropic `LLM_MODEL` default; keep the other provider vars documented.

Closes the T3.10 roadmap item. **No code change** — template only. Works with what we have today; **no Anthropic-on-Bedrock activation needed** (T3.8 deferred per Dan).

> Note: a per-request / daily Bedrock token cap (the other half of T3.10's roadmap note) is backend work — tracked as a follow-up, not in this template-only PR.