### PR TITLE
[backend] Rate-limit + size-cap expensive-compute endpoints (#917)

### DIFF
--- a/backend/archimedes/api/portfolio_routes.py
+++ b/backend/archimedes/api/portfolio_routes.py
@@ -12,8 +12,10 @@ import asyncio
 import logging
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
+
+from archimedes.api.limiter import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -125,13 +127,17 @@ class ScenarioRequest(BaseModel):
 
 
 class ScenarioAnalysisRequest(BaseModel):
-    weights: dict[str, float]
+    # Compute-amplification guard (#917): scenario analysis iterates
+    # len(weights) × len(scenarios), so both must be bounded at validation —
+    # before any work — or a single unauthenticated request can pin the worker.
+    weights: dict[str, float] = Field(..., max_length=100)
     portfolio_value: float = 10000.0
-    scenarios: list[ScenarioRequest] | None = None
+    scenarios: list[ScenarioRequest] | None = Field(None, max_length=10)
 
 
 @portfolio_router.post("/optimize")
-async def optimize_portfolio(req: OptimizeRequest) -> dict:
+@limiter.limit("5/minute")
+async def optimize_portfolio(req: OptimizeRequest, request: Request) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Compute optimal synth-asset weights with the requested optimizer.
 
     Returns {method, optimizer, risk_profile, usdc_weight, weights, symbols_used,
@@ -203,7 +209,8 @@ async def optimize_portfolio(req: OptimizeRequest) -> dict:
 
 
 @portfolio_router.post("/parameter-sweep")
-async def parameter_sweep(req: ParameterSweepRequest) -> dict:
+@limiter.limit("5/minute")
+async def parameter_sweep(req: ParameterSweepRequest, request: Request) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Run a 2D sensitivity sweep over two backtest parameters.
 
     Returns a heatmap-ready grid_2d with rows=param1 values, cols=param2 values,
@@ -282,7 +289,8 @@ async def parameter_sweep(req: ParameterSweepRequest) -> dict:
 
 
 @portfolio_router.post("/scenario-analysis")
-async def scenario_analysis(req: ScenarioAnalysisRequest) -> dict:
+@limiter.limit("10/minute")
+async def scenario_analysis(req: ScenarioAnalysisRequest, request: Request) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Apply mark-to-model stress shocks to a portfolio and return per-scenario P&L.
 
     Uses predefined scenarios when none are supplied. Applies a 1.2x stress beta

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -379,7 +379,9 @@ async def evaluate_rigor_gate(
 
 
 @selection_bias_router.get("/gate/{strategy_id}", response_model=StrategyRigorResult)
+@limiter.limit("10/minute")
 async def evaluate_strategy_rigor(
+    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     strategy_id: str,
     strictness: int = Query(DEFAULT_LEVEL, ge=STRICTEST_LEVEL, le=LOOSEST_LEVEL),
 ):

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -374,8 +374,19 @@ async def get_vault_metadata(address: str):
 
 @vaults_router.post("/{address}/derive-allocations", response_model=SetAllocationsResponse)
 @limiter.limit("20/minute")
-async def derive_vault_allocations(address: str, req: SetAllocationsRequest, request: Request, response: Response):  # noqa: ARG001 — slowapi @limiter.limit inspects param name; path param routes the request
-    """Derive target allocations from selected strategies."""
+async def derive_vault_allocations(
+    address: str,
+    req: SetAllocationsRequest,
+    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name; path param routes the request
+    response: Response,  # noqa: ARG001 — reserved for slowapi rate-limit headers
+    wallet: str = Depends(require_verified_wallet),  # noqa: ARG001 — SIWE gate (#917): auth required, wallet unused in body
+):
+    """Derive target allocations from selected strategies.
+
+    Gated behind a verified SIWE session (#917): the derivation runs a full
+    strategy scan + on-chain reads, so it is not exposed to unauthenticated
+    callers who could amplify it into a compute-DoS.
+    """
     from archimedes.chain.client import chain_client
     from archimedes.services.strategy_signal_evaluator import strategy_evaluator
 

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -375,9 +375,9 @@ async def get_vault_metadata(address: str):
 @vaults_router.post("/{address}/derive-allocations", response_model=SetAllocationsResponse)
 @limiter.limit("20/minute")
 async def derive_vault_allocations(
-    address: str,
+    address: str,  # noqa: ARG001 — path param routes the request; not referenced in body
     req: SetAllocationsRequest,
-    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name; path param routes the request
+    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     response: Response,  # noqa: ARG001 — reserved for slowapi rate-limit headers
     wallet: str = Depends(require_verified_wallet),  # noqa: ARG001 — SIWE gate (#917): auth required, wallet unused in body
 ):

--- a/backend/tests/test_portfolio_sweep_scenario.py
+++ b/backend/tests/test_portfolio_sweep_scenario.py
@@ -250,3 +250,36 @@ async def test_scenario_analysis_stress_amplification_applied():
         assert sc["stress_adjusted_pct"] == pytest.approx(sc["impact_pct"] * 1.2, rel=1e-4), (
             f"Stress amplification wrong for '{sc['scenario_name']}'"
         )
+
+
+@pytest.mark.asyncio
+async def test_scenario_analysis_rejects_oversized_weights():
+    """#917: >100 weights is rejected at validation (422) before any compute."""
+    from archimedes.main import app
+
+    payload = {
+        "weights": {f"SYM{i}": 0.01 for i in range(101)},
+        "portfolio_value": 10000.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/scenario-analysis", json=payload)
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_scenario_analysis_rejects_oversized_scenario_list():
+    """#917: >10 scenarios is rejected at validation (422) before the O(w×s) loop."""
+    from archimedes.main import app
+
+    payload = {
+        "weights": {"SPY": 1.0},
+        "portfolio_value": 10000.0,
+        "scenarios": [{"name": f"s{i}", "shocks": [{"asset": "SPY", "shock": -0.01}]} for i in range(11)],
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/portfolio/scenario-analysis", json=payload)
+
+    assert resp.status_code == 422, resp.text

--- a/backend/tests/test_strategy_sizer.py
+++ b/backend/tests/test_strategy_sizer.py
@@ -211,9 +211,8 @@ async def test_derive_allocations_sizes_passers_and_excludes_candidates(tmp_path
 @pytest.mark.asyncio
 async def test_derive_allocations_requires_siwe_session():
     """#917: derive-allocations is behind the SIWE gate — 401 without a session."""
-    from httpx import ASGITransport, AsyncClient
-
     from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
 
     body = {"strategy_ids": ["val"], "usdc_floor_pct": 20.0, "risk_profile": "moderate"}
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/backend/tests/test_strategy_sizer.py
+++ b/backend/tests/test_strategy_sizer.py
@@ -206,3 +206,17 @@ async def test_derive_allocations_sizes_passers_and_excludes_candidates(tmp_path
     assert resp.sized_strategies == {"val": pytest.approx(0.2)}
     assert resp.excluded_strategy_ids == ["cand"]
     assert resp.risk_profile == "moderate"
+
+
+@pytest.mark.asyncio
+async def test_derive_allocations_requires_siwe_session():
+    """#917: derive-allocations is behind the SIWE gate — 401 without a session."""
+    from httpx import ASGITransport, AsyncClient
+
+    from archimedes.main import app
+
+    body = {"strategy_ids": ["val"], "usdc_floor_pct": 20.0, "risk_profile": "moderate"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/vaults/0x" + "3" * 40 + "/derive-allocations", json=body)
+
+    assert resp.status_code == 401, resp.text


### PR DESCRIPTION
## Summary

Closes #917. Four unauthenticated expensive-compute endpoints were DoS-amplifiable with no size caps or throttling. This adds rate limits, input size caps, and (for the vault derivation) a SIWE gate.

## Changes

- **`/portfolio/optimize`** — `@limiter.limit("5/minute")`. `symbols` already capped at 50 in `OptimizeRequest`.
- **`/portfolio/parameter-sweep`** — `@limiter.limit("5/minute")` (already had a 25×25 Cartesian cap from a prior audit).
- **`/portfolio/scenario-analysis`** — `@limiter.limit("10/minute")` + schema caps `weights <= 100`, `scenarios <= 10`, so the `O(weights × scenarios)` loop is bounded at validation before any compute.
- **`/selection-bias/gate/{id}`** — `@limiter.limit("10/minute")`. The whole-library CSCV PBO is already cached on the store-file signature (`_library_pbo_payload`), so the per-call cost is bounded.
- **`/vaults/{addr}/derive-allocations`** — gated behind `require_verified_wallet` (SIWE). It runs a full strategy scan + on-chain reads for any caller/address; it is not called by the UI, so gating it closes the amplification vector without breaking a live flow. (It already carried a `20/minute` limit.)

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_portfolio_sweep_scenario.py \
  backend/tests/test_strategy_sizer.py \
  backend/tests/test_selection_bias_routes.py \
  backend/tests/test_portfolio_routes.py -q
```

New tests: oversized `weights`/`scenarios` → 422; `derive-allocations` → 401 without a SIWE session.

## Anti-goals

- Endpoints are not removed.
- Rate limits stay disabled under `TESTING` (existing limiter behavior), so tests assert the size caps + auth gate rather than the throttle.

## Notes

Rate-limit values are conservative starting points and can be tuned per endpoint cost.