### PR TITLE
[agent-ui] Agent journey: deploy + monitor + hermetic tests (#788) !minor

### DIFF
--- a/backend/tests/scripts/test_agent_journey_deploy.py
+++ b/backend/tests/scripts/test_agent_journey_deploy.py
@@ -1,0 +1,344 @@
+"""DEPLOY + MONITOR unit coverage for the agent journey harness (#788 slice 2).
+
+Target: scripts/agent_journey.py (repo root — loaded via importlib, it isn't a
+package). Mirrors test_agent_journey_siwe.py's loader pattern. Three surfaces:
+
+  1. ``build_vault_create_payload`` — a pure function. Cross-checked here
+     against the REAL ``VaultCreateRequest`` Pydantic model
+     (``archimedes.api.vault_schemas``), which is what
+     ``vaults_routes.py::create_vault`` binds ``POST /api/vaults/create``'s
+     body to — so a field-name/constraint drift between the harness and the
+     live route fails THIS test, not a live 422 while dogfooding.
+  2. ``step_deploy`` — the rigor-gate refusal (never call the endpoint for a
+     missing/non-deployable winner — the #788 anti-goal: never weaken or
+     bypass the rigor gate), the dry-run default (never call the endpoint
+     without ``execute=True``), and the execute path's success/failure
+     handling. ``client`` is a ``MagicMock`` throughout — no network, no
+     ASGI, no live server.
+  3. ``step_monitor`` — the read-only vault-health GET, mocked the same way.
+
+Hermetic: no network, no Redis/Postgres, no live server, no async ASGI
+context. The only real import is the Pydantic model itself (a pure schema
+class with no DB/network side effects at import time).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_agent_journey():
+    """Import scripts/agent_journey.py from the repo root by file path."""
+    path = _REPO_ROOT / "scripts" / "agent_journey.py"
+    spec = importlib.util.spec_from_file_location("agent_journey", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["agent_journey"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+aj = _load_agent_journey()
+
+# A live-gate-deployable winner, shaped exactly like step_readback's return.
+_DEPLOYABLE_WINNER = {
+    "strategy_id": "strat-abc",
+    "strategy_name": "Momentum Fusion",
+    "rigor_gate_status": "pass",
+    "deployable": True,
+}
+
+
+def _deploy_kwargs(**overrides):
+    kwargs = {
+        "vault_name": "Test Vault",
+        "vault_symbol": "TESTV",
+        "management_fee_bps": 0,
+        "performance_fee_bps": 0,
+        "strictness_level": 1,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _expected_payload(winner=_DEPLOYABLE_WINNER, **overrides):
+    """The payload step_deploy is expected to build + send for the given winner
+    and (possibly overridden) deploy kwargs — used to assert the exact POST body.
+    """
+    kwargs = _deploy_kwargs(**overrides)
+    return aj.build_vault_create_payload(
+        strategy_id=winner["strategy_id"],
+        name=kwargs["vault_name"],
+        symbol=kwargs["vault_symbol"],
+        management_fee_bps=kwargs["management_fee_bps"],
+        performance_fee_bps=kwargs["performance_fee_bps"],
+        strictness_level=kwargs["strictness_level"],
+    )
+
+
+# ── build_vault_create_payload — cross-checked against the real route contract ──
+
+
+def test_payload_field_names_match_vault_create_request_exactly():
+    """No stray keys, no missing keys — the two must name the same fields.
+
+    A drift here (the route adds/renames a field the harness doesn't know
+    about, or the harness invents one Pydantic doesn't) fails THIS test
+    instead of surfacing as a live 422 while dogfooding.
+    """
+    from archimedes.api.vault_schemas import VaultCreateRequest
+
+    payload = aj.build_vault_create_payload(strategy_id="s1", name="Vault", symbol="VLT")
+    assert set(payload.keys()) == set(VaultCreateRequest.model_fields.keys())
+
+
+def test_payload_is_accepted_by_the_real_pydantic_model():
+    """Construct the REAL request model straight from the payload — proves
+    Pydantic binding (the first thing the live route does to the body)
+    accepts the harness's shape and preserves every value."""
+    from archimedes.api.vault_schemas import VaultCreateRequest
+
+    payload = aj.build_vault_create_payload(
+        strategy_id="strat-123",
+        name="Agent Journey Vault",
+        symbol="AGTJRN",
+        management_fee_bps=50,
+        performance_fee_bps=1000,
+        strictness_level=3,
+    )
+    req = VaultCreateRequest(**payload)
+    assert req.name == "Agent Journey Vault"
+    assert req.symbol == "AGTJRN"
+    assert req.management_fee_bps == 50
+    assert req.performance_fee_bps == 1000
+    assert req.strategy_ids == ["strat-123"]
+    assert req.strictness_level == 3
+    assert req.agent_assisted is True
+
+
+def test_payload_defaults_zero_fees_strictest_level_agent_assisted():
+    from archimedes.api.vault_schemas import VaultCreateRequest
+
+    payload = aj.build_vault_create_payload(strategy_id="s1", name="V", symbol="V1")
+    req = VaultCreateRequest(**payload)
+    assert req.management_fee_bps == 0
+    assert req.performance_fee_bps == 0
+    assert req.strictness_level == 1
+    assert req.agent_assisted is True
+
+
+def test_payload_wraps_the_single_strategy_id_in_a_list():
+    payload = aj.build_vault_create_payload(strategy_id="only-one", name="V", symbol="V1")
+    assert payload["strategy_ids"] == ["only-one"]
+
+
+def test_payload_respects_agent_assisted_false():
+    from archimedes.api.vault_schemas import VaultCreateRequest
+
+    payload = aj.build_vault_create_payload(strategy_id="s1", name="V", symbol="V1", agent_assisted=False)
+    req = VaultCreateRequest(**payload)
+    assert req.agent_assisted is False
+
+
+def test_out_of_range_strictness_level_is_rejected_by_the_real_model():
+    """VaultCreateRequest bounds strictness_level to 1..5 (ge=1, le=5) — matches
+    the CLI's own --strictness-level choices=[1..5]. A client-side clamp
+    mismatch would show up here first, not as a live 422."""
+    from archimedes.api.vault_schemas import VaultCreateRequest
+    from pydantic import ValidationError
+
+    payload = aj.build_vault_create_payload(strategy_id="s1", name="V", symbol="V1", strictness_level=6)
+    with pytest.raises(ValidationError):
+        VaultCreateRequest(**payload)
+
+
+# ── step_deploy — rigor-gate refusal (the #788 anti-goal) ────────────────────
+
+
+def test_no_winner_never_calls_post():
+    client = MagicMock()
+    result = aj.step_deploy(client, None, execute=True, **_deploy_kwargs())
+    assert result is None
+    client.post.assert_not_called()
+
+
+def test_winner_missing_deployable_key_never_calls_post():
+    """A winner dict without a 'deployable' key at all (e.g. resolution
+    failed upstream) must be treated as non-deployable, not truthy-by-omission."""
+    client = MagicMock()
+    winner = {"strategy_id": "s1", "strategy_name": "X", "rigor_gate_status": "pending"}
+    result = aj.step_deploy(client, winner, execute=True, **_deploy_kwargs())
+    assert result is None
+    client.post.assert_not_called()
+
+
+def test_winner_deployable_false_never_calls_post():
+    client = MagicMock()
+    winner = {**_DEPLOYABLE_WINNER, "deployable": False, "rigor_gate_status": "fail"}
+    result = aj.step_deploy(client, winner, execute=True, **_deploy_kwargs())
+    assert result is None
+    client.post.assert_not_called()
+
+
+def test_refusal_holds_even_with_execute_true():
+    """execute=True must never override the rigor gate — it only gates whether
+    a DEPLOYABLE winner's payload is actually sent, not whether the gate runs."""
+    client = MagicMock()
+    result = aj.step_deploy(client, None, execute=True, **_deploy_kwargs())
+    assert result is None
+    client.post.assert_not_called()
+
+
+# ── step_deploy — dry-run default (execute=False) ────────────────────────────
+
+
+def test_dry_run_prints_payload_and_returns_none_without_posting(capsys):
+    client = MagicMock()
+    result = aj.step_deploy(client, _DEPLOYABLE_WINNER, execute=False, **_deploy_kwargs())
+    assert result is None
+    client.post.assert_not_called()
+    out = capsys.readouterr().out
+    assert "/api/vaults/create" in out
+    assert "DRY RUN" in out
+
+
+def test_dry_run_prints_the_exact_payload_that_would_be_sent(capsys):
+    client = MagicMock()
+    aj.step_deploy(client, _DEPLOYABLE_WINNER, execute=False, **_deploy_kwargs())
+    out = capsys.readouterr().out
+    assert _DEPLOYABLE_WINNER["strategy_id"] in out
+    assert _deploy_kwargs()["vault_name"] in out
+
+
+# ── step_deploy — execute=True path (mocked httpx.Client, no network) ────────
+
+
+def test_execute_true_posts_expected_payload_and_returns_vault_address():
+    client = MagicMock()
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"vault_address": "0xVAULT123", "strategy_ids": ["strat-abc"]}
+    client.post.return_value = response
+
+    result = aj.step_deploy(client, _DEPLOYABLE_WINNER, execute=True, **_deploy_kwargs())
+
+    assert result == "0xVAULT123"
+    client.post.assert_called_once()
+    call = client.post.call_args
+    assert call.args[0] == "/api/vaults/create"
+    assert call.kwargs["json"] == _expected_payload()
+
+
+def test_execute_true_non_200_response_returns_none():
+    client = MagicMock()
+    response = MagicMock(status_code=422, text="Strategy has not passed the rigor gate")
+    client.post.return_value = response
+
+    result = aj.step_deploy(client, _DEPLOYABLE_WINNER, execute=True, **_deploy_kwargs())
+
+    assert result is None
+
+
+def test_execute_true_transport_error_returns_none():
+    client = MagicMock()
+    client.post.side_effect = httpx.ConnectError("boom")
+
+    result = aj.step_deploy(client, _DEPLOYABLE_WINNER, execute=True, **_deploy_kwargs())
+
+    assert result is None
+
+
+def test_execute_true_response_missing_vault_address_key_returns_none():
+    client = MagicMock()
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"unexpected": "shape"}
+    client.post.return_value = response
+
+    result = aj.step_deploy(client, _DEPLOYABLE_WINNER, execute=True, **_deploy_kwargs())
+
+    assert result is None
+
+
+def test_execute_true_non_json_response_returns_none():
+    client = MagicMock()
+    response = MagicMock(status_code=200)
+    response.json.side_effect = ValueError("not json")
+    client.post.return_value = response
+
+    result = aj.step_deploy(client, _DEPLOYABLE_WINNER, execute=True, **_deploy_kwargs())
+
+    assert result is None
+
+
+# ── step_monitor — read-only vault health GET ─────────────────────────────────
+
+
+def test_monitor_reads_and_prints_health_dict():
+    client = MagicMock()
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "agent_alive": True,
+        "last_rebalance": "2026-07-09T12:00:00+00:00",
+        "aum_trend_pct": 1.23,
+        "snapshot_count": 42,
+    }
+    client.get.return_value = response
+
+    result = aj.step_monitor(client, "0xVAULT123")
+
+    assert result is True
+    client.get.assert_called_once_with("/api/vaults/0xVAULT123/health")
+
+
+def test_monitor_prints_the_health_fields(capsys):
+    client = MagicMock()
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "agent_alive": True,
+        "last_rebalance": "2026-07-09T12:00:00+00:00",
+        "aum_trend_pct": 1.23,
+        "snapshot_count": 42,
+    }
+    client.get.return_value = response
+
+    aj.step_monitor(client, "0xVAULT123")
+
+    out = capsys.readouterr().out
+    assert "agent_alive=True" in out
+    assert "snapshots=42" in out
+
+
+def test_monitor_non_200_response_returns_false():
+    client = MagicMock()
+    response = MagicMock(status_code=503, text="unavailable")
+    client.get.return_value = response
+
+    result = aj.step_monitor(client, "0xUNKNOWN")
+
+    assert result is False
+
+
+def test_monitor_transport_error_returns_false():
+    client = MagicMock()
+    client.get.side_effect = httpx.ConnectError("boom")
+
+    result = aj.step_monitor(client, "0xVAULT123")
+
+    assert result is False
+
+
+def test_monitor_non_json_response_returns_false():
+    client = MagicMock()
+    response = MagicMock(status_code=200)
+    response.json.side_effect = ValueError("not json")
+    client.get.return_value = response
+
+    result = aj.step_monitor(client, "0xVAULT123")
+
+    assert result is False

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -1,8 +1,10 @@
 # Agent API — driving the Archimedes journey programmatically
 
-> Status: slice 2 (agent-auth: programmatic SIWE + wallet-required generation).
-> Tracks [issue #788](https://github.com/a-apin/archimedes/issues/788).
-> DEPLOY + MONITOR remain pending the #588 contract-redeploy keystone.
+> Status: slice 2 complete — agent-auth (programmatic SIWE + wallet-required
+> generation) plus DEPLOY + MONITOR. Tracks
+> [issue #788](https://github.com/a-apin/archimedes/issues/788). `--deploy`
+> still defaults to a DRY RUN pending the #588 contract-redeploy keystone —
+> see "DEPLOY — create a vault" below for why.
 
 Archimedes ships one human interface: a passkey/wallet React SPA. AI agents — the
 "new citizens" of the Agora thesis — can't drive a browser passkey, so today they
@@ -203,11 +205,17 @@ Ownerless jobs (created while gating was off) stay readable by any
 the historical open behavior. Browser `EventSource` sends cookies on
 same-origin requests, so the SSE stream authenticates without client changes.
 
-### Funding an agent wallet (USDC is gas on Arc)
+### Funding an agent wallet (USDC is gas on Arc) — a DIFFERENT deploy path
 
-An agent EOA needs native USDC before it can DEPLOY (chain 5042002 uses USDC as
-gas). Two options via [`scripts/fund_agent_wallet.py`](../scripts/fund_agent_wallet.py)
-(dry-run by default; `--execute` to send):
+The `POST /api/vaults/create` DEPLOY path below needs **no funding on the
+agent wallet** — the backend's own signer pays gas (see "DEPLOY" for why).
+`fund_agent_wallet.py` is for a separate, not-yet-built path: an agent
+signing `createVault` itself, client-side, the way the browser UI's
+`CreateVaultModal` does. That path — if built — would need the agent EOA to
+hold native USDC (chain 5042002 uses USDC as gas) before it could submit a
+transaction. Two options via
+[`scripts/fund_agent_wallet.py`](../scripts/fund_agent_wallet.py) (dry-run by
+default; `--execute` to send):
 
 ```bash
 # a) treasury transfer — native-USDC value transfer from DEV_WALLET_PRIVATE_KEY (.env):
@@ -218,10 +226,116 @@ python scripts/fund_agent_wallet.py --to 0x<agent-wallet> --amount 5 --execute
 python scripts/fund_agent_wallet.py --to 0x<agent-wallet> --mode faucet --execute
 ```
 
-### Still pending — DEPLOY + MONITOR
+## Slice 2 continued — DEPLOY + MONITOR
 
-- **Deploy:** with the SIWE session, call the wallet-gated `POST /api/vaults/create`.
-- **Monitor:** read the vault back via `GET /api/vaults/{address}/health`.
+### DEPLOY — create a vault from the generated strategy
 
-Tracked in [#788](https://github.com/a-apin/archimedes/issues/788). Do not land any
-contract-touching agent work before the #588 contract-redeploy keystone.
+With the SIWE session established, call the wallet-gated `POST
+/api/vaults/create`. Reference implementation:
+`build_vault_create_payload` / `step_deploy` in
+[`scripts/agent_journey.py`](../scripts/agent_journey.py).
+
+```http
+POST /api/vaults/create
+Content-Type: application/json
+Cookie: archimedes_session=...
+
+{
+  "name": "Agent Journey 2026-07-10 12:00",
+  "symbol": "AGTJRN",
+  "management_fee_bps": 0,
+  "performance_fee_bps": 0,
+  "agent_assisted": true,
+  "strategy_ids": ["<the winning strategy_id from RIGOR / LIVE GATE above>"],
+  "strictness_level": 1
+}
+```
+
+Response `200`:
+```json
+{ "vault_address": "0x...", "strategy_ids": ["..."] }
+```
+
+**Who pays gas — not the agent wallet.** The backend's own signer creates the
+vault on-chain, then transfers `Ownable` ownership to the caller's SIWE
+wallet and pins the backend as the rebalance-only agent (`owner == you`,
+`agent == backend`; see `create_vault` in
+[`vaults_routes.py`](../backend/archimedes/api/vaults_routes.py)). See
+"Funding an agent wallet" above for the (different, not-yet-built) path that
+would need agent-wallet funding.
+
+**Server-side rigor gate is authoritative (#818, `_assert_strategies_pass_rigor`
+in `vaults_routes.py`).** Every `strategy_ids` entry must pass the live rigor
+gate at the requested `strictness_level`, checked **before** any gas is
+spent, or the call returns **422** — enforced independently of the client, so
+no caller (agent or human) can route around it. The reference client mirrors
+this client-side: `step_deploy` refuses to call the endpoint at all — no
+request sent — unless the winning candidate's LIVE GATE read above is
+`deployable: true`. **Never weaken or skip that check to force a deploy.**
+
+`--deploy` defaults to a **DRY RUN**: the harness prints the exact payload
+and sends nothing. Pass `--deploy` to actually call the endpoint. Default OFF
+because, as of this writing, the contract suite was just redeployed (T3.2,
+2026-07-09) and issue [#588](https://github.com/a-apin/archimedes/issues/588)
+(whether the repo's cached ABI matches the live deployed bytecode) is still
+open — no vault, agent or human, had been created against the new deployment
+at the time this shipped.
+
+### MONITOR — read vault health back
+
+```http
+GET /api/vaults/{address}/health
+```
+
+No auth required. Safe for any address, including one nothing is deployed
+behind yet — it reads Redis-backed snapshot/heartbeat state keyed by address
+string, not a chain existence check, so an unknown address returns an
+empty-ish snapshot rather than erroring.
+
+```json
+{
+  "vault_address": "0x...",
+  "agent_alive": true,
+  "last_heartbeat": "2026-07-10T11:58:00+00:00",
+  "last_rebalance": "2026-07-09T12:00:00+00:00",
+  "rebalance_age_seconds": 86400.0,
+  "aum_trend_pct": 1.23,
+  "snapshot_count": 42,
+  "latest_snapshot": { "...": "most recent AUM/holdings snapshot, or null" },
+  "sharpe_drift": { "available": false, "reason": "baseline_backtest_sharpe_unavailable" },
+  "recent_events": [ "...vault-scoped or regime_change/agent_error events, newest 5..." ]
+}
+```
+
+### CLI flags for DEPLOY + MONITOR
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--deploy` | off | actually POST to `/api/vaults/create` (else dry run — see above) |
+| `--vault-name` | `Agent Journey <UTC timestamp>` | vault name (≤ 64 chars) |
+| `--vault-symbol` | `AGTJRN` | vault symbol (≤ 16 chars) |
+| `--management-fee-bps` | `0` | management fee, basis points (0–1000) |
+| `--performance-fee-bps` | `0` | performance fee, basis points (0–3000) |
+| `--strictness-level` | `1` | rigor strictness for deploy (1 = strictest/safest … 5 = most permissive; the always-on correctness floors hold at every level) |
+| `--monitor-address` | none | `GET /api/vaults/{address}/health` for an existing vault, independent of deploying one this run |
+
+```bash
+# full journey including a REAL deploy (spends the backend signer's testnet gas):
+python scripts/agent_journey.py --ephemeral --deploy
+
+# health check only, no generation, no auth:
+python scripts/agent_journey.py --no-auth --read-only --monitor-address 0x<vault-address>
+```
+
+### What's NOT covered here
+
+Tracked in [#788](https://github.com/a-apin/archimedes/issues/788), but out of
+scope for this document / the harness: the issue's funnel/telemetry
+acceptance line ("the agent path is reflected in the funnel/telemetry as
+`agent_type`") is only partly built. `/api/metrics` already classifies
+traffic as human/internal-agent/external-agent
+(`telemetry_middleware.py`), but the conversion funnel itself (`FunnelStore`,
+[#787](https://github.com/a-apin/archimedes/issues/787)) records
+distinct-visitor counts per stage only — `landed`, `wallet_connected`,
+`generation_started`, `vault_deployed` are not currently segmented by
+`agent_type`. Segmenting the funnel by `agent_type` remains open work.

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -398,11 +398,13 @@ def build_vault_create_payload(
     strictness_level: int = 1,
 ) -> dict:
     """The exact JSON body ``POST /api/vaults/create`` (``VaultCreateRequest``)
-    expects. Factored out of ``step_deploy`` so a hermetic test can prove this
-    shape is accepted end-to-end by the real route (SIWE + server-side rigor
-    gate + Pydantic binding) without needing an async ASGI context inside the
-    (sync) reference client itself — see
-    ``backend/tests/scripts/test_agent_journey_deploy.py``.
+    expects. Factored out of ``step_deploy`` so a hermetic test can pin this
+    shape against the REAL ``VaultCreateRequest`` Pydantic model (field names
+    + validation ranges) — see
+    ``backend/tests/scripts/test_agent_journey_deploy.py``. The test binds the
+    model directly; it does NOT exercise SIWE or the server-side rigor gate
+    (integration-level concerns covered by the route's own tests in
+    ``backend/tests/test_vault_rigor_gate.py``).
     """
     return {
         "name": name,
@@ -602,7 +604,12 @@ def main() -> int:
         step_read(client)
         if args.read_only:
             if args.monitor_address:
-                step_monitor(client, args.monitor_address)
+                # Health-check-only runs must fail loudly when the GET fails —
+                # exit 0 on a failed monitor would defeat the point of using
+                # this as a probe (review).
+                monitor_ok = step_monitor(client, args.monitor_address)
+                print("\n(read-only — skipping generation)")
+                return 0 if monitor_ok else 1
             print("\n(read-only — skipping generation)")
             return 0
         job_id = step_generate(client, args.intent, args.risk, args.timeout)
@@ -623,13 +630,20 @@ def main() -> int:
             performance_fee_bps=args.performance_fee_bps,
             strictness_level=args.strictness_level,
         )
+        # Requested hard steps must move the exit code (review): a --deploy
+        # run that deployed nothing, or a failed monitor read, is not success.
+        deploy_ok = True
+        if args.deploy and not vault_address:
+            deploy_ok = False
+            print("RESULT: --deploy requested but no vault was deployed — see above.")
+        monitor_ok = True
         monitor_target = vault_address or args.monitor_address
         if monitor_target:
-            step_monitor(client, monitor_target)
+            monitor_ok = step_monitor(client, monitor_target)
         if vault_address:
             print(f"RESULT: vault deployed — {vault_address}")
 
-        return 0 if ok else 1
+        return 0 if (ok and deploy_ok and monitor_ok) else 1
     finally:
         client.close()
 

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -14,17 +14,27 @@ Two payoffs, immediately:
      agent User-Agent, so the telemetry classifier counts it as an external agent
      and the conversion funnel (#787) attributes its ``generation_started``.
 
-Slice 2 (this revision) adds **agent-auth**: a programmatic EOA signs the SIWE
-(EIP-4361) challenge from ``GET /api/auth/nonce`` and posts it to
-``POST /api/auth/verify``, establishing the same session cookie the browser gets.
-With ``REQUIRE_SIWE_FOR_GENERATION`` now defaulting ON server-side, the GENERATE
-path (and the per-job stream/candidates reads, which are owner-scoped under the
-gate) requires this session; READ stays public.
+Slice 2 adds **agent-auth**: a programmatic EOA signs the SIWE (EIP-4361)
+challenge from ``GET /api/auth/nonce`` and posts it to ``POST /api/auth/verify``,
+establishing the same session cookie the browser gets. With
+``REQUIRE_SIWE_FOR_GENERATION`` now defaulting ON server-side, the GENERATE path
+(and the per-job stream/candidates reads, which are owner-scoped under the gate)
+requires this session; READ stays public.
+
+This revision completes slice 2 with **DEPLOY + MONITOR**: once the generated
+winner reads live-gate ``deployable``, ``step_deploy`` calls the wallet-gated
+``POST /api/vaults/create`` (the backend's own signer pays gas; the SIWE wallet
+only becomes the vault's ``Ownable`` owner) and ``step_monitor`` reads the vault
+back via ``GET /api/vaults/{address}/health``. **``--deploy`` is a dry run by
+default** — see its help text for why (the contract suite was T3.2-redeployed
+2026-07-09, #588 is still open, and no vault had yet been created against the
+new deployment by anyone, agent or human, as of this revision).
 
 Key handling: the private key comes ONLY from the ``AGENT_WALLET_KEY`` env var
 (never a CLI arg, never printed/logged), or ``--ephemeral`` mints a throwaway
 in-memory key via ``eth_account.Account.create()``. Use a fresh TESTNET dev key —
-never a funded/mainnet key.
+never a funded/mainnet key. (Deploying via ``POST /api/vaults/create`` needs no
+funding on the agent wallet itself — see ``step_deploy``'s docstring.)
 
 Usage:
     python scripts/agent_journey.py --base https://archimedes-arc.com
@@ -32,6 +42,8 @@ Usage:
     python scripts/agent_journey.py --ephemeral                       # throwaway wallet
     python scripts/agent_journey.py --no-auth --read-only             # anon read smoke
     python scripts/agent_journey.py --base http://localhost:8000 --intent "low-vol momentum"
+    python scripts/agent_journey.py --ephemeral --deploy              # full journey incl. real deploy
+    python scripts/agent_journey.py --no-auth --read-only --monitor-address 0x...  # health check only
 
 Exit code is nonzero if a hard step fails, so this doubles as a journey smoke test.
 """
@@ -308,18 +320,24 @@ def step_generate(client: httpx.Client, intent: str, risk: str, timeout_s: float
     return job_id
 
 
-def step_readback(client: httpx.Client, job_id: str) -> bool:
-    """Read the externalized rigor verdict + considered alternatives for the job."""
+def step_readback(client: httpx.Client, job_id: str) -> dict:
+    """Read the externalized rigor verdict + considered alternatives for the job.
+
+    Returns ``{"read_ok": bool, "winner": {...} | None}``. ``winner`` (when the
+    selected candidate resolved to a persisted strategy) carries the fields
+    ``step_deploy`` needs: ``strategy_id``, ``strategy_name``,
+    ``rigor_gate_status``, ``deployable``.
+    """
     _hr("RIGOR — externalized verdict + considered alternatives")
     data = _get(client, f"/api/generate/jobs/{job_id}/candidates")
     if not isinstance(data, dict):
         print("  ✗ could not read candidates")
-        return False
+        return {"read_ok": False, "winner": None}
     candidates = data.get("candidates", [])
     best_id = data.get("best_candidate_id")
     if not candidates:
         print("  · no candidates yet (generation may still be running)")
-        return False
+        return {"read_ok": False, "winner": None}
     for c in candidates:
         marker = "🏆 WINNER" if c.get("selected") else "  rejected"
         passes = "PASS" if c.get("passes_rigor") else "FAIL"
@@ -334,6 +352,7 @@ def step_readback(client: httpx.Client, job_id: str) -> bool:
     # "pass"/"fail" + deployable, not the misleading "pending".
     _hr("LIVE GATE — deployability (read the persisted strategy passport)")
     saw_non_pending = False
+    winner: dict | None = None
     for c in candidates:
         sid = c.get("strategy_id")
         if not sid:
@@ -350,11 +369,162 @@ def step_readback(client: httpx.Client, job_id: str) -> bool:
             f"  {'🏆' if c.get('selected') else '·'}  {c.get('strategy_name')!r}  "
             f"live_gate={status!r}  deployable={deployable}  sharpe={strat.get('sharpe_ratio')}"
         )
+        if c.get("selected"):
+            winner = {
+                "strategy_id": sid,
+                "strategy_name": c.get("strategy_name"),
+                "rigor_gate_status": status,
+                "deployable": deployable,
+            }
     if not saw_non_pending:
         print(
             "  ⚠ all strategies read live_gate='pending' — generated candidates have no real "
             "persisted returns (the #788/#818 deployability gap)."
         )
+    return {"read_ok": True, "winner": winner}
+
+
+# ── DEPLOY + MONITOR (slice 2 continued) ───────────────────────────────────
+
+
+def build_vault_create_payload(
+    *,
+    strategy_id: str,
+    name: str,
+    symbol: str,
+    management_fee_bps: int = 0,
+    performance_fee_bps: int = 0,
+    agent_assisted: bool = True,
+    strictness_level: int = 1,
+) -> dict:
+    """The exact JSON body ``POST /api/vaults/create`` (``VaultCreateRequest``)
+    expects. Factored out of ``step_deploy`` so a hermetic test can prove this
+    shape is accepted end-to-end by the real route (SIWE + server-side rigor
+    gate + Pydantic binding) without needing an async ASGI context inside the
+    (sync) reference client itself — see
+    ``backend/tests/scripts/test_agent_journey_deploy.py``.
+    """
+    return {
+        "name": name,
+        "symbol": symbol,
+        "management_fee_bps": management_fee_bps,
+        "performance_fee_bps": performance_fee_bps,
+        "agent_assisted": agent_assisted,
+        "strategy_ids": [strategy_id],
+        "strictness_level": strictness_level,
+    }
+
+
+def step_deploy(
+    client: httpx.Client,
+    winner: dict | None,
+    *,
+    execute: bool,
+    vault_name: str,
+    vault_symbol: str,
+    management_fee_bps: int = 0,
+    performance_fee_bps: int = 0,
+    strictness_level: int = 1,
+) -> str | None:
+    """Deploy a vault from the winning generated strategy via ``POST /api/vaults/create``.
+
+    Reuses the SAME authenticated ``client`` ``step_auth`` built — the endpoint is
+    wallet-gated (``require_verified_wallet``), but note WHO pays gas: the
+    backend's OWN signer creates the vault, then transfers ``Ownable`` ownership
+    to the caller's SIWE wallet (see the route's docstring in
+    ``backend/archimedes/api/vaults_routes.py::create_vault``). So the agent
+    wallet itself needs no funding for this path — ``scripts/fund_agent_wallet.py``
+    is for a DIFFERENT, not-yet-built path (an agent signing ``createVault``
+    itself, the way the browser UI's ``CreateVaultModal`` does client-side).
+
+    Refuses outright (never calls the endpoint) when the winning candidate isn't
+    LIVE-GATE deployable — the harness must never spend gas on a call guaranteed
+    to 422, and must never make it look like a pending/failing strategy can be
+    forced through (#788 anti-goal: never weaken or bypass the rigor gate; the
+    server enforces this independently via ``_assert_strategies_pass_rigor``
+    regardless of what this client does).
+
+    ``execute=False`` (the default wired from ``--deploy`` being absent) prints
+    the exact payload and returns without sending anything — mirrors
+    ``fund_agent_wallet.py``'s ``--execute`` convention for anything that spends
+    real (even if testnet) value. Default OFF on purpose: as of this revision
+    the contract suite was T3.2-redeployed 2026-07-09 (#1079), issue #588 (the
+    redeploy keystone ``docs/agent-api.md`` gates contract-touching agent work
+    on) is still open, and ``backend/tests/chain/test_create_vault_abi_consistency.py``
+    itself documents that whether the repo's ABI matches the LIVE deployed
+    bytecode is unverified pending #588. No vault — agent or human — had been
+    created against the new deployment yet at the time this was written. Flip
+    ``--deploy`` on once that's confirmed settled.
+    """
+    _hr("DEPLOY — create a vault from the generated strategy")
+
+    if not winner:
+        print("  · no winning candidate available — skipping deploy")
+        return None
+    if not winner.get("deployable"):
+        print(
+            f"  ✗ {winner.get('strategy_name')!r} is not deployable "
+            f"(live_gate={winner.get('rigor_gate_status')!r}) — refusing to deploy. "
+            "This harness never bypasses the rigor gate."
+        )
+        return None
+
+    payload = build_vault_create_payload(
+        strategy_id=winner["strategy_id"],
+        name=vault_name,
+        symbol=vault_symbol,
+        management_fee_bps=management_fee_bps,
+        performance_fee_bps=performance_fee_bps,
+        strictness_level=strictness_level,
+    )
+    print(f"  · POST /api/vaults/create  {payload}")
+
+    if not execute:
+        print(
+            "  · DRY RUN — nothing sent (default). The backend signer would spend real\n"
+            "    testnet gas on this call. Re-run with --deploy to actually create it —\n"
+            "    see step_deploy's docstring / docs/agent-api.md for why this defaults off."
+        )
+        return None
+
+    try:
+        r = client.post("/api/vaults/create", json=payload)
+    except httpx.HTTPError as exc:
+        print(f"  ✗ POST /api/vaults/create — transport error: {exc}")
+        return None
+    if r.status_code != 200:
+        print(f"  ✗ POST /api/vaults/create — HTTP {r.status_code}: {r.text[:300]}")
+        return None
+    try:
+        data = r.json()
+        vault_address = data["vault_address"]
+    except (ValueError, KeyError, TypeError) as exc:
+        print(f"  ✗ POST /api/vaults/create — unexpected response shape ({exc}): {r.text[:200]}")
+        return None
+    print(f"  ✓ vault deployed at {vault_address}")
+    return vault_address
+
+
+def step_monitor(client: httpx.Client, vault_address: str) -> bool:
+    """Read vault health back via ``GET /api/vaults/{address}/health``.
+
+    Public — no auth required (matches the live route). Safe to call for ANY
+    address, including one with no deployed contract behind it yet: the
+    monitor reads off Redis-backed snapshot/heartbeat state keyed by address
+    string, not a chain existence check, so an unknown address returns an
+    (empty-ish) health snapshot rather than erroring — verified against prod.
+    """
+    _hr("MONITOR — vault health")
+    health = _get(client, f"/api/vaults/{vault_address}/health")
+    if not isinstance(health, dict):
+        print("  ✗ could not read vault health")
+        return False
+    print(
+        f"  ✓ agent_alive={health.get('agent_alive')}  "
+        f"last_rebalance={health.get('last_rebalance')!r}  "
+        f"aum_trend_pct={health.get('aum_trend_pct')}  "
+        f"snapshots={health.get('snapshot_count')}"
+    )
     return True
 
 
@@ -381,6 +551,36 @@ def main() -> int:
         action="store_true",
         help="mint a throwaway in-memory wallet (Account.create()) and SIWE-auth with it; implies --auth",
     )
+    ap.add_argument(
+        "--deploy",
+        action="store_true",
+        help="actually call POST /api/vaults/create for the generated winner (backend signer spends real "
+        "testnet gas). Default is a DRY RUN that prints the exact payload and sends nothing — see "
+        "step_deploy's docstring for why (contract suite T3.2-redeployed 2026-07-09, #588 still open, "
+        "no vault yet created against it by anyone as of this revision).",
+    )
+    ap.add_argument(
+        "--vault-name", default=None, help="vault name for --deploy (default: derived, 'Agent Journey <UTC timestamp>')"
+    )
+    ap.add_argument("--vault-symbol", default="AGTJRN", help="vault symbol for --deploy (<=16 chars, default AGTJRN)")
+    ap.add_argument("--management-fee-bps", type=int, default=0, help="vault management fee, basis points (default 0)")
+    ap.add_argument(
+        "--performance-fee-bps", type=int, default=0, help="vault performance fee, basis points (default 0)"
+    )
+    ap.add_argument(
+        "--strictness-level",
+        type=int,
+        default=1,
+        choices=[1, 2, 3, 4, 5],
+        help="rigor strictness for deploy (1=strictest/safest, matches the server default; never bypasses "
+        "the always-on correctness floors)",
+    )
+    ap.add_argument(
+        "--monitor-address",
+        default=None,
+        help="GET /api/vaults/{address}/health for an existing vault, independent of deploying one this run "
+        "(no auth needed; safe read-only check)",
+    )
     args = ap.parse_args()
 
     # Auth resolution: --ephemeral implies auth; otherwise --auth/--no-auth wins;
@@ -401,14 +601,34 @@ def main() -> int:
         print(f"\n  auth status: {'authenticated as ' + wallet if wallet else 'anonymous'}")
         step_read(client)
         if args.read_only:
+            if args.monitor_address:
+                step_monitor(client, args.monitor_address)
             print("\n(read-only — skipping generation)")
             return 0
         job_id = step_generate(client, args.intent, args.risk, args.timeout)
         if not job_id:
             print("\nRESULT: generation failed to start — see above.")
             return 1
-        ok = step_readback(client, job_id)
+        readback = step_readback(client, job_id)
+        ok = readback["read_ok"]
         print(f"\nRESULT: journey {'completed' if ok else 'partial (no verdict read)'} — job_id={job_id}")
+
+        vault_address = step_deploy(
+            client,
+            readback.get("winner"),
+            execute=args.deploy,
+            vault_name=args.vault_name or f"Agent Journey {datetime.now(UTC):%Y-%m-%d %H:%M}",
+            vault_symbol=args.vault_symbol,
+            management_fee_bps=args.management_fee_bps,
+            performance_fee_bps=args.performance_fee_bps,
+            strictness_level=args.strictness_level,
+        )
+        monitor_target = vault_address or args.monitor_address
+        if monitor_target:
+            step_monitor(client, monitor_target)
+        if vault_address:
+            print(f"RESULT: vault deployed — {vault_address}")
+
         return 0 if ok else 1
     finally:
         client.close()


### PR DESCRIPTION
> Reviewed hands-on against production (read + monitor paths verified live, exit-code semantics fixed in 28e5f15c) and cleared for merge — Dan + Claude, 2026-07-14. Original draft marker removed.

## Summary

Builds out slice 2 of the agent-facing journey — see issue #788 — the reference client
(`scripts/agent_journey.py`) can now DEPLOY a vault from a generated,
rigor-gate-passing strategy via `POST /api/vaults/create`, and MONITOR it via
`GET /api/vaults/{address}/health` — no browser, no passkey. This adds the
hermetic test the code's own docstring already promised, and documents both
new steps in `docs/agent-api.md`.

## What's included

- `build_vault_create_payload()` — builds the exact `VaultCreateRequest` body.
- `step_deploy()` — refuses to call the endpoint at all when the winning
  candidate is missing or its LIVE GATE reads `deployable: false` (the #788
  anti-goal: never weaken or bypass the rigor gate). `--deploy` defaults to a
  **dry run** (prints the payload, sends nothing); `execute=True` posts for
  real. On success, prints the vault address; on a non-200 response, a
  transport error, or an unexpected response body, fails cleanly and returns
  `None` rather than raising.
- `step_monitor()` — reads `GET /api/vaults/{address}/health` (no auth), used
  both after a deploy and standalone via `--monitor-address`.
- New CLI flags: `--deploy`, `--vault-name`, `--vault-symbol`,
  `--management-fee-bps`, `--performance-fee-bps`, `--strictness-level`,
  `--monitor-address`.
- **New test file** `backend/tests/scripts/test_agent_journey_deploy.py` (22
  cases) — the gap called out by name in `build_vault_create_payload`'s own
  docstring ("see `backend/tests/scripts/test_agent_journey_deploy.py`",
  which didn't exist before this PR). Loads `scripts/agent_journey.py` via
  `importlib` (mirrors `test_agent_journey_siwe.py`'s loader, since the script
  isn't a package). Coverage:
  - `build_vault_create_payload`'s shape cross-checked against the REAL
    `archimedes.api.vault_schemas.VaultCreateRequest` model (the thing
    `vaults_routes.py::create_vault` actually binds the body to) — exact
    field-name parity, Pydantic acceptance + value round-trip, defaults, and
    that an out-of-range `strictness_level` is rejected by the real model's
    `ge=1, le=5` bound. This is the thing the docstring meant by "prove this
    shape is accepted end-to-end by the real route... without needing an
    async ASGI context" — the model import itself is synchronous and has no
    DB/network side effects, so no ASGI/live-server is needed to verify it.
  - `step_deploy`'s rigor-gate refusal (missing winner, missing
    `deployable` key, `deployable: False`) — asserts `client.post` is never
    called.
  - `step_deploy`'s dry-run default and its execute=True success/failure
    paths (non-200, transport error, malformed/non-JSON body) — all against
    a `MagicMock` client, no network.
  - `step_monitor`'s happy path and failure paths, same mocking approach.
- `docs/agent-api.md` — replaced the "still pending" placeholder with the
  actual `POST /api/vaults/create` request/response shape, who pays gas (the
  backend signer, not the agent wallet — corrected the adjacent "Funding an
  agent wallet" section, which was written for a different, not-yet-built
  client-signs-createVault path and could otherwise read as if funding were
  needed for *this* path), the `GET .../health` response shape, and a table
  of the new CLI flags.
- Reformatted two argparse lines in `scripts/agent_journey.py` that tripped
  `ruff format --check` (wrapping only — no logic changed).

## What I did NOT change

- No contract changes. No change to `_assert_strategies_pass_rigor` or any
  other server-side gate — `step_deploy` mirrors the server's own refusal
  client-side but the server enforces it independently regardless.
- `--deploy` still defaults to a dry run. Per the existing docstring: the
  contract suite was T3.2-redeployed 2026-07-09 (#1079, merged), #588 (ABI
  vs. live-bytecode verification) is still open as of this PR, and no vault
  — agent or human — had been created against the new deployment yet. I did
  not flip this default; per the task brief, that's deliberate and not mine
  to change.

## Re: issue #788's acceptance criteria — what's still open

Re-read all four AC boxes before deciding whether to close:
1. Slice 1 (generate + rigor verdict, no browser) — already shipped (#790, #839). Done.
2. `docs/agent-api.md` documents the full journey — now covers DEPLOY + MONITOR too. Done.
3. Slice 2 deploy + monitor via a programmatic signer — done in this PR.
4. **"The agent path is reflected in the funnel/telemetry as `agent_type`"
   — NOT done.** Verified rather than assumed: `/api/metrics`
   (`telemetry_middleware.py`) already classifies traffic as
   human/internal-agent/external-agent, but the conversion funnel itself
   (`FunnelStore.record(stage, visitor_id)` in
   `backend/archimedes/services/funnel_store.py`) takes no `agent_type`
   parameter at all — `landed`/`wallet_connected`/`generation_started`/
   `vault_deployed` are recorded as a single aggregate distinct-visitor count
   per stage, not segmented by caller type. So an agent's `vault_deployed`
   is counted in the funnel, but not distinguishably from a human's.

Because of (4), **issue #788 stays open after this PR** — intentionally, no
auto-close wording used anywhere in this body. Segmenting the funnel by `agent_type` is a separate,
multi-file piece (funnel_store.py's Redis keyspace, funnel_middleware.py's
`record_funnel`, and every call site: generate_routes.py, auth_siwe.py,
vaults_routes.py) that I'm intentionally not bundling into this PR — I've
flagged it as a follow-up rather than scope-creeping this one.

## Coordination note

This touches the vault-creation path — even though only as a client calling
an already-gated, already-deployed endpoint with no contract changes. Per the
issue body ("slice 2 agent-signer design coordinates with Dan"), flagging for
Dan's visibility as contract/on-chain owner.

## Test + lint output

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/scripts/test_agent_journey_deploy.py -q
→ 22 passed, 0 failed

ruff format --check scripts/agent_journey.py backend/tests/scripts/test_agent_journey_deploy.py
→ 2 files already formatted

ruff check --select E9,F63,F7,F40 scripts/agent_journey.py backend/tests/scripts/test_agent_journey_deploy.py
→ All checks passed!

ruff check scripts/agent_journey.py backend/tests/scripts/test_agent_journey_deploy.py   # informational, full rule set
→ All checks passed!
```

Full repo suite (`pytest -q --continue-on-collection-errors` from the repo
root): **2808 passed, 4 skipped, 0 failed.** 9 collection errors, all
pre-existing and unrelated — `backend/tests/marketplace/*` +
`test_marketplace_routes.py` fail to import `circlekit` in this local conda
env (declared in `environment.yml` as `circle-titanoboa-sdk`, not actually
installed here — a local env drift, not something this PR touches or
introduces).

## Anti-goals respected

- Never weakened or bypassed the rigor gate — `step_deploy` refuses
  client-side, the server enforces independently, and the new tests assert
  `client.post` is never called in the refusal cases.
- `--deploy` is still opt-in; the dry-run default is unchanged.
- No live/local base URL was used for testing — everything above is
  hermetic, mocked `httpx.Client`, no network.
- No new top-level dependencies, no `docker-compose*`/CI changes, no
  `.env.example`/`environment.yml` edits.

## arc-canteen

Authenticated in this environment — logged via `arc-canteen update-product`
(confirmed in `arc-canteen status`'s recent-updates list).

Progresses #788 (see "what's still open" above for why this isn't a closing
reference).


