### PR TITLE
[backend] Per-user strategy ownership + private-until-published !minor

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1011,6 +1011,7 @@ async def run_generation(
     mode: str | None = None,
     model: str | None = None,
     dual_regime: bool = True,
+    owner_wallet: str | None = None,
 ) -> None:
     """Run the full streaming generation pipeline for one job.
 
@@ -1023,6 +1024,12 @@ async def run_generation(
     by the route). When set, the live path constructs a per-job LLM backend on
     that model; when ``None`` it uses the shared singleton on the env default —
     behavior UNCHANGED.
+
+    ``owner_wallet`` is the SIWE-derived wallet from the job payload (bound
+    server-side by ``gate_generation`` — never client-supplied). It is stamped
+    onto every persisted candidate so generated strategies are per-user and
+    private-until-published. ``None`` (anonymous / flag off) persists an
+    ownerless row, preserving today's behavior.
 
     Designed to be called as a fire-and-forget asyncio task from the route
     handler. Exceptions are caught + emitted as ``error`` events so the SSE
@@ -1303,7 +1310,7 @@ async def run_generation(
         # highlighted but both are navigable from the library.
         strategy_ids: dict[str, str] = {}  # candidate_id → strategy_id
         for c in candidates:
-            sid, thash = await _persist_candidate(c, brief)
+            sid, thash = await _persist_candidate(c, brief, owner_wallet=owner_wallet)
             strategy_ids[c.candidate_id] = sid
             await emit.emit(
                 "trace_hashed",
@@ -1443,11 +1450,16 @@ async def run_generation(
         await store.update_status(job_id, "error", error=str(exc))
 
 
-async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple[str, str]:
+async def _persist_candidate(
+    c: _CandidateResult, brief: GenerateBrief, *, owner_wallet: str | None = None
+) -> tuple[str, str]:
     """Upsert the candidate as a Strategy + return (strategy_id, trace_hash).
 
     Trace hash is the keccak of the canonical (brief, candidate) tuple — gives
     every generation a deterministic identifier mirrored on-chain in v1.5.
+
+    ``owner_wallet`` (SIWE-derived, threaded from run_generation) is stamped on
+    both the strategy_store row and its strategy_passports mirror.
     """
     from web3 import Web3
 
@@ -1484,6 +1496,7 @@ async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple
                 rigor_verdict=c.rigor_verdict,
                 provenance_hash=trace_hash,
                 is_example=False,
+                owner_wallet=owner_wallet,
             )
             session.commit()
 
@@ -1512,7 +1525,13 @@ async def _persist_candidate(c: _CandidateResult, brief: GenerateBrief) -> tuple
                     out_of_sample_sharpe=c.rigor_verdict.get("oos_sharpe") if c.rigor_verdict else None,
                 )
                 with get_session() as sess2:
-                    ingest_passport(sess2, passport, generation_method=c.generation_method, force_update=True)
+                    ingest_passport(
+                        sess2,
+                        passport,
+                        generation_method=c.generation_method,
+                        force_update=True,
+                        owner_wallet=owner_wallet,
+                    )
                     sess2.commit()
             except Exception as exc:
                 logger.warning("unified passport persist failed (non-blocking): %s", exc)

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -102,8 +102,8 @@ async def start_generation(
     # Tag the job with its creator (audit 2026-06-14) so cancel can be scoped to
     # the owner. When no SIWE session exists (flag off / anonymous), owner_wallet
     # is None and the job stays cancellable by anyone — preserving today's open
-    # behavior with no flag-day risk. owner_wallet is inert to the pipeline
-    # (run_generation reads brief/n_candidates from the task args, not payload).
+    # behavior with no flag-day risk. The same wallet is also threaded into
+    # run_generation below so persisted candidates carry per-user ownership.
     job_id = await store.enqueue(
         job_type="generate",
         payload={
@@ -121,7 +121,12 @@ async def start_generation(
 
     # Fire-and-forget the pipeline. The route doesn't await it; the SSE stream
     # below tails the event log written by the pipeline as it runs.
-    task = asyncio.create_task(_run_with_cleanup(job_id, req.brief, req.n_candidates, req.mode, selected_model))
+    # _wallet is the SIWE-derived owner from gate_generation — the SAME value
+    # stored in the job payload above; threading it into the pipeline stamps
+    # ownership onto every persisted candidate (never a client-supplied value).
+    task = asyncio.create_task(
+        _run_with_cleanup(job_id, req.brief, req.n_candidates, req.mode, selected_model, _wallet)
+    )
     _register_task(job_id, task)
 
     # Conversion funnel (#787): a generation actually started for this visitor —
@@ -141,9 +146,17 @@ async def _run_with_cleanup(
     n_candidates: int,
     mode: str | None = None,
     model: str | None = None,
+    owner_wallet: str | None = None,
 ) -> None:
     try:
-        await run_generation(job_id=job_id, brief=brief, n_candidates=n_candidates, mode=mode, model=model)
+        await run_generation(
+            job_id=job_id,
+            brief=brief,
+            n_candidates=n_candidates,
+            mode=mode,
+            model=model,
+            owner_wallet=owner_wallet,
+        )
     except asyncio.CancelledError:
         raise
     except Exception:  # safety net — run_generation already emits error events

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -234,7 +234,7 @@ async def list_generated_strategies(request: Request, limit: int = Query(50, ge=
     or published. Curated examples live on GET /api/strategies/ and stay public.
     """
 
-    from sqlalchemy import func, or_
+    from sqlalchemy import or_
 
     from archimedes.db import get_session
     from archimedes.models.strategy_store import StrategyRecord
@@ -246,10 +246,13 @@ async def list_generated_strategies(request: Request, limit: int = Query(50, ge=
         with get_session() as session:  # type: _Session
             query = session.query(StrategyRecord).filter(StrategyRecord.is_example.is_(False))
             if caller:
+                # owner_wallet is stored lowercase (upsert_strategy) and
+                # get_verified_wallet returns lowercase — compare directly so the
+                # owner_wallet index stays usable (no per-row func.lower()).
                 query = query.filter(
                     or_(
                         StrategyRecord.is_published.is_(True),
-                        func.lower(StrategyRecord.owner_wallet) == caller.lower(),
+                        StrategyRecord.owner_wallet == caller.lower(),
                     )
                 )
             else:

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -26,7 +26,7 @@ from archimedes.api.architect_schemas import (
     StrategyConstructionRequest,
     StrategyConstructionResponse,
 )
-from archimedes.api.auth_siwe import gate_generation
+from archimedes.api.auth_siwe import gate_generation, get_verified_wallet, require_verified_wallet
 from archimedes.api.limiter import limiter
 from archimedes.api.schemas import (
     SignalResponse,
@@ -224,22 +224,37 @@ async def list_strategies(
 
 
 @strategies_router.get("/generated")
-async def list_generated_strategies(limit: int = Query(50, ge=1, le=200)):
-    """List fusion/architect-generated strategies from the strategy_store table."""
+async def list_generated_strategies(request: Request, limit: int = Query(50, ge=1, le=200)):
+    """List fusion/architect-generated strategies from the strategy_store table.
+
+    Private-until-published: a row is visible when it ``is_published`` OR when
+    the caller's verified SIWE wallet matches ``owner_wallet`` (best-effort
+    session read — anonymous callers see only published rows). Legacy ownerless
+    rows are therefore invisible until purged (scripts/purge_orphan_generated.py)
+    or published. Curated examples live on GET /api/strategies/ and stay public.
+    """
+
+    from sqlalchemy import func, or_
 
     from archimedes.db import get_session
     from archimedes.models.strategy_store import StrategyRecord
 
+    caller = get_verified_wallet(request)  # None when anonymous — never an error
+
     rows: list[dict] = []
     try:
         with get_session() as session:  # type: _Session
-            records = (
-                session.query(StrategyRecord)
-                .filter(StrategyRecord.is_example.is_(False))
-                .order_by(StrategyRecord.created_at.desc())
-                .limit(limit)
-                .all()
-            )
+            query = session.query(StrategyRecord).filter(StrategyRecord.is_example.is_(False))
+            if caller:
+                query = query.filter(
+                    or_(
+                        StrategyRecord.is_published.is_(True),
+                        func.lower(StrategyRecord.owner_wallet) == caller.lower(),
+                    )
+                )
+            else:
+                query = query.filter(StrategyRecord.is_published.is_(True))
+            records = query.order_by(StrategyRecord.created_at.desc()).limit(limit).all()
             rows = [r.to_dict() for r in records]
     except Exception as exc:
         import logging as _logging
@@ -1277,10 +1292,16 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
 
 
 @strategies_router.get("/{strategy_id}", response_model=StrategyResponse)
-async def get_strategy(strategy_id: str):
+async def get_strategy(strategy_id: str, request: Request):
     """Get a single strategy by ID. Tries LocalStrategyProvider (curated)
     first; falls through to the strategy_passports table for fusion- and
-    architect-generated strategies so they're clickable from Library."""
+    architect-generated strategies so they're clickable from Library.
+
+    Private-until-published: a non-example, unpublished strategy_store row is
+    404 unless the caller's verified SIWE wallet is its owner (best-effort
+    session read). 404 — not 403 — so non-owners can't probe for existence.
+    Curated strategies (provider path / is_example rows) stay fully public.
+    """
     from fastapi import HTTPException
 
     strat = strategy_provider.get_strategy(strategy_id)
@@ -1288,14 +1309,68 @@ async def get_strategy(strategy_id: str):
         return _to_strategy_response(strat)
 
     from archimedes.db import get_session
+    from archimedes.models.strategy_store import StrategyRecord
     from archimedes.services.passport_loader import get_passport
 
     with get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+        if row is not None and not row.is_example and not row.is_published:
+            caller = get_verified_wallet(request)
+            is_owner = bool(row.owner_wallet and caller and row.owner_wallet.lower() == caller.lower())
+            if not is_owner:
+                raise HTTPException(status_code=404, detail="Strategy not found")
         record = get_passport(session, strategy_id)
         if record is not None:
             return _passport_to_strategy_response(record)
 
     raise HTTPException(status_code=404, detail="Strategy not found")
+
+
+@strategies_router.patch("/{strategy_id}")
+async def rename_strategy(
+    strategy_id: str,
+    payload: dict,
+    wallet: str = Depends(require_verified_wallet),
+):
+    """Rename an owned, generated strategy — ``{"name": "<1..80 chars>"}``.
+
+    Owner-gated: requires a verified SIWE session AND the caller must be the
+    row's ``owner_wallet``. Curated examples (``is_example``) are not renamable.
+    The generation-time ``content_hash``/``provenance_hash`` are deliberately
+    NOT recomputed — they are provenance of the original generation, not of the
+    display name. The strategy_passports table carries no display-name column,
+    so only strategy_store is updated.
+    """
+    from datetime import datetime
+
+    from fastapi import HTTPException
+
+    from archimedes.db import get_session
+    from archimedes.models.strategy_store import StrategyRecord
+
+    name = payload.get("name")
+    if not isinstance(name, str):
+        raise HTTPException(status_code=422, detail="'name' (string) is required")
+    name = name.strip()
+    if not 1 <= len(name) <= 80:
+        raise HTTPException(status_code=422, detail="name must be 1–80 characters after trimming")
+
+    with get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+        if row is None or row.is_example:
+            # Curated examples are not user-owned — same 404 as a missing row.
+            raise HTTPException(status_code=404, detail="Strategy not found")
+        if not (row.owner_wallet and row.owner_wallet.lower() == wallet.lower()):
+            # Hide unpublished rows from non-owners (404); published rows are
+            # visible, so an honest 403 is returned instead.
+            if row.is_published:
+                raise HTTPException(status_code=403, detail="Not authorized to rename this strategy.")
+            raise HTTPException(status_code=404, detail="Strategy not found")
+
+        row.strategy_name = name
+        row.updated_at = datetime.now(UTC)
+        session.commit()
+        return {"strategy": row.to_dict()}
 
 
 # ── Strategy generation (fusion / architect) ──────────────────
@@ -1399,6 +1474,10 @@ async def generate_strategy(
                 "strategic_direction": strategic_direction,
                 "max_papers": max_papers,
                 "market_context": market_context,
+                # SIWE-derived owner (gate_generation) — server-bound, never
+                # client-supplied. Stamped on the persisted fusion strategy so
+                # this legacy path stops producing ownerless orphan rows.
+                "owner_wallet": _wallet,
             },
         )
     finally:
@@ -1537,6 +1616,7 @@ async def _run_fusion_job(job_id: str) -> None:
                     risk_profile=rp.value,
                     provenance_hash=result.model,
                     rigor_verdict=rigor_verdict_dict,
+                    owner_wallet=payload.get("owner_wallet"),
                 )
                 session.commit()
                 strategy_id = record.id

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -255,7 +255,7 @@ async def list_generated_strategies(request: Request, limit: int = Query(50, ge=
             else:
                 query = query.filter(StrategyRecord.is_published.is_(True))
             records = query.order_by(StrategyRecord.created_at.desc()).limit(limit).all()
-            rows = [r.to_dict() for r in records]
+            rows = [_redact_owner_wallet(r.to_dict(), caller) for r in records]
     except Exception as exc:
         import logging as _logging
 
@@ -1163,36 +1163,98 @@ async def run_stress_test(payload: dict, request: Request, response: Response): 
 # ── Unified Passport Store (Issue #160 Phase 2) ───────────────────────────
 
 
+def _redact_owner_wallet(d: dict, caller: str | None) -> dict:
+    """Strip ``owner_wallet`` from a public payload unless the caller IS the owner.
+
+    Wallet addresses are pseudonymous PII and a linkability vector; publishing a
+    strategy publishes the strategy, not its creator's wallet. Attribution is a
+    marketplace (#713) decision to make deliberately later.
+    """
+    ow = d.get("owner_wallet")
+    if not (caller and ow and str(ow).lower() == caller.lower()):
+        d.pop("owner_wallet", None)
+    return d
+
+
+def _visible_passports(session, records: list, caller: str | None) -> list:
+    """Apply private-until-published to raw passport records.
+
+    The passports table mirrors ``strategy_store`` ids, so leaving these
+    endpoints ungated would defeat the 404-hides-existence design on
+    ``GET /api/strategies/{id}`` by simple id substitution. Visibility mirrors
+    ``list_generated_strategies``: curated passports are always public; a
+    generated passport is public when its store row is ``is_example`` or
+    ``is_published``; otherwise it is owner-only. Ownerless generated legacy
+    rows stay hidden (purge-pending — scripts/purge_orphan_generated.py).
+    """
+    from archimedes.models.strategy_store import StrategyRecord
+
+    ids = [r.id for r in records]
+    store_flags: dict[str, tuple[bool, bool]] = {}
+    if ids:
+        rows = (
+            session.query(StrategyRecord.id, StrategyRecord.is_example, StrategyRecord.is_published)
+            .filter(StrategyRecord.id.in_(ids))
+            .all()
+        )
+        store_flags = {sid: (bool(ex), bool(pub)) for sid, ex, pub in rows}
+
+    visible = []
+    for r in records:
+        if (r.generation_method or "").lower() == "curated":
+            visible.append(r)
+            continue
+        is_example, is_published = store_flags.get(r.id, (False, False))
+        if is_example or is_published:
+            visible.append(r)
+            continue
+        if caller and r.owner_wallet and r.owner_wallet.lower() == caller.lower():
+            visible.append(r)
+    return visible
+
+
 @strategies_router.get("/passports")
 async def list_strategy_passports(
+    request: Request,
     status: str | None = Query(None),
     regime_tag: str | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
 ):
-    """List strategies from the unified strategy_passports table."""
+    """List strategies from the unified strategy_passports table.
+
+    Private-until-published applies here exactly as on ``/generated`` — see
+    ``_visible_passports``.
+    """
     from archimedes.db import get_session
     from archimedes.services.passport_loader import list_passports
 
+    caller = get_verified_wallet(request)  # None when anonymous — never an error
     with get_session() as session:
         records = list_passports(session, status=status, regime_tag=regime_tag)
-        passports = [r.to_dict() for r in records[:limit]]
+        records = _visible_passports(session, records, caller)
+        passports = [_redact_owner_wallet(r.to_dict(), caller) for r in records[:limit]]
 
     return {"passports": passports, "total": len(passports), "source": "strategy_passports"}
 
 
 @strategies_router.get("/passports/{strategy_id}")
-async def get_strategy_passport(strategy_id: str):
-    """Get a single passport in its native dict shape from strategy_passports."""
+async def get_strategy_passport(request: Request, strategy_id: str):
+    """Get a single passport in its native dict shape from strategy_passports.
+
+    Unpublished non-example passports 404 for non-owners (never 403 — a 403
+    would confirm the id exists).
+    """
     from fastapi import HTTPException
 
     from archimedes.db import get_session
     from archimedes.services.passport_loader import get_passport
 
+    caller = get_verified_wallet(request)
     with get_session() as session:
         record = get_passport(session, strategy_id)
-        if record is None:
+        if record is None or not _visible_passports(session, [record], caller):
             raise HTTPException(status_code=404, detail="Passport not found")
-        return record.to_dict()
+        return _redact_owner_wallet(record.to_dict(), caller)
 
 
 def _passport_to_strategy_response(record) -> StrategyResponse:

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -101,6 +101,55 @@ def init_db() -> None:
         except Exception as exc:
             logger.warning("init_db: papers schema patch failed (non-fatal): %s", exc)
 
+    _ensure_ownership_columns()
+
+
+def _ensure_ownership_columns() -> None:
+    """Idempotent ADD COLUMN for per-user strategy ownership.
+
+    Unlike the Postgres-only ``ADD COLUMN IF NOT EXISTS`` patches above, these
+    columns must also land on a pre-existing SQLite file (local dev DBs that
+    predate the model change — create_all only covers FRESH databases), and
+    SQLite doesn't support ``IF NOT EXISTS`` in ``ADD COLUMN``. So this helper
+    uses dialect-safe introspection (``sqlalchemy.inspect``) and only ALTERs
+    when a column is actually missing — works identically on SQLite and
+    Postgres. Non-fatal on failure, matching the patch block above.
+    """
+    from sqlalchemy import inspect as sa_inspect
+    from sqlalchemy import text
+
+    wanted: dict[str, list[tuple[str, str]]] = {
+        "strategy_store": [
+            ("owner_wallet", "VARCHAR(42)"),
+            # TRUE/FALSE literals are valid DDL defaults on both dialects
+            # (SQLite ≥3.23 parses them as 1/0).
+            ("is_published", "BOOLEAN NOT NULL DEFAULT FALSE"),
+        ],
+        "strategy_passports": [
+            ("owner_wallet", "VARCHAR(42)"),
+        ],
+    }
+    try:
+        inspector = sa_inspect(engine)
+        with engine.begin() as conn:
+            for table, columns in wanted.items():
+                if not inspector.has_table(table):
+                    continue
+                existing = {col["name"] for col in inspector.get_columns(table)}
+                for name, ddl in columns:
+                    if name not in existing:
+                        conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}"))
+                        logger.info("init_db: added %s.%s", table, name)
+            # The model declares index=True on strategy_store.owner_wallet;
+            # create_all only builds it on fresh DBs, so mirror it here for
+            # ALTERed ones. IF NOT EXISTS is valid on both SQLite and Postgres.
+            if inspector.has_table("strategy_store"):
+                conn.execute(
+                    text("CREATE INDEX IF NOT EXISTS ix_strategy_store_owner_wallet ON strategy_store (owner_wallet)")
+                )
+    except Exception as exc:
+        logger.warning("init_db: ownership column patch failed (non-fatal): %s", exc)
+
 
 def get_session() -> Session:
     """Get a new DB session. Use as context manager."""

--- a/backend/archimedes/models/strategy_passport_record.py
+++ b/backend/archimedes/models/strategy_passport_record.py
@@ -70,6 +70,12 @@ class StrategyPassportRecord(Base):
     curator_wallet = Column(String(42), nullable=True)
     curator_note = Column(Text, nullable=True)
 
+    # ── Ownership (mirror of strategy_store.owner_wallet) ────
+    # SIWE-derived generating wallet, bound server-side; lowercase; NULL for
+    # curated/legacy rows. Visibility gating reads strategy_store (source of
+    # truth); this mirror keeps the passport row self-describing.
+    owner_wallet = Column(String(42), nullable=True)
+
     # ── Code binding ─────────────────────────────────────────
     strategy_code_path = Column(String(512), nullable=True)
     strategy_code_hash = Column(String(64), nullable=True)
@@ -189,6 +195,7 @@ class StrategyPassportRecord(Base):
             "asset_universe": json.loads(self.asset_universe) if self.asset_universe else [],
             "status": self.status,
             "regime_tag": self.regime_tag,
+            "owner_wallet": self.owner_wallet,
             "passes_rigor_gate": self.passes_rigor_gate,
             "sharpe_ratio": self.sharpe_ratio,
             "sortino_ratio": self.sortino_ratio,

--- a/backend/archimedes/models/strategy_store.py
+++ b/backend/archimedes/models/strategy_store.py
@@ -53,6 +53,15 @@ class StrategyRecord(Base):
     rigor_verdict = Column(Text, nullable=True)  # JSON: DSR/PBO/walk-forward results
     is_example = Column(Boolean, nullable=False, default=False)  # hand-curated static strategies
 
+    # Ownership + visibility (per-user strategies, private-until-published).
+    # owner_wallet is ALWAYS the SIWE-derived wallet bound server-side (mirrors
+    # VaultMetadata.creator_address) — never a client-supplied value. Stored
+    # lowercase. NULL = legacy/anonymous row. is_published is a dormant flag
+    # (nothing flips it yet — the publish flow is a future marketplace hop);
+    # unpublished non-example rows are visible only to their owner.
+    owner_wallet = Column(String(42), nullable=True, index=True)
+    is_published = Column(Boolean, nullable=False, default=False)
+
     # On-chain registration (populated when strategy passes rigor gate)
     on_chain_registration_tx = Column(String(66), nullable=True)  # 0x-prefixed tx hash
     on_chain_registration_block = Column(String(32), nullable=True)  # block number as string
@@ -92,6 +101,8 @@ class StrategyRecord(Base):
             "status": self.status,
             "rigor_verdict": json.loads(self.rigor_verdict) if self.rigor_verdict else None,
             "is_example": self.is_example,
+            "owner_wallet": self.owner_wallet,
+            "is_published": bool(self.is_published),
             "parent_id": self.parent_id,
             "on_chain_registration_tx": self.on_chain_registration_tx,
             "on_chain_registration_block": self.on_chain_registration_block,
@@ -137,8 +148,15 @@ def upsert_strategy(
     parent_id: str | None = None,
     provenance_hash: str | None = None,
     is_example: bool = False,
+    owner_wallet: str | None = None,
 ) -> StrategyRecord:
-    """Idempotent upsert: same content → same row, no duplicates."""
+    """Idempotent upsert: same content → same row, no duplicates.
+
+    ``owner_wallet`` must be the SIWE-derived wallet (never client-supplied);
+    it is normalized to lowercase. On a content-hash match, ownership is only
+    backfilled onto ownerless rows — an existing owner is never overwritten.
+    """
+    owner_wallet = owner_wallet.lower() if owner_wallet else None
     content_hash = _compute_content_hash(
         generation_method,
         strategy_name,
@@ -149,6 +167,11 @@ def upsert_strategy(
 
     existing = session.query(StrategyRecord).filter_by(content_hash=content_hash).first()
     if existing:
+        # Backfill ownership on a legacy/anonymous row; never reassign an owner.
+        if owner_wallet and not existing.owner_wallet:
+            existing.owner_wallet = owner_wallet
+            existing.updated_at = datetime.now(UTC)
+            session.flush()
         # Update status/verdict if provided, but don't duplicate
         if rigor_verdict is not None:
             existing.rigor_verdict = json.dumps(rigor_verdict)
@@ -179,6 +202,7 @@ def upsert_strategy(
         parent_id=parent_id,
         provenance_hash=provenance_hash,
         is_example=is_example,
+        owner_wallet=owner_wallet,
     )
     if rigor_verdict:
         # Same transition rule as the upsert-existing branch above

--- a/backend/archimedes/services/passport_loader.py
+++ b/backend/archimedes/services/passport_loader.py
@@ -73,6 +73,7 @@ def ingest_passport(
     *,
     generation_method: str = "curated",
     force_update: bool = False,
+    owner_wallet: str | None = None,
 ) -> StrategyPassportRecord:
     """Ingest a StrategyPassport dataclass into the unified Postgres table.
 
@@ -84,10 +85,14 @@ def ingest_passport(
         passport: The StrategyPassport dataclass to persist.
         generation_method: "curated", "fusion", or "architect".
         force_update: If True, overwrite existing record fields on hash match.
+        owner_wallet: SIWE-derived generating wallet (server-bound, lowercase).
+            Only set when provided — a later force_update refresh that omits it
+            (e.g. the post-backtest metrics refresh) never clears ownership.
 
     Returns:
         The persisted StrategyPassportRecord.
     """
+    owner_wallet = owner_wallet.lower() if owner_wallet else None
     content_hash = _compute_content_hash(passport)
 
     existing = session.query(StrategyPassportRecord).filter_by(id=passport.id).first()
@@ -99,6 +104,9 @@ def ingest_passport(
     if existing and force_update:
         # Update in place
         _update_record(existing, passport, generation_method, content_hash)
+        if owner_wallet and not existing.owner_wallet:
+            # Backfill only — an existing owner is never overwritten.
+            existing.owner_wallet = owner_wallet
         # Replace paper refs
         session.query(PassportPaperRef).filter_by(passport_id=passport.id).delete()
         existing.paper_refs = _build_paper_refs(passport.id, passport.papers)
@@ -130,6 +138,7 @@ def ingest_passport(
         extraction_prompt_hash=passport.extraction_prompt_hash,
         curator_wallet=passport.curator_wallet,
         curator_note=passport.curator_note,
+        owner_wallet=owner_wallet,
         strategy_code_path=passport.strategy_code_path,
         strategy_code_hash=passport.strategy_code_hash,
         on_chain_registration_tx=passport.on_chain_registration_tx,

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -336,7 +336,7 @@ async def test_dual_regime_persists_both_with_correct_regime_tags():
     persist_calls = []
     call_count = [0]
 
-    async def mock_persist(c, b):
+    async def mock_persist(c, b, **_kw):  # accepts owner_wallet kwarg
         call_count[0] += 1
         sid = f"strat_{c.regime}_{call_count[0]}"
         persist_calls.append({"regime": c.regime, "strategy_id": sid})

--- a/backend/tests/test_rigor_deploy_gate_contract.py
+++ b/backend/tests/test_rigor_deploy_gate_contract.py
@@ -154,7 +154,7 @@ async def test_live_pipeline_result_matches_candidates_contract(monkeypatch):
     future refactor can't drift one without the test catching it.
     """
 
-    async def _fake_persist(c, _brief):  # signature mirrors _persist_candidate(c, brief)
+    async def _fake_persist(c, _brief, **_kw):  # mirrors _persist_candidate(c, brief, *, owner_wallet=None)
         return (f"strat_{c.candidate_id}", f"0x{c.candidate_id}")
 
     monkeypatch.setattr(

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -433,3 +433,92 @@ def test_purge_execute_deletes_orphans_and_cascades():
         assert session.query(StrategyPassportRecord).filter_by(id="orphan0000000001").first() is None
         assert session.query(PassportPaperRef).filter_by(passport_id="orphan0000000001").count() == 0
         assert session.query(BacktestResultRecord).filter_by(strategy_id="orphan0000000001").count() == 0
+
+
+# ── /passports must not bypass private-until-published (adversarial-verify
+#    blocker fix): the passports table mirrors strategy_store ids, so these
+#    endpoints must enforce the SAME visibility rule as /generated and
+#    GET /api/strategies/{id}, and must not disclose owner wallets publicly. ──
+
+
+def _mk_owned_passport(sid: str, *, owner: str | None = None, generation_method: str = "fusion"):
+    from archimedes.models.strategy_passport_record import StrategyPassportRecord
+
+    with get_session() as session:
+        session.add(
+            StrategyPassportRecord(
+                id=sid,
+                content_hash=("0z" + sid).ljust(66, "0"),
+                generation_method=generation_method,
+                methodology_summary="test",
+                asset_universe="[]",
+                owner_wallet=owner.lower() if owner else None,
+            )
+        )
+        session.commit()
+
+
+async def test_passports_list_enforces_private_until_published():
+    _mk_strategy("ppb00000000000001", owner=_W_OTHER, published=True)
+    _mk_owned_passport("ppb00000000000001", owner=_W_OTHER)
+    _mk_strategy("ppv00000000000001", owner=_W_OWNER, published=False)
+    _mk_owned_passport("ppv00000000000001", owner=_W_OWNER)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = (await client.get("/api/strategies/passports")).json()["passports"]
+        anon_ids = {p["id"] for p in anon}
+        # The unpublished strategy must not be enumerable anonymously…
+        assert "ppv00000000000001" not in anon_ids
+        assert "ppb00000000000001" in anon_ids
+        # …and the published one must not disclose its owner's wallet.
+        pub = next(p for p in anon if p["id"] == "ppb00000000000001")
+        assert "owner_wallet" not in pub
+
+        owner = (await client.get("/api/strategies/passports", cookies=_siwe_cookies(_W_OWNER))).json()["passports"]
+        owner_ids = {p["id"] for p in owner}
+        assert "ppv00000000000001" in owner_ids  # owner sees their own private row
+        mine = next(p for p in owner if p["id"] == "ppv00000000000001")
+        assert mine.get("owner_wallet") == _W_OWNER.lower()  # visible to the owner only
+
+
+async def test_passport_detail_404_hides_unpublished_from_non_owners():
+    sid = "ppd00000000000001"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_owned_passport(sid, owner=_W_OWNER)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # The verifier's exact counterexample: id substitution into /passports/{id}.
+        assert (await client.get(f"/api/strategies/passports/{sid}")).status_code == 404
+        assert (
+            await client.get(f"/api/strategies/passports/{sid}", cookies=_siwe_cookies(_W_OTHER))
+        ).status_code == 404  # 404 (not 403) — existence stays hidden
+        ok = await client.get(f"/api/strategies/passports/{sid}", cookies=_siwe_cookies(_W_OWNER))
+        assert ok.status_code == 200
+        assert ok.json().get("owner_wallet") == _W_OWNER.lower()
+
+
+async def test_passport_curated_stays_public():
+    _mk_owned_passport("pcu00000000000001", owner=None, generation_method="curated")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/passports/pcu00000000000001")
+    assert resp.status_code == 200
+
+
+async def test_generated_list_redacts_owner_wallet_for_non_owners():
+    _mk_strategy("prd00000000000001", owner=_W_OTHER, published=True)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = (await client.get("/api/strategies/generated")).json()["strategies"]
+        assert all("owner_wallet" not in s for s in anon)
+        owned = (await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OTHER))).json()["strategies"]
+        mine = next(s for s in owned if s["id"] == "prd00000000000001")
+        assert mine.get("owner_wallet") == _W_OTHER.lower()

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import archimedes.db as db
 from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
-from archimedes.db import get_session
 from httpx import ASGITransport, AsyncClient
 
 _W_OWNER = "0xAbC0000000000000000000000000000000000001"  # mixed case on purpose
@@ -39,7 +39,6 @@ def _use_tmp_db(tmp_path, monkeypatch):
     re-point them; rebind both to a per-test engine, then init_db() registers
     every table (incl. the passport side-effect imports).
     """
-    import archimedes.db as db
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
 
@@ -68,7 +67,7 @@ def _mk_strategy(
 ):
     from archimedes.models.strategy_store import StrategyRecord
 
-    with get_session() as session:
+    with db.get_session() as session:
         row = StrategyRecord(
             id=sid,
             content_hash=("0x" + sid).ljust(66, "0"),
@@ -90,7 +89,7 @@ def _mk_strategy(
 def _mk_passport(sid: str, *, with_paper_ref: bool = True):
     from archimedes.models.strategy_passport_record import PassportPaperRef, StrategyPassportRecord
 
-    with get_session() as session:
+    with db.get_session() as session:
         record = StrategyPassportRecord(
             id=sid,
             content_hash=("0y" + sid).ljust(66, "0"),
@@ -107,7 +106,7 @@ def _mk_passport(sid: str, *, with_paper_ref: bool = True):
 def _mk_backtest(sid: str):
     from archimedes.models.backtest_store import BacktestResultRecord
 
-    with get_session() as session:
+    with db.get_session() as session:
         session.add(BacktestResultRecord(strategy_id=sid, content_hash=f"bt_{sid}"))
         session.commit()
 
@@ -119,7 +118,6 @@ def test_migration_adds_ownership_columns_to_legacy_sqlite(tmp_path, monkeypatch
     """A pre-existing strategy_store WITHOUT the new columns gets them ALTERed
     in by init_db() (create_all skips existing tables, so introspection-driven
     ADD COLUMN is what covers live DBs). Second init_db() is a no-op."""
-    import archimedes.db as db
     from sqlalchemy import create_engine, inspect, text
     from sqlalchemy.orm import sessionmaker
 
@@ -161,7 +159,7 @@ def test_migration_adds_ownership_columns_to_legacy_sqlite(tmp_path, monkeypatch
 def test_upsert_strategy_persists_lowercase_owner_and_defaults_unpublished():
     from archimedes.models.strategy_store import StrategyRecord, upsert_strategy
 
-    with get_session() as session:
+    with db.get_session() as session:
         record = upsert_strategy(
             session,
             generation_method="fusion",
@@ -174,7 +172,7 @@ def test_upsert_strategy_persists_lowercase_owner_and_defaults_unpublished():
         session.commit()
         sid = record.id
 
-    with get_session() as session:
+    with db.get_session() as session:
         row = session.query(StrategyRecord).filter_by(id=sid).first()
         assert row.owner_wallet == _W_OWNER.lower()
         assert row.is_published is False
@@ -193,16 +191,16 @@ def test_upsert_backfills_ownerless_row_but_never_reassigns():
         "source_papers": [],
         "asset_universe": ["SPY"],
     }
-    with get_session() as session:
+    with db.get_session() as session:
         sid = upsert_strategy(session, **kwargs).id  # ownerless legacy row
         session.commit()
-    with get_session() as session:
+    with db.get_session() as session:
         upsert_strategy(session, **kwargs, owner_wallet=_W_OWNER)  # backfills
         session.commit()
-    with get_session() as session:
+    with db.get_session() as session:
         upsert_strategy(session, **kwargs, owner_wallet=_W_OTHER)  # must NOT steal
         session.commit()
-    with get_session() as session:
+    with db.get_session() as session:
         row = session.query(StrategyRecord).filter_by(id=sid).first()
         assert row.owner_wallet == _W_OWNER.lower()
 
@@ -246,7 +244,7 @@ async def test_run_generation_threads_owner_wallet_to_store_and_passport(monkeyp
     with patch("archimedes.agents.generation_pipeline._backtest_and_persist", new=AsyncMock()):
         await run_generation(job_id="job_own_1", brief=brief, store=store, owner_wallet=_W_OWNER)
 
-    with get_session() as session:
+    with db.get_session() as session:
         rows = session.query(StrategyRecord).filter(StrategyRecord.is_example.is_(False)).all()
         assert rows, "pipeline persisted no strategies"
         for row in rows:
@@ -342,7 +340,7 @@ async def test_rename_owner_only():
     assert owner.status_code == 200
     assert owner.json()["strategy"]["strategy_name"] == "After"  # stripped
 
-    with get_session() as session:
+    with db.get_session() as session:
         assert session.query(StrategyRecord).filter_by(id=sid).first().strategy_name == "After"
 
 
@@ -412,7 +410,7 @@ def test_purge_dry_run_is_default_and_deletes_nothing(capsys):
     assert "orphan0000000001" in out  # prints exactly what would be deleted
     assert "owned00000000001" not in out
 
-    with get_session() as session:
+    with db.get_session() as session:
         assert session.query(StrategyRecord).count() == 3  # nothing deleted
 
 
@@ -427,7 +425,7 @@ def test_purge_execute_deletes_orphans_and_cascades():
     summary = purge.purge_orphans(execute=True)
     assert summary == {"strategies": 1, "passports": 1, "backtests": 1, "executed": True}
 
-    with get_session() as session:
+    with db.get_session() as session:
         remaining = {r.id for r in session.query(StrategyRecord).all()}
         assert remaining == {"owned00000000001", "examp00000000001"}
         assert session.query(StrategyPassportRecord).filter_by(id="orphan0000000001").first() is None
@@ -444,7 +442,7 @@ def test_purge_execute_deletes_orphans_and_cascades():
 def _mk_owned_passport(sid: str, *, owner: str | None = None, generation_method: str = "fusion"):
     from archimedes.models.strategy_passport_record import StrategyPassportRecord
 
-    with get_session() as session:
+    with db.get_session() as session:
         session.add(
             StrategyPassportRecord(
                 id=sid,

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -1,0 +1,435 @@
+"""Per-user strategy ownership + private-until-published (dbrowneup/strategy-ownership).
+
+Hermetic (tmp-sqlite, no .env / network / Redis). Covers:
+  * the idempotent ownership-column migration on a pre-existing legacy DB
+  * SIWE-wallet threading: run_generation → _persist_candidate → upsert_strategy
+    (+ the strategy_passports mirror), stored lowercase
+  * /api/strategies/generated visibility: anon sees only published; owner also
+    sees their own unpublished rows
+  * GET /api/strategies/{id}: unpublished non-example rows 404 for non-owners
+  * PATCH /api/strategies/{id}: owner-gated rename, non-example rows only
+  * scripts/purge_orphan_generated.py: dry-run (default) vs --execute
+
+DB fixture copies the `_use_tmp_db` pattern from test_live_gate_returns.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from archimedes.db import get_session
+from httpx import ASGITransport, AsyncClient
+
+_W_OWNER = "0xAbC0000000000000000000000000000000000001"  # mixed case on purpose
+_W_OTHER = "0x0000000000000000000000000000000000000002"
+
+_PURGE_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "purge_orphan_generated.py"
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Point the DB at a FRESH temp sqlite (rebinds db.engine + db.SessionLocal).
+
+    db.engine/SessionLocal are created once at import, so setenv alone doesn't
+    re-point them; rebind both to a per-test engine, then init_db() registers
+    every table (incl. the passport side-effect imports).
+    """
+    import archimedes.db as db
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'ownership.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Valid signed SIWE session cookie for `wallet` (same helper shape as
+    test_user_routes.py — a real signed session, not header spoofing)."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _mk_strategy(
+    sid: str,
+    *,
+    owner: str | None = None,
+    published: bool = False,
+    example: bool = False,
+    name: str = "Test Strategy",
+):
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with get_session() as session:
+        row = StrategyRecord(
+            id=sid,
+            content_hash=("0x" + sid).ljust(66, "0"),
+            generation_method="fusion",
+            source_papers="[]",
+            strategy_name=name,
+            thesis="test thesis",
+            asset_universe="[]",
+            risk_profile="moderate",
+            status="candidate",
+            is_example=example,
+            owner_wallet=owner.lower() if owner else None,
+            is_published=published,
+        )
+        session.add(row)
+        session.commit()
+
+
+def _mk_passport(sid: str, *, with_paper_ref: bool = True):
+    from archimedes.models.strategy_passport_record import PassportPaperRef, StrategyPassportRecord
+
+    with get_session() as session:
+        record = StrategyPassportRecord(
+            id=sid,
+            content_hash=("0y" + sid).ljust(66, "0"),
+            generation_method="fusion",
+            methodology_summary="test",
+            asset_universe="[]",
+        )
+        if with_paper_ref:
+            record.paper_refs = [PassportPaperRef(passport_id=sid, arxiv_id="2401.00001", title="Paper")]
+        session.add(record)
+        session.commit()
+
+
+def _mk_backtest(sid: str):
+    from archimedes.models.backtest_store import BacktestResultRecord
+
+    with get_session() as session:
+        session.add(BacktestResultRecord(strategy_id=sid, content_hash=f"bt_{sid}"))
+        session.commit()
+
+
+# ── Migration: idempotent ensure-columns on a legacy DB ──────────────────
+
+
+def test_migration_adds_ownership_columns_to_legacy_sqlite(tmp_path, monkeypatch):
+    """A pre-existing strategy_store WITHOUT the new columns gets them ALTERed
+    in by init_db() (create_all skips existing tables, so introspection-driven
+    ADD COLUMN is what covers live DBs). Second init_db() is a no-op."""
+    import archimedes.db as db
+    from sqlalchemy import create_engine, inspect, text
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'legacy.db'}"
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    with eng.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE strategy_store ("
+                "id VARCHAR(64) PRIMARY KEY, content_hash VARCHAR(66) NOT NULL, "
+                "generation_method VARCHAR(32) NOT NULL, source_papers TEXT NOT NULL, "
+                "strategy_name VARCHAR(256) NOT NULL, thesis TEXT NOT NULL, "
+                "asset_universe TEXT NOT NULL, risk_profile VARCHAR(32) NOT NULL, "
+                "status VARCHAR(16) NOT NULL, rigor_verdict TEXT, "
+                "is_example BOOLEAN NOT NULL DEFAULT 0, "
+                "created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)"
+            )
+        )
+
+    monkeypatch.setenv("DATABASE_URL", url)
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+
+    db.init_db()
+    cols = {c["name"] for c in inspect(eng).get_columns("strategy_store")}
+    assert "owner_wallet" in cols
+    assert "is_published" in cols
+    pcols = {c["name"] for c in inspect(eng).get_columns("strategy_passports")}
+    assert "owner_wallet" in pcols
+
+    db.init_db()  # idempotent — no duplicate-column error
+    cols2 = {c["name"] for c in inspect(eng).get_columns("strategy_store")}
+    assert cols2 == cols
+
+
+# ── Wallet threading: upsert + pipeline ──────────────────────────────────
+
+
+def test_upsert_strategy_persists_lowercase_owner_and_defaults_unpublished():
+    from archimedes.models.strategy_store import StrategyRecord, upsert_strategy
+
+    with get_session() as session:
+        record = upsert_strategy(
+            session,
+            generation_method="fusion",
+            strategy_name="Owned",
+            thesis="t",
+            source_papers=[],
+            asset_universe=["SPY"],
+            owner_wallet=_W_OWNER,  # mixed case in — lowercase out
+        )
+        session.commit()
+        sid = record.id
+
+    with get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=sid).first()
+        assert row.owner_wallet == _W_OWNER.lower()
+        assert row.is_published is False
+        d = row.to_dict()
+        assert d["owner_wallet"] == _W_OWNER.lower()
+        assert d["is_published"] is False
+
+
+def test_upsert_backfills_ownerless_row_but_never_reassigns():
+    from archimedes.models.strategy_store import StrategyRecord, upsert_strategy
+
+    kwargs = {
+        "generation_method": "fusion",
+        "strategy_name": "Backfill",
+        "thesis": "t",
+        "source_papers": [],
+        "asset_universe": ["SPY"],
+    }
+    with get_session() as session:
+        sid = upsert_strategy(session, **kwargs).id  # ownerless legacy row
+        session.commit()
+    with get_session() as session:
+        upsert_strategy(session, **kwargs, owner_wallet=_W_OWNER)  # backfills
+        session.commit()
+    with get_session() as session:
+        upsert_strategy(session, **kwargs, owner_wallet=_W_OTHER)  # must NOT steal
+        session.commit()
+    with get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=sid).first()
+        assert row.owner_wallet == _W_OWNER.lower()
+
+
+class _FakeStore:
+    """In-memory JobStore stand-in (same shape as test_generation_pipeline.py)."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.status: list[tuple[str, dict | None, str]] = []
+
+    async def push_event(self, job_id, payload):
+        self.events.append(payload)
+        return len(self.events)
+
+    async def update_status(self, job_id, status, *, result=None, error=""):
+        self.status.append((status, result, error))
+
+
+async def test_run_generation_threads_owner_wallet_to_store_and_passport(monkeypatch):
+    """Fixture-path run_generation stamps the SIWE wallet (lowercased) onto every
+    persisted strategy_store row AND its strategy_passports mirror."""
+    from archimedes.agents.generation_pipeline import run_generation
+    from archimedes.api.generate_schemas import GenerateBrief
+    from archimedes.models.strategy_passport_record import StrategyPassportRecord
+    from archimedes.models.strategy_store import StrategyRecord
+
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+    # Run persists inline (not on a worker thread) — deterministic under sqlite.
+    async def _inline(fn, *a, **k):
+        return fn(*a, **k)
+
+    monkeypatch.setattr("archimedes.agents.generation_pipeline.asyncio.to_thread", _inline)
+
+    store = _FakeStore()
+    brief = GenerateBrief(intent="balanced treasuries", risk_appetite="conservative")
+
+    # Mock the network boundary (yfinance-driven multi-year backtests), not the
+    # persist path under test.
+    with patch("archimedes.agents.generation_pipeline._backtest_and_persist", new=AsyncMock()):
+        await run_generation(job_id="job_own_1", brief=brief, store=store, owner_wallet=_W_OWNER)
+
+    with get_session() as session:
+        rows = session.query(StrategyRecord).filter(StrategyRecord.is_example.is_(False)).all()
+        assert rows, "pipeline persisted no strategies"
+        for row in rows:
+            assert row.owner_wallet == _W_OWNER.lower()
+            assert row.is_published is False
+        # Passport mirror for the GENERATED candidates only (the pipeline also
+        # auto-ingests the curated library passports, which are rightly ownerless).
+        generated_ids = [row.id for row in rows]
+        passports = session.query(StrategyPassportRecord).filter(StrategyPassportRecord.id.in_(generated_ids)).all()
+        assert len(passports) == len(generated_ids), "pipeline persisted no passport mirrors"
+        for p in passports:
+            assert p.owner_wallet == _W_OWNER.lower()
+
+
+# ── Visibility: /api/strategies/generated + single GET ───────────────────
+
+
+async def test_generated_list_anon_sees_only_published():
+    _mk_strategy("pub00000000000001", owner=_W_OTHER, published=True)
+    _mk_strategy("own00000000000001", owner=_W_OWNER, published=False)
+    _mk_strategy("orp00000000000001", owner=None, published=False)  # legacy orphan
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated")
+    assert resp.status_code == 200
+    ids = {s["id"] for s in resp.json()["strategies"]}
+    assert ids == {"pub00000000000001"}
+
+
+async def test_generated_list_owner_sees_own_unpublished():
+    _mk_strategy("pub00000000000002", owner=_W_OTHER, published=True)
+    _mk_strategy("own00000000000002", owner=_W_OWNER, published=False)
+    _mk_strategy("oth00000000000002", owner=_W_OTHER, published=False)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+    assert resp.status_code == 200
+    ids = {s["id"] for s in resp.json()["strategies"]}
+    assert ids == {"pub00000000000002", "own00000000000002"}  # not the other user's private row
+
+
+async def test_detail_unpublished_404_unless_owner():
+    sid = "det00000000000001"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_passport(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = await client.get(f"/api/strategies/{sid}")
+        other = await client.get(f"/api/strategies/{sid}", cookies=_siwe_cookies(_W_OTHER))
+        owner = await client.get(f"/api/strategies/{sid}", cookies=_siwe_cookies(_W_OWNER))
+    assert anon.status_code == 404
+    assert other.status_code == 404  # 404, not 403 — existence stays hidden
+    assert owner.status_code == 200
+    assert owner.json()["id"] == sid
+
+
+async def test_detail_published_is_public():
+    sid = "det00000000000002"
+    _mk_strategy(sid, owner=_W_OWNER, published=True)
+    _mk_passport(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}")
+    assert resp.status_code == 200
+
+
+# ── Owner-gated rename ────────────────────────────────────────────────────
+
+
+async def test_rename_owner_only():
+    sid = "ren00000000000001"
+    _mk_strategy(sid, owner=_W_OWNER, published=False, name="Before")
+
+    from archimedes.main import app
+    from archimedes.models.strategy_store import StrategyRecord
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = await client.patch(f"/api/strategies/{sid}", json={"name": "After"})
+        other = await client.patch(f"/api/strategies/{sid}", json={"name": "After"}, cookies=_siwe_cookies(_W_OTHER))
+        owner = await client.patch(
+            f"/api/strategies/{sid}", json={"name": "  After  "}, cookies=_siwe_cookies(_W_OWNER)
+        )
+    assert anon.status_code == 401
+    assert other.status_code == 404  # unpublished → hidden from non-owners
+    assert owner.status_code == 200
+    assert owner.json()["strategy"]["strategy_name"] == "After"  # stripped
+
+    with get_session() as session:
+        assert session.query(StrategyRecord).filter_by(id=sid).first().strategy_name == "After"
+
+
+async def test_rename_published_non_owner_403():
+    sid = "ren00000000000002"
+    _mk_strategy(sid, owner=_W_OWNER, published=True)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.patch(f"/api/strategies/{sid}", json={"name": "Hijack"}, cookies=_siwe_cookies(_W_OTHER))
+    assert resp.status_code == 403
+
+
+async def test_rename_rejects_bad_names_and_examples():
+    sid = "ren00000000000003"
+    _mk_strategy(sid, owner=_W_OWNER)
+    ex_sid = "exa00000000000003"
+    _mk_strategy(ex_sid, owner=_W_OWNER, example=True)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        empty = await client.patch(f"/api/strategies/{sid}", json={"name": "   "}, cookies=_siwe_cookies(_W_OWNER))
+        too_long = await client.patch(
+            f"/api/strategies/{sid}", json={"name": "x" * 81}, cookies=_siwe_cookies(_W_OWNER)
+        )
+        missing = await client.patch(f"/api/strategies/{sid}", json={}, cookies=_siwe_cookies(_W_OWNER))
+        example = await client.patch(
+            f"/api/strategies/{ex_sid}", json={"name": "Nope"}, cookies=_siwe_cookies(_W_OWNER)
+        )
+    assert empty.status_code == 422
+    assert too_long.status_code == 422
+    assert missing.status_code == 422
+    assert example.status_code == 404  # curated examples are never renamable
+
+
+# ── Purge script ──────────────────────────────────────────────────────────
+
+
+def _load_purge_module():
+    spec = importlib.util.spec_from_file_location("purge_orphan_generated", _PURGE_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _purge_fixture_rows():
+    _mk_strategy("orphan0000000001", owner=None)  # orphan → purged
+    _mk_passport("orphan0000000001")
+    _mk_backtest("orphan0000000001")
+    _mk_strategy("owned00000000001", owner=_W_OWNER)  # owned → kept
+    _mk_strategy("examp00000000001", owner=None, example=True)  # curated example → kept
+
+
+def test_purge_dry_run_is_default_and_deletes_nothing(capsys):
+    from archimedes.models.strategy_store import StrategyRecord
+
+    _purge_fixture_rows()
+    purge = _load_purge_module()
+
+    summary = purge.purge_orphans()  # execute defaults to False
+    assert summary == {"strategies": 1, "passports": 1, "backtests": 1, "executed": False}
+
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "orphan0000000001" in out  # prints exactly what would be deleted
+    assert "owned00000000001" not in out
+
+    with get_session() as session:
+        assert session.query(StrategyRecord).count() == 3  # nothing deleted
+
+
+def test_purge_execute_deletes_orphans_and_cascades():
+    from archimedes.models.backtest_store import BacktestResultRecord
+    from archimedes.models.strategy_passport_record import PassportPaperRef, StrategyPassportRecord
+    from archimedes.models.strategy_store import StrategyRecord
+
+    _purge_fixture_rows()
+    purge = _load_purge_module()
+
+    summary = purge.purge_orphans(execute=True)
+    assert summary == {"strategies": 1, "passports": 1, "backtests": 1, "executed": True}
+
+    with get_session() as session:
+        remaining = {r.id for r in session.query(StrategyRecord).all()}
+        assert remaining == {"owned00000000001", "examp00000000001"}
+        assert session.query(StrategyPassportRecord).filter_by(id="orphan0000000001").first() is None
+        assert session.query(PassportPaperRef).filter_by(passport_id="orphan0000000001").count() == 0
+        assert session.query(BacktestResultRecord).filter_by(strategy_id="orphan0000000001").count() == 0

--- a/scripts/purge_orphan_generated.py
+++ b/scripts/purge_orphan_generated.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Purge ownerless generated strategies (owner_wallet IS NULL, is_example=False).
+
+Before per-user ownership landed (dbrowneup/strategy-ownership), every generated
+strategy was persisted with no owner. Those legacy rows are now invisible to
+everyone under private-until-published (not published, no owner to match), so
+they are dead weight — e.g. the ~10 orphan rejected fusion strategies in prod.
+
+What gets deleted per orphan strategy id:
+  * the ``strategy_store`` row itself
+  * its ``strategy_passports`` mirror row (same id — the generation pipeline
+    reuses the StrategyRecord id for the passport), deleted via the ORM so the
+    ``passport_paper_refs`` children cascade (relationship cascade
+    "all, delete-orphan") on BOTH sqlite and postgres
+  * its ``backtest_results`` rows (``strategy_id`` column — indexed, no FK)
+
+NOT deleted — investigated, no strategy-id relationship exists:
+  * ``strategy_proposals`` (episodic memory, T-PE.8) carries generation_id /
+    proposal_id / its own content_hash; it has NO strategy_id column and its
+    content-hash space differs from strategy_store's, so rows cannot be safely
+    matched to a strategy id. Proposals are intentionally kept as episodic
+    history of every generation attempt.
+
+DEFAULT is a dry run that prints exactly what would be deleted. Pass
+``--execute`` to perform the deletion in one transaction.
+
+Usage (from the repo root, archimedes conda env; DATABASE_URL selects the DB):
+
+    python scripts/purge_orphan_generated.py             # dry run (default)
+    python scripts/purge_orphan_generated.py --execute   # delete for real
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "backend"))
+
+
+def find_orphans(session):
+    """Generated (non-example) strategies with no owner wallet."""
+    from archimedes.models.strategy_store import StrategyRecord
+
+    return (
+        session.query(StrategyRecord)
+        .filter(
+            StrategyRecord.is_example.is_(False),
+            StrategyRecord.owner_wallet.is_(None),
+        )
+        .order_by(StrategyRecord.created_at.asc())
+        .all()
+    )
+
+
+def purge_orphans(*, execute: bool = False) -> dict:
+    """Find (and with ``execute=True`` delete) orphan generated strategies.
+
+    Returns a summary dict:
+    ``{"strategies": int, "passports": int, "backtests": int, "executed": bool}``
+    """
+    from archimedes.db import get_session, init_db
+    from archimedes.models.backtest_store import BacktestResultRecord
+    from archimedes.models.strategy_passport_record import StrategyPassportRecord
+
+    init_db()  # ensure the ownership columns exist before querying them
+
+    with get_session() as session:
+        orphans = find_orphans(session)
+        ids = [r.id for r in orphans]
+
+        passports = (
+            session.query(StrategyPassportRecord).filter(StrategyPassportRecord.id.in_(ids)).all() if ids else []
+        )
+        backtests = (
+            session.query(BacktestResultRecord).filter(BacktestResultRecord.strategy_id.in_(ids)).all() if ids else []
+        )
+        backtests_by_sid: dict[str, int] = {}
+        for b in backtests:
+            backtests_by_sid[b.strategy_id] = backtests_by_sid.get(b.strategy_id, 0) + 1
+        passport_ids = {p.id for p in passports}
+
+        mode = "EXECUTE" if execute else "DRY RUN"
+        print(f"[{mode}] orphan generated strategies (is_example=False, owner_wallet IS NULL): {len(orphans)}")
+        for r in orphans:
+            created = r.created_at.isoformat() if r.created_at else "?"
+            print(
+                f"  - {r.id}  name={r.strategy_name!r}  method={r.generation_method}  "
+                f"status={r.status}  created={created}  "
+                f"passport={'yes' if r.id in passport_ids else 'no'}  "
+                f"backtest_rows={backtests_by_sid.get(r.id, 0)}"
+            )
+        print(
+            f"[{mode}] totals: {len(orphans)} strategy_store row(s), "
+            f"{len(passports)} strategy_passports row(s) (+ their passport_paper_refs), "
+            f"{len(backtests)} backtest_results row(s). "
+            "strategy_proposals: kept (no strategy-id relationship — see module docstring)."
+        )
+
+        summary = {
+            "strategies": len(orphans),
+            "passports": len(passports),
+            "backtests": len(backtests),
+            "executed": execute,
+        }
+
+        if not execute:
+            print("Dry run — nothing deleted. Re-run with --execute to delete.")
+            session.rollback()
+            return summary
+
+        # One transaction: ORM deletes so passport_paper_refs cascade in Python
+        # (works on sqlite without PRAGMA foreign_keys and on postgres alike).
+        for p in passports:
+            session.delete(p)
+        if ids:
+            session.query(BacktestResultRecord).filter(BacktestResultRecord.strategy_id.in_(ids)).delete(
+                synchronize_session=False
+            )
+        for r in orphans:
+            session.delete(r)
+        session.commit()
+        print(f"Deleted {len(orphans)} strategies, {len(passports)} passports, {len(backtests)} backtest rows.")
+        return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Print what would be deleted without deleting (the default).",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually delete the orphan rows (one transaction).",
+    )
+    args = parser.parse_args()
+
+    purge_orphans(execute=args.execute)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/purge_orphan_generated.py
+++ b/scripts/purge_orphan_generated.py
@@ -48,6 +48,9 @@ def find_orphans(session):
         .filter(
             StrategyRecord.is_example.is_(False),
             StrategyRecord.owner_wallet.is_(None),
+            # Published rows are deliberately public — never purge them, even
+            # if ownerless (Copilot review, #850).
+            StrategyRecord.is_published.is_(False),
         )
         .order_by(StrategyRecord.created_at.asc())
         .all()
@@ -127,16 +130,13 @@ def purge_orphans(*, execute: bool = False) -> dict:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        default=True,
-        help="Print what would be deleted without deleting (the default).",
-    )
+    # Dry-run IS the default; the only switch is the explicit opt-in to delete.
+    # (A separate --dry-run flag with default=True was decorative and misleading
+    # — it changed nothing. Copilot review, #850.)
     parser.add_argument(
         "--execute",
         action="store_true",
-        help="Actually delete the orphan rows (one transaction).",
+        help="Actually delete the orphan rows (one transaction). Without this flag the script only prints what would be deleted.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

Generated strategies had no owner and every row was globally visible. The generating wallet was already captured at job start (`gate_generation` → job payload `owner_wallet`) but never reached persistence. This PR makes strategies per-user and private-until-published:

- `strategy_store.owner_wallet` (String(42), nullable, indexed, stored lowercase) + `strategy_store.is_published` (Boolean NOT NULL default false — a **dormant** flag, flipped by nothing yet). `owner_wallet` mirrored onto `strategy_passports` via a new `ingest_passport(owner_wallet=...)` kwarg (the passport-build seam in `_persist_candidate` was clean).
- **Migration:** idempotent `_ensure_ownership_columns()` in `db.init_db()` using `sqlalchemy.inspect` + plain `ADD COLUMN` — the existing patch list is Postgres-only `IF NOT EXISTS` (SQLite doesn't support it), and live SQLite files need the ALTER too. Also mirrors the `owner_wallet` index with `CREATE INDEX IF NOT EXISTS` (valid on both dialects).
- **Wallet threading:** `start_generation` → `_run_with_cleanup` → `run_generation(owner_wallet=...)` → `_persist_candidate` → `upsert_strategy`/`ingest_passport`. The legacy fusion path (`POST /api/strategies/generate` → `_run_fusion_job`) threads it through its job payload too. Always the SIWE-derived wallet — never client-supplied (same pattern as `VaultMetadata.creator_address`). On content-hash dedup, ownership is only backfilled onto ownerless rows, never reassigned.
- **Visibility:** `GET /api/strategies/generated` returns rows where `is_published` OR `owner_wallet == caller` (best-effort session read; anon sees only published). `GET /api/strategies/{id}` 404s on unpublished non-example rows unless the caller is the owner (404, not 403 — existence stays hidden). Curated examples (`GET /api/strategies/`) untouched.
- **Rename:** `PATCH /api/strategies/{id}` with `{"name": "<1..80 chars after strip>"}` — `require_verified_wallet` + owner match, non-example rows only. Generation-time `content_hash`/`provenance_hash` deliberately NOT recomputed (provenance of the original generation). `strategy_passports` carries no display-name column, so only `strategy_store` is updated.
- **Purge:** `scripts/purge_orphan_generated.py` — dry-run by default (prints exactly what would be deleted), `--execute` deletes in one transaction: orphan `strategy_store` rows (is_example=False, owner IS NULL) + `strategy_passports` mirrors (ORM delete so `passport_paper_refs` cascade on both dialects) + `backtest_results` by strategy_id. **`strategy_proposals` is kept** — investigated: it has no strategy_id column and its content-hash space differs from strategy_store's, so rows can't be safely matched to a strategy. Intended for the 10 orphan rejected fusion strategies in prod.

## Fix

Legacy ownerless generated rows become invisible to everyone under the new rules (unpublished + no owner to match) — that's intentional; the purge script removes them. Existing behavior otherwise unchanged: anonymous generation still works (persists ownerless rows), `is_published` is inert until a future publish flow.

## Verify

```bash
export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"

# New hermetic tests (migration, threading, visibility, rename, purge):
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_strategy_ownership.py -q
# → 13 passed

# Touched surfaces:
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_strategy_store.py backend/tests/test_passport_loader.py backend/tests/test_strategies_routes.py backend/tests/test_live_gate_returns.py backend/tests/services/test_generation_pipeline.py backend/tests/test_rigor_deploy_gate_contract.py backend/tests/test_engine_v2.py backend/tests/test_strategy_ownership.py -q
# → 99 passed

# Full unit suite:
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests -m "not integration" -q --deselect backend/tests/test_auth_siwe.py::test_verify_rejects_expired_nonce
# → 2160 passed, 1 deselected
# (test_verify_rejects_expired_nonce fails identically on clean origin/main —
#  pre-existing, unrelated; this branch does not touch auth_siwe.py logic.)

# Lint:
ruff format --check <changed .py files> && ruff check --select E9,F63,F7,F40 <changed files>
# → clean

# Purge script smoke (empty tmp DB):
DATABASE_URL=sqlite:///tmp_purge.db python scripts/purge_orphan_generated.py            # dry run, exit 0
DATABASE_URL=sqlite:///tmp_purge.db python scripts/purge_orphan_generated.py --execute  # exit 0
```

## Anti-goals

- SIWE auth module logic untouched (`auth_siwe.py` only imported, never edited).
- Curated examples endpoint (`GET /api/strategies/`) not gated.
- No auth requirement added to generation start (another branch's scope).
- No marketplace flow invented — `is_published` stays a dormant flag flipped by nothing.
- `generate_schemas.py` untouched (another branch edits it).
- `/api/strategies/passports*` list/detail endpoints untouched (not in scope — note for a follow-up: unpublished passports remain readable there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
