### PR TITLE
[infra] Deploy health probe: retry loop instead of one 10s sleep

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,8 +129,7 @@ jobs:
               "docker compose exec -T backend python -m archimedes.scripts.seed_backtests_from_artifacts || echo WARN_SEED_SKIP",
               "docker compose exec -dT backend python -m archimedes.scripts.hydrate_corpus || echo WARN_HYDRATE_SKIP",
               "docker compose exec -T backend python -c '"'"'import asyncio; from archimedes.services.amm_bootstrap import bootstrap_amm_liquidity; r=asyncio.run(bootstrap_amm_liquidity()); print(dict(r))'"'"' || echo WARN_BOOTSTRAP_SKIP",
-              "sleep 10",
-              "docker compose exec -T backend python -c '"'"'import urllib.request; r=urllib.request.urlopen(\"http://localhost:8000/health\"); print(r.read().decode()[:80])'"'"'",
+              "for i in $(seq 1 24); do if docker compose exec -T backend python -c '"'"'import urllib.request; r=urllib.request.urlopen(\"http://localhost:8000/health\", timeout=5); print(r.read().decode()[:80])'"'"'; then echo HEALTH_OK after ${i}x5s; break; fi; if [ $i -eq 24 ]; then echo HEALTH_TIMEOUT after 120s; exit 1; fi; sleep 5; done",
               "echo DEPLOY_COMPLETE"
             ]' \
             --region "$AWS_REGION" \


### PR DESCRIPTION
## Summary
The last 4 deploy runs (b1474c8, 384fa65, d9ea1af, 350ce9c) were all marked **failed** by the single `sleep 10` → probe smoke, while the stack actually came up healthy seconds later (live site 200 on every one — verified). The backend's boot now exceeds 10s (strategy/passport load + Aurora TLS init). This replaces the fixed sleep with a 5s-interval poll up to 120s, still failing loudly if health never arrives.

## Why it matters now
Every merge auto-deploys; red-but-actually-fine deploy runs hide the day a deploy is *actually* broken.

## Verify
- yamllint/`yaml.safe_load` passes.
- Next merge to main: deploy run goes green with a `HEALTH_OK after Nx5s` line in the SSM output.

⚠️ CI/CD wiring change — flagging per convention: @dbrowneup (infra owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)