### PR TITLE
[frontend] Persist Circle passkey wallet name and surface it in the app UI

### DIFF
--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -101,6 +101,20 @@ export function sanitizeWalletName(name) {
   return cleaned.length >= 5 ? cleaned : null
 }
 
+// UI-facing display name for a newly registered wallet: the user's typed name,
+// trimmed and capped at 40 chars. Distinct from sanitizeWalletName above, which
+// maps the name into Circle's username charset for the OS passkey-picker label —
+// the display name keeps spaces/punctuation so the app UI shows what the user
+// actually typed. Returns undefined for empty/blank input so callers fall
+// through to the address-based label.
+const DISPLAY_NAME_MAX_CHARS = 40
+
+function toDisplayWalletName(name) {
+  if (typeof name !== 'string') return undefined
+  const trimmed = name.trim().slice(0, DISPLAY_NAME_MAX_CHARS)
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
 export function clearCircleSession() {
   try {
     localStorage.removeItem(CREDENTIAL_STORAGE_KEY)
@@ -153,7 +167,10 @@ function friendlyPasskeyError(err) {
 //     usernames. New credential → new MSCA address.
 //
 // Returns the smart account + address + credential (persisted to localStorage
-// for silent next-session rehydrate — see rehydrateSmartAccount). Throws a
+// for silent next-session rehydrate — see rehydrateSmartAccount). Register mode
+// also echoes the user-typed wallet name (trimmed, ≤40 chars) as `walletName`
+// so the caller can persist it for the app UI; login mode returns undefined —
+// discoverable login can't know which passkey the user picked. Throws a
 // friendly message on WebAuthn cancellation / domain mismatch / name collision.
 export async function connectCirclePasskey({ mode = 'login', walletName } = {}) {
   if (!circlePasskeyEnabled()) {
@@ -208,6 +225,10 @@ export async function connectCirclePasskey({ mode = 'login', walletName } = {}) 
     client,
     credential,
     mode,
+    // Register mode: the user-typed name (trimmed, ≤40 chars) for app-UI
+    // persistence; undefined when blank or in login mode (discoverable login
+    // doesn't reveal which passkey was picked).
+    walletName: mode === 'register' ? toDisplayWalletName(walletName) : undefined,
   }
 }
 

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import WalletConnect from './WalletConnect'
 import Breadcrumbs from './Breadcrumbs'
 import WelcomeProfileModal from './WelcomeProfileModal'
-import { NEW_CONTRACTS } from '../config'
+import { NEW_CONTRACTS, getStoredWalletName } from '../config'
 
 // Sidebar groups separate Home (anchor / landing) from the three product-state
 // bands. Empty group label is intentional for the Home entry — it renders as a
@@ -106,7 +106,11 @@ export default function Layout({ page, setPage, walletAddr, onConnect, onDisconn
     if (profile) setUserProfile(profile)
   }
 
+  // Display-name fallback chain: backend profile display_name → wallet name
+  // saved at Circle passkey creation (localStorage, keyed by address) →
+  // WalletConnect renders the truncated address when this is null.
   const displayName = userProfile?.display_name
+    || (walletAddr ? getStoredWalletName(walletAddr) : null)
 
   const handleNav = (id) => {
     setPage(id)

--- a/ui/src/components/WelcomeProfileModal.jsx
+++ b/ui/src/components/WelcomeProfileModal.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { createPortal } from 'react-dom'
+import { getStoredWalletName } from '../config'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 const STORAGE_PREFIX = 'archimedes.welcomeProfileSeen.'
@@ -17,7 +18,11 @@ const INTEREST_OPTIONS = ['Equities', 'Bonds', 'Commodities', 'Crypto', 'FX']
 // All fields remain optional in both modes.
 export default function WelcomeProfileModal({ walletAddr, onDone, mode = 'welcome', existingProfile = null }) {
   const isEdit = mode === 'edit'
-  const [displayName, setDisplayName] = useState(existingProfile?.display_name || '')
+  // Prefill priority: backend profile display_name → wallet name saved at
+  // Circle passkey creation (localStorage) → empty. Still fully editable.
+  const [displayName, setDisplayName] = useState(
+    existingProfile?.display_name || (walletAddr && getStoredWalletName(walletAddr)) || ''
+  )
   const [email, setEmail] = useState(existingProfile?.email || '')
   const [selectedInterests, setSelectedInterests] = useState(existingProfile?.interests || [])
   const [attribution, setAttribution] = useState(existingProfile?.attribution || '')

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -167,6 +167,13 @@ export function discoverEip6963Wallets() {
 }
 
 const STORAGE_KEY = 'archimedes_wallet'
+// User-chosen wallet display names keyed by LOWERCASE address, e.g.
+// { "0xabc…": "Trading" }. Deliberately a SEPARATE localStorage key from
+// STORAGE_KEY: disconnecting clears the connection meta (clearWalletMeta), and
+// the names must survive that so signing back into the same passkey wallet
+// re-surfaces its name. Clients that never wrote this key just read null —
+// same for the legacy {providerId, address} meta shape, which is unchanged.
+const WALLET_NAMES_KEY = 'archimedes_wallet_names'
 
 // Synthetic provider id for the Circle Modular Wallets path. Distinct from
 // the EOA paths (metamask / coinbase / eip6963:*) so connectWallet() +
@@ -191,9 +198,36 @@ export function getSmartAccount() { return _smartAccount }
 // account — required for createBundlerClient. Null for EOA paths.
 export function getSmartAccountClient() { return _smartAccountClient }
 
-function saveWalletMeta(providerId, address) {
+function loadWalletNames() {
+  try {
+    const raw = localStorage.getItem(WALLET_NAMES_KEY)
+    const parsed = raw ? JSON.parse(raw) : null
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch { return {} }
+}
+
+// Returns the user-chosen display name for a wallet address (saved when the
+// wallet was created via the Circle passkey register flow), or null when none
+// is stored. Middle rung of the UI display-name fallback chain:
+//   backend profile display_name → stored wallet name → truncated address.
+export function getStoredWalletName(address) {
+  if (!address) return null
+  const name = loadWalletNames()[address.toLowerCase()]
+  return typeof name === 'string' && name.length > 0 ? name : null
+}
+
+// Persist connection meta. `name` is optional — the Circle passkey register
+// flow passes the user-chosen wallet name; when present it is stored keyed by
+// lowercase address under WALLET_NAMES_KEY. The {providerId, address} shape
+// under STORAGE_KEY is unchanged so previously stored meta keeps parsing.
+function saveWalletMeta(providerId, address, name) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ providerId, address }))
+    if (address && typeof name === 'string' && name.trim().length > 0) {
+      const names = loadWalletNames()
+      names[address.toLowerCase()] = name.trim()
+      localStorage.setItem(WALLET_NAMES_KEY, JSON.stringify(names))
+    }
   } catch { /* storage unavailable */ }
 }
 
@@ -346,7 +380,10 @@ export async function connectCircleWallet({ mode = 'login', walletName } = {}) {
   _walletClient = null
   _smartAccount = result.smartAccount
   _smartAccountClient = result.client
-  saveWalletMeta(CIRCLE_PROVIDER_ID, _address)
+  // result.walletName is only set on register (trimmed, ≤40 chars) — login is
+  // discoverable so no name comes back; any previously stored name for this
+  // address is left intact for getStoredWalletName().
+  saveWalletMeta(CIRCLE_PROVIDER_ID, _address, result.walletName)
   return { address: _address, provider: CIRCLE_PROVIDER_ID }
 }
 


### PR DESCRIPTION
## Summary
The wallet name a user types when creating a Circle passkey wallet only reached the OS passkey-picker label (`registerUsername`) and was then dropped: `connectCirclePasskey` returned no name, `saveWalletMeta` stored only `{providerId, address}`, and Layout's `displayName` came exclusively from the backend profile `display_name`. The name never surfaced in the app UI. This PR makes it stick — frontend only.

## Fix
- **`ui/src/circle-wallet.js`** — `connectCirclePasskey` now returns `walletName` (the user-typed name, trimmed, capped at 40 chars) in the result object for `register` mode; `undefined` on `login` mode (discoverable login can't know which passkey was picked). `registerUsername` / Circle SDK params untouched.
- **`ui/src/config.js`** — `saveWalletMeta(providerId, address, name)` accepts an optional name, stored keyed by **lowercase address** under a new `archimedes_wallet_names` localStorage key. This is deliberately separate from `archimedes_wallet` so disconnect (`clearWalletMeta`) doesn't erase names — signing back into the same passkey wallet re-surfaces its name. The legacy `{providerId, address}` meta shape is unchanged (old clients parse fine; missing names key reads null). New exported `getStoredWalletName(address)`.
- **`ui/src/components/Layout.jsx`** — `displayName` fallback chain: backend profile `display_name` → stored wallet name for the connected address → truncated address (existing WalletConnect behavior).
- **`ui/src/components/WelcomeProfileModal.jsx`** — display-name input prefills from the stored wallet name when the profile has no `display_name`; still fully editable in both welcome and edit modes.

## Verify
```bash
export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
cd ui && npm ci --no-audit && npm run lint   # expected: exits 0, no findings
```
Manual (live path): Connect Wallet → Circle Modular Wallets → type a name (e.g. `Trading`) → Create new wallet → the topbar wallet chip and dropdown header show `Trading` instead of `0x…abcd`; the welcome profile modal's Display name input is prefilled with `Trading`. Saving a backend profile display_name still wins over the stored name.

Note: `ui/` has no vitest harness (checked `ui/package.json` — only eslint), so the saveWalletMeta round-trip test requested in the spec is skipped; lint is the verification gate.

## Anti-goals
- No backend changes (`git diff --name-only` shows only `ui/src/*`).
- Auth/SIWE flow untouched (`WalletConnect.jsx` handleConnect / `siwe.js` unmodified).
- Circle SDK params unrenamed (`registerUsername` intact at circle-wallet.js:185,194).
- Legacy stored-meta shape handled: `archimedes_wallet` still `{providerId, address}`; missing `archimedes_wallet_names` key gracefully returns null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
