### PR TITLE
[marketplace] Enforce PAYMENTS_DRY_RUN inside SettlementSweeper (close withdraw bypass)

### DIFF
--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -636,6 +636,13 @@ async def withdraw_publisher_earnings(
     if pub is None:
         raise HTTPException(status_code=404, detail="No publisher row found for this strategy/wallet")
 
+    # Fail-safe: no real settlement while PAYMENTS_DRY_RUN is on. The sweeper
+    # methods also short-circuit under dry-run (defense in depth); return here so
+    # the API responds with an honest no-op rather than a misleading 502 when
+    # withdraw_publisher returns None.
+    if market.payments_dry_run:
+        return {"status": "dry_run_noop", "detail": "PAYMENTS_DRY_RUN enabled — no on-chain settlement performed."}
+
     sweeper = market._sweeper
     await sweeper.sweep_publisher(pub)  # Stage A + B, refresh pool state
 

--- a/backend/archimedes/marketplace/service.py
+++ b/backend/archimedes/marketplace/service.py
@@ -205,7 +205,7 @@ class MarketService:
         self._stop = asyncio.Event()
         # Regime detection (same pattern as agent_runner)
         self.oracle = OracleUpdater()
-        self._sweeper = SettlementSweeper(self.settings)
+        self._sweeper = SettlementSweeper(self.settings, payments_dry_run=payments_dry_run)
         self.regime_detector: IRegimeDetector = GmmRegimeDetector(fallback=VixRegimeDetector())
         # Position sizer — throttles raw weights by regime + consensus
         self.portfolio_constructor: PortfolioConstructor = PortfolioConstructor()

--- a/backend/archimedes/marketplace/settlement.py
+++ b/backend/archimedes/marketplace/settlement.py
@@ -43,8 +43,13 @@ class SettlementSweeper:
     so the Circle SDK client is initialised once per publisher.
     """
 
-    def __init__(self, settings):
+    def __init__(self, settings, payments_dry_run: bool = False):
         self._settings = settings
+        # Fail-safe: when dry-run is on, every fund-moving method short-circuits so
+        # NO caller can move real value. Gating lives HERE (not only at call sites)
+        # so a future caller can't forget it — the manual withdraw endpoint (M1')
+        # did exactly that, bypassing PAYMENTS_DRY_RUN on a real on-chain path.
+        self._payments_dry_run = payments_dry_run
         self._signers: dict[str, CircleWalletSigner] = {}
         self._executors: dict[str, CircleTxExecutor] = {}
 
@@ -67,6 +72,11 @@ class SettlementSweeper:
     async def sweep_publisher(self, pub) -> None:
         """Run both sweep stages for *pub*.  Each stage is independently
         try/except'd so one failure never blocks the other."""
+        if self._payments_dry_run:
+            logger.info(
+                "[%s] sweep_publisher: PAYMENTS_DRY_RUN — skipping real settlement", getattr(pub, "strategy_id", "?")
+            )
+            return
         if not pub.agent_wallet_id or not pub.gateway_seller_address:
             logger.warning(
                 "Skipping sweep for %s — missing agent_wallet_id or gateway_seller_address",
@@ -186,6 +196,13 @@ class SettlementSweeper:
         Callable regardless of pool.active (D6 §2.5); caller no longer needs to be
         pool.creator/platform (see PaymentSplitter.vy withdraw docstring, changed 2026-07-03).
         """
+        if self._payments_dry_run:
+            logger.info(
+                "[%s] withdraw_publisher: PAYMENTS_DRY_RUN — skipping real withdraw of %d raw",
+                getattr(pub, "strategy_id", "?"),
+                amount_raw,
+            )
+            return None
         try:
             executor = self._get_executor(pub.agent_wallet_id, pub.gateway_seller_address)
             splitter = self._settings.payment_splitter_address
@@ -220,6 +237,9 @@ class SettlementSweeper:
         always completes; a failed sweep leaves the balance recoverable by a
         later retry.
         """
+        if self._payments_dry_run:
+            logger.info("withdraw_subscriber: PAYMENTS_DRY_RUN — skipping real return for sub %s", sub_id)
+            return None
         if not circle_wallet_id or not dcw_address or not to_wallet:
             return None
         try:

--- a/backend/tests/marketplace/test_settlement.py
+++ b/backend/tests/marketplace/test_settlement.py
@@ -43,6 +43,50 @@ def splitter_addr():
     return "0xSplitter0000000000000000000000000000000001"
 
 
+# ── PAYMENTS_DRY_RUN guard (issue: manual withdraw endpoint bypassed dry-run) ──
+# Every fund-moving method must be an inert no-op under dry-run, moving no real
+# value and never touching a signer/executor/RPC. The guard lives in the sweeper
+# so no caller can forget it.
+
+
+async def test_dry_run_sweep_publisher_is_noop(settings, pub):
+    """Under PAYMENTS_DRY_RUN, sweep_publisher moves no value — no signer/executor touched."""
+    sweeper = SettlementSweeper(settings, payments_dry_run=True)
+    sweeper._get_signer = MagicMock(side_effect=AssertionError("signer must not run under dry-run"))
+    sweeper._get_executor = MagicMock(side_effect=AssertionError("executor must not run under dry-run"))
+    result = await sweeper.sweep_publisher(pub)
+    assert result is None
+    sweeper._get_signer.assert_not_called()
+    sweeper._get_executor.assert_not_called()
+
+
+async def test_dry_run_withdraw_publisher_returns_none_without_chain_call(settings, pub):
+    """Stage C (PaymentSplitter.withdraw) is skipped entirely under dry-run."""
+    sweeper = SettlementSweeper(settings, payments_dry_run=True)
+    sweeper._get_executor = MagicMock(side_effect=AssertionError("executor must not run under dry-run"))
+    tx = await sweeper.withdraw_publisher(pub, 5_000_000)
+    assert tx is None
+    sweeper._get_executor.assert_not_called()
+
+
+async def test_dry_run_withdraw_subscriber_returns_none_without_chain_call(settings):
+    """Subscriber DCW return-transfer is skipped entirely under dry-run."""
+    sweeper = SettlementSweeper(settings, payments_dry_run=True)
+    sweeper._get_executor = MagicMock(side_effect=AssertionError("executor must not run under dry-run"))
+    sweeper._usdc_balance_of = MagicMock(side_effect=AssertionError("balance read must not run under dry-run"))
+    tx = await sweeper.withdraw_subscriber(
+        circle_wallet_id="w-1", dcw_address="0xdcw", to_wallet="0xto", sub_id="sub-1"
+    )
+    assert tx is None
+    sweeper._get_executor.assert_not_called()
+
+
+def test_sweeper_defaults_to_live_mode(settings):
+    """Constructing without the flag keeps live behavior (backwards-compatible)."""
+    assert SettlementSweeper(settings)._payments_dry_run is False
+    assert SettlementSweeper(settings, payments_dry_run=True)._payments_dry_run is True
+
+
 # ── Stage A: Gateway balance below threshold → no withdraw ──────────────
 
 

--- a/backend/tests/marketplace/test_settlement.py
+++ b/backend/tests/marketplace/test_settlement.py
@@ -49,6 +49,7 @@ def splitter_addr():
 # so no caller can forget it.
 
 
+@pytest.mark.asyncio
 async def test_dry_run_sweep_publisher_is_noop(settings, pub):
     """Under PAYMENTS_DRY_RUN, sweep_publisher moves no value — no signer/executor touched."""
     sweeper = SettlementSweeper(settings, payments_dry_run=True)
@@ -60,6 +61,7 @@ async def test_dry_run_sweep_publisher_is_noop(settings, pub):
     sweeper._get_executor.assert_not_called()
 
 
+@pytest.mark.asyncio
 async def test_dry_run_withdraw_publisher_returns_none_without_chain_call(settings, pub):
     """Stage C (PaymentSplitter.withdraw) is skipped entirely under dry-run."""
     sweeper = SettlementSweeper(settings, payments_dry_run=True)
@@ -69,6 +71,7 @@ async def test_dry_run_withdraw_publisher_returns_none_without_chain_call(settin
     sweeper._get_executor.assert_not_called()
 
 
+@pytest.mark.asyncio
 async def test_dry_run_withdraw_subscriber_returns_none_without_chain_call(settings):
     """Subscriber DCW return-transfer is skipped entirely under dry-run."""
     sweeper = SettlementSweeper(settings, payments_dry_run=True)


### PR DESCRIPTION
## Problem (red-team CRITICAL, verified)
`POST /api/marketplace/publish/{id}/withdraw` (manual creator disbursement, M1') called `sweeper.sweep_publisher()` + `sweeper.withdraw_publisher()` with **no `payments_dry_run` gate**. Every other fund-moving call site (`_charge_one`, the settlement sweep tick, `refund_subscriber`) checks the flag — this one caller forgot it. With a nonzero on-chain balance it would execute **real** USDC movement (Gateway withdraw → `depositToPool` → `PaymentSplitter.withdraw`) during a period `PAYMENTS_DRY_RUN=true` says must be fully inert. `main.py` states this invariant must hold platform-wide.

Blast radius is low today (fresh publishers have empty wallets), but it's a structural safety-invariant hole on a real money path.

## Fix
Push the guard **into `SettlementSweeper`** so no future caller can forget it:
- Constructor takes `payments_dry_run`; `sweep_publisher`, `withdraw_publisher`, `withdraw_subscriber` each short-circuit to an inert no-op under dry-run (no signer / executor / RPC touched).
- `MarketService` wires its own `payments_dry_run` into the sweeper.
- The withdraw endpoint also returns an honest `dry_run_noop` early (defense in depth) instead of a misleading 502 when `withdraw_publisher` returns `None`.

## Tests
Added hermetic guard tests asserting each fund-moving method is a no-op under dry-run **without touching a signer/executor/balance read** (side-effect asserts), plus a default-live-mode check. ✅ 81 marketplace tests pass; ruff (blocking subset) + format clean.

Note: `PAYMENTS_DRY_RUN` stays `true` in prod until #975 regardless — this hardens that guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)