### PR TITLE
[contracts] Raise Vault first-depositor floor MIN_LIQUIDITY 1e3 → 1e6 (#932)

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -37,14 +37,23 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         donation is overwhelmingly burned, making the attack strictly unprofitable,
     ///         and later depositors' shares no longer round to zero.
     ///
+    ///         Sizing (issue #932): set to 1e6 share-wei, matching OZ's 1e6 virtual-offset
+    ///         magnitude. At 1e3 the floor was too small: a first deposit just above 1e3
+    ///         plus a large NAV donation could still round a later small deposit to 0 shares
+    ///         (a griefable ZeroShares revert), and 1/(1e3+1) ≈ 0.1% of a donation is not
+    ///         negligible. 1e6 bounds the attacker's donation share to ~1e-6 and forces the
+    ///         attack's first deposit to be at least 1e6 share-wei (= 1 USDC), so the
+    ///         tiny-first-deposit setup reverts outright.
+    ///
     ///         Why not Option A (OZ-style virtual decimals offset): a decimals offset of
     ///         d > 0 rescales shares-per-asset by 10**d, which silently breaks this vault's
     ///         performance-fee math — `highWaterMark` is initialized to 1e18 assuming a 1:1
     ///         share:asset scale, so nav-per-share would start at 1e18/10**d and the
     ///         performance fee would never (or wrongly) accrue. Dead shares preserve the
     ///         1:1 scale and leave the fee logic untouched. Cost: the first depositor
-    ///         forfeits MIN_LIQUIDITY share-wei (1e3 = 0.001 USDC at 6 decimals) — negligible.
-    uint256 public constant MIN_LIQUIDITY = 1e3;
+    ///         forfeits MIN_LIQUIDITY share-wei (1e6 = 1 USDC at 6 decimals) — negligible
+    ///         against any realistic first deposit.
+    uint256 public constant MIN_LIQUIDITY = 1e6;
 
     /// @notice Sink for dead shares (OZ ERC20 forbids minting to address(0)).
     address public constant DEAD_SHARES_SINK = address(0xdEaD);

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -214,6 +214,34 @@ contract VaultTest is Test {
         vault.deposit(0, alice);
     }
 
+    /// @dev #932: the first-depositor inflation floor must be large enough that a
+    ///      minimal seed + a large NAV donation can't round a later small deposit
+    ///      down to zero shares (a griefable ZeroShares revert). The attacker seeds
+    ///      with the smallest valid first deposit (MIN_LIQUIDITY + 1) and donates
+    ///      10k USDC to inflate NAV-per-share; a victim's 1 USDC deposit must still
+    ///      mint > 0 shares. Because the seed scales with MIN_LIQUIDITY, this reverts
+    ///      at the old 1e3 floor (seed 1001 → victim rounds to 0) and passes at 1e6.
+    function test_min_liquidity_blocks_first_depositor_inflation_grief() public {
+        assertEq(vault.MIN_LIQUIDITY(), 1e6);
+
+        uint256 seed = vault.MIN_LIQUIDITY() + 1;
+        vm.startPrank(alice);
+        usdc.approve(address(vault), seed);
+        vault.deposit(seed, alice);
+        vm.stopPrank();
+
+        // Attacker donates USDC straight to the vault to inflate NAV-per-share.
+        usdc.mint(address(vault), 10_000 * 10**6);
+
+        // Victim's 1 USDC deposit must still mint a positive share amount.
+        vm.startPrank(bob);
+        usdc.approve(address(vault), 1 * 10**6);
+        uint256 bobShares = vault.deposit(1 * 10**6, bob);
+        vm.stopPrank();
+
+        assertGt(bobShares, 0);
+    }
+
     // ─── Withdraw Tests ──────────────────────────────────────────────
 
     function test_withdraw() public {


### PR DESCRIPTION
Closes #932. **Contract change — needs Dan (owner) + Bogdan review; do not merge without it.**

## The problem

The first-depositor inflation guard (dead shares, #507) was sized at `MIN_LIQUIDITY = 1e3` (0.001 USDC). That's too small: an attacker can make a minimal first deposit just above 1e3, donate a large amount to inflate NAV-per-share, and round a later small deposit **down to zero shares** — a griefable `ZeroShares` revert. And 1/(1e3+1) ≈ 0.1% of a donation is not negligible.

## The fix

Raise `MIN_LIQUIDITY` to **1e6** (matching OZ's virtual-offset magnitude):
- the attacker's donation share drops to ~1e-6, and
- the tiny-first-deposit **setup** now reverts outright (a first deposit must be ≥ 1e6 = 1 USDC).

Keeps the deliberate **dead-shares** design — not the OZ virtual offset, which would break this vault's 1:1 `highWaterMark` performance-fee math (documented in the existing `MIN_LIQUIDITY` doc, extended here).

## Tests (forge — 249/249 pass)

- `test_min_liquidity_blocks_first_depositor_inflation_grief` — attacker seeds with `MIN_LIQUIDITY()+1`, donates 10k USDC, victim's 1 USDC deposit still mints > 0 shares. Because the seed scales with the constant, this **reverts at the old 1e3 floor** (seed 1001 → victim rounds to 0) and passes at 1e6.
- Existing deposit/withdraw tests read `MIN_LIQUIDITY()` via the getter and deposit ≫ 1e6, so they're unaffected.

## Notes

- Constant-only source change; the cached ABI is unaffected (constant value isn't in the ABI). No `contracts/abis` change.

## Verify

```
cd contracts && forge test --match-path test/Vault.t.sol   # 64 passed
cd contracts && forge test                                  # 249 passed
```