### PR TITLE
[backend] Guard json.loads on Redis read paths (#919)

### DIFF
--- a/backend/archimedes/services/job_queue.py
+++ b/backend/archimedes/services/job_queue.py
@@ -26,6 +26,21 @@ JOB_TTL = 3600  # 1 hour
 EVENT_LOG_TTL = 900  # 15 minutes after terminal state — spec 0.5 § Reconnection
 
 
+def _safe_json(raw, default, *, context: str):
+    """``json.loads`` that returns ``default`` on malformed data (#919).
+
+    A truncated / tampered ``payload`` or ``result`` field must not 500 the job
+    read path; log and fall back to the default so the job still lists.
+    """
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.warning("Malformed JSON in job store (%s) — using default: %s", context, exc)
+        return default
+
+
 class JobStore:
     """Thin Redis wrapper for async job lifecycle."""
 
@@ -75,8 +90,8 @@ class JobStore:
             "id": raw.get("id", job_id),
             "type": raw.get("type", ""),
             "status": raw.get("status", "unknown"),
-            "payload": json.loads(raw["payload"]) if raw.get("payload") else {},
-            "result": json.loads(raw["result"]) if raw.get("result") else None,
+            "payload": _safe_json(raw.get("payload"), {}, context=f"job:{job_id}:payload"),
+            "result": _safe_json(raw.get("result"), None, context=f"job:{job_id}:result"),
             "error": raw.get("error", ""),
             "created_at": raw.get("created_at", ""),
             "updated_at": raw.get("updated_at", ""),
@@ -173,8 +188,8 @@ class JobStore:
                     "id": raw.get("id", key.removeprefix(KEY_PREFIX)),
                     "type": raw.get("type", ""),
                     "status": raw.get("status", "unknown"),
-                    "payload": json.loads(raw["payload"]) if raw.get("payload") else {},
-                    "result": json.loads(raw["result"]) if raw.get("result") else None,
+                    "payload": _safe_json(raw.get("payload"), {}, context=f"job:{key}:payload"),
+                    "result": _safe_json(raw.get("result"), None, context=f"job:{key}:result"),
                     "error": raw.get("error", ""),
                     "created_at": raw.get("created_at", ""),
                     "updated_at": raw.get("updated_at", ""),

--- a/backend/archimedes/services/redis_state.py
+++ b/backend/archimedes/services/redis_state.py
@@ -37,6 +37,20 @@ KEY_TRACE_INDEX = "archimedes:trace:index"
 KEY_SIWE_NONCE_PREFIX = "archimedes:auth:nonce:"
 
 
+def _safe_json_loads(raw, *, context: str):
+    """``json.loads`` that degrades gracefully on malformed data (#919).
+
+    A truncated, partial, or externally-tampered Redis value must not crash a
+    read path with a 500. Logs the decode failure and returns ``None`` so the
+    caller can skip the bad entry or return a null/empty response.
+    """
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.warning("Malformed JSON in Redis (%s) — dropping value: %s", context, exc)
+        return None
+
+
 class AgentStateStore:
     """Thin wrapper over Redis for agent state."""
 
@@ -122,7 +136,7 @@ class AgentStateStore:
         r = await self._get_redis()
         raw = await r.get(KEY_REGIME)
         if raw:
-            return json.loads(raw)
+            return _safe_json_loads(raw, context=KEY_REGIME)
         return None
 
     async def load_ensemble_consensus(self) -> dict | None:
@@ -130,7 +144,7 @@ class AgentStateStore:
         r = await self._get_redis()
         raw = await r.get(KEY_ENSEMBLE_CONSENSUS)
         if raw:
-            return json.loads(raw)
+            return _safe_json_loads(raw, context=KEY_ENSEMBLE_CONSENSUS)
         return None
 
     # ─── Heartbeat ────────────────────────────────────────────────
@@ -176,7 +190,7 @@ class AgentStateStore:
     async def get_events(self, count: int = 20) -> list[dict]:
         r = await self._get_redis()
         raw = await r.lrange("archimedes:agent:events", 0, count - 1)
-        return [json.loads(e) for e in raw]
+        return [d for e in raw if (d := _safe_json_loads(e, context="agent:events")) is not None]
 
     # ─── Vault Monitoring ─────────────────────────────────────────
 
@@ -197,7 +211,7 @@ class AgentStateStore:
         r = await self._get_redis()
         key = f"archimedes:vault:snapshots:{vault_address.lower()}"
         raw = await r.lrange(key, 0, count - 1)
-        return [json.loads(e) for e in raw]
+        return [d for e in raw if (d := _safe_json_loads(e, context="vault:snapshots")) is not None]
 
     # ─── Reasoning Trace Persistence ────────────────────────────
 
@@ -243,14 +257,18 @@ class AgentStateStore:
         # Try direct hash lookup
         raw = await r.get(f"{KEY_TRACE_PREFIX}{trace_id_or_hash}")
         if raw:
-            return json.loads(raw)
+            parsed = _safe_json_loads(raw, context="trace:hash")
+            if parsed is not None:
+                return parsed
 
         # Try UUID → hash → data
         hash_val = await r.get(f"{KEY_TRACE_PREFIX}id:{trace_id_or_hash}")
         if hash_val:
             raw = await r.get(f"{KEY_TRACE_PREFIX}{hash_val}")
             if raw:
-                return json.loads(raw)
+                parsed = _safe_json_loads(raw, context="trace:uuid")
+                if parsed is not None:
+                    return parsed
 
         return None
 
@@ -274,7 +292,9 @@ class AgentStateStore:
             raw = await r.get(f"{KEY_TRACE_PREFIX}{h}")
             if not raw:
                 continue
-            data = json.loads(raw)
+            data = _safe_json_loads(raw, context="trace:index")
+            if data is None:
+                continue
 
             # Apply filters
             if vault_address and data.get("vault_address", "").lower() != vault_address.lower():

--- a/backend/tests/services/test_redis_json_guard.py
+++ b/backend/tests/services/test_redis_json_guard.py
@@ -1,0 +1,81 @@
+"""Hermetic tests for malformed-JSON resilience on Redis read paths (#919).
+
+A truncated / partial / externally-tampered Redis value must degrade
+gracefully (drop the entry, return null/empty) instead of crashing the read
+path with a 500. No live Redis: the async client is a mock whose read methods
+return deliberately-malformed bytes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from archimedes.services.job_queue import JobStore, _safe_json
+from archimedes.services.redis_state import AgentStateStore, _safe_json_loads
+
+# ── pure helpers ─────────────────────────────────────────────────────────────
+
+
+def test_safe_json_loads_valid_returns_object():
+    assert _safe_json_loads('{"a": 1}', context="t") == {"a": 1}
+
+
+def test_safe_json_loads_malformed_returns_none():
+    assert _safe_json_loads('{"a": 1', context="t") is None
+    assert _safe_json_loads("not json", context="t") is None
+    assert _safe_json_loads(None, context="t") is None
+
+
+def test_safe_json_valid_and_default():
+    assert _safe_json('{"a": 1}', {}, context="t") == {"a": 1}
+    assert _safe_json("", {}, context="t") == {}  # empty → default, no error
+    assert _safe_json('{"a"', {"fallback": True}, context="t") == {"fallback": True}
+
+
+# ── redis_state read paths ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_regime_malformed_returns_none_not_500():
+    store = AgentStateStore()
+    store._redis = AsyncMock()
+    store._redis.get = AsyncMock(return_value='{"regime": "bull"')  # truncated
+    # Must not raise — degrades to None.
+    assert await store.load_regime() is None
+
+
+@pytest.mark.asyncio
+async def test_get_events_drops_malformed_entry():
+    store = AgentStateStore()
+    store._redis = AsyncMock()
+    store._redis.lrange = AsyncMock(return_value=['{"type": "ok"}', "{bad json", '{"type": "ok2"}'])
+    events = await store.get_events()
+    assert events == [{"type": "ok"}, {"type": "ok2"}]  # bad one dropped, no raise
+
+
+@pytest.mark.asyncio
+async def test_list_traces_skips_malformed_entry():
+    store = AgentStateStore()
+    store._redis = AsyncMock()
+    store._redis.zrevrange = AsyncMock(return_value=["hash1"])
+    store._redis.get = AsyncMock(return_value="{corrupted")
+    traces, total = await store.list_traces()
+    assert traces == [] and total == 0  # skipped, not a 500
+
+
+# ── job_queue read paths ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_job_get_malformed_payload_falls_back():
+    store = JobStore()
+    store._redis = AsyncMock()
+    store._redis.hgetall = AsyncMock(
+        return_value={"id": "j1", "type": "gen", "status": "done", "payload": "{trunc", "result": "also bad"}
+    )
+    job = await store.get("j1")
+    assert job is not None
+    assert job["payload"] == {}  # default on malformed
+    assert job["result"] is None  # default on malformed
+    assert job["status"] == "done"  # untouched fields still returned


### PR DESCRIPTION
## Summary

Closes #919. Multiple services called `json.loads(raw)` on Redis values without catching `JSONDecodeError`. A truncated, partial, or externally-tampered value crashed the read path with a 500 instead of degrading gracefully.

## Changes

Added a small guard helper to each module (`_safe_json_loads` in `redis_state.py`, `_safe_json` in `job_queue.py`) that catches `JSONDecodeError`/`TypeError`, logs a warning with a context tag, and returns `None` / a supplied default.

- **`redis_state.py`**: `load_regime`, `load_ensemble_consensus`, `get_events`, `get_vault_snapshots`, `get_trace` (both the direct-hash and UUID lookups), and `list_traces`. List reads drop the malformed entry and keep the good ones; single-value reads return `None`.
- **`job_queue.py`**: `JobStore.get` and `list_recent_jobs` `payload`/`result` fields fall back to their defaults (`{}` / `None`) so the job still lists. (`list_events` was already guarded — left as-is.)

Storage format is unchanged.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/services/test_redis_json_guard.py -q
```

Tests push deliberately-malformed bytes through a mocked async Redis client and assert a graceful `None`/default/skip rather than a raise, plus the pure-helper behavior.

## Anti-goals

- Storage format unchanged.
- Already-guarded sites (`job_queue.list_events`) left untouched.