### PR TITLE
[risk] Fix /cvar leaking bare NaN into JSON for single-return portfolios

### DIFF
--- a/backend/archimedes/api/risk_routes.py
+++ b/backend/archimedes/api/risk_routes.py
@@ -361,8 +361,12 @@ async def get_portfolio_cvar():
     portfolio_returns = stacked.mean(axis=1)
 
     n = len(portfolio_returns)
-    mu = portfolio_returns.mean()
-    sigma = portfolio_returns.std(ddof=1)
+    mu = float(portfolio_returns.mean())
+    # std(ddof=1) is 0/0 -> NaN for a single daily return, and a bare NaN
+    # serializes as an invalid JSON token that breaks strict parsers on the
+    # Risk page. Treat a single-sample portfolio as zero-volatility, and guard
+    # against any stray NaN/inf in the multi-sample path too.
+    sigma = float(np.nan_to_num(portfolio_returns.std(ddof=1), nan=0.0)) if n > 1 else 0.0
 
     levels: list[CVaRLevel] = []
     for conf in (0.90, 0.95, 0.99):

--- a/backend/tests/test_risk_cvar_greeks.py
+++ b/backend/tests/test_risk_cvar_greeks.py
@@ -139,6 +139,43 @@ async def test_cvar_cvar_exceeds_var():
         )
 
 
+@pytest.mark.asyncio
+async def test_cvar_single_return_emits_valid_json():
+    """A portfolio with exactly one daily return used to leak a bare NaN into
+    the JSON (std(ddof=1) divides by zero). The response must stay valid JSON
+    and every parametric number must be finite."""
+    import json
+    import math
+
+    from archimedes.main import app
+
+    # Two equity points -> exactly one daily return, so std(ddof=1) is 0/0.
+    s1 = _make_strategy("s1")
+    bt1 = _make_backtest(equity_curve=[100.0, 101.0])
+
+    mock_provider = MagicMock()
+    mock_provider.list_strategies.return_value = [s1]
+    mock_provider.get_backtest_result.return_value = bt1
+
+    with patch("archimedes.api.risk_routes._strategy_provider", lambda: mock_provider):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/risk/cvar")
+
+    assert resp.status_code == 200
+    # A bare NaN token is what strict parsers (JSON.parse, Swift, Go) reject.
+    assert "NaN" not in resp.text
+
+    # Re-parse rejecting the non-standard constants to prove it's strict JSON.
+    def _reject(_):
+        raise AssertionError("response contains a non-finite JSON constant")
+
+    parsed = json.loads(resp.text, parse_constant=_reject)
+    for lv in parsed["levels"]:
+        assert lv["sample_size"] == 1
+        for key in ("var_parametric", "cvar_parametric", "var_historical", "cvar_historical"):
+            assert math.isfinite(lv[key]), f"{key} is not finite: {lv[key]}"
+
+
 # ── Greeks tests ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

The `/api/risk/cvar` endpoint could put a bare `NaN` token into its JSON body, which strict parsers (`JSON.parse`, Swift, Go) reject, so the Risk page failed to load. The cause is on the parametric path: when the equal-weight portfolio has exactly one daily return, `portfolio_returns.std(ddof=1)` is 0/0 and returns `NaN`. That `NaN` flowed straight into `var_parametric`/`cvar_parametric` and got serialized as-is.

## Scope

- `backend/archimedes/api/risk_routes.py` — the `sigma` computation in `get_portfolio_cvar`.
- `backend/tests/test_risk_cvar_greeks.py` — one new hermetic test.

## What changed

- A single-sample portfolio is now treated as zero-volatility (`sigma = 0.0`) instead of running `std(ddof=1)` on one point. With `sigma = 0` the parametric VaR/CVaR collapse to `-mu`, which is finite and correct for a degenerate one-observation sample.
- The multi-sample path wraps `std(ddof=1)` in `np.nan_to_num(..., nan=0.0)` as a belt-and-suspenders guard so a stray `NaN` can never reach the response again.
- `mu` is cast to `float` up front so the parametric math stays in plain Python floats.

The change is confined to `sigma`; portfolio construction is untouched.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_risk_cvar_greeks.py -q
```

The new `test_cvar_single_return_emits_valid_json` builds a one-return portfolio, asserts the response has no bare `NaN` token, re-parses with `parse_constant` set to reject non-finite constants, and checks every VaR/CVaR field is finite. All 7 cvar/greeks tests pass; `ruff format --check` and `ruff check` are clean on both files.

## Anti-goals

- No change to portfolio construction or the equal-weight logic.
- No change to the Circle/backend tx handling.

Fixes #907
