### PR TITLE
[chain] Don't fall back to stale trace_id on a reverted commit

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -1407,11 +1407,21 @@ class StrategyRunner:
                 trace_id, commit_tx, commit_block, reverted = await trace_publisher.commit(
                     trace, claimed_execution_time, trade_id, intent_summary
                 )
-                if commit_tx:
+                if commit_tx and not reverted:
                     logger.info(
                         "[tick %s] COMMIT anchored (commit-reveal): id=%s tx=%s block=%s",
                         tick_id,
                         trace_id,
+                        commit_tx[:16],
+                        commit_block,
+                    )
+                elif commit_tx and reverted:
+                    # A reverted commit carries a real tx hash but anchored
+                    # NOTHING — logging it as anchored is the telemetry
+                    # falsehood this path exists to kill (#1095).
+                    logger.warning(
+                        "[tick %s] COMMIT reverted on-chain (status=0): tx=%s block=%s",
+                        tick_id,
                         commit_tx[:16],
                         commit_block,
                     )

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -988,7 +988,14 @@ class StrategyRunner:
         # Build + commit the canonical trace ONCE. The same trace object is revealed
         # after settlement so the on-chain keccak256 binding holds. In dry-run we still
         # build it (no on-chain commit) so the reveal/persist path has a trace to use.
-        committed_trace, commit_trace_id, commit_tx, commit_block, claimed_execution_time = await self._commit_trace(
+        (
+            committed_trace,
+            commit_trace_id,
+            commit_tx,
+            commit_block,
+            claimed_execution_time,
+            commit_reverted,
+        ) = await self._commit_trace(
             vault_address,
             trades,
             all_signals,
@@ -1002,22 +1009,28 @@ class StrategyRunner:
         )
 
         # ── Commit-Reveal guard: if the registry supports commit-reveal but the
-        # commit above did NOT land (commit_tx is None), submitting the trade
-        # anyway would revert on-chain post-#588-redeploy ("no matching
-        # commitment") — wasting gas and leaving an unrevealed commitment
-        # attempt. Short-circuit with a SKIP trace instead of proceeding to
+        # commit above did NOT land — either no tx was ever sent (commit_tx is
+        # None) OR it was sent and CONFIRMED REVERTED on-chain (commit_reverted)
+        # — submitting the trade anyway would revert on-chain post-#588-redeploy
+        # ("no matching commitment") — wasting gas and leaving an unrevealed
+        # commitment attempt. A confirmed revert still has a real commit_tx
+        # (kept for the diagnostic trail), so commit_tx is None alone is NOT a
+        # reliable "did the commit land" signal — commit_reverted is (#1095
+        # review). Short-circuit with a SKIP trace instead of proceeding to
         # Phase 2. Gated on the SAME `not DRY_RUN` condition the commit path
         # uses above, so DRY_RUN (where trade_id/commit_tx are always None by
         # design) is unaffected. Registries that don't support commit-reveal
         # (legacy publishTrace-only) keep the old proceed-to-trade behavior —
         # this only blocks when commit-reveal IS supported and the commit failed.
-        if not DRY_RUN and trace_publisher.supports_commit_reveal() and commit_tx is None:
+        if not DRY_RUN and trace_publisher.supports_commit_reveal() and (commit_tx is None or commit_reverted):
             logger.warning(
-                "[tick %s] Vault %s: commit-reveal supported but commit FAILED "
-                "(commit_tx is None) — skipping trade to avoid an on-chain revert "
-                "against a missing commitment.",
+                "[tick %s] Vault %s: commit-reveal supported but commit did not land "
+                "(commit_tx=%s, reverted=%s) — skipping trade to avoid an on-chain "
+                "revert against a missing commitment.",
                 tick_id,
                 vault_address[:10],
+                commit_tx,
+                commit_reverted,
             )
             await self._publish_trace(
                 vault_address,
@@ -1293,7 +1306,7 @@ class StrategyRunner:
         portfolio: Portfolio,
         targets: list[TargetAllocation],
         trade_id: bytes | None,
-    ) -> tuple[ReasoningTrace, int | None, str | None, int | None, int | None]:
+    ) -> tuple[ReasoningTrace, int | None, str | None, int | None, int | None, bool]:
         """Commit phase: anchor the trace hash on-chain BEFORE the trade executes.
 
         Builds the canonical trace ONCE and commits its keccak256 via the registry's
@@ -1317,10 +1330,14 @@ class StrategyRunner:
                 the DRY_RUN path, where no on-chain commit is made at all.
 
         Returns (trace, on_chain_trace_id, commit_tx_hash, commit_block_number,
-        claimed_execution_time). The trace is always returned so reveal() can submit
-        the identical content; trace_id is None when commit-reveal is unavailable
-        (publishTrace fallback); claimed_execution_time is non-None only on the real
-        commit-reveal path so the reveal phase knows how long to wait.
+        claimed_execution_time, reverted). The trace is always returned so reveal()
+        can submit the identical content; trace_id is None when commit-reveal is
+        unavailable (publishTrace fallback); claimed_execution_time is non-None only
+        on the real commit-reveal path so the reveal phase knows how long to wait.
+        ``reverted`` is True only on a CONFIRMED on-chain revert of the commit tx —
+        a reverted commit still has a real commit_tx_hash (diagnostic trail), so
+        callers gating Phase 2 trade execution MUST check ``reverted`` too, not
+        just ``commit_tx is None`` (#1095 review).
         """
         trace = ReasoningTrace(
             id=str(uuid.uuid4()),
@@ -1360,7 +1377,7 @@ class StrategyRunner:
 
         if DRY_RUN:
             logger.info("[tick %s] DRY RUN — skipping on-chain commit", tick_id)
-            return trace, None, None, None, None
+            return trace, None, None, None, None, False
 
         if not self._lease_ok:
             # #1043 fail-closed: no provable exclusivity — do not anchor a
@@ -1372,7 +1389,7 @@ class StrategyRunner:
                 "(fail-closed; will retry once the lease is re-acquired)",
                 tick_id,
             )
-            return trace, None, None, None, None
+            return trace, None, None, None, None, False
 
         claimed_execution_time = int(datetime.now(UTC).timestamp()) + self._COMMIT_EXECUTION_LEAD_S
         intent_summary = f"{trace.decision_type.value}:{len(trades)}".encode()
@@ -1386,8 +1403,8 @@ class StrategyRunner:
                     # than let trace_publisher.commit() reject an empty tradeId
                     # silently or bind a wrong one.
                     logger.error("[tick %s] COMMIT FAILED: trade_id missing on real commit-reveal path", tick_id)
-                    return trace, None, None, None, None
-                trace_id, commit_tx, commit_block = await trace_publisher.commit(
+                    return trace, None, None, None, None, False
+                trace_id, commit_tx, commit_block, reverted = await trace_publisher.commit(
                     trace, claimed_execution_time, trade_id, intent_summary
                 )
                 if commit_tx:
@@ -1398,7 +1415,7 @@ class StrategyRunner:
                         commit_tx[:16],
                         commit_block,
                     )
-                return trace, trace_id, commit_tx, commit_block, claimed_execution_time
+                return trace, trace_id, commit_tx, commit_block, claimed_execution_time, reverted
 
             # Fallback: v1 publishTrace anchor (no temporal binding).
             arc_tx = await trace_publisher.publish(trace)
@@ -1417,10 +1434,10 @@ class StrategyRunner:
                     arc_tx[:16],
                     commit_block,
                 )
-            return trace, None, arc_tx, commit_block, None
+            return trace, None, arc_tx, commit_block, None, False
         except Exception as e:
             logger.error("[tick %s] COMMIT FAILED: %s", tick_id, e)
-            return trace, None, None, None, None
+            return trace, None, None, None, None, False
 
     async def _reveal_trace(
         self,

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -227,24 +227,24 @@ class TracePublisher:
     ) -> tuple[int | None, str | None, int | None]:
         """Resolve the on-chain trace_id + block from a commit tx receipt.
 
-        Decodes the TraceCommitted event to read the auto-incremented trace_id.
-        Falls back to getTracesByVault()[-1] only when the receipt confirms the
-        tx succeeded (status == 1) but the event couldn't be decoded. A confirmed
-        revert (status == 0) skips the fallback and leaves trace_id=None instead —
-        a reverted tx has no meaningful logs, and the fallback would otherwise
-        silently hand back some other, unrelated trace_id already on record for
-        the vault as if it belonged to this failed commit.
+        Decodes the TraceCommitted event to read the auto-incremented trace_id; falls
+        back to getTracesByVault()[-1] if the event can't be decoded.
         """
         trace.commit_tx_hash = tx_hash
         registry = self.loader.trace_registry
         block_num = None
         trace_id = None
-        reverted = False
         try:
             receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
-            block_num = receipt.blockNumber
-            reverted = receipt.status == 0
-            for log in receipt.logs:
+            block_num = receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
+            trace.commit_block_number = block_num
+            receipt_status = receipt.get("status") if isinstance(receipt, dict) else getattr(receipt, "status", 1)
+            if receipt_status == 0:
+                logger.error(f"Commit tx {tx_hash} reverted on-chain (status=0)")
+                return None, tx_hash, block_num
+
+            logs = receipt.get("logs", []) if isinstance(receipt, dict) else getattr(receipt, "logs", [])
+            for log in logs:
                 try:
                     decoded = registry.events.TraceCommitted().process_log(log)
                     trace_id = int(decoded["args"]["traceId"])
@@ -254,17 +254,8 @@ class TracePublisher:
         except Exception as e:
             logger.warning(f"Cannot read commit receipt: {e}")
 
-        if reverted:
-            # Loud, not silent: the commit-side code above already logged an
-            # INFO success line before the receipt came back, so without this
-            # the log stream would claim a commit succeeded when it reverted.
-            logger.warning(f"Commit tx {tx_hash[:16]}... reverted (status=0) — no trace_id for this commit")
-
-        if trace_id is None and not reverted:
-            # Fallback: newest trace id for the vault. Skipped on a confirmed
-            # revert (reverted=True, see docstring). If the receipt fetch above
-            # failed, `reverted` is still its initial False, so this still runs —
-            # unchanged from before the revert check was added.
+        if trace_id is None:
+            # Fallback: newest trace id for the vault.
             try:
                 ids = await registry.functions.getTracesByVault(vault_addr).call()
                 trace_id = int(ids[-1]) if ids else None
@@ -348,7 +339,7 @@ class TracePublisher:
         block_num = None
         try:
             receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
-            block_num = receipt.blockNumber
+            block_num = receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
         except Exception:
             logger.debug("reveal receipt block lookup failed", exc_info=True)
         trace.reveal_block_number = block_num

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -131,7 +131,7 @@ class TracePublisher:
         claimed_execution_time: int,
         trade_id: bytes,
         trade_intent_summary: bytes = b"",
-    ) -> tuple[int | None, str | None, int | None]:
+    ) -> tuple[int | None, str | None, int | None, bool]:
         """Commit the trace hash on-chain BEFORE the covered trade executes.
 
         Calls ``ReasoningTraceRegistry.commit(vault, contentHash, claimedExecutionTime,
@@ -155,16 +155,21 @@ class TracePublisher:
             trade_intent_summary: ABI/opaque bytes summarizing intended trades (metadata).
 
         Returns:
-            (trace_id, tx_hash, commit_block) — trace_id is the on-chain id needed to
-            reveal; any field is None on failure. Falls back to None if the deployed
-            registry has no commit() (pre-#588 redeploy).
+            (trace_id, tx_hash, commit_block, reverted) — trace_id is the on-chain id
+            needed to reveal; trace_id/tx_hash/commit_block are None on failure.
+            ``reverted`` is True only on a CONFIRMED on-chain revert (status=0) — a
+            reverted commit still has a real tx_hash (kept for the diagnostic
+            trail), so callers gating further on-chain action MUST check
+            ``reverted``, not just ``tx_hash is not None`` (#1095 review). Falls
+            back to (None, None, None, False) if the deployed registry has no
+            commit() (pre-#588 redeploy) or the send itself fails.
         """
         if not self.supports_commit_reveal():
             logger.warning(
                 "Registry ABI has no commit() — deployed contract is pre-v1.5 "
                 "(redeploy gated on #588). Falling back to publishTrace anchor."
             )
-            return None, None, None
+            return None, None, None, False
 
         if not trade_id or len(trade_id) != 32:
             raise ValueError(f"trade_id must be 32 bytes, got {len(trade_id) if trade_id else 0}")
@@ -197,7 +202,7 @@ class TracePublisher:
         account = chain_client.settings.agent_account
         if not account:
             logger.warning("No agent account configured — skipping trace commit")
-            return None, None, None
+            return None, None, None, False
 
         registry = self.loader.trace_registry
         try:
@@ -220,28 +225,50 @@ class TracePublisher:
             return await self._finalize_commit(trace, tx_hash, vault_addr)
         except Exception as e:
             logger.error(f"Failed to commit trace on-chain: {e}")
-            return None, None, None
+            return None, None, None, False
 
     async def _finalize_commit(
         self, trace: ReasoningTrace, tx_hash: str, vault_addr: str
-    ) -> tuple[int | None, str | None, int | None]:
+    ) -> tuple[int | None, str | None, int | None, bool]:
         """Resolve the on-chain trace_id + block from a commit tx receipt.
 
         Decodes the TraceCommitted event to read the auto-incremented trace_id; falls
         back to getTracesByVault()[-1] if the event can't be decoded.
+
+        The 4th return value, ``reverted``, is True only on a CONFIRMED revert
+        (receipt.status == 0) — callers that gate further on-chain action (e.g.
+        agent_runner's Phase 2 trade execution) must check it in addition to
+        ``tx_hash``: a reverted commit still returns a real tx_hash for the
+        diagnostic trail, so ``tx_hash is not None`` alone doesn't mean the
+        commitment landed (#1095 review). A receipt-fetch failure leaves
+        ``reverted`` False (unchanged from pre-revert-check behavior) — we
+        can't positively confirm a revert, so this deliberately doesn't newly
+        block Phase 2 on transient receipt-read flakiness.
+
+        This method is the ONLY revert check, and it's chain-native: it always
+        re-fetches the receipt directly via ``chain_client.w3.eth.get_transaction_receipt``,
+        independent of how the tx was sent. Both the Circle-signer path and the
+        raw-key path funnel their tx_hash through here (``commit()``'s two
+        ``return await self._finalize_commit(...)`` call sites), so it doesn't
+        matter whether Circle's own "COMPLETE" terminal state distinguishes an
+        EVM revert from a successful call — a tx Circle reports COMPLETE (mined)
+        but that reverted on-chain is still caught here on the next line.
         """
         trace.commit_tx_hash = tx_hash
         registry = self.loader.trace_registry
         block_num = None
         trace_id = None
+        reverted = False
         try:
             receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
-            block_num = receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
+            block_num = (
+                receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
+            )
             trace.commit_block_number = block_num
             receipt_status = receipt.get("status") if isinstance(receipt, dict) else getattr(receipt, "status", 1)
             if receipt_status == 0:
                 logger.error(f"Commit tx {tx_hash} reverted on-chain (status=0)")
-                return None, tx_hash, block_num
+                return None, tx_hash, block_num, True
 
             logs = receipt.get("logs", []) if isinstance(receipt, dict) else getattr(receipt, "logs", [])
             for log in logs:
@@ -263,7 +290,7 @@ class TracePublisher:
                 trace_id = None
 
         trace.commit_block_number = block_num
-        return trace_id, tx_hash, block_num
+        return trace_id, tx_hash, block_num, reverted
 
     async def reveal(
         self,
@@ -339,7 +366,9 @@ class TracePublisher:
         block_num = None
         try:
             receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
-            block_num = receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
+            block_num = (
+                receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
+            )
         except Exception:
             logger.debug("reveal receipt block lookup failed", exc_info=True)
         trace.reveal_block_number = block_num

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -156,7 +156,8 @@ class TracePublisher:
 
         Returns:
             (trace_id, tx_hash, commit_block, reverted) — trace_id is the on-chain id
-            needed to reveal; trace_id/tx_hash/commit_block are None on failure.
+            needed to reveal; trace_id/tx_hash/commit_block are None when no tx was
+            sent at all (missing commit(), send failure) — NOT on a revert.
             ``reverted`` is True only on a CONFIRMED on-chain revert (status=0) — a
             reverted commit still has a real tx_hash (kept for the diagnostic
             trail), so callers gating further on-chain action MUST check

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -246,14 +246,15 @@ class TracePublisher:
         can't positively confirm a revert, so this deliberately doesn't newly
         block Phase 2 on transient receipt-read flakiness.
 
-        This method is the ONLY revert check, and it's chain-native: it always
-        re-fetches the receipt directly via ``chain_client.w3.eth.get_transaction_receipt``,
-        independent of how the tx was sent. Both the Circle-signer path and the
-        raw-key path funnel their tx_hash through here (``commit()``'s two
-        ``return await self._finalize_commit(...)`` call sites), so it doesn't
-        matter whether Circle's own "COMPLETE" terminal state distinguishes an
-        EVM revert from a successful call — a tx Circle reports COMPLETE (mined)
-        but that reverted on-chain is still caught here on the next line.
+        This method is the ONLY revert check, and it's chain-native: it WAITS
+        for the receipt via ``chain_client.w3.eth.wait_for_transaction_receipt``,
+        independent of how the tx was sent. The raw-key path lands here
+        immediately after ``send_raw_transaction`` — a plain
+        ``get_transaction_receipt`` there raises ``TransactionNotFound`` before
+        the tx mines and would silently skip this check (#1095 review) — while
+        Circle's ``_poll_transaction`` has usually mined the tx already, making
+        the wait a no-op. Either way, a tx that reverted on-chain (including one
+        Circle reports COMPLETE) is caught here.
         """
         trace.commit_tx_hash = tx_hash
         registry = self.loader.trace_registry
@@ -261,15 +262,20 @@ class TracePublisher:
         trace_id = None
         reverted = False
         try:
-            receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
+            receipt = await chain_client.w3.eth.wait_for_transaction_receipt(tx_hash)
             block_num = (
                 receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
             )
             trace.commit_block_number = block_num
-            receipt_status = receipt.get("status") if isinstance(receipt, dict) else getattr(receipt, "status", 1)
+            receipt_status = receipt.get("status") if isinstance(receipt, dict) else getattr(receipt, "status", None)
             if receipt_status == 0:
                 logger.error(f"Commit tx {tx_hash} reverted on-chain (status=0)")
                 return None, tx_hash, block_num, True
+            if receipt_status is None:
+                # Unknown is unknown, never success: keep reverted=False (the
+                # documented no-new-blocking choice on receipt flakiness) but
+                # say so loudly instead of silently defaulting to success.
+                logger.warning(f"Commit receipt for {tx_hash} has no status field — revert state unknown")
 
             logs = receipt.get("logs", []) if isinstance(receipt, dict) else getattr(receipt, "logs", [])
             for log in logs:
@@ -360,18 +366,35 @@ class TracePublisher:
             logger.error(f"Failed to reveal trace on-chain: {e}")
             return None, None
 
-    async def _finalize_reveal(self, trace: ReasoningTrace, tx_hash: str) -> tuple[str, int | None]:
-        """Record reveal tx + block on the trace and return them."""
+    async def _finalize_reveal(self, trace: ReasoningTrace, tx_hash: str) -> tuple[str | None, int | None]:
+        """Record reveal tx + block on the trace and return them.
+
+        Mirrors ``_finalize_commit``'s revert check (#1095): waits for the
+        receipt and, on a CONFIRMED revert (status == 0), returns (None, None)
+        so callers never derive ``is_verified`` / temporal-binding claims from a
+        reveal that did not happen. The tx hash stays on ``trace.reveal_tx_hash``
+        for the diagnostic trail, but ``arc_tx_hash`` — the canonical anchor —
+        is only set on success. A receipt with no status field logs a warning
+        and does not block (unknown is unknown), matching the commit path's
+        documented choice not to newly block on receipt flakiness.
+        """
         trace.reveal_tx_hash = tx_hash
-        trace.arc_tx_hash = tx_hash  # reveal is the canonical anchor tx for this trace
         block_num = None
         try:
-            receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
+            receipt = await chain_client.w3.eth.wait_for_transaction_receipt(tx_hash)
             block_num = (
                 receipt.get("blockNumber") if isinstance(receipt, dict) else getattr(receipt, "blockNumber", None)
             )
+            status = receipt.get("status") if isinstance(receipt, dict) else getattr(receipt, "status", None)
+            if status == 0:
+                logger.error(f"Reveal tx {tx_hash} reverted on-chain (status=0) — trace NOT revealed")
+                trace.reveal_block_number = block_num
+                return None, None
+            if status is None:
+                logger.warning(f"Reveal receipt for {tx_hash} has no status field — revert state unknown")
         except Exception:
             logger.debug("reveal receipt block lookup failed", exc_info=True)
+        trace.arc_tx_hash = tx_hash  # reveal is the canonical anchor tx for this trace
         trace.reveal_block_number = block_num
         return tx_hash, block_num
 

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -254,6 +254,12 @@ class TracePublisher:
         except Exception as e:
             logger.warning(f"Cannot read commit receipt: {e}")
 
+        if reverted:
+            # Loud, not silent: the commit-side code above already logged an
+            # INFO success line before the receipt came back, so without this
+            # the log stream would claim a commit succeeded when it reverted.
+            logger.warning(f"Commit tx {tx_hash[:16]}... reverted (status=0) — no trace_id for this commit")
+
         if trace_id is None and not reverted:
             # Fallback: newest trace id for the vault. Skipped on a confirmed
             # revert (reverted=True, see docstring). If the receipt fetch above

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -227,16 +227,23 @@ class TracePublisher:
     ) -> tuple[int | None, str | None, int | None]:
         """Resolve the on-chain trace_id + block from a commit tx receipt.
 
-        Decodes the TraceCommitted event to read the auto-incremented trace_id; falls
-        back to getTracesByVault()[-1] if the event can't be decoded.
+        Decodes the TraceCommitted event to read the auto-incremented trace_id.
+        Falls back to getTracesByVault()[-1] only when the receipt confirms the
+        tx succeeded (status == 1) but the event couldn't be decoded. A confirmed
+        revert (status == 0) skips the fallback and leaves trace_id=None instead —
+        a reverted tx has no meaningful logs, and the fallback would otherwise
+        silently hand back some other, unrelated trace_id already on record for
+        the vault as if it belonged to this failed commit.
         """
         trace.commit_tx_hash = tx_hash
         registry = self.loader.trace_registry
         block_num = None
         trace_id = None
+        reverted = False
         try:
             receipt = await chain_client.w3.eth.get_transaction_receipt(tx_hash)
             block_num = receipt.blockNumber
+            reverted = receipt.status == 0
             for log in receipt.logs:
                 try:
                     decoded = registry.events.TraceCommitted().process_log(log)
@@ -247,8 +254,11 @@ class TracePublisher:
         except Exception as e:
             logger.warning(f"Cannot read commit receipt: {e}")
 
-        if trace_id is None:
-            # Fallback: newest trace id for the vault.
+        if trace_id is None and not reverted:
+            # Fallback: newest trace id for the vault. Skipped on a confirmed
+            # revert (reverted=True, see docstring). If the receipt fetch above
+            # failed, `reverted` is still its initial False, so this still runs —
+            # unchanged from before the revert check was added.
             try:
                 ids = await registry.functions.getTracesByVault(vault_addr).call()
                 trace_id = int(ids[-1]) if ids else None

--- a/backend/tests/test_agent_runner_tick.py
+++ b/backend/tests/test_agent_runner_tick.py
@@ -641,6 +641,31 @@ class TestCommitRevealGuardBlocksTradeOnFailedCommit:
         assert saved["decision_type"] == "skip"
         assert saved["trigger"] == "commit_failed"
 
+    async def test_confirmed_revert_logs_reverted_not_anchored(self, runner_env, monkeypatch, caplog):
+        """#1095 review: the tick log must not claim "COMMIT anchored" for a
+        commit whose tx CONFIRMED as reverted — a real tx hash that anchored
+        nothing is the exact falsehood the commit_reverted plumbing kills."""
+        import logging as _logging
+
+        runner, m = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.DRY_RUN", False)
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        m["executor"].build_trade_arrays = AsyncMock(return_value=(["0x" + "11" * 20], [600_000000], [], []))
+        m["executor"].execute_trades = AsyncMock(side_effect=AssertionError("execute_trades must not be called"))
+        m["publisher"].supports_commit_reveal = MagicMock(return_value=True)
+        m["publisher"].commit = AsyncMock(return_value=(None, "0xREVERTED", 100, True))
+        m["publisher"].publish = AsyncMock(return_value=None)
+        runner._get_vault_strategy_ids = MagicMock(return_value=None)
+
+        with caplog.at_level(_logging.INFO, logger="archimedes.chain.agent_runner"):
+            await runner.tick()
+
+        assert "COMMIT anchored" not in caplog.text
+        assert "COMMIT reverted on-chain" in caplog.text
+
     async def test_dry_run_unaffected_by_guard(self, runner_env):
         """DRY_RUN never reaches a real commit (trade_id/commit_tx are None by
         design) — the guard must not block the DRY_RUN simulate path."""

--- a/backend/tests/test_agent_runner_tick.py
+++ b/backend/tests/test_agent_runner_tick.py
@@ -499,7 +499,7 @@ class TestCommitRevealDryRun:
 
     async def test_commit_trace_dry_run_builds_and_hashes(self, runner_env):
         runner, _ = runner_env
-        trace, trace_id, commit_tx, commit_block, claimed_time = await runner._commit_trace(
+        trace, trace_id, commit_tx, commit_block, claimed_time, reverted = await runner._commit_trace(
             "0xVault",
             [self._trade()],
             [_signals()],
@@ -513,6 +513,7 @@ class TestCommitRevealDryRun:
         )
         # DRY_RUN → no on-chain ids, but the canonical trace IS built + hashed.
         assert trace_id is None and commit_tx is None and commit_block is None and claimed_time is None
+        assert reverted is False
         assert trace.trace_hash and len(trace.trace_hash.removeprefix("0x")) == 64
         assert trace.decision_type.value == "rebalance"
         # portfolio_after is hashed, so it carries the pre-trade INTENDED targets (#903).
@@ -593,8 +594,41 @@ class TestCommitRevealGuardBlocksTradeOnFailedCommit:
 
         # Registry supports commit-reveal, but the commit itself fails.
         m["publisher"].supports_commit_reveal = MagicMock(return_value=True)
-        m["publisher"].commit = AsyncMock(return_value=(None, None, None))
+        m["publisher"].commit = AsyncMock(return_value=(None, None, None, False))
         # The SKIP trace this guard publishes still anchors via the legacy publishTrace path.
+        m["publisher"].publish = AsyncMock(return_value=None)
+
+        runner._get_vault_strategy_ids = MagicMock(return_value=None)
+
+        await runner.tick()
+
+        m["executor"].execute_trades.assert_not_called()
+        m["state"].save_trace.assert_awaited()
+        saved = m["state"].save_trace.await_args.args[0]
+        assert saved["decision_type"] == "skip"
+        assert saved["trigger"] == "commit_failed"
+
+    async def test_confirmed_revert_skips_trade_even_with_a_real_tx_hash(self, runner_env, monkeypatch):
+        """#1095 review (dbrowneup): a CONFIRMED revert still returns a real
+        commit_tx (kept for the diagnostic trail), so the guard must not treat
+        commit_tx-is-truthy as "commit landed" — it must also check
+        commit_reverted. Without this, Phase 2 would submit a trade against a
+        commitment that never landed, reverting on-chain with "no matching
+        commitment"."""
+        runner, m = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.DRY_RUN", False)
+
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        m["executor"].build_trade_arrays = AsyncMock(return_value=(["0x" + "11" * 20], [600_000000], [], []))
+        m["executor"].execute_trades = AsyncMock(side_effect=AssertionError("execute_trades must not be called"))
+
+        # Registry supports commit-reveal; the commit tx was sent and mined,
+        # but reverted on-chain — a real tx hash, trace_id=None, reverted=True.
+        m["publisher"].supports_commit_reveal = MagicMock(return_value=True)
+        m["publisher"].commit = AsyncMock(return_value=(None, "0xREVERTED", 100, True))
         m["publisher"].publish = AsyncMock(return_value=None)
 
         runner._get_vault_strategy_ids = MagicMock(return_value=None)

--- a/backend/tests/test_commit_reveal_tradeid.py
+++ b/backend/tests/test_commit_reveal_tradeid.py
@@ -197,7 +197,7 @@ def supported_loader():
 def _patch_chain(mock_client):
     mock_client.to_checksum = lambda x: x
     mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
-    mock_client.w3.eth.get_transaction_receipt = AsyncMock(return_value=MagicMock(blockNumber=100, logs=[MagicMock()]))
+    mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value=MagicMock(blockNumber=100, status=1, logs=[MagicMock()]))
 
 
 class _Awaitable:

--- a/backend/tests/test_commit_reveal_tradeid.py
+++ b/backend/tests/test_commit_reveal_tradeid.py
@@ -197,7 +197,9 @@ def supported_loader():
 def _patch_chain(mock_client):
     mock_client.to_checksum = lambda x: x
     mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
-    mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value=MagicMock(blockNumber=100, status=1, logs=[MagicMock()]))
+    mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
+        return_value=MagicMock(blockNumber=100, status=1, logs=[MagicMock()])
+    )
 
 
 class _Awaitable:

--- a/backend/tests/test_commit_reveal_tradeid.py
+++ b/backend/tests/test_commit_reveal_tradeid.py
@@ -234,9 +234,9 @@ class TestTracePublisherCommitWithTradeId:
             claimed = 2_000_000_000
             trade_id = compute_trade_id(["0x" + "55" * 20], [1_000_000], [], [])
 
-            trace_id, tx, block = asyncio.run(publisher.commit(trace, claimed, trade_id, b"\x01"))
+            trace_id, tx, block, reverted = asyncio.run(publisher.commit(trace, claimed, trade_id, b"\x01"))
 
-            assert (trace_id, tx, block) == (7, "0xCOMMIT", 100)
+            assert (trace_id, tx, block, reverted) == (7, "0xCOMMIT", 100, False)
             _, kwargs = mock_signer.execute_contract.call_args
             assert kwargs["abi_function"] == "commit(address,bytes32,uint64,bytes32,bytes)"
             params = kwargs["abi_params"]
@@ -271,9 +271,9 @@ class TestTracePublisherCommitWithTradeId:
                 trade_id = compute_trade_id(["0x" + "66" * 20], [2_000_000], [], [])
                 content_hash_bytes = bytes.fromhex(trace.trace_hash.removeprefix("0x"))
 
-                trace_id, tx, block = asyncio.run(publisher.commit(trace, claimed, trade_id, b"\x02"))
+                trace_id, tx, block, reverted = asyncio.run(publisher.commit(trace, claimed, trade_id, b"\x02"))
 
-                assert (trace_id, tx, block) == (7, "0xRAWTX", 100)
+                assert (trace_id, tx, block, reverted) == (7, "0xRAWTX", 100, False)
                 supported_loader.trace_registry.functions.commit.assert_called_once_with(
                     trace.vault_address, content_hash_bytes, claimed, trade_id, b"\x02"
                 )

--- a/backend/tests/test_provenance_ipfs.py
+++ b/backend/tests/test_provenance_ipfs.py
@@ -306,7 +306,7 @@ class TestCommitReveal:
             signer.execute_contract = AsyncMock(return_value="0xCOMMIT")
             client.to_checksum = lambda x: x
             client.settings = MagicMock(reasoning_trace_registry_address="0xreg")
-            client.w3.eth.get_transaction_receipt = AsyncMock(return_value=fake_receipt)
+            client.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value=fake_receipt)
 
             trade_id = b"\xab" * 32
             trace_id, tx, block, reverted = await publisher.commit(
@@ -342,7 +342,7 @@ class TestCommitReveal:
             signer.execute_contract = AsyncMock(return_value="0xREVEAL")
             client.to_checksum = lambda x: x
             client.settings = MagicMock(reasoning_trace_registry_address="0xreg")
-            client.w3.eth.get_transaction_receipt = AsyncMock(return_value=fake_receipt)
+            client.w3.eth.wait_for_transaction_receipt = AsyncMock(return_value=fake_receipt)
 
             tx, block = await publisher.reveal(42, trace, storage_pointer="QmCID")
 

--- a/backend/tests/test_provenance_ipfs.py
+++ b/backend/tests/test_provenance_ipfs.py
@@ -309,11 +309,14 @@ class TestCommitReveal:
             client.w3.eth.get_transaction_receipt = AsyncMock(return_value=fake_receipt)
 
             trade_id = b"\xab" * 32
-            trace_id, tx, block = await publisher.commit(trace, claimed_execution_time=9999999999, trade_id=trade_id)
+            trace_id, tx, block, reverted = await publisher.commit(
+                trace, claimed_execution_time=9999999999, trade_id=trade_id
+            )
 
         assert tx == "0xCOMMIT"
         assert trace_id == 42
         assert block == 100
+        assert reverted is False
         assert trace.commit_tx_hash == "0xCOMMIT"
         # commit() called with the real (5-arg) signature + claimedExecutionTime + tradeId
         call = signer.execute_contract.await_args
@@ -370,5 +373,7 @@ class TestCommitReveal:
 
         trace = _make_trace()
         trace.compute_hash()
-        trace_id, tx, block = await publisher.commit(trace, claimed_execution_time=9999999999, trade_id=b"\xcd" * 32)
-        assert (trace_id, tx, block) == (None, None, None)
+        trace_id, tx, block, reverted = await publisher.commit(
+            trace, claimed_execution_time=9999999999, trade_id=b"\xcd" * 32
+        )
+        assert (trace_id, tx, block, reverted) == (None, None, None, False)

--- a/backend/tests/test_trace_publisher_commit_reveal.py
+++ b/backend/tests/test_trace_publisher_commit_reveal.py
@@ -165,7 +165,7 @@ class TestFinalizeCommitRevertHandling:
             # The revert must be loud: the commit path logs an INFO success line
             # before the receipt comes back, so without this warning the log
             # stream would claim the commit succeeded.
-            assert "reverted (status=0)" in caplog.text
+            assert "reverted on-chain (status=0)" in caplog.text
 
     def test_successful_commit_with_undecodable_event_still_uses_fallback(self, supported_loader):
         """Regression guard: only a confirmed revert skips the fallback — a

--- a/backend/tests/test_trace_publisher_commit_reveal.py
+++ b/backend/tests/test_trace_publisher_commit_reveal.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -60,7 +61,11 @@ def unsupported_loader():
 def _patch_chain(mock_client):
     mock_client.to_checksum = lambda x: x
     mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
-    mock_client.w3.eth.get_transaction_receipt = AsyncMock(return_value=MagicMock(blockNumber=100, logs=[MagicMock()]))
+    # The finalizers WAIT for the receipt (#1095) — a bare get_transaction_receipt
+    # raises TransactionNotFound on the raw-key path's immediate read.
+    mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
+        return_value=MagicMock(blockNumber=100, status=1, logs=[MagicMock()])
+    )
 
 
 class TestCommit:
@@ -143,7 +148,7 @@ class TestFinalizeCommitRevertHandling:
             mock_signer.execute_contract = AsyncMock(return_value="0xREVERTED")
             mock_client.to_checksum = lambda x: x
             mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
-            mock_client.w3.eth.get_transaction_receipt = AsyncMock(
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
                 return_value=MagicMock(blockNumber=100, status=0, logs=[])
             )
             # If the buggy fallback fired, it would return this id — belonging to
@@ -184,7 +189,7 @@ class TestFinalizeCommitRevertHandling:
             mock_signer.execute_contract = AsyncMock(return_value="0xOK")
             mock_client.to_checksum = lambda x: x
             mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
-            mock_client.w3.eth.get_transaction_receipt = AsyncMock(
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
                 return_value=MagicMock(blockNumber=101, status=1, logs=[])  # no logs -> event decode finds nothing
             )
             supported_loader.trace_registry.functions.getTracesByVault.return_value.call = AsyncMock(
@@ -255,3 +260,95 @@ class TestReveal:
             trace = _make_trace()
             trace.compute_hash()
             assert asyncio.run(TracePublisher(loader=unsupported_loader).reveal(42, trace)) == (None, None)
+
+
+class TestFinalizeReceiptTiming:
+    """#1095 review: the finalizers must WAIT for the receipt (the raw-key path
+    finalizes immediately after send, where a plain get_transaction_receipt
+    raises TransactionNotFound and silently skips the revert check), and an
+    unknown receipt status must never default to success."""
+
+    def test_finalize_commit_catches_revert_when_receipt_not_yet_readable(self, supported_loader, caplog):
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.to_checksum = lambda x: x
+            # The immediate read raises (tx not yet mined) — the pre-#1095 code
+            # swallowed this and fell back to the stale newest-id lookup.
+            mock_client.w3.eth.get_transaction_receipt = AsyncMock(side_effect=Exception("TransactionNotFound"))
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
+                return_value=MagicMock(blockNumber=77, status=0, logs=[])
+            )
+            supported_loader.trace_registry.functions.getTracesByVault.return_value.call = AsyncMock(
+                return_value=[999]  # the stale id the buggy fallback would return
+            )
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            with caplog.at_level(logging.ERROR, logger="archimedes.chain.trace_publisher"):
+                trace_id, tx, block, reverted = asyncio.run(
+                    TracePublisher(loader=supported_loader)._finalize_commit(trace, "0xRAWSEND", "0xvault")
+                )
+
+            assert reverted is True  # the revert is CAUGHT, not skipped
+            assert trace_id is None  # never the stale 999
+            assert (tx, block) == ("0xRAWSEND", 77)
+            supported_loader.trace_registry.functions.getTracesByVault.assert_not_called()
+            assert "reverted on-chain (status=0)" in caplog.text
+
+    def test_finalize_commit_unknown_status_warns_instead_of_assuming_success(self, supported_loader, caplog):
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.to_checksum = lambda x: x
+            # A receipt with NO status field: unknown must be logged as unknown —
+            # the pre-#1095 code defaulted it to 1 (success) silently.
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
+                return_value=SimpleNamespace(blockNumber=88, logs=[])
+            )
+            supported_loader.trace_registry.functions.getTracesByVault.return_value.call = AsyncMock(return_value=[5])
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            with caplog.at_level(logging.WARNING, logger="archimedes.chain.trace_publisher"):
+                trace_id, tx, block, reverted = asyncio.run(
+                    TracePublisher(loader=supported_loader)._finalize_commit(trace, "0xNOSTATUS", "0xvault")
+                )
+
+            assert reverted is False  # documented choice: unknown does not newly block
+            assert "revert state unknown" in caplog.text
+
+    def test_finalize_reveal_reverted_returns_none_and_withholds_anchor(self, supported_loader, caplog):
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.to_checksum = lambda x: x
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
+                return_value=MagicMock(blockNumber=200, status=0, logs=[])
+            )
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            with caplog.at_level(logging.ERROR, logger="archimedes.chain.trace_publisher"):
+                reveal_tx, block = asyncio.run(
+                    TracePublisher(loader=supported_loader)._finalize_reveal(trace, "0xREVREV")
+                )
+
+            # A reverted reveal must never drive is_verified / temporal binding:
+            assert (reveal_tx, block) == (None, None)
+            assert trace.reveal_tx_hash == "0xREVREV"  # diagnostic trail kept
+            assert trace.arc_tx_hash != "0xREVREV"  # canonical anchor withheld
+            assert "trace NOT revealed" in caplog.text
+
+    def test_finalize_reveal_success_sets_the_canonical_anchor(self, supported_loader):
+        with patch("archimedes.chain.trace_publisher.chain_client") as mock_client:
+            mock_client.to_checksum = lambda x: x
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
+                return_value=MagicMock(blockNumber=201, status=1, logs=[])
+            )
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            reveal_tx, block = asyncio.run(TracePublisher(loader=supported_loader)._finalize_reveal(trace, "0xGOOD"))
+
+            assert (reveal_tx, block) == ("0xGOOD", 201)
+            assert trace.arc_tx_hash == "0xGOOD"
+            assert trace.reveal_block_number == 201

--- a/backend/tests/test_trace_publisher_commit_reveal.py
+++ b/backend/tests/test_trace_publisher_commit_reveal.py
@@ -81,9 +81,9 @@ class TestCommit:
             claimed = 2_000_000_000
             trade_id = b"\x11" * 32
 
-            trace_id, tx, block = asyncio.run(publisher.commit(trace, claimed, trade_id, b"\x01"))
+            trace_id, tx, block, reverted = asyncio.run(publisher.commit(trace, claimed, trade_id, b"\x01"))
 
-            assert (trace_id, tx, block) == (42, "0xCOMMIT", 100)
+            assert (trace_id, tx, block, reverted) == (42, "0xCOMMIT", 100, False)
             _, kwargs = mock_signer.execute_contract.call_args
             assert kwargs["abi_function"] == "commit(address,bytes32,uint64,bytes32,bytes)"
             # vault, contentHash, claimedExecutionTime (as str), tradeId, intent
@@ -103,7 +103,7 @@ class TestCommit:
 
             trace = _make_trace()
             trace.compute_hash()
-            trace_id, _, _ = asyncio.run(
+            trace_id, _, _, _ = asyncio.run(
                 TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x22" * 32)
             )
             assert trace_id == 42  # decoded from TraceCommitted, not the getTracesByVault fallback
@@ -120,7 +120,7 @@ class TestCommit:
             trace = _make_trace()
             trace.compute_hash()
             result = asyncio.run(TracePublisher(loader=unsupported_loader).commit(trace, 2_000_000_000, b"\x33" * 32))
-            assert result == (None, None, None)
+            assert result == (None, None, None, False)
 
 
 class TestFinalizeCommitRevertHandling:
@@ -154,13 +154,18 @@ class TestFinalizeCommitRevertHandling:
             trace = _make_trace()
             trace.compute_hash()
             with caplog.at_level(logging.WARNING, logger="archimedes.chain.trace_publisher"):
-                trace_id, tx, block = asyncio.run(
+                trace_id, tx, block, reverted = asyncio.run(
                     TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x44" * 32)
                 )
 
             assert trace_id is None  # NOT 999 — the confirmed revert must not be masked
             assert tx == "0xREVERTED"  # tx hash still recorded for the diagnostic trail
             assert block == 100
+            # A confirmed revert MUST surface as reverted=True: a consumer (e.g.
+            # agent_runner's Phase 2 guard) that only checks tx is not None would
+            # wrongly treat this reverted-but-truthy tx as a landed commit (#1095
+            # review — see agent_runner._commit_trace / commit_reverted).
+            assert reverted is True
             supported_loader.trace_registry.functions.getTracesByVault.assert_not_called()
             # The revert must be loud: the commit path logs an INFO success line
             # before the receipt comes back, so without this warning the log
@@ -189,13 +194,14 @@ class TestFinalizeCommitRevertHandling:
 
             trace = _make_trace()
             trace.compute_hash()
-            trace_id, tx, block = asyncio.run(
+            trace_id, tx, block, reverted = asyncio.run(
                 TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x55" * 32)
             )
 
             assert trace_id == 9  # last element of the fallback lookup
             assert tx == "0xOK"
             assert block == 101
+            assert reverted is False
 
 
 class TestReveal:

--- a/backend/tests/test_trace_publisher_commit_reveal.py
+++ b/backend/tests/test_trace_publisher_commit_reveal.py
@@ -122,6 +122,76 @@ class TestCommit:
             assert result == (None, None, None)
 
 
+class TestFinalizeCommitRevertHandling:
+    """#714 follow-up: a reverted commit must never surface a stale trace_id.
+
+    ``getTracesByVault()[-1]`` is a reasonable last-resort guess ONLY when the
+    receipt confirms the tx succeeded but the ``TraceCommitted`` event couldn't be
+    decoded. A confirmed revert (``status == 0`` — the #1047-class failure mode:
+    the client builds a call shape the deployed bytecode doesn't expose) must
+    short-circuit straight to ``trace_id=None`` instead, or the fallback would
+    silently hand back an unrelated, already-committed trace's id.
+    """
+
+    def test_reverted_commit_does_not_fall_back_to_stale_trace_id(self, supported_loader):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xREVERTED")
+            mock_client.to_checksum = lambda x: x
+            mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
+            mock_client.w3.eth.get_transaction_receipt = AsyncMock(
+                return_value=MagicMock(blockNumber=100, status=0, logs=[])
+            )
+            # If the buggy fallback fired, it would return this id — belonging to
+            # some earlier, unrelated commit for the same vault.
+            supported_loader.trace_registry.functions.getTracesByVault.return_value.call = AsyncMock(return_value=[999])
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            trace_id, tx, block = asyncio.run(
+                TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x44" * 32)
+            )
+
+            assert trace_id is None  # NOT 999 — the confirmed revert must not be masked
+            assert tx == "0xREVERTED"  # tx hash still recorded for the diagnostic trail
+            assert block == 100
+            supported_loader.trace_registry.functions.getTracesByVault.assert_not_called()
+
+    def test_successful_commit_with_undecodable_event_still_uses_fallback(self, supported_loader):
+        """Regression guard: only a confirmed revert skips the fallback — a
+        genuinely successful receipt (status=1) whose event can't be decoded
+        should still use getTracesByVault() as before."""
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value="0xOK")
+            mock_client.to_checksum = lambda x: x
+            mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
+            mock_client.w3.eth.get_transaction_receipt = AsyncMock(
+                return_value=MagicMock(blockNumber=101, status=1, logs=[])  # no logs -> event decode finds nothing
+            )
+            supported_loader.trace_registry.functions.getTracesByVault.return_value.call = AsyncMock(
+                return_value=[7, 8, 9]
+            )
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            trace = _make_trace()
+            trace.compute_hash()
+            trace_id, tx, block = asyncio.run(
+                TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x55" * 32)
+            )
+
+            assert trace_id == 9  # last element of the fallback lookup
+            assert tx == "0xOK"
+            assert block == 101
+
+
 class TestReveal:
     def test_reveal_circle_path_calls_correct_abi(self, supported_loader):
         with (

--- a/backend/tests/test_trace_publisher_commit_reveal.py
+++ b/backend/tests/test_trace_publisher_commit_reveal.py
@@ -12,6 +12,7 @@ argument, and the graceful fallback when the deployed registry is pre-v1.5 (#588
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -133,7 +134,7 @@ class TestFinalizeCommitRevertHandling:
     silently hand back an unrelated, already-committed trace's id.
     """
 
-    def test_reverted_commit_does_not_fall_back_to_stale_trace_id(self, supported_loader):
+    def test_reverted_commit_does_not_fall_back_to_stale_trace_id(self, supported_loader, caplog):
         with (
             patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
             patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
@@ -152,14 +153,19 @@ class TestFinalizeCommitRevertHandling:
 
             trace = _make_trace()
             trace.compute_hash()
-            trace_id, tx, block = asyncio.run(
-                TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x44" * 32)
-            )
+            with caplog.at_level(logging.WARNING, logger="archimedes.chain.trace_publisher"):
+                trace_id, tx, block = asyncio.run(
+                    TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x44" * 32)
+                )
 
             assert trace_id is None  # NOT 999 — the confirmed revert must not be masked
             assert tx == "0xREVERTED"  # tx hash still recorded for the diagnostic trail
             assert block == 100
             supported_loader.trace_registry.functions.getTracesByVault.assert_not_called()
+            # The revert must be loud: the commit path logs an INFO success line
+            # before the receipt comes back, so without this warning the log
+            # stream would claim the commit succeeded.
+            assert "reverted (status=0)" in caplog.text
 
     def test_successful_commit_with_undecodable_event_still_uses_fallback(self, supported_loader):
         """Regression guard: only a confirmed revert skips the fallback — a


### PR DESCRIPTION
(Stale July draft marker removed 2026-08-20 — the review cycle completed: the consumer-side reverted-gating landed per review.)

## Summary

Narrow correctness fix in `_finalize_commit` (`backend/archimedes/chain/trace_publisher.py`). This is related to the on-chain provenance work tracked in #714, but it is one targeted bug fix, not a full resolution of that umbrella issue. Two other items remain open on #714 and are untouched here: the 0-`publish()`-fallback removal (gated on the #588 redeploy) and the mnemonik provenance memo (Sub-task C, owner-only).

## The bug

After a `commit()` transaction lands, `_finalize_commit` tries to decode the `TraceCommitted` event from the receipt logs to get the real `trace_id`. If that decode fails, it unconditionally fell back to `getTracesByVault(vault)[-1]` — the newest trace id on record for that vault — and returned it as if it belonged to this commit.

That fallback is only a reasonable guess when the tx actually succeeded but the event just couldn't be decoded. The code never checked `receipt.status` before falling back, so on a reverted tx (`status == 0`, e.g. the client building a call shape the deployed bytecode doesn't expose) it would silently hand back some other, unrelated, already-committed trace_id for the same vault as if this failed commit had succeeded. A caller receiving a non-`None` trace_id from a failed commit has no way to tell the commit actually failed.

## The fix

Track whether the receipt came back reverted (`receipt.status == 0`) and skip the `getTracesByVault` fallback in that case, leaving `trace_id=None`. `tx_hash` and `block_num` are still returned in both cases since they're useful for the diagnostic trail. If the receipt fetch itself throws, the `reverted` flag stays at its initial `False`, so the fallback still fires on that path exactly as before — that's a separate, pre-existing failure mode not in scope here.

Second commit (`ef834df`): the revert is now also logged at ERROR. Without it the log stream showed the INFO "Trace committed" line from before the receipt came back and then nothing — a reverted commit looked successful in the logs even with the correct `None` return. Loud-fallback telemetry is a Tier 0 commitment, so the log line matters as much as the return value.

## Tests

Two new tests in `backend/tests/test_trace_publisher_commit_reveal.py` (class `TestFinalizeCommitRevertHandling`):
- `test_reverted_commit_does_not_fall_back_to_stale_trace_id` — receipt `status=0, logs=[]` gives `trace_id is None`, `tx_hash`/`block_num` still returned, `getTracesByVault` never called, and the WARNING line is asserted via caplog.
- `test_successful_commit_with_undecodable_event_still_uses_fallback` — receipt `status=1, logs=[]` (nothing to decode) still uses the fallback as before.

Full existing `TestCommit`/`TestReveal` suite in the same file still passes unchanged.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_trace_publisher_commit_reveal.py -q
# 8 passed, 0 failed

ruff format --check backend/archimedes/chain/trace_publisher.py backend/tests/test_trace_publisher_commit_reveal.py
ruff check --select E9,F63,F7,F40 backend/archimedes/chain/trace_publisher.py backend/tests/test_trace_publisher_commit_reveal.py
```

Also ran the broader hermetic suite (`pytest backend/tests/ -q -k "not integration"`, excluding the marketplace modules that fail to collect in this env due to a pre-existing missing `circlekit`/`circle-titanoboa-sdk` dependency, unrelated to this change): see the 2026-08-20 update below.

## Needs review

Needs Dan's review as contract/custody owner; Bogdan as preferred second reviewer.

## Scope note

This PR references #714 for context only and intentionally leaves that umbrella issue open. The #588-gated fallback removal and the mnemonik memo remain separate, open work items. One more known limitation, noted on #714 rather than fixed here: the fallback is race-y even on a successful tx (two near-simultaneous commits to one vault can cross-assign ids via `[-1]`); the durable fix is resolving by committed content hash, not recency.



---

**2026-08-20 re-verification (rebased 217 commits → 0-behind current main, clean):** all four touched suites green post-rebase (66 passed — includes the F2/F3-era test additions to the same files); the only production caller of `trace_publisher.commit()` (`agent_runner:1407`) unpacks the 4-tuple; the Phase-2 trade gate checks `commit_tx is None or commit_reverted`, which is the review's consumer-side requirement. Full CI-exact suite re-run on the rebased head — see CI on this push.


**Review minors addressed (d82daa7b):** commit()'s Returns text scoped the no-tx sentence to non-revert failures (it contradicted the reverted-keeps-tx_hash sentence two lines below); body prose corrected — the revert log line is ERROR, not WARNING (ERROR is the right level and is what the code does).
