### PR TITLE
[infra] Format auth_siwe.py to unblock the ruff-gate on main

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -182,9 +182,8 @@ async def get_nonce():
 
     return {
         "nonce": nonce,
-        "domain": os.getenv("PUBLIC_DOMAIN") or "https://archimedes-arc.com"
-        .replace("https://", "")
-        .replace("http://", ""),
+        "domain": os.getenv("PUBLIC_DOMAIN")
+        or "https://archimedes-arc.com".replace("https://", "").replace("http://", ""),
         "issued_at": int(now),
         "expiry_seconds": _NONCE_TTL_SECONDS,
     }


### PR DESCRIPTION
## Summary — merge this first; it unblocks every other open PR

`backend/archimedes/api/auth_siwe.py` on `main` has a **ruff-format violation** (introduced by the direct-to-main auth commit `5135abd`). Because the PR `ruff-gate` runs `ruff format --check .` against the **PR-merged-with-main** tree, this strands the ruff-gate on **every open PR** — including contract-only PRs (#1023–1026) that touch no Python at all.

`main-format-guard.yml` is supposed to self-heal this, but it **can't**: its `GITHUB_TOKEN` push is rejected by branch protection —

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
 ! [remote rejected] main -> main (protected branch hook declined)
```

So the guard fails its run without committing the fix, and `main` stays broken. The only way to restore a green base is a PR that passes the required checks.

## Change

`ruff format` on the single offending file. **Formatting-only** — it rewraps one `or`-expression across lines; the parsed operator precedence is identical, so there is no behavior change.

```diff
-        "domain": os.getenv("PUBLIC_DOMAIN") or "https://archimedes-arc.com"
-        .replace("https://", "")
-        .replace("http://", ""),
+        "domain": os.getenv("PUBLIC_DOMAIN")
+        or "https://archimedes-arc.com".replace("https://", "").replace("http://", ""),
```

## Verify

```
ruff format --check backend/archimedes/api/auth_siwe.py   # 1 file already formatted
ruff format --check .                                       # all files formatted
```

## Note for the team

- Once merged, the other open PRs' ruff-gates go green on their next run (re-run or a trivial rebase).
- Separately worth a look (not changed here to avoid touching auth behavior in a format PR): the `.replace(...)` chain binds to the `"https://archimedes-arc.com"` *fallback literal* only, not to a set `PUBLIC_DOMAIN` value — so a `PUBLIC_DOMAIN` like `https://foo.com` keeps its scheme. If stripping the scheme from the env value is intended, that's a one-line follow-up (relates to #940).