### PR TITLE
[backend] Enforce the rigor gate server-side on vault creation (#818)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1210,14 +1210,17 @@ async def run_generation(
             candidates.append(cand)
 
         if not candidates:
-            # Honest message (#818): this branch fires only when ZERO candidates were
-            # generated — distinct from "candidates exist but none passed rigor", which
-            # is surfaced below via best_selected's deployable=False signal.
+            # Honest code + message (#818): this branch fires only when ZERO candidates
+            # were generated (an upstream generation failure) — distinct from "candidates
+            # exist but none passed rigor", which is NOT an error but is surfaced below via
+            # best_selected's deployable=False (ABSTAIN) signal. Using RIGOR_FAIL here would
+            # mislead clients/telemetry into reading a generation failure as a rigor-gate
+            # failure, so this carries its own NO_CANDIDATES code.
             await emit.emit(
                 "error",
                 message="no candidates generated",
                 recoverable=True,
-                code="RIGOR_FAIL",
+                code="NO_CANDIDATES",
             )
             await store.update_status(job_id, "error", error="no candidates generated")
             return

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1210,13 +1210,16 @@ async def run_generation(
             candidates.append(cand)
 
         if not candidates:
+            # Honest message (#818): this branch fires only when ZERO candidates were
+            # generated — distinct from "candidates exist but none passed rigor", which
+            # is surfaced below via best_selected's deployable=False signal.
             await emit.emit(
                 "error",
-                message="no candidates passed rigor",
+                message="no candidates generated",
                 recoverable=True,
                 code="RIGOR_FAIL",
             )
-            await store.update_status(job_id, "error", error="no candidates passed rigor")
+            await store.update_status(job_id, "error", error="no candidates generated")
             return
 
         # Patch PBO across the candidate set (library-level metric — Bailey
@@ -1227,16 +1230,25 @@ async def run_generation(
         for c in candidates:
             c.passes_rigor = c.rigor_verdict.get("passing", False)
 
-        # Pick the best by passing-rigor first, then by a simple score.
-        passing = [c for c in candidates if c.passes_rigor] or candidates
+        # Selection: prefer rigor-passing candidates; fall back to the full set only to
+        # still surface a "considered best" for the alternatives panel. Whether that best
+        # is DEPLOYABLE is a separate, honest signal (#818): a candidate that failed the
+        # gate is persisted with passes_rigor_gate=False and the server-side vault gate
+        # refuses to deploy it — we must not imply it is validated.
+        validated = [c for c in candidates if c.passes_rigor]
+        pool = validated or candidates
         best = max(
-            passing,
+            pool,
             key=lambda c: c.rigor_verdict.get("dsr") or 0.0,
         )
         await emit.emit(
             "best_selected",
             best_candidate_id=best.candidate_id,
             considered_count=len(candidates),
+            validated_count=len(validated),
+            # deployable=False ⇒ no candidate cleared the rigor gate; the surfaced best is
+            # a considered alternative (ABSTAIN), not a validated, deployable winner.
+            deployable=best.passes_rigor,
         )
 
         # Persist ALL candidates (both regimes) as StrategyRecords.

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -65,6 +65,54 @@ async def _anchor_strategies_async(strategy_ids: list[str]) -> None:
             logger.warning("anchor failed for strategy %s (non-fatal): %s", sanitize_log_value(sid), exc)
 
 
+def _strategy_rigor_status(strategy_id: str) -> tuple[bool, bool]:
+    """``(found, passes_rigor_gate)`` for a strategy id, resolved across the curated
+    provider AND the generated ``strategy_passports`` table — the same two sources
+    ``GET /api/strategies/{id}`` uses. Server-side source of truth for the deploy
+    gate (#818).
+
+    Fail-closed: if the DB lookup raises (cannot verify a generated strategy), the
+    strategy is reported as not-found so the caller refuses the deploy rather than
+    waving through an unverifiable one.
+    """
+    strat = strategy_provider.get_strategy(strategy_id)
+    if strat is not None:
+        return True, bool(getattr(strat, "passes_rigor_gate", False))
+
+    from archimedes.db import get_session
+    from archimedes.services.passport_loader import get_passport
+
+    try:
+        with get_session() as session:
+            record = get_passport(session, strategy_id)
+            if record is not None:
+                return True, bool(getattr(record, "passes_rigor_gate", False))
+    except Exception:
+        logger.exception("rigor-status lookup failed for %s — failing closed", sanitize_log_value(strategy_id))
+        return False, False
+    return False, False
+
+
+def _assert_strategies_pass_rigor(strategy_ids: list[str]) -> None:
+    """Fail-closed deploy precondition (#818): every strategy bound to a vault must
+    resolve and carry a passing rigor verdict. Raises 422 otherwise. The frontend
+    Deploy gate (#782) is defense-in-depth; THIS is the guarantee a non-UI caller
+    cannot route around. A strategy with no computed verdict (placeholder) has
+    ``passes_rigor_gate == False`` and is correctly refused."""
+    for sid in strategy_ids:
+        found, passes = _strategy_rigor_status(sid)
+        if not found:
+            raise HTTPException(status_code=422, detail=f"Strategy '{sid}' not found — cannot deploy.")
+        if not passes:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Strategy '{sid}' has not passed the rigor gate — refusing to deploy "
+                    "(server-side rigor enforcement)."
+                ),
+            )
+
+
 @vaults_router.get("/", response_model=VaultListResponse)
 async def list_vaults(
     tier: int | None = Query(None, ge=1, le=2),
@@ -99,6 +147,11 @@ async def create_vault(
     widen slippage, pause, or otherwise drain the vault. This re-lands the intent
     of reverted PR #646 without changing the live 5-arg createVault selector.
     """
+    # Server-side rigor gate (#818): refuse to deploy any strategy that hasn't
+    # passed the rigor gate, BEFORE spending gas. The #782 frontend Deploy gate is
+    # defense-in-depth; this is the guarantee a direct/non-UI API call can't bypass.
+    _assert_strategies_pass_rigor(req.strategy_ids)
+
     try:
         vault_address = await chain_executor.create_vault(
             name=req.name,

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -435,6 +435,36 @@ async def test_pipeline_multi_candidate_picks_best():
     assert best["data"]["considered_count"] == 3
 
 
+@pytest.mark.asyncio
+async def test_best_selected_abstains_when_no_candidate_passes_rigor():
+    # ABSTAIN semantics (#818): when NO candidate clears the gate, best_selected must
+    # honestly carry validated_count=0 and deployable=False — the surfaced best is a
+    # *considered* alternative, not a validated, deployable winner. Pins the new fields
+    # so the ABSTAIN-vs-deployable distinction can't regress silently.
+    store = _FakeStore()
+    brief = GenerateBrief(intent="aggressive crypto", risk_appetite="aggressive")
+
+    def _fail_all(cands):
+        # Stand in for _patch_pbo: force every candidate to fail the gate.
+        for c in cands:
+            c.rigor_verdict["passing"] = False
+
+    with (
+        patch("archimedes.agents.generation_pipeline._patch_pbo", side_effect=_fail_all),
+        patch(
+            "archimedes.agents.generation_pipeline._persist_candidate",
+            new=AsyncMock(return_value=("strat_abstain_001", "0xfeed")),
+        ),
+    ):
+        await run_generation(job_id="job_abstain", brief=brief, n_candidates=3, store=store, dual_regime=False)
+
+    best = next((e for e in store.events if e["event"] == "best_selected"), None)
+    assert best is not None
+    assert best["data"]["considered_count"] == 3
+    assert best["data"]["validated_count"] == 0
+    assert best["data"]["deployable"] is False
+
+
 # ── Fusion dispatch wire — hermetic end-to-end (Stack A) ───────────────────
 #
 # Proves the #1 fix: the "fusion" pipeline choice ACTUALLY drives dispatch.

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -9,13 +9,34 @@ that failed the gate or was never validated.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import contextlib
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from archimedes.api.vaults_routes import _assert_strategies_pass_rigor, _strategy_rigor_status
 from fastapi import HTTPException
 
 V = "archimedes.api.vaults_routes"
+
+
+@contextlib.contextmanager
+def _override_verified_wallet(app, wallet: str = "0x000000000000000000000000000000000000dEaD"):
+    """Override the SIWE wallet dependency, then RESTORE the prior override on exit.
+
+    Restoring (rather than a global ``app.dependency_overrides.clear()``) keeps this
+    test from wiping overrides another test/fixture set on the shared ``app`` instance.
+    """
+    from archimedes.api.auth_siwe import require_verified_wallet
+
+    prev = app.dependency_overrides.get(require_verified_wallet)
+    app.dependency_overrides[require_verified_wallet] = lambda: wallet
+    try:
+        yield
+    finally:
+        if prev is None:
+            app.dependency_overrides.pop(require_verified_wallet, None)
+        else:
+            app.dependency_overrides[require_verified_wallet] = prev
 
 
 class _Strat:
@@ -86,24 +107,46 @@ def test_assert_blocks_if_any_one_fails():
 
 
 async def test_create_vault_rejects_failing_strategy_before_deploy():
-    from archimedes.api.auth_siwe import require_verified_wallet
     from archimedes.main import app
     from httpx import ASGITransport, AsyncClient
 
-    app.dependency_overrides[require_verified_wallet] = lambda: "0x000000000000000000000000000000000000dEaD"
-    try:
-        with (
-            patch(f"{V}._strategy_rigor_status", return_value=(True, False)),
-            patch(f"{V}.chain_executor.create_vault") as mock_create,
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-                resp = await client.post(
-                    "/api/vaults/create",
-                    json={"name": "V", "symbol": "V", "strategy_ids": ["failing"]},
-                )
-    finally:
-        app.dependency_overrides.clear()
+    with (
+        _override_verified_wallet(app),
+        patch(f"{V}._strategy_rigor_status", return_value=(True, False)),
+        patch(f"{V}.chain_executor.create_vault") as mock_create,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/vaults/create",
+                json={"name": "V", "symbol": "V", "strategy_ids": ["failing"]},
+            )
 
     assert resp.status_code == 422
     assert "rigor gate" in resp.json()["detail"]
     mock_create.assert_not_called()  # never spent gas — gate fired first
+
+
+async def test_create_vault_proceeds_when_rigor_passes():
+    # Complementary happy path: a passing strategy must NOT be blocked by the new
+    # precondition — the deploy proceeds and chain_executor.create_vault is called.
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    with (
+        _override_verified_wallet(app),
+        patch(f"{V}._strategy_rigor_status", return_value=(True, True)),
+        patch(f"{V}.chain_executor.create_vault", new=AsyncMock(return_value="0xVaultDeployedAddress")) as mock_create,
+        # record_funnel touches Redis; stub it so the test stays hermetic.
+        patch("archimedes.api.funnel_middleware.record_funnel", new=AsyncMock()),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/vaults/create",
+                json={"name": "V", "symbol": "V", "strategy_ids": ["passing"]},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["vault_address"] == "0xVaultDeployedAddress"
+    assert body["strategy_ids"] == ["passing"]
+    mock_create.assert_awaited_once()  # gate let it through → gas spent

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -1,0 +1,109 @@
+"""Hermetic tests for the server-side rigor deploy gate (#818).
+
+The guarantee "only rigor-passing strategies are deployed" must hold server-side,
+where a direct (non-UI) API call cannot route around it. These pin: the resolver
+reads the authoritative verdict across curated + generated sources, fails closed on
+a DB error, and `create_vault` returns 422 (without spending gas) for a strategy
+that failed the gate or was never validated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from archimedes.api.vaults_routes import _assert_strategies_pass_rigor, _strategy_rigor_status
+from fastapi import HTTPException
+
+V = "archimedes.api.vaults_routes"
+
+
+class _Strat:
+    def __init__(self, passes):
+        self.passes_rigor_gate = passes
+
+
+# ── _strategy_rigor_status ────────────────────────────────────────────────
+
+
+def test_status_curated_passing():
+    with patch(f"{V}.strategy_provider.get_strategy", return_value=_Strat(True)):
+        assert _strategy_rigor_status("s1") == (True, True)
+
+
+def test_status_curated_failing():
+    with patch(f"{V}.strategy_provider.get_strategy", return_value=_Strat(False)):
+        assert _strategy_rigor_status("s1") == (True, False)
+
+
+def test_status_fails_closed_on_db_error():
+    # Not curated → falls to the DB; if the session raises, we must report not-found
+    # (False, False) so the caller blocks the deploy rather than waving it through.
+    with (
+        patch(f"{V}.strategy_provider.get_strategy", return_value=None),
+        patch("archimedes.db.get_session", side_effect=RuntimeError("db down")),
+    ):
+        assert _strategy_rigor_status("missing") == (False, False)
+
+
+# ── _assert_strategies_pass_rigor ─────────────────────────────────────────
+
+
+def test_assert_raises_422_on_failing():
+    with patch(f"{V}._strategy_rigor_status", return_value=(True, False)), pytest.raises(HTTPException) as exc:
+        _assert_strategies_pass_rigor(["s1"])
+    assert exc.value.status_code == 422
+    assert "rigor gate" in exc.value.detail
+
+
+def test_assert_raises_422_on_not_found():
+    with patch(f"{V}._strategy_rigor_status", return_value=(False, False)), pytest.raises(HTTPException) as exc:
+        _assert_strategies_pass_rigor(["ghost"])
+    assert exc.value.status_code == 422
+    assert "not found" in exc.value.detail
+
+
+def test_assert_passes_on_passing():
+    with patch(f"{V}._strategy_rigor_status", return_value=(True, True)):
+        _assert_strategies_pass_rigor(["s1", "s2"])  # no raise
+
+
+def test_assert_empty_list_is_noop():
+    _assert_strategies_pass_rigor([])  # nothing to validate → no raise
+
+
+def test_assert_blocks_if_any_one_fails():
+    # All must pass; one failing id blocks the whole deploy.
+    def _status(sid):
+        return (True, sid != "bad")
+
+    with patch(f"{V}._strategy_rigor_status", side_effect=_status), pytest.raises(HTTPException) as exc:
+        _assert_strategies_pass_rigor(["good", "bad", "good2"])
+    assert exc.value.status_code == 422
+
+
+# ── HTTP: the gate fires BEFORE the on-chain deploy ───────────────────────
+
+
+async def test_create_vault_rejects_failing_strategy_before_deploy():
+    from archimedes.api.auth_siwe import require_verified_wallet
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    app.dependency_overrides[require_verified_wallet] = lambda: "0x000000000000000000000000000000000000dEaD"
+    try:
+        with (
+            patch(f"{V}._strategy_rigor_status", return_value=(True, False)),
+            patch(f"{V}.chain_executor.create_vault") as mock_create,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/vaults/create",
+                    json={"name": "V", "symbol": "V", "strategy_ids": ["failing"]},
+                )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 422
+    assert "rigor gate" in resp.json()["detail"]
+    mock_create.assert_not_called()  # never spent gas — gate fired first

--- a/docs/specs/generation-streaming-spec.md
+++ b/docs/specs/generation-streaming-spec.md
@@ -140,7 +140,8 @@ when the user explicitly clicks "Start over").
 |---|---|
 | Agent hits `MAX_AGENT_ITERATIONS=12` without a valid candidate | Emit `error { message: "max_iterations_exceeded", recoverable: true, code: "MAX_ITER" }`. Client offers "Regenerate" CTA. |
 | LLM API unreachable | Emit `error { message: "llm_unavailable", recoverable: true, code: "LLM_DOWN" }`. Client offers "Retry in 30s" CTA. |
-| All candidates fail rigor gate | Emit `best_selected: null` followed by `error { message: "no_candidate_passed_rigor", recoverable: true, code: "RIGOR_FAIL" }`. Client redirects to `/strategy/:id` for the **best Rejected** candidate so user can see why. |
+| All candidates fail rigor gate | **Not an error (since #818).** Emit `best_selected { deployable: false, validated_count: 0, ... }` (ABSTAIN): the best is surfaced as a *considered* candidate, persisted with `passes_rigor_gate=false`, and the server-side vault gate refuses to deploy it. Client redirects to `/strategy/:id` for the **best Rejected** candidate so the user can see why. (Legacy `code: "RIGOR_FAIL"` is no longer emitted.) |
+| No candidates generated at all | Upstream generation produced zero candidates. Emit `error { message: "no candidates generated", recoverable: true, code: "NO_CANDIDATES" }` — distinct from the all-failed-rigor ABSTAIN above, so telemetry doesn't read a generation failure as a rigor-gate failure. |
 | Brief is gibberish or out-of-scope | Brief-validation step fails; emit `error { message: "brief_invalid", recoverable: true, code: "BRIEF_INVALID", hint: "Try mentioning an asset class or risk appetite" }`. |
 | API process restarts mid-job | On restart, scan Redis for active job locks; resume jobs whose age < TTL. Lock-without-progress for > 5 min → mark errored with `code: "STALLED"`. |
 | Client disconnects + never returns | Server completes the job and writes events to Redis; on TTL expiry, GC removes them. Strategy still ends up in Library. |

--- a/docs/specs/multi-agent-debate-spec.md
+++ b/docs/specs/multi-agent-debate-spec.md
@@ -185,7 +185,7 @@ async def _run_debate_candidate(
 ) -> _CandidateResult: ...
 ```
 
-**Returned `_CandidateResult`:** fully populated per the existing contract. For the winner, set `has_real_rigor=True` (so `_patch_pbo:440` and the buy-and-hold gather `:1251` both correctly skip it — the CSCV PBO from `evaluate_fusion_spec` must not be clobbered). For ABSTAIN, return a populated result with empty `weights`, a passive-baseline `return_series`, and an abstain `rigor_verdict` stub — this does **not** hit the empty-guard at `:1183` (which would wrongly emit `RIGOR_FAIL`); it is a first-class SKIP.
+**Returned `_CandidateResult`:** fully populated per the existing contract. For the winner, set `has_real_rigor=True` (so `_patch_pbo:440` and the buy-and-hold gather `:1251` both correctly skip it — the CSCV PBO from `evaluate_fusion_spec` must not be clobbered). For ABSTAIN, return a populated result with empty `weights`, a passive-baseline `return_series`, and an abstain `rigor_verdict` stub — this does **not** hit the empty-guard (which would wrongly emit a `NO_CANDIDATES` error); it is a first-class SKIP.
 
 **Streaming:** emit `agent_iteration` / `tool_called` / `tool_result` per role, reusing the existing SSE vocabulary → **zero frontend changes**. (New event names would require `EventName` + listener edits; avoid.)
 


### PR DESCRIPTION
## The bypass (claim-integrity, #1 rule)

The rigor gate was enforced **only on the frontend** Deploy button (#782); the backend `create_vault` deployed any `strategy_ids` it was handed. A direct/non-UI API call could therefore deploy a strategy that **failed** the rigor gate — or one that never got a verdict. The guarantee *"only rigor-passing strategies are deployed"* must hold **server-side**, where it can't be bypassed.

## Part A — the server-side gate

- `_strategy_rigor_status(id)` → `(found, passes_rigor_gate)`, resolved across the **curated provider AND the generated `strategy_passports` table** (the same two sources `GET /api/strategies/{id}` uses). **Fails closed** on a DB error — an unverifiable strategy is blocked, not waved through.
- `_assert_strategies_pass_rigor(ids)` raises **422** if any id is unresolved or `passes_rigor_gate != True`. Called at the **top of `create_vault`, before any gas is spent**. The #782 frontend gate is now defense-in-depth.

## Part B — generation honesty

- `if not candidates` said *"no candidates passed rigor"* but only fires when **zero were generated** → corrected to *"no candidates generated"*.
- `best_selected` now carries `validated_count` + `deployable` (`= best.passes_rigor`). **`deployable=False` ⇒ no candidate cleared the gate**, so the surfaced best is a considered alternative (**ABSTAIN**), not a validated winner. Failing candidates stay persisted (`passes_rigor_gate=False`) for the alternatives panel, but the Part-A gate refuses to deploy them. (`best_selected` stays in the `EventName` allowlist; only its free-form `data` gained fields — backward-compatible.)

## Tests

9 hermetic tests: the resolver (curated pass/fail + **fail-closed-on-DB-error**), the assert (422 on failing / not-found / any-one-fails; passes on passing; empty no-op), and an **HTTP test proving `create_vault` returns 422 with `chain_executor.create_vault` NEVER called** (no gas spent). Existing `test_rigor_deploy_gate_contract` + `test_generation_pipeline` stay green. `env -i … pytest backend/tests/test_vault_rigor_gate.py -q` → 9 passed.

## Reviewer note

The `POST /metadata` `set_strategy_ids` path is **another binding surface**; applying the same `_assert_strategies_pass_rigor` guard there would fully close the bypass. Left out of this PR (out of the issue's `create_vault` scope + needs a check of that endpoint's draft/save callers) — **flagged as a follow-up.**

Closes #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)