### PR TITLE
[quant] look_ahead_audit false-positives on self.datas[N] feed-selection index (#881)

### DIFF
--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -125,6 +125,30 @@ def _is_backtrader_line_access(value_node: ast.expr) -> bool:
     return bool(attrs) and attrs[0] in _BACKTRADER_LINE_NAMES
 
 
+def _is_datas_feed_selection(value_node: ast.expr) -> bool:
+    """True when ``value_node`` (a Subscript's ``.value``) is exactly
+    ``self.datas`` — i.e. the subscript is ``self.datas[N]``, backtrader's
+    convention for selecting which data feed to address in a multi-asset
+    strategy (``self.datas[1]`` = the second asset in a pairs trade), not a
+    time offset (#881).
+
+    This is deliberately narrower than ``_is_backtrader_line_access``: it
+    exempts ONLY a subscript whose subscripted expression is the attribute
+    chain ``self.datas`` (root ``self``, single attribute ``datas``). It does
+    NOT exempt an arbitrary positive index on any other self-rooted chain —
+    e.g. ``self.highest[1]`` or ``self.datas[1].close[1]`` still fall through
+    to the general positive-index warning, since those are not feed-selection
+    and a positive offset there is bar 0 = now / N>0 = a future bar, exactly
+    the violation this audit exists to catch.
+    """
+    return (
+        isinstance(value_node, ast.Attribute)
+        and value_node.attr == "datas"
+        and isinstance(value_node.value, ast.Name)
+        and value_node.value.id == "self"
+    )
+
+
 def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
     """Static-analysis check for look-ahead bias in strategy code.
 
@@ -142,10 +166,15 @@ def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
     A negative index on anything else (a plain list/np.ndarray local variable,
     or a pandas ``.iloc``/``.loc``/``.at``/``.iat`` accessor) is still flagged,
     since on those objects ``[-1]`` means "last element", which is future data
-    on a forward-chronological series. A positive constant index is unaffected
-    by this distinction — it is always suspicious on ANY object, backtrader
-    included (bar 0 is "now"; any positive offset is a future bar) — and
-    continues to be flagged exactly as before.
+    on a forward-chronological series. A positive constant index is suspicious
+    on ANY object, backtrader included (bar 0 is "now"; any positive offset is
+    a future bar) — with one narrow exemption: ``self.datas[N]`` is
+    backtrader's convention for selecting which data feed to address in a
+    multi-asset strategy (e.g. ``self.datas[1]`` = the second asset in a pairs
+    trade), not a time offset, so it is excluded from the warning (see
+    ``_is_datas_feed_selection``, #881). Any other positive-constant subscript
+    — including a positive index on ``self.datas[N].close`` or any other
+    self-rooted line/attribute — still flags exactly as before.
 
     Args:
         strategy_code: Python source code of the strategy.
@@ -211,7 +240,19 @@ def look_ahead_audit(strategy_code: str) -> tuple[bool, list[str]]:
                         f"Line {node.lineno}: negative index on a non-backtrader object — "
                         f"verify this is not pandas/list last-row (future) access."
                     )
-            elif isinstance(slice_val, ast.Constant) and isinstance(slice_val.value, int) and slice_val.value > 0:
+            # self.datas[N] is backtrader's convention for selecting which data
+            # feed to address in a multi-asset strategy (e.g. self.datas[1] =
+            # the second asset in a pairs trade) — it is feed selection, not a
+            # time offset, so it is exempted from this warning (#881). Any
+            # other positive-constant subscript (including
+            # self.datas[N].close[1], or a positive index on a plain
+            # array/self-rooted line) still flags exactly as before.
+            elif (
+                isinstance(slice_val, ast.Constant)
+                and isinstance(slice_val.value, int)
+                and slice_val.value > 0
+                and not _is_datas_feed_selection(node.value)
+            ):
                 warnings.append(
                     f"Line {node.lineno}: positive data index [{slice_val.value}] may reference future bars"
                 )

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -509,40 +509,28 @@ class MyStrategy(bt.Strategy):
 
     def test_secondary_data_feed_negative_index_is_not_flagged_as_negative(self) -> None:
         """self.datas[1].close[-i] (gatev_2006_pairs_distance.py's pairs-trading
-        shape) — the NEGATIVE bars-ago index [-i] must not be flagged.
+        shape) — neither the NEGATIVE bars-ago index [-i] NOR the POSITIVE
+        feed-selector index [1] on self.datas should be flagged.
 
-        NOTE (found while writing this test, NOT part of #868's scope): this
-        exact snippet still fails look_ahead_audit overall today, because the
-        POSITIVE-index branch (unconditional, untouched by #868 — see
-        look_ahead_audit's `elif isinstance(slice_val, ast.Constant) ...
-        value > 0` leg) separately and incorrectly flags the `self.datas[1]`
+        Originally (pre-#881) this snippet still failed look_ahead_audit
+        overall, because the POSITIVE-index branch (unconditional, untouched
+        by #868) separately and incorrectly flagged the `self.datas[1]`
         data-FEED-selector subscript itself ("positive data index [1] may
         reference future bars") — conflating "index 1 selects the 2nd data
-        feed" with "index 1 is one bar in the future". This is a real,
-        pre-existing, independent false positive (confirmed present on
-        unmodified main before this fix) affecting every multi-leg/pairs
-        strategy that writes `self.datas[N]` directly rather than through a
-        pre-bound variable: gatev_2006_pairs_distance.py,
-        elliott_2005_kalman_pairs.py, and engle_granger_1987_cointegration_pairs.py
-        all still fail look_ahead_audit after this fix, dominated by this
-        secondary bug rather than the bars-ago issue #868 asked me to fix.
-        Out of scope here per the issue's explicit instruction to preserve the
-        positive-index ("genuine look-ahead") detector as-is; flagged in the
-        PR/report rather than silently widened.
+        feed" with "index 1 is one bar in the future". #881 fixed that: see
+        `_is_datas_feed_selection` and the positive-index branch in
+        `look_ahead_audit`.
         """
         code = "def f(self, i):\n    return self.datas[1].close[-i]\n"
-        _passed, warnings = look_ahead_audit(code)
+        passed, warnings = look_ahead_audit(code)
         assert not any("negative index" in w.lower() for w in warnings), (
             f"the bars-ago [-i] access must not be flagged as a negative-index violation: {warnings}"
         )
-        # Documents the known, separate, out-of-scope positive-index false
-        # positive on the self.datas[N] feed-selector subscript (see docstring).
-        # If this assertion ever starts failing, that pre-existing bug has been
-        # fixed elsewhere — which would be a welcome surprise, not a regression.
-        assert any("positive" in w.lower() for w in warnings), (
-            "expected the known pre-existing self.datas[N] positive-index false "
-            "positive to still be present (tracked separately, out of #868's scope)"
+        assert not any("positive" in w.lower() for w in warnings), (
+            f"self.datas[1] is feed selection, not a look-ahead violation (#881): {warnings}"
         )
+        assert passed
+        assert warnings == []
 
     def test_loop_variable_alias_over_datas(self) -> None:
         # d.close[-i] where `d` is a loop variable bound to a self.datas element
@@ -670,6 +658,181 @@ class MyStrategy(bt.Strategy):
         assert not any("negative index" in w.lower() for w in warnings), (
             "the legitimate self.data.close[-1] access must not also warn"
         )
+
+
+# ─── Look-ahead audit: self.datas[N] feed selection vs. positive look-ahead (#881) ──
+
+
+class TestLookAheadAuditDatasFeedSelection:
+    """#881: look_ahead_audit's positive-index branch previously flagged ANY
+    positive constant subscript, including `self.datas[N]` — backtrader's
+    convention for selecting which data feed to address in a multi-asset
+    strategy (e.g. `self.datas[1]` = the second asset in a pairs trade), not a
+    time offset. This false-positived every multi-leg/pairs strategy that
+    writes `self.datas[N]` directly (as opposed to via a pre-bound variable).
+    """
+
+    # ── self.datas[N] feed selection: must PASS (no warnings) ────────────
+
+    def test_datas_constant_index_one_not_flagged(self) -> None:
+        # self.datas[1] — the exact shape named in the issue.
+        code = "def f(self):\n    return self.datas[1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert warnings == []
+
+    def test_datas_index_zero_and_one_both_pass(self) -> None:
+        code = """
+class MyStrategy(bt.Strategy):
+    def next(self):
+        a = self.datas[0]
+        b = self.datas[1]
+"""
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert warnings == []
+
+    def test_datas_feed_selection_with_close_attribute_current_bar(self) -> None:
+        # self.datas[1].close[0] — feed selection (positive index on
+        # self.datas) chained with current-bar access (index 0, not positive).
+        code = "def f(self):\n    return self.datas[1].close[0]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert passed
+        assert warnings == []
+
+    def test_datas_feed_selection_used_in_getposition_and_order_calls(self) -> None:
+        # self.getposition(self.datas[1]) / self.close(data=self.datas[1]) /
+        # self.order_target_size(data=self.datas[0], ...) — the exact call
+        # shapes used by gatev_2006_pairs_distance.py and siblings.
+        code = """
+class MyStrategy(bt.Strategy):
+    def next(self):
+        in_position = bool(self.getposition(self.datas[0]).size) or bool(self.getposition(self.datas[1]).size)
+        if in_position:
+            self.close(data=self.datas[0])
+            self.close(data=self.datas[1])
+        else:
+            self.order_target_size(data=self.datas[0], target=-1)
+            self.order_target_size(data=self.datas[1], target=1)
+"""
+        passed, warnings = look_ahead_audit(code)
+        assert passed, f"self.datas[N] feed-selection calls incorrectly flagged: {warnings}"
+        assert warnings == []
+
+    # ── Genuine look-ahead: must still FAIL, even near self.datas ────────
+
+    def test_positive_index_on_close_after_datas_selection_still_warns(self) -> None:
+        # self.datas[1].close[1] — the feed-selector subscript ([1] on
+        # self.datas) is exempt, but the CHAINED [1] on .close is a genuine
+        # positive time-offset (a future bar) and must still be flagged. The
+        # exemption is narrowly for the self.datas[N] subscript itself, not
+        # "any positive index anywhere in a chain rooted at self.datas".
+        code = "def f(self):\n    return self.datas[1].close[1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+
+    def test_positive_index_on_other_self_attribute_still_warns(self) -> None:
+        # self.highest[1] — a positive index on a self-rooted attribute that
+        # is NOT self.datas must still be flagged; the exemption is specific
+        # to the literal `self.datas` chain, not "any self-rooted attribute".
+        code = "def f(self):\n    return self.highest[1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+
+    def test_positive_index_on_plain_array_still_warns(self) -> None:
+        # A genuine future-index violation unrelated to self.datas at all
+        # (e.g. indexing a returns array at a computed future position) must
+        # still fail — the acceptance-criteria synthetic fixture for #881.
+        code = "def f(returns):\n    return returns[3]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+
+    def test_datas_not_rooted_at_self_still_warns(self) -> None:
+        # local_datas[1] — a variable merely NAMED "datas" that is not the
+        # `self.datas` attribute chain must not be exempted; the check keys
+        # off the actual attribute access (self.datas), not the name "datas".
+        code = "def f(local_datas):\n    return local_datas[1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+
+    def test_non_self_rooted_datas_attribute_still_warns(self) -> None:
+        # other.datas[1] — an attribute chain with attr "datas" but whose root
+        # is NOT literally `self` must not be exempted; #881's issue text is
+        # specific to backtrader's `self.datas[N]` convention.
+        code = "def f(other):\n    return other.datas[1]\n"
+        passed, warnings = look_ahead_audit(code)
+        assert not passed
+        assert any("positive" in w.lower() for w in warnings)
+
+
+# ─── Look-ahead audit: real pairs-strategy files (#881 acceptance) ────
+
+
+class TestLookAheadAuditRealPairsStrategyFiles:
+    """ACCEPTANCE CRITERION (#881, end-to-end, real files): the three
+    multi-asset pairs strategies named in the issue now pass look_ahead_audit,
+    loaded from disk via the session-scoped ``strategies_dir`` fixture so this
+    exercises the same source run_rigor_gate sees on the live path."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "gatev_2006_pairs_distance.py",
+            "elliott_2005_kalman_pairs.py",
+        ],
+    )
+    def test_pairs_strategy_file_passes_look_ahead_audit(self, strategies_dir, filename) -> None:
+        path = strategies_dir / filename
+        assert path.is_file(), f"expected strategy file at {path}"
+        code = path.read_text()
+
+        passed, warnings = look_ahead_audit(code)
+        assert passed, f"{filename} still fails look-ahead audit: {warnings}"
+        assert warnings == []
+
+    def test_cointegration_pairs_file_has_only_unrelated_preexisting_warnings(self, strategies_dir) -> None:
+        """engle_granger_1987_cointegration_pairs.py: the self.datas[N]
+        false positives (#881's scope) are gone, but the file still has TWO
+        pre-existing, UNRELATED false positives this issue does not ask us to
+        fix (out of scope — see the issue's anti-goal against widening the
+        exemption beyond self.datas[N]):
+
+          - `coef[1]` (lines ~132, ~145): indexing into an OLS/AR(1)
+            regression-coefficient array (np.linalg.lstsq output) by position
+            — not a self.datas subscript, not a time offset at all.
+          - `spread[-1]`: a plain numpy local variable, correctly still
+            flagged by the (unrelated, #868-scoped) negative-index branch.
+
+        This test locks in that no NEW/different warnings appear and that the
+        self.datas[N] warnings specifically are gone, so a future change to
+        either branch that regresses this file is caught, without asserting
+        the file passes overall (it doesn't, for reasons outside #881).
+        """
+        path = strategies_dir / "engle_granger_1987_cointegration_pairs.py"
+        assert path.is_file(), f"expected strategy file at {path}"
+        code = path.read_text()
+
+        passed, warnings = look_ahead_audit(code)
+        assert passed is False, (
+            "expected this file to still fail on the two unrelated pre-existing "
+            "false positives (coef[1] regression-coefficient indexing, "
+            f"spread[-1] plain-array negative index) — got zero warnings: {warnings}"
+        )
+        # Exactly the two known unrelated categories, nothing else (in
+        # particular no self.datas[N] "positive data index" warning survives).
+        assert len(warnings) == 3, f"expected exactly 3 warnings (2 coef[1] + 1 spread[-1]), got: {warnings}"
+        for w in warnings:
+            assert ("negative index on a non-backtrader object" in w) or ("positive data index [1]" in w), (
+                f"unexpected new warning shape, investigate: {w}"
+            )
+        # None of the surviving warnings should be about a self.datas[N] line —
+        # the fixed lines (177/178, i.e. self.datas[0]/[1].close[0]) must be
+        # absent now.
+        assert not any("self.datas" in w for w in warnings)
 
 
 class TestLookAheadAuditRealMoreiraMuirFile:


### PR DESCRIPTION
## Summary

Split off from #868 during that fix. `look_ahead_audit`'s positive-index branch (`rigor_evaluator.py`) flagged any positive constant subscript as "may reference future bars" — but `self.datas[N]` is backtrader's convention for selecting which data feed to address in a multi-asset strategy (`self.datas[1]` = the second asset in a pairs trade), not a time offset. The check conflated feed-selection with look-ahead and false-positived on every multi-asset strategy that indexes `self.datas` by a constant.

## What changed

New `_is_datas_feed_selection` helper: true only when the subscripted expression is exactly the attribute chain `self.datas` (root `self`, single attribute `datas`). The positive-index branch now skips flagging when this is true. Deliberately narrow — `self.datas[1].close[1]`, `self.highest[1]`, `other.datas[1]`, and a plain array like `returns[3]` all still flag, since none of those are feed selection.

Doesn't touch the negative-index (bars-ago) branch #868 already fixed.

## Test plan

- `gatev_2006_pairs_distance.py` and `elliott_2005_kalman_pairs.py` now pass `look_ahead_audit` cleanly.
- `engle_granger_1987_cointegration_pairs.py` still fails, for reasons outside this issue's scope: `coef[1]` (lines 132/145) indexes an `np.linalg.lstsq` regression-coefficient vector — a positional array lookup, not `self.datas` and not a time offset — and `spread[-1]` (line 171) is a plain numpy local correctly caught by #868's negative-index branch. Widening the exemption to cover either would violate the anti-goal against making the check permissive beyond the `self.datas[N]` shape. Locked in with a test asserting exactly these two unrelated warnings survive and nothing else does.
- New tests in `test_rigor_evaluator.py`: `self.datas[1]` and `self.datas[0]` no longer warn; `self.datas[1].close[1]`, `self.highest[1]`, `returns[3]`, `other.datas[1]` (non-self-rooted) still warn.
- `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_rigor_evaluator.py -q` → 198 passed, 0 failed
- `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests -m "not integration" -q` → 2405 passed, 0 failed
- `ruff format --check` + `ruff check --select E9,F63,F7,F40` → clean

#868's negative-index / bars-ago tests re-run clean (26 passed) to confirm no regression there.
