### PR TITLE
[infra] Deploy observability: version stamp + rich-health CI gate + retire EC2 deploy job (#1039)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -254,16 +254,27 @@ jobs:
           # NOT asserted here: this throwaway Postgres is empty, so risk_data=mock
           # is correct in CI — it's validated post-deploy against Aurora.)
           HEALTH="$(curl -fsS http://localhost:8000/health)"
-          regime="$(printf '%s' "$HEALTH" | jq -r '.regime_detector')"
-          scount="$(printf '%s' "$HEALTH" | jq -r '.strategy_count // 0')"
-          version="$(printf '%s' "$HEALTH" | jq -r '.version')"
+          regime="$(printf '%s' "$HEALTH" | jq -r '.regime_detector // "MISSING"')"
+          scount="$(printf '%s' "$HEALTH" | jq -r '.strategy_count // "MISSING"')"
+          version="$(printf '%s' "$HEALTH" | jq -r '.version // "MISSING"')"
           fail=0
-          if [ "$regime" = "degraded" ]; then
-            echo "::error::rich-health gate: regime_detector=degraded (gmm_model.pkl missing from image?)"; fail=1
+          # Fail CLOSED: require regime == "live". A missing/null/"unknown"/"degraded"
+          # value (probe crash OR missing gmm_model.pkl) must NOT slip through on a
+          # soft "!= degraded" check.
+          if [ "$regime" != "live" ]; then
+            echo "::error::rich-health gate: regime_detector='$regime' (expected 'live' — gmm_model.pkl missing from image, or the probe failed)"; fail=1
           fi
-          if ! [ "$scount" -gt 0 ] 2>/dev/null; then
-            echo "::error::rich-health gate: strategy_count=$scount (analytics-engine/strategies missing from image?)"; fail=1
+          # strategy_count must be a positive integer (MISSING/0/non-numeric all fail).
+          if ! printf '%s' "$scount" | grep -qE '^[0-9]+$' || [ "$scount" -le 0 ]; then
+            echo "::error::rich-health gate: strategy_count='$scount' (expected > 0 — analytics-engine/strategies missing from image?)"; fail=1
           fi
+          # The build passed --build-arg GIT_SHA=<github.sha>, so version MUST be a
+          # real SHA here. MISSING/empty/"dev"/"null" means the GIT_SHA build-arg
+          # wiring regressed and prod would ship an unstamped image.
+          case "$version" in
+            ""|MISSING|dev|null)
+              echo "::error::rich-health gate: version='$version' (expected the build SHA — GIT_SHA build-arg wiring regressed)"; fail=1 ;;
+          esac
           [ "$fail" = 0 ] || exit 1
           echo "rich-health gate OK: regime=$regime strategy_count=$scount version=$version"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,19 +32,20 @@
 #                    before it ever reaches ECR or a serving host — then tags
 #                    both <commit-sha> + latest and pushes to ECR.
 #   migrate          (needs: build-and-push) Runs `alembic upgrade head` as a
-#                    one-off ECS Fargate task, ordered BEFORE `deploy` — the
-#                    #1039 P4 / #1028 Phase A shared migrate stage. Alembic
-#                    hasn't landed on this branch yet (see the job's own
-#                    comment), so today this is a safe, loud no-op; it
-#                    self-activates the moment `backend/alembic.ini` exists.
-#   deploy           (needs: [build-and-push, migrate]) SSMs the EC2 box:
-#                    pulls the just-pushed <commit-sha> image from ECR and
-#                    runs `docker compose up -d --force-recreate` — NO docker
-#                    build ever runs on the serving host. This is the P1
-#                    "stop the bleeding" interim from #1039: it ends the
-#                    docker-compose-build-on-a-4GB-serving-host OOM class that
-#                    caused 3 production outages on 2026-07-06 (#1001), ahead
-#                    of the full ECS Fargate cutover (later phases of #1039).
+#                    one-off ECS Fargate task, ordered BEFORE `deploy-ecs` — the
+#                    #1039 P4 / #1028 Phase A shared migrate stage. Fails closed
+#                    if the schema can't reach head, so a new task never serves
+#                    an out-of-date DB.
+#   deploy-ecs       (needs: [build-and-push, migrate]) Registers a new ECS task
+#                    definition revision pointing at the just-pushed <commit-sha>
+#                    image and force-redeploys the Fargate service behind the
+#                    existing ALB. NO docker build ever runs on a serving host.
+#                    (The legacy `deploy` job — SSM into the EC2 box + `docker
+#                    compose up` — was RETIRED in the #1039 observability
+#                    fast-follow: post-cutover the box is detached from the ALB,
+#                    so auto-deploying to it was pointless and its broken step
+#                    reddened every run. The box stays running as a rollback
+#                    window until Phase 8 decommission.)
 #
 # ECR repos expected: `archimedes-backend` (shared by the backend/oracle/agent/
 # kb-runner services — same image, different `command:` override, exactly as
@@ -65,7 +66,7 @@
 #     (also grants ECR push, scoped to repository/archimedes* — see
 #     infra/scripts/setup-github-oidc.sh)
 #   EC2_INSTANCE_ID — i-01803d3abc271d39b
-#   DEPLOY_ENABLED — gate flag; both jobs below run ONLY when this repo
+#   DEPLOY_ENABLED — gate flag; all three jobs below run ONLY when this repo
 #     variable equals 'true'. Unset/false → skipped (neutral, not failed). The
 #     stack was rebuilt on a NEW account (037613907429 / us-east-1) and is LIVE
 #     again at archimedes-arc.com (2026-06-24), so the deploy target exists. This
@@ -142,7 +143,9 @@ jobs:
         # analytics-engine/ + data/corpus + contracts/abis + the committed
         # gmm_model.pkl — assets Fargate can't get from a host volume. The root
         # .dockerignore keeps the context lean (.git / submodules / node_modules).
-        run: docker build -t archimedes-backend:ci -f backend/Dockerfile .
+        # --build-arg GIT_SHA stamps the commit into the image → /health "version"
+        # (issue #1039 observability fast-follow).
+        run: docker build -t archimedes-backend:ci -f backend/Dockerfile --build-arg GIT_SHA="${{ github.sha }}" .
 
       - name: Build nginx image
         # Env-parity fix (PR #1041 correctness pass, 2026-07-07): this is NOT
@@ -243,6 +246,26 @@ jobs:
             exit 1
           fi
           echo "backend /health OK (against Postgres)"
+
+          # Rich-health gate (issue #1039): GET-200 is NOT enough. A strategy-less
+          # or gmm-less image still answers 200 while silently degraded — the exact
+          # regression that shipped a mock/degraded Fargate build past this step.
+          # Assert the IMAGE-BAKED features are live. (risk_data is intentionally
+          # NOT asserted here: this throwaway Postgres is empty, so risk_data=mock
+          # is correct in CI — it's validated post-deploy against Aurora.)
+          HEALTH="$(curl -fsS http://localhost:8000/health)"
+          regime="$(printf '%s' "$HEALTH" | jq -r '.regime_detector')"
+          scount="$(printf '%s' "$HEALTH" | jq -r '.strategy_count // 0')"
+          version="$(printf '%s' "$HEALTH" | jq -r '.version')"
+          fail=0
+          if [ "$regime" = "degraded" ]; then
+            echo "::error::rich-health gate: regime_detector=degraded (gmm_model.pkl missing from image?)"; fail=1
+          fi
+          if ! [ "$scount" -gt 0 ] 2>/dev/null; then
+            echo "::error::rich-health gate: strategy_count=$scount (analytics-engine/strategies missing from image?)"; fail=1
+          fi
+          [ "$fail" = 0 ] || exit 1
+          echo "rich-health gate OK: regime=$regime strategy_count=$scount version=$version"
 
       - name: Validate nginx image boots + proxies (GET / and /health)
         # Runs on the same user-defined docker network as the backend
@@ -457,157 +480,6 @@ jobs:
             exit 1
           fi
           echo "alembic_migrate_preflight OK — schema is current (stamped + upgraded to head); safe for new tasks to serve."
-
-  deploy:
-    needs: [build-and-push, migrate]
-    name: Deploy
-    # Gated behind an explicit opt-in repo variable (also enforced transitively
-    # via `needs: [build-and-push, migrate]`, which carry the same `if:` —
-    # kept explicit here too so this job's own skip reason is legible in the
-    # Actions UI without following the dependency graph). The stack is LIVE
-    # again on the new account (037613907429 / us-east-1, instance
-    # i-01803d3abc271d39b), but the gate stays OFF until the migration PR
-    # (#716) merges and the OIDC role + trust policy are confirmed, so a
-    # stray push to main can't deploy mid-migration. With DEPLOY_ENABLED
-    # unset, all three jobs are SKIPPED (neutral, keeps the Actions history
-    # green); set DEPLOY_ENABLED=true to enable. `migrate` gating `deploy`
-    # is the #1039 P4 acceptance criterion: a new task must never serve
-    # before schema is current.
-    if: ${{ vars.DEPLOY_ENABLED == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 35  # SSM 30min + AWS API overhead + buffer
-
-    steps:
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6.2.1
-        with:
-          role-to-assume: arn:aws:iam::037613907429:role/archimedes-github-deploy
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Deploy via SSM SendCommand
-        run: |
-          # Build the deploy script as a single string for SSM
-          COMMAND_ID=$(aws ssm send-command \
-            --instance-ids "$EC2_INSTANCE_ID" \
-            --document-name "AWS-RunShellScript" \
-            --timeout-seconds 1800 \
-            --parameters commands='[
-              "#!/bin/bash",
-              "set -eux",
-              "export HOME=/root",
-              "# Issue #1039 C3: two rapid merges to main can queue two overlapping",
-              "# SSM SendCommand invocations on the SAME box, both racing through",
-              "# `docker compose up --force-recreate` below — the loser can hit",
-              "# mid-recreate container-name conflicts or a half-swapped stack. An",
-              "# flock on a fd (not `flock -c \"...\"` wrapping the whole body as one",
-              "# string, which would need re-escaping this entire multi-hundred-line",
-              "# script through the JSON array below) holds for the rest of THIS",
-              "# script'"'"'s process lifetime and releases automatically on exit —",
-              "# a second concurrent SSM command blocks here for up to 1500s (the",
-              "# document'"'"'s own --timeout-seconds budget) rather than racing.",
-              "exec 200>/var/run/archimedes-deploy.lock",
-              "flock -w 1500 200 || { echo '"'"'ERROR_DEPLOY_LOCKED: another deploy is already running on this box (timed out after 1500s waiting for the lock).'"'"'; exit 1; }",
-              "cd /opt/archimedes",
-              "git config --global --add safe.directory /opt/archimedes",
-              "mkdir -p analytics-engine/artifacts",
-              "sudo chown -R ubuntu:ubuntu analytics-engine/artifacts/ 2>/dev/null || true",
-              "git fetch origin main",
-              "git reset --hard origin/main",
-              "df -h / | tail -1 | awk '"'"'{print \"DISK_BEFORE: \"$0}'"'"'",
-              "docker container prune -f 2>/dev/null || true",
-              "docker image prune -af 2>/dev/null || true",
-              "df -h / | tail -1 | awk '"'"'{print \"DISK_AFTER_PRUNE: \"$0}'"'"'",
-              "# Pull-model (audit 2026-06-13 #5): secrets are NO LONGER injected from",
-              "# CI, so no secret value enters the SSM command body / CloudTrail. The",
-              "# backend reads LLM_*/EMAIL_ENCRYPTION_KEY from SSM Parameter Store at",
-              "# startup via its instance role (services/secrets_service.load_ssm_secrets);",
-              "# the box-local, gitignored .env (untouched by git reset) carries any",
-              "# RUNTIME values not yet in SSM. NOTE: this box now PULLS its images",
-              "# (below) rather than building them locally, so the box .env can no",
-              "# longer supply build-time frontend values like VITE_CIRCLE_CLIENT_KEY —",
-              "# that must be a GitHub Actions repo secret consumed by the",
-              "# build-and-push job's nginx build-arg (see this workflow file's header",
-              "# comment and the 'Build nginx image' step). See infra/iam/README.md",
-              "# for the SSM population runbook.",
-              "grep -q '"'"'^PUBLIC_DOMAIN='"'"' .env || echo '"'"'PUBLIC_DOMAIN=https://archimedes-arc.com'"'"' >> .env",
-              "# P1 interim (issue #1039): PULL the image the build-and-push job above",
-              "# already built + validated + pushed to ECR — NEVER build on this serving",
-              "# host again. This is what stops the docker-compose-build OOM that caused",
-              "# 3 outages on 2026-07-06 (#1001). Requires awscli + an ECR-pull-capable",
-              "# instance role on this box (archimedes-backend-role — issue #1039 chunk",
-              "# 2, infra/ec2_iam.tf, NOT applied as of this PR); fails closed below with",
-              "# an explicit message rather than falling back to a local build.",
-              "grep -q '"'"'^ECR_REGISTRY='"'"' .env && sed -i '"'"'s#^ECR_REGISTRY=.*#ECR_REGISTRY=${{ env.ECR_REGISTRY }}#'"'"' .env || echo '"'"'ECR_REGISTRY=${{ env.ECR_REGISTRY }}'"'"' >> .env",
-              "grep -q '"'"'^IMAGE_TAG='"'"' .env && sed -i '"'"'s#^IMAGE_TAG=.*#IMAGE_TAG=${{ github.sha }}#'"'"' .env || echo '"'"'IMAGE_TAG=${{ github.sha }}'"'"' >> .env",
-              "# Issue #1043 gated oracle/agent/kb-runner in docker-compose.yml behind a",
-              "# runners compose profile. This deploy runs a bare docker compose up with",
-              "# no -f and no COMPOSE_FILE, so it needs COMPOSE_PROFILES=runners set in .env",
-              "# or those three services STOP on this deploy; local docker compose up stays",
-              "# inert by default since it does not set this box-local .env value.",
-              "if grep -q '"'"'^COMPOSE_PROFILES='"'"' .env; then grep -qE '"'"'^COMPOSE_PROFILES=([^#]*,)?runners(,|$)'"'"' .env || sed -i '"'"'s/^COMPOSE_PROFILES=.*/&,runners/'"'"' .env; else echo '"'"'COMPOSE_PROFILES=runners'"'"' >> .env; fi",
-              "command -v aws >/dev/null 2>&1 || { echo '"'"'ERROR_NO_AWSCLI_ON_BOX: install awscli on this instance and grant archimedes-backend-role ECR pull permissions (see infra/ec2_iam.tf, issue #1039 chunk 2, and docs/deployment.md).'"'"'; exit 1; }",
-              "aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }} || { echo '"'"'ERROR_ECR_LOGIN_FAILED: verify archimedes-backend-role (EC2 instance role) has ecr:GetAuthorizationToken (infra/ec2_iam.tf).'"'"'; exit 1; }",
-              "docker compose pull || { echo '"'"'ERROR_ECR_PULL_FAILED: verify the archimedes-backend/archimedes-nginx ECR repos exist (terraform apply in infra/, issue #1039 chunk 2) and that tag ${{ github.sha }} was pushed by the build-and-push job.'"'"'; exit 1; }",
-              "# Remove orphan containers left by an interrupted --force-recreate.",
-              "# Docker renames the old container to <hex>_<name> before deleting it; if a",
-              "# run is interrupted mid-recreate the orphan survives, and the next recreate",
-              "# hits a name Conflict and fails the whole deploy (run 28382331990: the",
-              "# oracle orphan fbdabd2fa619_archimedes-oracle-1). The prior",
-              "# `docker ps --filter name=^...` never matched it because the filter anchor",
-              "# is unreliable against the slash-prefixed names Docker stores (/<hex>_...).",
-              "# Grep the clean `--format {{.Names}}` output (no leading slash) so ^ fires.",
-              "docker ps -a --format '"'"'{{.Names}}'"'"' | grep -E '"'"'^[0-9a-f]+_archimedes-'"'"' | xargs -r docker rm -f 2>/dev/null || true",
-              "docker compose up -d --force-recreate --remove-orphans",
-              "docker image prune -f",
-              "docker compose exec -T backend python -m archimedes.scripts.seed_backtests_from_artifacts || echo WARN_SEED_SKIP",
-              "docker compose exec -T backend python scripts/import_backtest_fixtures.py tests/fixtures/backtest_fixtures_snapshot.json || echo WARN_FIXTURES_SKIP",
-              "docker compose exec -dT backend python -m archimedes.scripts.hydrate_corpus || echo WARN_HYDRATE_SKIP",
-              "docker compose exec -T backend python -c '"'"'import asyncio; from archimedes.services.amm_bootstrap import bootstrap_amm_liquidity; r=asyncio.run(bootstrap_amm_liquidity()); print(dict(r))'"'"' || echo WARN_BOOTSTRAP_SKIP",
-              "for i in $(seq 1 24); do if docker compose exec -T backend python -c '"'"'import urllib.request; r=urllib.request.urlopen(\"http://localhost:8000/health\", timeout=5); print(r.read().decode()[:80])'"'"'; then echo HEALTH_OK after ${i}x5s; break; fi; if [ $i -eq 24 ]; then echo HEALTH_TIMEOUT after 120s; exit 1; fi; sleep 5; done",
-              "echo DEPLOY_COMPLETE"
-            ]' \
-            --region "$AWS_REGION" \
-            --query 'Command.CommandId' \
-            --output text)
-
-          echo "SSM Command ID: $COMMAND_ID"
-
-          # Poll for completion (180 × 10s = 30 min, matches SSM --timeout-seconds 1800)
-          for i in $(seq 1 180); do
-            STATUS=$(aws ssm get-command-invocation \
-              --command-id "$COMMAND_ID" \
-              --instance-id "$EC2_INSTANCE_ID" \
-              --region "$AWS_REGION" \
-              --query 'Status' \
-              --output text 2>/dev/null || echo "Pending")
-
-            if [ "$STATUS" = "Success" ]; then
-              echo "✅ Deploy succeeded"
-              # Print output
-              aws ssm get-command-invocation \
-                --command-id "$COMMAND_ID" \
-                --instance-id "$EC2_INSTANCE_ID" \
-                --region "$AWS_REGION" \
-                --query 'StandardOutputContent' \
-                --output text | tail -20
-              exit 0
-            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "TimedOut" ] || [ "$STATUS" = "Cancelled" ]; then
-              echo "❌ Deploy $STATUS"
-              aws ssm get-command-invocation \
-                --command-id "$COMMAND_ID" \
-                --instance-id "$EC2_INSTANCE_ID" \
-                --region "$AWS_REGION" \
-                --query '{Stdout:StandardOutputContent,Stderr:StandardErrorContent}' \
-                --output json | tail -50
-              exit 1
-            fi
-
-            echo "Status: $STATUS (attempt $i/60)"
-            sleep 10
-          done
-
-          echo "❌ Deploy timed out waiting for SSM command"
-          exit 1
 
   deploy-ecs:
     needs: [build-and-push, migrate]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -73,6 +73,12 @@ RUN HF_HUB_OFFLINE=0 PYTHONPATH=/deps python -c \
     "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['MINILM_MODEL'])" \
     && chown -R nonroot:nonroot /app/model_cache
 
+# Build provenance (issue #1039): stamp the git SHA in at build time so /health
+# reports it as "version" — "which code is live" in one glance. deploy.yml passes
+# --build-arg GIT_SHA=${{ github.sha }}; defaults to "dev" for local builds.
+ARG GIT_SHA=dev
+ENV ARCHIMEDES_GIT_SHA=${GIT_SHA}
+
 ENV PYTHONPATH=/deps:/app
 WORKDIR /app
 

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -575,6 +575,18 @@ async def health():
     except Exception:
         risk_data_reason = "import failed"
 
+    # Strategy-library presence (issue #1039). The provider reads the curated
+    # library from analytics-engine/strategies, baked into the image. 0 here means
+    # the library is missing from the build — the exact regression that shipped a
+    # strategy-less Fargate image (→ risk_data=mock, empty Explore). CI asserts > 0.
+    strategy_count = 0
+    try:
+        from archimedes.services.strategy_provider import default_provider
+
+        strategy_count = len(list(default_provider().list_strategies()))
+    except Exception:
+        logger.debug("strategy count read failed", exc_info=True)
+
     # Human-vs-agent traction counts (issue #428). Fail-safe: get_counts
     # returns (0, 0) when Redis is unreachable, so /health never degrades on it.
     # NOTE: these are cumulative per-request tallies (site traffic, NOT users).
@@ -645,6 +657,10 @@ async def health():
     return {
         "status": "ok" if connected else "degraded",
         "service": "archimedes-backend",
+        # Build provenance (issue #1039): the git SHA stamped in at image-build
+        # time (deploy.yml --build-arg GIT_SHA). "Which code is live?" in one glance
+        # — the question that turned the Fargate cutover into an hour of forensics.
+        "version": os.getenv("ARCHIMEDES_GIT_SHA", "dev"),
         "chain_connected": connected,
         # human_count / agent_count are cumulative per-request tallies (site
         # traffic, NOT users). real_users is the honest distinct-user count.
@@ -679,6 +695,9 @@ async def health():
         "regime_detector_reason": regime_detector_reason,
         "risk_data": risk_data_status,
         "risk_data_reason": risk_data_reason,
+        # Strategy-library presence (issue #1039) — 0 means the image is missing
+        # analytics-engine/strategies (the Fargate-cutover regression). CI gates on > 0.
+        "strategy_count": strategy_count,
     }
 
 

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -575,15 +575,17 @@ async def health():
     except Exception:
         risk_data_reason = "import failed"
 
-    # Strategy-library presence (issue #1039). The provider reads the curated
-    # library from analytics-engine/strategies, baked into the image. 0 here means
-    # the library is missing from the build — the exact regression that shipped a
-    # strategy-less Fargate image (→ risk_data=mock, empty Explore). CI asserts > 0.
+    # Strategy-library presence (issue #1039). count_strategy_files() is a cheap
+    # directory file count (NO provider construction → no filesystem refresh, DB
+    # backtest load, or unified-table sync side effect — /health is hit by the ALB
+    # every 30s). 0 here means the curated library is missing from the image — the
+    # exact regression that shipped a strategy-less Fargate build (→ risk_data=mock,
+    # empty Explore). CI asserts > 0.
     strategy_count = 0
     try:
-        from archimedes.services.strategy_provider import default_provider
+        from archimedes.services.strategy_provider import count_strategy_files
 
-        strategy_count = len(list(default_provider().list_strategies()))
+        strategy_count = count_strategy_files()
     except Exception:
         logger.debug("strategy count read failed", exc_info=True)
 

--- a/backend/archimedes/services/strategy_provider.py
+++ b/backend/archimedes/services/strategy_provider.py
@@ -645,28 +645,32 @@ class LocalStrategyProvider:
         return None
 
 
-def default_provider(repo_root: Path | None = None) -> LocalStrategyProvider:
-    """Resolve the strategies directory robustly across host and container.
+def resolve_strategies_dir(repo_root: Path | None = None) -> Path:
+    """Resolve the strategies directory robustly across host and container —
+    WITHOUT constructing a provider.
 
     Priority:
       1. explicit ``repo_root`` arg (tests)
-      2. ``ARCHIMEDES_STRATEGIES_DIR`` env var — the deployment override;
-         set it (or bind-mount to it) in docker-compose / EC2 so the
-         backend image does not have to vendor the strategy corpus
+      2. ``ARCHIMEDES_STRATEGIES_DIR`` env var — the deployment override
       3. first existing candidate among the known host repo layout and
          container-plausible mount points
 
-    The original ``parents[3]`` math only holds for the host checkout
-    layout — in the backend image ``__file__`` is ``/app/...`` so it
-    resolved to a nonexistent ``/analytics-engine/strategies``. This keeps
-    host dev identical while making the deployed path configurable.
+    Factored out of ``default_provider`` (issue #1039) so cheap callers — the
+    ``/health`` ``strategy_count`` probe — can locate the corpus without paying
+    for ``LocalStrategyProvider`` construction (filesystem refresh + DB backtest
+    load + a one-time unified-table sync side effect on every call).
+
+    The original ``parents[3]`` math only holds for the host checkout layout —
+    in the backend image ``__file__`` is ``/app/...`` so it resolved to a
+    nonexistent ``/analytics-engine/strategies``. This keeps host dev identical
+    while making the deployed path configurable.
     """
     if repo_root is not None:
-        return LocalStrategyProvider(repo_root / "analytics-engine" / "strategies")
+        return repo_root / "analytics-engine" / "strategies"
 
     env_dir = os.getenv("ARCHIMEDES_STRATEGIES_DIR")
     if env_dir:
-        return LocalStrategyProvider(Path(env_dir))
+        return Path(env_dir)
 
     here = Path(__file__).resolve()
     candidates = [
@@ -676,7 +680,32 @@ def default_provider(repo_root: Path | None = None) -> LocalStrategyProvider:
     ]
     for candidate in candidates:
         if candidate.exists():
-            return LocalStrategyProvider(candidate)
-    # None found: fall back to the host-layout path so the warning log
-    # names a sensible location rather than an arbitrary container root.
-    return LocalStrategyProvider(candidates[0])
+            return candidate
+    # None found: fall back to the host-layout path so the warning log names a
+    # sensible location rather than an arbitrary container root.
+    return candidates[0]
+
+
+def count_strategy_files() -> int:
+    """Cheap count of baked strategy files in the resolved strategies dir.
+
+    Counts ``*.py`` (excluding dunder helpers like ``__init__``), mirroring how
+    ``LocalStrategyProvider`` discovers strategies (``glob("*.py")``) — but with
+    NO filesystem refresh, DB load, or table sync. Used by ``/health`` to detect
+    whether the strategy corpus is baked into the image: ``0`` means it is
+    missing from the build (the Fargate-cutover regression, issue #1039).
+    """
+    d = resolve_strategies_dir()
+    if not d.exists():
+        return 0
+    return sum(1 for p in d.glob("*.py") if not p.name.startswith("_"))
+
+
+def default_provider(repo_root: Path | None = None) -> LocalStrategyProvider:
+    """Construct a ``LocalStrategyProvider`` over the resolved strategies dir.
+
+    Directory resolution lives in ``resolve_strategies_dir`` (shared with the
+    cheap ``count_strategy_files`` probe). See that function for the resolution
+    priority and the container-vs-host path rationale.
+    """
+    return LocalStrategyProvider(resolve_strategies_dir(repo_root))

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -237,6 +237,13 @@ class TestRootAndHealth:
         data = resp.json()
         assert data["service"] == "archimedes-backend"
         assert "status" in data
+        # Observability fields (issue #1039): build provenance ("version" = git
+        # SHA baked at build time, or "dev" locally) + strategy-library presence
+        # ("strategy_count"). Both are surfaced on /health and gated in CI so a
+        # strategy-less / gmm-less image can't ship silently degraded again.
+        assert "version" in data
+        assert "strategy_count" in data
+        assert isinstance(data["strategy_count"], int)
 
 
 # NOTE: TestFrontierRoutes and TestCorrelationRoutes were removed in the wake


### PR DESCRIPTION
## Summary

Fast-follow after the Fargate restore (#1057). Closes out #1039's operational tail with three changes so the silent-degradation class of bug we just hit can't recur — and so deploys go **green** again.

### 1. Retire the legacy EC2 SSM `deploy` job
Post-cutover the EC2 box is **detached from the ALB**, so auto-deploying to it is pointless. Worse, its "Deploy via SSM SendCommand" step had a shell syntax error (`line 41: token '('`) that reddened **every** deploy run (masking real failures) while `deploy-ecs` (Fargate) succeeded. Removed. Jobs are now `build-and-push → migrate → deploy-ecs`. The box stays running as a rollback window until Phase 8 decommission.

### 2. Version stamp on `/health` (your ask)
- `Dockerfile`: `ARG GIT_SHA=dev` → `ENV ARCHIMEDES_GIT_SHA`
- `deploy.yml`: `--build-arg GIT_SHA=${{ github.sha }}`
- `/health` reports `"version"` → "which code is live" in one glance (the question that turned the cutover into an hour of forensics).

### 3. Rich-health CI gate (your ask)
The build validation asserted only `GET /health` → 200, so a strategy-less / gmm-less image shipped **silently degraded** past it. Now:
- `/health` also reports `"strategy_count"`
- CI asserts `regime_detector != degraded` **AND** `strategy_count > 0` (jq)

These are **image-baked** features, so they're valid to assert in CI. `risk_data` is deliberately **not** asserted — CI's throwaway Postgres is empty, so `risk_data=mock` is correct there; it's validated post-deploy against Aurora.

## Verified locally
```
build --build-arg GIT_SHA=fastfollow-abc123
/health → version=fastfollow-abc123, strategy_count=34, regime=live
CI jq gate → PASS (regime=live strategy_count=34)
deploy.yml → valid YAML; jobs: build-and-push → migrate → deploy-ecs
ruff format + critical-lint → clean; test_api_routes::test_health → passes
```

## Notes / follow-ups (not in this PR)
- The header block still carries a couple of now-moot EC2 references (`EC2_INSTANCE_ID`, box-side ECR prereq); left as-is to keep the diff focused — cheap cleanup later.
- corpus KB artifact (`corpus_artifact_present:false`) + the `capital_preservation_tbill.py POSITION_SIZING` warning remain as separate cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M