### PR TITLE
[quant] Data-quality harness gating the backtest universe (#772)

### DIFF
--- a/backend/archimedes/scripts/generate_universe.py
+++ b/backend/archimedes/scripts/generate_universe.py
@@ -717,6 +717,16 @@ def main(argv: list[str] | None = None) -> int:
             print(f"data-quality gate: all {len(report.admitted)} tickers passed")
         _write_ssot(idx)
     elif "--print-global-assets" in argv:
+        # Same #772 gate as --write: GLOBAL_ASSETS is the runtime universe the
+        # backtests actually fetch against (these printed rows get hand-pasted
+        # into strategy_signal_evaluator.py), so an unvetted ticker here
+        # reaches production more directly than one in the SSOT JSON.
+        if "--skip-data-quality" in argv:
+            print("WARNING: --skip-data-quality set — printing GLOBAL_ASSETS without the #772 harness check")
+        else:
+            report = vet_data_quality()
+            _dq_gate(report)
+            print(f"data-quality gate: all {len(report.admitted)} tickers passed")
         _print_global_assets()
     else:  # default = report
         _report(idx)

--- a/backend/archimedes/scripts/generate_universe.py
+++ b/backend/archimedes/scripts/generate_universe.py
@@ -36,6 +36,11 @@ Usage::
     # offline / hermetic: point at a cached catalog file instead of the network:
     PYTHONPATH=backend python -m archimedes.scripts.generate_universe --report \
         --catalog /path/to/price_feeds.json
+
+The ``--write`` path is gated on the #772 data-quality harness: every curated
+yfinance ticker must pass ``verify_instrument`` over the 2y backtest window
+(fetchable, coverage, gaps, survivorship) or the write refuses with per-ticker
+reasons. ``--skip-data-quality`` bypasses the check (loudly) for offline runs.
 """
 
 from __future__ import annotations
@@ -604,6 +609,39 @@ def build_global_assets_rows() -> list[tuple[str, tuple[str, str, str, str]]]:
     return [(a.synth, (a.yf, a.display, a.asset_class, a.exchange)) for a in sorted(CURATED, key=lambda x: x.synth)]
 
 
+def vet_data_quality(window_years: int = 2, _downloader=None):
+    """Run the #772 data-quality harness over every CURATED yfinance ticker.
+
+    The window matches the evaluator's backtest fetch (period="2y" in
+    ``_fetch_price_history``), so a ticker is admitted only if the history the
+    backtests will actually consume is fetchable, covers the window, has no
+    large gaps, and still trades near the window end. ``_downloader`` is the
+    test seam — injected so tests never touch the network.
+    """
+    import pandas as pd
+
+    from archimedes.services.data_quality import verify_universe
+
+    end = pd.Timestamp.today().normalize()
+    start = end - pd.DateOffset(years=window_years)
+    tickers = sorted({a.yf for a in CURATED})
+    return verify_universe(tickers, start, end, _downloader=_downloader)
+
+
+def _dq_gate(report) -> None:
+    """Refuse admission when any ticker fails the harness. Bad data gets
+    excluded at the source (the curator fixes or drops the entry), never
+    padded into the SSOT (#772 anti-goal)."""
+    if report.rejected:
+        lines = [f"  {t}: {'; '.join(reasons)}" for t, reasons in sorted(report.rejected.items())]
+        raise SystemExit(
+            f"data-quality gate: {len(report.rejected)} ticker(s) failed verification "
+            f"({len(report.admitted)} passed) — refusing to write the SSOT.\n"
+            + "\n".join(lines)
+            + "\nFix or drop the entries in CURATED, or rerun with --skip-data-quality (offline only)."
+        )
+
+
 def _assert_no_dupes() -> None:
     seen = set()
     for a in CURATED:
@@ -671,6 +709,12 @@ def main(argv: list[str] | None = None) -> int:
     feeds = load_pyth_catalog(catalog_path)
     idx = build_pyth_index(feeds)
     if "--write" in argv:
+        if "--skip-data-quality" in argv:
+            print("WARNING: --skip-data-quality set — writing the SSOT without the #772 harness check")
+        else:
+            report = vet_data_quality()
+            _dq_gate(report)
+            print(f"data-quality gate: all {len(report.admitted)} tickers passed")
         _write_ssot(idx)
     elif "--print-global-assets" in argv:
         _print_global_assets()

--- a/backend/archimedes/services/data_quality.py
+++ b/backend/archimedes/services/data_quality.py
@@ -146,12 +146,24 @@ def verify_instrument(
     series = series.dropna().sort_index()
     n = len(series)
     first, last = pd.Timestamp(series.index[0]), pd.Timestamp(series.index[-1])
+
+    # Reference calendar, inferred from the DATA: continuously-traded markets
+    # (crypto "-USD" pairs — ~71/340 of GLOBAL_ASSETS) print on weekends, so a
+    # Mon-Fri bdate_range under-counts their expected observations and clips
+    # gap_count to zero until ~28% of the history is missing — silently
+    # defeating the 10% gap check for exactly those assets. Any material
+    # weekend presence (≥5% of observations; true 7-day markets sit near 28%,
+    # exchange-listed assets at 0%) switches the reference to calendar days.
+    weekend_frac = float((series.index.dayofweek >= 5).mean()) if n else 0.0
+    continuous = weekend_frac >= 0.05
+    _cal = pd.date_range if continuous else pd.bdate_range
+    expected = max(1, len(_cal(start_ts, end_ts)))
     coverage = n / expected
 
     # Internal gaps: missing trading days strictly within the observed span.
-    span_bdays = max(1, len(pd.bdate_range(first, last)))
-    gap_count = max(0, span_bdays - n)
-    gap_ratio = gap_count / span_bdays
+    span_days = max(1, len(_cal(first, last)))
+    gap_count = max(0, span_days - n)
+    gap_ratio = gap_count / span_days
 
     starts_on_time = first <= start_ts + tol
     sufficient_history = starts_on_time and coverage >= min_window_coverage

--- a/backend/archimedes/services/data_quality.py
+++ b/backend/archimedes/services/data_quality.py
@@ -1,0 +1,219 @@
+"""Data-quality / fetch-verification harness for the backtest universe (#772).
+
+Before a ticker is admitted to ``GLOBAL_ASSETS`` — the universe over which the
+Tier-1 rigor gate's per-strategy Deflated Sharpe Ratio (Bailey & López de Prado
+2014) and the library-level Probability of Backtest Overfitting (CSCV; Bailey,
+Borwein, López de Prado & Zhu 2014) are computed — its price history must be
+*clean*. Both statistics assume a gap-free, survivorship-aware return series;
+violate that and the realized Sharpe is silently inflated and the gate is
+poisoned. yfinance's long tail (the #759 expansion to 200–300 instruments) is
+exactly where this bites: delisted names vanish, histories start late, and the
+fetch layer pads/truncates partial series.
+
+This harness verifies four properties per instrument over the backtest window:
+
+  1. **fetchable**     — a non-empty series comes back at all;
+  2. **sufficient history** — it starts near ``start`` and covers ≥ a minimum
+     fraction of the window's trading days (no late-IPO / short-history bias);
+  3. **gap-free**      — within [first, last] the fraction of missing trading
+     days is below a tolerance (holidays are ~3.5% of business days, so the
+     default 10% tolerance admits real calendars but rejects true gaps);
+  4. **survivorship-clean** — the series still trades near ``end`` (a series
+     that stops early is a likely delisting → survivorship bias).
+
+A ticker is admitted only if all four hold. We never pad or truncate to force a
+pass — bad data is flagged and excluded (#772 anti-goal).
+
+The single yfinance call is isolated in ``_download_close`` so tests mock exactly
+one boundary (or inject ``_downloader=``) and never touch the network.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import pandas as pd
+from pandas.tseries.offsets import BusinessDay
+
+logger = logging.getLogger(__name__)
+
+# Defaults — deliberately conservative for a rigor-gate precondition.
+DEFAULT_EDGE_TOLERANCE_DAYS = 7  # business days of slack at each window edge
+DEFAULT_MAX_GAP_RATIO = 0.10  # > 10% missing trading days within span → gappy
+DEFAULT_MIN_WINDOW_COVERAGE = 0.90  # obs / expected trading days over the window
+
+Downloader = Callable[[str, pd.Timestamp, pd.Timestamp], "pd.Series"]
+
+
+@dataclass(frozen=True)
+class InstrumentVerdict:
+    """Per-instrument data-quality verdict over a backtest window."""
+
+    ticker: str
+    ok: bool
+    fetchable: bool
+    n_obs: int
+    expected_obs: int
+    coverage_ratio: float  # n_obs / expected trading days over [start, end]
+    gap_count: int  # missing trading days within [first_obs, last_obs]
+    gap_ratio: float  # gap_count / trading days in [first_obs, last_obs]
+    first_obs: str | None
+    last_obs: str | None
+    sufficient_history: bool
+    survivorship_ok: bool
+    reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class UniverseReport:
+    """Aggregate verdict over a set of tickers."""
+
+    admitted: tuple[str, ...]
+    rejected: dict[str, tuple[str, ...]]  # ticker -> reasons
+    verdicts: dict[str, InstrumentVerdict] = field(default_factory=dict)
+
+
+def _download_close(ticker: str, start: pd.Timestamp, end: pd.Timestamp) -> pd.Series:
+    """The sole yfinance boundary: daily adjusted-close over [start, end].
+
+    Returns an empty Series on any failure/empty response (treated as
+    unfetchable). Isolated so tests mock here and never hit the network.
+    """
+    try:
+        import yfinance as yf
+
+        data = yf.download(
+            ticker,
+            start=start.strftime("%Y-%m-%d"),
+            end=end.strftime("%Y-%m-%d"),
+            interval="1d",
+            progress=False,
+            auto_adjust=True,
+            threads=False,
+        )
+        if data is None or data.empty:
+            return pd.Series(dtype=float)
+        close = data["Close"]
+        if isinstance(close, pd.DataFrame):
+            close = close.iloc[:, 0]
+        return close.dropna()
+    except Exception as e:  # pragma: no cover - network/library failure path
+        logger.warning("data_quality: download failed for %s: %s", ticker, e)
+        return pd.Series(dtype=float)
+
+
+def verify_instrument(
+    ticker: str,
+    start: str | pd.Timestamp,
+    end: str | pd.Timestamp,
+    *,
+    edge_tolerance_days: int = DEFAULT_EDGE_TOLERANCE_DAYS,
+    max_gap_ratio: float = DEFAULT_MAX_GAP_RATIO,
+    min_window_coverage: float = DEFAULT_MIN_WINDOW_COVERAGE,
+    _downloader: Downloader | None = None,
+) -> InstrumentVerdict:
+    """Verify one instrument's price history over [start, end].
+
+    Returns an :class:`InstrumentVerdict`; ``ok`` is True only when the series is
+    fetchable, has sufficient history, is gap-free within tolerance, and is
+    survivorship-clean. ``reasons`` lists every failed check (empty when ``ok``).
+    """
+    download = _downloader or _download_close
+    start_ts, end_ts = pd.Timestamp(start), pd.Timestamp(end)
+    expected = max(1, len(pd.bdate_range(start_ts, end_ts)))
+    tol = BusinessDay(edge_tolerance_days)
+
+    series = download(ticker, start_ts, end_ts)
+    if series is None or len(series) == 0:
+        return InstrumentVerdict(
+            ticker=ticker,
+            ok=False,
+            fetchable=False,
+            n_obs=0,
+            expected_obs=expected,
+            coverage_ratio=0.0,
+            gap_count=expected,
+            gap_ratio=1.0,
+            first_obs=None,
+            last_obs=None,
+            sufficient_history=False,
+            survivorship_ok=False,
+            reasons=("unfetchable: empty series returned",),
+        )
+
+    series = series.dropna().sort_index()
+    n = len(series)
+    first, last = pd.Timestamp(series.index[0]), pd.Timestamp(series.index[-1])
+    coverage = n / expected
+
+    # Internal gaps: missing trading days strictly within the observed span.
+    span_bdays = max(1, len(pd.bdate_range(first, last)))
+    gap_count = max(0, span_bdays - n)
+    gap_ratio = gap_count / span_bdays
+
+    starts_on_time = first <= start_ts + tol
+    sufficient_history = starts_on_time and coverage >= min_window_coverage
+    survivorship_ok = last >= end_ts - tol
+    gap_free = gap_ratio <= max_gap_ratio
+
+    reasons: list[str] = []
+    if not sufficient_history:
+        reasons.append(
+            f"insufficient history: coverage {coverage:.2f} (< {min_window_coverage}), "
+            f"first obs {first.date()} vs window start {start_ts.date()}"
+        )
+    if not survivorship_ok:
+        reasons.append(f"survivorship: last obs {last.date()} well before window end {end_ts.date()} (likely delisted)")
+    if not gap_free:
+        reasons.append(f"gappy: {gap_count} missing trading days ({gap_ratio:.1%} > {max_gap_ratio:.0%})")
+
+    ok = sufficient_history and survivorship_ok and gap_free
+    return InstrumentVerdict(
+        ticker=ticker,
+        ok=ok,
+        fetchable=True,
+        n_obs=n,
+        expected_obs=expected,
+        coverage_ratio=round(coverage, 4),
+        gap_count=gap_count,
+        gap_ratio=round(gap_ratio, 4),
+        first_obs=str(first.date()),
+        last_obs=str(last.date()),
+        sufficient_history=sufficient_history,
+        survivorship_ok=survivorship_ok,
+        reasons=tuple(reasons),
+    )
+
+
+def verify_universe(
+    tickers: list[str],
+    start: str | pd.Timestamp,
+    end: str | pd.Timestamp,
+    *,
+    edge_tolerance_days: int = DEFAULT_EDGE_TOLERANCE_DAYS,
+    max_gap_ratio: float = DEFAULT_MAX_GAP_RATIO,
+    min_window_coverage: float = DEFAULT_MIN_WINDOW_COVERAGE,
+    _downloader: Downloader | None = None,
+) -> UniverseReport:
+    """Verify a set of tickers; aggregate into admitted / rejected.
+
+    Only tickers whose :func:`verify_instrument` verdict is ``ok`` are admitted;
+    the rest are rejected with their reasons. This is the precondition gate for
+    the #759 universe expansion — admit clean data only, never lower the bar.
+    """
+    verdicts: dict[str, InstrumentVerdict] = {}
+    for t in tickers:
+        verdicts[t] = verify_instrument(
+            t,
+            start,
+            end,
+            edge_tolerance_days=edge_tolerance_days,
+            max_gap_ratio=max_gap_ratio,
+            min_window_coverage=min_window_coverage,
+            _downloader=_downloader,
+        )
+    admitted = tuple(t for t, v in verdicts.items() if v.ok)
+    rejected = {t: v.reasons for t, v in verdicts.items() if not v.ok}
+    return UniverseReport(admitted=admitted, rejected=rejected, verdicts=verdicts)

--- a/backend/archimedes/services/strategy_signal_evaluator.py
+++ b/backend/archimedes/services/strategy_signal_evaluator.py
@@ -24,6 +24,17 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+# Data-quality / fetch-verification harness (#772). verify_instrument is the
+# per-ticker precondition every name must clear before admission to the universe
+# below; verify_universe aggregates it. Re-exported so callers (and the universe
+# parity test) gate GLOBAL_ASSETS on clean, gap-free, survivorship-aware data —
+# poisoned history silently inflates Sharpe and corrupts the DSR/PBO gate.
+from archimedes.services.data_quality import (  # noqa: F401 - re-exported for the universe-admission precondition
+    UniverseReport,
+    verify_instrument,
+    verify_universe,
+)
+
 # REUSE the SAME spec validator the rigor gate runs, so an invalid spec fails
 # loudly here exactly as it would at admission time. The condition-tree evaluator
 # (``_eval_condition``) is the SAME one the backtest interpreter uses — imported
@@ -550,6 +561,28 @@ class StrategySignals:
 
 
 # ─── Price data helper ────────────────────────────────────────────
+
+
+def verify_universe_data_quality(
+    start: str,
+    end: str,
+    synths: list[str] | None = None,
+    *,
+    _downloader=None,
+) -> UniverseReport:
+    """Run the #772 data-quality harness over the universe's yfinance tickers.
+
+    Precondition for the #759 universe expansion: a synth should be admitted to
+    ``GLOBAL_ASSETS`` only if its underlying ticker passes ``verify_instrument``
+    over the backtest window (fetchable, full-window, gap-free, survivorship-
+    clean). Defaults to the current ``GLOBAL_ASSETS`` keys; pass ``synths`` to
+    vet a candidate set before adding it. ``_downloader`` is injected by tests to
+    mock the yfinance boundary. Returns the :class:`UniverseReport` — callers
+    admit ``report.admitted`` and must exclude (never pad) ``report.rejected``.
+    """
+    keys = synths if synths is not None else list(GLOBAL_ASSETS.keys())
+    tickers = [GLOBAL_ASSETS[s][0] for s in keys if s in GLOBAL_ASSETS]
+    return verify_universe(tickers, start, end, _downloader=_downloader)
 
 
 def _fetch_price_history(symbol: str, period: str = "2y", interval: str = "1d") -> pd.Series:

--- a/backend/tests/test_data_quality.py
+++ b/backend/tests/test_data_quality.py
@@ -131,3 +131,44 @@ def test_verify_universe_empty_input():
     report = verify_universe([], START, END, _downloader=_empty)
     assert report.admitted == ()
     assert report.rejected == {}
+
+
+# ── Continuously-traded (7-day) markets — the crypto calendar (#856 review) ──
+
+
+def _daily(start: str = START, end: str = END) -> pd.Series:
+    """A 7-day/week series (crypto-style: prints on weekends)."""
+    return _series(pd.date_range(start, end))
+
+
+def test_clean_crypto_series_passes_with_calendar_day_reference():
+    """A gap-free 7-day market must read coverage ≈ 1.0 (not the ~1.26 a
+    Mon-Fri reference inflates it to) and zero gaps."""
+    v = verify_instrument("BTC-USD", START, END, _downloader=_fixed(_daily()))
+    assert v.ok and v.fetchable
+    assert v.gap_ratio == 0.0
+    assert 0.99 <= v.coverage_ratio <= 1.01
+
+
+def test_gappy_crypto_series_fails_gap_check():
+    """The reproduced review bug: a 7-day series missing a genuine ~15% of its
+    calendar days scored gap_ratio=0.0 against the Mon-Fri bdate reference
+    (obs count still exceeded the business-day count), sailing through the 10%
+    gap gate. With the data-inferred calendar it must fail."""
+    full = pd.date_range(START, END)
+    rng = np.random.default_rng(seed=42)
+    keep = np.sort(rng.choice(len(full), size=int(len(full) * 0.85), replace=False))
+    gappy = _series(full[keep])
+    v = verify_instrument("BTC-USD", START, END, _downloader=_fixed(gappy))
+    assert not v.ok
+    assert v.gap_ratio > 0.10
+    assert any("gappy" in r for r in v.reasons)
+
+
+def test_business_day_assets_keep_the_bday_reference():
+    """A Mon-Fri series (zero weekend observations) must still be measured
+    against business days — a clean equity series stays a clean pass."""
+    v = verify_instrument("SPY", START, END, _downloader=_fixed(_clean()))
+    assert v.ok
+    assert v.gap_ratio == 0.0
+    assert v.coverage_ratio >= 0.99

--- a/backend/tests/test_data_quality.py
+++ b/backend/tests/test_data_quality.py
@@ -1,0 +1,133 @@
+"""Hermetic tests for the data-quality / fetch-verification harness (#772).
+
+No network: the yfinance boundary is replaced by an injected ``_downloader``
+that returns synthetic pandas Series, so each property the harness gates on —
+fetchable / sufficient history / gap-free / survivorship-clean — is exercised
+deterministically. These prove a known-bad ticker is rejected (the gate excludes
+poisoned data rather than padding it to pass), per #772.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from archimedes.services.data_quality import (
+    verify_instrument,
+    verify_universe,
+)
+
+START = "2022-01-03"
+END = "2023-12-29"
+
+
+def _series(index: pd.DatetimeIndex) -> pd.Series:
+    # Values are irrelevant to the data-quality checks (which read only the index
+    # coverage/gaps), but must be finite + positive like real adjusted closes.
+    return pd.Series(100.0 + np.arange(len(index), dtype=float), index=index)
+
+
+def _clean(start: str = START, end: str = END) -> pd.Series:
+    return _series(pd.bdate_range(start, end))
+
+
+def _fixed(series: pd.Series):
+    """A downloader that returns ``series`` regardless of (ticker, start, end)."""
+
+    def _dl(ticker, s, e):
+        return series
+
+    return _dl
+
+
+def _empty(ticker, s, e):
+    return pd.Series(dtype=float)
+
+
+# ── verify_instrument — the four properties ───────────────────────────────
+
+
+def test_clean_instrument_passes():
+    v = verify_instrument("GOOD", START, END, _downloader=_fixed(_clean()))
+    assert v.ok and v.fetchable
+    assert v.reasons == ()
+    assert v.sufficient_history and v.survivorship_ok
+    assert v.gap_ratio == 0.0
+    assert v.coverage_ratio >= 0.99
+
+
+def test_unfetchable_rejected():
+    v = verify_instrument("DEAD", START, END, _downloader=_empty)
+    assert not v.ok and not v.fetchable
+    assert v.n_obs == 0
+    assert any("unfetchable" in r for r in v.reasons)
+
+
+def test_insufficient_history_rejected():
+    """A late-starting (short) series fails the coverage check, not the gap or
+    survivorship check — isolating the sufficiency property."""
+    half = _series(pd.bdate_range("2023-01-02", END))  # ~second half of the window
+    v = verify_instrument("SHORT", START, END, _downloader=_fixed(half))
+    assert not v.ok
+    assert not v.sufficient_history
+    assert v.coverage_ratio < 0.90
+    assert any("insufficient history" in r for r in v.reasons)
+
+
+def test_gappy_series_rejected():
+    """A full-span series with a large internal hole trips the gap check."""
+    idx = pd.bdate_range(START, END)
+    holed = idx.delete(range(120, 200))  # remove ~80 of ~520 trading days (>10%)
+    v = verify_instrument("GAPPY", START, END, _downloader=_fixed(_series(holed)))
+    assert not v.ok
+    assert v.gap_ratio > 0.10
+    assert any("gappy" in r for r in v.reasons)
+
+
+def test_delisted_survivorship_rejected():
+    """A series that starts on time and is dense but stops trading ~1 month
+    before the window end fails ONLY survivorship — isolating that property."""
+    early = _series(pd.bdate_range(START, "2023-11-30"))
+    v = verify_instrument("DELISTED", START, END, _downloader=_fixed(early))
+    assert not v.ok
+    assert not v.survivorship_ok
+    assert v.sufficient_history  # dense + on-time start → sufficiency passes
+    assert v.gap_ratio <= 0.10  # no internal gaps
+    assert any("survivorship" in r for r in v.reasons)
+
+
+def test_no_silent_padding_of_short_series():
+    """A short series is reported at its ACTUAL length and excluded — never
+    padded up to the expected window length to force a pass (#772 anti-goal)."""
+    half = _series(pd.bdate_range("2023-06-01", END))
+    v = verify_instrument("SHORT", START, END, _downloader=_fixed(half))
+    assert v.n_obs == len(half)
+    assert v.n_obs < v.expected_obs
+    assert not v.ok
+
+
+# ── verify_universe — aggregation ─────────────────────────────────────────
+
+
+def test_verify_universe_admits_only_clean_tickers():
+    feeds = {
+        "GOOD1": _clean(),
+        "GOOD2": _clean(),
+        "DEAD": pd.Series(dtype=float),
+        "SHORT": _series(pd.bdate_range("2023-06-01", END)),
+        "DELISTED": _series(pd.bdate_range(START, "2023-09-01")),
+    }
+
+    def _dl(ticker, s, e):
+        return feeds[ticker]
+
+    report = verify_universe(list(feeds), START, END, _downloader=_dl)
+    assert set(report.admitted) == {"GOOD1", "GOOD2"}
+    assert set(report.rejected) == {"DEAD", "SHORT", "DELISTED"}
+    assert all(report.verdicts[t].ok for t in report.admitted)
+    assert all(report.rejected[t] for t in report.rejected)  # every rejection has reasons
+
+
+def test_verify_universe_empty_input():
+    report = verify_universe([], START, END, _downloader=_empty)
+    assert report.admitted == ()
+    assert report.rejected == {}

--- a/backend/tests/test_generate_universe_data_quality.py
+++ b/backend/tests/test_generate_universe_data_quality.py
@@ -59,3 +59,34 @@ def test_gate_window_matches_backtest_fetch():
     report = vet_data_quality(_downloader=_short_feed)
     assert report.admitted == ()
     assert all(any("insufficient history" in r for r in reasons) for reasons in report.rejected.values())
+
+
+def test_print_global_assets_path_is_gated(monkeypatch, capsys):
+    """--print-global-assets runs the same #772 gate as --write: GLOBAL_ASSETS
+    is the runtime universe the backtests fetch against (the printed rows get
+    hand-pasted into strategy_signal_evaluator.py), so an unvetted ticker here
+    reaches production even more directly than one in the SSOT JSON."""
+    import archimedes.scripts.generate_universe as gu
+
+    bad = sorted({a.yf for a in CURATED})[0]
+
+    def _one_dead(ticker, start, end):
+        if ticker == bad:
+            return pd.Series(dtype=float)
+        return _clean_feed(ticker, start, end)
+
+    monkeypatch.setattr(gu, "load_pyth_catalog", lambda path=None: [])
+    monkeypatch.setattr(gu, "build_pyth_index", lambda feeds: {})
+    monkeypatch.setattr(gu, "vet_data_quality", lambda **kw: vet_data_quality(_downloader=_one_dead))
+    printed = []
+    monkeypatch.setattr(gu, "_print_global_assets", lambda: printed.append(True))
+
+    with pytest.raises(SystemExit) as exc:
+        gu.main(["--print-global-assets"])
+    assert bad in str(exc.value)
+    assert not printed, "GLOBAL_ASSETS must not print when the gate refuses"
+
+    # The loud bypass still works for offline runs.
+    gu.main(["--print-global-assets", "--skip-data-quality"])
+    assert printed == [True]
+    assert "skip-data-quality" in capsys.readouterr().out

--- a/backend/tests/test_generate_universe_data_quality.py
+++ b/backend/tests/test_generate_universe_data_quality.py
@@ -1,0 +1,61 @@
+"""Hermetic tests for the generator's data-quality admission gate (#772).
+
+The SSOT builder (`scripts/generate_universe.py --write`) is the single place
+new instruments enter the universe, so it is where the #772 harness gates
+admission. All feeds are injected — no network.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from archimedes.scripts.generate_universe import CURATED, _dq_gate, vet_data_quality
+
+
+def _clean_feed(ticker, start, end):
+    idx = pd.bdate_range(start, end)
+    return pd.Series(100.0 + np.arange(len(idx), dtype=float), index=idx)
+
+
+def test_vet_covers_every_curated_ticker():
+    report = vet_data_quality(_downloader=_clean_feed)
+    curated_tickers = {a.yf for a in CURATED}
+    assert set(report.verdicts) == curated_tickers
+    assert report.rejected == {}
+    assert set(report.admitted) == curated_tickers
+
+
+def test_gate_passes_on_clean_report():
+    report = vet_data_quality(_downloader=_clean_feed)
+    _dq_gate(report)  # must not raise
+
+
+def test_gate_refuses_write_on_bad_ticker():
+    bad = sorted({a.yf for a in CURATED})[0]
+
+    def _one_dead(ticker, start, end):
+        if ticker == bad:
+            return pd.Series(dtype=float)
+        return _clean_feed(ticker, start, end)
+
+    report = vet_data_quality(_downloader=_one_dead)
+    assert bad in report.rejected
+    with pytest.raises(SystemExit) as exc:
+        _dq_gate(report)
+    # The refusal names the ticker and its reason, so the curator can act on it.
+    assert bad in str(exc.value)
+    assert "unfetchable" in str(exc.value)
+
+
+def test_gate_window_matches_backtest_fetch():
+    # The evaluator fetches period="2y"; a series that only covers the last
+    # year must be rejected as insufficient for the window the backtests use.
+    def _short_feed(ticker, start, end):
+        late_start = pd.Timestamp(end) - pd.DateOffset(years=1)
+        idx = pd.bdate_range(late_start, end)
+        return pd.Series(100.0 + np.arange(len(idx), dtype=float), index=idx)
+
+    report = vet_data_quality(_downloader=_short_feed)
+    assert report.admitted == ()
+    assert all(any("insufficient history" in r for r in reasons) for reasons in report.rejected.values())

--- a/backend/tests/test_universe_parity.py
+++ b/backend/tests/test_universe_parity.py
@@ -47,6 +47,45 @@ BACKTEST_SYNTHS: frozenset[str] = frozenset(GLOBAL_ASSETS.keys())
 ON_CHAIN: frozenset[str] = frozenset(ON_CHAIN_SYNTHS)
 
 
+def test_global_assets_gated_on_data_quality_harness() -> None:
+    """Every admitted universe ticker clears verify_instrument over the backtest
+    window on a clean feed — proving GLOBAL_ASSETS is gated on the #772
+    data-quality harness (the gate excludes poisoned data; it does not lower the
+    DSR/PBO bar). Mocked at the yfinance boundary — no live network."""
+    import numpy as np
+    import pandas as pd
+    from archimedes.services.strategy_signal_evaluator import verify_universe_data_quality
+
+    start, end = "2022-01-03", "2023-12-29"
+
+    def _clean_feed(ticker, s, e):
+        idx = pd.bdate_range(s, e)
+        return pd.Series(100.0 + np.arange(len(idx), dtype=float), index=idx)
+
+    report = verify_universe_data_quality(start, end, _downloader=_clean_feed)
+    # On a clean feed nothing is rejected — the harness admits the full universe
+    # and (by construction) every admitted ticker passed verify_instrument.
+    assert report.rejected == {}, f"clean feed must admit all tickers; rejected={report.rejected}"
+    assert len(report.admitted) > 0
+    assert all(report.verdicts[t].ok for t in report.admitted)
+
+
+def test_data_quality_harness_excludes_bad_ticker() -> None:
+    """The parity gate rejects an un-fetchable ticker rather than admitting it —
+    the universe is not greened on data that cannot be fetched (#772)."""
+    import pandas as pd
+    from archimedes.services.strategy_signal_evaluator import verify_universe_data_quality
+
+    start, end = "2022-01-03", "2023-12-29"
+
+    def _all_empty(ticker, s, e):
+        return pd.Series(dtype=float)
+
+    report = verify_universe_data_quality(start, end, _downloader=_all_empty)
+    assert report.admitted == ()
+    assert len(report.rejected) > 0
+
+
 def test_ssot_loaded_non_empty() -> None:
     # A silent SSOT-load failure (missing/garbled JSON) would make every other
     # parity check pass vacuously on an empty set — guard against it.


### PR DESCRIPTION
Closes #772.

## What

The #759 expansion pulls yfinance's long tail, and those names are exactly where history goes bad: delisted tickers vanish, series start late, gaps appear mid-window. Gappy or survivorship-biased returns quietly inflate Sharpe and poison the DSR/PBO gate, which assumes clean series. So this adds a per-instrument data-quality check that runs as a precondition for universe admission.

- New `backend/archimedes/services/data_quality.py`: `verify_instrument(ticker, start, end)` checks four properties over the backtest window (fetchable, window coverage >= 90%, internal gap ratio <= 10%, still trading near the window end). `verify_universe` aggregates into admitted/rejected with reasons.
- `strategy_signal_evaluator.py` re-exports the harness and adds `verify_universe_data_quality()` over the `GLOBAL_ASSETS` tickers.
- The universe parity test now proves the harness admits the full universe on a clean feed and rejects an un-fetchable ticker instead of greening on it.

Bad data gets excluded, never padded or truncated to pass. Thresholds are deliberately conservative; the 10% gap tolerance clears real holiday calendars (~3.5% of business days) with room to spare while catching true holes.

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_data_quality.py backend/tests/test_universe_parity.py -q
grep -n "verify_instrument\|verify_universe" backend/archimedes/services/strategy_signal_evaluator.py
```

25 passed hermetically across the harness, parity, and generator-gate tests (the yfinance boundary is a single injectable function, tests never hit the network). Full backend unit suite on the branch rebased onto main: 2244 passed. ruff format + check clean.

## Notes

- No DSR/PBO thresholds touched; the gate excludes bad data, it doesn't lower the bar.
- Second commit wires the harness into the admission path: `scripts/generate_universe.py --write` (the one place instruments enter the SSOT) now refuses to write if any curated yfinance ticker fails verification over the 2y backtest window, with per-ticker reasons. `--skip-data-quality` bypasses it loudly for offline runs. Tests inject the downloader, so CI stays offline.
