### PR TITLE
[rigor] Deploy gate: grade generated strategies on their own context (unblock deploy)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1433,7 +1433,20 @@ async def _persist_real_returns(c: _CandidateResult, strategy_id: str, emit: _Em
         content_hash = hashlib.sha256(artifact_json.encode("utf-8")).hexdigest()
         # The live gate is the single source of truth: re-grade the REAL returns so the
         # persisted passes_rigor_gate matches what verdicts_for_strategies computes.
-        live = verdict_from_returns(strategy_id, returns, num_trials=int(num_trials))
+        # look_ahead_audit_passed threads the closed-DSL self-attestation computed
+        # above (result.look_ahead_audit_passed, from rv["lookahead_audit_passed"])
+        # through to the gate. Without this, strategy_code=None (this path has no
+        # inspectable source for the AST audit) left the gate's look_ahead_passed
+        # unconditionally False — an always-on floor failure that blocked deploy at
+        # EVERY strictness level regardless of DSR/PBO/OOS, no matter how strong the
+        # strategy. See live_rigor_gate.verdict_from_returns's docstring for why this
+        # matches the accepted DSL self-attestation policy (fusion_evaluator.py).
+        live = verdict_from_returns(
+            strategy_id,
+            returns,
+            num_trials=int(num_trials),
+            look_ahead_audit_passed=result.look_ahead_audit_passed,
+        )
 
         with get_session() as session:
             insert_backtest_if_missing(

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -510,6 +510,16 @@ def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: in
         # run_rigor_gate treats fail-closed (criterion 4 FAILs rather than
         # silently passing) — exactly the same fail-closed contract the curated
         # path relies on.
+        #
+        # NOTE: pbo_library_size is intentionally left unset (None) below. That
+        # parameter powers run_rigor_gate's PBO power-floor, which RELAXES
+        # criterion 4 when the PBO estimate is drawn from too small a cohort to be
+        # trustworthy. A single generated strategy has no such cohort, and we hold
+        # Dan's principle that a strategy's rigor must be measured on ITS OWN
+        # context — so we deliberately grant no cohort-size relaxation here. The
+        # effect is strictly CONSERVATIVE (a generated strategy's persisted PBO is
+        # judged on its face, never softened by a library-size argument it doesn't
+        # have) — consistent with "never weaken the gate", not an oversight.
         latest = latest_backtests_by_strategy(session, [strategy_id]).get(strategy_id)
         num_trials = latest.num_trials_in_selection if latest and latest.num_trials_in_selection else 1
         persisted_pbo = latest.pbo_score if latest else None

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -439,10 +439,124 @@ async def evaluate_rigor_gate(
     )
 
 
+def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: int) -> StrategyRigorResult | None:
+    """Grade a GENERATED (DB-persisted) strategy on its OWN persisted context.
+
+    ``evaluate_rigor_gate`` only knows about the curated, filesystem-backed
+    ``LocalStrategyProvider`` cohort, so ``GET /gate/{id}`` 404s for every
+    fusion/architect-generated strategy — the Strategy Passport's Deploy button
+    and Rigor Strictness slider are dead for them. This closes that gap WITHOUT
+    folding the strategy into the curated cohort computation: merging it in would
+    inflate ``num_trials`` for every curated strategy (a real strategy the
+    curated multiple-testing correction never accounted for), leak a private
+    strategy's existence/shape into a public cohort computation, and turn a
+    single-strategy request into an O(library) recompute. Instead this grades
+    the strategy on its OWN persisted ``num_trials_in_selection`` / ``pbo_score``
+    / ``look_ahead_audit_passed`` — the exact numbers already written by the
+    generation pipeline (``update_rigor_gate_fields`` / the DSL-fusion insert
+    path) — via the same ``run_rigor_gate`` primitive the curated path uses.
+
+    Ownership (security-critical — copied verbatim from
+    ``strategies_routes.get_strategy``'s #850 pattern): a non-example,
+    unpublished ``strategy_store`` row is visible only to its ``owner_wallet``.
+    Returns ``None`` for BOTH "no such strategy" and "exists but not visible to
+    this caller" so the route 404s either way — existence must never leak to a
+    non-owner via a different response shape.
+
+    Returns a MISSING-shaped result (mirroring the curated "no backtest data"
+    branch above) when the strategy exists, is visible, but has fewer than 10
+    persisted daily returns — the honest "Pending Backtest" case, not a 404.
+    """
+    from archimedes.api.auth_siwe import get_verified_wallet
+    from archimedes.db import get_session, init_db
+    from archimedes.models.strategy_store import StrategyRecord
+    from archimedes.services.backtest_repository import get_daily_returns, latest_backtests_by_strategy
+
+    init_db()
+    with get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+        if row is None:
+            return None
+        if not row.is_example and not row.is_published:
+            caller = get_verified_wallet(request)
+            is_owner = bool(row.owner_wallet and caller and row.owner_wallet.lower() == caller.lower())
+            if not is_owner:
+                return None
+
+        strategy_name = row.strategy_name
+        daily_returns = get_daily_returns(session, strategy_id)
+
+        if len(daily_returns) < 10:
+            return StrategyRigorResult(
+                strategy_id=strategy_id,
+                strategy_name=strategy_name,
+                passes_all=False,
+                gate_details=RigorGateDetail(
+                    dsr="MISSING (no backtest data)",
+                    pbo="MISSING (no backtest data)",
+                    oos_sharpe="MISSING (no backtest data)",
+                    look_ahead="MISSING (no code)",
+                ),
+                library_pbo=_library_pbo_payload(),
+                strictness_level=strictness,
+                min_passing_level=None,
+                blocked_by_floor=False,
+            )
+
+        # Persisted context from the latest backtest row — never recomputed
+        # against any cohort (curated or otherwise). A missing num_trials
+        # defaults to 1 (run_rigor_gate's own documented "genuinely single-trial"
+        # fallback, logged loudly there); a missing pbo_score stays None, which
+        # run_rigor_gate treats fail-closed (criterion 4 FAILs rather than
+        # silently passing) — exactly the same fail-closed contract the curated
+        # path relies on.
+        latest = latest_backtests_by_strategy(session, [strategy_id]).get(strategy_id)
+        num_trials = latest.num_trials_in_selection if latest and latest.num_trials_in_selection else 1
+        persisted_pbo = latest.pbo_score if latest else None
+        persisted_look_ahead = bool(latest.look_ahead_audit_passed) if latest else False
+
+    gate_result = run_rigor_gate(
+        strategy_id=strategy_id,
+        daily_returns=daily_returns,
+        num_trials=num_trials,
+        library_pbo=persisted_pbo,
+        look_ahead_audit_passed=persisted_look_ahead,
+        in_sample_sharpe=None,
+        average_correlation=0.0,
+        strictness_level=strictness,
+    )
+
+    details = gate_result.gate_details
+    return StrategyRigorResult(
+        strategy_id=strategy_id,
+        strategy_name=strategy_name,
+        passes_all=gate_result.passes_all,
+        gate_details=RigorGateDetail(
+            dsr=details.get("dsr", "MISSING"),
+            pbo=details.get("pbo", "MISSING"),
+            oos_sharpe=details.get("oos_sharpe", "MISSING"),
+            look_ahead=details.get("look_ahead", "MISSING"),
+            cpcv=details.get("cpcv", "MISSING"),
+            dsr_convention=details.get("dsr_convention", "MISSING"),
+            iid=details.get("iid", "MISSING"),
+            regime_robustness=details.get("regime_robustness", "MISSING"),
+        ),
+        deflated_sharpe=gate_result.deflated_sharpe,
+        dsr_p_value=gate_result.dsr_p_value,
+        pbo_score=gate_result.pbo_score,
+        oos_sharpe=gate_result.oos_sharpe,
+        in_sample_sharpe=gate_result.in_sample_sharpe,
+        library_pbo=_library_pbo_payload(),
+        strictness_level=strictness,
+        min_passing_level=gate_result.min_passing_level,
+        blocked_by_floor=gate_result.blocked_by_floor,
+    )
+
+
 @selection_bias_router.get("/gate/{strategy_id}", response_model=StrategyRigorResult)
 @limiter.limit("10/minute")
 async def evaluate_strategy_rigor(
-    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    request: Request,
     strategy_id: str,
     strictness: int = Query(DEFAULT_LEVEL, ge=STRICTEST_LEVEL, le=LOOSEST_LEVEL),
 ):
@@ -450,9 +564,18 @@ async def evaluate_strategy_rigor(
 
     The response's ``passes_all`` reflects ``strictness``; ``min_passing_level``
     tells the passport the lowest level at which the strategy is deployable.
+
+    Tries the curated ``LocalStrategyProvider`` cohort first (unchanged
+    behavior); when the id isn't curated, falls through to
+    ``_generated_strategy_rigor`` so fusion/architect-generated strategies grade
+    on their own persisted context instead of 404ing outright (#deploy-gate).
     """
     strategy = _provider().get_strategy(strategy_id)
     if strategy is None:
+        generated = _generated_strategy_rigor(strategy_id, request, strictness)
+        if generated is not None:
+            return generated
+
         from fastapi import HTTPException
 
         raise HTTPException(status_code=404, detail="Strategy not found")

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -163,9 +163,17 @@ def _deployable_levels(
                     rigor_result = None
             if rigor_result is not None:
                 out[sid] = (True, rigor_result.min_passing_level, rigor_result.blocked_by_floor)
+            elif request is not None:
+                # request present → `_generated_strategy_rigor` already applied the
+                # #850 ownership gate, so a None means "absent OR not visible to
+                # this caller". Do NOT fall back to the non-ownership-gated badge —
+                # that would leak a private strategy's deployability. Match this
+                # function's docstring: not found, not deployable (existence stays
+                # hidden either way).
+                out[sid] = (False, None, False)
             else:
-                # No request context, or the id didn't resolve to a visible
-                # strategy_store row — the pre-existing badge-gated fallback.
+                # No request context (internal/legacy caller) — the pre-existing
+                # badge-gated fallback.
                 found, passes_badge = _strategy_rigor_status(sid)
                 out[sid] = (found, (STRICTEST_LEVEL if passes_badge else None), False)
     return out
@@ -186,16 +194,23 @@ def _assert_strategies_pass_rigor(
     refused.
 
     ``request`` (optional) is threaded through to ``_deployable_levels`` so a
-    generated strategy's own per-strategy ladder — rather than the coarse
-    badge-only fallback — backs the looser-than-badge branch below. Omitted by
-    callers that only ever exercise the badge-level fast path (the default).
+    generated strategy's own ownership-gated per-strategy ladder — rather than the
+    coarse, non-ownership-gated badge — backs the check whenever a request is
+    present (every real HTTP deploy). Only request-less internal/legacy callers
+    take the badge-only fast path.
     """
     level = clamp_level(strictness_level)
 
-    # Fast, exact badge path at the strictest level: a badge-fail can never pass
-    # level 1, so no live per-level ladder computation is needed. This also keeps
-    # the default deploy path unchanged for callers that don't opt into strictness.
-    if level <= STRICTEST_LEVEL:
+    # Fast, exact badge path at the strictest level — ONLY for callers with no
+    # request context (internal/legacy). A badge-fail can never pass the strictest
+    # level, so no live per-level ladder is needed there. When a request IS present
+    # (every real HTTP deploy — create_vault always passes it) we fall through to
+    # the ownership-gated `_deployable_levels` below, so a generated strategy
+    # invisible to the caller is refused rather than revealed via the ungated
+    # badge. Curated strategies grade identically either way (verdicts_for_strategies
+    # uses the same library-cohort correction as the badge), so this closes the
+    # generated-strategy ownership bypass without changing curated deploy behavior.
+    if level <= STRICTEST_LEVEL and request is None:
         for sid in strategy_ids:
             found, passes = _strategy_rigor_status(sid)
             if not found:

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -95,18 +95,28 @@ def _strategy_rigor_status(strategy_id: str) -> tuple[bool, bool]:
     return False, False
 
 
-def _deployable_levels(strategy_ids: list[str]) -> dict[str, tuple[bool, int | None, bool]]:
+def _deployable_levels(
+    strategy_ids: list[str], request: Request | None = None
+) -> dict[str, tuple[bool, int | None, bool]]:
     """``{id: (found, min_passing_level, blocked_by_floor)}`` at the chosen level.
 
     Curated strategies get a LIVE per-level verdict computed over the whole-library
     cohort (``verdicts_for_strategies``), so the multiple-testing correction is
     the same one the badge uses — the strictness slider genuinely re-grades them.
-    Generated strategies fall back to their persisted level-1 badge (min level 1
-    if the badge holds, else ``None``): the slider does not loosen generated
-    deploys in this version, because a generated strategy's look-ahead provenance
-    is a closed-DSL self-attestation, not the AST audit the live re-grade runs, so
-    re-grading it here would be apples-to-oranges. This is fail-safe (a generated
-    strategy that fails its badge simply can't be deployed at a looser level yet).
+
+    Generated strategies consult their OWN per-strategy ladder
+    (``selection_bias_routes._generated_strategy_rigor`` — the same helper the
+    Strategy Passport's ``GET /gate/{id}`` reads, graded on the strategy's own
+    persisted num_trials/pbo/look-ahead, never merged into the curated cohort).
+    Previously this branch only offered a badge-gated fallback (min level 1 if
+    the badge held, else ``None``) that never consulted the real ladder, so a
+    generated strategy could show "deployable @ Balanced" on the passport yet
+    still 422 here at the exact same strictness — the server-side enforcement
+    disagreeing with what the user was shown. Falls back to the old badge-only
+    check when ``request`` isn't available (internal/legacy callers) or the id
+    doesn't resolve to a visible ``strategy_store`` row (unowned/unpublished —
+    #850 ownership gating; existence stays hidden either way, mirrored here as
+    "not found, not deployable").
 
     Never raises: any resolution failure degrades an id to not-deployable.
     """
@@ -135,13 +145,35 @@ def _deployable_levels(strategy_ids: list[str]) -> dict[str, tuple[bool, int | N
             # Curated but the verdict batch failed — fail closed (found, not deployable).
             out[sid] = (True, None, False)
         else:
-            # Generated (or unknown): badge-gated fallback.
-            found, passes_badge = _strategy_rigor_status(sid)
-            out[sid] = (found, (STRICTEST_LEVEL if passes_badge else None), False)
+            # Generated (or unknown): consult its own per-strategy ladder so this
+            # agrees with the passport. `_generated_strategy_rigor` already runs
+            # the ownership gate (#850) — a None here means "not found or not
+            # visible to this caller", not just "no ladder available".
+            rigor_result = None
+            if request is not None:
+                try:
+                    from archimedes.api.selection_bias_routes import _generated_strategy_rigor
+
+                    rigor_result = _generated_strategy_rigor(sid, request, STRICTEST_LEVEL)
+                except Exception:
+                    logger.exception(
+                        "deploy gate: generated-strategy ladder failed for %s — falling back to badge",
+                        sanitize_log_value(sid),
+                    )
+                    rigor_result = None
+            if rigor_result is not None:
+                out[sid] = (True, rigor_result.min_passing_level, rigor_result.blocked_by_floor)
+            else:
+                # No request context, or the id didn't resolve to a visible
+                # strategy_store row — the pre-existing badge-gated fallback.
+                found, passes_badge = _strategy_rigor_status(sid)
+                out[sid] = (found, (STRICTEST_LEVEL if passes_badge else None), False)
     return out
 
 
-def _assert_strategies_pass_rigor(strategy_ids: list[str], strictness_level: int = STRICTEST_LEVEL) -> None:
+def _assert_strategies_pass_rigor(
+    strategy_ids: list[str], strictness_level: int = STRICTEST_LEVEL, request: Request | None = None
+) -> None:
     """Fail-closed deploy precondition (#818): every strategy bound to a vault must
     resolve and pass the rigor gate at the caller's chosen ``strictness_level``.
     Raises 422 otherwise. The frontend Deploy gate (#782) is defense-in-depth;
@@ -152,6 +184,11 @@ def _assert_strategies_pass_rigor(strategy_ids: list[str], strictness_level: int
     trade statistical confidence for breadth, never admit a broken/curve-fit
     strategy. A strategy with no computed verdict (placeholder) is correctly
     refused.
+
+    ``request`` (optional) is threaded through to ``_deployable_levels`` so a
+    generated strategy's own per-strategy ladder — rather than the coarse
+    badge-only fallback — backs the looser-than-badge branch below. Omitted by
+    callers that only ever exercise the badge-level fast path (the default).
     """
     level = clamp_level(strictness_level)
 
@@ -174,7 +211,7 @@ def _assert_strategies_pass_rigor(strategy_ids: list[str], strictness_level: int
         return
 
     # Looser-than-badge level: consult the live per-level ladder.
-    levels = _deployable_levels(strategy_ids)
+    levels = _deployable_levels(strategy_ids, request)
     for sid in strategy_ids:
         found, min_level, blocked = levels.get(sid, (False, None, False))
         if not found:
@@ -238,7 +275,9 @@ async def create_vault(
     # passed the rigor gate AT THE REQUESTED STRICTNESS, BEFORE spending gas. The
     # #782 frontend Deploy gate is defense-in-depth; this is the guarantee a
     # direct/non-UI API call can't bypass. Always-on floors hold at every level.
-    _assert_strategies_pass_rigor(req.strategy_ids, req.strictness_level)
+    # `request` is threaded through so a generated strategy's own per-strategy
+    # ladder (not just its badge) backs a looser-than-badge strictness choice.
+    _assert_strategies_pass_rigor(req.strategy_ids, req.strictness_level, request=request)
 
     try:
         vault_address = await chain_executor.create_vault(
@@ -303,7 +342,7 @@ async def get_vault_detail(address: str):
 @limiter.limit("10/minute")
 async def store_vault_metadata(
     req: VaultMetadataRequest,
-    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    request: Request,
     response: Response,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     wallet: str = Depends(require_verified_wallet),
 ):
@@ -339,7 +378,7 @@ async def store_vault_metadata(
     # strictness. Always-on floors hold at every level, so the link can never
     # bind a look-ahead-biased / OOS-negative / worse-than-coin-flip strategy.
     if req.strategy_ids:
-        _assert_strategies_pass_rigor(req.strategy_ids, req.strictness_level)
+        _assert_strategies_pass_rigor(req.strategy_ids, req.strictness_level, request=request)
 
     from archimedes.db import get_session
 
@@ -405,7 +444,7 @@ async def get_vault_metadata(address: str):
 async def derive_vault_allocations(
     address: str,  # noqa: ARG001 — path param routes the request; not referenced in body
     req: SetAllocationsRequest,
-    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    request: Request,
     response: Response,  # noqa: ARG001 — reserved for slowapi rate-limit headers
     wallet: str = Depends(require_verified_wallet),  # noqa: ARG001 — SIWE gate (#917): auth required, wallet unused in body
 ):
@@ -464,7 +503,7 @@ async def derive_vault_allocations(
     deployable_ids: set[str] | None = None
     lvl = clamp_level(req.strictness_level)
     if lvl > STRICTEST_LEVEL:
-        levels = _deployable_levels([s.id for s in strategies])
+        levels = _deployable_levels([s.id for s in strategies], request)
         deployable_ids = {
             sid for sid, (found, ml, _blocked) in levels.items() if found and ml is not None and ml <= lvl
         }

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -194,23 +194,16 @@ def _assert_strategies_pass_rigor(
     refused.
 
     ``request`` (optional) is threaded through to ``_deployable_levels`` so a
-    generated strategy's own ownership-gated per-strategy ladder — rather than the
-    coarse, non-ownership-gated badge — backs the check whenever a request is
-    present (every real HTTP deploy). Only request-less internal/legacy callers
-    take the badge-only fast path.
+    generated strategy's own per-strategy ladder — rather than the coarse
+    badge-only fallback — backs the looser-than-badge branch below. Omitted by
+    callers that only ever exercise the badge-level fast path (the default).
     """
     level = clamp_level(strictness_level)
 
-    # Fast, exact badge path at the strictest level — ONLY for callers with no
-    # request context (internal/legacy). A badge-fail can never pass the strictest
-    # level, so no live per-level ladder is needed there. When a request IS present
-    # (every real HTTP deploy — create_vault always passes it) we fall through to
-    # the ownership-gated `_deployable_levels` below, so a generated strategy
-    # invisible to the caller is refused rather than revealed via the ungated
-    # badge. Curated strategies grade identically either way (verdicts_for_strategies
-    # uses the same library-cohort correction as the badge), so this closes the
-    # generated-strategy ownership bypass without changing curated deploy behavior.
-    if level <= STRICTEST_LEVEL and request is None:
+    # Fast, exact badge path at the strictest level: a badge-fail can never pass
+    # level 1, so no live per-level ladder computation is needed. This also keeps
+    # the default deploy path unchanged for callers that don't opt into strictness.
+    if level <= STRICTEST_LEVEL:
         for sid in strategy_ids:
             found, passes = _strategy_rigor_status(sid)
             if not found:

--- a/backend/archimedes/services/live_rigor_gate.py
+++ b/backend/archimedes/services/live_rigor_gate.py
@@ -143,6 +143,7 @@ def verdict_from_returns(
     strategy_code: str | None = None,
     paper_claimed_sharpe: float | None = None,
     average_correlation: float = 0.0,
+    look_ahead_audit_passed: bool | None = None,
 ) -> RigorGateVerdict:
     """Compute the live tri-state verdict from a strategy's persisted returns.
 
@@ -157,6 +158,23 @@ def verdict_from_returns(
     (``E_max_N=0``) and collapsed DSR to a plain Sharpe test, so an unspecified
     trial count silently ran the badge undeflated. Callers holding cohort context
     (``verdicts_for_strategies``, the generation pipeline) still pass it explicitly.
+
+    ``look_ahead_audit_passed=None`` (the default) leaves the look-ahead leg to
+    ``run_rigor_gate``'s own AST-audit-over-``strategy_code`` path — the right
+    behavior for curated strategies (``verdicts_for_strategies``, which passes
+    real cited source). Callers whose "code" is a closed DSL spec rather than
+    inspectable source (the fusion/DSL-generation path) have nothing for the AST
+    audit to run against, so ``strategy_code=None`` there would otherwise force
+    ``look_ahead_passed=False`` unconditionally — failing the always-on
+    look-ahead floor (``blocked_by_floor=True``) at every strictness level
+    regardless of DSR/PBO/OOS. Passing the pipeline's own closed-DSL
+    self-attestation through here (already enforced pre-evaluation by
+    ``validate_strategy_spec`` rejecting any spec with ``look_ahead_safe=False``)
+    matches the accepted policy in ``fusion_evaluator.py``'s
+    ``look_ahead_clean = True`` / "self-attested, not source-audited" framing —
+    it is NOT the independent AST audit, and is surfaced as such in
+    ``gate_details``, but it is the same admitted trust boundary already used
+    elsewhere in this codebase for exactly this class of strategy.
     """
     if not daily_returns or len(daily_returns) < _MIN_RETURNS_FOR_GATE:
         return RigorGateVerdict.pending()
@@ -181,6 +199,7 @@ def verdict_from_returns(
             in_sample_sharpe=None,
             paper_claimed_sharpe=paper_claimed_sharpe,
             average_correlation=average_correlation,
+            look_ahead_audit_passed=look_ahead_audit_passed,
         )
     except Exception as exc:  # never let the badge crash the library list
         logger.warning("live rigor gate failed for %s (badge → pending): %s", strategy_id, exc)

--- a/backend/tests/test_selection_bias_generated_gate.py
+++ b/backend/tests/test_selection_bias_generated_gate.py
@@ -1,0 +1,270 @@
+"""Tests for the GENERATED-strategy rigor gate (companion to test_selection_bias_routes.py).
+
+``GET /api/selection-bias/gate/{strategy_id}`` previously 404d for every
+GENERATED strategy (fusion/architect, persisted to ``strategy_store`` — not the
+filesystem-backed curated ``LocalStrategyProvider`` the route otherwise grades).
+That left the Strategy Passport's Deploy button + Rigor Strictness slider dead
+for every generated strategy. These tests cover the fix
+(``selection_bias_routes._generated_strategy_rigor``):
+
+  1. A generated strategy with a real persisted backtest grades on ITS OWN
+     context (never merged into the curated cohort) and returns 200 with a
+     non-null ``min_passing_level``.
+  2. Ownership (#850 pattern): an unpublished, non-owned strategy 404s for a
+     non-owner — existence never leaks via a different response shape.
+  3. "Pending Backtest": a strategy that exists but has no (or too few)
+     persisted daily returns returns 200 with a MISSING-shaped result, not a
+     404 and not a crash.
+  4. An unknown id is still a plain 404 (no regression on the pre-existing
+     curated-cohort-only behavior).
+  5. The companion look-ahead-threading fix in
+     ``live_rigor_gate.verdict_from_returns``: passing
+     ``look_ahead_audit_passed=True`` can flip a verdict that would otherwise
+     be blocked by the always-on look-ahead floor.
+
+DB fixture follows the proven rebind pattern from test_strategy_ownership.py /
+test_live_gate_returns.py: db.engine/SessionLocal are module-level globals
+created once at import, so ``monkeypatch.setenv`` alone does not repoint them —
+both must be rebound to a fresh per-test sqlite engine.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import archimedes.db as db
+import numpy as np
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from httpx import ASGITransport, AsyncClient
+
+_W_OWNER = "0xAbC1230000000000000000000000000000000A"  # mixed case on purpose
+_W_OTHER = "0x0000000000000000000000000000000000000B"
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Point the DB at a FRESH temp sqlite (rebinds db.engine + db.SessionLocal).
+
+    db.engine/SessionLocal are created once at import, so setenv alone doesn't
+    re-point them; rebind both to a per-test engine, then init_db() registers
+    every table (incl. the passport/backtest side-effect imports).
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'generated_gate.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Valid signed SIWE session cookie for `wallet` (same helper shape as
+    test_user_routes.py / test_strategy_ownership.py — a real signed session,
+    not header spoofing)."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _mk_strategy(
+    sid: str,
+    *,
+    owner: str | None = None,
+    published: bool = False,
+    example: bool = False,
+    name: str = "Generated Test Strategy",
+):
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with db.get_session() as session:
+        row = StrategyRecord(
+            id=sid,
+            content_hash=("0x" + sid).ljust(66, "0"),
+            generation_method="fusion",
+            source_papers="[]",
+            strategy_name=name,
+            thesis="test thesis",
+            asset_universe="[]",
+            risk_profile="moderate",
+            status="candidate",
+            is_example=example,
+            owner_wallet=owner.lower() if owner else None,
+            is_published=published,
+        )
+        session.add(row)
+        session.commit()
+
+
+def _strong_returns(seed: int = 42, n: int = 300) -> list[float]:
+    """A realistic, comfortably-passing daily-return series (deterministic)."""
+    return np.random.default_rng(seed).normal(0.0018, 0.006, n).tolist()
+
+
+def _mk_backtest(
+    sid: str,
+    *,
+    returns: list[float] | None,
+    num_trials: int | None = 1,
+    pbo: float | None = 0.05,
+    look_ahead: bool = True,
+):
+    """Persist a BacktestResultRecord whose artifact_json carries daily_returns
+    (mirrors how the real pipeline / analytics-engine writes them — see
+    backend/archimedes/services/backtest_repository.get_daily_returns)."""
+    from archimedes.models.backtest_store import BacktestResultRecord
+
+    artifact_json = None
+    if returns is not None:
+        artifact_json = json.dumps({"results": [{"metrics": {"daily_returns": returns}}]})
+
+    with db.get_session() as session:
+        session.add(
+            BacktestResultRecord(
+                strategy_id=sid,
+                content_hash=f"bt_{sid}",
+                artifact_json=artifact_json,
+                num_trials_in_selection=num_trials,
+                pbo_score=pbo,
+                look_ahead_audit_passed=look_ahead,
+            )
+        )
+        session.commit()
+
+
+# ── 1. Found + graded: real persisted backtest → 200, non-null min_passing_level ──
+
+
+async def test_generated_strategy_found_and_graded_not_404():
+    sid = "gen0000000000001"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_backtest(sid, returns=_strong_returns())
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/selection-bias/gate/{sid}", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["strategy_id"] == sid
+    assert body["min_passing_level"] is not None
+    # Real numbers, not the MISSING/pending shape.
+    assert body["gate_details"]["dsr"] != "MISSING (no backtest data)"
+    assert body["dsr_p_value"] is not None
+
+
+async def test_generated_strategy_published_visible_to_anonymous_caller():
+    sid = "gen0000000000002"
+    _mk_strategy(sid, owner=_W_OWNER, published=True)
+    _mk_backtest(sid, returns=_strong_returns())
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/selection-bias/gate/{sid}")  # no cookie
+
+    assert resp.status_code == 200
+    assert resp.json()["min_passing_level"] is not None
+
+
+# ── 2. Ownership: unpublished + non-owner (and anonymous) → 404, existence hidden ──
+
+
+async def test_generated_strategy_ownership_hides_existence():
+    sid = "gen0000000000003"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_backtest(sid, returns=_strong_returns())
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = await client.get(f"/api/selection-bias/gate/{sid}")
+        other = await client.get(f"/api/selection-bias/gate/{sid}", cookies=_siwe_cookies(_W_OTHER))
+        owner = await client.get(f"/api/selection-bias/gate/{sid}", cookies=_siwe_cookies(_W_OWNER))
+
+    assert anon.status_code == 404
+    assert other.status_code == 404  # 404, not 403 — existence stays hidden
+    assert owner.status_code == 200
+
+
+# ── 3. Pending: strategy exists but no (or too little) backtest data ─────────
+
+
+async def test_generated_strategy_no_backtest_row_is_missing_shaped_not_404():
+    sid = "gen0000000000004"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    # No BacktestResultRecord at all.
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/selection-bias/gate/{sid}", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["min_passing_level"] is None
+    assert body["blocked_by_floor"] is False
+    assert body["passes_all"] is False
+    assert body["gate_details"]["dsr"] == "MISSING (no backtest data)"
+    assert body["gate_details"]["look_ahead"] == "MISSING (no code)"
+
+
+async def test_generated_strategy_too_few_returns_is_missing_shaped_not_404():
+    sid = "gen0000000000005"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_backtest(sid, returns=[0.001] * 5)  # < 10 observations
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/selection-bias/gate/{sid}", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["min_passing_level"] is None
+    assert body["gate_details"]["pbo"] == "MISSING (no backtest data)"
+
+
+# ── 4. Unknown id is still a plain 404 (no regression) ────────────────────────
+
+
+async def test_unknown_id_still_404():
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/selection-bias/gate/totally-unknown-id-xyz")
+
+    assert resp.status_code == 404
+
+
+# ── 5. Look-ahead threading: verdict_from_returns(look_ahead_audit_passed=True) ──
+
+
+def test_look_ahead_override_flips_blocked_verdict_to_pass():
+    """Without the override, strategy_code=None forces look_ahead_passed=False
+    unconditionally, tripping the always-on floor (blocked_by_floor=True) no
+    matter how strong the DSR/PBO/OOS numbers are. Passing the pipeline's own
+    closed-DSL self-attestation through fixes that — the companion bug fix in
+    live_rigor_gate.verdict_from_returns (backend/archimedes/agents/
+    generation_pipeline.py:1436 wires this from the already-computed
+    result.look_ahead_audit_passed)."""
+    from archimedes.services.live_rigor_gate import verdict_from_returns
+    from archimedes.services.rigor_evaluator import compute_pbo
+
+    a = np.random.default_rng(0).normal(0.0015, 0.004, 500).tolist()
+    b = np.random.default_rng(1).normal(0.0015, 0.004, 500).tolist()
+    pbo = compute_pbo({"a": a, "b": b})
+
+    without = verdict_from_returns("a", a, num_trials=2, pbo_scores=pbo)
+    assert without.status == "fail"
+    assert without.passes is False
+    assert without.blocked_by_floor is True
+
+    with_override = verdict_from_returns("a", a, num_trials=2, pbo_scores=pbo, look_ahead_audit_passed=True)
+    assert with_override.status == "pass"
+    assert with_override.passes is True
+    assert with_override.blocked_by_floor is False


### PR DESCRIPTION
## Demo-blocker (the generate → **deploy** hero flow)
`GET /api/selection-bias/gate/{id}` only knew the curated, file-backed `LocalStrategyProvider` cohort, so it **404'd for every generated strategy** — the Strategy Passport's Deploy button + Rigor Strictness slider were dead for them, and a user could generate a strategy but never deploy it at **any** strictness. (Confirmed live: `curl /api/selection-bias/gate/<generated_id>` → 404.)

## Fix (4 sites) — grade each generated strategy on ITS OWN persisted context
Never merged into the curated cohort (that would inflate curated `num_trials`, leak a private strategy's shape into a public computation, and O(library) the request):

1. **`selection_bias_routes._generated_strategy_rigor`** — new helper. **Ownership-gated (#850):** a non-example/unpublished row is visible only to `owner_wallet == caller`; returns `None` for *both* "absent" and "not visible" → same 404, **existence never leaks**. Grades via `run_rigor_gate` on the strategy's own persisted `num_trials_in_selection` / `pbo_score` / `look_ahead_audit_passed`. `<10` returns → honest MISSING-shaped result (Pending Backtest), not a 404. **Curated cohort computation untouched.**
2. **`evaluate_strategy_rigor`** — falls through to the helper when the id isn't curated.
3. **Look-ahead threading** (`live_rigor_gate.verdict_from_returns` + `generation_pipeline._persist_real_returns`) — a DSL strategy has no inspectable source for the AST audit, so `strategy_code=None` was forcing `look_ahead_passed=False` → `blocked_by_floor` at every level regardless of DSR/PBO/OOS. Now passes the pipeline's closed-DSL **self-attestation** (already enforced by `validate_strategy_spec` rejecting `look_ahead_safe=False`), surfaced honestly in `gate_details` as *"self-attested, not source-audited"* — matching `fusion_evaluator`'s existing policy.
4. **`vaults_routes._deployable_levels` / `_assert_strategies_pass_rigor`** — generated strategies consult the **same** ownership-gated per-strategy ladder, so the server-side deploy precondition **agrees with the passport** instead of 422ing at a strictness the UI showed as deployable. Curated path + fail-closed unchanged.

## Tests
New `backend/tests/test_selection_bias_generated_gate.py`: found+graded, published-visible-to-anon, **ownership-hides-existence (anon/non-owner → 404, owner → 200)**, pending → MISSING-shaped, unknown → 404, look-ahead override. ✅ **266 pass** (new + `test_selection_bias_routes` + `test_rigor_evaluator` + `test_live_gate_returns`); ruff (blocking) + format clean. Reviewed line-by-line by the main session (ownership scoping, no cohort mutation, PBO fail-closed all verified).

## ⚠️ Needs sign-off (Dan + Önder)
Item 3 is a **rigor-FLOOR behavior change** — generated DSL strategies go from unconditionally-blocked to *conditionally-deployable* via self-attestation. Honest + matches existing DSL policy, but it touches a floor, so it wants explicit sign-off before merge.

## Scope note
The separate **num_trials decoupling** (Dan's "rigor must depend only on the strategy") is a **follow-up** — this PR uses the persisted `num_trials` as-is and **does not change rigor math for any existing strategy.** Part of the generate→deploy→publish loop fixes (with #1062 publish, #1063 dry-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)