### PR TITLE
[backend] Funnel order: Connected Wallet precedes Tried Generate (post-#851 journey)

### DIFF
--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -99,7 +99,7 @@ async def get_funnel(
 ) -> FunnelResponse:
     """Return the distinct-visitor conversion funnel (issue #787).
 
-    Stages: ``landed -> generation_started -> wallet_connected -> vault_deployed``.
+    Stages: ``landed -> wallet_connected -> generation_started -> vault_deployed``.
     Fail-safe: ``FunnelStore`` returns zeros when Redis is unreachable, so this
     endpoint always responds 200 with a well-formed funnel.
     """

--- a/backend/archimedes/services/funnel_store.py
+++ b/backend/archimedes/services/funnel_store.py
@@ -5,7 +5,7 @@ Backs the conversion-funnel instrument. We have a zero-conversion problem
 visitors drop. This records the distinct visitors that reach each stage of the
 journey:
 
-    landed → generation_started → wallet_connected → vault_deployed
+    landed → wallet_connected → generation_started → vault_deployed
 
 using Redis HyperLogLog (``PFADD`` / ``PFCOUNT``) so the counts are *distinct
 visitors* without retaining any raw identifier — privacy-friendly (no tracking
@@ -46,8 +46,8 @@ _PREFIX = "archimedes:funnel"
 # first stage (``landed``) and against the immediately preceding stage.
 STAGES: tuple[str, ...] = (
     "landed",
-    "generation_started",
     "wallet_connected",
+    "generation_started",
     "vault_deployed",
 )
 

--- a/backend/tests/test_funnel_store.py
+++ b/backend/tests/test_funnel_store.py
@@ -90,8 +90,8 @@ async def test_get_totals_reads_pfcount_in_stage_order():
 
     assert counts == {
         "landed": 10,
-        "generation_started": 4,
-        "wallet_connected": 2,
+        "wallet_connected": 4,
+        "generation_started": 2,
         "vault_deployed": 1,
     }
     assert pipe.pfcount.call_count == len(STAGES)
@@ -122,16 +122,17 @@ async def test_get_totals_failsafe_returns_zeros():
 
 
 def test_build_funnel_ratios():
-    counts = {"landed": 100, "generation_started": 25, "wallet_connected": 5, "vault_deployed": 2}
+    # Post-#851 journey: wallet_connected precedes generation_started.
+    counts = {"landed": 100, "wallet_connected": 25, "generation_started": 5, "vault_deployed": 2}
     resp = _build_funnel(counts, "all-time")
     by = {s.stage: s for s in resp.stages}
 
     assert resp.window == "all-time"
     assert by["landed"].pct_of_landed == 1.0
     assert by["landed"].step_conversion == 1.0
-    assert by["generation_started"].pct_of_landed == 0.25
-    assert by["generation_started"].step_conversion == 0.25
-    assert by["wallet_connected"].step_conversion == 0.2  # 5 / 25
+    assert by["wallet_connected"].pct_of_landed == 0.25
+    assert by["wallet_connected"].step_conversion == 0.25  # 25 / 100
+    assert by["generation_started"].step_conversion == 0.2  # 5 / 25
     assert by["vault_deployed"].pct_of_landed == 0.02
 
 

--- a/backend/tests/test_funnel_store.py
+++ b/backend/tests/test_funnel_store.py
@@ -132,8 +132,10 @@ def test_build_funnel_ratios():
     assert by["landed"].step_conversion == 1.0
     assert by["wallet_connected"].pct_of_landed == 0.25
     assert by["wallet_connected"].step_conversion == 0.25  # 25 / 100
+    assert by["generation_started"].pct_of_landed == 0.05
     assert by["generation_started"].step_conversion == 0.2  # 5 / 25
     assert by["vault_deployed"].pct_of_landed == 0.02
+    assert by["vault_deployed"].step_conversion == 0.4  # 2 / 5
 
 
 def test_build_funnel_zero_landed_no_divzero():

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -9,8 +9,8 @@ import { checkSession } from '../siwe'
 //   - Traction: human vs agent REQUEST counts (honestly labelled — these are
 //     cumulative request tallies, bot-inflated, NOT unique users) + the honest
 //     distinct real-users (wallet) count alongside them.
-//   - Conversion funnel: distinct visitors through landed → generation_started →
-//     wallet_connected → vault_deployed, with step-conversion %.
+//   - Conversion funnel: distinct visitors through landed → wallet_connected →
+//     generation_started → vault_deployed, with step-conversion %.
 //   - Visitor insights: distinct visitors by country + device, drawn from the
 //     SAME JS-gated `landed` beacon population as the funnel (#830) — geo/device
 //     count agrees with the funnel `landed` count by construction. Geography is


### PR DESCRIPTION
## Summary

- PR #851 flipped `REQUIRE_SIWE_FOR_GENERATION` on, making wallet connection a prerequisite for generation on the real user journey.
- The `STAGES` tuple in `funnel_store.py` still held the pre-#851 order (`generation_started` before `wallet_connected`), so the Insights funnel rendered "Tried Generate (14)" above "Connected Wallet (18)" — a visually impossible funnel where a later step has a larger count than an earlier one.
- Fix: swap the two middle stages so the canonical order is `landed → wallet_connected → generation_started → vault_deployed`. The UI iterates `funnel.stages` from the API response and requires no ordering change of its own.

## Fix

- **`backend/archimedes/services/funnel_store.py`** — swap `wallet_connected` and `generation_started` in the `STAGES` tuple (the single source of truth for stage order and `step_conversion` predecessor logic); update module docstring.
- **`backend/archimedes/api/metrics_routes.py`** — update the `get_funnel` docstring to reflect the corrected stage sequence.
- **`ui/src/components/Insights.jsx`** — update the stale comment that described the old stage order (rendering is API-driven, so no logic change needed).
- **`backend/tests/test_funnel_store.py`** — update `test_get_totals_reads_pfcount_in_stage_order` (stage-keyed dict now maps in new order) and `test_build_funnel_ratios` (counts and assertions now use `wallet_connected` as the predecessor of `generation_started`).

## Verify

```bash
export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_funnel_store.py -q
# → 15 passed, 0 failed

ruff format backend/archimedes/services/funnel_store.py backend/archimedes/api/metrics_routes.py backend/tests/test_funnel_store.py
ruff check --select E9,F63,F7,F40,F82 backend/archimedes/services/funnel_store.py backend/archimedes/api/metrics_routes.py backend/tests/test_funnel_store.py
# → clean

cd ui && npm ci --no-audit && npm run lint
# → clean
```

## Anti-goals

- No changes to how events are recorded or attributed (`record_funnel` call sites in `generate_routes.py`, `auth_siwe.py`, `vaults_routes.py` are untouched).
- No renaming of stage keys in stored data — Redis HLL key names (`archimedes:funnel:total:<stage>`, `archimedes:funnel:day:<date>:<stage>`) are unchanged.
- No schema changes to `FunnelStageCount` / `FunnelResponse` models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M