### PR TITLE
[contracts] Price held tokens by real decimals, not a hardcoded 1e18 (#942)

### DIFF
--- a/contracts/src/SyntheticVault.sol
+++ b/contracts/src/SyntheticVault.sol
@@ -75,6 +75,8 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
     /// @notice Oracle price is older than mintBurnMaxStaleness on a mint/burn path (issue #910).
     error StaleOraclePrice(uint256 lastUpdated, uint256 maxStaleness, uint256 nowTs);
     error InvalidStalenessWindow();
+    /// @notice Thrown when the wired synth token's decimals != SYNTH_DECIMALS (#942).
+    error UnexpectedSynthDecimals();
 
     // ─── Constructor ─────────────────────────────────────────────────
 
@@ -87,6 +89,15 @@ contract SyntheticVault is Ownable, ReentrancyGuard {
         usdc       = IERC20(_usdc);
         synthToken = SyntheticToken(_synthToken);
         oracle     = PriceOracle(_oracle);
+
+        // The mint/burn/solvency math hardcodes 10**SYNTH_DECIMALS to convert
+        // between synth units and USDC value. That is correct only if the synth
+        // token actually reports SYNTH_DECIMALS decimals; enforce it at wiring
+        // time so a mismatched token reverts here instead of silently mispricing
+        // NAV and collateral downstream (#942).
+        if (SyntheticToken(_synthToken).decimals() != SYNTH_DECIMALS) {
+            revert UnexpectedSynthDecimals();
+        }
     }
 
     // ─── User Actions ────────────────────────────────────────────────

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
@@ -98,6 +99,15 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
 
     /// @notice Oracle address for each held token (for NAV pricing)
     mapping(address => address) public override tokenOracle;
+
+    /// @notice Cached 10**decimals for each priced token (#942). NAV/swap math
+    ///         previously hardcoded a 1e18 divisor, silently mispricing any held
+    ///         token whose ERC-20 decimals != 18. The unit is snapshotted from
+    ///         `token.decimals()` when its oracle is wired (see _cacheTokenUnit),
+    ///         so the funds-path pricing views never make an external decimals()
+    ///         call that could revert. 0 means "unset" and _tokenUnit() falls back
+    ///         to 1e18 — preserving the pre-fix behavior for any legacy token.
+    mapping(address => uint256) public tokenUnit;
 
     /// @notice Max slippage tolerance (in bps) applied to every AMM swap,
     ///         relative to the oracle-implied fair output. Owner-configurable,
@@ -345,10 +355,11 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             address oracle = tokenOracle[heldTokens[i]];
             if (oracle == address(0)) continue;
 
-            // synth tokens: 18 decimals, oracle price: 6 decimals (USDC)
-            // value in USDC (6 decimals) = balance(18) * price(6) / 1e18
+            // oracle price: 6 decimals (USDC) per one whole token.
+            // value in USDC (6 decimals) = balance(tokenDecimals) * price(6)
+            //                              / 10**tokenDecimals  (#942)
             uint256 price = PriceOracle(oracle).getPrice();
-            nav += (balance * price) / 1e18;
+            nav += (balance * price) / _tokenUnit(heldTokens[i]);
         }
 
         return nav;
@@ -486,6 +497,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         if (tokens.length != oracles.length) revert InvalidAllocations();
         for (uint256 i = 0; i < tokens.length; i++) {
             tokenOracle[tokens[i]] = oracles[i];
+            _cacheTokenUnit(tokens[i]);
         }
         emit TokenOraclesSet(tokens.length);
     }
@@ -508,8 +520,32 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             address oracle = assetRegistry.registeredOracle(tokens[i]);
             if (oracle == address(0)) revert OracleNotRegistered(tokens[i]);
             tokenOracle[tokens[i]] = oracle;
+            _cacheTokenUnit(tokens[i]);
         }
         emit TokenOraclesSetFromRegistry(tokens.length);
+    }
+
+    /// @dev Snapshot 10**decimals for a token so NAV/swap math scales by the
+    ///      token's real precision instead of a hardcoded 1e18 (#942). Called
+    ///      when an oracle is wired for the token — an owner/manager action, so
+    ///      any misbehaving decimals() surfaces there, never inside the funds
+    ///      path. Falls back to 1e18 if the token doesn't expose decimals(),
+    ///      preserving the pre-fix behavior and keeping registration from
+    ///      reverting on a minimal ERC-20.
+    function _cacheTokenUnit(address token) internal {
+        try IERC20Metadata(token).decimals() returns (uint8 dec) {
+            tokenUnit[token] = 10 ** uint256(dec);
+        } catch {
+            tokenUnit[token] = 1e18;
+        }
+    }
+
+    /// @dev The cached 10**decimals scale for a token, defaulting to 1e18 when
+    ///      unset so a token priced before this cache existed keeps the old
+    ///      18-decimal assumption instead of dividing by 10**0 == 1.
+    function _tokenUnit(address token) internal view returns (uint256) {
+        uint256 unit = tokenUnit[token];
+        return unit == 0 ? 1e18 : unit;
     }
 
     function getHoldings()
@@ -581,11 +617,12 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         on-chain oracle price, minus the bounded slippage tolerance.
     /// @dev    Exactly one side of every vault swap is USDC (the vault asset);
     ///         the other side is a synth token. Decimal conventions (matching
-    ///         totalAssets()): USDC has 6 decimals; synth tokens have 18;
-    ///         oracle prices are USDC (6 decimals) per 1e18 synth units.
+    ///         totalAssets()): USDC has 6 decimals; oracle prices are USDC
+    ///         (6 decimals) per one whole synth token; the synth side scales by
+    ///         its cached unit = 10**decimals (#942), not a hardcoded 1e18.
     ///
-    ///         synth -> USDC: expectedOut(6) = amountIn(18) * price(6) / 1e18
-    ///         USDC -> synth: expectedOut(18) = amountIn(6) * 1e18 / price(6)
+    ///         synth -> USDC: expectedOut(6) = amountIn(dec) * price(6) / unit
+    ///         USDC -> synth: expectedOut(dec) = amountIn(6) * unit / price(6)
     ///
     ///         Reverts if the non-USDC side has no registered oracle (an
     ///         unpriced swap would be unprotected) or the oracle price is zero.
@@ -603,9 +640,11 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         uint256 price = PriceOracle(oracle).getPrice();
         if (price == 0) revert InvalidOraclePrice();
 
+        // Scale by the non-USDC token's real precision, not a hardcoded 1e18 (#942).
+        uint256 unit = _tokenUnit(synth);
         uint256 expectedOut = tokenIn == address(asset)
-            ? (amountIn * 1e18) / price // buy: USDC(6) -> synth(18)
-            : (amountIn * price) / 1e18; // sell: synth(18) -> USDC(6)
+            ? (amountIn * unit) / price // buy: USDC(6) -> synth(unit)
+            : (amountIn * price) / unit; // sell: synth(unit) -> USDC(6)
 
         minAmountOut = (expectedOut * (BPS - maxSlippageBps)) / BPS;
     }
@@ -623,7 +662,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             if (oracle == address(0)) continue;
 
             uint256 price = PriceOracle(oracle).getPrice();
-            totalNonUsdcValue += (balance * price) / 1e18;
+            totalNonUsdcValue += (balance * price) / _tokenUnit(heldTokens[i]);
         }
 
         if (totalNonUsdcValue == 0) revert InsufficientLiquidity();
@@ -648,12 +687,13 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             if (oracle == address(0)) continue;
 
             uint256 price = PriceOracle(oracle).getPrice();
-            uint256 tokenValue = (balance * price) / 1e18;
+            uint256 unit = _tokenUnit(heldTokens[i]);
+            uint256 tokenValue = (balance * price) / unit;
             if (tokenValue == 0) continue;
 
             // This token's proportional share of the liquidation
             uint256 targetValue = (liquidationTarget * tokenValue) / totalNonUsdcValue;
-            uint256 tokensToSell = (targetValue * 1e18) / price;
+            uint256 tokensToSell = (targetValue * unit) / price;
             if (tokensToSell == 0) continue;
             if (tokensToSell > balance) tokensToSell = balance;
 

--- a/contracts/test/SyntheticVault.t.sol
+++ b/contracts/test/SyntheticVault.t.sol
@@ -73,6 +73,23 @@ contract SyntheticVaultTest is Test {
         usdc.mint(bob,   100_000 * 10**6);
     }
 
+    // ─── #942: synth-decimals invariant ───────────────────────────
+
+    /// @dev The mint/burn/solvency math hardcodes 10**SYNTH_DECIMALS, so the
+    ///      constructor must reject a synth token whose decimals != 18 rather
+    ///      than silently mispricing NAV and collateral. MockUSDC reports 6
+    ///      decimals; using it as the synth token must revert.
+    function test_revert_constructor_non18_decimal_synth() public {
+        vm.expectRevert(SyntheticVault.UnexpectedSynthDecimals.selector);
+        new SyntheticVault(address(usdc), address(usdc), address(oracle), owner);
+    }
+
+    /// @dev Positive control: the real 18-decimal SyntheticToken constructs fine
+    ///      and the vault's SYNTH_DECIMALS matches the token's reported decimals.
+    function test_constructor_accepts_18_decimal_synth() public view {
+        assertEq(uint256(sTSLA.decimals()), vault.SYNTH_DECIMALS());
+    }
+
     // ─── Oracle Tests ─────────────────────────────────────────────
 
     function test_oracle_initial_price() public view {

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -34,6 +34,21 @@ contract MockToken is ERC20 {
     }
 }
 
+/// @dev A non-18-decimal token (8 decimals) for the #942 NAV-pricing tests.
+contract MockToken8 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+        _mint(msg.sender, 1_000_000 * 10**8);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 8;
+    }
+}
+
 contract VaultTest is Test {
     MockUSDC public usdc;
     AMMRouter public router;
@@ -1041,6 +1056,79 @@ contract VaultTest is Test {
         vault.deposit(amount, alice);
 
         assertEq(vault.totalAssets(), amount);
+    }
+
+    // ─── #942: decimal-aware NAV pricing ──────────────────────────────
+
+    /// @dev Wiring an oracle snapshots 10**decimals for the token, so NAV/swap
+    ///      math scales by the token's real precision. sTSLA (18 dec, wired in
+    ///      setUp) caches 1e18; an 8-decimal token caches 1e8; an unwired token
+    ///      falls back to 1e18 via the getter default (but the public mapping
+    ///      itself is still 0).
+    function test_tokenUnit_cached_from_decimals() public {
+        // sTSLA is 18-decimal and was wired in setUp.
+        assertEq(vault.tokenUnit(address(sTSLA)), 1e18);
+
+        MockToken8 eightDec = new MockToken8("Eight", "E8");
+        PriceOracle eightOracle = new PriceOracle("E8", 2 * 10**6, owner);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(eightDec);
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(eightOracle);
+        vm.prank(agent);
+        vault.setTokenOracles(tokens, oracles);
+
+        assertEq(vault.tokenUnit(address(eightDec)), 10**8);
+    }
+
+    /// @dev End-to-end regression: a rebalance-buy into an 8-decimal token
+    ///      conserves NAV. Under the old hardcoded 1e18 divisor the 8-decimal
+    ///      holding would be priced at ~1e-10 of its true value, so totalAssets
+    ///      would collapse to just the unspent USDC. With the cached 1e8 unit,
+    ///      totalAssets stays ~= the deposit (fee + price impact aside).
+    function test_totalAssets_prices_non18_decimal_token() public {
+        // Fresh 8-decimal synth + oracle + AMM pool, aligned at 2 USDC / token
+        // (10,000,000 USDC : 5,000,000 token, same value ratio as TSLA_PRICE).
+        MockToken8 s8 = new MockToken8("Synthetic8", "S8");
+        PriceOracle o8 = new PriceOracle("S8", TSLA_PRICE, owner);
+
+        router.createPool(address(usdc), address(s8));
+        uint256 poolUsdc = 10_000_000 * 10**6;
+        uint256 poolS8 = 5_000_000 * 10**8; // 8-decimal reserves
+        usdc.mint(address(this), poolUsdc);
+        s8.mint(address(this), poolS8);
+        usdc.approve(address(router), poolUsdc);
+        s8.approve(address(router), poolS8);
+        router.addLiquidity(address(usdc), address(s8), poolUsdc, poolS8, 0);
+
+        address[] memory oracleTokens = new address[](1);
+        oracleTokens[0] = address(s8);
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(o8);
+        vm.prank(agent);
+        vault.setTokenOracles(oracleTokens, oracles);
+
+        uint256 deposit = 50_000 * 10**6;
+        _depositAsAlice(deposit);
+
+        // Buy ~40k USDC of the 8-decimal token so most of the NAV sits in the
+        // non-USDC holding — the slice the old 1e18 scaling mispriced to dust.
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(s8);
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = 40_000 * 10**6;
+        address[] memory tokensOut = new address[](0);
+        uint256[] memory amountsOut = new uint256[](0);
+        _commitFor(tokensIn, amountsIn, tokensOut, amountsOut);
+        vm.prank(agent);
+        vault.rebalance(tokensIn, amountsIn, tokensOut, amountsOut);
+
+        // Vault holds ~40k of the 8-decimal token plus ~10k USDC. NAV must stay
+        // within ~1% of the deposit (30bps AMM fee + bounded price impact).
+        assertApproxEqRel(vault.totalAssets(), deposit, 0.01e18);
+        // And the 8-decimal holding must contribute the bulk of NAV, not dust:
+        // strictly more than the leftover USDC alone would (old-code failure).
+        assertGt(vault.totalAssets(), 20_000 * 10**6);
     }
 
     // ─── Fee Tests ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`Vault` NAV and swap math divided/multiplied by a hardcoded `1e18`, assuming **every** held token is 18-decimal. A non-18-decimal token (e.g. an 8-decimal synth) was mispriced by `10**(18 − decimals)` in `totalAssets`, `_oracleMinOut`, and `_liquidateToUsdc` — understating NAV and setting a wrong AMM slippage floor. `SyntheticVault` has the same hardcoded assumption for its synth token (issue #942).

## Changes

**`Vault.sol`** (acceptance option 2 — validate/cache on register):
- New `tokenUnit` mapping snapshots `10**decimals` per token when its oracle is wired (`setTokenOracles` / `setTokenOraclesFromRegistry`). The `decimals()` call happens at that owner/manager action — **never in the funds-path pricing views** — so a misbehaving token can't brick `totalAssets` and lock user funds. `try/catch` falls back to `1e18` if the token doesn't expose `decimals()`.
- `_tokenUnit()` returns `1e18` when unset, so the change is **strictly backward-compatible** for existing 18-decimal synths.
- Replaced the six pricing-path `1e18` divisors/multipliers with `_tokenUnit(token)`. The **share-accounting** `1e18` (`highWaterMark` / performance-fee scale) is deliberately left untouched.

**`SyntheticVault.sol`** (the synth is protocol-deployed and always 18-decimal):
- Enforce the invariant at construction: revert `UnexpectedSynthDecimals` if the wired synth token's `decimals() != SYNTH_DECIMALS`, turning a silent misprice into a loud deploy-time failure.

## Verify

```
cd contracts && forge build && forge test
```
→ **253 passed; 0 failed.**

New tests:
- `test_tokenUnit_cached_from_decimals` — caching + 18-dec default.
- `test_totalAssets_prices_non18_decimal_token` — 8-decimal token end-to-end NAV.
- `test_revert_constructor_non18_decimal_synth` + `test_constructor_accepts_18_decimal_synth`.

**Negative control:** neutralizing `_tokenUnit()` to always return `1e18` makes `test_totalAssets_prices_non18_decimal_token` fail with `SlippageExceeded()` (the 8-decimal token's min-out is off by 10^10), confirming the test catches the bug.

## Anti-goals

- No change to 18-decimal behavior (all pre-existing tests pass unchanged).
- Share-accounting / performance-fee `1e18` scale untouched.
- No external `decimals()` call added to any view on the deposit/withdraw path.

## Review

Contract change touching NAV + swap math (fund-path) — routing to **Dan** (contract/infra owner) with **Bogdan (`mnemonik-dev`)** as preferred two-eyes reviewer.

Closes #942
