### PR TITLE
[oracle] Secondary-source cross-check — primary vs independent yfinance, fail-closed + asymmetric (#775, replaces #832)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,10 +186,12 @@ ADMIN_PRICES_JSON=
 # Secondary-source cross-check (#775): before pushing a NON-yfinance primary
 # price (Pyth/Stork) on-chain, the oracle runner compares it to an independent
 # yfinance reading and FAILS CLOSED if they diverge beyond this band (bps).
-# Asymmetric by design: a stale/missing/flaky yfinance NEVER blocks a healthy
-# primary (it only logs) — only a confident divergence between two healthy
-# sources fails closed. No-op when PRICE_SOURCE=yfinance (same source). 0 to
-# disable. Generous default; Önder owns tuning the band + staleness.
+# Asymmetric: a MISSING / errored / non-positive yfinance NEVER blocks a healthy
+# primary (it only logs). Magnitude-band only — it does NOT yet detect a stale
+# (but positive) yfinance value, so the generous default band is what tolerates
+# off-hours/weekend drift; a real secondary-freshness check is #775 Phase 2
+# (Önder's lane). No-op when PRICE_SOURCE=yfinance (same source) or for admin
+# pins. 0 to disable.
 PRICE_CROSSCHECK_BAND_BPS=5000
 
 # ── Contract addresses (Arc testnet, Chain ID 5042002 / 0x4cef52) ─────────

--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,15 @@ PYTH_HERMES_URL=https://hermes.pyth.network
 # the cascade in any mode. Last-resort / demo pin. e.g. {"sSPY": 512.3}
 ADMIN_PRICES_JSON=
 
+# Secondary-source cross-check (#775): before pushing a NON-yfinance primary
+# price (Pyth/Stork) on-chain, the oracle runner compares it to an independent
+# yfinance reading and FAILS CLOSED if they diverge beyond this band (bps).
+# Asymmetric by design: a stale/missing/flaky yfinance NEVER blocks a healthy
+# primary (it only logs) — only a confident divergence between two healthy
+# sources fails closed. No-op when PRICE_SOURCE=yfinance (same source). 0 to
+# disable. Generous default; Önder owns tuning the band + staleness.
+PRICE_CROSSCHECK_BAND_BPS=5000
+
 # ── Contract addresses (Arc testnet, Chain ID 5042002 / 0x4cef52) ─────────
 # (Chain ID aligned with README/CLAUDE; verify with Dan/contracts before relying
 # on them — Dan owns the contracts + deploys them.)

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -50,6 +50,11 @@ DEFAULT_MAX_DEVIATION_BPS = 2000
 # Max age of the upstream observation before we refuse to push it on-chain.
 # Override via ORACLE_MAX_UPSTREAM_STALENESS_SECONDS.
 DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS = 900  # 15 minutes
+# Secondary-source cross-check band (#775): the max divergence (bps) between a
+# NON-yfinance primary (Pyth/Stork via the PRICE_SOURCE cascade) and an
+# independent yfinance reading before we fail closed. Generous default — both
+# sources lag between updates; Önder owns tuning. 0 disables the cross-check.
+DEFAULT_CROSSCHECK_BAND_BPS = 5000  # 50%
 
 
 def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
@@ -93,6 +98,9 @@ class OracleUpdater:
         # Last price (6-dec int) we successfully submitted, per symbol —
         # fallback deviation reference when the on-chain read fails.
         self._last_pushed_price_int: dict[str, int] = {}
+
+        # Secondary-source cross-check band (#775).
+        self._crosscheck_band_bps: int = int(os.getenv("PRICE_CROSSCHECK_BAND_BPS", str(DEFAULT_CROSSCHECK_BAND_BPS)))
 
     # ─── Public API ──────────────────────────────────────────────
 
@@ -218,6 +226,10 @@ class OracleUpdater:
                 # that are non-positive, stale upstream, or deviate too far
                 # from the last known good price.
                 rejection = await self._validate_for_push(price, price_int)
+                # Secondary-source cross-check (#775): only when the sanity gate
+                # already passed (avoid the extra yfinance fetch on a rejected price).
+                if rejection is None:
+                    rejection = await self._cross_check_secondary(price)
                 if rejection is not None:
                     logger.warning(f"Refusing to push {price.symbol} price {price.price_usd}: {rejection}")
                     continue
@@ -331,6 +343,65 @@ class OracleUpdater:
                     f"{reference_int / 1e6:.2f} exceeds {self._max_deviation_bps} bps cap"
                 )
 
+        return None
+
+    async def _cross_check_secondary(self, price: AssetPrice) -> str | None:
+        """Secondary-source cross-check (#775): compare a NON-yfinance primary
+        (Pyth/Stork via the PRICE_SOURCE cascade) against an independent yfinance
+        reading and fail closed when they diverge beyond the band. Returns a
+        rejection reason, or None to proceed.
+
+        **Asymmetric, by design.** A stale / missing / flaky yfinance NEVER blocks
+        a healthy primary — otherwise a yfinance outage (it's known-flaky, #772)
+        would become a trading halt and the guardrail itself the failure. yfinance
+        problems only proceed-and-log; only a *confident* divergence between two
+        healthy sources fails closed.
+
+        Honest claim this earns: *"primary cross-checked against an independent
+        yfinance market source, fail-closed on divergence beyond a band."* NOT
+        "decentralized 2-of-3" (yfinance is centralized + off-chain). The check is
+        a no-op when the primary IS yfinance (same source — not independent) or
+        when no yfinance ticker exists for the symbol. Band/staleness thresholds
+        are Önder's lane to tune (collaborate per #775).
+        """
+        if self._crosscheck_band_bps <= 0:
+            return None  # disabled
+        if price.source == "yfinance":
+            return None  # primary IS yfinance — not an independent second source
+        yf_ticker = YFINANCE_MAP.get(price.symbol)
+        if not yf_ticker:
+            return None  # no independent yfinance ticker for this symbol → can't cross-check → proceed
+        try:
+            secondary = await self._fetch_yfinance_single(yf_ticker)
+        except Exception as exc:
+            logger.warning(
+                "cross-check: yfinance fetch failed for %s (%s) — proceeding on primary (asymmetric)",
+                price.symbol,
+                exc,
+            )
+            return None
+        if secondary is None or secondary <= 0:
+            logger.info(
+                "cross-check: no usable yfinance secondary for %s — proceeding on primary (asymmetric)",
+                price.symbol,
+            )
+            return None
+
+        deviation_bps = abs(price.price_usd - secondary) / secondary * 10_000
+        if deviation_bps > self._crosscheck_band_bps:
+            return (
+                f"cross-check FAIL: primary({price.source}) {price.price_usd:.4f} diverges "
+                f"{deviation_bps:.0f} bps from independent yfinance {secondary:.4f} "
+                f"(band {self._crosscheck_band_bps} bps) — failing closed"
+            )
+        logger.debug(
+            "cross-check OK for %s: primary(%s) %.4f vs yfinance %.4f (%.0f bps)",
+            price.symbol,
+            price.source,
+            price.price_usd,
+            secondary,
+            deviation_bps,
+        )
         return None
 
     async def _get_reference_price_int(self, symbol: str) -> tuple[int | None, bool]:

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -57,6 +57,23 @@ DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS = 900  # 15 minutes
 DEFAULT_CROSSCHECK_BAND_BPS = 5000  # 50%
 
 
+def _int_env(name: str, default: int) -> int:
+    """Parse an integer env var, failing SAFE to ``default`` on a missing/blank/
+    non-numeric value (with a warning) rather than raising at oracle-runner startup.
+
+    A bare ``int(os.getenv(...))`` turns a typo'd or empty env var into a hard
+    startup crash; the oracle runner must degrade to the documented default instead.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        logger.warning("invalid %s=%r (not an integer) — falling back to %d", name, raw, default)
+        return default
+
+
 def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
     """Encrypt entity secret with Circle's RSA public key (OAEP/SHA-256).
 
@@ -90,17 +107,18 @@ class OracleUpdater:
         self._entity_secret: str = os.getenv("CIRCLE_ENTITY_SECRET", "")
         self._wallet_id: str = os.getenv("WALLET_ID", "")
 
-        # Sanity bounds (audit #13 / issue #508)
-        self._max_deviation_bps: int = int(os.getenv("ORACLE_MAX_DEVIATION_BPS", str(DEFAULT_MAX_DEVIATION_BPS)))
-        self._max_upstream_staleness_s: int = int(
-            os.getenv("ORACLE_MAX_UPSTREAM_STALENESS_SECONDS", str(DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS))
+        # Sanity bounds (audit #13 / issue #508). Parsed fail-safe: a non-numeric
+        # env var degrades to the default instead of crashing the runner at startup.
+        self._max_deviation_bps: int = _int_env("ORACLE_MAX_DEVIATION_BPS", DEFAULT_MAX_DEVIATION_BPS)
+        self._max_upstream_staleness_s: int = _int_env(
+            "ORACLE_MAX_UPSTREAM_STALENESS_SECONDS", DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS
         )
         # Last price (6-dec int) we successfully submitted, per symbol —
         # fallback deviation reference when the on-chain read fails.
         self._last_pushed_price_int: dict[str, int] = {}
 
         # Secondary-source cross-check band (#775).
-        self._crosscheck_band_bps: int = int(os.getenv("PRICE_CROSSCHECK_BAND_BPS", str(DEFAULT_CROSSCHECK_BAND_BPS)))
+        self._crosscheck_band_bps: int = _int_env("PRICE_CROSSCHECK_BAND_BPS", DEFAULT_CROSSCHECK_BAND_BPS)
 
     # ─── Public API ──────────────────────────────────────────────
 
@@ -358,16 +376,28 @@ class OracleUpdater:
         healthy sources fails closed.
 
         Honest claim this earns: *"primary cross-checked against an independent
-        yfinance market source, fail-closed on divergence beyond a band."* NOT
-        "decentralized 2-of-3" (yfinance is centralized + off-chain). The check is
-        a no-op when the primary IS yfinance (same source — not independent) or
-        when no yfinance ticker exists for the symbol. Band/staleness thresholds
-        are Önder's lane to tune (collaborate per #775).
+        yfinance market source, fail-closed on relative-magnitude divergence beyond
+        a band."* NOT "decentralized 2-of-3" (yfinance is centralized + off-chain).
+
+        **Scope + a known limitation (be precise, #775):** this is a *magnitude*
+        band check only. It does NOT verify the *freshness* of the yfinance secondary
+        — ``_fetch_yfinance_single`` returns a bare price with no observation
+        timestamp, so a stale weekend/off-hours yfinance read could in principle
+        trip a divergence against a healthy primary. The wide default band
+        (``DEFAULT_CROSSCHECK_BAND_BPS`` = 5000 bps / 50%) is what tolerates that for
+        now; a real secondary-freshness check (threading the yfinance bar timestamp
+        through) is follow-up tuning in Önder's lane (#775 Phase 2), NOT implemented
+        here. The check is a no-op when the primary is yfinance (same source), an
+        admin pin (operator last-resort override — must not be second-guessed), or
+        when the symbol has no yfinance ticker.
         """
         if self._crosscheck_band_bps <= 0:
             return None  # disabled
-        if price.source == "yfinance":
-            return None  # primary IS yfinance — not an independent second source
+        if price.source in ("yfinance", "admin"):
+            # yfinance: same source, not an independent second opinion.
+            # admin: a last-resort operator pin (ADMIN_PRICES_JSON) — the whole point
+            # is to override upstream, so the secondary guardrail must not block it.
+            return None
         yf_ticker = YFINANCE_MAP.get(price.symbol)
         if not yf_ticker:
             return None  # no independent yfinance ticker for this symbol → can't cross-check → proceed

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -58,15 +58,17 @@ DEFAULT_CROSSCHECK_BAND_BPS = 5000  # 50%
 
 
 def _int_env(name: str, default: int) -> int:
-    """Parse an integer env var, failing SAFE to ``default`` on a missing/blank/
-    non-numeric value (with a warning) rather than raising at oracle-runner startup.
+    """Parse an integer env var, failing SAFE to ``default`` rather than raising at
+    oracle-runner startup.
 
-    A bare ``int(os.getenv(...))`` turns a typo'd or empty env var into a hard
-    startup crash; the oracle runner must degrade to the documented default instead.
+    A missing or blank value silently uses ``default`` — an unset optional var is
+    normal and must not log on every startup. A value that is PRESENT but non-numeric
+    (a typo) is a real misconfiguration, so it logs a warning before falling back. A
+    bare ``int(os.getenv(...))`` would instead crash the runner on either.
     """
     raw = os.getenv(name)
     if raw is None or raw.strip() == "":
-        return default
+        return default  # unset/blank optional var → default, no warning (not a misconfig)
     try:
         return int(raw.strip())
     except ValueError:

--- a/backend/tests/chain/test_oracle_crosscheck.py
+++ b/backend/tests/chain/test_oracle_crosscheck.py
@@ -46,6 +46,16 @@ async def test_yfinance_primary_is_noop():
     m.assert_not_called()
 
 
+async def test_admin_source_is_noop():
+    # An admin pin (ADMIN_PRICES_JSON last-resort operator override) must NOT be
+    # second-guessed by the secondary guardrail — the whole point is to override
+    # upstream. yfinance must not even be fetched.
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock()) as m:
+        assert await u._cross_check_secondary(_price(source="admin")) is None
+    m.assert_not_called()
+
+
 async def test_unmapped_symbol_is_noop():
     # A symbol with no yfinance ticker can't be cross-checked → proceed.
     u = _updater()

--- a/backend/tests/chain/test_oracle_crosscheck.py
+++ b/backend/tests/chain/test_oracle_crosscheck.py
@@ -1,0 +1,100 @@
+"""Hermetic tests for the #775 secondary-source price cross-check.
+
+Pins the load-bearing safety property: the cross-check is **asymmetric** — a
+stale/missing/flaky yfinance NEVER blocks a healthy primary (only a confident
+divergence between two healthy sources fails closed) — and is a no-op when the
+primary is itself yfinance (not an independent source). No network: the single
+yfinance read is mocked at the boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from archimedes.chain.oracle_updater import OracleUpdater
+from archimedes.models.asset import AssetPrice
+
+NOW = datetime(2026, 6, 30, tzinfo=UTC)
+
+
+def _price(symbol: str = "sSPY", usd: float = 500.0, source: str = "pyth_hermes") -> AssetPrice:
+    return AssetPrice(symbol=symbol, price_usd=usd, timestamp=NOW, source=source)
+
+
+def _updater(band_bps: int = 5000) -> OracleUpdater:
+    u = OracleUpdater()
+    u._crosscheck_band_bps = band_bps
+    return u
+
+
+# ── no-op cases (nothing to cross-check) ──────────────────────────────────
+
+
+async def test_disabled_band_is_noop():
+    u = _updater(0)
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=1.0)) as m:
+        assert await u._cross_check_secondary(_price()) is None
+    m.assert_not_called()  # disabled → never even fetches
+
+
+async def test_yfinance_primary_is_noop():
+    # When the primary IS yfinance there is no independent second source.
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock()) as m:
+        assert await u._cross_check_secondary(_price(source="yfinance")) is None
+    m.assert_not_called()
+
+
+async def test_unmapped_symbol_is_noop():
+    # A symbol with no yfinance ticker can't be cross-checked → proceed.
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock()) as m:
+        assert await u._cross_check_secondary(_price(symbol="sNOTREAL")) is None
+    m.assert_not_called()
+
+
+# ── the asymmetry (the safety property) ───────────────────────────────────
+
+
+async def test_asymmetric_yfinance_exception_proceeds():
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(side_effect=RuntimeError("yfinance down"))):
+        # A yfinance OUTAGE must NOT halt a healthy primary.
+        assert await u._cross_check_secondary(_price()) is None
+
+
+async def test_asymmetric_yfinance_none_proceeds():
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=None)):
+        assert await u._cross_check_secondary(_price()) is None
+
+
+async def test_asymmetric_yfinance_nonpositive_proceeds():
+    u = _updater()
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=0.0)):
+        assert await u._cross_check_secondary(_price()) is None
+
+
+# ── the actual guardrail ──────────────────────────────────────────────────
+
+
+async def test_in_band_proceeds():
+    u = _updater(5000)  # 50% band
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=510.0)):  # ~2% off
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None
+
+
+async def test_out_of_band_fails_closed():
+    u = _updater(1000)  # 10% band
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=1000.0)):  # 2x off
+        reason = await u._cross_check_secondary(_price(usd=500.0))
+    assert reason is not None
+    assert "diverges" in reason and "failing closed" in reason
+
+
+async def test_band_boundary_inclusive_proceeds():
+    # Exactly at the band is allowed (strict > check). 500 vs 550 = 909bps < 1000.
+    u = _updater(1000)
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=550.0)):
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None


### PR DESCRIPTION
> **Replaces #832.** That PR was auto-closed by GitHub when its base branch
> (`dbrowneup/oracle-pyth-hermes`, PR #826) was merged + deleted, and a PR whose
> base branch is gone can't be reopened or retargeted. This PR is the same work,
> rebased onto `main`, **with all Copilot review feedback from #832 addressed.**

## What (#775 Phase 1, on top of the now-merged #826 cascade)

Before pushing a **non-yfinance** primary price (Pyth/Stork via the `PRICE_SOURCE` cascade) on-chain, the oracle runner cross-checks it against an **independent yfinance** reading and **fails closed** on divergence beyond a band. **No contract change.**

## The asymmetry (the load-bearing safety property)

A missing / errored / non-positive yfinance (it's known-flaky, #772) **NEVER blocks a healthy primary** — otherwise a yfinance outage becomes a *trading halt* and the guardrail itself the failure. A yfinance problem only **proceeds-and-logs**; only a **confident magnitude divergence between two healthy sources** fails closed. No-op when the primary IS yfinance (same source), an **admin pin**, or when no yfinance ticker exists for the symbol.

> Honest claim this earns: *"primary cross-checked against an independent yfinance market source, fail-closed on relative-magnitude divergence beyond a band."* **NOT** "decentralized 2-of-3" (yfinance is centralized + off-chain), and **NOT** a freshness check on the secondary (see below).

## Copilot review feedback addressed (vs #832)

- **Fail-safe env parsing.** `_int_env` helper — `ORACLE_MAX_DEVIATION_BPS` / `ORACLE_MAX_UPSTREAM_STALENESS_SECONDS` / `PRICE_CROSSCHECK_BAND_BPS` now degrade to their default (with a warning) on a missing/blank/non-numeric value instead of crashing the runner at startup.
- **Admin pins are not second-guessed.** `_cross_check_secondary` is now a no-op for `source=="admin"` (an `ADMIN_PRICES_JSON` last-resort override must override upstream, not be blocked). Pinned by `test_admin_source_is_noop`.
- **Honest staleness claim (claims-must-be-true).** The docstring + `.env.example` no longer imply the check handles a *stale* yfinance secondary — it's a **magnitude band only** and does **not** detect a stale-but-positive yfinance value (no observation timestamp). The wide default band tolerates off-hours drift; a real secondary-freshness check is called out as **#775 Phase 2** (Önder's lane).

## Build

- `_cross_check_secondary(price)` wired into `push_prices_on_chain` **after** the existing `_validate_for_push` (runs only on an otherwise-pushable price).
- `PRICE_CROSSCHECK_BAND_BPS` env (default `5000`=50%, `0` disables) + `.env.example`.
- **10 hermetic tests**: disabled-noop, yfinance-primary-noop, **admin-noop**, unmapped-symbol-noop, the **3 asymmetry cases** (yfinance exception / None / ≤0 all PROCEED), in-band proceeds, out-of-band fails closed, band boundary. Full chain suite (148 tests) green.

## Notes

- **Part of #775 — Phase 1.** #775 stays **open** for Phase 2 (the on-chain leg + the secondary-freshness check + band/staleness tuning — Önder's lane).
- The symbol→yfinance map broadens with the **#759 universe** expansion (per-asset `yfinance_ticker`).
