### PR TITLE
[strategy] Dedup debate proposer pool on canonical spec hash (#893)

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -176,25 +176,36 @@ def _dsl_conformance_ok(spec: dict[str, Any] | None) -> bool:
     return all(stem in _CONFORMANT_INDICATORS for stem in _indicator_alias_stems(spec))
 
 
+# Non-behavioral spec keys: the LLM-generated marketing name and the citation
+# list vary freely across steers (each proposer call re-fuses/re-labels) even
+# when the actual trading logic (entry/exit/universe/sizing) is identical.
+# #893's whole premise is that this happens; hashing these in would make the
+# dedup a no-op against the exact failure mode it's meant to catch.
+_HASH_IGNORED_SPEC_KEYS = frozenset({"name", "source_arxiv_ids"})
+
+
 def _canonical_spec_hash(spec: dict[str, Any]) -> str:
-    """Content hash of ``spec`` invariant to key order and float noise (fix #893).
+    """Content hash of the BEHAVIORAL fields of ``spec`` (fix #893).
 
     Different regime/mechanism steers can independently converge on the same
     strategy (byte-identical ``entry``/``exit`` trees) under a different marketing
-    name. Rounding floats to 6dp absorbs float-repr jitter without collapsing
-    genuinely distinct parameterizations (e.g. sma_20 vs sma_21).
+    name and/or citation set. Excludes ``_HASH_IGNORED_SPEC_KEYS`` so two specs
+    that only differ by name/provenance still dedupe. Rounding floats to 6dp
+    absorbs float-repr jitter without collapsing genuinely distinct
+    parameterizations (e.g. sma_20 vs sma_21).
     """
 
-    def _normalize(node: Any) -> Any:
+    def _normalize(node: Any, *, top_level: bool = False) -> Any:
         if isinstance(node, dict):
-            return {k: _normalize(node[k]) for k in sorted(node)}
+            keys = node.keys() - _HASH_IGNORED_SPEC_KEYS if top_level else node.keys()
+            return {k: _normalize(node[k]) for k in sorted(keys)}
         if isinstance(node, list):
             return [_normalize(v) for v in node]
         if isinstance(node, float):
             return round(node, 6)
         return node
 
-    canonical = json.dumps(_normalize(spec), sort_keys=True, separators=(",", ":"))
+    canonical = json.dumps(_normalize(spec, top_level=True), sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -10,7 +10,9 @@ checks corpus size. The pipeline:
      ``select_candidates(regime_bias=R)`` evidence sets (the A3 model seam
      threads the user's Generate-page model pick). Drops non-actionable
      (``FusionProposal.is_actionable``) and non-conformant (``_dsl_conformance_ok``,
-     fix A5) specs. ``pool_size = len(POOL)``.
+     fix A5) specs, then dedups by canonical spec hash (fix #893 — different
+     steers can converge on the same spec under a different name). ``pool_size
+     = len(POOL)`` counts unique specs only.
   2. **Adversarial round** — a thin, best-effort bull/bear transcript.
      Surfaces adversarial topology on the SSE stream but never gates;
      deterministic critics do the real culling (the budget trick).
@@ -31,6 +33,8 @@ back-compat callers); ``_run_debate_leaderboard`` returns the FULL ranked board
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 from typing import TYPE_CHECKING, Any
@@ -172,6 +176,28 @@ def _dsl_conformance_ok(spec: dict[str, Any] | None) -> bool:
     return all(stem in _CONFORMANT_INDICATORS for stem in _indicator_alias_stems(spec))
 
 
+def _canonical_spec_hash(spec: dict[str, Any]) -> str:
+    """Content hash of ``spec`` invariant to key order and float noise (fix #893).
+
+    Different regime/mechanism steers can independently converge on the same
+    strategy (byte-identical ``entry``/``exit`` trees) under a different marketing
+    name. Rounding floats to 6dp absorbs float-repr jitter without collapsing
+    genuinely distinct parameterizations (e.g. sma_20 vs sma_21).
+    """
+
+    def _normalize(node: Any) -> Any:
+        if isinstance(node, dict):
+            return {k: _normalize(node[k]) for k in sorted(node)}
+        if isinstance(node, list):
+            return [_normalize(v) for v in node]
+        if isinstance(node, float):
+            return round(node, 6)
+        return node
+
+    canonical = json.dumps(_normalize(spec), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
 # ── Viability precheck ────────────────────────────────────────────────────────
 
 
@@ -248,11 +274,22 @@ async def _propose_pool(brief: GenerateBrief, model: str | None, corpus: list[An
     )
 
     pool: list[Any] = []
+    seen_hashes: set[str] = set()
+    dropped = 0
     for p in proposals:
         if isinstance(p, BaseException) or p is None:
             continue
-        if p.is_actionable and _dsl_conformance_ok(p.strategy_spec):
-            pool.append(p)
+        if not (p.is_actionable and _dsl_conformance_ok(p.strategy_spec)):
+            continue
+        spec_hash = _canonical_spec_hash(p.strategy_spec)
+        if spec_hash in seen_hashes:
+            dropped += 1
+            continue
+        seen_hashes.add(spec_hash)
+        pool.append(p)
+
+    if dropped:
+        logger.info("debate proposer pool_deduped: kept=%d dropped=%d", len(pool), dropped)
     return pool
 
 

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -351,10 +351,68 @@ def test_canonical_spec_hash_ignores_key_order_and_float_noise():
     assert de._canonical_spec_hash(a) != de._canonical_spec_hash(c)
 
 
+def test_canonical_spec_hash_ignores_marketing_name_and_citations():
+    """Fix #893's actual failure mode: same trading logic, different LLM-picked
+    name and citation set. These MUST hash identically, or dedup is a no-op
+    against the exact scenario it's meant to catch."""
+    base = dict(_CONFORMANT_SPEC)
+    a = {**base, "name": "TrendFusionCryptoVolatility", "source_arxiv_ids": ["2401.00001", "2402.00001"]}
+    b = {**base, "name": "CryptoVolTrendGuard", "source_arxiv_ids": ["2402.00001", "2401.00001"]}
+    assert de._canonical_spec_hash(a) == de._canonical_spec_hash(b)
+    # But a genuinely different entry condition must still be caught.
+    c = {**b, "entry": {"gt": ["momentum_40", 0]}}
+    assert de._canonical_spec_hash(a) != de._canonical_spec_hash(c)
+
+
+class _NameVaryingFusionBackend:
+    """Like _CannedFusionBackend, but emits a different strategy_name and
+    source_arxiv_ids ORDER on every call while keeping strategy_spec's
+    behavioral fields (entry/exit/universe/sizing) fixed — the real #893
+    scenario: independently-generated proposals that converge on the same
+    trading logic under different marketing names."""
+
+    _MARKETING_NAMES = [
+        "TrendFusionCryptoVolatility",
+        "CryptoVolTrendGuard",
+        "Volatility-Hedge Trend-Follow",
+        "Crypto-TailHedging TrendFollow",
+    ]
+
+    def __init__(self, model=None, *, spec):
+        self.model_id = model or "env-default"
+        self.served_model = f"served::{self.model_id}"
+        self.available = True
+        self._spec = spec
+        self._call_n = 0
+
+    def complete(self, system: str, user: str) -> str:
+        payload = json.loads(user)
+        ids = [p["arxiv_id"] for p in payload["candidate_papers"][:2]]
+        if self._call_n % 2:
+            ids = list(reversed(ids))
+        name = self._MARKETING_NAMES[self._call_n % len(self._MARKETING_NAMES)]
+        self._call_n += 1
+        spec = dict(self._spec)
+        spec["name"] = name
+        spec["source_arxiv_ids"] = ids
+        return json.dumps(
+            {
+                "strategy_name": name,
+                "thesis": "Fuse momentum + vol mechanisms.",
+                "source_arxiv_ids": ids,
+                "fusion_reasoning": "canned",
+                "novelty_rationale": "canned",
+                "risk_notes": "canned",
+                "strategy_spec": spec,
+            }
+        )
+
+
 async def test_propose_pool_dedupes_identical_specs_across_steers(monkeypatch, corpus):
-    """Fix #893: different regime/mechanism steers converging on the same spec
-    (byte-identical under a different marketing name) must collapse to one pool
-    entry, not be counted as independent trials."""
+    """Fix #893: different regime/mechanism steers converging on the same
+    trading logic — but with a different LLM-picked marketing name and
+    citation order each time — must collapse to one pool entry, not be
+    counted as independent trials."""
     monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
     monkeypatch.setenv("DEBATE_POOL_MAX", "4")
 
@@ -364,12 +422,14 @@ async def test_propose_pool_dedupes_identical_specs_across_steers(monkeypatch, c
     # but rejected by the full propose() validation, which nulls strategy_spec).
     dedup_spec = {k: v for k, v in _CONFORMANT_SPEC.items() if k != "parameter_variants"}
 
-    def _fake_make(model=None, **kw):
-        return _CannedFusionBackend(model=model, spec=dedup_spec)
+    backend = _NameVaryingFusionBackend(spec=dedup_spec)
 
-    # Force every steer to select the SAME evidence set, so the canned backend's
-    # embedded source_arxiv_ids (and therefore the full spec) is byte-identical
-    # across all steers regardless of regime_bias/mechanism.
+    def _fake_make(model=None, **kw):
+        return backend
+
+    # Force every steer to select the SAME evidence set, so the only things
+    # that vary between calls are the marketing name and citation order
+    # (mimicking independent LLM calls converging on the same evidence).
     monkeypatch.setattr(
         "archimedes.agents.strategy_fusion.select_candidates",
         lambda fb, corpus, regime_bias=None: list(corpus)[:2],
@@ -380,6 +440,14 @@ async def test_propose_pool_dedupes_identical_specs_across_steers(monkeypatch, c
     brief = GenerateBrief(intent="momentum equities", max_papers=4)
     pool = await de._propose_pool(brief, "m", corpus)
 
+    # Sanity: the backend really did emit >1 distinct marketing name across
+    # steers (i.e. this test exercises the actual #893 failure mode, not an
+    # already-identical pool that would collapse trivially).
+    assert backend._call_n > 1
+    assert len({backend._MARKETING_NAMES[i % 4] for i in range(backend._call_n)}) > 1
+
+    # Despite differently-named proposals, the trading logic is identical —
+    # must collapse to a single unique entry.
     assert len(pool) == 1
     hashes = {de._canonical_spec_hash(p.strategy_spec) for p in pool}
     assert len(hashes) == len(pool)

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -340,6 +340,51 @@ async def test_propose_pool_drops_nonconformant_specs(monkeypatch, corpus):
     assert pool == []
 
 
+# ── Test #893 — proposer pool dedup ────────────────────────────────────────────
+
+
+def test_canonical_spec_hash_ignores_key_order_and_float_noise():
+    a = {"entry": {"gt": ["momentum_20", 0]}, "exit": {"lt": ["close", "sma_200"]}, "weight": 0.1 + 0.2}
+    b = {"exit": {"lt": ["close", "sma_200"]}, "entry": {"gt": ["momentum_20", 0]}, "weight": 0.3}
+    assert de._canonical_spec_hash(a) == de._canonical_spec_hash(b)
+    c = {"exit": {"lt": ["close", "sma_200"]}, "entry": {"gt": ["momentum_40", 0]}, "weight": 0.3}
+    assert de._canonical_spec_hash(a) != de._canonical_spec_hash(c)
+
+
+async def test_propose_pool_dedupes_identical_specs_across_steers(monkeypatch, corpus):
+    """Fix #893: different regime/mechanism steers converging on the same spec
+    (byte-identical under a different marketing name) must collapse to one pool
+    entry, not be counted as independent trials."""
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    monkeypatch.setenv("DEBATE_POOL_MAX", "4")
+
+    # A conformant spec that also survives the full validate_strategy_spec pass
+    # (unlike _CONFORMANT_SPEC, whose parameter_variants key doesn't reference an
+    # entry/exit alias — fine for the narrow _dsl_conformance_ok check elsewhere,
+    # but rejected by the full propose() validation, which nulls strategy_spec).
+    dedup_spec = {k: v for k, v in _CONFORMANT_SPEC.items() if k != "parameter_variants"}
+
+    def _fake_make(model=None, **kw):
+        return _CannedFusionBackend(model=model, spec=dedup_spec)
+
+    # Force every steer to select the SAME evidence set, so the canned backend's
+    # embedded source_arxiv_ids (and therefore the full spec) is byte-identical
+    # across all steers regardless of regime_bias/mechanism.
+    monkeypatch.setattr(
+        "archimedes.agents.strategy_fusion.select_candidates",
+        lambda fb, corpus, regime_bias=None: list(corpus)[:2],
+    )
+    monkeypatch.setattr("archimedes.agents.strategy_fusion.make_llm_backend", _fake_make)
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+
+    brief = GenerateBrief(intent="momentum equities", max_papers=4)
+    pool = await de._propose_pool(brief, "m", corpus)
+
+    assert len(pool) == 1
+    hashes = {de._canonical_spec_hash(p.strategy_spec) for p in pool}
+    assert len(hashes) == len(pool)
+
+
 # ── Test 8 — flag-OFF byte-identical (fix A2) ─────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Fixes #893. The debate proposer pool fanned proposals across 18 regime/mechanism steers; different steers routinely converge on the same underlying strategy spec but with a different LLM-generated marketing name. Observed on prod: 4 of 7 candidates in one job were byte-identical (same DSR, PBO, trade count to 6dp) under 4 different names.

This wastes real backtest wall-clock (each duplicate is a full cerebro run on a 2-vCPU box — contributes to the #891 SSE-stall window) and over-deflates DSR for the eventual winner, since `num_trials` counted every duplicate as an independent selection trial.

## Change
`_propose_pool` in `backend/archimedes/agents/debate_engine.py` now:
- Canonicalizes each conformant `strategy_spec` (recursively sorted keys, floats rounded to 6dp) and hashes it with sha256.
- Drops any proposal whose hash was already seen, keeping the first (by steer order).
- Logs `pool_deduped: kept=N dropped=M` when duplicates are found.

Since `pool_size = len(pool)` feeds `num_trials` downstream, num_trials now counts unique specs only — no code change needed there.

## Testing
- New unit test `test_canonical_spec_hash_ignores_key_order_and_float_noise` — hash equality/inequality on the canonicalization itself.
- New unit test `test_propose_pool_dedupes_identical_specs_across_steers` — forces all steers to converge on the same spec (via a fixed evidence set), asserts the pool collapses to 1 unique entry.
- `pytest backend/tests/test_debate_engine.py backend/tests/test_generation_pipeline.py` → 41 passed.
- `ruff format --check` + `ruff check --select E9,F63,F7,F40` clean on both touched files.

## Anti-goals honored
- Did not touch `num_trials` computation itself — dedup happens upstream so it inherits correctness for free.
- Did not change `_dsl_conformance_ok` or any DSL validation behavior.