### PR TITLE
[backend] Warn loudly on SIWE session-secret random fallback (#933)

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -35,15 +35,32 @@ logger = logging.getLogger(__name__)
 
 auth_router = APIRouter(prefix="/api/auth", tags=["auth"])
 
-# Session signing key — prefer SIWE_SESSION_KEY (dedicated session-signing secret);
-# falls back to EMAIL_ENCRYPTION_KEY for backwards compatibility. Production enforces
-# EMAIL_ENCRYPTION_KEY at boot (main.py RuntimeError), so the secrets.token_hex(32)
-# path is local-dev only.
-# Multi-worker note: main.py:~127 raises RuntimeError at boot if PUBLIC_DOMAIN is set
-# (production) and EMAIL_ENCRYPTION_KEY is unset, so the secrets.token_hex(32) fallback
-# is only reachable in single-worker local dev -- per-worker secret divergence (which
-# would break cross-worker session-cookie verification) can't occur there.
-_SESSION_SECRET = os.getenv("SIWE_SESSION_KEY") or os.getenv("EMAIL_ENCRYPTION_KEY", secrets.token_hex(32))
+
+def _resolve_session_secret() -> str:
+    """Resolve the session-cookie signing secret (issue #933).
+
+    Prefers SIWE_SESSION_KEY (dedicated), then EMAIL_ENCRYPTION_KEY (back-compat).
+    If neither is set, falls back to a per-process random secret AND logs a loud
+    WARNING: that fallback is only safe in single-worker local dev — across
+    multiple uvicorn workers each worker would get a DIFFERENT random secret, so
+    a cookie signed by one worker fails verification on another and users are
+    logged out at random. Production can't reach the random path: main.py raises
+    at boot when PUBLIC_DOMAIN is set (production) and EMAIL_ENCRYPTION_KEY is
+    unset. The warning makes a misconfigured multi-worker deploy visible instead
+    of silently churning sessions.
+    """
+    configured = os.getenv("SIWE_SESSION_KEY") or os.getenv("EMAIL_ENCRYPTION_KEY")
+    if configured:
+        return configured
+    logger.warning(
+        "No SIWE_SESSION_KEY / EMAIL_ENCRYPTION_KEY set — using a per-process random "
+        "session secret. Safe ONLY for single-worker local dev; a multi-worker deploy "
+        "will log users out at random (set SIWE_SESSION_KEY or EMAIL_ENCRYPTION_KEY)."
+    )
+    return secrets.token_hex(32)
+
+
+_SESSION_SECRET = _resolve_session_secret()
 _SESSION_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 _NONCE_TTL_SECONDS = 300  # 5 minutes
 _CLOCK_SKEW_SECONDS = 120  # tolerate small client/server clock drift on Issued At

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -19,12 +19,42 @@ from archimedes.api.auth_siwe import (
     _NONCE_TTL_SECONDS,
     _SESSION_TTL_SECONDS,
     _pending_nonces,
+    _resolve_session_secret,
     _sign_session,
     _verify_session,
     get_verified_wallet,
     require_verified_wallet,
 )
 from httpx import ASGITransport, AsyncClient
+
+
+class TestResolveSessionSecret:
+    """The session secret must be stable when configured, and warn loudly on the
+    per-process random fallback so a multi-worker misconfig is visible (#933)."""
+
+    def test_prefers_siwe_session_key(self, monkeypatch):
+        monkeypatch.setenv("SIWE_SESSION_KEY", "dedicated-key")
+        monkeypatch.setenv("EMAIL_ENCRYPTION_KEY", "email-key")
+        assert _resolve_session_secret() == "dedicated-key"
+
+    def test_falls_back_to_email_key(self, monkeypatch):
+        monkeypatch.delenv("SIWE_SESSION_KEY", raising=False)
+        monkeypatch.setenv("EMAIL_ENCRYPTION_KEY", "email-key")
+        assert _resolve_session_secret() == "email-key"
+
+    def test_random_fallback_warns_and_diverges(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.delenv("SIWE_SESSION_KEY", raising=False)
+        monkeypatch.delenv("EMAIL_ENCRYPTION_KEY", raising=False)
+        with caplog.at_level(logging.WARNING):
+            s1 = _resolve_session_secret()
+            s2 = _resolve_session_secret()
+        # Random per-process secret: 32 bytes → 64 hex chars, and two calls differ
+        # (this divergence is exactly what breaks cross-worker cookie verification).
+        assert len(s1) == 64
+        assert s1 != s2
+        assert any("random session secret" in r.message for r in caplog.records)
 
 
 def _now_iso() -> str:


### PR DESCRIPTION
Closes #933.

## The problem

The session-cookie signing secret fell back to `secrets.token_hex(32)` — a **per-process random** value — when neither `SIWE_SESSION_KEY` nor `EMAIL_ENCRYPTION_KEY` was set. Across multiple uvicorn workers, each worker gets a *different* random secret, so a cookie signed by one worker fails verification on another and users are logged out at random.

## Analysis / scope

Production **cannot reach the random path**: `main.py` already raises at boot when `PUBLIC_DOMAIN` is set (production) and `EMAIL_ENCRYPTION_KEY` is unset, and the secret falls back to `EMAIL_ENCRYPTION_KEY` (a stable, shared value). The remaining risk is a *misconfigured* multi-worker deploy that did this **silently**.

## The fix

Move resolution into `_resolve_session_secret()` and log a loud **WARNING** on the random path, so a misconfig is visible instead of silently churning sessions. Prefers `SIWE_SESSION_KEY`, then `EMAIL_ENCRYPTION_KEY`. Behavior is otherwise unchanged.

## Tests

- `test_prefers_siwe_session_key` / `test_falls_back_to_email_key` — stable secret when configured.
- `test_random_fallback_warns_and_diverges` — no key → 64-hex random, two calls **differ** (the exact cross-worker divergence), and a WARNING is logged.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_auth_siwe.py -q -k ResolveSessionSecret   # 3 passed
```