### PR TITLE
[quant] Feed the real candidate-pool correlation into the society DSR (#822)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -281,6 +281,12 @@ class _CandidateResult:
     # downstream buy-and-hold backtest step is skipped — it would clobber the
     # already-computed fusion metrics with a different, weight-less read).
     has_real_rigor: bool = False
+    # The society num_trials (#770, N + library_size) this candidate's DSR was
+    # first computed with. Recorded so the post-loop correlation patch (#822)
+    # recomputes DSR at the SAME trial count — only the average_correlation term
+    # changes, never the deflation count itself. 0 on the fixture/fusion paths,
+    # which don't run the buy-and-hold DSR patch.
+    dsr_num_trials: int = 0
 
 
 # ── Rigor adapter (Önder's rigor_evaluator on agent output) ───────────────
@@ -332,6 +338,7 @@ def _rigor_verdict_for(
     num_trials: int,
     *,
     lookahead_passed: bool = True,
+    average_correlation: float = 0.0,
 ) -> dict[str, Any]:
     """Run Önder's rigor primitives on a portfolio return series.
 
@@ -343,6 +350,12 @@ def _rigor_verdict_for(
     of the strategy universe the winner was selected from (the curated library),
     NOT 1. With ``num_trials=1`` the DSR expectation-of-max term collapses to 0
     and the ratio is undeflated, which silently defeats the gate.
+
+    ``average_correlation`` is the mean pairwise correlation among the
+    ``num_trials`` society candidates (approach B, issue #822). Defaults to
+    ``0.0`` — the independent-trials assumption (approach A, #811/#770) — which
+    the caller keeps as the fallback whenever a pool-wide correlation can't be
+    estimated (fewer than two candidate return series).
 
     ``lookahead_passed`` is the look-ahead-audit verdict, computed by the caller
     (see ``_lookahead_for_candidate``) so the primitive actually gates the
@@ -364,7 +377,7 @@ def _rigor_verdict_for(
         compute_oos_sharpe,
     )
 
-    dsr, dsr_p = compute_dsr(return_series, num_trials=max(1, num_trials))
+    dsr, dsr_p = compute_dsr(return_series, num_trials=max(1, num_trials), average_correlation=average_correlation)
     oos = compute_oos_sharpe(return_series)
     in_sample_sharpe = compute_in_sample_sharpe(return_series)
     # PBO is library-level (needs ≥2 candidate return series); the caller
@@ -465,6 +478,67 @@ def _patch_pbo(candidates: list[_CandidateResult]) -> None:
         # `passing` to require both the per-strategy DSR test AND library-PBO
         # under the 0.5 threshold.
         c.rigor_verdict["passing"] = bool(c.rigor_verdict.get("passing") and pbo < 0.5)
+
+
+def _patch_dsr_with_pool_correlation(candidates: list[_CandidateResult]) -> None:
+    """Re-deflate each buy-and-hold candidate's DSR using the REAL candidate-pool ρ̄.
+
+    Approach B (#822) for the society DSR multiple-testing correction. #811 (#770)
+    set ``average_correlation=0.0`` — i.e. treated the N society candidates as
+    mutually independent trials. They're generated from the same user brief over
+    overlapping universes, so they're typically strongly correlated (ρ̄ ≈ 0.5–0.9),
+    and feeding ρ̄=0 over-deflates ``E[max_N]``, over-stating the gate's strictness.
+    Under equicorrelation the effective trial count is
+    ``N_eff = N / (1 + (N-1)·ρ̄)`` (Cheverud 2001; Nyholt 2004) — this patch estimates
+    the real ρ̄ across the pool's return series (``compute_average_pairwise_correlation``)
+    and recomputes DSR at the SAME ``dsr_num_trials`` each candidate was already
+    deflated at, so only the correlation term changes.
+
+    Runs AFTER ``_patch_pbo`` and mirrors its shape and scope: fusion/debate
+    candidates (``has_real_rigor=True``) carry a real DSR from their own CSCV
+    evaluator and are SKIPPED — recomputing over the buy-and-hold pool would
+    clobber a correctly-computed value with an unrelated one. With fewer than
+    two eligible return series (no correlation estimable), every candidate's DSR
+    is left untouched — approach A (ρ̄=0) is the fallback, per the issue.
+
+    A correlated pool can only RELAX the deflation relative to ρ̄=0 (never tighten
+    beyond it — ``N_eff <= N`` always), so ``dsr_p_value`` only ever moves up or
+    stays the same here, never down. ``passing`` is re-derived from the full set
+    of admission legs (DSR, OOS/cliff, look-ahead) rather than AND-ed in, since a
+    higher DSR p-value can flip a candidate from failing to passing, not just the
+    reverse (unlike the PBO patch above, which can only tighten).
+    """
+    agent_cands = [c for c in candidates if not c.has_real_rigor]
+    series_map: dict[str, list[float]] = {c.candidate_id: c.return_series for c in agent_cands if c.return_series}
+    if len(series_map) < 2:
+        return  # approach A (ρ̄=0) fallback — nothing to patch, verdicts already reflect it
+
+    from archimedes.services.rigor_evaluator import compute_average_pairwise_correlation, compute_dsr
+
+    avg_correlation = compute_average_pairwise_correlation(series_map)
+    if avg_correlation <= 0.0:
+        return  # no correlation relief to apply — ρ̄=0 verdicts are already correct
+
+    for c in agent_cands:
+        v = c.rigor_verdict
+        if v.get("dsr") is None or not c.return_series or c.dsr_num_trials < 1:
+            continue  # too-short series or never ran the buy-and-hold DSR — nothing to recompute
+        dsr, dsr_p = compute_dsr(c.return_series, num_trials=c.dsr_num_trials, average_correlation=avg_correlation)
+        if dsr is None or dsr_p is None:
+            continue
+        v["dsr"] = round(float(dsr), 4)
+        v["dsr_p_value"] = round(float(dsr_p), 4)
+        oos = v.get("oos_sharpe")
+        in_sample = v.get("in_sample_sharpe")
+        oos_pass = oos is not None and oos > 0.0
+        if oos_pass and in_sample is not None and math.isfinite(in_sample) and in_sample > 0 and oos / in_sample < 0.5:
+            oos_pass = False
+        # PBO's own leg is folded into `passing` by `_patch_pbo` already; re-derive
+        # from the ORIGINAL passing value's PBO contribution by requiring it again
+        # here (pbo < 0.5, undefined-PBO / N<2 patched to 0.0 which always passes).
+        pbo = v.get("pbo")
+        pbo_pass = pbo is None or pbo < 0.5
+        v["passing"] = bool(dsr_p >= 0.95 and oos_pass and v.get("lookahead_audit_passed", False) and pbo_pass)
 
 
 # ── Event emitter ─────────────────────────────────────────────────────────
@@ -772,6 +846,7 @@ async def _run_live_candidate(
         passes_rigor=verdict.get("passing", False),
         regime=regime,
         return_series=return_series,
+        dsr_num_trials=num_trials,
     )
 
 
@@ -1298,6 +1373,11 @@ async def run_generation(
         # gracefully by setting PBO=0.0). After this, every candidate's
         # rigor_verdict has all four fields (DSR, PBO, OOS Sharpe, lookahead).
         _patch_pbo(candidates)
+        # Re-deflate DSR using the REAL candidate-pool correlation (#822, approach B
+        # for #770/#811). Runs after PBO so it can re-derive `passing`'s PBO leg from
+        # the already-patched value. Falls back to the untouched ρ̄=0 verdicts (approach
+        # A) whenever fewer than two buy-and-hold return series are available.
+        _patch_dsr_with_pool_correlation(candidates)
         for c in candidates:
             c.passes_rigor = c.rigor_verdict.get("passing", False)
 

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -7,12 +7,22 @@ best. Selection-from-N is itself a multiple-testing search, so the Deflated Shar
 must deflate for N + library_size, not library alone (which under-deflated and inflated
 the survivor's DSR). These tests pin the chosen formula (approach A) and prove the
 correction rejects a best-of-N survivor that the library-only count would have admitted.
+
+Also covers approach B (#822): feeding the REAL candidate-pool pairwise correlation ρ̄
+into the same DSR call, instead of the ρ̄=0 (independent-trials) assumption approach A
+ships with. The N society candidates share a brief and overlapping universes, so they
+are typically correlated — ρ̄=0 over-deflates and over-states the gate's strictness.
 """
 
 from __future__ import annotations
 
 import numpy as np
-from archimedes.agents.generation_pipeline import _rigor_verdict_for, _society_num_trials
+from archimedes.agents.generation_pipeline import (
+    _CandidateResult,
+    _patch_dsr_with_pool_correlation,
+    _rigor_verdict_for,
+    _society_num_trials,
+)
 
 
 class TestSocietyNumTrialsFormula:
@@ -57,3 +67,154 @@ class TestNumTrialsCorrection:
         p_small = _rigor_verdict_for(series, num_trials=4, lookahead_passed=True)["dsr_p_value"]
         p_large = _rigor_verdict_for(series, num_trials=24, lookahead_passed=True)["dsr_p_value"]
         assert p_large <= p_small
+
+
+def _candidate(candidate_id: str, return_series: list[float], num_trials: int) -> _CandidateResult:
+    """Build a buy-and-hold society candidate with a real DSR verdict already computed
+    at ρ̄=0 (approach A) — the state each candidate is in right after ``_run_live_candidate``,
+    before the post-loop pool-correlation patch runs."""
+    verdict = _rigor_verdict_for(return_series, num_trials=num_trials, lookahead_passed=True)
+    verdict["pbo"] = 0.0  # mirrors _patch_pbo's N<2 default; patch under test runs after PBO
+    return _CandidateResult(
+        candidate_id=candidate_id,
+        strategy_name=f"Strategy {candidate_id}",
+        thesis="t",
+        asset_universe=["sSPY"],
+        source_papers=[],
+        weights={"sSPY": 1.0},
+        reasoning="r",
+        rigor_verdict=verdict,
+        passes_rigor=verdict.get("passing", False),
+        return_series=return_series,
+        dsr_num_trials=num_trials,
+    )
+
+
+class TestPoolCorrelationDSR:
+    """Approach B (#822): feed the real candidate-pool ρ̄ into the society DSR, replacing
+    the ρ̄=0 (independent-trials) assumption approach A ships with for the N generated
+    candidates' own DSR call. ``_patch_dsr_with_pool_correlation`` is the post-loop patch
+    ``run_generation`` calls after ``_patch_pbo``, once every candidate's return series
+    is known — mirrors the existing PBO patch's two-pass shape."""
+
+    _NUM_TRIALS = 24  # library_size=4 + selection_pool_size=20, same as TestNumTrialsCorrection
+
+    def _correlated_pool(self, n: int, rho_target: float, seed: int = 11) -> list[list[float]]:
+        """N series sharing a common factor + idiosyncratic noise, engineered so the
+        realized average pairwise correlation is close to ``rho_target``. Same brief,
+        overlapping universe — the scenario #822 describes."""
+        rng = np.random.default_rng(seed)
+        t = 300
+        factor = rng.normal(0.0009, 0.009, t)
+        idio_scale = 0.009 * np.sqrt(max(1e-9, (1.0 - rho_target) / max(rho_target, 1e-9)))
+        series = []
+        for _ in range(n):
+            idio = rng.normal(0.0, idio_scale, t)
+            series.append((np.sqrt(rho_target) * factor + np.sqrt(1.0 - rho_target) * idio).tolist())
+        return series
+
+    def _independent_pool(self, n: int, seed: int = 23) -> list[list[float]]:
+        rng = np.random.default_rng(seed)
+        return [rng.normal(0.0009, 0.009, 300).tolist() for _ in range(n)]
+
+    def test_correlated_pool_relaxes_dsr_pvalue_never_tightens(self):
+        """Monotonicity pin (acceptance criterion #1): a correlated pool's DSR p-value
+        is >= the ρ̄=0 (approach A) value for every candidate — the correction only
+        relaxes over-deflation, never tightens the gate beyond approach A."""
+        series_list = self._correlated_pool(n=5, rho_target=0.75)
+        candidates = [_candidate(f"cand_{i}", s, self._NUM_TRIALS) for i, s in enumerate(series_list)]
+        baseline_p = [c.rigor_verdict["dsr_p_value"] for c in candidates]  # ρ̄=0, computed in _candidate()
+
+        _patch_dsr_with_pool_correlation(candidates)
+
+        patched_p = [c.rigor_verdict["dsr_p_value"] for c in candidates]
+        for base, patched in zip(baseline_p, patched_p, strict=True):
+            assert patched >= base, "approach B must relax (never tighten) the ρ̄=0 p-value"
+        # A materially correlated pool should show a REAL relaxation somewhere, not a no-op.
+        assert any(p > b for b, p in zip(baseline_p, patched_p, strict=True))
+
+    def test_correlated_pool_uses_n_eff_below_nominal_count(self):
+        """Acceptance criterion #1: the society DSR uses N_eff < N + library_size for a
+        correlated pool. Cross-check via compute_dsr directly at N_eff vs. the nominal
+        count, on the same series the patch would have used."""
+        from archimedes.services.rigor_evaluator import compute_average_pairwise_correlation, compute_dsr
+
+        series_list = self._correlated_pool(n=5, rho_target=0.75)
+        rho_bar = compute_average_pairwise_correlation({str(i): s for i, s in enumerate(series_list)})
+        assert 0.0 < rho_bar < 1.0, "the engineered pool must realize a real, non-trivial correlation"
+
+        _, p_nominal = compute_dsr(series_list[0], num_trials=self._NUM_TRIALS, average_correlation=0.0)
+        _, p_neff = compute_dsr(series_list[0], num_trials=self._NUM_TRIALS, average_correlation=rho_bar)
+        assert p_neff >= p_nominal
+
+    def test_fewer_than_two_series_falls_back_to_rho_zero(self):
+        """Acceptance criterion #2: with < 2 candidate return series, stay on approach A
+        (ρ̄=0) unchanged — no correlation is estimable from a single series."""
+        series_list = self._correlated_pool(n=1, rho_target=0.75)
+        candidates = [_candidate("cand_0", series_list[0], self._NUM_TRIALS)]
+        before = dict(candidates[0].rigor_verdict)
+
+        _patch_dsr_with_pool_correlation(candidates)
+
+        assert candidates[0].rigor_verdict["dsr_p_value"] == before["dsr_p_value"]
+        assert candidates[0].rigor_verdict["dsr"] == before["dsr"]
+
+    def test_no_return_series_at_all_falls_back_to_rho_zero(self):
+        """Zero eligible series (e.g. every candidate too-short / fixture path) is also
+        the < 2 fallback — must not raise."""
+        candidates = [_candidate("cand_0", [], self._NUM_TRIALS)]
+        before = dict(candidates[0].rigor_verdict)
+
+        _patch_dsr_with_pool_correlation(candidates)
+
+        assert candidates[0].rigor_verdict == before
+
+    def test_independent_pool_is_a_near_noop(self):
+        """A genuinely independent pool (ρ̄ ≈ 0) should leave the DSR verdict close to the
+        approach-A baseline — the correction only bites when candidates are actually
+        correlated, consistent with N_eff → N as ρ̄ → 0."""
+        series_list = self._independent_pool(n=5)
+        candidates = [_candidate(f"cand_{i}", s, self._NUM_TRIALS) for i, s in enumerate(series_list)]
+        baseline_p = [c.rigor_verdict["dsr_p_value"] for c in candidates]
+
+        _patch_dsr_with_pool_correlation(candidates)
+
+        patched_p = [c.rigor_verdict["dsr_p_value"] for c in candidates]
+        for base, patched in zip(baseline_p, patched_p, strict=True):
+            assert patched >= base  # monotonicity still holds even near ρ̄=0
+            assert abs(patched - base) < 0.02, "near-independent pool should barely move the p-value"
+
+    def test_fusion_candidates_excluded_from_pool_and_untouched(self):
+        """has_real_rigor candidates (fusion/debate) carry their own CSCV-derived DSR and
+        must never be folded into the buy-and-hold pool correlation, or patched — mirrors
+        _patch_pbo's existing scope boundary."""
+        series_list = self._correlated_pool(n=3, rho_target=0.8)
+        buy_and_hold = [_candidate(f"cand_{i}", s, self._NUM_TRIALS) for i, s in enumerate(series_list)]
+        fusion_verdict = {
+            "dsr": 1.23,
+            "dsr_p_value": 0.5,
+            "pbo": 0.1,
+            "oos_sharpe": 0.4,
+            "in_sample_sharpe": 0.5,
+            "lookahead_audit_passed": True,
+            "passing": True,
+        }
+        fusion_candidate = _CandidateResult(
+            candidate_id="cand_fusion",
+            strategy_name="Fusion X",
+            thesis="t",
+            asset_universe=["sSPY"],
+            source_papers=[],
+            weights={},
+            reasoning="r",
+            rigor_verdict=dict(fusion_verdict),
+            passes_rigor=True,
+            has_real_rigor=True,
+            return_series=series_list[0],  # even if it "looks like" pool data, must be ignored
+            generation_method="fusion",
+        )
+        candidates = [*buy_and_hold, fusion_candidate]
+
+        _patch_dsr_with_pool_correlation(candidates)
+
+        assert fusion_candidate.rigor_verdict == fusion_verdict, "fusion candidate's real DSR must be untouched"

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -156,6 +156,46 @@ fresh candidate pool, so that route keeps `num_trials = library_size`.
 > statistics call. This addendum records approach **A** as the shipped default pending his
 > review; promoting to B is a follow-up if candidate-pool over-deflation proves material.
 
+#### Addendum (#822) — approach B ships alongside A: real ρ̄ feeds the same `num_trials`
+
+Approach A's additive `num_trials = n_candidates + library_size` stays the trial *count* —
+this addendum does not change it. What it fixes is the `average_correlation` argument A
+shipped with: `0.0`, i.e. treating all `n_candidates` society candidates as mutually
+independent trials. They are generated from the **same user brief over overlapping
+universes**, so in practice they are typically strongly correlated (ρ̄ ≈ 0.5–0.9), and
+feeding ρ̄ = 0 over-deflates `E[max_N]` — over-stating the gate's strictness and risking
+rejection of genuinely-skilled strategies whose correlated siblings get counted as
+independent searches they aren't.
+
+**What ships.** The live society path (`agents/generation_pipeline.py`) estimates ρ̄ from
+the candidate pool's own return series via `compute_average_pairwise_correlation` (no
+change to that function or to `compute_dsr`'s `N_eff` formula — both are reused as-is) and
+feeds it into the same `compute_dsr` call each candidate's DSR was already computed with,
+at the same `num_trials`. `_patch_dsr_with_pool_correlation` runs once every candidate's
+return series is known (mirroring the existing `_patch_pbo` two-pass shape: DSR is first
+computed per-candidate at ρ̄=0 during the generation loop, then re-deflated with the pool's
+real ρ̄ once the full pool exists).
+
+**Fallback stays approach A.** With fewer than two candidate return series available (a
+single-candidate generation, or every series too short to correlate), ρ̄ cannot be
+estimated and the verdict is left exactly as approach A computed it — ρ̄=0, unchanged. The
+same applies to fusion/debate candidates (`has_real_rigor=True`): they carry a real DSR
+from their own CSCV evaluator over a parameter-variant grid, not the buy-and-hold return
+series this correlation estimate is scoped to, and are excluded from the pool the same way
+`_patch_pbo` already excludes them from cross-candidate PBO.
+
+**Why this can only relax, never loosen past the no-correction floor.** `N_eff = N / (1 +
+(N-1)ρ̄)` satisfies `1 ≤ N_eff ≤ N` for any `ρ̄ ∈ [0, 1]`, so the corrected DSR p-value sits
+between the ρ̄=0 (approach A) value and the value at `num_trials=1` (no multiple-testing
+penalty at all) — it never exceeds the latter, so the gate is never made looser than the
+IID-Sharpe baseline. At ρ̄→1 (candidates fully collapse to one effective trial) the
+corrected p-value converges to exactly the `num_trials=1` floor, never past it.
+
+**Scope.** Same as A: this applies to the live society generation path only. The
+`/api/selection-bias/gate` route (grading the persisted library) is untouched by this
+addendum — it already estimates a library-wide ρ̄ via `verdicts_for_strategies` in
+`live_rigor_gate.py`, a separate, pre-existing mechanism this issue doesn't touch.
+
 ## 2. Probability of Backtest Overfitting (PBO)
 
 **Reference:** Bailey, D. H., Borwein, J., López de Prado, M., & Zhu, J.


### PR DESCRIPTION
Closes #822. Also closes #770 (the reopened tracking parent — this is the calibration piece it was reopened for).

## What

Approach B for #770/#811. #811 set `num_trials = N + library_size` on the society path
but fed `average_correlation=0` into `compute_dsr`, i.e. treated the N society candidates
as mutually independent. They come from the same brief over overlapping universes so in
practice they're usually correlated (rho ~ 0.5-0.9), and rho=0 over-deflates `E[max_N]` —
over-states the gate's strictness and can reject a genuinely-skilled strategy whose
siblings get counted as independent searches they aren't.

- `_rigor_verdict_for` takes an `average_correlation` kwarg (default 0.0, so #811's own
  tests are untouched) and threads it straight into `compute_dsr`.
- New `_patch_dsr_with_pool_correlation`, wired in after `_patch_pbo`. Mirrors the PBO
  patch's two-pass shape: each candidate's DSR is first computed at rho=0 during the
  generation loop, then re-deflated once the full pool's return series are known.
  Estimates rho via `compute_average_pairwise_correlation` over the buy-and-hold
  candidates and recomputes DSR at the SAME `num_trials` each candidate already used —
  only the correlation term moves.
- Falls back to rho=0 (approach A) untouched with <2 usable return series, and
  fusion/debate candidates (`has_real_rigor`) are excluded from the pool the same way
  `_patch_pbo` already excludes them — they carry a real DSR from their own CSCV grid,
  not this buy-and-hold series.
- `passing` is fully re-derived (DSR + OOS/cliff + look-ahead + PBO), not AND-ed with the
  prior value — a relaxed p-value can flip a candidate from failing to passing, an AND
  could only ever remove candidates.
- No change to `compute_dsr` or the N_eff formula in `_rigor_helpers.py` — reused as-is.
  `N_eff = N/(1+(N-1)*rho)` is always in `[1, N]`, so the corrected p-value sits between
  the rho=0 value and the `num_trials=1` (no correction at all) floor — checked this
  numerically across rho in [0, 1], never crosses it.

Spec addendum in `selection-bias-corrections-spec.md` documents the rationale and the
never-looser-than-IID bound.

## Verify

```bash
pytest backend/tests/test_generation_pipeline.py -q
```

11 passed (5 existing #811 + 6 new). Hermetic gate clean. Broader rigor/generation/dsr/pbo
surface: 361 passed, 0 failed. ruff format + critical lint clean.

## Anti-goals checked

- Did not touch `compute_dsr` or the N_eff formula in `_rigor_helpers.py` — `git diff` on
  that file is empty.
- Correction never loosens past the IID (`num_trials=1`) baseline — true by construction
  (`N_eff` bounded in `[1, N]`) and confirmed with a numerical sweep of rho in [0, 1].
