### PR TITLE
[quant] Deflate DSR by N + library_size on the society path (#770)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -485,6 +485,7 @@ async def _run_fixture_candidate(
     emit: _Emitter,
     regime: str = "neutral",
     agent: Any = None,  # noqa: ARG001 — signature parity with _run_live_candidate; fixture path ignores it
+    selection_pool_size: int = 1,  # noqa: ARG001 — signature parity; fixture path computes no DSR num_trials
 ) -> _CandidateResult:
     """Synthetic generation that exercises every event the live agent emits.
 
@@ -587,8 +588,25 @@ _REGIME_PROMPT_SUFFIX = {
 }
 
 
+def _society_num_trials(library_size: int, selection_pool_size: int) -> int:
+    """Effective DSR multiple-testing trial count on the agentic society path (#770).
+
+    The winner survived selection from ``selection_pool_size`` (N) generated candidates
+    AND is promoted into a library of ``library_size`` — two independent selection layers,
+    so the deflation count is their SUM (approach A, Bailey & López de Prado 2014). See
+    ``docs/specs/selection-bias-corrections-spec.md`` § 1.3 addendum. Floored at 1.
+    """
+    return max(1, library_size + selection_pool_size)
+
+
 async def _run_live_candidate(
-    *, candidate_id: str, brief: GenerateBrief, emit: _Emitter, regime: str = "neutral", agent: Any = None
+    *,
+    candidate_id: str,
+    brief: GenerateBrief,
+    emit: _Emitter,
+    regime: str = "neutral",
+    agent: Any = None,
+    selection_pool_size: int = 1,
 ) -> _CandidateResult:
     """Drive the real ``portfolio_agent`` with per-iteration event emission.
 
@@ -705,7 +723,15 @@ async def _run_live_candidate(
     # primitive is computed from referenced curated source and gates `passing`.
     return_series = _portfolio_return_series(weights, price_histories)
     lookahead_passed = _lookahead_for_candidate(referenced_strategies)
-    verdict = _rigor_verdict_for(return_series, num_trials=max(1, len(strategies)), lookahead_passed=lookahead_passed)
+    # num_trials = selection-from-N candidates + library context (#770). The agentic
+    # society generates `selection_pool_size` candidates, backtests all, and keeps the
+    # best — selection-from-N is itself a multiple-testing search, so the DSR must be
+    # deflated for BOTH that pool AND the library the winner joins, not the library
+    # alone (which understated deflation and inflated the survivor's DSR). Additive
+    # N + library_size per the selection-bias-corrections spec § 1.3 (Bailey & López de
+    # Prado 2014); the correction can only make the gate stricter. (Önder's call — A.)
+    num_trials = _society_num_trials(len(strategies), selection_pool_size)
+    verdict = _rigor_verdict_for(return_series, num_trials=num_trials, lookahead_passed=lookahead_passed)
     # Derive meaningful name + thesis from the brief and agent output (#299)
     top_picks = sorted(weights.items(), key=lambda x: -x[1])[:3]
     pick_summary = " / ".join(t for t, _ in top_picks)
@@ -761,6 +787,7 @@ async def _run_fusion_candidate(
     emit: _Emitter,
     regime: str = "neutral",
     agent: Any = None,  # noqa: ARG001 — signature parity with _run_live_candidate; fusion path builds its own client
+    selection_pool_size: int = 1,  # noqa: ARG001 — signature parity; fusion candidates skip the static DSR path
 ) -> _CandidateResult:
     """Drive the existing fusion engine with per-step streaming event emission.
 
@@ -1123,6 +1150,7 @@ async def run_generation(
                     emit=emit,
                     regime=regime,
                     agent=job_agent,
+                    selection_pool_size=n_candidates,  # #770: DSR deflates for the N-candidate search
                 )
             except FusionUnavailable as exc:
                 # Fusion was selected + precheck passed, but at runtime the
@@ -1143,6 +1171,7 @@ async def run_generation(
                         emit=emit,
                         regime=regime,
                         agent=job_agent,  # preserve the user's free-tier model pick on fallback (#748)
+                        selection_pool_size=n_candidates,  # #770: DSR deflates for the N-candidate search
                     )
                 except Exception as exc2:
                     logger.exception("agent fallback %s (%s) failed: %s", candidate_id, regime, exc2)
@@ -1253,7 +1282,10 @@ async def run_generation(
         # static backtester on a fusion candidate that has nothing static to run.
         await asyncio.gather(
             *[
-                _backtest_and_persist(c, strategy_ids[c.candidate_id], emit, library_size)
+                # num_trials = N candidates + library context (#770), not library alone.
+                _backtest_and_persist(
+                    c, strategy_ids[c.candidate_id], emit, _society_num_trials(library_size, n_candidates)
+                )
                 for c in candidates
                 if c.generation_method != "fusion"
             ]
@@ -1428,8 +1460,9 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         c: The candidate that was just persisted.
         strategy_id: The DB id returned by :func:`_persist_candidate`.
         emit: The SSE emitter to surface backtest progress to the UI.
-        num_trials: Curated-library size, fed to ``backtest_portfolio`` as
-            ``num_trials_for_dsr`` for the DSR multiple-testing correction.
+        num_trials: Effective trial count for the DSR multiple-testing correction —
+            N generated candidates + curated-library size on the society path (#770),
+            fed to ``backtest_portfolio`` as ``num_trials_for_dsr``.
     """
     # Fixture mode (offline tests, no-LLM environments) — skip the network
     # round-trip. The test suite covers this function's behavior via direct
@@ -1472,9 +1505,10 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         from archimedes.services.portfolio_backtester import backtest_portfolio
 
         # Run the actual backtest. Raises on insufficient data / fetch failure.
-        # num_trials_for_dsr = curated-library size (selection-bias-corrections-
-        # spec.md § 1.3) — the DSR multiple-testing correction for the selection
-        # set this candidate was chosen from, not the default of 1.
+        # num_trials_for_dsr = N candidates + curated-library size (#770,
+        # selection-bias-corrections-spec.md § 1.3) — the DSR multiple-testing
+        # correction for the full selection set: the N-candidate society search
+        # this winner survived PLUS the library it joins, not library alone.
         result, artifact = backtest_portfolio(
             strategy_id=strategy_id,
             weights=c.weights,

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -174,6 +174,10 @@ async def evaluate_rigor_gate():
     valid_returns = {k: v for k, v in returns_by_strategy.items() if len(v) >= 10}
     pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
 
+    # num_trials = library size here (#770). This route grades the EXISTING persisted
+    # library, so the selection set is the library itself — there is no fresh
+    # N-candidate society pool to add (that additive correction, N + library_size,
+    # applies only on the live society generation path in generation_pipeline.py).
     num_trials = max(len(valid_returns), 1)
 
     # The strategy library is the multiple-testing selection set; correlated

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -1,0 +1,59 @@
+"""num_trials multiple-testing correction for the N-candidate society (#770).
+
+Hermetic: pure math over seeded return series — no LLM, no chain, no DB.
+
+The agentic society generates N candidates, backtests + rigor-gates all, and keeps the
+best. Selection-from-N is itself a multiple-testing search, so the Deflated Sharpe Ratio
+must deflate for N + library_size, not library alone (which under-deflated and inflated
+the survivor's DSR). These tests pin the chosen formula (approach A) and prove the
+correction rejects a best-of-N survivor that the library-only count would have admitted.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from archimedes.agents.generation_pipeline import _rigor_verdict_for, _society_num_trials
+
+
+class TestSocietyNumTrialsFormula:
+    def test_is_n_plus_library(self):
+        # Approach A: N candidates + library context.
+        assert _society_num_trials(library_size=4, selection_pool_size=20) == 24
+        assert _society_num_trials(library_size=10, selection_pool_size=10) == 20
+
+    def test_single_candidate_adds_one(self):
+        # N=1 (one generated candidate) is still a real trial on top of the library.
+        assert _society_num_trials(library_size=4, selection_pool_size=1) == 5
+
+    def test_floored_at_one(self):
+        assert _society_num_trials(library_size=0, selection_pool_size=0) == 1
+
+
+class TestNumTrialsCorrection:
+    # A seeded series with a real positive edge whose DSR p-value brackets the 0.95 gate
+    # between library-only (4) and society (library+N = 4+20 = 24). OOS is identical at
+    # both counts, so the ONLY thing that flips the verdict is the num_trials deflation.
+    _MU, _SD, _N, _SEED = 0.0009, 0.009, 300, 4
+
+    def _series(self):
+        return list(np.random.default_rng(self._SEED).normal(self._MU, self._SD, self._N))
+
+    def test_num_trials_overfit_survivor_fails_society_path(self):
+        """A best-of-N survivor that passes the library-only count FAILS once the society
+        correction (N + library_size) deflates it — the exact selection bias #770 closes."""
+        series = self._series()
+        library_only = _rigor_verdict_for(series, num_trials=4, lookahead_passed=True)
+        society = _rigor_verdict_for(series, num_trials=_society_num_trials(4, 20), lookahead_passed=True)
+
+        assert library_only["passing"] is True, "fixture must pass under the (wrong) library-only count"
+        assert society["passing"] is False, "society N+library correction must reject the inflated survivor"
+        # The flip is the DSR deflation, not OOS: OOS Sharpe is identical at both counts.
+        assert library_only["oos_sharpe"] == society["oos_sharpe"]
+        assert society["dsr_p_value"] < library_only["dsr_p_value"]
+
+    def test_dsr_pvalue_monotonic_stricter_in_trials(self):
+        """More trials can only deflate harder — the property the additive count relies on."""
+        series = self._series()
+        p_small = _rigor_verdict_for(series, num_trials=4, lookahead_passed=True)["dsr_p_value"]
+        p_large = _rigor_verdict_for(series, num_trials=24, lookahead_passed=True)["dsr_p_value"]
+        assert p_large <= p_small

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -120,6 +120,42 @@ the candidate pool size from the most recent extraction pass, not the
 library size — the LLM tried K methodology variants and we picked the best.
 This will be wired in T5 (post-hackathon if not reached).
 
+#### Addendum (#770) — the agentic society path: N + library_size
+
+The agentic society (PR #766) generates **N candidates** (`n_candidates`), backtests
+**all** of them, rigor-gates **all**, and keeps the **best**. Selection-from-N is itself
+a multiple-testing search distinct from the library context the winner then joins, so the
+effective trial count on the society path is the **sum**:
+
+```
+num_trials = n_candidates + library_size            # the chosen formula (A)
+```
+
+**Rationale.** The survivor was chosen through two independent selection layers — it beat
+`n_candidates - 1` siblings in the society round *and* it is being promoted into a library
+of `library_size` prior strategies. Both are searches over which the maximum was taken, so
+both inflate the observed Sharpe under the Bailey & López de Prado (2014) best-of-N null;
+the additive count is the conservative, defensible deflation. It can only make the gate
+**stricter** (anti-goal compliant): with `n_candidates ≥ 1` it is always `≥ library_size`,
+the prior (under-deflating) value.
+
+**Why not effective-N (correlation-adjusted) here.** `compute_dsr` already accepts an
+`average_correlation` and can deflate by effective *independent* trials
+`N_eff = N / (1 + (N-1)ρ̄)` — the principled refinement when candidates are correlated
+(same brief, overlapping universes). We deliberately ship the **simple additive count
+first** (smaller blast radius, strictly conservative) and leave the candidate-pool
+correlation correction as a follow-up; over-deflation (treating correlated candidates as
+independent) only *tightens* the gate, never loosens it, so the simple form is safe to ship.
+
+**Scope note.** This additive correction applies to the **live society generation path**
+(`agents/generation_pipeline.py`). The `/api/selection-bias/gate` route grades the
+**existing persisted library**, where the selection set is the library itself — there is no
+fresh candidate pool, so that route keeps `num_trials = library_size`.
+
+> **Owner sign-off:** the choice of formula (additive A vs. effective-N B) is Önder's
+> statistics call. This addendum records approach **A** as the shipped default pending his
+> review; promoting to B is a follow-up if candidate-pool over-deflation proves material.
+
 ## 2. Probability of Backtest Overfitting (PBO)
 
 **Reference:** Bailey, D. H., Borwein, J., López de Prado, M., & Zhu, J.


### PR DESCRIPTION
## Summary
Under the agentic society (PR #766), ~**N candidates** are generated, **all** backtested + rigor-gated, and the **best** selected — but DSR's `num_trials` was the **library size alone** (`agents/generation_pipeline.py:708`, `:1256`). Selection-from-N is itself a multiple-testing search, so this **under-deflated** the survivor's Sharpe and inflated its DSR — the exact selection bias the Tier-1 gate exists to prevent.

**Approach A** (the additive count): `num_trials = N + library_size`. The winner survived two independent selection layers (the N-candidate society round + the library it joins), so the deflation count is their sum. Conservative and **strictly stricter** than the prior library-only value (anti-goal compliant — never looser).

> ⚖️ **This is @onder-akkaya's statistics call.** I'm shipping **approach A** (simple, conservative, smallest blast radius) as a proposal for his sign-off. The correlation-adjusted **effective-N (B)** — `N_eff = N/(1+(N-1)ρ̄)`, for which `compute_dsr` already has the machinery — is documented as a follow-up if candidate-pool over-deflation proves material. **Does not auto-close #770** pending his review.

## Changes
- New `_society_num_trials(library_size, selection_pool_size)` helper, used at **both** derivation sites — no orphaned literal.
- `selection_pool_size=n_candidates` threaded into the candidate runners (the existing signature-parity convention; only the live runner computes a DSR verdict).
- `/api/selection-bias/gate` route left **library-based** (it grades the persisted library — there's no fresh candidate pool), documented inline.
- `docs/specs/selection-bias-corrections-spec.md` § 1.3 **addendum**: formula, rationale, citation (Bailey & López de Prado 2014), and the A-vs-B note.

## Tests (5; the load-bearing one)
`test_num_trials_overfit_survivor_fails_society_path`: a seeded best-of-N survivor **passes** at the library-only count (DSR p=0.977) but **fails** at the society count `N+library` (p=0.861) — **OOS identical at both**, so the flip is purely the num_trials deflation. Plus the formula helper + DSR-p monotonicity.

```
pytest backend/tests/test_generation_pipeline.py -q                 # 5 passed
pytest backend/tests/ -k "num_trials and overfit" -q                # 1 passed
ruff format --check . && ruff check --select E9,F63,F7,F40 .
```
Regression: `selection_bias_routes` + `rigor_evaluator` (206) and `services/test_generation_pipeline.py` (runner wiring) all pass.

## Note
The single-candidate (K=1) path now yields `library+1` (was `library`) — minor, stricter, documented.

**Part of #770** (approach A pending Önder's sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo5BWX3Utm5BCeSZMcUyPS