### PR TITLE
[backend] Mark fusion job FAILED, not done, when strategy persist fails (#948)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2054,6 +2054,7 @@ async def _run_fusion_job(job_id: str) -> None:
             }
 
         strategy_id = None
+        persist_error: str | None = None
         try:
             with get_session() as session:
                 source_papers = [{"arxiv_id": aid, "sha256": ""} for aid in result.source_arxiv_ids]
@@ -2071,8 +2072,13 @@ async def _run_fusion_job(job_id: str) -> None:
                 )
                 session.commit()
                 strategy_id = record.id
-        except Exception:
-            logger.debug("fusion strategy persist failed", exc_info=True)
+        except Exception as exc:
+            # Persist failure is NOT cosmetic: without a saved strategy_id there is
+            # no record for the "view" link to open, so the job must not be reported
+            # as a successful "done". Log at ERROR (was debug — the failure was
+            # silently swallowed) and mark the job failed below (#948).
+            persist_error = str(exc)
+            logger.error("fusion strategy persist failed for job %s", job_id, exc_info=True)
 
         try:
             import hashlib
@@ -2176,7 +2182,18 @@ async def _run_fusion_job(job_id: str) -> None:
             if eval_result.error:
                 job_result["eval_error"] = eval_result.error
 
-        await store.update_status(job_id, "done", result=job_result)
+        if strategy_id is None:
+            # The fusion produced an actionable strategy but it could not be saved,
+            # so there is nothing for the "view" link to open. Report the job as
+            # failed rather than a "done" job with a null strategy_id + dead link
+            # (#948). The proposal is still recorded in episodic memory below.
+            await store.update_status(
+                job_id,
+                "failed",
+                error=f"Strategy generated but could not be saved: {persist_error or 'persistence failed'}",
+            )
+        else:
+            await store.update_status(job_id, "done", result=job_result)
 
         # ── Persist fusion proposal to episodic memory (T-PE.8) ──
         try:

--- a/backend/tests/test_fusion_job_persist.py
+++ b/backend/tests/test_fusion_job_persist.py
@@ -1,0 +1,96 @@
+"""Fusion job persistence failure handling (#948).
+
+A fusion job that produces an actionable strategy but fails to PERSIST it must
+not be reported as a successful "done" job with a null strategy_id (which leaves
+the UI's "view" link dead). It must be marked "failed" instead.
+
+Hermetic: every boundary (job store, fusion runner, DB session, upsert) is
+mocked — no Redis, no DB, no LLM.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.api.strategies_routes import _run_fusion_job
+
+
+def _actionable_result() -> SimpleNamespace:
+    """A minimal actionable fusion result with strategy_spec=None (skips eval)."""
+    return SimpleNamespace(
+        is_actionable=True,
+        strategy_spec=None,  # skip the backtest/rigor evaluator branch
+        status="done",
+        strategy_name="Fused Strat",
+        thesis="thesis",
+        source_arxiv_ids=[],
+        fusion_reasoning="because",
+        novelty_rationale="novel",
+        risk_notes="risky",
+        model="nova-micro",
+        requested_model="nova-micro",
+    )
+
+
+def _mock_store() -> MagicMock:
+    store = MagicMock()
+    store.update_status = AsyncMock()
+    store.get = AsyncMock(return_value={"payload": {"risk_appetite": "moderate", "asset_classes": ["equities"]}})
+    store.close = AsyncMock()
+    return store
+
+
+@pytest.mark.asyncio
+async def test_persist_failure_marks_job_failed_not_done():
+    """upsert_strategy raising → job is marked 'failed', never 'done' (#948)."""
+    store = _mock_store()
+    fusion = MagicMock()
+    fusion.propose = MagicMock(return_value=_actionable_result())
+
+    with (
+        patch("archimedes.services.job_queue.JobStore", return_value=store),
+        patch("archimedes.agents.strategy_fusion.default_fusion", return_value=fusion),
+        patch("archimedes.db.get_session"),
+        patch(
+            "archimedes.models.strategy_store.upsert_strategy",
+            side_effect=RuntimeError("db down"),
+        ),
+    ):
+        await _run_fusion_job("job-123")
+
+    # Collect every (positional) status update the job received.
+    statuses = [call.args[1] for call in store.update_status.await_args_list if len(call.args) >= 2]
+    assert "done" not in statuses, f"job must NOT be marked done on persist failure; got {statuses}"
+    # The final status must be 'failed' with an explanatory error.
+    failed_calls = [c for c in store.update_status.await_args_list if len(c.args) >= 2 and c.args[1] == "failed"]
+    assert failed_calls, f"expected a 'failed' status update; got {statuses}"
+    assert "could not be saved" in (failed_calls[-1].kwargs.get("error") or "")
+
+
+@pytest.mark.asyncio
+async def test_persist_success_marks_job_done():
+    """When persistence succeeds, the job is marked 'done' with the strategy_id."""
+    store = _mock_store()
+    fusion = MagicMock()
+    fusion.propose = MagicMock(return_value=_actionable_result())
+
+    session_cm = MagicMock()
+    session_cm.__enter__ = MagicMock(return_value=MagicMock())
+    session_cm.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("archimedes.services.job_queue.JobStore", return_value=store),
+        patch("archimedes.agents.strategy_fusion.default_fusion", return_value=fusion),
+        patch("archimedes.db.get_session", return_value=session_cm),
+        patch(
+            "archimedes.models.strategy_store.upsert_strategy",
+            return_value=SimpleNamespace(id="strat-42"),
+        ),
+    ):
+        await _run_fusion_job("job-456")
+
+    done_calls = [c for c in store.update_status.await_args_list if len(c.args) >= 2 and c.args[1] == "done"]
+    assert done_calls, "expected a 'done' status update on successful persist"
+    assert done_calls[-1].kwargs["result"]["strategy_id"] == "strat-42"


### PR DESCRIPTION
Closes #948.

## The problem

In `_run_fusion_job`, a failed strategy persist was caught, logged at `debug`, and dropped. The job was then marked `"done"` with `strategy_id=None` — so the UI's "view" link pointed at a strategy that was never saved (dead link).

## The fix

- Capture the persist error and log at **ERROR** (was debug — it was silently swallowed).
- When `strategy_id is None` after the persist attempt, mark the job **"failed"** with `"Strategy generated but could not be saved: …"` instead of `"done"`. The proposal is still recorded in episodic memory; successful persist is unchanged.

## Tests

- `test_persist_failure_marks_job_failed_not_done` — `upsert_strategy` raises → job marked `failed`, never `done`. Verified it **fails on `main`** (job goes to `done`).
- `test_persist_success_marks_job_done` — happy path → `done` with the `strategy_id`.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_fusion_job_persist.py -q   # 2 passed
```