### PR TITLE
[backend] Build live-Sharpe NAV series from aum_usdc only (#931)

### DIFF
--- a/backend/archimedes/services/vault_monitor.py
+++ b/backend/archimedes/services/vault_monitor.py
@@ -45,8 +45,13 @@ def compute_sharpe_drift(
             "status": "INSUFFICIENT_DATA",
         }
 
-    # Compute period returns from AUM history (most-recent first in snapshots)
-    navs = [s.get("aum_usdc", 0) or s.get("share_price", 0) for s in reversed(aum_snapshots)]
+    # Compute period returns from AUM history (most-recent first in snapshots).
+    # Build the NAV series from aum_usdc ONLY. The old `aum_usdc or share_price`
+    # fallback mixed a ~50_000-scale series with a ~1.0-scale one, so a single
+    # snapshot with aum_usdc=0/null dropped to share_price≈1.0 and manufactured
+    # a spurious ±99.99% return that poisoned the live Sharpe/drift (issue #931).
+    # Skip snapshots without a usable positive aum_usdc instead.
+    navs = [aum for s in reversed(aum_snapshots) if isinstance((aum := s.get("aum_usdc")), (int, float)) and aum > 0]
     returns = [(navs[i] - navs[i - 1]) / navs[i - 1] for i in range(1, len(navs)) if navs[i - 1] > 0]
 
     if len(returns) < _MIN_SNAPSHOTS_FOR_SHARPE - 1:

--- a/backend/tests/test_vault_monitor.py
+++ b/backend/tests/test_vault_monitor.py
@@ -54,6 +54,22 @@ def test_zero_variance_aum_returns_insufficient():
     assert result["live_sharpe"] is None
 
 
+def test_zero_aum_snapshot_does_not_manufacture_return():
+    """A snapshot with aum_usdc=0 must be skipped, not dropped to share_price≈1.0
+    (issue #931). Otherwise a flat ~50_000 AUM series gains a spurious ±99.99%
+    round-trip that fabricates variance and a garbage live Sharpe.
+
+    Snapshots are most-recent-first; one carries aum_usdc=0 + share_price=1.0.
+    With the old fallback that becomes a 50_000→1→50_000 spike; skipping it
+    leaves the series flat → INSUFFICIENT_DATA (Sharpe undefined for zero var).
+    """
+    snaps = [{"aum_usdc": 50_000.0} for _ in range(20)]
+    snaps[5] = {"aum_usdc": 0, "share_price": 1.0}  # poison snapshot
+    result = compute_sharpe_drift(snaps, backtest_sharpe=1.0)
+    assert result["status"] == "INSUFFICIENT_DATA"
+    assert result["live_sharpe"] is None
+
+
 # ─── McLean-Pontiff decay floor ───────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #931.

## The problem

`compute_sharpe_drift` built its NAV series with `s.get("aum_usdc", 0) or s.get("share_price", 0)`, mixing a ~50_000-scale AUM series with a ~1.0-scale share-price series. A single snapshot with `aum_usdc=0`/null dropped to `share_price≈1.0`, so the return series gained a spurious 50_000→1→50_000 round-trip (±99.99%) that fabricated variance and produced a garbage live Sharpe / drift on the dashboard.

## The fix

Build the series from `aum_usdc` only, skipping snapshots without a usable positive value. No more scale-mixing.

## Test

`test_zero_aum_snapshot_does_not_manufacture_return` — an otherwise-flat 50_000 AUM series with one `aum_usdc=0, share_price=1.0` snapshot. With the fix the poison snapshot is skipped → flat series → `INSUFFICIENT_DATA`. Verified it **fails on `main`** (returns `NORMAL` off the fabricated variance) and passes with the fix.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_vault_monitor.py -q   # 12 passed
```