### PR TITLE
[strategy] T1.1 Phase-3 cutover: the debate society IS the pipeline + Considered-Alternatives fan-out !minor

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -1,44 +1,31 @@
-"""T1.1 — Multi-agent debate society (Phase 1 skeleton: additive + flag-gated).
+"""T1.1 — Multi-agent debate society (Phase 3: debate is the sole pipeline).
 
-Design of record: ``docs/specs/multi-agent-debate-spec.md`` (v2, staged
-replacement). This is the strictly **additive** Phase-1 increment — a
-``pipeline_name="debate"`` generation runner gated behind
-``ARCHIMEDES_DEBATE_ENABLED`` (default OFF). While the flag is OFF the legacy
-live path is byte-identical (the dispatch never reaches this module). The
-society:
+Design of record: ``docs/specs/multi-agent-debate-spec.md`` (v2).
+
+The society is unconditional as of Phase-3 (T1.1 flag audit, issue #834).
+The ``ARCHIMEDES_DEBATE_ENABLED`` flag is retired; ``_debate_can_run`` only
+checks corpus size. The pipeline:
 
   1. **Proposer pool** — fans ``StrategyFusion(model=...).propose`` across
      ``select_candidates(regime_bias=R)`` evidence sets (the A3 model seam
-     threads the user's Generate-page model pick; the steered selection is the
-     cheap diversity axis). Drops non-actionable
+     threads the user's Generate-page model pick). Drops non-actionable
      (``FusionProposal.is_actionable``) and non-conformant (``_dsl_conformance_ok``,
      fix A5) specs. ``pool_size = len(POOL)``.
-  2. **Adversarial round** — a thin, best-effort bull/bear transcript (Phase 1).
-     It surfaces the adversarial topology on the SSE stream but never gates;
-     the deterministic critics do the real culling (the budget trick). The full
-     rebuttal + LLM risk-debate is Phase 2.
-  3. **C-rigor** — backtests EVERY survivor for real via ``evaluate_fusion_spec``
+  2. **Adversarial round** — a thin, best-effort bull/bear transcript.
+     Surfaces adversarial topology on the SSE stream but never gates;
+     deterministic critics do the real culling (the budget trick).
+  3. **C-rigor** — backtests EVERY survivor via ``evaluate_fusion_spec``
      (deterministic Python, 0 tokens), each wrapped in try/except (fix A5
      backstop), with ``num_trials=_society_num_trials(library_size, pool_size)``
-     (library + N, #770/#820 — not ``pool_size`` alone) so the DSR
-     multiple-testing correction counts both the selection-from-pool search AND
-     the library the winner joins, the same selection set the live agent path
-     deflates for.
+     (#770/#820) so the DSR multiple-testing correction counts both the
+     selection-from-pool search AND the library the winner joins.
   4. **C-null** — a survivor must beat the passive null (buy-and-hold) net of
      cost by ``MIN_COST_BENEFIT``. If none clears it → first-class ABSTAIN.
-  5. **Synthesizer** — deterministic rank of the survivors (Phase 1 collapses the
-     synthesizer to 0 LLM calls per spec §8) → top-N leaderboard; the user picks.
+  5. **Synthesizer** — deterministic rank of the survivors → top-N leaderboard.
 
-``_run_debate_candidate`` returns the **leader** ``_CandidateResult`` (carrier
-contract preserving); the full leaderboard is built by ``build_leaderboard``
-(directly unit-tested) and the Considered-Alternatives fan-out is Phase 2.
-
-⚠️  PHASE-1 BLOCKER: ``ARCHIMEDES_DEBATE_ENABLED`` must stay OFF on the live path
-until this module's rigor badge has been validated end-to-end there (A1's
-denominator now matches the live path's — library + N via
-``_society_num_trials``, #770/#820 — but the flag still needs a real on-flag
-run before it's trusted). The flag-OFF additive skeleton in this module is
-safe to merge.
+``_run_debate_candidate`` returns the **leader** ``_CandidateResult`` (for
+back-compat callers); ``_run_debate_leaderboard`` returns the FULL ranked board
+(the Phase-3 fan-out path used by ``run_generation``).
 """
 
 from __future__ import annotations
@@ -61,9 +48,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from archimedes.api.generate_schemas import GenerateBrief
 
 logger = logging.getLogger(__name__)
-
-# ── Env knobs ───────────────────────────────────────────────────────────────
-_TRUE = {"1", "true", "yes", "on"}
 
 # Steer grid = regime × mechanism. Each (regime_bias, mechanism) pair gives the
 # proposer a distinct evidence ranking (regime_bias → select_candidates) AND a
@@ -98,11 +82,6 @@ _PRICE_OPERANDS = {"close", "open", "high", "low", "volume"}
 # backtest's own annualized edge (cagr); the explicit buy-and-hold differential
 # is Phase 2.
 MIN_COST_BENEFIT = 0.0005  # 5 bps
-
-
-def debate_enabled() -> bool:
-    """True iff ``ARCHIMEDES_DEBATE_ENABLED`` is set truthy (default OFF)."""
-    return os.getenv("ARCHIMEDES_DEBATE_ENABLED", "").strip().lower() in _TRUE
 
 
 def _pool_max() -> int:
@@ -141,9 +120,9 @@ def _library_size() -> int:
 class DebateUnavailable(FusionUnavailable):
     """The society produced no actionable + conformant + backtestable candidate.
 
-    Subclasses ``FusionUnavailable`` so the existing ``run_generation`` fallback
-    (``except FusionUnavailable``) relabels honestly to the agent path — no
-    dispatch except-clause change is needed.
+    Subclasses ``FusionUnavailable`` so ``run_generation``'s
+    ``except FusionUnavailable`` clause catches it and emits
+    ``GENERATION_UNAVAILABLE`` — no silent fallback (T1.1 Phase-3).
     """
 
 
@@ -192,28 +171,26 @@ def _dsl_conformance_ok(spec: dict[str, Any] | None) -> bool:
     return all(stem in _CONFORMANT_INDICATORS for stem in _indicator_alias_stems(spec))
 
 
-# ── Viability precheck (mirrors generation_pipeline._fusion_can_run) ──────────
+# ── Viability precheck ────────────────────────────────────────────────────────
 
 
 def _debate_can_run(brief: GenerateBrief) -> bool:
-    """No-LLM viability precheck: flag on AND ≥ MIN_PAPERS for the steer.
+    """No-LLM corpus viability precheck: ≥ MIN_PAPERS available for the steer.
 
-    Never raises — any failure degrades to ``False`` so the caller falls back to
-    the agent path. (Mirrors ``generation_pipeline._fusion_can_run``.)
+    Phase-3: the ``ARCHIMEDES_DEBATE_ENABLED`` flag is retired — the society is
+    unconditional. This precheck only guards against an empty/insufficient corpus
+    (which would cause every proposer call to return ``insufficient_corpus``).
+    Never raises — any failure degrades to ``False`` so ``run_generation`` emits
+    ``GENERATION_UNAVAILABLE`` honestly rather than crashing.
     """
-    if not debate_enabled():
-        return False
     try:
         from archimedes.agents.strategy_fusion import (
             MIN_PAPERS,
             FusionBrief,
-            fusion_enabled,
             load_corpus,
             select_candidates,
         )
 
-        if not fusion_enabled():
-            return False
         fb = FusionBrief(
             asset_classes=list(brief.asset_classes or []),
             risk_appetite=brief.risk_appetite,
@@ -446,8 +423,7 @@ def _score(ev: Any) -> tuple[int, float, float]:
 def _rigor_verdict_dict(ev: Any) -> dict[str, Any]:
     """Build the passport ``rigor_verdict`` from a FusionEvalResult.
 
-    Mirrors ``generation_pipeline._run_fusion_candidate``'s verdict shape so the
-    passport renders identically for debate and fusion candidates.
+    Canonical rigor_verdict shape consumed by the passport renderer.
     """
     r = ev.rigor
     bt = ev.backtest
@@ -655,8 +631,8 @@ async def _run_debate_leaderboard(
     Phase-3 fan-out: entry [0] is the society's leader (its deterministic rank
     is authoritative — the orchestrator must NOT re-rank); the tail entries are
     the Considered Alternatives. Raises ``DebateUnavailable``
-    (a ``FusionUnavailable`` subclass) when no candidate survives, so the existing
-    run_generation fallback relabels to the agent path.
+    (a ``FusionUnavailable`` subclass) when no candidate survives, so
+    ``run_generation`` emits ``GENERATION_UNAVAILABLE`` (T1.1 Phase-3).
 
     ``selection_pool_size`` is accepted for parity with the #770 runner contract
     (the dispatch threads it to every runner), but the society ignores the passed

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -640,7 +640,7 @@ def build_leaderboard(
 # ── Runner (the dispatch entry point) ─────────────────────────────────────────
 
 
-async def _run_debate_candidate(
+async def _run_debate_leaderboard(
     *,
     candidate_id: str,
     brief: GenerateBrief,
@@ -649,12 +649,12 @@ async def _run_debate_candidate(
     agent: Any = None,  # noqa: ARG001 — signature parity with the other runners
     model: str | None = None,
     selection_pool_size: int = 1,  # noqa: ARG001 — parity with the #770 runner contract; the debate computes its OWN pool_size (the real selection count) internally
-) -> _CandidateResult:
-    """Run the debate society once and return the leader ``_CandidateResult``.
+) -> list[_CandidateResult]:
+    """Run the debate society once and return the FULL ranked leaderboard.
 
-    Carrier-contract preserving: returns a single ``_CandidateResult`` (the
-    leader). The full leaderboard is built by ``build_leaderboard`` (testable);
-    the Considered-Alternatives fan-out is Phase 2. Raises ``DebateUnavailable``
+    Phase-3 fan-out: entry [0] is the society's leader (its deterministic rank
+    is authoritative — the orchestrator must NOT re-rank); the tail entries are
+    the Considered Alternatives. Raises ``DebateUnavailable``
     (a ``FusionUnavailable`` subclass) when no candidate survives, so the existing
     run_generation fallback relabels to the agent path.
 
@@ -750,4 +750,10 @@ async def _run_debate_candidate(
             else f"leader={leader.strategy_name} dsr={leader.rigor_verdict.get('dsr')} of {len(leaderboard)} entries"
         ),
     )
-    return leader
+    return leaderboard
+
+
+async def _run_debate_candidate(**kwargs: Any) -> _CandidateResult:
+    """Back-compat wrapper: the leader only (leaderboard[0])."""
+    board = await _run_debate_leaderboard(**kwargs)
+    return board[0]

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1,30 +1,38 @@
-"""Streaming strategy generation orchestrator.
+"""Streaming strategy generation orchestrator — T1.1 Phase-3 (debate-only).
 
-Wraps ``portfolio_agent.PortfolioAgent.propose_portfolio_with_tools`` with an
-event-emitting pipeline that powers the Generate page's SSE stream
-(see ``docs/specs/generation-streaming-spec.md``).
+The **debate society** is the sole generation pipeline. The legacy
+fusion/architect/agent decision tree is retired as of Phase-3 (issue #834).
 
-The pipeline lifecycle:
+Pipeline lifecycle (SSE stream):
 
   job_queued
     → brief_validated
-    → candidates_selected (which existing strategies the agent will reason over)
-    → for each candidate: agent_iteration / tool_called / tool_result …
-    → candidate_drafted
-    → candidate_evaluated (rigor verdict — synthesized from agent stress-tests)
+    → pipeline_selected (always "debate" on the live path)
+    → candidates_selected
+    → for each leaderboard entry:
+        candidate_drafted → candidate_evaluated
     → best_selected
     → trace_hashed → persisted → done
 
-Multi-candidate mechanic: ``n_candidates`` ≥ 1 (default 1). Each candidate is
-a full agent run with a different seed prompt suffix. The best by rigor is
-surfaced; the rest persist in the job's event log so the frontend can show
-them under "considered N candidates".
+Dispatch rules:
+
+* **debate** — ``_llm_available()`` AND ``_debate_can_run(brief)`` → runs the
+  full ``_run_debate_leaderboard`` path in ``debate_engine``.
+* **fixture** — deterministic stub for hermetic tests (``GENERATION_PIPELINE_FIXTURE=1``
+  or ``TESTING`` env + no LLM). No LLM call, no network.
+* **error** (``GENERATION_UNAVAILABLE``) — prod environment with no reachable LLM
+  or an empty corpus. No silent fallback.
+
+K=1 persistence: only the leaderboard winner becomes a ``StrategyRecord``;
+alternates are recorded in ``strategy_memory.persist_proposal`` (verdict="rejected")
+and surfaced via the job's candidates payload.
+
+See ``docs/specs/generation-streaming-spec.md`` for the full SSE contract.
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import functools
 import hashlib
 import json
@@ -88,40 +96,6 @@ def _pick_pipeline(
     if mode_override and mode_override != "debate":
         logger.info("generation: ignoring legacy mode override %r (debate-only cutover)", mode_override)
     return "debate", "debate society is the generation pipeline (T1.1 Phase-3 cutover)"
-
-
-def _fusion_can_run(brief: GenerateBrief) -> bool:
-    """No-LLM viability precheck for the fusion path.
-
-    Returns True iff the fusion flag is on AND the deterministic candidate
-    selection yields ≥ ``MIN_PAPERS`` papers for this brief's steer — i.e. the
-    engine would not immediately return ``insufficient_corpus``. Used to keep
-    ``pipeline_selected`` honest: we only announce "fusion" if it can actually
-    produce a ≥2-paper synthesis. Never raises — any failure degrades to False
-    so the caller falls back to the agent path.
-    """
-    try:
-        from archimedes.agents.strategy_fusion import (
-            MIN_PAPERS,
-            FusionBrief,
-            fusion_enabled,
-            load_corpus,
-            select_candidates,
-        )
-
-        if not fusion_enabled():
-            return False
-        fusion_brief = FusionBrief(
-            asset_classes=list(brief.asset_classes or []),
-            risk_appetite=brief.risk_appetite,
-            strategic_direction=brief.intent or "",
-            max_papers=brief.max_papers,
-        )
-        candidates = select_candidates(fusion_brief, load_corpus())
-        return len(candidates) >= MIN_PAPERS
-    except Exception:
-        logger.debug("fusion viability precheck failed; treating as not runnable", exc_info=True)
-        return False
 
 
 # ── Brief validation (real LLM step on the live path) ─────────────────────
@@ -555,7 +529,7 @@ async def _run_fixture_candidate(
     brief: GenerateBrief,
     emit: _Emitter,
     regime: str = "neutral",
-    agent: Any = None,  # noqa: ARG001 — signature parity with _run_live_candidate; fixture path ignores it
+    agent: Any = None,  # noqa: ARG001 — signature parity; fixture path ignores it
     selection_pool_size: int = 1,  # noqa: ARG001 — signature parity; fixture path computes no DSR num_trials
 ) -> _CandidateResult:
     """Synthetic generation that exercises every event the live agent emits.
@@ -637,28 +611,6 @@ async def _run_fixture_candidate(
     )
 
 
-# ── Live agent path ───────────────────────────────────────────────────────
-
-
-# Regime-specific prompt suffixes that steer the agent's allocation (Issue #163)
-_REGIME_PROMPT_SUFFIX = {
-    "bull": (
-        "\n\nREGIME CONTEXT: You are constructing a BULL-tilted portfolio. "
-        "Favor momentum, trend-following, carry, and risk-on strategies. "
-        "Overweight assets with strong recent momentum and positive trend signals. "
-        "Allocate more to growth-oriented and higher-beta instruments. "
-        "Still respect the risk envelope, but tilt toward upside capture."
-    ),
-    "bear": (
-        "\n\nREGIME CONTEXT: You are constructing a BEAR-tilted / defensive portfolio. "
-        "Favor volatility-managed, minimum-variance, defensive, and mean-reversion strategies. "
-        "Overweight safe-haven assets (gold, treasuries, USDC/stablecoins). "
-        "Prioritize drawdown protection and tail-risk hedging over return maximization. "
-        "The goal is to survive and preserve capital in adverse market conditions."
-    ),
-}
-
-
 def _society_num_trials(library_size: int, selection_pool_size: int) -> int:
     """Effective DSR multiple-testing trial count on the agentic society path (#770).
 
@@ -670,387 +622,13 @@ def _society_num_trials(library_size: int, selection_pool_size: int) -> int:
     return max(1, library_size + selection_pool_size)
 
 
-async def _run_live_candidate(
-    *,
-    candidate_id: str,
-    brief: GenerateBrief,
-    emit: _Emitter,
-    regime: str = "neutral",
-    agent: Any = None,
-    selection_pool_size: int = 1,
-) -> _CandidateResult:
-    """Drive the real ``portfolio_agent`` with per-iteration event emission.
-
-    The agent's iteration loop is sync and runs in a thread. The thread uses
-    a sync emit shim that schedules the async ``Emitter.emit`` back onto the
-    main event loop — this keeps the agent unchanged while still streaming.
-
-    ``agent`` is an optional pre-built ``PortfolioAgent`` (e.g. bound to the
-    user's free-tier model pick). When ``None`` the shared process singleton is
-    used — the default, unchanged behavior.
-    """
-    from archimedes.agents.portfolio_agent import get_portfolio_agent
-    from archimedes.services.strategy_provider import default_provider
-    from archimedes.services.strategy_signal_evaluator import (
-        DEFAULT_SCAN_UNIVERSE,
-        _fetch_price_histories,
-        strategy_evaluator,
-    )
-
-    loop = asyncio.get_running_loop()
-
-    def _sync_emit(event: str, **payload: Any) -> None:
-        # Bridge from the agent's sync thread into the async event log.
-        fut = asyncio.run_coroutine_threadsafe(
-            emit.emit(event, candidate_id=candidate_id, **payload),
-            loop,
-        )
-        # event emission is best-effort
-        with contextlib.suppress(Exception):
-            fut.result(timeout=2.0)
-
-    price_histories = await asyncio.wait_for(
-        asyncio.to_thread(_fetch_price_histories, DEFAULT_SCAN_UNIVERSE, "1y"),
-        timeout=30.0,
-    )
-    market_ranking = strategy_evaluator.rank_market(price_histories, lookback_days=90, top_n=20)
-    strategies = default_provider().list_strategies()
-
-    # Map regime to agent regime string + confidence
-    agent_regime = {"bull": "expansion", "bear": "contraction"}.get(regime, "transition")
-    agent_confidence = 0.80 if regime in ("bull", "bear") else 0.65
-
-    agent = agent or get_portfolio_agent()
-    # Inject regime suffix into the agent's system prompt via the risk_appetite
-    # string (the agent reads it as context). The suffix is appended to the
-    # user-visible risk profile so the agent sees the regime steer.
-    regime_suffix = _REGIME_PROMPT_SUFFIX.get(regime, "")
-    if regime_suffix:
-        agent._regime_context = regime_suffix  # noqa: SLF001 — deliberate: consumed by _build_tool_user_prompt if available
-
-    portfolio = await asyncio.wait_for(
-        asyncio.to_thread(
-            agent.propose_portfolio_with_tools,
-            agent_regime,  # regime: expansion/contraction/transition
-            agent_confidence,  # regime_confidence
-            brief.risk_appetite,
-            0.30,  # usdc_floor (moderate default)
-            0.70,  # synth_budget
-            market_ranking,
-            strategies,
-            set(DEFAULT_SCAN_UNIVERSE),
-            price_histories,
-        ),
-        timeout=120.0,
-    )
-
-    if portfolio is None:
-        raise RuntimeError("agent returned no portfolio")
-
-    weights = {pick.ticker: pick.weight for pick in (portfolio.picks or [])}
-    # Collect paper anchors — try matching by ID first, then by fuzzy name match
-    referenced = {pick.paper_anchor for pick in (portfolio.picks or []) if pick.paper_anchor}
-    source_papers = []
-    referenced_strategies: list[Any] = []  # matched curated strategies (for look-ahead audit)
-    strat_by_id = {s.id: s for s in strategies}
-    strat_by_name = {s.paper_title.lower(): s for s in strategies if s.paper_title}
-    for anchor in referenced:
-        s = strat_by_id.get(anchor)
-        if not s:
-            # Fuzzy match: the LLM often returns a short name instead of the ID
-            s = strat_by_name.get(anchor.lower())
-        if not s:
-            # Try substring match
-            s = next((st for st in strategies if anchor.lower() in st.paper_title.lower()), None)
-        if s:
-            referenced_strategies.append(s)
-        if s and getattr(s, "paper_arxiv_id", None):
-            source_papers.append({"arxiv_id": s.paper_arxiv_id, "title": s.paper_title})
-    # Defensive fallback: if agent returned no anchors, include strategies
-    # from the curated library as potential sources (honest: they were
-    # available to the agent even if it didn't cite them explicitly).
-    # Include any strategy with a paper_title OR paper_arxiv_id — curated
-    # strategies reference seminal papers (Faber 2007, Moreira-Muir 2017)
-    # that predate arxiv, so paper_arxiv_id is often empty while paper_title
-    # is always populated.
-    if not source_papers and strategies:
-        for s in strategies[:5]:  # cap at 5 to avoid noise
-            title = getattr(s, "paper_title", "") or ""
-            arxiv_id = getattr(s, "paper_arxiv_id", "") or ""
-            if title or arxiv_id:
-                source_papers.append({"arxiv_id": arxiv_id, "title": title})
-        if not source_papers:
-            logger.warning(
-                "agent returned no paper anchors AND fallback couldn't find "
-                "library strategies with paper refs — source_papers will be empty"
-            )
-
-    # Real rigor verdict via Önder's compute_dsr + compute_oos_sharpe on the
-    # buy-and-hold return series of the agent's allocation. PBO is patched
-    # later (after all candidates are in) since it's a library-level metric.
-    # num_trials = library size: the winner was selected from this universe, so
-    # the DSR must be deflated for that multiple-testing count (spec § 1.3), not
-    # the previous hardcoded 1 (which left the DSR undeflated). The look-ahead
-    # primitive is computed from referenced curated source and gates `passing`.
-    return_series = _portfolio_return_series(weights, price_histories)
-    lookahead_passed = _lookahead_for_candidate(referenced_strategies)
-    # num_trials = selection-from-N candidates + library context (#770). The agentic
-    # society generates `selection_pool_size` candidates, backtests all, and keeps the
-    # best — selection-from-N is itself a multiple-testing search, so the DSR must be
-    # deflated for BOTH that pool AND the library the winner joins, not the library
-    # alone (which understated deflation and inflated the survivor's DSR). Additive
-    # N + library_size per the selection-bias-corrections spec § 1.3 (Bailey & López de
-    # Prado 2014); the correction can only make the gate stricter. (Önder's call — A.)
-    num_trials = _society_num_trials(len(strategies), selection_pool_size)
-    verdict = _rigor_verdict_for(return_series, num_trials=num_trials, lookahead_passed=lookahead_passed)
-    # Derive meaningful name + thesis from the brief and agent output (#299)
-    top_picks = sorted(weights.items(), key=lambda x: -x[1])[:3]
-    pick_summary = " / ".join(t for t, _ in top_picks)
-    regime_label = {"bull": "🟢 Bull", "bear": "🔴 Bear"}.get(regime, "")
-    regime_prefix = f"{regime_label} " if regime_label else ""
-    strategy_name = f"{regime_prefix}{brief.risk_appetite.title()} Blend — {brief.intent[:50].strip()}"
-    agent_reasoning = getattr(portfolio, "reasoning_text", "") or ""
-    thesis = (
-        agent_reasoning
-        if len(agent_reasoning) > 20
-        else (
-            f"For brief '{brief.intent[:100]}': allocates {pick_summary} "
-            f"across {len(weights)} assets with {brief.risk_appetite} risk appetite."
-        )
-    )
-
-    return _CandidateResult(
-        candidate_id=candidate_id,
-        strategy_name=strategy_name,
-        thesis=thesis,
-        asset_universe=list(weights.keys()),
-        source_papers=source_papers,
-        weights=weights,
-        reasoning=getattr(portfolio, "reasoning_text", "") or "",
-        rigor_verdict=verdict,
-        passes_rigor=verdict.get("passing", False),
-        regime=regime,
-        return_series=return_series,
-        dsr_num_trials=num_trials,
-    )
-
-
-# ── Fusion path (multi-paper synthesis folded into the live stream) ───────
-#
-# Stack A previously computed a "fusion" LABEL via _pick_pipeline() and emitted
-# a cosmetic pipeline_selected event, then ALWAYS dispatched to the single-agent
-# portfolio path — the choice was thrown away. This runner makes the choice
-# actually drive dispatch: it REUSES the existing, unit-tested fusion engine
-# (StrategyFusion.propose → evaluate_fusion_spec, the same path Stack B's
-# _run_fusion_job wires) and emits the SAME streaming SSE events the agent path
-# emits, so the UI surfaces fusion transparently with real DSR/PBO/OOS.
-
-
 class FusionUnavailable(Exception):
-    """Fusion was selected but couldn't actually run (disabled / <2 papers /
-    LLM declined). The caller falls back to the agent path and relabels the
-    pipeline honestly rather than silently mislabeling an agent run as fusion."""
+    """The debate society could not produce a conformant candidate for this brief.
 
-
-async def _run_fusion_candidate(
-    *,
-    candidate_id: str,
-    brief: GenerateBrief,
-    emit: _Emitter,
-    regime: str = "neutral",
-    agent: Any = None,  # noqa: ARG001 — signature parity with _run_live_candidate; fusion path builds its own client
-    selection_pool_size: int = 1,
-) -> _CandidateResult:
-    """Drive the existing fusion engine with per-step streaming event emission.
-
-    Builds a ``FusionBrief`` from the incoming ``GenerateBrief``, calls the
-    EXISTING engine (``StrategyFusion.propose()`` → ``evaluate_fusion_spec()`` —
-    reuse, no duplication), and returns a ``_CandidateResult`` carrying the real
-    rigor verdict (DSR/PBO/OOS/look-ahead) computed by the DSL backtest.
-
-    Raises ``FusionUnavailable`` when the engine can't produce an actionable,
-    ≥2-paper fusion (disabled, insufficient corpus, unparseable, or fewer than
-    ``MIN_PAPERS`` fused) so the caller can fall back to the agent path and
-    relabel honestly — fusion never silently degrades into a single-paper or
-    mislabeled result.
+    Raised by ``debate_engine.DebateUnavailable`` (a subclass) when no proposal
+    survived the critics. ``run_generation`` catches it and emits
+    ``GENERATION_UNAVAILABLE`` — no silent fallback (T1.1 Phase-3).
     """
-    from archimedes.agents.strategy_fusion import (
-        MIN_PAPERS,
-        FusionBrief,
-        default_fusion,
-    )
-
-    # Surface the same "agent is thinking" cadence the agent path emits so the
-    # SSE stream renders progress rather than dumping the result on connect.
-    await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=1, max_iterations=3)
-    await emit.emit(
-        "tool_called",
-        candidate_id=candidate_id,
-        tool_name="select_candidates",
-        args_summary=f"asset_classes={brief.asset_classes or '(any)'}, regime={regime}",
-    )
-
-    # Map the GenerateBrief → FusionBrief (the engine's steer). asset_classes
-    # carries the user's universe steer; strategic_direction carries the intent.
-    fusion_brief = FusionBrief(
-        asset_classes=list(brief.asset_classes or []),
-        risk_appetite=brief.risk_appetite,
-        strategic_direction=brief.intent or "",
-        max_papers=brief.max_papers,
-    )
-
-    fusion = default_fusion()
-    proposal = await asyncio.wait_for(
-        asyncio.to_thread(fusion.propose, fusion_brief),
-        timeout=120.0,
-    )
-
-    await emit.emit(
-        "tool_result",
-        candidate_id=candidate_id,
-        tool_name="select_candidates",
-        result_summary=(f"fusion status={proposal.status}, papers={len(proposal.source_arxiv_ids)}"),
-    )
-
-    if not proposal.is_actionable:
-        # status in {disabled, insufficient_corpus, unparseable} OR <2 papers.
-        # Don't fabricate a fusion — bubble up so the caller falls back honestly.
-        raise FusionUnavailable(
-            f"fusion not actionable (status={proposal.status}, "
-            f"papers={len(proposal.source_arxiv_ids)}): {proposal.thesis[:160]}"
-        )
-
-    # ── Run the fusion evaluator pipeline (validate → backtest → rigor gate) ──
-    # Same call Stack B's _run_fusion_job makes. Produces the real DSR/PBO/OOS
-    # verdict on a DSL-interpreted backtest. Degrade gracefully (text-only
-    # fusion) if no machine-readable strategy_spec was emitted.
-    rigor_verdict: dict[str, Any]
-    has_real_rigor = False
-    asset_universe: list[str] = []
-    # Real DSL-backtest daily returns, captured so run_generation can persist them →
-    # live_rigor_gate reads pass/fail (not "pending") and the strategy is deployable
-    # (#788/#818). Fusion candidates skip the static buy-and-hold backtester (weights={}),
-    # so this is their only returns-persistence path.
-    real_return_series: list[float] = []
-    if proposal.strategy_spec is not None:
-        await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=3)
-        await emit.emit(
-            "tool_called",
-            candidate_id=candidate_id,
-            tool_name="evaluate_fusion_spec",
-            args_summary="backtest + DSR/PBO/OOS rigor gate",
-        )
-        from archimedes.services.fusion_evaluator import evaluate_fusion_spec
-        from archimedes.services.fusion_market_data import real_data_enabled
-        from archimedes.services.strategy_provider import default_provider
-
-        # #820: this candidate is one of `selection_pool_size` society candidates
-        # and its winner joins the library, same as the live agent path — so it
-        # needs the same num_trials, not evaluate_fusion_spec's own library-size-
-        # only default (which under-deflates relative to _run_live_candidate).
-        library_size = len(default_provider().list_strategies())
-        num_trials = _society_num_trials(library_size, selection_pool_size)
-
-        # Real data (the deployability unlock, #788/#818): a cold yfinance fetch
-        # for the spec's universe plus the per-asset variant grid can take a few
-        # minutes — 300s bounds it; the panel cache makes warm runs fast again.
-        eval_result = await asyncio.wait_for(
-            asyncio.to_thread(
-                evaluate_fusion_spec,
-                proposal.strategy_spec,
-                num_trials=num_trials,
-                use_real_data=real_data_enabled(),
-            ),
-            timeout=300.0,
-        )
-        asset_universe = list(proposal.strategy_spec.get("asset_universe", []) or [])
-        if eval_result.success and eval_result.rigor is not None:
-            r = eval_result.rigor
-            bt = eval_result.backtest
-            rigor_verdict = {
-                "dsr": r.dsr,
-                "dsr_p_value": r.dsr_p_value,
-                "pbo": r.pbo_score,
-                "oos_sharpe": r.oos_sharpe,
-                "in_sample_sharpe": r.in_sample_sharpe,
-                "lookahead_audit_passed": bool(r.look_ahead_clean),
-                "look_ahead_label": r.look_ahead_label,
-                "num_trials": int(r.num_trials),
-                "passing": bool(r.passing),
-                "data_source": r.data_source,
-                "admissible": bool(r.admissible),
-                # Backtest headline metrics — surfaced alongside so the passport
-                # renders without denormalizing from a separate field (parity
-                # with Stack B's rigor_verdict_dict).
-                "sharpe_ratio": bt.sharpe_ratio,
-                "sortino_ratio": bt.sortino_ratio,
-                "max_drawdown": bt.max_drawdown,
-                "cagr": bt.cagr,
-                "calmar_ratio": bt.calmar_ratio,
-                "win_rate": bt.win_rate,
-                "total_trades": bt.total_trades,
-            }
-            has_real_rigor = True
-            # Daily returns from the real DSL backtest's equity curve (for live-gate persistence).
-            _ec = list(getattr(bt, "equity_curve", None) or [])
-            real_return_series = [(_ec[i] - _ec[i - 1]) / _ec[i - 1] for i in range(1, len(_ec)) if _ec[i - 1] > 0]
-            await emit.emit(
-                "tool_result",
-                candidate_id=candidate_id,
-                tool_name="evaluate_fusion_spec",
-                result_summary=(
-                    f"DSR={r.dsr} p={r.dsr_p_value} PBO={r.pbo_score} OOS={r.oos_sharpe} passing={r.passing}"
-                ),
-            )
-        else:
-            rigor_verdict = {
-                "dsr": None,
-                "pbo": None,
-                "oos_sharpe": None,
-                "in_sample_sharpe": None,
-                "lookahead_audit_passed": False,
-                "passing": False,
-                "reason": (eval_result.error or "fusion backtest produced no metrics"),
-            }
-            await emit.emit(
-                "tool_result",
-                candidate_id=candidate_id,
-                tool_name="evaluate_fusion_spec",
-                result_summary=f"evaluation failed: {(eval_result.error or 'no metrics')[:120]}",
-            )
-    else:
-        # Text-only fusion (no DSL spec) — honest pre-backtest verdict, not a
-        # fabricated pass. The proposal is still actionable (≥2 papers fused).
-        rigor_verdict = {
-            "dsr": None,
-            "pbo": None,
-            "oos_sharpe": None,
-            "in_sample_sharpe": None,
-            "lookahead_audit_passed": False,
-            "passing": False,
-            "reason": "fusion produced no machine-readable strategy_spec — rigor gate not run",
-        }
-
-    source_papers = [{"arxiv_id": aid, "title": ""} for aid in proposal.source_arxiv_ids]
-    # Defensive: the engine already guarantees ≥ MIN_PAPERS via is_actionable.
-    assert len(proposal.source_arxiv_ids) >= MIN_PAPERS  # invariant guard (engine guarantees via is_actionable)
-
-    return _CandidateResult(
-        candidate_id=candidate_id,
-        strategy_name=proposal.strategy_name or f"Fusion — {brief.intent[:50].strip()}",
-        thesis=proposal.thesis,
-        asset_universe=asset_universe,
-        source_papers=source_papers,
-        weights={},  # fusion emits a DSL spec, not a static weight vector
-        reasoning=proposal.fusion_reasoning or proposal.novelty_rationale or "",
-        rigor_verdict=rigor_verdict,
-        passes_rigor=bool(rigor_verdict.get("passing", False)),
-        regime=regime,
-        generation_method="fusion",
-        source_arxiv_ids=list(proposal.source_arxiv_ids),
-        has_real_rigor=has_real_rigor,
-        return_series=real_return_series or None,
-    )
 
 
 # ── Pipeline entry point ──────────────────────────────────────────────────
@@ -1060,7 +638,7 @@ def _resolve_name(brief: GenerateBrief, default: str) -> str:
     """Prefer the user's ``brief.name`` over an auto-derived default.
 
     Single choke point for user-chosen strategy names: every runner
-    (fixture / live agent / fusion / debate) auto-derives a ``strategy_name``,
+    (fixture / debate) auto-derives a ``strategy_name``,
     and ``run_generation`` applies the user's name to the WINNER only — right
     before persistence, so the library record, passport, episodic memory, and
     job result all carry it. ``brief.name`` is already sanitized (stripped,
@@ -1228,11 +806,7 @@ async def run_generation(
         # singleton on the env default (behavior unchanged). Constructed once and
         # shared across both regime candidates so we don't rebuild a client twice.
         #
-        # NOTE: `use_live` and `runner` are already resolved ABOVE, where the
-        # fusion-vs-agent dispatch decision is made. Do NOT redefine `runner`
-        # here — a second `runner = _run_live_candidate ...` would clobber the
-        # fusion runner selected for a "fusion" pipeline and silently revert to
-        # the agent path (the bug this rebase had to reconcile).
+        # NOTE: `runner` is resolved ABOVE in the dispatch block. Do NOT redefine it here.
         job_agent = None
         if use_live and model:
             try:

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -981,27 +981,6 @@ async def run_generation(
             regime=best.regime,
             redirect_url=f"/library?highlight={sid}",
         )
-        for c in candidates:
-            if c.candidate_id == best.candidate_id:
-                continue
-            from archimedes.services.strategy_memory import persist_proposal
-
-            await asyncio.to_thread(
-                persist_proposal,
-                generation_id=job_id,
-                agent=c.generation_method or "debate",
-                intent=brief.intent,
-                papers=list(c.source_arxiv_ids or []),
-                rigor_verdict=c.rigor_verdict,
-                verdict="rejected",
-                regime_tag=c.regime,
-                extra={
-                    "candidate_id": c.candidate_id,
-                    "strategy_name": c.strategy_name,
-                    "thesis": c.thesis,
-                    "reject_reason": (c.rigor_verdict or {}).get("reason") or "outranked by the society leader",
-                },
-            )
         strategy_id = strategy_ids.get(best.candidate_id, "")
 
         # ── Run real multi-year backtests on every persisted candidate ──
@@ -1079,7 +1058,20 @@ async def run_generation(
                     },
                     papers=[p.get("arxiv_id", "") for p in cand.source_papers] or list(cand.source_arxiv_ids),
                     rigor_verdict=cand.rigor_verdict,
-                    extra={"candidate_id": cand.candidate_id, "selected": cand is best},
+                    # K=1 (Phase-3): this loop is the SINGLE episodic writer for the
+                    # whole board — winner marked selected, alternates carry the
+                    # honest reject reason. (A second per-alternate writer here
+                    # produced 2N-1 rows per run; verify finding, removed.)
+                    verdict="selected" if cand is best else "rejected",
+                    regime_tag=cand.regime,
+                    extra={
+                        "candidate_id": cand.candidate_id,
+                        "selected": cand is best,
+                        "strategy_name": cand.strategy_name,
+                        "reject_reason": None
+                        if cand is best
+                        else (cand.rigor_verdict or {}).get("reason") or "outranked by the society leader",
+                    },
                 )
         except Exception:
             pass  # Non-blocking per spec

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1100,6 +1100,7 @@ async def run_generation(
                         "passes_rigor": c.passes_rigor,
                         "selected": c is best,
                         "regime": c.regime,
+                        "generation_method": c.generation_method,
                     }
                     for c in candidates
                 ],

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -763,7 +763,7 @@ async def run_generation(
         fixture_mode = os.getenv("GENERATION_PIPELINE_FIXTURE", "").lower() in ("1", "true") or (
             not use_live and os.getenv("TESTING")
         )
-        if use_live and _debate_can_run(brief):
+        if use_live and await asyncio.to_thread(_debate_can_run, brief):
             runner: Callable[..., Awaitable[Any]] = functools.partial(_run_debate_leaderboard, model=model)
         elif fixture_mode:
             pipeline_name = "fixture"
@@ -1056,7 +1056,8 @@ async def run_generation(
                         "weights": cand.weights,
                         "asset_universe": cand.asset_universe,
                     },
-                    papers=[p.get("arxiv_id", "") for p in cand.source_papers] or list(cand.source_arxiv_ids),
+                    papers=[aid for p in cand.source_papers if (aid := p.get("arxiv_id", ""))]
+                    or list(cand.source_arxiv_ids),
                     rigor_verdict=cand.rigor_verdict,
                     # K=1 (Phase-3): this loop is the SINGLE episodic writer for the
                     # whole board — winner marked selected, alternates carry the

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -81,45 +81,13 @@ def _pick_pipeline(
        brief's inferred asset classes.
     3. **agent** (SSE streaming portfolio-advisor path) as the fallback.
     """
-    # ── Debate society (flag-gated, additive — T1.1) ──
-    # When ARCHIMEDES_DEBATE_ENABLED is set, the debate society IS the generation
-    # pipeline (staged replacement). While the flag is OFF the legacy decision
-    # tree below runs UNCHANGED — so the flag-OFF live path stays byte-identical
-    # even if a client passes mode="debate". The legacy-runner deletions are
-    # deferred to the Phase-3 cutover PR.
-    from archimedes.agents.debate_engine import debate_enabled
-
-    if debate_enabled():
-        return "debate", "debate society pipeline (ARCHIMEDES_DEBATE_ENABLED)"
-
-    # ── User-selected mode override (#290) ──
-    if mode_override and mode_override in ("fusion", "architect", "agent"):
-        return mode_override, f"user selected {mode_override} mode"
-
-    # ── Fusion check ──
-    try:
-        from archimedes.agents.strategy_fusion import fusion_enabled, load_corpus
-
-        if fusion_enabled():
-            corpus = load_corpus()
-            corpus_count = len(corpus) if corpus else 0
-            if corpus_count >= 20 and _llm_available():
-                return "fusion", (f"fusion engine enabled, corpus={corpus_count} papers, LLM backend alive")
-    except Exception:
-        pass  # fall through
-
-    # ── Architect check ──
-    try:
-        from archimedes.services.strategy_provider import default_provider
-
-        lib = default_provider().list_strategies()
-        if len(lib) >= 3:
-            return "architect", (f"curated library has {len(lib)} strategies; fast preview available")
-    except Exception:
-        pass  # fall through
-
-    # ── Agent (fallback) ──
-    return "agent", "streaming agent — general-purpose fallback"
+    # ── T1.1 Phase-3 cutover: the debate society IS the generation pipeline. ──
+    # The legacy fusion/architect/agent decision tree is retired; a client-sent
+    # mode override is accepted for API compatibility but no longer routes —
+    # the society owns candidate generation (spec §Phase-3; #834 flag audit).
+    if mode_override and mode_override != "debate":
+        logger.info("generation: ignoring legacy mode override %r (debate-only cutover)", mode_override)
+    return "debate", "debate society is the generation pipeline (T1.1 Phase-3 cutover)"
 
 
 def _fusion_can_run(brief: GenerateBrief) -> bool:
@@ -1207,63 +1175,46 @@ async def run_generation(
         # ── Auto-route to the best pipeline ──
         pipeline_name, pipeline_reason = _pick_pipeline(brief, mode_override=mode)
 
-        # Determine regime plan: dual_regime emits both bull + bear (Issue #163).
-        # The debate society owns its OWN internal regime/mechanism split, so its
-        # per-regime loop runs ONCE ("neutral") and the expensive PBO/persist tail
-        # stays a single self-contained unit (spec §5b).
+        # ── T1.1 Phase-3 dispatch: debate is THE runner. ──
+        # No silent fallback to the retired single-agent paths: if the society
+        # cannot run, the job errors HONESTLY. The deterministic fixture runner
+        # survives strictly for hermetic tests (TESTING / explicit fixture env).
+        from archimedes.agents.debate_engine import _debate_can_run, _run_debate_leaderboard
+
+        use_live = _llm_available()
+        fixture_mode = os.getenv("GENERATION_PIPELINE_FIXTURE", "").lower() in ("1", "true") or (
+            not use_live and os.getenv("TESTING")
+        )
+        if use_live and _debate_can_run(brief):
+            runner: Callable[..., Awaitable[Any]] = functools.partial(_run_debate_leaderboard, model=model)
+        elif fixture_mode:
+            pipeline_name = "fixture"
+            pipeline_reason = "deterministic fixture runner (tests only — no LLM in the environment)"
+            runner = _run_fixture_candidate
+        else:
+            reason = (
+                "no LLM backend reachable"
+                if not use_live
+                else "the corpus yielded <2 papers for this steer — the society cannot fuse"
+            )
+            await emit.emit(
+                "error",
+                message=f"Generation is unavailable right now: {reason}.",
+                recoverable=True,
+                code="GENERATION_UNAVAILABLE",
+            )
+            await store.update_status(job_id, "error", error=f"generation unavailable: {reason}")
+            return
+
+        # Regime plan AFTER the runner is final: the society owns its own
+        # regime/mechanism split internally (spec §5b) → a single "neutral"
+        # pass; the fixture path keeps the legacy dual-regime shape for tests.
         if pipeline_name == "debate":
             regimes: list[str] = ["neutral"]
         elif dual_regime:
             regimes = ["bull", "bear"]
         else:
             regimes = ["neutral"] * n_candidates
-
-        # ── Resolve the ACTUAL runner that will drive dispatch ──
-        # _pick_pipeline computes a label; before this fix that label was thrown
-        # away and the agent path always ran. Now the choice DRIVES dispatch:
-        # when "fusion" is selected, dispatch to the real (unit-tested) fusion
-        # engine via _run_fusion_candidate. A lightweight, no-LLM viability
-        # precheck (fusion flag on + ≥2 candidate papers for the steer) keeps
-        # pipeline_selected honest — we only announce "fusion" if it can run.
-        # The single-agent path remains the FALLBACK (fusion not selected / no
-        # LLM / corpus <2 papers).
-        use_live = _llm_available()
-        agent_runner: Callable[..., Awaitable[_CandidateResult]] = (
-            _run_live_candidate if use_live else _run_fixture_candidate
-        )
-        runner = agent_runner
-        if pipeline_name == "fusion":
-            if use_live and _fusion_can_run(brief):
-                runner = _run_fusion_candidate
-            else:
-                # Selected fusion but it can't actually run (no LLM, or the steer
-                # yields <2 papers). Relabel honestly rather than mislabeling an
-                # agent run as fusion (claim integrity).
-                pipeline_name = "agent"
-                pipeline_reason = (
-                    "fusion selected but not runnable "
-                    f"({'no LLM backend' if not use_live else 'corpus yielded <2 papers for the steer'})"
-                    " — falling back to streaming agent"
-                )
-                runner = agent_runner
-        elif pipeline_name == "debate":
-            # Flag-gated debate society (T1.1). model is bound now via partial so
-            # the proposer threads the user's pick (A3); the loop calls runner()
-            # with the same kwargs as every other runner (signature parity). A
-            # DebateUnavailable raised at runtime is a FusionUnavailable subclass,
-            # so the existing fallback below relabels it to the agent path.
-            from archimedes.agents.debate_engine import _debate_can_run, _run_debate_candidate
-
-            if use_live and _debate_can_run(brief):
-                runner = functools.partial(_run_debate_candidate, model=model)
-            else:
-                pipeline_name = "agent"
-                pipeline_reason = (
-                    "debate selected but not runnable "
-                    f"({'no LLM backend' if not use_live else 'corpus yielded <2 papers for the steer'})"
-                    " — falling back to streaming agent"
-                )
-                runner = agent_runner
 
         await emit.emit(
             "pipeline_selected",
@@ -1326,36 +1277,19 @@ async def run_generation(
                     selection_pool_size=n_candidates,  # #770: DSR deflates for the N-candidate search
                 )
             except FusionUnavailable as exc:
-                # Fusion was selected + precheck passed, but at runtime the
-                # engine declined (e.g. the LLM fused <2 valid papers). Fall
-                # back to the agent path for THIS candidate rather than failing
-                # — and surface the relabel so the stream stays honest.
-                logger.info("fusion declined for %s (%s); falling back to agent: %s", candidate_id, regime, exc)
+                # T1.1 Phase-3: the society declined at runtime (empty pool /
+                # nothing conformant). There is NO fallback pipeline anymore —
+                # surface the honest first-class ABSTAIN and let the
+                # NO_CANDIDATES path below report it if nothing else lands.
+                logger.info("debate society abstained for %s (%s): %s", candidate_id, regime, exc)
                 await emit.emit(
-                    "pipeline_selected",
-                    pipeline="agent",
-                    reason=f"fusion declined at runtime ({exc}); using streaming agent",
-                    regimes=regimes,
+                    "candidate_failed",
+                    candidate_id=candidate_id,
+                    regime=regime,
+                    error=str(exc),
+                    message="The debate society abstained — no proposal survived the critics for this brief.",
                 )
-                try:
-                    cand = await agent_runner(
-                        candidate_id=candidate_id,
-                        brief=brief,
-                        emit=emit,
-                        regime=regime,
-                        agent=job_agent,  # preserve the user's free-tier model pick on fallback (#748)
-                        selection_pool_size=n_candidates,  # #770: DSR deflates for the N-candidate search
-                    )
-                except Exception as exc2:
-                    logger.exception("agent fallback %s (%s) failed: %s", candidate_id, regime, exc2)
-                    await emit.emit(
-                        "candidate_failed",
-                        candidate_id=candidate_id,
-                        regime=regime,
-                        error=str(exc2),
-                        message=f"No {regime} candidate available — your brief may be structurally one-sided.",
-                    )
-                    continue
+                continue
             except Exception as exc:
                 logger.exception("candidate %s (%s) failed: %s", candidate_id, regime, exc)
                 await emit.emit(
@@ -1367,20 +1301,26 @@ async def run_generation(
                 )
                 continue
 
-            await emit.emit(
-                "candidate_drafted",
-                candidate_id=cand.candidate_id,
-                strategy_name=cand.strategy_name,
-                weights_preview=cand.weights,
-                regime=regime,
-            )
-            await emit.emit(
-                "candidate_evaluated",
-                candidate_id=cand.candidate_id,
-                rigor_verdict=cand.rigor_verdict,
-                regime=regime,
-            )
-            candidates.append(cand)
+            # Phase-3 fan-out: the debate runner returns the FULL ranked
+            # leaderboard (leader first); legacy/fixture runners return one
+            # candidate. Every entry is surfaced on the stream — the tail IS
+            # the Considered-Alternatives panel's content.
+            entries = cand if isinstance(cand, list) else [cand]
+            for entry in entries:
+                await emit.emit(
+                    "candidate_drafted",
+                    candidate_id=entry.candidate_id,
+                    strategy_name=entry.strategy_name,
+                    weights_preview=entry.weights,
+                    regime=regime,
+                )
+                await emit.emit(
+                    "candidate_evaluated",
+                    candidate_id=entry.candidate_id,
+                    rigor_verdict=entry.rigor_verdict,
+                    regime=regime,
+                )
+            candidates.extend(entries)
 
         if not candidates:
             # Honest code + message (#818): this branch fires only when ZERO candidates
@@ -1418,10 +1358,17 @@ async def run_generation(
         # refuses to deploy it — we must not imply it is validated.
         validated = [c for c in candidates if c.passes_rigor]
         pool = validated or candidates
-        best = max(
-            pool,
-            key=lambda c: c.rigor_verdict.get("dsr") or 0.0,
-        )
+        if pipeline_name == "debate":
+            # The society's deterministic synthesizer already ranked the board
+            # (composite of rigor + null-margin + regime fit) — re-ranking by
+            # raw DSR here would silently override the debate outcome. Take the
+            # first pool member in board order.
+            best = next(c for c in candidates if c in pool)
+        else:
+            best = max(
+                pool,
+                key=lambda c: c.rigor_verdict.get("dsr") or 0.0,
+            )
         # User-chosen name (brief.name) applies to the WINNER only, and must land
         # BEFORE the persist loop below so every downstream surface (library
         # record, passport, episodic memory, job result) reads it. Considered-
@@ -1438,25 +1385,48 @@ async def run_generation(
             deployable=best.passes_rigor,
         )
 
-        # Persist ALL candidates (both regimes) as StrategyRecords.
-        # Each gets its own strategy_id and trace_hash. The "best" is still
-        # highlighted but both are navigable from the library.
+        # K=1 persistence (Phase-3): only the WINNER becomes a library
+        # strategy (+passport +trace). Considered alternatives are recorded in
+        # the episodic strategy_proposals store (content-hashed, with their
+        # rigor verdicts) and surfaced via the job's candidates payload — they
+        # must NOT accumulate as rejected StrategyRecords (the orphan pattern
+        # the ownership purge removed).
         strategy_ids: dict[str, str] = {}  # candidate_id → strategy_id
+        sid, thash = await _persist_candidate(best, brief, owner_wallet=owner_wallet)
+        strategy_ids[best.candidate_id] = sid
+        await emit.emit(
+            "trace_hashed",
+            trace_hash=thash,
+            candidate_id=best.candidate_id,
+            regime=best.regime,
+        )
+        await emit.emit(
+            "persisted",
+            strategy_id=sid,
+            candidate_id=best.candidate_id,
+            regime=best.regime,
+            redirect_url=f"/library?highlight={sid}",
+        )
         for c in candidates:
-            sid, thash = await _persist_candidate(c, brief, owner_wallet=owner_wallet)
-            strategy_ids[c.candidate_id] = sid
-            await emit.emit(
-                "trace_hashed",
-                trace_hash=thash,
-                candidate_id=c.candidate_id,
-                regime=c.regime,
-            )
-            await emit.emit(
-                "persisted",
-                strategy_id=sid,
-                candidate_id=c.candidate_id,
-                regime=c.regime,
-                redirect_url=f"/library?highlight={sid}",
+            if c.candidate_id == best.candidate_id:
+                continue
+            from archimedes.services.strategy_memory import persist_proposal
+
+            await asyncio.to_thread(
+                persist_proposal,
+                generation_id=job_id,
+                agent=c.generation_method or "debate",
+                intent=brief.intent,
+                papers=list(c.source_arxiv_ids or []),
+                rigor_verdict=c.rigor_verdict,
+                verdict="rejected",
+                regime_tag=c.regime,
+                extra={
+                    "candidate_id": c.candidate_id,
+                    "strategy_name": c.strategy_name,
+                    "thesis": c.thesis,
+                    "reject_reason": (c.rigor_verdict or {}).get("reason") or "outranked by the society leader",
+                },
             )
         strategy_id = strategy_ids.get(best.candidate_id, "")
 
@@ -1490,7 +1460,7 @@ async def run_generation(
                     c, strategy_ids[c.candidate_id], emit, _society_num_trials(library_size, n_candidates)
                 )
                 for c in candidates
-                if c.generation_method not in _static_skip
+                if c.generation_method not in _static_skip and c.candidate_id in strategy_ids
             ]
         )
 
@@ -1505,7 +1475,7 @@ async def run_generation(
                     c, strategy_ids[c.candidate_id], emit, _society_num_trials(library_size, n_candidates)
                 )
                 for c in candidates
-                if c.has_real_rigor and c.return_series
+                if c.has_real_rigor and c.return_series and c.candidate_id in strategy_ids
             ]
         )
 

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -65,7 +65,7 @@ class GenerateStartRequest(BaseModel):
         default=None,
         description=(
             "Optional pipeline override (API compatibility; ignored as of T1.1 Phase-3 cutover). "
-            "The debate society is the sole generation pipeline — any override is logged and discarded."
+            "The debate society is the sole generation pipeline — non-debate overrides are logged and discarded."
         ),
     )
     model: str | None = Field(

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -64,10 +64,8 @@ class GenerateStartRequest(BaseModel):
     mode: str | None = Field(
         default=None,
         description=(
-            "Optional pipeline override: 'fusion', 'architect', or 'agent'. When set, bypasses "
-            "auto-routing. The 'debate' society pipeline (T1.1) is selected by the "
-            "ARCHIMEDES_DEBATE_ENABLED flag rather than this override, so flag-OFF stays "
-            "byte-identical; the deletions of the legacy runners are deferred to the Phase-3 cutover."
+            "Optional pipeline override (API compatibility; ignored as of T1.1 Phase-3 cutover). "
+            "The debate society is the sole generation pipeline — any override is logged and discarded."
         ),
     )
     model: str | None = Field(

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -153,6 +153,7 @@ class CandidateSummary(BaseModel):
     passes_rigor: bool
     selected: bool
     regime: str | None = None  # "bull", "bear", or "neutral" (Issue #163)
+    generation_method: str | None = None  # "debate" | "debate_abstain" | "fusion" | …
 
 
 class CandidatesListResponse(BaseModel):

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -548,7 +548,7 @@ class TestFusionGateUsesRealTrialCount:
     def test_larger_passed_num_trials_is_not_overridden_by_a_small_variant_grid(self):
         """#820: a small parameter-variant grid must not silently undercut a
         bigger, correct caller-supplied num_trials (e.g. the society count,
-        library_size + selection_pool_size, threaded from _run_fusion_candidate).
+        library_size + selection_pool_size, threaded from the debate C-rigor path).
         Before this fix, any >=2-entry variants_metrics unconditionally replaced
         num_trials, so a 3-variant grid could under-deflate a strategy that
         actually needed a much larger society-wide trial count."""

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -628,9 +628,9 @@ async def test_debate_dispatch_end_to_end_persists_debate_strategy(tmp_path, mon
     Asserts: (a) pipeline_selected=debate, (b) candidate_drafted + persisted
     emitted, (c) StrategyRecord.generation_method == 'debate'.
     """
-    import archimedes.db as _db
     import archimedes.agents.debate_engine as de
     import archimedes.agents.strategy_fusion as sf
+    import archimedes.db as _db
     import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp
     from archimedes.models.strategy_store import StrategyRecord
@@ -710,9 +710,9 @@ async def test_debate_critic_rigor_num_trials_matches_society_formula(tmp_path, 
     set), not n_candidates. The spy asserts evaluate_fusion_spec receives the right
     value across the full proposal pool.
     """
-    import archimedes.db as _db
     import archimedes.agents.debate_engine as de
     import archimedes.agents.strategy_fusion as sf
+    import archimedes.db as _db
     import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp
     from sqlalchemy import create_engine
@@ -831,9 +831,9 @@ async def test_debate_text_only_pool_no_spurious_backtest_failed(tmp_path, monke
     Re-targets test_fusion_text_only_does_not_emit_spurious_backtest_failed which
     tested the same _static_skip guard on the retired standalone-fusion dispatch.
     """
-    import archimedes.db as _db
     import archimedes.agents.debate_engine as de
     import archimedes.agents.strategy_fusion as sf
+    import archimedes.db as _db
     import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp
     from archimedes.models.strategy_store import StrategyRecord

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -3,12 +3,18 @@
 Forces the fixture path (no LLM credentials needed) and asserts that the
 event sequence matches the spec ordering and that a strategy is persisted
 at the end.
+
+Debate-path tests (test_debate_dispatch_*, test_debate_critic_rigor_*,
+test_debate_text_only_*) stub the debate engine's proposer and evaluator
+seams to run _run_debate_leaderboard hermetically without a live LLM or
+real market-data backtest. Pattern mirrors test_debate_engine.py.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -216,27 +222,21 @@ def test_lookahead_for_candidate_ignores_backtrader_negative_index(tmp_path):
     assert _lookahead_for_candidate([]) is True
 
 
-def test_pick_pipeline_architect_branch_calls_provider_factory(monkeypatch):
-    # `default_provider` is a factory function. The architect-check branch
-    # of _pick_pipeline previously called `default_provider.list_strategies()`
-    # without the `()`, raising AttributeError that the broad `except
-    # Exception` swallowed silently — collapsing the pipeline to "agent" on
-    # every call. This test forces the architect path (fusion disabled) and
-    # asserts it actually selects "architect" — which can only happen if
-    # `.list_strategies()` succeeds.
+def test_pick_pipeline_always_debate_after_cutover(monkeypatch):
+    # T1.1 Phase-3: _pick_pipeline always returns 'debate' regardless of flag
+    # state, fusion enabled/disabled, library size, or mode override.
+    # The legacy fusion/architect/agent decision tree is deleted; no mocking of
+    # fusion_enabled or default_provider is needed or meaningful.
+    #
+    # Equivalent coverage of the old architect-branch regression now lives in
+    # test_debate_engine.py::test_pick_pipeline_is_debate_unconditionally.
     from archimedes.agents import generation_pipeline as gp
-    from archimedes.api.generate_schemas import GenerateBrief
-
-    # Force fusion off so we exit the fusion branch and hit architect.
-    monkeypatch.setattr(
-        "archimedes.agents.strategy_fusion.fusion_enabled",
-        lambda: False,
-    )
 
     brief = GenerateBrief(intent="trend-following", risk_appetite="moderate")
-    pipeline, reason = gp._pick_pipeline(brief)
-    assert pipeline == "architect", f"expected architect, got {pipeline!r} (reason={reason!r})"
-    assert "strategies" in reason
+    for override in (None, "fusion", "architect", "agent", "debate"):
+        name, reason = gp._pick_pipeline(brief, mode_override=override)
+        assert name == "debate", f"override {override!r} routed off the society (got {name!r})"
+        assert "debate" in reason.lower() or "Phase-3" in reason
 
 
 @pytest.mark.asyncio
@@ -328,37 +328,52 @@ async def test_dual_regime_always_emits_both_bull_and_bear():
 
 
 @pytest.mark.asyncio
-async def test_dual_regime_persists_both_with_correct_regime_tags():
-    """Both bull and bear candidates are persisted (both get strategy_id)."""
+async def test_dual_regime_k1_only_winner_persisted():
+    """K=1 persistence (Phase-3 contract): fixture dual-regime run yields 2
+    candidates in the result payload (bull+bear regimes intact) but exactly
+    ONE _persist_candidate call (the winner) and ONE persist_proposal call
+    for the reject (verdict='rejected').
+
+    Replaces test_dual_regime_persists_both_with_correct_regime_tags which
+    tested the retired K=2 pattern (both regimes persisted as StrategyRecords).
+    """
+    import archimedes.services.strategy_memory as sm
+
     store = _FakeStore()
     brief = GenerateBrief(intent="balanced equities", risk_appetite="conservative")
 
-    persist_calls = []
-    call_count = [0]
+    persist_calls: list[dict] = []
 
-    async def mock_persist(c, b, **_kw):  # accepts owner_wallet kwarg
-        call_count[0] += 1
-        sid = f"strat_{c.regime}_{call_count[0]}"
-        persist_calls.append({"regime": c.regime, "strategy_id": sid})
-        return (sid, f"0x{c.regime}")
+    async def mock_persist(c, b, **_kw):
+        persist_calls.append({"regime": c.regime, "candidate_id": c.candidate_id})
+        return (f"strat_{c.regime}", f"0x{c.regime}")
 
-    with patch(
-        "archimedes.agents.generation_pipeline._persist_candidate",
-        new=mock_persist,
+    proposal_calls: list[dict] = []
+
+    def mock_persist_proposal(**kwargs):
+        proposal_calls.append(kwargs)
+
+    with (
+        patch("archimedes.agents.generation_pipeline._persist_candidate", new=mock_persist),
+        patch.object(sm, "persist_proposal", side_effect=mock_persist_proposal),
     ):
-        await run_generation(job_id="job_dual_persist", brief=brief, store=store)
+        await run_generation(job_id="job_k1_persist", brief=brief, store=store)
 
-    # Both candidates persisted
-    assert len(persist_calls) == 2
-    persisted_regimes = {p["regime"] for p in persist_calls}
-    assert persisted_regimes == {"bull", "bear"}
+    # K=1: exactly ONE _persist_candidate call (the winner only)
+    assert len(persist_calls) == 1, f"K=1 must persist exactly 1 winner; got {len(persist_calls)} calls"
 
-    # Done result has both candidates with strategy_ids
+    # The rejected candidate lands in strategy_proposals with verdict='rejected'
+    rejected = [c for c in proposal_calls if c.get("verdict") == "rejected"]
+    assert len(rejected) == 1, f"Expected 1 rejected persist_proposal; got {rejected}"
+    assert rejected[0]["regime_tag"] in ("bull", "bear"), "reject must carry a regime_tag"
+
+    # Both candidates still surface in the result payload (stream visibility preserved)
     last_result = store.status[-1][1]
     assert last_result is not None
-    for c in last_result["candidates"]:
-        assert c["strategy_id"] is not None
-        assert c["regime"] in ("bull", "bear")
+    candidates = last_result["candidates"]
+    assert len(candidates) == 2
+    regimes = {c["regime"] for c in candidates}
+    assert regimes == {"bull", "bear"}
 
 
 @pytest.mark.asyncio
@@ -465,126 +480,128 @@ async def test_best_selected_abstains_when_no_candidate_passes_rigor():
     assert best["data"]["deployable"] is False
 
 
-# ── Fusion dispatch wire — hermetic end-to-end (Stack A) ───────────────────
+# ── Debate dispatch wire — hermetic end-to-end ─────────────────────────────
 #
-# Proves the #1 fix: the "fusion" pipeline choice ACTUALLY drives dispatch.
-# Drives run_generation with fusion_enabled=true + a ≥20-paper fixture corpus +
-# a MOCKED LLM backend (no network, no real Anthropic/Bedrock), and asserts the
-# persisted strategy is generation_method=="fusion", cites ≥2 source_arxiv_ids,
-# and carries a non-null rigor verdict (real DSR/PBO/OOS from the DSL backtest).
+# Re-targets the old "fusion dispatch wire" tests at the debate path. Instead
+# of the retired standalone-fusion dispatch, we stub the debate engine's
+# proposer (_propose_pool) and evaluator (evaluate_fusion_spec) seams so
+# _run_debate_leaderboard runs hermetically through run_generation — no live
+# LLM, no real market-data backtest, no network. Pattern follows the
+# _CannedFusionBackend + monkeypatch seams in test_debate_engine.py.
 
 
-def _fixture_corpus(n: int = 24):
-    """A ≥n-paper fixture corpus the deterministic selector can rank.
+# ── Shared helpers for debate dispatch tests ──────────────────────────────────
 
-    Returns CorpusPaper objects (the type load_corpus yields). Titles/abstracts
-    carry equities+momentum+volatility terms so select_candidates matches them
-    for a generic steer.
+
+def _debate_fake_corpus(n: int = 4):
+    """A small fixture corpus whose arxiv_ids match the fake proposals' citations.
+
+    Kept small (n=4) since we're mocking _propose_pool anyway and just need
+    _critic_prov to pass provenance checks.
     """
     from archimedes.agents.strategy_fusion import CorpusPaper
 
-    papers = []
-    for i in range(n):
-        papers.append(
-            CorpusPaper(
-                arxiv_id=f"24{i:02d}.{1000 + i}",
-                title=f"Cross-sectional equity momentum and volatility timing #{i}",
-                abstract=(
-                    "We study momentum, trend-following and volatility-managed "
-                    "portfolios across equities, with risk-on and defensive regimes."
-                ),
-                primary_category="q-fin.PM",
-                categories=("q-fin.PM", "q-fin.ST"),
-                published=f"2024-01-{(i % 27) + 1:02d}",
-            )
+    return [
+        CorpusPaper(
+            arxiv_id=f"240{r}.0000{i}",
+            title=f"Paper {r}-{i}",
+            abstract="Momentum trend-following equities volatility hedge.",
+            primary_category="q-fin.PM",
+            categories=("q-fin.PM",),
+            published="2024-01-01",
         )
-    return papers
+        for r in (1, 2)
+        for i in range(1, (n // 2) + 1)
+    ]
 
 
-class _MockFusionBackend:
-    """Deterministic LLM stand-in that returns a REAL, parseable fusion.
-
-    Mirrors the live LLMBackend Protocol (model_id / served_model / available /
-    complete). ``available`` is True so the fusion path treats it as a live
-    model. ``complete`` echoes back ≥2 of the candidate arxiv_ids it sees in the
-    user prompt (so the engine's anti-hallucination filter keeps them) and emits
-    a real Archimedes DSL strategy_spec the evaluator can backtest + rigor-gate.
-    """
-
-    model_id = "mock-fusion-model"
-    served_model = "mock-fusion-model-served"
-
-    @property
-    def available(self) -> bool:
-        return True
-
-    def complete(self, system: str, user: str) -> str:
-        import json as _json
-        import re as _re
-
-        ids = _re.findall(r'"arxiv_id"\s*:\s*"([^"]+)"', user)[:3]
-        return _json.dumps(
-            {
-                "strategy_name": "Mock Fused SMA+Vol Strategy",
-                "thesis": "Fuses SMA-200 trend timing with vol-managed sizing (pre-backtest).",
-                "source_arxiv_ids": ids,
-                "fusion_reasoning": "Paper A contributes trend timing; paper B vol scaling.",
-                "novelty_rationale": "Combination not published together.",
-                "risk_notes": "Pre-backtest hypothesis; rigor gate applies.",
-                "strategy_spec": {
-                    "name": "Mock Fused SMA+Vol Strategy",
-                    "asset_universe": ["SPY"],
-                    "rebalance_frequency": "monthly",
-                    "entry": {"gt": ["close", "sma_200"]},
-                    "exit": {"lt": ["close", "sma_200"]},
-                    "position_sizing": {"type": "full_invested_when_in_market"},
-                    "source_arxiv_ids": ids,
-                    "look_ahead_safe": True,
-                    "indicators": ["sma_200"],
-                    "parameter_variants": {"sma_200": [150, 200, 250]},
-                },
-            }
-        )
+# Conformant DSL spec — passes _dsl_conformance_ok and evaluate_fusion_spec.
+_DEBATE_SPEC = {
+    "name": "Debate canned SMA",
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "monthly",
+    "entry": {"gt": ["sma_50", 0]},
+    "exit": {"lt": ["close", "sma_200"]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "look_ahead_safe": True,
+}
 
 
-@pytest.mark.asyncio
-async def test_fusion_dispatch_end_to_end_persists_fusion_strategy(tmp_path, monkeypatch):
-    """The fusion choice drives dispatch → a fusion strategy is persisted.
-
-    Hermetic: tmp SQLite DB, fixture corpus, mocked LLM backend — no network.
-    """
-    # Real (temp) DB so _persist_candidate's upsert_strategy lands a row. db.py
-    # binds its engine/SessionLocal at IMPORT time, so an env tweak alone won't
-    # rebind them once another test has imported db — rebind the globals here so
-    # get_session() (used by upsert_strategy) writes to OUR isolated sqlite file.
-    import archimedes.db as _db
-    from archimedes.agents import generation_pipeline as gp
-    from archimedes.agents import strategy_fusion as sf
-    from archimedes.models.strategy_store import StrategyRecord
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
-
-    test_engine = create_engine(
-        f"sqlite:///{tmp_path / 'fusion_e2e.db'}",
-        connect_args={"check_same_thread": False},
+def _make_fake_proposal(name: str, ids: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        strategy_name=name,
+        thesis=f"Thesis for {name}.",
+        source_arxiv_ids=ids,
+        strategy_spec=dict(_DEBATE_SPEC, name=name),
+        fusion_reasoning="canned reasoning",
+        novelty_rationale="canned novelty",
+        is_actionable=True,
     )
-    monkeypatch.setattr(_db, "engine", test_engine)
-    monkeypatch.setattr(_db, "SessionLocal", sessionmaker(bind=test_engine, autocommit=False, autoflush=False))
-    # Register all ORM tables, then create them on the isolated engine.
-    from archimedes.models import kg, strategy_passport_record  # noqa: F401
 
-    _db.Base.metadata.create_all(bind=test_engine)
 
-    # Enable fusion + take the LIVE path (override the file's fixture autouse).
-    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
-    monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
-    # Skip the buy-and-hold backtest network round-trip for any agent fallback.
-    monkeypatch.setenv("GENERATION_PIPELINE_SKIP_BACKTEST", "1")
+def _fake_eval_result(*, num_trials: int | None = None) -> SimpleNamespace:
+    """Canned FusionEvalResult that passes all rigor gates + C-null."""
+    rigor = SimpleNamespace(
+        dsr=1.5,
+        dsr_p_value=0.01,
+        pbo_score=0.1,
+        oos_sharpe=1.2,
+        in_sample_sharpe=1.3,
+        look_ahead_clean=True,
+        look_ahead_label="clean",
+        num_trials=num_trials,
+        passing=True,
+        data_source="synthetic",
+        admissible=False,
+    )
+    bt = SimpleNamespace(
+        sharpe_ratio=1.4,
+        sortino_ratio=1.6,
+        max_drawdown=-0.1,
+        cagr=0.2,  # > MIN_COST_BENEFIT (0.05%) → clears C-null
+        calmar_ratio=1.1,
+        win_rate=0.55,
+        total_trades=42,
+        equity_curve=None,  # no return series needed for hermetic tests
+    )
+    return SimpleNamespace(rigor=rigor, backtest=bt, success=True, admissible=False, error=None, spec={})
 
-    # Live LLM available (validator + fusion gating both read this).
+
+def _setup_debate_hermetic(monkeypatch, *, gp, de, sf, fe, fake_proposals, fake_corpus):
+    """Apply the standard debate-path hermetic stubs.
+
+    Monkeypatches:
+    - gp._llm_available → True (live path)
+    - de._debate_can_run → True (bypass flag + corpus size check)
+    - de._propose_pool → returns fake_proposals (no LLM call)
+    - sf.load_corpus → returns fake_corpus (no DB/disk read)
+    - fe.evaluate_fusion_spec → returns _fake_eval_result (no backtest)
+    - de._debate_round → no-op (best-effort transcript, never gates)
+    """
     monkeypatch.setattr(gp, "_llm_available", lambda: True)
+    monkeypatch.setattr(de, "_debate_can_run", lambda brief: True)
 
-    async def _permissive_validate(brief):
+    async def _fake_pool(*a, **k):
+        return list(fake_proposals)
+
+    monkeypatch.setattr(de, "_propose_pool", _fake_pool)
+    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: list(fake_corpus))
+
+    def _fake_eval(spec, *, num_trials=None, use_real_data=False, **kw):
+        return _fake_eval_result(num_trials=num_trials)
+
+    monkeypatch.setattr(fe, "evaluate_fusion_spec", _fake_eval)
+
+    async def _noop_debate_round(*a, **k):
+        return []
+
+    monkeypatch.setattr(de, "_debate_round", _noop_debate_round)
+
+
+def _permissive_validate(brief):
+    """Permissive brief validator (no LLM call)."""
+
+    async def _inner(brief):
         return {
             "is_valid": True,
             "intent_summary": brief.intent[:140],
@@ -593,21 +610,57 @@ async def test_fusion_dispatch_end_to_end_persists_fusion_strategy(tmp_path, mon
             "risk_appetite_adjusted": brief.risk_appetite,
         }
 
-    monkeypatch.setattr(gp, "_validate_brief", _permissive_validate)
+    return _inner(brief)
 
-    # ≥20-paper fixture corpus, injected at the engine's load_corpus seam (both
-    # the no-LLM precheck and StrategyFusion read through this).
-    corpus = _fixture_corpus(24)
-    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: corpus)
 
-    # MOCKED LLM backend — inject via a StrategyFusion built with our backend +
-    # corpus so propose() does no network call. Patch on the agents module
-    # (the canonical home; services.strategy_fusion is the same object via
-    # the services/__init__ re-export).
-    monkeypatch.setattr(
-        sf,
-        "default_fusion",
-        lambda: sf.StrategyFusion(backend=_MockFusionBackend(), corpus=corpus),
+# ── Test 3 — debate dispatch end-to-end persists a debate strategy ────────────
+
+
+@pytest.mark.asyncio
+async def test_debate_dispatch_end_to_end_persists_debate_strategy(tmp_path, monkeypatch):
+    """Debate dispatch drives run_generation → a StrategyRecord with
+    generation_method='debate' is persisted.
+
+    Re-targets test_fusion_dispatch_end_to_end_persists_fusion_strategy which
+    tested the retired standalone-fusion dispatch. Hermetic: tmp SQLite, mocked
+    proposer + evaluator — no network, no LLM.
+
+    Asserts: (a) pipeline_selected=debate, (b) candidate_drafted + persisted
+    emitted, (c) StrategyRecord.generation_method == 'debate'.
+    """
+    import archimedes.db as _db
+    import archimedes.agents.debate_engine as de
+    import archimedes.agents.strategy_fusion as sf
+    import archimedes.services.fusion_evaluator as fe
+    from archimedes.agents import generation_pipeline as gp
+    from archimedes.models.strategy_store import StrategyRecord
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    test_engine = create_engine(
+        f"sqlite:///{tmp_path / 'debate_e2e.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    monkeypatch.setattr(_db, "engine", test_engine)
+    monkeypatch.setattr(_db, "SessionLocal", sessionmaker(bind=test_engine, autocommit=False, autoflush=False))
+    from archimedes.models import kg, strategy_passport_record  # noqa: F401
+
+    _db.Base.metadata.create_all(bind=test_engine)
+
+    monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
+
+    async def _pv(brief):
+        return await _permissive_validate(brief)
+
+    monkeypatch.setattr(gp, "_validate_brief", _pv)
+
+    fake_corpus = _debate_fake_corpus(4)
+    fake_proposals = [
+        _make_fake_proposal("Debate A", ["2401.00001", "2402.00001"]),
+        _make_fake_proposal("Debate B", ["2401.00002", "2402.00002"]),
+    ]
+    _setup_debate_hermetic(
+        monkeypatch, gp=gp, de=de, sf=sf, fe=fe, fake_proposals=fake_proposals, fake_corpus=fake_corpus
     )
 
     store = _FakeStore()
@@ -616,76 +669,57 @@ async def test_fusion_dispatch_end_to_end_persists_fusion_strategy(tmp_path, mon
         risk_appetite="moderate",
         asset_classes=["equities"],
     )
+    await run_generation(job_id="job_debate_e2e", brief=brief, store=store, dual_regime=False, n_candidates=1)
 
-    await run_generation(job_id="job_fusion_e2e", brief=brief, store=store, dual_regime=False, n_candidates=1)
-
-    # ── pipeline_selected announced fusion (and it actually ran) ──
+    # pipeline_selected announced debate
     ps = [e for e in store.events if e["event"] == "pipeline_selected"]
     assert ps, "no pipeline_selected event emitted"
-    assert ps[0]["data"]["pipeline"] == "fusion", (
-        f"fusion was not dispatched; got {ps[0]['data']['pipeline']!r} (reason={ps[0]['data'].get('reason')!r})"
+    assert ps[0]["data"]["pipeline"] == "debate", (
+        f"debate not dispatched; got {ps[0]['data']['pipeline']!r} (reason={ps[0]['data'].get('reason')!r})"
     )
 
-    # ── Same streaming events the agent path emits surfaced the fusion run ──
+    # Required streaming events present
     names = [e["event"] for e in store.events]
     for required in ("candidate_drafted", "candidate_evaluated", "persisted", "done"):
-        assert required in names, f"fusion run did not emit {required!r} (events={names})"
+        assert required in names, f"debate run did not emit {required!r} (events={names})"
 
-    # ── The persisted strategy is a real fusion with provenance + rigor ──
-    # Filter on the mock's exact name (not just generation_method) so a fusion
-    # row left by another test in the same session can't be mistaken for ours.
+    # Persisted as a debate strategy (generation_method='debate')
     with _db.get_session() as session:
-        record = (
-            session.query(StrategyRecord)
-            .filter(
-                StrategyRecord.generation_method == "fusion",
-                StrategyRecord.strategy_name == "Mock Fused SMA+Vol Strategy",
-            )
-            .first()
-        )
+        record = session.query(StrategyRecord).filter(StrategyRecord.generation_method == "debate").first()
+    assert record is not None, "no debate StrategyRecord was persisted"
+    assert record.generation_method == "debate"
 
-    assert record is not None, "no fusion StrategyRecord was persisted"
-    assert record.generation_method == "fusion"
-
-    source_papers = json.loads(record.source_papers)
-    arxiv_ids = [p.get("arxiv_id") for p in source_papers if p.get("arxiv_id")]
-    assert len(arxiv_ids) >= 2, f"fusion must cite ≥2 source_arxiv_ids; got {arxiv_ids}"
-
-    assert record.rigor_verdict is not None, "fusion strategy persisted without a rigor verdict"
+    # Rigor verdict shape present and has required fields
+    assert record.rigor_verdict is not None, "debate strategy persisted without a rigor verdict"
     verdict = json.loads(record.rigor_verdict)
-    # Real DSL backtest verdict: the four admission primitives + a passing bool.
     for key in ("dsr", "pbo", "oos_sharpe", "passing"):
         assert key in verdict, f"rigor verdict missing {key!r}: {verdict}"
     assert isinstance(verdict["passing"], bool)
-    # A non-null rigor verdict (real DSR/PBO/OOS) — at least one numeric metric
-    # populated, proving evaluate_fusion_spec actually ran a backtest.
-    assert any(verdict.get(k) is not None for k in ("dsr", "pbo", "oos_sharpe")), (
-        f"rigor verdict has no populated numeric metric (backtest didn't run?): {verdict}"
-    )
+
+
+# ── Test 4 — debate C-rigor threads _society_num_trials(library, pool) ────────
 
 
 @pytest.mark.asyncio
-async def test_fusion_path_num_trials_matches_society_formula(tmp_path, monkeypatch):
-    """#820: the fusion candidate must deflate for the SAME selection set as the
-    live agent path — library_size + selection_pool_size (_society_num_trials) —
-    not evaluate_fusion_spec's own library-size-only default.
+async def test_debate_critic_rigor_num_trials_matches_society_formula(tmp_path, monkeypatch):
+    """Debate C-rigor passes num_trials = _society_num_trials(library_size, pool_size)
+    to evaluate_fusion_spec — the same formula the live agent path uses.
 
-    Before this fix, ``selection_pool_size`` reached ``_run_fusion_candidate`` but
-    was never threaded into ``evaluate_fusion_spec``, so the fusion path silently
-    under-deflated relative to the live path for an identical (pool, library) pair.
-    The mock spec also carries a 3-variant ``parameter_variants`` grid, so this
-    also proves a small variant grid no longer silently overrides a bigger,
-    correct society count (the ``apply_rigor_gate`` composition fix).
+    Re-targets test_fusion_path_num_trials_matches_society_formula.  pool_size is
+    the society's own internal count of conformant proposals (the real selection
+    set), not n_candidates. The spy asserts evaluate_fusion_spec receives the right
+    value across the full proposal pool.
     """
     import archimedes.db as _db
+    import archimedes.agents.debate_engine as de
+    import archimedes.agents.strategy_fusion as sf
     import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp
-    from archimedes.agents import strategy_fusion as sf
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
 
     test_engine = create_engine(
-        f"sqlite:///{tmp_path / 'fusion_num_trials.db'}",
+        f"sqlite:///{tmp_path / 'debate_num_trials.db'}",
         connect_args={"check_same_thread": False},
     )
     monkeypatch.setattr(_db, "engine", test_engine)
@@ -694,32 +728,14 @@ async def test_fusion_path_num_trials_matches_society_formula(tmp_path, monkeypa
 
     _db.Base.metadata.create_all(bind=test_engine)
 
-    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
     monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
-    monkeypatch.setenv("GENERATION_PIPELINE_SKIP_BACKTEST", "1")
-    monkeypatch.setattr(gp, "_llm_available", lambda: True)
 
-    async def _permissive_validate(brief):
-        return {
-            "is_valid": True,
-            "intent_summary": brief.intent[:140],
-            "asset_classes_inferred": brief.asset_classes or [],
-            "time_horizon_inferred": "unknown",
-            "risk_appetite_adjusted": brief.risk_appetite,
-        }
+    async def _pv(brief):
+        return await _permissive_validate(brief)
 
-    monkeypatch.setattr(gp, "_validate_brief", _permissive_validate)
+    monkeypatch.setattr(gp, "_validate_brief", _pv)
 
-    corpus = _fixture_corpus(24)
-    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: corpus)
-    monkeypatch.setattr(
-        sf,
-        "default_fusion",
-        lambda: sf.StrategyFusion(backend=_MockFusionBackend(), corpus=corpus),
-    )
-
-    # Fixed, known library size (4) so the expected num_trials is computable —
-    # decoupled from however many strategies happen to be curated right now.
+    # Fixed library_size so _society_num_trials(library, pool) is computable.
     library_size = 4
 
     class _FakeStrategy:
@@ -734,109 +750,98 @@ async def test_fusion_path_num_trials_matches_society_formula(tmp_path, monkeypa
 
     monkeypatch.setattr(sp, "default_provider", lambda *a, **k: _FakeProvider())
 
+    # The pool has 3 proposals → pool_size = 3 inside _run_debate_leaderboard.
+    pool_size = 3
+    fake_corpus = _debate_fake_corpus(pool_size * 2)
+    fake_proposals = [
+        _make_fake_proposal(f"Debate {i}", [f"2401.0000{i}", f"2402.0000{i}"]) for i in range(1, pool_size + 1)
+    ]
+
+    # Spy on evaluate_fusion_spec — capture num_trials for every call.
     captured_num_trials: list[int | None] = []
-    real_evaluate = fe.evaluate_fusion_spec
 
-    def _spy_evaluate(spec_dict, **kwargs):
-        captured_num_trials.append(kwargs.get("num_trials"))
-        return real_evaluate(spec_dict, **kwargs)
+    def _spy_evaluate(spec, *, num_trials=None, use_real_data=False, **kw):
+        captured_num_trials.append(num_trials)
+        return _fake_eval_result(num_trials=num_trials)
 
+    # Setup hermetic stubs but override evaluate_fusion_spec with the spy.
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+    monkeypatch.setattr(de, "_debate_can_run", lambda brief: True)
+
+    async def _fake_pool(*a, **k):
+        return list(fake_proposals)
+
+    monkeypatch.setattr(de, "_propose_pool", _fake_pool)
+    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: list(fake_corpus))
     monkeypatch.setattr(fe, "evaluate_fusion_spec", _spy_evaluate)
+
+    async def _noop_debate_round(*a, **k):
+        return []
+
+    monkeypatch.setattr(de, "_debate_round", _noop_debate_round)
 
     store = _FakeStore()
     brief = GenerateBrief(
-        intent="equity momentum with a volatility overlay",
+        intent="equity momentum with volatility overlay",
         risk_appetite="moderate",
         asset_classes=["equities"],
     )
-    selection_pool_size = 5  # != library_size, so an additive bug can't hide by coincidence
-
     await run_generation(
-        job_id="job_fusion_num_trials",
+        job_id="job_debate_num_trials",
         brief=brief,
         store=store,
         dual_regime=False,
-        n_candidates=selection_pool_size,
+        n_candidates=1,
     )
 
-    assert captured_num_trials, "evaluate_fusion_spec was never called — fusion path did not run"
-    expected = gp._society_num_trials(library_size, selection_pool_size)
+    assert captured_num_trials, "evaluate_fusion_spec was never called — debate C-rigor did not run"
+    expected = gp._society_num_trials(library_size, pool_size)
     assert all(n == expected for n in captured_num_trials), (
-        f"fusion path num_trials {captured_num_trials} != live-path formula {expected} "
-        f"(library_size={library_size}, selection_pool_size={selection_pool_size})"
+        f"debate num_trials {captured_num_trials} != formula {expected} "
+        f"(library_size={library_size}, pool_size={pool_size})"
     )
 
-    # The verdict actually persisted must carry the same value through the
-    # variant-grid composition in apply_rigor_gate (max(), not a silent replace).
-    persisted = [e for e in store.events if e["event"] == "candidate_evaluated"]
-    assert persisted, "no candidate_evaluated event emitted"
-    for e in persisted:
+    # candidate_evaluated event carries the verdict; num_trials should match.
+    evaluated = [e for e in store.events if e["event"] == "candidate_evaluated"]
+    assert evaluated, "no candidate_evaluated event emitted"
+    for e in evaluated:
         verdict = e["data"].get("rigor_verdict") or {}
         if verdict.get("num_trials") is not None:
-            assert verdict["num_trials"] == expected
+            assert verdict["num_trials"] == expected, (
+                f"candidate_evaluated verdict num_trials={verdict['num_trials']} != {expected}"
+            )
 
 
-class _MockTextOnlyFusionBackend:
-    """Deterministic LLM stand-in returning a parseable fusion WITHOUT a
-    machine-readable strategy_spec — the *text-only* path (``has_real_rigor``
-    stays False).
-
-    This is the path that produced the live #784 conversion bug: such a candidate
-    carries ``weights={}`` AND ``has_real_rigor=False``, so before the fix it
-    slipped past the ``if not c.has_real_rigor`` skip-guard into the static-weights
-    backtester and emitted a misleading ``backtest_failed("no weights emitted by
-    agent")`` — making every Generate result look broken.
-    """
-
-    model_id = "mock-textonly-fusion"
-    served_model = "mock-textonly-fusion-served"
-
-    @property
-    def available(self) -> bool:
-        return True
-
-    def complete(self, system: str, user: str) -> str:
-        import json as _json
-        import re as _re
-
-        ids = _re.findall(r'"arxiv_id"\s*:\s*"([^"]+)"', user)[:3]
-        # NOTE: no "strategy_spec" key → proposal.strategy_spec is None → text-only.
-        return _json.dumps(
-            {
-                "strategy_name": "Mock Text-Only Fusion",
-                "thesis": "Fuses two papers as prose; no machine-readable DSL spec emitted.",
-                "source_arxiv_ids": ids,
-                "fusion_reasoning": "Paper A contributes trend timing; paper B vol scaling.",
-                "novelty_rationale": "Combination not published together.",
-                "risk_notes": "Pre-backtest hypothesis; rigor gate applies.",
-            }
-        )
+# ── Test 5 — debate winner with weights={} never causes spurious backtest_failed ─
 
 
 @pytest.mark.asyncio
-async def test_fusion_text_only_does_not_emit_spurious_backtest_failed(tmp_path, monkeypatch):
-    """Regression guard for the live #784 conversion bug.
+async def test_debate_text_only_pool_no_spurious_backtest_failed(tmp_path, monkeypatch):
+    """Regression guard (debate-path re-target of #784 live bug).
 
-    A text-only fusion candidate (no DSL spec → has_real_rigor=False) must NOT
-    emit the misleading ``backtest_failed("no weights emitted by agent")``. Fusion
-    candidates carry ``weights={}`` by design and must never be routed into the
-    static-weights backtester — the skip is keyed on ``generation_method``, not
-    ``has_real_rigor`` (which is False for the text-only path).
+    A debate winner has weights={} by design (it emits a DSL spec scored by
+    C-rigor, not a static weight vector). It must NOT be routed into
+    _backtest_and_persist (the static buy-and-hold backtester), which would
+    emit the misleading backtest_failed("no weights emitted by agent").
 
-    Hermetic: tmp SQLite DB, fixture corpus, mocked LLM backend — no network.
-    Crucially does NOT set GENERATION_PIPELINE_SKIP_BACKTEST: the bug only
-    manifests when ``_backtest_and_persist`` is actually reached (SKIP_BACKTEST
-    returns earlier, masking it).
+    Protection: generation_method='debate' is in _static_skip. Crucially, the
+    test does NOT set GENERATION_PIPELINE_SKIP_BACKTEST — the bug only surfaces
+    when _backtest_and_persist is actually reachable.
+
+    Re-targets test_fusion_text_only_does_not_emit_spurious_backtest_failed which
+    tested the same _static_skip guard on the retired standalone-fusion dispatch.
     """
     import archimedes.db as _db
+    import archimedes.agents.debate_engine as de
+    import archimedes.agents.strategy_fusion as sf
+    import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp
-    from archimedes.agents import strategy_fusion as sf
     from archimedes.models.strategy_store import StrategyRecord
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
 
     test_engine = create_engine(
-        f"sqlite:///{tmp_path / 'fusion_textonly.db'}",
+        f"sqlite:///{tmp_path / 'debate_textonly.db'}",
         connect_args={"check_same_thread": False},
     )
     monkeypatch.setattr(_db, "engine", test_engine)
@@ -845,97 +850,107 @@ async def test_fusion_text_only_does_not_emit_spurious_backtest_failed(tmp_path,
 
     _db.Base.metadata.create_all(bind=test_engine)
 
-    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
     monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
-    # Intentionally NOT setting GENERATION_PIPELINE_SKIP_BACKTEST — see docstring.
-    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+    # Intentionally NOT setting GENERATION_PIPELINE_SKIP_BACKTEST — the bug only
+    # manifests when _backtest_and_persist is reachable (SKIP_BACKTEST masks it).
 
-    async def _permissive_validate(brief):
-        return {
-            "is_valid": True,
-            "intent_summary": brief.intent[:140],
-            "asset_classes_inferred": brief.asset_classes or [],
-            "time_horizon_inferred": "unknown",
-            "risk_appetite_adjusted": brief.risk_appetite,
-        }
+    async def _pv(brief):
+        return await _permissive_validate(brief)
 
-    monkeypatch.setattr(gp, "_validate_brief", _permissive_validate)
+    monkeypatch.setattr(gp, "_validate_brief", _pv)
 
-    corpus = _fixture_corpus(24)
-    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: corpus)
-    monkeypatch.setattr(
-        sf,
-        "default_fusion",
-        lambda: sf.StrategyFusion(backend=_MockTextOnlyFusionBackend(), corpus=corpus),
+    fake_corpus = _debate_fake_corpus(4)
+    fake_proposals = [
+        _make_fake_proposal("Debate Winner", ["2401.00001", "2402.00001"]),
+    ]
+    _setup_debate_hermetic(
+        monkeypatch, gp=gp, de=de, sf=sf, fe=fe, fake_proposals=fake_proposals, fake_corpus=fake_corpus
     )
 
     store = _FakeStore()
     brief = GenerateBrief(
-        intent="equity momentum with a volatility overlay",
+        intent="equity momentum with volatility overlay",
         risk_appetite="moderate",
         asset_classes=["equities"],
     )
+    await run_generation(job_id="job_debate_textonly", brief=brief, store=store, dual_regime=False, n_candidates=1)
 
-    await run_generation(job_id="job_fusion_textonly", brief=brief, store=store, dual_regime=False, n_candidates=1)
-
-    # Fusion was dispatched (the candidate IS a fusion candidate).
+    # Debate was dispatched.
     ps = [e for e in store.events if e["event"] == "pipeline_selected"]
-    assert ps and ps[0]["data"]["pipeline"] == "fusion", f"fusion not dispatched: {ps}"
+    assert ps and ps[0]["data"]["pipeline"] == "debate", f"debate not dispatched: {ps}"
 
-    # The run still produced + persisted a candidate and finished cleanly.
+    # Run completed cleanly.
     names = [e["event"] for e in store.events]
     for required in ("candidate_drafted", "persisted", "done"):
-        assert required in names, f"text-only fusion run did not emit {required!r} (events={names})"
+        assert required in names, f"debate run did not emit {required!r} (events={names})"
 
-    # THE FIX: no spurious "no weights" backtest_failed for the fusion candidate.
+    # THE FIX: no spurious "no weights" backtest_failed for the debate winner.
     backtest_failed = [e for e in store.events if e["event"] == "backtest_failed"]
     spurious = [e for e in backtest_failed if "no weights" in (e["data"].get("error", "") or "")]
-    assert not spurious, f"fusion candidate was wrongly routed into the static backtester: {spurious}"
+    assert not spurious, f"debate winner (weights={{}}) was wrongly routed into the static backtester: {spurious}"
 
-    # Persisted as a fusion strategy (generation_method preserved).
+    # Persisted as a debate strategy.
     with _db.get_session() as session:
-        record = (
-            session.query(StrategyRecord)
-            .filter(
-                StrategyRecord.generation_method == "fusion",
-                StrategyRecord.strategy_name == "Mock Text-Only Fusion",
-            )
-            .first()
-        )
-    assert record is not None, "no text-only fusion StrategyRecord was persisted"
-    assert record.generation_method == "fusion"
+        record = session.query(StrategyRecord).filter(StrategyRecord.generation_method == "debate").first()
+    assert record is not None, "no debate StrategyRecord was persisted"
+    assert record.generation_method == "debate"
+
+
+# ── Test 6 — no-LLM dispatch: fixture path or GENERATION_UNAVAILABLE ──────────
 
 
 @pytest.mark.asyncio
-async def test_fusion_falls_back_to_agent_when_no_llm(monkeypatch):
-    """Fusion selected but no LLM → relabel to agent + run the fixture path.
+async def test_no_llm_testing_mode_selects_fixture_pipeline():
+    """Under TESTING with no LLM, dispatch selects the 'fixture' pipeline.
 
-    Confirms the agent FALLBACK still works when fusion can't run, and that the
-    pipeline_selected event is HONEST (says "agent", not "fusion").
+    The autouse fixture already sets GENERATION_PIPELINE_FIXTURE=1, which forces
+    _llm_available() → False AND sets fixture_mode=True. Asserts pipeline_selected
+    says 'fixture' and the run completes cleanly.
+
+    Replaces test_fusion_falls_back_to_agent_when_no_llm (which tested the
+    retired agent-fallback relabeling; fixture/GENERATION_UNAVAILABLE is now the
+    honest contract).
+    """
+    store = _FakeStore()
+    brief = GenerateBrief(intent="balanced macro", risk_appetite="moderate")
+    # autouse fixture forces GENERATION_PIPELINE_FIXTURE=1 → fixture path.
+    with patch(
+        "archimedes.agents.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_fixture_nollm", "0xfx")),
+    ):
+        await run_generation(job_id="job_nollm_testing", brief=brief, store=store, dual_regime=False, n_candidates=1)
+
+    ps = next(e for e in store.events if e["event"] == "pipeline_selected")
+    assert ps["data"]["pipeline"] == "fixture", (
+        f"no-LLM+fixture-env must select 'fixture', got {ps['data']['pipeline']!r}"
+    )
+    names = [e["event"] for e in store.events]
+    assert "candidate_drafted" in names
+    assert names[-1] == "done"
+
+
+@pytest.mark.asyncio
+async def test_no_llm_prod_shape_emits_generation_unavailable(monkeypatch):
+    """Prod shape (no TESTING, no fixture env, no LLM) → GENERATION_UNAVAILABLE.
+
+    With the retired agent-fallback removed, an LLM-less prod environment emits
+    an honest GENERATION_UNAVAILABLE error code and sets status to 'error'.
+    Completes the new no-LLM contract (both cases of TASK 1 test 6).
     """
     from archimedes.agents import generation_pipeline as gp
 
-    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
-    # Fixture path (no LLM) is forced by the file's autouse fixture; _pick_pipeline
-    # may still select fusion via the flag, but use_live=False must relabel.
-    monkeypatch.setattr(gp, "_pick_pipeline", lambda brief, mode_override=None: ("fusion", "forced fusion for test"))
+    monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(gp, "_llm_available", lambda: False)
 
     store = _FakeStore()
     brief = GenerateBrief(intent="balanced macro", risk_appetite="moderate")
+    await gp.run_generation(job_id="job_nollm_prod", brief=brief, store=store, dual_regime=False, n_candidates=1)
 
-    with patch(
-        "archimedes.agents.generation_pipeline._persist_candidate",
-        new=AsyncMock(return_value=("strat_fallback_001", "0xfb")),
-    ):
-        await run_generation(job_id="job_fusion_fallback", brief=brief, store=store, dual_regime=False, n_candidates=1)
-
-    ps = next(e for e in store.events if e["event"] == "pipeline_selected")
-    # No LLM (fixture path) → fusion is NOT runnable → honest relabel to agent.
-    assert ps["data"]["pipeline"] == "agent", (
-        f"fusion with no LLM must relabel to agent, got {ps['data']['pipeline']!r}"
+    err = next((e for e in store.events if e["event"] == "error"), None)
+    assert err is not None, "prod no-LLM must emit an error event"
+    assert err["data"]["code"] == "GENERATION_UNAVAILABLE", (
+        f"expected GENERATION_UNAVAILABLE, got {err['data']['code']!r}"
     )
-    # And the agent fallback still produced + persisted a candidate.
-    names = [e["event"] for e in store.events]
-    assert "candidate_drafted" in names
-    assert "persisted" in names
-    assert names[-1] == "done"
+    statuses = [s[0] for s in store.status]
+    assert "error" in statuses

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -629,7 +629,7 @@ async def test_debate_dispatch_end_to_end_persists_debate_strategy(tmp_path, mon
     emitted, (c) StrategyRecord.generation_method == 'debate'.
     """
     import archimedes.agents.debate_engine as de
-    import archimedes.agents.strategy_fusion as sf
+    from archimedes.agents import strategy_fusion as sf
     import archimedes.db as _db
     import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp
@@ -711,7 +711,7 @@ async def test_debate_critic_rigor_num_trials_matches_society_formula(tmp_path, 
     value across the full proposal pool.
     """
     import archimedes.agents.debate_engine as de
-    import archimedes.agents.strategy_fusion as sf
+    from archimedes.agents import strategy_fusion as sf
     import archimedes.db as _db
     import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp
@@ -832,7 +832,7 @@ async def test_debate_text_only_pool_no_spurious_backtest_failed(tmp_path, monke
     tested the same _static_skip guard on the retired standalone-fusion dispatch.
     """
     import archimedes.agents.debate_engine as de
-    import archimedes.agents.strategy_fusion as sf
+    from archimedes.agents import strategy_fusion as sf
     import archimedes.db as _db
     import archimedes.services.fusion_evaluator as fe
     from archimedes.agents import generation_pipeline as gp

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -343,24 +343,17 @@ async def test_propose_pool_drops_nonconformant_specs(monkeypatch, corpus):
 # ── Test 8 — flag-OFF byte-identical (fix A2) ─────────────────────────────────
 
 
-def test_pick_pipeline_never_returns_debate_when_flag_off(monkeypatch):
+def test_pick_pipeline_is_debate_unconditionally(monkeypatch):
+    """T1.1 Phase-3 cutover: the society IS the pipeline — no flag, no legacy
+    decision tree, and client mode overrides are accepted-but-ignored."""
     from archimedes.agents.generation_pipeline import _pick_pipeline
 
     monkeypatch.delenv("ARCHIMEDES_DEBATE_ENABLED", raising=False)
     brief = GenerateBrief(intent="momentum equities")
-    name, _reason = _pick_pipeline(brief, mode_override="debate")
-    assert name != "debate"
-    assert name in ("fusion", "architect", "agent")
-
-
-def test_pick_pipeline_returns_debate_when_flag_on(monkeypatch):
-    from archimedes.agents.generation_pipeline import _pick_pipeline
-
-    monkeypatch.setenv("ARCHIMEDES_DEBATE_ENABLED", "1")
-    brief = GenerateBrief(intent="momentum equities")
-    name, reason = _pick_pipeline(brief)
-    assert name == "debate"
-    assert "ARCHIMEDES_DEBATE_ENABLED" in reason
+    for override in (None, "fusion", "architect", "agent", "debate"):
+        name, reason = _pick_pipeline(brief, mode_override=override)
+        assert name == "debate", f"override {override!r} must not route off the society"
+        assert "Phase-3" in reason
 
 
 # ── Test 9 — cited-paper union non-empty; transcript fixed role order ─────────

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -71,7 +71,7 @@ class TestNumTrialsCorrection:
 
 def _candidate(candidate_id: str, return_series: list[float], num_trials: int) -> _CandidateResult:
     """Build a buy-and-hold society candidate with a real DSR verdict already computed
-    at ρ̄=0 (approach A) — the state each candidate is in right after ``_run_live_candidate``,
+    at ρ̄=0 (approach A) — the state each candidate is in after the debate runner,
     before the post-loop pool-correlation patch runs."""
     verdict = _rigor_verdict_for(return_series, num_trials=num_trials, lookahead_passed=True)
     verdict["pbo"] = 0.0  # mirrors _patch_pbo's N<2 default; patch under test runs after PBO

--- a/backend/tests/test_strategy_custom_names.py
+++ b/backend/tests/test_strategy_custom_names.py
@@ -134,11 +134,11 @@ async def test_winner_gets_user_name_rejects_keep_auto_names(persisted):
     assert rejects[0]["strategy_name"] != "Dan's Custom Alpha"
     assert "—" in rejects[0]["strategy_name"]  # fixture auto-name template
 
-    # The rename landed BEFORE persistence: the persisted record set contains
-    # the user's name exactly once (winner) and the auto name for the reject.
-    persisted_names = sorted(name for _cid, name in persisted)
-    assert persisted_names.count("Dan's Custom Alpha") == 1
-    assert len(persisted_names) == 2
+    # K=1 (Phase-3): ONLY the winner is persisted as a strategy, carrying the
+    # user's name; the reject lives in the candidates payload + episodic
+    # proposals, never as a StrategyRecord.
+    persisted_names = [name for _cid, name in persisted]
+    assert persisted_names == ["Dan's Custom Alpha"]
 
 
 async def test_no_name_keeps_auto_names_for_all(persisted):
@@ -151,5 +151,7 @@ async def test_no_name_keeps_auto_names_for_all(persisted):
     for c in result["candidates"]:
         # Auto-derived fixture names embed the intent snippet + risk appetite.
         assert "dual regime trend following" in c["strategy_name"]
-    # Persisted names match the surfaced names (nothing renamed on the way in).
-    assert sorted(name for _cid, name in persisted) == sorted(c["strategy_name"] for c in result["candidates"])
+    # K=1: exactly the WINNER is persisted, under its auto-derived name.
+    selected = [c for c in result["candidates"] if c["selected"]]
+    assert len(persisted) == 1 and len(selected) == 1
+    assert persisted[0][1] == selected[0]["strategy_name"]

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -342,7 +342,7 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
       )}
 
       {showRejected && (
-        <RejectedCandidates jobId={jobId} onClose={() => setShowRejected(false)} />
+        <RejectedCandidates jobId={jobId} onClose={() => setShowRejected(false)} onNavigate={onNavigate} />
       )}
     </div>
   )

--- a/ui/src/components/RejectedCandidates.jsx
+++ b/ui/src/components/RejectedCandidates.jsx
@@ -118,7 +118,7 @@ export default function RejectedCandidates({ jobId, onClose, onNavigate }) {
             <h3 style={{ marginBottom: 4 }}>Considered alternatives</h3>
             <p className="caption" style={{ marginBottom: 0 }}>
               The debate society ranked {candidates.length} candidate{candidates.length !== 1 ? 's' : ''};
-              the winner passed the rigor gate and was persisted to the library.
+              the top-ranked candidate was persisted to the library (see its tag for rigor status).
               Alternates are episodic proposals — no library entry.
             </p>
           </div>

--- a/ui/src/components/RejectedCandidates.jsx
+++ b/ui/src/components/RejectedCandidates.jsx
@@ -2,11 +2,68 @@ import { useEffect, useState } from 'react'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
-// Modal-ish overlay showing all candidates the agent produced for a job.
-// The 'best' one was surfaced in the main flow; this view lets the user see
-// the others and why they weren't picked.
+// Considered-Alternatives panel — upgraded for the T1.1 Phase-3 fan-out.
+//
+// Data shape (GET /api/generate/jobs/{job_id}/candidates):
+//   candidates: ranked leaderboard (entry order = society rank); one entry has
+//   selected=true (the winner); alternates carry strategy_id=null (episodic
+//   proposals, not library strategies — no dead links); every entry has a
+//   rigor_verdict with dsr, dsr_p_value, pbo, oos_sharpe, or a 'reason' for
+//   abstain/text-only entries; generation_method="debate_abstain" entries get
+//   the abstain framing.
 
-export default function RejectedCandidates({ jobId, onClose }) {
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function fmt(val, digits = 3) {
+  if (val == null || (typeof val === 'number' && !isFinite(val))) return '—'
+  return Number(val).toFixed(digits)
+}
+
+// Compact rigor chip: coloured label + value
+function RigorChip({ label, value, bad }) {
+  const color = value === '—'
+    ? 'var(--text-4)'
+    : bad
+      ? 'var(--negative, #ef4444)'
+      : 'var(--positive, #22c55e)'
+  return (
+    <span style={{ marginRight: 10, whiteSpace: 'nowrap' }}>
+      <span style={{ color: 'var(--text-4)' }}>{label}</span>
+      {' '}
+      <strong style={{ color }}>{value}</strong>
+    </span>
+  )
+}
+
+// Regime tag: bull / bear / neutral
+function RegimeTag({ regime }) {
+  if (!regime || regime === 'neutral') return null
+  const bull = regime === 'bull'
+  return (
+    <span className="tag" style={{
+      background: bull ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)',
+      color: bull ? 'var(--positive, #22c55e)' : 'var(--negative, #ef4444)',
+      marginLeft: 6,
+    }}>
+      <span className={bull ? 'i-lucide-trending-up w-3.5 h-3.5' : 'i-lucide-trending-down w-3.5 h-3.5'} />
+      {' '}{bull ? 'Bull' : 'Bear'}
+    </span>
+  )
+}
+
+function isAbstain(c) {
+  return c.generation_method === 'debate_abstain'
+}
+
+function rejectReason(c) {
+  if (isAbstain(c)) return c.rigor_verdict?.reason || 'Debate abstain — hold current weights'
+  if (c.rigor_verdict?.reason) return c.rigor_verdict.reason
+  return 'Outranked by the society leader'
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export default function RejectedCandidates({ jobId, onClose, onNavigate }) {
   const [data, setData] = useState(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
@@ -21,14 +78,25 @@ export default function RejectedCandidates({ jobId, onClose }) {
     return () => { cancelled = true }
   }, [jobId])
 
+  // Partition: winner first, then up to 10 alternates (society order preserved)
+  const candidates = data?.candidates ?? []
+  const winner = candidates.find(c => c.selected)
+  const alternates = candidates.filter(c => !c.selected).slice(0, 10)
+
+  const goToStrategy = (strategyId) => {
+    if (!strategyId) return
+    if (onNavigate) {
+      onNavigate('strategy', { strategyId })
+    } else {
+      window.location.hash = `#/strategy/${encodeURIComponent(strategyId)}`
+    }
+    onClose?.()
+  }
+
   return (
     <div
       onClick={onClose}
       style={{
-        // Bumped backdrop opacity 0.6 → 0.85 so the modal body pops; the
-        // inner card also gets a solid background + border + drop-shadow so
-        // the page's glass-blur 'card' class doesn't render translucent
-        // over the dimmed backdrop (which had been leaving text semi-readable).
         position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.85)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
         zIndex: 1000, padding: 20,
@@ -44,83 +112,153 @@ export default function RejectedCandidates({ jobId, onClose }) {
           boxShadow: '0 24px 48px rgba(0,0,0,0.5)',
         }}
       >
+        {/* Header */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
           <div>
-            <h3 style={{ marginBottom: 4 }}>Candidates considered</h3>
+            <h3 style={{ marginBottom: 4 }}>Considered alternatives</h3>
             <p className="caption" style={{ marginBottom: 0 }}>
-              The agent generated multiple candidates and picked the best by rigor verdict.
-              The others are shown here for inspection.
+              The debate society ranked {candidates.length} candidate{candidates.length !== 1 ? 's' : ''};
+              the winner passed the rigor gate and was persisted to the library.
+              Alternates are episodic proposals — no library entry.
             </p>
           </div>
-          <button className="btn btn-outline btn-sm" onClick={onClose}>Close</button>
+          <button className="btn btn-outline btn-sm" onClick={onClose} style={{ flexShrink: 0, marginLeft: 12 }}>
+            Close
+          </button>
         </div>
 
         {loading && <div className="caption">Loading…</div>}
         {error && <div className="info-box warning">{error}</div>}
 
-        {data && data.candidates?.length === 0 && (
+        {!loading && !error && candidates.length === 0 && (
           <div className="caption">No candidate data on file for this job.</div>
         )}
 
-        {data && data.candidates?.length > 0 && (
+        {!loading && !error && candidates.length > 0 && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {data.candidates.map(c => (
-              <div
-                key={c.candidate_id}
-                className="card-flat"
-                style={{
-                  padding: 12,
-                  border: c.selected ? '1px solid var(--accent)' : '1px solid var(--glass-border)',
-                  background: c.selected ? 'rgba(255,209,102,0.06)' : 'transparent',
-                }}
-              >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
-                  <div>
-                    <strong>{c.strategy_name || c.candidate_id}</strong>
-                    <span className="caption" style={{ marginLeft: 8 }}>({c.candidate_id})</span>
-                  </div>
-                  <div style={{ display: 'flex', gap: 6 }}>
-                    {c.regime && c.regime !== 'neutral' && (
-                      <span className="tag" style={{
-                        background: c.regime === 'bull' ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)',
-                        color: c.regime === 'bull' ? 'var(--positive, #22c55e)' : 'var(--negative, #ef4444)',
-                      }}>
-                        {c.regime === 'bull'
-                          ? <><span className="i-lucide-trending-up w-3.5 h-3.5" /> Bull</>
-                          : <><span className="i-lucide-trending-down w-3.5 h-3.5" /> Bear</>}
-                      </span>
-                    )}
-                    {c.selected && <span className="tag tag-accent">Selected</span>}
-                    {c.passes_rigor
-                      ? <span className="tag tag-positive">Passes rigor</span>
-                      : <span className="tag tag-negative">Failed rigor</span>}
-                  </div>
-                </div>
-                {c.rigor_verdict && (
-                  <div className="caption" style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-                    <span>DSR: <strong style={{ color: c.rigor_verdict.dsr != null && c.rigor_verdict.dsr < 0.5 ? 'var(--negative)' : undefined }}>
-                      {c.rigor_verdict.dsr != null ? c.rigor_verdict.dsr.toFixed(3) : '—'}
-                    </strong></span>
-                    <span>PBO: <strong style={{ color: c.rigor_verdict.pbo != null && c.rigor_verdict.pbo > 0.5 ? 'var(--negative)' : undefined }}>
-                      {c.rigor_verdict.pbo != null ? c.rigor_verdict.pbo.toFixed(3) : '—'}
-                    </strong></span>
-                    <span>OOS Sharpe: <strong>
-                      {c.rigor_verdict.oos_sharpe != null ? c.rigor_verdict.oos_sharpe.toFixed(3) : '—'}
-                    </strong></span>
-                    <span>Lookahead: {c.rigor_verdict.lookahead_audit_passed !== false
-                      ? <span style={{ color: 'var(--positive)' }}>✓</span>
-                      : <span style={{ color: 'var(--negative)' }}>✗</span>}
-                    </span>
-                    {c.rigor_verdict.reason && (
-                      <span style={{ color: 'var(--text-4)', fontStyle: 'italic' }}>{c.rigor_verdict.reason}</span>
-                    )}
+
+            {/* Winner — pinned first with trophy treatment */}
+            {winner && (
+              <CandidateRow
+                c={winner}
+                rank={1}
+                isWinner
+                onNavigate={winner.strategy_id ? goToStrategy : null}
+              />
+            )}
+
+            {/* Alternates (up to 10, society order) */}
+            {alternates.length > 0 && (
+              <>
+                {alternates.length > 0 && candidates.length > 1 && (
+                  <div className="label" style={{ marginTop: 4, marginBottom: 2, color: 'var(--text-4)', fontSize: '0.75rem' }}>
+                    ALTERNATES
                   </div>
                 )}
+                {alternates.map((c, i) => (
+                  <CandidateRow key={c.candidate_id} c={c} rank={i + 2} isWinner={false} onNavigate={null} />
+                ))}
+              </>
+            )}
+
+            {/* Edge case: exactly 1 candidate, no alternates */}
+            {candidates.length === 1 && (
+              <div className="caption" style={{ color: 'var(--text-4)', marginTop: 4 }}>
+                The society produced a single candidate this run.
               </div>
-            ))}
+            )}
           </div>
         )}
       </div>
+    </div>
+  )
+}
+
+// ── CandidateRow ─────────────────────────────────────────────────────────
+
+function CandidateRow({ c, rank, isWinner, onNavigate }) {
+  const rv = c.rigor_verdict || {}
+  const abstain = isAbstain(c)
+
+  // Rigor chip values
+  const dsrP = rv.dsr_p_value != null ? fmt(rv.dsr_p_value) : '—'
+  const pbo   = rv.pbo != null ? fmt(rv.pbo) : '—'
+  const oos   = rv.oos_sharpe != null ? fmt(rv.oos_sharpe) : '—'
+
+  // Colour guidance
+  const dsrBad = rv.dsr_p_value != null && rv.dsr_p_value < 0.95
+  const pboBad  = rv.pbo != null && rv.pbo >= 0.5
+  const oosBad  = rv.oos_sharpe != null && rv.oos_sharpe <= 0
+
+  return (
+    <div
+      className="card-flat"
+      style={{
+        padding: 12,
+        border: isWinner ? '1px solid var(--accent)' : '1px solid var(--glass-border)',
+        background: isWinner ? 'rgba(255,209,102,0.06)' : 'transparent',
+      }}
+    >
+      {/* Row header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 6 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+          {/* Rank / trophy */}
+          {isWinner
+            ? <span style={{ fontSize: '1rem' }}>&#x1F3C6;</span>
+            : <span className="caption" style={{ color: 'var(--text-4)', minWidth: 20 }}>#{rank}</span>}
+          <strong style={{ fontSize: '0.9rem' }}>{c.strategy_name || c.candidate_id}</strong>
+          <RegimeTag regime={c.regime} />
+          {abstain && (
+            <span className="tag" style={{ background: 'rgba(255,209,102,0.15)', color: 'var(--accent)' }}>
+              Abstain
+            </span>
+          )}
+        </div>
+
+        {/* Tags: selected / rigor pass */}
+        <div style={{ display: 'flex', gap: 6, flexShrink: 0, marginLeft: 8 }}>
+          {isWinner && <span className="tag tag-accent">Selected</span>}
+          {!abstain && (
+            c.passes_rigor
+              ? <span className="tag tag-positive">Passes rigor</span>
+              : <span className="tag tag-negative">Failed rigor</span>
+          )}
+        </div>
+      </div>
+
+      {/* Rigor chips (skip for abstain — those have no real stats) */}
+      {!abstain && (
+        <div className="caption" style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', marginBottom: 4 }}>
+          <RigorChip label="DSR p" value={dsrP} bad={dsrBad} />
+          <RigorChip label="PBO" value={pbo} bad={pboBad} />
+          <RigorChip label="OOS" value={oos} bad={oosBad} />
+        </div>
+      )}
+
+      {/* Abstain body */}
+      {abstain && rv.reason && (
+        <div className="caption" style={{ color: 'var(--text-3)', fontStyle: 'italic', marginBottom: 4 }}>
+          {rv.reason}
+        </div>
+      )}
+
+      {/* Reject reason (alternates only) */}
+      {!isWinner && !abstain && (
+        <div className="caption" style={{ color: 'var(--text-4)', marginTop: 2 }}>
+          {rejectReason(c)}
+        </div>
+      )}
+
+      {/* Winner link — only when strategy_id is present */}
+      {isWinner && onNavigate && c.strategy_id && (
+        <button
+          className="btn btn-outline btn-sm"
+          style={{ marginTop: 8 }}
+          onClick={() => onNavigate(c.strategy_id)}
+        >
+          View strategy passport →
+        </button>
+      )}
     </div>
   )
 }

--- a/ui/src/components/RejectedCandidates.jsx
+++ b/ui/src/components/RejectedCandidates.jsx
@@ -150,7 +150,7 @@ export default function RejectedCandidates({ jobId, onClose, onNavigate }) {
             {/* Alternates (up to 10, society order) */}
             {alternates.length > 0 && (
               <>
-                {alternates.length > 0 && candidates.length > 1 && (
+                {candidates.length > 1 && (
                   <div className="label" style={{ marginTop: 4, marginBottom: 2, color: 'var(--text-4)', fontSize: '0.75rem' }}>
                     ALTERNATES
                   </div>


### PR DESCRIPTION
## Summary

The staged replacement completes (ROADMAP C1 / spec §Phase-3): the debate society becomes the **sole** generation pipeline, the three legacy single-agent paths are **deleted** (not just bypassed), and the society's full ranked leaderboard fans out into the Considered-Alternatives surface.

## What changed

**Cutover (no silent fallbacks, ever):**
- `_pick_pipeline` → debate unconditionally; client `mode` accepted-but-ignored (API compat); `ARCHIMEDES_DEBATE_ENABLED` retired (deleted, per the #834 flag audit).
- Not runnable → honest `GENERATION_UNAVAILABLE`; runtime society abstention → honest first-class ABSTAIN. The deterministic fixture runner survives strictly for hermetic tests.
- **Deleted with grep-proofs:** `_run_live_candidate` (the streaming single-agent), `_run_fusion_candidate` (single-shot fusion), `_fusion_can_run`, architect remnants, `debate_enabled()`.

**Considered-Alternatives fan-out:**
- `_run_debate_leaderboard` returns the full ranked board; every entry is drafted/evaluated on the stream and lands in the candidates payload (alternates carry `strategy_id=null`).
- Selection **respects the society's deterministic rank** — verified by counterexample (a higher-DSR runner-up must NOT usurp the leader).
- **K=1 persistence:** only the winner becomes a StrategyRecord (+passport+trace+real returns); the whole board is content-hashed into episodic `strategy_proposals` (single writer, verdict selected/rejected + honest reject reason). The rejected-strategy-orphan pattern is dead by construction.
- UI: `RejectedCandidates` panel renders the ranked board — winner pinned, rigor chips per alternate (DSR-p/PBO/OOS), reject reasons, honest abstain framing, no dead links for unpersisted alternates.

## Verify
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest -m "not integration" -q   # 2347 passed
grep -rn "_run_fusion_candidate\|_run_live_candidate\|_fusion_can_run\|debate_enabled" backend/archimedes/  # no live references
```
Adversarially verified end-to-end (full suite + deletion proofs + executed contract counterexamples); both minor findings from the verify fixed in the final commit.

## Anti-goals
- `portfolio_agent.py` (the allocation advisor) untouched — separate disposition decision.
- No rigor/gate changes; `_backtest_and_persist`/fixture path preserved for tests.

Closes the Phase-3 line of #815/#816. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M