### PR TITLE
[infra] Phase 4 cutover: detach EC2 from the ALB target group (#1039)

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -243,12 +243,18 @@ resource "aws_lb_target_group" "backend" {
   }
 }
 
-resource "aws_lb_target_group_attachment" "backend" {
-  target_group_arn  = aws_lb_target_group.backend.arn
-  target_id         = aws_instance.archimedes.private_ip # IP target, not instance ID
-  port              = 80
-  availability_zone = "all" # Cross-VPC IP target
-}
+# ── Phase 4 cutover (issue #1039): EC2 detached from the target group ──
+# Fargate (the ECS service's own target registrations) is now the sole web tier.
+# The EC2 instance stays RUNNING (attached to nothing) as a one-deploy-cycle
+# rollback window per the runbook — to roll back, uncomment this block and
+# `terraform apply` to re-register the box alongside Fargate. This block is
+# deleted for good at Phase 8 (EC2 decommission), along with aws_instance.archimedes.
+# resource "aws_lb_target_group_attachment" "backend" {
+#   target_group_arn  = aws_lb_target_group.backend.arn
+#   target_id         = aws_instance.archimedes.private_ip # IP target, not instance ID
+#   port              = 80
+#   availability_zone = "all" # Cross-VPC IP target
+# }
 
 # ── Listeners ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Final step of the ECS Fargate cutover (issue #1039). Comments out
`aws_lb_target_group_attachment.backend` in `infra/alb.tf`, which detaches the
EC2 instance from `archimedes-backend-tg`. **Fargate becomes the sole web tier.**

Context: Fargate has been verified healthy and serving live traffic end-to-end
(rollout `COMPLETED`; `/health`, `/`, `/api/health` all 200 through the live
domain; `chain_connected:true`, corpus loaded, frontend served). Right now the
ALB blends the EC2 box and Fargate — and the EC2 box may serve a **stale
build-on-box image** (the #1001 OOM outages were failing those on-box builds),
so the blend risks two-different-code-versions. This PR ends the blend.

## Scope

- `infra/alb.tf` — comment out the single `aws_lb_target_group_attachment.backend`
  resource. Nothing else.

## What terraform does

```bash
terraform plan   # EXACTLY ONE resource destroyed:
                 #   aws_lb_target_group_attachment.backend
                 # (ECS's own registrations are untouched — managed by the
                 #  service, not this resource)
terraform apply
```

## Verify (after apply)

```bash
aws elbv2 describe-target-health --target-group-arn "$(aws elbv2 \
  describe-target-groups --names archimedes-backend-tg \
  --query 'TargetGroups[0].TargetGroupArn' --output text)"
# expect: only ip-type (Fargate ENI) targets; zero instance/EC2-IP entries
```
Then smoke-test the live domain end-to-end (login, Generate, wallet-connect).

## Rollback

The EC2 instance stays **running, attached to nothing**, for one deploy cycle.
To roll back: uncomment the block and `terraform apply` to re-register the box
alongside Fargate. The block is deleted for good at **Phase 8** (EC2 decommission).

## Anti-goals

- Do NOT terminate the EC2 instance in this PR (that's Phase 8).
- Do NOT touch the ECS service, task def, or any Fargate registration.
- Do NOT retire the EC2 SSM `deploy` job yet (Phase 8 step 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M