### PR TITLE
[marketplace] Fix: generated strategies can't be published/subscribed (curated-only 404)

### DIFF
--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -13,7 +13,6 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.exc import IntegrityError
 
-from archimedes.api._route_helpers import strategy_provider
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
 from archimedes.db import get_session
@@ -77,9 +76,14 @@ async def publish_strategy(
             detail="Marketplace not configured: ARCHIMEDES_TREASURY_WALLET is unset",
         )
 
-    # 0. Validate strategy exists in the provider
-    if strategy_provider().get_strategy(strategy_id) is None:
-        raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+    # NOTE: existence is validated authoritatively against StrategyRecord in the
+    # D5 ownership block below (§1a). We deliberately do NOT gate on
+    # strategy_provider().get_strategy() here: that provider is the curated,
+    # file-backed LocalStrategyProvider (examples only), so an early guard on it
+    # 404s every *generated* strategy before the real StrategyRecord check can
+    # run — which is exactly the "I can't publish my strategy" bug. Curated
+    # examples are also seeded into StrategyRecord (main.py is_example=True), so
+    # the StrategyRecord check covers both curated and generated strategies.
 
     # 1. Reject if publisher already running for this strategy
     with get_session() as session:
@@ -279,9 +283,11 @@ async def subscribe_strategy(
     if int(sub_id, 16) == 0:
         raise HTTPException(status_code=400, detail="sub_id cannot be zero")
 
-    # 0b. Validate strategy exists in the provider (M2)
-    if strategy_provider().get_strategy(strategy_id) is None:
-        raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+    # NOTE: existence is validated by the running-publisher check below — you can
+    # only subscribe to a strategy that has a live publisher. We do NOT gate on
+    # strategy_provider().get_strategy() (curated, file-backed examples only): that
+    # 404s every *generated* strategy that was published, breaking subscribe on
+    # exactly the strategies the marketplace exists to distribute.
 
     # 1. Find the publisher
     pub_row = None

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -30,17 +30,6 @@ def _treasury_wallet(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _mock_strategy_provider():
-    """Patch strategy_provider.get_strategy to return a truthy value for test IDs."""
-    with patch("archimedes.api.marketplace_routes.strategy_provider") as mock:
-        # strategy_provider is the lru_cache'd FACTORY (post-#863 lazy
-        # singleton) — routes call strategy_provider().get_strategy(...).
-        # Yield the inner provider so tests configure .get_strategy directly.
-        mock.return_value.get_strategy.return_value = MagicMock(id="test_strat")
-        yield mock.return_value
-
-
-@pytest.fixture(autouse=True)
 def _seed_strategy_records(_setup_db):
     """Insert minimal StrategyRecord rows so the D5 ownership check doesn't 404.
 
@@ -51,7 +40,15 @@ def _seed_strategy_records(_setup_db):
     from archimedes.db import get_session
     from archimedes.models.strategy_store import StrategyRecord
 
-    _STRATEGY_IDS = ["test_strat", "dup_strat", "check_pool", "dup_sid_strat", "redact_strat", "refund_strat"]
+    _STRATEGY_IDS = [
+        "test_strat",
+        "dup_strat",
+        "check_pool",
+        "dup_sid_strat",
+        "redact_strat",
+        "refund_strat",
+        "gen_strat",
+    ]
     with get_session() as session:
         for i, sid in enumerate(_STRATEGY_IDS):
             if session.query(StrategyRecord).filter_by(id=sid).first() is None:
@@ -134,14 +131,36 @@ def client(app):
     return TestClient(app)
 
 
-def test_publish_rejects_unknown_strategy(client, _mock_strategy_provider):
-    """Publish with a non-existent strategy_id returns 404."""
-    _mock_strategy_provider.get_strategy.return_value = None
+def test_publish_rejects_unknown_strategy(client):
+    """Publish with a strategy_id that has no StrategyRecord returns 404.
+
+    Existence is validated against StrategyRecord (not the curated-only, file-backed
+    LocalStrategyProvider), so an id that was never generated or seeded 404s. "nonexistent"
+    is deliberately absent from _seed_strategy_records.
+    """
     resp = client.post(
         "/api/marketplace/publish",
         json={"strategy_id": "nonexistent", "vault_address": "0xvault"},
     )
     assert resp.status_code == 404, resp.text
+
+
+def test_publish_generated_strategy_not_in_curated_provider(client):
+    """A GENERATED strategy (is_example=False, not a curated file id) must be publishable.
+
+    Regression: publish previously gated on strategy_provider().get_strategy() — the
+    curated-only file provider — BEFORE the real StrategyRecord check, so every generated
+    strategy 404'd "Strategy not found". "gen_strat" is seeded as a StrategyRecord with
+    is_example=False and is not a curated file id, so a 200 here proves existence resolves
+    from StrategyRecord, not the file provider.
+    """
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "gen_strat", "vault_address": "0xvault_gen"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["strategy_id"] == "gen_strat"
+    assert resp.json()["role"] == "publisher"
 
 
 def test_publish_creates_publisher_row(client):

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -154,6 +154,12 @@ def test_publish_generated_strategy_not_in_curated_provider(client):
     is_example=False and is not a curated file id, so a 200 here proves existence resolves
     from StrategyRecord, not the file provider.
     """
+    # The test name's premise, made explicit: gen_strat is genuinely absent from the
+    # curated file provider — so the 200 below can only come from the StrategyRecord path.
+    from archimedes.api._route_helpers import strategy_provider
+
+    assert strategy_provider().get_strategy("gen_strat") is None
+
     resp = client.post(
         "/api/marketplace/publish",
         json={"strategy_id": "gen_strat", "vault_address": "0xvault_gen"},


### PR DESCRIPTION
## Problem (demo-blocker for the generate→deploy→publish→subscribe loop)
`POST /api/marketplace/publish` and `/subscribe` each ran an **early existence guard against the curated-only, file-backed `LocalStrategyProvider`** (`strategy_provider().get_strategy()`) *before* the authoritative checks. Every **generated** strategy (a `StrategyRecord` row, not a curated file) therefore 404'd `"Strategy not found"` — so a user could never publish a strategy they generated, and no generated strategy could be subscribed to.

Confirmed live: `POST /api/marketplace/publish` on a generated strategy → 404.

## Fix
Remove both redundant curated-only guards. Existence is already validated authoritatively downstream:
- **publish**: the D5 ownership block queries `StrategyRecord` (404 if absent).
- **subscribe**: the running-publisher check (you can only subscribe to a strategy with a live publisher).

Curated examples are **also** seeded into `StrategyRecord` at startup (`main.py`, `is_example=True`), so the `StrategyRecord` path covers curated **and** generated strategies. Also removed the now-unused `strategy_provider` import.

## Tests
- Deleted the dead `_mock_strategy_provider` autouse fixture (it patched the removed import).
- Rewired `test_publish_rejects_unknown_strategy` to rely on `StrategyRecord` absence.
- Added `test_publish_generated_strategy_not_in_curated_provider` as an explicit regression.
- ✅ 15/15 marketplace-route tests pass; 94 ownership + marketplace-service tests unaffected; ruff (blocking subset) + format clean.

## Coordination
Part of the generate→deploy→publish loop fixes. Publish still requires the Circle/marketplace secrets to be present in the Fargate env (`infra/ecs.tf`) to complete on-chain — see `docs/T32-COORDINATION-DELTA-2026-07-08.md` §2. This PR fixes the **code** 404; the env gap is the T3.2/infra track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)