### PR TITLE
[security] Strict per-IP daily cap on wallet-less generations (anti-abuse)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,17 @@ INTERNAL_AGENT_API_KEY=
 # closing the IP-rotation budget-drain vector (audit 2026-06-13).
 REQUIRE_SIWE_FOR_GENERATION=false
 
+# Strict per-IP DAILY cap on WALLET-LESS generations (anti-abuse). The Generate
+# path is open by default (REQUIRE_SIWE_FOR_GENERATION=false) so visitors —
+# humans and agents — can try it before connecting a wallet, but an open
+# LLM-spending endpoint is a flood risk. A wallet-less caller gets this many free
+# generations per UTC day (keyed on the real client IP); past it they get a 429
+# steering them to connect a wallet (so the cap doubles as a conversion prompt).
+# Authenticated (SIWE-wallet) callers bypass the cap entirely. Sits on top of the
+# slowapi (5/min) + nginx per-IP rate limits, which bound the burst RATE; this
+# bounds the wallet-less daily VOLUME. Set to 0 to disable (unlimited).
+WALLET_LESS_GENERATION_DAILY_CAP=5
+
 # How often the oracle runner pushes prices (seconds, default 60).
 ORACLE_INTERVAL_SECONDS=60
 

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -35,6 +36,7 @@ from archimedes.api.generate_schemas import (
     JobSummary,
 )
 from archimedes.api.limiter import limiter
+from archimedes.services.generation_quota import enforce_generation_quota
 from archimedes.services.job_queue import EVENT_LOG_TTL, get_job_store
 from archimedes.services.llm_backend import is_allowed_model
 from archimedes.services.log_scrubber import sanitize_log_value
@@ -68,6 +70,17 @@ async def start_generation(
     _wallet: str | None = Depends(gate_generation),  # 401 when REQUIRE_SIWE_FOR_GENERATION is on
 ) -> GenerateStartResponse:
     """Create a generation job and start the pipeline in the background."""
+    # Anti-abuse (Dan, 2026-06-28): a STRICT per-IP daily cap on WALLET-LESS
+    # generations. The Generate path is open (value-before-wallet, #787), but an
+    # open LLM-spending endpoint is a flood risk — an agent in a loop could burn
+    # budget. Authenticated (SIWE) callers bypass it entirely; a wallet-less caller
+    # gets a small free daily allowance, then a 429 steering them to connect a
+    # wallet (so the cap doubles as a conversion prompt). Enforced BEFORE any work
+    # so a capped request burns nothing. Disabled under TESTING (conftest sets it),
+    # matching the slowapi limiter; the quota logic is unit-tested directly.
+    if not os.getenv("TESTING"):
+        await enforce_generation_quota(request, _wallet)
+
     # Paid-tier gating (T1.8): a premium (Anthropic) model requires a
     # wallet-connected entitlement. Enforced BEFORE the job is enqueued so a
     # non-entitled premium request is rejected (HTTP 402) without burning any

--- a/backend/archimedes/services/generation_quota.py
+++ b/backend/archimedes/services/generation_quota.py
@@ -1,0 +1,156 @@
+"""Wallet-less generation quota — a strict per-IP daily cap (anti-abuse).
+
+The Generate path is intentionally **open** (`REQUIRE_SIWE_FOR_GENERATION` off) so
+visitors — humans *and* agents — can try the product before connecting a wallet
+(value-before-wallet, #787). But an open LLM-spending endpoint is a flood/abuse
+risk: an agent in a loop could hammer `/api/generate/start` and burn LLM budget.
+
+This module caps **wallet-less** generations to a small daily allowance per client
+IP. Authenticated (SIWE-wallet) callers bypass the cap entirely. When the cap is
+hit we return HTTP 429 with a steering payload — so the cap doubles as a
+**conversion prompt** ("connect a wallet to keep generating") rather than a dead
+end.
+
+Defense in depth: this sits *on top of* the existing slowapi per-route limit
+(`5/minute`) and the nginx `limit_req_zone` per-IP limits — those bound the burst
+*rate*; this bounds the wallet-less *daily volume*.
+
+Rigor + keying:
+  - Keyed on the **real client IP**, read from the `X-Real-IP` header that nginx
+    sets from its `real_ip`-resolved `$remote_addr`. nginx overwrites any
+    client-supplied value and binds `real_ip_header` to the trusted ALB CIDR, so
+    this header is not client-spoofable. (Uvicorn runs without `--proxy-headers`,
+    so `request.client.host` is nginx, not the client — hence we read the header.)
+  - IP-keyed on purpose: an agent that drops the anonymous `archimedes_vid` cookie
+    would defeat a cookie-keyed cap. A sophisticated IP-rotating abuser is out of
+    scope for this MVP cap (the slowapi + nginx limits remain the rate backstop).
+
+Fail-open: a Redis error returns "allowed" (logged at WARNING). Blocking every
+wallet-less generation during a Redis blip would be worse than the narrow abuse
+window, and the slowapi/nginx rate limits remain in force regardless. Set
+`WALLET_LESS_GENERATION_DAILY_CAP=0` to disable the cap (unlimited).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+import redis.asyncio as aioredis
+from fastapi import HTTPException
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+_DEFAULT_DAILY_CAP = 5
+# Day-bucket TTL: a bit over 24h to cover the UTC-day boundary + clock skew, so
+# each key self-expires and the allowance resets daily without a sweep.
+_QUOTA_TTL_SECONDS = 36 * 60 * 60
+
+
+def daily_cap() -> int:
+    """The wallet-less daily generation cap. ``<= 0`` disables the cap."""
+    raw = os.getenv("WALLET_LESS_GENERATION_DAILY_CAP", str(_DEFAULT_DAILY_CAP))
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("invalid WALLET_LESS_GENERATION_DAILY_CAP=%r; using default %d", raw, _DEFAULT_DAILY_CAP)
+        return _DEFAULT_DAILY_CAP
+
+
+def client_ip(request: Request) -> str:
+    """Resolve the real client IP behind nginx/ALB.
+
+    Prefers ``X-Real-IP`` (nginx-set, not client-spoofable), then the first hop of
+    ``X-Forwarded-For``, then the socket peer. Returns ``"unknown"`` if nothing is
+    available (a single shared bucket — still capped, just coarser).
+    """
+    xri = request.headers.get("x-real-ip")
+    if xri and xri.strip():
+        return xri.strip()
+    xff = request.headers.get("x-forwarded-for")
+    if xff and xff.strip():
+        return xff.split(",")[0].strip()
+    client = request.client
+    return client.host if client and client.host else "unknown"
+
+
+class GenerationQuota:
+    """Fail-safe Redis wrapper for the per-IP daily wallet-less generation cap."""
+
+    def __init__(self, url: str | None = None) -> None:
+        self._url = url or REDIS_URL
+        self._redis: aioredis.Redis | None = None
+
+    async def _get_redis(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = aioredis.from_url(self._url, decode_responses=True)
+        return self._redis
+
+    async def check_and_increment(self, ip: str, cap: int) -> tuple[bool, int]:
+        """Atomically count this wallet-less generation for ``ip`` today.
+
+        Returns ``(allowed, used)`` where ``used`` is the count *after* this
+        attempt. ``allowed`` is ``used <= cap``. **Fails open** — on any Redis
+        error returns ``(True, 0)`` so a cache outage never blocks generation
+        (the slowapi/nginx rate limits remain the backstop).
+        """
+        try:
+            r = await self._get_redis()
+            day = datetime.now(UTC).strftime("%Y-%m-%d")
+            key = f"archimedes:genquota:{day}:{ip}"
+            count = await r.incr(key)
+            if count == 1:
+                # First use today — stamp the TTL so the bucket self-expires.
+                await r.expire(key, _QUOTA_TTL_SECONDS)
+            return (count <= cap, int(count))
+        except Exception as exc:
+            logger.warning("generation quota check failed for ip=%s — FAILING OPEN: %s", ip, exc)
+            return (True, 0)
+
+    async def close(self) -> None:
+        if self._redis:
+            try:
+                await self._redis.aclose()
+            except Exception as exc:
+                logger.debug("generation quota close failed: %s", exc)
+            self._redis = None
+
+
+async def enforce_generation_quota(request: Request, wallet: str | None) -> None:
+    """Enforce the wallet-less daily generation cap. Raises HTTP 429 when exceeded.
+
+    - Authenticated (``wallet`` truthy) callers bypass the cap.
+    - A cap of ``<= 0`` disables enforcement (unlimited).
+    - On the cap being hit, raises 429 with a structured, UI-friendly payload so
+      the frontend can turn the limit into a connect-wallet prompt.
+    """
+    if wallet:
+        return
+    cap = daily_cap()
+    if cap <= 0:
+        return
+
+    ip = client_ip(request)
+    quota = GenerationQuota()
+    try:
+        allowed, used = await quota.check_and_increment(ip, cap)
+    finally:
+        await quota.close()
+
+    if not allowed:
+        logger.info("wallet-less generation cap hit ip=%s used=%d cap=%d", ip, used, cap)
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "message": (
+                    f"You've reached the free generation limit ({cap}/day). "
+                    "Connect a wallet to keep generating — it's free and takes a few seconds."
+                ),
+                "reason": "wallet_less_generation_cap",
+                "cap": cap,
+            },
+        )

--- a/backend/archimedes/services/generation_quota.py
+++ b/backend/archimedes/services/generation_quota.py
@@ -33,6 +33,7 @@ window, and the slowapi/nginx rate limits remain in force regardless. Set
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
 from datetime import UTC, datetime
@@ -61,21 +62,39 @@ def daily_cap() -> int:
         return _DEFAULT_DAILY_CAP
 
 
-def client_ip(request: Request) -> str:
-    """Resolve the real client IP behind nginx/ALB.
+def _valid_ip(value: str) -> bool:
+    """True iff ``value`` parses as an IPv4/IPv6 address."""
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
 
-    Prefers ``X-Real-IP`` (nginx-set, not client-spoofable), then the first hop of
-    ``X-Forwarded-For``, then the socket peer. Returns ``"unknown"`` if nothing is
-    available (a single shared bucket — still capped, just coarser).
+
+def client_ip(request: Request) -> str:
+    """Resolve the real client IP behind nginx/ALB for the per-IP cap key.
+
+    Uses ONLY trustworthy sources — a spoofed value must not let a caller rotate
+    the quota key:
+      1. ``X-Real-IP`` — set by nginx from its ``real_ip``-resolved ``$remote_addr``
+         (it OVERWRITES any client-supplied value and binds ``real_ip_header`` to
+         the trusted ALB CIDR), so it is not client-spoofable.
+      2. the socket peer (``request.client.host``) — for local/non-proxied runs.
+
+    ``X-Forwarded-For`` is DELIBERATELY NOT used: its first hop is the original
+    client-supplied value, which an attacker could forge to dodge the cap.
+    (Copilot #792). Every candidate is validated as a real IP before use, so a
+    malformed header can't create arbitrary Redis keys; falls back to ``"unknown"``
+    (a single shared bucket — still capped, just coarser).
     """
-    xri = request.headers.get("x-real-ip")
-    if xri and xri.strip():
-        return xri.strip()
-    xff = request.headers.get("x-forwarded-for")
-    if xff and xff.strip():
-        return xff.split(",")[0].strip()
+    xri = (request.headers.get("x-real-ip") or "").strip()
+    if xri and _valid_ip(xri):
+        return xri
     client = request.client
-    return client.host if client and client.host else "unknown"
+    host = (client.host if client and client.host else "").strip()
+    if host and _valid_ip(host):
+        return host
+    return "unknown"
 
 
 class GenerationQuota:
@@ -94,8 +113,8 @@ class GenerationQuota:
         """Atomically count this wallet-less generation for ``ip`` today.
 
         Returns ``(allowed, used)`` where ``used`` is the count *after* this
-        attempt. ``allowed`` is ``used <= cap``. **Fails open** — on any Redis
-        error returns ``(True, 0)`` so a cache outage never blocks generation
+        attempt. ``allowed`` is ``used <= cap``. **Fails open** — a Redis error on
+        the INCR returns ``(True, 0)`` so a cache outage never blocks generation
         (the slowapi/nginx rate limits remain the backstop).
         """
         try:
@@ -103,13 +122,22 @@ class GenerationQuota:
             day = datetime.now(UTC).strftime("%Y-%m-%d")
             key = f"archimedes:genquota:{day}:{ip}"
             count = await r.incr(key)
-            if count == 1:
-                # First use today — stamp the TTL so the bucket self-expires.
-                await r.expire(key, _QUOTA_TTL_SECONDS)
-            return (count <= cap, int(count))
         except Exception as exc:
             logger.warning("generation quota check failed for ip=%s — FAILING OPEN: %s", ip, exc)
             return (True, 0)
+
+        # TTL is BEST-EFFORT and must not discard the already-successful INCR.
+        # ``EXPIRE ... NX`` sets the TTL only when the key has none, so it
+        # (a) self-heals a key whose prior EXPIRE failed / was interrupted between
+        # the INCR and EXPIRE — no key is left without a TTL to grow unbounded —
+        # and (b) does NOT slide the window on every hit. A failure here is logged
+        # and retried (NX) on the next hit, never swallowing the count. (Copilot #792)
+        try:
+            await r.expire(key, _QUOTA_TTL_SECONDS, nx=True)
+        except Exception as exc:
+            logger.debug("genquota TTL set failed for %s (retried NX next hit): %s", key, exc)
+
+        return (count <= cap, int(count))
 
     async def close(self) -> None:
         if self._redis:

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -1,0 +1,192 @@
+"""Tests for the wallet-less generation quota (anti-abuse per-IP daily cap).
+
+Hermetic — mocks at the Redis boundary; tests the cap logic, the real-IP
+resolver, the 429 steering response, the authenticated bypass, and fail-open.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from archimedes.services.generation_quota import (
+    GenerationQuota,
+    client_ip,
+    daily_cap,
+    enforce_generation_quota,
+)
+from fastapi import HTTPException
+
+
+def _mock_redis(incr_return: int):
+    r = MagicMock()
+    r.incr = AsyncMock(return_value=incr_return)
+    r.expire = AsyncMock(return_value=True)
+    return r
+
+
+def _req(headers: dict | None = None, client_host: str | None = None):
+    client = SimpleNamespace(host=client_host) if client_host else None
+    return SimpleNamespace(headers=headers or {}, client=client)
+
+
+# ─── GenerationQuota.check_and_increment ─────────────────────────────────
+
+
+async def test_under_cap_allowed():
+    q = GenerationQuota()
+    q._get_redis = AsyncMock(return_value=_mock_redis(3))
+    allowed, used = await q.check_and_increment("1.2.3.4", 5)
+    assert allowed is True
+    assert used == 3
+
+
+async def test_at_cap_allowed():
+    q = GenerationQuota()
+    q._get_redis = AsyncMock(return_value=_mock_redis(5))
+    allowed, used = await q.check_and_increment("1.2.3.4", 5)
+    assert allowed is True  # the 5th is still allowed
+    assert used == 5
+
+
+async def test_over_cap_not_allowed():
+    q = GenerationQuota()
+    q._get_redis = AsyncMock(return_value=_mock_redis(6))
+    allowed, used = await q.check_and_increment("1.2.3.4", 5)
+    assert allowed is False
+    assert used == 6
+
+
+async def test_first_use_sets_ttl():
+    r = _mock_redis(1)
+    q = GenerationQuota()
+    q._get_redis = AsyncMock(return_value=r)
+    await q.check_and_increment("1.2.3.4", 5)
+    r.expire.assert_awaited_once()  # TTL stamped exactly on the first use
+
+
+async def test_subsequent_use_does_not_reset_ttl():
+    r = _mock_redis(2)
+    q = GenerationQuota()
+    q._get_redis = AsyncMock(return_value=r)
+    await q.check_and_increment("1.2.3.4", 5)
+    r.expire.assert_not_awaited()  # don't slide the window on every hit
+
+
+async def test_check_fails_open_on_redis_error():
+    q = GenerationQuota()
+    q._get_redis = AsyncMock(side_effect=ConnectionError("redis down"))
+    allowed, used = await q.check_and_increment("1.2.3.4", 5)
+    assert allowed is True  # fail OPEN — never block on a cache outage
+    assert used == 0
+
+
+# ─── client_ip resolver ──────────────────────────────────────────────────
+
+
+def test_client_ip_prefers_x_real_ip():
+    req = _req({"x-real-ip": "9.9.9.9", "x-forwarded-for": "1.1.1.1"})
+    assert client_ip(req) == "9.9.9.9"
+
+
+def test_client_ip_xff_first_hop_fallback():
+    req = _req({"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"})
+    assert client_ip(req) == "1.1.1.1"
+
+
+def test_client_ip_socket_fallback():
+    assert client_ip(_req({}, client_host="3.3.3.3")) == "3.3.3.3"
+
+
+def test_client_ip_unknown_when_nothing_available():
+    assert client_ip(_req({})) == "unknown"
+
+
+# ─── enforce_generation_quota ────────────────────────────────────────────
+
+
+async def test_enforce_skips_authenticated_wallet(monkeypatch):
+    called = {"n": 0}
+
+    class Boom:
+        async def check_and_increment(self, *a):
+            called["n"] += 1
+            return (False, 99)
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.generation_quota.GenerationQuota", Boom)
+    # A wallet-bearing caller must bypass the cap entirely — never touch Redis.
+    await enforce_generation_quota(_req({"x-real-ip": "1.1.1.1"}), wallet="0xabc")
+    assert called["n"] == 0
+
+
+async def test_enforce_disabled_when_cap_zero(monkeypatch):
+    monkeypatch.setenv("WALLET_LESS_GENERATION_DAILY_CAP", "0")
+    called = {"n": 0}
+
+    class Boom:
+        async def check_and_increment(self, *a):
+            called["n"] += 1
+            return (False, 99)
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.generation_quota.GenerationQuota", Boom)
+    await enforce_generation_quota(_req({"x-real-ip": "1.1.1.1"}), wallet=None)
+    assert called["n"] == 0
+
+
+async def test_enforce_allows_under_cap(monkeypatch):
+    monkeypatch.setenv("WALLET_LESS_GENERATION_DAILY_CAP", "5")
+
+    class Under:
+        async def check_and_increment(self, ip, cap):
+            return (True, 2)
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.generation_quota.GenerationQuota", Under)
+    # No raise.
+    await enforce_generation_quota(_req({"x-real-ip": "1.1.1.1"}), wallet=None)
+
+
+async def test_enforce_raises_429_over_cap(monkeypatch):
+    monkeypatch.setenv("WALLET_LESS_GENERATION_DAILY_CAP", "5")
+
+    class Over:
+        async def check_and_increment(self, ip, cap):
+            return (False, 6)
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.generation_quota.GenerationQuota", Over)
+    with pytest.raises(HTTPException) as ei:
+        await enforce_generation_quota(_req({"x-real-ip": "1.1.1.1"}), wallet=None)
+    assert ei.value.status_code == 429
+    assert ei.value.detail["reason"] == "wallet_less_generation_cap"
+    assert ei.value.detail["cap"] == 5
+    assert "Connect a wallet" in ei.value.detail["message"]
+
+
+# ─── daily_cap config ────────────────────────────────────────────────────
+
+
+def test_daily_cap_default(monkeypatch):
+    monkeypatch.delenv("WALLET_LESS_GENERATION_DAILY_CAP", raising=False)
+    assert daily_cap() == 5
+
+
+def test_daily_cap_env_override(monkeypatch):
+    monkeypatch.setenv("WALLET_LESS_GENERATION_DAILY_CAP", "3")
+    assert daily_cap() == 3
+
+
+def test_daily_cap_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("WALLET_LESS_GENERATION_DAILY_CAP", "not-an-int")
+    assert daily_cap() == 5

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -58,20 +58,27 @@ async def test_over_cap_not_allowed():
     assert used == 6
 
 
-async def test_first_use_sets_ttl():
-    r = _mock_redis(1)
-    q = GenerationQuota()
-    q._get_redis = AsyncMock(return_value=r)
-    await q.check_and_increment("1.2.3.4", 5)
-    r.expire.assert_awaited_once()  # TTL stamped exactly on the first use
-
-
-async def test_subsequent_use_does_not_reset_ttl():
+async def test_ttl_set_with_nx_every_hit():
+    # EXPIRE ... NX runs on every hit: it self-heals a missing TTL but (being NX)
+    # only applies when the key has none, so it never slides the window.
     r = _mock_redis(2)
     q = GenerationQuota()
     q._get_redis = AsyncMock(return_value=r)
     await q.check_and_increment("1.2.3.4", 5)
-    r.expire.assert_not_awaited()  # don't slide the window on every hit
+    r.expire.assert_awaited_once()
+    assert r.expire.await_args.kwargs.get("nx") is True
+
+
+async def test_expire_failure_does_not_discard_count():
+    # A failed TTL set must NOT throw away the successful INCR — the cap decision
+    # is still made from the real count. (Copilot #792)
+    r = _mock_redis(6)
+    r.expire = AsyncMock(side_effect=ConnectionError("expire blip"))
+    q = GenerationQuota()
+    q._get_redis = AsyncMock(return_value=r)
+    allowed, used = await q.check_and_increment("1.2.3.4", 5)
+    assert used == 6  # the count survived the EXPIRE failure
+    assert allowed is False  # 6 > 5 still enforced
 
 
 async def test_check_fails_open_on_redis_error():
@@ -90,9 +97,19 @@ def test_client_ip_prefers_x_real_ip():
     assert client_ip(req) == "9.9.9.9"
 
 
-def test_client_ip_xff_first_hop_fallback():
-    req = _req({"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"})
-    assert client_ip(req) == "1.1.1.1"
+def test_client_ip_ignores_spoofable_xff():
+    # X-Forwarded-For is client-forgeable and must NOT be used; with no X-Real-IP,
+    # fall back to the socket peer, never the XFF value. (Copilot #792)
+    req = _req({"x-forwarded-for": "1.1.1.1, 2.2.2.2"}, client_host="3.3.3.3")
+    assert client_ip(req) == "3.3.3.3"
+    # And with no socket either, it's "unknown" — never the spoofable XFF.
+    assert client_ip(_req({"x-forwarded-for": "1.1.1.1"})) == "unknown"
+
+
+def test_client_ip_rejects_malformed_x_real_ip():
+    # A non-IP header value must not become a Redis key — fall back. (Copilot #792)
+    req = _req({"x-real-ip": "not-an-ip; DROP"}, client_host="3.3.3.3")
+    assert client_ip(req) == "3.3.3.3"
 
 
 def test_client_ip_socket_fallback():
@@ -101,6 +118,10 @@ def test_client_ip_socket_fallback():
 
 def test_client_ip_unknown_when_nothing_available():
     assert client_ip(_req({})) == "unknown"
+
+
+def test_client_ip_accepts_ipv6_real_ip():
+    assert client_ip(_req({"x-real-ip": "2001:db8::1"})) == "2001:db8::1"
 
 
 # ─── enforce_generation_quota ────────────────────────────────────────────


### PR DESCRIPTION
## Why (Dan's ask)

The Generate path is intentionally **open** (`REQUIRE_SIWE_FOR_GENERATION=false`) so visitors — humans **and** agents — can try the product before connecting a wallet (value-before-wallet, #787). But an open LLM-spending endpoint is a **flood/abuse risk**: an agent in a loop could hammer `/api/generate/start` and burn LLM budget. *"Let them try it cheaply, but hard-cap the flood."*

## What

- **`services/generation_quota.py`** — `GenerationQuota`: a fail-open, Redis-backed **per-IP daily** counter for wallet-less generations.
  - **Authenticated (SIWE-wallet) callers bypass the cap entirely.**
  - Keyed on the **real client IP** via the nginx-set, **non-spoofable** `X-Real-IP` header (uvicorn runs without `--proxy-headers`, so `request.client` is nginx, not the client — nginx overwrites `X-Real-IP` from its `real_ip`-resolved `$remote_addr`, bound to the trusted ALB CIDR). IP-keyed on purpose: a cookie-keyed cap would be defeated by an agent dropping the `archimedes_vid` cookie.
  - On the cap being hit → **HTTP 429 with a structured steering payload** (`{message, reason: "wallet_less_generation_cap", cap}`), so the cap doubles as a **connect-wallet conversion prompt** rather than a dead end.
- **Defense in depth:** sits *on top of* the existing slowapi (`5/min`) + nginx per-IP `limit_req_zone` limits, which bound the burst **rate**; this bounds the wallet-less daily **volume**.
- **Fail-open:** a Redis blip returns "allowed" (logged WARNING) — the slowapi/nginx rate limits remain the backstop, and blocking *all* wallet-less generation during a cache outage would be worse than the narrow window. (Happy to switch to fail-closed if you'd rather — it's a one-line change; flagging the tradeoff.)
- Wired into `start_generation` **before any work** (a capped request burns nothing). Disabled under `TESTING` (conftest sets it), matching the slowapi limiter.
- **`WALLET_LESS_GENERATION_DAILY_CAP`** (default **5**; `0` disables) documented in `.env.example` — tunable without a code change.

## Verification
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_generation_quota.py -q   # 17 passed
```
17 hermetic tests (mock the Redis boundary): under/at/over cap, TTL stamped once, fail-open, real-IP resolution (X-Real-IP → XFF → socket → unknown), authenticated bypass, cap-disabled, the 429 payload, and the env config. ruff clean; import graph verified.

## Review note
**Security-adjacent + gates the open Generate path — requesting review, not auto-merging.** Two knobs worth your eyes: the **cap value** (5/day — "try it a bit" vs stricter) and the **fail-open vs fail-closed** choice on a Redis outage. Both are trivial to change.