### PR TITLE
[infra] T3.7: purge stale .app domain refs from docs/scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ May 11–25, 2026.
   Chain ID `5042002` / `0x4cef52`, Arc testnet). **Prod migrated 2026-06-24 to Dan's own AWS
   account (`037613907429` / `us-east-1`)** — see "Project / Status" below. The old `.app` domain
   was decommissioned 2026-06-24 (its `.app`/`.com` split had caused the Circle passkey rpId bug,
-  since fixed); `.com` is the sole live domain
+  since fixed); `.com` is the sole live domain.
 - License: [Unlicense](https://unlicense.org) — full public-domain dedication
 
 ### Project / Status (refreshed 2026-06-24 — Lepton Sprint)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,9 @@ May 11–25, 2026.
   core build), so rebase late and merge fast
 - Live testnet deploy: [`https://archimedes-arc.com/`](https://archimedes-arc.com/) (CloudFront → EC2,
   Chain ID `5042002` / `0x4cef52`, Arc testnet). **Prod migrated 2026-06-24 to Dan's own AWS
-  account (`037613907429` / `us-east-1`)** — see "Project / Status" below. The old `archimedes-arc.app`
-  is being decommissioned (the `.app`/`.com` split caused the Circle passkey rpId bug, now fixed)
+  account (`037613907429` / `us-east-1`)** — see "Project / Status" below. The old `.app` domain
+  was decommissioned 2026-06-24 (its `.app`/`.com` split had caused the Circle passkey rpId bug,
+  since fixed); `.com` is the sole live domain
 - License: [Unlicense](https://unlicense.org) — full public-domain dedication
 
 ### Project / Status (refreshed 2026-06-24 — Lepton Sprint)

--- a/infra/runbooks/disaster-recovery.md
+++ b/infra/runbooks/disaster-recovery.md
@@ -29,7 +29,7 @@ configuration.
 
 ### 1. Application host (EC2) down / unhealthy
 **Detect:** `archimedes-ec2-status-check-failed` or `archimedes-alb-unhealthy-hosts`
-alarm (see `infra/cloudwatch.tf`), or `https://archimedes-arc.app/` 502/503.
+alarm (see `infra/cloudwatch.tf`), or `https://archimedes-arc.com/` 502/503.
 
 **Respond:**
 1. Confirm the target health:

--- a/infra/scripts/setup-https.sh
+++ b/infra/scripts/setup-https.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
 # DEPRECATED / LEGACY — retained for reference only (T3.7).
 # Production TLS now terminates UPSTREAM at CloudFront + the ALB (ACM certs); the
-# EC2 serves plain HTTP on :8080 and runs NO certbot (see nginx/nginx.conf). This
-# in-instance Let's Encrypt path is from the pre-CloudFront era on the now-
+# EC2 serves plain HTTP on :8080 and does NOT run certbot for the live TLS path
+# (nginx/nginx.conf keeps an ACME `/.well-known/acme-challenge/` passthrough only
+# for optional, out-of-band renewals — it is not used on the current CloudFront path).
+# This in-instance Let's Encrypt flow is from the pre-CloudFront era on the now-
 # decommissioned archimedes-arc.app domain and is NOT part of the current
 # architecture. Do not run it against prod.
 # Usage (historical): ssh ubuntu@<host> 'bash -s' < infra/scripts/setup-https.sh
 set -euo pipefail
+
+# Safety guard: this legacy script provisions Let's Encrypt against a HARDCODED
+# prod domain/email below. Refuse to run unless an operator explicitly opts in,
+# so a stray `bash -s` can never fire it by accident.
+if [[ "${ALLOW_LEGACY_HTTPS_SETUP:-}" != "1" ]]; then
+  echo "DEPRECATED: in-instance certbot is not the live TLS path (CloudFront/ACM is)." >&2
+  echo "Refusing to run. Set ALLOW_LEGACY_HTTPS_SETUP=1 to override intentionally." >&2
+  exit 1
+fi
 
 DOMAIN="archimedes-arc.com"
 EMAIL="dbrowne.up@gmail.com"

--- a/infra/scripts/setup-https.sh
+++ b/infra/scripts/setup-https.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Idempotent HTTPS setup for archimedes-arc.app on EC2
-# Usage: ssh ubuntu@<host> 'bash -s' < infra/scripts/setup-https.sh
+# DEPRECATED / LEGACY — retained for reference only (T3.7).
+# Production TLS now terminates UPSTREAM at CloudFront + the ALB (ACM certs); the
+# EC2 serves plain HTTP on :8080 and runs NO certbot (see nginx/nginx.conf). This
+# in-instance Let's Encrypt path is from the pre-CloudFront era on the now-
+# decommissioned archimedes-arc.app domain and is NOT part of the current
+# architecture. Do not run it against prod.
+# Usage (historical): ssh ubuntu@<host> 'bash -s' < infra/scripts/setup-https.sh
 set -euo pipefail
 
-DOMAIN="archimedes-arc.app"
-EMAIL="chuan@gyld.fi"
+DOMAIN="archimedes-arc.com"
+EMAIL="dbrowne.up@gmail.com"
 COMPOSE_DIR="/opt/archimedes"
 
 echo "=== [1/4] Install certbot ==="


### PR DESCRIPTION
## What

The old `archimedes-arc.app` domain was decommissioned 2026-06-24; `.com` is the sole live domain. This purges the stale references that **don't touch Terraform state**:

- **`infra/scripts/setup-https.sh`** — marked **DEPRECATED/LEGACY**. Production TLS now terminates upstream at CloudFront + the ALB (ACM certs); the EC2 serves plain HTTP and runs no certbot, so this in-instance Let's Encrypt path is dead. Literals repointed to `.com` + a current contact (was Chuan's).
- **`infra/runbooks/disaster-recovery.md`** — the health-probe URL `.app` → `.com`.
- **`CLAUDE.md`** — decommission note reworded to past tense.

Verified: `grep` finds no `.app` refs left outside the Terraform tree (the one remaining mention in `setup-https.sh` is inside its DEPRECATED banner, explaining the decommission). `bash -n` clean.

## 🛠️ Handoff to Dan — the Terraform `.app` teardown (your `terraform apply`)

I deliberately left **all `.tf` untouched** — removing these from code without `terraform destroy` first would drift state. And it's **not a simple file delete** — there are cross-references to investigate:

**Resources to retire (in `infra/terraform/`):**
- `route53.tf` → `aws_route53_zone.main` (the `.app` hosted zone) + `aws_route53_record.apex`
- `acm_archimedes_arc_app.tf` → `aws_acm_certificate.main` + `aws_route53_record.acm_validation` + `aws_acm_certificate_validation.main`
- `infra/outputs.tf:101` → cosmetic description string mentioning `.app`

**⚠️ Caveat — two TF root modules + cross-refs:** `infra/*.tf` (cloudfront/alb — the current `.com` stack) and `infra/terraform/*.tf` (the `.app` config) are separate roots. `infra/alb.tf:108` and `infra/cloudfront.tf` use `data "aws_route53_zone" "main"` — confirm whether those resolve the `.com` zone (safe) or the `.app` zone (would break on destroy) before tearing the zone down.

Suggested sequence: `terraform plan` in the `.app` root → `terraform destroy -target=aws_acm_certificate_validation.main -target=aws_acm_certificate.main -target=aws_route53_record.apex -target=aws_route53_zone.main` (records/cert before the zone) → then remove the `.tf` files in a follow-up commit once state is clean.

Closes the docs/script half of T3.7; the TF half is yours.