### PR TITLE
[contracts] Add AMMPool.sync() to recover directly-transferred tokens (#955)

### DIFF
--- a/contracts/src/AMMPool.sol
+++ b/contracts/src/AMMPool.sol
@@ -193,6 +193,22 @@ contract AMMPool is IAMMPool, ERC20, Ownable, ReentrancyGuard {
         emit LiquidityRemoved(msg.sender, amount0, amount1, lpTokens);
     }
 
+    /// @notice Emitted when sync() folds a direct-transfer surplus into the reserves.
+    event Sync(uint256 reserve0, uint256 reserve1);
+
+    /// @notice Force the tracked reserves to match the pool's actual token balances.
+    /// @dev    Reserves are updated only inside swap/addLiquidity/removeLiquidity, so
+    ///         tokens transferred DIRECTLY to the pool (not via addLiquidity) are
+    ///         otherwise stranded — invisible to pricing and unrecoverable. sync()
+    ///         folds any such surplus into the reserves, where it accrues to every LP
+    ///         (k grows); it never extracts value. Permissionless, mirroring Uniswap
+    ///         V2's Pair.sync (issue #955).
+    function sync() external nonReentrant {
+        reserve0 = IERC20(token0).balanceOf(address(this));
+        reserve1 = IERC20(token1).balanceOf(address(this));
+        emit Sync(reserve0, reserve1);
+    }
+
     // ─── Views ───────────────────────────────────────────────────────
 
     function getAmountOut(address tokenIn, uint256 amountIn)

--- a/contracts/test/AMM.t.sol
+++ b/contracts/test/AMM.t.sol
@@ -116,6 +116,45 @@ contract AMMTest is Test {
         assertEq(IERC20(pool).balanceOf(alice), lpTokens);
     }
 
+    /// @dev #955: tokens transferred directly to the pool (not via addLiquidity)
+    ///      are stranded — the balance grows but the tracked reserves don't. sync()
+    ///      folds that surplus into the reserves (accruing to LPs) instead.
+    function test_sync_folds_direct_transfer_into_reserves() public {
+        address pool = router.createPool(address(tokenA), address(tokenB));
+        uint256 amountA = 10_000 * 1e18;
+        uint256 amountB = 20_000 * 1e18;
+
+        vm.startPrank(alice);
+        tokenA.approve(address(router), amountA);
+        tokenB.approve(address(router), amountB);
+        router.addLiquidity(address(tokenA), address(tokenB), amountA, amountB, 0);
+        vm.stopPrank();
+
+        AMMPool amm = AMMPool(pool);
+        uint256 r0Before = amm.reserve0();
+        uint256 r1Before = amm.reserve1();
+
+        // Donate tokenA straight to the pool, bypassing addLiquidity.
+        uint256 donation = 500 * 1e18;
+        vm.prank(bob);
+        tokenA.transfer(pool, donation);
+
+        // Stranded: reserves are unchanged until sync().
+        assertEq(amm.reserve0(), r0Before);
+        assertEq(amm.reserve1(), r1Before);
+
+        amm.sync();
+
+        // After sync the reserves equal the real balances, folding in the donation.
+        assertEq(amm.reserve0(), IERC20(amm.token0()).balanceOf(pool));
+        assertEq(amm.reserve1(), IERC20(amm.token1()).balanceOf(pool));
+        if (amm.token0() == address(tokenA)) {
+            assertEq(amm.reserve0(), r0Before + donation);
+        } else {
+            assertEq(amm.reserve1(), r1Before + donation);
+        }
+    }
+
     function test_addLiquidity_second_deposit() public {
         address pool = router.createPool(address(tokenA), address(tokenB));
 


### PR DESCRIPTION
Closes #955. **Contract change — needs Dan (owner) + Bogdan review; do not merge without it.**

## The problem

`AMMPool` tracks `reserve0`/`reserve1` in storage, updated only inside `swap`/`addLiquidity`/`removeLiquidity`. Tokens transferred **directly** to the pool (not via `addLiquidity`) never enter the reserves — they're invisible to pricing and stranded, with no way to resync or skim.

## The fix

Add a permissionless `sync()` that sets the reserves to the pool's actual token balances, folding any direct-transfer surplus into the reserves where it accrues to every LP (k grows) — mirroring Uniswap V2's `Pair.sync`. It never extracts value: reserves only move toward the real balances.

## Test (forge — 249/249 pass)

`test_sync_folds_direct_transfer_into_reserves` — add liquidity, donate tokenA directly to the pool, assert reserves are **stranded** (unchanged), call `sync()`, assert reserves now equal the real balances and the donation was folded into the tokenA-side reserve.

## Notes

- Adds one external function + a local `Sync` event. The cached ABI (`contracts/abis/AMMPool.json`) does not yet include `sync`; the backend doesn't call it, and the ABI resync is tracked separately (#974), so I left the cached ABI untouched to avoid a conflict with that PR.

## Verify

```
cd contracts && forge test --match-path test/AMM.t.sol   # 27 passed
cd contracts && forge test                                # 249 passed
```