### PR TITLE
[quant] Fix DSL rebalance-counter phase shift (#944)

### DIFF
--- a/backend/archimedes/services/dsl_to_backtrader.py
+++ b/backend/archimedes/services/dsl_to_backtrader.py
@@ -116,7 +116,12 @@ def interpret_spec(spec: StrategySpec) -> type[bt.Strategy]:
                 self._indicators[alias] = _make_indicator(self.data.close, name, period)
             self._warmup = max_period
             self._vol_target = self.params.vol_target_annual
-            self._rebal_counter = 0
+            # Seed the counter so the first post-warmup bar rebalances instead of
+            # waiting a full period first. _should_rebalance() increments before
+            # testing the modulus, so starting one short of a period boundary makes
+            # the first executed bar (counter -> period) the first rebalance. Without
+            # this the strategy phase-shifts by up to period-1 bars versus the paper.
+            self._rebal_counter = self._rebalance_period() - 1
 
         def _bar_values(self) -> dict[str, float]:
             vals: dict[str, float] = {
@@ -133,15 +138,23 @@ def interpret_spec(spec: StrategySpec) -> type[bt.Strategy]:
                     vals[alias] = float("nan")
             return vals
 
+        @staticmethod
+        def _rebalance_period() -> int:
+            """Bars between rebalances for the spec's rebalance frequency."""
+            if spec.rebalance_frequency == "weekly":
+                return 5
+            if spec.rebalance_frequency == "monthly":
+                return 21
+            return 1
+
         def _should_rebalance(self) -> bool:
             if spec.rebalance_frequency == "daily":
                 return True
+            period = self._rebalance_period()
+            if period <= 1:
+                return True
             self._rebal_counter += 1
-            if spec.rebalance_frequency == "weekly":
-                return self._rebal_counter % 5 == 0
-            if spec.rebalance_frequency == "monthly":
-                return self._rebal_counter % 21 == 0
-            return True
+            return self._rebal_counter % period == 0
 
         def next(self) -> None:
             if len(self) <= self._warmup:

--- a/backend/tests/services/test_dsl_to_backtrader.py
+++ b/backend/tests/services/test_dsl_to_backtrader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from itertools import pairwise
+
 import pytest
 from archimedes.services.dsl_to_backtrader import (
     _eval_condition,
@@ -97,6 +99,91 @@ def _get_bt_strategy_class():
     import backtrader as bt
 
     return bt.Strategy
+
+
+def _record_rebalance_bars(cls, n_bars: int) -> list[int]:
+    """Run ``cls`` over ``n_bars`` of synthetic data, returning rebalance bar indices.
+
+    Wraps the generated strategy's ``_should_rebalance`` so that every bar where it
+    returns True records ``len(self)`` (backtrader's 1-indexed bar count). This lets
+    the test observe the rebalance cadence without depending on order fills.
+    """
+    import backtrader as bt
+    import pandas as pd
+
+    fired: list[int] = []
+    original = cls._should_rebalance
+
+    def _recording_should_rebalance(self):
+        result = original(self)
+        if result:
+            fired.append(len(self))
+        return result
+
+    cls._should_rebalance = _recording_should_rebalance
+    try:
+        # Monotone-rising close keeps entry (close > sma) true so rebalances that
+        # act do so consistently; the cadence itself is what we measure.
+        dates = pd.date_range("2020-01-01", periods=n_bars, freq="D")
+        prices = [100.0 + i for i in range(n_bars)]
+        frame = pd.DataFrame(
+            {
+                "open": prices,
+                "high": [p + 0.5 for p in prices],
+                "low": [p - 0.5 for p in prices],
+                "close": prices,
+                "volume": [1000] * n_bars,
+            },
+            index=dates,
+        )
+        cerebro = bt.Cerebro()
+        cerebro.adddata(bt.feeds.PandasData(dataname=frame))
+        cerebro.addstrategy(cls)
+        cerebro.broker.setcash(100000.0)
+        cerebro.run()
+    finally:
+        cls._should_rebalance = original
+    return fired
+
+
+class TestRebalanceCadencePhase:
+    """The first rebalance must land right after warmup, not a full period later."""
+
+    def _monthly_sma21_spec(self):
+        # sma_21 -> warmup == 21; monthly -> period == 21. Before the phase-shift
+        # fix the counter started at 0, so the first rebalance fired ~21 bars after
+        # warmup ended (~bar 42) instead of on the first post-warmup bar (~bar 21).
+        spec_dict = {
+            "name": "SMA-21 Monthly",
+            "asset_universe": ["SPY"],
+            "rebalance_frequency": "monthly",
+            "entry": {"gt": ["close", "sma_21"]},
+            "exit": {"lt": ["close", "sma_21"]},
+            "position_sizing": {"type": "full_invested_when_in_market"},
+            "source_arxiv_ids": ["0706.1497"],
+            "look_ahead_safe": True,
+        }
+        return validate_strategy_spec(spec_dict)
+
+    def test_first_rebalance_near_warmup_not_double(self):
+        cls = interpret_spec(self._monthly_sma21_spec())
+        fired = _record_rebalance_bars(cls, n_bars=252)
+
+        assert fired, "expected at least one rebalance over a 252-bar year"
+        first = fired[0]
+        # First rebalance should be the first post-warmup bar (~22), well below the
+        # phase-shifted ~42 the old counter produced.
+        assert first <= 30, f"first rebalance at bar {first}, expected near warmup (~22)"
+        assert first < 40, f"first rebalance at bar {first} shows the period-1 phase shift"
+
+    def test_steady_state_cadence_preserved(self):
+        cls = interpret_spec(self._monthly_sma21_spec())
+        fired = _record_rebalance_bars(cls, n_bars=252)
+
+        assert len(fired) >= 3, "need several rebalances to check cadence"
+        gaps = [b - a for a, b in pairwise(fired)]
+        # Every rebalance after the first stays on the 21-bar monthly cadence.
+        assert all(gap == 21 for gap in gaps), f"steady-state cadence broke: gaps={gaps}"
 
 
 class TestInterpretVariant:


### PR DESCRIPTION
Closes #944.

## The problem

The generated-strategy rebalance counter started at 0, and `_should_rebalance` incremented it *then* tested the modulus. So a weekly/monthly strategy waited a **full period** after warmup before its first rebalance — up to `period-1` bars of lag versus the cited paper. Concretely, a monthly SMA-21 strategy first rebalanced ~bar 42 instead of ~bar 21.

## The fix

Seed `_rebal_counter = period - 1` so the first post-warmup bar rebalances, and factor the frequency→period map into a single `_rebalance_period()` helper. Steady-state cadence (every `period` bars) is unchanged.

## Tests

- `test_first_rebalance_near_warmup_not_double` — runs a real backtrader sim over 252 bars, records rebalance bars, asserts the first is ≤30 (near warmup ~22). **Verified it fails on `main` with `first rebalance at bar 42`** and passes with the fix.
- `test_steady_state_cadence_preserved` — spacing between rebalances stays == period.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_dsl_to_backtrader.py -q   # 18 passed
```