### PR TITLE
[contracts] Constrain rebalance to move each token toward its target weight (closes #915)

### DIFF
--- a/contracts/abis/Vault.json
+++ b/contracts/abis/Vault.json
@@ -88,6 +88,19 @@
   },
   {
     "type": "function",
+    "name": "MAX_REBALANCE_BAND_BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "MAX_SLIPPAGE_CAP_BPS",
     "inputs": [],
     "outputs": [
@@ -599,6 +612,19 @@
   },
   {
     "type": "function",
+    "name": "rebalanceBandBps",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "redeem",
     "inputs": [
       {
@@ -680,6 +706,19 @@
         "name": "_recipient",
         "type": "address",
         "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRebalanceBandBps",
+    "inputs": [
+      {
+        "name": "_bandBps",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "outputs": [],
@@ -1137,6 +1176,25 @@
   },
   {
     "type": "event",
+    "name": "RebalanceBandBpsSet",
+    "inputs": [
+      {
+        "name": "oldBps",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newBps",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "RebalanceTrace",
     "inputs": [
       {
@@ -1172,6 +1230,25 @@
       },
       {
         "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedemptionLiquidationCharge",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "slippageLoss",
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
@@ -1292,25 +1369,6 @@
       },
       {
         "name": "shares",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RedemptionLiquidationCharge",
-    "inputs": [
-      {
-        "name": "owner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "slippageLoss",
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
@@ -1441,6 +1499,11 @@
   },
   {
     "type": "error",
+    "name": "InvalidRebalanceBand",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "OracleNotRegistered",
     "inputs": [
       {
@@ -1472,6 +1535,28 @@
     "inputs": [
       {
         "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RebalanceNotTowardTarget",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RebalanceOvershootsTarget",
+    "inputs": [
+      {
+        "name": "token",
         "type": "address",
         "internalType": "address"
       }

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -62,6 +62,11 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         Prevents the owner from effectively disabling swap protection.
     uint256 public constant MAX_SLIPPAGE_CAP_BPS = 500;
 
+    /// @notice Upper bound on the owner-configurable rebalance dead-band (20%). A band
+    ///         wider than this would let the manager drift arbitrarily far from target
+    ///         before a correction is required, defeating the churn guard (issue #915).
+    uint256 public constant MAX_REBALANCE_BAND_BPS = 2000;
+
     // ─── Immutables ──────────────────────────────────────────────────
 
     address public immutable override asset;
@@ -105,6 +110,16 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         covers the 30 bps AMM fee plus bounded price impact.
     uint256 public maxSlippageBps = 100;
 
+    /// @notice Dead-band (bps) around each token's target weight inside which rebalance()
+    ///         will not trade it (issue #915). A token is only tradable once it is more than
+    ///         this far off target, and only in the direction that closes the gap (never past
+    ///         target). This is the churn guard: without it the manager's only bound was the
+    ///         per-swap oracle floor, so a compromised agent could wash USDC↔synth every
+    ///         rebalance and bleed the fee + impact each way. Owner-configurable, bounded by
+    ///         MAX_REBALANCE_BAND_BPS. Default 100 bps (1%). Only enforced once a target
+    ///         allocation policy exists (see _requireTowardTarget).
+    uint256 public rebalanceBandBps = 100;
+
     /// @notice Owner-curated registry consulted by setTokenOraclesFromRegistry.
     ///         The manager may wire oracles only from this allowlist, never an
     ///         arbitrary address — see setTokenOraclesFromRegistry.
@@ -131,6 +146,12 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     error OracleNotRegistered(address token);
     error AssetRegistryNotSet();
     error TraceRegistryNotSet();
+    /// @notice A rebalance swap would move `token` away from its target weight, or trade it
+    ///         while it is already within the dead-band of target (issue #915).
+    error RebalanceNotTowardTarget(address token);
+    /// @notice A rebalance swap would overshoot `token` past its target weight (issue #915).
+    error RebalanceOvershootsTarget(address token);
+    error InvalidRebalanceBand();
 
     // ─── Events (Vault-local) ────────────────────────────────────────
 
@@ -140,6 +161,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         AMM impact + fees; for redeem it reduces the USDC paid out, for withdraw it
     ///         is charged as extra burned shares.
     event RedemptionLiquidationCharge(address indexed owner, uint256 slippageLoss);
+    event RebalanceBandBpsSet(uint256 oldBps, uint256 newBps);
     event AgentSet(address indexed oldAgent, address indexed newAgent);
     event PlatformFeeRecipientSet(address indexed oldRecipient, address indexed newRecipient);
     event AssetRegistrySet(address indexed registry);
@@ -408,12 +430,19 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
                 continue;
             }
 
+            // Compute the oracle floor first (reverts on missing oracle / stale / zero price),
+            // so tokenOracle[tokenOut] is known-nonzero for the toward-target check below.
+            uint256 minOut = _oracleMinOut(tokenOut, asset, amount);
+            // #915 churn guard: this sell must move tokenOut toward its target weight
+            // (over-allocated → sell) and not past it. sellValue is the synth's oracle NAV.
+            uint256 sellValue = (amount * PriceOracle(tokenOracle[tokenOut]).getPrice()) / 1e18;
+            _requireTowardTarget(tokenOut, sellValue, false);
+
             // Approve router
             IERC20(tokenOut).safeIncreaseAllowance(address(ammRouter), amount);
 
             // Swap tokenOut -> USDC with oracle-derived slippage floor
-            uint256 usdcReceived =
-                ammRouter.swap(tokenOut, asset, amount, _oracleMinOut(tokenOut, asset, amount));
+            uint256 usdcReceived = ammRouter.swap(tokenOut, asset, amount, minOut);
 
             _removeHolding(tokenOut, amount);
             _addHolding(address(asset), usdcReceived);
@@ -429,12 +458,18 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
                 continue;
             }
 
+            // Oracle floor first (reverts on missing oracle / stale / zero price).
+            uint256 minOut = _oracleMinOut(asset, tokenIn, amount);
+            // #915 churn guard: this buy must move tokenIn toward its target weight
+            // (under-allocated → buy) and not past it. The USDC spent (`amount`) is the
+            // NAV added to the position.
+            _requireTowardTarget(tokenIn, amount, true);
+
             // Approve router
             IERC20(asset).safeIncreaseAllowance(address(ammRouter), amount);
 
             // Swap USDC -> tokenIn with oracle-derived slippage floor
-            uint256 tokensReceived =
-                ammRouter.swap(asset, tokenIn, amount, _oracleMinOut(asset, tokenIn, amount));
+            uint256 tokensReceived = ammRouter.swap(asset, tokenIn, amount, minOut);
 
             _removeHolding(asset, amount);
             _addHolding(tokenIn, tokensReceived);
@@ -567,6 +602,16 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         maxSlippageBps = _maxSlippageBps;
     }
 
+    /// @notice Tune the rebalance dead-band around target weights (issue #915). Bounded by
+    ///         MAX_REBALANCE_BAND_BPS. A value of 0 is allowed — it removes the band but keeps
+    ///         the directional "toward target, never overshoot" constraint, the load-bearing
+    ///         part of the churn guard.
+    function setRebalanceBandBps(uint256 _bandBps) external onlyOwner {
+        if (_bandBps > MAX_REBALANCE_BAND_BPS) revert InvalidRebalanceBand();
+        emit RebalanceBandBpsSet(rebalanceBandBps, _bandBps);
+        rebalanceBandBps = _bandBps;
+    }
+
     function pause() external onlyOwner {
         _pause();
     }
@@ -576,6 +621,53 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     }
 
     // ─── Internal ────────────────────────────────────────────────────
+
+    /// @notice A token's current value in USDC (6-decimal) terms, matching totalAssets()'s
+    ///         convention: USDC at face value, synths at balance(18) * price(6) / 1e18.
+    ///         Unpriced tokens contribute 0 (they can't be weighted); a rebalance touching
+    ///         such a token reverts earlier in _oracleMinOut anyway.
+    function _tokenValueUsdc(address token) internal view returns (uint256) {
+        uint256 bal = IERC20(token).balanceOf(address(this));
+        if (token == address(asset)) return bal;
+        address oracle = tokenOracle[token];
+        if (oracle == address(0)) return 0;
+        return (bal * PriceOracle(oracle).getPrice()) / 1e18;
+    }
+
+    /// @notice Enforce that a rebalance swap moves `token` toward its target weight and does
+    ///         not overshoot it (issue #915). `tradeValueUsdc` is the USDC NAV moved by the
+    ///         swap; `isBuy` distinguishes a weight-raising buy from a weight-lowering sell.
+    /// @dev    The churn guard. Evaluated against LIVE state so it composes correctly across
+    ///         multiple swaps in one call and across repeated rebalances: once a token reaches
+    ///         (within the dead-band of) its target, further trades in that direction revert,
+    ///         so USDC↔synth washing can't drain the vault a fee at a time. Only enforced once
+    ///         a target allocation policy exists — with no targets set there is no "toward" to
+    ///         define, and blocking every trade would break initial position-building; a vault
+    ///         run without target weights therefore has no churn guard (set targets to arm it).
+    function _requireTowardTarget(address token, uint256 tradeValueUsdc, bool isBuy) internal view {
+        if (targetTokens.length == 0) return; // no policy → nothing to enforce against
+        uint256 nav = totalAssets();
+        if (nav == 0) return;
+
+        uint256 currentValue = _tokenValueUsdc(token);
+        uint256 currentWeight = (currentValue * BPS) / nav;
+        uint256 target = targetWeightBps[token]; // 0 for a token not in the target set
+        uint256 targetValue = (target * nav) / BPS;
+
+        if (isBuy) {
+            // Buying raises the weight: only allowed while under target by more than the
+            // dead-band, and only up to the target (never past it).
+            if (currentWeight + rebalanceBandBps >= target) revert RebalanceNotTowardTarget(token);
+            uint256 maxBuy = targetValue > currentValue ? targetValue - currentValue : 0;
+            if (tradeValueUsdc > maxBuy) revert RebalanceOvershootsTarget(token);
+        } else {
+            // Selling lowers the weight: only allowed while over target by more than the
+            // dead-band, and only down to the target (never past it).
+            if (currentWeight <= target + rebalanceBandBps) revert RebalanceNotTowardTarget(token);
+            uint256 maxSell = currentValue > targetValue ? currentValue - targetValue : 0;
+            if (tradeValueUsdc > maxSell) revert RebalanceOvershootsTarget(token);
+        }
+    }
 
     /// @notice Compute the minimum acceptable output for an AMM swap from the
     ///         on-chain oracle price, minus the bounded slippage tolerance.

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -1561,4 +1561,121 @@ contract VaultTest is Test {
             assertTrue(logs[i].topics[0] != sig, "no charge event when USDC covers the redemption");
         }
     }
+
+    // ─── Rebalance Toward-Target / Anti-Churn (issue #915) ───────────
+
+    /// @dev Set a 50/50 USDC/sTSLA target allocation (as the manager).
+    function _setTarget5050() internal {
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(sTSLA);
+        uint256[] memory weights = new uint256[](2);
+        weights[0] = 5000;
+        weights[1] = 5000;
+        vm.prank(agent);
+        vault.setTargetAllocations(tokens, weights);
+    }
+
+    /// @dev Put the vault at ~98% sTSLA (buy before any target exists, so the buy is
+    ///      unconstrained), then arm the 50/50 target.
+    function _vaultMostlySynthWithTarget() internal {
+        _depositAsAlice(50_000 * 10**6);
+        _rebalanceBuyTsla(49_000 * 10**6); // ~98% synth, no target set yet → unconstrained
+        _setTarget5050();
+    }
+
+    /// @dev A rebalance that buys MORE of an already-over-target token is rejected — this is
+    ///      the churn vector: the manager can't push the vault further from target.
+    function test_revert_rebalance_buy_away_from_target() public {
+        _vaultMostlySynthWithTarget();
+
+        address[] memory tIn = _singleton(address(sTSLA));
+        uint256[] memory aIn = _singletonUint(500 * 10**6);
+        address[] memory tOut = new address[](0);
+        uint256[] memory aOut = new uint256[](0);
+        _commitFor(tIn, aIn, tOut, aOut);
+        vm.prank(agent);
+        vm.expectRevert(abi.encodeWithSelector(Vault.RebalanceNotTowardTarget.selector, address(sTSLA)));
+        vault.rebalance(tIn, aIn, tOut, aOut);
+    }
+
+    /// @dev A rebalance that sells an over-target token toward its target is allowed, and the
+    ///      token's weight moves down toward 50%.
+    function test_rebalance_sell_toward_target_succeeds() public {
+        _vaultMostlySynthWithTarget();
+
+        uint256 nav = vault.totalAssets();
+        uint256 synthWeightBefore = (_synthValue() * 10000) / nav;
+
+        // 10k tokens = ~20k USDC of synth, comfortably under the ~24k that would reach target.
+        _rebalanceSellTsla(10_000 * 1e18);
+
+        uint256 synthWeightAfter = (_synthValue() * 10000) / vault.totalAssets();
+        assertLt(synthWeightAfter, synthWeightBefore, "sell moved synth weight toward target");
+        assertGt(synthWeightAfter, 5000, "did not overshoot below target");
+    }
+
+    /// @dev Selling far more than needed to reach target overshoots below it and is rejected.
+    function test_revert_rebalance_sell_overshoots_target() public {
+        _vaultMostlySynthWithTarget();
+
+        // The vault holds ~24.3k sTSLA tokens (~48.7k USDC). Selling 20k tokens (~40k USDC)
+        // blows well past the ~24k that reaches the 50% target.
+        address[] memory tIn = new address[](0);
+        uint256[] memory aIn = new uint256[](0);
+        address[] memory tOut = _singleton(address(sTSLA));
+        uint256[] memory aOut = _singletonUint(20_000 * 1e18);
+        _commitFor(tIn, aIn, tOut, aOut);
+        vm.prank(agent);
+        vm.expectRevert(abi.encodeWithSelector(Vault.RebalanceOvershootsTarget.selector, address(sTSLA)));
+        vault.rebalance(tIn, aIn, tOut, aOut);
+    }
+
+    /// @dev Acceptance scenario (#915): a single rebalance that sells synth toward target and
+    ///      then buys it back (the wash) reverts — the buy-back is evaluated against the
+    ///      post-sell weight, which is still above target, so it is rejected as away-from-target.
+    function test_revert_rebalance_churn_in_one_call() public {
+        _vaultMostlySynthWithTarget();
+
+        address[] memory tIn = _singleton(address(sTSLA)); // buy back
+        uint256[] memory aIn = _singletonUint(5_000 * 10**6);
+        address[] memory tOut = _singleton(address(sTSLA)); // sell first
+        uint256[] memory aOut = _singletonUint(5_000 * 1e18);
+        _commitFor(tIn, aIn, tOut, aOut);
+        vm.prank(agent);
+        vm.expectRevert(abi.encodeWithSelector(Vault.RebalanceNotTowardTarget.selector, address(sTSLA)));
+        vault.rebalance(tIn, aIn, tOut, aOut);
+    }
+
+    /// @dev Regression: with no target allocation set, rebalance stays unconstrained (the
+    ///      guard only arms once a policy exists) — a plain buy still works.
+    function test_rebalance_unconstrained_without_target() public {
+        _depositAsAlice(50_000 * 10**6);
+        _rebalanceBuyTsla(10_000 * 10**6); // no target set → allowed
+        assertGt(sTSLA.balanceOf(address(vault)), 0, "buy executed with no target policy");
+    }
+
+    function test_setRebalanceBandBps() public {
+        vm.prank(agent);
+        vault.setRebalanceBandBps(300);
+        assertEq(vault.rebalanceBandBps(), 300);
+    }
+
+    function test_revert_setRebalanceBandBps_above_max() public {
+        uint256 aboveMax = vault.MAX_REBALANCE_BAND_BPS() + 1;
+        vm.prank(agent);
+        vm.expectRevert(Vault.InvalidRebalanceBand.selector);
+        vault.setRebalanceBandBps(aboveMax);
+    }
+
+    function test_revert_setRebalanceBandBps_non_owner() public {
+        vm.prank(bob);
+        vm.expectRevert();
+        vault.setRebalanceBandBps(300);
+    }
+
+    /// @dev sTSLA's USDC value held by the vault (18-dec balance * 6-dec price / 1e18).
+    function _synthValue() internal view returns (uint256) {
+        return (sTSLA.balanceOf(address(vault)) * tslaOracle.getPrice()) / 1e18;
+    }
 }


### PR DESCRIPTION
Closes #915.

## The problem

`rebalance` let the manager pick any set of swaps. The only thing checking them was the per-swap oracle floor (`_oracleMinOut`, capped at 5%). Nothing tied the trades to `targetWeightBps`, and nothing capped how many times a token could be traded.

So a compromised or misbehaving agent could wash USDC → synth → USDC on every rebalance — each round-trip pays the AMM fee plus price impact, and over enough rebalances that bleeds the vault dry. The strategy's own target allocation, which is supposed to be the point, had no say in what trades were allowed.

## The fix

Tie every swap to the target. A token is only tradable when it's more than a dead-band away from its target weight, and only in the direction that closes the gap — never past the target:

- a **buy** is allowed only while the token is under target by more than the band, and only up to the amount that reaches target
- a **sell** is allowed only while it's over target by more than the band, and only down to target

The check runs against live state, which is what makes it hold up:

- within one rebalance call, a sell-then-buy-back wash reverts — by the time the buy-back is checked, the sell already moved the token to (or toward) target, so buying it back reads as moving *away* from target and is rejected
- across rebalances, once a token sits inside its dead-band it simply can't be traded again in that direction, so there's no fee-at-a-time drain to run

`rebalanceBandBps` is owner-tunable (default 1%, capped at `MAX_REBALANCE_BAND_BPS` = 20%).

One deliberate scoping choice: the guard only arms once a target allocation exists. With no targets set there's no "toward" to define, and rejecting every trade would break the normal flow of building the initial position from a fresh USDC deposit. So a vault run with no target weights keeps the old behavior — setting target weights is what turns the guard on. I've documented that at the check.

## Tests

8 new cases in `Vault.t.sol`:

- `test_revert_rebalance_buy_away_from_target` — buying more of an already-over-target token reverts
- `test_rebalance_sell_toward_target_succeeds` — selling an over-target token toward target works and its weight drops
- `test_revert_rebalance_sell_overshoots_target` — selling far past target reverts
- `test_revert_rebalance_churn_in_one_call` — the acceptance scenario: a single rebalance that sells synth then buys it back reverts
- `test_rebalance_unconstrained_without_target` — regression: no target set → rebalance still works as before
- band setter tests — bounds and owner-only

`forge test` is green: 71/71 in the Vault suite, 233/233 across all contract suites. Added the new members to the cached `Vault.json` ABI (scoped to this change; the file's older drift is tracked separately).

## Review

Changes the manager's trade authority on a live vault, so it needs the contract owner's sign-off before merge — **@dbrowneup** to review, **@mnemonik-dev** for the second look at the weight math. Left open, not merged.
