### PR TITLE
[infra][fix] Fargate-awsvpc nginx upstream (fix 502-on-/health, KNOWN GAP #1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,7 +248,15 @@ jobs:
         # standalone nginx boot.
         run: |
           set -euo pipefail
-          docker run -d --name nginx-validate --network archimedes-ci -p 18080:8080 archimedes-nginx:ci
+          # Docker-network path (a `backend` container on archimedes-ci) → set
+          # the Docker-DNS NGINX_* values that render nginx.conf's upstream, same
+          # as docker-compose. (Fargate sets the localhost values in ecs.tf.)
+          docker run -d --name nginx-validate --network archimedes-ci -p 18080:8080 \
+            -e NGINX_ENVSUBST_FILTER='^NGINX_' \
+            -e NGINX_RESOLVER_LINE='resolver 127.0.0.11 valid=10s ipv6=off;' \
+            -e NGINX_BACKEND_UPSTREAM='backend:8000' \
+            -e NGINX_UPSTREAM_RESOLVE='resolve' \
+            archimedes-nginx:ci
           ok=""
           for _ in $(seq 1 40); do
             if curl -fsS http://localhost:18080/ >/dev/null 2>&1 && curl -fsS http://localhost:18080/health >/dev/null 2>&1; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,14 @@ services:
         VITE_CIRCLE_CLIENT_URL: ${VITE_CIRCLE_CLIENT_URL:-https://modular-sdk.circle.com/v1/rpc/w3s/buidl}
         VITE_API_BASE: ${VITE_API_BASE:-}
     restart: unless-stopped
+    environment:
+      # Render the runtime-agnostic nginx template (see nginx.conf's upstream
+      # block). In compose, Docker's embedded DNS (127.0.0.11) resolves the
+      # `backend` service name at runtime.
+      NGINX_ENVSUBST_FILTER: "^NGINX_"
+      NGINX_RESOLVER_LINE: "resolver 127.0.0.11 valid=10s ipv6=off;"
+      NGINX_BACKEND_UPSTREAM: "backend:8000"
+      NGINX_UPSTREAM_RESOLVE: "resolve"
     ports:
       # TLS terminates upstream at CloudFront + the ALB; nginx serves plain
       # HTTP on :8080. No :443/8443 mapping and no cert mounts — the

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -521,14 +521,24 @@ resource "aws_ecs_task_definition" "backend" {
       image     = "${aws_ecr_repository.nginx.repository_url}:${var.backend_image_tag}"
       essential = true
 
+      # Render the runtime-agnostic nginx template (nginx.conf's upstream block).
+      # In Fargate awsvpc the nginx + backend containers share the task's network
+      # namespace (localhost) and there is NO Docker embedded DNS at 127.0.0.11 —
+      # so the backend is reached at 127.0.0.1:8000 with an empty resolver line
+      # and no `resolve` param. (Compose/local set the Docker-DNS values instead;
+      # see docker-compose.yml.) Fixes the awsvpc 502-on-/health that made the
+      # ALB target-group health check fail — was formerly "KNOWN GAP #1".
+      environment = [
+        { name = "NGINX_ENVSUBST_FILTER", value = "^NGINX_" },
+        { name = "NGINX_RESOLVER_LINE", value = "" },
+        { name = "NGINX_BACKEND_UPSTREAM", value = "127.0.0.1:8000" },
+        { name = "NGINX_UPSTREAM_RESOLVE", value = "" },
+      ]
+
       portMappings = [
         { containerPort = 8080, protocol = "tcp" } # the ALB target — matches archimedes-backend-tg's traffic-port health check
       ]
 
-      # KNOWN GAP #1 (see file header): nginx.conf's `server backend:8000` is
-      # a docker-compose-bridge-network DNS name that does not resolve in
-      # ECS awsvpc mode — must become `localhost:8000` before this actually
-      # proxies successfully.
       dependsOn = [
         { containerName = "backend", condition = "HEALTHY" }
       ]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -27,4 +27,9 @@ RUN npm run build
 # box (`Server: nginx/1.31.2`) — never downgrade prod. Bump this tag deliberately. (#780)
 FROM nginxinc/nginx-unprivileged:1.31.2-alpine
 COPY --from=ui-build /app/dist /usr/share/nginx/html
-COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
+# Land the config as a TEMPLATE: the nginx image's docker-entrypoint
+# (20-envsubst-on-templates.sh) renders /etc/nginx/templates/*.template →
+# /etc/nginx/conf.d/*.conf at startup, substituting the NGINX_* env vars
+# (see nginx.conf's upstream block). NGINX_ENVSUBST_FILTER=^NGINX_ (set per-env)
+# restricts substitution to our own vars so nginx's own $variables are untouched.
+COPY nginx/nginx.conf /etc/nginx/templates/default.conf.template

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -34,10 +34,20 @@ real_ip_recursive on;
 # (valid=10s) at RUNTIME, so a backend recreate self-heals without an nginx
 # restart. Requires nginx ≥ 1.27.3 for open-source upstream `resolve`; the image
 # is pinned to 1.31.2 (nginx/Dockerfile) to match the live box. keepalive is preserved.
-resolver 127.0.0.11 valid=10s ipv6=off;
+# Upstream + resolver are ENV-DRIVEN (rendered by the nginx image's built-in
+# envsubst-on-templates entrypoint) so ONE config serves both runtimes:
+#   • docker-compose / local: Docker's embedded DNS resolves the `backend`
+#     service name — NGINX_RESOLVER_LINE="resolver 127.0.0.11 …",
+#     NGINX_BACKEND_UPSTREAM="backend:8000", NGINX_UPSTREAM_RESOLVE="resolve".
+#   • Fargate (awsvpc): the two containers share the task's network namespace
+#     (localhost), and there is NO Docker DNS at 127.0.0.11 — so the resolver
+#     line is empty, NGINX_BACKEND_UPSTREAM="127.0.0.1:8000", RESOLVE empty.
+# Values set per-env in docker-compose.yml, infra/ecs.tf, and deploy.yml's
+# nginx-validate step. (Fixes the awsvpc 502-on-/health the red-team flagged.)
+${NGINX_RESOLVER_LINE}
 upstream backend_api {
     zone backend_api 64k;
-    server backend:8000 resolve;
+    server ${NGINX_BACKEND_UPSTREAM} ${NGINX_UPSTREAM_RESOLVE};
     keepalive 32;
 }
 


### PR DESCRIPTION
The Fargate ECS service crash-looped: nginx returned **502 on /health** (ALB `Target.ResponseCodeMismatch`) because `nginx.conf` hardcodes Docker's embedded DNS (`resolver 127.0.0.11`) + the compose service name (`server backend:8000 resolve`), neither of which exists in Fargate `awsvpc` (containers share `localhost`, no Docker DNS). `ecs.tf` documented this as "KNOWN GAP #1"; the CI nginx check passed only because it runs on a Docker network.

**Fix:** parameterize the resolver + upstream via the nginx image's built-in `envsubst`-on-templates entrypoint. Compose/CI keep Docker-DNS values; Fargate (ecs.tf) uses `127.0.0.1:8000` + empty resolver. **`nginx -t` validated on both rendered forms.**

Surfaced live during the Fargate cutover. Prod unaffected (EC2 box still serving; Fargate service scaled to 0).