### PR TITLE
[backend] Key paper_rag score map by dict identity, zero empty arxiv_ids (#938)

### DIFF
--- a/backend/archimedes/services/paper_rag.py
+++ b/backend/archimedes/services/paper_rag.py
@@ -385,13 +385,22 @@ def augment_candidate_scores(
         logger.warning("paper_rag: semantic rerank failed, keyword-only fallback: %s", exc)
         return [(c, 1.0) for c in candidates]
 
-    # Map back to original objects, preserving score
-    arxiv_to_score = {s[0]["arxiv_id"]: s[1] for s in scored}
+    # Map scores back to the original objects by paper-dict OBJECT IDENTITY, not
+    # by arxiv_id. Keying on arxiv_id let empty or duplicate ids collapse in the
+    # dict — a real candidate then fell through to the 0.5 default, which can
+    # outrank a genuinely-scored paper and reorder fusion pair selection (#938).
+    # semantic_rerank returns the same dict objects it was handed, one per input,
+    # so identity is a stable, collision-free key.
+    score_by_dict_id = {id(s[0]): s[1] for s in scored}
     result = []
-    for c in head:
-        aid = getattr(c, "arxiv_id", "")
-        score = arxiv_to_score.get(aid, 0.5)
-        result.append((c, score))
+    for c, paper_dict in zip(head, paper_dicts, strict=True):
+        aid = str(getattr(c, "arxiv_id", "") or "").strip()
+        if not aid:
+            # A candidate with no arxiv_id can't be provenance-tracked into a
+            # fusion pair — score it 0.0 so it can't outrank a real paper (#938).
+            result.append((c, 0.0))
+            continue
+        result.append((c, score_by_dict_id.get(id(paper_dict), 0.0)))
     # Tail candidates were not semantically scored; rank them below the head.
     for c in tail:
         result.append((c, 0.0))

--- a/backend/tests/test_paper_rag.py
+++ b/backend/tests/test_paper_rag.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 import types
 from unittest.mock import MagicMock, patch
 
-import numpy as np
-
 import archimedes.services.paper_rag as rag_module
+import numpy as np
 
 # Access all symbols via the module alias so monkeypatching the module-level
 # globals (e.g. rag_module._embedding_model) is always reflected in calls.

--- a/backend/tests/test_paper_rag.py
+++ b/backend/tests/test_paper_rag.py
@@ -360,3 +360,42 @@ class TestAugmentCandidateScores:
             with patch.object(rag_module, "_get_embedding_model", return_value=_fake_model()):
                 results = augment_candidate_scores("direction", candidates)
         assert all(s == 1.0 for _, s in results)
+
+    def test_empty_arxiv_ids_get_zero_not_default_promotion(self, monkeypatch):
+        """Candidates with empty arxiv_id must not ride the old 0.5 default above a
+        genuinely-scored paper — they get 0.0 and rank below it (#938)."""
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
+        c_real = self._make_candidate("2401.v1", "Volatility Portfolio")
+        c_empty1 = self._make_candidate("", "Mystery Paper A")
+        c_empty2 = self._make_candidate("", "Mystery Paper B")
+
+        # Every paper scores 0.3 — below the OLD 0.5 default that empty ids used to get.
+        def fake_rerank(query, papers, **kw):
+            return [(p, 0.3) for p in papers]
+
+        with patch.object(rag_module, "semantic_rerank", side_effect=fake_rerank):
+            results = augment_candidate_scores("volatility", [c_real, c_empty1, c_empty2])
+
+        empty_scores = [s for c, s in results if not c.arxiv_id]
+        assert empty_scores == [0.0, 0.0]  # not 0.5
+        real_score = next(s for c, s in results if c.arxiv_id == "2401.v1")
+        assert real_score == 0.3
+        assert results[0][0].arxiv_id == "2401.v1"  # real paper ranks first
+
+    def test_duplicate_arxiv_ids_each_keep_their_own_score(self, monkeypatch):
+        """Two candidates sharing an arxiv_id must not collapse to one score in the
+        map — each keeps its own semantic score (#938)."""
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
+        c1 = self._make_candidate("dup", "Paper One about momentum")
+        c2 = self._make_candidate("dup", "Paper Two about value")
+
+        # papers preserve head order, so papers[0] is c1's dict, papers[1] is c2's.
+        def fake_rerank(query, papers, **kw):
+            return [(papers[0], 0.9), (papers[1], 0.2)]
+
+        with patch.object(rag_module, "semantic_rerank", side_effect=fake_rerank):
+            results = augment_candidate_scores("x", [c1, c2])
+
+        by_title = {c.title: s for c, s in results}
+        assert by_title["Paper One about momentum"] == 0.9  # not collapsed to 0.2
+        assert by_title["Paper Two about value"] == 0.2


### PR DESCRIPTION
Closes #938.

## The problem

`augment_candidate_scores` mapped semantic scores back with `{s[0]["arxiv_id"]: s[1] for s in scored}`. Keying on `arxiv_id` meant empty or duplicate ids **collapsed** in the dict, so a real candidate fell through to the `0.5` default — which can outrank a genuinely-scored paper and reorder fusion pair selection.

## The fix

- Key the score map by paper-dict **object identity** (`id(s[0])`). `semantic_rerank` returns the same dict objects it was handed, one per input, so identity is a collision-free key — immune to empty/duplicate arxiv_ids.
- A candidate with a missing/empty `arxiv_id` scores **0.0** (it can't be provenance-tracked into a fusion pair, so it must not outrank a real paper). The unscored default is also lowered 0.5 → 0.0 for consistency with the tail treatment.

## Tests

- `test_empty_arxiv_ids_get_zero_not_default_promotion` — two empty-id candidates get 0.0, rank below the real paper.
- `test_duplicate_arxiv_ids_each_keep_their_own_score` — two candidates sharing an id each keep their own score (no collapse).

Both **fail on `main`** (collapse reproduced) and pass with the fix.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_paper_rag.py -q   # 26 passed
```