### PR TITLE
[backend] Library passes_rigor_gate badge from the live gate, not a fixture (#821)

### DIFF
--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -201,6 +201,12 @@ class StrategyResponse(BaseModel):
     out_of_sample_sharpe: float | None = None
     kelly_fraction: float | None = None
     passes_rigor_gate: bool = False
+    # Tri-state live rigor-gate badge (#821): "pass" | "fail" | "pending".
+    # Sourced from the LIVE run_rigor_gate verdict on persisted real returns — never
+    # from a stored fixture boolean. "pending" = no real backtest data yet (the gate
+    # cannot run), surfaced honestly instead of defaulting to a fixture True/False.
+    # ``passes_rigor_gate`` stays the fail-closed boolean (True only when status == "pass").
+    rigor_gate_status: str = "pending"
     paper_claimed_sharpe: float | None = None
     paper_claim_blended_sharpe: float | None = None
     is_backtest_placeholder: bool = False

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -466,6 +466,14 @@ async def get_portfolio_advisor(
 
     strat_by_id = {s.id: s for s in strategies}
 
+    # Live rigor verdicts (#821): the advisor's per-pick badge must come from the
+    # LIVE gate on real persisted returns, NOT the in-memory Strategy.passes_rigor_gate
+    # (which strategy_provider initialises to False/fail-closed so no fixture leaks).
+    # Computed once here and reused by _rigor_fields so this surface matches the
+    # library list. verdicts_for_strategies is itself fail-closed (→ all "pending"),
+    # so it never raises into this route.
+    advisor_verdicts = verdicts_for_strategies(strategies)
+
     from archimedes.services.stress_engine import stress_all as _stress_all
 
     async def _build_and_anchor_trace(
@@ -570,8 +578,13 @@ async def get_portfolio_advisor(
         if st.paper_claimed_max_dd is not None and st.real_max_dd is not None:
             paper_delta_max_dd = round(st.real_max_dd - st.paper_claimed_max_dd, 4)
 
+        # Badge from the live gate (#821), not st.passes_rigor_gate (always False on
+        # the in-memory object). Fail-closed to "pending" if the strategy isn't in the
+        # verdict map (it always should be, but never claim an unearned pass).
+        _verdict = advisor_verdicts.get(st.id)
         return {
-            "passes_rigor_gate": st.passes_rigor_gate,
+            "passes_rigor_gate": _verdict.passes if _verdict else False,
+            "rigor_gate_status": _verdict.status if _verdict else "pending",
             "deflated_sharpe_ratio": st.deflated_sharpe_ratio,
             "dsr_p_value": st.dsr_p_value,
             "num_trials_in_selection": st.num_trials_in_selection,

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -37,6 +37,11 @@ from archimedes.api.schemas import (
 )
 from archimedes.models.strategy import Strategy, StrategyStatus
 from archimedes.services.construction_trace import build_construction_trace
+from archimedes.services.live_rigor_gate import (
+    RigorGateVerdict,
+    verdict_from_returns,
+    verdicts_for_strategies,
+)
 from archimedes.services.strategy_guardrail import apply_guardrail
 
 logger = logging.getLogger(__name__)
@@ -44,14 +49,34 @@ logger = logging.getLogger(__name__)
 strategies_router = APIRouter(prefix="/api/strategies", tags=["strategies"])
 
 
-def _to_strategy_response(s: Strategy) -> StrategyResponse:
-    """Map StrategyPassport + persisted BacktestResult to API schema."""
+def _to_strategy_response(s: Strategy, verdict: RigorGateVerdict | None = None) -> StrategyResponse:
+    """Map StrategyPassport + persisted BacktestResult to API schema.
+
+    ``verdict`` is the LIVE rigor-gate verdict for this strategy (#821), computed
+    on its persisted real returns via ``run_rigor_gate`` — the SAME machinery the
+    ``/api/selection-bias/gate`` route uses. The served ``passes_rigor_gate`` badge
+    and the CANDIDATE → VALIDATED promotion are derived from it, NOT from the stored
+    fixture boolean. When ``verdict is None`` (single-strategy fetch) it is computed
+    on demand here. A strategy with no real returns yields a ``pending`` verdict so
+    the badge surfaces "unknown" rather than a fixture ``True``/``False``.
+    """
     from archimedes.api.schemas import PaperRefResponse
     from archimedes.services.return_source_classifier import classify_strategy
+
+    if verdict is None:
+        verdict = _live_verdict_for_one(s)
 
     bt = strategy_provider.get_backtest_result(s.id)
     has_real = s.real_sharpe is not None
     return_source, return_source_note = classify_strategy(s)
+
+    # Served status overlays the LIVE gate verdict on the file-declared status:
+    # a CANDIDATE is promoted to VALIDATED only when the live gate PASSES on real
+    # returns (#821). The fixture boolean no longer promotes anything. Hand-declared
+    # advanced states (live/retired) are preserved.
+    served_status = s.status.value
+    if s.status == StrategyStatus.CANDIDATE and verdict.passes:
+        served_status = StrategyStatus.VALIDATED.value
 
     # Build papers list from passport
     papers_list = [
@@ -79,7 +104,7 @@ def _to_strategy_response(s: Strategy) -> StrategyResponse:
         asset_universe=s.asset_universe,
         position_sizing=s.position_sizing.value,
         rebalance_frequency=s.rebalance_frequency.value,
-        status=s.status.value,
+        status=served_status,
         paper_venue=s.paper_venue,
         paper_year=s.paper_year,
         paper_doi=s.paper_doi,
@@ -104,7 +129,11 @@ def _to_strategy_response(s: Strategy) -> StrategyResponse:
         pbo_score=s.pbo_score if has_real else (bt.pbo_score if bt else None),
         out_of_sample_sharpe=s.out_of_sample_sharpe if has_real else (bt.out_of_sample_sharpe if bt else None),
         kelly_fraction=s.kelly_fraction,
-        passes_rigor_gate=s.passes_rigor_gate if has_real else (bt.passes_rigor_gate if bt else s.passes_rigor_gate),
+        # Badge from the LIVE gate verdict (#821) — never the fixture boolean.
+        # passes_rigor_gate is the fail-closed boolean (True only when status=="pass");
+        # rigor_gate_status carries the honest tri-state ("pass"|"fail"|"pending").
+        passes_rigor_gate=verdict.passes,
+        rigor_gate_status=verdict.status,
         is_backtest_placeholder=not has_real,
         sharpe_ci_lower=s.sharpe_ci_lower,
         sharpe_ci_upper=s.sharpe_ci_upper,
@@ -124,6 +153,42 @@ def _to_strategy_response(s: Strategy) -> StrategyResponse:
     )
 
 
+def _live_verdict_for_one(s: Strategy) -> RigorGateVerdict:
+    """Live rigor-gate verdict for a single strategy (#821).
+
+    Used by the single-strategy fetch path (``get_strategy``) where there is no
+    batch to amortize over. Loads this strategy's persisted real returns and runs
+    ``run_rigor_gate`` (num_trials=1 — single-strategy context, same as the gate's
+    own no-cohort fallback). No real returns → ``pending``, never a fixture value.
+    Never raises: any failure degrades to ``pending`` (fail-closed badge).
+    """
+    try:
+        from archimedes.db import get_session, init_db
+        from archimedes.services.backtest_repository import get_daily_returns
+
+        init_db()
+        with get_session() as session:
+            daily_returns = get_daily_returns(session, s.id)
+    except Exception as exc:
+        logger.warning("live verdict DB read failed for %s (badge → pending): %s", s.id, exc)
+        return RigorGateVerdict.pending()
+
+    code = None
+    if s.strategy_code_path:
+        from archimedes.api.selection_bias_routes import _load_strategy_code
+
+        with contextlib.suppress(Exception):
+            code = _load_strategy_code(s.strategy_code_path)
+
+    return verdict_from_returns(
+        s.id,
+        daily_returns,
+        num_trials=1,
+        strategy_code=code,
+        paper_claimed_sharpe=s.paper_claimed_sharpe,
+    )
+
+
 # ── Library listing ─────────────────────────────────────────────
 
 
@@ -133,13 +198,27 @@ async def list_strategies(
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
-    """List strategies in the library. Backed by LocalStrategyProvider."""
+    """List strategies in the library. Backed by LocalStrategyProvider.
+
+    The ``passes_rigor_gate`` badge + CANDIDATE → VALIDATED promotion come from the
+    LIVE gate verdict computed on persisted real returns (#821) — the same machinery
+    the /api/selection-bias/gate route uses — NOT from the stored fixture boolean.
+    Verdicts are computed once for the page window (one DB read + one library-wide
+    PBO/num_trials context) and threaded into each serializer.
+
+    NOTE on the ``status`` filter: it filters on the file-declared status BEFORE the
+    live-gate promotion overlay, so a CANDIDATE that the live gate promotes to
+    VALIDATED still appears under ``?status=candidate`` (its stored status) with a
+    served ``status: "validated"``. This is intentional — the stored status is the
+    stable filter key; the served status reflects the live verdict.
+    """
     status_filter = StrategyStatus(status) if status else None
     strats = strategy_provider.list_strategies(status=status_filter)
     total = len(strats)
     window = strats[offset : offset + limit]
+    verdicts = verdicts_for_strategies(window)
     return StrategyListResponse(
-        strategies=[_to_strategy_response(s) for s in window],
+        strategies=[_to_strategy_response(s, verdicts.get(s.id)) for s in window],
         total=total,
     )
 
@@ -1164,7 +1243,15 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
         pbo_score=record.pbo_score,
         out_of_sample_sharpe=record.out_of_sample_sharpe,
         kelly_fraction=None,
+        # Generated/fusion strategies carry a PERSISTED live-gate verdict written by
+        # the generation pipeline (strategy_passports.passes_rigor_gate) — a stored
+        # *live* verdict, not a fixture boolean — so it is a legitimate badge source
+        # per #821 ("read a persisted live-gate verdict"). Map it to the tri-state:
+        # a passport with no real backtest (sharpe_ratio is None) is "pending".
         passes_rigor_gate=bool(record.passes_rigor_gate),
+        rigor_gate_status=(
+            "pending" if record.sharpe_ratio is None else ("pass" if bool(record.passes_rigor_gate) else "fail")
+        ),
         is_backtest_placeholder=record.sharpe_ratio is None,
         sharpe_ci_lower=None,
         sharpe_ci_upper=None,

--- a/backend/archimedes/services/live_rigor_gate.py
+++ b/backend/archimedes/services/live_rigor_gate.py
@@ -1,0 +1,195 @@
+"""Live rigor-gate badge — the single source of truth for ``passes_rigor_gate``.
+
+Issue #821. The user-facing library badge (``passes_rigor_gate`` and the
+CANDIDATE → VALIDATED 🏆 promotion) must come from a LIVE ``run_rigor_gate``
+verdict computed on the strategy's *persisted real returns*, NOT from a stored
+fixture boolean. A cached boolean that the gate never re-derives is exactly the
+pattern the #1 rule forbids ("claims must be true on the live path") and the one
+Bogdan's audit (#710) flagged.
+
+This module reuses the SAME machinery the ``/api/selection-bias/gate`` route
+uses — ``get_all_daily_returns`` (real persisted returns from the DB) +
+``run_rigor_gate`` (the four-primitive gate) — so the library list and the gate
+route share one source of truth. It deliberately does NOT synthesize returns
+from stubs: a strategy with no real backtest data surfaces an explicit
+``pending`` verdict, never a fixture ``True``/``False``.
+
+Tri-state result (``RigorGateVerdict``):
+  - ``"pass"``    — real returns exist and the live gate passed.
+  - ``"fail"``    — real returns exist and the live gate failed at ≥1 criterion.
+  - ``"pending"`` — no real returns yet (genuinely pre-backtest): the gate cannot
+                    run, so the badge is honestly "unknown", not a boolean.
+
+Cheap-by-default: ``passes`` is ``True`` only for ``"pass"``; ``"pending"`` and
+``"fail"`` both map to ``passes is False`` so existing boolean consumers stay
+fail-closed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Mirror the selection-bias /gate route: a strategy needs at least this many real
+# daily returns before the gate can run. Fewer than this → "pending" (the same
+# "no backtest data" branch the route reports as MISSING), never a fixture value.
+_MIN_RETURNS_FOR_GATE = 10
+
+# Literal verdict labels for the tri-state badge.
+PASS = "pass"
+FAIL = "fail"
+PENDING = "pending"
+
+
+@dataclass(frozen=True)
+class RigorGateVerdict:
+    """A live rigor-gate verdict for one strategy.
+
+    ``status`` is the tri-state label ("pass" | "fail" | "pending"). ``passes``
+    is the fail-closed boolean for legacy consumers: only "pass" is truthy.
+    ``source`` records provenance — always "live_gate" or "pending" here, NEVER
+    "fixture" (that is the whole point of #821).
+    """
+
+    status: str
+    passes: bool
+    source: str
+
+    @classmethod
+    def pending(cls) -> RigorGateVerdict:
+        return cls(status=PENDING, passes=False, source="pending")
+
+    @classmethod
+    def passed(cls) -> RigorGateVerdict:
+        return cls(status=PASS, passes=True, source="live_gate")
+
+    @classmethod
+    def failed(cls) -> RigorGateVerdict:
+        return cls(status=FAIL, passes=False, source="live_gate")
+
+
+def verdict_from_returns(
+    strategy_id: str,
+    daily_returns: list[float],
+    *,
+    num_trials: int = 1,
+    pbo_scores: dict[str, float] | None = None,
+    strategy_code: str | None = None,
+    paper_claimed_sharpe: float | None = None,
+    average_correlation: float = 0.0,
+) -> RigorGateVerdict:
+    """Compute the live tri-state verdict from a strategy's persisted returns.
+
+    Reuses ``run_rigor_gate`` — the exact gate the ``/gate`` route runs — rather
+    than reinventing it. With fewer than ``_MIN_RETURNS_FOR_GATE`` real returns the
+    gate cannot run and the verdict is ``pending`` (NOT a fixture boolean). Any
+    unexpected failure inside the gate fails closed to ``pending`` so the badge can
+    never claim a pass it did not earn.
+    """
+    if not daily_returns or len(daily_returns) < _MIN_RETURNS_FOR_GATE:
+        return RigorGateVerdict.pending()
+
+    # Local import keeps this module importable without pulling the full rigor stack
+    # at API import time, and avoids any import cycle with rigor_evaluator.
+    from archimedes.services.rigor_evaluator import run_rigor_gate
+
+    try:
+        # in_sample_sharpe=None on purpose: run_rigor_gate derives the IS denominator
+        # from the first 70% of the same series, identical to the /gate route. Passing
+        # a full-sample Sharpe would make the OOS/IS cliff trivially passable.
+        result = run_rigor_gate(
+            strategy_id=strategy_id,
+            daily_returns=daily_returns,
+            num_trials=num_trials,
+            pbo_scores=pbo_scores,
+            strategy_code=strategy_code,
+            in_sample_sharpe=None,
+            paper_claimed_sharpe=paper_claimed_sharpe,
+            average_correlation=average_correlation,
+        )
+    except Exception as exc:  # never let the badge crash the library list
+        logger.warning("live rigor gate failed for %s (badge → pending): %s", strategy_id, exc)
+        return RigorGateVerdict.pending()
+
+    return RigorGateVerdict.passed() if result.passes_all else RigorGateVerdict.failed()
+
+
+def verdicts_for_strategies(strategies: list) -> dict[str, RigorGateVerdict]:
+    """Compute live verdicts for a batch of strategies from persisted DB returns.
+
+    Single source of truth for the library-list badge (#821). Mirrors the
+    ``/api/selection-bias/gate`` route's data path:
+      * load real daily returns from the DB (``get_all_daily_returns``);
+      * compute the library-wide ``num_trials`` + cohort PBO + avg-correlation from
+        the strategies that actually HAVE returns (≥10 obs);
+      * run ``run_rigor_gate`` per strategy and map ``passes_all`` to a tri-state.
+
+    Strategies with no real returns map to ``pending`` — never a fixture boolean.
+    Returns ``{strategy_id: RigorGateVerdict}`` for every input strategy. Any DB or
+    gate failure degrades the whole batch to ``pending`` (fail-closed): the badge
+    is never allowed to fabricate a pass.
+    """
+    if not strategies:
+        return {}
+
+    strategy_ids = [s.id for s in strategies]
+
+    try:
+        from archimedes.db import get_session, init_db
+        from archimedes.services.backtest_repository import get_all_daily_returns
+        from archimedes.services.rigor_evaluator import (
+            compute_average_pairwise_correlation,
+            compute_pbo,
+        )
+
+        init_db()
+        with get_session() as session:
+            returns_by_strategy = get_all_daily_returns(session, strategy_ids)
+    except Exception as exc:
+        logger.warning("live rigor gate batch: DB read failed (all → pending): %s", exc)
+        return {sid: RigorGateVerdict.pending() for sid in strategy_ids}
+
+    # Strategies WITHOUT real returns are pending; do NOT synthesize from stubs
+    # (that is the circular validation the /gate route explicitly refuses).
+    valid_returns = {k: v for k, v in returns_by_strategy.items() if len(v) >= _MIN_RETURNS_FOR_GATE}
+
+    # The library is the multiple-testing selection set (mirrors selection_bias_routes).
+    pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
+    num_trials = max(len(valid_returns), 1)
+    avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+
+    code_by_id = {s.id: _load_strategy_code_safe(s) for s in strategies}
+
+    verdicts: dict[str, RigorGateVerdict] = {}
+    for s in strategies:
+        daily_returns = returns_by_strategy.get(s.id, [])
+        verdicts[s.id] = verdict_from_returns(
+            s.id,
+            daily_returns,
+            num_trials=num_trials,
+            pbo_scores=pbo_scores,
+            strategy_code=code_by_id.get(s.id),
+            paper_claimed_sharpe=getattr(s, "paper_claimed_sharpe", None),
+            average_correlation=avg_correlation,
+        )
+    return verdicts
+
+
+def _load_strategy_code_safe(strategy) -> str | None:
+    """Best-effort read of a strategy's source for the look-ahead audit.
+
+    Reuses the path-traversal-guarded loader from the selection-bias route so the
+    library badge runs the same look-ahead audit input as the /gate route. Never
+    raises: returns None on any failure (the gate then fails the look-ahead leg).
+    """
+    code_path = getattr(strategy, "strategy_code_path", None)
+    if not code_path:
+        return None
+    try:
+        from archimedes.api.selection_bias_routes import _load_strategy_code
+
+        return _load_strategy_code(code_path)
+    except Exception:
+        return None

--- a/backend/archimedes/services/live_rigor_gate.py
+++ b/backend/archimedes/services/live_rigor_gate.py
@@ -156,11 +156,21 @@ def verdicts_for_strategies(strategies: list) -> dict[str, RigorGateVerdict]:
     valid_returns = {k: v for k, v in returns_by_strategy.items() if len(v) >= _MIN_RETURNS_FOR_GATE}
 
     # The library is the multiple-testing selection set (mirrors selection_bias_routes).
-    pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
-    num_trials = max(len(valid_returns), 1)
-    avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+    # Wrap the cohort-context compute in the same fail-closed contract the docstring
+    # promises: if compute_pbo / compute_average_pairwise_correlation raises, degrade
+    # the whole batch to pending rather than 500-ing the library list.
+    try:
+        pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
+        num_trials = max(len(valid_returns), 1)
+        avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+    except Exception as exc:
+        logger.warning("live rigor gate batch: cohort-context compute failed (all → pending): %s", exc)
+        return {sid: RigorGateVerdict.pending() for sid in strategy_ids}
 
-    code_by_id = {s.id: _load_strategy_code_safe(s) for s in strategies}
+    # Only load source for strategies that can actually run the gate (≥10 returns).
+    # A strategy with too few returns short-circuits to `pending` inside
+    # verdict_from_returns and never reads strategy_code, so loading it is wasted I/O.
+    code_by_id = {s.id: _load_strategy_code_safe(s) for s in strategies if s.id in valid_returns}
 
     verdicts: dict[str, RigorGateVerdict] = {}
     for s in strategies:

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -285,10 +285,14 @@ def _to_strategy(
         logger.warning("unknown STATUS=%s in %s, defaulting to candidate", status_raw, path)
         status = StrategyStatus.CANDIDATE
 
-    # Promote status from fixture when the strategy passes the rigor gate,
-    # unless the file already declares a more advanced state (live/retired).
-    if fixture and fixture.get("passes_rigor_gate") and status == StrategyStatus.CANDIDATE:
-        status = StrategyStatus.VALIDATED
+    # CANDIDATE → VALIDATED promotion is NOT driven by the fixture boolean (#821).
+    # The fixture's ``passes_rigor_gate`` is a stored value the live gate never
+    # re-derives — exactly the cached-pass pattern the #1 rule forbids. Promotion
+    # is now driven off the LIVE gate verdict computed on persisted real returns
+    # (see api/strategies_routes.py + services/live_rigor_gate.py): the served
+    # status is overlaid there from the live verdict. Here we keep only the file's
+    # declared STATUS (so a curator can still hand-declare live/retired); the
+    # fixture boolean no longer promotes anything.
 
     paper_claimed_sharpe = metadata.get("PAPER_CLAIMED_SHARPE")
     paper_claimed_cagr = metadata.get("PAPER_CLAIMED_CAGR")
@@ -319,7 +323,15 @@ def _to_strategy(
     num_trials_in_selection = fx.get("num_trials_in_selection")
     pbo_score = fx.get("pbo_score")
     out_of_sample_sharpe = fx.get("out_of_sample_sharpe")
-    passes_rigor_gate = bool(fx.get("passes_rigor_gate", False))
+    # NOTE (#821): the badge ``passes_rigor_gate`` is NOT sourced from the fixture
+    # boolean. The fixture value (``fx.get("passes_rigor_gate")``) is a stored
+    # constant the live gate never re-derives — the cached-pass anti-pattern the
+    # #1 rule forbids. The served badge is overlaid from the LIVE gate verdict
+    # computed on persisted real returns in api/strategies_routes (single source of
+    # truth via services/live_rigor_gate). We initialise to False (fail-closed) here
+    # so nothing downstream that reads ``Strategy.passes_rigor_gate`` directly can
+    # leak a fixture pass; the served path replaces it with the live verdict.
+    passes_rigor_gate = False
     kelly_fraction = fx.get("kelly_fraction")
     n_obs_daily = fx.get("n_obs_daily")
 

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -255,8 +255,12 @@ class TestStrategyRoutes:
             assert "dsr_p_value" in s, f"dsr_p_value missing for {s.get('id')}"
             assert "passes_rigor_gate" in s, f"passes_rigor_gate missing for {s.get('id')}"
 
-    def test_rigor_gate_fields_correct_for_tier1(self, client, seeded_db):
-        """Moreira-Muir fixture values flow correctly: dsr_p_value ≥ 0.95, passes_rigor_gate=True."""
+    def test_rigor_gate_badge_is_live_not_fixture_for_tier1(self, client, seeded_db):
+        """#821: the served ``passes_rigor_gate`` badge for Moreira-Muir comes from
+        the LIVE gate on persisted returns — NOT the fixture boolean. ``seeded_db``
+        only seeds Buy-and-Hold's backtest, so Moreira-Muir has no live returns and
+        the badge must be ``pending`` (False), even though its fixture row says True.
+        The fixture-derived display metric (dsr_p_value) still flows for rendering."""
         strategies = _list_all_strategies(client)
         # Match Moreira-Muir specifically by its full title. A bare "Volatility"
         # substring also matches Ang-Hodrick's "The Cross-Section of Volatility
@@ -267,9 +271,9 @@ class TestStrategyRoutes:
         )
         if mm is None:
             pytest.skip("Moreira-Muir strategy not found in fixture")
-        assert mm["passes_rigor_gate"] is True
-        assert mm["dsr_p_value"] is not None
-        assert mm["dsr_p_value"] >= 0.95, f"Expected p≥0.95, got {mm['dsr_p_value']}"
+        # No live returns for this strategy → pending, NOT a fixture True/False.
+        assert mm["rigor_gate_status"] == "pending"
+        assert mm["passes_rigor_gate"] is False, "fixture boolean must NOT drive the live badge (#821)"
 
 
 class TestRiskRoutes:

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -109,13 +109,13 @@ class TestVerdictFromReturns:
 
     def test_gate_exception_fails_closed_to_pending(self, monkeypatch):
         # If run_rigor_gate raises, the badge must NOT claim a pass.
-        import archimedes.services.live_rigor_gate as lrg
-
         def _boom(*a, **k):
             raise RuntimeError("gate exploded")
 
         monkeypatch.setattr("archimedes.services.rigor_evaluator.run_rigor_gate", _boom)
-        v = lrg.verdict_from_returns("s", _passing_series(), num_trials=2)
+        # verdict_from_returns is already imported at module top; patching the source
+        # module's run_rigor_gate (which it imports locally) is what makes this work.
+        v = verdict_from_returns("s", _passing_series(), num_trials=2)
         assert v.status == PENDING
         assert v.passes is False
 

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -1,0 +1,334 @@
+"""Tests for strategies_routes — the library-list rigor badge (#821).
+
+The user-facing ``passes_rigor_gate`` badge (and the CANDIDATE → VALIDATED 🏆
+promotion) on ``GET /api/strategies/`` must come from a LIVE ``run_rigor_gate``
+verdict computed on the strategy's persisted real returns — the SAME machinery
+the ``/api/selection-bias/gate`` route uses — NOT from the stored fixture boolean
+in ``analytics-engine/strategies/backtest_fixtures.json``. A strategy with no real
+returns surfaces an explicit ``pending`` badge, never a fixture ``True``/``False``.
+
+These tests mock at the DB boundary (``get_all_daily_returns``) — the persisted
+real-returns source — and assert the served badge equals an independently-computed
+``run_rigor_gate`` verdict on the same returns.
+
+Hermetic gate:
+  env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \\
+      backend/tests/test_strategies_routes.py -q
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from archimedes.services.live_rigor_gate import (
+    FAIL,
+    PASS,
+    PENDING,
+    RigorGateVerdict,
+    verdict_from_returns,
+)
+from archimedes.services.rigor_evaluator import (
+    compute_average_pairwise_correlation,
+    compute_pbo,
+    run_rigor_gate,
+)
+from httpx import ASGITransport, AsyncClient
+
+# ── Hermetic DB fixture ────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Redirect DATABASE_URL to a per-test temp SQLite file.
+
+    The list endpoint calls init_db() (via verdicts_for_strategies) before
+    querying persisted backtest data. Isolating the DB per test satisfies the
+    hermetic-test mandate and prevents cross-run state.
+    """
+    from archimedes.db import init_db
+
+    db_path = tmp_path / "test_strategies_routes.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    init_db()
+    yield
+
+
+# A clean strategy snippet that passes the AST look-ahead audit (no future/peek
+# access). Real curated strategy files also pass; this keeps the test independent
+# of any particular file on disk.
+_CLEAN_CODE = "def init(self):\n    self.sma = 0\n"
+
+
+def _passing_series(seed: int = 0, n: int = 500) -> list[float]:
+    """A return series engineered to clear the live gate when paired with a
+    cohort (≥2 strategies for PBO) + clean code (look-ahead pass)."""
+    return np.random.default_rng(seed).normal(0.0015, 0.004, n).tolist()
+
+
+def _failing_series(seed: int = 99, n: int = 500) -> list[float]:
+    """Pure-noise series — negative/zero drift, high vol — that the gate fails."""
+    return np.random.default_rng(seed).normal(0.0, 0.02, n).tolist()
+
+
+# ── live_rigor_gate unit tests (the single source of truth) ─────────────
+
+
+class TestVerdictFromReturns:
+    def test_no_returns_is_pending(self):
+        v = verdict_from_returns("s", [])
+        assert v.status == PENDING
+        assert v.passes is False
+        assert v.source == "pending"
+
+    def test_too_few_returns_is_pending(self):
+        # Below the 10-obs floor the gate cannot run → pending, NOT a boolean.
+        v = verdict_from_returns("s", [0.01] * 9)
+        assert v.status == PENDING
+        assert v.passes is False
+
+    def test_pending_source_is_never_fixture(self):
+        # The whole point of #821: pending must never be a stored boolean.
+        v = verdict_from_returns("s", [])
+        assert v.source != "fixture"
+
+    def test_real_returns_yield_live_verdict_not_boolean(self):
+        # With real returns the verdict comes from run_rigor_gate, not a constant.
+        a = _passing_series(0)
+        b = _passing_series(1)
+        pbo = compute_pbo({"a": a, "b": b})
+        v = verdict_from_returns("a", a, num_trials=2, pbo_scores=pbo, strategy_code=_CLEAN_CODE)
+        expected = run_rigor_gate("a", a, num_trials=2, pbo_scores=pbo, strategy_code=_CLEAN_CODE)
+        assert v.passes == expected.passes_all
+        assert v.status == (PASS if expected.passes_all else FAIL)
+        assert v.source == "live_gate"
+
+    def test_noise_series_fails_live_gate(self):
+        v = verdict_from_returns("noise", _failing_series(), num_trials=4)
+        assert v.status == FAIL
+        assert v.passes is False
+
+    def test_gate_exception_fails_closed_to_pending(self, monkeypatch):
+        # If run_rigor_gate raises, the badge must NOT claim a pass.
+        import archimedes.services.live_rigor_gate as lrg
+
+        def _boom(*a, **k):
+            raise RuntimeError("gate exploded")
+
+        monkeypatch.setattr("archimedes.services.rigor_evaluator.run_rigor_gate", _boom)
+        v = lrg.verdict_from_returns("s", _passing_series(), num_trials=2)
+        assert v.status == PENDING
+        assert v.passes is False
+
+
+class TestRigorGateVerdict:
+    def test_passes_only_truthy_for_pass(self):
+        assert RigorGateVerdict.passed().passes is True
+        assert RigorGateVerdict.failed().passes is False
+        assert RigorGateVerdict.pending().passes is False
+
+    def test_status_labels(self):
+        assert RigorGateVerdict.passed().status == PASS
+        assert RigorGateVerdict.failed().status == FAIL
+        assert RigorGateVerdict.pending().status == PENDING
+
+
+# ── Acceptance #1: served badge == live run_rigor_gate verdict ──────────
+
+
+@pytest.mark.asyncio
+async def test_library_badge_equals_live_gate_verdict_on_persisted_returns(monkeypatch):
+    """ACCEPTANCE #1: the library-list ``passes_rigor_gate`` for a real strategy
+    equals the live ``run_rigor_gate`` verdict computed on its persisted returns.
+
+    We inject known persisted returns at the DB boundary (get_all_daily_returns),
+    serve the real ``GET /api/strategies/`` endpoint, then independently recompute
+    the gate verdict over the SAME returns (same num_trials / cohort PBO /
+    avg-correlation the route derives) and assert every served badge matches.
+    """
+    from archimedes.api import strategies_routes as sr
+    from archimedes.main import app
+
+    strategies = sr.strategy_provider.list_strategies()
+    assert len(strategies) >= 2, "need ≥2 curated strategies for a PBO cohort"
+
+    # Give the first two real strategies persisted returns: one engineered to
+    # pass, one engineered to fail. The rest get no returns (→ pending).
+    s_pass, s_fail = strategies[0], strategies[1]
+    returns = {s_pass.id: _passing_series(0), s_fail.id: _failing_series()}
+
+    # Patch the DB boundary used by verdicts_for_strategies (imported inside the
+    # function body, so patch the definition module).
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    # Make the look-ahead audit deterministic (clean code → pass) for both.
+    monkeypatch.setattr(
+        "archimedes.services.live_rigor_gate._load_strategy_code_safe",
+        lambda strategy: _CLEAN_CODE,
+    )
+
+    # Independently reproduce the route's library context.
+    valid = {k: v for k, v in returns.items() if len(v) >= 10}
+    pbo_scores = compute_pbo(valid) if len(valid) >= 2 else {}
+    num_trials = max(len(valid), 1)
+    avg_corr = compute_average_pairwise_correlation(valid) if len(valid) >= 2 else 0.0
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=100")
+    assert resp.status_code == 200
+    by_id = {s["id"]: s for s in resp.json()["strategies"]}
+
+    for sid, series in returns.items():
+        expected = run_rigor_gate(
+            strategy_id=sid,
+            daily_returns=series,
+            num_trials=num_trials,
+            pbo_scores=pbo_scores,
+            strategy_code=_CLEAN_CODE,
+            in_sample_sharpe=None,
+            average_correlation=avg_corr,
+        )
+        served = by_id[sid]
+        assert served["passes_rigor_gate"] == expected.passes_all, (
+            f"served badge for {sid} ({served['passes_rigor_gate']}) != live gate verdict ({expected.passes_all})"
+        )
+        assert served["rigor_gate_status"] == (PASS if expected.passes_all else FAIL)
+
+    # The engineered pass strategy passes; the noise strategy fails — on the LIVE path.
+    assert by_id[s_pass.id]["passes_rigor_gate"] is True
+    assert by_id[s_fail.id]["passes_rigor_gate"] is False
+
+
+# ── Acceptance #2: no real returns → pending, not a fixture boolean ─────
+
+
+@pytest.mark.asyncio
+async def test_strategy_without_real_returns_is_pending(monkeypatch):
+    """ACCEPTANCE #2: a strategy with NO persisted returns surfaces a ``pending``
+    badge — never a fixture True/False. We force the DB to return nothing for
+    every strategy, so the live gate cannot run for any of them."""
+    from archimedes.main import app
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: {},
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=100")
+    assert resp.status_code == 200
+    served = resp.json()["strategies"]
+    assert served, "expected curated strategies in the library"
+
+    # EVERY strategy is pending with passes_rigor_gate=False — including the two
+    # strategies whose FIXTURE value is True (moreira_muir, moskowitz_ooi_pedersen).
+    # If the fixture boolean were still the source, those two would read True.
+    for s in served:
+        assert s["rigor_gate_status"] == PENDING, f"{s['id']} not pending: {s['rigor_gate_status']}"
+        assert s["passes_rigor_gate"] is False, f"{s['id']} leaked a non-live pass badge"
+
+
+@pytest.mark.asyncio
+async def test_fixture_true_strategies_do_not_read_true_without_live_returns(monkeypatch):
+    """The two fixture-True strategies (moreira_muir, moskowitz_ooi_pedersen) must
+    NOT show passes_rigor_gate=True purely from the fixture: with no live returns
+    they are ``pending``. This is the direct anti-regression for #821."""
+    from archimedes.api import strategies_routes as sr
+    from archimedes.main import app
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: {},
+    )
+
+    # Resolve the deterministic strategy ids for the two fixture-True stems.
+    by_path = {}
+    for s in sr.strategy_provider.list_strategies():
+        by_path[s.strategy_code_path or ""] = s
+    fixture_true_stems = ("moreira_muir_2017_volatility_managed", "moskowitz_ooi_pedersen_2012_tsmom")
+    targets = [s for path, s in by_path.items() if any(stem in path for stem in fixture_true_stems)]
+    assert targets, "could not resolve the fixture-True strategies"
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=100")
+    by_id = {s["id"]: s for s in resp.json()["strategies"]}
+
+    for t in targets:
+        served = by_id[t.id]
+        assert served["passes_rigor_gate"] is False, f"{t.id} read fixture True on the live path"
+        assert served["rigor_gate_status"] == PENDING
+
+
+# ── CANDIDATE → VALIDATED promotion is live, not fixture-driven ─────────
+
+
+@pytest.mark.asyncio
+async def test_validated_promotion_only_when_live_gate_passes(monkeypatch):
+    """A CANDIDATE is promoted to VALIDATED only when the LIVE gate passes on real
+    returns — not because a fixture said so. With no live returns, every CANDIDATE
+    stays CANDIDATE (no fixture-driven 🏆)."""
+    from archimedes.main import app
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: {},
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=100")
+    served = resp.json()["strategies"]
+
+    # No live returns → no strategy may be served as "validated" purely from a fixture.
+    for s in served:
+        if s["rigor_gate_status"] == PENDING:
+            assert s["status"] != "validated", f"{s['id']} promoted to validated without a live pass"
+
+
+@pytest.mark.asyncio
+async def test_validated_promotion_fires_on_live_pass(monkeypatch):
+    """When the live gate passes on persisted returns for a CANDIDATE strategy, the
+    served status is promoted to VALIDATED."""
+    from archimedes.api import strategies_routes as sr
+    from archimedes.main import app
+    from archimedes.models.strategy import StrategyStatus
+
+    strategies = sr.strategy_provider.list_strategies()
+    candidates = [s for s in strategies if s.status == StrategyStatus.CANDIDATE]
+    assert len(candidates) >= 2, "need ≥2 CANDIDATE strategies"
+    s_pass = candidates[0]
+    cohort = candidates[1]
+    returns = {s_pass.id: _passing_series(0), cohort.id: _passing_series(1)}
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    monkeypatch.setattr(
+        "archimedes.services.live_rigor_gate._load_strategy_code_safe",
+        lambda strategy: _CLEAN_CODE,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=100")
+    by_id = {s["id"]: s for s in resp.json()["strategies"]}
+
+    if by_id[s_pass.id]["passes_rigor_gate"]:
+        assert by_id[s_pass.id]["status"] == "validated"
+
+
+# ── Endpoint smoke + schema shape ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_endpoint_returns_200_and_status_field():
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "strategies" in data and "total" in data
+    for s in data["strategies"]:
+        assert s["rigor_gate_status"] in (PASS, FAIL, PENDING)
+        assert isinstance(s["passes_rigor_gate"], bool)


### PR DESCRIPTION
## Summary

The user-facing library badge `passes_rigor_gate` (and the CANDIDATE → VALIDATED 🏆 promotion) on `GET /api/strategies/` was served from a **stored fixture boolean** (`analytics-engine/strategies/backtest_fixtures.json` → `strategy_provider.py:322` `passes_rigor_gate = bool(fx.get("passes_rigor_gate", False))`), not a live `run_rigor_gate` verdict. The same boolean drove the status promotion (`strategy_provider.py:290`).

That is the cached-pass anti-pattern the **#1 rule forbids** ("claims must be true on the live path") and the one Bogdan's audit (#710) called out. Today's fixture values happen to be internally consistent — so there's no fabricated alpha *today* — but the **pattern** is the bug: a cached boolean the live gate never re-derives. This PR brings the library list onto the **same source of truth** the `/api/selection-bias/gate` route already uses (it recomputes the gate live from persisted DB returns and refuses to synthesize returns from stubs).

## Before → after (badge source of truth)

| | Badge `passes_rigor_gate` | VALIDATED promotion |
| --- | --- | --- |
| **Before** | `Strategy.passes_rigor_gate` ← `fx.get("passes_rigor_gate")` — a fixture constant the gate never re-derives | keyed on the same fixture boolean |
| **After** | LIVE `run_rigor_gate(...).passes_all` computed on the strategy's **persisted real returns** (`get_all_daily_returns` + cohort PBO + `num_trials` + avg-correlation — the exact context the `/gate` route builds) | fires only when the **live gate passes** on real returns |

The fixture boolean is no longer read into the badge or the promotion **anywhere** on the served path.

## How the live verdict is derived: **compute-on-read**

New `backend/archimedes/services/live_rigor_gate.py` is the single source of truth. It **reuses `run_rigor_gate`** (does not reinvent the gate), batches one DB read + one library-wide PBO/`num_trials` context for the list-page window, and **fails closed to `pending`** on any DB/gate error so the badge can never fabricate a pass. The single-strategy fetch path (`get_strategy`) computes the verdict on demand.

## Pending / unknown handling

A strategy with no real returns (< 10 persisted daily returns — genuinely pre-backtest) surfaces an explicit tri-state **`rigor_gate_status: "pending"`** with `passes_rigor_gate: false` (fail-closed) — **never a fixture True/False**. New `rigor_gate_status` field on `StrategyResponse` carries `"pass" | "fail" | "pending"`; `passes_rigor_gate` stays the fail-closed boolean (True only when status == `"pass"`).

## Anti-goals honored

- **Offline/fixture test fixtures untouched** — fixtures still load for display metrics (`dsr_p_value`, `sharpe`, …) and the offline fixture tests; only their *boolean* is no longer the production badge.
- **Gate thresholds unchanged** — `run_rigor_gate` is called as-is.
- **Hermetic** — tests mock at the DB boundary (`get_all_daily_returns`), no live Redis/Postgres/RPC.
- No `asyncio.get_event_loop().run_until_complete`; `pytest.ini` untouched.

## Tests

- **new** `backend/tests/test_strategies_routes.py` — served badge **==** live `run_rigor_gate` verdict on persisted returns (acceptance #1); no-real-returns → `pending` (acceptance #2); the two fixture-True strategies (moreira_muir, moskowitz_ooi_pedersen) do **not** read True on the live path; VALIDATED promotion fires only on a live pass.
- **updated** `test_api_routes.py::test_rigor_gate_badge_is_live_not_fixture_for_tier1` (was `..._fields_correct_for_tier1`, which asserted the *old* fixture-driven `True`).

## Hermetic verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_strategies_routes.py backend/tests/test_selection_bias_routes.py -q
# → 64 passed
```

## Note on a pre-existing flaky test (NOT introduced here)

`test_api_routes.py::TestAdvisorRoutes::test_advisor_happy_path` is **pre-existing flaky** — it depends on non-deterministic market-data fetch in the optimizer and fails identically on pristine `origin/main` under hermetic `env -i` (verified by reverting all of this PR's tracked files and re-running: same ~0.82 allocation-sum failure). Out of scope; not touched.

Reviewer note: backend `services`/`api` lane — same single-source-of-truth principle as the live `/gate` route. Flagging @danielscoffee / @dbrowneup.

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)