### PR TITLE
[backend] Document the non-standard Sortino downside convention + pin it (#952)

### DIFF
--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -264,7 +264,17 @@ def _annualized_metrics(daily_returns: list[float], equity_curve: list[float]) -
     sharpe = ((mu - RF_DAILY) / sigma) * np.sqrt(ANNUALIZATION) if sigma > 0 else 0.0
 
     downside = arr[arr < 0]
-    # RMS of negative returns (consistent with analytics-engine/engine.py Sortino)
+    # Sortino denominator = RMS of the NEGATIVE returns only, i.e. the divisor is
+    # the COUNT of downside observations, not the total N. This is a deliberate,
+    # non-standard convention ("downside-frequency-weighted"): the textbook
+    # Sortino & Price (1994) target-downside-deviation divides by total N (treating
+    # non-negative returns as zero deviation), which gives a larger denominator and
+    # a smaller ratio when downside days are sparse. We keep the count-of-negatives
+    # form so the metric matches analytics-engine/engine.py::_compute_sortino exactly
+    # (pinned there by test_sortino_rms_of_negatives_convention, and here by
+    # test_sortino_uses_rms_of_negatives_convention). Sortino is a reported metric
+    # only — it does NOT feed the rigor gate — so the convention has no bearing on
+    # strategy admission (#952).
     down_rms = float(np.sqrt(np.mean(downside**2))) if len(downside) > 0 else 0.0
     sortino = ((mu - RF_DAILY) / down_rms) * np.sqrt(ANNUALIZATION) if down_rms > 0 else 0.0
 

--- a/backend/tests/services/test_portfolio_backtester.py
+++ b/backend/tests/services/test_portfolio_backtester.py
@@ -8,6 +8,7 @@ so the suite stays offline + DB-free per pytest.ini's unit profile.
 
 from __future__ import annotations
 
+import math
 from datetime import date
 from unittest.mock import patch
 
@@ -190,6 +191,33 @@ class TestAnnualizedMetrics:
         assert m["cagr"] == 0.0
         m1 = _annualized_metrics([0.01], [100_000])
         assert m1["sharpe_ratio"] == 0.0
+
+    def test_sortino_uses_rms_of_negatives_convention(self) -> None:
+        """Pin the deliberate downside-frequency-weighted Sortino convention (#952):
+        the denominator is the RMS over the NEGATIVE returns only (divisor = count of
+        negatives), not the textbook total-N target-downside-deviation. Mirrors
+        analytics-engine/engine.py::test_sortino_rms_of_negatives_convention so the two
+        implementations stay verifiably identical."""
+        from archimedes.services.portfolio_backtester import RF_DAILY
+
+        rets = [0.05, -0.02, 0.03, -0.04]
+        eq = [100_000.0]
+        for r in rets:
+            eq.append(eq[-1] * (1 + r))
+
+        downside = [r for r in rets if r < 0]
+        dd_rms = math.sqrt(sum(r * r for r in downside) / len(downside))  # ÷ count of negatives
+        mean = sum(rets) / len(rets)
+        expected = ((mean - RF_DAILY) / dd_rms) * math.sqrt(ANNUALIZATION)
+
+        m = _annualized_metrics(rets, eq[1:])
+        assert m["sortino_ratio"] == pytest.approx(expected)
+
+        # And it must NOT equal the total-N (textbook) convention when downside days
+        # are sparse — proving the count-of-negatives divisor is the one in force.
+        dd_rms_total_n = math.sqrt(sum(r * r for r in downside) / len(rets))
+        textbook = ((mean - RF_DAILY) / dd_rms_total_n) * math.sqrt(ANNUALIZATION)
+        assert m["sortino_ratio"] != pytest.approx(textbook)
 
 
 class TestCorrelation:


### PR DESCRIPTION
Closes #952.

## Context

The Sortino denominator (`_annualized_metrics`) is the RMS over the **negative returns only** — divisor = count of negatives — not the textbook Sortino & Price (1994) total-N target-downside-deviation. The issue flags this as non-standard.

## Why document rather than change

This is a **deliberate, tested** convention, not a silent bug:
- It's shared verbatim with `analytics-engine/engine.py::_compute_sortino`, which pins it with an explicit test (`test_sortino_rms_of_negatives_convention`).
- `sortino_ratio` is a **reported metric only — it does not feed the rigor gate** (DSR / PBO / OOS Sharpe), so the convention has zero bearing on strategy admission.
- Changing it would diverge the two implementations and force a numeric shift with no admission benefit, overriding a deliberate team decision on a LOW cosmetic-definition issue.

Per the acceptance's "or document" option, I made the convention explicit instead:

- Expanded the comment to name it ("downside-frequency-weighted"), contrast it with the textbook total-N form, and note it's gate-irrelevant.
- Added `test_sortino_uses_rms_of_negatives_convention` mirroring the engine's test, so the backend convention is now pinned and provably identical to the engine's (and asserts it is *not* the total-N form when downside days are sparse).

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_portfolio_backtester.py -q   # 20 passed
```