### PR TITLE
[telemetry] Conversion funnel instrument — distinct-visitor stage tracking !minor

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -306,6 +306,12 @@ async def verify_signature(request: Request, response: Response):
 
     logger.info("SIWE session issued for wallet %s", recovered_lower[:10])
 
+    # Conversion funnel (#787): the visitor connected a wallet — the trust step
+    # we most need to move. Fail-safe; never blocks the auth response.
+    from archimedes.api.funnel_middleware import record_funnel
+
+    await record_funnel(request, "wallet_connected")
+
     return {
         "status": "authenticated",
         "wallet": recovered_lower,

--- a/backend/archimedes/api/funnel_middleware.py
+++ b/backend/archimedes/api/funnel_middleware.py
@@ -1,0 +1,98 @@
+"""Funnel middleware + emit helper — anonymous visitor id for the funnel (#787).
+
+Two pieces, both fail-safe so they can never turn a request into a 5xx:
+
+1. ``ensure_visitor_id_middleware`` — guarantees every visitor carries a stable,
+   anonymous ``archimedes_vid`` cookie and exposes it as ``request.state.visitor_id``.
+   The id is a random opaque token (no PII, no wallet linkage); it exists only so
+   the funnel can join ``landed → generation_started → wallet_connected →
+   vault_deployed`` for the *same* browser and report distinct-visitor drop-off.
+   The cookie is HttpOnly: the SPA never needs to read it (it rides along on the
+   same-origin beacon POST automatically), and the server-side emit points read
+   it off ``request.state``.
+
+2. ``record_funnel(request, stage)`` — the helper the route handlers call at the
+   three server-authoritative transitions (generation start, SIWE verify, vault
+   deploy). Reads the visitor id off ``request.state`` and writes one HLL entry
+   via ``FunnelStore``. Swallows everything — instrumentation must be invisible
+   to the request it measures.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+_VID_COOKIE = "archimedes_vid"
+_VID_TTL_SECONDS = 180 * 24 * 60 * 60  # 180 days — a "returning visitor" horizon.
+
+
+def _cookie_is_secure() -> bool:
+    """Secure cookies in production (HTTPS), plain in local dev (HTTP).
+
+    Mirrors how the app distinguishes prod from local: ``PUBLIC_DOMAIN`` is set
+    only in the deployed environment. A Secure cookie would never be stored over
+    local http, which would silently disable funnel tracking in dev.
+    """
+    return bool(os.getenv("PUBLIC_DOMAIN"))
+
+
+async def ensure_visitor_id_middleware(request: Request, call_next):
+    """Attach a stable anonymous visitor id; set the cookie if it's new.
+
+    Fail-safe: any error here is swallowed so the request proceeds untouched.
+    """
+    new_vid: str | None = None
+    try:
+        vid = request.cookies.get(_VID_COOKIE)
+        if not vid:
+            vid = secrets.token_hex(16)
+            new_vid = vid
+        request.state.visitor_id = vid
+    except Exception as exc:
+        logger.debug("visitor-id middleware setup failed: %s", exc)
+
+    response: Response = await call_next(request)
+
+    if new_vid is not None:
+        try:
+            response.set_cookie(
+                key=_VID_COOKIE,
+                value=new_vid,
+                httponly=True,
+                secure=_cookie_is_secure(),
+                samesite="lax",  # same-origin SPA; lax is sufficient and works on top-level nav
+                max_age=_VID_TTL_SECONDS,
+                path="/",
+            )
+        except Exception as exc:
+            logger.debug("visitor-id cookie set failed: %s", exc)
+
+    return response
+
+
+async def record_funnel(request: Request, stage: str) -> None:
+    """Record a server-authoritative funnel transition for this request's visitor.
+
+    Reads ``request.state.visitor_id`` (set by the middleware) and writes one HLL
+    entry. Never raises — a telemetry write must not affect the user's action.
+    """
+    try:
+        visitor_id = getattr(request.state, "visitor_id", "") or ""
+        if not visitor_id:
+            return
+        from archimedes.services.funnel_store import FunnelStore
+
+        store = FunnelStore()
+        try:
+            await store.record(stage, visitor_id)
+        finally:
+            await store.close()
+    except Exception as exc:
+        logger.debug("record_funnel failed for stage %s: %s", stage, exc)

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -24,6 +24,7 @@ from fastapi.responses import StreamingResponse
 
 from archimedes.agents.generation_pipeline import run_generation
 from archimedes.api.auth_siwe import gate_generation, get_verified_wallet
+from archimedes.api.funnel_middleware import record_funnel
 from archimedes.api.generate_schemas import (
     CandidatesListResponse,
     CandidateSummary,
@@ -62,7 +63,7 @@ def _register_task(job_id: str, task: asyncio.Task) -> None:
 @limiter.limit("5/minute")
 async def start_generation(
     req: GenerateStartRequest,
-    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    request: Request,  # used for slowapi rate-limit keying AND funnel attribution (#787)
     response: Response,  # noqa: ARG001
     _wallet: str | None = Depends(gate_generation),  # 401 when REQUIRE_SIWE_FOR_GENERATION is on
 ) -> GenerateStartResponse:
@@ -109,6 +110,10 @@ async def start_generation(
     # below tails the event log written by the pipeline as it runs.
     task = asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates, req.mode, selected_model))
     _register_task(job_id, task)
+
+    # Conversion funnel (#787): a generation actually started for this visitor —
+    # the key "tried the product" transition. Fail-safe; never blocks the response.
+    await record_funnel(request, "generation_started")
 
     return GenerateStartResponse(
         job_id=job_id,

--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -14,12 +14,45 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query, Request
 
-from archimedes.models.telemetry import MetricsResponse
+from archimedes.api.funnel_middleware import record_funnel
+from archimedes.models.telemetry import (
+    FunnelEventRequest,
+    FunnelResponse,
+    FunnelStageCount,
+    MetricsResponse,
+)
+from archimedes.services.funnel_store import CLIENT_EMITTABLE_STAGES, STAGES, FunnelStore
 from archimedes.services.telemetry_store import TelemetryStore
 
 metrics_router = APIRouter(prefix="/api", tags=["metrics"])
+
+
+def _build_funnel(counts: dict[str, int], window: str) -> FunnelResponse:
+    """Turn an ordered stage->count map into a funnel with ratios.
+
+    ``pct_of_landed`` is each stage vs the first stage; ``step_conversion`` is
+    each stage vs the previous one. Both default to 0.0 when the denominator is
+    zero so the response is always well-formed (no divide-by-zero).
+    """
+    landed = counts.get(STAGES[0], 0)
+    stages: list[FunnelStageCount] = []
+    prev = landed
+    for i, stage in enumerate(STAGES):
+        n = counts.get(stage, 0)
+        pct = (n / landed) if landed else 0.0
+        step = 1.0 if i == 0 else ((n / prev) if prev else 0.0)
+        stages.append(
+            FunnelStageCount(
+                stage=stage,
+                distinct_visitors=n,
+                pct_of_landed=round(pct, 4),
+                step_conversion=round(step, 4),
+            )
+        )
+        prev = n
+    return FunnelResponse(window=window, stages=stages, timestamp=datetime.now(UTC).isoformat())
 
 
 @metrics_router.get("/metrics", response_model=MetricsResponse)
@@ -41,3 +74,44 @@ async def get_metrics() -> MetricsResponse:
         total_requests=human_count + agent_count,
         timestamp=datetime.now(UTC).isoformat(),
     )
+
+
+@metrics_router.get("/metrics/funnel", response_model=FunnelResponse)
+async def get_funnel(
+    day: str | None = Query(
+        default=None,
+        description="ISO date (YYYY-MM-DD) for a single-day window; omit for the all-time funnel.",
+    ),
+) -> FunnelResponse:
+    """Return the distinct-visitor conversion funnel (issue #787).
+
+    Stages: ``landed -> generation_started -> wallet_connected -> vault_deployed``.
+    Fail-safe: ``FunnelStore`` returns zeros when Redis is unreachable, so this
+    endpoint always responds 200 with a well-formed funnel.
+    """
+    store = FunnelStore()
+    try:
+        if day:
+            counts = await store.get_day(day)
+            window = day
+        else:
+            counts = await store.get_totals()
+            window = "all-time"
+    finally:
+        await store.close()
+    return _build_funnel(counts, window)
+
+
+@metrics_router.post("/metrics/funnel/event")
+async def record_funnel_event(req: FunnelEventRequest, request: Request) -> dict[str, bool]:
+    """Client beacon for top-of-funnel stages (issue #787).
+
+    Only ``CLIENT_EMITTABLE_STAGES`` (today: ``landed``) are accepted — every
+    downstream stage is recorded server-side at its authoritative transition so a
+    client cannot inflate it. Always 200 (``recorded`` flags whether it counted);
+    the visitor id is read from the ``archimedes_vid`` cookie via request state.
+    """
+    if req.stage not in CLIENT_EMITTABLE_STAGES:
+        return {"recorded": False}
+    await record_funnel(request, req.stage)
+    return {"recorded": True}

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -81,7 +81,7 @@ async def list_vaults(
 @limiter.limit("5/minute")
 async def create_vault(
     req: VaultCreateRequest,
-    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    request: Request,  # used for slowapi rate-limit keying AND funnel attribution (#787)
     response: Response,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     wallet: str = Depends(require_verified_wallet),
 ):
@@ -115,6 +115,12 @@ async def create_vault(
         # log the full detail server-side and return a generic message.
         logger.exception("Vault deployment failed")
         raise HTTPException(status_code=500, detail="Vault deployment failed") from exc
+
+    # Conversion funnel (#787): the bottom of funnel — a vault was actually
+    # deployed for this visitor. Fail-safe; never blocks the response.
+    from archimedes.api.funnel_middleware import record_funnel
+
+    await record_funnel(request, "vault_deployed")
 
     return VaultCreateResponse(vault_address=vault_address, strategy_ids=req.strategy_ids)
 

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -158,6 +158,18 @@ from archimedes.api.telemetry_middleware import telemetry_middleware
 app.middleware("http")(telemetry_middleware)
 
 
+# ── Visitor-id middleware: anonymous funnel attribution (issue #787) ────
+# Registered LAST so it is the OUTERMOST middleware: it guarantees every request
+# carries a stable anonymous `archimedes_vid` cookie and exposes it as
+# request.state.visitor_id BEFORE any route or downstream middleware runs. This
+# is what lets the conversion funnel (landed → generation_started →
+# wallet_connected → vault_deployed) join stages for the same visitor. Fail-safe
+# — never turns a request into a 5xx.
+from archimedes.api.funnel_middleware import ensure_visitor_id_middleware
+
+app.middleware("http")(ensure_visitor_id_middleware)
+
+
 # Initialize database (creates chat tables if needed)
 init_db()
 

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -32,3 +32,41 @@ class MetricsResponse(BaseModel):
     agent_count: int = Field(..., description="Requests classified as agent (internal key / bot UA).")
     total_requests: int = Field(..., description="human_count + agent_count.")
     timestamp: str = Field(..., description="ISO-8601 UTC timestamp this snapshot was read.")
+
+
+class FunnelStageCount(BaseModel):
+    """One stage of the conversion funnel (issue #787).
+
+    ``distinct_visitors`` is an HLL estimate of unique visitors that reached this
+    stage. ``pct_of_landed`` is this stage vs the top of funnel; ``step_conversion``
+    is this stage vs the immediately preceding stage — the drop-off we care about.
+    """
+
+    stage: str = Field(..., description="Funnel stage name.")
+    distinct_visitors: int = Field(..., description="Distinct visitors that reached this stage (HLL estimate).")
+    pct_of_landed: float = Field(..., description="distinct_visitors / landed, as a fraction (0.0-1.0).")
+    step_conversion: float = Field(..., description="distinct_visitors / previous-stage count (0.0-1.0).")
+
+
+class FunnelResponse(BaseModel):
+    """Distinct-visitor conversion funnel over the live deployment (issue #787).
+
+    Served by ``GET /api/metrics/funnel``. Stages are ordered
+    ``landed -> generation_started -> wallet_connected -> vault_deployed``.
+    """
+
+    window: str = Field(..., description='"all-time" or the ISO date (YYYY-MM-DD) the counts are for.')
+    stages: list[FunnelStageCount] = Field(..., description="Ordered funnel stages with counts + ratios.")
+    timestamp: str = Field(..., description="ISO-8601 UTC timestamp this snapshot was read.")
+
+
+class FunnelEventRequest(BaseModel):
+    """Client beacon body for ``POST /api/metrics/funnel/event`` (issue #787).
+
+    Only top-of-funnel stages are client-emittable (see
+    ``services.funnel_store.CLIENT_EMITTABLE_STAGES``); every downstream stage is
+    recorded server-side at its authoritative transition so a client can't
+    inflate it.
+    """
+
+    stage: str = Field(..., description="The funnel stage the browser is reporting (e.g. 'landed').")

--- a/backend/archimedes/services/funnel_store.py
+++ b/backend/archimedes/services/funnel_store.py
@@ -1,0 +1,134 @@
+"""Funnel store — distinct-visitor conversion-funnel counters in Redis (#787).
+
+Backs the conversion-funnel instrument. We have a zero-conversion problem
+(~40k requests → 2 wallets → 2 vaults) and, until now, no way to see *where*
+visitors drop. This records the distinct visitors that reach each stage of the
+journey:
+
+    landed → generation_started → wallet_connected → vault_deployed
+
+using Redis HyperLogLog (``PFADD`` / ``PFCOUNT``) so the counts are *distinct
+visitors* without retaining any raw identifier — privacy-friendly (no tracking
+dossier) and O(1) memory per stage.
+
+The funnel is naturally human-weighted, unlike the raw human/agent counters in
+``telemetry_store.py``: ``landed`` is emitted by the SPA's JS (crawlers don't
+run JS) and the downstream stages are real product actions, so the bot floor
+that dominates the raw request counts largely drops out here.
+
+Design mirrors ``services/telemetry_store.py`` deliberately:
+  - same ``redis.asyncio.from_url`` + ``REDIS_URL`` convention,
+  - **fail-safe by construction** — every method swallows Redis errors and logs
+    at ``debug``; a Redis outage must never turn a request into a 5xx. The write
+    path returns silently; the read path returns zeros.
+
+Two keyspaces per stage:
+  - ``archimedes:funnel:total:<stage>`` — all-time distinct visitors (no TTL).
+  - ``archimedes:funnel:day:<YYYY-MM-DD>:<stage>`` — per-day distinct visitors,
+    with a TTL so old day-buckets self-expire (no unbounded growth).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+import redis.asyncio as aioredis
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+_PREFIX = "archimedes:funnel"
+
+# Ordered funnel stages. Order is load-bearing: ratios are computed against the
+# first stage (``landed``) and against the immediately preceding stage.
+STAGES: tuple[str, ...] = (
+    "landed",
+    "generation_started",
+    "wallet_connected",
+    "vault_deployed",
+)
+
+# Stages a browser client is allowed to self-report via the beacon endpoint.
+# Only the top of funnel is client-emittable; every downstream stage is recorded
+# server-side at the authoritative transition so a client can't inflate them.
+CLIENT_EMITTABLE_STAGES: frozenset[str] = frozenset({"landed"})
+
+# Per-day buckets self-expire after this window (90 days of trend history).
+_DAY_TTL_SECONDS = 90 * 24 * 60 * 60
+
+
+def _today() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+class FunnelStore:
+    """Thin, fail-safe Redis wrapper for the conversion-funnel HLL counters."""
+
+    def __init__(self, url: str | None = None) -> None:
+        self._url = url or REDIS_URL
+        self._redis: aioredis.Redis | None = None
+
+    async def _get_redis(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = aioredis.from_url(self._url, decode_responses=True)
+        return self._redis
+
+    # ─── Record (write path — server-side emit + client beacon) ──────────
+
+    async def record(self, stage: str, visitor_id: str) -> None:
+        """Record that ``visitor_id`` reached ``stage``. Never raises.
+
+        No-ops on an unknown stage or an empty visitor id (defensive — a missing
+        id must not create a bogus distinct count).
+        """
+        if stage not in STAGES or not visitor_id:
+            return
+        try:
+            r = await self._get_redis()
+            day_key = f"{_PREFIX}:day:{_today()}:{stage}"
+            pipe = r.pipeline()
+            pipe.pfadd(f"{_PREFIX}:total:{stage}", visitor_id)
+            pipe.pfadd(day_key, visitor_id)
+            pipe.expire(day_key, _DAY_TTL_SECONDS)
+            await pipe.execute()
+        except Exception as exc:
+            # Fail-safe: a Redis outage must never break the request it measures.
+            logger.debug("funnel record failed for stage %s: %s", stage, exc)
+
+    # ─── Read (exposure path — GET /api/metrics/funnel) ──────────────────
+
+    async def get_totals(self) -> dict[str, int]:
+        """All-time distinct visitors per stage. Returns zeros on error."""
+        return await self._counts(f"{_PREFIX}:total:{{stage}}")
+
+    async def get_day(self, date_str: str | None = None) -> dict[str, int]:
+        """Per-day distinct visitors per stage (defaults to today). Zeros on error."""
+        day = date_str or _today()
+        return await self._counts(f"{_PREFIX}:day:{day}:{{stage}}")
+
+    async def _counts(self, key_template: str) -> dict[str, int]:
+        counts = dict.fromkeys(STAGES, 0)
+        try:
+            r = await self._get_redis()
+            pipe = r.pipeline()
+            for stage in STAGES:
+                pipe.pfcount(key_template.format(stage=stage))
+            results = await pipe.execute()
+            for stage, count in zip(STAGES, results, strict=False):
+                counts[stage] = int(count or 0)
+        except Exception as exc:
+            logger.debug("funnel read failed: %s", exc)
+        return counts
+
+    # ─── Lifecycle ───────────────────────────────────────────────────────
+
+    async def close(self) -> None:
+        if self._redis:
+            try:
+                await self._redis.aclose()
+            except Exception as exc:
+                logger.debug("funnel store close failed: %s", exc)
+            self._redis = None

--- a/backend/tests/test_funnel_store.py
+++ b/backend/tests/test_funnel_store.py
@@ -1,0 +1,259 @@
+"""Tests for the conversion-funnel instrument (issue #787).
+
+Hermetic — mocks at the Redis boundary (the project standard; no live Redis).
+Covers: FunnelStore record/read + fail-safe, the ratio math in
+``metrics_routes._build_funnel``, the ``record_funnel`` emit helper, the beacon
+stage allowlist, and the visitor-id middleware.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from archimedes.api import metrics_routes
+from archimedes.api.funnel_middleware import ensure_visitor_id_middleware, record_funnel
+from archimedes.api.metrics_routes import _build_funnel
+from archimedes.models.telemetry import FunnelEventRequest
+from archimedes.services.funnel_store import STAGES, FunnelStore
+
+
+def _mock_redis_with_pipeline(execute_return):
+    """A mock redis whose .pipeline() queues sync commands and awaits execute()."""
+    pipe = MagicMock()
+    pipe.pfadd = MagicMock(return_value=pipe)
+    pipe.pfcount = MagicMock(return_value=pipe)
+    pipe.expire = MagicMock(return_value=pipe)
+    pipe.execute = AsyncMock(return_value=execute_return)
+    redis = MagicMock()
+    redis.pipeline = MagicMock(return_value=pipe)
+    return redis, pipe
+
+
+# ─── FunnelStore.record ──────────────────────────────────────────────────
+
+
+async def test_record_pfadds_total_and_day_with_ttl():
+    store = FunnelStore()
+    redis, pipe = _mock_redis_with_pipeline([1, 1, True])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    await store.record("landed", "vid-abc")
+
+    assert pipe.pfadd.call_count == 2  # total + day
+    assert pipe.expire.call_count == 1  # TTL on the day bucket only
+    total_key = pipe.pfadd.call_args_list[0].args[0]
+    day_key = pipe.pfadd.call_args_list[1].args[0]
+    assert total_key == "archimedes:funnel:total:landed"
+    assert day_key.startswith("archimedes:funnel:day:")
+    assert day_key.endswith(":landed")
+    pipe.execute.assert_awaited_once()
+
+
+async def test_record_noops_on_unknown_stage():
+    store = FunnelStore()
+    redis, _ = _mock_redis_with_pipeline([])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    await store.record("not-a-real-stage", "vid")
+
+    redis.pipeline.assert_not_called()
+
+
+async def test_record_noops_on_empty_visitor():
+    store = FunnelStore()
+    redis, _ = _mock_redis_with_pipeline([])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    await store.record("landed", "")
+
+    redis.pipeline.assert_not_called()
+
+
+async def test_record_failsafe_on_redis_error():
+    store = FunnelStore()
+    store._get_redis = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    # Must not raise — telemetry can never break the request it measures.
+    await store.record("landed", "vid")
+
+
+# ─── FunnelStore reads ───────────────────────────────────────────────────
+
+
+async def test_get_totals_reads_pfcount_in_stage_order():
+    store = FunnelStore()
+    redis, pipe = _mock_redis_with_pipeline([10, 4, 2, 1])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    counts = await store.get_totals()
+
+    assert counts == {
+        "landed": 10,
+        "generation_started": 4,
+        "wallet_connected": 2,
+        "vault_deployed": 1,
+    }
+    assert pipe.pfcount.call_count == len(STAGES)
+
+
+async def test_get_day_uses_day_keyspace():
+    store = FunnelStore()
+    redis, pipe = _mock_redis_with_pipeline([3, 1, 0, 0])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    counts = await store.get_day("2026-06-28")
+
+    assert counts["landed"] == 3
+    first_key = pipe.pfcount.call_args_list[0].args[0]
+    assert first_key == "archimedes:funnel:day:2026-06-28:landed"
+
+
+async def test_get_totals_failsafe_returns_zeros():
+    store = FunnelStore()
+    store._get_redis = AsyncMock(side_effect=ConnectionError("down"))
+
+    counts = await store.get_totals()
+
+    assert counts == dict.fromkeys(STAGES, 0)
+
+
+# ─── Ratio math (_build_funnel) ──────────────────────────────────────────
+
+
+def test_build_funnel_ratios():
+    counts = {"landed": 100, "generation_started": 25, "wallet_connected": 5, "vault_deployed": 2}
+    resp = _build_funnel(counts, "all-time")
+    by = {s.stage: s for s in resp.stages}
+
+    assert resp.window == "all-time"
+    assert by["landed"].pct_of_landed == 1.0
+    assert by["landed"].step_conversion == 1.0
+    assert by["generation_started"].pct_of_landed == 0.25
+    assert by["generation_started"].step_conversion == 0.25
+    assert by["wallet_connected"].step_conversion == 0.2  # 5 / 25
+    assert by["vault_deployed"].pct_of_landed == 0.02
+
+
+def test_build_funnel_zero_landed_no_divzero():
+    counts = dict.fromkeys(STAGES, 0)
+    resp = _build_funnel(counts, "all-time")
+
+    for s in resp.stages:
+        assert s.pct_of_landed == 0.0
+    # The top of funnel is defined as 1.0 step-conversion (nothing precedes it).
+    assert resp.stages[0].step_conversion == 1.0
+    # A zero previous stage yields 0.0, never a ZeroDivisionError.
+    assert resp.stages[1].step_conversion == 0.0
+
+
+# ─── record_funnel emit helper ───────────────────────────────────────────
+
+
+async def test_record_funnel_uses_request_visitor_id(monkeypatch):
+    recorded = {}
+
+    class FakeStore:
+        async def record(self, stage, vid):
+            recorded["call"] = (stage, vid)
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.funnel_store.FunnelStore", FakeStore)
+    req = SimpleNamespace(state=SimpleNamespace(visitor_id="vid-xyz"))
+
+    await record_funnel(req, "generation_started")
+
+    assert recorded["call"] == ("generation_started", "vid-xyz")
+
+
+async def test_record_funnel_noop_without_visitor_id(monkeypatch):
+    called = {"n": 0}
+
+    class FakeStore:
+        async def record(self, *a):
+            called["n"] += 1
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.funnel_store.FunnelStore", FakeStore)
+    req = SimpleNamespace(state=SimpleNamespace())  # no visitor_id attribute
+
+    await record_funnel(req, "landed")
+
+    assert called["n"] == 0
+
+
+# ─── Beacon stage allowlist ──────────────────────────────────────────────
+
+
+async def test_funnel_event_rejects_non_landed_stage(monkeypatch):
+    calls = []
+
+    async def fake_record(request, stage):
+        calls.append(stage)
+
+    monkeypatch.setattr(metrics_routes, "record_funnel", fake_record)
+    req = SimpleNamespace(state=SimpleNamespace(visitor_id="v"))
+
+    out = await metrics_routes.record_funnel_event(FunnelEventRequest(stage="vault_deployed"), req)
+
+    assert out == {"recorded": False}
+    assert calls == []  # a client can NEVER record a server-authoritative stage
+
+
+async def test_funnel_event_accepts_landed(monkeypatch):
+    calls = []
+
+    async def fake_record(request, stage):
+        calls.append(stage)
+
+    monkeypatch.setattr(metrics_routes, "record_funnel", fake_record)
+    req = SimpleNamespace(state=SimpleNamespace(visitor_id="v"))
+
+    out = await metrics_routes.record_funnel_event(FunnelEventRequest(stage="landed"), req)
+
+    assert out == {"recorded": True}
+    assert calls == ["landed"]
+
+
+# ─── Visitor-id middleware ───────────────────────────────────────────────
+
+
+async def test_visitor_id_middleware_sets_state_and_cookie():
+    req = SimpleNamespace(cookies={}, state=SimpleNamespace())
+    set_cookies = {}
+
+    class FakeResp:
+        def set_cookie(self, **kw):
+            set_cookies.update(kw)
+
+    async def call_next(r):
+        # The id must be on request.state BEFORE the route runs.
+        assert getattr(r.state, "visitor_id", None)
+        return FakeResp()
+
+    await ensure_visitor_id_middleware(req, call_next)
+
+    assert set_cookies["key"] == "archimedes_vid"
+    assert set_cookies["httponly"] is True
+    assert len(set_cookies["value"]) >= 16
+
+
+async def test_visitor_id_middleware_reuses_existing_cookie():
+    req = SimpleNamespace(cookies={"archimedes_vid": "existing-vid"}, state=SimpleNamespace())
+    set_cookies = {}
+
+    class FakeResp:
+        def set_cookie(self, **kw):
+            set_cookies.update(kw)
+
+    async def call_next(r):
+        assert r.state.visitor_id == "existing-vid"
+        return FakeResp()
+
+    await ensure_visitor_id_middleware(req, call_next)
+
+    assert set_cookies == {}  # no new cookie when one already exists

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -18,6 +18,7 @@ import VaultDetail from './components/VaultDetail'
 import OnboardingTour, { hasCompletedOnboarding } from './components/OnboardingTour'
 import WalletGate from './components/WalletGate'
 import MobileBanner from './components/MobileBanner'
+import { apiPost } from './api'
 import './App.css'
 
 const openConnectModal = () => window.dispatchEvent(new Event('open-wallet-modal'))
@@ -114,6 +115,21 @@ export default function App() {
     const handler = (e) => setWalletAddr(e.detail.address)
     window.addEventListener('wallet-changed', handler)
     return () => window.removeEventListener('wallet-changed', handler)
+  }, [])
+
+  // Conversion funnel (#787): emit the top-of-funnel "landed" beacon once per
+  // browser session. This is JS-only, so crawlers (which dominate raw request
+  // counts but don't run JS) are naturally excluded — the funnel is a truer
+  // human signal than the cumulative request counters. Best-effort: a failed
+  // beacon must never affect the page.
+  useEffect(() => {
+    try {
+      if (sessionStorage.getItem('archimedes_landed')) return
+      sessionStorage.setItem('archimedes_landed', '1')
+    } catch {
+      // sessionStorage unavailable (private mode / blocked) — still try once.
+    }
+    apiPost('/api/metrics/funnel/event', { stage: 'landed' }).catch(() => {})
   }, [])
 
   const handleConnect = (addr) => setWalletAddr(addr)


### PR DESCRIPTION
## What & why

We have a **zero-conversion problem** — pulled from prod this session: ~40k cumulative requests → **2 wallets → 2 vaults → 0 chats → 0 live generations**. The product has essentially never been used by a real external human, and we had **no way to see where visitors drop**. Fixing native-traffic conversion *before* any public promotion is the cheapest, highest-leverage win available (and positions us far better for launch).

This PR is **lever 1 of #787 — instrument the funnel.** It adds a distinct-visitor conversion funnel over the real journey transitions:

```
landed → generation_started → wallet_connected → vault_deployed
```

## How

- **`services/funnel_store.py`** — `FunnelStore`: Redis **HyperLogLog** (`PFADD`/`PFCOUNT`) for **distinct-visitor** counts without retaining any raw identifier (privacy-friendly, O(1) memory/stage). All-time + per-day buckets (day buckets self-expire after 90d). **Fail-safe by construction** — mirrors `TelemetryStore` exactly (swallows Redis errors, reads return zeros).
- **`api/funnel_middleware.py`** — an anonymous `archimedes_vid` cookie (HttpOnly, no PII, no wallet linkage) + `request.state.visitor_id`, and a `record_funnel()` emit helper. Both fail-safe.
- **Server-authoritative emits** at the 3 real transitions: `start_generation`, SIWE `POST /api/auth/verify`, `create_vault`. `landed` is a **JS beacon** (`POST /api/metrics/funnel/event`) — so crawlers (which don't run JS and dominate the raw request counts) are **naturally excluded**, giving a *truer human funnel* than the raw UA counters.
- **`GET /api/metrics/funnel`** — stage counts + `pct_of_landed` + `step_conversion` ratios (the drop-off we care about). Optional `?day=YYYY-MM-DD`. The client beacon is **allowlisted to top-of-funnel only** — downstream stages can't be client-inflated.
- **`ui/src/App.jsx`** — emits `landed` once per browser session.

## Verification

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_funnel_store.py -q   # 15 passed
```
- 15 hermetic tests (mock at the Redis boundary) covering record/read/fail-safe, ratio math (incl. divide-by-zero), the emit helper, the beacon allowlist, and the visitor-id middleware.
- `ruff format --check` + `ruff check` clean on all changed files; `eslint src/App.jsx` clean.
- Regression: existing `test_metrics_routes` / `test_telemetry_classifier` / `test_generation_gating` (39 passed) + app-boot `test_api_routes` (28 passed, exercises the new middleware on every request).

After deploy:
```
curl -s https://archimedes-arc.com/api/metrics/funnel | jq
```

## Scope / anti-goals (per #787)

- **No PII / no tracking dossier** — HLL stores only what distinct-count needs; the vid is an opaque random token with no wallet linkage.
- **Instrumentation can never 5xx a request** — every funnel write is fail-safe.
- **Generate stays open** (`REQUIRE_SIWE_FOR_GENERATION` off) — value-before-wallet is the strategy; we do NOT gate Generate to force conversion.
- **No contracts touched.**

## Follow-ups (tracked in #787)

Lever 2 (value-before-wallet hero CTA), lever 3 (passkey-default + testnet-USDC faucet), lever 5 (no-wallet demo mode), plus the retrospective **ALB-log analysis** (S3 `archimedes-alb-logs`). The agent-user lever is #788.

Closes part of #787 (lever 1).
