### PR TITLE
[leaderboard] Public gamified strategy leaderboard — transparent conviction score + honest forward axis !minor

### DIFF
--- a/backend/archimedes/api/leaderboard_routes.py
+++ b/backend/archimedes/api/leaderboard_routes.py
@@ -1,0 +1,65 @@
+"""Leaderboard endpoint — /api/leaderboard (public, no wallet).
+
+The testnet engagement engine (North Star §5): a public, gamified ranking of the
+strategy library by the transparent conviction score (real rigor gate + backtest),
+paired with an honest, pending StockBench / live-P&L forward axis.
+
+Source for v1 is the curated/validated library (``strategy_provider``) — the
+strategies that carry real, rigor-gated numbers. Extending the board to
+generated passports is a fast-follow once their backtest completeness is
+confirmed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Query
+
+from archimedes.api._route_helpers import strategy_provider
+from archimedes.api.leaderboard_schemas import LeaderboardResponse
+from archimedes.services.leaderboard import build_leaderboard
+
+logger = logging.getLogger(__name__)
+
+leaderboard_router = APIRouter(prefix="/api/leaderboard", tags=["leaderboard"])
+
+_SORT_FIELDS = (
+    "conviction_score|sharpe_ratio|cagr|sortino_ratio|calmar_ratio|"
+    "deflated_sharpe_ratio|dsr_p_value|out_of_sample_sharpe|pbo_score"
+)
+
+
+@leaderboard_router.get("", response_model=LeaderboardResponse)
+async def get_leaderboard(
+    sort_by: str = Query("conviction_score", pattern=f"^({_SORT_FIELDS})$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
+    regime_tag: str | None = Query(None, pattern="^(bull|bear|regime_neutral)$"),
+    min_rigor: bool = Query(False),
+    limit: int = Query(50, ge=1, le=200),
+) -> LeaderboardResponse:
+    """Public, gamified strategy leaderboard.
+
+    Fail-safe: if the strategy provider is unavailable, returns an empty board
+    (with the scoring-engine metadata intact) rather than erroring — the public
+    page must never hard-fail.
+    """
+    # Imported lazily to avoid import-time coupling with the heavy strategies
+    # module (and any future cycle).
+    from archimedes.api.strategies_routes import _to_strategy_response
+
+    try:
+        strategies = strategy_provider.list_strategies()
+        responses = [_to_strategy_response(s) for s in strategies]
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("leaderboard: strategy provider unavailable: %s", exc)
+        responses = []
+
+    return build_leaderboard(
+        responses,
+        sort_by=sort_by,
+        order=order,
+        regime_tag=regime_tag,
+        min_rigor=min_rigor,
+        limit=limit,
+    )

--- a/backend/archimedes/api/leaderboard_schemas.py
+++ b/backend/archimedes/api/leaderboard_schemas.py
@@ -29,7 +29,13 @@ class LeaderboardScoreComponents(BaseModel):
 
     gate: float = Field(..., description="1.0 if passes_rigor_gate else 0.0")
     dsr_confidence: float = Field(
-        ..., description="DSR p-value, clamped [0,1] — confidence the Sharpe survives deflation/multiple-testing"
+        ...,
+        description=(
+            "DSR confidence in [0,1] — the probability the Sharpe survives "
+            "deflation/multiple-testing. HIGHER IS BETTER. (Sourced from the "
+            "`dsr_p_value` field, which despite its legacy name holds a 0–1 "
+            "confidence, NOT a classical p-value where lower is better.)"
+        ),
     )
     oos_performance: float = Field(..., description="out_of_sample_sharpe / OOS_TARGET, clamped [0,1]")
     overfitting_resistance: float = Field(..., description="1 - pbo_score, clamped [0,1]")
@@ -74,7 +80,14 @@ class LeaderboardEntry(BaseModel):
 
     # Rigor (selection-bias gate) — the credibility moat, surfaced honestly.
     deflated_sharpe_ratio: float | None = None
-    dsr_p_value: float | None = None
+    dsr_p_value: float | None = Field(
+        None,
+        description=(
+            "DSR confidence in [0,1] — HIGHER IS BETTER. Despite the legacy "
+            "`p_value` name this is a confidence (probability the Sharpe survives "
+            "deflation), not a classical p-value where lower is better."
+        ),
+    )
     pbo_score: float | None = None
     out_of_sample_sharpe: float | None = None
     passes_rigor_gate: bool = False

--- a/backend/archimedes/api/leaderboard_schemas.py
+++ b/backend/archimedes/api/leaderboard_schemas.py
@@ -1,0 +1,126 @@
+"""Leaderboard API schemas — /api/leaderboard.
+
+The public, gamified strategy leaderboard (North Star §5 — the testnet
+engagement engine). It ranks every library strategy by a **transparent**
+conviction score built from *real* passport data (rigor gate + backtest), and
+pairs that validation axis with a clearly-labelled **forward axis** (per-strategy
+StockBench + live paper-P&L) that is honest about what is live now vs pending.
+
+Design rule (the #1 rule — claims must be true): the leaderboard NEVER invents a
+number. Every ranking input is a real passport field; the score weights are
+explicit and echoed in the response; and the StockBench / live-P&L axis renders
+an honest "pending" state per strategy until that data actually flows. (A prior
+marketplace surface was removed for "hardcoded fees + invented math", #381 — we
+do not repeat that.)
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from archimedes.api.schemas import PaperRefResponse
+
+
+class LeaderboardScoreComponents(BaseModel):
+    """The four real, [0,1]-normalised inputs to the conviction score. Surfaced
+    per-entry so the gamified score is never a black box — the user sees exactly
+    what drove it. None inputs (e.g. a placeholder strategy with no DSR) score 0
+    and are reflected in ``data_completeness``."""
+
+    gate: float = Field(..., description="1.0 if passes_rigor_gate else 0.0")
+    dsr_confidence: float = Field(
+        ..., description="DSR p-value, clamped [0,1] — confidence the Sharpe survives deflation/multiple-testing"
+    )
+    oos_performance: float = Field(..., description="out_of_sample_sharpe / OOS_TARGET, clamped [0,1]")
+    overfitting_resistance: float = Field(..., description="1 - pbo_score, clamped [0,1]")
+    data_completeness: float = Field(..., description="Fraction of the four inputs backed by real data [0,1]")
+
+
+class LeaderboardForwardAxis(BaseModel):
+    """The forward-looking axis paired with validation in the scoring engine.
+    Per-strategy StockBench and live paper-P&L are not tracked yet, so these are
+    honestly ``pending`` per entry until the engagement-engine wiring lands. We
+    surface them (not hide them) so the scoring engine visibly pairs them with
+    validation, per the North Star, without fabricating values."""
+
+    stockbench_status: str = Field(
+        "pending",
+        description="'pending' until per-strategy StockBench eval exists; the global benchmark context lives in the engine metadata",
+    )
+    stockbench_sortino: float | None = None
+    live_pnl_status: str = Field(
+        "pending", description="'pending' until live paper-P&L tracking is wired (testnet — paper/simulated)"
+    )
+    live_pnl_pct: float | None = None
+
+
+class LeaderboardEntry(BaseModel):
+    rank: int
+    medal: str | None = Field(None, description="'gold' | 'silver' | 'bronze' for the top 3, else null")
+    id: str
+    name: str = Field(..., description="Paper title, else methodology summary — human label for the strategy")
+    creator: str = Field(..., description="curator_wallet, else 'Archimedes' for the curated seed library")
+
+    # The gamified, transparent score (0–100) and its real components.
+    conviction_score: float
+    score_components: LeaderboardScoreComponents
+
+    # Validation axis — real backtest metrics (None = not yet evaluated).
+    sharpe_ratio: float | None = None
+    cagr: float | None = None
+    sortino_ratio: float | None = None
+    max_drawdown: float | None = None
+    calmar_ratio: float | None = None
+
+    # Rigor (selection-bias gate) — the credibility moat, surfaced honestly.
+    deflated_sharpe_ratio: float | None = None
+    dsr_p_value: float | None = None
+    pbo_score: float | None = None
+    out_of_sample_sharpe: float | None = None
+    passes_rigor_gate: bool = False
+    is_backtest_placeholder: bool = False
+
+    # Forward axis (paired, honest-pending).
+    forward: LeaderboardForwardAxis
+
+    # Provenance + context.
+    regime_tag: str = "regime_neutral"
+    return_source: str = "noise"
+    status: str = "candidate"
+    papers: list[PaperRefResponse] = []
+
+
+class StockBenchGlobalContext(BaseModel):
+    """The one real StockBench result we have: the *whole* agent pipeline run
+    (Chen et al. 2026), not per-strategy. Surfaced as honest context so the
+    forward axis means something today without faking per-strategy numbers."""
+
+    scope: str = "agent_pipeline_global"
+    sortino: float
+    return_pct: float
+    max_drawdown_pct: float
+    rank: str
+    window: str
+    source: str
+
+
+class LeaderboardScoringEngine(BaseModel):
+    """Transparent metadata: the weights, the methodology, what's live vs pending,
+    and the StockBench global context. Rendered alongside the board so the score
+    is explainable and the testnet/paper framing is loud."""
+
+    weights: dict[str, float]
+    oos_target: float
+    methodology: str
+    validation_axis: str = "live"
+    forward_axis: str = "pending"
+    stockbench_global: StockBenchGlobalContext
+    disclaimer: str
+
+
+class LeaderboardResponse(BaseModel):
+    entries: list[LeaderboardEntry]
+    total: int
+    sort_by: str
+    order: str
+    scoring_engine: LeaderboardScoringEngine

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -36,7 +36,7 @@ from archimedes.api.generate_routes import generate_router
 from archimedes.api.leaderboard_routes import leaderboard_router
 from archimedes.api.limiter import limiter
 
-# marketplace_router removed — hardcoded fees + invented math (Issue #381)
+# (the marketplace route registration was removed — hardcoded fees + invented math, Issue #381)
 from archimedes.api.metrics_routes import metrics_router
 from archimedes.api.portfolio_routes import portfolio_router
 from archimedes.api.proposals_routes import proposals_router

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -33,6 +33,7 @@ from archimedes.api.chat_routes import chat_router
 from archimedes.api.corpus_routes import corpus_router
 from archimedes.api.explore_routes import explore_router
 from archimedes.api.generate_routes import generate_router
+from archimedes.api.leaderboard_routes import leaderboard_router
 from archimedes.api.limiter import limiter
 
 # marketplace_router removed — hardcoded fees + invented math (Issue #381)
@@ -259,6 +260,7 @@ app.include_router(user_router)
 app.include_router(auth_router)
 app.include_router(proposals_router)
 app.include_router(metrics_router)
+app.include_router(leaderboard_router)
 
 
 @app.get("/health")

--- a/backend/archimedes/services/leaderboard.py
+++ b/backend/archimedes/services/leaderboard.py
@@ -84,11 +84,23 @@ def _clamp01(x: float) -> float:
 def compute_conviction(resp: StrategyResponse) -> tuple[float, LeaderboardScoreComponents]:
     """Return (score 0–100, the four real components). Missing inputs score 0 and
     lower ``data_completeness`` — so placeholders honestly sink, never inflate."""
-    placeholder = resp.is_backtest_placeholder
+    # A placeholder backtest carries NO real validation data. Even if DSR/OOS/PBO
+    # fields happen to be populated (a seeded record can carry placeholder
+    # numbers), they are not real backtest output — so EVERY component scores 0
+    # and the entry sinks. Without this guard a placeholder could ride borrowed
+    # DSR/OOS/PBO values (75% of the weight) above a real-but-partially-missing
+    # strategy, which is exactly the inflation the docstring promises not to do.
+    if resp.is_backtest_placeholder:
+        zero = LeaderboardScoreComponents(
+            gate=0.0,
+            dsr_confidence=0.0,
+            oos_performance=0.0,
+            overfitting_resistance=0.0,
+            data_completeness=0.0,
+        )
+        return 0.0, zero
 
-    # gate is only meaningful when there's a real backtest behind it.
-    gate_real = not placeholder
-    gate = 1.0 if (resp.passes_rigor_gate and gate_real) else 0.0
+    gate = 1.0 if resp.passes_rigor_gate else 0.0
 
     dsr_real = resp.dsr_p_value is not None
     dsr_confidence = _clamp01(resp.dsr_p_value) if dsr_real else 0.0
@@ -99,7 +111,9 @@ def compute_conviction(resp: StrategyResponse) -> tuple[float, LeaderboardScoreC
     pbo_real = resp.pbo_score is not None
     overfitting_resistance = _clamp01(1.0 - resp.pbo_score) if pbo_real else 0.0
 
-    real_count = sum((gate_real, dsr_real, oos_real, pbo_real))
+    # gate is always a real signal for a non-placeholder strategy (+1); the other
+    # three count only when their field is populated.
+    real_count = 1 + int(dsr_real) + int(oos_real) + int(pbo_real)
     components = LeaderboardScoreComponents(
         gate=gate,
         dsr_confidence=dsr_confidence,

--- a/backend/archimedes/services/leaderboard.py
+++ b/backend/archimedes/services/leaderboard.py
@@ -1,0 +1,215 @@
+"""Leaderboard scoring engine — the testnet engagement engine (North Star §5).
+
+Ranks library strategies by a **transparent conviction score** built from *real*
+passport data: the rigor gate (DSR / PBO / OOS) plus backtest performance. The
+score is a documented weighted sum of four [0,1] inputs — never a black box — and
+every input is echoed per-entry so the user sees what drove the rank.
+
+Two axes, honestly separated:
+  • Validation axis (LIVE NOW): rigor gate + backtest — real passport fields.
+  • Forward axis (PENDING): per-strategy StockBench + live paper-P&L — surfaced
+    as honest "pending" until that data flows, so the engine visibly *pairs*
+    them with validation (per Dan's call) without inventing values.
+
+This module is pure: it takes ``StrategyResponse`` objects and returns schema
+objects. No DB, no network — trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from archimedes.api.leaderboard_schemas import (
+    LeaderboardEntry,
+    LeaderboardForwardAxis,
+    LeaderboardResponse,
+    LeaderboardScoreComponents,
+    LeaderboardScoringEngine,
+    StockBenchGlobalContext,
+)
+from archimedes.api.schemas import StrategyResponse
+
+# ── Scoring weights (explicit + echoed in the response) ──────────────────────
+# Rationale: passing the selection-bias gate is the single biggest *honest*
+# credibility signal, so it carries the most weight; DSR confidence and
+# out-of-sample performance are the next strongest "is the edge real?" signals;
+# overfitting resistance (low PBO) rounds it out. Sum = 1.0.
+WEIGHTS: dict[str, float] = {
+    "gate": 0.35,
+    "dsr_confidence": 0.25,
+    "oos_performance": 0.25,
+    "overfitting_resistance": 0.15,
+}
+
+#: An out-of-sample Sharpe of 1.0 earns full marks on the OOS component.
+OOS_TARGET = 1.0
+
+#: The one real StockBench datum we have — the whole agent pipeline run
+#: (Chen et al. 2026), NOT per-strategy. Surfaced as honest global context.
+#: Source: docs/benchmarks/stockbench-results.md.
+STOCKBENCH_GLOBAL = StockBenchGlobalContext(
+    sortino=-0.91,
+    return_pct=-2.3,
+    max_drawdown_pct=-6.2,
+    rank="15/15",
+    window="2025-03-03 → 2025-06-30 (82 trading days)",
+    source="docs/benchmarks/stockbench-results.md",
+)
+
+_DISCLAIMER = (
+    "Testnet — paper/simulated performance. Strategies are ranked on real, "
+    "rigor-gated backtest results. Per-strategy StockBench and live paper-P&L "
+    "are the next inputs to this engine and render as 'pending' until that data "
+    "flows; no number here is fabricated."
+)
+
+# Sortable real fields → (StrategyResponse attribute, higher_is_better).
+_SORTABLE: dict[str, tuple[str, bool]] = {
+    "conviction_score": ("conviction_score", True),  # computed, handled specially
+    "sharpe_ratio": ("sharpe_ratio", True),
+    "cagr": ("cagr", True),
+    "sortino_ratio": ("sortino_ratio", True),
+    "calmar_ratio": ("calmar_ratio", True),
+    "deflated_sharpe_ratio": ("deflated_sharpe_ratio", True),
+    "dsr_p_value": ("dsr_p_value", True),
+    "out_of_sample_sharpe": ("out_of_sample_sharpe", True),
+    "pbo_score": ("pbo_score", False),  # lower is better
+}
+
+_MEDALS = {1: "gold", 2: "silver", 3: "bronze"}
+
+
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+
+def compute_conviction(resp: StrategyResponse) -> tuple[float, LeaderboardScoreComponents]:
+    """Return (score 0–100, the four real components). Missing inputs score 0 and
+    lower ``data_completeness`` — so placeholders honestly sink, never inflate."""
+    placeholder = resp.is_backtest_placeholder
+
+    # gate is only meaningful when there's a real backtest behind it.
+    gate_real = not placeholder
+    gate = 1.0 if (resp.passes_rigor_gate and gate_real) else 0.0
+
+    dsr_real = resp.dsr_p_value is not None
+    dsr_confidence = _clamp01(resp.dsr_p_value) if dsr_real else 0.0
+
+    oos_real = resp.out_of_sample_sharpe is not None
+    oos_performance = _clamp01(resp.out_of_sample_sharpe / OOS_TARGET) if oos_real else 0.0
+
+    pbo_real = resp.pbo_score is not None
+    overfitting_resistance = _clamp01(1.0 - resp.pbo_score) if pbo_real else 0.0
+
+    real_count = sum((gate_real, dsr_real, oos_real, pbo_real))
+    components = LeaderboardScoreComponents(
+        gate=gate,
+        dsr_confidence=dsr_confidence,
+        oos_performance=oos_performance,
+        overfitting_resistance=overfitting_resistance,
+        data_completeness=real_count / 4.0,
+    )
+
+    score = 100.0 * (
+        WEIGHTS["gate"] * gate
+        + WEIGHTS["dsr_confidence"] * dsr_confidence
+        + WEIGHTS["oos_performance"] * oos_performance
+        + WEIGHTS["overfitting_resistance"] * overfitting_resistance
+    )
+    return round(score, 1), components
+
+
+def _entry(resp: StrategyResponse) -> LeaderboardEntry:
+    score, components = compute_conviction(resp)
+    name = resp.paper_title or (resp.methodology_summary or resp.id)[:80]
+    creator = resp.curator_wallet or "Archimedes"
+    return LeaderboardEntry(
+        rank=0,  # assigned after sort
+        medal=None,
+        id=resp.id,
+        name=name,
+        creator=creator,
+        conviction_score=score,
+        score_components=components,
+        sharpe_ratio=resp.sharpe_ratio,
+        cagr=resp.cagr,
+        sortino_ratio=resp.sortino_ratio,
+        max_drawdown=resp.max_drawdown,
+        calmar_ratio=resp.calmar_ratio,
+        deflated_sharpe_ratio=resp.deflated_sharpe_ratio,
+        dsr_p_value=resp.dsr_p_value,
+        pbo_score=resp.pbo_score,
+        out_of_sample_sharpe=resp.out_of_sample_sharpe,
+        passes_rigor_gate=resp.passes_rigor_gate,
+        is_backtest_placeholder=resp.is_backtest_placeholder,
+        forward=LeaderboardForwardAxis(),
+        regime_tag=resp.regime_tag,
+        return_source=resp.return_source,
+        status=resp.status,
+        papers=resp.papers,
+    )
+
+
+def _sort_key(entry: LeaderboardEntry, field: str):
+    """Raw value of the sort field for an entry (None if not evaluated).
+    None-handling (push to bottom regardless of order) is done by the caller."""
+    if field == "conviction_score":
+        return entry.conviction_score
+    attr, _ = _SORTABLE[field]
+    return getattr(entry, attr)
+
+
+def build_leaderboard(
+    responses: list[StrategyResponse],
+    *,
+    sort_by: str = "conviction_score",
+    order: str = "desc",
+    regime_tag: str | None = None,
+    min_rigor: bool = False,
+    limit: int = 50,
+) -> LeaderboardResponse:
+    """Rank strategies into a leaderboard. Pure — no I/O."""
+    if sort_by not in _SORTABLE:
+        sort_by = "conviction_score"
+    order = "asc" if order == "asc" else "desc"
+
+    entries = [_entry(r) for r in responses]
+
+    if regime_tag:
+        entries = [e for e in entries if e.regime_tag == regime_tag]
+    if min_rigor:
+        entries = [e for e in entries if e.passes_rigor_gate and not e.is_backtest_placeholder]
+
+    # Split present vs missing so None always lands at the bottom, whatever the
+    # order. Present values sort by the requested direction.
+    def value_of(e: LeaderboardEntry):
+        return _sort_key(e, sort_by)
+
+    present = [e for e in entries if value_of(e) is not None]
+    missing = [e for e in entries if value_of(e) is None]
+    present.sort(key=value_of, reverse=(order == "desc"))
+    ranked = present + missing
+
+    for i, e in enumerate(ranked, start=1):
+        e.rank = i
+        e.medal = _MEDALS.get(i)
+
+    total = len(ranked)
+    ranked = ranked[:limit]
+
+    engine = LeaderboardScoringEngine(
+        weights=WEIGHTS,
+        oos_target=OOS_TARGET,
+        methodology=(
+            "conviction_score = 100 × (0.35·gate + 0.25·DSR_confidence + "
+            "0.25·OOS_performance + 0.15·overfitting_resistance); every input is a "
+            "real passport field, clamped to [0,1]."
+        ),
+        stockbench_global=STOCKBENCH_GLOBAL,
+        disclaimer=_DISCLAIMER,
+    )
+    return LeaderboardResponse(
+        entries=ranked,
+        total=total,
+        sort_by=sort_by,
+        order=order,
+        scoring_engine=engine,
+    )

--- a/backend/tests/test_leaderboard.py
+++ b/backend/tests/test_leaderboard.py
@@ -85,6 +85,25 @@ def test_gate_not_counted_when_placeholder():
     assert score == 0.0
 
 
+def test_placeholder_with_borrowed_rigor_still_sinks():
+    # Regression: a placeholder that ALSO carries DSR/OOS/PBO values (e.g. seeded
+    # numbers on a placeholder record) must NOT ride them to a non-zero score and
+    # outrank a real-but-partially-missing strategy. Every component zeros.
+    ph = _strat("ph", passes_gate=True, dsr_p=0.99, oos=1.5, pbo=0.05, placeholder=True)
+    score, comp = compute_conviction(ph)
+    assert score == 0.0
+    assert comp.gate == 0.0
+    assert comp.dsr_confidence == 0.0
+    assert comp.oos_performance == 0.0
+    assert comp.overfitting_resistance == 0.0
+    assert comp.data_completeness == 0.0
+
+    # ... and it sorts strictly below a real strategy with only partial data.
+    real_partial = _strat("real", passes_gate=True, dsr_p=0.6)  # gate + dsr only
+    real_score, _ = compute_conviction(real_partial)
+    assert real_score > score
+
+
 def test_negative_oos_clamps_to_zero():
     s = _strat("N", passes_gate=True, oos=-0.5)
     _, comp = compute_conviction(s)

--- a/backend/tests/test_leaderboard.py
+++ b/backend/tests/test_leaderboard.py
@@ -1,0 +1,262 @@
+"""Hermetic tests for the leaderboard scoring engine (services/leaderboard.py).
+
+No DB, no network — build ``StrategyResponse`` objects directly and assert the
+ranking, the transparent score, None-handling, filters, and the honest
+forward-axis/pending behaviour. The leaderboard's #1 rule is "never fabricate a
+number", so the tests pin: placeholders sink (score 0), missing sort values land
+last, and the scoring-engine metadata is always intact.
+"""
+
+from __future__ import annotations
+
+from archimedes.api.schemas import StrategyResponse
+from archimedes.services.leaderboard import (
+    OOS_TARGET,
+    WEIGHTS,
+    build_leaderboard,
+    compute_conviction,
+)
+
+
+def _strat(
+    sid: str,
+    *,
+    passes_gate: bool = False,
+    dsr_p: float | None = None,
+    oos: float | None = None,
+    pbo: float | None = None,
+    sharpe: float | None = None,
+    placeholder: bool = False,
+    regime: str = "regime_neutral",
+    status: str = "validated",
+    title: str = "",
+    curator: str | None = None,
+) -> StrategyResponse:
+    return StrategyResponse(
+        id=sid,
+        methodology_summary=f"methodology for {sid}",
+        asset_universe=["SPY", "GLD"],
+        position_sizing="equal_weight",
+        rebalance_frequency="monthly",
+        status=status,
+        paper_title=title,
+        passes_rigor_gate=passes_gate,
+        dsr_p_value=dsr_p,
+        out_of_sample_sharpe=oos,
+        pbo_score=pbo,
+        sharpe_ratio=sharpe,
+        is_backtest_placeholder=placeholder,
+        regime_tag=regime,
+        curator_wallet=curator,
+    )
+
+
+# ── compute_conviction ────────────────────────────────────────────────────
+
+
+def test_weights_sum_to_one():
+    assert abs(sum(WEIGHTS.values()) - 1.0) < 1e-9
+
+
+def test_fully_validated_strategy_scores_high():
+    s = _strat("A", passes_gate=True, dsr_p=0.99, oos=1.2, pbo=0.1)
+    score, comp = compute_conviction(s)
+    # 100*(0.35*1 + 0.25*0.99 + 0.25*1.0(clamped) + 0.15*0.9) = 98.25
+    assert score == 98.2 or score == 98.3 or abs(score - 98.25) < 0.2
+    assert comp.gate == 1.0
+    assert comp.oos_performance == 1.0  # 1.2/1.0 clamps to 1.0
+    assert comp.overfitting_resistance == 0.9
+    assert comp.data_completeness == 1.0
+
+
+def test_placeholder_scores_zero_and_incomplete():
+    s = _strat("P", placeholder=True)  # all rigor None, gate not real
+    score, comp = compute_conviction(s)
+    assert score == 0.0
+    assert comp.data_completeness == 0.0
+    assert comp.gate == 0.0
+
+
+def test_gate_not_counted_when_placeholder():
+    # passes_rigor_gate True but placeholder → gate must NOT credit (no real backtest).
+    s = _strat("X", passes_gate=True, placeholder=True)
+    score, comp = compute_conviction(s)
+    assert comp.gate == 0.0
+    assert score == 0.0
+
+
+def test_negative_oos_clamps_to_zero():
+    s = _strat("N", passes_gate=True, oos=-0.5)
+    _, comp = compute_conviction(s)
+    assert comp.oos_performance == 0.0
+
+
+def test_oos_target_constant_is_one():
+    assert OOS_TARGET == 1.0
+
+
+# ── build_leaderboard: ranking + medals ───────────────────────────────────
+
+
+def test_ranks_by_conviction_desc_with_medals():
+    weak = _strat("weak", passes_gate=False, dsr_p=0.2, oos=0.1, pbo=0.8)
+    strong = _strat("strong", passes_gate=True, dsr_p=0.99, oos=1.5, pbo=0.05)
+    mid = _strat("mid", passes_gate=True, dsr_p=0.7, oos=0.6, pbo=0.4)
+    board = build_leaderboard([weak, strong, mid])
+    ids = [e.id for e in board.entries]
+    assert ids == ["strong", "mid", "weak"]
+    assert board.entries[0].rank == 1 and board.entries[0].medal == "gold"
+    assert board.entries[1].medal == "silver"
+    assert board.entries[2].medal == "bronze"
+
+
+def test_placeholders_sink_to_bottom():
+    real = _strat("real", passes_gate=True, dsr_p=0.9, oos=1.0, pbo=0.1)
+    ph = _strat("ph", placeholder=True)
+    board = build_leaderboard([ph, real])
+    assert board.entries[0].id == "real"
+    assert board.entries[-1].id == "ph"
+
+
+def test_missing_sort_value_pushed_to_bottom_regardless_of_order():
+    has = _strat("has", sharpe=1.5)
+    none1 = _strat("none1", sharpe=None)
+    # desc
+    board = build_leaderboard([none1, has], sort_by="sharpe_ratio", order="desc")
+    assert board.entries[0].id == "has"
+    assert board.entries[-1].id == "none1"
+    # asc — None still last, not first
+    board2 = build_leaderboard([none1, has], sort_by="sharpe_ratio", order="asc")
+    assert board2.entries[-1].id == "none1"
+
+
+def test_sort_by_pbo_respects_order():
+    low = _strat("low", passes_gate=True, pbo=0.1, dsr_p=0.9, oos=1.0)
+    high = _strat("high", passes_gate=True, pbo=0.6, dsr_p=0.9, oos=1.0)
+    board = build_leaderboard([high, low], sort_by="pbo_score", order="asc")
+    assert [e.id for e in board.entries] == ["low", "high"]
+
+
+# ── filters ───────────────────────────────────────────────────────────────
+
+
+def test_min_rigor_filters_out_failing_and_placeholders():
+    passing = _strat("pass", passes_gate=True, dsr_p=0.9, oos=1.0, pbo=0.1)
+    failing = _strat("fail", passes_gate=False, dsr_p=0.3)
+    ph = _strat("ph", passes_gate=True, placeholder=True)
+    board = build_leaderboard([passing, failing, ph], min_rigor=True)
+    assert [e.id for e in board.entries] == ["pass"]
+    assert board.total == 1
+
+
+def test_regime_filter():
+    bull = _strat("bull", regime="bull", passes_gate=True, dsr_p=0.9, oos=1.0, pbo=0.1)
+    bear = _strat("bear", regime="bear", passes_gate=True, dsr_p=0.9, oos=1.0, pbo=0.1)
+    board = build_leaderboard([bull, bear], regime_tag="bull")
+    assert [e.id for e in board.entries] == ["bull"]
+
+
+def test_limit_caps_entries_but_total_is_full_count():
+    strats = [_strat(f"s{i}", passes_gate=True, dsr_p=0.5 + i * 0.01, oos=0.5, pbo=0.3) for i in range(10)]
+    board = build_leaderboard(strats, limit=3)
+    assert len(board.entries) == 3
+    assert board.total == 10
+    # ranks are global (1,2,3), not re-based after the cap
+    assert [e.rank for e in board.entries] == [1, 2, 3]
+
+
+# ── honesty / metadata ────────────────────────────────────────────────────
+
+
+def test_forward_axis_is_honest_pending():
+    board = build_leaderboard([_strat("a", passes_gate=True, dsr_p=0.9, oos=1.0, pbo=0.1)])
+    fwd = board.entries[0].forward
+    assert fwd.stockbench_status == "pending"
+    assert fwd.stockbench_sortino is None
+    assert fwd.live_pnl_status == "pending"
+    assert fwd.live_pnl_pct is None
+
+
+def test_scoring_engine_metadata_intact_even_when_empty():
+    board = build_leaderboard([])
+    assert board.entries == []
+    assert board.total == 0
+    eng = board.scoring_engine
+    assert abs(sum(eng.weights.values()) - 1.0) < 1e-9
+    assert eng.validation_axis == "live"
+    assert eng.forward_axis == "pending"
+    assert eng.stockbench_global.rank == "15/15"
+    assert "fabricat" in eng.disclaimer.lower()  # the no-fabrication promise is loud
+
+
+def test_creator_defaults_to_archimedes_for_curated():
+    board = build_leaderboard([_strat("c", curator=None)])
+    assert board.entries[0].creator == "Archimedes"
+    board2 = build_leaderboard([_strat("c2", curator="0xabc")])
+    assert board2.entries[0].creator == "0xabc"
+
+
+def test_invalid_sort_by_falls_back_to_conviction():
+    a = _strat("a", passes_gate=True, dsr_p=0.99, oos=1.5, pbo=0.05)
+    b = _strat("b", passes_gate=False, dsr_p=0.1, oos=0.1, pbo=0.9)
+    board = build_leaderboard([b, a], sort_by="nonsense_field")
+    assert board.sort_by == "conviction_score"
+    assert board.entries[0].id == "a"
+
+
+def test_name_falls_back_to_methodology_when_no_paper_title():
+    board = build_leaderboard([_strat("nm", title="")])
+    assert board.entries[0].name.startswith("methodology for nm")
+
+
+# ── HTTP route (full app boot → route → service) ──────────────────────────
+# Mirrors test_risk_routes: import the app and exercise the real wiring. The
+# route is fail-safe, so it returns 200 with intact scoring-engine metadata even
+# if the strategy provider has no data.
+
+
+async def test_leaderboard_endpoint_returns_200_with_scoring_engine():
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/leaderboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "entries" in data and isinstance(data["entries"], list)
+    assert "scoring_engine" in data
+    eng = data["scoring_engine"]
+    assert abs(sum(eng["weights"].values()) - 1.0) < 1e-9
+    assert eng["stockbench_global"]["rank"] == "15/15"
+    assert "fabricat" in eng["disclaimer"].lower()
+    # Every entry (if any) must carry the honest forward axis.
+    for e in data["entries"]:
+        assert e["forward"]["stockbench_status"] == "pending"
+        assert e["forward"]["live_pnl_status"] == "pending"
+
+
+async def test_leaderboard_endpoint_respects_query_params():
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/leaderboard?sort_by=sharpe_ratio&order=asc&min_rigor=true&limit=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sort_by"] == "sharpe_ratio"
+    assert data["order"] == "asc"
+    assert len(data["entries"]) <= 5
+    # min_rigor → every returned entry passes the gate and is not a placeholder.
+    for e in data["entries"]:
+        assert e["passes_rigor_gate"] is True
+        assert e["is_backtest_placeholder"] is False
+
+
+async def test_leaderboard_rejects_bad_sort_param():
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/leaderboard?sort_by=DROP_TABLE")
+    # Query pattern guard → 422, never a 500.
+    assert resp.status_code == 422

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -7,6 +7,7 @@ import Generate from './components/Generate'
 import Portfolio from './components/Portfolio'
 import Learnings from './components/Learnings'
 import Insights from './components/Insights'
+import Leaderboard from './components/Leaderboard'
 import Strategies from './components/Strategies'   // serves /library route ("Example Library")
 import StrategyPassport from './components/StrategyPassport'
 import CorpusExplorer from './components/CorpusExplorer'
@@ -30,6 +31,7 @@ const openConnectModal = () => window.dispatchEvent(new Event('open-wallet-modal
 const PAGE_TO_PATH = {
   landing:   '/',
   explore:   '/explore',
+  leaderboard: '/leaderboard',
   generate:  '/generate',
   architecture: '/architecture',
   library:   '/library',
@@ -188,6 +190,7 @@ export default function App() {
     const titles = {
       landing:        'Archimedes',
       explore:        'Explore · Archimedes',
+      leaderboard:    'Leaderboard · Archimedes',
       generate:       'Generate · Archimedes',
       architecture:   'Architecture · Archimedes',
       library:        'Library · Archimedes',
@@ -222,6 +225,7 @@ export default function App() {
     switch (page) {
       case 'landing':     return <Landing onNavigate={navigateToPage} />
       case 'explore':      return <Explore />
+      case 'leaderboard':  return <Leaderboard />
       case 'generate':     return (
         <WalletGate
           walletAddr={walletAddr}

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -21,6 +21,7 @@ const NAV = [
   ]},
   { group: 'Discover', items: [
     { id: 'explore',      label: 'Explore',      icon: 'i-lucide-compass' },
+    { id: 'leaderboard',  label: 'Leaderboard',  icon: 'i-lucide-trophy' },
     { id: 'corpus',       label: 'Corpus',       icon: 'i-lucide-library' },
     { id: 'architecture', label: 'Architecture', icon: 'i-lucide-network' },
   ]},
@@ -42,6 +43,7 @@ const NAV = [
 export const PAGE_LABELS = {
   landing: 'Home',
   explore: 'Explore',
+  leaderboard: 'Leaderboard',
   generate: 'Generate',
   architecture: 'Architecture',
   library: 'Library',

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -1,0 +1,210 @@
+import { useState, useEffect, useCallback } from 'react'
+import { apiGet } from '../api'
+
+// The public, gamified strategy leaderboard (North Star §5 — the testnet
+// engagement engine). Ranks the library by the backend's transparent conviction
+// score (real rigor gate + backtest), and pairs an honest, pending StockBench /
+// live-P&L "forward axis". Nothing here is fabricated: validation metrics are
+// real passport fields; the forward axis renders as "pending" until that data
+// flows. Public — no wallet required.
+
+const SORT_OPTIONS = [
+  { id: 'conviction_score', label: 'Conviction' },
+  { id: 'deflated_sharpe_ratio', label: 'Deflated Sharpe' },
+  { id: 'dsr_p_value', label: 'DSR confidence' },
+  { id: 'sharpe_ratio', label: 'Sharpe' },
+  { id: 'cagr', label: 'CAGR' },
+  { id: 'pbo_score', label: 'Overfitting (PBO)' },
+]
+
+const REGIMES = [
+  { id: '', label: 'All regimes' },
+  { id: 'bull', label: 'Bull' },
+  { id: 'bear', label: 'Bear' },
+  { id: 'regime_neutral', label: 'Neutral' },
+]
+
+const MEDAL = { gold: '🥇', silver: '🥈', bronze: '🥉' }
+
+function fmt(v, d = 2) {
+  return v != null ? Number(v).toFixed(d) : '—'
+}
+function fmtPct(v, d = 1) {
+  return v != null ? `${(v * 100).toFixed(d)}%` : '—'
+}
+
+function rigorBadge(entry) {
+  if (entry.is_backtest_placeholder) {
+    return <span className="tag-muted" title="No real backtest yet">No backtest</span>
+  }
+  if (entry.passes_rigor_gate) {
+    return <span className="tag-positive" title="Passes the selection-bias rigor gate (DSR / PBO / OOS)">✓ Rigor gate</span>
+  }
+  return <span className="tag-warning" title="Did not pass the rigor gate — surfaced honestly">Gate failed</span>
+}
+
+// Compact stacked bar of the four real score components, each scaled by its weight.
+function ScoreBar({ components, weights }) {
+  if (!components || !weights) return null
+  const parts = [
+    { key: 'gate', color: '#e0a64f', label: 'Rigor gate' },
+    { key: 'dsr_confidence', color: '#4f9be0', label: 'DSR confidence' },
+    { key: 'oos_performance', color: '#5fc08a', label: 'Out-of-sample' },
+    { key: 'overfitting_resistance', color: '#b07fd0', label: 'Overfit-resistant' },
+  ]
+  return (
+    <div style={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden', background: '#1c1c20', width: 120 }}>
+      {parts.map(p => {
+        const w = (weights[p.key] ?? 0) * (components[p.key] ?? 0) * 100
+        return <div key={p.key} title={`${p.label}: ${((components[p.key] ?? 0) * 100).toFixed(0)}% × weight ${weights[p.key]}`} style={{ width: `${w}%`, background: p.color }} />
+      })}
+    </div>
+  )
+}
+
+export default function Leaderboard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [sortBy, setSortBy] = useState('conviction_score')
+  const [order, setOrder] = useState('desc')
+  const [minRigor, setMinRigor] = useState(false)
+  const [regime, setRegime] = useState('')
+
+  const load = useCallback(() => {
+    setLoading(true)
+    const params = new URLSearchParams({ sort_by: sortBy, order, limit: '100' })
+    if (minRigor) params.set('min_rigor', 'true')
+    if (regime) params.set('regime_tag', regime)
+    apiGet(`/api/leaderboard?${params.toString()}`)
+      .then(d => { setData(d); setError(null) })
+      .catch(e => setError(e.message || 'Failed to load leaderboard'))
+      .finally(() => setLoading(false))
+  }, [sortBy, order, minRigor, regime])
+
+  useEffect(() => { load() }, [load])
+
+  const engine = data?.scoring_engine
+  const sb = engine?.stockbench_global
+
+  return (
+    <div className="leaderboard-page" style={{ maxWidth: 1100 }}>
+      <div style={{ marginBottom: 18 }}>
+        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 8 }}>Strategy Leaderboard</h2>
+        <p className="body" style={{ maxWidth: 760 }}>
+          Every library strategy, ranked by a transparent <strong>conviction score</strong> built from
+          real rigor-gate and backtest results — the ugly numbers included. Build your track record now;
+          it carries to mainnet.
+        </p>
+        {engine?.disclaimer && (
+          <div style={{ marginTop: 10, padding: '8px 12px', borderLeft: '3px solid #e0a64f', background: 'rgba(224,166,79,0.08)', borderRadius: 4, fontSize: 13, color: '#cfcfcf' }}>
+            <strong style={{ color: '#e0a64f' }}>Testnet — paper/simulated.</strong> {engine.disclaimer}
+          </div>
+        )}
+      </div>
+
+      {/* Scoring engine: weights + methodology + the one real StockBench datum, as honest context */}
+      {engine && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginBottom: 18, padding: 14, background: '#141417', borderRadius: 8, border: '1px solid #26262b' }}>
+          <div style={{ flex: '1 1 320px' }}>
+            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: '#8a8a92', marginBottom: 6 }}>Scoring engine · validation axis (live)</div>
+            <div style={{ fontSize: 13, color: '#cfcfcf' }}>{engine.methodology}</div>
+          </div>
+          <div style={{ flex: '1 1 260px' }}>
+            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: '#8a8a92', marginBottom: 6 }}>Forward axis (pending)</div>
+            <div style={{ fontSize: 13, color: '#cfcfcf' }}>
+              Per-strategy <strong>StockBench</strong> + <strong>live paper-P&L</strong> pair into this engine next.
+              StockBench today is a single whole-pipeline run (honest, not per-strategy):{' '}
+              {sb && <span title={`${sb.window} · ${sb.source}`}>Sortino {fmt(sb.sortino)}, return {sb.return_pct}%, rank {sb.rank}</span>}.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Controls */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center', marginBottom: 14 }}>
+        <span style={{ fontSize: 12, color: '#8a8a92' }}>Sort</span>
+        {SORT_OPTIONS.map(o => (
+          <button key={o.id} type="button" onClick={() => setSortBy(o.id)}
+            className={sortBy === o.id ? 'tag-accent' : 'tag-muted'}
+            style={{ cursor: 'pointer', border: 'none', padding: '4px 10px', borderRadius: 14, fontSize: 12 }}>
+            {o.label}
+          </button>
+        ))}
+        <button type="button" onClick={() => setOrder(o => o === 'desc' ? 'asc' : 'desc')}
+          className="tag-muted" style={{ cursor: 'pointer', border: 'none', padding: '4px 10px', borderRadius: 14, fontSize: 12 }}
+          title="Toggle sort direction">
+          {order === 'desc' ? '↓ desc' : '↑ asc'}
+        </button>
+        <span style={{ width: 1, height: 18, background: '#2a2a30', margin: '0 4px' }} />
+        <label style={{ fontSize: 12, color: '#cfcfcf', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}>
+          <input type="checkbox" checked={minRigor} onChange={e => setMinRigor(e.target.checked)} /> Rigor-gated only
+        </label>
+        <select value={regime} onChange={e => setRegime(e.target.value)}
+          style={{ background: '#1c1c20', color: '#cfcfcf', border: '1px solid #2a2a30', borderRadius: 6, padding: '4px 8px', fontSize: 12 }}>
+          {REGIMES.map(r => <option key={r.id} value={r.id}>{r.label}</option>)}
+        </select>
+        {data && <span style={{ fontSize: 12, color: '#8a8a92', marginLeft: 'auto' }}>{data.total} strateg{data.total === 1 ? 'y' : 'ies'}</span>}
+      </div>
+
+      {loading && <div className="body" style={{ color: '#8a8a92' }}>Loading the board…</div>}
+      {error && <div className="tag-warning" style={{ display: 'inline-block', padding: '6px 10px' }}>Couldn’t load the leaderboard: {error}</div>}
+
+      {!loading && !error && data && data.entries.length === 0 && (
+        <div className="body" style={{ color: '#8a8a92', padding: 20, textAlign: 'center', border: '1px dashed #2a2a30', borderRadius: 8 }}>
+          No strategies match these filters yet.
+        </div>
+      )}
+
+      {!loading && !error && data && data.entries.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{ textAlign: 'left', color: '#8a8a92', fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                <th style={{ padding: '8px 10px' }}>#</th>
+                <th style={{ padding: '8px 10px' }}>Strategy</th>
+                <th style={{ padding: '8px 10px' }}>Conviction</th>
+                <th style={{ padding: '8px 10px' }}>Sharpe</th>
+                <th style={{ padding: '8px 10px' }}>CAGR</th>
+                <th style={{ padding: '8px 10px' }}>Max DD</th>
+                <th style={{ padding: '8px 10px' }}>Rigor</th>
+                <th style={{ padding: '8px 10px' }}>Forward</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.entries.map(e => (
+                <tr key={e.id} style={{ borderTop: '1px solid #1f1f24' }}>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap', fontWeight: 600 }}>
+                    {e.medal ? <span style={{ marginRight: 4 }}>{MEDAL[e.medal]}</span> : null}{e.rank}
+                  </td>
+                  <td style={{ padding: '10px', maxWidth: 280 }}>
+                    <div style={{ color: '#f0f0f0', fontWeight: 500 }}>{e.name}</div>
+                    <div style={{ fontSize: 11, color: '#8a8a92' }}>
+                      {e.creator === 'Archimedes' ? 'Archimedes (curated)' : `by ${e.creator.slice(0, 6)}…${e.creator.slice(-4)}`}
+                      {e.regime_tag && e.regime_tag !== 'regime_neutral' ? ` · ${e.regime_tag}` : ''}
+                    </div>
+                  </td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    <div style={{ fontWeight: 600, color: '#e0a64f' }}>{fmt(e.conviction_score, 1)}</div>
+                    <ScoreBar components={e.score_components} weights={engine?.weights} />
+                  </td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmt(e.sharpe_ratio)}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmtPct(e.cagr)}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap', color: '#d08a8a' }}>{fmtPct(e.max_drawdown)}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    {rigorBadge(e)}
+                    {e.dsr_p_value != null && <div style={{ fontSize: 11, color: '#8a8a92', marginTop: 2 }}>DSR p={fmt(e.dsr_p_value)}{e.pbo_score != null ? ` · PBO ${fmt(e.pbo_score)}` : ''}</div>}
+                  </td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    <span className="tag-muted" title="Per-strategy StockBench eval is pending">SB pending</span>{' '}
+                    <span className="tag-muted" title="Live paper-P&L tracking is pending (testnet — paper)">P&L pending</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -193,7 +193,7 @@ export default function Leaderboard() {
                   <td style={{ padding: '10px', whiteSpace: 'nowrap', color: '#d08a8a' }}>{fmtPct(e.max_drawdown)}</td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     {rigorBadge(e)}
-                    {e.dsr_p_value != null && <div style={{ fontSize: 11, color: '#8a8a92', marginTop: 2 }}>DSR p={fmt(e.dsr_p_value)}{e.pbo_score != null ? ` · PBO ${fmt(e.pbo_score)}` : ''}</div>}
+                    {e.dsr_p_value != null && <div style={{ fontSize: 11, color: '#8a8a92', marginTop: 2 }} title="DSR confidence (0–1, higher is better): probability the Sharpe survives deflation/multiple-testing. Not a classical p-value.">DSR conf={fmt(e.dsr_p_value)}{e.pbo_score != null ? ` · PBO ${fmt(e.pbo_score)}` : ''}</div>}
                   </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     <span className="tag-muted" title="Per-strategy StockBench eval is pending">SB pending</span>{' '}


### PR DESCRIPTION
## The testnet engagement engine (North Star §5)

A **public, gamified strategy leaderboard** — the near-term traction priority. It
ranks every library strategy by a **transparent conviction score** built from
*real* passport data, with loud testnet/paper framing. Build your track record
now; it carries to mainnet.

**Public** (no wallet) — lives under the **Discover** nav.

## The scoring engine is honest by construction

The #1 rule is *claims must be true*. A prior marketplace surface was removed for
"hardcoded fees + invented math" (#381) — this does the opposite:

- **conviction_score (0–100)** = `100 × (0.35·gate + 0.25·DSR_confidence +
  0.25·OOS_performance + 0.15·overfitting_resistance)`. Every input is a **real**
  passport field (`passes_rigor_gate`, `dsr_p_value`, `out_of_sample_sharpe`,
  `pbo_score`), clamped to [0,1]. The **weights are explicit and echoed in the
  response**, and the per-entry component breakdown renders as a stacked bar — the
  score is never a black box.
- **Placeholders score 0 and sink**; a strategy with no real backtest can never
  inflate the board. Missing sort values always land last, regardless of order.

## Two axes, honestly separated

- **Validation axis — LIVE NOW**: rigor gate + backtest (Sharpe, CAGR, Max DD,
  DSR, PBO, OOS). Real numbers, the ugly ones included.
- **Forward axis — PENDING**: per-strategy **StockBench** + **live paper-P&L**.
  These aren't tracked per-strategy yet, so they render as honest `pending` pills —
  *surfaced, not hidden*, so the engine visibly **pairs** them with validation (per
  the North Star) without inventing values. The one real StockBench datum we have
  (the whole-pipeline run — Sortino −0.91, rank 15/15) is shown as **global
  context**, explicitly not per-strategy.

This is exactly the "pair live P&L + StockBench, make them visible in the scoring
engine" call — delivered without fabricating a single number.

## What's in it

**Backend** — `services/leaderboard.py` (pure scoring), `api/leaderboard_schemas.py`,
`api/leaderboard_routes.py` (`GET /api/leaderboard` — `sort_by` / `order` /
`min_rigor` / `regime_tag` / `limit`; fail-safe → empty board on provider failure),
registered in `main.py`. **21 hermetic tests** (18 service + 3 HTTP via
`ASGITransport`): ranking, medals, None-handling, filters, the no-fabrication
promise, query-guard `422`.

**Frontend** — `Leaderboard.jsx`: medals, the stacked conviction-score bar (its
four real components), rigor badges, sort/filter controls, the scoring-engine
explainer, and the loud "Testnet — paper/simulated" disclaimer. Wired into
`App.jsx` + `Layout.jsx`.

## Deferred (the forward axis activates when these land)

- A **per-strategy StockBench harness** (today StockBench is a single
  whole-pipeline run) and **live paper-P&L tracking** — both feed the forward axis.
- Extending the board from the curated library to **generated passports** is a
  fast-follow once their backtest completeness is confirmed.

## Validation

- 21/21 backend tests pass under the hermetic gate · ruff format + critical lint clean
- ESLint clean · `vite build` green

## Review

Non-contract change → one review. Auto-deploys on merge (no users yet → fine; the
testnet/paper framing keeps every claim true on the live path). Happy to spin up a
local preview or attach a screenshot of the board if useful before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
