### PR TITLE
[strategy] Cast Sharpe CI to plain float — fix passport DB sync rollback

### DIFF
--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -741,7 +741,12 @@ def compute_sharpe_ci(
     sr_daily = sharpe_annual / math.sqrt(_ANNUALIZATION)
     se = math.sqrt((1.0 + 0.5 * sr_daily**2) * _ANNUALIZATION / n_obs_daily)
     z = norm.ppf((1.0 + confidence) / 2.0)
-    return (sharpe_annual - z * se, sharpe_annual + z * se)
+    # `norm.ppf` returns a numpy scalar, so `z * se` (and the returned tuple)
+    # is np.float64 unless cast. A raw np.float64 breaks the passport DB insert:
+    # psycopg2 renders it as `np.float64(-0.33)` and parses `np` as a schema →
+    # `InvalidSchemaName: schema "np" does not exist`, rolling back the passport
+    # sync. Cast to plain float to honor the tuple[float, float] contract.
+    return (float(sharpe_annual - z * se), float(sharpe_annual + z * se))
 
 
 # ─── 6. Private helpers ──────────────────────────────────────────────

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -295,6 +295,21 @@ def test_sharpe_ci_symmetric_around_point_estimate():
     assert abs(mid - sr) < 1e-9, f"CI midpoint {mid:.6f} must equal SR {sr}"
 
 
+def test_sharpe_ci_returns_plain_python_float():
+    """Regression: the CI must be plain ``float``, never ``np.float64``.
+
+    ``norm.ppf`` returns a numpy scalar, so without an explicit cast the tuple
+    leaks ``np.float64`` into ``sharpe_ci_lower``/``sharpe_ci_upper`` on the
+    strategy passport. psycopg2 then renders it as ``np.float64(-0.33)`` and
+    parses ``np`` as a schema, raising ``InvalidSchemaName: schema "np" does
+    not exist`` and rolling back the passport DB sync. ``isinstance(x, float)``
+    does NOT catch this (np.float64 subclasses float) — assert the exact type.
+    """
+    lower, upper = compute_sharpe_ci(1.0, n_obs_daily=252, confidence=0.95)
+    assert type(lower) is float, f"lower is {type(lower).__name__}, must be plain float"
+    assert type(upper) is float, f"upper is {type(upper).__name__}, must be plain float"
+
+
 def test_sharpe_ci_wider_with_fewer_obs():
     """Fewer observations → wider confidence interval."""
     sr = 0.8


### PR DESCRIPTION
## Summary

Local BYOK dogfooding of the generation pipeline surfaced a silent, live-path
bug: the strategy-passport **"unified table sync" rolls back** on any strategy
whose Sharpe confidence interval is computed.

```
unified table sync failed (non-blocking): (psycopg2.errors.InvalidSchemaName)
schema "np" does not exist
[parameters: {... 'sharpe_ci_lower': np.float64(-0.3294),
              'sharpe_ci_upper': np.float64(0.528) ...}]
```

**Root cause.** `compute_sharpe_ci` computes `z = norm.ppf(...)`, and scipy's
`norm.ppf` returns a **numpy scalar**. Without a cast, `z * se` and the returned
tuple are `np.float64`, so `sharpe_ci_lower` / `sharpe_ci_upper` reach the
`strategy_passports` INSERT as numpy scalars. On **numpy ≥ 2.0** (what the
backend container runs) `repr(np.float64(-0.33))` is `np.float64(-0.33)`;
psycopg2 emits that into the SQL and parses `np` as a schema →
`InvalidSchemaName: schema "np" does not exist` → the whole passport-sync
transaction rolls back. It's caught and logged `(non-blocking)`, so it failed
**silently** — the passport just never synced.

## Fix

Cast the returned tuple to plain `float`, honoring the existing
`-> tuple[float, float]` annotation. One-line change at the source, so **every**
caller is fixed (the passport insert, `strategy_provider`, etc.).

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
  python -m pytest backend/tests/test_rigor_evaluator.py -k sharpe_ci -q   # 7 passed
```

The new `test_sharpe_ci_returns_plain_python_float` is an airtight guard: run
against the un-fixed helper it fails with `lower is float64, must be plain
float`; it uses `type(x) is float` because `isinstance(np.float64(x), float)`
is `True` (numpy subclasses float) and would not catch the regression.

## Anti-goals

- No change to the CI math (Lo 2002 formula untouched — the symmetric/width
  pins still pass).
- No threshold or gate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)