### PR TITLE
[quant] Convert Ledoit-Wolf output to the ddof=1 convention (#950)

### DIFF
--- a/backend/archimedes/services/portfolio_optimizer.py
+++ b/backend/archimedes/services/portfolio_optimizer.py
@@ -928,13 +928,25 @@ def ledoit_wolf_shrinkage(returns: np.ndarray) -> tuple[np.ndarray, float]:
     X = X - X.mean(axis=0, keepdims=True)
     S = (X.T @ X) / T  # MLE sample covariance (1/T convention, per LW2004)
 
+    # LW2004's derivation (target μ·I, intensity δ, and the b̄²/d² closed forms
+    # below) is all internally consistent in the 1/T MLE convention, so we do the
+    # whole estimate in 1/T and convert the FINAL output to the unbiased ddof=1
+    # convention (1/(T-1)) that the rest of this module uses (np.cov(..., ddof=1)).
+    # Without this, LW sits a factor (T-1)/T below the other covariance paths —
+    # ~5% low at T=20 — understating variance (issue #950). δ is scale-invariant
+    # (b² and d² both scale with S), so scaling the output by T/(T-1) is exactly
+    # the LW estimate on the unbiased sample covariance and leaves δ unchanged.
+    # (Rescaling S mid-function would instead break the b̄² closed form, which
+    # couples tr(S²) with the raw ‖x_k‖² norms.) T ≥ 2 here, so T-1 ≥ 1.
+    ddof_correction = T / (T - 1)
+
     mu = float(np.trace(S)) / N  # ⟨S, I⟩ — average sample variance
     tr_s2 = float(np.trace(S @ S))
     d2 = tr_s2 / N - mu**2  # ‖S − μI‖²_F / N — dispersion of S around target
 
     if d2 <= 0.0:
         # S is already isotropic (e.g. N == 1): nothing to shrink.
-        return S, 0.0
+        return S * ddof_correction, 0.0
 
     # b̄² = (1/T²)·Σ_k‖x_k x_kᵀ − S‖²_F / N, via the closed form
     #      Σ_k‖x_k‖⁴ − T·tr(S²)  (avoids the per-observation outer-product loop).
@@ -944,7 +956,7 @@ def ledoit_wolf_shrinkage(returns: np.ndarray) -> tuple[np.ndarray, float]:
 
     delta = b2 / d2
     shrunk = delta * mu * np.eye(N) + (1.0 - delta) * S
-    return shrunk, float(delta)
+    return shrunk * ddof_correction, float(delta)
 
 
 def _shrink_cov(cov: np.ndarray, intensity: float = 0.10) -> np.ndarray:

--- a/backend/tests/test_portfolio_optimizer.py
+++ b/backend/tests/test_portfolio_optimizer.py
@@ -255,6 +255,32 @@ class TestLedoitWolfShrinkage:
         with pytest.raises(ValueError):
             ledoit_wolf_shrinkage(np.array([[0.01, 0.02, 0.03]]))  # T=1
 
+    def test_output_uses_unbiased_ddof1_convention(self):
+        # Issue #950: the LW output must match the ddof=1 convention used
+        # everywhere else (np.cov(..., ddof=1)), NOT the 1/T MLE — otherwise
+        # variance is understated ~5% at T=20. Single asset ⇒ no shrinkage, so
+        # the output is exactly the unbiased sample variance.
+        rng = np.random.default_rng(7)
+        X = rng.normal(0.0, 1.0, (20, 1))  # small T where 1/T vs 1/(T-1) differ ~5%
+        shrunk, delta = ledoit_wolf_shrinkage(X)
+        assert delta == 0.0
+        unbiased_var = float(np.cov(X, rowvar=False, ddof=1))
+        mle_var = float(((X - X.mean()) ** 2).sum() / len(X))
+        assert shrunk[0, 0] == pytest.approx(unbiased_var, rel=1e-9)
+        assert shrunk[0, 0] > mle_var  # strictly larger than the old 1/T value
+
+    def test_ddof1_scaling_applied_but_delta_unchanged(self):
+        # The shrunk covariance is the 1/T LW estimate scaled by T/(T-1); δ is
+        # scale-invariant, so the correction leaves it unchanged (#950).
+        X = self._correlated_returns(T=25, N=5)
+        shrunk, delta = ledoit_wolf_shrinkage(X)
+        T, N = X.shape
+        Xc = X - X.mean(axis=0)
+        S = Xc.T @ Xc / T  # the pre-correction 1/T estimate the function builds
+        mu = float(np.trace(S)) / N
+        mle_lw = delta * mu * np.eye(N) + (1.0 - delta) * S
+        np.testing.assert_allclose(shrunk, mle_lw * (T / (T - 1)), rtol=1e-9, atol=1e-12)
+
 
 # ---------------------------------------------------------------------------
 # Section 6 — TestGmv


### PR DESCRIPTION
Closes #950.

## The problem

`ledoit_wolf_shrinkage` built the sample covariance as `X.T @ X / T` (the 1/T MLE, per LW2004), while every other covariance path in the module uses `np.cov(..., ddof=1)` = 1/(T-1). So the LW estimate sat a factor `(T-1)/T` below the others — **~5% low at T=20** — understating variance.

## The fix

Scale the final shrunk covariance by `T/(T-1)` to the unbiased convention. The LW intensity δ is **scale-invariant** (b² and d² both scale with S), so this is exactly the LW estimate computed on the unbiased sample covariance and leaves δ unchanged. The internal `b̄²` closed form still runs in 1/T on purpose — rescaling S mid-function would break it, since it couples `tr(S²)` with the raw per-observation `‖x_k‖²` norms.

## Blast radius

The LW output feeds the optimizer (line ~1008), **not the rigor gate or any stored fixture**, so weights shift slightly but no gate verdict / fixture changes. All 84 existing optimizer tests pass unchanged (they assert invariants / loose tolerances, not the exact 1/T value).

## Tests

- `test_output_uses_unbiased_ddof1_convention` — single asset, T=20 → output equals `np.cov(ddof=1)`, strictly larger than the old MLE value.
- `test_ddof1_scaling_applied_but_delta_unchanged` — output == 1/T LW × T/(T-1), δ unchanged.

Both **fail on `main`** (0.5797 MLE vs 0.6102 unbiased — the ~5% gap) and pass with the fix.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_portfolio_optimizer.py -q   # 84 passed
```