### PR TITLE
[backend] Gate SSE deployable on real-data grading, not just passing (#937)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -254,6 +254,24 @@ class _CandidateResult:
     universe_source: str = "full"
 
 
+def _is_deployable(c: _CandidateResult) -> bool:
+    """Whether a winning candidate is safe to advertise as deployable (issue #937).
+
+    ``passes_rigor`` alone is not enough: a candidate graded on the synthetic
+    fallback series (``evaluate_fusion_spec`` defaults to a random walk when no
+    ``data_feed`` is wired) can have ``passing=True`` yet is NOT admissible — its
+    verdict is not grounded in real data. Require BOTH the rigor pass AND
+    real-data grading, the same condition that gates real-returns persistence
+    (``_persist_real_returns``): ``has_real_rigor`` and a non-synthetic
+    ``data_source``. Otherwise the SSE ``deployable`` flag misrepresents rigor
+    status even though the server-side vault gate still fail-closes on deploy.
+    """
+    if not c.passes_rigor:
+        return False
+    rv = c.rigor_verdict or {}
+    return bool(c.has_real_rigor) and str(rv.get("data_source") or "synthetic") != "synthetic"
+
+
 # ── Rigor adapter (Önder's rigor_evaluator on agent output) ───────────────
 
 
@@ -960,9 +978,11 @@ async def run_generation(
             best_candidate_id=best.candidate_id,
             considered_count=len(candidates),
             validated_count=len(validated),
-            # deployable=False ⇒ no candidate cleared the rigor gate; the surfaced best is
-            # a considered alternative (ABSTAIN), not a validated, deployable winner.
-            deployable=best.passes_rigor,
+            # deployable=False ⇒ the surfaced best is a considered alternative (ABSTAIN),
+            # not a validated, deployable winner. This requires BOTH a rigor pass AND
+            # real-data grading — a synthetic-data-graded candidate can pass the gate but
+            # is not admissible, so it must not be advertised deployable (issue #937).
+            deployable=_is_deployable(best),
         )
 
         # K=1 persistence (Phase-3): only the WINNER becomes a library

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -19,10 +19,64 @@ from __future__ import annotations
 import numpy as np
 from archimedes.agents.generation_pipeline import (
     _CandidateResult,
+    _is_deployable,
     _patch_dsr_with_pool_correlation,
     _rigor_verdict_for,
     _society_num_trials,
 )
+
+
+def _deployability_candidate(*, passing: bool, has_real_rigor: bool, data_source: str) -> _CandidateResult:
+    """Minimal candidate to exercise the SSE deployable signal (#937)."""
+    return _CandidateResult(
+        candidate_id="c1",
+        strategy_name="S",
+        thesis="t",
+        asset_universe=["sSPY"],
+        source_papers=[],
+        weights={"sSPY": 1.0},
+        reasoning="r",
+        rigor_verdict={"passing": passing, "data_source": data_source},
+        passes_rigor=passing,
+        has_real_rigor=has_real_rigor,
+    )
+
+
+class TestDeployableSignal:
+    """deployable must be (passing AND real-data-graded), not just passing (#937)."""
+
+    def test_passing_on_real_data_is_deployable(self):
+        c = _deployability_candidate(passing=True, has_real_rigor=True, data_source="real")
+        assert _is_deployable(c) is True
+
+    def test_passing_on_synthetic_data_is_not_deployable(self):
+        # The bug: a synthetic-data-graded candidate can pass the gate but must
+        # not be advertised deployable.
+        c = _deployability_candidate(passing=True, has_real_rigor=True, data_source="synthetic")
+        assert _is_deployable(c) is False
+
+    def test_passing_without_real_rigor_is_not_deployable(self):
+        c = _deployability_candidate(passing=True, has_real_rigor=False, data_source="real")
+        assert _is_deployable(c) is False
+
+    def test_missing_data_source_defaults_to_synthetic_not_deployable(self):
+        c = _CandidateResult(
+            candidate_id="c1",
+            strategy_name="S",
+            thesis="t",
+            asset_universe=["sSPY"],
+            source_papers=[],
+            weights={"sSPY": 1.0},
+            reasoning="r",
+            rigor_verdict={"passing": True},  # no data_source key → treated as synthetic
+            passes_rigor=True,
+            has_real_rigor=True,
+        )
+        assert _is_deployable(c) is False
+
+    def test_failing_gate_is_never_deployable(self):
+        c = _deployability_candidate(passing=False, has_real_rigor=True, data_source="real")
+        assert _is_deployable(c) is False
 
 
 class TestSocietyNumTrialsFormula:


### PR DESCRIPTION
Closes #937.

## The problem

The `best_selected` SSE event emitted `deployable=best.passes_rigor`. But `rigor.passing` can be true while the candidate is not admissible — a candidate graded on the **synthetic fallback** series (`evaluate_fusion_spec` defaults to a random walk when no `data_feed` is wired) can pass the gate on data that isn't real. The server-side vault gate still fail-closes on deploy, so no actual deploy happens, but the UI misrepresented rigor status.

## The fix

New `_is_deployable(candidate)`: `passes_rigor` **AND** real-data grading — `has_real_rigor` and a non-synthetic `data_source`. This is the exact condition that gates real-returns persistence (`_persist_real_returns`), so the two now agree. `deployable=_is_deployable(best)`.

## Tests

`TestDeployableSignal` — passing+real → deployable; passing+synthetic → **not** deployable (the bug); passing+no-real-rigor → not; missing `data_source` (defaults synthetic) → not; failing gate → never.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_generation_pipeline.py -q   # 16 passed
```