### PR TITLE
[backend] Confirm oracle price pushes to terminal state before trusting them

### DIFF
--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -41,6 +41,15 @@ CRYPTO_MAP = {
 CIRCLE_API_BASE = "https://api.circle.com/v1/w3s"
 CIRCLE_BLOCKCHAIN = "ARC-TESTNET"
 
+# ─── Push-confirmation polling (#905) ───
+# A 201 from Circle's contractExecution endpoint means "submission accepted",
+# NOT "landed on-chain" — the tx can still FAIL/revert later. Every push is
+# polled to a terminal state before the price is treated as pushed; mirrors
+# circle_signer._poll_transaction's states/cadence.
+_TX_TERMINAL_STATES = {"COMPLETE", "FAILED", "DENIED", "CANCELLED"}
+_TX_POLL_INTERVAL_S = 2.0
+_TX_MAX_POLLS = 60  # 2 minutes max per tx
+
 # ─── Sanity bounds for on-chain pushes (audit #13 / issue #508) ───
 # Max allowed move vs the last known good price, in basis points.
 # Default mirrors PriceOracle.sol's maxDeviationBps (2000 bps = 20%) so the
@@ -227,7 +236,16 @@ class OracleUpdater:
         return prices
 
     async def push_prices_on_chain(self, prices: list[AssetPrice]) -> str | None:
-        """Call PriceOracle.setPrice() for each asset via Circle Wallets API."""
+        """Call PriceOracle.setPrice() for each asset via Circle Wallets API.
+
+        Two phases (#905): submit every price, then poll each Circle tx to a
+        terminal state. ``_last_pushed_price_int`` — the deviation guard's
+        fallback reference — is updated ONLY for txs that reach ``COMPLETE``.
+        Recording it on HTTP 201 (submission accepted) treated a later on-chain
+        revert as success: the next tick's deviation guard then compared against
+        a price that was never written, silently defeating the guard and masking
+        a stuck oracle.
+        """
         if not self._api_key or not self._entity_secret or not self._wallet_id:
             logger.warning(
                 "Circle credentials not configured "
@@ -239,7 +257,10 @@ class OracleUpdater:
         from archimedes.chain.client import chain_client
 
         oracle_addresses = chain_client.settings.oracle_addresses
-        tx_ids: list[str] = []
+        # (symbol, human price, 6-dec int, Circle tx id) per accepted submission,
+        # pending on-chain confirmation.
+        submitted: list[tuple[str, float, int, str]] = []
+        confirmed_tx_ids: list[str] = []
 
         async with aiohttp.ClientSession() as session:
             public_key = await self._get_circle_public_key(session)
@@ -292,15 +313,63 @@ class OracleUpdater:
                         body = await resp.json()
                         if resp.status == 201:
                             tx_id = body["data"]["id"]
-                            tx_ids.append(tx_id)
-                            self._last_pushed_price_int[price.symbol] = price_int
-                            logger.info(f"Pushed {price.symbol} price {price.price_usd:.2f} → Circle tx {tx_id}")
+                            submitted.append((price.symbol, price.price_usd, price_int, tx_id))
+                            logger.info(f"Submitted {price.symbol} price {price.price_usd:.2f} → Circle tx {tx_id}")
                         else:
                             logger.error(f"Circle API error for {price.symbol} ({resp.status}): {body}")
                 except Exception:
                     logger.exception(f"Failed to push price for {price.symbol}")
 
-        return tx_ids[0] if tx_ids else None
+            # ── Confirmation phase (#905): poll each submission to a terminal
+            # state. Only a COMPLETE tx counts as pushed; anything else leaves
+            # the cached deviation reference untouched and is logged loudly so
+            # a stuck oracle is visible to operators, never masked.
+            for symbol, price_usd, price_int, tx_id in submitted:
+                state = await self._poll_circle_tx(session, tx_id)
+                if state == "COMPLETE":
+                    self._last_pushed_price_int[symbol] = price_int
+                    confirmed_tx_ids.append(tx_id)
+                    logger.info(f"Pushed {symbol} price {price_usd:.2f} on-chain (Circle tx {tx_id} COMPLETE)")
+                else:
+                    logger.error(
+                        "Oracle push for %s (price %.2f, Circle tx %s) ended %s — "
+                        "on-chain price NOT updated; deviation-guard reference unchanged",
+                        symbol,
+                        price_usd,
+                        tx_id,
+                        state,
+                    )
+
+        return confirmed_tx_ids[0] if confirmed_tx_ids else None
+
+    async def _poll_circle_tx(self, session: aiohttp.ClientSession, circle_tx_id: str) -> str:
+        """Poll a Circle tx to a terminal state (#905).
+
+        Same states/cadence as ``circle_signer._poll_transaction``, but returns
+        the terminal state string (``"TIMEOUT"`` after ``_TX_MAX_POLLS``) instead
+        of raising, so one failed price push cannot abort the confirmation of
+        the other symbols in the same batch. Poll errors are treated as
+        still-processing — only an explicit terminal state or the timeout ends
+        the loop, and only ``COMPLETE`` is ever treated as success.
+        """
+        for _ in range(_TX_MAX_POLLS):
+            try:
+                async with session.get(
+                    f"{CIRCLE_API_BASE}/transactions?pageSize=50",
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                ) as resp:
+                    if resp.status == 200:
+                        body = await resp.json()
+                        for tx in body.get("data", {}).get("transactions", []):
+                            if tx.get("id") == circle_tx_id:
+                                state = tx.get("state", "UNKNOWN")
+                                if state in _TX_TERMINAL_STATES:
+                                    return state
+                                break  # found but still processing
+            except Exception:
+                logger.warning("Circle tx %s poll attempt failed — retrying", circle_tx_id, exc_info=True)
+            await asyncio.sleep(_TX_POLL_INTERVAL_S)
+        return "TIMEOUT"
 
     async def fetch_market_snapshot(self) -> MarketSnapshot:
         """Fetch a full market snapshot with prices + regime signals."""

--- a/backend/tests/chain/test_oracle_price_formatting.py
+++ b/backend/tests/chain/test_oracle_price_formatting.py
@@ -80,6 +80,8 @@ class TestOraclePriceFormatting:
             ),
             # First push for this symbol → reference confirmed absent → allowed.
             patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))),
+            # Confirmation phase (#905): the tx lands COMPLETE on-chain.
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="COMPLETE")),
         ):
             result = await updater.push_prices_on_chain([_price(usd=185.50)])
 
@@ -111,6 +113,7 @@ class TestOraclePriceFormatting:
                 return_value=_TEST_ORACLE_ADDRS,
             ),
             patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(None, True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="COMPLETE")),
         ):
             await updater.push_prices_on_chain([_price(symbol="sNVDA", usd=1.0000005)])
 

--- a/backend/tests/chain/test_oracle_updater.py
+++ b/backend/tests/chain/test_oracle_updater.py
@@ -12,6 +12,7 @@ Hermetic: chain reads and Circle HTTP calls are mocked at the boundary
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -243,6 +244,7 @@ class TestPushPricesOnChain:
             patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
             patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
             patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="COMPLETE")),
         ):
             result = await updater.push_prices_on_chain([good])
 
@@ -290,3 +292,85 @@ class TestPushPricesOnChain:
 
         assert result is None
         session.post.assert_not_called()
+
+
+# ── push_prices_on_chain confirms txs before trusting them (#905) ──────
+
+
+@pytest.mark.usefixtures("circle_creds")
+class TestPushConfirmation:
+    """A 201 from Circle is submission-accepted, not landed-on-chain. The cached
+    deviation reference must move ONLY on a COMPLETE terminal state — a reverted
+    push that still updates the cache poisons every later deviation check."""
+
+    def _updater_with_submission(self):
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        resp = MagicMock(status=201)
+        resp.json = AsyncMock(return_value={"data": {"id": "tx-905"}})
+        return updater, _mock_aiohttp_session(post_response=resp)
+
+    async def _push_with_terminal_state(self, state: str):
+        updater, (session_cm, session) = self._updater_with_submission()
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value=state)) as poll,
+        ):
+            result = await updater.push_prices_on_chain([good])
+        return updater, session, poll, result
+
+    async def test_complete_tx_updates_cache(self):
+        updater, session, poll, result = await self._push_with_terminal_state("COMPLETE")
+        poll.assert_awaited_once()
+        assert result == "tx-905"
+        assert updater._last_pushed_price_int["sSPY"] == _int6(110.0)
+
+    async def test_failed_tx_leaves_cache_unchanged_and_logs_error(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="archimedes.chain.oracle_updater"):
+            updater, session, poll, result = await self._push_with_terminal_state("FAILED")
+        poll.assert_awaited_once()
+        # The tx was submitted but reverted: no success signal, no cache update.
+        assert result is None
+        assert "sSPY" not in updater._last_pushed_price_int
+        assert any("deviation-guard reference unchanged" in r.message for r in caplog.records)
+
+    async def test_timeout_treated_as_failure(self):
+        updater, session, poll, result = await self._push_with_terminal_state("TIMEOUT")
+        assert result is None
+        assert "sSPY" not in updater._last_pushed_price_int
+
+    async def test_poll_returns_terminal_state_from_circle(self):
+        # _poll_circle_tx itself: a FAILED state on the list endpoint is returned
+        # verbatim (the caller decides what to do with it — never raises).
+        updater = OracleUpdater()
+        get_resp = MagicMock(status=200)
+        get_resp.json = AsyncMock(
+            return_value={"data": {"transactions": [{"id": "tx-905", "state": "FAILED", "txHash": "0xdead"}]}}
+        )
+        session = MagicMock()
+        get_cm = MagicMock()
+        get_cm.__aenter__ = AsyncMock(return_value=get_resp)
+        get_cm.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=get_cm)
+
+        assert await updater._poll_circle_tx(session, "tx-905") == "FAILED"
+
+    async def test_poll_times_out_on_never_terminal_tx(self, monkeypatch):
+        import archimedes.chain.oracle_updater as ou
+
+        monkeypatch.setattr(ou, "_TX_MAX_POLLS", 2)
+        monkeypatch.setattr(ou, "_TX_POLL_INTERVAL_S", 0)
+
+        updater = OracleUpdater()
+        get_resp = MagicMock(status=200)
+        get_resp.json = AsyncMock(return_value={"data": {"transactions": [{"id": "tx-905", "state": "QUEUED"}]}})
+        session = MagicMock()
+        get_cm = MagicMock()
+        get_cm.__aenter__ = AsyncMock(return_value=get_resp)
+        get_cm.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=get_cm)
+
+        assert await updater._poll_circle_tx(session, "tx-905") == "TIMEOUT"

--- a/backend/tests/chain/test_oracle_updater.py
+++ b/backend/tests/chain/test_oracle_updater.py
@@ -323,14 +323,14 @@ class TestPushConfirmation:
         return updater, session, poll, result
 
     async def test_complete_tx_updates_cache(self):
-        updater, session, poll, result = await self._push_with_terminal_state("COMPLETE")
+        updater, _session, poll, result = await self._push_with_terminal_state("COMPLETE")
         poll.assert_awaited_once()
         assert result == "tx-905"
         assert updater._last_pushed_price_int["sSPY"] == _int6(110.0)
 
     async def test_failed_tx_leaves_cache_unchanged_and_logs_error(self, caplog):
         with caplog.at_level(logging.ERROR, logger="archimedes.chain.oracle_updater"):
-            updater, session, poll, result = await self._push_with_terminal_state("FAILED")
+            updater, _session, poll, result = await self._push_with_terminal_state("FAILED")
         poll.assert_awaited_once()
         # The tx was submitted but reverted: no success signal, no cache update.
         assert result is None
@@ -338,7 +338,7 @@ class TestPushConfirmation:
         assert any("deviation-guard reference unchanged" in r.message for r in caplog.records)
 
     async def test_timeout_treated_as_failure(self):
-        updater, session, poll, result = await self._push_with_terminal_state("TIMEOUT")
+        updater, _session, _poll, result = await self._push_with_terminal_state("TIMEOUT")
         assert result is None
         assert "sSPY" not in updater._last_pushed_price_int
 


### PR DESCRIPTION
## What

`push_prices_on_chain` treated Circle's HTTP 201 as success and immediately recorded `_last_pushed_price_int[symbol]` — but 201 only means the submission was accepted. If the tx later reverted on-chain, the backend still believed the price was pushed, and the next tick's deviation guard compared against a value that was never written: the guard was silently defeated and a stuck oracle looked healthy.

The push is now two-phase: submit every price, then poll each Circle tx to a terminal state (same states and 2s/60-poll cadence as `circle_signer._poll_transaction`). Only `COMPLETE` updates the cached deviation reference and counts toward the returned tx id. `FAILED`/`DENIED`/`CANCELLED`/poll-timeout leave the cache untouched and log an error with the symbol, price, tx id, and terminal state. Poll errors retry rather than abort, and one bad symbol can't block confirmation of the others in the batch.

Kept out of scope per the issue: the oracle architecture and the Chainlink feed path are untouched — this only fixes the confirmation gap on the Circle push path.

## Tests

New `TestPushConfirmation` in `test_oracle_updater.py`: COMPLETE updates the cache and returns the tx id; FAILED leaves the cache unchanged and logs the "deviation-guard reference unchanged" error (caplog-asserted); TIMEOUT treated as failure; `_poll_circle_tx` unit tests for terminal-state passthrough and timeout. The two existing push-path tests and the two price-formatting tests gained the confirmation mock.

- `backend/tests/chain/`: 161 passed, 0 failed
- Hermetic gate (`env -i ... PYTHONPATH=backend`): 26 passed
- `ruff format --check` + blocking lint gate: clean

## Operational note

Confirmation adds up to ~2 min of polling per stuck tx to the oracle tick — on the happy path Arc finality is sub-second so the first or second poll resolves it. Tagging Dan for the chain-integration review.

Fixes #905