### PR TITLE
[quant] Fix rigor gate root causes: degenerate series, look-ahead false positives, stale leaderboard (#868)

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -7,6 +7,7 @@ page (shows full gate breakdown).
 
 from __future__ import annotations
 
+import numpy as np
 from fastapi import APIRouter, Request, Response
 
 from archimedes.api.limiter import limiter
@@ -172,8 +173,22 @@ async def evaluate_rigor_gate():
     # meaningless. The stubs remain available for UI display (portfolio page)
     # but must not feed into the rigor gate.
 
-    # Compute PBO across all strategies that have returns
-    valid_returns = {k: v for k, v in returns_by_strategy.items() if len(v) >= 10}
+    # Compute PBO across all strategies that have returns. Exclude zero-variance
+    # (degenerate/placeholder-flat) series BEFORE they can inflate num_trials or
+    # dilute avg_correlation (#868): a flat daily_returns series (e.g. a stub row
+    # that was never replaced with a real backtest) has no informational content,
+    # but counting it toward the multiple-testing correction still stiffens DSR
+    # for every REAL strategy in the cohort. Mirrors the exact degeneracy test
+    # _rigor_helpers._sharpe_dsr_inputs already uses (np.ptp(arr) == 0 — peak-to-
+    # peak range zero) so "degenerate" means the same thing everywhere in the
+    # gate. This only trims the cohort-level context (num_trials/avg_correlation/
+    # pbo_scores below); the per-strategy gate loop still runs every strategy
+    # (including degenerate ones) against its own returns via
+    # returns_by_strategy.get(s.id, []) so a degenerate strategy still correctly
+    # reports MISSING/FAIL on its own row instead of silently disappearing.
+    valid_returns = {
+        k: v for k, v in returns_by_strategy.items() if len(v) >= 10 and float(np.ptp(np.asarray(v, dtype=float))) > 0.0
+    }
     pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
 
     # num_trials = library size here (#770). This route grades the EXISTING persisted

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -13,6 +13,7 @@ import logging
 import math
 from datetime import UTC
 
+import numpy as np
 from fastapi import APIRouter, Depends, Query, Request, Response
 
 from archimedes.api._route_helpers import (
@@ -42,6 +43,7 @@ from archimedes.services.live_rigor_gate import (
     verdict_from_returns,
     verdicts_for_strategies,
 )
+from archimedes.services.rigor_evaluator import RigorGateResult
 from archimedes.services.strategy_guardrail import apply_guardrail
 
 logger = logging.getLogger(__name__)
@@ -49,7 +51,11 @@ logger = logging.getLogger(__name__)
 strategies_router = APIRouter(prefix="/api/strategies", tags=["strategies"])
 
 
-def _to_strategy_response(s: Strategy, verdict: RigorGateVerdict | None = None) -> StrategyResponse:
+def _to_strategy_response(
+    s: Strategy,
+    verdict: RigorGateVerdict | None = None,
+    rigor_result: RigorGateResult | None = None,
+) -> StrategyResponse:
     """Map StrategyPassport + persisted BacktestResult to API schema.
 
     ``verdict`` is the LIVE rigor-gate verdict for this strategy (#821), computed
@@ -59,12 +65,24 @@ def _to_strategy_response(s: Strategy, verdict: RigorGateVerdict | None = None) 
     fixture boolean. When ``verdict is None`` (single-strategy fetch) it is computed
     on demand here. A strategy with no real returns yields a ``pending`` verdict so
     the badge surfaces "unknown" rather than a fixture ``True``/``False``.
+
+    ``rigor_result`` is the companion full ``RigorGateResult`` (#868) — the SAME
+    live gate run ``verdict`` was reduced from — used to serve the numeric fields
+    (``deflated_sharpe_ratio``, ``dsr_p_value``, ``pbo_score``,
+    ``out_of_sample_sharpe``) so the leaderboard can never disagree with
+    ``GET /api/selection-bias/gate`` for a given strategy id. ``None`` means the
+    live gate could not run for this strategy (no/insufficient persisted returns,
+    or a batch/DB failure); the numeric fields then fall back to the stale
+    ``s.<field>``/``bt.<field>`` fixture values exactly as before — the fallback
+    is unchanged, only the preferred source is new. When ``verdict is None``
+    (single-strategy fetch) ``rigor_result`` is also computed on demand here.
     """
     from archimedes.api.schemas import PaperRefResponse
     from archimedes.services.return_source_classifier import classify_strategy
 
     if verdict is None:
         verdict = _live_verdict_for_one(s)
+        rigor_result = _live_rigor_result_for_one(s)
 
     bt = strategy_provider.get_backtest_result(s.id)
     has_real = s.real_sharpe is not None
@@ -124,10 +142,33 @@ def _to_strategy_response(s: Strategy, verdict: RigorGateVerdict | None = None) 
         calmar_ratio=s.real_calmar if has_real else (bt.calmar_ratio if bt else s.stub_calmar),
         correlation_to_spy=s.real_corr_spy if has_real else (bt.correlation_to_spy if bt else s.stub_corr_spy),
         total_trades=s.real_total_trades if has_real else (bt.total_trades if bt else None),
-        deflated_sharpe_ratio=s.deflated_sharpe_ratio if has_real else (bt.deflated_sharpe_ratio if bt else None),
-        dsr_p_value=s.dsr_p_value if has_real else (bt.dsr_p_value if bt else None),
-        pbo_score=s.pbo_score if has_real else (bt.pbo_score if bt else None),
-        out_of_sample_sharpe=s.out_of_sample_sharpe if has_real else (bt.out_of_sample_sharpe if bt else None),
+        # Numeric rigor fields (#868): prefer the LIVE gate result — the SAME
+        # run_rigor_gate call that produced `verdict` above — so the leaderboard
+        # can never disagree with GET /api/selection-bias/gate for this id.
+        # rigor_result is None when the live gate could not run (no/insufficient
+        # persisted returns, or a batch failure); fall back to the stale
+        # s.<field>/bt.<field> fixture values exactly as before in that case —
+        # only the preferred source changed, the fallback chain is unchanged.
+        deflated_sharpe_ratio=(
+            rigor_result.deflated_sharpe
+            if rigor_result is not None
+            else (s.deflated_sharpe_ratio if has_real else (bt.deflated_sharpe_ratio if bt else None))
+        ),
+        dsr_p_value=(
+            rigor_result.dsr_p_value
+            if rigor_result is not None
+            else (s.dsr_p_value if has_real else (bt.dsr_p_value if bt else None))
+        ),
+        pbo_score=(
+            rigor_result.pbo_score
+            if rigor_result is not None
+            else (s.pbo_score if has_real else (bt.pbo_score if bt else None))
+        ),
+        out_of_sample_sharpe=(
+            rigor_result.oos_sharpe
+            if rigor_result is not None
+            else (s.out_of_sample_sharpe if has_real else (bt.out_of_sample_sharpe if bt else None))
+        ),
         kelly_fraction=s.kelly_fraction,
         # Badge from the LIVE gate verdict (#821) — never the fixture boolean.
         # passes_rigor_gate is the fail-closed boolean (True only when status=="pass");
@@ -189,6 +230,158 @@ def _live_verdict_for_one(s: Strategy) -> RigorGateVerdict:
     )
 
 
+def _live_rigor_result_for_one(s: Strategy) -> RigorGateResult | None:
+    """Full live ``RigorGateResult`` for a single strategy (#868).
+
+    Companion to ``_live_verdict_for_one``: that function reduces the live gate
+    to the tri-state pass/fail/pending badge (``RigorGateVerdict`` carries no
+    numeric fields), but the served leaderboard numbers (``dsr_p_value``,
+    ``pbo_score``, ``out_of_sample_sharpe``, ``deflated_sharpe_ratio``) must
+    also come from the SAME live gate run, not the stale ``s.dsr_p_value`` /
+    ``bt.dsr_p_value`` fixture fields — otherwise the leaderboard can show
+    numbers that disagree with what ``GET /api/selection-bias/gate`` computes
+    for the same strategy right now. Mirrors ``_live_verdict_for_one``'s DB
+    read + code load exactly (num_trials=1, single-strategy context, no
+    cohort). Returns ``None`` on no/insufficient persisted returns or any
+    failure — the caller must fall back to the stale fixture fields rather
+    than fabricate a number, matching the fail-closed badge contract.
+    """
+    try:
+        from archimedes.db import get_session, init_db
+        from archimedes.services.backtest_repository import get_daily_returns
+
+        init_db()
+        with get_session() as session:
+            daily_returns = get_daily_returns(session, s.id)
+    except Exception as exc:
+        logger.warning("live rigor result DB read failed for %s (numbers → stale fallback): %s", s.id, exc)
+        return None
+
+    if not daily_returns or len(daily_returns) < 10:
+        return None
+
+    code = None
+    if s.strategy_code_path:
+        from archimedes.api.selection_bias_routes import _load_strategy_code
+
+        with contextlib.suppress(Exception):
+            code = _load_strategy_code(s.strategy_code_path)
+
+    from archimedes.services.rigor_evaluator import run_rigor_gate
+
+    try:
+        return run_rigor_gate(
+            strategy_id=s.id,
+            daily_returns=daily_returns,
+            num_trials=1,
+            strategy_code=code,
+            in_sample_sharpe=None,
+            paper_claimed_sharpe=s.paper_claimed_sharpe,
+        )
+    except Exception as exc:
+        logger.warning("live rigor gate failed for %s (numbers → stale fallback): %s", s.id, exc)
+        return None
+
+
+def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, RigorGateResult]:
+    """Batch live ``RigorGateResult`` per strategy (#868), for the library list.
+
+    Companion to ``verdicts_for_strategies``: that function collapses the live
+    gate to a tri-state pass/fail/pending badge, discarding the underlying
+    DSR/PBO/OOS numbers. The served leaderboard numeric fields must equal what
+    ``GET /api/selection-bias/gate`` computes for the same strategy right now
+    (not the stale ``s.dsr_p_value``/``bt.dsr_p_value`` fixture fields), so this
+    mirrors that route's cohort context exactly: real persisted returns from
+    the DB, zero-variance series excluded before they can inflate num_trials or
+    dilute avg_correlation (same fix as #868's selection_bias_routes.py change),
+    cohort PBO + avg-correlation over the survivors, one ``run_rigor_gate`` call
+    per strategy. Strategies with no/insufficient persisted returns or a
+    degenerate series are simply absent from the returned dict — the caller
+    falls back to the stale fixture fields for those ids (fail-closed: no
+    fabricated number for a strategy the live gate cannot evaluate).
+
+    Any DB or cohort-compute failure degrades to ``{}`` (every id falls back to
+    the stale fields) rather than raising into the library-list response.
+    """
+    if not strategies:
+        return {}
+
+    strategy_ids = [s.id for s in strategies]
+
+    try:
+        from archimedes.db import get_session, init_db
+        from archimedes.services.backtest_repository import get_all_daily_returns
+        from archimedes.services.rigor_evaluator import (
+            compute_average_pairwise_correlation,
+            compute_pbo,
+            run_rigor_gate,
+        )
+
+        init_db()
+        with get_session() as session:
+            returns_by_strategy = get_all_daily_returns(session, strategy_ids)
+    except Exception as exc:
+        logger.warning("live rigor result batch: DB read failed (all → stale fallback): %s", exc)
+        return {}
+
+    # Exclude zero-variance (degenerate/placeholder-flat) series from the cohort
+    # context — same fix as selection_bias_routes.py's valid_returns filter
+    # (#868), so num_trials/avg_correlation/pbo_scores here match that route's
+    # library-wide gate exactly rather than drifting apart on this input.
+    valid_returns = {
+        k: v for k, v in returns_by_strategy.items() if len(v) >= 10 and float(np.ptp(np.asarray(v, dtype=float))) > 0.0
+    }
+
+    try:
+        pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
+        num_trials = max(len(valid_returns), 1)
+        avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+    except Exception as exc:
+        logger.warning("live rigor result batch: cohort-context compute failed (all → stale fallback): %s", exc)
+        return {}
+
+    code_by_id = {s.id: _load_strategy_code_safe_local(s) for s in strategies if s.id in valid_returns}
+
+    results: dict[str, RigorGateResult] = {}
+    for s in strategies:
+        if s.id not in valid_returns:
+            continue
+        daily_returns = returns_by_strategy.get(s.id, [])
+        try:
+            results[s.id] = run_rigor_gate(
+                strategy_id=s.id,
+                daily_returns=daily_returns,
+                num_trials=num_trials,
+                pbo_scores=pbo_scores,
+                strategy_code=code_by_id.get(s.id),
+                in_sample_sharpe=None,
+                paper_claimed_sharpe=getattr(s, "paper_claimed_sharpe", None),
+                average_correlation=avg_correlation,
+            )
+        except Exception as exc:
+            logger.warning("live rigor gate failed for %s in batch (numbers → stale fallback): %s", s.id, exc)
+    return results
+
+
+def _load_strategy_code_safe_local(strategy: Strategy) -> str | None:
+    """Best-effort strategy-source read for the batch look-ahead audit input.
+
+    Local twin of ``live_rigor_gate._load_strategy_code_safe`` (out of scope for
+    #868 — that module is untouched) so ``_live_rigor_results_for_strategies``
+    doesn't need to reach into it. Never raises: ``None`` on any failure, which
+    makes the gate's look-ahead leg fail rather than crash the library list.
+    """
+    code_path = getattr(strategy, "strategy_code_path", None)
+    if not code_path:
+        return None
+    try:
+        from archimedes.api.selection_bias_routes import _load_strategy_code
+
+        return _load_strategy_code(code_path)
+    except Exception:
+        return None
+
+
 # ── Library listing ─────────────────────────────────────────────
 
 
@@ -206,6 +399,13 @@ async def list_strategies(
     Verdicts are computed once for the page window (one DB read + one library-wide
     PBO/num_trials context) and threaded into each serializer.
 
+    The numeric rigor fields (``dsr_p_value``, ``pbo_score``, ``out_of_sample_sharpe``,
+    ``deflated_sharpe_ratio``) come from the SAME live gate run via
+    ``_live_rigor_results_for_strategies`` (#868), so the leaderboard can never
+    disagree with ``/api/selection-bias/gate`` for a given strategy id — previously
+    only the ``passes_rigor_gate`` boolean read the live verdict while these numbers
+    still read the stale fixture-derived fields.
+
     NOTE on the ``status`` filter: it filters on the file-declared status BEFORE the
     live-gate promotion overlay, so a CANDIDATE that the live gate promotes to
     VALIDATED still appears under ``?status=candidate`` (its stored status) with a
@@ -217,8 +417,9 @@ async def list_strategies(
     total = len(strats)
     window = strats[offset : offset + limit]
     verdicts = verdicts_for_strategies(window)
+    rigor_results = _live_rigor_results_for_strategies(window)
     return StrategyListResponse(
-        strategies=[_to_strategy_response(s, verdicts.get(s.id)) for s in window],
+        strategies=[_to_strategy_response(s, verdicts.get(s.id), rigor_results.get(s.id)) for s in window],
         total=total,
     )
 

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -340,23 +340,40 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
         logger.warning("live rigor result batch: cohort-context compute failed (all → stale fallback): %s", exc)
         return {}
 
-    code_by_id = {s.id: _load_strategy_code_safe_local(s) for s in strategies if s.id in valid_returns}
+    # Load code for every strategy that has >= 10 returns — degenerate series
+    # (excluded from valid_returns) still run their own gate (#868) and need the
+    # look-ahead audit input.
+    code_by_id = {
+        s.id: _load_strategy_code_safe_local(s) for s in strategies if len(returns_by_strategy.get(s.id, [])) >= 10
+    }
 
     results: dict[str, RigorGateResult] = {}
     for s in strategies:
-        if s.id not in valid_returns:
-            continue
         daily_returns = returns_by_strategy.get(s.id, [])
+        if len(daily_returns) < 10:
+            continue  # No sufficient returns — caller falls back to stale fields
+        if s.id in valid_returns:
+            # Non-degenerate series: run with the full cohort context so
+            # num_trials / pbo_scores / avg_correlation match the library gate.
+            gate_kwargs: dict = {
+                "num_trials": num_trials,
+                "pbo_scores": pbo_scores,
+                "average_correlation": avg_correlation,
+            }
+        else:
+            # Degenerate (zero-variance) series: excluded from cohort context to
+            # prevent inflating num_trials or diluting avg_correlation (#868), but
+            # the strategy still runs its own gate so the caller gets a live "fail"
+            # verdict rather than falling back to a stale fixture value.
+            gate_kwargs = {"num_trials": 1, "pbo_scores": {}, "average_correlation": 0.0}
         try:
             results[s.id] = run_rigor_gate(
                 strategy_id=s.id,
                 daily_returns=daily_returns,
-                num_trials=num_trials,
-                pbo_scores=pbo_scores,
                 strategy_code=code_by_id.get(s.id),
                 in_sample_sharpe=None,
                 paper_claimed_sharpe=getattr(s, "paper_claimed_sharpe", None),
-                average_correlation=avg_correlation,
+                **gate_kwargs,
             )
         except Exception as exc:
             logger.warning("live rigor gate failed for %s in batch (numbers → stale fallback): %s", s.id, exc)
@@ -382,6 +399,20 @@ def _load_strategy_code_safe_local(strategy: Strategy) -> str | None:
         return None
 
 
+def _verdict_from_result(result: RigorGateResult | None) -> RigorGateVerdict:
+    """Derive a RigorGateVerdict from an already-computed RigorGateResult.
+
+    Used by list_strategies so the badge and the numeric rigor fields always
+    come from the same single live-gate computation — avoids the double DB read and
+    duplicate gate run that verdicts_for_strategies would add, and eliminates
+    the badge/numeric-fields divergence that arose when the two paths used different
+    cohort filtering (#868, Copilot review).
+    """
+    if result is None:
+        return RigorGateVerdict.pending()
+    return RigorGateVerdict.passed() if result.passes_all else RigorGateVerdict.failed()
+
+
 # ── Library listing ─────────────────────────────────────────────
 
 
@@ -393,18 +424,15 @@ async def list_strategies(
 ):
     """List strategies in the library. Backed by LocalStrategyProvider.
 
-    The ``passes_rigor_gate`` badge + CANDIDATE → VALIDATED promotion come from the
-    LIVE gate verdict computed on persisted real returns (#821) — the same machinery
-    the /api/selection-bias/gate route uses — NOT from the stored fixture boolean.
-    Verdicts are computed once for the page window (one DB read + one library-wide
-    PBO/num_trials context) and threaded into each serializer.
-
-    The numeric rigor fields (``dsr_p_value``, ``pbo_score``, ``out_of_sample_sharpe``,
-    ``deflated_sharpe_ratio``) come from the SAME live gate run via
-    ``_live_rigor_results_for_strategies`` (#868), so the leaderboard can never
-    disagree with ``/api/selection-bias/gate`` for a given strategy id — previously
-    only the ``passes_rigor_gate`` boolean read the live verdict while these numbers
-    still read the stale fixture-derived fields.
+    Both the ``passes_rigor_gate`` badge and the numeric rigor fields
+    (``dsr_p_value``, ``pbo_score``, ``out_of_sample_sharpe``,
+    ``deflated_sharpe_ratio``) come from a SINGLE live-gate run via
+    ``_live_rigor_results_for_strategies`` (#868). The badge is derived from the
+    result via ``_verdict_from_result`` — a second DB read + duplicate gate run
+    through ``verdicts_for_strategies`` is not needed, and the inconsistency that
+    arose when the two paths used different cohort filtering (degenerate-series
+    exclusion existed only in ``_live_rigor_results_for_strategies``) is
+    eliminated.
 
     NOTE on the ``status`` filter: it filters on the file-declared status BEFORE the
     live-gate promotion overlay, so a CANDIDATE that the live gate promotes to
@@ -416,10 +444,12 @@ async def list_strategies(
     strats = strategy_provider.list_strategies(status=status_filter)
     total = len(strats)
     window = strats[offset : offset + limit]
-    verdicts = verdicts_for_strategies(window)
     rigor_results = _live_rigor_results_for_strategies(window)
     return StrategyListResponse(
-        strategies=[_to_strategy_response(s, verdicts.get(s.id), rigor_results.get(s.id)) for s in window],
+        strategies=[
+            _to_strategy_response(s, _verdict_from_result(rigor_results.get(s.id)), rigor_results.get(s.id))
+            for s in window
+        ],
         total=total,
     )
 

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -61,6 +61,69 @@ _LOOK_AHEAD_FUNCTIONS = {
     "look_ahead",
 }
 
+# backtrader's Lines/LineBuffer objects (self.data.<line>, self.datas[i].<line>,
+# a loop variable bound to a self.datas element, or a custom bt.Indicator stored
+# on self) use NEGATIVE subscripts by convention to mean "N bars ago" — the
+# opposite of a plain Python list/np.ndarray, where a negative index means "from
+# the end" and would silently read into the future on a forward-chronological
+# array (#868). These are the standard OHLCV/line attribute names backtrader
+# feeds expose; any subscript chain ending in one of these is bars-ago access
+# regardless of the root variable's name (covers `self.data.close[-i]` AND a
+# loop-var alias like `for d in self.datas: ... d.close[-i]`).
+_BACKTRADER_LINE_NAMES = {"close", "open", "high", "low", "volume", "openinterest", "datetime"}
+
+# pandas accessor attributes that index by POSITION/label on a DataFrame/Series —
+# `df.iloc[-1]` is last-row (future-leaking) access, structurally identical to
+# `self.highest[-1]` (self-rooted) at the AST level. Checked first so a
+# self-rooted pandas accessor (e.g. `self.df.iloc[-1]`) is never whitelisted
+# just because its root happens to be `self`.
+_PANDAS_ACCESSOR_ATTRS = {"iloc", "loc", "at", "iat"}
+
+
+def _is_backtrader_line_access(value_node: ast.expr) -> bool:
+    """True when ``value_node`` (a Subscript's ``.value``) is backtrader
+    bars-ago-indexed line access rather than a plain list/array/pandas object.
+
+    A bare local variable subscript (``spread[-1]``, ``scored[-n:]``) is never
+    whitelisted — only a dotted attribute chain is a candidate, since every
+    backtrader line access in this codebase is reached via attribute access
+    (``self.data.close``, ``self.highest``, ``d.close`` for a ``self.datas``
+    loop variable) while plain return/price arrays are always bare names.
+    Whitelists when either:
+      - the chain's ultimate root is ``self`` (covers ``self.data.close[-i]``,
+        ``self.datas[1].close[-i]``, and a custom indicator like
+        ``self.highest[-1]``), or
+      - the chain ends in a standard backtrader OHLCV/line name (covers a
+        ``self.datas`` loop-variable alias, e.g. ``d.close[-i]``, whose root is
+        not literally ``self``).
+    A pandas positional/label accessor (``.iloc``/``.loc``/``.at``/``.iat``)
+    anywhere in the chain always disqualifies the whitelist, even under a
+    ``self``-rooted chain, since that access pattern reads the DataFrame's
+    last row (future data), not a backtrader line.
+    """
+    if not isinstance(value_node, ast.Attribute):
+        return False
+
+    attrs: list[str] = []
+    node: ast.expr = value_node
+    while isinstance(node, (ast.Attribute, ast.Subscript)):
+        if isinstance(node, ast.Attribute):
+            attrs.append(node.attr)
+            node = node.value
+        else:
+            node = node.value
+    root = node.id if isinstance(node, ast.Name) else None
+
+    if any(a in _PANDAS_ACCESSOR_ATTRS for a in attrs):
+        return False
+    if root == "self":
+        return True
+    # attrs[0] is the innermost-collected == outermost/subscripted attribute
+    # (e.g. for `d.close`, attrs == ["close"]; for `self.data.close`,
+    # attrs == ["close", "data"]) — either way the subscripted attribute is
+    # attrs[0].
+    return bool(attrs) and attrs[0] in _BACKTRADER_LINE_NAMES
+
 
 def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
     """Static-analysis check for look-ahead bias in strategy code.
@@ -70,6 +133,19 @@ def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
     2. Calls to functions with look-ahead-suggestive names
     3. Direct indexing into data feeds beyond current bar
     4. Negative shifts (e.g., pandas df.shift(-1)) which leak future data.
+
+    Negative-index subscripts on a backtrader line-buffer object
+    (``self.data.close[-i]``, ``self.datas[k].close[-i]``, a ``self.datas``
+    loop-variable alias, or a ``self``-rooted custom indicator) are backtrader's
+    standard, correct "N bars ago" convention — NOT a look-ahead violation — and
+    are excluded from the warning (see ``_is_backtrader_line_access``, #868).
+    A negative index on anything else (a plain list/np.ndarray local variable,
+    or a pandas ``.iloc``/``.loc``/``.at``/``.iat`` accessor) is still flagged,
+    since on those objects ``[-1]`` means "last element", which is future data
+    on a forward-chronological series. A positive constant index is unaffected
+    by this distinction — it is always suspicious on ANY object, backtrader
+    included (bar 0 is "now"; any positive offset is a future bar) — and
+    continues to be flagged exactly as before.
 
     Args:
         strategy_code: Python source code of the strategy.
@@ -122,14 +198,19 @@ def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
         if isinstance(node, ast.Subscript):
             slice_val = node.slice
             if isinstance(slice_val, ast.UnaryOp) and isinstance(slice_val.op, ast.USub):
-                # Negative indices are safe in backtrader ([-N] = N bars ago) but
-                # would reference the last row of future data in a pandas DataFrame
-                # (df.iloc[-1], df["col"][-1]).  Flag so reviewers can verify the
-                # calling context before promotion to Tier-1.
-                warnings.append(
-                    f"Line {node.lineno}: negative index — verify this is backtrader "
-                    f"(bars-ago) not pandas (last-row) access."
-                )
+                # Negative indices are backtrader's standard, correct "N bars ago"
+                # convention on a Lines/LineBuffer object (self.data.close[-i],
+                # self.highest[-1], a self.datas loop-variable alias) — NOT a
+                # look-ahead violation, so skip the warning there (#868). Still
+                # flag a negative index on anything else (a plain list/np.ndarray
+                # local variable, or a pandas .iloc/.loc/.at/.iat accessor), where
+                # [-1] means "last element" and would silently read future data on
+                # a forward-chronological series.
+                if not _is_backtrader_line_access(node.value):
+                    warnings.append(
+                        f"Line {node.lineno}: negative index on a non-backtrader object — "
+                        f"verify this is not pandas/list last-row (future) access."
+                    )
             elif isinstance(slice_val, ast.Constant) and isinstance(slice_val.value, int) and slice_val.value > 0:
                 warnings.append(
                     f"Line {node.lineno}: positive data index [{slice_val.value}] may reference future bars"

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -390,9 +390,12 @@ class MyStrategy(bt.Strategy):
         assert passed
         assert len(warnings) == 0
 
-    def test_negative_index_emits_warning(self) -> None:
-        # Negative indices are safe in backtrader (bars-ago) but would be
-        # last-row future data in pandas.  The audit flags them for human review.
+    def test_negative_index_on_backtrader_data_no_longer_warns(self) -> None:
+        # #868: self.data.close[-1] is backtrader's standard, CORRECT "1 bar ago"
+        # convention — NOT a look-ahead violation. Previously this false-flagged
+        # (see the old test_negative_index_emits_warning, now superseded), which
+        # meant every strategy using idiomatic backtrader indexing hard-failed
+        # look_ahead_audit (passes_all requires zero warnings).
         code = """
 class MyStrategy(bt.Strategy):
     def next(self):
@@ -400,8 +403,8 @@ class MyStrategy(bt.Strategy):
             self.buy()
 """
         passed, warnings = look_ahead_audit(code)
-        assert not passed
-        assert any("negative index" in w.lower() for w in warnings)
+        assert passed
+        assert len(warnings) == 0
 
     def test_positive_index(self) -> None:
         code = """
@@ -431,6 +434,279 @@ class MyStrategy(bt.Strategy):
         passed, warnings = look_ahead_audit("def broken(:")
         assert not passed
         assert any("parse" in w.lower() for w in warnings)
+
+
+# ─── Look-ahead audit: backtrader bars-ago vs. true look-ahead (#868) ──
+
+
+class TestLookAheadAuditBacktraderVsLookAhead:
+    """#868 fix 2: look_ahead_audit previously flagged ANY negative-index
+    subscript as a violation, but backtrader's Lines/LineBuffer objects
+    (self.data.<line>[-i], self.datas[k].<line>[-i], a self.datas loop-variable
+    alias, or a self-rooted custom bt.Indicator) use negative indices by
+    convention to mean "N bars ago" — backward-looking, not a violation.
+    Because passes_all requires ZERO warnings, this single false positive
+    alone failed an otherwise-clean strategy (concrete failing example:
+    analytics-engine/strategies/moreira_muir_2017_volatility_managed.py:99-100).
+
+    These tests cover every negative-index SHAPE actually present in
+    analytics-engine/strategies/*.py (verified via a full-corpus grep before
+    writing the fix) plus the genuine-look-ahead cases that must still fail.
+    """
+
+    # ── Backtrader bars-ago access: must PASS (no warnings) ──────────────
+
+    def test_moreira_muir_realized_vol_pattern_passes(self) -> None:
+        """The exact concrete failing example from the issue:
+        moreira_muir_2017_volatility_managed.py:99-100 — self.data.close[-i-1]
+        and self.data.close[-i] inside a rolling-volatility loop."""
+        code = """
+class MyStrategy(bt.Strategy):
+    def _realized_vol_annual(self):
+        returns = []
+        for i in range(1, 22):
+            prev = float(self.data.close[-i - 1])
+            curr = float(self.data.close[-i])
+            if prev > 0:
+                returns.append((curr / prev) - 1.0)
+        return returns
+"""
+        passed, warnings = look_ahead_audit(code)
+        assert passed, f"unexpected warnings on the moreira-muir bars-ago pattern: {warnings}"
+        assert len(warnings) == 0
+
+    def test_simple_bars_ago_variable_index(self) -> None:
+        # self.data.close[-i] — the exact pattern named in the issue.
+        code = "def f(self, i):\n    return self.data.close[-i]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert warnings == []
+
+    def test_bars_ago_constant_index(self) -> None:
+        # self.data.close[-1] — already covered by
+        # test_negative_index_on_backtrader_data_no_longer_warns above; repeated
+        # here for locality with the rest of this class's coverage.
+        code = "def f(self):\n    return self.data.close[-1]\n"
+        passed, _warnings = look_ahead_audit(code)
+        assert passed
+
+    def test_bars_ago_parenthesized_binop_index(self) -> None:
+        # data.close[-(i + 1)] — frazzini_pedersen_2014_bab.py's exact shape
+        # (UnaryOp wrapping a BinOp, not a bare Name/Constant operand).
+        code = "def f(data, i):\n    return data.close[-(i + 1)]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert warnings == []
+
+    def test_bars_ago_binop_subtraction_index(self) -> None:
+        # self.data.close[-i - 1] (outer node is a BinOp, not a UnaryOp) — the
+        # AST shape the OLD code already silently ignored; confirm the new
+        # code still does not warn on it either.
+        code = "def f(self, i):\n    return self.data.close[-i - 1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert warnings == []
+
+    def test_secondary_data_feed_negative_index_is_not_flagged_as_negative(self) -> None:
+        """self.datas[1].close[-i] (gatev_2006_pairs_distance.py's pairs-trading
+        shape) — the NEGATIVE bars-ago index [-i] must not be flagged.
+
+        NOTE (found while writing this test, NOT part of #868's scope): this
+        exact snippet still fails look_ahead_audit overall today, because the
+        POSITIVE-index branch (unconditional, untouched by #868 — see
+        look_ahead_audit's `elif isinstance(slice_val, ast.Constant) ...
+        value > 0` leg) separately and incorrectly flags the `self.datas[1]`
+        data-FEED-selector subscript itself ("positive data index [1] may
+        reference future bars") — conflating "index 1 selects the 2nd data
+        feed" with "index 1 is one bar in the future". This is a real,
+        pre-existing, independent false positive (confirmed present on
+        unmodified main before this fix) affecting every multi-leg/pairs
+        strategy that writes `self.datas[N]` directly rather than through a
+        pre-bound variable: gatev_2006_pairs_distance.py,
+        elliott_2005_kalman_pairs.py, and engle_granger_1987_cointegration_pairs.py
+        all still fail look_ahead_audit after this fix, dominated by this
+        secondary bug rather than the bars-ago issue #868 asked me to fix.
+        Out of scope here per the issue's explicit instruction to preserve the
+        positive-index ("genuine look-ahead") detector as-is; flagged in the
+        PR/report rather than silently widened.
+        """
+        code = "def f(self, i):\n    return self.datas[1].close[-i]\n"
+        _passed, warnings = look_ahead_audit(code)
+        assert not any("negative index" in w.lower() for w in warnings), (
+            f"the bars-ago [-i] access must not be flagged as a negative-index violation: {warnings}"
+        )
+        # Documents the known, separate, out-of-scope positive-index false
+        # positive on the self.datas[N] feed-selector subscript (see docstring).
+        # If this assertion ever starts failing, that pre-existing bug has been
+        # fixed elsewhere — which would be a welcome surprise, not a regression.
+        assert any("positive" in w.lower() for w in warnings), (
+            "expected the known pre-existing self.datas[N] positive-index false "
+            "positive to still be present (tracked separately, out of #868's scope)"
+        )
+
+    def test_loop_variable_alias_over_datas(self) -> None:
+        # d.close[-i] where `d` is a loop variable bound to a self.datas element
+        # (avellaneda_lee_2010_pca_statarb.py's exact shape: `for d in
+        # self.datas: ... d.close[-i]`). The root is `d`, not `self`/`data` — the
+        # fix must key off the backtrader OHLCV line name (`close`), not the
+        # root variable's literal spelling, to catch this.
+        code = """
+class MyStrategy(bt.Strategy):
+    def next(self):
+        for d in self.datas:
+            prev = float(d.close[-2])
+            curr = float(d.close[-1])
+"""
+        passed, warnings = look_ahead_audit(code)
+        assert passed, f"loop-variable alias over self.datas incorrectly flagged: {warnings}"
+        assert len(warnings) == 0
+
+    def test_self_rooted_custom_indicator(self) -> None:
+        # self.highest[-1] (donchian_breakout.py) — a custom bt.Indicator stored
+        # on self, not an OHLCV line name. Root == "self" is the fallback signal
+        # that whitelists this even though "highest" isn't in the OHLCV name set.
+        code = "def f(self):\n    return self.highest[-1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert warnings == []
+
+    def test_high_low_open_volume_lines_all_pass(self) -> None:
+        for line in ("high", "low", "open", "volume", "openinterest", "datetime"):
+            code = f"def f(self, i):\n    return self.data.{line}[-i]\n"
+            passed, warnings = look_ahead_audit(code)
+            assert passed, f"self.data.{line}[-i] incorrectly flagged: {warnings}"
+
+    # ── Genuine look-ahead: must still FAIL ───────────────────────────────
+
+    def test_plain_list_negative_index_still_warns(self) -> None:
+        # spread[-1] where `spread` is a bare local variable (a plain Python
+        # list/np.ndarray, e.g. engle_granger_1987_cointegration_pairs.py's
+        # spread series) — NOT a backtrader line object. [-1] on a plain
+        # sequence means "last element", which is future data on a
+        # forward-chronological series if used incorrectly, so this must still
+        # be flagged for human review exactly as before.
+        code = "def f(spread):\n    return spread[-1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("negative index" in w.lower() for w in warnings)
+
+    def test_plain_variable_negative_index_still_warns(self) -> None:
+        code = "def f(x):\n    return x[-1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("negative index" in w.lower() for w in warnings)
+
+    def test_pandas_iloc_negative_index_still_warns(self) -> None:
+        # df.iloc[-1] — pandas last-row access. Structurally similar to a
+        # self-rooted backtrader indicator (both are Attribute-chain subscripts)
+        # but must NOT be whitelisted: the .iloc accessor is the exact false
+        # negative the original docstring worried about ("df.iloc[-1],
+        # df['col'][-1]"), so it stays flagged even under a self-rooted chain.
+        code = "def f(df):\n    return df.iloc[-1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("negative index" in w.lower() for w in warnings)
+
+    def test_self_rooted_pandas_iloc_still_warns(self) -> None:
+        # self.df.iloc[-1] — pandas accessor stored on self. The `self` root
+        # alone must not whitelist it; the .iloc blocklist must win.
+        code = "def f(self):\n    return self.df.iloc[-1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("negative index" in w.lower() for w in warnings)
+
+    def test_pandas_bracket_column_negative_index_still_warns(self) -> None:
+        # df["col"][-1] — pandas last-row access via bracket column selection.
+        code = 'def f(df):\n    return df["col"][-1]\n'
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("negative index" in w.lower() for w in warnings)
+
+    def test_synthetic_true_look_ahead_positive_future_index_still_fails(self) -> None:
+        """ACCEPTANCE CRITERION: a synthetic true-look-ahead fixture (positive
+        future index) still FAILS after the fix — the bars-ago whitelist must
+        not weaken genuine look-ahead detection. Positive indices are suspicious
+        on ANY object (backtrader included: bar 0 is "now", any positive offset
+        is a future bar), so this behavior is intentionally UNCHANGED by #868."""
+        code = """
+class MyStrategy(bt.Strategy):
+    def next(self):
+        future_price = self.data.close[5]
+        if future_price > self.data.close[0]:
+            self.buy()
+"""
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+
+    def test_synthetic_true_look_ahead_on_plain_array_still_fails(self) -> None:
+        # A positive future index into a plain array is equally suspicious and
+        # was already covered by test_positive_index above for self.data; this
+        # confirms the same holds for a non-backtrader object too (the positive-
+        # index branch is unconditional — it doesn't consult
+        # _is_backtrader_line_access at all).
+        code = "def f(prices):\n    return prices[5]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+
+    def test_mixed_clean_bars_ago_and_genuine_violation_still_fails_overall(self) -> None:
+        """A strategy with BOTH legitimate bars-ago access AND one genuine
+        look-ahead violation must still fail overall (passes_all requires zero
+        warnings) — the fix narrows false positives, it does not turn off
+        detection for a strategy that also happens to use clean backtrader
+        indexing elsewhere."""
+        code = """
+class MyStrategy(bt.Strategy):
+    def next(self):
+        safe = self.data.close[-1]          # legitimate bars-ago — no warning
+        future_price = self.data.close[5]   # genuine look-ahead — must warn
+        if future_price > safe:
+            self.buy()
+"""
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+        assert not any("negative index" in w.lower() for w in warnings), (
+            "the legitimate self.data.close[-1] access must not also warn"
+        )
+
+
+class TestLookAheadAuditRealMoreiraMuirFile:
+    """ACCEPTANCE CRITERION (end-to-end, real file — not a synthetic snippet):
+    moreira_muir_2017_volatility_managed no longer fails look-ahead on
+    close[-i]. Loads the actual strategy source from disk via the session-scoped
+    ``strategies_dir`` fixture (conftest.py) so this is a faithful reproduction
+    of what run_rigor_gate sees for this strategy on the live path, not just an
+    isolated code snippet."""
+
+    def test_moreira_muir_file_passes_look_ahead_audit(self, strategies_dir) -> None:
+        path = strategies_dir / "moreira_muir_2017_volatility_managed.py"
+        assert path.is_file(), f"expected strategy file at {path}"
+        code = path.read_text()
+
+        passed, warnings = look_ahead_audit(code)
+        assert passed, f"moreira_muir_2017_volatility_managed.py still fails look-ahead audit: {warnings}"
+        assert warnings == []
+
+    def test_moreira_muir_file_passes_full_rigor_gate_look_ahead_leg(self, strategies_dir) -> None:
+        """The look_ahead leg of the composite run_rigor_gate result (not just
+        the standalone look_ahead_audit call) reports PASS for this file — the
+        exact leg that previously hard-failed passes_all regardless of DSR/PBO/
+        OOS, since passes_all requires look_ahead_passed to be True."""
+        path = strategies_dir / "moreira_muir_2017_volatility_managed.py"
+        code = path.read_text()
+
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.001, 0.008, size=300).tolist()
+        result = run_rigor_gate(
+            strategy_id="moreira_muir_2017_volatility_managed",
+            daily_returns=returns,
+            num_trials=1,
+            strategy_code=code,
+        )
+        assert result.look_ahead_passed is True
+        assert result.gate_details["look_ahead"] == "PASS"
 
 
 # ─── Rigor gate composite (migrated from selection_bias.py) ──────────

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -839,3 +839,199 @@ async def test_run_rigor_gate_called_without_library_pbo_kwarg(monkeypatch):
     assert captured_kwargs, "run_rigor_gate was never called — the full branch did not execute"
     for kwargs in captured_kwargs:
         assert "library_pbo" not in kwargs, "run_rigor_gate must NOT receive library_pbo (option-3 guard)"
+
+
+# ── Degenerate (zero-variance) series excluded from num_trials/avg_corr (#868) ──
+
+
+class TestDegenerateSeriesExcludedFromCohort:
+    """#868 fix 1: a zero-variance daily_returns series (a flat placeholder row
+    that was never replaced with a real backtest — 11/31 in the live library at
+    filing time) must not count toward num_trials or feed avg_correlation/PBO,
+    since that unfairly stiffens the DSR multiple-testing correction applied to
+    every REAL strategy in the cohort. Mirrors the exact degeneracy test
+    _rigor_helpers._sharpe_dsr_inputs already uses (np.ptp(arr) == 0) rather than
+    inventing a new heuristic (per the issue's explicit instruction).
+
+    These tests inject a KNOWN mixed cohort at the get_all_daily_returns DB
+    boundary — some real (non-degenerate) series, some flat (degenerate) ones —
+    and spy on run_rigor_gate's num_trials/average_correlation kwargs to assert
+    only the real series were counted.
+    """
+
+    @staticmethod
+    def _real_series(seed: int, n: int = 300) -> list[float]:
+        return np.random.default_rng(seed).normal(0.001, 0.01, n).tolist()
+
+    @staticmethod
+    def _flat_series(value: float = 0.0, n: int = 300) -> list[float]:
+        # A zero-variance placeholder row: every observation identical.
+        # len >= 10 so it clears the pre-existing length filter and would have
+        # counted toward num_trials before this fix.
+        return [value] * n
+
+    def _patch_returns(self, monkeypatch, returns_by_strategy: dict[str, list[float]]):
+        monkeypatch.setattr(
+            "archimedes.services.backtest_repository.get_all_daily_returns",
+            lambda session, ids: dict(returns_by_strategy),
+        )
+
+    @pytest.mark.asyncio
+    async def test_num_trials_excludes_degenerate_series(self, monkeypatch):
+        """3 real + 2 degenerate (flat) series in the cohort → num_trials == 3,
+        not 5. Before the fix, num_trials counted len(valid_returns) == 5."""
+        from archimedes.api import selection_bias_routes as routes
+        from archimedes.main import app
+        from archimedes.services.rigor_evaluator import run_rigor_gate as real_run_rigor_gate
+
+        strategies = routes._provider.list_strategies()
+        assert len(strategies) >= 5, "need >=5 curated strategies to build this cohort"
+        ids = [s.id for s in strategies[:5]]
+
+        returns = {
+            ids[0]: self._real_series(0),
+            ids[1]: self._real_series(1),
+            ids[2]: self._real_series(2),
+            ids[3]: self._flat_series(0.0),  # degenerate: constant zero
+            ids[4]: self._flat_series(0.0007),  # degenerate: constant nonzero
+        }
+        self._patch_returns(monkeypatch, returns)
+
+        captured_kwargs = []
+
+        def _spy(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return real_run_rigor_gate(*args, **kwargs)
+
+        monkeypatch.setattr(routes, "run_rigor_gate", _spy)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/selection-bias/gate")
+        assert resp.status_code == 200
+        assert captured_kwargs, "run_rigor_gate was never called"
+
+        # Every call in this run shares the same library-wide num_trials context.
+        num_trials_seen = {kwargs["num_trials"] for kwargs in captured_kwargs}
+        assert num_trials_seen == {3}, (
+            f"num_trials should count only the 3 non-degenerate series, got {num_trials_seen}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_avg_correlation_excludes_degenerate_series(self, monkeypatch):
+        """The average_correlation fed to run_rigor_gate is computed only over
+        the non-degenerate cohort — a degenerate (zero-variance) series has an
+        undefined correlation with anything and must not dilute the average."""
+        from archimedes.api import selection_bias_routes as routes
+        from archimedes.main import app
+        from archimedes.services.rigor_evaluator import (
+            compute_average_pairwise_correlation,
+        )
+        from archimedes.services.rigor_evaluator import (
+            run_rigor_gate as real_run_rigor_gate,
+        )
+
+        strategies = routes._provider.list_strategies()
+        assert len(strategies) >= 4
+        ids = [s.id for s in strategies[:4]]
+
+        real_a, real_b, real_c = self._real_series(10), self._real_series(11), self._real_series(12)
+        returns = {
+            ids[0]: real_a,
+            ids[1]: real_b,
+            ids[2]: real_c,
+            ids[3]: self._flat_series(0.0),  # degenerate
+        }
+        self._patch_returns(monkeypatch, returns)
+
+        expected_avg_corr = compute_average_pairwise_correlation({"a": real_a, "b": real_b, "c": real_c})
+
+        captured_kwargs = []
+
+        def _spy(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return real_run_rigor_gate(*args, **kwargs)
+
+        monkeypatch.setattr(routes, "run_rigor_gate", _spy)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/selection-bias/gate")
+        assert resp.status_code == 200
+        assert captured_kwargs
+
+        for kwargs in captured_kwargs:
+            assert kwargs["average_correlation"] == pytest.approx(expected_avg_corr), (
+                "average_correlation must be computed over the non-degenerate cohort only "
+                f"(expected {expected_avg_corr}, got {kwargs['average_correlation']})"
+            )
+
+    @pytest.mark.asyncio
+    async def test_all_degenerate_cohort_yields_num_trials_floor_of_one(self, monkeypatch):
+        """If EVERY persisted series in the cohort is degenerate, valid_returns is
+        empty and num_trials floors to 1 (max(len(valid_returns), 1)) — matching
+        the pre-existing floor semantics for an empty/near-empty cohort."""
+        from archimedes.api import selection_bias_routes as routes
+        from archimedes.main import app
+        from archimedes.services.rigor_evaluator import run_rigor_gate as real_run_rigor_gate
+
+        strategies = routes._provider.list_strategies()
+        assert len(strategies) >= 2
+        ids = [s.id for s in strategies[:2]]
+
+        returns = {
+            ids[0]: self._flat_series(0.0),
+            ids[1]: self._flat_series(0.001),
+        }
+        self._patch_returns(monkeypatch, returns)
+
+        captured_kwargs = []
+
+        def _spy(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return real_run_rigor_gate(*args, **kwargs)
+
+        monkeypatch.setattr(routes, "run_rigor_gate", _spy)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/selection-bias/gate")
+        assert resp.status_code == 200
+        # Both strategies still have len(daily_returns) >= 10 individually, so
+        # BOTH still go through the per-strategy run_rigor_gate call (each reports
+        # its own honest MISSING/FAIL from _rigor_helpers's own degeneracy guard)
+        # — only the cohort-level num_trials context floors to 1.
+        assert captured_kwargs, "degenerate-but-len>=10 strategies must still run their own gate"
+        num_trials_seen = {kwargs["num_trials"] for kwargs in captured_kwargs}
+        assert num_trials_seen == {1}
+
+    @pytest.mark.asyncio
+    async def test_short_series_still_excluded_alongside_degenerate(self, monkeypatch):
+        """Pre-existing len>=10 filter and the new variance filter compose
+        correctly: a too-short series and a flat series are both excluded,
+        leaving only the real series in num_trials."""
+        from archimedes.api import selection_bias_routes as routes
+        from archimedes.main import app
+        from archimedes.services.rigor_evaluator import run_rigor_gate as real_run_rigor_gate
+
+        strategies = routes._provider.list_strategies()
+        assert len(strategies) >= 3
+        ids = [s.id for s in strategies[:3]]
+
+        returns = {
+            ids[0]: self._real_series(20),
+            ids[1]: [0.001] * 5,  # too short (< 10) — pre-existing filter
+            ids[2]: self._flat_series(0.002),  # long enough but degenerate
+        }
+        self._patch_returns(monkeypatch, returns)
+
+        captured_kwargs = []
+
+        def _spy(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return real_run_rigor_gate(*args, **kwargs)
+
+        monkeypatch.setattr(routes, "run_rigor_gate", _spy)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/selection-bias/gate")
+        assert resp.status_code == 200
+        num_trials_seen = {kwargs["num_trials"] for kwargs in captured_kwargs}
+        assert num_trials_seen == {1}, "only 1 real series survives both filters"

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -332,3 +332,229 @@ async def test_list_endpoint_returns_200_and_status_field():
     for s in data["strategies"]:
         assert s["rigor_gate_status"] in (PASS, FAIL, PENDING)
         assert isinstance(s["passes_rigor_gate"], bool)
+
+
+# ── Acceptance #3 (#868): leaderboard numeric fields == live gate values ────
+#
+# GET /api/strategies/ must serve dsr_p_value / pbo_score / out_of_sample_sharpe /
+# deflated_sharpe_ratio computed by the SAME live run_rigor_gate call that backs
+# GET /api/selection-bias/gate for the same strategy id — previously only the
+# passes_rigor_gate BOOLEAN read the live verdict (#821) while these numeric
+# fields still read stale s.<field>/bt.<field> fixture values, so the two
+# surfaces could disagree on the numbers for one strategy even when they agreed
+# on pass/fail.
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_numeric_fields_equal_live_gate_on_persisted_returns(monkeypatch):
+    """ACCEPTANCE #3: for a strategy with real persisted returns, the served
+    dsr_p_value/pbo_score/out_of_sample_sharpe/deflated_sharpe_ratio on
+    GET /api/strategies/ equal an independently-computed run_rigor_gate result
+    over the SAME returns + SAME cohort context the route derives — mirroring
+    test_library_badge_equals_live_gate_verdict_on_persisted_returns's
+    established pattern for the boolean badge, extended to the numeric fields."""
+    from archimedes.api import strategies_routes as sr
+    from archimedes.main import app
+
+    strategies = sr.strategy_provider.list_strategies()
+    assert len(strategies) >= 2, "need ≥2 curated strategies for a PBO cohort"
+
+    s_pass, s_fail = strategies[0], strategies[1]
+    returns = {s_pass.id: _passing_series(0), s_fail.id: _failing_series()}
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    # verdicts_for_strategies (the boolean path) reads live_rigor_gate's loader;
+    # _live_rigor_results_for_strategies (the new numeric path) reads its own
+    # local loader — patch BOTH so the two paths see identical code and the
+    # look-ahead leg is deterministic across both.
+    monkeypatch.setattr(
+        "archimedes.services.live_rigor_gate._load_strategy_code_safe",
+        lambda strategy: _CLEAN_CODE,
+    )
+    monkeypatch.setattr(
+        "archimedes.api.strategies_routes._load_strategy_code_safe_local",
+        lambda strategy: _CLEAN_CODE,
+    )
+
+    # Independently reproduce the route's library context (same recipe as
+    # test_library_badge_equals_live_gate_verdict_on_persisted_returns).
+    valid = {k: v for k, v in returns.items() if len(v) >= 10}
+    pbo_scores = compute_pbo(valid) if len(valid) >= 2 else {}
+    num_trials = max(len(valid), 1)
+    avg_corr = compute_average_pairwise_correlation(valid) if len(valid) >= 2 else 0.0
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=100")
+    assert resp.status_code == 200
+    by_id = {s["id"]: s for s in resp.json()["strategies"]}
+
+    for sid, series in returns.items():
+        expected = run_rigor_gate(
+            strategy_id=sid,
+            daily_returns=series,
+            num_trials=num_trials,
+            pbo_scores=pbo_scores,
+            strategy_code=_CLEAN_CODE,
+            in_sample_sharpe=None,
+            average_correlation=avg_corr,
+        )
+        served = by_id[sid]
+        assert served["dsr_p_value"] == pytest.approx(expected.dsr_p_value, rel=1e-9), (
+            f"dsr_p_value for {sid}: served={served['dsr_p_value']} vs live gate={expected.dsr_p_value}"
+        )
+        assert served["pbo_score"] == pytest.approx(expected.pbo_score, rel=1e-9), (
+            f"pbo_score for {sid}: served={served['pbo_score']} vs live gate={expected.pbo_score}"
+        )
+        assert served["out_of_sample_sharpe"] == pytest.approx(expected.oos_sharpe, rel=1e-9), (
+            f"out_of_sample_sharpe for {sid}: served={served['out_of_sample_sharpe']} vs live gate={expected.oos_sharpe}"
+        )
+        assert served["deflated_sharpe_ratio"] == pytest.approx(expected.deflated_sharpe, rel=1e-9), (
+            f"deflated_sharpe_ratio for {sid}: served={served['deflated_sharpe_ratio']} vs "
+            f"live gate={expected.deflated_sharpe}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_never_disagrees_with_selection_bias_gate_route(monkeypatch):
+    """ACCEPTANCE #3 (framed exactly as the issue states it): for a given
+    strategy id, GET /api/strategies/ 's numeric rigor fields equal what
+    GET /api/selection-bias/gate computes for that SAME id right now — the two
+    live surfaces are queried back-to-back against the same injected DB state
+    and must not disagree, rather than each being checked against an
+    independently-reproduced expectation (belt-and-suspenders vs. the test
+    above, which pins the exact machinery instead)."""
+    from archimedes.api import strategies_routes as sr
+    from archimedes.main import app
+
+    strategies = sr.strategy_provider.list_strategies()
+    assert len(strategies) >= 3, "need ≥3 curated strategies for a shared cohort"
+
+    ids = [s.id for s in strategies[:3]]
+    returns = {
+        ids[0]: _passing_series(2),
+        ids[1]: _passing_series(3),
+        ids[2]: _failing_series(seed=101),
+    }
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    monkeypatch.setattr(
+        "archimedes.services.live_rigor_gate._load_strategy_code_safe",
+        lambda strategy: _CLEAN_CODE,
+    )
+    monkeypatch.setattr(
+        "archimedes.api.strategies_routes._load_strategy_code_safe_local",
+        lambda strategy: _CLEAN_CODE,
+    )
+    monkeypatch.setattr(
+        "archimedes.api.selection_bias_routes._load_strategy_code",
+        lambda path: _CLEAN_CODE,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        leaderboard_resp = await client.get("/api/strategies/?limit=100")
+        gate_resp = await client.get("/api/selection-bias/gate")
+    assert leaderboard_resp.status_code == 200
+    assert gate_resp.status_code == 200
+
+    leaderboard_by_id = {s["id"]: s for s in leaderboard_resp.json()["strategies"]}
+    gate_by_id = {s["strategy_id"]: s for s in gate_resp.json()["strategies"]}
+
+    checked = 0
+    for sid in ids:
+        lb = leaderboard_by_id.get(sid)
+        gate = gate_by_id.get(sid)
+        if lb is None or gate is None:
+            continue
+        # Both routes recompute num_trials/cohort context from the FULL injected
+        # returns dict (3 series here), so — for THIS shared fixture — the two
+        # independently-computed live gates should agree on every number.
+        checked += 1
+        assert lb["dsr_p_value"] == pytest.approx(gate["dsr_p_value"], rel=1e-6, abs=1e-9), (
+            f"dsr_p_value disagreement for {sid}: leaderboard={lb['dsr_p_value']} vs gate={gate['dsr_p_value']}"
+        )
+        assert lb["pbo_score"] == pytest.approx(gate["pbo_score"], rel=1e-6, abs=1e-9), (
+            f"pbo_score disagreement for {sid}: leaderboard={lb['pbo_score']} vs gate={gate['pbo_score']}"
+        )
+        assert lb["out_of_sample_sharpe"] == pytest.approx(gate["oos_sharpe"], rel=1e-6, abs=1e-9), (
+            f"out_of_sample_sharpe disagreement for {sid}: "
+            f"leaderboard={lb['out_of_sample_sharpe']} vs gate={gate['oos_sharpe']}"
+        )
+        assert lb["deflated_sharpe_ratio"] == pytest.approx(gate["deflated_sharpe"], rel=1e-6, abs=1e-9), (
+            f"deflated_sharpe_ratio disagreement for {sid}: "
+            f"leaderboard={lb['deflated_sharpe_ratio']} vs gate={gate['deflated_sharpe']}"
+        )
+    assert checked >= 1, "no shared ids resolved between the two routes — fixture setup is broken"
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_falls_back_to_stale_fields_without_real_returns(monkeypatch):
+    """A strategy with NO persisted returns still serves numeric fields from the
+    pre-existing fallback chain (stub/None) — rigor_result is None in that case,
+    so _to_strategy_response's fallback branch (unchanged by #868) is exercised,
+    not a crash or a fabricated number."""
+    from archimedes.main import app
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: {},
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/?limit=100")
+    assert resp.status_code == 200
+    served = resp.json()["strategies"]
+    assert served
+    # No assertion on the specific fallback values (those come from whatever
+    # fixtures/stubs the curated library happens to carry) — the point is the
+    # route does not 500 and does not fabricate a rigor_result-sourced number
+    # when the live gate could not run.
+
+
+@pytest.mark.asyncio
+async def test_single_strategy_endpoint_numeric_fields_equal_live_gate(monkeypatch):
+    """The single-strategy fetch path (GET /api/strategies/{id}) also serves
+    live-gate-sourced numeric fields, not just the batch list path — mirrors
+    _live_verdict_for_one's existing on-demand-computation precedent
+    (verdict is None → compute here), extended to _live_rigor_result_for_one."""
+    from archimedes.api import strategies_routes as sr
+    from archimedes.main import app
+
+    strategies = sr.strategy_provider.list_strategies()
+    assert strategies, "need at least one curated strategy"
+    target = strategies[0]
+    series = _passing_series(5)
+
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_daily_returns",
+        lambda session, sid: series if sid == target.id else [],
+    )
+    monkeypatch.setattr(
+        "archimedes.api.selection_bias_routes._load_strategy_code",
+        lambda path: _CLEAN_CODE,
+    )
+
+    expected = run_rigor_gate(
+        strategy_id=target.id,
+        daily_returns=series,
+        num_trials=1,
+        strategy_code=_CLEAN_CODE,
+        in_sample_sharpe=None,
+        paper_claimed_sharpe=target.paper_claimed_sharpe,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{target.id}")
+    assert resp.status_code == 200
+    served = resp.json()
+
+    assert served["dsr_p_value"] == pytest.approx(expected.dsr_p_value, rel=1e-9)
+    assert served["pbo_score"] == pytest.approx(expected.pbo_score, rel=1e-9)
+    assert served["out_of_sample_sharpe"] == pytest.approx(expected.oos_sharpe, rel=1e-9)
+    assert served["deflated_sharpe_ratio"] == pytest.approx(expected.deflated_sharpe, rel=1e-9)
+    assert served["passes_rigor_gate"] == expected.passes_all


### PR DESCRIPTION
## Summary

Closes #868. The live rigor gate was passing 0 of 31 library strategies. Not because the library is all bad, three separate bugs were feeding the gate bad inputs, plus one of its own checks had a false-positive problem. The 14 strategies that genuinely fail DSR honestly still fail after this PR, that part of the gate was working correctly the whole time.

## What changed

- `backend/archimedes/api/selection_bias_routes.py`: `valid_returns` now excludes zero-variance (flat/placeholder) daily-return series before computing `num_trials`, `avg_correlation`, and cohort PBO. 11 of the 31 library entries are placeholder stubs with no real backtest behind them; counting them toward the multiple-testing correction was unfairly stiffening DSR for the 14 real strategies with a genuine shot at passing. Mirrors the same degeneracy test (`np.ptp(arr) == 0`) `_rigor_helpers._sharpe_dsr_inputs` already uses, so "degenerate" means the same thing everywhere in the gate. Every strategy, degenerate or not, still runs its own gate check individually and reports its own honest verdict; this only trims the cohort-level context.
- `backend/archimedes/services/rigor_evaluator.py`, `look_ahead_audit`: negative-index subscripts on backtrader line-buffer access (`self.data.close[-i]`, a `self.datas` loop-variable alias, a self-rooted custom indicator) no longer trigger a false positive. `self.data.close[-i]` is backtrader's standard "i bars ago" convention, not a look-ahead violation, but the old check flagged it anyway and the gate requires zero warnings to pass. A pandas `.iloc`/`.loc`/`.at`/`.iat` accessor, or a negative index on anything that isn't backtrader line access, still gets flagged. The positive-index branch (genuine future-index detection) is untouched.
- `backend/archimedes/api/strategies_routes.py`: the leaderboard's numeric fields (`dsr_p_value`, `pbo_score`, `out_of_sample_sharpe`, `deflated_sharpe_ratio`) now come from the same live gate run that already produces the `passes_rigor_gate` badge (#821), instead of stale fixture-derived fields. Previously only the boolean badge read the live verdict while the numbers next to it could show something else entirely for the same strategy. Falls back to the old fixture chain when the live gate can't run (no persisted returns, DB failure), fail-closed, no fabricated numbers.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_rigor_evaluator.py backend/tests/test_selection_bias_routes.py backend/tests/test_strategies_routes.py -q   # 259 passed
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest -m "not integration" -q   # 2374 passed
```

## Found but deliberately not fixed here

The look-ahead audit's positive-index branch has its own, separate false positive: `self.datas[N]` (a constant selecting which data feed, standard in a multi-asset strategy) gets flagged as "may reference future bars," conflating feed selection with a time offset. This is present on unmodified `main`, independent of anything in this PR, and is currently why `gatev_2006_pairs_distance.py`, `elliott_2005_kalman_pairs.py`, and `engle_granger_1987_cointegration_pairs.py` still fail look-ahead after this lands, for a different reason than #868 asked me to fix. Left the positive-index detector untouched per #868's own anti-goal against touching it casually. Filed #881 to track it separately.

## Anti-goals checked

- No gate threshold changed. DSR p≥0.95 and PBO<0.5 are exactly what they were.
- `_rigor_helpers.py`'s DSR/PBO math is untouched. This PR only changes what feeds it and what the leaderboard displays.
- Did not touch the positive-index look-ahead detector (see above, #881).

## One acceptance criterion I couldn't verify hermetically

#868 asks to spot-check 5 real strategy ids, including one of the "6 broken ones," against live data. This sandbox has no persisted `strategy_daily_returns` rows to check against, so I wrote the parity test as "the leaderboard route serves the same values `selection_bias_routes` computes for a given id" against fixture data instead (`test_leaderboard_never_disagrees_with_selection_bias_gate_route`), which passes. Live-id spot-checking is a follow-up for whoever has prod DB access, same shape as the #862/#864 backfill gap.

## Cross-lane note

Touches the rigor gate's routing/evaluator layer, which #822/#819/#817 also live in. No overlap with those PRs' files. Requesting @dbrowneup's review given the live-gate surface this touches and his #868 investigation.
