### PR TITLE
[backend] Fix commit-reveal reverts so temporal binding can land on-chain

### DIFF
--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -371,6 +371,9 @@ async def get_trace_canonical(trace_id: str):
             confidence=off_chain.get("confidence", 0.0),
             trades_executed=off_chain.get("trades_executed", []),
             strategies_referenced=off_chain.get("strategies_referenced", []),
+            # Hashed field (#903): without it the rebuilt canonical bytes can
+            # never match the committed hash for paper-grounded decisions.
+            consulted_paper_hashes=off_chain.get("consulted_paper_hashes", []),
         )
         return PlainTextResponse(trace.canonical_json(), media_type="application/json")
     finally:

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -681,7 +681,7 @@ class StrategyRunner:
         # Build + commit the canonical trace ONCE. The same trace object is revealed
         # after settlement so the on-chain keccak256 binding holds. In dry-run we still
         # build it (no on-chain commit) so the reveal/persist path has a trace to use.
-        committed_trace, commit_trace_id, commit_tx, commit_block = await self._commit_trace(
+        committed_trace, commit_trace_id, commit_tx, commit_block, claimed_execution_time = await self._commit_trace(
             vault_address,
             trades,
             all_signals,
@@ -690,6 +690,7 @@ class StrategyRunner:
             tick_id,
             reasoning,
             portfolio,
+            targets,
         )
 
         # Phase 2: TRADE — execute the rebalance
@@ -772,6 +773,7 @@ class StrategyRunner:
             commit_tx=commit_tx,
             commit_block=commit_block,
             trade_block=trade_block,
+            claimed_execution_time=claimed_execution_time,
         )
 
     # ─── Signal → target allocation ───────────────────────────────
@@ -843,10 +845,20 @@ class StrategyRunner:
     # ─── Commit-Reveal Trace ────────────────────────────────────
 
     # How far in the future the committed execution is claimed to land. The
-    # contract requires claimedExecutionTime > commit-block timestamp, so the
-    # reveal can only succeed once this lead window has elapsed — proving the
-    # trade landed strictly after the commit (causal ordering).
-    _COMMIT_EXECUTION_LEAD_S = 60
+    # contract requires claimedExecutionTime > commit-block timestamp AND
+    # reveal-block timestamp >= claimedExecutionTime, so the lead is the
+    # minimum commit->reveal separation: bigger lead = stronger "content was
+    # fixed well before reveal" proof, but the reveal phase must wait the
+    # remainder of this window out (see _reveal_trace) — raising it stalls the
+    # tick longer, it does NOT make reveals safer (#903). Must stay well under
+    # AGENT_INTERVAL_SECONDS. Trades settle in seconds on Arc, so 60s already
+    # upper-bounds real execution latency; override via env if that changes.
+    _COMMIT_EXECUTION_LEAD_S = int(os.getenv("TRACE_COMMIT_EXECUTION_LEAD_S", "60"))
+
+    # Clock-skew allowance added on top of claimedExecutionTime before the
+    # reveal is submitted, so the reveal block's timestamp cannot land behind
+    # the local clock and trip "Reveal before claimed execution".
+    _REVEAL_SKEW_BUFFER_S = 3
 
     async def _commit_trace(
         self,
@@ -858,7 +870,8 @@ class StrategyRunner:
         tick_id: str,
         reasoning: str,
         portfolio: Portfolio,
-    ) -> tuple[ReasoningTrace, int | None, str | None, int | None]:
+        targets: list[TargetAllocation],
+    ) -> tuple[ReasoningTrace, int | None, str | None, int | None, int | None]:
         """Commit phase: anchor the trace hash on-chain BEFORE the trade executes.
 
         Builds the canonical trace ONCE and commits its keccak256 via the registry's
@@ -866,9 +879,18 @@ class StrategyRunner:
         after settlement and the on-chain hash binding holds. Falls back to the v1
         ``publishTrace`` anchor when the deployed registry is pre-v1.5 (#588 redeploy).
 
-        Returns (trace, on_chain_trace_id, commit_tx_hash, commit_block_number).
-        The trace is always returned so reveal() can submit the identical content;
-        trace_id is None when commit-reveal is unavailable (publishTrace fallback).
+        Every hashed field — including ``portfolio_after`` — is FINAL here: mutating
+        any of them after this point changes ``canonical_json()`` and the on-chain
+        ``keccak256(fullTraceContent) == contentHash`` reveal check reverts with
+        "Hash mismatch" (#903). ``portfolio_after`` therefore records the *intended*
+        post-trade allocation (deterministic, known pre-trade); actual settlement tx
+        hashes live in non-hashed fields and the off-chain record only.
+
+        Returns (trace, on_chain_trace_id, commit_tx_hash, commit_block_number,
+        claimed_execution_time). The trace is always returned so reveal() can submit
+        the identical content; trace_id is None when commit-reveal is unavailable
+        (publishTrace fallback); claimed_execution_time is non-None only on the real
+        commit-reveal path so the reveal phase knows how long to wait.
         """
         trace = ReasoningTrace(
             id=str(uuid.uuid4()),
@@ -889,6 +911,13 @@ class StrategyRunner:
                     h.symbol: {"weight": f"{h.weight:.1%}", "value_usdc": h.value_usdc} for h in portfolio.holdings
                 },
             },
+            # Hashed field, so it must be knowable pre-trade: the target
+            # allocation this rebalance intends to reach. Settlement tx hashes
+            # are recorded post-trade in non-hashed fields (#903).
+            portfolio_after={
+                "intended": True,
+                "target_weights": {t.symbol: round(t.weight, 6) for t in targets},
+            },
             reasoning=reasoning,
             confidence=_compute_confidence(all_signals),
             trades_executed=[{"symbol": t.symbol, "direction": t.direction.value, "amount": t.amount} for t in trades],
@@ -901,7 +930,7 @@ class StrategyRunner:
 
         if DRY_RUN:
             logger.info("[tick %s] DRY RUN — skipping on-chain commit", tick_id)
-            return trace, None, None, None
+            return trace, None, None, None, None
 
         claimed_execution_time = int(datetime.now(UTC).timestamp()) + self._COMMIT_EXECUTION_LEAD_S
         intent_summary = f"{trace.decision_type.value}:{len(trades)}".encode()
@@ -919,7 +948,7 @@ class StrategyRunner:
                         commit_tx[:16],
                         commit_block,
                     )
-                return trace, trace_id, commit_tx, commit_block
+                return trace, trace_id, commit_tx, commit_block, claimed_execution_time
 
             # Fallback: v1 publishTrace anchor (no temporal binding).
             arc_tx = await trace_publisher.publish(trace)
@@ -938,10 +967,10 @@ class StrategyRunner:
                     arc_tx[:16],
                     commit_block,
                 )
-            return trace, None, arc_tx, commit_block
+            return trace, None, arc_tx, commit_block, None
         except Exception as e:
             logger.error("[tick %s] COMMIT FAILED: %s", tick_id, e)
-            return trace, None, None, None
+            return trace, None, None, None, None
 
     async def _reveal_trace(
         self,
@@ -952,21 +981,26 @@ class StrategyRunner:
         commit_tx: str | None = None,
         commit_block: int | None = None,
         trade_block: int | None = None,
+        claimed_execution_time: int | None = None,
     ) -> None:
         """Reveal phase: pin public provenance to IPFS, then reveal the SAME trace.
 
         ``trace`` is the exact object committed in the commit phase — we do NOT rebuild
-        it, so the canonical bytes revealed on-chain match the committed hash. Steps:
+        it, and we must NOT touch any field in ``_HASH_FIELDS`` (``portfolio_after``
+        included: mutating it here was the #903 "Hash mismatch" revert). Only the
+        non-hashed settlement annotations below are safe to set. Steps:
           1. Pin the PUBLIC provenance layer (papers/methodology/rigor — not executable
              params) to IPFS → CID. Degrades loudly to hash-only if PINATA_JWT is unset.
-          2. reveal(trace_id, cid, canonicalBytes) — contract recomputes keccak256 and
+          2. Wait out the remainder of the claimedExecutionTime window — the contract
+             requires reveal-block timestamp >= claimedExecutionTime, and trades settle
+             in seconds on Arc, so an immediate reveal is structurally too early (#903).
+          3. reveal(trace_id, cid, canonicalBytes) — contract recomputes keccak256 and
              enforces commit block < execution < reveal block.
-          3. Fall back to publishTrace if the deployed registry is pre-v1.5 (#588).
+          4. Fall back to publishTrace if the deployed registry is pre-v1.5 (#588).
         """
         # Annotate the (already-committed) trace with trade settlement data. These
         # fields are NOT in the hashed canonical set (_HASH_FIELDS), so adding them
         # does not change trace_hash — the commit binding stays intact.
-        trace.portfolio_after = {"tx_hashes": tx_hashes or []}
         trace.commit_tx_hash = commit_tx
         trace.commit_block_number = commit_block
         trace.trade_tx_hash = tx_hashes[0] if tx_hashes else None
@@ -989,6 +1023,15 @@ class StrategyRunner:
             # ── 2. Reveal on-chain, anchoring the CID as the storage pointer ──
             try:
                 if trace_id is not None and trace_publisher.supports_commit_reveal():
+                    if claimed_execution_time is not None:
+                        wait_s = claimed_execution_time + self._REVEAL_SKEW_BUFFER_S - datetime.now(UTC).timestamp()
+                        if wait_s > 0:
+                            logger.info(
+                                "[tick %s] REVEAL waiting %.0fs for claimedExecutionTime window",
+                                tick_id,
+                                wait_s,
+                            )
+                            await asyncio.sleep(wait_s)
                     reveal_tx, reveal_block = await trace_publisher.reveal(
                         trace_id, trace, storage_pointer=ipfs_cid or ""
                     )
@@ -1029,6 +1072,12 @@ class StrategyRunner:
                 "confidence": trace.confidence,
                 "trades_executed": trace.trades_executed,
                 "strategies_referenced": trace.strategies_referenced,
+                # Hashed field — persist it so /traces/{id}/canonical can rebuild
+                # the exact committed bytes for external re-verification (#903).
+                "consulted_paper_hashes": trace.consulted_paper_hashes,
+                # Settlement txs live OUTSIDE the hashed set: they are only known
+                # post-trade, and the committed canonical bytes are immutable (#903).
+                "settlement_tx_hashes": tx_hashes or [],
                 "trace_hash": trace.trace_hash,
                 "arc_tx_hash": reveal_tx,
                 "is_verified": reveal_tx is not None,

--- a/backend/archimedes/models/trace.py
+++ b/backend/archimedes/models/trace.py
@@ -42,7 +42,11 @@ class ReasoningTrace:
     # Context at decision time
     market_context: dict = field(default_factory=dict)  # Regime, key prices, VIX, etc.
     portfolio_before: dict = field(default_factory=dict)  # Holdings before action
-    portfolio_after: dict = field(default_factory=dict)  # Holdings after action
+    # Holdings after action. HASHED field: on the commit-reveal path this is the
+    # *intended* post-trade allocation, set before compute_hash() and immutable
+    # afterwards — mutating it post-commit breaks the on-chain reveal (#903).
+    # Settlement tx hashes belong in the non-hashed fields below.
+    portfolio_after: dict = field(default_factory=dict)
 
     # The reasoning
     reasoning: str = ""  # LLM-generated explanation of the decision

--- a/backend/tests/test_agent_runner_commit_reveal.py
+++ b/backend/tests/test_agent_runner_commit_reveal.py
@@ -145,6 +145,126 @@ class TestTemporalBindingPersistence:
         assert not saved["temporal_binding_valid"]
 
 
+class TestHashBindingIntegrity:
+    """#903: the reveal phase must submit byte-identical canonical content.
+
+    Pre-fix, ``_reveal_trace`` overwrote ``portfolio_after`` (a hashed field) with
+    settlement tx hashes, so the revealed ``canonical_json()`` no longer matched the
+    committed keccak256 and the contract reverted "Hash mismatch" on every rebalance.
+    """
+
+    def test_reveal_does_not_mutate_hashed_fields(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
+        mock_tp.publish = AsyncMock(return_value=None)
+
+        trace = _make_trace()
+        trace.portfolio_after = {"intended": True, "target_weights": {"sSPY": 0.6}}
+        committed_hash = trace.compute_hash()
+        committed_bytes = trace.canonical_json()
+
+        asyncio.run(
+            runner._reveal_trace(
+                trace,
+                trace_id=42,
+                tick_id="t1",
+                tx_hashes=["0xtrade"],
+                commit_tx="0xcommit",
+                commit_block=100,
+                trade_block=101,
+            )
+        )
+
+        # The exact committed bytes are what got revealed — no hashed field moved.
+        assert trace.portfolio_after == {"intended": True, "target_weights": {"sSPY": 0.6}}
+        assert trace.canonical_json() == committed_bytes
+        assert trace.compute_hash() == committed_hash
+        revealed_trace = mock_tp.reveal.call_args.args[1]
+        assert revealed_trace.canonical_json() == committed_bytes
+
+    def test_settlement_tx_hashes_persisted_outside_hashed_set(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
+
+        trace = _make_trace()
+        trace.consulted_paper_hashes = ["1706.03762:abc123"]
+        trace.compute_hash()
+
+        asyncio.run(
+            runner._reveal_trace(
+                trace,
+                trace_id=42,
+                tick_id="t1",
+                tx_hashes=["0xtrade1", "0xtrade2"],
+                commit_tx="0xcommit",
+                commit_block=100,
+                trade_block=101,
+            )
+        )
+
+        saved = _saved(runner)
+        assert saved["settlement_tx_hashes"] == ["0xtrade1", "0xtrade2"]
+        # Hashed fields round-trip so /traces/{id}/canonical can rebuild the
+        # exact committed bytes for external verification.
+        assert saved["consulted_paper_hashes"] == ["1706.03762:abc123"]
+        assert saved["portfolio_after"] == trace.portfolio_after
+
+
+class TestRevealTimingWindow:
+    """#903: reveal must not fire before claimedExecutionTime.
+
+    The contract requires reveal-block timestamp >= claimedExecutionTime; trades
+    settle in seconds on Arc, so an immediate intra-tick reveal always reverted
+    "Reveal before claimed execution". The reveal now waits the window out.
+    """
+
+    def _run_reveal(self, runner, mock_tp, claimed_execution_time):
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
+        with patch("archimedes.chain.agent_runner.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            asyncio.run(
+                runner._reveal_trace(
+                    _make_trace(),
+                    trace_id=42,
+                    tick_id="t1",
+                    tx_hashes=["0xtrade"],
+                    commit_tx="0xcommit",
+                    commit_block=100,
+                    trade_block=101,
+                    claimed_execution_time=claimed_execution_time,
+                )
+            )
+        return mock_sleep, mock_tp.reveal
+
+    def test_reveal_waits_out_remaining_claimed_window(self, runner_env):
+        runner, mock_tp = runner_env
+        claimed = int(datetime.now(UTC).timestamp()) + 30
+        mock_sleep, mock_reveal = self._run_reveal(runner, mock_tp, claimed)
+
+        mock_sleep.assert_awaited_once()
+        waited = mock_sleep.await_args.args[0]
+        # Remaining window (~30s) plus the skew buffer, minus test overhead.
+        assert 25 <= waited <= 30 + runner._REVEAL_SKEW_BUFFER_S
+        mock_reveal.assert_awaited_once()
+
+    def test_reveal_does_not_wait_when_window_already_passed(self, runner_env):
+        runner, mock_tp = runner_env
+        claimed = int(datetime.now(UTC).timestamp()) - 120
+        mock_sleep, mock_reveal = self._run_reveal(runner, mock_tp, claimed)
+
+        mock_sleep.assert_not_awaited()
+        mock_reveal.assert_awaited_once()
+
+    def test_reveal_does_not_wait_without_claimed_time(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_sleep, mock_reveal = self._run_reveal(runner, mock_tp, None)
+
+        mock_sleep.assert_not_awaited()
+        mock_reveal.assert_awaited_once()
+
+
 class TestTraceResponseClaimGuard:
     """The schema is the last line of defense against a stale Redis True binding."""
 

--- a/backend/tests/test_agent_runner_tick.py
+++ b/backend/tests/test_agent_runner_tick.py
@@ -251,7 +251,7 @@ class TestCommitRevealDryRun:
 
     async def test_commit_trace_dry_run_builds_and_hashes(self, runner_env):
         runner, _ = runner_env
-        trace, trace_id, commit_tx, commit_block = await runner._commit_trace(
+        trace, trace_id, commit_tx, commit_block, claimed_time = await runner._commit_trace(
             "0xVault",
             [self._trade()],
             [_signals()],
@@ -260,17 +260,29 @@ class TestCommitRevealDryRun:
             "tick-1",
             "reasoning text",
             _portfolio(),
+            _allocs(sSPY=0.6, USDC=0.4),
         )
         # DRY_RUN → no on-chain ids, but the canonical trace IS built + hashed.
-        assert trace_id is None and commit_tx is None and commit_block is None
+        assert trace_id is None and commit_tx is None and commit_block is None and claimed_time is None
         assert trace.trace_hash and len(trace.trace_hash.removeprefix("0x")) == 64
         assert trace.decision_type.value == "rebalance"
+        # portfolio_after is hashed, so it carries the pre-trade INTENDED targets (#903).
+        assert trace.portfolio_after["intended"] is True
+        assert trace.portfolio_after["target_weights"] == {"sSPY": 0.6, "USDC": 0.4}
 
     async def test_reveal_trace_dry_run_persists_off_chain(self, runner_env):
         runner, m = runner_env
         # Build a trace via commit, then reveal it (DRY_RUN → no IPFS/chain).
         trace, trace_id, *_ = await runner._commit_trace(
-            "0xVault", [self._trade()], [_signals()], "risk_on", _consensus(), "t", "r", _portfolio()
+            "0xVault",
+            [self._trade()],
+            [_signals()],
+            "risk_on",
+            _consensus(),
+            "t",
+            "r",
+            _portfolio(),
+            _allocs(sSPY=0.6, USDC=0.4),
         )
         await runner._reveal_trace(trace, trace_id, "tick-1", tx_hashes=[])
         # Off-chain persist happened with temporal_binding_source = "none" (dry-run).


### PR DESCRIPTION
## What

Two fixes on the commit-reveal path in `agent_runner`, no contract changes needed:

1. **Hash mismatch.** `portfolio_after` is a hashed field (`_HASH_FIELDS`, trace.py), but `_reveal_trace` overwrote it with settlement tx hashes after the commit — the comment above that line even claimed the field wasn't hashed. Every reveal therefore submitted bytes that no longer matched the committed keccak256 and reverted `Hash mismatch`. Now `portfolio_after` is set at commit time to the **intended target allocation** (deterministic, known pre-trade) and never touched again; settlement tx hashes persist off-chain under a new `settlement_tx_hashes` key. I went this way rather than dropping the field from `_HASH_FIELDS` because changing the canonical set would break re-verification of every previously anchored trace.

2. **Reveal too early.** The contract requires reveal-block timestamp ≥ `claimedExecutionTime` (commit + 60s), but trades settle in seconds on Arc, so the intra-tick reveal always reverted `Reveal before claimed execution`. The reveal now waits out the remainder of the window (+3s skew buffer) before submitting.

## Deviation from the issue's acceptance criteria

#903 asked to **raise** the lead to 5–10 min. That's inverted: the revert fires when the reveal comes *before* the claimed time, so a bigger lead widens the too-early window — and with the wait fix it would stall the tick 5–10 min per rebalance (tick interval is 300s). I kept the 60s default (still a full minute of commit→reveal separation, and an honest upper bound on Arc execution latency) and made it env-tunable via `TRACE_COMMIT_EXECUTION_LEAD_S` if execution latency ever grows.

## Also in here

`consulted_paper_hashes` (a hashed field) never round-tripped through the off-chain store, so `/traces/{id}/canonical` could not rebuild the committed bytes for paper-grounded decisions — same defect class, one-line fixes on both sides.

## Tests

New in `test_agent_runner_commit_reveal.py`: reveal submits byte-identical canonical content (hash invariance), settlement hashes persist outside the hashed set, reveal waits the remaining window / skips waiting when it already passed / skips without a claimed time. Updated `_commit_trace` tests for the new signature + intended-targets assertion.

- `pytest` (trace + agent-runner + api-routes files): 130 passed, 0 failed
- Hermetic gate (`env -i ... PYTHONPATH=backend`): 25 passed, 0 failed
- `ruff format --check` + `ruff check`: clean

## Verify on live (after deploy)

```bash
psql $DATABASE_URL -c "SELECT id, is_verified, temporal_binding_valid, reveal_tx_hash FROM reasoning_traces WHERE decision_type='rebalance' ORDER BY created_at DESC LIMIT 5;"
```

Recent REBALANCE traces should show `temporal_binding_valid=true` with a non-null `reveal_tx_hash` once the next drift-triggered rebalance runs. Needs the v1.5 registry with `commit()`/`reveal()` live (#588) — on the pre-v1.5 registry the code keeps the loud publishTrace fallback.

Fixes #903