### PR TITLE
[auth] Fix passkey SIWE: stop double ERC-6492-wrapping the signature

### DIFF
--- a/backend/archimedes/api/_erc6492.py
+++ b/backend/archimedes/api/_erc6492.py
@@ -90,9 +90,13 @@ async def verify_smart_wallet_signature(wallet: str, message_text: str, signatur
         # unwrapped sig), or a malformed signature must never authenticate. An
         # exception here is a DIFFERENT failure class than a clean 0x00 above.
         # Mirror the INVALID branch's correlation metadata (wallet + sig length)
-        # so the two log lines can be joined; compute the length defensively from
-        # the raw string since hex-decoding the signature may be what raised.
-        sig_len = len(signature.removeprefix("0x")) // 2 if isinstance(signature, str) else -1
+        # so the two log lines can be joined. Compute byte length via fromhex so
+        # the value is accurate; fall back to -1 when the string is non-hex or
+        # not a string at all (hex-decode failure may itself be what raised).
+        try:
+            sig_len = len(bytes.fromhex(signature.removeprefix("0x"))) if isinstance(signature, str) else -1
+        except (ValueError, AttributeError):
+            sig_len = -1
         logger.warning(
             "smart-wallet SIWE ERRORED (fail-closed, %s) wallet=%s sig_len=%d: %s",
             type(exc).__name__,

--- a/backend/archimedes/api/_erc6492.py
+++ b/backend/archimedes/api/_erc6492.py
@@ -89,5 +89,15 @@ async def verify_smart_wallet_signature(wallet: str, message_text: str, signatur
         # Fail closed: an unreachable RPC, a revert (e.g. undeployed account +
         # unwrapped sig), or a malformed signature must never authenticate. An
         # exception here is a DIFFERENT failure class than a clean 0x00 above.
-        logger.warning("smart-wallet SIWE ERRORED (fail-closed, %s): %s", type(exc).__name__, str(exc)[:300])
+        # Mirror the INVALID branch's correlation metadata (wallet + sig length)
+        # so the two log lines can be joined; compute the length defensively from
+        # the raw string since hex-decoding the signature may be what raised.
+        sig_len = len(signature.removeprefix("0x")) // 2 if isinstance(signature, str) else -1
+        logger.warning(
+            "smart-wallet SIWE ERRORED (fail-closed, %s) wallet=%s sig_len=%d: %s",
+            type(exc).__name__,
+            wallet[:12],
+            sig_len,
+            str(exc)[:300],
+        )
         return False

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -462,43 +462,20 @@ export async function getWalletClient() {
 // Sign a plain text message with WHATEVER wallet is connected (#869).
 // EOA path: viem walletClient.signMessage (secp256k1 personal_sign).
 // Circle passkey path: the smart account's WebAuthn owner signs the account's
-// replay-safe hash (ERC-1271 convention); if the account contract is not yet
-// deployed (no user-op sent yet), the signature is wrapped per ERC-6492 with
-// the account's factory args so the backend's deployless verifier can
-// deploy-and-check it counterfactually.
+// replay-safe hash (ERC-1271 convention). Circle's `toCircleSmartAccount` is a
+// viem `toSmartAccount`, whose `signMessage` ALREADY returns the correct wire
+// format for the backend's deployless verifier: a bare ERC-1271 signature once
+// the account is deployed, and an ERC-6492-wrapped signature (with the account's
+// own factory args) while it is still counterfactual. We must NOT wrap it a
+// second time — an earlier version did (#870/#871) and that double ERC-6492
+// wrap is what made every passkey SIWE fail with "validator ran, rejected":
+// the outer wrapper deployed the wrong CREATE2 address so `isValidSignature`
+// landed on an empty account. Verified against a captured live signature: the
+// singly-wrapped output of `signMessage` verifies true via viem's own
+// `verifyMessage` (== our backend); re-wrapping it verifies false.
 export async function signSiweMessage(message) {
   if (_providerId === CIRCLE_PROVIDER_ID && _smartAccount) {
-    const signature = await _smartAccount.signMessage({ message })
-    // A Circle passkey account is *counterfactual*: it has on-chain code only
-    // after its first user-op deploys it — receiving USDC does NOT deploy it.
-    // Until then a bare ERC-1271 signature has no contract to validate against,
-    // so it must be ERC-6492-wrapped with the account's factory args (the
-    // backend's universal validator deploy-and-checks it). Circle's account
-    // object has no isDeployed(), so detect via on-chain bytecode.
-    const wrapWithFactory = async () => {
-      if (typeof _smartAccount.getFactoryArgs !== 'function') return signature
-      const { factory, factoryData } = await _smartAccount.getFactoryArgs()
-      if (!factory || !factoryData) return signature
-      const { serializeErc6492Signature } = await import('viem')
-      return serializeErc6492Signature({ address: factory, data: factoryData, signature })
-    }
-    try {
-      const code = await publicClient.getCode({ address: _smartAccount.address })
-      const isDeployed = !!code && code !== '0x'
-      return isDeployed ? signature : await wrapWithFactory()
-    } catch (checkErr) {
-      // Deploy-check failed (RPC hiccup): a brand-new user is the case we most
-      // need to get right, and they're undeployed — wrap defensively. ERC-6492's
-      // magic suffix is safely handled by the validator for a deployed account
-      // too, so wrapping is the safer default when deployment is unknown.
-      console.warn('ERC-6492 deploy-check failed, wrapping defensively:', checkErr.message)
-      try {
-        return await wrapWithFactory()
-      } catch (wrapErr) {
-        console.warn('ERC-6492 defensive wrap failed, sending bare 1271 sig:', wrapErr.message)
-        return signature
-      }
-    }
+    return _smartAccount.signMessage({ message })
   }
   const walletClient = await getWalletClient()
   return walletClient.signMessage({ message })


### PR DESCRIPTION
## Summary

Fixes the **#1 dogfooding blocker**: every passkey (Circle Modular Wallet) SIWE sign-in failed with `401 Invalid signature (EOA recovery and smart-wallet verification both failed)`. Because Generate re-runs SIWE on a 401, this also made **Generate dead for every passkey user** — the promoted onboarding path was fully broken. #870 and #871 fixed the wrong layer.

## Root cause — double ERC-6492 wrapping

Circle's `toCircleSmartAccount` is a viem `toSmartAccount`. Its `signMessage` **already** returns the correct wire format for deployless verification:
- a **bare ERC-1271** signature once the account is deployed, and
- an **ERC-6492-wrapped** signature (with the account's own `getFactoryArgs`) while the account is still counterfactual/undeployed.

`signSiweMessage` in `ui/src/config.js` then wrapped it a **second** time. The outer wrapper's `factoryData` deploys a *different* CREATE2 address than the claimed account, so the universal validator's `isValidSignature` call landed on the still-empty claimed account and returned 0 → "validator ran, rejected."

## Proof (deterministic, against a real captured signature)

Captured a live failing `/api/auth/verify` payload from prod and analyzed it with viem 2.53.1 (the exact pinned frontend version):

| Input | `viem verifyMessage` (== our backend) |
| --- | --- |
| Full signature, as sent (double-wrapped) | **false** ❌ |
| Inner signature, after stripping ONE 6492 layer | **true** ✅ |

Recursive unwrap confirmed the blob was 6492-wrapped **twice**. The inner (single-wrapped) signature is exactly what `_smartAccount.signMessage` returns — and it verifies. So returning Circle's signature **as-is** is the fix.

Also separately confirmed our backend `_erc6492` verifier is **byte-for-byte identical** to viem's own `verifyHash` (same deploy-data encoding, no `to`, `hexToBool`) — the backend was correct all along and is **unchanged** here.

## Changes

- **`ui/src/config.js`** — `signSiweMessage` returns `_smartAccount.signMessage({ message })` directly for the Circle path; removes the manual `getFactoryArgs` / `getCode` / `serializeErc6492Signature` re-wrap added in #870/#871. EOA path unchanged.
- **`backend/archimedes/api/_erc6492.py`** — folds in the open #871 Copilot follow-up: the `SIWE ERRORED` log branch now carries the same `wallet` + `sig_len` correlation metadata as the `INVALID` branch, computed defensively (survives even when hex-decoding the sig is what raised).

## Verify

- `pytest backend/tests/test_auth_siwe.py backend/tests/test_auth_siwe_smart_wallet.py` → **42 passed** (local, hermetic).
- `eslint src/config.js` → clean. `ruff` → clean.
- **HUMAN STEP (required before merge):** @dbrowneup connect a passkey wallet → confirm SIWE succeeds at connect (no 401) → Generate should run **without** a second Touch ID and no "Invalid signature" error. I cannot exercise the WebAuthn path myself — this needs a real authenticator.

## Known follow-ups (out of scope here)

- **Two Touch IDs at connect** (Circle login ceremony + SIWE sign) is a separate UX refinement; this PR does not change ceremony count. It makes the SIWE ceremony actually *succeed*, which removes the extra Touch ID at **Generate**.
- Connect-time SIWE failure is still swallowed as a non-fatal `console.warn` in `WalletConnect.jsx` — worth surfacing louder in a follow-up now that it should normally succeed.

## Anti-goals

- No backend verifier logic changed (it was correct).
- No change to the EOA/programmatic-agent SIWE path.
