### PR TITLE
[chain] Scope Circle poll query to the target wallet (#941)

### DIFF
--- a/backend/archimedes/chain/circle_signer.py
+++ b/backend/archimedes/chain/circle_signer.py
@@ -201,10 +201,13 @@ class CircleSigner:
     async def _poll_transaction(self, session: aiohttp.ClientSession, circle_tx_id: str) -> str:
         """Poll Circle transaction until terminal state."""
         for _ in range(_MAX_POLLS):
-            # Use the list endpoint — Circle's GET /transactions returns
-            # all recent txs for the wallet. Find ours by ID.
+            # Scope the list to this wallet's transactions via the walletIds
+            # filter. An unfiltered GET /transactions returns the newest txs
+            # across every wallet, so with >50 txs in flight the one we care
+            # about can fall off the page before it reaches a terminal state,
+            # producing a false timeout on a tx that actually succeeded (#941).
             async with session.get(
-                f"{CIRCLE_API_BASE}/transactions?pageSize=50",
+                f"{CIRCLE_API_BASE}/transactions?pageSize=50&walletIds={self._wallet_id}",
                 headers={"Authorization": f"Bearer {self._api_key}"},
             ) as resp:
                 if resp.status == 200:

--- a/backend/tests/chain/test_circle_signer.py
+++ b/backend/tests/chain/test_circle_signer.py
@@ -179,6 +179,25 @@ class TestPollTransaction:
             with pytest.raises(RuntimeError, match="timed out"):
                 await configured._poll_transaction(session, "tx-1")
 
+    async def test_poll_query_scoped_to_wallet(self, configured):
+        """The poll GET must filter by walletIds so the target tx can't fall off
+        an unfiltered global page (#941).
+
+        Without the walletIds filter, Circle's GET /transactions returns the
+        newest txs across every wallet capped at pageSize; with >50 in flight
+        the real tx drops off the window and polling false-times-out on a tx
+        that actually completed. This asserts the filter is on the request URL.
+        """
+        session = _mock_session()
+        body = {"data": {"transactions": [{"id": "tx-1", "state": "COMPLETE", "txHash": "0xHASH"}]}}
+        session.get = MagicMock(return_value=session._cm(_resp(200, body)))
+
+        result = await configured._poll_transaction(session, "tx-1")
+
+        assert result == "0xHASH"
+        called_url = session.get.call_args.args[0]
+        assert "walletIds=wallet-uuid" in called_url
+
 
 # ── sign_and_broadcast ────────────────────────────────────────
 


### PR DESCRIPTION
Closes #941.

## The problem
`_poll_transaction` in `backend/archimedes/chain/circle_signer.py` polled Circle's `GET /transactions?pageSize=50` — an unfiltered list that returns the newest transactions across *every* wallet, capped at 50. When more than 50 transactions are in flight, the tx we just submitted can fall off the page before it reaches a terminal state. The poll loop then never finds it and raises a timeout, so a rebalance that actually completed on-chain is reported as failed and publishes a SKIP/error trace — a false negative on a successful settlement.

## The fix
Add the `walletIds` filter to the poll query (`?pageSize=50&walletIds={wallet_id}`), scoping the returned list to this wallet's own transactions. The signer already holds `self._wallet_id`, so this reuses existing state. The target tx now stays on the page regardless of global volume, so polling finds it and reads its real terminal state. Narrowest correct change — no unbounded pagination, no new API calls.

## Tests
Added `TestPollTransaction::test_poll_query_scoped_to_wallet` to the existing hermetic suite (aiohttp boundary mocked, no network). It asserts the poll GET URL carries `walletIds={wallet_id}`. Negative control verified: with the fix reverted (`git stash`) the new test fails on the unfiltered URL; with the fix it passes. Full file: 16 passed.

## Verify
```
env -i HOME="$HOME" PATH="/opt/homebrew/Caskroom/miniconda/base/envs/archimedes/bin:/usr/bin:/bin" PYTHONPATH=backend /opt/homebrew/Caskroom/miniconda/base/envs/archimedes/bin/python -m pytest backend/tests/chain/test_circle_signer.py -q
```
Expected: `16 passed`.