### PR TITLE
[quant] Report CPCV as explicit NOT_RUN, not bare MISSING (#771)

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -129,8 +129,10 @@ async def evaluate_rigor_gate():
     per-split OOS returns that comes from re-running the full backtest engine
     across combinatorial window splits.  That rolling re-backtest pipeline is
     not yet wired here, so run_rigor_gate() is called without cv_returns_matrix
-    and CPCV is honestly reported as MISSING on every strategy.  Wire it once
-    the analytics-engine supports combinatorial window output.
+    and CPCV is reported as an explicit NOT_RUN status (with the reason) on every
+    strategy — never a bare "MISSING" that would imply a method silently producing
+    no number (#771).  Wire it once the analytics-engine supports combinatorial
+    window output.
     """
     strategies = _provider.list_strategies()
 
@@ -215,7 +217,8 @@ async def evaluate_rigor_gate():
 
         # cv_returns_matrix intentionally omitted — CPCV requires a 2-D array
         # of per-combinatorial-split OOS returns that the analytics-engine does
-        # not yet produce.  run_rigor_gate() will report cpcv as MISSING.
+        # not yet produce.  run_rigor_gate() reports cpcv as an explicit NOT_RUN
+        # status with the reason (#771), not a bare "MISSING".
         gate_result = run_rigor_gate(
             strategy_id=s.id,
             daily_returns=daily_returns,

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -473,7 +473,14 @@ class RigorGateResult:
             else:
                 details["cpcv"] = f"FAIL (OOS+ only {self.cpcv_positive_fraction:.0%} of paths, need ≥ 50%)"
         else:
-            details["cpcv"] = "MISSING"
+            # Honest not-run status (#771): the surface must never advertise CPCV as a
+            # method while silently emitting a bare "MISSING". CPCV needs a 2-D (S, T)
+            # matrix of per-combinatorial-split OOS returns; it is mathematically invalid
+            # on a single static return series, so when no matrix is supplied we say so
+            # explicitly rather than implying a method that produced no number.
+            details["cpcv"] = (
+                "NOT_RUN (no combinatorial OOS matrix supplied; CPCV is invalid on a single static return series)"
+            )
 
         details["look_ahead"] = "PASS" if self.look_ahead_passed else "FAIL"
 

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -28,6 +28,7 @@ from archimedes.api.selection_bias_routes import (
     StrategyRigorResult,
     _load_strategy_code,
 )
+from archimedes.services.rigor_evaluator import run_rigor_gate
 from httpx import ASGITransport, AsyncClient
 
 # ── Hermetic DB fixture ────────────────────────────────────────────────
@@ -49,6 +50,43 @@ def _use_tmp_db(tmp_path, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
     init_db()
     yield
+
+
+# ── CPCV honest not-run reporting (#771) ───────────────────────────────
+
+
+class TestCpcvHonestNotRun:
+    """#771: the selection-bias surface must not advertise CPCV as a method while
+    emitting a bare "MISSING". The live route calls run_rigor_gate WITHOUT a
+    cv_returns_matrix (the analytics-engine doesn't emit one yet), so CPCV must be
+    reported as an explicit NOT_RUN status with its reason — never a bare placeholder
+    and never a fabricated value.
+    """
+
+    @staticmethod
+    def _series():
+        rng = np.random.default_rng(7)
+        return list(rng.normal(0.001, 0.01, 400))
+
+    def test_cpcv_reports_explicit_not_run_label(self):
+        # Exactly how selection_bias_routes.evaluate_rigor_gate calls it: no matrix.
+        result = run_rigor_gate("s1", self._series(), num_trials=6)
+        cpcv = result.gate_details["cpcv"]
+        assert cpcv.startswith("NOT_RUN"), cpcv
+        assert "combinatorial" in cpcv.lower(), "the not-run reason must be surfaced"
+        assert cpcv != "MISSING", "no bare placeholder that implies a silent method"
+
+    def test_cpcv_label_is_not_a_fabricated_value(self):
+        # Anti-goal: the not-run label must not look like a computed CPCV verdict.
+        cpcv = run_rigor_gate("s1", self._series(), num_trials=6).gate_details["cpcv"]
+        assert not cpcv.startswith(("PASS", "FAIL")), "must not mimic a computed verdict"
+
+    def test_cpcv_not_run_stays_non_gating(self):
+        # CPCV is not enforced when absent: no positive_fraction is computed, so the
+        # NOT_RUN status cannot, by itself, flip pass/fail for the other criteria.
+        result = run_rigor_gate("s1", self._series(), num_trials=6)
+        assert result.cpcv_positive_fraction is None
+        assert isinstance(result.passes_all, bool)
 
 
 # ── Schema unit tests ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`/api/selection-bias/gate` advertised a `cpcv` field but every strategy reported a bare `"MISSING"` — a method named on the surface that silently produced no number, which violates the **claims-must-be-true** rule the rigor gate exists to enforce.

This takes **fork (b) "honest-scope"** from #771, scoped to CPCV only (the "A1" approach, agreed with the reviewer): when `run_rigor_gate` is called **without** a combinatorial OOS matrix — the live route's path, because the analytics-engine doesn't emit one yet and CPCV is mathematically invalid on a single static return series — the gate now reports an explicit:

```
NOT_RUN (no combinatorial OOS matrix supplied; CPCV is invalid on a single static return series)
```

Fixed at the **single source** (`rigor_evaluator.py`) so every caller of `run_rigor_gate` is honest, not just the one route. The two now-stale "reported as MISSING" comments in `selection_bias_routes.py` are updated to match.

## Deliberate non-goals
- **The literal `grep "MISSING" selection_bias_routes.py -> no match` acceptance is intentionally NOT met.** The `dsr/pbo/oos = "MISSING (no backtest data)"` labels are left untouched, because removing them collides with the issue's own anti-goal *"do not alter the existing DSR/library-PBO reporting."* So this resolves the CPCV-scoped honesty problem and leaves the other methods' (already-honest, data-scoped) labels alone.
- **Real CPCV (fork a) is out of scope** — it requires the analytics-engine to emit per-combinatorial-split OOS returns; synthesizing "paths" from one realized series is exactly the *"do not fabricate a CPCV number"* anti-goal.
- The no-data branch is unchanged: there every field is missing because there is no data (honest), which is not the "advertises a method it doesn't run" problem #771 targets.

## Verify
```
pytest backend/tests/test_selection_bias_routes.py -q -k cpcv      # 3 passed
pytest backend/tests/test_selection_bias_routes.py backend/tests/test_rigor_evaluator.py -q   # 209 passed
ruff format --check . && ruff check .
```
`TestCpcvHonestNotRun` covers: honest NOT_RUN label + reason, not-a-fabricated-value (anti-goal), and that CPCV stays non-gating when absent. Tested via `run_rigor_gate(...)` directly — the exact call the route makes (`selection_bias_routes.py:219`), a verified pass-through.

Fixes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo5BWX3Utm5BCeSZMcUyPS