### PR TITLE
[backend] Escape arXiv metadata in rendered exec'd module — code injection (#920)

### DIFF
--- a/backend/archimedes/services/arxiv_pipeline.py
+++ b/backend/archimedes/services/arxiv_pipeline.py
@@ -190,6 +190,23 @@ _ALLOWED_FREQ = {"daily", "weekly", "monthly"}
 _ALLOWED_PROFILES = {"conservative", "moderate", "aggressive", "hyper_risky"}
 
 
+def _doc_safe(v: object) -> str:
+    """Escape a value for safe *literal* inclusion in a docstring or ``"..."`` string.
+
+    The rendered module is ``exec_module``'d downstream (analytics-engine
+    ``strategy_loader``), so unescaped quotes/backslashes/newlines in
+    attacker-controlled arXiv metadata (a paper ``title`` / ``arxiv_id``) could
+    break out of the enclosing string and execute arbitrary code (#920). Escape
+    backslashes first, then every double-quote (so no run can form or terminate
+    a ``\"\"\"`` docstring), and collapse CR/LF to spaces (a raw newline would
+    break the single-line ``CURATOR_NOTE`` literal). Legit metadata — which has
+    none of these — passes through unchanged. The repr()-based ``lit()`` path
+    for the PAPER_* constants is already injection-safe; this guards only the
+    human-readable prose that is interpolated as raw text.
+    """
+    return str(v).replace("\\", "\\\\").replace('"', '\\"').replace("\r", " ").replace("\n", " ")
+
+
 def render_strategy_module(meta: PaperMeta, synth: dict, *, extraction_llm: str) -> str:
     """Emit Python the LocalStrategyProvider AST reader can parse.
 
@@ -209,9 +226,13 @@ def render_strategy_module(meta: PaperMeta, synth: dict, *, extraction_llm: str)
     def lit(v: object) -> str:
         return repr(v)
 
-    return f'''"""LLM-extracted strategy — {meta.title}
+    title = _doc_safe(meta.title)
+    arxiv_id = _doc_safe(meta.arxiv_id)
+    extraction_llm_s = _doc_safe(extraction_llm)
 
-AUTO-GENERATED from arXiv:{meta.arxiv_id} by {extraction_llm}.
+    return f'''"""LLM-extracted strategy — {title}
+
+AUTO-GENERATED from arXiv:{arxiv_id} by {extraction_llm_s}.
 This is a CANDIDATE passport, NOT validated alpha. A human curator must
 review it and it must pass the selection-bias gate (DSR / PBO / walk-forward
 OOS / look-ahead) before promotion to VALIDATED. The strategy body below is
@@ -244,7 +265,7 @@ PAPER_CLAIMED_MAX_DD = {lit(synth.get("paper_claimed_max_dd"))}
 EXTRACTION_LLM = {lit(extraction_llm)}
 CURATOR_WALLET = None
 CURATOR_NOTE = (
-    "LLM-extracted from arXiv:{meta.arxiv_id}. Passport only — requires human "
+    "LLM-extracted from arXiv:{arxiv_id}. Passport only — requires human "
     "curation and the selection-bias admission gate before it can go LIVE."
 )
 

--- a/backend/tests/services/test_arxiv_render_injection.py
+++ b/backend/tests/services/test_arxiv_render_injection.py
@@ -1,0 +1,64 @@
+"""Security tests for arxiv_pipeline.render_strategy_module (#920).
+
+The rendered module is later exec_module'd by the analytics-engine strategy
+loader, so any attacker-controlled arXiv metadata (a malicious paper title or
+id) interpolated raw into the module docstring / CURATOR_NOTE literal would be
+a remote code-execution vector. These tests render a module from hostile
+metadata and prove the injection does NOT execute.
+"""
+
+from __future__ import annotations
+
+from archimedes.services.arxiv_pipeline import PaperMeta, _doc_safe, render_strategy_module
+
+
+def _render(title: str, arxiv_id: str = "1234.5678") -> str:
+    meta = PaperMeta(
+        arxiv_id=arxiv_id,
+        title=title,
+        authors=["A. Author"],
+        abstract="abstract",
+        year=2020,
+        doi=None,
+    )
+    return render_strategy_module(meta, {"asset_universe": ["SPY"]}, extraction_llm="test-model")
+
+
+def test_doc_safe_neutralizes_triple_quotes_and_backslashes():
+    out = _doc_safe('"""\nimport os\n"""')
+    assert '"""' not in out.replace('\\"', "")  # every quote escaped
+    assert "\n" not in out  # newlines collapsed
+
+
+def test_malicious_title_does_not_execute_on_exec():
+    # A title that tries to close the docstring and define a global.
+    payload = '"""\nINJECTED_BY_TITLE = 1\n"""'
+    source = _render(payload)
+
+    compile(source, "<rendered>", "exec")  # must be syntactically valid
+    ns: dict = {}
+    exec(source, ns)
+
+    assert "INJECTED_BY_TITLE" not in ns, "docstring breakout executed injected code"
+    # repr()-based constant round-trips the original title exactly.
+    assert ns["PAPER_TITLE"] == payload
+
+
+def test_malicious_arxiv_id_does_not_break_curator_note():
+    # An id trying to break out of the CURATOR_NOTE "..." literal.
+    payload = '"; INJECTED_BY_ID = 1; "'
+    source = _render("Benign Title", arxiv_id=payload)
+
+    compile(source, "<rendered>", "exec")
+    ns: dict = {}
+    exec(source, ns)
+
+    assert "INJECTED_BY_ID" not in ns, "CURATOR_NOTE breakout executed injected code"
+    assert ns["PAPER_ARXIV_ID"] == payload
+    assert "CURATOR_NOTE" in ns and payload in ns["CURATOR_NOTE"]
+
+
+def test_benign_metadata_unchanged():
+    # Legitimate metadata (no quotes/backslashes/newlines) passes through.
+    assert _doc_safe("Time Series Momentum") == "Time Series Momentum"
+    assert _doc_safe("2211.01234") == "2211.01234"


### PR DESCRIPTION
## Summary

Closes #920. `arxiv_pipeline.render_strategy_module` interpolated the paper **title**, **arxiv_id**, and **extraction LLM** raw into the generated module's docstring and its `CURATOR_NOTE` string literal. The rendered file is later `exec_module`'d by the analytics-engine strategy loader (`strategy_loader.py`), so a paper title such as:

```
"""
import os; os.system("…")
"""
```

would close the docstring and execute arbitrary code — a remote code-execution vector triggered by a malicious arXiv publication.

## Change

Added `_doc_safe()`: escapes backslashes, escapes **every** double-quote (so no run can form or terminate a `"""` docstring), and collapses CR/LF to spaces (a raw newline would break the single-line `CURATOR_NOTE` literal). Applied to the title/arxiv_id/extraction_llm docstring interpolations and to the `CURATOR_NOTE` arxiv_id.

The `repr()`-based `lit()` path for the `PAPER_*` constants was already injection-safe (Python's `repr` always emits a valid literal) and is unchanged. Legit metadata — which contains none of these characters — passes through untouched, so the AST `literal_eval` reader still recovers every constant.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/services/test_arxiv_render_injection.py -q
```

Tests render a module from a hostile title (`"""\nINJECTED_BY_TITLE = 1\n"""`) and a hostile arxiv_id, `exec` the result, and assert the injected sentinel never enters the namespace while `PAPER_TITLE`/`PAPER_ARXIV_ID` round-trip exactly.

## Anti-goals

- The arXiv extraction feature is unchanged.
- The AST-`literal_eval` constant contract (`PAPER_*`) is preserved.