### PR TITLE
[telemetry] Dashboard coherence + public/private SIWE split — one honest visitor model (#830) !minor

### DIFF
--- a/backend/archimedes/api/metrics_private_routes.py
+++ b/backend/archimedes/api/metrics_private_routes.py
@@ -1,0 +1,66 @@
+"""Private metrics routes — SIWE-gated cost/ops dashboard (issue #830).
+
+The public ``metrics_router`` (``/api/metrics``, ``/funnel``, ``/visitors``) is
+PII-free by design and stays anonymous — it is the "agents make markets" traction
+instrument. This router is the OTHER half of the split: the internal cost / ops /
+infra dashboard (the ARCH-COST-DASHBOARDS content), which must NOT be public.
+
+Gating reuses the existing SIWE session gate — the same mechanism ``user_routes``
+uses to protect PII (``auth_siwe.require_verified_wallet``). No new auth system:
+a request without a valid ``archimedes_session`` cookie gets **401**.
+
+Claim integrity (issue #830): the private numbers here are recomputed against the
+honest instruments — distinct wallets (``user_profiles``) and strategy generations
+— NEVER the cumulative request tallies. ``$/user`` / ``$/gen`` figures are derived
+from true users or generations, not from ``human_count``.
+
+Today's cost fields are DRAFT/illustrative placeholders (the live Bedrock/infra
+billing wiring — AWS Cost Explorer + Bedrock token metering — is roadmap work);
+they are labelled ``draft`` so a reader can't mistake them for metered live spend.
+Real distinct users are read live so the per-user denominators are honest.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends
+
+from archimedes.api.auth_siwe import require_verified_wallet
+from archimedes.services.user_stats import get_distinct_user_count
+
+# Every route on this router requires a valid SIWE session (401 otherwise). The
+# router-level dependency is the same gate user_routes uses for PII.
+metrics_private_router = APIRouter(
+    prefix="/api/metrics/private",
+    tags=["metrics", "private"],
+    dependencies=[Depends(require_verified_wallet)],
+)
+
+
+@metrics_private_router.get("/cost")
+async def get_private_cost(wallet: str = Depends(require_verified_wallet)) -> dict:
+    """SIWE-gated cost/billing dashboard (issue #830). Anonymous → 401.
+
+    Cost fields are DRAFT placeholders until the live billing wiring lands
+    (roadmap: AWS Cost Explorer + Bedrock token metering). ``real_users`` is read
+    live so any per-user figure a consumer computes is anchored to the honest
+    distinct-user denominator, never the request counter.
+    """
+    real_users = get_distinct_user_count()
+    return {
+        "source": "draft",  # NOT live-metered spend — placeholders pending billing wiring.
+        "real_users": real_users,
+        "bedrock_monthly_usd": None,
+        "bedrock_daily_usd": None,
+        "infra_monthly_usd": None,
+        "cost_per_user_usd": None,
+        "cost_per_generation_usd": None,
+        "note": (
+            "Draft placeholders. Per-user / per-generation figures must be derived from "
+            "real_users (distinct wallets) or strategy generations — never the cumulative "
+            "request tallies on /api/metrics (issue #830)."
+        ),
+        "authenticated_wallet": wallet,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }

--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -134,7 +134,13 @@ async def record_funnel_event(req: FunnelEventRequest, request: Request) -> dict
         return {"recorded": False}
     await record_funnel(request, req.stage)
     # Geography + device off the same landed beacon (one distinct-visitor source).
-    await record_visitor_insight(request)
+    # Pass the telemetry classifier's verdict through so the defense-in-depth
+    # ``is_agent`` skip in ``record_visitor_insight`` actually fires — a beacon
+    # carrying an internal-agent key / bot UA must not inflate the visitor count.
+    # ``request.state.is_agent`` is set by the telemetry middleware; default to
+    # ``False`` (an ordinary human beacon) if that middleware error-swallowed.
+    is_agent = bool(getattr(request.state, "is_agent", False))
+    await record_visitor_insight(request, is_agent=is_agent)
     return {"recorded": True}
 
 

--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Query, Request
 
 from archimedes.api.funnel_middleware import record_funnel
+from archimedes.api.visitor_insights import record_visitor_insight
 from archimedes.models.telemetry import (
     CountryCount,
     FunnelEventRequest,
@@ -27,6 +28,7 @@ from archimedes.models.telemetry import (
 )
 from archimedes.services.funnel_store import CLIENT_EMITTABLE_STAGES, STAGES, FunnelStore
 from archimedes.services.telemetry_store import TelemetryStore
+from archimedes.services.user_stats import get_distinct_user_count
 from archimedes.services.visitor_insights_store import VisitorInsightsStore
 
 metrics_router = APIRouter(prefix="/api", tags=["metrics"])
@@ -60,10 +62,16 @@ def _build_funnel(counts: dict[str, int], window: str) -> FunnelResponse:
 
 @metrics_router.get("/metrics", response_model=MetricsResponse)
 async def get_metrics() -> MetricsResponse:
-    """Return the live human-vs-agent traction counts.
+    """Return the live human-vs-agent traction counts + the honest user count.
 
-    Fail-safe: ``TelemetryStore.get_counts`` returns ``(0, 0)`` when Redis is
-    unreachable, so this endpoint always responds 200 with a well-formed shape.
+    ``human_count`` / ``agent_count`` / ``total_requests`` are cumulative
+    per-request tallies (site traffic, NOT users). ``real_users`` is the distinct
+    wallet count from ``user_profiles`` — the honest distinct-user number surfaced
+    alongside so the tallies can't be mis-cited as users (issue #830).
+
+    Fail-safe: ``TelemetryStore.get_counts`` returns ``(0, 0)`` and
+    ``get_distinct_user_count`` returns ``0`` on error, so this endpoint always
+    responds 200 with a well-formed shape.
     """
     store = TelemetryStore()
     try:
@@ -71,10 +79,13 @@ async def get_metrics() -> MetricsResponse:
     finally:
         await store.close()
 
+    real_users = get_distinct_user_count()
+
     return MetricsResponse(
         human_count=human_count,
         agent_count=agent_count,
         total_requests=human_count + agent_count,
+        real_users=real_users,
         timestamp=datetime.now(UTC).isoformat(),
     )
 
@@ -113,10 +124,17 @@ async def record_funnel_event(req: FunnelEventRequest, request: Request) -> dict
     downstream stage is recorded server-side at its authoritative transition so a
     client cannot inflate it. Always 200 (``recorded`` flags whether it counted);
     the visitor id is read from the ``archimedes_vid`` cookie via request state.
+
+    Issue #830: this JS-gated ``landed`` beacon is the single source of truth for
+    "distinct visitor". We record geography + device here (same ``archimedes_vid``
+    dedup key as the funnel) so geo/device count exactly the ``landed`` population
+    — reconciling the funnel-vs-visitors discrepancy. Both writes are fail-safe.
     """
     if req.stage not in CLIENT_EMITTABLE_STAGES:
         return {"recorded": False}
     await record_funnel(request, req.stage)
+    # Geography + device off the same landed beacon (one distinct-visitor source).
+    await record_visitor_insight(request)
     return {"recorded": True}
 
 

--- a/backend/archimedes/api/telemetry_middleware.py
+++ b/backend/archimedes/api/telemetry_middleware.py
@@ -46,26 +46,40 @@ _AGENT_UA_PATTERN = re.compile(
 )
 
 # Paths whose traffic is infra/telemetry polling, not a real visit: the health
-# probes (Docker/CI/CloudFront) and the metrics-read endpoints (the dashboard
+# probes (Docker/CI/CloudFront) and the metrics-READ endpoints (the dashboard
 # polling *itself*). Excluding them from the counter stops the instrument from
 # counting its own reads (issue #830). This changes WHICH requests increment, not
 # the INCR semantics of the requests that do — a real page hit still counts once.
+#
+# NOTE: the exclusion is a READ exclusion. The metrics-read surfaces are only ever
+# read via GET/HEAD, so we exclude those methods only. The one WRITE under
+# ``/api/metrics`` — the POST ``/api/metrics/funnel/event`` beacon — is a real user
+# action (a browser that rendered the page fired it) and MUST still count.
 _COUNTER_EXCLUDED_PREFIXES: tuple[str, ...] = (
     "/health",
     "/api/health",
     "/api/metrics",
 )
 
+# Methods that a metrics-read/health poll uses. Only these are excluded on the
+# telemetry prefixes; a POST (the funnel/event beacon) always counts.
+_READ_METHODS: frozenset[str] = frozenset({"GET", "HEAD"})
+
 
 def _is_counted_request(request: Request) -> bool:
-    """False for infra/telemetry-poll paths + CORS preflights (issue #830).
+    """False for infra/telemetry-poll READS + CORS preflights (issue #830).
 
-    OPTIONS is a CORS preflight, never a user action. The excluded prefixes are
-    health probes and the metrics-read endpoints (the dashboard polling itself).
-    Everything else counts, exactly as before.
+    OPTIONS is a CORS preflight, never a user action → never counted. The excluded
+    prefixes (health probes + metrics-read endpoints) are only skipped for READ
+    methods (GET/HEAD); the POST ``/api/metrics/funnel/event`` beacon is a real
+    user action and still counts. Everything else counts, exactly as before.
     """
-    if request.method == "OPTIONS":
+    method = request.method
+    if method == "OPTIONS":
         return False
+    if method not in _READ_METHODS:
+        # A write (e.g. the funnel/event beacon POST) is a real action → count it.
+        return True
     path = request.url.path
     return not any(path == p or path.startswith(p + "/") for p in _COUNTER_EXCLUDED_PREFIXES)
 

--- a/backend/archimedes/api/telemetry_middleware.py
+++ b/backend/archimedes/api/telemetry_middleware.py
@@ -45,6 +45,30 @@ _AGENT_UA_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Paths whose traffic is infra/telemetry polling, not a real visit: the health
+# probes (Docker/CI/CloudFront) and the metrics-read endpoints (the dashboard
+# polling *itself*). Excluding them from the counter stops the instrument from
+# counting its own reads (issue #830). This changes WHICH requests increment, not
+# the INCR semantics of the requests that do — a real page hit still counts once.
+_COUNTER_EXCLUDED_PREFIXES: tuple[str, ...] = (
+    "/health",
+    "/api/health",
+    "/api/metrics",
+)
+
+
+def _is_counted_request(request: Request) -> bool:
+    """False for infra/telemetry-poll paths + CORS preflights (issue #830).
+
+    OPTIONS is a CORS preflight, never a user action. The excluded prefixes are
+    health probes and the metrics-read endpoints (the dashboard polling itself).
+    Everything else counts, exactly as before.
+    """
+    if request.method == "OPTIONS":
+        return False
+    path = request.url.path
+    return not any(path == p or path.startswith(p + "/") for p in _COUNTER_EXCLUDED_PREFIXES)
+
 
 def _is_browser_ua(user_agent: str) -> bool:
     """A real browser sends a ``Mozilla/...`` UA. Empty/non-Mozilla → not a browser."""
@@ -114,26 +138,30 @@ async def telemetry_middleware(request: Request, call_next):
         request.state.is_agent = is_agent
         request.state.agent_type = agent_type
 
-        # Lazy import keeps the store off the import-time critical path and
-        # makes the boundary (the Redis client) easy to mock in tests.
-        from archimedes.services.telemetry_store import TelemetryStore
+        # Count every real request, but skip infra/telemetry-poll paths and CORS
+        # preflights (issue #830) so the counter stops counting its own reads. The
+        # request is still classified + tagged above; only the INCR is skipped.
+        if _is_counted_request(request):
+            # Lazy import keeps the store off the import-time critical path and
+            # makes the boundary (the Redis client) easy to mock in tests.
+            from archimedes.services.telemetry_store import TelemetryStore
 
-        store = TelemetryStore()
-        try:
-            if is_agent:
-                await store.increment_agent()
-            else:
-                await store.increment_human()
-        finally:
-            await store.close()
+            store = TelemetryStore()
+            try:
+                if is_agent:
+                    await store.increment_agent()
+                else:
+                    await store.increment_human()
+            finally:
+                await store.close()
 
-        # Visitor insights (#787): record country + device for HUMAN visitors so we
-        # can see where our (un-promoted) traffic comes from. Fail-safe + humans-only
-        # (skips agents/crawlers). Uses request.state.visitor_id, set by the
-        # visitor-id middleware which runs outermost (before this one).
-        from archimedes.api.visitor_insights import record_visitor_insight
-
-        await record_visitor_insight(request, is_agent)
+        # Visitor insights (#787, #830): geography + device are NOT recorded here.
+        # Recording on every human-classified request leaked browser-UA bots
+        # through the open-demo default and inflated the distinct-visitor count
+        # (the 17-vs-50 discrepancy). The single source of truth for "distinct
+        # visitor" is the JS-gated `landed` beacon (see api/metrics_routes.py
+        # record_funnel_event), which shares the same archimedes_vid dedup key as
+        # the funnel — so geo/device and the funnel `landed` count agree.
     except Exception as exc:
         # Fail-safe: never let telemetry raise into the request path.
         logger.debug("telemetry middleware classify/count failed: %s", exc)

--- a/backend/archimedes/api/visitor_insights.py
+++ b/backend/archimedes/api/visitor_insights.py
@@ -2,11 +2,17 @@
 
 Derives the visitor's country (CloudFront-Viewer-Country) and device class
 (CloudFront device headers, falling back to a User-Agent sniff) and records them
-via ``VisitorInsightsStore``. Called from the telemetry middleware, which already
-classifies human-vs-agent and has the anonymous ``visitor_id`` on request state.
+via ``VisitorInsightsStore``.
 
-Humans only: agent/crawler traffic is skipped so the geography reflects real
-visitors, not datacenter crawler IPs. Fail-safe — never raises into the request.
+Population (issue #830): called from the **JS-gated ``landed`` beacon path**
+(``POST /api/metrics/funnel/event`` with ``stage="landed"``), the same trigger
+and same ``archimedes_vid`` dedup key the conversion funnel uses. This is the one
+source of truth for "distinct visitor": geography + device now count exactly the
+population the funnel's ``landed`` stage counts, reconciling the 17-vs-50 gap that
+came from recording on every server-side human-classified request (which leaked
+browser-UA bots through the open-demo default). Non-JS crawlers don't run the
+beacon, so they don't appear here — but this is still an UA/beacon-derived signal,
+not a verified-identity count. Fail-safe — never raises into the request.
 """
 
 from __future__ import annotations
@@ -40,8 +46,14 @@ def _device_class(request: Request) -> str:
     return "unknown"
 
 
-async def record_visitor_insight(request: Request, is_agent: bool) -> None:
-    """Record this request's visitor geography + device (humans only). Never raises."""
+async def record_visitor_insight(request: Request, is_agent: bool = False) -> None:
+    """Record this visitor's geography + device. Never raises.
+
+    Called from the JS-gated ``landed`` beacon path (issue #830), so the caller is
+    a browser that actually rendered the page. ``is_agent`` is retained as a
+    defense-in-depth skip (a beacon carrying an internal-agent key / bot UA is not
+    a real visitor) and defaults to ``False`` for the ordinary beacon call.
+    """
     if is_agent:
         return
     try:

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -37,6 +37,7 @@ from archimedes.api.leaderboard_routes import leaderboard_router
 from archimedes.api.limiter import limiter
 
 # (the marketplace route registration was removed — hardcoded fees + invented math, Issue #381)
+from archimedes.api.metrics_private_routes import metrics_private_router
 from archimedes.api.metrics_routes import metrics_router
 from archimedes.api.portfolio_routes import portfolio_router
 from archimedes.api.proposals_routes import proposals_router
@@ -260,6 +261,7 @@ app.include_router(user_router)
 app.include_router(auth_router)
 app.include_router(proposals_router)
 app.include_router(metrics_router)
+app.include_router(metrics_private_router)
 app.include_router(leaderboard_router)
 
 
@@ -342,6 +344,7 @@ async def health():
 
     # Human-vs-agent traction counts (issue #428). Fail-safe: get_counts
     # returns (0, 0) when Redis is unreachable, so /health never degrades on it.
+    # NOTE: these are cumulative per-request tallies (site traffic, NOT users).
     human_count = 0
     agent_count = 0
     try:
@@ -354,6 +357,17 @@ async def health():
             await _store.close()
     except Exception:
         logger.debug("telemetry counts read failed", exc_info=True)
+
+    # Distinct "real users" = wallet rows in user_profiles (issue #830). Surfaced
+    # next to the request tallies so no doc/monitor can conflate traffic with
+    # users. Fail-safe: returns 0 on any DB error.
+    real_users = 0
+    try:
+        from archimedes.services.user_stats import get_distinct_user_count
+
+        real_users = get_distinct_user_count()
+    except Exception:
+        logger.debug("real_users count read failed", exc_info=True)
 
     # Claim-integrity: corpus honesty fields (issue #778).
     # The `corpus_papers` / `corpus_db_count` counts above are *metadata records*
@@ -398,8 +412,11 @@ async def health():
         "status": "ok" if connected else "degraded",
         "service": "archimedes-backend",
         "chain_connected": connected,
+        # human_count / agent_count are cumulative per-request tallies (site
+        # traffic, NOT users). real_users is the honest distinct-user count.
         "human_count": human_count,
         "agent_count": agent_count,
+        "real_users": real_users,
         "corpus_papers": len(corpus),
         "corpus_db_count": db_count,
         "corpus_source": corpus_source,

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -24,13 +24,20 @@ from pydantic import BaseModel, Field
 class MetricsResponse(BaseModel):
     """Public traction counter — humans vs agents over the live deployment.
 
-    Served by ``GET /api/metrics``. Counts are monotonic cumulative totals
-    since the Redis counters were last reset (deploy / flush).
+    Served by ``GET /api/metrics``. The ``*_count`` / ``total_requests`` fields are
+    **cumulative per-request tallies (site traffic, NOT users)** — monotonic totals
+    since the Redis counters were last reset (deploy / flush). ``real_users`` is the
+    honest distinct-user number (wallet rows in ``user_profiles``) surfaced adjacent
+    so the traffic tallies can never be read as a user count (issue #830).
     """
 
-    human_count: int = Field(..., description="Requests classified as human (SIWE session / browser).")
-    agent_count: int = Field(..., description="Requests classified as agent (internal key / bot UA).")
-    total_requests: int = Field(..., description="human_count + agent_count.")
+    human_count: int = Field(..., description="Human-UA REQUESTS (cumulative, site traffic — NOT users).")
+    agent_count: int = Field(..., description="Agent/bot REQUESTS (cumulative, site traffic — NOT users).")
+    total_requests: int = Field(..., description="human_count + agent_count (cumulative requests — NOT users).")
+    real_users: int = Field(
+        default=0,
+        description="Distinct users = wallet rows in user_profiles. The honest distinct-user count (issue #830).",
+    )
     timestamp: str = Field(..., description="ISO-8601 UTC timestamp this snapshot was read.")
 
 

--- a/backend/archimedes/services/user_stats.py
+++ b/backend/archimedes/services/user_stats.py
@@ -23,16 +23,20 @@ logger = logging.getLogger(__name__)
 # Small in-process TTL cache. ``get_distinct_user_count`` is called from the
 # highly-polled ``/health`` + ``/api/metrics`` endpoints, and the wallet count is
 # a slowly-changing stat — caching it for a few seconds keeps frequent polling
-# from running a Postgres COUNT on every request. The cache is per-process and
-# fail-safe: a query error caches nothing (so the next call retries) and still
-# returns 0.
+# from running a Postgres COUNT on every request. Per-process and fail-safe: only a
+# SUCCESSFUL read (a genuine count, including a real 0) is cached; a query error is
+# NOT cached (the next call retries) and still returns 0.
 _CACHE_TTL_SECONDS = 30.0
-_cache_value: int = 0
-_cache_ts: float = 0.0
+# (last successful count, monotonic timestamp of that read). ts == 0 → nothing cached yet.
+_cache: tuple[int, float] = (0, 0.0)
 
 
-def _query_distinct_user_count() -> int:
-    """Run the actual COUNT query. Returns 0 on any error (never raises)."""
+def _query_distinct_user_count() -> int | None:
+    """Run the actual COUNT query.
+
+    Returns the distinct-wallet count, or ``None`` on any error (never raises) so the
+    caller can tell a failed read apart from a genuine zero and avoid caching the failure.
+    """
     try:
         from sqlalchemy import func
 
@@ -46,28 +50,31 @@ def _query_distinct_user_count() -> int:
             session.close()
     except Exception as exc:
         logger.debug("distinct user count read failed: %s", exc)
-        return 0
+        return None
 
 
 def get_distinct_user_count() -> int:
     """Return the number of distinct users = wallet rows in ``user_profiles``.
 
-    ``wallet_address`` is the table's primary key, so a plain row count is already
-    a distinct-wallet count. Result is cached in-process for ``_CACHE_TTL_SECONDS``
-    so highly-polled callers (``/health``, ``/api/metrics``) don't hammer Postgres.
+    ``wallet_address`` is the table's primary key, so a plain row count is already a
+    distinct-wallet count. A successful result (including a genuine 0) is cached for
+    ``_CACHE_TTL_SECONDS`` so highly-polled callers (``/health``, ``/api/metrics``)
+    don't hammer Postgres; a failed read is NOT cached, so the next call retries.
     Returns 0 on any error (never raises).
     """
-    global _cache_value, _cache_ts
+    global _cache
     now = time.monotonic()
-    if _cache_ts and (now - _cache_ts) < _CACHE_TTL_SECONDS:
-        return _cache_value
-    _cache_value = _query_distinct_user_count()
-    _cache_ts = now
-    return _cache_value
+    value, ts = _cache
+    if ts and (now - ts) < _CACHE_TTL_SECONDS:
+        return value
+    result = _query_distinct_user_count()
+    if result is None:
+        return 0  # query error → don't cache; the next call retries
+    _cache = (result, now)
+    return result
 
 
 def _reset_cache() -> None:
     """Clear the TTL cache. Test hook so cached state can't leak between tests."""
-    global _cache_value, _cache_ts
-    _cache_value = 0
-    _cache_ts = 0.0
+    global _cache
+    _cache = (0, 0.0)

--- a/backend/archimedes/services/user_stats.py
+++ b/backend/archimedes/services/user_stats.py
@@ -1,0 +1,42 @@
+"""User stats — the honest "real users" count (issue #830).
+
+The distinct-user number that is safe to cite anywhere: the count of rows in the
+``user_profiles`` table (one row per wallet, wallet address is the primary key).
+This is the ONLY distinct-user instrument that is actually distinct — the
+``/api/metrics`` human/agent counters are cumulative per-request tallies (site
+traffic, NOT users), and the JS-gated distinct-visitor HLL counts browsers, not
+verified identities. Surfacing this number alongside those keeps the honest count
+adjacent so no surface can conflate traffic with users.
+
+Fail-safe by construction: any DB error returns 0 rather than raising, mirroring
+the telemetry/funnel stores — an instrument read must never turn a request into a
+5xx.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_distinct_user_count() -> int:
+    """Return the number of distinct users = wallet rows in ``user_profiles``.
+
+    ``wallet_address`` is the table's primary key, so a plain row count is already
+    a distinct-wallet count. Returns 0 on any error (never raises).
+    """
+    try:
+        from sqlalchemy import func
+
+        from archimedes.db import get_session
+        from archimedes.models.user_profile import UserProfile
+
+        session = get_session()
+        try:
+            return int(session.query(func.count(UserProfile.wallet_address)).scalar() or 0)
+        finally:
+            session.close()
+    except Exception as exc:
+        logger.debug("distinct user count read failed: %s", exc)
+        return 0

--- a/backend/archimedes/services/user_stats.py
+++ b/backend/archimedes/services/user_stats.py
@@ -16,16 +16,23 @@ the telemetry/funnel stores — an instrument read must never turn a request int
 from __future__ import annotations
 
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
+# Small in-process TTL cache. ``get_distinct_user_count`` is called from the
+# highly-polled ``/health`` + ``/api/metrics`` endpoints, and the wallet count is
+# a slowly-changing stat — caching it for a few seconds keeps frequent polling
+# from running a Postgres COUNT on every request. The cache is per-process and
+# fail-safe: a query error caches nothing (so the next call retries) and still
+# returns 0.
+_CACHE_TTL_SECONDS = 30.0
+_cache_value: int = 0
+_cache_ts: float = 0.0
 
-def get_distinct_user_count() -> int:
-    """Return the number of distinct users = wallet rows in ``user_profiles``.
 
-    ``wallet_address`` is the table's primary key, so a plain row count is already
-    a distinct-wallet count. Returns 0 on any error (never raises).
-    """
+def _query_distinct_user_count() -> int:
+    """Run the actual COUNT query. Returns 0 on any error (never raises)."""
     try:
         from sqlalchemy import func
 
@@ -40,3 +47,27 @@ def get_distinct_user_count() -> int:
     except Exception as exc:
         logger.debug("distinct user count read failed: %s", exc)
         return 0
+
+
+def get_distinct_user_count() -> int:
+    """Return the number of distinct users = wallet rows in ``user_profiles``.
+
+    ``wallet_address`` is the table's primary key, so a plain row count is already
+    a distinct-wallet count. Result is cached in-process for ``_CACHE_TTL_SECONDS``
+    so highly-polled callers (``/health``, ``/api/metrics``) don't hammer Postgres.
+    Returns 0 on any error (never raises).
+    """
+    global _cache_value, _cache_ts
+    now = time.monotonic()
+    if _cache_ts and (now - _cache_ts) < _CACHE_TTL_SECONDS:
+        return _cache_value
+    _cache_value = _query_distinct_user_count()
+    _cache_ts = now
+    return _cache_value
+
+
+def _reset_cache() -> None:
+    """Clear the TTL cache. Test hook so cached state can't leak between tests."""
+    global _cache_value, _cache_ts
+    _cache_value = 0
+    _cache_ts = 0.0

--- a/backend/archimedes/services/user_stats.py
+++ b/backend/archimedes/services/user_stats.py
@@ -26,9 +26,11 @@ logger = logging.getLogger(__name__)
 # from running a Postgres COUNT on every request. Per-process and fail-safe: only a
 # SUCCESSFUL read (a genuine count, including a real 0) is cached; a query error is
 # NOT cached (the next call retries) and still returns 0.
+#
+# Held in a MUTATED-IN-PLACE dict (never reassigned) so there is no module global to
+# rebind — ``"ts" == 0`` means nothing is cached yet.
 _CACHE_TTL_SECONDS = 30.0
-# (last successful count, monotonic timestamp of that read). ts == 0 → nothing cached yet.
-_cache: tuple[int, float] = (0, 0.0)
+_cache: dict[str, float] = {"value": 0.0, "ts": 0.0}
 
 
 def _query_distinct_user_count() -> int | None:
@@ -62,19 +64,18 @@ def get_distinct_user_count() -> int:
     don't hammer Postgres; a failed read is NOT cached, so the next call retries.
     Returns 0 on any error (never raises).
     """
-    global _cache
     now = time.monotonic()
-    value, ts = _cache
-    if ts and (now - ts) < _CACHE_TTL_SECONDS:
-        return value
+    if _cache["ts"] and (now - _cache["ts"]) < _CACHE_TTL_SECONDS:
+        return int(_cache["value"])
     result = _query_distinct_user_count()
     if result is None:
         return 0  # query error → don't cache; the next call retries
-    _cache = (result, now)
+    _cache["value"] = result
+    _cache["ts"] = now
     return result
 
 
 def _reset_cache() -> None:
     """Clear the TTL cache. Test hook so cached state can't leak between tests."""
-    global _cache
-    _cache = (0, 0.0)
+    _cache["value"] = 0.0
+    _cache["ts"] = 0.0

--- a/backend/archimedes/services/visitor_insights_store.py
+++ b/backend/archimedes/services/visitor_insights_store.py
@@ -2,7 +2,7 @@
 
 We have zero promotion and a zero-conversion problem, so understanding WHO lands
 on the site (where from, on what kind of device) is high-value signal. This
-records, per day, the distinct *human-ish* visitors broken down by:
+records, per day, the distinct visitors broken down by:
 
   - **country** — the ISO-3166 code CloudFront geolocates from the viewer IP and
     forwards as the ``CloudFront-Viewer-Country`` header (the ALB/origin can't see
@@ -13,8 +13,16 @@ records, per day, the distinct *human-ish* visitors broken down by:
 
 Distinct counts use Redis HyperLogLog keyed on the anonymous ``archimedes_vid``
 (no PII, no raw-id retention) — same privacy-friendly approach as the funnel.
-Only requests classified as human (not agents/bots) are recorded, so the
-geography reflects real visitors, not datacenter crawler IPs.
+
+Population (issue #830): this is recorded from the **same JS-gated ``landed``
+beacon population the conversion funnel uses** — one source of truth for
+"distinct visitor" across funnel, geography, and device. The beacon is emitted
+by the SPA's JavaScript, which non-JS crawlers don't execute, so the recorded
+population is browser-rendered visitors — NOT every server-side human-classified
+request (that population leaks browser-UA bots through the open-demo default and
+was the source of the 17-vs-50 discrepancy this issue reconciles). It is still an
+UA/beacon-derived signal, not a verified-identity count; distinct *users* are the
+wallet count in ``user_profiles``.
 
 Mirrors ``services/funnel_store.py`` / ``telemetry_store.py``: same
 ``redis.asyncio`` convention and **fail-safe by construction** — every method
@@ -65,10 +73,10 @@ class VisitorInsightsStore:
             self._redis = aioredis.from_url(self._url, decode_responses=True)
         return self._redis
 
-    # ─── Record (write path — telemetry middleware, humans only) ─────────
+    # ─── Record (write path — JS-gated `landed` beacon, issue #830) ──────
 
     async def record(self, country: str | None, device: str, visitor_id: str) -> None:
-        """Record one human visit's country + device for ``visitor_id``. Never raises."""
+        """Record one landed visit's country + device for ``visitor_id``. Never raises."""
         if not visitor_id:
             return
         cc = _norm_country(country)

--- a/backend/tests/test_metrics_private_routes.py
+++ b/backend/tests/test_metrics_private_routes.py
@@ -1,0 +1,84 @@
+"""Tests for the SIWE-gated private metrics routes (issue #830).
+
+The public metrics endpoints (/api/metrics, /funnel, /visitors) are PII-free and
+stay anonymous. The private cost/ops dashboard (/api/metrics/private/*) reuses the
+existing SIWE session gate (auth_siwe.require_verified_wallet) — the same
+mechanism user_routes uses for PII. Anonymous → 401; valid SIWE session → 200.
+
+Hermetic: the SIWE session cookie is built with the real ``_sign_session`` (the
+auth layer's own signer), exercising the production ``_verify_session`` gate
+rather than a mock — the same ``_siwe_cookies`` helper pattern as
+``test_user_routes.py``. The distinct-user count is mocked at the DB boundary so
+no live Postgres is touched.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from fastapi.testclient import TestClient
+
+_WALLET = "0x1111111111111111111111111111111111111111"
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Build a valid SIWE session cookie for `wallet` (copied from test_user_routes)."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+@pytest.fixture
+def client():
+    """Test client over the real app, with the user-count boundary pinned to a known value.
+
+    ``get_distinct_user_count`` is imported by-name into the route modules, so we
+    patch it where it is *used* (the route modules), not where it is defined —
+    otherwise a sibling test that seeds real ``user_profiles`` rows into the shared
+    in-memory DB would leak into the assertion (order-dependent flake).
+    """
+    from archimedes.main import app
+
+    with (
+        patch("archimedes.api.metrics_private_routes.get_distinct_user_count", return_value=2),
+        patch("archimedes.api.metrics_routes.get_distinct_user_count", return_value=2),
+    ):
+        yield TestClient(app)
+
+
+def test_private_cost_401_without_session(client):
+    """Anonymous GET /api/metrics/private/cost → 401 (no SIWE session)."""
+    res = client.get("/api/metrics/private/cost")
+    assert res.status_code == 401
+
+
+def test_private_cost_401_with_bad_cookie(client):
+    """A forged/garbage session cookie must not authenticate → 401."""
+    res = client.get("/api/metrics/private/cost", cookies={_COOKIE_NAME: "not-a-valid-token"})
+    assert res.status_code == 401
+
+
+def test_private_cost_200_with_valid_siwe_session(client):
+    """Valid SIWE session → 200, with the honest real-users denominator present."""
+    res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_WALLET))
+    assert res.status_code == 200
+    body = res.json()
+    # The honest distinct-user count is present (denominator for any per-user $).
+    assert body["real_users"] == 2
+    assert body["authenticated_wallet"] == _WALLET.lower()
+    # Cost fields are draft placeholders until billing wiring lands.
+    assert body["source"] == "draft"
+
+
+def test_public_metrics_stays_public_and_pii_free(client):
+    """The public /api/metrics endpoint is anonymous + PII-free (diagnosis #5)."""
+    res = client.get("/api/metrics")
+    assert res.status_code == 200
+    body = res.json()
+    # Request tallies + the honest real-users count; no PII.
+    assert "human_count" in body
+    assert "agent_count" in body
+    assert body["real_users"] == 2
+    assert "email" not in body
+    assert "display_name" not in body

--- a/backend/tests/test_telemetry_classifier.py
+++ b/backend/tests/test_telemetry_classifier.py
@@ -28,7 +28,12 @@ from starlette.requests import Request
 _WALLET = "0x1111111111111111111111111111111111111111"
 
 
-def _make_request(headers: dict[str, str] | None = None, cookies: dict[str, str] | None = None) -> Request:
+def _make_request(
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+    method: str = "GET",
+    path: str = "/api/anything",
+) -> Request:
     """Build a minimal ASGI ``Request`` with given headers/cookies (hermetic)."""
     raw_headers: list[tuple[bytes, bytes]] = []
     for k, v in (headers or {}).items():
@@ -38,8 +43,8 @@ def _make_request(headers: dict[str, str] | None = None, cookies: dict[str, str]
         raw_headers.append((b"cookie", cookie_str.encode()))
     scope = {
         "type": "http",
-        "method": "GET",
-        "path": "/api/anything",
+        "method": method,
+        "path": path,
         "headers": raw_headers,
         "query_string": b"",
     }
@@ -118,6 +123,43 @@ def test_expired_session_is_not_human_session():
     is_agent, agent_type = classify_request(request)
     assert is_agent is True
     assert agent_type == "external"
+
+
+# ── _is_counted_request: read-exclusion is method-aware (issue #830) ──────────
+
+
+def test_metrics_read_get_is_not_counted():
+    """A GET metrics-read poll (the dashboard polling itself) is excluded."""
+    from archimedes.api.telemetry_middleware import _is_counted_request
+
+    for path in ("/api/metrics", "/api/metrics/funnel", "/api/metrics/visitors", "/health", "/api/health"):
+        assert _is_counted_request(_make_request(method="GET", path=path)) is False
+
+
+def test_funnel_event_beacon_post_is_counted():
+    """The POST ``/api/metrics/funnel/event`` beacon is a real user action → counts.
+
+    Regression for the read-exclusion bug: excluding the ``/api/metrics`` prefix for
+    ALL methods wrongly stopped counting the beacon POST (issue #830 review).
+    """
+    from archimedes.api.telemetry_middleware import _is_counted_request
+
+    assert _is_counted_request(_make_request(method="POST", path="/api/metrics/funnel/event")) is True
+
+
+def test_options_preflight_is_not_counted():
+    """OPTIONS is a CORS preflight, never a user action."""
+    from archimedes.api.telemetry_middleware import _is_counted_request
+
+    assert _is_counted_request(_make_request(method="OPTIONS", path="/api/metrics/funnel/event")) is False
+    assert _is_counted_request(_make_request(method="OPTIONS", path="/api/strategies")) is False
+
+
+def test_ordinary_request_is_counted():
+    """A normal page/API GET (not a metrics-read/health path) still counts."""
+    from archimedes.api.telemetry_middleware import _is_counted_request
+
+    assert _is_counted_request(_make_request(method="GET", path="/api/strategies")) is True
 
 
 # ── middleware fail-safe ─────────────────────────────────────────

--- a/backend/tests/test_visitor_insights.py
+++ b/backend/tests/test_visitor_insights.py
@@ -10,12 +10,19 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
-from archimedes.api.visitor_insights import _device_class, record_visitor_insight
-from archimedes.services.visitor_insights_store import (
-    DEVICE_CLASSES,
-    VisitorInsightsStore,
-    _norm_country,
-)
+# Single import style per module (CodeQL: no mixed ``import`` / ``from ... import``
+# for the same module). These three modules are also monkeypatched by attribute in
+# some tests, so we bind them as module aliases and reference their symbols through
+# the alias everywhere — one consistent style, and the monkeypatch targets stay live.
+import archimedes.api.metrics_routes as mr
+import archimedes.api.visitor_insights as vmod
+import archimedes.services.visitor_insights_store as vstore
+
+_device_class = vmod._device_class
+record_visitor_insight = vmod.record_visitor_insight
+DEVICE_CLASSES = vstore.DEVICE_CLASSES
+VisitorInsightsStore = vstore.VisitorInsightsStore
+_norm_country = vstore._norm_country
 
 
 def _mock_redis(pfcounts=None, members=None):
@@ -278,7 +285,6 @@ async def test_beacon_path_records_both_funnel_and_visitor_insight():
     Confirms the single trigger drives both surfaces with the same visitor id —
     this is the wiring that keeps the two distinct-visitor counts in lockstep.
     """
-    from archimedes.api.metrics_routes import record_funnel_event
     from archimedes.models.telemetry import FunnelEventRequest
 
     funnel_calls: list = []
@@ -288,9 +294,7 @@ async def test_beacon_path_records_both_funnel_and_visitor_insight():
         funnel_calls.append((getattr(request.state, "visitor_id", None), stage))
 
     async def _fake_record_insight(request, is_agent=False):
-        insight_calls.append(getattr(request.state, "visitor_id", None))
-
-    import archimedes.api.metrics_routes as mr
+        insight_calls.append((getattr(request.state, "visitor_id", None), is_agent))
 
     orig_funnel = mr.record_funnel
     orig_insight = mr.record_visitor_insight
@@ -299,20 +303,53 @@ async def test_beacon_path_records_both_funnel_and_visitor_insight():
     try:
         req = _req({"user-agent": "Mozilla/5.0"})
         req.state.visitor_id = "vid-beacon"
-        await record_funnel_event(FunnelEventRequest(stage="landed"), req)
+        # No is_agent on state → the beacon defaults it to False (ordinary human).
+        await mr.record_funnel_event(FunnelEventRequest(stage="landed"), req)
     finally:
         mr.record_funnel = orig_funnel
         mr.record_visitor_insight = orig_insight
 
-    # Same vid drove both surfaces off the single landed beacon.
+    # Same vid drove both surfaces off the single landed beacon; is_agent=False.
     assert funnel_calls == [("vid-beacon", "landed")]
-    assert insight_calls == ["vid-beacon"]
+    assert insight_calls == [("vid-beacon", False)]
+
+
+async def test_beacon_passes_is_agent_through_to_visitor_insight():
+    """The beacon forwards ``request.state.is_agent`` so the agent-skip fires (issue #830 review).
+
+    Copilot flagged that ``record_funnel_event`` dropped the classifier's ``is_agent``
+    verdict, defeating the defense-in-depth skip in ``record_visitor_insight``. This
+    pins that the beacon now passes it through — an agent-classified beacon reaches
+    ``record_visitor_insight`` with ``is_agent=True``.
+    """
+    from archimedes.models.telemetry import FunnelEventRequest
+
+    seen: list = []
+
+    async def _noop_funnel(request, stage):
+        pass
+
+    async def _capture_insight(request, is_agent=False):
+        seen.append(is_agent)
+
+    orig_funnel = mr.record_funnel
+    orig_insight = mr.record_visitor_insight
+    mr.record_funnel = _noop_funnel
+    mr.record_visitor_insight = _capture_insight
+    try:
+        req = _req({"user-agent": "curl/8.0"})
+        req.state.visitor_id = "vid-agent"
+        req.state.is_agent = True  # what the telemetry middleware would have set
+        await mr.record_funnel_event(FunnelEventRequest(stage="landed"), req)
+    finally:
+        mr.record_funnel = orig_funnel
+        mr.record_visitor_insight = orig_insight
+
+    assert seen == [True]
 
 
 async def test_non_landed_beacon_records_neither():
     """A non-emittable stage records nothing (only `landed` is client-emittable)."""
-    import archimedes.api.metrics_routes as mr
-    from archimedes.api.metrics_routes import record_funnel_event
     from archimedes.models.telemetry import FunnelEventRequest
 
     calls = {"n": 0}
@@ -325,7 +362,7 @@ async def test_non_landed_beacon_records_neither():
     mr.record_funnel = _boom
     mr.record_visitor_insight = _boom
     try:
-        out = await record_funnel_event(FunnelEventRequest(stage="wallet_connected"), _req())
+        out = await mr.record_funnel_event(FunnelEventRequest(stage="wallet_connected"), _req())
     finally:
         mr.record_funnel = orig_funnel
         mr.record_visitor_insight = orig_insight
@@ -351,8 +388,6 @@ async def test_browser_ua_no_session_is_recorded_by_the_classifier():
         async def close(self):
             pass
 
-    import archimedes.services.visitor_insights_store as vstore
-
     orig = vstore.VisitorInsightsStore
     vstore.VisitorInsightsStore = FakeStore
     try:
@@ -371,8 +406,6 @@ async def test_browser_ua_no_session_is_recorded_by_the_classifier():
 
 def test_store_docstring_does_not_overclaim_real_visitors():
     """The store docstring must not claim 'real visitors, not datacenter crawler IPs' (#830)."""
-    import archimedes.services.visitor_insights_store as vstore
-
     doc = (vstore.__doc__ or "") + (vstore.VisitorInsightsStore.__doc__ or "")
     assert "real visitors, not datacenter" not in doc
     assert "human-ish" not in doc
@@ -380,7 +413,5 @@ def test_store_docstring_does_not_overclaim_real_visitors():
 
 def test_capture_helper_docstring_does_not_overclaim():
     """The capture helper docstring must not claim it excludes crawlers as 'real visitors' (#830)."""
-    import archimedes.api.visitor_insights as vmod
-
     doc = vmod.__doc__ or ""
     assert "real visitors, not datacenter" not in doc

--- a/backend/tests/test_visitor_insights.py
+++ b/backend/tests/test_visitor_insights.py
@@ -164,3 +164,223 @@ async def test_capture_records_humans(monkeypatch):
     req = _req({"cloudfront-viewer-country": "DE", "cloudfront-is-mobile-viewer": "true"})
     await record_visitor_insight(req, is_agent=False)
     assert recorded["args"] == ("DE", "mobile", "vid-1")
+
+
+# ─── one-source-of-truth reconciliation (issue #830) ──────────────────────
+#
+# The funnel `landed` population and the geo/device population MUST be the same
+# set of distinct visitors, keyed on the same archimedes_vid. A tiny in-memory
+# HLL (distinct-set) Redis lets us drive N synthetic visitors through BOTH stores
+# and assert country-sum == device-sum == funnel `landed`.
+
+
+class _FakeHLLRedis:
+    """Minimal in-memory Redis with HLL semantics (PFADD/PFCOUNT via a set) + SADD.
+
+    Mirrors the boundary the stores use (``pipeline`` → ``pfadd``/``pfcount``/
+    ``sadd``/``expire`` → ``execute``). PFCOUNT is exact here (a set), which is
+    fine for a small deterministic reconciliation test.
+    """
+
+    def __init__(self) -> None:
+        self.hll: dict[str, set[str]] = {}
+        self.sets: dict[str, set[str]] = {}
+
+    def pipeline(self):
+        return _FakePipe(self)
+
+    async def smembers(self, key: str):
+        return set(self.sets.get(key, set()))
+
+
+class _FakePipe:
+    def __init__(self, r: _FakeHLLRedis) -> None:
+        self._r = r
+        self._ops: list = []
+
+    def pfadd(self, key: str, member: str):
+        self._ops.append(("pfadd", key, member))
+        return self
+
+    def pfcount(self, key: str):
+        self._ops.append(("pfcount", key, None))
+        return self
+
+    def sadd(self, key: str, member: str):
+        self._ops.append(("sadd", key, member))
+        return self
+
+    def expire(self, *a, **kw):
+        self._ops.append(("expire", None, None))
+        return self
+
+    async def execute(self):
+        results: list = []
+        for op, key, member in self._ops:
+            if op == "pfadd":
+                self._r.hll.setdefault(key, set()).add(member)
+                results.append(1)
+            elif op == "pfcount":
+                results.append(len(self._r.hll.get(key, set())))
+            elif op == "sadd":
+                self._r.sets.setdefault(key, set()).add(member)
+                results.append(1)
+            else:
+                results.append(True)
+        self._ops = []
+        return results
+
+
+async def test_landed_population_reconciles_funnel_and_geo_device():
+    """N distinct landed visitors → country-sum == device-sum == funnel `landed`.
+
+    Drives the SAME visitor ids through the funnel store (`landed`) and the
+    visitor-insights store (country + device), on a shared HLL Redis, then reads
+    both back. The three distinct counts must agree — that is the invariant the
+    single-source-of-truth reconciliation guarantees (issue #830).
+    """
+    from unittest.mock import AsyncMock
+
+    from archimedes.services.funnel_store import FunnelStore
+
+    shared = _FakeHLLRedis()
+
+    funnel = FunnelStore()
+    funnel._get_redis = AsyncMock(return_value=shared)
+    insights = VisitorInsightsStore()
+    insights._get_redis = AsyncMock(return_value=shared)
+
+    n = 7
+    for i in range(n):
+        vid = f"vid-{i}"
+        # Same trigger (landed), same dedup key (vid), for both surfaces.
+        await funnel.record("landed", vid)
+        # Country cycles US/DE, device cycles mobile/desktop — the SUM across
+        # buckets must still equal the distinct landed population.
+        country = "US" if i % 2 == 0 else "DE"
+        device = "mobile" if i % 3 == 0 else "desktop"
+        await insights.record(country, device, vid)
+
+    landed = (await funnel.get_totals())["landed"]
+    countries, devices = await insights.get_insights()
+    country_sum = sum(countries.values())
+    device_sum = sum(devices.values())
+
+    assert landed == n
+    assert country_sum == n
+    assert device_sum == n
+    assert country_sum == device_sum == landed
+
+
+async def test_beacon_path_records_both_funnel_and_visitor_insight():
+    """The JS-gated `landed` beacon endpoint records funnel AND geo/device (issue #830).
+
+    Confirms the single trigger drives both surfaces with the same visitor id —
+    this is the wiring that keeps the two distinct-visitor counts in lockstep.
+    """
+    from archimedes.api.metrics_routes import record_funnel_event
+    from archimedes.models.telemetry import FunnelEventRequest
+
+    funnel_calls: list = []
+    insight_calls: list = []
+
+    async def _fake_record_funnel(request, stage):
+        funnel_calls.append((getattr(request.state, "visitor_id", None), stage))
+
+    async def _fake_record_insight(request, is_agent=False):
+        insight_calls.append(getattr(request.state, "visitor_id", None))
+
+    import archimedes.api.metrics_routes as mr
+
+    orig_funnel = mr.record_funnel
+    orig_insight = mr.record_visitor_insight
+    mr.record_funnel = _fake_record_funnel
+    mr.record_visitor_insight = _fake_record_insight
+    try:
+        req = _req({"user-agent": "Mozilla/5.0"})
+        req.state.visitor_id = "vid-beacon"
+        await record_funnel_event(FunnelEventRequest(stage="landed"), req)
+    finally:
+        mr.record_funnel = orig_funnel
+        mr.record_visitor_insight = orig_insight
+
+    # Same vid drove both surfaces off the single landed beacon.
+    assert funnel_calls == [("vid-beacon", "landed")]
+    assert insight_calls == ["vid-beacon"]
+
+
+async def test_non_landed_beacon_records_neither():
+    """A non-emittable stage records nothing (only `landed` is client-emittable)."""
+    import archimedes.api.metrics_routes as mr
+    from archimedes.api.metrics_routes import record_funnel_event
+    from archimedes.models.telemetry import FunnelEventRequest
+
+    calls = {"n": 0}
+
+    async def _boom(*a, **kw):
+        calls["n"] += 1
+
+    orig_funnel = mr.record_funnel
+    orig_insight = mr.record_visitor_insight
+    mr.record_funnel = _boom
+    mr.record_visitor_insight = _boom
+    try:
+        out = await record_funnel_event(FunnelEventRequest(stage="wallet_connected"), _req())
+    finally:
+        mr.record_funnel = orig_funnel
+        mr.record_visitor_insight = orig_insight
+
+    assert out == {"recorded": False}
+    assert calls["n"] == 0
+
+
+async def test_browser_ua_no_session_is_recorded_by_the_classifier():
+    """A browser-UA-no-session request (open-demo human) IS recorded (issue #830).
+
+    Pins label-to-behavior: the classifier's open-demo default is `human`, and the
+    beacon path DOES record such a visitor — so the docstring must NOT claim the
+    population is "real visitors, not crawlers". The companion docstring assertion
+    below proves the over-claiming language is gone.
+    """
+    recorded = {}
+
+    class FakeStore:
+        async def record(self, country, device, vid):
+            recorded["args"] = (country, device, vid)
+
+        async def close(self):
+            pass
+
+    import archimedes.services.visitor_insights_store as vstore
+
+    orig = vstore.VisitorInsightsStore
+    vstore.VisitorInsightsStore = FakeStore
+    try:
+        # Browser UA, NO session, NO CloudFront country header → open-demo human,
+        # device via UA fallback. This is exactly the population the old docstring
+        # falsely claimed was excluded.
+        req = _req({"user-agent": "Mozilla/5.0 (Macintosh)"})
+        await record_visitor_insight(req)  # default is_agent=False (beacon call)
+    finally:
+        vstore.VisitorInsightsStore = orig
+
+    # It WAS recorded (country ZZ via missing header, device desktop via UA).
+    assert recorded["args"][2] == "vid-1"
+    assert recorded["args"][1] == "desktop"
+
+
+def test_store_docstring_does_not_overclaim_real_visitors():
+    """The store docstring must not claim 'real visitors, not datacenter crawler IPs' (#830)."""
+    import archimedes.services.visitor_insights_store as vstore
+
+    doc = (vstore.__doc__ or "") + (vstore.VisitorInsightsStore.__doc__ or "")
+    assert "real visitors, not datacenter" not in doc
+    assert "human-ish" not in doc
+
+
+def test_capture_helper_docstring_does_not_overclaim():
+    """The capture helper docstring must not claim it excludes crawlers as 'real visitors' (#830)."""
+    import archimedes.api.visitor_insights as vmod
+
+    doc = vmod.__doc__ or ""
+    assert "real visitors, not datacenter" not in doc

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -124,8 +124,11 @@ export default function App() {
   // Conversion funnel (#787): emit the top-of-funnel "landed" beacon once per
   // browser session. This is JS-only, so crawlers (which dominate raw request
   // counts but don't run JS) are naturally excluded — the funnel is a truer
-  // human signal than the cumulative request counters. Best-effort: a failed
-  // beacon must never affect the page.
+  // human signal than the cumulative request counters. As of #830 this same
+  // beacon is the single source of truth for "distinct visitor": the server
+  // records geography + device off it too (same archimedes_vid dedup key), so
+  // the funnel `landed` count and the geo/device counts agree by construction.
+  // Best-effort: a failed beacon must never affect the page.
   useEffect(() => {
     try {
       if (sessionStorage.getItem('archimedes_landed')) return

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -56,6 +56,7 @@ export default function Insights() {
   const [visitors, setVisitors] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [visitorsError, setVisitorsError] = useState(null)
 
   // SIWE session drives the private (cost/ops) tab. Anonymous viewers only ever
   // see the public dashboard; the internal cards read SIWE-gated endpoints.
@@ -65,19 +66,27 @@ export default function Insights() {
   const load = useCallback(async () => {
     setLoading(true)
     setError(null)
+    setVisitorsError(null)
+    // Core dashboard = metrics + funnel; visitor-insights is loaded independently
+    // so a transient visitors failure (500/network) degrades to a partial render
+    // (the visitors card shows an error/empty state) instead of blanking the whole
+    // dashboard — per-endpoint resilience (#830 review).
     try {
-      // All three are public GET endpoints; visitor-insights is deployed alongside
-      // the funnel now (same JS-gated population, #830), so no not-live branch.
-      const [m, f, v] = await Promise.all([
+      const [m, f] = await Promise.all([
         apiGet('/api/metrics'),
         apiGet('/api/metrics/funnel'),
-        apiGet('/api/metrics/visitors'),
       ])
       setMetrics(m)
       setFunnel(f)
-      setVisitors(v)
     } catch (e) {
       setError(String(e.message || e))
+    }
+    try {
+      const v = await apiGet('/api/metrics/visitors')
+      setVisitors(v)
+    } catch (e) {
+      setVisitors(null)
+      setVisitorsError(String(e.message || e))
     }
     setLoading(false)
   }, [])
@@ -169,8 +178,10 @@ export default function Insights() {
               counts reconcile with the funnel’s <em>Landed</em> number. Country is <code>ZZ</code> until the
               CloudFront <code>terraform apply</code> (#795) forwards <code>Viewer-Country</code>.
             </p>
-            {loading && !visitors ? (
+            {loading && !visitors && !visitorsError ? (
               <Empty>Loading visitor insights…</Empty>
+            ) : visitorsError ? (
+              <Empty>Couldn’t load visitor insights: {visitorsError}</Empty>
             ) : !visitors || ((visitors.countries?.length ?? 0) === 0 && totalDevices === 0) ? (
               <Empty>No visitors recorded yet.</Empty>
             ) : (

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -271,6 +271,7 @@ function InternalDashboard({ session }) {
 function TabButton({ active, onClick, children }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       style={{
         fontSize: 13,

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -1,18 +1,24 @@
 import { useState, useEffect, useCallback } from 'react'
 import { apiGet } from '../api'
+import { checkSession } from '../siwe'
 
-// Insights — the internal metrics dashboard (#787).
+// Insights — the public conversion + traction dashboard (#787, #830).
 //
 // Renders the live conversion instruments as a human-readable dashboard instead
-// of raw JSON:
+// of raw JSON. Everything on the PUBLIC tab is PII-free by design:
 //   - Traction: human vs agent REQUEST counts (honestly labelled — these are
-//     cumulative request tallies, bot-inflated, NOT unique users).
+//     cumulative request tallies, bot-inflated, NOT unique users) + the honest
+//     distinct real-users (wallet) count alongside them.
 //   - Conversion funnel: distinct visitors through landed → generation_started →
 //     wallet_connected → vault_deployed, with step-conversion %.
-//   - Visitor insights: distinct human visitors by country + device (live only
-//     once #795 is merged + the CloudFront TF applied; degrades to an empty state).
+//   - Visitor insights: distinct visitors by country + device, drawn from the
+//     SAME JS-gated `landed` beacon population as the funnel (#830) — geo/device
+//     count agrees with the funnel `landed` count by construction. Geography is
+//     `ZZ` until Dan's CloudFront terraform apply lands (#795).
 //
-// All three are public GET endpoints; this page only reads them.
+// The INTERNAL tab (cost / ops) is SIWE-gated: it only renders the private
+// dashboard when the viewer holds a valid session, and its cards read the
+// SIWE-gated /api/metrics/private/* endpoints (401 when anonymous).
 
 const FUNNEL_LABELS = {
   landed: 'Landed',
@@ -48,39 +54,36 @@ export default function Insights() {
   const [metrics, setMetrics] = useState(null)
   const [funnel, setFunnel] = useState(null)
   const [visitors, setVisitors] = useState(null)
-  const [visitorsLive, setVisitorsLive] = useState(true)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+
+  // SIWE session drives the private (cost/ops) tab. Anonymous viewers only ever
+  // see the public dashboard; the internal cards read SIWE-gated endpoints.
+  const [session, setSession] = useState({ authenticated: false, wallet: null })
+  const [tab, setTab] = useState('public')
 
   const load = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      const [m, f] = await Promise.all([apiGet('/api/metrics'), apiGet('/api/metrics/funnel')])
+      // All three are public GET endpoints; visitor-insights is deployed alongside
+      // the funnel now (same JS-gated population, #830), so no not-live branch.
+      const [m, f, v] = await Promise.all([
+        apiGet('/api/metrics'),
+        apiGet('/api/metrics/funnel'),
+        apiGet('/api/metrics/visitors'),
+      ])
       setMetrics(m)
       setFunnel(f)
+      setVisitors(v)
     } catch (e) {
       setError(String(e.message || e))
-    }
-    // Visitor insights may not be deployed yet (#795) — tolerate ONLY a 404 as
-    // "not live yet"; surface any other failure (500 / network) instead of
-    // masking it as a missing endpoint.
-    try {
-      setVisitors(await apiGet('/api/metrics/visitors'))
-      setVisitorsLive(true)
-    } catch (e) {
-      setVisitors(null)
-      if (e?.status === 404) {
-        setVisitorsLive(false)
-      } else {
-        setVisitorsLive(true)
-        setError(prev => prev || `Visitor insights failed: ${e?.message || e}`)
-      }
     }
     setLoading(false)
   }, [])
 
   useEffect(() => { load() }, [load])
+  useEffect(() => { checkSession().then(setSession).catch(() => {}) }, [])
 
   const landed = funnel?.stages?.find(s => s.stage === 'landed')?.distinct_visitors ?? 0
   const totalDevices = visitors ? Object.values(visitors.devices || {}).reduce((a, b) => a + b, 0) : 0
@@ -95,8 +98,16 @@ export default function Insights() {
         </button>
       </div>
       <p style={{ color: 'var(--text-dim, #8b93a7)', marginTop: 0, fontSize: 14 }}>
-        Live conversion instruments for our (un-promoted) traffic. Read-only.
+        Live conversion instruments for our (un-promoted) traffic. Read-only, PII-free.
       </p>
+
+      {/* Public / Internal tabs — Internal is SIWE-gated. */}
+      <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+        <TabButton active={tab === 'public'} onClick={() => setTab('public')}>Public</TabButton>
+        <TabButton active={tab === 'internal'} onClick={() => setTab('internal')}>
+          Internal {session.authenticated ? '' : '🔒'}
+        </TabButton>
+      </div>
 
       {error && (
         <div style={{ ...card, borderColor: '#a3434a', color: '#ff9aa2', marginBottom: 16 }}>
@@ -104,102 +115,173 @@ export default function Insights() {
         </div>
       )}
 
-      {/* ── Traction ── */}
-      <section style={{ ...card, marginBottom: 16 }}>
-        <h2 style={{ marginTop: 0, fontSize: 16 }}>Traction — requests</h2>
-        <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
-          <Stat label="Human-UA requests" value={metrics?.human_count} />
-          <Stat label="Agent / bot requests" value={metrics?.agent_count} />
-          <Stat label="Total requests" value={metrics?.total_requests} />
-        </div>
-        <p style={{ color: 'var(--text-dim, #8b93a7)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
-          ⚠️ These are <strong>cumulative request counts</strong>, not unique users — and the
-          “human” bucket is inflated by browser-UA bots. The funnel below (distinct visitors,
-          JS-gated so crawlers drop out) is the clean signal.
-        </p>
-      </section>
+      {tab === 'internal' ? (
+        <InternalDashboard session={session} />
+      ) : (
+        <>
+          {/* ── Traction ── */}
+          <section style={{ ...card, marginBottom: 16 }}>
+            <h2 style={{ marginTop: 0, fontSize: 16 }}>Traction — requests &amp; users</h2>
+            <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
+              <Stat label="Human-UA requests" value={metrics?.human_count} />
+              <Stat label="Agent / bot requests" value={metrics?.agent_count} />
+              <Stat label="Total requests" value={metrics?.total_requests} />
+              <Stat label="Real users (wallets)" value={metrics?.real_users} accent="#3fb56b" />
+            </div>
+            <p style={{ color: 'var(--text-dim, #8b93a7)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
+              ⚠️ The request counts are <strong>cumulative request counts</strong>, not unique users — and the
+              “human” bucket is inflated by browser-UA bots. <strong>Real users</strong> is the honest distinct
+              count (wallet rows). The funnel below (distinct visitors, JS-gated so crawlers drop out) is the
+              clean visitor signal.
+            </p>
+          </section>
 
-      {/* ── Conversion funnel ── */}
-      <section style={{ ...card, marginBottom: 16 }}>
-        <h2 style={{ marginTop: 0, fontSize: 16 }}>Conversion funnel — distinct visitors</h2>
-        {!funnel ? (
-          <Empty>Loading…</Empty>
-        ) : landed === 0 ? (
-          <Empty>No visitors recorded yet. The funnel started collecting when it deployed today.</Empty>
-        ) : (
-          <div style={{ display: 'grid', gap: 14 }}>
-            {funnel.stages.map((s, i) => (
-              <div key={s.stage}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, marginBottom: 5 }}>
-                  <span>{FUNNEL_LABELS[s.stage] || s.stage}</span>
-                  <span style={{ color: 'var(--text-dim, #8b93a7)' }}>
-                    <strong style={{ color: 'var(--text, #e6e9f0)' }}>{s.distinct_visitors}</strong>
-                    {i > 0 && <> · {(s.step_conversion * 100).toFixed(0)}% of prev</>}
-                  </span>
-                </div>
-                <Bar pct={s.pct_of_landed * 100} color={i === 0 ? '#5b9dff' : s.distinct_visitors > 0 ? '#3fb56b' : '#3a3f4b'} />
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* ── Visitor insights (geo + device) ── */}
-      <section style={card}>
-        <h2 style={{ marginTop: 0, fontSize: 16 }}>Who’s visiting — geography &amp; device</h2>
-        {!visitorsLive ? (
-          <Empty>
-            Not live yet — merge <strong>#795</strong> and run the CloudFront <code>terraform apply</code> to
-            enable viewer-country capture. (Device works on the UA fallback once #795 deploys.)
-          </Empty>
-        ) : loading && !visitors ? (
-          <Empty>Loading visitor insights…</Empty>
-        ) : !visitors || ((visitors.countries?.length ?? 0) === 0 && totalDevices === 0) ? (
-          <Empty>No human visitors recorded yet.</Empty>
-        ) : (
-          <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 24 }}>
-            <div>
-              <h3 style={{ fontSize: 13, color: 'var(--text-dim,#8b93a7)', margin: '0 0 10px' }}>Top countries</h3>
-              <div style={{ display: 'grid', gap: 10 }}>
-                {(visitors.countries || []).slice(0, 8).map(c => (
-                  <div key={c.code}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
-                      <span>{COUNTRY_NAMES[c.code] || c.code}</span>
-                      <strong>{c.distinct_visitors}</strong>
+          {/* ── Conversion funnel ── */}
+          <section style={{ ...card, marginBottom: 16 }}>
+            <h2 style={{ marginTop: 0, fontSize: 16 }}>Conversion funnel — distinct visitors</h2>
+            {!funnel ? (
+              <Empty>Loading…</Empty>
+            ) : landed === 0 ? (
+              <Empty>No visitors recorded yet. The funnel started collecting when it deployed today.</Empty>
+            ) : (
+              <div style={{ display: 'grid', gap: 14 }}>
+                {funnel.stages.map((s, i) => (
+                  <div key={s.stage}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, marginBottom: 5 }}>
+                      <span>{FUNNEL_LABELS[s.stage] || s.stage}</span>
+                      <span style={{ color: 'var(--text-dim, #8b93a7)' }}>
+                        <strong style={{ color: 'var(--text, #e6e9f0)' }}>{s.distinct_visitors}</strong>
+                        {i > 0 && <> · {(s.step_conversion * 100).toFixed(0)}% of prev</>}
+                      </span>
                     </div>
-                    <Bar pct={maxCountry ? (c.distinct_visitors / maxCountry) * 100 : 0} color="#7c6cff" />
+                    <Bar pct={s.pct_of_landed * 100} color={i === 0 ? '#5b9dff' : s.distinct_visitors > 0 ? '#3fb56b' : '#3a3f4b'} />
                   </div>
                 ))}
               </div>
-            </div>
-            <div>
-              <h3 style={{ fontSize: 13, color: 'var(--text-dim,#8b93a7)', margin: '0 0 10px' }}>Device</h3>
-              <div style={{ display: 'grid', gap: 10 }}>
-                {Object.entries(visitors.devices || {})
-                  .filter(([, n]) => n > 0)
-                  .sort((a, b) => b[1] - a[1])
-                  .map(([dev, n]) => (
-                    <div key={dev}>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
-                        <span>{DEVICE_LABELS[dev] || dev}</span>
-                        <strong>{n}</strong>
+            )}
+          </section>
+
+          {/* ── Visitor insights (geo + device) ── */}
+          <section style={card}>
+            <h2 style={{ marginTop: 0, fontSize: 16 }}>Who’s visiting — geography &amp; device</h2>
+            <p style={{ color: 'var(--text-dim, #8b93a7)', fontSize: 12.5, marginTop: 0, marginBottom: 14 }}>
+              Same JS-gated <strong>landed</strong> population as the funnel (#830) — distinct visitors, so these
+              counts reconcile with the funnel’s <em>Landed</em> number. Country is <code>ZZ</code> until the
+              CloudFront <code>terraform apply</code> (#795) forwards <code>Viewer-Country</code>.
+            </p>
+            {loading && !visitors ? (
+              <Empty>Loading visitor insights…</Empty>
+            ) : !visitors || ((visitors.countries?.length ?? 0) === 0 && totalDevices === 0) ? (
+              <Empty>No visitors recorded yet.</Empty>
+            ) : (
+              <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 24 }}>
+                <div>
+                  <h3 style={{ fontSize: 13, color: 'var(--text-dim,#8b93a7)', margin: '0 0 10px' }}>Top countries</h3>
+                  <div style={{ display: 'grid', gap: 10 }}>
+                    {(visitors.countries || []).slice(0, 8).map(c => (
+                      <div key={c.code}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
+                          <span>{COUNTRY_NAMES[c.code] || c.code}</span>
+                          <strong>{c.distinct_visitors}</strong>
+                        </div>
+                        <Bar pct={maxCountry ? (c.distinct_visitors / maxCountry) * 100 : 0} color="#7c6cff" />
                       </div>
-                      <Bar pct={totalDevices ? (n / totalDevices) * 100 : 0} color="#3fb56b" />
-                    </div>
-                  ))}
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <h3 style={{ fontSize: 13, color: 'var(--text-dim,#8b93a7)', margin: '0 0 10px' }}>Device</h3>
+                  <div style={{ display: 'grid', gap: 10 }}>
+                    {Object.entries(visitors.devices || {})
+                      .filter(([, n]) => n > 0)
+                      .sort((a, b) => b[1] - a[1])
+                      .map(([dev, n]) => (
+                        <div key={dev}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
+                            <span>{DEVICE_LABELS[dev] || dev}</span>
+                            <strong>{n}</strong>
+                          </div>
+                          <Bar pct={totalDevices ? (n / totalDevices) * 100 : 0} color="#3fb56b" />
+                        </div>
+                      ))}
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        )}
-      </section>
+            )}
+          </section>
+        </>
+      )}
     </div>
   )
 }
 
-function Stat({ label, value }) {
+// ── Internal (SIWE-gated) cost/ops dashboard ────────────────────────────────
+
+function InternalDashboard({ session }) {
+  const [cost, setCost] = useState(null)
+  const [err, setErr] = useState(null)
+
+  useEffect(() => {
+    if (!session.authenticated) return
+    apiGet('/api/metrics/private/cost').then(setCost).catch(e => setErr(String(e.message || e)))
+  }, [session.authenticated])
+
+  if (!session.authenticated) {
+    return (
+      <section style={card}>
+        <h2 style={{ marginTop: 0, fontSize: 16 }}>Internal — cost &amp; ops 🔒</h2>
+        <Empty>
+          Sign in with your wallet to view the internal cost / ops dashboard. Bedrock spend, infra
+          cost, and ops health are SIWE-gated — the public tab stays PII- and cost-free by design.
+        </Empty>
+      </section>
+    )
+  }
+
+  return (
+    <section style={card}>
+      <h2 style={{ marginTop: 0, fontSize: 16 }}>Internal — cost &amp; ops</h2>
+      {err && <div style={{ color: '#ff9aa2', fontSize: 13, marginBottom: 12 }}>Couldn’t load: {err}</div>}
+      <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
+        <Stat label="Real users (wallets)" value={cost?.real_users} accent="#3fb56b" />
+        <Stat label="Bedrock / mo (USD)" value={cost?.bedrock_monthly_usd} />
+        <Stat label="Infra / mo (USD)" value={cost?.infra_monthly_usd} />
+        <Stat label="Cost / user (USD)" value={cost?.cost_per_user_usd} />
+      </div>
+      <p style={{ color: 'var(--text-dim, #8b93a7)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
+        {cost?.source === 'draft'
+          ? 'Draft placeholders — live Bedrock/infra billing wiring is roadmap work. Any $/user or $/gen figure is derived from real users (wallets) or generations, never the request tallies (#830).'
+          : 'Per-user / per-generation figures are derived from real users or generations, never the request tallies (#830).'}
+      </p>
+    </section>
+  )
+}
+
+function TabButton({ active, onClick, children }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        fontSize: 13,
+        padding: '6px 14px',
+        borderRadius: 8,
+        cursor: 'pointer',
+        border: '1px solid var(--border, #262a34)',
+        background: active ? 'var(--surface, #14161c)' : 'transparent',
+        color: active ? 'var(--text, #e6e9f0)' : 'var(--text-dim, #8b93a7)',
+        fontWeight: active ? 700 : 400,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function Stat({ label, value, accent }) {
+  const display = value == null ? '—' : (typeof value === 'number' ? value.toLocaleString() : value)
   return (
     <div>
-      <div style={{ fontSize: 26, fontWeight: 700 }}>{value == null ? '—' : value.toLocaleString()}</div>
+      <div style={{ fontSize: 26, fontWeight: 700, color: accent || 'var(--text, #e6e9f0)' }}>{display}</div>
       <div style={{ fontSize: 12.5, color: 'var(--text-dim, #8b93a7)' }}>{label}</div>
     </div>
   )


### PR DESCRIPTION
## Summary

Makes the Insights dashboard **coherent and honest** and adds a clean **public-vs-private split**. This is a **claim-integrity** change (repo #1 rule): the defects were labels, reconciliation, and the missing auth split — the code paths behaved as documented. No classifier or counter-semantics rewrite.

Closes #830.

## What changed, per area

### 1. One source of truth for distinct visitors = the JS-gated `landed` population
Reconciles the funnel `landed`=17 vs visitors=50 discrepancy to a single number.
- `api/visitor_insights.py` — `record_visitor_insight` now fires on the **JS-gated `landed` beacon path**, not on every server-side human-classified request (which leaked browser-UA bots through the open-demo default). Same `archimedes_vid` dedup key.
- `api/telemetry_middleware.py` — removed the every-request `record_visitor_insight` call (middleware ordering unchanged; `ensure_visitor_id` stays outermost).
- `api/metrics_routes.py` — `record_funnel_event` (the `landed` beacon) now records funnel **and** geo/device off the one trigger → geo/device count == funnel `landed` by construction.
- `services/visitor_insights_store.py` — fixed the over-claiming docstrings (`:5` "distinct human-ish visitors", `:17` "real visitors, not datacenter crawler IPs") to honest language.
- `ui/src/components/Insights.jsx` — relabeled "Who's visiting" to the honest funnel population; surfaced a distinct **real-users (wallet)** stat; fixed the stale `:4` "internal metrics dashboard" label; removed the dead 404 branch (`:73-78`); preserved the already-honest request-count captions.
- `ui/src/App.jsx` — beacon comment now notes it is the single distinct-visitor source.

### 2. Public/private SIWE split (reuses the existing SIWE gate — no new auth)
- New `api/metrics_private_routes.py` exposing `/api/metrics/private/*` (incl. `/cost`) with `Depends(require_verified_wallet)` copied from the `user_routes.py` PII-gate pattern → anonymous = **401**. Mounted in `main.py`.
- Public `metrics_router` (`/api/metrics`, `/funnel`, `/visitors`) **unchanged** in exposure (PII-free by design — diagnosis #5).
- `Insights.jsx` gained a SIWE-gated **Internal** tab (cost/ops cards render only with a live session; the internal cards read the SIWE-gated endpoint). Implemented in-page rather than touching `Layout.jsx` — see judgment calls.

### 3. Cumulative-counter labeling (semantics unchanged)
- `services/telemetry_store.py` INCR-per-request **untouched**.
- Optional hardening: `telemetry_middleware.py` now excludes `/health`, `/api/metrics`, and `OPTIONS` from the increment so the dashboard stops counting its own polling (classification + `X-Telemetry-Agent` tagging still happen for every request; only the INCR is skipped).
- New honest distinct-user field `real_users` (= wallet rows in `user_profiles`) on `/api/metrics` and `/health` via new `services/user_stats.py` (fail-safe, returns 0 on any DB error).

### 4. Draft-artifact relabeling
The Lepton artifacts live in the **separate `a-apin/docs` repo**, not the archimedes tree — already relabeled there on branch `dbrowneup/relabel-traffic-not-users` (commit "Relabel '143 users' as site traffic"). Not duplicated here. See flags.

## Acceptance (hermetic/local equivalents run now)

- `pytest backend/tests/test_visitor_insights.py backend/tests/test_telemetry_classifier.py -q` → **34 passed, 0 failed**.
- `grep -n "real visitors, not datacenter" backend/archimedes/services/visitor_insights_store.py` → **no match** ✅.
- `grep -n "INCR\|incr" backend/archimedes/services/telemetry_store.py` → **still present** ✅ (semantics unchanged).
- `grep -rn "users" ui/src/components/Insights.jsx` → only the **Real users (wallets)** stat + honest "not unique users" captions; never the request counters ✅.
- Private-endpoint test: anon `GET /api/metrics/private/cost` → **401**; valid SIWE session (via `_siwe_cookies`) → **200** ✅ (verified via TestClient, not live curl).
- `ruff format --check` + `ruff check --select E9,F63,F7,F40` + broad `ruff check` on all touched Python → **all pass** ✅.
- Live-`curl https://archimedes-arc.com/...` acceptance criteria are **post-merge** (require deploy).

## Cross-lane flag — geography (Dan's infra/security lane)

**Geography fix is Dan's `terraform apply`** on CloudFront dist **E34KG22GWPO075** — push the merged `cloudfront.tf` `CloudFront-Viewer-Country` header allowlist onto the live `archimedes-all-viewer` policy, then invalidate. **NOT done in this PR** (security-relevant edge config). Pre-apply, `/api/metrics/visitors` stays `ZZ`, which is expected and handled honestly.

## Anti-goals honored
No fabricated numbers · public aggregates NOT auth'd · funnel/telemetry intact (INCR #428, `archimedes_vid` cookie, HLL keys, middleware ordering) · classifier not "fixed" · `Insights.jsx:109-119` captions preserved · hermetic tests, no `@pytest.mark.skip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
