### PR TITLE
[backend] Ownership-gate the strictest-level deploy fast path (#1073)

### DIFF
--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -95,6 +95,38 @@ def _strategy_rigor_status(strategy_id: str) -> tuple[bool, bool]:
     return False, False
 
 
+def _strategy_record_visible(strategy_id: str, request: Request) -> bool | None:
+    """``None`` if no ``StrategyRecord`` exists for ``strategy_id``; otherwise
+    whether that record is visible to the caller identified by ``request``.
+
+    Reuses the ``#850`` ownership rule verbatim (copied from
+    ``selection_bias_routes._generated_strategy_rigor``, itself copied from
+    ``strategies_routes.get_strategy``): a non-example, unpublished
+    ``strategy_store`` row is visible only to its ``owner_wallet``. Curated
+    strategies (no ``StrategyRecord`` row at all) fall outside this check
+    entirely — they return ``None`` here and are resolved via the passport
+    badge instead, unchanged.
+
+    Used to close the strictest-level deploy fast path (#1073): the badge
+    (``_strategy_rigor_status``) is not ownership-gated, so without this check
+    a caller who knows a private generated strategy's id could learn its
+    deployability and deploy a vault bound to it.
+    """
+    from archimedes.api.auth_siwe import get_verified_wallet
+    from archimedes.db import get_session, init_db
+    from archimedes.models.strategy_store import StrategyRecord
+
+    init_db()
+    with get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+        if row is None:
+            return None
+        if row.is_example or row.is_published:
+            return True
+        caller = get_verified_wallet(request)
+        return bool(row.owner_wallet and caller and row.owner_wallet.lower() == caller.lower())
+
+
 def _deployable_levels(
     strategy_ids: list[str], request: Request | None = None
 ) -> dict[str, tuple[bool, int | None, bool]]:
@@ -205,6 +237,18 @@ def _assert_strategies_pass_rigor(
     # the default deploy path unchanged for callers that don't opt into strictness.
     if level <= STRICTEST_LEVEL:
         for sid in strategy_ids:
+            # Ownership gate (#1073): `_strategy_rigor_status` below resolves the
+            # passport badge without regard to ownership, so a private/unpublished
+            # generated strategy would otherwise be deployable by anyone who knows
+            # its id. Reject BEFORE consulting the badge when a request is present
+            # and the id resolves to a StrategyRecord not visible to this caller.
+            # `visible is None` means "no StrategyRecord at all" (curated strategy,
+            # or unknown id) — falls through to the badge unchanged either way.
+            if request is not None:
+                visible = _strategy_record_visible(sid, request)
+                if visible is False:
+                    raise HTTPException(status_code=422, detail=f"Strategy '{sid}' not found — cannot deploy.")
+
             found, passes = _strategy_rigor_status(sid)
             if not found:
                 raise HTTPException(status_code=422, detail=f"Strategy '{sid}' not found — cannot deploy.")

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -101,11 +101,13 @@ def _strategy_record_visible(strategy_id: str, request: Request) -> bool | None:
 
     Reuses the ``#850`` ownership rule verbatim (copied from
     ``selection_bias_routes._generated_strategy_rigor``, itself copied from
-    ``strategies_routes.get_strategy``): a non-example, unpublished
-    ``strategy_store`` row is visible only to its ``owner_wallet``. Curated
-    strategies (no ``StrategyRecord`` row at all) fall outside this check
-    entirely — they return ``None`` here and are resolved via the passport
-    badge instead, unchanged.
+    ``strategies_routes.get_strategy`` — consolidation tracked in #1120): a
+    non-example, unpublished ``strategy_store`` row is visible only to its
+    ``owner_wallet``. Curated strategies are typically seeded into
+    ``strategy_store`` with ``is_example=True`` at startup (``main.py``), so
+    they resolve ``True`` here (visible to everyone); ``None`` (no row at
+    all — an unseeded environment or an unknown id) falls through to the
+    passport badge, which handles both identically to pre-#1073 behavior.
 
     Used to close the strictest-level deploy fast path (#1073): the badge
     (``_strategy_rigor_status``) is not ownership-gated, so without this check
@@ -113,11 +115,14 @@ def _strategy_record_visible(strategy_id: str, request: Request) -> bool | None:
     deployability and deploy a vault bound to it.
     """
     from archimedes.api.auth_siwe import get_verified_wallet
-    from archimedes.db import get_session, init_db
+    from archimedes.db import get_session
     from archimedes.models.strategy_store import StrategyRecord
 
     try:
-        init_db()
+        # No init_db() here: the app calls it once at startup (main.py), and
+        # re-running its schema inspection/patch pass per deploy request (× per
+        # strategy id) is wasted DB work on a hot, funds-adjacent path. Direct
+        # test callers create their own schema (see test_vault_rigor_gate.py).
         with get_session() as session:
             row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
             if row is None:

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -116,15 +116,32 @@ def _strategy_record_visible(strategy_id: str, request: Request) -> bool | None:
     from archimedes.db import get_session, init_db
     from archimedes.models.strategy_store import StrategyRecord
 
-    init_db()
-    with get_session() as session:
-        row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
-        if row is None:
-            return None
-        if row.is_example or row.is_published:
-            return True
-        caller = get_verified_wallet(request)
-        return bool(row.owner_wallet and caller and row.owner_wallet.lower() == caller.lower())
+    try:
+        init_db()
+        with get_session() as session:
+            row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+            if row is None:
+                return None
+            if row.is_example or row.is_published:
+                return True
+            caller = get_verified_wallet(request)
+            return bool(row.owner_wallet and caller and row.owner_wallet.lower() == caller.lower())
+    except HTTPException:
+        raise
+    except Exception:
+        # Fail CLOSED. Returning None here would make the gate silently
+        # disappear on a DB error (None means "no record — fall through to the
+        # ownership-blind badge"), i.e. private strategies would become
+        # deployable exactly when the DB is down. Surfacing a raw exception
+        # would 500 past the deploy endpoint's error handling. A 503 blocks
+        # the deploy loudly and recoverably instead.
+        logger.exception(
+            "ownership-visibility lookup failed for %s — failing closed",
+            sanitize_log_value(strategy_id),
+        )
+        raise HTTPException(
+            status_code=503, detail="Strategy ownership check temporarily unavailable — try again."
+        ) from None
 
 
 def _deployable_levels(

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -10,10 +10,15 @@ that failed the gate or was never validated.
 from __future__ import annotations
 
 import contextlib
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from archimedes.api.vaults_routes import _assert_strategies_pass_rigor, _strategy_rigor_status
+from archimedes.api.vaults_routes import (
+    _assert_strategies_pass_rigor,
+    _strategy_record_visible,
+    _strategy_rigor_status,
+)
 from fastapi import HTTPException
 
 V = "archimedes.api.vaults_routes"
@@ -198,3 +203,158 @@ async def test_create_vault_writes_the_identity_ledger_vault_created_event():
     assert actor_class == "human"
     assert meta["vault_address"] == "0xLedgerVaultAddress"
     assert meta["strategy_ids"] == ["passing"]
+
+
+# ── _strategy_record_visible (#1073) ──────────────────────────────────────
+
+_OWNER = "0x000000000000000000000000000000000000dEaD"
+_OTHER = "0x0000000000000000000000000000000000000BAD"
+
+
+@contextlib.contextmanager
+def _private_strategy_record(sid: str, *, owner: str):
+    """Create a private (non-example, unpublished) StrategyRecord owned by
+    `owner`, yield, then delete it — mirrors the identity-ledger test's
+    real-DB-with-cleanup pattern above rather than a tmp-sqlite swap, since
+    this file has no per-test DB fixture."""
+    from archimedes.db import get_session, init_db
+    from archimedes.models.strategy_store import StrategyRecord
+
+    init_db()
+    session = get_session()
+    try:
+        session.add(
+            StrategyRecord(
+                id=sid,
+                content_hash=("0x" + sid).ljust(66, "0"),
+                generation_method="fusion",
+                source_papers="[]",
+                strategy_name="Private Test Strategy",
+                thesis="test thesis",
+                asset_universe="[]",
+                risk_profile="moderate",
+                status="candidate",
+                is_example=False,
+                owner_wallet=owner.lower(),
+                is_published=False,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    try:
+        yield
+    finally:
+        session = get_session()
+        try:
+            session.query(StrategyRecord).filter_by(id=sid).delete(synchronize_session=False)
+            session.commit()
+        finally:
+            session.close()
+
+
+class _FakeRequest:
+    """Minimal stand-in for a FastAPI Request carrying a SIWE session cookie,
+    for calling `_strategy_record_visible` directly without a real HTTP call."""
+
+    def __init__(self, wallet: str | None):
+        self._wallet = wallet
+
+    @property
+    def cookies(self):
+        if self._wallet is None:
+            return {}
+        from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+
+        return {_COOKIE_NAME: _sign_session(self._wallet, time.time())}
+
+
+def test_strategy_record_visible_none_when_no_record():
+    assert _strategy_record_visible("no-such-strategy-id", _FakeRequest(_OWNER)) is None
+
+
+def test_strategy_record_visible_true_for_owner():
+    sid = "priv-visible-owner"
+    with _private_strategy_record(sid, owner=_OWNER):
+        assert _strategy_record_visible(sid, _FakeRequest(_OWNER)) is True
+
+
+def test_strategy_record_visible_false_for_non_owner():
+    sid = "priv-visible-nonowner"
+    with _private_strategy_record(sid, owner=_OWNER):
+        assert _strategy_record_visible(sid, _FakeRequest(_OTHER)) is False
+
+
+def test_strategy_record_visible_false_for_anonymous():
+    sid = "priv-visible-anon"
+    with _private_strategy_record(sid, owner=_OWNER):
+        assert _strategy_record_visible(sid, _FakeRequest(None)) is False
+
+
+# ── HTTP: strictest-level fast path is ownership-gated (#1073) ────────────
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Real signed SIWE session cookie (same helper shape as
+    test_strategy_ownership.py / test_user_routes.py). Needed here (rather
+    than the `require_verified_wallet` dependency override above) because
+    `_strategy_record_visible` reads the wallet directly off the request
+    cookie via `get_verified_wallet(request)`, not via the FastAPI dependency."""
+    from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+async def test_create_vault_hides_private_strategy_from_non_owner():
+    """A non-owner deploying a vault bound to a private generated strategy's
+    id gets 422 not-found — even though the (ownership-blind) passport badge
+    would say it passes. This is the #1073 regression: the badge alone can't
+    be trusted at the strictest-level fast path once a request is present."""
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    sid = "priv-deploy-nonowner"
+    with (
+        _private_strategy_record(sid, owner=_OWNER),
+        patch(f"{V}._strategy_rigor_status", return_value=(True, True)),
+        patch(f"{V}.chain_executor.create_vault") as mock_create,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test", cookies=_siwe_cookies(_OTHER)
+        ) as client:
+            resp = await client.post(
+                "/api/vaults/create",
+                json={"name": "V", "symbol": "V", "strategy_ids": [sid]},
+            )
+
+    assert resp.status_code == 422
+    assert "not found" in resp.json()["detail"]
+    mock_create.assert_not_called()  # never spent gas — ownership gate fired first
+
+
+async def test_create_vault_allows_owner_to_deploy_private_strategy():
+    """Complementary happy path: the strategy's OWNER deploying the same
+    private strategy id is unaffected by the new ownership check."""
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    sid = "priv-deploy-owner"
+    with (
+        _private_strategy_record(sid, owner=_OWNER),
+        patch(f"{V}._strategy_rigor_status", return_value=(True, True)),
+        patch(f"{V}.chain_executor.create_vault", new=AsyncMock(return_value="0xOwnerDeployedAddress")) as mock_create,
+        patch("archimedes.api.funnel_middleware.record_funnel", new=AsyncMock()),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test", cookies=_siwe_cookies(_OWNER)
+        ) as client:
+            resp = await client.post(
+                "/api/vaults/create",
+                json={"name": "V", "symbol": "V", "strategy_ids": [sid]},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["vault_address"] == "0xOwnerDeployedAddress"
+    mock_create.assert_awaited_once()  # owner → gate lets it through

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -292,6 +292,17 @@ def test_strategy_record_visible_false_for_anonymous():
         assert _strategy_record_visible(sid, _FakeRequest(None)) is False
 
 
+def test_strategy_record_visible_fails_closed_on_db_error():
+    """A DB error during the ownership lookup must NOT return None (None means
+    'no record — fall through to the ownership-blind badge', i.e. fail-open
+    for private strategies exactly when the DB is down). It must raise a 503
+    so the deploy is blocked loudly and recoverably."""
+    with patch("archimedes.db.get_session", side_effect=RuntimeError("db down")):
+        with pytest.raises(HTTPException) as exc_info:
+            _strategy_record_visible("any-id", _FakeRequest(_OWNER))
+    assert exc_info.value.status_code == 503
+
+
 # ── HTTP: strictest-level fast path is ownership-gated (#1073) ────────────
 
 


### PR DESCRIPTION
## Summary
Follow-up from PR #1066 review (Copilot, `vaults_routes.py:191`). The strictest-level (default) deploy fast path in `_assert_strategies_pass_rigor` resolved each strategy via `_strategy_rigor_status` (the passport badge), which is not ownership-gated. Since passports are created at generation time, a private, unpublished generated strategy has a passport row, so a caller who knew its `strategy_id` could learn its deployability and deploy a vault bound to it, even though `_generated_strategy_rigor`'s `#850` ownership gate already hides it on the looser-than-badge path.

Severity is low: not funds-affecting (the attacker funds their own vault, no theft), and private strategy ids aren't enumerable after PR #1070 closed the `/api/proposals` leak. It's unauthorized use of a private strategy's logic, not a custody risk. Still worth closing since the fix is small and well-scoped.

## Scope
`backend/archimedes/api/vaults_routes.py` and `backend/tests/test_vault_rigor_gate.py` only.

- Added `_strategy_record_visible(strategy_id, request) -> bool | None`. Returns `None` when no `StrategyRecord` exists for the id at all (curated strategies fall in this bucket and resolve via the badge unchanged). Returns `True`/`False` when a record exists, reusing the `#850` visibility rule copied verbatim from `_generated_strategy_rigor` in `selection_bias_routes.py` (example or published rows are visible to everyone; otherwise only the `owner_wallet` can see it).
- Wired it into the strictest-level fast path in `_assert_strategies_pass_rigor`: when `request` is present and `_strategy_record_visible` returns `False`, raise the same 422 "not found" the genuinely-missing-id branch raises, so existence never leaks through a different message. Everything else in the fast path is untouched.

## Acceptance criteria
- [x] `_strategy_record_visible` added, reusing the `#850` visibility logic rather than reimplementing it.
- [x] Fast path rejects with 422 "not found" when a request is present and the strategy resolves to a non-visible `StrategyRecord`; unchanged otherwise.
- [x] `backend/tests/test_vault_rigor_gate.py` stays green.
- [x] New test: non-owner deploying a private generated strategy by id gets 422 not-found; the owner deploying the same strategy succeeds.

## Verify
```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_vault_rigor_gate.py -q
# 17 passed, 0 failed

ruff format --check backend/archimedes/api/vaults_routes.py backend/tests/test_vault_rigor_gate.py
# 2 files already formatted

ruff check --select E9,F63,F7,F40 backend/archimedes/api/vaults_routes.py backend/tests/test_vault_rigor_gate.py
# All checks passed!
```

## Anti-goals
- Curated-strategy deploy behavior is untouched — curated strategies have no `StrategyRecord` row, so `_strategy_record_visible` returns `None` for them and the badge resolves them exactly as before.
- No rigor floor or threshold changed. This only tightens who is allowed to *resolve* a private strategy id before the badge is even consulted.
