### PR TITLE
[rigor] Fail-closed PBO on too-short fusion variant window (#918)

### DIFF
--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -53,6 +53,12 @@ from archimedes.services.strategy_dsl import (
 
 logger = logging.getLogger(__name__)
 
+# CSCV partition count used when calling compute_pbo without an explicit
+# s_partitions (its default). Mirrored here so the fusion path can detect a
+# too-short window (T // S < 1) before compute_pbo returns its all-0.0 sentinel
+# (#918). Keep in sync with _rigor_helpers.compute_pbo's default.
+_PBO_S_PARTITIONS = 16
+
 # ── Result types ──────────────────────────────────────────────────────
 
 
@@ -667,11 +673,21 @@ def apply_rigor_gate(
     # PBO: compute real CSCV PBO when >= 2 variant backtests are available.
     pbo_score: float | None = None
     if len(variant_returns) >= 2:
-        pbo_map = compute_pbo(variant_returns)
-        # All strategies in the matrix get the same PBO score (library-level
-        # metric per Bailey et al. 2014). Pick the first entry's value.
-        first_key = next(iter(pbo_map))
-        pbo_score = pbo_map[first_key]
+        # Fail-closed on a too-short variant window (#918). compute_pbo returns
+        # an all-0.0 sentinel (a spurious PASS, since 0.0 < pbo_max) when
+        # rows_per_block = T // s_partitions < 1 — i.e. fewer aligned bars than
+        # partitions (e.g. a 5-day fusion window against the default S=16). That
+        # 0.0 is meaningless, so guard it here exactly as the curated path does
+        # in rigor_evaluator.compute_library_pbo: an under-length window is
+        # non-computable and must FAIL the PBO criterion, not pass it. Leaving
+        # pbo_score = None routes into the pbo_pass fail-closed branch below.
+        shortest = min((len(r) for r in variant_returns.values()), default=0)
+        if shortest // _PBO_S_PARTITIONS >= 1:
+            pbo_map = compute_pbo(variant_returns)
+            # All strategies in the matrix get the same PBO score (library-level
+            # metric per Bailey et al. 2014). Pick the first entry's value.
+            first_key = next(iter(pbo_map))
+            pbo_score = pbo_map[first_key]
 
     # Look-ahead admission: validate_strategy_spec rejects any DSL spec with a
     # self-declared look_ahead_safe=False before this evaluator ever runs, so

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -300,6 +300,25 @@ class TestFusionWithVariantsComputesRealPbo:
         verdict = apply_rigor_gate(metrics, variants_metrics=single_variant)
         assert verdict.pbo_score is None, "PBO must be None when fewer than 2 variant backtests are provided"
 
+    def test_fusion_short_variant_window_pbo_stays_none_and_fails(self):
+        """#918: variant series shorter than the CSCV partition count (S=16) are
+        non-computable. compute_pbo returns an all-0.0 sentinel there — a spurious
+        'best possible' PASS — so the fusion path must guard it: pbo_score must be
+        None (fail-closed) and the verdict must NOT pass. A ~5-day fusion window
+        (6-point curve → 5 daily returns, well under S=16) is the canonical
+        trigger from the issue."""
+        short_curve_a = [100_000.0 * (1.002**i) for i in range(6)]
+        short_curve_b = [100_000.0 * (1.001**i) for i in range(6)]
+        variants = {
+            "v0": _metrics_from_curve(short_curve_a),
+            "v1": _metrics_from_curve(short_curve_b),
+        }
+        verdict = apply_rigor_gate(_metrics_from_curve(short_curve_a), variants_metrics=variants)
+        assert verdict.pbo_score is None, (
+            "a <16-bar variant window is non-computable; PBO must be None, not the 0.0 sentinel"
+        )
+        assert verdict.passing is False, "a non-computable PBO must FAIL the fusion gate, not pass it"
+
     def test_fusion_high_pbo_fails_rigor_gate(self):
         """A synthetic overfit grid where PBO > 0.5 must cause passing=False.
 


### PR DESCRIPTION
## Summary

Closes #918. `compute_pbo` returns an all-`0.0` sentinel (the *best possible* PBO) when the aligned window is too short to form the CSCV partitions (`rows_per_block = T // s_partitions < 1`, i.e. fewer bars than `s_partitions`, default 16). The fusion path assigned that `0.0` straight to `pbo_score`, so a fusion variant built on a short window (e.g. a 5-day backtest) sailed through the overfitting check and was certified Tier-1 — the strongest verdict — on non-computable data.

The **curated** library path already guards this (`rigor_evaluator.compute_library_pbo` returns `None` → criterion-4 FAIL when `shortest // s_partitions < 1`); the **fusion** path did not.

## Change

`fusion_evaluator.apply_rigor_gate` now mirrors the curated guard: before calling `compute_pbo`, it checks the shortest variant series against the partition count and, if under-length, leaves `pbo_score = None`. That routes into the existing fail-closed branch (`pbo_pass = pbo_score is not None and math.isfinite(pbo_score) and pbo_score < pbo_max`), so the variant FAILS rather than passing.

`compute_pbo`'s shared `dict[str, float]` contract is intentionally left unchanged — 5+ other callers (`compute_library_pbo`, `live_rigor_gate`, two `selection_bias_routes` endpoints, `strategies_routes`) depend on it, and the curated path already pre-guards the same condition. Fixing at the fusion boundary keeps blast radius to one logical change.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/services/test_fusion_evaluator.py backend/tests/test_rigor_evaluator.py -q
```

New test `test_fusion_short_variant_window_pbo_stays_none_and_fails`: two 6-point (5-return) variant curves → `pbo_score is None` and `passing is False`.

## Anti-goals

- The CSCV PBO formula is unchanged.
- `compute_pbo`'s return type is unchanged (no ripple to its other callers).