### PR TITLE
[frontend] Fail the deposit flow on a mined-but-reverted tx

### DIFF
--- a/ui/src/components/DepositFlow.jsx
+++ b/ui/src/components/DepositFlow.jsx
@@ -140,7 +140,13 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
       updateStep(0, 'txHash', hash)
       updateStep(0, 'status', CONFIRMING)
 
-      await publicClient.waitForTransactionReceipt({ hash })
+      // viem does NOT throw on a mined-but-reverted tx — it returns a receipt
+      // with status 'reverted'. Check it, or a reverted approve would read as
+      // "Confirmed" and the flow would advance as if funds moved.
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status !== 'success') {
+        throw new Error(`Approval reverted on-chain (${shortHash(hash)})`)
+      }
 
       updateStep(0, 'status', DONE)
       setCurrentStep(1)
@@ -170,7 +176,12 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
       updateStep(1, 'txHash', hash)
       updateStep(1, 'status', CONFIRMING)
 
-      await publicClient.waitForTransactionReceipt({ hash })
+      // A reverted deposit still returns a receipt; guard it so we never report
+      // the deposit as done when the funds didn't actually move.
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status !== 'success') {
+        throw new Error(`Deposit reverted on-chain (${shortHash(hash)})`)
+      }
 
       updateStep(1, 'status', DONE)
       setCurrentStep(2)
@@ -198,7 +209,12 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
       updateStep(2, 'txHash', hash)
       updateStep(2, 'status', CONFIRMING)
 
-      await publicClient.waitForTransactionReceipt({ hash })
+      // A reverted setTargetAllocations still returns a receipt; guard it so the
+      // flow doesn't finish "successfully" with allocations that never set.
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status !== 'success') {
+        throw new Error(`Allocation reverted on-chain (${shortHash(hash)})`)
+      }
 
       updateStep(2, 'status', DONE)
       clearProgress(vaultAddress)


### PR DESCRIPTION
## Summary

The deposit flow treated a mined-but-reverted transaction as a success. `waitForTransactionReceipt` in viem does not throw on a revert — it returns a receipt with `status: 'reverted'`. All three steps (`runApprove`, `runDeposit`, `runAllocate`) awaited the receipt and then set the step to `DONE` unconditionally, never reading `receipt.status`. So a reverted approve/deposit/setTargetAllocations showed as "Confirmed ✓", the flow advanced, and the user believed funds moved when they hadn't.

## Scope

- `ui/src/components/DepositFlow.jsx` — the three step callbacks.

## What changed

Each step now captures the receipt and throws when `receipt.status !== 'success'`. The throw lands in the step's existing `catch`, which sets the step to `FAILED` and surfaces the revert message — and because the throw happens before `updateStep(..., DONE)` and `setCurrentStep(...)`, the flow no longer advances on a revert. A successful tx still advances exactly as before.

## Verify

The UI has no unit-test harness (ESLint + `vite build` only), so:

```
cd ui && ./node_modules/.bin/eslint src/components/DepositFlow.jsx   # clean
cd ui && npm run build                                               # builds OK
```

Both pass. This path needs a genuinely reverted on-chain tx to exercise end-to-end, which isn't reproducible in a static preview; the logic change is small and self-contained (check the receipt status, reuse the existing failure handling).

## Anti-goals

- No change to the backend Circle tx handling (it already polls to a terminal state).

Fixes #906
