### PR TITLE
[frontend][backend] Dogfooding sweep round 1 — 8 scoped fixes (#854)

### DIFF
--- a/backend/archimedes/api/corpus_routes.py
+++ b/backend/archimedes/api/corpus_routes.py
@@ -122,18 +122,27 @@ async def corpus_overview() -> dict[str, Any]:
                 .group_by(PaperRecord.cluster_id)
                 .all()
             )
-            # Category + year histograms restricted to KB-processed papers so
-            # the chart numbers match what the user can actually inspect end
-            # to end (paper detail + topic cluster + similarity neighbors).
-            # Showing histogram over all 10K metadata rows would imply the
-            # KB pipeline ran on rows it hasn't touched yet.
+            # Category + year histograms cover the FULL catalog (not just
+            # KB-processed papers) — issue #854 finding #5: restricting these
+            # to `cluster_id IS NOT NULL` meant they read 0/0/0 with the
+            # header badges reading "0 papers · 0 categories" while the
+            # Catalog tab in the same view listed all 10,000 papers, because
+            # the KB pipeline (SPECTER2/HDBSCAN clustering) hasn't produced
+            # an artifact yet and so never populates `cluster_id`. Category +
+            # year are arxiv metadata facts (ingested for every paper up
+            # front, same source Catalog already reads), not KB-pipeline
+            # output — showing them for the full catalog makes no claim
+            # about KB-processing status. KB-derived facts (similarity
+            # graph, topic clusters) still correctly gate on the pipeline
+            # artifact via /api/corpus/graph + /api/corpus/kg/* (503 with an
+            # honest "pipeline not yet run" message) — only the plain
+            # metadata histograms below were mis-scoped.
             cat_rows = (
                 session.query(
                     PaperRecord.primary_category,
                     func.count(PaperRecord.arxiv_id),
                 )
                 .filter(PaperRecord.primary_category != "")
-                .filter(PaperRecord.cluster_id.isnot(None))
                 .group_by(PaperRecord.primary_category)
                 .order_by(func.count(PaperRecord.arxiv_id).desc())
                 .all()
@@ -153,7 +162,6 @@ async def corpus_overview() -> dict[str, Any]:
                     func.count(PaperRecord.arxiv_id),
                 )
                 .filter(PaperRecord.published != "")
-                .filter(PaperRecord.cluster_id.isnot(None))
                 .group_by("yr")
                 .order_by("yr")
                 .all()
@@ -178,10 +186,15 @@ async def corpus_overview() -> dict[str, Any]:
         "last_run_ts": (manifest or {}).get("run_ts"),
         "pipeline_status": (manifest or {}).get("status", "never run"),
         # UI shape — read by CorpusExplorer.jsx for header chips + Overview tab.
-        # total_papers reflects the *processed* count so the prominent number
-        # users see matches what they can inspect end to end. Catalog tab
-        # defaults to processed_only=true (see papers_routes.py).
-        "total_papers": processed_papers,
+        # total_papers reflects the full catalog count (paper_count), matching
+        # what the Catalog tab shows: papers_routes.py's `processed_only=true`
+        # default falls back to the full 10K-row corpus (via load_corpus())
+        # whenever the KB-processed subset is empty, so Catalog's real total
+        # is `paper_count`, not `processed_papers`. Reporting `processed_papers`
+        # here — 0 until the KB pipeline's first clustering run — produced the
+        # "0 papers · 0 categories" header while Catalog listed 10,000
+        # (issue #854 finding #5).
+        "total_papers": paper_count,
         "categories": categories,
         "year_distribution": year_distribution,
         "source": "arxiv q-fin + adjacent",

--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -15,6 +15,24 @@ logger = logging.getLogger(__name__)
 papers_router = APIRouter(prefix="/api/papers", tags=["papers"])
 
 
+def _paper_row_to_dict(r) -> dict:
+    """Shared DB-row → API-dict mapping so every read path (processed-only,
+    unfiltered fallback) carries the same fields — notably ``authors``,
+    which was silently dropped when the fallback routed through
+    ``strategy_fusion.load_corpus()``'s reduced ``CorpusPaper`` (no authors
+    field) instead of the real DB row (issue #854 finding #9)."""
+    return {
+        "arxiv_id": r.arxiv_id,
+        "title": r.title,
+        "authors": json.loads(r.authors) if r.authors else [],
+        "primary_category": r.primary_category,
+        "category_label": _category_label(r.primary_category),
+        "categories": json.loads(r.categories) if r.categories else [],
+        "published": r.published,
+        "abstract": r.abstract[:200] + "..." if len(r.abstract) > 200 else r.abstract,
+    }
+
+
 @papers_router.get("/")
 async def list_papers(
     page: int = Query(1, ge=1),
@@ -56,21 +74,33 @@ async def list_papers(
         total = query.count()
         rows = query.order_by(PaperRecord.published.desc()).offset((page - 1) * page_size).limit(page_size).all()
 
-        papers = [
-            {
-                "arxiv_id": r.arxiv_id,
-                "title": r.title,
-                "authors": json.loads(r.authors) if r.authors else [],
-                "primary_category": r.primary_category,
-                "category_label": _category_label(r.primary_category),
-                "categories": json.loads(r.categories) if r.categories else [],
-                "published": r.published,
-                "abstract": r.abstract[:200] + "..." if len(r.abstract) > 200 else r.abstract,
-            }
-            for r in rows
-        ]
+        papers = [_paper_row_to_dict(r) for r in rows]
+
+        # `processed_only=True` (default) can legitimately return zero rows
+        # while the DB still holds the full unprocessed corpus — the KB
+        # pipeline hasn't clustered anything yet (see corpus_routes.py's
+        # `corpus_overview()`). Re-query the DB *unfiltered* first so real
+        # DB fields (authors, category, abstract) survive the fallback,
+        # rather than routing through the file-manifest loader whose
+        # reduced `CorpusPaper` type has no author data at all.
+        if total == 0 and not category and not search:
+            fallback_query = session.query(PaperRecord)
+            total = fallback_query.count()
+            if total:
+                rows = (
+                    fallback_query.order_by(PaperRecord.published.desc())
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                    .all()
+                )
+                papers = [_paper_row_to_dict(r) for r in rows]
 
     if total == 0 and not category and not search:
+        # DB is genuinely empty (e.g. fresh local dev, no seeding yet) —
+        # last-resort file-manifest fallback. This path's `CorpusPaper` has
+        # no `authors` field, so authors render "—" here; that's an honest
+        # reflection of what the manifest fallback actually carries, not a
+        # dropped/fabricated field.
         from archimedes.agents.strategy_fusion import load_corpus
 
         corpus = load_corpus()

--- a/backend/archimedes/services/visitor_insights_store.py
+++ b/backend/archimedes/services/visitor_insights_store.py
@@ -76,13 +76,28 @@ class VisitorInsightsStore:
     # ─── Record (write path — JS-gated `landed` beacon, issue #830) ──────
 
     async def record(self, country: str | None, device: str, visitor_id: str) -> None:
-        """Record one landed visit's country + device for ``visitor_id``. Never raises."""
+        """Record ``visitor_id``'s country + device, attributed once per visitor.
+
+        Only the visitor's FIRST recorded landed beacon buckets them into a
+        country/device — a repeat visitor whose classified country or device
+        differs across visits (VPN, mobile hotspot vs. home wifi, a flaky UA
+        parse, …) is NOT re-bucketed. Without this gate, summing the
+        per-country or per-device breakdowns can exceed the funnel's single
+        overall ``landed`` distinct-visitor count, even though each
+        individual bucket's own HLL count is internally correct — the
+        Insights page promises these sums reconcile with ``landed``
+        (issue #854 finding #6), and first-seen attribution is what makes
+        that true by construction rather than by coincidence. Never raises.
+        """
         if not visitor_id:
             return
         cc = _norm_country(country)
         dev = device if device in DEVICE_CLASSES else "unknown"
         try:
             r = await self._get_redis()
+            first_seen = await r.sadd(f"{_PREFIX}:attributed", visitor_id)
+            if not first_seen:
+                return
             day = _today()
             country_day = f"{_PREFIX}:country:day:{day}:{cc}"
             device_day = f"{_PREFIX}:device:day:{day}:{dev}"

--- a/backend/tests/test_corpus_routes_overview.py
+++ b/backend/tests/test_corpus_routes_overview.py
@@ -1,0 +1,137 @@
+"""Regression tests for GET /api/corpus/overview (issue #854 finding #5).
+
+Header badges + Overview tab previously read "0 papers · 0 categories" while
+the Catalog tab (papers_routes.py) listed all 10,000 real papers, because
+`corpus_overview()` scoped `total_papers` / category / year counts to only
+the KB-pipeline-*processed* subset (`cluster_id IS NOT NULL`) — which is
+empty until the KB pipeline's first clustering run. Catalog never hits that
+emptiness because `list_papers()` falls back to the full corpus whenever the
+processed-only query returns zero rows. This test locks in that
+`corpus_overview()` now reports the same full-catalog totals Catalog uses,
+while genuinely-KB-pipeline-only facts (graph/kg endpoints) are untouched.
+
+Hermetic — no network, no Redis, in-memory SQLite only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from archimedes.models.chat import Base
+from archimedes.models.corpus_store import PaperRecord
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+
+
+class _CtxSession:
+    """Context-manager wrapper so `with get_session() as s:` works."""
+
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, *args):
+        pass
+
+
+def _ctx_session(session):
+    return _CtxSession(session)
+
+
+def _add_paper(session, arxiv_id, category, year, *, cluster_id=None):
+    session.add(
+        PaperRecord(
+            arxiv_id=arxiv_id,
+            title=f"Paper {arxiv_id}",
+            abstract="Abstract",
+            primary_category=category,
+            categories=f'["{category}"]',
+            published=f"{year}-01-01",
+            updated=f"{year}-01-01",
+            source="seed",
+            cluster_id=cluster_id,
+        )
+    )
+
+
+class TestCorpusOverviewUnprocessedCatalog:
+    """The realistic prod state: 10K (here, 3) ingested papers, 0 KB-processed."""
+
+    def test_total_papers_reflects_full_catalog_not_zero(self, session, monkeypatch):
+        from archimedes.api import corpus_routes
+
+        _add_paper(session, "2601.00001", "q-fin.PM", 2026)
+        _add_paper(session, "2601.00002", "q-fin.TR", 2026)
+        _add_paper(session, "2601.00003", "cs.LG", 2025)
+        session.commit()
+
+        monkeypatch.setattr("archimedes.db.get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(corpus_routes.corpus_overview())
+
+        # Before the fix these were all 0/0/0/empty despite 3 real rows —
+        # matching the live "0 papers · 0 categories" header bug.
+        assert result["total_papers"] == 3
+        assert len(result["categories"]) == 3
+        assert len(result["year_distribution"]) == 2
+
+    def test_category_and_year_counts_match_full_catalog(self, session, monkeypatch):
+        from archimedes.api import corpus_routes
+
+        _add_paper(session, "2601.00001", "q-fin.PM", 2026)
+        _add_paper(session, "2601.00002", "q-fin.PM", 2026)
+        _add_paper(session, "2601.00003", "cs.LG", 2025)
+        session.commit()
+
+        monkeypatch.setattr("archimedes.db.get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(corpus_routes.corpus_overview())
+
+        by_name = {c["name"]: c["count"] for c in result["categories"]}
+        assert by_name == {"q-fin.PM": 2, "cs.LG": 1}
+
+        by_year = {y["year"]: y["count"] for y in result["year_distribution"]}
+        assert by_year == {2026: 2, 2025: 1}
+
+    def test_processed_papers_still_reports_kb_pipeline_subset(self, session, monkeypatch):
+        """The legacy KB-pipeline fields must still reflect only clustered rows —
+        this fix broadens the UI-facing catalog totals, not the KB-processing
+        signal itself."""
+        from archimedes.api import corpus_routes
+
+        _add_paper(session, "2601.00001", "q-fin.PM", 2026, cluster_id="c1")
+        _add_paper(session, "2601.00002", "q-fin.TR", 2026)
+        session.commit()
+
+        monkeypatch.setattr("archimedes.db.get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(corpus_routes.corpus_overview())
+
+        assert result["total_papers"] == 2
+        assert result["processed_papers"] == 1
+        assert result["metadata_only_papers"] == 1
+
+    def test_empty_db_still_reports_zero_honestly(self, session, monkeypatch):
+        """No papers ingested at all → zero is the honest answer, not a bug."""
+        from archimedes.api import corpus_routes
+
+        monkeypatch.setattr("archimedes.db.get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(corpus_routes.corpus_overview())
+
+        assert result["total_papers"] == 0
+        assert result["categories"] == []
+        assert result["year_distribution"] == []

--- a/backend/tests/test_papers_routes.py
+++ b/backend/tests/test_papers_routes.py
@@ -1,0 +1,127 @@
+"""Regression tests for GET /api/papers/ (issue #854 finding #9).
+
+Corpus Catalog's Authors column rendered "—" for every row because the
+`processed_only=True` (default) fallback — triggered whenever no paper has
+been through KB-pipeline clustering yet — routed through
+`strategy_fusion.load_corpus()`'s reduced `CorpusPaper` dataclass, which has
+no `authors` field at all. The DB itself carries real author data (see
+`PaperRecord.authors` / `to_dict()`); this test locks in that the fallback
+now reads directly from the DB (preserving authors) instead of losing the
+field through the reduced dataclass, and only drops to the truly-author-less
+file manifest when the DB itself is empty.
+
+Hermetic — no network, no Redis, in-memory SQLite only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from archimedes.models.chat import Base
+from archimedes.models.corpus_store import PaperRecord
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+
+
+class _CtxSession:
+    """Context-manager wrapper so `with get_session() as s:` works."""
+
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, *args):
+        pass
+
+
+def _ctx_session(session):
+    return _CtxSession(session)
+
+
+def _add_paper(session, arxiv_id, *, authors, cluster_id=None):
+    session.add(
+        PaperRecord(
+            arxiv_id=arxiv_id,
+            title=f"Paper {arxiv_id}",
+            abstract="Abstract",
+            authors=json.dumps(authors),
+            primary_category="q-fin.PM",
+            categories='["q-fin.PM"]',
+            published="2026-01-01",
+            updated="2026-01-01",
+            source="seed",
+            cluster_id=cluster_id,
+        )
+    )
+
+
+class TestListPapersAuthorsFallback:
+    def test_unprocessed_catalog_still_returns_real_authors(self, session, monkeypatch):
+        """No paper is KB-processed (cluster_id all null) — the fallback must
+        still surface the real author names from the DB, not '—' for every
+        row."""
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.00001", authors=["Ada Lovelace", "Alan Turing"])
+        _add_paper(session, "2601.00002", authors=["Grace Hopper"])
+        session.commit()
+
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search=None, processed_only=True)
+        )
+
+        assert result["total"] == 2
+        authors_by_id = {p["arxiv_id"]: p["authors"] for p in result["papers"]}
+        assert authors_by_id["2601.00001"] == ["Ada Lovelace", "Alan Turing"]
+        assert authors_by_id["2601.00002"] == ["Grace Hopper"]
+
+    def test_processed_papers_take_normal_path_unaffected(self, session, monkeypatch):
+        """When KB-processed rows exist, the primary (non-fallback) path is
+        unchanged and still carries authors."""
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.00001", authors=["Ada Lovelace"], cluster_id="c1")
+        session.commit()
+
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search=None, processed_only=True)
+        )
+
+        assert result["total"] == 1
+        assert result["papers"][0]["authors"] == ["Ada Lovelace"]
+
+    def test_empty_db_falls_back_to_file_manifest(self, session, monkeypatch, tmp_path):
+        """DB has zero rows — falls through to the file-manifest loader (which
+        genuinely has no author data), not an error."""
+        from archimedes.api import papers_routes
+
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+        # Point the file-fallback at an empty manifest dir so `load_corpus()`
+        # resolves deterministically to zero papers rather than picking up
+        # whatever manifest happens to exist on this machine.
+        monkeypatch.setenv("ARCHIMEDES_CORPUS_MANIFEST", str(tmp_path / "does-not-exist.jsonl"))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search=None, processed_only=True)
+        )
+
+        assert result["total"] == 0
+        assert result["papers"] == []

--- a/backend/tests/test_visitor_insights.py
+++ b/backend/tests/test_visitor_insights.py
@@ -25,7 +25,7 @@ VisitorInsightsStore = vstore.VisitorInsightsStore
 _norm_country = vstore._norm_country
 
 
-def _mock_redis(pfcounts=None, members=None):
+def _mock_redis(pfcounts=None, members=None, first_seen=1):
     pipe = MagicMock()
     pipe.pfadd = MagicMock(return_value=pipe)
     pipe.expire = MagicMock(return_value=pipe)
@@ -35,6 +35,10 @@ def _mock_redis(pfcounts=None, members=None):
     r = MagicMock()
     r.pipeline = MagicMock(return_value=pipe)
     r.smembers = AsyncMock(return_value=members or set())
+    # Top-level (non-pipelined) SADD used by `record()`'s first-seen-only
+    # attribution gate — 1 = newly attributed (proceed), 0 = already
+    # attributed on an earlier visit (short-circuit, no re-bucketing).
+    r.sadd = AsyncMock(return_value=first_seen)
     return r, pipe
 
 
@@ -199,6 +203,18 @@ class _FakeHLLRedis:
     async def smembers(self, key: str):
         return set(self.sets.get(key, set()))
 
+    async def sadd(self, key: str, member: str) -> int:
+        """Top-level (non-pipelined) SADD — used by the first-seen gate.
+
+        Exact SET semantics (unlike PFADD/HLL): returns 1 if newly added,
+        0 if the member was already present.
+        """
+        bucket = self.sets.setdefault(key, set())
+        if member in bucket:
+            return 0
+        bucket.add(member)
+        return 1
+
 
 class _FakePipe:
     def __init__(self, r: _FakeHLLRedis) -> None:
@@ -277,6 +293,56 @@ async def test_landed_population_reconciles_funnel_and_geo_device():
     assert country_sum == n
     assert device_sum == n
     assert country_sum == device_sum == landed
+
+
+async def test_repeat_visits_with_drifting_country_device_still_reconcile():
+    """A returning visitor classified under a DIFFERENT country/device on a
+    later visit must NOT be double-bucketed (issue #854 finding #6).
+
+    Before first-seen attribution, Insights showed Top Countries summing to
+    106 and Device summing to 104 against a funnel `landed` of 61 — because
+    a repeat visitor recorded under >1 country or device across visits was
+    counted once per bucket even though the funnel counts them once overall.
+    This drives 5 distinct visitors through 2 visits each, with country and
+    device DRIFTING on the second visit, and asserts the sums still equal
+    the funnel population.
+    """
+    from unittest.mock import AsyncMock
+
+    from archimedes.services.funnel_store import FunnelStore
+
+    shared = _FakeHLLRedis()
+
+    funnel = FunnelStore()
+    funnel._get_redis = AsyncMock(return_value=shared)
+    insights = VisitorInsightsStore()
+    insights._get_redis = AsyncMock(return_value=shared)
+
+    n = 5
+    for i in range(n):
+        vid = f"vid-{i}"
+        # First visit.
+        await funnel.record("landed", vid)
+        await insights.record("US", "desktop", vid)
+        # Second visit, later — classified differently (VPN / new device /
+        # flaky UA sniff). The funnel sees the SAME distinct visitor again
+        # (idempotent); the naive pre-fix behavior would double-bucket them
+        # into a second country AND a second device.
+        await funnel.record("landed", vid)
+        await insights.record("DE", "mobile", vid)
+
+    landed = (await funnel.get_totals())["landed"]
+    countries, devices = await insights.get_insights()
+    country_sum = sum(countries.values())
+    device_sum = sum(devices.values())
+
+    assert landed == n
+    assert country_sum == n
+    assert device_sum == n
+    # First-seen attribution: every visitor's ONE bucket is their first visit.
+    assert countries == {"US": n}
+    assert devices["desktop"] == n
+    assert devices.get("mobile", 0) == 0
 
 
 async def test_beacon_path_records_both_funnel_and_visitor_insight():

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -2156,11 +2156,20 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
     width: 260px !important;
     transform: translateX(-100%);
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    z-index: 200;
+    /* Must outrank MobileBanner.jsx's inline z-index: 9999 — otherwise the
+       sticky "Best on desktop" banner renders on top of the open drawer and
+       covers its brand header + close button (issue #854 finding #2). */
+    z-index: 10000;
     box-shadow: 4px 0 32px rgba(0, 0, 0, 0.5);
     overflow-y: auto;
   }
-  .sidebar.sidebar-open { transform: translateX(0); }
+  /* !important pins the open-state transform so no other rule (present or
+     future) can leave the drawer stuck at its closed, off-canvas position. */
+  .sidebar.sidebar-open { transform: translateX(0) !important; }
+  /* Overlay backdrop (only rendered while menuOpen) must also outrank the
+     mobile banner so it dims/blocks the banner — and its own "tap to
+     dismiss" handler — while the drawer is open. */
+  .sidebar-overlay { z-index: 9998; }
   .sidebar-collapsed .logo-copy,
   .sidebar-collapsed .logo-text,
   .sidebar-collapsed .logo-sub,

--- a/ui/src/components/GenerationStatus.jsx
+++ b/ui/src/components/GenerationStatus.jsx
@@ -18,6 +18,10 @@ function timeAgo(iso) {
   if (!iso) return '—'
   const d = new Date(iso)
   if (isNaN(d.getTime())) return iso
+  // A missing timestamp often round-trips as epoch 0 rather than an empty
+  // value — that's not a real multi-decade-old event, it's an absent
+  // timestamp, so render it the same as the no-value case.
+  if (d.getTime() <= 0) return '—'
   const secs = Math.floor((Date.now() - d.getTime()) / 1000)
   if (secs < 60) return `${secs}s ago`
   if (secs < 3600) return `${Math.floor(secs / 60)}m ago`

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -174,9 +174,9 @@ export default function Insights() {
           <section style={card}>
             <h2 style={{ marginTop: 0, fontSize: 16 }}>Who’s visiting — geography &amp; device</h2>
             <p style={{ color: 'var(--text-dim, #8b93a7)', fontSize: 12.5, marginTop: 0, marginBottom: 14 }}>
-              Same JS-gated <strong>landed</strong> population as the funnel (#830) — distinct visitors, so these
-              counts reconcile with the funnel’s <em>Landed</em> number. Country is <code>ZZ</code> until the
-              CloudFront <code>terraform apply</code> (#795) forwards <code>Viewer-Country</code>.
+              Same JS-gated <strong>landed</strong> population as the funnel — distinct visitors, attributed once
+              per visitor, so these counts reconcile with the funnel’s <em>Landed</em> number. Country shows{' '}
+              <code>ZZ</code> (unknown / not provided) until CloudFront forwards the visitor's country.
             </p>
             {loading && !visitors && !visitorsError ? (
               <Empty>Loading visitor insights…</Empty>

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -81,7 +81,7 @@ export default function Landing({ onNavigate }) {
             { name: 'Arc',         desc: 'EVM · Sub-second finality' },
             { name: 'Circle',      desc: 'USDC · Wallets · CCTP' },
             { name: 'Foundry',     desc: '11 deployed contracts' },
-            { name: 'Claude',      desc: 'Strategy extraction · Reasoning' },
+            { name: 'AWS Bedrock', desc: 'Nova Micro · Strategy extraction · Reasoning' },
             { name: 'React + viem',desc: 'Frontend · Wallet UX' },
             { name: 'FastAPI',     desc: 'Backend · Agent runner' },
           ].map(t => (

--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -16,9 +16,13 @@ const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 // happens via /library (curated examples) instead.
 
 function timeAgo(iso) {
+  if (!iso) return '—'
   const d = typeof iso === 'string' ? new Date(iso) : new Date(iso * 1000)
+  // A missing timestamp often round-trips as epoch 0 rather than an empty
+  // value — that's not a real multi-decade-old event, it's an absent
+  // timestamp, so render it the same as the no-value case.
+  if (Number.isNaN(d.getTime()) || d.getTime() <= 0) return '—'
   const secs = Math.floor((Date.now() - d.getTime()) / 1000)
-  if (Number.isNaN(secs)) return '—'
   if (secs < 60) return `${secs}s ago`
   if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
   if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
@@ -330,7 +334,12 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace, on
       {/* Agent activity feed — real traces from /api/traces */}
       <div>
         <div className="label mb-3">Your Traces</div>
-        {tracesLoading && <div className="caption">Loading traces…</div>}
+        {/* Only show the loading label before the FIRST successful load —
+            loadTraces() also re-runs on the 30s poll, and gating this purely
+            on `tracesLoading` meant "Loading traces…" re-appeared above the
+            already-rendered trace list on every background refresh, reading
+            as permanently stuck rather than a live-updating feed. */}
+        {tracesLoading && recentTraces.length === 0 && <div className="caption">Loading traces…</div>}
         {!tracesLoading && recentTraces.length === 0 && (
           <div className="card" style={{ padding: 18 }}>
             <p className="body" style={{ marginBottom: 6 }}>No agent activity yet.</p>

--- a/ui/src/components/Reasoning.jsx
+++ b/ui/src/components/Reasoning.jsx
@@ -8,21 +8,28 @@ import { regimeMeta } from '../regime'
 
 
 
-function timeAgo(ts) {
-  if (!ts) return '—'
-  const d = new Date(ts)
-  if (isNaN(d.getTime())) {
-    // Unix timestamp
-    const secs = Math.floor(Date.now() / 1000) - Number(ts)
-    if (secs < 60) return `${secs}s ago`
-    if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
-    if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
-    return `${Math.floor(secs / 86400)}d ago`
-  }
-  const secs = Math.floor((Date.now() - d.getTime()) / 1000)
+function formatAgo(secs) {
   if (secs < 60) return `${secs}s ago`
   if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
-  return `${Math.floor(secs / 3600)}h ago`
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
+  return `${Math.floor(secs / 86400)}d ago`
+}
+
+function timeAgo(ts) {
+  if (!ts) return 'unknown'
+  // Resolve to an epoch-ms value via both a date-string parse and a raw
+  // numeric (Unix seconds) parse, then use whichever succeeds.
+  const asDate = new Date(ts)
+  const epochMs = !isNaN(asDate.getTime()) ? asDate.getTime() : Number(ts) * 1000
+  // A missing/null timestamp from the backend often serializes as epoch 0
+  // ("1970-01-01T00:00:00Z" or numeric 0) rather than an empty value — that
+  // is not a real 56-years-ago event, it's an absent timestamp. Guard it
+  // explicitly so it renders "unknown" instead of a nonsensical multi-decade
+  // relative delta (observed live as "494774h ago").
+  if (!Number.isFinite(epochMs) || epochMs <= 0) return 'unknown'
+  const secs = Math.floor((Date.now() - epochMs) / 1000)
+  if (secs < 0) return 'unknown'
+  return formatAgo(secs)
 }
 
 function shortAddr(addr) {

--- a/ui/src/components/VaultDetail.jsx
+++ b/ui/src/components/VaultDetail.jsx
@@ -14,6 +14,10 @@ function timeAgo(ts) {
   if (!ts) return '—'
   const d = new Date(ts)
   if (isNaN(d.getTime())) return ts
+  // A missing timestamp often round-trips as epoch 0 rather than an empty
+  // value — that's not a real multi-decade-old event, it's an absent
+  // timestamp, so render it the same as the no-value case.
+  if (d.getTime() <= 0) return '—'
   const secs = Math.floor((Date.now() - d.getTime()) / 1000)
   if (secs < 60) return `${secs}s ago`
   if (secs < 3600) return `${Math.floor(secs / 60)}m ago`


### PR DESCRIPTION
## Summary
Fixes the 8 mechanically-scoped findings from the #854 dogfooding sweep (mobile drawer occlusion, dishonest Built-On credit, zeroed Corpus Overview, non-reconciling Insights sums, epoch-0 timestamps ×4 components, internal-ref leaks in public copy, sticky loading label, empty Authors column). Details per-fix in the commit message.

**Deliberately NOT here** (tracked separately with root-cause investigations done this session):
- 🔴 #854-1 passkey Generate dead-end — root cause = `getWalletClient()` unconditional throw for Circle provider + the #851 secure-by-default SIWE flip (prod container has `REQUIRE_SIWE_FOR_GENERATION` UNSET → gate ON). Needs a product decision + the DepositFlow-style provider branch.
- 🔴 #854-3 0/31 rigor gate — quant investigation delivered separately.
- Quant-data outliers (624% IV, 130% MaxDD) — need quant eyes, not mechanical fixes.

## Verify
```
env -i HOME=$HOME PATH=… PYTHONPATH=backend python -m pytest backend/tests/test_corpus_routes_overview.py backend/tests/test_papers_routes.py backend/tests/test_visitor_insights.py -q
→ 27 passed
```
Suite: 2237/2238 (1 pre-existing SIWE-nonce failure, reproduced on main). eslint + `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)