### PR TITLE
[quant] Fix pairs-family backtest backfill: single-symbol arity crash + non-importable sibling module (#887)

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/cli.py
+++ b/analytics-engine/src/archimedes_analytics_engine/cli.py
@@ -9,10 +9,11 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
+import backtrader as bt
 import pandas as pd
 
 from .data import fetch_ohlcv
-from .engine import BACKTEST_ENGINE_TAG, run_backtest
+from .engine import BACKTEST_ENGINE_TAG, FeedArityError, required_feeds, run_backtest, run_pairs_backtest
 from .instruments import OPERATION_TO_SYMBOL, resolve_operations
 from .strategy_loader import load_strategy
 
@@ -51,6 +52,34 @@ def _merge_metadata(
     return merged
 
 
+def _pair_legs(
+    strategy_cls: type[bt.Strategy],
+    metadata: dict[str, Any],
+    strategy_path: Path,
+) -> list[str]:
+    """Resolve the two thesis-true legs of a pairs strategy from its declared universe.
+
+    The pairs family declares its traded pair as ``ASSET_UNIVERSE`` (e.g.
+    ``["GLD", "GDX"]``), which is exactly the leg mapping the fixture
+    regenerator uses. Dedupes case-insensitively and fails closed with a typed
+    :class:`FeedArityError` when fewer than two distinct instruments survive —
+    never lets the strategy reach ``self.datas[1]`` on a single feed.
+    """
+    universe = metadata.get("asset_universe") or []
+    legs: list[str] = []
+    for symbol in universe:
+        normalized = str(symbol).upper()
+        if normalized and normalized not in legs:
+            legs.append(normalized)
+    if len(legs) < 2:
+        raise FeedArityError(
+            f"pairs strategy {strategy_cls.__name__} ({strategy_path.name}) needs >= 2 "
+            f"distinct instruments, but its declared ASSET_UNIVERSE {universe!r} resolves "
+            f"to {len(legs)} — failing closed instead of crashing on the missing second leg"
+        )
+    return resolve_operations(legs[:2])
+
+
 def run_command(
     *,
     operations: list[str],
@@ -71,7 +100,6 @@ def run_command(
     walk_forward_split: float | None = None,
     fetcher: Callable[[str, str, str], pd.DataFrame] = fetch_ohlcv,
 ) -> dict:
-    ops = resolve_operations(operations)
     run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     bundle = load_strategy(strategy_path, strategy_class)
 
@@ -91,26 +119,64 @@ def run_command(
     results: list[dict] = []
     data_hashes: list[str] = []
 
-    for op in ops:
-        symbol = OPERATION_TO_SYMBOL[op]
-        prices = fetcher(symbol, start, end)
-        data_hashes.append(_hash_frame(prices))
+    feeds_needed = required_feeds(bundle.cls)
+    if feeds_needed > 2:
+        raise FeedArityError(
+            f"strategy {bundle.cls.__name__} declares REQUIRED_FEEDS={feeds_needed}, "
+            "but this runner supports 1 (single-feed) or 2 (pairs) feeds today"
+        )
 
-        bt_result = run_backtest(
-            prices,
+    if feeds_needed == 2:
+        # Pairs strategies trade their declared two-leg universe, not the
+        # requested benchmark operations — a single benchmark feed would crash
+        # on self.datas[1] (issue #887). Same leg mapping as regen_fixtures.py.
+        ops = _pair_legs(bundle.cls, metadata, strategy_path)
+        symbol_a, symbol_b = OPERATION_TO_SYMBOL[ops[0]], OPERATION_TO_SYMBOL[ops[1]]
+        prices_a = fetcher(symbol_a, start, end)
+        prices_b = fetcher(symbol_b, start, end)
+        data_hashes.append(_hash_frame(prices_a))
+        data_hashes.append(_hash_frame(prices_b))
+
+        bt_result = run_pairs_backtest(
+            prices_a,
+            prices_b,
             strategy_cls=bundle.cls,
             initial_cash=initial_cash,
+            name_a=ops[0],
+            name_b=ops[1],
             transaction_cost_bps=tx_cost_bps,
             slippage_bps=slippage_bps,
         )
 
         results.append(
             {
-                "operation": op,
-                "symbol": symbol,
+                "operation": f"{ops[0]}/{ops[1]}",
+                "symbol": f"{symbol_a}/{symbol_b}",
                 "metrics": asdict(bt_result),
             }
         )
+    else:
+        ops = resolve_operations(operations)
+        for op in ops:
+            symbol = OPERATION_TO_SYMBOL[op]
+            prices = fetcher(symbol, start, end)
+            data_hashes.append(_hash_frame(prices))
+
+            bt_result = run_backtest(
+                prices,
+                strategy_cls=bundle.cls,
+                initial_cash=initial_cash,
+                transaction_cost_bps=tx_cost_bps,
+                slippage_bps=slippage_bps,
+            )
+
+            results.append(
+                {
+                    "operation": op,
+                    "symbol": symbol,
+                    "metrics": asdict(bt_result),
+                }
+            )
 
     lookahead_passed = all(r["metrics"]["look_ahead_audit_passed"] for r in results) if results else False
     paper_claim_applied = metadata.get("paper_claimed_sharpe") is not None

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -16,6 +16,30 @@ RF_DAILY = RF_ANNUAL / ANNUALIZATION
 BACKTEST_ENGINE_TAG = "backtrader"
 
 
+class FeedArityError(ValueError):
+    """A strategy that hard-requires N aligned data feeds was given fewer.
+
+    Raised fail-closed at the runner boundary (issue #887) instead of letting
+    a pairs strategy crash mid-run with a bare ``IndexError`` on
+    ``self.datas[1]``. The message is passport-grade: it says what the
+    strategy needs ("pairs needs >= 2 instruments") rather than where a list
+    index went out of range.
+    """
+
+
+def required_feeds(strategy_cls: type[bt.Strategy]) -> int:
+    """How many aligned data feeds ``strategy_cls`` declares it hard-requires.
+
+    Strategies that index ``self.datas[1]`` (the pairs family) declare
+    ``REQUIRED_FEEDS = 2`` as a class attribute; anything undeclared or
+    malformed is treated as the single-feed default of 1.
+    """
+    try:
+        return max(1, int(getattr(strategy_cls, "REQUIRED_FEEDS", 1) or 1))
+    except (TypeError, ValueError):
+        return 1
+
+
 @dataclass
 class BacktestResult:
     """Container for every metric a single backtest run produces.
@@ -318,7 +342,23 @@ def run_backtest(
     -------
     BacktestResult
         Full metric record for the run.
+
+    Raises
+    ------
+    FeedArityError
+        If ``strategy_cls`` declares ``REQUIRED_FEEDS > 1`` — a pairs /
+        multi-feed strategy cannot run on a single feed and must go through
+        :func:`run_pairs_backtest` or :func:`run_multi_backtest`.
     """
+    required = required_feeds(strategy_cls)
+    if required > 1:
+        raise FeedArityError(
+            f"strategy {strategy_cls.__name__} requires {required} aligned data feeds "
+            "but the single-feed runner provides 1 — a pairs strategy needs >= 2 "
+            "instruments; run it via run_pairs_backtest/run_multi_backtest with its "
+            "declared asset universe"
+        )
+
     cerebro = bt.Cerebro(stdstats=False)
     transaction_cost_bps, slippage_bps = _configure_broker(
         cerebro,

--- a/analytics-engine/src/archimedes_analytics_engine/strategy_loader.py
+++ b/analytics-engine/src/archimedes_analytics_engine/strategy_loader.py
@@ -21,6 +21,11 @@ METADATA_KEYS: tuple[str, ...] = (
     "PAPER_CLAIMED_SHARPE",
     "PAPER_CLAIMED_CAGR",
     "PAPER_CLAIMED_MAX_DD",
+    # Feed-universe declarations: which instruments the strategy trades and how
+    # many aligned data feeds it hard-requires (pairs strategies declare 2 so
+    # the runner can pick run_pairs_backtest instead of the single-feed path).
+    "ASSET_UNIVERSE",
+    "REQUIRED_FEEDS",
 )
 
 
@@ -36,6 +41,17 @@ def _load_module(path: Path) -> ModuleType:
         raise ValueError(f"Strategy file not found: {path}")
     if path.suffix != ".py":
         raise ValueError(f"Strategy file must be .py: {path}")
+
+    # Sibling-import support (issue #887): strategy modules may import a
+    # neighbour by bare name (the gatev pair variants import
+    # gatev_2006_pairs_distance). That resolved only when CWD happened to be
+    # the strategies dir; under the scheduler/backfill import path it is not,
+    # so exec_module raised ModuleNotFoundError. Injecting the file's parent
+    # dir onto sys.path at the loader boundary makes siblings resolvable
+    # regardless of CWD for every current and future strategy file.
+    parent_dir = str(path.resolve().parent)
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
 
     module_name = f"archimedes_strategy_{path.stem}_{abs(hash(path))}"
     spec = importlib.util.spec_from_file_location(module_name, path)

--- a/analytics-engine/strategies/elliott_2005_kalman_pairs.py
+++ b/analytics-engine/strategies/elliott_2005_kalman_pairs.py
@@ -104,6 +104,10 @@ class KalmanPairsTrading(bt.Strategy):
     ``engine.run_pairs_backtest``.
     """
 
+    # Runner contract (issue #887): this class hard-indexes self.datas[1], so a
+    # single-feed run must fail closed with a typed error, not an IndexError.
+    REQUIRED_FEEDS = 2
+
     params = (
         ("delta", 1e-4),  # state-drift scale; W = delta/(1-delta) * I (small => slow hedge drift)
         ("ve", 1e-3),  # observation-noise variance

--- a/analytics-engine/strategies/engle_granger_1987_cointegration_pairs.py
+++ b/analytics-engine/strategies/engle_granger_1987_cointegration_pairs.py
@@ -111,6 +111,10 @@ class CointegrationPairsTrading(bt.Strategy):
     ``self.datas[1]`` (leg B). Driven by ``engine.run_pairs_backtest``.
     """
 
+    # Runner contract (issue #887): this class hard-indexes self.datas[1], so a
+    # single-feed run must fail closed with a typed error, not an IndexError.
+    REQUIRED_FEEDS = 2
+
     params = (
         ("lookback", 252),  # formation window for OLS hedge ratio + spread stats
         ("entry_z", 2.0),

--- a/analytics-engine/strategies/gatev_2006_pairs_distance.py
+++ b/analytics-engine/strategies/gatev_2006_pairs_distance.py
@@ -99,6 +99,10 @@ class PairsDistanceTrading(bt.Strategy):
     ``self.datas[1]`` (leg B). Driven by ``engine.run_pairs_backtest``.
     """
 
+    # Runner contract (issue #887): this class hard-indexes self.datas[1], so a
+    # single-feed run must fail closed with a typed error, not an IndexError.
+    REQUIRED_FEEDS = 2
+
     params = (
         ("lookback", 252),
         ("entry_z", 2.0),

--- a/analytics-engine/tests/test_cli.py
+++ b/analytics-engine/tests/test_cli.py
@@ -2,7 +2,9 @@ import json
 from pathlib import Path
 
 import pandas as pd
+import pytest
 from archimedes_analytics_engine.cli import run_command
+from archimedes_analytics_engine.engine import FeedArityError
 
 
 def _fake_fetch(symbol: str, start: str, end: str) -> pd.DataFrame:
@@ -180,3 +182,64 @@ def test_artifact_results_carry_metrics_block(tmp_path: Path) -> None:
         assert key in metrics, f"missing metric key: {key}"
     assert metrics["backtest_engine"] == "backtrader"
     assert metrics["look_ahead_audit_passed"] is True
+
+
+# Issue #887: run_command must route two-feed (pairs) strategies through the
+# two-feed runner on their declared universe legs, and fail closed with a
+# typed error when the universe collapses to a single instrument.
+
+
+def _write_pairs_strategy(path: Path, universe: str = "['GLD', 'GDX']") -> None:
+    path.write_text(
+        "import backtrader as bt\n\n"
+        f"ASSET_UNIVERSE = {universe}\n\n"
+        "class PairsProbe(bt.Strategy):\n"
+        "    REQUIRED_FEEDS = 2\n\n"
+        "    def next(self):\n"
+        "        float(self.datas[1].close[0])  # hard two-feed dependency\n"
+    )
+
+
+def test_run_command_routes_pairs_strategy_through_two_feed_runner(tmp_path: Path) -> None:
+    strategy_file = tmp_path / "pairs_probe.py"
+    _write_pairs_strategy(strategy_file)
+
+    output = run_command(
+        operations=["SPY"],  # benchmark ops are ignored for pairs — the universe legs win
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=_fake_fetch,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    assert payload["operations"] == ["GLD", "GDX"]
+    assert len(payload["results"]) == 1
+    result = payload["results"][0]
+    assert result["operation"] == "GLD/GDX"
+    assert result["symbol"] == "GLD/GDX"
+    assert result["metrics"]["bars"] == 5
+    assert result["metrics"]["look_ahead_audit_passed"] is True
+    assert len(payload["data_hashes"]) == 2  # one per leg
+
+
+def test_run_command_fails_closed_on_single_symbol_pairs_universe(tmp_path: Path) -> None:
+    strategy_file = tmp_path / "degenerate_pairs.py"
+    _write_pairs_strategy(strategy_file, universe="['GLD', 'GLD']")
+
+    with pytest.raises(FeedArityError, match="needs >= 2 distinct instruments"):
+        run_command(
+            operations=["SPY"],
+            start="2024-01-01",
+            end="2024-01-10",
+            initial_cash=10000.0,
+            tx_cost_bps=10,
+            slippage_bps=5,
+            artifact_dir=tmp_path,
+            strategy_path=strategy_file,
+            fetcher=_fake_fetch,
+        )

--- a/analytics-engine/tests/test_pairs_engine.py
+++ b/analytics-engine/tests/test_pairs_engine.py
@@ -11,7 +11,7 @@ import math
 import backtrader as bt
 import pandas as pd
 import pytest
-from archimedes_analytics_engine.engine import BacktestResult, run_pairs_backtest
+from archimedes_analytics_engine.engine import BacktestResult, FeedArityError, run_backtest, run_pairs_backtest
 
 
 def _synthetic_prices(periods: int, start: str = "2020-01-01", base: float = 100.0, drift: float = 0.1) -> pd.DataFrame:
@@ -123,6 +123,30 @@ def test_second_wave_pair_files_load_and_run(stem: str) -> None:
     assert isinstance(result, BacktestResult)
     assert result.bars == 300
     assert result.look_ahead_audit_passed is True
+
+
+# Issue #887 bug 1: the single-feed runner used to let two-feed strategies
+# crash mid-run with a bare IndexError on self.datas[1]. It must now fail
+# closed with the typed FeedArityError before the run starts.
+@pytest.mark.parametrize(
+    "stem",
+    [
+        "gatev_2006_pairs_distance",
+        "engle_granger_1987_cointegration_pairs",
+        "elliott_2005_kalman_pairs",
+    ],
+)
+def test_single_feed_runner_fails_closed_for_pairs_classes(stem: str) -> None:
+    import sys
+    from pathlib import Path
+
+    strategies_dir = Path(__file__).parent.parent / "strategies"
+    sys.path.insert(0, str(strategies_dir.parent / "src"))
+    from archimedes_analytics_engine.strategy_loader import load_strategy
+
+    bundle = load_strategy(strategies_dir / f"{stem}.py")
+    with pytest.raises(FeedArityError, match="needs >= 2"):
+        run_backtest(_synthetic_prices(40), strategy_cls=bundle.cls, initial_cash=100_000.0)
 
 
 def _cointegrated_pair(n: int = 600, seed: int = 7, beta: float = 1.2, alpha: float = 4.0, half_life: float = 20.0):

--- a/analytics-engine/tests/test_strategy_loader.py
+++ b/analytics-engine/tests/test_strategy_loader.py
@@ -101,6 +101,40 @@ def test_new_strategy_files_load_with_metadata(filename: str) -> None:
     assert bundle.metadata.get("methodology_text")
 
 
+def test_load_strategy_resolves_sibling_imports_from_any_cwd(tmp_path: Path, monkeypatch) -> None:
+    """Regression (issue #887 bug 2): variant pair files import their sibling
+    module by bare name (``from gatev_2006_pairs_distance import ...``). That
+    only resolved when CWD happened to be the strategies dir; the loader must
+    inject the strategy file's parent dir onto sys.path so the scheduler /
+    backfill import path works from any CWD."""
+    import sys
+
+    monkeypatch.chdir(tmp_path)  # CWD far away from the strategies dir
+    # Simulate the scheduler/backfill environment: strategies dir absent from
+    # sys.path and no cached sibling module to fall back on.
+    strat_variants = {str(_STRATEGIES_DIR), str(_STRATEGIES_DIR.resolve())}
+    monkeypatch.setattr(sys, "path", [p for p in sys.path if p not in strat_variants])
+    monkeypatch.delitem(sys.modules, "gatev_2006_pairs_distance", raising=False)
+
+    bundle = load_strategy(_STRATEGIES_DIR / "gatev_2006_pairs_ko_pep.py")
+
+    assert bundle.cls.__name__ == "PairsDistanceTrading"
+    assert bundle.metadata["asset_universe"] == ["KO", "PEP"]
+    assert bundle.metadata["required_feeds"] == 2
+
+
+def test_pairs_family_declares_required_feeds() -> None:
+    """All three two-feed strategy classes must carry the REQUIRED_FEEDS=2
+    runner contract so the single-feed runner fails closed (issue #887)."""
+    for filename in (
+        "gatev_2006_pairs_distance.py",
+        "engle_granger_1987_cointegration_pairs.py",
+        "elliott_2005_kalman_pairs.py",
+    ):
+        bundle = load_strategy(_STRATEGIES_DIR / filename)
+        assert bundle.metadata.get("required_feeds") == 2, f"{filename} missing REQUIRED_FEEDS=2"
+
+
 def test_pairs_strategy_declares_two_asset_universe() -> None:
     """The Gatev pairs strategy must declare exactly two assets (it is multi-asset)."""
     import importlib.util

--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -75,6 +75,23 @@ def _load_run_command(repo_root: Path):
     return run_command
 
 
+def _typed_error_types(repo_root: Path) -> tuple[type[BaseException], ...]:
+    """Typed, explanatory strategy-run errors — log the message, not a stack trace.
+
+    ``FeedArityError`` (issue #887) is the analytics engine failing closed with
+    a passport-grade explanation (e.g. "pairs needs >= 2 instruments"); a
+    traceback adds nothing. Returns an empty tuple when the engine is not
+    importable so the caller degrades to generic exception handling.
+    """
+    try:
+        _ensure_analytics_import(repo_root)
+        from archimedes_analytics_engine.engine import FeedArityError
+
+        return (FeedArityError,)
+    except Exception:
+        return ()
+
+
 def _read_config() -> RunConfig:
     operations = [op.strip().upper() for op in os.getenv("BACKTEST_OPERATIONS", "SPY").split(",") if op.strip()]
     # Full curated evidence depth by default (~5,400 daily bars). The old
@@ -96,13 +113,14 @@ def _read_config() -> RunConfig:
     )
 
 
-def run_backtests() -> dict[str, int]:
+def run_backtests() -> dict:
     repo_root = _repo_root()
     strategy_dir = _analytics_strategy_dir(repo_root)
     artifact_dir = _artifact_dir(repo_root)
     cfg = _read_config()
 
     run_command = _load_run_command(repo_root)
+    typed_errors = _typed_error_types(repo_root)
 
     provider = default_provider(repo_root=repo_root)
     strategy_by_path = {
@@ -114,6 +132,7 @@ def run_backtests() -> dict[str, int]:
     inserted = 0
     skipped = 0
     failed = 0
+    errors: dict[str, str] = {}
 
     for strategy_file in sorted(strategy_dir.glob("*.py")):
         if strategy_file.name.startswith("_"):
@@ -168,13 +187,22 @@ def run_backtests() -> dict[str, int]:
 
         except Exception as exc:
             failed += 1
-            logger.exception("backtest failed for %s: %s", strategy_file, exc)
+            if typed_errors and isinstance(exc, typed_errors):
+                # Typed fail-closed error from the engine (e.g. FeedArityError,
+                # issue #887): the message is the explanation — log it clean
+                # and carry it in the summary instead of dumping a stack trace.
+                errors[strategy.id] = f"{type(exc).__name__}: {exc}"
+                logger.warning("backtest failed for %s: %s: %s", strategy_file.name, type(exc).__name__, exc)
+            else:
+                logger.exception("backtest failed for %s: %s", strategy_file, exc)
 
-    summary = {
+    summary: dict = {
         "inserted": inserted,
         "skipped": skipped,
         "failed": failed,
     }
+    if errors:
+        summary["errors"] = errors
     logger.info("backtest run summary: %s", summary)
     return summary
 

--- a/backend/tests/test_run_backtests_script.py
+++ b/backend/tests/test_run_backtests_script.py
@@ -111,3 +111,50 @@ def test_run_backtests_is_idempotent(monkeypatch, tmp_path) -> None:
     assert first["failed"] == 0
     assert second["inserted"] == 0
     assert second["skipped"] == 1
+
+
+def test_run_backtests_surfaces_typed_errors_without_traceback(monkeypatch, tmp_path, caplog) -> None:
+    """Typed engine errors (issue #887 FeedArityError) must be counted as
+    failed, carried in summary['errors'] with their explanatory message, and
+    logged as a clean warning — not a stack trace."""
+    import logging
+
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    _write_strategy(strategies_dir / "test_strategy.py")
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    class FakeFeedArityError(ValueError):
+        pass
+
+    def fake_run_command(**kwargs):
+        raise FakeFeedArityError("pairs strategy needs >= 2 distinct instruments")
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+    monkeypatch.setattr(run_backtests_mod, "_typed_error_types", lambda _repo: (FakeFeedArityError,))
+    monkeypatch.setattr(run_backtests_mod, "init_db", lambda: Base.metadata.create_all(bind=engine))
+    monkeypatch.setattr(run_backtests_mod, "get_session", lambda: SessionLocal())
+
+    with caplog.at_level(logging.INFO, logger=run_backtests_mod.logger.name):
+        summary = run_backtests_mod.run_backtests()
+
+    assert summary["inserted"] == 0
+    assert summary["failed"] == 1
+    assert len(summary["errors"]) == 1
+    message = next(iter(summary["errors"].values()))
+    assert "FakeFeedArityError" in message
+    assert ">= 2 distinct instruments" in message
+
+    records = [r for r in caplog.records if r.name == run_backtests_mod.logger.name]
+    warning_lines = [r for r in records if r.levelno == logging.WARNING]
+    assert any(">= 2 distinct instruments" in r.getMessage() for r in warning_lines)
+    # Typed errors are explanatory by construction — no traceback allowed.
+    assert not any(r.exc_info for r in records)


### PR DESCRIPTION
## Summary

6 of the 31 curated strategies fail the `run_backtests` backfill, all in the pairs-trading family, two bug classes:

1. `list index out of range` — pairs strategies whose resolved universe collapses to a single symbol still index `self.datas[1]`.
2. `No module named 'gatev_2006_pairs_distance'` — sibling-name imports only resolve when CWD happens to be the strategies dir.

## What changed

- `engine.py`: new `FeedArityError` + `required_feeds()`. A strategy declares `REQUIRED_FEEDS = 2` as a class attribute; `run_backtest` now fails closed with a typed, explanatory error instead of letting a pairs strategy crash on `self.datas[1]`.
- `cli.py`: `run_command` branches on `required_feeds(bundle.cls)`. Feeds == 2 resolves the two-leg universe from `ASSET_UNIVERSE` (same mapping `regen_fixtures.py` already uses) and runs `run_pairs_backtest`; feeds > 2 fails closed (not supported by this runner yet); feeds == 1 keeps the existing single-feed path unchanged.
- `strategy_loader.py`: injects the strategy file's parent dir onto `sys.path` at load time, so a sibling import (the three `gatev_2006_pairs_*` variants importing `PairsDistanceTrading` from `gatev_2006_pairs_distance`) resolves regardless of CWD. Also picks up `ASSET_UNIVERSE`/`REQUIRED_FEEDS` as strategy metadata.
- The three pairs strategy classes (`gatev_2006_pairs_distance`, `elliott_2005_kalman_pairs`, `engle_granger_1987_cointegration_pairs`) declare `REQUIRED_FEEDS = 2`; the ewa_ewc/gld_slv/ko_pep variants inherit it since they import the class directly.
- `run_backtests.py`: catches `FeedArityError` specifically and logs the message instead of a stack trace, and carries it in the run summary (`summary["errors"]`) keyed by strategy id.

## Test plan

- `cd analytics-engine && uv run pytest tests/test_cli.py tests/test_pairs_engine.py tests/test_strategy_loader.py -q` → 33 passed
- `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests -m "not integration" -q` → 2394 passed, 0 failed
- `ruff format --check` + `ruff check --select E9,F63,F7,F40,F82` on all changed files → clean

## Notes

`gatev_2006_portfolio_of_pairs.py` (the 26-ETF `run_multi_backtest` strategy) is untouched — it's outside this issue's 6-strategy scope and doesn't declare `REQUIRED_FEEDS`, so it isn't affected by this change either way.
