### PR TITLE
[backend] Automated in-app backtest refresh — no more operator-invoked backtests !minor

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -4,6 +4,7 @@ Minimal bootstrap for the hackathon MVP. All routes are wired to
 chain services that read/write Arc smart contracts.
 """
 
+import asyncio
 import logging
 import os
 
@@ -237,6 +238,27 @@ async def _startup_seed_corpus():
             _logger.info("startup: corpus seed — no new papers to add")
     except Exception as exc:
         _logger.warning("startup: corpus seed failed (non-fatal): %s", exc)
+
+
+@app.on_event("startup")
+async def _startup_backtest_scheduler():
+    """Keep curated backtests fresh IN-APP — no operator-invoked CLI runs.
+
+    The scheduler owns staleness checks + refresh cadence; see
+    services/backtest_scheduler.py. Disabled under TESTING and via
+    BACKTEST_REFRESH_ENABLED=0. Fail-soft: never blocks startup.
+    """
+    _logger = logging.getLogger("archimedes.startup")
+    try:
+        from archimedes.services.backtest_scheduler import backtest_refresh_loop, refresh_enabled
+
+        if refresh_enabled():
+            asyncio.create_task(backtest_refresh_loop())
+            _logger.info("startup: backtest refresh scheduler armed")
+        else:
+            _logger.info("startup: backtest refresh scheduler disabled")
+    except Exception as exc:
+        _logger.warning("startup: backtest scheduler failed to arm (non-fatal): %s", exc)
 
 
 # Wire all routers

--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -77,7 +77,11 @@ def _load_run_command(repo_root: Path):
 
 def _read_config() -> RunConfig:
     operations = [op.strip().upper() for op in os.getenv("BACKTEST_OPERATIONS", "SPY").split(",") if op.strip()]
-    start = os.getenv("BACKTEST_START", "2018-01-01")
+    # Full curated evidence depth by default (~5,400 daily bars). The old
+    # 2018 default silently produced 8-year runs with materially weaker DSR
+    # statistics than the seed-time store — the scheduler and the CLI should
+    # both grade on the same evidence window the passports were built on.
+    start = os.getenv("BACKTEST_START", "2004-01-02")
     end = os.getenv("BACKTEST_END", datetime.now(UTC).date().isoformat())
     initial_cash = float(os.getenv("BACKTEST_INITIAL_CASH", "100000"))
     tx_cost_bps = int(os.getenv("BACKTEST_TX_COST_BPS", "10"))

--- a/backend/archimedes/services/backtest_scheduler.py
+++ b/backend/archimedes/services/backtest_scheduler.py
@@ -1,0 +1,119 @@
+"""In-app automated backtest refresh — no more operator-invoked backtests.
+
+``archimedes.scripts.run_backtests`` existed only as a manual CLI (invoked by
+hand over SSM), so the curated library's real backtests refreshed exactly as
+often as a human remembered to run them — which is how prod sat at "pending"
+for weeks. A product whose wedge is *autonomous* rigor cannot depend on an
+operator for its evidence. This scheduler makes the backend keep its own
+backtests fresh:
+
+- On startup (after a settle delay) and then on a fixed cadence, it checks
+  staleness: any curated strategy with NO persisted backtest, or whose latest
+  run is older than ``BACKTEST_MAX_AGE_HOURS``, triggers a refresh.
+- The refresh IS ``run_backtests()`` — the exact same code path as the CLI
+  (content-hash dedup included), run on a worker thread so the event loop
+  stays responsive. One implementation, two entry points.
+- Fail-soft everywhere: a refresh failure logs loudly and the loop continues;
+  the scheduler can never take the app down. ``TESTING`` disables it outright
+  (hermetic tests must never hit yfinance).
+
+Env knobs:
+  BACKTEST_REFRESH_ENABLED          default on   ("0"/"false" disables)
+  BACKTEST_REFRESH_INTERVAL_HOURS   default 24   (cadence of staleness checks)
+  BACKTEST_MAX_AGE_HOURS            default 168  (7 days — refresh when older)
+  BACKTEST_REFRESH_STARTUP_DELAY_S  default 180  (let the app settle first)
+
+Single-writer note: prod runs one backend replica; if that ever changes, the
+content-hash dedup in ``insert_backtest_if_missing`` keeps concurrent runs
+idempotent (wasted compute, never corrupt data).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+_FALSY = {"0", "false", "no", "off"}
+
+
+def refresh_enabled() -> bool:
+    """On by default; off under TESTING (hermetic) or via the env kill switch."""
+    if os.getenv("TESTING"):
+        return False
+    return os.getenv("BACKTEST_REFRESH_ENABLED", "1").strip().lower() not in _FALSY
+
+
+def _hours(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return max(lo, min(hi, float(os.getenv(name, str(default)))))
+    except ValueError:
+        return default
+
+
+def needs_refresh() -> tuple[bool, str]:
+    """(should_refresh, reason) from the curated library's persisted backtests.
+
+    Missing rows or a latest run older than ``BACKTEST_MAX_AGE_HOURS`` → stale.
+    Fail-soft: any error reports (False, reason) — the next tick retries; a
+    broken staleness check must not stampede refreshes.
+    """
+    max_age = timedelta(hours=_hours("BACKTEST_MAX_AGE_HOURS", 168.0, 1.0, 24 * 90.0))
+    try:
+        from archimedes.db import get_session
+        from archimedes.services.backtest_repository import latest_backtests_by_strategy
+        from archimedes.services.strategy_provider import default_provider
+
+        strategies = default_provider().list_strategies()
+        ids = [s.id for s in strategies]
+        if not ids:
+            return False, "no curated strategies"
+        with get_session() as session:
+            latest = latest_backtests_by_strategy(session, ids)
+        missing = [sid for sid in ids if sid not in latest]
+        if missing:
+            return True, f"{len(missing)}/{len(ids)} strategies have no persisted backtest"
+        now = datetime.now(UTC)
+        oldest = None
+        for row in latest.values():
+            created = getattr(row, "created_at", None)
+            if created is None:
+                return True, "a backtest row lacks created_at"
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=UTC)
+            oldest = created if oldest is None or created < oldest else oldest
+        if oldest is not None and (now - oldest) > max_age:
+            return True, f"oldest backtest is {(now - oldest).days}d old (max {max_age.days}d)"
+        return False, "all curated backtests fresh"
+    except Exception as exc:
+        return False, f"staleness check failed ({type(exc).__name__}: {exc})"
+
+
+def _run_refresh() -> dict:
+    """One refresh — the SAME implementation as the manual CLI."""
+    from archimedes.scripts.run_backtests import run_backtests
+
+    return run_backtests()
+
+
+async def backtest_refresh_loop() -> None:
+    """Long-lived task: settle → check staleness → refresh when needed → sleep."""
+    delay = _hours("BACKTEST_REFRESH_STARTUP_DELAY_S", 180.0, 0.0, 3600.0)
+    interval_s = _hours("BACKTEST_REFRESH_INTERVAL_HOURS", 24.0, 1.0, 168.0) * 3600.0
+    await asyncio.sleep(delay)
+    while True:
+        try:
+            should, reason = needs_refresh()
+            if should:
+                logger.info("backtest refresh: starting (%s)", reason)
+                summary = await asyncio.to_thread(_run_refresh)
+                logger.info("backtest refresh: done — %s", summary)
+            else:
+                logger.info("backtest refresh: skipped (%s)", reason)
+        except Exception as exc:
+            # Fail-soft by contract: the scheduler must never take the app down.
+            logger.warning("backtest refresh: cycle failed (%s: %s) — will retry next tick", type(exc).__name__, exc)
+        await asyncio.sleep(interval_s)

--- a/backend/tests/test_backtest_scheduler.py
+++ b/backend/tests/test_backtest_scheduler.py
@@ -1,0 +1,153 @@
+"""In-app automated backtest refresh (services/backtest_scheduler.py).
+
+The refresh must be a product behavior, not an operator ritual: stale or
+missing curated backtests trigger the SAME run_backtests implementation the
+CLI uses, from a background loop the app arms at startup. Hermetic: tmp-sqlite
+DB, run_backtests monkeypatched (never yfinance), TESTING guard respected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import archimedes.services.backtest_scheduler as sched
+import pytest
+from archimedes.db import get_session
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    import archimedes.db as db
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'sched.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+class _Strat:
+    def __init__(self, sid):
+        self.id = sid
+
+
+def _patch_provider(monkeypatch, ids):
+    provider = type("P", (), {"list_strategies": lambda self: [_Strat(i) for i in ids]})()
+    monkeypatch.setattr("archimedes.services.strategy_provider.default_provider", lambda: provider)
+
+
+def _insert_backtest(sid: str, created_at: datetime):
+    from archimedes.models.backtest_store import BacktestResultRecord
+
+    with get_session() as session:
+        session.add(
+            BacktestResultRecord(
+                strategy_id=sid,
+                content_hash=("0x" + sid).ljust(66, "0"),
+                artifact_json="{}",
+                created_at=created_at,
+            )
+        )
+        session.commit()
+
+
+# ── enable/disable semantics ──────────────────────────────────────────
+
+
+def test_disabled_under_testing(monkeypatch):
+    monkeypatch.setenv("TESTING", "1")
+    assert sched.refresh_enabled() is False  # hermetic suites never hit yfinance
+
+
+def test_enabled_by_default_outside_testing(monkeypatch):
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("BACKTEST_REFRESH_ENABLED", raising=False)
+    assert sched.refresh_enabled() is True
+    monkeypatch.setenv("BACKTEST_REFRESH_ENABLED", "0")
+    assert sched.refresh_enabled() is False
+
+
+# ── staleness detection ───────────────────────────────────────────────
+
+
+def test_missing_rows_trigger_refresh(monkeypatch):
+    _patch_provider(monkeypatch, ["s1", "s2"])
+    _insert_backtest("s1", datetime.now(UTC))
+    should, reason = sched.needs_refresh()
+    assert should is True
+    assert "no persisted backtest" in reason
+
+
+def test_fresh_rows_do_not_trigger(monkeypatch):
+    _patch_provider(monkeypatch, ["s1"])
+    _insert_backtest("s1", datetime.now(UTC))
+    should, reason = sched.needs_refresh()
+    assert should is False
+    assert "fresh" in reason
+
+
+def test_stale_rows_trigger(monkeypatch):
+    _patch_provider(monkeypatch, ["s1"])
+    _insert_backtest("s1", datetime.now(UTC) - timedelta(days=30))
+    monkeypatch.setenv("BACKTEST_MAX_AGE_HOURS", "168")
+    should, reason = sched.needs_refresh()
+    assert should is True
+    assert "old" in reason
+
+
+def test_staleness_check_fails_soft(monkeypatch):
+    def _boom():
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr("archimedes.services.strategy_provider.default_provider", _boom)
+    should, reason = sched.needs_refresh()
+    assert should is False  # a broken check must not stampede refreshes
+    assert "failed" in reason
+
+
+# ── the loop actually refreshes via the shared implementation ─────────
+
+
+async def test_loop_runs_refresh_when_stale(monkeypatch):
+    monkeypatch.setenv("BACKTEST_REFRESH_STARTUP_DELAY_S", "0")
+    monkeypatch.setenv("BACKTEST_REFRESH_INTERVAL_HOURS", "1")
+    calls = []
+    monkeypatch.setattr(sched, "needs_refresh", lambda: (True, "test"))
+    monkeypatch.setattr(sched, "_run_refresh", lambda: calls.append(1) or {"inserted": 1})
+
+    task = asyncio.create_task(sched.backtest_refresh_loop())
+    for _ in range(200):
+        if calls:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    assert calls, "the loop must invoke the shared run_backtests implementation when stale"
+
+
+async def test_loop_survives_refresh_failure(monkeypatch):
+    monkeypatch.setenv("BACKTEST_REFRESH_STARTUP_DELAY_S", "0")
+    monkeypatch.setenv("BACKTEST_REFRESH_INTERVAL_HOURS", "1")
+    checks = []
+
+    def _needs():
+        checks.append(1)
+        return (True, "test")
+
+    def _explode():
+        raise RuntimeError("yfinance down")
+
+    monkeypatch.setattr(sched, "needs_refresh", _needs)
+    monkeypatch.setattr(sched, "_run_refresh", _explode)
+    task = asyncio.create_task(sched.backtest_refresh_loop())
+    for _ in range(200):
+        if checks:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)  # give the exception path time to run
+    assert not task.done(), "a failed refresh must never kill the loop"
+    task.cancel()


### PR DESCRIPTION
## Summary
Dan called it exactly right: backtest refresh was an **operator ritual** (a manual CLI lately invoked over SSM), which is how prod sat at `pending` for weeks. A product whose wedge is *autonomous* rigor must own its own evidence.

## Fix
New `services/backtest_scheduler.py`, armed at startup (same fail-soft pattern as the other startup hooks):
- **Staleness-driven**: refreshes when any curated strategy has no persisted backtest, or the oldest run exceeds `BACKTEST_MAX_AGE_HOURS` (default 7d), checked every `BACKTEST_REFRESH_INTERVAL_HOURS` (default 24h) after a startup settle delay.
- **One implementation, two entry points**: the refresh calls the exact same `run_backtests()` the CLI uses, on a worker thread; content-hash dedup keeps it idempotent.
- **Can never take the app down**: fail-soft arming, fail-soft cycles (log + retry next tick), disabled under `TESTING` and via `BACKTEST_REFRESH_ENABLED=0`.
- Also bumps the `BACKTEST_START` default 2018→2004: the 2018 default silently produced 8-year runs with materially weaker DSR statistics than the curated store's evidence depth.

## Verify
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_backtest_scheduler.py -q   # 8 passed
```
Post-merge, on deploy: backend logs show `backtest refresh scheduler armed`, then within ~3 minutes either a refresh (currently stale after 7d) or an explicit `skipped (all curated backtests fresh)`.

## Anti-goals
No gate changes; the CLI keeps working; single-replica assumption documented (dedup keeps concurrent runs safe anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M