### PR TITLE
feat: debate society as flag-gated generation pipeline (additive, deterministic-critic) !minor

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -404,7 +404,9 @@ def _critic_prov(pool: list[Any], corpus: list[Any]) -> tuple[list[Any], list[An
     kept: list[Any] = []
     dropped: list[Any] = []
     for prop in pool:
-        cited = set(prop.source_arxiv_ids)
+        # Robust to a proposal missing/None source_arxiv_ids — treat as empty (→ drop,
+        # "not provenance-verifiable"), never raise and abort the whole run (Copilot review).
+        cited = set(getattr(prop, "source_arxiv_ids", None) or [])
         if cited and cited <= surface:
             kept.append(prop)
         else:
@@ -542,11 +544,14 @@ def _critic_regime() -> dict[str, Any]:
     }
     try:
         from archimedes.models.regime import Regime
-        from archimedes.services.gmm_regime_detector import GmmRegimeDetector, gmm_regime_health
+        from archimedes.services.gmm_regime_detector import current_regime, gmm_regime_health
 
         health = gmm_regime_health()
         degraded = health.status != "live"
-        rc = GmmRegimeDetector().get_current_regime()
+        # Read the SHARED live detector (the one the oracle/agent runner feeds), NOT a
+        # fresh GmmRegimeDetector — a new instance has no current classification, so it
+        # would always read None and the gate would never fire (Copilot review).
+        rc = current_regime()
         regime = rc.regime if rc is not None else None
         confidence = float(rc.confidence) if rc is not None else 0.0
         force_abstain = regime == Regime.CRISIS

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -279,18 +279,26 @@ async def _propose_pool(brief: GenerateBrief, model: str | None, corpus: list[An
 # ── Step 2 — best-effort adversarial round (transcript only, never gates) ─────
 
 _DEBATE_SYSTEM = (
-    "You are the {role} researcher in a quant strategy debate. {stance}. "
-    "Cite ONLY the listed candidate strategies. Reply with ONE JSON object: "
-    '{{"verdict": "act"|"decline", "confidence": <0..1>, "key_claims": [<str>...]}}.'
+    "You are the {role} researcher in a quant strategy debate, round {rnd}. {stance}. "
+    "Cite ONLY the listed candidate strategies. {rebuttal}"
+    'Reply with ONE JSON object: {{"verdict": "act"|"decline", "confidence": <0..1>, "key_claims": [<str>...]}}.'
 )
+
+_DEBATE_STANCES = {
+    "bull": "Argue FOR acting on the strongest candidate",
+    "bear": "Argue for ABSTENTION — the null is buy-and-hold; attack overfit/cost",
+}
 
 
 async def _debate_round(pool: list[Any], model: str | None, emit: _Emitter, candidate_id: str) -> list[dict[str, Any]]:
-    """Thin best-effort bull/bear round — transcript only, never gates (Phase 1).
+    """Best-effort bull/bear research debate with ONE visible rebuttal round.
 
-    Surfaces the adversarial topology on the SSE stream. Any failure (no backend,
-    unparseable output) degrades to a neutral transcript entry. The transcript is
-    built in fixed [bull, bear] role order for R3 determinism (sort-before-hash).
+    Round 1: bull + bear state initial positions. Round 2: each REBUTS the other's
+    round-1 claims (the visible adversarial turn — the "debate" the roadmap names).
+    Transcript ONLY — it never gates; the deterministic critics do the real culling.
+    Built in fixed ``[bull-r1, bear-r1, bull-r2, bear-r2]`` order for R3 determinism
+    (sort-before-hash). Any failure (no backend, unparseable output) degrades to a
+    neutral entry; the whole round is skipped if no backend is available.
     """
     from archimedes.agents.strategy_architect import extract_json
     from archimedes.services.llm_backend import make_llm_backend
@@ -305,28 +313,43 @@ async def _debate_round(pool: list[Any], model: str | None, emit: _Emitter, cand
     if not getattr(backend, "available", False):
         return transcript
 
-    for role, stance in (
-        ("bull", "Argue FOR acting on the strongest candidate"),
-        ("bear", "Argue for ABSTENTION — the null is buy-and-hold; attack overfit/cost"),
-    ):
-        await emit.emit(
-            "tool_called",
-            candidate_id=candidate_id,
-            tool_name=f"debate_{role}",
-            args_summary=f"candidates: {names[:120]}",
-        )
-        try:
-            raw = await asyncio.to_thread(backend.complete, _DEBATE_SYSTEM.format(role=role, stance=stance), names)
-            parsed = extract_json(raw)
-            transcript.append(
-                {
-                    "role": role,
-                    "verdict": str(parsed.get("verdict", "n/a")),
-                    "claims": list(parsed.get("key_claims") or parsed.get("fatal_flaws") or []),
-                }
+    def _turn(role: str, rnd: int, opponent_claims: list[str]) -> dict[str, Any]:
+        rebuttal = ""
+        if opponent_claims:
+            rebuttal = (
+                f"The opposing researcher argued: {'; '.join(str(c) for c in opponent_claims[:3])}. "
+                "Directly rebut their strongest point. "
             )
+        try:
+            raw = backend.complete(
+                _DEBATE_SYSTEM.format(role=role, rnd=rnd, stance=_DEBATE_STANCES[role], rebuttal=rebuttal),
+                names,
+            )
+            parsed = extract_json(raw)
+            return {
+                "role": role,
+                "round": rnd,
+                "verdict": str(parsed.get("verdict", "n/a")),
+                "claims": list(parsed.get("key_claims") or parsed.get("fatal_flaws") or []),
+            }
         except Exception:
-            transcript.append({"role": role, "verdict": "n/a", "claims": []})
+            return {"role": role, "round": rnd, "verdict": "n/a", "claims": []}
+
+    # Round 1 — initial positions (fixed bull→bear order).
+    for role in ("bull", "bear"):
+        await emit.emit(
+            "tool_called", candidate_id=candidate_id, tool_name=f"debate_{role}_r1", args_summary=names[:120]
+        )
+        transcript.append(await asyncio.to_thread(_turn, role, 1, []))
+
+    # Round 2 — visible rebuttal: each researcher sees the other's round-1 claims.
+    claims_by_role = {t["role"]: t["claims"] for t in transcript}
+    for role, opponent in (("bull", "bear"), ("bear", "bull")):
+        await emit.emit(
+            "tool_called", candidate_id=candidate_id, tool_name=f"debate_{role}_r2", args_summary="rebuttal"
+        )
+        transcript.append(await asyncio.to_thread(_turn, role, 2, claims_by_role.get(opponent, [])))
+
     return transcript
 
 

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -455,6 +455,7 @@ async def _run_debate_candidate(
     regime: str = "neutral",
     agent: Any = None,  # noqa: ARG001 — signature parity with the other runners
     model: str | None = None,
+    selection_pool_size: int = 1,  # noqa: ARG001 — parity with the #770 runner contract; the debate computes its OWN pool_size (the real selection count) internally
 ) -> _CandidateResult:
     """Run the debate society once and return the leader ``_CandidateResult``.
 
@@ -463,6 +464,12 @@ async def _run_debate_candidate(
     the Considered-Alternatives fan-out is Phase 2. Raises ``DebateUnavailable``
     (a ``FusionUnavailable`` subclass) when no candidate survives, so the existing
     run_generation fallback relabels to the agent path.
+
+    ``selection_pool_size`` is accepted for parity with the #770 runner contract
+    (the dispatch threads it to every runner), but the society ignores the passed
+    value and uses its OWN internally-computed ``pool_size = len(POOL)`` — the
+    actual count of conformant proposed specs, which is the correct DSR
+    selection set, not the user's ``n_candidates``.
     """
     from archimedes.agents.strategy_fusion import load_corpus
 

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -1,0 +1,519 @@
+"""T1.1 — Multi-agent debate society (Phase 1 skeleton: additive + flag-gated).
+
+Design of record: ``docs/specs/multi-agent-debate-spec.md`` (v2, staged
+replacement). This is the strictly **additive** Phase-1 increment — a
+``pipeline_name="debate"`` generation runner gated behind
+``ARCHIMEDES_DEBATE_ENABLED`` (default OFF). While the flag is OFF the legacy
+live path is byte-identical (the dispatch never reaches this module). The
+society:
+
+  1. **Proposer pool** — fans ``StrategyFusion(model=...).propose`` across
+     ``select_candidates(regime_bias=R)`` evidence sets (the A3 model seam
+     threads the user's Generate-page model pick; the steered selection is the
+     cheap diversity axis). Drops non-actionable
+     (``FusionProposal.is_actionable``) and non-conformant (``_dsl_conformance_ok``,
+     fix A5) specs. ``pool_size = len(POOL)``.
+  2. **Adversarial round** — a thin, best-effort bull/bear transcript (Phase 1).
+     It surfaces the adversarial topology on the SSE stream but never gates;
+     the deterministic critics do the real culling (the budget trick). The full
+     rebuttal + LLM risk-debate is Phase 2.
+  3. **C-rigor** — backtests EVERY survivor for real via ``evaluate_fusion_spec``
+     (deterministic Python, 0 tokens), each wrapped in try/except (fix A5
+     backstop), with ``num_trials=pool_size`` so the DSR multiple-testing
+     correction counts the selection-from-pool search. This is the self-contained
+     A1 deflation at the per-candidate evaluator — it coordinates with #770's
+     ``library + N`` additive correction on the generation path rather than the
+     library-grading external route, so it does not fight that PR.
+  4. **C-null** — a survivor must beat the passive null (buy-and-hold) net of
+     cost by ``MIN_COST_BENEFIT``. If none clears it → first-class ABSTAIN.
+  5. **Synthesizer** — deterministic rank of the survivors (Phase 1 collapses the
+     synthesizer to 0 LLM calls per spec §8) → top-N leaderboard; the user picks.
+
+``_run_debate_candidate`` returns the **leader** ``_CandidateResult`` (carrier
+contract preserving); the full leaderboard is built by ``build_leaderboard``
+(directly unit-tested) and the Considered-Alternatives fan-out is Phase 2.
+
+⚠️  PHASE-1 BLOCKER: ``ARCHIMEDES_DEBATE_ENABLED`` must stay OFF on the live path
+until A1 (``pool_size`` → the external rigor gate, the OPEN Önder denominator)
+is proven there — else the rigor badge can false-PASS. The flag-OFF additive
+skeleton in this module is safe to merge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+# Imported at module top: generation_pipeline does NOT import this module at top
+# level (only lazily inside the dispatch), so there is no import cycle.
+from archimedes.agents.generation_pipeline import (
+    FusionUnavailable,
+    _CandidateResult,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from archimedes.agents.generation_pipeline import _Emitter
+    from archimedes.api.generate_schemas import GenerateBrief
+
+logger = logging.getLogger(__name__)
+
+# ── Env knobs ───────────────────────────────────────────────────────────────
+_TRUE = {"1", "true", "yes", "on"}
+
+# Phase-1 leaner steer set (regime axis). Phase 2 scales to ~15-20 across
+# regime × mechanism × risk-appetite. None = unbiased; "bull"/"bear" map to
+# strategy_fusion._REGIME_BIAS_TERMS.
+_STEERS: tuple[str | None, ...] = ("bull", "bear", "bull", "bear", None)
+
+# Indicator stems interpret_spec actually supports. ``realized_vol_N`` *validates*
+# via validate_strategy_spec but raises DSLError("unsupported indicator") inside
+# interpret_spec — which would throw in C-rigor. The conformance guard (fix A5)
+# drops such specs from the pool BEFORE they reach evaluate_fusion_spec.
+_CONFORMANT_INDICATORS = {"sma", "ema", "rsi", "momentum"}
+
+# DSL price operands (not indicator aliases) — excluded from the conformance scan.
+_PRICE_OPERANDS = {"close", "open", "high", "low", "volume"}
+
+# C-null passive-null bar (V_check min_cost_benefit_bps = 5 bps): a survivor must
+# beat buy-and-hold net of cost by at least this. Phase-1 proxy uses the
+# backtest's own annualized edge (cagr); the explicit buy-and-hold differential
+# is Phase 2.
+MIN_COST_BENEFIT = 0.0005  # 5 bps
+
+
+def debate_enabled() -> bool:
+    """True iff ``ARCHIMEDES_DEBATE_ENABLED`` is set truthy (default OFF)."""
+    return os.getenv("ARCHIMEDES_DEBATE_ENABLED", "").strip().lower() in _TRUE
+
+
+def _pool_max() -> int:
+    """``DEBATE_POOL_MAX`` clamped to [2, 24] (default 10 for Phase 1)."""
+    try:
+        return max(2, min(24, int(os.getenv("DEBATE_POOL_MAX", "10"))))
+    except ValueError:
+        return 10
+
+
+class DebateUnavailable(FusionUnavailable):
+    """The society produced no actionable + conformant + backtestable candidate.
+
+    Subclasses ``FusionUnavailable`` so the existing ``run_generation`` fallback
+    (``except FusionUnavailable``) relabels honestly to the agent path — no
+    dispatch except-clause change is needed.
+    """
+
+
+# ── DSL conformance guard (fix A5) ───────────────────────────────────────────
+
+
+def _indicator_alias_stems(spec: dict[str, Any]) -> set[str]:
+    """Collect the indicator stems referenced as ``{indicator}_{period}`` operands.
+
+    Walks the entry/exit condition trees. A string operand is an indicator alias
+    iff it has a trailing ``_<int>`` (e.g. ``sma_50`` → ``sma``,
+    ``realized_vol_5`` → ``realized_vol``). Price operands (``close`` …) and
+    numeric operands are ignored.
+    """
+    stems: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+        elif isinstance(node, str) and node not in _PRICE_OPERANDS:
+            stem, sep, period = node.rpartition("_")
+            if sep and stem and period.isdigit():
+                stems.add(stem)
+
+    walk(spec.get("entry"))
+    walk(spec.get("exit"))
+    return stems
+
+
+def _dsl_conformance_ok(spec: dict[str, Any] | None) -> bool:
+    """True iff ``spec`` is backtestable by ``interpret_spec`` (fix A5).
+
+    Rejects specs whose indicator aliases fall outside ``{sma, ema, rsi,
+    momentum}`` — those validate but raise ``DSLError`` at interpret time, which
+    would otherwise throw inside C-rigor and take down the whole leaderboard
+    build. A spec must also carry both an ``entry`` and an ``exit`` tree.
+    """
+    if not isinstance(spec, dict):
+        return False
+    if not isinstance(spec.get("entry"), dict) or not isinstance(spec.get("exit"), dict):
+        return False
+    return all(stem in _CONFORMANT_INDICATORS for stem in _indicator_alias_stems(spec))
+
+
+# ── Viability precheck (mirrors generation_pipeline._fusion_can_run) ──────────
+
+
+def _debate_can_run(brief: GenerateBrief) -> bool:
+    """No-LLM viability precheck: flag on AND ≥ MIN_PAPERS for the steer.
+
+    Never raises — any failure degrades to ``False`` so the caller falls back to
+    the agent path. (Mirrors ``generation_pipeline._fusion_can_run``.)
+    """
+    if not debate_enabled():
+        return False
+    try:
+        from archimedes.agents.strategy_fusion import (
+            MIN_PAPERS,
+            FusionBrief,
+            fusion_enabled,
+            load_corpus,
+            select_candidates,
+        )
+
+        if not fusion_enabled():
+            return False
+        fb = FusionBrief(
+            asset_classes=list(brief.asset_classes or []),
+            risk_appetite=brief.risk_appetite,
+            strategic_direction=brief.intent or "",
+            max_papers=brief.max_papers,
+        )
+        return len(select_candidates(fb, load_corpus())) >= MIN_PAPERS
+    except Exception:
+        logger.debug("debate viability precheck failed; treating as not runnable", exc_info=True)
+        return False
+
+
+# ── Step 1 — proposer pool ────────────────────────────────────────────────────
+
+
+async def _propose_pool(brief: GenerateBrief, model: str | None, corpus: list[Any]) -> list[Any]:
+    """Fan ``StrategyFusion(model=...).propose`` across regime-steered evidence.
+
+    Returns the POOL: proposals that are both *actionable*
+    (``FusionProposal.is_actionable``) AND *conformant* (``_dsl_conformance_ok``).
+    ``pool_size = len(returned list)`` is the DSR multiple-testing selection set.
+    """
+    from archimedes.agents.strategy_fusion import (
+        MIN_PAPERS,
+        FusionBrief,
+        StrategyFusion,
+        select_candidates,
+    )
+
+    fb = FusionBrief(
+        asset_classes=list(brief.asset_classes or []),
+        risk_appetite=brief.risk_appetite,
+        strategic_direction=brief.intent or "",
+        max_papers=brief.max_papers,
+    )
+    steers = list(_STEERS)[: _pool_max()]
+
+    def _propose_one(regime_bias: str | None) -> Any:
+        # Pre-build the steered evidence set (the caller-gap fix: select_candidates
+        # accepts regime_bias but StrategyFusion.propose never threads it). The
+        # proposer fuses over THIS steered set via the injected corpus.
+        evidence = select_candidates(fb, corpus, regime_bias=regime_bias)
+        if len(evidence) < MIN_PAPERS:
+            return None
+        return StrategyFusion(model=model, corpus=evidence).propose(fb)
+
+    proposals = await asyncio.gather(
+        *(asyncio.to_thread(_propose_one, r) for r in steers),
+        return_exceptions=True,
+    )
+
+    pool: list[Any] = []
+    for p in proposals:
+        if isinstance(p, BaseException) or p is None:
+            continue
+        if p.is_actionable and _dsl_conformance_ok(p.strategy_spec):
+            pool.append(p)
+    return pool
+
+
+# ── Step 2 — best-effort adversarial round (transcript only, never gates) ─────
+
+_DEBATE_SYSTEM = (
+    "You are the {role} researcher in a quant strategy debate. {stance}. "
+    "Cite ONLY the listed candidate strategies. Reply with ONE JSON object: "
+    '{{"verdict": "act"|"decline", "confidence": <0..1>, "key_claims": [<str>...]}}.'
+)
+
+
+async def _debate_round(pool: list[Any], model: str | None, emit: _Emitter, candidate_id: str) -> list[dict[str, Any]]:
+    """Thin best-effort bull/bear round — transcript only, never gates (Phase 1).
+
+    Surfaces the adversarial topology on the SSE stream. Any failure (no backend,
+    unparseable output) degrades to a neutral transcript entry. The transcript is
+    built in fixed [bull, bear] role order for R3 determinism (sort-before-hash).
+    """
+    from archimedes.agents.strategy_architect import extract_json
+    from archimedes.services.llm_backend import make_llm_backend
+
+    names = "; ".join(p.strategy_name for p in pool[:5] if p.strategy_name)
+    transcript: list[dict[str, Any]] = []
+    try:
+        backend = make_llm_backend(model=model)
+    except Exception:
+        logger.debug("debate round skipped (backend construction failed)", exc_info=True)
+        return transcript
+    if not getattr(backend, "available", False):
+        return transcript
+
+    for role, stance in (
+        ("bull", "Argue FOR acting on the strongest candidate"),
+        ("bear", "Argue for ABSTENTION — the null is buy-and-hold; attack overfit/cost"),
+    ):
+        await emit.emit(
+            "tool_called",
+            candidate_id=candidate_id,
+            tool_name=f"debate_{role}",
+            args_summary=f"candidates: {names[:120]}",
+        )
+        try:
+            raw = await asyncio.to_thread(backend.complete, _DEBATE_SYSTEM.format(role=role, stance=stance), names)
+            parsed = extract_json(raw)
+            transcript.append(
+                {
+                    "role": role,
+                    "verdict": str(parsed.get("verdict", "n/a")),
+                    "claims": list(parsed.get("key_claims") or parsed.get("fatal_flaws") or []),
+                }
+            )
+        except Exception:
+            transcript.append({"role": role, "verdict": "n/a", "claims": []})
+    return transcript
+
+
+# ── Step 3 — C-rigor (deterministic, real backtests) ──────────────────────────
+
+
+async def _critic_rigor(pool: list[Any], num_trials: int) -> list[tuple[Any, Any]]:
+    """Backtest every pooled spec for real; return ``[(proposal, eval_result)]``.
+
+    ``num_trials=pool_size`` so the DSR deflation counts the selection-from-pool
+    search (A1). Each ``evaluate_fusion_spec`` is wrapped in try/except so one bad
+    spec (despite the A5 pre-guard) drops with an honest emit, never aborting the
+    cohort.
+    """
+    from archimedes.services.fusion_evaluator import evaluate_fusion_spec
+
+    def _backtest(proposal: Any) -> Any:
+        try:
+            return evaluate_fusion_spec(proposal.strategy_spec, num_trials=num_trials)
+        except Exception as exc:
+            logger.info("debate C-rigor: dropped a candidate on backtest error: %s", exc)
+            return None
+
+    results = await asyncio.gather(*(asyncio.to_thread(_backtest, p) for p in pool))
+    out: list[tuple[Any, Any]] = []
+    for proposal, ev in zip(pool, results, strict=True):
+        if ev is not None and ev.success and ev.rigor is not None:
+            out.append((proposal, ev))
+    return out
+
+
+# ── Step 4/5 — C-null + synthesize → leaderboard ──────────────────────────────
+
+
+def _survives_null(ev: Any) -> bool:
+    """C-null: the candidate beats the passive null net of cost by ≥ 5 bps.
+
+    Phase-1 proxy: the backtest's own annualized edge (cagr) clears
+    ``MIN_COST_BENEFIT``. The explicit buy-and-hold differential is Phase 2.
+    """
+    cagr = getattr(ev.backtest, "cagr", None)
+    return cagr is not None and cagr > MIN_COST_BENEFIT
+
+
+def _score(ev: Any) -> tuple[int, float, float]:
+    """Deterministic leaderboard rank key: (passing, DSR, OOS Sharpe), desc."""
+    r = ev.rigor
+    dsr = r.dsr if r.dsr is not None else -1e18
+    oos = r.oos_sharpe if r.oos_sharpe is not None else -1e18
+    return (1 if r.passing else 0, dsr, oos)
+
+
+def _rigor_verdict_dict(ev: Any) -> dict[str, Any]:
+    """Build the passport ``rigor_verdict`` from a FusionEvalResult.
+
+    Mirrors ``generation_pipeline._run_fusion_candidate``'s verdict shape so the
+    passport renders identically for debate and fusion candidates.
+    """
+    r = ev.rigor
+    bt = ev.backtest
+    return {
+        "dsr": r.dsr,
+        "dsr_p_value": r.dsr_p_value,
+        "pbo": r.pbo_score,
+        "oos_sharpe": r.oos_sharpe,
+        "in_sample_sharpe": r.in_sample_sharpe,
+        "lookahead_audit_passed": bool(r.look_ahead_clean),
+        "look_ahead_label": r.look_ahead_label,
+        "num_trials": int(r.num_trials),  # == pool_size (A1)
+        "passing": bool(r.passing),
+        "data_source": r.data_source,
+        "admissible": bool(ev.admissible),
+        "sharpe_ratio": bt.sharpe_ratio,
+        "sortino_ratio": bt.sortino_ratio,
+        "max_drawdown": bt.max_drawdown,
+        "cagr": bt.cagr,
+        "calmar_ratio": bt.calmar_ratio,
+        "win_rate": bt.win_rate,
+        "total_trades": bt.total_trades,
+    }
+
+
+def _make_entry(candidate_id: str, proposal: Any, ev: Any, *, regime: str) -> _CandidateResult:
+    """One leaderboard entry — a fully-populated ``_CandidateResult``.
+
+    ``has_real_rigor=True`` (carries C-rigor's real backtest) so the downstream
+    ``_patch_pbo`` and buy-and-hold gather correctly SKIP it (keyed on
+    ``has_real_rigor``), preserving the CSCV PBO from ``evaluate_fusion_spec``.
+    """
+    spec = proposal.strategy_spec or {}
+    return _CandidateResult(
+        candidate_id=candidate_id,
+        strategy_name=proposal.strategy_name or "Debate candidate",
+        thesis=proposal.thesis,
+        asset_universe=list(spec.get("asset_universe", []) or []),
+        source_papers=[{"arxiv_id": a, "title": ""} for a in proposal.source_arxiv_ids],
+        weights={},  # debate emits a DSL spec, not a static weight vector
+        reasoning=proposal.fusion_reasoning or proposal.novelty_rationale or "",
+        rigor_verdict=_rigor_verdict_dict(ev),
+        passes_rigor=bool(ev.rigor.passing),
+        regime=regime,
+        generation_method="debate",
+        source_arxiv_ids=list(proposal.source_arxiv_ids),
+        has_real_rigor=True,
+    )
+
+
+def _abstain_result(candidate_id: str, *, regime: str, reason: str) -> _CandidateResult:
+    """First-class ABSTAIN — a populated, SKIP-shaped ``_CandidateResult``.
+
+    ``generation_method="debate_abstain"`` flows through the existing emit/persist
+    path (and V_check's SKIP-trace mechanism); it is NOT a new error code.
+    """
+    return _CandidateResult(
+        candidate_id=candidate_id,
+        strategy_name="Debate — abstain (hold current weights)",
+        thesis=reason,
+        asset_universe=[],
+        source_papers=[],
+        weights={},
+        reasoning=reason,
+        rigor_verdict={
+            "dsr": None,
+            "pbo": None,
+            "oos_sharpe": None,
+            "in_sample_sharpe": None,
+            "lookahead_audit_passed": False,
+            "passing": False,
+            "reason": reason,
+        },
+        passes_rigor=False,
+        regime=regime,
+        generation_method="debate_abstain",
+        source_arxiv_ids=[],
+        has_real_rigor=False,
+    )
+
+
+def build_leaderboard(rigor_results: list[tuple[Any, Any]], *, regime: str, base_id: str) -> list[_CandidateResult]:
+    """Deterministic C-null cull + rank → the top-N leaderboard (leader first).
+
+    Returns ``[abstain]`` when no candidate clears the passive null. The leader
+    keeps ``base_id``; alternatives get ``base_id_alt{n}`` so the persist tail can
+    distinguish them. Pure + deterministic — directly unit-tested.
+    """
+    survivors = [(p, ev) for (p, ev) in rigor_results if _survives_null(ev)]
+    if not survivors:
+        return [
+            _abstain_result(
+                base_id,
+                regime=regime,
+                reason="No candidate beat the passive null by ≥ 5 bps net of cost — abstaining (hold current weights).",
+            )
+        ]
+    survivors.sort(key=lambda pe: _score(pe[1]), reverse=True)
+    return [
+        _make_entry(base_id if i == 0 else f"{base_id}_alt{i}", p, ev, regime=regime)
+        for i, (p, ev) in enumerate(survivors)
+    ]
+
+
+# ── Runner (the dispatch entry point) ─────────────────────────────────────────
+
+
+async def _run_debate_candidate(
+    *,
+    candidate_id: str,
+    brief: GenerateBrief,
+    emit: _Emitter,
+    regime: str = "neutral",
+    agent: Any = None,  # noqa: ARG001 — signature parity with the other runners
+    model: str | None = None,
+) -> _CandidateResult:
+    """Run the debate society once and return the leader ``_CandidateResult``.
+
+    Carrier-contract preserving: returns a single ``_CandidateResult`` (the
+    leader). The full leaderboard is built by ``build_leaderboard`` (testable);
+    the Considered-Alternatives fan-out is Phase 2. Raises ``DebateUnavailable``
+    (a ``FusionUnavailable`` subclass) when no candidate survives, so the existing
+    run_generation fallback relabels to the agent path.
+    """
+    from archimedes.agents.strategy_fusion import load_corpus
+
+    await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=1, max_iterations=4)
+    await emit.emit(
+        "tool_called",
+        candidate_id=candidate_id,
+        tool_name="propose_pool",
+        args_summary=f"steers={len(_STEERS)}, asset_classes={brief.asset_classes or '(any)'}",
+    )
+
+    corpus = await asyncio.to_thread(load_corpus)
+    pool = await _propose_pool(brief, model, corpus)
+    pool_size = len(pool)
+    if pool_size == 0:
+        raise DebateUnavailable("debate produced no actionable, DSL-conformant candidate (empty pool)")
+
+    await emit.emit(
+        "tool_result",
+        candidate_id=candidate_id,
+        tool_name="propose_pool",
+        result_summary=f"pool_size={pool_size} actionable+conformant specs",
+    )
+
+    # Step 2 — best-effort adversarial transcript (never gates).
+    await _debate_round(pool, model, emit, candidate_id)
+
+    # Step 3 — C-rigor: backtest every survivor with num_trials = pool_size (A1).
+    await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=4)
+    await emit.emit(
+        "tool_called",
+        candidate_id=candidate_id,
+        tool_name="evaluate_fusion_spec",
+        args_summary=f"backtest ×{pool_size}, num_trials={pool_size}",
+    )
+    rigor_results = await _critic_rigor(pool, pool_size)
+    if not rigor_results:
+        raise DebateUnavailable("debate: no candidate produced a successful backtest")
+
+    # Steps 4/5 — C-null cull + deterministic synthesize → leaderboard.
+    await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=3, max_iterations=4)
+    leaderboard = build_leaderboard(rigor_results, regime=regime, base_id=candidate_id)
+    leader = leaderboard[0]
+    await emit.emit(
+        "tool_result",
+        candidate_id=candidate_id,
+        tool_name="synthesize",
+        result_summary=(
+            "ABSTAIN — no candidate beat the passive null"
+            if leader.generation_method == "debate_abstain"
+            else f"leader={leader.strategy_name} dsr={leader.rigor_verdict.get('dsr')} of {len(leaderboard)} entries"
+        ),
+    )
+    return leader

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -465,13 +465,85 @@ def _abstain_result(candidate_id: str, *, regime: str, reason: str) -> _Candidat
     )
 
 
-def build_leaderboard(rigor_results: list[tuple[Any, Any]], *, regime: str, base_id: str) -> list[_CandidateResult]:
-    """Deterministic C-null cull + rank → the top-N leaderboard (leader first).
+def _critic_regime() -> dict[str, Any]:
+    """C-regime (Xia §4.4 Hierarchy-of-Truth) — read the live exogenous regime.
 
-    Returns ``[abstain]`` when no candidate clears the passive null. The leader
-    keeps ``base_id``; alternatives get ``base_id_alt{n}`` so the persist tail can
-    distinguish them. Pure + deterministic — directly unit-tested.
+    **Non-votable.** A live CRISIS read forces ABSTAIN regardless of how good the
+    candidates look — crisis is exactly when you do NOT deploy a fresh strategy,
+    and no bull argument can override it. DEGRADED (GMM artifact missing → VIX
+    rule-based fallback) is surfaced honestly and lowers confidence, but does not
+    by itself force abstain (else the society would always abstain when the model
+    is unavailable). Never raises — any failure degrades to "unavailable, don't
+    force" so the regime critic can only ABSTAIN, never spuriously APPROVE.
+
+    Returns a dict: ``regime`` (str|None), ``confidence`` (float), ``degraded``
+    (bool), ``force_abstain`` (bool), ``reason`` (str).
     """
+    out: dict[str, Any] = {
+        "regime": None,
+        "confidence": 0.0,
+        "degraded": True,
+        "force_abstain": False,
+        "reason": "regime detector unavailable — not gating",
+    }
+    try:
+        from archimedes.models.regime import Regime
+        from archimedes.services.gmm_regime_detector import GmmRegimeDetector, gmm_regime_health
+
+        health = gmm_regime_health()
+        degraded = health.status != "live"
+        rc = GmmRegimeDetector().get_current_regime()
+        regime = rc.regime if rc is not None else None
+        confidence = float(rc.confidence) if rc is not None else 0.0
+        force_abstain = regime == Regime.CRISIS
+        if regime is None:
+            reason = "no regime read — not gating"
+        elif force_abstain:
+            reason = (
+                f"CRISIS regime (confidence={confidence:.2f}"
+                f"{', GMM degraded → VIX fallback' if degraded else ''}) — non-votable ABSTAIN"
+            )
+        else:
+            reason = (
+                f"regime={regime.value} confidence={confidence:.2f}"
+                f"{' (GMM degraded → VIX rule-based fallback)' if degraded else ''}"
+            )
+        out = {
+            "regime": regime.value if regime is not None else None,
+            "confidence": confidence,
+            "degraded": degraded,
+            "force_abstain": force_abstain,
+            "reason": reason,
+        }
+    except Exception:
+        logger.debug("C-regime read failed; treating as unavailable (not gating)", exc_info=True)
+    return out
+
+
+def build_leaderboard(
+    rigor_results: list[tuple[Any, Any]],
+    *,
+    regime: str,
+    base_id: str,
+    regime_force_abstain: bool = False,
+    regime_reason: str = "",
+) -> list[_CandidateResult]:
+    """Deterministic C-regime gate → C-null cull + rank → top-N leaderboard.
+
+    The **non-votable C-regime gate runs first**: a live-CRISIS
+    ``regime_force_abstain`` short-circuits to ABSTAIN before C-null even runs —
+    market regime structurally overrides candidate consensus (Hierarchy-of-Truth).
+    Otherwise: C-null cull → rank → leaderboard (leader keeps ``base_id``,
+    alternatives get ``base_id_alt{n}``). Pure + deterministic — directly tested.
+    """
+    if regime_force_abstain:
+        return [
+            _abstain_result(
+                base_id,
+                regime=regime,
+                reason=f"Regime gate (non-votable, Hierarchy-of-Truth): {regime_reason}",
+            )
+        ]
     survivors = [(p, ev) for (p, ev) in rigor_results if _survives_null(ev)]
     if not survivors:
         return [
@@ -562,9 +634,24 @@ async def _run_debate_candidate(
     if not rigor_results:
         raise DebateUnavailable("debate: no candidate produced a successful backtest")
 
-    # Steps 4/5 — C-null cull + deterministic synthesize → leaderboard.
+    # Step 4 — C-regime (non-votable Hierarchy-of-Truth): read the live regime.
+    regime_gate = await asyncio.to_thread(_critic_regime)
+    await emit.emit(
+        "tool_result",
+        candidate_id=candidate_id,
+        tool_name="critic_regime",
+        result_summary=regime_gate["reason"],
+    )
+
+    # Step 5 — C-null cull + deterministic synthesize → leaderboard (C-regime gates first).
     await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=3, max_iterations=4)
-    leaderboard = build_leaderboard(rigor_results, regime=regime, base_id=candidate_id)
+    leaderboard = build_leaderboard(
+        rigor_results,
+        regime=regime,
+        base_id=candidate_id,
+        regime_force_abstain=regime_gate["force_abstain"],
+        regime_reason=regime_gate["reason"],
+    )
     leader = leaderboard[0]
     await emit.emit(
         "tool_result",

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any
 from archimedes.agents.generation_pipeline import (
     FusionUnavailable,
     _CandidateResult,
+    _society_num_trials,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -62,10 +63,24 @@ logger = logging.getLogger(__name__)
 # ── Env knobs ───────────────────────────────────────────────────────────────
 _TRUE = {"1", "true", "yes", "on"}
 
-# Phase-1 leaner steer set (regime axis). Phase 2 scales to ~15-20 across
-# regime × mechanism × risk-appetite. None = unbiased; "bull"/"bear" map to
-# strategy_fusion._REGIME_BIAS_TERMS.
-_STEERS: tuple[str | None, ...] = ("bull", "bear", "bull", "bear", None)
+# Steer grid = regime × mechanism. Each (regime_bias, mechanism) pair gives the
+# proposer a distinct evidence ranking (regime_bias → select_candidates) AND a
+# distinct mechanism hint (appended to strategic_direction), so the pool diverges
+# on TWO axes — not just the 3 regime_bias values. This is the non-corpus diversity
+# dimension that mitigates the "diversity theater" risk when the corpus is degraded
+# (a degraded reranker can collapse regime steers; the mechanism hint still varies
+# the proposer prompt). `_pool_max()` bounds how many of these steers actually fan out.
+_REGIME_AXIS: tuple[str | None, ...] = ("bull", "bear", None)
+_MECHANISM_AXIS: tuple[str, ...] = (
+    "momentum / trend-following",
+    "volatility-managed / defensive",
+    "carry",
+    "breakout",
+    "mean-reversion",
+    "minimum-variance",
+)
+# Cartesian product (regime × mechanism) = 18 distinct steers; `_pool_max()` caps the fan-out.
+_STEERS: tuple[tuple[str | None, str], ...] = tuple((r, m) for r in _REGIME_AXIS for m in _MECHANISM_AXIS)
 
 # Indicator stems interpret_spec actually supports. ``realized_vol_N`` *validates*
 # via validate_strategy_spec but raises DSLError("unsupported indicator") inside
@@ -89,11 +104,36 @@ def debate_enabled() -> bool:
 
 
 def _pool_max() -> int:
-    """``DEBATE_POOL_MAX`` clamped to [2, 24] (default 10 for Phase 1)."""
+    """``DEBATE_POOL_MAX`` clamped to [2, 24] (default 10 for Phase 1).
+
+    Bounds how many of the regime×mechanism ``_STEERS`` (18 total) actually fan out
+    as proposer calls — so the env knob meaningfully caps the LLM cost.
+    """
     try:
-        return max(2, min(24, int(os.getenv("DEBATE_POOL_MAX", "10"))))
+        return max(2, min(len(_STEERS), int(os.getenv("DEBATE_POOL_MAX", "10"))))
     except ValueError:
         return 10
+
+
+def _leaderboard_max() -> int:
+    """``DEBATE_LEADERBOARD_MAX`` clamped to [1, 24] (default 10 — the spec's top-10)."""
+    try:
+        return max(1, min(24, int(os.getenv("DEBATE_LEADERBOARD_MAX", "10"))))
+    except ValueError:
+        return 10
+
+
+def _library_size() -> int:
+    """Curated strategy-library size — the library-context selection layer for the
+    DSR deflation (mirrors the live path's ``len(strategies)``). Never raises;
+    degrades to 1 (the minimum), which can only UNDER-count, never over-deflate."""
+    try:
+        from archimedes.services.strategy_provider import default_provider
+
+        return max(1, len(default_provider().list_strategies()))
+    except Exception:
+        logger.debug("debate: library-size lookup failed; defaulting to 1", exc_info=True)
+        return 1
 
 
 class DebateUnavailable(FusionUnavailable):
@@ -201,25 +241,29 @@ async def _propose_pool(brief: GenerateBrief, model: str | None, corpus: list[An
         select_candidates,
     )
 
-    fb = FusionBrief(
-        asset_classes=list(brief.asset_classes or []),
-        risk_appetite=brief.risk_appetite,
-        strategic_direction=brief.intent or "",
-        max_papers=brief.max_papers,
-    )
     steers = list(_STEERS)[: _pool_max()]
 
-    def _propose_one(regime_bias: str | None) -> Any:
-        # Pre-build the steered evidence set (the caller-gap fix: select_candidates
-        # accepts regime_bias but StrategyFusion.propose never threads it). The
-        # proposer fuses over THIS steered set via the injected corpus.
+    def _propose_one(steer: tuple[str | None, str]) -> Any:
+        regime_bias, mechanism = steer
+        # Thread BOTH axes: regime_bias steers select_candidates' evidence ranking,
+        # and the mechanism hint (appended to strategic_direction) steers the proposer
+        # prompt so the same evidence + a different mechanism yields a genuinely
+        # different spec — not an LLM-noise duplicate. (The caller-gap fix:
+        # select_candidates accepts regime_bias but StrategyFusion.propose never
+        # threads it; the proposer fuses over THIS steered set via the injected corpus.)
+        fb = FusionBrief(
+            asset_classes=list(brief.asset_classes or []),
+            risk_appetite=brief.risk_appetite,
+            strategic_direction=f"{brief.intent or ''} — favor {mechanism} mechanisms".strip(" —"),
+            max_papers=brief.max_papers,
+        )
         evidence = select_candidates(fb, corpus, regime_bias=regime_bias)
         if len(evidence) < MIN_PAPERS:
             return None
         return StrategyFusion(model=model, corpus=evidence).propose(fb)
 
     proposals = await asyncio.gather(
-        *(asyncio.to_thread(_propose_one, r) for r in steers),
+        *(asyncio.to_thread(_propose_one, s) for s in steers),
         return_exceptions=True,
     )
 
@@ -438,6 +482,9 @@ def build_leaderboard(rigor_results: list[tuple[Any, Any]], *, regime: str, base
             )
         ]
     survivors.sort(key=lambda pe: _score(pe[1]), reverse=True)
+    # Cap to the top-N leaderboard (spec's top-10 contract) so the persisted/streamed
+    # candidate set can't balloon when the pool is large.
+    survivors = survivors[: _leaderboard_max()]
     return [
         _make_entry(base_id if i == 0 else f"{base_id}_alt{i}", p, ev, regime=regime)
         for i, (p, ev) in enumerate(survivors)
@@ -497,15 +544,21 @@ async def _run_debate_candidate(
     # Step 2 — best-effort adversarial transcript (never gates).
     await _debate_round(pool, model, emit, candidate_id)
 
-    # Step 3 — C-rigor: backtest every survivor with num_trials = pool_size (A1).
+    # Step 3 — C-rigor (A1, aligned with #770/#811 + Önder's #820 unification): the
+    # DSR multiple-testing count is `_society_num_trials(library_size, pool_size) =
+    # library + N`, NOT pool_size alone. The winner survived selection from the pool
+    # AND is promoted into the library, so both selection layers must deflate it —
+    # otherwise the debate "passing" badge is more permissive than the live path's.
+    # When #820 lands the shared helper, this should read from that single source.
+    num_trials = await asyncio.to_thread(lambda: _society_num_trials(_library_size(), pool_size))
     await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=4)
     await emit.emit(
         "tool_called",
         candidate_id=candidate_id,
         tool_name="evaluate_fusion_spec",
-        args_summary=f"backtest ×{pool_size}, num_trials={pool_size}",
+        args_summary=f"backtest ×{pool_size}, num_trials={num_trials} (library+pool, #770/#820)",
     )
-    rigor_results = await _critic_rigor(pool, pool_size)
+    rigor_results = await _critic_rigor(pool, num_trials)
     if not rigor_results:
         raise DebateUnavailable("debate: no candidate produced a successful backtest")
 

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -358,6 +358,37 @@ async def _critic_rigor(pool: list[Any], num_trials: int) -> list[tuple[Any, Any
     return out
 
 
+# ── C-prov (deterministic provenance/embargo gate — Xia 1/2/4) ────────────────
+
+
+def _critic_prov(pool: list[Any], corpus: list[Any]) -> tuple[list[Any], list[Any]]:
+    """C-prov (Xia 1/2/4, non-votable): hard-fail any candidate citing a paper
+    OUTSIDE the shared embargo + decay-applied evidence surface.
+
+    The surface is the ``load_corpus()`` output, which already excludes post-embargo
+    papers (``apply_outcome_embargo`` runs inside ``load_papers_from_db``), so a
+    candidate whose ``source_arxiv_ids`` are all in the corpus is provenance-clean.
+    A candidate citing an id NOT in the surface (a post-embargo leak or a
+    hallucination that slipped the proposer's ``valid_ids`` filter) is dropped —
+    deterministic defense-in-depth that cannot be argued out of its position.
+
+    Does NOT change ``pool_size`` (the DSR denominator counts every conformant spec
+    we proposed/searched, per spec §5c); it only culls which survivors reach C-rigor.
+    Returns ``(kept, dropped)``.
+    """
+    surface = {getattr(p, "arxiv_id", None) for p in corpus}
+    surface.discard(None)
+    kept: list[Any] = []
+    dropped: list[Any] = []
+    for prop in pool:
+        cited = set(prop.source_arxiv_ids)
+        if cited and cited <= surface:
+            kept.append(prop)
+        else:
+            dropped.append(prop)
+    return kept, dropped
+
+
 # ── Step 4/5 — C-null + synthesize → leaderboard ──────────────────────────────
 
 
@@ -616,21 +647,34 @@ async def _run_debate_candidate(
     # Step 2 — best-effort adversarial transcript (never gates).
     await _debate_round(pool, model, emit, candidate_id)
 
-    # Step 3 — C-rigor (A1, aligned with #770/#811 + Önder's #820 unification): the
-    # DSR multiple-testing count is `_society_num_trials(library_size, pool_size) =
-    # library + N`, NOT pool_size alone. The winner survived selection from the pool
-    # AND is promoted into the library, so both selection layers must deflate it —
-    # otherwise the debate "passing" badge is more permissive than the live path's.
-    # When #820 lands the shared helper, this should read from that single source.
+    # Step 3a — C-prov (non-votable, Xia 1/2/4): cull candidates citing outside the
+    # embargo+decay surface. Does NOT change pool_size (the DSR denominator counts
+    # every conformant spec we proposed; §5c) — only which survivors reach C-rigor.
+    prov_clean, prov_dropped = _critic_prov(pool, corpus)
+    if prov_dropped:
+        await emit.emit(
+            "tool_result",
+            candidate_id=candidate_id,
+            tool_name="critic_prov",
+            result_summary=f"dropped {len(prov_dropped)} candidate(s) citing outside the embargo surface",
+        )
+    if not prov_clean:
+        raise DebateUnavailable("debate: all candidates failed provenance (cited outside the embargo+decay surface)")
+
+    # Step 3b — C-rigor (A1, aligned with #770/#811 + Önder's #820): num_trials =
+    # _society_num_trials(library_size, pool_size) = library + N, NOT pool_size alone,
+    # so the debate "passing" badge is not more permissive than the live path. pool_size
+    # (the full conformant proposed count) is the selection set; C-prov only culls which
+    # survivors are backtested. When #820 lands the shared helper, read from that source.
     num_trials = await asyncio.to_thread(lambda: _society_num_trials(_library_size(), pool_size))
     await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=4)
     await emit.emit(
         "tool_called",
         candidate_id=candidate_id,
         tool_name="evaluate_fusion_spec",
-        args_summary=f"backtest ×{pool_size}, num_trials={num_trials} (library+pool, #770/#820)",
+        args_summary=f"backtest ×{len(prov_clean)}, num_trials={num_trials} (library+pool, #770/#820)",
     )
-    rigor_results = await _critic_rigor(pool, num_trials)
+    rigor_results = await _critic_rigor(prov_clean, num_trials)
     if not rigor_results:
         raise DebateUnavailable("debate: no candidate produced a successful backtest")
 

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import hashlib
 import json
 import logging
@@ -80,6 +81,17 @@ def _pick_pipeline(
        brief's inferred asset classes.
     3. **agent** (SSE streaming portfolio-advisor path) as the fallback.
     """
+    # ── Debate society (flag-gated, additive — T1.1) ──
+    # When ARCHIMEDES_DEBATE_ENABLED is set, the debate society IS the generation
+    # pipeline (staged replacement). While the flag is OFF the legacy decision
+    # tree below runs UNCHANGED — so the flag-OFF live path stays byte-identical
+    # even if a client passes mode="debate". The legacy-runner deletions are
+    # deferred to the Phase-3 cutover PR.
+    from archimedes.agents.debate_engine import debate_enabled
+
+    if debate_enabled():
+        return "debate", "debate society pipeline (ARCHIMEDES_DEBATE_ENABLED)"
+
     # ── User-selected mode override (#290) ──
     if mode_override and mode_override in ("fusion", "architect", "agent"):
         return mode_override, f"user selected {mode_override} mode"
@@ -1057,9 +1069,14 @@ async def run_generation(
         # ── Auto-route to the best pipeline ──
         pipeline_name, pipeline_reason = _pick_pipeline(brief, mode_override=mode)
 
-        # Determine regime plan: dual_regime emits both bull + bear (Issue #163)
-        if dual_regime:
-            regimes: list[str] = ["bull", "bear"]
+        # Determine regime plan: dual_regime emits both bull + bear (Issue #163).
+        # The debate society owns its OWN internal regime/mechanism split, so its
+        # per-regime loop runs ONCE ("neutral") and the expensive PBO/persist tail
+        # stays a single self-contained unit (spec §5b).
+        if pipeline_name == "debate":
+            regimes: list[str] = ["neutral"]
+        elif dual_regime:
+            regimes = ["bull", "bear"]
         else:
             regimes = ["neutral"] * n_candidates
 
@@ -1087,6 +1104,24 @@ async def run_generation(
                 pipeline_name = "agent"
                 pipeline_reason = (
                     "fusion selected but not runnable "
+                    f"({'no LLM backend' if not use_live else 'corpus yielded <2 papers for the steer'})"
+                    " — falling back to streaming agent"
+                )
+                runner = agent_runner
+        elif pipeline_name == "debate":
+            # Flag-gated debate society (T1.1). model is bound now via partial so
+            # the proposer threads the user's pick (A3); the loop calls runner()
+            # with the same kwargs as every other runner (signature parity). A
+            # DebateUnavailable raised at runtime is a FusionUnavailable subclass,
+            # so the existing fallback below relabels it to the agent path.
+            from archimedes.agents.debate_engine import _debate_can_run, _run_debate_candidate
+
+            if use_live and _debate_can_run(brief):
+                runner = functools.partial(_run_debate_candidate, model=model)
+            else:
+                pipeline_name = "agent"
+                pipeline_reason = (
+                    "debate selected but not runnable "
                     f"({'no LLM backend' if not use_live else 'corpus yielded <2 papers for the steer'})"
                     " — falling back to streaming agent"
                 )
@@ -1313,10 +1348,16 @@ async def run_generation(
             for cand in candidates:
                 persist_proposal(
                     generation_id=job_id,
-                    # "fusion" for fused candidates, "agent" otherwise — the
-                    # episodic record now reflects which engine produced the
-                    # proposal rather than always claiming "agent".
-                    agent="fusion" if cand.generation_method == "fusion" else "agent",
+                    # "debate" for society candidates, "fusion" for fused, "agent"
+                    # otherwise — the episodic record reflects which engine produced
+                    # the proposal rather than always claiming "agent".
+                    agent=(
+                        "debate"
+                        if cand.generation_method in ("debate", "debate_abstain")
+                        else "fusion"
+                        if cand.generation_method == "fusion"
+                        else "agent"
+                    ),
                     intent=brief.intent,
                     strategy_spec={
                         "strategy_name": cand.strategy_name,

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1330,6 +1330,10 @@ async def run_generation(
         # generation_method preserves the HONEST "no weights" signal for a genuine
         # agent-path failure (agent emitted no allocation) while never running the
         # static backtester on a fusion candidate that has nothing static to run.
+        # Debate candidates ("debate"/"debate_abstain") are the same shape — they
+        # emit a DSL spec (weights={}) scored by evaluate_fusion_spec, or are a
+        # populated ABSTAIN — so they skip the static backtester too (T1.1).
+        _static_skip = ("fusion", "debate", "debate_abstain")
         await asyncio.gather(
             *[
                 # num_trials = N candidates + library context (#770), not library alone.
@@ -1337,7 +1341,7 @@ async def run_generation(
                     c, strategy_ids[c.candidate_id], emit, _society_num_trials(library_size, n_candidates)
                 )
                 for c in candidates
-                if c.generation_method != "fusion"
+                if c.generation_method not in _static_skip
             ]
         )
 

--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -602,6 +602,7 @@ class StrategyFusion:
         self,
         backend: LLMBackend | None = None,
         corpus: list[CorpusPaper] | None = None,
+        model: str | None = None,
     ) -> None:
         # Backend/corpus are injectable for offline tests. They are resolved
         # lazily in `propose` so constructing the service never triggers an
@@ -609,11 +610,18 @@ class StrategyFusion:
         # and dependency-light import sites).
         self._backend = backend
         self._corpus = corpus
+        # Model id to thread into the lazily-resolved backend (A3 seam, T1.1).
+        # When set (and no explicit backend was injected), `_resolve_backend`
+        # builds `make_llm_backend(model=...)` so the user's Generate-page model
+        # pick is honored and `served_model` reports the TRUE model rather than
+        # the env default. Was the gap that let the debate proposer silently run
+        # on Nova regardless of the user's pick (spec §8 item 10 / fix A3).
+        self._model = model
 
     def _resolve_backend(self) -> LLMBackend:
         if self._backend is not None:
             return self._backend
-        self._backend = default_backend()
+        self._backend = default_backend(self._model)
         return self._backend
 
     def _resolve_corpus(self) -> list[CorpusPaper]:
@@ -717,18 +725,25 @@ class StrategyFusion:
         )
 
 
-def default_backend() -> LLMBackend:
+def default_backend(model: str | None = None) -> LLMBackend:
     """Claude or GLM when credentials are present; canned fallback otherwise.
 
     Delegates to the provider-agnostic ``llm_backend.make_llm_backend()`` factory.
+    ``model`` threads the user's Generate-page model pick through to the factory
+    (A3 seam, T1.1); ``None`` keeps the env default — behavior unchanged.
     """
-    backend = make_llm_backend()
+    backend = make_llm_backend(model=model)
     if backend.available:
         return backend  # type: ignore[return-value]
     logger.warning("No LLM credentials (LLM_* or ANTHROPIC_* env vars) — strategy fusion using canned fallback")
     return FusionCannedBackend()
 
 
-def default_fusion() -> StrategyFusion:
-    """Factory mirroring `default_architect()`. Not yet route-wired."""
-    return StrategyFusion()
+def default_fusion(model: str | None = None) -> StrategyFusion:
+    """Factory mirroring `default_architect()`. Not yet route-wired.
+
+    ``model`` threads the user's selected model through to the lazily-resolved
+    backend (A3 seam, T1.1) so ``served_model`` provenance is truthful; ``None``
+    preserves the env-default behavior.
+    """
+    return StrategyFusion(model=model)

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -31,7 +31,12 @@ class GenerateStartRequest(BaseModel):
     n_candidates: int = Field(default=1, ge=1, le=5, description="How many candidates to consider internally")
     mode: str | None = Field(
         default=None,
-        description="Optional pipeline override: 'fusion', 'architect', or 'agent'. When set, bypasses auto-routing.",
+        description=(
+            "Optional pipeline override: 'fusion', 'architect', or 'agent'. When set, bypasses "
+            "auto-routing. The 'debate' society pipeline (T1.1) is selected by the "
+            "ARCHIMEDES_DEBATE_ENABLED flag rather than this override, so flag-OFF stays "
+            "byte-identical; the deletions of the legacy runners are deferred to the Phase-3 cutover."
+        ),
     )
     model: str | None = Field(
         default=None,

--- a/backend/archimedes/services/gmm_regime_detector.py
+++ b/backend/archimedes/services/gmm_regime_detector.py
@@ -179,6 +179,20 @@ def gmm_regime_health() -> GmmRegimeHealth:
     )
 
 
+def current_regime() -> RegimeClassification | None:
+    """The live regime classification from the most-recently-constructed detector.
+
+    Reads the SHARED detector (the one the oracle/agent runner feeds market data),
+    mirroring ``gmm_regime_health``. Constructing a fresh ``GmmRegimeDetector`` here
+    would be wrong — a new instance has no current classification until it has been
+    fed snapshots, so it would always return ``None``. Returns ``None`` when no
+    detector has been constructed/fed yet (the cold path) — callers treat that as
+    "no regime read" rather than a market signal.
+    """
+    detector = _LAST_DETECTOR() if _LAST_DETECTOR is not None else None
+    return detector.get_current_regime() if detector is not None else None
+
+
 def _label_components(scaler: StandardScaler, gmm: GaussianMixture) -> dict[int, Regime]:
     """Deterministically map each latent component to a ``Regime``.
 

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -385,3 +385,28 @@ async def test_debate_round_transcript_in_fixed_role_order(monkeypatch):
     transcript = await de._debate_round(pool, "m", _FakeEmit(), "cand_1")
     # Best-effort round still produces a deterministic [bull, bear] ordering.
     assert [t["role"] for t in transcript] == ["bull", "bear"]
+
+
+# ── Review fixes: pool-max bound + leaderboard top-N cap ──────────────────────
+
+
+def test_pool_max_meaningfully_bounds_the_steer_grid(monkeypatch):
+    # The steer grid is regime×mechanism (18), so DEBATE_POOL_MAX can actually cap
+    # the fan-out (the prior 5-element _STEERS made the knob a no-op above 5).
+    assert len(de._STEERS) == 18
+    monkeypatch.setenv("DEBATE_POOL_MAX", "6")
+    assert de._pool_max() == 6
+    monkeypatch.setenv("DEBATE_POOL_MAX", "99")
+    assert de._pool_max() == len(de._STEERS)  # clamped to the grid size, not unbounded
+
+
+def test_build_leaderboard_caps_to_top_n(monkeypatch):
+    monkeypatch.setenv("DEBATE_LEADERBOARD_MAX", "3")
+    rigor_results = [
+        (_fake_proposal(f"c{i}", [f"24{i}.0001", f"24{i}.0002"]), _fake_ev(cagr=0.2, dsr=float(i))) for i in range(8)
+    ]
+    board = de.build_leaderboard(rigor_results, regime="neutral", base_id="cand_1")
+    assert len(board) == 3  # capped, not all 8 survivors
+    # Highest-DSR leader kept its base id; the cap takes the top-3 by score.
+    assert board[0].candidate_id == "cand_1"
+    assert all(e.has_real_rigor for e in board)

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -410,3 +410,79 @@ def test_build_leaderboard_caps_to_top_n(monkeypatch):
     # Highest-DSR leader kept its base id; the cap takes the top-3 by score.
     assert board[0].candidate_id == "cand_1"
     assert all(e.has_real_rigor for e in board)
+# ── Phase 2 — C-regime non-votable Hierarchy-of-Truth gate ────────────────────
+
+
+def _patch_regime(monkeypatch, regime, *, confidence=0.9, status="live"):
+    """Patch the GMM regime read at its lazy-import boundary."""
+    from types import SimpleNamespace as NS
+
+    class _FakeDetector:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_current_regime(self):
+            return NS(regime=regime, confidence=confidence) if regime is not None else None
+
+    monkeypatch.setattr("archimedes.services.gmm_regime_detector.GmmRegimeDetector", _FakeDetector)
+    monkeypatch.setattr(
+        "archimedes.services.gmm_regime_detector.gmm_regime_health",
+        lambda: NS(status=status, reason="test"),
+    )
+
+
+def test_critic_regime_crisis_forces_abstain(monkeypatch):
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.CRISIS)
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is True
+    assert gate["regime"] == "crisis"
+    assert "CRISIS" in gate["reason"]
+
+
+def test_critic_regime_risk_on_does_not_gate(monkeypatch):
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.RISK_ON)
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is False
+    assert gate["regime"] == "risk_on"
+
+
+def test_critic_regime_unavailable_fails_safe_to_no_gate(monkeypatch):
+    # No regime read (None) must NEVER force-approve and must not crash — it simply
+    # does not gate (the critic can only ABSTAIN, never spuriously APPROVE).
+    _patch_regime(monkeypatch, None)
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is False
+    assert gate["regime"] is None
+
+
+def test_regime_degraded_does_not_force_abstain(monkeypatch):
+    # DEGRADED (VIX fallback) on a non-crisis regime must not force abstain — else
+    # the society would always abstain whenever the GMM artifact is missing.
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.RISK_OFF, status="degraded")
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is False
+    assert gate["degraded"] is True
+
+
+def test_build_leaderboard_regime_gate_overrides_strong_survivors():
+    # Even with candidates that clear C-null, a non-votable CRISIS gate abstains.
+    rigor_results = [
+        (_fake_proposal("A", ["2401.00001", "2402.00001"]), _fake_ev(cagr=0.3, dsr=3.0)),
+        (_fake_proposal("B", ["2401.00002", "2402.00002"]), _fake_ev(cagr=0.2, dsr=2.0)),
+    ]
+    board = de.build_leaderboard(
+        rigor_results,
+        regime="neutral",
+        base_id="cand_1",
+        regime_force_abstain=True,
+        regime_reason="CRISIS regime (confidence=0.90) — non-votable ABSTAIN",
+    )
+    assert len(board) == 1
+    assert board[0].generation_method == "debate_abstain"
+    assert "Hierarchy-of-Truth" in board[0].thesis or "Regime gate" in board[0].reasoning

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -1,0 +1,387 @@
+"""Hermetic tests for the T1.1 debate society (Phase 1 skeleton).
+
+No live LLM / Redis / Postgres / Arc RPC. The proposer/critic LLM seams are
+mocked at the boundary (``make_llm_backend`` / ``evaluate_fusion_spec``); the
+deterministic cull/rank/abstain logic is tested directly against fake
+``FusionEvalResult``-shaped objects.
+
+Covers spec §9 Phase-1 tests:
+  1. canned society → leaderboard, every entry has_real_rigor=True
+  2. regime divergence (fix A4): bull vs bear evidence sets differ (Jaccard < 1)
+  3. ABSTAIN → populated SKIP-shaped result (generation_method="debate_abstain")
+  4. DebateUnavailable on empty pool → honest fallback signal (subclass)
+  5. pool_size → num_trials (fix A1): evaluate_fusion_spec called with pool_size
+  6. model threading (fix A3): FusionProposal.model reflects the user pick
+  7. DSL conformance (fix A5): realized_vol_N dropped, no DSLError escapes
+  8. flag-OFF byte-identical (fix A2): _pick_pipeline never returns "debate" OFF
+  9. cited-paper union non-empty; transcript in fixed role order (R3 determinism)
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from archimedes.agents import debate_engine as de
+from archimedes.agents.strategy_fusion import FusionBrief, StrategyFusion, load_corpus, select_candidates
+from archimedes.api.generate_schemas import GenerateBrief
+
+# ── Fixture corpus: 3 momentum-flavored + 3 defensive-flavored + 1 noise ──────
+
+_MOMENTUM_ROWS = [
+    {
+        "arxiv_id": f"2401.0000{i}",
+        "title": f"Cross-Sectional Equity Momentum and Trend Following {i}",
+        "authors": ["A. Mom"],
+        "primary_category": "q-fin.PM",
+        "categories": ["q-fin.PM"],
+        "published": f"2024-01-0{i}",
+        "updated": f"2024-01-0{i}",
+        "abstract": "Momentum, trend-following, breakout and carry factor alpha in the cross-section of equities.",
+        "pdf_url": f"http://x/m{i}",
+        "pdf_sha256": "a" * 64,
+        "pdf_path": f"data/corpus/pdfs/2401.0000{i}.pdf",
+        "text_path": f"data/corpus/text/2401.0000{i}.txt",
+        "fetched_at": "2026-05-16T00:00:00Z",
+    }
+    for i in (1, 2, 3)
+]
+
+_DEFENSIVE_ROWS = [
+    {
+        "arxiv_id": f"2402.0000{i}",
+        "title": f"Volatility-Managed Defensive Hedging {i}",
+        "authors": ["B. Def"],
+        "primary_category": "q-fin.PM",
+        "categories": ["q-fin.PM"],
+        "published": f"2024-02-0{i}",
+        "updated": f"2024-02-0{i}",
+        "abstract": "Volatility, vol-managed defensive hedge tail risk drawdown and mean-reversion overlays.",
+        "pdf_url": f"http://x/d{i}",
+        "pdf_sha256": "b" * 64,
+        "pdf_path": f"data/corpus/pdfs/2402.0000{i}.pdf",
+        "text_path": f"data/corpus/text/2402.0000{i}.txt",
+        "fetched_at": "2026-05-16T00:00:00Z",
+    }
+    for i in (1, 2, 3)
+]
+
+_ALL_ROWS = _MOMENTUM_ROWS + _DEFENSIVE_ROWS
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    p = tmp_path / "manifest.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in _ALL_ROWS), encoding="utf-8")
+    return load_corpus(p)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Every test starts with both flags explicitly cleared."""
+    monkeypatch.delenv("ARCHIMEDES_DEBATE_ENABLED", raising=False)
+    monkeypatch.delenv("ARCHIMEDES_FUSION_ENABLED", raising=False)
+    monkeypatch.delenv("ARCHIMEDES_CORPUS_MANIFEST", raising=False)
+    monkeypatch.delenv("DEBATE_POOL_MAX", raising=False)
+
+
+# ── Canned backends ───────────────────────────────────────────────────────────
+
+_CONFORMANT_SPEC = {
+    "name": "Momentum/vol fusion",
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "monthly",
+    "entry": {"gt": ["momentum_20", 0]},
+    "exit": {"lt": ["close", "sma_200"]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "look_ahead_safe": True,
+    "parameter_variants": {"momentum": [10, 20, 40]},
+}
+
+_NONCONFORMANT_SPEC = {
+    "name": "Realized-vol trap",
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "monthly",
+    "entry": {"gt": ["realized_vol_5", 0.2]},  # validates but raises DSLError at interpret
+    "exit": {"lt": ["close", "sma_200"]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "look_ahead_safe": True,
+}
+
+
+class _CannedFusionBackend:
+    """Returns a parseable fusion of the first 2 candidate papers + a spec.
+
+    ``served_model`` is derived from the requested model so the A3 model-threading
+    test can prove the user's pick flowed through.
+    """
+
+    def __init__(self, model=None, *, spec=None):
+        self.model_id = model or "env-default"
+        self.served_model = f"served::{self.model_id}"
+        self.available = True
+        self._spec = spec if spec is not None else _CONFORMANT_SPEC
+
+    def complete(self, system: str, user: str) -> str:
+        payload = json.loads(user)
+        ids = [p["arxiv_id"] for p in payload["candidate_papers"][:2]]
+        spec = dict(self._spec)
+        spec["source_arxiv_ids"] = ids
+        return json.dumps(
+            {
+                "strategy_name": "Debate canned fusion",
+                "thesis": "Fuse momentum + vol mechanisms.",
+                "source_arxiv_ids": ids,
+                "fusion_reasoning": "canned",
+                "novelty_rationale": "canned",
+                "risk_notes": "canned",
+                "strategy_spec": spec,
+            }
+        )
+
+
+# ── Fake FusionEvalResult-shaped objects (deterministic critic inputs) ────────
+
+
+def _fake_ev(*, cagr, dsr=1.5, passing=True, oos=1.2, num_trials=5):
+    rigor = SimpleNamespace(
+        dsr=dsr,
+        dsr_p_value=0.01,
+        pbo_score=0.1,
+        oos_sharpe=oos,
+        in_sample_sharpe=1.3,
+        look_ahead_clean=True,
+        look_ahead_label="clean",
+        num_trials=num_trials,
+        passing=passing,
+        data_source="synthetic",
+        admissible=False,
+    )
+    bt = SimpleNamespace(
+        sharpe_ratio=1.4,
+        sortino_ratio=1.6,
+        max_drawdown=-0.1,
+        cagr=cagr,
+        calmar_ratio=1.1,
+        win_rate=0.55,
+        total_trades=42,
+    )
+    return SimpleNamespace(rigor=rigor, backtest=bt, success=True, admissible=False, error=None, spec={})
+
+
+def _fake_proposal(name, ids, spec=None):
+    return SimpleNamespace(
+        strategy_name=name,
+        thesis="thesis",
+        source_arxiv_ids=ids,
+        strategy_spec=spec or dict(_CONFORMANT_SPEC),
+        fusion_reasoning="reasoning",
+        novelty_rationale="novelty",
+        is_actionable=True,
+    )
+
+
+class _FakeEmit:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, name, **kw):
+        self.events.append((name, kw))
+
+
+# ── Test 1 — leaderboard build, every entry has_real_rigor=True ───────────────
+
+
+def test_build_leaderboard_all_entries_have_real_rigor():
+    rigor_results = [
+        (_fake_proposal("A", ["2401.00001", "2402.00001"]), _fake_ev(cagr=0.2, dsr=2.0)),
+        (_fake_proposal("B", ["2401.00002", "2402.00002"]), _fake_ev(cagr=0.1, dsr=1.0)),
+    ]
+    board = de.build_leaderboard(rigor_results, regime="neutral", base_id="cand_1")
+    assert len(board) == 2
+    assert all(e.has_real_rigor for e in board)
+    assert all(e.generation_method == "debate" for e in board)
+    # Leader is the higher-DSR candidate and keeps the base id.
+    assert board[0].strategy_name == "A"
+    assert board[0].candidate_id == "cand_1"
+    assert board[1].candidate_id == "cand_1_alt1"
+
+
+# ── Test 2 — regime divergence (fix A4) ───────────────────────────────────────
+
+
+def test_regime_steers_diverge_on_fixture_corpus(monkeypatch, corpus):
+    # Isolate the KEYWORD+bias divergence guarantee (fix A4). The semantic rerank
+    # (FUSION_SEMANTIC_RETRIEVAL, default ON) keys on strategic_direction — IDENTICAL
+    # for both steers — so on a degraded/TF-IDF corpus it re-sorts bull and bear to
+    # the SAME order and ERASES the divergence. That collapse is precisely the
+    # diversity-theater risk the spec flags (§4): genuine divergence needs real
+    # embeddings (#778). The bias-at-the-keyword-core guarantee is what must hold now.
+    monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "false")
+    brief = FusionBrief(asset_classes=[], strategic_direction="systematic equity strategy", max_papers=3)
+    bull = {p.arxiv_id for p in select_candidates(brief, corpus, regime_bias="bull")}
+    bear = {p.arxiv_id for p in select_candidates(brief, corpus, regime_bias="bear")}
+    assert bull and bear
+    # Jaccard < 1.0 — the steers must NOT collapse to the same tail.
+    jaccard = len(bull & bear) / len(bull | bear)
+    assert jaccard < 1.0
+
+
+# ── Test 3 — ABSTAIN path ─────────────────────────────────────────────────────
+
+
+def test_abstain_when_no_candidate_beats_passive_null():
+    # Every candidate's edge (cagr) is below the 5 bps null bar → abstain.
+    rigor_results = [
+        (_fake_proposal("A", ["2401.00001", "2402.00001"]), _fake_ev(cagr=0.0)),
+        (_fake_proposal("B", ["2401.00002", "2402.00002"]), _fake_ev(cagr=0.0001)),
+    ]
+    board = de.build_leaderboard(rigor_results, regime="neutral", base_id="cand_1")
+    assert len(board) == 1
+    abstain = board[0]
+    assert abstain.generation_method == "debate_abstain"
+    assert abstain.has_real_rigor is False
+    assert abstain.passes_rigor is False
+    assert abstain.weights == {}
+    assert "abstain" in abstain.strategy_name.lower()
+
+
+# ── Test 4 — DebateUnavailable on empty pool ──────────────────────────────────
+
+
+async def test_empty_pool_raises_debate_unavailable(monkeypatch):
+    from archimedes.agents.generation_pipeline import FusionUnavailable
+
+    async def _empty_pool(*a, **k):
+        return []
+
+    monkeypatch.setattr(de, "_propose_pool", _empty_pool)
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+
+    brief = GenerateBrief(intent="momentum equities")
+    with pytest.raises(de.DebateUnavailable) as exc:
+        await de._run_debate_candidate(candidate_id="cand_1", brief=brief, emit=_FakeEmit())
+    # Subclasses FusionUnavailable so the existing fallback relabels to agent.
+    assert isinstance(exc.value, FusionUnavailable)
+
+
+async def _passthrough_to_thread(fn, *a, **k):
+    return fn(*a, **k)
+
+
+# ── Test 5 — pool_size → num_trials (fix A1) ──────────────────────────────────
+
+
+async def test_critic_rigor_threads_pool_size_as_num_trials(monkeypatch):
+    seen_num_trials = []
+
+    def _fake_eval(spec, *, num_trials=None, **kw):
+        seen_num_trials.append(num_trials)
+        return _fake_ev(cagr=0.2, num_trials=num_trials)
+
+    monkeypatch.setattr("archimedes.services.fusion_evaluator.evaluate_fusion_spec", _fake_eval)
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+
+    pool = [_fake_proposal(f"P{i}", [f"id{i}a", f"id{i}b"]) for i in range(3)]
+    pool_size = len(pool)
+    results = await de._critic_rigor(pool, pool_size)
+
+    assert seen_num_trials == [pool_size, pool_size, pool_size]
+    # And the persisted verdict echoes pool_size as the DSR denominator.
+    board = de.build_leaderboard(results, regime="neutral", base_id="cand_1")
+    assert board[0].rigor_verdict["num_trials"] == pool_size
+
+
+# ── Test 6 — model threading (fix A3) ─────────────────────────────────────────
+
+
+def test_model_pick_threads_into_served_model(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    captured = {}
+
+    def _fake_make(model=None, **kw):
+        captured["model"] = model
+        return _CannedFusionBackend(model=model)
+
+    monkeypatch.setattr("archimedes.agents.strategy_fusion.make_llm_backend", _fake_make)
+
+    brief = FusionBrief(asset_classes=[], strategic_direction="momentum", max_papers=4)
+    proposal = StrategyFusion(model="user-model-x", corpus=corpus).propose(brief)
+
+    assert captured["model"] == "user-model-x"
+    assert proposal.requested_model == "user-model-x"  # what we asked for (backend.model_id)
+    assert proposal.model == "served::user-model-x"  # the TRUE served model (field of record)
+    assert proposal.is_actionable
+
+
+# ── Test 7 — DSL conformance (fix A5) ─────────────────────────────────────────
+
+
+def test_dsl_conformance_guard_rejects_realized_vol():
+    assert de._dsl_conformance_ok(_CONFORMANT_SPEC) is True
+    assert de._dsl_conformance_ok(_NONCONFORMANT_SPEC) is False
+    assert de._dsl_conformance_ok(None) is False
+    assert de._dsl_conformance_ok({"name": "no trees"}) is False
+
+
+async def test_propose_pool_drops_nonconformant_specs(monkeypatch, corpus):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+
+    def _fake_make(model=None, **kw):
+        return _CannedFusionBackend(model=model, spec=_NONCONFORMANT_SPEC)
+
+    monkeypatch.setattr("archimedes.agents.strategy_fusion.make_llm_backend", _fake_make)
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+
+    brief = GenerateBrief(intent="momentum equities", max_papers=4)
+    pool = await de._propose_pool(brief, "m", corpus)
+    # Every proposal emitted realized_vol_5 → all dropped by the A5 guard; no DSLError.
+    assert pool == []
+
+
+# ── Test 8 — flag-OFF byte-identical (fix A2) ─────────────────────────────────
+
+
+def test_pick_pipeline_never_returns_debate_when_flag_off(monkeypatch):
+    from archimedes.agents.generation_pipeline import _pick_pipeline
+
+    monkeypatch.delenv("ARCHIMEDES_DEBATE_ENABLED", raising=False)
+    brief = GenerateBrief(intent="momentum equities")
+    name, _reason = _pick_pipeline(brief, mode_override="debate")
+    assert name != "debate"
+    assert name in ("fusion", "architect", "agent")
+
+
+def test_pick_pipeline_returns_debate_when_flag_on(monkeypatch):
+    from archimedes.agents.generation_pipeline import _pick_pipeline
+
+    monkeypatch.setenv("ARCHIMEDES_DEBATE_ENABLED", "1")
+    brief = GenerateBrief(intent="momentum equities")
+    name, reason = _pick_pipeline(brief)
+    assert name == "debate"
+    assert "ARCHIMEDES_DEBATE_ENABLED" in reason
+
+
+# ── Test 9 — cited-paper union non-empty; transcript fixed role order ─────────
+
+
+def test_leaderboard_entries_carry_cited_papers():
+    rigor_results = [
+        (_fake_proposal("A", ["2401.00001", "2402.00001"]), _fake_ev(cagr=0.2)),
+    ]
+    board = de.build_leaderboard(rigor_results, regime="neutral", base_id="cand_1")
+    union = {a for e in board for a in e.source_arxiv_ids}
+    assert union == {"2401.00001", "2402.00001"}
+
+
+async def test_debate_round_transcript_in_fixed_role_order(monkeypatch):
+    monkeypatch.setattr(
+        "archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: _CannedFusionBackend(model=model)
+    )
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+
+    pool = [_fake_proposal("A", ["2401.00001", "2402.00001"])]
+    transcript = await de._debate_round(pool, "m", _FakeEmit(), "cand_1")
+    # Best-effort round still produces a deterministic [bull, bear] ordering.
+    assert [t["role"] for t in transcript] == ["bull", "bear"]

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -375,16 +375,51 @@ def test_leaderboard_entries_carry_cited_papers():
     assert union == {"2401.00001", "2402.00001"}
 
 
-async def test_debate_round_transcript_in_fixed_role_order(monkeypatch):
-    monkeypatch.setattr(
-        "archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: _CannedFusionBackend(model=model)
-    )
+class _DebateBackend:
+    """Records prompts; returns role-appropriate claims so the rebuttal is testable."""
+
+    model_id = "x"
+    served_model = "x"
+    available = True
+
+    def __init__(self):
+        self.prompts = []
+
+    def complete(self, system, user):
+        self.prompts.append(system)
+        role = "bull" if "bull researcher" in system else "bear"
+        return json.dumps(
+            {
+                "verdict": "act" if role == "bull" else "decline",
+                "confidence": 0.7,
+                "key_claims": [f"{role}-claim"],
+            }
+        )
+
+
+async def test_debate_round_two_rounds_with_visible_rebuttal(monkeypatch):
+    backend = _DebateBackend()
+    monkeypatch.setattr("archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: backend)
     monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
 
     pool = [_fake_proposal("A", ["2401.00001", "2402.00001"])]
     transcript = await de._debate_round(pool, "m", _FakeEmit(), "cand_1")
-    # Best-effort round still produces a deterministic [bull, bear] ordering.
-    assert [t["role"] for t in transcript] == ["bull", "bear"]
+    # Fixed [bull-r1, bear-r1, bull-r2, bear-r2] order (R3 determinism).
+    assert [(t["role"], t["round"]) for t in transcript] == [("bull", 1), ("bear", 1), ("bull", 2), ("bear", 2)]
+    # The visible rebuttal: each round-2 prompt carries the OTHER side's round-1 claim.
+    bull_r2_prompt, bear_r2_prompt = backend.prompts[2], backend.prompts[3]
+    assert "bear-claim" in bull_r2_prompt  # bull rebuts the bear
+    assert "bull-claim" in bear_r2_prompt  # bear rebuts the bull
+
+
+async def test_debate_round_degrades_when_backend_unavailable(monkeypatch):
+    class _Down:
+        available = False
+
+    monkeypatch.setattr("archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: _Down())
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+    transcript = await de._debate_round([_fake_proposal("A", ["1", "2"])], "m", _FakeEmit(), "cand_1")
+    assert transcript == []  # never gates; no backend → empty best-effort transcript
 
 
 # ── Review fixes: pool-max bound + leaderboard top-N cap ──────────────────────

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -445,21 +445,22 @@ def test_build_leaderboard_caps_to_top_n(monkeypatch):
     # Highest-DSR leader kept its base id; the cap takes the top-3 by score.
     assert board[0].candidate_id == "cand_1"
     assert all(e.has_real_rigor for e in board)
+
+
 # ── Phase 2 — C-regime non-votable Hierarchy-of-Truth gate ────────────────────
 
 
 def _patch_regime(monkeypatch, regime, *, confidence=0.9, status="live"):
-    """Patch the GMM regime read at its lazy-import boundary."""
+    """Patch the SHARED live-regime read (`current_regime`) + health at the boundary.
+
+    `_critic_regime` reads the most-recently-constructed detector via the module-level
+    `current_regime()` accessor (NOT a fresh GmmRegimeDetector, which would have no
+    classification), so the test patches that accessor.
+    """
     from types import SimpleNamespace as NS
 
-    class _FakeDetector:
-        def __init__(self, *a, **k):
-            pass
-
-        def get_current_regime(self):
-            return NS(regime=regime, confidence=confidence) if regime is not None else None
-
-    monkeypatch.setattr("archimedes.services.gmm_regime_detector.GmmRegimeDetector", _FakeDetector)
+    rc = NS(regime=regime, confidence=confidence) if regime is not None else None
+    monkeypatch.setattr("archimedes.services.gmm_regime_detector.current_regime", lambda: rc)
     monkeypatch.setattr(
         "archimedes.services.gmm_regime_detector.gmm_regime_health",
         lambda: NS(status=status, reason="test"),
@@ -542,3 +543,14 @@ def test_critic_prov_keeps_fully_grounded_candidates(corpus):
     kept, dropped = de._critic_prov([a, b], corpus)
     assert len(kept) == 2
     assert dropped == []
+
+
+def test_critic_prov_robust_to_missing_citations(corpus):
+    # A proposal missing source_arxiv_ids (None / absent attr) must DROP, not raise
+    # and abort the whole run (Copilot review).
+    none_cited = SimpleNamespace(strategy_name="none", source_arxiv_ids=None)
+    no_attr = SimpleNamespace(strategy_name="noattr")  # attribute absent entirely
+    good = _fake_proposal("good", ["2401.00001", "2402.00001"])
+    kept, dropped = de._critic_prov([none_cited, no_attr, good], corpus)
+    assert [p.strategy_name for p in kept] == ["good"]
+    assert {p.strategy_name for p in dropped} == {"none", "noattr"}

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -486,3 +486,24 @@ def test_build_leaderboard_regime_gate_overrides_strong_survivors():
     assert len(board) == 1
     assert board[0].generation_method == "debate_abstain"
     assert "Hierarchy-of-Truth" in board[0].thesis or "Regime gate" in board[0].reasoning
+
+
+# ── Phase 2 — C-prov non-votable provenance/embargo gate (Xia 1/2/4) ──────────
+
+
+def test_critic_prov_drops_citations_outside_the_surface(corpus):
+    # The fixture corpus surface = {2401.0000{1,2,3}, 2402.0000{1,2,3}} (embargo-clean).
+    clean = _fake_proposal("clean", ["2401.00001", "2402.00001"])
+    dirty = _fake_proposal("dirty", ["2401.00001", "9999.99999"])  # 9999.* not in the surface
+    empty = _fake_proposal("empty", [])  # no citations → cannot verify provenance
+    kept, dropped = de._critic_prov([clean, dirty, empty], corpus)
+    assert [p.strategy_name for p in kept] == ["clean"]
+    assert {p.strategy_name for p in dropped} == {"dirty", "empty"}
+
+
+def test_critic_prov_keeps_fully_grounded_candidates(corpus):
+    a = _fake_proposal("a", ["2401.00002", "2402.00002"])
+    b = _fake_proposal("b", ["2401.00003", "2402.00003"])
+    kept, dropped = de._critic_prov([a, b], corpus)
+    assert len(kept) == 2
+    assert dropped == []

--- a/docs/specs/execution-trading-agent-society-spec.md
+++ b/docs/specs/execution-trading-agent-society-spec.md
@@ -1,0 +1,427 @@
+# Execution / Trading Agent Society — Spec (DRAFT)
+
+> **Status:** DRAFT, 2026-06-28. Seed-and-refine artifact for T1.1's *second*
+> agent society — the **Type‑2 / Execution** society that trades and rebalances the
+> strategies users **deploy**. Distinct from the generation/debate society
+> (`docs/specs/multi-agent-debate-spec.md`), which produces and rigor-gates
+> *candidate* strategies. This spec describes what happens **after Deploy**: a
+> deployed strategy's DSL "blueprint" is executed and kept in line with its own
+> instructions, on-chain, under a hard custody boundary.
+>
+> **Scope fence (mirror of the generation spec's fence):** the generation society
+> is **generation-only**; *this* society is **execution-only**. It NEVER authors a
+> strategy, NEVER re-derives target weights from a brief, NEVER touches the rigor
+> gate. It consumes a *frozen blueprint* and acts within it. The two societies meet
+> at exactly one artifact: the **deployed-strategy blueprint** (§2).
+>
+> **Lineage to read together:**
+> - [`docs/user-stories.md`](../user-stories.md) — the locked product spine (execute → monitor is this society's lane)
+> - [issue #760](https://github.com/a-apin/archimedes/issues/760) — the "blueprint" concept this spec formalizes (Type‑2 Agent Readiness Dependency Map)
+> - [`docs/specs/strategy-lifecycle-spec.md`](./strategy-lifecycle-spec.md) — `Deployed → Active → Completed`; this society drives those transitions
+> - [`docs/specs/vault-semantics-spec.md`](./vault-semantics-spec.md) + [`docs/specs/commit-reveal-trace-spec.md`](./commit-reveal-trace-spec.md) — the on-chain settlement + provenance contracts
+> - [`docs/specs/selection-bias-corrections-spec.md`](./selection-bias-corrections-spec.md) + [`docs/specs/xia-2026-protocols.md`](./xia-2026-protocols.md) — `V_check`, Source Tracking, Hierarchy of Truth (consumed here, enforced upstream)
+
+---
+
+## §0. The two societies, side by side
+
+Archimedes runs **two** agent societies over one strategy library. They share data
+(the library, the corpus, the regime detector, the trace registry) but are
+operationally independent — different entry points, different cadence, different
+authority.
+
+```
+┌──────────────────────────────────────┐        ┌──────────────────────────────────────┐
+│  GENERATION / DEBATE SOCIETY (Type 1) │        │  EXECUTION / TRADING SOCIETY (Type 2) │
+│  agents/generation_pipeline.py        │        │  chain/agent_runner.py  (StrategyRunner)│
+│                                       │        │                                       │
+│  brief → debate → N candidates →      │ DEPLOY │  blueprint → schedule → regime+drift  │
+│  rigor gate → best → PERSIST          │ ─────▶ │  → V_check → commit → trade → reveal   │
+│                                       │ (hand- │                                       │
+│  authority: NONE on-chain.            │  off)  │  authority: rebalance-only. NEVER     │
+│  writes StrategyRecord + Passport.    │        │  withdraw-to-platform. (PR #731)      │
+│  cadence: per Generate request (SSE). │        │  cadence: per-tick loop (default 300s)│
+└──────────────────────────────────────┘        └──────────────────────────────────────┘
+        run_generation(...)                              StrategyRunner.tick()
+        terminal event: "done"                           terminal: commit→trade→reveal
+```
+
+The hand-off is a **frozen artifact, not a function call**. The generation society
+finishes (`run_generation` emits `done`, persists a `StrategyRecord` +
+`StrategyPassport`); the user clicks Deploy; a vault is created; this society
+*discovers* the deployed strategy on its next tick and begins executing it. No live
+coupling — the societies can be redeployed independently.
+
+**What already exists vs. what this spec adds.** The execution loop is **largely
+built and live** today — `chain/agent_runner.py:StrategyRunner.tick()` is the real
+per-tick cycle, `chain/executor.py:ChainExecutor.execute_trades()` builds the real
+on-chain rebalance, the custody boundary (PR #731) and commit-before-trade (#589 /
+#755) are enforced on-chain, and #783 killed the silent buy-and-hold fallback by
+driving live signals from validated DSL specs (`services/strategy_signal_evaluator.py:_spec_signal`).
+**This spec's job is to (a) name that machinery as a first-class "society," (b)
+formalize the blueprint hand-off contract, and (c) define the agent roster + the
+metered-compute tie-in as the build-out path** — not to invent the loop from scratch.
+
+---
+
+## §1. Purpose + scope
+
+### In scope
+
+1. **Consume a deployed strategy's blueprint** (§2) — the DSL spec, target weights,
+   rebalance cadence/triggers, regime conditions, and provenance — and execute it
+   per its own instructions.
+2. **Decide when to rebalance** — read the live GMM regime + portfolio drift, and
+   rebalance only when the strategy's blueprint says to (drift threshold crossed,
+   cadence bar reached, or regime condition triggered).
+3. **Gate every action deterministically** — `V_check` (Xia §5) on the target weights
+   before any swap; refuse the rebalance if weights are invalid, regardless of any
+   model's confidence.
+4. **Build + submit the on-chain rebalance** — diff current vs. target, construct the
+   swap legs, commit the reasoning trace *before* the trade (#589), execute, reveal.
+5. **Drive lifecycle transitions** — `Deployed → Active` (first funded rebalance) and
+   `Active → Completed` (window end), per the lifecycle spec.
+6. **Be meterable** — every rebalance run is a discrete, attributable unit of compute
+   that the nanopayment/metered-compute layer (§6) can price and freemium-cap.
+
+### Explicitly out of scope (the fence)
+
+- **Generating or re-deriving a strategy.** Target weights come from the blueprint /
+  the strategy's own signal rule, never from a brief. (`PortfolioConstructor.construct`
+  *throttles* blueprint weights by regime; it does not author them — its
+  `_fallback_weights` path has no production caller.)
+- **The rigor gate.** DSR/PBO/OOS/look-ahead run upstream in the generation society;
+  this society trusts the `passes_rigor`/passport verdict it inherits and never
+  re-runs it.
+- **Withdraw / custody.** The agent has `onlyManager` (rebalance) authority on the
+  `Vault`, never owner authority (oracles, slippage cap, pause, `setAgent`,
+  withdraw-to-platform). See §4.
+
+---
+
+## §2. The hand-off contract — what a deployed strategy carries
+
+The blueprint is the **single artifact** that crosses the society boundary. Issue
+#760 frames it as the "agent behavior requirements" (its sections 1, 2, 4 — the
+strategy library, the signal evaluators, and the runtime parameters); this spec pins
+it to the **already-persisted** carriers so the two societies stay decoupled.
+
+### 2.1 Where the blueprint lives today (the real carriers)
+
+A deployed strategy is **already** persisted by the generation society's tail
+(`generation_pipeline.py:_persist_candidate` → `upsert_strategy(...)` +
+`ingest_passport(...)`). The execution society reads it back through the strategy
+provider and the vault metadata — it does **not** receive a fresh object.
+
+| Blueprint field | Type / carrier | Source of truth (verified symbol) | Consumed by (execution side) |
+|---|---|---|---|
+| **DSL spec** (`entry`/`exit`/`position_sizing`/…) | `dict` on `StrategyRecord.strategy_spec` | `validate_strategy_spec()` → `StrategySpec` (`services/strategy_dsl.py`); set at persist time | `strategy_signal_evaluator._spec_signal()` interprets it live (#783) |
+| **Asset universe** | `list[str]` (tickers/synths) | `derive_asset_universe(brief.asset_classes)` overrides spec's `asset_universe` in fusion | `evaluate_strategies()` maps `asset_universe → synth` via `synth_map` |
+| **Target weights** (per asset) | derived per-tick from the signal rule | `aggregate_signals()` averages per-asset votes, applies `usdc_floor` | `StrategyRunner.tick()` step 3 |
+| **Rebalance cadence** | `rebalance_frequency ∈ {daily,weekly,monthly}` | `StrategySpec.rebalance_frequency` (DSL) | (cadence agent — §3; today the runner ticks every `AGENT_INTERVAL_SECONDS`) |
+| **Rebalance trigger (drift)** | scalar threshold | `agent_runner._DRIFT_THRESHOLD = 0.15` (hardcoded today) | `_compute_trades()` skips legs with `abs(drift) < threshold` |
+| **Regime conditions** | regime-aware throttle | `REGIME_MULTIPLIER` (`portfolio_constructor.py`) + per-asset regime bias | `PortfolioConstructor.construct(regime=…, ensemble_consensus=…)` |
+| **Provenance** | `source_arxiv_ids`, `methodology_hash`, paper hashes | `StrategyPassport` (ingested at persist) | `_paper_hashes_from_signals()` → trace `consulted_paper_hashes` |
+| **Per-vault scope** | `list[str]` strategy_ids | `VaultMetadata.get_strategy_ids()` | `agent_runner._get_vault_strategy_ids()` |
+
+> **Drift to fix in v2 of this spec (#760 follow-up).** The blueprint's cadence and
+> drift trigger are currently *implicit*: cadence collapses to the global tick
+> interval and the drift threshold is a module constant, so a "monthly, 5%-drift"
+> strategy and a "daily, 20%-drift" strategy are executed identically. Promoting
+> `rebalance_frequency` + a per-strategy drift threshold to **honored** blueprint
+> fields (read by the cadence/rebalance-decision agents in §3) is the headline
+> behavioral upgrade this society needs. Until then, document the gap honestly — do
+> not claim per-strategy cadence on stage.
+
+### 2.2 Blueprint schema (the data format #760 asks for)
+
+A **derived, read-only** projection assembled by the execution society at deploy-
+discovery time — NOT a new persisted table (it is a view over the carriers above):
+
+```jsonc
+{
+  "strategy_id": "cand_bull_a1b2",          // StrategyRecord.id
+  "vault_address": "0x…",                    // the deployed vault
+  "dsl_spec": { /* validated StrategySpec dict — entry/exit/sizing/… */ },
+  "asset_universe": ["sSPY", "sQQQ"],        // resolved synths
+  "rebalance": {
+    "cadence": "monthly",                    // from rebalance_frequency  (OPEN: honor it — §3)
+    "drift_threshold": 0.15,                 // per-strategy  (OPEN: currently global _DRIFT_THRESHOLD)
+    "regime_aware": true                      // does PortfolioConstructor throttle apply
+  },
+  "provenance": {
+    "source_arxiv_ids": ["0706.1497", "1704.03022"],
+    "methodology_hash": "0x…",
+    "passes_rigor": true,                    // inherited verdict — NOT re-checked here
+    "admissible": true
+  },
+  "lifecycle": { "state": "Deployed", "window_start": null, "window_end": null }
+}
+```
+
+**Invariant:** the execution society treats `dsl_spec` + `provenance` as **frozen**.
+If the spec is invalid at execution time, the live path returns a **loud FLAT with a
+reason** (`_spec_signal` on `DSLError`), never a silent buy-and-hold (#783) — the
+strategy simply holds cash until a human re-deploys a corrected blueprint.
+
+---
+
+## §3. Agent roster
+
+Four roles. Three are **deterministic gates / builders** (cheap, auditable, no LLM
+budget); the regime/decision role reads the live GMM detector. This mirrors the
+generation spec's "deterministic-critic budget trick" — keep the expensive reasoning
+in the generation society; the execution society is mostly mechanical and provable.
+
+| # | Agent | Job | Backed by (real symbol) | Determinism |
+|---|---|---|---|---|
+| 1 | **Scheduler / Cadence** | Decide *whether this tick is a decision point* for each deployed strategy (cadence bar reached? window open?). | today: the `StrategyRunner.run()` loop (`AGENT_INTERVAL_SECONDS`); **to build:** honor `rebalance_frequency` per strategy | deterministic |
+| 2 | **Rebalance‑Decision** | Read live regime + portfolio drift; decide *what* the target should be and whether drift warrants a trade. | `GmmRegimeDetector.classify()/get_current_regime()` + `EnsembleConsensus` + `PortfolioConstructor.construct()` + `_compute_trades()` (`_DRIFT_THRESHOLD`) | deterministic (regime read is a model, the decision is rule-based) |
+| 3 | **Risk / Guardrail** | Deterministic validity gate on the target weights; SKIP the whole rebalance on failure regardless of confidence. | `chain/v_check.py:VCheck(weights_bps=…).run()` + `ChainExecutor._validate_trade_liquidity()` (fail-closed on thin pools) | **fully deterministic** |
+| 4 | **Execution** | Build the on-chain rebalance: commit trace → execute swaps → reveal; drive lifecycle transitions. | `chain/agent_runner.StrategyRunner._process_vault()` → `_commit_trace` → `chain_executor.execute_trades` → `_reveal_trace` | deterministic build; on-chain effects |
+
+### 3.1 The tick (real control flow, `StrategyRunner.tick()`)
+
+```
+EVERY AGENT_INTERVAL_SECONDS (default 300):
+
+  1. provider.list_strategies()                 → deployed blueprints
+  2. strategy_evaluator.evaluate_strategies(...) → per-asset signals
+       └─ DSL-spec strategies → _spec_signal (live↔backtest parity, #783)
+       └─ legacy/curated      → keyword evaluator  (Faber/TSMOM/Vol-managed/…)
+  3. aggregate_signals(usdc_floor)              → raw target weights
+  4. classify_market_regime()                   → GMM (degrades → VixRegimeDetector)
+     PortfolioConstructor.construct(regime, consensus, base_weights)  → throttled targets
+  5. discover + scope vaults (VaultFactory poll; per-vault strategy_ids)
+  6. FOR EACH vault:
+       read_portfolio → _compute_trades (drift gate)
+       if no trades  → SKIP trace (deduped)            ◀── agent #2 says "aligned"
+       VCheck(weights_bps).run()                        ◀── agent #3 GUARDRAIL
+         └─ fail → SKIP trace "v_check_failed", no trade
+       _commit_trace(...)   (COMMIT hash on-chain, claimedExecutionTime)  ◀── #589
+       execute_trades(...)  (real swaps; InsufficientLiquidityError → SKIP+retry)
+       _reveal_trace(...)   (pin IPFS provenance → reveal SAME committed trace)  ◀── agent #4
+  7. save_heartbeat()
+```
+
+Every branch already emits a **reasoning trace** (REBALANCE / SKIP with an explicit
+trigger: `aligned`, `empty_vault`, `v_check_failed`, `insufficient_liquidity`,
+`execution_failed`). That trace stream IS the execution society's "thinking out loud"
+surface — the Type‑2 analogue of the generation society's SSE event vocabulary.
+
+### 3.2 Regime read — honest degradation
+
+The Rebalance‑Decision agent reads `GmmRegimeDetector`, which **falls back to the
+rule-based `VixRegimeDetector`** whenever no fitted `gmm_model.pkl` exists, history
+`< 22` ticks, or VIX/price are missing — the expected steady state until the offline
+fit runs (`gmm_regime_health()` reports `degraded`). On total snapshot failure the
+regime degrades to `"unknown"` and `PortfolioConstructor` applies the conservative
+`REGIME_MULTIPLIER_NONE = 0.7`. The decision is never blocked by an absent model.
+
+---
+
+## §4. The custody boundary it MUST respect
+
+This is the load-bearing constraint and the #1 product invariant
+(`docs/architectural-principles.md` §3). **Owner ≠ agent.** Two enforcement layers,
+both already live:
+
+### 4.1 On-chain authority split (PR #731, `Vault.sol`)
+
+- The agent address holds **`onlyManager`** authority: `rebalance()`,
+  `setTargetAllocations()`, `setTokenOraclesFromRegistry()` (registry-allowlisted
+  oracles only). That is the **entire** surface this society touches.
+- The **owner** (the depositing user, or a governance cold key) holds **`onlyOwner`**:
+  `setTokenOracles`, `setMaxSlippageBps`, `setAgent`, `pause`, `setAssetRegistry`,
+  `setPlatformFeeRecipient`. The agent can **never** call these — verified by the
+  `onlyOwner` modifier and the in-contract comment: *"the agent must not be able to
+  redefine the oracles that feed the rebalance slippage floor … defeating the 'agent
+  has rebalance-only authority' invariant."*
+- **No withdraw-to-platform path exists.** `withdraw`/`redeem` burn the **caller's
+  own** shares (or a spender with allowance); there is no function that lets the agent
+  move user funds to a platform address. Non-custodial by construction.
+- The handoff is applied at vault creation by `executor._apply_non_custodial_ownership`:
+  `setAgent(backendSigner)` then `transferOwnership(user|governance)`. It **refuses to
+  hand ownership to the agent address** and **fails loud** (warns, skips transfer)
+  rather than minting a custodial vault when no distinct owner is resolvable
+  (`ARC_VAULT_GOVERNANCE_ADDRESS`).
+
+### 4.2 Commit‑before‑trade (#589 / #755)
+
+Every swap is bound to a reasoning trace committed in an **earlier block**:
+
+- `Vault.rebalance()` recomputes `tradeId = keccak256(abi.encode(tokensIn, amountsIn,
+  tokensOut, amountsOut))` and calls `traceRegistry.executeTrade(tradeId)` — which
+  **reverts** if no fresh commitment binds this `(vault, trade)`. A trade physically
+  cannot settle without a prior commit. The constructor wires `traceRegistry` so a
+  vault can never exist in a state where `rebalance()` skips the check (#755).
+- The Python side honors this causally: `_process_vault` does
+  `_commit_trace` (anchors the keccak256 with `claimedExecutionTime`, lead window
+  `_COMMIT_EXECUTION_LEAD_S = 60`) **before** `execute_trades`, then `_reveal_trace`
+  reveals the **same** committed `ReasoningTrace` object (settlement fields are added
+  outside the hashed set, so the binding holds). `temporal_binding_valid` is persisted
+  as `commit_block < trade_block`.
+
+**Invariant the society must preserve in every new code path:** *no swap without a
+prior committed trace bound to that exact trade*, and *no owner-only call from the
+agent*. Any agent that builds a rebalance MUST route it through
+`chain_executor.execute_trades` (which goes through `Vault.rebalance`) — never a
+direct router swap that bypasses the registry check.
+
+---
+
+## §5. Where it plugs into existing code
+
+| Concern | File / symbol | Role in this society |
+|---|---|---|
+| **Society entry point + loop** | `chain/agent_runner.py` → `StrategyRunner.tick()` / `run()` | the per-tick orchestrator; agents #1–#4 are stages within it |
+| **Signal evaluation (blueprint → signals)** | `services/strategy_signal_evaluator.py` → `evaluate_strategies` / `_spec_signal` | DSL-spec interpretation (live↔backtest parity, #783); legacy keyword fallback for curated strategies |
+| **Regime + drift sizing (agent #2)** | `services/portfolio_constructor.py` → `PortfolioConstructor.construct` / `compute_position_scale` | regime + ensemble-consensus throttle on blueprint weights (NOT weight authorship) |
+| **Regime read** | `services/gmm_regime_detector.py` → `classify` / `get_current_regime` / `gmm_regime_health` | live regime; degrades to `VixRegimeDetector` |
+| **Risk guardrail (agent #3)** | `chain/v_check.py` → `VCheck.run`; `chain/executor.py` → `_validate_trade_liquidity` | deterministic weight validity + fail-closed liquidity preflight |
+| **Execution build (agent #4)** | `chain/executor.py` → `ChainExecutor.execute_trades` / `read_portfolio` / `create_vault` | builds + submits the `Vault.rebalance` tx (Circle signer or raw key); revert-aware via `_confirm_receipt` |
+| **Trace commit/reveal** | `chain/agent_runner.py` → `_commit_trace` / `_reveal_trace`; `chain/trace_publisher.py` | commit-before-trade + IPFS provenance reveal |
+| **Vault contract** | `contracts/src/Vault.sol` → `rebalance` (`onlyManager`), owner-only setters | the custody-enforcing settlement contract |
+| **State / heartbeat** | `services/redis_state.py` → `AgentStateStore` | regime, ensemble consensus, heartbeat, per-vault last-rebalance, trace index |
+| **Per-vault scope** | `models/chat.py:VaultMetadata` + `agent_runner._get_vault_strategy_ids` | restricts a vault to its owner-selected strategies |
+
+The society is a **standalone process** (`python -m archimedes.chain.agent_runner`),
+separate from the FastAPI app the generation society lives in — reinforcing the
+operational independence in §0.
+
+---
+
+## §6. Metered‑compute / nanopayment tie‑in
+
+Each **rebalance run is a discrete, attributable unit of compute** — exactly the
+shape the nanopayment marketplace ([issue #713](https://github.com/a-apin/archimedes/issues/713),
+x402 + Circle Gateway, sub-cent USDC) prices. This society is the natural metering
+boundary.
+
+### 6.1 What gets metered
+
+- **Unit of metering = one `_process_vault` rebalance** that results in a real trade
+  (`trigger="strategy_signal_drift"`, trace REVEALED). SKIPs (`aligned`,
+  `v_check_failed`, …) are **free** — they cost no swap and produce no value, so they
+  must not be billed (and the runner already dedups identical aligned SKIPs to avoid
+  trace spam).
+- **Provenance for billing is already on the trace:** `vault_address`, `trace_hash`,
+  `trade_tx_hash`, `commit_block`/`trade_block`, `strategies_referenced`. A nanopayment
+  charge can be bound to the same `tradeId`/`trace_hash` the on-chain commit uses, so
+  the charge is *provably* tied to a real, committed rebalance.
+
+### 6.2 Freemium cap + Lambda metering
+
+- **Lambda-metered runs:** when the execution society runs per-vault rebalance
+  evaluations as discrete invocations (a roadmap migration off the always-on tick
+  loop), each invocation is a billable compute event — Lambda duration + a per-trade
+  nanopayment. The always-on `StrategyRunner` loop is the demo path; the metered-
+  Lambda path is the scale path. Keep `tick()` decomposable into per-vault units so a
+  vault's rebalance can be lifted into its own invocation without rewriting the loop.
+- **Freemium cap:** a free tier gets N agent-driven rebalances per window (or
+  cadence-capped to e.g. monthly); beyond that, rebalances require a funded
+  nanopayment / x402 settlement before `execute_trades` runs. The cap check is a new
+  deterministic gate placed **between** the drift decision (agent #2) and the V_check
+  (agent #3) — a "rebalances remaining?" guard that, on exhaustion, emits a SKIP trace
+  (`trigger="freemium_cap_reached"`) instead of trading. It is a *spend* gate, distinct
+  from the generation society's *model-entitlement* gate
+  (`services/model_gate.py:enforce_model_entitlement`, which gates premium LLM models
+  by wallet) — but both share the per-user spend-cap substrate.
+
+> **Out of scope for the draft, named for v2:** the exact x402 challenge/settle
+> handshake and the Gateway revenue split live in #713's spec; this society only needs
+> to expose the **metering hook** (a billable-rebalance event with a trace-bound id)
+> and the **cap gate** (a deterministic pre-trade check). Both are additive — they do
+> not touch the custody or commit-before-trade invariants.
+
+---
+
+## §7. Phased build plan
+
+The loop exists; the work is to **name it as a society, formalize the blueprint, and
+honor the blueprint's cadence/trigger fields** — then add metering. Each phase ships
+behind the existing `AGENT_DRY_RUN` switch so on-chain effects stay gated until proven.
+
+### Phase 0 — Skeleton + blueprint projection (draft-first)
+- [ ] Land **this spec** in `docs/specs/`; cross-link from the generation spec and #760.
+- [ ] Implement the **read-only blueprint projection** (§2.2) as a pure view over
+      `StrategyRecord` + `VaultMetadata` + `StrategyPassport` — *no new table*. A
+      function `build_blueprint(strategy_id, vault_address) -> Blueprint` that the
+      runner can log per deployed strategy at tick start.
+- [ ] **Acceptance:** hermetic test asserting a deployed fusion strategy's persisted
+      `strategy_spec` + arxiv ids round-trip into a `Blueprint` with `passes_rigor`
+      inherited (not recomputed). `env -i … pytest backend/tests/test_blueprint.py -q` → `0 failed`.
+
+### Phase 1 — Honor blueprint cadence + per-strategy drift (the #760 behavioral gap)
+- [ ] Scheduler agent (#1): read `rebalance_frequency` per deployed strategy; a tick is
+      a decision point for a strategy only when its cadence bar has elapsed since its
+      last rebalance (`AgentStateStore` last-rebalance key already exists per vault).
+- [ ] Rebalance‑Decision agent (#2): replace the global `_DRIFT_THRESHOLD` with a
+      per-strategy threshold sourced from the blueprint (default 0.15 preserves current
+      behavior).
+- [ ] **Acceptance:** a "monthly" strategy does not trade on consecutive daily ticks
+      with sub-threshold drift; a "daily" one does. Test against a fake clock + fixture
+      portfolios. **Anti-goal:** do not weaken the existing drift skip or the dedup.
+
+### Phase 2 — Make the roster explicit + the trace stream first-class
+- [ ] Refactor `tick()`/`_process_vault` into the four named stages (§3) with a
+      typed `RebalanceDecision` carrier between them (mirrors the generation society's
+      `_CandidateResult`), so each agent is independently testable.
+- [ ] Ensure every stage's SKIP/REBALANCE branch carries a structured `trigger` (most
+      already do) and surface the trace stream as the Type‑2 "reasoning" view.
+- [ ] **Acceptance:** unit tests per stage; the guardrail stage proven to SKIP on an
+      invalid-weights fixture without ever reaching `execute_trades` (mock the executor,
+      assert not called). **Anti-goal:** do not bypass `VCheck` or commit-before-trade.
+
+### Phase 3 — Metering hook + freemium cap (additive)
+- [ ] Emit a **billable-rebalance event** (trace-bound id) on every REVEALED trade; no
+      event on SKIPs.
+- [ ] Insert the deterministic **freemium-cap gate** between agents #2 and #3; on
+      exhaustion emit `trigger="freemium_cap_reached"` SKIP.
+- [ ] **Acceptance:** capped user's N+1th rebalance SKIPs (executor mock not called);
+      under-cap rebalance proceeds. **Anti-goal:** never bill a SKIP; never let the cap
+      gate touch the custody or commit-before-trade path.
+
+### Phase 4 — Lambda metering (scale path, post-demo)
+- [ ] Lift per-vault rebalance into a discrete invocation; wire Lambda duration + the
+      per-trade nanopayment to #713's settlement. Always-on loop stays the demo path.
+
+---
+
+## §8. Open questions (own-before-bake)
+
+1. **Per-strategy drift threshold source** — is it a blueprint/DSL field, a vault
+   setting, or a strategy-class default? (Önder owns the turnover/cost tradeoff that
+   sets it — see `transaction-cost-turnover-model.md`.) Do **not** bake a single
+   global value into the spec beyond the current 0.15 default.
+2. **Cadence vs. tick granularity** — a "monthly" cadence on a 300s tick means
+   ~8,640 ticks between rebalances; confirm the last-rebalance key is the source of
+   truth for "elapsed," not the loop counter.
+3. **Multi-strategy vaults** — a vault scoped to several strategies aggregates their
+   signals (`aggregate_signals`); does each contributing strategy's cadence apply, or
+   the vault's? (Likely: rebalance when *any* scoped strategy's cadence + drift fire.)
+4. **Metering unit under aggregation** — one charge per vault-rebalance, or per
+   contributing strategy? (Billing simplicity argues per vault-rebalance.)
+5. **Regime-condition triggers in the blueprint** — beyond the throttle, should a
+   blueprint be able to say "go flat on CRISIS"? Today regime only *scales* exposure
+   (`REGIME_MULTIPLIER[CRISIS]=0.1`); a hard regime exit is a blueprint capability to
+   design, not assume.
+
+---
+
+## §9. Invariants checklist (every PR in this society must preserve)
+
+- [ ] **Owner ≠ agent.** No agent code path calls an `onlyOwner` setter or any
+      withdraw-to-platform function. (Grep the diff for `setTokenOracles(` without
+      `FromRegistry`, `setMaxSlippageBps`, `setAgent`, `pause`, `transferOwnership`
+      from agent paths.)
+- [ ] **No swap without a prior committed trace** bound to that exact `tradeId`.
+      Rebalances route through `chain_executor.execute_trades` → `Vault.rebalance`,
+      never a direct router swap.
+- [ ] **`V_check` is unconditional** — invalid weights SKIP, regardless of confidence.
+- [ ] **Liquidity preflight fails closed** — a probe error treats the pool as thin.
+- [ ] **No silent buy-and-hold** — an invalid/missing spec returns loud FLAT-with-reason
+      (#783), never always-long.
+- [ ] **SKIPs are free** — the metering hook never bills a non-trading tick.
+- [ ] **Generation-only / execution-only fence holds** — this society never authors a
+      strategy or runs the rigor gate.

--- a/docs/specs/multi-agent-debate-spec.md
+++ b/docs/specs/multi-agent-debate-spec.md
@@ -1,183 +1,235 @@
-# T1.1 — Multi-Agent Debate Engine Spec
+# T1.1 — Multi-Agent Debate Engine Spec (v2, replacement-scope)
 
 **Status:** design / not yet built · **Owner:** Dan Browne · **Track:** Lepton Tier-1 vertical (Agentic Sophistication, 30%)
-**Slot-in:** `pipeline_name="debate"` runner in `backend/archimedes/agents/generation_pipeline.py`
-**Flag:** `ARCHIMEDES_DEBATE_ENABLED` (default OFF) · **Last verified against source:** 2026-06-26
+**Slot-in:** `pipeline_name="debate"` runner in `backend/archimedes/agents/generation_pipeline.py` (`run_generation` dispatch)
+**Flag:** `ARCHIMEDES_DEBATE_ENABLED` (default OFF) · **Last verified against source:** 2026-06-28 (branch `dbrowneup/t1.1-debate-spec`)
 
-This is a complete, self-contained design. It synthesizes three competing proposals (TradingAgents-faithful, lean-pragmatic, fusion-ensemble-critic) into one recommended architecture, grafting the best of each.
+This is a complete, self-contained, build-ready design. It is the **v2 replacement-scope rewrite** that resolves PR #766. The earlier draft framed the debate as a *fourth, flag-gated peer* alongside fusion/architect/agent with a byte-identical live path. **Dan's call is the opposite: the debate society becomes the only generation pipeline, fusion folds in as an internal capability, and the architect + single-agent paths are deleted.** The flag exists for the *cutover window* (default OFF until the replacement is verified on the live path), and the end state has no legacy generation path to guard — **but the deletions are deferred to a separate cutover PR (Phase 3); Phase 1 is strictly additive** (see §5a and the delete-vs-byte-identical resolution below).
+
+> **Why version refs, not line numbers.** PR #766 demonstrated empirically that raw `file.py:NNN` anchors rot — the prior draft's own anchors had already drifted from HEAD. This spec references **symbols** (functions, classes, fields, dataclass attributes). Where a single permalink is useful, pin a commit SHA. Every symbol below was re-verified against the working tree.
 
 ---
 
 ## 0. Source-of-truth corrections (verified against the code, not the briefs)
 
-Two claims in the upstream current-state map were wrong. Both are confirmed below by direct grep, and both *change* the design — so they are stated up front:
+The v1 draft and the upstream current-state map carried four source-accuracy errors. All four are corrected here and the corrections are load-bearing.
 
-1. **`evaluate_fusion_spec()` EXISTS** — `backend/archimedes/services/fusion_evaluator.py:578`. It runs `validate → interpret → backtest → rigor gate` and returns `FusionEvalResult{spec, backtest, rigor, error}` with `.is_actionable` / `.admissible` properties. `_run_fusion_candidate` already calls it (`generation_pipeline.py:839`). **Consequence:** the debate's real-DSL-backtest path is *reuse*, not build-new. This is the single biggest cost saver in the whole design.
-2. **`dual_regime` is a `regime_bias` parameter, not a function** — `select_candidates(brief, corpus, regime_bias=...)` at `strategy_fusion.py:389`, driven by `_REGIME_BIAS_TERMS` at `:133`. **Consequence:** a bull-grounded vs. bear-grounded evidence set is free — call the same function twice with opposite biases.
+1. **`.is_actionable` lives on `FusionProposal`, not `FusionEvalResult`.** `FusionProposal.is_actionable` (in `agents/strategy_fusion.py`) is a property: `status == "ok" and len(source_arxiv_ids) >= MIN_PAPERS` (MIN_PAPERS = 2). It gates **proposal viability** (did we get a parseable, paper-grounded spec). `FusionEvalResult` (in `services/fusion_evaluator.py`) exposes only `.success` (`error is None and backtest is not None`) and `.admissible` (`rigor is not None and rigor.admissible`, where admissible = `passing AND data_source != "synthetic"`). It gates **post-backtest rigor**. The debate uses both, at different stages: `FusionProposal.is_actionable` to admit a candidate into the pool, `FusionEvalResult.success`/`.admissible` to rank it after the real backtest.
 
-Verified integration line numbers (current `generation_pipeline.py`): `_pick_pipeline` allowlist `:84` · dispatch block `:1053` · `FusionUnavailable` `:751` · `_fusion_can_run` `:113` · `_patch_pbo` skip `:440` · buy-and-hold gather skip `:1251` · episodic `agent=` ternary `:1265`. Re-exported regime-conditional rigor: `regime_robustness_score` / `regime_conditional_sharpe` / `regime_conditional_dsr` at `rigor_evaluator.py:44-46`. External gate `run_rigor_gate` at `rigor_evaluator.py:463`.
+2. **There is no `embargo_filter()` / `time_aware_retrieval()` callable.** The Xia Outcome-Embargo (§4.2 protocol 1) and Time-Aware-Retrieval (protocol 2) are **enforced inside `load_papers_from_db`** (`services/corpus_service.py`), which calls `apply_outcome_embargo(papers, embargo_days=...)` and `apply_time_aware_retrieval(papers, lam=regime_lambda(...))` — the real implementations live in `services/embargo_filter.py` (`apply_outcome_embargo(papers, *, at=None, embargo_days=30)`, keyword-only) and `services/time_aware_retrieval.py` (`apply_time_aware_retrieval(papers, *, now=None, lam=..., score_field="similarity")`, keyword-only). The debate does **not** re-derive embargo/decay; it **consumes** them by calling `load_corpus()` → `load_papers_from_db()`, which applies both by default. There is no standalone `time_aware_retrieval(corpus, regime, λ)` signature.
+
+3. **`dict` ↔ `CorpusPaper` boundary, pinned.** `load_papers_from_db(...) -> list[dict]` (rows `.to_dict()`'d, embargo+decay applied). `load_corpus(path=None) -> list[CorpusPaper]` (`agents/strategy_fusion.py`) is DB-first: it calls `load_papers_from_db()` and **maps the dicts → `CorpusPaper`**, falling back to the manifest file only when the DB is empty. **The debate evidence surface takes `list[CorpusPaper]`** (it calls `load_corpus()`), and `select_candidates(brief, corpus, regime_bias=...)` consumes `list[CorpusPaper]` → returns `list[CorpusPaper]`. The dict form never crosses into the debate; the conversion happens once, inside `load_corpus()`.
+
+4. **`strategy_fusion.py` is in `agents/`, not `services/`.** Full path: `backend/archimedes/agents/strategy_fusion.py`. (`regime_robustness_score` is *defined* in `services/_rigor_helpers.py` and only *re-exported* through `services/rigor_evaluator.py` — cite the helper as source of truth.)
+
+**Key reused symbols (current working tree):**
+
+| Symbol | Module | Role in the debate |
+|---|---|---|
+| `run_generation(*, job_id, brief, n_candidates, store, mode, model, dual_regime)` | `agents/generation_pipeline.py` | async pipeline entry; dispatches on `pipeline_name`; owns the persist/backtest/episodic tail |
+| `_pick_pipeline(brief, mode_override) -> (name, reason)` | `agents/generation_pipeline.py` | pipeline selector — **gains a flag-gated `"debate"` branch** (§5); legacy tree untouched while OFF |
+| `_CandidateResult` (`@dataclass`) | `agents/generation_pipeline.py` | the carrier contract every runner returns; fields incl. `passes_rigor`, `has_real_rigor`, `rigor_verdict`, `return_series`, `source_arxiv_ids`, `generation_method` |
+| `_patch_pbo(candidates)` | `agents/generation_pipeline.py` | library PBO over **non-`has_real_rigor`** candidates only |
+| `select_candidates(brief, corpus, regime_bias=None)` | `agents/strategy_fusion.py` | deterministic pre-LLM paper selection; `regime_bias ∈ {"bull","bear",None}` boosts `_REGIME_BIAS_TERMS`; **ranks by integer keyword-hit count first, then recency, then arxiv_id** (the diversity-theater risk — §4, fix A4) |
+| `StrategyFusion.__init__(...)` · `StrategyFusion._resolve_backend(...)` | `agents/strategy_fusion.py` | constructor + backend resolver — **the model-threading edit sites** (§8 item 10, fix A3) |
+| `StrategyFusion.propose(brief) -> FusionProposal` | `agents/strategy_fusion.py` | one LLM synthesis → DSL `strategy_spec`; anti-hallucination `valid_ids` drop |
+| `default_fusion() -> StrategyFusion`, `MIN_PAPERS=2`, `FUSION_MAX_PAPERS=6`, `fusion_enabled()` | `agents/strategy_fusion.py` | fusion factory + constants. **`default_fusion()` returns `StrategyFusion()` with NO model arg — model-blind today** (the gap A3 closes) |
+| `load_corpus(path=None) -> list[CorpusPaper]` | `agents/strategy_fusion.py` | DB-first corpus load (embargo+decay already applied inside) |
+| `load_papers_from_db(*, embargo_days, decay_lambda, regime, apply_embargo, apply_decay) -> list[dict]` | `services/corpus_service.py` | where Xia 1 + Xia 2 are enforced |
+| `evaluate_fusion_spec(spec_dict, *, data_feed=None, num_trials=None) -> FusionEvalResult` | `services/fusion_evaluator.py` | validate → interpret → DSL backtest → rigor gate |
+| `FusionEvalResult{spec, backtest, rigor, error}` · `.success` · `.admissible` | `services/fusion_evaluator.py` | post-backtest rigor verdict |
+| `run_rigor_gate(strategy_id, daily_returns, num_trials=1, ...) -> RigorGateResult` | `services/rigor_evaluator.py` | **external** gate (primitive #5); `num_trials` is the DSR denominator |
+| `selection_bias_routes.py` gate endpoint (`POST /api/selection-bias/...`) | `api/selection_bias_routes.py` | the live external-gate route; **derives `num_trials = max(len(valid_returns), 1)` internally (library size) and exposes NO `pool_size`/caller seam** — the wiring gap A1 closes; `num_trials_in_selection` is an existing persisted field on the strategy row |
+| `regime_robustness_score(strategy_returns, regime_labels)` | `services/_rigor_helpers.py` (re-exported via `rigor_evaluator`) | regime-conditional robustness; `robust = min_regime_sharpe > 0` |
+| `GmmRegimeDetector.get_current_regime() -> RegimeClassification \| None` · `gmm_regime_health()` | `services/gmm_regime_detector.py` | live exogenous regime read; `degraded` is the expected steady state |
+| `make_llm_backend(model=...)` | `services/llm_backend.py` | per-role backend constructor (model selection seam, §8/§9 item 10) |
+| `extract_json(...)` | `agents/strategy_architect.py` | JSON decode for every LLM role |
+| `persist_proposal(...)` | `services/strategy_memory.py` | episodic compounding tail |
+| `validate_strategy_spec(...)` | `services/strategy_dsl.py` | DSL validator (proposer-spec gate; §11) |
+| `interpret_spec(...)` | `services/dsl_to_backtrader.py` | DSL → backtrader; raises `DSLError` on unsupported indicators (the `realized_vol_N` trap; §11, fix A5) |
 
 ---
 
 ## 1. TL;DR + recommendation
 
-**Recommended architecture: a structured adversarial debate with deterministic critics — "Proposer → Bull/Bear research round → deterministic critic panel (incl. GMM-regime risk) → LLM synthesizer," run once per Generate over a shared embargoed/time-decayed evidence surface, emitting N=2–3 regime-steered candidates of which exactly one goes deep.** It is wired as a new `pipeline_name="debate"` runner (`_run_debate_candidate`), a fourth peer to the existing fusion/live/fixture runners, with three edit sites and zero schema/route/persistence changes.
+**Recommended architecture: a structured adversarial society that is the *sole* generation pipeline.** It generates a **larger diverse pool** of regime/mechanism/risk-steered DSL proposals (~15–20), runs a **bull/bear adversarial round with one visible rebuttal** plus a **deterministic critic panel** (rigor-backtest, GMM-regime risk, passive-null, provenance/embargo) that **culls and ranks to a top-10**, **backtests all 10 for real** via `evaluate_fusion_spec` (deterministic Python → DSR/PBO/OOS), and presents a **true top-10 leaderboard**. The user-chosen winner (**K=1**) is the only candidate that goes through the **external rigor gate + on-chain anchor**.
 
-**Why this over the alternatives.** This grafts the three proposals deliberately:
+This is wired as the **`pipeline_name="debate"` runner** that **replaces** fusion/architect/agent dispatch *as the end state* — **but in Phase 1 it is added alongside the legacy runners, not in place of them** (see §5a). Fusion is not deleted — it folds in as the **proposer's internal capability** (`StrategyFusion.propose` is how each proposer turns a paper set into a DSL spec — but the *steering* is applied by the proposer calling `select_candidates(regime_bias=R)` itself and constructing `StrategyFusion(model=…)`; `propose()` today takes neither a `regime_bias`/explicit-evidence set nor a `model` arg, so both are **required edits**, not existing reuse — see the §4 caller-gap note and fix A3). What eventually gets deleted (in the Phase-3 cutover PR) is the *standalone fusion runner + dispatch/relabel block*, the *architect path*, the *single-agent `portfolio_agent` path*, and the *duplicate generate endpoint*.
 
-- **From Proposal A (TradingAgents-faithful):** the genuine adversarial *topology* — a real bull-vs-bear research round with rebuttal, a moderator/synthesizer, and first-class ABSTAIN — because that is what scores on Lepton's Agentic-Sophistication axis. A naked ensemble (all critics scoring independently, no cross-agent argument) under-delivers the "multi-agent debate" the roadmap names.
-- **From Proposal B (lean):** the **deterministic risk agent**. The Hierarchy-of-Truth protocol (Xia §4.4) says the regime/vault state is *non-votable* — it must override consensus structurally. An LLM risk agent can be argued out of its position; a Python gate cannot. This is both a correctness win (non-votable truth enforced in code) and the load-bearing budget win (the risk work costs zero tokens). Also from B: building shared evidence *once* and caching it across regime steers, and letting the synthesizer collapse to zero LLM calls when the deterministic floor already forces the outcome.
-- **From Proposal C (fusion-ensemble):** the **deterministic critic panel** pattern (rigor-backtest, regime-risk, passive-null, embargo/provenance critics are *code, not models*), the `evaluate_fusion_spec` real-backtest spine, and the strict `num_trials = len(candidate_pool)` wiring on the external gate — the single most important number in the integration.
+**The reshape vs. v1 (Dan's mandatory refinements):**
 
-**What we reject from each:** A's full 9-role, 12-call roster (4× budget directly fights primitive #5's affordability reason — deferred to a stretch phase, not the ship). The pure-ensemble framing of C (no visible cross-agent argument under-sells the Agentic-Sophistication axis — we keep *one* bounded rebuttal round). B's "skip the rebuttal entirely" (we keep one round for the demo's sophistication story, but make it cheap).
+- **"N=2–3, exactly one goes deep" is REPLACED.** The society proposes a **larger pool** (~15–20), the adversarial round + deterministic critics **cull & rank to a top-10**, and **all 10 survivors run the real DSL backtest** (cheap deterministic Python — `evaluate_fusion_spec` per candidate). "Deep" is no longer "one expensive generation"; it is the **external rigor gate + on-chain anchor**, which stays **K=1** (the user-chosen leaderboard winner).
+- **`num_trials = pool_size` (the FULL proposed pool, not 10, not 1, not library size).** The DSR multiple-testing correction must count **every spec we proposed and backtested**, because selecting the best-of-pool against the library is exactly the multiple-testing inflation DSR deflates. **This does NOT exist in the live gate yet** — the gate computes `num_trials` internally from the strategy library. The exact edit that threads `pool_size` into the gate is named in §5c (the "Gate wiring delta") and tested in §9. `pool_size` itself is precisely defined in §5c.
+- **Fourth-peer / byte-identical-live-path framing is reconciled.** The flag guards the cutover window; Phase 1 keeps every legacy runner intact and merely *adds* the `"debate"` branch, so "flag OFF ⇒ legacy path is byte-identical" is *true by construction* (the deletions move to the Phase-3 cutover PR). The earlier draft's self-contradiction — delete the runners AND keep a byte-identical legacy path — is resolved in favor of additive Phase 1 (fix A2).
 
-**The synthesis in one line:** *N>1 diversity is bought in the cheap dimension (regime-steered grounding + adversarial reasoning over shared evidence), the deterministic critics do the risk work for zero tokens, exactly one candidate goes through deep generation + the external rigor gate, and the whole panel collapses into one canonical provenance hash — so K=1's two protected invariants (deep-generation cost, single re-derivable provenance) survive untouched.*
+**Why this topology (carried forward from v1, endorsed by #766):**
+
+- **Genuine adversarial topology** — a real bull-vs-bear research round with one rebuttal, a moderator/synthesizer, first-class ABSTAIN — scores on Lepton's Agentic-Sophistication axis. A naked ensemble under-delivers the "multi-agent debate" the roadmap names.
+- **Deterministic critics (0 tokens).** The Hierarchy-of-Truth protocol (Xia §4.4) makes regime/vault state *non-votable* — a Python gate cannot be argued out of its position. This is both a correctness win (non-votable truth in code) and the load-bearing budget win (the risk work + all backtests cost zero LLM tokens).
+- **`evaluate_fusion_spec` is the real-backtest spine** — reuse, not build-new. The single biggest cost saver.
+
+**What we reject:** the full 9-role, 12-call TradingAgents roster (deferred to stretch — it fights primitive #5's affordability reason). BYOK per-role model diversity (deferred to stretch — complicates the single-provenance story). An LLM risk agent (the risk agent stays **deterministic** — non-votable Hierarchy-of-Truth).
+
+**The synthesis in one line:** *N>1 diversity is bought cheap (regime/mechanism-steered grounding + one adversarial round over shared embargoed evidence); the deterministic critics cull, rank, and run all 10 real backtests for zero tokens; the user picks the leaderboard winner; and K=1 survives at the **external rigor gate + single on-chain provenance anchor** — the one place "going deep" still costs.*
 
 ---
 
 ## 2. Agent roster + roles
 
-Seven logical roles. **Only 3–4 are LLM calls**; the four critics are deterministic Python (the budget trick, grafted from Proposals B and C). Every LLM role constructs through `make_llm_backend(model=...)` and parses with `architect.extract_json` — they are *prompt modes over the shared seam*, not new backends. Every cited claim is run through the existing anti-hallucination `valid_ids` filter (fusion) so no fabricated paper enters the debate record.
+Logical roles below. **Only the proposers + bull/bear + synthesizer are LLM calls**; the four critics and all backtests are deterministic Python (the budget trick). Every LLM role constructs through `make_llm_backend(model=...)` and parses with `strategy_architect.extract_json` — they are *prompt modes over the shared seam*, not new backends. Every cited claim runs through the fusion `valid_ids` anti-hallucination filter (in `StrategyFusion.propose`) so no fabricated paper enters the debate record.
 
 | # | Role | LLM? | Reuses | Behavior |
 |---|------|------|--------|----------|
-| **P** | **Proposer** | yes (1 call / regime-steer) | `StrategyFusion.propose()` → `select_candidates(brief, corpus, regime_bias=R)`; `extract_json`; fusion `valid_ids` filter | Emits ONE candidate Archimedes-DSL `strategy_spec` grounded in a regime-biased paper set. Status-honest: returns `{status:'insufficient'}` rather than inventing if <2 papers support a coherent thesis. |
-| **R1** | **Bull researcher** | yes (1 call) | `extract_json`; inline empirical stats from `_agent_tools` (`_tool_get_asset_stats`/corr/stress, computed in Python, fed as text) | Argues FOR acting on the candidate, citing only the proposer's papers + the inline stats. Round 2 sees the Bear's prior turn (rebuttal). Output `{verdict:'act', confidence, key_claims:[…], strongest_evidence_id}`. |
-| **R2** | **Bear researcher** | yes (1 call) | same | Argues for ABSTENTION — the null is buy-and-hold. Cites the StockBench base rate (active LLM agents underperform passive baselines; our own agent ranked #15/15). Attacks overfit / regime-fragility / cost-vs-benefit (<5 bps ⇒ don't trade). **Structurally privileged toward abstention.** Output `{verdict:'decline'|'act', confidence, fatal_flaws:[…]}`. |
-| **C-prov** | **Provenance/Embargo critic** | **no** | `embargo_filter`, `time_aware_retrieval`, `source_tracker`, fusion `valid_ids` | Hard-fails any candidate citing a post-embargo paper or an arxiv_id not in the shared decay-weighted surface. Enforces Xia 1/2/4. Non-votable. |
-| **C-rigor** | **Rigor-backtest critic** | **no** | `evaluate_fusion_spec()` (`fusion_evaluator.py:578`) | Runs the candidate's spec → real DSL backtest → DSR/PBO/OOS. Produces `FusionEvalResult`. Deterministic; cannot be argued with. This is the spine that keeps deep generation at K=1 (one real backtest, not N). |
-| **C-regime** | **GMM-regime risk critic** | **no** | `GmmRegimeDetector.get_current_regime()`; `regime_robustness_score`/`regime_conditional_sharpe` | Reads the live exogenous regime; penalizes candidates whose edge collapses in the *current* regime, rewards regime-robust ones. Discounts its own weight when `gmm_regime_health().status=="degraded"`. **The non-votable Hierarchy-of-Truth gate** — crisis/degraded biases the panel toward decline regardless of consensus. |
-| **C-null** | **Passive-null critic ("StockBench skeptic")** | **no** | `V_check`'s `min_cost_benefit_bps≥5`; buy-and-hold baseline | The standing "do nothing" debater. A candidate survives only if it beats buy-and-hold net of cost by ≥5 bps. If none clears it → ABSTAIN (first-class SKIP). |
-| **S** | **Synthesizer / Fund manager** | yes (1 call, or **0** — §8) | `extract_json`; `_CandidateResult` builder | Reads survivors + each critic's structured scorecard + the bull/bear transcript; picks the winner OR abstains; writes the human-readable "why this beat the others" rationale that populates Considered Alternatives. **Collapses to zero LLM calls when the deterministic floor already forces the outcome** (crisis/degraded, or no candidate clears the null). |
+| **P** | **Proposer (pool)** | yes (1 call / steer; ~15–20 steers) | `select_candidates(brief, corpus, regime_bias=R)`; `StrategyFusion(model=brief.model).propose(brief)` → DSL spec; fusion `valid_ids` filter; `extract_json` | Each proposer emits ONE Archimedes-DSL `strategy_spec` grounded in a steered paper set (regime × mechanism × risk-appetite). Status-honest: a proposer whose `FusionProposal.is_actionable` is false (status≠"ok" or <2 papers) is dropped from the pool, not invented around. **A proposal that validates but is not backtestable (e.g. emits `realized_vol_N`, or omits `parameter_variants`) is also dropped by the pre-backtest conformance guard — see fix A5/§5b.** |
+| **R1** | **Bull researcher** | yes (1 call, +1 rebuttal) | `extract_json`; inline empirical stats (`_tool_get_asset_stats`/corr/stress computed in Python, fed as text) | Argues FOR acting, citing only proposer papers + inline stats. Rebuttal turn sees the Bear's prior claims. Output `{verdict:'act', confidence, key_claims:[…], strongest_evidence_id}`. |
+| **R2** | **Bear researcher** | yes (1 call, +1 rebuttal) | same | Argues for ABSTENTION — the null is buy-and-hold. Cites the StockBench base rate (active LLM agents underperform passive baselines; our own agent ranked #15/15). Attacks overfit / regime-fragility / cost-vs-benefit (<5 bps net ⇒ don't trade). **Structurally privileged toward abstention.** Output `{verdict:'decline'|'act', confidence, fatal_flaws:[…]}`. |
+| **C-prov** | **Provenance/Embargo critic** | **no** | embargo+decay already applied in `load_corpus()`; fusion `valid_ids`; consulted-hash union | Hard-fails any candidate citing an arxiv_id not in the shared decay-weighted surface (post-embargo papers never enter the surface — they are filtered in `load_papers_from_db`). Enforces Xia 1/2/4. Non-votable. |
+| **C-rigor** | **Rigor-backtest critic** | **no** | `evaluate_fusion_spec(spec)`, each call wrapped in try/except that drops-with-honest-emit | Runs **each top-10 survivor's** spec → real DSL backtest → `FusionEvalResult{backtest, rigor}` (DSR/PBO/OOS). Deterministic; cannot be argued with. This is the spine — all 10 backtests are cheap Python. A per-candidate `evaluate_fusion_spec` that raises (despite the A5 pre-guard) is caught and drops that one entry with an honest emit, never aborts the cohort. |
+| **C-regime** | **GMM-regime risk critic** | **no** | `GmmRegimeDetector.get_current_regime()`; `regime_robustness_score` / `regime_conditional_sharpe`; `gmm_regime_health()` | Reads the live exogenous regime; penalizes candidates whose edge collapses in the *current* regime, rewards regime-robust ones (`robust = min_regime_sharpe > 0`). Discounts its weight when `gmm_regime_health().status == "degraded"` (the expected steady state). **The non-votable Hierarchy-of-Truth gate** — crisis/degraded biases the panel toward decline regardless of consensus. |
+| **C-null** | **Passive-null critic ("StockBench skeptic")** | **no** | V_check `min_cost_benefit_bps ≥ 5`; buy-and-hold baseline | The standing "do nothing" debater. A candidate survives only if it beats buy-and-hold net of cost by ≥5 bps. If none clears it → ABSTAIN (first-class). |
+| **S** | **Synthesizer / Fund manager** | yes (1 call, or **0** — §8) | `extract_json`; `_CandidateResult` builder | Reads the top-10 leaderboard + each critic's scorecard + the bull/bear transcript; selects/ranks for the user OR abstains; writes the "why this leads" rationale that populates Considered Alternatives. **Collapses to 0 LLM calls when the deterministic floor forces the outcome** (crisis/degraded, or no candidate clears C-null). |
 
-### Prompt sketches (the load-bearing discipline, borrowed from `strategy_architect._SYSTEM_PROMPT` + `strategy_fusion`)
+### Prompt sketches (discipline borrowed from `strategy_architect._SYSTEM_PROMPT` + `strategy_fusion._SYSTEM_PROMPT`)
 
 **Proposer (P):**
-> *System:* "You are a quant strategy proposer. You may ONLY fuse the papers in the provided candidate set `[arxiv_ids…]`. Invent no papers, no Sharpe ratios. You are arguing the **{regime}** case — favor {momentum/trend/carry | vol-managed/defensive/hedge/tail-risk} mechanisms grounded in these papers. Your peers argue the opposite; differentiate honestly, do not strawman. Emit a single Archimedes-DSL `strategy_spec` JSON. If <2 papers support a coherent thesis, return `{status:'insufficient'}` — do not guess."
+> *System:* "You are a quant strategy proposer. You may ONLY fuse the papers in the provided candidate set `[arxiv_ids…]`. Invent no papers, no Sharpe ratios. You are arguing the **{regime}/{mechanism}** case — favor {momentum/trend/carry/breakout | vol-managed/defensive/hedge/tail-risk/min-variance} mechanisms grounded in these papers. Emit a single Archimedes-DSL `strategy_spec` JSON. Use ONLY the indicator aliases `sma_N`, `ema_N`, `rsi_N`, `momentum_N` and include a `parameter_variants` grid on your entry indicator. If <2 papers support a coherent thesis, return `{status:'insufficient'}` — do not guess."
 
-**Bull (R1):**
-> *System:* "You are the BULL. Argue FOR acting on this candidate. Empirical stats: {Sharpe, vol, maxDD, ρ from `_tool_get_asset_stats`/corr/stress}. {round≥2: Your opponent argued: <bear_claims>. Respond directly.} Cite only the proposer's papers + these stats. Output `{verdict:'act', confidence, key_claims:[…], strongest_evidence_id}`."
+(DSL contract the proposer MUST obey is pinned in §11; the conformance guard that enforces it before backtest is in §5b / fix A5.)
 
-**Bear (R2):**
-> *System:* "You are the BEAR. The null is buy-and-hold. The empirical base rate is that active LLM agents underperform passive baselines on most windows — our own Strategy-Generation agent ranked #15/15 on StockBench (Sortino −0.91 vs the raw model's +1.94). Attack overfit, regime-fragility, and cost-vs-benefit (<5 bps net ⇒ DON'T trade). {round≥2: The bull argued: <bull_claims>. Rebut.} Abstention is a correct and respected verdict. Output `{verdict:'decline'|'act', confidence, fatal_flaws:[…]}`."
+**Bull (R1) / Bear (R2):** as v1 — see roster. Round 2 rebuttal: each sees the other's prior `key_claims`/`fatal_flaws`.
 
 **Synthesizer (S):**
-> *System:* "You are an impartial fund manager. Below are the surviving candidates, each with a deterministic scorecard from four critics (rigor, regime-risk, passive-null, provenance), plus the bull/bear transcript. Pick the single best risk-adjusted, regime-robust, cost-justified candidate — OR ABSTAIN. **ABSTAIN ('hold current weights') is first-class and often correct**; if no candidate beats the passive null by ≥5 bps net, OR the regime critic flags crisis/degraded, you MUST output `{decision:'abstain'}`. On-chain vault state and curated-over-uncurated evidence OVERRIDE any consensus — you cannot vote past deterministic truth. Cite only the critics' numbers; invent nothing. Output `{winner_id | 'ABSTAIN', rationale, per_candidate_reject_reason{}}`."
+> *System:* "You are an impartial fund manager. Below is a top-10 leaderboard, each candidate with a deterministic scorecard (real backtest DSR/PBO/OOS, regime-risk, passive-null, provenance) and the bull/bear transcript. Rank them for the user and name the leader — OR ABSTAIN. **ABSTAIN ('hold current weights') is first-class and often correct**; if no candidate beats the passive null by ≥5 bps net, OR the regime critic flags crisis/degraded, you MUST output `{decision:'abstain'}`. On-chain vault state and curated-over-uncurated evidence OVERRIDE any consensus. Cite only the critics' numbers; invent nothing. Output `{leaderboard:[…ranked candidate_ids…], leader_id | 'ABSTAIN', rationale, per_candidate_note{}}`."
 
 ---
 
 ## 3. Control / debate flow
 
 ```
-run_generation(brief, mode="debate")  ──pipeline_name="debate"──►  _run_debate_candidate(*, candidate_id, brief, emit, regime, agent)
-                                                                    (called ONCE; owns the whole panel; regimes collapses to ["neutral"])
+run_generation(brief, mode="debate")  ──pipeline_name="debate" (flag-ON branch; legacy tree intact)──►  _run_debate_candidate(*, candidate_id, brief, emit, regime, agent)
+                                                                    (called ONCE; owns the whole society; regime collapses to ["neutral"])
 ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  ONE shared decision t  ·  ONE embargo+time-aware retrieval surface  ·  ONE consulted-hash union  (Xia 1,2,4)        │
+│  ONE shared decision t  ·  ONE embargoed + time-decayed evidence surface  ·  ONE consulted-hash union  (Xia 1,2,4)   │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                     │
   STEP 0 — SHARED EVIDENCE (built ONCE per Generate, cached across all steers — the budget win)
-     corpus = load_corpus()
-     corpus = embargo_filter(corpus, t)                 # Xia 1  (one decision t shared by all agents)
-     corpus = time_aware_retrieval(corpus, regime, λ)   # Xia 2  (decay + regime scaling, identical for every agent)
-     for R in {bull, bear[, neutral]}:                   # the ONLY thing that varies per steer — pure Python, free
-         evidence[R] = select_candidates(brief, corpus, regime_bias=R)   # strategy_fusion.py:389
+     corpus = load_corpus()                              # -> list[CorpusPaper]; embargo (Xia 1) + time-decay (Xia 2)
+                                                          #    ALREADY applied inside load_papers_from_db()
+     for R in STEERS:                                    # ~15-20 (regime × mechanism × risk-appetite) — pure Python, free
+         evidence[R] = select_candidates(brief, corpus, regime_bias=R)   # agents/strategy_fusion.py
+     # NOTE: select_candidates ranks hit-count→recency→arxiv_id; on a DEGRADED TF-IDF corpus bull/bear
+     #       steers can collapse to the same tail. The §9 divergence test (A4) guards this at unit level.
      valid_ids = sorted(union of evidence[R] arxiv_ids)
      consulted_hashes = sorted("arxiv_id:content_hash" for paper in valid_ids)   # Xia 4
      emit candidates_selected(source_arxiv_ids=valid_ids)
                                                                     │
-  STEP 1 — PROPOSE  (N cheap LLM calls — the only N× cost; asyncio.gather)
-     ┌────────────┐  ┌────────────┐  [┌────────────┐]
-     │ Proposer   │  │ Proposer   │   │ Proposer    │   each = StrategyFusion.propose(brief, regime_bias=R)
-     │  bull      │  │  bear      │   │  neutral    │   → strategy_spec ; valid_ids anti-hallucination filter on EACH
-     └─────┬──────┘  └─────┬──────┘   [└─────┬──────┘]   status='insufficient' on all ⇒ raise DebateUnavailable → agent fallback
-           │ spec_bull     │ spec_bear      │ spec_neutral
+  STEP 1 — PROPOSE A LARGER POOL  (~15-20 cheap LLM calls; asyncio.gather, bounded by DEBATE_POOL_MAX)
+     Proposer×K  →  each = StrategyFusion(model=brief.model).propose(brief over evidence[R])  →  strategy_spec
+                    # NB: shorthand. propose() takes neither `model` nor an explicit evidence[R] today (it
+                    #     calls select_candidates(brief, corpus) internally, unbiased). The proposer must
+                    #     (a) construct StrategyFusion(model=brief.model)  [fix A3 seam], and (b) pre-build
+                    #     evidence[R]=select_candidates(brief, corpus, regime_bias=R) and propose over THAT
+                    #     set, reusing propose()'s prompt + valid_ids filter — see §4 caller-gap + §5b.
+       drop any candidate whose FusionProposal.is_actionable is False (status!="ok" OR <MIN_PAPERS)
+       drop any candidate failing the pre-backtest DSL conformance guard (A5: unsupported indicator alias,
+         or missing parameter_variants) — honest emit, NOT a throw inside C-rigor
+       POOL = [actionable AND conformant proposals]   ◄── pool_size = len(POOL)  (the count that enters
+                                                            deterministic ranking/backtest — the DSR set; see §5c)
+       if POOL empty: raise DebateUnavailable   (honest fallback — see §5)
      emit agent_iteration / tool_called("propose") per proposer
                                                                     │  candidate pool  (+ inline empirical stats, computed once)
-  STEP 2 — RESEARCH DEBATE  (ONE adversarial round, R=1 default; Bull ∥ Bear via asyncio.gather)
-     ┌── R1 BULL ──┐   ┌── R2 BEAR (+passive null framing) ──┐    each sees SAME candidates + SAME stats
-     │ argue ACT   │◄─►│ argue DECLINE                       │    round 2 (optional): each sees the other's claims (rebuttal)
+  STEP 2 — RESEARCH DEBATE  (ONE round + ONE visible rebuttal, R=1; Bull ∥ Bear via asyncio.gather)
+     ┌── R1 BULL ──┐   ┌── R2 BEAR (+passive-null framing) ──┐    both see SAME pool + SAME stats
+     │ argue ACT   │◄─►│ argue DECLINE                       │    rebuttal: each sees the other's prior claims
      └──────┬──────┘   └──────────────┬─────────────────────┘    emit agent_iteration(iteration_n=round) per turn
             └────────────┬────────────┘
                                                                     │  debate_transcript (sorted by fixed role order before hashing)
-  STEP 3 — CRITIC PANEL  (DETERMINISTIC — ZERO LLM CALLS)
-     for each candidate:
-        C-prov   embargo/id audit ───────────────► hard FAIL ⇒ drop (Xia 1,2,4, non-votable)
-        C-rigor  evaluate_fusion_spec(spec) ──────► real DSL backtest → FusionEvalResult{DSR,PBO,OOS}
-        C-regime GmmRegimeDetector.get_current_regime() + regime_robustness_score ──► regime-conditional score (Xia 3)
-        C-null   beats buy-and-hold by ≥5 bps net? ► else flag (StockBench honesty floor)
-     survivors = [c for c if not hard-failed]
+  STEP 3 — CRITIC PANEL  (DETERMINISTIC — ZERO LLM CALLS)  → CULL & RANK to TOP-10
+     C-prov   embargo/id audit over the pool ──────────► hard FAIL ⇒ drop (Xia 1,2,4, non-votable)
+     C-null   beats buy-and-hold by ≥5 bps net? ───────► else flag (StockBench honesty floor)
+     C-regime GmmRegimeDetector.get_current_regime() + regime_robustness_score ──► regime-conditional score (Xia 3)
+     rank the survivors; TOP10 = best 10 by the composite cull score
+     C-rigor  for c in TOP10: try: evaluate_fusion_spec(c.spec) except DSLError/Exception: drop c with honest emit
+              ──► real DSL backtest → FusionEvalResult{DSR,PBO,OOS}
+              (ALL surviving entries backtested — deterministic Python, 0 tokens)
      emit tool_result per (candidate × critic)   # the audit trail
-                                                                    │
+                                                                    │  TOP-10 LEADERBOARD (every entry carries a real backtest)
   STEP 4 — SYNTHESIZE / ADJUDICATE  (1 LLM call — or 0 if the floor forces it)
      if no survivor clears C-null  OR  C-regime flags crisis/degraded:  ───────────► ABSTAIN  (mechanical, 0 LLM)
-     else:  Synthesizer(survivors, scorecards, transcript) ─► winner_id + rationale + per-reject reason
+     else:  Synthesizer(top10, scorecards, transcript) ─► ranked leaderboard + leader_id + per-candidate notes
      emit agent_iteration("synthesize")
                                                                     │
-  build ONE _CandidateResult(
+  build _CandidateResult PER TOP-10 ENTRY (the leaderboard) — leader flagged:
        generation_method="debate"  (or "debate_abstain"),
-       has_real_rigor=True,                      # winner carries C-rigor's real backtest
-       rigor_verdict=<from evaluate_fusion_spec>,
-       source_arxiv_ids=<winner papers>, source_papers=<union>,   reasoning=<synth rationale>,
-       debate_transcript=[…], consulted_paper_hashes=<union>)
-  losers → Considered Alternatives (with per-critic / synth reject rationale)
-                                                                    │  returns _CandidateResult (the existing contract — unchanged)
+       has_real_rigor=True,                      # every leaderboard entry carries C-rigor's real backtest
+       rigor_verdict=<from evaluate_fusion_spec>, return_series=<from backtest>,
+       source_arxiv_ids=<candidate papers>, source_papers=<union>, reasoning=<synth note>,
+       debate_transcript=[…], consulted_paper_hashes=<union>,
+       num_trials_in_selection=pool_size)        # persisted so the gate can read it back (A1)
+                                                                    │  returns the leaderboard _CandidateResult set (existing contract)
                                                                     ▼
-  ════════ run_generation TAIL — UNCHANGED ════════
-  _patch_pbo SKIPS it (has_real_rigor) · best_selected · _persist_candidate · persist_proposal(agent="debate") · backtest gather SKIPS it · done
+  ════════ run_generation TAIL — REUSED ════════
+  _patch_pbo SKIPS all (has_real_rigor=True) · best_selected (leader) · _persist_candidate per entry ·
+  persist_proposal(agent="debate") · buy-and-hold backtest gather SKIPS all (has_real_rigor) · done
                                                                     │
-  ════════ EXTERNAL RIGOR GATE — primitive #5, OUTSIDE the debate ════════
-  GET /api/selection-bias/gate/{winner_id} → run_rigor_gate(
-        strategy_id, daily_returns, strategy_code,
-        num_trials = len(candidate_pool),   ◄── FULL debate pool, NOT 1 (DSR multiple-testing correction)
-        library_pbo=…, average_correlation=…)
+  ════════ EXTERNAL RIGOR GATE — primitive #5, K=1, OUTSIDE the society (user-chosen winner) ════════
+  POST /api/selection-bias/...  (live route on api/selection_bias_routes.py) — see §5c "Gate wiring delta":
+     for a generation_method=="debate" strategy, the route reads num_trials from the persisted
+     num_trials_in_selection (== pool_size) instead of max(len(valid_returns), 1) (library size).
+     run_rigor_gate(strategy_id, daily_returns, strategy_code, num_trials=pool_size, library_pbo=…, average_correlation=…)
   → RigorGateResult{passes_all, gate_details}  ──renders on passport──►  enables Deploy
   ════════ V_check (deterministic floor) ════════
   weights_sum_bps==10000 ∧ max_concentration≤60% ∧ cost_benefit≥5bps  ──fail──► SKIP trace published (even on unanimous APPROVE)
 ```
 
-**Reproducibility (R3):** agent ordering is fixed and deterministic; the Bull∥Bear concurrency is collapsed back to a fixed role order before the transcript is hashed. The transcript, each agent's `consulted_paper_hashes`, and their union go into one trace. No nondeterministic fan-out.
+**Reproducibility (R3):** agent ordering is fixed and deterministic; the Bull∥Bear concurrency collapses back to a fixed role order before the transcript is hashed. The transcript, each agent's `consulted_paper_hashes`, and their union go into one trace. No nondeterministic fan-out. The top-10 ranking is a deterministic sort over the critic scorecards; only the synthesizer's prose ordering is LLM-derived, and it is constrained to a permutation of the deterministically-admitted top-10.
 
 ---
 
-## 4. How N>1 diverse candidates emerge + how the winner is chosen + K=1 reconciliation
+## 4. How the larger pool + top-10 leaderboard emerge + K=1 reconciliation
 
-**Diversity axis (cheap, the only N× cost):** regime-steered grounding. `select_candidates(brief, corpus, regime_bias="bull")` ranks momentum/trend/carry/breakout papers to the top; `"bear"` ranks vol-managed/defensive/hedge/tail-risk/min-variance papers (driven by `_REGIME_BIAS_TERMS:133`). Same embargo, same decay surface, same decision `t` — the divergence is in *which decay-weighted papers rank top*, never in reaching past the decay to a stale paper (that's a C-prov hard-fail, not a stronger argument). Default ship: **N=2** (bull/bear); generalizes to **N=3** (+neutral) or risk-appetite steers, bounded by `DEBATE_N` (hard cap 5, reusing the existing `n_candidates` 1..5 ceiling).
+**Diversity axis (cheap, the only N× LLM cost):** steered grounding. `select_candidates(brief, corpus, regime_bias="bull")` ranks momentum/trend/carry/breakout papers to the top; `"bear"` ranks vol-managed/defensive/hedge/tail-risk/min-variance papers (driven by `_REGIME_BIAS_TERMS`). The pool fans this out across **regime × mechanism × risk-appetite** steers (~15–20). Same embargo, same decay surface, same decision `t` — the divergence is in *which decay-weighted papers rank top* and *which mechanism the proposer is told to favor*, never in reaching past the decay to a stale paper (that's a C-prov hard-fail, not a stronger argument).
 
-**Winner selection:** the deterministic critic panel culls (C-prov hard-fail → C-rigor real backtest → C-regime conditioning → C-null cost-benefit). The surviving pool feeds the LLM synthesizer, which picks one OR abstains. **Exactly ONE candidate goes deep** — the winner carries the one real DSL backtest (`evaluate_fusion_spec`) and the one `return_series`. We do **not** run N independent deep generations.
+> **Diversity-theater risk (verified, load-bearing).** `select_candidates` ranks by **integer keyword-hit count first**, then recency, then `arxiv_id`; `regime_bias` adds a fixed boost per bull/bear keyword hit. On the **current DEGRADED corpus** (`paper_rag: degraded`, TF-IDF fallback, MiniLM-not-SPECTER2), if a brief's bull and bear keyword sets both hit few papers, **both steers can collapse to the same recency-sorted tail** → proposers see near-identical evidence → convergent specs → a leaderboard that *looks* like a debate but is N copies of one idea. This is not merely "no SPECTER2 yet" (§10.2); the *ranking primitive itself* is hit-count+recency, which is weakly discriminating across regime steers on abstracts. **The mitigation is a Phase-1 unit test that bull-vs-bear evidence sets actually differ on the fixture corpus (Jaccard < 1.0), not a Phase-3 embeddings promise** — see §9 test #2 (fix A4). Real embeddings (#778) are the *quality* lift; the *divergence-exists* guarantee must be testable now.
 
-**Reconciliation with primitive #5 (K=1) — explicit:**
+> **Caller-gap note (verified):** `select_candidates` accepts `regime_bias`, but neither `StrategyFusion.propose` nor the existing fusion callers pass it (`propose` calls `select_candidates(brief, corpus)` with no bias). The debate is the **first** caller to actually thread `regime_bias` through. The proposer step therefore calls `select_candidates(brief, corpus, regime_bias=R)` directly to build `evidence[R]`, then hands that steered set to the proposing LLM — it does not rely on `propose` to steer.
 
-| What #5 protects | How it survives N>1 |
+**Cull → rank → backtest-all-10:** the deterministic critic panel culls (C-prov hard-fail → C-null cost-benefit → C-regime conditioning), ranks the survivors by a composite score, takes the **top 10**, and runs `evaluate_fusion_spec` on **every one** of them (real DSL backtests — deterministic Python, 0 tokens, each wrapped in try/except per fix A5). The result is a **true top-10 leaderboard**, each entry carrying its own real DSR/PBO/OOS. The synthesizer ranks/annotates; **the user picks the winner** from the leaderboard.
+
+**Reconciliation with primitive #5 (K=1) — explicit, reshaped:**
+
+| What #5 protects | How it survives the larger pool + top-10 |
 |---|---|
-| **Deep-generation cost** (reason #5.1) | Only the winner gets a real backtest. Proposers are cheap single `complete()` calls emitting one DSL spec each over a small grounded set; the critics are deterministic (0 tokens). Diversity is bought in the cheap reasoning/grounding dimension, not in N× expensive synthesis. |
-| **Single re-derivable provenance** (reason #5.2) | ONE `methodology_hash` per Generate carrying the **union** of all proposers' `consulted_paper_hashes` + the debate transcript, anchored once via `ReasoningTraceRegistry`. N>1 surfaces in the UI; provenance stays K=1-clean. |
-| **Considered-Alternatives panel** (#5 user surface) | The debate's losing candidates *become* the considered-rejects — a richer version at the same architectural slot, carrying inter-agent reject rationale, at near-zero extra cost. |
-| **External rigor gate** | The winner — and only the winner — goes through the unchanged external `run_rigor_gate`. The debate never self-certifies. |
-| **Episodic compounding** | The full candidate set + verdicts persist to `strategy_proposals` via the unchanged `persist_proposal` tail (`agent="debate"`). |
+| **Deep cost** (reason #5.1) | "Deep" is no longer N expensive generations — it is the **external rigor gate + on-chain anchor**, run for **exactly one** user-chosen winner. The pool's proposers are cheap single `complete()` calls; the critics + all 10 backtests are deterministic (0 tokens). The expensive, irreversible step (on-chain anchor) stays K=1. |
+| **Single re-derivable provenance** (reason #5.2) | The on-chain `methodology_hash` is anchored once, for the user-chosen winner, carrying the **union** of all proposers' `consulted_paper_hashes` + the debate transcript. The full top-10 surfaces in the UI; the on-chain provenance stays K=1-clean. |
+| **Considered-Alternatives panel** (#5 surface) | The leaderboard's non-winning entries *are* the considered-alternatives — now with real backtests + per-critic / synth notes, a strict upgrade at near-zero extra cost. |
+| **External rigor gate** | Only the user-chosen winner goes through the unchanged external `run_rigor_gate`, with **`num_trials = pool_size`** (§5c) — *once the gate-wiring delta in §5c lands*. The society never self-certifies. |
+| **Episodic compounding** | The full leaderboard + verdicts persist to `strategy_proposals` via the unchanged `persist_proposal` tail (`agent="debate"`). |
 
-One line: *N>1 lives at the cheap debate-over-shared-evidence layer; K=1 survives at the deep-generation + external-rigor-gate + single-anchored-provenance layer.*
+One line: *the larger pool + top-10 leaderboard live at the cheap debate-over-shared-evidence + deterministic-backtest layer; K=1 survives at the external-rigor-gate + single-on-chain-anchor layer (the user-chosen winner).*
 
 ---
 
-## 5. Integration
+## 5. Integration — replacement scope (additive in Phase 1, deletions deferred to cutover)
 
-### 5a. `generation_pipeline.run_generation` — new `pipeline_name="debate"` runner (Option A, mirrors fusion exactly)
+The society **becomes** the sole generation pipeline as the end state — but the path there is **additive first, delete later**. Phase 1 *adds* the `"debate"` branch behind `ARCHIMEDES_DEBATE_ENABLED` (default OFF) and leaves every legacy runner untouched; the deletions land in a separate Phase-3 cutover PR after the society is verified on the live path. Reuse stays ~80% (the persist/backtest/episodic tail, `evaluate_fusion_spec`, `StrategyFusion.propose`, `select_candidates`, SSE vocabulary, the external gate). The ~20% new is the society runner + the deterministic critics + the synthesizer adapter.
 
-This is the cleanest slot-in, confirmed against source. **Three edit sites, no schema/route/persistence changes.**
+### 5a. Phase 1 is additive; the deletions are the Phase-3 cutover PR (fix A2)
 
-1. **Allowlist** (`_pick_pipeline`, `:84`): `("fusion","architect","agent")` → `("fusion","architect","agent","debate")`. Add `"debate"` to `GenerateStartRequest.mode` docstring (`generate_schemas.py:32`). Phase 1 is **opt-in via `mode="debate"` only** — the default path stays byte-identical, de-risking the ship.
-2. **Dispatch block** (`:1053`, peer to the fusion branch):
-   ```python
-   if pipeline_name == "debate":
-       if use_live and _debate_can_run(brief):     # mirror _fusion_can_run (:113); requires >= MIN_PAPERS
-           runner = _run_debate_candidate
-       else:
-           pipeline_name = "agent"; runner = agent_runner   # honest relabel, same as fusion
-   ```
-   When `pipeline_name=="debate"`, also set `regimes = ["neutral"]` so the per-regime loop (`:1037`/`:1117`) runs **once** — the debate panel owns its own internal bull/bear/neutral split. (This is Proposal C's "regime collapse"; it keeps the expensive PBO/backtest/persist tail untouched and the panel a single self-contained unit.)
-3. **New `_run_debate_candidate`** + `DebateUnavailable(Exception)` (mirror `FusionUnavailable:751` so the existing `:1127` fallback catches it → relabels to agent → honest `pipeline_selected`). Set `generation_method="debate"`; extend the episodic `agent=` ternary at `:1265` to `"debate"`.
+**The delete-vs-byte-identical contradiction is resolved in favor of additive Phase 1.** v1 mandated *deleting* the architect path, the `portfolio_agent` runners, and the duplicate endpoint in Phase 1 while *also* promising a byte-identical legacy path under flag-OFF. Both cannot hold. The resolution:
 
-**Exact signature (all five kwargs required):**
+- **Phase 1 (this spec's first increment): ADD only.** `_pick_pipeline` gains a flag-gated branch: when `ARCHIMEDES_DEBATE_ENABLED` is set, return `("debate", "society pipeline (flag-on)")`; **otherwise the existing legacy decision tree runs unchanged.** No runner is deleted, no endpoint is removed, `"architect"` stays in the mode allowlist. This makes "flag OFF ⇒ legacy live path is byte-identical" *true by construction* and the §9 test (grep proves `_run_debate_candidate` unreachable while OFF) actually passable.
+- **Phase 3 (the cutover PR, after the society is verified on the live path): DELETE.** Only then do we remove (1) the pipeline-selection decision tree's legacy branches (collapse `_pick_pipeline` to the `"debate"` constant), (2) the standalone fusion runner + dispatch/relabel block in `run_generation`, (3) the architect `"architect"` selection + silent fall-through, (4) the single-agent `portfolio_agent` runners (`generation_method` default `"portfolio_agent_streaming"`), and (5) the duplicate generate endpoint in `api/strategies_routes.py` (the older `generate_strategy` → `_run_fusion_job` poll/generate path; one SSE `/api/generate` survives). Fusion's *capability* is preserved throughout — it folds into the proposer (`StrategyFusion.propose`); only the standalone runner is eventually removed.
+
+**KEEP as fixtures/docs only:** the example strategies (Faber 2007 SMA200, Moreira-Muir 2017 vol-managed, Moskowitz-Ooi-Pedersen 2012 TSMOM, buy-and-hold) remain as test fixtures + library seeds. They are not a generation pipeline.
+
+**The `ARCHIMEDES_DEBATE_ENABLED` flag is a cutover guard, not a fourth-peer guard.** While OFF, `_pick_pipeline` returns the legacy selection (so the live path is unchanged during the cutover window); while ON, it returns the `"debate"` branch. Once the replacement is verified on the live path, the legacy branches — and eventually the flag — are removed in the Phase-3 cutover PR. There is no permanent "fourth peer."
+
+### 5b. New runner + the carrier contract
+
+**New file** `backend/archimedes/agents/debate_engine.py`: `_run_debate_candidate` + `DebateUnavailable(Exception)` + `_debate_can_run(brief)` (mirrors the existing fusion viability precheck — true iff `fusion_enabled()` AND `len(select_candidates(FusionBrief(...), load_corpus())) >= MIN_PAPERS`) + the four deterministic critics + the synthesizer adapter + `_dsl_conformance_ok(spec_dict) -> bool` (the A5 pre-backtest guard).
+
+**Exact signature (matches the runner contract `run_generation` invokes):**
 ```python
 async def _run_debate_candidate(
     *, candidate_id: str, brief: GenerateBrief, emit: _Emitter,
@@ -185,50 +237,71 @@ async def _run_debate_candidate(
 ) -> _CandidateResult: ...
 ```
 
-**Returned `_CandidateResult`:** fully populated per the existing contract. For the winner, set `has_real_rigor=True` (so `_patch_pbo:440` and the buy-and-hold gather `:1251` both correctly skip it — the CSCV PBO from `evaluate_fusion_spec` must not be clobbered). For ABSTAIN, return a populated result with empty `weights`, a passive-baseline `return_series`, and an abstain `rigor_verdict` stub — this does **not** hit the empty-guard (which would wrongly emit a `NO_CANDIDATES` error); it is a first-class SKIP.
+**Returned `_CandidateResult`:** fully populated per the existing contract. For the winner, set `has_real_rigor=True` (so `_patch_pbo` and the buy-and-hold gather both correctly skip it — the CSCV PBO from `evaluate_fusion_spec` must not be clobbered). For ABSTAIN, return a populated result with empty `weights`, a passive-baseline `return_series`, and an abstain `rigor_verdict` stub — this does **not** hit the empty-guard (which would wrongly emit a `NO_CANDIDATES` error); it is a first-class SKIP.
 
-**Streaming:** emit `agent_iteration` / `tool_called` / `tool_result` per role, reusing the existing SSE vocabulary → **zero frontend changes**. (New event names would require `EventName` + listener edits; avoid.)
+> **Carrier-contract mismatch — RESOLVED (Phase 1, option b):** the existing runners return a *single* `_CandidateResult` but the society produces a leaderboard. Phase 1 takes option (b): `_run_debate_candidate` returns the **leader** `_CandidateResult`; the full top-N leaderboard is built by the pure, unit-tested `build_leaderboard` helper. The Considered-Alternatives fan-out (persisting the non-winning entries) is deferred to Phase 2. Buy-and-hold/PBO skip is keyed on `generation_method` (`"debate"`/`"debate_abstain"`) — reconciled with #829's `!= "fusion"` skip so debate candidates (which emit a DSL spec, `weights={}`) never hit the static portfolio backtester.
 
-**New files:** `backend/archimedes/agents/debate_engine.py` (runner + `DebateUnavailable` + `_debate_can_run` + the deterministic critics + the synthesizer adapter). **Reused unchanged:** `strategy_fusion.py` (`select_candidates`, `propose`), `strategy_architect.py` (`extract_json`, prompt template), `fusion_evaluator.py` (`evaluate_fusion_spec`), `llm_backend.py` (`make_llm_backend`), `gmm_regime_detector.py`, `rigor_evaluator.py`, `strategy_memory.py` (`persist_proposal`).
+When `pipeline_name == "debate"`, set `regimes = ["neutral"]` so the per-regime loop runs **once** — the society owns its own internal regime/mechanism split, and the expensive PBO/persist tail stays a single self-contained unit. The runner returns the **top-10 leaderboard** (leader flagged via `best_selected`).
 
-### 5b. GMM-regime risk-agent input (Surface 1, in-process Path A)
+**Returned `_CandidateResult` (per leaderboard entry):** fully populated per the existing contract. Set `has_real_rigor=True` on every entry (each carries C-rigor's real backtest), so `_patch_pbo` and the buy-and-hold gather both correctly **skip** them — the CSCV PBO from `evaluate_fusion_spec` must not be clobbered. Set `generation_method="debate"`; extend the episodic `agent=` ternary so `generation_method=="debate"` persists `agent="debate"`. **Persist `num_trials_in_selection=pool_size` on each entry** so the external gate can read it back (the A1 wiring delta, §5c).
 
-The deterministic **C-regime** critic reads:
-```python
-detector = GmmRegimeDetector(fallback=VixRegimeDetector())
-rc = detector.get_current_regime()          # RegimeClassification | None
-# or cross-process: rc = await AgentStateStore().load_regime()
-degraded = gmm_regime_health().status == "degraded"
-```
-Branch on `rc.regime` (4-way: `risk_on|risk_off|transition|crisis`), weight by `rc.confidence`, react to `rc.regime_changed`, and **discount when degraded** (treat as lower confidence, bias toward decline — honest degradation per contract). Score each candidate's regime-conditional edge via `regime_robustness_score` / `regime_conditional_sharpe` (the bridge between Surface 1 and Surface 2). **Never** read `KEY_ENSEMBLE_CONSENSUS` as a market regime (that is endogenous consensus, issue #659). Because C-regime is deterministic Python, the regime gate is structurally non-votable — Xia §4.4 enforced.
+**Pre-backtest DSL conformance guard (fix A5).** After `StrategyFusion.propose`, before a spec is admitted to POOL, the proposer step runs `_dsl_conformance_ok(spec_dict)`: it **rejects** specs whose indicator aliases are not in `{sma, ema, rsi, momentum}` (an alias like `realized_vol_N` *validates* via `validate_strategy_spec` but raises `DSLError("unsupported indicator")` in `interpret_spec`), and **(optionally) injects a default `parameter_variants` grid on the entry indicator** so PBO is computable (a missing/<2-variant grid yields PBO `None` → fail-closed). An unbacktestable-but-actionable proposal is **dropped from POOL with an honest emit — not allowed to throw in C-rigor.** As a belt-and-suspenders backstop, every per-candidate `evaluate_fusion_spec` in C-rigor is additionally wrapped in try/except that drops-with-honest-emit, so a single bad spec never aborts the whole leaderboard build.
 
-### 5c. External rigor gate (Surface 2, primitive #5 — stays OUTSIDE the debate)
+**ABSTAIN is a real `_CandidateResult` state routed through the existing emit path — not a new error.** A deliberate all-abstain returns a populated `_CandidateResult` with empty `weights`, a passive-baseline `return_series`, and an abstain `rigor_verdict` stub (`generation_method="debate_abstain"`). **A genuinely empty pool** (no actionable+conformant proposal) raises `DebateUnavailable`, which the runner-fallback path catches and relabels honestly; the existing `RIGOR_FAIL` emit (the empty-candidates path) is the route for a deliberate all-abstain that produces zero deployable candidates — do **not** invent a new error. (`passes_rigor` / `has_real_rigor` remain the live carrier fields; `_patch_pbo` and the buy-and-hold skip key on `has_real_rigor`, verified.)
 
-The debate emits a candidate; the existing external path adjudicates. The authoritative verdict is `GET /api/selection-bias/gate/{winner_id}`:
+**Streaming:** emit `agent_iteration` / `tool_called` / `tool_result` per role, reusing the existing SSE vocabulary (`job_queued`, `brief_validated`, `pipeline_selected`, `candidates_selected`, `agent_iteration`, `tool_called`, `tool_result`, `candidate_drafted`, `candidate_evaluated`, `candidate_failed`, `best_selected`, `trace_hashed`, `persisted`, `backtest_running`, `backtest_done`, `backtest_failed`, `done`, `error`) → **zero frontend changes**.
+
+**Reused unchanged:** `strategy_fusion.py` (`select_candidates`, `propose`, `load_corpus`), `strategy_architect.py` (`extract_json`), `fusion_evaluator.py` (`evaluate_fusion_spec`), `llm_backend.py` (`make_llm_backend`), `gmm_regime_detector.py`, `rigor_evaluator.py` / `_rigor_helpers.py`, `strategy_memory.py` (`persist_proposal`). **Newly threaded (not unchanged):** `StrategyFusion.__init__` / `_resolve_backend` / `default_fusion` gain a `model` parameter (§8 item 10, fix A3), and `api/selection_bias_routes.py` gains the debate-aware `num_trials` read (§5c, fix A1).
+
+### 5c. External rigor gate (primitive #5 — stays OUTSIDE the society, K=1) + the gate-wiring delta
+
+The society emits the leaderboard; the user picks; the existing external path adjudicates the winner. The authoritative verdict comes from the live external gate on `api/selection_bias_routes.py` (`POST /api/selection-bias/...`).
+
+**Defining `pool_size` precisely (fix A6).** `pool_size` is **the count of specs that entered the deterministic ranking/backtest stage** — i.e. proposals that were both *actionable* (`FusionProposal.is_actionable`) **and** *conformant* (passed the A5 DSL guard). It is **not** the number of `complete()` calls fanned out, and **not** the post-cull top-10; it is exactly the multiple-testing selection set DSR must deflate (we proposed this many candidate specs and selected the best against the library). The raw-vs-conformant choice, and the library-context adjustment, are folded into the OPEN-Önder denominator question below — not left as a separate ambiguity.
+
+**The gate-wiring delta (fix A1 — the single most important wire, and it does NOT exist yet).** The live gate does **not** accept a `pool_size`/`num_trials` argument from the caller. `api/selection_bias_routes.py` computes `num_trials = max(len(valid_returns), 1)` **internally** (the size of the strategy library that has returns) and passes that to `run_rigor_gate`; the in-pipeline path (`generation_pipeline.py`) likewise uses `num_trials = max(1, len(strategies))` (library size). There is no `GET /api/selection-bias/gate/{winner_id}` route in that shape. So `assert num_trials == pool_size` is **unrunnable until a code change threads `pool_size` into the gate.** The required edit, named exactly:
+
+1. **Persist `pool_size` at debate time** on the winner's strategy row / passport — reuse the **existing** `num_trials_in_selection` field (already persisted on the strategy row) by writing `num_trials_in_selection = pool_size` per leaderboard entry (§5b).
+2. **Modify `selection_bias_routes.py`** so that for a `generation_method == "debate"` strategy it reads `num_trials` from the persisted `num_trials_in_selection` value **instead of** `max(len(valid_returns), 1)`.
+3. **Gate the override behind `generation_method == "debate"`** so all non-debate strategies keep the current library-size behavior exactly.
+
+The effective call for a debate winner then becomes:
 ```python
 gate_result = run_rigor_gate(
     strategy_id=winner.candidate_id,
     daily_returns=winner.return_series,
-    num_trials=len(candidate_pool),     # ◄── FULL debate pool, NOT 1, NOT library size
+    num_trials=pool_size,               # ◄── read from persisted num_trials_in_selection for debate strategies
     library_pbo=library_pbo,
     strategy_code=winner_strategy_code,
     average_correlation=avg_correlation,
 )
 deploy_enabled = gate_result.passes_all
 ```
-**The single most important number in the integration: `num_trials = len(candidate_pool)`.** A debate *introduces* exactly the multiple-testing inflation DSR is meant to deflate; passing `num_trials=1` silently disables the correction and produces a *false* strict-rigor badge — the "build on sand" failure. **Assert `num_trials == pool_size` in a test** and surface the pool size on the passport. `gate_details` (per-criterion PASS/FAIL with `source=library|cohort`) renders on the passport; `passes_all` gates Deploy. The debate never sets `passing` itself.
+
+**Why this matters: the "build on sand" failure.** A society that proposes ~15–20 specs and selects the best introduces exactly the multiple-testing inflation DSR is meant to deflate; leaving `num_trials` at library size (or 1, or 10) silently weakens the correction and produces a *false* strict-rigor badge. **Assert `num_trials == pool_size` in a test** (§9 test #5) and surface the pool size on the passport. `gate_details` (per-criterion PASS/FAIL with `source=library|cohort`) renders on the passport; `passes_all` gates Deploy. The society never sets `passing` itself. **Do not flip `ARCHIMEDES_DEBATE_ENABLED` ON until the persisted-`pool_size`→gate path is proven on the live route.**
+
+> **OPEN — Önder owns the DSR-deflation denominator.** Whether `num_trials` should be the raw `pool_size` (count of conformant proposed specs), or that count adjusted for the library-context selection (the best-of-pool is selected *against* the curated library, which changes the effective multiple-testing count), is **Önder's call** — not a value this spec asserts beyond "it is the full conformant proposed pool, never 1, never library size." The raw-vs-conformant precision from fix A6 is part of this same denominator question. Do not bake a specific arithmetic into the gate without Önder's sign-off.
+
+### 5d. GMM-regime risk-agent input (deterministic C-regime)
+
+```python
+detector = GmmRegimeDetector(fallback=VixRegimeDetector())
+rc = detector.get_current_regime()          # RegimeClassification | None
+degraded = gmm_regime_health().status == "degraded"   # the EXPECTED steady state (no fitted artifact)
+```
+Branch on `rc.regime` (`risk_on|risk_off|transition|crisis`), weight by `rc.confidence`, and **discount when degraded** (bias toward decline — honest degradation per contract). Score each candidate's regime-conditional edge via `regime_robustness_score` (`robust = min_regime_sharpe > 0`). **Never** read ensemble-consensus state as a market regime (endogenous, issue #659). Because C-regime is deterministic Python, the regime gate is structurally non-votable — Xia §4.4 enforced.
 
 ---
 
 ## 6. Enforced Xia protocols mapping
 
-| # | Protocol | Where enforced in the debate | Non-votable? |
-|---|----------|------------------------------|--------------|
-| 1 | **Outcome Embargo** (§4.2) | STEP 0 builds the surface through `embargo_filter(corpus, t)` once; all agents share one decision `t`. **C-prov** hard-fails any candidate citing a post-`t` paper. | yes |
-| 2 | **Time-Aware Retrieval** (§4.2) | STEP 0 `time_aware_retrieval(corpus, regime, λ)` once; every proposer draws from the same decay-weighted, regime-scaled surface. Diversity = reasoning over shared evidence; reaching past the decay is a **C-prov** hard-fail. | yes |
+| # | Protocol | Where enforced in the society | Non-votable? |
+|---|----------|-------------------------------|--------------|
+| 1 | **Outcome Embargo** (§4.2) | `load_corpus()` → `load_papers_from_db()` applies `apply_outcome_embargo(papers, embargo_days=30)` before the surface is built; all agents share one decision `t`. **C-prov** hard-fails any candidate citing a paper not in the embargoed surface. | yes |
+| 2 | **Time-Aware Retrieval** (§4.2) | `load_papers_from_db()` applies `apply_time_aware_retrieval(papers, lam=regime_lambda(...))`; every proposer draws from the same decay-weighted surface. Diversity = reasoning over shared evidence; reaching past the decay is a **C-prov** hard-fail. | yes |
 | 3 | **Hierarchy of Truth** (§4.4) | **C-regime is deterministic Python** — regime/vault state structurally override consensus; crisis/degraded biases toward decline regardless of what the bull argues. On-chain vault state + curated-over-uncurated outrank any synthesis. | yes |
-| 4 | **Source Tracking** (§4.3) | Every cited claim runs through the fusion `valid_ids` filter. The **union** of all agents' `consulted_paper_hashes` + transcript goes into ONE `methodology_hash` anchored via `ReasoningTraceRegistry`. | — |
-| 5 | **Reasoning I/O — V_check** (§5) | The synthesizer's pick is an **input** to V_check (`weights_sum_bps==10000` ∧ `max_concentration≤60%` ∧ `min_cost_benefit_bps≥5`). Fail → SKIP trace, even on unanimous agreement. The debate cannot override it. | yes |
+| 4 | **Source Tracking** (§4.3) | Every cited claim runs through the fusion `valid_ids` filter (in `StrategyFusion.propose`). The **union** of all agents' `consulted_paper_hashes` + transcript goes into ONE `methodology_hash` anchored via `ReasoningTraceRegistry`. | — |
+| 5 | **Reasoning I/O — V_check** (§5) | The user-chosen winner is an **input** to V_check (`weights_sum_bps==10000` ∧ `max_concentration≤60%` ∧ `min_cost_benefit_bps≥5`). Fail → SKIP trace, even on unanimous agreement. | yes |
 
 **R3 target:** fixed deterministic agent order + transcript-sorted-before-hashing + union-of-hashes + the external gate = fully replayable, immutable provenance. No non-replayable element introduced.
 
@@ -238,77 +311,112 @@ deploy_enabled = gate_result.passes_all
 
 The StockBench finding (our agent ranked **#15/15**, Sortino −0.91 vs the raw GLM-4.5's +1.94 — adding the agent made it *worse*) is load-bearing and surfaced, not hidden. Three structural mechanisms:
 
-1. **First-class ABSTAIN.** The synthesizer can output `{decision:'abstain'}` (hold current weights). This is NOT a failure — it returns a populated `_CandidateResult` (empty weights, passive-baseline `return_series`, abstain rigor stub) that flows to V_check's existing SKIP-trace mechanism. It does not hit the empty-guard. A debate structurally forced to produce a trade would be dishonest by construction; ours is not.
-2. **The passive-null is a standing position, not an afterthought.** **C-null** (deterministic) is the StockBench skeptic — a candidate survives only if it beats buy-and-hold net of cost by ≥5 bps (the V_check `min_cost_benefit_bps` bar). The **Bear researcher** argues this case in natural language and is structurally privileged toward abstention. Action is never privileged; the null is a hard-to-beat default.
-3. **Underperformance is surfaced on the passport.** Whatever the debate concludes, the honest-comparison discipline carries forward: mean ± stdev, no seed cherry-picking, the paper-claim delta. The synthesizer is instructed to cite the unfavorable active-agent base rate even on APPROVE. Abstention renders as a *confident, explained* verdict ("Passive null wins by X bps; rebalancing costs more than its expected edge — StockBench base rate: active agents rank below passive on most windows"), not as a broken product.
+1. **First-class ABSTAIN.** The synthesizer can output `{decision:'abstain'}` (hold current weights) → a populated `_CandidateResult` (empty weights, passive-baseline `return_series`, abstain rigor stub, `generation_method="debate_abstain"`) that flows to V_check's SKIP-trace mechanism. A deliberate all-abstain that yields zero deployable candidates routes through the existing `RIGOR_FAIL` emit — not a new error. A society structurally forced to produce a trade would be dishonest by construction; ours is not.
+2. **The passive-null is a standing position.** **C-null** (deterministic) is the StockBench skeptic — a candidate survives only if it beats buy-and-hold net of cost by ≥5 bps (the V_check `min_cost_benefit_bps` bar). The **Bear researcher** argues this in natural language and is structurally privileged toward abstention. Action is never privileged; the null is a hard-to-beat default.
+3. **Underperformance is surfaced on the passport.** The honest-comparison discipline carries forward: mean ± stdev, no seed cherry-picking, the paper-claim delta. The synthesizer is instructed to cite the unfavorable active-agent base rate even on APPROVE. Abstention renders as a *confident, explained* verdict, not a broken product.
 
 ---
 
-## 8. LLM budget — calls per Generate, cheap-by-default, BYOK tie-in
+## 8. LLM budget — calls per Generate, recomputed for the new shape
 
-**Current K=1 baseline (fusion path):** ~1 brief-validation + ~1 fusion synthesis per regime ≈ **~2–3 calls/Generate**.
+The new shape proposes a **larger pool** (~15–20), but the critics and **all 10 backtests are 0 tokens**. The cost is the proposers + bull/bear + synthesizer.
 
-**Debate path (default N=2 bull/bear, R=1 round):**
+**Current K=1 baseline (legacy fusion path):** ~1 brief-validation + ~1 fusion synthesis ≈ **~2–3 calls/Generate**.
 
-| Step | Calls |
-|------|-------|
-| Brief validation (existing) | 1 |
-| Proposers (N=2, `asyncio.gather`) | 2 |
-| Research debate (Bull ∥ Bear, R=1) | 2 |
-| Critic panel (4 critics, **deterministic**) | **0** |
-| Synthesizer (or 0 when floor forces it) | 1 |
-| **Total** | **~6 calls/Generate** (~2–3× K=1) |
+**Society path (pool P≈15–20, R=1 round + 1 rebuttal):**
 
-**The five cheap-by-default moves (grafted from B + C):**
+| Step | Calls | Serial depth |
+|------|-------|--------------|
+| Brief validation (existing) | 1 | 1 |
+| Proposers (P≈15–20, `asyncio.gather`, bounded by `DEBATE_POOL_MAX`) | P | 1 (parallel fan-out) |
+| Research debate — Bull ∥ Bear, round 1 | 2 | +1 (Bull∥Bear parallel) |
+| Research debate — Bull ∥ Bear, rebuttal | 2 | +1 (depends on round 1) |
+| Critic panel (4 critics, **deterministic**) | **0** | 0 |
+| **All-10 real backtests** (`evaluate_fusion_spec` ×10, **deterministic**) | **0** | 0 |
+| Synthesizer (or 0 when the floor forces it) | 1 | +1 (depends on critics) |
+| **Total** | **≈ P + 6 ≈ 21–27 calls/Generate** at the upper pool, **≈ 12–14** at a leaner P≈8 | **serial depth ≈ 4** |
 
-1. **Critics are code, not models** — the adversarial risk work (rigor backtest, regime conditioning, cost-benefit, embargo) costs **zero tokens**. This is the core win over an all-LLM TradingAgents debate (which would be N proposers × R rounds × M critics ≈ 15–20 calls).
-2. **Shared evidence built once** — embargo/decay/retrieval run once per Generate; only `select_candidates` re-ranks per steer (pure Python, free).
-3. **Bull ∥ Bear concurrent** (`asyncio.gather`) — latency ≈ 1 call, not 2; keeps the demo responsive.
-4. **Inline stats, not live tool-use** — `_tool_get_asset_stats`/corr/stress computed in Python and fed as text. Deliberately avoids the `propose_portfolio_with_tools` 12-iteration loop, which is **Anthropic-SDK-only and silently no-ops on the live Bedrock/Nova prod path** — no portability cliff.
-5. **Synthesizer collapses to 0 LLM calls** when the deterministic floor already forces the outcome (crisis/degraded, or no candidate clears C-null). Realistic ceiling: **4–6 calls/Generate.**
+> **Token cost ≠ latency (latency note — a clarification, not one of the gating A1–A6 fixes).** The "≈ P + 6 ≈ 21–27 calls" headline is an honest *token-cost* figure, not a latency budget: the proposers and Bull∥Bear run in parallel via `asyncio.gather`, but the rebuttal is serial-after-round-1 and the synthesizer is serial-after-critics, giving a **serial depth of ≈4** (round1 ∥ → rebuttal ∥ → critics(0) → synth). Read the call count for cost and the serial-depth column for latency; do not conflate them. Each proposer is a `complete()` that can retry, which adds tail latency without adding to the nominal count.
 
-**Bounded + configurable:** `DEBATE_N` (default 2, cap 5), `DEBATE_ROUNDS` (default 1), `DEBATE_MAX_LLM_CALLS` (hard ceiling → `DebateUnavailable` if exceeded), all env-gated; flag-off by default so the default path keeps K=1's cost.
+**The cost lever is `DEBATE_POOL_MAX`, not the backtests.** The reshape's "all 10 backtested" adds **zero** LLM cost — `evaluate_fusion_spec` is deterministic Python (validate → interpret → backtrader → rigor gate). The N× LLM cost is purely the proposer fan-out. Tune `DEBATE_POOL_MAX` for the demo budget; the leaderboard top-10 and the rigor story are unaffected by trimming the pool toward, say, P≈10–12.
 
-**Model-selection / BYOK tie-in.** Every LLM role constructs via `make_llm_backend(model=...)`, so **per-role model diversity is free** and gated by `FREE_TIER_MODELS` / `is_allowed_model()`. Default: cheap model (Nova Micro / cost-picker) for proposers + bull/bear; the synthesizer may warrant a stronger model. **BYOK is the natural escalation path** — a user supplying their own key can run a stronger model per role (a Nova bull vs. a Llama bear) without changing the topology; `served_model` provenance is captured per agent. Deferred to a stretch phase because it complicates the single-provenance story and isn't needed for the demo.
+**The cheap-by-default moves:**
+
+1. **Critics + all backtests are code, not models** — rigor backtest (×10), regime conditioning, cost-benefit, embargo cost **zero tokens**. This is the core win over an all-LLM TradingAgents society.
+2. **Shared evidence built once** — `load_corpus()` (embargo+decay) runs once; only `select_candidates` re-ranks per steer (pure Python, free).
+3. **Bull ∥ Bear concurrent** (`asyncio.gather`) — latency ≈ 1 call per round.
+4. **Inline stats, not live tool-use** — `_tool_get_asset_stats`/corr/stress computed in Python and fed as text. Deliberately avoids the Anthropic-SDK-only tool loop that silently no-ops on the live Bedrock/Nova path — no portability cliff.
+5. **Synthesizer collapses to 0 LLM calls** when the deterministic floor forces the outcome.
+
+**Bounded + configurable:** `DEBATE_POOL_MAX` (default ~15, hard cap 24), `DEBATE_ROUNDS` (default 1 + 1 rebuttal), `DEBATE_MAX_LLM_CALLS` (hard ceiling → `DebateUnavailable` if exceeded), all env-gated; `ARCHIMEDES_DEBATE_ENABLED` OFF during cutover.
+
+**Model selection (T1.1 acceptance criterion — item 10).** Every LLM role constructs via `make_llm_backend(model=...)`, so the user's Generate-page model pick must thread into **every** candidate-generation path. **The gap is real and verified:** `default_fusion()` is `return StrategyFusion()` (no model arg), and `_run_fusion_candidate` calls `default_fusion()`, so the dominant fusion path runs on the env-default model (Nova) and a user's pick is **silently ignored** when fusion runs — only the PortfolioAgent fallback threads the pick (`make_llm_backend(model=model)`). The society's proposers call `StrategyFusion.propose`, so the society MUST construct fusion with the selected model rather than the shared model-blind singleton. **Required edit sites (fix A3):** add a `model` parameter to `StrategyFusion.__init__` and `_resolve_backend` (and to `default_fusion(model=...)`), and have the debate proposer call `StrategyFusion(model=brief.model)` / `make_llm_backend(model=brief.model)` explicitly — **not** `default_fusion()`. **Required in this spec (acceptance):** (a) the selected model is threaded into *every* proposer + bull/bear + synthesizer call; (b) `served_model` provenance reflects the actual model used (`FusionProposal.model` = `backend.served_model`, the field of record) and is persisted per candidate; (c) the UI model selection persists across the generation session; (d) premium (Anthropic) models stay gated by `enforce_model_entitlement`. Without the A3 seam, (a)/(b) are aspirational, not built. **BYOK per-role model diversity is deferred to stretch.**
 
 ---
 
 ## 9. Phased build plan
 
-### Phase 1 — flag-gated, PR-able skeleton (the concrete first increment)
+### Phase 1 — flag-gated, additive society skeleton (the concrete first increment)
 
-> **PR: "feat: debate pipeline skeleton (flag-gated, deterministic-critic, tool-free)"**
+> **PR: "feat: debate society as flag-gated generation pipeline (additive, deterministic-critic, tool-free) !minor"**
 
-**Minimal roster (3 LLM roles + 2 deterministic critics):** Proposer (reuse `StrategyFusion.propose`) → Bull ∥ Bear (one round, two new prompts) → **C-rigor** (`evaluate_fusion_spec`) + **C-null** (cost-benefit) → Synthesizer (act/abstain). N=2 (bull/bear regimes). ~6 LLM calls, behind a default-OFF flag.
+**Scope fence (fix A2):** ADD the `"debate"` branch behind `ARCHIMEDES_DEBATE_ENABLED` (default OFF). **Do NOT delete** the architect path, the `portfolio_agent` runners, or the duplicate endpoint — those move to the Phase-3 cutover PR. Generation-only; no execution-agent code.
 
-**Files:**
-- **New** `backend/archimedes/agents/debate_engine.py`: `_run_debate_candidate` + `DebateUnavailable` + `_debate_can_run` (mirror `_fusion_can_run:113`) + the two deterministic critics + a thin JSON-decision synthesizer adapter (`extract_json` + anti-hallucination filter — keep it a decision adapter, not a clever synthesizer; it's the highest-defect-density new surface).
-- **Edit** `backend/archimedes/agents/generation_pipeline.py`: allowlist `:84`, dispatch branch `:1053` (+ regime collapse to `["neutral"]`), episodic ternary `:1265`.
-- **Edit** `backend/archimedes/api/generate_schemas.py:32`: add `"debate"` to the `mode` docstring.
+> **🚧 Phase-1 blocker (explicit — per Bogdan's #808 review): the flag stays OFF until A1 is wired.** The strict-rigor path (`pool_size` → the external selection-bias gate) is **not wired yet** — `api/selection_bias_routes.py` derives `num_trials` internally from library size. Flipping `ARCHIMEDES_DEBATE_ENABLED` ON before the §5c gate-wiring delta lands risks a **false-PASS on the rigor badge**, which violates the #1 "claims must be true" rule. A1 (thread `pool_size` into the gate) + its test #5 are therefore hard Phase-1 acceptance gates for flag-ON; the flag-OFF additive skeleton may merge before A1, but **must not be enabled on the live path until A1 is proven there.**
 
-**Reuse verbatim:** `select_candidates(regime_bias=...)`, `extract_json` + both anti-hallucination id-filters, `make_llm_backend`, `evaluate_fusion_spec`, `GmmRegimeDetector.get_current_regime()`, the unchanged PBO/backtest/persist/external-gate tail.
+**Minimal society (proposers + bull/bear + 2 deterministic critics):** Proposer pool (reuse `StrategyFusion(model=brief.model).propose`, leaner P≈8–10) → Bull ∥ Bear (one round) → **C-rigor** (`evaluate_fusion_spec`, all survivors, each try/except-wrapped) + **C-null** (cost-benefit) → Synthesizer (rank/abstain). While OFF, `_pick_pipeline` returns the legacy selection so the live path is byte-identical during cutover.
 
-**Tests (hermetic — no live LLM/Redis):**
-- canned-backend debate produces a valid `_CandidateResult` with `has_real_rigor=True`;
-- ABSTAIN path returns a populated SKIP-shaped result (does NOT hit the empty-guard);
-- the cited-paper union is non-empty;
-- `DebateUnavailable` → agent-runner fallback + honest relabel;
-- **`assert num_trials == len(candidate_pool)`** when the external gate is called;
-- with the flag OFF, the live path is byte-identical (grep proves `"debate"` is unreachable).
+**New files:**
+- `backend/archimedes/agents/debate_engine.py`:
+  - `async def _run_debate_candidate(*, candidate_id, brief, emit, regime="neutral", agent=None) -> _CandidateResult` (returns the leader, with the full leaderboard stashed for the persist tail; **resolve the single-vs-list carrier mismatch in this PR — see §5b**).
+  - `DebateUnavailable(Exception)`, `_debate_can_run(brief) -> bool` (mirror the fusion viability precheck).
+  - `_propose_pool(brief, corpus, steers, model) -> list[FusionProposal]` — fans `StrategyFusion(model=...)` across `select_candidates(..., regime_bias=R)`; drops non-actionable (`is_actionable`) and non-conformant (A5) specs.
+  - `_critic_rigor(top) -> dict` (calls `evaluate_fusion_spec` per entry, try/except-wrapped), `_critic_null(...)` (≥5 bps vs buy-and-hold).
+  - `_synthesize(top, scorecards, transcript, model) -> decision` (thin `extract_json` adapter; can return ABSTAIN).
+  - `_dsl_conformance_ok(spec_dict) -> bool` (the A5 guard).
 
-This is already a real N>1 debate with adversarial culling and first-class abstention, at ~6 calls, in one reviewable PR.
+**Edit sites (by symbol, additive):**
+- `backend/archimedes/agents/generation_pipeline.py`
+  - `_pick_pipeline` → if `ARCHIMEDES_DEBATE_ENABLED` return `("debate", "society pipeline (flag-on)")`; else **unchanged** legacy tree (no `"architect"` removal).
+  - `run_generation` dispatch → when `pipeline_name == "debate"`, set `regimes = ["neutral"]` and `runner = _run_debate_candidate`; leave the existing fusion/agent dispatch in the `else`.
+  - episodic `agent=` ternary → add the `"debate"` case.
+- `backend/archimedes/agents/strategy_fusion.py`
+  - `StrategyFusion.__init__` + `_resolve_backend` + `default_fusion` → accept/forward `model` (fix A3).
+- `backend/archimedes/api/selection_bias_routes.py`
+  - the `num_trials` derivation → for `generation_method == "debate"` strategies, read the persisted `num_trials_in_selection` instead of `max(len(valid_returns), 1)` (fix A1).
+- the Generate request schema (`api/strategies_routes.py` brief model) → **add** `"debate"` to the mode allowlist (do **not** drop `"architect"` yet — fix A2).
+- thread the selected model into the proposer's fusion construction (item 10 (a)/(b), fix A3).
 
-### Phase 2 — full deterministic panel + GMM risk + rebuttal
+**Reuse verbatim:** `select_candidates(regime_bias=...)`, `extract_json` + the fusion `valid_ids` filter, `make_llm_backend`, `evaluate_fusion_spec`, `GmmRegimeDetector.get_current_regime()` / `gmm_regime_health()`, `_patch_pbo`/buy-and-hold-skip (keyed on `has_real_rigor`), `persist_proposal`, the SSE emit vocabulary, the unchanged PBO/backtest/persist/external-gate tail.
 
-Add **C-regime** (GMM, Surface 1) and **C-prov** (embargo/provenance, Xia 1/2/4). Add the second adversarial round (Bull sees Bear's claims and vice versa — visible rebuttal). Add the neutral steer (N=3). Wire Considered Alternatives to render per-critic / synth reject rationale. Add the synthesizer-collapse-to-0 optimization. Emit the full `agent_iteration`/`tool_called`/`tool_result` transparency trace.
+**Tests (hermetic — no live LLM/Redis/Postgres; copy `_FIXTURE_ROWS` + `_MockBackend` from `backend/tests/test_strategy_fusion.py` and the tmp-sqlite DB path from `backend/tests/test_corpus_service.py`; file `backend/tests/test_debate_engine.py`):**
+1. canned-backend society → top-N `_CandidateResult` leaderboard, **every entry `has_real_rigor=True`**.
+2. **regime divergence (fix A4):** on a fixture corpus seeded with ≥3 momentum-flavored and ≥3 defensive-flavored papers, `select_candidates(brief, corpus, regime_bias='bull')` and `regime_bias='bear'` differ in their top-`paper_budget` sets (Jaccard < 1.0). Catches diversity-theater at the unit level — this is the divergence-exists guarantee, not a Phase-3 embeddings promise.
+3. ABSTAIN path → populated SKIP-shaped `_CandidateResult` (`generation_method="debate_abstain"`); a deliberate all-abstain routes through the existing `RIGOR_FAIL` emit (assert no new error code).
+4. `DebateUnavailable` on empty pool → honest fallback (assert relabel, not crash).
+5. **`pool_size` denominator + gate wiring (fix A1/A6):** assert the value persisted to `num_trials_in_selection` equals the count of conformant proposed specs, and that the debate-aware gate path reads it back as `num_trials` — `assert num_trials == pool_size`. (Untestable until the §5c gate-wiring delta lands; this test ships *with* that edit.)
+6. **model threading (fix A3):** with a `_MockBackend` whose `served_model != model_id`, assert every proposer's `FusionProposal.model` reflects the user-selected model, not the env default.
+7. **DSL conformance (fix A5):** a proposal emitting `realized_vol_5` is dropped from POOL (not passed to `evaluate_fusion_spec`); assert no `DSLError` escapes.
+8. **flag-OFF byte-identical (fix A2):** with `ARCHIMEDES_DEBATE_ENABLED` unset, `_pick_pipeline` returns a legacy label and a grep-equivalent assert proves `_run_debate_candidate` is unreachable.
+9. cited-paper union non-empty; transcript sorted by fixed role order before hashing (R3 determinism).
 
-### Phase 3 — provenance hardening + polish
+**Hermetic gate:** `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_debate_engine.py -q` → `N passed, 0 failed`.
 
-Union `consulted_paper_hashes` into the single `methodology_hash` anchored via `ReasoningTraceRegistry` (C-2); persist the full candidate set + verdicts to `strategy_proposals` content-hashed (C-6); render the panel transcript on the passport; regime-conditional rigor scoring on the passport (`regime_robustness_score`). Flip `ARCHIMEDES_DEBATE_ENABLED` on for the demo once `num_trials` wiring is verified on the live path.
+### Phase 2 — full deterministic panel + GMM risk + rebuttal + all-10 backtests
+
+Add **C-regime** (GMM, Xia §4.4) and **C-prov** (embargo/provenance, Xia 1/2/4). Scale the pool to ~15–20 steers (regime × mechanism × risk-appetite). Add the visible rebuttal round (Bull sees Bear's claims and vice versa). Run `evaluate_fusion_spec` on **all top-10** survivors to build the true leaderboard. Wire Considered Alternatives to render the full leaderboard + per-critic / synth notes. Add the synthesizer-collapse-to-0 optimization.
+
+### Phase 3 — cutover (deletions) + provenance hardening + corpus/RAG prerequisite
+
+This is the PR where the deletions deferred from Phase 1 (fix A2) finally land: collapse `_pick_pipeline` to the `"debate"` constant, delete the standalone fusion runner + dispatch/relabel block, the architect selection, the `portfolio_agent` runners, and the duplicate `generate_strategy` → `_run_fusion_job` endpoint; drop `"architect"` from the mode allowlist. Then provenance hardening: union `consulted_paper_hashes` into the single `methodology_hash` anchored via `ReasoningTraceRegistry`; persist the full leaderboard + verdicts to `strategy_proposals` content-hashed; render the panel transcript + the top-10 leaderboard on the passport; regime-conditional rigor scoring on the passport. **Land the KnowledgeBase pipeline prerequisite (§10, #778)** so the proposer pool diverges on real embeddings, not TF-IDF. Flip `ARCHIMEDES_DEBATE_ENABLED` ON for the demo **only once** `num_trials = pool_size` (the §5c gate-wiring delta), the model-threading (A3), and the divergence test (A4) are verified on the live path; then remove the legacy `_pick_pipeline` branch + eventually the flag.
 
 ### Stretch (only if judges want maximal sophistication) — full TradingAgents roster + BYOK model diversity
 
-Expand to the 9-role A-style roster (separate fundamental/sentiment/technical analysts, an aggressive-vs-conservative risk *debate* as LLMs rather than the deterministic gate, a REVISE re-synth loop). Per-role model diversity via BYOK (Nova bull vs. Llama bear). Optional Bedrock-Converse `toolConfig` port so risk agents pull live empirical evidence on the Nova path. **This is where the 30% Agentic-Sophistication axis peaks — but at ~12 calls (4× K=1), gated behind Phases 1–3 proving the budget and honesty constraints hold.** Explicitly a stretch, not the ship.
+Expand to the 9-role A-style roster (separate fundamental/sentiment/technical analysts, an aggressive-vs-conservative risk *debate* as LLMs rather than the deterministic gate, a REVISE re-synth loop). Per-role model diversity via BYOK (Nova bull vs. Llama bear). **This is where the 30% Agentic-Sophistication axis peaks — but at materially higher call count, gated behind Phases 1–3 proving the budget + honesty constraints hold.** Explicitly a stretch, not the ship.
+
+### Scale-out compute (Phase-2 infra layer, parallel track)
+
+The **10 real backtests + the rigor stats are embarrassingly parallel and deterministic** — a natural fit for **AWS Lambda**: fan the per-candidate `evaluate_fusion_spec` runs out to metered Lambda invocations, **nanopayment-settled** (x402/Gateway, sub-cent USDC), **freemium with a free cap + wallet-to-pay beyond**. Phase-1 runs the backtests in-process on **EC2** (no infra change needed for the ship); the Lambda fan-out is a Phase-2 infra layer that ties the society directly into the nanopayment marketplace narrative (Circle tools 20% + Traction 30%). The society's clean per-candidate boundary (each backtest is a pure `spec_dict → FusionEvalResult`) is what makes this metered split cheap to add later.
 
 ---
 
@@ -316,25 +424,46 @@ Expand to the 9-role A-style roster (separate fundamental/sentiment/technical an
 
 **Risks (with mitigations):**
 
-1. **`num_trials` mis-wiring silently weakens rigor (highest-stakes).** `num_trials=1` disables the DSR correction and produces a false strict-rigor badge — the exact "build on sand" failure. *Mitigation:* assert `num_trials==len(candidate_pool)` in a test; surface pool size on the passport.
-2. **Diversity theater on an empty corpus.** Per MEMORY (paper-corpus-empty), prod has no real ingested papers → the bull/bear proposers may converge to near-identical specs. *Mitigation:* `_debate_can_run` requires `≥MIN_PAPERS`; if the bull/bear sets don't actually differ, log it and fall back to fusion (honest relabel). **This is a hard prerequisite, not a code mitigation — populating the corpus is on the critical path for the demo to land.**
-3. **Budget creep.** ~2–3× call count is real, not hidden. *Mitigation:* deterministic critics, shared evidence, synthesizer-collapse-to-0, `DEBATE_MAX_LLM_CALLS` cap, flag-off by default.
-4. **Latency on prod Nova/Bedrock.** *Mitigation:* `asyncio.gather` the proposers and Bull∥Bear; stream `agent_iteration` so the UI shows progress (zero frontend change).
-5. **Compounding hallucination** (more agents = more error surface, Xia §5's whole point). *Mitigation:* `valid_ids` filter on every cited turn; deterministic critics bound the blast radius (an all-LLM panel would compound errors, not catch them); V_check is the non-overridable floor.
-6. **GMM degradation read as data-driven.** *Mitigation:* C-regime discounts its weight on `status=="degraded"` and the passport surfaces "regime risk: rule-based fallback."
-7. **Non-replayable agent ordering** from Bull∥Bear concurrency. *Mitigation:* sort transcript by fixed role order before hashing.
-8. **The synthesizer is new code with no analog** — highest defect density. *Mitigation:* keep it a thin APPROVE/ABSTAIN + rationale JSON adapter, not a clever synthesizer; reuse `extract_json` + anti-hallucination filters.
+1. **`num_trials` never actually becomes `pool_size` — the "build on sand" failure (highest-stakes).** The spec's single most important wire targets a route (`api/selection_bias_routes.py`) that derives the denominator internally (`max(len(valid_returns), 1)`, library size) and exposes no caller seam; if the §5c gate-wiring delta (A1) isn't built, the strict-rigor badge is computed against library size and the pool-of-20 multiple-testing inflation goes uncorrected — a *false* PASS. *Mitigation:* A1 is a hard Phase-1 acceptance item with test #5 (which ships *with* the gate edit); **do not flip the flag ON until the persisted-`pool_size`→gate path is proven on the live route.** Hold the exact arithmetic for Önder (§5c OPEN).
+2. **Diversity theater on the DEGRADED corpus.** Reality on `main`: the 10k q-fin papers ARE in prod (`corpus_db_count = 10000`, idempotently seeded from `data/corpus/manifest.jsonl` at startup), but they are **metadata-only** — `corpus_embedded: false`, `corpus_kg_built: false`, `paper_rag: degraded` (TF-IDF fallback; `sentence-transformers` commented out in `backend/requirements.txt`; the "live" reranker is MiniLM, **not** SPECTER2). `select_candidates` ranks by **integer keyword-hit count first, then recency** — a weakly discriminating primitive across regime steers on abstracts, so bull/bear proposers can converge → "diversity theater" (§4). *Mitigation:* the **unit-level divergence test (#2 / fix A4)** enforces bull≠bear at the fixture level **now** — it is the divergence-exists guarantee, not a Phase-3 promise. The corpus is **real and Dan is driving population** — see the corpus-population plan (`scripts/bulk_ingest_arxiv.py` to refresh; `CORPUS_MAX=10000` to unblock growth; uncomment `sentence-transformers` to flip `paper_rag` → live MiniLM). **Promote the KnowledgeBase pipeline (embeddings + KG) to a named in-spec dependency, tracked as #778** — but as the *quality* lift, not the divergence guarantee. *Honesty trap for the stage:* do **not** claim SPECTER2/RAG until `corpus_embedded` reads `true` and the KB pipeline (`/api/corpus/graph`, currently 503) has run.
+3. **Unbacktestable proposals crash a leaderboard entry.** A proposer can emit `realized_vol_N` (validates via `validate_strategy_spec`, raises `DSLError("unsupported indicator")` in `interpret_spec`) or omit `parameter_variants` (→ PBO `None` → fail-closed); a throw inside C-rigor's `evaluate_fusion_spec` loop can take down the whole leaderboard build. *Mitigation:* the A5 pre-backtest conformance guard (`_dsl_conformance_ok`, drop-with-honest-emit before POOL admission) + the per-candidate try/except in C-rigor + test #7.
+4. **Model-pick silently ignored (a provenance lie, violates the CLAUDE.md "claims must be true" hard constraint).** `default_fusion()` is `return StrategyFusion()` — model-blind; the debate proposer would inherit Nova regardless of the user's pick, and `served_model` would misreport. *Mitigation:* the A3 constructor seam (`StrategyFusion(model=...)` / `default_fusion(model=...)`) + test #6; persist `FusionProposal.model` (the true served model) per candidate; gate premium models via `enforce_model_entitlement`.
+5. **Phase-1 over-reach breaks the live path during the sprint.** Deleting three runners + an endpoint in the same PR that adds the society maximizes blast radius on a build-on-deploy `main`. *Mitigation:* fix A2 — Phase 1 is strictly additive behind a default-OFF flag; the deletions are the separate Phase-3 cutover PR after the society is verified on the live path. This also makes the flag-OFF byte-identical test (#8) honest.
+6. **Budget creep.** The proposer fan-out (P≈15–20) is the real N× cost. *Mitigation:* deterministic critics + all-10 backtests cost 0 tokens; `DEBATE_POOL_MAX` cap; synthesizer-collapse-to-0; flag-off during cutover. Read the call count for token cost and the §8 serial-depth column for latency — they are different budgets (see the §8 latency note).
+7. **Latency on prod Nova/Bedrock.** *Mitigation:* `asyncio.gather` the proposer pool and Bull∥Bear; stream `agent_iteration` (zero frontend change). Phase-2 Lambda fan-out for the backtests (§9).
+8. **Compounding hallucination** (more agents = more error surface, Xia §5). *Mitigation:* `valid_ids` filter on every cited turn; deterministic critics bound the blast radius; V_check is the non-overridable floor.
+9. **GMM degradation read as data-driven.** *Mitigation:* C-regime discounts its weight on `status == "degraded"` (the expected steady state) and the passport surfaces "regime risk: rule-based fallback."
+10. **Non-replayable agent ordering** from Bull∥Bear concurrency. *Mitigation:* sort transcript by fixed role order before hashing.
+11. **The synthesizer is new code with no analog** — highest defect density. *Mitigation:* keep it a thin rank/ABSTAIN + rationale JSON adapter; reuse `extract_json` + anti-hallucination filters.
+12. **Execution-agent boundary (scope fence).** This society is **generation-only.** The agentic keeper/rebalancer is a sibling first-class pillar with its own spec — the live-execution path lives in `services/strategy_signal_evaluator.py` (now a loud FLAT-with-reason fallback after #783's DSL `_spec_signal` evaluator merged; completion tracked as #784). The generation-only fence holds: nothing in this spec touches live execution.
 
 **Open questions for Dan:**
 
-- **A. Default N — 2 or 3?** N=2 (bull/bear) is the cheapest genuine debate; N=3 (+neutral) reads as more sophisticated to judges. Recommend ship N=2, demo N=3.
-- **B. One rebuttal round or zero for the ship?** R=1 with no cross-agent visibility is cheapest (Proposal B); one visible rebuttal round (Bull sees Bear's claims) is materially more "debate-like" for the 30% axis at +0 cost if collapsed into the same calls. Recommend R=1 with rebuttal in Phase 2, R=1 no-rebuttal in Phase 1.
-- **C. Risk agent — deterministic (recommended) or LLM?** I've made it deterministic to enforce non-votable Hierarchy-of-Truth and save tokens. The stretch phase can add an LLM aggressive-vs-conservative risk *debate* on top if judges specifically want visible risk argument. Confirm you're happy with deterministic-by-default.
-- **D. Corpus population timeline.** The debate's diversity is only as real as the corpus, and prod's is empty. Is corpus population landing before the T1.1 demo, or do we demo on a seeded fixture corpus? This gates whether the diversity is genuine or theater.
-- **E. BYOK model diversity in scope for the demo?** Free per `make_llm_backend(model=)`, but complicates the single-provenance story. Recommend defer to stretch.
+- **A. Pool size P for the demo.** The reshape says ~15–20 proposed, top-10 backtested. Is P≈15 the demo target, or trim to P≈10–12 for budget/latency while keeping the top-10 leaderboard intact? (`DEBATE_POOL_MAX` makes this a config call.)
+- **B. `num_trials` denominator — Önder's call.** Raw `pool_size` (count of conformant proposed specs), or pool size adjusted for library-context selection? This changes the DSR deflation; the raw-vs-conformant precision (A6) is part of the same question. Confirm Önder owns and signs off before the §5c gate wiring lands.
+- **C. Risk agent — deterministic (recommended, decided) or LLM?** Decided deterministic for non-votable Hierarchy-of-Truth + token savings. The stretch phase can add an LLM aggressive-vs-conservative risk *debate* on top if judges want visible risk argument.
+- **D. Corpus embeddings before the demo?** The corpus is real (10k papers) and Dan is driving population; do we flip `sentence-transformers` on (MiniLM, one-line requirements change) for the demo, or ship on keyword+recency selection and treat embeddings as fast-follow (#778)? The divergence test (#2/A4) makes the keyword path *honest* either way, but embeddings are what make the diversity *genuine* rather than fixture-passing.
+- **E. Cutover timing for the flag.** Phase-3 flips `ARCHIMEDES_DEBATE_ENABLED` ON and removes the legacy `_pick_pipeline` branch + the deferred deletions. Confirm the cutover lands before the demo (so the society is the live path), or stays flag-gated for the demo with a manual toggle.
+- **F. Process to-do (not a spec edit).** `danielscoffee`'s APPROVE asked for a status issue documenting the real agent-engine state and linking this spec. File it.
 
 ---
 
 ### Honest bottom line
 
-This ships because it's ~80% reuse (fusion grounding, `evaluate_fusion_spec`, the loop, SSE vocabulary, the rigor/V_check/persist tail) and ~20% new (two/three prompts, four deterministic critics, one runner, one thin synthesizer). It costs ~2–3× K=1 in calls — real, bounded, flag-gated, not hidden — and contains that cost by keeping deep generation and provenance at K=1 while buying diversity only in cheap debate passes. Its differentiator is the StockBench-honest abstention path: a genuinely multi-agent debate that can say "do nothing," and proves it. The single biggest non-code risk is the empty prod corpus — without papers, the diversity is theater, so corpus population is on the critical path.
+This ships because it's ~80% reuse (fusion grounding via `StrategyFusion.propose`, `evaluate_fusion_spec`, the `run_generation` loop, the SSE vocabulary, the rigor/V_check/persist tail) and ~20% new (the proposer fan-out, four deterministic critics, one society runner, one thin synthesizer). The reshape — a **larger proposed pool, top-10 all backtested for real, a true leaderboard, the user picks K=1** — adds **zero LLM cost** for the backtests (deterministic Python) and buys a far stronger Agentic-Sophistication story. The topology, the deterministic-critic budget trick, and the §0 source-accuracy work are sound and endorsed. The spec is blocked only by the three wiring claims that did not match the live code — **A1** (thread `pool_size` into the gate; it derives `num_trials` from library size today), **A2** (additive Phase 1; deletions deferred so flag-OFF is byte-identical), **A3** (the `StrategyFusion(model=...)` seam; `default_fusion()` is model-blind) — plus **A4–A6** (the unit-level divergence test, the pre-backtest DSL conformance guard, and the precise `pool_size` denominator). Fix those six and Phase 1 is a clean, hermetic, flag-gated, additive PR. The single most important wire is `num_trials = pool_size` at the external gate (via the §5c delta); the single most important honesty surface is the StockBench-grounded first-class ABSTAIN. The corpus is real and Dan is driving population; the remaining prerequisite is real embeddings (#778) so the diversity is genuine, not theater.
+
+---
+
+## 11. Appendix — Archimedes DSL contract the proposer MUST obey
+
+The proposer emits a `strategy_spec` JSON that must pass `validate_strategy_spec` (`services/strategy_dsl.py`) **and** be backtestable by `interpret_spec` (`services/dsl_to_backtrader.py`). The validator/interpreter gap below is load-bearing — and it is exactly why the §5b `_dsl_conformance_ok` pre-backtest guard (fix A5) exists: a spec that validates but won't interpret must be dropped from POOL with an honest emit, never allowed to throw inside C-rigor.
+
+**Required top-level fields (all 8):** `name` (non-empty str), `asset_universe` (`list[str]`, ≥1; **overridden** by the platform via `derive_asset_universe(brief.asset_classes)` — list real tickers), `rebalance_frequency` (`daily|weekly|monthly`), `entry` + `exit` (condition trees), `position_sizing` (`dict` with `.type`), `source_arxiv_ids` (`list[str]`), `look_ahead_safe` (**MUST be `true`** — `false` is hard-rejected pre-backtest). Optional: `parameter_variants` (`dict[str, list[number]]`, each key an indicator alias used in entry/exit, each list 2–8 numerics — **required for a non-`None` PBO**; <2 variants → PBO `None` → fail-closed). **The proposer SHOULD always emit a `parameter_variants` grid on its entry indicator; if it does not, the A5 guard injects a default grid so PBO is computable.**
+
+**Condition trees:** single-key dicts. Logic: `and`/`or` (value = list of **≥2** conditions), `not` (value = one condition). Comparison: `gt`/`lt`/`gte`/`lte` (value = list of **exactly 2** operands). Operands: a number, a price operand (`close|open|high|low|volume`), or an indicator alias `"{indicator}_{period}"`.
+
+**Two gaps the proposer MUST respect (enforced by the A5 guard):**
+1. **Do NOT emit `realized_vol_N`.** It passes the validator (it is in `INDICATOR_NAMES`) but the interpreter's `_make_indicator` only handles `sma, ema, rsi, momentum` — `realized_vol` raises `DSLError("unsupported indicator")` at interpret time, which would otherwise throw inside C-rigor. Use only `sma_N`, `ema_N`, `rsi_N`, `momentum_N` (int N ≤ 10000). The `_dsl_conformance_ok` guard rejects any spec whose indicator aliases fall outside `{sma, ema, rsi, momentum}` before it reaches `evaluate_fusion_spec`.
+2. **`equal_weight`/`inverse_vol` sizing validate but silently fall through to full-invest** in the interpreter. Only `full_invested_when_in_market` and `volatility_target` (requires `annual_pct > 0`) produce distinct behavior.
+
+**Admissibility:** a Tier-1 (`FusionEvalResult.admissible`) result requires the backtest to run on **real** data (not the default deterministic synthetic feed; `data_source != "synthetic"`). That is the caller's data-feed responsibility, not the spec's — the proposer controls validity + backtestability; admissibility is gated downstream on data provenance.


### PR DESCRIPTION
**T1.1 Phase 1** — the multi-agent debate society, built against the spec in **#808**. Draft for your review (pairs with #808). **Strictly additive behind `ARCHIMEDES_DEBATE_ENABLED` (default OFF)** so the flag-OFF live path is byte-identical; the legacy-runner deletions are deferred to the Phase-3 cutover PR (fix A2).

## What's here
**New `agents/debate_engine.py`** — the society runner:
- **Proposer pool** — fans `StrategyFusion(model=...).propose` across `select_candidates(regime_bias=R)` evidence sets. Drops non-actionable (`FusionProposal.is_actionable`) + non-conformant (`_dsl_conformance_ok`, **A5**) specs. `pool_size = len(POOL)`.
- **C-rigor** — `evaluate_fusion_spec` per survivor (deterministic, 0 tokens), each try/except-wrapped, with **`num_trials=pool_size`** (the **A1** deflation, self-contained at the evaluator).
- **C-null** — survivor must beat the passive null by ≥ 5 bps (Phase-1 `cagr` proxy) → else **first-class ABSTAIN** (`generation_method="debate_abstain"`).
- **Deterministic synthesizer** → top-N leaderboard; returns the leader `_CandidateResult` (carrier-contract preserving; the leaderboard fan-out is Phase 2).
- Best-effort **bull/bear transcript** (never gates; full rebuttal is Phase 2). `DebateUnavailable(FusionUnavailable)` → existing fallback relabels to agent.

**Edits:** `generation_pipeline.py` (`_pick_pipeline` flag branch + dispatch + `regimes=["neutral"]` + episodic ternary), `strategy_fusion.py` (**A3** model seam: `StrategyFusion(model=…)` / `default_fusion(model=…)`), `generate_schemas.py` (mode docstring).

## Tests — 12 hermetic (`env -i` clean) + 118 regression
Covers spec §9 tests 1–9: leaderboard/`has_real_rigor`, regime divergence (A4), ABSTAIN, `DebateUnavailable`, `pool_size`→`num_trials` (A1), model threading (A3), DSL conformance (A5), flag-OFF never returns `"debate"` (A2), cited-paper union, transcript role order. Regression: **118 passed** across pipeline/fusion/selection-bias/model-gating (flag-OFF byte-identical).

## ⚠️ Two things to read before flipping the flag
1. **A1 coordination with #770/#811.** I put the `pool_size` deflation at `evaluate_fusion_spec(num_trials=pool_size)` (per-candidate), which **dovetails #770's `library + N` additive correction on the generation path** rather than fighting the library-grading external route (#811 correctly keeps that route at library size). The exact denominator is **Önder's OPEN call** (spec §5c). **PHASE-1 BLOCKER: do not enable the flag on the live path until A1 is proven there** — else the rigor badge can false-PASS.
2. **A4 finding (real).** The regime-divergence guarantee holds at the keyword+bias core, but the semantic rerank (`FUSION_SEMANTIC_RETRIEVAL`, default ON) **collapses it** on the degraded/TF-IDF corpus — the documented diversity-theater risk that needs real embeddings (**#778**). The test isolates the keyword guarantee and documents the collapse.

## Scope notes
- Phase 1 = minimal society (proposers + bull/bear + C-rigor + C-null + synth). Full deterministic panel (C-regime/GMM, C-prov), the visible rebuttal, all-10 backtests, and the Considered-Alternatives fan-out are **Phase 2**. Deletions + provenance hardening + flag-ON are **Phase 3**.
- Corpus is metadata-only today; tests run on a fixture corpus (population is in-scope, Dan driving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)