### PR TITLE
[backend] Fix swap-quote amount conversion float64 precision loss (#922)

### DIFF
--- a/backend/archimedes/api/swap_routes.py
+++ b/backend/archimedes/api/swap_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from decimal import Decimal
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 
@@ -14,6 +15,18 @@ from archimedes.services.log_scrubber import sanitize_log_value
 logger = logging.getLogger(__name__)
 
 swap_router = APIRouter(prefix="/api/swap", tags=["swap"])
+
+
+def _to_token_raw(amount: float, decimals: int) -> int:
+    """Convert a human amount to integer base units without float64 precision loss.
+
+    ``int(amount * 10**decimals)`` runs the multiply in float64 (~15–16 significant
+    digits), so it loses integer precision for large amounts (e.g. 1e9 tokens at 18
+    decimals lands ~2e13 off) and can truncate sub-unit amounts to 0. Route through
+    ``Decimal`` on the float's shortest round-trip string so the multiply is exact
+    and only the final ``int()`` truncates to whole base units (#922).
+    """
+    return int(Decimal(str(amount)) * (Decimal(10) ** decimals))
 
 
 def _known_token_meta(address: str) -> tuple[str, int]:
@@ -60,7 +73,7 @@ async def get_swap_quote(
         router = loader.amm_router
         decimals_in = await _token_decimals(token_in)
         decimals_out = await _token_decimals(token_out)
-        amount_in_raw = int(amount_in * 10**decimals_in)
+        amount_in_raw = _to_token_raw(amount_in, decimals_in)
 
         amount_out_raw = await router.functions.getAmountOut(
             chain_client.to_checksum(token_in),

--- a/backend/tests/test_swap_quote_precision.py
+++ b/backend/tests/test_swap_quote_precision.py
@@ -1,0 +1,32 @@
+"""Precision tests for swap-quote amount conversion (#922).
+
+`int(amount_in * 10**decimals)` runs the multiply in float64 and loses integer
+precision for large amounts (and truncates sub-unit amounts). The Decimal-based
+`_to_token_raw` must be exact.
+"""
+
+from __future__ import annotations
+
+from archimedes.api.swap_routes import _to_token_raw
+
+
+def test_large_amount_is_exact_not_float_rounded():
+    # The float path `int(1e9 * 10**18)` lands ~1.3e13 off; Decimal is exact.
+    assert _to_token_raw(1e9, 18) == 10**27
+    assert _to_token_raw(1e9, 18) != int(1e9 * 10**18)
+
+
+def test_typical_usdc_amount():
+    assert _to_token_raw(100.0, 6) == 100_000_000
+    assert _to_token_raw(1234.56, 6) == 1_234_560_000
+
+
+def test_sub_unit_amount_floors_to_whole_base_units():
+    # 1.5 base units → floor to 1 (not lost to a float artifact).
+    assert _to_token_raw(0.0000015, 6) == 1
+    # Genuinely below one base unit → 0 (correct: below token resolution).
+    assert _to_token_raw(0.0000004, 6) == 0
+
+
+def test_eighteen_decimal_fractional_amount_exact():
+    assert _to_token_raw(1.5, 18) == 1_500_000_000_000_000_000


### PR DESCRIPTION
## Summary

Closes #922. `get_swap_quote` computed `amount_in_raw = int(amount_in * 10**decimals_in)`. The multiply runs in float64 (~15–16 significant digits), so it loses integer precision for large amounts — a `1e9`-token quote at 18 decimals lands ~1.3e13 base units off (`1000000000000000013287555072` vs `10**27`) — and can truncate sub-unit amounts to `0`.

## Change

Added `_to_token_raw(amount, decimals)` which routes through `Decimal` on the float's shortest round-trip string (`Decimal(str(amount)) * Decimal(10)**decimals`), so the multiply is exact and only the final `int()` truncates to whole base units. `get_swap_quote` now calls it. (`one_unit_raw = 10**decimals_in` was already an exact int and is unchanged.)

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_swap_quote_precision.py -q
```

Asserts `_to_token_raw(1e9, 18) == 10**27` (and `!= int(1e9 * 10**18)`), typical USDC amounts, and sub-unit flooring.

## Anti-goals

- The AMM router call path and response shape are unchanged.