### PR TITLE
[strategy] Debate winners persist real returns — live gate reads pass/fail

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -481,6 +481,12 @@ def _make_entry(candidate_id: str, proposal: Any, ev: Any, *, regime: str) -> _C
     ``has_real_rigor``), preserving the CSCV PBO from ``evaluate_fusion_spec``.
     """
     spec = proposal.strategy_spec or {}
+    # Real per-bar returns for the live gate (#788/#818, mirrors the fusion
+    # path): without return_series, _persist_real_returns SKIPS the winner and
+    # the passport reads "pending" forever even though C-rigor just ran a real
+    # backtest (first prod debate run surfaced exactly this).
+    _ec = list(getattr(ev.backtest, "equity_curve", None) or [])
+    real_returns = [(_ec[i] - _ec[i - 1]) / _ec[i - 1] for i in range(1, len(_ec)) if _ec[i - 1] > 0]
     return _CandidateResult(
         candidate_id=candidate_id,
         strategy_name=proposal.strategy_name or "Debate candidate",
@@ -495,6 +501,7 @@ def _make_entry(candidate_id: str, proposal: Any, ev: Any, *, regime: str) -> _C
         generation_method="debate",
         source_arxiv_ids=list(proposal.source_arxiv_ids),
         has_real_rigor=True,
+        return_series=real_returns or None,
     )
 
 

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -554,3 +554,28 @@ def test_critic_prov_robust_to_missing_citations(corpus):
     kept, dropped = de._critic_prov([none_cited, no_attr, good], corpus)
     assert [p.strategy_name for p in kept] == ["good"]
     assert {p.strategy_name for p in dropped} == {"none", "noattr"}
+
+
+# ── Live-gate persistence seam (#788): entries carry real return_series ──────
+
+
+def test_leaderboard_entries_carry_return_series_for_live_gate():
+    """Without return_series, _persist_real_returns SKIPS debate winners and the
+    passport reads 'pending' forever despite C-rigor's real backtest (first prod
+    debate run, 2026-07-04). Entries must derive per-bar returns from the
+    evaluator's equity curve — and stay None when no curve exists (never fabricate)."""
+    ev = _fake_ev(cagr=0.2, dsr=2.0)
+    ev.backtest.equity_curve = [100.0, 101.0, 99.99, 102.0]
+    board = de.build_leaderboard(
+        [(_fake_proposal("A", ["2401.00001", "2402.00001"]), ev)], regime="neutral", base_id="c1"
+    )
+    rs = board[0].return_series
+    assert rs is not None and len(rs) == 3
+    assert abs(rs[0] - 0.01) < 1e-9
+
+    board2 = de.build_leaderboard(
+        [(_fake_proposal("B", ["2401.00001", "2402.00001"]), _fake_ev(cagr=0.1, dsr=1.0))],
+        regime="neutral",
+        base_id="c2",
+    )
+    assert board2[0].return_series is None


### PR DESCRIPTION
## Summary
First prod debate run: the winner ran a REAL backtest (`yfinance:SPY,GLD,BTC-USD,XLE` — thesis-true universe) and **cleared the DSR bar for the first time ever** (dsr_p=0.997; honestly rejected on PBO=0.73) — yet its passport read `pending` because the debate path never populated `return_series`, so `_persist_real_returns` (#839) skipped it.

## Fix
`_make_entry` derives per-bar returns from the evaluator's equity curve (mirrors the fusion path); entries without a curve stay `None` — never fabricated. Regression test proves both directions.

## Verify
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_debate_engine.py backend/tests/test_live_gate_returns.py -q   # 28 passed
```

## Anti-goals
No gate/threshold changes; synthetic data still never persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M