### PR TITLE
[backend] Fail wallet-less generation quota CLOSED on Redis error (#929)

### DIFF
--- a/backend/archimedes/services/generation_quota.py
+++ b/backend/archimedes/services/generation_quota.py
@@ -26,10 +26,12 @@ Rigor + keying:
     would defeat a cookie-keyed cap. A sophisticated IP-rotating abuser is out of
     scope for this MVP cap (the slowapi + nginx limits remain the rate backstop).
 
-Fail-open: a Redis error returns "allowed" (logged at WARNING). Blocking every
-wallet-less generation during a Redis blip would be worse than the narrow abuse
-window, and the slowapi/nginx rate limits remain in force regardless. Set
-`WALLET_LESS_GENERATION_DAILY_CAP=0` to disable the cap (unlimited).
+Fail-closed: a Redis error returns "not allowed" (logged at WARNING) so the
+wallet-less LLM-spend cap can't be bypassed by inducing a cache blip (issue
+#929). This blocks only *wallet-less* generation during the outage —
+SIWE-authenticated callers bypass the cap entirely, so a wallet-connected user
+is never affected, and the blocked anonymous caller is steered to connect a
+wallet. Set `WALLET_LESS_GENERATION_DAILY_CAP=0` to disable the cap (unlimited).
 """
 
 from __future__ import annotations
@@ -114,9 +116,13 @@ class GenerationQuota:
         """Atomically count this wallet-less generation for ``ip`` today.
 
         Returns ``(allowed, used)`` where ``used`` is the count *after* this
-        attempt. ``allowed`` is ``used <= cap``. **Fails open** — a Redis error on
-        the INCR returns ``(True, 0)`` so a cache outage never blocks generation
-        (the slowapi/nginx rate limits remain the backstop).
+        attempt. ``allowed`` is ``used <= cap``. **Fails closed** — a Redis error
+        on the INCR returns ``(False, 0)`` so the wallet-less LLM-spend cap is not
+        silently bypassable during a cache outage (issue #929). This only affects
+        *wallet-less* callers: SIWE-authenticated callers bypass the cap entirely
+        (see ``enforce_generation_quota``), so a Redis blip can never block a
+        wallet-connected user — the blocked wallet-less caller is steered to
+        connect a wallet, which is the intended escape hatch.
         """
         try:
             r = await self._get_redis()
@@ -124,8 +130,8 @@ class GenerationQuota:
             key = f"archimedes:genquota:{day}:{ip}"
             count = await r.incr(key)
         except Exception as exc:
-            logger.warning("generation quota check failed for ip=%s — FAILING OPEN: %s", ip, exc)
-            return (True, 0)
+            logger.warning("generation quota check failed for ip=%s — FAILING CLOSED (spend cap held): %s", ip, exc)
+            return (False, 0)
 
         # TTL is BEST-EFFORT and must not discard the already-successful INCR.
         # ``EXPIRE ... NX`` sets the TTL only when the key has none, so it

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -1,7 +1,7 @@
 """Tests for the wallet-less generation quota (anti-abuse per-IP daily cap).
 
 Hermetic — mocks at the Redis boundary; tests the cap logic, the real-IP
-resolver, the 429 steering response, the authenticated bypass, and fail-open.
+resolver, the 429 steering response, the authenticated bypass, and fail-closed.
 """
 
 from __future__ import annotations
@@ -81,11 +81,12 @@ async def test_expire_failure_does_not_discard_count():
     assert allowed is False  # 6 > 5 still enforced
 
 
-async def test_check_fails_open_on_redis_error():
+async def test_check_fails_closed_on_redis_error():
+    # A Redis outage must NOT silently disable the wallet-less spend cap (#929).
     q = GenerationQuota()
     q._get_redis = AsyncMock(side_effect=ConnectionError("redis down"))
     allowed, used = await q.check_and_increment("1.2.3.4", 5)
-    assert allowed is True  # fail OPEN — never block on a cache outage
+    assert allowed is False  # fail CLOSED — cap held, not bypassed
     assert used == 0
 
 
@@ -193,6 +194,31 @@ async def test_enforce_raises_429_over_cap(monkeypatch):
     assert ei.value.detail["reason"] == "wallet_less_generation_cap"
     assert ei.value.detail["cap"] == 5
     assert "Connect a wallet" in ei.value.detail["message"]
+
+
+async def test_enforce_rejects_wallet_less_when_redis_down(monkeypatch):
+    # End-to-end fail-closed: a real GenerationQuota whose Redis is unreachable
+    # rejects the wallet-less caller with a 429 (the cap is not bypassed, #929).
+    monkeypatch.setenv("WALLET_LESS_GENERATION_DAILY_CAP", "5")
+    monkeypatch.setattr(
+        "archimedes.services.generation_quota.GenerationQuota._get_redis",
+        AsyncMock(side_effect=ConnectionError("redis down")),
+    )
+    with pytest.raises(HTTPException) as ei:
+        await enforce_generation_quota(_req({"x-real-ip": "1.1.1.1"}), wallet=None)
+    assert ei.value.status_code == 429
+
+
+async def test_enforce_still_allows_authenticated_wallet_when_redis_down(monkeypatch):
+    # The fail-closed cap must NOT affect a SIWE-authenticated caller — they
+    # bypass the cap before any Redis call, so a cache outage can't block them.
+    monkeypatch.setenv("WALLET_LESS_GENERATION_DAILY_CAP", "5")
+    monkeypatch.setattr(
+        "archimedes.services.generation_quota.GenerationQuota._get_redis",
+        AsyncMock(side_effect=ConnectionError("redis down")),
+    )
+    # No exception — wallet-connected user sails through.
+    await enforce_generation_quota(_req({"x-real-ip": "1.1.1.1"}), wallet="0x" + "a" * 40)
 
 
 # ─── daily_cap config ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #929.

## The problem

`GenerationQuota.check_and_increment` returned `(True, 0)` on any Redis error — failing **open**. The wallet-less LLM-spend cap therefore silently vanished during a Redis blip, and an abuser could induce one to bypass it. The slowapi/nginx limits are not a substitute: per #908 they key on the nginx upstream IP (one global bucket), so they don't bound per-caller wallet-less volume.

## The fix

Return `(False, 0)` on Redis error — fail **closed**, so an outage holds the cap instead of dropping it. This blocks only *wallet-less* callers during the outage: `enforce_generation_quota` returns early for a truthy `wallet` before any Redis call, so a SIWE-authenticated user is never affected, and the blocked anonymous caller gets the existing 429 that steers them to connect a wallet. Module + function docstrings rewritten to document the fail-closed posture.

## Tests

- `test_check_fails_closed_on_redis_error` — `(False, 0)` on Redis error (was the old fail-open test, flipped).
- `test_enforce_rejects_wallet_less_when_redis_down` — real quota, unreachable Redis, wallet-less → 429.
- `test_enforce_still_allows_authenticated_wallet_when_redis_down` — wallet-connected caller sails through even with Redis down.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_generation_quota.py -q   # 21 passed
```