### PR TITLE
[contracts] Gate SyntheticVault mint/burn on a tight 1h oracle-staleness window (closes #910)

### DIFF
--- a/contracts/abis/SyntheticVault.json
+++ b/contracts/abis/SyntheticVault.json
@@ -137,6 +137,19 @@
   },
   {
     "type": "function",
+    "name": "mintBurnMaxStaleness",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "mintFeeBps",
     "inputs": [],
     "outputs": [
@@ -205,7 +218,7 @@
     ],
     "outputs": [
       {
-        "name": "",
+        "name": "synthAmount",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -238,6 +251,19 @@
     "inputs": [
       {
         "name": "newRatio",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMintBurnMaxStaleness",
+    "inputs": [
+      {
+        "name": "newSeconds",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -375,6 +401,25 @@
   },
   {
     "type": "event",
+    "name": "MintBurnMaxStalenessUpdated",
+    "inputs": [
+      {
+        "name": "oldSeconds",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newSeconds",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "Minted",
     "inputs": [
       {
@@ -424,8 +469,38 @@
     "anonymous": false
   },
   {
+    "type": "event",
+    "name": "RedemptionHaircut",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "grossValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cappedValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
     "type": "error",
     "name": "InsufficientCollateral",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidStalenessWindow",
     "inputs": []
   },
   {
@@ -463,6 +538,27 @@
         "name": "token",
         "type": "address",
         "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "StaleOraclePrice",
+    "inputs": [
+      {
+        "name": "lastUpdated",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxStaleness",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "nowTs",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ]
   },

--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -60,7 +60,17 @@ contract PriceOracle is Ownable {
     /// @notice Timestamp of the last price update
     uint256 public lastUpdated;
 
-    /// @notice Maximum age before stale (24 hours — hackathon testnet, Circle daily limit)
+    /// @notice Maximum age before the admin-fed `price` reads as stale (24 hours).
+    /// @dev    ⚠️ TESTNET/HACKATHON TRADEOFF — MUST be tightened before mainnet. 24h is a
+    ///         deliberately loose fallback so a missed oracle push (or a degraded feed) can't
+    ///         brick NAV reads / deposits / withdrawals / rebalances — those paths degrade to
+    ///         "last known price" rather than reverting. It is FAR too loose for the mint/burn
+    ///         value-transfer paths, where settling at a price the market has already moved
+    ///         away from is a direct stale-price arbitrage (issue #910). Those paths therefore
+    ///         do NOT rely on this window: SyntheticVault enforces its own tight
+    ///         `mintBurnMaxStaleness` (default 1h) on mint/burn/previewMint/previewBurn. For
+    ///         mainnet, reduce this constant (and the feed heartbeat) to the asset's real
+    ///         update cadence.
     uint256 public constant MAX_STALENESS = 24 hours;
 
     /// @notice Address allowed to push price updates (e.g. Circle wallet)

--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -24,6 +24,26 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     /// @notice Collateralization ratio in basis points. 12000 = 120%
     uint256 public collateralRatio = 12000;
 
+    /// @notice Max age (seconds) the oracle price may be on the mint/burn value-transfer
+    ///         paths. Default 1 hour — deliberately far tighter than PriceOracle's 24h
+    ///         MAX_STALENESS admin fallback (issue #910).
+    ///
+    ///         Why a mint/burn-specific window: getPrice()'s 24h admin fallback exists so a
+    ///         degraded feed can't brick NAV reads / deposits / withdrawals / rebalances —
+    ///         those paths want "return the last known price, don't revert". Mint and burn
+    ///         are different: they exchange USDC for synth (and back) AT the oracle price, so
+    ///         a price the market has already moved away from is a direct arbitrage — mint
+    ///         cheap when the real price is higher, or burn rich when it's lower, at the
+    ///         expense of the collateral pool. On the value-transfer path we want the
+    ///         opposite of degrade: revert rather than settle at a known-stale price.
+    ///
+    ///         Feed-aware: when a Chainlink feed is configured, getPrice() already enforces
+    ///         the feed's own (≤1h) heartbeat before returning a feed price, so this guard
+    ///         only applies to the admin-fed path (the live testnet source, which has no feed
+    ///         wired). Owner-tunable via setMintBurnMaxStaleness, bounded by the oracle's
+    ///         MAX_STALENESS.
+    uint256 public mintBurnMaxStaleness = 1 hours;
+
     /// @notice Protocol fee in basis points on mint. 50 = 0.5%
     uint256 public mintFeeBps = 50;
 
@@ -41,6 +61,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     event Minted(address indexed user, uint256 usdcIn, uint256 synthOut, uint256 fee);
     event Burned(address indexed user, uint256 synthIn, uint256 usdcOut, uint256 fee);
     event CollateralRatioUpdated(uint256 oldRatio, uint256 newRatio);
+    event MintBurnMaxStalenessUpdated(uint256 oldSeconds, uint256 newSeconds);
     event FeesCollected(uint256 amount);
     /// @notice Emitted when a redemption is scaled down by the pro-rata solvency cap
     ///         (collateral C < liability L). `grossValue` is the uncapped current-price
@@ -51,6 +72,9 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
 
     error ZeroAmount();
     error InsufficientCollateral();
+    /// @notice Oracle price is older than mintBurnMaxStaleness on a mint/burn path (issue #910).
+    error StaleOraclePrice(uint256 lastUpdated, uint256 maxStaleness, uint256 nowTs);
+    error InvalidStalenessWindow();
 
     // ─── Constructor ─────────────────────────────────────────────────
 
@@ -67,10 +91,25 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
 
     // ─── User Actions ────────────────────────────────────────────────
 
+    /// @dev Reject the mint/burn value-transfer paths when the oracle price is staler than
+    ///      mintBurnMaxStaleness (issue #910). Only enforced on the admin-fed path: when a
+    ///      Chainlink feed is configured, getPrice() already applies the feed's own ≤1h
+    ///      heartbeat before returning a feed price, and consulting the admin push timestamp
+    ///      would wrongly reject a fresh-feed asset whose admin reference happens to lag.
+    ///      Testnet has no feed wired, so this is the live guard there.
+    function _requireFreshForValueTransfer() internal view {
+        if (address(oracle.priceFeed()) != address(0)) return; // feed path self-guards in getPrice()
+        uint256 updatedAt = oracle.lastUpdated();
+        if (block.timestamp > updatedAt + mintBurnMaxStaleness) {
+            revert StaleOraclePrice(updatedAt, mintBurnMaxStaleness, block.timestamp);
+        }
+    }
+
     /// @notice Mint synth tokens by depositing USDC.
     function mint(uint256 amountUsdc) external nonReentrant returns (uint256) {
         if (amountUsdc == 0) revert ZeroAmount();
 
+        _requireFreshForValueTransfer();
         uint256 assetPrice = oracle.getPrice();
         uint256 fee = (amountUsdc * mintFeeBps) / BPS;
         uint256 netUsdc = amountUsdc - fee;
@@ -124,6 +163,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     function burn(uint256 synthAmount) external nonReentrant returns (uint256) {
         if (synthAmount == 0) revert ZeroAmount();
 
+        _requireFreshForValueTransfer();
         uint256 assetPrice = oracle.getPrice();
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
 
@@ -180,6 +220,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     ///         previewMint to detect inputs that would revert before submitting a tx.
     function previewMint(uint256 amountUsdc) external view returns (uint256 synthAmount) {
         if (amountUsdc == 0) revert ZeroAmount();
+        _requireFreshForValueTransfer();
         uint256 assetPrice = oracle.getPrice();
         uint256 fee = (amountUsdc * mintFeeBps) / BPS;
         uint256 netUsdc = amountUsdc - fee;
@@ -188,6 +229,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     }
 
     function previewBurn(uint256 synthAmount) external view returns (uint256) {
+        _requireFreshForValueTransfer();
         uint256 assetPrice = oracle.getPrice();
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
 
@@ -219,6 +261,15 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         require(newRatio >= BPS, "ratio must be >= 100%");
         emit CollateralRatioUpdated(collateralRatio, newRatio);
         collateralRatio = newRatio;
+    }
+
+    /// @notice Tune the mint/burn oracle-staleness window (issue #910). Must be in
+    ///         (0, oracle.MAX_STALENESS()] — 0 would brick mint/burn entirely, and a value
+    ///         above the oracle's own 24h ceiling can never bind. Default 1h.
+    function setMintBurnMaxStaleness(uint256 newSeconds) external onlyOwner {
+        if (newSeconds == 0 || newSeconds > oracle.MAX_STALENESS()) revert InvalidStalenessWindow();
+        emit MintBurnMaxStalenessUpdated(mintBurnMaxStaleness, newSeconds);
+        mintBurnMaxStaleness = newSeconds;
     }
 
     function collectFees() external onlyOwner {

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -609,4 +609,154 @@ contract SyntheticVaultTest is Test {
 
         assertEq(usdc.balanceOf(address(vault)), vaultBalBefore + amount);
     }
+
+    // ─── Mint/Burn Staleness Guard Tests (issue #910) ─────────────
+
+    /// @dev Default guard window is 1 hour, well under the oracle's 24h MAX_STALENESS.
+    function test_mintBurn_staleness_default_is_one_hour() public view {
+        assertEq(vault.mintBurnMaxStaleness(), 1 hours);
+    }
+
+    /// @dev A price fresh within the 1h window mints fine (regression guard: the new check
+    ///      must not break the healthy path).
+    function test_mint_succeeds_when_price_fresh() public {
+        // 59 minutes old — still inside the 1h window.
+        vm.warp(block.timestamp + 59 minutes);
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 out = vault.mint(usdcAmount);
+        vm.stopPrank();
+        assertGt(out, 0);
+    }
+
+    /// @dev The core arbitrage guard: once the admin price is older than the 1h window,
+    ///      mint reverts instead of settling at a stale price — even though the oracle's
+    ///      own 24h MAX_STALENESS would still accept it.
+    function test_revert_mint_when_price_stale_past_window() public {
+        uint256 lastUpdated = oracle.lastUpdated();
+        vm.warp(block.timestamp + 1 hours + 1); // just past the 1h window, far under 24h
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SyntheticVault.StaleOraclePrice.selector, lastUpdated, uint256(1 hours), block.timestamp
+            )
+        );
+        vault.mint(usdcAmount);
+        vm.stopPrank();
+    }
+
+    /// @dev The oracle would still serve this price (getPrice does not revert under 24h),
+    ///      proving the mint revert comes from the vault's tighter guard, not the oracle.
+    function test_oracle_still_serves_price_that_mint_rejects() public {
+        vm.warp(block.timestamp + 2 hours); // stale for mint/burn, fresh for the oracle
+        assertEq(oracle.getPrice(), INITIAL_PRICE); // no revert — 2h < 24h
+    }
+
+    /// @dev burn is guarded on the same window. Mint while fresh, warp past the window,
+    ///      then burn must revert.
+    function test_revert_burn_when_price_stale_past_window() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synthOut = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        uint256 lastUpdated = oracle.lastUpdated();
+        vm.warp(block.timestamp + 1 hours + 1);
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SyntheticVault.StaleOraclePrice.selector, lastUpdated, uint256(1 hours), block.timestamp
+            )
+        );
+        vault.burn(synthOut);
+    }
+
+    /// @dev previewMint mirrors mint's staleness revert so callers can detect it pre-submit.
+    function test_revert_previewMint_when_stale() public {
+        uint256 lastUpdated = oracle.lastUpdated();
+        vm.warp(block.timestamp + 1 hours + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SyntheticVault.StaleOraclePrice.selector, lastUpdated, uint256(1 hours), block.timestamp
+            )
+        );
+        vault.previewMint(10_000 * 10**6);
+    }
+
+    /// @dev previewBurn mirrors burn's staleness revert.
+    function test_revert_previewBurn_when_stale() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synthOut = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        uint256 lastUpdated = oracle.lastUpdated();
+        vm.warp(block.timestamp + 1 hours + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SyntheticVault.StaleOraclePrice.selector, lastUpdated, uint256(1 hours), block.timestamp
+            )
+        );
+        vault.previewBurn(synthOut);
+    }
+
+    /// @dev A fresh admin push re-opens mint/burn after a stale gap: warp past the window,
+    ///      confirm the revert, push a new price, then the same mint succeeds.
+    function test_fresh_push_reopens_mint_after_stale_gap() public {
+        vm.warp(block.timestamp + 3 hours); // stale
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        vm.expectRevert(); // stale
+        vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        // Oracle runner pushes a fresh price (within the 20% deviation bound).
+        vm.prank(owner);
+        oracle.setPrice(INITIAL_PRICE);
+
+        vm.startPrank(alice);
+        uint256 out = vault.mint(usdcAmount);
+        vm.stopPrank();
+        assertGt(out, 0);
+    }
+
+    /// @dev Owner can widen the window; after widening to 4h a 2h-old price mints again.
+    function test_setMintBurnMaxStaleness_widens_window() public {
+        vm.prank(owner);
+        vault.setMintBurnMaxStaleness(4 hours);
+        assertEq(vault.mintBurnMaxStaleness(), 4 hours);
+
+        vm.warp(block.timestamp + 2 hours); // stale under 1h, fresh under 4h
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 out = vault.mint(usdcAmount);
+        vm.stopPrank();
+        assertGt(out, 0);
+    }
+
+    function test_revert_setMintBurnMaxStaleness_invalid() public {
+        // Read the oracle constant BEFORE arming expectRevert so the view call doesn't
+        // consume the expectation (same gotcha as test_revert_forceSetPrice_exceeds_hard_cap).
+        uint256 aboveMax = oracle.MAX_STALENESS() + 1;
+        vm.startPrank(owner);
+        vm.expectRevert(SyntheticVault.InvalidStalenessWindow.selector);
+        vault.setMintBurnMaxStaleness(0);
+        vm.expectRevert(SyntheticVault.InvalidStalenessWindow.selector);
+        vault.setMintBurnMaxStaleness(aboveMax);
+        vm.stopPrank();
+    }
+
+    function test_revert_setMintBurnMaxStaleness_non_owner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        vault.setMintBurnMaxStaleness(2 hours);
+    }
 }


### PR DESCRIPTION
Closes #910.

## The problem

`SyntheticVault.mint` and `burn` exchange USDC for synth (and back) at whatever `oracle.getPrice()` returns. That price has a 24h admin fallback window (`PriceOracle.MAX_STALENESS`). 24h is fine for the read paths it was built for — NAV, deposits, withdrawals, rebalances all want "give me the last known price, don't revert" so a missed oracle push or a degraded feed can't brick the vault.

Mint and burn are the opposite case. They move value at that price, so a price the market has already left is a straight arbitrage: mint cheap when the real price is higher, or burn rich when it's lower, and the difference comes out of everyone else's collateral. On testnet there's no Chainlink feed wired, so the admin price with its 24h window is the live source — the exposure is real, not theoretical.

## The fix

I kept the 24h fallback where it belongs (the read paths) and added a separate, tighter window for the value-transfer paths:

- New `mintBurnMaxStaleness` on `SyntheticVault`, default 1h, owner-tunable, bounded by the oracle's own `MAX_STALENESS` so it can never be set to something the oracle would already reject.
- Enforced on `mint`, `burn`, `previewMint`, `previewBurn` (previews mirror the real path so a caller can see the revert before submitting).
- It only checks the admin timestamp when no feed is configured. When a Chainlink feed is wired, `getPrice()` already applies the feed's own ≤1h heartbeat, and reading the admin push time there would wrongly reject a fresh-feed asset whose admin reference happens to lag. Testnet has no feed, so this is the guard that actually runs today.

I also expanded the comment on `MAX_STALENESS` to say plainly that 24h is a testnet choice and has to be tightened before mainnet, and pointed it at this new guard so the next reader sees why mint/burn don't lean on it.

## Tests

Added 11 cases to `SyntheticVault.t.sol`:

- fresh price (59 min old) still mints — the healthy path isn't broken
- a price just past 1h reverts `StaleOraclePrice` on mint, burn, previewMint, previewBurn
- the oracle still serves that same 2h-old price without reverting, which shows the revert is the vault's tighter guard and not the oracle
- a fresh admin push re-opens mint after a stale gap
- owner can widen the window (4h) and a 2h-old price mints again
- setter rejects 0 and anything above the oracle ceiling, and is owner-only

`forge test` is green: 51/51 in the SyntheticVault suite, 236/236 across all contract suites. Regenerated the cached `SyntheticVault.json` ABI — the diff is the new members plus the `RedemptionHaircut` event, which was already in the contract but had been missing from the tracked ABI.

## Review

This touches contract funds logic, so it needs the contract owner's sign-off before merge — flagging **@dbrowneup** to review and, ideally, **@mnemonik-dev** for the second pair of eyes. I've left it open rather than merging.
