### PR TITLE
[frontend][chain] Route vault deploy through the Circle bundler for passkey wallets

### DIFF
--- a/ui/src/components/CreateVaultModal.jsx
+++ b/ui/src/components/CreateVaultModal.jsx
@@ -42,7 +42,14 @@ function sendContractCall({ address, abi, functionName, args }) {
       smartAccount,
       client,
       calls: [encodeCall({ address, abi, functionName, args })],
-    }).then(out => ({ hash: out.txHash, logs: out.receipt.logs }))
+    }).then(out => ({
+      hash: out.txHash,
+      // executeUserOp only reaches here after receipt.success, so the bundled tx
+      // was mined — out.receipt.receipt (the real TransactionReceipt) always has
+      // .logs. The bundler-reported top-level out.receipt.logs is spec-optional
+      // and not every bundler populates it, so it's a fallback, not the primary.
+      logs: out.receipt.receipt?.logs ?? out.receipt.logs ?? [],
+    }))
   }
   return getWalletClient().then(async walletClient => {
     const hash = await walletClient.writeContract({ address, abi, functionName, args })

--- a/ui/src/components/CreateVaultModal.jsx
+++ b/ui/src/components/CreateVaultModal.jsx
@@ -3,12 +3,17 @@ import { createPortal } from 'react-dom'
 import DepositFlow from './DepositFlow'
 import {
   getWalletClient,
+  getConnectedProvider,
+  getSmartAccount,
+  getSmartAccountClient,
   publicClient,
   VAULT_ABI,
   VAULT_FACTORY_ABI,
   NEW_CONTRACTS,
+  CIRCLE_PROVIDER_ID,
 } from '../config'
 import { decodeEventLog } from 'viem'
+import { executeUserOp, encodeCall } from '../circle-tx-executor'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -18,6 +23,33 @@ const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 // persists vault metadata (off-chain) via POST /api/vaults/metadata so the
 // strategy↔vault link survives reloads. On success, hands off to DepositFlow
 // for the 3-step approve→deposit→allocate.
+//
+// Wallet routing (#1089): EOA wallets sign each call via viem writeContract;
+// passkey/Circle Modular Wallets sign via the bundler (executeUserOp). Unlike
+// DepositFlow's passkey path, createVault + setAgent canNOT be batched into
+// one user op — setAgent's target is the new vault's address, which only
+// exists after createVault has executed (plain CREATE inside the factory, no
+// precomputable CREATE2 address). So both wallet types take two sequential
+// signs here; sendContractCall just picks the right signer per call.
+function sendContractCall({ address, abi, functionName, args }) {
+  if (getConnectedProvider() === CIRCLE_PROVIDER_ID) {
+    const smartAccount = getSmartAccount()
+    const client = getSmartAccountClient()
+    if (!smartAccount || !client) {
+      throw new Error('Passkey wallet not initialized — please reconnect.')
+    }
+    return executeUserOp({
+      smartAccount,
+      client,
+      calls: [encodeCall({ address, abi, functionName, args })],
+    }).then(out => ({ hash: out.txHash, logs: out.receipt.logs }))
+  }
+  return getWalletClient().then(async walletClient => {
+    const hash = await walletClient.writeContract({ address, abi, functionName, args })
+    const receipt = await publicClient.waitForTransactionReceipt({ hash })
+    return { hash, logs: receipt.logs }
+  })
+}
 
 function nowPlusDays(days) {
   const d = new Date()
@@ -28,6 +60,10 @@ function nowPlusDays(days) {
 }
 
 export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel = 1, onClose, onDeployed }) {
+  // Passkey wallets confirm via WebAuthn, not a wallet extension popup —
+  // the button copy below should say so rather than "(sign in wallet)".
+  const signSuffix = getConnectedProvider() === CIRCLE_PROVIDER_ID ? '(confirm passkey)' : '(sign in wallet)'
+
   // Esc closes modal (Issue #338)
   useEffect(() => {
     const onKey = (e) => { if (e.key === 'Escape' && onClose) onClose() }
@@ -87,7 +123,7 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
 
   // Authorize the autonomous agent on the vault. Returns null on success, or an
   // error message on failure — the caller surfaces it rather than swallowing it.
-  const authorizeAgent = async (vaultAddress, walletClient) => {
+  const authorizeAgent = async (vaultAddress) => {
     try {
       // Read the factory's configured agent address
       const agentAddr = await publicClient.readContract({
@@ -96,13 +132,12 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
         functionName: 'agentAddress',
       })
       if (agentAddr && agentAddr !== '0x' + '0'.repeat(40)) {
-        const setAgentHash = await walletClient.writeContract({
+        await sendContractCall({
           address: vaultAddress,
           abi: VAULT_ABI,
           functionName: 'setAgent',
           args: [agentAddr],
         })
-        await publicClient.waitForTransactionReceipt({ hash: setAgentHash })
       }
       return null
     } catch (agentErr) {
@@ -116,8 +151,7 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
     if (!agentPending?.address) return
     setSubmitting(true)
     setDeployPhase('authorizing')
-    const walletClient = await getWalletClient()
-    const agentErr = await authorizeAgent(agentPending.address, walletClient)
+    const agentErr = await authorizeAgent(agentPending.address)
     setDeployPhase('')
     setSubmitting(false)
     if (agentErr) {
@@ -150,21 +184,18 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
     }
     setSubmitting(true)
     try {
-      const walletClient = await getWalletClient()
-
       // Step 1: Client-side createVault — user signs, so creator == user wallet
       setDeployPhase('creating')
-      const createHash = await walletClient.writeContract({
+      const { logs } = await sendContractCall({
         address: NEW_CONTRACTS.vaultFactory,
         abi: VAULT_FACTORY_ABI,
         functionName: 'createVault',
         args: [name, symbol, 0, 0, agentAssisted],
       })
 
-      // Wait for receipt and extract vault address from VaultCreated event
-      const receipt = await publicClient.waitForTransactionReceipt({ hash: createHash })
+      // Extract vault address from the VaultCreated event
       let vaultAddress = null
-      for (const log of receipt.logs) {
+      for (const log of logs) {
         try {
           const decoded = decodeEventLog({
             abi: VAULT_FACTORY_ABI,
@@ -184,7 +215,7 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
       let agentErr = null
       if (agentAssisted) {
         setDeployPhase('authorizing')
-        agentErr = await authorizeAgent(vaultAddress, walletClient)
+        agentErr = await authorizeAgent(vaultAddress)
       }
 
       // Step 3: Persist off-chain metadata (strategy↔vault link, creator wallet).
@@ -276,7 +307,7 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
               onClick={handleRetryAgent}
               disabled={submitting}
             >
-              {submitting ? 'Authorizing agent… (sign in wallet)' : 'Retry setAgent'}
+              {submitting ? `Authorizing agent… ${signSuffix}` : 'Retry setAgent'}
             </button>
           </div>
         </div>
@@ -403,8 +434,8 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
             title={!walletAddr ? 'Connect wallet to deploy' : ''}
           >
             {submitting
-              ? (deployPhase === 'creating' ? 'Creating vault… (sign in wallet)'
-                : deployPhase === 'authorizing' ? 'Authorizing agent… (sign in wallet)'
+              ? (deployPhase === 'creating' ? `Creating vault… ${signSuffix}`
+                : deployPhase === 'authorizing' ? `Authorizing agent… ${signSuffix}`
                 : deployPhase === 'metadata' ? 'Saving metadata…'
                 : 'Deploying…')
               : 'Create Vault'}

--- a/ui/src/components/CreateVaultModal.jsx
+++ b/ui/src/components/CreateVaultModal.jsx
@@ -193,9 +193,20 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
         args: [name, symbol, 0, 0, agentAssisted],
       })
 
-      // Extract vault address from the VaultCreated event
+      // Extract vault address from the VaultCreated event. Two guards beyond
+      // naive first-match decoding, because on the passkey path `logs` come
+      // from the BUNDLER transaction's receipt, which can contain logs from
+      // OTHER user operations batched into the same bundle:
+      //   1. only consider logs emitted by our VaultFactory address;
+      //   2. prefer the VaultCreated whose creator is this wallet (the smart
+      //      account is the factory's msg.sender on the passkey path), falling
+      //      back to the first factory VaultCreated (EOA receipts only ever
+      //      carry our own tx's logs, so the fallback preserves that path).
       let vaultAddress = null
+      const factoryAddr = NEW_CONTRACTS.vaultFactory?.toLowerCase()
+      const ourWallet = walletAddr?.toLowerCase()
       for (const log of logs) {
+        if (factoryAddr && log.address?.toLowerCase() !== factoryAddr) continue
         try {
           const decoded = decodeEventLog({
             abi: VAULT_FACTORY_ABI,
@@ -203,8 +214,11 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
             topics: log.topics,
           })
           if (decoded.eventName === 'VaultCreated') {
-            vaultAddress = decoded.args.vault
-            break
+            if (ourWallet && decoded.args.creator?.toLowerCase() === ourWallet) {
+              vaultAddress = decoded.args.vault
+              break
+            }
+            if (!vaultAddress) vaultAddress = decoded.args.vault
           }
         } catch { /* not our event */ }
       }


### PR DESCRIPTION
## Summary
Closes #1089. The Home CTA promotes passkey/Circle Modular Wallet sign-in for the Generate → Deploy journey, but `CreateVaultModal.handleDeploy` called `getWalletClient()` unconditionally — which throws `"This action is not yet wired for passkey wallets"` for any passkey session. A passkey user could generate a strategy (SIWE already branches correctly via `signSiweMessage`) but couldn't complete the "Deploy as Vault" step, which is where the onboarding path actually dead-ended.

## What changed
`DepositFlow.jsx` already has the right pattern: branch on `getConnectedProvider() === CIRCLE_PROVIDER_ID` and route through `executeUserOp`/`encodeCall` (the bundler wrapper) instead of `viem.writeContract`. `CreateVaultModal.jsx` never got that treatment.

Added a small `sendContractCall({ address, abi, functionName, args })` helper that picks the right signer per wallet type and returns `{ hash, logs }` either way, then swapped the three call sites (`handleDeploy`'s `createVault`, `authorizeAgent`'s `setAgent`, `handleRetryAgent`) to use it instead of `getWalletClient()` + `walletClient.writeContract`.

**Why not one batched user op** (like DepositFlow's single-prompt approve+deposit+setAllocations): `setAgent`'s target is the *new vault's* address, which doesn't exist until `createVault` executes — `VaultFactory` uses a plain `CREATE` (`new Vault(...)`), not a precomputable `CREATE2` address, so there's nothing to encode ahead of time. Both wallet types keep two sequential signs (same shape as EOA's two wallet popups today); passkey users see two WebAuthn prompts instead of one. No regression, just parity.

Also swapped the button-label suffix during signing (`"(sign in wallet)"` → `"(confirm passkey)"` for passkey sessions) so the copy doesn't imply a wallet-extension popup that won't appear.

## Scope check against the issue
- Outcome (1) from the issue (wire Generate *and* Deploy through the bundler) — done, not the fallback minimum bar.
- Generate itself needed no change — `ensureSiweSession` → `signSiweMessage` in `config.js` already branches correctly for passkey.
- `DepositFlow.jsx` / `circle-tx-executor.js` untouched — no regression risk to the existing deposit bundler wrapper (acceptance criterion 2).
- Anti-goals respected: no Circle secrets/bundler credentials touched; no contract changes (createVault's signature is unchanged, confirmed against `contracts/src/VaultFactory.sol`).

## Verified
- `./node_modules/.bin/eslint src/components/CreateVaultModal.jsx` → clean.
- `npm run build` → succeeds, no new warnings.
- Dev server (`npm run dev`) boots with no console errors; Home page confirms the passkey CTA copy this issue is about.
- **Not verified end-to-end**: an actual passkey deploy needs `VITE_CIRCLE_CLIENT_KEY` (not set in local `.env`) plus a real WebAuthn authenticator and testnet gas sponsorship — none available in this sandbox. This matches the issue's own Verify note ("connect a passkey wallet on archimedes-arc.com") — that leg needs a live-site manual check.

## Owner
Per the issue: wallet-execution/Circle-integration surface — flagging for Dan's review rather than merging on a single approval.