### PR TITLE
[backend] Treat a future oracle updated_at as stale (#934)

### DIFF
--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -332,7 +332,13 @@ class AssetMarketService:
                     timeout=max(0.1, min(_ORACLE_READ_TIMEOUT, remaining)),
                 )
                 price_usd = float(price_raw) / 1e6  # 6 decimals per PriceOracle.sol
-                stale = (now_ts - updated_at) > _STALE_WINDOW_SECONDS
+                # A future updated_at (block time ahead of the host clock) is
+                # anomalous: normal block timestamps are ≤ wall clock, and a
+                # timestamp in the future would leave the age permanently
+                # negative — masking genuine staleness forever. Treat any
+                # future timestamp as stale rather than "fresh" (#934).
+                age = now_ts - updated_at
+                stale = age < 0 or age > _STALE_WINDOW_SECONDS
                 results[symbol] = {
                     "price": price_usd,
                     "updated_at": updated_at,

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -119,6 +119,29 @@ class TestOracleReads:
         assert result["sSPY"]["stale"] is True
 
     @pytest.mark.asyncio
+    async def test_read_oracle_prices_future_timestamp_stale(self, mock_chain_client):
+        """An updated_at ahead of the host clock reads as stale, not fresh (#934).
+
+        A future block timestamp otherwise leaves (now_ts - updated_at) negative
+        forever, so a frozen price could never trip the staleness gate."""
+        future_ts = time.time() + 1  # 1 second in the future
+        service = AssetMarketService()
+
+        mock_contract = MagicMock()
+        mock_contract.functions.getPrice.return_value.call = AsyncMock(
+            return_value=(100_000_000, int(future_ts) + 1),  # ceil past now to stay in the future
+        )
+        mock_client_w3 = MagicMock()
+        mock_client_w3.eth.contract.return_value = mock_contract
+        mock_chain_client.w3 = mock_client_w3
+
+        with patch("archimedes.chain.client.chain_client", mock_chain_client):
+            result = await service._read_oracle_prices(["sSPY"])
+
+        assert "sSPY" in result
+        assert result["sSPY"]["stale"] is True
+
+    @pytest.mark.asyncio
     async def test_read_oracle_prices_missing_symbol(self, mock_chain_client):
         """Symbol not in oracle_addresses → skipped, not error."""
         service = AssetMarketService()


### PR DESCRIPTION
Closes #934.

## The problem

The oracle staleness check was `stale = (now_ts - updated_at) > _STALE_WINDOW_SECONDS` with no lower bound on the age. If the on-chain `updated_at` block timestamp is ahead of the backend host clock, the age goes negative, `negative > window` is false, and the price is served as `is_stale=False`. Worse, a timestamp far in the future leaves the age negative **forever**, so a frozen price could never trip the staleness gate.

## The fix

```python
age = now_ts - updated_at
stale = age < 0 or age > _STALE_WINDOW_SECONDS
```
Any future timestamp (age < 0) now reads as stale. Normal block timestamps are ≤ wall clock, so this only fires on the anomalous case it's meant to catch.

## Test

`test_read_oracle_prices_future_timestamp_stale` sets `updated_at` ~1s in the future and asserts `stale is True`. Verified it **fails on `main`** (`assert False is True`) and passes with the fix.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_asset_market_service.py -q   # 21 passed
```