### PR TITLE
[backend] Extract first text block from LLM responses, not content[0] (#930)

### DIFF
--- a/backend/archimedes/services/llm_backend.py
+++ b/backend/archimedes/services/llm_backend.py
@@ -69,6 +69,21 @@ def is_allowed_model(model: str | None) -> bool:
     return bool(model) and model in FREE_TIER_MODELS
 
 
+def _first_text_block(content) -> str:
+    """Return the first text block's text from an Anthropic-style content list.
+
+    The first block is not always text: with extended thinking or tool use the
+    response leads with a ``thinking``/``tool_use`` block that has no ``.text``
+    attribute, so ``content[0].text`` raises ``AttributeError`` (issue #930).
+    Iterate to the first block that actually carries text; return "" if none does.
+    """
+    for block in content or []:
+        text = getattr(block, "text", None)
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return ""
+
+
 class LLMBackend(Protocol):
     """Minimal text-completion seam consumed by architect + fusion."""
 
@@ -127,7 +142,7 @@ class AnthropicBackend:
         served = getattr(resp, "model", None)
         if served:
             self._served = str(served)
-        return resp.content[0].text.strip() if resp.content else ""
+        return _first_text_block(resp.content)
 
 
 # ── Anthropic-compatible (auth_token + base_url, e.g. GLM via z.ai) ──
@@ -178,7 +193,7 @@ class AnthropicCompatibleBackend:
         served = getattr(resp, "model", None)
         if served:
             self._served = str(served)
-        return resp.content[0].text.strip() if resp.content else ""
+        return _first_text_block(resp.content)
 
 
 # ── AWS Bedrock (IAM auth, no API key) ───────────────────────────────
@@ -244,7 +259,7 @@ class BedrockBackend:
         served = getattr(resp, "model", None)
         if served:
             self._served = str(served)
-        return resp.content[0].text.strip() if resp.content else ""
+        return _first_text_block(resp.content)
 
 
 # ── AWS Bedrock via the Converse API (uniform across ALL providers, IAM auth) ──

--- a/backend/tests/services/test_llm_backend_unification.py
+++ b/backend/tests/services/test_llm_backend_unification.py
@@ -263,6 +263,46 @@ def test_bedrock_backend_available_and_completes_with_mocked_client(monkeypatch)
         assert client.messages.create.call_args.kwargs["model"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
+class _ThinkingBlock:
+    """A leading response block with no ``.text`` (thinking/tool_use shape)."""
+
+    def __init__(self, thinking: str) -> None:
+        self.thinking = thinking
+
+
+class _TextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+def test_first_text_block_skips_non_text_and_handles_empty():
+    """_first_text_block returns the first block carrying real text, else "" (#930)."""
+    from archimedes.services.llm_backend import _first_text_block
+
+    assert _first_text_block([_ThinkingBlock("pondering"), _TextBlock("  hi  ")]) == "hi"
+    assert _first_text_block([_ThinkingBlock("only thinking")]) == ""  # no text block at all
+    assert _first_text_block([]) == ""
+    assert _first_text_block(None) == ""
+
+
+def test_bedrock_backend_skips_leading_thinking_block(monkeypatch):
+    """When the SDK response leads with a thinking block (no ``.text``), the backend
+    must iterate to the first real text block instead of AttributeError-ing on
+    ``content[0].text`` (#930)."""
+    monkeypatch.setenv("LLM_BEDROCK_MODEL", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    response = MagicMock()
+    response.content = [_ThinkingBlock("let me think"), _TextBlock("  ANSWER  ")]
+    response.model = "claude-haiku-4-5-20251001"
+    client = MagicMock()
+    client.messages.create.return_value = response
+
+    with patch.dict(sys.modules, {"boto3": _fake_boto3(object()), "anthropic": _fake_anthropic(client)}):
+        from archimedes.services.llm_backend import BedrockBackend
+
+        backend = BedrockBackend()
+        assert backend.complete("sys", "user") == "ANSWER"
+
+
 def test_make_llm_backend_selects_bedrock(monkeypatch):
     """LLM_PROVIDER=bedrock routes the factory to BedrockBackend (creds present)."""
     monkeypatch.setenv("LLM_PROVIDER", "bedrock")


### PR DESCRIPTION
Closes #930.

## The problem

Three SDK backends (`AnthropicBackend`, `AnthropicCompatibleBackend`, `BedrockBackend`) read `resp.content[0].text.strip()`, assuming the first content block is text. With extended thinking or tool use, the response leads with a `thinking`/`tool_use` block that has no `.text` attribute → `AttributeError` (or empty text). Only the Converse backend iterated correctly.

## The fix

A shared `_first_text_block(content)` helper iterates to the first block that carries real text (returns `""` if none), used in all three SDK backends.

## Tests

- `test_first_text_block_skips_non_text_and_handles_empty` — thinking-then-text, thinking-only, empty, None.
- `test_bedrock_backend_skips_leading_thinking_block` — SDK response with a leading thinking block → extracts the second block's text.

Verified both **fail on `main`** (AttributeError / ImportError) and pass with the fix.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_llm_backend_unification.py -q   # 18 passed
```