### PR TITLE
[backend] Derive circle_service contract count + description from one list (#951)

### DIFF
--- a/backend/archimedes/services/circle_service.py
+++ b/backend/archimedes/services/circle_service.py
@@ -65,6 +65,23 @@ class CircleService:
         """Get comprehensive Circle integration status for the demo."""
         from archimedes.chain.client import chain_client
 
+        # Single source of truth for the deployed-contract list so the count and
+        # the human-readable description can never drift apart (#951 — the
+        # description said "10 contracts" beside a hardcoded count of 11).
+        deployed_contracts = [
+            "Vault",
+            "VaultFactory",
+            "AMMPool",
+            "AMMRouter",
+            "AssetRegistry",
+            "PriceOracle",
+            "ReasoningTraceRegistry",
+            "SyntheticFactory",
+            "SyntheticToken",
+            "SyntheticVault",
+            "StrategyRegistry",
+        ]
+
         # What we currently use
         tools_used = {
             "developer_controlled_wallets": {
@@ -75,21 +92,9 @@ class CircleService:
             },
             "smart_contracts": {
                 "status": "active",
-                "description": "10 contracts deployed on Arc testnet via Circle wallet",
-                "contracts": [
-                    "Vault",
-                    "VaultFactory",
-                    "AMMPool",
-                    "AMMRouter",
-                    "AssetRegistry",
-                    "PriceOracle",
-                    "ReasoningTraceRegistry",
-                    "SyntheticFactory",
-                    "SyntheticToken",
-                    "SyntheticVault",
-                    "StrategyRegistry",
-                ],
-                "count": 11,
+                "description": f"{len(deployed_contracts)} contracts deployed on Arc testnet via Circle wallet",
+                "contracts": deployed_contracts,
+                "count": len(deployed_contracts),
             },
             "usdc_settlement": {
                 "status": "active",

--- a/backend/tests/services/test_circle_service.py
+++ b/backend/tests/services/test_circle_service.py
@@ -146,7 +146,13 @@ class TestGetIntegrationStatus:
         # Was 10; updated to 11 after StrategyRegistry was added to the Arc-testnet
         # contract list (Issue #380 — Pi's `908cce9` bundle commit). Keep the assertion
         # explicit + commented so any future contract-count drift is caught here.
-        assert result["tools"]["smart_contracts"]["count"] == 11
+        sc = result["tools"]["smart_contracts"]
+        assert sc["count"] == 11
+        # count, the contract list length, and the number stated in the human-readable
+        # description must all agree — no hardcoded "10 contracts" beside a count of 11
+        # (#951). Deriving all three from one list is what keeps them in lock-step.
+        assert sc["count"] == len(sc["contracts"])
+        assert sc["description"] == f"{sc['count']} contracts deployed on Arc testnet via Circle wallet"
         assert result["tools"]["usdc_settlement"]["usdc_address"] == "0xUSDC"
         assert result["wallet"]["balance_usdc"] == "100"
         # `next_tools` + `rubric_score_estimate` were intentionally removed by Pi's


### PR DESCRIPTION
Closes #951.

## The problem

The Circle integration-status payload had `"description": "10 contracts deployed on Arc testnet…"` next to a hardcoded `"count": 11` and an 11-item contract list — a cosmetic claim mismatch (StrategyRegistry was added, bumping the real count to 11, but the description string was never updated).

## The fix

Pull the contract list into a single `deployed_contracts` variable and derive **both** `count` and the number in `description` from `len(deployed_contracts)`. They can't drift again.

## Test

Extended the existing inventory test to assert `count == len(contracts)` **and** that the description reads `f"{count} contracts deployed…"`.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_circle_service.py -q   # 10 passed
```