### PR TITLE
[frontend] Insights: remove Internal tab, lead with real people, lock cost endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,13 +157,18 @@ ARC_VAULT_GOVERNANCE_ADDRESS=
 #   Publishing is refused (503) until this is configured. Checksummed 0x… .
 ARCHIMEDES_TREASURY_WALLET=
 # PLATFORM_ADMIN_WALLETS: comma- or space-separated allowlist of wallet
-#   addresses permitted to publish EXAMPLE strategies (is_example=true) that they
-#   did not generate — the sole exception to the D5 "only the generator may
-#   publish" rule (see wallet_can_publish in models/strategy_generators.py).
+#   addresses granted platform-admin capabilities. Two consumers today:
+#   1. Publishing EXAMPLE strategies (is_example=true) that the wallet did not
+#      generate — the sole exception to the D5 "only the generator may
+#      publish" rule (see wallet_can_publish in models/strategy_generators.py).
+#   2. Reading the SIWE-gated internal cost/ops dashboard, GET
+#      /api/metrics/private/cost (see require_platform_admin in
+#      api/metrics_private_routes.py) — a verified-but-non-admin wallet gets
+#      403 there, not just any authenticated wallet.
 #   Parsed case-insensitively; a stray leading/trailing comma is harmless.
-#   Grants NO fund/custody/treasury authority — publish-example only, and a
-#   listed wallet must still SIWE-authenticate to publish. Empty by default
-#   (no admin wallets).
+#   Grants NO fund/custody/treasury authority — a listed wallet must still
+#   SIWE-authenticate for either capability. Empty by default (no admin
+#   wallets).
 PLATFORM_ADMIN_WALLETS=
 # ARC_PAYMENT_SPLITTER_ADDRESS: the deployed PaymentSplitter contract (set
 #   after the T3.2 deploy). The settlement sweep deposits/withdraws here.

--- a/backend/archimedes/api/metrics_private_routes.py
+++ b/backend/archimedes/api/metrics_private_routes.py
@@ -1,13 +1,19 @@
-"""Private metrics routes — SIWE-gated cost/ops dashboard (issue #830).
+"""Private metrics routes — SIWE + platform-admin-gated cost/ops dashboard (issue #830).
 
 The public ``metrics_router`` (``/api/metrics``, ``/funnel``, ``/visitors``) is
 PII-free by design and stays anonymous — it is the "agents make markets" traction
 instrument. This router is the OTHER half of the split: the internal cost / ops /
 infra dashboard (the ARCH-COST-DASHBOARDS content), which must NOT be public.
 
-Gating reuses the existing SIWE session gate — the same mechanism ``user_routes``
-uses to protect PII (``auth_siwe.require_verified_wallet``). No new auth system:
-a request without a valid ``archimedes_session`` cookie gets **401**.
+Gating (tightened — the Insights-page fix): a valid SIWE session
+(``auth_siwe.require_verified_wallet``) is necessary but no longer sufficient.
+Cost/ops data (Bedrock spend, infra spend, cost-per-user) is operationally
+sensitive, not merely PII — ANY authenticated wallet is not an appropriate bar
+for it. The router now also requires membership in ``PLATFORM_ADMIN_WALLETS``,
+the same env-driven admin allowlist ``models/strategy_generators.wallet_can_publish``
+already uses for the "publish an example strategy you didn't generate" exception.
+A verified-but-non-admin wallet gets **403**; an unauthenticated request still
+gets **401** (session check runs first).
 
 Claim integrity (issue #830, denominator honesty updated by #1028 AC1): the
 private numbers here are recomputed against the honest instruments — distinct
@@ -24,25 +30,45 @@ Real distinct users are read live so the per-user denominators are honest.
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.services.user_stats import get_distinct_user_count
 
-# Every route on this router requires a valid SIWE session (401 otherwise). The
-# router-level dependency is the same gate user_routes uses for PII.
+
+def _platform_admin_wallets() -> set[str]:
+    """Env-driven admin allowlist, lowercased. Same parse as ``wallet_can_publish``."""
+    return {w.strip().lower() for w in os.getenv("PLATFORM_ADMIN_WALLETS", "").replace(",", " ").split() if w.strip()}
+
+
+def require_platform_admin(wallet: str = Depends(require_verified_wallet)) -> str:
+    """FastAPI dependency: verified SIWE session AND ``PLATFORM_ADMIN_WALLETS`` membership.
+
+    401 with no/invalid session (via ``require_verified_wallet``); 403 for a
+    verified wallet that isn't a listed admin. Cost/ops data must not be
+    readable by "any authenticated wallet" — only platform admins.
+    """
+    if wallet not in _platform_admin_wallets():
+        raise HTTPException(status_code=403, detail="Admin access required.")
+    return wallet
+
+
+# Every route on this router requires a valid SIWE session AND platform-admin
+# membership (403 for a non-admin wallet, 401 for no session at all).
 metrics_private_router = APIRouter(
     prefix="/api/metrics/private",
     tags=["metrics", "private"],
-    dependencies=[Depends(require_verified_wallet)],
+    dependencies=[Depends(require_platform_admin)],
 )
 
 
 @metrics_private_router.get("/cost")
-async def get_private_cost(wallet: str = Depends(require_verified_wallet)) -> dict:
-    """SIWE-gated cost/billing dashboard (issue #830). Anonymous → 401.
+async def get_private_cost(wallet: str = Depends(require_platform_admin)) -> dict:
+    """SIWE + platform-admin-gated cost/billing dashboard (issue #830). Anonymous
+    → 401; verified-but-non-admin → 403.
 
     Cost fields are DRAFT placeholders until the live billing wiring lands
     (roadmap: AWS Cost Explorer + Bedrock token metering). ``real_users`` is read

--- a/backend/archimedes/services/visitor_insights_store.py
+++ b/backend/archimedes/services/visitor_insights_store.py
@@ -27,6 +27,22 @@ wallet count in ``user_profiles``.
 Mirrors ``services/funnel_store.py`` / ``telemetry_store.py``: same
 ``redis.asyncio`` convention and **fail-safe by construction** — every method
 swallows Redis errors; instrumentation never turns a request into a 5xx.
+
+Known caveat (Insights-page reconciliation follow-up, post-#854): the
+first-seen-only attribution gate below (``:attributed`` SADD) only prevents
+NEW double-counting from the moment it shipped (2026-07-03). The
+``:country:total:*`` / ``:device:total:*`` HyperLogLog keys are append-only —
+visits recorded before the gate existed (when every landed beacon re-bucketed
+the visitor, so a visitor whose apparent country/device varied across visits —
+VPN, mobile vs. desktop — inflated multiple buckets) remain permanently baked
+into the all-time totals. That pre-existing skew is why the live country/device
+sums can still run ahead of the funnel's ``landed`` count even with this gate in
+place; it is a stale-data problem, not a logic bug, and can only be fully
+resolved by an operator deleting the ``archimedes:visitors:*`` keys (a Redis
+counter reset) so the totals start accumulating exclusively under the
+first-seen gate. The Insights UI states the relationship as directional
+("designed to track… may not match exactly") rather than promising exact
+equality, precisely because of this.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_metrics_private_routes.py
+++ b/backend/tests/test_metrics_private_routes.py
@@ -1,15 +1,18 @@
-"""Tests for the SIWE-gated private metrics routes (issue #830).
+"""Tests for the SIWE + platform-admin-gated private metrics routes (issue #830).
 
 The public metrics endpoints (/api/metrics, /funnel, /visitors) are PII-free and
 stay anonymous. The private cost/ops dashboard (/api/metrics/private/*) reuses the
-existing SIWE session gate (auth_siwe.require_verified_wallet) — the same
-mechanism user_routes uses for PII. Anonymous → 401; valid SIWE session → 200.
+existing SIWE session gate (auth_siwe.require_verified_wallet) AND additionally
+requires ``PLATFORM_ADMIN_WALLETS`` membership (Insights-page fix — cost/ops data
+is operationally sensitive, not just PII, so "any authenticated wallet" was too
+wide a bar). Anonymous → 401; verified-but-non-admin → 403; verified admin → 200.
 
 Hermetic: the SIWE session cookie is built with the real ``_sign_session`` (the
 auth layer's own signer), exercising the production ``_verify_session`` gate
 rather than a mock — the same ``_siwe_cookies`` helper pattern as
 ``test_user_routes.py``. The distinct-user count is mocked at the DB boundary so
-no live Postgres is touched.
+no live Postgres is touched. ``PLATFORM_ADMIN_WALLETS`` is set via monkeypatch,
+not read from a real ``.env``, so the admin allowlist is hermetic too.
 """
 
 from __future__ import annotations
@@ -21,7 +24,8 @@ import pytest
 from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
 from fastapi.testclient import TestClient
 
-_WALLET = "0x1111111111111111111111111111111111111111"
+_ADMIN_WALLET = "0x1111111111111111111111111111111111111111"
+_NON_ADMIN_WALLET = "0x2222222222222222222222222222222222222222"
 
 
 def _siwe_cookies(wallet: str) -> dict[str, str]:
@@ -30,16 +34,20 @@ def _siwe_cookies(wallet: str) -> dict[str, str]:
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
     """Test client over the real app, with the user-count boundary pinned to a known value.
 
     ``get_distinct_user_count`` is imported by-name into the route modules, so we
     patch it where it is *used* (the route modules), not where it is defined —
     otherwise a sibling test that seeds real ``user_profiles`` rows into the shared
     in-memory DB would leak into the assertion (order-dependent flake).
+
+    ``PLATFORM_ADMIN_WALLETS`` is pinned to ``_ADMIN_WALLET`` so admin-gate tests
+    are hermetic (independent of whatever a real deploy's env sets).
     """
     from archimedes.main import app
 
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", _ADMIN_WALLET)
     with (
         patch("archimedes.api.metrics_private_routes.get_distinct_user_count", return_value=2),
         patch("archimedes.api.metrics_routes.get_distinct_user_count", return_value=2),
@@ -59,16 +67,34 @@ def test_private_cost_401_with_bad_cookie(client):
     assert res.status_code == 401
 
 
-def test_private_cost_200_with_valid_siwe_session(client):
-    """Valid SIWE session → 200, with the honest real-users denominator present."""
-    res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_WALLET))
+def test_private_cost_403_for_non_admin_wallet(client):
+    """A verified SIWE session for a wallet NOT in PLATFORM_ADMIN_WALLETS → 403.
+
+    This is the core of the Insights-page lockdown: before this fix, ANY
+    authenticated wallet could read Bedrock/infra/cost-per-user data. Now only
+    admin wallets can.
+    """
+    res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_NON_ADMIN_WALLET))
+    assert res.status_code == 403
+
+
+def test_private_cost_200_with_valid_admin_siwe_session(client):
+    """Valid SIWE session for an admin wallet → 200, with the honest real-users denominator present."""
+    res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_ADMIN_WALLET))
     assert res.status_code == 200
     body = res.json()
     # The honest distinct-user count is present (denominator for any per-user $).
     assert body["real_users"] == 2
-    assert body["authenticated_wallet"] == _WALLET.lower()
+    assert body["authenticated_wallet"] == _ADMIN_WALLET.lower()
     # Cost fields are draft placeholders until billing wiring lands.
     assert body["source"] == "draft"
+
+
+def test_private_cost_admin_wallets_parsed_case_insensitively(client, monkeypatch):
+    """Admin match is case-insensitive, mirroring wallet_can_publish's parsing."""
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", _ADMIN_WALLET.upper())
+    res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_ADMIN_WALLET))
+    assert res.status_code == 200
 
 
 def test_public_metrics_stays_public_and_pii_free(client):

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -99,7 +99,9 @@ export default function Insights() {
 
   useEffect(() => { load() }, [load])
 
-  const landed = funnel?.stages?.find(s => s.stage === 'landed')?.distinct_visitors ?? 0
+  // null (not 0) when the funnel hasn't loaded / failed — so "Distinct visitors"
+  // renders an honest "—" (unknown) rather than a misleading "0".
+  const landed = funnel ? (funnel.stages?.find(s => s.stage === 'landed')?.distinct_visitors ?? 0) : null
   const totalDevices = visitors ? Object.values(visitors.devices || {}).reduce((a, b) => a + b, 0) : 0
   const maxCountry = visitors?.countries?.[0]?.distinct_visitors ?? 0
 
@@ -148,8 +150,10 @@ export default function Insights() {
       {/* ── Conversion funnel ── */}
       <section style={{ ...card, marginBottom: 16 }}>
         <h2 style={{ marginTop: 0, fontSize: 16 }}>Conversion funnel — distinct visitors</h2>
-        {!funnel ? (
+        {loading && !funnel ? (
           <Empty>Loading…</Empty>
+        ) : !funnel ? (
+          <Empty>Couldn’t load the funnel{error ? `: ${error}` : '.'}</Empty>
         ) : landed === 0 ? (
           <Empty>No visitors recorded yet. The funnel started collecting when it deployed today.</Empty>
         ) : (

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -1,24 +1,35 @@
 import { useState, useEffect, useCallback } from 'react'
 import { apiGet } from '../api'
-import { checkSession } from '../siwe'
 
-// Insights — the public conversion + traction dashboard (#787, #830).
+// Insights — the public conversion + traction dashboard (#787, #830, #854).
 //
 // Renders the live conversion instruments as a human-readable dashboard instead
-// of raw JSON. Everything on the PUBLIC tab is PII-free by design:
+// of raw JSON. Public-only, PII-free by design — the cost/ops dashboard is a
+// SEPARATE, SIWE + platform-admin-gated surface
+// (backend/archimedes/api/metrics_private_routes.py, GET
+// /api/metrics/private/cost) and is intentionally NOT rendered anywhere in this
+// component:
 //   - Traction: human vs agent REQUEST counts (honestly labelled — these are
 //     cumulative request tallies, bot-inflated, NOT unique users) + the honest
-//     distinct real-users (wallet) count alongside them.
+//     distinct real-users (wallet) count alongside them. "Real users (wallets)"
+//     is a distinct-DB-row, all-time count; it is a DIFFERENT population from
+//     the funnel's "Connected Wallet" below (distinct anonymous visitor
+//     SESSIONS that reached that step) — the two numbers are not expected to
+//     match, and the copy says so explicitly rather than leaving readers to
+//     guess.
 //   - Conversion funnel: distinct visitors through landed → wallet_connected →
 //     generation_started → vault_deployed, with step-conversion %.
 //   - Visitor insights: distinct visitors by country + device, drawn from the
-//     SAME JS-gated `landed` beacon population as the funnel (#830) — geo/device
-//     count agrees with the funnel `landed` count by construction. Geography is
-//     `ZZ` until Dan's CloudFront terraform apply lands (#795).
-//
-// The INTERNAL tab (cost / ops) is SIWE-gated: it only renders the private
-// dashboard when the viewer holds a valid session, and its cards read the
-// SIWE-gated /api/metrics/private/* endpoints (401 when anonymous).
+//     SAME JS-gated `landed` beacon population as the funnel, attributed once
+//     per visitor (issue #854 finding #6: a Redis SADD first-seen gate in
+//     services/visitor_insights_store.py). This is INTENDED to sum to the
+//     funnel's `landed` count going forward, but the underlying HyperLogLog
+//     counters are append-only — visits recorded before the attribution gate
+//     shipped (2026-07-03) remain baked into the all-time totals and can't be
+//     retroactively de-duplicated without an operator resetting the Redis
+//     keys. The UI states this as a directional relationship, not an exact
+//     equality, until that reset happens. Geography is `ZZ` until Dan's
+//     CloudFront terraform apply lands (#795).
 
 const FUNNEL_LABELS = {
   landed: 'Landed',
@@ -58,11 +69,6 @@ export default function Insights() {
   const [error, setError] = useState(null)
   const [visitorsError, setVisitorsError] = useState(null)
 
-  // SIWE session drives the private (cost/ops) tab. Anonymous viewers only ever
-  // see the public dashboard; the internal cards read SIWE-gated endpoints.
-  const [session, setSession] = useState({ authenticated: false, wallet: null })
-  const [tab, setTab] = useState('public')
-
   const load = useCallback(async () => {
     setLoading(true)
     setError(null)
@@ -92,7 +98,6 @@ export default function Insights() {
   }, [])
 
   useEffect(() => { load() }, [load])
-  useEffect(() => { checkSession().then(setSession).catch(() => {}) }, [])
 
   const landed = funnel?.stages?.find(s => s.stage === 'landed')?.distinct_visitors ?? 0
   const totalDevices = visitors ? Object.values(visitors.devices || {}).reduce((a, b) => a + b, 0) : 0
@@ -110,182 +115,111 @@ export default function Insights() {
         Live conversion instruments for our (un-promoted) traffic. Read-only, PII-free.
       </p>
 
-      {/* Public / Internal tabs — Internal is SIWE-gated. */}
-      <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-        <TabButton active={tab === 'public'} onClick={() => setTab('public')}>Public</TabButton>
-        <TabButton active={tab === 'internal'} onClick={() => setTab('internal')}>
-          Internal {session.authenticated ? '' : '🔒'}
-        </TabButton>
-      </div>
-
       {error && (
         <div style={{ ...card, borderColor: 'var(--negative-bd)', color: 'var(--negative)', marginBottom: 16 }}>
           Couldn’t load metrics: {error}
         </div>
       )}
 
-      {tab === 'internal' ? (
-        <InternalDashboard session={session} />
-      ) : (
-        <>
-          {/* ── Traction ── */}
-          <section style={{ ...card, marginBottom: 16 }}>
-            <h2 style={{ marginTop: 0, fontSize: 16 }}>Traction — requests &amp; users</h2>
-            <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
-              <Stat label="Human-UA requests" value={metrics?.human_count} />
-              <Stat label="Agent / bot requests" value={metrics?.agent_count} />
-              <Stat label="Total requests" value={metrics?.total_requests} />
-              <Stat label="Real users (wallets)" value={metrics?.real_users} accent="#3fb56b" />
-            </div>
-            <p style={{ color: 'var(--text-2)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
-              ⚠️ The request counts are <strong>cumulative request counts</strong>, not unique users — and the
-              “human” bucket is inflated by browser-UA bots. <strong>Real users</strong> is the honest distinct
-              count (wallet rows). The funnel below (distinct visitors, JS-gated so crawlers drop out) is the
-              clean visitor signal.
-            </p>
-          </section>
+      {/* ── Traction ── */}
+      <section style={{ ...card, marginBottom: 16 }}>
+        <h2 style={{ marginTop: 0, fontSize: 16 }}>Traction — requests &amp; users</h2>
+        <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
+          <Stat label="Human-UA requests" value={metrics?.human_count} />
+          <Stat label="Agent / bot requests" value={metrics?.agent_count} />
+          <Stat label="Total requests" value={metrics?.total_requests} />
+          <Stat label="Real users (wallets)" value={metrics?.real_users} accent="#3fb56b" />
+        </div>
+        <p style={{ color: 'var(--text-2)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
+          ⚠️ The request counts are <strong>cumulative request counts</strong>, not unique users — and the
+          “human” bucket is inflated by browser-UA bots. <strong>Real users (wallets)</strong> is the honest
+          distinct count of wallet addresses in our database, all-time. It is <em>not</em> the same number as
+          “Connected Wallet” in the funnel below — that counts distinct <em>visitor sessions</em> (anonymous,
+          cookie-based) that reached the wallet-connect step, so one real wallet can show up as several
+          sessions across devices, browsers, or repeat visits. The two numbers measure different things by
+          design; seeing them differ is expected, not a bug.
+        </p>
+      </section>
 
-          {/* ── Conversion funnel ── */}
-          <section style={{ ...card, marginBottom: 16 }}>
-            <h2 style={{ marginTop: 0, fontSize: 16 }}>Conversion funnel — distinct visitors</h2>
-            {!funnel ? (
-              <Empty>Loading…</Empty>
-            ) : landed === 0 ? (
-              <Empty>No visitors recorded yet. The funnel started collecting when it deployed today.</Empty>
-            ) : (
-              <div style={{ display: 'grid', gap: 14 }}>
-                {funnel.stages.map((s, i) => (
-                  <div key={s.stage}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, marginBottom: 5 }}>
-                      <span>{FUNNEL_LABELS[s.stage] || s.stage}</span>
-                      <span style={{ color: 'var(--text-2)' }}>
-                        <strong style={{ color: 'var(--text-1)' }}>{s.distinct_visitors}</strong>
-                        {i > 0 && <> · {(s.step_conversion * 100).toFixed(0)}% of prev</>}
-                      </span>
+      {/* ── Conversion funnel ── */}
+      <section style={{ ...card, marginBottom: 16 }}>
+        <h2 style={{ marginTop: 0, fontSize: 16 }}>Conversion funnel — distinct visitors</h2>
+        {!funnel ? (
+          <Empty>Loading…</Empty>
+        ) : landed === 0 ? (
+          <Empty>No visitors recorded yet. The funnel started collecting when it deployed today.</Empty>
+        ) : (
+          <div style={{ display: 'grid', gap: 14 }}>
+            {funnel.stages.map((s, i) => (
+              <div key={s.stage}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, marginBottom: 5 }}>
+                  <span>{FUNNEL_LABELS[s.stage] || s.stage}</span>
+                  <span style={{ color: 'var(--text-2)' }}>
+                    <strong style={{ color: 'var(--text-1)' }}>{s.distinct_visitors}</strong>
+                    {i > 0 && <> · {(s.step_conversion * 100).toFixed(0)}% of prev</>}
+                  </span>
+                </div>
+                <Bar pct={s.pct_of_landed * 100} color={i === 0 ? '#5b9dff' : s.distinct_visitors > 0 ? '#3fb56b' : '#3a3f4b'} />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Visitor insights (geo + device) ── */}
+      <section style={card}>
+        <h2 style={{ marginTop: 0, fontSize: 16 }}>Who’s visiting — geography &amp; device</h2>
+        <p style={{ color: 'var(--text-2)', fontSize: 12.5, marginTop: 0, marginBottom: 14 }}>
+          Same JS-gated <strong>landed</strong> population as the funnel, attributed once per visitor so a
+          repeat visit doesn’t get double-counted. These sums are designed to track the funnel’s{' '}
+          <em>Landed</em> number above, but may not match it exactly — both are HyperLogLog estimates, and
+          visits recorded before once-per-visitor attribution shipped can still show up in the all-time
+          totals. Treat this as directional, not a precise reconciliation. Country shows{' '}
+          <code>ZZ</code> (unknown / not provided) until CloudFront forwards the visitor's country.
+        </p>
+        {loading && !visitors && !visitorsError ? (
+          <Empty>Loading visitor insights…</Empty>
+        ) : visitorsError ? (
+          <Empty>Couldn’t load visitor insights: {visitorsError}</Empty>
+        ) : !visitors || ((visitors.countries?.length ?? 0) === 0 && totalDevices === 0) ? (
+          <Empty>No visitors recorded yet.</Empty>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 24 }}>
+            <div>
+              <h3 style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 10px' }}>Top countries</h3>
+              <div style={{ display: 'grid', gap: 10 }}>
+                {(visitors.countries || []).slice(0, 8).map(c => (
+                  <div key={c.code}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
+                      <span>{COUNTRY_NAMES[c.code] || c.code}</span>
+                      <strong>{c.distinct_visitors}</strong>
                     </div>
-                    <Bar pct={s.pct_of_landed * 100} color={i === 0 ? '#5b9dff' : s.distinct_visitors > 0 ? '#3fb56b' : '#3a3f4b'} />
+                    <Bar pct={maxCountry ? (c.distinct_visitors / maxCountry) * 100 : 0} color="#7c6cff" />
                   </div>
                 ))}
               </div>
-            )}
-          </section>
-
-          {/* ── Visitor insights (geo + device) ── */}
-          <section style={card}>
-            <h2 style={{ marginTop: 0, fontSize: 16 }}>Who’s visiting — geography &amp; device</h2>
-            <p style={{ color: 'var(--text-2)', fontSize: 12.5, marginTop: 0, marginBottom: 14 }}>
-              Same JS-gated <strong>landed</strong> population as the funnel — distinct visitors, attributed once
-              per visitor, so these counts reconcile with the funnel’s <em>Landed</em> number. Country shows{' '}
-              <code>ZZ</code> (unknown / not provided) until CloudFront forwards the visitor's country.
-            </p>
-            {loading && !visitors && !visitorsError ? (
-              <Empty>Loading visitor insights…</Empty>
-            ) : visitorsError ? (
-              <Empty>Couldn’t load visitor insights: {visitorsError}</Empty>
-            ) : !visitors || ((visitors.countries?.length ?? 0) === 0 && totalDevices === 0) ? (
-              <Empty>No visitors recorded yet.</Empty>
-            ) : (
-              <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 24 }}>
-                <div>
-                  <h3 style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 10px' }}>Top countries</h3>
-                  <div style={{ display: 'grid', gap: 10 }}>
-                    {(visitors.countries || []).slice(0, 8).map(c => (
-                      <div key={c.code}>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
-                          <span>{COUNTRY_NAMES[c.code] || c.code}</span>
-                          <strong>{c.distinct_visitors}</strong>
-                        </div>
-                        <Bar pct={maxCountry ? (c.distinct_visitors / maxCountry) * 100 : 0} color="#7c6cff" />
+            </div>
+            <div>
+              <h3 style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 10px' }}>Device</h3>
+              <div style={{ display: 'grid', gap: 10 }}>
+                {Object.entries(visitors.devices || {})
+                  .filter(([, n]) => n > 0)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([dev, n]) => (
+                    <div key={dev}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
+                        <span>{DEVICE_LABELS[dev] || dev}</span>
+                        <strong>{n}</strong>
                       </div>
-                    ))}
-                  </div>
-                </div>
-                <div>
-                  <h3 style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 10px' }}>Device</h3>
-                  <div style={{ display: 'grid', gap: 10 }}>
-                    {Object.entries(visitors.devices || {})
-                      .filter(([, n]) => n > 0)
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([dev, n]) => (
-                        <div key={dev}>
-                          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
-                            <span>{DEVICE_LABELS[dev] || dev}</span>
-                            <strong>{n}</strong>
-                          </div>
-                          <Bar pct={totalDevices ? (n / totalDevices) * 100 : 0} color="#3fb56b" />
-                        </div>
-                      ))}
-                  </div>
-                </div>
+                      <Bar pct={totalDevices ? (n / totalDevices) * 100 : 0} color="#3fb56b" />
+                    </div>
+                  ))}
               </div>
-            )}
-          </section>
-        </>
-      )}
-    </div>
-  )
-}
-
-// ── Internal (SIWE-gated) cost/ops dashboard ────────────────────────────────
-
-function InternalDashboard({ session }) {
-  const [cost, setCost] = useState(null)
-  const [err, setErr] = useState(null)
-
-  useEffect(() => {
-    if (!session.authenticated) return
-    apiGet('/api/metrics/private/cost').then(setCost).catch(e => setErr(String(e.message || e)))
-  }, [session.authenticated])
-
-  if (!session.authenticated) {
-    return (
-      <section style={card}>
-        <h2 style={{ marginTop: 0, fontSize: 16 }}>Internal — cost &amp; ops 🔒</h2>
-        <Empty>
-          Sign in with your wallet to view the internal cost / ops dashboard. Bedrock spend, infra
-          cost, and ops health are SIWE-gated — the public tab stays PII- and cost-free by design.
-        </Empty>
+            </div>
+          </div>
+        )}
       </section>
-    )
-  }
-
-  return (
-    <section style={card}>
-      <h2 style={{ marginTop: 0, fontSize: 16 }}>Internal — cost &amp; ops</h2>
-      {err && <div style={{ color: 'var(--negative)', fontSize: 13, marginBottom: 12 }}>Couldn’t load: {err}</div>}
-      <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
-        <Stat label="Real users (wallets)" value={cost?.real_users} accent="#3fb56b" />
-        <Stat label="Bedrock / mo (USD)" value={cost?.bedrock_monthly_usd} />
-        <Stat label="Infra / mo (USD)" value={cost?.infra_monthly_usd} />
-        <Stat label="Cost / user (USD)" value={cost?.cost_per_user_usd} />
-      </div>
-      <p style={{ color: 'var(--text-2)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
-        {cost?.source === 'draft'
-          ? 'Draft placeholders — live Bedrock/infra billing wiring is roadmap work. Any $/user or $/gen figure is derived from real users (wallets) or generations, never the request tallies (#830).'
-          : 'Per-user / per-generation figures are derived from real users or generations, never the request tallies (#830).'}
-      </p>
-    </section>
-  )
-}
-
-function TabButton({ active, onClick, children }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      style={{
-        fontSize: 13,
-        padding: '6px 14px',
-        borderRadius: 8,
-        cursor: 'pointer',
-        border: '1px solid var(--glass-border)',
-        background: active ? 'var(--surface-1)' : 'transparent',
-        color: active ? 'var(--text-1)' : 'var(--text-2)',
-        fontWeight: active ? 700 : 400,
-      }}
-    >
-      {children}
-    </button>
+    </div>
   )
 }
 

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -121,24 +121,28 @@ export default function Insights() {
         </div>
       )}
 
-      {/* ── Traction ── */}
+      {/* ── Real people (the honest headline) — distinct people first; raw request
+          volume is demoted to a footnote because it's bot-inflated server hits, not people. */}
       <section style={{ ...card, marginBottom: 16 }}>
-        <h2 style={{ marginTop: 0, fontSize: 16 }}>Traction — requests &amp; users</h2>
+        <h2 style={{ marginTop: 0, fontSize: 16 }}>Real people</h2>
         <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
-          <Stat label="Human-UA requests" value={metrics?.human_count} />
-          <Stat label="Agent / bot requests" value={metrics?.agent_count} />
-          <Stat label="Total requests" value={metrics?.total_requests} />
+          <Stat label="Distinct visitors" value={landed} accent="#5b9dff" />
           <Stat label="Real users (wallets)" value={metrics?.real_users} accent="#3fb56b" />
         </div>
         <p style={{ color: 'var(--text-2)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
-          ⚠️ The request counts are <strong>cumulative request counts</strong>, not unique users — and the
-          “human” bucket is inflated by browser-UA bots. <strong>Real users (wallets)</strong> is the honest
-          distinct count of wallet addresses in our database, all-time. It is <em>not</em> the same number as
-          “Connected Wallet” in the funnel below — that counts distinct <em>visitor sessions</em> (anonymous,
-          cookie-based) that reached the wallet-connect step, so one real wallet can show up as several
-          sessions across devices, browsers, or repeat visits. The two numbers measure different things by
-          design; seeing them differ is expected, not a bug.
+          The honest “how many people” numbers. <strong>Distinct visitors</strong> = unique people who loaded
+          the app (JS-gated, so crawlers and bots drop out — this is the funnel’s <em>Landed</em> count below).
+          <strong> Real users</strong> = distinct wallet addresses that have signed in, all-time. (These differ
+          from the funnel’s “Connected Wallet”, which counts anonymous visitor <em>sessions</em> that reached
+          wallet-connect — one person can be several sessions across devices or repeat visits.)
         </p>
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid var(--glass-border)', fontSize: 12, color: 'var(--text-3)' }}>
+          <strong style={{ color: 'var(--text-2)' }}>Raw request volume</strong> — server hits, <em>not</em> people
+          (cumulative all-time, heavily bot-inflated; kept only as an infra signal):{' '}
+          {metrics?.total_requests?.toLocaleString() ?? '—'} total ·{' '}
+          {metrics?.human_count?.toLocaleString() ?? '—'} browser-UA ·{' '}
+          {metrics?.agent_count?.toLocaleString() ?? '—'} agent/bot.
+        </div>
       </section>
 
       {/* ── Conversion funnel ── */}


### PR DESCRIPTION
Addresses Dan's Insights feedback: remove the Internal tab (cost/ops data isn't appropriate to display publicly), and make the Public numbers **coherent** — a viewer couldn't tell how many *real people* had visited.

## Changes
1. **Removed the Internal tab entirely** — dropped the Public/Internal toggle, `InternalDashboard`, `TabButton`, and the dead `session`/`checkSession` wiring. Insights is public-only.
2. **Locked `GET /api/metrics/private/cost`** — was gated only by `require_verified_wallet` (any authenticated wallet). Now requires a `PLATFORM_ADMIN_WALLETS` admin (reuses the existing allowlist from `wallet_can_publish`): non-admins get **403**, anon **401**. So the internal cost data isn't fetchable either, not just hidden.
3. **Reframed the headline to "Real people"** — the section used to lead with the giant cumulative, **bot-inflated** request tallies (49k human-UA / 47k agent/bot), which made "how many real people visited?" unanswerable. Now:
   - Headline = **Distinct visitors** (JS-gated unique loaders = the funnel's Landed) + **Real users** (distinct signed-in wallets, all-time).
   - Raw request counts demoted to a small "**server hits, not people** (bot-inflated)" footnote.
   - Copy makes the visitors-vs-sessions and real-users-vs-connected-wallet distinctions explicit, so 8-vs-28 reads as two honest measurements, not a contradiction.
4. **Honest reconciliation** — the geo/device "by construction reconciles with Landed" claim was false (root cause: pre-fix duplicate visitor writes are permanently baked into append-only HyperLogLog sketches — the query-level dedupe fix from #854 is forward-only). Copy now states the relationship as directional/estimate-based, and a `visitor_insights_store.py` docstring names the exact `archimedes:visitors:*` Redis keys an operator would reset to make the all-time totals actually reconcile.

## Verification
- ✅ 2837 backend tests pass (`-m "not integration"`); 87 metrics/funnel/visitor tests pass; ruff (blocking) + format clean; `npm run lint` clean on Insights.jsx.
- Added 3 tests for the admin lockdown (403 non-admin, 200 admin, case-insensitive match).

## Follow-up (ops, not code)
To make the live all-time geo/device totals *actually* reconcile (not just honestly labeled), an operator resets the `archimedes:visitors:country:total:*` / `:device:total:*` Redis keys (documented in the store). Optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)