### PR TITLE
Render full paper provenance for multi-paper strategies !minor

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1260,11 +1260,41 @@ async def get_strategy_passport(request: Request, strategy_id: str):
         return _redact_owner_wallet(record.to_dict(), caller)
 
 
-def _passport_to_strategy_response(record) -> StrategyResponse:
+def _enrich_paper_titles_from_corpus(
+    refs: list,
+    session,
+) -> dict[str, str]:
+    """Return a map of arxiv_id → corpus title for refs with empty stored titles.
+
+    Queries the ``papers`` corpus table (PaperRecord) for refs whose stored
+    ``title`` is blank but whose ``arxiv_id`` is known.  Non-fatal — any DB
+    error returns an empty map so the caller falls back to the bare arxiv_id.
+    Only fires when at least one ref needs enrichment.
+    """
+    missing_ids = [r.arxiv_id for r in refs if r.arxiv_id and not (r.title or "").strip()]
+    if not missing_ids:
+        return {}
+    try:
+        from archimedes.models.corpus_store import PaperRecord
+
+        rows = session.query(PaperRecord).filter(PaperRecord.arxiv_id.in_(missing_ids)).all()
+        return {row.arxiv_id: row.title for row in rows if row.title}
+    except Exception:
+        return {}
+
+
+def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
     """Reshape a StrategyPassportRecord (fusion/architect output) into the
     StrategyResponse schema that StrategyPassport.jsx expects. Curated
     strategies still flow through LocalStrategyProvider above; this is the
-    fallback that makes generated strategies clickable from Library."""
+    fallback that makes generated strategies clickable from Library.
+
+    ``session`` — optional SQLAlchemy session used to enrich empty paper titles
+    from the corpus ``papers`` table at read time.  When titles are missing
+    (fusion generation stores only arxiv_ids), the corpus join backfills them so
+    the UI can display a human-readable title instead of a bare arxiv id.
+    Falls back to the arxiv_id string when the corpus has no matching row.
+    """
     from archimedes.api.schemas import PaperRefResponse
     from archimedes.services.return_source_classifier import (
         StrategyView,
@@ -1274,10 +1304,21 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
     refs = list(record.paper_refs or [])
     first = refs[0] if refs else None
 
+    # Enrich missing titles from the corpus when a session is available.
+    corpus_titles: dict[str, str] = _enrich_paper_titles_from_corpus(refs, session) if session is not None else {}
+
+    def _resolved_title(r) -> str:
+        """Stored title wins; fall back to corpus; fall back to bare arxiv_id."""
+        if (r.title or "").strip():
+            return r.title
+        if r.arxiv_id and corpus_titles.get(r.arxiv_id):
+            return corpus_titles[r.arxiv_id]
+        return r.arxiv_id or ""
+
     papers_list = [
         PaperRefResponse(
             arxiv_id=r.arxiv_id,
-            title=r.title or "",
+            title=_resolved_title(r),
             authors=json.loads(r.authors) if r.authors else [],
             doi=r.doi,
             venue=r.venue,
@@ -1290,9 +1331,12 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
 
     asset_universe = json.loads(record.asset_universe) if record.asset_universe else []
 
+    # The enriched first-paper title (may have been filled from corpus above).
+    first_title = papers_list[0].title if papers_list else (first.title if first else "")
+
     return_source_enum, return_source_note = classify_return_source(
         StrategyView(
-            paper_title=(first.title if first else "") or "",
+            paper_title=first_title or "",
             methodology_summary=record.methodology_summary or "",
             asset_universe=tuple(asset_universe),
             deflated_sharpe_ratio=record.deflated_sharpe_ratio,
@@ -1305,7 +1349,7 @@ def _passport_to_strategy_response(record) -> StrategyResponse:
         id=record.id,
         papers=papers_list,
         paper_arxiv_id=first.arxiv_id if first else None,
-        paper_title=first.title if first else None,
+        paper_title=first_title or None,
         paper_authors=json.loads(first.authors) if first and first.authors else [],
         paper_venue=first.venue if first else None,
         paper_year=first.year if first else None,
@@ -1386,7 +1430,7 @@ async def get_strategy(strategy_id: str, request: Request):
                 raise HTTPException(status_code=404, detail="Strategy not found")
         record = get_passport(session, strategy_id)
         if record is not None:
-            return _passport_to_strategy_response(record)
+            return _passport_to_strategy_response(record, session=session)
 
     raise HTTPException(status_code=404, detail="Strategy not found")
 

--- a/backend/tests/test_multipaper_passport.py
+++ b/backend/tests/test_multipaper_passport.py
@@ -1,0 +1,283 @@
+"""Hermetic tests for multi-paper passport provenance rendering.
+
+Covers the server-side paper title enrichment in
+``_passport_to_strategy_response``: when a ``PassportPaperRef`` row has an
+empty title but the corpus ``papers`` table has a matching arxiv_id, the API
+response should use the corpus title instead of an empty string.  Falls back
+to the bare arxiv_id string when the corpus has no matching row.
+
+All tests use in-memory SQLite — no real Postgres, no network, no .env.
+Run: env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
+       backend/tests/test_multipaper_passport.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from archimedes.models.chat import Base
+from archimedes.models.corpus_store import PaperRecord
+from archimedes.models.strategy_passport_record import PassportPaperRef, StrategyPassportRecord
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session() -> Session:
+    """In-memory SQLite session with all ORM tables created."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    sess = SessionLocal()
+    yield sess
+    sess.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_corpus_paper(
+    session: Session,
+    arxiv_id: str,
+    title: str,
+) -> PaperRecord:
+    row = PaperRecord(
+        arxiv_id=arxiv_id,
+        title=title,
+        authors="[]",
+        abstract="",
+        primary_category="q-fin",
+        categories="[]",
+        published="2023-01-01",
+        updated="2023-01-01",
+        source="seed",
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_passport_record(
+    session: Session,
+    strategy_id: str,
+    papers: list[dict],  # [{arxiv_id, title}]
+) -> StrategyPassportRecord:
+    """Create a StrategyPassportRecord with the given paper refs."""
+    record = StrategyPassportRecord(
+        id=strategy_id,
+        generation_method="fusion",
+        methodology_summary="Test fusion methodology",
+        asset_universe="[]",
+        position_sizing="equal_weight",
+        rebalance_frequency="weekly",
+        status="candidate",
+        regime_tag="regime_neutral",
+        passes_rigor_gate=False,
+    )
+    session.add(record)
+    session.flush()
+
+    for p in papers:
+        ref = PassportPaperRef(
+            passport_id=strategy_id,
+            arxiv_id=p.get("arxiv_id"),
+            title=p.get("title", ""),
+            authors="[]",
+        )
+        session.add(ref)
+    session.flush()
+    return record
+
+
+# ---------------------------------------------------------------------------
+# _enrich_paper_titles_from_corpus (unit-level)
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichPaperTitlesFromCorpus:
+    """Unit tests for the standalone enrichment helper."""
+
+    def test_returns_title_for_matching_arxiv_id(self, session: Session):
+        _add_corpus_paper(session, "2301.00001", "Momentum Everywhere")
+
+        from archimedes.api.strategies_routes import _enrich_paper_titles_from_corpus
+        from archimedes.models.strategy_passport_record import PassportPaperRef
+
+        refs = [PassportPaperRef(arxiv_id="2301.00001", title="", authors="[]")]
+        result = _enrich_paper_titles_from_corpus(refs, session)
+        assert result == {"2301.00001": "Momentum Everywhere"}
+
+    def test_skips_refs_with_stored_titles(self, session: Session):
+        _add_corpus_paper(session, "2301.00002", "Corpus Title")
+
+        from archimedes.api.strategies_routes import _enrich_paper_titles_from_corpus
+        from archimedes.models.strategy_passport_record import PassportPaperRef
+
+        # Title already stored — should NOT appear in missing_ids query
+        refs = [PassportPaperRef(arxiv_id="2301.00002", title="Stored Title", authors="[]")]
+        result = _enrich_paper_titles_from_corpus(refs, session)
+        # No missing ids → empty map
+        assert result == {}
+
+    def test_returns_empty_map_when_no_corpus_match(self, session: Session):
+        from archimedes.api.strategies_routes import _enrich_paper_titles_from_corpus
+        from archimedes.models.strategy_passport_record import PassportPaperRef
+
+        refs = [PassportPaperRef(arxiv_id="2301.99999", title="", authors="[]")]
+        result = _enrich_paper_titles_from_corpus(refs, session)
+        assert result == {}
+
+    def test_empty_refs_returns_empty_map(self, session: Session):
+        from archimedes.api.strategies_routes import _enrich_paper_titles_from_corpus
+
+        result = _enrich_paper_titles_from_corpus([], session)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _passport_to_strategy_response (integration-level, SQLite)
+# ---------------------------------------------------------------------------
+
+
+class TestPassportToStrategyResponse:
+    """Integration tests for the full API response builder with title enrichment."""
+
+    def test_multi_paper_titles_enriched_from_corpus(self, session: Session):
+        """Two fusion papers with empty titles get filled from corpus."""
+        _add_corpus_paper(session, "2301.00001", "Momentum Everywhere")
+        _add_corpus_paper(session, "2301.00002", "Volatility-Managed Portfolios")
+
+        _make_passport_record(
+            session,
+            "fuse-001",
+            [
+                {"arxiv_id": "2301.00001", "title": ""},
+                {"arxiv_id": "2301.00002", "title": ""},
+            ],
+        )
+        session.flush()
+
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        record = get_passport(session, "fuse-001")
+        assert record is not None
+
+        resp = _passport_to_strategy_response(record, session=session)
+
+        assert len(resp.papers) == 2
+        title_by_id = {p.arxiv_id: p.title for p in resp.papers}
+        assert title_by_id["2301.00001"] == "Momentum Everywhere"
+        assert title_by_id["2301.00002"] == "Volatility-Managed Portfolios"
+
+    def test_stored_titles_take_priority_over_corpus(self, session: Session):
+        """Pre-stored non-empty titles are NOT overwritten by corpus."""
+        _add_corpus_paper(session, "2301.00003", "Corpus Title")
+
+        _make_passport_record(
+            session,
+            "fuse-002",
+            [{"arxiv_id": "2301.00003", "title": "Hand-curated Title"}],
+        )
+        session.flush()
+
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        record = get_passport(session, "fuse-002")
+        resp = _passport_to_strategy_response(record, session=session)
+
+        assert resp.papers[0].title == "Hand-curated Title"
+
+    def test_unknown_arxiv_id_falls_back_to_arxiv_id(self, session: Session):
+        """When corpus has no matching row, the title falls back to the arxiv_id."""
+        _make_passport_record(
+            session,
+            "fuse-003",
+            [{"arxiv_id": "2301.99999", "title": ""}],
+        )
+        session.flush()
+
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        record = get_passport(session, "fuse-003")
+        resp = _passport_to_strategy_response(record, session=session)
+
+        assert resp.papers[0].title == "2301.99999"
+
+    def test_no_session_leaves_empty_title(self, session: Session):
+        """Without a session, enrichment is skipped (session=None path)."""
+        _add_corpus_paper(session, "2301.00004", "Would be enriched")
+
+        _make_passport_record(
+            session,
+            "fuse-004",
+            [{"arxiv_id": "2301.00004", "title": ""}],
+        )
+        session.flush()
+
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        record = get_passport(session, "fuse-004")
+        resp = _passport_to_strategy_response(record, session=None)
+
+        # No session → falls back to arxiv_id (the title is "" so _resolved_title
+        # returns arxiv_id as the final fallback)
+        assert resp.papers[0].title == "2301.00004"
+
+    def test_papers_field_populated_for_multi_paper_strategy(self, session: Session):
+        """The ``papers`` list on the response contains all source papers."""
+        _add_corpus_paper(session, "2301.00010", "Paper Alpha")
+        _add_corpus_paper(session, "2301.00011", "Paper Beta")
+        _add_corpus_paper(session, "2301.00012", "Paper Gamma")
+
+        _make_passport_record(
+            session,
+            "fuse-005",
+            [
+                {"arxiv_id": "2301.00010", "title": ""},
+                {"arxiv_id": "2301.00011", "title": ""},
+                {"arxiv_id": "2301.00012", "title": ""},
+            ],
+        )
+        session.flush()
+
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        record = get_passport(session, "fuse-005")
+        resp = _passport_to_strategy_response(record, session=session)
+
+        assert len(resp.papers) == 3
+        assert resp.paper_title in ("Paper Alpha", "2301.00010", "")  # legacy field = first paper
+
+    def test_single_paper_curated_strategy_unaffected(self, session: Session):
+        """Single-paper curated strategies render correctly — no regression."""
+        _make_passport_record(
+            session,
+            "cur-001",
+            [{"arxiv_id": "0706.2631", "title": "Quantitative Trading with ML"}],
+        )
+        session.flush()
+
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        record = get_passport(session, "cur-001")
+        resp = _passport_to_strategy_response(record, session=session)
+
+        assert len(resp.papers) == 1
+        assert resp.papers[0].title == "Quantitative Trading with ML"
+        assert resp.papers[0].arxiv_id == "0706.2631"
+        # Legacy scalar fields still populated
+        assert resp.paper_title == "Quantitative Trading with ML"
+        assert resp.paper_arxiv_id == "0706.2631"

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -403,6 +403,15 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport })
         <td className="font-semibold">
           <span className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3 h-3 mr-1.5 text-[var(--text-4)] flex-shrink-0 inline-block`} />
           {s.paper_title}
+          {(s.papers || []).length > 1 && (
+            <span
+              className="tag tag-accent"
+              style={{ fontSize: '0.68rem', marginLeft: 6, verticalAlign: 'middle', padding: '1px 5px' }}
+              title={`Fused from ${s.papers.length} papers`}
+            >
+              {s.papers.length} papers
+            </span>
+          )}
         </td>
         <td className="caption">{paperCite || (s.paper_year ? `(${s.paper_year})` : '—')}</td>
         <td>
@@ -458,22 +467,51 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport })
                 <div className="body">{s.methodology_summary || '—'}</div>
               </div>
               <div>
-                <div className="label mb-2">Source paper</div>
-                <div className="body">"{s.paper_title}"</div>
-                <div className="caption mt-2">
-                  {s.paper_authors?.slice(0, 3).join(', ')}{s.paper_authors?.length > 3 ? ' et al.' : ''}
-                  {s.paper_year ? ` (${s.paper_year})` : ''}
-                  {s.paper_venue ? ` · ${s.paper_venue}` : ''}
-                </div>
-                {s.paper_arxiv_id && (
-                  <a
-                    href={`https://arxiv.org/abs/${s.paper_arxiv_id}`}
-                    target="_blank" rel="noreferrer"
-                    style={{ color: 'var(--accent)', fontSize: '0.78rem', marginTop: 6, display: 'inline-block' }}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    arxiv:{s.paper_arxiv_id} ↗
-                  </a>
+                {(s.papers || []).length > 1 ? (
+                  <>
+                    <div className="label mb-2">
+                      Fused from {s.papers.length} papers
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      {s.papers.map((p, idx) => (
+                        <div key={idx}>
+                          <div className="body" style={{ fontStyle: 'italic' }}>
+                            "{p.title || p.arxiv_id || '—'}"
+                          </div>
+                          {p.arxiv_id && (
+                            <a
+                              href={`https://arxiv.org/abs/${p.arxiv_id}`}
+                              target="_blank" rel="noreferrer"
+                              style={{ color: 'var(--accent)', fontSize: '0.75rem', marginTop: 3, display: 'inline-block' }}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              arxiv:{p.arxiv_id} ↗
+                            </a>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="label mb-2">Source paper</div>
+                    <div className="body">"{s.paper_title}"</div>
+                    <div className="caption mt-2">
+                      {s.paper_authors?.slice(0, 3).join(', ')}{s.paper_authors?.length > 3 ? ' et al.' : ''}
+                      {s.paper_year ? ` (${s.paper_year})` : ''}
+                      {s.paper_venue ? ` · ${s.paper_venue}` : ''}
+                    </div>
+                    {s.paper_arxiv_id && (
+                      <a
+                        href={`https://arxiv.org/abs/${s.paper_arxiv_id}`}
+                        target="_blank" rel="noreferrer"
+                        style={{ color: 'var(--accent)', fontSize: '0.78rem', marginTop: 6, display: 'inline-block' }}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        arxiv:{s.paper_arxiv_id} ↗
+                      </a>
+                    )}
+                  </>
                 )}
               </div>
               <div>

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -159,15 +159,22 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
           {s.passes_rigor_gate === false && (
             <span className="tag tag-muted">rigor gate not passed</span>
           )}
-          {s.paper_arxiv_id && (
-            <a
-              href={`https://arxiv.org/abs/${s.paper_arxiv_id}`}
-              target="_blank" rel="noreferrer"
-              className="tag tag-muted"
-              style={{ fontFamily: 'var(--mono, monospace)', fontSize: '0.75rem' }}
-            >
-              arxiv:{s.paper_arxiv_id} ↗
-            </a>
+          {(s.papers || []).length > 1 ? (
+            <span className="tag tag-accent inline-flex items-center gap-1">
+              <span className="i-lucide-layers w-3.5 h-3.5" />
+              {s.papers.length} fused papers
+            </span>
+          ) : (
+            s.paper_arxiv_id && (
+              <a
+                href={`https://arxiv.org/abs/${s.paper_arxiv_id}`}
+                target="_blank" rel="noreferrer"
+                className="tag tag-muted"
+                style={{ fontFamily: 'var(--mono, monospace)', fontSize: '0.75rem' }}
+              >
+                arxiv:{s.paper_arxiv_id} ↗
+              </a>
+            )
           )}
         </div>
       </div>
@@ -205,7 +212,7 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
         </button>
       </div>
 
-      {/* Methodology + source paper */}
+      {/* Methodology + source paper(s) */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6 fade-up fade-up-3">
         <div className="card p-5">
           <div className="label mb-3">Methodology</div>
@@ -232,26 +239,71 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
           </div>
         </div>
 
-        <div className="card p-5">
-          <div className="label mb-3">Source paper</div>
-          <p className="body leading-snug" style={{ fontStyle: 'italic' }}>"{s.paper_title}"</p>
-          <p className="caption mt-2 leading-relaxed">
-            {s.paper_authors?.slice(0, 4).join(', ')}{s.paper_authors?.length > 4 ? ' et al.' : ''}
-            {s.paper_year ? ` (${s.paper_year})` : ''}
-            {s.paper_venue && <> · {s.paper_venue}</>}
-          </p>
-          {s.paper_doi && (
-            <div className="caption mt-2">DOI: <span className="mono">{s.paper_doi}</span></div>
-          )}
-          {s.paper_citation_count != null && (
-            <div className="caption">Cited by {s.paper_citation_count} other works</div>
-          )}
-          {s.methodology_hash && (
-            <div className="caption mt-3 mono text-[var(--text-4)]">
-              hash: {s.methodology_hash.slice(0, 24)}…
+        {/* Multi-paper (fusion/debate) vs. single-paper (curated) layout */}
+        {(s.papers || []).length > 1 ? (
+          <div className="card p-5">
+            <div className="label mb-1">Fused from {s.papers.length} papers</div>
+            <p className="caption mb-3 text-[var(--text-3)]">
+              This strategy synthesises ideas from multiple research papers into
+              a single investment methodology.
+            </p>
+            <div className="flex flex-col gap-3">
+              {s.papers.map((p, idx) => (
+                <div
+                  key={idx}
+                  className="pb-3"
+                  style={idx < s.papers.length - 1 ? { borderBottom: '1px solid var(--border, rgba(255,255,255,0.08))' } : undefined}
+                >
+                  <p className="body leading-snug" style={{ fontStyle: 'italic', fontWeight: 600 }}>
+                    "{p.title || p.arxiv_id || '—'}"
+                  </p>
+                  {p.arxiv_id && (
+                    <a
+                      href={`https://arxiv.org/abs/${p.arxiv_id}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="tag tag-muted"
+                      style={{ fontFamily: 'var(--mono, monospace)', fontSize: '0.72rem', marginTop: 4, display: 'inline-block' }}
+                    >
+                      arxiv:{p.arxiv_id} ↗
+                    </a>
+                  )}
+                  {p.contribution && (
+                    <p className="caption mt-1 leading-relaxed" style={{ fontStyle: 'italic', color: 'var(--text-3)' }}>
+                      {p.contribution}
+                    </p>
+                  )}
+                </div>
+              ))}
             </div>
-          )}
-        </div>
+            {s.methodology_hash && (
+              <div className="caption mt-3 mono text-[var(--text-4)]">
+                hash: {s.methodology_hash.slice(0, 24)}…
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="card p-5">
+            <div className="label mb-3">Source paper</div>
+            <p className="body leading-snug" style={{ fontStyle: 'italic' }}>"{s.paper_title}"</p>
+            <p className="caption mt-2 leading-relaxed">
+              {s.paper_authors?.slice(0, 4).join(', ')}{s.paper_authors?.length > 4 ? ' et al.' : ''}
+              {s.paper_year ? ` (${s.paper_year})` : ''}
+              {s.paper_venue && <> · {s.paper_venue}</>}
+            </p>
+            {s.paper_doi && (
+              <div className="caption mt-2">DOI: <span className="mono">{s.paper_doi}</span></div>
+            )}
+            {s.paper_citation_count != null && (
+              <div className="caption">Cited by {s.paper_citation_count} other works</div>
+            )}
+            {s.methodology_hash && (
+              <div className="caption mt-3 mono text-[var(--text-4)]">
+                hash: {s.methodology_hash.slice(0, 24)}…
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Backtest metrics */}


### PR DESCRIPTION
## Summary

- **Strategy Passport page now shows all source papers** for fusion/debate strategies in a "Fused from N papers" section instead of only the first paper's title. Each entry shows the paper title (or bare arxiv_id as fallback), an arxiv link badge, and the per-paper contribution text if stored.
- **Library list rows** get a small "[N papers]" count badge next to the strategy name, and the row expansion panel renders the full multi-paper list.
- **Single-paper curated strategies are unchanged** — they continue to use the existing "Source paper" card layout exactly as before.

## Fix

The multi-paper provenance was already stored in `passport_paper_refs` and included in the API response as `papers: list[PaperRefResponse]`. The UI was only reading legacy scalar fields (`paper_title`, `paper_arxiv_id`) which are populated from `papers[0]` alone, making the fusion/debate paper wedge invisible.

**Backend** (`strategies_routes.py`):
- Added `_enrich_paper_titles_from_corpus()` — queries the `papers` corpus table (arxiv_id → title) for refs with blank stored titles. Non-fatal; falls back to the bare arxiv_id. No schema change.
- `_passport_to_strategy_response()` now accepts an optional `session` kwarg. The `GET /{strategy_id}` call site passes its session so title enrichment fires on single-strategy fetches.
- `first_title` is derived from the enriched `papers_list` so the legacy `paper_title` scalar is also correct.

**UI** (`StrategyPassport.jsx`):
- Header: single-paper → arxiv tag; multi-paper → "N fused papers" chip (accent colour, layers icon).
- Right-hand card: `papers.length > 1` → "Fused from N papers" card with per-paper rows (italic title, arxiv link badge, contribution sub-line if present); `papers.length ≤ 1` → existing "Source paper" layout unchanged.

**UI** (`Strategies.jsx`):
- Row title: appends `[N papers]` badge when `papers.length > 1`.
- Row expansion panel: multi-paper list instead of single "Source paper" block.

**What the new multi-paper section looks like** (prose screenshot):  
On the Strategy Passport page for a fusion strategy that fused e.g. three papers, the right-hand card reads "Fused from 3 papers" with a brief sub-heading noting the methodology synthesises ideas from multiple papers. Below that, three rows appear separated by dividers: each row shows the paper title in italic bold (e.g. "Momentum Everywhere", "Volatility-Managed Portfolios", "Cross-Sectional Momentum"), an `arxiv:2301.00001 ↗` link badge, and a short contribution note if the generation pipeline stored one. In the Library list, the strategy row title shows `Trend-Fused Alpha [3 papers]` with the badge in accent colour.

## Verify

```bash
# Backend: 10 hermetic tests (no Postgres, no .env)
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
  python -m pytest backend/tests/test_multipaper_passport.py -q
# expected: 10 passed, 0 failed

# Ruff
ruff format backend/archimedes/api/strategies_routes.py backend/tests/test_multipaper_passport.py
ruff check --select E9,F63,F7,F40,F82 backend/archimedes/api/strategies_routes.py backend/tests/test_multipaper_passport.py

# UI lint
export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
cd ui && npm ci --no-audit && npm run lint
# expected: exit 0
```

## Anti-goals

- No schema migrations — existing `passport_paper_refs` and `papers` tables are read-only here.
- Paper selection or storage logic is not touched.
- Single-paper curated strategies render exactly as before (regression tested).
- No new npm or pip dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M