### PR TITLE
[docs] Document PLATFORM_ADMIN_WALLETS in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,15 @@ ARC_VAULT_GOVERNANCE_ADDRESS=
 #   server-side at pool creation (the 10% platform split). NEVER client-set.
 #   Publishing is refused (503) until this is configured. Checksummed 0x… .
 ARCHIMEDES_TREASURY_WALLET=
+# PLATFORM_ADMIN_WALLETS: comma- or space-separated allowlist of wallet
+#   addresses permitted to publish EXAMPLE strategies (is_example=true) that they
+#   did not generate — the sole exception to the D5 "only the generator may
+#   publish" rule (see wallet_can_publish in models/strategy_generators.py).
+#   Parsed case-insensitively; a stray leading/trailing comma is harmless.
+#   Grants NO fund/custody/treasury authority — publish-example only, and a
+#   listed wallet must still SIWE-authenticate to publish. Empty by default
+#   (no admin wallets).
+PLATFORM_ADMIN_WALLETS=
 # ARC_PAYMENT_SPLITTER_ADDRESS: the deployed PaymentSplitter contract (set
 #   after the T3.2 deploy). The settlement sweep deposits/withdraws here.
 ARC_PAYMENT_SPLITTER_ADDRESS=


### PR DESCRIPTION
## Summary
`PLATFORM_ADMIN_WALLETS` gates the one exception to the D5 "only the wallet that generated a strategy may publish it" rule: wallets in this allowlist may also publish **example** strategies (`is_example=true`) they didn't generate. It's enforced by `wallet_can_publish()` in `backend/archimedes/models/strategy_generators.py:48` and consumed in `marketplace_routes.py:98`, but it was **missing from `.env.example`**, so the team had no signal it exists.

This PR documents it with an **empty default** (no admin wallets out of the box) and a comment covering:
- what it grants — **publish-example only**, explicitly *no* fund/custody/treasury authority;
- parsing — comma- or space-separated, case-insensitive, stray leading/trailing comma harmless;
- the caveat that a listed wallet must still SIWE-authenticate to actually publish.

## Scope
- `.env.example` only. One added block, empty value. No code, no behavior change.

## Not in this PR
- Setting a real value on the live box (that's a deliberate operator action in `/opt/archimedes/.env`, e.g. adding a tester's wallet, followed by `docker compose up -d backend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)