### PR TITLE
[testing] Backend coverage: chain/ modules + chain_client unlock fixture (#738)

### DIFF
--- a/backend/tests/chain/test_circle_signer.py
+++ b/backend/tests/chain/test_circle_signer.py
@@ -1,0 +1,252 @@
+"""Tests for CircleSigner — Circle Developer-Controlled Wallet signing (#738).
+
+Target: backend/archimedes/chain/circle_signer.py
+The signer encrypts the entity secret with Circle's RSA public key, submits a
+contract execution, and polls until a terminal state. It holds funds-adjacent
+authority (it is the wallet that signs vault rebalance / ownership txs), so the
+configured/unconfigured gate, the submit path, and the poll loop must all be
+exercised.
+
+Hermetic: the aiohttp HTTP boundary is mocked; the RSA encrypt helper is mocked
+where a real key would otherwise be needed. No network, no Circle, no Arc RPC.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.circle_signer import CircleSigner, _encrypt_entity_secret
+
+# ── Helpers ───────────────────────────────────────────────────
+
+
+def _mock_session() -> MagicMock:
+    """An aiohttp.ClientSession whose `get`/`post` return async context managers.
+
+    Each call to `_set_get`/`_set_post` installs the response object the next
+    `async with session.get(...)` / `session.post(...)` should yield.
+    """
+    session = MagicMock()
+
+    def _cm(resp):
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    session._cm = _cm
+    return session
+
+
+def _session_context(session: MagicMock) -> MagicMock:
+    """Wrap a session in the `async with aiohttp.ClientSession() as s` CM."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _resp(status: int, body: dict) -> MagicMock:
+    resp = MagicMock(status=status)
+    resp.json = AsyncMock(return_value=body)
+    return resp
+
+
+@pytest.fixture
+def configured(monkeypatch) -> CircleSigner:
+    monkeypatch.setenv("CIRCLE_API_KEY", "test-api-key")
+    monkeypatch.setenv("CIRCLE_ENTITY_SECRET", "ab" * 32)
+    monkeypatch.setenv("WALLET_ID", "wallet-uuid")
+    return CircleSigner()
+
+
+# ── is_configured ─────────────────────────────────────────────
+
+
+class TestIsConfigured:
+    def test_true_when_all_creds_present(self, configured):
+        assert configured.is_configured is True
+
+    def test_false_when_any_cred_missing(self, monkeypatch):
+        monkeypatch.delenv("CIRCLE_API_KEY", raising=False)
+        monkeypatch.delenv("CIRCLE_ENTITY_SECRET", raising=False)
+        monkeypatch.delenv("WALLET_ID", raising=False)
+        assert CircleSigner().is_configured is False
+
+
+# ── _get_public_key ───────────────────────────────────────────
+
+
+class TestGetPublicKey:
+    async def test_fetches_and_caches(self, configured):
+        session = _mock_session()
+        resp = _resp(200, {"data": {"publicKey": "PEM-DATA"}})
+        session.get = MagicMock(return_value=session._cm(resp))
+
+        key = await configured._get_public_key(session)
+        assert key == "PEM-DATA"
+        # Second call uses the cache — no second HTTP get.
+        session.get.reset_mock()
+        key2 = await configured._get_public_key(session)
+        assert key2 == "PEM-DATA"
+        session.get.assert_not_called()
+
+    async def test_non_200_returns_none(self, configured):
+        session = _mock_session()
+        session.get = MagicMock(return_value=session._cm(_resp(403, {"error": "denied"})))
+        assert await configured._get_public_key(session) is None
+
+
+# ── execute_contract ──────────────────────────────────────────
+
+
+class TestExecuteContract:
+    async def test_raises_when_unconfigured(self, monkeypatch):
+        monkeypatch.delenv("CIRCLE_API_KEY", raising=False)
+        signer = CircleSigner()
+        with pytest.raises(RuntimeError, match="not configured"):
+            await signer.execute_contract("0xVault", "setAgent(address)", ["0xabc"])
+
+    async def test_happy_path_submits_then_polls_to_complete(self, configured):
+        session = _mock_session()
+        # 1) public key fetch, 2) POST contractExecution (201), then polling GET.
+        key_resp = _resp(200, {"data": {"publicKey": "PEM"}})
+        submit_resp = _resp(201, {"data": {"id": "circle-tx-1"}})
+        session.get = MagicMock(return_value=session._cm(key_resp))
+        session.post = MagicMock(return_value=session._cm(submit_resp))
+
+        with (
+            patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)),
+            patch("archimedes.chain.circle_signer._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(configured, "_poll_transaction", AsyncMock(return_value="0xONCHAIN")),
+        ):
+            result = await configured.execute_contract(
+                "0xVault", "setTargetAllocations(address[],uint256[])", [["0xT"], [10000]]
+            )
+        assert result == "0xONCHAIN"
+        session.post.assert_called_once()
+
+    async def test_public_key_failure_raises(self, configured):
+        session = _mock_session()
+        session.get = MagicMock(return_value=session._cm(_resp(500, {})))
+        with (
+            patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)),
+            patch("archimedes.chain.circle_signer._encrypt_entity_secret", return_value="ciphertext"),
+        ):
+            with pytest.raises(RuntimeError, match="public key"):
+                await configured.execute_contract("0xVault", "setAgent(address)", ["0xabc"])
+
+    async def test_non_201_submit_raises(self, configured):
+        session = _mock_session()
+        session.get = MagicMock(return_value=session._cm(_resp(200, {"data": {"publicKey": "PEM"}})))
+        session.post = MagicMock(return_value=session._cm(_resp(400, {"error": "bad"})))
+        with (
+            patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)),
+            patch("archimedes.chain.circle_signer._encrypt_entity_secret", return_value="ciphertext"),
+        ):
+            with pytest.raises(RuntimeError, match="contract execution failed"):
+                await configured.execute_contract("0xVault", "setAgent(address)", ["0xabc"])
+
+
+# ── _poll_transaction ─────────────────────────────────────────
+
+
+class TestPollTransaction:
+    async def test_returns_tx_hash_on_complete(self, configured):
+        session = _mock_session()
+        body = {"data": {"transactions": [{"id": "tx-1", "state": "COMPLETE", "txHash": "0xHASH"}]}}
+        session.get = MagicMock(return_value=session._cm(_resp(200, body)))
+        result = await configured._poll_transaction(session, "tx-1")
+        assert result == "0xHASH"
+
+    async def test_raises_on_failed_terminal_state(self, configured):
+        session = _mock_session()
+        body = {"data": {"transactions": [{"id": "tx-1", "state": "FAILED", "txHash": ""}]}}
+        session.get = MagicMock(return_value=session._cm(_resp(200, body)))
+        with pytest.raises(RuntimeError, match="ended in FAILED"):
+            await configured._poll_transaction(session, "tx-1")
+
+    async def test_times_out_after_max_polls(self, configured):
+        session = _mock_session()
+        # Tx never reaches terminal state → loop exhausts and raises.
+        body = {"data": {"transactions": [{"id": "tx-1", "state": "PROCESSING", "txHash": ""}]}}
+        session.get = MagicMock(return_value=session._cm(_resp(200, body)))
+        with (
+            patch("archimedes.chain.circle_signer._MAX_POLLS", 2),
+            patch("archimedes.chain.circle_signer.asyncio.sleep", AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await configured._poll_transaction(session, "tx-1")
+
+
+# ── sign_and_broadcast ────────────────────────────────────────
+
+
+class TestSignAndBroadcast:
+    async def test_raises_when_unconfigured(self, monkeypatch):
+        monkeypatch.delenv("CIRCLE_API_KEY", raising=False)
+        signer = CircleSigner()
+        with pytest.raises(RuntimeError, match="not configured"):
+            await signer.sign_and_broadcast({"to": "0x", "value": 0})
+
+    async def test_signs_and_broadcasts_via_arc_rpc(self, configured):
+        session = _mock_session()
+        sign_resp = _resp(201, {"data": {"signedTransaction": "0xabcd", "txHash": ""}})
+        session.post = MagicMock(return_value=session._cm(sign_resp))
+
+        mock_chain = MagicMock()
+        sent_hash = MagicMock()
+        sent_hash.hex = MagicMock(return_value="0xBROADCAST")
+        mock_chain.w3.eth.send_raw_transaction = AsyncMock(return_value=sent_hash)
+
+        with (
+            patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)),
+            patch("archimedes.chain.client.chain_client", mock_chain),
+        ):
+            result = await configured.sign_and_broadcast({"to": "0xabc", "value": 0})
+        assert result == "0xBROADCAST"
+        mock_chain.w3.eth.send_raw_transaction.assert_awaited_once()
+
+    async def test_sign_failure_raises(self, configured):
+        session = _mock_session()
+        session.post = MagicMock(return_value=session._cm(_resp(422, {"error": "bad tx"})))
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)):
+            with pytest.raises(RuntimeError, match="sign failed"):
+                await configured.sign_and_broadcast({"to": "0xabc", "value": 0})
+
+
+# ── _encrypt_entity_secret ────────────────────────────────────
+
+
+class TestEncryptEntitySecret:
+    def test_round_trips_with_real_rsa_key(self):
+        """The encrypt helper must produce a base64 ciphertext that decrypts back
+        to the entity secret with the matching private key — proving the OAEP
+        padding + key handling is correct (no network needed)."""
+        import base64
+
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        public_pem = (
+            private_key.public_key()
+            .public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode()
+        )
+
+        secret_hex = "ab" * 32
+        ciphertext_b64 = _encrypt_entity_secret(secret_hex, public_pem)
+        decrypted = private_key.decrypt(
+            base64.b64decode(ciphertext_b64),
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        assert decrypted == bytes.fromhex(secret_hex)

--- a/backend/tests/chain/test_executor_reads.py
+++ b/backend/tests/chain/test_executor_reads.py
@@ -1,0 +1,302 @@
+"""ChainExecutor read + setter coverage (#738 Tier-A).
+
+Target: backend/archimedes/chain/executor.py
+Complements test_chain_executor.py (which covers execute_trades / create_vault /
+liquidity) by exercising the on-chain READ surface and the vault setters that the
+agent tick depends on: read_portfolio, get_vault_metrics, get_all_vaults,
+get_vault_count, set_token_oracles, set_target_allocations, and the token /
+NAV helpers (_get_token_symbol, _get_token_decimals, _token_to_usdc,
+_safe_total_assets, _parse_vault_created).
+
+Hermetic: the ContractLoader and chain_client are mocked at the boundary — every
+contract `.functions.X().call()` is an AsyncMock. No network, no Arc RPC, no Circle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+from archimedes.chain.executor import ChainExecutor
+from hexbytes import HexBytes
+
+USDC = "0x3600000000000000000000000000000000000000"
+STSLA = "0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388"
+
+
+class _Awaitable:
+    """await-able attribute wrapper (see test_chain_executor.py)."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def __await__(self):
+        async def _coro():
+            return self._value
+
+        return _coro().__await__()
+
+
+@pytest.fixture
+def mock_loader():
+    loader = MagicMock()
+    mock_router = MagicMock()
+    type(loader).amm_router = PropertyMock(return_value=mock_router)
+    loader.amm_pool.return_value = MagicMock()
+    loader.vault.return_value = MagicMock()
+    loader.vault_factory = MagicMock()
+    loader.oracle_for.return_value = MagicMock()
+    loader.token.return_value = MagicMock()
+    return loader
+
+
+@pytest.fixture
+def executor(mock_loader):
+    with patch("archimedes.chain.executor.chain_client") as mock_cc:
+        mock_cc.settings = MagicMock()
+        mock_cc.settings.usdc_address = USDC
+        mock_cc.settings.synth_addresses = {"sTSLA": STSLA}
+        mock_cc.settings.oracle_addresses = {"sTSLA": "0xOracleTSLA"}
+        mock_cc.settings.chain_id = 5042002
+        mock_cc.settings.agent_account = None
+        mock_cc.to_checksum = lambda addr: addr
+        mock_cc.w3 = MagicMock()
+        mock_cc.w3.eth = MagicMock()
+        mock_cc.w3.eth.gas_price = _Awaitable(1_000_000_000)
+        mock_cc.w3.eth.get_transaction_count = AsyncMock(return_value=1)
+        mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=HexBytes(b"\x00" * 32))
+        mock_cc.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value={"status": 1})
+        ex = ChainExecutor(loader=mock_loader)
+        ex._mock_cc = mock_cc
+        yield ex
+
+
+def _vault_fn(vault, name, return_value=None, side_effect=None):
+    """Wire vault.functions.<name>().call() to an AsyncMock."""
+    fn = getattr(vault.functions, name)
+    fn.return_value.call = AsyncMock(return_value=return_value, side_effect=side_effect)
+
+
+# ── read_portfolio ────────────────────────────────────────────
+
+
+class TestReadPortfolio:
+    def test_builds_portfolio_from_holdings(self, executor, mock_loader):
+        vault = mock_loader.vault.return_value
+        # getHoldings → ([token addrs], [raw amounts]); one synth + one zero leg.
+        _vault_fn(vault, "getHoldings", return_value=[[STSLA, USDC], [2 * 10**18, 0]])
+        _vault_fn(vault, "totalAssets", return_value=400_000_000)  # $400 (6 dec)
+        # token symbol/decimals for the synth
+        token = mock_loader.token.return_value
+        _vault_fn(token, "symbol", return_value="sTSLA")
+        _vault_fn(token, "decimals", return_value=18)
+        # oracle getPrice for value: 200 USDC (6 dec) per token
+        oracle = mock_loader.oracle_for.return_value
+        _vault_fn(oracle, "getPrice", return_value=200_000_000)
+
+        portfolio = asyncio.run(executor.read_portfolio("0xVault"))
+        assert portfolio.vault_address == "0xVault"
+        assert portfolio.total_value_usdc == pytest.approx(400.0)
+        # The zero-amount USDC leg is skipped; only the synth holding remains.
+        assert len(portfolio.holdings) == 1
+        h = portfolio.holdings[0]
+        assert h.symbol == "sTSLA"
+        assert h.amount == pytest.approx(2.0)
+
+    def test_total_assets_revert_falls_back_to_offchain_nav(self, executor, mock_loader):
+        vault = mock_loader.vault.return_value
+        _vault_fn(vault, "getHoldings", return_value=[[USDC], [500_000_000]])  # $500 USDC
+        _vault_fn(vault, "totalAssets", side_effect=RuntimeError("StalePrice"))
+        portfolio = asyncio.run(executor.read_portfolio("0xVault"))
+        # NAV recomputed off-chain: USDC leg contributes its raw amount directly.
+        assert portfolio.total_value_usdc == pytest.approx(500.0)
+
+
+# ── get_vault_metrics ─────────────────────────────────────────
+
+
+class TestGetVaultMetrics:
+    def test_reads_all_metric_fields(self, executor, mock_loader):
+        vault = mock_loader.vault.return_value
+        _vault_fn(vault, "totalAssets", return_value=1_000_000_000)  # $1000
+        _vault_fn(vault, "totalSupply", return_value=1_000_000_000)
+        _vault_fn(vault, "highWaterMark", return_value=123)
+        _vault_fn(vault, "creator", return_value="0xCreator")
+        _vault_fn(vault, "tier", return_value=1)
+        _vault_fn(vault, "managementFeeBps", return_value=100)
+        _vault_fn(vault, "performanceFeeBps", return_value=1500)
+        _vault_fn(vault, "isAgentAssisted", return_value=True)
+        _vault_fn(vault, "paused", return_value=False)
+
+        m = asyncio.run(executor.get_vault_metrics("0xVault"))
+        assert m["vault_address"] == "0xVault"
+        assert m["total_aum_usdc"] == pytest.approx(1000.0)
+        assert m["tier"] == 1
+        assert m["management_fee_bps"] == 100
+        assert m["is_agent_assisted"] is True
+        # share_price = (totalAssets/totalSupply)/1e6. With equal raw units the
+        # ratio is 1, scaled by /1e6 → 1e-6 (the contract's share decimals).
+        assert m["share_price_usdc"] == pytest.approx(1e-6)
+        assert m["total_supply"] == 1_000_000_000
+        assert m["high_water_mark"] == 123
+        assert m["creator"] == "0xCreator"
+
+    def test_degrades_when_reads_revert(self, executor, mock_loader):
+        vault = mock_loader.vault.return_value
+        for fn in (
+            "totalAssets",
+            "totalSupply",
+            "highWaterMark",
+            "creator",
+            "tier",
+            "managementFeeBps",
+            "performanceFeeBps",
+            "isAgentAssisted",
+            "paused",
+        ):
+            _vault_fn(vault, fn, side_effect=RuntimeError("revert"))
+        # getHoldings also reverts so the stale-price fallback yields 0.
+        _vault_fn(vault, "getHoldings", side_effect=RuntimeError("revert"))
+        m = asyncio.run(executor.get_vault_metrics("0xVault"))
+        assert m["total_aum_usdc"] == 0.0
+        assert m["total_supply"] == 0
+        # No supply → share price defaults to 1 USDC.
+        assert m["share_price_usdc"] == pytest.approx(1.0)
+        assert m["creator"] == "0x0000000000000000000000000000000000000000"
+        assert m["tier"] == 2  # default
+        assert m["is_agent_assisted"] is False
+
+
+# ── get_all_vaults / get_vault_count ──────────────────────────
+
+
+class TestVaultEnumeration:
+    def test_get_all_vaults(self, executor, mock_loader):
+        _vault_fn(mock_loader.vault_factory, "getVaults", return_value=["0xV1", "0xV2"])
+        vaults = asyncio.run(executor.get_all_vaults())
+        assert vaults == ["0xV1", "0xV2"]
+
+    def test_get_vault_count(self, executor, mock_loader):
+        _vault_fn(mock_loader.vault_factory, "vaultCount", return_value=7)
+        assert asyncio.run(executor.get_vault_count()) == 7
+
+
+# ── set_token_oracles / set_target_allocations (Circle path) ──
+
+
+class TestVaultSettersCircle:
+    def test_set_token_oracles_circle(self, executor, mock_loader):
+        with patch("archimedes.chain.executor.circle_signer") as signer:
+            signer.is_configured = True
+            signer.execute_contract = AsyncMock(return_value="0xtx-oracles")
+            tx = asyncio.run(executor.set_token_oracles("0xVault", [STSLA], ["0xOracleTSLA"]))
+        assert tx == "0xtx-oracles"
+        signer.execute_contract.assert_awaited_once()
+        assert signer.execute_contract.await_args.kwargs["abi_function"] == "setTokenOracles(address[],address[])"
+
+    def test_set_target_allocations_circle(self, executor, mock_loader):
+        with patch("archimedes.chain.executor.circle_signer") as signer:
+            signer.is_configured = True
+            signer.execute_contract = AsyncMock(return_value="0xtx-alloc")
+            tx = asyncio.run(executor.set_target_allocations("0xVault", [STSLA], [10000]))
+        assert tx == "0xtx-alloc"
+        assert signer.execute_contract.await_args.kwargs["abi_function"] == "setTargetAllocations(address[],uint256[])"
+
+
+# ── set_target_allocations (raw-key path) + no-account guard ───
+
+
+class TestVaultSettersRawKey:
+    def test_set_target_allocations_raw_key(self, executor, mock_loader):
+        account = MagicMock()
+        account.address = "0xAGENT00000000000000000000000000000000aa"
+        account.sign_transaction.return_value = MagicMock(raw_transaction=b"\x01")
+        executor._mock_cc.settings.agent_account = account
+        vault = mock_loader.vault.return_value
+        vault.functions.setTargetAllocations.return_value.build_transaction = AsyncMock(
+            return_value={"from": account.address, "nonce": 1}
+        )
+        sent = HexBytes("0x" + "ab" * 32)
+        executor._mock_cc.w3.eth.send_raw_transaction = AsyncMock(return_value=sent)
+        with patch("archimedes.chain.executor.circle_signer") as signer:
+            signer.is_configured = False
+            tx = asyncio.run(executor.set_target_allocations("0xVault", [STSLA], [10000]))
+        assert tx == sent.hex() if sent.hex().startswith("0x") else "0x" + sent.hex()
+
+    def test_set_token_oracles_no_account_raises(self, executor):
+        executor._mock_cc.settings.agent_account = None
+        with patch("archimedes.chain.executor.circle_signer") as signer:
+            signer.is_configured = False
+            with pytest.raises(RuntimeError, match="No agent account"):
+                asyncio.run(executor.set_token_oracles("0xVault", [STSLA], ["0xOracleTSLA"]))
+
+
+# ── helpers: token symbol / decimals / value / parse ──────────
+
+
+class TestTokenHelpers:
+    def test_get_token_symbol_known_usdc(self, executor):
+        assert asyncio.run(executor._get_token_symbol(USDC)) == "USDC"
+
+    def test_get_token_symbol_known_synth(self, executor):
+        assert asyncio.run(executor._get_token_symbol(STSLA)) == "sTSLA"
+
+    def test_get_token_symbol_unknown_queries_contract(self, executor, mock_loader):
+        token = mock_loader.token.return_value
+        _vault_fn(token, "symbol", return_value="WHO")
+        assert asyncio.run(executor._get_token_symbol("0x0000000000000000000000000000000000009999")) == "WHO"
+
+    def test_get_token_symbol_contract_revert_truncates_address(self, executor, mock_loader):
+        token = mock_loader.token.return_value
+        _vault_fn(token, "symbol", side_effect=RuntimeError("no symbol"))
+        addr = "0x0000000000000000000000000000000000009999"
+        assert asyncio.run(executor._get_token_symbol(addr)) == addr[:8]
+
+    def test_get_token_decimals_usdc_is_6(self, executor):
+        assert asyncio.run(executor._get_token_decimals(USDC)) == 6
+
+    def test_get_token_decimals_contract(self, executor, mock_loader):
+        token = mock_loader.token.return_value
+        _vault_fn(token, "decimals", return_value=8)
+        assert asyncio.run(executor._get_token_decimals(STSLA)) == 8
+
+    def test_get_token_decimals_revert_defaults_18(self, executor, mock_loader):
+        token = mock_loader.token.return_value
+        _vault_fn(token, "decimals", side_effect=RuntimeError("boom"))
+        assert asyncio.run(executor._get_token_decimals(STSLA)) == 18
+
+    def test_token_to_usdc_for_usdc_is_identity(self, executor):
+        assert asyncio.run(executor._token_to_usdc(USDC, 12_345, 6)) == 12_345
+
+    def test_token_to_usdc_synth_with_getprice(self, executor, mock_loader):
+        oracle = mock_loader.oracle_for.return_value
+        _vault_fn(oracle, "getPrice", return_value=200_000_000)  # $200 (6 dec)
+        # 2 tokens (18 dec) * 200_000_000 / 1e18 = 400_000_000 → $400
+        result = asyncio.run(executor._token_to_usdc(STSLA, 2 * 10**18, 18))
+        assert result == 400_000_000
+
+    def test_token_to_usdc_uses_raw_price_when_requested(self, executor, mock_loader):
+        oracle = mock_loader.oracle_for.return_value
+        _vault_fn(oracle, "price", return_value=100_000_000)
+        result = asyncio.run(executor._token_to_usdc(STSLA, 1 * 10**18, 18, use_raw_price=True))
+        assert result == 100_000_000
+
+    def test_token_to_usdc_unknown_token_returns_amount(self, executor):
+        assert asyncio.run(executor._token_to_usdc("0x0000000000000000000000000000000000008888", 42, 18)) == 42
+
+
+class TestParseVaultCreated:
+    def test_extracts_vault_from_event(self):
+        factory = MagicMock()
+        factory.events.VaultCreated.return_value.process_log.return_value = {"args": {"vault": "0xNew"}}
+        receipt = MagicMock()
+        receipt.logs = [MagicMock()]
+        assert ChainExecutor._parse_vault_created(factory, receipt) == "0xNew"
+
+    def test_returns_none_when_no_matching_log(self):
+        factory = MagicMock()
+        factory.events.VaultCreated.return_value.process_log.side_effect = ValueError("not this log")
+        receipt = MagicMock()
+        receipt.logs = [MagicMock(), MagicMock()]
+        assert ChainExecutor._parse_vault_created(factory, receipt) is None

--- a/backend/tests/chain/test_oracle_price_formatting.py
+++ b/backend/tests/chain/test_oracle_price_formatting.py
@@ -1,0 +1,99 @@
+"""Oracle on-chain price formatting (#738 behavior b).
+
+Target: backend/archimedes/chain/oracle_updater.py — push_prices_on_chain()
+
+The issue speculated an 8-decimal convention ($185.50 → 18_550_000_000), but the
+code (and its inline comment "6 decimals, matches PriceOracle.sol") fixes the
+on-chain integer at SIX decimals:
+
+    price_int = int(price.price_usd * 1e6)
+
+So $185.50 → 185_500_000. This test pins that real convention by asserting the
+exact `abiParameters` value submitted to Circle's contractExecution endpoint —
+not by re-deriving the formula in the test (which would just restate the bug if
+there were one). Guards against a silent 6↔8 decimal drift that would mis-price
+every on-chain push.
+
+Hermetic: the aiohttp HTTP boundary + the deviation-reference read are mocked.
+No network, no Circle, no Arc RPC.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.oracle_updater import OracleUpdater
+from archimedes.models.asset import AssetPrice
+
+
+def _price(symbol: str = "sTSLA", usd: float = 185.50) -> AssetPrice:
+    return AssetPrice(symbol=symbol, price_usd=usd, timestamp=datetime.now(UTC), source="yfinance")
+
+
+def _mock_aiohttp_session(post_response: MagicMock):
+    """Build a mock aiohttp.ClientSession CM whose .post yields post_response."""
+    session = MagicMock()
+    post_cm = MagicMock()
+    post_cm.__aenter__ = AsyncMock(return_value=post_response)
+    post_cm.__aexit__ = AsyncMock(return_value=False)
+    session.post = MagicMock(return_value=post_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return session_cm, session
+
+
+@pytest.fixture
+def circle_creds(monkeypatch):
+    monkeypatch.setenv("CIRCLE_API_KEY", "test-api-key")
+    monkeypatch.setenv("CIRCLE_ENTITY_SECRET", "ab" * 32)
+    monkeypatch.setenv("WALLET_ID", "wallet-uuid")
+
+
+class TestOraclePriceFormatting:
+    async def test_185_50_pushes_six_decimal_integer(self, circle_creds):
+        """$185.50 → 185_500_000 (6-dec), NOT 18_550_000_000 (8-dec)."""
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"  # skip the key fetch
+
+        resp = MagicMock(status=201)
+        resp.json = AsyncMock(return_value={"data": {"id": "tx-1"}})
+        session_cm, session = _mock_aiohttp_session(resp)
+
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            # First push for this symbol → reference confirmed absent → allowed.
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))),
+        ):
+            result = await updater.push_prices_on_chain([_price(usd=185.50)])
+
+        assert result == "tx-1"
+        session.post.assert_called_once()
+        payload = session.post.call_args.kwargs["json"]
+        # The on-chain int is the single uint256 abiParameter.
+        assert payload["abiFunctionSignature"] == "setPrice(uint256)"
+        assert payload["abiParameters"] == ["185500000"]
+        assert payload["abiParameters"] != ["18550000000"]  # explicitly NOT 8-dec
+        # The cached last-pushed reference is recorded in the SAME 6-dec units.
+        assert updater._last_pushed_price_int["sTSLA"] == 185_500_000
+
+    async def test_fractional_cents_truncate_toward_zero(self, circle_creds):
+        """int(x * 1e6) truncates — $1.0000005 → 1_000_000 (not 1_000_001)."""
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        resp = MagicMock(status=201)
+        resp.json = AsyncMock(return_value={"data": {"id": "tx-2"}})
+        session_cm, session = _mock_aiohttp_session(resp)
+
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))),
+        ):
+            await updater.push_prices_on_chain([_price(symbol="sNVDA", usd=1.0000005)])
+
+        payload = session.post.call_args.kwargs["json"]
+        assert payload["abiParameters"] == ["1000000"]

--- a/backend/tests/chain/test_oracle_runner.py
+++ b/backend/tests/chain/test_oracle_runner.py
@@ -1,0 +1,80 @@
+"""Tests for the oracle runner loop (#738).
+
+Target: backend/archimedes/chain/oracle_runner.py
+The runner is the periodic process that fetches prices and pushes them on-chain.
+It was at 0% coverage. We exercise one full loop iteration (fetch → push), the
+"no prices this cycle" branch, the "fetch error" branch, and the "push returns
+no tx" branch — breaking out of the otherwise-infinite `while True` by making
+`asyncio.sleep` raise a sentinel.
+
+Hermetic: the OracleUpdater is mocked at the boundary; `asyncio.sleep` is
+patched to stop the loop. No network, no Arc RPC, no Circle.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain import oracle_runner
+from archimedes.models.asset import AssetPrice
+
+
+class _StopLoop(Exception):
+    """Sentinel raised by the patched sleep to break the runner's while-loop."""
+
+
+def _price(symbol: str = "sTSLA", usd: float = 100.0) -> AssetPrice:
+    from datetime import UTC, datetime
+
+    return AssetPrice(symbol=symbol, price_usd=usd, timestamp=datetime.now(UTC), source="yfinance")
+
+
+async def _run_one_cycle(updater: MagicMock) -> None:
+    """Run oracle_runner.run() through exactly one loop body, then stop."""
+    with (
+        patch("archimedes.chain.oracle_runner.OracleUpdater", return_value=updater),
+        patch("archimedes.chain.oracle_runner.asyncio.sleep", AsyncMock(side_effect=_StopLoop)),
+        pytest.raises(_StopLoop),
+    ):
+        await oracle_runner.run()
+
+
+class TestOracleRunnerLoop:
+    async def test_fetch_then_push_path(self):
+        updater = MagicMock()
+        updater.fetch_prices = AsyncMock(return_value=[_price()])
+        updater.push_prices_on_chain = AsyncMock(return_value="0xtx-1")
+        await _run_one_cycle(updater)
+        updater.fetch_prices.assert_awaited_once()
+        updater.push_prices_on_chain.assert_awaited_once()
+
+    async def test_prices_fetched_but_no_push_tx(self):
+        # push returns None (owner key not configured) — must not crash.
+        updater = MagicMock()
+        updater.fetch_prices = AsyncMock(return_value=[_price()])
+        updater.push_prices_on_chain = AsyncMock(return_value=None)
+        await _run_one_cycle(updater)
+        updater.push_prices_on_chain.assert_awaited_once()
+
+    async def test_no_prices_this_cycle_skips_push(self):
+        updater = MagicMock()
+        updater.fetch_prices = AsyncMock(return_value=[])
+        updater.push_prices_on_chain = AsyncMock()
+        await _run_one_cycle(updater)
+        # No prices → push is never attempted.
+        updater.push_prices_on_chain.assert_not_called()
+
+    async def test_fetch_exception_is_caught_and_loop_continues(self):
+        # A fetch error must be swallowed (logged) and the loop proceed to sleep
+        # — the _StopLoop from sleep proves we reached the end of the body.
+        updater = MagicMock()
+        updater.fetch_prices = AsyncMock(side_effect=RuntimeError("yfinance down"))
+        updater.push_prices_on_chain = AsyncMock()
+        await _run_one_cycle(updater)
+        updater.push_prices_on_chain.assert_not_called()
+
+    def test_interval_default_is_60s(self):
+        # Sanity: the module-level INTERVAL falls back to 60 when env is unset.
+        assert isinstance(oracle_runner.INTERVAL, int)
+        assert oracle_runner.INTERVAL >= 1

--- a/backend/tests/chain/test_oracle_updater_fetch.py
+++ b/backend/tests/chain/test_oracle_updater_fetch.py
@@ -1,0 +1,240 @@
+"""OracleUpdater price-fetch + snapshot coverage (#738 Tier-A).
+
+Target: backend/archimedes/chain/oracle_updater.py
+Complements test_oracle_updater.py (which covers the sanity-bound / push-refusal
+logic) by exercising the *fetch* surface: yfinance equity prices, CoinGecko
+crypto prices, the market snapshot (VIX + S&P MAs), the cache, the Circle
+public-key fetch, and the no-credentials push early-return.
+
+Hermetic: yfinance is replaced with a fake module via sys.modules; the aiohttp
+CoinGecko/Circle boundary is mocked. No network, no Arc RPC, no Circle.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.oracle_updater import OracleUpdater
+from archimedes.models.asset import AssetPrice
+
+
+@pytest.fixture
+def updater() -> OracleUpdater:
+    return OracleUpdater()
+
+
+def _fake_yfinance_multi(prices_by_ticker: dict[str, float]):
+    """A fake `yfinance` module whose download() returns a multi-ticker frame.
+
+    The real code reads `data["Close"]` and indexes `.columns` per ticker, then
+    takes `.dropna().iloc[-1]`. We mimic the pandas surface the code touches.
+    """
+    import pandas as pd
+
+    close = pd.DataFrame({t: [p] for t, p in prices_by_ticker.items()})
+    frame = MagicMock()
+    frame.empty = False
+    frame.__getitem__ = MagicMock(side_effect=lambda k: close if k == "Close" else None)
+    fake = MagicMock()
+    fake.download = MagicMock(return_value=frame)
+    return fake
+
+
+class TestFetchYfinance:
+    def test_parses_multi_ticker_close(self, updater):
+        fake_yf = _fake_yfinance_multi({"TSLA": 250.0, "SPY": 500.0})
+        with patch.dict(sys.modules, {"yfinance": fake_yf}):
+            results = updater._fetch_yfinance({"sTSLA": "TSLA", "sSPY": "SPY"}, datetime.now(UTC))
+        by_symbol = {r.symbol: r.price_usd for r in results}
+        assert by_symbol["sTSLA"] == 250.0
+        assert by_symbol["sSPY"] == 500.0
+
+    def test_import_error_returns_empty(self, updater):
+        fake_yf = MagicMock()
+        fake_yf.download = MagicMock(side_effect=ImportError("yfinance missing"))
+        # Force the `import yfinance as yf` inside to raise.
+        with patch.dict(sys.modules, {"yfinance": None}):
+            results = updater._fetch_yfinance({"sTSLA": "TSLA"}, datetime.now(UTC))
+        assert results == []
+
+
+class TestFetchPrices:
+    async def test_combines_equity_and_crypto(self, updater):
+        now = datetime.now(UTC)
+        equities = [AssetPrice(symbol="sTSLA", price_usd=250.0, timestamp=now, source="yfinance")]
+        crypto = [AssetPrice(symbol="sBTC", price_usd=65000.0, timestamp=now, source="coingecko")]
+        with (
+            patch.object(updater, "_fetch_yfinance", return_value=equities),
+            patch.object(updater, "_fetch_crypto", AsyncMock(return_value=crypto)),
+        ):
+            prices = await updater.fetch_prices()
+        symbols = {p.symbol for p in prices}
+        assert {"sTSLA", "sBTC"} <= symbols
+        # fetch_prices populates the per-instance cache.
+        assert updater.get_cached_price("sTSLA").price_usd == 250.0
+        assert updater.get_cached_price("sBTC").price_usd == 65000.0
+
+    def test_get_cached_price_miss_returns_none(self, updater):
+        assert updater.get_cached_price("sNOPE") is None
+
+
+class TestFetchCrypto:
+    async def test_parses_coingecko_response(self, updater):
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"bitcoin": {"usd": 64000.0}})
+        get_cm = MagicMock()
+        get_cm.__aenter__ = AsyncMock(return_value=resp)
+        get_cm.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=get_cm)
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+        by_symbol = {r.symbol: r.price_usd for r in results}
+        assert by_symbol["sBTC"] == 64000.0
+
+    async def test_coingecko_error_is_swallowed(self, updater):
+        # A non-200 / raising session must not crash — returns [] for that symbol.
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(side_effect=RuntimeError("network down"))
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+        with patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+        assert results == []
+
+
+class TestFetchMarketSnapshot:
+    async def test_assembles_prices_vix_and_mas(self, updater):
+        now = datetime.now(UTC)
+        equities = [AssetPrice(symbol="sSPY", price_usd=500.0, timestamp=now, source="yfinance")]
+        with (
+            patch.object(updater, "fetch_prices", AsyncMock(return_value=equities)),
+            patch.object(updater, "_fetch_yfinance_single", AsyncMock(return_value=14.5)),
+            patch.object(updater, "_fetch_sp500_moving_averages", return_value={"ma50": 4900.0, "ma200": 4800.0}),
+        ):
+            snap = await updater.fetch_market_snapshot()
+        assert snap.vix == 14.5
+        assert snap.sp500_ma50 == 4900.0
+        assert snap.sp500_ma200 == 4800.0
+        assert snap.prices["sSPY"] == 500.0
+        # VIX + MAs present → the snapshot reports it carries regime signals.
+        assert snap.has_regime_signals is True
+
+
+class TestFetchYfinanceSingle:
+    async def test_returns_last_close(self, updater):
+        import pandas as pd
+
+        close = pd.DataFrame({"^VIX": [13.2, 14.0]})
+        frame = MagicMock()
+        frame.empty = False
+        frame.__getitem__ = MagicMock(side_effect=lambda k: close if k == "Close" else None)
+        fake_yf = MagicMock()
+        fake_yf.download = MagicMock(return_value=frame)
+        with patch.dict(sys.modules, {"yfinance": fake_yf}):
+            val = await updater._fetch_yfinance_single("^VIX")
+        assert val == 14.0
+
+    async def test_swallows_error_returns_none(self, updater):
+        fake_yf = MagicMock()
+        fake_yf.download = MagicMock(side_effect=RuntimeError("yf boom"))
+        with patch.dict(sys.modules, {"yfinance": fake_yf}):
+            assert await updater._fetch_yfinance_single("^VIX") is None
+
+
+class TestSp500MovingAverages:
+    def test_computes_rolling_means(self, updater):
+        import pandas as pd
+
+        hist = pd.DataFrame({"Close": list(range(1, 301))})
+        ticker = MagicMock()
+        ticker.history = MagicMock(return_value=hist)
+        fake_yf = MagicMock()
+        fake_yf.Ticker = MagicMock(return_value=ticker)
+        with patch.dict(sys.modules, {"yfinance": fake_yf}):
+            mas = updater._fetch_sp500_moving_averages()
+        # rolling(50)/(200) means over 1..300 → finite numbers, ma200 < ma50.
+        assert mas["ma50"] > mas["ma200"] > 0
+
+    def test_empty_history_returns_empty_dict(self, updater):
+        import pandas as pd
+
+        ticker = MagicMock()
+        ticker.history = MagicMock(return_value=pd.DataFrame())
+        fake_yf = MagicMock()
+        fake_yf.Ticker = MagicMock(return_value=ticker)
+        with patch.dict(sys.modules, {"yfinance": fake_yf}):
+            assert updater._fetch_sp500_moving_averages() == {}
+
+
+class TestGetCirclePublicKey:
+    async def test_fetches_and_caches(self, monkeypatch, updater):
+        monkeypatch.setenv("CIRCLE_API_KEY", "key")
+        upd = OracleUpdater()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"data": {"publicKey": "PEM"}})
+        get_cm = MagicMock()
+        get_cm.__aenter__ = AsyncMock(return_value=resp)
+        get_cm.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=get_cm)
+        key = await upd._get_circle_public_key(session)
+        assert key == "PEM"
+        # Cached → second call doesn't re-fetch.
+        session.get.reset_mock()
+        assert await upd._get_circle_public_key(session) == "PEM"
+        session.get.assert_not_called()
+
+    async def test_non_200_returns_none(self, updater):
+        resp = MagicMock(status=500)
+        get_cm = MagicMock()
+        get_cm.__aenter__ = AsyncMock(return_value=resp)
+        get_cm.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=get_cm)
+        assert await updater._get_circle_public_key(session) is None
+
+
+class TestPushNoCredentials:
+    async def test_returns_none_without_creds(self, monkeypatch):
+        for var in ("CIRCLE_API_KEY", "CIRCLE_ENTITY_SECRET", "WALLET_ID"):
+            monkeypatch.delenv(var, raising=False)
+        upd = OracleUpdater()
+        price = AssetPrice(symbol="sTSLA", price_usd=100.0, timestamp=datetime.now(UTC), source="yfinance")
+        # No creds → early return None, nothing submitted.
+        assert await upd.push_prices_on_chain([price]) is None
+
+    async def test_push_aborts_when_public_key_unavailable(self, monkeypatch):
+        for var, val in (("CIRCLE_API_KEY", "k"), ("CIRCLE_ENTITY_SECRET", "ab" * 32), ("WALLET_ID", "w")):
+            monkeypatch.setenv(var, val)
+        upd = OracleUpdater()
+        session = MagicMock()
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+        price = AssetPrice(symbol="sTSLA", price_usd=100.0, timestamp=datetime.now(UTC), source="yfinance")
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch.object(upd, "_get_circle_public_key", AsyncMock(return_value=None)),
+        ):
+            assert await upd.push_prices_on_chain([price]) is None
+
+
+class TestModuleConstants:
+    def test_symbol_maps_present(self):
+        from archimedes.chain.oracle_updater import CRYPTO_MAP, YFINANCE_MAP
+
+        assert YFINANCE_MAP["sTSLA"] == "TSLA"
+        assert CRYPTO_MAP["sBTC"] == "bitcoin"
+
+    def test_circle_constants(self):
+        from archimedes.chain.oracle_updater import CIRCLE_API_BASE, CIRCLE_BLOCKCHAIN
+
+        assert CIRCLE_BLOCKCHAIN == "ARC-TESTNET"
+        assert CIRCLE_API_BASE.startswith("https://")

--- a/backend/tests/chain/test_oracle_updater_fetch.py
+++ b/backend/tests/chain/test_oracle_updater_fetch.py
@@ -53,9 +53,8 @@ class TestFetchYfinance:
         assert by_symbol["sSPY"] == 500.0
 
     def test_import_error_returns_empty(self, updater):
-        fake_yf = MagicMock()
-        fake_yf.download = MagicMock(side_effect=ImportError("yfinance missing"))
-        # Force the `import yfinance as yf` inside to raise.
+        # Force the `import yfinance as yf` inside to raise (no mock object needed —
+        # mapping the module to None makes the import statement itself raise).
         with patch.dict(sys.modules, {"yfinance": None}):
             results = updater._fetch_yfinance({"sTSLA": "TSLA"}, datetime.now(UTC))
         assert results == []

--- a/backend/tests/test_agent_runner_tick.py
+++ b/backend/tests/test_agent_runner_tick.py
@@ -1,0 +1,330 @@
+"""StrategyRunner tick-pipeline coverage (#738 Tier-A + behavior c).
+
+Target: backend/archimedes/chain/agent_runner.py
+Complements test_agent_runner.py (deterministic _compute_trades / regime /
+dedup) by exercising the *full tick pipeline* and the on-chain commit/reveal +
+vault-discovery surface:
+
+  behavior c — one tick (mocked chain/redis/oracle) flows
+  strategies → signals → regime classification → position-scale (portfolio
+  constructor) → target allocations → per-vault processing.
+
+Plus: _get_managed_vaults, _discover_new_vaults, _commit_trace / _reveal_trace
+(DRY_RUN so no on-chain), and the run() loop body.
+
+Hermetic: every boundary (strategy provider/evaluator, oracle, regime detector,
+portfolio constructor, chain executor, trace publisher, Redis AgentStateStore)
+is mocked. No network, no Arc RPC, no Circle, no Redis.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.models.portfolio import Portfolio, PortfolioHolding, TargetAllocation
+from archimedes.models.regime import ConsensusLabel, EnsembleConsensus, Regime, RegimeClassification
+from archimedes.services.strategy_signal_evaluator import AssetSignal, Signal, StrategySignals
+
+# ── Builders ──────────────────────────────────────────────────
+
+
+def _signals(asset: str = "sSPY", weight: float = 0.6, sig: Signal = Signal.LONG) -> StrategySignals:
+    return StrategySignals(
+        strategy_id="faber_001",
+        strategy_name="Faber SMA200",
+        paper_title="A Quantitative Approach to Tactical Asset Allocation",
+        signals=[
+            AssetSignal(
+                strategy_id="faber_001",
+                strategy_name="Faber SMA200",
+                asset=asset,
+                signal=sig,
+                weight=weight,
+                reason="Price above SMA200",
+            )
+        ],
+        paper_arxiv_id="0001",
+    )
+
+
+def _allocs(**weights: float) -> list[TargetAllocation]:
+    return [TargetAllocation(symbol=s, token_address="", weight=w, strategy_ids=[]) for s, w in weights.items()]
+
+
+def _portfolio(total: float = 1000.0) -> Portfolio:
+    return Portfolio(
+        vault_address="0xVault",
+        total_value_usdc=total,
+        holdings=[PortfolioHolding(symbol="USDC", token_address="0xusdc", amount=total, weight=1.0, value_usdc=total)],
+        risk_profile="moderate",
+    )
+
+
+def _regime() -> RegimeClassification:
+    cls = MagicMock(spec=RegimeClassification)
+    cls.regime = Regime.RISK_ON
+    cls.confidence = 0.9
+    cls.regime_changed = False
+    cls.signals = MagicMock(vix_level=13.0)
+    return cls
+
+
+def _consensus() -> EnsembleConsensus:
+    return EnsembleConsensus(flat_pct=0.1, signal_count=3, label=ConsensusLabel.RISK_ON)
+
+
+@pytest.fixture
+def runner_env(monkeypatch):
+    """A StrategyRunner with every chain/redis/oracle boundary mocked.
+
+    Yields (runner, mocks-dict). DRY_RUN is forced on so the commit/reveal path
+    builds + hashes traces without touching the chain.
+    """
+    monkeypatch.setattr("archimedes.chain.agent_runner.DRY_RUN", True)
+    monkeypatch.setattr("archimedes.chain.agent_runner.EXPLICIT_VAULTS", "")
+    with (
+        patch("archimedes.chain.agent_runner.chain_client") as mock_client,
+        patch("archimedes.chain.agent_runner.chain_executor") as mock_executor,
+        patch("archimedes.chain.agent_runner.trace_publisher") as mock_publisher,
+        patch("archimedes.chain.agent_runner.default_provider") as mock_provider,
+        patch("archimedes.chain.agent_runner.AgentStateStore") as mock_state_cls,
+        patch("archimedes.chain.agent_runner.strategy_evaluator") as mock_eval,
+    ):
+        mock_client.settings = MagicMock(
+            synth_addresses={"sSPY": "0xsspy", "sGOLD": "0xsgold"},
+            usdc_address="0xusdc",
+            oracle_addresses={"sSPY": "0xoraclespy"},
+        )
+        mock_client.to_checksum = lambda a: a
+        # Strategy provider returns a couple of strategies.
+        strat = MagicMock(paper_title="Faber SMA200", id="faber_001")
+        mock_provider.return_value.list_strategies.return_value = [strat]
+
+        # Evaluator: signals + aggregate weights.
+        mock_eval.evaluate_strategies.return_value = [_signals()]
+        mock_eval.aggregate_signals.return_value = {"sSPY": 0.6, "USDC": 0.4}
+
+        # Redis state store: all awaitables no-op.
+        state = mock_state_cls.return_value
+        state.save_regime = AsyncMock()
+        state.save_ensemble_consensus = AsyncMock()
+        state.save_heartbeat = AsyncMock()
+        state.save_trace = AsyncMock()
+        state.get_last_trace = AsyncMock(return_value=None)
+        state.save_last_rebalance = AsyncMock()
+
+        from archimedes.chain.agent_runner import StrategyRunner
+
+        runner = StrategyRunner()
+        # Position-scaler (portfolio constructor) returns scaled allocations.
+        runner.portfolio_constructor = MagicMock()
+        runner.portfolio_constructor.construct.return_value = _allocs(sSPY=0.6, USDC=0.4)
+        # Regime detector + oracle snapshot.
+        runner.oracle = MagicMock()
+        runner.oracle.fetch_market_snapshot = AsyncMock(return_value=MagicMock(has_regime_signals=True))
+        runner.regime_detector = MagicMock()
+        runner.regime_detector.classify.return_value = _regime()
+
+        yield (
+            runner,
+            {
+                "client": mock_client,
+                "executor": mock_executor,
+                "publisher": mock_publisher,
+                "eval": mock_eval,
+                "state": state,
+            },
+        )
+
+
+# ── behavior c: full tick pipeline ────────────────────────────
+
+
+class TestTickPipeline:
+    async def test_tick_flows_signals_regime_scale_allocations(self, runner_env):
+        runner, m = runner_env
+        # One managed vault with an empty (USDC-only) portfolio.
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        # No metadata → legacy/global-consensus path.
+        runner._get_vault_strategy_ids = MagicMock(return_value=None)
+
+        await runner.tick()
+
+        # Pipeline stages all fired:
+        m["eval"].evaluate_strategies.assert_called_once()
+        m["eval"].aggregate_signals.assert_called()  # global aggregate
+        runner.regime_detector.classify.assert_called_once()  # regime classified
+        # Position-scaler (portfolio constructor) consumed regime + consensus.
+        runner.portfolio_constructor.construct.assert_called()
+        ckw = runner.portfolio_constructor.construct.call_args.kwargs
+        assert ckw["regime"] is not None
+        assert isinstance(ckw["ensemble_consensus"], EnsembleConsensus)
+        assert ckw["base_weights"] == {"sSPY": 0.6, "USDC": 0.4}
+        # Regime + consensus persisted to Redis.
+        m["state"].save_regime.assert_awaited()
+        m["state"].save_ensemble_consensus.assert_awaited()
+        m["state"].save_heartbeat.assert_awaited()
+
+    async def test_tick_no_strategies_returns_early(self, runner_env):
+        runner, m = runner_env
+        runner.provider.list_strategies = MagicMock(return_value=[])
+        await runner.tick()
+        # Bailed before evaluating signals.
+        m["eval"].evaluate_strategies.assert_not_called()
+
+    async def test_tick_no_vaults_returns_after_regime(self, runner_env):
+        runner, m = runner_env
+        m["executor"].get_all_vaults = AsyncMock(return_value=[])
+        await runner.tick()
+        # Regime still classified, but no vault processed → no portfolio reads.
+        runner.regime_detector.classify.assert_called_once()
+        m["executor"].read_portfolio.assert_not_called()
+
+    async def test_tick_scoped_vault_filters_signals(self, runner_env):
+        runner, m = runner_env
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        # Vault scoped to the strategy that produced signals → scoped path.
+        runner._get_vault_strategy_ids = MagicMock(return_value=["faber_001"])
+        await runner.tick()
+        # aggregate_signals called for the per-vault scope (≥2 total calls).
+        assert m["eval"].aggregate_signals.call_count >= 2
+
+
+# ── vault discovery ───────────────────────────────────────────
+
+
+class TestVaultDiscovery:
+    async def test_get_managed_vaults_from_factory(self, runner_env):
+        runner, m = runner_env
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xA", "0xB"])
+        vaults = await runner._get_managed_vaults()
+        assert set(vaults) == {"0xA", "0xB"}
+        assert runner._known_vaults == {"0xA", "0xB"}
+
+    async def test_get_managed_vaults_factory_error_returns_empty(self, runner_env):
+        runner, m = runner_env
+        m["executor"].get_all_vaults = AsyncMock(side_effect=ConnectionError("RPC down"))
+        assert await runner._get_managed_vaults() == []
+
+    async def test_discover_new_vaults_returns_only_unseen(self, runner_env):
+        runner, m = runner_env
+        runner._known_vaults = {"0xA"}
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xA", "0xB"])
+        new = await runner._discover_new_vaults()
+        assert new == ["0xB"]
+        assert "0xB" in runner._known_vaults
+
+    async def test_discover_new_vaults_none_when_all_known(self, runner_env):
+        runner, m = runner_env
+        runner._known_vaults = {"0xA", "0xB"}
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xA", "0xB"])
+        assert await runner._discover_new_vaults() == []
+
+    async def test_discover_new_vaults_factory_error_returns_empty(self, runner_env):
+        runner, m = runner_env
+        m["executor"].get_all_vaults = AsyncMock(side_effect=RuntimeError("boom"))
+        assert await runner._discover_new_vaults() == []
+
+
+# ── commit / reveal (DRY_RUN) ─────────────────────────────────
+
+
+class TestCommitRevealDryRun:
+    @staticmethod
+    def _trade():
+        from archimedes.models.portfolio import TradeDirection, TradeOrder
+
+        return TradeOrder(
+            symbol="sSPY",
+            token_address="0xsspy",
+            direction=TradeDirection.BUY,
+            amount=100.0,
+            estimated_usdc_value=100.0,
+        )
+
+    async def test_commit_trace_dry_run_builds_and_hashes(self, runner_env):
+        runner, _ = runner_env
+        trace, trace_id, commit_tx, commit_block = await runner._commit_trace(
+            "0xVault",
+            [self._trade()],
+            [_signals()],
+            "risk_on",
+            _consensus(),
+            "tick-1",
+            "reasoning text",
+            _portfolio(),
+        )
+        # DRY_RUN → no on-chain ids, but the canonical trace IS built + hashed.
+        assert trace_id is None and commit_tx is None and commit_block is None
+        assert trace.trace_hash and len(trace.trace_hash.removeprefix("0x")) == 64
+        assert trace.decision_type.value == "rebalance"
+
+    async def test_reveal_trace_dry_run_persists_off_chain(self, runner_env):
+        runner, m = runner_env
+        # Build a trace via commit, then reveal it (DRY_RUN → no IPFS/chain).
+        trace, trace_id, *_ = await runner._commit_trace(
+            "0xVault", [self._trade()], [_signals()], "risk_on", _consensus(), "t", "r", _portfolio()
+        )
+        await runner._reveal_trace(trace, trace_id, "tick-1", tx_hashes=[])
+        # Off-chain persist happened with temporal_binding_source = "none" (dry-run).
+        m["state"].save_trace.assert_awaited()
+        saved = m["state"].save_trace.await_args.args[0]
+        assert saved["temporal_binding_source"] == "none"
+        assert saved["is_verified"] is False
+
+
+# ── _publish_trace (legacy SKIP path) ─────────────────────────
+
+
+class TestPublishTrace:
+    async def test_empty_vault_publishes_skip_trace(self, runner_env):
+        runner, m = runner_env
+        # Empty portfolio → _process_vault publishes an "empty_vault" SKIP trace.
+        m["executor"].read_portfolio = AsyncMock(
+            return_value=Portfolio(vault_address="0xVault", total_value_usdc=0.0, holdings=[])
+        )
+        spy = AsyncMock(wraps=runner._publish_trace)
+        runner._publish_trace = spy
+        await runner._process_vault("0xVault", _allocs(sSPY=0.6), [_signals()], "risk_on", _consensus(), "tick-1")
+        spy.assert_awaited_once()
+        # The trigger names the empty-vault decision.
+        assert spy.await_args.args[2] == "empty_vault"
+        # The trace was hashed + persisted off-chain (DRY_RUN → no anchor).
+        m["state"].save_trace.assert_awaited()
+        saved = m["state"].save_trace.await_args.args[0]
+        assert saved["decision_type"] == "skip"
+        assert saved["is_verified"] is False
+        assert len(saved["trace_hash"].removeprefix("0x")) == 64
+
+
+# ── run() loop body ───────────────────────────────────────────
+
+
+class TestRunLoop:
+    async def test_run_executes_one_tick_then_sleeps(self, runner_env, monkeypatch):
+        runner, m = runner_env
+        m["client"].is_connected = AsyncMock(return_value=True)
+
+        class _Stop(Exception):
+            pass
+
+        # Patch the module symbols run() uses, plus a sleep that breaks the loop.
+        with (
+            patch("archimedes.chain.agent_runner.StrategyRunner", return_value=runner),
+            patch("archimedes.chain.agent_runner.chain_client", m["client"]),
+            patch("archimedes.chain.agent_runner.asyncio.sleep", AsyncMock(side_effect=_Stop)),
+        ):
+            runner.tick = AsyncMock()
+            runner.state.save_heartbeat = AsyncMock()
+            from archimedes.chain.agent_runner import run
+
+            with pytest.raises(_Stop):
+                await run()
+            runner.tick.assert_awaited_once()

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +22,13 @@ from archimedes.services.backtest_repository import insert_backtest_if_missing
 from fastapi.testclient import TestClient
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "analytics_artifact_buy_hold.json"
+
+
+def _utcnow():
+    """Timezone-aware UTC now — AssetPrice requires a tz-aware timestamp."""
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC)
 
 
 @pytest.fixture(autouse=True)
@@ -59,6 +67,71 @@ def client(tmp_path, monkeypatch):
 
         tc = TestClient(app)
         yield tc
+
+
+# ── Tier-B unlock: a real chain_client.settings (#738) ───────────────
+# ConfigService / AssetService / swap routes read addresses off
+# chain_client.settings (NOT chain_client directly). The real ChainSettings is
+# constructed at module-init from .env; under the hermetic gate there is no
+# .env, so this namespace substitutes the exact fields the route layer reads.
+#
+# Why a SEPARATE fixture (not baked into `client`): the bare `client` fixture
+# leaves `chain_client.settings` as an auto-MagicMock, which some pre-existing
+# tests rely on (e.g. the advisor optimizer fails fast against the mock and
+# falls back to a budget-normalized allocation). Installing a real settings
+# object only for the routes that need it keeps every other test's behavior
+# exactly as it was on main.
+_SETTINGS_NAMESPACE = SimpleNamespace(
+    usdc_address="0x3600000000000000000000000000000000000000",
+    synthetic_factory_address="",
+    amm_router_address="0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4",
+    vault_factory_address="0xca873414070844aeb98b0bf1051f81969c79cc32",
+    reasoning_trace_registry_address="0x42d8a23edb897cbee203e9fa197eb05ab5106ca6",
+    asset_registry_address="0x2d44550711137916df6175587d17886281a0fbc7",
+    stsla_oracle_address="0xe1c9f2b11be97097223a66a188fca541e07873a6",
+    chain_id=5042002,
+    arc_rpc_url="https://rpc.testnet.arc.network",
+    synth_addresses={
+        "sTSLA": "0xd514cd27baf762c650536765cde9b61c876abacd",
+        "sSPY": "0x6fea38dedea0c6bb66ce93e5383c34385d8b889f",
+    },
+    oracle_addresses={
+        "sTSLA": "0xe1c9f2b11be97097223a66a188fca541e07873a6",
+        "sSPY": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
+    },
+)
+
+
+@pytest.fixture()
+def chain_settings_client(client, monkeypatch):
+    """`client` with a real `chain_client.settings` namespace + to_checksum.
+
+    Unblocks the Tier-B routes (config/contracts, assets, swap/quote) that read
+    `chain_client.settings.*` at request time. `to_checksum` is the only
+    ChainClient method those paths call; a pass-through is safe because every
+    seeded address is already checksum-shaped (or its case is irrelevant to the
+    assertion).
+
+    Bindings matter: ``config_service`` captures ``chain_client`` at MODULE
+    import time, so the `client` fixture's `patch("archimedes.chain.client.
+    chain_client")` (which only rebinds the *client module* attribute) does not
+    reach it. ``asset_service`` / ``swap_routes`` re-import inside the function,
+    so they see the patched mock. We set the settings on the patched mock AND
+    rebind ``config_service.chain_client`` to it so every Tier-B path reads the
+    same namespace.
+    """
+    from archimedes.chain.client import chain_client as patched_client
+    from archimedes.chain.contracts import get_contract_loader
+
+    patched_client.settings = _SETTINGS_NAMESPACE
+    patched_client.to_checksum = lambda addr: addr
+    # Point config_service's module-level binding at the same patched client.
+    monkeypatch.setattr("archimedes.services.config_service.chain_client", patched_client)
+    # The loader is @lru_cache'd and captures chain_client.settings at build
+    # time; clear it so a loader cached by an earlier test can't leak a stale
+    # settings reference into these routes.
+    get_contract_loader.cache_clear()
+    return client
 
 
 @pytest.fixture()
@@ -255,18 +328,137 @@ class TestSelectionBiasRoutes:
 
 
 class TestConfigRoutes:
-    def test_contracts(self, client):
-        # ConfigService reads contract addresses from chain_client.settings
-        # which is initialized at import time — requires deeper mocking.
-        # The /api/config/contracts endpoint is tested live on EC2.
-        pytest.skip("Requires chain_client.settings module-level init mocking")
+    def test_contracts(self, chain_settings_client):
+        """/api/config/contracts surfaces the deployed addresses from
+        chain_client.settings.
+
+        Un-skipped by the Tier-B unlock (#738): `chain_settings_client` installs
+        a real `chain_client.settings` namespace, so ConfigService reads the
+        addresses without a live chain. The contract loader is mocked so pool /
+        vault enumeration returns empty lists deterministically — the address
+        fields are what this endpoint guarantees.
+        """
+        mock_loader = MagicMock()
+        mock_loader.amm_router.functions.getAllPools.return_value.call = AsyncMock(return_value=[])
+        mock_loader.vault_factory.functions.getVaults.return_value.call = AsyncMock(return_value=[])
+        with patch("archimedes.chain.contracts.get_contract_loader", return_value=mock_loader):
+            resp = chain_settings_client.get("/api/config/contracts")
+        assert resp.status_code == 200
+        data = resp.json()
+        # The settings-sourced addresses must flow straight through.
+        assert data["usdc"] == "0x3600000000000000000000000000000000000000"
+        assert data["amm_router"] == "0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4"
+        assert data["vault_factory"] == "0xca873414070844aeb98b0bf1051f81969c79cc32"
+        assert data["chain_id"] == 5042002
+        # Synthetics map omits empty addresses; the two seeded synths must appear.
+        assert "sTSLA" in data["synthetics"]
+        # Pool/vault enumeration returns empty under the mocked loader.
+        assert data["pools"] == {}
+        assert data["vaults"] == {}
 
 
 class TestAssetRoutes:
-    def test_list_assets(self, client):
-        # AssetService reads from on-chain via chain_client — requires deeper mocking.
-        # The /api/assets/ endpoint is tested live on EC2.
-        pytest.skip("Requires chain_client.settings module-level init mocking")
+    def test_list_assets(self, chain_settings_client):
+        """/api/assets/ composes chain settings + oracle prices into the asset list.
+
+        Un-skipped by the Tier-B unlock (#738). The oracle HTTP boundary
+        (OracleUpdater.fetch_prices, which hits yfinance/CoinGecko) is mocked so
+        the test is hermetic; USDC plus the configured synths must surface.
+        """
+        from archimedes.models.asset import AssetPrice
+
+        priced = [
+            AssetPrice(symbol="sTSLA", price_usd=185.50, timestamp=_utcnow(), source="yfinance"),
+        ]
+        with patch(
+            "archimedes.chain.oracle_updater.OracleUpdater.fetch_prices",
+            new=AsyncMock(return_value=priced),
+        ):
+            resp = chain_settings_client.get("/api/assets/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assets = data["assets"]
+        by_symbol = {a["symbol"]: a for a in assets}
+        # USDC is always present, pegged at $1 with 6 decimals.
+        assert "USDC" in by_symbol
+        assert by_symbol["USDC"]["price_usd"] == 1.0
+        assert by_symbol["USDC"]["decimals"] == 6
+        # The configured synths surface; the priced one carries the oracle price.
+        assert "sTSLA" in by_symbol
+        assert by_symbol["sTSLA"]["price_usd"] == 185.50
+        assert by_symbol["sTSLA"]["decimals"] == 18
+        # A synth with no oracle price falls back to 0.0 (not a fabricated value).
+        assert by_symbol["sSPY"]["price_usd"] == 0.0
+
+
+class TestSwapRoutes:
+    def test_swap_quote_returns_amount_out_fee_and_price_impact(self, chain_settings_client):
+        """/api/swap/quote previews a swap via the AMM router (#738 behavior d).
+
+        Hermetic: the contract loader's amm_router is mocked so getAmountOut
+        returns deterministic raw amounts. The quote must expose amount_out, a
+        fee, a non-negative price impact, and a slippage-bounded min_amount_out.
+        """
+        usdc = "0x3600000000000000000000000000000000000000"
+        stsla = "0xd514cd27baf762c650536765cde9b61c876abacd"
+
+        def _amount_out_for(amount_in_raw: int) -> int:
+            # USDC (6 dec) → sTSLA (18 dec). Spot ~ 1 USDC → 0.005 sTSLA.
+            # Larger trades get slightly less per unit (positive price impact):
+            #   100 USDC (1e8 raw) → 0.49 sTSLA (4.9e17 raw)
+            #     1 USDC (1e6 raw) → 0.005 sTSLA (5e15 raw) — the spot quote.
+            if amount_in_raw == 100_000_000:
+                return 490_000_000_000_000_000
+            return 5_000_000_000_000_000
+
+        mock_router = MagicMock()
+        # Route calls produce a contract-fn object whose .call() awaits the
+        # deterministic amount-out for that raw input — mirrors web3's
+        # `router.functions.getAmountOut(a, b, n).call()` shape.
+        mock_router.functions.getAmountOut = MagicMock(
+            side_effect=lambda _ti, _to, amount_in_raw: SimpleNamespace(
+                call=AsyncMock(return_value=_amount_out_for(amount_in_raw))
+            )
+        )
+
+        mock_loader = MagicMock()
+        type(mock_loader).amm_router = property(lambda self: mock_router)
+
+        with patch("archimedes.chain.contracts.get_contract_loader", return_value=mock_loader):
+            resp = chain_settings_client.get(
+                "/api/swap/quote",
+                params={"token_in": usdc, "token_out": stsla, "amount_in": 100.0},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["token_in"] == usdc
+        assert data["token_out"] == stsla
+        assert data["amount_in"] == 100.0
+        # 4.9e17 raw / 1e18 = 0.49 sTSLA out.
+        assert data["amount_out"] == pytest.approx(0.49)
+        assert data["fee_pct"] == 0.3
+        assert data["price_impact_pct"] >= 0.0
+        # min_amount_out applies the 0.5% slippage floor.
+        assert data["min_amount_out"] == pytest.approx(0.49 * 0.995)
+
+    def test_swap_quote_bad_pair_returns_400(self, chain_settings_client):
+        """A router failure is surfaced as a generic 400 (no RPC-internal leak)."""
+        mock_router = MagicMock()
+        mock_router.functions.getAmountOut.return_value.call = AsyncMock(side_effect=RuntimeError("no pool for pair"))
+        mock_loader = MagicMock()
+        type(mock_loader).amm_router = property(lambda self: mock_router)
+        with patch("archimedes.chain.contracts.get_contract_loader", return_value=mock_loader):
+            resp = chain_settings_client.get(
+                "/api/swap/quote",
+                params={
+                    "token_in": "0x3600000000000000000000000000000000000000",
+                    "token_out": "0xd514cd27baf762c650536765cde9b61c876abacd",
+                    "amount_in": 1.0,
+                },
+            )
+        assert resp.status_code == 400
+        # The raw exception text must NOT leak to the client.
+        assert "no pool for pair" not in resp.json()["detail"]
 
 
 class TestRegimeRoutes:

--- a/backend/tests/test_trace_hash_tamper.py
+++ b/backend/tests/test_trace_hash_tamper.py
@@ -1,0 +1,122 @@
+"""Trace-hash tamper detection (#738 behavior a).
+
+Target: backend/archimedes/models/trace.py — ReasoningTrace.compute_hash()
+
+The reasoning-trace hash is the on-chain integrity anchor: anyone can recompute
+keccak256 over the canonical content and compare against the value committed to
+the ReasoningTraceRegistry. The load-bearing property is *tamper evidence* — if
+any hashed field changes, the hash MUST change; if a non-hashed field (e.g. the
+on-chain tx hash, added after the fact) changes, the hash MUST NOT change (so a
+committed hash stays valid through the reveal phase).
+
+Hermetic: pure in-memory dataclass + keccak; no chain, no network.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from archimedes.models.trace import DecisionType, ReasoningTrace
+
+
+def _trace(**overrides) -> ReasoningTrace:
+    base = {
+        "id": "trace-001",
+        "vault_address": "0xVault00000000000000000000000000000000abcd",
+        "decision_type": DecisionType.REBALANCE,
+        "trigger": "strategy_signal_drift",
+        "timestamp": datetime(2026, 6, 28, 12, 0, 0, tzinfo=UTC),
+        "market_context": {"regime": "risk_on"},
+        "portfolio_before": {"aum_usdc": 1000.0},
+        "reasoning": "Momentum positive; rebalance into sSPY.",
+        "confidence": 0.8,
+        "trades_executed": [{"symbol": "sSPY", "direction": "buy", "amount": 100.0}],
+        "strategies_referenced": ["faber_001"],
+        "consulted_paper_hashes": ["arxiv:0001:deadbeef"],
+    }
+    base.update(overrides)
+    return ReasoningTrace(**base)
+
+
+class TestComputeHashDeterminism:
+    def test_same_content_same_hash(self):
+        h1 = _trace().compute_hash()
+        h2 = _trace().compute_hash()
+        assert h1 == h2
+        # keccak256 hex is 32 bytes → 64 hex chars (+ "0x").
+        assert len(h1.removeprefix("0x")) == 64
+
+    def test_compute_hash_sets_trace_hash_attr(self):
+        t = _trace()
+        assert t.trace_hash == ""
+        h = t.compute_hash()
+        assert t.trace_hash == h
+
+
+class TestComputeHashTamperEvidence:
+    @pytest.mark.parametrize(
+        ("field", "mutated"),
+        [
+            ("reasoning", "TAMPERED — sell everything."),
+            ("confidence", 0.2),
+            ("trigger", "manual_override"),
+            ("vault_address", "0xATTACKER000000000000000000000000000000ff"),
+            ("market_context", {"regime": "crisis"}),
+            ("trades_executed", [{"symbol": "sBTC", "direction": "sell", "amount": 9999.0}]),
+            ("strategies_referenced", ["evil_999"]),
+            ("consulted_paper_hashes", ["arxiv:9999:cafebabe"]),
+        ],
+    )
+    def test_mutating_a_hashed_field_changes_the_hash(self, field, mutated):
+        original = _trace().compute_hash()
+        tampered = _trace(**{field: mutated}).compute_hash()
+        assert tampered != original, f"Mutating hashed field {field!r} must change the trace hash"
+
+    def test_timestamp_is_part_of_the_hash(self):
+        a = _trace(timestamp=datetime(2026, 6, 28, 12, 0, 0, tzinfo=UTC)).compute_hash()
+        b = _trace(timestamp=datetime(2026, 6, 28, 12, 0, 1, tzinfo=UTC)).compute_hash()
+        assert a != b
+
+    def test_non_hashed_fields_do_not_change_the_hash(self):
+        """The on-chain anchoring fields added AFTER the commit (arc_tx_hash,
+        commit/reveal tx hashes + block numbers, trade tx/block) are intentionally
+        OUTSIDE _HASH_FIELDS so the committed hash survives the reveal phase.
+        Setting them must NOT move the hash.
+
+        (Note: portfolio_after IS in _HASH_FIELDS, so it is deliberately excluded
+        here — it is part of the canonical hashed content.)"""
+        baseline = _trace()
+        baseline_hash = baseline.compute_hash()
+
+        annotated = _trace()
+        annotated.arc_tx_hash = "0xANCHOR"
+        annotated.commit_tx_hash = "0xCOMMIT"
+        annotated.commit_block_number = 100
+        annotated.reveal_tx_hash = "0xREVEAL"
+        annotated.reveal_block_number = 102
+        annotated.trade_tx_hash = "0xTRADE"
+        annotated.trade_block_number = 101
+        annotated.expected_outcome = "Outperform buy-and-hold"
+
+        assert annotated.compute_hash() == baseline_hash
+
+    def test_portfolio_after_is_part_of_the_hash(self):
+        """portfolio_after IS in _HASH_FIELDS — changing it changes the hash.
+
+        This documents the actual canonical set and guards against silently
+        dropping portfolio_after from the hash (which would let a settled
+        portfolio be edited without detection)."""
+        a = _trace(portfolio_after={"tx_hashes": []}).compute_hash()
+        b = _trace(portfolio_after={"tx_hashes": ["0xTRADE"]}).compute_hash()
+        assert a != b
+
+    def test_recompute_after_mutation_detects_tamper(self):
+        """End-to-end: commit a hash, then mutate a hashed field — recomputing
+        yields a different value, which is exactly how on-chain verifyTrace
+        would catch a tampered off-chain record."""
+        t = _trace()
+        committed = t.compute_hash()
+        # Adversary edits the persisted reasoning after the fact.
+        t.reasoning = "Approved by the fund manager (forged)."
+        assert t.compute_hash() != committed


### PR DESCRIPTION
## Summary

Hermetic test-coverage push for the funds-adjacent `chain/` modules plus the
Tier-B `chain_client.settings` unlock that frees the previously-blocked route
tests. All new tests mock at boundaries (chain client, Circle signer, oracle
HTTP, redis, contract loader) — no live chain, no network, no `.env`.

`Closes #738`

## The enabling unlock

- New `chain_settings_client` fixture in `backend/tests/test_api_routes.py`
  installs a real `chain_client.settings` namespace (+ `to_checksum`) and clears
  the contract-loader `lru_cache`, so the `config/contracts`, `assets`, and
  `swap/quote` routes are testable.
- Both `pytest.skip("Requires chain_client.settings module-level init mocking")`
  markers (lines ~262/269) are removed — `test_contracts` + `test_list_assets`
  now run and pass.
- The fixture is deliberately **separate** from the shared `client` fixture so
  no other route test changes behavior (the advisor optimizer path relies on the
  bare-mock settings; leaving it untouched avoids a spurious regression).

## Tier-A `chain/` module coverage (before → after)

| Module | Before | After | New tests |
| --- | --- | --- | --- |
| `chain/circle_signer.py` | 30% | **99%** | `test_circle_signer.py` |
| `chain/oracle_runner.py` | 0% | **96%** | `test_oracle_runner.py` |
| `chain/oracle_updater.py` | 47% | **86%** | `test_oracle_updater_fetch.py` + `test_oracle_price_formatting.py` |
| `chain/executor.py` | 48% | **88%** | `test_executor_reads.py` (reads / metrics / setters / NAV helpers) |
| `chain/agent_runner.py` | 42% | **76%** | `test_agent_runner_tick.py` (tick pipeline + discovery + commit/reveal) |

Overall backend coverage (no-integration suite): **69% → 73%.**

## The four extracted behaviors (real hermetic tests)

- **(a) Trace-hash tamper detection** — `ReasoningTrace.compute_hash()` changes
  when any `_HASH_FIELDS` value mutates; the post-commit anchoring fields
  (`arc_tx_hash`, commit/reveal tx + block) do NOT move it, so a committed hash
  survives the reveal phase (`test_trace_hash_tamper.py`).
- **(b) Oracle price formatting** — verified the **actual** convention in code is
  **6-decimal** (`int(price * 1e6)`, "matches PriceOracle.sol"), so $185.50 →
  `185_500_000`, **not** the issue's speculated 8-dec `18_550_000_000`. Pinned by
  asserting the exact `abiParameters` submitted to Circle, plus a NOT-8-dec guard
  (`test_oracle_price_formatting.py`).
- **(c) Agent tick pipeline** — one `StrategyRunner.tick()` (mocked
  chain/redis/oracle) flows strategies → signals → regime classification →
  position-scale (portfolio constructor consumes regime + ensemble consensus) →
  target allocations → per-vault processing (`test_agent_runner_tick.py`).
- **(d) Swap quote** — `/api/swap/quote` returns `amount_out` / `fee_pct` /
  `price_impact_pct` / `min_amount_out`, plus a 400-no-leak case (needs the
  Tier-B unlock) (`test_api_routes.py::TestSwapRoutes`).

## Verify (exact hermetic command a reviewer runs)

```bash
export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/chain/test_circle_signer.py \
  backend/tests/chain/test_oracle_runner.py \
  backend/tests/chain/test_oracle_price_formatting.py \
  backend/tests/chain/test_oracle_updater_fetch.py \
  backend/tests/chain/test_executor_reads.py \
  backend/tests/test_trace_hash_tamper.py \
  backend/tests/test_agent_runner_tick.py \
  backend/tests/test_api_routes.py::TestConfigRoutes \
  backend/tests/test_api_routes.py::TestAssetRoutes \
  backend/tests/test_api_routes.py::TestSwapRoutes -q
# → 93 passed, 0 failed
```

`ruff format --check` and `ruff check --select E9,F63,F7,F40` are clean on all
new/modified files.

## Pre-existing failures (NOT caused by this PR)

The full no-integration suite shows 2 failures, both pre-existing and unrelated:
- `test_api_routes.py::TestAdvisorRoutes::test_advisor_happy_path` — a
  network-dependent advisor test that fails at the current `main` HEAD even with
  this branch's changes stashed (it reaches yfinance and the Kelly optimizer is
  non-deterministic). Out of scope for #738.
- `test_auth_siwe.py::test_verify_rejects_expired_nonce` — passes in isolation,
  fails under full-suite ordering (SIWE nonce state pollution). Unrelated to the
  `chain/` + traces surface this PR touches.

## Anti-goals respected

No production code changed; no rigor thresholds weakened; `pytest.ini` untouched;
no live-chain / anvil / network / `.env` deps; no `tests/flows/` mock-against-mock
scaffolding (tests exercise real code paths); no `.t.sol` changes; no
`asyncio.get_event_loop().run_until_complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
