### PR TITLE
[chain] Fail rebalance on oracle-price gap; skip zero-value SELL legs (#923)

### DIFF
--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -34,6 +34,15 @@ class InsufficientLiquidityError(RuntimeError):
     """Raised when an AMM pool's USDC reserve is below MIN_HEALTHY_LIQUIDITY_USDC."""
 
 
+class OraclePriceUnavailableError(RuntimeError):
+    """Raised when a synth's oracle price can't be read for a SELL sizing (#923).
+
+    The old behavior fell back to a 1:1 ($1) price, which on a high-priced synth
+    (e.g. sSPY ≈ $600) meant ordering ~price× too many units — bleeding the vault.
+    Failing the rebalance is the safe choice: no trade beats a grossly mis-sized one.
+    """
+
+
 class TradeRevertedError(RuntimeError):
     """Raised when a submitted rebalance transaction reverts on-chain (status 0).
 
@@ -226,11 +235,28 @@ class ChainExecutor:
                 tokens_in.append(token_addr)
                 amounts_in.append(int(trade.amount * 1e6))
             else:
-                # SELL: amount is USDC value → convert to token raw amount via oracle price
+                # SELL: amount is USDC value → convert to token raw amount via oracle price.
+                # Guard a zero/sub-cent estimated value (#923): estimated_usdc_value is
+                # rounded to 2dp upstream, so a sub-cent leg arrives as 0.00 and would
+                # size to 0 units. Skip it rather than submit a no-op 0-unit SELL.
+                if trade.estimated_usdc_value <= 0:
+                    logger.warning(
+                        "Skipping SELL leg for %s: estimated_usdc_value=%s (zero/sub-cent) — nothing to sell",
+                        token_addr,
+                        trade.estimated_usdc_value,
+                    )
+                    continue
                 token_raw = await self._usdc_value_to_token_raw(
                     token_addr,
                     trade.estimated_usdc_value,
                 )
+                if token_raw <= 0:
+                    logger.warning(
+                        "Skipping SELL leg for %s: $%.4f priced to 0 raw units",
+                        token_addr,
+                        trade.estimated_usdc_value,
+                    )
+                    continue
                 tokens_out.append(token_addr)
                 amounts_out.append(token_raw)
 
@@ -752,17 +778,29 @@ class ChainExecutor:
                 try:
                     oracle = loader.oracle_for(sym)
                     price_raw = await oracle.functions.price().call()  # 6 decimals
-                    price_usd = price_raw / 1e6  # e.g. 592.40 for sSPY
-                    if price_usd > 0:
-                        token_amount = usdc_value / price_usd
-                        return int(token_amount * 1e18)  # synths have 18 decimals
                 except Exception as e:
-                    logger.warning(f"Oracle price lookup failed for {sym}: {e}")
-                    break
+                    # Do NOT fall back to a 1:1 ($1) price (#923): on a high-priced
+                    # synth (sSPY ≈ $600) that orders ~price× too many units and
+                    # bleeds the vault. Fail the rebalance instead.
+                    logger.error("Oracle price lookup failed for %s (%s) — failing rebalance: %s", sym, addr, e)
+                    raise OraclePriceUnavailableError(
+                        f"Cannot size SELL for {sym}: oracle price read failed ({e})"
+                    ) from e
+                price_usd = price_raw / 1e6  # e.g. 592.40 for sSPY
+                if price_usd <= 0:
+                    logger.error(
+                        "Oracle returned non-positive price for %s (raw=%s) — failing rebalance", sym, price_raw
+                    )
+                    raise OraclePriceUnavailableError(
+                        f"Cannot size SELL for {sym}: oracle price is non-positive ({price_raw})"
+                    )
+                token_amount = usdc_value / price_usd
+                return int(token_amount * 1e18)  # synths have 18 decimals
 
-        # Fallback: treat as 18-decimal token, estimate at $1
-        logger.warning(f"No oracle for {token_address[:10]}, estimating 1:1 USDC for SELL amount")
-        return int(usdc_value * 1e18)
+        # No oracle wired for this token: refuse to guess a 1:1 price (#923) —
+        # a mis-sized SELL is worse than a failed rebalance.
+        logger.error("No oracle for %s — failing rebalance (was: 1:1 USDC estimate)", token_address[:10])
+        raise OraclePriceUnavailableError(f"No oracle configured for token {token_address} — cannot size SELL")
 
     # ─── Helpers ───────────────────────────────────────────────────
 

--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -16,6 +16,7 @@ from archimedes.chain.executor import (
     MIN_HEALTHY_LIQUIDITY_USDC,
     ChainExecutor,
     InsufficientLiquidityError,
+    OraclePriceUnavailableError,
     TradeRevertedError,
     VaultCreationRevertedError,
 )
@@ -726,19 +727,21 @@ class TestUsdcValueToTokenRaw:
         # $100 / $500 = 0.2 tokens × 1e18
         assert result == 200_000_000_000_000_000  # 0.2 × 1e18
 
-    def test_fallback_on_oracle_failure(self, executor, mock_loader):
-        """Oracle failure → fallback 1:1 at 18 decimals."""
+    def test_oracle_failure_raises_not_1to1(self, executor, mock_loader):
+        """Oracle failure must FAIL the rebalance, not fall back to a 1:1 ($1) price (#923).
+
+        The old 1:1 fallback ordered ~price× too many units on a high-priced synth.
+        """
         mock_oracle = mock_loader.oracle_for.return_value
         mock_oracle.functions.price.return_value.call = AsyncMock(side_effect=RuntimeError("oracle down"))
 
-        result = asyncio.run(executor._usdc_value_to_token_raw("0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388", 5.0))
-        # Fallback: 5 × 1e18
-        assert result == 5_000_000_000_000_000_000
+        with pytest.raises(OraclePriceUnavailableError):
+            asyncio.run(executor._usdc_value_to_token_raw("0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388", 5.0))
 
-    def test_unknown_token_fallback(self, executor):
-        """Unknown token address → fallback 1:1 at 18 decimals."""
-        result = asyncio.run(executor._usdc_value_to_token_raw("0x0000000000000000000000000000000000099999", 1.0))
-        assert result == 1_000_000_000_000_000_000  # 1 × 1e18
+    def test_unknown_token_raises_not_1to1(self, executor):
+        """Unknown token (no oracle) must raise, not guess a 1:1 ($1) price (#923)."""
+        with pytest.raises(OraclePriceUnavailableError):
+            asyncio.run(executor._usdc_value_to_token_raw("0x0000000000000000000000000000000000099999", 1.0))
 
 
 # ── InsufficientLiquidityError ────────────────────────────────

--- a/backend/tests/chain/test_executor_oracle_guards.py
+++ b/backend/tests/chain/test_executor_oracle_guards.py
@@ -1,0 +1,101 @@
+"""Executor SELL-sizing guards (#923).
+
+Two failure modes fixed:
+  1. `_usdc_value_to_token_raw` fell back to a 1:1 ($1) price on an oracle read
+     error / missing oracle — on a high-priced synth that orders ~price× too
+     many units. It must now FAIL the rebalance instead.
+  2. A SELL leg with a zero/sub-cent `estimated_usdc_value` (rounded to 2dp
+     upstream) sized to 0 units; it must be skipped, not submitted.
+
+Hermetic: the loader / oracle / circle signer are mocked; no chain access.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.executor import ChainExecutor, OraclePriceUnavailableError
+from archimedes.models.portfolio import TradeDirection, TradeOrder
+
+USDC = "0x3600000000000000000000000000000000000000"
+SYNTH = "0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388"  # sSPY-style synth
+VAULT = "0x1111111111111111111111111111111111111111"
+
+
+def _executor(*, price_raw=None, oracle_raises=False) -> ChainExecutor:
+    loader = MagicMock()
+    price_call = MagicMock()
+    price_call.call = (
+        AsyncMock(side_effect=Exception("RPC down")) if oracle_raises else AsyncMock(return_value=price_raw)
+    )
+    oracle = MagicMock()
+    oracle.functions.price = MagicMock(return_value=price_call)
+    loader.oracle_for = MagicMock(return_value=oracle)
+    return ChainExecutor(loader=loader)
+
+
+def _patch_settings():
+    settings = MagicMock()
+    settings.usdc_address = USDC
+    settings.synth_addresses = {"sSPY": SYNTH}
+    cc = MagicMock()
+    cc.settings = settings
+    return patch("archimedes.chain.executor.chain_client", cc)
+
+
+@pytest.mark.asyncio
+async def test_valid_oracle_price_sizes_correctly():
+    executor = _executor(price_raw=600_000_000)  # $600.00, 6 decimals
+    with _patch_settings():
+        # $600 of a $600 synth → 1.0 unit → 1e18 raw (18 decimals).
+        raw = await executor._usdc_value_to_token_raw(SYNTH, 600.0)
+    assert raw == 10**18
+
+
+@pytest.mark.asyncio
+async def test_oracle_read_error_raises_not_1to1():
+    executor = _executor(oracle_raises=True)
+    with _patch_settings(), pytest.raises(OraclePriceUnavailableError):
+        # Old behavior returned int(60000 * 1e18) = 60000 units of a $600 asset.
+        await executor._usdc_value_to_token_raw(SYNTH, 60_000.0)
+
+
+@pytest.mark.asyncio
+async def test_non_positive_oracle_price_raises():
+    executor = _executor(price_raw=0)
+    with _patch_settings(), pytest.raises(OraclePriceUnavailableError):
+        await executor._usdc_value_to_token_raw(SYNTH, 100.0)
+
+
+@pytest.mark.asyncio
+async def test_missing_oracle_raises_not_1to1():
+    executor = _executor(price_raw=600_000_000)
+    unknown = "0x9999999999999999999999999999999999999999"  # not in synth_addresses
+    with _patch_settings(), pytest.raises(OraclePriceUnavailableError):
+        await executor._usdc_value_to_token_raw(unknown, 60_000.0)
+
+
+@pytest.mark.asyncio
+async def test_zero_value_sell_leg_is_skipped_not_sized():
+    executor = _executor(price_raw=600_000_000)
+    executor._validate_trade_liquidity = AsyncMock()  # no-op liquidity preflight
+    executor._confirm_receipt = AsyncMock(return_value="0xconfirmed")
+    sizing_spy = AsyncMock(wraps=executor._usdc_value_to_token_raw)
+    executor._usdc_value_to_token_raw = sizing_spy
+
+    sell_zero = TradeOrder(
+        symbol="sSPY",
+        token_address=SYNTH,
+        direction=TradeDirection.SELL,
+        amount=0.0,
+        estimated_usdc_value=0.0,  # sub-cent leg rounded to 0.00
+    )
+
+    with _patch_settings(), patch("archimedes.chain.executor.circle_signer") as cs:
+        cs.is_configured = True
+        cs.execute_contract = AsyncMock(return_value="0xhash")
+        await executor.execute_trades(VAULT, [sell_zero])
+
+    # The zero-value SELL leg is skipped before sizing — never sent as 0 units.
+    sizing_spy.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #923. Two SELL-sizing hazards in the rebalance executor:

1. **Unsafe 1:1 oracle fallback.** `_usdc_value_to_token_raw` fell back to a 1:1 ($1) price on an oracle read error *or* a missing oracle. On a high-priced synth (sSPY ≈ $600) that orders ~`price`× too many units — e.g. a $60k SELL becomes 60,000 units instead of ~100 — bleeding the vault.
2. **Zero-value SELL legs.** `estimated_usdc_value` is rounded to 2dp upstream, so a sub-cent SELL leg arrives as `0.00` and sized to 0 units.

## Changes

- `_usdc_value_to_token_raw` now raises a new `OraclePriceUnavailableError` on oracle read failure, a non-positive price, or a missing oracle — the rebalance fails loudly instead of submitting a grossly mis-sized SELL. (USDC-itself and healthy-oracle paths are unchanged.)
- `execute_trades` skips a SELL leg whose `estimated_usdc_value <= 0` (or that prices to 0 raw units) with a warning, instead of submitting a no-op 0-unit SELL.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/chain/ -q
```

New `test_executor_oracle_guards.py`: valid price sizes correctly; oracle error / non-positive / missing-oracle raise `OraclePriceUnavailableError`; zero-value SELL is skipped before sizing. The two prior tests that asserted the old 1:1 fallback were updated to assert the new fail-closed contract.

## Notes / review

- Chain-layer (Python) change in Dan's lane — **no Solidity touched**.
- Adjacent to #925 (skip a fully-empty rebalance tx): both touch `execute_trades`, so expect a small merge conflict; they're complementary.

## Anti-goals

- Healthy-oracle sizing and the USDC-itself path are unchanged.