### PR TITLE
[security] Fix /api/proposals unauthenticated privacy leak (owner-scope + migration)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1129,6 +1129,7 @@ async def run_generation(
                         if cand is best
                         else (cand.rigor_verdict or {}).get("reason") or "outranked by the society leader",
                     },
+                    owner_wallet=owner_wallet,
                 )
         except Exception:
             pass  # Non-blocking per spec

--- a/backend/archimedes/api/proposals_routes.py
+++ b/backend/archimedes/api/proposals_routes.py
@@ -67,10 +67,11 @@ async def get_proposal_siblings(generation_id: str, wallet: str = Depends(requir
     """Get all proposals from the same generation — 'considered alternatives'.
 
     Owner-scoped: 401 without a verified SIWE session; a generation owned by
-    another wallet (or a legacy NULL-owner generation) returns an empty
-    sibling list rather than 403/404 — existence of another user's generation
-    stays unconfirmed, mirroring the 404-not-403 pattern used elsewhere in
-    this codebase for owner-gated resources.
+    another wallet (or a legacy NULL-owner generation) returns HTTP 200 with an
+    empty sibling list — never a 403 or 404. Returning an empty list rather than
+    an error keeps the existence of another user's generation unconfirmed, the
+    same non-disclosure goal as the 404-not-403 convention used elsewhere for
+    owner-gated resources.
     """
     from archimedes.services.strategy_memory import get_siblings
 

--- a/backend/archimedes/api/proposals_routes.py
+++ b/backend/archimedes/api/proposals_routes.py
@@ -1,13 +1,25 @@
 """Proposals API — read endpoint for the strategy_proposals episodic table.
 
-Exposes ``GET /api/strategies/proposals`` with filtering and pagination.
+Exposes ``GET /api/proposals/`` with filtering and pagination.
 Write path lives in ``services/strategy_memory.py`` and is called from
 the generation pipeline / fusion / architect code paths.
+
+Owner-scoped (privacy fix, `dbrowneup/proposals-owner-scope`): every
+``StrategyProposal`` row carries a user's private ``intent`` (their
+strategic brief), full ``strategy_spec``, and ``rigor_verdict`` — including
+rejected candidates. Both endpoints below previously had no auth at all and
+returned EVERY user's rows. They now require a verified SIWE session
+(``require_verified_wallet``, the same dependency other owner-scoped routes
+use — see ``strategies_routes.py`` / ``vaults_routes.py``) and filter to the
+caller's own wallet in the DB query. A legacy row with ``owner_wallet IS
+NULL`` (written before this column existed) is returned to NO ONE.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
+
+from archimedes.api.auth_siwe import require_verified_wallet
 
 proposals_router = APIRouter(prefix="/api/proposals", tags=["proposals"])
 
@@ -21,11 +33,16 @@ async def list_proposals(
     since: str | None = Query(None, description="ISO datetime lower bound"),
     limit: int = Query(50, ge=1, le=200, description="Page size"),
     offset: int = Query(0, ge=0, description="Offset"),
+    wallet: str = Depends(require_verified_wallet),
 ):
     """List episodic strategy proposals with filtering and pagination.
 
     Every fusion / architect / agent generation writes a proposal row here.
     The endpoint is read-only; writes happen via ``strategy_memory.persist_proposal``.
+
+    Owner-scoped: 401 without a verified SIWE session; scoped to the caller's
+    own ``owner_wallet`` (case-insensitive) otherwise. The DB query does the
+    filtering — see ``strategy_memory.query_proposals``.
     """
     from archimedes.services.strategy_memory import query_proposals
 
@@ -35,6 +52,7 @@ async def list_proposals(
         since=since,
         limit=limit,
         offset=offset,
+        owner_wallet=wallet,
     )
     return {
         "proposals": proposals,
@@ -45,11 +63,18 @@ async def list_proposals(
 
 
 @proposals_router.get("/{generation_id}/siblings")
-async def get_proposal_siblings(generation_id: str):
-    """Get all proposals from the same generation — 'considered alternatives'."""
+async def get_proposal_siblings(generation_id: str, wallet: str = Depends(require_verified_wallet)):
+    """Get all proposals from the same generation — 'considered alternatives'.
+
+    Owner-scoped: 401 without a verified SIWE session; a generation owned by
+    another wallet (or a legacy NULL-owner generation) returns an empty
+    sibling list rather than 403/404 — existence of another user's generation
+    stays unconfirmed, mirroring the 404-not-403 pattern used elsewhere in
+    this codebase for owner-gated resources.
+    """
     from archimedes.services.strategy_memory import get_siblings
 
-    siblings = get_siblings(generation_id)
+    siblings = get_siblings(generation_id, owner_wallet=wallet)
     return {
         "generation_id": generation_id,
         "siblings": siblings,

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2276,6 +2276,9 @@ async def _run_fusion_job(job_id: str) -> None:
                     "fusion_reasoning": result.fusion_reasoning,
                     "novelty_rationale": result.novelty_rationale,
                 },
+                # SIWE-derived owner threaded from the job payload (stamped at
+                # enqueue time by generate_strategy — never client-supplied).
+                owner_wallet=payload.get("owner_wallet"),
             )
         except Exception:
             pass  # Non-blocking per spec
@@ -2336,6 +2339,9 @@ async def construct_strategy(
                 "risk_notes": proposal.risk_notes,
                 "regime": proposal.regime,
             },
+            # SIWE-derived owner (gate_generation) — None when
+            # REQUIRE_SIWE_FOR_GENERATION is off (local dev/demo opt-out).
+            owner_wallet=_wallet,
         )
     except Exception:
         pass  # Non-blocking per spec

--- a/backend/archimedes/models/strategy_proposal.py
+++ b/backend/archimedes/models/strategy_proposal.py
@@ -51,6 +51,16 @@ class StrategyProposal(Base):
     # Regime tag (nullable — only populated when regime is known)
     regime_tag = Column(String(16), nullable=True)
 
+    # SIWE-derived owner wallet, lowercased (never client-supplied — threaded
+    # server-side from persist_proposal callers). NULL on rows written before
+    # this column existed (legacy) — those rows are private to NO ONE; the
+    # owner-scoped read path (proposals_routes.py) filters on an exact
+    # non-NULL match, so NULL never satisfies any caller's filter (privacy
+    # leak fix — every user's proposals, including rejected candidates with
+    # their private intent/strategy_spec/rigor_verdict, were previously
+    # readable by anyone via the unauthenticated GET /api/proposals/).
+    owner_wallet = Column(String(42), nullable=True, index=True)
+
     # Full proposal payload as JSONB
     payload = Column(Text, nullable=False, default="{}")
 
@@ -83,6 +93,7 @@ class StrategyProposal(Base):
             "content_hash": self.content_hash,
             "agent": self.agent,
             "regime_tag": self.regime_tag,
+            "owner_wallet": self.owner_wallet,
             "payload": json.loads(self.payload) if self.payload else {},
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/backend/archimedes/services/strategy_memory.py
+++ b/backend/archimedes/services/strategy_memory.py
@@ -61,8 +61,16 @@ def persist_proposal(
     regime_tag: str | None = None,
     parent_proposal_id: str | None = None,
     extra: dict | None = None,
+    owner_wallet: str | None = None,
 ) -> str | None:
     """Persist a proposal row. Returns the proposal ID or None on failure.
+
+    ``owner_wallet`` is the SIWE-derived wallet (never client-supplied) —
+    threaded from the call site's own verified session / job payload. Stored
+    lowercased for case-insensitive matching against the caller wallet the
+    owner-scoped read path (``proposals_routes.py``) compares against. ``None``
+    means anonymous/unattributed generation — those rows are private to NO
+    ONE once persisted (the owner-scoped query never matches a NULL column).
 
     Non-blocking: catches all DB errors, logs them, returns None.
     """
@@ -72,6 +80,7 @@ def persist_proposal(
 
         papers = papers or []
         proposal_id = uuid.uuid4().hex[:16]
+        owner_wallet = owner_wallet.lower() if owner_wallet else None
 
         canonical = _canonicalize_payload(intent, strategy_spec, papers, rigor_verdict, agent, extra)
         content_hash = _compute_keccak256(canonical)
@@ -102,10 +111,19 @@ def persist_proposal(
                 .first()
             )
             if existing:
+                changed = False
                 # Update verdict if changed
                 if verdict != existing.verdict:
                     existing.verdict = verdict
                     existing.trust_level = trust_level
+                    changed = True
+                # Backfill ownership on a dedup hit (mirrors
+                # strategy_store.upsert_strategy): never overwrite an existing
+                # owner, only attach one to a previously-anonymous row.
+                if owner_wallet and not existing.owner_wallet:
+                    existing.owner_wallet = owner_wallet
+                    changed = True
+                if changed:
                     existing.updated_at = datetime.now(UTC)
                     session.commit()
                 return existing.proposal_id
@@ -120,6 +138,7 @@ def persist_proposal(
                 content_hash=content_hash,
                 agent=agent,
                 regime_tag=regime_tag,
+                owner_wallet=owner_wallet,
                 payload=json.dumps(payload, ensure_ascii=False),
             )
             session.add(row)
@@ -145,8 +164,18 @@ def query_proposals(
     since: str | None = None,
     limit: int = 50,
     offset: int = 0,
+    owner_wallet: str | None = None,
 ) -> tuple[list[dict], int]:
     """Query proposals with filtering and pagination.
+
+    ``owner_wallet``, when given, scopes the query to rows whose stored
+    ``owner_wallet`` exactly (case-insensitively) matches — pushed into the
+    SQL ``WHERE`` clause, not filtered in Python after a fetch-all. A NULL
+    ``owner_wallet`` column (legacy, pre-ownership rows) never satisfies this
+    equality filter, so those rows are returned to no caller. Callers that
+    omit ``owner_wallet`` get the unscoped query — internal/trusted use only;
+    every HTTP-facing caller (``proposals_routes.py``) must pass the SIWE
+    session wallet here.
 
     Returns (proposals, total_count).
     """
@@ -157,6 +186,8 @@ def query_proposals(
         with get_session() as session:
             q = session.query(StrategyProposal)
 
+            if owner_wallet:
+                q = q.filter(StrategyProposal.owner_wallet == owner_wallet.lower())
             if verdict:
                 q = q.filter(StrategyProposal.verdict == verdict)
             if agent:
@@ -177,19 +208,24 @@ def query_proposals(
         return [], 0
 
 
-def get_siblings(generation_id: str) -> list[dict]:
-    """Get all proposals from the same generation (for 'considered alternatives')."""
+def get_siblings(generation_id: str, *, owner_wallet: str | None = None) -> list[dict]:
+    """Get all proposals from the same generation (for 'considered alternatives').
+
+    ``owner_wallet``, when given, scopes to rows owned by that wallet
+    (case-insensitive, pushed into the SQL filter — see ``query_proposals``
+    docstring for the same NULL-never-matches guarantee). Omitting it returns
+    the unscoped sibling set — internal/trusted use only; the HTTP-facing
+    caller (``proposals_routes.py``) must always pass the SIWE session wallet.
+    """
     try:
         from archimedes.db import get_session
         from archimedes.models.strategy_proposal import StrategyProposal
 
         with get_session() as session:
-            rows = (
-                session.query(StrategyProposal)
-                .filter(StrategyProposal.generation_id == generation_id)
-                .order_by(StrategyProposal.created_at.asc())
-                .all()
-            )
+            q = session.query(StrategyProposal).filter(StrategyProposal.generation_id == generation_id)
+            if owner_wallet:
+                q = q.filter(StrategyProposal.owner_wallet == owner_wallet.lower())
+            rows = q.order_by(StrategyProposal.created_at.asc()).all()
             return [r.to_dict() for r in rows]
 
     except Exception as exc:

--- a/backend/archimedes/services/strategy_memory.py
+++ b/backend/archimedes/services/strategy_memory.py
@@ -186,7 +186,10 @@ def query_proposals(
         with get_session() as session:
             q = session.query(StrategyProposal)
 
-            if owner_wallet:
+            # `is not None` (not truthiness): only an OMITTED owner_wallet (None)
+            # gets the unscoped internal query. An empty string "" is an explicit
+            # (empty) scope that matches no rows — never a silent scope bypass.
+            if owner_wallet is not None:
                 q = q.filter(StrategyProposal.owner_wallet == owner_wallet.lower())
             if verdict:
                 q = q.filter(StrategyProposal.verdict == verdict)
@@ -223,7 +226,10 @@ def get_siblings(generation_id: str, *, owner_wallet: str | None = None) -> list
 
         with get_session() as session:
             q = session.query(StrategyProposal).filter(StrategyProposal.generation_id == generation_id)
-            if owner_wallet:
+            # `is not None` (not truthiness): an empty string "" is an explicit
+            # empty scope (matches no rows), never a silent unscoped bypass — only
+            # an omitted owner_wallet (None) gets the unscoped internal query.
+            if owner_wallet is not None:
                 q = q.filter(StrategyProposal.owner_wallet == owner_wallet.lower())
             rows = q.order_by(StrategyProposal.created_at.asc()).all()
             return [r.to_dict() for r in rows]

--- a/backend/migrations/versions/7b6e8d812331_add_owner_wallet_to_strategy_proposals.py
+++ b/backend/migrations/versions/7b6e8d812331_add_owner_wallet_to_strategy_proposals.py
@@ -1,0 +1,52 @@
+"""add owner_wallet to strategy_proposals
+
+Privacy-leak fix (`dbrowneup/proposals-owner-scope`): ``GET /api/proposals/``
+and ``GET /api/proposals/{generation_id}/siblings`` were completely
+unauthenticated and returned EVERY user's ``StrategyProposal`` rows —
+including each user's private ``intent``, full ``strategy_spec``, and
+``rigor_verdict``, for rejected candidates too. ``strategy_proposals`` had no
+owner column, so there was nothing to scope reads on. This revision adds
+``owner_wallet`` (SIWE-derived, lowercased, server-bound — mirrors
+``strategy_store.owner_wallet``'s shape) so ``proposals_routes.py`` can filter
+in the query rather than fetch-all-then-filter in Python.
+
+Backfill: existing rows are left with ``owner_wallet IS NULL``. They predate
+per-user ownership, so there is no wallet to backfill them with; the
+owner-scoped read path treats a NULL-owner row as private to NO ONE (an exact
+``owner_wallet = :caller`` match never satisfies NULL), not as visible to
+everyone the way the old unauthenticated endpoint made every row.
+
+Revision ID: 7b6e8d812331
+Revises: 4c320621f047
+Create Date: 2026-07-08 19:33:56.219407
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7b6e8d812331"
+down_revision: str | Sequence[str] | None = "4c320621f047"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("strategy_proposals", schema=None) as batch_op:
+        # String(42) matches strategy_store.owner_wallet's width (0x + 40 hex
+        # chars); nullable — legacy rows stay NULL (see module docstring).
+        batch_op.add_column(sa.Column("owner_wallet", sa.String(length=42), nullable=True))
+        batch_op.create_index(batch_op.f("ix_strategy_proposals_owner_wallet"), ["owner_wallet"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("strategy_proposals", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_strategy_proposals_owner_wallet"))
+        batch_op.drop_column("owner_wallet")

--- a/backend/tests/services/test_strategy_memory.py
+++ b/backend/tests/services/test_strategy_memory.py
@@ -1,15 +1,36 @@
 """Tests for strategy_proposals episodic memory (Issue #165).
 
 Covers: ORM model, strategy_memory write path, proposals API endpoint.
+
+The API endpoint tests (``TestProposalsAPI``) were updated for the
+`dbrowneup/proposals-owner-scope` privacy fix: ``GET /api/proposals/`` and
+``GET /api/proposals/{generation_id}/siblings`` now require a verified SIWE
+session and scope to the caller's own ``owner_wallet``. Fuller ownership
+coverage (cross-user isolation, legacy NULL-owner rows, siblings scoping)
+lives in ``tests/test_proposals_ownership.py``; this file's own API tests are
+adapted just enough to keep exercising list/filter/siblings under the new
+auth-required shape.
 """
 
 from __future__ import annotations
 
+import time
 from datetime import UTC
 from unittest.mock import patch
 
 import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
 from fastapi.testclient import TestClient
+
+_WALLET = "0xAAAA000000000000000000000000000000000A"
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Valid signed SIWE session cookie for `wallet` (same helper shape as
+    test_strategy_ownership.py / test_user_routes.py — a real signed session,
+    not header spoofing)."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
 
 # ── ORM model tests ──────────────────────────────────────────────────────
 
@@ -37,6 +58,7 @@ class TestStrategyProposalModel:
             content_hash="0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
             agent="fusion",
             regime_tag="bull",
+            owner_wallet="0xabc0000000000000000000000000000000000a",
             payload='{"intent": "test"}',
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
@@ -44,6 +66,7 @@ class TestStrategyProposalModel:
         d = row.to_dict()
         assert d["id"] == "abc123"
         assert d["generation_id"] == "gen_001"
+        assert d["owner_wallet"] == "0xabc0000000000000000000000000000000000a"
         assert d["verdict"] == "rigor_pass"
         assert d["trust_level"] == "VALIDATED"
         assert d["agent"] == "fusion"
@@ -101,6 +124,48 @@ class TestStrategyMemory:
         )
         assert proposal_id is not None
         assert len(proposal_id) == 16
+
+    def test_persist_proposal_stamps_owner_wallet_lowercased(self):
+        """persist_proposal(owner_wallet=...) stamps the column, lowercased —
+        case-insensitive matching depends on the stored value always being
+        lowercase (dbrowneup/proposals-owner-scope)."""
+        from archimedes import db as db_mod
+        from archimedes.models.strategy_proposal import StrategyProposal
+        from archimedes.services.strategy_memory import persist_proposal
+
+        mixed_case_wallet = "0xAbCDEF0000000000000000000000000000000A"
+
+        proposal_id = persist_proposal(
+            generation_id="gen_owner_stamp",
+            agent="fusion",
+            intent="owner stamping test",
+            owner_wallet=mixed_case_wallet,
+        )
+        assert proposal_id is not None
+
+        with db_mod.get_session() as session:
+            row = session.query(StrategyProposal).filter_by(proposal_id=proposal_id).one()
+            assert row.owner_wallet == mixed_case_wallet.lower()
+
+    def test_persist_proposal_no_owner_stays_null(self):
+        """Omitting owner_wallet (anonymous generation) leaves the column
+        NULL — must not default to an empty string or any other falsy-but-
+        present sentinel, since the owner-scoped filter's NULL-never-matches
+        guarantee depends on it being a real SQL NULL."""
+        from archimedes import db as db_mod
+        from archimedes.models.strategy_proposal import StrategyProposal
+        from archimedes.services.strategy_memory import persist_proposal
+
+        proposal_id = persist_proposal(
+            generation_id="gen_owner_none",
+            agent="fusion",
+            intent="anonymous generation test",
+        )
+        assert proposal_id is not None
+
+        with db_mod.get_session() as session:
+            row = session.query(StrategyProposal).filter_by(proposal_id=proposal_id).one()
+            assert row.owner_wallet is None
 
     def test_persist_proposal_rigor_fail(self):
         from archimedes.services.strategy_memory import persist_proposal
@@ -263,12 +328,20 @@ class TestProposalsAPI:
 
         return TestClient(app)
 
-    def test_list_proposals_empty(self, client):
+    def test_list_proposals_unauthenticated_401(self, client):
+        """dbrowneup/proposals-owner-scope: the endpoint used to be wide open
+        and return every user's proposals. It must now 401 without a
+        verified SIWE session."""
         resp = client.get("/api/proposals")
+        assert resp.status_code == 401
+
+    def test_list_proposals_empty(self, client):
+        resp = client.get("/api/proposals/", cookies=_siwe_cookies(_WALLET))
         assert resp.status_code == 200
         data = resp.json()
         assert "proposals" in data
         assert "total" in data
+        assert data["total"] == 0
 
     def test_list_proposals_after_persist(self, client):
         from archimedes.services.strategy_memory import persist_proposal
@@ -277,8 +350,9 @@ class TestProposalsAPI:
             generation_id="gen_api_test",
             agent="fusion",
             intent="api test proposal",
+            owner_wallet=_WALLET,
         )
-        resp = client.get("/api/proposals")
+        resp = client.get("/api/proposals/", cookies=_siwe_cookies(_WALLET))
         assert resp.status_code == 200
         data = resp.json()
         assert data["total"] >= 1
@@ -291,19 +365,25 @@ class TestProposalsAPI:
             agent="fusion",
             intent="failing proposal",
             rigor_verdict={"passing": False},
+            owner_wallet=_WALLET,
         )
-        resp = client.get("/api/proposals?verdict=rigor_fail")
+        resp = client.get("/api/proposals/?verdict=rigor_fail", cookies=_siwe_cookies(_WALLET))
         assert resp.status_code == 200
         data = resp.json()
+        assert data["proposals"], "expected the seeded rigor_fail proposal back for its owner"
         assert all(p["verdict"] == "rigor_fail" for p in data["proposals"])
+
+    def test_siblings_endpoint_unauthenticated_401(self, client):
+        resp = client.get("/api/proposals/gen_sib_api/siblings")
+        assert resp.status_code == 401
 
     def test_siblings_endpoint(self, client):
         from archimedes.services.strategy_memory import persist_proposal
 
         gid = "gen_sib_api"
-        persist_proposal(generation_id=gid, agent="fusion", intent="sib api 1")
-        persist_proposal(generation_id=gid, agent="architect", intent="sib api 2")
-        resp = client.get(f"/api/proposals/{gid}/siblings")
+        persist_proposal(generation_id=gid, agent="fusion", intent="sib api 1", owner_wallet=_WALLET)
+        persist_proposal(generation_id=gid, agent="architect", intent="sib api 2", owner_wallet=_WALLET)
+        resp = client.get(f"/api/proposals/{gid}/siblings", cookies=_siwe_cookies(_WALLET))
         assert resp.status_code == 200
         data = resp.json()
         assert data["generation_id"] == gid

--- a/backend/tests/test_proposals_ownership.py
+++ b/backend/tests/test_proposals_ownership.py
@@ -1,0 +1,234 @@
+"""Per-user proposals ownership (dbrowneup/proposals-owner-scope).
+
+Confirmed-live privacy leak: `GET /api/proposals/` and
+`GET /api/proposals/{generation_id}/siblings` (backend/archimedes/api/
+proposals_routes.py) were completely unauthenticated and returned EVERY
+user's `StrategyProposal` rows — each row's `payload` carries the user's
+private `intent` (their strategic brief), full `strategy_spec`, and
+`rigor_verdict`, including rejected candidates. `StrategyProposal` had no
+owner column, so there was nothing to scope on.
+
+Hermetic (tmp-sqlite, no .env / network / Redis). Covers:
+  * unauthenticated GET /api/proposals/ -> 401
+  * authenticated wallet A sees only A's proposals (B's rows excluded)
+  * get_proposal_siblings for a generation owned by B -> empty for A
+  * a legacy NULL-owner row (pre-dates this column) -> returned to NO ONE
+  * persist_proposal(owner_wallet=...) stamps the column, lowercased
+
+DB fixture + SIWE cookie helper copy the `_use_tmp_db` / `_siwe_cookies`
+pattern from test_strategy_ownership.py.
+"""
+
+from __future__ import annotations
+
+import time
+
+import archimedes.db as db
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from httpx import ASGITransport, AsyncClient
+
+_W_A = "0xAaAa00000000000000000000000000000000000A"  # mixed case on purpose
+_W_B = "0x000000000000000000000000000000000000000B"
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Point the DB at a FRESH temp sqlite (rebinds db.engine + db.SessionLocal).
+
+    db.engine/SessionLocal are created once at import, so setenv alone doesn't
+    re-point them; rebind both to a per-test engine, then init_db() registers
+    every table.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'proposals_ownership.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Valid signed SIWE session cookie for `wallet` (same helper shape as
+    test_strategy_ownership.py / test_user_routes.py — a real signed session,
+    not header spoofing)."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _mk_proposal(
+    generation_id: str,
+    *,
+    owner: str | None,
+    intent: str = "test intent",
+    verdict: str = "pending",
+):
+    """Write a StrategyProposal row directly (bypasses persist_proposal's
+    content-hash dedup so every seeded row is guaranteed distinct + present,
+    including the legacy-NULL-owner case that predates the owner_wallet
+    column ever being populated)."""
+    import json
+    import uuid
+
+    from archimedes.models.strategy_proposal import StrategyProposal
+
+    proposal_id = uuid.uuid4().hex[:16]
+    content_hash = "0x" + uuid.uuid4().hex + uuid.uuid4().hex[:24]  # unique, right shape
+    with db.get_session() as session:
+        session.add(
+            StrategyProposal(
+                id=content_hash[:16],
+                generation_id=generation_id,
+                proposal_id=proposal_id,
+                verdict=verdict,
+                trust_level="CANDIDATE",
+                content_hash=content_hash,
+                agent="fusion",
+                owner_wallet=owner.lower() if owner else None,
+                payload=json.dumps({"intent": intent, "strategy_spec": {}, "rigor_verdict": None}),
+            )
+        )
+        session.commit()
+    return proposal_id
+
+
+# ── GET /api/proposals/ ────────────────────────────────────────────────
+
+
+async def test_list_proposals_unauthenticated_401():
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/proposals/")
+    assert resp.status_code == 401
+
+
+async def test_list_proposals_owner_a_excludes_owner_b():
+    _mk_proposal("gen_a_1", owner=_W_A, intent="A's private brief")
+    _mk_proposal("gen_a_2", owner=_W_A, intent="A's second brief")
+    _mk_proposal("gen_b_1", owner=_W_B, intent="B's private brief")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp_a = await client.get("/api/proposals/", cookies=_siwe_cookies(_W_A))
+        resp_b = await client.get("/api/proposals/", cookies=_siwe_cookies(_W_B))
+
+    assert resp_a.status_code == 200
+    data_a = resp_a.json()
+    gen_ids_a = {p["generation_id"] for p in data_a["proposals"]}
+    assert gen_ids_a == {"gen_a_1", "gen_a_2"}
+    assert data_a["total"] == 2
+    # B's private intent text must never appear in A's response.
+    intents_a = {p["payload"]["intent"] for p in data_a["proposals"]}
+    assert "B's private brief" not in intents_a
+
+    assert resp_b.status_code == 200
+    data_b = resp_b.json()
+    gen_ids_b = {p["generation_id"] for p in data_b["proposals"]}
+    assert gen_ids_b == {"gen_b_1"}
+    assert data_b["total"] == 1
+
+
+async def test_list_proposals_legacy_null_owner_returned_to_no_one():
+    _mk_proposal("gen_orphan", owner=None, intent="orphaned legacy row")
+    _mk_proposal("gen_a_owned", owner=_W_A, intent="A owns this one")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp_a = await client.get("/api/proposals/", cookies=_siwe_cookies(_W_A))
+        resp_b = await client.get("/api/proposals/", cookies=_siwe_cookies(_W_B))
+
+    gen_ids_a = {p["generation_id"] for p in resp_a.json()["proposals"]}
+    gen_ids_b = {p["generation_id"] for p in resp_b.json()["proposals"]}
+    assert "gen_orphan" not in gen_ids_a
+    assert "gen_orphan" not in gen_ids_b
+    assert gen_ids_a == {"gen_a_owned"}
+    assert gen_ids_b == set()
+
+
+async def test_list_proposals_case_insensitive_wallet_match():
+    """owner_wallet is stored lowercase; the SIWE session wallet is also
+    lowercase (get_verified_wallet), but the seeded row + the caller wallet
+    here are deliberately mixed-case at the call boundary to prove the match
+    isn't accidentally case-sensitive."""
+    _mk_proposal("gen_case", owner="0xCaFe00000000000000000000000000000000000C", intent="case test")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/proposals/", cookies=_siwe_cookies("0xCAFE00000000000000000000000000000000000C"))
+
+    assert resp.status_code == 200
+    gen_ids = {p["generation_id"] for p in resp.json()["proposals"]}
+    assert gen_ids == {"gen_case"}
+
+
+# ── GET /api/proposals/{generation_id}/siblings ──────────────────────────
+
+
+async def test_siblings_unauthenticated_401():
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/proposals/gen_a_1/siblings")
+    assert resp.status_code == 401
+
+
+async def test_siblings_owned_by_other_wallet_empty_for_caller():
+    gid = "gen_b_siblings"
+    _mk_proposal(gid, owner=_W_B, intent="B sibling 1")
+    _mk_proposal(gid, owner=_W_B, intent="B sibling 2")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp_a = await client.get(f"/api/proposals/{gid}/siblings", cookies=_siwe_cookies(_W_A))
+        resp_b = await client.get(f"/api/proposals/{gid}/siblings", cookies=_siwe_cookies(_W_B))
+
+    assert resp_a.status_code == 200
+    data_a = resp_a.json()
+    assert data_a["siblings"] == []
+    assert data_a["count"] == 0
+
+    assert resp_b.status_code == 200
+    data_b = resp_b.json()
+    assert data_b["count"] == 2
+
+
+async def test_siblings_legacy_null_owner_empty_for_everyone():
+    gid = "gen_legacy_siblings"
+    _mk_proposal(gid, owner=None, intent="legacy sibling 1")
+    _mk_proposal(gid, owner=None, intent="legacy sibling 2")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp_a = await client.get(f"/api/proposals/{gid}/siblings", cookies=_siwe_cookies(_W_A))
+
+    assert resp_a.status_code == 200
+    assert resp_a.json()["count"] == 0
+
+
+# ── persist_proposal(owner_wallet=...) write path ────────────────────────
+
+
+def test_persist_proposal_stamps_owner_wallet_lowercased():
+    from archimedes.models.strategy_proposal import StrategyProposal
+    from archimedes.services.strategy_memory import persist_proposal
+
+    proposal_id = persist_proposal(
+        generation_id="gen_write_path",
+        agent="fusion",
+        intent="write-path ownership test",
+        owner_wallet="0xDEAD00000000000000000000000000000000000F",
+    )
+    assert proposal_id is not None
+
+    with db.get_session() as session:
+        row = session.query(StrategyProposal).filter_by(proposal_id=proposal_id).one()
+        assert row.owner_wallet == "0xdead00000000000000000000000000000000000f"


### PR DESCRIPTION
## The leak (confirmed live)
`GET /api/proposals/` and `/api/proposals/{generation_id}/siblings` were **completely unauthenticated** and returned **every** user's `StrategyProposal` rows — each row's payload contains the user's private `intent` (their strategic brief), full `strategy_spec`, and `rigor_verdict`, including rejected candidates. `curl https://archimedes-arc.com/api/proposals/?limit=200` returned all 53 users' private briefs. (No UI references `/api/proposals` — grep-confirmed — so gating breaks nothing.)

## Fix (owner_wallet column + query-level scope)
1. **Migration** `7b6e8d812331_...` — adds `owner_wallet VARCHAR(42)` (nullable) + index to `strategy_proposals` via `batch_alter_table` (SQLite-safe). **Backfill: existing rows stay NULL** (deliberately not guessed) — the read filter treats NULL as private-to-no-one. Verified: upgrade/downgrade/idempotent; schema matches a fresh `create_all()`.
2. **Ownership filter in SQL** (`strategy_memory.query_proposals` + `get_siblings`): `filter(StrategyProposal.owner_wallet == owner_wallet.lower())`. SQL equality never matches NULL → legacy rows excluded **by construction**, not a post-hoc check.
3. **Write path** — `persist_proposal(owner_wallet=...)`, stored lowercased, threaded from `run_generation` + the two `strategies_routes` call sites. On a content-hash dedup hit it backfills ownership onto a previously-anonymous row but **never overwrites an existing owner** (no hijack).
4. **Route gating** — both endpoints now `Depends(require_verified_wallet)`: 401 unauthenticated, scoped to the caller's own wallet. Siblings for another wallet's generation returns empty (existence unconfirmed, 404-not-403 pattern).

## Verification
- Live-exploit smoke test: unauth `GET /api/proposals/` → **401**; authenticated wallet A sees only A's row, with B's row **and** a legacy NULL-owner row both excluded.
- ✅ **2847 backend tests pass** (2 skipped, no Postgres); `test_alembic_migrations.py` 4/4; new `test_proposals_ownership.py`; ruff (blocking) + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)