### PR TITLE
[contracts] Paginate AssetRegistry.getLeaderboard to bound gas (#927)

### DIFF
--- a/contracts/src/AssetRegistry.sol
+++ b/contracts/src/AssetRegistry.sol
@@ -139,13 +139,25 @@ contract AssetRegistry is IAssetRegistry, Ownable {
         emit VaultMetricsUpdated(vault, _vaults[vault].aum, block.timestamp);
     }
 
-    function getLeaderboard(uint8 tier, uint256 limit)
+    /// @notice Top vaults by AUM for a tier, paginated (issue #927).
+    /// @param tier   1 or 2 (0 = all tiers).
+    /// @param offset Number of top-ranked vaults to skip (the page start).
+    /// @param limit  Max results to return; 0 = all from ``offset`` onward.
+    /// @dev    Was a full O(n²) insertion sort over EVERY matching vault before
+    ///         applying the limit — as the vault set grows that view exceeds the
+    ///         block gas limit and bricks on-chain callers + eth_call reads. Now a
+    ///         PARTIAL selection sort: it extracts only the top ``offset + limit``
+    ///         vaults (O(n · (offset+limit))) and returns the ``[offset, …)`` slice,
+    ///         so a bounded page stays bounded in gas regardless of total size.
+    ///         (limit == 0 keeps the old "return all" behavior and its O(n²) cost —
+    ///         callers should page with a real limit for large sets.)
+    function getLeaderboard(uint8 tier, uint256 offset, uint256 limit)
         external
         view
         override
         returns (address[] memory vaults)
     {
-        // Count matching vaults
+        // Count matching vaults.
         uint256 total;
         for (uint256 i = 0; i < _vaultList.length; i++) {
             if (tier == 0 || _vaults[_vaultList[i]].tier == tier) {
@@ -153,13 +165,12 @@ contract AssetRegistry is IAssetRegistry, Ownable {
             }
         }
 
-        if (total == 0) return new address[](0);
+        if (total == 0 || offset >= total) return new address[](0);
 
-        // Build full sorted array
+        // Build the filtered (addr, aum) arrays.
         address[] memory allAddrs = new address[](total);
         uint256[] memory allAums = new uint256[](total);
         uint256 idx;
-
         for (uint256 i = 0; i < _vaultList.length; i++) {
             if (tier == 0 || _vaults[_vaultList[i]].tier == tier) {
                 allAddrs[idx] = _vaultList[i];
@@ -168,26 +179,29 @@ contract AssetRegistry is IAssetRegistry, Ownable {
             }
         }
 
-        // Simple insertion sort descending by AUM
-        for (uint256 i = 1; i < total; i++) {
-            address keyAddr = allAddrs[i];
-            uint256 keyAum = allAums[i];
-            uint256 j = i;
-            while (j > 0 && allAums[j - 1] < keyAum) {
-                allAddrs[j] = allAddrs[j - 1];
-                allAums[j] = allAums[j - 1];
-                j--;
+        // We only need the top `needed` ranked to serve [offset, offset+limit).
+        uint256 needed = (limit == 0 || offset + limit > total) ? total : offset + limit;
+
+        // Partial selection sort: pull the max into each of the first `needed`
+        // positions. O(total · needed) — bounded by the page for a real limit,
+        // versus the old O(total²) full sort.
+        for (uint256 i = 0; i < needed; i++) {
+            uint256 maxJ = i;
+            for (uint256 j = i + 1; j < total; j++) {
+                if (allAums[j] > allAums[maxJ]) {
+                    maxJ = j;
+                }
             }
-            allAddrs[j] = keyAddr;
-            allAums[j] = keyAum;
+            if (maxJ != i) {
+                (allAddrs[i], allAddrs[maxJ]) = (allAddrs[maxJ], allAddrs[i]);
+                (allAums[i], allAums[maxJ]) = (allAums[maxJ], allAums[i]);
+            }
         }
 
-        // Apply limit
-        uint256 resultCount = limit > 0 && limit < total ? limit : total;
-
+        uint256 resultCount = needed - offset;
         vaults = new address[](resultCount);
         for (uint256 i = 0; i < resultCount; i++) {
-            vaults[i] = allAddrs[i];
+            vaults[i] = allAddrs[offset + i];
         }
     }
 

--- a/contracts/src/interfaces/IAssetRegistry.sol
+++ b/contracts/src/interfaces/IAssetRegistry.sol
@@ -69,12 +69,14 @@ interface IAssetRegistry {
         bytes calldata metrics
     ) external;
 
-    /// @notice Get the top vaults by AUM for a given tier.
+    /// @notice Get the top vaults by AUM for a given tier, paginated (#927).
     /// @param tier 1 or 2 (0 = all tiers)
-    /// @param limit Max results to return
+    /// @param offset Number of top-ranked vaults to skip (page start)
+    /// @param limit Max results to return; 0 = all from offset onward
     /// @return vaults Array of vault addresses sorted by AUM descending
     function getLeaderboard(
         uint8 tier,
+        uint256 offset,
         uint256 limit
     ) external view returns (address[] memory vaults);
 

--- a/contracts/test/Registry.t.sol
+++ b/contracts/test/Registry.t.sol
@@ -672,7 +672,7 @@ contract AssetRegistryTest is Test {
         vm.stopPrank();
 
         // Get all tiers leaderboard
-        address[] memory leaderboard = registry.getLeaderboard(0, 0);
+        address[] memory leaderboard = registry.getLeaderboard(0, 0, 0);
         assertEq(leaderboard.length, 3);
         assertEq(leaderboard[0], v2); // AUM 3000
         assertEq(leaderboard[1], v3); // AUM 2000
@@ -692,12 +692,12 @@ contract AssetRegistryTest is Test {
         vm.stopPrank();
 
         // Tier 1 only
-        address[] memory tier1 = registry.getLeaderboard(1, 0);
+        address[] memory tier1 = registry.getLeaderboard(1, 0, 0);
         assertEq(tier1.length, 1);
         assertEq(tier1[0], v1);
 
         // Tier 2 only
-        address[] memory tier2 = registry.getLeaderboard(2, 0);
+        address[] memory tier2 = registry.getLeaderboard(2, 0, 0);
         assertEq(tier2.length, 1);
         assertEq(tier2[0], v2);
     }
@@ -718,14 +718,46 @@ contract AssetRegistryTest is Test {
         vm.stopPrank();
 
         // Limit to top 2
-        address[] memory top2 = registry.getLeaderboard(0, 2);
+        address[] memory top2 = registry.getLeaderboard(0, 0, 2);
         assertEq(top2.length, 2);
         assertEq(top2[0], v2); // 3000
         assertEq(top2[1], v3); // 2000
     }
 
+    /// @dev #927: pages via (offset, limit) must be sorted and DISJOINT.
+    function test_getLeaderboard_pagination_disjoint_pages() public {
+        address v1 = address(0x400);
+        address v2 = address(0x401);
+        address v3 = address(0x402);
+
+        vm.startPrank(owner);
+        registry.registerVault(v1, 1, "");
+        registry.registerVault(v2, 1, "");
+        registry.registerVault(v3, 1, "");
+        registry.updateVaultMetrics(v1, abi.encode(uint256(1000)));
+        registry.updateVaultMetrics(v2, abi.encode(uint256(3000)));
+        registry.updateVaultMetrics(v3, abi.encode(uint256(2000)));
+        vm.stopPrank();
+
+        // Sorted order is [v2 (3000), v3 (2000), v1 (1000)].
+        address[] memory page0 = registry.getLeaderboard(0, 0, 2); // offset 0, limit 2
+        assertEq(page0.length, 2);
+        assertEq(page0[0], v2);
+        assertEq(page0[1], v3);
+
+        address[] memory page1 = registry.getLeaderboard(0, 2, 2); // offset 2, limit 2
+        assertEq(page1.length, 1); // only one vault left past offset 2
+        assertEq(page1[0], v1);
+
+        // The two pages are disjoint and together cover the whole set.
+        assertTrue(page0[0] != page1[0] && page0[1] != page1[0]);
+
+        // An offset at or beyond the end returns empty (not a revert).
+        assertEq(registry.getLeaderboard(0, 3, 2).length, 0);
+    }
+
     function test_getLeaderboard_empty() public view {
-        address[] memory leaderboard = registry.getLeaderboard(0, 0);
+        address[] memory leaderboard = registry.getLeaderboard(0, 0, 0);
         assertEq(leaderboard.length, 0);
     }
 

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -616,7 +616,7 @@ export const TRACE_REGISTRY_ABI = [
 export const ASSET_REGISTRY_ABI = [
   { name: 'getAllSynthetics', type: 'function', stateMutability: 'view', inputs: [], outputs: [{ type: 'address[]' }] },
   { name: 'vaultCount',       type: 'function', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
-  { name: 'getLeaderboard',   type: 'function', stateMutability: 'view', inputs: [{ type: 'uint8' }, { type: 'uint256' }], outputs: [{ type: 'address[]' }] },
+  { name: 'getLeaderboard',   type: 'function', stateMutability: 'view', inputs: [{ type: 'uint8' }, { type: 'uint256' }, { type: 'uint256' }], outputs: [{ type: 'address[]' }] }, // (tier, offset, limit) — paginated (#927)
 ]
 
 export const VAULT_ABI = [


### PR DESCRIPTION
## Summary

`AssetRegistry.getLeaderboard` ran a full O(n²) insertion sort over **every** matching vault before applying the limit. As the vault set grows, that view exceeds the block gas limit and bricks both on-chain callers and `eth_call` reads (issue #927).

This replaces it with a **partial selection sort**: it extracts only the top `offset + limit` ranked vaults (O(total · (offset+limit))) and returns the `[offset, …)` slice, so a bounded page stays bounded in gas regardless of total vault count.

## Changes

- `getLeaderboard` gains an `offset` parameter → `(tier, offset, limit)`.
- `limit == 0` preserves the old "return all" behavior (and its O(n²) cost — callers should page with a real limit for large sets).
- `offset >= total` returns an empty array instead of reverting.
- `IAssetRegistry` interface + the cached frontend ABI in `ui/src/config.js` updated to the 3-arg signature.
- New test `test_getLeaderboard_pagination_disjoint_pages` asserts pages are sorted, disjoint, and that an out-of-range offset returns empty.

## Verify

```
cd contracts && forge build && forge test --match-contract AssetRegistryTest
```
→ 17 passed; 0 failed.

## Blast radius

`getLeaderboard` is only **declared** (interface + frontend ABI), not invoked anywhere in `backend/` or `ui/src/` — verified with grep — so the signature change has no runtime call sites to update beyond the ABI.

## Anti-goals

- No change to sort semantics (still AUM-descending).
- No touching of unrelated registry methods.

## Review

Contract change — routing to **Dan** (contract/infra owner) with **Bogdan (`mnemonik-dev`)** as preferred two-eyes reviewer, per the contract-review convention.

Closes #927
