### PR TITLE
[contracts] Stork AggregatorV3 adapter — real decentralized Arc oracle feed (#794)

### DIFF
--- a/contracts/abis/StorkAggregatorV3Adapter.json
+++ b/contracts/abis/StorkAggregatorV3Adapter.json
@@ -1,0 +1,113 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_stork",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_priceId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "STORK_DECIMALS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "latestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "priceId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stork",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IStorkTemporalNumericValueUnsafeGetter"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "ZeroPriceId",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroStork",
+    "inputs": []
+  }
+]

--- a/contracts/script/DeployStorkAdapter.s.sol
+++ b/contracts/script/DeployStorkAdapter.s.sol
@@ -35,6 +35,8 @@ contract DeployStorkAdapter is Script {
         console.log("Stork contract:", storkContract);
         console.logBytes32(priceId);
         console.log("Adapter:", address(adapter));
-        console.log("Next: PriceOracle(asset).setPriceFeed(", address(adapter), ") as owner");
+        // The adapter address is logged above; forge-std has no console.log(string,address,string)
+        // overload, so keep this a plain-string hint rather than interpolating the address inline.
+        console.log("Next: call PriceOracle(asset).setPriceFeed(adapter) as owner");
     }
 }

--- a/contracts/script/DeployStorkAdapter.s.sol
+++ b/contracts/script/DeployStorkAdapter.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/StorkAggregatorV3Adapter.sol";
+
+/// @notice Deploy one StorkAggregatorV3Adapter, binding a Stork feed id to the
+///         AggregatorV3 interface PriceOracle (#724) consumes. One adapter per asset.
+///
+///         Env:
+///           STORK_CONTRACT  — Stork on-chain contract (Arc testnet default below)
+///           STORK_PRICE_ID  — the bytes32 Stork feed id for this asset
+///
+///         Usage:
+///           STORK_CONTRACT=0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62 \
+///           STORK_PRICE_ID=0x<feedId> \
+///           forge script contracts/script/DeployStorkAdapter.s.sol \
+///             --rpc-url https://rpc.testnet.arc.network --broadcast
+///
+///         After deploy: PriceOracle(asset).setPriceFeed(adapter) — owner-only (Dan).
+///         The #724 oracle keeps the admin-fed value as the degrade target behind it.
+contract DeployStorkAdapter is Script {
+    /// @dev Stork's verified Arc-testnet deployment (#794).
+    address constant ARC_STORK_DEFAULT = 0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62;
+
+    function run() external {
+        address storkContract = vm.envOr("STORK_CONTRACT", ARC_STORK_DEFAULT);
+        bytes32 priceId = vm.envBytes32("STORK_PRICE_ID");
+
+        vm.startBroadcast();
+        StorkAggregatorV3Adapter adapter = new StorkAggregatorV3Adapter(storkContract, priceId);
+        vm.stopBroadcast();
+
+        console.log("=== Stork AggregatorV3 adapter deployed ===");
+        console.log("Stork contract:", storkContract);
+        console.logBytes32(priceId);
+        console.log("Adapter:", address(adapter));
+        console.log("Next: PriceOracle(asset).setPriceFeed(", address(adapter), ") as owner");
+    }
+}

--- a/contracts/src/StorkAggregatorV3Adapter.sol
+++ b/contracts/src/StorkAggregatorV3Adapter.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Minimal read interface for the Stork on-chain price contract (live on Arc
+///         testnet at 0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62, verified #794). Stork
+///         stores a per-asset temporal numeric value keyed by a bytes32 feed id; the
+///         "Unsafe" getter returns the stored value WITHOUT reverting on staleness —
+///         staleness is enforced downstream by the consuming PriceOracle, which degrades
+///         to the admin-fed price on a stale/invalid feed (#724 design).
+interface IStorkTemporalNumericValueUnsafeGetter {
+    struct TemporalNumericValue {
+        uint64 timestampNs; // observation time, NANOSECONDS
+        int192 quantizedValue; // value scaled to 18 decimals (Stork convention)
+    }
+
+    function getTemporalNumericValueUnsafeV1(bytes32 id) external view returns (TemporalNumericValue memory value);
+}
+
+/// @notice Chainlink AggregatorV3 signature — function selectors are byte-identical to the
+///         `AggregatorV3Interface` PriceOracle.sol declares locally, so this adapter is a
+///         drop-in `setPriceFeed` target. Named `IAggregatorV3` (not `AggregatorV3Interface`)
+///         only to avoid an identifier clash when a consumer imports both files.
+/// @dev    ⚠️ DUPLICATE (tracked): this restates PriceOracle.sol's local `AggregatorV3Interface`.
+///         The clean fix is one shared `src/interfaces/IAggregatorV3.sol` imported by BOTH —
+///         deferred to the #588 redeploy because it edits the deployed PriceOracle.sol
+///         (bytecode-neutral, but contract-review-grade). See the consolidation follow-up issue.
+interface IAggregatorV3 {
+    function decimals() external view returns (uint8);
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+/// @title StorkAggregatorV3Adapter
+/// @notice Adapts ONE Stork price feed to Chainlink's AggregatorV3Interface so the existing
+///         #724 PriceOracle (Chainlink-first, degrade-to-admin) can consume Stork on Arc —
+///         where Chainlink has no Data Feeds (#794). One adapter instance per asset (one
+///         Stork feed id), pointed at by `PriceOracle.setPriceFeed(adapter)`.
+/// @dev    Thin, view-only, holds no funds. Stork quantizes to 18 decimals; the adapter
+///         reports `decimals() = 18` and PriceOracle rescales to its 6-decimal convention.
+///         The adapter does NOT enforce staleness itself (it uses the Unsafe getter) —
+///         PriceOracle owns staleness / round-completeness / sanity-band validation and
+///         degrades to the admin price on ANY feed failure, so a frozen or garbled Stork
+///         feed can never brick a vault read. It is a real decentralized primary sitting in
+///         front of the admin safety net, not a replacement for it.
+///
+///         ⚠️ Funds-adjacent (feeds vault collateral math via PriceOracle). Contract work →
+///         Dan owns + deploys; Bogdan reviews (#794).
+contract StorkAggregatorV3Adapter is IAggregatorV3 {
+    /// @notice The Stork on-chain contract this adapter reads from.
+    IStorkTemporalNumericValueUnsafeGetter public immutable stork;
+
+    /// @notice The Stork feed id (asset) this adapter exposes.
+    bytes32 public immutable priceId;
+
+    /// @notice Stork quantizes values to 18 decimals; PriceOracle rescales to 6.
+    uint8 public constant STORK_DECIMALS = 18;
+
+    error ZeroStork();
+    error ZeroPriceId();
+
+    constructor(address _stork, bytes32 _priceId) {
+        if (_stork == address(0)) revert ZeroStork();
+        if (_priceId == bytes32(0)) revert ZeroPriceId();
+        stork = IStorkTemporalNumericValueUnsafeGetter(_stork);
+        priceId = _priceId;
+    }
+
+    /// @inheritdoc IAggregatorV3
+    function decimals() external pure returns (uint8) {
+        return STORK_DECIMALS;
+    }
+
+    /// @inheritdoc IAggregatorV3
+    /// @dev Maps Stork's (timestampNs, quantizedValue) → Chainlink round data:
+    ///        answer              = quantizedValue (18-dec; PriceOracle rescales to 6)
+    ///        updatedAt/startedAt = timestampNs / 1e9 (ns → s; PriceOracle's staleness key)
+    ///        roundId = answeredInRound = the second-resolution timestamp. Stork has no round
+    ///          concept, so a monotonic-by-time id keeps PriceOracle's carry-over guard
+    ///          (`answeredInRound >= roundId`) satisfied while advancing on each update.
+    ///      An uninitialized feed (timestampNs == 0) yields updatedAt == 0, which PriceOracle
+    ///      reads as an incomplete round and degrades to admin — the intended fail-soft.
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        IStorkTemporalNumericValueUnsafeGetter.TemporalNumericValue memory v =
+            stork.getTemporalNumericValueUnsafeV1(priceId);
+        uint256 tsSeconds = uint256(v.timestampNs) / 1e9;
+        answer = int256(v.quantizedValue);
+        startedAt = tsSeconds;
+        updatedAt = tsSeconds;
+        roundId = uint80(tsSeconds);
+        answeredInRound = uint80(tsSeconds);
+    }
+}

--- a/contracts/test/StorkAggregatorV3Adapter.t.sol
+++ b/contracts/test/StorkAggregatorV3Adapter.t.sol
@@ -28,7 +28,6 @@ contract StorkAggregatorV3AdapterTest is Test {
     uint256 constant EXPECTED_6DEC = 392_600_000;
 
     address constant OWNER = address(0x1);
-    address constant ALICE = address(0x2);
 
     function setUp() public {
         vm.warp(1_000_000);

--- a/contracts/test/StorkAggregatorV3Adapter.t.sol
+++ b/contracts/test/StorkAggregatorV3Adapter.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/StorkAggregatorV3Adapter.sol";
+import "../src/PriceOracle.sol";
+
+/// @dev Minimal mock of the Stork on-chain getter — settable per-id value + timestamp.
+contract MockStork is IStorkTemporalNumericValueUnsafeGetter {
+    mapping(bytes32 => TemporalNumericValue) internal _values;
+
+    function set(bytes32 id, uint64 timestampNs, int192 quantizedValue) external {
+        _values[id] = TemporalNumericValue(timestampNs, quantizedValue);
+    }
+
+    function getTemporalNumericValueUnsafeV1(bytes32 id) external view returns (TemporalNumericValue memory) {
+        return _values[id];
+    }
+}
+
+contract StorkAggregatorV3AdapterTest is Test {
+    MockStork internal stork;
+    StorkAggregatorV3Adapter internal adapter;
+
+    bytes32 constant FEED_ID = keccak256("SPY/USD");
+    // $392.60 at Stork's 18-decimal quantization (3.926e20) and PriceOracle's 6 (392_600_000).
+    int192 constant STORK_392_60 = 392_600_000_000_000_000_000;
+    uint256 constant EXPECTED_6DEC = 392_600_000;
+
+    address constant OWNER = address(0x1);
+    address constant ALICE = address(0x2);
+
+    function setUp() public {
+        vm.warp(1_000_000);
+        stork = new MockStork();
+        adapter = new StorkAggregatorV3Adapter(address(stork), FEED_ID);
+    }
+
+    function _setFresh(int192 value) internal {
+        stork.set(FEED_ID, uint64(block.timestamp * 1e9), value);
+    }
+
+    // ── Adapter unit ──────────────────────────────────────────────
+
+    function test_decimals_is_18() public view {
+        assertEq(adapter.decimals(), 18);
+    }
+
+    function test_immutables() public view {
+        assertEq(address(adapter.stork()), address(stork));
+        assertEq(adapter.priceId(), FEED_ID);
+    }
+
+    function test_constructor_reverts_on_zero_stork() public {
+        vm.expectRevert(StorkAggregatorV3Adapter.ZeroStork.selector);
+        new StorkAggregatorV3Adapter(address(0), FEED_ID);
+    }
+
+    function test_constructor_reverts_on_zero_id() public {
+        vm.expectRevert(StorkAggregatorV3Adapter.ZeroPriceId.selector);
+        new StorkAggregatorV3Adapter(address(stork), bytes32(0));
+    }
+
+    function test_latestRoundData_maps_stork_value() public {
+        uint64 tsNs = uint64(block.timestamp * 1e9);
+        stork.set(FEED_ID, tsNs, STORK_392_60);
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            adapter.latestRoundData();
+        assertEq(answer, int256(STORK_392_60));
+        assertEq(updatedAt, block.timestamp); // ns / 1e9
+        assertEq(startedAt, block.timestamp);
+        assertEq(roundId, uint80(block.timestamp));
+        assertEq(answeredInRound, roundId); // carry-over guard always satisfied
+    }
+
+    function test_latestRoundData_uninitialized_feed_is_incomplete_round() public view {
+        // No value set → timestampNs 0 → updatedAt 0 (PriceOracle reads as incomplete round).
+        (, int256 answer,, uint256 updatedAt,) = adapter.latestRoundData();
+        assertEq(answer, 0);
+        assertEq(updatedAt, 0);
+    }
+
+    // ── Integration with PriceOracle (#724 read path) ─────────────
+
+    function _oracle(uint256 adminPrice) internal returns (PriceOracle o) {
+        vm.prank(OWNER);
+        o = new PriceOracle("SPY", adminPrice, OWNER);
+        vm.prank(OWNER);
+        o.setPriceFeed(address(adapter));
+    }
+
+    function test_setPriceFeed_caches_18_decimals() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        assertEq(o.feedDecimals(), 18);
+        assertEq(address(o.priceFeed()), address(adapter));
+    }
+
+    function test_oracle_reads_stork_via_adapter_scaled_to_6dec() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(STORK_392_60);
+        // 18-dec Stork $392.60 → 6-dec 392_600_000 through the adapter + PriceOracle.
+        assertEq(o.getPrice(), EXPECTED_6DEC);
+        assertTrue(o.isFresh());
+    }
+
+    function test_oracle_feed_precedence_in_band() public {
+        // Admin $392.60; Stork reads $450 (in the 50% band) → feed wins.
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(450_000_000_000_000_000_000); // $450 @ 18 dec
+        assertEq(o.getPrice(), 450_000_000);
+    }
+
+    function test_oracle_degrades_to_admin_on_stale_stork() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        // Stork value observed now, then time advances past the feed heartbeat while the
+        // admin reference stays fresh → PriceOracle degrades to admin (fail-soft).
+        _setFresh(450_000_000_000_000_000_000);
+        vm.warp(block.timestamp + o.feedStaleness() + 1);
+        assertEq(o.getPrice(), EXPECTED_6DEC); // admin, not the stale feed
+        assertTrue(o.isFresh());
+    }
+
+    function test_oracle_degrades_to_admin_on_negative_stork() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(-1);
+        assertEq(o.getPrice(), EXPECTED_6DEC);
+    }
+
+    function test_oracle_out_of_band_stork_degrades_to_admin() public {
+        // Stork $5000 vs admin $392.60 — way outside the 50% band → degrade to admin.
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(5_000_000_000_000_000_000_000); // $5000 @ 18 dec
+        assertEq(o.getPrice(), EXPECTED_6DEC);
+    }
+}


### PR DESCRIPTION
## What + why

#794 verified **Chainlink has no Data Feeds on Arc testnet**, so PriceOracle's Chainlink-first branch (#724) had nothing to point at. **Stork IS live on Arc** (`0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62`, cast-verified). This adds the thin `AggregatorV3` adapter #794 called for, so `PriceOracle.setPriceFeed(adapter)` can consume a **real decentralized on-chain feed** — sitting in front of the admin-fed safety net, not replacing it.

## Design (thin translator; PriceOracle owns all safety)

`StorkAggregatorV3Adapter` maps Stork's `getTemporalNumericValueUnsafeV1(bytes32 id) → (uint64 timestampNs, int192 quantizedValue)` onto Chainlink `latestRoundData()`:
- `answer` = quantizedValue (Stork's 18-dec); `decimals() = 18` → **PriceOracle rescales to its 6-dec convention**.
- `updatedAt`/`startedAt` = `timestampNs / 1e9` (PriceOracle's staleness key); `roundId = answeredInRound` = the second-resolution timestamp (monotonic, satisfies the carry-over guard).
- Uses the **Unsafe** getter on purpose: the adapter **never enforces staleness** — PriceOracle owns staleness / round-completeness / sanity-band validation and **degrades to admin on any feed failure**, so a frozen or garbled Stork feed can never brick a vault read. View-only, holds no funds.

## Validation

**12 Foundry tests** — adapter mapping (incl. uninitialized-feed → incomplete-round) + **full PriceOracle integration**: reads via adapter 18→6 scaled, feed precedence in-band, and **degrade-to-admin on stale / negative / out-of-band**. Deploy script (one adapter per Stork feed id, Arc Stork addr defaulted) + cached ABI. **Zero change to `PriceOracle.sol` or any deployed contract** (#794 anti-goal honored).

## Two things flagged (your "no duplicate / no dead code" review)

- **Known duplicate, tracked → #827.** The adapter restates PriceOracle's local `AggregatorV3Interface` (renamed `IAggregatorV3` only to dodge a compile clash). The clean fix is one shared `src/interfaces/IAggregatorV3.sol` imported by both — **bytecode-neutral** but edits the *deployed* PriceOracle.sol, so it's bundled with the **#588 redeploy** (issue #827).
- **Dropped dead code.** Removed the adapter's `description()`/`version()` — no consumer reads them (`priceId()` already exposes asset identity).

## Review

⚠️ **Funds-adjacent contract → Dan owns + deploys; Bogdan reviews.** NOT deployed/wired. Independent of #826 (no code dependency — that's the off-chain Pyth path; this is the on-chain feed).

Refs #794, #724. Follow-up #827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)