### PR TITLE
[strategy] Surface or wire missing asset-class universe legs instead of silently dropping (#892)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -775,7 +775,16 @@ async def run_generation(
         # steering below never saw the LLM's better read of the brief. Union
         # (not replace) so an explicit user ticker pick is never dropped by a
         # coarser class inference.
-        inferred_classes = [str(a).strip() for a in validated.get("asset_classes_inferred", []) if str(a).strip()]
+        # The validator's output is LLM-generated and not type-enforced, so
+        # `asset_classes_inferred` could come back as something other than a
+        # list (e.g. a bare string) — guard against that before iterating, or
+        # a string would silently explode into a "class per character" and
+        # pollute brief.asset_classes downstream (Copilot review comment on
+        # PR #1033).
+        _raw_inferred = validated.get("asset_classes_inferred", [])
+        if not isinstance(_raw_inferred, list):
+            _raw_inferred = [_raw_inferred] if _raw_inferred else []
+        inferred_classes = [str(a).strip() for a in _raw_inferred if str(a).strip()]
         if inferred_classes:
             merged_classes = list(brief.asset_classes or [])
             seen_classes = {c.strip().lower() for c in merged_classes}

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -766,6 +766,26 @@ async def run_generation(
         if validated.get("risk_appetite_adjusted") and validated["risk_appetite_adjusted"] != brief.risk_appetite:
             brief = brief.model_copy(update={"risk_appetite": validated["risk_appetite_adjusted"]})
 
+        # Fold the validator's classified asset_classes back into the brief
+        # (#892). Bug: brief_validated correctly classified e.g.
+        # ["crypto", "treasuries"] and emitted it on the SSE event for display,
+        # but the classification was then discarded — brief.asset_classes kept
+        # whatever the client originally sent (often empty, or only the
+        # explicit ticker picks), so the debate society / fusion universe
+        # steering below never saw the LLM's better read of the brief. Union
+        # (not replace) so an explicit user ticker pick is never dropped by a
+        # coarser class inference.
+        inferred_classes = [str(a).strip() for a in validated.get("asset_classes_inferred", []) if str(a).strip()]
+        if inferred_classes:
+            merged_classes = list(brief.asset_classes or [])
+            seen_classes = {c.strip().lower() for c in merged_classes}
+            for ac in inferred_classes:
+                if ac.lower() not in seen_classes:
+                    seen_classes.add(ac.lower())
+                    merged_classes.append(ac)
+            if merged_classes != (brief.asset_classes or []):
+                brief = brief.model_copy(update={"asset_classes": merged_classes})
+
         await emit.emit(
             "brief_validated",
             asset_classes=validated.get("asset_classes_inferred", []),

--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -298,6 +298,13 @@ def _gap_fill_tickers(asset_classes: list[str], universe: list[str]) -> list[str
     treasuries" brief keeps the model's BTC/ETH AND gains the treasury proxy,
     rather than one leg clobbering the other). Order-preserving, de-duped
     against what's already present.
+
+    A class with ANY of its proxy tickers already in ``universe`` (e.g. "IEF"
+    present for "treasuries") counts as already represented — a gap-fill tops
+    up a *missing* leg, it does not pad out a partially-present one, so no
+    further proxies are injected once at least one is present (mirrors the
+    "already represented" check in ``_unrepresented_asset_classes`` above;
+    Copilot review comment on PR #1033).
     """
     universe_set = {u.casefold() for u in universe}
     fill: list[str] = []
@@ -306,7 +313,10 @@ def _gap_fill_tickers(asset_classes: list[str], universe: list[str]) -> list[str
         name = str(ac).strip()
         if not name or name.casefold() in universe_set:
             continue  # already a concrete ticker present in the universe
-        for proxy in _class_proxy_tickers(name):
+        proxies = _class_proxy_tickers(name)
+        if any(p.casefold() in universe_set for p in proxies):
+            continue  # class already has at least one proxy represented
+        for proxy in proxies:
             if proxy.casefold() not in seen:
                 seen.add(proxy.casefold())
                 fill.append(proxy)

--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -103,10 +103,71 @@ SUPPORTED_UNIVERSE: tuple[str, ...] = tuple(
 # synth key ("sSPY") the user / UI might send, mapping both to the canonical
 # display symbol used in the strategy_spec.
 _UNIVERSE_LOOKUP: dict[str, str] = {}
+# Display symbol -> SSOT asset_class tag (e.g. "BTC" -> "crypto"). Used by
+# `_unrepresented_asset_classes` (#892) to recognize that a classified class
+# name IS represented when the universe already contains a ticker of that
+# SSOT class — even where the class name has no entry in
+# `_ASSET_CLASS_PROXIES` below (e.g. "crypto": BTC/ETH are named directly by
+# the model, so the class itself needs no proxy-ticker injection, but it
+# should still read as covered rather than a false-positive gap).
+_DISPLAY_TO_ASSET_CLASS: dict[str, str] = {}
 for _synth, (_yf, _display, _ac, _exch) in GLOBAL_ASSETS.items():
     _UNIVERSE_LOOKUP[_display.casefold()] = _display
     _UNIVERSE_LOOKUP[_synth.casefold()] = _display
     _UNIVERSE_LOOKUP[_yf.casefold()] = _display
+    _DISPLAY_TO_ASSET_CLASS[_display.casefold()] = _ac
+
+# ── Asset-CLASS (not ticker) → representative SSOT proxies (#892) ──────────
+#
+# `brief.asset_classes` can carry a coarse class NAME (e.g. "treasuries") from
+# either an explicit user steer or the LLM brief-validator's
+# `asset_classes_inferred` — never a ticker. `_UNIVERSE_LOOKUP` above only
+# indexes concrete display/synth/yfinance symbols, so a class name silently
+# resolved to nothing and the leg vanished from the universe with no signal
+# (issue #892: "treasuries" requested + correctly classified, but every
+# candidate traded crypto only). This map gives each class name a small,
+# deterministic set of representative tickers actually present in
+# `GLOBAL_ASSETS`, so a classified class with real data-source coverage is
+# never dropped just because the caller said the class name instead of a
+# ticker.
+#
+# Deliberately DISJOINT from `_ASSET_SYNONYMS`' keys (equities/rates/credit/
+# fx/commodities/crypto/vol/macro): those are established, test-pinned as
+# PAPER-RETRIEVAL-ONLY class filters that intentionally do NOT resolve to a
+# concrete universe (`derive_asset_universe`'s docstring: broad-class steers
+# "are dropped from the *universe*"; see test_universe_falls_back_to_ssot_
+# when_no_instrument_steer et al. in test_strategy_fusion.py, which assert
+# `["equities", "rates"]` falls through to the model/full branch). Overloading
+# those same keys here would silently flip that established behavior. Instead
+# this map only covers class names that (a) have no existing universe
+# resolution path at all today and (b) are what the brief-validator / a user
+# steer realistically emits for a class the SSOT actually has tickers for —
+# "treasuries" (this issue's exact reproduction) plus its close synonyms.
+_ASSET_CLASS_PROXIES: dict[str, tuple[str, ...]] = {
+    "treasuries": ("IEF", "SHY", "TLT"),
+    "treasury": ("IEF", "SHY", "TLT"),
+    "treasury_bonds": ("IEF", "SHY", "TLT"),
+    "us_treasuries": ("IEF", "SHY", "TLT"),
+    "bonds": ("IEF", "SHY", "TLT", "AGG"),
+    "bond": ("IEF", "SHY", "TLT", "AGG"),
+    "fixed_income": ("IEF", "SHY", "TLT", "AGG"),
+    "fixed income": ("IEF", "SHY", "TLT", "AGG"),
+    "govt_bonds": ("IEF", "SHY", "TLT"),
+    "government_bonds": ("IEF", "SHY", "TLT"),
+    "munis": ("MUB",),
+    "municipal_bonds": ("MUB",),
+    "reits": ("VNQ",),
+    "real_estate": ("VNQ",),
+    "real estate": ("VNQ",),
+}
+
+
+def _class_proxy_tickers(class_name: str) -> list[str]:
+    """Representative SSOT tickers for a class NAME, filtered to what's actually
+    registered in ``GLOBAL_ASSETS`` (defensive — the literal map above is hand
+    maintained and could drift from the SSOT)."""
+    candidates = _ASSET_CLASS_PROXIES.get(class_name.strip().lower(), ())
+    return [_UNIVERSE_LOOKUP[c.casefold()] for c in candidates if c.casefold() in _UNIVERSE_LOOKUP]
 
 
 def _repair_spec(backend: Any, brief: FusionBrief, parsed: dict[str, Any]) -> dict[str, Any] | None:
@@ -141,7 +202,17 @@ def _repair_spec(backend: Any, brief: FusionBrief, parsed: dict[str, Any]) -> di
 
 
 def _resolve_user_assets(selected_assets: list[str]) -> list[str]:
-    """Resolve user tokens to canonical SSOT display symbols (may be empty)."""
+    """Resolve user tokens to canonical SSOT display symbols (may be empty).
+
+    Concrete-ticker resolution ONLY (exact SSOT display/synth/yfinance match).
+    Coarse asset-CLASS names (e.g. "equities", "treasuries") deliberately do
+    NOT resolve here — that's long-established behavior
+    (``derive_asset_universe``'s docstring: broad-class steers "are dropped
+    from the *universe*") that several tests pin. Class-name → proxy-ticker
+    resolution for #892 lives in ``_class_proxy_tickers`` / ``_gap_fill_tickers``
+    below and is applied as a supplement, never a same-function override, so it
+    can never silently clobber a concrete user/model ticker pick.
+    """
     resolved: list[str] = []
     seen: set[str] = set()
     for token in selected_assets or []:
@@ -152,10 +223,100 @@ def _resolve_user_assets(selected_assets: list[str]) -> list[str]:
     return resolved
 
 
+def _class_represented_by_ssot_tag(class_name: str, universe: list[str]) -> bool:
+    """True iff ``universe`` already contains a ticker whose SSOT ``asset_class``
+    tag matches ``class_name`` (#892: e.g. "crypto" is represented once BTC/ETH
+    — SSOT tag "crypto" — are in the universe, even with no
+    ``_ASSET_CLASS_PROXIES`` entry, since the model/user already named concrete
+    tickers for it).
+
+    Reuses ``_ASSET_SYNONYMS`` (the existing class-name -> keyword-stem map) so
+    "equities" also recognizes tags like "us_equity_etf" via its "equit" stem,
+    not just a literal "equities" substring — the same vocabulary the paper
+    filter already trusts for this class name. Falls back to a direct
+    substring match (both directions) for class names outside that map (e.g.
+    "treasuries", which isn't an ``_ASSET_SYNONYMS`` key).
+    """
+    key = class_name.strip().lower()
+    if not key:
+        return False
+    stems = _ASSET_SYNONYMS.get(key, (key,))
+    for sym in universe:
+        tag = _DISPLAY_TO_ASSET_CLASS.get(sym.casefold(), "")
+        if not tag:
+            continue
+        tag_words = tag.replace("_", " ")
+        if any(stem in tag_words for stem in stems) or key in tag_words or tag_words in key:
+            return True
+    return False
+
+
+def _unrepresented_asset_classes(asset_classes: list[str], universe: list[str]) -> list[str]:
+    """Which classified ``asset_classes`` have ZERO representation in ``universe``.
+
+    #892: the honest-surfacing half of the fix. A class name is "represented"
+    if any of: (1) it's itself a concrete ticker already in the universe; (2)
+    its ``_ASSET_CLASS_PROXIES`` proxy tickers are present; (3) the universe
+    already contains a ticker whose SSOT ``asset_class`` tag matches the name
+    (covers classes like "crypto" that the model names directly with no proxy
+    map entry needed). A class matching none of these is reported as a gap —
+    either there is no data source for it, or the caller's classification is a
+    broad paper-retrieval-only filter (e.g. "equities"/"rates") we have no
+    independent universe evidence for. Order-preserving, de-duped,
+    case-insensitive.
+    """
+    universe_set = {u.casefold() for u in universe}
+    gaps: list[str] = []
+    seen: set[str] = set()
+    for ac in asset_classes or []:
+        name = str(ac).strip()
+        key = name.lower()
+        if not name or key in seen:
+            continue
+        seen.add(key)
+        # Already a concrete ticker that made it in? Not a gap.
+        canonical = _UNIVERSE_LOOKUP.get(name.casefold())
+        if canonical and canonical.casefold() in universe_set:
+            continue
+        proxies = _class_proxy_tickers(name)
+        if proxies and any(p.casefold() in universe_set for p in proxies):
+            continue
+        if _class_represented_by_ssot_tag(name, universe):
+            continue
+        gaps.append(name)
+    return gaps
+
+
+def _gap_fill_tickers(asset_classes: list[str], universe: list[str]) -> list[str]:
+    """Proxy tickers for any classified class that ``_ASSET_CLASS_PROXIES`` covers
+    but that has zero representation in ``universe`` yet (#892).
+
+    This is an ADDITIVE supplement, never a replacement: it only fills in a
+    class the caller explicitly named (e.g. "treasuries") that a concrete user
+    ticker pick or the model's own universe failed to cover — it never removes
+    or overrides anything the user/model already chose (so a "crypto +
+    treasuries" brief keeps the model's BTC/ETH AND gains the treasury proxy,
+    rather than one leg clobbering the other). Order-preserving, de-duped
+    against what's already present.
+    """
+    universe_set = {u.casefold() for u in universe}
+    fill: list[str] = []
+    seen: set[str] = set(universe_set)
+    for ac in asset_classes or []:
+        name = str(ac).strip()
+        if not name or name.casefold() in universe_set:
+            continue  # already a concrete ticker present in the universe
+        for proxy in _class_proxy_tickers(name):
+            if proxy.casefold() not in seen:
+                seen.add(proxy.casefold())
+                fill.append(proxy)
+    return fill
+
+
 _MODEL_UNIVERSE_CAP = 8
 
 
-def _spec_universe(brief: FusionBrief, strategy_spec: dict[str, Any]) -> tuple[list[str], str]:
+def _spec_universe(brief: FusionBrief, strategy_spec: dict[str, Any]) -> tuple[list[str], str, list[str]]:
     """Pick the spec's asset universe: user steer > model suggestion > full SSOT.
 
     Fixes #847: the old unconditional ``derive_asset_universe`` override sent
@@ -167,15 +328,37 @@ def _spec_universe(brief: FusionBrief, strategy_spec: dict[str, Any]) -> tuple[l
     the full supported universe (preserving #682's "never a hardcoded SPY"
     floor).
 
-    Returns ``(universe, universe_source)`` where ``universe_source`` is one of
-    ``"user" | "model" | "full"`` (#857) — a model-picked universe is a mild
-    look-ahead channel (the model can pick names it already "knows" did well
-    over the window from training data), so which branch fired is recorded for
-    the passport rather than silently collapsed into just the resulting list.
+    #892 gap-fill: whichever branch above fires, any ``brief.asset_classes``
+    entry that has a known proxy (``_ASSET_CLASS_PROXIES``) but zero
+    representation in that branch's universe gets its proxy tickers appended
+    — additively, never replacing what the branch already chose. This is what
+    keeps a "trend-following on BTC/ETH with a defensive rotation into
+    treasuries" brief from losing the treasury leg just because the model only
+    named BTC/ETH explicitly: the user/model branch still wins for the assets
+    it *did* address, and the gap-fill covers the classified class it missed.
+
+    Returns ``(universe, universe_source, universe_gaps)``:
+      - ``universe_source`` is one of ``"user" | "model" | "full"`` (#857) — a
+        model-picked universe is a mild look-ahead channel (the model can pick
+        names it already "knows" did well over the window from training
+        data), so which branch fired is recorded for the passport rather than
+        silently collapsed into just the resulting list. Gap-filling does not
+        change which branch is recorded — it is applied on top.
+      - ``universe_gaps`` (#892) lists any ``brief.asset_classes`` entry that
+        STILL has zero representation after gap-fill — i.e. a classified class
+        with no known data-source proxy at all (or, for the broad
+        paper-retrieval-only class names like "equities"/"rates" that
+        deliberately have no proxy map entry, no independent universe
+        evidence). Empty when every classified class is represented. This is
+        the claim-integrity signal: the passport/reasoning trace must say "X
+        was requested but not available" rather than silently proceeding as
+        if X was honored.
     """
     user_assets = _resolve_user_assets(brief.asset_classes)
     if user_assets:
-        return user_assets, "user"
+        universe = user_assets + _gap_fill_tickers(brief.asset_classes, user_assets)
+        gaps = _unrepresented_asset_classes(brief.asset_classes, universe)
+        return universe, "user", gaps
     model_assets = _resolve_user_assets([str(a) for a in strategy_spec.get("asset_universe") or []])
     # Parrot defense: a bare single proxy (the classic ["SPY"] default weak
     # models emit regardless of thesis) is indistinguishable from a non-choice —
@@ -184,8 +367,17 @@ def _spec_universe(brief: FusionBrief, strategy_spec: dict[str, Any]) -> tuple[l
     if len(model_assets) >= 2:
         if len(model_assets) > _MODEL_UNIVERSE_CAP:
             logger.info("fusion: model universe capped %d → %d", len(model_assets), _MODEL_UNIVERSE_CAP)
-        return model_assets[:_MODEL_UNIVERSE_CAP], "model"
-    return list(SUPPORTED_UNIVERSE), "full"
+        capped = model_assets[:_MODEL_UNIVERSE_CAP]
+        universe = capped + _gap_fill_tickers(brief.asset_classes, capped)
+        gaps = _unrepresented_asset_classes(brief.asset_classes, universe)
+        return universe, "model", gaps
+    full = list(SUPPORTED_UNIVERSE)
+    # No user/model steer fired, so the full SSOT is already in play — nothing
+    # to gap-fill (every proxy ticker is already a member of "full" by
+    # construction); a classified class is only a real gap here if it has no
+    # known proxy at all.
+    gaps = _unrepresented_asset_classes(brief.asset_classes, full)
+    return full, "full", gaps
 
 
 def derive_asset_universe(selected_assets: list[str]) -> list[str]:
@@ -558,6 +750,14 @@ class FusionProposal:
     # (disabled / insufficient_corpus / unparseable) — there is no universe to
     # attribute a source to.
     universe_source: str | None = None
+    # (#892) Any brief.asset_classes entries with ZERO representation in the
+    # final strategy_spec["asset_universe"] — e.g. a classified asset class
+    # with no data source wired up, or one whose proxies were dropped by the
+    # model-universe cap. Empty (the common case) when every classified class
+    # is represented. Claim-integrity signal: surfaced in risk_notes and
+    # persisted so the passport/reasoning trace says so honestly instead of
+    # silently proceeding as if the request was fully honored.
+    universe_gaps: list[str] = field(default_factory=list)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -809,6 +1009,7 @@ class StrategyFusion:
         if not isinstance(strategy_spec, dict):
             strategy_spec = _repair_spec(backend, brief, parsed)
         universe_source: str | None = None
+        universe_gaps: list[str] = []
         if not isinstance(strategy_spec, dict):
             strategy_spec = None
         else:
@@ -817,7 +1018,10 @@ class StrategyFusion:
             # (#857) the branch taken is recorded as universe_source so the
             # passport can surface which one fired — a model-picked universe
             # is a mild look-ahead channel worth being auditable, not blocked.
-            strategy_spec["asset_universe"], universe_source = _spec_universe(brief, strategy_spec)
+            # (#892) universe_gaps carries any classified asset_classes that
+            # ended up with zero representation — surfaced below, never
+            # silently dropped.
+            strategy_spec["asset_universe"], universe_source, universe_gaps = _spec_universe(brief, strategy_spec)
             # Validate the FINAL dict (post-steering). An invalid spec — a
             # partial repair that happened to carry entry/exit, or a malformed
             # model emission — must degrade to honest text-only HERE, not
@@ -828,6 +1032,16 @@ class StrategyFusion:
                 logger.warning("fusion: strategy_spec failed DSL validation (%s) — falling back to text-only", exc)
                 strategy_spec = None
                 universe_source = None
+                universe_gaps = []
+
+        risk_notes = str(parsed.get("risk_notes", "")).strip()
+        if universe_gaps:
+            gap_note = (
+                f"Universe gap: {', '.join(universe_gaps)} requested/classified but not available "
+                "in the current data universe — the traded universe above does not include it."
+            )
+            logger.warning("fusion: universe gap for brief asset_classes=%s -> %s", brief.asset_classes, universe_gaps)
+            risk_notes = f"{risk_notes} {gap_note}".strip() if risk_notes else gap_note
 
         return FusionProposal(
             status="ok",
@@ -837,11 +1051,12 @@ class StrategyFusion:
             source_arxiv_ids=source_ids,
             fusion_reasoning=str(parsed.get("fusion_reasoning", "")).strip(),
             novelty_rationale=str(parsed.get("novelty_rationale", "")).strip(),
-            risk_notes=str(parsed.get("risk_notes", "")).strip(),
+            risk_notes=risk_notes,
             model=backend.served_model,  # TRUE served model — field of record
             requested_model=backend.model_id,  # what we asked for
             strategy_spec=strategy_spec,
             universe_source=universe_source,
+            universe_gaps=universe_gaps,
         )
 
 

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -305,6 +305,129 @@ async def test_brief_validation_rejects_invalid_brief(monkeypatch):
     assert statuses[-1] == "error"
 
 
+@pytest.mark.asyncio
+async def test_validated_asset_classes_are_folded_into_brief_before_dispatch(monkeypatch):
+    """#892: brief_validated's asset_classes_inferred must reach the brief the
+    pipeline actually dispatches with — not just the SSE event payload.
+
+    Reproduces the issue's exact bug: the user's brief is classified with
+    ["crypto", "treasuries"] (brief_validated correctly reports it), but before
+    this fix, brief.asset_classes downstream still held whatever the CLIENT
+    originally sent (here: nothing at all) because the validator's inferred
+    classes were only ever used for the SSE display event, never folded back
+    into the brief object that the debate society / fusion universe steering
+    consumes. Forces the live-validator branch (_llm_available=True) but
+    routes to the fixture runner (_debate_can_run=False) so the assertion is
+    hermetic — no LLM, no corpus.
+    """
+    from archimedes.services import generation_pipeline as gp
+
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+
+    async def fake_validate(brief):
+        return {
+            "is_valid": True,
+            "intent_summary": brief.intent[:140],
+            "asset_classes_inferred": ["crypto", "treasuries"],
+            "time_horizon_inferred": "unknown",
+            "risk_appetite_adjusted": brief.risk_appetite,
+        }
+
+    monkeypatch.setattr(gp, "_validate_brief", fake_validate)
+
+    # Force the fixture runner (not the debate society) so this stays
+    # hermetic, while still exercising the live-style validation branch above.
+    import archimedes.agents.debate_engine as de
+
+    monkeypatch.setattr(de, "_debate_can_run", lambda brief: False)
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+    seen_asset_classes: list[list[str] | None] = []
+    real_runner = gp._run_fixture_candidate
+
+    async def _spy_runner(*, brief, **kwargs):
+        seen_asset_classes.append(list(brief.asset_classes or []))
+        return await real_runner(brief=brief, **kwargs)
+
+    monkeypatch.setattr(gp, "_run_fixture_candidate", _spy_runner)
+
+    store = _FakeStore()
+    brief = GenerateBrief(
+        intent="trend-following on BTC and ETH with a defensive rotation into treasuries when volatility spikes",
+        risk_appetite="moderate",
+        asset_classes=None,  # the client sent nothing explicit — only the LLM classified it
+    )
+    with patch(
+        "archimedes.agents.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_892_001", "0x892")),
+    ):
+        await gp.run_generation(job_id="job_892_001", brief=brief, n_candidates=1, store=store)
+
+    # The SSE event still reports the validator's classification (unchanged UX).
+    bv = next(e for e in store.events if e["event"] == "brief_validated")
+    assert set(bv["data"]["asset_classes"]) == {"crypto", "treasuries"}
+
+    # THE BUG: every dispatched candidate must actually see the classified
+    # classes on brief.asset_classes, not just the discarded SSE payload.
+    assert seen_asset_classes, "fixture runner was never invoked — test setup is wrong"
+    for classes in seen_asset_classes:
+        assert set(classes) == {"crypto", "treasuries"}, (
+            f"brief.asset_classes at dispatch time was {classes!r} — the validator's "
+            "asset_classes_inferred was not folded back into the brief"
+        )
+
+
+@pytest.mark.asyncio
+async def test_validated_asset_classes_union_with_explicit_user_picks(monkeypatch):
+    """#892: an explicit user ticker pick must survive the merge, not be
+    replaced by the validator's coarser class inference."""
+    from archimedes.services import generation_pipeline as gp
+
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+
+    async def fake_validate(brief):
+        return {
+            "is_valid": True,
+            "intent_summary": brief.intent[:140],
+            "asset_classes_inferred": ["treasuries"],
+            "time_horizon_inferred": "unknown",
+            "risk_appetite_adjusted": brief.risk_appetite,
+        }
+
+    monkeypatch.setattr(gp, "_validate_brief", fake_validate)
+
+    import archimedes.agents.debate_engine as de
+
+    monkeypatch.setattr(de, "_debate_can_run", lambda brief: False)
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+    seen_asset_classes: list[list[str] | None] = []
+    real_runner = gp._run_fixture_candidate
+
+    async def _spy_runner(*, brief, **kwargs):
+        seen_asset_classes.append(list(brief.asset_classes or []))
+        return await real_runner(brief=brief, **kwargs)
+
+    monkeypatch.setattr(gp, "_run_fixture_candidate", _spy_runner)
+
+    store = _FakeStore()
+    brief = GenerateBrief(
+        intent="BTC momentum with a treasury hedge",
+        risk_appetite="moderate",
+        asset_classes=["BTC"],  # explicit user pick — must not be dropped
+    )
+    with patch(
+        "archimedes.agents.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_892_002", "0x892b")),
+    ):
+        await gp.run_generation(job_id="job_892_002", brief=brief, n_candidates=1, store=store)
+
+    assert seen_asset_classes
+    for classes in seen_asset_classes:
+        assert "BTC" in classes, "explicit user pick must survive the validator merge"
+        assert "treasuries" in classes, "validator's inferred class must be folded in alongside the user pick"
+
+
 # ── Dual bull/bear regime tests (Issue #163) ───────────────────────────────
 
 

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -428,6 +428,61 @@ async def test_validated_asset_classes_union_with_explicit_user_picks(monkeypatc
         assert "treasuries" in classes, "validator's inferred class must be folded in alongside the user pick"
 
 
+@pytest.mark.asyncio
+async def test_validated_asset_classes_non_list_is_not_exploded_into_characters(monkeypatch):
+    """Copilot review comment on PR #1033: `_validate_brief`'s output is
+    LLM-generated and not type-enforced, so `asset_classes_inferred` could
+    come back as a bare string instead of a list. Iterating a string
+    character-by-character would merge garbage single-letter "classes" into
+    brief.asset_classes; the non-list case must be treated as one whole class
+    name instead.
+    """
+    from archimedes.services import generation_pipeline as gp
+
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+
+    async def fake_validate(brief):
+        return {
+            "is_valid": True,
+            "intent_summary": brief.intent[:140],
+            "asset_classes_inferred": "treasuries",  # malformed: string, not list
+            "time_horizon_inferred": "unknown",
+            "risk_appetite_adjusted": brief.risk_appetite,
+        }
+
+    monkeypatch.setattr(gp, "_validate_brief", fake_validate)
+
+    import archimedes.agents.debate_engine as de
+
+    monkeypatch.setattr(de, "_debate_can_run", lambda brief: False)
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+    seen_asset_classes: list[list[str] | None] = []
+    real_runner = gp._run_fixture_candidate
+
+    async def _spy_runner(*, brief, **kwargs):
+        seen_asset_classes.append(list(brief.asset_classes or []))
+        return await real_runner(brief=brief, **kwargs)
+
+    monkeypatch.setattr(gp, "_run_fixture_candidate", _spy_runner)
+
+    store = _FakeStore()
+    brief = GenerateBrief(
+        intent="defensive rotation into treasuries",
+        risk_appetite="moderate",
+        asset_classes=None,
+    )
+    with patch(
+        "archimedes.agents.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_892_003", "0x892c")),
+    ):
+        await gp.run_generation(job_id="job_892_003", brief=brief, n_candidates=1, store=store)
+
+    assert seen_asset_classes
+    for classes in seen_asset_classes:
+        assert classes == ["treasuries"], f"non-list validator output was exploded into: {classes!r}"
+
+
 # ── Dual bull/bear regime tests (Issue #163) ───────────────────────────────
 
 

--- a/backend/tests/test_fusion_spec_repair.py
+++ b/backend/tests/test_fusion_spec_repair.py
@@ -164,30 +164,34 @@ def test_invalid_model_spec_degrades_to_text_only(monkeypatch):
 
 def test_user_assets_win_over_model_universe():
     spec = {"asset_universe": ["TSLA", "NVDA"]}
-    out, source = sf._spec_universe(_brief(asset_classes=["SPY", "gld"]), spec)
+    out, source, gaps = sf._spec_universe(_brief(asset_classes=["SPY", "gld"]), spec)
     assert out == ["SPY", "GLD"]  # canonical, order-preserving
     assert source == "user"
+    assert gaps == []
 
 
 def test_unsteered_brief_uses_models_validated_universe():
     spec = {"asset_universe": ["SPY", "GLD", "NOT_A_REAL_TICKER_XYZ"]}
-    out, source = sf._spec_universe(_brief(), spec)
+    out, source, gaps = sf._spec_universe(_brief(), spec)
     assert out == ["SPY", "GLD"]  # SSOT-validated; garbage dropped
     assert "NOT_A_REAL_TICKER_XYZ" not in out
     assert source == "model"
+    assert gaps == []
 
 
 def test_model_universe_is_capped():
     many = list(sf.SUPPORTED_UNIVERSE)[: sf._MODEL_UNIVERSE_CAP + 5]
-    out, source = sf._spec_universe(_brief(), {"asset_universe": many})
+    out, source, gaps = sf._spec_universe(_brief(), {"asset_universe": many})
     assert len(out) == sf._MODEL_UNIVERSE_CAP
     assert source == "model"
+    assert gaps == []
 
 
 def test_no_user_no_model_falls_back_to_full_universe():
-    out, source = sf._spec_universe(_brief(), {"asset_universe": []})
+    out, source, gaps = sf._spec_universe(_brief(), {"asset_universe": []})
     assert out == list(sf.SUPPORTED_UNIVERSE)  # #682's floor preserved
     assert source == "full"
+    assert gaps == []
 
 
 def test_propose_threads_model_universe_when_unsteered(monkeypatch):
@@ -214,6 +218,7 @@ def test_invalid_brief_message_guides_instead_of_insults(reason):
 def test_single_proxy_model_universe_is_treated_as_parroted_default():
     # A weak model emitting the classic bare ["SPY"] regardless of thesis is a
     # non-choice — fall back to the full universe (never trust the parrot).
-    out, source = sf._spec_universe(_brief(), {"asset_universe": ["SPY"]})
+    out, source, gaps = sf._spec_universe(_brief(), {"asset_universe": ["SPY"]})
     assert out == list(sf.SUPPORTED_UNIVERSE)
     assert source == "full"
+    assert gaps == []

--- a/backend/tests/test_strategy_fusion.py
+++ b/backend/tests/test_strategy_fusion.py
@@ -27,6 +27,7 @@ from archimedes.agents.strategy_fusion import (
     FusionBrief,
     FusionCannedBackend,
     StrategyFusion,
+    _gap_fill_tickers,
     derive_asset_universe,
     fusion_enabled,
     load_corpus,
@@ -716,6 +717,21 @@ def test_gap_fill_never_overrides_explicit_user_ticker_picks(monkeypatch, crypto
     assert any(t in universe for t in ("IEF", "SHY", "TLT"))
     assert proposal.universe_source == "user"
     assert proposal.universe_gaps == ["crypto"]  # honest: no crypto ticker was ever named
+
+
+def test_gap_fill_tickers_does_not_top_up_a_partially_represented_class():
+    """Copilot review comment on PR #1033: `_gap_fill_tickers` must treat a
+    class as represented once ANY of its proxy tickers is already in the
+    universe — it should not keep injecting the remaining proxies (e.g. add
+    SHY/TLT on top of an already-present IEF). Gap-fill patches in a *missing*
+    leg; it doesn't pad out a partially-present one.
+    """
+    fill = _gap_fill_tickers(["treasuries"], ["IEF"])
+    assert fill == []
+
+    # Still fills when genuinely absent.
+    fill = _gap_fill_tickers(["treasuries"], ["BTC", "ETH"])
+    assert set(fill) == {"IEF", "SHY", "TLT"}
 
 
 def test_broad_paper_filter_classes_still_report_as_gaps_on_full_fallback(monkeypatch, corpus):

--- a/backend/tests/test_strategy_fusion.py
+++ b/backend/tests/test_strategy_fusion.py
@@ -23,6 +23,7 @@ import pytest
 from archimedes.agents.strategy_fusion import (
     MIN_PAPERS,
     SUPPORTED_UNIVERSE,
+    CorpusPaper,
     FusionBrief,
     FusionCannedBackend,
     StrategyFusion,
@@ -576,3 +577,157 @@ def test_universe_source_is_full_on_fallback(monkeypatch, corpus):
     assert proposal.status == "ok"
     assert proposal.strategy_spec["asset_universe"] == list(SUPPORTED_UNIVERSE)
     assert proposal.universe_source == "full"
+
+
+# ── Defensive-leg universe gap-fill + honest surfacing (#892) ─────────────
+#
+# Issue #892: a brief classified with multiple asset_classes (e.g.
+# ["crypto", "treasuries"]) had its "treasuries" leg silently vanish from
+# every candidate's traded universe — the model named concrete crypto tickers
+# but "treasuries" is a class, not a ticker, so `_resolve_user_assets` /
+# `_spec_universe` dropped it with no signal. Fixed by (a) wiring the
+# already-registered treasury tickers (IEF/SHY/TLT etc.) into the universe
+# via a class-name -> proxy-ticker gap-fill, and (b) honestly surfacing any
+# classified class that STILL has zero representation (universe_gaps /
+# risk_notes) instead of silently proceeding.
+
+
+@pytest.fixture
+def crypto_treasury_corpus():
+    """A tiny dedicated corpus whose abstracts literally contain "crypto" and
+    "treasuries" so the deterministic pre-LLM paper filter (select_candidates,
+    keyed on _ASSET_SYNONYMS + the raw class term) yields >=MIN_PAPERS for
+    those exact asset_classes — independent of the shared fixture corpus
+    above, which has no crypto paper and only a singular "treasury" (not
+    "treasuries") mention.
+    """
+    return [
+        CorpusPaper(
+            arxiv_id="2501.00001",
+            title="Momentum and Trend-Following in Crypto Markets",
+            abstract="A trend-following strategy on major crypto assets with regime conditioning.",
+            primary_category="q-fin.PM",
+            categories=("q-fin.PM",),
+            published="2025-01-05",
+        ),
+        CorpusPaper(
+            arxiv_id="2502.00002",
+            title="Defensive Rotation into Treasuries During Volatility Spikes",
+            abstract="A volatility-managed rotation into treasuries as a defensive overlay.",
+            primary_category="q-fin.PM",
+            categories=("q-fin.PM",),
+            published="2025-02-10",
+        ),
+    ]
+
+
+class _CryptoOnlyUniverseBackend:
+    """Mirrors the issue's exact reproduction: the model names concrete crypto
+    tickers (BTC, ETH) but never mentions the classified "treasuries" leg —
+    a class name, not a ticker, so it can't appear in a ticker-only spec."""
+
+    model_id = "claude-sonnet-4-20250514"
+    served_model = "glm-4.7"
+
+    def complete(self, system: str, user: str) -> str:
+        payload = json.loads(user)
+        ids = [p["arxiv_id"] for p in payload["candidate_papers"][:2]]
+        return json.dumps(
+            {
+                "strategy_name": "TrendFusion Momentum Strategy",
+                "thesis": "Trend-following on BTC/ETH with a defensive rotation.",
+                "source_arxiv_ids": ids,
+                "fusion_reasoning": "Paper A momentum + paper B vol-managed rotation.",
+                "novelty_rationale": "Joint combination unpublished.",
+                "risk_notes": "Pre-backtest; rigor gate pending.",
+                "strategy_spec": {
+                    "name": "TrendFusion Momentum Strategy",
+                    "asset_universe": ["BTC", "ETH"],  # the model only named the crypto leg
+                    "rebalance_frequency": "monthly",
+                    "entry": {"gt": ["close", "sma_200"]},
+                    "exit": {"lt": ["close", "sma_200"]},
+                    "position_sizing": {"type": "full_invested_when_in_market"},
+                    "source_arxiv_ids": ids,
+                    "look_ahead_safe": True,
+                    "indicators": ["sma_200"],
+                },
+            }
+        )
+
+
+def test_defensive_leg_is_gap_filled_not_silently_dropped(monkeypatch, crypto_treasury_corpus):
+    """Reproduces #892: brief classified ["crypto", "treasuries"]; the model's
+    spec only names BTC/ETH. The treasury leg must be injected into the final
+    universe (real registered tickers, e.g. IEF/SHY/TLT), not silently lost —
+    and universe_gaps must be empty since both classified legs end up
+    represented (crypto directly by the model, treasuries via gap-fill)."""
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    svc = StrategyFusion(backend=_CryptoOnlyUniverseBackend(), corpus=crypto_treasury_corpus)
+    proposal = svc.propose(FusionBrief(asset_classes=["crypto", "treasuries"]))
+
+    assert proposal.status == "ok"
+    universe = proposal.strategy_spec["asset_universe"]
+    assert "BTC" in universe and "ETH" in universe  # the model's crypto leg survives
+    assert any(t in universe for t in ("IEF", "SHY", "TLT")), (
+        f"treasury leg was dropped from the universe: {universe!r}"
+    )
+    assert proposal.universe_gaps == []  # both classified legs are represented
+    assert "gap" not in proposal.risk_notes.lower()
+
+
+def test_genuinely_unavailable_asset_class_is_surfaced_not_fabricated(monkeypatch, crypto_treasury_corpus):
+    """Option (b) of the issue: a classified class with NO real data source at
+    all must be surfaced honestly (universe_gaps + risk_notes), never silently
+    dropped AND never covered by a fabricated data feed."""
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    svc = StrategyFusion(backend=_CryptoOnlyUniverseBackend(), corpus=crypto_treasury_corpus)
+    # "lunar_futures" has no proxy map entry and no SSOT asset_class tag match —
+    # there is genuinely no data source for it. "treasuries" is included purely
+    # so the paper filter matches both fixture papers (>=MIN_PAPERS) — the
+    # model's spec below never names a treasury ticker either, so this brief
+    # exercises "two classified classes, one gets a real proxy, one doesn't".
+    proposal = svc.propose(FusionBrief(asset_classes=["crypto", "lunar_futures", "treasuries"]))
+
+    assert proposal.status == "ok"
+    universe = proposal.strategy_spec["asset_universe"]
+    assert "lunar_futures" not in universe  # never fabricated as if it were a real ticker
+    assert proposal.universe_gaps == ["lunar_futures"]
+    assert "lunar_futures" in proposal.risk_notes
+    assert "not available" in proposal.risk_notes.lower()
+
+
+def test_gap_fill_never_overrides_explicit_user_ticker_picks(monkeypatch, crypto_treasury_corpus):
+    """The user's own concrete ticker picks stay the authoritative universe;
+    gap-fill only ADDS a classified class's proxy, never removes a user pick.
+
+    "crypto" is included purely so the paper filter matches both fixture
+    papers (>=MIN_PAPERS); this particular brief's model backend never names
+    a crypto ticker, so "crypto" is honestly (and separately, correctly)
+    reported as a gap — the assertion below is about QQQ/treasuries, which
+    are NOT gaps.
+    """
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    svc = StrategyFusion(backend=_SpecBackend(), corpus=crypto_treasury_corpus)  # model parrots ["SPY"], ignored
+    proposal = svc.propose(FusionBrief(asset_classes=["QQQ", "treasuries", "crypto"]))
+
+    assert proposal.status == "ok"
+    universe = proposal.strategy_spec["asset_universe"]
+    assert "QQQ" in universe
+    assert any(t in universe for t in ("IEF", "SHY", "TLT"))
+    assert proposal.universe_source == "user"
+    assert proposal.universe_gaps == ["crypto"]  # honest: no crypto ticker was ever named
+
+
+def test_broad_paper_filter_classes_still_report_as_gaps_on_full_fallback(monkeypatch, corpus):
+    """ "equities"/"rates" remain paper-RETRIEVAL-only class filters (established
+    behavior, #847/#682) — they resolve no proxy ticker of their own. On the
+    full-SSOT fallback the SSOT-tag check still recognizes them as represented
+    (equities/bonds ARE abundantly present in the full universe), so this must
+    NOT be a false-positive gap.
+    """
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    svc = StrategyFusion(backend=_SpecBackend(), corpus=corpus)
+    proposal = svc.propose(FusionBrief(asset_classes=["equities", "rates"]))
+    assert proposal.status == "ok"
+    assert proposal.universe_source == "full"
+    assert proposal.universe_gaps == []


### PR DESCRIPTION
## Summary

Addresses #892: a brief classified with multiple `asset_classes` (e.g. `["crypto", "treasuries"]` for *"trend-following on BTC and ETH with a defensive rotation into treasuries when volatility spikes"*) had the treasury leg silently vanish from every generated candidate's traded universe, even though `brief_validated` correctly classified it.

## Root cause — (a): the data existed, it just wasn't wired through

Two separate gaps, both real, both fixed:

1. **`run_generation` discarded the validator's classification.** `_validate_brief` correctly returns `asset_classes_inferred` (used for the `brief_validated` SSE event's display payload), but the code never folded that list back into `brief.asset_classes`. Only `risk_appetite_adjusted` was merged back into the brief; the classified asset classes were shown to the user on the event stream and then thrown away. Every downstream consumer (the debate society → `StrategyFusion.propose`) kept using whatever `asset_classes` the *client* originally sent — which for a free-text brief is often empty.
2. **Even with `asset_classes` populated, class *names* didn't resolve.** `strategy_fusion.py`'s `_resolve_user_assets` / `_spec_universe` only matched concrete tickers/synth-keys/yfinance-symbols (`_UNIVERSE_LOOKUP`) — a class name like `"treasuries"` (as opposed to a ticker like `IEF`) had no resolution path at all, despite treasury tickers (`IEF`, `SHY`, `TLT`, `AGG`, ...) already being registered in the `GLOBAL_ASSETS` SSOT.

## Fix

- `generation_pipeline.py`: after brief validation, union `asset_classes_inferred` into `brief.asset_classes` (never replace — an explicit user ticker pick always survives) before pipeline dispatch.
- `strategy_fusion.py`: added `_ASSET_CLASS_PROXIES` (class name → representative registered tickers, e.g. `"treasuries"` → `IEF/SHY/TLT`) and an **additive** `_gap_fill_tickers` step in `_spec_universe` — it patches in a classified class's proxy tickers without ever overriding what the user/model already chose (so a "crypto + treasuries" brief keeps the model's BTC/ETH *and* gains the treasury leg, instead of one clobbering the other).
- Added `universe_gaps` to `FusionProposal`: any classified class that still has zero representation after gap-fill (i.e. genuinely no data source, or an unmapped class name) is surfaced honestly in `risk_notes` (`"Universe gap: X requested/classified but not available..."`) — never silently dropped, never fabricated. This is option (b) from the issue, applied only where option (a) (real wiring) doesn't fully close the gap.
- Deliberately kept the new proxy map **disjoint** from `_ASSET_SYNONYMS`'s established keys (`equities`, `rates`, `credit`, `fx`, `commodities`, `crypto`, `vol`, `macro`) — those are long-established, test-pinned as paper-retrieval-only class filters that intentionally do *not* resolve to a universe (see `derive_asset_universe`'s docstring). Overloading them would have silently changed existing, tested behavior.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/ -k "universe or asset_class or generation_pipeline" -q
# 114 passed, 0 failed (excluding backend/tests/marketplace/* — pre-existing
# ModuleNotFoundError: circlekit in this env, unrelated to this change, verified
# to also fail on a clean main before this diff)

ruff format --check backend/archimedes/agents/generation_pipeline.py backend/archimedes/agents/strategy_fusion.py backend/tests/services/test_generation_pipeline.py backend/tests/test_fusion_spec_repair.py backend/tests/test_strategy_fusion.py
ruff check --select E9,F63,F7,F40 backend/archimedes/agents/generation_pipeline.py backend/archimedes/agents/strategy_fusion.py backend/tests/services/test_generation_pipeline.py backend/tests/test_fusion_spec_repair.py backend/tests/test_strategy_fusion.py
# both clean
```

New tests added:
- `test_generation_pipeline.py`: `test_validated_asset_classes_are_folded_into_brief_before_dispatch`, `test_validated_asset_classes_union_with_explicit_user_picks` — prove the merge happens and that an explicit user pick survives it. Both fail against the pre-fix code (verified).
- `test_strategy_fusion.py`: `test_defensive_leg_is_gap_filled_not_silently_dropped` (the issue's exact repro), `test_genuinely_unavailable_asset_class_is_surfaced_not_fabricated` (option-b honesty for a truly unmapped class), `test_gap_fill_never_overrides_explicit_user_ticker_picks`, `test_broad_paper_filter_classes_still_report_as_gaps_on_full_fallback` (no false-positive gaps for the existing `equities`/`rates` paper-filter convention).
- `test_fusion_spec_repair.py`: updated 5 existing direct `_spec_universe` callers for its new 3-tuple return (`universe, source, gaps`).

## Anti-goals / scope notes

- Did not touch `_ASSET_SYNONYMS` or its established semantics for `equities`/`rates`/`credit`/`fx`/`commodities`/`crypto`/`vol`/`macro` as paper-retrieval filters.
- Did not add a new persisted DB column for the gap signal — `universe_gaps` is threaded through `FusionProposal` and surfaced via the existing free-text `risk_notes` field (already flows to the passport) rather than a schema change, to keep this a contained fix.
- No new dependencies, no contract changes, no infra changes.
