### PR TITLE
[auth] Passkey SIWE: ERC-6492-wrap undeployed accounts + sharper failure logs (#869 follow-up)

### DIFF
--- a/backend/archimedes/api/_erc6492.py
+++ b/backend/archimedes/api/_erc6492.py
@@ -66,18 +66,28 @@ async def verify_smart_wallet_signature(wallet: str, message_text: str, signatur
 
     try:
         sig_bytes = bytes.fromhex(signature.removeprefix("0x"))
-        args = abi_encode(
-            ["address", "bytes32", "bytes"],
-            [wallet, _eip191_hash(message_text), sig_bytes],
-        )
+        msg_hash = _eip191_hash(message_text)
+        args = abi_encode(["address", "bytes32", "bytes"], [wallet, msg_hash, sig_bytes])
         data = ERC6492_VALIDATOR_BYTECODE + args.hex()
         result = await asyncio.wait_for(_eth_call(rpc_url, data), timeout=_RPC_TIMEOUT_SECONDS + 2)
         valid = int(result, 16) == 1
         if not valid:
-            logger.info("smart-wallet SIWE verification returned invalid for %s…", wallet[:10])
+            # A CLEAN 0x00 (validator ran, rejected) — distinct from an
+            # exception (RPC/revert). Signals a hash- or signature-format
+            # mismatch, not connectivity. Log enough to debug without leaking
+            # the signature: hash + sig length + 6492-wrapped detection.
+            is_6492 = sig_bytes[-32:].hex() == "6492" * 16 if len(sig_bytes) >= 32 else False
+            logger.warning(
+                "smart-wallet SIWE INVALID (validator ran, rejected) wallet=%s hash=%s sig_len=%d erc6492_wrapped=%s",
+                wallet[:12],
+                "0x" + msg_hash.hex(),
+                len(sig_bytes),
+                is_6492,
+            )
         return valid
     except Exception as exc:
-        # Fail closed: an unreachable RPC or malformed signature must never
-        # authenticate. The caller surfaces a 401; we log the WHY.
-        logger.warning("smart-wallet SIWE verification errored (fail-closed): %s", exc)
+        # Fail closed: an unreachable RPC, a revert (e.g. undeployed account +
+        # unwrapped sig), or a malformed signature must never authenticate. An
+        # exception here is a DIFFERENT failure class than a clean 0x00 above.
+        logger.warning("smart-wallet SIWE ERRORED (fail-closed, %s): %s", type(exc).__name__, str(exc)[:300])
         return False

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -469,23 +469,36 @@ export async function getWalletClient() {
 export async function signSiweMessage(message) {
   if (_providerId === CIRCLE_PROVIDER_ID && _smartAccount) {
     const signature = await _smartAccount.signMessage({ message })
-    try {
-      const deployed = typeof _smartAccount.isDeployed === 'function'
-        ? await _smartAccount.isDeployed()
-        : true
-      if (!deployed && typeof _smartAccount.getFactoryArgs === 'function') {
-        const { factory, factoryData } = await _smartAccount.getFactoryArgs()
-        if (factory && factoryData) {
-          const { serializeErc6492Signature } = await import('viem')
-          return serializeErc6492Signature({ address: factory, data: factoryData, signature })
-        }
-      }
-    } catch (wrapErr) {
-      // Wrapping is an optimization for counterfactual accounts — a deployed
-      // account's plain ERC-1271 signature verifies fine without it.
-      console.warn('ERC-6492 wrap skipped:', wrapErr.message)
+    // A Circle passkey account is *counterfactual*: it has on-chain code only
+    // after its first user-op deploys it — receiving USDC does NOT deploy it.
+    // Until then a bare ERC-1271 signature has no contract to validate against,
+    // so it must be ERC-6492-wrapped with the account's factory args (the
+    // backend's universal validator deploy-and-checks it). Circle's account
+    // object has no isDeployed(), so detect via on-chain bytecode.
+    const wrapWithFactory = async () => {
+      if (typeof _smartAccount.getFactoryArgs !== 'function') return signature
+      const { factory, factoryData } = await _smartAccount.getFactoryArgs()
+      if (!factory || !factoryData) return signature
+      const { serializeErc6492Signature } = await import('viem')
+      return serializeErc6492Signature({ address: factory, data: factoryData, signature })
     }
-    return signature
+    try {
+      const code = await publicClient.getCode({ address: _smartAccount.address })
+      const isDeployed = !!code && code !== '0x'
+      return isDeployed ? signature : await wrapWithFactory()
+    } catch (checkErr) {
+      // Deploy-check failed (RPC hiccup): a brand-new user is the case we most
+      // need to get right, and they're undeployed — wrap defensively. ERC-6492's
+      // magic suffix is safely handled by the validator for a deployed account
+      // too, so wrapping is the safer default when deployment is unknown.
+      console.warn('ERC-6492 deploy-check failed, wrapping defensively:', checkErr.message)
+      try {
+        return await wrapWithFactory()
+      } catch (wrapErr) {
+        console.warn('ERC-6492 defensive wrap failed, sending bare 1271 sig:', wrapErr.message)
+        return signature
+      }
+    }
   }
   const walletClient = await getWalletClient()
   return walletClient.signMessage({ message })


### PR DESCRIPTION
## The bug Dan hit live
After #870, connecting a passkey wallet and signing in still returned **"Invalid signature (EOA recovery and smart-wallet verification both failed)."**

Root cause: #870's wrap guard checked `_smartAccount.isDeployed()`, but **Circle's `toCircleSmartAccount` builds its own account object without that viem method** — so the guard always fell to `deployed = true` and **never ERC-6492-wrapped**. A brand-new passkey account has no on-chain code (receiving USDC doesn't deploy it — only its first user-op does), so its bare ERC-1271 signature has no contract to validate against → the universal validator rejects it → 401. **Every first-time passkey user was blocked.**

## Fix
- **Frontend (`config.js`):** detect deployment via `publicClient.getCode(address)` (Circle has no `isDeployed()`), and ERC-6492-wrap with `getFactoryArgs()` when undeployed. On an RPC hiccup during the check, wrap defensively — the brand-new-user case *is* undeployed, and 6492's magic suffix is safely handled by the validator for a deployed account too.
- **Backend (`_erc6492.py`):** enrich the failure logs to distinguish a **clean validator reject** (`0x00` → hash/sig-format mismatch) from an **exception** (RPC error / revert → connectivity or undeployed-account), with hash + sig-length + 6492-wrapped detection — so any remaining failure is one-glance diagnosable via `docker logs`.

Hash convention re-confirmed against viem source: `verifyMessage` computes `hashMessage(message)`, exactly what the backend passes — the replay-safe wrapping happens inside the account contract, so no change needed there.

## Verified
- 9 hermetic backend tests still green (logging change is behavior-preserving).
- eslint + `npm run build` clean.

## The one human step (unchanged)
@dbrowneup — after this deploys, retry passkey connect → Touch ID → Generate. If it *still* fails, the backend now logs the exact failure class (`smart-wallet SIWE INVALID …` vs `… ERRORED …`) — grab that line and I'll pinpoint it immediately.

Follow-up to #870 / closes the live blocker on #869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)