### PR TITLE
[frontend] Fix GenerationStream onerror reading stale terminal state (#939)

### DIFF
--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -106,11 +106,17 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
   const [failedRegimes, setFailedRegimes] = useState([])  // {regime, message}
   const esRef = useRef(null)
   const scrollRef = useRef(null)
+  // Mirror of `terminal` so the EventSource `onerror` handler reads the current
+  // state. `onerror` closes over the effect's first render, where `terminal` is
+  // null; without this ref it would never see 'done'/'error' and could keep
+  // auto-reconnecting after the stream has legitimately ended.
+  const terminalRef = useRef(null)
 
   useEffect(() => {
     if (!jobId) return
     setEvents([])
     setTerminal(null)
+    terminalRef.current = null
     setStrategyId(null)
     setServedModel(null)
     setErrorMsg('')
@@ -149,6 +155,7 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
       }
       if (name === 'done') {
         setTerminal('done')
+        terminalRef.current = 'done'
         if (data?.strategy_id) setStrategyId(data.strategy_id)
         if (data?.served_model) setServedModel(data.served_model)
         es.close()
@@ -160,6 +167,7 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
       }
       if (name === 'error') {
         setTerminal('error')
+        terminalRef.current = 'error'
         setErrorMsg(data?.message || 'Generation failed')
         es.close()
       }
@@ -169,7 +177,10 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
 
     es.onerror = () => {
       // EventSource will auto-reconnect; only treat as fatal once terminal.
-      if (terminal) es.close()
+      // Read the live state via the ref — the closed-over `terminal` is stale
+      // (captured at first render), so relying on it would let the stream
+      // reconnect-loop instead of settling after 'done'/'error'.
+      if (terminalRef.current) es.close()
     }
 
     return () => { es.close() }


### PR DESCRIPTION
Closes #939.

## The problem

The `EventSource` `onerror` handler in `ui/src/components/GenerationStream.jsx` closed over the `terminal` state variable. That closure is created on the effect's first render, when `terminal` is `null`, and it's never refreshed: `terminal` is deliberately excluded from the effect deps (the `eslint-disable react-hooks/exhaustive-deps` on the effect) so we don't tear down and re-subscribe the stream on every state change.

The consequence is that `onerror` always saw `terminal === null`. On a mid-stream network disconnect, the guard `if (terminal) es.close()` never fired, so `EventSource` kept auto-reconnecting even after the stream had legitimately reached `done`/`error` — a reconnect loop that never settles to an ended state.

## The fix

Mirror `terminal` into a `terminalRef` and have `onerror` read `terminalRef.current` instead of the stale closed-over value. A ref is mutable and shared across renders, so the handler always reads the live state without needing the effect to re-run:

- `terminalRef` is reset to `null` when the effect re-runs for a new `jobId` (next to the existing `setTerminal(null)`).
- It's set to `'done'` / `'error'` right alongside the existing `setTerminal(...)` calls in the event handler.
- `onerror` now closes the connection when `terminalRef.current` is truthy.

Why this fixes the loop: after a `done`/`error` event the ref holds the terminal value, so the very next `onerror` (from the disconnect that follows the server closing the stream) reads the live terminal state and calls `es.close()` — no further reconnect. While the stream is still mid-flight (`terminalRef.current === null`), `onerror` still lets `EventSource` auto-reconnect on a transient blip, preserving the existing resume-on-network-blip behavior. `jobId` remains the only effect dep, so we don't re-subscribe on state changes.

No behavior changes beyond the fix; the SSE protocol is untouched.

## Verification

No unit-test runner exists in `ui/`, so this was verified via lint + build (run from `ui/`):

```
/opt/homebrew/bin/npm run lint    # eslint . — clean, no errors/warnings on the changed file
/opt/homebrew/bin/npm run build   # vite build — succeeds
```

Both pass. The only build output warnings are the pre-existing chunk-size and ineffective-dynamic-import advisories, unrelated to this change.