### PR TITLE
[rigor] Decouple num_trials from library size — a strategy's DSR depends only on itself (decouple #2)

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -18,9 +18,9 @@ checks corpus size. The pipeline:
      deterministic critics do the real culling (the budget trick).
   3. **C-rigor** — backtests EVERY survivor via ``evaluate_fusion_spec``
      (deterministic Python, 0 tokens), each wrapped in try/except (fix A5
-     backstop), with ``num_trials=_society_num_trials(library_size, pool_size)``
-     (#770/#820) so the DSR multiple-testing correction counts both the
-     selection-from-pool search AND the library the winner joins.
+     backstop), with ``num_trials=_society_num_trials(pool_size)`` (decouple
+     #2) so the DSR multiple-testing correction counts only the strategy's
+     OWN selection-from-pool search — never the library it joins.
   4. **C-null** — a survivor must beat the passive null (buy-and-hold) net of
      cost by ``MIN_COST_BENEFIT``. If none clears it → first-class ABSTAIN.
   5. **Synthesizer** — deterministic rank of the survivors → top-N leaderboard.
@@ -107,19 +107,6 @@ def _leaderboard_max() -> int:
         return max(1, min(24, int(os.getenv("DEBATE_LEADERBOARD_MAX", "10"))))
     except ValueError:
         return 10
-
-
-def _library_size() -> int:
-    """Curated strategy-library size — the library-context selection layer for the
-    DSR deflation (mirrors the live path's ``len(strategies)``). Never raises;
-    degrades to 1 (the minimum), which can only UNDER-count, never over-deflate."""
-    try:
-        from archimedes.services.strategy_provider import default_provider
-
-        return max(1, len(default_provider().list_strategies()))
-    except Exception:
-        logger.debug("debate: library-size lookup failed; defaulting to 1", exc_info=True)
-        return 1
 
 
 class DebateUnavailable(FusionUnavailable):
@@ -387,11 +374,11 @@ async def _debate_round(pool: list[Any], model: str | None, emit: _Emitter, cand
 async def _critic_rigor(pool: list[Any], num_trials: int) -> list[tuple[Any, Any]]:
     """Backtest every pooled spec for real; return ``[(proposal, eval_result)]``.
 
-    ``num_trials`` is ``_society_num_trials(library_size, pool_size)`` (library + N,
-    #770/#820), so the DSR deflation counts the selection-from-pool search AND the
-    library the winner joins — not ``pool_size`` alone. Each ``evaluate_fusion_spec``
-    is wrapped in try/except so one bad spec (despite the A5 pre-guard) drops with
-    an honest emit, never aborting the cohort.
+    ``num_trials`` is ``_society_num_trials(pool_size)`` (decouple #2), so the
+    DSR deflation counts only the strategy's OWN selection-from-pool search —
+    never the library it joins. Each ``evaluate_fusion_spec`` is wrapped in
+    try/except so one bad spec (despite the A5 pre-guard) drops with an honest
+    emit, never aborting the cohort.
     """
     from archimedes.services.fusion_evaluator import evaluate_fusion_spec
     from archimedes.services.fusion_market_data import real_data_enabled
@@ -484,7 +471,7 @@ def _rigor_verdict_dict(ev: Any) -> dict[str, Any]:
         "in_sample_sharpe": r.in_sample_sharpe,
         "lookahead_audit_passed": bool(r.look_ahead_clean),
         "look_ahead_label": r.look_ahead_label,
-        "num_trials": int(r.num_trials),  # library + pool_size, #770/#820 (A1)
+        "num_trials": int(r.num_trials),  # own pool_size, decouple #2
         "passing": bool(r.passing),
         "data_source": r.data_source,
         "admissible": bool(ev.admissible),

--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -733,18 +733,18 @@ async def _run_debate_leaderboard(
     if not prov_clean:
         raise DebateUnavailable("debate: all candidates failed provenance (cited outside the embargo+decay surface)")
 
-    # Step 3b — C-rigor (A1, aligned with #770/#811 + Önder's #820): num_trials =
-    # _society_num_trials(library_size, pool_size) = library + N, NOT pool_size alone,
-    # so the debate "passing" badge is not more permissive than the live path. pool_size
-    # (the full conformant proposed count) is the selection set; C-prov only culls which
-    # survivors are backtested. When #820 lands the shared helper, read from that source.
-    num_trials = await asyncio.to_thread(lambda: _society_num_trials(_library_size(), pool_size))
+    # Step 3b — C-rigor: num_trials = _society_num_trials(pool_size) = the strategy's
+    # OWN candidate pool (N), NOT N + library_size. A strategy's rigor depends only on
+    # itself, never on the library it joins (decouple #2, reverses #770/#811/#820 —
+    # needs Önder's sign-off). pool_size (the full conformant proposed count) is the
+    # selection set; C-prov only culls which survivors are backtested.
+    num_trials = _society_num_trials(pool_size)
     await emit.emit("agent_iteration", candidate_id=candidate_id, iteration_n=2, max_iterations=4)
     await emit.emit(
         "tool_called",
         candidate_id=candidate_id,
         tool_name="evaluate_fusion_spec",
-        args_summary=f"backtest ×{len(prov_clean)}, num_trials={num_trials} (library+pool, #770/#820)",
+        args_summary=f"backtest ×{len(prov_clean)}, num_trials={num_trials} (own pool, decouple #2)",
     )
     rigor_results = await _critic_rigor(prov_clean, num_trials)
     if not rigor_results:

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -636,15 +636,22 @@ async def _run_fixture_candidate(
     )
 
 
-def _society_num_trials(library_size: int, selection_pool_size: int) -> int:
-    """Effective DSR multiple-testing trial count on the agentic society path (#770).
+def _society_num_trials(selection_pool_size: int) -> int:
+    """Effective DSR multiple-testing trial count on the agentic society path.
 
-    The winner survived selection from ``selection_pool_size`` (N) generated candidates
-    AND is promoted into a library of ``library_size`` — two independent selection layers,
-    so the deflation count is their SUM (approach A, Bailey & López de Prado 2014). See
-    ``docs/specs/selection-bias-corrections-spec.md`` § 1.3 addendum. Floored at 1.
+    A strategy's rigor must depend ONLY on that strategy — never on how many OTHER
+    strategies happen to sit in the library (Dan's principle, 2026-07-09). The trial
+    count that deflates this winner's Sharpe is therefore the size of ITS OWN
+    selection set: the ``selection_pool_size`` (N) generated candidates it was chosen
+    from — NOT ``N + library_size``. Promoting a strategy into a bigger library must
+    not retroactively change its Deflated Sharpe. Floored at 1.
+
+    NOTE: this REVERSES the ``N + library_size`` additive convention from #770/#811/#820
+    (which treated the library as a second selection layer). See the decouple plan in
+    ``docs/CURATED-STRATEGY-DECOUPLE-AND-CONSOLIDATE-2026-07-08.md`` Part A #2.
+    Needs Önder's sign-off (portfolio math) — it changes DSR p-values.
     """
-    return max(1, library_size + selection_pool_size)
+    return max(1, selection_pool_size)
 
 
 class FusionUnavailable(Exception):
@@ -871,20 +878,17 @@ async def run_generation(
             except Exception as exc:
                 logger.warning("could not build per-job agent for model %r (%s); using default", model, exc)
                 job_agent = None
-        # Library is the candidate pool the agent reasons over; surface it so
-        # the UI can show "agent is considering N papers". Its size also feeds
-        # the DSR multiple-testing correction below (selection-bias-corrections-
-        # spec.md § 1.3) — num_trials must be the size of the selection set the
-        # winner was chosen from, not 1.
+        # Library = the candidate pool the agent reasons over; surface it so the UI
+        # can show "agent is considering N papers". The DSR multiple-testing count is
+        # the strategy's OWN candidate pool (computed per-candidate below), NOT the
+        # library size — a strategy's rigor depends only on itself (decouple #2).
         try:
             from archimedes.services.strategy_provider import default_provider
 
             lib = default_provider().list_strategies()
             arxiv_ids = [s.paper_arxiv_id for s in lib if getattr(s, "paper_arxiv_id", None)]
-            library_size = max(1, len(lib))
         except Exception:
             arxiv_ids = []
-            library_size = 1
         await emit.emit(
             "candidates_selected",
             candidate_count=len(regimes),
@@ -1064,9 +1068,10 @@ async def run_generation(
         _static_skip = ("fusion", "debate", "debate_abstain")
         await asyncio.gather(
             *[
-                # num_trials = N candidates + library context (#770), not library alone.
+                # num_trials = the strategy's OWN candidate pool (N), never the library
+                # size — a strategy's rigor depends only on itself (decouple #2).
                 _backtest_and_persist(
-                    c, strategy_ids[c.candidate_id], emit, _society_num_trials(library_size, n_candidates)
+                    c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates)
                 )
                 for c in candidates
                 if c.generation_method not in _static_skip and c.candidate_id in strategy_ids
@@ -1081,7 +1086,7 @@ async def run_generation(
         await asyncio.gather(
             *[
                 _persist_real_returns(
-                    c, strategy_ids[c.candidate_id], emit, _society_num_trials(library_size, n_candidates)
+                    c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates)
                 )
                 for c in candidates
                 if c.has_real_rigor and c.return_series and c.candidate_id in strategy_ids

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -241,8 +241,9 @@ class _CandidateResult:
     # downstream buy-and-hold backtest step is skipped — it would clobber the
     # already-computed fusion metrics with a different, weight-less read).
     has_real_rigor: bool = False
-    # The society num_trials (#770, N + library_size) this candidate's DSR was
-    # first computed with. Recorded so the post-loop correlation patch (#822)
+    # The society num_trials (``_society_num_trials(N)``, decouple #2 — the
+    # candidate's OWN pool, never the library) this candidate's DSR was first
+    # computed with. Recorded so the post-loop correlation patch (#822)
     # recomputes DSR at the SAME trial count — only the average_correlation term
     # changes, never the deflation count itself. 0 on the fixture/fusion paths,
     # which don't run the buy-and-hold DSR patch.
@@ -330,10 +331,11 @@ def _rigor_verdict_for(
     emitter + frontend) doesn't care which path produced the verdict.
 
     ``num_trials`` is the multiple-testing count fed to the Deflated Sharpe
-    Ratio — per ``selection-bias-corrections-spec.md`` § 1.3 this is the size
-    of the strategy universe the winner was selected from (the curated library),
-    NOT 1. With ``num_trials=1`` the DSR expectation-of-max term collapses to 0
-    and the ratio is undeflated, which silently defeats the gate.
+    Ratio — the candidate's OWN N-candidate selection pool it was chosen from
+    (``_society_num_trials(N)``, decouple #2), NEVER the curated library's
+    count. With ``num_trials=1`` the DSR expectation-of-max term collapses to
+    0 and the ratio is undeflated — correct only when the caller genuinely has
+    no selection pool larger than 1.
 
     ``average_correlation`` is the mean pairwise correlation among the
     ``num_trials`` society candidates (approach B, issue #822). Defaults to
@@ -1502,8 +1504,9 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         strategy_id: The DB id returned by :func:`_persist_candidate`.
         emit: The SSE emitter to surface backtest progress to the UI.
         num_trials: Effective trial count for the DSR multiple-testing correction —
-            N generated candidates + curated-library size on the society path (#770),
-            fed to ``backtest_portfolio`` as ``num_trials_for_dsr``.
+            the candidate's OWN N-candidate selection pool on the society path
+            (``_society_num_trials(N)``, decouple #2 — never the curated-library
+            size), fed to ``backtest_portfolio`` as ``num_trials_for_dsr``.
     """
     # Fixture mode (offline tests, no-LLM environments) — skip the network
     # round-trip. The test suite covers this function's behavior via direct
@@ -1546,10 +1549,10 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         from archimedes.services.portfolio_backtester import backtest_portfolio
 
         # Run the actual backtest. Raises on insufficient data / fetch failure.
-        # num_trials_for_dsr = N candidates + curated-library size (#770,
-        # selection-bias-corrections-spec.md § 1.3) — the DSR multiple-testing
-        # correction for the full selection set: the N-candidate society search
-        # this winner survived PLUS the library it joins, not library alone.
+        # num_trials_for_dsr = the candidate's OWN N-candidate society-search pool
+        # (``_society_num_trials(N)``, decouple #2) — the DSR multiple-testing
+        # correction for the selection set this winner survived, never the
+        # curated library it happens to join.
         result, artifact = backtest_portfolio(
             strategy_id=strategy_id,
             weights=c.weights,

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -389,6 +389,11 @@ def _rigor_verdict_for(
         "in_sample_sharpe": round(float(in_sample_sharpe), 4) if in_sample_sharpe is not None else None,
         "lookahead_audit_passed": lookahead_passed,
         "passing": passing,
+        # Deflation provenance (#1075): the N actually used and the convention
+        # marker distinguishing post-decouple verdicts from stored pre-change
+        # blobs (formula A included the curated library count; this one never does).
+        "num_trials": int(max(1, num_trials)),
+        "num_trials_convention": "self_contained_v2",
     }
 
 
@@ -1072,9 +1077,7 @@ async def run_generation(
             *[
                 # num_trials = the strategy's OWN candidate pool (N), never the library
                 # size — a strategy's rigor depends only on itself (decouple #2).
-                _backtest_and_persist(
-                    c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates)
-                )
+                _backtest_and_persist(c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates))
                 for c in candidates
                 if c.generation_method not in _static_skip and c.candidate_id in strategy_ids
             ]
@@ -1087,9 +1090,7 @@ async def run_generation(
         # and the server-side create_vault gate (#829) refuses to deploy it.
         await asyncio.gather(
             *[
-                _persist_real_returns(
-                    c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates)
-                )
+                _persist_real_returns(c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates))
                 for c in candidates
                 if c.has_real_rigor and c.return_series and c.candidate_id in strategy_ids
             ]

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -300,14 +300,15 @@ async def evaluate_rigor_gate(
         }
         pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
 
-        # num_trials = library size here (#770). This route grades the EXISTING persisted
-        # library, so the selection set is the library itself — there is no fresh
-        # N-candidate society pool to add (that additive correction, N + library_size,
-        # applies only on the live society generation path in generation_pipeline.py).
-        # #820 unified the live and fusion generation paths on that additive count;
-        # this route staying on library-size alone is the deliberate exception, not
-        # a fourth convention that slipped through.
-        num_trials = max(len(valid_returns), 1)
+        # num_trials = 1: each curated strategy is graded on ITS OWN Sharpe, NOT
+        # deflated by how many OTHER strategies sit in the library (Dan's principle,
+        # decouple #2, 2026-07-09). A curated single-paper strategy carries no
+        # generation search of ours, so its self-contained trial count is 1 (the
+        # paper's headline config) — with num_trials=1 the DSR expectation-of-max
+        # term collapses, so the strategy is judged purely on its own return series.
+        # REVERSES the prior library-size deflation (#770/#820) — needs Önder's
+        # sign-off; it raises curated pass rates by removing a cross-strategy penalty.
+        num_trials = 1
 
         # The strategy library is the multiple-testing selection set; correlated
         # strategies (overlapping assets/signals) carry fewer independent trials, so

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2109,6 +2109,11 @@ async def _run_fusion_job(job_id: str) -> None:
                 # audit having passed (audit 06-14, Q6).
                 "look_ahead_label": r.look_ahead_label,
                 "num_trials": int(r.num_trials),
+                # Methodology marker (#1075): this verdict was computed under the
+                # self-contained num_trials convention (decouple #2). Blobs
+                # WITHOUT this key predate the change (formula A, N+library_size)
+                # and are not directly comparable.
+                "num_trials_convention": "self_contained_v2",
                 # Backtest metrics — surface alongside so the passport renders
                 # without the UI having to denormalize from a separate field.
                 "sharpe_ratio": bt.sharpe_ratio,

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -221,12 +221,12 @@ def _live_verdict_for_one(s: Strategy) -> RigorGateVerdict:
 
     Used by the single-strategy fetch path (``get_strategy``). Delegates to
     ``verdicts_for_strategies`` over the FULL library so the verdict is computed
-    with the library-wide cohort context — num_trials = library size, cohort PBO,
-    avg correlation (#902). The old per-strategy path ran ``num_trials=1``, which
-    zeroes the DSR multiple-testing deflation and let the detail view disagree
-    with the (properly deflated) list badge for the same strategy. No real
-    returns → ``pending``, never a fixture value. Never raises: any failure
-    degrades to ``pending`` (fail-closed badge).
+    with the same cohort PBO + avg correlation context the list badge uses,
+    keeping the detail view consistent with the list. ``num_trials`` is
+    self-contained (1 per strategy, decouple #2) — it does NOT come from the
+    library size; only PBO/avg_correlation are cohort-derived. No real returns
+    → ``pending``, never a fixture value. Never raises: any failure degrades to
+    ``pending`` (fail-closed badge).
     """
     try:
         cohort = _library_cohort_including(s)
@@ -237,11 +237,12 @@ def _live_verdict_for_one(s: Strategy) -> RigorGateVerdict:
 
 
 def _library_cohort_including(s: Strategy) -> list[Strategy]:
-    """The full library selection set, guaranteed to contain ``s``.
+    """The full library cohort, guaranteed to contain ``s``.
 
-    The library IS the multiple-testing cohort for a single-strategy grade
-    (#902); ``s`` is appended only if the provider list somehow misses it
-    (e.g. a just-generated strategy not yet listed).
+    This cohort feeds cohort-scoped PBO + avg_correlation ONLY — it must NOT
+    drive ``num_trials`` (self-contained at 1 per strategy, decouple #2). ``s``
+    is appended only if the provider list somehow misses it (e.g. a
+    just-generated strategy not yet listed).
     """
     try:
         cohort = list(strategy_provider().list_strategies())
@@ -263,13 +264,12 @@ def _live_rigor_result_for_one(s: Strategy) -> RigorGateResult | None:
     ``bt.dsr_p_value`` fixture fields — otherwise the leaderboard can show
     numbers that disagree with what ``GET /api/selection-bias/gate`` computes
     for the same strategy right now. Delegates to
-    ``_live_rigor_results_for_strategies`` over the FULL library (#902) so the
-    single fetch carries the same cohort context (num_trials = library size,
-    cohort PBO, avg correlation) as the list — the old per-strategy path ran
-    ``num_trials=1``, zeroing the DSR multiple-testing deflation. Returns
-    ``None`` on no/insufficient persisted returns or any failure — the caller
-    must fall back to the stale fixture fields rather than fabricate a number,
-    matching the fail-closed badge contract.
+    ``_live_rigor_results_for_strategies`` over the FULL library so the single
+    fetch carries the same cohort PBO + avg correlation context as the list.
+    ``num_trials`` is self-contained (1, decouple #2) — it does NOT come from
+    the library size. Returns ``None`` on no/insufficient persisted returns or
+    any failure — the caller must fall back to the stale fixture fields rather
+    than fabricate a number, matching the fail-closed badge contract.
     """
     try:
         cohort = _library_cohort_including(s)
@@ -288,13 +288,15 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
     ``GET /api/selection-bias/gate`` computes for the same strategy right now
     (not the stale ``s.dsr_p_value``/``bt.dsr_p_value`` fixture fields), so this
     mirrors that route's cohort context exactly: real persisted returns from
-    the DB, zero-variance series excluded before they can inflate num_trials or
-    dilute avg_correlation (same fix as #868's selection_bias_routes.py change),
-    cohort PBO + avg-correlation over the survivors, one ``run_rigor_gate`` call
-    per strategy. Strategies with no/insufficient persisted returns or a
-    degenerate series are simply absent from the returned dict — the caller
-    falls back to the stale fixture fields for those ids (fail-closed: no
-    fabricated number for a strategy the live gate cannot evaluate).
+    the DB, zero-variance series excluded before they can dilute avg_correlation
+    (same fix as #868's selection_bias_routes.py change), cohort PBO +
+    avg-correlation over the survivors, one ``run_rigor_gate`` call per
+    strategy. ``num_trials`` is self-contained (1 per strategy, decouple #2) —
+    it is NOT derived from this cohort. Strategies with no/insufficient
+    persisted returns or a degenerate series are simply absent from the
+    returned dict — the caller falls back to the stale fixture fields for
+    those ids (fail-closed: no fabricated number for a strategy the live gate
+    cannot evaluate).
 
     Any DB or cohort-compute failure degrades to ``{}`` (every id falls back to
     the stale fields) rather than raising into the library-list response.
@@ -356,8 +358,8 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
 
         # Exclude zero-variance (degenerate/placeholder-flat) series from the cohort
         # context — same fix as selection_bias_routes.py's valid_returns filter
-        # (#868), so num_trials/avg_correlation/pbo_scores here match that route's
-        # library-wide gate exactly rather than drifting apart on this input.
+        # (#868), so avg_correlation/pbo_scores here match that route's cohort gate
+        # exactly rather than drifting apart on this input.
         valid_returns = {
             k: v
             for k, v in returns_by_strategy.items()
@@ -366,7 +368,10 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
 
         try:
             pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
-            num_trials = max(len(valid_returns), 1)
+            # num_trials = 1: each strategy is graded on ITS OWN Sharpe, never
+            # deflated by how many OTHER strategies sit in the library (decouple
+            # #2). PBO/avg_correlation stay cohort-wide (out of scope here).
+            num_trials = 1
             avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
         except Exception as exc:
             logger.warning("live rigor result batch: cohort-context compute failed (all → stale fallback): %s", exc)
@@ -385,8 +390,9 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
             if len(daily_returns) < 10:
                 continue  # No sufficient returns — caller falls back to stale fields
             if s.id in valid_returns:
-                # Non-degenerate series: run with the full cohort context so
-                # num_trials / pbo_scores / avg_correlation match the library gate.
+                # Non-degenerate series: num_trials is self-contained (1, decouple
+                # #2); pbo_scores / avg_correlation still come from the cohort so
+                # they match the library gate.
                 gate_kwargs: dict = {
                     "num_trials": num_trials,
                     "pbo_scores": pbo_scores,
@@ -394,9 +400,10 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
                 }
             else:
                 # Degenerate (zero-variance) series: excluded from cohort context to
-                # prevent inflating num_trials or diluting avg_correlation (#868), but
-                # the strategy still runs its own gate so the caller gets a live "fail"
-                # verdict rather than falling back to a stale fixture value.
+                # prevent diluting avg_correlation (#868); num_trials is self-contained
+                # (1) either way, but the strategy still runs its own gate so the
+                # caller gets a live "fail" verdict rather than falling back to a
+                # stale fixture value.
                 gate_kwargs = {"num_trials": 1, "pbo_scores": {}, "average_correlation": 0.0}
             try:
                 computed[s.id] = run_rigor_gate(
@@ -2059,19 +2066,20 @@ async def _run_fusion_job(job_id: str) -> None:
                 from archimedes.agents.generation_pipeline import _society_num_trials
                 from archimedes.services.fusion_evaluator import evaluate_fusion_spec
                 from archimedes.services.fusion_market_data import real_data_enabled
-                from archimedes.services.strategy_provider import default_provider
 
-                # #820: same deflation denominator as the society/live paths —
-                # library + pool (pool=1 here: a single direct-fusion candidate).
-                # Without this, evaluate_fusion_spec falls back to its
-                # library-size-only default and this route under-deflates
-                # relative to every other generation path.
-                library_size = len(default_provider().list_strategies())
+                # Decouple #2: num_trials = the strategy's OWN selection pool, NOT
+                # the curated library's count. A single direct-fusion job proposes
+                # exactly one candidate spec (pool=1) — no N-candidate search
+                # happens on this route — so the self-contained trial count is
+                # _society_num_trials(1) == 1. Passed explicitly (not left as
+                # None) so this route's deflation matches the same formula the
+                # society/live generation paths use, without reaching for the
+                # library size the way the old ``library_size + pool`` term did.
                 eval_result = await asyncio.to_thread(
                     evaluate_fusion_spec,
                     result.strategy_spec,
                     use_real_data=real_data_enabled(),
-                    num_trials=_society_num_trials(library_size, 1),
+                    num_trials=_society_num_trials(1),
                 )
             except Exception as _eval_exc:
                 import logging as _logging

--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -774,7 +774,7 @@ def evaluate_fusion_spec(
     """Full pipeline: validate → interpret → backtest → rigor gate.
 
     ``num_trials=None`` (the default) defers to ``apply_rigor_gate``'s own
-    fallback (the curated library size) — see ``_default_num_trials``.
+    self-contained fallback of ``1`` (decouple #2) — see ``_default_num_trials``.
 
     ``use_real_data=True`` (the live generate/debate paths) fetches real daily
     OHLCV for the spec's asset universe via ``fusion_market_data`` and runs the

--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -594,19 +594,16 @@ def run_dsl_backtest_portfolio_variants(
 
 
 def _default_num_trials() -> int:
-    """Fallback selection-set size: the curated strategy library's count.
+    """Self-contained default selection-set size = 1 (decouple #2, Dan's principle).
 
-    Mirrors the pattern in ``generation_pipeline.run_generation`` — a lazy
-    import (avoids a module-load-time dependency on the DB-backed provider)
-    inside a try/except, with a safe ``1`` fallback if the provider is
-    unavailable (e.g. in a hermetic unit test with no DB).
+    A strategy's rigor depends ONLY on itself, never on the curated library's count.
+    With no explicit caller-supplied selection count, a single fusion-generated
+    strategy is one trial — NOT the library size (the prior behavior). Its own
+    parameter-variant grid, when present, is layered on separately in
+    ``apply_rigor_gate`` (the ``max(num_trials, len(variants))`` below), which is
+    genuinely part of the strategy's own selection process.
     """
-    try:
-        from archimedes.services.strategy_provider import default_provider
-
-        return max(1, len(default_provider().list_strategies()))
-    except Exception:
-        return 1
+    return 1
 
 
 def apply_rigor_gate(
@@ -626,10 +623,10 @@ def apply_rigor_gate(
     When ``variants_metrics`` is provided with >= 2 entries, real CSCV PBO
     is computed from the variant returns matrix and attached to the verdict.
 
-    ``num_trials``, when ``None`` (the default), falls back to the curated
-    strategy library's size via ``_default_num_trials()`` — the real
-    multiple-testing selection set a fusion-generated strategy is being
-    compared against, rather than an arbitrary placeholder (audit 06-14, Q4).
+    ``num_trials``, when ``None`` (the default), falls back to a self-contained
+    ``1`` via ``_default_num_trials()`` — a strategy is graded on its own selection
+    set, never deflated by the curated library's count (decouple #2). The caller
+    passes an explicit count when the strategy came from a real N-candidate pool.
     """
     if num_trials is None:
         num_trials = _default_num_trials()

--- a/backend/archimedes/services/live_rigor_gate.py
+++ b/backend/archimedes/services/live_rigor_gate.py
@@ -42,39 +42,19 @@ PASS = "pass"
 FAIL = "fail"
 PENDING = "pending"
 
-# Fail-safe selection-set size when the true library trial count cannot be
-# derived (#902). Deflating with too many trials errs toward rejecting a
-# strategy; deflating with num_trials=1 errs toward an UNDEFLATED pass — the
-# exact failure mode #902 flags. So when the DB/provider is unreachable the
-# default leans conservative (the seeded v1 library size), never 1.
-_FALLBACK_NUM_TRIALS = 5
-
 
 def _default_num_trials() -> int:
-    """Library-wide selection-set size for DSR deflation (#902).
+    """Self-contained default selection-set size = 1 (decouple #2, Dan's principle).
 
-    The multiple-testing set for a library strategy is the library itself —
-    the number of strategies with enough persisted real returns to grade
-    (same valid-set definition as ``verdicts_for_strategies``). Callers that
-    already hold cohort context pass ``num_trials`` explicitly; this default
-    exists so the single-verdict path can never silently run undeflated
-    (``num_trials=1`` collapses DSR to plain Sharpe > 0). Fail-safe to
-    ``_FALLBACK_NUM_TRIALS`` — more deflation, never less — on any failure.
+    A strategy's rigor depends ONLY on itself, never on how many OTHER strategies
+    happen to sit in the curated library. With no explicit caller-supplied trial
+    count, a single strategy's own selection set is one trial — NOT the library
+    size (the prior #902 behavior, which deflated every strategy by the count of
+    strategies with enough persisted returns to grade). Callers holding real
+    cohort context of their OWN (e.g. a strategy's own N-candidate generation
+    pool, or its own parameter-variant grid) still pass ``num_trials`` explicitly.
     """
-    try:
-        from archimedes.db import get_session, init_db
-        from archimedes.services.backtest_repository import get_all_daily_returns
-        from archimedes.services.strategy_provider import default_provider
-
-        strategy_ids = [s.id for s in default_provider().list_strategies()]
-        init_db()
-        with get_session() as session:
-            returns_by_strategy = get_all_daily_returns(session, strategy_ids)
-        n = sum(1 for v in returns_by_strategy.values() if len(v) >= _MIN_RETURNS_FOR_GATE)
-        return max(n, 1)
-    except Exception as exc:
-        logger.warning("default num_trials derivation failed (fallback=%d): %s", _FALLBACK_NUM_TRIALS, exc)
-        return _FALLBACK_NUM_TRIALS
+    return 1
 
 
 @dataclass(frozen=True)
@@ -153,11 +133,12 @@ def verdict_from_returns(
     unexpected failure inside the gate fails closed to ``pending`` so the badge can
     never claim a pass it did not earn.
 
-    ``num_trials=None`` (the default) derives the library-wide selection-set size
-    (#902) — the old ``num_trials=1`` default zeroed the multiple-testing penalty
-    (``E_max_N=0``) and collapsed DSR to a plain Sharpe test, so an unspecified
-    trial count silently ran the badge undeflated. Callers holding cohort context
-    (``verdicts_for_strategies``, the generation pipeline) still pass it explicitly.
+    ``num_trials=None`` (the default) derives a self-contained ``1`` via
+    ``_default_num_trials()`` — a strategy is graded on its own selection set,
+    never deflated by the curated library's count (decouple #2, reverses the
+    #902 library-wide-count default). Callers holding a real selection-set of
+    their OWN (a strategy's own N-candidate generation pool, or its own
+    parameter-variant grid) still pass ``num_trials`` explicitly.
 
     ``look_ahead_audit_passed=None`` (the default) leaves the look-ahead leg to
     ``run_rigor_gate``'s own AST-audit-over-``strategy_code`` path — the right
@@ -216,8 +197,9 @@ def verdicts_for_strategies(strategies: list) -> dict[str, RigorGateVerdict]:
     Single source of truth for the library-list badge (#821). Mirrors the
     ``/api/selection-bias/gate`` route's data path:
       * load real daily returns from the DB (``get_all_daily_returns``);
-      * compute the library-wide ``num_trials`` + cohort PBO + avg-correlation from
-        the strategies that actually HAVE returns (≥10 obs);
+      * compute cohort PBO + avg-correlation from the strategies that actually
+        HAVE returns (≥10 obs) — ``num_trials`` is self-contained (1 per
+        strategy, decouple #2) and does NOT come from this cohort;
       * run ``run_rigor_gate`` per strategy and map ``passes_all`` to a tri-state.
 
     Strategies with no real returns map to ``pending`` — never a fixture boolean.
@@ -249,13 +231,17 @@ def verdicts_for_strategies(strategies: list) -> dict[str, RigorGateVerdict]:
     # (that is the circular validation the /gate route explicitly refuses).
     valid_returns = {k: v for k, v in returns_by_strategy.items() if len(v) >= _MIN_RETURNS_FOR_GATE}
 
-    # The library is the multiple-testing selection set (mirrors selection_bias_routes).
-    # Wrap the cohort-context compute in the same fail-closed contract the docstring
-    # promises: if compute_pbo / compute_average_pairwise_correlation raises, degrade
-    # the whole batch to pending rather than 500-ing the library list.
+    # num_trials = 1: each strategy is graded on ITS OWN Sharpe, NOT deflated by
+    # how many OTHER strategies sit in the library (Dan's principle, decouple #2,
+    # mirrors selection_bias_routes.evaluate_rigor_gate). PBO and avg_correlation
+    # stay cohort-wide (unchanged, out of scope for this decouple) — only
+    # num_trials is self-contained. Wrap the cohort-context compute in the same
+    # fail-closed contract the docstring promises: if compute_pbo /
+    # compute_average_pairwise_correlation raises, degrade the whole batch to
+    # pending rather than 500-ing the library list.
     try:
         pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
-        num_trials = max(len(valid_returns), 1)
+        num_trials = 1
         avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
     except Exception as exc:
         logger.warning("live rigor gate batch: cohort-context compute failed (all → pending): %s", exc)

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -362,8 +362,10 @@ def backtest_portfolio(
         rebalance_days: Periodic rebalance interval in trading days.
         initial_cash: Starting equity.
         tx_cost_bps: Round-trip cost in basis points (10 = 0.10%, matches default).
-        num_trials_for_dsr: Multiple-testing correction; pass library size for
-            meaningful DSR. Default 1 = no correction (passport's own row).
+        num_trials_for_dsr: Multiple-testing correction; pass the strategy's OWN
+            selection-set size (e.g. its N-candidate generation pool) for a
+            meaningful DSR — never the curated library's count (decouple #2).
+            Default 1 = no correction (a self-contained, single-trial grade).
         paper_claimed_sharpe: If set, recorded for paper-vs-actual delta display.
         paper_title: Optional human-readable title for the artifact metadata.
 

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -815,13 +815,20 @@ def run_rigor_gate(
             explicitly if that path should ever gate on the floor too.
     """
     if num_trials == 1:
-        # Loud on purpose (#902): num_trials=1 zeroes E[max SR] and collapses DSR
-        # to a plain "Sharpe > 0" test — the exact silent-undeflation failure mode
-        # that made the badge weaker than claimed. Legitimate only for a genuinely
-        # single-trial context, never for grading a library member.
+        # Loud on purpose (#902, reworded for decouple #2): num_trials=1 zeroes
+        # E[max SR] and collapses DSR to a plain "Sharpe > 0" test. This is the
+        # CORRECT, expected value for a strategy graded on its own self-contained
+        # selection set (a curated single-paper strategy, or a strategy with no
+        # real N-candidate search behind it) — a strategy's rigor depends ONLY on
+        # itself, never on the count of other strategies in the library (Dan's
+        # principle). The warning stays as a diagnostic breadcrumb: if a caller
+        # meant to pass the strategy's OWN selection-pool size (its N generated
+        # candidates or parameter-variant grid) and forgot, this line is the tell.
         logger.warning(
             "Rigor gate [%s]: num_trials=1 — DSR runs UNDEFLATED (no multiple-testing correction). "
-            "Pass num_trials=len(strategy_library) for a meaningful deflated verdict.",
+            "Correct for a self-contained strategy; if this strategy has its own real selection "
+            "set (an N-candidate generation pool or parameter-variant grid), pass that count "
+            "explicitly instead — never the curated library's size.",
             strategy_id,
         )
 

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -815,16 +815,15 @@ def run_rigor_gate(
             explicitly if that path should ever gate on the floor too.
     """
     if num_trials == 1:
-        # Loud on purpose (#902, reworded for decouple #2): num_trials=1 zeroes
-        # E[max SR] and collapses DSR to a plain "Sharpe > 0" test. This is the
-        # CORRECT, expected value for a strategy graded on its own self-contained
-        # selection set (a curated single-paper strategy, or a strategy with no
-        # real N-candidate search behind it) — a strategy's rigor depends ONLY on
-        # itself, never on the count of other strategies in the library (Dan's
-        # principle). The warning stays as a diagnostic breadcrumb: if a caller
-        # meant to pass the strategy's OWN selection-pool size (its N generated
-        # candidates or parameter-variant grid) and forgot, this line is the tell.
-        logger.warning(
+        # Debug-level breadcrumb (#902; demoted from WARNING in the #1075
+        # review): num_trials=1 zeroes E[max SR] and collapses DSR to a plain
+        # "Sharpe > 0" test. Pre-decouple that was anomalous and deserved a
+        # loud line; post-decouple-#2 it is the DOCUMENTED DEFAULT for every
+        # curated serving call (list/detail/gate), so at WARNING it would spam
+        # the hot path with non-actionable noise. Kept at debug as the tell
+        # for the one real misuse: a caller with an N-candidate pool or
+        # variant grid that forgot to pass its own count.
+        logger.debug(
             "Rigor gate [%s]: num_trials=1 — DSR runs UNDEFLATED (no multiple-testing correction). "
             "Correct for a self-contained strategy; if this strategy has its own real selection "
             "set (an N-candidate generation pool or parameter-variant grid), pass that count "

--- a/backend/archimedes/services/rigor_profiles.py
+++ b/backend/archimedes/services/rigor_profiles.py
@@ -67,11 +67,16 @@ class RigorProfile:
 # Level-1 dsr_p_min = 0.90 is INTENTIONAL (recalibrated 0.95 → 0.90 in PR #901,
 # team-sanctioned), with an explicit risk caveat (#902): 0.90 is a one-sided
 # ~10% test — real but not overwhelming evidence, and materially weaker than a
-# conventional 0.95 bar. It was chosen so the badge stays achievable at the
-# current library size, where the multiple-testing deflation (num_trials =
-# library N) already stiffens the p-value; anyone marketing the badge should
-# say "deflated-Sharpe evidence at the 0.90 level", not "statistically proven".
-# Revisit toward 0.95 as the library and return histories grow.
+# conventional 0.95 bar. This threshold VALUE is unchanged by decouple #2 (a
+# rigor floor, never loosened here) — but its original rationale ("achievable
+# at the library-size deflation, num_trials = library N") is now stale: a
+# strategy's num_trials is self-contained (decouple #2, Dan's principle — 1
+# for curated/single-candidate strategies, its own N for a real generation
+# pool), so the badge is often LESS deflated than when this bar was picked.
+# Anyone marketing the badge should say "deflated-Sharpe evidence at the 0.90
+# level", not "statistically proven". Revisit toward 0.95 as return histories
+# grow — needs Önder's re-derivation now that the deflation denominator has
+# changed.
 _PROFILES: dict[int, RigorProfile] = {
     1: RigorProfile(
         1,

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -989,7 +989,8 @@ async def test_debate_critic_rigor_num_trials_matches_society_formula(tmp_path, 
 
     monkeypatch.setattr(gp, "_validate_brief", _pv)
 
-    # Fixed library_size so _society_num_trials(library, pool) is computable.
+    # library_size only sizes the fake provider's list — decouple #2 means it must
+    # NOT affect num_trials (which is the strategy's own pool_size).
     library_size = 4
 
     class _FakeStrategy:
@@ -1049,7 +1050,7 @@ async def test_debate_critic_rigor_num_trials_matches_society_formula(tmp_path, 
     )
 
     assert captured_num_trials, "evaluate_fusion_spec was never called — debate C-rigor did not run"
-    expected = gp._society_num_trials(library_size, pool_size)
+    expected = gp._society_num_trials(pool_size)  # own pool only — NOT library+pool
     assert all(n == expected for n in captured_num_trials), (
         f"debate num_trials {captured_num_trials} != formula {expected} "
         f"(library_size={library_size}, pool_size={pool_size})"

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -932,17 +932,16 @@ class TestFusionEvaluatorIntegration:
         _no_redis_job_store,
         _no_redis_agent_state,
     ):
-        """#820: the direct-fusion job route must deflate for the SAME selection
-        set as the society/live paths — ``_society_num_trials(library, pool=1)``
-        — not ``evaluate_fusion_spec``'s library-size-only default. The spy
-        captures the kwarg then raises; the job's non-fatal eval path tolerates
-        that, so no FusionEvalResult needs fabricating."""
+        """Decouple #2: the direct-fusion job route must deflate for the SAME
+        selection set as the society/live paths — ``_society_num_trials(pool=1)``,
+        the strategy's OWN pool, NOT the library size. The spy captures the kwarg
+        then raises; the job's non-fatal eval path tolerates that, so no
+        FusionEvalResult needs fabricating."""
         from archimedes.agents.generation_pipeline import _society_num_trials
         from archimedes.agents.strategy_fusion import FusionBrief, FusionProposal
         from archimedes.api.strategies_routes import _run_fusion_job
         from archimedes.models.portfolio import RiskProfile
         from archimedes.services.strategy_dsl import FABER_2007_SPEC
-        from archimedes.services.strategy_provider import default_provider
 
         mock_proposal = FusionProposal(
             status="ok",
@@ -970,7 +969,7 @@ class TestFusionEvaluatorIntegration:
             captured["num_trials"] = num_trials
             raise RuntimeError("spy: captured num_trials; eval is non-fatal")
 
-        expected = _society_num_trials(len(default_provider().list_strategies()), 1)
+        expected = _society_num_trials(1)  # own pool of 1, library-independent
 
         job_id = "test-job-num-trials"
         self._seed_job(

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -80,40 +80,47 @@ class TestDeployableSignal:
 
 
 class TestSocietyNumTrialsFormula:
-    def test_is_n_plus_library(self):
-        # Approach A: N candidates + library context.
-        assert _society_num_trials(library_size=4, selection_pool_size=20) == 24
-        assert _society_num_trials(library_size=10, selection_pool_size=10) == 20
+    # Decouple #2 (2026-07-09): num_trials is the strategy's OWN candidate pool (N),
+    # NOT N + library_size — a strategy's rigor depends only on itself, never on how
+    # many other strategies sit in the library.
+    def test_is_own_pool_only(self):
+        assert _society_num_trials(20) == 20
+        assert _society_num_trials(10) == 10
 
-    def test_single_candidate_adds_one(self):
-        # N=1 (one generated candidate) is still a real trial on top of the library.
-        assert _society_num_trials(library_size=4, selection_pool_size=1) == 5
+    def test_single_candidate_is_one(self):
+        # N=1 (one generated candidate) is a single-trial grade — no library term added.
+        assert _society_num_trials(1) == 1
 
     def test_floored_at_one(self):
-        assert _society_num_trials(library_size=0, selection_pool_size=0) == 1
+        assert _society_num_trials(0) == 1
+
+    def test_independent_of_library_size(self):
+        # The whole point: growing the library must NOT change a strategy's num_trials.
+        assert _society_num_trials(20) == _society_num_trials(20)
 
 
 class TestNumTrialsCorrection:
-    # A seeded series with a real positive edge whose DSR p-value brackets the 0.95 gate
-    # between library-only (4) and society (library+N = 4+20 = 24). OOS is identical at
-    # both counts, so the ONLY thing that flips the verdict is the num_trials deflation.
+    # A seeded series with a real positive edge whose DSR p-value brackets the gate
+    # between a single-trial grade (num_trials=1) and a best-of-N pool (N=20). OOS is
+    # identical at both counts, so the ONLY thing that flips the verdict is the
+    # pool-based num_trials deflation — the honest selection-bias correction.
     _MU, _SD, _N, _SEED = 0.0009, 0.009, 300, 4
 
     def _series(self):
         return list(np.random.default_rng(self._SEED).normal(self._MU, self._SD, self._N))
 
     def test_num_trials_overfit_survivor_fails_society_path(self):
-        """A best-of-N survivor that passes the library-only count FAILS once the society
-        correction (N + library_size) deflates it — the exact selection bias #770 closes."""
+        """A best-of-N survivor that passes as a single trial FAILS once the strategy's
+        OWN pool (N=20) deflates it — the selection bias, measured on the strategy itself."""
         series = self._series()
-        library_only = _rigor_verdict_for(series, num_trials=4, lookahead_passed=True)
-        society = _rigor_verdict_for(series, num_trials=_society_num_trials(4, 20), lookahead_passed=True)
+        single_trial = _rigor_verdict_for(series, num_trials=1, lookahead_passed=True)
+        society = _rigor_verdict_for(series, num_trials=_society_num_trials(20), lookahead_passed=True)
 
-        assert library_only["passing"] is True, "fixture must pass under the (wrong) library-only count"
-        assert society["passing"] is False, "society N+library correction must reject the inflated survivor"
+        assert single_trial["passing"] is True, "fixture must pass as a single self-contained trial"
+        assert society["passing"] is False, "best-of-N pool deflation must reject the inflated survivor"
         # The flip is the DSR deflation, not OOS: OOS Sharpe is identical at both counts.
-        assert library_only["oos_sharpe"] == society["oos_sharpe"]
-        assert society["dsr_p_value"] < library_only["dsr_p_value"]
+        assert single_trial["oos_sharpe"] == society["oos_sharpe"]
+        assert society["dsr_p_value"] < single_trial["dsr_p_value"]
 
     def test_dsr_pvalue_monotonic_stricter_in_trials(self):
         """More trials can only deflate harder — the property the additive count relies on."""

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -17,6 +17,7 @@ are typically correlated — ρ̄=0 over-deflates and over-states the gate's str
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from archimedes.agents.generation_pipeline import (
     _CandidateResult,
     _is_deployable,
@@ -95,8 +96,16 @@ class TestSocietyNumTrialsFormula:
         assert _society_num_trials(0) == 1
 
     def test_independent_of_library_size(self):
-        # The whole point: growing the library must NOT change a strategy's num_trials.
-        assert _society_num_trials(20) == _society_num_trials(20)
+        # The whole point: growing the library must NOT change a strategy's
+        # num_trials. Pin it structurally — the function must not even ACCEPT
+        # a second (library_size) argument, so a refactor can't quietly
+        # reintroduce the coupling. (Review follow-up: the previous assertion
+        # compared the call to itself, which could never fail.)
+        import inspect
+
+        assert len(inspect.signature(_society_num_trials).parameters) == 1
+        with pytest.raises(TypeError):
+            _society_num_trials(20, 34)  # the old (N, library_size) shape must be rejected
 
 
 class TestNumTrialsCorrection:

--- a/backend/tests/test_rigor_cache.py
+++ b/backend/tests/test_rigor_cache.py
@@ -116,10 +116,11 @@ def _expected_result(sid: str, returns_by_strategy: dict[str, list[float]]):
     """Independently reproduce what the (uncached) live gate should compute for
     ``sid`` given ``returns_by_strategy`` — the same cohort-context derivation
     ``_live_rigor_results_for_strategies`` performs, used to assert the cache
-    never changes the served numbers."""
+    never changes the served numbers. num_trials is self-contained (1, decouple
+    #2) — it does NOT come from this cohort; only PBO/avg_correlation do."""
     valid = {k: v for k, v in returns_by_strategy.items() if len(v) >= 10 and float(np.ptp(np.asarray(v))) > 0.0}
     pbo_scores = compute_pbo(valid) if len(valid) >= 2 else {}
-    num_trials = max(len(valid), 1)
+    num_trials = 1
     avg_corr = compute_average_pairwise_correlation(valid) if len(valid) >= 2 else 0.0
     return run_rigor_gate(
         strategy_id=sid,

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -936,9 +936,13 @@ class TestDegenerateSeriesExcludedFromCohort:
         )
 
     @pytest.mark.asyncio
-    async def test_num_trials_excludes_degenerate_series(self, monkeypatch):
-        """3 real + 2 degenerate (flat) series in the cohort → num_trials == 3,
-        not 5. Before the fix, num_trials counted len(valid_returns) == 5."""
+    async def test_degenerate_series_excluded_from_avg_correlation(self, monkeypatch):
+        """3 real + 2 degenerate (flat) series in the cohort. Post-decouple #2,
+        num_trials is a self-contained 1 (each curated strategy graded on its own
+        Sharpe, never deflated by cohort size), so the degeneracy filter no longer
+        affects num_trials — but it MUST still keep the 2 flat placeholders out of
+        the cohort avg_correlation/PBO context (#868), so avg_correlation stays a
+        finite number computed from only the 3 real series."""
         from archimedes.api import selection_bias_routes as routes
         from archimedes.main import app
         from archimedes.services.rigor_evaluator import run_rigor_gate as real_run_rigor_gate
@@ -969,10 +973,16 @@ class TestDegenerateSeriesExcludedFromCohort:
         assert resp.status_code == 200
         assert captured_kwargs, "run_rigor_gate was never called"
 
-        # Every call in this run shares the same library-wide num_trials context.
+        # Decouple #2: num_trials is a self-contained 1 for every curated strategy,
+        # independent of cohort size (degenerate or not).
         num_trials_seen = {kwargs["num_trials"] for kwargs in captured_kwargs}
-        assert num_trials_seen == {3}, (
-            f"num_trials should count only the 3 non-degenerate series, got {num_trials_seen}"
+        assert num_trials_seen == {1}, f"curated num_trials must be self-contained 1, got {num_trials_seen}"
+
+        # The #868 protection that REMAINS meaningful: the 2 flat placeholders must
+        # not corrupt the cohort avg_correlation (computed from the 3 real series).
+        avg_corr_seen = {kwargs["average_correlation"] for kwargs in captured_kwargs}
+        assert all(np.isfinite(c) for c in avg_corr_seen), (
+            f"avg_correlation must be finite (degenerate series excluded), got {avg_corr_seen}"
         )
 
     @pytest.mark.asyncio

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -123,11 +123,13 @@ class TestVerdictFromReturns:
 
 
 class TestDefaultNumTrials:
-    """#902: an unspecified num_trials must never silently run undeflated."""
+    """Decouple #2: an unspecified num_trials defaults to a self-contained 1 —
+    never derived from the curated library's count."""
 
-    def test_default_num_trials_derives_library_size(self, monkeypatch):
-        # The default resolves to the count of library strategies with enough
-        # persisted returns — NOT 1 (which zeroes the DSR deflation).
+    def test_verdict_from_returns_defers_to_default_num_trials(self, monkeypatch):
+        # verdict_from_returns still delegates to _default_num_trials() when the
+        # caller passes nothing — this pins the indirection, independent of what
+        # _default_num_trials() itself resolves to.
         from archimedes.services import live_rigor_gate
 
         captured = {}
@@ -142,17 +144,18 @@ class TestDefaultNumTrials:
         verdict_from_returns("a", _passing_series(0), strategy_code=_CLEAN_CODE)
         assert captured["num_trials"] == 7
 
-    def test_default_num_trials_fail_safe_is_not_one(self, monkeypatch):
-        # When the library size cannot be derived, the fallback must lean toward
-        # MORE deflation (a conservative floor), never num_trials=1.
+    def test_default_num_trials_is_self_contained_one(self, monkeypatch):
+        # A strategy's rigor depends ONLY on itself — _default_num_trials() must
+        # always resolve to 1, regardless of the curated library's size or
+        # whether the strategy provider is even reachable (decouple #2 removed
+        # the library-size lookup entirely, so this must not touch it at all).
         from archimedes.services import live_rigor_gate
 
         def _boom():
-            raise RuntimeError("no provider")
+            raise AssertionError("_default_num_trials must not consult the strategy provider")
 
         monkeypatch.setattr("archimedes.services.strategy_provider.default_provider", _boom)
-        assert live_rigor_gate._default_num_trials() == live_rigor_gate._FALLBACK_NUM_TRIALS
-        assert live_rigor_gate._FALLBACK_NUM_TRIALS > 1
+        assert live_rigor_gate._default_num_trials() == 1
 
     def test_explicit_num_trials_still_wins(self, monkeypatch):
         from archimedes.services import live_rigor_gate
@@ -282,16 +285,30 @@ async def test_library_badge_equals_live_gate_verdict_on_persisted_returns(monke
         "archimedes.services.backtest_repository.get_all_daily_returns",
         lambda session, ids: dict(returns),
     )
-    # Make the look-ahead audit deterministic (clean code → pass) for both.
+    # Make the look-ahead audit deterministic (clean code → pass) for both. The
+    # served badge on GET /api/strategies/ comes from _live_rigor_results_for_
+    # strategies (#868), which reads its OWN local loader — patch both loaders
+    # so this test and test_leaderboard_numeric_fields_equal_live_gate_on_
+    # persisted_returns (below) see identical code. Only patching the
+    # live_rigor_gate loader left the served badge reading REAL (uncontrolled)
+    # strategy source, a gap that stayed masked while num_trials=len(cohort)
+    # deflation dominated passes_all; it surfaces now that num_trials=1
+    # (decouple #2) makes DSR pass easily and the look-ahead leg decide.
     monkeypatch.setattr(
         "archimedes.services.live_rigor_gate._load_strategy_code_safe",
         lambda strategy: _CLEAN_CODE,
     )
+    monkeypatch.setattr(
+        "archimedes.api.strategies_routes._load_strategy_code_safe_local",
+        lambda strategy: _CLEAN_CODE,
+    )
 
-    # Independently reproduce the route's library context.
+    # Independently reproduce the route's cohort context. num_trials is
+    # self-contained (1, decouple #2) — it does NOT come from this cohort;
+    # only PBO/avg_correlation are cohort-derived.
     valid = {k: v for k, v in returns.items() if len(v) >= 10}
     pbo_scores = compute_pbo(valid) if len(valid) >= 2 else {}
-    num_trials = max(len(valid), 1)
+    num_trials = 1
     avg_corr = compute_average_pairwise_correlation(valid) if len(valid) >= 2 else 0.0
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -499,11 +516,12 @@ async def test_leaderboard_numeric_fields_equal_live_gate_on_persisted_returns(m
         lambda strategy: _CLEAN_CODE,
     )
 
-    # Independently reproduce the route's library context (same recipe as
+    # Independently reproduce the route's cohort context (same recipe as
     # test_library_badge_equals_live_gate_verdict_on_persisted_returns).
+    # num_trials is self-contained (1, decouple #2), not cohort-derived.
     valid = {k: v for k, v in returns.items() if len(v) >= 10}
     pbo_scores = compute_pbo(valid) if len(valid) >= 2 else {}
-    num_trials = max(len(valid), 1)
+    num_trials = 1
     avg_corr = compute_average_pairwise_correlation(valid) if len(valid) >= 2 else 0.0
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -156,6 +156,40 @@ fresh candidate pool, so that route keeps `num_trials = library_size`.
 > statistics call. This addendum records approach **A** as the shipped default pending his
 > review; promoting to B is a follow-up if candidate-pool over-deflation proves material.
 
+#### Addendum (#1075, 2026-07-14) — decouple #2: num_trials is self-contained — SUPERSEDES the `+ library_size` term above
+
+PR #1075 deliberately reverses formula (A)'s `+ library_size` term. This is the one
+documented exception to #770's "only stricter" anti-goal, reviewed as such — the
+loosening is the point, not a side effect. Owner + statistics sign-off is the merge
+of that PR itself.
+
+```
+num_trials = n_candidates      # society/fusion generation paths (_society_num_trials(N))
+num_trials = 1                 # curated single-methodology serving paths
+```
+
+**Rationale.** Bailey & López de Prado's deflation corrects for the *search that
+produced the reported Sharpe*. The society round genuinely searched `n_candidates`
+variants — that term stays. But a strategy does not become more overfit because the
+shelf it later joins grows: `library_size` is a property of the library, not of the
+trial that produced the strategy. Under formula (A) the *same* strategy's DSR verdict
+changed as unrelated strategies were added — the gate verdict was not a stable
+property of the strategy. Cross-library selection bias ("the shelf displays its best")
+is real but is a *ranking/display* correction belonging to library-level PBO (which is
+unchanged), not a per-strategy admission correction.
+
+**Effect direction.** `num_trials` can only shrink relative to formula (A)
+(`N + library ≥ N ≥ 1`), so deflation strictly weakens and pass rates can rise — an
+acknowledged, reviewed loosening, stated here so nobody reads the old addendum as
+current.
+
+**Methodology versioning.** `rigor_verdict` JSON blobs written after this change carry
+`"num_trials_convention": "self_contained_v2"`. Blobs without the key were computed
+under formula (A) (or the pre-#770 bare library-size convention) and are **not**
+directly comparable to post-change numbers. Whether to backfill/recompute stored
+verdicts or surface the distinction in the UI is an open follow-up (merge-board
+2026-07-14).
+
 #### Addendum (#822) — approach B ships alongside A: real ρ̄ feeds the same `num_trials`
 
 Approach A's additive `num_trials = n_candidates + library_size` stays the trial *count* —

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -147,10 +147,13 @@ first** (smaller blast radius, strictly conservative) and leave the candidate-po
 correlation correction as a follow-up; over-deflation (treating correlated candidates as
 independent) only *tightens* the gate, never loosens it, so the simple form is safe to ship.
 
-**Scope note.** This additive correction applies to the **live society generation path**
-(`agents/generation_pipeline.py`). The `/api/selection-bias/gate` route grades the
-**existing persisted library**, where the selection set is the library itself — there is no
-fresh candidate pool, so that route keeps `num_trials = library_size`.
+**Scope note.** *(Superseded by the #1075 addendum below, including for the gate route:
+`/api/selection-bias/gate` now grades curated strategies at `num_trials = 1`, not
+`library_size` — kept verbatim for history.)* This additive correction applies to the
+**live society generation path** (`agents/generation_pipeline.py`). The
+`/api/selection-bias/gate` route grades the **existing persisted library**, where the
+selection set is the library itself — there is no fresh candidate pool, so that route
+keeps `num_trials = library_size`.
 
 > **Owner sign-off:** the choice of formula (additive A vs. effective-N B) is Önder's
 > statistics call. This addendum records approach **A** as the shipped default pending his


### PR DESCRIPTION
## Principle (Dan, 2026-07-09)
**A strategy's statistical rigor must depend ONLY on that strategy — never on how many other strategies (curated or generated) sit in the library.** Today the DSR multiple-testing `num_trials` keys off the curated library COUNT, so adding/removing a fixture silently changes every other strategy's Deflated Sharpe. This is the exact violation from the decouple+consolidate plan (`docs/CURATED-STRATEGY-DECOUPLE-AND-CONSOLIDATE-2026-07-08.md` Part A #2).

## What changed — `num_trials` is now self-contained everywhere
- **Generated (society/debate) path** → `num_trials` = the strategy's OWN candidate pool `N` (`_society_num_trials(pool)`), dropping the `+ library_size` term. `generation_pipeline.py`, `debate_engine.py`.
- **Curated `/gate` + batch/live paths** → `num_trials = 1` (each curated single-paper strategy graded on its own Sharpe; with `num_trials=1` the DSR expectation-of-max term collapses). `selection_bias_routes.py`, `live_rigor_gate.py` (`_default_num_trials`, `verdicts_for_strategies`), `strategies_routes.py` (`_live_rigor_results_for_strategies`, `_run_fusion_job`).
- **Fusion default** → `fusion_evaluator._default_num_trials()` returns `1` (was library size). A strategy's own parameter-variant grid stays a legitimate self-contained selection layer (the `max(num_trials, len(variants))` logic is untouched).
- Removed dead `_library_size()`; reworded all stale "N + library" / #770/#820 rationale.

## ⚠️ Needs Dan + Önder sign-off before merge
1. **This REVERSES the `N + library_size` convention from #770/#811/#820** — Önder argued the library is a second selection layer. Dan's principle is that it isn't (a strategy's rigor can't change because the library grew).
2. **It raises rigor pass rates** — removing the cross-strategy penalty means more strategies clear the DSR gate. That's the *correct* consequence of the fix, but it's a visible, claim-integrity-adjacent shift, so it should land deliberately, not silently.

## What did NOT change (verified)
- **No rigor FLOOR value moved** (DSR_P_FLOOR, OOS, look-ahead — only stale rationale comments reworded; `dsr_p_min=0.90` untouched, flagged for Önder's re-derivation given the deflation denominator changed).
- **PBO and average_correlation semantics untouched** — they stay cohort-derived; only `num_trials` was decoupled.

## Tests
- Tests that encoded the old `N + library` / library-size math updated to the new self-contained semantics (not weakened).
- Fixed a **real latent test bug** exposed once `num_trials` stopped dominating the verdict (`test_library_badge_equals_live_gate_verdict_on_persisted_returns` was missing a `_load_strategy_code_safe_local` monkeypatch → the look-ahead leg read uncontrolled source).
- ✅ 617 rigor-relevant tests pass; full `-k "not integration"` sweep green (2843); ruff clean. Independently re-verified by the main session.

Part of the curated decouple+consolidate program. Follow-ups (separate PRs): the rebalancer decouple (#1, generated vaults never rebalance), and the 34→~6 consolidation (Part B).