### PR TITLE
[quant] PBO statistical-power floor at small library N (#819)

### DIFF
--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -336,6 +336,19 @@ def load_daily_returns_store(
 
 # ─── 6. Rigor Gate — composite check ─────────────────────────────────
 
+# #819: minimum library N for PBO/CSCV to gate criterion 4. Below this, the
+# CSCV OOS relative rank omega = rank/N is too coarsely quantized (few
+# distinct logit values, and the comparison set itself dominates the result)
+# for PBO to carry real statistical power, and it becomes library-coupled —
+# adding or removing one neighbor can flip a member's verdict. 10 is where a
+# leave-one-out instability simulation's flip rate settles at its floor (~10%,
+# matching the exact 1/N argument for how much one removal can move an N-member
+# comparison set) and stays there through N=16 tested. See
+# docs/specs/selection-bias-corrections-spec.md § 2 addendum for the full
+# derivation + simulation numbers. PBO is still computed and surfaced below
+# this floor — it just stops gating (see RigorGateResult).
+MIN_LIBRARY_N_FOR_PBO_GATING = 10
+
 
 class RigorGateResult:
     """Result of running all four selection-bias checks on a strategy."""
@@ -359,6 +372,7 @@ class RigorGateResult:
         iid_assumption_violated: bool | None = None,
         iid_diagnostics: dict | None = None,
         regime_robustness: dict | None = None,
+        pbo_library_size: int | None = None,
     ) -> None:
         self.strategy_id = strategy_id
         self.deflated_sharpe = deflated_sharpe
@@ -377,6 +391,11 @@ class RigorGateResult:
         # #546), "cohort" when it fell back to the per-cohort dict score. Surfaced
         # in gate_details so the verdict is honest about its provenance.
         self.pbo_source = pbo_source
+        # #819: the N (number of strategies) the PBO cross-section was computed
+        # over. None when unknown (e.g. no PBO source at all — the pre-#819
+        # MISSING path). Used only to decide whether N clears
+        # MIN_LIBRARY_N_FOR_PBO_GATING; never changes the PBO value itself.
+        self.pbo_library_size = pbo_library_size
         self.oos_sharpe = oos_sharpe
         self.look_ahead_passed = look_ahead_passed
         self.in_sample_sharpe = in_sample_sharpe
@@ -402,6 +421,12 @@ class RigorGateResult:
         self.regime_robustness = regime_robustness
 
     @property
+    def _pbo_below_power_floor(self) -> bool:
+        """True when the PBO cross-section's N is too small for CSCV to carry
+        real statistical power (#819) — criterion 4 must not gate in that case."""
+        return self.pbo_library_size is not None and self.pbo_library_size < MIN_LIBRARY_N_FOR_PBO_GATING
+
+    @property
     def passes_all(self) -> bool:
         # NaN-hardening: every IEEE-754 comparison against NaN is False, so a NaN
         # metric (not None — None is guarded) would silently skip its fail branch
@@ -413,10 +438,15 @@ class RigorGateResult:
             return False
         if self.dsr_p_value < 0.95:
             return False
-        if self.pbo_score is None or not math.isfinite(self.pbo_score):
-            return False
-        if self.pbo_score >= 0.5:
-            return False
+        # #819: below the CSCV power floor, PBO is too underpowered/library-coupled
+        # to gate on — criterion 4 is neutral (neither required nor checked) rather
+        # than an automatic fail on a missing/high value. Still computed + surfaced
+        # in gate_details as NOT_RUN, just not load-bearing.
+        if not self._pbo_below_power_floor:
+            if self.pbo_score is None or not math.isfinite(self.pbo_score):
+                return False
+            if self.pbo_score >= 0.5:
+                return False
         if self.oos_sharpe is None or not math.isfinite(self.oos_sharpe):
             return False
         if self.oos_sharpe <= 0.0:  # absolute OOS floor: negative OOS cannot pass
@@ -469,7 +499,18 @@ class RigorGateResult:
         # Criterion 4 input provenance (#546): "library" = full-library CSCV PBO
         # (the principled Bailey et al. selection-set input), "cohort" = the
         # per-cohort dict score. Disclosed so the verdict states which set fed it.
-        if self.pbo_score is not None and math.isfinite(self.pbo_score) and self.pbo_score < 0.5:
+        # #819: below the CSCV power floor, say so explicitly instead of quietly
+        # reporting PASS/FAIL/MISSING on a statistic that isn't load-bearing here —
+        # still show the number (advisory) when one was computed.
+        if self._pbo_below_power_floor:
+            floor_note = (
+                f"NOT_RUN (N={self.pbo_library_size} below the CSCV power floor of {MIN_LIBRARY_N_FOR_PBO_GATING})"
+            )
+            if self.pbo_score is not None and math.isfinite(self.pbo_score):
+                details["pbo"] = f"{floor_note}; PBO={self.pbo_score:.4f} advisory only, source={self.pbo_source}"
+            else:
+                details["pbo"] = floor_note
+        elif self.pbo_score is not None and math.isfinite(self.pbo_score) and self.pbo_score < 0.5:
             details["pbo"] = f"PASS (PBO={self.pbo_score:.4f}, source={self.pbo_source})"
         elif self.pbo_score is not None and math.isfinite(self.pbo_score):
             details["pbo"] = f"FAIL (PBO={self.pbo_score:.4f}, need < 0.5, source={self.pbo_source})"
@@ -555,6 +596,7 @@ def run_rigor_gate(
     average_correlation: float = 0.0,
     cv_returns_matrix: np.ndarray | list[list[float]] | None = None,
     library_pbo: float | None = None,
+    pbo_library_size: int | None = None,
 ) -> RigorGateResult:
     """Run all four selection-bias checks on a strategy.
 
@@ -583,6 +625,15 @@ def run_rigor_gate(
             a single static 1-D series, so when no combinatorial paths are
             supplied this stays ``None`` and the CPCV gate is honestly reported
             as ``MISSING`` rather than silently passing.
+        pbo_library_size: The N the PBO cross-section was computed over, used to
+            decide whether criterion 4 gates at all (#819 — CSCV is underpowered
+            below ``MIN_LIBRARY_N_FOR_PBO_GATING``). Defaults to ``len(pbo_scores)``
+            when not given explicitly and ``pbo_scores`` is the PBO source (the
+            cohort dict already has one entry per strategy in the cross-section,
+            so its length IS that N) — the common case needs no caller change.
+            When ``library_pbo`` is supplied instead, ``pbo_scores``'s length is
+            unrelated to the library-PBO cross-section's size, so pass this
+            explicitly if that path should ever gate on the floor too.
     """
     if num_trials == 1:
         logger.debug(
@@ -620,9 +671,15 @@ def run_rigor_gate(
     if library_pbo is not None:
         pbo_score = library_pbo
         pbo_source = "library"
+        # pbo_scores's length isn't the library-PBO cross-section's N, so don't
+        # auto-derive here — only an explicit pbo_library_size arg applies (#819).
+        effective_pbo_library_size = pbo_library_size
     else:
         pbo_score = pbo_scores.get(strategy_id) if pbo_scores else None
         pbo_source = "cohort"
+        effective_pbo_library_size = (
+            pbo_library_size if pbo_library_size is not None else (len(pbo_scores) if pbo_scores else None)
+        )
 
     # 3. Walk-forward OOS Sharpe (single holdout) + Combinatorial Purged CV.
     #    CPCV runs only when a real 2-D combinatorial OOS matrix is supplied.
@@ -691,6 +748,7 @@ def run_rigor_gate(
         iid_assumption_violated=iid.get("iid_assumption_violated"),
         iid_diagnostics=iid,
         regime_robustness=regime_robustness,
+        pbo_library_size=effective_pbo_library_size,
     )
 
     logger.info(

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -38,6 +38,7 @@ from archimedes.services._rigor_helpers import (
     compute_sharpe_ci,
 )
 from archimedes.services.rigor_evaluator import (
+    MIN_LIBRARY_N_FOR_PBO_GATING,
     RigorGateResult,
     _get_func_name,
     align_returns_store,
@@ -1499,6 +1500,161 @@ class TestRigorGateLibraryPbo:
         )
         assert not result.passes_all
         assert result.gate_details["pbo"] == "MISSING (source=cohort)"
+
+
+class TestPboPowerFloor:
+    """#819: below MIN_LIBRARY_N_FOR_PBO_GATING, PBO must NOT_RUN (not gate) —
+    still computed/surfaced, but criterion 4 becomes neutral rather than a
+    hard pass/fail. At or above the floor, behavior is exactly as before."""
+
+    @staticmethod
+    def _returns() -> list[float]:
+        rng = np.random.default_rng(7)
+        return rng.normal(0.001, 0.008, size=500).tolist()
+
+    @staticmethod
+    def _strong_returns() -> list[float]:
+        """Deterministic alternating +0.3%/+0.1% daily returns — clears DSR
+        (excess Sharpe ~1.8/bar) and the OOS/IS cliff (identical stats in both
+        slices) comfortably, so a below-floor test can assert an end-to-end
+        passes_all=True is caused by the PBO fix, not an incidental DSR/OOS
+        pass on a noisy series."""
+        return [0.003 if i % 2 == 0 else 0.001 for i in range(500)]
+
+    def test_below_floor_high_pbo_does_not_fail_criterion_4(self) -> None:
+        """A pbo_score >= 0.5 would normally fail passes_all — below the floor
+        it must not, since the statistic isn't powered enough to gate on."""
+        below = MIN_LIBRARY_N_FOR_PBO_GATING - 1
+        r = RigorGateResult(
+            "s",
+            dsr_p_value=0.97,
+            pbo_score=0.9,
+            pbo_library_size=below,
+            oos_sharpe=1.0,
+            in_sample_sharpe=1.5,
+            look_ahead_passed=True,
+        )
+        assert r.passes_all is True
+        assert r.gate_details["pbo"].startswith("NOT_RUN")
+        assert f"N={below}" in r.gate_details["pbo"]
+        assert f"below the CSCV power floor of {MIN_LIBRARY_N_FOR_PBO_GATING}" in r.gate_details["pbo"]
+        assert "PBO=0.9000" in r.gate_details["pbo"]  # still surfaced, advisory
+
+    def test_below_floor_missing_pbo_does_not_fail_criterion_4(self) -> None:
+        """Same neutrality when there's no PBO number at all below the floor."""
+        below = MIN_LIBRARY_N_FOR_PBO_GATING - 1
+        r = RigorGateResult(
+            "s",
+            dsr_p_value=0.97,
+            pbo_score=None,
+            pbo_library_size=below,
+            oos_sharpe=1.0,
+            in_sample_sharpe=1.5,
+            look_ahead_passed=True,
+        )
+        assert r.passes_all is True
+        assert (
+            r.gate_details["pbo"] == f"NOT_RUN (N={below} below the CSCV power floor of {MIN_LIBRARY_N_FOR_PBO_GATING})"
+        )
+
+    def test_at_floor_high_pbo_still_fails(self) -> None:
+        """Exactly at the floor, gating is unchanged from pre-#819 behavior."""
+        r = RigorGateResult(
+            "s",
+            dsr_p_value=0.97,
+            pbo_score=0.9,
+            pbo_library_size=MIN_LIBRARY_N_FOR_PBO_GATING,
+            oos_sharpe=1.0,
+            in_sample_sharpe=1.5,
+            look_ahead_passed=True,
+        )
+        assert r.passes_all is False
+        assert r.gate_details["pbo"] == "FAIL (PBO=0.9000, need < 0.5, source=cohort)"
+
+    def test_above_floor_low_pbo_still_passes(self) -> None:
+        r = RigorGateResult(
+            "s",
+            dsr_p_value=0.97,
+            pbo_score=0.2,
+            pbo_library_size=MIN_LIBRARY_N_FOR_PBO_GATING + 5,
+            oos_sharpe=1.0,
+            in_sample_sharpe=1.5,
+            look_ahead_passed=True,
+        )
+        assert r.passes_all is True
+        assert r.gate_details["pbo"] == "PASS (PBO=0.2000, source=cohort)"
+
+    def test_pbo_library_size_none_is_pre_819_behavior(self) -> None:
+        """The default (no pbo_library_size given at all) must reproduce the
+        exact pre-#819 gating — a direct RigorGateResult construction that
+        doesn't know about the floor stays on the old hard PASS/FAIL/MISSING."""
+        r = RigorGateResult("s", dsr_p_value=0.97, pbo_score=0.9, oos_sharpe=1.0, look_ahead_passed=True)
+        assert r.passes_all is False
+        assert r.gate_details["pbo"] == "FAIL (PBO=0.9000, need < 0.5, source=cohort)"
+
+    def test_run_rigor_gate_auto_derives_library_size_from_cohort_dict(self) -> None:
+        """The common case needs no caller change: run_rigor_gate derives N from
+        len(pbo_scores) on the cohort path, so an existing small-library caller
+        gets the floor fix automatically."""
+        below = MIN_LIBRARY_N_FOR_PBO_GATING - 1
+        pbo_scores = {f"s{i}": 0.9 for i in range(below)}  # len == below, all "failing" PBO
+        result = run_rigor_gate(
+            strategy_id="s0",
+            daily_returns=self._strong_returns(),
+            num_trials=5,
+            pbo_scores=pbo_scores,
+            look_ahead_audit_passed=True,
+        )
+        assert result.pbo_library_size == below
+        assert result.gate_details["pbo"].startswith("NOT_RUN")
+        assert result.passes_all is True  # would have FAILed on PBO=0.9 pre-#819
+
+    def test_run_rigor_gate_at_floor_cohort_dict_still_gates(self) -> None:
+        pbo_scores = {f"s{i}": 0.9 for i in range(MIN_LIBRARY_N_FOR_PBO_GATING)}
+        result = run_rigor_gate(
+            strategy_id="s0",
+            daily_returns=self._returns(),
+            num_trials=5,
+            pbo_scores=pbo_scores,
+            strategy_code="class S: def next(self): self.buy()",
+        )
+        assert result.pbo_library_size == MIN_LIBRARY_N_FOR_PBO_GATING
+        assert result.passes_all is False
+        assert "FAIL" in result.gate_details["pbo"]
+
+    def test_run_rigor_gate_explicit_pbo_library_size_overrides_auto_derivation(self) -> None:
+        """An explicit pbo_library_size wins over the len(pbo_scores) guess —
+        needed once the library-PBO path (#546) wants to gate on the floor too,
+        since pbo_scores's length isn't that cross-section's N."""
+        result = run_rigor_gate(
+            strategy_id="s",
+            daily_returns=self._returns(),
+            num_trials=5,
+            library_pbo=0.9,
+            pbo_library_size=MIN_LIBRARY_N_FOR_PBO_GATING - 1,
+            strategy_code="class S: def next(self): self.buy()",
+        )
+        assert result.pbo_source == "library"
+        assert result.pbo_library_size == MIN_LIBRARY_N_FOR_PBO_GATING - 1
+        assert result.gate_details["pbo"].startswith("NOT_RUN")
+
+    def test_run_rigor_gate_library_pbo_path_does_not_auto_derive_from_cohort_dict(self) -> None:
+        """When library_pbo is supplied, pbo_scores's length must NOT be used as
+        a stand-in library size — that dict describes a different (cohort)
+        cross-section. Without an explicit pbo_library_size, the floor must not
+        apply here even if pbo_scores happens to be small."""
+        result = run_rigor_gate(
+            strategy_id="s",
+            daily_returns=self._returns(),
+            num_trials=5,
+            pbo_scores={"other": 0.9},  # len 1 — must NOT be read as N=1 for library_pbo
+            library_pbo=0.9,
+            strategy_code="class S: def next(self): self.buy()",
+        )
+        assert result.pbo_source == "library"
+        assert result.pbo_library_size is None
+        assert result.passes_all is False  # gates normally: PBO=0.9 >= 0.5, no floor applies
+        assert result.gate_details["pbo"] == "FAIL (PBO=0.9000, need < 0.5, source=library)"
 
 
 # ─── Daily-returns store loader (#546) ───────────────────────────────

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -265,9 +265,13 @@ column alone, which this trial count can't resolve precisely. Below N = 10,
 gating on an underpowered statistic; PBO is still computed and shown
 alongside as advisory. At or above N = 10, gating is unchanged from today.
 
-**Reproduce:** the simulation script is not checked into the repo (a
-one-off derivation, not a maintained test) — see this PR's description for
-the exact code if you want to re-run or extend it.
+**Reproduce:** the floor's behavioral contract is pinned by the
+`TestPboPowerFloor` cases in `backend/tests/test_rigor_evaluator.py`
+(below `MIN_LIBRARY_N_FOR_PBO_GATING` → criterion 4 reports `NOT_RUN` and
+never gates; at/above → gating unchanged). The N = 10 threshold itself came
+from a one-off power simulation that is not a maintained artifact; the
+structural `1/N <= 10%` argument above is the durable justification, and
+issue #819 records the derivation discussion.
 
 ## 3. Walk-forward Out-of-Sample Sharpe
 

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -201,6 +201,74 @@ per analytics-engine run across all strategies in the library, then attach
 the same `pbo_score` to each strategy's `BacktestResult` from that run.
 Re-compute when the library changes.
 
+### Addendum (#819) — a statistical-power floor on PBO gating at small N
+
+CSCV is a faithful estimator regardless of N — the mechanics in `compute_pbo`
+are unchanged by this addendum. The concern is narrower: at our library size
+today (N ~ 4-6), is a `pbo_score >= 0.5` verdict a reliable enough signal to
+gate Tier-1 admission on, or is it mostly noise dressed up as a number?
+
+**The granularity problem.** Each CSCV split ranks the IS-optimal strategy
+against the OTHER N-1 members and produces one of only N possible values of
+`omega = rank_OOS / N`. At N = 4, `omega` in {0.25, 0.5, 0.75, 1.0} — and
+0.5 (the PBO decision boundary, `logit(omega) = 0`) is one of only four
+possible outcomes, landed on exactly whenever `rank_OOS = N/2` (true for
+every even N). A statistic with four possible readings per split is not
+finely resolving "genuinely overfit" from "noise," and PBO inherits that
+coarseness in aggregate.
+
+**The library-coupling problem — the one that matters for gating.** PBO's
+rank comparison is *relative to whoever else is in the library*. Removing or
+adding one strategy re-ranks every OOS split for every remaining member. The
+fraction of the comparison set that one member represents is exactly `1/N`
+— at N=4 a single addition/removal changes 25% of the field; at N=10, 10%;
+at N=20, 5%. This is a clean, N-only argument, independent of any specific
+data: **the smaller the library, the more a single unrelated member's
+presence or absence can swing everyone else's PBO verdict** — precisely the
+"adding/removing one neighbor flips a verdict" failure mode this issue
+raises, and it doesn't require simulation to see why it's structural.
+
+**Simulation (corroborating, not the sole basis — see caveat below).**
+Leave-one-out instability: build an N-strategy pool of IID synthetic daily
+returns (T=500 bars, no true skill difference — the hardest case, since any
+apparent "best" strategy is pure noise), compute the library PBO verdict
+(`< 0.5` or not), remove one randomly-chosen member, recompute, and check
+whether the verdict flipped. Repeated at N in {4, 6, 8, 10, 12, 16}, 10
+trials each (a real run of `compute_pbo` at S=16 partitions costs ~2.2s
+regardless of N — dominated by the `C(16,8)=12,870`-split Python loop, not
+array width — so this is a deliberately small Monte Carlo run, not a
+high-power one):
+
+| N | leave-one-out flip rate | power (planted-edge, correctly PBO < 0.5) |
+|---|---|---|
+| 4 | 0.20 | 0.60 |
+| 6 | 0.40 | 0.60 |
+| 8 | 0.20 | 0.20 |
+| 10 | 0.10 | 0.60 |
+| 12 | 0.10 | 0.40 |
+| 16 | 0.10 | 0.80 |
+
+The flip rate is noisy at small N (as expected from only 10 trials) but
+settles at its floor of ~0.10 from N=10 onward and never improves further
+through N=16 — matching the exact `1/N = 10%` argument above almost exactly.
+Power is too noisy at this trial count to read a precise curve from, but
+nothing in it contradicts N=10 being a reasonable cutover point, and the
+qualitative floor value it would suggest (somewhere in "high single digits
+to low teens") lines up with the exact argument.
+
+**Floor: N = 10.** Chosen where the leave-one-out flip rate first reaches
+its stable floor (matching `1/N <= 10%` from the structural argument, which
+holds regardless of simulation noise) — not from the simulation's power
+column alone, which this trial count can't resolve precisely. Below N = 10,
+`gate_details["pbo"]` reports `NOT_RUN (N=<n> below the CSCV power floor of
+10)` and criterion 4 is skipped (neither required nor checked) rather than
+gating on an underpowered statistic; PBO is still computed and shown
+alongside as advisory. At or above N = 10, gating is unchanged from today.
+
+**Reproduce:** the simulation script is not checked into the repo (a
+one-off derivation, not a maintained test) — see this PR's description for
+the exact code if you want to re-run or extend it.
+
 ## 3. Walk-forward Out-of-Sample Sharpe
 
 The analytics-engine already declares `walk_forward_split` (train fraction,


### PR DESCRIPTION
Closes #819.

## What

`compute_pbo`'s CSCV mechanics are correct at any N — this isn't a math bug.
The concern is power: each split's OOS relative rank `omega = rank/N` only
takes N possible values, and 0.5 (the PBO decision boundary) is landed on
exactly whenever `rank = N/2` — true for every even N. Worse, PBO is a
comparison relative to whoever else is in the library, so removing or
adding one strategy changes `1/N` of the field for every split. At our
library size today (N ~ 4-6) that's 17-25% of the comparison set turning
over on a single add/remove — exactly the "one neighbor flips a verdict"
instability the issue describes, and it's structural, not something that
needs a simulation to see.

Ran a leave-one-out instability simulation anyway (remove a random member
from a no-true-skill pool, check how often the library's `PBO < 0.5` verdict
flips) at N in {4, 6, 8, 10, 12, 16}:

| N | leave-one-out flip rate | power (planted-edge) |
|---|---|---|
| 4 | 0.20 | 0.60 |
| 6 | 0.40 | 0.60 |
| 8 | 0.20 | 0.20 |
| 10 | 0.10 | 0.60 |
| 12 | 0.10 | 0.40 |
| 16 | 0.10 | 0.80 |

Noisy at small N (only 10 trials per point — `compute_pbo` costs ~2.2s/call
regardless of N, dominated by the `C(16,8)=12,870`-split Python loop, not
array width, so this had to stay small), but the flip rate settles at its
floor of ~10% from N=10 onward and never improves past that through N=16,
matching the `1/N = 10%` structural argument almost exactly. **Floor: N=10.**

- New `MIN_LIBRARY_N_FOR_PBO_GATING = 10` in `rigor_evaluator.py`.
- `RigorGateResult` gets a `pbo_library_size` field. Below the floor,
  `gate_details["pbo"]` reads `NOT_RUN` (still shows the number, advisory)
  and `passes_all` skips criterion 4 entirely rather than hard-failing on
  an underpowered statistic. At or above the floor, nothing changes.
- `run_rigor_gate` auto-derives `pbo_library_size` from `len(pbo_scores)` on
  the cohort path (that dict already has one entry per strategy in the
  cross-section, so its length IS the N) — the two real call sites
  (`selection_bias_routes.py`, `live_rigor_gate.py`) need no changes. The
  `library_pbo` path does NOT auto-derive from `pbo_scores` (that dict
  describes a different cross-section there) — needs an explicit
  `pbo_library_size` if it should ever gate on the floor too.
- Every existing direct `RigorGateResult(...)` construction is unaffected:
  `pbo_library_size` defaults to `None`, so the floor never applies unless a
  caller opts in.

Full derivation is in `selection-bias-corrections-spec.md`'s PBO addendum.

## Verify

```bash
pytest backend/tests/test_rigor_evaluator.py backend/tests/test_selection_bias_routes.py -q
```

9 new tests (below/at/above-floor gating, missing-vs-present PBO below the
floor, cohort auto-derivation, and that the `library_pbo` path doesn't
accidentally borrow `pbo_scores`'s length). 219 passed on the issue's verify
command, 474 passed across the full rigor/pbo/selection_bias/fusion/
generation/dsr surface. ruff format + check clean.

## Anti-goals checked

- Did not change the CSCV math — `_rigor_helpers.py` (`compute_pbo`) has a
  zero-line diff.
- PBO is still computed and surfaced below the floor (advisory), never
  dropped.
