### PR TITLE
[contracts] Make SyntheticToken.setVault set-once (closes #904 drain vector)

### DIFF
--- a/contracts/src/SyntheticToken.sol
+++ b/contracts/src/SyntheticToken.sol
@@ -11,6 +11,8 @@ contract SyntheticToken is ERC20, Ownable {
     address public vault;
 
     error NotVault();
+    error VaultAlreadySet();
+    error ZeroVault();
 
     modifier onlyVault() {
         if (msg.sender != vault) revert NotVault();
@@ -22,8 +24,16 @@ contract SyntheticToken is ERC20, Ownable {
         Ownable(_owner)
     {}
 
-    /// @notice Set the vault address (owner only). Called after vault deploys.
+    /// @notice Set the vault address (owner only). Called once after the vault
+    ///         deploys; immutable afterwards. A mutable pointer would let the
+    ///         owner re-point `vault` at a contract they control, mint unbacked
+    ///         synth, and burn it against the real vault to drain user USDC —
+    ///         breaking the non-custodial guarantee (issue #904). Vault
+    ///         evolution requires deploying a new token+vault pair via the
+    ///         factory, never re-pointing a live token.
     function setVault(address _vault) external onlyOwner {
+        if (vault != address(0)) revert VaultAlreadySet();
+        if (_vault == address(0)) revert ZeroVault();
         vault = _vault;
     }
 

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -21,6 +21,21 @@ contract MockUSDC is ERC20 {
     }
 }
 
+/// @dev Attacker-controlled "vault" for the issue #904 drain scenario: if the
+///      owner could re-point SyntheticToken.vault here, this contract would
+///      mint unbacked synth to the attacker for free.
+contract MaliciousVault {
+    SyntheticToken public token;
+
+    constructor(SyntheticToken _token) {
+        token = _token;
+    }
+
+    function mintUnbacked(address to, uint256 amount) external {
+        token.mint(to, amount);
+    }
+}
+
 contract SyntheticVaultTest is Test {
     MockUSDC public usdc;
     PriceOracle public oracle;
@@ -559,6 +574,66 @@ contract SyntheticVaultTest is Test {
         vm.stopPrank();
 
         assertEq(preview, actual);
+    }
+
+    // ─── setVault Immutability Tests (issue #904) ─────────────────
+
+    /// @dev setVault is set-once: a second call reverts even for the owner.
+    ///      Pre-fix, the owner could re-point `vault` at any contract and
+    ///      mint unbacked synth against the real vault's collateral.
+    function test_revert_setVault_already_set() public {
+        vm.prank(owner);
+        vm.expectRevert(SyntheticToken.VaultAlreadySet.selector);
+        sTSLA.setVault(address(0xBAD));
+    }
+
+    function test_revert_setVault_zero_address() public {
+        SyntheticToken fresh = new SyntheticToken("Fresh", "FRSH", owner);
+        vm.prank(owner);
+        vm.expectRevert(SyntheticToken.ZeroVault.selector);
+        fresh.setVault(address(0));
+    }
+
+    function test_revert_setVault_non_owner() public {
+        SyntheticToken fresh = new SyntheticToken("Fresh", "FRSH", owner);
+        vm.prank(alice);
+        vm.expectRevert();
+        fresh.setVault(address(vault));
+    }
+
+    /// @dev Full drain scenario from issue #904: alice deposits real USDC, the
+    ///      owner tries to re-point the synth token at a malicious "vault" and
+    ///      mint unlimited synth to burn against alice's collateral. Post-fix
+    ///      the re-point reverts, the malicious mint reverts, and the real
+    ///      vault keeps working with its collateral intact.
+    function test_owner_cannot_drain_via_setVault_repoint() public {
+        // Alice deposits real collateral into the legitimate vault.
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 aliceSynth = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        uint256 collateralBefore = usdc.balanceOf(address(vault));
+
+        // Owner deploys a malicious vault and tries to re-point the token.
+        MaliciousVault evil = new MaliciousVault(sTSLA);
+        vm.prank(owner);
+        vm.expectRevert(SyntheticToken.VaultAlreadySet.selector);
+        sTSLA.setVault(address(evil));
+
+        // The malicious contract cannot mint — it never became the vault.
+        vm.expectRevert(SyntheticToken.NotVault.selector);
+        evil.mintUnbacked(owner, 1_000_000 * 1e18);
+
+        // Real vault is unaffected: collateral intact, alice can still redeem.
+        assertEq(usdc.balanceOf(address(vault)), collateralBefore);
+        assertEq(sTSLA.vault(), address(vault), "vault pointer unchanged");
+
+        vm.prank(alice);
+        uint256 usdcBack = vault.burn(aliceSynth);
+        assertGt(usdcBack, 0);
+        assertEq(sTSLA.balanceOf(alice), 0);
     }
 
     // ─── Admin Tests ──────────────────────────────────────────────


### PR DESCRIPTION
## What

`SyntheticToken.setVault` is now set-once: second call reverts `VaultAlreadySet`, `address(0)` reverts `ZeroVault`. Nothing else about the token changes.

## Why

The pointer was owner-mutable, so the owner could re-point `vault` at a contract they control, mint unbacked synth, and burn it against the real `SyntheticVault` to withdraw user USDC — a direct break of the non-custodial guarantee. Full write-up in #904.

Set-once keeps the existing deploy flow intact: the factory constructs the token, constructs the vault, calls `setVault` exactly once, then transfers ownership. Every call site in the tree (factory + tests) already sets it exactly once on a fresh token, so nothing breaks. If we ever need vault evolution, the honest path is a new token+vault pair via the factory, not re-pointing a live token.

## Tests

- `test_owner_cannot_drain_via_setVault_repoint` — the full drain scenario from the issue: alice deposits, owner deploys a malicious vault and tries to re-point, mint attempt fails, real vault collateral intact, alice still redeems
- `test_revert_setVault_already_set` / `_zero_address` / `_non_owner`

`forge test`: 229 passed, 0 failed.

## Notes for review

- Contract change — needs Dan's approval as contract owner, Bogdan as second reviewer.
- The live `SyntheticToken` instances on Arc testnet still have the mutable setter; this fix needs a redeploy of the synth token+vault set to apply on-chain. Merging this doesn't redeploy contracts by itself (deploy.yml rebuilds the app stack, not contracts), so no on-chain risk from merging, but the issue isn't closed operationally until the redeploy.

Fixes #904