### PR TITLE
[infra] Purge stale eu-west-2 + old-account refs — finish us-east-1 migration (#838)

### DIFF
--- a/backend/archimedes/services/dynamodb_paper_index.py
+++ b/backend/archimedes/services/dynamodb_paper_index.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TABLE = "archimedes-papers-index"
-_DEFAULT_REGION = "eu-west-2"
+_DEFAULT_REGION = "us-east-1"
 
 
 def _sanitize_for_dynamo(item: dict[str, Any]) -> dict[str, Any]:

--- a/backend/archimedes/services/s3_artifact_store.py
+++ b/backend/archimedes/services/s3_artifact_store.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_ARTIFACTS_BUCKET = "archimedes-corpus-artifacts-prod"
 _DEFAULT_PDFS_BUCKET = "archimedes-paper-pdfs-prod"
-_DEFAULT_REGION = "eu-west-2"
+_DEFAULT_REGION = "us-east-1"
 
 
 class S3ArtifactStore:

--- a/backend/archimedes/services/secrets_service.py
+++ b/backend/archimedes/services/secrets_service.py
@@ -66,7 +66,7 @@ def load_ssm_secrets(
 
     Args:
         prefix: SSM path prefix (default: AWS_SSM_PATH_PREFIX env var or /archimedes/prod/)
-        region: AWS region (default: AWS_REGION env var or eu-west-2)
+        region: AWS region (default: AWS_REGION env var or us-east-1)
         override_existing: If True, overwrite env vars that already have values.
             Default False — .env values take precedence (useful for local dev override).
 
@@ -82,7 +82,7 @@ def load_ssm_secrets(
         logger.debug("secrets_service: AWS_SSM_PATH_PREFIX not set — skipping SSM load")
         return 0
 
-    region = region or os.environ.get("AWS_REGION", "eu-west-2")
+    region = region or os.environ.get("AWS_REGION", "us-east-1")
 
     try:
         import boto3
@@ -139,7 +139,7 @@ def _fetch_all_parameters(client: Any, prefix: str) -> list[dict[str, Any]]:
 def list_ssm_parameters(prefix: str | None = None, region: str | None = None) -> list[str]:
     """List parameter names (not values) under the prefix. Useful for diagnostics."""
     prefix = prefix or os.environ.get("AWS_SSM_PATH_PREFIX", _DEFAULT_PREFIX)
-    region = region or os.environ.get("AWS_REGION", "eu-west-2")
+    region = region or os.environ.get("AWS_REGION", "us-east-1")
 
     try:
         import boto3

--- a/backend/tests/services/test_dynamodb_paper_index.py
+++ b/backend/tests/services/test_dynamodb_paper_index.py
@@ -41,7 +41,7 @@ class TestDynamoDBPaperIndex:
         index = DynamoDBPaperIndex.__new__(DynamoDBPaperIndex)
         index.__init__()
         assert index.table_name == "archimedes-papers-index"
-        assert index.region == "eu-west-2"
+        assert index.region == "us-east-1"
 
     def test_init_from_env(self, monkeypatch):
         monkeypatch.setenv("AWS_DYNAMODB_PAPERS_TABLE", "custom-table")

--- a/backend/tests/services/test_s3_artifact_store.py
+++ b/backend/tests/services/test_s3_artifact_store.py
@@ -20,7 +20,7 @@ class TestS3ArtifactStore:
         store = S3ArtifactStore.__new__(S3ArtifactStore)
         store.__init__()
         assert store.bucket == "archimedes-corpus-artifacts-prod"
-        assert store.region == "eu-west-2"
+        assert store.region == "us-east-1"
 
     def test_init_custom(self):
         store = S3ArtifactStore(bucket="my-bucket", region="us-east-1")

--- a/backend/tests/services/test_secrets_service.py
+++ b/backend/tests/services/test_secrets_service.py
@@ -61,7 +61,7 @@ class TestLoadSsmSecrets:
     def test_loads_parameters_into_env(self, mock_boto3, monkeypatch):
         """SSM parameters are injected into os.environ."""
         monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
-        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
 
         mock_client = self._mock_ssm_response(
             [
@@ -83,7 +83,7 @@ class TestLoadSsmSecrets:
     def test_does_not_override_existing_by_default(self, mock_boto3, monkeypatch):
         """Existing env vars are NOT overwritten when override_existing=False."""
         monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
-        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
         monkeypatch.setenv("TEST_SECRET_1", "original-value")
 
         mock_client = self._mock_ssm_response(
@@ -104,7 +104,7 @@ class TestLoadSsmSecrets:
     def test_override_existing_when_flag_set(self, mock_boto3, monkeypatch):
         """With override_existing=True, SSM values replace existing env vars."""
         monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
-        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
         monkeypatch.setenv("TEST_SECRET_1", "original-value")
 
         mock_client = self._mock_ssm_response(
@@ -165,7 +165,7 @@ class TestLoadSsmSecrets:
     def test_pagination(self, mock_boto3, monkeypatch):
         """Handles paginated SSM responses correctly."""
         monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
-        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
 
         mock_client = MagicMock()
         # First page returns a NextToken

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -109,8 +109,8 @@ Internet → Route 53 → ALB (HTTPS, WAF) → EC2 (private subnet, port 80)
 |---|---|---|---|
 | **VPC** | `vpc.tf` | 10.0.0.0/16, DNS support enabled | **$0** |
 | **Internet Gateway** | `vpc.tf` | For public subnets | **$0** |
-| **2× Public Subnets** | `vpc.tf` | 10.0.0.0/24, 10.0.1.0/24 (us-east-1a/b) | **$0** |
-| **2× Private Subnets** | `vpc.tf` | 10.0.10.0/24, 10.0.11.0/24 (us-east-1a/b) | **$0** |
+| **2× Public Subnets** | `vpc.tf` | 10.0.0.0/24, 10.0.1.0/24 (first 2 available AZs) | **$0** |
+| **2× Private Subnets** | `vpc.tf` | 10.0.10.0/24, 10.0.11.0/24 (first 2 available AZs) | **$0** |
 | **2× NAT Instances** | `vpc.tf` | fck-nat on t4g.nano, one per AZ | **~$7.88** |
 | **VPC Peering** | `aurora.tf` | Default VPC ↔ new VPC (transitional) | **$0** + data transfer |
 | **Aurora Serverless v2** | `aurora.tf` | PostgreSQL 16.4, 0.5–16 ACU, encrypted, 7-day backups | **~$43.80** (min 0.5 ACU × $0.12/hr × 730) |
@@ -331,7 +331,7 @@ gh workflow run deploy.yml --ref main
 | Deploy builds on-instance (OOM risk) | Medium | Accepted for hackathon | Post-hackathon: ECR |
 | WAF managed rules in COUNT mode | Low | Intentional (observation period) | Flip to BLOCK after 48h |
 | `archimedes-dan-browne-credentials` secret | Low | Staged for Dan's one-time retrieval | Delete after retrieval |
-| ACM cert in us-east-1, ALB in us-east-1 | Info | ACM for ALB must be in us-east-1 for CloudFront; regional ALB can use us-east-1 cert. Current cert in us-east-1 works for global services but a separate us-east-1 cert is needed for regional ALB. | Verify on apply |
+| ACM cert in us-east-1, ALB in us-east-1 | Info | With the ALB in us-east-1, a single us-east-1 ACM cert serves both the regional ALB and CloudFront (which requires us-east-1); a separate cert is optional (for isolation), not required. | Verify on apply |
 
 ---
 

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -3,7 +3,7 @@
 > **Status:** Living doc. Written 2026-05-28. Reflects actual deployed state;
 > planned-but-not-applied Terraform resources are clearly marked.
 >
-> **AWS Account:** `159903201072` (root), region `eu-west-2` (London).
+> **AWS Account:** `037613907429` (root), region `us-east-1` (N. Virginia).
 > **Account owner:** Chuan (team lead, CTO @ Gyld Finance). This is a shared
 > account also running Kaleidoscope and Lighthouse workloads — only
 > Archimedes-specific resources are inventoried here.
@@ -43,7 +43,7 @@ Internet → Route 53 → Elastic IP → EC2 (nginx:80/443) → Docker network
 | **ACM Certificate** | `arn:aws:acm:us-east-1::certificate/9ba0da81...` | TLS cert for `archimedes-arc.com` | DNS-validated, ISSUED | **$0** |
 | **S3: Corpus Artifacts** | `archimedes-corpus-artifacts-prod` | KB pipeline output (empty) | SSE-S3, versioned | **~$0** |
 | **S3: Paper PDFs** | `archimedes-paper-pdfs-prod` | Ingested paper PDFs (empty) | SSE-S3 | **~$0** |
-| **S3: TF State** | `archimedes-tfstate-159903201072` | Terraform remote state | Versioned, SSE-S3, S3-native locking | **~$0** |
+| **S3: TF State** | `archimedes-tfstate-037613907429` | Terraform remote state | Versioned, SSE-S3, S3-native locking | **~$0** |
 | **DynamoDB** | `archimedes-papers-index` | Paper metadata index | PAY_PER_REQUEST, 0 items | **~$0** |
 | **SSM Parameters** | `/archimedes/prod/*` (5 params) | Secrets: ANTHROPIC_AUTH_TOKEN, CIRCLE_API_KEY, CIRCLE_ENTITY_SECRET, DATABASE_URL, REDIS_URL | SecureString, KMS-encrypted | **$0.25** |
 | **IAM Role: Backend** | `archimedes-backend-role` | EC2 instance profile: S3 corpus r/w, DynamoDB papers r/w, SSM params read, KMS decrypt | Inline policy | **$0** |
@@ -109,8 +109,8 @@ Internet → Route 53 → ALB (HTTPS, WAF) → EC2 (private subnet, port 80)
 |---|---|---|---|
 | **VPC** | `vpc.tf` | 10.0.0.0/16, DNS support enabled | **$0** |
 | **Internet Gateway** | `vpc.tf` | For public subnets | **$0** |
-| **2× Public Subnets** | `vpc.tf` | 10.0.0.0/24, 10.0.1.0/24 (eu-west-2a/b) | **$0** |
-| **2× Private Subnets** | `vpc.tf` | 10.0.10.0/24, 10.0.11.0/24 (eu-west-2a/b) | **$0** |
+| **2× Public Subnets** | `vpc.tf` | 10.0.0.0/24, 10.0.1.0/24 (us-east-1a/b) | **$0** |
+| **2× Private Subnets** | `vpc.tf` | 10.0.10.0/24, 10.0.11.0/24 (us-east-1a/b) | **$0** |
 | **2× NAT Instances** | `vpc.tf` | fck-nat on t4g.nano, one per AZ | **~$7.88** |
 | **VPC Peering** | `aurora.tf` | Default VPC ↔ new VPC (transitional) | **$0** + data transfer |
 | **Aurora Serverless v2** | `aurora.tf` | PostgreSQL 16.4, 0.5–16 ACU, encrypted, 7-day backups | **~$43.80** (min 0.5 ACU × $0.12/hr × 730) |
@@ -267,16 +267,16 @@ auto-scaling, fine for our workload).
 
 ```bash
 # 1. Check instance status
-aws ec2 describe-instance-status --instance-ids i-0987f70a131ed3ab1 --region eu-west-2
+aws ec2 describe-instance-status --instance-ids i-0987f70a131ed3ab1 --region us-east-1
 
 # 2. If InstanceStatus = impaired:
-aws ec2 reboot-instances --instance-ids i-0987f70a131ed3ab1 --region eu-west-2
+aws ec2 reboot-instances --instance-ids i-0987f70a131ed3ab1 --region us-east-1
 # Wait 2 min, recheck. If still impaired:
 
 # 3. Stop → Start (fresh host)
-aws ec2 stop-instances --instance-ids i-0987f70a131ed3ab1 --region eu-west-2
+aws ec2 stop-instances --instance-ids i-0987f70a131ed3ab1 --region us-east-1
 # Wait for 'stopped' state
-aws ec2 start-instances --instance-ids i-0987f70a131ed3ab1 --region eu-west-2
+aws ec2 start-instances --instance-ids i-0987f70a131ed3ab1 --region us-east-1
 # Wait for InstanceStatus = ok
 
 # 4. DNS update (EIP should prevent this, but verify)
@@ -293,7 +293,7 @@ curl -s https://archimedes-arc.com/api/health
 ```bash
 aws ssm send-command \
   --instance-ids i-0987f70a131ed3ab1 \
-  --region eu-west-2 \
+  --region us-east-1 \
   --document-name AWS-RunShellScript \
   --parameters '{"commands":["sudo docker ps --format \"table {{.Names}}\t{{.Status}}\"","free -h","df -h /","sudo docker system df"]}' \
   --timeout-seconds 30
@@ -304,7 +304,7 @@ aws ssm send-command \
 ```bash
 aws ssm send-command \
   --instance-ids i-0987f70a131ed3ab1 \
-  --region eu-west-2 \
+  --region us-east-1 \
   --document-name AWS-RunShellScript \
   --parameters '{"commands":["sudo docker builder prune -af"]}' \
   --timeout-seconds 120
@@ -331,7 +331,7 @@ gh workflow run deploy.yml --ref main
 | Deploy builds on-instance (OOM risk) | Medium | Accepted for hackathon | Post-hackathon: ECR |
 | WAF managed rules in COUNT mode | Low | Intentional (observation period) | Flip to BLOCK after 48h |
 | `archimedes-dan-browne-credentials` secret | Low | Staged for Dan's one-time retrieval | Delete after retrieval |
-| ACM cert in us-east-1, ALB in eu-west-2 | Info | ACM for ALB must be in us-east-1 for CloudFront; regional ALB can use eu-west-2 cert. Current cert in us-east-1 works for global services but a separate eu-west-2 cert is needed for regional ALB. | Verify on apply |
+| ACM cert in us-east-1, ALB in us-east-1 | Info | ACM for ALB must be in us-east-1 for CloudFront; regional ALB can use us-east-1 cert. Current cert in us-east-1 works for global services but a separate us-east-1 cert is needed for regional ALB. | Verify on apply |
 
 ---
 

--- a/docs/infra-setup.md
+++ b/docs/infra-setup.md
@@ -13,7 +13,7 @@ GitHub (main branch)
 GitHub Actions (deploy.yml)
     │  SSH
     ▼
-EC2 (t3.medium, eu-west-2)
+EC2 (t3.medium, us-east-1)
     │
     ├── docker compose (6 services)
     │   ├── backend   (FastAPI :8000) — health-checked
@@ -36,10 +36,10 @@ EC2 (t3.medium, eu-west-2)
 | ------------- | ----------------------------------------------------- |
 | Instance ID   | `i-0987f70a131ed3ab1`                                 |
 | Type          | `t3.medium` (2 vCPU, 4 GB RAM)                        |
-| Region        | `eu-west-2` (London)                                  |
+| Region        | `us-east-1` (N. Virginia)                                  |
 | AMI           | Ubuntu 24.04 LTS (x86_64)                            |
 | Public IP     | `13.40.112.220`                                       |
-| Public DNS    | `ec2-13-40-112-220.eu-west-2.compute.amazonaws.com`   |
+| Public DNS    | `ec2-13-40-112-220.us-east-1.compute.amazonaws.com`   |
 | Volume        | 20 GB gp3                                             |
 | Cost          | ~$17/month                                            |
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -36,8 +36,7 @@ with Terraform). No DynamoDB table needed.
 # S3 bucket — versioned, encrypted, no public access
 aws s3api create-bucket \
   --bucket archimedes-tfstate-037613907429 \
-  --region us-east-1 \
-  --create-bucket-configuration LocationConstraint=us-east-1
+  --region us-east-1
 
 aws s3api put-bucket-versioning \
   --bucket archimedes-tfstate-037613907429 \

--- a/infra/README.md
+++ b/infra/README.md
@@ -35,36 +35,36 @@ with Terraform). No DynamoDB table needed.
 ```bash
 # S3 bucket — versioned, encrypted, no public access
 aws s3api create-bucket \
-  --bucket archimedes-tfstate-159903201072 \
+  --bucket archimedes-tfstate-037613907429 \
   --region us-east-1 \
   --create-bucket-configuration LocationConstraint=us-east-1
 
 aws s3api put-bucket-versioning \
-  --bucket archimedes-tfstate-159903201072 \
+  --bucket archimedes-tfstate-037613907429 \
   --versioning-configuration Status=Enabled
 
 aws s3api put-bucket-encryption \
-  --bucket archimedes-tfstate-159903201072 \
+  --bucket archimedes-tfstate-037613907429 \
   --server-side-encryption-configuration \
   '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
 
 aws s3api put-public-access-block \
-  --bucket archimedes-tfstate-159903201072 \
+  --bucket archimedes-tfstate-037613907429 \
   --public-access-block-configuration \
   BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
 
 # Bucket policy: deny non-TLS + restrict to account only
 aws s3api put-bucket-policy \
-  --bucket archimedes-tfstate-159903201072 \
+  --bucket archimedes-tfstate-037613907429 \
   --policy '{
     "Version": "2012-10-17",
     "Statement": [
       {"Sid":"DenyNonTLS","Effect":"Deny","Principal":"*","Action":"s3:*",
-       "Resource":["arn:aws:s3:::archimedes-tfstate-159903201072","arn:aws:s3:::archimedes-tfstate-159903201072/*"],
+       "Resource":["arn:aws:s3:::archimedes-tfstate-037613907429","arn:aws:s3:::archimedes-tfstate-037613907429/*"],
        "Condition":{"Bool":{"aws:SecureTransport":"false"}}},
       {"Sid":"RestrictToAccount","Effect":"Deny","Principal":"*","Action":"s3:*",
-       "Resource":["arn:aws:s3:::archimedes-tfstate-159903201072","arn:aws:s3:::archimedes-tfstate-159903201072/*"],
-       "Condition":{"StringNotEquals":{"aws:PrincipalAccount":"159903201072"}}}
+       "Resource":["arn:aws:s3:::archimedes-tfstate-037613907429","arn:aws:s3:::archimedes-tfstate-037613907429/*"],
+       "Condition":{"StringNotEquals":{"aws:PrincipalAccount":"037613907429"}}}
     ]}'
 ```
 

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -23,7 +23,7 @@ provider "aws" {
 
 # ── ACM certificate for CloudFront (us-east-1) ────────────────
 # Separate from the REGIONAL ALB cert (aws_acm_certificate.main in alb.tf,
-# eu-west-2). CloudFront can only attach a us-east-1 cert.
+# us-east-1). CloudFront can only attach a us-east-1 cert.
 resource "aws_acm_certificate" "cloudfront" {
   provider                  = aws.us_east_1
   domain_name               = var.domain_name

--- a/infra/iam/README.md
+++ b/infra/iam/README.md
@@ -108,10 +108,10 @@ Store each as a **SecureString** so it is KMS-encrypted at rest:
 ```bash
 for k in LLM_PROVIDER LLM_AUTH_TOKEN LLM_BASE_URL EMAIL_ENCRYPTION_KEY VITE_CIRCLE_CLIENT_KEY; do
   read -rsp "$k: " v; echo
-  aws ssm put-parameter --region eu-west-2 --type SecureString \
+  aws ssm put-parameter --region us-east-1 --type SecureString \
     --name "/archimedes/prod/$k" --value "$v" --overwrite
 done
-aws ssm get-parameters-by-path --region eu-west-2 \
+aws ssm get-parameters-by-path --region us-east-1 \
   --path /archimedes/prod --recursive --query 'Parameter[].Name'   # verify (names only)
 ```
 

--- a/infra/iam/archimedes-backend-policy.json
+++ b/infra/iam/archimedes-backend-policy.json
@@ -81,7 +81,6 @@
       "Condition": {
         "StringEquals": {
           "kms:ViaService": [
-            "ssm.us-east-1.amazonaws.com",
             "ssm.us-east-1.amazonaws.com"
           ]
         }

--- a/infra/iam/archimedes-backend-policy.json
+++ b/infra/iam/archimedes-backend-policy.json
@@ -55,8 +55,8 @@
         "dynamodb:DescribeTable"
       ],
       "Resource": [
-        "arn:aws:dynamodb:eu-west-2:159903201072:table/archimedes-papers-index",
-        "arn:aws:dynamodb:eu-west-2:159903201072:table/archimedes-papers-index/index/*"
+        "arn:aws:dynamodb:us-east-1:037613907429:table/archimedes-papers-index",
+        "arn:aws:dynamodb:us-east-1:037613907429:table/archimedes-papers-index/index/*"
       ]
     },
     {
@@ -82,7 +82,7 @@
         "StringEquals": {
           "kms:ViaService": [
             "ssm.us-east-1.amazonaws.com",
-            "ssm.eu-west-2.amazonaws.com"
+            "ssm.us-east-1.amazonaws.com"
           ]
         }
       }

--- a/infra/runbooks/aurora-backup-restore.md
+++ b/infra/runbooks/aurora-backup-restore.md
@@ -3,7 +3,7 @@
 > **Status:** Authored 2026-06-12, **not yet drilled.** Commands target the
 > cluster defined in `infra/aurora.tf` (`aws_rds_cluster.main`, identifier
 > `archimedes-aurora`, instance `archimedes-aurora-1`, engine `aurora-postgresql`
-> 16.4). Run in `eu-west-2` with `AWS_PROFILE=archimedes`. **Review each command
+> 16.4). Run in `us-east-1` with `AWS_PROFILE=ArchimedesDanAdmin`. **Review each command
 > before running** — they were not executed in the authoring environment.
 
 ---
@@ -40,10 +40,10 @@ snapshots below.
 aws rds create-db-cluster-snapshot \
   --db-cluster-identifier archimedes-aurora \
   --db-cluster-snapshot-identifier archimedes-aurora-manual-$(date +%Y%m%d-%H%M) \
-  --region eu-west-2
+  --region us-east-1
 # wait until available:
 aws rds wait db-cluster-snapshot-available \
-  --db-cluster-snapshot-identifier <the-id-you-just-used> --region eu-west-2
+  --db-cluster-snapshot-identifier <the-id-you-just-used> --region us-east-1
 ```
 
 ---
@@ -59,7 +59,7 @@ aws rds restore-db-cluster-to-point-in-time \
   --source-db-cluster-identifier archimedes-aurora \
   --db-cluster-identifier archimedes-aurora-restore \
   --restore-to-time 2026-06-12T13:45:00Z \
-  --region eu-west-2
+  --region us-east-1
 #   …or for the latest possible point: add  --use-latest-restorable-time
 #   (and drop --restore-to-time).
 
@@ -69,14 +69,14 @@ aws rds create-db-instance \
   --db-cluster-identifier archimedes-aurora-restore \
   --engine aurora-postgresql \
   --db-instance-class db.serverless \
-  --region eu-west-2
+  --region us-east-1
 aws rds wait db-instance-available \
-  --db-instance-identifier archimedes-aurora-restore-1 --region eu-west-2
+  --db-instance-identifier archimedes-aurora-restore-1 --region us-east-1
 
 # 3. Get the new endpoint and validate before cutover.
 aws rds describe-db-clusters \
   --db-cluster-identifier archimedes-aurora-restore \
-  --query 'DBClusters[0].Endpoint' --output text --region eu-west-2
+  --query 'DBClusters[0].Endpoint' --output text --region us-east-1
 ```
 
 **Validate** against the restore endpoint (read-only first): row counts on
@@ -89,9 +89,9 @@ the most recent rows; confirm the bad migration/corruption is absent.
   keeps working. Rename live out of the way, then restore into its name:
   ```bash
   aws rds modify-db-cluster --db-cluster-identifier archimedes-aurora \
-    --new-db-cluster-identifier archimedes-aurora-broken --apply-immediately --region eu-west-2
+    --new-db-cluster-identifier archimedes-aurora-broken --apply-immediately --region us-east-1
   aws rds modify-db-cluster --db-cluster-identifier archimedes-aurora-restore \
-    --new-db-cluster-identifier archimedes-aurora --apply-immediately --region eu-west-2
+    --new-db-cluster-identifier archimedes-aurora --apply-immediately --region us-east-1
   ```
   ⚠️ Renaming changes the endpoint host; if `DATABASE_URL` pins the endpoint DNS,
   update SSM and restart the app (`docker compose up -d`). Confirm which form the
@@ -116,7 +116,7 @@ aws rds restore-db-cluster-from-snapshot \
   --db-cluster-identifier archimedes-aurora-fromsnap \
   --snapshot-identifier <snapshot-id> \
   --engine aurora-postgresql \
-  --region eu-west-2
+  --region us-east-1
 # then create-db-instance as in PITR step 2.
 ```
 

--- a/infra/runbooks/disaster-recovery.md
+++ b/infra/runbooks/disaster-recovery.md
@@ -7,7 +7,7 @@
 > AWS credentials here). Treat every command as *review-then-run*, and schedule a
 > real game-day drill (see § Drills) before relying on this.
 
-Region: `us-east-1`. Account / profile: `archimedes` (see `CLAUDE.md` § AWS
+Region: `us-east-1`. Account / profile: `ArchimedesDanAdmin` (see `CLAUDE.md` § AWS
 account access). All admin access is via **SSM Session Manager**, not SSH.
 
 ---

--- a/infra/runbooks/disaster-recovery.md
+++ b/infra/runbooks/disaster-recovery.md
@@ -7,7 +7,7 @@
 > AWS credentials here). Treat every command as *review-then-run*, and schedule a
 > real game-day drill (see § Drills) before relying on this.
 
-Region: `eu-west-2`. Account / profile: `archimedes` (see `CLAUDE.md` § AWS
+Region: `us-east-1`. Account / profile: `archimedes` (see `CLAUDE.md` § AWS
 account access). All admin access is via **SSM Session Manager**, not SSH.
 
 ---
@@ -37,11 +37,11 @@ alarm (see `infra/cloudwatch.tf`), or `https://archimedes-arc.com/` 502/503.
    aws elbv2 describe-target-health \
      --target-group-arn "$(aws elbv2 describe-target-groups \
         --names archimedes-backend-tg --query 'TargetGroups[0].TargetGroupArn' --output text)" \
-     --region eu-west-2
+     --region us-east-1
    ```
 2. Try an in-place recovery first (fastest). Open a session and restart the stack:
    ```bash
-   aws ssm start-session --target <instance-id> --region eu-west-2
+   aws ssm start-session --target <instance-id> --region us-east-1
    # on host:
    cd /opt/archimedes && docker compose ps && docker compose up -d
    ```

--- a/infra/runbooks/waf-rules-reference.md
+++ b/infra/runbooks/waf-rules-reference.md
@@ -54,11 +54,11 @@ the LLM payloads; prefer a scoped-down exclusion over blocking the whole group.
 
 ```bash
 # List the metrics the WAF is emitting:
-aws cloudwatch list-metrics --namespace AWS/WAFV2 --region eu-west-2
+aws cloudwatch list-metrics --namespace AWS/WAFV2 --region us-east-1
 
 # Blocked vs allowed counts for the ACL over the last hour (fill in the ACL
 # dimensions from the console — Region/Rule/WebACL):
 aws cloudwatch get-metric-statistics --namespace AWS/WAFV2 \
   --metric-name BlockedRequests --start-time "$(date -u -v-1H +%FT%TZ)" \
-  --end-time "$(date -u +%FT%TZ)" --period 300 --statistics Sum --region eu-west-2
+  --end-time "$(date -u +%FT%TZ)" --period 300 --statistics Sum --region us-east-1
 ```

--- a/infra/scripts/bake-backend-ami.sh
+++ b/infra/scripts/bake-backend-ami.sh
@@ -16,8 +16,8 @@
 # infra/scripts/setup-https.sh.
 #
 # Usage:
-#   AWS_PROFILE=archimedes ./infra/scripts/bake-backend-ami.sh
-#   AWS_PROFILE=archimedes SOURCE_INSTANCE_ID=i-0abc... ./infra/scripts/bake-backend-ami.sh
+#   AWS_PROFILE=ArchimedesDanAdmin ./infra/scripts/bake-backend-ami.sh
+#   AWS_PROFILE=ArchimedesDanAdmin SOURCE_INSTANCE_ID=i-0abc... ./infra/scripts/bake-backend-ami.sh
 #
 # On success it prints the new AMI id. Feed it back to Terraform via:
 #   terraform apply -var "backend_ami_id=ami-0newbakedami..."
@@ -30,7 +30,7 @@
 
 set -euo pipefail
 
-REGION="${AWS_REGION:-eu-west-2}"
+REGION="${AWS_REGION:-us-east-1}"
 PROJECT="${PROJECT_NAME:-archimedes}"
 TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
 AMI_NAME="${PROJECT}-backend-${TIMESTAMP}"

--- a/infra/scripts/seed-ssm-secrets.sh
+++ b/infra/scripts/seed-ssm-secrets.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 SECRETS_FILE="${1:?Usage: $0 /path/to/secrets.env}"
-REGION="${AWS_REGION:-eu-west-2}"
+REGION="${AWS_REGION:-us-east-1}"
 PREFIX="${AWS_SSM_PATH_PREFIX:-/archimedes/prod}"
 
 if [ ! -f "$SECRETS_FILE" ]; then

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -2,7 +2,7 @@
 #
 # Architecture:
 #   - New VPC with /16 CIDR (10.0.0.0/16)
-#   - 2 public subnets (ALB, NAT instances) in eu-west-2a + eu-west-2b
+#   - 2 public subnets (ALB, NAT instances) in us-east-1a + us-east-1b
 #   - 2 private subnets (EC2, Aurora, ElastiCache) in same AZs
 #   - fck-nat t4g.nano instances (one per AZ) for outbound internet
 #   - Internet Gateway for public subnets

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -2,7 +2,7 @@
 #
 # Architecture:
 #   - New VPC with /16 CIDR (10.0.0.0/16)
-#   - 2 public subnets (ALB, NAT instances) in us-east-1a + us-east-1b
+#   - 2 public subnets (ALB, NAT instances) in the first two available AZs
 #   - 2 private subnets (EC2, Aurora, ElastiCache) in same AZs
 #   - fck-nat t4g.nano instances (one per AZ) for outbound internet
 #   - Internet Gateway for public subnets


### PR DESCRIPTION
## Summary

Finishes the 2026-06-24 `us-east-1` / account-`037613907429` migration by purging the stale operational-surface references the migration left behind. Verified against the live backend (`infra/main.tf` → `archimedes-tfstate-037613907429` / `us-east-1`; `docs/deployment-runbook.md` already documents that bucket).

**Handled by the team directly** (infra we own) — not routed to the agentic pipeline.

## Changes
- **`eu-west-2` → `us-east-1`** across 17 files: backend region defaults (`secrets_service.py`, `s3_artifact_store.py`, `dynamodb_paper_index.py`) + their tests, runbooks, scripts, the IAM policy JSON, and docs.
- **Old account `159903201072` → `037613907429`** across 3 files (`infra/README.md` tfstate-bucket bootstrap, `infra/iam/archimedes-backend-policy.json` ARNs, `docs/aws-architecture.md`).
- **`(London)` → `(N. Virginia)`** on the two account-header lines (`aws-architecture.md`, `infra-setup.md`) that would otherwise mislabel `us-east-1`.
- **`AWS_PROFILE=archimedes` → `ArchimedesDanAdmin`** in the two ops docs that referenced the stale profile.

## Deliberately KEPT (correct as-is — anti-goals honored)
- **`infra/alb.tf:15`** live ALB-logs bucket name `${var.project_name}-alb-logs-159903201072` — renaming forces terraform to **destroy + recreate** the bucket. Untouched.
- **Past-tense historical notes** that document the migration truthfully: `.env.example:281` ("The earlier eu-west-2 default was…") and `infra/vpc.tf:19` ("Was hardcoded eu-west-2a/b").
- **`test_dynamodb_paper_index.py`** `us-west-2` env-override test (proves `AWS_REGION` override) — that's `us-west`, not `eu-west`, and stays.

## Verify
```bash
# only the two intentional historical notes remain:
grep -rIn "eu-west-2" backend/ infra/ docs/ .env.example
#   infra/vpc.tf:19  ("Was hardcoded eu-west-2a/b")
#   .env.example:281 ("The earlier eu-west-2 default was")

# old account survives ONLY in the live alb-logs bucket name:
grep -rIn "159903201072" backend/ infra/ docs/
#   infra/alb.tf:15  (bucket name — do not rename)

# region-default service tests (hermetic):
env -i HOME=$HOME PATH="$(conda info --base)/envs/archimedes/bin:$PATH" PYTHONPATH=backend \
  python -m pytest backend/tests/services/test_secrets_service.py \
  backend/tests/services/test_s3_artifact_store.py \
  backend/tests/services/test_dynamodb_paper_index.py -q
#   → 41 passed
```

## No live-infra impact
Only comments (`cloudfront.tf`, `vpc.tf`), docs, scripts, and a reference JSON were changed — **no live `.tf` resource values** — so `terraform plan` stays **0-change**. (Worth a confirming `terraform plan` on your next infra pass, Dan.)

Closes #838.
