### PR TITLE
[agents] Make extract_json return a dict or raise, never a list/scalar

### DIFF
--- a/backend/archimedes/agents/strategy_architect.py
+++ b/backend/archimedes/agents/strategy_architect.py
@@ -211,9 +211,12 @@ def _build_user_prompt(
 def extract_json(text: str) -> dict:
     """Pull the first balanced JSON object out of an LLM response.
 
-    Tolerates ```json fences and surrounding prose. Raises ValueError if no
-    parseable object is found so the caller can degrade explicitly rather
-    than silently shipping an empty portfolio.
+    Tolerates ```json fences and surrounding prose, and always returns a
+    dict. When the top-level value is a JSON array or scalar (models
+    sometimes wrap the object in a one-element array, e.g. ``[{...}]``), the
+    brace scan below recovers the first embedded ``{...}`` object. Raises
+    ValueError if no object can be recovered so the caller can degrade
+    explicitly rather than calling ``.get()`` on a non-dict and crashing.
     """
     cleaned = text.strip()
     fence = re.search(r"```(?:json)?\s*(.+?)```", cleaned, re.DOTALL)
@@ -221,7 +224,12 @@ def extract_json(text: str) -> dict:
         cleaned = fence.group(1).strip()
 
     try:
-        return json.loads(cleaned)
+        parsed = json.loads(cleaned)
+        # Only a top-level object is returned directly; a bare array/string/
+        # number falls through to the brace scan (which yields the first
+        # embedded object) so callers always receive a dict.
+        if isinstance(parsed, dict):
+            return parsed
     except json.JSONDecodeError:
         pass
 

--- a/backend/tests/test_extract_json.py
+++ b/backend/tests/test_extract_json.py
@@ -8,7 +8,6 @@ no LLM, no network, no .env.
 from __future__ import annotations
 
 import pytest
-
 from archimedes.agents.strategy_architect import extract_json
 
 

--- a/backend/tests/test_extract_json.py
+++ b/backend/tests/test_extract_json.py
@@ -1,0 +1,41 @@
+"""Unit tests for extract_json (#911).
+
+extract_json must always return a dict or raise ValueError — never hand a
+list/scalar back to a caller that immediately does ``.get()`` on it. Hermetic:
+no LLM, no network, no .env.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from archimedes.agents.strategy_architect import extract_json
+
+
+def test_plain_object():
+    assert extract_json('{"a": 1}') == {"a": 1}
+
+
+def test_object_in_json_fence():
+    assert extract_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_array_wrapped_object_is_salvaged():
+    # Weak-JSON models sometimes wrap the single object in a one-element array.
+    assert extract_json('[{"a": 1}]') == {"a": 1}
+
+
+def test_first_object_of_multi_element_array():
+    assert extract_json('[{"a": 1}, {"b": 2}]') == {"a": 1}
+
+
+def test_object_embedded_in_prose():
+    assert extract_json('here you go: {"a": 1} thanks') == {"a": 1}
+
+
+@pytest.mark.parametrize("raw", ['"just a string"', "42", "[1, 2, 3]", "[]", "not json at all"])
+def test_non_object_raises_valueerror(raw):
+    # A bare scalar or an object-free array can't become a dict, so the caller
+    # gets the explicit ValueError it already handles rather than a bad type.
+    with pytest.raises(ValueError):
+        extract_json(raw)

--- a/backend/tests/test_strategy_fusion.py
+++ b/backend/tests/test_strategy_fusion.py
@@ -294,6 +294,31 @@ def test_propose_fuses_and_records_provenance(monkeypatch, corpus):
     assert proposal.requested_model == "claude-sonnet-4-20250514"
 
 
+def test_propose_survives_array_wrapped_object(monkeypatch, corpus):
+    """Regression for #911: a model that wraps its object in a JSON array
+    (``[{...}]``) must not crash the ``parsed.get(...)`` calls in propose.
+    extract_json recovers the embedded object instead of returning a list."""
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+
+    class _ArrayWrappingBackend(_MockBackend):
+        def complete(self, system: str, user: str) -> str:
+            return "[" + super().complete(system, user) + "]"
+
+    backend = _ArrayWrappingBackend()
+    svc = StrategyFusion(backend=backend, corpus=corpus)
+    brief = FusionBrief(
+        asset_classes=["equities", "rates"],
+        risk_appetite=RiskProfile.MODERATE,
+        strategic_direction="regime conditioning",
+        max_papers=4,
+    )
+    # Before the fix this raised AttributeError inside propose.
+    proposal = svc.propose(brief)
+    assert proposal.status == "ok"
+    assert proposal.is_actionable is True
+    assert len(proposal.source_arxiv_ids) >= MIN_PAPERS
+
+
 def test_prompt_demands_at_least_two_papers(monkeypatch, corpus):
     monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
     backend = _MockBackend()


### PR DESCRIPTION
## Summary

`extract_json` is annotated `-> dict` but its first `json.loads(cleaned)` returned whatever the top-level JSON value parsed to. When a model answered with an array (`[{...}]`, common with weak-JSON models) or a bare string, callers got a non-dict back. Fusion (`propose`), arxiv-synth (`synthesize_passport`) and the architect (`propose`) all wrap only the parse in `try/except ValueError` and then call `.get()` on the result, so a list/string raised `AttributeError` and crashed those paths. (The debate pool masked it via `gather(return_exceptions=True)`.)

## Scope

- `backend/archimedes/agents/strategy_architect.py` — `extract_json`.
- `backend/tests/test_extract_json.py` — new unit tests.
- `backend/tests/test_strategy_fusion.py` — one regression test.

## What changed

`extract_json` now only returns the top-level value when it's a dict. Anything else (array, string, number, or unparseable prose) falls through to the existing brace scan, which recovers the first balanced `{...}` object — so a one-element `[{...}]` wrapper is salvaged into the object it contained. If no object can be recovered, it raises `ValueError`, which every caller already handles by returning a graceful "unparseable" fallback. Fixing it at the source covers all three call sites without touching each caller.

I chose not to change the LLM prompts to forbid arrays; that's fragile and doesn't help when a model ignores the instruction.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_extract_json.py backend/tests/test_strategy_fusion.py -q
```

`test_extract_json.py` covers plain objects, fenced objects, array-wrapped objects, prose-embedded objects, and the non-object cases that must raise. `test_propose_survives_array_wrapped_object` drives `StrategyFusion.propose` with a backend that wraps its output in `[...]` and asserts it no longer crashes. 46 passed; `ruff format --check` and `ruff check` clean.

## Anti-goals

- No prompt changes to forbid arrays.
- No change to the fusion/architect/arxiv logic beyond the parse contract.

Fixes #911
