### PR TITLE
[backend] Scheduler backoff for permanently-missing backtests

### DIFF
--- a/backend/archimedes/services/backtest_scheduler.py
+++ b/backend/archimedes/services/backtest_scheduler.py
@@ -85,9 +85,13 @@ def needs_refresh() -> tuple[bool, str]:
         if missing:
             if set(missing) == _last_unresolved_missing:
                 # A previous refresh already failed to produce rows for exactly
-                # this set — they need code fixes, not compute. Fall through to
-                # the age check instead of thrashing.
-                pass
+                # this set — they need code fixes, not compute. Return an
+                # explicit backoff reason so the skipped log is unambiguous.
+                return (
+                    False,
+                    f"backing off: {len(missing)} strategies still missing and unchanged"
+                    " since last refresh (likely need code fixes, not re-runs)",
+                )
             else:
                 return True, f"{len(missing)}/{len(ids)} strategies have no persisted backtest"
         now = datetime.now(UTC)
@@ -131,8 +135,15 @@ def _remember_unresolved_missing() -> None:
                 "(likely need code fixes, e.g. the pairs family) — backing off to the age cadence",
                 len(_last_unresolved_missing),
             )
-    except Exception:
-        _last_unresolved_missing = set()
+    except Exception as exc:
+        # Leave _last_unresolved_missing unchanged so the existing backoff is
+        # preserved.  Resetting to empty would re-arm the missing trigger and
+        # potentially cause thrashing if the DB is consistently unavailable.
+        logger.warning(
+            "backtest refresh: could not update unresolved-missing set (%s: %s) — backoff state is unchanged",
+            type(exc).__name__,
+            exc,
+        )
 
 
 async def backtest_refresh_loop() -> None:

--- a/backend/archimedes/services/backtest_scheduler.py
+++ b/backend/archimedes/services/backtest_scheduler.py
@@ -39,6 +39,14 @@ logger = logging.getLogger(__name__)
 
 _FALSY = {"0", "false", "no", "off"}
 
+# Backoff memory: if a refresh ran and the SAME strategies are still missing
+# afterwards, they are permanently failing (e.g. the pairs family needs code
+# fixes, not re-runs) — re-triggering on every startup/tick just burns the
+# box's 2 vCPUs for ~15 min right when users are generating. Missing-driven
+# refreshes only fire again once the missing SET changes; age-driven
+# refreshes keep their normal cadence.
+_last_unresolved_missing: set[str] = set()
+
 
 def refresh_enabled() -> bool:
     """On by default; off under TESTING (hermetic) or via the env kill switch."""
@@ -75,7 +83,13 @@ def needs_refresh() -> tuple[bool, str]:
             latest = latest_backtests_by_strategy(session, ids)
         missing = [sid for sid in ids if sid not in latest]
         if missing:
-            return True, f"{len(missing)}/{len(ids)} strategies have no persisted backtest"
+            if set(missing) == _last_unresolved_missing:
+                # A previous refresh already failed to produce rows for exactly
+                # this set — they need code fixes, not compute. Fall through to
+                # the age check instead of thrashing.
+                pass
+            else:
+                return True, f"{len(missing)}/{len(ids)} strategies have no persisted backtest"
         now = datetime.now(UTC)
         oldest = None
         for row in latest.values():
@@ -99,6 +113,28 @@ def _run_refresh() -> dict:
     return run_backtests()
 
 
+def _remember_unresolved_missing() -> None:
+    """After a refresh, record which strategies STILL have no rows (backoff set)."""
+    global _last_unresolved_missing
+    try:
+        from archimedes.db import get_session
+        from archimedes.services.backtest_repository import latest_backtests_by_strategy
+        from archimedes.services.strategy_provider import default_provider
+
+        ids = [st.id for st in default_provider().list_strategies()]
+        with get_session() as session:
+            latest = latest_backtests_by_strategy(session, ids)
+        _last_unresolved_missing = {sid for sid in ids if sid not in latest}
+        if _last_unresolved_missing:
+            logger.warning(
+                "backtest refresh: %d strategies still have no rows after a refresh "
+                "(likely need code fixes, e.g. the pairs family) — backing off to the age cadence",
+                len(_last_unresolved_missing),
+            )
+    except Exception:
+        _last_unresolved_missing = set()
+
+
 async def backtest_refresh_loop() -> None:
     """Long-lived task: settle → check staleness → refresh when needed → sleep."""
     delay = _hours("BACKTEST_REFRESH_STARTUP_DELAY_S", 180.0, 0.0, 3600.0)
@@ -111,6 +147,7 @@ async def backtest_refresh_loop() -> None:
                 logger.info("backtest refresh: starting (%s)", reason)
                 summary = await asyncio.to_thread(_run_refresh)
                 logger.info("backtest refresh: done — %s", summary)
+                _remember_unresolved_missing()
             else:
                 logger.info("backtest refresh: skipped (%s)", reason)
         except Exception as exc:

--- a/backend/tests/test_backtest_scheduler.py
+++ b/backend/tests/test_backtest_scheduler.py
@@ -151,3 +151,26 @@ async def test_loop_survives_refresh_failure(monkeypatch):
     await asyncio.sleep(0.05)  # give the exception path time to run
     assert not task.done(), "a failed refresh must never kill the loop"
     task.cancel()
+
+
+def test_unresolved_missing_backs_off(monkeypatch):
+    """Strategies that STILL have no rows after a refresh (permanently failing,
+    e.g. the pairs family) must not re-trigger a missing-driven refresh every
+    startup — that burned ~15 min of a 2-vCPU box per deploy, starving live
+    generations. Once remembered, only the age cadence (or a CHANGED missing
+    set) refreshes again."""
+    _patch_provider(monkeypatch, ["ok1", "dead1"])
+    _insert_backtest("ok1", datetime.now(UTC))
+
+    should, reason = sched.needs_refresh()
+    assert should is True  # first sighting → refresh attempt is correct
+
+    sched._remember_unresolved_missing()  # refresh "ran"; dead1 still rowless
+    should, reason = sched.needs_refresh()
+    assert should is False, "identical unresolved-missing set must back off"
+    assert "fresh" in reason
+
+    # A NEW missing strategy (set changed) re-arms the missing trigger.
+    _patch_provider(monkeypatch, ["ok1", "dead1", "new1"])
+    should, _ = sched.needs_refresh()
+    assert should is True

--- a/backend/tests/test_backtest_scheduler.py
+++ b/backend/tests/test_backtest_scheduler.py
@@ -31,6 +31,14 @@ def _use_tmp_db(tmp_path, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _reset_backoff_state():
+    """Reset module-level backoff state before each test to prevent order-dependence."""
+    sched._last_unresolved_missing = set()
+    yield
+    sched._last_unresolved_missing = set()
+
+
 class _Strat:
     def __init__(self, sid):
         self.id = sid
@@ -168,7 +176,7 @@ def test_unresolved_missing_backs_off(monkeypatch):
     sched._remember_unresolved_missing()  # refresh "ran"; dead1 still rowless
     should, reason = sched.needs_refresh()
     assert should is False, "identical unresolved-missing set must back off"
-    assert "fresh" in reason
+    assert "backing off" in reason, f"expected explicit backoff reason, got: {reason!r}"
 
     # A NEW missing strategy (set changed) re-arms the missing trigger.
     _patch_provider(monkeypatch, ["ok1", "dead1", "new1"])


### PR DESCRIPTION
## Summary
Post-deploy finding: the #876 scheduler re-triggered a FULL refresh on every container start, because the 6 pairs-family strategies can never produce rows (their import/arity bugs are code problems, not staleness) — 'missing' read as 'stale' forever. Each trigger burns ~15 min of the t3.medium's 2 vCPUs starting 3 minutes after startup, exactly when post-deploy generations run; it starved a live generation job this morning (job stuck with no status, zero candidates).

## Fix
After a refresh completes, remember which strategies STILL lack rows. An identical unresolved-missing set no longer triggers a missing-driven refresh — only the normal age cadence (7d) or a *changed* missing set does. Loud log when backing off.

## Verify
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_backtest_scheduler.py -q  # 9 passed
```

## Anti-goals
No change to the refresh implementation or cadence; the pairs-family fixes remain separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M