### PR TITLE
[backend] Return 422 on malformed /stress/run allocations (#926)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1392,8 +1392,34 @@ async def run_stress_test(payload: dict, request: Request, response: Response): 
     allocations = payload.get("allocations") or []
     if not isinstance(allocations, list) or not allocations:
         raise HTTPException(status_code=400, detail="allocations[] is required")
+
+    # Validate each allocation's shape before handing it to the stress engine.
+    # stress_one indexes ``a["symbol"]`` and does ``float(a.get("weight") or 0.0)``,
+    # so a missing symbol (KeyError) or a non-numeric weight (ValueError) would
+    # otherwise surface as an opaque 500. Reject those as a 422 client error
+    # instead (issue #926). ``usdc_weight`` per-element is not consumed by the
+    # engine (it is the top-level field below), so it is not required here.
+    for i, a in enumerate(allocations):
+        if not isinstance(a, dict):
+            raise HTTPException(status_code=422, detail=f"allocations[{i}] must be an object")
+        sym = a.get("symbol")
+        if not isinstance(sym, str) or not sym.strip():
+            raise HTTPException(
+                status_code=422,
+                detail=f"allocations[{i}].symbol is required and must be a non-empty string",
+            )
+        w = a.get("weight")
+        if w is not None:
+            try:
+                float(w)
+            except (TypeError, ValueError):
+                raise HTTPException(status_code=422, detail=f"allocations[{i}].weight must be a number") from None
+
     scenario = payload.get("scenario", "all")
-    usdc_weight = float(payload.get("usdc_weight") or 0.0)
+    try:
+        usdc_weight = float(payload.get("usdc_weight") or 0.0)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=422, detail="usdc_weight must be a number") from None
 
     if scenario == "all":
         results = stress_all(allocations, usdc_weight=usdc_weight)

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -225,6 +225,41 @@ async def test_strategies_stress_run_has_rate_limit():
 
 
 @pytest.mark.asyncio
+async def test_stress_run_missing_symbol_is_422():
+    """POST /stress/run with an allocation missing `symbol` → 422, not 500 (#926)."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/strategies/stress/run", json={"allocations": [{"weight": 0.1}]})
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+    assert "symbol" in resp.json().get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_stress_run_non_numeric_weight_is_422():
+    """A non-numeric `weight` is a client error (422), not a server 500 (#926)."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/strategies/stress/run",
+            json={"allocations": [{"symbol": "sTSLA", "weight": "not-a-number"}]},
+        )
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+    assert "weight" in resp.json().get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_stress_run_non_dict_allocation_is_422():
+    """A non-object allocation element → 422, not 500 (#926)."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/strategies/stress/run", json={"allocations": ["sTSLA"]})
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+@pytest.mark.asyncio
 async def test_swap_quote_has_rate_limit():
     """GET /api/swap/quote has rate limiting decorator."""
     from archimedes.api.swap_routes import get_swap_quote


### PR DESCRIPTION
Closes #926.

## The problem

`POST /api/strategies/stress/run` 500s on a malformed `allocations` element. The stress engine indexes `a["symbol"]` (KeyError on a missing symbol) and does `float(a.get("weight") or 0.0)` (ValueError on a non-numeric weight). Both bubbled up as an opaque 500.

## The fix

Validate each allocation's shape before handing it to the engine, and return a **422** with a field-specific message on failure:
- element must be an object
- `symbol` required, non-empty string
- `weight`, if present, must be `float()`-able (numeric strings like `"0.1"` still accepted, matching the engine's own tolerance)

The top-level `usdc_weight` float conversion is guarded too. Per-element `usdc_weight` is **not** required — the engine never reads it (allocations are `{symbol, weight, asset_class}`; `usdc_weight` is the top-level field), so requiring it would reject valid advisor output.

## Tests

- `test_stress_run_missing_symbol_is_422` — `{"allocations":[{"weight":0.1}]}` → 422 (the acceptance case).
- `test_stress_run_non_numeric_weight_is_422` — `weight: "not-a-number"` → 422.
- `test_stress_run_non_dict_allocation_is_422` — `allocations: ["sTSLA"]` → 422.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_security_hardening.py -q   # 23 passed
```