### PR TITLE
[backend] Gate /vaults/metadata on the on-chain vault owner (close IDOR)

### DIFF
--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -299,11 +299,21 @@ async def store_vault_metadata(
     """Store off-chain vault metadata (strategy associations, display name).
 
     SIWE-gated and owner-scoped: this write triggers `_anchor_strategies_async`,
-    a backend-signed on-chain transaction. Previously anyone could overwrite any
-    vault's metadata and spend gas. The authenticated wallet now becomes the
-    metadata owner on first write, and subsequent writes require the caller to
-    be that owner.
+    a backend-signed on-chain transaction. The caller must be the vault's
+    on-chain Ownable owner — the authoritative controller read from the
+    contract, not "whoever wrote metadata first". This closes the IDOR (#916)
+    where the first authenticated writer could claim `creator_address` on any
+    vault that had no metadata row yet.
     """
+    # Ownership gate first, before any rigor compute or DB work: only the vault's
+    # on-chain owner may write its metadata. A read failure fails closed (503) —
+    # we never let an unverifiable caller claim a vault.
+    on_chain_owner = await chain_executor.get_vault_owner(req.vault_address)
+    if on_chain_owner is None:
+        raise HTTPException(status_code=503, detail="Could not verify vault ownership on-chain; try again shortly.")
+    if on_chain_owner.lower() != wallet.lower():
+        raise HTTPException(status_code=403, detail="Only the vault's on-chain owner may edit its metadata.")
+
     # Server-side rigor enforcement on the client-signed deploy path — the real
     # choke point. The UI creates the vault on-chain from the user's own wallet
     # (bypassing POST /create), then links strategies here, so THIS is where a
@@ -321,14 +331,13 @@ async def store_vault_metadata(
         if meta is None:
             meta = VaultMetadata(vault_address=req.vault_address)
             session.add(meta)
-        elif meta.creator_address and meta.creator_address.lower() != wallet.lower():
-            # An owner already claimed this vault's metadata; only they may edit it.
-            raise HTTPException(status_code=403, detail="Not authorized to edit this vault's metadata.")
 
         meta.name = req.name
         meta.symbol = req.symbol
-        # Bind ownership to the authenticated wallet — never trust a
-        # caller-supplied creator_address (that was the spoofing vector).
+        # Record the writer, who the gate above proved is the on-chain owner.
+        # Never trust a caller-supplied creator_address (that was the spoofing
+        # vector), and don't gate on a stale recorded value either — that would
+        # wrongly block a legitimately transferred new on-chain owner.
         meta.creator_address = wallet.lower()
         meta.set_strategy_ids(req.strategy_ids)
         session.commit()

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -618,6 +618,23 @@ class ChainExecutor:
             "paused": paused,
         }
 
+    async def get_vault_owner(self, vault_address: str) -> str | None:
+        """Read the vault's on-chain Ownable owner — the authoritative controller.
+
+        The owner (not the immutable ``creator``, which is the deploy signer for
+        vaults minted through ``createVault``) is who currently controls the
+        vault after any ``transferOwnership``. Returns the address string, or
+        ``None`` if it can't be read so the caller can fail closed rather than
+        assume ownership.
+        """
+        try:
+            vault = self.loader.vault(vault_address)
+            owner = await vault.functions.owner().call()
+            return str(owner)
+        except Exception as exc:
+            logger.warning("Could not read on-chain owner for vault %s: %s", vault_address, exc)
+            return None
+
     async def get_all_vaults(self) -> list[str]:
         """Get all vault addresses from VaultFactory."""
         factory = self.loader.vault_factory

--- a/backend/tests/test_vault_metadata_anchor.py
+++ b/backend/tests/test_vault_metadata_anchor.py
@@ -38,13 +38,15 @@ def _make_passport(sid: str, methodology_hash: str | None = "abcd1234" * 8):
 
 
 class TestVaultMetadataAnchor:
+    @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
-    def test_metadata_post_calls_anchor_once_per_strategy_id(self, mock_provider, mock_publisher):
+    def test_metadata_post_calls_anchor_once_per_strategy_id(self, mock_provider, mock_publisher, mock_owner):
         # strategy_provider is now a lazily-cached accessor (strategy_provider()),
         # so the mocked callable's return_value stands in for the provider instance.
         mock_provider.return_value.get_strategy.side_effect = _make_passport
         mock_publisher.anchor = AsyncMock()
+        mock_owner.return_value = _WALLET  # caller is the on-chain owner
 
         resp = client.post(
             "/api/vaults/metadata",
@@ -63,9 +65,10 @@ class TestVaultMetadataAnchor:
 
         assert mock_publisher.anchor.call_count == 3
 
+    @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
-    def test_metadata_post_skips_passports_without_methodology_hash(self, mock_provider, mock_publisher):
+    def test_metadata_post_skips_passports_without_methodology_hash(self, mock_provider, mock_publisher, mock_owner):
         def get_strat(sid):
             if sid == "s2":
                 return _make_passport(sid, methodology_hash=None)
@@ -73,6 +76,7 @@ class TestVaultMetadataAnchor:
 
         mock_provider.return_value.get_strategy.side_effect = get_strat
         mock_publisher.anchor = AsyncMock()
+        mock_owner.return_value = _WALLET
 
         resp = client.post(
             "/api/vaults/metadata",
@@ -90,11 +94,13 @@ class TestVaultMetadataAnchor:
         # s2 skipped due to no methodology_hash
         assert mock_publisher.anchor.call_count == 2
 
+    @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
-    def test_metadata_post_succeeds_when_anchor_raises(self, mock_provider, mock_publisher):
+    def test_metadata_post_succeeds_when_anchor_raises(self, mock_provider, mock_publisher, mock_owner):
         mock_provider.return_value.get_strategy.side_effect = _make_passport
         mock_publisher.anchor = AsyncMock(side_effect=RuntimeError("simulated chain failure"))
+        mock_owner.return_value = _WALLET
 
         resp = client.post(
             "/api/vaults/metadata",
@@ -109,15 +115,17 @@ class TestVaultMetadataAnchor:
         # Handler still returns 200 — anchor failure is non-fatal
         assert resp.status_code == 200
 
+    @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
-    def test_metadata_post_with_unknown_strategy_id_is_refused(self, mock_provider, mock_publisher):
+    def test_metadata_post_with_unknown_strategy_id_is_refused(self, mock_provider, mock_publisher, mock_owner):
         # The metadata route is the client-signed deploy path's rigor choke point:
         # an unknown/unverified strategy id can no longer be bound to a vault. It is
         # cleanly refused with 422 (not a crash) BEFORE any anchoring is attempted —
         # this is the server-side "you can never fully bypass the rigor gate" guarantee.
         mock_provider.return_value.get_strategy.return_value = None
         mock_publisher.anchor = AsyncMock()
+        mock_owner.return_value = _WALLET
 
         resp = client.post(
             "/api/vaults/metadata",
@@ -152,10 +160,12 @@ class TestVaultMetadataAuth:
         )
         assert resp.status_code == 401
 
-    def test_metadata_post_rejects_non_owner_overwrite(self):
+    @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
+    def test_metadata_post_rejects_non_owner_overwrite(self, mock_owner):
         vault = "0x" + "33" * 20
         owner = "0x" + "aa" * 20
         attacker = "0x" + "bb" * 20
+        mock_owner.return_value = owner  # the vault's on-chain owner
 
         # Owner claims the vault metadata first.
         first = client.post(
@@ -180,6 +190,43 @@ class TestVaultMetadataAuth:
             cookies=_siwe_cookies(owner),
         )
         assert again.status_code == 200
+
+    @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
+    def test_metadata_post_rejects_non_onchain_owner_on_first_write(self, mock_owner):
+        """#916 IDOR: a vault created directly on-chain (no metadata row yet)
+        must not have its metadata claimed by a wallet that isn't its on-chain
+        owner. Before the fix, the first authenticated writer won."""
+        vault = "0x" + "44" * 20
+        real_owner = "0x" + "cc" * 20
+        attacker = "0x" + "dd" * 20
+        mock_owner.return_value = real_owner
+
+        resp = client.post(
+            "/api/vaults/metadata",
+            json={"vault_address": vault, "name": "Claimed", "symbol": "tCLM", "strategy_ids": []},
+            cookies=_siwe_cookies(attacker),
+        )
+        assert resp.status_code == 403
+
+        # The real on-chain owner can claim it.
+        ok = client.post(
+            "/api/vaults/metadata",
+            json={"vault_address": vault, "name": "Mine", "symbol": "tMIN", "strategy_ids": []},
+            cookies=_siwe_cookies(real_owner),
+        )
+        assert ok.status_code == 200
+
+    @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
+    def test_metadata_post_fails_closed_when_owner_unreadable(self, mock_owner):
+        """If the on-chain owner can't be read, refuse (503) rather than let an
+        unverifiable caller write — never fail open on the ownership gate."""
+        mock_owner.return_value = None
+        resp = client.post(
+            "/api/vaults/metadata",
+            json={"vault_address": "0x" + "55" * 20, "name": "X", "symbol": "tX", "strategy_ids": []},
+            cookies=_siwe_cookies("0x" + "ee" * 20),
+        )
+        assert resp.status_code == 503
 
 
 def test_create_vault_requires_auth():


### PR DESCRIPTION
## Summary

`POST /api/vaults/metadata` only enforced ownership once `meta.creator_address` was set. A vault created directly on-chain (before any metadata row exists) could have its metadata claimed by the first authenticated wallet to POST — a classic IDOR. That write also triggers a backend-signed on-chain anchor, so the claim isn't cosmetic.

## Scope

- `backend/archimedes/api/vaults_routes.py` — `store_vault_metadata`.
- `backend/archimedes/chain/executor.py` — new `get_vault_owner` read.
- `backend/tests/test_vault_metadata_anchor.py` — updated existing tests + new regression tests.

## What changed

- The route now reads the vault's on-chain Ownable `owner()` and requires the authenticated wallet to match it before doing any work. Mismatch → 403; an unreadable owner → 503 (fail closed — we never let an unverifiable caller claim a vault). The gate runs first, before the rigor check and the DB, so an unauthorized caller does no work.
- Added `chain_executor.get_vault_owner`, which reads `owner()` and returns `None` on failure. I used `owner()` rather than the immutable `creator`, because for vaults minted through `createVault` the creator is the backend deploy signer while ownership is transferred to the user — `owner()` is the authoritative current controller.
- Dropped the old `creator_address`-mismatch 403 branch. It's now redundant (the on-chain gate is the authority), and worse, it would have wrongly blocked a legitimately transferred new on-chain owner whose wallet no longer matched the first recorded writer.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_vault_metadata_anchor.py -q
```

New `test_metadata_post_rejects_non_onchain_owner_on_first_write` (attacker on a fresh vault → 403; real owner → 200) and `test_metadata_post_fails_closed_when_owner_unreadable` (owner unreadable → 503). Existing tests now mock `get_vault_owner`. I checked the IDOR test against the unfixed route on a clean DB and it fails with `assert 200 == 403`, so it's genuinely discriminating. 9 passed; `ruff` clean.

## Anti-goals

- No change to the vault creation flow.

Fixes #916
