### PR TITLE
[contracts] On-chain quorum price oracle — Stork+Pyth median, Chainlink-ready !minor

### DIFF
--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -310,7 +310,7 @@ contract PriceOracle is Ownable {
     ///         unusable — a bad feed degrades rather than bricking every consumer.
     /// @dev    Signature unchanged (no-arg) so Vault / SyntheticVault / SyntheticFactory
     ///         keep compiling and behaving identically. (#724 review: fixes 1 + 2.)
-    function getPrice() external view returns (uint256) {
+    function getPrice() external view virtual returns (uint256) {
         // The admin-fed value is the trusted fallback reference; freshness computed once.
         bool adminFresh = block.timestamp <= lastUpdated + MAX_STALENESS;
 
@@ -358,7 +358,7 @@ contract PriceOracle is Ownable {
     ///         (when the feed is absent/bad) the admin fallback is fresh. View-safe and
     ///         never reverts — no external self-call (#724 review). Note: this does not
     ///         re-check the sanity band; it reports source liveness, not band agreement.
-    function isFresh() external view returns (bool) {
+    function isFresh() external view virtual returns (bool) {
         bool adminFresh = block.timestamp <= lastUpdated + MAX_STALENESS;
         if (address(priceFeed) != address(0)) {
             (bool ok,) = _tryReadChainlink();
@@ -385,7 +385,22 @@ contract PriceOracle is Ownable {
     ///         feed, so the canonical mitigation is unwireable; the underlying "stale
     ///         price survives a restart" risk is covered by the degrade + tight heartbeat.
     function _tryReadChainlink() internal view returns (bool ok, uint256 scaledPrice) {
-        try priceFeed.latestRoundData() returns (
+        return _tryReadFeed(priceFeed, feedDecimals);
+    }
+
+    /// @notice Read + validate + scale ONE AggregatorV3 feed answer to 6 decimals WITHOUT
+    ///         reverting (returns (false, 0) on any problem). Parameterized over
+    ///         (feed, cached decimals) so the single-feed wrapper above AND the multi-feed
+    ///         quorum (QuorumPriceOracle) reuse the identical #724 validation + scaling —
+    ///         one audited primitive, two callers. Fail-soft cases are exactly as documented
+    ///         on `_tryReadChainlink` above. `feed`/`dec` are caller-supplied (the single
+    ///         feed, or one entry of a quorum feed set), never re-read from storage here.
+    function _tryReadFeed(AggregatorV3Interface feed, uint8 dec)
+        internal
+        view
+        returns (bool ok, uint256 scaledPrice)
+    {
+        try feed.latestRoundData() returns (
             uint80 roundId, int256 answer, uint256, uint256 updatedAt, uint80 answeredInRound
         ) {
             if (answer <= 0) return (false, 0);
@@ -395,7 +410,7 @@ contract PriceOracle is Ownable {
             if (block.timestamp > updatedAt + feedStaleness) return (false, 0);
 
             uint256 raw = uint256(answer); // safe: answer > 0 checked above
-            uint8 d = feedDecimals; // cached at setPriceFeed — no per-read external call
+            uint8 d = dec; // cached at config time — no per-read external call
             uint256 scaled;
             if (d == PRICE_DECIMALS) {
                 scaled = raw;

--- a/contracts/src/QuorumPriceOracle.sol
+++ b/contracts/src/QuorumPriceOracle.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PriceOracle.sol";
+
+/// @title QuorumPriceOracle
+/// @notice On-chain N-feed **quorum** price oracle: reads every configured
+///         `AggregatorV3Interface` source (e.g. Chainlink Data Feed, the Stork
+///         `AggregatorV3` adapter, a Pyth `AggregatorV3` wrapper), validates each with the
+///         *exact* #724 round/staleness/scaling guards (inherited `_tryReadFeed`), and
+///         returns the **median of the fresh ones** — requiring **≥2 fresh feeds that agree
+///         within a band** (fail-closed on divergence), degrading cleanly to a single-feed
+///         admin-cross-checked read and then to the bounded admin fallback as fewer feeds
+///         are live.
+/// @dev    ⚠️ Funds-adjacent (Dan owns contracts; Bogdan reviews). IS-A {PriceOracle}, so it
+///         drops in anywhere a `PriceOracle` is expected (Vault / SyntheticVault /
+///         SyntheticFactory all cast to the concrete type and call the no-arg
+///         `getPrice() → uint256`) with **zero consumer change**. Every audited admin-path
+///         guard (`maxDeviationBps`, `updateCooldown`, `forceSetPrice` / `MAX_STALENESS`,
+///         the feed-vs-admin sanity band) is inherited intact and backs the degrade target.
+///
+///         **Pricing only — NOT settlement.** This changes only the *price* a vault reads.
+///         No settlement behavior changes (testnet trading stays paper/simulated per the
+///         North Star). Spec: docs/specs/onchain-quorum-oracle-spec.md.
+///
+///         **Feed management.** Quorum sources are managed via {addFeed} / {removeFeed};
+///         the inherited single `priceFeed` (`setPriceFeed`) is **ignored** by this
+///         contract's `getPrice()` override — use `addFeed`, not `setPriceFeed`, on a
+///         QuorumPriceOracle. The inherited admin-fed `price` remains the bounded fallback.
+contract QuorumPriceOracle is PriceOracle {
+    /// @notice Pricing tiers reported by {priceWithProvenance} — an on-chain provenance fact
+    ///         (which source priced the asset), not a cached boolean.
+    uint8 public constant TIER_ADMIN = 0; // no fresh on-chain feed → bounded admin fallback
+    uint8 public constant TIER_SINGLE = 1; // exactly 1 fresh feed → feed + admin sanity band
+    uint8 public constant TIER_QUORUM = 2; // ≥2 fresh feeds that agree → median
+
+    /// @notice Minimum fresh feeds required to form a quorum (median of ≥2 agreeing feeds).
+    uint256 public constant MIN_QUORUM = 2;
+
+    /// @notice The quorum source set. Each entry presents `AggregatorV3Interface` — a
+    ///         Chainlink feed, the Stork adapter (#828/#794), or a Pyth `AggregatorV3`
+    ///         wrapper. Owner-managed via {addFeed} / {removeFeed}.
+    AggregatorV3Interface[] public feeds;
+
+    /// @notice `feeds[i].decimals()` cached at add time (parallel to `feeds`), so the hot
+    ///         read path makes a single external call per feed (`latestRoundData`) and never
+    ///         trusts a feed to report stable decimals across calls — same TOCTOU hardening
+    ///         as the inherited single-feed `feedDecimals` (#724).
+    uint8[] public feedDecs;
+
+    /// @notice Max spread `(max−min)/median` (bps) for the fresh feeds to be considered
+    ///         *agreeing* and thus eligible for the median. Distinct from the inherited
+    ///         `maxFeedDeviationBps` (feed-vs-admin band). Default 200 (2%) — tight enough
+    ///         that a single compromised/mis-pointed feed in the set drags the spread out of
+    ///         band and forces a fail-closed degrade rather than poisoning the median.
+    ///         0 → require exact agreement. Owner-tunable, bounded by BPS_DENOMINATOR.
+    uint256 public quorumBandBps = 200;
+
+    event FeedAdded(address indexed feed, uint8 decimals, uint256 count);
+    event FeedRemoved(address indexed feed, uint256 count);
+    event QuorumBandBpsChanged(uint256 oldBps, uint256 newBps);
+
+    error ZeroFeed();
+    error FeedAlreadyAdded(address feed);
+    error IndexOutOfBounds(uint256 index, uint256 length);
+
+    constructor(string memory _symbol, uint256 _initialPrice, address _owner)
+        PriceOracle(_symbol, _initialPrice, _owner)
+    {}
+
+    // ── Feed-set management (owner-only) ──────────────────────────────────
+
+    /// @notice Add a quorum feed. Probes + caches `decimals()` (bounded ≤36 like
+    ///         {setPriceFeed}); rejects the zero address and duplicates.
+    /// @dev    ⚠️ Funds-adjacent: adding a wrong/mis-denominated feed lets a bad source into
+    ///         the median. Verify the feed address + asset/USD denomination before calling.
+    function addFeed(address feed) external onlyOwner {
+        if (feed == address(0)) revert ZeroFeed();
+        uint256 len = feeds.length;
+        for (uint256 i; i < len; ++i) {
+            if (address(feeds[i]) == feed) revert FeedAlreadyAdded(feed);
+        }
+        uint8 d = AggregatorV3Interface(feed).decimals();
+        if (d > 36) revert InvalidFeedDecimals(d);
+        feeds.push(AggregatorV3Interface(feed));
+        feedDecs.push(d);
+        emit FeedAdded(feed, d, feeds.length);
+    }
+
+    /// @notice Remove the feed at `index` (swap-and-pop; order not preserved). Lets the
+    ///         owner retire a deprecated/compromised feed without redeploying.
+    function removeFeed(uint256 index) external onlyOwner {
+        uint256 len = feeds.length;
+        if (index >= len) revert IndexOutOfBounds(index, len);
+        address removed = address(feeds[index]);
+        feeds[index] = feeds[len - 1];
+        feedDecs[index] = feedDecs[len - 1];
+        feeds.pop();
+        feedDecs.pop();
+        emit FeedRemoved(removed, feeds.length);
+    }
+
+    /// @notice Tune the quorum agreement band (bps), or 0 to require exact agreement.
+    ///         Owner-only; bounded by BPS_DENOMINATOR (a band ≥100% is no band at all).
+    function setQuorumBandBps(uint256 bps) external onlyOwner {
+        if (bps > BPS_DENOMINATOR) revert InvalidDeviationBound();
+        uint256 old = quorumBandBps;
+        quorumBandBps = bps;
+        emit QuorumBandBpsChanged(old, bps);
+    }
+
+    /// @notice Number of configured quorum feeds.
+    function feedCount() external view returns (uint256) {
+        return feeds.length;
+    }
+
+    // ── Read path (the quorum) ────────────────────────────────────────────
+
+    /// @notice Current asset price in USDC 6-decimal units, via the quorum.
+    ///         Reverts ({StalePrice}) only when no tier can produce a usable price.
+    /// @dev    Signature identical to {PriceOracle.getPrice} (no-arg) — drop-in for every
+    ///         consumer. Overrides the inherited single-feed path with the N-feed quorum.
+    function getPrice() external view override returns (uint256) {
+        (uint256 p,,, bool usable) = _resolve();
+        if (!usable) revert StalePrice();
+        return p;
+    }
+
+    /// @notice Non-reverting provenance read for telemetry / UI / the #759 `oracle_tier`
+    ///         mapping: the price, which tier produced it, how many feeds were fresh, and
+    ///         whether the result is usable. Claims-true: this is the on-chain fact of how
+    ///         the asset was priced, not a label.
+    function priceWithProvenance()
+        external
+        view
+        returns (uint256 priceUsdc, uint8 tier, uint256 nFresh, bool usable)
+    {
+        return _resolve();
+    }
+
+    /// @notice True when {getPrice} would return (any tier produces a usable price).
+    function isFresh() external view override returns (bool) {
+        (,,, bool usable) = _resolve();
+        return usable;
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────
+
+    /// @dev The N-aware tiered resolution. Pure of side effects; both {getPrice} and
+    ///      {priceWithProvenance} read through it so the price and its provenance can never
+    ///      disagree. Fail-closed: a divergent ≥2-feed set is NEVER priced off the feeds.
+    function _resolve()
+        internal
+        view
+        returns (uint256 resolvedPrice, uint8 tier, uint256 nFresh, bool usable)
+    {
+        bool adminFresh = block.timestamp <= lastUpdated + MAX_STALENESS;
+
+        // Collect the fresh, valid on-chain feed reads (each via the inherited #724 guard).
+        uint256 len = feeds.length;
+        uint256[] memory vals = new uint256[](len);
+        uint256 n;
+        for (uint256 i; i < len; ++i) {
+            (bool ok, uint256 p) = _tryReadFeed(feeds[i], feedDecs[i]);
+            if (ok) {
+                vals[n] = p;
+                ++n;
+            }
+        }
+        nFresh = n;
+
+        // ── Tier QUORUM: ≥2 fresh feeds ──────────────────────────────────
+        if (n >= MIN_QUORUM) {
+            (uint256 med, uint256 lo, uint256 hi) = _median(vals, n);
+            if (_agree(med, hi - lo)) {
+                return (med, TIER_QUORUM, n, true); // agree → median is the price
+            }
+            // Feeds DISAGREE → fail-closed: refuse to price off a divergent set.
+            // Degrade to the bounded admin fallback if fresh; else unusable.
+            if (adminFresh) return (price, TIER_ADMIN, n, true);
+            return (0, TIER_QUORUM, n, false);
+        }
+
+        // ── Tier SINGLE: exactly 1 fresh feed (the #724 single-feed behavior) ──
+        if (n == 1) {
+            uint256 feedPrice = vals[0];
+            if (maxFeedDeviationBps == 0 || !adminFresh || price == 0) {
+                return (feedPrice, TIER_SINGLE, 1, true); // nothing to cross-check against
+            }
+            uint256 diff = feedPrice > price ? feedPrice - price : price - feedPrice;
+            // Overflow-proof, revert-free feed-vs-admin band (mirrors #724 getPrice).
+            if (price <= type(uint256).max / maxFeedDeviationBps && diff <= (price * maxFeedDeviationBps) / BPS_DENOMINATOR)
+            {
+                return (feedPrice, TIER_SINGLE, 1, true); // in band → trust the live feed
+            }
+            if (adminFresh) return (price, TIER_ADMIN, 1, true); // out of band → degrade
+            return (0, TIER_SINGLE, 1, false);
+        }
+
+        // ── Tier ADMIN: no fresh feed → bounded admin fallback ───────────
+        if (adminFresh) return (price, TIER_ADMIN, 0, true);
+        return (0, TIER_ADMIN, 0, false);
+    }
+
+    /// @dev Are the fresh feeds in agreement? `spread = max − min`; agree when
+    ///      `spread ≤ median * quorumBandBps / BPS`. Overflow-guarded + revert-free: if even
+    ///      `median * quorumBandBps` would exceed uint256 the median is absurd, so we treat
+    ///      it as DISAGREE (degrade) rather than overflow-revert and brick the read.
+    function _agree(uint256 med, uint256 spread) internal view returns (bool) {
+        if (quorumBandBps == 0) return spread == 0; // band 0 → require exact agreement
+        if (med > type(uint256).max / quorumBandBps) return false; // median absurd → disagree
+        return spread <= (med * quorumBandBps) / BPS_DENOMINATOR;
+    }
+
+    /// @dev Median + (min, max) of the first `n` entries of `vals` (n ≥ 1). Insertion sort
+    ///      on a copy — feed counts are tiny (2–3), so this is gas-trivial and avoids
+    ///      mutating the caller's array. Even n → mean of the two middles (overflow-safe
+    ///      `a + (b−a)/2`).
+    function _median(uint256[] memory vals, uint256 n)
+        internal
+        pure
+        returns (uint256 med, uint256 lo, uint256 hi)
+    {
+        uint256[] memory a = new uint256[](n);
+        for (uint256 i; i < n; ++i) {
+            a[i] = vals[i];
+        }
+        for (uint256 i = 1; i < n; ++i) {
+            uint256 key = a[i];
+            uint256 j = i;
+            while (j > 0 && a[j - 1] > key) {
+                a[j] = a[j - 1];
+                --j;
+            }
+            a[j] = key;
+        }
+        lo = a[0];
+        hi = a[n - 1];
+        if (n % 2 == 1) {
+            med = a[n / 2];
+        } else {
+            uint256 left = a[n / 2 - 1];
+            uint256 right = a[n / 2];
+            med = left + (right - left) / 2;
+        }
+    }
+}

--- a/contracts/test/QuorumPriceOracle.t.sol
+++ b/contracts/test/QuorumPriceOracle.t.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/QuorumPriceOracle.sol";
+
+/// @dev Settable mock AggregatorV3 feed — answer, decimals, round metadata all drivable so
+///      we can exercise the quorum deterministically (fresh/stale, agree/diverge, scaling).
+contract MockFeed is AggregatorV3Interface {
+    uint8 internal _decimals;
+    int256 internal _answer;
+    uint80 internal _roundId = 1;
+    uint256 internal _updatedAt;
+    uint80 internal _answeredInRound = 1;
+    bool internal _revert;
+
+    constructor(uint8 d, int256 answer, uint256 updatedAt) {
+        _decimals = d;
+        _answer = answer;
+        _updatedAt = updatedAt;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        if (_revert) revert("feed down");
+        return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+
+    function setAnswer(int256 a) external {
+        _answer = a;
+    }
+
+    function setUpdatedAt(uint256 t) external {
+        _updatedAt = t;
+    }
+
+    function setRevert(bool r) external {
+        _revert = r;
+    }
+}
+
+/// @dev Quorum read-path tests for QuorumPriceOracle. Pins the load-bearing safety
+///      properties: median of agreeing feeds (tier QUORUM), fail-closed on divergence,
+///      N-aware tier transitions (QUORUM → SINGLE → ADMIN), 8→6 decimal scaling inside the
+///      quorum, and the provenance surface. The no-arg getPrice() is the exact path
+///      Vault/SyntheticVault read.
+contract QuorumPriceOracleTest is Test {
+    QuorumPriceOracle public oracle;
+
+    address public owner = address(0x1);
+    address public alice = address(0x2);
+
+    // Admin-fed reference, 6-dec USDC: $500.00.
+    uint256 constant ADMIN_PRICE = 500_000000;
+
+    // Chainlink-style 8-dec USD answers; _tryReadFeed scales /100 → 6-dec.
+    uint8 constant D8 = 8;
+
+    function _8dec(uint256 dollars6) internal pure returns (int256) {
+        // 6-dec USDC value → 8-dec feed answer (×100).
+        return int256(dollars6 * 100);
+    }
+
+    function setUp() public {
+        vm.warp(1_000_000); // baseline well above any staleness window
+        vm.prank(owner);
+        oracle = new QuorumPriceOracle("sSPY", ADMIN_PRICE, owner);
+    }
+
+    function _add(address feed) internal {
+        vm.prank(owner);
+        oracle.addFeed(feed);
+    }
+
+    // ── Tier ADMIN (no feeds) ────────────────────────────────────────────
+
+    function test_no_feeds_uses_admin() public view {
+        assertEq(oracle.getPrice(), ADMIN_PRICE);
+        (uint256 p, uint8 tier, uint256 n, bool usable) = oracle.priceWithProvenance();
+        assertEq(p, ADMIN_PRICE);
+        assertEq(tier, oracle.TIER_ADMIN());
+        assertEq(n, 0);
+        assertTrue(usable);
+        assertEq(oracle.feedCount(), 0);
+    }
+
+    function test_no_feeds_admin_stale_reverts() public {
+        vm.warp(block.timestamp + 25 hours); // past admin MAX_STALENESS
+        vm.expectRevert(PriceOracle.StalePrice.selector);
+        oracle.getPrice();
+        assertFalse(oracle.isFresh());
+        (,,, bool usable) = oracle.priceWithProvenance();
+        assertFalse(usable);
+    }
+
+    // ── Tier SINGLE (1 fresh feed) ───────────────────────────────────────
+
+    function test_single_feed_in_band() public {
+        MockFeed f = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        _add(address(f));
+        assertEq(oracle.getPrice(), 500_000000);
+        (uint256 p, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(p, 500_000000);
+        assertEq(tier, oracle.TIER_SINGLE());
+        assertEq(n, 1);
+    }
+
+    function test_single_feed_out_of_band_degrades_to_admin() public {
+        // One feed 10× the admin reference → out of band → degrade to admin (admin fresh).
+        MockFeed f = new MockFeed(D8, _8dec(5_000_000000), block.timestamp);
+        _add(address(f));
+        assertEq(oracle.getPrice(), ADMIN_PRICE);
+        (, uint8 tier,,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_ADMIN());
+    }
+
+    function test_single_feed_trusted_when_admin_stale() public {
+        // With no fresh admin reference, the single feed cannot be cross-checked → trust it.
+        MockFeed f = new MockFeed(D8, _8dec(600_000000), block.timestamp);
+        _add(address(f));
+        vm.warp(block.timestamp + 25 hours); // admin now stale
+        f.setUpdatedAt(block.timestamp); // keep the feed fresh
+        assertEq(oracle.getPrice(), 600_000000);
+        (, uint8 tier,,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_SINGLE());
+    }
+
+    // ── Tier QUORUM (≥2 fresh feeds) ─────────────────────────────────────
+
+    function test_quorum_two_feeds_agree_returns_median() public {
+        MockFeed a = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        MockFeed b = new MockFeed(D8, _8dec(501_000000), block.timestamp);
+        _add(address(a));
+        _add(address(b));
+        // median of {500.00, 501.00} = 500.50, within the 2% band.
+        assertEq(oracle.getPrice(), 500_500000);
+        (uint256 p, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(p, 500_500000);
+        assertEq(tier, oracle.TIER_QUORUM());
+        assertEq(n, 2);
+    }
+
+    function test_quorum_three_feeds_returns_middle() public {
+        _add(address(new MockFeed(D8, _8dec(501_000000), block.timestamp)));
+        _add(address(new MockFeed(D8, _8dec(499_000000), block.timestamp)));
+        _add(address(new MockFeed(D8, _8dec(500_000000), block.timestamp)));
+        assertEq(oracle.getPrice(), 500_000000); // middle of {499,500,501}
+        (, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_QUORUM());
+        assertEq(n, 3);
+    }
+
+    function test_quorum_divergence_fails_closed_to_admin() public {
+        // {500, 600} → 20% spread ≫ 2% band → fail-closed; admin fresh → degrade to admin.
+        _add(address(new MockFeed(D8, _8dec(500_000000), block.timestamp)));
+        _add(address(new MockFeed(D8, _8dec(600_000000), block.timestamp)));
+        assertEq(oracle.getPrice(), ADMIN_PRICE);
+        (, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_ADMIN()); // never priced off the divergent feeds
+        assertEq(n, 2);
+    }
+
+    function test_quorum_divergence_admin_stale_reverts() public {
+        MockFeed a = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        MockFeed b = new MockFeed(D8, _8dec(600_000000), block.timestamp);
+        _add(address(a));
+        _add(address(b));
+        vm.warp(block.timestamp + 25 hours); // admin stale
+        a.setUpdatedAt(block.timestamp);
+        b.setUpdatedAt(block.timestamp);
+        vm.expectRevert(PriceOracle.StalePrice.selector); // divergent + no fresh fallback → fail-closed
+        oracle.getPrice();
+        assertFalse(oracle.isFresh());
+    }
+
+    function test_stale_feed_drops_quorum_to_single() public {
+        MockFeed a = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        MockFeed b = new MockFeed(D8, _8dec(501_000000), block.timestamp);
+        _add(address(a));
+        _add(address(b));
+        // Age b past the 1h feed heartbeat → only a is fresh → tier SINGLE.
+        b.setUpdatedAt(block.timestamp - 2 hours);
+        assertEq(oracle.getPrice(), 500_000000);
+        (, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_SINGLE());
+        assertEq(n, 1);
+    }
+
+    function test_reverting_feed_is_skipped() public {
+        MockFeed a = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        MockFeed b = new MockFeed(D8, _8dec(501_000000), block.timestamp);
+        _add(address(a));
+        _add(address(b));
+        a.setRevert(true); // a bricks → only b fresh → SINGLE on b
+        assertEq(oracle.getPrice(), 501_000000);
+        (, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_SINGLE());
+        assertEq(n, 1);
+    }
+
+    // ── Agreement band tuning ────────────────────────────────────────────
+
+    function test_band_zero_requires_exact_agreement() public {
+        vm.prank(owner);
+        oracle.setQuorumBandBps(0);
+        MockFeed a = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        MockFeed b = new MockFeed(D8, _8dec(500_010000), block.timestamp); // 1 cent off
+        _add(address(a));
+        _add(address(b));
+        // Not exactly equal → disagree → degrade to admin.
+        assertEq(oracle.getPrice(), ADMIN_PRICE);
+        // Now make them exactly equal → quorum.
+        b.setAnswer(_8dec(500_000000));
+        assertEq(oracle.getPrice(), 500_000000);
+        (, uint8 tier,,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_QUORUM());
+    }
+
+    // ── Feed-set management ──────────────────────────────────────────────
+
+    function test_addFeed_rejects_zero_dup_and_bad_decimals() public {
+        vm.prank(owner);
+        vm.expectRevert(QuorumPriceOracle.ZeroFeed.selector);
+        oracle.addFeed(address(0));
+
+        MockFeed f = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        _add(address(f));
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(QuorumPriceOracle.FeedAlreadyAdded.selector, address(f)));
+        oracle.addFeed(address(f));
+
+        MockFeed bad = new MockFeed(37, _8dec(500_000000), block.timestamp); // decimals > 36
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(PriceOracle.InvalidFeedDecimals.selector, uint8(37)));
+        oracle.addFeed(address(bad));
+    }
+
+    function test_removeFeed_swap_pop() public {
+        MockFeed a = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        MockFeed b = new MockFeed(D8, _8dec(501_000000), block.timestamp);
+        _add(address(a));
+        _add(address(b));
+        assertEq(oracle.feedCount(), 2);
+        vm.prank(owner);
+        oracle.removeFeed(0);
+        assertEq(oracle.feedCount(), 1);
+        // Remaining feed (b, swapped into slot 0) is the only fresh source → SINGLE.
+        (, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_SINGLE());
+        assertEq(n, 1);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(QuorumPriceOracle.IndexOutOfBounds.selector, uint256(5), uint256(1)));
+        oracle.removeFeed(5);
+    }
+
+    function test_onlyOwner_guards() public {
+        MockFeed f = new MockFeed(D8, _8dec(500_000000), block.timestamp);
+        vm.prank(alice);
+        vm.expectRevert();
+        oracle.addFeed(address(f));
+        vm.prank(alice);
+        vm.expectRevert();
+        oracle.setQuorumBandBps(100);
+    }
+
+    // ── Inherited single priceFeed is ignored by the quorum override ─────
+
+    function test_inherited_priceFeed_ignored() public {
+        // setPriceFeed wires the inherited single feed — the quorum override must NOT read it
+        // (feeds are managed via addFeed). With no addFeed call, we stay tier ADMIN.
+        MockFeed f = new MockFeed(D8, _8dec(700_000000), block.timestamp);
+        vm.prank(owner);
+        oracle.setPriceFeed(address(f));
+        assertEq(oracle.getPrice(), ADMIN_PRICE); // priceFeed ignored
+        (, uint8 tier, uint256 n,) = oracle.priceWithProvenance();
+        assertEq(tier, oracle.TIER_ADMIN());
+        assertEq(n, 0);
+    }
+
+    // ── Inherited admin write-path still works (the bounded fallback leg) ─
+
+    function test_inherited_admin_setPrice_still_works() public {
+        vm.warp(block.timestamp + 60); // clear the update cooldown
+        vm.prank(owner);
+        oracle.setPrice(505_000000); // within 20% deviation bound
+        assertEq(oracle.getPrice(), 505_000000); // no feeds → admin tier reflects the new price
+    }
+}

--- a/docs/adr/chainlink-primary-oracle.md
+++ b/docs/adr/chainlink-primary-oracle.md
@@ -5,6 +5,25 @@
 > **Question being decided:** Where does the on-chain USD price that feeds vault collateral math come from — our admin-set `PriceOracle`, a well-validated external oracle (Chainlink), or some composition of the two?
 > **Related issues/PRs:** [#724](https://github.com/a-apin/archimedes/pull/724) (Chainlink-first read path **+ the #724-review hardening**), [#731](https://github.com/a-apin/archimedes/pull/731) (owner≠agent non-custodial vaults — closed the drain vector). Feed-outage telemetry/alerting is operational follow-up.
 
+> **⚡ Update 2026-06-30 — evolved single-primary → N-feed QUORUM (Arc × Chainlink).** Arc
+> joined the Chainlink Scale program today. Two verified facts reshape this ADR: (1)
+> **what shipped on Arc testnet today is CCIP only** (Router `0xdE4E…`, chain selector,
+> registries) — **Chainlink price *Data Feed* aggregator addresses are NOT published on Arc
+> yet** (announced capability), so per the #1 rule we do not claim "priced by Chainlink on
+> Arc" today; and (2) **Stork + Pyth price feeds ARE verified live on Arc**, so a real
+> ≥2-feed on-chain quorum is achievable *now*. The decision below (single-primary feed +
+> admin fallback) is **superseded by a quorum medianizer**: read all configured
+> `AggregatorV3Interface` sources (Chainlink-when-published, Stork, Pyth-wrapper), return the
+> **median of the fresh ones requiring ≥2 that agree within a band, fail-closed on
+> divergence**, degrading to the same single-feed-plus-admin-band and bounded-admin tiers
+> this ADR specifies. The #724 read path is *generalized*, not discarded — its per-feed
+> validation (`_tryReadFeed`) is the quorum's per-source primitive. **This is pricing only —
+> not settlement** (North Star: price on-chain now, settle on-chain at mainnet). Full design:
+> [`docs/specs/onchain-quorum-oracle-spec.md`](../specs/onchain-quorum-oracle-spec.md)
+> (contract: `QuorumPriceOracle is PriceOracle`). Everything below remains the rationale for
+> *why* an external feed beats a lone admin writer — the quorum just removes the
+> single-feed trust point too.
+
 ## TL;DR
 
 **Make Chainlink (or an equivalent well-validated, generally-accepted oracle) PRIMARY everywhere a feed exists. Keep our custom admin-set `PriceOracle` ONLY as an explicit, logged, tightly-bounded fallback** for the long tail of assets that have no native feed and for the window when a feed is stale or down. This is exactly the "Chainlink-first, admin fallback" architecture PR #724 implements: `getPrice()` reads `latestRoundData()` from a configured `AggregatorV3Interface` feed with full staleness/round-completeness/non-negative validation, and **degrades to the admin-fed `price` whenever the feed is absent (`priceFeed == address(0)`), unusable (reverts/stale/bad answer), or grossly out of band** — reverting only when *both* sources are unusable. The fallback is the weaker link, so it stays bounded (deviation caps + staleness + rate-limit) and loud (distinct events), and it is used only on feed absence or outage — never as the default trust source.

--- a/docs/specs/onchain-quorum-oracle-spec.md
+++ b/docs/specs/onchain-quorum-oracle-spec.md
@@ -1,0 +1,147 @@
+# Spec: On-chain quorum price oracle (Stork + Pyth + Chainlink-ready), pricing-only
+
+> **Status:** Proposed (2026-06-30). Funds-adjacent contract change — **Dan approves as
+> contract owner; Bogdan (`mnemonik-dev`) two-eyes review. DO NOT MERGE until both.**
+> **Builds on:** [`docs/adr/chainlink-primary-oracle.md`](../adr/chainlink-primary-oracle.md)
+> (#724, merged — single-feed Chainlink-first read path) and the Stork `AggregatorV3`
+> adapter (#828, held). **Decision owner:** Dan. **Author:** Claude (Dan's session).
+
+## TL;DR
+
+Generalize the merged single-feed [`PriceOracle`](../../contracts/src/PriceOracle.sol)
+into an **on-chain N-feed quorum medianizer**: read every configured
+`AggregatorV3Interface` source for an asset, validate each with the *exact* #724 round/
+staleness/scaling guards, and return the **median of the fresh ones** — requiring **≥2
+fresh feeds that agree within a band** (fail-closed on divergence), degrading cleanly to
+single-feed-plus-admin-crosscheck and then to the bounded admin fallback when fewer feeds
+are live. This removes the single-oracle trust point for *pricing* without touching
+*settlement* (which stays mainnet-deferred per the North Star).
+
+## Why now (the Arc × Chainlink unlock, verified 2026-06-30)
+
+- **Arc joined Chainlink Scale today.** Verified against the Arc Core announcement + the
+  Arc×Chainlink blog: **what shipped with addresses on testnet today is CCIP only** (Router
+  `0xdE4E7FED43FAC37EB21aA0643d9852f75332eab8`, chain selector `3034092155422581607`, ARM
+  proxy, registries). **Data Feeds + Data Streams are announced *capability* — no Arc
+  price-feed aggregator addresses are published yet.** So per the #1 rule we do **not** claim
+  "priced by Chainlink on Arc" today; we make the read path *Chainlink-ready* and wire feeds
+  the moment Arc publishes them.
+- **Stork + Pyth price feeds ARE verified live on Arc** (Stork has published Arc EVM
+  addresses; Pyth on-chain pull is deployed on Arc). → **a real ≥2-feed quorum is achievable
+  today** (Stork + Pyth), with Chainlink as the third leg on publish.
+- **North Star alignment:** *price on-chain now, settle on-chain only at mainnet.* This is
+  the **pricing** layer (real on testnet) — it does **not** introduce real settlement. "Don't
+  go full send": build the quorum core + the live legs; leave heavy mainnet hardening as
+  marked TODOs.
+
+## Design
+
+### Drop-in surface (zero consumer churn)
+
+The live consumers — `SyntheticVault` (`PriceOracle immutable oracle; oracle.getPrice()`),
+`Vault` (`PriceOracle(tokenOracle[t]).getPrice()`), `SyntheticFactory` — all cast to the
+concrete `PriceOracle` type and call the **no-arg `getPrice() → uint256` (6-dec USDC)**.
+`QuorumPriceOracle is PriceOracle`, so those casts resolve to the override with **no consumer
+change** and the contract IS-A `PriceOracle` everywhere one is expected (e.g.
+`SyntheticVault`'s constructor).
+
+### Minimal, behavior-preserving change to the audited #724 contract
+
+1. **Extract** the per-feed validation body of `_tryReadChainlink()` into
+   `_tryReadFeed(AggregatorV3Interface feed, uint8 dec) internal view returns (bool ok,
+   uint256 scaled)` (round completeness, `answer>0`, future-timestamp, `answeredInRound`,
+   per-feed heartbeat, overflow-safe 6-dec scaling — unchanged). `_tryReadChainlink()`
+   becomes `return _tryReadFeed(priceFeed, feedDecimals);`. Pure extraction — guarded by the
+   existing `PriceOracleChainlink.t.sol`.
+2. **Mark `getPrice()` `virtual`** so the subclass overrides it. (One keyword.)
+
+No other change to #724. All admin-path guards (`maxDeviationBps`, `updateCooldown`,
+`forceSetPrice`/`FORCE_MAX_DEVIATION_BPS`, `MAX_STALENESS`, the sanity band) are **inherited
+intact** and back the quorum's degrade target.
+
+### `QuorumPriceOracle is PriceOracle` — the medianizer
+
+State (additive):
+- `AggregatorV3Interface[] public feeds; uint8[] public feedDecs;` — the quorum source set
+  (each entry is a Chainlink feed, the Stork adapter, or a Pyth adapter — all present
+  `AggregatorV3Interface`). Owner-managed via `addFeed(address)` / `removeFeed(uint256)`
+  (decimals probed + cached at add time, exactly like `setPriceFeed`).
+- `quorumBandBps` (default e.g. 200 = 2%) — max spread `(max−min)/median` for the fresh feeds
+  to be considered *agreeing*. Distinct from the inherited `maxFeedDeviationBps` (feed-vs-admin
+  band). Owner-tunable, bounded.
+
+`getPrice()` override — **N-aware tiers, fail-closed**:
+- **n ≥ 2 fresh** (`_tryReadFeed` over `feeds`): sort, take the **median**; if
+  `(max−min)/median ≤ quorumBandBps` → **return median** (tier `QUORUM`). Else the feeds
+  *disagree* → **fail-closed**: do not trust a divergent set; degrade to the admin fallback
+  if it is fresh, else `revert StalePrice()`. (We refuse to price off feeds that don't agree.)
+- **n == 1 fresh**: return it, cross-checked against the fresh admin reference via the
+  inherited `maxFeedDeviationBps` band (the existing #724 single-feed behavior) (tier
+  `SINGLE_CHECKED`).
+- **n == 0**: bounded admin fallback — inherited `price` + `MAX_STALENESS` (tier `ADMIN`);
+  `revert StalePrice()` if the admin price is also stale.
+
+`priceWithProvenance() external view returns (uint256 price, uint8 tier, uint256 nFresh)` —
+the **claims-true provenance surface**: which tier priced and how many feeds were fresh, for
+telemetry, the UI badge, and the #759 `oracle_tier` mapping. (On-chain fact, not a cached
+boolean.)
+
+### Median + agreement (small-N, gas-trivial)
+Feed count is tiny (2–3). Insertion-sort the fresh scaled values; median = middle (odd) or
+mean-of-two-middles (even); spread = `(max−min)`. All arithmetic overflow-checked the same
+revert-free way as #724's band (guard the `median * bandBps` multiply; degrade rather than
+overflow-revert).
+
+## Live configuration today → tomorrow (claims-true)
+
+| Asset coverage | Feeds wired today | Tier today | On Chainlink-Arc publish |
+|---|---|---|---|
+| Stork **and** Pyth cover it | Stork adapter + Pyth adapter | **QUORUM** (2-of-2) | add Chainlink → 2-of-3 |
+| Only one of Stork/Pyth | that one | SINGLE_CHECKED | add the others → QUORUM |
+| Neither (long tail) | none | ADMIN (bounded) | add when a feed exists |
+
+Adding Chainlink later is **one `addFeed` call per asset** — no code change, no redeploy of
+consumers. This is the forward-compatibility that makes "first to build the Chainlink-on-Arc
+quorum" honest: the path is live and Chainlink-ready; the Chainlink leg lights up on publish.
+Maps directly onto the #759 universe `oracle_tier` field.
+
+## Pyth as an `AggregatorV3` leg
+
+Pyth's native interface is pull-based (`IPyth.getPriceNoOlderThan`), not `AggregatorV3`.
+Two honest options, both leave the medianizer untouched (it consumes any `AggregatorV3`
+address):
+1. **Preferred:** deploy Pyth's official `PythAggregatorV3` wrapper
+   (`@pythnetwork/pyth-sdk-solidity`) per asset — audited upstream, least new trusted code.
+2. Thin in-repo `PythAggregatorV3Adapter` mirroring the #828 Stork adapter, if we want a
+   single adapter style. (Carries its own review burden — prefer (1) for a funds path.)
+The PR ships tests against a mock `AggregatorV3` for both, and documents the deploy-config
+choice; the **adapter address is a deploy-time config detail, not a code dependency.**
+
+## Scope boundary — build now vs mainnet-defer ("don't go full send")
+
+**Build now:** the `_tryReadFeed` extraction + `virtual` on #724; `QuorumPriceOracle`
+(feeds set, median, tiers, fail-closed, provenance view); Foundry tests (median, 2-of-2
+agree, divergence fail-closed, 1-feed cross-check, 0-feed admin, tier reporting, overflow
+guards); this spec + an ADR-update note; the deploy/config runbook for wiring Stork+Pyth.
+
+**Mainnet TODO (marked, not built):** wiring the actual Chainlink Arc feed addresses (none
+published yet); N≥3 outlier rejection beyond median+band; gas-tuned sort; per-source
+heartbeat tuning against real cadence; **any settlement change** (explicitly out of scope —
+this is pricing only).
+
+## Anti-goals
+- **No settlement change.** Vaults still don't do real on-chain settlement on testnet
+  (North Star §6). This changes only the *price* a vault reads.
+- **No weakening of #724's guards.** The admin fallback keeps every deviation/cooldown/
+  staleness bound; the quorum *adds* a stricter on-chain path, it does not relax the existing
+  one.
+- **No claim of "priced by Chainlink on Arc"** until Arc publishes feed addresses and we wire
+  + verify them. The honest claim today is "live Stork+Pyth on-chain quorum, Chainlink-ready."
+- **Don't mutate the no-arg `getPrice()` selector** — consumer drop-in compat is load-bearing.
+
+## Verify (reviewer commands)
+- `cd contracts && forge test --match-contract QuorumPriceOracle -vvv` → all pass.
+- `forge test --match-contract PriceOracleChainlink` → still green (refactor preserved #724).
+- `grep -n "virtual" contracts/src/PriceOracle.sol` → only `getPrice` (+ extracted helper) marked.
+- Provenance: a 2-of-2 agreeing read returns tier `QUORUM`; a divergent read returns admin/
+  revert, never a feed value.


### PR DESCRIPTION
## ⛔ DO NOT MERGE — funds-adjacent. Dan approves (contract owner) + Bogdan (`mnemonik-dev`) two-eyes review.

## Summary

Generalize the merged single-feed [`PriceOracle`](contracts/src/PriceOracle.sol) (#724) into
an **on-chain N-feed quorum medianizer**: read every configured `AggregatorV3Interface`
source for an asset, validate each with the *exact* #724 round/staleness/scaling guards, and
return the **median of the fresh ones — requiring ≥2 that agree within a band, fail-closed on
divergence** — degrading cleanly to single-feed-plus-admin-cross-check and then to the bounded
admin fallback as fewer feeds are live. This removes the single-oracle trust point for
**pricing** without touching **settlement**.

**Why now — Arc × Chainlink (verified 2026-06-30).** Arc joined the Chainlink Scale program
today. Two verified facts shape this:
- **What shipped on Arc testnet today is CCIP only** (Router `0xdE4E7FED…`, chain selector
  `3034092155422581607`, ARM/registries). **Chainlink price *Data Feed* aggregator addresses
  are NOT published on Arc yet** (announced capability). Per the #1 rule we do **not** claim
  "priced by Chainlink on Arc" today — the read path is *Chainlink-ready*; the leg lights up
  with one `addFeed` call when Arc publishes feed addresses.
- **Stork + Pyth price feeds ARE verified live on Arc** → a real ≥2-feed quorum is achievable
  **today** (Stork + Pyth), Chainlink as the third leg on publish.

**Pricing only — NOT settlement.** Per the North Star (*price on-chain now, settle on-chain at
mainnet*), this changes only the *price* a vault reads. No settlement behavior changes; testnet
trading stays paper/simulated.

## What changed

- **`contracts/src/PriceOracle.sol`** — behavior-preserving refactor: extract the per-feed
  validation body into `_tryReadFeed(AggregatorV3Interface feed, uint8 dec)` (single audited
  primitive); `_tryReadChainlink()` now delegates to it; mark `getPrice()` / `isFresh()`
  `virtual`. **No logic change** — guarded by the existing 31-test `PriceOracleChainlink.t.sol`.
- **`contracts/src/QuorumPriceOracle.sol`** (new) — `is PriceOracle`, so it drops in anywhere a
  `PriceOracle` is expected (Vault / SyntheticVault / SyntheticFactory all cast to the concrete
  type and call the no-arg `getPrice() → uint256`) with **zero consumer change**. Adds
  `addFeed` / `removeFeed`, the N-aware tiered `getPrice()` override, a `setQuorumBandBps`
  agreement band, and a non-reverting `priceWithProvenance() → (price, tier, nFresh, usable)`
  on-chain provenance view. Every #724 admin-path guard is inherited intact as the degrade target.
- **`contracts/test/QuorumPriceOracle.t.sol`** (new) — 17 tests: median (2 & 3 feeds), divergence
  **fail-closed** (degrade to admin / revert when admin stale), tier transitions
  (QUORUM→SINGLE→ADMIN on stale/reverting feeds), 8→6 decimal scaling in the quorum, band-zero
  exact-agreement, feed-set management (zero/dup/bad-decimals/swap-pop/onlyOwner), inherited
  single-`priceFeed` ignored, inherited admin `setPrice` still works.
- **`docs/specs/onchain-quorum-oracle-spec.md`** (new) + **ADR update** in
  `docs/adr/chainlink-primary-oracle.md` (single-primary → quorum; records the verified
  Arc-feed reality).

## Net-closing (not sprawl)

- **Closes #794** (Leg B on-chain oracle).
- **Pairs with #828** (Stork `AggregatorV3` adapter) — the adapter becomes a quorum *leg*;
  review the two together as the on-chain-pricing bundle.
- **Supersedes the single-primary decision** in the #724 ADR (updated in-place, not duplicated).
- **Grounds #759's `oracle_tier`** field as a real on-chain fact via `priceWithProvenance()`.

## Verify

```bash
cd contracts && forge test --match-contract "QuorumPriceOracle|PriceOracleChainlink"
# 48 passed (17 quorum + 31 #724 preserved)
forge test            # full suite: 242 passed, 0 failed
grep -n "virtual" src/PriceOracle.sol   # only getPrice + isFresh marked
```

## Scope boundary (mainnet-deferred, marked TODO — not built)

Wiring actual Chainlink Arc feed addresses (none published yet); N≥3 outlier rejection beyond
median+band; gas-tuned sort; per-source heartbeat tuning against real cadence; **any settlement
change** (explicitly out of scope — pricing only).

## Anti-goals
- No settlement change. No weakening of #724's guards. No "priced by Chainlink on Arc" claim
  until Arc publishes feed addresses and we wire + verify them. No change to the no-arg
  `getPrice()` selector (consumer drop-in compat is load-bearing).
