### PR TITLE
Add optional user-chosen strategy names on Generate !minor

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -979,6 +979,19 @@ async def _run_fusion_candidate(
 # ── Pipeline entry point ──────────────────────────────────────────────────
 
 
+def _resolve_name(brief: GenerateBrief, default: str) -> str:
+    """Prefer the user's ``brief.name`` over an auto-derived default.
+
+    Single choke point for user-chosen strategy names: every runner
+    (fixture / live agent / fusion / debate) auto-derives a ``strategy_name``,
+    and ``run_generation`` applies the user's name to the WINNER only — right
+    before persistence, so the library record, passport, episodic memory, and
+    job result all carry it. ``brief.name`` is already sanitized (stripped,
+    whitespace-collapsed, 1–80 chars) by the ``GenerateBrief`` validator.
+    """
+    return brief.name or default
+
+
 def _served_model_for(job_agent: Any, use_live: bool) -> str:
     """Resolve the model id that actually served this job, for provenance.
 
@@ -1288,6 +1301,12 @@ async def run_generation(
             pool,
             key=lambda c: c.rigor_verdict.get("dsr") or 0.0,
         )
+        # User-chosen name (brief.name) applies to the WINNER only, and must land
+        # BEFORE the persist loop below so every downstream surface (library
+        # record, passport, episodic memory, job result) reads it. Considered-
+        # rejects keep their auto-derived names — renaming them too would produce
+        # multiple identically-named strategies per generation.
+        best.strategy_name = _resolve_name(brief, best.strategy_name)
         await emit.emit(
             "best_selected",
             best_candidate_id=best.candidate_id,

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -8,12 +8,20 @@ one definition of what an event looks like on the wire.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # ── Request side ──────────────────────────────────────────────────────────
+
+# User-chosen strategy name limits. Whitespace is collapsed BEFORE these
+# checks, so \t/\n arriving in a paste are normalized rather than rejected;
+# any control character that survives collapsing (NUL, ESC, DEL, …) is a
+# hard reject — those never belong in a display name.
+NAME_MAX_LEN = 80
+_NAME_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
 
 
 class GenerateBrief(BaseModel):
@@ -24,6 +32,30 @@ class GenerateBrief(BaseModel):
     asset_classes: list[str] | None = None
     capital_usdc: float | None = None
     max_papers: int = Field(default=5, ge=1, le=20)
+    name: str | None = Field(
+        default=None,
+        description=(
+            "Optional user-chosen strategy name (1–80 chars after whitespace normalization). "
+            "Applied verbatim to the WINNING candidate only; considered-rejects keep their "
+            "auto-derived names so the library never shows N identically-named strategies "
+            "per generation. Empty/whitespace-only is treated as unset."
+        ),
+    )
+
+    @field_validator("name")
+    @classmethod
+    def _sanitize_name(cls, v: str | None) -> str | None:
+        """Strip + collapse internal whitespace; empty → None; reject control chars / >80 chars."""
+        if v is None:
+            return None
+        v = re.sub(r"\s+", " ", v).strip()
+        if not v:
+            return None
+        if _NAME_CONTROL_CHARS.search(v):
+            raise ValueError("name must not contain control characters")
+        if len(v) > NAME_MAX_LEN:
+            raise ValueError(f"name must be at most {NAME_MAX_LEN} characters")
+        return v
 
 
 class GenerateStartRequest(BaseModel):

--- a/backend/tests/test_strategy_custom_names.py
+++ b/backend/tests/test_strategy_custom_names.py
@@ -103,7 +103,10 @@ def persisted(monkeypatch):
     captured: list = []
 
     async def _fake_persist(c, _brief):  # signature mirrors _persist_candidate(c, brief)
-        captured.append(c)
+        # Snapshot immutable values AT persist time — appending the mutable
+        # candidate object would let a later rename slip past these assertions
+        # (Copilot, #849).
+        captured.append((c.candidate_id, c.strategy_name))
         return (f"strat_{c.candidate_id}", f"0x{c.candidate_id}")
 
     monkeypatch.setattr("archimedes.agents.generation_pipeline._persist_candidate", _fake_persist)
@@ -133,7 +136,7 @@ async def test_winner_gets_user_name_rejects_keep_auto_names(persisted):
 
     # The rename landed BEFORE persistence: the persisted record set contains
     # the user's name exactly once (winner) and the auto name for the reject.
-    persisted_names = sorted(c.strategy_name for c in persisted)
+    persisted_names = sorted(name for _cid, name in persisted)
     assert persisted_names.count("Dan's Custom Alpha") == 1
     assert len(persisted_names) == 2
 
@@ -149,4 +152,4 @@ async def test_no_name_keeps_auto_names_for_all(persisted):
         # Auto-derived fixture names embed the intent snippet + risk appetite.
         assert "dual regime trend following" in c["strategy_name"]
     # Persisted names match the surfaced names (nothing renamed on the way in).
-    assert sorted(c.strategy_name for c in persisted) == sorted(c["strategy_name"] for c in result["candidates"])
+    assert sorted(name for _cid, name in persisted) == sorted(c["strategy_name"] for c in result["candidates"])

--- a/backend/tests/test_strategy_custom_names.py
+++ b/backend/tests/test_strategy_custom_names.py
@@ -1,0 +1,152 @@
+"""User-chosen strategy names (dbrowneup/strategy-custom-names).
+
+Two contracts under test:
+
+  1. Schema — ``GenerateBrief.name`` is optional, sanitized (strip + collapse
+     internal whitespace), treats empty/whitespace-only as unset (None), and
+     rejects control characters and names longer than 80 chars.
+  2. Pipeline — ``run_generation`` applies ``brief.name`` to the WINNING
+     candidate only, at the single ``_resolve_name`` choke point, before
+     persistence. Considered-rejects keep their auto-derived names so a
+     generation never produces N identically-named strategies.
+
+Hermetic by construction: fixture pipeline (GENERATION_PIPELINE_FIXTURE=1 —
+no LLM, no network, static backtester skipped), in-memory JobStore stand-in,
+and ``_persist_candidate`` monkeypatched (no DB). Pattern copied from
+``test_rigor_deploy_gate_contract.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.agents.generation_pipeline import _resolve_name, run_generation
+from archimedes.api.generate_schemas import GenerateBrief
+from pydantic import ValidationError
+
+# ── 1. Schema validation ──────────────────────────────────────────────────
+
+
+class TestGenerateBriefName:
+    def test_name_defaults_to_none(self):
+        assert GenerateBrief(intent="momentum").name is None
+
+    def test_valid_name_is_kept(self):
+        assert GenerateBrief(intent="momentum", name="My Alpha").name == "My Alpha"
+
+    def test_name_is_stripped_and_whitespace_collapsed(self):
+        brief = GenerateBrief(intent="momentum", name="  My   Alpha \t\n Strategy  ")
+        assert brief.name == "My Alpha Strategy"
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", " \t \n "])
+    def test_empty_or_whitespace_only_treated_as_none(self, raw):
+        assert GenerateBrief(intent="momentum", name=raw).name is None
+
+    def test_max_length_80_accepted(self):
+        assert GenerateBrief(intent="momentum", name="x" * 80).name == "x" * 80
+
+    def test_over_80_chars_rejected(self):
+        with pytest.raises(ValidationError, match="at most 80"):
+            GenerateBrief(intent="momentum", name="x" * 81)
+
+    @pytest.mark.parametrize("bad", ["nul\x00name", "esc\x1bname", "del\x7fname"])
+    def test_control_chars_rejected(self, bad):
+        # \t/\n are whitespace → collapsed, not rejected; non-whitespace control
+        # chars (NUL, ESC, DEL) survive collapsing and must hard-fail.
+        with pytest.raises(ValidationError, match="control characters"):
+            GenerateBrief(intent="momentum", name=bad)
+
+    def test_non_string_rejected(self):
+        with pytest.raises(ValidationError):
+            GenerateBrief(intent="momentum", name=123)
+
+
+# ── 2. _resolve_name choke point ──────────────────────────────────────────
+
+
+class TestResolveName:
+    def test_prefers_brief_name(self):
+        brief = GenerateBrief(intent="momentum", name="My Alpha")
+        assert _resolve_name(brief, "Auto Blend — momentum") == "My Alpha"
+
+    def test_falls_back_to_default_when_unset(self):
+        brief = GenerateBrief(intent="momentum")
+        assert _resolve_name(brief, "Auto Blend — momentum") == "Auto Blend — momentum"
+
+
+# ── 3. Pipeline: winner gets the user's name; rejects keep auto names ─────
+
+
+@pytest.fixture(autouse=True)
+def force_fixture_path(monkeypatch):
+    """No LLM / network / static backtest — drive the deterministic fixture pipeline."""
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+
+class _FakeStore:
+    """In-memory JobStore stand-in (mirrors test_rigor_deploy_gate_contract.py)."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.status: list[tuple[str, dict | None, str]] = []
+
+    async def push_event(self, job_id, payload):
+        self.events.append(payload)
+        return len(self.events)
+
+    async def update_status(self, job_id, status, *, result=None, error=""):
+        self.status.append((status, result, error))
+
+
+@pytest.fixture
+def persisted(monkeypatch):
+    """Capture what _persist_candidate would write, without a DB."""
+    captured: list = []
+
+    async def _fake_persist(c, _brief):  # signature mirrors _persist_candidate(c, brief)
+        captured.append(c)
+        return (f"strat_{c.candidate_id}", f"0x{c.candidate_id}")
+
+    monkeypatch.setattr("archimedes.agents.generation_pipeline._persist_candidate", _fake_persist)
+    return captured
+
+
+async def test_winner_gets_user_name_rejects_keep_auto_names(persisted):
+    store = _FakeStore()
+    brief = GenerateBrief(intent="dual regime trend following", name="Dan's Custom Alpha")
+    # Default dual_regime=True → bull + bear candidates; exactly one is selected.
+    await run_generation(job_id="job_names", brief=brief, store=store)
+
+    result = store.status[-1][1]
+    assert result is not None
+    cands = result["candidates"]
+    assert len(cands) == 2
+
+    winners = [c for c in cands if c["selected"]]
+    rejects = [c for c in cands if not c["selected"]]
+    assert len(winners) == 1 and len(rejects) == 1
+
+    # Winner carries the user's name verbatim.
+    assert winners[0]["strategy_name"] == "Dan's Custom Alpha"
+    # Rejects keep their auto-derived name (no duplicate-name confusion).
+    assert rejects[0]["strategy_name"] != "Dan's Custom Alpha"
+    assert "—" in rejects[0]["strategy_name"]  # fixture auto-name template
+
+    # The rename landed BEFORE persistence: the persisted record set contains
+    # the user's name exactly once (winner) and the auto name for the reject.
+    persisted_names = sorted(c.strategy_name for c in persisted)
+    assert persisted_names.count("Dan's Custom Alpha") == 1
+    assert len(persisted_names) == 2
+
+
+async def test_no_name_keeps_auto_names_for_all(persisted):
+    store = _FakeStore()
+    brief = GenerateBrief(intent="dual regime trend following")
+    await run_generation(job_id="job_no_name", brief=brief, store=store)
+
+    result = store.status[-1][1]
+    assert result is not None
+    for c in result["candidates"]:
+        # Auto-derived fixture names embed the intent snippet + risk appetite.
+        assert "dual regime trend following" in c["strategy_name"]
+    # Persisted names match the surfaced names (nothing renamed on the way in).
+    assert sorted(c.strategy_name for c in persisted) == sorted(c["strategy_name"] for c in result["candidates"])

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -36,6 +36,9 @@ const RISK_PROFILES = [
 export default function Generate({ onNavigate }) {
   // ── Unified form state ──
   const [intent, setIntent] = useState('')
+  // Optional user-chosen strategy name. Empty → backend auto-derives one; when
+  // set, the WINNING candidate takes it verbatim (rejects keep auto names).
+  const [strategyName, setStrategyName] = useState('')
   const [helpOpen, setHelpOpen] = useState(false)
   const [riskAppetite, setRiskAppetite] = useState('moderate')
   const [selectedAssets, setSelectedAssets] = useState([])
@@ -113,6 +116,7 @@ export default function Generate({ onNavigate }) {
         risk_appetite: riskAppetite,
         asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
         max_papers: depth,
+        ...(strategyName.trim() ? { name: strategyName.trim() } : {}),
       },
       ...(selectedModel ? { model: selectedModel } : {}),
     }
@@ -377,6 +381,17 @@ export default function Generate({ onNavigate }) {
             placeholder="e.g. A 13-week treasury alternative with low volatility and crypto upside on Fridays"
             rows={4}
             className="chat-input w-full mb-3 p-2.5 leading-relaxed"
+            disabled={starting}
+          />
+
+          <div className="label mb-2">Strategy name (optional)</div>
+          <input
+            type="text"
+            value={strategyName}
+            onChange={e => setStrategyName(e.target.value)}
+            placeholder="Optional — name your strategy"
+            maxLength={80}
+            className="chat-input w-full mb-3 px-2.5 py-1.5"
             disabled={starting}
           />
 


### PR DESCRIPTION
## Summary

Let users name their generated strategies. `GenerateBrief` gains an optional `name` field; when provided, the **winning** candidate takes it verbatim while considered-rejects keep their auto-derived names (so one generation never produces N identically-named strategies). The Generate page gets a matching optional "Strategy name" input.

## Fix

- **`backend/archimedes/api/generate_schemas.py`** — `GenerateBrief.name: str | None` with a pydantic `field_validator`: strip + collapse internal whitespace, empty/whitespace-only → `None`, reject control chars (NUL/ESC/DEL — `\t`/`\n` are collapsed, not rejected) and names > 80 chars.
- **`backend/archimedes/agents/generation_pipeline.py`** — single choke point instead of patching 5 auto-naming sites: `_resolve_name(brief, default)` is applied to `best.strategy_name` in `run_generation` right after winner selection and **before** the persist loop, so the library record, passport, episodic memory, and job result all read the user's name. Because every runner (fixture `:552`, live agent `:766`, fusion `:977` incl. the LLM-JSON `strategy_name` from `strategy_fusion.py`, debate) returns a `_CandidateResult` through this selection, all auto-naming paths are covered. Rejects are untouched by construction.
- **`ui/src/components/Generate.jsx`** — optional "Strategy name" text input (placeholder "Optional — name your strategy", `maxLength=80`, same `chat-input`/`label` styling + `disabled={starting}` pattern as siblings); `name` is included in the `brief` only when non-empty.
- **`backend/tests/test_strategy_custom_names.py`** — hermetic (fixture pipeline, in-memory JobStore, no DB/LLM/network): schema validation matrix (too long, empty→None, control chars, whitespace collapsing) + `run_generation` round-trips proving the winner gets the user's name, exactly once, pre-persistence, and rejects keep auto names.

## Verify

```bash
export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_strategy_custom_names.py -q
# → 17 passed

env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_generation_pipeline.py backend/tests/test_debate_engine.py \
  backend/tests/test_live_gate_returns.py backend/tests/test_rigor_deploy_gate_contract.py \
  backend/tests/test_strategy_custom_names.py backend/tests/test_generate_cancel_scoping.py \
  backend/tests/test_generate_model_gating.py backend/tests/test_generation_gating.py -q
# → 67 passed

ruff format --check backend/archimedes/api/generate_schemas.py backend/archimedes/agents/generation_pipeline.py backend/tests/test_strategy_custom_names.py
ruff check --select E9,F63,F7,F40 backend/archimedes/api/generate_schemas.py backend/archimedes/agents/generation_pipeline.py backend/tests/test_strategy_custom_names.py
# → All checks passed!

cd ui && npm ci && npm run lint
# → exit 0
```

## Anti-goals

- No rename/PATCH endpoint (owned by another branch).
- `strategy_store` schema untouched — the name rides the existing `strategy_name` column.
- No renaming of existing strategies; the SSE `candidate_drafted` events still stream the auto names (the winner isn't known until selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
