### PR TITLE
[telemetry] Visitor insights — distinct-visitor geography + device class !minor

### DIFF
--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -18,13 +18,16 @@ from fastapi import APIRouter, Query, Request
 
 from archimedes.api.funnel_middleware import record_funnel
 from archimedes.models.telemetry import (
+    CountryCount,
     FunnelEventRequest,
     FunnelResponse,
     FunnelStageCount,
     MetricsResponse,
+    VisitorInsightsResponse,
 )
 from archimedes.services.funnel_store import CLIENT_EMITTABLE_STAGES, STAGES, FunnelStore
 from archimedes.services.telemetry_store import TelemetryStore
+from archimedes.services.visitor_insights_store import VisitorInsightsStore
 
 metrics_router = APIRouter(prefix="/api", tags=["metrics"])
 
@@ -115,3 +118,25 @@ async def record_funnel_event(req: FunnelEventRequest, request: Request) -> dict
         return {"recorded": False}
     await record_funnel(request, req.stage)
     return {"recorded": True}
+
+
+@metrics_router.get("/metrics/visitors", response_model=VisitorInsightsResponse)
+async def get_visitor_insights() -> VisitorInsightsResponse:
+    """Where our human traffic comes from + on what device (issue #787).
+
+    Distinct HUMAN visitors (agents excluded), country via CloudFront viewer-country,
+    device via CloudFront device headers (UA fallback). Fail-safe: returns empty
+    maps when Redis is unreachable, so this always responds 200.
+    """
+    store = VisitorInsightsStore()
+    try:
+        countries, devices = await store.get_insights()
+    finally:
+        await store.close()
+    ranked = sorted(countries.items(), key=lambda kv: (-kv[1], kv[0]))
+    return VisitorInsightsResponse(
+        window="all-time",
+        countries=[CountryCount(code=c, distinct_visitors=n) for c, n in ranked],
+        devices=devices,
+        timestamp=datetime.now(UTC).isoformat(),
+    )

--- a/backend/archimedes/api/telemetry_middleware.py
+++ b/backend/archimedes/api/telemetry_middleware.py
@@ -126,6 +126,14 @@ async def telemetry_middleware(request: Request, call_next):
                 await store.increment_human()
         finally:
             await store.close()
+
+        # Visitor insights (#787): record country + device for HUMAN visitors so we
+        # can see where our (un-promoted) traffic comes from. Fail-safe + humans-only
+        # (skips agents/crawlers). Uses request.state.visitor_id, set by the
+        # visitor-id middleware which runs outermost (before this one).
+        from archimedes.api.visitor_insights import record_visitor_insight
+
+        await record_visitor_insight(request, is_agent)
     except Exception as exc:
         # Fail-safe: never let telemetry raise into the request path.
         logger.debug("telemetry middleware classify/count failed: %s", exc)

--- a/backend/archimedes/api/visitor_insights.py
+++ b/backend/archimedes/api/visitor_insights.py
@@ -1,0 +1,62 @@
+"""Visitor-insight capture helper — geography + device from a request (#787).
+
+Derives the visitor's country (CloudFront-Viewer-Country) and device class
+(CloudFront device headers, falling back to a User-Agent sniff) and records them
+via ``VisitorInsightsStore``. Called from the telemetry middleware, which already
+classifies human-vs-agent and has the anonymous ``visitor_id`` on request state.
+
+Humans only: agent/crawler traffic is skipped so the geography reflects real
+visitors, not datacenter crawler IPs. Fail-safe — never raises into the request.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+
+def _device_class(request: Request) -> str:
+    """Best-effort device class: prefer CloudFront's device headers, else UA sniff."""
+    h = request.headers
+    if h.get("cloudfront-is-tablet-viewer", "").lower() == "true":
+        return "tablet"
+    if h.get("cloudfront-is-mobile-viewer", "").lower() == "true":
+        return "mobile"
+    if h.get("cloudfront-is-smarttv-viewer", "").lower() == "true":
+        return "tv"
+    if h.get("cloudfront-is-desktop-viewer", "").lower() == "true":
+        return "desktop"
+    # Fallback (no CloudFront headers — local/dev, or before the TF change lands):
+    ua = h.get("user-agent", "").lower()
+    if "ipad" in ua or "tablet" in ua:
+        return "tablet"
+    if "mobi" in ua or "android" in ua or "iphone" in ua:
+        return "mobile"
+    if ua:
+        return "desktop"
+    return "unknown"
+
+
+async def record_visitor_insight(request: Request, is_agent: bool) -> None:
+    """Record this request's visitor geography + device (humans only). Never raises."""
+    if is_agent:
+        return
+    try:
+        visitor_id = getattr(request.state, "visitor_id", "") or ""
+        if not visitor_id:
+            return
+        country = request.headers.get("cloudfront-viewer-country")
+        device = _device_class(request)
+
+        from archimedes.services.visitor_insights_store import VisitorInsightsStore
+
+        store = VisitorInsightsStore()
+        try:
+            await store.record(country, device, visitor_id)
+        finally:
+            await store.close()
+    except Exception as exc:
+        logger.debug("record_visitor_insight failed: %s", exc)

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -90,5 +90,7 @@ class VisitorInsightsResponse(BaseModel):
 
     window: str = Field(..., description='"all-time" snapshot window.')
     countries: list[CountryCount] = Field(..., description="Countries, sorted by distinct visitors (desc).")
-    devices: dict[str, int] = Field(..., description="Distinct visitors per device class (mobile/tablet/desktop/tv).")
+    devices: dict[str, int] = Field(
+        ..., description="Distinct visitors per device class (mobile/tablet/desktop/tv, or 'unknown' if unclassified)."
+    )
     timestamp: str = Field(..., description="ISO-8601 UTC timestamp this snapshot was read.")

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -70,3 +70,25 @@ class FunnelEventRequest(BaseModel):
     """
 
     stage: str = Field(..., description="The funnel stage the browser is reporting (e.g. 'landed').")
+
+
+class CountryCount(BaseModel):
+    """Distinct human visitors from one country (issue #787)."""
+
+    code: str = Field(..., description="ISO-3166 alpha-2 country code, or 'ZZ' when unknown.")
+    distinct_visitors: int = Field(..., description="Distinct human visitors from this country (HLL estimate).")
+
+
+class VisitorInsightsResponse(BaseModel):
+    """Where our (un-promoted) human traffic comes from + on what device (issue #787).
+
+    Served by ``GET /api/metrics/visitors``. Counts are distinct HUMAN visitors
+    (agents/crawlers excluded) keyed on the anonymous visitor id. Country comes
+    from CloudFront's viewer-country geolocation; device from CloudFront device
+    headers (UA fallback).
+    """
+
+    window: str = Field(..., description='"all-time" snapshot window.')
+    countries: list[CountryCount] = Field(..., description="Countries, sorted by distinct visitors (desc).")
+    devices: dict[str, int] = Field(..., description="Distinct visitors per device class (mobile/tablet/desktop/tv).")
+    timestamp: str = Field(..., description="ISO-8601 UTC timestamp this snapshot was read.")

--- a/backend/archimedes/services/visitor_insights_store.py
+++ b/backend/archimedes/services/visitor_insights_store.py
@@ -67,7 +67,7 @@ class VisitorInsightsStore:
 
     # ─── Record (write path — telemetry middleware, humans only) ─────────
 
-    async def record(self, country: str, device: str, visitor_id: str) -> None:
+    async def record(self, country: str | None, device: str, visitor_id: str) -> None:
         """Record one human visit's country + device for ``visitor_id``. Never raises."""
         if not visitor_id:
             return

--- a/backend/archimedes/services/visitor_insights_store.py
+++ b/backend/archimedes/services/visitor_insights_store.py
@@ -1,0 +1,127 @@
+"""Visitor insights — distinct-visitor geography + device class (issue #787).
+
+We have zero promotion and a zero-conversion problem, so understanding WHO lands
+on the site (where from, on what kind of device) is high-value signal. This
+records, per day, the distinct *human-ish* visitors broken down by:
+
+  - **country** — the ISO-3166 code CloudFront geolocates from the viewer IP and
+    forwards as the ``CloudFront-Viewer-Country`` header (the ALB/origin can't see
+    the real client IP — CloudFront masks it — so this header is the only clean
+    geo source);
+  - **device class** — mobile / tablet / desktop / tv, from CloudFront's
+    ``CloudFront-Is-*-Viewer`` headers (falling back to a User-Agent sniff).
+
+Distinct counts use Redis HyperLogLog keyed on the anonymous ``archimedes_vid``
+(no PII, no raw-id retention) — same privacy-friendly approach as the funnel.
+Only requests classified as human (not agents/bots) are recorded, so the
+geography reflects real visitors, not datacenter crawler IPs.
+
+Mirrors ``services/funnel_store.py`` / ``telemetry_store.py``: same
+``redis.asyncio`` convention and **fail-safe by construction** — every method
+swallows Redis errors; instrumentation never turns a request into a 5xx.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+import redis.asyncio as aioredis
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+_PREFIX = "archimedes:visitors"
+# Day buckets self-expire after 90 days (trend history without unbounded growth).
+_DAY_TTL_SECONDS = 90 * 24 * 60 * 60
+
+DEVICE_CLASSES = ("mobile", "tablet", "desktop", "tv", "unknown")
+_UNKNOWN_COUNTRY = "ZZ"  # ISO 3166 user-assigned code — "unknown / not provided"
+
+
+def _today() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+def _norm_country(raw: str | None) -> str:
+    """Normalize a CloudFront-Viewer-Country value to a 2-letter upper code or ZZ."""
+    if not raw:
+        return _UNKNOWN_COUNTRY
+    code = raw.strip().upper()
+    return code if len(code) == 2 and code.isalpha() else _UNKNOWN_COUNTRY
+
+
+class VisitorInsightsStore:
+    """Fail-safe Redis wrapper for distinct-visitor geo + device counters."""
+
+    def __init__(self, url: str | None = None) -> None:
+        self._url = url or REDIS_URL
+        self._redis: aioredis.Redis | None = None
+
+    async def _get_redis(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = aioredis.from_url(self._url, decode_responses=True)
+        return self._redis
+
+    # ─── Record (write path — telemetry middleware, humans only) ─────────
+
+    async def record(self, country: str, device: str, visitor_id: str) -> None:
+        """Record one human visit's country + device for ``visitor_id``. Never raises."""
+        if not visitor_id:
+            return
+        cc = _norm_country(country)
+        dev = device if device in DEVICE_CLASSES else "unknown"
+        try:
+            r = await self._get_redis()
+            day = _today()
+            country_day = f"{_PREFIX}:country:day:{day}:{cc}"
+            device_day = f"{_PREFIX}:device:day:{day}:{dev}"
+            pipe = r.pipeline()
+            # All-time distinct (no TTL).
+            pipe.pfadd(f"{_PREFIX}:country:total:{cc}", visitor_id)
+            pipe.pfadd(f"{_PREFIX}:device:total:{dev}", visitor_id)
+            # Per-day distinct (TTL'd).
+            pipe.pfadd(country_day, visitor_id)
+            pipe.expire(country_day, _DAY_TTL_SECONDS, nx=True)
+            pipe.pfadd(device_day, visitor_id)
+            pipe.expire(device_day, _DAY_TTL_SECONDS, nx=True)
+            # Index of which country codes have been seen, so reads can enumerate
+            # them without SCANning the keyspace.
+            pipe.sadd(f"{_PREFIX}:countries", cc)
+            await pipe.execute()
+        except Exception as exc:
+            logger.debug("visitor insight record failed (%s/%s): %s", cc, dev, exc)
+
+    # ─── Read (exposure path — GET /api/metrics/visitors) ────────────────
+
+    async def get_insights(self) -> tuple[dict[str, int], dict[str, int]]:
+        """Return ``(countries, devices)`` all-time distinct-visitor maps. Zeros on error."""
+        try:
+            r = await self._get_redis()
+            seen = await r.smembers(f"{_PREFIX}:countries")
+            countries: dict[str, int] = {}
+            if seen:
+                codes = sorted(seen)
+                pipe = r.pipeline()
+                for cc in codes:
+                    pipe.pfcount(f"{_PREFIX}:country:total:{cc}")
+                for cc, n in zip(codes, await pipe.execute(), strict=False):
+                    countries[cc] = int(n or 0)
+            pipe = r.pipeline()
+            for dev in DEVICE_CLASSES:
+                pipe.pfcount(f"{_PREFIX}:device:total:{dev}")
+            devices = {dev: int(n or 0) for dev, n in zip(DEVICE_CLASSES, await pipe.execute(), strict=False)}
+            return countries, devices
+        except Exception as exc:
+            logger.debug("visitor insight read failed: %s", exc)
+            return {}, dict.fromkeys(DEVICE_CLASSES, 0)
+
+    async def close(self) -> None:
+        if self._redis:
+            try:
+                await self._redis.aclose()
+            except Exception as exc:
+                logger.debug("visitor insight store close failed: %s", exc)
+            self._redis = None

--- a/backend/tests/test_visitor_insights.py
+++ b/backend/tests/test_visitor_insights.py
@@ -1,0 +1,166 @@
+"""Tests for the visitor-insights instrument — geography + device class (#787).
+
+Hermetic — mocks the Redis boundary. Covers the store (record + read + fail-safe),
+country normalization, the device-class derivation (CloudFront headers + UA
+fallback), and the humans-only capture gate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from archimedes.api.visitor_insights import _device_class, record_visitor_insight
+from archimedes.services.visitor_insights_store import (
+    DEVICE_CLASSES,
+    VisitorInsightsStore,
+    _norm_country,
+)
+
+
+def _mock_redis(pfcounts=None, members=None):
+    pipe = MagicMock()
+    pipe.pfadd = MagicMock(return_value=pipe)
+    pipe.expire = MagicMock(return_value=pipe)
+    pipe.sadd = MagicMock(return_value=pipe)
+    pipe.pfcount = MagicMock(return_value=pipe)
+    pipe.execute = AsyncMock(return_value=pfcounts if pfcounts is not None else [])
+    r = MagicMock()
+    r.pipeline = MagicMock(return_value=pipe)
+    r.smembers = AsyncMock(return_value=members or set())
+    return r, pipe
+
+
+def _req(headers=None):
+    return SimpleNamespace(headers=headers or {}, state=SimpleNamespace(visitor_id="vid-1"))
+
+
+# ─── country normalization ───────────────────────────────────────────────
+
+
+def test_norm_country_valid():
+    assert _norm_country("us") == "US"
+    assert _norm_country("DE") == "DE"
+
+
+def test_norm_country_invalid_or_missing():
+    assert _norm_country(None) == "ZZ"
+    assert _norm_country("") == "ZZ"
+    assert _norm_country("USA") == "ZZ"  # not 2 letters
+    assert _norm_country("1!") == "ZZ"
+
+
+# ─── device class derivation ─────────────────────────────────────────────
+
+
+def test_device_class_cloudfront_headers_win():
+    assert _device_class(_req({"cloudfront-is-mobile-viewer": "true"})) == "mobile"
+    assert _device_class(_req({"cloudfront-is-tablet-viewer": "true"})) == "tablet"
+    assert _device_class(_req({"cloudfront-is-desktop-viewer": "true"})) == "desktop"
+    assert _device_class(_req({"cloudfront-is-smarttv-viewer": "true"})) == "tv"
+
+
+def test_device_class_ua_fallback():
+    assert _device_class(_req({"user-agent": "Mozilla/5.0 (iPhone) Mobile"})) == "mobile"
+    assert _device_class(_req({"user-agent": "Mozilla/5.0 (iPad)"})) == "tablet"
+    assert _device_class(_req({"user-agent": "Mozilla/5.0 (Macintosh)"})) == "desktop"
+    assert _device_class(_req({})) == "unknown"
+
+
+# ─── store record + read ─────────────────────────────────────────────────
+
+
+async def test_record_pfadds_country_and_device_and_indexes():
+    store = VisitorInsightsStore()
+    r, pipe = _mock_redis()
+    store._get_redis = AsyncMock(return_value=r)
+
+    await store.record("US", "mobile", "vid-1")
+
+    # 4 pfadds: country total + device total + country day + device day
+    assert pipe.pfadd.call_count == 4
+    # country code indexed for enumeration on read
+    pipe.sadd.assert_called_once()
+    assert pipe.sadd.call_args.args[1] == "US"
+    pipe.execute.assert_awaited_once()
+
+
+async def test_record_normalizes_bad_country_and_device():
+    store = VisitorInsightsStore()
+    r, pipe = _mock_redis()
+    store._get_redis = AsyncMock(return_value=r)
+    await store.record("not-a-country", "watch", "vid-1")
+    # bad country → ZZ, bad device → unknown (in the key names)
+    keys = [c.args[0] for c in pipe.pfadd.call_args_list]
+    assert any(k.endswith(":ZZ") for k in keys)
+    assert any(":device:" in k and k.endswith(":unknown") for k in keys)
+
+
+async def test_record_noop_without_visitor_id():
+    store = VisitorInsightsStore()
+    r, _ = _mock_redis()
+    store._get_redis = AsyncMock(return_value=r)
+    await store.record("US", "mobile", "")
+    r.pipeline.assert_not_called()
+
+
+async def test_record_fails_open():
+    store = VisitorInsightsStore()
+    store._get_redis = AsyncMock(side_effect=ConnectionError("down"))
+    await store.record("US", "mobile", "vid-1")  # must not raise
+
+
+async def test_get_insights_reads_countries_and_devices():
+    store = VisitorInsightsStore()
+    # smembers → {US, DE}; first pipeline (countries) → [10, 4]; second (devices, 5
+    # classes in DEVICE_CLASSES order) → [7, 1, 6, 0, 0]
+    r, pipe = _mock_redis(members={"US", "DE"})
+    pipe.execute = AsyncMock(side_effect=[[10, 4], [7, 1, 6, 0, 0]])
+    store._get_redis = AsyncMock(return_value=r)
+
+    countries, devices = await store.get_insights()
+
+    assert countries == {"DE": 10, "US": 4}  # sorted(codes) = [DE, US]
+    assert devices == dict(zip(DEVICE_CLASSES, [7, 1, 6, 0, 0], strict=False))
+
+
+async def test_get_insights_fails_open():
+    store = VisitorInsightsStore()
+    store._get_redis = AsyncMock(side_effect=ConnectionError("down"))
+    countries, devices = await store.get_insights()
+    assert countries == {}
+    assert devices == dict.fromkeys(DEVICE_CLASSES, 0)
+
+
+# ─── capture gate (humans only) ──────────────────────────────────────────
+
+
+async def test_capture_skips_agents(monkeypatch):
+    calls = {"n": 0}
+
+    class FakeStore:
+        async def record(self, *a):
+            calls["n"] += 1
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.visitor_insights_store.VisitorInsightsStore", FakeStore)
+    await record_visitor_insight(_req({"cloudfront-viewer-country": "US"}), is_agent=True)
+    assert calls["n"] == 0  # agents are NOT recorded — keep geography human-only
+
+
+async def test_capture_records_humans(monkeypatch):
+    recorded = {}
+
+    class FakeStore:
+        async def record(self, country, device, vid):
+            recorded["args"] = (country, device, vid)
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.visitor_insights_store.VisitorInsightsStore", FakeStore)
+    req = _req({"cloudfront-viewer-country": "DE", "cloudfront-is-mobile-viewer": "true"})
+    await record_visitor_insight(req, is_agent=False)
+    assert recorded["args"] == ("DE", "mobile", "vid-1")

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -171,7 +171,18 @@ resource "aws_cloudfront_origin_request_policy" "all_viewer" {
   headers_config {
     header_behavior = "allViewerAndWhitelistCloudFront"
     headers {
-      items = ["CloudFront-Forwarded-Proto"]
+      # CloudFront-Viewer-Country + device headers feed the visitor-insights
+      # instrument (#787): the backend can't see the real client IP (CloudFront
+      # masks it), so these CloudFront-derived headers are the only clean source
+      # for visitor geography + device class. Forwarded to origin here.
+      items = [
+        "CloudFront-Forwarded-Proto",
+        "CloudFront-Viewer-Country",
+        "CloudFront-Is-Mobile-Viewer",
+        "CloudFront-Is-Tablet-Viewer",
+        "CloudFront-Is-Desktop-Viewer",
+        "CloudFront-Is-SmartTV-Viewer",
+      ]
     }
   }
   query_strings_config {


### PR DESCRIPTION
## Why

You asked: *where is our (un-promoted) traffic coming from?* The ALB logs **can't** tell us — CloudFront fronts the ALB, so the origin never sees the real client IP. The clean source is **CloudFront's viewer-country geolocation** (+ device headers). This adds a distinct-visitor breakdown by **country** and **device class**, pairing with the funnel (#789) to answer *who lands, from where, on what device*.

## How

- **`services/visitor_insights_store.py`** — `VisitorInsightsStore`: Redis **HyperLogLog** distinct-visitor counts by country + device (all-time + per-day TTL'd). Fail-safe (mirrors `FunnelStore`/`TelemetryStore`). **No PII** — country normalized to ISO-2 or `ZZ`; keyed on the anonymous `archimedes_vid`.
- **`api/visitor_insights.py`** — `record_visitor_insight()` + device derivation (CloudFront `Is-*-Viewer` headers → UA fallback). **Humans only** — agents/crawlers are skipped so the geography reflects real visitors, not datacenter crawler IPs.
- **`telemetry_middleware`** — wires the capture (it already classifies human-vs-agent and carries the `visitor_id`). Fail-safe; never 5xx.
- **`GET /api/metrics/visitors`** — top countries (sorted) + device breakdown, distinct humans.
- **`infra/cloudfront.tf`** — forward `CloudFront-Viewer-Country` + the 4 `CloudFront-Is-*-Viewer` headers to origin (added to the `all_viewer` origin-request policy). `terraform fmt` clean.

## ⚠️ Needs your `terraform apply` (infra)

The TF change forwards 5 CloudFront headers to origin — it **requires `terraform apply`** to take effect. Until applied: **country** reads `ZZ` (header absent) but **device** still works via the UA fallback, so the endpoint is useful immediately and gets geo the moment you apply. The change is additive (a header allowlist on an existing origin-request policy) — no behavior change to caching or routing.

## Verify
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_visitor_insights.py -q   # 12 passed
curl -s https://archimedes-arc.com/api/metrics/visitors | jq    # after deploy
```
12 hermetic tests (Redis-boundary mocks): record/read/fail-safe, country normalization, device derivation (CloudFront + UA), humans-only gate. ruff clean; existing telemetry/metrics + app-boot route tests green; `terraform fmt` clean.

## Anti-goals
- No PII / no raw-IP retention — HLL distinct counts + a country code only.
- Instrumentation never 5xx's a request (fail-safe).
- No caching/routing change — only a header allowlist addition.

Part of #787 (the "insights on what they do / who visits" lever).