### PR TITLE
[oracle] Thread yfinance bar timestamp through cross-check for staleness gate (#775)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,13 +198,18 @@ ADMIN_PRICES_JSON=
 # Secondary-source cross-check (#775): before pushing a NON-yfinance primary
 # price (Pyth/Stork) on-chain, the oracle runner compares it to an independent
 # yfinance reading and FAILS CLOSED if they diverge beyond this band (bps).
-# Asymmetric: a MISSING / errored / non-positive yfinance NEVER blocks a healthy
-# primary (it only logs). Magnitude-band only — it does NOT yet detect a stale
-# (but positive) yfinance value, so the generous default band is what tolerates
-# off-hours/weekend drift; a real secondary-freshness check is #775 Phase 2
-# (Önder's lane). No-op when PRICE_SOURCE=yfinance (same source) or for admin
-# pins. 0 to disable.
+# Asymmetric: a MISSING / errored / non-positive / STALE yfinance secondary
+# NEVER blocks a healthy primary (it only logs and proceeds). No-op when
+# PRICE_SOURCE=yfinance (same source) or for admin pins. 0 to disable.
 PRICE_CROSSCHECK_BAND_BPS=5000
+
+# Secondary-source staleness window (#775 Phase 2, implemented): max age
+# (seconds) of the yfinance secondary's own bar timestamp before it's treated
+# as unusable for the cross-check above (same fail-open behavior as a missing
+# secondary — a stale reading is never compared for divergence). Default 4
+# days covers weekend + a 3-day holiday gap in equity-like intraday bars.
+# Phase 2 on-chain enforcement (PriceOracle.sol) is still future work, Dan's call.
+PRICE_CROSSCHECK_MAX_STALENESS_SECONDS=345600
 
 # ── Contract addresses (Arc testnet, Chain ID 5042002 / 0x4cef52) ─────────
 # (Chain ID aligned with README/CLAUDE; verify with Dan/contracts before relying

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -55,6 +55,15 @@ DEFAULT_MAX_UPSTREAM_STALENESS_SECONDS = 900  # 15 minutes
 # independent yfinance reading before we fail closed. Generous default — both
 # sources lag between updates; Önder owns tuning. 0 disables the cross-check.
 DEFAULT_CROSSCHECK_BAND_BPS = 5000  # 50%
+# Secondary-source staleness window (#775 Phase 2): max age (seconds) of the
+# yfinance secondary's bar timestamp before it's treated as unusable for the
+# cross-check (fail-open, same as a missing secondary). yfinance's
+# interval="1m" intraday bar goes stale over weekends/holidays for equity-like
+# instruments — a Friday-close bar can be up to ~65 hours old by Monday
+# morning before market open, so the threshold needs headroom past a normal
+# 2-day weekend to avoid spurious staleness flags every Monday; 4 days covers
+# a 3-day holiday weekend too.
+DEFAULT_CROSSCHECK_MAX_STALENESS_SECONDS = 345_600  # 4 days
 
 
 def _int_env(name: str, default: int) -> int:
@@ -121,6 +130,10 @@ class OracleUpdater:
 
         # Secondary-source cross-check band (#775).
         self._crosscheck_band_bps: int = _int_env("PRICE_CROSSCHECK_BAND_BPS", DEFAULT_CROSSCHECK_BAND_BPS)
+        # Secondary-source staleness window (#775 Phase 2).
+        self._crosscheck_max_staleness_s: int = _int_env(
+            "PRICE_CROSSCHECK_MAX_STALENESS_SECONDS", DEFAULT_CROSSCHECK_MAX_STALENESS_SECONDS
+        )
 
     # ─── Public API ──────────────────────────────────────────────
 
@@ -295,7 +308,8 @@ class OracleUpdater:
         price_map = {p.symbol: p.price_usd for p in prices}
         now = datetime.now(UTC)
 
-        vix = await self._fetch_yfinance_single("^VIX")
+        vix_result = await self._fetch_yfinance_single("^VIX")
+        vix = vix_result[0] if vix_result is not None else None
         sp500_data = await asyncio.to_thread(self._fetch_sp500_moving_averages)
 
         return MarketSnapshot(
@@ -379,17 +393,19 @@ class OracleUpdater:
 
         Honest claim this earns: *"primary cross-checked against an independent
         yfinance market source, fail-closed on relative-magnitude divergence beyond
-        a band."* NOT "decentralized 2-of-3" (yfinance is centralized + off-chain).
+        a band, with the secondary's own bar timestamp checked for staleness first."*
+        NOT "decentralized 2-of-3" (yfinance is centralized + off-chain).
 
-        **Scope + a known limitation (be precise, #775):** this is a *magnitude*
-        band check only. It does NOT verify the *freshness* of the yfinance secondary
-        — ``_fetch_yfinance_single`` returns a bare price with no observation
-        timestamp, so a stale weekend/off-hours yfinance read could in principle
-        trip a divergence against a healthy primary. The wide default band
-        (``DEFAULT_CROSSCHECK_BAND_BPS`` = 5000 bps / 50%) is what tolerates that for
-        now; a real secondary-freshness check (threading the yfinance bar timestamp
-        through) is follow-up tuning in Önder's lane (#775 Phase 2), NOT implemented
-        here. The check is a no-op when the primary is yfinance (same source), an
+        **Staleness gate (#775 Phase 2).** Before comparing magnitudes, the
+        secondary's bar timestamp is checked against
+        ``PRICE_CROSSCHECK_MAX_STALENESS_SECONDS``. A stale secondary is treated the
+        same as a missing one (fail-open, proceed on primary) — a stale reading was
+        never validly comparable, so no divergence verdict is computed or reported,
+        only a staleness verdict. This closes the previous magnitude-only gap where a
+        stale-but-numerically-close yfinance value could pass silently, or a
+        stale-and-wildly-different one could in principle trip a false divergence.
+
+        The check is a no-op when the primary is yfinance (same source), an
         admin pin (operator last-resort override — must not be second-guessed), or
         when the symbol has no yfinance ticker.
         """
@@ -404,7 +420,7 @@ class OracleUpdater:
         if not yf_ticker:
             return None  # no independent yfinance ticker for this symbol → can't cross-check → proceed
         try:
-            secondary = await self._fetch_yfinance_single(yf_ticker)
+            result = await self._fetch_yfinance_single(yf_ticker)
         except Exception as exc:
             logger.warning(
                 "cross-check: yfinance fetch failed for %s (%s) — proceeding on primary (asymmetric)",
@@ -412,10 +428,28 @@ class OracleUpdater:
                 exc,
             )
             return None
-        if secondary is None or secondary <= 0:
+        if result is None:
             logger.info(
                 "cross-check: no usable yfinance secondary for %s — proceeding on primary (asymmetric)",
                 price.symbol,
+            )
+            return None
+        secondary, bar_ts = result
+        if secondary <= 0:
+            logger.info(
+                "cross-check: no usable yfinance secondary for %s — proceeding on primary (asymmetric)",
+                price.symbol,
+            )
+            return None
+
+        age_s = (datetime.now(UTC) - bar_ts).total_seconds()
+        if age_s > self._crosscheck_max_staleness_s:
+            logger.info(
+                "cross-check: stale yfinance secondary for %s (bar age %.0fs > %ds cap) — "
+                "proceeding on primary (asymmetric)",
+                price.symbol,
+                age_s,
+                self._crosscheck_max_staleness_s,
             )
             return None
 
@@ -565,8 +599,14 @@ class OracleUpdater:
             logger.warning(f"Crypto fetch error: {e}")
         return results
 
-    async def _fetch_yfinance_single(self, symbol: str) -> float | None:
-        """Fetch a single yfinance price (e.g. VIX)."""
+    async def _fetch_yfinance_single(self, symbol: str) -> tuple[float, datetime] | None:
+        """Fetch a single yfinance price + its bar timestamp (e.g. VIX, or the
+        secondary-source cross-check's independent reading, #775).
+
+        Returns ``(price, bar_ts)`` on success with ``bar_ts`` normalized to a
+        tz-aware UTC ``datetime``, or ``None`` on any failure (empty data, missing
+        column, exception).
+        """
         try:
             import yfinance as yf
 
@@ -577,7 +617,14 @@ class OracleUpdater:
                 # downloads; squeeze to a Series before taking the last value.
                 if hasattr(close, "columns"):
                     close = close.iloc[:, 0]
-                return float(close.iloc[-1])
+                bar_ts = data.index[-1]
+                # Normalize to tz-aware UTC. yfinance intraday bars are tz-aware
+                # (exchange-local) in current versions; if a tz-naive Timestamp ever
+                # shows up, assume UTC to match this file's existing convention for
+                # AssetPrice.timestamp (see _validate_for_push / _is_fresh above,
+                # which treat a naive timestamp as already-UTC rather than local).
+                bar_ts = bar_ts.tz_convert("UTC") if bar_ts.tzinfo is not None else bar_ts.tz_localize("UTC")
+                return float(close.iloc[-1]), bar_ts.to_pydatetime()
         except Exception as e:
             logger.warning(f"Failed to fetch {symbol}: {e}")
         return None

--- a/backend/tests/chain/test_oracle_crosscheck.py
+++ b/backend/tests/chain/test_oracle_crosscheck.py
@@ -5,14 +5,20 @@ stale/missing/flaky yfinance NEVER blocks a healthy primary (only a confident
 divergence between two healthy sources fails closed) — and is a no-op when the
 primary is itself yfinance (not an independent source). No network: the single
 yfinance read is mocked at the boundary.
+
+Staleness fixtures (``_fresh_ts`` / ``_stale_ts`` / ``_boundary_ts``) compute bar
+timestamps relative to wall-clock ``datetime.now(UTC)`` at call time (no frozen
+clock) since ``_cross_check_secondary`` itself calls ``datetime.now(UTC)`` when
+computing bar age — the offsets are large enough (minutes vs. days vs. the exact
+cap) that this is stable regardless of test run time.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
-from archimedes.chain.oracle_updater import OracleUpdater
+from archimedes.chain.oracle_updater import DEFAULT_CROSSCHECK_MAX_STALENESS_SECONDS, OracleUpdater
 from archimedes.models.asset import AssetPrice
 
 NOW = datetime(2026, 6, 30, tzinfo=UTC)
@@ -28,12 +34,30 @@ def _updater(band_bps: int = 5000) -> OracleUpdater:
     return u
 
 
+def _fresh_ts() -> datetime:
+    return datetime.now(UTC) - timedelta(minutes=5)
+
+
+def _stale_ts() -> datetime:
+    return datetime.now(UTC) - timedelta(days=5)
+
+
+def _boundary_ts() -> datetime:
+    # Just inside the cap (not exactly at it): the check computes age at
+    # assertion time, a fraction of a second after this fixture is built, so an
+    # exact-cap fixture would nondeterministically tip over the strict `>`
+    # threshold under real wall-clock elapsed time. One second of slack keeps
+    # this deterministically on the "not stale" side while still exercising the
+    # boundary (mirrors the band-boundary test's "inclusive" framing above).
+    return datetime.now(UTC) - timedelta(seconds=DEFAULT_CROSSCHECK_MAX_STALENESS_SECONDS - 1)
+
+
 # ── no-op cases (nothing to cross-check) ──────────────────────────────────
 
 
 async def test_disabled_band_is_noop():
     u = _updater(0)
-    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=1.0)) as m:
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(1.0, _fresh_ts()))) as m:
         assert await u._cross_check_secondary(_price()) is None
     m.assert_not_called()  # disabled → never even fetches
 
@@ -82,7 +106,7 @@ async def test_asymmetric_yfinance_none_proceeds():
 
 async def test_asymmetric_yfinance_nonpositive_proceeds():
     u = _updater()
-    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=0.0)):
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(0.0, _fresh_ts()))):
         assert await u._cross_check_secondary(_price()) is None
 
 
@@ -91,13 +115,13 @@ async def test_asymmetric_yfinance_nonpositive_proceeds():
 
 async def test_in_band_proceeds():
     u = _updater(5000)  # 50% band
-    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=510.0)):  # ~2% off
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(510.0, _fresh_ts()))):  # ~2% off
         assert await u._cross_check_secondary(_price(usd=500.0)) is None
 
 
 async def test_out_of_band_fails_closed():
     u = _updater(1000)  # 10% band
-    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=1000.0)):  # 2x off
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(1000.0, _fresh_ts()))):  # 2x off
         reason = await u._cross_check_secondary(_price(usd=500.0))
     assert reason is not None
     assert "diverges" in reason and "failing closed" in reason
@@ -106,5 +130,60 @@ async def test_out_of_band_fails_closed():
 async def test_band_boundary_inclusive_proceeds():
     # Exactly at the band is allowed (strict > check). 500 vs 550 = 909bps < 1000.
     u = _updater(1000)
-    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=550.0)):
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(550.0, _fresh_ts()))):
         assert await u._cross_check_secondary(_price(usd=500.0)) is None
+
+
+# ── secondary staleness window (#775 Phase 2) ─────────────────────────────
+
+
+async def test_fresh_bar_in_band_proceeds():
+    # Regression check: fresh bar timestamp + in-band deviation still proceeds
+    # exactly like the pre-staleness-gate behavior.
+    u = _updater(5000)
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(510.0, _fresh_ts()))):
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None
+
+
+async def test_stale_bar_in_band_logs_stale_not_ok(caplog):
+    # A stale secondary is fail-open (like a missing one), but the caller can't
+    # observe a distinguishing string from a bare None return — this exercises
+    # the log path instead by asserting the outcome (proceeds) while confirming
+    # via caplog that the reasoning says "stale", not a normal pass-through.
+    import logging
+
+    u = _updater(5000)
+    with (
+        caplog.at_level(logging.INFO, logger="archimedes.chain.oracle_updater"),
+        patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(510.0, _stale_ts()))),
+    ):
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None
+    assert any("stale" in rec.message for rec in caplog.records)
+    assert not any("cross-check OK" in rec.message for rec in caplog.records)
+
+
+async def test_stale_bar_out_of_band_still_proceeds():
+    # KEY regression proof: staleness must short-circuit BEFORE the divergence
+    # check, so a stale-and-wildly-different reading does NOT incorrectly fail
+    # closed. Without the staleness gate this divergence (2x) would fail closed
+    # under a 1000bps band.
+    u = _updater(1000)
+    with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(1000.0, _stale_ts()))):
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None
+
+
+async def test_staleness_boundary_at_cap_treated_as_ok_not_stale(caplog):
+    # Mirrors the band-boundary convention above (strict `>` check): at/under
+    # the staleness cap is NOT stale, so it falls through to the normal
+    # in-band-proceeds path (not the staleness-proceeds path) and logs the
+    # ordinary "cross-check OK" line rather than a staleness reason.
+    import logging
+
+    u = _updater(5000)
+    with (
+        caplog.at_level(logging.DEBUG, logger="archimedes.chain.oracle_updater"),
+        patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(510.0, _boundary_ts()))),
+    ):
+        assert await u._cross_check_secondary(_price(usd=500.0)) is None
+    assert any("cross-check OK" in rec.message for rec in caplog.records)
+    assert not any("stale" in rec.message for rec in caplog.records)

--- a/backend/tests/chain/test_oracle_updater_fetch.py
+++ b/backend/tests/chain/test_oracle_updater_fetch.py
@@ -114,7 +114,7 @@ class TestFetchMarketSnapshot:
         equities = [AssetPrice(symbol="sSPY", price_usd=500.0, timestamp=now, source="yfinance")]
         with (
             patch.object(updater, "fetch_prices", AsyncMock(return_value=equities)),
-            patch.object(updater, "_fetch_yfinance_single", AsyncMock(return_value=14.5)),
+            patch.object(updater, "_fetch_yfinance_single", AsyncMock(return_value=(14.5, now))),
             patch.object(updater, "_fetch_sp500_moving_averages", return_value={"ma50": 4900.0, "ma200": 4800.0}),
         ):
             snap = await updater.fetch_market_snapshot()
@@ -125,20 +125,57 @@ class TestFetchMarketSnapshot:
         # VIX + MAs present → the snapshot reports it carries regime signals.
         assert snap.has_regime_signals is True
 
+    async def test_vix_none_when_yfinance_single_fails(self, updater):
+        # _fetch_yfinance_single returns a bare None on failure (not a 2-tuple) —
+        # fetch_market_snapshot must unpack that shape safely.
+        now = datetime.now(UTC)
+        equities = [AssetPrice(symbol="sSPY", price_usd=500.0, timestamp=now, source="yfinance")]
+        with (
+            patch.object(updater, "fetch_prices", AsyncMock(return_value=equities)),
+            patch.object(updater, "_fetch_yfinance_single", AsyncMock(return_value=None)),
+            patch.object(updater, "_fetch_sp500_moving_averages", return_value={}),
+        ):
+            snap = await updater.fetch_market_snapshot()
+        assert snap.vix is None
+
 
 class TestFetchYfinanceSingle:
-    async def test_returns_last_close(self, updater):
+    async def test_returns_last_close_and_bar_timestamp(self, updater):
         import pandas as pd
 
-        close = pd.DataFrame({"^VIX": [13.2, 14.0]})
+        idx = pd.date_range("2026-06-30 00:00", periods=2, freq="min", tz="UTC")
+        close = pd.DataFrame({"^VIX": [13.2, 14.0]}, index=idx)
         frame = MagicMock()
         frame.empty = False
         frame.__getitem__ = MagicMock(side_effect=lambda k: close if k == "Close" else None)
+        frame.index = idx
         fake_yf = MagicMock()
         fake_yf.download = MagicMock(return_value=frame)
         with patch.dict(sys.modules, {"yfinance": fake_yf}):
-            val = await updater._fetch_yfinance_single("^VIX")
-        assert val == 14.0
+            result = await updater._fetch_yfinance_single("^VIX")
+        assert result is not None
+        price, bar_ts = result
+        assert price == 14.0
+        assert bar_ts == idx[-1].to_pydatetime()
+        assert bar_ts.tzinfo is not None
+
+    async def test_naive_bar_timestamp_normalized_to_utc(self, updater):
+        import pandas as pd
+
+        idx = pd.date_range("2026-06-30 00:00", periods=2, freq="min")  # tz-naive
+        close = pd.DataFrame({"^VIX": [13.2, 14.0]}, index=idx)
+        frame = MagicMock()
+        frame.empty = False
+        frame.__getitem__ = MagicMock(side_effect=lambda k: close if k == "Close" else None)
+        frame.index = idx
+        fake_yf = MagicMock()
+        fake_yf.download = MagicMock(return_value=frame)
+        with patch.dict(sys.modules, {"yfinance": fake_yf}):
+            result = await updater._fetch_yfinance_single("^VIX")
+        assert result is not None
+        _, bar_ts = result
+        assert bar_ts.tzinfo is not None
+        assert bar_ts.utcoffset().total_seconds() == 0
 
     async def test_swallows_error_returns_none(self, updater):
         fake_yf = MagicMock()


### PR DESCRIPTION
## Summary

Closes the one remaining item on #775: Phase 1 (magnitude cross-check, PR #835) landed 6/30, but noted it was magnitude-only — a stale-but-positive yfinance reading wasn't detected, the wide band just tolerated it. This threads the yfinance bar timestamp through and adds a staleness gate ahead of the divergence check.

## What changed

`backend/archimedes/chain/oracle_updater.py`:

- `_fetch_yfinance_single` now returns `(price, bar_ts)` instead of a bare price, with `bar_ts` normalized to tz-aware UTC. Also fixed its other caller (`fetch_market_snapshot`'s VIX fetch) for the new shape.
- `_cross_check_secondary` checks the secondary's bar age against a new `PRICE_CROSSCHECK_MAX_STALENESS_SECONDS` (default 345600s / 4 days — sized for a 3-day holiday weekend on equity-like intraday bars) before computing divergence at all. A stale secondary is treated the same as a missing one: fail-open, proceed on primary, no divergence verdict computed (a stale reading was never validly comparable either way).
- `.env.example` documents the new var next to `PRICE_CROSSCHECK_BAND_BPS`.

Two deliberate non-changes, both noted in code comments:

- `PRICE_CROSSCHECK_BAND_BPS` default (5000 bps) is untouched. Tuning it needs backtested false-positive-rate data I don't have on hand right now.
- The #772/#856 per-instrument data-quality harness (`data_quality.py`) is not wired into this path. It's a full 2-year batch fetch per call, built for offline universe admission (`generate_universe.py`, `strategy_signal_evaluator.py`), not a per-push oracle check. Threading the bar timestamp gets the practical staleness detection without that cost.

The asymmetric fail-open design from Phase 1 is unchanged: missing/errored/non-positive/stale secondary never blocks a healthy primary.

## Test plan

- `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/chain/ -q` → 156 passed, 0 failed
- `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests -m "not integration" -q` → 2399 passed, 0 failed
- `ruff format --check` + `ruff check --select E9,F63,F7,F40` on changed files → clean

New tests in `test_oracle_crosscheck.py`: fresh-bar regression, stale-in-band still proceeds (asserts the log distinguishes "stale" from a normal pass), stale-out-of-band still proceeds (proves staleness short-circuits before the divergence check, so a stale-and-wildly-different reading doesn't false-positive a fail-closed), boundary case at the staleness cap. `test_oracle_updater_fetch.py` updated for the new tuple return shape plus a naive-timestamp normalization test.

## Still open after this

Per my last comment on the issue: Phase 2 (on-chain enforcement in `PriceOracle.sol`) is a contract change, Dan's call with Bogdan reviewing. And the honest-claim gate still holds — `getPrice()` is admin-fed until the Stork adapter (#794) lands, so we shouldn't ship the two-source claim yet. This PR doesn't change either of those; it's the staleness item only.

@mnemonik-dev — flagging you as a reviewer since this is oracle/price-feed trust surface, even though it's backend-only (no contract changes).
