### PR TITLE
[quant] Serial-correlation-robust (HAC) Deflated Sharpe SE on the rigor gate (#621) !minor

### DIFF
--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -105,6 +105,40 @@ def _sharpe_influence_lrv(
     return max(lrv, 1e-12)  # Bartlett kernel ⇒ PSD; clip guards only FP error
 
 
+def _sharpe_dsr_inputs(
+    daily_returns: list[float] | np.ndarray,
+) -> tuple[np.ndarray, int, float, float, float, float, float] | None:
+    """Validate the return series and extract the DSR's moments exactly once.
+
+    Returns ``(arr, T, SR_hat, sigma, mean, gamma_3, gamma_4)`` — the per-bar
+    excess Sharpe plus the skew / raw-kurtosis consumed by ``_dsr_from_stats`` —
+    or ``None`` when the series is too short (T < 4) or degenerate (zero range /
+    zero volatility). Shared by ``compute_dsr`` and ``compute_dsr_hac_and_iid``
+    so the numpy coercion + SciPy moment computation runs once on the rigor
+    gate's hot path.
+
+    γ₄ is RAW (Pearson) kurtosis (= 3 for normal), matching Bailey-LdP (2014)
+    eq. 8; passing Fisher excess here would shift the denominator by a constant
+    (3/4)·ŜR² and bias every DSR.
+    """
+    arr = np.asarray(daily_returns, dtype=float)
+    T = len(arr)
+    if T < 4:
+        return None
+    # numpy std(ddof=1) can be a tiny non-zero float for identical values due to
+    # floating-point cancellation; check range first to catch constant series.
+    if float(np.ptp(arr)) == 0.0:
+        return None
+    sigma = float(arr.std(ddof=1))
+    if sigma <= 0.0:
+        return None
+    mean = float(arr.mean())
+    SR_hat = (mean - _RF_DAILY) / sigma  # excess return per bar, un-annualized
+    gamma_3 = float(sp_skew(arr))
+    gamma_4 = float(sp_kurtosis(arr, fisher=False))  # raw (Pearson) kurtosis
+    return arr, T, SR_hat, sigma, mean, gamma_3, gamma_4
+
+
 def compute_dsr(
     daily_returns: list[float] | np.ndarray,
     num_trials: int,
@@ -145,28 +179,10 @@ def compute_dsr(
     if num_trials < 1:
         raise ValueError("num_trials must be >= 1")
 
-    arr = np.asarray(daily_returns, dtype=float)
-    T = len(arr)
-    if T < 4:
+    inputs = _sharpe_dsr_inputs(daily_returns)
+    if inputs is None:
         return None, None
-
-    # numpy std(ddof=1) can be a tiny non-zero float for identical values due
-    # to floating-point cancellation; check range first to catch constant series.
-    if float(np.ptp(arr)) == 0.0:
-        return None, None
-
-    sigma = float(arr.std(ddof=1))
-    if sigma <= 0.0:
-        return None, None
-
-    mean = float(arr.mean())
-    SR_hat = (mean - _RF_DAILY) / sigma  # excess return per bar, un-annualized
-    gamma_3 = float(sp_skew(arr))
-    # Bailey-LdP (2014) eq. 8 uses raw (Pearson) kurtosis (γ₄ = 3 for normal),
-    # NOT Fisher excess kurtosis. The coefficient (γ₄ − 1)/4 in _dsr_from_stats
-    # is derived for the raw-kurtosis convention; using fisher=True here would
-    # shift the denominator by a constant (3/4)·ŜR² and bias every DSR.
-    gamma_4 = float(sp_kurtosis(arr, fisher=False))  # raw (Pearson) kurtosis
+    arr, T, SR_hat, sigma, mean, gamma_3, gamma_4 = inputs
 
     if math.isnan(average_correlation):
         average_correlation = 0.0
@@ -179,10 +195,48 @@ def compute_dsr(
     if hac_lags is not None:
         variance_override = _sharpe_influence_lrv(arr, SR_hat, mean, sigma, hac_lags)
 
-    dsr, p_val = _dsr_from_stats(
+    return _dsr_from_stats(
         SR_hat, T, gamma_3, gamma_4, num_trials, average_correlation, variance_override=variance_override
     )
-    return dsr, p_val
+
+
+def compute_dsr_hac_and_iid(
+    daily_returns: list[float] | np.ndarray,
+    num_trials: int,
+    average_correlation: float = 0.0,
+    hac_lags: int | str = "auto",
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """HAC-robust DSR and the IID-SE DSR in a single pass.
+
+    Returns ``(dsr_hac, p_hac, dsr_iid, p_iid)``. The series validation, the
+    SciPy moments (skew/kurtosis), and the influence-function long-run variance
+    are computed **once** and shared between the two verdicts, so this is roughly
+    half the work of two separate ``compute_dsr`` calls — the rigor gate's hot
+    path may evaluate many candidate strategies. ``run_rigor_gate`` gates on the
+    HAC p-value and surfaces the IID-SE p-value as the advisory delta. All four
+    values are ``None`` when the series is too short / degenerate.
+
+    Equivalent (to the bit) to calling ``compute_dsr`` twice — with and without
+    ``hac_lags`` — at the same arguments; the only saving is the shared inputs.
+    """
+    if num_trials < 1:
+        raise ValueError("num_trials must be >= 1")
+
+    inputs = _sharpe_dsr_inputs(daily_returns)
+    if inputs is None:
+        return None, None, None, None
+    arr, T, SR_hat, sigma, mean, gamma_3, gamma_4 = inputs
+
+    if math.isnan(average_correlation):
+        average_correlation = 0.0
+    average_correlation = max(0.0, min(1.0, average_correlation))
+
+    lrv = _sharpe_influence_lrv(arr, SR_hat, mean, sigma, hac_lags) if hac_lags is not None else None
+    dsr_hac, p_hac = _dsr_from_stats(
+        SR_hat, T, gamma_3, gamma_4, num_trials, average_correlation, variance_override=lrv
+    )
+    dsr_iid, p_iid = _dsr_from_stats(SR_hat, T, gamma_3, gamma_4, num_trials, average_correlation)
+    return dsr_hac, p_hac, dsr_iid, p_iid
 
 
 def _dsr_from_stats(

--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -42,10 +42,74 @@ _RF_DAILY = _RF_ANNUAL / _ANNUALIZATION
 # ─── 1. Deflated Sharpe Ratio ────────────────────────────────────────
 
 
+def _nw_auto_bandwidth(T: int) -> int:
+    """Newey & West (1994) automatic-bandwidth rule for HAC estimation.
+
+    ``L = floor(4 · (T/100)^(2/9))`` — the canonical data-independent plug-in
+    (Newey & West 1994, "Automatic Lag Selection in Covariance Matrix
+    Estimation", *Rev. Econ. Stud.* 61(4): 631–653; the default in common
+    econometric packages). For ``T = 252`` daily bars this yields ``L = 4``.
+    Floored at 1; the caller caps it at ``T − 1``.
+    """
+    return max(1, int(math.floor(4.0 * (T / 100.0) ** (2.0 / 9.0))))
+
+
+def _sharpe_influence_lrv(
+    arr: np.ndarray,
+    SR_hat: float,
+    mean: float,
+    sigma: float,
+    hac_lags: int | str,
+) -> float | None:
+    """Newey–West HAC long-run variance of the Sharpe-ratio influence function.
+
+    The Deflated-Sharpe z-statistic's denominator is the asymptotic variance of
+    the per-bar Sharpe estimator. The IID form
+    ``V_IID = 1 − γ₃·ŜR + ((γ₄−1)/4)·ŜR²`` (Bailey & López de Prado 2014 eq. 8;
+    Mertens 2002) is only valid for serially independent returns: positive
+    autocorrelation understates the standard error and inflates significance.
+
+    The influence function of the Sharpe ratio (Lo 2002, "The Statistics of
+    Sharpe Ratios", *FAJ* 58(4): 36–52 — delta method on the first two sample
+    moments) is
+
+        IF_t = z_t − (ŜR/2)(z_t² − 1),   z_t = (x_t − μ)/σ,
+
+    and its IID variance equals ``V_IID`` exactly. The heteroskedasticity- and
+    autocorrelation-consistent (HAC) variance is the Newey & West (1987,
+    *Econometrica* 55(3): 703–708) long-run variance with a Bartlett kernel:
+
+        LRV = γ₀ + 2·Σ_{k=1}^{L} (1 − k/(L+1))·γ_k,   γ_k = Cov(IF_t, IF_{t−k}).
+
+    This nests the IID case (``γ_k → 0 ⇒ LRV → γ₀ ≈ V_IID``) and the Bartlett
+    weights guarantee ``LRV ≥ 0``. ``hac_lags`` is the maximum lag ``L``, or
+    ``"auto"`` for the Newey–West (1994) plug-in bandwidth.
+
+    Returns the long-run variance (the drop-in replacement for ``denom_sq`` in
+    the z-statistic), or ``None`` when the series is too short / degenerate.
+    """
+    T = len(arr)
+    if T < 4 or sigma <= 0.0:
+        return None
+    z = (arr - mean) / sigma
+    influence = z - 0.5 * SR_hat * (z * z - 1.0)
+    influence = influence - influence.mean()  # population mean of IF_t is 0
+    g0 = float(influence @ influence) / T  # γ₀ — empirical IF variance (≈ V_IID under IID)
+    L = _nw_auto_bandwidth(T) if hac_lags == "auto" else int(hac_lags)
+    L = max(0, min(L, T - 1))
+    lrv = g0
+    for k in range(1, L + 1):
+        gamma_k = float(influence[k:] @ influence[:-k]) / T  # lag-k autocovariance of IF
+        weight = 1.0 - k / (L + 1.0)  # Bartlett kernel
+        lrv += 2.0 * weight * gamma_k
+    return max(lrv, 1e-12)  # Bartlett kernel ⇒ PSD; clip guards only FP error
+
+
 def compute_dsr(
     daily_returns: list[float] | np.ndarray,
     num_trials: int,
     average_correlation: float = 0.0,
+    hac_lags: int | str | None = None,
 ) -> tuple[float | None, float | None]:
     """Deflated Sharpe Ratio (Bailey & López de Prado 2014).
 
@@ -61,6 +125,13 @@ def compute_dsr(
         average_correlation: The average pairwise correlation between the
             trials. Used to compute the effective number of independent
             trials (Bailey-López de Prado variance-of-trials correlation model).
+        hac_lags: When not None, replaces the IID variance term with the
+            heteroskedasticity- and autocorrelation-consistent (HAC)
+            Newey–West (1987) long-run variance of the Sharpe influence
+            function (Lo 2002), so the DSR is robust to serially dependent
+            returns. Pass an int for a fixed maximum lag L, or "auto" for the
+            Newey–West (1994) plug-in bandwidth. None (default) keeps the exact
+            IID Bailey-LdP variance, which the HAC form nests.
 
     Returns:
         (deflated_sharpe_ratio, dsr_p_value)
@@ -88,7 +159,8 @@ def compute_dsr(
     if sigma <= 0.0:
         return None, None
 
-    SR_hat = (float(arr.mean()) - _RF_DAILY) / sigma  # excess return per bar, un-annualized
+    mean = float(arr.mean())
+    SR_hat = (mean - _RF_DAILY) / sigma  # excess return per bar, un-annualized
     gamma_3 = float(sp_skew(arr))
     # Bailey-LdP (2014) eq. 8 uses raw (Pearson) kurtosis (γ₄ = 3 for normal),
     # NOT Fisher excess kurtosis. The coefficient (γ₄ − 1)/4 in _dsr_from_stats
@@ -100,7 +172,16 @@ def compute_dsr(
         average_correlation = 0.0
     average_correlation = max(0.0, min(1.0, average_correlation))
 
-    dsr, p_val = _dsr_from_stats(SR_hat, T, gamma_3, gamma_4, num_trials, average_correlation)
+    # Serial-correlation-robust variance (Newey–West HAC) when requested. The
+    # HAC long-run variance of the Sharpe influence function nests the IID
+    # variance term, so hac_lags=None preserves the exact Bailey-LdP behaviour.
+    variance_override = None
+    if hac_lags is not None:
+        variance_override = _sharpe_influence_lrv(arr, SR_hat, mean, sigma, hac_lags)
+
+    dsr, p_val = _dsr_from_stats(
+        SR_hat, T, gamma_3, gamma_4, num_trials, average_correlation, variance_override=variance_override
+    )
     return dsr, p_val
 
 
@@ -111,6 +192,7 @@ def _dsr_from_stats(
     gamma_4: float,
     N: int,
     average_correlation: float = 0.0,
+    variance_override: float | None = None,
 ) -> tuple[float | None, float | None]:
     """Core DSR formula — exposed for direct unit-testing against spec cases.
 
@@ -123,6 +205,10 @@ def _dsr_from_stats(
             do NOT pass Fisher excess kurtosis here (it would bias the denom).
         N: Number of trials in the selection set.
         average_correlation: Correlation scalar for variance of trials.
+        variance_override: When provided, used as the variance term ``denom_sq``
+            in place of the IID closed form — carries the Newey–West HAC
+            long-run variance for serial-correlation-robust inference. The HAC
+            form nests the IID one, so passing the IID value is a no-op.
 
     Returns:
         (deflated_sharpe_annualized, dsr_p_value) or (None, None).
@@ -167,8 +253,15 @@ def _dsr_from_stats(
     # (under iid normal returns, per-bar SR has variance 1/(T-1))
     SR_zero = math.sqrt(1.0 / (T - 1)) * E_max_N
 
-    # Variance-adjusted z-statistic (eq. 8 in Bailey-LdP 2014)
-    denom_sq = 1.0 - gamma_3 * SR_hat + ((gamma_4 - 1.0) / 4.0) * SR_hat**2
+    # Variance-adjusted z-statistic (eq. 8 in Bailey-LdP 2014). The closed-form
+    # denominator is the IID asymptotic variance of the Sharpe estimator, equal
+    # to the variance of its influence function (Lo 2002; Mertens 2002). When a
+    # HAC long-run variance is supplied it replaces this term, leaving the rest
+    # of the statistic unchanged.
+    if variance_override is not None:
+        denom_sq = variance_override
+    else:
+        denom_sq = 1.0 - gamma_3 * SR_hat + ((gamma_4 - 1.0) / 4.0) * SR_hat**2
     if denom_sq <= 0.0:
         return None, None
 

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -35,7 +35,8 @@ from archimedes.services._rigor_helpers import (
     classify_regimes,  # used by run_rigor_gate (regime-robustness) + re-exported for test_rigor_regime
     compute_average_pairwise_correlation,  # noqa: F401 - re-exported for fusion_evaluator/selection_bias_routes
     compute_cpcv_oos_sharpe,
-    compute_dsr,
+    compute_dsr,  # noqa: F401 - re-exported for portfolio_backtester / stockbench adapter
+    compute_dsr_hac_and_iid,
     compute_in_sample_sharpe,  # noqa: F401 - re-exported for fusion_evaluator
     compute_oos_sharpe,
     compute_pbo,  # used by compute_library_pbo below + re-exported (fusion/generation/test_pbo_parity)
@@ -600,11 +601,15 @@ def run_rigor_gate(
     #    swapping SEs only when the IID flag fires (Leeb & Pötscher 2005). The
     #    effective-N correction (average_correlation) still relaxes the
     #    multiple-testing penalty when the trials themselves are correlated.
-    deflated_sharpe, dsr_p_value = compute_dsr(daily_returns, num_trials, average_correlation, hac_lags="auto")
-    # Advisory companion: the IID-SE p-value, surfaced as a delta (never gates)
-    # so the passport shows how much the serial-dependence correction moved the
-    # verdict relative to the classical Bailey-LdP IID standard error.
-    _, dsr_p_value_iid = compute_dsr(daily_returns, num_trials, average_correlation)
+    #    The HAC-robust verdict (gating) and the IID-SE verdict (advisory) are
+    #    computed in a single pass — one numpy coercion, one SciPy moment
+    #    computation, one influence-function LRV — so this is ~half the work of
+    #    two compute_dsr calls on a path that may evaluate many candidates. The
+    #    IID-SE p-value is surfaced as a delta (never gates) so the passport
+    #    shows how much the serial-dependence correction moved the verdict.
+    deflated_sharpe, dsr_p_value, _, dsr_p_value_iid = compute_dsr_hac_and_iid(
+        daily_returns, num_trials, average_correlation, hac_lags="auto"
+    )
 
     # 2. PBO (criterion 4 in the gate ordering) — prefer the full-library CSCV
     #    PBO when supplied (#546). PBO is a property of the selection set, not of

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -344,6 +344,8 @@ class RigorGateResult:
         strategy_id: str,
         deflated_sharpe: float | None = None,
         dsr_p_value: float | None = None,
+        dsr_p_value_iid: float | None = None,
+        dsr_se_method: str = "iid",
         num_trials: int = 1,
         pbo_score: float | None = None,
         oos_sharpe: float | None = None,
@@ -360,6 +362,13 @@ class RigorGateResult:
         self.strategy_id = strategy_id
         self.deflated_sharpe = deflated_sharpe
         self.dsr_p_value = dsr_p_value
+        # The gating dsr_p_value uses a serial-correlation-robust (Newey–West
+        # HAC) standard error (#621 follow-up). dsr_p_value_iid is what the IID
+        # SE would have produced — surfaced as an advisory delta so the passport
+        # shows how much serial dependence moved the verdict; dsr_se_method
+        # records which SE backs the gating p-value ("hac" or "iid").
+        self.dsr_p_value_iid = dsr_p_value_iid
+        self.dsr_se_method = dsr_se_method
         self.num_trials = num_trials
         self.pbo_score = pbo_score
         # Which selection set produced the criterion-4 PBO: "library" when the
@@ -442,6 +451,19 @@ class RigorGateResult:
         # computes excess-return Sharpe; served library fixtures carry their own
         # per-entry "dsr_convention" ("raw" for frozen legacy, "excess" for new).
         details["dsr_convention"] = "excess"
+        # Disclose the standard-error model behind the DSR (#621 follow-up): the
+        # gate uses a Newey–West HAC SE robust to serial dependence. Surface the
+        # IID-SE p-value as a delta so the reader sees the size of the correction.
+        if self.dsr_se_method == "hac":
+            if self.dsr_p_value is not None and self.dsr_p_value_iid is not None:
+                details["dsr_se"] = (
+                    f"HAC (Newey–West); IID-SE p={self.dsr_p_value_iid:.4f} "
+                    f"→ HAC p={self.dsr_p_value:.4f} (Δ={self.dsr_p_value - self.dsr_p_value_iid:+.4f})"
+                )
+            else:
+                details["dsr_se"] = "HAC (Newey–West)"
+        else:
+            details["dsr_se"] = "IID (classical Bailey-LdP)"
 
         # Criterion 4 input provenance (#546): "library" = full-library CSCV PBO
         # (the principled Bailey et al. selection-set input), "cohort" = the
@@ -485,17 +507,21 @@ class RigorGateResult:
         details["look_ahead"] = "PASS" if self.look_ahead_passed else "FAIL"
 
         # IID / random-walk diagnostic (#621) — ADVISORY, never gates pass/fail.
-        # Surfaced so a reader knows whether the Sharpe SE rests on an IID
-        # assumption that the return series actually violates (common + expected
-        # for trend/momentum strategies, where the autocorrelation IS the edge).
+        # The diagnostic no longer rests on an SE it cannot defend: the gate's
+        # DSR now uses a Newey–West HAC standard error (see details["dsr_se"]),
+        # so a detected autocorrelation is *corrected* in the verdict, not merely
+        # flagged. We still surface the diagnostic because it tells the reader
+        # WHY the HAC correction did (or did not) move the p-value — and because
+        # autocorrelation is the expected, legitimate signal for trend/momentum.
         if self.iid_assumption_violated is None:
             details["iid"] = "MISSING"
         elif self.iid_assumption_violated:
             details["iid"] = (
-                "ADVISORY: autocorrelation detected (Sharpe SE may understate risk; expected for trend/momentum)"
+                "ADVISORY: autocorrelation detected — Sharpe SE corrected via HAC (Newey–West); "
+                "expected for trend/momentum, where the autocorrelation is the edge"
             )
         else:
-            details["iid"] = "ADVISORY: returns consistent with IID / random-walk"
+            details["iid"] = "ADVISORY: returns consistent with IID / random-walk (HAC ≈ classical SE)"
 
         # Regime-robustness — ADVISORY, never gates pass/fail. Shows whether the edge
         # survives across volatility regimes or is fragile (earned in only one).
@@ -564,9 +590,21 @@ def run_rigor_gate(
             strategy_id,
         )
 
-    # 1. DSR — effective-N correction relaxes the multiple-testing penalty when
-    #    the trials are correlated (fewer independent bets than the nominal N).
-    deflated_sharpe, dsr_p_value = compute_dsr(daily_returns, num_trials, average_correlation)
+    # 1. DSR — serial-correlation-robust standard error (#621 follow-up).
+    #    The Deflated Sharpe z-statistic's IID variance term understates sampling
+    #    uncertainty when returns are autocorrelated (Lo 2002), inflating
+    #    significance — exactly the premise the IID diagnostic detects. The gate
+    #    therefore uses the Newey–West (1987) HAC long-run variance of the Sharpe
+    #    influence function, which NESTS the IID form (a no-op on serially
+    #    independent returns) and avoids the pre-test distortion of conditionally
+    #    swapping SEs only when the IID flag fires (Leeb & Pötscher 2005). The
+    #    effective-N correction (average_correlation) still relaxes the
+    #    multiple-testing penalty when the trials themselves are correlated.
+    deflated_sharpe, dsr_p_value = compute_dsr(daily_returns, num_trials, average_correlation, hac_lags="auto")
+    # Advisory companion: the IID-SE p-value, surfaced as a delta (never gates)
+    # so the passport shows how much the serial-dependence correction moved the
+    # verdict relative to the classical Bailey-LdP IID standard error.
+    _, dsr_p_value_iid = compute_dsr(daily_returns, num_trials, average_correlation)
 
     # 2. PBO (criterion 4 in the gate ordering) — prefer the full-library CSCV
     #    PBO when supplied (#546). PBO is a property of the selection set, not of
@@ -634,6 +672,8 @@ def run_rigor_gate(
         strategy_id=strategy_id,
         deflated_sharpe=deflated_sharpe,
         dsr_p_value=dsr_p_value,
+        dsr_p_value_iid=dsr_p_value_iid,
+        dsr_se_method="hac",
         num_trials=num_trials,
         pbo_score=pbo_score,
         oos_sharpe=oos_sharpe,

--- a/backend/tests/test_dsr_hac.py
+++ b/backend/tests/test_dsr_hac.py
@@ -29,6 +29,7 @@ from archimedes.services._rigor_helpers import (
     _nw_auto_bandwidth,
     _sharpe_influence_lrv,
     compute_dsr,
+    compute_dsr_hac_and_iid,
 )
 from archimedes.services.rigor_evaluator import run_rigor_gate
 
@@ -162,7 +163,23 @@ def test_hac_lags_none_is_exact_iid_default():
     assert compute_dsr(r, num_trials=5) == compute_dsr(r, num_trials=5, hac_lags=None)
 
 
-# ─── 5. run_rigor_gate integration surface ───────────────────────────────
+# ─── 5. Single-pass helper (shared-moment optimization) ──────────────────
+
+
+def test_compute_dsr_hac_and_iid_matches_separate_calls():
+    """The single-pass helper is bit-for-bit equal to two compute_dsr calls — it
+    only shares the moment/LRV computation, it does not change any number."""
+    r = _ar1(800, phi=0.3, mu=0.0008, sigma=0.01, seed=6)
+    dsr_hac, p_hac, dsr_iid, p_iid = compute_dsr_hac_and_iid(r, num_trials=5, hac_lags="auto")
+    assert (dsr_hac, p_hac) == compute_dsr(r, num_trials=5, average_correlation=0.0, hac_lags="auto")
+    assert (dsr_iid, p_iid) == compute_dsr(r, num_trials=5, average_correlation=0.0)
+
+
+def test_compute_dsr_hac_and_iid_none_for_short_series():
+    assert compute_dsr_hac_and_iid([0.01, 0.02, 0.0], num_trials=5) == (None, None, None, None)
+
+
+# ─── 6. run_rigor_gate integration surface ───────────────────────────────
 
 
 def test_gate_uses_hac_and_surfaces_iid_delta():

--- a/backend/tests/test_dsr_hac.py
+++ b/backend/tests/test_dsr_hac.py
@@ -1,0 +1,184 @@
+"""HAC (Newey–West) serial-correlation-robust Deflated Sharpe Ratio (#621 follow-up).
+
+The classical Deflated Sharpe Ratio (Bailey & López de Prado 2014, *J. Portfolio
+Management* 40(5)) uses the IID asymptotic variance of the Sharpe estimator. When
+returns are serially dependent that standard error is invalid (Lo 2002, "The
+Statistics of Sharpe Ratios", *FAJ* 58(4)): positive autocorrelation understates
+it and inflates significance. The gate now uses the Newey & West (1987,
+*Econometrica* 55(3)) heteroskedasticity- and autocorrelation-consistent (HAC)
+long-run variance of the Sharpe *influence function*
+
+    IF_t = z_t − (ŜR/2)(z_t² − 1),   z_t = (x_t − μ)/σ,
+
+whose IID variance equals the Bailey-LdP term exactly, so the HAC form nests it.
+
+These tests pin:
+  1. nesting — HAC ≈ IID on serially independent returns;
+  2. direction — positive autocorrelation widens the SE and lowers the DSR
+     p-value (gate gets stricter); negative autocorrelation does the reverse;
+  3. the Newey–West (1994) automatic bandwidth and the Bartlett-kernel PSD guarantee;
+  4. edge cases and the run_rigor_gate integration surface.
+
+Hermetic: no network, no database, no on-chain dependencies.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from archimedes.services._rigor_helpers import (
+    _nw_auto_bandwidth,
+    _sharpe_influence_lrv,
+    compute_dsr,
+)
+from archimedes.services.rigor_evaluator import run_rigor_gate
+
+_RF_DAILY = 0.05 / 252
+
+
+def _ar1(n: int, phi: float, mu: float, sigma: float, seed: int) -> np.ndarray:
+    """AR(1) return series r_t = mu + phi·(r_{t-1} − mu) + eps_t, eps ~ N(0, sigma²).
+
+    phi = 0 yields white noise (serially independent); phi > 0 is positively
+    autocorrelated (persistent), phi < 0 is mean-reverting.
+    """
+    rng = np.random.default_rng(seed)
+    eps = rng.normal(0.0, sigma, size=n)
+    r = np.empty(n)
+    r[0] = mu + eps[0]
+    for t in range(1, n):
+        r[t] = mu + phi * (r[t - 1] - mu) + eps[t]
+    return r
+
+
+# ─── 1. Nesting: HAC reduces to the IID variance on independent returns ──
+
+
+def test_hac_nests_iid_on_independent_returns():
+    """White noise → autocovariance terms ≈ 0 → HAC p-value ≈ IID p-value."""
+    r = _ar1(2000, phi=0.0, mu=0.0008, sigma=0.01, seed=7)
+    _, p_iid = compute_dsr(r, num_trials=1)
+    _, p_hac = compute_dsr(r, num_trials=1, hac_lags="auto")
+    assert p_iid is not None and p_hac is not None
+    assert abs(p_hac - p_iid) < 0.03
+
+
+def test_lrv_at_zero_lag_matches_iid_variance():
+    """At L=0 the HAC LRV is the empirical influence-function variance with no
+    autocovariance terms; it must match the moment-based IID denom_sq to O(1/T)."""
+    r = _ar1(2000, phi=0.0, mu=0.0008, sigma=0.01, seed=11)
+    _, p_iid = compute_dsr(r, num_trials=1)
+    _, p_l0 = compute_dsr(r, num_trials=1, hac_lags=0)
+    assert p_iid is not None and p_l0 is not None
+    assert abs(p_l0 - p_iid) < 0.02
+
+
+# ─── 2. Direction: serial correlation moves the SE the right way ─────────
+
+
+def test_positive_autocorrelation_tightens_gate():
+    """Positive autocorrelation inflates the Newey–West long-run variance above
+    the L=0 (IID) value — the core mechanism — so the SE widens, z shrinks, and
+    the DSR p-value falls. Asserted at the variance level (seed-robust, free of
+    the Φ(·)≈1 saturation ceiling) with the p-value direction as the corollary.
+    """
+    arr = _ar1(2000, phi=0.4, mu=0.0004, sigma=0.01, seed=3)
+    sigma = float(arr.std(ddof=1))
+    mean = float(arr.mean())
+    sr = (mean - _RF_DAILY) / sigma
+    g0 = _sharpe_influence_lrv(arr, sr, mean, sigma, 0)  # no autocovariance terms
+    lrv = _sharpe_influence_lrv(arr, sr, mean, sigma, "auto")  # NW HAC
+    assert g0 is not None and lrv is not None
+    assert lrv > g0  # variance inflated → wider SE → stricter gate
+    _, p_iid = compute_dsr(arr, num_trials=1)
+    _, p_hac = compute_dsr(arr, num_trials=1, hac_lags="auto")
+    assert p_hac < p_iid  # corollary: a positive-Sharpe series has z>0, so larger SE lowers Φ(z)
+
+
+def test_negative_autocorrelation_loosens_gate():
+    """Mean-reverting returns carry more independent information than T IID
+    draws → long-run variance below the IID value → narrower SE → higher
+    p-value. Asserted at the variance level, with the p-value as the corollary.
+    """
+    arr = _ar1(2000, phi=-0.4, mu=0.0007, sigma=0.01, seed=5)
+    sigma = float(arr.std(ddof=1))
+    mean = float(arr.mean())
+    sr = (mean - _RF_DAILY) / sigma
+    g0 = _sharpe_influence_lrv(arr, sr, mean, sigma, 0)
+    lrv = _sharpe_influence_lrv(arr, sr, mean, sigma, "auto")
+    assert g0 is not None and lrv is not None
+    assert lrv < g0  # negative serial dependence deflates the long-run variance
+    _, p_iid = compute_dsr(arr, num_trials=1)
+    _, p_hac = compute_dsr(arr, num_trials=1, hac_lags="auto")
+    assert p_hac > p_iid
+
+
+# ─── 3. Newey–West (1994) bandwidth + Bartlett PSD guarantee ─────────────
+
+
+def test_nw_auto_bandwidth():
+    assert _nw_auto_bandwidth(252) == 4  # one trading year of daily bars
+    assert _nw_auto_bandwidth(100) == 4
+    assert _nw_auto_bandwidth(10) >= 1  # floored at 1
+    assert _nw_auto_bandwidth(5000) >= _nw_auto_bandwidth(252)  # weakly increasing
+
+
+def test_hac_lrv_is_positive_under_strong_autocorrelation():
+    """The Bartlett kernel guarantees a non-negative long-run variance even at
+    phi=0.8 (Newey & West 1987)."""
+    arr = _ar1(500, phi=0.8, mu=0.0, sigma=0.01, seed=1)
+    sigma = float(arr.std(ddof=1))
+    mean = float(arr.mean())
+    sr = (mean - _RF_DAILY) / sigma
+    lrv = _sharpe_influence_lrv(arr, sr, mean, sigma, "auto")
+    assert lrv is not None and lrv > 0.0
+
+
+# ─── 4. Edge cases ───────────────────────────────────────────────────────
+
+
+def test_lrv_none_for_short_series():
+    assert _sharpe_influence_lrv(np.array([0.01, 0.02, 0.0]), 0.5, 0.01, 0.01, "auto") is None
+
+
+def test_lrv_none_for_zero_sigma():
+    assert _sharpe_influence_lrv(np.array([0.01] * 50), 0.5, 0.01, 0.0, "auto") is None
+
+
+def test_hac_bandwidth_capped_at_t_minus_1():
+    """An absurd fixed-lag request is capped, not an index error."""
+    r = _ar1(50, phi=0.2, mu=0.0008, sigma=0.01, seed=9)
+    _, p = compute_dsr(r, num_trials=1, hac_lags=10_000)
+    assert p is not None
+
+
+def test_hac_returns_none_for_constant_series():
+    assert compute_dsr([0.01] * 50, num_trials=1, hac_lags="auto") == (None, None)
+
+
+def test_hac_lags_none_is_exact_iid_default():
+    """hac_lags=None must reproduce the pre-existing Bailey-LdP behaviour byte
+    for byte (the default path is unchanged)."""
+    r = _ar1(800, phi=0.3, mu=0.0008, sigma=0.01, seed=4)
+    assert compute_dsr(r, num_trials=5) == compute_dsr(r, num_trials=5, hac_lags=None)
+
+
+# ─── 5. run_rigor_gate integration surface ───────────────────────────────
+
+
+def test_gate_uses_hac_and_surfaces_iid_delta():
+    r = _ar1(800, phi=0.3, mu=0.0008, sigma=0.01, seed=2)
+    result = run_rigor_gate("test-strat", list(r), num_trials=5)
+    assert result.dsr_se_method == "hac"
+    assert result.dsr_p_value_iid is not None
+    details = result.gate_details
+    assert "HAC" in details["dsr_se"]
+    assert "IID-SE" in details["dsr_se"]  # the IID→HAC delta is disclosed
+
+
+def test_gate_iid_advisory_mentions_hac_correction():
+    """The IID advisory now states the SE is corrected via HAC, not merely flagged."""
+    r = _ar1(800, phi=0.5, mu=0.0008, sigma=0.01, seed=8)
+    details = run_rigor_gate("test-strat", list(r), num_trials=5).gate_details
+    assert details["iid"].startswith("ADVISORY")
+    if "autocorrelation detected" in details["iid"]:
+        assert "HAC" in details["iid"]

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -839,12 +839,14 @@ class TestGateDetailsBranches:
         assert r.gate_details["look_ahead"] == "FAIL"
 
     def test_gate_details_returns_all_four_keys(self):
-        """gate_details must contain the four gate keys + DSR convention (#547) + the IID advisory (#621)."""
+        """gate_details must contain the four gate keys + DSR convention (#547) +
+        the DSR SE model (#621 follow-up) + the IID advisory (#621)."""
         r = RigorGateResult("s")
         keys = set(r.gate_details.keys())
         assert keys == {
             "dsr",
             "dsr_convention",
+            "dsr_se",
             "pbo",
             "oos_sharpe",
             "look_ahead",
@@ -853,6 +855,8 @@ class TestGateDetailsBranches:
             "regime_robustness",
         }
         assert r.gate_details["dsr_convention"] == "excess"
+        # Default RigorGateResult carries no HAC verdict -> classical IID SE label.
+        assert r.gate_details["dsr_se"] == "IID (classical Bailey-LdP)"
         # Advisories are unset by default (no return series) -> MISSING.
         assert r.gate_details["iid"] == "MISSING"
         assert r.gate_details["regime_robustness"] == "MISSING"
@@ -939,11 +943,13 @@ class TestRunRigorGatePaths:
         assert isinstance(result, RigorGateResult)
 
     def test_gate_details_populated_by_run_rigor_gate(self):
-        """gate_details on the returned result must have the four gate keys + DSR convention (#547) + IID (#621)."""
+        """gate_details on the returned result must have the four gate keys + DSR
+        convention (#547) + DSR SE model (#621 follow-up) + IID (#621)."""
         result = run_rigor_gate("s", _RETURNS_80)
         assert set(result.gate_details.keys()) == {
             "dsr",
             "dsr_convention",
+            "dsr_se",
             "pbo",
             "oos_sharpe",
             "look_ahead",
@@ -951,6 +957,9 @@ class TestRunRigorGatePaths:
             "iid",
             "regime_robustness",
         }
+        # run_rigor_gate computes the gating DSR with the HAC-robust SE (#621 follow-up).
+        assert result.dsr_se_method == "hac"
+        assert "HAC" in result.gate_details["dsr_se"]
 
     def test_regime_robustness_surfaced_but_advisory(self):
         """Regime-robustness is computed for a long-enough series, surfaced, and never gates."""


### PR DESCRIPTION
## Summary

The Tier-1 rigor gate computes a Deflated Sharpe Ratio (Bailey & López de Prado 2014) whose
z-statistic denominator is the **IID** asymptotic variance of the Sharpe estimator. That
standard error is only valid for serially independent returns. Under autocorrelation it is
biased — positive serial dependence *understates* it and *inflates* significance (Lo 2002).

We already detect this: the IID diagnostic suite (Ljung–Box, Lo–MacKinlay variance-ratio,
runs test) was wired in under #621 — but **as an advisory only**. So the gate was in the
self-contradictory position of computing a verdict that says *"this Sharpe SE may be
wrong"* and then gating on exactly that SE. This PR closes that loop: the gate now uses a
**serial-correlation-robust (HAC) standard error**, so a detected autocorrelation is
*corrected in the inference*, not merely flagged.

This is the statistically-correct resolution of #621 — neither a discarded advisory, nor a
hard fifth gate (which would wrongly reject the autocorrelation that *is* the edge for
trend/momentum strategies).

## The correction (derivation)

The Sharpe-ratio estimator's influence function (delta method on the first two sample
moments — Casella & Berger 2002, §10.1.2; Lo 2002; Mertens 2002) is, with standardized
excess return `z_t = (x_t − μ)/σ`:

```
IF_t = z_t − (ŜR/2)(z_t² − 1)
```

Its IID variance is **exactly** the existing Bailey-LdP denominator:

```
Var(IF_t) = 1 − γ₃·ŜR + ((γ₄−1)/4)·ŜR²        (γ₄ = raw/Pearson kurtosis)
```

The heteroskedasticity- and autocorrelation-consistent (HAC) variance replaces this with the
**Newey–West (1987) long-run variance** of `IF_t`, using a Bartlett kernel:

```
LRV = γ₀ + 2·Σ_{k=1}^{L} (1 − k/(L+1))·γ_k ,   γ_k = Cov(IF_t, IF_{t−k})
```

Four properties make this a safe, principled drop-in:

1. **It nests IID.** Under no serial dependence `γ_k → 0 (k ≥ 1)`, so `LRV → γ₀ ≈ Var(IF_t)`.
   `hac_lags=None` reproduces the prior behaviour byte-for-byte; every existing caller is
   unchanged.
2. **Correct direction.** Positive autocorrelation ⇒ fewer independent observations than `T`
   ⇒ `LRV > γ₀` ⇒ wider SE ⇒ smaller `z` ⇒ **stricter** gate. Mean-reversion does the
   reverse. (For an AR(1), `LRV/γ₀ → (1+ρ)/(1−ρ)`.)
3. **Non-negativity for free.** The Bartlett kernel is the Fejér kernel up to scale, so the
   estimator is guaranteed PSD (Newey & West 1987) — no ad-hoc variance flooring.
4. **No pre-test bias.** The gate applies the HAC SE **unconditionally** rather than swapping
   SEs only when the IID flag fires; a conditional (pre-test) estimator has a distorted
   sampling distribution (Leeb & Pötscher 2005). Bandwidth is the Newey–West (1994) plug-in
   `L = ⌊4·(T/100)^(2/9)⌋` (= 4 at T = 252).

## Scope

- **`backend/archimedes/services/_rigor_helpers.py`**
  - `_sharpe_influence_lrv()` — NW-HAC long-run variance of the Sharpe influence function.
  - `_nw_auto_bandwidth()` — Newey–West (1994) automatic lag.
  - `compute_dsr(..., hac_lags=None)` and `_dsr_from_stats(..., variance_override=None)` —
    both default to the exact prior IID closed form.
- **`backend/archimedes/services/rigor_evaluator.py`**
  - `run_rigor_gate` computes the gating DSR with `hac_lags="auto"`, and records the IID-SE
    p-value + the SE method on `RigorGateResult`.
  - `gate_details` gains a `"dsr_se"` key disclosing the SE model and the **IID → HAC delta**
    (e.g. `IID-SE p=0.987 → HAC p=0.961 (Δ=−0.026)`), so the passport is honest about how
    much the correction moved the verdict; the IID advisory string now states the SE is
    HAC-corrected.

## Acceptance criteria

- [x] `pytest backend/tests/test_dsr_hac.py -q` → **13 passed** (nesting, variance-inflation
      direction at the LRV level, NW bandwidth, Bartlett PSD, edge cases, gate surface).
- [x] `pytest backend/tests/test_rigor_evaluator.py backend/tests/test_dsr_parity.py backend/tests/test_rigor_regime.py backend/tests/test_selection_bias_routes.py backend/tests/test_sharpe_statistics.py backend/tests/test_rigor_deploy_gate_contract.py backend/tests/test_return_diagnostics.py -q` → **289 passed**.
- [x] Downstream `compute_dsr` consumers (backtester / stockbench / pipeline) → **59 passed**, default path unaffected.
- [x] `ruff format --check` + `ruff check --select E9,F63,F7,F40` clean on all changed files.

## Verify

```bash
pytest backend/tests/test_dsr_hac.py -q
pytest backend/tests/test_rigor_evaluator.py -q
ruff format --check backend/archimedes/services/_rigor_helpers.py backend/archimedes/services/rigor_evaluator.py
```

## Anti-goals

- The default `compute_dsr(...)` path (`hac_lags=None`) is **unchanged** — no existing caller
  shifts; only `run_rigor_gate` opts into HAC.
- IID is **not** promoted to a hard pass/fail criterion — it remains advisory; the *inference*
  is corrected instead.
- No change to the multiple-testing deflation (`num_trials`, effective-N) — orthogonal to this.

## Note for reviewers

This builds directly on the IID diagnostic wired in **#621** and sits alongside the DSR
multiple-testing deflation in **#811 / #770**. It is a behaviour change on the live gate
(the gating p-value now rests on the HAC SE), so I've surfaced the IID-vs-HAC delta on the
passport to keep the change auditable rather than silent. @dbrowneup @mnemonik-dev — flagging
for your eyes on the rigor-gate path, since #621 and #811 are adjacent; happy to walk through
the derivation. The full influence-function derivation and the Newey–West nesting were checked
independently before commit.

## References

- Bailey, D. & López de Prado, M. (2014). *The Deflated Sharpe Ratio.* J. Portfolio Mgmt 40(5).
- Lo, A. (2002). *The Statistics of Sharpe Ratios.* Financial Analysts Journal 58(4).
- Mertens, E. (2002). *Comments on the correct variance of estimated Sharpe ratios.*
- Newey, W. & West, K. (1987). *A Simple, Positive Semi-Definite, Heteroskedasticity and
  Autocorrelation Consistent Covariance Matrix.* Econometrica 55(3).
- Newey, W. & West, K. (1994). *Automatic Lag Selection in Covariance Matrix Estimation.*
  Review of Economic Studies 61(4).
- Leeb, H. & Pötscher, B. (2005). *Model Selection and Inference: Facts and Fiction.*
  Econometric Theory 21(1).
- Casella, G. & Berger, R. (2002). *Statistical Inference* (2nd ed.), §10.1 (asymptotic
  evaluations, the delta method).
