### PR TITLE
[passport-honesty] four honesty fixes: has_real, dsr_p_value, /returns endpoint, BacktestVisualizer rewire

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1192,6 +1192,11 @@ async def _persist_candidate(
                     regime_tag=_regime_tag,
                     passes_rigor_gate=bool(c.rigor_verdict.get("passing", False)) if c.rigor_verdict else False,
                     deflated_sharpe_ratio=c.rigor_verdict.get("dsr") if c.rigor_verdict else None,
+                    # dsr_p_value was missing from the initial passport persist (#passport-honesty):
+                    # the rigor verdict carries it under "dsr_p_value" but earlier code only wrote
+                    # "dsr", "pbo", and "oos_sharpe" — leaving the passport column NULL even when
+                    # the generation leaderboard had the correct value.
+                    dsr_p_value=c.rigor_verdict.get("dsr_p_value") if c.rigor_verdict else None,
                     pbo_score=c.rigor_verdict.get("pbo") if c.rigor_verdict else None,
                     out_of_sample_sharpe=c.rigor_verdict.get("oos_sharpe") if c.rigor_verdict else None,
                 )

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -580,3 +580,19 @@ class AMMHealthResponse(BaseModel):
     pools: list[AMMPoolHealth]
     healthy_count: int = 0
     total_pools: int = 0
+
+
+class StrategyReturnsResponse(BaseModel):
+    """Persisted real daily returns for a strategy.
+
+    Returned by GET /api/strategies/{id}/returns. Only present when the
+    strategy has a real BacktestResultRecord row — never synthesized from
+    fixture metrics (#passport-honesty).
+    """
+
+    strategy_id: str
+    source: str = "persisted_backtest"
+    start: str | None = None
+    end: str | None = None
+    n: int
+    daily_returns: list[float]

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -85,7 +85,13 @@ def _to_strategy_response(
         rigor_result = _live_rigor_result_for_one(s)
 
     bt = strategy_provider().get_backtest_result(s.id)
-    has_real = s.real_sharpe is not None
+    # has_real: a BacktestResultRecord (persisted daily-returns row) exists.
+    # Previously derived from ``s.real_sharpe is not None`` (a metric field that can
+    # be populated from fixture stubs without a real returns row — a false positive).
+    # Now strictly tied to the persisted backtest/daily-returns row so that
+    # ``is_backtest_placeholder`` is honest: it is False ONLY when we have actual
+    # persisted run data the rigor gate can re-grade (#passport-honesty).
+    has_real = bt is not None
     return_source, return_source_note = classify_strategy(s)
 
     # Served status overlays the LIVE gate verdict on the file-declared status:
@@ -134,40 +140,53 @@ def _to_strategy_response(
         on_chain_registration_tx=s.on_chain_registration_tx,
         paper_claimed_sharpe=bt.paper_claimed_sharpe if bt else s.paper_claimed_sharpe,
         paper_claim_blended_sharpe=s.paper_claim_blended_sharpe,
-        sharpe_ratio=s.real_sharpe if has_real else (bt.sharpe_ratio if bt else s.stub_sharpe),
-        sortino_ratio=s.real_sortino if has_real else (bt.sortino_ratio if bt else None),
-        cagr=s.real_cagr if has_real else (bt.cagr if bt else s.stub_cagr),
-        max_drawdown=s.real_max_dd if has_real else (bt.max_drawdown if bt else s.stub_max_dd),
-        win_rate=s.real_win_rate if has_real else (bt.win_rate if bt else s.stub_win_rate),
-        calmar_ratio=s.real_calmar if has_real else (bt.calmar_ratio if bt else s.stub_calmar),
-        correlation_to_spy=s.real_corr_spy if has_real else (bt.correlation_to_spy if bt else s.stub_corr_spy),
-        total_trades=s.real_total_trades if has_real else (bt.total_trades if bt else None),
+        # Metric display: use s.real_* (fixture data) when available, fall through
+        # to the persisted backtest row, then the stub placeholder.  This is
+        # independent of ``has_real`` so curated strategies retain their fixture
+        # metrics even when no BacktestResultRecord row exists yet.
+        sharpe_ratio=s.real_sharpe if s.real_sharpe is not None else (bt.sharpe_ratio if bt else s.stub_sharpe),
+        sortino_ratio=s.real_sortino if s.real_sortino is not None else (bt.sortino_ratio if bt else None),
+        cagr=s.real_cagr if s.real_cagr is not None else (bt.cagr if bt else s.stub_cagr),
+        max_drawdown=s.real_max_dd if s.real_max_dd is not None else (bt.max_drawdown if bt else s.stub_max_dd),
+        win_rate=s.real_win_rate if s.real_win_rate is not None else (bt.win_rate if bt else s.stub_win_rate),
+        calmar_ratio=s.real_calmar if s.real_calmar is not None else (bt.calmar_ratio if bt else s.stub_calmar),
+        correlation_to_spy=s.real_corr_spy
+        if s.real_corr_spy is not None
+        else (bt.correlation_to_spy if bt else s.stub_corr_spy),
+        total_trades=s.real_total_trades if s.real_total_trades is not None else (bt.total_trades if bt else None),
         # Numeric rigor fields (#868): prefer the LIVE gate result — the SAME
         # run_rigor_gate call that produced `verdict` above — so the leaderboard
         # can never disagree with GET /api/selection-bias/gate for this id.
         # rigor_result is None when the live gate could not run (no/insufficient
-        # persisted returns, or a batch failure); fall back to the stale
-        # s.<field>/bt.<field> fixture values exactly as before in that case —
-        # only the preferred source changed, the fallback chain is unchanged.
+        # persisted returns, or a batch failure); fall back to the best stored
+        # value (s.<field> fixture first, then bt.<field> from the backtest row).
         deflated_sharpe_ratio=(
             rigor_result.deflated_sharpe
             if rigor_result is not None
-            else (s.deflated_sharpe_ratio if has_real else (bt.deflated_sharpe_ratio if bt else None))
+            else (
+                s.deflated_sharpe_ratio
+                if s.deflated_sharpe_ratio is not None
+                else (bt.deflated_sharpe_ratio if bt else None)
+            )
         ),
         dsr_p_value=(
             rigor_result.dsr_p_value
             if rigor_result is not None
-            else (s.dsr_p_value if has_real else (bt.dsr_p_value if bt else None))
+            else (s.dsr_p_value if s.dsr_p_value is not None else (bt.dsr_p_value if bt else None))
         ),
         pbo_score=(
             rigor_result.pbo_score
             if rigor_result is not None
-            else (s.pbo_score if has_real else (bt.pbo_score if bt else None))
+            else (s.pbo_score if s.pbo_score is not None else (bt.pbo_score if bt else None))
         ),
         out_of_sample_sharpe=(
             rigor_result.oos_sharpe
             if rigor_result is not None
-            else (s.out_of_sample_sharpe if has_real else (bt.out_of_sample_sharpe if bt else None))
+            else (
+                s.out_of_sample_sharpe
+                if s.out_of_sample_sharpe is not None
+                else (bt.out_of_sample_sharpe if bt else None)
+            )
         ),
         kelly_fraction=s.kelly_fraction,
         # Badge from the LIVE gate verdict (#821) — never the fixture boolean.
@@ -175,17 +194,19 @@ def _to_strategy_response(
         # rigor_gate_status carries the honest tri-state ("pass"|"fail"|"pending").
         passes_rigor_gate=verdict.passes,
         rigor_gate_status=verdict.status,
+        # is_backtest_placeholder: True when no BacktestResultRecord row exists.
+        # ``has_real`` is now bt is not None so this is the honest gate.
         is_backtest_placeholder=not has_real,
         sharpe_ci_lower=s.sharpe_ci_lower,
         sharpe_ci_upper=s.sharpe_ci_upper,
         backtest_start=(
             s.real_backtest_start
-            if has_real and s.real_backtest_start
+            if s.real_backtest_start
             else (bt.backtest_start.isoformat() if bt and bt.backtest_start else None)
         ),
         backtest_end=(
             s.real_backtest_end
-            if has_real and s.real_backtest_end
+            if s.real_backtest_end
             else (bt.backtest_end.isoformat() if bt and bt.backtest_end else None)
         ),
         regime_tag=s.regime_tag,
@@ -1628,6 +1649,81 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
         regime_tag=record.regime_tag,
         return_source=return_source_enum.value,
         return_source_note=return_source_note,
+    )
+
+
+@strategies_router.get("/{strategy_id}/returns")
+async def get_strategy_returns(strategy_id: str, request: Request):
+    """Return persisted real daily returns for a strategy.
+
+    Response schema: {strategy_id, source: "persisted_backtest", start, end,
+    n, daily_returns: [...]}
+
+    404 when the strategy does not exist (or is private and the caller is not
+    the owner — 404-hides-existence per the #850 ownership gating contract).
+    404 with body ``{"detail": "no persisted returns"}`` when the strategy
+    exists but has no BacktestResultRecord row. Never synthesizes data from
+    fixture metrics; only real persisted run data is returned (#passport-honesty).
+
+    ``owner_wallet`` is intentionally absent from the response — pseudonymous
+    PII, redacted per the same policy as GET /api/strategies/{id}.
+    """
+    from fastapi import HTTPException
+
+    from archimedes.api.schemas import StrategyReturnsResponse
+
+    # ── 1. Existence + ownership gate (mirrors get_strategy) ────────────────
+    # Curated strategies (in LocalStrategyProvider) are always public.
+    strat = strategy_provider().get_strategy(strategy_id)
+    is_curated = strat is not None
+
+    if not is_curated:
+        from archimedes.db import get_session
+        from archimedes.models.strategy_store import StrategyRecord
+
+        with get_session() as session:
+            row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+            if row is None:
+                raise HTTPException(status_code=404, detail="Strategy not found")
+            if not row.is_example and not row.is_published:
+                caller = get_verified_wallet(request)
+                is_owner = bool(row.owner_wallet and caller and row.owner_wallet.lower() == caller.lower())
+                if not is_owner:
+                    raise HTTPException(status_code=404, detail="Strategy not found")
+
+    # ── 2. Load persisted daily returns from backtest_results ────────────────
+    try:
+        from archimedes.db import get_session, init_db
+        from archimedes.services.backtest_repository import get_daily_returns, latest_backtests_by_strategy
+
+        init_db()
+        with get_session() as session:
+            daily_returns = get_daily_returns(session, strategy_id)
+            rows = latest_backtests_by_strategy(session, [strategy_id])
+            latest_row = rows.get(strategy_id)
+    except Exception as exc:
+        logger.warning("returns endpoint DB read failed for %s: %s", strategy_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to load returns")
+
+    if not daily_returns:
+        raise HTTPException(status_code=404, detail="no persisted returns")
+
+    # ── 3. Build date window from the backtest row (best-effort) ─────────────
+    start: str | None = None
+    end: str | None = None
+    if latest_row is not None:
+        if latest_row.backtest_start:
+            start = str(latest_row.backtest_start)
+        if latest_row.backtest_end:
+            end = str(latest_row.backtest_end)
+
+    return StrategyReturnsResponse(
+        strategy_id=strategy_id,
+        source="persisted_backtest",
+        start=start,
+        end=end,
+        n=len(daily_returns),
+        daily_returns=daily_returns,
     )
 
 

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -33,6 +33,7 @@ from archimedes.api.schemas import (
     SignalResponse,
     StrategyListResponse,
     StrategyResponse,
+    StrategyReturnsResponse,
     StrategySignalResponse,
     StrategySignalsResponse,
 )
@@ -1652,7 +1653,7 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
     )
 
 
-@strategies_router.get("/{strategy_id}/returns")
+@strategies_router.get("/{strategy_id}/returns", response_model=StrategyReturnsResponse)
 async def get_strategy_returns(strategy_id: str, request: Request):
     """Return persisted real daily returns for a strategy.
 
@@ -1669,8 +1670,6 @@ async def get_strategy_returns(strategy_id: str, request: Request):
     PII, redacted per the same policy as GET /api/strategies/{id}.
     """
     from fastapi import HTTPException
-
-    from archimedes.api.schemas import StrategyReturnsResponse
 
     # ── 1. Existence + ownership gate (mirrors get_strategy) ────────────────
     # Curated strategies (in LocalStrategyProvider) are always public.

--- a/backend/archimedes/services/passport_loader.py
+++ b/backend/archimedes/services/passport_loader.py
@@ -205,6 +205,11 @@ def _update_record(
     record.max_drawdown = passport.real_max_dd
     record.cagr = passport.real_cagr
     record.deflated_sharpe_ratio = passport.deflated_sharpe_ratio
+    # dsr_p_value was not updated by _update_record (#passport-honesty): the
+    # _refresh_passport_real_metrics call from _persist_real_returns sets it on
+    # the StrategyPassport but _update_record never wrote it to the DB row,
+    # so strategy_passports.dsr_p_value stayed NULL even after the backtest ran.
+    record.dsr_p_value = passport.dsr_p_value
     record.pbo_score = passport.pbo_score
     record.out_of_sample_sharpe = passport.out_of_sample_sharpe
     record.kelly_fraction = passport.kelly_fraction

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -247,6 +247,7 @@ class TestRootAndHealth:
 
 class TestStrategyRoutes:
     def test_list_strategies(self, client, seeded_db):
+        # Verify the first page returns a well-formed response.
         resp = client.get("/api/strategies/")
         assert resp.status_code == 200
         data = resp.json()
@@ -256,12 +257,17 @@ class TestStrategyRoutes:
         assert "id" in s
         assert "paper_title" in s
         assert "sharpe_ratio" in s
-        # A strategy with a real backtest fixture must surface as non-placeholder.
-        # Don't assume index[0] is fixtured: candidate strategies added without a
-        # backtest fixture can legitimately sort first alphabetically and read as
-        # placeholders, so assert the non-placeholder path is exercised somewhere
-        # in the listing rather than at a brittle fixed position.
-        assert any(st["is_backtest_placeholder"] is False for st in data["strategies"])
+        # A strategy with a real BacktestResultRecord must surface as
+        # non-placeholder across the full catalogue.  ``seeded_db`` inserts one
+        # row (Buy-and-Hold, pipeline_buy_hold.py) into ``backtest_results``.
+        # That file sorts alphabetically after the default page size (20), so we
+        # must paginate to find it — ``_list_all_strategies`` does that.
+        # Don't assume index[0] is the seeded strategy: candidate strategies
+        # added without a BacktestResultRecord legitimately sort first and read
+        # as placeholders, so assert the non-placeholder path is exercised
+        # somewhere across the full listing rather than at a brittle fixed position.
+        all_strategies = _list_all_strategies(client)
+        assert any(st["is_backtest_placeholder"] is False for st in all_strategies)
 
     def test_get_strategy_signals(self, client):
         resp = client.get("/api/strategies/signals")

--- a/backend/tests/test_passport_honesty.py
+++ b/backend/tests/test_passport_honesty.py
@@ -1,0 +1,542 @@
+"""Passport Honesty tests — four fixes, one file.
+
+Covers:
+1. has_real false-positive: strategy with metrics but no BacktestResultRecord
+   must have is_backtest_placeholder=True (has_real derives from persisted row).
+2. dsr_p_value plumbing: persisted record carries dsr_p_value from rigor verdict;
+   _update_record propagates it; API passport returns the correct number.
+3. GET /api/strategies/{id}/returns endpoint:
+   - exists + real returns → 200 with daily_returns list
+   - exists + no returns  → 404 with {"detail": "no persisted returns"}
+   - private strategy as anonymous → 404 (hides existence)
+4. BacktestVisualizer wired: the component fetches the /returns endpoint and
+   does not fall back to mock data (UI lint gate; no backend test needed here).
+
+Gates:
+  env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \\
+      backend/tests/test_passport_honesty.py -q
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+# ── DB isolation fixture ────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Per-test SQLite DB so each test starts empty."""
+    from archimedes.db import init_db
+
+    db_path = tmp_path / "passport_honesty.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    init_db()
+    yield
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _sid() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _make_strategy(
+    *,
+    real_sharpe: float | None = 1.2,
+    strategy_id: str | None = None,
+) -> object:
+    """Fabricate a Strategy dataclass with real_sharpe set but NO backtest row.
+
+    This is the canonical 'metrics-but-no-returns' scenario for Fix 1.
+    """
+    from archimedes.models.paper_ref import PaperRef
+    from archimedes.models.strategy import (
+        PositionSizing,
+        RebalanceFrequency,
+        StrategyPassport,
+        StrategyStatus,
+    )
+
+    sid = strategy_id or _sid()
+    return StrategyPassport(
+        id=sid,
+        papers=[PaperRef(arxiv_id="2301.99999", title="Test", authors=[])],
+        methodology_summary="Test strategy",
+        asset_universe=["SPY"],
+        position_sizing=PositionSizing.EQUAL_WEIGHT,
+        rebalance_frequency=RebalanceFrequency.WEEKLY,
+        status=StrategyStatus.CANDIDATE,
+        regime_tag="regime_neutral",
+        real_sharpe=real_sharpe,
+        deflated_sharpe_ratio=0.5,
+        dsr_p_value=0.85,
+        pbo_score=0.3,
+    )
+
+
+def _passing_returns(n: int = 300) -> list[float]:
+    import numpy as np
+
+    return np.random.default_rng(42).normal(0.0015, 0.004, n).tolist()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fix 1 — has_real false-positive
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestHasRealFalsePositive:
+    """has_real must derive from the presence of a BacktestResultRecord, not
+    from a metric field (real_sharpe).  A strategy with real_sharpe set but
+    no persisted row must report is_backtest_placeholder=True (#passport-honesty).
+    """
+
+    def _call_to_strategy_response(self, strategy, mock_bt=None):
+        """Call _to_strategy_response with a controlled get_backtest_result."""
+        from unittest.mock import MagicMock, patch
+
+        from archimedes.api.strategies_routes import _to_strategy_response
+        from archimedes.services.live_rigor_gate import RigorGateVerdict
+
+        provider = MagicMock()
+        provider.get_backtest_result.return_value = mock_bt
+
+        with (
+            patch("archimedes.api.strategies_routes.strategy_provider", return_value=provider),
+            patch(
+                "archimedes.api.strategies_routes._live_verdict_for_one",
+                return_value=RigorGateVerdict.pending(),
+            ),
+            patch(
+                "archimedes.api.strategies_routes._live_rigor_result_for_one",
+                return_value=None,
+            ),
+        ):
+            return _to_strategy_response(strategy)
+
+    def test_metrics_but_no_returns_is_placeholder(self):
+        """FAILING before the fix: real_sharpe=1.2 but bt=None → is_backtest_placeholder must be True."""
+        s = _make_strategy(real_sharpe=1.2)
+        resp = self._call_to_strategy_response(s, mock_bt=None)
+        assert resp.is_backtest_placeholder is True, (
+            f"Expected is_backtest_placeholder=True when bt=None; got {resp.is_backtest_placeholder}. "
+            "has_real must come from the persisted row, not from real_sharpe."
+        )
+
+    def test_metrics_with_returns_is_not_placeholder(self):
+        """Strategy with a BacktestResultRecord must report is_backtest_placeholder=False."""
+        from archimedes.models.backtest import BacktestResult
+
+        s = _make_strategy(real_sharpe=1.2)
+        bt = BacktestResult(
+            strategy_id=s.id,
+            sharpe_ratio=1.2,
+            sortino_ratio=1.5,
+            max_drawdown=0.1,
+            cagr=0.2,
+            calmar_ratio=2.0,
+            win_rate=0.55,
+            profit_factor=1.3,
+            total_trades=50,
+            avg_holding_period_days=5.0,
+            correlation_to_spy=0.3,
+            correlation_to_btc=0.0,
+            equity_curve=[1.0, 1.05, 1.1],
+        )
+        resp = self._call_to_strategy_response(s, mock_bt=bt)
+        assert resp.is_backtest_placeholder is False
+
+    def test_no_metrics_no_returns_is_placeholder(self):
+        """A strategy with neither real_sharpe nor bt must also be placeholder."""
+        s = _make_strategy(real_sharpe=None)
+        resp = self._call_to_strategy_response(s, mock_bt=None)
+        assert resp.is_backtest_placeholder is True
+
+    def test_fixture_metrics_preserved_when_bt_absent(self):
+        """When bt=None, the display metrics should still use s.real_* from fixture
+        (not be silently None).  This verifies the companion metric-chain fix."""
+        s = _make_strategy(real_sharpe=1.23)
+        resp = self._call_to_strategy_response(s, mock_bt=None)
+        # is_backtest_placeholder correctly True (no bt row)
+        assert resp.is_backtest_placeholder is True
+        # But the stored metric is still surfaced (fixture data is real data)
+        assert resp.sharpe_ratio == pytest.approx(1.23)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fix 2 — dsr_p_value plumbing
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDsrPValuePlumbing:
+    """dsr_p_value written at persist time and survives force_update refresh.
+
+    Regression: _persist_candidate initial write omitted dsr_p_value; and
+    _update_record did not propagate it even when _refresh_passport_real_metrics
+    passed it in.
+    """
+
+    def _make_session(self, tmp_path):
+        """Return a fresh SQLAlchemy session backed by an in-memory SQLite DB."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from archimedes.models.chat import Base
+
+        engine = create_engine(f"sqlite:///{tmp_path}/dsr_test.db")
+        Base.metadata.create_all(engine)
+        return sessionmaker(bind=engine)()
+
+    def test_ingest_passport_with_dsr_p_value(self, tmp_path):
+        """A passport with dsr_p_value persisted correctly on first insert."""
+        from archimedes.models.paper_ref import PaperRef
+        from archimedes.models.strategy import (
+            PositionSizing,
+            RebalanceFrequency,
+            StrategyPassport,
+            StrategyStatus,
+        )
+        from archimedes.services.passport_loader import ingest_passport
+
+        session = self._make_session(tmp_path)
+        passport = StrategyPassport(
+            id="dsr-test-001",
+            papers=[PaperRef(arxiv_id="2301.00001", title="DSR Test", authors=[])],
+            methodology_summary="DSR plumbing test",
+            asset_universe=["SPY"],
+            position_sizing=PositionSizing.EQUAL_WEIGHT,
+            rebalance_frequency=RebalanceFrequency.WEEKLY,
+            status=StrategyStatus.CANDIDATE,
+            regime_tag="regime_neutral",
+            dsr_p_value=0.941561,
+            deflated_sharpe_ratio=0.451103,
+            pbo_score=0.550894,
+        )
+        record = ingest_passport(session, passport, generation_method="fusion")
+        session.flush()
+
+        assert record.dsr_p_value == pytest.approx(0.941561), (
+            f"Expected dsr_p_value=0.941561 after first ingest; got {record.dsr_p_value}"
+        )
+
+    def test_update_record_propagates_dsr_p_value(self, tmp_path):
+        """force_update=True must propagate dsr_p_value (was missing from _update_record)."""
+        from archimedes.models.paper_ref import PaperRef
+        from archimedes.models.strategy import (
+            PositionSizing,
+            RebalanceFrequency,
+            StrategyPassport,
+            StrategyStatus,
+        )
+        from archimedes.services.passport_loader import ingest_passport
+
+        session = self._make_session(tmp_path)
+
+        # First write: dsr_p_value=None (mimics _persist_candidate before fix)
+        passport_v1 = StrategyPassport(
+            id="dsr-test-002",
+            papers=[PaperRef(arxiv_id="2301.00002", title="DSR Refresh Test", authors=[])],
+            methodology_summary="DSR update test",
+            asset_universe=["QQQ"],
+            position_sizing=PositionSizing.EQUAL_WEIGHT,
+            rebalance_frequency=RebalanceFrequency.WEEKLY,
+            status=StrategyStatus.CANDIDATE,
+            regime_tag="regime_neutral",
+            dsr_p_value=None,
+            deflated_sharpe_ratio=0.45,
+        )
+        r1 = ingest_passport(session, passport_v1, generation_method="fusion", force_update=True)
+        session.flush()
+        assert r1.dsr_p_value is None
+
+        # Second write: dsr_p_value set (mimics _refresh_passport_real_metrics)
+        passport_v2 = StrategyPassport(
+            id="dsr-test-002",
+            papers=[PaperRef(arxiv_id="2301.00002", title="DSR Refresh Test", authors=[])],
+            methodology_summary="DSR update test",
+            asset_universe=["QQQ"],
+            position_sizing=PositionSizing.EQUAL_WEIGHT,
+            rebalance_frequency=RebalanceFrequency.WEEKLY,
+            status=StrategyStatus.CANDIDATE,
+            regime_tag="regime_neutral",
+            dsr_p_value=0.941561,
+            deflated_sharpe_ratio=0.451103,
+        )
+        r2 = ingest_passport(session, passport_v2, generation_method="fusion", force_update=True)
+        session.flush()
+
+        assert r2.dsr_p_value == pytest.approx(0.941561), (
+            f"Expected dsr_p_value=0.941561 after force_update; got {r2.dsr_p_value}. "
+            "_update_record must propagate dsr_p_value."
+        )
+        assert r2.id == r1.id, "force_update must update the existing row, not insert a new one"
+
+    @pytest.mark.asyncio
+    async def test_api_returns_dsr_p_value_from_persisted_record(self, tmp_path, monkeypatch):
+        """GET /api/strategies/{id} returns dsr_p_value from the persisted passport record.
+
+        Simulates the prod scenario: fusion strategy with dsr_p_value stored in
+        strategy_passports (via _persist_candidate fix + _update_record fix).
+        """
+        from archimedes.db import get_session, init_db
+        from archimedes.main import app
+        from archimedes.models.paper_ref import PaperRef
+        from archimedes.models.strategy import (
+            PositionSizing,
+            RebalanceFrequency,
+            StrategyPassport,
+            StrategyStatus,
+        )
+        from archimedes.models.strategy_store import upsert_strategy
+        from archimedes.services.passport_loader import ingest_passport
+
+        db_path = tmp_path / "dsr_api.db"
+        monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+        init_db()
+
+        with get_session() as session:
+            # Create a strategy_store row via the proper upsert (handles content_hash)
+            row = upsert_strategy(
+                session,
+                generation_method="fusion",
+                strategy_name="DSR Test Strategy",
+                thesis="Test",
+                source_papers=[{"arxiv_id": "2301.99999"}],
+                asset_universe=["SPY"],
+                is_example=True,
+            )
+            session.flush()
+            sid = row.id
+
+            passport = StrategyPassport(
+                id=sid,
+                papers=[PaperRef(arxiv_id="2301.99999", title="DSR API Test", authors=[])],
+                methodology_summary="DSR API test",
+                asset_universe=["SPY"],
+                position_sizing=PositionSizing.EQUAL_WEIGHT,
+                rebalance_frequency=RebalanceFrequency.WEEKLY,
+                status=StrategyStatus.CANDIDATE,
+                regime_tag="regime_neutral",
+                dsr_p_value=0.941561,
+                deflated_sharpe_ratio=0.451103,
+                pbo_score=0.550894,
+                real_sharpe=1.1,
+            )
+            ingest_passport(session, passport, generation_method="fusion")
+            session.commit()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get(f"/api/strategies/{sid}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["dsr_p_value"] == pytest.approx(0.941561), (
+            f"Expected dsr_p_value=0.941561 from persisted passport; got {body['dsr_p_value']}"
+        )
+        assert body["deflated_sharpe_ratio"] == pytest.approx(0.451103)
+        assert body["pbo_score"] == pytest.approx(0.550894)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fix 3 — GET /api/strategies/{id}/returns endpoint
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStrategyReturnsEndpoint:
+    """Hermetic tests for GET /api/strategies/{id}/returns."""
+
+    def _insert_strategy_and_backtest(
+        self,
+        session,
+        sid: str,
+        returns: list[float],
+        *,
+        owner_wallet: str | None = None,
+        is_example: bool = True,
+        is_published: bool = True,
+    ):
+        """Insert a strategy_store + strategy_passports row + BacktestResultRecord."""
+        import json as _json
+
+        from archimedes.models.backtest import BacktestResult
+        from archimedes.models.paper_ref import PaperRef
+        from archimedes.models.strategy import (
+            PositionSizing,
+            RebalanceFrequency,
+            StrategyPassport,
+            StrategyStatus,
+        )
+        from archimedes.models.strategy_store import StrategyRecord
+        from archimedes.services.backtest_repository import insert_backtest_if_missing
+        from archimedes.services.passport_loader import ingest_passport
+
+        # Use a fake but valid-format content_hash derived from the sid.
+        fake_hash = ("0x" + sid).ljust(66, "0")
+        row = StrategyRecord(
+            id=sid,
+            content_hash=fake_hash,
+            generation_method="fusion",
+            source_papers="[]",
+            strategy_name=f"Test {sid[:8]}",
+            thesis="Returns endpoint test",
+            asset_universe='["SPY"]',
+            risk_profile="moderate",
+            status="candidate",
+            is_example=is_example,
+            is_published=is_published,
+            owner_wallet=owner_wallet,
+        )
+        session.add(row)
+        session.flush()
+
+        passport = StrategyPassport(
+            id=sid,
+            # Unique arxiv_id + summary per sid so ingest_passport's content_hash
+            # is distinct across tests that share the autouse DB.
+            papers=[PaperRef(arxiv_id=f"2301.{sid[:8]}", title=f"Returns Test {sid[:4]}", authors=[])],
+            methodology_summary=f"Returns endpoint test {sid}",
+            asset_universe=["SPY"],
+            position_sizing=PositionSizing.EQUAL_WEIGHT,
+            rebalance_frequency=RebalanceFrequency.WEEKLY,
+            status=StrategyStatus.CANDIDATE,
+            regime_tag="regime_neutral",
+        )
+        ingest_passport(session, passport, generation_method="fusion")
+
+        if returns:
+            equity = [1.0]
+            for r in returns:
+                equity.append(equity[-1] * (1.0 + r))
+            result = BacktestResult(
+                strategy_id=sid,
+                sharpe_ratio=1.0,
+                sortino_ratio=1.2,
+                max_drawdown=0.1,
+                cagr=0.15,
+                calmar_ratio=1.5,
+                win_rate=0.55,
+                profit_factor=1.2,
+                total_trades=20,
+                avg_holding_period_days=5.0,
+                correlation_to_spy=0.3,
+                correlation_to_btc=0.0,
+                equity_curve=equity,
+            )
+            artifact = {"results": [{"metrics": {"daily_returns": returns}}]}
+            import hashlib
+
+            artifact_json = _json.dumps(artifact)
+            content_hash = hashlib.sha256(artifact_json.encode()).hexdigest()
+            insert_backtest_if_missing(
+                session,
+                strategy_id=sid,
+                content_hash=content_hash,
+                result=result,
+                artifact_json=artifact_json,
+            )
+
+        session.commit()
+
+    @pytest.mark.asyncio
+    async def test_exists_with_returns_200(self, tmp_path, monkeypatch):
+        """Strategy with persisted daily returns → 200 with correct payload."""
+        from archimedes.db import get_session, init_db
+        from archimedes.main import app
+
+        db_path = tmp_path / "returns_200.db"
+        monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+        init_db()
+
+        sid = "ret-" + _sid()
+        returns = _passing_returns(50)
+
+        with get_session() as session:
+            self._insert_strategy_and_backtest(session, sid, returns)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get(f"/api/strategies/{sid}/returns")
+
+        assert resp.status_code == 200, f"Expected 200; got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body["strategy_id"] == sid
+        assert body["source"] == "persisted_backtest"
+        assert body["n"] == len(returns)
+        assert body["n"] == len(body["daily_returns"])
+        assert body["daily_returns"] == pytest.approx(returns, rel=1e-6)
+        # owner_wallet must NOT appear in the response
+        assert "owner_wallet" not in body
+
+    @pytest.mark.asyncio
+    async def test_exists_no_returns_404(self, tmp_path, monkeypatch):
+        """Strategy exists but has no BacktestResultRecord → 404 with JSON error."""
+        from archimedes.db import get_session, init_db
+        from archimedes.main import app
+
+        db_path = tmp_path / "returns_404.db"
+        monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+        init_db()
+
+        sid = "ret-" + _sid()
+
+        with get_session() as session:
+            self._insert_strategy_and_backtest(session, sid, [])  # no returns
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get(f"/api/strategies/{sid}/returns")
+
+        assert resp.status_code == 404, f"Expected 404; got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body.get("detail") == "no persisted returns", f"Expected detail='no persisted returns'; got {body}"
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_strategy_404(self, tmp_path, monkeypatch):
+        """Strategy does not exist → 404."""
+        from archimedes.db import init_db
+        from archimedes.main import app
+
+        db_path = tmp_path / "returns_nonexistent.db"
+        monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+        init_db()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/strategies/does-not-exist-123/returns")
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_private_strategy_as_anonymous_404(self, tmp_path, monkeypatch):
+        """Private (not is_example, not is_published) strategy → 404 for anonymous caller.
+
+        404-hides-existence: a non-owner must not learn whether the strategy exists.
+        """
+        from archimedes.db import get_session, init_db
+        from archimedes.main import app
+
+        db_path = tmp_path / "returns_private.db"
+        monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+        init_db()
+
+        sid = "prv-" + _sid()
+        owner = "0x" + "a" * 40
+
+        with get_session() as session:
+            self._insert_strategy_and_backtest(
+                session,
+                sid,
+                _passing_returns(50),
+                owner_wallet=owner,
+                is_example=False,
+                is_published=False,
+            )
+
+        # Anonymous caller — no SIWE session — must get 404
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get(f"/api/strategies/{sid}/returns")
+
+        assert resp.status_code == 404, f"Private strategy must 404 for anonymous caller; got {resp.status_code}"

--- a/ui/src/components/BacktestVisualizer.jsx
+++ b/ui/src/components/BacktestVisualizer.jsx
@@ -346,39 +346,64 @@ export default function BacktestVisualizer({ result, strategyId, weights } = {})
   const [realReturns, setRealReturns] = useState(null)   // float[] | null
   const [returnsNoData, setReturnsNoData] = useState(false)
 
+  // Depend on the minimal inputs (strategyId + the returns array itself), NOT
+  // the whole `result` object — parents recreate `result` on unrelated
+  // re-renders and that identity churn must not trigger refetches.
+  const propReturns = result?.returns ?? null
+
   useEffect(() => {
-    // If the caller passes real returns via result prop, use those directly.
-    if (result?.returns) {
-      setRealReturns(result.returns)
+    // If the caller passes real returns via the result prop, use those directly.
+    // Clear any loading state a prior strategyId's in-flight fetch left behind.
+    if (propReturns) {
+      setRealReturns(propReturns)
       setReturnsNoData(false)
+      setReturnsLoading(false)
       return
     }
     if (!strategyId) {
       setRealReturns(null)
       setReturnsNoData(false)
+      setReturnsLoading(false)
       return
     }
+    // Cancellation guard: abort the in-flight request and drop late setState
+    // when strategyId changes or the component unmounts.
+    const controller = new AbortController()
+    let cancelled = false
     setReturnsLoading(true)
     setRealReturns(null)
     setReturnsNoData(false)
-    fetch(`${API_BASE}/api/strategies/${encodeURIComponent(strategyId)}/returns`)
+    // credentials:'include' sends the SIWE session cookie (same idiom as
+    // ui/src/api.js apiGet) so owners of private strategies get their returns
+    // when VITE_API_BASE is cross-origin instead of always seeing the 404 state.
+    fetch(`${API_BASE}/api/strategies/${encodeURIComponent(strategyId)}/returns`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
       .then((res) => {
         if (res.status === 404) {
-          setReturnsNoData(true)
+          if (!cancelled) setReturnsNoData(true)
           return null
         }
         if (!res.ok) throw new Error(`Server error ${res.status}`)
         return res.json()
       })
       .then((data) => {
-        if (data?.daily_returns) setRealReturns(data.daily_returns)
+        if (!cancelled && data?.daily_returns) setRealReturns(data.daily_returns)
       })
-      .catch(() => {
-        // Network / unexpected error — treat as no data rather than crashing.
-        setReturnsNoData(true)
+      .catch((err) => {
+        // Abort is not an error state; network/unexpected errors read as no data
+        // rather than crashing — still never a mock fallback.
+        if (!cancelled && err?.name !== 'AbortError') setReturnsNoData(true)
       })
-      .finally(() => setReturnsLoading(false))
-  }, [strategyId, result])
+      .finally(() => {
+        if (!cancelled) setReturnsLoading(false)
+      })
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [strategyId, propReturns])
 
   // Mock scaffold for walk-forward/sweep/trade sections (interactive demos).
   const data = useMemo(() => {

--- a/ui/src/components/BacktestVisualizer.jsx
+++ b/ui/src/components/BacktestVisualizer.jsx
@@ -1,6 +1,7 @@
 // BacktestVisualizer — equity+drawdown dual chart, chronological IS/OOS bands,
 // parameter-sweep heatmap, filterable trade log, and rolling-stat confidence
-// band. Renders standalone with mock defaults; accepts real props.
+// band. Accepts real props; fetches daily returns from the API when strategyId
+// is set (#passport-honesty: never falls back to mock data for the equity curve).
 //
 // Suggested integration: import into the StrategyPassport / backtest detail
 // surface, e.g.
@@ -10,12 +11,11 @@
 // All inline SVG (no chart lib). Styling reuses shared App.css classes plus a
 // small colocated BacktestVisualizer.css.
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import {
   equityFromReturns,
   drawdownSeries,
   rollingSharpe,
-  mockReturns,
   seededRng,
 } from '../utils/riskMath'
 import './BacktestVisualizer.css'
@@ -278,9 +278,9 @@ function RollingStatBand({ returns, window }) {
   )
 }
 
-// ─── mock defaults ──────────────────────────────────────────
-function buildMockResult() {
-  const returns = mockReturns(252, { seed: 21, drift: 0.0006 })
+// ─── mock scaffolding for walk-forward/sweep/trade sections ─
+// Returns (equity curve) are fetched from the real API — no mock data for those.
+function buildMockScaffold() {
   const rng = seededRng(5)
   const folds = Array.from({ length: 6 }, (_, i) => ({
     isSharpe: 1.0 + rng() * 0.8,
@@ -317,7 +317,7 @@ function buildMockResult() {
       price: 50 + rng() * 400,
     }
   })
-  return { returns, folds, sweep, trades }
+  return { folds, sweep, trades }
 }
 
 const METRIC_OPTIONS = [
@@ -339,10 +339,51 @@ export default function BacktestVisualizer({ result, strategyId, weights } = {})
     metric: 'sharpe_ratio',
   })
 
+  // ── Real returns state (#passport-honesty) ───────────────────────────────
+  // Fetched from GET /api/strategies/{id}/returns. Never falls back to mock
+  // data: on 404 ("no persisted returns") we render an honest empty state.
+  const [returnsLoading, setReturnsLoading] = useState(false)
+  const [realReturns, setRealReturns] = useState(null)   // float[] | null
+  const [returnsNoData, setReturnsNoData] = useState(false)
+
+  useEffect(() => {
+    // If the caller passes real returns via result prop, use those directly.
+    if (result?.returns) {
+      setRealReturns(result.returns)
+      setReturnsNoData(false)
+      return
+    }
+    if (!strategyId) {
+      setRealReturns(null)
+      setReturnsNoData(false)
+      return
+    }
+    setReturnsLoading(true)
+    setRealReturns(null)
+    setReturnsNoData(false)
+    fetch(`${API_BASE}/api/strategies/${encodeURIComponent(strategyId)}/returns`)
+      .then((res) => {
+        if (res.status === 404) {
+          setReturnsNoData(true)
+          return null
+        }
+        if (!res.ok) throw new Error(`Server error ${res.status}`)
+        return res.json()
+      })
+      .then((data) => {
+        if (data?.daily_returns) setRealReturns(data.daily_returns)
+      })
+      .catch(() => {
+        // Network / unexpected error — treat as no data rather than crashing.
+        setReturnsNoData(true)
+      })
+      .finally(() => setReturnsLoading(false))
+  }, [strategyId, result])
+
+  // Mock scaffold for walk-forward/sweep/trade sections (interactive demos).
   const data = useMemo(() => {
-    const mock = buildMockResult()
+    const mock = buildMockScaffold()
     return {
-      returns: result?.returns ?? mock.returns,
       folds: result?.folds ?? mock.folds,
       sweep: result?.sweep ?? mock.sweep,
       trades: result?.trades ?? mock.trades,
@@ -410,7 +451,23 @@ export default function BacktestVisualizer({ result, strategyId, weights } = {})
         </p>
       </div>
 
-      <EquityDrawdownChart returns={data.returns} oosStartFrac={0.7} />
+      {/* ── Equity curve: real returns from API or honest empty state ── */}
+      {returnsLoading && (
+        <div className="card-elevated" style={{ padding: 24, marginBottom: 20, textAlign: 'center', color: 'var(--text-3)' }}>
+          Loading backtest returns…
+        </div>
+      )}
+      {!returnsLoading && realReturns && (
+        <EquityDrawdownChart returns={realReturns} oosStartFrac={0.7} />
+      )}
+      {!returnsLoading && returnsNoData && (
+        <div className="card-elevated" style={{ padding: 24, marginBottom: 20 }}>
+          <div className="label mb-2">Equity Curve &amp; Drawdown</div>
+          <p className="body" style={{ color: 'var(--text-3)', fontStyle: 'italic' }}>
+            No real backtest returns persisted yet — this strategy has not completed a real-data backtest.
+          </p>
+        </div>
+      )}
       <WalkForwardBands folds={data.folds} />
 
       {/* Parameter sweep section */}
@@ -499,7 +556,7 @@ export default function BacktestVisualizer({ result, strategyId, weights } = {})
       </div>
 
       <TradeLog trades={data.trades} />
-      <RollingStatBand returns={data.returns} window={60} />
+      {realReturns && <RollingStatBand returns={realReturns} window={60} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Four fixes ensuring every UI/pitch surface is backed by a live data path — no fixtures, no silent mocks.

**Fix 1 — `has_real` false-positive** (`strategies_routes.py`):
`is_backtest_placeholder` previously derived from `s.real_sharpe is not None`, which is a fixture field that can be populated without any actual persisted run data. It now checks `bt is not None` (actual `BacktestResultRecord` row presence). Metric display chain is unchanged — curated fixture sharpe/cagr/drawdown still served; only the placeholder gate is now honest.

**Fix 2 — `dsr_p_value` plumbing** (`generation_pipeline.py`, `passport_loader.py`):
Two gaps: (1) `_persist_candidate` was missing `dsr_p_value` from the initial passport write; (2) `_update_record` never propagated it on `force_update`. Both closed. Resolves the `GET /api/strategies/7d1e554f...` → `dsr_p_value: null` while the generation leaderboard showed `0.941561`.

**Fix 3 — `GET /api/strategies/{id}/returns`** (`strategies_routes.py`, `schemas.py`):
New endpoint returns persisted daily returns from `BacktestResultRecord.artifact_json`. 404 for unknown/private strategies (hides existence for non-owners). 404 with `{"detail": "no persisted returns"}` when no persisted row exists. Never synthesizes. Ownership gating mirrors the #850 pattern.

**Fix 4 — `BacktestVisualizer` rewired** (`ui/src/components/BacktestVisualizer.jsx`):
Component now fetches `/api/strategies/{id}/returns` via `useEffect`. On 200: renders real `EquityDrawdownChart`. On 404: renders honest empty state ("No real backtest returns persisted yet — this strategy has not completed a real-data backtest."). Never falls back to mock data for the equity curve. Mock scaffold kept only for walk-forward/sweep/trade demo sections (no real-data path yet).

## Test plan

- [x] 11 new tests in `backend/tests/test_passport_honesty.py` (has_real false-positive, dsr_p_value plumbing, /returns endpoint — 200/404/private/nonexistent)
- [x] `test_list_strategies` updated to paginate full catalogue — `pipeline_buy_hold.py` sorts past the default page-20 boundary; old test was exercising a different code path
- [x] `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests -m "not integration" -q` → 2393 passed, 0 failed
- [x] `ruff format` + `ruff check --select E9,F63,F7,F40,F82` on all changed `.py` files → clean
- [x] `cd ui && npm run lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M