### PR TITLE
[backend] Guard math.isnan on non-numeric price-series elements in /explore/assets (#928)

### DIFF
--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -434,7 +434,12 @@ class AssetMarketService:
             # Convert Series to a plain list for downstream math.
             raw_hist = histories.get(synth)
             if raw_hist is not None and hasattr(raw_hist, "tolist"):
-                hist_prices = [float(v) for v in raw_hist.tolist() if not math.isnan(v)]
+                # An object-dtype series (a feed gap, a mixed column) can hold
+                # None or other non-numbers. math.isnan() raises TypeError on a
+                # non-float, which previously aborted the entire /explore/assets
+                # response over one bad element — guard the type and drop those
+                # instead of dropping the whole universe (#928).
+                hist_prices = [float(v) for v in raw_hist.tolist() if isinstance(v, (int, float)) and not math.isnan(v)]
             elif isinstance(raw_hist, dict):
                 hist_prices = raw_hist.get("close") or []
             else:

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -228,6 +228,36 @@ class TestListAssets:
         assert spy.is_stale is False  # displayed price is fresh; only the unused oracle slot is empty
 
     @pytest.mark.asyncio
+    async def test_list_assets_survives_none_in_price_series(self):
+        """A None in a raw (object-dtype) price series must not abort the whole
+        /explore/assets response — the bad element is dropped, the card still
+        renders (#928). Uses dtype=object so the None stays a None (a float64
+        series would coerce it to NaN, which math.isnan handles fine and would
+        not reproduce the TypeError this guards against)."""
+        import pandas as pd
+
+        service = AssetMarketService()
+        bad_series = pd.Series([540.0, None, 548.0], dtype=object)
+
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch.object(
+                service,
+                "_fetch_histories_budgeted",
+                AsyncMock(return_value={"sSPY": bad_series}),
+            ),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sSPY"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sSPY": ("SPY", "SPY", "us_equity_etf", "NYSE")},
+            ),
+        ):
+            resp = await service.list_assets()  # must not raise TypeError
+
+        spy = next((a for a in resp.assets if a.symbol == "sSPY"), None)
+        assert spy is not None  # card served, not dropped by a single bad element
+
+    @pytest.mark.asyncio
     async def test_cache_ttl(self):
         """Second call within TTL returns cached result."""
         service = AssetMarketService()


### PR DESCRIPTION
Closes #928.

## The problem

`list_assets` builds each asset's price history with:
```python
hist_prices = [float(v) for v in raw_hist.tolist() if not math.isnan(v)]
```
On an object-dtype series that holds a `None` (a gap in the yfinance feed, a mixed-type column), `math.isnan(None)` raises `TypeError: must be real number, not NoneType`. There's no try/except around the build loop, so a single bad element aborted the whole `/explore/assets` response — the user saw an error instead of the universe.

## The fix

Guard the element type before `math.isnan`:
```python
hist_prices = [float(v) for v in raw_hist.tolist() if isinstance(v, (int, float)) and not math.isnan(v)]
```
Non-numeric elements (and NaN) are dropped; the rest of the series — and every other asset — still renders.

## Test

`test_list_assets_survives_none_in_price_series` feeds a `pd.Series([540.0, None, 548.0], dtype=object)` and asserts the response still returns the card. Verified it **fails with `TypeError` on `main`** and passes with the fix. (dtype=object is load-bearing — a float64 series coerces `None`→`NaN`, which `math.isnan` handles fine and would not reproduce the bug.)

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_asset_market_service.py -q   # 21 passed
```