### PR TITLE
[chain] Skip empty rebalance tx when only cash legs remain (#925)

### DIFF
--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -234,6 +234,14 @@ class ChainExecutor:
                 tokens_out.append(token_addr)
                 amounts_out.append(token_raw)
 
+        # Nothing left to swap once the cash/USDC legs are filtered out (or a
+        # rebalance that was cash-only to begin with). Submitting an all-empty
+        # rebalance([],[],[],[]) still costs gas and publishes a REBALANCE trace
+        # that never moved a position, so skip the tx entirely (issue #925).
+        if not tokens_in and not tokens_out:
+            logger.info(f"SKIP rebalance for {vault_address}: no non-cash legs after filtering")
+            return []
+
         # Circle path
         if circle_signer.is_configured:
             # Convert address[] and uint256[] to ABI-compatible strings

--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -289,10 +289,10 @@ class TestExecuteTradesDepth:
     path uses str. Both must be tested.
     """
 
-    def test_empty_trades_no_amm_calls(self, executor, mock_loader):
-        """Empty trades list — _validate_trade_liquidity sees no synth legs,
-        so no AMM getPool calls fire. The rebalance() invocation does
-        proceed with empty arrays (current behavior — not short-circuited).
+    def test_empty_trades_skips_tx(self, executor, mock_loader):
+        """Empty trades list — no synth legs to swap, so the executor skips the
+        rebalance tx entirely rather than submitting rebalance([],[],[],[])
+        (issue #925). No AMM getPool calls and no signer call fire.
         """
         with (
             patch.object(executor, "_confirm_receipt", new=AsyncMock(return_value="0xtxhash")),
@@ -301,11 +301,13 @@ class TestExecuteTradesDepth:
             mock_signer.is_configured = True
             mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
             result = asyncio.run(executor.execute_trades("0xvault", []))
-            assert result == ["0xtxhash"]
+            assert result == []
+            mock_signer.execute_contract.assert_not_called()
             mock_loader.amm_router.functions.getPool.assert_not_called()
 
-    def test_all_usdc_legs_filtered_no_pool_calls(self, executor, mock_loader):
-        """All-USDC trades filtered out (#399) — no AMM `getPool` invocations."""
+    def test_all_usdc_legs_filtered_skips_tx(self, executor, mock_loader):
+        """All-USDC (cash) trades filtered out (#399) — nothing left to swap, so
+        no AMM `getPool` calls and no rebalance tx is submitted (issue #925)."""
         usdc_trade = _make_trade(
             symbol="USDC",
             token_address="0x3600000000000000000000000000000000000000",
@@ -316,8 +318,10 @@ class TestExecuteTradesDepth:
         ):
             mock_signer.is_configured = True
             mock_signer.execute_contract = AsyncMock(return_value="0xtxhash")
-            asyncio.run(executor.execute_trades("0xvault", [usdc_trade]))
-            # _validate_trade_liquidity should have seen an empty list after filtering
+            result = asyncio.run(executor.execute_trades("0xvault", [usdc_trade]))
+            # Cash-only rebalance is skipped: empty result, no swap lookups, no tx.
+            assert result == []
+            mock_signer.execute_contract.assert_not_called()
             mock_loader.amm_router.functions.getPool.assert_not_called()
 
     def test_sell_direction_calls_usdc_value_to_token_raw(self, executor, mock_loader):


### PR DESCRIPTION
Closes #925.

## The problem

`execute_trades` drops USDC/cash-denominated legs (issue #399 — there is no USDC/USDC pool to swap through). But when that filter leaves nothing (a cash-only rebalance, or every leg mapped to cash), it still built and submitted `rebalance([],[],[],[])`. That costs gas, and on the caller side it publishes a REBALANCE reasoning trace for a rebalance that never moved a single position.

## The fix

After the leg arrays are built, if both `tokens_in` and `tokens_out` are empty, log a `SKIP` and return `[]` without submitting a tx. The short-circuit sits above both the Circle and raw-key paths, so neither submits.

## Tests

- `test_empty_trades_skips_tx` — empty trades → `[]`, no signer call, no getPool.
- `test_all_usdc_legs_filtered_skips_tx` — a single cash (USDC) leg → `[]`, no signer call.

Both previously pinned the old always-submit behavior; updated to the new skip semantics.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/chain/test_chain_executor.py -q   # 37 passed
```