### PR TITLE
[frontend] Grouped asset allocation cards with icons and detail view (#464)

### DIFF
--- a/ui/src/assetGroups.js
+++ b/ui/src/assetGroups.js
@@ -1,0 +1,191 @@
+// Grouped-asset metadata for the /explore card view (#464).
+//
+// The grouping key IS the existing `asset_class` field returned by
+// /api/explore/assets (see backend/archimedes/data/synthetic_universe.json
+// and explore_schemas.py) — the same field Explore.jsx already uses to build
+// its filter pills. There is no separate "category" concept in the backend
+// today, so a card == one asset_class bucket. If/when the strategy engine
+// grows a richer sector/theme taxonomy, this map is the place to extend.
+//
+// Each entry is a plain-English description of what the bucket represents,
+// plus a simple inline SVG icon (no new icon-library dependency — see PR
+// #464 report for why: @iconify-json/* packages are already declared in
+// ui/package.json but nothing wires up @iconify/react to consume them, so
+// pulling that thread in would be a genuinely new dependency).
+export const ASSET_GROUP_META = {
+  crypto: {
+    label: 'Crypto',
+    description:
+      'Digital-native assets — major coins and tokens traded 24/7 across on-chain and centralized venues. ' +
+      'No market close, so prices move on weekends and holidays too.',
+    icon: 'crypto',
+  },
+  fx: {
+    label: 'FX',
+    description:
+      'Currency pairs. Used as a diversifier against USD-denominated risk and as a macro regime signal ' +
+      '(risk-on/risk-off shows up here first for a lot of strategies).',
+    icon: 'fx',
+  },
+  us_thematic_etf: {
+    label: 'US Thematic ETFs',
+    description:
+      'US-listed funds built around a theme (AI, clean energy, robotics, etc.) rather than a sector or index. ' +
+      'Higher concentration risk than a broad index fund in exchange for a more targeted bet.',
+    icon: 'theme',
+  },
+  asia_equity_etf: {
+    label: 'Asia Equity ETFs',
+    description: 'Funds tracking equity markets across Asia — a regional diversifier outside US and EU exposure.',
+    icon: 'globe',
+  },
+  us_equity_etf: {
+    label: 'US Equity ETFs',
+    description: 'Broad US equity index funds (S&P 500, total market, etc.) — the core beta building block for most portfolios.',
+    icon: 'chart',
+  },
+  factor_etf: {
+    label: 'Factor ETFs',
+    description:
+      'Funds that tilt toward a specific academic risk factor — value, momentum, quality, low-volatility — ' +
+      'instead of market-cap weighting.',
+    icon: 'factor',
+  },
+  eu_equity_etf: {
+    label: 'EU Equity ETFs',
+    description: 'Funds tracking equity markets across Europe — a regional diversifier outside US and Asia exposure.',
+    icon: 'globe',
+  },
+  us_sector_etf: {
+    label: 'US Sector ETFs',
+    description: 'US equity funds sliced by sector (tech, energy, financials, etc.) for sector rotation strategies.',
+    icon: 'sector',
+  },
+  commodity_etf: {
+    label: 'Commodity ETFs',
+    description: 'Funds tracking broad commodity baskets or indices — an inflation hedge and a diversifier against equities.',
+    icon: 'commodity',
+  },
+  intl_equity_etf: {
+    label: 'International Equity ETFs',
+    description: 'Developed-market equity funds outside the US — ex-US diversification without single-country concentration.',
+    icon: 'globe',
+  },
+  latam_equity_etf: {
+    label: 'LatAm Equity ETFs',
+    description: 'Funds tracking equity markets across Latin America.',
+    icon: 'globe',
+  },
+  us_bond_agg: {
+    label: 'US Aggregate Bonds',
+    description: 'Broad US fixed-income funds spanning maturities and issuers — the classic ballast against equity drawdowns.',
+    icon: 'bond',
+  },
+  metal_eq_etf: {
+    label: 'Metals & Mining Equities',
+    description: 'Equity funds holding metals and mining companies — leveraged exposure to metal prices via producers rather than the spot metal.',
+    icon: 'metal',
+  },
+  credit_ig: {
+    label: 'Investment-Grade Credit',
+    description: 'Corporate bond funds rated investment-grade — more yield than treasuries, more safety than high-yield.',
+    icon: 'bond',
+  },
+  metal_etf: {
+    label: 'Metals ETFs',
+    description: 'Funds tracking physical or futures-based precious-metal prices (gold, silver, etc.).',
+    icon: 'metal',
+  },
+  metal_spot: {
+    label: 'Metal Spot',
+    description: 'Direct spot-price exposure to precious metals, without a fund wrapper.',
+    icon: 'metal',
+  },
+  credit_hy: {
+    label: 'High-Yield Credit',
+    description: 'Corporate bond funds rated below investment-grade — more yield, more default and rate-cycle risk.',
+    icon: 'bond',
+  },
+  agri_etf: {
+    label: 'Agriculture ETFs',
+    description: 'Funds tracking agricultural commodities (grains, softs) — a different macro driver than metals or energy.',
+    icon: 'commodity',
+  },
+  reit_etf: {
+    label: 'REIT ETFs',
+    description: 'Real-estate investment trust funds — equity-like exposure to property income and valuations.',
+    icon: 'reit',
+  },
+  us_bond_tbill: {
+    label: 'US T-Bills',
+    description: 'Short-dated US Treasury bills — the closest thing to a risk-free rate proxy in the universe.',
+    icon: 'bond',
+  },
+  energy_etf: {
+    label: 'Energy ETFs',
+    description: 'Funds tracking oil, gas, and broader energy-sector prices.',
+    icon: 'commodity',
+  },
+  em_equity_etf: {
+    label: 'Emerging Market Equity ETFs',
+    description: 'Equity funds across emerging markets — higher growth potential, higher volatility and currency risk.',
+    icon: 'globe',
+  },
+  volatility_etf: {
+    label: 'Volatility ETFs',
+    description: 'Funds tracking implied or realized volatility indices — used as a hedge or a tail-risk signal, not a buy-and-hold position.',
+    icon: 'volatility',
+  },
+  intl_bond: {
+    label: 'International Bonds',
+    description: 'Fixed-income exposure outside the US — diversifies rate-cycle and currency risk away from USD bonds.',
+    icon: 'bond',
+  },
+  em_bond: {
+    label: 'Emerging Market Bonds',
+    description: 'Fixed-income exposure to emerging-market sovereign and corporate debt — higher yield, higher credit and currency risk.',
+    icon: 'bond',
+  },
+  us_bond_mid: {
+    label: 'US Mid-Duration Bonds',
+    description: 'US Treasury exposure in the middle of the curve — a balance between rate sensitivity and yield.',
+    icon: 'bond',
+  },
+  us_muni: {
+    label: 'US Municipal Bonds',
+    description: 'US state and local government debt — often tax-advantaged, lower yield in exchange for that treatment.',
+    icon: 'bond',
+  },
+  us_bond_short: {
+    label: 'US Short-Duration Bonds',
+    description: 'US Treasury exposure at the short end of the curve — low rate sensitivity, closer to a cash-equivalent.',
+    icon: 'bond',
+  },
+  us_bond_tips: {
+    label: 'US TIPS',
+    description: 'Treasury Inflation-Protected Securities — principal adjusts with CPI, an explicit inflation hedge inside fixed income.',
+    icon: 'bond',
+  },
+  us_bond_long: {
+    label: 'US Long-Duration Bonds',
+    description: 'US Treasury exposure at the long end of the curve — highest rate sensitivity, biggest swings when yields move.',
+    icon: 'bond',
+  },
+  tr_equity_etf: {
+    label: 'Turkey Equity ETFs',
+    description: 'Funds tracking Turkish equity markets.',
+    icon: 'globe',
+  },
+}
+
+const FALLBACK_META = {
+  label: null, // filled in with the raw class name at call site
+  description: 'A grouping of related assets from the tradable universe.',
+  icon: 'default',
+}
+
+export function groupMeta(assetClass) {
+  const meta = ASSET_GROUP_META[assetClass]
+  if (meta) return meta
+  return { ...FALLBACK_META, label: (assetClass || 'Other').replace(/_/g, ' ') }
+}

--- a/ui/src/components/AssetGroupIcon.jsx
+++ b/ui/src/components/AssetGroupIcon.jsx
@@ -1,0 +1,44 @@
+// Simple inline-SVG icon set for the /explore grouped-asset cards (#464).
+//
+// The repo has @iconify-json/* packages declared in ui/package.json but no
+// @iconify/react (or any other icon-component library) wired up to consume
+// them — nothing in ui/src imports from an icon package today (checked via
+// grep). Pulling in @iconify/react to use those JSON sets would be a new
+// runtime dependency, which needs a human sign-off per CLAUDE.md. Plain
+// inline SVGs stay dependency-free and match the existing pattern of
+// hand-rolled SVGs already used for the price chart (AssetModal.jsx).
+
+const PATHS = {
+  crypto: 'M12 2 L20 7 L20 17 L12 22 L4 17 L4 7 Z M12 2 L12 22 M4 7 L20 17 M20 7 L4 17',
+  fx: 'M6 8 h10 M6 8 l3 -3 M6 8 l3 3 M18 16 H8 M18 16 l-3 -3 M18 16 l-3 3',
+  theme: 'M12 3 l2.5 5.5 6 0.8 -4.3 4.2 1 6 -5.2 -2.9 -5.2 2.9 1 -6 L3.5 9.3 9.5 8.5 Z',
+  globe: 'M12 3 a9 9 0 1 0 0 18 a9 9 0 1 0 0 -18 M3 12 h18 M12 3 c3 3 3 15 0 18 M12 3 c-3 3 -3 15 0 18',
+  chart: 'M4 20 V4 M4 20 H20 M7 17 V11 M12 17 V7 M17 17 V13',
+  factor: 'M4 12 h4 M4 8 h7 M4 16 h2 M13 4 v16 M17 6 l3 3 -3 3 M17 14 l3 3 -3 3',
+  sector: 'M12 12 L12 3 A9 9 0 0 1 20.5 9 Z M12 12 L20.5 9 A9 9 0 0 1 15 20.5 Z M12 12 L15 20.5 A9 9 0 1 1 12 3 Z',
+  commodity: 'M4 18 L9 8 L12 13 L15 6 L20 18 Z',
+  bond: 'M4 6 h16 v4 H4 Z M4 14 h16 v4 H4 Z M8 6 v4 M16 6 v4 M8 14 v4 M16 14 v4',
+  metal: 'M12 2 L21 8 L18 20 H6 L3 8 Z M3 8 h18 M9 8 l3 12 M15 8 l-3 12',
+  reit: 'M4 21 V10 L12 4 L20 10 V21 H14 V15 H10 V21 Z',
+  volatility: 'M3 12 q2 -8 4 0 t4 0 t4 0 t4 0 q2 -8 4 0',
+  default: 'M4 4 h16 v16 H4 Z M4 10 h16 M10 4 v16',
+}
+
+export default function AssetGroupIcon({ icon = 'default', size = 22 }) {
+  const d = PATHS[icon] || PATHS.default
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={d} />
+    </svg>
+  )
+}

--- a/ui/src/components/AssetGroupModal.jsx
+++ b/ui/src/components/AssetGroupModal.jsx
@@ -1,0 +1,262 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import PriceHistoryChart from './PriceHistoryChart'
+import AssetGroupIcon from './AssetGroupIcon'
+import { groupMeta } from '../assetGroups'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+const RANGES = ['1D', '1W', '1M', '1Y', '5Y', '10Y', 'MAX']
+// Aggregating every member of a large bucket (crypto = 71 symbols) on every
+// range change is expensive for both the browser and the backend cache. Cap
+// how many symbols feed the aggregate chart; the card/list below still shows
+// the full membership and true asset count.
+const MAX_AGGREGATE_MEMBERS = 20
+
+function fmtPct(v) {
+  if (v == null || Number.isNaN(v)) return '—'
+  const sign = v >= 0 ? '+' : ''
+  return `${sign}${v.toFixed(2)}%`
+}
+
+function changeClass(v) {
+  if (v == null || Number.isNaN(v)) return ''
+  return v >= 0 ? 'positive' : 'negative'
+}
+
+/**
+ * Aggregate several symbols' history series into a single equal-weight
+ * "index" series, expressed as % change from each series' own first point.
+ * Normalizing to % change is what makes it valid to average across symbols
+ * with wildly different price scales (e.g. a $0.001 token next to a $60,000
+ * one) — anchoring on any single symbol's price units would misrepresent
+ * the group.
+ *
+ * We align on index position rather than timestamp: all history requests
+ * share the same `range`, so the backend returns bars on the same cadence
+ * per symbol; index alignment is the same approach the single-asset x-axis
+ * tick heuristic already assumes (see PriceHistoryChart's isIntraday check).
+ */
+function buildGroupIndex(seriesList) {
+  const usable = seriesList.filter(s => s.points && s.points.length > 1)
+  if (usable.length === 0) return []
+
+  const maxLen = Math.max(...usable.map(s => s.points.length))
+  const out = []
+  for (let i = 0; i < maxLen; i++) {
+    let sum = 0
+    let count = 0
+    let ts = null
+    for (const s of usable) {
+      const pt = s.points[i]
+      if (!pt) continue
+      const base = s.points[0].price
+      if (base == null || base === 0) continue
+      sum += ((pt.price - base) / base) * 100
+      count += 1
+      if (!ts) ts = pt.ts
+    }
+    if (count > 0) out.push({ ts: ts || String(i), price: sum / count })
+  }
+  return out
+}
+
+export default function AssetGroupModal({ assetClass, assets, onClose }) {
+  const [range, setRange] = useState('1M')
+  const [seriesBySymbol, setSeriesBySymbol] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const meta = groupMeta(assetClass)
+  const members = useMemo(
+    () => [...assets].sort((a, b) => (b.current_price ?? 0) - (a.current_price ?? 0)),
+    [assets]
+  )
+  const aggregateMembers = useMemo(() => members.slice(0, MAX_AGGREGATE_MEMBERS), [members])
+
+  useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  useEffect(() => {
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = prev }
+  }, [])
+
+  useEffect(() => {
+    if (aggregateMembers.length === 0) return
+    let cancelled = false
+    setLoading(true)
+    setError('')
+    Promise.all(
+      aggregateMembers.map(a =>
+        fetch(`${API_BASE}/api/explore/assets/${a.symbol}/history?range=${range}`)
+          .then(res => (res.ok ? res.json() : { points: [] }))
+          .then(data => ({ symbol: a.symbol, points: Array.isArray(data.points) ? data.points : [] }))
+          .catch(() => ({ symbol: a.symbol, points: [] }))
+      )
+    )
+      .then(results => {
+        if (cancelled) return
+        const bySymbol = {}
+        for (const r of results) bySymbol[r.symbol] = r.points
+        setSeriesBySymbol(bySymbol)
+        if (results.every(r => r.points.length === 0)) {
+          setError('No historical data available for this group in the selected range.')
+        }
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [aggregateMembers, range])
+
+  const groupIndexPoints = useMemo(
+    () => buildGroupIndex(Object.entries(seriesBySymbol).map(([symbol, points]) => ({ symbol, points }))),
+    [seriesBySymbol]
+  )
+
+  // Aggregate 24h change across the whole group (not just the capped
+  // aggregate-chart subset) — cheap since it's already in the /assets payload.
+  const avgChange24h = useMemo(() => {
+    const vals = members.map(a => a.change_24h_pct).filter(v => v != null && !Number.isNaN(v))
+    if (vals.length === 0) return null
+    return vals.reduce((a, b) => a + b, 0) / vals.length
+  }, [members])
+
+  if (!assetClass) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-center justify-center z-[1000]"
+      style={{ background: 'rgba(0,0,0,0.78)', backdropFilter: 'blur(6px)' }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="asset-group-modal-title"
+    >
+      <div
+        className="card-elevated p-6"
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: 'var(--surface-1)',
+          maxHeight: '90vh', overflowY: 'auto',
+          width: 'min(860px, 94vw)',
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16 }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+            <div
+              style={{
+                width: 40, height: 40, borderRadius: 8,
+                background: 'var(--glass)', border: '1px solid var(--glass-border)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: 'var(--accent)', flexShrink: 0,
+              }}
+            >
+              <AssetGroupIcon icon={meta.icon} size={22} />
+            </div>
+            <div>
+              <h3 id="asset-group-modal-title" className="serif" style={{ fontSize: '1.5rem', margin: 0 }}>
+                {meta.label}
+              </h3>
+              <div className="caption" style={{ color: 'var(--text-3)', marginTop: 2 }}>
+                {members.length} asset{members.length === 1 ? '' : 's'} in this group
+              </div>
+            </div>
+          </div>
+          <button className="btn btn-outline btn-sm" onClick={onClose} aria-label="Close group details">
+            Close (Esc)
+          </button>
+        </div>
+
+        {/* Plain-English description */}
+        <p className="body" style={{ marginTop: 14, color: 'var(--text-3)', maxWidth: 700 }}>
+          {meta.description}
+        </p>
+
+        {/* Aggregate stat */}
+        <div style={{ display: 'flex', gap: 24, alignItems: 'baseline', marginTop: 16, flexWrap: 'wrap' }}>
+          <div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
+              Avg 24h change (equal-weight, {members.length} assets)
+            </div>
+            <div className={`mono ${changeClass(avgChange24h)}`} style={{ fontSize: '1.3rem', fontWeight: 600 }}>
+              {fmtPct(avgChange24h)}
+            </div>
+          </div>
+        </div>
+
+        {/* Range toggle */}
+        <div style={{ marginTop: 18, display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+          {RANGES.map(r => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`btn btn-sm ${range === r ? '' : 'btn-outline'}`}
+              style={{
+                minWidth: 48,
+                background: range === r ? 'var(--accent-muted)' : undefined,
+                color: range === r ? 'var(--accent)' : undefined,
+                borderColor: range === r ? 'var(--accent)' : undefined,
+              }}
+              aria-pressed={range === r}
+            >
+              {r}
+            </button>
+          ))}
+          <span className="caption" style={{ marginLeft: 'auto', color: 'var(--text-4)', fontSize: '0.7rem' }}>
+            Equal-weight % change index
+            {members.length > MAX_AGGREGATE_MEMBERS ? ` · first ${MAX_AGGREGATE_MEMBERS} of ${members.length} assets` : ''}
+          </span>
+        </div>
+
+        {/* Aggregated chart — reuses the same PriceHistoryChart component/pattern
+            as the single-asset detail view (AssetModal.jsx), plotting % change
+            instead of $ price via the formatValue override. */}
+        <div style={{ marginTop: 10 }}>
+          <PriceHistoryChart
+            points={groupIndexPoints}
+            loading={loading}
+            error={error}
+            formatValue={v => `${v >= 0 ? '+' : ''}${v.toFixed(1)}%`}
+          />
+        </div>
+
+        {/* Member list */}
+        <div style={{ marginTop: 20, paddingTop: 14, borderTop: '1px solid var(--glass-border)' }}>
+          <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem', marginBottom: 8 }}>
+            Assets in this group
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+              gap: 8,
+              maxHeight: 220,
+              overflowY: 'auto',
+            }}
+          >
+            {members.map(a => (
+              <div
+                key={a.symbol}
+                style={{
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+                  padding: '6px 8px', background: 'var(--glass)', borderRadius: 6,
+                  border: '1px solid var(--glass-border)',
+                }}
+              >
+                <span className="mono" style={{ fontSize: '0.78rem', fontWeight: 600 }}>{a.symbol}</span>
+                <span className={`mono ${changeClass(a.change_24h_pct)}`} style={{ fontSize: '0.7rem' }}>
+                  {fmtPct(a.change_24h_pct)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/ui/src/components/AssetGroupModal.jsx
+++ b/ui/src/components/AssetGroupModal.jsx
@@ -129,9 +129,10 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
     Promise.all(
       aggregateMembers.map(a =>
         fetch(`${API_BASE}/api/explore/assets/${a.symbol}/history?range=${range}`)
-          .then(res => (res.ok ? res.json() : { points: [] }))
-          .then(data => ({ symbol: a.symbol, points: Array.isArray(data.points) ? data.points : [] }))
-          .catch(() => ({ symbol: a.symbol, points: [] }))
+          .then(res => (res.ok
+            ? res.json().then(data => ({ symbol: a.symbol, points: Array.isArray(data.points) ? data.points : [], failed: false }))
+            : { symbol: a.symbol, points: [], failed: true }))
+          .catch(() => ({ symbol: a.symbol, points: [], failed: true }))
       )
     )
       .then(results => {
@@ -140,7 +141,12 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
         for (const r of results) bySymbol[r.symbol] = r.points
         setSeriesBySymbol(bySymbol)
         if (results.every(r => r.points.length === 0)) {
-          setError('No historical data available for this group in the selected range.')
+          // Distinguish "backend/network failing" from "genuinely no bars in
+          // this range" — telling a user there's no data when every request
+          // 5xx'd is misleading (review).
+          setError(results.some(r => r.failed)
+            ? 'Could not load history for this group right now — retry shortly.'
+            : 'No historical data available for this group in the selected range.')
         }
       })
       .finally(() => { if (!cancelled) setLoading(false) })

--- a/ui/src/components/AssetGroupModal.jsx
+++ b/ui/src/components/AssetGroupModal.jsx
@@ -31,31 +31,67 @@ function changeClass(v) {
  * one) — anchoring on any single symbol's price units would misrepresent
  * the group.
  *
- * We align on index position rather than timestamp: all history requests
- * share the same `range`, so the backend returns bars on the same cadence
- * per symbol; index alignment is the same approach the single-asset x-axis
- * tick heuristic already assumes (see PriceHistoryChart's isIntraday check).
+ * We align by TIMESTAMP on the common overlapping window — never by array
+ * index. Same-range requests share a cadence, but NOT a start date: group
+ * members have wildly different history lengths (sBTC ~15y vs sARB ~2y on
+ * MAX), so index i lands on different calendar dates per symbol. And
+ * rebasing each series to its OWN first bar mixes epochs (%-since-2010
+ * averaged with %-since-2023 at the same x position). Instead: the group
+ * index starts at the LATEST first-bar across members (the youngest
+ * member's inception within the range), every series is rebased to its
+ * first bar at/after that common start, and each time bucket averages only
+ * the symbols that actually have a bar there. Consequence, by design: on
+ * long ranges the group chart's window is capped by its youngest member —
+ * a shorter, honest window beats a longer, distorted one.
  */
-function buildGroupIndex(seriesList) {
+function buildGroupIndex(seriesList, range) {
   const usable = seriesList.filter(s => s.points && s.points.length > 1)
   if (usable.length === 0) return []
 
-  const maxLen = Math.max(...usable.map(s => s.points.length))
+  // Daily+ ranges bucket on the ISO date part; intraday (1D) on the full ts.
+  const bucketKey = (ts) => (range === '1D' ? String(ts) : String(ts).slice(0, 10))
+
+  const seriesMaps = usable
+    .map(s => {
+      const map = new Map()
+      for (const pt of s.points) {
+        if (pt?.price == null) continue
+        map.set(bucketKey(pt.ts), pt)
+      }
+      return { map, firstKey: bucketKey(s.points[0].ts) }
+    })
+    .filter(m => m.map.size > 1)
+  if (seriesMaps.length === 0) return []
+
+  // ISO8601 strings compare lexicographically — the max firstKey is the
+  // youngest member's inception, i.e. the common window start.
+  const commonStartKey = seriesMaps.map(m => m.firstKey).sort().at(-1)
+
+  const rebased = []
+  for (const { map } of seriesMaps) {
+    const keys = [...map.keys()].sort()
+    const startIdx = keys.findIndex(k => k >= commonStartKey)
+    if (startIdx === -1) continue
+    const base = map.get(keys[startIdx])?.price
+    if (base == null || base === 0) continue
+    rebased.push({ map, keys: keys.slice(startIdx), base })
+  }
+  if (rebased.length === 0) return []
+
+  const allKeys = [...new Set(rebased.flatMap(r => r.keys))].sort()
   const out = []
-  for (let i = 0; i < maxLen; i++) {
+  for (const k of allKeys) {
     let sum = 0
     let count = 0
     let ts = null
-    for (const s of usable) {
-      const pt = s.points[i]
+    for (const r of rebased) {
+      const pt = r.map.get(k)
       if (!pt) continue
-      const base = s.points[0].price
-      if (base == null || base === 0) continue
-      sum += ((pt.price - base) / base) * 100
+      sum += ((pt.price - r.base) / r.base) * 100
       count += 1
       if (!ts) ts = pt.ts
     }
-    if (count > 0) out.push({ ts: ts || String(i), price: sum / count })
+    if (count > 0) out.push({ ts: ts || k, price: sum / count })
   }
   return out
 }
@@ -112,8 +148,8 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
   }, [aggregateMembers, range])
 
   const groupIndexPoints = useMemo(
-    () => buildGroupIndex(Object.entries(seriesBySymbol).map(([symbol, points]) => ({ symbol, points }))),
-    [seriesBySymbol]
+    () => buildGroupIndex(Object.entries(seriesBySymbol).map(([symbol, points]) => ({ symbol, points })), range),
+    [seriesBySymbol, range]
   )
 
   // Aggregate 24h change across the whole group (not just the capped

--- a/ui/src/components/AssetModal.jsx
+++ b/ui/src/components/AssetModal.jsx
@@ -181,7 +181,7 @@ export default function AssetModal({ asset, onClose }) {
 
         {/* Chart */}
         <div style={{ marginTop: 10 }}>
-          <PriceHistoryChart points={history} loading={loading} error={error} />
+          <PriceHistoryChart points={history} loading={loading} error={error} emptyHeadline="Historical chart unavailable for this asset in the selected range." />
         </div>
 
         {/* Meta grid: source, last updated, longer-window changes, vol */}

--- a/ui/src/components/AssetModal.jsx
+++ b/ui/src/components/AssetModal.jsx
@@ -1,15 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
+import PriceHistoryChart, { fmtPrice } from './PriceHistoryChart'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 const RANGES = ['1D', '1W', '1M', '1Y', '5Y', '10Y', 'MAX']
-
-function fmtPrice(v) {
-  if (v == null || Number.isNaN(v)) return '—'
-  if (v >= 1000) return `$${v.toFixed(0)}`
-  if (v >= 10) return `$${v.toFixed(2)}`
-  return `$${v.toFixed(4)}`
-}
 
 function fmtPct(v) {
   if (v == null || Number.isNaN(v)) return '—'
@@ -26,144 +20,6 @@ function sourceLabel(price_source) {
   if (price_source === 'oracle') return 'On-chain PriceOracle (Arc)'
   if (price_source === 'yfinance') return 'yfinance (off-chain fallback)'
   return 'No source available'
-}
-
-/**
- * PriceHistoryChart — SVG line chart of one symbol's price series.
- *
- * Honest fallback: when `points` is empty (range unsupported or upstream
- * feed returned nothing) we render an explicit empty state. We never
- * synthesize a flat line.
- */
-function PriceHistoryChart({ points, loading, error }) {
-  const SVG_W = 720
-  const SVG_H = 260
-  const PAD_L = 56
-  const PAD_R = 18
-  const PAD_T = 16
-  const PAD_B = 36
-
-  if (loading) {
-    return (
-      <div style={{ height: SVG_H, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div className="caption" style={{ color: 'var(--text-4)' }}>Loading price history…</div>
-      </div>
-    )
-  }
-  if (error || !points || points.length === 0) {
-    return (
-      <div
-        style={{
-          height: SVG_H,
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          background: 'var(--glass)',
-          border: '1px dashed var(--glass-border)',
-          borderRadius: 6,
-        }}
-      >
-        <div className="caption" style={{ color: 'var(--text-4)', textAlign: 'center', maxWidth: 380 }}>
-          Historical chart unavailable on this asset for the selected range.
-          {error ? <><br /><span style={{ fontSize: '0.7rem', opacity: 0.7 }}>{error}</span></> : null}
-        </div>
-      </div>
-    )
-  }
-
-  const prices = points.map(p => p.price)
-  const minP = Math.min(...prices)
-  const maxP = Math.max(...prices)
-  const range = maxP - minP || Math.max(1e-6, Math.abs(maxP) * 0.01)
-  // Light vertical padding so the line never touches the top/bottom border.
-  const yPad = range * 0.08
-
-  const toX = i => PAD_L + (i / Math.max(1, points.length - 1)) * (SVG_W - PAD_L - PAD_R)
-  const toY = p => SVG_H - PAD_B - ((p - minP + yPad) / (range + 2 * yPad)) * (SVG_H - PAD_T - PAD_B)
-
-  const linePath = points
-    .map((pt, i) => `${i === 0 ? 'M' : 'L'} ${toX(i).toFixed(1)} ${toY(pt.price).toFixed(1)}`)
-    .join(' ')
-  const areaPath =
-    `M ${toX(0).toFixed(1)} ${(SVG_H - PAD_B).toFixed(1)} ` +
-    points.map((pt, i) => `L ${toX(i).toFixed(1)} ${toY(pt.price).toFixed(1)}`).join(' ') +
-    ` L ${toX(points.length - 1).toFixed(1)} ${(SVG_H - PAD_B).toFixed(1)} Z`
-
-  // y-axis labels (5 ticks)
-  const yTicks = [0, 1, 2, 3, 4].map(i => {
-    const p = minP + (range * i) / 4
-    return { y: toY(p), label: fmtPrice(p) }
-  })
-
-  // x-axis labels (4 ticks at first/quarter/half/three-quarter/last)
-  const xTickIdx = [0, Math.floor((points.length - 1) / 3), Math.floor((2 * (points.length - 1)) / 3), points.length - 1]
-  // Heuristic: if the first two timestamps differ by less than a day, this
-  // is intraday data and we want HH:MM labels. Otherwise show MM-DD.
-  const isIntraday = (() => {
-    if (points.length < 2) return false
-    const a = Date.parse(points[0].ts.replace(' ', 'T'))
-    const b = Date.parse(points[1].ts.replace(' ', 'T'))
-    if (Number.isNaN(a) || Number.isNaN(b)) return false
-    return Math.abs(b - a) < 12 * 60 * 60 * 1000
-  })()
-  const xTicks = xTickIdx
-    .filter((idx, i, arr) => i === 0 || idx !== arr[i - 1])  // dedupe at edges
-    .map(idx => {
-      const tsStr = points[idx]?.ts || ''
-      // pandas Timestamps stringify as "2026-05-25 00:00:00+00:00" or
-      // "2026-05-25". Normalize and format based on intraday / daily.
-      const parsed = Date.parse(tsStr.replace(' ', 'T'))
-      let label = tsStr.slice(0, 10)
-      if (!Number.isNaN(parsed)) {
-        const d = new Date(parsed)
-        if (isIntraday) {
-          label = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-        } else {
-          label = `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-        }
-      }
-      return { x: toX(idx), label }
-    })
-
-  // Coloring: green if last > first, red otherwise — matches the 24h
-  // change badge convention.
-  const first = points[0].price
-  const last = points[points.length - 1].price
-  const stroke = last >= first ? 'var(--positive)' : 'var(--negative)'
-  const fill = last >= first ? 'rgba(34,197,94,0.10)' : 'rgba(239,68,68,0.10)'
-
-  return (
-    <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} width="100%" style={{ display: 'block', maxHeight: 320 }}>
-      {/* horizontal grid */}
-      {yTicks.map((t, i) => (
-        <line key={i} x1={PAD_L} y1={t.y} x2={SVG_W - PAD_R} y2={t.y}
-          stroke="var(--chart-grid)" strokeWidth="1" />
-      ))}
-      {/* axes */}
-      <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={SVG_H - PAD_B}
-        stroke="var(--chart-grid-strong)" strokeWidth="1" />
-      <line x1={PAD_L} y1={SVG_H - PAD_B} x2={SVG_W - PAD_R} y2={SVG_H - PAD_B}
-        stroke="var(--chart-grid-strong)" strokeWidth="1" />
-
-      {/* y-axis labels */}
-      {yTicks.map((t, i) => (
-        <text key={i} x={PAD_L - 6} y={t.y + 4} textAnchor="end"
-          fill="var(--chart-label)" fontSize="9" className="mono">
-          {t.label}
-        </text>
-      ))}
-      {/* x-axis labels */}
-      {xTicks.map((t, i) => (
-        <text key={i} x={t.x} y={SVG_H - PAD_B + 14} textAnchor="middle"
-          fill="var(--chart-label)" fontSize="9">
-          {t.label}
-        </text>
-      ))}
-
-      {/* area under the line */}
-      <path d={areaPath} fill={fill} stroke="none" />
-      {/* main line */}
-      <path d={linePath} fill="none" stroke={stroke} strokeWidth="1.8" strokeLinejoin="round" />
-    </svg>
-  )
 }
 
 export default function AssetModal({ asset, onClose }) {

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -72,13 +72,13 @@ export default function Explore() {
   // grouping the filter pills above already use. Sorted by member count so
   // the largest, most-populated groups surface first.
   const groups = useMemo(() => {
-    const bySymbolClass = new Map()
+    const byAssetClass = new Map()
     for (const a of assets) {
       if (!a.asset_class) continue
-      if (!bySymbolClass.has(a.asset_class)) bySymbolClass.set(a.asset_class, [])
-      bySymbolClass.get(a.asset_class).push(a)
+      if (!byAssetClass.has(a.asset_class)) byAssetClass.set(a.asset_class, [])
+      byAssetClass.get(a.asset_class).push(a)
     }
-    return Array.from(bySymbolClass.entries())
+    return Array.from(byAssetClass.entries())
       .map(([assetClass, members]) => ({ assetClass, members, meta: groupMeta(assetClass) }))
       .sort((a, b) => b.members.length - a.members.length)
   }, [assets])

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -1,5 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import AssetModal from './AssetModal'
+import AssetGroupModal from './AssetGroupModal'
+import AssetGroupIcon from './AssetGroupIcon'
+import { groupMeta } from '../assetGroups'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -32,6 +35,8 @@ export default function Explore() {
   const [error, setError] = useState('')
   const [filterClass, setFilterClass] = useState('all')
   const [openAsset, setOpenAsset] = useState(null)
+  const [openGroup, setOpenGroup] = useState(null)
+  const [view, setView] = useState('groups')
 
   useEffect(() => {
     let cancelled = false
@@ -62,6 +67,21 @@ export default function Explore() {
 
   const classes = ['all', ...Array.from(new Set(assets.map(a => a.asset_class).filter(Boolean)))]
   const filtered = filterClass === 'all' ? assets : assets.filter(a => a.asset_class === filterClass)
+
+  // Grouped-card view (#464): one card per asset_class bucket, the same
+  // grouping the filter pills above already use. Sorted by member count so
+  // the largest, most-populated groups surface first.
+  const groups = useMemo(() => {
+    const bySymbolClass = new Map()
+    for (const a of assets) {
+      if (!a.asset_class) continue
+      if (!bySymbolClass.has(a.asset_class)) bySymbolClass.set(a.asset_class, [])
+      bySymbolClass.get(a.asset_class).push(a)
+    }
+    return Array.from(bySymbolClass.entries())
+      .map(([assetClass, members]) => ({ assetClass, members, meta: groupMeta(assetClass) }))
+      .sort((a, b) => b.members.length - a.members.length)
+  }, [assets])
 
   // Banner only fires when *every* asset's displayed price is itself stale.
   // The backend now treats a missing on-chain oracle as "not stale" when
@@ -98,20 +118,52 @@ export default function Explore() {
         </p>
       </div>
 
-      {/* Filter pills */}
-      <div className="strat-filter-bar" style={{ marginBottom: 18 }}>
-        {classes.map(c => (
-          <span
-            key={c}
-            className={`tag ${filterClass === c ? 'tag-accent' : 'tag-muted'}`}
-            onClick={() => setFilterClass(c)}
-            style={{ cursor: 'pointer' }}
-          >
-            {c === 'all' ? 'All' : c.replace(/_/g, ' ')}
-            {c !== 'all' && ` (${assets.filter(a => a.asset_class === c).length})`}
-          </span>
-        ))}
+      {/* Grouped-cards vs. flat-list view toggle */}
+      <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
+        <button
+          type="button"
+          className={`btn btn-sm ${view === 'groups' ? '' : 'btn-outline'}`}
+          onClick={() => setView('groups')}
+          style={{
+            background: view === 'groups' ? 'var(--accent-muted)' : undefined,
+            color: view === 'groups' ? 'var(--accent)' : undefined,
+            borderColor: view === 'groups' ? 'var(--accent)' : undefined,
+          }}
+          aria-pressed={view === 'groups'}
+        >
+          By group
+        </button>
+        <button
+          type="button"
+          className={`btn btn-sm ${view === 'assets' ? '' : 'btn-outline'}`}
+          onClick={() => setView('assets')}
+          style={{
+            background: view === 'assets' ? 'var(--accent-muted)' : undefined,
+            color: view === 'assets' ? 'var(--accent)' : undefined,
+            borderColor: view === 'assets' ? 'var(--accent)' : undefined,
+          }}
+          aria-pressed={view === 'assets'}
+        >
+          All assets
+        </button>
       </div>
+
+      {/* Filter pills — only meaningful for the flat asset list */}
+      {view === 'assets' && (
+        <div className="strat-filter-bar" style={{ marginBottom: 18 }}>
+          {classes.map(c => (
+            <span
+              key={c}
+              className={`tag ${filterClass === c ? 'tag-accent' : 'tag-muted'}`}
+              onClick={() => setFilterClass(c)}
+              style={{ cursor: 'pointer' }}
+            >
+              {c === 'all' ? 'All' : c.replace(/_/g, ' ')}
+              {c !== 'all' && ` (${assets.filter(a => a.asset_class === c).length})`}
+            </span>
+          ))}
+        </div>
+      )}
 
       {/* Loading / error / empty states */}
       {loading && !assets.length && <div className="caption">Loading market data…</div>}
@@ -147,8 +199,99 @@ export default function Explore() {
         </div>
       )}
 
+      {/* Grouped-asset card grid */}
+      {view === 'groups' && groups.length > 0 && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+            gap: 14,
+          }}
+        >
+          {groups.map(g => {
+            const avgChange = (() => {
+              const vals = g.members.map(a => a.change_24h_pct).filter(v => v != null && !Number.isNaN(v))
+              if (vals.length === 0) return null
+              return vals.reduce((a, b) => a + b, 0) / vals.length
+            })()
+            return (
+              <button
+                key={g.assetClass}
+                type="button"
+                onClick={() => setOpenGroup(g)}
+                className="card-flat"
+                style={{
+                  textAlign: 'left',
+                  padding: 16,
+                  background: 'var(--glass)',
+                  border: '1px solid var(--glass-border)',
+                  borderRadius: 8,
+                  cursor: 'pointer',
+                  color: 'inherit',
+                  font: 'inherit',
+                  transition: 'background 0.15s, border-color 0.15s',
+                }}
+                onMouseEnter={e => {
+                  e.currentTarget.style.background = 'var(--glass-hover)'
+                  e.currentTarget.style.borderColor = 'var(--text-4)'
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.background = 'var(--glass)'
+                  e.currentTarget.style.borderColor = 'var(--glass-border)'
+                }}
+                aria-label={`Open details for ${g.meta.label} group`}
+              >
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+                  <div
+                    style={{
+                      width: 34, height: 34, borderRadius: 7, flexShrink: 0,
+                      background: 'var(--surface-1)', border: '1px solid var(--glass-border)',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      color: 'var(--accent)',
+                    }}
+                  >
+                    <AssetGroupIcon icon={g.meta.icon} size={18} />
+                  </div>
+                  <div style={{ minWidth: 0 }}>
+                    <div style={{ fontSize: '1.02rem', fontWeight: 700, lineHeight: 1.2 }}>{g.meta.label}</div>
+                    <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem', marginTop: 2 }}>
+                      {g.members.length} asset{g.members.length === 1 ? '' : 's'}
+                    </div>
+                  </div>
+                </div>
+
+                <p
+                  className="caption"
+                  style={{
+                    color: 'var(--text-3)',
+                    fontSize: '0.76rem',
+                    marginTop: 10,
+                    lineHeight: 1.4,
+                    display: '-webkit-box',
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {g.meta.description}
+                </p>
+
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginTop: 12 }}>
+                  <span className={`mono ${changeClass(avgChange)}`} style={{ fontSize: '0.85rem' }}>
+                    {fmtPct(avgChange)}
+                  </span>
+                  <span className="caption" style={{ color: 'var(--text-4)', fontSize: '0.65rem' }}>
+                    avg 24h
+                  </span>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
       {/* Asset card grid */}
-      {filtered.length > 0 && (
+      {view === 'assets' && filtered.length > 0 && (
         <div
           style={{
             display: 'grid',
@@ -243,6 +386,13 @@ export default function Explore() {
       </p>
 
       {openAsset && <AssetModal asset={openAsset} onClose={() => setOpenAsset(null)} />}
+      {openGroup && (
+        <AssetGroupModal
+          assetClass={openGroup.assetClass}
+          assets={openGroup.members}
+          onClose={() => setOpenGroup(null)}
+        />
+      )}
     </div>
   )
 }

--- a/ui/src/components/PriceHistoryChart.jsx
+++ b/ui/src/components/PriceHistoryChart.jsx
@@ -21,7 +21,16 @@ export function fmtPrice(v) {
  * rather than a dollar price) override the y-axis / label formatting without
  * forking the chart.
  */
-export default function PriceHistoryChart({ points, loading, error, formatValue = fmtPrice }) {
+export default function PriceHistoryChart({
+  points,
+  loading,
+  error,
+  formatValue = fmtPrice,
+  // Callers can restore context lost when this chart was extracted from
+  // AssetModal (e.g. the single-asset modal's more specific 'on this asset'
+  // wording) without forking the component (review).
+  emptyHeadline = 'Historical chart unavailable for the selected range.',
+}) {
   const SVG_W = 720
   const SVG_H = 260
   const PAD_L = 56
@@ -48,7 +57,7 @@ export default function PriceHistoryChart({ points, loading, error, formatValue 
         }}
       >
         <div className="caption" style={{ color: 'var(--text-4)', textAlign: 'center', maxWidth: 380 }}>
-          Historical chart unavailable for the selected range.
+          {emptyHeadline}
           {error ? <><br /><span style={{ fontSize: '0.7rem', opacity: 0.7 }}>{error}</span></> : null}
         </div>
       </div>

--- a/ui/src/components/PriceHistoryChart.jsx
+++ b/ui/src/components/PriceHistoryChart.jsx
@@ -1,0 +1,153 @@
+// Shared SVG line-chart for a price/index time series. Extracted from
+// AssetModal.jsx (#464) so the grouped-asset detail view can reuse the exact
+// same charting approach instead of introducing a second pattern or a new
+// charting library.
+
+export function fmtPrice(v) {
+  if (v == null || Number.isNaN(v)) return '—'
+  if (v >= 1000) return `$${v.toFixed(0)}`
+  if (v >= 10) return `$${v.toFixed(2)}`
+  return `$${v.toFixed(4)}`
+}
+
+/**
+ * PriceHistoryChart — SVG line chart of one series of {ts, price} points.
+ *
+ * Honest fallback: when `points` is empty (range unsupported or upstream
+ * feed returned nothing) we render an explicit empty state. We never
+ * synthesize a flat line.
+ *
+ * `formatValue` lets callers (e.g. a group-index chart plotting a % change
+ * rather than a dollar price) override the y-axis / label formatting without
+ * forking the chart.
+ */
+export default function PriceHistoryChart({ points, loading, error, formatValue = fmtPrice }) {
+  const SVG_W = 720
+  const SVG_H = 260
+  const PAD_L = 56
+  const PAD_R = 18
+  const PAD_T = 16
+  const PAD_B = 36
+
+  if (loading) {
+    return (
+      <div style={{ height: SVG_H, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div className="caption" style={{ color: 'var(--text-4)' }}>Loading price history…</div>
+      </div>
+    )
+  }
+  if (error || !points || points.length === 0) {
+    return (
+      <div
+        style={{
+          height: SVG_H,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'var(--glass)',
+          border: '1px dashed var(--glass-border)',
+          borderRadius: 6,
+        }}
+      >
+        <div className="caption" style={{ color: 'var(--text-4)', textAlign: 'center', maxWidth: 380 }}>
+          Historical chart unavailable for the selected range.
+          {error ? <><br /><span style={{ fontSize: '0.7rem', opacity: 0.7 }}>{error}</span></> : null}
+        </div>
+      </div>
+    )
+  }
+
+  const prices = points.map(p => p.price)
+  const minP = Math.min(...prices)
+  const maxP = Math.max(...prices)
+  const range = maxP - minP || Math.max(1e-6, Math.abs(maxP) * 0.01)
+  // Light vertical padding so the line never touches the top/bottom border.
+  const yPad = range * 0.08
+
+  const toX = i => PAD_L + (i / Math.max(1, points.length - 1)) * (SVG_W - PAD_L - PAD_R)
+  const toY = p => SVG_H - PAD_B - ((p - minP + yPad) / (range + 2 * yPad)) * (SVG_H - PAD_T - PAD_B)
+
+  const linePath = points
+    .map((pt, i) => `${i === 0 ? 'M' : 'L'} ${toX(i).toFixed(1)} ${toY(pt.price).toFixed(1)}`)
+    .join(' ')
+  const areaPath =
+    `M ${toX(0).toFixed(1)} ${(SVG_H - PAD_B).toFixed(1)} ` +
+    points.map((pt, i) => `L ${toX(i).toFixed(1)} ${toY(pt.price).toFixed(1)}`).join(' ') +
+    ` L ${toX(points.length - 1).toFixed(1)} ${(SVG_H - PAD_B).toFixed(1)} Z`
+
+  // y-axis labels (5 ticks)
+  const yTicks = [0, 1, 2, 3, 4].map(i => {
+    const p = minP + (range * i) / 4
+    return { y: toY(p), label: formatValue(p) }
+  })
+
+  // x-axis labels (4 ticks at first/quarter/half/three-quarter/last)
+  const xTickIdx = [0, Math.floor((points.length - 1) / 3), Math.floor((2 * (points.length - 1)) / 3), points.length - 1]
+  // Heuristic: if the first two timestamps differ by less than a day, this
+  // is intraday data and we want HH:MM labels. Otherwise show MM-DD.
+  const isIntraday = (() => {
+    if (points.length < 2) return false
+    const a = Date.parse(points[0].ts.replace(' ', 'T'))
+    const b = Date.parse(points[1].ts.replace(' ', 'T'))
+    if (Number.isNaN(a) || Number.isNaN(b)) return false
+    return Math.abs(b - a) < 12 * 60 * 60 * 1000
+  })()
+  const xTicks = xTickIdx
+    .filter((idx, i, arr) => i === 0 || idx !== arr[i - 1])  // dedupe at edges
+    .map(idx => {
+      const tsStr = points[idx]?.ts || ''
+      // pandas Timestamps stringify as "2026-05-25 00:00:00+00:00" or
+      // "2026-05-25". Normalize and format based on intraday / daily.
+      const parsed = Date.parse(tsStr.replace(' ', 'T'))
+      let label = tsStr.slice(0, 10)
+      if (!Number.isNaN(parsed)) {
+        const d = new Date(parsed)
+        if (isIntraday) {
+          label = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+        } else {
+          label = `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+        }
+      }
+      return { x: toX(idx), label }
+    })
+
+  // Coloring: green if last > first, red otherwise — matches the 24h
+  // change badge convention.
+  const first = points[0].price
+  const last = points[points.length - 1].price
+  const stroke = last >= first ? 'var(--positive)' : 'var(--negative)'
+  const fill = last >= first ? 'rgba(34,197,94,0.10)' : 'rgba(239,68,68,0.10)'
+
+  return (
+    <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} width="100%" style={{ display: 'block', maxHeight: 320 }}>
+      {/* horizontal grid */}
+      {yTicks.map((t, i) => (
+        <line key={i} x1={PAD_L} y1={t.y} x2={SVG_W - PAD_R} y2={t.y}
+          stroke="var(--chart-grid)" strokeWidth="1" />
+      ))}
+      {/* axes */}
+      <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={SVG_H - PAD_B}
+        stroke="var(--chart-grid-strong)" strokeWidth="1" />
+      <line x1={PAD_L} y1={SVG_H - PAD_B} x2={SVG_W - PAD_R} y2={SVG_H - PAD_B}
+        stroke="var(--chart-grid-strong)" strokeWidth="1" />
+
+      {/* y-axis labels */}
+      {yTicks.map((t, i) => (
+        <text key={i} x={PAD_L - 6} y={t.y + 4} textAnchor="end"
+          fill="var(--chart-label)" fontSize="9" className="mono">
+          {t.label}
+        </text>
+      ))}
+      {/* x-axis labels */}
+      {xTicks.map((t, i) => (
+        <text key={i} x={t.x} y={SVG_H - PAD_B + 14} textAnchor="middle"
+          fill="var(--chart-label)" fontSize="9">
+          {t.label}
+        </text>
+      ))}
+
+      {/* area under the line */}
+      <path d={areaPath} fill={fill} stroke="none" />
+      {/* main line */}
+      <path d={linePath} fill="none" stroke={stroke} strokeWidth="1.8" strokeLinejoin="round" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
Explore listed every asset flat with a class filter pill, but no grouped view of what each asset_class bucket actually contains or represents. Add a card-per-group view with an icon, a plain-English description, and a detail modal showing the group's aggregated price history.

## Scope
New: `ui/src/assetGroups.js` (group metadata + descriptions), `ui/src/components/AssetGroupIcon.jsx`, `ui/src/components/AssetGroupModal.jsx`.
Modified: `ui/src/components/Explore.jsx` (wires in the card view), `ui/src/components/AssetModal.jsx` (chart extracted, see below).
Extracted: `ui/src/components/PriceHistoryChart.jsx` — the time-series chart already used by the single-asset detail view, pulled out so the new group detail view reuses the same charting code instead of a second implementation.

Grouping key is `asset_class`, the same field `/api/explore/assets` already returns and the existing filter pills already key on — there's no separate "category" concept in the backend today, so a card is one asset_class bucket. Noted this assumption directly in `assetGroups.js` for whoever extends it later.

Icons are inline SVG, no new dependency. `@iconify-json/*` packages are already in `package.json` but nothing in the app actually consumes them via `@iconify/react` — wiring that up for this would be a genuinely new dependency, not reuse of an existing one, so I didn't.

## Acceptance criteria
- [x] Grouped assets shown as cards by category.
- [x] Card detail view with a descriptive paragraph of what the group represents.
- [x] Group performance aggregated into a single time-series, same chart pattern as the single-asset view.

## Verify
`cd ui && npm run lint` — clean.
Manual: open `/explore`, confirm the card view renders one card per asset class, click through to the detail view, confirm the chart renders.

## Anti-goals
No new npm dependency. Didn't touch the single-asset detail view's behavior, only extracted its chart into a shared component.