### PR TITLE
Potential fix for code scanning alert no. 8: Construction of a cookie using user-supplied input

### DIFF
--- a/backend/archimedes/api/auth_siwe.py
+++ b/backend/archimedes/api/auth_siwe.py
@@ -25,6 +25,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import secrets
 import time
 from datetime import datetime, timedelta
@@ -129,6 +130,16 @@ def _address_from_siwe_message(message: str) -> str | None:
         addr = lines[1].strip()
         if addr.startswith("0x") and len(addr) == 42:
             return addr.lower()
+    return None
+
+
+def _canonical_wallet_or_none(wallet: str) -> str | None:
+    """Return strict lowercase 0x-prefixed 40-hex wallet, else None."""
+    if not isinstance(wallet, str):
+        return None
+    w = wallet.strip().lower()
+    if re.fullmatch(r"0x[a-f0-9]{40}", w):
+        return w
     return None
 
 
@@ -392,7 +403,9 @@ async def verify_signature(request: Request, response: Response):
     else:
         raise HTTPException(status_code=401, detail="Invalid signature")
 
-    recovered_lower = verified_wallet
+    recovered_lower = _canonical_wallet_or_none(verified_wallet)
+    if not recovered_lower:
+        raise HTTPException(status_code=401, detail="Invalid signature")
 
     # Issue session cookie
     now = time.time()

--- a/backend/tests/test_auth_siwe.py
+++ b/backend/tests/test_auth_siwe.py
@@ -19,6 +19,7 @@ from archimedes.api.auth_siwe import (
     _NONCE_TTL_SECONDS,
     _SESSION_TTL_SECONDS,
     _address_from_siwe_message,
+    _canonical_wallet_or_none,
     _pending_nonces,
     _resolve_session_secret,
     _sign_session,
@@ -27,6 +28,45 @@ from archimedes.api.auth_siwe import (
     require_verified_wallet,
 )
 from httpx import ASGITransport, AsyncClient
+
+
+class TestCanonicalWalletOrNone:
+    """`_canonical_wallet_or_none` guards the value that flows into the signed
+    session cookie (code-scanning alert #8: cookie built from user input). It
+    must accept ONLY a strict ``0x`` + 40-hex wallet (lowercased, trimmed) and
+    reject everything else — including injection payloads."""
+
+    def test_accepts_lowercase_hex(self):
+        w = "0x" + "0123456789abcdef0123456789abcdef01234567"
+        assert _canonical_wallet_or_none(w) == w
+
+    def test_lowercases_checksummed_input(self):
+        checksummed = "0x" + "0123456789ABCDEF0123456789abcdef01234567"
+        assert _canonical_wallet_or_none(checksummed) == checksummed.lower()
+
+    def test_strips_surrounding_whitespace(self):
+        w = "0x" + "b" * 40
+        assert _canonical_wallet_or_none(f"  {w}\n") == w
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "0x",
+            "0x" + "0" * 39,  # too short
+            "0x" + "0" * 41,  # too long
+            "0x" + "g" * 40,  # non-hex char
+            "0" * 40,  # missing 0x prefix
+            "0x" + "0" * 40 + "; Path=/; Domain=evil.com",  # cookie-injection payload
+            "0x" + "0" * 40 + "\r\nSet-Cookie: evil=1",  # CRLF header-injection payload
+        ],
+    )
+    def test_rejects_malformed_and_injection(self, bad):
+        assert _canonical_wallet_or_none(bad) is None
+
+    def test_rejects_non_string(self):
+        assert _canonical_wallet_or_none(None) is None
+        assert _canonical_wallet_or_none(12345) is None
 
 
 class TestResolveSessionSecret:


### PR DESCRIPTION
Potential fix for [https://github.com/a-apin/archimedes/security/code-scanning/8](https://github.com/a-apin/archimedes/security/code-scanning/8)

To fix this safely without changing functionality, enforce a strict canonical wallet format immediately before session token creation, and only sign/set a token derived from that sanitized value.

Best approach in this file:
- Add a helper that validates and canonicalizes wallet addresses to strict `0x[a-f0-9]{40}` lowercase form.
- In `verify_signature`, run `verified_wallet` through this helper before assigning `recovered_lower` and before `_sign_session(...)`.
- If canonicalization fails, reject with 401.

This keeps existing auth flow intact (EOA/ERC-1271 verification still required) while ensuring cookie content is built from a tightly constrained value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
