### PR TITLE
[infra] Runner relocation IaC — oracle+agent EC2 + scheduled-Fargate kb + EFS (draft)

### DIFF
--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -132,6 +132,15 @@ jobs:
           # near ')'" failures.
           cat > /tmp/remote.sh <<EOS
           set -euo pipefail
+          # Instance-local mutex: GitHub's concurrency.cancel-in-progress only
+          # cancels the Actions JOB — an already-dispatched SSM command keeps
+          # executing on the box. Two overlapping deploys would interleave
+          # docker pull/tag/restart on the funds-adjacent oracle/agent runners
+          # (mixed image tags, double restarts mid-tick). flock -n fails the
+          # second invocation fast and loud instead; rerun it once the first
+          # finishes.
+          exec 200>/var/lock/archimedes-runner-deploy.lock
+          flock -n 200 || { echo "another runner deploy is already in progress on this instance — aborting" >&2; exit 1; }
           aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
           docker pull ${ECR_REGISTRY}/${BACKEND_ECR_REPO}:${IMAGE_TAG}
           docker tag ${ECR_REGISTRY}/${BACKEND_ECR_REPO}:${IMAGE_TAG} ${ECR_REGISTRY}/${BACKEND_ECR_REPO}:latest

--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -1,0 +1,217 @@
+# Archimedes — Deploy the relocated runners (oracle+agent EC2, kb scheduled Fargate task)
+#
+# Issue #1065 (execution checklist) / #1043 (parent). Companion to
+# `.github/workflows/deploy.yml`'s `build-and-push` job — this workflow
+# does NOT build or push images itself; it consumes whatever
+# `archimedes-backend:<tag>` build-and-push already pushed to ECR and:
+#   (a) SSM RunCommand's the runner EC2 to `docker pull` the fresh tag +
+#       restart the `archimedes-oracle`/`archimedes-agent` systemd units
+#       (infra/runner_ec2.tf's runner-user-data.sh sets these up).
+#   (b) registers a new `archimedes-kb-runner` ECS task-definition revision
+#       carrying the fresh image tag (infra/kb_runner.tf) — the EventBridge
+#       Schedule targets the family's latest ACTIVE revision (no pinned
+#       revision, see that file's comment), so no further action is needed
+#       for the next scheduled run to pick it up.
+#
+# IAM: reuses the EXISTING `archimedes-github-deploy` OIDC role unchanged —
+# no new permissions needed. Verified against
+# infra/scripts/setup-github-oidc.sh's starter policy: `ssm:SendCommand` /
+# `ssm:GetCommandInvocation` / `ec2:DescribeInstances` are already granted
+# (Resource "*"), and `ecs:RegisterTaskDefinition` / `DescribeTaskDefinition`
+# are already granted by ecs.tf's `aws_iam_role_policy.github_deploy_ecs`
+# (also Resource "*", covering every task-definition family including the
+# new `archimedes-kb-runner`).
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# SAFETY — THIS WORKFLOW IS INERT UNTIL DAN ENABLES IT POST-APPLY. Merging
+# the PR that adds this file CANNOT trigger a deploy against infrastructure
+# that doesn't exist yet. Three independent layers:
+#   1. NO `push` TRIGGER. Only `workflow_dispatch` (manual) is wired below.
+#      The `push: branches: [main]` trigger a live version of this workflow
+#      would eventually want is written but COMMENTED OUT — uncomment it only
+#      once #1065 Step 2 (terraform apply) and Step 3 (verify on-chain) are
+#      both green. (infra/runbooks/ecs-fargate-cutover.md Phase 8 step 2
+#      references this exact moment.)
+#   2. `if: vars.RUNNER_DEPLOY_ENABLED == 'true'` gates BOTH jobs — a NEW,
+#      separate repo variable from `DEPLOY_ENABLED` (which already gates
+#      deploy.yml). Unset/false (the default — nothing sets it) skips both
+#      jobs cleanly even if this workflow is ever manually dispatched or the
+#      push trigger above is prematurely uncommented.
+#   3. RUNTIME EXISTENCE CHECKS. Even with both gates open, each job first
+#      confirms its target actually exists (a `Name=archimedes-runner`
+#      running EC2 instance; an ACTIVE `archimedes-kb-runner` task-definition
+#      family) and no-ops loudly rather than erroring if #1065 Step 2 hasn't
+#      run yet — same convention as deploy.yml's `migrate` / `deploy-ecs`
+#      jobs' own self-activating checks.
+# ═══════════════════════════════════════════════════════════════════════════
+
+name: Deploy Runners (oracle+agent EC2, kb scheduled Fargate task)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "archimedes-backend image tag to deploy (defaults to the current commit SHA)"
+        required: false
+        type: string
+  # SAFETY layer 1 (see header) — intentionally commented out. Uncomment only
+  # after #1065 Step 2 (terraform apply) + Step 3 (on-chain verification) are
+  # both done; see infra/runbooks/ecs-fargate-cutover.md Phase 8 step 2.
+  # push:
+  #   branches:
+  #     - main
+
+concurrency:
+  group: deploy-runners
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # Required for OIDC token request
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: 037613907429.dkr.ecr.us-east-1.amazonaws.com
+  BACKEND_ECR_REPO: archimedes-backend
+  KB_TASK_FAMILY: archimedes-kb-runner
+  # Matches infra/runner_ec2.tf's `aws_instance.runner` tag (Name =
+  # "${var.project_name}-runner" = "archimedes-runner" with the default
+  # project_name). Resolved to an instance id at runtime, not hardcoded —
+  # unlike deploy.yml's EC2_INSTANCE_ID literal, this box doesn't exist yet
+  # at the time this workflow is authored, so there is no id to hardcode.
+  RUNNER_INSTANCE_NAME_TAG: archimedes-runner
+
+jobs:
+  deploy-runner-ec2:
+    name: Deploy oracle+agent (SSM -> runner EC2)
+    if: ${{ vars.RUNNER_DEPLOY_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: arn:aws:iam::037613907429:role/archimedes-github-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve the runner EC2 instance id (SAFETY layer 3 — no-ops if not applied yet)
+        id: find
+        run: |
+          set -euo pipefail
+          ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=${RUNNER_INSTANCE_NAME_TAG}" "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].InstanceId' --output text 2>/dev/null || echo "None")
+          if [ -z "$ID" ] || [ "$ID" = "None" ]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "NO-OP: no running EC2 tagged Name=$RUNNER_INSTANCE_NAME_TAG found. The runner-relocation Terraform (infra/runner_ec2.tf) hasn't been applied yet — see issue #1065 Step 2. Skipping cleanly (not a failure)."
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "instance_id=$ID" >> "$GITHUB_OUTPUT"
+            echo "Found runner instance: $ID"
+          fi
+
+      - name: docker pull + restart oracle/agent systemd units via SSM RunCommand
+        if: steps.find.outputs.present == 'true'
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
+          INSTANCE_ID: ${{ steps.find.outputs.instance_id }}
+        run: |
+          set -euo pipefail
+
+          # Unquoted heredoc — $AWS_REGION/$ECR_REGISTRY/$BACKEND_ECR_REPO/
+          # $IMAGE_TAG are all REAL shell env vars in THIS runner's
+          # environment (workflow-level `env:` + this step's own `env:`
+          # above), so they expand into literal values here, before the
+          # script is ever shipped to the target instance — the box on the
+          # other end just runs a plain, already-resolved shell script, no
+          # further interpolation needed there. Written to a file (rather
+          # than inlined into `--parameters commands=[...]`) per CLAUDE.md's
+          # documented convention: building a multi-line SSM command payload
+          # inline through shell quoting is a reliable source of "parse error
+          # near ')'" failures.
+          cat > /tmp/remote.sh <<EOS
+          set -euo pipefail
+          aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+          docker pull ${ECR_REGISTRY}/${BACKEND_ECR_REPO}:${IMAGE_TAG}
+          docker tag ${ECR_REGISTRY}/${BACKEND_ECR_REPO}:${IMAGE_TAG} ${ECR_REGISTRY}/${BACKEND_ECR_REPO}:latest
+          systemctl restart archimedes-oracle.service archimedes-agent.service
+          EOS
+
+          python3 -c "
+          import json
+          script = open('/tmp/remote.sh').read()
+          json.dump({'commands': [script]}, open('/tmp/ssm-params.json', 'w'))
+          "
+
+          CMD_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --parameters file:///tmp/ssm-params.json \
+            --query 'Command.CommandId' --output text)
+          echo "SSM command: $CMD_ID"
+
+          aws ssm wait command-executed --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" || true
+
+          STATUS=$(aws ssm get-command-invocation --command-id "$CMD_ID" \
+            --instance-id "$INSTANCE_ID" --query Status --output text)
+          echo "SSM command status: $STATUS"
+          if [ "$STATUS" != "Success" ]; then
+            echo "::error::SSM RunCommand did not succeed (status=$STATUS) — stderr below"
+            aws ssm get-command-invocation --command-id "$CMD_ID" \
+              --instance-id "$INSTANCE_ID" --query StandardErrorContent --output text
+            exit 1
+          fi
+          echo "oracle + agent restarted on tag $IMAGE_TAG"
+
+  deploy-kb-runner:
+    name: Deploy kb-runner (new scheduled Fargate task-def revision)
+    if: ${{ vars.RUNNER_DEPLOY_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: arn:aws:iam::037613907429:role/archimedes-github-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Check whether the kb-runner task family exists yet (SAFETY layer 3)
+        id: check
+        run: |
+          set -euo pipefail
+          STATUS=$(aws ecs describe-task-definition --task-definition "$KB_TASK_FAMILY" \
+            --query 'taskDefinition.status' --output text 2>/dev/null || echo "")
+          if [ "$STATUS" = "ACTIVE" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "NO-OP: task family '$KB_TASK_FAMILY' not found. infra/kb_runner.tf hasn't been applied yet — see issue #1065 Step 2. Skipping cleanly (not a failure)."
+          fi
+
+      - name: Register a new kb-runner task-definition revision with the fresh image tag
+        if: steps.check.outputs.present == 'true'
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
+        run: |
+          set -euo pipefail
+
+          aws ecs describe-task-definition --task-definition "$KB_TASK_FAMILY" \
+            --query 'taskDefinition' > current-kb-task-def.json
+
+          jq --arg image "$ECR_REGISTRY/$BACKEND_ECR_REPO:$IMAGE_TAG" '
+            .containerDefinitions = (.containerDefinitions | map(
+              if .name == "kb-runner" then .image = $image else . end
+            )) |
+            del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
+          ' current-kb-task-def.json > new-kb-task-def.json
+
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json file://new-kb-task-def.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+
+          if [ -z "$NEW_ARN" ] || [ "$NEW_ARN" = "None" ]; then
+            echo "::error::ecs register-task-definition did not return a task definition ARN — see the command output above."
+            exit 1
+          fi
+          echo "Registered $NEW_ARN — the EventBridge Schedule targets the family's latest ACTIVE revision (infra/kb_runner.tf), so the NEXT scheduled invocation picks this up automatically. No schedule update needed."

--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -119,6 +119,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Validate the tag BEFORE it is interpolated into the root-run SSM
+          # script below: image_tag is a workflow_dispatch input, and while
+          # dispatch requires repo write access, a crafted value would inject
+          # shell into the runner box (review). Docker tag charset only.
+          if ! [[ "$IMAGE_TAG" =~ ^[A-Za-z0-9._-]{1,128}$ ]]; then
+            echo "::error::invalid image_tag '$IMAGE_TAG' — must match ^[A-Za-z0-9._-]{1,128}$"
+            exit 1
+          fi
+
           # Unquoted heredoc — $AWS_REGION/$ECR_REGISTRY/$BACKEND_ECR_REPO/
           # $IMAGE_TAG are all REAL shell env vars in THIS runner's
           # environment (workflow-level `env:` + this step's own `env:`

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -417,6 +417,32 @@ resource "aws_ecs_task_definition" "backend" {
     cpu_architecture        = "X86_64"
   }
 
+  # ── EFS companion mount (issue #1065 decision #3 / infra/efs.tf) ─────────
+  # Shared KB corpus-artifact storage — the backend's read side of the SAME
+  # EFS access point the kb-runner scheduled task (infra/kb_runner.tf) writes
+  # into, replacing docker-compose.yml's single named volume
+  # (`archimedes-corpus-artifact`, mounted at this same
+  # `/app/data/corpus-artifact` path there too). Adding this volume block +
+  # the "backend" container's mountPoints entry below is the ONE additive,
+  # in-place update this PR makes to an existing resource (new task-def
+  # revision; aws_ecs_service.backend keeps `lifecycle.ignore_changes =
+  # [task_definition]`, so this revision does NOT auto-roll the live
+  # service — a human/CI still points the service at it explicitly, same as
+  # any other deploy).
+  volume {
+    name = "corpus-artifact"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.corpus_artifact.id # efs.tf
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.corpus_artifact.id # efs.tf
+        iam             = "ENABLED"
+      }
+    }
+  }
+
   container_definitions = jsonencode([
     {
       name      = "backend"
@@ -425,6 +451,16 @@ resource "aws_ecs_task_definition" "backend" {
 
       portMappings = [
         { containerPort = 8000, protocol = "tcp" }
+      ]
+
+      # Backend/Dockerfile pre-creates + chowns this exact path to the
+      # nonroot (uid 1001) user, matching the EFS access point's posix_user
+      # (efs.tf) — the KB pipeline's read side (kb-runner writes the SAME
+      # underlying files via infra/kb_runner.tf's mount at
+      # /srv/corpus-artifact). KB_ARTIFACT_DIR (env, below) already points
+      # here; only the volume was previously missing.
+      mountPoints = [
+        { sourceVolume = "corpus-artifact", containerPath = "/app/data/corpus-artifact", readOnly = false }
       ]
 
       # Mirrors backend/Dockerfile's own HEALTHCHECK exactly. Declaring it

--- a/infra/efs.tf
+++ b/infra/efs.tf
@@ -1,0 +1,136 @@
+# ── EFS — shared KB corpus-artifact storage (backend ⇄ kb-runner) ──────────
+#
+# Issue #1065 decision #3 (drafted default: EFS, not S3 — "zero app-code
+# change; needs a companion mount added to ecs.tf's backend task"). Replaces
+# docker-compose.yml's single named volume (`archimedes-corpus-artifact`,
+# mounted read-write at BOTH `backend`'s `/app/data/corpus-artifact` AND
+# `kb-runner`'s `/srv/corpus-artifact` — see docker-compose.yml lines
+# ~246-247 and ~289-291) with ONE EFS access point mounted into BOTH Fargate
+# task definitions at those same two container paths. backend/Dockerfile
+# already pre-creates and chowns both paths to the nonroot (uid 1001) user
+# ("Paths mirror docker-compose.yml: corpus-artifact is mounted at both
+# locations") — the access point's POSIX user below matches that uid/gid so
+# neither container hits an EFS permission error on first write.
+#
+# Companion change (this PR): ecs.tf's `aws_ecs_task_definition.backend` gets
+# a `volume` block + `mountPoints` entry added for the "backend" container —
+# see that file's diff. That's the ONE additive, in-place update to an
+# EXISTING resource this PR makes (new task-definition revision; the
+# aws_ecs_service.backend service itself is untouched and keeps
+# lifecycle.ignore_changes = [task_definition], so this revision does NOT
+# auto-roll — a human/CI still has to point the service at it, same as any
+# other deploy).
+
+# ── Security group — NFS 2049 from the backend + kb-runner ECS tasks only ──
+
+resource "aws_security_group" "efs" {
+  name        = "${var.project_name}-efs-sg"
+  description = "EFS corpus-artifact - NFS 2049 from backend + kb-runner Fargate tasks only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "NFS from the backend ECS task"
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_backend.id] # ecs.tf
+  }
+
+  ingress {
+    description     = "NFS from the kb-runner scheduled Fargate task"
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [aws_security_group.kb_runner.id] # kb_runner.tf
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-efs-sg"
+    Project = var.project_name
+  }
+}
+
+# ── File system ─────────────────────────────────────────────────────────
+
+resource "aws_efs_file_system" "corpus_artifact" {
+  creation_token = "${var.project_name}-corpus-artifact"
+  encrypted      = true
+
+  # Bursting is the standard default and fine for this workload (small
+  # JSON/JSONL/npy artifacts, infrequent kb-runner writes, occasional
+  # backend reads via /api/corpus/*) — no provisioned throughput needed.
+
+  tags = {
+    Name    = "${var.project_name}-corpus-artifact"
+    Project = var.project_name
+  }
+}
+
+resource "aws_efs_mount_target" "corpus_artifact" {
+  count           = 2
+  file_system_id  = aws_efs_file_system.corpus_artifact.id
+  subnet_id       = aws_subnet.private[count.index].id
+  security_groups = [aws_security_group.efs.id]
+}
+
+# Access point enforces a fixed POSIX identity + a scoped root directory —
+# uid/gid 1001 matches backend/Dockerfile's `useradd --uid 1001 nonroot`
+# exactly, so both the backend and kb-runner containers (both run as
+# `nonroot`) can read/write without a permission error, and neither task
+# needs `elasticfilesystem:ClientRootAccess` (root bypass) in its IAM policy.
+resource "aws_efs_access_point" "corpus_artifact" {
+  file_system_id = aws_efs_file_system.corpus_artifact.id
+
+  posix_user {
+    uid = 1001
+    gid = 1001
+  }
+
+  root_directory {
+    path = "/corpus-artifact"
+    creation_info {
+      owner_uid   = 1001
+      owner_gid   = 1001
+      permissions = "0775"
+    }
+  }
+
+  tags = {
+    Name    = "${var.project_name}-corpus-artifact-ap"
+    Project = var.project_name
+  }
+}
+
+# ── IAM — EFS client mount/write, added to the EXISTING ECS task role ──────
+# aws_iam_role.ecs_task (ecs.tf) is shared by the backend service task, the
+# one-off migrate task (ecs_migrate.tf), and — as of this PR — the new
+# kb-runner task (kb_runner.tf). One additive inline policy covers all three;
+# only backend + kb-runner actually mount the volume, migrate is unaffected
+# (an unused grant, not a functional change for it). Scoped to exactly this
+# one access point via the AccessPointArn condition, per AWS's documented
+# least-privilege pattern for EFS + ECS IAM authorization.
+resource "aws_iam_role_policy" "ecs_task_efs_access" {
+  name = "archimedes-ecs-task-efs-access"
+  role = aws_iam_role.ecs_task.id # ecs.tf
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "EfsClientAccessCorpusArtifact"
+        Effect   = "Allow"
+        Action   = ["elasticfilesystem:ClientMount", "elasticfilesystem:ClientWrite"]
+        Resource = aws_efs_file_system.corpus_artifact.arn
+        Condition = {
+          StringEquals = { "elasticfilesystem:AccessPointArn" = aws_efs_access_point.corpus_artifact.arn }
+        }
+      }
+    ]
+  })
+}

--- a/infra/kb_runner.tf
+++ b/infra/kb_runner.tf
@@ -1,0 +1,285 @@
+# ── kb-runner — scheduled (batch) Fargate task, not a loop ─────────────────
+#
+# Issue #1065 decision #2 (drafted default: point the schedule at the
+# already-one-shot `python -m archimedes.scripts.run_kb_pipeline` — verified
+# present at backend/archimedes/scripts/run_kb_pipeline.py — rather than
+# adding a `run_once()` to services/kb_runner.py). Trade-off this draft
+# accepts: `run_kb_pipeline.py` skips `needs_rerun()` gating (new-paper
+# threshold / max-days-since-last, services/kb_runner.py's own logic) and the
+# Redis lease services/runner_lease.py provides for the async singleton
+# runners — every scheduled invocation just runs (or, with
+# KB_PIPELINE_ENABLED unset, writes a `{"status": "skipped"}` manifest.json
+# and returns — see that module's `run_pipeline()`). That's an accepted,
+# documented gap, not an oversight: kb-runner is a batch job, not a
+# funds-adjacent singleton like oracle/agent, so a rare overlapping run is a
+# wasted-compute risk, not a double-spend risk.
+#
+# This is intentionally NOT an ECS *service* (no desired_count, no ALB, no
+# autoscaling) — EventBridge Scheduler invokes `ecs:RunTask` directly on the
+# schedule below, and the task runs to completion and stops, exactly like
+# ecs_migrate.tf's one-off migrate task (closest existing template).
+
+# ── Security group — no ingress; egress only (EFS, ECR, SSM, CloudWatch) ───
+
+resource "aws_security_group" "kb_runner" {
+  name        = "${var.project_name}-kb-runner-sg"
+  description = "kb-runner scheduled Fargate task - no ingress, outbound only"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    description = "All outbound (EFS, ECR, SSM secrets resolution, CloudWatch Logs)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-kb-runner-sg"
+    Project = var.project_name
+  }
+}
+
+# ── CloudWatch log group — dedicated (not the shared /archimedes/app group)
+# so the failure-detection metric filter below can't cross-contaminate with
+# unrelated backend/migrate log lines (a log-group-wide filter has no
+# per-stream scoping in Terraform).
+
+resource "aws_cloudwatch_log_group" "kb_runner" {
+  name              = "/archimedes/kb-runner"
+  retention_in_days = 90
+  tags              = { Project = var.project_name }
+}
+
+# ── Task definition ─────────────────────────────────────────────────────
+# Single container, run-to-completion — no healthCheck/dependsOn (same
+# shape as ecs_migrate.tf's aws_ecs_task_definition.migrate, the closest
+# existing template for a Fargate one-off).
+
+resource "aws_ecs_task_definition" "kb_runner" {
+  family                   = "${var.project_name}-kb-runner"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.kb_runner_cpu
+  memory                   = var.kb_runner_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn # ecs.tf — reused, no new execution role needed
+  task_role_arn            = aws_iam_role.ecs_task.arn           # ecs.tf — reused; carries the EFS grant added in efs.tf
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  volume {
+    name = "corpus-artifact"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.corpus_artifact.id
+      transit_encryption = "ENABLED" # required by AWS whenever an access point is used
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.corpus_artifact.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "kb-runner"
+      image     = "${aws_ecr_repository.backend.repository_url}:${var.backend_image_tag}"
+      essential = true
+
+      # run_kb_pipeline.py (verified present, see file header) — one-shot,
+      # exits after writing manifest.json, unlike docker-compose's
+      # `services.kb_runner` module (an infinite poll loop; NOT used here).
+      command = ["python", "-m", "archimedes.scripts.run_kb_pipeline"]
+
+      mountPoints = [
+        { sourceVolume = "corpus-artifact", containerPath = "/srv/corpus-artifact", readOnly = false }
+      ]
+
+      environment = [
+        { name = "AWS_REGION", value = var.aws_region },
+        { name = "KB_ARTIFACT_DIR", value = "/srv/corpus-artifact" },
+        # backend/Dockerfile COPYs data/corpus → /app/data/corpus into the
+        # SAME image this task runs (verified in the Dockerfile) — the
+        # corpus TEXT source needs no EFS mount and no docker-compose-style
+        # host bind mount; it's already baked in at build time.
+        { name = "KB_CORPUS_DIR", value = "/app/data/corpus" },
+        # KB_PIPELINE_ENABLED deliberately left UNSET (matches
+        # docker-compose.yml's own default): the real SPECTER2/HDBSCAN/
+        # BERTopic/REBEL/SciSpacy pipeline needs a dedicated ~6 GB-model
+        # image this task definition does not yet build/reference (see
+        # run_kb_pipeline.py's own NotImplementedError guard). Until that
+        # ships, every scheduled run intentionally no-ops to a "skipped"
+        # manifest.json — which is still enough to satisfy #1065 Step 3's
+        # "confirm a manifest.json lands under the EFS artifact path" check
+        # and to prove the schedule → EFS path works end-to-end.
+      ]
+
+      # NOTE: no `secrets` block — DATABASE_URL is deliberately NOT wired
+      # here. run_kb_pipeline.py's current skeleton (verified via grep) does
+      # not read DATABASE_URL at all; the docstring's "Postgres
+      # papers.cluster_id / kg_entities / kg_relations" writes are the REAL
+      # pipeline's future behavior, gated behind the same KB_PIPELINE_ENABLED
+      # flag as above. Adding a DATABASE_URL secret now would make this
+      # task's launch depend on the /archimedes/prod/DATABASE_URL SSM
+      # parameter existing (per ecs.tf's own header comment, NOT seeded as of
+      # that file) — an unnecessary hard-fail risk for a still-skip-mode
+      # batch job. Add it back (same SSM ARN pattern as ecs.tf /
+      # ecs_migrate.tf) in the same PR that flips KB_PIPELINE_ENABLED on.
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.kb_runner.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "kb"
+        }
+      }
+    }
+  ])
+
+  tags = { Project = var.project_name }
+}
+
+# ── IAM — EventBridge Scheduler's own role (assumes into ecs:RunTask) ──────
+
+resource "aws_iam_role" "kb_scheduler" {
+  name = "archimedes-kb-scheduler-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "scheduler.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+      Condition = {
+        StringEquals = { "aws:SourceAccount" = data.aws_caller_identity.current.account_id } # ecs.tf
+      }
+    }]
+  })
+  tags = { Project = var.project_name }
+}
+
+resource "aws_iam_role_policy" "kb_scheduler_run_task" {
+  name = "archimedes-kb-scheduler-run-task"
+  role = aws_iam_role.kb_scheduler.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RunKbTask"
+        Effect = "Allow"
+        Action = ["ecs:RunTask"]
+        # Family-wildcard (no pinned revision) ARN — matches the schedule
+        # target's own `task_definition_arn` below (also revision-less), so
+        # this grant stays valid across every future CI-registered revision
+        # without a Terraform change.
+        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.kb_runner.family}:*"
+        Condition = {
+          ArnLike = { "ecs:cluster" = aws_ecs_cluster.main.arn } # ecs.tf
+        }
+      },
+      {
+        Sid      = "PassKbTaskRoles"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = [aws_iam_role.ecs_task_execution.arn, aws_iam_role.ecs_task.arn] # ecs.tf
+        Condition = {
+          StringEquals = { "iam:PassedToService" = "ecs-tasks.amazonaws.com" }
+        }
+      }
+    ]
+  })
+}
+
+# ── Schedule ─────────────────────────────────────────────────────────────
+# `task_definition_arn` is deliberately the REVISION-LESS ARN (family only,
+# no trailing `:N`) — per AWS's own EventBridge Scheduler + ECS RunTask
+# behavior, this resolves to the latest ACTIVE revision at invocation time,
+# so `.github/workflows/deploy-runners.yml` registering a new revision after
+# every image push is picked up automatically with NO schedule update. Using
+# `aws_ecs_task_definition.kb_runner.arn` instead (Terraform's own
+# `revision`-suffixed ARN) would pin the schedule to whatever revision this
+# PR's `terraform apply` happens to create and never move again — verify
+# this at `terraform plan`/apply time; if AWS rejects a revision-less ARN
+# here, fall back to `.arn` and have deploy-runners.yml additionally call
+# `aws scheduler update-schedule` with the new revision ARN.
+
+resource "aws_scheduler_schedule" "kb_runner" {
+  name                = "${var.project_name}-kb-runner"
+  schedule_expression = var.kb_runner_schedule_expression
+  state               = "ENABLED"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_ecs_cluster.main.arn # ecs.tf
+    role_arn = aws_iam_role.kb_scheduler.arn
+
+    ecs_parameters {
+      task_definition_arn = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.kb_runner.family}"
+      launch_type         = "FARGATE"
+
+      network_configuration {
+        subnets          = aws_subnet.private[*].id # vpc.tf
+        security_groups  = [aws_security_group.kb_runner.id]
+        assign_public_ip = false
+      }
+    }
+
+    retry_policy {
+      maximum_retry_attempts = 1
+    }
+  }
+}
+
+# ── CloudWatch — failure alarm ──────────────────────────────────────────
+# Heuristic proxy (log-pattern metric filter), not a precise ECS exit-code
+# signal: matches an ERROR/Exception/unhandled-Traceback line in the
+# task's own stdout/stderr. This is simple, needs no extra Lambda/EventBridge
+# plumbing, and catches both a logged `logger.error(...)` and an unhandled
+# Python exception's traceback (which is what a crash from
+# run_kb_pipeline.py's NotImplementedError guard, or any future real-pipeline
+# failure, would emit). A more PRECISE signal is possible (an EventBridge
+# rule on "ECS Task State Change" events filtered to this task family +
+# non-zero container exitCode, routed straight to the SNS topic) but adds a
+# second alerting path for a draft that's not yet applied — noted here as a
+# documented follow-up, not implemented in this PR.
+
+resource "aws_cloudwatch_log_metric_filter" "kb_runner_errors" {
+  name           = "${var.project_name}-kb-runner-errors"
+  log_group_name = aws_cloudwatch_log_group.kb_runner.name
+  pattern        = "?ERROR ?Error ?Traceback"
+
+  metric_transformation {
+    name          = "KbRunnerErrorCount"
+    namespace     = "Archimedes/KbRunner"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kb_runner_failed" {
+  alarm_name          = "archimedes-kb-runner-failed"
+  alarm_description   = "kb-runner scheduled Fargate task logged an ERROR/Exception/Traceback in its last run — heuristic proxy for a failed pipeline invocation (see infra/kb_runner.tf for a more precise EventBridge-based alternative)."
+  namespace           = "Archimedes/KbRunner"
+  metric_name         = "KbRunnerErrorCount"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 0
+  # kb-runner is a batch job on the schedule below (default: daily), not a
+  # continuous loop — a short evaluation window would sit permanently
+  # INSUFFICIENT_DATA between runs. An hourly window with notBreaching on
+  # missing data means the alarm only evaluates (and can only fire) in the
+  # hour a run's error output actually lands.
+  period             = 3600
+  evaluation_periods = 1
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.alerts.arn] # cloudwatch.tf's existing SNS topic
+  ok_actions         = [aws_sns_topic.alerts.arn]
+  tags               = { Project = var.project_name }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -185,3 +185,40 @@ output "ecs_migrate_network_configuration" {
     }
   })
 }
+
+# ── Runner relocation outputs (issue #1065 / #1043) ────────────────────────
+
+output "runner_instance_id" {
+  description = "Instance id of the dedicated oracle+agent runner EC2 (infra/runner_ec2.tf) — target for `aws ssm start-session` / `aws ssm send-command`, and for #1065 Step 4's Phase 8 gate check."
+  value       = aws_instance.runner.id
+}
+
+output "runner_log_group_name" {
+  description = "CloudWatch log group both runner systemd units ship to (docker awslogs driver, distinct stream prefixes 'oracle'/'agent') — `aws logs tail <this> --since 10m --filter-pattern oracle` per #1065 Step 3."
+  value       = aws_cloudwatch_log_group.runners.name
+}
+
+output "efs_file_system_id" {
+  description = "EFS file system id for the shared KB corpus-artifact storage (infra/efs.tf) — mounted by both the backend service task (ecs.tf) and the kb-runner scheduled task (infra/kb_runner.tf)."
+  value       = aws_efs_file_system.corpus_artifact.id
+}
+
+output "efs_access_point_id" {
+  description = "EFS access point id (posix uid/gid 1001, matches backend/Dockerfile's nonroot user) — referenced by both task definitions' `efs_volume_configuration.authorization_config.access_point_id`."
+  value       = aws_efs_access_point.corpus_artifact.id
+}
+
+output "kb_runner_task_definition_family" {
+  description = "ECS task definition family for the scheduled kb-runner task (infra/kb_runner.tf) — register new revisions against this family for CI deploys (.github/workflows/deploy-runners.yml); the EventBridge Schedule always targets the latest ACTIVE revision (revision-less ARN), not a pinned one."
+  value       = aws_ecs_task_definition.kb_runner.family
+}
+
+output "kb_runner_schedule_name" {
+  description = "EventBridge Scheduler schedule name for kb-runner — `aws scheduler get-schedule --name <this>` to confirm ENABLED state (#1065 Step 3)."
+  value       = aws_scheduler_schedule.kb_runner.name
+}
+
+output "kb_runner_log_group_name" {
+  description = "CloudWatch log group the kb-runner scheduled task ships to — `aws logs tail <this> --since 10m` to verify a run."
+  value       = aws_cloudwatch_log_group.kb_runner.name
+}

--- a/infra/runbooks/ecs-fargate-cutover.md
+++ b/infra/runbooks/ecs-fargate-cutover.md
@@ -26,7 +26,16 @@
 > with empty `VITE_*` build-args (no Circle client key baked into the served
 > bundle); added the PRE-CUTOVER ENV-PARITY CHECKLIST as a hard gate before
 > Phase 4; and locked in **Option C — hard cutover, no parallel-traffic
-> soak** as the chosen cutover strategy, rewriting Phase 4 accordingly).
+> soak** as the chosen cutover strategy, rewriting Phase 4 accordingly);
+> updated 2026-07-08 (issue #1065 runner-relocation draft — **Phase 8's old
+> gate (three ECS *services* named `archimedes-oracle`/`archimedes-agent`/
+> `archimedes-kb-runner`) never matched what actually got built and is
+> REPLACED below.** The shipped shape is a dedicated EC2 instance for
+> oracle+agent (funds-adjacent exactly-once singletons — never a Fargate
+> service with autoscaling, never an ASG) and a scheduled (not
+> long-running) Fargate task for kb-runner. See `infra/runner_ec2.tf`,
+> `infra/kb_runner.tf`, `infra/efs.tf`, and #1065 for the full IaC + the
+> post-apply execution checklist).
 > **Not yet applied, not yet drilled.** Written against `infra/ecr.tf` +
 > `infra/ecs.tf` on the `dbrowneup/1039-fargate-infra` epic branch. No
 > `terraform apply`, ALB cutover, or EC2 decommission has happened — those are
@@ -742,37 +751,71 @@ step 1's gate is still red.**
 
 1. **HARD GATE — confirm the oracle/agent/kb-runner background daemons have
    somewhere to run, with a concrete verification command, BEFORE touching
-   the EC2 instance at all.** These are singleton, no-ALB background loops
-   (Phase 0's residual — no Fargate home in this chunk; they need their own
-   Fargate service(s), `desired_count = 1`, no autoscaling — same anti-goal
-   as the EC2 ASG tier: these loops must not be duplicated) that are today
-   the vault/regime-state source of truth as `docker compose` services on
-   the EC2 box. Decommissioning the box while they still only exist there
-   silently kills that state — this is the one step in this runbook that is
-   NOT just "detach and delete."
+   the EC2 instance at all.** **REPLACED 2026-07-08 (issue #1065):** the
+   original version of this gate checked for three ECS *services* named
+   `archimedes-oracle` / `archimedes-agent` / `archimedes-kb-runner` — that
+   was always aspirational and doesn't match what actually got built.
+   oracle + agent are funds-adjacent, exactly-once singletons
+   (`services/runner_lease.py` is the app-layer Redis lease control) that
+   live on their OWN dedicated EC2 instance (`infra/runner_ec2.tf`) —
+   deliberately NOT an ECS service, NOT autoscaled, NOT an ASG (duplicating
+   either process risks a double-signed on-chain tx). kb-runner is a
+   scheduled (batch), not long-running, Fargate task
+   (`infra/kb_runner.tf` + an EventBridge Scheduler schedule) — it has no
+   `aws ecs describe-services` entry at all; it exists only as task
+   invocations on its schedule. Decommissioning the old box while these
+   still only run there (as `docker compose` services) would silently kill
+   the vault/regime-state source of truth — this is still the one step in
+   this runbook that is NOT just "detach and delete," just checked
+   differently:
 
    ```bash
-   for svc in archimedes-oracle archimedes-agent archimedes-kb-runner; do
-     echo "=== $svc ==="
-     aws ecs describe-services --cluster "$(terraform output -raw ecs_cluster_name)" \
-       --services "$svc" \
-       --query 'services[0].{status:status,running:runningCount,desired:desiredCount}' \
-       --output table || echo "MISSING: $svc has no Fargate service yet — GATE FAILS"
-   done
+   # 1. Oracle + agent EC2 — must be running.
+   aws ec2 describe-instances \
+     --instance-ids "$(terraform output -raw runner_instance_id)" \
+     --query 'Reservations[0].Instances[0].State.Name' --output text
+   # Expect: running
+
+   # 2. Oracle + agent — each completed >= 1 successful on-chain action in
+   #    the last hour (price push / rebalance), not just "the process is up."
+   aws logs tail "$(terraform output -raw runner_log_group_name)" \
+     --since 1h --filter-pattern "oracle" | grep -i "price push complete" \
+     || echo "GATE FAILS: no oracle price push in the last hour"
+   aws logs tail "$(terraform output -raw runner_log_group_name)" \
+     --since 1h --filter-pattern "agent" | grep -i "rebalance" \
+     || echo "GATE FAILS: no agent rebalance activity in the last hour"
+
+   # 3. kb-runner schedule — must be ENABLED, with >= 1 successful invocation.
+   aws scheduler get-schedule --name "$(terraform output -raw kb_runner_schedule_name)" \
+     --query 'State' --output text
+   # Expect: ENABLED
+   aws logs tail "$(terraform output -raw kb_runner_log_group_name)" --since 24h \
+     | grep -i "manifest" || echo "GATE FAILS: no kb-runner manifest.json write logged in the last 24h"
+
+   # 4. Both CloudWatch alarms show OK, not INSUFFICIENT_DATA.
+   aws cloudwatch describe-alarms \
+     --alarm-names archimedes-runner-ec2-status-check-failed archimedes-kb-runner-failed \
+     --query 'MetricAlarms[].{Name:AlarmName,State:StateValue}' --output table
    ```
 
-   **Gate passes only if all three print `status: ACTIVE` with
-   `running >= desired >= 1`.** Any `MISSING` line, any `status` other than
-   `ACTIVE`, or `running < desired` — STOP. Do not proceed to step 2 or 3.
-   (These singleton services aren't provisioned by this PR — see the note at
-   the top of this file: they're pending cost sign-off as a follow-up.)
+   **Gate passes only if:** the runner EC2 is `running`; both oracle and
+   agent show real on-chain activity in the last hour (not just process
+   liveness); the kb schedule is `ENABLED` with at least one completed
+   invocation; and both alarms are `OK`. Any failure — STOP. Do not proceed
+   to step 2 or 3. (Full step-by-step verification detail: issue #1065 Step
+   3 of the execution checklist.)
 2. Remove the now-dead `EC2_INSTANCE_ID` / SSM `deploy` job from `deploy.yml`
    entirely — the `deploy-ecs` job (issue #1039 C1) has independently
    redeployed Fargate on every push since before Phase 4 ran, so this step is
    purely deleting the now-unreachable EC2 code path, not changing behavior.
+   (Separately, once step 1's gate is green, `.github/workflows/deploy-runners.yml`'s
+   `push` trigger can be uncommented — see that workflow's header — so runner
+   deploys stop being a manual `workflow_dispatch`.)
 3. **Only now, last:** terminate `aws_instance.archimedes` (remove from
    `main.tf`, `terraform apply`). Aurora/ElastiCache/ALB/WAF/CloudFront/
-   Route 53 are all unaffected; this chunk never touched them.
+   Route 53 are all unaffected; this chunk never touched them. The NEW
+   runner EC2 (`aws_instance.runner`, `infra/runner_ec2.tf`) is a SEPARATE
+   resource and is not affected by this termination.
 
 ---
 

--- a/infra/runner-user-data.sh
+++ b/infra/runner-user-data.sh
@@ -63,7 +63,10 @@ systemctl start docker
 # `aws ssm get-parameters-by-path` (fetch-secrets.sh below). Ubuntu's apt
 # `awscli` package is v1 and too old for some SSO/SSM flags; install v2
 # directly from AWS, same as infra/scripts/bake-backend-ami.sh does.
-curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+# Arch-aware: hardcoding x86_64 would break bootstrap (and with it ECR login
+# + secret fetch) the day runner_instance_type moves to Graviton (review).
+ARCH="$(uname -m)"   # x86_64 | aarch64 — matches AWS's installer naming
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o /tmp/awscliv2.zip
 unzip -q /tmp/awscliv2.zip -d /tmp
 /tmp/aws/install
 rm -rf /tmp/awscliv2.zip /tmp/aws

--- a/infra/runner-user-data.sh
+++ b/infra/runner-user-data.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+set -euxo pipefail
+
+# ---------------------------------------------------------------------------
+# Archimedes runner EC2 bootstrap — runs once on first boot via cloud-init.
+#
+# Issue #1065 / #1043 — relocates the `oracle` + `agent` docker-compose
+# services (docker-compose.yml, formerly stranded on the detached backend
+# box) onto their OWN dedicated EC2 instance, as two systemd-managed docker
+# containers pulling the SAME `archimedes-backend` ECR image the backend/kb
+# tasks use (different `command:` override each — exactly the docker-compose
+# pattern, just relocated). This box:
+#   - NEVER builds an image on-box — ECR pull only (anti-goal, #1065).
+#   - Has NO inbound SSH — admin access is SSM Session Manager only, same
+#     posture as the main EC2 (see main.tf's aws_security_group.archimedes).
+#   - Does NOT run oracle/agent in an ASG — these are funds-adjacent,
+#     exactly-once singletons (services/runner_lease.py is the app-layer
+#     lease control); duplicating the box would risk a double-signed tx.
+#
+# Unlike the main box's user-data.sh, this script does NOT `git clone` the
+# repo or write a docker-compose .env — there is no local build context and
+# no docker-compose stack here, just two `docker run` invocations managed by
+# systemd, each pulling its own secrets from SSM at every (re)start via
+# fetch-secrets.sh below.
+#
+# NOTE: like the main user-data.sh, this file is rendered by Terraform's
+# templatefile() (see infra/runner_ec2.tf), which parses the WHOLE file
+# (comments included, even THIS sentence) and treats a dollar-sign followed
+# by a brace as the start of a template directive. Any literal shell
+# variable-in-braces reference in this script is therefore written with a
+# DOUBLED leading dollar sign so the rendered script keeps real shell
+# expansion at runtime; a plain dollar-variable with no braces needs no
+# escaping. The only REAL Terraform
+# template variables in this file are `ecr_registry` (full repository URL,
+# e.g. "<acct>.dkr.ecr.<region>.amazonaws.com/archimedes-backend" — used for
+# `docker pull`/`docker run`), `ecr_registry_host` (bare registry host only,
+# no repo path — the correct `docker login` target), `aws_region`, and
+# `log_group_name` (all substituted below, undoubled).
+# ---------------------------------------------------------------------------
+
+export DEBIAN_FRONTEND=noninteractive
+
+# ── System + Docker (same as the main box's user-data.sh) ──────────────────
+apt-get update -y
+apt-get upgrade -y
+
+apt-get install -y ca-certificates curl gnupg unzip
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable docker
+systemctl start docker
+
+# ── AWS CLI v2 — needed for `aws ecr get-login-password` (image pulls) and
+# `aws ssm get-parameters-by-path` (fetch-secrets.sh below). Ubuntu's apt
+# `awscli` package is v1 and too old for some SSO/SSM flags; install v2
+# directly from AWS, same as infra/scripts/bake-backend-ami.sh does.
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/awscliv2.zip /tmp/aws
+
+mkdir -p /opt/archimedes-runners
+chmod 700 /opt/archimedes-runners
+
+# ── fetch-secrets.sh — pulls the FLAT /archimedes/prod/* namespace into a
+# docker --env-file at every (re)start (systemd ExecStartPre, below), so a
+# secret ROTATION in SSM takes effect on the next `systemctl restart` with no
+# redeploy. Same SSM prefix + same IAM scope
+# (services/secrets_service.load_ssm_secrets()'s /archimedes/prod/* contract)
+# the backend already reads — this mirrors that access pattern for a
+# standalone (non-FastAPI) process where there is no in-process SSM fetch to
+# reuse. Pulls the WHOLE prefix (DATABASE_URL, REDIS_URL,
+# AURORA_MASTER_PASSWORD, EMAIL_ENCRYPTION_KEY, CIRCLE_*, WALLET_ID,
+# WALLET_ADDRESS, INTERNAL_AGENT_API_KEY, ARC_AGENT_PRIVATE_KEY,
+# ARC_STRATEGY_REGISTRY_ADDRESS, ARC_PAYMENT_SPLITTER_ADDRESS, ...) into ONE
+# env file consumed by BOTH containers — harmless unused vars in either
+# container's env, and avoids maintaining two divergent per-service param
+# lists here. NEVER logs a value, only parameter NAMES (matches
+# setup-ssm-secrets.sh's own norm).
+#
+# KNOWN LIMITATION: docker's --env-file format is `KEY=VALUE` per line, no
+# shell expansion, and treats a line starting with `#` as a comment — a
+# secret VALUE containing an embedded newline or a leading `#` would break
+# this. None of the current /archimedes/prod/* secrets are multi-line
+# (API keys, hex secrets, DB URLs, addresses), so this is a documented,
+# not-yet-hit edge case, not a live bug.
+cat > /opt/archimedes-runners/fetch-secrets.sh <<'FETCHEOF'
+#!/bin/bash
+set -euo pipefail
+
+# NOTE: the region is a Terraform-templated literal (substituted at render
+# time, below), not a bash-runtime default-value fallback — nesting a bash
+# "variable colon-dash default" expansion inside a templatefile() directive
+# would be parsed as an (invalid) HCL expression and fail the render. If
+# this ever needs to vary at runtime instead, read it as a plain doubled-
+# dollar env var with NO nested directive inside it, e.g. (doubled so
+# Terraform emits it literally): REGION="$${AWS_REGION:-us-east-1}"
+REGION="${aws_region}"
+PREFIX="/archimedes/prod"
+OUT="/opt/archimedes-runners/runner.env"
+
+umask 077
+: > "$OUT"
+
+aws ssm get-parameters-by-path \
+  --path "$PREFIX" \
+  --recursive \
+  --with-decryption \
+  --region "$REGION" \
+  --query 'Parameters[*].[Name,Value]' \
+  --output text |
+while IFS=$'\t' read -r name value; do
+  key="$(basename "$name")"
+  printf '%s=%s\n' "$key" "$value" >> "$OUT"
+done
+
+chmod 600 "$OUT"
+echo "fetch-secrets: wrote $(wc -l < "$OUT") parameter(s) to $OUT (names only, never values, in this log line)"
+FETCHEOF
+chmod 700 /opt/archimedes-runners/fetch-secrets.sh
+
+# ── ECR login helper — re-run before every `docker pull` since ECR tokens
+# expire after 12h and both units restart independently of each other.
+cat > /opt/archimedes-runners/ecr-login.sh <<'LOGINEOF'
+#!/bin/bash
+set -euo pipefail
+aws ecr get-login-password --region "${aws_region}" | \
+  docker login --username AWS --password-stdin "${ecr_registry_host}"
+LOGINEOF
+chmod 700 /opt/archimedes-runners/ecr-login.sh
+
+# ── systemd units — one per singleton runner. Both:
+#   - pull the SAME archimedes-backend image (never build on-box)
+#   - refresh secrets from SSM on every (re)start (ExecStartPre)
+#   - ship stdout/stderr to the /archimedes/runners CloudWatch log group via
+#     docker's native `awslogs` log driver (uses the instance role's
+#     credentials automatically — no CloudWatch agent needed)
+#   - Restart=always — systemd itself is the box-local restart policy; the
+#     Redis lease in services/runner_lease.py is the SEPARATE, authoritative
+#     exactly-once control if this box is ever accidentally duplicated.
+#
+# Image tag: both units run the mutable `:latest` tag (same convention the
+# retired EC2 backend docker-compose path used — see the old `deploy` job in
+# .github/workflows/deploy.yml, git history). `.github/workflows/deploy-runners.yml`'s
+# SSM RunCommand step re-`docker pull`s `:latest` after every CI image push,
+# then restarts these two units so the freshly-pulled layer becomes the
+# running container — no unit-file edit needed per deploy.
+cat > /etc/systemd/system/archimedes-oracle.service <<'ORACLEEOF'
+[Unit]
+Description=Archimedes oracle runner (price feeder, funds-adjacent singleton)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+TimeoutStartSec=120
+ExecStartPre=-/usr/bin/docker stop archimedes-oracle
+ExecStartPre=-/usr/bin/docker rm archimedes-oracle
+ExecStartPre=/opt/archimedes-runners/fetch-secrets.sh
+ExecStartPre=/opt/archimedes-runners/ecr-login.sh
+ExecStart=/usr/bin/docker run --rm --name archimedes-oracle \
+  --env-file /opt/archimedes-runners/runner.env \
+  -e AWS_REGION=${aws_region} \
+  -e ORACLE_INTERVAL_SECONDS=60 \
+  -e ARC_VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32 \
+  -e ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6 \
+  --log-driver=awslogs \
+  --log-opt awslogs-region=${aws_region} \
+  --log-opt awslogs-group=${log_group_name} \
+  --log-opt awslogs-stream-prefix=oracle \
+  ${ecr_registry}:latest \
+  python -m archimedes.chain.oracle_runner
+ExecStop=/usr/bin/docker stop archimedes-oracle
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+ORACLEEOF
+
+cat > /etc/systemd/system/archimedes-agent.service <<'AGENTEOF'
+[Unit]
+Description=Archimedes strategy agent runner (autonomous rebalancer, funds-adjacent singleton)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+TimeoutStartSec=120
+ExecStartPre=-/usr/bin/docker stop archimedes-agent
+ExecStartPre=-/usr/bin/docker rm archimedes-agent
+ExecStartPre=/opt/archimedes-runners/fetch-secrets.sh
+ExecStartPre=/opt/archimedes-runners/ecr-login.sh
+ExecStart=/usr/bin/docker run --rm --name archimedes-agent \
+  --env-file /opt/archimedes-runners/runner.env \
+  -e AWS_REGION=${aws_region} \
+  -e AGENT_INTERVAL_SECONDS=300 \
+  -e AGENT_DRY_RUN=false \
+  -e ARC_VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32 \
+  -e ARC_AMM_ROUTER_ADDRESS=0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4 \
+  -e ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6 \
+  --log-driver=awslogs \
+  --log-opt awslogs-region=${aws_region} \
+  --log-opt awslogs-group=${log_group_name} \
+  --log-opt awslogs-stream-prefix=agent \
+  ${ecr_registry}:latest \
+  python -m archimedes.chain.agent_runner
+ExecStop=/usr/bin/docker stop archimedes-agent
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+AGENTEOF
+
+systemctl daemon-reload
+
+# First-boot image pull + login (subsequent pulls happen via CI's SSM
+# RunCommand step, .github/workflows/deploy-runners.yml — inert until Dan
+# flips vars.RUNNER_DEPLOY_ENABLED post-apply, see that workflow's header).
+/opt/archimedes-runners/ecr-login.sh || echo "WARN: initial ECR login failed — image pull below may fail closed; the unit will retry on next restart once SSM/ECR access is confirmed."
+docker pull "${ecr_registry}:latest" || echo "WARN: initial image pull failed — archimedes-backend:latest may not be pushed to ECR yet. Units will retry per Restart=always once an image exists."
+
+systemctl enable archimedes-oracle.service archimedes-agent.service
+systemctl start archimedes-oracle.service archimedes-agent.service
+
+echo "archimedes-runner-bootstrap-complete" > /tmp/bootstrap-done

--- a/infra/runner-user-data.sh
+++ b/infra/runner-user-data.sh
@@ -80,12 +80,28 @@ chmod 700 /opt/archimedes-runners
 # standalone (non-FastAPI) process where there is no in-process SSM fetch to
 # reuse. Pulls the WHOLE prefix (DATABASE_URL, REDIS_URL,
 # AURORA_MASTER_PASSWORD, EMAIL_ENCRYPTION_KEY, CIRCLE_*, WALLET_ID,
-# WALLET_ADDRESS, INTERNAL_AGENT_API_KEY, ARC_AGENT_PRIVATE_KEY,
+# WALLET_ADDRESS, INTERNAL_AGENT_API_KEY, ARC_AGENT_PRIVATE_KEY, and ALL of
+# the ARC_*_ADDRESS contract addresses — ARC_VAULT_FACTORY_ADDRESS,
+# ARC_AMM_ROUTER_ADDRESS, ARC_REASONING_TRACE_REGISTRY_ADDRESS,
 # ARC_STRATEGY_REGISTRY_ADDRESS, ARC_PAYMENT_SPLITTER_ADDRESS, ...) into ONE
 # env file consumed by BOTH containers — harmless unused vars in either
 # container's env, and avoids maintaining two divergent per-service param
 # lists here. NEVER logs a value, only parameter NAMES (matches
 # setup-ssm-secrets.sh's own norm).
+#
+# SINGLE SOURCE OF TRUTH FOR CONTRACT ADDRESSES (correctness, coordinator
+# review): the ARC_*_ADDRESS values are pulled from SSM here and are the ONLY
+# place they come from — the systemd units below pass NO `-e ARC_*_ADDRESS`
+# flag, deliberately. A `docker run -e KEY=VAL` flag OVERRIDES the
+# `--env-file`, so a hardcoded literal `-e ARC_VAULT_FACTORY_ADDRESS=0x...`
+# would pin the runner to whatever address was baked into this bootstrap
+# script, silently defeating a T3.2 re-seed in SSM and making the runner sign
+# against a DEAD contract. Sourcing them here instead means Dan re-seeds every
+# new address in ONE step at T3.2 (`setup-ssm-secrets.sh --apply`) and both
+# runners pick them up on their next `systemctl restart`, no bootstrap edit.
+# This is also fail-CLOSED: a missing/empty address in SSM → the container
+# raises loudly at startup rather than silently transacting on a stale/wrong
+# contract, the correct posture for a funds-adjacent runner.
 #
 # KNOWN LIMITATION: docker's --env-file format is `KEY=VALUE` per line, no
 # shell expansion, and treats a line starting with `#` as a comment — a
@@ -141,6 +157,12 @@ chmod 700 /opt/archimedes-runners/ecr-login.sh
 # ── systemd units — one per singleton runner. Both:
 #   - pull the SAME archimedes-backend image (never build on-box)
 #   - refresh secrets from SSM on every (re)start (ExecStartPre)
+#   - pass ONLY static, non-redeploy-variable config as `-e` flags
+#     (AWS_REGION, ORACLE_INTERVAL_SECONDS/AGENT_INTERVAL_SECONDS,
+#     AGENT_DRY_RUN). Every mutable ARC_*_ADDRESS contract address comes from
+#     the SSM-sourced --env-file instead — NEVER as an `-e` flag, which would
+#     override the env-file and re-hardcode a soon-to-be-stale address (see
+#     the fetch-secrets.sh preamble above for the full rationale).
 #   - ship stdout/stderr to the /archimedes/runners CloudWatch log group via
 #     docker's native `awslogs` log driver (uses the instance role's
 #     credentials automatically — no CloudWatch agent needed)
@@ -172,8 +194,6 @@ ExecStart=/usr/bin/docker run --rm --name archimedes-oracle \
   --env-file /opt/archimedes-runners/runner.env \
   -e AWS_REGION=${aws_region} \
   -e ORACLE_INTERVAL_SECONDS=60 \
-  -e ARC_VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32 \
-  -e ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6 \
   --log-driver=awslogs \
   --log-opt awslogs-region=${aws_region} \
   --log-opt awslogs-group=${log_group_name} \
@@ -207,9 +227,6 @@ ExecStart=/usr/bin/docker run --rm --name archimedes-agent \
   -e AWS_REGION=${aws_region} \
   -e AGENT_INTERVAL_SECONDS=300 \
   -e AGENT_DRY_RUN=false \
-  -e ARC_VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32 \
-  -e ARC_AMM_ROUTER_ADDRESS=0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4 \
-  -e ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6 \
   --log-driver=awslogs \
   --log-opt awslogs-region=${aws_region} \
   --log-opt awslogs-group=${log_group_name} \

--- a/infra/runner_ec2.tf
+++ b/infra/runner_ec2.tf
@@ -1,0 +1,262 @@
+# ── Runner EC2 — oracle + agent, relocated off the stranded backend box ────
+#
+# Issue #1065 (execution checklist) / #1043 (parent). DRAFT — Dan applies
+# this himself POST-T3.2 (`terraform plan` is the real gate; see the PR body
+# for the full caveat list). The `oracle_runner` / `agent_runner`
+# docker-compose services (docker-compose.yml lines ~122-198) were EXCLUDED
+# from the ECS Fargate cutover (ecs.tf's file header, "KNOWN GAP #4") because
+# they are funds-adjacent, exactly-once singletons — services/runner_lease.py
+# is the authoritative app-layer Redis lease control, and duplicating either
+# process (an ASG, a Fargate service with desired_count > 1, or two live
+# copies during a bad deploy) risks a double-signed on-chain tx. Decision #1
+# in #1065: a SINGLE dedicated `aws_instance`, never an ASG.
+#
+# Placement: the PRIVATE subnets (same as the ECS backend task, Aurora,
+# ElastiCache — aws_subnet.private, vpc.tf) rather than a new SG surface on
+# Aurora/ElastiCache. Both aws_security_group.aurora (aurora.tf) and
+# aws_security_group.redis (elasticache.tf) already have an ingress rule for
+# "Postgres/Redis from private subnets" (10.0.10.0/24, 10.0.11.0/24) — so
+# this instance reaches both with ZERO edits to those other-lane files,
+# mirroring the same "don't touch aurora.tf/elasticache.tf, use what's
+# already open to the private subnet CIDRs" reasoning asg.tf documents for
+# its own (unused) backend_asg tier.
+#
+# No inbound SSH — admin access is SSM Session Manager only (same posture as
+# main.tf's aws_security_group.archimedes). Outbound is unrestricted
+# (0.0.0.0/0) via the existing fck-nat instances (vpc.tf): ECR, Arc RPC,
+# Aurora, ElastiCache, SSM, and CloudWatch Logs (for the docker awslogs
+# driver) all go out that path.
+
+# ── Security group ──────────────────────────────────────────────────────
+
+resource "aws_security_group" "runner" {
+  name        = "${var.project_name}-runner-sg"
+  description = "Oracle+agent runner EC2 - no inbound (SSM Session Manager only)"
+  vpc_id      = aws_vpc.main.id
+
+  # No ingress block at all — SSM Session Manager needs no inbound port
+  # (outbound HTTPS to the SSM/EC2Messages/SSMMessages VPC endpoints or, as
+  # here, out through the NAT instances, is sufficient).
+
+  egress {
+    description = "All outbound (ECR, Arc RPC, Aurora, ElastiCache, SSM, CloudWatch Logs)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-runner-sg"
+    Project = var.project_name
+  }
+}
+
+# ── IAM — instance role ─────────────────────────────────────────────────
+# Deliberately a NEW, separate role from aws_iam_role.ec2 (ec2_iam.tf, the
+# main backend box's role) rather than reusing it: this is a dedicated
+# instance per #1065 decision #1, and least-privilege scoping is cleaner
+# with its own role (e.g. it needs ECR pull + a NEW log group; it does NOT
+# need Bedrock invoke — neither oracle_runner.py nor agent_runner.py imports
+# any LLM/Bedrock backend, verified by grep — so that grant is deliberately
+# omitted here, unlike ec2_iam.tf's ec2_bedrock_invoke / ecs.tf's
+# ecs_task_bedrock_invoke).
+
+resource "aws_iam_role" "runner" {
+  name = "archimedes-runner-ec2-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+  tags = { Project = var.project_name }
+}
+
+# SSM agent registration + Session Manager (no inbound port needed).
+resource "aws_iam_role_policy_attachment" "runner_ssm_core" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Read /archimedes/prod/* secrets at every (re)start — mirrors
+# ec2_iam.tf's ec2_ssm_params exactly (same prefix, same KMS-via-SSM
+# condition), for the SAME reason: fetch-secrets.sh (runner-user-data.sh)
+# is this box's equivalent of services/secrets_service.load_ssm_secrets(),
+# just invoked from a shell script instead of at Python import time (neither
+# oracle_runner.py nor agent_runner.py calls load_ssm_secrets() itself — they
+# read os.environ directly, e.g. chain/executor.py's CIRCLE_API_KEY /
+# ARC_AGENT_PRIVATE_KEY / WALLET_ADDRESS reads — so the env must already be
+# populated before `docker run`, which is exactly what fetch-secrets.sh
+# + `--env-file` do).
+resource "aws_iam_role_policy" "runner_ssm_params" {
+  name = "archimedes-runner-ssm-parameter-read"
+  role = aws_iam_role.runner.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadAppSecrets"
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+        Resource = "arn:aws:ssm:*:*:parameter/archimedes/prod/*"
+      },
+      {
+        Sid      = "DecryptSecureStringViaSSM"
+        Effect   = "Allow"
+        Action   = "kms:Decrypt"
+        Resource = "*"
+        Condition = {
+          StringEquals = { "kms:ViaService" = "ssm.${var.aws_region}.amazonaws.com" }
+        }
+      }
+    ]
+  })
+}
+
+# ECR pull — GetAuthorizationToken is account-level (Resource "*" is the only
+# valid scope per AWS's own policy grammar for that action); the actual pull
+# actions are scoped to the one repository this box ever pulls from. This is
+# a real gap the main backend box's role (ec2_iam.tf) also has today per
+# deploy.yml's own header comment ("Box-side prerequisite ... NOT applied by
+# this PR — tracked in #1039 chunk 2") — not fixed here (out of scope for
+# this PR, which only owns the NEW runner role), but the pattern below is
+# exactly what that box will eventually need too.
+resource "aws_iam_role_policy" "runner_ecr_pull" {
+  name = "archimedes-runner-ecr-pull"
+  role = aws_iam_role.runner.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "EcrAuth"
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Sid    = "EcrPullBackendImage"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Resource = aws_ecr_repository.backend.arn
+      }
+    ]
+  })
+}
+
+# CloudWatch Logs write for the docker `awslogs` log driver (runner-user-data.sh's
+# systemd units) — scoped to the new /archimedes/runners log group only.
+# awslogs-create-group is NOT set (defaults false) since the log group is
+# Terraform-managed below, so logs:CreateLogGroup is deliberately not granted
+# (least privilege, mirrors ecs_task_exec_command's own scoped-stream-only
+# pattern in ecs.tf).
+resource "aws_iam_role_policy" "runner_logs" {
+  name = "archimedes-runner-logs-write"
+  role = aws_iam_role.runner.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RunnerLogStreamWrite"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = [
+          aws_cloudwatch_log_group.runners.arn,
+          "${aws_cloudwatch_log_group.runners.arn}:*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name = "archimedes-runner-ec2-profile"
+  role = aws_iam_role.runner.name
+}
+
+# ── CloudWatch log group ────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "runners" {
+  name              = "/archimedes/runners"
+  retention_in_days = 90 # matches aws_cloudwatch_log_group.app / .nginx (cloudwatch.tf)
+  tags              = { Project = var.project_name }
+}
+
+# ── EC2 instance ─────────────────────────────────────────────────────────
+
+resource "aws_instance" "runner" {
+  ami                    = data.aws_ami.ubuntu.id # reuses main.tf's Ubuntu 24.04 LTS data source
+  instance_type          = var.runner_instance_type
+  subnet_id              = aws_subnet.private[0].id
+  vpc_security_group_ids = [aws_security_group.runner.id]
+  iam_instance_profile   = aws_iam_instance_profile.runner.name
+  # No key_name: SSM Session Manager only, no SSH surface at all on this box
+  # (main.tf's single EC2 still carries an SSH key pair for legacy/rollback
+  # reasons; this new box has no such history to preserve).
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    delete_on_termination = true
+    encrypted             = true # same posture as main.tf's aws_instance.archimedes
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # IMDSv2 only, same as asg.tf's launch template
+    http_put_response_hop_limit = 2
+  }
+
+  user_data = templatefile("${path.module}/runner-user-data.sh", {
+    ecr_registry      = "${aws_ecr_repository.backend.repository_url}"
+    ecr_registry_host = split("/", aws_ecr_repository.backend.repository_url)[0]
+    aws_region        = var.aws_region
+    log_group_name    = aws_cloudwatch_log_group.runners.name
+  })
+
+  tags = {
+    Name    = "${var.project_name}-runner"
+    Project = var.project_name
+  }
+
+  lifecycle {
+    # Same rationale as main.tf's aws_instance.archimedes: an unrelated
+    # `terraform apply` picking up a newer Ubuntu AMI, or a user-data.sh edit
+    # that's bootstrap-only (runs once at first boot), must not silently
+    # replace/reboot this live funds-adjacent singleton.
+    ignore_changes = [ami, user_data]
+  }
+}
+
+# ── CloudWatch alarm ─────────────────────────────────────────────────────
+# EC2 instance/system status check failed — mirrors cloudwatch.tf's
+# ec2_status_check_failed alarm exactly (same thresholds/periods), scoped to
+# this instance. Named per #1065 decision (exact literal name specified in
+# the issue).
+
+resource "aws_cloudwatch_metric_alarm" "runner_ec2_status_check_failed" {
+  alarm_name          = "archimedes-runner-ec2-status-check-failed"
+  alarm_description   = "Oracle+agent runner EC2 instance/system status check failed — the funds-adjacent singleton runners are down (no oracle price pushes, no agent rebalances) until this recovers."
+  namespace           = "AWS/EC2"
+  metric_name         = "StatusCheckFailed"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 0
+  period              = 60
+  evaluation_periods  = 3
+  dimensions          = { InstanceId = aws_instance.runner.id }
+  alarm_actions       = [aws_sns_topic.alerts.arn] # cloudwatch.tf's existing SNS topic
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "breaching"
+  tags                = { Project = var.project_name }
+}

--- a/infra/scripts/setup-ssm-secrets.sh
+++ b/infra/scripts/setup-ssm-secrets.sh
@@ -28,11 +28,19 @@ PARAMS=(
   AURORA_MASTER_PASSWORD   # DB master password (mirror TF_VAR_aurora_master_password)
   # --- Forthcoming, as features land (roadmap T1.x) ---
   PINATA_JWT               # IPFS pinning for reasoning-trace provenance (T1.4)
-  CIRCLE_API_KEY           # Circle wallets / Gateway nanopayments (T1.2)
-  CIRCLE_ENTITY_SECRET     # Circle dev-controlled wallet entity secret
-  WALLET_ID                # Circle DCW wallet UUID (oracle/agent Circle signer) — T3.2
-  WALLET_ADDRESS           # Circle DCW EVM address (public; agent signer) — T3.2
-  INTERNAL_AGENT_API_KEY   # X-Internal-Agent-Key runner->backend auth — T3.2
+  CIRCLE_API_KEY           # Circle wallets / Gateway nanopayments (T1.2) — also the oracle+agent Circle DCW signer (#1065)
+  CIRCLE_ENTITY_SECRET     # Circle dev-controlled wallet entity secret (oracle+agent, #1065)
+  # --- Runner relocation (issue #1065 / #1043) — oracle+agent EC2 + kb-runner ---
+  # Names only, matching issue #1065's execution checklist Step 1 (the
+  # Agora-workspace-level coordination doc T32-COORDINATION-DELTA-2026-07-08.md
+  # §2 has the same list). Values set by Dan post-T3.2, once decision #1
+  # (agent signer: Circle DCW vs raw key) is resolved.
+  WALLET_ID                # Circle DCW wallet UUID (oracle/agent Circle signer)
+  WALLET_ADDRESS           # that wallet's EVM address (public, informational)
+  INTERNAL_AGENT_API_KEY   # X-Internal-Agent-Key shared secret, agent runner -> backend internal API
+  ARC_AGENT_PRIVATE_KEY    # raw-key agent signer FALLBACK (chain/executor.py) — only if not using Circle DCW for the agent (decision #1)
+  ARC_STRATEGY_REGISTRY_ADDRESS  # StrategyRegistry — changes at every contract redeploy (T3.2), so SSM-sourced, not hardcoded
+  ARC_PAYMENT_SPLITTER_ADDRESS   # PaymentSplitter (marketplace payouts) — same rationale
 )
 # NOTE: VITE_CIRCLE_CLIENT_KEY is a BUILD-TIME secret baked into the UI bundle at
 # `docker compose build` — it lives in the box-local .env (seeded by user-data.sh),

--- a/infra/scripts/setup-ssm-secrets.sh
+++ b/infra/scripts/setup-ssm-secrets.sh
@@ -26,6 +26,8 @@ PARAMS=(
   LLM_BASE_URL             # LLM endpoint base URL
   EMAIL_ENCRYPTION_KEY     # at-rest encryption key for stored user emails
   AURORA_MASTER_PASSWORD   # DB master password (mirror TF_VAR_aurora_master_password)
+  DATABASE_URL             # Aurora connection URL — consumed by the backend Fargate task (ecs.tf secrets) AND the relocated oracle/agent runners (fetch-secrets.sh); ecs.tf's header flags this as not-yet-seeded
+  REDIS_URL                # ElastiCache connection URL — same two consumers; same not-yet-seeded gap
   # --- Forthcoming, as features land (roadmap T1.x) ---
   PINATA_JWT               # IPFS pinning for reasoning-trace provenance (T1.4)
   CIRCLE_API_KEY           # Circle wallets / Gateway nanopayments (T1.2) — also the oracle+agent Circle DCW signer (#1065)
@@ -39,8 +41,17 @@ PARAMS=(
   WALLET_ADDRESS           # that wallet's EVM address (public, informational)
   INTERNAL_AGENT_API_KEY   # X-Internal-Agent-Key shared secret, agent runner -> backend internal API
   ARC_AGENT_PRIVATE_KEY    # raw-key agent signer FALLBACK (chain/executor.py) — only if not using Circle DCW for the agent (decision #1)
-  ARC_STRATEGY_REGISTRY_ADDRESS  # StrategyRegistry — changes at every contract redeploy (T3.2), so SSM-sourced, not hardcoded
-  ARC_PAYMENT_SPLITTER_ADDRESS   # PaymentSplitter (marketplace payouts) — same rationale
+  # ALL mutable ARC_*_ADDRESS values are SSM-sourced (never hardcoded): they
+  # change at every contract redeploy (T3.2), so the runner reads them from
+  # here via fetch-secrets.sh → --env-file (single source of truth; the
+  # systemd units pass NO `-e ARC_*_ADDRESS` flag that could override them,
+  # and a missing address fails the container closed rather than signing a
+  # dead contract). Seed every new address in ONE `--apply` at T3.2.
+  ARC_VAULT_FACTORY_ADDRESS           # VaultFactory — oracle + agent runner (fetch-secrets.sh)
+  ARC_AMM_ROUTER_ADDRESS              # AMMRouter — agent runner rebalance path (fetch-secrets.sh)
+  ARC_REASONING_TRACE_REGISTRY_ADDRESS # ReasoningTraceRegistry — oracle + agent runner (fetch-secrets.sh)
+  ARC_STRATEGY_REGISTRY_ADDRESS       # StrategyRegistry — changes at every contract redeploy (T3.2), so SSM-sourced, not hardcoded
+  ARC_PAYMENT_SPLITTER_ADDRESS        # PaymentSplitter (marketplace payouts) — same rationale
 )
 # NOTE: VITE_CIRCLE_CLIENT_KEY is a BUILD-TIME secret baked into the UI bundle at
 # `docker compose build` — it lives in the box-local .env (seeded by user-data.sh),

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -119,3 +119,31 @@ variable "archimedes_treasury_wallet" {
   type        = string
   default     = ""
 }
+
+# ── Runner relocation (issue #1065 / #1043) ─────────────────────────────────
+# Draft IaC — Dan applies POST-T3.2. See infra/runner_ec2.tf, infra/kb_runner.tf,
+# infra/efs.tf, and the PR body for the full architecture + caveats.
+
+variable "runner_instance_type" {
+  description = "EC2 instance type for the dedicated oracle+agent runner box (issue #1065 decision #1 — a single instance, never an ASG). t3.small is generous headroom for two lightweight async Python loops; bump if the agent's regime/backtest compute proves heavier in practice."
+  type        = string
+  default     = "t3.small"
+}
+
+variable "kb_runner_cpu" {
+  description = "Fargate task-level vCPU units for the scheduled kb-runner task (infra/kb_runner.tf). 1024 = 1 vCPU. Sized for the current skip-mode default (KB_PIPELINE_ENABLED unset) — bump substantially (and add GPU-appropriate compute, out of scope for Fargate) when the real ~6 GB SPECTER2/REBEL/SciSpacy pipeline is enabled."
+  type        = string
+  default     = "1024"
+}
+
+variable "kb_runner_memory" {
+  description = "Fargate task-level memory (MiB) for the scheduled kb-runner task. Must pair validly with kb_runner_cpu — see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html."
+  type        = string
+  default     = "4096"
+}
+
+variable "kb_runner_schedule_expression" {
+  description = "EventBridge Scheduler rate/cron expression for the kb-runner scheduled Fargate task (infra/kb_runner.tf's aws_scheduler_schedule). Daily is a conservative default for a batch job that currently no-ops to a 'skipped' manifest.json (KB_PIPELINE_ENABLED unset) — tighten or loosen once the real pipeline is live and its actual runtime/cost is known."
+  type        = string
+  default     = "rate(1 day)"
+}


### PR DESCRIPTION
## Summary

Drafts the Terraform + CI for relocating the three stranded background runners (`oracle`, `agent`, `kb-runner` — `docker-compose.yml`) off the detached EC2 box, per #1065's execution checklist. **This is a draft for Dan to apply POST-T3.2** — `terraform plan` is the real gate, not this PR. Nothing here is applied; nothing here can auto-deploy (see the CI safety note below).

Architecture (issue #1065's drafted defaults, all followed as-is):

1. **Oracle + agent → one dedicated `aws_instance`** (`infra/runner_ec2.tf`), never an ASG, never an ECS service. Both are funds-adjacent, exactly-once singletons — `services/runner_lease.py`'s Redis lease is the authoritative app-layer control; this box just gives each process somewhere to run. No inbound SSH (SSM Session Manager only). Pulls the same `archimedes-backend` ECR image as everything else and runs `oracle_runner`/`agent_runner` as two systemd-managed `docker run` containers. Secrets are fetched from SSM `/archimedes/prod/*` into a `--env-file` on every `systemctl restart` (`fetch-secrets.sh`, baked in via `runner-user-data.sh`) — mirrors `load_ssm_secrets()`'s access pattern for a process that isn't FastAPI and doesn't call it directly. New log group `/archimedes/runners` (docker `awslogs` driver, no CloudWatch agent).
2. **kb-runner → a scheduled (batch) Fargate task**, not a service (`infra/kb_runner.tf`). EventBridge Scheduler (`aws_scheduler_schedule`, daily default) invokes `ecs:RunTask` directly. Command is the already-one-shot `python -m archimedes.scripts.run_kb_pipeline` (verified present) — decision #2's option (A), not a new `run_once()`.
3. **EFS for shared KB corpus-artifact storage** (`infra/efs.tf`) — one access point (POSIX uid/gid 1001, matching `backend/Dockerfile`'s nonroot user) mounted into both the backend task (`/app/data/corpus-artifact`) and the kb-runner task (`/srv/corpus-artifact`), replacing docker-compose's single named volume mounted at both those same paths today.
4. **SSM secrets stay script-seeded**, not `aws_ssm_parameter` resources — matches the repo's existing convention (`infra/scripts/setup-ssm-secrets.sh`). Added the new runner secret **names** there (values are Dan's to set, post-T3.2): `WALLET_ID`, `WALLET_ADDRESS`, `INTERNAL_AGENT_API_KEY`, `ARC_AGENT_PRIVATE_KEY`, `ARC_STRATEGY_REGISTRY_ADDRESS`, `ARC_PAYMENT_SPLITTER_ADDRESS`. `CIRCLE_API_KEY`/`CIRCLE_ENTITY_SECRET` already existed in that script; annotated them as also covering the oracle/agent Circle DCW signer.

## New resources (the `terraform plan` surface)

**`infra/runner_ec2.tf`** — `aws_security_group.runner` (no ingress, all egress) · `aws_iam_role.runner` + SSM-core attachment + 3 inline policies (SSM param read, ECR pull scoped to the `archimedes-backend` repo, CloudWatch Logs write scoped to the new log group) · `aws_iam_instance_profile.runner` · `aws_cloudwatch_log_group.runners` (`/archimedes/runners`) · `aws_instance.runner` (private subnet, IMDSv2-only, encrypted root volume, no SSH key) · `aws_cloudwatch_metric_alarm.runner_ec2_status_check_failed` (exact name `archimedes-runner-ec2-status-check-failed`, per #1065).

**`infra/efs.tf`** — `aws_security_group.efs` (NFS 2049 from the backend + kb-runner task SGs only) · `aws_efs_file_system.corpus_artifact` · `aws_efs_mount_target.corpus_artifact` × 2 (one per private subnet) · `aws_efs_access_point.corpus_artifact` (posix uid/gid 1001) · `aws_iam_role_policy.ecs_task_efs_access` (**additive** policy on the *existing* `aws_iam_role.ecs_task` from `ecs.tf` — shared by backend, migrate, and kb-runner; scoped via the `AccessPointArn` condition).

**`infra/kb_runner.tf`** — `aws_security_group.kb_runner` (no ingress) · `aws_cloudwatch_log_group.kb_runner` (`/archimedes/kb-runner`, dedicated so the failure metric filter can't cross-contaminate with backend/migrate logs) · `aws_ecs_task_definition.kb_runner` (single container, EFS volume, no `secrets` block — see caveats) · `aws_iam_role.kb_scheduler` + inline `RunTask`/`PassRole` policy · `aws_scheduler_schedule.kb_runner` (daily default, targets the task family's latest ACTIVE revision via a revision-less ARN — verified via AWS docs, not just assumed) · `aws_cloudwatch_log_metric_filter.kb_runner_errors` + `aws_cloudwatch_metric_alarm.kb_runner_failed` (exact name `archimedes-kb-runner-failed`, per #1065).

**`infra/ecs.tf` (existing resource, additive diff)** — adds a `volume` block + the "backend" container's `mountPoints` entry to `aws_ecs_task_definition.backend`, so the backend can read what kb-runner writes. This is the one Terraform-classified in-place update (`~`) to an existing resource — **not a destroy** (`container_definitions`/`volume` aren't `ForceNew` on this resource; ECS task-def revisioning happens via the provider's normal update path). New task-definition revision only; `aws_ecs_service.backend` keeps `lifecycle.ignore_changes = [task_definition]`, so this revision does **not** auto-roll the live service.

**Variables added** (`infra/variables.tf`): `runner_instance_type` (default `t3.small`), `kb_runner_cpu`/`kb_runner_memory` (1024/4096), `kb_runner_schedule_expression` (default `rate(1 day)`).

**Outputs added** (`infra/outputs.tf`): `runner_instance_id`, `runner_log_group_name`, `efs_file_system_id`, `efs_access_point_id`, `kb_runner_task_definition_family`, `kb_runner_schedule_name`, `kb_runner_log_group_name`.

## Zero-destroy expectation

Every new resource above is a pure add. The **only** diff on an existing resource is `aws_ecs_task_definition.backend` gaining a volume + mountPoint — confirmed via the AWS provider schema (those attributes aren't `ForceNew`), so this should plan as `~ update in-place`, not `-/+ replace`. **If `terraform plan` shows anything else as a destroy or replace, stop and don't apply** — that would mean either a schema assumption here was wrong or something else drifted; flag it rather than pushing through.

## CI — inert until Dan enables it

`.github/workflows/deploy-runners.yml` is a new, separate workflow (doesn't touch `deploy.yml`). **Merging this PR cannot trigger a deploy against infrastructure that doesn't exist yet** — three independent layers:
1. **No `push` trigger.** Only `workflow_dispatch` (manual) is wired; the eventual `push: branches: [main]` trigger is written but commented out in the file, with a pointer to when to uncomment it (post `terraform apply` + on-chain verification, referenced from the runbook's Phase 8 step 2).
2. **`if: vars.RUNNER_DEPLOY_ENABLED == 'true'`** gates both jobs — a new repo variable, separate from the existing `DEPLOY_ENABLED`, unset/false by default.
3. **Runtime existence checks** — each job resolves its target (a running EC2 tagged `Name=archimedes-runner`; an `ACTIVE` `archimedes-kb-runner` task-definition family) and no-ops loudly if it isn't there yet, same convention as `deploy.yml`'s self-activating `migrate`/`deploy-ecs` jobs.

No new IAM was needed for CI — the existing `archimedes-github-deploy` OIDC role already grants `ssm:SendCommand`, `ec2:DescribeInstances` (both `Resource: "*"`, from `setup-github-oidc.sh`'s starter policy) and `ecs:RegisterTaskDefinition`/`DescribeTaskDefinition` (from `ecs.tf`'s `github_deploy_ecs` policy, also `Resource: "*"`).

## Runbook update

`infra/runbooks/ecs-fargate-cutover.md` Phase 8's decommission gate previously checked for three ECS *services* (`archimedes-oracle`/`archimedes-agent`/`archimedes-kb-runner`) — that was always aspirational and never matched what got built. Replaced with the real shape: EC2 `running` + on-chain-activity-in-the-last-hour checks for oracle/agent, `aws scheduler get-schedule` + manifest-log check for kb, both new CloudWatch alarms `OK`. Per #1065 Step 4.

## Pre-apply prerequisites (all must be seeded in SSM before the runners do anything on-chain)

`setup-ssm-secrets.sh --apply` must be run for the new **names** below (this PR only adds names, per decision #4) — including `DATABASE_URL` + `REDIS_URL`, which `ecs.tf`'s own header flags as not-yet-seeded and which both the backend Fargate task and the relocated runners depend on:

- `DATABASE_URL`, `REDIS_URL` (Aurora/ElastiCache connection URLs)
- The Circle DCW trio (`CIRCLE_API_KEY`/`CIRCLE_ENTITY_SECRET`/`WALLET_ID`) or `ARC_AGENT_PRIVATE_KEY` (decision #1), plus `WALLET_ADDRESS`, `INTERNAL_AGENT_API_KEY`
- **Every** T3.2 contract address: `ARC_VAULT_FACTORY_ADDRESS`, `ARC_AMM_ROUTER_ADDRESS`, `ARC_REASONING_TRACE_REGISTRY_ADDRESS`, `ARC_STRATEGY_REGISTRY_ADDRESS`, `ARC_PAYMENT_SPLITTER_ADDRESS`

## Honest caveats (cross-referencing #1065's execution checklist)

- **ALL mutable ARC contract addresses are SSM-sourced for the runner — single source of truth, fail-closed** (correctness fix, coordinator review). The systemd units pass **no** `-e ARC_*_ADDRESS` flag; every address flows from `fetch-secrets.sh` → `--env-file`. This matters because `docker run -e KEY=VAL` *overrides* `--env-file` — an earlier draft hardcoded the pre-T3.2 addresses as `-e` flags, which would have silently pinned the runners to **dead** contracts after the T3.2 redeploy even with the new addresses correctly seeded in SSM. Now at T3.2 Dan seeds every new address in **one** step (`setup-ssm-secrets.sh --apply`) and both runners pick them up on their next `systemctl restart`, no code/IaC edit. A missing/empty address in SSM makes the container **fail loudly at startup** rather than silently transacting on a stale/wrong contract — the correct posture for a funds-adjacent runner (the app code already defaults these to empty and fails closed).
- **Needs T3.2's new contract addresses first** — don't seed them until T3.2 ships, since they change at the redeploy.
- **Decision #1 (agent signer) is Dan's call**, not resolved by this PR — the systemd units fetch whatever's in SSM (Circle DCW trio or `ARC_AGENT_PRIVATE_KEY`) and `chain/executor.py` already prefers Circle when configured.
- **`kb-runner`'s task definition has no `DATABASE_URL` secret** — deliberate. `run_kb_pipeline.py`'s current skeleton doesn't read it (verified via grep); adding an unused hard SSM dependency would risk failing task launch on a param that may not exist yet. Add it back (same SSM ARN pattern as `ecs.tf`/`ecs_migrate.tf`) in the same PR that flips `KB_PIPELINE_ENABLED` on.
- **Out of scope, flagged not fixed:** #1065's Step 1b ("backend Fargate task is also missing `CIRCLE_API_KEY`/`CIRCLE_ENTITY_SECRET`/`ARC_PAYMENT_SPLITTER_ADDRESS`/`ARC_STRATEGY_REGISTRY_ADDRESS`" — a pre-existing, separate publish-502 bug) is **not** touched here. This PR's only `ecs.tf` diff is the EFS companion mount. Also not touched: whether `INTERNAL_AGENT_API_KEY` needs wiring into the backend's own `secrets` block for the agent's `X-Internal-Agent-Key` calls to validate — same reasoning, separate concern.
- **kb-runner failure alarm is a heuristic** (CloudWatch Logs metric filter on `?ERROR ?Error ?Traceback`), not a precise ECS-exit-code signal. Documented in `kb_runner.tf` as a follow-up if tighter precision (an EventBridge rule on ECS Task State Change + exit code) is wanted later.
- **`terraform validate` passed; `terraform plan`/`apply` did not run** (no AWS credentials in this environment) — see Verification below.

## Verification

- `terraform fmt -check -diff -recursive` → clean, no diffs.
- `terraform validate` → **Success** (ran against the already-initialized local provider cache in this clone; caught and fixed a real `templatefile()` escaping bug in `runner-user-data.sh` before landing). This confirms every resource/attribute name against the AWS provider v5.100.0 schema and that the template renders.
- `terraform plan`/`apply` did **not** run — no AWS credentials available in this environment. **Dan must run `terraform plan` and review it (esp. the zero-destroy expectation above) before applying.**
- GitHub Actions YAML parsed with PyYAML — valid.
- `git diff --stat`: only new `infra/*.tf` files, the `ecs.tf` EFS-companion diff, the runbook edit, the new CI workflow, `variables.tf`/`outputs.tf` additions, and `setup-ssm-secrets.sh` name additions — no other files touched.

## Links

- Execution checklist (apply this PR, then work through it): #1065
- Parent: #1043


---
**Review note (2026-07-14, adjacent gap — NOT fixed here):** `infra/ecs.tf`'s backend Fargate task hardcodes the contract addresses (`ARC_VAULT_FACTORY_ADDRESS`, `ARC_AMM_ROUTER_ADDRESS`, `ARC_REASONING_TRACE_REGISTRY_ADDRESS`, `ARC_ASSET_REGISTRY_ADDRESS`, `ARC_SYNTHETIC_FACTORY_ADDRESS`, `ARC_STRATEGY_REGISTRY_ADDRESS`, `ARC_PAYMENT_SPLITTER_ADDRESS`) as literal `environment` entries — pre-existing and directly adjacent to this PR's EFS hunk, so flagging it here per the same next-redeploy-breaks-everything logic as the #588 commit-reveal ABI landmine: at the next contract redeploy these go stale unless updated in Terraform too. Belongs with the address-SSOT work, not this PR.


**Pre-apply hardening (from review, 2026-07-14):** `fetch-secrets.sh` currently pulls the entire `/archimedes/prod/*` SSM namespace onto the runner box (chmod-600 env file). Least-privilege follow-up before `terraform apply`: scope the fetch to the key subset the oracle/agent units actually need (oracle signer, RPC, DB/Redis URLs) so a compromised runner can't read web-tier secrets (Circle keys, SIWE session key, LLM keys). Needs Dan's confirmation of the per-unit key list as infra owner.
