### PR TITLE
[perf] Cache live rigor-gate results to fix slow Library load

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -416,6 +416,18 @@ async def evaluate_rigor_gate(
     # nothing when `_compute()` returns its normal non-empty list.
     results = get_or_compute(cache_key, _compute, cache_if=bool)
 
+    # Copilot review (PR #1040): on a rigor_cache HIT, `results` are memoized
+    # StrategyRigorResult objects whose `library_pbo` reflects whatever was
+    # current at cache-WRITE time. `library_pbo` (above, line ~211) is always
+    # freshly computed for THIS request. Without this reconciliation, a cache
+    # hit could serve a response where the top-level `library_pbo` and each
+    # per-strategy `result.library_pbo` disagree — an internally inconsistent
+    # response. Rebuild (never mutate the cached objects in place, since
+    # `results` may be the exact list object shared with a concurrent
+    # reader of the same cache entry) with the fresh payload so top-level and
+    # per-strategy always agree, on both cache hits and misses.
+    results = [r.model_copy(update={"library_pbo": library_pbo}) for r in results]
+
     passing = sum(1 for r in results if r.passes_all)
     return RigorGateResponse(
         strategies=results,

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -243,6 +243,16 @@ async def evaluate_rigor_gate(
     # any cache-layer error falls back to calling the compute closure directly —
     # so a cache bug can only make a request slow, never wrong.
     #
+    # code_versions folds each strategy's strategy_code_hash into the key
+    # (Copilot review, PR #1040): run_rigor_gate's look-ahead audit below reads
+    # strategy_code_map[s.id], which is loaded FROM s.strategy_code_path — so the
+    # cached result depends on strategy code, not just returns + strictness. A
+    # key built from returns+strictness alone could keep serving a stale
+    # look-ahead verdict/passes_all after a code edit even though returns are
+    # unchanged. strategy_code_hash is already computed onto the Strategy object
+    # by LocalStrategyProvider, so reading it here is free — no extra I/O on the
+    # request path.
+    #
     # NOTE: on a cache HIT the per-strategy DB rigor-fields write-back
     # (update_rigor_gate_fields) below does NOT re-run. That write-back is
     # idempotent — it re-persists the exact numbers already written the first
@@ -252,7 +262,10 @@ async def evaluate_rigor_gate(
     # resumes on the next (now-live) call.
     from archimedes.services.rigor_cache import cohort_key, get_or_compute
 
-    cache_key = f"selection_bias_gate:strictness={strictness}:" + cohort_key(strategy_ids, returns_by_strategy)
+    code_versions = {s.id: getattr(s, "strategy_code_hash", None) for s in strategies}
+    cache_key = f"selection_bias_gate:strictness={strictness}:" + cohort_key(
+        strategy_ids, returns_by_strategy, code_versions
+    )
 
     def _compute() -> list[StrategyRigorResult]:
         strategy_code_map: dict[str, str | None] = {}
@@ -395,7 +408,13 @@ async def evaluate_rigor_gate(
             )
         return computed
 
-    results = get_or_compute(cache_key, _compute)
+    # cache_if=lambda v: bool(v): `strategies` is non-empty here (checked
+    # above), so `_compute()` always appends one result per strategy today —
+    # but a hard guard against ever memoizing an empty list matches
+    # strategies_routes.py's `_live_rigor_results_for_strategies` (same failure
+    # class: an empty result must never get "sticky" for the TTL) and costs
+    # nothing when `_compute()` returns its normal non-empty list.
+    results = get_or_compute(cache_key, _compute, cache_if=lambda v: bool(v))
 
     passing = sum(1 for r in results if r.passes_all)
     return RigorGateResponse(

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -225,147 +225,177 @@ async def evaluate_rigor_gate(
     init_db()
 
     strategy_ids = [s.id for s in strategies]
-    strategy_code_map: dict[str, str | None] = {}
 
     # Load real returns from DB
     with get_session() as session:
         returns_by_strategy = get_all_daily_returns(session, strategy_ids)
 
-    for s in strategies:
-        code = _load_strategy_code(s.strategy_code_path) if s.strategy_code_path else None
-        strategy_code_map[s.id] = code
+    # ── Perf (Library page load latency, ~8-10s measured for this route) ──
+    # Everything below this point — code loads for the look-ahead audit, cohort
+    # PBO + average correlation, and one run_rigor_gate call per strategy (plus
+    # its DB rigor-fields write-back) — is memoized in services.rigor_cache keyed
+    # on a data-version token (rigor_cache.cohort_key + strictness, since the
+    # strictness level changes which profile run_rigor_gate grades against). The
+    # DB read above is NEVER cached — it always runs live, so the key reacts the
+    # instant persisted returns change. This is honest caching: a cache hit
+    # serves exactly the same StrategyRigorResult list a cache miss would have
+    # computed, not a fake or stale one. rigor_cache.get_or_compute fails open —
+    # any cache-layer error falls back to calling the compute closure directly —
+    # so a cache bug can only make a request slow, never wrong.
+    #
+    # NOTE: on a cache HIT the per-strategy DB rigor-fields write-back
+    # (update_rigor_gate_fields) below does NOT re-run. That write-back is
+    # idempotent — it re-persists the exact numbers already written the first
+    # time this cohort+strictness combination was computed — so skipping it on a
+    # hit changes no served or stored value; it just skips a redundant write. The
+    # moment underlying returns change, the cache key changes and the write-back
+    # resumes on the next (now-live) call.
+    from archimedes.services.rigor_cache import cohort_key, get_or_compute
 
-    # Strategies with no real backtest data report all gate fields as MISSING
-    # (handled in the per-strategy loop below). Do NOT synthesize returns from
-    # stub_sharpe — DSR would trivially pass because the series was constructed
-    # to hit exactly that Sharpe, creating a circular validation that is
-    # meaningless. The stubs remain available for UI display (portfolio page)
-    # but must not feed into the rigor gate.
+    cache_key = f"selection_bias_gate:strictness={strictness}:" + cohort_key(strategy_ids, returns_by_strategy)
 
-    # Compute PBO across all strategies that have returns. Exclude zero-variance
-    # (degenerate/placeholder-flat) series BEFORE they can inflate num_trials or
-    # dilute avg_correlation (#868): a flat daily_returns series (e.g. a stub row
-    # that was never replaced with a real backtest) has no informational content,
-    # but counting it toward the multiple-testing correction still stiffens DSR
-    # for every REAL strategy in the cohort. Mirrors the exact degeneracy test
-    # _rigor_helpers._sharpe_dsr_inputs already uses (np.ptp(arr) == 0 — peak-to-
-    # peak range zero) so "degenerate" means the same thing everywhere in the
-    # gate. This only trims the cohort-level context (num_trials/avg_correlation/
-    # pbo_scores below); the per-strategy gate loop still runs every strategy
-    # (including degenerate ones) against its own returns via
-    # returns_by_strategy.get(s.id, []) so a degenerate strategy still correctly
-    # reports MISSING/FAIL on its own row instead of silently disappearing.
-    valid_returns = {
-        k: v for k, v in returns_by_strategy.items() if len(v) >= 10 and float(np.ptp(np.asarray(v, dtype=float))) > 0.0
-    }
-    pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
+    def _compute() -> list[StrategyRigorResult]:
+        strategy_code_map: dict[str, str | None] = {}
+        for s in strategies:
+            code = _load_strategy_code(s.strategy_code_path) if s.strategy_code_path else None
+            strategy_code_map[s.id] = code
 
-    # num_trials = library size here (#770). This route grades the EXISTING persisted
-    # library, so the selection set is the library itself — there is no fresh
-    # N-candidate society pool to add (that additive correction, N + library_size,
-    # applies only on the live society generation path in generation_pipeline.py).
-    # #820 unified the live and fusion generation paths on that additive count;
-    # this route staying on library-size alone is the deliberate exception, not
-    # a fourth convention that slipped through.
-    num_trials = max(len(valid_returns), 1)
+        # Strategies with no real backtest data report all gate fields as MISSING
+        # (handled in the per-strategy loop below). Do NOT synthesize returns from
+        # stub_sharpe — DSR would trivially pass because the series was constructed
+        # to hit exactly that Sharpe, creating a circular validation that is
+        # meaningless. The stubs remain available for UI display (portfolio page)
+        # but must not feed into the rigor gate.
 
-    # The strategy library is the multiple-testing selection set; correlated
-    # strategies (overlapping assets/signals) carry fewer independent trials, so
-    # the DSR effective-N correction relaxes the penalty via N_eff = N/(1+(N-1)ρ̄).
-    avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+        # Compute PBO across all strategies that have returns. Exclude zero-variance
+        # (degenerate/placeholder-flat) series BEFORE they can inflate num_trials or
+        # dilute avg_correlation (#868): a flat daily_returns series (e.g. a stub row
+        # that was never replaced with a real backtest) has no informational content,
+        # but counting it toward the multiple-testing correction still stiffens DSR
+        # for every REAL strategy in the cohort. Mirrors the exact degeneracy test
+        # _rigor_helpers._sharpe_dsr_inputs already uses (np.ptp(arr) == 0 — peak-to-
+        # peak range zero) so "degenerate" means the same thing everywhere in the
+        # gate. This only trims the cohort-level context (num_trials/avg_correlation/
+        # pbo_scores below); the per-strategy gate loop still runs every strategy
+        # (including degenerate ones) against its own returns via
+        # returns_by_strategy.get(s.id, []) so a degenerate strategy still correctly
+        # reports MISSING/FAIL on its own row instead of silently disappearing.
+        valid_returns = {
+            k: v
+            for k, v in returns_by_strategy.items()
+            if len(v) >= 10 and float(np.ptp(np.asarray(v, dtype=float))) > 0.0
+        }
+        pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
 
-    # Run rigor gate for each strategy
-    results: list[StrategyRigorResult] = []
-    for s in strategies:
-        daily_returns = returns_by_strategy.get(s.id, [])
+        # num_trials = library size here (#770). This route grades the EXISTING persisted
+        # library, so the selection set is the library itself — there is no fresh
+        # N-candidate society pool to add (that additive correction, N + library_size,
+        # applies only on the live society generation path in generation_pipeline.py).
+        # #820 unified the live and fusion generation paths on that additive count;
+        # this route staying on library-size alone is the deliberate exception, not
+        # a fourth convention that slipped through.
+        num_trials = max(len(valid_returns), 1)
 
-        if len(daily_returns) < 10:
-            results.append(
+        # The strategy library is the multiple-testing selection set; correlated
+        # strategies (overlapping assets/signals) carry fewer independent trials, so
+        # the DSR effective-N correction relaxes the penalty via N_eff = N/(1+(N-1)ρ̄).
+        avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+
+        # Run rigor gate for each strategy
+        computed: list[StrategyRigorResult] = []
+        for s in strategies:
+            daily_returns = returns_by_strategy.get(s.id, [])
+
+            if len(daily_returns) < 10:
+                computed.append(
+                    StrategyRigorResult(
+                        strategy_id=s.id,
+                        strategy_name=s.paper_title,
+                        passes_all=False,
+                        gate_details=RigorGateDetail(
+                            dsr="MISSING (no backtest data)",
+                            pbo="MISSING (no backtest data)",
+                            oos_sharpe="MISSING (no backtest data)",
+                            look_ahead="MISSING (no code)",
+                        ),
+                        library_pbo=library_pbo,
+                        strictness_level=strictness,
+                        min_passing_level=None,
+                        blocked_by_floor=False,
+                    )
+                )
+                continue
+
+            # in_sample_sharpe is left None on purpose: run_rigor_gate derives it
+            # from the first 70% of `daily_returns`, the same series whose last 30%
+            # produces oos_sharpe. Passing the *full-sample* backtest Sharpe here
+            # (the previous `bt_map[s.id].sharpe_ratio`) made the OOS/IS cliff check
+            # trivially passable — a bad OOS tail drags the full-sample denominator
+            # down, inflating the ratio (see rigor_evaluator.run_rigor_gate's own
+            # warning at the IS-slice fallback). Let the gate compute the honest
+            # first-70% in-sample denominator instead of overriding it.
+            in_sample_sharpe = None
+
+            # cv_returns_matrix intentionally omitted — CPCV requires a 2-D array
+            # of per-combinatorial-split OOS returns that the analytics-engine does
+            # not yet produce.  run_rigor_gate() reports cpcv as an explicit NOT_RUN
+            # status with the reason (#771), not a bare "MISSING".
+            gate_result = run_rigor_gate(
+                strategy_id=s.id,
+                daily_returns=daily_returns,
+                num_trials=num_trials,
+                pbo_scores=pbo_scores,
+                strategy_code=strategy_code_map.get(s.id),
+                in_sample_sharpe=in_sample_sharpe,
+                paper_claimed_sharpe=s.paper_claimed_sharpe,
+                average_correlation=avg_correlation,
+                strictness_level=strictness,
+            )
+
+            # Persist rigor gate results to DB
+            with get_session() as session:
+                update_rigor_gate_fields(
+                    session,
+                    s.id,
+                    deflated_sharpe_ratio=gate_result.deflated_sharpe,
+                    dsr_p_value=gate_result.dsr_p_value,
+                    num_trials_in_selection=num_trials,
+                    pbo_score=gate_result.pbo_score,
+                    out_of_sample_sharpe=gate_result.oos_sharpe,
+                    look_ahead_audit_passed=gate_result.look_ahead_passed,
+                )
+                session.commit()
+
+            details = gate_result.gate_details
+            computed.append(
                 StrategyRigorResult(
                     strategy_id=s.id,
                     strategy_name=s.paper_title,
-                    passes_all=False,
+                    passes_all=gate_result.passes_all,
                     gate_details=RigorGateDetail(
-                        dsr="MISSING (no backtest data)",
-                        pbo="MISSING (no backtest data)",
-                        oos_sharpe="MISSING (no backtest data)",
-                        look_ahead="MISSING (no code)",
+                        dsr=details.get("dsr", "MISSING"),
+                        pbo=details.get("pbo", "MISSING"),
+                        oos_sharpe=details.get("oos_sharpe", "MISSING"),
+                        look_ahead=details.get("look_ahead", "MISSING"),
+                        cpcv=details.get("cpcv", "MISSING"),
+                        dsr_convention=details.get("dsr_convention", "MISSING"),
+                        iid=details.get("iid", "MISSING"),
+                        regime_robustness=details.get("regime_robustness", "MISSING"),
                     ),
+                    deflated_sharpe=gate_result.deflated_sharpe,
+                    dsr_p_value=gate_result.dsr_p_value,
+                    pbo_score=gate_result.pbo_score,
+                    oos_sharpe=gate_result.oos_sharpe,
+                    in_sample_sharpe=gate_result.in_sample_sharpe,
                     library_pbo=library_pbo,
                     strictness_level=strictness,
-                    min_passing_level=None,
-                    blocked_by_floor=False,
+                    min_passing_level=gate_result.min_passing_level,
+                    blocked_by_floor=gate_result.blocked_by_floor,
                 )
             )
-            continue
+        return computed
 
-        # in_sample_sharpe is left None on purpose: run_rigor_gate derives it
-        # from the first 70% of `daily_returns`, the same series whose last 30%
-        # produces oos_sharpe. Passing the *full-sample* backtest Sharpe here
-        # (the previous `bt_map[s.id].sharpe_ratio`) made the OOS/IS cliff check
-        # trivially passable — a bad OOS tail drags the full-sample denominator
-        # down, inflating the ratio (see rigor_evaluator.run_rigor_gate's own
-        # warning at the IS-slice fallback). Let the gate compute the honest
-        # first-70% in-sample denominator instead of overriding it.
-        in_sample_sharpe = None
-
-        # cv_returns_matrix intentionally omitted — CPCV requires a 2-D array
-        # of per-combinatorial-split OOS returns that the analytics-engine does
-        # not yet produce.  run_rigor_gate() reports cpcv as an explicit NOT_RUN
-        # status with the reason (#771), not a bare "MISSING".
-        gate_result = run_rigor_gate(
-            strategy_id=s.id,
-            daily_returns=daily_returns,
-            num_trials=num_trials,
-            pbo_scores=pbo_scores,
-            strategy_code=strategy_code_map.get(s.id),
-            in_sample_sharpe=in_sample_sharpe,
-            paper_claimed_sharpe=s.paper_claimed_sharpe,
-            average_correlation=avg_correlation,
-            strictness_level=strictness,
-        )
-
-        # Persist rigor gate results to DB
-        with get_session() as session:
-            update_rigor_gate_fields(
-                session,
-                s.id,
-                deflated_sharpe_ratio=gate_result.deflated_sharpe,
-                dsr_p_value=gate_result.dsr_p_value,
-                num_trials_in_selection=num_trials,
-                pbo_score=gate_result.pbo_score,
-                out_of_sample_sharpe=gate_result.oos_sharpe,
-                look_ahead_audit_passed=gate_result.look_ahead_passed,
-            )
-            session.commit()
-
-        details = gate_result.gate_details
-        results.append(
-            StrategyRigorResult(
-                strategy_id=s.id,
-                strategy_name=s.paper_title,
-                passes_all=gate_result.passes_all,
-                gate_details=RigorGateDetail(
-                    dsr=details.get("dsr", "MISSING"),
-                    pbo=details.get("pbo", "MISSING"),
-                    oos_sharpe=details.get("oos_sharpe", "MISSING"),
-                    look_ahead=details.get("look_ahead", "MISSING"),
-                    cpcv=details.get("cpcv", "MISSING"),
-                    dsr_convention=details.get("dsr_convention", "MISSING"),
-                    iid=details.get("iid", "MISSING"),
-                    regime_robustness=details.get("regime_robustness", "MISSING"),
-                ),
-                deflated_sharpe=gate_result.deflated_sharpe,
-                dsr_p_value=gate_result.dsr_p_value,
-                pbo_score=gate_result.pbo_score,
-                oos_sharpe=gate_result.oos_sharpe,
-                in_sample_sharpe=gate_result.in_sample_sharpe,
-                library_pbo=library_pbo,
-                strictness_level=strictness,
-                min_passing_level=gate_result.min_passing_level,
-                blocked_by_floor=gate_result.blocked_by_floor,
-            )
-        )
+    results = get_or_compute(cache_key, _compute)
 
     passing = sum(1 for r in results if r.passes_all)
     return RigorGateResponse(

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -408,13 +408,13 @@ async def evaluate_rigor_gate(
             )
         return computed
 
-    # cache_if=lambda v: bool(v): `strategies` is non-empty here (checked
+    # cache_if=bool: `strategies` is non-empty here (checked
     # above), so `_compute()` always appends one result per strategy today —
     # but a hard guard against ever memoizing an empty list matches
     # strategies_routes.py's `_live_rigor_results_for_strategies` (same failure
     # class: an empty result must never get "sticky" for the TTL) and costs
     # nothing when `_compute()` returns its normal non-empty list.
-    results = get_or_compute(cache_key, _compute, cache_if=lambda v: bool(v))
+    results = get_or_compute(cache_key, _compute, cache_if=bool)
 
     passing = sum(1 for r in results if r.passes_all)
     return RigorGateResponse(

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -314,7 +314,7 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
     what a cache miss would have computed. ``rigor_cache.get_or_compute`` fails
     open (any cache-layer error falls back to calling the compute closure
     directly), so a cache bug can only make a request slow, never wrong. It also
-    never caches the ``{}`` failure sentinel (``cache_if=lambda v: bool(v)``) so
+    never caches the ``{}`` failure sentinel (``cache_if=bool``) so
     a transient cohort-compute failure can't strand every strategy on stale
     fallback fields for the full TTL.
     """
@@ -411,14 +411,14 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
                 logger.warning("live rigor gate failed for %s in batch (numbers → stale fallback): %s", s.id, exc)
         return computed
 
-    # cache_if=lambda v: bool(v): `_compute()` returns `{}` on a transient
+    # cache_if=bool: `_compute()` returns `{}` on a transient
     # cohort-context compute failure (see the `except Exception` above), and an
     # empty dict must never be memoized — caching it would make that transient
     # failure "sticky" for the full TTL, serving every strategy's stale
     # fallback fields long after the underlying failure has passed (Copilot
     # review, PR #1040). The live `{}` is still returned to THIS caller either
     # way; only whether it's written to the store for the NEXT caller changes.
-    return get_or_compute(cache_key, _compute, cache_if=lambda v: bool(v))
+    return get_or_compute(cache_key, _compute, cache_if=bool)
 
 
 def _load_strategy_code_safe_local(strategy: Strategy) -> str | None:

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -298,6 +298,18 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
 
     Any DB or cohort-compute failure degrades to ``{}`` (every id falls back to
     the stale fields) rather than raising into the library-list response.
+
+    **Perf (Library page load latency):** the batch cohort compute below (PBO,
+    average correlation, per-strategy look-ahead code load, one ``run_rigor_gate``
+    call per strategy — measured ~6s for this route) is memoized in
+    ``services.rigor_cache`` keyed on a data-version token
+    (``rigor_cache.cohort_key``) derived from the exact persisted-returns read just
+    above. The DB read itself is NEVER cached — it always runs live, which is what
+    lets the key react the instant persisted returns change. This is honest
+    caching: the cached value IS the real live-computed result, so a cache hit
+    serves exactly what a cache miss would have computed. ``rigor_cache.get_or_compute``
+    fails open (any cache-layer error falls back to calling the compute closure
+    directly), so a cache bug can only make a request slow, never wrong.
     """
     if not strategies:
         return {}
@@ -307,11 +319,6 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
     try:
         from archimedes.db import get_session, init_db
         from archimedes.services.backtest_repository import get_all_daily_returns
-        from archimedes.services.rigor_evaluator import (
-            compute_average_pairwise_correlation,
-            compute_pbo,
-            run_rigor_gate,
-        )
 
         init_db()
         with get_session() as session:
@@ -320,60 +327,75 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
         logger.warning("live rigor result batch: DB read failed (all → stale fallback): %s", exc)
         return {}
 
-    # Exclude zero-variance (degenerate/placeholder-flat) series from the cohort
-    # context — same fix as selection_bias_routes.py's valid_returns filter
-    # (#868), so num_trials/avg_correlation/pbo_scores here match that route's
-    # library-wide gate exactly rather than drifting apart on this input.
-    valid_returns = {
-        k: v for k, v in returns_by_strategy.items() if len(v) >= 10 and float(np.ptp(np.asarray(v, dtype=float))) > 0.0
-    }
+    from archimedes.services.rigor_cache import cohort_key, get_or_compute
 
-    try:
-        pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
-        num_trials = max(len(valid_returns), 1)
-        avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
-    except Exception as exc:
-        logger.warning("live rigor result batch: cohort-context compute failed (all → stale fallback): %s", exc)
-        return {}
+    cache_key = "strategies_list:" + cohort_key(strategy_ids, returns_by_strategy)
 
-    # Load code for every strategy that has >= 10 returns — degenerate series
-    # (excluded from valid_returns) still run their own gate (#868) and need the
-    # look-ahead audit input.
-    code_by_id = {
-        s.id: _load_strategy_code_safe_local(s) for s in strategies if len(returns_by_strategy.get(s.id, [])) >= 10
-    }
+    def _compute() -> dict[str, RigorGateResult]:
+        from archimedes.services.rigor_evaluator import (
+            compute_average_pairwise_correlation,
+            compute_pbo,
+            run_rigor_gate,
+        )
 
-    results: dict[str, RigorGateResult] = {}
-    for s in strategies:
-        daily_returns = returns_by_strategy.get(s.id, [])
-        if len(daily_returns) < 10:
-            continue  # No sufficient returns — caller falls back to stale fields
-        if s.id in valid_returns:
-            # Non-degenerate series: run with the full cohort context so
-            # num_trials / pbo_scores / avg_correlation match the library gate.
-            gate_kwargs: dict = {
-                "num_trials": num_trials,
-                "pbo_scores": pbo_scores,
-                "average_correlation": avg_correlation,
-            }
-        else:
-            # Degenerate (zero-variance) series: excluded from cohort context to
-            # prevent inflating num_trials or diluting avg_correlation (#868), but
-            # the strategy still runs its own gate so the caller gets a live "fail"
-            # verdict rather than falling back to a stale fixture value.
-            gate_kwargs = {"num_trials": 1, "pbo_scores": {}, "average_correlation": 0.0}
+        # Exclude zero-variance (degenerate/placeholder-flat) series from the cohort
+        # context — same fix as selection_bias_routes.py's valid_returns filter
+        # (#868), so num_trials/avg_correlation/pbo_scores here match that route's
+        # library-wide gate exactly rather than drifting apart on this input.
+        valid_returns = {
+            k: v
+            for k, v in returns_by_strategy.items()
+            if len(v) >= 10 and float(np.ptp(np.asarray(v, dtype=float))) > 0.0
+        }
+
         try:
-            results[s.id] = run_rigor_gate(
-                strategy_id=s.id,
-                daily_returns=daily_returns,
-                strategy_code=code_by_id.get(s.id),
-                in_sample_sharpe=None,
-                paper_claimed_sharpe=getattr(s, "paper_claimed_sharpe", None),
-                **gate_kwargs,
-            )
+            pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
+            num_trials = max(len(valid_returns), 1)
+            avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
         except Exception as exc:
-            logger.warning("live rigor gate failed for %s in batch (numbers → stale fallback): %s", s.id, exc)
-    return results
+            logger.warning("live rigor result batch: cohort-context compute failed (all → stale fallback): %s", exc)
+            return {}
+
+        # Load code for every strategy that has >= 10 returns — degenerate series
+        # (excluded from valid_returns) still run their own gate (#868) and need the
+        # look-ahead audit input.
+        code_by_id = {
+            s.id: _load_strategy_code_safe_local(s) for s in strategies if len(returns_by_strategy.get(s.id, [])) >= 10
+        }
+
+        computed: dict[str, RigorGateResult] = {}
+        for s in strategies:
+            daily_returns = returns_by_strategy.get(s.id, [])
+            if len(daily_returns) < 10:
+                continue  # No sufficient returns — caller falls back to stale fields
+            if s.id in valid_returns:
+                # Non-degenerate series: run with the full cohort context so
+                # num_trials / pbo_scores / avg_correlation match the library gate.
+                gate_kwargs: dict = {
+                    "num_trials": num_trials,
+                    "pbo_scores": pbo_scores,
+                    "average_correlation": avg_correlation,
+                }
+            else:
+                # Degenerate (zero-variance) series: excluded from cohort context to
+                # prevent inflating num_trials or diluting avg_correlation (#868), but
+                # the strategy still runs its own gate so the caller gets a live "fail"
+                # verdict rather than falling back to a stale fixture value.
+                gate_kwargs = {"num_trials": 1, "pbo_scores": {}, "average_correlation": 0.0}
+            try:
+                computed[s.id] = run_rigor_gate(
+                    strategy_id=s.id,
+                    daily_returns=daily_returns,
+                    strategy_code=code_by_id.get(s.id),
+                    in_sample_sharpe=None,
+                    paper_claimed_sharpe=getattr(s, "paper_claimed_sharpe", None),
+                    **gate_kwargs,
+                )
+            except Exception as exc:
+                logger.warning("live rigor gate failed for %s in batch (numbers → stale fallback): %s", s.id, exc)
+        return computed
+
+    return get_or_compute(cache_key, _compute)
 
 
 def _load_strategy_code_safe_local(strategy: Strategy) -> str | None:

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -304,12 +304,19 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
     call per strategy — measured ~6s for this route) is memoized in
     ``services.rigor_cache`` keyed on a data-version token
     (``rigor_cache.cohort_key``) derived from the exact persisted-returns read just
-    above. The DB read itself is NEVER cached — it always runs live, which is what
-    lets the key react the instant persisted returns change. This is honest
-    caching: the cached value IS the real live-computed result, so a cache hit
-    serves exactly what a cache miss would have computed. ``rigor_cache.get_or_compute``
-    fails open (any cache-layer error falls back to calling the compute closure
-    directly), so a cache bug can only make a request slow, never wrong.
+    above, PLUS each strategy's ``strategy_code_hash`` — the look-ahead audit
+    inside ``run_rigor_gate`` also depends on the strategy's code, so the code
+    hash has to participate in the key or a code edit could serve a stale
+    look-ahead verdict for up to the TTL (Copilot review, PR #1040). The DB read
+    itself is NEVER cached — it always runs live, which is what lets the key
+    react the instant persisted returns change. This is honest caching: the
+    cached value IS the real live-computed result, so a cache hit serves exactly
+    what a cache miss would have computed. ``rigor_cache.get_or_compute`` fails
+    open (any cache-layer error falls back to calling the compute closure
+    directly), so a cache bug can only make a request slow, never wrong. It also
+    never caches the ``{}`` failure sentinel (``cache_if=lambda v: bool(v)``) so
+    a transient cohort-compute failure can't strand every strategy on stale
+    fallback fields for the full TTL.
     """
     if not strategies:
         return {}
@@ -329,7 +336,16 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
 
     from archimedes.services.rigor_cache import cohort_key, get_or_compute
 
-    cache_key = "strategies_list:" + cohort_key(strategy_ids, returns_by_strategy)
+    # Fold each strategy's code-version token into the key (Copilot review, PR
+    # #1040): run_rigor_gate's look-ahead audit reads `strategy_code`, so a key
+    # built from returns alone can serve a stale look-ahead verdict/passes_all
+    # after a code edit even though returns are unchanged. `strategy_code_hash`
+    # is a SHA-256 of the strategy file contents already computed onto the
+    # Strategy object by LocalStrategyProvider — reading it here costs no extra
+    # I/O on the request path (the cheap-identifier preference `cohort_key`'s
+    # docstring calls for).
+    code_versions = {s.id: getattr(s, "strategy_code_hash", None) for s in strategies}
+    cache_key = "strategies_list:" + cohort_key(strategy_ids, returns_by_strategy, code_versions)
 
     def _compute() -> dict[str, RigorGateResult]:
         from archimedes.services.rigor_evaluator import (
@@ -395,7 +411,14 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
                 logger.warning("live rigor gate failed for %s in batch (numbers → stale fallback): %s", s.id, exc)
         return computed
 
-    return get_or_compute(cache_key, _compute)
+    # cache_if=lambda v: bool(v): `_compute()` returns `{}` on a transient
+    # cohort-context compute failure (see the `except Exception` above), and an
+    # empty dict must never be memoized — caching it would make that transient
+    # failure "sticky" for the full TTL, serving every strategy's stale
+    # fallback fields long after the underlying failure has passed (Copilot
+    # review, PR #1040). The live `{}` is still returned to THIS caller either
+    # way; only whether it's written to the store for the NEXT caller changes.
+    return get_or_compute(cache_key, _compute, cache_if=lambda v: bool(v))
 
 
 def _load_strategy_code_safe_local(strategy: Strategy) -> str | None:

--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -49,6 +49,26 @@ def insert_backtest_if_missing(
     )
     session.add(row)
     session.flush()
+
+    # Invalidate the live rigor-gate cache (#library-load-latency): a genuinely
+    # new backtest row means this strategy's persisted daily returns just
+    # changed, so any cached rigor-gate computation over the old cohort is now
+    # stale-in-waiting. rigor_cache.cohort_key already changes the moment the
+    # underlying returns change, which is what makes the cache safe even
+    # WITHOUT this call — this just tightens the window between "new backtest
+    # written" and "next Library read recomputes live" from up to the cache's
+    # TTL down to ~0. This is every writer path funneling through the single
+    # insert point (generation_pipeline.py, run_backtests.py,
+    # seed_backtests_from_artifacts.py all call insert_backtest_if_missing), so
+    # one hook here covers all of them. Best-effort: never let a cache-clear
+    # failure block a real backtest write from committing.
+    try:
+        from archimedes.services import rigor_cache
+
+        rigor_cache.clear()
+    except Exception as exc:
+        logger.warning("rigor_cache invalidation failed after new backtest row (non-fatal): %s", exc)
+
     return row, True
 
 

--- a/backend/archimedes/services/rigor_cache.py
+++ b/backend/archimedes/services/rigor_cache.py
@@ -46,8 +46,37 @@ logger = logging.getLogger(__name__)
 # path that doesn't call `clear()`) so a cached entry can never live forever.
 _TTL_SECONDS = 600.0
 
+# Hard backstop on memory growth (Copilot review, PR #1040). The TTL alone only
+# stops STALE entries from being SERVED — it does nothing to reclaim the memory
+# an expired/obsolete entry occupies, since nothing ever revisits a key once it
+# stops being requested. A frequently-changing key (e.g. a returns-rewrite path,
+# or a growing/rotating strategy set) can otherwise accumulate keys in `_store`
+# forever. Two backstops, both applied opportunistically on every cache WRITE
+# (never on the read/lookup path, so a cache hit stays O(1)):
+#   1. Prune every entry older than `_TTL_SECONDS` — cheap, and removes the
+#      overwhelming majority of garbage in the common case.
+#   2. Cap `_store` at `_MAX_STORE_SIZE` entries, evicting the OLDEST (by
+#      `stored_at`) first — a hard ceiling independent of the TTL, so even a
+#      pathological key-churn rate can't grow `_store` without bound.
+_MAX_STORE_SIZE = 256
+
 _lock = threading.Lock()
 _store: dict[str, tuple[float, Any]] = {}
+
+
+def _prune_expired_locked(now: float) -> None:
+    """Remove every entry older than ``_TTL_SECONDS``. Caller must hold ``_lock``."""
+    expired = [k for k, (stored_at, _value) in _store.items() if now - stored_at >= _TTL_SECONDS]
+    for k in expired:
+        del _store[k]
+
+
+def _evict_oldest_locked(max_size: int) -> None:
+    """Hard backstop: cap ``_store`` at ``max_size`` entries, evicting the
+    oldest (smallest ``stored_at``) first. Caller must hold ``_lock``."""
+    while len(_store) > max_size:
+        oldest_key = min(_store, key=lambda k: _store[k][0])
+        del _store[oldest_key]
 
 
 def _fingerprint(series: list[float]) -> bytes:
@@ -70,11 +99,16 @@ def _fingerprint(series: list[float]) -> bytes:
         return repr((len(series), series[0], series[-1])).encode("utf-8", errors="replace")
 
 
-def cohort_key(strategy_ids: list[str], returns_by_strategy: dict[str, list[float]]) -> str:
+def cohort_key(
+    strategy_ids: list[str],
+    returns_by_strategy: dict[str, list[float]],
+    code_versions: dict[str, str | None] | None = None,
+) -> str:
     """Stable data-version token for a rigor-gate cohort.
 
     Hashes ``sorted(strategy_ids)`` together with a fingerprint of each strategy's
-    persisted returns series, so the key is:
+    persisted returns series (and, when supplied, a code-version token per
+    strategy — see below), so the key is:
       - independent of dict/list ordering (ids are sorted before hashing), and
       - guaranteed to change the moment ANY strategy's returns change, are added,
         or are removed — the property that makes caching the downstream
@@ -84,19 +118,53 @@ def cohort_key(strategy_ids: list[str], returns_by_strategy: dict[str, list[floa
     (no persisted returns yet) still participate in the key via the empty-series
     fingerprint, so a strategy gaining its first persisted returns also changes
     the key.
+
+    ``code_versions`` (optional) maps each strategy id to a cheap code-version
+    token — the caller's ``Strategy.strategy_code_hash`` (a SHA-256 of the
+    strategy file contents, already computed and held in memory — no extra I/O
+    on the request path). This closes a real staleness gap (Copilot review, PR
+    #1040): the cached computation this key guards doesn't just read persisted
+    returns, it also runs the look-ahead code audit inside ``run_rigor_gate``
+    (``strategy_code=...``), so a key built from returns alone would keep
+    serving a stale look-ahead verdict / ``passes_all`` for up to the TTL after
+    a strategy's code changed, even though its returns didn't. Folding the code
+    hash in means a code edit changes the key exactly like a returns change
+    does. Omitted or ``None`` for an id is treated as ``""`` — i.e. an id with
+    no known code-version token doesn't perturb the key beyond that fixed
+    placeholder, matching the prior (returns-only) behavior for callers that
+    don't pass ``code_versions`` at all.
     """
     hasher = hashlib.sha256()
+    code_versions = code_versions or {}
     for sid in sorted(strategy_ids):
         hasher.update(sid.encode("utf-8"))
         hasher.update(b"\x00")
         hasher.update(_fingerprint(returns_by_strategy.get(sid) or []))
         hasher.update(b"\x01")
+        hasher.update((code_versions.get(sid) or "").encode("utf-8"))
+        hasher.update(b"\x02")
     return hasher.hexdigest()
 
 
-def get_or_compute(key: str, compute_fn: Callable[[], Any]) -> Any:
+def get_or_compute(
+    key: str,
+    compute_fn: Callable[[], Any],
+    cache_if: Callable[[Any], bool] = lambda _value: True,
+) -> Any:
     """Return the cached value for ``key`` if present and still fresh; else compute
-    it via ``compute_fn()``, cache it, and return it.
+    it via ``compute_fn()``, cache it (subject to ``cache_if``), and return it.
+
+    ``cache_if`` (optional, defaults to "always cache") is evaluated against the
+    freshly computed value before it's written to the store. Callers whose
+    ``compute_fn`` can legitimately return an empty/failure sentinel on a
+    transient error (e.g. ``{}`` on a DB or cohort-compute failure) should pass
+    ``cache_if=lambda v: bool(v)`` so that sentinel is never cached (Copilot
+    review, PR #1040) — caching it would make a transient failure "sticky" for
+    the full TTL, serving every caller a stale fallback long after the failure
+    that caused it has passed. The live, correct value is still returned either
+    way; ``cache_if`` only controls whether it's memoized for the NEXT caller.
+    A ``cache_if`` that itself raises is treated as "don't cache" (never as
+    "crash the request") — consistent with this module's fail-open contract.
 
     FAIL-OPEN: any exception raised while reading or writing the cache store itself
     is logged and swallowed — the function still calls ``compute_fn()`` and returns
@@ -119,10 +187,24 @@ def get_or_compute(key: str, compute_fn: Callable[[], Any]) -> Any:
     value = compute_fn()
 
     try:
-        with _lock:
-            _store[key] = (time.monotonic(), value)
-    except Exception as exc:  # pragma: no cover - defensive; cache store must never break the request
-        logger.warning("rigor_cache: store failed, serving live result anyway: %s", exc)
+        should_cache = cache_if(value)
+    except Exception as exc:
+        logger.warning("rigor_cache: cache_if predicate failed, not caching this result: %s", exc)
+        should_cache = False
+
+    if should_cache:
+        try:
+            with _lock:
+                store_time = time.monotonic()
+                # Opportunistic bound-keeping on every write (never on the read
+                # path, so a cache hit stays O(1)): first reclaim anything
+                # that's aged out, then enforce the hard size cap. See the
+                # `_MAX_STORE_SIZE` docstring above for why both are needed.
+                _prune_expired_locked(store_time)
+                _store[key] = (store_time, value)
+                _evict_oldest_locked(_MAX_STORE_SIZE)
+        except Exception as exc:  # pragma: no cover - defensive; cache store must never break the request
+            logger.warning("rigor_cache: store failed, serving live result anyway: %s", exc)
 
     return value
 

--- a/backend/archimedes/services/rigor_cache.py
+++ b/backend/archimedes/services/rigor_cache.py
@@ -1,0 +1,142 @@
+"""Process-level TTL cache for the (expensive but always-honest) live rigor gate.
+
+**Why this exists (perf):** ``GET /api/strategies/`` and ``GET /api/selection-bias/gate``
+each recompute the full rigor gate LIVE on every request — cohort PBO, average
+pairwise correlation, the look-ahead code audit, and one ``run_rigor_gate`` call per
+strategy. Measured cost: ~6s and ~8-10s respectively, and the Library page's
+``Promise.all`` blocks on the slower one. That is unacceptable page-load latency for a
+computation whose inputs (persisted daily returns) change only when a new backtest is
+written — i.e. rarely, compared to how often the page is loaded.
+
+**Why this is safe (correctness):** this module caches the REAL computed result, not a
+fake or precomputed one. The cache key (``cohort_key``) is a data-version token derived
+from the exact returns data the computation would read — the moment any strategy's
+persisted returns change, the key changes, and the next call recomputes live. Nothing
+here weakens a threshold, skips a check, or serves a stale number for changed data. It
+is pure memoization of an idempotent, deterministic function of its inputs.
+
+**Fail-open, always.** Any exception raised by the cache layer itself (lookup or store)
+is caught and the call falls back to ``compute_fn()`` — a live, correct result. A cache
+bug can only ever cost a slow request, never a wrong or crashed one.
+
+``cachetools`` is NOT currently a dependency (checked ``backend/requirements.txt`` and
+``environment.yml`` on 2026-07-06) — rather than add one for a single call site, this
+is a small hand-rolled dict-with-timestamps cache. If ``cachetools`` becomes a
+dependency for an unrelated reason later, ``_Store`` below can be swapped for
+``cachetools.TTLCache`` without changing the public API (``cohort_key`` /
+``get_or_compute`` / ``clear``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import struct
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Safety cap only. The cohort_key is the real invalidation mechanism — it changes
+# the instant underlying returns data changes, so in practice a cache entry is
+# almost always invalidated by a key change long before this TTL would matter. The
+# TTL exists purely as a backstop against any invalidation-hook gap (e.g. a writer
+# path that doesn't call `clear()`) so a cached entry can never live forever.
+_TTL_SECONDS = 600.0
+
+_lock = threading.Lock()
+_store: dict[str, tuple[float, Any]] = {}
+
+
+def _fingerprint(series: list[float]) -> bytes:
+    """Cheap, order-and-value-sensitive fingerprint of one strategy's return series.
+
+    Packed IEEE-754 doubles change on ANY element changing (not just length/sum),
+    so this is stronger than the ``(len, first, last, round(sum, 6))`` shorthand
+    the docstring elsewhere describes as a minimum bar — this does that one better
+    for about the same cost (struct.pack over a few hundred floats is microseconds,
+    negligible next to the rigor-gate computation it's guarding).
+    """
+    if not series:
+        return b"\x00empty"
+    try:
+        return struct.pack(f"{len(series)}d", *series)
+    except (struct.error, TypeError):
+        # Non-float-coercible input (shouldn't happen for persisted daily returns,
+        # but never let a fingerprint failure crash the caller) — falls back to a
+        # coarser summary that still changes whenever length/edges do.
+        return repr((len(series), series[0], series[-1])).encode("utf-8", errors="replace")
+
+
+def cohort_key(strategy_ids: list[str], returns_by_strategy: dict[str, list[float]]) -> str:
+    """Stable data-version token for a rigor-gate cohort.
+
+    Hashes ``sorted(strategy_ids)`` together with a fingerprint of each strategy's
+    persisted returns series, so the key is:
+      - independent of dict/list ordering (ids are sorted before hashing), and
+      - guaranteed to change the moment ANY strategy's returns change, are added,
+        or are removed — the property that makes caching the downstream
+        computation safe without an explicit invalidation call.
+
+    Strategies present in ``strategy_ids`` but absent from ``returns_by_strategy``
+    (no persisted returns yet) still participate in the key via the empty-series
+    fingerprint, so a strategy gaining its first persisted returns also changes
+    the key.
+    """
+    hasher = hashlib.sha256()
+    for sid in sorted(strategy_ids):
+        hasher.update(sid.encode("utf-8"))
+        hasher.update(b"\x00")
+        hasher.update(_fingerprint(returns_by_strategy.get(sid) or []))
+        hasher.update(b"\x01")
+    return hasher.hexdigest()
+
+
+def get_or_compute(key: str, compute_fn: Callable[[], Any]) -> Any:
+    """Return the cached value for ``key`` if present and still fresh; else compute
+    it via ``compute_fn()``, cache it, and return it.
+
+    FAIL-OPEN: any exception raised while reading or writing the cache store itself
+    is logged and swallowed — the function still calls ``compute_fn()`` and returns
+    its (real, correct) result. This function never suppresses an exception raised
+    BY ``compute_fn()`` itself — that is the caller's live computation failing, and
+    must propagate exactly as it would without a cache in front of it.
+    """
+    try:
+        now = time.monotonic()
+        with _lock:
+            entry = _store.get(key)
+        if entry is not None:
+            stored_at, value = entry
+            if now - stored_at < _TTL_SECONDS:
+                return value
+    except Exception as exc:  # pragma: no cover - defensive; cache lookup must never break the request
+        logger.warning("rigor_cache: lookup failed, falling back to live compute: %s", exc)
+        return compute_fn()
+
+    value = compute_fn()
+
+    try:
+        with _lock:
+            _store[key] = (time.monotonic(), value)
+    except Exception as exc:  # pragma: no cover - defensive; cache store must never break the request
+        logger.warning("rigor_cache: store failed, serving live result anyway: %s", exc)
+
+    return value
+
+
+def clear() -> None:
+    """Invalidate every cached rigor-gate result.
+
+    Call this wherever persisted daily-returns data is (re)written (e.g.
+    ``backtest_repository.insert_backtest_if_missing`` on a real insert) so a
+    request immediately after a new backtest is written never has to wait out the
+    TTL to see it. Not strictly required for correctness — ``cohort_key`` already
+    changes the moment the underlying returns change, which is what makes an
+    un-cleared cache still safe — this only tightens the window between "data
+    written" and "next read recomputes" from up to ``_TTL_SECONDS`` to ~0.
+    """
+    with _lock:
+        _store.clear()

--- a/backend/archimedes/services/rigor_cache.py
+++ b/backend/archimedes/services/rigor_cache.py
@@ -63,6 +63,12 @@ _MAX_STORE_SIZE = 256
 _lock = threading.Lock()
 _store: dict[str, tuple[float, Any]] = {}
 
+# Single-flight bookkeeping (Copilot review, PR #1040 — thundering herd fix).
+# Maps a key currently being computed by some caller to a threading.Event
+# that fires when that computation finishes. Guarded by `_lock` exactly like
+# `_store` — but never held across `compute_fn()` itself (see `get_or_compute`).
+_inflight: dict[str, threading.Event] = {}
+
 
 def _prune_expired_locked(now: float) -> None:
     """Remove every entry older than ``_TTL_SECONDS``. Caller must hold ``_lock``."""
@@ -175,6 +181,25 @@ def get_or_compute(
     its (real, correct) result. This function never suppresses an exception raised
     BY ``compute_fn()`` itself — that is the caller's live computation failing, and
     must propagate exactly as it would without a cache in front of it.
+
+    SINGLE-FLIGHT (Copilot review, PR #1040 — thundering herd): a cache MISS
+    previously released ``_lock`` before calling ``compute_fn()``, so N
+    concurrent misses for the SAME key each ran the (expensive) computation in
+    parallel. Now, only the first concurrent caller for a given key (the
+    "leader") actually calls ``compute_fn()``; every other concurrent caller
+    for that SAME key (a "follower") waits on a per-key ``threading.Event``
+    (registered in ``_inflight``, guarded by ``_lock`` exactly like ``_store``)
+    and then reads whatever the leader stored. ``compute_fn()`` itself is
+    NEVER called while holding ``_lock`` — an expensive computation must never
+    block other keys' cache reads/writes, and must never run underneath a lock
+    other threads are blocked on. A follower that wakes to find nothing usable
+    was stored (the leader's ``compute_fn`` raised, or its result failed
+    ``cache_if``) simply computes live itself — a follower must never hang or
+    fabricate a value. Any error in the single-flight bookkeeping itself
+    (registering/looking up/clearing an ``_inflight`` entry) falls back to
+    calling ``compute_fn()`` directly, and — critically — never leaves a
+    follower waiting forever: any Event this call created is always released
+    before that fallback returns.
     """
     try:
         now = time.monotonic()
@@ -188,7 +213,71 @@ def get_or_compute(
         logger.warning("rigor_cache: lookup failed, falling back to live compute: %s", exc)
         return compute_fn()
 
-    value = compute_fn()
+    # ── Single-flight: register as the leader for `key`, or discover we're a
+    # follower behind an already-in-flight computation for the same key. ──
+    event: threading.Event | None = None
+    is_leader = False
+    try:
+        with _lock:
+            existing = _inflight.get(key)
+            if existing is None:
+                event = threading.Event()
+                _inflight[key] = event
+                is_leader = True
+            else:
+                event = existing
+    except Exception as exc:  # pragma: no cover - defensive; bookkeeping must never break the request
+        logger.warning("rigor_cache: single-flight registration failed, falling back to live compute: %s", exc)
+        # Best-effort: if we created (and possibly stored) an Event before the
+        # failure, never strand a follower waiting on it forever.
+        if event is not None:
+            try:
+                with _lock:
+                    _inflight.pop(key, None)
+            except Exception:  # pragma: no cover - defensive, best-effort only
+                pass
+            event.set()
+        return compute_fn()
+
+    if not is_leader:
+        # A concurrent caller is already computing this exact key. Wait for
+        # it to finish (releasing NO lock while waiting — we never held one),
+        # then read whatever it stored. This is the dedup: N followers pay
+        # for one compute_fn() call, not N.
+        try:
+            event.wait()
+            with _lock:
+                entry = _store.get(key)
+            if entry is not None:
+                stored_at, value = entry
+                if time.monotonic() - stored_at < _TTL_SECONDS:
+                    return value
+        except Exception as exc:  # pragma: no cover - defensive; a follower must never hang or crash
+            logger.warning("rigor_cache: single-flight wait failed, falling back to live compute: %s", exc)
+        # The leader's result wasn't usable to us (it computed but `cache_if`
+        # said "don't cache", it raised, or re-reading `_store` itself
+        # raised) — fall back to computing live ourselves. Never suppresses
+        # anything: this is OUR OWN compute_fn() call, so if it raises, that
+        # exception propagates exactly as it would with no cache in front.
+        return compute_fn()
+
+    # ── Leader path: compute WITHOUT holding `_lock`. ──
+    try:
+        value = compute_fn()
+    except Exception:
+        # The LIVE computation itself failed — this is the leader's own
+        # exception, not a cache-layer bug, so it must propagate exactly as it
+        # would without single-flight in front of it (never suppressed). Still
+        # release any followers first so none of them hang forever on a
+        # leader that errored; each falls back to computing live itself.
+        try:
+            with _lock:
+                _inflight.pop(key, None)
+        except Exception as exc:  # pragma: no cover - defensive, best-effort only
+            logger.warning("rigor_cache: single-flight cleanup after a failed compute also failed: %s", exc)
+        finally:
+            event.set()
+        raise
 
     try:
         should_cache = cache_if(value)
@@ -209,6 +298,17 @@ def get_or_compute(
                 _evict_oldest_locked(_MAX_STORE_SIZE)
         except Exception as exc:  # pragma: no cover - defensive; cache store must never break the request
             logger.warning("rigor_cache: store failed, serving live result anyway: %s", exc)
+
+    # Release any followers waiting on this key — they'll read the entry we
+    # just (attempted to) store above, or fall back to their own live compute
+    # if `should_cache` was False / the store write itself failed.
+    try:
+        with _lock:
+            _inflight.pop(key, None)
+    except Exception as exc:  # pragma: no cover - defensive, best-effort only
+        logger.warning("rigor_cache: single-flight cleanup failed: %s", exc)
+    finally:
+        event.set()
 
     return value
 

--- a/backend/archimedes/services/rigor_cache.py
+++ b/backend/archimedes/services/rigor_cache.py
@@ -31,9 +31,9 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import struct
 import threading
 import time
+from array import array
 from collections.abc import Callable
 from typing import Any
 
@@ -91,8 +91,12 @@ def _fingerprint(series: list[float]) -> bytes:
     if not series:
         return b"\x00empty"
     try:
-        return struct.pack(f"{len(series)}d", *series)
-    except (struct.error, TypeError):
+        # array(...).tobytes() serializes the whole series without expanding it
+        # into positional args (struct.pack(fmt, *series) would materialize one
+        # arg per element — costly for large cohorts). Same order-and-value
+        # sensitivity, C-contiguous double bytes.
+        return array("d", series).tobytes()
+    except (TypeError, ValueError, OverflowError):
         # Non-float-coercible input (shouldn't happen for persisted daily returns,
         # but never let a fingerprint failure crash the caller) — falls back to a
         # coarser summary that still changes whenever length/edges do.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -71,3 +71,27 @@ def returns_matrix():
 def regime_shift_returns():
     """Factory fixture: (market, strategy) returns with a mid-series vol regime shift."""
     return quant_factories.make_regime_shift_returns
+
+
+@pytest.fixture(autouse=True)
+def _clear_rigor_cache():
+    """Reset the process-level live-rigor-gate cache (services/rigor_cache.py)
+    around every test.
+
+    That cache is a module-global dict keyed on a data-version token
+    (strategy ids + a fingerprint of their returns). Several test files reuse
+    the SAME real curated strategy ids (via the session-scoped ``provider`` /
+    ``default_provider()``) with the SAME synthetic returns fixtures across
+    different test functions — without this reset, a cache entry populated by
+    one test could be silently served to a later, unrelated test in the same
+    pytest process, making that test's assertions (e.g. call-count spies on
+    ``run_rigor_gate``) order-dependent on whatever ran before it. Clearing
+    before AND after keeps every test's view of the cache empty regardless of
+    suite order, matching the hermetic-test mandate (no hidden environmental
+    state leaking between tests).
+    """
+    from archimedes.services import rigor_cache
+
+    rigor_cache.clear()
+    yield
+    rigor_cache.clear()

--- a/backend/tests/test_rigor_cache.py
+++ b/backend/tests/test_rigor_cache.py
@@ -20,6 +20,9 @@ Hermetic gate:
 
 from __future__ import annotations
 
+import threading
+import time
+
 import numpy as np
 import pytest
 from archimedes.services import rigor_cache
@@ -51,10 +54,15 @@ def _use_tmp_db(tmp_path, monkeypatch):
 def _isolated_rigor_cache():
     """Every test gets a clean process-level cache — this module's cache is a
     module-global dict, so without this fixture, state (and the raise-on-access
-    monkeypatches used in the fail-open tests) would leak across tests."""
+    monkeypatches used in the fail-open tests) would leak across tests. Also
+    resets ``_inflight`` (the single-flight bookkeeping dict, Copilot review,
+    PR #1040) — ``rigor_cache.clear()`` deliberately does NOT touch it (see its
+    docstring), so it's reset here instead, purely for test isolation."""
     rigor_cache.clear()
+    rigor_cache._inflight.clear()
     yield
     rigor_cache.clear()
+    rigor_cache._inflight.clear()
 
 
 # A clean strategy snippet that passes the AST look-ahead audit (no future/peek
@@ -354,6 +362,147 @@ def test_live_rigor_results_survive_a_broken_cache(monkeypatch):
     assert result["s0"].passes_all == expected_s0.passes_all
     _assert_close(result["s1"].deflated_sharpe, expected_s1.deflated_sharpe)
     assert result["s1"].passes_all == expected_s1.passes_all
+
+
+# ── single-flight: thundering-herd fix (Copilot review, PR #1040) ──────────
+# ``get_or_compute`` previously released ``_lock`` before calling
+# ``compute_fn()``, so N concurrent misses for the SAME key each ran the
+# (expensive) live computation in parallel. Proven below: N threads racing on
+# one key invoke ``compute_fn`` exactly once; every other thread waits for
+# that call and reuses its result.
+
+
+def test_concurrent_misses_for_the_same_key_invoke_compute_fn_once():
+    """N concurrent get_or_compute MISSES for the SAME key must invoke
+    compute_fn exactly once. The lone caller who becomes the "leader" is held
+    inside compute_fn (via ``release``) until every other thread has had time
+    to reach the follower's wait state — this proves the dedup holds under
+    real contention, not just when the leader happens to finish instantly."""
+    n_threads = 8
+    call_count = {"n": 0}
+    call_lock = threading.Lock()
+    start_barrier = threading.Barrier(n_threads)
+    release = threading.Event()
+
+    def _slow_compute():
+        with call_lock:
+            call_count["n"] += 1
+        assert release.wait(timeout=5.0), "test setup: release was never signaled"
+        return "computed-value"
+
+    results: list[str | None] = [None] * n_threads
+    errors: list[BaseException] = []
+
+    def _worker(i):
+        start_barrier.wait(timeout=5.0)
+        try:
+            results[i] = rigor_cache.get_or_compute("single-flight-key", _slow_compute)
+        except BaseException as exc:  # noqa: BLE001 - surfaced via `errors`, not swallowed
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+
+    # Give every thread time to register as leader-or-follower (i.e. reach
+    # either compute_fn's release.wait() or the follower's event.wait())
+    # before letting the single compute_fn call complete.
+    time.sleep(0.2)
+    release.set()
+
+    for t in threads:
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "a worker thread never finished — likely a single-flight deadlock"
+
+    assert not errors, f"worker thread(s) raised: {errors}"
+    assert call_count["n"] == 1, (
+        f"compute_fn ran {call_count['n']} times for {n_threads} concurrent same-key misses — "
+        "single-flight failed to dedup the thundering herd"
+    )
+    assert results == ["computed-value"] * n_threads
+
+
+def test_single_flight_does_not_dedup_across_different_keys():
+    """Sanity companion: single-flight scopes to ONE key — concurrent misses
+    for DIFFERENT keys must each still invoke their own compute_fn (dedup must
+    never over-apply and merge unrelated computations)."""
+    n_threads = 4
+    calls: dict[str, int] = {f"key-{i}": 0 for i in range(n_threads)}
+    calls_lock = threading.Lock()
+    start_barrier = threading.Barrier(n_threads)
+
+    def _make_compute(key):
+        def _compute():
+            with calls_lock:
+                calls[key] += 1
+            return f"value-for-{key}"
+
+        return _compute
+
+    results: dict[str, str] = {}
+    results_lock = threading.Lock()
+
+    def _worker(key):
+        start_barrier.wait(timeout=5.0)
+        value = rigor_cache.get_or_compute(key, _make_compute(key))
+        with results_lock:
+            results[key] = value
+
+    threads = [threading.Thread(target=_worker, args=(f"key-{i}",)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert all(n == 1 for n in calls.values()), f"each distinct key must compute exactly once: {calls}"
+    assert results == {f"key-{i}": f"value-for-key-{i}" for i in range(n_threads)}
+
+
+def test_follower_falls_back_to_live_compute_when_leader_result_is_not_cached():
+    """A follower waking up to find the leader's result was NOT written to
+    `_store` (because `cache_if` rejected it) must fall back to computing
+    live itself — never hang, never fabricate a value, never wait forever."""
+    release = threading.Event()
+    leader_started = threading.Event()
+
+    def _leader_compute():
+        leader_started.set()
+        assert release.wait(timeout=5.0), "test setup: release was never signaled"
+        return {}  # falsy -> rejected by cache_if=bool, nothing gets stored
+
+    follower_result = {}
+
+    def _follower_compute():
+        return {"from": "follower-live-compute"}
+
+    def _leader_worker():
+        follower_result["leader"] = rigor_cache.get_or_compute("cache-if-key", _leader_compute, cache_if=bool)
+
+    def _follower_worker():
+        assert leader_started.wait(timeout=5.0), "leader never started"
+        # Give the leader a moment to actually register in `_inflight` (it does
+        # so before signaling `leader_started` via compute_fn, so this is a
+        # belt-and-suspenders wait, not load-bearing on its own).
+        time.sleep(0.05)
+        follower_result["follower"] = rigor_cache.get_or_compute("cache-if-key", _follower_compute, cache_if=bool)
+
+    t_leader = threading.Thread(target=_leader_worker)
+    t_follower = threading.Thread(target=_follower_worker)
+    t_leader.start()
+    t_follower.start()
+
+    # Let the follower reach event.wait() before releasing the leader.
+    time.sleep(0.2)
+    release.set()
+
+    t_leader.join(timeout=5.0)
+    t_follower.join(timeout=5.0)
+    assert not t_leader.is_alive()
+    assert not t_follower.is_alive()
+
+    assert follower_result["leader"] == {}
+    assert follower_result["follower"] == {"from": "follower-live-compute"}
+    assert "cache-if-key" not in rigor_cache._store
 
 
 # ── cache_if: a transient failure result must never get "sticky" ───────────

--- a/backend/tests/test_rigor_cache.py
+++ b/backend/tests/test_rigor_cache.py
@@ -374,13 +374,13 @@ def test_get_or_compute_cache_if_false_does_not_cache_the_result():
         calls["n"] += 1
         return {}  # falsy — the failure-sentinel shape this predicate guards against
 
-    result = rigor_cache.get_or_compute("k-cache-if", _compute, cache_if=lambda v: bool(v))
+    result = rigor_cache.get_or_compute("k-cache-if", _compute, cache_if=bool)
     assert result == {}
     assert calls["n"] == 1
     assert "k-cache-if" not in rigor_cache._store, "a falsy result must never be written to the store"
 
     # Second call: still a miss (nothing was cached), so compute_fn runs again.
-    rigor_cache.get_or_compute("k-cache-if", _compute, cache_if=lambda v: bool(v))
+    rigor_cache.get_or_compute("k-cache-if", _compute, cache_if=bool)
     assert calls["n"] == 2, "an un-cached falsy result must force recompute on the next call"
 
 
@@ -394,8 +394,8 @@ def test_get_or_compute_cache_if_true_caches_normally():
         calls["n"] += 1
         return {"strategy": "real result"}
 
-    first = rigor_cache.get_or_compute("k-cache-if-true", _compute, cache_if=lambda v: bool(v))
-    second = rigor_cache.get_or_compute("k-cache-if-true", _compute, cache_if=lambda v: bool(v))
+    first = rigor_cache.get_or_compute("k-cache-if-true", _compute, cache_if=bool)
+    second = rigor_cache.get_or_compute("k-cache-if-true", _compute, cache_if=bool)
     assert first == second == {"strategy": "real result"}
     assert calls["n"] == 1, "a truthy result under cache_if must still be cached (second call is a hit)"
 

--- a/backend/tests/test_rigor_cache.py
+++ b/backend/tests/test_rigor_cache.py
@@ -1,0 +1,313 @@
+"""Tests for services.rigor_cache — the honest, data-version-keyed TTL cache that
+fixes the slow Library page load (``GET /api/strategies/`` ~6s, ``GET
+/api/selection-bias/gate`` ~8-10s, both from recomputing the live rigor gate on
+every request).
+
+Three properties must hold, proven below:
+  (a) Two consecutive calls with UNCHANGED persisted data return IDENTICAL results
+      and ``run_rigor_gate`` runs only ONCE per strategy (the second call is a
+      cache hit) — the cache never re-does work it doesn't need to.
+  (b) Changing a strategy's persisted returns changes the cache key, so
+      ``run_rigor_gate`` runs again and the served numbers reflect the new data —
+      the cache never serves a stale number for changed data.
+  (c) A cache-layer error (the cache itself, not the live computation) falls back
+      to live compute — the cache can only make a request slow, never wrong.
+
+Hermetic gate:
+  env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \\
+      backend/tests/test_rigor_cache.py -q
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from archimedes.services import rigor_cache
+from archimedes.services.rigor_evaluator import (
+    compute_average_pairwise_correlation,
+    compute_pbo,
+    run_rigor_gate,
+)
+
+# ── Hermetic DB fixture (same pattern as test_strategies_routes.py) ────────
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Redirect DATABASE_URL to a per-test temp SQLite file.
+
+    ``_live_rigor_results_for_strategies`` calls ``init_db()`` before the (here
+    monkeypatched) DB read, so a real, isolated DB backs every test.
+    """
+    from archimedes.db import init_db
+
+    db_path = tmp_path / "test_rigor_cache.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_rigor_cache():
+    """Every test gets a clean process-level cache — this module's cache is a
+    module-global dict, so without this fixture, state (and the raise-on-access
+    monkeypatches used in the fail-open tests) would leak across tests."""
+    rigor_cache.clear()
+    yield
+    rigor_cache.clear()
+
+
+# A clean strategy snippet that passes the AST look-ahead audit (no future/peek
+# access) — same fixture literal test_strategies_routes.py uses.
+_CLEAN_CODE = "def init(self):\n    self.sma = 0\n"
+
+
+def _series(seed: int, n: int = 300) -> list[float]:
+    return np.random.default_rng(seed).normal(0.0015, 0.004, n).tolist()
+
+
+class _FakeStrategy:
+    """Minimal duck-typed stand-in for ``models.strategy.Strategy`` — only the
+    attributes ``_live_rigor_results_for_strategies`` / ``_load_strategy_code_safe_local``
+    actually touch."""
+
+    def __init__(self, id_: str, paper_claimed_sharpe: float | None = None):
+        self.id = id_
+        self.paper_claimed_sharpe = paper_claimed_sharpe
+        self.strategy_code_path = None  # None -> _load_strategy_code_safe_local short-circuits, no file I/O
+
+
+def _spy_run_rigor_gate(monkeypatch, calls: list):
+    """Patch archimedes.services.rigor_evaluator.run_rigor_gate with a counting
+    wrapper that still delegates to the real implementation — same technique
+    test_strategies_routes.py::TestDefaultNumTrials uses. The batch compute
+    closure in strategies_routes imports run_rigor_gate locally (function-local
+    import), so patching the source module's attribute is what makes this work:
+    the local import re-reads the module namespace on every call.
+    """
+
+    def _spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return run_rigor_gate(*args, **kwargs)
+
+    monkeypatch.setattr("archimedes.services.rigor_evaluator.run_rigor_gate", _spy)
+
+
+def _assert_close(actual, expected) -> None:
+    """``pytest.approx`` chokes on ``None`` — both metrics can legitimately be
+    ``None`` (e.g. an OOS Sharpe the gate could not compute), so compare those
+    cases with plain equality and everything else with a NaN-tolerant approx."""
+    if expected is None or actual is None:
+        assert actual == expected
+    else:
+        assert actual == pytest.approx(expected, nan_ok=True)
+
+
+def _expected_result(sid: str, returns_by_strategy: dict[str, list[float]]):
+    """Independently reproduce what the (uncached) live gate should compute for
+    ``sid`` given ``returns_by_strategy`` — the same cohort-context derivation
+    ``_live_rigor_results_for_strategies`` performs, used to assert the cache
+    never changes the served numbers."""
+    valid = {k: v for k, v in returns_by_strategy.items() if len(v) >= 10 and float(np.ptp(np.asarray(v))) > 0.0}
+    pbo_scores = compute_pbo(valid) if len(valid) >= 2 else {}
+    num_trials = max(len(valid), 1)
+    avg_corr = compute_average_pairwise_correlation(valid) if len(valid) >= 2 else 0.0
+    return run_rigor_gate(
+        strategy_id=sid,
+        daily_returns=returns_by_strategy[sid],
+        num_trials=num_trials,
+        pbo_scores=pbo_scores,
+        strategy_code=_CLEAN_CODE,
+        in_sample_sharpe=None,
+        average_correlation=avg_corr,
+    )
+
+
+# ── (a) unchanged data -> cache hit, identical results, one live call each ──
+
+
+def test_second_call_with_unchanged_data_is_a_cache_hit(monkeypatch):
+    from archimedes.api import strategies_routes as sr
+
+    returns = {"s0": _series(0), "s1": _series(1)}
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    monkeypatch.setattr(sr, "_load_strategy_code_safe_local", lambda s: _CLEAN_CODE)
+
+    calls: list = []
+    _spy_run_rigor_gate(monkeypatch, calls)
+
+    strategies = [_FakeStrategy("s0"), _FakeStrategy("s1")]
+
+    first = sr._live_rigor_results_for_strategies(strategies)
+    assert len(calls) == 2, "first call must run the live gate once per strategy"
+
+    second = sr._live_rigor_results_for_strategies(strategies)
+    assert len(calls) == 2, "second call with unchanged data must be a pure cache hit — no new run_rigor_gate calls"
+
+    assert set(first) == set(second) == {"s0", "s1"}
+    for sid in first:
+        assert second[sid] is first[sid], f"cache hit for {sid} should return the SAME cached object"
+        assert second[sid].deflated_sharpe == first[sid].deflated_sharpe
+        assert second[sid].pbo_score == first[sid].pbo_score
+        assert second[sid].oos_sharpe == first[sid].oos_sharpe
+        assert second[sid].passes_all == first[sid].passes_all
+
+
+# ── (b) changed returns -> different key -> live gate runs again ───────────
+
+
+def test_changed_returns_invalidate_the_cache_and_recompute(monkeypatch):
+    from archimedes.api import strategies_routes as sr
+
+    returns = {"s0": _series(0), "s1": _series(1)}
+    get_all = {"value": dict(returns)}
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(get_all["value"]),
+    )
+    monkeypatch.setattr(sr, "_load_strategy_code_safe_local", lambda s: _CLEAN_CODE)
+
+    calls: list = []
+    _spy_run_rigor_gate(monkeypatch, calls)
+
+    strategies = [_FakeStrategy("s0"), _FakeStrategy("s1")]
+
+    first = sr._live_rigor_results_for_strategies(strategies)
+    assert len(calls) == 2
+
+    # s0's persisted returns change (e.g. a fresh backtest was written) — a
+    # DIFFERENT series than the one the first call was keyed on.
+    new_returns = {"s0": _series(123), "s1": _series(1)}
+    get_all["value"] = new_returns
+
+    second = sr._live_rigor_results_for_strategies(strategies)
+    assert len(calls) == 4, "changed cohort data must bust the cache key -> the live gate reruns for both strategies"
+
+    expected_s0 = _expected_result("s0", new_returns)
+    _assert_close(second["s0"].deflated_sharpe, expected_s0.deflated_sharpe)
+    _assert_close(second["s0"].oos_sharpe, expected_s0.oos_sharpe)
+    assert second["s0"].passes_all == expected_s0.passes_all
+
+    # s1's series is unchanged, but it still shares a cohort with s0 (its cache
+    # key includes both strategies' fingerprints), so it recomputes too — and
+    # must still reflect the SAME live numbers as before, since ITS data didn't
+    # change (only the pbo/correlation cohort context could shift with s0's new
+    # series, so we recompute the "expected" for s1 with the new cohort too).
+    expected_s1 = _expected_result("s1", new_returns)
+    _assert_close(second["s1"].deflated_sharpe, expected_s1.deflated_sharpe)
+
+    # And critically: results actually differ from the first call's stale cache
+    # entry (proving this isn't accidentally still serving the old value).
+    assert (
+        first["s0"].deflated_sharpe != second["s0"].deflated_sharpe
+        or first["s0"].oos_sharpe != second["s0"].oos_sharpe
+        or first["s0"].pbo_score != second["s0"].pbo_score
+    ), "second call must reflect the new data, not the first call's cached result"
+
+
+# ── (c) cache-layer error -> fail open to live compute ──────────────────────
+
+
+class _BoomOnGet(dict):
+    """A dict-like whose ``.get`` raises — simulates a cache-layer bug (e.g. a
+    corrupted store, a serialization error) independent of the live computation."""
+
+    def get(self, *args, **kwargs):
+        raise RuntimeError("simulated cache-layer failure")
+
+
+def test_get_or_compute_fails_open_on_lookup_error(monkeypatch):
+    """Pure unit-level proof: if reading the cache store raises, get_or_compute
+    still calls compute_fn and returns its (real, correct) result — never raises,
+    never serves a stale/fabricated value."""
+    monkeypatch.setattr(rigor_cache, "_store", _BoomOnGet())
+
+    sentinel = object()
+    calls = {"n": 0}
+
+    def _compute():
+        calls["n"] += 1
+        return sentinel
+
+    result = rigor_cache.get_or_compute("some-key", _compute)
+    assert result is sentinel
+    assert calls["n"] == 1
+
+
+def test_get_or_compute_fails_open_on_store_error(monkeypatch):
+    """Same fail-open guarantee when WRITING to the cache raises (e.g. the
+    store rejects the value) — compute_fn's result must still be returned."""
+
+    class _BoomOnSet(dict):
+        def __setitem__(self, key, value):
+            raise RuntimeError("simulated cache write failure")
+
+    monkeypatch.setattr(rigor_cache, "_store", _BoomOnSet())
+
+    sentinel = object()
+    result = rigor_cache.get_or_compute("some-key", lambda: sentinel)
+    assert result is sentinel
+
+
+def test_live_rigor_results_survive_a_broken_cache(monkeypatch):
+    """Route-level proof of the same guarantee: with the cache store patched to
+    raise on lookup, ``_live_rigor_results_for_strategies`` must still return the
+    exact same numbers a healthy cache would have — the cache is fully
+    bypassable without breaking or staling the served rigor numbers."""
+    from archimedes.api import strategies_routes as sr
+
+    returns = {"s0": _series(0), "s1": _series(1)}
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    monkeypatch.setattr(sr, "_load_strategy_code_safe_local", lambda s: _CLEAN_CODE)
+    monkeypatch.setattr(rigor_cache, "_store", _BoomOnGet())
+
+    strategies = [_FakeStrategy("s0"), _FakeStrategy("s1")]
+    result = sr._live_rigor_results_for_strategies(strategies)
+
+    expected_s0 = _expected_result("s0", returns)
+    expected_s1 = _expected_result("s1", returns)
+    _assert_close(result["s0"].deflated_sharpe, expected_s0.deflated_sharpe)
+    assert result["s0"].passes_all == expected_s0.passes_all
+    _assert_close(result["s1"].deflated_sharpe, expected_s1.deflated_sharpe)
+    assert result["s1"].passes_all == expected_s1.passes_all
+
+
+# ── cohort_key unit properties ──────────────────────────────────────────────
+
+
+def test_cohort_key_stable_for_identical_input():
+    returns = {"a": _series(1), "b": _series(2)}
+    k1 = rigor_cache.cohort_key(["a", "b"], returns)
+    k2 = rigor_cache.cohort_key(["b", "a"], dict(returns))  # order-independent
+    assert k1 == k2
+
+
+def test_cohort_key_changes_when_any_series_changes():
+    returns = {"a": _series(1), "b": _series(2)}
+    k1 = rigor_cache.cohort_key(["a", "b"], returns)
+
+    mutated = dict(returns)
+    mutated["a"] = _series(1)[:-1] + [0.999]  # tweak one strategy's series
+    k2 = rigor_cache.cohort_key(["a", "b"], mutated)
+    assert k1 != k2
+
+
+def test_cohort_key_changes_when_a_strategy_is_added_or_removed():
+    returns = {"a": _series(1)}
+    k1 = rigor_cache.cohort_key(["a"], returns)
+    k2 = rigor_cache.cohort_key(["a", "b"], {**returns, "b": _series(2)})
+    assert k1 != k2
+
+
+def test_clear_removes_all_entries():
+    rigor_cache.get_or_compute("k1", lambda: 1)
+    rigor_cache.get_or_compute("k2", lambda: 2)
+    assert rigor_cache._store  # sanity: something is cached
+    rigor_cache.clear()
+    assert rigor_cache._store == {}

--- a/backend/tests/test_rigor_cache.py
+++ b/backend/tests/test_rigor_cache.py
@@ -71,10 +71,11 @@ class _FakeStrategy:
     attributes ``_live_rigor_results_for_strategies`` / ``_load_strategy_code_safe_local``
     actually touch."""
 
-    def __init__(self, id_: str, paper_claimed_sharpe: float | None = None):
+    def __init__(self, id_: str, paper_claimed_sharpe: float | None = None, strategy_code_hash: str | None = None):
         self.id = id_
         self.paper_claimed_sharpe = paper_claimed_sharpe
         self.strategy_code_path = None  # None -> _load_strategy_code_safe_local short-circuits, no file I/O
+        self.strategy_code_hash = strategy_code_hash  # cheap code-version token folded into cohort_key
 
 
 def _spy_run_rigor_gate(monkeypatch, calls: list):
@@ -208,6 +209,83 @@ def test_changed_returns_invalidate_the_cache_and_recompute(monkeypatch):
     ), "second call must reflect the new data, not the first call's cached result"
 
 
+# ── (d) code change with UNCHANGED returns -> different key -> live gate reruns
+# (Copilot review, PR #1040): cohort_key previously fingerprinted only persisted
+# returns, but run_rigor_gate's look-ahead audit also depends on strategy_code —
+# so editing a strategy's code and reloading served a STALE cached look-ahead
+# verdict/passes_all for up to the TTL even though returns never changed. Proven
+# below at both the cohort_key unit level and the route level. ─────────────────
+
+
+def test_code_hash_change_with_unchanged_returns_busts_cache_and_recomputes(monkeypatch):
+    """Route-level proof: only strategy_code_hash changes between the two calls
+    (persisted returns are byte-identical) — this alone must bust the cache key
+    and rerun run_rigor_gate, closing the stale-look-ahead-verdict gap."""
+    from archimedes.api import strategies_routes as sr
+
+    returns = {"s0": _series(0), "s1": _series(1)}
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    monkeypatch.setattr(sr, "_load_strategy_code_safe_local", lambda s: _CLEAN_CODE)
+
+    calls: list = []
+    _spy_run_rigor_gate(monkeypatch, calls)
+
+    strategies = [_FakeStrategy("s0", strategy_code_hash="hash-v1"), _FakeStrategy("s1", strategy_code_hash="hash-v1")]
+
+    first = sr._live_rigor_results_for_strategies(strategies)
+    assert len(calls) == 2
+
+    # Same object, same returns — pure cache hit.
+    second = sr._live_rigor_results_for_strategies(strategies)
+    assert len(calls) == 2, "unchanged returns AND unchanged code must still be a cache hit"
+    for sid in first:
+        assert second[sid] is first[sid]
+
+    # Simulate a code edit on s0 ONLY — its persisted returns are untouched.
+    strategies[0].strategy_code_hash = "hash-v2-edited"
+
+    third = sr._live_rigor_results_for_strategies(strategies)
+    assert len(calls) == 4, (
+        "a strategy's code_hash changing (with byte-identical returns) must bust "
+        "the cache key and rerun run_rigor_gate for the whole cohort — a code "
+        "edit must never keep serving the pre-edit look-ahead verdict"
+    )
+    assert set(third) == {"s0", "s1"}
+
+
+def test_cohort_key_changes_when_a_code_version_changes_but_returns_do_not():
+    """Pure unit-level proof, isolated from run_rigor_gate/DB entirely: two
+    cohort_key calls with byte-identical strategy_ids + returns_by_strategy but
+    a different code_versions entry for one strategy must produce different
+    keys."""
+    returns = {"a": _series(1), "b": _series(2)}
+
+    k1 = rigor_cache.cohort_key(["a", "b"], returns, {"a": "hash-v1", "b": "hash-v1"})
+    k2 = rigor_cache.cohort_key(["a", "b"], returns, {"a": "hash-v2", "b": "hash-v1"})
+    assert k1 != k2, "changing ONE strategy's code_versions token must change the key"
+
+    # Sanity: re-supplying the ORIGINAL code_versions reproduces the original key
+    # (proves the difference above was solely due to the code_versions delta).
+    k1_again = rigor_cache.cohort_key(["a", "b"], returns, {"a": "hash-v1", "b": "hash-v1"})
+    assert k1 == k1_again
+
+
+def test_cohort_key_omitting_code_versions_matches_empty_code_versions():
+    """Backward compatibility: a caller that omits code_versions entirely (the
+    pre-#1040 call shape, still used by any caller that hasn't been updated)
+    must produce the same key as one that explicitly passes an all-empty-string
+    code_versions map — so existing callers aren't silently broken by the new
+    optional parameter."""
+    returns = {"a": _series(1), "b": _series(2)}
+    k_omitted = rigor_cache.cohort_key(["a", "b"], returns)
+    k_explicit_empty = rigor_cache.cohort_key(["a", "b"], returns, {"a": "", "b": ""})
+    k_none_values = rigor_cache.cohort_key(["a", "b"], returns, {"a": None, "b": None})
+    assert k_omitted == k_explicit_empty == k_none_values
+
+
 # ── (c) cache-layer error -> fail open to live compute ──────────────────────
 
 
@@ -278,6 +356,111 @@ def test_live_rigor_results_survive_a_broken_cache(monkeypatch):
     assert result["s1"].passes_all == expected_s1.passes_all
 
 
+# ── cache_if: a transient failure result must never get "sticky" ───────────
+# (Copilot review, PR #1040): ``_compute()`` returns ``{}`` on a transient
+# cohort-context compute failure, and an un-guarded get_or_compute would cache
+# that ``{}`` — every strategy then falls back to stale fields for the FULL
+# TTL, even though the very next request would have succeeded live. Proven
+# below at both the pure get_or_compute unit level and the route level.
+
+
+def test_get_or_compute_cache_if_false_does_not_cache_the_result():
+    """Pure unit-level proof: when cache_if(value) is False, get_or_compute
+    still returns the live value but does NOT write it to the store — the next
+    call recomputes rather than replaying the un-cached (e.g. failure) value."""
+    calls = {"n": 0}
+
+    def _compute():
+        calls["n"] += 1
+        return {}  # falsy — the failure-sentinel shape this predicate guards against
+
+    result = rigor_cache.get_or_compute("k-cache-if", _compute, cache_if=lambda v: bool(v))
+    assert result == {}
+    assert calls["n"] == 1
+    assert "k-cache-if" not in rigor_cache._store, "a falsy result must never be written to the store"
+
+    # Second call: still a miss (nothing was cached), so compute_fn runs again.
+    rigor_cache.get_or_compute("k-cache-if", _compute, cache_if=lambda v: bool(v))
+    assert calls["n"] == 2, "an un-cached falsy result must force recompute on the next call"
+
+
+def test_get_or_compute_cache_if_true_caches_normally():
+    """Sanity companion: a truthy result under the same predicate IS cached and
+    the second call is a pure hit — cache_if doesn't disable caching outright,
+    only for values that fail the predicate."""
+    calls = {"n": 0}
+
+    def _compute():
+        calls["n"] += 1
+        return {"strategy": "real result"}
+
+    first = rigor_cache.get_or_compute("k-cache-if-true", _compute, cache_if=lambda v: bool(v))
+    second = rigor_cache.get_or_compute("k-cache-if-true", _compute, cache_if=lambda v: bool(v))
+    assert first == second == {"strategy": "real result"}
+    assert calls["n"] == 1, "a truthy result under cache_if must still be cached (second call is a hit)"
+
+
+def test_get_or_compute_cache_if_predicate_error_falls_back_to_not_caching():
+    """A cache_if predicate that itself raises must never crash the request —
+    consistent with this module's fail-open contract, the safe default on any
+    doubt is "don't cache" (never "crash" or "cache blindly")."""
+
+    def _boom_predicate(_value):
+        raise RuntimeError("simulated predicate bug")
+
+    sentinel = object()
+    result = rigor_cache.get_or_compute("k-cache-if-boom", lambda: sentinel, cache_if=_boom_predicate)
+    assert result is sentinel
+    assert "k-cache-if-boom" not in rigor_cache._store
+
+
+def test_transient_cohort_failure_is_not_sticky_across_calls(monkeypatch):
+    """Route-level proof of the concrete bug this closes: the FIRST call's
+    cohort-context compute fails (-> {} degraded response, per the existing
+    fail-closed contract), and the SECOND call — even with the exact same
+    cache key (unchanged returns/code) — must recompute live and return the
+    real result, not replay the cached {} from the failed first call."""
+    from archimedes.api import strategies_routes as sr
+
+    returns = {"s0": _series(0), "s1": _series(1)}
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+    monkeypatch.setattr(sr, "_load_strategy_code_safe_local", lambda s: _CLEAN_CODE)
+
+    strategies = [_FakeStrategy("s0"), _FakeStrategy("s1")]
+
+    # First call: force the cohort-context compute (PBO) to blow up on ITS
+    # FIRST invocation only, simulating a transient failure (e.g. a momentary
+    # numerical/DB hiccup) that has cleared by the time the next request lands.
+    from archimedes.services.rigor_evaluator import compute_pbo as _real_compute_pbo
+
+    pbo_call_count = {"n": 0}
+
+    def _flaky_pbo(*args, **kwargs):
+        pbo_call_count["n"] += 1
+        if pbo_call_count["n"] == 1:
+            raise RuntimeError("simulated transient cohort-compute failure")
+        return _real_compute_pbo(*args, **kwargs)
+
+    monkeypatch.setattr("archimedes.services.rigor_evaluator.compute_pbo", _flaky_pbo)
+
+    first = sr._live_rigor_results_for_strategies(strategies)
+    assert first == {}, "a cohort-compute failure must degrade to {} (existing fail-closed contract)"
+
+    # Second call: same cache key as the first (unchanged returns AND code) —
+    # the transient failure has cleared, so this must recompute live and NOT
+    # replay the cached {} from the failed first call.
+    second = sr._live_rigor_results_for_strategies(strategies)
+    assert second != {}, (
+        "the {} from the first (failed) call must never have been cached — a "
+        "transient failure must not strand every strategy on stale fallback "
+        "fields for the full TTL"
+    )
+    assert set(second) == {"s0", "s1"}
+
+
 # ── cohort_key unit properties ──────────────────────────────────────────────
 
 
@@ -311,3 +494,77 @@ def test_clear_removes_all_entries():
     assert rigor_cache._store  # sanity: something is cached
     rigor_cache.clear()
     assert rigor_cache._store == {}
+
+
+# ── unbounded-store backstop (Copilot review, PR #1040) ─────────────────────
+# The TTL only stops STALE entries from being SERVED — nothing previously
+# reclaimed the memory an expired/obsolete key occupied, so a frequently-
+# changing key (a returns-rewrite path, a growing/rotating strategy set) could
+# grow `_store` without bound despite the TTL. Two independent backstops, both
+# proven below: (1) opportunistic pruning of expired entries on every write,
+# and (2) a hard `_MAX_STORE_SIZE` cap, oldest-evicted-first, as a ceiling that
+# doesn't depend on anything ever expiring.
+
+
+def test_store_stays_bounded_across_many_distinct_keys():
+    """The store must never exceed `_MAX_STORE_SIZE` entries even when many
+    more distinct keys than that are written across the cache's lifetime —
+    proving the hard cap backstop actually bounds memory, not just the TTL."""
+    n_keys = rigor_cache._MAX_STORE_SIZE * 3
+    for i in range(n_keys):
+        rigor_cache.get_or_compute(f"bounded-key-{i}", lambda i=i: i)
+
+    assert len(rigor_cache._store) <= rigor_cache._MAX_STORE_SIZE, (
+        f"_store grew to {len(rigor_cache._store)} entries across {n_keys} distinct "
+        f"keys — the hard cap of {rigor_cache._MAX_STORE_SIZE} was not enforced"
+    )
+
+
+def test_store_cap_evicts_oldest_entries_first():
+    """The hard-cap eviction removes the OLDEST entries (by stored_at), not an
+    arbitrary subset — so the most-recently-written keys survive."""
+    max_size = rigor_cache._MAX_STORE_SIZE
+    for i in range(max_size + 10):
+        rigor_cache.get_or_compute(f"evict-order-{i}", lambda i=i: i)
+
+    # The 10 oldest keys (0..9) must have been evicted; the most recent
+    # max_size keys (10..max_size+9) must all still be present.
+    for i in range(10):
+        assert f"evict-order-{i}" not in rigor_cache._store, f"oldest key evict-order-{i} should have been evicted"
+    for i in range(10, max_size + 10):
+        assert f"evict-order-{i}" in rigor_cache._store, f"recent key evict-order-{i} should still be cached"
+
+
+def test_prune_expired_locked_removes_only_entries_past_ttl(monkeypatch):
+    """Unit-level proof of the opportunistic-pruning half of the backstop:
+    entries older than `_TTL_SECONDS` are removed by `_prune_expired_locked`;
+    fresh entries are left alone."""
+    now = 10_000.0
+    rigor_cache._store["fresh"] = (now - 1.0, "fresh-value")
+    rigor_cache._store["stale"] = (now - rigor_cache._TTL_SECONDS - 1.0, "stale-value")
+
+    rigor_cache._prune_expired_locked(now)
+
+    assert "fresh" in rigor_cache._store
+    assert "stale" not in rigor_cache._store
+
+
+def test_pruning_reclaims_expired_entries_on_the_next_write(monkeypatch):
+    """Route-adjacent proof: an entry that has aged past the TTL is reclaimed
+    the next time get_or_compute WRITES (not merely skipped on read) — i.e. the
+    prune actually runs as part of the normal get_or_compute write path, not
+    just as an isolated helper."""
+    fake_now = {"t": 0.0}
+    monkeypatch.setattr(rigor_cache.time, "monotonic", lambda: fake_now["t"])
+
+    rigor_cache.get_or_compute("old-entry", lambda: "v1")
+    assert "old-entry" in rigor_cache._store
+
+    # Advance time past the TTL, then write a DIFFERENT key — the opportunistic
+    # prune on that write must reclaim "old-entry" even though nothing ever
+    # looked it up again.
+    fake_now["t"] = rigor_cache._TTL_SECONDS + 1.0
+    rigor_cache.get_or_compute("new-entry", lambda: "v2")
+
+    assert "old-entry" not in rigor_cache._store, "expired entry must be reclaimed on the next cache write"
+    assert "new-entry" in rigor_cache._store

--- a/backend/tests/test_rigor_cache.py
+++ b/backend/tests/test_rigor_cache.py
@@ -391,13 +391,13 @@ def test_concurrent_misses_for_the_same_key_invoke_compute_fn_once():
         return "computed-value"
 
     results: list[str | None] = [None] * n_threads
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def _worker(i):
         start_barrier.wait(timeout=5.0)
         try:
             results[i] = rigor_cache.get_or_compute("single-flight-key", _slow_compute)
-        except BaseException as exc:  # noqa: BLE001 - surfaced via `errors`, not swallowed
+        except Exception as exc:  # noqa: BLE001 - surfaced via `errors`, not swallowed
             errors.append(exc)
 
     threads = [threading.Thread(target=_worker, args=(i,)) for i in range(n_threads)]

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -800,6 +800,61 @@ async def test_library_pbo_does_not_change_verdict_or_pbo_score(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_library_pbo_stays_consistent_between_top_level_and_per_strategy_on_cache_hit(monkeypatch):
+    """Regression test (Copilot review, PR #1040): ``get_or_compute`` may return a
+    CACHED list of ``StrategyRigorResult`` objects whose ``library_pbo`` reflects
+    an earlier request, while the top-level ``library_pbo`` on the response is
+    always freshly computed via ``_library_pbo_payload()``. Without reconciling
+    the two, a cache HIT could serve an internally inconsistent response
+    (top-level != some per-strategy ``library_pbo``). Call the gate endpoint
+    twice with the SAME underlying returns/code (so the rigor_cache
+    ``cohort_key`` is identical -> the second call is guaranteed to be a cache
+    hit) but a DIFFERENT ``_library_pbo_payload`` mock each time, and assert
+    every per-strategy ``library_pbo`` always matches the top-level one — on
+    both the cache-priming call and the cache-hit call."""
+    from archimedes.api import selection_bias_routes as routes
+    from archimedes.main import app
+
+    async def _run_once():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            return (await client.get("/api/selection-bias/gate")).json()
+
+    def _assert_internally_consistent(data):
+        top = data["library_pbo"]
+        for strat in data["strategies"]:
+            assert strat["library_pbo"] == top, (
+                f"strategy {strat['strategy_id']}'s library_pbo {strat['library_pbo']} "
+                f"disagrees with the top-level library_pbo {top}"
+            )
+
+    # Call A: primes the rigor_cache (this cohort has not been computed yet in
+    # this test) with library_pbo forced to a concrete value.
+    monkeypatch.setattr(
+        routes,
+        "_library_pbo_payload",
+        lambda: routes.LibraryPbo(value=0.42, data_vintage="2026-06-11", selection_set_size=22),
+    )
+    data_a = await _run_once()
+    _assert_internally_consistent(data_a)
+
+    # Call B: SAME underlying returns/code (nothing else changed) -> the exact
+    # same rigor_cache cohort_key -> `results` from get_or_compute is a CACHE
+    # HIT carrying run-A's per-strategy library_pbo (0.42) unless the route
+    # reconciles it against the freshly-computed top-level value. The
+    # top-level library_pbo is recomputed as "unavailable" (None) this time —
+    # the two must still agree.
+    monkeypatch.setattr(
+        routes,
+        "_library_pbo_payload",
+        lambda: routes.LibraryPbo(value=None, source="unavailable"),
+    )
+    data_b = await _run_once()
+    _assert_internally_consistent(data_b)
+    assert data_b["library_pbo"]["value"] is None
+    assert data_b["library_pbo"]["source"] == "unavailable"
+
+
+@pytest.mark.asyncio
 async def test_run_rigor_gate_called_without_library_pbo_kwarg(monkeypatch):
     """The gate verdict path must be provably unchanged: run_rigor_gate is called
     WITHOUT a library_pbo= argument (passing it would alter criterion 4 = option 3,

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -1039,3 +1039,78 @@ class TestDegenerateSeriesExcludedFromCohort:
         assert resp.status_code == 200
         num_trials_seen = {kwargs["num_trials"] for kwargs in captured_kwargs}
         assert num_trials_seen == {1}, "only 1 real series survives both filters"
+
+
+class TestCacheKeyReactsToStrategyCodeChange:
+    """Copilot review, PR #1040: the /api/selection-bias/gate cache key
+    (rigor_cache.cohort_key + strictness) previously fingerprinted only
+    persisted returns, but run_rigor_gate's look-ahead audit also depends on
+    strategy_code (loaded from s.strategy_code_path). Editing a strategy's code
+    without touching its returns therefore served a STALE cached look-ahead
+    verdict/passes_all for up to the TTL. Proves the fix: run_rigor_gate reruns
+    when a strategy's strategy_code_hash changes, even with byte-identical
+    persisted returns.
+    """
+
+    @staticmethod
+    def _real_series(seed: int, n: int = 300) -> list[float]:
+        return np.random.default_rng(seed).normal(0.001, 0.01, n).tolist()
+
+    @pytest.mark.asyncio
+    async def test_code_hash_change_busts_cache_with_unchanged_returns(self, monkeypatch):
+        from archimedes.api import selection_bias_routes as routes
+        from archimedes.main import app
+        from archimedes.services.rigor_evaluator import run_rigor_gate as real_run_rigor_gate
+
+        strategies = routes._provider().list_strategies()
+        assert len(strategies) >= 1, "need >=1 curated strategy for this cohort"
+        target = strategies[0]
+        original_hash = target.strategy_code_hash
+
+        returns = {s.id: self._real_series(abs(hash(s.id)) % 10_000) for s in strategies}
+        monkeypatch.setattr(
+            "archimedes.services.backtest_repository.get_all_daily_returns",
+            lambda session, ids: dict(returns),
+        )
+
+        call_count = {"n": 0}
+
+        def _spy(*args, **kwargs):
+            call_count["n"] += 1
+            return real_run_rigor_gate(*args, **kwargs)
+
+        monkeypatch.setattr(routes, "run_rigor_gate", _spy)
+
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp1 = await client.get("/api/selection-bias/gate")
+            assert resp1.status_code == 200
+            first_calls = call_count["n"]
+            assert first_calls > 0, "first call must run the live gate"
+
+            # Second call: everything unchanged (same returns, same code) — pure
+            # cache hit, no new run_rigor_gate invocations.
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp2 = await client.get("/api/selection-bias/gate")
+            assert resp2.status_code == 200
+            assert call_count["n"] == first_calls, "unchanged returns+code must be a cache hit"
+
+            # Simulate a code edit on `target`: persisted returns are UNCHANGED,
+            # only its code hash differs (mirrors what LocalStrategyProvider.refresh()
+            # would compute after the underlying file's contents actually changed).
+            target.strategy_code_hash = f"{original_hash}-edited"
+
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp3 = await client.get("/api/selection-bias/gate")
+            assert resp3.status_code == 200
+            assert call_count["n"] > first_calls, (
+                "a strategy's strategy_code_hash changing (with byte-identical "
+                "returns) must bust the /api/selection-bias/gate cache key and "
+                "rerun run_rigor_gate — otherwise a stale look-ahead verdict can "
+                "be served for up to the TTL after a real code edit"
+            )
+        finally:
+            # `_provider()` is a process-lifetime lru_cache singleton (shared
+            # across the whole test session) — restore the mutated attribute so
+            # this test can't leak state into any other test.
+            target.strategy_code_hash = original_hash


### PR DESCRIPTION
## Problem (measured)

The Library page takes ~10-20s to load. Root cause: two endpoints recompute
the rigor gate LIVE on every request, and the frontend's `Promise.all` blocks
on the slower one:

- `GET /api/strategies/` → `_live_rigor_results_for_strategies()` in
  `backend/archimedes/api/strategies_routes.py` (~6s measured). Reads all
  persisted daily returns, then runs `compute_pbo()` +
  `compute_average_pairwise_correlation()` over the cohort and
  `run_rigor_gate()` PER strategy (plus a look-ahead code-audit file read).
- `GET /api/selection-bias/gate` in
  `backend/archimedes/api/selection_bias_routes.py` (~8-10s measured) — the
  same family of live computation, plus a per-strategy DB write-back of the
  rigor fields.

A synthetic micro-benchmark on a 20-strategy / 500-observation cohort shows
the shape of the fix: **~1173ms cold vs ~3ms warm (≈363x)** for the cached
computation itself (see "Verification" below for the harness — this is not
a committed test, just a sanity check of the mechanism).

## The fix — a correctness-preserving cache

**Non-negotiable constraint honored:** this does NOT weaken the rigor gate,
skip a check, or change any served number. It caches the exact real computed
result, keyed by a data-version token that changes the instant the
underlying data changes.

New module `backend/archimedes/services/rigor_cache.py`:

- **No new dependency.** `cachetools` is not currently in
  `backend/requirements.txt` / `environment.yml`, so rather than add one for
  a single call site, this is a small hand-rolled dict-with-timestamps store
  behind the same API `cachetools.TTLCache` would offer — a drop-in swap
  later if `cachetools` becomes a dependency for an unrelated reason.
- `cohort_key(strategy_ids, returns_by_strategy)` — a stable SHA-256 hash over
  `sorted(strategy_ids)` plus a packed-float fingerprint of each strategy's
  persisted returns series. ANY change to any strategy's returns (or a
  strategy being added/removed) yields a different key.
- `get_or_compute(key, compute_fn)` — cache hit returns the stored value;
  miss calls `compute_fn()`, stores, returns. **Fails open:** any exception
  in the cache layer itself (lookup or store) is caught and falls back to
  calling `compute_fn()` directly — a cache bug can only make a request
  slow, never wrong or crashed.
- TTL = 600s, a **safety cap only** — `cohort_key` is the real invalidation
  mechanism (changes the moment data changes); the TTL just bounds how long
  a cache entry could theoretically survive if an invalidation hook were
  ever missed.
- `clear()` — invalidate everything.

**strategies_routes.py** (`_live_rigor_results_for_strategies`): the DB read
of persisted returns is UNCHANGED and never cached. Immediately after it,
the expensive remainder (zero-variance filtering, cohort PBO/correlation,
per-strategy look-ahead code load, one `run_rigor_gate` call per strategy)
is wrapped in `get_or_compute`, keyed on `cohort_key(...)`. Every existing
fallback/fail-closed path is untouched — just moved inside the cached
closure.

**selection_bias_routes.py** (`evaluate_rigor_gate`): same shape. The cache
key also folds in `strictness`, since that query param changes which
threshold profile `run_rigor_gate` grades against (the underlying numeric
metrics are strictness-independent, but `passes_all`/`gate_details` are
not, so a level-3 result must never be served for a level-1 request).

One residual worth reviewer scrutiny: on a cache HIT, this route's
per-strategy DB write-back (`update_rigor_gate_fields` + `commit`) does
NOT re-run. That write-back is idempotent — it re-persists the exact
numbers already written the first time this cohort+strictness combination
was computed — so a skipped hit changes no served or stored value, only
skips a redundant write. The moment the underlying returns change, the key
changes and the write-back resumes on the next (live) call.

## Invalidation

`backend/archimedes/services/backtest_repository.py`'s
`insert_backtest_if_missing()` calls `rigor_cache.clear()` right after a
genuinely new row is inserted. This is the single choke point every writer
path funnels through (`generation_pipeline.py`'s `_persist_real_returns` /
`_backtest_and_persist`, `scripts/run_backtests.py`,
`scripts/seed_backtests_from_artifacts.py`) — one hook covers all of them.
Not strictly required for correctness (`cohort_key` already invalidates on
its own the moment returns change) — this just tightens "new backtest
written" → "next read recomputes live" from up to the TTL down to ~0.

## Tests

`backend/tests/test_rigor_cache.py` (9 tests, all passing):

- **(a)** two consecutive `_live_rigor_results_for_strategies` calls with
  unchanged data return identical results, and a spy on
  `run_rigor_gate` shows it's invoked exactly once per strategy (second call
  is a pure cache hit).
- **(b)** changing a strategy's persisted returns changes the cohort key;
  `run_rigor_gate` runs again and the served numbers are independently
  reproduced against the new data.
- **(c)** cache-layer errors (patched to raise on both lookup and store)
  fall back to live compute, at both the `rigor_cache.get_or_compute` unit
  level and the `_live_rigor_results_for_strategies` route level — the real
  result is still returned.
- Plus `cohort_key` unit properties (order-independence, sensitivity to any
  series change, sensitivity to cohort membership change) and `clear()`.

Also added an autouse fixture to `backend/tests/conftest.py` that clears
`rigor_cache` around every backend test — it's a process-global store, and
several existing test files reuse the same real curated strategy ids across
functions, which could otherwise leak cache state between unrelated tests.

No existing test was weakened or deleted.

## Verification run

```
ruff format backend/ && ruff check backend/archimedes --select E9,F63,F7,F40,F821
python -m pytest backend/tests/test_rigor_cache.py backend/tests/api/test_marketplace_routes.py \
    backend/tests/test_selection_bias_routes.py backend/tests/test_strategies_routes.py \
    backend/tests/test_backtest_repository.py -q
# 100 passed
```

Also ran the full hermetic backend suite for regressions:
`python -m pytest backend/tests -q -m "not integration"` → **2664 passed, 0 failed**.

## Bottom line

**The served rigor numbers are UNCHANGED.** This PR only memoizes the live
computation behind a data-version key with a fail-open cache layer — no
threshold, gate logic, or fallback behavior was touched.

Draft PR — not merging, not marking ready for review. Please scrutinize the
cache-hit DB write-back skip in `selection_bias_routes.py` (noted above) and
the single-choke-point invalidation hook in `insert_backtest_if_missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)