### PR TITLE
[infra] Codify Aurora deletion protection + final snapshot

### DIFF
--- a/infra/aurora.tf
+++ b/infra/aurora.tf
@@ -67,7 +67,9 @@ resource "aws_rds_cluster" "main" {
   vpc_security_group_ids = [aws_security_group.aurora.id]
 
   storage_encrypted = true
-  # deletion_protection = true  # Enable after migration is verified — see follow-up note in PR
+  # Real user data has been live in this cluster since 2026-06-24. Deletion protection was
+  # enabled live via the CLI on 2026-07-05; this codifies it so `terraform apply` won't revert it.
+  deletion_protection                 = true
   iam_database_authentication_enabled = true # enables IAM-based DB auth as alternative to password (no cost)
 
   # Aurora automated backups — 7 days is the standard production retention.
@@ -79,10 +81,11 @@ resource "aws_rds_cluster" "main" {
     max_capacity = 16
   }
 
-  # Skip final snapshot during development (enable for production)
-  # Follow-up: flip skip_final_snapshot=false + deletion_protection=true
-  # BEFORE any real user data lands in the cluster.
-  skip_final_snapshot = true
+  # Real user data is live — take a final snapshot on deletion (destroy-time-only attrs;
+  # changing these produces no infrastructure change on apply). deletion_protection above
+  # blocks destroy outright; this is the second safety net if protection is ever lifted.
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.project_name}-aurora-final"
 
   tags = {
     Project = var.project_name


### PR DESCRIPTION
## Summary

`deletion_protection` and `skip_final_snapshot` were both **commented out** in `infra/aurora.tf`, so the next `terraform apply` would revert the deletion protection that was enabled **live via the CLI on 2026-07-05**. Real user data has been in the cluster since the 2026-06-24 migration, so an accidental `terraform destroy` / console delete with the old config would mean **total, unrecoverable data loss** (no final snapshot).

Surfaced by the 2026-07-05 data-architecture audit — this is Phase 0 ("stop the bleeding") of #1028.

## Changes

- **`deletion_protection = true`** — the one that matters. It now **matches the live cluster**, so `terraform plan` shows **no change** for it (no drift, no revert).
- **`skip_final_snapshot = false` + `final_snapshot_identifier`** — second safety net (a final snapshot if protection is ever deliberately lifted before a destroy).

## Apply-safety note

`skip_final_snapshot` / `final_snapshot_identifier` are **destroy-time-only** attributes — changing them produces **no infrastructure change on apply**. The only live-affecting attribute, `deletion_protection`, already matches the running cluster. Net: reviewing the plan during the T3.2 redeploy, the only Aurora line items should be these benign state-only fields.

`terraform fmt -check` passes.

## Verify

```bash
cd infra && terraform plan   # Aurora: no destructive changes; deletion_protection already true on the live cluster
```

## Anti-goals

- No changes to scaling, backup retention, encryption, subnet/SG wiring, or any other resource.
- Not part of this PR: the broader identity/data-architecture work tracked in #1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)