### PR TITLE
[frontend] Show full knot title on hover in the knowledge graph (#432)

### DIFF
--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -147,7 +147,9 @@ export default function CorpusKG({ onOpenPaper }) {
   // Full entity behind the current hover, for the tooltip below — looked up
   // by id rather than trusting the label already baked into the SVG <text>
   // so the tooltip always shows the complete, untruncated title.
-  const hoveredEntityObj = hoverEntity ? entityMap[hoverEntity] : null
+  // Explicit null check: entity ids are integer PKs — truthiness would
+  // treat a (theoretical) id of 0 as not-hovered (review).
+  const hoveredEntityObj = hoverEntity != null ? entityMap[hoverEntity] : null
 
   return (
     <div className="corpus-kg-wrapper">

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -144,6 +144,11 @@ export default function CorpusKG({ onOpenPaper }) {
   const displayIds = new Set(displayEntities.map(e => e.id))
   const displayRelations = relations.filter(r => displayIds.has(r.source) && displayIds.has(r.target))
 
+  // Full entity behind the current hover, for the tooltip below — looked up
+  // by id rather than trusting the label already baked into the SVG <text>
+  // so the tooltip always shows the complete, untruncated title.
+  const hoveredEntityObj = hoverEntity ? entityMap[hoverEntity] : null
+
   return (
     <div className="corpus-kg-wrapper">
       <form onSubmit={handleSearch} className="flex gap-2 mb-4" style={{ padding: '0 12px' }}>
@@ -174,7 +179,7 @@ export default function CorpusKG({ onOpenPaper }) {
       ) : entities.length === 0 ? (
         <div style={{ padding: 40, textAlign: 'center' }} className="caption">No entities found.</div>
       ) : (
-        <div style={{ overflow: 'auto', padding: '0 12px 12px' }}>
+        <div style={{ position: 'relative', overflow: 'auto', padding: '0 12px 12px' }}>
           <svg
             ref={svgRef}
             viewBox={`0 0 ${layout.svgW} ${layout.svgH}`}
@@ -211,6 +216,9 @@ export default function CorpusKG({ onOpenPaper }) {
                   style={{ cursor: e.type === 'paper' ? 'pointer' : 'default' }}
                   onClick={() => e.type === 'paper' && onOpenPaper?.(e.id)}
                 >
+                  {/* Native SVG tooltip: full, untruncated label as a browser-rendered
+                      title on hover — a fallback alongside the HTML tooltip below. */}
+                  <title>{e.label}</title>
                   <circle
                     r={isHovered ? r + 3 : r}
                     fill={color}
@@ -246,6 +254,29 @@ export default function CorpusKG({ onOpenPaper }) {
               ))}
             </g>
           </svg>
+
+          {/* Hover tooltip — full, untruncated entity title with strong
+              contrast so it stays readable over a busy/filtered graph. */}
+          {hoveredEntityObj && (
+            <div
+              className="corpus-kg-tooltip"
+              style={{
+                position: 'absolute', bottom: 16, left: 24, zIndex: 5,
+                background: 'rgba(10,10,16,0.95)', borderRadius: 8, padding: '10px 14px',
+                border: '1px solid var(--glass-border)', maxWidth: 420, pointerEvents: 'none',
+              }}
+            >
+              <div
+                className="caption"
+                style={{ color: TYPE_COLORS[hoveredEntityObj.type] || 'var(--text-4)', marginBottom: 4, textTransform: 'capitalize' }}
+              >
+                {hoveredEntityObj.type}
+              </div>
+              <div className="body" style={{ color: '#fff', lineHeight: 1.4, fontSize: '0.95rem', wordBreak: 'break-word' }}>
+                {hoveredEntityObj.label}
+              </div>
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
After filtering the corpus knowledge graph (e.g. searching "bitcoin"), a node's title wasn't reliably readable. The inline SVG label only rendered for hovered or high-degree nodes and truncated at 35 characters with no way to see the rest.

## Scope
`ui/src/components/CorpusKG.jsx` only. Two additions:
- A native SVG `<title>` on each node as a browser-rendered hover fallback (untruncated).
- An HTML tooltip panel, positioned bottom-left of the graph, showing the full label plus the entity type, looked up by id from `entityMap` rather than reading whatever the inline SVG label happened to truncate to.

## Acceptance criteria
- [x] After filtering, hovering a knot shows its full, unclamped title.
- [x] The title is prominently displayed, not truncated.
- [x] Sufficient contrast (white text on a dark panel) and font size for readability.

## Verify
`cd ui && npm run lint` — clean.
Manual: filter the corpus graph, hover any node, confirm the tooltip panel shows the complete label.

## Anti-goals
Didn't touch zoom/scroll/pan (#431, separate PR, same file — expect a merge conflict between the two, whichever lands second should rebase). Didn't touch backend or add a dependency.