### PR TITLE
[backend] Fail closed on SIWE domain check when PUBLIC_DOMAIN unset (#940)

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -68,7 +68,14 @@ _CLOCK_SKEW_SECONDS = 120  # tolerate small client/server clock drift on Issued 
 # SIWE message binding — a valid signature must be for THIS site and chain, not
 # merely carry a live nonce. Must match what GET /api/auth/nonce advertises and
 # what the UI puts in the message (see ui/src/siwe.js).
-_EXPECTED_DOMAIN = os.getenv("PUBLIC_DOMAIN") or "https://archimedes-arc.com"
+#
+# No hardcoded literal fallback here (#940): a fallback like
+# "https://archimedes-arc.com" would mean every deployment that forgets to set
+# PUBLIC_DOMAIN — including a phishing clone — advertises and verifies against
+# the SAME domain string, defeating the entire point of domain binding (a
+# signature scoped to one site being replayed against another). May be None;
+# callers must go through _require_configured_domain() before using it.
+_EXPECTED_DOMAIN = os.getenv("PUBLIC_DOMAIN")
 _EXPECTED_CHAIN_ID = int(os.getenv("ARC_CHAIN_ID", "5042002"))
 
 # Pending-nonce store: Redis-backed (via AgentStateStore) so /nonce and /verify
@@ -83,6 +90,26 @@ _COOKIE_NAME = "archimedes_session"
 def _normalize_domain(domain: str) -> str:
     """Bare authority for domain comparison — drop scheme and trailing slash."""
     return domain.strip().removeprefix("https://").removeprefix("http://").rstrip("/").lower()
+
+
+def _require_configured_domain() -> str:
+    """Return the configured SIWE domain, or fail closed if PUBLIC_DOMAIN is unset.
+
+    (#940) Both /api/auth/nonce and /api/auth/verify must call this — a single
+    source of truth kills the drift risk of two independent os.getenv() reads
+    going out of sync, and the missing-config case now fails closed (503)
+    instead of silently falling back to a spoofable hardcoded domain.
+
+    This deliberately does NOT raise at module-import time: main.py's
+    `_is_production = bool(os.getenv("PUBLIC_DOMAIN"))` switch treats an unset
+    PUBLIC_DOMAIN as the intentional local-dev mode (per .env.example), and the
+    app must still boot cleanly in that mode (test_docs_enabled_in_local_dev).
+    Raising here only at first use of the two SIWE endpoints keeps that
+    contract intact while still closing the domain-binding hole at request time.
+    """
+    if not _EXPECTED_DOMAIN:
+        raise HTTPException(status_code=503, detail="SIWE auth requires PUBLIC_DOMAIN to be configured")
+    return _EXPECTED_DOMAIN
 
 
 def _address_from_siwe_message(message: str) -> str | None:
@@ -194,11 +221,15 @@ def gate_generation(request: Request) -> str | None:
 async def get_nonce():
     """Issue a challenge nonce for SIWE signing.
 
-    Stored in Redis (via AgentStateStore) with a TTL so /verify on a
-    different worker can find it -- Redis handles expiry via SETEX, so no
-    manual sweep is needed on that path. Falls back to the in-process
-    `_pending_nonces` dict if Redis is unreachable (single-worker local dev).
+    Fails closed (503) if PUBLIC_DOMAIN isn't configured (#940) — see
+    _require_configured_domain for why. Otherwise: stored in Redis (via
+    AgentStateStore) with a TTL so /verify on a different worker can find it --
+    Redis handles expiry via SETEX, so no manual sweep is needed on that path.
+    Falls back to the in-process `_pending_nonces` dict if Redis is unreachable
+    (single-worker local dev).
     """
+    domain = _normalize_domain(_require_configured_domain())
+
     now = time.time()
     nonce = secrets.token_hex(16)
 
@@ -219,8 +250,7 @@ async def get_nonce():
 
     return {
         "nonce": nonce,
-        "domain": os.getenv("PUBLIC_DOMAIN")
-        or "https://archimedes-arc.com".replace("https://", "").replace("http://", ""),
+        "domain": domain,
         "issued_at": int(now),
         "expiry_seconds": _NONCE_TTL_SECONDS,
     }
@@ -231,7 +261,12 @@ async def verify_signature(request: Request, response: Response):
     """Verify a signed SIWE message and issue a session cookie.
 
     Body: { "message": "<SIWE message text>", "signature": "0x..." }
+
+    Fails closed (503) if PUBLIC_DOMAIN isn't configured (#940), before any
+    domain comparison happens — see _require_configured_domain.
     """
+    expected_domain = _require_configured_domain()
+
     from eth_account import Account
     from eth_account.messages import encode_defunct
 
@@ -277,7 +312,7 @@ async def verify_signature(request: Request, response: Response):
     # "https://archimedes-arc.com/" are treated as the same site.
     if domain_from_message is None:
         raise HTTPException(status_code=400, detail="SIWE message is missing the domain line")
-    if _normalize_domain(domain_from_message) != _normalize_domain(_EXPECTED_DOMAIN):
+    if _normalize_domain(domain_from_message) != _normalize_domain(expected_domain):
         raise HTTPException(status_code=401, detail="SIWE message domain does not match this site")
 
     # Chain-id binding — reject messages signed for the wrong chain (or with none).

--- a/backend/tests/scripts/test_agent_journey_siwe.py
+++ b/backend/tests/scripts/test_agent_journey_siwe.py
@@ -39,6 +39,20 @@ def _load_agent_journey():
 aj = _load_agent_journey()
 
 
+@pytest.fixture(autouse=True)
+def _configured_domain(monkeypatch):
+    """Default PUBLIC_DOMAIN to configured for this module (#940).
+
+    archimedes.api.auth_siwe._EXPECTED_DOMAIN is read once at import time from
+    os.getenv("PUBLIC_DOMAIN"), and the hermetic test process never sets it --
+    without this, the round-trip test below 503s on /api/auth/nonce instead of
+    exercising the harness's message-building recipe against the real
+    verifier. See test_auth_siwe.py's fixture of the same name for the full
+    rationale.
+    """
+    monkeypatch.setattr("archimedes.api.auth_siwe._EXPECTED_DOMAIN", "archimedes-arc.com")
+
+
 # ── Unit: message shape carries every server-enforced binding ─────────
 
 

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -555,7 +555,10 @@ async def test_verify_fails_closed_even_with_no_body(monkeypatch):
     monkeypatch.setattr("archimedes.api.auth_siwe._EXPECTED_DOMAIN", None)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.post("/api/auth/verify", json={"message": "", "signature": ""})
+        # No `json=`/`content=` at all -- a literal empty body. If the domain
+        # check ran after `await request.json()`, this would 400/500 on the
+        # empty-body JSON parse instead of the 503 we're asserting.
+        resp = await client.post("/api/auth/verify")
     assert resp.status_code == 503
 
 

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -94,6 +94,22 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+@pytest.fixture(autouse=True)
+def _configured_domain(monkeypatch):
+    """Default all tests in this module to a configured PUBLIC_DOMAIN (#940).
+
+    _EXPECTED_DOMAIN is read from os.getenv("PUBLIC_DOMAIN") once at module
+    import time, and the hermetic test process never sets PUBLIC_DOMAIN (see
+    backend/tests/conftest.py) — so without this, every existing test hitting
+    /api/auth/nonce or /api/auth/verify would 503 under the new fail-closed
+    behavior. Patching the already-imported module attribute (rather than the
+    env var, which is read once at import and won't be re-read) restores the
+    prior "configured" behavior as the default for this file; the dedicated
+    fail-closed tests below override this back to None to exercise the 503 path.
+    """
+    monkeypatch.setattr("archimedes.api.auth_siwe._EXPECTED_DOMAIN", "archimedes-arc.com")
+
+
 # ── Unit tests for session token functions ─────────────────────
 
 
@@ -485,6 +501,62 @@ async def test_verify_rejects_message_missing_chain_id():
         resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
     assert resp.status_code == 400
     assert "Chain ID" in resp.json()["detail"]
+
+
+# ── Fail closed when PUBLIC_DOMAIN is unconfigured (#940) ───────────
+#
+# Two independent hardcoded fallbacks (one in _EXPECTED_DOMAIN, one inline in
+# the /nonce handler) used to make domain binding a no-op whenever
+# PUBLIC_DOMAIN was unset: both sides silently agreed on the same literal, so
+# the check "passed" without actually proving anything. These tests pin the
+# fixed behavior: with no domain configured, both endpoints refuse to serve
+# the SIWE flow at all (503) rather than silently authenticating against a
+# spoofable default.
+
+
+@pytest.mark.asyncio
+async def test_nonce_endpoint_fails_closed_when_domain_unconfigured(monkeypatch):
+    from archimedes.main import app
+
+    monkeypatch.setattr("archimedes.api.auth_siwe._EXPECTED_DOMAIN", None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/auth/nonce")
+    assert resp.status_code == 503
+    assert "PUBLIC_DOMAIN" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_verify_fails_closed_when_domain_unconfigured(monkeypatch):
+    """503 before even reaching the nonce/signature checks -- an otherwise
+    well-formed, correctly-domained message must still be rejected."""
+    from archimedes.main import app
+
+    monkeypatch.setattr("archimedes.api.auth_siwe._EXPECTED_DOMAIN", None)
+
+    message = (
+        "archimedes-arc.com wants you to sign in with your Ethereum account:\n"
+        "0xabcdef1234567890abcdef1234567890abcdef12\n\n"
+        "Chain ID: 5042002\n"
+        f"Nonce: somenonce123456\nIssued At: {_now_iso()}"
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/auth/verify", json={"message": message, "signature": "0xfake"})
+    assert resp.status_code == 503
+    assert "PUBLIC_DOMAIN" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_verify_fails_closed_even_with_no_body(monkeypatch):
+    """The domain-configuration check runs before message/signature validation
+    -- a request with no body at all still gets 503, not 400."""
+    from archimedes.main import app
+
+    monkeypatch.setattr("archimedes.api.auth_siwe._EXPECTED_DOMAIN", None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/auth/verify", json={"message": "", "signature": ""})
+    assert resp.status_code == 503
 
 
 # ── Redis-backed nonce store (multi-worker support) ─────────────

--- a/backend/tests/test_auth_siwe_smart_wallet.py
+++ b/backend/tests/test_auth_siwe_smart_wallet.py
@@ -30,6 +30,20 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+@pytest.fixture(autouse=True)
+def _configured_domain(monkeypatch):
+    """Default PUBLIC_DOMAIN to configured for this module (#940).
+
+    _EXPECTED_DOMAIN is read once at archimedes.api.auth_siwe import time, and
+    the hermetic test process never sets PUBLIC_DOMAIN -- without this, every
+    /api/auth/nonce and /api/auth/verify call below 503s under the new
+    fail-closed behavior instead of exercising the smart-wallet path this file
+    is actually testing. See test_auth_siwe.py's fixture of the same name for
+    the full rationale.
+    """
+    monkeypatch.setattr("archimedes.api.auth_siwe._EXPECTED_DOMAIN", "archimedes-arc.com")
+
+
 async def _nonce_and_message(client: AsyncClient, wallet: str) -> str:
     nonce_data = (await client.get("/api/auth/nonce")).json()
     return (


### PR DESCRIPTION
## Summary

Fixes the two independent hardcoded-fallback copies of the SIWE expected domain in `backend/archimedes/api/auth_siwe.py`:

- `_EXPECTED_DOMAIN = os.getenv("PUBLIC_DOMAIN") or "https://archimedes-arc.com"` (module level, used by `/api/auth/verify`)
- a second, separately-computed `os.getenv("PUBLIC_DOMAIN") or "https://archimedes-arc.com".replace(...)` inline in the `/api/auth/nonce` handler

Both problems from the issue are addressed:
- **Drift risk** — there is now exactly one source of truth (`_EXPECTED_DOMAIN`), read by a single helper both endpoints call.
- **Security hole** — when `PUBLIC_DOMAIN` is unset, both endpoints previously fell back to the *same* hardcoded literal, so domain binding provided zero protection in that state (a phishing clone with `PUBLIC_DOMAIN` unset would produce SIWE messages that verify successfully against a real deployment too). Now, with `PUBLIC_DOMAIN` unset, both endpoints return `503 SIWE auth requires PUBLIC_DOMAIN to be configured` instead of silently working.

## What changed

`backend/archimedes/api/auth_siwe.py`:
- `_EXPECTED_DOMAIN` is now `os.getenv("PUBLIC_DOMAIN")` — no fallback literal, may be `None`.
- New `_require_configured_domain() -> str` helper: raises `HTTPException(503, ...)` if `_EXPECTED_DOMAIN` is falsy, else returns it.
- `/api/auth/nonce` calls the helper first, derives its `"domain"` response field from the helper's return value (previously a second independent `os.getenv` read).
- `/api/auth/verify` calls the helper at the top of the function, before any parsing/comparison, and uses the returned value in the domain comparison (previously read `_EXPECTED_DOMAIN` directly at comparison time — same net effect for the configured case, but now goes through the single checked path).

Test files updated (all previously depended on the old hardcoded fallback, since the hermetic test process never sets `PUBLIC_DOMAIN`):
- `backend/tests/test_auth_siwe.py` — added an `autouse` fixture that patches `_EXPECTED_DOMAIN` to `"archimedes-arc.com"` for this module's tests (restoring prior behavior as the default), plus three new tests pinning the 503 fail-closed behavior on `/nonce` and `/verify` (including a request with no body reaching 503 before 400).
- `backend/tests/test_auth_siwe_smart_wallet.py` and `backend/tests/scripts/test_agent_journey_siwe.py` — same autouse-fixture pattern; these files also call `/api/auth/nonce` / `/api/auth/verify` and would otherwise 503 under the new behavior.

## Local-dev-boot constraint (preserved)

`backend/archimedes/main.py` uses `_is_production = bool(os.getenv("PUBLIC_DOMAIN"))` as the canonical prod/dev switch (docs gate, CORS, `EMAIL_ENCRYPTION_KEY` fail-closed check), and `PUBLIC_DOMAIN` is intentionally left unset in `.env.example` for local dev. This fix does **not** raise at module-import time — only at first *request* to the two SIWE endpoints — so `cp .env.example .env` still boots the app fine. Confirmed `test_docs_enabled_in_local_dev` still passes.

## Interpretation note (verbatim, for review)

> The issue's literal acceptance checkbox says "fail at boot if missing" — I implemented fail-closed at first *use* of the two SIWE endpoints instead, because failing at module-import time would break the local-dev-boots-fine test and contradict the rest of the codebase's `PUBLIC_DOMAIN`-unset-means-dev-mode convention.

Happy to switch to boot-time failure if the team wants stricter enforcement (e.g. gated behind the same `_is_production` switch main.py already uses), but that felt like a bigger blast-radius change than this issue asked for.

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_auth_siwe.py backend/tests/test_security_hardening.py -q
# → 65 passed, 0 failed

ruff format --check backend/archimedes/api/auth_siwe.py backend/tests/test_auth_siwe.py
ruff check --select E9,F63,F7,F40 backend/archimedes/api/auth_siwe.py backend/tests/test_auth_siwe.py
# → both clean
```

Also ran the full hermetic backend suite (excluding the marketplace tests, which fail to collect in this sandbox due to an unrelated missing `circlekit` package, pre-existing on `main`): 2555 passed, 0 failed.

## Out of scope

Did not touch `docker-compose.production.yml`'s `PUBLIC_DOMAIN` default or any other file — production already sets `PUBLIC_DOMAIN`, so this PR's behavior change only bites in the unset-domain (local dev / misconfigured deploy) case, exactly as intended.

Addresses #940 — not marking "Closes" since the boot-time-vs-first-use interpretation deviates from the issue's literal acceptance checkbox and I want a human to weigh in on that tradeoff before this is considered fully resolved.
