### PR TITLE
[frontend] Livestream UI prep: promote Strategy name + hide Quant Lab

### DIFF
--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -181,6 +181,23 @@ export default function Generate({ onNavigate, walletAddr }) {
 
       {/* ── 2. BRIEF INPUT + SUBMIT ── */}
       <div className="card p-5 mb-4">
+        {/* Strategy name — promoted from Advanced options so it's seen before the brief */}
+        <div className="mb-3">
+          <div className="label mb-1">Strategy name (optional)</div>
+          <input
+            type="text"
+            value={strategyName}
+            onChange={e => setStrategyName(e.target.value)}
+            placeholder="Leave blank — backend auto-derives a name"
+            maxLength={80}
+            className="chat-input w-full px-2.5 py-1.5"
+            disabled={starting}
+          />
+          <p className="caption mt-1" style={{ color: 'var(--text-3)' }}>
+            Short and memorable — leave blank to auto-name. {strategyName.length}/80
+          </p>
+        </div>
+
         <div className="label mb-1">Your brief</div>
         <p className="caption mb-2" style={{ color: 'var(--text-3)' }}>
           A good brief names concrete assets or classes, a mechanism (momentum /
@@ -252,7 +269,7 @@ export default function Generate({ onNavigate, walletAddr }) {
               className={`${advancedOpen ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3.5 h-3.5`}
             />
             Advanced options
-            {(selectedAssets.length > 0 || strategyName || riskAppetite !== 'moderate' || depth !== 5) && (
+            {(selectedAssets.length > 0 || riskAppetite !== 'moderate' || depth !== 5) && (
               <span className="tag tag-accent" style={{ fontSize: '0.7rem', padding: '1px 6px' }}>
                 active
               </span>
@@ -290,20 +307,6 @@ export default function Generate({ onNavigate, walletAddr }) {
                     ))}
                   </select>
                 </label>
-              </div>
-
-              {/* Strategy name */}
-              <div className="mb-3">
-                <div className="label mb-1" style={{ fontSize: '0.82rem' }}>Strategy name (optional)</div>
-                <input
-                  type="text"
-                  value={strategyName}
-                  onChange={e => setStrategyName(e.target.value)}
-                  placeholder="Leave blank — backend auto-derives a name"
-                  maxLength={80}
-                  className="chat-input w-full px-2.5 py-1.5"
-                  disabled={starting}
-                />
               </div>
 
               {/* Asset picker */}

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -29,7 +29,8 @@ const NAV = [
   { group: 'Strategy', items: [
     { id: 'generate', label: 'Generate', icon: 'i-lucide-sparkles' },
     { id: 'library',  label: 'Library',  icon: 'i-lucide-line-chart' },
-    { id: 'quant',    label: 'Quant Lab', icon: 'i-lucide-flask-conical' },
+    // Quant Lab hidden from nav for the livestream — renders synthetic sample data;
+    // route/component intact, reachable by direct URL. Re-enable + wire to live data: see tracking issue.
   ]},
   { group: 'Position', items: [
     { id: 'portfolio', label: 'Portfolio', icon: 'i-lucide-layout-dashboard' },

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -30,7 +30,7 @@ const NAV = [
     { id: 'generate', label: 'Generate', icon: 'i-lucide-sparkles' },
     { id: 'library',  label: 'Library',  icon: 'i-lucide-line-chart' },
     // Quant Lab hidden from nav for the livestream — renders synthetic sample data;
-    // route/component intact, reachable by direct URL. Re-enable + wire to live data: see tracking issue.
+    // route/component intact, reachable by direct URL. Re-enable + wire to live data: see issue #1060.
   ]},
   { group: 'Position', items: [
     { id: 'portfolio', label: 'Portfolio', icon: 'i-lucide-layout-dashboard' },


### PR DESCRIPTION
Two demo-readiness UI changes ahead of the Circle livestream. **Frontend-only, no backend/schema change.**

### 1. Promote the "Strategy name" input on Generate
The field already existed and was wired to `brief.name` (80-char backend limit via `GenerateBrief`), but it was buried inside the **collapsed "Advanced options"** section — so users (incl. Dan) never saw it, and strategies ended up auto-named (sometimes after a source paper's title). Moved it to a **primary field directly above "Your brief"** with a live `N/80` char counter. `brief.name` plumbing unchanged. Also dropped `strategyName` from the Advanced-options "active" badge condition (it no longer lives there).

### 2. Hide "Quant Lab" from the sidebar nav
`/quant` renders **100% synthetic sample data** (mock VaR / efficient frontier / `MOCK_DRIFT` / 14 fabricated trade-log rows) with only one easy-to-miss disclaimer — a claim-integrity risk on a public livestream. Removed the nav entry only; **route + component + PAGE_LABELS left intact** (reachable by direct URL, trivially re-enableable). Proper fix (wire-to-live or per-section badges) tracked in #1060.

### Testing
- `eslint src/components/Generate.jsx src/components/Layout.jsx` → clean.
- Verified `brief.name` send path and `strategyName` state untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)