### PR TITLE
[backend] Remove dead chainlink_covered field and _pick_pipeline vestiges (#834)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -74,26 +74,16 @@ def _llm_available() -> bool:
 
 
 def _pick_pipeline(
-    brief: GenerateBrief,  # noqa: ARG001 — accepted for forward-compat brief-aware routing; current heuristic uses env/corpus only
     mode_override: str | None = None,
 ) -> tuple[str, str]:
-    """Decide which generation pipeline to use based on runtime conditions.
+    """Return the generation pipeline to use: unconditionally ``"debate"``.
 
-    Returns ``(pipeline_name, reason)`` where *pipeline_name* is one of
-    ``"fusion"``, ``"architect"``, or ``"agent"``.
-
-    Decision tree (per issue #167):
-
-    1. **fusion** if the fusion engine is enabled, the corpus has ≥ 20 papers,
-       and an LLM backend is reachable.
-    2. **architect** if the curated library has ≥ 3 strategies that match the
-       brief's inferred asset classes.
-    3. **agent** (SSE streaming portfolio-advisor path) as the fallback.
+    T1.1 Phase-3 cutover: the debate society IS the generation pipeline. The
+    legacy fusion/architect/agent decision tree (issue #167) is retired; a
+    client-sent ``mode_override`` is accepted for API compatibility but no
+    longer routes anything — the society owns candidate generation (spec
+    §Phase-3; #834 flag audit).
     """
-    # ── T1.1 Phase-3 cutover: the debate society IS the generation pipeline. ──
-    # The legacy fusion/architect/agent decision tree is retired; a client-sent
-    # mode override is accepted for API compatibility but no longer routes —
-    # the society owns candidate generation (spec §Phase-3; #834 flag audit).
     if mode_override and mode_override != "debate":
         logger.info("generation: ignoring legacy mode override %r (debate-only cutover)", mode_override)
     return "debate", "debate society is the generation pipeline (T1.1 Phase-3 cutover)"
@@ -805,7 +795,7 @@ async def run_generation(
         )
 
         # ── Auto-route to the best pipeline ──
-        pipeline_name, pipeline_reason = _pick_pipeline(brief, mode_override=mode)
+        pipeline_name, pipeline_reason = _pick_pipeline(mode_override=mode)
 
         # ── T1.1 Phase-3 dispatch: debate is THE runner. ──
         # No silent fallback to the retired single-agent paths: if the society

--- a/backend/archimedes/universe.py
+++ b/backend/archimedes/universe.py
@@ -67,9 +67,6 @@ class SyntheticSpec:
     stork_asset_id: str | None = None
     chainlink_feed: str | None = None
     oracle_tier: str = "admin"
-    # Deprecated boolean retained for backward compat with any pre-#759 SSOT /
-    # doc code that reads it; derived from `chainlink_feed is not None` at load.
-    chainlink_covered: bool = False
 
     @property
     def price_int(self) -> int:
@@ -94,10 +91,6 @@ def _load_universe() -> dict[str, SyntheticSpec]:
         pyth = spec.get("pyth_feed_id")
         stork = spec.get("stork_asset_id")
         chainlink = spec.get("chainlink_feed")
-        # `chainlink_covered` is kept only for back-compat; the honest signal is
-        # whether a chainlink_feed is configured (null everywhere while Arc has
-        # no price Data Feeds). Fall back to the legacy bool if present.
-        chainlink_covered = chainlink is not None or bool(spec.get("chainlink_covered", False))
         universe[symbol] = SyntheticSpec(
             symbol=symbol,
             name=spec["name"],
@@ -109,7 +102,6 @@ def _load_universe() -> dict[str, SyntheticSpec]:
             stork_asset_id=str(stork) if stork else None,
             chainlink_feed=str(chainlink) if chainlink else None,
             oracle_tier=str(spec.get("oracle_tier") or _derive_oracle_tier(pyth, stork, chainlink)),
-            chainlink_covered=chainlink_covered,
         )
     return universe
 
@@ -161,8 +153,3 @@ def synthetics_for_deploy() -> list[tuple[str, str, int]]:
     return [
         (spec.name, spec.symbol, spec.price_int) for spec in sorted(SYNTHETIC_UNIVERSE.values(), key=lambda s: s.symbol)
     ]
-
-
-def chainlink_covered_synths() -> list[str]:
-    """Synth symbols whose underlying has a Chainlink data feed."""
-    return sorted(s for s, spec in SYNTHETIC_UNIVERSE.items() if spec.chainlink_covered)

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -308,9 +308,8 @@ def test_pick_pipeline_always_debate_after_cutover(monkeypatch):
     # test_debate_engine.py::test_pick_pipeline_is_debate_unconditionally.
     from archimedes.agents import generation_pipeline as gp
 
-    brief = GenerateBrief(intent="trend-following", risk_appetite="moderate")
     for override in (None, "fusion", "architect", "agent", "debate"):
-        name, reason = gp._pick_pipeline(brief, mode_override=override)
+        name, reason = gp._pick_pipeline(mode_override=override)
         assert name == "debate", f"override {override!r} routed off the society (got {name!r})"
         assert "debate" in reason.lower() or "Phase-3" in reason
 

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -462,9 +462,8 @@ def test_pick_pipeline_is_debate_unconditionally(monkeypatch):
     from archimedes.agents.generation_pipeline import _pick_pipeline
 
     monkeypatch.delenv("ARCHIMEDES_DEBATE_ENABLED", raising=False)
-    brief = GenerateBrief(intent="momentum equities")
     for override in (None, "fusion", "architect", "agent", "debate"):
-        name, reason = _pick_pipeline(brief, mode_override=override)
+        name, reason = _pick_pipeline(mode_override=override)
         assert name == "debate", f"override {override!r} must not route off the society"
         assert "Phase-3" in reason
 


### PR DESCRIPTION
## Summary

Issue #834's flag audit flags two items as genuinely dead and ready for cleanup, independent of the larger tracking checklist. This PR does only those two.

## Scope

- `backend/archimedes/universe.py`: remove the `chainlink_covered` field on `SyntheticSpec`, its back-compat computation in `_load_universe()`, and the `chainlink_covered_synths()` function. The honest signal (`chainlink_feed is not None`) already lives in `oracle_tier` derivation via `_derive_oracle_tier()` and is unaffected.
- `backend/archimedes/agents/generation_pipeline.py`: `_pick_pipeline()` docstring described a retired fusion/architect/agent decision tree (issue #167); rewrote it to describe the actual T1.1 Phase-3 debate-only behavior. Also dropped the unused `brief` parameter (it was never read in the function body, only carried a `noqa: ARG001`), and updated the one production call site plus both test call sites accordingly.

## Acceptance criteria

- [x] `grep -rn "chainlink_covered" --include="*.py" .` returns zero code references (two remaining hits are historical prose comments in `generate_universe.py` and `test_asset_universe_doc.py`, not code)
- [x] `_pick_pipeline` no longer takes a `brief` argument; all three call sites (`generation_pipeline.py`, `test_debate_engine.py`, `test_generation_pipeline.py`) updated
- [x] Hermetic test gate passes on the touched files

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/test_debate_engine.py \
  backend/tests/services/test_generation_pipeline.py \
  backend/tests/test_asset_universe_doc.py \
  backend/tests/test_universe_parity.py -q
# 74 passed, 0 failed

ruff format --check backend/archimedes/universe.py backend/archimedes/agents/generation_pipeline.py backend/tests/test_debate_engine.py backend/tests/services/test_generation_pipeline.py
ruff check --select E9,F63,F7,F40 backend/archimedes/universe.py backend/archimedes/agents/generation_pipeline.py backend/tests/test_debate_engine.py backend/tests/services/test_generation_pipeline.py
```

Both pass clean.

Note: the repo-wide `pytest backend/tests/ -q -k "universe or pipeline or generation"` run hits 11 pre-existing collection errors (`ModuleNotFoundError: circlekit`, `fakeredis`) unrelated to this change — confirmed identical on a clean `main` checkout before touching anything.

## Anti-goals

- Did not touch `.env.example`. Issue #834 mentions adding `ARCHIMEDES_FUSION_ENABLED=true` there, but editing `.env.example` needs a human sign-off per this repo's CLAUDE.md ("signals an env contract change for everyone") — left for a human to do separately.
- Did not touch any flag defaults or flip any flags (`PAYMENTS_DRY_RUN`, `PREMIUM_MODELS_ENABLED`, `KB_PIPELINE_ENABLED`, `PRICE_SOURCE`, `REQUIRE_SIWE_FOR_GENERATION`) — those are Dan's calls per the issue.
- No other items from #834's checklist are in scope here; this PR is only the two cleanup items the issue marks as ready.