### PR TITLE
[frontend] Add smooth zoom + pan to the corpus knowledge graph (#431)

### DIFF
--- a/ui/src/components/CorpusGraph.jsx
+++ b/ui/src/components/CorpusGraph.jsx
@@ -28,6 +28,10 @@ export default function CorpusGraph() {
   const [containerWidth, setContainerWidth] = useState(800)
   const containerRef = useRef(null)
   const fgRef = useRef(null)
+  // Tracks whether the initial zoom-to-fit has run, so a later re-fetch
+  // (e.g. a future filter/search feature) can re-frame the graph instead
+  // of being silently skipped forever.
+  const didInitialFit = useRef(false)
 
   // Track the container's actual width so the canvas always matches it —
   // both on first paint (in case the ref attaches after the first data-ready
@@ -61,10 +65,24 @@ export default function CorpusGraph() {
         if (!r.ok) throw new Error(r.statusText)
         return r.json()
       })
-      .then(d => { if (!cancelled) setData(d) })
+      .then(d => { if (!cancelled) { didInitialFit.current = false; setData(d) } })
       .catch(e => { if (!cancelled) setError(e.message || 'Failed to load graph') })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
+  }, [])
+
+  // Frame the full point cloud once the graph has settled, instead of
+  // opening on whatever the default d3 transform happens to be — on a
+  // 1000-point UMAP scatter that default is often zoomed too far in/out
+  // to be useful on first paint.
+  const handleEngineStop = useCallback(() => {
+    if (didInitialFit.current) return
+    didInitialFit.current = true
+    fgRef.current?.zoomToFit(400, 40)
+  }, [])
+
+  const resetView = useCallback(() => {
+    fgRef.current?.zoomToFit(400, 40)
   }, [])
 
   // Build a lookup for cluster → color
@@ -193,6 +211,7 @@ export default function CorpusGraph() {
         nodeCanvasObject={nodeCanvasObject}
         nodePointerAreaPaint={nodePointerAreaPaint}
         onNodeHover={node => setHoverNode(node)}
+        onEngineStop={handleEngineStop}
         linkColor={() => 'rgba(100,100,140,0.08)'}
         linkWidth={0.5}
         backgroundColor="transparent"
@@ -201,7 +220,29 @@ export default function CorpusGraph() {
         cooldownTicks={100}
         width={containerWidth}
         height={500}
+        minZoom={0.3}
+        maxZoom={40}
+        onNodeClick={node => {
+          // Zoom in on the clicked node's neighborhood so a user can jump
+          // straight into a cluster instead of hand-scrolling to it.
+          fgRef.current?.centerAt(node.x, node.y, 400)
+          fgRef.current?.zoom(6, 400)
+        }}
       />
+
+      {/* Reset view — bounded zoom + click-to-zoom-in can leave a user
+          stranded deep inside a cluster with no obvious way back out. */}
+      <button
+        type="button"
+        className="btn btn-outline corpus-graph-reset-view"
+        onClick={resetView}
+        style={{
+          position: 'absolute', top: 8, left: 12,
+          padding: '4px 10px', fontSize: '0.75rem',
+        }}
+      >
+        Reset view
+      </button>
 
       {/* Legend — shrinks on narrow containers so it doesn't permanently
           cover most of the graph on a phone-width viewport. */}

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -111,18 +111,31 @@ export default function CorpusKG({ onOpenPaper }) {
 
   const clampScale = (s) => Math.min(8, Math.max(0.4, s))
 
+  // Map a pointer/wheel event to viewBox coordinates via the SVG's actual
+  // screen CTM. Proportional getBoundingClientRect math breaks whenever the
+  // rendered element's aspect differs from the 800×500 viewBox (width:100% +
+  // fixed height ⇒ preserveAspectRatio letterboxing on most viewports), which
+  // made the zoom anchor drift away from the cursor and pan deltas run fast/
+  // slow (#431 review). The CTM inverse maps through the letterboxing exactly.
+  const clientToViewBox = useCallback((e) => {
+    const svg = svgRef.current
+    if (!svg) return null
+    const ctm = svg.getScreenCTM?.()
+    if (!ctm || typeof DOMPoint === 'undefined') return null
+    return new DOMPoint(e.clientX, e.clientY).matrixTransform(ctm.inverse())
+  }, [])
+
   const handleWheel = useCallback((e) => {
     // Only effective because the listener is attached natively with
     // passive:false (see setSvgRef) — React 19 registers the JSX onWheel
     // prop as a PASSIVE root listener, where preventDefault() is a silent
     // no-op and the page scrolls while the graph zooms (#431 review).
     e.preventDefault()
-    const svg = svgRef.current
-    if (!svg) return
-    const rect = svg.getBoundingClientRect()
+    const pt = clientToViewBox(e)
+    if (!pt) return
     // Cursor position in viewBox units (before this zoom step).
-    const px = ((e.clientX - rect.left) / rect.width) * layout.svgW
-    const py = ((e.clientY - rect.top) / rect.height) * layout.svgH
+    const px = pt.x
+    const py = pt.y
 
     setViewTransform((prev) => {
       const factor = Math.exp(-e.deltaY * 0.0015)
@@ -132,7 +145,7 @@ export default function CorpusKG({ onOpenPaper }) {
       const ny = py - ((py - prev.y) / prev.scale) * nextScale
       return { scale: nextScale, x: nx, y: ny }
     })
-  }, [layout.svgW, layout.svgH])
+  }, [clientToViewBox])
 
   // Native wheel attachment with passive:false. Two constraints force this
   // shape: (1) React 19 makes JSX onWheel passive, so preventDefault can't
@@ -159,21 +172,31 @@ export default function CorpusKG({ onOpenPaper }) {
   }, [])
 
   const handlePointerDown = useCallback((e) => {
-    dragState.current = { startX: e.clientX, startY: e.clientY, origin: viewTransform }
-  }, [viewTransform])
+    const startPt = clientToViewBox(e)
+    if (!startPt) return
+    // Capture the pointer so the drag keeps tracking when the cursor leaves
+    // the <svg> mid-pan (without capture, pointermove stops at the edge and
+    // the pan "sticks" — #431 review).
+    e.currentTarget.setPointerCapture?.(e.pointerId)
+    dragState.current = { startX: startPt.x, startY: startPt.y, origin: viewTransform }
+  }, [viewTransform, clientToViewBox])
 
   const handlePointerMove = useCallback((e) => {
     if (!dragState.current) return
-    const svg = svgRef.current
-    if (!svg) return
-    const rect = svg.getBoundingClientRect()
-    const dx = ((e.clientX - dragState.current.startX) / rect.width) * layout.svgW
-    const dy = ((e.clientY - dragState.current.startY) / rect.height) * layout.svgH
+    const pt = clientToViewBox(e)
+    if (!pt) return
+    // Deltas in viewBox units via the same CTM mapping as the zoom anchor —
+    // no letterboxing drift on narrow viewports.
+    const dx = pt.x - dragState.current.startX
+    const dy = pt.y - dragState.current.startY
     const { origin } = dragState.current
     setViewTransform({ scale: origin.scale, x: origin.x + dx, y: origin.y + dy })
-  }, [layout.svgW, layout.svgH])
+  }, [clientToViewBox])
 
-  const handlePointerUp = useCallback(() => {
+  const handlePointerUp = useCallback((e) => {
+    if (e?.currentTarget?.hasPointerCapture?.(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
     dragState.current = null
   }, [])
 

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -36,6 +36,13 @@ export default function CorpusKG({ onOpenPaper }) {
   const [hoverEntity, setHoverEntity] = useState(null)
   const svgRef = useRef(null)
 
+  // Zoom/pan state — scale + translation applied to a wrapping <g> so
+  // node/edge/label rendering below is untouched. Wheel zooms around the
+  // cursor position; drag pans. Kept intentionally simple (no d3-zoom dep)
+  // since this is a plain SVG, not a canvas force-graph.
+  const [viewTransform, setViewTransform] = useState({ scale: 1, x: 0, y: 0 })
+  const dragState = useRef(null)
+
   const fetchKG = useCallback(async (q) => {
     setLoading(true)
     setError('')
@@ -58,6 +65,7 @@ export default function CorpusKG({ onOpenPaper }) {
         }))
       }
       setData(raw)
+      setViewTransform({ scale: 1, x: 0, y: 0 })
     } catch (e) {
       setError(e.message || 'Failed to load topic clusters')
     } finally {
@@ -100,6 +108,48 @@ export default function CorpusKG({ onOpenPaper }) {
 
     return { positions, svgW: 800, svgH: 500 }
   }, [data])
+
+  const clampScale = (s) => Math.min(8, Math.max(0.4, s))
+
+  const handleWheel = useCallback((e) => {
+    e.preventDefault()
+    const svg = svgRef.current
+    if (!svg) return
+    const rect = svg.getBoundingClientRect()
+    // Cursor position in viewBox units (before this zoom step).
+    const px = ((e.clientX - rect.left) / rect.width) * layout.svgW
+    const py = ((e.clientY - rect.top) / rect.height) * layout.svgH
+
+    setViewTransform((prev) => {
+      const factor = Math.exp(-e.deltaY * 0.0015)
+      const nextScale = clampScale(prev.scale * factor)
+      // Keep the point under the cursor fixed while scaling.
+      const nx = px - ((px - prev.x) / prev.scale) * nextScale
+      const ny = py - ((py - prev.y) / prev.scale) * nextScale
+      return { scale: nextScale, x: nx, y: ny }
+    })
+  }, [layout.svgW, layout.svgH])
+
+  const handlePointerDown = useCallback((e) => {
+    dragState.current = { startX: e.clientX, startY: e.clientY, origin: viewTransform }
+  }, [viewTransform])
+
+  const handlePointerMove = useCallback((e) => {
+    if (!dragState.current) return
+    const svg = svgRef.current
+    if (!svg) return
+    const rect = svg.getBoundingClientRect()
+    const dx = ((e.clientX - dragState.current.startX) / rect.width) * layout.svgW
+    const dy = ((e.clientY - dragState.current.startY) / rect.height) * layout.svgH
+    const { origin } = dragState.current
+    setViewTransform({ scale: origin.scale, x: origin.x + dx, y: origin.y + dy })
+  }, [layout.svgW, layout.svgH])
+
+  const handlePointerUp = useCallback(() => {
+    dragState.current = null
+  }, [])
+
+  const resetView = useCallback(() => setViewTransform({ scale: 1, x: 0, y: 0 }), [])
 
   // --- Render ---
 
@@ -174,67 +224,77 @@ export default function CorpusKG({ onOpenPaper }) {
       ) : entities.length === 0 ? (
         <div style={{ padding: 40, textAlign: 'center' }} className="caption">No entities found.</div>
       ) : (
-        <div style={{ overflow: 'auto', padding: '0 12px 12px' }}>
+        <div style={{ overflow: 'hidden', padding: '0 12px 12px', position: 'relative' }}>
           <svg
             ref={svgRef}
             viewBox={`0 0 ${layout.svgW} ${layout.svgH}`}
-            style={{ width: '100%', maxWidth: 800, height: 500, background: 'rgba(0,0,0,0.15)', borderRadius: 8 }}
+            style={{
+              width: '100%', maxWidth: 800, height: 500, background: 'rgba(0,0,0,0.15)', borderRadius: 8,
+              cursor: 'grab', touchAction: 'none',
+            }}
+            onWheel={handleWheel}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerLeave={handlePointerUp}
           >
-            {/* Edges */}
-            {displayRelations.map((r, i) => {
-              const s = layout.positions[r.source]
-              const t = layout.positions[r.target]
-              if (!s || !t) return null
-              return (
-                <line
-                  key={`edge-${i}`}
-                  x1={s.x} y1={s.y} x2={t.x} y2={t.y}
-                  stroke="rgba(100,100,140,0.15)"
-                  strokeWidth={0.8}
-                />
-              )
-            })}
-
-            {/* Nodes */}
-            {displayEntities.map(e => {
-              const pos = layout.positions[e.id]
-              if (!pos) return null
-              const r = 4 + (connCount[e.id] || 0) / maxConn * 8
-              const color = TYPE_COLORS[e.type] || '#6366f1'
-              const isHovered = hoverEntity === e.id
-              return (
-                <g
-                  key={`node-${e.id}`}
-                  transform={`translate(${pos.x},${pos.y})`}
-                  onMouseEnter={() => setHoverEntity(e.id)}
-                  onMouseLeave={() => setHoverEntity(null)}
-                  style={{ cursor: e.type === 'paper' ? 'pointer' : 'default' }}
-                  onClick={() => e.type === 'paper' && onOpenPaper?.(e.id)}
-                >
-                  <circle
-                    r={isHovered ? r + 3 : r}
-                    fill={color}
-                    opacity={isHovered ? 1 : 0.75}
-                    stroke={isHovered ? '#fff' : 'none'}
-                    strokeWidth={1.5}
+            <g transform={`translate(${viewTransform.x},${viewTransform.y}) scale(${viewTransform.scale})`}>
+              {/* Edges */}
+              {displayRelations.map((r, i) => {
+                const s = layout.positions[r.source]
+                const t = layout.positions[r.target]
+                if (!s || !t) return null
+                return (
+                  <line
+                    key={`edge-${i}`}
+                    x1={s.x} y1={s.y} x2={t.x} y2={t.y}
+                    stroke="rgba(100,100,140,0.15)"
+                    strokeWidth={0.8}
                   />
-                  {/* Label on hover or for high-degree nodes */}
-                  {(isHovered || (connCount[e.id] || 0) > maxConn * 0.3) && (
-                    <text
-                      x={r + 4}
-                      y={4}
-                      fontSize={10}
-                      fill={isHovered ? '#fff' : 'var(--text-3)'}
-                      fontFamily="system-ui"
-                    >
-                      {e.label?.length > 35 ? `${e.label.slice(0, 35)}…` : e.label}
-                    </text>
-                  )}
-                </g>
-              )
-            })}
+                )
+              })}
 
-            {/* Legend */}
+              {/* Nodes */}
+              {displayEntities.map(e => {
+                const pos = layout.positions[e.id]
+                if (!pos) return null
+                const r = 4 + (connCount[e.id] || 0) / maxConn * 8
+                const color = TYPE_COLORS[e.type] || '#6366f1'
+                const isHovered = hoverEntity === e.id
+                return (
+                  <g
+                    key={`node-${e.id}`}
+                    transform={`translate(${pos.x},${pos.y})`}
+                    onMouseEnter={() => setHoverEntity(e.id)}
+                    onMouseLeave={() => setHoverEntity(null)}
+                    style={{ cursor: e.type === 'paper' ? 'pointer' : 'default' }}
+                    onClick={() => e.type === 'paper' && onOpenPaper?.(e.id)}
+                  >
+                    <circle
+                      r={isHovered ? r + 3 : r}
+                      fill={color}
+                      opacity={isHovered ? 1 : 0.75}
+                      stroke={isHovered ? '#fff' : 'none'}
+                      strokeWidth={1.5}
+                    />
+                    {/* Label on hover or for high-degree nodes */}
+                    {(isHovered || (connCount[e.id] || 0) > maxConn * 0.3) && (
+                      <text
+                        x={r + 4}
+                        y={4}
+                        fontSize={10}
+                        fill={isHovered ? '#fff' : 'var(--text-3)'}
+                        fontFamily="system-ui"
+                      >
+                        {e.label?.length > 35 ? `${e.label.slice(0, 35)}…` : e.label}
+                      </text>
+                    )}
+                  </g>
+                )
+              })}
+            </g>
+
+            {/* Legend — stays fixed in screen space, outside the zoom/pan group */}
             <g transform={`translate(12, 12)`}>
               {Object.keys(TYPE_ICONS).map((type, i) => (
                 <g key={type} transform={`translate(0, ${i * 18})`}>
@@ -246,6 +306,15 @@ export default function CorpusKG({ onOpenPaper }) {
               ))}
             </g>
           </svg>
+
+          <button
+            type="button"
+            className="btn btn-outline corpus-kg-reset-view"
+            onClick={resetView}
+            style={{ position: 'absolute', top: 8, right: 20, padding: '4px 10px', fontSize: '0.75rem' }}
+          >
+            Reset view
+          </button>
         </div>
       )}
 

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -112,6 +112,10 @@ export default function CorpusKG({ onOpenPaper }) {
   const clampScale = (s) => Math.min(8, Math.max(0.4, s))
 
   const handleWheel = useCallback((e) => {
+    // Only effective because the listener is attached natively with
+    // passive:false (see setSvgRef) — React 19 registers the JSX onWheel
+    // prop as a PASSIVE root listener, where preventDefault() is a silent
+    // no-op and the page scrolls while the graph zooms (#431 review).
     e.preventDefault()
     const svg = svgRef.current
     if (!svg) return
@@ -129,6 +133,30 @@ export default function CorpusKG({ onOpenPaper }) {
       return { scale: nextScale, x: nx, y: ny }
     })
   }, [layout.svgW, layout.svgH])
+
+  // Native wheel attachment with passive:false. Two constraints force this
+  // shape: (1) React 19 makes JSX onWheel passive, so preventDefault can't
+  // work through the prop; (2) the <svg> mounts conditionally after data
+  // loads, so a mount-only useEffect would attach to null — a callback ref
+  // attaches/detaches with the element itself (same reasoning as
+  // CorpusGraph's ResizeObserver callback ref).
+  const wheelHandlerRef = useRef(handleWheel)
+  useEffect(() => {
+    wheelHandlerRef.current = handleWheel
+  }, [handleWheel])
+  const wheelCleanupRef = useRef(null)
+  const setSvgRef = useCallback((el) => {
+    if (wheelCleanupRef.current) {
+      wheelCleanupRef.current()
+      wheelCleanupRef.current = null
+    }
+    svgRef.current = el
+    if (el) {
+      const listener = (e) => wheelHandlerRef.current(e)
+      el.addEventListener('wheel', listener, { passive: false })
+      wheelCleanupRef.current = () => el.removeEventListener('wheel', listener)
+    }
+  }, [])
 
   const handlePointerDown = useCallback((e) => {
     dragState.current = { startX: e.clientX, startY: e.clientY, origin: viewTransform }
@@ -226,13 +254,12 @@ export default function CorpusKG({ onOpenPaper }) {
       ) : (
         <div style={{ overflow: 'hidden', padding: '0 12px 12px', position: 'relative' }}>
           <svg
-            ref={svgRef}
+            ref={setSvgRef}
             viewBox={`0 0 ${layout.svgW} ${layout.svgH}`}
             style={{
               width: '100%', maxWidth: 800, height: 500, background: 'rgba(0,0,0,0.15)', borderRadius: 8,
               cursor: 'grab', touchAction: 'none',
             }}
-            onWheel={handleWheel}
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}


### PR DESCRIPTION
## Summary
The corpus knowledge graph gave no way to zoom into a cluster or pan around one at a fixed scale. `CorpusGraph` (the UMAP scatter) opened on whatever transform the force simulation happened to settle on, with unbounded zoom. `CorpusKG` (the plain SVG entity graph) had no zoom or pan at all, just a scrolling container.

## Scope
`ui/src/components/CorpusGraph.jsx` and `ui/src/components/CorpusKG.jsx`.

CorpusGraph (uses react-force-graph, which already has zoom/pan built in — this just wires it up properly):
- Zoom-to-fit once the layout engine settles, instead of leaving the initial transform to chance.
- `minZoom`/`maxZoom` bounds.
- Click a node to zoom into its neighborhood.
- Reset-view button.

CorpusKG (plain SVG, no existing zoom library):
- Wheel-to-zoom anchored on cursor position, clamped 0.4x-8x.
- Click-drag to pan.
- Applied via a wrapping `<g transform>` around nodes/edges so the rendering logic itself is untouched; the legend stays fixed in screen space outside that group.
- Reset-view button.

## Acceptance criteria
- [x] Smooth zoom to focus on a cluster.
- [x] Scroll/pan across clusters at different scales.
- [x] Bounded zoom range and a reset affordance so a user can't get stranded.

## Verify
`cd ui && npm run lint` — clean.
Manual: open `/corpus`, both the Graph and Knowledge Graph tabs — scroll to zoom, drag to pan, click Reset view.

## Anti-goals
Didn't touch hover/tooltip behavior (#432, separate PR, touches CorpusKG.jsx too — expect a merge conflict between the two, whichever lands second should rebase onto the other). No new dependency; CorpusGraph reuses react-force-graph's existing zoom API, CorpusKG's zoom/pan is plain SVG transform math.