### PR TITLE
[t1.1][phase2] Critic panel (C-regime + C-prov) + visible bull/bear rebuttal !minor

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -404,7 +404,9 @@ def _critic_prov(pool: list[Any], corpus: list[Any]) -> tuple[list[Any], list[An
     kept: list[Any] = []
     dropped: list[Any] = []
     for prop in pool:
-        cited = set(prop.source_arxiv_ids)
+        # Robust to a proposal missing/None source_arxiv_ids — treat as empty (→ drop,
+        # "not provenance-verifiable"), never raise and abort the whole run (Copilot review).
+        cited = set(getattr(prop, "source_arxiv_ids", None) or [])
         if cited and cited <= surface:
             kept.append(prop)
         else:
@@ -542,11 +544,14 @@ def _critic_regime() -> dict[str, Any]:
     }
     try:
         from archimedes.models.regime import Regime
-        from archimedes.services.gmm_regime_detector import GmmRegimeDetector, gmm_regime_health
+        from archimedes.services.gmm_regime_detector import current_regime, gmm_regime_health
 
         health = gmm_regime_health()
         degraded = health.status != "live"
-        rc = GmmRegimeDetector().get_current_regime()
+        # Read the SHARED live detector (the one the oracle/agent runner feeds), NOT a
+        # fresh GmmRegimeDetector — a new instance has no current classification, so it
+        # would always read None and the gate would never fire (Copilot review).
+        rc = current_regime()
         regime = rc.regime if rc is not None else None
         confidence = float(rc.confidence) if rc is not None else 0.0
         force_abstain = regime == Regime.CRISIS

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -279,18 +279,26 @@ async def _propose_pool(brief: GenerateBrief, model: str | None, corpus: list[An
 # ── Step 2 — best-effort adversarial round (transcript only, never gates) ─────
 
 _DEBATE_SYSTEM = (
-    "You are the {role} researcher in a quant strategy debate. {stance}. "
-    "Cite ONLY the listed candidate strategies. Reply with ONE JSON object: "
-    '{{"verdict": "act"|"decline", "confidence": <0..1>, "key_claims": [<str>...]}}.'
+    "You are the {role} researcher in a quant strategy debate, round {rnd}. {stance}. "
+    "Cite ONLY the listed candidate strategies. {rebuttal}"
+    'Reply with ONE JSON object: {{"verdict": "act"|"decline", "confidence": <0..1>, "key_claims": [<str>...]}}.'
 )
+
+_DEBATE_STANCES = {
+    "bull": "Argue FOR acting on the strongest candidate",
+    "bear": "Argue for ABSTENTION — the null is buy-and-hold; attack overfit/cost",
+}
 
 
 async def _debate_round(pool: list[Any], model: str | None, emit: _Emitter, candidate_id: str) -> list[dict[str, Any]]:
-    """Thin best-effort bull/bear round — transcript only, never gates (Phase 1).
+    """Best-effort bull/bear research debate with ONE visible rebuttal round.
 
-    Surfaces the adversarial topology on the SSE stream. Any failure (no backend,
-    unparseable output) degrades to a neutral transcript entry. The transcript is
-    built in fixed [bull, bear] role order for R3 determinism (sort-before-hash).
+    Round 1: bull + bear state initial positions. Round 2: each REBUTS the other's
+    round-1 claims (the visible adversarial turn — the "debate" the roadmap names).
+    Transcript ONLY — it never gates; the deterministic critics do the real culling.
+    Built in fixed ``[bull-r1, bear-r1, bull-r2, bear-r2]`` order for R3 determinism
+    (sort-before-hash). Any failure (no backend, unparseable output) degrades to a
+    neutral entry; the whole round is skipped if no backend is available.
     """
     from archimedes.agents.strategy_architect import extract_json
     from archimedes.services.llm_backend import make_llm_backend
@@ -305,28 +313,43 @@ async def _debate_round(pool: list[Any], model: str | None, emit: _Emitter, cand
     if not getattr(backend, "available", False):
         return transcript
 
-    for role, stance in (
-        ("bull", "Argue FOR acting on the strongest candidate"),
-        ("bear", "Argue for ABSTENTION — the null is buy-and-hold; attack overfit/cost"),
-    ):
-        await emit.emit(
-            "tool_called",
-            candidate_id=candidate_id,
-            tool_name=f"debate_{role}",
-            args_summary=f"candidates: {names[:120]}",
-        )
-        try:
-            raw = await asyncio.to_thread(backend.complete, _DEBATE_SYSTEM.format(role=role, stance=stance), names)
-            parsed = extract_json(raw)
-            transcript.append(
-                {
-                    "role": role,
-                    "verdict": str(parsed.get("verdict", "n/a")),
-                    "claims": list(parsed.get("key_claims") or parsed.get("fatal_flaws") or []),
-                }
+    def _turn(role: str, rnd: int, opponent_claims: list[str]) -> dict[str, Any]:
+        rebuttal = ""
+        if opponent_claims:
+            rebuttal = (
+                f"The opposing researcher argued: {'; '.join(str(c) for c in opponent_claims[:3])}. "
+                "Directly rebut their strongest point. "
             )
+        try:
+            raw = backend.complete(
+                _DEBATE_SYSTEM.format(role=role, rnd=rnd, stance=_DEBATE_STANCES[role], rebuttal=rebuttal),
+                names,
+            )
+            parsed = extract_json(raw)
+            return {
+                "role": role,
+                "round": rnd,
+                "verdict": str(parsed.get("verdict", "n/a")),
+                "claims": list(parsed.get("key_claims") or parsed.get("fatal_flaws") or []),
+            }
         except Exception:
-            transcript.append({"role": role, "verdict": "n/a", "claims": []})
+            return {"role": role, "round": rnd, "verdict": "n/a", "claims": []}
+
+    # Round 1 — initial positions (fixed bull→bear order).
+    for role in ("bull", "bear"):
+        await emit.emit(
+            "tool_called", candidate_id=candidate_id, tool_name=f"debate_{role}_r1", args_summary=names[:120]
+        )
+        transcript.append(await asyncio.to_thread(_turn, role, 1, []))
+
+    # Round 2 — visible rebuttal: each researcher sees the other's round-1 claims.
+    claims_by_role = {t["role"]: t["claims"] for t in transcript}
+    for role, opponent in (("bull", "bear"), ("bear", "bull")):
+        await emit.emit(
+            "tool_called", candidate_id=candidate_id, tool_name=f"debate_{role}_r2", args_summary="rebuttal"
+        )
+        transcript.append(await asyncio.to_thread(_turn, role, 2, claims_by_role.get(opponent, [])))
+
     return transcript
 
 

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -465,13 +465,85 @@ def _abstain_result(candidate_id: str, *, regime: str, reason: str) -> _Candidat
     )
 
 
-def build_leaderboard(rigor_results: list[tuple[Any, Any]], *, regime: str, base_id: str) -> list[_CandidateResult]:
-    """Deterministic C-null cull + rank → the top-N leaderboard (leader first).
+def _critic_regime() -> dict[str, Any]:
+    """C-regime (Xia §4.4 Hierarchy-of-Truth) — read the live exogenous regime.
 
-    Returns ``[abstain]`` when no candidate clears the passive null. The leader
-    keeps ``base_id``; alternatives get ``base_id_alt{n}`` so the persist tail can
-    distinguish them. Pure + deterministic — directly unit-tested.
+    **Non-votable.** A live CRISIS read forces ABSTAIN regardless of how good the
+    candidates look — crisis is exactly when you do NOT deploy a fresh strategy,
+    and no bull argument can override it. DEGRADED (GMM artifact missing → VIX
+    rule-based fallback) is surfaced honestly and lowers confidence, but does not
+    by itself force abstain (else the society would always abstain when the model
+    is unavailable). Never raises — any failure degrades to "unavailable, don't
+    force" so the regime critic can only ABSTAIN, never spuriously APPROVE.
+
+    Returns a dict: ``regime`` (str|None), ``confidence`` (float), ``degraded``
+    (bool), ``force_abstain`` (bool), ``reason`` (str).
     """
+    out: dict[str, Any] = {
+        "regime": None,
+        "confidence": 0.0,
+        "degraded": True,
+        "force_abstain": False,
+        "reason": "regime detector unavailable — not gating",
+    }
+    try:
+        from archimedes.models.regime import Regime
+        from archimedes.services.gmm_regime_detector import GmmRegimeDetector, gmm_regime_health
+
+        health = gmm_regime_health()
+        degraded = health.status != "live"
+        rc = GmmRegimeDetector().get_current_regime()
+        regime = rc.regime if rc is not None else None
+        confidence = float(rc.confidence) if rc is not None else 0.0
+        force_abstain = regime == Regime.CRISIS
+        if regime is None:
+            reason = "no regime read — not gating"
+        elif force_abstain:
+            reason = (
+                f"CRISIS regime (confidence={confidence:.2f}"
+                f"{', GMM degraded → VIX fallback' if degraded else ''}) — non-votable ABSTAIN"
+            )
+        else:
+            reason = (
+                f"regime={regime.value} confidence={confidence:.2f}"
+                f"{' (GMM degraded → VIX rule-based fallback)' if degraded else ''}"
+            )
+        out = {
+            "regime": regime.value if regime is not None else None,
+            "confidence": confidence,
+            "degraded": degraded,
+            "force_abstain": force_abstain,
+            "reason": reason,
+        }
+    except Exception:
+        logger.debug("C-regime read failed; treating as unavailable (not gating)", exc_info=True)
+    return out
+
+
+def build_leaderboard(
+    rigor_results: list[tuple[Any, Any]],
+    *,
+    regime: str,
+    base_id: str,
+    regime_force_abstain: bool = False,
+    regime_reason: str = "",
+) -> list[_CandidateResult]:
+    """Deterministic C-regime gate → C-null cull + rank → top-N leaderboard.
+
+    The **non-votable C-regime gate runs first**: a live-CRISIS
+    ``regime_force_abstain`` short-circuits to ABSTAIN before C-null even runs —
+    market regime structurally overrides candidate consensus (Hierarchy-of-Truth).
+    Otherwise: C-null cull → rank → leaderboard (leader keeps ``base_id``,
+    alternatives get ``base_id_alt{n}``). Pure + deterministic — directly tested.
+    """
+    if regime_force_abstain:
+        return [
+            _abstain_result(
+                base_id,
+                regime=regime,
+                reason=f"Regime gate (non-votable, Hierarchy-of-Truth): {regime_reason}",
+            )
+        ]
     survivors = [(p, ev) for (p, ev) in rigor_results if _survives_null(ev)]
     if not survivors:
         return [
@@ -562,9 +634,24 @@ async def _run_debate_candidate(
     if not rigor_results:
         raise DebateUnavailable("debate: no candidate produced a successful backtest")
 
-    # Steps 4/5 — C-null cull + deterministic synthesize → leaderboard.
+    # Step 4 — C-regime (non-votable Hierarchy-of-Truth): read the live regime.
+    regime_gate = await asyncio.to_thread(_critic_regime)
+    await emit.emit(
+        "tool_result",
+        candidate_id=candidate_id,
+        tool_name="critic_regime",
+        result_summary=regime_gate["reason"],
+    )
+
+    # Step 5 — C-null cull + deterministic synthesize → leaderboard (C-regime gates first).
     await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=3, max_iterations=4)
-    leaderboard = build_leaderboard(rigor_results, regime=regime, base_id=candidate_id)
+    leaderboard = build_leaderboard(
+        rigor_results,
+        regime=regime,
+        base_id=candidate_id,
+        regime_force_abstain=regime_gate["force_abstain"],
+        regime_reason=regime_gate["reason"],
+    )
     leader = leaderboard[0]
     await emit.emit(
         "tool_result",

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -358,6 +358,37 @@ async def _critic_rigor(pool: list[Any], num_trials: int) -> list[tuple[Any, Any
     return out
 
 
+# ── C-prov (deterministic provenance/embargo gate — Xia 1/2/4) ────────────────
+
+
+def _critic_prov(pool: list[Any], corpus: list[Any]) -> tuple[list[Any], list[Any]]:
+    """C-prov (Xia 1/2/4, non-votable): hard-fail any candidate citing a paper
+    OUTSIDE the shared embargo + decay-applied evidence surface.
+
+    The surface is the ``load_corpus()`` output, which already excludes post-embargo
+    papers (``apply_outcome_embargo`` runs inside ``load_papers_from_db``), so a
+    candidate whose ``source_arxiv_ids`` are all in the corpus is provenance-clean.
+    A candidate citing an id NOT in the surface (a post-embargo leak or a
+    hallucination that slipped the proposer's ``valid_ids`` filter) is dropped —
+    deterministic defense-in-depth that cannot be argued out of its position.
+
+    Does NOT change ``pool_size`` (the DSR denominator counts every conformant spec
+    we proposed/searched, per spec §5c); it only culls which survivors reach C-rigor.
+    Returns ``(kept, dropped)``.
+    """
+    surface = {getattr(p, "arxiv_id", None) for p in corpus}
+    surface.discard(None)
+    kept: list[Any] = []
+    dropped: list[Any] = []
+    for prop in pool:
+        cited = set(prop.source_arxiv_ids)
+        if cited and cited <= surface:
+            kept.append(prop)
+        else:
+            dropped.append(prop)
+    return kept, dropped
+
+
 # ── Step 4/5 — C-null + synthesize → leaderboard ──────────────────────────────
 
 
@@ -616,21 +647,34 @@ async def _run_debate_candidate(
     # Step 2 — best-effort adversarial transcript (never gates).
     await _debate_round(pool, model, emit, candidate_id)
 
-    # Step 3 — C-rigor (A1, aligned with #770/#811 + Önder's #820 unification): the
-    # DSR multiple-testing count is `_society_num_trials(library_size, pool_size) =
-    # library + N`, NOT pool_size alone. The winner survived selection from the pool
-    # AND is promoted into the library, so both selection layers must deflate it —
-    # otherwise the debate "passing" badge is more permissive than the live path's.
-    # When #820 lands the shared helper, this should read from that single source.
+    # Step 3a — C-prov (non-votable, Xia 1/2/4): cull candidates citing outside the
+    # embargo+decay surface. Does NOT change pool_size (the DSR denominator counts
+    # every conformant spec we proposed; §5c) — only which survivors reach C-rigor.
+    prov_clean, prov_dropped = _critic_prov(pool, corpus)
+    if prov_dropped:
+        await emit.emit(
+            "tool_result",
+            candidate_id=candidate_id,
+            tool_name="critic_prov",
+            result_summary=f"dropped {len(prov_dropped)} candidate(s) citing outside the embargo surface",
+        )
+    if not prov_clean:
+        raise DebateUnavailable("debate: all candidates failed provenance (cited outside the embargo+decay surface)")
+
+    # Step 3b — C-rigor (A1, aligned with #770/#811 + Önder's #820): num_trials =
+    # _society_num_trials(library_size, pool_size) = library + N, NOT pool_size alone,
+    # so the debate "passing" badge is not more permissive than the live path. pool_size
+    # (the full conformant proposed count) is the selection set; C-prov only culls which
+    # survivors are backtested. When #820 lands the shared helper, read from that source.
     num_trials = await asyncio.to_thread(lambda: _society_num_trials(_library_size(), pool_size))
     await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=4)
     await emit.emit(
         "tool_called",
         candidate_id=candidate_id,
         tool_name="evaluate_fusion_spec",
-        args_summary=f"backtest ×{pool_size}, num_trials={num_trials} (library+pool, #770/#820)",
+        args_summary=f"backtest ×{len(prov_clean)}, num_trials={num_trials} (library+pool, #770/#820)",
     )
-    rigor_results = await _critic_rigor(pool, num_trials)
+    rigor_results = await _critic_rigor(prov_clean, num_trials)
     if not rigor_results:
         raise DebateUnavailable("debate: no candidate produced a successful backtest")
 

--- a/backend/archimedes/services/gmm_regime_detector.py
+++ b/backend/archimedes/services/gmm_regime_detector.py
@@ -179,6 +179,20 @@ def gmm_regime_health() -> GmmRegimeHealth:
     )
 
 
+def current_regime() -> RegimeClassification | None:
+    """The live regime classification from the most-recently-constructed detector.
+
+    Reads the SHARED detector (the one the oracle/agent runner feeds market data),
+    mirroring ``gmm_regime_health``. Constructing a fresh ``GmmRegimeDetector`` here
+    would be wrong — a new instance has no current classification until it has been
+    fed snapshots, so it would always return ``None``. Returns ``None`` when no
+    detector has been constructed/fed yet (the cold path) — callers treat that as
+    "no regime read" rather than a market signal.
+    """
+    detector = _LAST_DETECTOR() if _LAST_DETECTOR is not None else None
+    return detector.get_current_regime() if detector is not None else None
+
+
 def _label_components(scaler: StandardScaler, gmm: GaussianMixture) -> dict[int, Regime]:
     """Deterministically map each latent component to a ``Regime``.
 

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -410,3 +410,79 @@ def test_build_leaderboard_caps_to_top_n(monkeypatch):
     # Highest-DSR leader kept its base id; the cap takes the top-3 by score.
     assert board[0].candidate_id == "cand_1"
     assert all(e.has_real_rigor for e in board)
+# ── Phase 2 — C-regime non-votable Hierarchy-of-Truth gate ────────────────────
+
+
+def _patch_regime(monkeypatch, regime, *, confidence=0.9, status="live"):
+    """Patch the GMM regime read at its lazy-import boundary."""
+    from types import SimpleNamespace as NS
+
+    class _FakeDetector:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_current_regime(self):
+            return NS(regime=regime, confidence=confidence) if regime is not None else None
+
+    monkeypatch.setattr("archimedes.services.gmm_regime_detector.GmmRegimeDetector", _FakeDetector)
+    monkeypatch.setattr(
+        "archimedes.services.gmm_regime_detector.gmm_regime_health",
+        lambda: NS(status=status, reason="test"),
+    )
+
+
+def test_critic_regime_crisis_forces_abstain(monkeypatch):
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.CRISIS)
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is True
+    assert gate["regime"] == "crisis"
+    assert "CRISIS" in gate["reason"]
+
+
+def test_critic_regime_risk_on_does_not_gate(monkeypatch):
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.RISK_ON)
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is False
+    assert gate["regime"] == "risk_on"
+
+
+def test_critic_regime_unavailable_fails_safe_to_no_gate(monkeypatch):
+    # No regime read (None) must NEVER force-approve and must not crash — it simply
+    # does not gate (the critic can only ABSTAIN, never spuriously APPROVE).
+    _patch_regime(monkeypatch, None)
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is False
+    assert gate["regime"] is None
+
+
+def test_regime_degraded_does_not_force_abstain(monkeypatch):
+    # DEGRADED (VIX fallback) on a non-crisis regime must not force abstain — else
+    # the society would always abstain whenever the GMM artifact is missing.
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.RISK_OFF, status="degraded")
+    gate = de._critic_regime()
+    assert gate["force_abstain"] is False
+    assert gate["degraded"] is True
+
+
+def test_build_leaderboard_regime_gate_overrides_strong_survivors():
+    # Even with candidates that clear C-null, a non-votable CRISIS gate abstains.
+    rigor_results = [
+        (_fake_proposal("A", ["2401.00001", "2402.00001"]), _fake_ev(cagr=0.3, dsr=3.0)),
+        (_fake_proposal("B", ["2401.00002", "2402.00002"]), _fake_ev(cagr=0.2, dsr=2.0)),
+    ]
+    board = de.build_leaderboard(
+        rigor_results,
+        regime="neutral",
+        base_id="cand_1",
+        regime_force_abstain=True,
+        regime_reason="CRISIS regime (confidence=0.90) — non-votable ABSTAIN",
+    )
+    assert len(board) == 1
+    assert board[0].generation_method == "debate_abstain"
+    assert "Hierarchy-of-Truth" in board[0].thesis or "Regime gate" in board[0].reasoning

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -375,16 +375,51 @@ def test_leaderboard_entries_carry_cited_papers():
     assert union == {"2401.00001", "2402.00001"}
 
 
-async def test_debate_round_transcript_in_fixed_role_order(monkeypatch):
-    monkeypatch.setattr(
-        "archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: _CannedFusionBackend(model=model)
-    )
+class _DebateBackend:
+    """Records prompts; returns role-appropriate claims so the rebuttal is testable."""
+
+    model_id = "x"
+    served_model = "x"
+    available = True
+
+    def __init__(self):
+        self.prompts = []
+
+    def complete(self, system, user):
+        self.prompts.append(system)
+        role = "bull" if "bull researcher" in system else "bear"
+        return json.dumps(
+            {
+                "verdict": "act" if role == "bull" else "decline",
+                "confidence": 0.7,
+                "key_claims": [f"{role}-claim"],
+            }
+        )
+
+
+async def test_debate_round_two_rounds_with_visible_rebuttal(monkeypatch):
+    backend = _DebateBackend()
+    monkeypatch.setattr("archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: backend)
     monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
 
     pool = [_fake_proposal("A", ["2401.00001", "2402.00001"])]
     transcript = await de._debate_round(pool, "m", _FakeEmit(), "cand_1")
-    # Best-effort round still produces a deterministic [bull, bear] ordering.
-    assert [t["role"] for t in transcript] == ["bull", "bear"]
+    # Fixed [bull-r1, bear-r1, bull-r2, bear-r2] order (R3 determinism).
+    assert [(t["role"], t["round"]) for t in transcript] == [("bull", 1), ("bear", 1), ("bull", 2), ("bear", 2)]
+    # The visible rebuttal: each round-2 prompt carries the OTHER side's round-1 claim.
+    bull_r2_prompt, bear_r2_prompt = backend.prompts[2], backend.prompts[3]
+    assert "bear-claim" in bull_r2_prompt  # bull rebuts the bear
+    assert "bull-claim" in bear_r2_prompt  # bear rebuts the bull
+
+
+async def test_debate_round_degrades_when_backend_unavailable(monkeypatch):
+    class _Down:
+        available = False
+
+    monkeypatch.setattr("archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: _Down())
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+    transcript = await de._debate_round([_fake_proposal("A", ["1", "2"])], "m", _FakeEmit(), "cand_1")
+    assert transcript == []  # never gates; no backend → empty best-effort transcript
 
 
 # ── Review fixes: pool-max bound + leaderboard top-N cap ──────────────────────

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -445,21 +445,22 @@ def test_build_leaderboard_caps_to_top_n(monkeypatch):
     # Highest-DSR leader kept its base id; the cap takes the top-3 by score.
     assert board[0].candidate_id == "cand_1"
     assert all(e.has_real_rigor for e in board)
+
+
 # ── Phase 2 — C-regime non-votable Hierarchy-of-Truth gate ────────────────────
 
 
 def _patch_regime(monkeypatch, regime, *, confidence=0.9, status="live"):
-    """Patch the GMM regime read at its lazy-import boundary."""
+    """Patch the SHARED live-regime read (`current_regime`) + health at the boundary.
+
+    `_critic_regime` reads the most-recently-constructed detector via the module-level
+    `current_regime()` accessor (NOT a fresh GmmRegimeDetector, which would have no
+    classification), so the test patches that accessor.
+    """
     from types import SimpleNamespace as NS
 
-    class _FakeDetector:
-        def __init__(self, *a, **k):
-            pass
-
-        def get_current_regime(self):
-            return NS(regime=regime, confidence=confidence) if regime is not None else None
-
-    monkeypatch.setattr("archimedes.services.gmm_regime_detector.GmmRegimeDetector", _FakeDetector)
+    rc = NS(regime=regime, confidence=confidence) if regime is not None else None
+    monkeypatch.setattr("archimedes.services.gmm_regime_detector.current_regime", lambda: rc)
     monkeypatch.setattr(
         "archimedes.services.gmm_regime_detector.gmm_regime_health",
         lambda: NS(status=status, reason="test"),
@@ -542,3 +543,14 @@ def test_critic_prov_keeps_fully_grounded_candidates(corpus):
     kept, dropped = de._critic_prov([a, b], corpus)
     assert len(kept) == 2
     assert dropped == []
+
+
+def test_critic_prov_robust_to_missing_citations(corpus):
+    # A proposal missing source_arxiv_ids (None / absent attr) must DROP, not raise
+    # and abort the whole run (Copilot review).
+    none_cited = SimpleNamespace(strategy_name="none", source_arxiv_ids=None)
+    no_attr = SimpleNamespace(strategy_name="noattr")  # attribute absent entirely
+    good = _fake_proposal("good", ["2401.00001", "2402.00001"])
+    kept, dropped = de._critic_prov([none_cited, no_attr, good], corpus)
+    assert [p.strategy_name for p in kept] == ["good"]
+    assert {p.strategy_name for p in dropped} == {"none", "noattr"}

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -486,3 +486,24 @@ def test_build_leaderboard_regime_gate_overrides_strong_survivors():
     assert len(board) == 1
     assert board[0].generation_method == "debate_abstain"
     assert "Hierarchy-of-Truth" in board[0].thesis or "Regime gate" in board[0].reasoning
+
+
+# ── Phase 2 — C-prov non-votable provenance/embargo gate (Xia 1/2/4) ──────────
+
+
+def test_critic_prov_drops_citations_outside_the_surface(corpus):
+    # The fixture corpus surface = {2401.0000{1,2,3}, 2402.0000{1,2,3}} (embargo-clean).
+    clean = _fake_proposal("clean", ["2401.00001", "2402.00001"])
+    dirty = _fake_proposal("dirty", ["2401.00001", "9999.99999"])  # 9999.* not in the surface
+    empty = _fake_proposal("empty", [])  # no citations → cannot verify provenance
+    kept, dropped = de._critic_prov([clean, dirty, empty], corpus)
+    assert [p.strategy_name for p in kept] == ["clean"]
+    assert {p.strategy_name for p in dropped} == {"dirty", "empty"}
+
+
+def test_critic_prov_keeps_fully_grounded_candidates(corpus):
+    a = _fake_proposal("a", ["2401.00002", "2402.00002"])
+    b = _fake_proposal("b", ["2401.00003", "2402.00003"])
+    kept, dropped = de._critic_prov([a, b], corpus)
+    assert len(kept) == 2
+    assert dropped == []


### PR DESCRIPTION
**T1.1 Phase 2 — increment 1.** Stacked on **#815** (base = the Phase-1 branch; merge #815 first, then I'll retarget this to main). Adds the deterministic **C-regime critic** — the non-votable Hierarchy-of-Truth gate (Xia §4.4).

## What it does
- `_critic_regime()` reads the live exogenous regime (`GmmRegimeDetector.get_current_regime()` + `gmm_regime_health()`). A **live CRISIS** read **forces ABSTAIN** — market regime structurally overrides candidate consensus; no bull argument can vote it down. Crisis is exactly when you do *not* deploy a fresh strategy.
- **DEGRADED** (GMM artifact missing → VIX rule-based fallback) is surfaced honestly and lowers confidence, but does **not** by itself force abstain (else the society would always abstain whenever the GMM is unavailable).
- **Fail-safe:** any error or no-read → "unavailable, not gating" — the critic can only ever ABSTAIN, never spuriously APPROVE.
- `build_leaderboard` runs the regime gate **first** (short-circuits before C-null); `_run_debate_candidate` calls it off-thread and emits its verdict on the SSE stream.

## Tests (+5, hermetic — GMM patched at the lazy-import boundary)
CRISIS forces abstain · risk_on does not gate · no-read fails safe · degraded+non-crisis does not force abstain · the gate overrides even strong C-null survivors. **17 debate tests pass.**

## Next Phase-2 increments (separate PRs)
C-prov (embargo/provenance critic) · visible bull/bear rebuttal round · scale pool to ~15–20 · all-10 backtests + Considered-Alternatives leaderboard fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)