### PR TITLE
[backend] Batch the rigor gate on /leaderboard instead of recomputing per strategy

### DIFF
--- a/backend/archimedes/api/leaderboard_routes.py
+++ b/backend/archimedes/api/leaderboard_routes.py
@@ -46,11 +46,24 @@ async def get_leaderboard(
     """
     # Imported lazily to avoid import-time coupling with the heavy strategies
     # module (and any future cycle).
-    from archimedes.api.strategies_routes import _to_strategy_response
+    from archimedes.api.strategies_routes import (
+        _live_rigor_results_for_strategies,
+        _to_strategy_response,
+        _verdict_from_result,
+    )
 
     try:
         strategies = strategy_provider().list_strategies()
-        responses = [_to_strategy_response(s) for s in strategies]
+        # One batched live-gate run over the whole cohort (single DB session),
+        # then derive the badge from each result. Calling _to_strategy_response
+        # with no verdict recomputes the full gate per strategy (2 DB reads +
+        # 2 gate runs each) — an unauthenticated DoS on a public endpoint.
+        # Mirrors GET /api/strategies/ (#868).
+        rigor_results = _live_rigor_results_for_strategies(strategies)
+        responses = [
+            _to_strategy_response(s, _verdict_from_result(rigor_results.get(s.id)), rigor_results.get(s.id))
+            for s in strategies
+        ]
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("leaderboard: strategy provider unavailable: %s", exc)
         responses = []

--- a/backend/tests/test_leaderboard.py
+++ b/backend/tests/test_leaderboard.py
@@ -279,3 +279,32 @@ async def test_leaderboard_rejects_bad_sort_param():
         resp = await client.get("/api/leaderboard?sort_by=DROP_TABLE")
     # Query pattern guard → 422, never a 500.
     assert resp.status_code == 422
+
+
+async def test_leaderboard_batches_rigor_gate_once(monkeypatch):
+    """Regression for #912: the public leaderboard must run the rigor gate ONCE
+    over the whole cohort (batch), not recompute it per strategy. The per-
+    strategy path (_live_verdict_for_one + _live_rigor_result_for_one, 2 DB reads
+    + 2 gate runs each) on an unauth, unratelimited endpoint is a trivial DoS."""
+    from unittest.mock import MagicMock
+
+    import archimedes.api.strategies_routes as sr
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    batch = MagicMock(return_value={})
+    per_verdict = MagicMock()
+    per_result = MagicMock()
+    monkeypatch.setattr(sr, "_live_rigor_results_for_strategies", batch)
+    monkeypatch.setattr(sr, "_live_verdict_for_one", per_verdict)
+    monkeypatch.setattr(sr, "_live_rigor_result_for_one", per_result)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/leaderboard")
+
+    assert resp.status_code == 200
+    # Exactly one batched gate run for the whole board ...
+    assert batch.call_count == 1
+    # ... and never the per-strategy recompute.
+    assert per_verdict.call_count == 0
+    assert per_result.call_count == 0


### PR DESCRIPTION
## Summary

`GET /api/leaderboard` is public, unauthenticated, and not rate-limited, yet it called `_to_strategy_response(s)` with no precomputed verdict. That path recomputes the full rigor gate per strategy — `_live_verdict_for_one` + `_live_rigor_result_for_one`, each opening its own DB session, reading daily returns, and running DSR/PBO. So a single `GET /api/leaderboard?limit=200` did 200+ DB sessions and up to 400 gate runs. Repeating it is a trivial DoS.

## Scope

- `backend/archimedes/api/leaderboard_routes.py` — the response-building loop.
- `backend/tests/test_leaderboard.py` — one regression test.

## What changed

The route now calls the existing batch helper `_live_rigor_results_for_strategies(strategies)` once (one DB session for the whole cohort), then derives each badge with `_verdict_from_result` and passes the verdict + result into `_to_strategy_response`. This is exactly the pattern `GET /api/strategies/` already uses (#868), so the served numbers stay consistent between the two endpoints. The batch helper is unchanged.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_leaderboard.py -q
```

`test_leaderboard_batches_rigor_gate_once` patches the batch helper and both per-strategy helpers, hits the endpoint, and asserts the batch helper runs exactly once while the per-strategy helpers never run. I confirmed it fails against the old route (`assert 0 == 1` — batch never called) and passes with the fix. 23 passed; `ruff` clean.

## Anti-goals

- No change to the batch helper or the scoring engine.

Fixes #912
