### PR TITLE
[strategy] Real multi-asset market data for fusion/DSL backtests — the deployability unlock !minor

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -365,10 +365,15 @@ async def _critic_rigor(pool: list[Any], num_trials: int) -> list[tuple[Any, Any
     cohort.
     """
     from archimedes.services.fusion_evaluator import evaluate_fusion_spec
+    from archimedes.services.fusion_market_data import real_data_enabled
+
+    # Real data per candidate (#788/#818): the fetch is cached per ticker-set,
+    # so a pool sharing a universe costs one yfinance round-trip, not N.
+    _use_real = real_data_enabled()
 
     def _backtest(proposal: Any) -> Any:
         try:
-            return evaluate_fusion_spec(proposal.strategy_spec, num_trials=num_trials)
+            return evaluate_fusion_spec(proposal.strategy_spec, num_trials=num_trials, use_real_data=_use_real)
         except Exception as exc:
             logger.info("debate C-rigor: dropped a candidate on backtest error: %s", exc)
             return None

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -881,10 +881,14 @@ async def _run_fusion_candidate(
             args_summary="backtest + DSR/PBO/OOS rigor gate",
         )
         from archimedes.services.fusion_evaluator import evaluate_fusion_spec
+        from archimedes.services.fusion_market_data import real_data_enabled
 
+        # Real data (the deployability unlock, #788/#818): a cold yfinance fetch
+        # for the spec's universe plus the per-asset variant grid can take a few
+        # minutes — 300s bounds it; the panel cache makes warm runs fast again.
         eval_result = await asyncio.wait_for(
-            asyncio.to_thread(evaluate_fusion_spec, proposal.strategy_spec),
-            timeout=120.0,
+            asyncio.to_thread(evaluate_fusion_spec, proposal.strategy_spec, use_real_data=real_data_enabled()),
+            timeout=300.0,
         )
         asset_universe = list(proposal.strategy_spec.get("asset_universe", []) or [])
         if eval_result.success and eval_result.rigor is not None:

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1480,8 +1480,11 @@ async def _run_fusion_job(job_id: str) -> None:
         if result.strategy_spec is not None:
             try:
                 from archimedes.services.fusion_evaluator import evaluate_fusion_spec
+                from archimedes.services.fusion_market_data import real_data_enabled
 
-                eval_result = await asyncio.to_thread(evaluate_fusion_spec, result.strategy_spec)
+                eval_result = await asyncio.to_thread(
+                    evaluate_fusion_spec, result.strategy_spec, use_real_data=real_data_enabled()
+                )
             except Exception as _eval_exc:
                 import logging as _logging
 

--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -145,9 +145,16 @@ _DEFAULT_TX_BPS = 10
 _SYNTHETIC_SOURCE = "synthetic"
 
 
-def _data_source_label(data_feed: Any, data_csv_path: str | Path | None) -> str:
+def _data_source_label(
+    data_feed: Any,
+    data_csv_path: str | Path | None,
+    data_feed_factory: Any = None,
+    label_override: str | None = None,
+) -> str:
     """Honest provenance label for the price series a backtest ran on."""
-    if data_feed is not None:
+    if label_override is not None:
+        return label_override
+    if data_feed is not None or data_feed_factory is not None:
         return "provided"
     if data_csv_path is not None:
         return f"csv:{Path(data_csv_path).name}"
@@ -167,14 +174,19 @@ def run_dsl_backtest(
     spec: StrategySpec,
     *,
     data_feed: Any = None,
+    data_feed_factory: Any = None,
+    data_source_label: str | None = None,
     data_csv_path: str | Path | None = None,
     initial_cash: float = _DEFAULT_CASH,
     tx_cost_bps: int = _DEFAULT_TX_BPS,
 ) -> BacktestMetrics:
     """Run a backtest for a DSL-interpreted strategy.
 
-    If ``data_feed`` is None and ``data_csv_path`` is set, builds a
-    ``GenericCSVData`` feed from the CSV. If both are None, generates a
+    ``data_feed_factory`` (preferred for real data) is a zero-arg callable
+    returning a FRESH feed — a concrete backtrader feed is consumed by a single
+    ``cerebro.run()``, so anything that re-runs (the variant grid) must build a
+    new feed per run. If ``data_feed`` is None and ``data_csv_path`` is set,
+    builds a ``GenericCSVData`` feed from the CSV. If all are None, generates a
     deterministic synthetic price series. The equity curve is captured
     **bar-by-bar** via a backtrader analyzer.
     """
@@ -184,7 +196,7 @@ def run_dsl_backtest(
     cerebro = bt.Cerebro(stdstats=False)
     cerebro.addstrategy(strategy_cls)
 
-    data_source = _data_source_label(data_feed, data_csv_path)
+    data_source = _data_source_label(data_feed, data_csv_path, data_feed_factory, data_source_label)
     if data_source == _SYNTHETIC_SOURCE:
         logger.warning(
             "run_dsl_backtest[%s] is using SYNTHETIC price data — rigor metrics "
@@ -193,6 +205,8 @@ def run_dsl_backtest(
             spec.name,
         )
 
+    if data_feed is None and data_feed_factory is not None:
+        data_feed = data_feed_factory()
     if data_feed is None:
         data_feed = _csv_data_feed(Path(data_csv_path)) if data_csv_path is not None else _synthetic_data()
 
@@ -274,6 +288,8 @@ def run_dsl_backtest_variants(
     spec: StrategySpec,
     *,
     data_feed: Any = None,
+    data_feed_factory: Any = None,
+    data_source_label: str | None = None,
     data_csv_path: str | Path | None = None,
     initial_cash: float = _DEFAULT_CASH,
     tx_cost_bps: int = _DEFAULT_TX_BPS,
@@ -283,6 +299,8 @@ def run_dsl_backtest_variants(
     If ``spec.parameter_variants`` is ``None`` or empty, returns a
     single-entry dict ``{"base": metrics}`` for the unmodified spec.
     Otherwise expands the variant grid and runs one backtest per combination.
+    Prefer ``data_feed_factory`` over ``data_feed`` when running a real grid:
+    a concrete feed object is consumed by the first run.
 
     Returns:
         ``{variant_id: BacktestMetrics}`` where variant_id is a
@@ -292,6 +310,8 @@ def run_dsl_backtest_variants(
         metrics = run_dsl_backtest(
             spec,
             data_feed=data_feed,
+            data_feed_factory=data_feed_factory,
+            data_source_label=data_source_label,
             data_csv_path=data_csv_path,
             initial_cash=initial_cash,
             tx_cost_bps=tx_cost_bps,
@@ -318,6 +338,8 @@ def run_dsl_backtest_variants(
         variant_metrics = _run_variant_backtest(
             strategy_cls,
             data_feed=data_feed,
+            data_feed_factory=data_feed_factory,
+            data_source_label=data_source_label,
             data_csv_path=data_csv_path,
             initial_cash=initial_cash,
             tx_cost_bps=tx_cost_bps,
@@ -331,6 +353,8 @@ def _run_variant_backtest(
     strategy_cls: Any,
     *,
     data_feed: Any = None,
+    data_feed_factory: Any = None,
+    data_source_label: str | None = None,
     data_csv_path: str | Path | None = None,
     initial_cash: float = _DEFAULT_CASH,
     tx_cost_bps: int = _DEFAULT_TX_BPS,
@@ -338,10 +362,12 @@ def _run_variant_backtest(
     """Run a single variant backtest given an already-interpreted strategy class."""
     import backtrader as bt
 
-    data_source = _data_source_label(data_feed, data_csv_path)
+    data_source = _data_source_label(data_feed, data_csv_path, data_feed_factory, data_source_label)
     cerebro = bt.Cerebro(stdstats=False)
     cerebro.addstrategy(strategy_cls)
 
+    if data_feed is None and data_feed_factory is not None:
+        data_feed = data_feed_factory()
     if data_feed is None:
         data_feed = _csv_data_feed(Path(data_csv_path)) if data_csv_path is not None else _synthetic_data()
 
@@ -413,6 +439,155 @@ def _run_variant_backtest(
         backtest_end=date(2026, 4, 30) if data_csv_path is None else None,
         data_source=data_source,
     )
+
+
+# ── Multi-asset portfolio runner (real data, #788/#818) ──────────────
+#
+# The DSL engine is single-feed by construction (the interpreted strategy only
+# reads ``self.data``), so a multi-asset spec is evaluated honestly by applying
+# the SAME rules to EACH asset over an inner-joined real panel (identical dates
+# per sleeve) with equal cash per sleeve, then judging the SUMMED sleeve equity
+# as the portfolio. No cross-sleeve rebalancing is simulated — the aggregate is
+# a buy-the-sleeves portfolio, which matches the DSL's per-asset semantics.
+
+
+def _aggregate_portfolio_metrics(
+    per_asset: dict[str, BacktestMetrics],
+    *,
+    label: str,
+    backtest_start: date | None,
+    backtest_end: date | None,
+) -> BacktestMetrics:
+    """Combine per-asset sleeve backtests into portfolio-level metrics."""
+    curves = [m.equity_curve for m in per_asset.values()]
+    n_bars = min(len(c) for c in curves)
+    if any(len(c) != n_bars for c in curves):
+        # Sleeves run on an inner-joined panel, so equal lengths are expected;
+        # a mismatch means a feed dropped bars — truncate and say so.
+        logger.warning(
+            "portfolio sleeves have unequal bar counts %s — truncating to %d",
+            [len(c) for c in curves],
+            n_bars,
+        )
+    portfolio_curve = [sum(c[i] for c in curves) for i in range(n_bars)]
+
+    daily_returns = [
+        (portfolio_curve[i] - portfolio_curve[i - 1]) / portfolio_curve[i - 1]
+        for i in range(1, len(portfolio_curve))
+        if portfolio_curve[i - 1] > 0
+    ]
+    initial = portfolio_curve[0] if portfolio_curve else 0.0
+    final = portfolio_curve[-1] if portfolio_curve else 0.0
+    total_return = (final - initial) / initial if initial > 0 else 0.0
+    years = max(n_bars / 252, 0.01)
+    cagr = (1 + total_return) ** (1 / years) - 1 if total_return > -1 else -1.0
+
+    # Same rf-convention split as the single-feed runner (display rf=0).
+    sharpe = _annualized_sharpe(daily_returns, rf_annual=0.0)
+    sortino = _annualized_sortino(daily_returns, rf_annual=0.0)
+    max_dd = _max_drawdown(portfolio_curve)
+    calmar = cagr / max_dd if max_dd > 0 else 0.0
+
+    total_trades = sum(m.total_trades for m in per_asset.values())
+    if total_trades > 0:
+        win_rate = sum(m.win_rate * m.total_trades for m in per_asset.values()) / total_trades
+        avg_holding = sum(m.avg_holding_period_days * m.total_trades for m in per_asset.values()) / total_trades
+    else:
+        win_rate = 0.0
+        avg_holding = 0.0
+
+    return BacktestMetrics(
+        sharpe_ratio=round(sharpe, 4),
+        sortino_ratio=round(sortino, 4),
+        max_drawdown=round(max_dd, 4),
+        cagr=round(cagr, 4),
+        calmar_ratio=round(calmar, 4),
+        win_rate=round(win_rate, 4),
+        total_trades=total_trades,
+        avg_holding_period_days=round(avg_holding, 2),
+        equity_curve=[round(e, 2) for e in portfolio_curve],
+        monthly_returns=[round(m, 4) for m in _compute_monthly_returns(portfolio_curve)],
+        backtest_start=backtest_start,
+        backtest_end=backtest_end,
+        data_source=label,
+    )
+
+
+def run_dsl_backtest_portfolio(
+    spec: StrategySpec,
+    feed_factories: dict[str, Any],
+    *,
+    label: str,
+    backtest_start: date | None = None,
+    backtest_end: date | None = None,
+    initial_cash: float = _DEFAULT_CASH,
+    tx_cost_bps: int = _DEFAULT_TX_BPS,
+) -> BacktestMetrics:
+    """Backtest a DSL spec per asset over real feeds and aggregate the sleeves."""
+    per_asset: dict[str, BacktestMetrics] = {}
+    sleeve_cash = initial_cash / max(1, len(feed_factories))
+    for sym, factory in feed_factories.items():
+        per_asset[sym] = run_dsl_backtest(
+            spec,
+            data_feed_factory=factory,
+            data_source_label=label,
+            initial_cash=sleeve_cash,
+            tx_cost_bps=tx_cost_bps,
+        )
+    return _aggregate_portfolio_metrics(
+        per_asset, label=label, backtest_start=backtest_start, backtest_end=backtest_end
+    )
+
+
+def run_dsl_backtest_portfolio_variants(
+    spec: StrategySpec,
+    feed_factories: dict[str, Any],
+    *,
+    label: str,
+    backtest_start: date | None = None,
+    backtest_end: date | None = None,
+    initial_cash: float = _DEFAULT_CASH,
+    tx_cost_bps: int = _DEFAULT_TX_BPS,
+) -> dict[str, BacktestMetrics]:
+    """Variant grid over real multi-asset feeds — one aggregated portfolio per combo."""
+    if spec.parameter_variants is None or not spec.parameter_variants:
+        return {
+            "base": run_dsl_backtest_portfolio(
+                spec,
+                feed_factories,
+                label=label,
+                backtest_start=backtest_start,
+                backtest_end=backtest_end,
+                initial_cash=initial_cash,
+                tx_cost_bps=tx_cost_bps,
+            )
+        }
+
+    import itertools
+
+    variant_keys = sorted(spec.parameter_variants.keys())
+    variant_value_lists = [spec.parameter_variants[k] for k in variant_keys]
+    sleeve_cash = initial_cash / max(1, len(feed_factories))
+
+    results: dict[str, BacktestMetrics] = {}
+    for combo in itertools.product(*variant_value_lists):
+        overrides = {k: int(v) for k, v in zip(variant_keys, combo, strict=False)}
+        variant_id = "_".join(str(v) for v in combo)
+        strategy_cls = interpret_variant(spec, overrides)
+        per_asset = {
+            sym: _run_variant_backtest(
+                strategy_cls,
+                data_feed_factory=factory,
+                data_source_label=label,
+                initial_cash=sleeve_cash,
+                tx_cost_bps=tx_cost_bps,
+            )
+            for sym, factory in feed_factories.items()
+        }
+        results[variant_id] = _aggregate_portfolio_metrics(
+            per_asset, label=label, backtest_start=backtest_start, backtest_end=backtest_end
+        )
+    return results
 
 
 # ── Rigor gate ────────────────────────────────────────────────────────
@@ -580,11 +755,20 @@ def evaluate_fusion_spec(
     *,
     data_feed: Any = None,
     num_trials: int | None = None,
+    use_real_data: bool = False,
 ) -> FusionEvalResult:
     """Full pipeline: validate → interpret → backtest → rigor gate.
 
     ``num_trials=None`` (the default) defers to ``apply_rigor_gate``'s own
     fallback (the curated library size) — see ``_default_num_trials``.
+
+    ``use_real_data=True`` (the live generate/debate paths) fetches real daily
+    OHLCV for the spec's asset universe via ``fusion_market_data`` and runs the
+    multi-asset portfolio backtest — the only route to an ``admissible``
+    verdict. It fails CLOSED: if nothing in the universe maps to the SSOT or
+    the fetch/join comes up short, the run falls back to the synthetic path,
+    which stays honestly inadmissible ("pending" at the live gate) — never a
+    fake pass. Default False keeps unit tests hermetic (no network).
     """
     try:
         spec = validate_strategy_spec(spec_dict)
@@ -597,8 +781,36 @@ def evaluate_fusion_spec(
             error=str(e),
         )
 
+    real_factories: dict[str, Any] | None = None
+    real_label = ""
+    real_start: date | None = None
+    real_end: date | None = None
+    if use_real_data and data_feed is None:
+        from archimedes.services import fusion_market_data
+
+        panel = fusion_market_data.fetch_real_panel(spec.asset_universe)
+        if panel is not None:
+            real_factories = {sym: fusion_market_data.feed_factory(df) for sym, df in panel.frames.items()}
+            real_label, real_start, real_end = panel.label, panel.start, panel.end
+        else:
+            logger.warning(
+                "fusion eval[%s]: real data unavailable for universe %s — "
+                "falling back to SYNTHETIC (verdict will be inadmissible)",
+                spec.name,
+                spec.asset_universe,
+            )
+
     try:
-        metrics = run_dsl_backtest(spec, data_feed=data_feed)
+        if real_factories:
+            metrics = run_dsl_backtest_portfolio(
+                spec,
+                real_factories,
+                label=real_label,
+                backtest_start=real_start,
+                backtest_end=real_end,
+            )
+        else:
+            metrics = run_dsl_backtest(spec, data_feed=data_feed)
     except Exception as e:
         logger.exception("DSL backtest failed for %s", spec.name)
         return FusionEvalResult(spec=spec, backtest=None, rigor=None, error=str(e))
@@ -607,7 +819,16 @@ def evaluate_fusion_spec(
     variants_metrics: dict[str, BacktestMetrics] | None = None
     if spec.parameter_variants is not None and len(spec.parameter_variants) >= 1:
         try:
-            variants_metrics = run_dsl_backtest_variants(spec, data_feed=data_feed)
+            if real_factories:
+                variants_metrics = run_dsl_backtest_portfolio_variants(
+                    spec,
+                    real_factories,
+                    label=real_label,
+                    backtest_start=real_start,
+                    backtest_end=real_end,
+                )
+            else:
+                variants_metrics = run_dsl_backtest_variants(spec, data_feed=data_feed)
         except Exception as e:
             logger.warning("variant backtest failed for %s: %s", spec.name, e)
             variants_metrics = None

--- a/backend/archimedes/services/fusion_market_data.py
+++ b/backend/archimedes/services/fusion_market_data.py
@@ -1,0 +1,231 @@
+"""Real market data for fusion/DSL backtests — the #788/#818 deployability unlock.
+
+``evaluate_fusion_spec`` historically ran on synthetic random-walk prices unless
+a caller passed ``data_feed`` — and no caller ever did, so every fusion/debate
+candidate carried ``data_source="synthetic"``, was inadmissible by design, and
+the live rigor gate honestly read "pending" forever. This module is the missing
+supplier:
+
+- resolves a spec's ``asset_universe`` to yfinance tickers via the
+  Chainlink-only universe SSOT (``GLOBAL_ASSETS``, PR #842),
+- fetches real daily OHLCV through the analytics-engine's ``fetch_ohlcv``
+  (the single owner of the fetch+normalize contract — same reuse rationale as
+  ``portfolio_backtester``),
+- strictly inner-joins the panel across assets (missing data is a lookahead /
+  survivorship vector — same rule as ``portfolio_backtester._fetch_price_panel``),
+- hands back per-asset **feed factories**: a backtrader feed object is consumed
+  by a single ``cerebro.run()``, so the variant grid needs a *fresh* feed per
+  run — sharing one concrete feed silently corrupts every run after the first.
+
+Fail-closed: any resolution/fetch problem returns ``None`` and the caller falls
+back to the synthetic path, which stays honestly inadmissible ("pending") —
+never a fake pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Full-history start mirrors the curated backtests (Faber et al. run 2004→now,
+# ~5,600 daily bars) so fusion strategies are graded on the same evidence depth.
+_DEFAULT_START = "2004-01-02"
+
+# Rigor needs enough bars for the walk-forward OOS split + indicator warmup
+# (e.g. sma_200 consumes 200 bars before the first signal). 252 = one trading
+# year, well above live_rigor_gate's floor; mixed universes with young assets
+# (crypto listed ~2017+) shrink the inner-join and can legitimately fail this.
+_MIN_BARS = 252
+
+# Cap the per-spec asset fan-out: each asset is one yfinance fetch + one
+# backtest per variant combo. Deeper universes get truncated LOUDLY (logged +
+# visible in the provenance label), never silently.
+_MAX_ASSETS = 6
+
+_CACHE_TTL_S = 6 * 3600.0
+_panel_cache: dict[tuple, tuple[float, dict[str, Any]]] = {}
+_cache_lock = threading.Lock()
+
+
+def real_data_enabled() -> bool:
+    """Whether fusion backtests should fetch real market data.
+
+    Off under pytest (``TESTING`` — hermetic tests must never hit the network)
+    and via the ``ARCHIMEDES_FUSION_REAL_DATA=0`` kill switch; on otherwise.
+    """
+    if os.getenv("TESTING"):
+        return False
+    return os.getenv("ARCHIMEDES_FUSION_REAL_DATA", "1").strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _ensure_analytics_import() -> None:
+    """Place ``analytics-engine/src`` on sys.path so its ``data`` module imports.
+
+    Mirrors ``portfolio_backtester._ensure_analytics_import`` — one function
+    (``fetch_ohlcv``) owns the yfinance fetch+normalize contract repo-wide.
+    """
+    analytics_src = Path(__file__).resolve().parents[3] / "analytics-engine" / "src"
+    if str(analytics_src) not in sys.path:
+        sys.path.insert(0, str(analytics_src))
+
+
+def _fetch_one(yf_ticker: str, start: str, end: str) -> Any:
+    """Fetch one symbol's normalized OHLCV DataFrame. Test seam — monkeypatch me."""
+    _ensure_analytics_import()
+    from archimedes_analytics_engine.data import fetch_ohlcv
+
+    return fetch_ohlcv(yf_ticker, start, end)
+
+
+def resolve_universe(asset_universe: list[str]) -> dict[str, str]:
+    """Map spec asset symbols → yfinance tickers via the universe SSOT.
+
+    Accepts any of the shapes LLM output actually produces: the synth key
+    (``sSPY``), the display name (``SPY``, ``AAVE``), or the yfinance ticker
+    itself (``AAVE-USD``). Unmappable symbols are skipped with a warning —
+    the universe SSOT is the boundary; we never backtest arbitrary tickers.
+    """
+    from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
+
+    display_index = {display.upper(): yf for yf, display, _cls, _exch in GLOBAL_ASSETS.values()}
+    yf_index = {yf.upper(): yf for yf, _d, _c, _e in GLOBAL_ASSETS.values()}
+
+    resolved: dict[str, str] = {}
+    for raw in asset_universe:
+        sym = str(raw).strip()
+        if not sym:
+            continue
+        entry = GLOBAL_ASSETS.get(sym) or GLOBAL_ASSETS.get(f"s{sym}")
+        if entry is not None:
+            resolved[sym] = entry[0]
+            continue
+        yf_ticker = display_index.get(sym.upper()) or yf_index.get(sym.upper())
+        if yf_ticker is not None:
+            resolved[sym] = yf_ticker
+            continue
+        logger.warning("fusion real-data: %r is outside the universe SSOT — skipping", sym)
+
+    if len(resolved) > _MAX_ASSETS:
+        dropped = list(resolved)[_MAX_ASSETS:]
+        logger.warning(
+            "fusion real-data: universe capped at %d assets — dropped %s",
+            _MAX_ASSETS,
+            dropped,
+        )
+        resolved = dict(list(resolved.items())[:_MAX_ASSETS])
+    return resolved
+
+
+@dataclass(frozen=True)
+class RealPanel:
+    """Inner-joined real OHLCV frames for a spec's (mappable) asset universe."""
+
+    frames: dict[str, Any]  # spec symbol -> pd.DataFrame (aligned on a common date index)
+    label: str  # provenance, e.g. "yfinance:SPY,AAVE-USD"
+    start: date
+    end: date
+    n_bars: int
+
+
+def fetch_real_panel(
+    asset_universe: list[str],
+    *,
+    start: str = _DEFAULT_START,
+    end: str | None = None,
+    min_bars: int = _MIN_BARS,
+) -> RealPanel | None:
+    """Fetch + inner-join real daily OHLCV for the mappable subset of a universe.
+
+    Returns ``None`` (caller falls back to synthetic → honest "pending") when
+    nothing maps, a fetch fails, or the joined history is too short. Results
+    are cached per ticker-set for ``_CACHE_TTL_S`` so a debate pool / variant
+    sweep doesn't re-hit yfinance.
+    """
+    resolved = resolve_universe(list(asset_universe or []))
+    if not resolved:
+        logger.warning("fusion real-data: no asset in %s maps to the universe SSOT", asset_universe)
+        return None
+
+    end = end or date.today().isoformat()
+    cache_key = (tuple(sorted(resolved.values())), start, end)
+    fetched: dict[str, Any] | None = None
+    with _cache_lock:
+        hit = _panel_cache.get(cache_key)
+        if hit is not None and (time.monotonic() - hit[0]) < _CACHE_TTL_S:
+            fetched = hit[1]
+
+    if fetched is None:
+        fetched = {}
+        for sym, yf_ticker in resolved.items():
+            try:
+                fetched[yf_ticker] = _fetch_one(yf_ticker, start, end)
+            except Exception as exc:
+                # One dead ticker shrinks the panel rather than killing it; if
+                # everything dies we return None below.
+                logger.warning("fusion real-data: fetch failed for %s (%s): %s", sym, yf_ticker, exc)
+        if not fetched:
+            return None
+        with _cache_lock:
+            _panel_cache[cache_key] = (time.monotonic(), fetched)
+
+    frames = {sym: fetched[yf] for sym, yf in resolved.items() if yf in fetched}
+    panel = _panel_from_frames(frames, resolved)
+    if panel is None:
+        return None
+    if panel.n_bars < min_bars:
+        logger.warning(
+            "fusion real-data: only %d overlapping bars across %s (min %d) — refusing",
+            panel.n_bars,
+            list(frames),
+            min_bars,
+        )
+        return None
+    return panel
+
+
+def _panel_from_frames(frames: dict[str, Any], resolved: dict[str, str]) -> RealPanel | None:
+    """Strictly inner-join frames on their date index (anti-lookahead join)."""
+    if not frames:
+        return None
+    common = None
+    for df in frames.values():
+        common = df.index if common is None else common.intersection(df.index)
+    if common is None or len(common) == 0:
+        return None
+    aligned = {sym: df.loc[common] for sym, df in frames.items()}
+    label = "yfinance:" + ",".join(resolved[sym] for sym in aligned)
+    return RealPanel(
+        frames=aligned,
+        label=label,
+        start=common.min().date(),
+        end=common.max().date(),
+        n_bars=len(common),
+    )
+
+
+def feed_factory(df: Any) -> Callable[[], Any]:
+    """Return a zero-arg factory producing a FRESH backtrader feed per call.
+
+    A ``bt.feeds.PandasData`` instance is stateful and consumed by a single
+    ``cerebro.run()``; reusing one across the base run + every variant run
+    silently yields empty/corrupt backtests. The factory closes over an
+    immutable lowercase-column copy and builds a new feed each call.
+    """
+    prepared = df.rename(columns=str.lower)
+
+    def _make() -> Any:
+        import backtrader as bt
+
+        return bt.feeds.PandasData(dataname=prepared, openinterest=None)
+
+    return _make

--- a/backend/archimedes/services/fusion_market_data.py
+++ b/backend/archimedes/services/fusion_market_data.py
@@ -129,6 +129,19 @@ def resolve_universe(asset_universe: list[str]) -> dict[str, str]:
             continue
         logger.warning("fusion real-data: %r is outside the universe SSOT — skipping", sym)
 
+    # Dedupe by yfinance ticker: an LLM can emit the same asset in two forms
+    # ("AAVE" + "AAVE-USD"), which would double-fetch and — worse — double the
+    # sleeve in the portfolio backtest, silently reweighting it. First form wins.
+    seen_yf: set[str] = set()
+    deduped: dict[str, str] = {}
+    for sym, yf_ticker in resolved.items():
+        if yf_ticker in seen_yf:
+            logger.warning("fusion real-data: %r duplicates %s — dropping the duplicate form", sym, yf_ticker)
+            continue
+        seen_yf.add(yf_ticker)
+        deduped[sym] = yf_ticker
+    resolved = deduped
+
     if len(resolved) > _MAX_ASSETS:
         dropped = list(resolved)[_MAX_ASSETS:]
         logger.warning(
@@ -184,13 +197,24 @@ def fetch_real_panel(
             try:
                 fetched[yf_ticker] = _fetch_one(yf_ticker, start, end)
             except Exception as exc:
-                # One dead ticker shrinks the panel rather than killing it; if
-                # everything dies we return None below.
-                logger.warning("fusion real-data: fetch failed for %s (%s): %s", sym, yf_ticker, exc)
-        if not fetched:
-            return None
+                # Fail CLOSED on ANY mapped-ticker failure: a shrunken panel is a
+                # DIFFERENT universe than the spec requested, and grading it as if
+                # complete would attach an admissible verdict to a strategy that
+                # was never actually backtested as specified.
+                logger.warning(
+                    "fusion real-data: fetch failed for %s (%s): %s — failing closed to synthetic",
+                    sym,
+                    yf_ticker,
+                    exc,
+                )
+                return None
+        now = time.monotonic()
         with _cache_lock:
-            _panel_cache[cache_key] = (time.monotonic(), fetched)
+            # Opportunistic pruning: the key includes `end` (changes daily), so
+            # without this the cache grows without bound in a long-lived service.
+            for k in [k for k, (ts, _) in _panel_cache.items() if now - ts >= _CACHE_TTL_S]:
+                del _panel_cache[k]
+            _panel_cache[cache_key] = (now, fetched)
 
     frames = {sym: fetched[yf] for sym, yf in resolved.items() if yf in fetched}
     panel = _panel_from_frames(frames, resolved)

--- a/backend/archimedes/services/fusion_market_data.py
+++ b/backend/archimedes/services/fusion_market_data.py
@@ -71,12 +71,26 @@ def real_data_enabled() -> bool:
 def _ensure_analytics_import() -> None:
     """Place ``analytics-engine/src`` on sys.path so its ``data`` module imports.
 
-    Mirrors ``portfolio_backtester._ensure_analytics_import`` — one function
-    (``fetch_ohlcv``) owns the yfinance fetch+normalize contract repo-wide.
+    Walks UP from this file until it finds the package: the host repo layout
+    (``backend/archimedes/...`` with ``analytics-engine`` at the repo root) and
+    the container layout (``/app/archimedes/...`` with ``/app/analytics-engine``
+    mounted) put it a different number of levels up. The previous fixed
+    ``parents[3]`` silently resolved to ``/`` inside the container, which broke
+    EVERY real-data backtest in prod (dogfood find, 2026-07-01 — the reason
+    strategies never left "pending"). ``portfolio_backtester`` delegates here so
+    one function owns the path contract repo-wide.
     """
-    analytics_src = Path(__file__).resolve().parents[3] / "analytics-engine" / "src"
-    if str(analytics_src) not in sys.path:
-        sys.path.insert(0, str(analytics_src))
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        src = parent / "analytics-engine" / "src"
+        if (src / "archimedes_analytics_engine").is_dir():
+            if str(src) not in sys.path:
+                sys.path.insert(0, str(src))
+            return
+    logger.warning(
+        "analytics-engine/src not found above %s — real-data fetches will fail closed to synthetic",
+        here,
+    )
 
 
 def _fetch_one(yf_ticker: str, start: str, end: str) -> Any:

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -63,14 +63,16 @@ MIN_BARS_FOR_BACKTEST = 60  # ~3 months; refuse to backtest shorter windows
 def _ensure_analytics_import() -> None:
     """Place ``analytics-engine/src`` on sys.path so its ``data`` module imports.
 
-    Mirrors :func:`archimedes.scripts.run_backtests._ensure_analytics_import` —
-    we deliberately reuse the analytics-engine's yfinance wrapper rather than
-    pulling yfinance directly here, so a single function owns the fetch+
-    normalize contract.
+    Delegates to ``fusion_market_data._ensure_analytics_import``, which walks up
+    from its own file to find the package. The previous fixed ``parents[3]``
+    resolved to ``/`` inside the container (host and image layouts differ), so
+    every real-data backtest in prod raised ``No module named
+    'archimedes_analytics_engine'`` and strategies never left "pending"
+    (dogfood find, 2026-07-01). One function owns the path contract now.
     """
-    analytics_src = Path(__file__).resolve().parents[3] / "analytics-engine" / "src"
-    if str(analytics_src) not in sys.path:
-        sys.path.insert(0, str(analytics_src))
+    from archimedes.services.fusion_market_data import _ensure_analytics_import as _walk_and_insert
+
+    _walk_and_insert()
 
 
 def _fetch_price_panel(symbols: list[str], start: str, end: str) -> tuple[pd.DataFrame, pd.DataFrame]:

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -33,11 +33,9 @@ from __future__ import annotations
 import hashlib
 import inspect
 import logging
-import sys
 import time
 import tracemalloc
 from datetime import UTC, date, datetime, timedelta
-from pathlib import Path
 from typing import Any
 
 import numpy as np

--- a/backend/tests/services/test_fusion_real_data.py
+++ b/backend/tests/services/test_fusion_real_data.py
@@ -1,0 +1,197 @@
+"""Real-data wiring for fusion/DSL backtests (#788/#818 deployability unlock).
+
+Hermetic: the yfinance boundary (``fusion_market_data._fetch_one``) is
+monkeypatched with deterministic frames — no network. These tests prove:
+
+1. universe resolution goes through the SSOT (synth key / display / yf ticker),
+   never arbitrary tickers;
+2. panels are strictly inner-joined (anti-lookahead) and cached, and the cache
+   hit path enforces the same min-bars floor as the miss path;
+3. ``evaluate_fusion_spec(use_real_data=True)`` produces an admissible-eligible
+   verdict with real provenance, and fails CLOSED to synthetic (inadmissible)
+   when data is unavailable;
+4. feed factories yield a FRESH feed per run — the variant grid on a shared
+   concrete feed is the silent-corruption bug this design exists to prevent.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from archimedes.services import fusion_market_data as fmd
+from archimedes.services.fusion_evaluator import evaluate_fusion_spec, run_dsl_backtest
+from archimedes.services.strategy_dsl import FABER_2007_SPEC
+
+
+def _frame(seed: int, n: int = 700, start: str = "2019-01-02") -> pd.DataFrame:
+    idx = pd.bdate_range(start, periods=n)
+    rng = np.random.default_rng(seed)
+    close = 100.0 * np.cumprod(1.0 + rng.normal(0.0004, 0.012, n))
+    return pd.DataFrame(
+        {
+            "Open": close * 0.999,
+            "High": close * 1.005,
+            "Low": close * 0.995,
+            "Close": close,
+            "Volume": np.full(n, 1_000_000.0),
+        },
+        index=idx,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_panel_cache():
+    fmd._panel_cache.clear()
+    yield
+    fmd._panel_cache.clear()
+
+
+def _patch_fetch(monkeypatch, frames_by_ticker: dict[str, pd.DataFrame], calls: list | None = None):
+    def _fake(yf_ticker: str, start: str, end: str) -> pd.DataFrame:
+        if calls is not None:
+            calls.append(yf_ticker)
+        if yf_ticker not in frames_by_ticker:
+            raise ValueError(f"no data for {yf_ticker}")
+        return frames_by_ticker[yf_ticker]
+
+    monkeypatch.setattr(fmd, "_fetch_one", _fake)
+
+
+# ── universe resolution ───────────────────────────────────────────────
+
+
+def test_resolve_universe_maps_synth_display_and_yf_forms():
+    resolved = fmd.resolve_universe(["sSPY", "AAVE", "AAVE-USD", "TOTALLY_FAKE_XYZ"])
+    assert resolved.get("sSPY") == "SPY"
+    assert resolved.get("AAVE") == "AAVE-USD"
+    assert resolved.get("AAVE-USD") == "AAVE-USD"
+    assert "TOTALLY_FAKE_XYZ" not in resolved  # outside the SSOT → skipped
+
+
+def test_resolve_universe_caps_asset_fanout():
+    from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
+
+    many = list(GLOBAL_ASSETS)[: fmd._MAX_ASSETS + 4]
+    resolved = fmd.resolve_universe(many)
+    assert len(resolved) == fmd._MAX_ASSETS
+
+
+# ── panel fetch: inner join, cache, fail-closed ───────────────────────
+
+
+def test_fetch_real_panel_inner_joins_on_common_dates(monkeypatch):
+    # AAVE-USD starts 100 business days later → the join must shrink to the overlap.
+    _patch_fetch(monkeypatch, {"SPY": _frame(1, n=700), "AAVE-USD": _frame(2, n=600, start="2019-05-22")})
+    panel = fmd.fetch_real_panel(["SPY", "AAVE"], min_bars=252)
+    assert panel is not None
+    lengths = {len(df) for df in panel.frames.values()}
+    assert lengths == {panel.n_bars}  # every frame aligned to the common index
+    assert panel.n_bars < 700  # strictly the overlap, not the union
+    assert panel.label == "yfinance:SPY,AAVE-USD"
+    assert panel.start < panel.end
+
+
+def test_fetch_real_panel_caches_by_ticker_set(monkeypatch):
+    calls: list[str] = []
+    _patch_fetch(monkeypatch, {"SPY": _frame(1)}, calls)
+    first = fmd.fetch_real_panel(["SPY"])
+    again = fmd.fetch_real_panel(["SPY"])
+    assert first is not None and again is not None
+    assert calls == ["SPY"]  # second call served from cache — no refetch
+
+
+def test_fetch_real_panel_min_bars_fails_closed_even_from_cache(monkeypatch):
+    _patch_fetch(monkeypatch, {"SPY": _frame(1, n=100)})
+    assert fmd.fetch_real_panel(["SPY"], min_bars=252) is None
+    # The short frames are cached; the HIT path must enforce the same floor.
+    assert fmd.fetch_real_panel(["SPY"], min_bars=252) is None
+
+
+def test_fetch_real_panel_unmappable_universe_returns_none(monkeypatch):
+    _patch_fetch(monkeypatch, {})
+    assert fmd.fetch_real_panel(["NOT_IN_SSOT"]) is None
+
+
+# ── evaluate_fusion_spec on real data ─────────────────────────────────
+
+
+def test_evaluate_real_data_multi_asset_admissible_flow(monkeypatch):
+    _patch_fetch(monkeypatch, {"SPY": _frame(1), "AAVE-USD": _frame(2)})
+    spec = {
+        **FABER_2007_SPEC,
+        "asset_universe": ["SPY", "AAVE"],
+        "parameter_variants": {"sma_200": [150, 200, 250]},
+    }
+    result = evaluate_fusion_spec(spec, use_real_data=True)
+    assert result.success, f"evaluation failed: {result.error}"
+    assert result.backtest is not None and result.rigor is not None
+    # Real provenance end-to-end: metrics AND verdict carry the yfinance label.
+    assert result.backtest.data_source == "yfinance:SPY,AAVE-USD"
+    assert result.rigor.data_source == "yfinance:SPY,AAVE-USD"
+    # Admissibility now tracks the statistics (no synthetic disqualifier).
+    assert result.rigor.admissible == result.rigor.passing
+    # Portfolio curve covers the joined panel (700 aligned bars), real dates set.
+    assert len(result.backtest.equity_curve) > 600
+    assert result.backtest.backtest_start is not None
+    assert result.backtest.backtest_end is not None
+    # The 3-variant grid ran on real data → CSCV PBO is a real number.
+    assert result.rigor.pbo_score is not None
+    assert 0.0 <= result.rigor.pbo_score <= 1.0
+
+
+def test_evaluate_real_data_unavailable_falls_back_synthetic(monkeypatch):
+    def _boom(yf_ticker, start, end):
+        raise RuntimeError("yfinance down")
+
+    monkeypatch.setattr(fmd, "_fetch_one", _boom)
+    result = evaluate_fusion_spec(dict(FABER_2007_SPEC), use_real_data=True)
+    assert result.success
+    # Fail-closed: synthetic provenance, never admissible — the live gate
+    # keeps reading an honest "pending" for this strategy.
+    assert result.backtest.data_source == "synthetic"
+    assert result.rigor.admissible is False
+
+
+def test_evaluate_default_stays_hermetic_and_synthetic(monkeypatch):
+    # No use_real_data → the fetch boundary must never be touched.
+    def _forbidden(*a, **k):
+        raise AssertionError("network path must not run by default")
+
+    monkeypatch.setattr(fmd, "_fetch_one", _forbidden)
+    result = evaluate_fusion_spec(dict(FABER_2007_SPEC))
+    assert result.success
+    assert result.backtest.data_source == "synthetic"
+
+
+# ── feed factories ────────────────────────────────────────────────────
+
+
+def test_feed_factory_yields_fresh_consumable_feeds():
+    factory = fmd.feed_factory(_frame(7))
+    assert factory() is not factory()  # fresh object per call
+    from archimedes.services.strategy_dsl import validate_strategy_spec
+
+    spec = validate_strategy_spec(dict(FABER_2007_SPEC))
+    # Two full cerebro runs off the SAME factory: a shared concrete feed would
+    # leave the second run with an exhausted feed (degenerate 1-bar curve).
+    m1 = run_dsl_backtest(spec, data_feed_factory=factory, data_source_label="yfinance:SPY")
+    m2 = run_dsl_backtest(spec, data_feed_factory=factory, data_source_label="yfinance:SPY")
+    assert len(m1.equity_curve) > 600
+    assert len(m2.equity_curve) > 600
+    assert m1.data_source == "yfinance:SPY"
+
+
+# ── env gate ──────────────────────────────────────────────────────────
+
+
+def test_real_data_enabled_env_gate(monkeypatch):
+    monkeypatch.setenv("TESTING", "1")
+    assert fmd.real_data_enabled() is False  # hermetic under pytest, always
+
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("ARCHIMEDES_FUSION_REAL_DATA", "0")
+    assert fmd.real_data_enabled() is False  # explicit kill switch
+
+    monkeypatch.delenv("ARCHIMEDES_FUSION_REAL_DATA", raising=False)
+    assert fmd.real_data_enabled() is True  # default ON in prod

--- a/backend/tests/services/test_fusion_real_data.py
+++ b/backend/tests/services/test_fusion_real_data.py
@@ -65,7 +65,10 @@ def test_resolve_universe_maps_synth_display_and_yf_forms():
     resolved = fmd.resolve_universe(["sSPY", "AAVE", "AAVE-USD", "TOTALLY_FAKE_XYZ"])
     assert resolved.get("sSPY") == "SPY"
     assert resolved.get("AAVE") == "AAVE-USD"
-    assert resolved.get("AAVE-USD") == "AAVE-USD"
+    # "AAVE-USD" duplicates the same yfinance ticker as "AAVE" — deduped (first
+    # form wins), else the portfolio would carry the sleeve twice.
+    assert "AAVE-USD" not in resolved
+    assert list(resolved.values()).count("AAVE-USD") == 1
     assert "TOTALLY_FAKE_XYZ" not in resolved  # outside the SSOT → skipped
 
 
@@ -111,6 +114,13 @@ def test_fetch_real_panel_min_bars_fails_closed_even_from_cache(monkeypatch):
 def test_fetch_real_panel_unmappable_universe_returns_none(monkeypatch):
     _patch_fetch(monkeypatch, {})
     assert fmd.fetch_real_panel(["NOT_IN_SSOT"]) is None
+
+
+def test_fetch_real_panel_fails_closed_on_partial_fetch(monkeypatch):
+    # SPY resolves+fetches fine but AAVE-USD errors: a shrunken panel would be a
+    # DIFFERENT universe than the spec requested — must fail closed, not shrink.
+    _patch_fetch(monkeypatch, {"SPY": _frame(1)})
+    assert fmd.fetch_real_panel(["SPY", "AAVE"]) is None
 
 
 # ── evaluate_fusion_spec on real data ─────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,10 @@ services:
       - .env
     volumes:
       - ./analytics-engine/strategies:/app/analytics-engine/strategies:ro
+      # src/ carries the archimedes_analytics_engine package (fetch_ohlcv) —
+      # without it, every real-data backtest in the container fails closed to
+      # synthetic/"pending" (dogfood find, 2026-07-01).
+      - ./analytics-engine/src:/app/analytics-engine/src:ro
       - ./contracts/abis:/contracts/abis:ro
     healthcheck:
       disable: true
@@ -163,6 +167,10 @@ services:
     volumes:
       - ./analytics-engine/strategies:/app/analytics-engine/strategies:ro
       - ./analytics-engine/artifacts:/app/analytics-engine/artifacts:ro
+      # src/ carries the archimedes_analytics_engine package (fetch_ohlcv) —
+      # without it, every real-data backtest in the container fails closed to
+      # synthetic/"pending" (dogfood find, 2026-07-01).
+      - ./analytics-engine/src:/app/analytics-engine/src:ro
       - ./contracts/abis:/contracts/abis:ro
       - ./data/corpus:/app/data/corpus:ro
       - archimedes-corpus-artifact:/app/data/corpus-artifact


### PR DESCRIPTION
## Summary

Closes the last gap in the generation → live-gate → deployability chain (#788/#818): fusion/debate candidates **always** backtested on synthetic `random.gauss` prices (`data_feed=None` at all 3 call sites), so every verdict carried `data_source="synthetic"`, was inadmissible by design, and the live rigor gate honestly read `pending` forever. Generated strategies could never become deployable.

## Fix

**New `services/fusion_market_data.py`** — the missing data supplier:
- Resolves the spec's `asset_universe` through the **Chainlink-only universe SSOT** (`GLOBAL_ASSETS`, #842) — accepts synth keys (`sSPY`), display names (`AAVE`), or yfinance tickers; anything outside the SSOT is skipped loudly (we never backtest arbitrary tickers).
- Fetches real daily OHLCV via the analytics-engine's `fetch_ohlcv` (the single owner of the fetch+normalize contract — same reuse rationale as `portfolio_backtester`).
- **Strictly inner-joins** the panel across assets (the anti-lookahead/survivorship join rule from `portfolio_backtester._fetch_price_panel`), caches per ticker-set (6h TTL — a debate pool sharing a universe costs one round-trip), floors at 252 overlapping bars (enforced on cache hits too).
- Returns per-asset **feed factories**: a concrete backtrader feed is consumed by a single `cerebro.run()` — sharing one across the base run + variant grid silently corrupts every run after the first. Regression-tested.

**Multi-asset-first** (per Dan: the curated single-asset specs are test fixtures; the value is multi-paper multi-asset): the DSL engine is single-feed by construction (`self.data` only), so a multi-asset spec is evaluated honestly — the same rules applied **per asset** over the aligned real panel with equal sleeve cash, sleeves summed into the portfolio equity that the rigor gate judges (`run_dsl_backtest_portfolio` + variant-grid twin).

**Opt-in + fail-closed:** `evaluate_fusion_spec(..., use_real_data=True)` at the 3 live call sites behind `real_data_enabled()` (off under `TESTING`; kill switch `ARCHIMEDES_FUSION_REAL_DATA=0`; default ON). Unmappable universe / fetch failure / short join → synthetic fallback → still inadmissible → honest `pending`. **Never a fake pass.**

## Real-world smoke (live yfinance)

```
spec: FABER SMA-200, universe [SPY, QQQ, GLD], variants sma_200=[150,200,250]
data_source: yfinance:SPY,QQQ,GLD
bars: 5,436 | 2004-11-18 → 2026-06-30   (8.7s cold, cached after)
rigor: passing=True  ADMISSIBLE=True  dsr_p=0.969  pbo=0.063  oos=0.69
```

First admissible fusion verdict in the project's history. Chained with #839's returns persistence, fusion winners now read **pass/fail** at the live gate and become genuinely deployable.

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/services/test_fusion_real_data.py -q          # 11 passed
python -m pytest backend/tests/services/test_fusion_evaluator.py \
  backend/tests/test_debate_engine.py \
  backend/tests/services/test_generation_pipeline.py \
  backend/tests/test_live_gate_returns.py -q                  # 70 passed
```

## Anti-goals

- No rigor thresholds touched; the admissibility gate is strengthened (real data can now satisfy it), never weakened.
- No new deps (yfinance via the existing analytics-engine wrapper).
- Default `use_real_data=False` keeps every existing unit test hermetic — the network path cannot run under pytest (`TESTING` gate + explicit test proving the fetch boundary is untouched by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M