### PR TITLE
[infra][fix] Fix two AWS-charset violations surfaced by terraform apply (SG description + ECR tag)

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -29,7 +29,7 @@ resource "aws_ecr_repository" "backend" {
 
   tags = {
     Project = var.project_name
-    Purpose = "backend + oracle + agent + kb-runner (one image, different CMD overrides)"
+    Purpose = "backend + oracle + agent + kb-runner - one shared image with different CMD overrides"
   }
 }
 

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -135,7 +135,7 @@ resource "aws_security_group" "ecs_backend" {
   # avoid-the-SG-cycle rationale main.tf's `aws_security_group.archimedes`
   # documents for its own CIDR-based rule.
   ingress {
-    description = "HTTP from ALB (nginx container port), restricted to the ALB's public subnet CIDRs"
+    description = "HTTP from ALB (nginx container port), restricted to the ALB public subnet CIDRs"
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"


### PR DESCRIPTION
Two AWS API-level string-charset violations that `terraform validate` cannot catch (they're AWS API rules, not HCL) — both surfaced only against live AWS during the Fargate-cutover Stage 1 apply.

### 1. Security-group description — `infra/ecs.tf`
`aws_security_group.ecs_backend` ingress description contained an apostrophe (`ALB's`). AWS restricts SG descriptions to `^[0-9A-Za-z_ .:/()#,@\[\]+=&;{}!$*-]*$` — no `'`. → reworded to drop the apostrophe. (Blocked `terraform plan`.)

### 2. ECR repository tag value — `infra/ecr.tf`
`aws_ecr_repository.backend`'s `Purpose` tag value `"...(one image, different CMD overrides)"` contained parentheses + a comma. AWS tag VALUES allow only `[a-zA-Z0-9 _.:/=+@-]` → `InvalidTagParameterException`. → reworded without `()`/`,`. (Blocked the Stage 1 `terraform apply` — the nginx repo, which has no such chars, created fine; the backend repo failed.)

Scanned the rest of infra: no other SG description or tag value has a disallowed char (the `Name = "${var.project_name}-..."` tags interpolate to clean values before reaching AWS).

_Found live during the terraform cutover; the `-target` Stage 1 apply is otherwise clean (4 add / 0 change / 0 destroy)._