### PR TITLE
[oracle] Secondary-source cross-check — primary vs independent yfinance, fail-closed + asymmetric (#775)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,15 @@ PYTH_HERMES_URL=https://hermes.pyth.network
 # the cascade in any mode. Last-resort / demo pin. e.g. {"sSPY": 512.3}
 ADMIN_PRICES_JSON=
 
+# Secondary-source cross-check (#775): before pushing a NON-yfinance primary
+# price (Pyth/Stork) on-chain, the oracle runner compares it to an independent
+# yfinance reading and FAILS CLOSED if they diverge beyond this band (bps).
+# Asymmetric by design: a stale/missing/flaky yfinance NEVER blocks a healthy
+# primary (it only logs) — only a confident divergence between two healthy
+# sources fails closed. No-op when PRICE_SOURCE=yfinance (same source). 0 to
+# disable. Generous default; Önder owns tuning the band + staleness.
+PRICE_CROSSCHECK_BAND_BPS=5000
+
 # ── Contract addresses (Arc testnet, Chain ID 5042002 / 0x4cef52) ─────────
 # (Chain ID aligned with README/CLAUDE; verify with Dan/contracts before relying
 # on them — Dan owns the contracts + deploys them.)

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -50,6 +50,11 @@ DEFAULT_MAX_DEVIATION_BPS = 2000
 # Max age of the upstream observation before we refuse to push it on-chain.
 # Override via ORACLE_MAX_UPSTREAM_STALENESS_SECONDS.
 DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS = 900  # 15 minutes
+# Secondary-source cross-check band (#775): the max divergence (bps) between a
+# NON-yfinance primary (Pyth/Stork via the PRICE_SOURCE cascade) and an
+# independent yfinance reading before we fail closed. Generous default — both
+# sources lag between updates; Önder owns tuning. 0 disables the cross-check.
+DEFAULT_CROSSCHECK_BAND_BPS = 5000  # 50%
 
 
 def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
@@ -93,6 +98,9 @@ class OracleUpdater:
         # Last price (6-dec int) we successfully submitted, per symbol —
         # fallback deviation reference when the on-chain read fails.
         self._last_pushed_price_int: dict[str, int] = {}
+
+        # Secondary-source cross-check band (#775).
+        self._crosscheck_band_bps: int = int(os.getenv("PRICE_CROSSCHECK_BAND_BPS", str(DEFAULT_CROSSCHECK_BAND_BPS)))
 
     # ─── Public API ──────────────────────────────────────────────
 
@@ -194,6 +202,10 @@ class OracleUpdater:
                 # that are non-positive, stale upstream, or deviate too far
                 # from the last known good price.
                 rejection = await self._validate_for_push(price, price_int)
+                # Secondary-source cross-check (#775): only when the sanity gate
+                # already passed (avoid the extra yfinance fetch on a rejected price).
+                if rejection is None:
+                    rejection = await self._cross_check_secondary(price)
                 if rejection is not None:
                     logger.warning(f"Refusing to push {price.symbol} price {price.price_usd}: {rejection}")
                     continue
@@ -307,6 +319,65 @@ class OracleUpdater:
                     f"{reference_int / 1e6:.2f} exceeds {self._max_deviation_bps} bps cap"
                 )
 
+        return None
+
+    async def _cross_check_secondary(self, price: AssetPrice) -> str | None:
+        """Secondary-source cross-check (#775): compare a NON-yfinance primary
+        (Pyth/Stork via the PRICE_SOURCE cascade) against an independent yfinance
+        reading and fail closed when they diverge beyond the band. Returns a
+        rejection reason, or None to proceed.
+
+        **Asymmetric, by design.** A stale / missing / flaky yfinance NEVER blocks
+        a healthy primary — otherwise a yfinance outage (it's known-flaky, #772)
+        would become a trading halt and the guardrail itself the failure. yfinance
+        problems only proceed-and-log; only a *confident* divergence between two
+        healthy sources fails closed.
+
+        Honest claim this earns: *"primary cross-checked against an independent
+        yfinance market source, fail-closed on divergence beyond a band."* NOT
+        "decentralized 2-of-3" (yfinance is centralized + off-chain). The check is
+        a no-op when the primary IS yfinance (same source — not independent) or
+        when no yfinance ticker exists for the symbol. Band/staleness thresholds
+        are Önder's lane to tune (collaborate per #775).
+        """
+        if self._crosscheck_band_bps <= 0:
+            return None  # disabled
+        if price.source == "yfinance":
+            return None  # primary IS yfinance — not an independent second source
+        yf_ticker = YFINANCE_MAP.get(price.symbol)
+        if not yf_ticker:
+            return None  # no independent yfinance ticker for this symbol → can't cross-check → proceed
+        try:
+            secondary = await self._fetch_yfinance_single(yf_ticker)
+        except Exception as exc:
+            logger.warning(
+                "cross-check: yfinance fetch failed for %s (%s) — proceeding on primary (asymmetric)",
+                price.symbol,
+                exc,
+            )
+            return None
+        if secondary is None or secondary <= 0:
+            logger.info(
+                "cross-check: no usable yfinance secondary for %s — proceeding on primary (asymmetric)",
+                price.symbol,
+            )
+            return None
+
+        deviation_bps = abs(price.price_usd - secondary) / secondary * 10_000
+        if deviation_bps > self._crosscheck_band_bps:
+            return (
+                f"cross-check FAIL: primary({price.source}) {price.price_usd:.4f} diverges "
+                f"{deviation_bps:.0f} bps from independent yfinance {secondary:.4f} "
+                f"(band {self._crosscheck_band_bps} bps) — failing closed"
+            )
+        logger.debug(
+            "cross-check OK for %s: primary(%s) %.4f vs yfinance %.4f (%.0f bps)",
+            price.symbol,
+            price.source,
+            price.price_usd,
+            secondary,
+            deviation_bps,
+        )
         return None
 
     async def _get_reference_price_int(self, symbol: str) -> tuple[int | None, bool]:

--- a/backend/tests/chain/test_oracle_crosscheck.py
+++ b/backend/tests/chain/test_oracle_crosscheck.py
@@ -1,0 +1,100 @@
+"""Hermetic tests for the #775 secondary-source price cross-check.
+
+Pins the load-bearing safety property: the cross-check is **asymmetric** — a
+stale/missing/flaky yfinance NEVER blocks a healthy primary (only a confident
+divergence between two healthy sources fails closed) — and is a no-op when the
+primary is itself yfinance (not an independent source). No network: the single
+yfinance read is mocked at the boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from archimedes.chain.oracle_updater import OracleUpdater
+from archimedes.models.asset import AssetPrice
+
+NOW = datetime(2026, 6, 30, tzinfo=UTC)
+
+
+def _price(symbol: str = "sSPY", usd: float = 500.0, source: str = "pyth_hermes") -> AssetPrice:
+    return AssetPrice(symbol=symbol, price_usd=usd, timestamp=NOW, source=source)
+
+
+def _updater(band_bps: int = 5000) -> OracleUpdater:
+    u = OracleUpdater()
+    u._crosscheck_band_bps = band_bps
+    return u
+
+
+# ── no-op cases (nothing to cross-check) ──────────────────────────────────
+
+
+async def test_disabled_band_is_noop():
+    u = _updater(0)
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=1.0)) as m:
+        assert await u._cross_check_secondary(_price()) is None
+    m.assert_not_called()  # disabled → never even fetches
+
+
+async def test_yfinance_primary_is_noop():
+    # When the primary IS yfinance there is no independent second source.
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock()) as m:
+        assert await u._cross_check_secondary(_price(source="yfinance")) is None
+    m.assert_not_called()
+
+
+async def test_unmapped_symbol_is_noop():
+    # A symbol with no yfinance ticker can't be cross-checked → proceed.
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock()) as m:
+        assert await u._cross_check_secondary(_price(symbol="sNOTREAL")) is None
+    m.assert_not_called()
+
+
+# ── the asymmetry (the safety property) ───────────────────────────────────
+
+
+async def test_asymmetric_yfinance_exception_proceeds():
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(side_effect=RuntimeError("yfinance down"))):
+        # A yfinance OUTAGE must NOT halt a healthy primary.
+        assert await u._cross_check_secondary(_price()) is None
+
+
+async def test_asymmetric_yfinance_none_proceeds():
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=None)):
+        assert await u._cross_check_secondary(_price()) is None
+
+
+async def test_asymmetric_yfinance_nonpositive_proceeds():
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=0.0)):
+        assert await u._cross_check_secondary(_price()) is None
+
+
+# ── the actual guardrail ──────────────────────────────────────────────────
+
+
+async def test_in_band_proceeds():
+    u = _updater(5000)  # 50% band
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=510.0)):  # ~2% off
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None
+
+
+async def test_out_of_band_fails_closed():
+    u = _updater(1000)  # 10% band
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=1000.0)):  # 2x off
+        reason = await u._cross_check_secondary(_price(usd=500.0))
+    assert reason is not None
+    assert "diverges" in reason and "failing closed" in reason
+
+
+async def test_band_boundary_inclusive_proceeds():
+    # Exactly at the band is allowed (strict > check). 500 vs 550 = 909bps < 1000.
+    u = _updater(1000)
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=550.0)):
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None


### PR DESCRIPTION
## What (#775 Phase 1, on top of the #826 cascade)

Before pushing a **non-yfinance** primary price (Pyth/Stork via the `PRICE_SOURCE` cascade) on-chain, the oracle runner cross-checks it against an **independent yfinance** reading and **fails closed** on divergence beyond a band. **No contract change.**

## The asymmetry (the load-bearing safety property)

A stale / missing / flaky yfinance (it's known-flaky, #772) **NEVER blocks a healthy primary** — otherwise a yfinance outage becomes a *trading halt* and the guardrail itself the failure. A yfinance problem only **proceeds-and-logs**; only a **confident divergence between two healthy sources** fails closed. No-op when the primary IS yfinance (same source) or when no yfinance ticker exists for the symbol.

> Honest claim this earns: *"primary cross-checked against an independent yfinance market source, fail-closed on divergence beyond a band."* **NOT** "decentralized 2-of-3" (yfinance is centralized + off-chain).

## Build

- `_cross_check_secondary(price)` wired into `push_prices_on_chain` **after** the existing `_validate_for_push` (runs only on an otherwise-pushable price).
- `PRICE_CROSSCHECK_BAND_BPS` env (default `5000`=50%, `0` disables) + `.env.example`.
- **9 hermetic tests**: disabled-noop, yfinance-primary-noop, unmapped-symbol-noop, the **3 asymmetry cases** (yfinance exception / None / ≤0 all PROCEED), in-band proceeds, out-of-band fails closed, band boundary. **38 existing oracle/price_source tests stay green** (cross-check is a no-op for their yfinance-source prices).

## Notes

- **Band + staleness thresholds are Önder's lane to tune** (collaborate per #775 — it's flaky-data risk-math).
- The symbol→yfinance map currently covers the `YFINANCE_MAP` set; it broadens with the **#759 universe** expansion (per-asset `yfinance_ticker`).
- ⚠️ Feed-adjacent (chain/) → **Dan close-review**. **Stacked on [#826](https://github.com/a-apin/archimedes/pull/826)** (needs the cascade's `price.source` field) — base is the oracle branch; I'll retarget to `main` once #826 merges.

Refs #775, #826, #772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)