### PR TITLE
[contracts] Rate-limit consecutive forceSetPrice calls to block owner ratchet (#935)

### DIFF
--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -107,6 +107,16 @@ contract PriceOracle is Ownable {
     ///         touch this field; the cooldown only governs the setPrice path.
     uint256 public lastSetPriceTime;
 
+    /// @notice Timestamp of the last *forceSetPrice* call (0 until the first one).
+    ///         forceSetPrice keeps its OWN cooldown clock, separate from
+    ///         lastSetPriceTime, so a single emergency reprice is still immediate
+    ///         (the escape hatch works even right after a setPrice push) but two
+    ///         consecutive force calls are spaced by updateCooldown. A single call
+    ///         is already bounded to FORCE_MAX_DEVIATION_BPS (10×); the spacing is
+    ///         what stops a compromised owner from CHAINING 10× moves in one
+    ///         block/window to ratchet the price arbitrarily fast (issue #935).
+    uint256 public lastForceSetPriceTime;
+
     /// @notice Max allowed move per setPrice, in basis points vs the prior price.
     ///         Default 2000 bps (20%) — generous for a daily-update cadence but
     ///         blocks fat-finger / glitched-feed / compromised-key writes that
@@ -132,8 +142,11 @@ contract PriceOracle is Ownable {
     ///         updateCooldown seconds between accepted updates blocks that intra-block
     ///         chaining and limits a compromised key to one bounded move per window,
     ///         giving the owner time to react (rotate the key / forceSetPrice).
-    ///         Owner-configurable via setUpdateCooldown; forceSetPrice (owner escape
-    ///         hatch) is exempt so the owner can always reprice out-of-band.
+    ///         Owner-configurable via setUpdateCooldown. forceSetPrice does not
+    ///         share the setPrice clock — a single emergency reprice is always
+    ///         immediate — but consecutive force calls are spaced by this same
+    ///         window (its own lastForceSetPriceTime clock) so a compromised owner
+    ///         can't chain force moves to ratchet the price (issue #935).
     ///         Default 30s — well above Arc's sub-second block time (so it defeats the
     ///         same-block ratchet this guards against) yet comfortably below the oracle
     ///         runner's 60s push cadence (ORACLE_INTERVAL_SECONDS), so legitimate
@@ -212,10 +225,22 @@ contract PriceOracle is Ownable {
     /// @notice Emergency override — owner-only escape hatch for legitimately
     ///         gapped markets (e.g. a >maxDeviationBps overnight move). Bounded
     ///         by FORCE_MAX_DEVIATION_BPS (900% / 10×) when a prior price exists;
-    ///         a legitimate >10× gap requires two sequential calls. Emits a
-    ///         distinct event so forced updates are auditable on-chain.
+    ///         a legitimate >10× gap requires two sequential calls, now spaced by
+    ///         updateCooldown. Emits a distinct event so forced updates are
+    ///         auditable on-chain.
+    /// @dev    The FIRST force call is immediate (single-move escape hatch intact,
+    ///         even right after a setPrice push — it reads lastForceSetPriceTime,
+    ///         not lastSetPriceTime). Consecutive force calls within updateCooldown
+    ///         revert, so a compromised owner cannot chain 10× moves in one
+    ///         block/window to ratchet the price arbitrarily fast (issue #935).
     function forceSetPrice(uint256 _newPrice) external onlyOwner {
         if (_newPrice == 0) revert ZeroPrice();
+        // Rate-limit consecutive force calls (issue #935). Skipped on the very
+        // first call (lastForceSetPriceTime == 0), so a single emergency reprice
+        // is always immediate; a chained second call must wait updateCooldown.
+        if (lastForceSetPriceTime != 0 && block.timestamp < lastForceSetPriceTime + updateCooldown) {
+            revert UpdateRateLimited(lastForceSetPriceTime, updateCooldown, block.timestamp);
+        }
         uint256 oldPrice = price;
         if (oldPrice != 0) {
             uint256 diff = _newPrice > oldPrice ? _newPrice - oldPrice : oldPrice - _newPrice;
@@ -225,6 +250,7 @@ contract PriceOracle is Ownable {
         }
         price = _newPrice;
         lastUpdated = block.timestamp;
+        lastForceSetPriceTime = block.timestamp;
         emit PriceForced(oldPrice, _newPrice, block.timestamp);
     }
 

--- a/contracts/test/PriceOracle.t.sol
+++ b/contracts/test/PriceOracle.t.sol
@@ -103,6 +103,34 @@ contract PriceOracleCooldownTest is Test {
         assertEq(oracle.lastSetPriceTime(), 0);
     }
 
+    /// @dev #935: a compromised owner must not be able to CHAIN forceSetPrice
+    ///      calls (each bounded to 10×) with no spacing to ratchet the price
+    ///      arbitrarily fast. The first force call is immediate (escape hatch),
+    ///      but a consecutive one within updateCooldown reverts.
+    function test_forceSetPrice_second_call_rate_limited() public {
+        // First force call is immediate.
+        vm.prank(owner);
+        oracle.forceSetPrice(WITHIN_BOUND);
+        assertEq(oracle.lastForceSetPriceTime(), block.timestamp);
+
+        // A second force call in the same block (within the cooldown) is blocked.
+        vm.expectRevert(); // UpdateRateLimited
+        vm.prank(owner);
+        oracle.forceSetPrice(WITHIN_BOUND + 1);
+
+        // One second short of the window: still blocked.
+        vm.warp(block.timestamp + oracle.updateCooldown() - 1);
+        vm.expectRevert(); // UpdateRateLimited
+        vm.prank(owner);
+        oracle.forceSetPrice(WITHIN_BOUND + 1);
+
+        // Once the window elapses, the owner can force again (gap recovery).
+        vm.warp(block.timestamp + 1);
+        vm.prank(owner);
+        oracle.forceSetPrice(WITHIN_BOUND + 1);
+        assertEq(oracle.price(), WITHIN_BOUND + 1);
+    }
+
     function test_setUpdateCooldown_changes_window_and_emits() public {
         vm.expectEmit(false, false, false, true);
         emit PriceOracle.UpdateCooldownChanged(30, 600);


### PR DESCRIPTION
Closes #935. **Contract change — needs Dan (owner) + Bogdan review; do not merge without it.**

## The problem

`forceSetPrice` was fully exempt from the update cooldown (the #587 owner escape hatch). A single call is bounded to `FORCE_MAX_DEVIATION_BPS` (10×), but nothing stopped a **compromised owner** from *chaining* 10×-per-call moves with no spacing — repricing a synth arbitrarily fast in one block/window before any rebalance could react.

## The fix (design tradeoff — please confirm)

Give `forceSetPrice` its **own** cooldown clock, `lastForceSetPriceTime`, separate from the `setPrice` clock:
- The **first** emergency reprice is still immediate — the escape hatch works even right after a `setPrice` push (it reads `lastForceSetPriceTime`, not `lastSetPriceTime`).
- A **consecutive** force call within `updateCooldown` reverts, so force moves can't be chained to ratchet the price.
- A legitimate >10× gap recovery now takes two calls spaced by `updateCooldown` (default 30s).

This deliberately narrows the #587 "forceSetPrice is exempt" decision. The tradeoff is *single-move immediacy (kept)* vs *chained-move immediacy (removed)* — I judged blocking the ratchet worth a 30s delay on the rare >10× two-step recovery, but this is the owner's call to confirm.

## Tests (forge — 226/226 pass)

- **New:** `test_forceSetPrice_second_call_rate_limited` — first call immediate; second within the window reverts; allowed again after `updateCooldown`.
- **Preserved:** `test_forceSetPrice_is_exempt_from_cooldown` and `test_forceSetPrice_does_not_touch_lastSetPriceTime` — the fix keeps forceSetPrice independent of the setPrice clock, so both still pass.

## Notes

- Adds one public getter (`lastForceSetPriceTime`); the backend does not call it. The cached ABI resync is handled separately by #974, so I did not touch `contracts/abis/PriceOracle.json` here (avoids a conflict with that PR).

## Verify

```
cd contracts && forge test --match-path test/PriceOracle.t.sol   # 14 passed
cd contracts && forge test                                        # 226 passed
```