### PR TITLE
[auth] SIWE for passkey wallets — ERC-1271/6492 smart-account verification (#869) !minor

### DIFF
--- a/backend/archimedes/api/_erc6492.py
+++ b/backend/archimedes/api/_erc6492.py
@@ -1,0 +1,83 @@
+"""Smart-wallet (ERC-1271 / ERC-6492) signature verification for SIWE.
+
+Circle Modular Wallets (passkey wallets) are ERC-4337 smart CONTRACT accounts
+with a WebAuthn P-256 owner — `eth_account.Account.recover_message` (secp256k1
+EOA recovery) can never validate their signatures. The on-chain contract
+validates them via ERC-1271 `isValidSignature(bytes32,bytes)`; a *counterfactual*
+(not-yet-deployed) account instead ships an ERC-6492-wrapped signature carrying
+its factory + factoryData so a verifier can deploy-and-check inside a sandboxed
+`eth_call`.
+
+Both cases (plus plain EOA ecrecover, as a fallback) are handled by ONE
+deployless call: the Ambire **universal signature validator** — its constructor
+runs the whole validation and "returns" the boolean as the deployed runtime
+code, so `eth_call` with `data = bytecode ++ abi.encode(signer, hash, sig)`
+and NO `to` address yields 0x01/0x00 without anything being deployed for real.
+
+Provenance of the bytecode blob: viem's `erc6492SignatureValidatorByteCode`
+(viem 2.x, `src/constants/contracts.ts`), byte-identical to the audited Ambire
+reference implementation (github.com/AmbireTech/signature-validator). This is
+the exact blob every viem `publicClient.verifyMessage` call uses — extracted
+from the pinned dependency in `ui/node_modules`, not hand-typed.
+
+Fail-closed: any RPC error, timeout, or non-0x01 result → NOT verified.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# viem erc6492SignatureValidatorByteCode — see module docstring for provenance.
+ERC6492_VALIDATOR_BYTECODE = "0x608060405234801561001057600080fd5b5060405161069438038061069483398101604081905261002f9161051e565b600061003c848484610048565b9050806000526001601ff35b60007f64926492649264926492649264926492649264926492649264926492649264926100748361040c565b036101e7576000606080848060200190518101906100929190610577565b60405192955090935091506000906001600160a01b038516906100b69085906105dd565b6000604051808303816000865af19150503d80600081146100f3576040519150601f19603f3d011682016040523d82523d6000602084013e6100f8565b606091505b50509050876001600160a01b03163b60000361016057806101605760405162461bcd60e51b815260206004820152601e60248201527f5369676e617475726556616c696461746f723a206465706c6f796d656e74000060448201526064015b60405180910390fd5b604051630b135d3f60e11b808252906001600160a01b038a1690631626ba7e90610190908b9087906004016105f9565b602060405180830381865afa1580156101ad573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906101d19190610633565b6001600160e01b03191614945050505050610405565b6001600160a01b0384163b1561027a57604051630b135d3f60e11b808252906001600160a01b03861690631626ba7e9061022790879087906004016105f9565b602060405180830381865afa158015610244573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906102689190610633565b6001600160e01b031916149050610405565b81516041146102df5760405162461bcd60e51b815260206004820152603a602482015260008051602061067483398151915260448201527f3a20696e76616c6964207369676e6174757265206c656e6774680000000000006064820152608401610157565b6102e7610425565b5060208201516040808401518451859392600091859190811061030c5761030c61065d565b016020015160f81c9050601b811480159061032b57508060ff16601c14155b1561038c5760405162461bcd60e51b815260206004820152603b602482015260008051602061067483398151915260448201527f3a20696e76616c6964207369676e617475726520762076616c756500000000006064820152608401610157565b60408051600081526020810180835289905260ff83169181019190915260608101849052608081018390526001600160a01b0389169060019060a0016020604051602081039080840390855afa1580156103ea573d6000803e3d6000fd5b505050602060405103516001600160a01b0316149450505050505b9392505050565b600060208251101561041d57600080fd5b508051015190565b60405180606001604052806003906020820280368337509192915050565b6001600160a01b038116811461045857600080fd5b50565b634e487b7160e01b600052604160045260246000fd5b60005b8381101561048c578181015183820152602001610474565b50506000910152565b600082601f8301126104a657600080fd5b81516001600160401b038111156104bf576104bf61045b565b604051601f8201601f19908116603f011681016001600160401b03811182821017156104ed576104ed61045b565b60405281815283820160200185101561050557600080fd5b610516826020830160208701610471565b949350505050565b60008060006060848603121561053357600080fd5b835161053e81610443565b6020850151604086015191945092506001600160401b0381111561056157600080fd5b61056d86828701610495565b9150509250925092565b60008060006060848603121561058c57600080fd5b835161059781610443565b60208501519093506001600160401b038111156105b357600080fd5b6105bf86828701610495565b604086015190935090506001600160401b0381111561056157600080fd5b600082516105ef818460208701610471565b9190910192915050565b828152604060208201526000825180604084015261061e816060850160208701610471565b601f01601f1916919091016060019392505050565b60006020828403121561064557600080fd5b81516001600160e01b03198116811461040557600080fd5b634e487b7160e01b600052603260045260246000fdfe5369676e617475726556616c696461746f72237265636f7665725369676e6572"
+
+_RPC_TIMEOUT_SECONDS = 8.0
+
+
+def _eip191_hash(message_text: str) -> bytes:
+    """The EIP-191 personal-message digest — identical to what
+    `eth_account.messages.encode_defunct` + hashing produce, and the hash a
+    wallet contract's `isValidSignature` expects for a personal_sign payload."""
+    from eth_utils import keccak
+
+    body = message_text.encode("utf-8")
+    return keccak(b"\x19Ethereum Signed Message:\n" + str(len(body)).encode("ascii") + body)
+
+
+async def _eth_call(rpc_url: str, data: str) -> str:
+    """One deployless eth_call (no `to`). Isolated so tests mock THIS boundary."""
+    from web3 import AsyncHTTPProvider, AsyncWeb3
+
+    w3 = AsyncWeb3(AsyncHTTPProvider(rpc_url, request_kwargs={"timeout": _RPC_TIMEOUT_SECONDS}))
+    try:
+        result = await w3.eth.call({"data": data})
+    finally:
+        await w3.provider.disconnect()
+    return result.to_0x_hex() if hasattr(result, "to_0x_hex") else "0x" + bytes(result).hex()
+
+
+async def verify_smart_wallet_signature(wallet: str, message_text: str, signature: str, rpc_url: str) -> bool:
+    """True iff `signature` over `message_text` is valid for the smart-contract
+    wallet at `wallet` (ERC-1271 for deployed accounts, ERC-6492 for
+    counterfactual ones). Never raises — every failure path returns False."""
+    from eth_abi import encode as abi_encode
+
+    try:
+        sig_bytes = bytes.fromhex(signature.removeprefix("0x"))
+        args = abi_encode(
+            ["address", "bytes32", "bytes"],
+            [wallet, _eip191_hash(message_text), sig_bytes],
+        )
+        data = ERC6492_VALIDATOR_BYTECODE + args.hex()
+        result = await asyncio.wait_for(_eth_call(rpc_url, data), timeout=_RPC_TIMEOUT_SECONDS + 2)
+        valid = int(result, 16) == 1
+        if not valid:
+            logger.info("smart-wallet SIWE verification returned invalid for %s…", wallet[:10])
+        return valid
+    except Exception as exc:
+        # Fail closed: an unreachable RPC or malformed signature must never
+        # authenticate. The caller surfaces a 401; we log the WHY.
+        logger.warning("smart-wallet SIWE verification errored (fail-closed): %s", exc)
+        return False

--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -288,21 +288,39 @@ async def verify_signature(request: Request, response: Response):
     elif not found:
         raise HTTPException(status_code=401, detail="Nonce not found or already used")
 
-    # Recover the signer address from the signature
+    # Recover the signer address from the signature (EOA fast path — no RPC).
+    # Smart-contract wallets (Circle passkey MSCAs, #869) sign with a WebAuthn
+    # P-256 owner, so secp256k1 recovery either fails outright or recovers an
+    # unrelated address — those fall through to the ERC-1271/6492 path below.
+    recovered_lower = None
     try:
         signable = encode_defunct(text=message)
         recovered = Account.recover_message(signable, signature=signature)
         recovered_lower = recovered.lower()
     except Exception as exc:
-        logger.warning("SIWE signature recovery failed: %s", exc)
-        raise HTTPException(status_code=401, detail="Invalid signature") from exc
+        logger.info("SIWE EOA recovery failed (may be a smart-wallet signature): %s", exc)
 
-    # Verify the recovered address matches the claimed wallet
-    if wallet_from_message and recovered_lower != wallet_from_message:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Signature address {recovered_lower} does not match claimed wallet {wallet_from_message}",
-        )
+    if recovered_lower and (not wallet_from_message or recovered_lower == wallet_from_message):
+        verified_wallet = recovered_lower
+    elif wallet_from_message:
+        # ERC-1271 (deployed) / ERC-6492 (counterfactual) smart-account
+        # verification via one deployless eth_call — see _erc6492.py. The
+        # claimed wallet is what gets verified: only a signature its contract
+        # (or its 6492 factory-deployed instance) accepts authenticates it.
+        from archimedes.api._erc6492 import verify_smart_wallet_signature
+
+        rpc_url = os.getenv("ARC_ARC_RPC_URL", "https://rpc.testnet.arc.network")
+        if not await verify_smart_wallet_signature(wallet_from_message, message, signature, rpc_url):
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid signature (EOA recovery and smart-wallet verification both failed)",
+            )
+        verified_wallet = wallet_from_message
+        logger.info("SIWE smart-wallet (ERC-1271/6492) verification succeeded for %s…", verified_wallet[:10])
+    else:
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    recovered_lower = verified_wallet
 
     # Issue session cookie
     now = time.time()

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -285,7 +285,13 @@ async def test_verify_with_valid_signature():
 
 @pytest.mark.asyncio
 async def test_verify_rejects_wrong_signer():
-    """Signature from wallet A cannot authenticate as wallet B."""
+    """Signature from wallet A cannot authenticate as wallet B.
+
+    Since the smart-wallet path landed (#869), an EOA mismatch falls through
+    to ERC-1271/6492 verification of the CLAIMED wallet instead of hard-401ing
+    on the recovery mismatch — so the RPC boundary is mocked to refuse here
+    (a contract wallet that doesn't accept the signature), keeping the test
+    hermetic and the wrong-signer guarantee pinned end-to-end."""
     from archimedes.main import app
     from eth_account import Account
     from eth_account.messages import encode_defunct
@@ -293,27 +299,28 @@ async def test_verify_rejects_wrong_signer():
     acct_real = Account.create()
     acct_fake = "0x" + "1" * 40  # claimed wallet (not the signer)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        nonce_resp = await client.get("/api/auth/nonce")
-        nonce_data = nonce_resp.json()
+    with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(return_value="0x" + "00" * 32)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            nonce_resp = await client.get("/api/auth/nonce")
+            nonce_data = nonce_resp.json()
 
-        # Message claims acct_fake but signed by acct_real
-        message = (
-            f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
-            f"{acct_fake}\n\n"
-            f"Chain ID: 5042002\n"
-            f"Nonce: {nonce_data['nonce']}\n"
-            f"Issued At: {_now_iso()}"
-        )
-        signable = encode_defunct(text=message)
-        signed = acct_real.sign_message(signable)
+            # Message claims acct_fake but signed by acct_real
+            message = (
+                f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
+                f"{acct_fake}\n\n"
+                f"Chain ID: 5042002\n"
+                f"Nonce: {nonce_data['nonce']}\n"
+                f"Issued At: {_now_iso()}"
+            )
+            signable = encode_defunct(text=message)
+            signed = acct_real.sign_message(signable)
 
-        verify_resp = await client.post(
-            "/api/auth/verify",
-            json={"message": message, "signature": signed.signature.hex()},
-        )
-        assert verify_resp.status_code == 401
-        assert "does not match" in verify_resp.json()["detail"]
+            verify_resp = await client.post(
+                "/api/auth/verify",
+                json={"message": message, "signature": signed.signature.hex()},
+            )
+            assert verify_resp.status_code == 401
+            assert "Invalid signature" in verify_resp.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_auth_siwe_smart_wallet.py
+++ b/backend/tests/test_auth_siwe_smart_wallet.py
@@ -1,0 +1,148 @@
+"""SIWE smart-wallet (ERC-1271 / ERC-6492) verification — the passkey path (#869).
+
+Circle Modular Wallets are smart CONTRACT accounts with a WebAuthn P-256 owner:
+EOA ecrecover can never validate their signatures, so `/api/auth/verify` falls
+through to a deployless universal-validator `eth_call` (see `api/_erc6492.py`).
+
+Hermetic: the RPC boundary (`_erc6492._eth_call`) is mocked — no network, no
+Arc RPC. The EOA fast path is covered by test_auth_siwe.py and re-pinned here
+only where its interaction with the fallback changed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from archimedes.api._erc6492 import (
+    ERC6492_VALIDATOR_BYTECODE,
+    _eip191_hash,
+    verify_smart_wallet_signature,
+)
+from httpx import ASGITransport, AsyncClient
+
+SMART_WALLET = "0x3de2000000000000000000000000000000084fa1"
+RPC = "http://rpc.invalid"  # never contacted — _eth_call is mocked everywhere
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def _nonce_and_message(client: AsyncClient, wallet: str) -> str:
+    nonce_data = (await client.get("/api/auth/nonce")).json()
+    return (
+        f"{nonce_data['domain']} wants you to sign in with your Ethereum account:\n"
+        f"{wallet}\n\n"
+        f"Sign in to Archimedes.\n\n"
+        f"URI: https://{nonce_data['domain']}\n"
+        f"Version: 1\n"
+        f"Chain ID: 5042002\n"
+        f"Nonce: {nonce_data['nonce']}\n"
+        f"Issued At: {_now_iso()}"
+    )
+
+
+# ── Unit: the verifier helper ─────────────────────────────────────────
+
+
+class TestVerifySmartWalletSignature:
+    async def test_valid_result_accepts(self):
+        with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(return_value="0x01")) as call:
+            ok = await verify_smart_wallet_signature(SMART_WALLET, "msg", "0x" + "ab" * 65, RPC)
+        assert ok is True
+        # The deployless call carries the validator bytecode + ABI-encoded
+        # (signer, hash, sig) constructor args — pin the calldata prefix.
+        data = call.call_args.args[1]
+        assert data.startswith(ERC6492_VALIDATOR_BYTECODE)
+        assert SMART_WALLET.removeprefix("0x") in data  # encoded signer address
+
+    async def test_invalid_result_rejects(self):
+        with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(return_value="0x" + "00" * 32)):
+            ok = await verify_smart_wallet_signature(SMART_WALLET, "msg", "0x" + "ab" * 65, RPC)
+        assert ok is False
+
+    async def test_rpc_error_fails_closed(self):
+        with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(side_effect=ConnectionError("rpc down"))):
+            ok = await verify_smart_wallet_signature(SMART_WALLET, "msg", "0x" + "ab" * 65, RPC)
+        assert ok is False
+
+    async def test_malformed_signature_fails_closed(self):
+        with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(return_value="0x01")):
+            ok = await verify_smart_wallet_signature(SMART_WALLET, "msg", "0xnothex", RPC)
+        assert ok is False
+
+    def test_eip191_hash_matches_eth_account(self):
+        """The digest handed to isValidSignature must equal eth_account's own
+        EIP-191 encoding — the two implementations may never drift."""
+        from eth_account.messages import _hash_eip191_message, encode_defunct
+
+        for msg in ("hello", "multi\nline\nsiwe message", "ünïcödé 🎯"):
+            assert _eip191_hash(msg) == _hash_eip191_message(encode_defunct(text=msg))
+
+
+# ── Endpoint: /api/auth/verify falls through to the smart-wallet path ─
+
+
+@pytest.mark.asyncio
+async def test_smart_wallet_signature_authenticates():
+    """A signature EOA recovery can't handle authenticates the CLAIMED wallet
+    when the on-chain validator accepts it — the Circle passkey login path."""
+    from archimedes.main import app
+
+    with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(return_value="0x01")):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            message = await _nonce_and_message(client, SMART_WALLET)
+            # A WebAuthn-style blob: not ecrecoverable, longer than 65 bytes.
+            resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0x" + "cd" * 200})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "authenticated"
+    assert data["wallet"] == SMART_WALLET
+    assert "set-cookie" in {k.lower() for k in resp.headers}
+
+
+@pytest.mark.asyncio
+async def test_smart_wallet_invalid_signature_rejected():
+    from archimedes.main import app
+
+    with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(return_value="0x" + "00" * 32)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            message = await _nonce_and_message(client, SMART_WALLET)
+            resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0x" + "cd" * 200})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_smart_wallet_rpc_down_fails_closed():
+    from archimedes.main import app
+
+    with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(side_effect=TimeoutError("rpc timeout"))):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            message = await _nonce_and_message(client, SMART_WALLET)
+            resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0x" + "cd" * 200})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_eoa_mismatch_still_rejected_when_validator_refuses():
+    """An ECDSA signature recovering to a DIFFERENT address must not
+    authenticate the claimed wallet unless the claimed wallet's contract
+    accepts it — with the validator refusing, this stays a 401 (the old
+    hard-mismatch behavior, now routed through the smart-wallet check)."""
+    from archimedes.main import app
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+
+    attacker = Account.create()  # recovers to attacker.address, not SMART_WALLET
+
+    with patch("archimedes.api._erc6492._eth_call", new=AsyncMock(return_value="0x" + "00" * 32)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            message = await _nonce_and_message(client, SMART_WALLET)
+            signed = attacker.sign_message(encode_defunct(text=message))
+            resp = await client.post(
+                "/api/auth/verify",
+                json={"message": message, "signature": signed.signature.hex()},
+            )
+    assert resp.status_code == 401

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -87,12 +87,13 @@ export default function Generate({ onNavigate }) {
   // when REQUIRE_SIWE_FOR_GENERATION is enabled; until then this is invoked
   // lazily on a 401 so the flow keeps working the moment the flag flips.
   const ensureSiweSession = async () => {
-    const { getWalletClient, getAddress } = await import('../config')
+    const { getAddress } = await import('../config')
     const { authenticateWithSIWE } = await import('../siwe')
     const address = getAddress()
     if (!address) throw new Error('Connect your wallet, then sign in to generate.')
-    const walletClient = await getWalletClient()
-    await authenticateWithSIWE(walletClient, address)
+    // Provider-aware signing (#869): passkey wallets sign via their smart
+    // account, EOAs via the viem wallet client — never getWalletClient() here.
+    await authenticateWithSIWE(address)
   }
 
   const startJob = async () => {

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -5,7 +5,6 @@ import {
   getAvailableProviders,
   getConnectedProvider,
   getUsdcBalance,
-  getWalletClient,
   CIRCLE_PROVIDER_ID,
 } from '../config'
 import { sanitizeWalletName } from '../circle-wallet'
@@ -99,11 +98,12 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
     try {
       const result = await connectWallet(providerId, opts)
 
-      // SIWE: prove wallet ownership via signature (EIP-4361)
+      // SIWE: prove wallet ownership via signature (EIP-4361). Provider-aware:
+      // EOA wallets personal_sign; Circle passkey wallets sign via their smart
+      // account (#869) — no getWalletClient() here, it throws for passkeys.
       try {
         const { authenticateWithSIWE } = await import('../siwe')
-        const walletClient = await getWalletClient()
-        await authenticateWithSIWE(walletClient, result.address)
+        await authenticateWithSIWE(result.address)
       } catch (siweErr) {
         // SIWE failure is non-fatal during transition — wallet still connects,
         // but PII endpoints won't return sensitive data without a session.

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -449,14 +449,46 @@ export async function getWalletClient() {
   if (_providerId === CIRCLE_PROVIDER_ID) {
     // Passkey wallets sign via Circle's bundler (executeUserOp), not viem
     // writeContract — callers should branch on getConnectedProvider() and
-    // use the executor for that path. This error fires only if a code path
-    // forgot to branch.
+    // use the executor for that path (message signing: signSiweMessage below).
+    // This error fires only if a code path forgot to branch.
     throw new Error(
       'This action is not yet wired for passkey wallets. ' +
       'The deposit flow uses Circle bundler execution; other flows still need that wrapper.',
     )
   }
   throw new Error('No wallet connected. Click "Connect Wallet" to continue.')
+}
+
+// Sign a plain text message with WHATEVER wallet is connected (#869).
+// EOA path: viem walletClient.signMessage (secp256k1 personal_sign).
+// Circle passkey path: the smart account's WebAuthn owner signs the account's
+// replay-safe hash (ERC-1271 convention); if the account contract is not yet
+// deployed (no user-op sent yet), the signature is wrapped per ERC-6492 with
+// the account's factory args so the backend's deployless verifier can
+// deploy-and-check it counterfactually.
+export async function signSiweMessage(message) {
+  if (_providerId === CIRCLE_PROVIDER_ID && _smartAccount) {
+    const signature = await _smartAccount.signMessage({ message })
+    try {
+      const deployed = typeof _smartAccount.isDeployed === 'function'
+        ? await _smartAccount.isDeployed()
+        : true
+      if (!deployed && typeof _smartAccount.getFactoryArgs === 'function') {
+        const { factory, factoryData } = await _smartAccount.getFactoryArgs()
+        if (factory && factoryData) {
+          const { serializeErc6492Signature } = await import('viem')
+          return serializeErc6492Signature({ address: factory, data: factoryData, signature })
+        }
+      }
+    } catch (wrapErr) {
+      // Wrapping is an optimization for counterfactual accounts — a deployed
+      // account's plain ERC-1271 signature verifies fine without it.
+      console.warn('ERC-6492 wrap skipped:', wrapErr.message)
+    }
+    return signature
+  }
+  const walletClient = await getWalletClient()
+  return walletClient.signMessage({ message })
 }
 
 // Returns all wallet providers detected in the page — curated WALLET_PROVIDERS

--- a/ui/src/siwe.js
+++ b/ui/src/siwe.js
@@ -17,11 +17,14 @@ const CHAIN_ID = import.meta.env.VITE_ARC_CHAIN_ID ?? '5042002'
 /**
  * Perform SIWE authentication: request nonce, sign message, verify.
  *
- * @param {object} walletClient — viem wallet client (from getWalletClient())
+ * Signing is provider-aware via config.signSiweMessage (#869): EOA wallets
+ * personal_sign; Circle passkey wallets sign through their smart account
+ * (WebAuthn → ERC-1271, ERC-6492-wrapped when the account is undeployed).
+ *
  * @param {string} address — the connected wallet address
  * @returns {Promise<{authenticated: boolean, wallet: string}>}
  */
-export async function authenticateWithSIWE(walletClient, address) {
+export async function authenticateWithSIWE(address) {
   // Step 1: Request a nonce from the backend
   const nonceRes = await fetch(`${API_BASE}/api/auth/nonce`)
   if (!nonceRes.ok) throw new Error(`Nonce request failed (${nonceRes.status})`)
@@ -42,7 +45,8 @@ export async function authenticateWithSIWE(walletClient, address) {
   ].join('\n')
 
   // Step 3: Sign the message (wallet popup — Touch ID or MetaMask confirm)
-  const signature = await walletClient.signMessage({ message })
+  const { signSiweMessage } = await import('./config')
+  const signature = await signSiweMessage(message)
 
   // Step 4: Send to backend for verification
   const verifyRes = await fetch(`${API_BASE}/api/auth/verify`, {


### PR DESCRIPTION
## Summary
Fixes the **biggest dogfooding finding** (#854-1 / #869): Circle passkey wallet users could never SIWE — so with generation now wallet-gated (Dan's confirmed posture), the promoted onboarding path was dead end-to-end. Closes #869.

**Frontend:** provider-aware `signSiweMessage()` — passkey wallets sign via their smart account (WebAuthn → ERC-1271; **ERC-6492-wrapped when the account is still undeployed**, i.e. every brand-new passkey user), EOAs unchanged. `getWalletClient()` is off the SIWE path entirely.

**Backend:** `/api/auth/verify` keeps the EOA ecrecover fast path and falls through to one **deployless `eth_call` of the universal signature validator** (same audited Ambire blob viem's `verifyMessage` uses, extracted from our pinned viem dep — provenance in `_erc6492.py`'s docstring). Fail-closed on RPC errors. All EIP-4361 bindings (nonce/domain/chain/issued-at) unchanged.

## Verified
- 9 new hermetic tests (RPC boundary mocked), incl. attacker case: an ECDSA sig recovering to a *different* address cannot authenticate a claimed smart wallet the validator refuses.
- Auth suite 41/42 — the 1 failure is `test_verify_rejects_expired_nonce`, **pre-existing on clean main** (reproduced by this week's review workflow).
- eslint + `npm run build` clean.
- **Live smoke against the real Arc testnet RPC**: validator accepts a genuine signature, rejects a mismatched claim (ecrecover-fallback path — proves bytecode + encoding + RPC pipeline end-to-end).

## Post-merge verification (needs a human passkey)
Connect via passkey on the live site → SIWE prompt (Touch ID) → Generate queues a job. @dbrowneup — this is the one step that needs your finger.

## Out of scope (noted in #869)
Other `getWalletClient()` tx-flow callers (VaultDetail, CreateVaultModal) still need the executor-pattern branch — those are *transactions*, a different wrapper than message signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)