### PR TITLE
[backend] Use async Redis in _compute_returns so it can't freeze the event loop

### DIFF
--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -245,22 +245,26 @@ class VaultService:
         """
         import os
 
-        import redis as _redis
+        import redis.asyncio as _aioredis
 
         logger = logging.getLogger(__name__)
 
-        # Try Redis-based real returns first
+        # Try Redis-based real returns first. This runs inside an async request
+        # handler, so the client MUST be the asyncio one and every call awaited
+        # — a blocking sync client here freezes the whole uvicorn event loop
+        # (every concurrent request on the worker stalls) if Redis is slow.
+        r = None
         try:
-            r = _redis.Redis(
+            r = _aioredis.Redis(
                 host=os.getenv("REDIS_HOST", "localhost"),
                 port=int(os.getenv("REDIS_PORT", "6379")),
                 decode_responses=True,
             )
-            r.ping()
+            await r.ping()
 
             # Check if we have a price snapshot for this vault
             snapshot_key = f"vault:prices:{vault_address}"
-            snapshot = r.get(snapshot_key)
+            snapshot = await r.get(snapshot_key)
 
             if snapshot:
                 prices_at_creation = json.loads(snapshot)
@@ -307,6 +311,12 @@ class VaultService:
                     }
         except Exception as e:
             logger.debug("Redis price snapshot not available for %s: %s", sanitize_log_value(vault_address), e)
+        finally:
+            if r is not None:
+                try:
+                    await r.aclose()
+                except Exception:
+                    pass
 
         # Fallback: compute simulated returns from allocation weights
         # This gives realistic numbers until real price history accumulates

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -313,10 +314,8 @@ class VaultService:
             logger.debug("Redis price snapshot not available for %s: %s", sanitize_log_value(vault_address), e)
         finally:
             if r is not None:
-                try:
+                with contextlib.suppress(Exception):
                     await r.aclose()
-                except Exception:
-                    pass
 
         # Fallback: compute simulated returns from allocation weights
         # This gives realistic numbers until real price history accumulates

--- a/backend/tests/services/test_vault_service.py
+++ b/backend/tests/services/test_vault_service.py
@@ -211,6 +211,46 @@ class TestComputeReturnsFallback:
         assert abs(result["return_30d"]) >= abs(result["return_24h"])
 
 
+class TestComputeReturnsAsyncRedis:
+    @pytest.mark.asyncio
+    async def test_uses_async_redis_and_awaits_snapshot(self) -> None:
+        """Regression for #914: the Redis snapshot path must use the asyncio
+        client and await ping/get so it never blocks the event loop. We mock
+        redis.asyncio.Redis with a valid snapshot plus a mocked oracle; the
+        returns must come from the Redis price path (not the deterministic
+        fallback), which only happens if the awaits land. A revert to the sync
+        redis.Redis would miss this patch and fall through to the fallback."""
+        import json
+
+        alloc = VaultHolding(symbol="sSPY", token_address="0xT", amount=1.0, value_usdc=1.0, weight_pct=100.0)
+
+        fake_redis = MagicMock()
+        fake_redis.ping = AsyncMock(return_value=True)
+        fake_redis.get = AsyncMock(return_value=json.dumps({"0xT": 1.0}))
+        fake_redis.aclose = AsyncMock()
+
+        # Oracle reports $2.0 (raw 2_000_000 / 1e6) → +100% vs the $1.0 creation
+        # price stored in the snapshot.
+        oracle = MagicMock()
+        oracle.functions.price.return_value.call = AsyncMock(return_value=2_000_000)
+        loader = MagicMock()
+        loader.oracle_for.return_value = oracle
+
+        svc = VaultService()
+        with (
+            patch("redis.asyncio.Redis", return_value=fake_redis),
+            patch("archimedes.chain.contracts.get_contract_loader", return_value=loader),
+        ):
+            result = await svc._compute_returns("0xVault", [alloc])
+
+        fake_redis.ping.assert_awaited_once()
+        fake_redis.get.assert_awaited_once()
+        fake_redis.aclose.assert_awaited_once()
+        # 100% weighted return → return_30d == 1.0, return_24h == 1.0 * 0.033.
+        assert result["return_30d"] == pytest.approx(1.0)
+        assert result["return_24h"] == pytest.approx(0.033)
+
+
 class TestRecentTracesSwallowFailures:
     @pytest.mark.asyncio
     async def test_chain_failure_returns_empty_list(self) -> None:


### PR DESCRIPTION
## Summary

`VaultService._compute_returns` is an `async def` on the vault-detail request path, but it built a synchronous `redis.Redis(...)` client and called `.ping()`/`.get()` synchronously. Those blocking calls run on the event loop, so a slow or unreachable Redis freezes the entire uvicorn worker — every concurrent request on that worker stalls, not just the one reading the vault.

## Scope

- `backend/archimedes/services/vault_service.py` — the Redis snapshot block in `_compute_returns`.
- `backend/tests/services/test_vault_service.py` — one regression test.

## What changed

- Swap `import redis` for `import redis.asyncio` and `await` the `ping`/`get` calls. This matches the convention already used in `funnel_store.py`, `generation_quota.py`, and `redis_state.py`.
- Close the client in a `finally` so we don't leak connections on the event loop.
- The fallback path (Redis unreachable → simulated returns from allocation weights) is unchanged.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_vault_service.py -q
```

`test_uses_async_redis_and_awaits_snapshot` mocks `redis.asyncio.Redis` with a valid snapshot and a mocked oracle, then asserts the returns come from the Redis price path and that `ping`/`get`/`aclose` were awaited. If someone reverts to the sync `redis.Redis`, the patch on `redis.asyncio.Redis` no longer intercepts and the test drops to the fallback, so it fails — the test doubles as a revert guard. 23 passed; `ruff` clean.

Note on timing: the existing fallback tests take a few seconds because they attempt a real connection to `localhost:6379` (no Redis in a hermetic run). That delay is unchanged from `main` — the old sync client did the same — so it's not introduced here.

## Anti-goals

- No change to services that are already async.
- No change to the fallback return math.

Fixes #914
