### PR TITLE
[backend] Emit SSE heartbeat during debate compute to prevent transport drop (#891)

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -49,6 +49,17 @@ generate_router = APIRouter(prefix="/api/generate", tags=["generate"])
 _TERMINAL_EVENTS = {"done", "error"}
 _POLL_INTERVAL_SECONDS = 0.4
 _STREAM_TIMEOUT_SECONDS = 300  # cap a single SSE connection at 5 min
+# How long the connection may go byte-silent before we push a keep-alive
+# comment (#891). Debate/fan-out compute (sequential adversarial LLM turns,
+# then a parallel backtest gather across the whole candidate pool) can run
+# for tens of seconds without producing a new job-store event — the poll
+# loop previously just slept through that stretch and wrote nothing to the
+# socket. CloudFront's default origin idle-read timeout (60s) and various
+# corporate/browser proxies will drop a chunked connection that's gone
+# quiet that long, even though the origin is still alive and the job keeps
+# running server-side. A ~15s heartbeat cadence gives multiple safety
+# margins under any such timeout.
+_HEARTBEAT_INTERVAL_SECONDS = 15.0
 
 # Live registry of in-flight asyncio tasks per job. Lets cancel_job actually
 # stop the work — without this, /cancel only flips Redis status while the
@@ -233,6 +244,7 @@ async def stream_events(
 
         cursor = last_event_id
         elapsed = 0.0
+        since_heartbeat = 0.0
         while elapsed < _STREAM_TIMEOUT_SECONDS:
             if await request.is_disconnected():
                 logger.info("sse client disconnected (job=%s, after=%d)", sanitize_log_value(job_id), cursor)
@@ -242,11 +254,23 @@ async def stream_events(
             for ev in new_events:
                 cursor = ev["id"]
                 yield _format_sse(ev)
+                since_heartbeat = 0.0  # a real event resets the silence clock too
                 if ev.get("event") in _TERMINAL_EVENTS:
                     return
 
+            # No new events this cycle — a long-running compute step (debate
+            # turns, candidate-fan-out backtests) may keep the job busy for a
+            # while yet. Emit a keep-alive comment so the connection never
+            # goes byte-silent long enough for an intermediary to decide it's
+            # dead (#891). SSE comment lines are ignored by EventSource/any
+            # spec-compliant parser, so this is invisible to application code.
+            if since_heartbeat >= _HEARTBEAT_INTERVAL_SECONDS:
+                yield ": heartbeat\n\n"
+                since_heartbeat = 0.0
+
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)
             elapsed += _POLL_INTERVAL_SECONDS
+            since_heartbeat += _POLL_INTERVAL_SECONDS
 
         # Heartbeat-timeout exit — client can reconnect with Last-Event-ID.
         yield ": stream timeout\n\n"

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -243,9 +243,16 @@ async def stream_events(
         yield ": stream opened\n\n"
 
         cursor = last_event_id
-        elapsed = 0.0
-        since_heartbeat = 0.0
-        while elapsed < _STREAM_TIMEOUT_SECONDS:
+        # Wall-clock, not accumulated sleep duration: list_events() latency or
+        # scheduler jitter can make a single loop iteration take longer than
+        # _POLL_INTERVAL_SECONDS, and summing the intended sleep length instead
+        # of measuring real elapsed time would undercount silence and could
+        # delay a heartbeat past _HEARTBEAT_INTERVAL_SECONDS -- reintroducing
+        # the idle-disconnect this fix exists to prevent.
+        loop = asyncio.get_running_loop()
+        stream_start = loop.time()
+        last_heartbeat_at = stream_start
+        while loop.time() - stream_start < _STREAM_TIMEOUT_SECONDS:
             if await request.is_disconnected():
                 logger.info("sse client disconnected (job=%s, after=%d)", sanitize_log_value(job_id), cursor)
                 return
@@ -254,7 +261,7 @@ async def stream_events(
             for ev in new_events:
                 cursor = ev["id"]
                 yield _format_sse(ev)
-                since_heartbeat = 0.0  # a real event resets the silence clock too
+                last_heartbeat_at = loop.time()  # a real event resets the silence clock too
                 if ev.get("event") in _TERMINAL_EVENTS:
                     return
 
@@ -264,13 +271,12 @@ async def stream_events(
             # goes byte-silent long enough for an intermediary to decide it's
             # dead (#891). SSE comment lines are ignored by EventSource/any
             # spec-compliant parser, so this is invisible to application code.
-            if since_heartbeat >= _HEARTBEAT_INTERVAL_SECONDS:
+            now = loop.time()
+            if now - last_heartbeat_at >= _HEARTBEAT_INTERVAL_SECONDS:
                 yield ": heartbeat\n\n"
-                since_heartbeat = 0.0
+                last_heartbeat_at = now
 
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)
-            elapsed += _POLL_INTERVAL_SECONDS
-            since_heartbeat += _POLL_INTERVAL_SECONDS
 
         # Heartbeat-timeout exit — client can reconnect with Last-Event-ID.
         yield ": stream timeout\n\n"

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -54,11 +54,11 @@ _STREAM_TIMEOUT_SECONDS = 300  # cap a single SSE connection at 5 min
 # then a parallel backtest gather across the whole candidate pool) can run
 # for tens of seconds without producing a new job-store event — the poll
 # loop previously just slept through that stretch and wrote nothing to the
-# socket. CloudFront's default origin idle-read timeout (60s) and various
-# corporate/browser proxies will drop a chunked connection that's gone
-# quiet that long, even though the origin is still alive and the job keeps
-# running server-side. A ~15s heartbeat cadence gives multiple safety
-# margins under any such timeout.
+# socket. Intermediaries with an idle-read timeout shorter than that stretch
+# (CloudFront's origin idle timeout, corporate/browser proxies) will drop a
+# chunked connection that's gone quiet that long, even though the origin is
+# still alive and the job keeps running server-side. A ~15s heartbeat
+# cadence gives multiple safety margins under any such timeout.
 _HEARTBEAT_INTERVAL_SECONDS = 15.0
 
 # Live registry of in-flight asyncio tasks per job. Lets cancel_job actually

--- a/backend/tests/test_generate_stream_heartbeat.py
+++ b/backend/tests/test_generate_stream_heartbeat.py
@@ -1,0 +1,142 @@
+"""SSE heartbeat during long-running debate/fan-out compute (#891).
+
+Reproduced against prod: the generation SSE stream advances through
+``job_queued -> ... -> agent_iteration -> tool_called`` then the transport
+dies ("peer closed connection ... incomplete chunked read") once debate
+compute starts, even though the job keeps running server-side. Root cause:
+``stream_events``'s poll loop only wrote bytes to the response when a new
+job-store event existed; during a long silent compute stretch (sequential
+debate LLM turns, then a parallel backtest gather across the whole
+candidate pool) it would sit in ``asyncio.sleep`` cycles writing nothing at
+all. Any intermediary with an idle-read timeout shorter than that stretch
+(CloudFront's default origin idle timeout, corporate proxies, etc.) drops a
+chunked connection that goes byte-silent that long, independent of whether
+the origin is still alive.
+
+Fix: emit a ``: heartbeat\\n\\n`` SSE comment every
+``_HEARTBEAT_INTERVAL_SECONDS`` of silence. SSE comments are ignored by
+EventSource/any spec-compliant parser, so this changes nothing for the
+client's event handling — it only keeps the transport from going quiet.
+
+Hermetic: the Redis-backed job store is boundary-mocked (test_generate_job_scoping
+precedent); no real Redis/DB/LLM call. The poll/heartbeat cadence constants are
+monkeypatched down so the test runs in well under a second of wall-clock time
+instead of needing tens of real seconds to observe a heartbeat.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+_JOB_ID = "job-heartbeat-1"
+
+
+def _job() -> dict:
+    return {
+        "id": _JOB_ID,
+        "type": "generate",
+        "status": "running",
+        "created_at": "2026-07-07T00:00:00+00:00",
+        "updated_at": "2026-07-07T00:00:05+00:00",
+        "payload": {"owner_wallet": None, "brief": {"intent": "x"}, "n_candidates": 1},
+        "result": {},
+    }
+
+
+def _mock_store_with_delayed_terminal_event(*, silent_cycles: int) -> MagicMock:
+    """A store whose ``list_events`` returns nothing for ``silent_cycles`` polls
+    (simulating a long-running debate/backtest compute stretch with no new
+    job-store event), then returns a terminal ``done`` event so the stream
+    generator returns cleanly.
+    """
+    store = MagicMock()
+    store.get = AsyncMock(return_value=_job())
+    calls = {"n": 0}
+
+    async def _list_events(_job_id: str, *, after_id: int = 0):
+        calls["n"] += 1
+        if calls["n"] <= silent_cycles:
+            return []
+        return [{"id": after_id + 1, "event": "done", "data": {"job_id": _job_id}}]
+
+    store.list_events = AsyncMock(side_effect=_list_events)
+    return store
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_emitted_during_long_silent_compute_stretch(monkeypatch):
+    """The stream must not go byte-silent across a simulated long compute step.
+
+    Sets a tiny poll interval and heartbeat interval so ~30 silent poll cycles
+    (standing in for a slow debate/backtest phase that produces no job-store
+    event) comfortably cross several heartbeat boundaries — proving the
+    generator writes keep-alive bytes on its own, not just at connect/timeout.
+    """
+    import archimedes.api.generate_routes as routes
+
+    monkeypatch.setattr(routes, "_POLL_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(routes, "_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setenv("TESTING", "1")
+
+    store = _mock_store_with_delayed_terminal_event(silent_cycles=30)
+
+    with patch("archimedes.api.generate_routes.get_job_store", return_value=store):
+        from archimedes.main import app
+
+        chunks: list[str] = []
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with client.stream("GET", f"/api/generate/stream/{_JOB_ID}") as resp:
+                assert resp.status_code == 200
+                async for line in resp.aiter_lines():
+                    chunks.append(line)
+
+    heartbeat_lines = [c for c in chunks if c.strip() == ": heartbeat"]
+    done_lines = [c for c in chunks if c.strip() == "event: done"]
+
+    # The silent stretch (30 cycles x 0.001s poll, heartbeat every 0.01s) must
+    # have produced at least one keep-alive comment before the terminal event —
+    # this is the exact byte-silence gap that let CloudFront/proxies drop the
+    # connection in the #891 repro.
+    assert len(heartbeat_lines) >= 1, f"expected at least one heartbeat, got chunks={chunks}"
+    # And the stream still correctly delivers the terminal event afterward —
+    # heartbeats must not interfere with normal event delivery or the
+    # generator's terminal-event return.
+    assert done_lines, f"expected a terminal 'done' event in the stream, got chunks={chunks}"
+
+
+@pytest.mark.asyncio
+async def test_no_heartbeat_needed_when_events_flow_continuously(monkeypatch):
+    """Sanity check: when events keep arriving, no heartbeat filler is needed —
+    the silence clock resets on every real event so we don't spam comments
+    into an already-live stream.
+    """
+    import archimedes.api.generate_routes as routes
+
+    monkeypatch.setattr(routes, "_POLL_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(routes, "_HEARTBEAT_INTERVAL_SECONDS", 10.0)  # effectively unreachable
+    monkeypatch.setenv("TESTING", "1")
+
+    store = MagicMock()
+    store.get = AsyncMock(return_value=_job())
+    store.list_events = AsyncMock(
+        side_effect=[
+            [{"id": 1, "event": "agent_iteration", "data": {"job_id": _JOB_ID}}],
+            [{"id": 2, "event": "done", "data": {"job_id": _JOB_ID}}],
+        ]
+    )
+
+    with patch("archimedes.api.generate_routes.get_job_store", return_value=store):
+        from archimedes.main import app
+
+        chunks: list[str] = []
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with client.stream("GET", f"/api/generate/stream/{_JOB_ID}") as resp:
+                assert resp.status_code == 200
+                async for line in resp.aiter_lines():
+                    chunks.append(line)
+
+    heartbeat_lines = [c for c in chunks if c.strip() == ": heartbeat"]
+    assert not heartbeat_lines, f"unexpected heartbeat with continuously-flowing events: {chunks}"

--- a/backend/tests/test_generate_stream_heartbeat.py
+++ b/backend/tests/test_generate_stream_heartbeat.py
@@ -1,6 +1,6 @@
 """SSE heartbeat during long-running debate/fan-out compute (#891).
 
-Reproduced against prod: the generation SSE stream advances through
+Reported/observed in prod (#891): the generation SSE stream advances through
 ``job_queued -> ... -> agent_iteration -> tool_called`` then the transport
 dies ("peer closed connection ... incomplete chunked read") once debate
 compute starts, even though the job keeps running server-side. Root cause:


### PR DESCRIPTION
## Root cause

`stream_events` in `backend/archimedes/api/generate_routes.py` polls the job's Redis event log every 0.4s and only ever writes bytes to the response inside the `for ev in new_events` loop — when there are no new events it just `await asyncio.sleep(0.4)`s with nothing written to the socket.

During the debate/fan-out pipeline (`backend/archimedes/agents/debate_engine.py`) this produces a real silent stretch:
- `_debate_round` runs 4 sequential LLM turns (`backend.complete` via `asyncio.to_thread`), only emitting `tool_called`/`tool_result` around each turn, not mid-call.
- `_critic_rigor` does `asyncio.gather` of `to_thread(_backtest, p)` across the **whole candidate pool** with a single `tool_called: evaluate_fusion_spec` before it and nothing until it returns.

Neither step blocks the event loop (everything CPU/LLM-bound is correctly wrapped in `asyncio.to_thread`), so the SSE generator task keeps getting scheduled — it just has nothing to say. That silent stretch can run tens of seconds, comfortably past a default CloudFront origin idle-read timeout (60s) or various proxy/browser idle timeouts, which will terminate a chunked connection that's gone quiet that long even though the origin is still alive. That matches the report exactly: the client sees "peer closed connection... incomplete chunked read" right as debate starts, while the job keeps running server-side (it's driven by a detached `asyncio.create_task`, unaffected by the client stream dying).

nginx (`nginx/nginx.conf`) and the ALB (`infra/alb.tf`) are already sized generously for SSE (`proxy_read_timeout 300s` / `idle_timeout 300`) — this isn't an nginx/ALB timeout problem. **I could not verify the CloudFront-layer idle timeout directly** (no AWS access in this environment) — `infra/cloudfront.tf`'s `/api/*` behavior doesn't set a custom `origin_read_timeout` on the origin, so it's on CloudFront's default. Flagging this per repo convention: **infra config (CloudFront origin timeout) is Dan's review lane** — worth a look alongside this app-side fix, since the file's own header comment ("OPTIONAL / virality-prep... INERT until terraform apply") reads as stale given CLAUDE.md says CloudFront is live in front of prod.

## Fix

Track elapsed silence since the last byte written; when a poll cycle finds no new events and `_HEARTBEAT_INTERVAL_SECONDS` (15s) of silence has accumulated, yield `": heartbeat\n\n"` — an SSE comment line, ignored by `EventSource`/any spec-compliant parser, so no client-side change needed. The silence clock resets on every real event too, so a normally-flowing stream never gets filler. 15s heartbeat cadence gives multiple safety margins under nginx/ALB's 300s and any plausible CloudFront default.

## What I verified vs inferred

- **Verified locally:** wrote `backend/tests/test_generate_stream_heartbeat.py` which mocks the job store's `list_events` to return nothing for 30 poll cycles (standing in for the silent debate/backtest stretch) then a terminal event, monkeypatches the poll/heartbeat intervals down to milliseconds, and asserts at least one `: heartbeat` comment is written before the terminal event — reproducing the byte-silence gap and proving the fix closes it. A second test asserts no heartbeat filler appears when events flow continuously (no regression to normal-path behavior).
- **Verified:** full test run `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/ -k "generation or sse or stream" -q` → `241 passed` (scoped away from `backend/tests/marketplace/` + `test_marketplace_routes.py`, which fail to collect in this sandbox on a missing `circlekit` module unrelated to this change — confirmed pre-existing via `python3 -c "import circlekit"` failing identically on a clean checkout). Full suite minus those files: `2554 passed`.
- **Verified:** `ruff format --check` and `ruff check --select E9,F63,F7,F40` both pass on the two touched files.
- **Could not reproduce against live prod** (no access to the live stack or CloudFront console from this environment) — root cause is derived from reading the SSE generator, the debate/fan-out call graph, and the nginx/ALB/CloudFront config, not from a live repro. The code-level silent-stretch mechanism is confirmed by the new test; the CloudFront-idle-timeout link is the inferred (not directly measured) piece of the causal chain.

## Anti-goals respected

- Did not touch `nginx/nginx.conf` or `infra/alb.tf` (already correctly sized for SSE).
- Did not touch `infra/cloudfront.tf` — flagging the origin-timeout gap for Dan's infra review rather than changing infra config myself.
- Did not change the debate/backtest compute path itself (no event-loop-blocking bug found there — everything already runs via `asyncio.to_thread`).

Addresses #891.