### PR TITLE
[oracle] Prune retired synths from YFINANCE_MAP (#943)

### DIFF
--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -21,16 +21,23 @@ from archimedes.models.asset import AssetPrice, MarketSnapshot
 
 logger = logging.getLogger(__name__)
 
-# Symbol → yfinance ticker mapping
+# Symbol → yfinance ticker mapping.
+#
+# Only synths that are actually on the live on-chain universe belong here — the
+# fetch loop (fetch_prices) and the secondary cross-check (_cross_check_secondary)
+# both key off this map, so a stale entry means a wasted download and a misleading
+# "fetched N prices" log every cycle. Retired single-stock synths (sTSLA/sNVDA,
+# dropped from the SSOT in #725 pending securities-compliance review) and the
+# futures/index synths retired in #842 (sGOLD → sGLD/sXAU, sOIL/sNKY dropped) are
+# no longer in universe.ON_CHAIN_SYNTHS, so they are removed here too. sSPY is the
+# only live synth with a yfinance ticker; the ^-prefixed entries are index tickers
+# (not synths) used for regime signals — the S&P 500 moving averages
+# (_fetch_sp500_moving_averages) and VIX (fetch_market_snapshot) — and are excluded
+# from the synth fetch loop by the leading-"s" filter, so they stay.
 YFINANCE_MAP = {
-    "sTSLA": "TSLA",
-    "sNVDA": "NVDA",
     "sSPY": "SPY",
-    "sGOLD": "GC=F",  # Gold futures
-    "sOIL": "CL=F",  # WTI crude oil futures
-    "sNKY": "^N225",  # Nikkei 225
-    "^GSPC": "^GSPC",  # S&P 500 index
-    "^VIX": "^VIX",  # VIX index
+    "^GSPC": "^GSPC",  # S&P 500 index (regime signal, not a synth)
+    "^VIX": "^VIX",  # VIX index (regime signal, not a synth)
 }
 
 # Symbol → CoinGecko ID

--- a/backend/tests/chain/test_oracle_updater_fetch.py
+++ b/backend/tests/chain/test_oracle_updater_fetch.py
@@ -266,7 +266,8 @@ class TestModuleConstants:
     def test_symbol_maps_present(self):
         from archimedes.chain.oracle_updater import CRYPTO_MAP, YFINANCE_MAP
 
-        assert YFINANCE_MAP["sTSLA"] == "TSLA"
+        # sSPY is the one live synth with a yfinance ticker; sBTC is the one crypto.
+        assert YFINANCE_MAP["sSPY"] == "SPY"
         assert CRYPTO_MAP["sBTC"] == "bitcoin"
 
     def test_circle_constants(self):
@@ -274,3 +275,67 @@ class TestModuleConstants:
 
         assert CIRCLE_BLOCKCHAIN == "ARC-TESTNET"
         assert CIRCLE_API_BASE.startswith("https://")
+
+
+# Synths dropped from the on-chain universe: sTSLA/sNVDA (single stocks, #725,
+# compliance-flagged backtest-only) and sGOLD/sOIL/sNKY (#842 — sGOLD→sGLD/sXAU,
+# sOIL/sNKY dropped). None are in universe.ON_CHAIN_SYNTHS, so none must be fetched.
+RETIRED_SYNTHS = ("sTSLA", "sNVDA", "sGOLD", "sOIL", "sNKY")
+
+
+class TestYfinanceMapPrunedToLiveUniverse:
+    """Issue #943 — YFINANCE_MAP must not carry retired synths (wasted fetch + misleading log)."""
+
+    def test_retired_synths_absent_from_yfinance_map(self):
+        from archimedes.chain.oracle_updater import YFINANCE_MAP
+
+        for symbol in RETIRED_SYNTHS:
+            assert symbol not in YFINANCE_MAP, (
+                f"{symbol} is retired from the on-chain universe and must not be in YFINANCE_MAP"
+            )
+
+    def test_every_synth_key_is_in_the_live_universe(self):
+        """Every ``s``-prefixed YFINANCE_MAP key must be a live on-chain synth.
+
+        The ``^``-prefixed keys (^GSPC, ^VIX) are index tickers used for regime
+        signals, not synths, so they are exempt — and the fetch loop's leading-"s"
+        filter already excludes them from the synth fetch. This is the parity guard
+        that stops a future stale entry from creeping back in.
+        """
+        from archimedes import universe
+        from archimedes.chain.oracle_updater import YFINANCE_MAP
+
+        live = set(universe.ON_CHAIN_SYNTHS)
+        synth_keys = {k for k in YFINANCE_MAP if k.startswith("s")}
+        assert synth_keys, "expected at least one live synth in YFINANCE_MAP"
+        stale = synth_keys - live
+        assert not stale, f"YFINANCE_MAP carries synths absent from the live universe: {sorted(stale)}"
+
+    async def test_fetch_prices_does_not_fetch_retired_symbols(self, updater):
+        """Negative control: the yfinance fetch is handed only live-universe synths.
+
+        ``fetch_prices`` builds ``equity_symbols`` from YFINANCE_MAP and passes it to
+        ``_fetch_yfinance``. We spy on that boundary (no network) and assert none of the
+        retired symbols — nor their old tickers — reach the fetch. Positive control: the
+        one live synth (sSPY) IS passed through, proving the filter isn't just empty.
+        """
+        captured: dict[str, str] = {}
+
+        def _spy_fetch(symbols, timestamp):
+            captured.update(symbols)
+            return []
+
+        with (
+            patch.object(updater, "_fetch_yfinance", side_effect=_spy_fetch),
+            patch.object(updater, "_fetch_crypto", AsyncMock(return_value=[])),
+        ):
+            await updater.fetch_prices()
+
+        # No retired synth key reaches the fetch...
+        for symbol in RETIRED_SYNTHS:
+            assert symbol not in captured
+        # ...and neither do their old upstream tickers.
+        for stale_ticker in ("GC=F", "CL=F", "^N225", "TSLA", "NVDA"):
+            assert stale_ticker not in captured.values()
+        # Positive control: the live synth is still fetched.
+        assert captured.get("sSPY") == "SPY"

--- a/backend/tests/services/test_price_source.py
+++ b/backend/tests/services/test_price_source.py
@@ -215,27 +215,26 @@ async def test_cascade_mode_prefers_pyth_then_yfinance(monkeypatch):
     from archimedes.chain.oracle_updater import OracleUpdater
 
     upd = OracleUpdater()
-    # Pyth covers sBTC + sSPY (FRESH observations); yfinance must fill the rest
-    # (sOIL/sNKY/sTSLA/sNVDA/sGOLD). Use a real-fresh timestamp: a fresh Pyth read is
-    # what counts as "covered" now that stale observations fall through (below).
+    # Pyth covers sBTC (FRESH observation) but not sSPY (the only remaining synth
+    # in YFINANCE_MAP after the #943 prune) — yfinance must fill that gap. Use a
+    # real-fresh timestamp: a fresh Pyth read is what counts as "covered" now that
+    # stale observations fall through (below).
     fresh = datetime.now(UTC)
     pyth_ret = {
         "sBTC": AssetPrice("sBTC", 58000, fresh, "pyth_hermes"),
-        "sSPY": AssetPrice("sSPY", 512, fresh, "pyth_hermes"),
     }
     with (
         patch("archimedes.services.price_source.fetch_pyth_prices", AsyncMock(return_value=pyth_ret)),
-        patch.object(upd, "_fetch_yfinance", return_value=[AssetPrice("sOIL", 70, fresh, "yfinance")]) as yf_mock,
+        patch.object(upd, "_fetch_yfinance", return_value=[AssetPrice("sSPY", 512, fresh, "yfinance")]) as yf_mock,
         patch.object(upd, "_fetch_crypto", AsyncMock(return_value=[])) as crypto_mock,
     ):
         prices = await upd.fetch_prices()
     by = {p.symbol: p for p in prices}
     assert by["sBTC"].source == "pyth_hermes"  # Pyth wins for covered
-    assert by["sSPY"].source == "pyth_hermes"
-    assert by["sOIL"].source == "yfinance"  # fallback filled the gap
+    assert by["sSPY"].source == "yfinance"  # fallback filled the gap
     # yfinance was asked only for the symbols Pyth didn't cover
     called_symbols = set(yf_mock.call_args[0][0].keys())
-    assert "sSPY" not in called_symbols and "sGOLD" in called_symbols
+    assert called_symbols == {"sSPY"}
     crypto_mock.assert_not_called()  # sBTC came from Pyth → no CoinGecko
 
 


### PR DESCRIPTION
Closes #943.

## The problem

`YFINANCE_MAP` in `oracle_updater.py` still carried synths that are no longer on the live on-chain universe: `sTSLA`/`sNVDA` (single stocks removed from the SSOT in #725) and `sGOLD`/`sOIL`/`sNKY` (retired in #842, `sGOLD`→`sGLD`/`sXAU`). The fetch loop keys off this map, so each retired entry meant a wasted yfinance download and a misleading `fetched N prices` log every cycle.

## The fix

Remove the five retired synths. What remains: `sSPY` (the one live synth with a yfinance ticker) plus the `^GSPC`/`^VIX` index tickers used for regime signals (not synths — the leading-`s` filter already excludes them from the synth fetch). `client.py`'s `_SYNTH_DEFAULTS` was already pruned to the live subset (`sSPY`/`sBTC`), so it needs no change — verified against the in-file #725/#842 notes and `universe.ON_CHAIN_SYNTHS`.

## Tests

- `test_retired_synths_absent_from_yfinance_map` — the five retired symbols are gone.
- `test_every_synth_key_is_in_the_live_universe` — **parity guard**: any `s`-prefixed key must be in `ON_CHAIN_SYNTHS`, so a stale entry can't creep back.
- `test_fetch_prices_does_not_fetch_retired_symbols` — negative control (no retired symbol/ticker reaches the fetch) + positive control (`sSPY` still fetched).

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/chain/test_oracle_updater_fetch.py -q   # 22 passed
```