### PR TITLE
[backend] Extract SIWE signer address from EIP-4361 line 2, not the last 0x line (#946)

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -85,6 +85,26 @@ def _normalize_domain(domain: str) -> str:
     return domain.strip().removeprefix("https://").removeprefix("http://").rstrip("/").lower()
 
 
+def _address_from_siwe_message(message: str) -> str | None:
+    """Return the lowercased signer address from an EIP-4361 SIWE message.
+
+    The address is line 2 (index 1), immediately after the
+    ``"<domain> wants you to sign in with your Ethereum account:"`` preamble.
+    Read it positionally: scanning for "the last 42-char 0x line" (the previous
+    behavior) let a 0x address appearing later in the message — e.g. inside a
+    ``Resources:`` URI — overwrite the real signer. On the EOA-recovery-fail →
+    ERC-1271 smart-wallet path that misplaced address is the wallet we verify
+    against, so a crafted message could point verification at the wrong account
+    (#946). Returns ``None`` if line 2 is absent or not a 42-char 0x string.
+    """
+    lines = message.split("\n")
+    if len(lines) >= 2:
+        addr = lines[1].strip()
+        if addr.startswith("0x") and len(addr) == 42:
+            return addr.lower()
+    return None
+
+
 def _sign_session(wallet: str, issued_at: float) -> str:
     """Create an HMAC-signed session token."""
     payload = json.dumps({"wallet": wallet.lower(), "iat": issued_at})
@@ -232,6 +252,9 @@ async def verify_signature(request: Request, response: Response):
     lines = message.split("\n")
     if lines and " wants you to sign in" in lines[0]:
         domain_from_message = lines[0].split(" wants you to sign in")[0].strip()
+    # Read the signer address positionally from EIP-4361 line 2 — see
+    # _address_from_siwe_message for why "the last 0x line" was wrong (#946).
+    wallet_from_message = _address_from_siwe_message(message)
     for line in lines:
         line = line.strip()
         if line.startswith("Nonce: "):
@@ -240,8 +263,6 @@ async def verify_signature(request: Request, response: Response):
             chain_id_from_message = line[len("Chain ID: ") :].strip()
         elif line.startswith("Issued At: "):
             issued_at_from_message = line[len("Issued At: ") :].strip()
-        elif line.startswith("0x") and len(line) == 42:
-            wallet_from_message = line.lower()
 
     if not nonce:
         raise HTTPException(status_code=400, detail="Nonce not found in message")

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -18,6 +18,7 @@ from archimedes.api.auth_siwe import (
     _COOKIE_NAME,
     _NONCE_TTL_SECONDS,
     _SESSION_TTL_SECONDS,
+    _address_from_siwe_message,
     _pending_nonces,
     _resolve_session_secret,
     _sign_session,
@@ -55,6 +56,36 @@ class TestResolveSessionSecret:
         assert len(s1) == 64
         assert s1 != s2
         assert any("random session secret" in r.message for r in caplog.records)
+
+
+class TestAddressFromSiweMessage:
+    """The signer address must come from EIP-4361 line 2, not the last 0x line (#946)."""
+
+    _SIGNER = "0x" + "a" * 40
+    _DECOY = "0x" + "b" * 40
+
+    def _msg(self, body: str) -> str:
+        return (
+            f"archimedes-arc.com wants you to sign in with your Ethereum account:\n"
+            f"{self._SIGNER}\n\n"
+            f"Sign in to Archimedes\n\n"
+            f"{body}"
+        )
+
+    def test_reads_line_two(self):
+        msg = self._msg("URI: https://archimedes-arc.com\nNonce: abc\nChain ID: 5042002")
+        assert _address_from_siwe_message(msg) == self._SIGNER
+
+    def test_trailing_decoy_address_does_not_override_signer(self):
+        # A 42-char 0x string in a Resources URI must NOT become the signer.
+        body = f"Nonce: abc\nChain ID: 5042002\nResources:\n- {self._DECOY}"
+        msg = self._msg(body)
+        assert _address_from_siwe_message(msg) == self._SIGNER
+        assert _address_from_siwe_message(msg) != self._DECOY
+
+    def test_returns_none_when_line_two_not_an_address(self):
+        assert _address_from_siwe_message("only one line") is None
+        assert _address_from_siwe_message("preamble\nnot-an-address\nNonce: x") is None
 
 
 def _now_iso() -> str:


### PR DESCRIPTION
Closes #946.

## The problem

The SIWE verify handler scanned every line of the message and took the **last** 42-char `0x` line as the signer. Per EIP-4361 the address is on **line 2** (right after the `"<domain> wants you to sign in…"` preamble). A `0x` address appearing later — e.g. inside a `Resources:` URI — would overwrite the real signer. On the EOA-recovery-fail → ERC-1271 smart-wallet path, `wallet_from_message` is the account verification runs against, so a crafted trailing address could redirect the check.

## The fix

Read the address positionally from line 2 via a new `_address_from_siwe_message(message)` helper; drop the "last 0x line" scan.

## Tests

- `test_reads_line_two` — normal message → line-2 address.
- `test_trailing_decoy_address_does_not_override_signer` — a decoy `0x` in a Resources URI does **not** win.
- `test_returns_none_when_line_two_not_an_address` — malformed input → None.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_auth_siwe.py -q -k AddressFromSiwe   # 3 passed
```
(Note: the full file has pre-existing `circlekit` import failures from the marketplace merge — unrelated to this change; CI has that dep.)