### PR TITLE
[backend] Fail outcome embargo CLOSED on unparseable publish dates (#953)

### DIFF
--- a/backend/archimedes/services/embargo_filter.py
+++ b/backend/archimedes/services/embargo_filter.py
@@ -58,7 +58,10 @@ def apply_outcome_embargo(
     Returns
     -------
     list[dict]
-        Papers whose publication date is before ``at - embargo_days``.
+        Papers whose publication date is before ``at - embargo_days``. Papers
+        with a missing or unparseable ``published`` date are dropped (fail
+        closed) — their age can't be verified, so keeping them would risk a
+        look-ahead leak (#953).
     """
     if at is None:
         at = date.today()
@@ -69,10 +72,15 @@ def apply_outcome_embargo(
     for p in papers:
         pub = _parse_published(p.get("published", ""))
         if pub is None:
-            # Cannot determine age — keep (conservative: include rather
-            # than silently drop papers with missing dates).
-            logger.debug("embargo: paper %s has no parseable published date — keeping", p.get("arxiv_id", "?"))
-            result.append(p)
+            # Cannot determine age — DROP the paper (fail closed). Keeping it
+            # would let a too-recent paper with a missing/malformed date bypass
+            # the embargo, leaking future-outcome information into a backtest
+            # decision — the exact Oracle Fallacy this filter exists to prevent
+            # (#953). Look-ahead safety beats corpus completeness.
+            logger.warning(
+                "embargo: paper %s has no parseable published date — dropping (fail-closed)",
+                p.get("arxiv_id", "?"),
+            )
             continue
         if pub.toordinal() <= cutoff:
             result.append(p)

--- a/backend/tests/services/test_xia_protocols.py
+++ b/backend/tests/services/test_xia_protocols.py
@@ -44,13 +44,35 @@ class TestOutcomeEmbargo:
         result = apply_outcome_embargo(papers, at=date(2025, 10, 31), embargo_days=30)
         assert len(result) == 1
 
-    def test_missing_published_kept(self):
-        """Paper with no published date is kept (conservative)."""
+    def test_missing_published_dropped(self):
+        """Paper with no published date is DROPPED — fail closed (#953).
+
+        Its age can't be verified, so keeping it would let a too-recent paper
+        with a missing/malformed date bypass the embargo and leak look-ahead."""
         from archimedes.services.embargo_filter import apply_outcome_embargo
 
         papers = [{"arxiv_id": "no.date", "published": ""}]
         result = apply_outcome_embargo(papers, embargo_days=30)
-        assert len(result) == 1
+        assert result == []
+
+    def test_unparseable_published_dropped(self):
+        """A malformed (unparseable) published date is also dropped (#953)."""
+        from archimedes.services.embargo_filter import apply_outcome_embargo
+
+        papers = [{"arxiv_id": "bad.date", "published": "not-a-date"}]
+        result = apply_outcome_embargo(papers, at=date(2025, 11, 2), embargo_days=30)
+        assert result == []
+
+    def test_old_paper_kept_when_date_present(self):
+        """Fail-closed drop must NOT affect a paper with a valid, old-enough date."""
+        from archimedes.services.embargo_filter import apply_outcome_embargo
+
+        papers = [
+            {"arxiv_id": "old.ok", "published": "2025-01-01"},
+            {"arxiv_id": "no.date", "published": ""},
+        ]
+        result = apply_outcome_embargo(papers, at=date(2025, 11, 2), embargo_days=30)
+        assert [p["arxiv_id"] for p in result] == ["old.ok"]
 
     def test_default_embargo_30_days(self):
         """Default embargo is 30 days."""


### PR DESCRIPTION
Closes #953.

## The problem

`apply_outcome_embargo` kept papers whose `published` date was missing or unparseable — "conservative: include rather than silently drop." That's **fail-open**: a too-recent paper with a malformed date bypasses the embargo, leaking future-outcome information into a backtest decision (the Oracle Fallacy, Xia et al. 2026 §4.2, that this filter exists to prevent).

## The fix

Drop papers whose age can't be verified (fail **closed**); log at WARNING. Look-ahead safety beats corpus completeness. Papers with valid dates are unaffected.

## Tests

- `test_missing_published_dropped` — `published=""` → dropped (was the fail-open test, flipped).
- `test_unparseable_published_dropped` — `published="not-a-date"` → dropped.
- `test_old_paper_kept_when_date_present` — a valid old paper alongside a dateless one keeps only the valid one.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_xia_protocols.py -q   # 41 passed
```