### PR TITLE
[backend] Vault holdings: value unpriceable synths at 0, weight against portfolio sum

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -1017,8 +1017,9 @@ class StrategyRunner:
         for sym in all_symbols:
             if sym in unpriced:
                 logger.warning(
-                    "skipping trade for %s: oracle price unavailable — holding weight is 0 by "
-                    "construction, not truth; refusing to size a trade against it (#1080)",
+                    "vault %s: skipping trade for %s — oracle price unavailable; holding weight "
+                    "is 0 by construction, not truth; refusing to size a trade against it (#1080)",
+                    portfolio.vault_address[:10],
                     sym,
                 )
                 continue

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -1005,10 +1005,23 @@ class StrategyRunner:
         current_weights = portfolio.weights_dict
         target_map = {t.symbol: t for t in targets}
 
+        # Holdings whose oracle price couldn't be read report weight 0 BY
+        # CONSTRUCTION (#1080) — the balance is real, the value is unknown.
+        # Trading on that fake 0 would buy more of an unpriceable asset every
+        # tick (current 0 vs target >0, forever) or size a blind sell. Skip.
+        unpriced = {h.symbol for h in portfolio.holdings if not getattr(h, "priced", True)}
+
         trades: list[TradeOrder] = []
         all_symbols = set(target_map.keys()) | set(current_weights.keys())
 
         for sym in all_symbols:
+            if sym in unpriced:
+                logger.warning(
+                    "skipping trade for %s: oracle price unavailable — holding weight is 0 by "
+                    "construction, not truth; refusing to size a trade against it (#1080)",
+                    sym,
+                )
+                continue
             current_w = current_weights.get(sym, 0.0)
             target = target_map.get(sym)
             target_w = target.weight if target else 0.0

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -113,8 +113,11 @@ class ChainExecutor:
         # Read total assets — fall back to off-chain NAV if stale price
         total_assets = await self._safe_total_assets(vault, token_addresses, amounts)
 
-        # Build portfolio
-        holdings: list[PortfolioHolding] = []
+        # Value every holding first, then weight against the sum of holding
+        # values. Weighting against totalAssets() breaks when the on-chain NAV
+        # excludes tokens (e.g. an unwired oracle values a synth at 0 in the
+        # contract): USDC alone reads 100% and weights can't sum to 100 (#1080).
+        priced: list[tuple[str, str, int, int, int]] = []
         for i in range(len(token_addresses)):
             token_addr = token_addresses[i]
             amount = amounts[i]
@@ -128,17 +131,21 @@ class ChainExecutor:
 
             # Calculate USDC value
             value_usdc = await self._token_to_usdc(token_addr, amount, decimals, total_assets > 0)
-            weight = value_usdc / total_assets if total_assets > 0 else 0.0
+            priced.append((symbol, token_addr, amount, decimals, value_usdc))
 
-            holdings.append(
-                PortfolioHolding(
-                    symbol=symbol,
-                    token_address=token_addr,
-                    amount=amount / 10**decimals if decimals else float(amount),
-                    value_usdc=value_usdc / 1e6,  # USDC has 6 decimals
-                    weight=weight,
-                )
+        portfolio_value = sum(value for *_, value in priced)
+        denominator = portfolio_value if portfolio_value > 0 else total_assets
+
+        holdings = [
+            PortfolioHolding(
+                symbol=symbol,
+                token_address=token_addr,
+                amount=amount / 10**decimals if decimals else float(amount),
+                value_usdc=value_usdc / 1e6,  # USDC has 6 decimals
+                weight=value_usdc / denominator if denominator > 0 else 0.0,
             )
+            for symbol, token_addr, amount, decimals, value_usdc in priced
+        ]
 
         return Portfolio(
             vault_address=vault_address,
@@ -954,6 +961,10 @@ class ChainExecutor:
 
         If use_raw_price is True (stale oracle fallback), uses the raw price()
         getter which doesn't check staleness.
+
+        Returns 0 (with a warning) when no price can be read — never the raw
+        base-unit amount: callers treat the result as 6-decimal USDC, so an
+        18-decimal raw amount inflates the value 10**12x (#1080).
         """
         if token_address.lower() == chain_client.settings.usdc_address.lower():
             return amount
@@ -961,20 +972,25 @@ class ChainExecutor:
         # For synth tokens, use the oracle price
         for sym, addr in chain_client.settings.synth_addresses.items():
             if addr and addr.lower() == token_address.lower():
-                try:
-                    oracle = self.loader.oracle_for(sym)
-                    if use_raw_price:
-                        # Use raw price getter (no staleness check) as fallback
-                        price = await oracle.functions.price().call()
-                    else:
+                if not use_raw_price:
+                    try:
+                        oracle = self.loader.oracle_for(sym)
                         price = await oracle.functions.getPrice().call()
-                    # USDC value = amount (18 dec) * price (6 dec) / 1e18
+                        # USDC value = amount (10**decimals base units) * price (6 dec)
+                        return (amount * price) // (10**decimals)
+                    except Exception:
+                        logger.warning("getPrice() failed for %s — retrying with raw price()", sym)
+                try:
+                    # Raw price getter (no staleness check)
+                    oracle = self.loader.oracle_for(sym)
+                    price = await oracle.functions.price().call()
                     return (amount * price) // (10**decimals)
                 except Exception:
-                    pass
+                    logger.warning("oracle price unavailable for %s — valuing holding at 0", sym)
+                    return 0
 
-        # Fallback: return raw amount
-        return amount
+        logger.warning("no oracle mapping for token %s — valuing holding at 0", token_address)
+        return 0
 
     async def _safe_total_assets(
         self,

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -117,7 +117,7 @@ class ChainExecutor:
         # values. Weighting against totalAssets() breaks when the on-chain NAV
         # excludes tokens (e.g. an unwired oracle values a synth at 0 in the
         # contract): USDC alone reads 100% and weights can't sum to 100 (#1080).
-        priced: list[tuple[str, str, int, int, int]] = []
+        valued: list[tuple[str, str, int, int, int, bool]] = []
         for i in range(len(token_addresses)):
             token_addr = token_addresses[i]
             amount = amounts[i]
@@ -129,11 +129,11 @@ class ChainExecutor:
             symbol = await self._get_token_symbol(token_addr)
             decimals = await self._get_token_decimals(token_addr)
 
-            # Calculate USDC value
-            value_usdc = await self._token_to_usdc(token_addr, amount, decimals, total_assets > 0)
-            priced.append((symbol, token_addr, amount, decimals, value_usdc))
+            # Calculate USDC value (was_priced=False → value is 0 by construction)
+            value_usdc, was_priced = await self._token_to_usdc(token_addr, amount, decimals, total_assets > 0)
+            valued.append((symbol, token_addr, amount, decimals, value_usdc, was_priced))
 
-        portfolio_value = sum(value for *_, value in priced)
+        portfolio_value = sum(value for *_, value, _ in valued)
         denominator = portfolio_value if portfolio_value > 0 else total_assets
 
         holdings = [
@@ -143,8 +143,9 @@ class ChainExecutor:
                 amount=amount / 10**decimals if decimals else float(amount),
                 value_usdc=value_usdc / 1e6,  # USDC has 6 decimals
                 weight=value_usdc / denominator if denominator > 0 else 0.0,
+                priced=was_priced,
             )
-            for symbol, token_addr, amount, decimals, value_usdc in priced
+            for symbol, token_addr, amount, decimals, value_usdc, was_priced in valued
         ]
 
         return Portfolio(
@@ -956,18 +957,22 @@ class ChainExecutor:
         except Exception:
             return 18
 
-    async def _token_to_usdc(self, token_address: str, amount: int, decimals: int, use_raw_price: bool = False) -> int:
-        """Estimate USDC value of a token holding.
+    async def _token_to_usdc(
+        self, token_address: str, amount: int, decimals: int, use_raw_price: bool = False
+    ) -> tuple[int, bool]:
+        """Estimate USDC value of a token holding → ``(value_usdc, priced)``.
 
         If use_raw_price is True (stale oracle fallback), uses the raw price()
         getter which doesn't check staleness.
 
-        Returns 0 (with a warning) when no price can be read — never the raw
-        base-unit amount: callers treat the result as 6-decimal USDC, so an
-        18-decimal raw amount inflates the value 10**12x (#1080).
+        Returns ``(0, False)`` (with a warning) when no price can be read —
+        never the raw base-unit amount: callers treat the result as 6-decimal
+        USDC, so an 18-decimal raw amount inflates the value 10**12x (#1080).
+        The ``priced`` flag lets callers distinguish "worth 0" from "value
+        unknown" — a distinction trade sizing depends on (see PortfolioHolding).
         """
         if token_address.lower() == chain_client.settings.usdc_address.lower():
-            return amount
+            return amount, True
 
         # For synth tokens, use the oracle price
         for sym, addr in chain_client.settings.synth_addresses.items():
@@ -977,20 +982,20 @@ class ChainExecutor:
                         oracle = self.loader.oracle_for(sym)
                         price = await oracle.functions.getPrice().call()
                         # USDC value = amount (10**decimals base units) * price (6 dec)
-                        return (amount * price) // (10**decimals)
+                        return (amount * price) // (10**decimals), True
                     except Exception:
                         logger.warning("getPrice() failed for %s — retrying with raw price()", sym)
                 try:
                     # Raw price getter (no staleness check)
                     oracle = self.loader.oracle_for(sym)
                     price = await oracle.functions.price().call()
-                    return (amount * price) // (10**decimals)
+                    return (amount * price) // (10**decimals), True
                 except Exception:
-                    logger.warning("oracle price unavailable for %s — valuing holding at 0", sym)
-                    return 0
+                    logger.warning("oracle price unavailable for %s — valuing holding at 0 (unpriced)", sym)
+                    return 0, False
 
-        logger.warning("no oracle mapping for token %s — valuing holding at 0", token_address)
-        return 0
+        logger.warning("no oracle mapping for token %s — valuing holding at 0 (unpriced)", token_address)
+        return 0, False
 
     async def _safe_total_assets(
         self,
@@ -1020,7 +1025,7 @@ class ChainExecutor:
                 else:
                     # Use raw price() (no staleness check)
                     decimals = await self._get_token_decimals(token_addr)
-                    value = await self._token_to_usdc(token_addr, amount, decimals, use_raw_price=True)
+                    value, _priced = await self._token_to_usdc(token_addr, amount, decimals, use_raw_price=True)
                     nav += value
             return nav
 

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -151,7 +151,14 @@ class ChainExecutor:
         return Portfolio(
             vault_address=vault_address,
             holdings=holdings,
-            total_value_usdc=total_assets / 1e6,
+            # Same NAV the weights were computed against (review follow-up):
+            # weights use `denominator` (sum of priced holdings, falling back
+            # to totalAssets), while trade sizing multiplies drift by
+            # total_value_usdc — if this stayed on raw totalAssets(), the
+            # #1080 scenario (on-chain NAV excluding an unwired-oracle synth)
+            # would size trades against a NAV inconsistent with the weights
+            # being diffed. One denominator for both surfaces.
+            total_value_usdc=denominator / 1e6,
         )
 
     async def _validate_trade_liquidity(self, trades: list[TradeOrder]) -> None:

--- a/backend/archimedes/models/portfolio.py
+++ b/backend/archimedes/models/portfolio.py
@@ -71,6 +71,10 @@ class PortfolioHolding:
     amount: float  # Token amount held
     value_usdc: float  # Current USDC value
     weight: float  # Fraction of total portfolio (0-1)
+    # False when the oracle price could not be read (#1080): value_usdc/weight
+    # are then 0 BY CONSTRUCTION, not real zeros — trade sizing must treat the
+    # holding as unknown-value (skip), never as absent (buy more every tick).
+    priced: bool = True
 
 
 @dataclass(frozen=True)

--- a/backend/tests/chain/test_executor_reads.py
+++ b/backend/tests/chain/test_executor_reads.py
@@ -131,6 +131,10 @@ class TestReadPortfolio:
         assert weights["sTSLA"] == pytest.approx(0.25)
         assert sum(weights.values()) == pytest.approx(1.0)
         assert all(0.0 <= w <= 1.0 for w in weights.values())
+        # total_value_usdc uses the SAME denominator as the weights (sum of
+        # priced holdings = $400), not the USDC-only on-chain totalAssets
+        # ($300) — trade sizing and weight diffs must share one NAV.
+        assert portfolio.total_value_usdc == pytest.approx(400.0)
 
     def test_unpriceable_synth_valued_zero_not_raw_amount(self, executor, mock_loader):
         """Regression for #1080: a synth whose oracle can't be read was valued

--- a/backend/tests/chain/test_executor_reads.py
+++ b/backend/tests/chain/test_executor_reads.py
@@ -154,6 +154,10 @@ class TestReadPortfolio:
         assert by_symbol["sTSLA"].weight == 0.0
         assert by_symbol["USDC"].weight == pytest.approx(1.0)
         assert sum(h.weight for h in portfolio.holdings) == pytest.approx(1.0)
+        # The unpriceable holding is flagged so trade sizing can refuse to act
+        # on its fake-zero weight (#1080 review follow-up).
+        assert by_symbol["sTSLA"].priced is False
+        assert by_symbol["USDC"].priced is True
 
     def test_total_assets_revert_falls_back_to_offchain_nav(self, executor, mock_loader):
         vault = mock_loader.vault.return_value
@@ -318,38 +322,39 @@ class TestTokenHelpers:
         assert asyncio.run(executor._get_token_decimals(STSLA)) == 18
 
     def test_token_to_usdc_for_usdc_is_identity(self, executor):
-        assert asyncio.run(executor._token_to_usdc(USDC, 12_345, 6)) == 12_345
+        assert asyncio.run(executor._token_to_usdc(USDC, 12_345, 6)) == (12_345, True)
 
     def test_token_to_usdc_synth_with_getprice(self, executor, mock_loader):
         oracle = mock_loader.oracle_for.return_value
         _vault_fn(oracle, "getPrice", return_value=200_000_000)  # $200 (6 dec)
         # 2 tokens (18 dec) * 200_000_000 / 1e18 = 400_000_000 → $400
         result = asyncio.run(executor._token_to_usdc(STSLA, 2 * 10**18, 18))
-        assert result == 400_000_000
+        assert result == (400_000_000, True)
 
     def test_token_to_usdc_uses_raw_price_when_requested(self, executor, mock_loader):
         oracle = mock_loader.oracle_for.return_value
         _vault_fn(oracle, "price", return_value=100_000_000)
         result = asyncio.run(executor._token_to_usdc(STSLA, 1 * 10**18, 18, use_raw_price=True))
-        assert result == 100_000_000
+        assert result == (100_000_000, True)
 
     def test_token_to_usdc_getprice_revert_falls_back_to_raw_price(self, executor, mock_loader):
         oracle = mock_loader.oracle_for.return_value
         _vault_fn(oracle, "getPrice", side_effect=RuntimeError("StalePrice"))
         _vault_fn(oracle, "price", return_value=100_000_000)
         result = asyncio.run(executor._token_to_usdc(STSLA, 3 * 10**18, 18))
-        assert result == 300_000_000
+        assert result == (300_000_000, True)
 
-    def test_token_to_usdc_synth_unpriceable_returns_zero(self, executor, mock_loader):
-        # Both getters revert → 0, never the raw base-unit amount (#1080).
+    def test_token_to_usdc_synth_unpriceable_returns_zero_unpriced(self, executor, mock_loader):
+        # Both getters revert → (0, priced=False): never the raw base-unit
+        # amount (#1080), and the caller can tell "worth 0" from "unknown".
         oracle = mock_loader.oracle_for.return_value
         _vault_fn(oracle, "getPrice", side_effect=RuntimeError("StalePrice"))
         _vault_fn(oracle, "price", side_effect=RuntimeError("revert"))
-        assert asyncio.run(executor._token_to_usdc(STSLA, 2 * 10**18, 18)) == 0
+        assert asyncio.run(executor._token_to_usdc(STSLA, 2 * 10**18, 18)) == (0, False)
 
-    def test_token_to_usdc_unknown_token_returns_zero(self, executor):
-        # No oracle mapping → 0, never the raw base-unit amount (#1080).
-        assert asyncio.run(executor._token_to_usdc("0x0000000000000000000000000000000000008888", 42, 18)) == 0
+    def test_token_to_usdc_unknown_token_returns_zero_unpriced(self, executor):
+        # No oracle mapping → (0, priced=False), never the raw base-unit amount (#1080).
+        assert asyncio.run(executor._token_to_usdc("0x0000000000000000000000000000000000008888", 42, 18)) == (0, False)
 
 
 class TestParseVaultCreated:

--- a/backend/tests/chain/test_executor_reads.py
+++ b/backend/tests/chain/test_executor_reads.py
@@ -91,9 +91,11 @@ class TestReadPortfolio:
         token = mock_loader.token.return_value
         _vault_fn(token, "symbol", return_value="sTSLA")
         _vault_fn(token, "decimals", return_value=18)
-        # oracle getPrice for value: 200 USDC (6 dec) per token
+        # oracle price for value: 200 USDC (6 dec) per token. read_portfolio
+        # uses the raw price() getter when totalAssets() succeeded.
         oracle = mock_loader.oracle_for.return_value
         _vault_fn(oracle, "getPrice", return_value=200_000_000)
+        _vault_fn(oracle, "price", return_value=200_000_000)
 
         portfolio = asyncio.run(executor.read_portfolio("0xVault"))
         assert portfolio.vault_address == "0xVault"
@@ -103,6 +105,55 @@ class TestReadPortfolio:
         h = portfolio.holdings[0]
         assert h.symbol == "sTSLA"
         assert h.amount == pytest.approx(2.0)
+        assert h.value_usdc == pytest.approx(400.0)
+        assert h.weight == pytest.approx(1.0)
+
+    def test_weights_sum_to_one_when_totalassets_excludes_synths(self, executor, mock_loader):
+        """Regression for #1080: the live vault's on-chain totalAssets() counted
+        only USDC, so weights computed against it had USDC at 100% and could
+        never sum to 100. Weights must be computed against the sum of priced
+        holdings instead."""
+        vault = mock_loader.vault.return_value
+        usdc_raw = 300_000_000  # $300 (6 dec)
+        synth_raw = 1 * 10**18  # 1 token (18 dec) @ $100 → $100
+        _vault_fn(vault, "getHoldings", return_value=[[USDC, STSLA], [usdc_raw, synth_raw]])
+        _vault_fn(vault, "totalAssets", return_value=usdc_raw)  # USDC-only NAV
+        token = mock_loader.token.return_value
+        _vault_fn(token, "symbol", return_value="sTSLA")
+        _vault_fn(token, "decimals", return_value=18)
+        oracle = mock_loader.oracle_for.return_value
+        _vault_fn(oracle, "getPrice", return_value=100_000_000)
+        _vault_fn(oracle, "price", return_value=100_000_000)
+
+        portfolio = asyncio.run(executor.read_portfolio("0xVault"))
+        weights = {h.symbol: h.weight for h in portfolio.holdings}
+        assert weights["USDC"] == pytest.approx(0.75)
+        assert weights["sTSLA"] == pytest.approx(0.25)
+        assert sum(weights.values()) == pytest.approx(1.0)
+        assert all(0.0 <= w <= 1.0 for w in weights.values())
+
+    def test_unpriceable_synth_valued_zero_not_raw_amount(self, executor, mock_loader):
+        """Regression for #1080: a synth whose oracle can't be read was valued
+        at its raw 18-decimal base-unit amount, inflating value_usdc/weight by
+        10**12 (live vault showed weight_pct of 3,070,572,228%)."""
+        vault = mock_loader.vault.return_value
+        usdc_raw = 300_000_000
+        synth_raw = 595_357_148_956_678  # the live sGOLD raw amount
+        _vault_fn(vault, "getHoldings", return_value=[[USDC, STSLA], [usdc_raw, synth_raw]])
+        _vault_fn(vault, "totalAssets", return_value=usdc_raw)
+        token = mock_loader.token.return_value
+        _vault_fn(token, "symbol", return_value="sTSLA")
+        _vault_fn(token, "decimals", return_value=18)
+        oracle = mock_loader.oracle_for.return_value
+        _vault_fn(oracle, "getPrice", side_effect=RuntimeError("StalePrice"))
+        _vault_fn(oracle, "price", side_effect=RuntimeError("revert"))
+
+        portfolio = asyncio.run(executor.read_portfolio("0xVault"))
+        by_symbol = {h.symbol: h for h in portfolio.holdings}
+        assert by_symbol["sTSLA"].value_usdc == 0.0
+        assert by_symbol["sTSLA"].weight == 0.0
+        assert by_symbol["USDC"].weight == pytest.approx(1.0)
+        assert sum(h.weight for h in portfolio.holdings) == pytest.approx(1.0)
 
     def test_total_assets_revert_falls_back_to_offchain_nav(self, executor, mock_loader):
         vault = mock_loader.vault.return_value
@@ -282,8 +333,23 @@ class TestTokenHelpers:
         result = asyncio.run(executor._token_to_usdc(STSLA, 1 * 10**18, 18, use_raw_price=True))
         assert result == 100_000_000
 
-    def test_token_to_usdc_unknown_token_returns_amount(self, executor):
-        assert asyncio.run(executor._token_to_usdc("0x0000000000000000000000000000000000008888", 42, 18)) == 42
+    def test_token_to_usdc_getprice_revert_falls_back_to_raw_price(self, executor, mock_loader):
+        oracle = mock_loader.oracle_for.return_value
+        _vault_fn(oracle, "getPrice", side_effect=RuntimeError("StalePrice"))
+        _vault_fn(oracle, "price", return_value=100_000_000)
+        result = asyncio.run(executor._token_to_usdc(STSLA, 3 * 10**18, 18))
+        assert result == 300_000_000
+
+    def test_token_to_usdc_synth_unpriceable_returns_zero(self, executor, mock_loader):
+        # Both getters revert → 0, never the raw base-unit amount (#1080).
+        oracle = mock_loader.oracle_for.return_value
+        _vault_fn(oracle, "getPrice", side_effect=RuntimeError("StalePrice"))
+        _vault_fn(oracle, "price", side_effect=RuntimeError("revert"))
+        assert asyncio.run(executor._token_to_usdc(STSLA, 2 * 10**18, 18)) == 0
+
+    def test_token_to_usdc_unknown_token_returns_zero(self, executor):
+        # No oracle mapping → 0, never the raw base-unit amount (#1080).
+        assert asyncio.run(executor._token_to_usdc("0x0000000000000000000000000000000000008888", 42, 18)) == 0
 
 
 class TestParseVaultCreated:

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -122,6 +122,30 @@ class TestComputeTrades:
         assert len(gold_trades) == 1
         assert gold_trades[0].direction == TradeDirection.SELL
 
+    def test_unpriced_holding_is_never_traded(self, runner):
+        """#1080 review follow-up: a holding whose oracle price couldn't be
+        read reports weight 0 BY CONSTRUCTION (priced=False) while its balance
+        is real. Trading on that fake 0 would BUY more of the unpriceable
+        asset every tick (current 0 vs target >0, forever). It must be
+        skipped — in both directions — until the oracle prices it again."""
+        holdings = [
+            PortfolioHolding(symbol="USDC", token_address="0xusdc", amount=7000.0, weight=0.70, value_usdc=7000.0),
+            PortfolioHolding(symbol="sSPY", token_address="0xsspy", amount=30.0, weight=0.30, value_usdc=3000.0),
+            # Real balance, unreadable price: weight/value are fake zeros.
+            PortfolioHolding(
+                symbol="sGOLD", token_address="0xsgold", amount=15.0, weight=0.0, value_usdc=0.0, priced=False
+            ),
+        ]
+        portfolio = _make_portfolio(holdings=holdings)
+        # Target wants 30% sGOLD — naive diff would BUY (0 → 0.30).
+        targets = _make_targets(USDC=0.40, sSPY=0.30, sGOLD=0.30)
+        trades = runner._compute_trades(portfolio, targets)
+        assert [t for t in trades if t.symbol == "sGOLD"] == [], (
+            "unpriced holding must not be traded on its fake-zero weight"
+        )
+        # Other symbols still trade normally (USDC 0.70→0.40 is a real drift).
+        assert any(t.symbol != "sGOLD" for t in trades)
+
 
 class TestWeightsToTargets:
     """Test _weights_to_targets: dict → TargetAllocation list."""


### PR DESCRIPTION
Closes #1080.

## Summary

GET /api/vaults/{address} returned corrupted holdings for synths whose oracle price can't be read — the live vault `0xA3b077...ada7` showed sNKY at 96,543,640% and sGOLD at 3,070,572,228% weight. Two defects in `ChainExecutor.read_portfolio` / `_token_to_usdc`:

1. **Raw-amount fallthrough.** When the oracle lookup or price call failed, `_token_to_usdc` returned the raw 18-decimal base-unit amount, which the caller divides by 1e6 as if it were USDC — a 10^12 inflation. Verified against the live payload: for both bad holdings, `value_usdc * 1e6` equals the raw on-chain token amount exactly. sSPY was sane only because its oracle answered ($747.40).
2. **Wrong weight denominator.** Weights were computed against on-chain `totalAssets()`, which for this vault counts only USDC (19.389) — so USDC read 100% and weights could never sum to 100.

The same fallthrough also poisoned the off-chain NAV fallback in `_safe_total_assets`, which sums `_token_to_usdc` results.

## Changes

`backend/archimedes/chain/executor.py`:
- `_token_to_usdc`: `getPrice()` failure now retries the raw `price()` getter (no staleness check); if that fails too, or the token has no oracle mapping at all, the holding is valued at **0 with a warning log** — never the raw base-unit amount. Loud fallback over a silently wrong number, per the Tier-0 claim-integrity rule.
- `read_portfolio`: weights are computed against the **sum of priced holdings** instead of `totalAssets()`, so each weight is in [0, 1] and they sum to 1 by construction. `total_value_usdc` (NAV of record) is unchanged.

`backend/tests/chain/test_executor_reads.py`:
- Regression: unpriceable synth (both getters revert) → value 0, weight 0, USDC at 100% — using the live sGOLD raw amount as the fixture.
- Regression: `totalAssets()` excluding synths → weights still sum to 1 (75/25 split).
- `getPrice()`-revert → raw-`price()` fallback; unknown token → 0 (this replaces the old test that asserted the buggy raw-amount return).

## Verify

```
pytest backend/tests/chain/test_executor_reads.py -q   # 27 passed
pytest -m "not integration" -q                          # 2725 passed, 0 failed*
ruff format --check . && ruff check --select E9,F63,F7,F40 .
```

*local run excludes `backend/tests/marketplace/`, `test_marketplace_routes.py`, `test_kb_runner.py`, `test_runner_lease.py` — pre-existing local-env collection errors (`circlekit` not installed here); they collect fine in CI.

After deploy:

```
curl -s https://archimedes-arc.com/api/vaults/0xA3b077e16C208cD794581db46b559FDC9619ada7 | jq '[.holdings[].weight_pct] | (add, max)'
```
→ sum ≈ 100, max ≤ 100. Expect `oracle price unavailable` warnings in backend logs for sNKY/sGOLD until their oracle feeds answer — that's the loud-fallback telemetry doing its job, and worth a follow-up look at why those two feeds fail on prod.

## Anti-goals

- No invented prices: a token we can't price is 0 + warning, not a pretend 1:1.
- No contract changes (the on-chain `totalAssets()` undercount is a separate question for the #942/#1026 lineage).
- `ui/src/components/QuantLab.jsx`'s weight_pct > 150 sanity gate is left in place as defense in depth; it can be relaxed once this is deployed.