### PR TITLE
[contracts] Charge redemption liquidation slippage to the redeemer, not remaining holders (closes #913)

### DIFF
--- a/contracts/abis/Vault.json
+++ b/contracts/abis/Vault.json
@@ -1076,6 +1076,25 @@
     "anonymous": false
   },
   {
+    "type": "event",
+    "name": "RedemptionLiquidationCharge",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "slippageLoss",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
     "type": "error",
     "name": "ERC20InsufficientAllowance",
     "inputs": [

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -126,6 +126,11 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     // ─── Events (Vault-local) ────────────────────────────────────────
 
     event MaxSlippageBpsSet(uint256 oldBps, uint256 newBps);
+    /// @notice Emitted when a redeem/withdraw forced a liquidation and the caller was
+    ///         charged its slippage cost (issue #913). `slippageLoss` is the NAV lost to
+    ///         AMM impact + fees; for redeem it reduces the USDC paid out, for withdraw it
+    ///         is charged as extra burned shares.
+    event RedemptionLiquidationCharge(address indexed owner, uint256 slippageLoss);
     event AgentSet(address indexed oldAgent, address indexed newAgent);
     event PlatformFeeRecipientSet(address indexed oldRecipient, address indexed newRecipient);
     event AssetRegistrySet(address indexed registry);
@@ -219,13 +224,22 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
 
         _accrueFees();
 
+        // Snapshot the pre-liquidation rate so any slippage charge below is sized against
+        // the same NAV/share the base shares were priced at (issue #913).
+        uint256 navBefore = totalAssets();
+        uint256 supplyBefore = totalSupply();
+
         shares = _convertToShares(assets);
         if (shares == 0) revert ZeroShares();
 
         // ERC-4626 allowance enforcement — CEI: check BEFORE any external call (audit B6).
         // A caller may only burn `owner_`'s shares when it IS the owner, or when the owner
         // has granted it a share allowance. `_spendAllowance` is a no-op for an infinite
-        // (type(uint256).max) allowance, matching the canonical pattern.
+        // (type(uint256).max) allowance, matching the canonical pattern. Any extra shares
+        // charged for liquidation slippage below are a bounded top-up whose size isn't
+        // knowable until the AMM has executed; that incremental allowance is spent
+        // post-liquidation, which is safe — _spendAllowance makes no external call and the
+        // function is nonReentrant.
         if (msg.sender != owner_) {
             _spendAllowance(owner_, msg.sender, shares);
         }
@@ -234,7 +248,23 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         // after the allowance check, satisfying the Check-Effects-Interactions pattern).
         uint256 usdcOnHand = IERC20(asset).balanceOf(address(this));
         if (usdcOnHand < assets) {
-            _liquidateToUsdc(assets - usdcOnHand);
+            uint256 slippageLoss = _liquidateAndMeasureLoss(assets - usdcOnHand);
+            if (slippageLoss > 0 && navBefore > 0) {
+                // withdraw() must deliver EXACTLY `assets`, so the caller pays the slippage
+                // they forced in EXTRA burned shares (worth `slippageLoss` at the pre-trade
+                // rate) rather than in reduced USDC — preserving remaining holders' per-share
+                // NAV (issue #913). Round up against the withdrawer. If the caller lacks the
+                // shares to cover the charge, _burn reverts — the correct outcome (they should
+                // use redeem() for a slippage-absorbing full exit).
+                uint256 extraShares = (slippageLoss * supplyBefore + navBefore - 1) / navBefore;
+                if (extraShares > 0) {
+                    if (msg.sender != owner_) {
+                        _spendAllowance(owner_, msg.sender, extraShares);
+                    }
+                    shares += extraShares;
+                    emit RedemptionLiquidationCharge(owner_, slippageLoss);
+                }
+            }
         }
 
         _burn(owner_, shares);
@@ -270,9 +300,19 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
 
         // Ensure we have enough USDC — liquidate positions if needed (external AMM calls
         // after the allowance check, satisfying the Check-Effects-Interactions pattern).
+        // The redeemer bears the slippage of the liquidation THEY forced: without this the
+        // ~0.3–5% AMM cost drops totalAssets() while the redeemer still receives the full
+        // pre-trade claim, silently draining every remaining holder's NAV (issue #913).
+        // Charging it here keeps the payout no larger than the vault can afford at the
+        // realized rate, so per-share NAV for those who stay is preserved.
         uint256 usdcOnHand = IERC20(asset).balanceOf(address(this));
         if (usdcOnHand < assets) {
-            _liquidateToUsdc(assets - usdcOnHand);
+            uint256 slippageLoss = _liquidateAndMeasureLoss(assets - usdcOnHand);
+            if (slippageLoss > 0) {
+                assets = assets > slippageLoss ? assets - slippageLoss : 0;
+                if (assets == 0) revert ZeroAssets();
+                emit RedemptionLiquidationCharge(owner_, slippageLoss);
+            }
         }
 
         _burn(owner_, shares);
@@ -618,6 +658,22 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         // Verify we now have enough USDC
         uint256 usdcAfter = IERC20(asset).balanceOf(address(this));
         if (usdcAfter < shortfall) revert InsufficientLiquidity();
+    }
+
+    /// @notice Liquidate to cover a `shortfall` of USDC and return the NAV lost to
+    ///         AMM slippage + fees in doing so (issue #913).
+    /// @dev    Liquidation sells synths at the AMM, which realizes strictly less USDC than
+    ///         their oracle-priced NAV (price impact + the 0.3% AMM fee). Because
+    ///         totalAssets() marks synths at the oracle price, converting synth-NAV into
+    ///         USDC at a worse rate drops totalAssets() by exactly that realized loss. The
+    ///         oracle price is unchanged within the call, so `navBefore - navAfter` is the
+    ///         precise cost the redeeming caller imposed. Returning it lets redeem()/withdraw()
+    ///         charge that caller instead of socializing it onto the holders who stayed.
+    function _liquidateAndMeasureLoss(uint256 shortfall) internal returns (uint256 slippageLoss) {
+        uint256 navBefore = totalAssets();
+        _liquidateToUsdc(shortfall);
+        uint256 navAfter = totalAssets();
+        slippageLoss = navBefore > navAfter ? navBefore - navAfter : 0;
     }
 
     function _accrueFees() internal {

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -1399,4 +1399,138 @@ contract VaultTest is Test {
         arr = new uint256[](1);
         arr[0] = x;
     }
+
+    // ─── Redemption Liquidation-Slippage Fairness (issue #913) ───────
+
+    /// @dev Deposit alice + bob equally, then rebalance most USDC into sTSLA so a full-exit
+    ///      redemption has to liquidate at a loss.
+    function _twoUserVaultMostlyInSynth() internal returns (uint256 aliceShares, uint256 bobShares) {
+        // Give the swaps room: raise the oracle-floor tolerance to the 5% cap so the later
+        // liquidation isn't rejected. The realized slippage the test measures is still just
+        // the AMM fee + price impact — the tolerance only gates whether the swap is allowed.
+        vm.prank(agent);
+        vault.setMaxSlippageBps(500);
+
+        // Alice + bob each own ~half the vault.
+        _depositAsAlice(5_000 * 10**6);
+        vm.startPrank(bob);
+        usdc.approve(address(vault), 5_000 * 10**6);
+        vault.deposit(5_000 * 10**6, bob);
+        vm.stopPrank();
+
+        // Register sTSLA in heldTokens with a negligible 1-USDC buy (keeps the pool at its
+        // oracle-aligned starting ratio), then seed a large synth position directly — same
+        // fixture shape as test_withdraw_liquidation_slippage_buffer_covers_oracle_floor.
+        // The vault now holds ~10k USDC + ~90k sTSLA NAV, so a half-vault exit must liquidate
+        // ~40k of synth into an oracle-aligned pool and eat the fee + impact (a real loss vs
+        // oracle NAV, unlike selling back into a pool a prior buy already skewed upward).
+        _rebalanceBuyTsla(1 * 10**6);
+        sTSLA.mint(address(vault), 45_000 * 1e18); // 45k tokens * 2 USDC = 90k NAV
+
+        aliceShares = vault.balanceOf(alice);
+        bobShares = vault.balanceOf(bob);
+    }
+
+    /// @dev The core #913 invariant: a redemption that forces a liquidation must not lower
+    ///      the per-share NAV of the holders who stay. Pre-fix, alice got the full pre-trade
+    ///      claim and bob silently ate the liquidation slippage.
+    function test_redeem_liquidation_slippage_not_socialized() public {
+        (uint256 aliceShares,) = _twoUserVaultMostlyInSynth();
+
+        uint256 navPerShareBefore = (vault.totalAssets() * 1e18) / vault.totalSupply();
+
+        vm.prank(alice);
+        vault.redeem(aliceShares, alice, alice);
+
+        uint256 navPerShareAfter = (vault.totalAssets() * 1e18) / vault.totalSupply();
+
+        // Bob's per-share NAV must not fall. It can tick up a hair (integer-division dust
+        // rounds in the vault's favor), so assert non-decreasing rather than exact.
+        assertGe(navPerShareAfter, navPerShareBefore, "remaining holders' NAV must not drop");
+    }
+
+    /// @dev The flip side: the redeemer actually absorbs the slippage — her payout is below
+    ///      the pre-trade claim, and RedemptionLiquidationCharge is emitted.
+    function test_redeem_charges_redeemer_the_slippage() public {
+        (uint256 aliceShares,) = _twoUserVaultMostlyInSynth();
+
+        uint256 claim = vault.previewRedeem(aliceShares); // pre-trade (uncharged) value
+        uint256 aliceBefore = usdc.balanceOf(alice);
+
+        vm.recordLogs();
+        vm.prank(alice);
+        uint256 paid = vault.redeem(aliceShares, alice, alice);
+
+        assertEq(usdc.balanceOf(alice) - aliceBefore, paid, "payout matches return value");
+        assertLt(paid, claim, "redeemer bears the liquidation slippage");
+
+        // RedemptionLiquidationCharge(owner, slippageLoss) was emitted, and the charge
+        // equals the gap between the pre-trade claim and what was actually paid.
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("RedemptionLiquidationCharge(address,uint256)");
+        bool found;
+        for (uint256 i; i < logs.length; i++) {
+            if (logs[i].topics[0] == sig) {
+                found = true;
+                assertEq(address(uint160(uint256(logs[i].topics[1]))), alice, "owner indexed");
+                uint256 loss = abi.decode(logs[i].data, (uint256));
+                assertEq(loss, claim - paid, "charge equals claim - payout");
+            }
+        }
+        assertTrue(found, "RedemptionLiquidationCharge emitted");
+    }
+
+    /// @dev withdraw() must still deliver EXACTLY the requested USDC, charging the caller
+    ///      the slippage in extra burned shares — so remaining holders are protected the
+    ///      same way, without changing the exact-assets-out contract.
+    function test_withdraw_liquidation_burns_extra_shares_from_withdrawer() public {
+        (uint256 aliceSharesBefore,) = _twoUserVaultMostlyInSynth();
+
+        uint256 navPerShareBefore = (vault.totalAssets() * 1e18) / vault.totalSupply();
+
+        // Base shares withdraw() would burn with no slippage (mirrors _convertToShares:
+        // ceil(assets * totalSupply / totalAssets)), for comparison.
+        uint256 baseShares =
+            (30_000 * 10**6 * vault.totalSupply() + vault.totalAssets() - 1) / vault.totalAssets();
+
+        uint256 aliceUsdcBefore = usdc.balanceOf(alice);
+        vm.prank(alice);
+        uint256 sharesBurned = vault.withdraw(30_000 * 10**6, alice, alice);
+
+        // Exactly the requested USDC is delivered.
+        assertEq(usdc.balanceOf(alice) - aliceUsdcBefore, 30_000 * 10**6, "exact assets out");
+        // More shares were burned than the no-slippage base — that's the slippage charge.
+        assertGt(sharesBurned, baseShares, "extra shares cover the slippage");
+        assertEq(aliceSharesBefore - vault.balanceOf(alice), sharesBurned, "burned from the withdrawer");
+
+        // Remaining holders' NAV/share is preserved.
+        uint256 navPerShareAfter = (vault.totalAssets() * 1e18) / vault.totalSupply();
+        assertGe(navPerShareAfter, navPerShareBefore, "remaining holders' NAV must not drop");
+    }
+
+    /// @dev Regression: when the vault holds enough USDC on hand, no liquidation runs, so
+    ///      no charge is applied and the redeemer gets the full pre-trade claim.
+    function test_redeem_no_charge_when_usdc_on_hand() public {
+        _depositAsAlice(50_000 * 10**6);
+        vm.startPrank(bob);
+        usdc.approve(address(vault), 50_000 * 10**6);
+        vault.deposit(50_000 * 10**6, bob);
+        vm.stopPrank();
+        // No rebalance — the vault is all USDC, so redeem is fully covered.
+
+        uint256 aliceShares = vault.balanceOf(alice);
+        uint256 claim = vault.previewRedeem(aliceShares);
+
+        vm.recordLogs();
+        vm.prank(alice);
+        uint256 paid = vault.redeem(aliceShares, alice, alice);
+
+        assertEq(paid, claim, "full claim when no liquidation needed");
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("RedemptionLiquidationCharge(address,uint256)");
+        for (uint256 i; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != sig, "no charge event when USDC covers the redemption");
+        }
+    }
 }


### PR DESCRIPTION
Closes #913.

## The problem

`redeem` and `withdraw` figure out how much the caller is owed from `totalAssets()` *before* selling anything — the full current NAV of their shares. If the vault doesn't hold enough USDC on hand, `_liquidateToUsdc` then sells synths on the AMM at up to `maxSlippageBps` (5% cap) plus the 0.3% pool fee.

The caller walks away with the full pre-trade value. The trading cost — the gap between what the synths were marked at and what they actually sold for — comes straight out of `totalAssets()`, which lowers the per-share NAV of everyone who stayed in the vault. So one person's exit quietly bills the remaining holders for the liquidity they consumed.

## The fix

Charge that cost to the person who caused it.

I measure the loss as `navBefore - navAfter` around the liquidation. The oracle price doesn't change inside the call, so `totalAssets()` marks the synths at the same price before and after — the only reason it drops is the fee and price impact of the sell. That drop *is* the realized slippage, to the wei.

Then each path charges it in the way that fits its semantics:

- **`redeem`** (caller names the shares): reduce the USDC paid out by the loss. Shares burned stay fixed.
- **`withdraw`** (caller names the exact USDC): keep delivering exactly that USDC, and burn *extra* shares worth the loss at the pre-trade rate instead. If the caller doesn't hold enough shares to cover the charge, `_burn` reverts — which is the right outcome; `redeem` is the path for a full exit that has to eat its own slippage.

Both leave the post-redemption NAV/share of the remaining holders unchanged. A `RedemptionLiquidationCharge` event fires whenever the charge actually binds.

One CEI note for the reviewer: `withdraw`'s base-share allowance is still spent before any external call (audit B6). The extra-share charge can't be sized until the AMM has run, so that incremental allowance is spent afterward — safe here because `_spendAllowance` makes no external call and the whole function is `nonReentrant`. I've commented this at the call site.

## What I didn't change

Previews (`previewRedeem`) still return the gross, pre-liquidation claim. They can't predict actual AMM slippage without simulating the swap, and the vault already couldn't. The on-chain path is where the charge is applied.

## Tests

4 new cases in `Vault.t.sol`, all against an oracle-aligned pool so the liquidation realizes a genuine loss vs oracle NAV:

- `test_redeem_liquidation_slippage_not_socialized` — the core invariant: the remaining holder's NAV/share does not fall when someone else redeems into a liquidation.
- `test_redeem_charges_redeemer_the_slippage` — the redeemer's payout drops below the pre-trade claim by exactly the charge, and the event fires with that amount.
- `test_withdraw_liquidation_burns_extra_shares_from_withdrawer` — withdraw still hands over the exact USDC, burns more shares than the no-slippage base, and the remaining holder is protected.
- `test_redeem_no_charge_when_usdc_on_hand` — regression: when the vault holds enough USDC, nothing is liquidated, no charge, full payout.

`forge test` is green: 67/67 in the Vault suite, 229/229 across all contract suites.

The cached `Vault.json` ABI gets the one new event. Its wider drift (a stale constructor sig and ~20 members from older PRs) is real but out of scope here — I've left a separate task to resync all the cached ABIs from a clean build rather than smuggle unrelated churn into this PR.

## Review

Funds logic on a live vault, so it needs the contract owner's sign-off before merge — **@dbrowneup** to review, and **@mnemonik-dev** for the second pair of eyes on the redeem/withdraw accounting. Left open, not merged.
