### PR TITLE
[contracts] Enforce a 1h price-freshness window on SyntheticVault mint/burn

### DIFF
--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -60,7 +60,16 @@ contract PriceOracle is Ownable {
     /// @notice Timestamp of the last price update
     uint256 public lastUpdated;
 
-    /// @notice Maximum age before stale (24 hours — hackathon testnet, Circle daily limit)
+    /// @notice Maximum age before the admin-fed price is stale (24 hours —
+    ///         hackathon testnet, Circle daily push limit).
+    /// @dev    TESTNET/HACKATHON TRADEOFF — MUST be tightened before mainnet.
+    ///         24h is deliberately loose so NAV, deposits and withdrawals never
+    ///         brick between the (currently daily) admin price pushes. It is far
+    ///         too loose for value-moving operations: SyntheticVault.mint/burn
+    ///         enforce their own tighter `mintBurnMaxStaleness` (default 1h) so a
+    ///         stale admin price can't be arbitraged (#910). On mainnet, wire a
+    ///         Chainlink feed (guarded by the 1h `feedStaleness` heartbeat) and
+    ///         drop this window to match.
     uint256 public constant MAX_STALENESS = 24 hours;
 
     /// @notice Address allowed to push price updates (e.g. Circle wallet)

--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -33,6 +33,16 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     /// @notice Accumulated protocol fees in USDC (6 decimals)
     uint256 public protocolFees;
 
+    /// @notice Max age of the oracle price accepted by mint/burn (default 1h).
+    ///         The PriceOracle's admin fallback tolerates a price up to
+    ///         MAX_STALENESS (24h) so NAV/deposits never brick, but mint and burn
+    ///         MOVE value at that price — trusting a stale one is the classic
+    ///         stale-price arbitrage (mint cheap / burn rich against an old admin
+    ///         price, #910). mint/burn therefore enforce this tighter window.
+    ///         Owner-tunable within (0, oracle.MAX_STALENESS()] as an operational
+    ///         escape hatch; the safe default matches the 1h feed heartbeat.
+    uint256 public mintBurnMaxStaleness = 1 hours;
+
     uint256 public constant BPS = 10000;
     uint256 public constant SYNTH_DECIMALS = 18;
 
@@ -46,11 +56,17 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     ///         (collateral C < liability L). `grossValue` is the uncapped current-price
     ///         claim; `cappedValue` is the C/L-scaled payout (haircut = gross - capped).
     event RedemptionHaircut(address indexed user, uint256 grossValue, uint256 cappedValue);
+    /// @notice Emitted when the owner retunes the mint/burn price-freshness window.
+    event MintBurnMaxStalenessUpdated(uint256 oldValue, uint256 newValue);
 
     // ─── Errors ──────────────────────────────────────────────────────
 
     error ZeroAmount();
     error InsufficientCollateral();
+    /// @notice mint/burn were called with an oracle price older than mintBurnMaxStaleness.
+    error StaleOraclePrice();
+    /// @notice setMintBurnMaxStaleness given 0 or a value above oracle.MAX_STALENESS().
+    error InvalidStaleness();
 
     // ─── Constructor ─────────────────────────────────────────────────
 
@@ -70,6 +86,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     /// @notice Mint synth tokens by depositing USDC.
     function mint(uint256 amountUsdc) external nonReentrant returns (uint256) {
         if (amountUsdc == 0) revert ZeroAmount();
+        _requireFreshOraclePrice();
 
         uint256 assetPrice = oracle.getPrice();
         uint256 fee = (amountUsdc * mintFeeBps) / BPS;
@@ -123,6 +140,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     ///        identical to the pre-fix path: full current-price value, minus burn fee.
     function burn(uint256 synthAmount) external nonReentrant returns (uint256) {
         if (synthAmount == 0) revert ZeroAmount();
+        _requireFreshOraclePrice();
 
         uint256 assetPrice = oracle.getPrice();
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
@@ -174,12 +192,25 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         return (usdcValue, false);
     }
 
+    /// @dev Reverts if the oracle price is older than `mintBurnMaxStaleness`.
+    ///      Guards the value-moving paths (mint/burn and their previews) against
+    ///      the stale-price arbitrage in #910. Keyed on the admin `lastUpdated`
+    ///      timestamp — the live source on this testnet, which has no Chainlink
+    ///      feed wired. NAV/health views (totalCollateral, vaultCollateralization)
+    ///      deliberately skip this so a merely-stale price can't brick reads.
+    function _requireFreshOraclePrice() internal view {
+        if (block.timestamp > oracle.lastUpdated() + mintBurnMaxStaleness) {
+            revert StaleOraclePrice();
+        }
+    }
+
     // ─── Views ───────────────────────────────────────────────────────
 
     /// @notice Mirror mint()'s zero-amount guards exactly so callers can rely on
     ///         previewMint to detect inputs that would revert before submitting a tx.
     function previewMint(uint256 amountUsdc) external view returns (uint256 synthAmount) {
         if (amountUsdc == 0) revert ZeroAmount();
+        _requireFreshOraclePrice();
         uint256 assetPrice = oracle.getPrice();
         uint256 fee = (amountUsdc * mintFeeBps) / BPS;
         uint256 netUsdc = amountUsdc - fee;
@@ -188,6 +219,7 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     }
 
     function previewBurn(uint256 synthAmount) external view returns (uint256) {
+        _requireFreshOraclePrice();
         uint256 assetPrice = oracle.getPrice();
         uint256 usdcValue = (synthAmount * assetPrice) / (10 ** SYNTH_DECIMALS);
 
@@ -219,6 +251,16 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         require(newRatio >= BPS, "ratio must be >= 100%");
         emit CollateralRatioUpdated(collateralRatio, newRatio);
         collateralRatio = newRatio;
+    }
+
+    /// @notice Retune the mint/burn price-freshness window (#910). Bounded to
+    ///         (0, oracle.MAX_STALENESS()]: 0 would brick mint/burn, and accepting
+    ///         a price staler than the oracle itself serves makes no sense. The
+    ///         default is 1h; loosen only if the price-push cadence forces it.
+    function setMintBurnMaxStaleness(uint256 newMaxStaleness) external onlyOwner {
+        if (newMaxStaleness == 0 || newMaxStaleness > oracle.MAX_STALENESS()) revert InvalidStaleness();
+        emit MintBurnMaxStalenessUpdated(mintBurnMaxStaleness, newMaxStaleness);
+        mintBurnMaxStaleness = newMaxStaleness;
     }
 
     function collectFees() external onlyOwner {

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -609,4 +609,104 @@ contract SyntheticVaultTest is Test {
 
         assertEq(usdc.balanceOf(address(vault)), vaultBalBefore + amount);
     }
+
+    // ─── Mint/burn price-freshness guard (#910) ───────────────────
+
+    function test_mint_burn_default_staleness_is_one_hour() public view {
+        assertEq(vault.mintBurnMaxStaleness(), 1 hours);
+    }
+
+    function test_mint_succeeds_when_price_fresh() public {
+        // Price is set within the window (setUp seeded it this block).
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 out = vault.mint(usdcAmount);
+        vm.stopPrank();
+        assertGt(out, 0);
+    }
+
+    function test_revert_mint_when_price_stale() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        // Past the 1h mint/burn window but still inside the oracle's 24h admin
+        // window, so getPrice() would happily return the old price — this is the
+        // exact arbitrage window mint must refuse.
+        vm.warp(block.timestamp + 2 hours);
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        vm.expectRevert(SyntheticVault.StaleOraclePrice.selector);
+        vault.mint(usdcAmount);
+        vm.stopPrank();
+    }
+
+    function test_revert_burn_when_price_stale() public {
+        // Mint fresh, then let the price go stale before burning.
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synth = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 2 hours);
+        vm.prank(alice);
+        vm.expectRevert(SyntheticVault.StaleOraclePrice.selector);
+        vault.burn(synth);
+    }
+
+    function test_burn_succeeds_after_fresh_price_push() public {
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        uint256 synth = vault.mint(usdcAmount);
+        vm.stopPrank();
+
+        // Price goes stale, then the oracle is refreshed — burn works again.
+        vm.warp(block.timestamp + 2 hours);
+        vm.prank(owner);
+        oracle.setPrice(INITIAL_PRICE + 1_000_000); // fresh push, small deviation
+        vm.prank(alice);
+        uint256 usdcOut = vault.burn(synth);
+        assertGt(usdcOut, 0);
+    }
+
+    function test_previewMint_reverts_when_price_stale() public {
+        vm.warp(block.timestamp + 2 hours);
+        vm.expectRevert(SyntheticVault.StaleOraclePrice.selector);
+        vault.previewMint(10_000 * 10**6);
+    }
+
+    function test_setMintBurnMaxStaleness_updates_window() public {
+        vm.prank(owner);
+        vault.setMintBurnMaxStaleness(6 hours);
+        assertEq(vault.mintBurnMaxStaleness(), 6 hours);
+
+        // A 2h-old price now passes the loosened window.
+        vm.warp(block.timestamp + 2 hours);
+        uint256 usdcAmount = 10_000 * 10**6;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), usdcAmount);
+        assertGt(vault.mint(usdcAmount), 0);
+        vm.stopPrank();
+    }
+
+    function test_revert_setMintBurnMaxStaleness_zero() public {
+        vm.prank(owner);
+        vm.expectRevert(SyntheticVault.InvalidStaleness.selector);
+        vault.setMintBurnMaxStaleness(0);
+    }
+
+    function test_revert_setMintBurnMaxStaleness_above_oracle_max() public {
+        // Read the constant BEFORE the prank so vm.prank applies to the
+        // setMintBurnMaxStaleness call, not the MAX_STALENESS() read.
+        uint256 tooBig = oracle.MAX_STALENESS() + 1;
+        vm.prank(owner);
+        vm.expectRevert(SyntheticVault.InvalidStaleness.selector);
+        vault.setMintBurnMaxStaleness(tooBig);
+    }
+
+    function test_revert_setMintBurnMaxStaleness_non_owner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        vault.setMintBurnMaxStaleness(2 hours);
+    }
 }

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -29,13 +29,63 @@ export const publicClient = createPublicClient({
 // Keyed by rdns (reverse-DNS identifier the wallet self-declares).
 const eip6963Providers = new Map()
 
+// ── Live account/chain-change listeners (EIP-6963-aware) ──────────────────
+// Providers we've already bound change-listeners to. WeakSet dedups so a
+// re-announcement doesn't stack duplicate handlers, and lets GC reclaim
+// providers we never keep.
+const _listenerBoundProviders = new WeakSet()
+let _lastSeenChainId = null
+
+// Bound per-provider so the ACTIVE wallet drives session state regardless of
+// whether it is window.ethereum (injected EOA) or an EIP-6963 provider
+// (Rabby/Brave/…) whose object is NOT window.ethereum (#921). Every handler
+// no-ops unless the event's provider is the one connectWallet selected
+// (_provider), so an announced-but-inactive wallet can't hijack the session.
+function _onAccountsChanged(provider, accounts) {
+  if (provider !== _provider) return
+  if (!accounts?.length) {
+    disconnectWallet()
+    window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: null } }))
+    return
+  }
+  _address = accounts[0]
+  if (_providerId) saveWalletMeta(_providerId, _address)
+  _walletClient = createWalletClient({ account: _address, chain: arcTestnet, transport: custom(provider) })
+  window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: _address } }))
+}
+
+function _onChainChanged(provider, newChainId) {
+  if (provider !== _provider) return
+  // Coinbase Wallet (Chrome) re-emits chainChanged on internal lifecycle
+  // events (tab sync, popup re-open) even when the chain hasn't changed; the
+  // previous handler reloaded on every emit → infinite reload loop. Track the
+  // last-seen chain id and react only to actual transitions. viem clients are
+  // pinned to arcTestnet at construction, so no rebuild is needed — just notify.
+  if (newChainId === _lastSeenChainId) return
+  _lastSeenChainId = newChainId
+  window.dispatchEvent(new CustomEvent('wallet-chain-changed', { detail: { chainId: newChainId } }))
+}
+
+function attachWalletListeners(provider) {
+  if (!provider?.on || _listenerBoundProviders.has(provider)) return
+  _listenerBoundProviders.add(provider)
+  provider.on('accountsChanged', (accounts) => _onAccountsChanged(provider, accounts))
+  provider.on('chainChanged', (chainId) => _onChainChanged(provider, chainId))
+}
+
 if (typeof window !== 'undefined') {
   window.addEventListener('eip6963:announceProvider', (event) => {
     const detail = event.detail
     if (detail?.info?.rdns && detail?.provider) {
       eip6963Providers.set(detail.info.rdns, detail)
+      // Attach change-listeners to every announced provider so account/chain
+      // switches in a non-window.ethereum wallet are detected (#921).
+      attachWalletListeners(detail.provider)
     }
   })
+  // Injected EOAs still expose window.ethereum — bind it too (deduped if it is
+  // also announced via EIP-6963, since it's the same provider object).
+  if (window.ethereum) attachWalletListeners(window.ethereum)
   // Ask wallets that loaded before this listener was attached to re-announce.
   window.dispatchEvent(new Event('eip6963:requestProvider'))
 }
@@ -507,39 +557,9 @@ export function getAvailableProviders() {
   return [...passkey, ...filtered, ...discovered]
 }
 
-// Listen for account/chain changes from the wallet extension
-if (typeof window !== 'undefined' && window.ethereum) {
-  window.ethereum.on?.('accountsChanged', (accounts) => {
-    if (!accounts?.length) {
-      disconnectWallet()
-      window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: null } }))
-    } else {
-      _address = accounts[0]
-      if (_providerId) saveWalletMeta(_providerId, _address)
-      if (_provider) {
-        _walletClient = createWalletClient({
-          account: _address,
-          chain: arcTestnet,
-          transport: custom(_provider),
-        })
-      }
-      window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: _address } }))
-    }
-  })
-  // Coinbase Wallet (Chrome) re-emits chainChanged on internal lifecycle
-  // events — tab sync, popup re-open, multi-tab state sync — even when
-  // the chain hasn't changed. The previous handler reloaded on every
-  // emit, which produced an infinite reload loop on Chrome + Coinbase.
-  // Track the last-seen chain id and only react to actual transitions.
-  // viem clients are pinned to arcTestnet at construction so we don't
-  // need to rebuild them; just notify any consumer that wants to know.
-  let _lastChainId = null
-  window.ethereum.on?.('chainChanged', (newChainId) => {
-    if (newChainId === _lastChainId) return
-    _lastChainId = newChainId
-    window.dispatchEvent(new CustomEvent('wallet-chain-changed', { detail: { chainId: newChainId } }))
-  })
-}
+// Account/chain-change listeners are attached at module load via
+// attachWalletListeners() — bound to window.ethereum AND every EIP-6963
+// announced provider (see the top of this file, #921).
 
 // ─── ABIs (minimal, just what we need) ──────────────────────
 


### PR DESCRIPTION
## Summary

`SyntheticVault` mint/burn trusted a price up to 24 hours stale. `PriceOracle.getPrice()`'s admin fallback uses `MAX_STALENESS = 24 hours`, and the conservative 1h `feedStaleness` heartbeat only guards the Chainlink feed path — which the testnet doesn't have wired. mint and burn move value at the oracle price, so a stale admin price is a classic arbitrage: mint synth cheap when the market has moved up, or burn it for more USDC than the collateral is worth when it's moved down.

## Scope

- `contracts/src/SyntheticVault.sol` — mint/burn (and their previews) + a new freshness window.
- `contracts/src/PriceOracle.sol` — documentation on the 24h window.
- `contracts/test/SyntheticVault.t.sol` — new tests.

## What changed

- Added `mintBurnMaxStaleness` (default `1 hours`) and a `_requireFreshOraclePrice()` guard at the top of `mint`, `burn`, `previewMint`, and `previewBurn`. If the oracle's admin price is older than the window, they revert `StaleOraclePrice`. NAV/health views (`totalCollateral`, `vaultCollateralization`) deliberately keep the looser oracle window so reads never brick.
- The window is owner-tunable via `setMintBurnMaxStaleness`, bounded to `(0, oracle.MAX_STALENESS()]` — an operational escape hatch if the price-push cadence forces it, with a safe 1h default.
- Kept `PriceOracle.MAX_STALENESS = 24 hours` (tightening it globally would brick NAV/deposits between the currently-daily admin pushes and affects the `Vault` too), and documented it as a testnet tradeoff that must be tightened — and moved to a Chainlink feed — before mainnet.
- The freshness check keys on the admin `lastUpdated` timestamp, which is the live price source on this testnet (no feed). The doc comment notes this must be revisited to use the effective feed freshness once a Chainlink feed is wired.

## Verify

```
cd contracts && forge test
```

New tests cover: default window is 1h; mint/burn succeed when fresh; both revert `StaleOraclePrice` when the price is 2h old (inside the oracle's 24h window but past the mint/burn window); burn works again after a fresh push; `previewMint` reverts when stale; and the setter's update path + bounds + owner-only guard. All 235 contract tests pass.

## Review + deploy note

This touches a live contract, so it needs Dan's approval as contract owner with Bogdan (`mnemonik-dev`) as the two-eyes reviewer, and a redeploy of `SyntheticVault` — please do not merge on backend sign-off alone. The cached ABI in `contracts/abis/` isn't regenerated here; that belongs with the redeploy. Nothing on the live backend/UI calls the new functions, so there's no off-chain change riding on this.

## Anti-goals

- The oracle architecture is unchanged.
- `MAX_STALENESS` is not lowered (that would brick NAV/deposits and the `Vault`).

Fixes #910
