### PR TITLE
[ci][fix] Harden the Postgres validation step (fast-follow of #1050 Copilot review)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,10 +194,12 @@ jobs:
         # fallback for tests/local is tracked in #1044.
         run: |
           set -euo pipefail
-          # Idempotent: `docker network create` errors (and, under `set -e`,
-          # aborts the step) if the network survived a prior attempt on the
-          # same runner. Tolerate an already-existing network.
-          docker network create archimedes-ci 2>/dev/null || true
+          # Idempotent, but ONLY tolerate "already exists": inspect first and
+          # create only when the network is missing — so a leftover network
+          # from a prior attempt on the same runner doesn't abort the step
+          # under `set -e`, while a REAL `docker network create` failure still
+          # stops the step with its original error (not swallowed by `|| true`).
+          docker network inspect archimedes-ci >/dev/null 2>&1 || docker network create archimedes-ci
           docker run -d --name pg --network archimedes-ci \
             -e POSTGRES_USER=archimedes -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=archimedes \
             postgres:18-alpine

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,15 +194,26 @@ jobs:
         # fallback for tests/local is tracked in #1044.
         run: |
           set -euo pipefail
-          docker network create archimedes-ci
+          # Idempotent: `docker network create` errors (and, under `set -e`,
+          # aborts the step) if the network survived a prior attempt on the
+          # same runner. Tolerate an already-existing network.
+          docker network create archimedes-ci 2>/dev/null || true
           docker run -d --name pg --network archimedes-ci \
             -e POSTGRES_USER=archimedes -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=archimedes \
             postgres:18-alpine
           echo "waiting for Postgres to accept connections..."
+          pg_ready=""
           for _ in $(seq 1 30); do
-            if docker exec pg pg_isready -U archimedes -d archimedes >/dev/null 2>&1; then break; fi
+            if docker exec pg pg_isready -U archimedes -d archimedes >/dev/null 2>&1; then pg_ready=1; break; fi
             sleep 2
           done
+          # Fail loudly instead of proceeding to a migrate that would surface a
+          # harder-to-debug connection error if Postgres never came up.
+          if [ -z "$pg_ready" ]; then
+            echo "::error::Postgres did not become ready within 60s — see logs below"
+            docker logs pg || true
+            exit 1
+          fi
           DB_URL="postgresql://archimedes:ci@pg:5432/archimedes"
           # Apply the schema exactly as the prod ECS migrate task does (a fresh
           # DB → `alembic upgrade head` from the baseline). Also validates the


### PR DESCRIPTION
Fast-follow addressing the two Copilot comments on #1050 (already merged):
1. **Idempotent network create** — `docker network create archimedes-ci 2>/dev/null || true` so a leftover network from a prior runner attempt doesn't abort the step under `set -e`.
2. **Fail-loud Postgres wait** — the readiness loop now exits 1 + emits `docker logs pg` if Postgres never comes up, instead of silently continuing to the migrate.

CI-workflow-only; no app code. The validate step itself already works (build-and-push confirmed the /health-against-Postgres check passes on main).