### PR TITLE
[strategy] Fusion spec-repair retry + thesis-true universes + friendly brief errors !minor

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -202,6 +202,23 @@ def _parse_validation_json(raw: str) -> dict[str, Any] | None:
         return None
 
 
+def _invalid_brief_message(reason: object) -> str:
+    """Frame a validator rejection as guidance, never as a bare category label.
+
+    Lives in the ORCHESTRATOR (brief validation runs before pipeline dispatch),
+    so the debate-society cutover keeps this path. The validator LLM can return
+    a terse ``reason`` like "gibberish" — surfacing that verbatim reads as an
+    insult with zero direction (a user typing "test" saw ``Error — gibberish``).
+    Keep the honest reason, wrap it in what-to-do-instead.
+    """
+    raw = str(reason or "it did not describe an investment goal").strip().rstrip(".")
+    return (
+        f"We couldn't turn that into an investment brief ({raw}). "
+        "Describe what you want from a portfolio in a sentence — e.g. "
+        '"diversified low-volatility strategy for idle USDC".'
+    )
+
+
 async def _validate_brief(brief: GenerateBrief) -> dict[str, Any]:
     """Call the LLM to validate the brief.
 
@@ -1078,8 +1095,8 @@ async def run_generation(
             # offering a "regenerate" CTA with the reason inline.
             await emit.emit(
                 "error",
-                message=validated.get("reason", "brief did not pass validation"),
-                hint=validated.get("hint", "Try mentioning an asset class or risk appetite."),
+                message=_invalid_brief_message(validated.get("reason")),
+                hint=validated.get("hint") or "Mention an asset class, a goal, or a risk appetite.",
                 recoverable=True,
                 code="BRIEF_INVALID",
             )

--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -45,6 +45,7 @@ from typing import Any
 from archimedes.agents.strategy_architect import extract_json
 from archimedes.models.portfolio import RISK_PROFILE_PARAMS, RiskProfile
 from archimedes.services.llm_backend import LLMBackend, make_llm_backend
+from archimedes.services.strategy_dsl import DSLError, validate_strategy_spec
 from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
 
 logger = logging.getLogger(__name__)
@@ -123,7 +124,7 @@ def _repair_spec(backend: Any, brief: FusionBrief, parsed: dict[str, Any]) -> di
                 "thesis": parsed.get("thesis"),
                 "fusion_reasoning": parsed.get("fusion_reasoning"),
                 "source_arxiv_ids": parsed.get("source_arxiv_ids", []),
-                "user_asset_classes": brief.asset_classes,
+                "user_steer": {"asset_classes": brief.asset_classes},
             }
         )
         raw = backend.complete(_SPEC_REPAIR_SYSTEM, user_msg)
@@ -162,9 +163,10 @@ def _spec_universe(brief: FusionBrief, strategy_spec: dict[str, Any]) -> list[st
     real-data backtest graded an arbitrary alphabetical basket unrelated to the
     thesis. Order now: (1) the user's resolved assets always win (their lever);
     (2) else the MODEL's emitted universe, validated against the SSOT and
-    capped at {cap} (the thesis's own instruments); (3) else the full supported
-    universe (preserving #682's "never a hardcoded SPY" floor).
-    """.format(cap=_MODEL_UNIVERSE_CAP)
+    capped at ``_MODEL_UNIVERSE_CAP`` (the thesis's own instruments); (3) else
+    the full supported universe (preserving #682's "never a hardcoded SPY"
+    floor).
+    """
     user_assets = _resolve_user_assets(brief.asset_classes)
     if user_assets:
         return user_assets
@@ -617,7 +619,6 @@ literature>",
 
 """
     + _SPEC_CONTRACT
-    + """"""
 )
 
 
@@ -802,6 +803,15 @@ class StrategyFusion:
             # Universe steering (#847): user's resolved assets > the model's
             # SSOT-validated suggestion (capped) > full supported universe.
             strategy_spec["asset_universe"] = _spec_universe(brief, strategy_spec)
+            # Validate the FINAL dict (post-steering). An invalid spec — a
+            # partial repair that happened to carry entry/exit, or a malformed
+            # model emission — must degrade to honest text-only HERE, not
+            # surface later as a DSLError mid-evaluation/debate.
+            try:
+                validate_strategy_spec(strategy_spec)
+            except DSLError as exc:
+                logger.warning("fusion: strategy_spec failed DSL validation (%s) — falling back to text-only", exc)
+                strategy_spec = None
 
         return FusionProposal(
             status="ok",

--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -108,6 +108,78 @@ for _synth, (_yf, _display, _ac, _exch) in GLOBAL_ASSETS.items():
     _UNIVERSE_LOOKUP[_yf.casefold()] = _display
 
 
+def _repair_spec(backend: Any, brief: FusionBrief, parsed: dict[str, Any]) -> dict[str, Any] | None:
+    """One bounded retry when the model omitted ``strategy_spec``.
+
+    Sends the already-accepted proposal back and asks for ONLY the spec JSON.
+    Tolerates a ``{"strategy_spec": {...}}`` wrapper. Returns None (text-only
+    fallback, honest pre-backtest verdict) if the retry also fails — never
+    loops, never fabricates.
+    """
+    try:
+        user_msg = json.dumps(
+            {
+                "strategy_name": parsed.get("strategy_name"),
+                "thesis": parsed.get("thesis"),
+                "fusion_reasoning": parsed.get("fusion_reasoning"),
+                "source_arxiv_ids": parsed.get("source_arxiv_ids", []),
+                "user_asset_classes": brief.asset_classes,
+            }
+        )
+        raw = backend.complete(_SPEC_REPAIR_SYSTEM, user_msg)
+        repaired = extract_json(raw)
+        if isinstance(repaired, dict) and isinstance(repaired.get("strategy_spec"), dict):
+            repaired = repaired["strategy_spec"]
+        if isinstance(repaired, dict) and repaired.get("entry") and repaired.get("exit"):
+            logger.info("fusion: strategy_spec repaired on retry (model omitted it)")
+            return repaired
+        logger.warning("fusion: spec-repair retry returned no usable spec — falling back to text-only")
+    except Exception as exc:
+        logger.warning("fusion: spec-repair retry failed (%s) — falling back to text-only", exc)
+    return None
+
+
+def _resolve_user_assets(selected_assets: list[str]) -> list[str]:
+    """Resolve user tokens to canonical SSOT display symbols (may be empty)."""
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for token in selected_assets or []:
+        canonical = _UNIVERSE_LOOKUP.get(str(token).strip().casefold())
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            resolved.append(canonical)
+    return resolved
+
+
+_MODEL_UNIVERSE_CAP = 8
+
+
+def _spec_universe(brief: FusionBrief, strategy_spec: dict[str, Any]) -> list[str]:
+    """Pick the spec's asset universe: user steer > model suggestion > full SSOT.
+
+    Fixes #847: the old unconditional ``derive_asset_universe`` override sent
+    every UNSTEERED brief to the full ~300-asset supported universe, so the
+    real-data backtest graded an arbitrary alphabetical basket unrelated to the
+    thesis. Order now: (1) the user's resolved assets always win (their lever);
+    (2) else the MODEL's emitted universe, validated against the SSOT and
+    capped at {cap} (the thesis's own instruments); (3) else the full supported
+    universe (preserving #682's "never a hardcoded SPY" floor).
+    """.format(cap=_MODEL_UNIVERSE_CAP)
+    user_assets = _resolve_user_assets(brief.asset_classes)
+    if user_assets:
+        return user_assets
+    model_assets = _resolve_user_assets([str(a) for a in strategy_spec.get("asset_universe") or []])
+    # Parrot defense: a bare single proxy (the classic ["SPY"] default weak
+    # models emit regardless of thesis) is indistinguishable from a non-choice —
+    # only a deliberate MULTI-instrument selection is trusted as the thesis's
+    # own universe. Single-asset intent is still expressible via the user steer.
+    if len(model_assets) >= 2:
+        if len(model_assets) > _MODEL_UNIVERSE_CAP:
+            logger.info("fusion: model universe capped %d → %d", len(model_assets), _MODEL_UNIVERSE_CAP)
+        return model_assets[:_MODEL_UNIVERSE_CAP]
+    return list(SUPPORTED_UNIVERSE)
+
+
 def derive_asset_universe(selected_assets: list[str]) -> list[str]:
     """Derive the strategy_spec asset_universe from the user's selected assets.
 
@@ -484,7 +556,22 @@ class FusionProposal:
 # ── Prompt construction ─────────────────────────────────────────
 
 
-_SYSTEM_PROMPT = """You are Archimedes Fusion, an AI quant-research synthesizer. \
+_SPEC_CONTRACT = """The strategy_spec field is REQUIRED. It is a machine-readable strategy definition \
+using the Archimedes DSL (closed-enum vocabulary). For asset_universe, list the \
+tickers the mechanism trades from the user's selected assets (in user_steer); the \
+platform overrides this with the user's chosen universe, so do not default to a \
+single broad-market proxy. Valid rebalance_frequency values: \
+daily, weekly, monthly. Valid indicators: sma_N, ema_N, rsi_N, momentum_N (replace \
+N with an integer period). Entry/exit conditions use comparison ops (gt, lt, gte, lte) \
+or logic ops (and, or, not). Position sizing types: full_invested_when_in_market, \
+equal_weight, volatility_target (needs annual_pct). look_ahead_safe MUST be true. \
+parameter_variants is OPTIONAL: a dict mapping indicator aliases to 2-8 numeric \
+values for CSCV overfitting detection (e.g. {"sma_200": [150, 175, 200, 225, 250]}). \
+Keys must reference indicators used in entry/exit conditions."""
+
+
+_SYSTEM_PROMPT = (
+    """You are Archimedes Fusion, an AI quant-research synthesizer. \
 You design a NOVEL trading-strategy hypothesis by FUSING the mechanisms of \
 MULTIPLE peer-reviewed quantitative-finance papers into one combined approach.
 
@@ -528,18 +615,19 @@ literature>",
   }
 }
 
-The strategy_spec field is REQUIRED. It is a machine-readable strategy definition \
-using the Archimedes DSL (closed-enum vocabulary). For asset_universe, list the \
-tickers the mechanism trades from the user's selected assets (in user_steer); the \
-platform overrides this with the user's chosen universe, so do not default to a \
-single broad-market proxy. Valid rebalance_frequency values: \
-daily, weekly, monthly. Valid indicators: sma_N, ema_N, rsi_N, momentum_N (replace \
-N with an integer period). Entry/exit conditions use comparison ops (gt, lt, gte, lte) \
-or logic ops (and, or, not). Position sizing types: full_invested_when_in_market, \
-equal_weight, volatility_target (needs annual_pct). look_ahead_safe MUST be true. \
-parameter_variants is OPTIONAL: a dict mapping indicator aliases to 2-8 numeric \
-values for CSCV overfitting detection (e.g. {"sma_200": [150, 175, 200, 225, 250]}). \
-Keys must reference indicators used in entry/exit conditions."""
+"""
+    + _SPEC_CONTRACT
+    + """"""
+)
+
+
+_SPEC_REPAIR_SYSTEM = (
+    "You are the spec compiler for Archimedes. A strategy proposal was produced "
+    "WITHOUT the REQUIRED machine-readable strategy_spec. From the proposal JSON "
+    "the user sends, output STRICT JSON ONLY — a single object that IS the "
+    "strategy_spec (no wrapper key, no prose, no markdown fences).\n\n"
+    "" + _SPEC_CONTRACT
+)
 
 
 def _build_user_prompt(brief: FusionBrief, candidates: list[CorpusPaper]) -> str:
@@ -699,16 +787,21 @@ class StrategyFusion:
                 "single-paper hypothesis is produced.",
             )
 
-        # Extract strategy_spec if present (additive — back-compat if missing)
+        # Extract strategy_spec if present. Weak-JSON models (Nova Micro) often
+        # omit it despite the REQUIRED contract — without a spec there is no
+        # backtest, no rigor verdict, and the strategy is stuck at "pending"
+        # forever (#788); the debate society outright DROPS spec-less proposals
+        # (A5 conformance), so its pool would come up empty. One bounded repair
+        # retry asks for ONLY the spec before we fall back to text-only.
         strategy_spec = parsed.get("strategy_spec")
+        if not isinstance(strategy_spec, dict):
+            strategy_spec = _repair_spec(backend, brief, parsed)
         if not isinstance(strategy_spec, dict):
             strategy_spec = None
         else:
-            # Steer the asset universe from the user's selected assets (falling
-            # back to the SSOT-derived supported universe), overriding whatever
-            # the model emitted. The universe is the user's lever — never a
-            # hardcoded `["SPY"]` default and never silently the model's guess.
-            strategy_spec["asset_universe"] = derive_asset_universe(brief.asset_classes)
+            # Universe steering (#847): user's resolved assets > the model's
+            # SSOT-validated suggestion (capped) > full supported universe.
+            strategy_spec["asset_universe"] = _spec_universe(brief, strategy_spec)
 
         return FusionProposal(
             status="ok",

--- a/backend/tests/test_fusion_spec_repair.py
+++ b/backend/tests/test_fusion_spec_repair.py
@@ -1,0 +1,189 @@
+"""Spec-repair retry + universe steering + friendly brief errors.
+
+These paths all survive the T1.1 debate-society cutover: brief validation lives
+in the orchestrator (runs before pipeline dispatch), and ``StrategyFusion.propose``
+IS the debate society's proposer (the pool fans it across steers, and the A5
+conformance guard DROPS spec-less proposals — so a model that omits the spec
+would silently empty the debate pool).
+
+Hermetic: the LLM backend is a stub; no network, no DB.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import archimedes.agents.strategy_fusion as sf
+import pytest
+from archimedes.agents.generation_pipeline import _invalid_brief_message
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+_SPEC = {
+    "name": "Fused Trend",
+    "asset_universe": ["SPY", "GLD"],
+    "rebalance_frequency": "monthly",
+    "entry": {"gt": ["close", "sma_200"]},
+    "exit": {"lt": ["close", "sma_200"]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "source_arxiv_ids": ["0706.1497", "1704.03022"],
+    "look_ahead_safe": True,
+    "indicators": ["sma_200"],
+}
+
+_PROPOSAL_NO_SPEC = {
+    "strategy_name": "Fused Trend",
+    "thesis": "Trend plus vol management.",
+    "source_arxiv_ids": ["0706.1497", "1704.03022"],
+    "fusion_reasoning": "Faber timing gates Moreira-Muir sizing.",
+    "novelty_rationale": "Combination not in either paper.",
+    "risk_notes": "Pre-backtest.",
+}
+
+
+class _StubBackend:
+    """LLM stub returning queued responses; records every (system, user) call."""
+
+    available = True
+    served_model = "stub-model"
+    model_id = "stub-model"
+
+    def __init__(self, responses: list[str]):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, str]] = []
+
+    def complete(self, system: str, user: str) -> str:
+        self.calls.append((system, user))
+        return self._responses.pop(0)
+
+
+def _brief(asset_classes: list[str] | None = None) -> sf.FusionBrief:
+    return sf.FusionBrief(asset_classes=asset_classes or [], risk_appetite=sf.RiskProfile.MODERATE)
+
+
+def _papers(n: int = 3) -> list:
+    return [
+        SimpleNamespace(
+            arxiv_id=f"070{i}.1497",
+            title=f"Paper {i}",
+            abstract="a",
+            categories=["q-fin.PM"],
+            published="2007-01-01",
+            summary="s",
+        )
+        for i in range(n)
+    ]
+
+
+def _propose_with(monkeypatch, backend: _StubBackend, brief=None) -> sf.FusionProposal:
+    """Run the REAL propose() with corpus/backend/prompt seams stubbed."""
+    fusion = sf.StrategyFusion()
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    papers = _papers()
+    monkeypatch.setattr(sf.StrategyFusion, "_resolve_corpus", lambda self: papers)
+    monkeypatch.setattr(sf, "select_candidates", lambda brief, corpus: papers)
+    monkeypatch.setattr(sf.StrategyFusion, "_resolve_backend", lambda self: backend)
+    monkeypatch.setattr(sf, "_build_user_prompt", lambda brief, candidates: "prompt")
+    return fusion.propose(brief or _brief())
+
+
+def _ok_response(spec=None) -> str:
+    payload = dict(_PROPOSAL_NO_SPEC)
+    payload["source_arxiv_ids"] = ["0700.1497", "0701.1497"]
+    if spec is not None:
+        payload["strategy_spec"] = spec
+    return json.dumps(payload)
+
+
+# ── spec-repair retry ─────────────────────────────────────────────────
+
+
+def test_missing_spec_is_repaired_with_one_retry(monkeypatch):
+    spec = dict(_SPEC, source_arxiv_ids=["0700.1497", "0701.1497"])
+    backend = _StubBackend([_ok_response(spec=None), json.dumps(spec)])
+    proposal = _propose_with(monkeypatch, backend)
+    assert proposal.status == "ok"
+    assert isinstance(proposal.strategy_spec, dict)
+    assert proposal.strategy_spec["entry"] == {"gt": ["close", "sma_200"]}
+    # Exactly one extra call, using the repair prompt.
+    assert len(backend.calls) == 2
+    assert "spec compiler" in backend.calls[1][0]
+
+
+def test_repair_tolerates_wrapped_response(monkeypatch):
+    spec = dict(_SPEC, source_arxiv_ids=["0700.1497", "0701.1497"])
+    backend = _StubBackend([_ok_response(spec=None), json.dumps({"strategy_spec": spec})])
+    proposal = _propose_with(monkeypatch, backend)
+    assert isinstance(proposal.strategy_spec, dict)
+    assert proposal.strategy_spec["exit"] == {"lt": ["close", "sma_200"]}
+
+
+def test_failed_repair_falls_back_to_text_only(monkeypatch):
+    backend = _StubBackend([_ok_response(spec=None), "not json at all"])
+    proposal = _propose_with(monkeypatch, backend)
+    assert proposal.status == "ok"  # the text proposal is still actionable
+    assert proposal.strategy_spec is None  # honest text-only, never fabricated
+    assert len(backend.calls) == 2  # one retry, no loop
+
+
+def test_present_spec_needs_no_retry(monkeypatch):
+    spec = dict(_SPEC, source_arxiv_ids=["0700.1497", "0701.1497"])
+    backend = _StubBackend([_ok_response(spec=spec)])
+    proposal = _propose_with(monkeypatch, backend)
+    assert isinstance(proposal.strategy_spec, dict)
+    assert len(backend.calls) == 1
+
+
+# ── universe steering (#847) ──────────────────────────────────────────
+
+
+def test_user_assets_win_over_model_universe():
+    spec = {"asset_universe": ["TSLA", "NVDA"]}
+    out = sf._spec_universe(_brief(asset_classes=["SPY", "gld"]), spec)
+    assert out == ["SPY", "GLD"]  # canonical, order-preserving
+
+
+def test_unsteered_brief_uses_models_validated_universe():
+    spec = {"asset_universe": ["SPY", "GLD", "NOT_A_REAL_TICKER_XYZ"]}
+    out = sf._spec_universe(_brief(), spec)
+    assert out == ["SPY", "GLD"]  # SSOT-validated; garbage dropped
+    assert "NOT_A_REAL_TICKER_XYZ" not in out
+
+
+def test_model_universe_is_capped():
+    many = list(sf.SUPPORTED_UNIVERSE)[: sf._MODEL_UNIVERSE_CAP + 5]
+    out = sf._spec_universe(_brief(), {"asset_universe": many})
+    assert len(out) == sf._MODEL_UNIVERSE_CAP
+
+
+def test_no_user_no_model_falls_back_to_full_universe():
+    out = sf._spec_universe(_brief(), {"asset_universe": []})
+    assert out == list(sf.SUPPORTED_UNIVERSE)  # #682's floor preserved
+
+
+def test_propose_threads_model_universe_when_unsteered(monkeypatch):
+    spec = dict(_SPEC, source_arxiv_ids=["0700.1497", "0701.1497"], asset_universe=["SPY", "GLD"])
+    backend = _StubBackend([_ok_response(spec=spec)])
+    proposal = _propose_with(monkeypatch, backend, brief=_brief())
+    # The thesis's own instruments survive — not the full ~300-asset SSOT dump.
+    assert proposal.strategy_spec["asset_universe"] == ["SPY", "GLD"]
+
+
+# ── friendly brief-validation errors ──────────────────────────────────
+
+
+@pytest.mark.parametrize("reason", ["gibberish", "off-topic", None])
+def test_invalid_brief_message_guides_instead_of_insults(reason):
+    m = _invalid_brief_message(reason)
+    assert "Describe what you want" in m
+    assert "e.g." in m
+    if reason:
+        assert reason in m  # the honest reason is kept, framed
+
+
+def test_single_proxy_model_universe_is_treated_as_parroted_default():
+    # A weak model emitting the classic bare ["SPY"] regardless of thesis is a
+    # non-choice — fall back to the full universe (never trust the parrot).
+    out = sf._spec_universe(_brief(), {"asset_universe": ["SPY"]})
+    assert out == list(sf.SUPPORTED_UNIVERSE)

--- a/backend/tests/test_fusion_spec_repair.py
+++ b/backend/tests/test_fusion_spec_repair.py
@@ -135,6 +135,30 @@ def test_present_spec_needs_no_retry(monkeypatch):
     assert len(backend.calls) == 1
 
 
+def test_partially_repaired_spec_degrades_to_text_only(monkeypatch):
+    """A repair that returns entry/exit but misses required DSL fields must not
+    slip through — the proposal degrades to honest text-only, never a spec that
+    explodes later in evaluation/debate."""
+    partial = {"entry": {"gt": ["close", "sma_200"]}, "exit": {"lt": ["close", "sma_200"]}}
+    backend = _StubBackend([_ok_response(spec=None), json.dumps(partial)])
+    proposal = _propose_with(monkeypatch, backend)
+    assert proposal.status == "ok"
+    assert proposal.strategy_spec is None
+    assert len(backend.calls) == 2  # the one bounded retry, no loop
+
+
+def test_invalid_model_spec_degrades_to_text_only(monkeypatch):
+    """A model-emitted spec that fails DSL validation (look_ahead_safe=false is
+    rejected by the interpreter) degrades to text-only instead of returning a
+    spec the rigor/backtest path would refuse."""
+    spec = dict(_SPEC, source_arxiv_ids=["0700.1497", "0701.1497"], look_ahead_safe=False)
+    backend = _StubBackend([_ok_response(spec=spec)])
+    proposal = _propose_with(monkeypatch, backend)
+    assert proposal.status == "ok"
+    assert proposal.strategy_spec is None
+    assert len(backend.calls) == 1  # invalid ≠ missing: no repair retry burned
+
+
 # ── universe steering (#847) ──────────────────────────────────────────
 
 

--- a/backend/tests/test_strategy_fusion.py
+++ b/backend/tests/test_strategy_fusion.py
@@ -137,13 +137,18 @@ class _MockBackend:
     served_model = "glm-4.7"  # what actually answers (response.model)
 
     def __init__(self) -> None:
+        # .system/.user hold the FIRST (proposal) call — the spec-repair retry
+        # appends later calls to .calls without clobbering what tests assert on.
         self.system: str | None = None
         self.user: str | None = None
+        self.calls: list[tuple[str, str]] = []
 
     def complete(self, system: str, user: str) -> str:
-        self.system = system
-        self.user = user
-        payload = json.loads(user)
+        self.calls.append((system, user))
+        if self.system is None:
+            self.system = system
+            self.user = user
+        payload = json.loads(self.user)
         ids = [p["arxiv_id"] for p in payload["candidate_papers"][:2]]
         return json.dumps(
             {


### PR DESCRIPTION
## Summary

Prod SIWE dogfooding found why **no generated strategy can become deployable**: Nova Micro omits the REQUIRED `strategy_spec` from the fusion JSON → text-only branch → no backtest → live gate `pending` forever. The **debate society is blocked identically** — its A5 conformance guard drops spec-less proposals, so flipping `ARCHIMEDES_DEBATE_ENABLED` today would yield an empty pool. This PR is the flip prerequisite.

## Fixes (all in code the T1.1 debate cutover keeps)

1. **Spec-repair retry** — one bounded follow-up asking for ONLY the spec (shared `_SPEC_CONTRACT` so the two prompts can't drift). Wrapped responses tolerated; honest text-only fallback if the retry fails. Never loops, never fabricates.
2. **Universe steering (closes #847)** — user's resolved assets > the model's SSOT-validated **multi-instrument** universe (cap 8) > full supported universe. Previously every unsteered brief was overridden to the full ~300-asset list, so real-data backtests graded an alphabetical basket (`AAPL, AAVE, ACWI…`) unrelated to the thesis. Parrot defense: a bare `["SPY"]` is a non-choice.
3. **Brief-validation UX** — `Error — gibberish` becomes: *We couldn't turn that into an investment brief (gibberish). Describe what you want from a portfolio in a sentence — e.g. "diversified low-volatility strategy for idle USDC".* Lives in the orchestrator; survives the debate cutover.

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_fusion_spec_repair.py backend/tests/test_strategy_fusion.py \
  backend/tests/services/test_generation_pipeline.py backend/tests/test_debate_engine.py -q  # 88 passed
```

## Anti-goals
No rigor/gate changes. No new deps. The spec contract is unchanged — just enforced with a second chance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M