### PR TITLE
[contracts] SyntheticVault: RedemptionHaircut event + dedup pro-rata cap (#588 item 4)

### DIFF
--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -42,6 +42,10 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     event Burned(address indexed user, uint256 synthIn, uint256 usdcOut, uint256 fee);
     event CollateralRatioUpdated(uint256 oldRatio, uint256 newRatio);
     event FeesCollected(uint256 amount);
+    /// @notice Emitted when a redemption is scaled down by the pro-rata solvency cap
+    ///         (collateral C < liability L). `grossValue` is the uncapped current-price
+    ///         claim; `cappedValue` is the C/L-scaled payout (haircut = gross - capped).
+    event RedemptionHaircut(address indexed user, uint256 grossValue, uint256 cappedValue);
 
     // ─── Errors ──────────────────────────────────────────────────────
 
@@ -124,14 +128,12 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
 
         // Pro-rata solvency cap: under stress, scale the claim by C/L so redemption
-        // order cannot redistribute value between holders (see @dev above).
-        // Safe subtraction: protocolFees should never exceed balance, but fee rounding
-        // over many small operations could cause a transient underflow; clamp to 0.
-        uint256 _burnBal = usdc.balanceOf(address(this));
-        uint256 available = _burnBal > protocolFees ? _burnBal - protocolFees : 0;
-        uint256 totalLiability = (synthToken.totalSupply() * assetPrice) / (10 ** SYNTH_DECIMALS);
-        if (totalLiability > available) {
-            usdcValue = (usdcValue * available) / totalLiability;
+        // order cannot redistribute value between holders (see @dev above + _applySolvencyCap).
+        uint256 grossValue = usdcValue;
+        bool haircutApplied;
+        (usdcValue, haircutApplied) = _applySolvencyCap(usdcValue, assetPrice);
+        if (haircutApplied) {
+            emit RedemptionHaircut(msg.sender, grossValue, usdcValue);
         }
 
         uint256 fee = (usdcValue * burnFeeBps) / BPS;
@@ -149,6 +151,27 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
 
         emit Burned(msg.sender, synthAmount, usdcOut, fee);
         return usdcOut;
+    }
+
+    /// @dev Apply the pro-rata solvency cap to a redemption's gross USDC claim. Under
+    ///      stress (total liability L > available collateral C) the claim is scaled by
+    ///      C/L so redemption order cannot redistribute value between holders (audit
+    ///      #509). Shared verbatim by burn() and previewBurn() so preview == actual.
+    ///      Returns the (possibly capped) value and whether the cap bound. Safe
+    ///      subtraction: protocolFees should never exceed balance, but fee rounding over
+    ///      many small operations could cause a transient underflow; clamp to 0.
+    function _applySolvencyCap(uint256 usdcValue, uint256 assetPrice)
+        internal
+        view
+        returns (uint256 cappedValue, bool haircutApplied)
+    {
+        uint256 bal = usdc.balanceOf(address(this));
+        uint256 available = bal > protocolFees ? bal - protocolFees : 0;
+        uint256 totalLiability = (synthToken.totalSupply() * assetPrice) / (10 ** SYNTH_DECIMALS);
+        if (totalLiability > available) {
+            return ((usdcValue * available) / totalLiability, true);
+        }
+        return (usdcValue, false);
     }
 
     // ─── Views ───────────────────────────────────────────────────────
@@ -169,13 +192,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
 
         // Mirror burn()'s pro-rata solvency cap so preview == actual under stress.
-        // Safe subtraction: clamp to 0 in the contrived case protocolFees > balance.
-        uint256 _previewBal = usdc.balanceOf(address(this));
-        uint256 available = _previewBal > protocolFees ? _previewBal - protocolFees : 0;
-        uint256 totalLiability = (synthToken.totalSupply() * assetPrice) / (10 ** SYNTH_DECIMALS);
-        if (totalLiability > available) {
-            usdcValue = (usdcValue * available) / totalLiability;
-        }
+        (usdcValue, ) = _applySolvencyCap(usdcValue, assetPrice);
 
         uint256 fee = (usdcValue * burnFeeBps) / BPS;
         return usdcValue - fee;

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -438,6 +438,54 @@ contract SyntheticVaultTest is Test {
         assertEq(payout, expected, "full price value when solvent");
     }
 
+    /// @dev Under stress the pro-rata cap binds, so burn() emits RedemptionHaircut with
+    ///      the redeemer indexed and grossValue > cappedValue (the haircut magnitude).
+    function test_burn_emits_RedemptionHaircut_under_stress() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synthOut = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        oracle.forceSetPrice((INITIAL_PRICE * 150) / 100); // +50% -> C < L
+
+        vm.recordLogs();
+        vm.prank(alice);
+        vault.burn(synthOut);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("RedemptionHaircut(address,uint256,uint256)");
+        bool found;
+        for (uint256 i; i < logs.length; i++) {
+            if (logs[i].topics[0] == sig) {
+                found = true;
+                assertEq(address(uint160(uint256(logs[i].topics[1]))), alice, "redeemer indexed");
+                (uint256 gross, uint256 capped) = abi.decode(logs[i].data, (uint256, uint256));
+                assertGt(gross, capped, "haircut reduces the payout");
+            }
+        }
+        assertTrue(found, "RedemptionHaircut emitted when the cap binds");
+    }
+
+    /// @dev When healthy (cap inactive) burn() must NOT emit RedemptionHaircut.
+    function test_burn_no_RedemptionHaircut_when_healthy() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synthOut = vault.mint(usdcAmount);
+
+        vm.recordLogs();
+        vault.burn(synthOut);
+        vm.stopPrank();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("RedemptionHaircut(address,uint256,uint256)");
+        for (uint256 i; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != sig, "no haircut event when solvent");
+        }
+    }
+
     /// @dev previewBurn must mirror burn exactly while the haircut is active.
     function test_preview_burn_matches_under_stress() public {
         uint256 usdcAmount = 10_000 * 10**6;


### PR DESCRIPTION
## Summary
The two "fold-in-at-redeploy" SyntheticVault cleanups from the #582 review — **#588 scope item 4** — with **no behavior change** to the audit-verified solvency math.

1. **Dedup the pro-rata solvency cap.** It was duplicated verbatim between `burn()` and `previewBurn()`. Extracted into an internal `_applySolvencyCap(usdcValue, assetPrice) → (cappedValue, haircutApplied)`, so preview can never drift from actual. The capped-value arithmetic is **byte-identical** to the prior inline code (audit #509).
2. **Emit `RedemptionHaircut(address indexed user, uint256 grossValue, uint256 cappedValue)`** from `burn()` **only when the cap binds** — observability for indexers/UI to surface a stress redemption. `previewBurn()` (view) ignores the flag.

## Tests
`forge test --match-contract SyntheticVault` → **40 passed** (the 38 pre-existing — including the audit-#509 pro-rata and preview-mirror tests — unchanged + green, plus two new ones):
- `test_burn_emits_RedemptionHaircut_under_stress` — under +50% price stress the cap binds; asserts the event fires with the redeemer indexed and `gross > capped`.
- `test_burn_no_RedemptionHaircut_when_healthy` — no event when solvent.

Full `forge test` suite: **225/225 passed** — the dedup broke nothing downstream.

## Deliberately NOT done
- **`contracts/abis/SyntheticVault.json` is untouched** — per CLAUDE.md the cached ABIs mirror the **LIVE (pre-redeploy)** deployment; the ABI refresh is **#588 item 2**, done at the redeploy (the new event can't fire until then anyway).
- No deploy — that's #588 items 1/5 (Dan).
- No `forge fmt` canonical reformat (the repo uses `10**6` style; matched it to avoid churning the file).

## ⚠️ Review gate
This is a Solidity change to a **deployed, funds-holding** contract. Per CLAUDE.md it **requires @dbrowneup's explicit owner approval to merge**, and it only takes effect at the **#588 redeploy**. I (mnemonik-dev, contract reviewer) implemented + validated it with Foundry; **please do not merge without Dan's sign-off.**

**Part of #588 (item 4)** — does not close the umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo5BWX3Utm5BCeSZMcUyPS