### PR TITLE
[infra] Fix deploy runner syntax: bare apostrophe broke the SSM command blob

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
               "# hits a name Conflict and fails the whole deploy (run 28382331990: the",
               "# oracle orphan fbdabd2fa619_archimedes-oracle-1). The prior",
               "# `docker ps --filter name=^...` never matched it because the filter anchor",
-              "# is unreliable against Docker's internal slash-prefixed names (/<hex>_...).",
+              "# is unreliable against the slash-prefixed names Docker stores (/<hex>_...).",
               "# Grep the clean `--format {{.Names}}` output (no leading slash) so ^ fires.",
               "docker ps -a --format '"'"'{{.Names}}'"'"' | grep -E '"'"'^[0-9a-f]+_archimedes-'"'"' | xargs -r docker rm -f 2>/dev/null || true",
               "docker compose up -d --force-recreate --remove-orphans",


### PR DESCRIPTION
Follow-up hotfix to #813.

#813 fixed the orphan-cleanup logic, but its explanatory **comment** contained `Docker's` — a bare apostrophe inside the shell-level `commands='[...]'` single-quoted blob. That apostrophe prematurely closes the single quote, exposing the `(` later on the line to the runner shell:

```
/home/runner/work/_temp/...sh: line 35: syntax error near unexpected token '('
```

So deploy [run 28393141604](https://github.com/a-apin/archimedes/actions/runs/28393141604) **fast-failed on the GitHub runner** before reaching the EC2 box. The stuck orphan and undeployed main persist — **site stayed up on the old containers, no outage.**

Why #813 missed it: YAML-validation passes (it's a valid double-quoted YAML string), and the `bash -n` I ran covered only the resolved *cleanup command*, not the *comment* line where the break is.

## Fix
Reworded the comment to drop the apostrophe (`Docker's` → `Docker stores`).

## Validation (the gap #813 had)
Extracted the **entire `run:` block** (the actual runner script) via the YAML parser and ran `bash -n` on the whole thing → **passes**. That is precisely the check that failed in CI, so it now directly covers the SSM-blob quoting.

Merging this triggers the deploy that finally self-heals (orphan cleanup runs + pandas resolves + recreate succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)