### PR TITLE
[frontend] Guard Sharpe-vs-paper ratio against zero/negative denominator (#924)

### DIFF
--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -558,11 +558,14 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
                 {s.paper_claimed_sharpe != null && (
                   <div className="caption mt-2">
                     Paper claim: <strong>{fmt(s.paper_claimed_sharpe)}</strong> · Backtest: <strong>{fmt(s.sharpe_ratio)}</strong>
-                    {s.sharpe_ratio != null && (
-                      <span className={s.sharpe_ratio / s.paper_claimed_sharpe >= 0.5 ? 'positive' : 'negative'} style={{ marginLeft: 6 }}>
-                        ({((s.sharpe_ratio / s.paper_claimed_sharpe) * 100).toFixed(0)}%)
-                      </span>
-                    )}
+                    {s.sharpe_ratio != null && (() => {
+                      const ratio = s.paper_claimed_sharpe > 0.01 ? s.sharpe_ratio / s.paper_claimed_sharpe : null
+                      return (
+                        <span className={ratio != null && ratio >= 0.5 ? 'positive' : 'negative'} style={{ marginLeft: 6 }}>
+                          ({ratio != null ? `${(ratio * 100).toFixed(0)}%` : '—'})
+                        </span>
+                      )
+                    })()}
                   </div>
                 )}
                 {years != null && (

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -397,11 +397,14 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
           <div className="caption mt-2">
             Paper-claimed Sharpe: <strong>{fmt(s.paper_claimed_sharpe)}</strong>{' '}
             · realized: <strong>{fmt(s.sharpe_ratio)}</strong>{' '}
-            {s.sharpe_ratio != null && (
-              <span className={s.sharpe_ratio / s.paper_claimed_sharpe >= 0.5 ? 'positive' : 'negative'}>
-                ({((s.sharpe_ratio / s.paper_claimed_sharpe) * 100).toFixed(0)}% of paper claim)
-              </span>
-            )}
+            {s.sharpe_ratio != null && (() => {
+              const ratio = s.paper_claimed_sharpe > 0.01 ? s.sharpe_ratio / s.paper_claimed_sharpe : null
+              return (
+                <span className={ratio != null && ratio >= 0.5 ? 'positive' : 'negative'}>
+                  ({ratio != null ? `${(ratio * 100).toFixed(0)}% of paper claim` : '—'})
+                </span>
+              )
+            })()}
           </div>
         )}
       </div>


### PR DESCRIPTION
Closes #924.

## The problem

Both the strategy passport and the strategy list render a "realized Sharpe vs paper-claimed Sharpe" comparison as `sharpe_ratio / paper_claimed_sharpe`, with no guard on the denominator. Two bad cases fell out of that:

- `paper_claimed_sharpe === 0` → division by zero → the badge showed `Infinity%`.
- `paper_claimed_sharpe < 0` → the sign flipped, so a worse realized Sharpe could render green (the `>= 0.5` class check passed on a negative-over-negative ratio).

## The fix

Compute the ratio once, behind a guard, in both components:

```
const ratio = s.paper_claimed_sharpe > 0.01 ? s.sharpe_ratio / s.paper_claimed_sharpe : null
```

Guard cases:
- `paper_claimed_sharpe === 0` → `ratio = null` → renders "—".
- `paper_claimed_sharpe < 0` → `ratio = null` → renders "—" (no more green-on-worse).
- `paper_claimed_sharpe > 0.01` → real ratio, rendered as before (`% of paper claim` in the passport, `%` in the list).

A null ratio also falls through to the `negative` class rather than a misleading `positive`. The two components don't share a helper, so the guard is applied at both call sites; each keeps its own existing text and formatting.

## Verification

Node/npm from `/opt/homebrew/bin`, run in `ui/`:

- `npm run lint` → clean, no new eslint errors.
- `npm run build` → succeeds (only pre-existing chunk-size / dynamic-import warnings, unrelated to this change).