### PR TITLE
[chain] Gate temporal-binding claim on real commit-reveal source (#714 Sub-task A)

### DIFF
--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -13,7 +13,9 @@ Convention:
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Literal
+
+from pydantic import BaseModel, model_validator
 
 # ═══════════════════════════════════════════════════════════════
 # Assets
@@ -261,6 +263,27 @@ class TraceResponse(BaseModel):
     trade_tx_hash: str | None = None
     trade_block_number: int | None = None
     temporal_binding_valid: bool | None = None
+    # Provenance of the temporal-binding claim (#714 / T0.3). "chain" only when the
+    # real commit-reveal path ran (an on-chain trace_id was minted); "none" otherwise
+    # (legacy publishTrace anchor, dry-run, or no commit recorded). The UI "Temporal
+    # Binding ✓ VERIFIED" badge must key off this, not a bare boolean from Redis.
+    temporal_binding_source: Literal["chain", "none"] = "none"
+
+    @model_validator(mode="after")
+    def _temporal_binding_requires_chain_source(self) -> TraceResponse:
+        """Claim-integrity guard (#714): temporal_binding_valid may only assert a
+        verified binding when it is backed by on-chain commit-reveal receipts.
+
+        Closes the audit finding (AUDIT_2026-06-14 #3) where the badge could read True
+        off a Redis boolean: regardless of what the persisted dict holds, a non-"chain"
+        source can never surface a True binding — it is coerced to None ("not applicable").
+        ``is_verified`` is deliberately left untouched: a publishTrace anchor is a genuine
+        on-chain hash confirmation, so reporting it verified is honest — only the stronger
+        *temporal* binding claim is gated here.
+        """
+        if self.temporal_binding_source != "chain" and self.temporal_binding_valid:
+            self.temporal_binding_valid = None
+        return self
 
 
 class TradeExecutedResponse(BaseModel):

--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -69,6 +69,7 @@ async def list_traces(
                         trade_tx_hash=t.get("trade_tx_hash"),
                         trade_block_number=t.get("trade_block_number"),
                         temporal_binding_valid=t.get("temporal_binding_valid"),
+                        temporal_binding_source=t.get("temporal_binding_source", "none"),
                     )
                 )
             return TraceListResponse(traces=traces, total=total)
@@ -147,6 +148,7 @@ async def get_trace(trace_id: str):
                 trade_tx_hash=off_chain.get("trade_tx_hash"),
                 trade_block_number=off_chain.get("trade_block_number"),
                 temporal_binding_valid=off_chain.get("temporal_binding_valid"),
+                temporal_binding_source=off_chain.get("temporal_binding_source", "none"),
             )
 
         try:

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -1034,15 +1034,25 @@ class StrategyRunner:
                 "is_verified": reveal_tx is not None,
                 # IPFS provenance pointer (T1.4)
                 "ipfs_cid": ipfs_cid,
-                # Temporal binding fields
+                # Temporal binding fields. The "chain" source — and any True binding —
+                # require the REAL commit-reveal path: trace_id is non-None ONLY when
+                # ReasoningTraceRegistry.commit() minted an on-chain id (the publishTrace
+                # fallback returns trace_id=None but still carries a commit_block from its
+                # receipt). Gating on trace_id stops a fallback anchor's blocks from
+                # masquerading as a verified temporal binding (#714 / AUDIT_2026-06-14 #3).
                 "commit_tx_hash": commit_tx,
                 "commit_block_number": commit_block,
                 "reveal_tx_hash": reveal_tx,
                 "reveal_block_number": reveal_block,
                 "trade_tx_hash": tx_hashes[0] if tx_hashes else None,
                 "trade_block_number": trade_block,
+                "temporal_binding_source": "chain" if trace_id is not None else "none",
                 "temporal_binding_valid": (
-                    commit_block is not None and trade_block is not None and commit_block < trade_block
+                    trace_id is not None
+                    and commit_block is not None
+                    and trade_block is not None
+                    and reveal_block is not None
+                    and commit_block < trade_block <= reveal_block
                 ),
             }
             await self.state.save_trace(off_chain_data)

--- a/backend/tests/test_agent_runner_commit_reveal.py
+++ b/backend/tests/test_agent_runner_commit_reveal.py
@@ -1,0 +1,180 @@
+"""Agent-tick commit-reveal wiring + claim-integrity tests (#714 / T0.3).
+
+Hermetic: the chain client, executor, trace_publisher, IPFS pin, provider, and state
+store are all mocked at the boundary (mirrors ``test_agent_runner.py``'s runner fixture).
+
+Covers:
+  - the reveal phase uses the real ``trace_publisher.reveal()`` (NOT publishTrace) when a
+    commit-reveal trace_id exists, and gracefully falls back to ``publish()`` when it does
+    not (pre-v1.5 registry, #588 still open);
+  - ``temporal_binding_source`` is "chain" ONLY on the real commit-reveal path, and the
+    persisted ``temporal_binding_valid`` requires commit < trade <= reveal block ordering;
+  - the TraceResponse schema guard can never surface a True binding without a chain source
+    (closes AUDIT_2026-06-14 #3 — the "Temporal Binding VERIFIED" badge off a Redis bool).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.models.trace import DecisionType, ReasoningTrace
+
+
+def _make_trace() -> ReasoningTrace:
+    trace = ReasoningTrace(
+        id="tick-trace-001",
+        vault_address="0x1234567890abcdef1234567890abcdef12345678",
+        decision_type=DecisionType.REBALANCE,
+        trigger="strategy_signal_drift",
+        timestamp=datetime.now(UTC),
+        reasoning="Agent tick commit-reveal test",
+        confidence=0.9,
+    )
+    trace.compute_hash()
+    return trace
+
+
+@pytest.fixture()
+def runner_env():
+    """A StrategyRunner with all chain boundaries mocked and the on-chain path armed."""
+    with (
+        patch("archimedes.chain.agent_runner.chain_client"),
+        patch("archimedes.chain.agent_runner.chain_executor"),
+        patch("archimedes.chain.agent_runner.trace_publisher") as mock_tp,
+        patch("archimedes.chain.agent_runner.default_provider"),
+        patch("archimedes.chain.agent_runner.AgentStateStore"),
+        patch("archimedes.chain.agent_runner.pin_public_provenance", new=AsyncMock(return_value=(None, None))),
+        patch("archimedes.chain.agent_runner.DRY_RUN", False),
+    ):
+        from archimedes.chain.agent_runner import StrategyRunner
+
+        runner = StrategyRunner()
+        runner.state = MagicMock()
+        runner.state.save_trace = AsyncMock()
+        yield runner, mock_tp
+
+
+def _saved(runner) -> dict:
+    return runner.state.save_trace.call_args[0][0]
+
+
+class TestRevealWiring:
+    def test_reveal_uses_commit_reveal_not_publish(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
+        mock_tp.publish = AsyncMock(return_value=None)
+
+        asyncio.run(
+            runner._reveal_trace(
+                _make_trace(),
+                trace_id=42,
+                tick_id="t1",
+                tx_hashes=["0xtrade"],
+                commit_tx="0xcommit",
+                commit_block=100,
+                trade_block=101,
+            )
+        )
+
+        mock_tp.reveal.assert_called_once()
+        mock_tp.publish.assert_not_called()  # the live path is commit-reveal, never publishTrace
+
+    def test_reveal_falls_back_to_publish_without_trace_id(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
+        mock_tp.publish = AsyncMock(return_value=None)
+
+        # trace_id None => pre-v1.5 registry path => graceful publishTrace fallback (#588).
+        asyncio.run(runner._reveal_trace(_make_trace(), trace_id=None, tick_id="t1", tx_hashes=["0xtrade"]))
+
+        mock_tp.publish.assert_called_once()
+        mock_tp.reveal.assert_not_called()
+
+
+class TestTemporalBindingPersistence:
+    def test_source_chain_and_valid_on_real_commit_reveal(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
+        mock_tp.publish = AsyncMock(return_value=None)
+
+        asyncio.run(
+            runner._reveal_trace(
+                _make_trace(),
+                trace_id=42,
+                tick_id="t1",
+                tx_hashes=["0xtrade"],
+                commit_tx="0xcommit",
+                commit_block=100,
+                trade_block=101,
+            )
+        )
+
+        saved = _saved(runner)
+        assert saved["temporal_binding_source"] == "chain"
+        # commit(100) < trade(101) <= reveal(102) -> a genuine, verified binding.
+        assert saved["temporal_binding_valid"] is True
+
+    def test_source_none_and_not_valid_on_fallback(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
+        mock_tp.publish = AsyncMock(return_value="0xPUB")
+
+        asyncio.run(
+            runner._reveal_trace(
+                _make_trace(),
+                trace_id=None,
+                tick_id="t1",
+                tx_hashes=["0xtrade"],
+                commit_tx=None,
+                commit_block=99,
+                trade_block=101,
+            )
+        )
+
+        saved = _saved(runner)
+        assert saved["temporal_binding_source"] == "none"
+        # No real commit-reveal trace_id -> binding cannot be asserted, even though
+        # a fallback commit_block exists (this is the exact masquerade #714 closes).
+        assert not saved["temporal_binding_valid"]
+
+
+class TestTraceResponseClaimGuard:
+    """The schema is the last line of defense against a stale Redis True binding."""
+
+    @staticmethod
+    def _resp(**kw):
+        from archimedes.api.schemas import TraceResponse
+
+        base = dict(
+            id="t",
+            vault_address="0xv",
+            decision_type="rebalance",
+            trigger="x",
+            timestamp="2026-06-29T00:00:00Z",
+            reasoning="r",
+            confidence=0.5,
+            trace_hash="ab",
+        )
+        base.update(kw)
+        return TraceResponse(**base)
+
+    def test_true_binding_coerced_to_none_without_chain_source(self):
+        r = self._resp(temporal_binding_valid=True, temporal_binding_source="none")
+        assert r.temporal_binding_valid is None  # cannot claim a binding off a non-chain source
+
+    def test_true_binding_preserved_with_chain_source(self):
+        r = self._resp(temporal_binding_valid=True, temporal_binding_source="chain")
+        assert r.temporal_binding_valid is True
+
+    def test_is_verified_left_honest(self):
+        # A publishTrace anchor is a genuine on-chain hash confirmation: is_verified stays
+        # honest even when the stronger temporal binding is absent.
+        r = self._resp(is_verified=True, temporal_binding_source="none")
+        assert r.is_verified is True

--- a/backend/tests/test_trace_publisher_commit_reveal.py
+++ b/backend/tests/test_trace_publisher_commit_reveal.py
@@ -1,0 +1,171 @@
+"""Commit-reveal path tests for TracePublisher (#714 / T0.3).
+
+Hermetic: no testnet, no Circle SDK, no real chain calls — circle_signer and the
+chain client / contract loader are mocked at the boundary, mirroring the precedent in
+``test_trace_publisher.py`` (per CLAUDE.md §"Mock at boundaries, not internals").
+
+Covers the real ``commit()`` / ``reveal()`` ABI calls the live agent path now uses,
+the trace_id parse from the ``TraceCommitted`` event, the ``claimedExecutionTime``
+argument, and the graceful fallback when the deployed registry is pre-v1.5 (#588).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.models.trace import DecisionType, ReasoningTrace
+
+
+def _make_trace(**overrides) -> ReasoningTrace:
+    defaults = {
+        "id": "test-trace-cr-001",
+        "vault_address": "0x1234567890abcdef1234567890abcdef12345678",
+        "decision_type": DecisionType.REBALANCE,
+        "trigger": "strategy_signal_drift",
+        "timestamp": datetime.now(UTC),
+        "reasoning": "Commit-reveal unit test trace",
+        "confidence": 0.85,
+    }
+    defaults.update(overrides)
+    return ReasoningTrace(**defaults)
+
+
+@pytest.fixture()
+def supported_loader():
+    """A loader whose registry ABI exposes commit()/reveal() (v1.5).
+
+    A bare MagicMock auto-creates the ``commit``/``reveal`` attributes, so
+    ``supports_commit_reveal()`` (which does ``hasattr(functions, "commit")``) is True.
+    The TraceCommitted event decode is stubbed to yield a deterministic trace_id.
+    """
+    loader = MagicMock()
+    loader.trace_registry = MagicMock()
+    loader.trace_registry.events.TraceCommitted.return_value.process_log.return_value = {"args": {"traceId": 42}}
+    return loader
+
+
+@pytest.fixture()
+def unsupported_loader():
+    """A loader whose registry has NO commit()/reveal() (pre-v1.5, #588 pending)."""
+    loader = MagicMock()
+    loader.trace_registry = MagicMock()
+    loader.trace_registry.functions = MagicMock(spec=[])  # hasattr(..., "commit") -> False
+    return loader
+
+
+def _patch_chain(mock_client):
+    mock_client.to_checksum = lambda x: x
+    mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
+    mock_client.w3.eth.get_transaction_receipt = AsyncMock(return_value=MagicMock(blockNumber=100, logs=[MagicMock()]))
+
+
+class TestCommit:
+    def test_commit_circle_path_calls_correct_abi(self, supported_loader):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xCOMMIT")
+            _patch_chain(mock_client)
+
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            publisher = TracePublisher(loader=supported_loader)
+            trace = _make_trace()
+            trace.compute_hash()
+            claimed = 2_000_000_000
+
+            trace_id, tx, block = asyncio.run(publisher.commit(trace, claimed, b"\x01"))
+
+            assert (trace_id, tx, block) == (42, "0xCOMMIT", 100)
+            _, kwargs = mock_signer.execute_contract.call_args
+            assert kwargs["abi_function"] == "commit(address,bytes32,uint64,bytes)"
+            # vault, contentHash, claimedExecutionTime (as str), intent
+            assert kwargs["abi_params"][0] == trace.vault_address
+            assert kwargs["abi_params"][2] == str(claimed)
+
+    def test_commit_parses_trace_id_from_event(self, supported_loader):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xCOMMIT")
+            _patch_chain(mock_client)
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            trace_id, _, _ = asyncio.run(TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000))
+            assert trace_id == 42  # decoded from TraceCommitted, not the getTracesByVault fallback
+
+    def test_commit_returns_none_when_registry_pre_v1_5(self, unsupported_loader):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            _patch_chain(mock_client)
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            result = asyncio.run(TracePublisher(loader=unsupported_loader).commit(trace, 2_000_000_000))
+            assert result == (None, None, None)
+
+
+class TestReveal:
+    def test_reveal_circle_path_calls_correct_abi(self, supported_loader):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xREVEAL")
+            _patch_chain(mock_client)
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            cid = "ipfs://bafytest"
+
+            reveal_tx, block = asyncio.run(
+                TracePublisher(loader=supported_loader).reveal(42, trace, storage_pointer=cid)
+            )
+
+            assert (reveal_tx, block) == ("0xREVEAL", 100)
+            _, kwargs = mock_signer.execute_contract.call_args
+            assert kwargs["abi_function"] == "reveal(uint256,string,bytes)"
+            assert kwargs["abi_params"][0] == "42"
+            assert kwargs["abi_params"][1] == cid  # the IPFS CID is the storage pointer
+
+    def test_reveal_returns_none_without_trace_id(self, supported_loader):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xREVEAL")
+            _patch_chain(mock_client)
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            assert asyncio.run(TracePublisher(loader=supported_loader).reveal(None, trace)) == (None, None)
+
+    def test_reveal_returns_none_when_registry_pre_v1_5(self, unsupported_loader):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            _patch_chain(mock_client)
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            assert asyncio.run(TracePublisher(loader=unsupported_loader).reveal(42, trace)) == (None, None)


### PR DESCRIPTION
## Summary
Closes the **claim-integrity** half of `AUDIT_2026-06-14` finding #3: the "Temporal Binding ✓ VERIFIED" badge could read `true` off a Redis boolean. On `main`, the reveal phase derived `temporal_binding_valid` from `commit_block < trade_block` alone — but on the **publishTrace fallback** a `commit_block` is populated while `trace_id` is `None`, so a fallback anchor's block numbers could **masquerade as a verified on-chain commit-reveal binding**.

This is the claim-integrity slice of **Sub-task A** — **no contract changes**, and the load-bearing fallbacks are intentionally preserved (see below).

## Changes
- **`schemas.py`** — add `temporal_binding_source: Literal["chain","none"]` to `TraceResponse` + a `model_validator` that coerces a truthy `temporal_binding_valid` to `None` whenever the source isn't `"chain"`. So **no stale/persisted value can surface a binding without on-chain commit-reveal receipts.** `is_verified` is deliberately left honest — a `publishTrace` anchor is a genuine on-chain hash confirmation; only the stronger *temporal* claim is gated.
- **`agent_runner.py`** — `temporal_binding_source = "chain"` only when a real commit-reveal `trace_id` was minted; `temporal_binding_valid` tightened to require `trace_id` present **and** `commit_block < trade_block <= reveal_block`.
- **`traces_routes.py`** — surface `temporal_binding_source` on the list + detail responses.

## Tests (13, all green; hermetic)
`test_trace_publisher_commit_reveal.py` (6) — `commit()`/`reveal()` ABI sigs, trace_id parse from `TraceCommitted`, `claimedExecutionTime`, pre-v1.5 fallback. `test_agent_runner_commit_reveal.py` (7) — tick uses commit-reveal not publishTrace (and falls back gracefully without a trace_id), source/valid persistence, and the schema guard.

```
pytest backend/tests/test_trace_publisher_commit_reveal.py backend/tests/test_agent_runner_commit_reveal.py -q   # 13 passed
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_trace_publisher_commit_reveal.py -q   # 6 passed (hermetic)
ruff format --check . && ruff check --select E9,F63,F7,F40,F82 .
```
Regression: `test_trace_publisher.py`, `test_provenance_ipfs.py`, `test_agent_runner.py`, `test_api_routes.py` all pass (2 pre-existing skips unrelated).

## Deliberately NOT done (reviewer note)
- **The "0 `trace_publisher.publish(` calls" anti-goal gate is NOT met (still 3) — by design.** They are graceful-degradation fallbacks for the **pre-v1.5 deployed registry**; removing them regresses live anchoring until **#588** redeploys the commit-reveal contract. That gate should land **with #588**.
- Sub-task B (IPFS) equivalent already exists (`chain/provenance_publisher.py` + `test_provenance_ipfs.py`); Sub-task C (mnemonik memo) is owner-only.
- `TraceVerifyResponse` (the `/verify` surface) not guarded — different surface; the persisted value is now honest at the source.

**Part of #714 (Sub-task A — claim-integrity slice). Intentionally does NOT close the umbrella** (Sub-tasks B/C + the 0-publish gate remain).

cc @dbrowneup (contract-adjacent integration review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo5BWX3Utm5BCeSZMcUyPS