### PR TITLE
Agent-auth happy path + wallet-required generation (SIWE secure-by-default) !minor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,15 @@ RPC=
 DEV_WALLET_ADDRESS=
 DEV_WALLET_PRIVATE_KEY=
 
+# Dev-only EOA private key for the agent harness's SIWE sign-in (scripts/
+# agent_journey.py reads it from the env, never a CLI arg) — fresh TESTNET key
+# only, never commit a real value.
+AGENT_WALLET_KEY=
+
+# Dev-only Circle API key for the testnet faucet mode of scripts/
+# fund_agent_wallet.py (Bearer auth) — never commit a real value.
+CIRCLE_API_KEY=
+
 # ── Circle Developer Controlled Wallets ───────────────────────────────────
 # Used by the oracle runner to push prices on-chain via the Circle wallet
 # that owns the PriceOracle contracts (address 0xc221dC...9aC9).
@@ -144,15 +153,18 @@ INTERNAL_AGENT_API_KEY=
 
 # Gate the expensive LLM-generation endpoints (/api/generate/start,
 # /api/strategies/generate, /api/strategies/construct) behind a SIWE session.
-# Default OFF — anonymous callers pass through (today's open behavior) so a
-# verbatim `cp .env.example .env` never silently breaks the live Generate flow.
-# Flip to true ONCE the UI SIWE round-trip is confirmed end-to-end; then these
-# paid Claude/GLM endpoints return 401 without a verified-wallet session,
-# closing the IP-rotation budget-drain vector (audit 2026-06-13).
+# DEFAULT IS NOW ON (secure by default, 2026-07): with the variable UNSET the
+# backend requires a verified-wallet session (401 otherwise) and owner-scopes
+# the per-job stream/jobs/candidates reads — closing the IP-rotation
+# budget-drain vector (audit 2026-06-13 B12). Agents authenticate
+# programmatically via SIWE (see docs/agent-api.md / scripts/agent_journey.py).
+# LOCAL-DEV OPT-OUT: keep the explicit `false` below (docker compose reads this
+# file as .env) to preserve the open, wallet-less Generate flow on localhost.
+# Set to true — or simply delete the line — to run local dev with the gate on.
 REQUIRE_SIWE_FOR_GENERATION=false
 
-# Strict per-IP DAILY cap on WALLET-LESS generations (anti-abuse). The Generate
-# path is open by default (REQUIRE_SIWE_FOR_GENERATION=false) so visitors —
+# Strict per-IP DAILY cap on WALLET-LESS generations (anti-abuse). When the
+# Generate path is run open (REQUIRE_SIWE_FOR_GENERATION=false) visitors —
 # humans and agents — can try it before connecting a wallet, but an open
 # LLM-spending endpoint is a flood risk. A wallet-less caller gets this many free
 # generations per UTC day (keyed on the real client IP); past it they get a 429

--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -114,22 +114,36 @@ def require_verified_wallet(request: Request) -> str:
 def _generation_auth_required() -> bool:
     """Whether expensive LLM-generation endpoints require a SIWE session.
 
-    Off by default so enabling is an explicit, post-verification flip — gating
-    paid endpoints can never *silently* break the live Generate flow on deploy.
-    Set REQUIRE_SIWE_FOR_GENERATION=true once the UI SIWE round-trip is confirmed
-    working end-to-end (a session cookie is established before Generate is called).
+    Secure by default (flipped 2026-07-01, agent-auth slice 2): with
+    REQUIRE_SIWE_FOR_GENERATION unset, paid LLM endpoints require a verified
+    SIWE session — closing the unauthenticated budget-drain vector (audit
+    2026-06-13 B12). Opt out explicitly with REQUIRE_SIWE_FOR_GENERATION=false
+    (local dev / demo — documented in .env.example).
+
+    TESTING carve-out: the hermetic suite runs with TESTING=1 (conftest) and
+    exercises the open path throughout; when the flag is UNSET under TESTING the
+    gate stays off, mirroring how the slowapi limiter and the wallet-less quota
+    already treat TESTING. An explicit true/false always wins over the carve-out,
+    so gating-on tests simply set REQUIRE_SIWE_FOR_GENERATION=true.
     """
-    return os.getenv("REQUIRE_SIWE_FOR_GENERATION", "").strip().lower() in ("1", "true", "yes", "on")
+    raw = os.getenv("REQUIRE_SIWE_FOR_GENERATION", "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return True
+    if raw in ("0", "false", "no", "off"):
+        return False
+    # Unset/unrecognized → secure by default, except under the hermetic test env.
+    return not os.getenv("TESTING")
 
 
 def gate_generation(request: Request) -> str | None:
     """FastAPI dependency for paid LLM-generation endpoints.
 
-    When REQUIRE_SIWE_FOR_GENERATION is enabled, behaves like
-    ``require_verified_wallet`` (401 without a session). When disabled (default),
-    returns the best-effort wallet for attribution without enforcing — preserving
-    today's open behavior. This mitigates the unauthenticated-LLM budget-drain
-    vector (audit 2026-06-13) without a flag-day risk to the live demo.
+    When REQUIRE_SIWE_FOR_GENERATION is enabled (the default — see
+    ``_generation_auth_required``), behaves like ``require_verified_wallet``
+    (401 without a session). When explicitly disabled, returns the best-effort
+    wallet for attribution without enforcing — the old open behavior, kept as
+    a local-dev/demo opt-out. This closes the unauthenticated-LLM budget-drain
+    vector (audit 2026-06-13).
     """
     if _generation_auth_required():
         return require_verified_wallet(request)

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -61,6 +61,18 @@ def _register_task(job_id: str, task: asyncio.Task) -> None:
     task.add_done_callback(lambda _t, jid=job_id: _RUNNING_TASKS.pop(jid, None))
 
 
+def _require_job_auth(caller_wallet: str | None) -> None:
+    """Pre-lookup auth gate for per-job READ endpoints (gating ON only).
+
+    Must run BEFORE the job-store lookup: answering 404 (missing) vs 401
+    (exists, auth required) from a post-lookup check lets an unauthenticated
+    caller probe job_id existence. With this guard an anonymous caller gets
+    401 for every job_id — real or not — and learns nothing (Copilot, #851).
+    """
+    if _generation_auth_required() and not caller_wallet:
+        raise HTTPException(status_code=401, detail="Authentication required. Connect your wallet and sign in.")
+
+
 def _require_job_access(job: dict, caller_wallet: str | None, job_id: str) -> None:
     """Owner-scope per-job READ endpoints when SIWE-for-generation is ON.
 
@@ -189,6 +201,7 @@ async def stream_events(
     and re-subscribes on mount). Owner-scoped when SIWE-for-generation is on
     (see ``_require_job_access``); open when the gate is explicitly off.
     """
+    _require_job_auth(caller_wallet)  # 401 BEFORE the lookup — no existence oracle
     store = get_job_store()
     job = await store.get(job_id)
     if not job:
@@ -356,6 +369,7 @@ async def list_candidates(
 
     Owner-scoped when SIWE-for-generation is on (``_require_job_access``).
     """
+    _require_job_auth(caller_wallet)  # 401 BEFORE the lookup — no existence oracle
     store = get_job_store()
     job = await store.get(job_id)
     if not job:

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 
 from archimedes.agents.generation_pipeline import run_generation
-from archimedes.api.auth_siwe import gate_generation, get_verified_wallet
+from archimedes.api.auth_siwe import _generation_auth_required, gate_generation, get_verified_wallet
 from archimedes.api.funnel_middleware import record_funnel
 from archimedes.api.generate_schemas import (
     CandidatesListResponse,
@@ -59,6 +59,32 @@ _RUNNING_TASKS: dict[str, asyncio.Task] = {}
 def _register_task(job_id: str, task: asyncio.Task) -> None:
     _RUNNING_TASKS[job_id] = task
     task.add_done_callback(lambda _t, jid=job_id: _RUNNING_TASKS.pop(jid, None))
+
+
+def _require_job_access(job: dict, caller_wallet: str | None, job_id: str) -> None:
+    """Owner-scope per-job READ endpoints when SIWE-for-generation is ON.
+
+    Gating OFF (explicit local-dev opt-out) → no-op, preserving the historical
+    open behavior: anyone who knows a job_id can stream/read it.
+
+    Gating ON (secure default):
+      - no verified session → 401 (same contract as gate_generation);
+      - session wallet ≠ ``payload.owner_wallet`` → **404, not 403** — a
+        mismatched caller must not be able to confirm the job even exists
+        (existence-oracle avoidance; message identical to the not-found path);
+      - ownerless jobs (created while gating was off) stay readable by any
+        *authenticated* caller — no lock-out of pre-flip jobs, no anon leak.
+
+    Browser note: EventSource sends cookies on same-origin requests, so the
+    SSE stream authenticates exactly like fetch() does — no client change.
+    """
+    if not _generation_auth_required():
+        return
+    if not caller_wallet:
+        raise HTTPException(status_code=401, detail="Authentication required. Connect your wallet and sign in.")
+    owner_wallet = (job.get("payload") or {}).get("owner_wallet")
+    if owner_wallet and owner_wallet.lower() != caller_wallet.lower():
+        raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
 
 
 @generate_router.post("/start", response_model=GenerateStartResponse, status_code=202)
@@ -151,17 +177,23 @@ async def _run_with_cleanup(
 
 
 @generate_router.get("/stream/{job_id}")
-async def stream_events(job_id: str, request: Request) -> StreamingResponse:
+async def stream_events(
+    job_id: str,
+    request: Request,
+    caller_wallet: str | None = Depends(get_verified_wallet),
+) -> StreamingResponse:
     """Server-Sent Events. Tails the job's Redis event log.
 
     Honours ``Last-Event-ID`` for client resume after a disconnect (the spec
     calls this out — the frontend stashes ``currentJobId`` in localStorage
-    and re-subscribes on mount).
+    and re-subscribes on mount). Owner-scoped when SIWE-for-generation is on
+    (see ``_require_job_access``); open when the gate is explicitly off.
     """
     store = get_job_store()
     job = await store.get(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+    _require_job_access(job, caller_wallet, job_id)
 
     try:
         last_event_id = int(request.headers.get("Last-Event-ID", "0"))
@@ -269,8 +301,20 @@ async def cancel_job(
 
 
 @generate_router.get("/jobs", response_model=JobsListResponse)
-async def list_jobs(limit: int = Query(default=20, ge=1, le=100)) -> JobsListResponse:
-    """Recent jobs for the GenerationStatus UI."""
+async def list_jobs(
+    limit: int = Query(default=20, ge=1, le=100),
+    caller_wallet: str | None = Depends(get_verified_wallet),
+) -> JobsListResponse:
+    """Recent jobs for the GenerationStatus UI.
+
+    When SIWE-for-generation is ON the listing requires a session and is
+    filtered to the caller's own jobs (plus ownerless pre-flip jobs) — the
+    same no-existence-oracle stance as the per-job endpoints. When the gate
+    is explicitly off, the historical open listing is preserved.
+    """
+    gated = _generation_auth_required()
+    if gated and not caller_wallet:
+        raise HTTPException(status_code=401, detail="Authentication required. Connect your wallet and sign in.")
     store = get_job_store()
     raw = await store.list_recent_jobs(limit=limit)
     summaries: list[JobSummary] = []
@@ -278,6 +322,9 @@ async def list_jobs(limit: int = Query(default=20, ge=1, le=100)) -> JobsListRes
         if j.get("type") != "generate":
             continue
         payload = j.get("payload") or {}
+        owner_wallet = payload.get("owner_wallet")
+        if gated and owner_wallet and owner_wallet.lower() != (caller_wallet or "").lower():
+            continue
         brief = payload.get("brief") or {}
         result = j.get("result") or {}
         summaries.append(
@@ -301,12 +348,19 @@ def _normalize_state(s: str) -> str:
 
 
 @generate_router.get("/jobs/{job_id}/candidates", response_model=CandidatesListResponse)
-async def list_candidates(job_id: str) -> CandidatesListResponse:
-    """Rejected-candidate viewer. Empty list until ``done``."""
+async def list_candidates(
+    job_id: str,
+    caller_wallet: str | None = Depends(get_verified_wallet),
+) -> CandidatesListResponse:
+    """Rejected-candidate viewer. Empty list until ``done``.
+
+    Owner-scoped when SIWE-for-generation is on (``_require_job_access``).
+    """
     store = get_job_store()
     job = await store.get(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+    _require_job_access(job, caller_wallet, job_id)
     result = job.get("result") or {}
     cands = result.get("candidates", []) or []
     return CandidatesListResponse(

--- a/backend/archimedes/services/generation_quota.py
+++ b/backend/archimedes/services/generation_quota.py
@@ -1,9 +1,10 @@
 """Wallet-less generation quota — a strict per-IP daily cap (anti-abuse).
 
-The Generate path is intentionally **open** (`REQUIRE_SIWE_FOR_GENERATION` off) so
-visitors — humans *and* agents — can try the product before connecting a wallet
-(value-before-wallet, #787). But an open LLM-spending endpoint is a flood/abuse
-risk: an agent in a loop could hammer `/api/generate/start` and burn LLM budget.
+When the Generate path is run **open** (`REQUIRE_SIWE_FOR_GENERATION=false` — an
+explicit opt-out since the 2026-07 secure-by-default flip), visitors — humans
+*and* agents — can try the product before connecting a wallet (value-before-wallet,
+#787). But an open LLM-spending endpoint is a flood/abuse risk: an agent in a loop
+could hammer `/api/generate/start` and burn LLM budget.
 
 This module caps **wallet-less** generations to a small daily allowance per client
 IP. Authenticated (SIWE-wallet) callers bypass the cap entirely. When the cap is

--- a/backend/tests/scripts/test_agent_journey_siwe.py
+++ b/backend/tests/scripts/test_agent_journey_siwe.py
@@ -1,0 +1,122 @@
+"""SIWE message construction in the agent journey harness (#788 slice 2).
+
+Target: scripts/agent_journey.py (repo root — loaded via importlib, it isn't a
+package). Two layers:
+  1. unit — ``build_siwe_message`` embeds the exact EIP-4361 bindings the backend
+     verifier enforces (domain first-line, wallet line, Chain ID 5042002, Nonce,
+     Issued At) and ``_domain_from_base`` derives a bare authority from --base;
+  2. round-trip — a message built by the harness's builder, signed with a real
+     throwaway ``eth_account`` key, is ACCEPTED by the real ``/api/auth/verify``
+     (mirrors test_auth_siwe.py::test_verify_with_valid_signature, but through
+     the harness's code path — proving the recipe matches the verifier).
+
+Hermetic: ASGI transport, in-process nonce fallback, no network / Redis / .env.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_agent_journey():
+    """Import scripts/agent_journey.py from the repo root by file path."""
+    path = _REPO_ROOT / "scripts" / "agent_journey.py"
+    spec = importlib.util.spec_from_file_location("agent_journey", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["agent_journey"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+aj = _load_agent_journey()
+
+
+# ── Unit: message shape carries every server-enforced binding ─────────
+
+
+def test_message_embeds_domain_wallet_chain_nonce_issued_at():
+    msg = aj.build_siwe_message(
+        domain="archimedes-arc.com",
+        wallet="0x" + "ab" * 20,
+        nonce="deadbeefdeadbeefdeadbeefdeadbeef",
+        issued_at="2026-07-01T12:00:00+00:00",
+    )
+    lines = msg.split("\n")
+    # Domain binding: bare authority on the first line, EIP-4361 phrasing.
+    assert lines[0] == "archimedes-arc.com wants you to sign in with your Ethereum account:"
+    # Wallet: the first 42-char 0x line (how the verifier extracts it).
+    assert lines[1] == "0x" + "ab" * 20
+    # Chain binding: Arc testnet, exactly the id the verifier compares.
+    assert "Chain ID: 5042002" in msg
+    assert f"Chain ID: {aj.ARC_CHAIN_ID}" in msg
+    # Nonce + freshness bindings, with the exact "Key: " prefixes parsed server-side.
+    assert "Nonce: deadbeefdeadbeefdeadbeefdeadbeef" in msg
+    assert "Issued At: 2026-07-01T12:00:00+00:00" in msg
+
+
+def test_message_chain_id_override_is_respected():
+    msg = aj.build_siwe_message(domain="d.example", wallet="0x" + "cd" * 20, nonce="n1", issued_at="t", chain_id=1)
+    assert "Chain ID: 1" in msg
+    assert "Chain ID: 5042002" not in msg
+
+
+@pytest.mark.parametrize(
+    ("base", "expected"),
+    [
+        ("http://localhost:8000", "localhost:8000"),
+        ("https://archimedes-arc.com", "archimedes-arc.com"),
+        ("https://archimedes-arc.com/", "archimedes-arc.com"),
+        ("archimedes-arc.com", "archimedes-arc.com"),
+    ],
+)
+def test_domain_from_base_bare_authority(base, expected):
+    assert aj._domain_from_base(base) == expected
+
+
+# ── Round-trip: the harness recipe satisfies the real verifier ────────
+
+
+@pytest.mark.asyncio
+async def test_builder_message_accepted_by_real_verifier():
+    """nonce → build_siwe_message → sign → /api/auth/verify → authenticated.
+
+    Uses the server-advertised domain + issued_at exactly as step_auth does,
+    proving no binding (domain/chain/nonce/freshness) was weakened client-side.
+    """
+    from archimedes.main import app
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+
+    acct = Account.create()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        nonce_resp = await client.get("/api/auth/nonce")
+        assert nonce_resp.status_code == 200
+        nonce_data = nonce_resp.json()
+
+        issued_at = datetime.fromtimestamp(int(nonce_data["issued_at"]), tz=UTC).isoformat()
+        message = aj.build_siwe_message(
+            domain=nonce_data["domain"],
+            wallet=acct.address.lower(),
+            nonce=nonce_data["nonce"],
+            issued_at=issued_at,
+        )
+        signed = acct.sign_message(encode_defunct(text=message))
+
+        verify_resp = await client.post(
+            "/api/auth/verify",
+            json={"message": message, "signature": signed.signature.hex()},
+        )
+
+    assert verify_resp.status_code == 200, verify_resp.text
+    data = verify_resp.json()
+    assert data["status"] == "authenticated"
+    assert data["wallet"] == acct.address.lower()

--- a/backend/tests/test_generate_job_scoping.py
+++ b/backend/tests/test_generate_job_scoping.py
@@ -1,0 +1,211 @@
+"""Owner scoping of the generate job READ endpoints under SIWE gating (#788 slice 2).
+
+With REQUIRE_SIWE_FOR_GENERATION ON (the secure default outside TESTING), the
+per-job read surfaces — ``GET /api/generate/stream/{job_id}``, ``GET
+/api/generate/jobs`` and ``GET /api/generate/jobs/{job_id}/candidates`` — plus
+``POST /api/generate/start`` require a verified session, and per-job reads are
+scoped to the job's ``payload.owner_wallet``. A wallet mismatch returns **404**
+(indistinguishable from not-found — no existence oracle), not 403. With the gate
+explicitly OFF, the historical open behavior is preserved bit-for-bit.
+
+Hermetic: the Redis-backed job store is boundary-mocked (test_generate_cancel_scoping
+precedent); SIWE sessions are real signed cookies (test_user_routes precedent);
+the fire-and-forget pipeline is stubbed (test_model_gating precedent).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from fastapi.testclient import TestClient
+
+_OWNER = "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+_ATTACKER = "0x9999999999999999999999999999999999999999"
+_JOB_ID = "job-scope-1"
+
+
+def _cookies(wallet: str) -> dict[str, str]:
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _job(owner_wallet: str | None) -> dict:
+    return {
+        "id": _JOB_ID,
+        "type": "generate",
+        "status": "done",
+        "created_at": "2026-07-01T00:00:00+00:00",
+        "updated_at": "2026-07-01T00:00:05+00:00",
+        "payload": {"owner_wallet": owner_wallet, "brief": {"intent": "x"}, "n_candidates": 1},
+        "result": {"best_candidate_id": None, "candidates": []},
+    }
+
+
+def _mock_store(owner_wallet: str | None, *, job_exists: bool = True) -> MagicMock:
+    """Boundary-mocked job store: .get, .list_events (one terminal event so the
+    SSE generator finishes immediately), .list_recent_jobs, .enqueue."""
+    store = MagicMock()
+    store.get = AsyncMock(return_value=_job(owner_wallet) if job_exists else None)
+    store.list_events = AsyncMock(return_value=[{"id": 1, "event": "done", "data": {"job_id": _JOB_ID}}])
+    store.list_recent_jobs = AsyncMock(return_value=[_job(_OWNER.lower()), _job(_ATTACKER.lower()), _job(None)])
+    store.enqueue = AsyncMock(return_value=_JOB_ID)
+    return store
+
+
+def _patched(store: MagicMock):
+    return (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        patch("archimedes.api.generate_routes._run_with_cleanup", new=AsyncMock(return_value=None)),
+    )
+
+
+@pytest.fixture
+def gate_on(monkeypatch):
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "true")
+
+
+@pytest.fixture
+def gate_off(monkeypatch):
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "false")
+
+
+_START_BODY = {"brief": {"intent": "momentum on majors", "risk_appetite": "moderate"}, "n_candidates": 1}
+
+
+# ── Gating ON: session required everywhere ───────────────────────────
+
+
+def test_start_anonymous_401_when_gated(gate_on):
+    p1, p2 = _patched(_mock_store(None))
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_START_BODY)
+    assert resp.status_code == 401, resp.text
+
+
+def test_start_with_session_202_when_gated(gate_on):
+    store = _mock_store(None)
+    p1, p2 = _patched(store)
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_START_BODY, cookies=_cookies(_OWNER))
+    assert resp.status_code == 202, resp.text
+    # The job is tagged with the verified wallet, not a header-spoofable value.
+    assert store.enqueue.await_args.kwargs["payload"]["owner_wallet"] == _OWNER.lower()
+
+
+def test_stream_anonymous_401_when_gated(gate_on):
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/stream/{_JOB_ID}")
+    assert resp.status_code == 401, resp.text
+
+
+def test_stream_owner_can_read_when_gated(gate_on):
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/stream/{_JOB_ID}", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    assert "event: done" in resp.text
+
+
+def test_stream_mismatch_404_no_existence_oracle(gate_on):
+    """Another wallet gets a 404 whose body is IDENTICAL to a truly-missing job —
+    an attacker cannot distinguish 'exists but not mine' from 'does not exist'."""
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        mismatch = _client().get(f"/api/generate/stream/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    p1, p2 = _patched(_mock_store(None, job_exists=False))
+    with p1, p2:
+        missing = _client().get(f"/api/generate/stream/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    assert mismatch.status_code == 404, mismatch.text
+    assert missing.status_code == 404
+    assert mismatch.json()["detail"] == missing.json()["detail"]
+
+
+def test_candidates_anonymous_401_when_gated(gate_on):
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}/candidates")
+    assert resp.status_code == 401, resp.text
+
+
+def test_candidates_owner_can_read_when_gated(gate_on):
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}/candidates", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["job_id"] == _JOB_ID
+
+
+def test_candidates_mismatch_404_when_gated(gate_on):
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}/candidates", cookies=_cookies(_ATTACKER))
+    assert resp.status_code == 404, resp.text
+
+
+def test_ownerless_job_readable_by_any_authenticated_caller_when_gated(gate_on):
+    """Pre-flip jobs (owner_wallet None) stay readable by authenticated callers —
+    no lock-out, but still no anonymous access."""
+    p1, p2 = _patched(_mock_store(None))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}/candidates", cookies=_cookies(_ATTACKER))
+    assert resp.status_code == 200, resp.text
+
+
+def test_jobs_list_anonymous_401_when_gated(gate_on):
+    p1, p2 = _patched(_mock_store(None))
+    with p1, p2:
+        resp = _client().get("/api/generate/jobs")
+    assert resp.status_code == 401, resp.text
+
+
+def test_jobs_list_filtered_to_caller_when_gated(gate_on):
+    """The listing shows the caller's own jobs + ownerless ones — never another
+    wallet's job ids (that would be the existence oracle the 404 avoids)."""
+    p1, p2 = _patched(_mock_store(None))
+    with p1, p2:
+        resp = _client().get("/api/generate/jobs", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    jobs = resp.json()["jobs"]
+    assert len(jobs) == 2  # own + ownerless; the attacker-owned job is filtered out
+
+
+# ── Gating OFF (explicit opt-out): historical open behavior preserved ─
+
+
+def test_start_anonymous_202_when_open(gate_off):
+    p1, p2 = _patched(_mock_store(None))
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_START_BODY)
+    assert resp.status_code == 202, resp.text
+
+
+def test_stream_anonymous_open_when_off(gate_off):
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/stream/{_JOB_ID}")
+    assert resp.status_code == 200, resp.text
+    assert "event: done" in resp.text
+
+
+def test_candidates_anonymous_open_when_off(gate_off):
+    p1, p2 = _patched(_mock_store(_OWNER.lower()))
+    with p1, p2:
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}/candidates")
+    assert resp.status_code == 200, resp.text
+
+
+def test_jobs_list_anonymous_unfiltered_when_off(gate_off):
+    p1, p2 = _patched(_mock_store(None))
+    with p1, p2:
+        resp = _client().get("/api/generate/jobs")
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["jobs"]) == 3

--- a/backend/tests/test_generation_gating.py
+++ b/backend/tests/test_generation_gating.py
@@ -114,3 +114,25 @@ def test_gate_on_rejects_tampered_session(monkeypatch):
     client.cookies.set(_COOKIE_NAME, '{"wallet":"0xdeadbeef","iat":9999999999}|deadbeef')
     resp = client.post("/g")
     assert resp.status_code == 401
+
+
+# ── No existence oracle on per-job reads (Copilot, #851) ─────────────────────
+
+
+async def test_gated_job_reads_401_before_lookup_no_existence_oracle(monkeypatch):
+    """Gating ON + anonymous: a MISSING job must yield 401 (same as an existing
+    one), never 404 — a 404-for-missing / 401-for-existing split lets an
+    unauthenticated caller probe which job_ids exist. The auth check must run
+    before the store lookup on both the SSE stream and the candidates read."""
+    from httpx import ASGITransport, AsyncClient
+
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "true")
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for path in (
+            "/api/generate/stream/nonexistent-job-id",
+            "/api/generate/jobs/nonexistent-job-id/candidates",
+        ):
+            resp = await client.get(path)
+            assert resp.status_code == 401, f"{path}: expected 401 pre-lookup, got {resp.status_code}"

--- a/backend/tests/test_generation_gating.py
+++ b/backend/tests/test_generation_gating.py
@@ -1,15 +1,20 @@
 """Tests for the SIWE gate on expensive LLM-generation endpoints.
 
 The gate (``gate_generation``) is controlled by REQUIRE_SIWE_FOR_GENERATION and
-defaults OFF so enabling it is an explicit, post-verification flip — it can never
-silently break the live Generate flow on deploy. These tests exercise the
-dependency in isolation against a minimal app (no Redis / job store needed),
-minting a session cookie with the same in-process HMAC key the verifier uses.
+is now SECURE BY DEFAULT (2026-07 flip): with the flag unset, production requires
+a verified SIWE session. Two carve-outs keep everything else working:
+  - an explicit ``false`` opts out (local dev / demo — documented in .env.example);
+  - under TESTING (the hermetic suite, set by conftest) an UNSET flag stays off,
+    mirroring the slowapi-limiter / wallet-less-quota TESTING treatment — an
+    explicit true/false always wins over the carve-out.
+These tests exercise the dependency in isolation against a minimal app (no
+Redis / job store needed), minting a session cookie with the same in-process
+HMAC key the verifier uses.
 """
 
 import time
 
-from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session, gate_generation
+from archimedes.api.auth_siwe import _COOKIE_NAME, _generation_auth_required, _sign_session, gate_generation
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
@@ -25,11 +30,52 @@ def _make_client() -> TestClient:
 
 
 def test_gate_off_allows_anonymous(monkeypatch):
-    """Default (flag unset): anonymous callers pass through, wallet is None."""
+    """Flag unset under TESTING (conftest sets it): anonymous callers pass through."""
     monkeypatch.delenv("REQUIRE_SIWE_FOR_GENERATION", raising=False)
     resp = _make_client().post("/g")
     assert resp.status_code == 200
     assert resp.json()["wallet"] is None
+
+
+# ── The 2026-07 secure-by-default flip ──────────────────────────────
+
+
+def test_default_is_secure_outside_testing(monkeypatch):
+    """Flag unset AND no TESTING (production shape): the gate is ON — anon → 401."""
+    monkeypatch.delenv("REQUIRE_SIWE_FOR_GENERATION", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    assert _generation_auth_required() is True
+    resp = _make_client().post("/g")
+    assert resp.status_code == 401
+
+
+def test_explicit_false_opts_out_outside_testing(monkeypatch):
+    """REQUIRE_SIWE_FOR_GENERATION=false (the documented local-dev opt-out) keeps
+    the open behavior even without TESTING."""
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "false")
+    monkeypatch.delenv("TESTING", raising=False)
+    assert _generation_auth_required() is False
+    resp = _make_client().post("/g")
+    assert resp.status_code == 200
+    assert resp.json()["wallet"] is None
+
+
+def test_explicit_true_wins_over_testing_carveout(monkeypatch):
+    """An explicit true is enforced even under TESTING — gating-on tests rely on this."""
+    monkeypatch.setenv("REQUIRE_SIWE_FOR_GENERATION", "true")
+    assert _generation_auth_required() is True
+
+
+def test_default_secure_with_valid_session(monkeypatch):
+    """Production default (gate on): a valid SIWE session is accepted."""
+    monkeypatch.delenv("REQUIRE_SIWE_FOR_GENERATION", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    wallet = "0x" + "ef" * 20
+    client = _make_client()
+    client.cookies.set(_COOKIE_NAME, _sign_session(wallet, time.time()))
+    resp = client.post("/g")
+    assert resp.status_code == 200
+    assert resp.json()["wallet"] == wallet.lower()
 
 
 def test_gate_off_attributes_session_when_present(monkeypatch):

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -1,7 +1,8 @@
 # Agent API — driving the Archimedes journey programmatically
 
-> Status: slice 1 (READ + GENERATE, no signing). Tracks [issue #788](https://github.com/a-apin/archimedes/issues/788).
-> Slice 2 (agent-auth + programmatic signer for DEPLOY + MONITOR) is pending.
+> Status: slice 2 (agent-auth: programmatic SIWE + wallet-required generation).
+> Tracks [issue #788](https://github.com/a-apin/archimedes/issues/788).
+> DEPLOY + MONITOR remain pending the #588 contract-redeploy keystone.
 
 Archimedes ships one human interface: a passkey/wallet React SPA. AI agents — the
 "new citizens" of the Agora thesis — can't drive a browser passkey, so today they
@@ -16,18 +17,25 @@ Two reasons this matters:
    classified as an external agent by the telemetry middleware and its
    `generation_started` is attributed in the conversion funnel ([#787](https://github.com/a-apin/archimedes/issues/787)).
 
-The **READ** and **GENERATE** paths need **no authentication**
-(`REQUIRE_SIWE_FOR_GENERATION` is off), so slice 1 runs against prod today.
+The **READ** path needs no authentication. **GENERATE now requires a verified
+SIWE session by default** (`REQUIRE_SIWE_FOR_GENERATION` flipped to secure-by-default,
+2026-07): anonymous `POST /api/generate/start` returns 401, and the per-job
+stream/jobs/candidates reads are owner-scoped (see "Job-endpoint scoping" below).
+Agents authenticate with a programmatic EOA — no browser, no passkey.
 
 ## Quick start
 
 ```bash
-# read-only smoke (no LLM spend):
-python scripts/agent_journey.py --base https://archimedes-arc.com --read-only
+# read-only smoke (no LLM spend, no auth):
+python scripts/agent_journey.py --base https://archimedes-arc.com --read-only --no-auth
 
-# full journey (starts a real generation — Amazon Nova Micro, sub-cent):
-python scripts/agent_journey.py --base https://archimedes-arc.com \
+# full journey, authenticated with your dev key (env only — never a CLI arg):
+AGENT_WALLET_KEY=0x<fresh-testnet-key> python scripts/agent_journey.py \
+  --base https://archimedes-arc.com \
   --intent "diversified low-volatility strategy for idle USDC" --risk moderate
+
+# full journey with a throwaway in-memory wallet:
+python scripts/agent_journey.py --base https://archimedes-arc.com --ephemeral
 ```
 
 The client identifies itself with an agent `User-Agent`, so its traffic shows up
@@ -44,7 +52,7 @@ as an external agent in `/api/metrics`.
 | `GET /api/metrics/funnel` | distinct-visitor conversion funnel (`landed → generation_started → wallet_connected → vault_deployed`) with `pct_of_landed` + `step_conversion` per stage (#787). Add `?day=YYYY-MM-DD` for one day. |
 | `GET /api/strategies/` | the curated/example strategy library |
 
-### 2. GENERATE — start + stream (no wallet)
+### 2. GENERATE — start + stream (SIWE session required by default)
 
 ```http
 POST /api/generate/start
@@ -131,15 +139,88 @@ GET /api/strategies/{strategy_id}
 > fusion/debate winner reads `pass`/`fail` like any other strategy. **Never weaken
 > the gate to force a `pass` — `pending`/`fail` are honest, deployable-only-on-`pass`.**
 
-## Slice 2 (pending) — DEPLOY + MONITOR
+## Slice 2 — agent-auth (SIWE) + wallet-required generation
 
-Deploying a vault and reading it back needs a **programmatic signer** (agents
-can't do browser passkeys). The flow:
-- **Agent-auth (not a passkey):** an agent-held EOA — a testnet dev key the agent
-  controls, never a funded/mainnet key — signs the **SIWE** challenge from
-  `GET /api/auth/nonce` and posts it to `POST /api/auth/verify`, which establishes
-  the session cookie.
-- **Deploy:** with that session, call the wallet-gated `POST /api/vaults/create`.
+### The SIWE recipe (EIP-4361, programmatic EOA)
+
+The backend is fully programmatic-EOA compatible — no browser, no passkey. The
+reference implementation is `step_auth`/`build_siwe_message` in
+[`scripts/agent_journey.py`](../scripts/agent_journey.py) (mirrors the backend
+test `test_auth_siwe.py::test_verify_with_valid_signature`). Exact calls:
+
+1. **Challenge** — `GET /api/auth/nonce` →
+   `{ "nonce": "...", "domain": "archimedes-arc.com", "issued_at": <epoch>, "expiry_seconds": 300 }`.
+   Use the **server-advertised `domain`** (the verifier binds on its
+   `PUBLIC_DOMAIN`) and convert `issued_at` to ISO-8601 UTC.
+2. **Message** — build the EIP-4361 text. Every binding is REQUIRED and enforced
+   server-side (domain match, `Chain ID: 5042002`, live single-use nonce,
+   `Issued At` fresh within 5 minutes):
+
+   ```
+   {domain} wants you to sign in with your Ethereum account:
+   {wallet}
+
+   Sign in to Archimedes.
+
+   URI: https://{domain}
+   Version: 1
+   Chain ID: 5042002
+   Nonce: {nonce}
+   Issued At: {issued_at ISO-8601}
+   ```
+3. **Sign** — `eth_account`: `Account.sign_message(encode_defunct(text=message))`.
+4. **Verify** — `POST /api/auth/verify` with `{"message": ..., "signature": "0x..."}`
+   → 200 `{ "status": "authenticated", "wallet": "0x...", "expires_in": 86400 }`
+   and a `Set-Cookie: archimedes_session=...` (HttpOnly, Secure, SameSite=Strict).
+   Keep the cookie on your HTTP client; it authenticates everything below.
+5. **Check** — `GET /api/auth/session` → `{ "authenticated": true, "wallet": "0x..." }`.
+
+Key handling: the harness reads the private key ONLY from the
+`AGENT_WALLET_KEY` env var (never a CLI arg, never logged), or mints a
+throwaway with `--ephemeral`. Fresh testnet keys only.
+
+### Wallet-required generation (secure by default)
+
+`REQUIRE_SIWE_FOR_GENERATION` now defaults **ON** when unset: the paid LLM
+endpoints (`POST /api/generate/start`, `/api/strategies/generate`,
+`/api/strategies/construct`, the AI vault-chat branch) return 401 without a
+verified session. Local-dev opt-out: `REQUIRE_SIWE_FOR_GENERATION=false` in
+`.env` (docker compose passes it through; `.env.example` documents it).
+
+### Job-endpoint scoping (when the gate is ON)
+
+Jobs are tagged with their creator (`payload.owner_wallet`). With gating on:
+
+| Endpoint | Rule |
+| --- | --- |
+| `GET /api/generate/stream/{job_id}` | session required (401); wallet must match the job owner — mismatch → **404** (no existence oracle) |
+| `GET /api/generate/jobs` | session required (401); listing filtered to the caller's own jobs (+ ownerless pre-flip jobs) |
+| `GET /api/generate/jobs/{job_id}/candidates` | same owner rule as the stream — mismatch → **404** |
+| `POST /api/generate/jobs/{job_id}/cancel` | owner-scoped since the 2026-06-14 audit (403 on mismatch) |
+
+Ownerless jobs (created while gating was off) stay readable by any
+*authenticated* caller. With gating explicitly OFF, all of the above preserve
+the historical open behavior. Browser `EventSource` sends cookies on
+same-origin requests, so the SSE stream authenticates without client changes.
+
+### Funding an agent wallet (USDC is gas on Arc)
+
+An agent EOA needs native USDC before it can DEPLOY (chain 5042002 uses USDC as
+gas). Two options via [`scripts/fund_agent_wallet.py`](../scripts/fund_agent_wallet.py)
+(dry-run by default; `--execute` to send):
+
+```bash
+# a) treasury transfer — native-USDC value transfer from DEV_WALLET_PRIVATE_KEY (.env):
+python scripts/fund_agent_wallet.py --to 0x<agent-wallet> --amount 5 --execute
+
+# b) Circle faucet API (Bearer $CIRCLE_API_KEY). The Arc blockchain enum is
+#    UNVERIFIED — the raw response is printed so the right value can be learned:
+python scripts/fund_agent_wallet.py --to 0x<agent-wallet> --mode faucet --execute
+```
+
+### Still pending — DEPLOY + MONITOR
+
+- **Deploy:** with the SIWE session, call the wallet-gated `POST /api/vaults/create`.
 - **Monitor:** read the vault back via `GET /api/vaults/{address}/health`.
 
 Tracked in [#788](https://github.com/a-apin/archimedes/issues/788). Do not land any

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -151,6 +151,12 @@ def step_auth(client: httpx.Client, base: str, *, ephemeral: bool) -> str | None
     # plain client cookie so the authenticated journey works on http too. The
     # server is untouched — this is purely harness-side cookie plumbing.
     if urlsplit(base).scheme == "http":
+        host = (urlsplit(base).hostname or "").lower()
+        if host not in {"localhost", "127.0.0.1", "::1"}:
+            # Downgrading a Secure cookie over non-local plain HTTP would send
+            # the session token in cleartext across a real network — refuse.
+            print(f"  ✗ refusing to send the session cookie over http to non-local host {host!r}; use https")
+            return None
         token = r.cookies.get(_SESSION_COOKIE)
         if token:
             client.cookies.set(_SESSION_COOKIE, token)

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -14,14 +14,24 @@ Two payoffs, immediately:
      agent User-Agent, so the telemetry classifier counts it as an external agent
      and the conversion funnel (#787) attributes its ``generation_started``.
 
-The READ + GENERATE paths need NO signing (``REQUIRE_SIWE_FOR_GENERATION`` is off),
-so this slice runs today. DEPLOY + MONITOR (which need a programmatic signer, since
-agents can't do browser passkeys) are slice 2 — see issue #788.
+Slice 2 (this revision) adds **agent-auth**: a programmatic EOA signs the SIWE
+(EIP-4361) challenge from ``GET /api/auth/nonce`` and posts it to
+``POST /api/auth/verify``, establishing the same session cookie the browser gets.
+With ``REQUIRE_SIWE_FOR_GENERATION`` now defaulting ON server-side, the GENERATE
+path (and the per-job stream/candidates reads, which are owner-scoped under the
+gate) requires this session; READ stays public.
+
+Key handling: the private key comes ONLY from the ``AGENT_WALLET_KEY`` env var
+(never a CLI arg, never printed/logged), or ``--ephemeral`` mints a throwaway
+in-memory key via ``eth_account.Account.create()``. Use a fresh TESTNET dev key —
+never a funded/mainnet key.
 
 Usage:
     python scripts/agent_journey.py --base https://archimedes-arc.com
+    AGENT_WALLET_KEY=0x... python scripts/agent_journey.py            # auth auto-on
+    python scripts/agent_journey.py --ephemeral                       # throwaway wallet
+    python scripts/agent_journey.py --no-auth --read-only             # anon read smoke
     python scripts/agent_journey.py --base http://localhost:8000 --intent "low-vol momentum"
-    python scripts/agent_journey.py --read-only          # skip generation (cheap smoke)
 
 Exit code is nonzero if a hard step fails, so this doubles as a journey smoke test.
 """
@@ -29,8 +39,11 @@ Exit code is nonzero if a hard step fails, so this doubles as a journey smoke te
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
+from datetime import UTC, datetime
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -40,6 +53,115 @@ AGENT_UA = "archimedes-agent-journey/0.1 (+https://github.com/a-apin/archimedes/
 
 # Terminal SSE event names from api/generate_schemas.py::EventName.
 _TERMINAL_EVENTS = {"done", "error"}
+
+# SIWE constants — must match the backend bindings (api/auth_siwe.py): the
+# verifier REQUIRES domain + chain-id + fresh Issued At, and rejects mismatches.
+ARC_CHAIN_ID = 5042002  # Arc testnet (0x4cef52)
+_SESSION_COOKIE = "archimedes_session"
+_KEY_ENV = "AGENT_WALLET_KEY"  # the ONLY source for a persistent key — never a CLI arg
+
+
+def build_siwe_message(
+    domain: str,
+    wallet: str,
+    nonce: str,
+    issued_at: str,
+    chain_id: int = ARC_CHAIN_ID,
+    statement: str = "Sign in to Archimedes.",
+) -> str:
+    """Build an EIP-4361 (SIWE) message the backend verifier accepts.
+
+    Mirrors backend/tests/test_auth_siwe.py::test_verify_with_valid_signature —
+    the reference programmatic recipe. The backend binds on: the domain in the
+    first line (must equal its PUBLIC_DOMAIN), ``Chain ID:`` (must be Arc's
+    5042002), ``Nonce:`` (live, single-use), and ``Issued At:`` (fresh within
+    5 min). The wallet is the first 42-char 0x line.
+    """
+    return (
+        f"{domain} wants you to sign in with your Ethereum account:\n"
+        f"{wallet}\n\n"
+        f"{statement}\n\n"
+        f"URI: https://{domain}\n"
+        f"Version: 1\n"
+        f"Chain ID: {chain_id}\n"
+        f"Nonce: {nonce}\n"
+        f"Issued At: {issued_at}"
+    )
+
+
+def _domain_from_base(base: str) -> str:
+    """Bare authority from a --base URL (scheme/path stripped) — SIWE domain shape."""
+    parts = urlsplit(base if "://" in base else f"https://{base}")
+    return (parts.netloc or parts.path).rstrip("/")
+
+
+def step_auth(client: httpx.Client, base: str, *, ephemeral: bool) -> str | None:
+    """SIWE sign-in with a programmatic EOA. Returns the wallet address, or None.
+
+    nonce + issued_at come from ``GET /api/auth/nonce``; the domain is the one
+    the server advertises in that same response (its PUBLIC_DOMAIN — the value
+    the verifier binds on), falling back to the --base host if absent. Using the
+    server-advertised domain keeps the harness working against localhost dev,
+    where PUBLIC_DOMAIN and the --base host differ; the server still enforces
+    every binding, so nothing is weakened client-side.
+    """
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+
+    _hr("AUTH — SIWE (EIP-4361) with a programmatic EOA")
+
+    if ephemeral:
+        acct = Account.create()
+        print("  · ephemeral wallet (throwaway key, in-memory only)")
+    else:
+        key = os.environ.get(_KEY_ENV, "").strip()
+        if not key:
+            print(f"  ✗ {_KEY_ENV} not set (and --ephemeral not given) — cannot authenticate")
+            return None
+        try:
+            acct = Account.from_key(key)
+        except (ValueError, TypeError):
+            # Never echo the key material — not even in the error path.
+            print(f"  ✗ {_KEY_ENV} is not a valid private key")
+            return None
+    wallet = acct.address
+    print(f"  · wallet address: {wallet}")
+
+    nonce_data = _get(client, "/api/auth/nonce")
+    if not isinstance(nonce_data, dict) or "nonce" not in nonce_data:
+        print("  ✗ /api/auth/nonce — unusable response; cannot authenticate")
+        return None
+    domain = nonce_data.get("domain") or _domain_from_base(base)
+    issued_at = datetime.fromtimestamp(int(nonce_data.get("issued_at", time.time())), tz=UTC).isoformat()
+
+    message = build_siwe_message(domain=domain, wallet=wallet.lower(), nonce=nonce_data["nonce"], issued_at=issued_at)
+    signed = acct.sign_message(encode_defunct(text=message))
+
+    try:
+        r = client.post("/api/auth/verify", json={"message": message, "signature": signed.signature.hex()})
+    except httpx.HTTPError as exc:
+        print(f"  ✗ POST /api/auth/verify — transport error: {exc}")
+        return None
+    if r.status_code != 200:
+        print(f"  ✗ POST /api/auth/verify — HTTP {r.status_code}: {r.text[:200]}")
+        return None
+
+    # The session cookie is flagged Secure; over a plain-http --base (local dev)
+    # the stdlib cookie policy would store but never SEND it. Re-set it as a
+    # plain client cookie so the authenticated journey works on http too. The
+    # server is untouched — this is purely harness-side cookie plumbing.
+    if urlsplit(base).scheme == "http":
+        token = r.cookies.get(_SESSION_COOKIE)
+        if token:
+            client.cookies.set(_SESSION_COOKIE, token)
+
+    session = _get(client, "/api/auth/session")
+    authenticated = isinstance(session, dict) and session.get("authenticated") is True
+    print(f"  ✓ authenticated as {r.json().get('wallet')}  (session check: {authenticated})")
+    if not authenticated:
+        print("  ✗ session cookie did not round-trip — continuing unauthenticated")
+        return None
+    return wallet
 
 
 def _hr(title: str) -> None:
@@ -110,7 +232,7 @@ def step_generate(client: httpx.Client, intent: str, risk: str, timeout_s: float
     deadline check never runs, so the harness can hang until the process is killed. Acceptable
     for a dogfooding harness; a production client should add a wall-clock watchdog / cancel.
     """
-    _hr("GENERATE — start + stream (no wallet)")
+    _hr("GENERATE — start + stream (session cookie if authenticated)")
 
     body = {
         "brief": {"intent": intent, "risk_appetite": risk, "max_papers": 5},
@@ -241,11 +363,36 @@ def main() -> int:
     )
     ap.add_argument("--read-only", action="store_true", help="skip generation (cheap smoke test)")
     ap.add_argument("--timeout", type=float, default=120.0, help="generation stream timeout (s)")
+    ap.add_argument(
+        "--auth",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=f"SIWE sign-in with the EOA key from ${_KEY_ENV} (env only — never a CLI arg). "
+        f"Default: on when ${_KEY_ENV} is set; --no-auth forces anonymous.",
+    )
+    ap.add_argument(
+        "--ephemeral",
+        action="store_true",
+        help="mint a throwaway in-memory wallet (Account.create()) and SIWE-auth with it; implies --auth",
+    )
     args = ap.parse_args()
+
+    # Auth resolution: --ephemeral implies auth; otherwise --auth/--no-auth wins;
+    # otherwise auto — on exactly when the key env var is present.
+    want_auth = args.ephemeral or (args.auth if args.auth is not None else bool(os.environ.get(_KEY_ENV)))
 
     print(f"Archimedes agent journey → {args.base}")
     client = httpx.Client(base_url=args.base, headers={"User-Agent": AGENT_UA}, timeout=30.0, follow_redirects=True)
+    wallet: str | None = None
     try:
+        if want_auth:
+            wallet = step_auth(client, args.base, ephemeral=args.ephemeral)
+            if wallet is None and not args.read_only:
+                # With the server's secure-by-default generation gate, an unauthenticated
+                # generate would just 401 — fail loudly here instead.
+                print("\nRESULT: SIWE auth failed and generation requires it — aborting.")
+                return 2
+        print(f"\n  auth status: {'authenticated as ' + wallet if wallet else 'anonymous'}")
         step_read(client)
         if args.read_only:
             print("\n(read-only — skipping generation)")

--- a/scripts/fund_agent_wallet.py
+++ b/scripts/fund_agent_wallet.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Fund an agent wallet with native USDC on Arc testnet (#788 slice 2).
+
+Agent EOAs created for SIWE auth (see scripts/agent_journey.py) start empty; to
+DEPLOY they need gas — and on Arc, **USDC IS the gas token** (chain 5042002).
+Two funding modes:
+
+  treasury (default)
+      A plain native-value transfer from the dev treasury wallet
+      (``DEV_WALLET_PRIVATE_KEY`` from your .env — never a CLI arg, never
+      printed) to ``--to``. Implemented with eth_account signing + raw JSON-RPC
+      over httpx (both already backend deps — no web3 provider needed). The RPC
+      URL comes from ``--rpc``, else ``$RPC`` (arc-canteen), else
+      ``$ARC_ARC_RPC_URL``. Native value is denominated in wei-style 18-decimal
+      units at the RPC level (repo precedent: chain/executor.py,
+      bootstrap_vaults.py); ``--decimals`` is the escape hatch if Arc ever
+      reads differently.
+
+  faucet
+      POST https://api.circle.com/v1/faucet/drips with ``Bearer $CIRCLE_API_KEY``
+      and body ``{"address": ..., "blockchain": <--blockchain>, "usdc": true}``.
+      CAVEAT: the exact Circle blockchain enum for Arc testnet is UNVERIFIED —
+      ``--blockchain`` defaults to ``ARC-TESTNET`` and the script prints the RAW
+      API response so the right enum can be learned empirically (a 400 naming
+      valid enums is useful output, not a bug).
+
+SAFETY: dry-run by default — prints exactly what would happen; add ``--execute``
+to actually send. Testnet only; never point this at a funded/mainnet key.
+
+Usage:
+    python scripts/fund_agent_wallet.py --to 0xAbc... --amount 5            # dry-run
+    python scripts/fund_agent_wallet.py --to 0xAbc... --amount 5 --execute  # send
+    python scripts/fund_agent_wallet.py --to 0xAbc... --mode faucet --execute
+    python scripts/fund_agent_wallet.py --to 0xAbc... --mode faucet --blockchain ARC-SEPOLIA --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import httpx
+
+ARC_CHAIN_ID = 5042002  # Arc testnet (0x4cef52)
+CIRCLE_FAUCET_URL = "https://api.circle.com/v1/faucet/drips"
+_RECEIPT_POLL_SECONDS = 2.0
+_RECEIPT_POLL_ATTEMPTS = 15
+
+
+def _load_dotenv_if_available() -> None:
+    """Pick up the repo .env (DEV_WALLET_PRIVATE_KEY, RPC, CIRCLE_API_KEY) when
+    python-dotenv is installed (it's a backend dep). Existing env vars win."""
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+
+
+def _rpc_call(client: httpx.Client, url: str, method: str, params: list) -> object:
+    """One JSON-RPC call; raises RuntimeError on a JSON-RPC error response."""
+    resp = client.post(url, json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+    resp.raise_for_status()
+    body = resp.json()
+    if "error" in body:
+        raise RuntimeError(f"{method} → RPC error: {body['error']}")
+    return body.get("result")
+
+
+def fund_via_treasury(to: str, amount: float, rpc: str, decimals: int, execute: bool) -> int:
+    """Native-USDC value transfer from the DEV_WALLET_PRIVATE_KEY treasury."""
+    from eth_account import Account
+
+    key = os.environ.get("DEV_WALLET_PRIVATE_KEY", "").strip()
+    if not key:
+        print("✗ DEV_WALLET_PRIVATE_KEY not set (fill it in .env — testnet dev wallet only).")
+        return 2
+    try:
+        acct = Account.from_key(key)
+    except (ValueError, TypeError):
+        print("✗ DEV_WALLET_PRIVATE_KEY is not a valid private key.")  # never echo the value
+        return 2
+
+    value = int(amount * 10**decimals)
+    print(f"treasury transfer plan (chain {ARC_CHAIN_ID}, native USDC = gas):")
+    print(f"  from:    {acct.address}")
+    print(f"  to:      {to}")
+    print(f"  amount:  {amount} USDC  (value={value} @ 10^{decimals})")
+    print(f"  rpc:     {rpc}")
+
+    with httpx.Client(timeout=30.0) as client:
+        chain_id = int(str(_rpc_call(client, rpc, "eth_chainId", [])), 16)
+        if chain_id != ARC_CHAIN_ID:
+            print(f"✗ RPC reports chain id {chain_id}, expected Arc testnet {ARC_CHAIN_ID} — refusing.")
+            return 2
+        balance = int(str(_rpc_call(client, rpc, "eth_getBalance", [acct.address, "latest"])), 16)
+        nonce = int(str(_rpc_call(client, rpc, "eth_getTransactionCount", [acct.address, "pending"])), 16)
+        gas_price = int(str(_rpc_call(client, rpc, "eth_gasPrice", [])), 16)
+        print(f"  treasury balance: {balance / 10**decimals:.6f} USDC   nonce: {nonce}   gasPrice: {gas_price}")
+
+        tx = {
+            "to": to,
+            "value": value,
+            "gas": 21_000,  # plain value transfer
+            "gasPrice": gas_price,
+            "nonce": nonce,
+            "chainId": ARC_CHAIN_ID,
+        }
+        if balance < value + 21_000 * gas_price:
+            print("✗ treasury balance is insufficient for amount + gas.")
+            return 2
+
+        if not execute:
+            print("\nDRY RUN — no transaction sent. Re-run with --execute to send.")
+            return 0
+
+        signed = Account.sign_transaction(tx, key)
+        tx_hash = _rpc_call(
+            client, rpc, "eth_sendRawTransaction", ["0x" + signed.raw_transaction.hex().removeprefix("0x")]
+        )
+        print(f"  → sent: {tx_hash}")
+
+        for _ in range(_RECEIPT_POLL_ATTEMPTS):
+            receipt = _rpc_call(client, rpc, "eth_getTransactionReceipt", [tx_hash])
+            if isinstance(receipt, dict):
+                status = int(str(receipt.get("status", "0x0")), 16)
+                print(
+                    f"  → receipt: status={'success' if status == 1 else 'FAILED'} block={receipt.get('blockNumber')}"
+                )
+                return 0 if status == 1 else 1
+            time.sleep(_RECEIPT_POLL_SECONDS)
+        print("  · no receipt yet (still pending) — check the explorer for the tx hash above.")
+        return 0
+
+
+def fund_via_faucet(to: str, blockchain: str, execute: bool) -> int:
+    """Request testnet USDC from the Circle faucet API. Prints the RAW response
+    so the correct Arc blockchain enum can be learned empirically."""
+    api_key = os.environ.get("CIRCLE_API_KEY", "").strip()
+    body = {"address": to, "blockchain": blockchain, "usdc": True}
+    print("Circle faucet request plan:")
+    print(f"  POST {CIRCLE_FAUCET_URL}")
+    print(f"  body: {json.dumps(body)}")
+    print(f"  auth: Bearer $CIRCLE_API_KEY ({'set' if api_key else 'NOT SET'})")
+    print("  note: blockchain enum for Arc is UNVERIFIED — default ARC-TESTNET; adjust with --blockchain")
+
+    if not execute:
+        print("\nDRY RUN — no request sent. Re-run with --execute to send.")
+        return 0
+    if not api_key:
+        print("✗ CIRCLE_API_KEY not set — cannot call the faucet.")
+        return 2
+
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.post(CIRCLE_FAUCET_URL, json=body, headers={"Authorization": f"Bearer {api_key}"})
+    # Print the raw response verbatim: on an enum mismatch Circle's error names
+    # the valid values — exactly the empirical signal we're after.
+    print(f"\nRAW response — HTTP {resp.status_code}:")
+    print(resp.text)
+    return 0 if resp.status_code < 300 else 1
+
+
+def main() -> int:
+    _load_dotenv_if_available()
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--to", required=True, help="target wallet address (0x...)")
+    ap.add_argument("--amount", type=float, default=5.0, help="USDC amount for treasury mode (default 5)")
+    ap.add_argument(
+        "--mode", choices=["treasury", "faucet"], default="treasury", help="funding source (default treasury)"
+    )
+    ap.add_argument("--rpc", default=None, help="Arc RPC URL (default: $RPC, then $ARC_ARC_RPC_URL)")
+    ap.add_argument(
+        "--decimals", type=int, default=18, help="native value decimals at the RPC level (default 18, repo precedent)"
+    )
+    ap.add_argument(
+        "--blockchain",
+        default="ARC-TESTNET",
+        help="Circle faucet blockchain enum (faucet mode). The Arc enum is UNVERIFIED — "
+        "the raw API response is printed so the right value can be learned empirically.",
+    )
+    ap.add_argument("--execute", action="store_true", help="actually send (default is dry-run)")
+    args = ap.parse_args()
+
+    if not (args.to.startswith("0x") and len(args.to) == 42):
+        print(f"✗ --to does not look like an EVM address: {args.to!r}")
+        return 2
+
+    if args.mode == "faucet":
+        return fund_via_faucet(args.to, args.blockchain, args.execute)
+
+    rpc = args.rpc or os.environ.get("RPC") or os.environ.get("ARC_ARC_RPC_URL", "")
+    if not rpc:
+        print("✗ no RPC URL — pass --rpc or set RPC in .env (from `arc-canteen login`).")
+        return 2
+    return fund_via_treasury(args.to, args.amount, rpc, args.decimals, args.execute)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fund_agent_wallet.py
+++ b/scripts/fund_agent_wallet.py
@@ -42,6 +42,8 @@ import os
 import sys
 import time
 
+from decimal import ROUND_DOWN, Decimal
+
 import httpx
 
 ARC_CHAIN_ID = 5042002  # Arc testnet (0x4cef52)
@@ -58,7 +60,9 @@ def _load_dotenv_if_available() -> None:
 
         load_dotenv()
     except ImportError:
-        pass
+        # Optional convenience only: without python-dotenv the caller simply
+        # exports the env vars themselves — nothing to do here.
+        return
 
 
 def _rpc_call(client: httpx.Client, url: str, method: str, params: list) -> object:
@@ -85,7 +89,10 @@ def fund_via_treasury(to: str, amount: float, rpc: str, decimals: int, execute: 
         print("✗ DEV_WALLET_PRIVATE_KEY is not a valid private key.")  # never echo the value
         return 2
 
-    value = int(amount * 10**decimals)
+    # Decimal, not binary float: int(0.1 * 10**6) style truncation silently
+    # under/over-funds on-chain amounts (Copilot, #851). The CLI string parses
+    # exactly; quantize to whole base units.
+    value = int((Decimal(str(amount)) * (10**decimals)).to_integral_value(rounding=ROUND_DOWN))
     print(f"treasury transfer plan (chain {ARC_CHAIN_ID}, native USDC = gas):")
     print(f"  from:    {acct.address}")
     print(f"  to:      {to}")


### PR DESCRIPTION
## Summary

Slice 2 of the agent-facing path (#788): agents can now **authenticate with a programmatic EOA via SIWE** and run the journey wallet-first — and the paid generation surface is **secure by default**.

1. **`scripts/agent_journey.py` — SIWE auth.** `--auth` (auto-on when `AGENT_WALLET_KEY` is set; env-only, never a CLI arg, never logged) or `--ephemeral` (throwaway `Account.create()`). Builds a full EIP-4361 message (server-advertised domain, chain `5042002`, nonce + issued_at from `/api/auth/nonce`), signs with `eth_account`, posts to `/api/auth/verify`, keeps the `archimedes_session` cookie, and prints wallet + auth status.
2. **`REQUIRE_SIWE_FOR_GENERATION` default flipped to ON** (`auth_siwe.py`). Explicit `false` = local-dev opt-out (documented in `.env.example`; compose passes `.env` through). Unset-under-`TESTING` stays off — the same carve-out the slowapi limiter and wallet-less quota already use — so the hermetic suite (2173 tests) passes unchanged; an explicit value always wins.
3. **Job-endpoint owner scoping** (`generate_routes.py`). Gate ON: `stream/{job_id}` + `jobs/{id}/candidates` require a session and return **404 on wallet mismatch** (body identical to not-found — no existence oracle); `GET /jobs` requires a session and filters to the caller's own + ownerless jobs. Gate OFF: historical open behavior preserved bit-for-bit. Ownerless (pre-flip) jobs stay readable by any authenticated caller.
4. **`scripts/fund_agent_wallet.py`** — dry-run-by-default funding: (a) treasury native-USDC value transfer from `DEV_WALLET_PRIVATE_KEY` (eth_account + raw JSON-RPC via httpx — no new deps); (b) Circle faucet mode (`Bearer $CIRCLE_API_KEY`), `--blockchain` defaulting to the **UNVERIFIED** `ARC-TESTNET` enum with the raw API response printed so the right value is learned empirically.
5. **Docs**: `docs/agent-api.md` slice-2 rewrite (exact SIWE recipe, gating, scoping table, funding); `.env.example` gains `AGENT_WALLET_KEY` + `CIRCLE_API_KEY` (dev-only).

## Fix

- `backend/archimedes/api/auth_siwe.py` — `_generation_auth_required()` secure default + TESTING carve-out; `gate_generation` docstring.
- `backend/archimedes/api/generate_routes.py` — `_require_job_access()` helper; `get_verified_wallet` deps on stream/jobs/candidates; owner filtering on `/jobs`.
- `scripts/agent_journey.py`, `scripts/fund_agent_wallet.py`, `.env.example`, `docs/agent-api.md`, `backend/archimedes/services/generation_quota.py` (docstring only).
- Tests: `backend/tests/test_generate_job_scoping.py` (new, 16 cases), `backend/tests/scripts/test_agent_journey_siwe.py` (new — message-builder unit + round-trip through the REAL `/api/auth/verify`), `backend/tests/test_generation_gating.py` (default-flip cases).

## Verify

```bash
export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_generation_gating.py backend/tests/test_generate_job_scoping.py \
  backend/tests/scripts/test_agent_journey_siwe.py -q
# → 31 passed, 0 failed
ruff format --check . && ruff check --select E9,F63,F7,F40 .
# → "382 files already formatted" / "All checks passed!"
# live smoke (after deploy): throwaway wallet, full authed journey:
python scripts/agent_journey.py --base https://archimedes-arc.com --ephemeral --read-only
```

Full suite: `2173 passed, 1 failed` — the one failure is `test_auth_siwe.py::test_verify_rejects_expired_nonce`, **pre-existing on unmodified `main`** on machines with a live local Redis on :6379 (the test assumes the Redis-down in-process fallback); passes in CI where no Redis runs.

## Deploy note (build-on-deploy)

Prod's `.env` does not set `REQUIRE_SIWE_FOR_GENERATION`, so merging this **turns the gate ON in prod**: anonymous Generate → 401, and the UI must have a SIWE session before Generate (the UI SIWE round-trip is live; agents use the recipe in `docs/agent-api.md`). To stage the flip instead, add `REQUIRE_SIWE_FOR_GENERATION=false` to the prod `.env` before merging.

## Anti-goals (respected)

- No SIWE binding weakened (domain/chain/freshness untouched; round-trip test proves the client recipe satisfies the unmodified verifier).
- No changes to `strategy_store` / ownership columns (other branch).
- No new top-level deps (eth-account, httpx, python-dotenv all pre-existing).
- No real keys anywhere; keys are env-only and never logged.
- `docker-compose*.yml` and CI workflows untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M