### PR TITLE
Feature/marketplace examples publish

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,3 +41,9 @@ CHARGE_BATCH_SIZE=10
 SWEEP_WITHDRAW_THRESHOLD_USDC=10.0
 # Settlement sweep (P5): minimum wallet USDC (raw 6-dec) to trigger on-chain depositToPool.
 SWEEP_MIN_DEPOSIT_RAW=1000000
+
+# ─── Publishing ──────────────────────────────────────────────────
+# Minimum idle USDC (raw, 6-dec) a vault must hold before a strategy can be published. 1000000 = 1 USDC.
+MARKETPLACE_MIN_VAULT_FUNDS_RAW=1000000
+# Comma-separated wallet addresses allowed to publish strategies (incl. examples).
+PLATFORM_ADMIN_WALLETS=0x...

--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -119,7 +119,18 @@ async def publish_strategy(
             owner_wallet=wallet,
         )
 
-    # 3a. Auto-provision publisher settlement wallet (Circle DCW).
+    # 3a. Publish funding gate (D7) — vault MUST hold at least
+    #     MARKETPLACE_MIN_VAULT_FUNDS_RAW idle USDC (raw 6-dec).
+    #     Single threshold for both new and reused vaults.
+    min_funds_raw = int(os.getenv("MARKETPLACE_MIN_VAULT_FUNDS_RAW", "1000000"))
+    balance = await market._usdc_balance_of(vault_address)
+    if balance < min_funds_raw:
+        raise HTTPException(
+            status_code=402,
+            detail=f"Vault USDC balance {balance} below minimum {min_funds_raw}",
+        )
+
+    # 3b. Auto-provision publisher settlement wallet (Circle DCW).
     #     Must happen before on-chain createPool so a wallet failure never
     #     leaves an on-chain pool with no way to be funded.
     from archimedes.marketplace.wallet_provisioner import provision_publisher_wallet

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -235,6 +235,12 @@ class StrategyResponse(BaseModel):
     return_source: str = "noise"  # "risk_premium" | "mispricing" | "productive_growth" | "noise"
     return_source_note: str = ""
 
+    # Whether the caller's wallet is permitted to publish this strategy.
+    # Always False for anonymous requests; True only when the caller is the
+    # generating wallet (generated strategies) or a platform admin (examples).
+    # Backend-authoritative — the frontend uses this to hide the publish affordance.
+    can_publish: bool = False
+
 
 class StrategyListResponse(BaseModel):
     strategies: list[StrategyResponse]

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -437,6 +437,7 @@ async def list_strategies(
     served ``status: "validated"``. This is intentional — the stored status is the
     stable filter key; the served status reflects the live verdict.
     """
+    from archimedes.db import get_session
     from archimedes.models.strategy_generators import wallet_can_publish
 
     status_filter = StrategyStatus(status) if status else None

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -414,6 +414,7 @@ def _verdict_from_result(result: RigorGateResult | None) -> RigorGateVerdict:
 
 @strategies_router.get("/", response_model=StrategyListResponse)
 async def list_strategies(
+    request: Request,
     status: str | None = Query(None, pattern="^(candidate|validated|live|retired)$"),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
@@ -436,16 +437,24 @@ async def list_strategies(
     served ``status: "validated"``. This is intentional — the stored status is the
     stable filter key; the served status reflects the live verdict.
     """
+    from archimedes.models.strategy_generators import wallet_can_publish
+
     status_filter = StrategyStatus(status) if status else None
     strats = strategy_provider().list_strategies(status=status_filter)
     total = len(strats)
     window = strats[offset : offset + limit]
     rigor_results = _live_rigor_results_for_strategies(window)
+    caller = get_verified_wallet(request)
+    responses: list[StrategyResponse] = []
+    with get_session() as session:
+        for s in window:
+            resp = _to_strategy_response(s, _verdict_from_result(rigor_results.get(s.id)), rigor_results.get(s.id))
+            resp.can_publish = bool(caller) and wallet_can_publish(
+                session, strategy_id=s.id, wallet_address=caller, is_example=True
+            )
+            responses.append(resp)
     return StrategyListResponse(
-        strategies=[
-            _to_strategy_response(s, _verdict_from_result(rigor_results.get(s.id)), rigor_results.get(s.id))
-            for s in window
-        ],
+        strategies=responses,
         total=total,
     )
 
@@ -464,6 +473,7 @@ async def list_generated_strategies(request: Request, limit: int = Query(50, ge=
     from sqlalchemy import or_
 
     from archimedes.db import get_session
+    from archimedes.models.strategy_generators import wallet_can_publish
     from archimedes.models.strategy_store import StrategyRecord
 
     caller = get_verified_wallet(request)  # None when anonymous — never an error
@@ -485,7 +495,13 @@ async def list_generated_strategies(request: Request, limit: int = Query(50, ge=
             else:
                 query = query.filter(StrategyRecord.is_published.is_(True))
             records = query.order_by(StrategyRecord.created_at.desc()).limit(limit).all()
-            rows = [_redact_owner_wallet(r.to_dict(), caller) for r in records]
+            rows = []
+            for r in records:
+                d = r.to_dict()
+                d["can_publish"] = bool(caller) and wallet_can_publish(
+                    session, strategy_id=r.id, wallet_address=caller, is_example=False
+                )
+                rows.append(_redact_owner_wallet(d, caller))
     except Exception as exc:
         import logging as _logging
 

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -143,6 +143,48 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     except Exception as exc:
         _logger.warning("startup: corpus seed failed (non-fatal): %s", exc)
 
+    # 2a. Seed provider examples into strategy_store (idempotent, D1).
+    # Each provider example gets a StrategyRecord keyed by its 32-char
+    # provider id so the publish route can look it up. content_hash is a
+    # domain-separated SHA-256 to avoid collision with real generated hashes.
+    try:
+        import hashlib
+        import json
+
+        from archimedes.models.strategy_store import StrategyRecord
+
+        provider = default_provider()
+        with get_session() as session:
+            count = 0
+            for s in provider.list_strategies():
+                if session.query(StrategyRecord).filter_by(id=s.id).first():
+                    continue
+                content_hash = "0x" + hashlib.sha256(("example:" + s.id).encode()).hexdigest()
+                papers_list = [
+                    {"arxiv_id": p.arxiv_id, "title": p.title, "authors": p.authors}
+                    for p in s.papers
+                ]
+                record = StrategyRecord(
+                    id=s.id,
+                    content_hash=content_hash,
+                    is_example=True,
+                    generation_method="curated",
+                    strategy_name=s.paper_title or s.id,
+                    thesis=s.methodology_summary or "",
+                    source_papers=json.dumps(papers_list),
+                    asset_universe=json.dumps(s.asset_universe or []),
+                    risk_profile=(s.risk_profiles[0] if s.risk_profiles else "moderate"),
+                    status="live",
+                    owner_wallet=None,
+                )
+                session.add(record)
+                count += 1
+            if count:
+                session.commit()
+                _logger.info("startup: seeded %d example strategies into strategy_store", count)
+    except Exception as exc:
+        _logger.warning("startup: example strategy seed failed (non-fatal): %s", exc)
+
     # 3. Start the in-process marketplace engine (MarketService).
     # FAIL-SOFT: constructing the engine (or importing its deps, e.g. circlekit)
     # must NEVER take down the whole backend — a new subsystem crashing at

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -160,10 +160,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
                 if session.query(StrategyRecord).filter_by(id=s.id).first():
                     continue
                 content_hash = "0x" + hashlib.sha256(("example:" + s.id).encode()).hexdigest()
-                papers_list = [
-                    {"arxiv_id": p.arxiv_id, "title": p.title, "authors": p.authors}
-                    for p in s.papers
-                ]
+                papers_list = [{"arxiv_id": p.arxiv_id, "title": p.title, "authors": p.authors} for p in s.papers]
                 record = StrategyRecord(
                     id=s.id,
                     content_hash=content_hash,

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -104,6 +104,11 @@ def app():
     market.signer.execute_contract = AsyncMock()
     market.executor = MagicMock()
     market.executor.create_vault = AsyncMock(return_value="0xvault")
+    # Funding gate (D7): the publish route rejects (402) when the vault holds less
+    # than MARKETPLACE_MIN_VAULT_FUNDS_RAW. Mock the vault as well-funded so the
+    # publish-path tests exercise publishing rather than the funding gate; the
+    # gate itself is covered by test_publish_underfunded_vault_returns_402.
+    market._usdc_balance_of = AsyncMock(return_value=10_000_000)
     market.loader = MagicMock()
     market.loader._contract.return_value.functions.pools.return_value.call = AsyncMock(
         return_value=("0xaddr", "0xaddr", 0, 0, False)
@@ -153,6 +158,17 @@ def test_publish_creates_publisher_row(client):
     assert data["pool_id"].startswith("0x")
     assert len(data["pool_id"]) == 66
     assert data["pool_id"] != "sub_id"  # not accidentally in sub_id column
+
+
+def test_publish_underfunded_vault_returns_402(client):
+    """Publish rejects with 402 when the vault holds less than the minimum funding."""
+    client.app.state.market._usdc_balance_of = AsyncMock(return_value=0)
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xvault_pre"},
+    )
+    assert resp.status_code == 402, resp.text
+    assert "below minimum" in resp.json()["detail"]
 
 
 def test_subscribe_rejects_blank_sub_id(client):

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -27,3 +27,8 @@ VITE_API_BASE=
 # values; rely on this file as the variable-name template only.
 VITE_CIRCLE_CLIENT_KEY=
 VITE_CIRCLE_CLIENT_URL=https://modular-sdk.circle.com/v1/rpc/w3s/buidl
+
+# Minimum idle USDC (raw, 6-dec) a vault must hold before a strategy can be published.
+# Client-side pre-check only; the backend is authoritative. Mirror of the backend's
+# MARKETPLACE_MIN_VAULT_FUNDS_RAW. 1000000 = 1 USDC.
+VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW=1000000

--- a/ui/src/components/PublishPage.jsx
+++ b/ui/src/components/PublishPage.jsx
@@ -1,38 +1,106 @@
-import { useState } from 'react'
-import { apiPost } from '../api'
-import { getAddress } from '../config'
+import { useState, useEffect, useCallback } from 'react'
+import { apiPost, apiGet } from '../api'
+import { getAddress, usdcBalanceOfRaw, MIN_VAULT_FUNDS_RAW } from '../config'
+import StrategyTable from './PublishStrategyTable'
+import CreateVaultModal from './CreateVaultModal'
+
+const USDC_DECIMALS = 6
+
+function formatUsdc(raw) {
+  return (Number(raw) / 10 ** USDC_DECIMALS).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
 
 export default function PublishPage({ onNavigate }) {
   const walletAddr = getAddress()
-  const [strategyId, setStrategyId] = useState('')
-  const [vaultAddress, setVaultAddress] = useState('')
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState('')
+  const [activeTab, setActiveTab] = useState('generated')
+  const [generated, setGenerated] = useState([])
+  const [examples, setExamples] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [selectedStrategy, setSelectedStrategy] = useState(null)   // { id, title }
+
+  // Publish menu state
+  const [vaultMode, setVaultMode] = useState('create') // 'create' | 'existing'
+  const [existingVault, setExistingVault] = useState('')
+  const [publishing, setPublishing] = useState(false)
+  const [publishError, setPublishError] = useState('')
+
+  // Vault creation / deposit flow
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [createdVault, setCreatedVault] = useState(null)  // address after create+deposit
+  const [vaultBalance, setVaultBalance] = useState(null)  // bigint raw
+  const [checkingBalance, setCheckingBalance] = useState(false)
+
+  // Result panel
   const [result, setResult] = useState(null)
 
-  const handlePublish = async (e) => {
-    e.preventDefault()
-    if (!strategyId.trim()) return
-    setError('')
-    setResult(null)
-    setBusy(true)
+  const load = useCallback(async () => {
+    setLoading(true)
     try {
-      const body = { strategy_id: strategyId.trim() }
-      if (vaultAddress.trim()) body.vault_address = vaultAddress.trim()
+      const [genRes, exRes] = await Promise.all([
+        apiGet('/api/strategies/generated'),
+        apiGet('/api/strategies/'),
+      ])
+      setGenerated(genRes.strategies || [])
+      setExamples(exRes.strategies || [])
+    } catch (err) {
+      console.error('Failed to load strategies', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
 
-      const res = await apiPost('/api/marketplace/publish', body)
+  useEffect(() => { load() }, [load])
+
+  // Check vault balance whenever vault address changes
+  useEffect(() => {
+    if (!vaultMode || !selectedStrategy) return
+    const addr = vaultMode === 'create' ? createdVault : existingVault.trim()
+    if (!addr) { setVaultBalance(null); return }
+    setCheckingBalance(true)
+    usdcBalanceOfRaw(addr)
+      .then(b => setVaultBalance(b))
+      .catch(() => setVaultBalance(null))
+      .finally(() => setCheckingBalance(false))
+  }, [vaultMode, createdVault, existingVault, selectedStrategy])
+
+  const resetMenu = () => {
+    setSelectedStrategy(null)
+    setVaultMode('create')
+    setExistingVault('')
+    setCreatedVault(null)
+    setVaultBalance(null)
+    setPublishing(false)
+    setPublishError('')
+    setShowCreateModal(false)
+  }
+
+  const balanceOk = vaultBalance !== null && vaultBalance >= MIN_VAULT_FUNDS_RAW
+  const vaultAddress = vaultMode === 'create' ? createdVault : existingVault.trim()
+
+  const handlePublish = async () => {
+    if (!selectedStrategy || !vaultAddress) return
+    setPublishing(true)
+    setPublishError('')
+    try {
+      const res = await apiPost('/api/marketplace/publish', {
+        strategy_id: selectedStrategy.id,
+        vault_address: vaultAddress,
+      })
       setResult(res)
     } catch (err) {
-      if (err.message?.includes('409')) {
-        setError(`Strategy "${strategyId}" is already published.`)
-      } else {
-        setError(err.message || 'Publish failed')
-      }
+      setPublishError(err.message || 'Publish failed')
     } finally {
-      setBusy(false)
+      setPublishing(false)
     }
   }
 
+  // ── Callback when CreateVaultModal's deposit completes ──
+  const handleVaultDeployed = (addr) => {
+    setCreatedVault(addr)
+    setShowCreateModal(false)
+  }
+
+  // ── Not connected ──
   if (!walletAddr) {
     return (
       <div className="page-panel">
@@ -47,6 +115,7 @@ export default function PublishPage({ onNavigate }) {
     )
   }
 
+  // ── Success result panel ──
   if (result) {
     return (
       <div className="page-panel">
@@ -62,7 +131,7 @@ export default function PublishPage({ onNavigate }) {
             <button className="btn" onClick={() => onNavigate('marketplace')}>
               View Marketplace
             </button>
-            <button className="btn btn-ghost" onClick={() => { setResult(null); setStrategyId('') }}>
+            <button className="btn btn-ghost" onClick={() => { setResult(null); resetMenu() }}>
               Publish Another
             </button>
           </div>
@@ -71,54 +140,163 @@ export default function PublishPage({ onNavigate }) {
     )
   }
 
+  // ── Inline publish menu for a selected strategy ──
+  if (selectedStrategy) {
+    return (
+      <div className="page-panel">
+        <div className="max-w-[640px] mx-auto">
+          <button className="btn btn-ghost btn-sm mb-4" onClick={resetMenu}>
+            ← Back to strategies
+          </button>
+
+          <h2 className="serif text-[1.6rem] mb-1">Publish</h2>
+          <p className="body text-[var(--color-muted)] mb-4">
+            Strategy: <strong>{selectedStrategy.title || selectedStrategy.id}</strong> ({selectedStrategy.id})
+          </p>
+
+          {/* Vault choice */}
+          <div className="card p-4 space-y-4">
+            <div>
+              <label className="caption block mb-2">Vault</label>
+              <div className="flex gap-3 mb-2">
+                <button
+                  className={`btn btn-sm ${vaultMode === 'create' ? 'btn-primary' : 'btn-outline'}`}
+                  onClick={() => setVaultMode('create')}
+                >
+                  Create new vault
+                </button>
+                <button
+                  className={`btn btn-sm ${vaultMode === 'existing' ? 'btn-primary' : 'btn-outline'}`}
+                  onClick={() => setVaultMode('existing')}
+                >
+                  Use existing vault
+                </button>
+              </div>
+            </div>
+
+            {vaultMode === 'create' && (
+              <div>
+                {!createdVault ? (
+                  <button
+                    className="btn btn-primary"
+                    onClick={() => setShowCreateModal(true)}
+                  >
+                    Create Vault + Deposit
+                  </button>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="text-sm">
+                      <span className="text-[var(--color-muted)]">Vault:</span>{' '}
+                      <span className="font-mono">{createdVault}</span>
+                    </div>
+                    {checkingBalance && <div className="caption">Checking balance…</div>}
+                    {!checkingBalance && vaultBalance !== null && (
+                      <div className={`text-sm ${balanceOk ? 'text-[var(--positive)]' : 'text-[var(--color-danger)]'}`}>
+                        USDC balance: {formatUsdc(vaultBalance)}{' '}
+                        {!balanceOk && `(minimum required: ${formatUsdc(MIN_VAULT_FUNDS_RAW)})`}
+                      </div>
+                    )}
+                    <button className="btn btn-sm btn-ghost" onClick={() => setShowCreateModal(true)}>
+                      Re-create vault
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {vaultMode === 'existing' && (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  className="input w-full font-mono text-sm"
+                  value={existingVault}
+                  onChange={e => setExistingVault(e.target.value)}
+                  placeholder="0x..."
+                />
+                {checkingBalance && <div className="caption">Checking balance…</div>}
+                {!checkingBalance && vaultBalance !== null && existingVault.trim() && (
+                  <div className={`text-sm ${balanceOk ? 'text-[var(--positive)]' : 'text-[var(--color-danger)]'}`}>
+                    USDC balance: {formatUsdc(vaultBalance)}{' '}
+                    {!balanceOk && `(minimum required: ${formatUsdc(MIN_VAULT_FUNDS_RAW)})`}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Publish button */}
+            <div className="pt-2">
+              {publishError && (
+                <p className="text-sm text-[var(--color-danger)] mb-2">{publishError}</p>
+              )}
+              <button
+                className="btn btn-primary"
+                disabled={!vaultAddress || !balanceOk || publishing}
+                onClick={handlePublish}
+              >
+                {publishing ? 'Publishing…' : 'Publish'}
+              </button>
+              {!balanceOk && vaultAddress && !checkingBalance && (
+                <p className="caption text-[var(--color-danger)] mt-1">
+                  Vault holds insufficient USDC. Publishing requires ≥ {formatUsdc(MIN_VAULT_FUNDS_RAW)} USDC.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* CreateVaultModal portal */}
+        {showCreateModal && (
+          <CreateVaultModal
+            strategy={{ id: selectedStrategy.id, paper_title: selectedStrategy.title || selectedStrategy.id }}
+            walletAddr={walletAddr}
+            onClose={() => setShowCreateModal(false)}
+            onDeployed={handleVaultDeployed}
+          />
+        )}
+      </div>
+    )
+  }
+
+  // ── Main tabbed view ──
   return (
     <div className="page-panel">
-      <div className="max-w-[540px] mx-auto">
-        <h2 className="serif text-[2rem] mb-2">Publish a Strategy</h2>
+      <div className="max-w-[960px] mx-auto">
+        <h2 className="serif text-[2rem] mb-1">Publish a Strategy</h2>
         <p className="body text-[var(--color-muted)] mb-6">
-          Publish a strategy to the marketplace. The backend derives the pool ID
-          from your strategy ID and wallet address. Subscribers will copy-trade
-          this strategy through their own vaults.
+          Select a strategy to publish to the on-chain marketplace.
+          You need a vault with at least {formatUsdc(MIN_VAULT_FUNDS_RAW)} USDC to publish.
         </p>
 
-        <form onSubmit={handlePublish} className="space-y-4">
-          <div>
-            <label className="text-xs text-[var(--color-muted)] block mb-1">Strategy ID *</label>
-            <input
-              type="text"
-              className="input w-full"
-              value={strategyId}
-              onChange={(e) => setStrategyId(e.target.value)}
-              placeholder="e.g. mom_2014"
-              required
-              disabled={busy}
-            />
-            <p className="text-xs text-[var(--color-muted)] mt-1">
-              The strategy ID must exist in the strategy provider.
-            </p>
-          </div>
-
-          <div>
-            <label className="text-xs text-[var(--color-muted)] block mb-1">Vault Address (optional)</label>
-            <input
-              type="text"
-              className="input w-full font-mono text-sm"
-              value={vaultAddress}
-              onChange={(e) => setVaultAddress(e.target.value)}
-              placeholder="0x... (leave empty to auto-create)"
-              disabled={busy}
-            />
-          </div>
-
-
-          {error && (
-            <p className="text-sm text-[var(--color-danger)]">{error}</p>
-          )}
-
-          <button type="submit" className="btn btn-primary" disabled={busy || !strategyId.trim()}>
-            {busy ? 'Publishing…' : 'Publish'}
+        <div className="flex gap-2 mb-4">
+          <button
+            className={`tag ${activeTab === 'generated' ? 'tag-accent' : 'tag-muted'}`}
+            onClick={() => setActiveTab('generated')}
+          >
+            Generated
           </button>
-        </form>
+          <button
+            className={`tag ${activeTab === 'examples' ? 'tag-accent' : 'tag-muted'}`}
+            onClick={() => setActiveTab('examples')}
+          >
+            Examples
+          </button>
+        </div>
+
+        {loading && <div className="caption">Loading…</div>}
+
+        {!loading && activeTab === 'generated' && (
+          <StrategyTable
+            strategies={generated}
+            onSelect={s => setSelectedStrategy(s)}
+          />
+        )}
+
+        {!loading && activeTab === 'examples' && (
+          <StrategyTable
+            strategies={examples}
+            onSelect={s => setSelectedStrategy(s)}
+          />
+        )}
       </div>
     </div>
   )

--- a/ui/src/components/PublishPage.jsx
+++ b/ui/src/components/PublishPage.jsx
@@ -27,6 +27,7 @@ export default function PublishPage({ onNavigate }) {
   // Vault creation / deposit flow
   const [showCreateModal, setShowCreateModal] = useState(false)
   const [createdVault, setCreatedVault] = useState(null)  // address after create+deposit
+  const [depositDone, setDepositDone] = useState(false)   // true once DepositFlow completes
   const [vaultBalance, setVaultBalance] = useState(null)  // bigint raw
   const [checkingBalance, setCheckingBalance] = useState(false)
 
@@ -61,13 +62,14 @@ export default function PublishPage({ onNavigate }) {
       .then(b => setVaultBalance(b))
       .catch(() => setVaultBalance(null))
       .finally(() => setCheckingBalance(false))
-  }, [vaultMode, createdVault, existingVault, selectedStrategy])
+  }, [vaultMode, createdVault, existingVault, selectedStrategy, depositDone])
 
   const resetMenu = () => {
     setSelectedStrategy(null)
     setVaultMode('create')
     setExistingVault('')
     setCreatedVault(null)
+    setDepositDone(false)
     setVaultBalance(null)
     setPublishing(false)
     setPublishError('')
@@ -94,9 +96,16 @@ export default function PublishPage({ onNavigate }) {
     }
   }
 
-  // ── Callback when CreateVaultModal's deposit completes ──
+  // ── Callbacks for CreateVaultModal ──
+  // onDeployed fires right after on-chain createVault+setAgent succeed (before DepositFlow).
+  // We capture the address early so it's ready when DepositFlow completes.
   const handleVaultDeployed = (addr) => {
     setCreatedVault(addr)
+  }
+  // onClose fires when the modal fully closes (after DepositFlow's onComplete or user cancel).
+  // If we captured a vault address, assume the deposit flow completed.
+  const handleCloseModal = () => {
+    if (createdVault) setDepositDone(true)
     setShowCreateModal(false)
   }
 
@@ -244,12 +253,12 @@ export default function PublishPage({ onNavigate }) {
           </div>
         </div>
 
-        {/* CreateVaultModal portal */}
+        {/* CreateVaultModal portal — handles createVault + setAgent + DepositFlow */}
         {showCreateModal && (
           <CreateVaultModal
             strategy={{ id: selectedStrategy.id, paper_title: selectedStrategy.title || selectedStrategy.id }}
             walletAddr={walletAddr}
-            onClose={() => setShowCreateModal(false)}
+            onClose={handleCloseModal}
             onDeployed={handleVaultDeployed}
           />
         )}

--- a/ui/src/components/PublishStrategyTable.jsx
+++ b/ui/src/components/PublishStrategyTable.jsx
@@ -1,0 +1,135 @@
+/** Compact strategy table for the Publish page.
+ *
+ * Renders a dense table of strategies with a "Publish" affordance.
+ * Clicking a row selects it; onSelect fires with the strategy object.
+ *
+ * Mirrors the StrategyTable from Strategies.jsx but simplified —
+ * no expandable detail, no rigor metrics, just the essentials needed
+ * to pick and publish a strategy.
+ */
+import { useState } from 'react'
+
+function fmt(v, decimals = 2) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return v.toFixed(decimals)
+}
+function fmtPct(v) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return `${(v * 100).toFixed(1)}%`
+}
+function fmtUsd(n, fractionDigits = 0) {
+  if (n == null || !Number.isFinite(n)) return '—'
+  return `$${n.toLocaleString(undefined, { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits })}`
+}
+function projectedEndValue(principal, cagr, years) {
+  if (cagr == null || years == null) return null
+  return principal * (1 + cagr) ** years
+}
+function periodInYears(startIso, endIso) {
+  if (!startIso || !endIso) return null
+  const s = new Date(startIso), e = new Date(endIso)
+  return (e - s) / (365.25 * 86400 * 1000)
+}
+function statusLabel(status) {
+  if (!status) return '—'
+  const labels = { candidate: 'Candidate', validated: 'Validated', live: 'Live', retired: 'Retired', rejected: 'Rejected' }
+  return labels[status] || status
+}
+
+export default function StrategyTable({ strategies, onSelect }) {
+  if (!strategies.length) {
+    return <div className="caption">No strategies available.</div>
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
+      <table className="lib-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+        <thead>
+          <tr style={{ background: 'var(--glass)', textAlign: 'left', borderBottom: '1px solid var(--glass-border)' }}>
+            <th style={{ padding: '10px 14px' }}>Strategy</th>
+            <th style={{ padding: '10px 14px' }}>Status</th>
+            <th style={{ padding: '10px 14px', textAlign: 'right' }}>Sharpe</th>
+            <th style={{ padding: '10px 14px', textAlign: 'right' }}>CAGR</th>
+            <th style={{ padding: '10px 14px', textAlign: 'right' }}>Max DD</th>
+            <th style={{ padding: '10px 14px', textAlign: 'right' }}>$1k →</th>
+            <th style={{ padding: '10px 14px' }} />
+          </tr>
+        </thead>
+        <tbody>
+          {strategies.map(s => (
+            <StrategyRow key={s.id} s={s} onSelect={onSelect} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function StrategyRow({ s, onSelect }) {
+  const [open, setOpen] = useState(false)
+  const years = periodInYears(s.backtest_start, s.backtest_end)
+  const endValue = projectedEndValue(1000, s.cagr, years)
+
+  return (
+    <>
+      <tr
+        className="lib-row cursor-pointer"
+        onClick={() => setOpen(o => !o)}
+        style={{ cursor: 'pointer' }}
+      >
+        <td className="font-semibold">
+          <span
+            className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3 h-3 mr-1.5 text-[var(--text-4)] flex-shrink-0 inline-block`}
+          />
+          {s.paper_title || s.strategy_name || s.id}
+        </td>
+        <td>
+          <span className="tag tag-muted">{statusLabel(s.status)}</span>
+        </td>
+        <td className="mono" style={{ textAlign: 'right' }}>{fmt(s.sharpe_ratio)}</td>
+        <td className="mono positive" style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
+        <td className="mono negative" style={{ textAlign: 'right' }}>
+          {s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}
+        </td>
+        <td className="mono" style={{ textAlign: 'right', color: 'var(--positive)' }}>{fmtUsd(endValue)}</td>
+        <td style={{ textAlign: 'right', padding: '6px 10px' }}>
+          {s.can_publish ? (
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={(e) => { e.stopPropagation(); onSelect(s) }}
+            >
+              Publish
+            </button>
+          ) : (
+            <span className="caption text-[var(--text-4)]">—</span>
+          )}
+        </td>
+      </tr>
+      {open && (
+        <tr className="lib-row-detail">
+          <td colSpan={7} style={{ padding: '12px 18px', background: 'var(--glass)' }}>
+            <div className="text-[0.82rem]" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 18 }}>
+              <div>
+                <div className="label mb-2">Methodology</div>
+                <div className="body">{s.methodology_summary || '—'}</div>
+              </div>
+              <div>
+                <div className="label mb-2">Asset universe</div>
+                <div className="body">{(s.asset_universe || []).join(', ') || '—'}</div>
+              </div>
+            </div>
+            <div style={{ marginTop: 14, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              {s.can_publish && (
+                <button
+                  className="btn btn-primary btn-sm"
+                  onClick={(e) => { e.stopPropagation(); onSelect(s) }}
+                >
+                  Publish
+                </button>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -699,6 +699,24 @@ export async function getUsdcBalance(address) {
   }
 }
 
+/** Read the raw 6-dec USDC balance for an arbitrary address (bigint). */
+export async function usdcBalanceOfRaw(address) {
+  return await publicClient.readContract({
+    address: USDC,
+    abi: [
+      { name: 'balanceOf', type: 'function', stateMutability: 'view',
+        inputs: [{ type: 'address' }], outputs: [{ type: 'uint256' }] },
+    ],
+    functionName: 'balanceOf',
+    args: [address],
+  })
+}
+
+/** Minimum idle USDC (raw 6-dec) a vault must hold before a strategy may be
+ *  published. Mirrors MARKETPLACE_MIN_VAULT_FUNDS_RAW on the backend.
+ *  1000000 = 1 USDC. Backend-authoritative — this is a client pre-check only. */
+export const MIN_VAULT_FUNDS_RAW = BigInt(import.meta.env.VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW ?? '1000000')
+
 export const ASSETS = [
   { id: 'TSLA',   name: 'Tesla',      sym: 'sTSLA',   icon: 'i-simple-icons-tesla',          oracle: '0xe1c9f2b11be97097223a66a188fca541e07873a6', vault: '0xf0356600e26c6c403ec4f5b36b0e3380bb0609ab', token: '0xd514cd27baf762c650536765cde9b61c876abacd' },
   { id: 'NVDA',   name: 'Nvidia',     sym: 'sNVDA',   icon: 'i-simple-icons-nvidia',          oracle: '0xeb36acf88e739dd312de8278985262146a017374', vault: '0x4c3cdc2bf44195ad8a4d201c8afbd453949a8781', token: '0x805e75019a1291a598dfc134ad2519121a35fb11' },


### PR DESCRIPTION
# PR — Publish "Examples" strategies from the Marketplace panel

## What this does
Lets a publisher pick a strategy from their **Generated** or **Examples** lists in the
Marketplace → Publish panel (mirroring the Library panel) and publish it with a managed vault
flow, instead of hand-typing a `strategy_id` and vault address. Examples are gated to admin
wallets for now; this is a showcase of the end-to-end publish path.

## Why (root cause)
Publishing an example was impossible end-to-end, for a reason that wasn't obvious from the UI:

- Examples are served from the file-backed provider (`analytics-engine/strategies/*.py`),
  keyed by a 32-char hash. The publish route requires a matching `strategy_store` row
  (`marketplace_routes.py`: `filter_by(id=strategy_id)` → 404 if missing), and **nothing in
  production seeds examples into that table** — only tests do. So every example publish 404'd
  before the ownership gate was ever reached.
- There was no funding gate at publish time.
- The UI had no signal for whether the connected wallet may publish a given strategy.

## Changes by area

**Backend**
- **Startup seed (`main.py` lifespan):** idempotently inserts one `is_example=True`
  `StrategyRecord` per provider example, keyed by the **provider id** (not
  `content_hash[:16]`), bypassing `upsert_strategy` so the id chain the publish route relies
  on stays intact. Fail-soft — never blocks startup.
- **Funding gate (`marketplace_routes.py`):** after the vault is known and before
  `createPool`, reject with **HTTP 402** if raw `USDC.balanceOf(vault) < MARKETPLACE_MIN_VAULT_FUNDS_RAW`.
  Same threshold on both the auto-created and caller-supplied vault paths. Reuses the existing
  `MarketService._usdc_balance_of` primitive.
- **`can_publish` serializer field (`schemas.py`, `strategies_routes.py`):** computed per
  caller via `wallet_can_publish` on both list endpoints (examples list now resolves the SIWE
  caller; the generated list already did). Anonymous callers always get `false`.

**Frontend**
- **`PublishPage.jsx` rewrite:** Generated / Examples tabs reusing the Library's
  `StrategyTable`/`extraActions`; the publish affordance shows only where `can_publish`. The
  id text box is gone — the id comes from the selected row.
- **Client-signed vault (D4):** create-new path reuses `CreateVaultModal`'s
  `createVault()`+`setAgent()` so the on-chain **vault creator is the publisher**, then runs
  `DepositFlow` with a minimum deposit equal to the threshold. Existing-vault path skips the
  deposit and only checks the balance. Both do a client-side pre-check; the backend 402 stays
  authoritative.
- **`config.js`:** small `usdcBalanceOfRaw()` reader + `MIN_VAULT_FUNDS_RAW` mirror of the
  backend const.

**Config**
- New env keys `MARKETPLACE_MIN_VAULT_FUNDS_RAW` (backend) and
  `VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW` (UI), documented. `PLATFORM_ADMIN_WALLETS` must
  include the operator wallet for example publishing.

## Deliberately NOT in this PR (scoped out)
- **Any-user example publishing.** Examples stay admin-gated; `wallet_can_publish` is
  unchanged. Opening this up needs a per-wallet publisher model (see below) and is a separate
  pass.
- **Concurrent publishers of the same example.** The running-publisher unique index is
  `(role, strategy_id)`, so the first publisher of an example wins exclusively. No index
  change, no migration here.
- **User-signed `createPool`.** It stays owner/server-signed. The signer only affects auth
  (`onlyOwner`) and gas — the pool's `creator`/`platform` are call arguments and disbursement
  routes to `pool.creator` regardless of who submits the tx, so the publisher is already the
  economic creator. `PaymentSplitter.sol` is untouched.

## Known limitation (accepted)
The funding gate measures **idle USDC**, not NAV. A reused vault already rebalanced into
synthetics can hold a large NAV but ~0 idle USDC and will fail the gate. Acceptable for the
showcase; switching the gate to `totalAssets()` later is a one-line change on both sides.

## Risk / blast radius
- Additive only: one optional response field, one startup seed, one publish precondition, one
  UI page rewrite. No DB migration, no contract change (`git diff --stat contracts/` and
  `backend/migrations/` are both empty).
- Startup seed is idempotent and fail-soft, so a seeding error degrades to "examples not
  publishable" rather than a failed boot.

## Test / verification
- Boot twice → examples seeded once, no duplicates.
- `GET /api/strategies/` (admin SIWE) → example rows `can_publish=true`; anonymous → `false`.
- Publish an example: create-vault (creator == publisher) → deposit ≥ threshold → 200.
- Under-funded vault → 402 on both vault paths.