### PR TITLE
[infra][ci] Decouple the required unit-test check from the PyTorch wheel CDN

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -37,7 +37,14 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install
-        run: pip install --quiet -r backend/requirements.txt "pytest>=8.3" "pytest-asyncio>=0.24" "pytest-cov>=5.0" "fakeredis[lua]>=2.26.0"
+        # Unit tests never load the embedding model — paper_rag.py lazy-imports
+        # torch/sentence-transformers and falls back to TF-IDF on ImportError, and
+        # test_paper_rag.py mocks sentence_transformers. Skipping them here keeps the
+        # required check off the pytorch wheel CDN (an SSL-flaky external dependency)
+        # and cuts ~2.5GB + minutes off every run. They stay in the prod Docker image.
+        run: |
+          grep -vE '^(--extra-index-url https://download\.pytorch\.org|torch[ >=<~!]|sentence-transformers[ >=<~!])' backend/requirements.txt > /tmp/req-ci.txt
+          pip install --quiet -r /tmp/req-ci.txt "pytest>=8.3" "pytest-asyncio>=0.24" "pytest-cov>=5.0" "fakeredis[lua]>=2.26.0"
       - name: Test
         run: pytest -m "not integration" --tb=short -q
 
@@ -185,7 +192,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install --quiet -r backend/requirements.txt "pytest>=8.3" "pytest-asyncio>=0.24" "pytest-cov>=5.0"
+      # Same torch/sentence-transformers skip as the unit-test job above (CDN-independent).
+      - run: |
+          grep -vE '^(--extra-index-url https://download\.pytorch\.org|torch[ >=<~!]|sentence-transformers[ >=<~!])' backend/requirements.txt > /tmp/req-ci.txt
+          pip install --quiet -r /tmp/req-ci.txt "pytest>=8.3" "pytest-asyncio>=0.24" "pytest-cov>=5.0"
       - run: pytest -m "not integration" --cov=archimedes --cov-fail-under=60 --tb=short -q
 
   supply-chain:


### PR DESCRIPTION
## Summary

The **required** \`Backend — unit tests\` check installs \`backend/requirements.txt\`, which pulls **torch (CPU wheel) + sentence-transformers** from \`download.pytorch.org\`. That CDN (\`download-r2.pytorch.org\`) began throwing sustained **\`SSLV3_ALERT_HANDSHAKE_FAILURE\`** errors on 2026-07-06 ~17:29 UTC, failing the required check on **main itself** and **every open PR** — walling all merges on an external outage.

## Why this is safe

Unit tests never load the embedding model:
- \`paper_rag.py\` lazy-imports torch/sentence-transformers *inside* \`get_embedding_model()\` and falls back to **TF-IDF** on \`ImportError\`.
- \`test_paper_rag.py\` **mocks** \`sentence_transformers\` to exercise exactly that degradation path.

So \`pytest -m "not integration"\` doesn't need either package. **Verified locally without torch installed: \`2571 passed, 0 failed\`** (the exact CI command).

## Change

Filter \`torch\`, \`sentence-transformers\`, and the pytorch \`--extra-index-url\` out of the two Python test-job installs (unit + coverage). They remain in \`requirements.txt\` and the **prod Docker image** unchanged. Net: the required check no longer touches the pytorch CDN, and every run drops ~2.5GB + several minutes.

## Verify

```bash
# with torch NOT installed:
pytest -m "not integration" -q   # → 2571 passed
```

This PR must land on \`main\` first so other open PRs pick up the CDN-independent workflow on rebase.

## Anti-goals

- No change to \`requirements.txt\`, the Docker image, or runtime behavior — torch/sentence-transformers still ship to prod.
- No change to which tests run or the coverage threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)