### PR TITLE
[infra] Fix private route tables: stop deleting the VPC-peering route on apply

### DIFF
--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -101,20 +101,28 @@ resource "aws_subnet" "private" {
   }
 }
 
-# Each private subnet routes outbound through its AZ's NAT instance
+# Each private subnet routes outbound through its AZ's NAT instance.
+# IMPORTANT: routes are defined as standalone aws_route resources (the NAT default
+# route below + aws_route.main_to_default in aurora.tf for the VPC-peering return
+# path to the app EC2 in the default VPC). Do NOT add inline `route` blocks to this
+# table — Terraform forbids mixing inline routes with aws_route resources on the same
+# table, and doing so makes it churn/DELETE the peering route on every apply (which
+# severs Aurora/ElastiCache → app connectivity).
 resource "aws_route_table" "private" {
   count  = 2
   vpc_id = aws_vpc.main.id
-
-  route {
-    cidr_block           = "0.0.0.0/0"
-    network_interface_id = aws_instance.nat[count.index].primary_network_interface_id
-  }
 
   tags = {
     Name    = "${var.project_name}-private-rt-${local.azs[count.index]}"
     Project = var.project_name
   }
+}
+
+resource "aws_route" "private_nat" {
+  count                  = 2
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = aws_instance.nat[count.index].primary_network_interface_id
 }
 
 resource "aws_route_table_association" "private" {


### PR DESCRIPTION
## Problem (caught while verifying a pending `terraform apply`)

A `terraform plan` against current `main` proposed **deleting the `172.31.0.0/16 → VPC-peering` route from both archimedes-vpc private route tables.** That route is the **return path from Aurora/ElastiCache (10.0.0.0/16) to the app EC2 (172.31.17.86 in the default VPC)** — applying it would have severed the live DB + Redis connectivity and taken the site down.

## Root cause — terraform anti-pattern (drift)

`aws_route_table.private` had an **inline `route` block** (NAT default route) *and* a standalone **`aws_route.main_to_default`** (the peering route, in `aurora.tf`) on the same table. Terraform forbids mixing inline routes with `aws_route` resources — the inline block owns the whole route set and kept trying to delete the peering route the standalone resource adds. The peering route was added live during the Aurora/ElastiCache cutover; the config never reconciled.

## Fix

Convert the private RT to **all standalone `aws_route`**: drop the inline `route` block, add `aws_route.private_nat` for the NAT default route (mirrors the existing `aws_route.main_to_default`). **Verified via a read-only plan** in an isolated worktree: the peering-route deletion disappears — `0 to destroy`, no `172.31` change, `aws_route.main_to_default` only refreshes.

## ⚠️ Required before `terraform apply`

The NAT routes already exist live, so a bare apply errors `RouteAlreadyExists`. Import them first so terraform adopts them:

```bash
terraform import 'aws_route.private_nat[0]' rtb-0b36e697382957ea3_0.0.0.0/0
terraform import 'aws_route.private_nat[1]' rtb-0e3c1d6f419a7d508_0.0.0.0/0
```

Then `terraform plan` must show **0-destroy + no route deletions** before applying.

## Verification done

- Live topology confirmed: app EC2 `i-01803d3abc271d39b` in default VPC (172.31.17.86); Aurora + private subnets in archimedes-vpc (10.0.0.0/16); peering `pcx-02bd9fed` active.
- Read-only plan with the fix → peering-route deletion gone; only benign changes remain (CloudFront viewer-geo in-place #795, EC2 user_data in-place #780 — no restart, Bedrock IAM additive, local key file). Nothing applied/imported by me — that stays with Dan.

Infra change — Dan owns the AWS account + the apply.
