### PR TITLE
[chain] Read pending-block nonce in set_token_oracles/set_target_allocations

### DIFF
--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -657,7 +657,11 @@ class ChainExecutor:
             raise RuntimeError("No agent account configured")
 
         vault = self.loader.vault(vault_address)
-        nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+        # Use the pending-block nonce so a second raw-key tx submitted in the
+        # same tick (e.g. set_target_allocations right after this) doesn't reuse
+        # a nonce already sitting in the mempool and silently drop one of them.
+        # Matches execute_rebalance / _send_vault_admin_tx in this file.
+        nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
 
         tx = await vault.functions.setTokenOracles(
             checksummed_tokens,
@@ -706,7 +710,10 @@ class ChainExecutor:
             raise RuntimeError("No agent account configured — set CIRCLE_API_KEY or ARC_AGENT_PRIVATE_KEY")
 
         vault = self.loader.vault(vault_address)
-        nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+        # Pending-block nonce (see set_token_oracles): when _process_vault calls
+        # this right after set_token_oracles, the first tx is still in the
+        # mempool and "latest" would hand back its nonce, dropping one tx.
+        nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
 
         tx = await vault.functions.setTargetAllocations(
             checksummed,

--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -754,3 +754,34 @@ class TestInsufficientLiquidityError:
 
     def test_min_threshold_is_positive(self):
         assert MIN_HEALTHY_LIQUIDITY_USDC > 0
+
+
+# ── Nonce handling on the raw-key path (#909) ─────────────────
+
+
+class TestSequentialNonce:
+    @pytest.mark.asyncio
+    async def test_set_oracles_and_allocations_read_pending_nonce(self, executor, mock_loader):
+        """Regression for #909: set_token_oracles + set_target_allocations run
+        back-to-back in one _process_vault tick. Both must read the PENDING-block
+        nonce, otherwise the second reuses the first's still-in-mempool nonce and
+        one tx is silently dropped."""
+        mock_cc = executor._mock_cc
+        account = MagicMock()
+        account.address = "0xAbC0000000000000000000000000000000000001"
+        account.sign_transaction.return_value.raw_transaction = b"\x01" * 32
+        mock_cc.settings.agent_account = account
+
+        vault = mock_loader.vault.return_value
+        vault.functions.setTokenOracles.return_value.build_transaction = AsyncMock(return_value={})
+        vault.functions.setTargetAllocations.return_value.build_transaction = AsyncMock(return_value={})
+
+        with patch("archimedes.chain.executor.circle_signer") as mock_signer:
+            mock_signer.is_configured = False  # force the raw-key path
+            await executor.set_token_oracles("0xVault", ["0xT"], ["0xO"])
+            await executor.set_target_allocations("0xVault", ["0xT"], [10000])
+
+        assert mock_cc.w3.eth.get_transaction_count.await_count == 2
+        for call in mock_cc.w3.eth.get_transaction_count.await_args_list:
+            # (address, "pending") — the unfixed code passed only (address,).
+            assert call.args == (account.address, "pending"), f"nonce read used {call.args}, must request pending"


### PR DESCRIPTION
## Summary

`set_token_oracles` and `set_target_allocations` both read the nonce with `get_transaction_count(account.address)` — the default `"latest"` block, which excludes txs still in the mempool — and return before their tx is mined. `_process_vault` calls them back-to-back in one tick, so the second read the same nonce as the first (still unmined), and one tx replaced/dropped the other. The tick reported success while the vault's oracles or allocations never got set.

## Scope

- `backend/archimedes/chain/executor.py` — the two raw-key nonce reads.
- `backend/tests/chain/test_chain_executor.py` — one regression test.

## What changed

Both now read `get_transaction_count(account.address, "pending")`, which includes the first tx already sitting in the mempool, so the second gets the next nonce. This is the same pattern `execute_rebalance` and `_send_vault_admin_tx` already use in this file — the two fixed functions were the odd ones out. The two-step flow is unchanged.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/chain/test_chain_executor.py -q
```

`test_set_oracles_and_allocations_read_pending_nonce` drives both calls on the raw-key path and asserts each nonce read requests the pending block. I checked it fails against the unfixed code (`('0x...',) != ('0x...', 'pending')`). 38 passed; `ruff` clean.

## Anti-goals

- No change to the two-step oracle-then-allocations flow or the Circle-signer path.

Fixes #909
