### PR TITLE
[infra] Aurora master_password ignore_changes — de-risk the 18.3 upgrade (#777)

### DIFF
--- a/infra/aurora.tf
+++ b/infra/aurora.tf
@@ -107,6 +107,19 @@ resource "aws_rds_cluster" "main" {
   tags = {
     Project = var.project_name
   }
+
+  # Do NOT let terraform rotate the master password as a side effect of other
+  # cluster applies (e.g. the 16.4 -> 18.3 engine upgrade). The password is
+  # bootstrapped once at creation from TF_VAR_aurora_master_password. If that env
+  # var drifts from the live value at plan time, terraform shows a spurious
+  # `~ master_password` diff and an apply would RESET the live password —
+  # breaking the backend's DATABASE_URL (seeded in SSM) and taking prod down.
+  # Ignoring it decouples the password from every other cluster change. To
+  # deliberately rotate, do it out-of-band (aws rds modify-db-cluster) and update
+  # the SSM DATABASE_URL / AURORA_MASTER_PASSWORD params in lockstep. (#777/#1039)
+  lifecycle {
+    ignore_changes = [master_password]
+  }
 }
 
 resource "aws_rds_cluster_instance" "main" {


### PR DESCRIPTION
## Summary

Pre-work to make the Aurora 16.4 → 18.3 upgrade safe to apply.

The upgrade plan showed a **`~ master_password = (sensitive value)`** change alongside the `engine_version` bump. Because `master_password = var.aurora_master_password` (set via `TF_VAR_aurora_master_password`), that diff means the env var **drifted from the live value** at plan time. Applying it would **reset the live Aurora master password** → the backend's SSM `DATABASE_URL` stops matching → **prod outage** — folded into what should be an engine-only upgrade.

## Fix
`lifecycle { ignore_changes = [master_password] }` on `aws_rds_cluster.main` — Terraform no longer rotates the password as a side effect of any cluster apply. Deliberate rotation stays possible out-of-band (`aws rds modify-db-cluster`) with the SSM params updated in lockstep.

**After this, the upgrade plan is `engine_version`-only** (+ the destroy-time snapshot attrs, which don't change infra).

## Verify
`terraform validate` → Success; `terraform fmt` clean. Post-merge, `terraform plan` should show `~ engine_version 16.4 -> 18.3` on the cluster + instance and **no** `master_password` line.

## Anti-goals
- Does NOT change the engine version target, `apply_immediately`, or snapshot settings (those already landed).
- Does NOT rotate or read the password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M