### PR TITLE
[quant] Unify DSR num_trials across the live and fusion generation paths (#820)

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -19,11 +19,11 @@ society:
      rebuttal + LLM risk-debate is Phase 2.
   3. **C-rigor** — backtests EVERY survivor for real via ``evaluate_fusion_spec``
      (deterministic Python, 0 tokens), each wrapped in try/except (fix A5
-     backstop), with ``num_trials=pool_size`` so the DSR multiple-testing
-     correction counts the selection-from-pool search. This is the self-contained
-     A1 deflation at the per-candidate evaluator — it coordinates with #770's
-     ``library + N`` additive correction on the generation path rather than the
-     library-grading external route, so it does not fight that PR.
+     backstop), with ``num_trials=_society_num_trials(library_size, pool_size)``
+     (library + N, #770/#820 — not ``pool_size`` alone) so the DSR
+     multiple-testing correction counts both the selection-from-pool search AND
+     the library the winner joins, the same selection set the live agent path
+     deflates for.
   4. **C-null** — a survivor must beat the passive null (buy-and-hold) net of
      cost by ``MIN_COST_BENEFIT``. If none clears it → first-class ABSTAIN.
   5. **Synthesizer** — deterministic rank of the survivors (Phase 1 collapses the
@@ -34,9 +34,11 @@ contract preserving); the full leaderboard is built by ``build_leaderboard``
 (directly unit-tested) and the Considered-Alternatives fan-out is Phase 2.
 
 ⚠️  PHASE-1 BLOCKER: ``ARCHIMEDES_DEBATE_ENABLED`` must stay OFF on the live path
-until A1 (``pool_size`` → the external rigor gate, the OPEN Önder denominator)
-is proven there — else the rigor badge can false-PASS. The flag-OFF additive
-skeleton in this module is safe to merge.
+until this module's rigor badge has been validated end-to-end there (A1's
+denominator now matches the live path's — library + N via
+``_society_num_trials``, #770/#820 — but the flag still needs a real on-flag
+run before it's trusted). The flag-OFF additive skeleton in this module is
+safe to merge.
 """
 
 from __future__ import annotations
@@ -359,10 +361,11 @@ async def _debate_round(pool: list[Any], model: str | None, emit: _Emitter, cand
 async def _critic_rigor(pool: list[Any], num_trials: int) -> list[tuple[Any, Any]]:
     """Backtest every pooled spec for real; return ``[(proposal, eval_result)]``.
 
-    ``num_trials=pool_size`` so the DSR deflation counts the selection-from-pool
-    search (A1). Each ``evaluate_fusion_spec`` is wrapped in try/except so one bad
-    spec (despite the A5 pre-guard) drops with an honest emit, never aborting the
-    cohort.
+    ``num_trials`` is ``_society_num_trials(library_size, pool_size)`` (library + N,
+    #770/#820), so the DSR deflation counts the selection-from-pool search AND the
+    library the winner joins — not ``pool_size`` alone. Each ``evaluate_fusion_spec``
+    is wrapped in try/except so one bad spec (despite the A5 pre-guard) drops with
+    an honest emit, never aborting the cohort.
     """
     from archimedes.services.fusion_evaluator import evaluate_fusion_spec
     from archimedes.services.fusion_market_data import real_data_enabled
@@ -456,7 +459,7 @@ def _rigor_verdict_dict(ev: Any) -> dict[str, Any]:
         "in_sample_sharpe": r.in_sample_sharpe,
         "lookahead_audit_passed": bool(r.look_ahead_clean),
         "look_ahead_label": r.look_ahead_label,
-        "num_trials": int(r.num_trials),  # == pool_size (A1)
+        "num_trials": int(r.num_trials),  # library + pool_size, #770/#820 (A1)
         "passing": bool(r.passing),
         "data_source": r.data_source,
         "admissible": bool(ev.admissible),

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -799,7 +799,7 @@ async def _run_fusion_candidate(
     emit: _Emitter,
     regime: str = "neutral",
     agent: Any = None,  # noqa: ARG001 — signature parity with _run_live_candidate; fusion path builds its own client
-    selection_pool_size: int = 1,  # noqa: ARG001 — signature parity; fusion candidates skip the static DSR path
+    selection_pool_size: int = 1,
 ) -> _CandidateResult:
     """Drive the existing fusion engine with per-step streaming event emission.
 
@@ -882,12 +882,25 @@ async def _run_fusion_candidate(
         )
         from archimedes.services.fusion_evaluator import evaluate_fusion_spec
         from archimedes.services.fusion_market_data import real_data_enabled
+        from archimedes.services.strategy_provider import default_provider
+
+        # #820: this candidate is one of `selection_pool_size` society candidates
+        # and its winner joins the library, same as the live agent path — so it
+        # needs the same num_trials, not evaluate_fusion_spec's own library-size-
+        # only default (which under-deflates relative to _run_live_candidate).
+        library_size = len(default_provider().list_strategies())
+        num_trials = _society_num_trials(library_size, selection_pool_size)
 
         # Real data (the deployability unlock, #788/#818): a cold yfinance fetch
         # for the spec's universe plus the per-asset variant grid can take a few
         # minutes — 300s bounds it; the panel cache makes warm runs fast again.
         eval_result = await asyncio.wait_for(
-            asyncio.to_thread(evaluate_fusion_spec, proposal.strategy_spec, use_real_data=real_data_enabled()),
+            asyncio.to_thread(
+                evaluate_fusion_spec,
+                proposal.strategy_spec,
+                num_trials=num_trials,
+                use_real_data=real_data_enabled(),
+            ),
             timeout=300.0,
         )
         asset_universe = list(proposal.strategy_spec.get("asset_universe", []) or [])

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -180,6 +180,9 @@ async def evaluate_rigor_gate():
     # library, so the selection set is the library itself — there is no fresh
     # N-candidate society pool to add (that additive correction, N + library_size,
     # applies only on the live society generation path in generation_pipeline.py).
+    # #820 unified the live and fusion generation paths on that additive count;
+    # this route staying on library-size alone is the deliberate exception, not
+    # a fourth convention that slipped through.
     num_trials = max(len(valid_returns), 1)
 
     # The strategy library is the multiple-testing selection set; correlated

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1623,11 +1623,22 @@ async def _run_fusion_job(job_id: str) -> None:
         eval_result = None
         if result.strategy_spec is not None:
             try:
+                from archimedes.agents.generation_pipeline import _society_num_trials
                 from archimedes.services.fusion_evaluator import evaluate_fusion_spec
                 from archimedes.services.fusion_market_data import real_data_enabled
+                from archimedes.services.strategy_provider import default_provider
 
+                # #820: same deflation denominator as the society/live paths —
+                # library + pool (pool=1 here: a single direct-fusion candidate).
+                # Without this, evaluate_fusion_spec falls back to its
+                # library-size-only default and this route under-deflates
+                # relative to every other generation path.
+                library_size = len(default_provider().list_strategies())
                 eval_result = await asyncio.to_thread(
-                    evaluate_fusion_spec, result.strategy_spec, use_real_data=real_data_enabled()
+                    evaluate_fusion_spec,
+                    result.strategy_spec,
+                    use_real_data=real_data_enabled(),
+                    num_trials=_society_num_trials(library_size, 1),
                 )
             except Exception as _eval_exc:
                 import logging as _logging

--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -650,15 +650,18 @@ def apply_rigor_gate(
                 (curve[i] - curve[i - 1]) / curve[i - 1] for i in range(1, len(curve)) if curve[i - 1] > 0
             ]
 
-    # num_trials = actual size of the multiple-testing selection set. The
-    # caller-supplied/default value (curated library size — see
-    # _default_num_trials) under-deflates a large variant grid (e.g. a
-    # 50-variant sweep gets only a library-sized penalty) and over-deflates a
-    # small one. When the variant matrix is known, it is a MORE precise
-    # selection-set size, so it takes priority over the library-size fallback.
+    # num_trials = actual size of the multiple-testing selection set. A variant
+    # grid is a second, independent selection layer — a parameter sweep within
+    # this one candidate, on top of whatever selection set the caller already
+    # accounted for (society N + library, #820, or the plain library-size
+    # fallback when the caller passed nothing more precise). Take whichever
+    # count is larger rather than letting a small grid (e.g. 3 variants)
+    # silently override a bigger, correct caller-supplied count — this can
+    # only make the gate at least as strict as either layer alone, never
+    # looser than either (#820).
     effective_trials = num_trials
     if variants_metrics is not None and len(variants_metrics) >= 2:
-        effective_trials = len(variants_metrics)
+        effective_trials = max(num_trials, len(variants_metrics))
 
     # Correlated variants carry fewer independent trials than their nominal
     # count, so the multiple-testing penalty in the DSR is relaxed accordingly.

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -544,3 +544,34 @@ class TestFusionGateUsesRealTrialCount:
             base.append(base[-1] * (1.003 if i % 2 == 0 else 1.001))
         verdict = apply_rigor_gate(_metrics_from_curve(base), num_trials=7)
         assert verdict.num_trials == 7
+
+    def test_larger_passed_num_trials_is_not_overridden_by_a_small_variant_grid(self):
+        """#820: a small parameter-variant grid must not silently undercut a
+        bigger, correct caller-supplied num_trials (e.g. the society count,
+        library_size + selection_pool_size, threaded from _run_fusion_candidate).
+        Before this fix, any >=2-entry variants_metrics unconditionally replaced
+        num_trials, so a 3-variant grid could under-deflate a strategy that
+        actually needed a much larger society-wide trial count."""
+        base = [100_000.0]
+        for i in range(800):
+            base.append(base[-1] * (1.003 if i % 2 == 0 else 1.001))
+        base_metrics = _metrics_from_curve(base)
+
+        # Only 3 variants (a small parameter sweep), but num_trials=15 reflects a
+        # bigger selection set (e.g. library_size=10 + selection_pool_size=5).
+        variants = {f"v{i}": _metrics_from_curve(base) for i in range(3)}
+        verdict = apply_rigor_gate(base_metrics, num_trials=15, variants_metrics=variants)
+        assert verdict.num_trials == 15
+
+    def test_smaller_passed_num_trials_still_yields_to_a_larger_variant_grid(self):
+        """The max() composition is symmetric: a genuinely larger variant grid
+        still wins over a smaller passed-in num_trials, preserving the original
+        under-deflation fix this class's first test pins."""
+        base = [100_000.0]
+        for i in range(800):
+            base.append(base[-1] * (1.003 if i % 2 == 0 else 1.001))
+        base_metrics = _metrics_from_curve(base)
+
+        variants = {f"v{i}": _metrics_from_curve(base) for i in range(30)}
+        verdict = apply_rigor_gate(base_metrics, num_trials=10, variants_metrics=variants)
+        assert verdict.num_trials == 30

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -664,6 +664,118 @@ async def test_fusion_dispatch_end_to_end_persists_fusion_strategy(tmp_path, mon
     )
 
 
+@pytest.mark.asyncio
+async def test_fusion_path_num_trials_matches_society_formula(tmp_path, monkeypatch):
+    """#820: the fusion candidate must deflate for the SAME selection set as the
+    live agent path — library_size + selection_pool_size (_society_num_trials) —
+    not evaluate_fusion_spec's own library-size-only default.
+
+    Before this fix, ``selection_pool_size`` reached ``_run_fusion_candidate`` but
+    was never threaded into ``evaluate_fusion_spec``, so the fusion path silently
+    under-deflated relative to the live path for an identical (pool, library) pair.
+    The mock spec also carries a 3-variant ``parameter_variants`` grid, so this
+    also proves a small variant grid no longer silently overrides a bigger,
+    correct society count (the ``apply_rigor_gate`` composition fix).
+    """
+    import archimedes.db as _db
+    import archimedes.services.fusion_evaluator as fe
+    from archimedes.agents import generation_pipeline as gp
+    from archimedes.agents import strategy_fusion as sf
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    test_engine = create_engine(
+        f"sqlite:///{tmp_path / 'fusion_num_trials.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    monkeypatch.setattr(_db, "engine", test_engine)
+    monkeypatch.setattr(_db, "SessionLocal", sessionmaker(bind=test_engine, autocommit=False, autoflush=False))
+    from archimedes.models import kg, strategy_passport_record  # noqa: F401
+
+    _db.Base.metadata.create_all(bind=test_engine)
+
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
+    monkeypatch.setenv("GENERATION_PIPELINE_SKIP_BACKTEST", "1")
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+
+    async def _permissive_validate(brief):
+        return {
+            "is_valid": True,
+            "intent_summary": brief.intent[:140],
+            "asset_classes_inferred": brief.asset_classes or [],
+            "time_horizon_inferred": "unknown",
+            "risk_appetite_adjusted": brief.risk_appetite,
+        }
+
+    monkeypatch.setattr(gp, "_validate_brief", _permissive_validate)
+
+    corpus = _fixture_corpus(24)
+    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: corpus)
+    monkeypatch.setattr(
+        sf,
+        "default_fusion",
+        lambda: sf.StrategyFusion(backend=_MockFusionBackend(), corpus=corpus),
+    )
+
+    # Fixed, known library size (4) so the expected num_trials is computable —
+    # decoupled from however many strategies happen to be curated right now.
+    library_size = 4
+
+    class _FakeStrategy:
+        paper_arxiv_id = "1234.5678"
+        paper_title = "Fake Paper"
+
+    class _FakeProvider:
+        def list_strategies(self, *a, **k):
+            return [_FakeStrategy() for _ in range(library_size)]
+
+    import archimedes.services.strategy_provider as sp
+
+    monkeypatch.setattr(sp, "default_provider", lambda *a, **k: _FakeProvider())
+
+    captured_num_trials: list[int | None] = []
+    real_evaluate = fe.evaluate_fusion_spec
+
+    def _spy_evaluate(spec_dict, **kwargs):
+        captured_num_trials.append(kwargs.get("num_trials"))
+        return real_evaluate(spec_dict, **kwargs)
+
+    monkeypatch.setattr(fe, "evaluate_fusion_spec", _spy_evaluate)
+
+    store = _FakeStore()
+    brief = GenerateBrief(
+        intent="equity momentum with a volatility overlay",
+        risk_appetite="moderate",
+        asset_classes=["equities"],
+    )
+    selection_pool_size = 5  # != library_size, so an additive bug can't hide by coincidence
+
+    await run_generation(
+        job_id="job_fusion_num_trials",
+        brief=brief,
+        store=store,
+        dual_regime=False,
+        n_candidates=selection_pool_size,
+    )
+
+    assert captured_num_trials, "evaluate_fusion_spec was never called — fusion path did not run"
+    expected = gp._society_num_trials(library_size, selection_pool_size)
+    assert all(n == expected for n in captured_num_trials), (
+        f"fusion path num_trials {captured_num_trials} != live-path formula {expected} "
+        f"(library_size={library_size}, selection_pool_size={selection_pool_size})"
+    )
+
+    # The verdict actually persisted must carry the same value through the
+    # variant-grid composition in apply_rigor_gate (max(), not a silent replace).
+    persisted = [e for e in store.events if e["event"] == "candidate_evaluated"]
+    assert persisted, "no candidate_evaluated event emitted"
+    for e in persisted:
+        verdict = e["data"].get("rigor_verdict") or {}
+        if verdict.get("num_trials") is not None:
+            assert verdict["num_trials"] == expected
+
+
 class _MockTextOnlyFusionBackend:
     """Deterministic LLM stand-in returning a parseable fusion WITHOUT a
     machine-readable strategy_spec — the *text-only* path (``has_real_rigor``

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -878,6 +878,69 @@ class TestFusionEvaluatorIntegration:
         else:
             assert record.status == "rejected"
 
+    async def test_fusion_job_num_trials_matches_society_formula(
+        self,
+        client,
+        _no_redis_job_store,
+        _no_redis_agent_state,
+    ):
+        """#820: the direct-fusion job route must deflate for the SAME selection
+        set as the society/live paths — ``_society_num_trials(library, pool=1)``
+        — not ``evaluate_fusion_spec``'s library-size-only default. The spy
+        captures the kwarg then raises; the job's non-fatal eval path tolerates
+        that, so no FusionEvalResult needs fabricating."""
+        from archimedes.agents.generation_pipeline import _society_num_trials
+        from archimedes.agents.strategy_fusion import FusionBrief, FusionProposal
+        from archimedes.api.strategies_routes import _run_fusion_job
+        from archimedes.models.portfolio import RiskProfile
+        from archimedes.services.strategy_dsl import FABER_2007_SPEC
+        from archimedes.services.strategy_provider import default_provider
+
+        mock_proposal = FusionProposal(
+            status="ok",
+            brief=FusionBrief(
+                asset_classes=["SPY"],
+                risk_appetite=RiskProfile.MODERATE,
+                strategic_direction="",
+            ),
+            strategy_name="test_fusion_job_num_trials",
+            thesis="t",
+            source_arxiv_ids=["0706.1497", "1710.00727"],
+            fusion_reasoning="r",
+            novelty_rationale="n",
+            risk_notes="rn",
+            model="canned",
+            requested_model="canned",
+            strategy_spec=FABER_2007_SPEC,
+        )
+        mock_fusion = MagicMock()
+        mock_fusion.propose.return_value = mock_proposal
+
+        captured: dict = {}
+
+        def _spy(spec, *, num_trials=None, use_real_data=False, **kw):
+            captured["num_trials"] = num_trials
+            raise RuntimeError("spy: captured num_trials; eval is non-fatal")
+
+        expected = _society_num_trials(len(default_provider().list_strategies()), 1)
+
+        job_id = "test-job-num-trials"
+        self._seed_job(
+            _no_redis_job_store,
+            job_id,
+            {"asset_classes": ["SPY"], "risk_appetite": "moderate"},
+        )
+        with (
+            patch("archimedes.services.strategy_fusion.default_fusion", return_value=mock_fusion),
+            patch("archimedes.services.fusion_evaluator.evaluate_fusion_spec", side_effect=_spy),
+        ):
+            await _run_fusion_job(job_id)
+
+        assert captured.get("num_trials") == expected, (
+            f"fusion job deflated with num_trials={captured.get('num_trials')}, "
+            f"expected the society formula's {expected}"
+        )
+
     async def test_fusion_without_spec_falls_back_to_candidate(
         self,
         client,


### PR DESCRIPTION
Closes #820.

## What

The fusion candidate path received `selection_pool_size` but never used it
(marked `noqa: ARG001`) and called `evaluate_fusion_spec` with no `num_trials`
at all, so it fell back to library-size-only deflation. The live society path
already deflates for `library_size + selection_pool_size` via
`_society_num_trials`. Same brief, same candidate pool, different (weaker)
correction — a strategy could clear the fusion path's DSR gate at a count the
live path would have rejected it at.

- `_run_fusion_candidate` now computes `num_trials = _society_num_trials(library_size, selection_pool_size)`,
  same as `_run_live_candidate`, and threads it into `evaluate_fusion_spec`.
- `apply_rigor_gate`'s variant-grid override used to replace `num_trials` with
  `len(variants_metrics)` outright whenever a parameter sweep existed, which
  could silently undercut a correct, larger passed-in count (a 3-variant grid
  overriding a real library+pool count of 15, say). Now takes
  `max(num_trials, len(variants_metrics))` — whichever selection layer is
  bigger wins, so the gate is never looser than either alone.
- `debate_engine.py`'s `num_trials` was already fixed to use
  `_society_num_trials(library_size, pool_size)` (the call site's own comment
  says so), but several docstrings and one inline comment still described the
  old `num_trials=pool_size` behavior. Corrected those so the file doesn't
  contradict its own logic.
- One-line comment in `selection_bias_routes.py` noting the `/gate` route's
  library-size-only count is the deliberate exception, not a leftover fourth
  convention — per the issue's ask to reconcile or document each convention.

## Verify

```bash
pytest backend/tests/test_generation_pipeline.py backend/tests/services/test_fusion_evaluator.py -q
```

New `test_fusion_path_num_trials_matches_society_formula` proves the fusion
path and the live-path formula agree for an identical `(library_size,
selection_pool_size)`, including with a 3-variant grid in play. Two new
`apply_rigor_gate` tests pin the `max()` composition both ways (a larger
passed-in count wins over a small grid; a genuinely larger grid still wins
over a smaller passed-in count). 489 passed across the full
rigor/generation/fusion/debate/selection_bias surface. ruff format + check
clean.

## Anti-goals checked

- Did not change the `/selection-bias/gate` route's `library_size` count —
  comment-only addition there, confirmed via diff.
- Did not touch the DSR formula or effective-N correlation handling
  (`_rigor_helpers.py` is untouched by this PR — that's #822, a separate
  concurrent PR).
