### PR TITLE
[agent] Discoverability layer: llms.txt + agent.json + AGENTS.md + JSON-LD + /api/agent/manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+Two different kinds of agent read this repo — point each at its own doc rather than
+duplicating content here.
+
+- **Working on this codebase** (an AI coding agent contributing code, tests, or infra to
+  Archimedes itself): start at [`CLAUDE.md`](CLAUDE.md) — team, architecture, conventions,
+  and the engineering rules for this repo.
+- **Using the deployed product** (an autonomous AI agent driving Archimedes as a user — an
+  investor, a trading bot, a research assistant): start at
+  [`docs/agent-api.md`](docs/agent-api.md) for the full programmatic API contract, or
+  [`/llms.txt`](https://archimedes-arc.com/llms.txt) on the live site for a curated,
+  low-token entry point. Both cover the same SIWE-authenticated, browser-free journey:
+  read → authenticate → generate → read the rigor verdict.
+
+A machine-readable manifest is also live at
+[`/api/agent/manifest`](https://archimedes-arc.com/api/agent/manifest) and
+[`/.well-known/agent.json`](https://archimedes-arc.com/.well-known/agent.json).

--- a/backend/archimedes/api/agent_manifest_routes.py
+++ b/backend/archimedes/api/agent_manifest_routes.py
@@ -12,7 +12,8 @@ system health). This file's "agent" is an external AI agent consuming the produc
 user. Same URL prefix (``/api/agent``), different concept — kept in separate modules so
 neither docstring has to disambiguate the other's meaning inline.
 
-Honesty note (mirrors docs/agent-api.md): READ / AUTH / GENERATE / RIGOR are live today.
+Honesty note (mirrors docs/agent-api.md): READ / AUTH / GENERATE — including the rigor
+readback surfaced under the generate group (there is no separate ``rigor`` group) — are live today.
 DEPLOY, and the marketplace PUBLISH/SUBSCRIBE + MONITOR endpoints that depend on a
 deployed vault, are real routes but not yet wired for agent-driven end-to-end use --
 they land with the T3.2 contract redeploy (issue #588). Never advertise these as

--- a/backend/archimedes/api/agent_manifest_routes.py
+++ b/backend/archimedes/api/agent_manifest_routes.py
@@ -1,0 +1,116 @@
+"""Agent-discoverability manifest — GET /api/agent/manifest.
+
+A small, unauthenticated, machine-readable summary of the agent-facing API contract
+documented in full at ``docs/agent-api.md`` (and curated for low-token consumption at
+``/llms.txt``). Intent: give an autonomous AI agent landing on the API surface with no
+prior context a single cheap GET that says what this product is, how to authenticate,
+and which endpoints matter.
+
+Deliberately a SEPARATE module from ``agent_routes.py`` (``/api/agent/status`` etc.):
+that file's "agent" is the autonomous on-chain trading/rebalancing agent (internal
+system health). This file's "agent" is an external AI agent consuming the product as a
+user. Same URL prefix (``/api/agent``), different concept — kept in separate modules so
+neither docstring has to disambiguate the other's meaning inline.
+
+Honesty note (mirrors docs/agent-api.md): READ / AUTH / GENERATE / RIGOR are live today.
+DEPLOY, and the marketplace PUBLISH/SUBSCRIBE + MONITOR endpoints that depend on a
+deployed vault, are real routes but not yet wired for agent-driven end-to-end use --
+they land with the T3.2 contract redeploy (issue #588). Never advertise these as
+complete; the ``status`` field on each group says so explicitly.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+agent_manifest_router = APIRouter(prefix="/api/agent", tags=["agent"])
+
+_PENDING_T32 = "landing with the T3.2 contract redeploy (issue #588) — endpoint exists but agent-driven use isn't wired end-to-end yet"
+
+
+@agent_manifest_router.get("/manifest")
+async def get_agent_manifest():
+    """Small JSON contract for programmatic discovery by AI agents.
+
+    Unauthenticated, rate-limited like sibling public GETs (no decorator -> the
+    limiter's default_limits apply, matching e.g. /api/config/contracts).
+    """
+    return {
+        "name": "Archimedes",
+        "blurb": (
+            "Agentic trading, grounded in research — settled on Arc. Turns a "
+            "natural-language investment intent into a research-grounded, "
+            "rigor-gated portfolio strategy, executed in a non-custodial USDC "
+            "vault on the Arc testnet (chain ID 5042002)."
+        ),
+        "docs": {
+            "llms_txt": "/llms.txt",
+            "agent_api": "https://github.com/a-apin/archimedes/blob/main/docs/agent-api.md",
+            "agent_card": "/.well-known/agent.json",
+        },
+        "auth": {
+            "scheme": "SIWE",
+            "spec": "EIP-4361",
+            "description": (
+                "Sign-In with Ethereum via a programmatic EOA — no browser or passkey "
+                "required. GET /api/auth/nonce for a challenge, sign it, POST "
+                "/api/auth/verify to get a session cookie."
+            ),
+            "chain_id": 5042002,
+        },
+        "endpoints": {
+            "read": {
+                "status": "live",
+                "auth_required": False,
+                "routes": {
+                    "strategies": "GET /api/strategies/",
+                    "assets": "GET /api/explore/assets",
+                    "health": "GET /api/health",
+                },
+            },
+            "auth": {
+                "status": "live",
+                "auth_required": False,
+                "routes": {
+                    "nonce": "GET /api/auth/nonce",
+                    "verify": "POST /api/auth/verify",
+                    "session": "GET /api/auth/session",
+                },
+            },
+            "generate": {
+                "status": "live",
+                "auth_required": True,
+                "routes": {
+                    "start": "POST /api/generate/start",
+                    "stream": "GET /api/generate/stream/{job_id}",
+                    "candidates": "GET /api/generate/jobs/{job_id}/candidates",
+                },
+            },
+            "deploy": {
+                "status": _PENDING_T32,
+                "auth_required": True,
+                "routes": {
+                    "create_vault": "POST /api/vaults/create",
+                },
+            },
+            "marketplace": {
+                "status": _PENDING_T32,
+                "auth_required": True,
+                "routes": {
+                    "publish": "POST /api/marketplace/publish",
+                    "subscribe": "POST /api/marketplace/subscribe",
+                },
+            },
+            "monitor": {
+                "status": _PENDING_T32,
+                "auth_required": False,
+                "routes": {
+                    "vault_health": "GET /api/vaults/{address}/health",
+                },
+            },
+        },
+        "faucet": {
+            "url": "https://faucet.circle.com/",
+            "description": "Free Arc testnet USDC (also used as gas on Arc). No real funds at risk.",
+        },
+    }

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -32,6 +32,7 @@ load_ssm_secrets()
 
 # Shared rate limiter (Redis-backed, falls back to in-memory).
 # Defined in a separate module to avoid circular imports with route modules.
+from archimedes.api.agent_manifest_routes import agent_manifest_router
 from archimedes.api.auth_siwe import auth_router
 from archimedes.api.chat_routes import chat_router
 from archimedes.api.corpus_routes import corpus_router
@@ -465,6 +466,7 @@ init_db()
 
 # Wire all routers
 app.include_router(assets_router)
+app.include_router(agent_manifest_router)
 app.include_router(vaults_router)
 app.include_router(strategies_router)
 app.include_router(traces_router)
@@ -802,4 +804,9 @@ async def root():
         "name": "Archimedes",
         "tagline": "Agentic trading, grounded in research — settled on Arc.",
         "docs": _docs_url or "disabled (production)",
+        # Agent-discoverability pointers (additive, backwards-compatible — see /llms.txt
+        # and docs/agent-api.md for the full agent-facing contract).
+        "llms_txt": "/llms.txt",
+        "agent_manifest": "/api/agent/manifest",
+        "agent_docs": "see /llms.txt",
     }

--- a/backend/tests/test_agent_manifest.py
+++ b/backend/tests/test_agent_manifest.py
@@ -1,0 +1,79 @@
+"""Tests for GET /api/agent/manifest — the agent-discoverability manifest."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_agent_manifest_returns_200_with_expected_top_level_keys():
+    """The manifest is a public GET returning the documented top-level contract."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data.keys()) == {"name", "blurb", "docs", "auth", "endpoints", "faucet"}
+    assert data["name"] == "Archimedes"
+
+
+@pytest.mark.asyncio
+async def test_agent_manifest_auth_scheme_is_siwe():
+    """The auth block advertises SIWE / EIP-4361 with the Arc chain id."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+
+    data = resp.json()
+    assert data["auth"]["scheme"] == "SIWE"
+    assert data["auth"]["spec"] == "EIP-4361"
+    assert data["auth"]["chain_id"] == 5042002
+
+
+@pytest.mark.asyncio
+async def test_agent_manifest_endpoint_groups_present():
+    """All the documented endpoint groups are present, each with a status + routes."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+
+    endpoints = resp.json()["endpoints"]
+    expected_groups = {"read", "auth", "generate", "deploy", "marketplace", "monitor"}
+    assert set(endpoints.keys()) == expected_groups
+    for group in expected_groups:
+        assert "status" in endpoints[group]
+        assert "routes" in endpoints[group]
+        assert endpoints[group]["routes"], f"{group} routes must be non-empty"
+
+
+@pytest.mark.asyncio
+async def test_agent_manifest_deploy_and_marketplace_marked_pending():
+    """Deploy / marketplace / monitor are honestly marked pending the T3.2 redeploy (#588)."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+
+    endpoints = resp.json()["endpoints"]
+    for group in ("deploy", "marketplace", "monitor"):
+        assert "#588" in endpoints[group]["status"]
+
+    # READ / AUTH / GENERATE are live, not pending.
+    for group in ("read", "auth", "generate"):
+        assert endpoints[group]["status"] == "live"
+
+
+@pytest.mark.asyncio
+async def test_agent_manifest_includes_faucet_url():
+    """The Circle faucet URL is surfaced for funding a test wallet."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+
+    assert resp.json()["faucet"]["url"] == "https://faucet.circle.com/"

--- a/ui/index.html
+++ b/ui/index.html
@@ -21,6 +21,30 @@
         } catch (e) {}
       })();
     </script>
+    <!-- Static JSON-LD for non-JS fetchers (search engines, AI agents/crawlers). Additive
+         only -- does not affect rendering or existing meta/OG tags above. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Archimedes",
+        "applicationCategory": "FinanceApplication",
+        "description": "Tell Archimedes what you want in plain English. It fuses your intent with the quant-finance literature, live market data, and statistical rigor \u2014 into an autonomous trading strategy that runs in a non-custodial vault on Arc, with every decision hashed and verifiable on-chain.",
+        "url": "https://archimedes-arc.com/",
+        "operatingSystem": "Web",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "potentialAction": {
+          "@type": "Action",
+          "name": "Generate strategy",
+          "description": "Describe an investment intent in plain English and get back a research-grounded, rigor-gated portfolio strategy.",
+          "target": "https://archimedes-arc.com/#/generate"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/public/.well-known/agent.json
+++ b/ui/public/.well-known/agent.json
@@ -1,0 +1,58 @@
+{
+  "schema": "a2a-agent-card (informal, simplified)",
+  "name": "Archimedes",
+  "description": "Agentic trading, grounded in research — settled on Arc. Turns a natural-language investment intent into a research-grounded, rigor-gated portfolio strategy, executed in a non-custodial USDC vault on the Arc testnet (chain ID 5042002).",
+  "url": "https://archimedes-arc.com",
+  "version": "0.1.0",
+  "provider": {
+    "organization": "Archimedes",
+    "url": "https://archimedes-arc.com"
+  },
+  "documentationUrl": "https://github.com/a-apin/archimedes/blob/main/docs/agent-api.md",
+  "service": {
+    "endpoint": "https://archimedes-arc.com/api",
+    "manifest": "https://archimedes-arc.com/api/agent/manifest",
+    "protocols": ["REST+JSON", "Server-Sent Events (generation streaming)"]
+  },
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false
+  },
+  "authentication": {
+    "schemes": ["SIWE"],
+    "description": "Sign-In with Ethereum (EIP-4361) via a programmatic EOA — no browser or passkey required. GET /api/auth/nonce, then POST /api/auth/verify.",
+    "chainId": 5042002
+  },
+  "skills": [
+    {
+      "id": "generate-strategy",
+      "name": "Generate strategy",
+      "description": "Turn a natural-language investment intent into a rigor-gated portfolio strategy (DSR / PBO / walk-forward OOS), grounded in the quantitative-finance research corpus.",
+      "status": "live"
+    },
+    {
+      "id": "deploy-vault",
+      "name": "Deploy vault",
+      "description": "Execute a generated, rigor-passing strategy into a non-custodial USDC vault on Arc.",
+      "status": "landing with the T3.2 redeploy (#588)"
+    },
+    {
+      "id": "monitor",
+      "name": "Monitor",
+      "description": "Read a deployed vault's live health, allocations, and performance.",
+      "status": "landing with the T3.2 redeploy (#588)"
+    },
+    {
+      "id": "publish",
+      "name": "Publish",
+      "description": "Publish a strategy to the nanopayment marketplace for other agents or users to subscribe to.",
+      "status": "landing with the T3.2 redeploy (#588)"
+    },
+    {
+      "id": "subscribe",
+      "name": "Subscribe",
+      "description": "Subscribe to a published strategy via sub-cent USDC nanopayments (x402 / Circle Gateway).",
+      "status": "landing with the T3.2 redeploy (#588)"
+    }
+  ]
+}

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -1,0 +1,77 @@
+# Archimedes
+
+> Agentic trading, grounded in research — settled on Arc. Archimedes turns a
+> natural-language investment intent into a research-grounded, rigor-gated portfolio
+> strategy, backed by a ~10,000-paper quantitative-finance corpus, and executes it into a
+> non-custodial USDC vault on the Arc testnet (chain ID 5042002). Every reasoning step is
+> traceable to a source paper and anchored on-chain.
+
+Archimedes ships one human interface (a wallet-based React SPA), but the same journey is
+fully driveable over plain HTTP — no browser, no passkey. AI agents authenticate with a
+programmatic EOA wallet via Sign-In with Ethereum, then call the same `/api/*` surface the
+UI does. This file is the curated, low-token entry point; the full byte-for-byte contract
+is linked at the bottom.
+
+## The agent journey
+
+1. **Read** — public, no auth required.
+   - `GET https://archimedes-arc.com/api/strategies/` — the curated/generated strategy library
+   - `GET https://archimedes-arc.com/api/explore/assets` — the tradable asset universe
+   - `GET https://archimedes-arc.com/api/health` — liveness + corpus/rigor/LLM diagnostics
+2. **Authenticate** — SIWE (EIP-4361) with a programmatic EOA. See the recipe below. Required
+   before generation (`REQUIRE_SIWE_FOR_GENERATION` is on by default).
+3. **Generate** — `POST https://archimedes-arc.com/api/generate/start` with a `brief`
+   (`intent`, `risk_appetite`), then tail `GET
+   https://archimedes-arc.com/api/generate/stream/{job_id}` (Server-Sent Events) for live
+   reasoning.
+4. **Rigor** — `GET https://archimedes-arc.com/api/generate/jobs/{job_id}/candidates` for the
+   externalized rigor verdict (Deflated Sharpe Ratio / Probability of Backtest Overfitting /
+   walk-forward OOS) and the considered-and-rejected alternatives; `GET
+   https://archimedes-arc.com/api/strategies/{strategy_id}` for the authoritative live
+   deployability gate (`rigor_gate_status`: `pass` | `fail` | `pending`).
+5. **Deploy, publish, subscribe, monitor** — *landing with the T3.2 contract redeploy
+   ([issue #588](https://github.com/a-apin/archimedes/issues/588))*. `POST /api/vaults/create`
+   (deploy), `POST /api/marketplace/publish` + `/subscribe` (the nanopayment marketplace), and
+   `GET /api/vaults/{address}/health` (monitor) are real endpoints today, but agent-driven
+   end-to-end use isn't wired until the redeploy ships. Read-only + generate-only agents are
+   fully supported now; don't expect a deploy call to close the loop yet.
+
+## SIWE for agents — no browser required
+
+1. `GET /api/auth/nonce` → `{ nonce, domain, issued_at, expiry_seconds }`
+2. Build the EIP-4361 message using the **server-advertised `domain`**, `Chain ID: 5042002`
+   (Arc testnet), the live nonce, and a fresh `Issued At` (UTC ISO-8601, within 5 minutes).
+3. Sign it with a programmatic EOA (e.g. `eth_account.Account.sign_message`).
+4. `POST /api/auth/verify` with `{ "message": ..., "signature": "0x..." }` → `200` +
+   `Set-Cookie: archimedes_session=...` (HttpOnly, Secure, SameSite=Strict). Keep the cookie
+   on your HTTP client — it authenticates everything else.
+5. `GET /api/auth/session` → `{ "authenticated": true, "wallet": "0x..." }` to confirm.
+
+A runnable reference implementation lives at
+[`scripts/agent_journey.py`](https://github.com/a-apin/archimedes/blob/main/scripts/agent_journey.py)
+in the repo:
+
+```bash
+# read-only smoke test, no auth, no LLM spend
+python scripts/agent_journey.py --base https://archimedes-arc.com --read-only --no-auth
+
+# full journey with a throwaway in-memory wallet
+python scripts/agent_journey.py --base https://archimedes-arc.com --ephemeral
+```
+
+## Funding a test wallet
+
+Arc testnet uses USDC as gas. Get free testnet USDC from the Circle faucet:
+**https://faucet.circle.com/** (20 USDC / 2h). No real funds are ever at risk — Arc has no
+mainnet yet.
+
+## Machine-readable references
+
+- [`/api/agent/manifest`](https://archimedes-arc.com/api/agent/manifest) — small JSON
+  contract: auth scheme, grouped endpoints, faucet URL. Good for a first programmatic probe.
+- [`/.well-known/agent.json`](https://archimedes-arc.com/.well-known/agent.json) — A2A-style
+  agent card (name, service endpoint, auth scheme, skills).
+- [`docs/agent-api.md`](https://github.com/a-apin/archimedes/blob/main/docs/agent-api.md) —
+  the full, byte-for-byte agent contract: every endpoint, request/response shape, SSE event
+  ordering, job-endpoint ownership scoping, and the honest pass/fail/pending semantics of the
+  rigor gate. Read this before writing a production agent client.

--- a/ui/public/robots.txt
+++ b/ui/public/robots.txt
@@ -1,0 +1,23 @@
+# Archimedes (archimedes-arc.com) — agentic trading, grounded in research, settled on Arc.
+# AI agents: start at /llms.txt for a curated, low-token entry point into the programmatic
+# /api/* surface (SIWE auth, strategy generation, rigor verdicts). Also see
+# /.well-known/agent.json and /api/agent/manifest for machine-readable discovery.
+
+# AI-search crawlers — explicitly welcome. Citations from these are good for us.
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+# Everyone else
+User-agent: *
+Allow: /
+
+Sitemap: https://archimedes-arc.com/sitemap.xml


### PR DESCRIPTION
## Why
Archimedes is **already agent-usable** — full programmatic SIWE (no browser/passkey), JSON generate/deploy/publish/subscribe, a runnable reference client (`scripts/agent_journey.py`). But **nothing on the live domain advertises it**: `/docs` + `/openapi.json` are disabled in prod, and `GET /` just said "docs disabled." An agent that discovers `archimedes-arc.com` organically had zero in-band way to find the API. This ships the discoverability layer — the first step of the agent-native strategy (`docs/AGENT-NATIVE-STRATEGY-2026-07-08.md`).

## What (all additive, inert to humans)
- **`ui/public/llms.txt`** — curated agent entry point: product blurb, the read→auth→generate→rigor→(deploy…) journey with exact endpoints, the SIWE-for-agents recipe, faucet, links to the manifest/agent-card/full docs.
- **`ui/public/robots.txt`** — explicit `Allow` for ClaudeBot / OAI-SearchBot / PerplexityBot / Google-Extended; sitemap + `/llms.txt` pointer.
- **`ui/public/.well-known/agent.json`** — A2A-style agent card (identity, service endpoint, SIWE auth, skills).
- **root `AGENTS.md`** — thin pointer (codebase agents → CLAUDE.md; product-usage agents → agent-api.md + /llms.txt).
- **JSON-LD** in `ui/index.html` (`WebApplication`/`FinanceApplication`, static so non-JS fetchers see it).
- **`GET /`** now returns `llms_txt` / `agent_manifest` / `agent_docs` pointers (additive; existing keys unchanged).
- **`GET /api/agent/manifest`** (new `agent_manifest_routes.py`) — small JSON contract: auth scheme + grouped endpoints + faucet.

## Claim-integrity
Every surface **honestly marks deploy/publish/subscribe/monitor as "landing with the T3.2 redeploy (#588)"** — read + generate are advertised as live; the deploy loop is explicitly *not* promised until T3.2 ships. No overclaiming.

## Verification
- ✅ 47 tests pass (incl. 5 new manifest tests + the backwards-compat `test_root`); ruff (blocking) + format clean; `npm run lint` clean.
- ✅ Empirically confirmed `npm run build` copies `public/` dotfiles (incl. `.well-known/`) into `dist/`, and nginx serves `/.well-known/agent.json` via the general `location /` block (the acme-challenge block is a longer-prefix match only) — **no nginx change needed.**

## Sequencing
Safe to ship now (points only at the proven read/generate/auth legs). The high-leverage follow-ups (MCP server, Circle Agent Marketplace listing) land after T3.2 closes the deploy loop — see the strategy doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)