### PR TITLE
Thread agent_type through the conversion funnel (#788) !minor

### DIFF
--- a/backend/archimedes/api/funnel_middleware.py
+++ b/backend/archimedes/api/funnel_middleware.py
@@ -92,17 +92,24 @@ async def record_funnel(request: Request, stage: str) -> None:
     """Record a server-authoritative funnel transition for this request's visitor.
 
     Reads ``request.state.visitor_id`` (set by the middleware) and writes one HLL
-    entry. Never raises — a telemetry write must not affect the user's action.
+    entry, tagged with ``request.state.agent_type`` when present (#788) — that
+    attribute is set by ``api.telemetry_middleware`` earlier in the ASGI stack,
+    so any route that already calls this helper gets the agent/human breakdown
+    for free, no call-site changes needed. Degrades gracefully to ``None`` (the
+    pre-#788 aggregate-only write) if the attribute is missing, e.g. in a test
+    request that never went through that middleware. Never raises — a telemetry
+    write must not affect the user's action.
     """
     try:
         visitor_id = getattr(request.state, "visitor_id", "") or ""
         if not visitor_id:
             return
+        agent_type = getattr(request.state, "agent_type", None)
         from archimedes.services.funnel_store import FunnelStore
 
         store = FunnelStore()
         try:
-            await store.record(stage, visitor_id)
+            await store.record(stage, visitor_id, agent_type=agent_type)
         finally:
             await store.close()
     except Exception as exc:

--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -76,6 +76,7 @@ def _build_funnel(
     source: str = "visitor",
     stage_order: Sequence[str] = STAGES,
     stage_label: Mapping[str, str] | None = None,
+    breakdown: Mapping[str, Mapping[str, int]] | None = None,
 ) -> FunnelResponse:
     """Turn an ordered stage->count map into a funnel with ratios.
 
@@ -88,6 +89,11 @@ def _build_funnel(
     (e.g. the identity ledger's ``auth_verified`` -> the funnel's existing
     ``wallet_connected`` label) without changing the ratio math, which always
     runs over the raw, ordered counts.
+
+    ``breakdown`` (optional, issue #788): stage -> {agent_type: count}, surfaced
+    per-stage as ``by_agent_type``. Omitted (e.g. the ``source=identity`` path,
+    which has no per-request agent_type) or missing a stage just yields ``{}``
+    for that stage.
     """
     labels = stage_label or {}
     first = counts.get(stage_order[0], 0) if stage_order else 0
@@ -103,6 +109,7 @@ def _build_funnel(
                 distinct_visitors=n,
                 pct_of_landed=round(pct, 4),
                 step_conversion=round(step, 4),
+                by_agent_type=dict(breakdown[stage]) if breakdown and stage in breakdown else {},
             )
         )
         prev = n
@@ -221,6 +228,14 @@ async def get_funnel(
     'agent')`` exclusion so dogfooding/agent traffic can't inflate the honest
     human funnel; pass ``human_only=false`` to see everyone. Fail-safe: an
     all-zero funnel on any DB error.
+
+    Every stage in the ``source=visitor`` response also carries
+    ``by_agent_type`` (issue #788): the same distinct-visitor count, broken out
+    by the telemetry middleware's classification (``internal``/``external``/
+    ``human``), so agent conversion through the funnel can be measured
+    separately from human conversion. Additive — ``distinct_visitors`` and the
+    ratios are unchanged. Empty per stage on ``source=identity`` (no
+    per-request agent_type there).
     """
     if source == "identity":
         counts = get_identity_funnel(exclude_dogfood=human_only)
@@ -237,13 +252,15 @@ async def get_funnel(
     try:
         if day:
             counts = await store.get_day(day)
+            breakdown = await store.get_day_by_agent_type(day)
             window = day
         else:
             counts = await store.get_totals()
+            breakdown = await store.get_totals_by_agent_type()
             window = "all-time"
     finally:
         await store.close()
-    return _build_funnel(counts, window, source="visitor")
+    return _build_funnel(counts, window, source="visitor", breakdown=breakdown)
 
 
 @metrics_router.post("/metrics/funnel/event")

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -74,6 +74,12 @@ class FunnelStageCount(BaseModel):
     distinct_visitors: int = Field(..., description="Distinct visitors that reached this stage (HLL estimate).")
     pct_of_landed: float = Field(..., description="distinct_visitors / landed, as a fraction (0.0-1.0).")
     step_conversion: float = Field(..., description="distinct_visitors / previous-stage count (0.0-1.0).")
+    by_agent_type: dict[str, int] = Field(
+        default_factory=dict,
+        description="distinct_visitors at this stage, broken out by agent_type ('internal'/'external'/'human') "
+        "so agent conversion can be measured separately from human (issue #788). Empty for source=identity, "
+        "which has no per-request agent_type.",
+    )
 
 
 class FunnelResponse(BaseModel):

--- a/backend/archimedes/services/funnel_store.py
+++ b/backend/archimedes/services/funnel_store.py
@@ -110,13 +110,17 @@ class FunnelStore:
             return
         try:
             r = await self._get_redis()
-            day_key = f"{_PREFIX}:day:{_today()}:{stage}"
+            # One _today() call for both buckets: two calls straddling a UTC
+            # midnight would file the aggregate and the agent_type split of
+            # the SAME record under different days (review follow-up).
+            today = _today()
+            day_key = f"{_PREFIX}:day:{today}:{stage}"
             pipe = r.pipeline()
             pipe.pfadd(f"{_PREFIX}:total:{stage}", visitor_id)
             pipe.pfadd(day_key, visitor_id)
             pipe.expire(day_key, _DAY_TTL_SECONDS)
             if agent_type in AGENT_TYPES:
-                at_day_key = f"{_PREFIX}:day:{_today()}:{stage}:{agent_type}"
+                at_day_key = f"{_PREFIX}:day:{today}:{stage}:{agent_type}"
                 pipe.pfadd(f"{_PREFIX}:total:{stage}:{agent_type}", visitor_id)
                 pipe.pfadd(at_day_key, visitor_id)
                 pipe.expire(at_day_key, _DAY_TTL_SECONDS)

--- a/backend/archimedes/services/funnel_store.py
+++ b/backend/archimedes/services/funnel_store.py
@@ -26,6 +26,14 @@ Two keyspaces per stage:
   - ``archimedes:funnel:total:<stage>`` — all-time distinct visitors (no TTL).
   - ``archimedes:funnel:day:<YYYY-MM-DD>:<stage>`` — per-day distinct visitors,
     with a TTL so old day-buckets self-expire (no unbounded growth).
+
+Issue #788 — agent-vs-human breakdown: alongside the two keyspaces above, each
+``record()`` call additionally tags the same visitor into a per-``agent_type``
+HLL (``...:<stage>:<agent_type>``, same TTL rules) whenever the caller has a
+classified ``agent_type`` (see ``api/telemetry_middleware.py``). This is
+purely additive — the stage-only aggregate is written and read exactly as
+before, so it stays the source of truth for every existing consumer. The
+breakdown lets the funnel measure agent conversion separately from human.
 """
 
 from __future__ import annotations
@@ -56,6 +64,13 @@ STAGES: tuple[str, ...] = (
 # server-side at the authoritative transition so a client can't inflate them.
 CLIENT_EMITTABLE_STAGES: frozenset[str] = frozenset({"landed"})
 
+# The closed set of classifier verdicts (#788). Mirrors the return values of
+# ``api.telemetry_middleware.classify_request`` — duplicated here rather than
+# imported to keep this services-layer module independent of the api layer.
+# An agent_type outside this set is treated like an unknown stage: no-op on
+# write, not a bogus key.
+AGENT_TYPES: tuple[str, ...] = ("internal", "external", "human")
+
 # Per-day buckets self-expire after this window (90 days of trend history).
 _DAY_TTL_SECONDS = 90 * 24 * 60 * 60
 
@@ -78,11 +93,18 @@ class FunnelStore:
 
     # ─── Record (write path — server-side emit + client beacon) ──────────
 
-    async def record(self, stage: str, visitor_id: str) -> None:
+    async def record(self, stage: str, visitor_id: str, agent_type: str | None = None) -> None:
         """Record that ``visitor_id`` reached ``stage``. Never raises.
 
         No-ops on an unknown stage or an empty visitor id (defensive — a missing
         id must not create a bogus distinct count).
+
+        ``agent_type`` (#788), when it's one of ``AGENT_TYPES``, additionally
+        tags the same visitor into a per-agent_type HLL so agent conversion can
+        be measured separately from human. Omitted or unrecognized values just
+        skip the extra tagging — the stage-only aggregate above is unaffected,
+        so a legacy caller (or one whose request never got classified) records
+        exactly as it did before this parameter existed.
         """
         if stage not in STAGES or not visitor_id:
             return
@@ -93,6 +115,11 @@ class FunnelStore:
             pipe.pfadd(f"{_PREFIX}:total:{stage}", visitor_id)
             pipe.pfadd(day_key, visitor_id)
             pipe.expire(day_key, _DAY_TTL_SECONDS)
+            if agent_type in AGENT_TYPES:
+                at_day_key = f"{_PREFIX}:day:{_today()}:{stage}:{agent_type}"
+                pipe.pfadd(f"{_PREFIX}:total:{stage}:{agent_type}", visitor_id)
+                pipe.pfadd(at_day_key, visitor_id)
+                pipe.expire(at_day_key, _DAY_TTL_SECONDS)
             await pipe.execute()
         except Exception as exc:
             # Fail-safe: a Redis outage must never break the request it measures.
@@ -121,6 +148,32 @@ class FunnelStore:
                 counts[stage] = int(count or 0)
         except Exception as exc:
             logger.debug("funnel read failed: %s", exc)
+        return counts
+
+    # ─── Read — agent_type breakdown (#788) ───────────────────────────────
+
+    async def get_totals_by_agent_type(self) -> dict[str, dict[str, int]]:
+        """All-time distinct visitors per stage, broken out by agent_type. Zeros on error."""
+        return await self._counts_by_agent_type(f"{_PREFIX}:total:{{stage}}:{{agent_type}}")
+
+    async def get_day_by_agent_type(self, date_str: str | None = None) -> dict[str, dict[str, int]]:
+        """Per-day distinct visitors per stage, broken out by agent_type (defaults to today). Zeros on error."""
+        day = date_str or _today()
+        return await self._counts_by_agent_type(f"{_PREFIX}:day:{day}:{{stage}}:{{agent_type}}")
+
+    async def _counts_by_agent_type(self, key_template: str) -> dict[str, dict[str, int]]:
+        counts: dict[str, dict[str, int]] = {stage: dict.fromkeys(AGENT_TYPES, 0) for stage in STAGES}
+        try:
+            r = await self._get_redis()
+            pipe = r.pipeline()
+            pairs = [(stage, agent_type) for stage in STAGES for agent_type in AGENT_TYPES]
+            for stage, agent_type in pairs:
+                pipe.pfcount(key_template.format(stage=stage, agent_type=agent_type))
+            results = await pipe.execute()
+            for (stage, agent_type), count in zip(pairs, results, strict=False):
+                counts[stage][agent_type] = int(count or 0)
+        except Exception as exc:
+            logger.debug("funnel agent-type read failed: %s", exc)
         return counts
 
     # ─── Lifecycle ───────────────────────────────────────────────────────

--- a/backend/tests/test_funnel_store.py
+++ b/backend/tests/test_funnel_store.py
@@ -3,7 +3,10 @@
 Hermetic — mocks at the Redis boundary (the project standard; no live Redis).
 Covers: FunnelStore record/read + fail-safe, the ratio math in
 ``metrics_routes._build_funnel``, the ``record_funnel`` emit helper, the beacon
-stage allowlist, and the visitor-id middleware.
+stage allowlist, and the visitor-id middleware. Also covers the issue #788
+agent_type breakdown (record-side tagging, the by-agent-type reads, threading
+through ``_build_funnel``, and the backward-compat default when a request's
+``agent_type`` was never classified).
 """
 
 from __future__ import annotations
@@ -15,7 +18,7 @@ from archimedes.api import metrics_routes
 from archimedes.api.funnel_middleware import ensure_visitor_id_middleware, record_funnel
 from archimedes.api.metrics_routes import _build_funnel
 from archimedes.models.telemetry import FunnelEventRequest
-from archimedes.services.funnel_store import STAGES, FunnelStore
+from archimedes.services.funnel_store import AGENT_TYPES, STAGES, FunnelStore
 
 
 def _mock_redis_with_pipeline(execute_return):
@@ -78,6 +81,50 @@ async def test_record_failsafe_on_redis_error():
     await store.record("landed", "vid")
 
 
+# ─── FunnelStore.record — agent_type breakdown (#788) ────────────────────
+
+
+async def test_record_pfadds_agent_type_keyed_when_provided():
+    store = FunnelStore()
+    redis, pipe = _mock_redis_with_pipeline([1, 1, True, 1, 1, True])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    await store.record("landed", "vid-abc", agent_type="human")
+
+    assert pipe.pfadd.call_count == 4  # stage-only total+day, PLUS agent_type-keyed total+day
+    assert pipe.expire.call_count == 2  # TTL on both day buckets
+    keys = [c.args[0] for c in pipe.pfadd.call_args_list]
+    # The pre-#788 aggregate keys are untouched...
+    assert "archimedes:funnel:total:landed" in keys
+    assert any(k.startswith("archimedes:funnel:day:") and k.endswith(":landed") for k in keys)
+    # ...and the new agent_type-keyed ones are additive alongside them.
+    assert "archimedes:funnel:total:landed:human" in keys
+    assert any(k.startswith("archimedes:funnel:day:") and k.endswith(":landed:human") for k in keys)
+
+
+async def test_record_agent_type_none_keeps_legacy_pfadd_count():
+    """No agent_type (the pre-#788 call shape) writes exactly the original 2 keys."""
+    store = FunnelStore()
+    redis, pipe = _mock_redis_with_pipeline([1, 1, True])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    await store.record("landed", "vid-abc", agent_type=None)
+
+    assert pipe.pfadd.call_count == 2
+    assert pipe.expire.call_count == 1
+
+
+async def test_record_ignores_unrecognized_agent_type():
+    """An agent_type outside AGENT_TYPES no-ops the extra tagging (defensive, mirrors unknown-stage)."""
+    store = FunnelStore()
+    redis, pipe = _mock_redis_with_pipeline([1, 1, True])
+    store._get_redis = AsyncMock(return_value=redis)
+
+    await store.record("landed", "vid-abc", agent_type="bogus")
+
+    assert pipe.pfadd.call_count == 2
+
+
 # ─── FunnelStore reads ───────────────────────────────────────────────────
 
 
@@ -118,6 +165,47 @@ async def test_get_totals_failsafe_returns_zeros():
     assert counts == dict.fromkeys(STAGES, 0)
 
 
+# ─── FunnelStore reads — agent_type breakdown (#788) ─────────────────────
+
+
+async def test_get_totals_by_agent_type_reads_pfcount_per_stage_and_type():
+    store = FunnelStore()
+    n = len(STAGES) * len(AGENT_TYPES)
+    redis, pipe = _mock_redis_with_pipeline(list(range(n)))
+    store._get_redis = AsyncMock(return_value=redis)
+
+    counts = await store.get_totals_by_agent_type()
+
+    assert set(counts.keys()) == set(STAGES)
+    for stage in STAGES:
+        assert set(counts[stage].keys()) == set(AGENT_TYPES)
+    assert pipe.pfcount.call_count == n
+    # Key shape matches the write side: total:<stage>:<agent_type>.
+    first_key = pipe.pfcount.call_args_list[0].args[0]
+    assert first_key == f"archimedes:funnel:total:{STAGES[0]}:{AGENT_TYPES[0]}"
+
+
+async def test_get_day_by_agent_type_uses_day_keyspace():
+    store = FunnelStore()
+    n = len(STAGES) * len(AGENT_TYPES)
+    redis, pipe = _mock_redis_with_pipeline(list(range(n)))
+    store._get_redis = AsyncMock(return_value=redis)
+
+    await store.get_day_by_agent_type("2026-06-28")
+
+    first_key = pipe.pfcount.call_args_list[0].args[0]
+    assert first_key == f"archimedes:funnel:day:2026-06-28:{STAGES[0]}:{AGENT_TYPES[0]}"
+
+
+async def test_get_totals_by_agent_type_failsafe_returns_zeros():
+    store = FunnelStore()
+    store._get_redis = AsyncMock(side_effect=ConnectionError("down"))
+
+    counts = await store.get_totals_by_agent_type()
+
+    assert counts == {stage: dict.fromkeys(AGENT_TYPES, 0) for stage in STAGES}
+
+
 # ─── Ratio math (_build_funnel) ──────────────────────────────────────────
 
 
@@ -150,6 +238,31 @@ def test_build_funnel_zero_landed_no_divzero():
     assert resp.stages[1].step_conversion == 0.0
 
 
+def test_build_funnel_no_breakdown_defaults_empty():
+    """Omitting ``breakdown`` (e.g. the source=identity call site) yields {} per stage, not a crash."""
+    counts = {"landed": 100, "wallet_connected": 25, "generation_started": 5, "vault_deployed": 2}
+    resp = _build_funnel(counts, "all-time")
+
+    assert all(s.by_agent_type == {} for s in resp.stages)
+
+
+def test_build_funnel_threads_agent_type_breakdown():
+    counts = {"landed": 100, "wallet_connected": 25, "generation_started": 5, "vault_deployed": 2}
+    breakdown = {
+        "landed": {"internal": 1, "external": 9, "human": 90},
+        "wallet_connected": {"internal": 0, "external": 0, "human": 25},
+        # generation_started intentionally absent — a stage missing from the
+        # breakdown map must still yield {}, not a KeyError.
+        "vault_deployed": {"internal": 0, "external": 0, "human": 2},
+    }
+    resp = _build_funnel(counts, "all-time", breakdown=breakdown)
+    by = {s.stage: s for s in resp.stages}
+
+    assert by["landed"].by_agent_type == {"internal": 1, "external": 9, "human": 90}
+    assert by["landed"].distinct_visitors == 100  # aggregate field unchanged by the breakdown
+    assert by["generation_started"].by_agent_type == {}
+
+
 # ─── record_funnel emit helper ───────────────────────────────────────────
 
 
@@ -157,18 +270,42 @@ async def test_record_funnel_uses_request_visitor_id(monkeypatch):
     recorded = {}
 
     class FakeStore:
-        async def record(self, stage, vid):
-            recorded["call"] = (stage, vid)
+        async def record(self, stage, vid, agent_type=None):
+            recorded["call"] = (stage, vid, agent_type)
 
         async def close(self):
             pass
 
     monkeypatch.setattr("archimedes.services.funnel_store.FunnelStore", FakeStore)
-    req = SimpleNamespace(state=SimpleNamespace(visitor_id="vid-xyz"))
+    req = SimpleNamespace(state=SimpleNamespace(visitor_id="vid-xyz", agent_type="external"))
 
     await record_funnel(req, "generation_started")
 
-    assert recorded["call"] == ("generation_started", "vid-xyz")
+    assert recorded["call"] == ("generation_started", "vid-xyz", "external")
+
+
+async def test_record_funnel_defaults_agent_type_when_unset(monkeypatch):
+    """#788 backward compat: request.state.agent_type isn't always set (e.g. a request
+
+    that never passed through ``telemetry_middleware``, or a legacy caller predating
+    this attribute). ``record_funnel`` must still record — degrading to ``agent_type=None``
+    (the pre-#788 aggregate-only write), not raising.
+    """
+    recorded = {}
+
+    class FakeStore:
+        async def record(self, stage, vid, agent_type=None):
+            recorded["call"] = (stage, vid, agent_type)
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("archimedes.services.funnel_store.FunnelStore", FakeStore)
+    req = SimpleNamespace(state=SimpleNamespace(visitor_id="vid-legacy"))  # no agent_type attribute
+
+    await record_funnel(req, "landed")
+
+    assert recorded["call"] == ("landed", "vid-legacy", None)
 
 
 async def test_record_funnel_noop_without_visitor_id(monkeypatch):

--- a/backend/tests/test_metrics_routes.py
+++ b/backend/tests/test_metrics_routes.py
@@ -199,15 +199,28 @@ async def test_get_funnel_defaults_to_visitor_source():
     """GET /api/metrics/funnel with no params stays the pre-#1028 Redis/HLL funnel (no behavior change)."""
     from archimedes.main import app
 
-    with patch(
-        "archimedes.api.metrics_routes.FunnelStore.get_totals",
-        new=AsyncMock(
-            return_value={
-                "landed": 10,
-                "wallet_connected": 4,
-                "generation_started": 2,
-                "vault_deployed": 1,
-            }
+    with (
+        patch(
+            "archimedes.api.metrics_routes.FunnelStore.get_totals",
+            new=AsyncMock(
+                return_value={
+                    "landed": 10,
+                    "wallet_connected": 4,
+                    "generation_started": 2,
+                    "vault_deployed": 1,
+                }
+            ),
+        ),
+        patch(
+            "archimedes.api.metrics_routes.FunnelStore.get_totals_by_agent_type",
+            new=AsyncMock(
+                return_value={
+                    "landed": {"internal": 1, "external": 2, "human": 7},
+                    "wallet_connected": {"internal": 0, "external": 0, "human": 4},
+                    "generation_started": {"internal": 0, "external": 0, "human": 2},
+                    "vault_deployed": {"internal": 0, "external": 0, "human": 1},
+                }
+            ),
         ),
     ):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -222,6 +235,11 @@ async def test_get_funnel_defaults_to_visitor_source():
         "generation_started",
         "vault_deployed",
     ]
+    # #788: the per-stage agent_type breakdown rides alongside the unchanged aggregate.
+    by_stage = {s["stage"]: s["by_agent_type"] for s in data["stages"]}
+    assert by_stage["landed"] == {"internal": 1, "external": 2, "human": 7}
+    landed = next(s for s in data["stages"] if s["stage"] == "landed")
+    assert landed["distinct_visitors"] == 10  # unchanged by the additive breakdown
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Issue #788's acceptance criterion — "the agent path is reflected in the
funnel/telemetry as agent_type so we can measure agent conversion
separately from human" — wasn't actually wired up. `telemetry_middleware.py`
already classifies every request into `request.state.agent_type`
(`internal`/`external`/`human`), but that classification was dropped before
it reached the funnel: `FunnelStore.record(stage, visitor_id)` had no
`agent_type` parameter, and `record_funnel()` never read it off the
request.

This PR threads it through, purely additively:

- `FunnelStore.record()` gains an optional `agent_type` param. When it's a
  recognized value, the visitor is *additionally* tagged into a per-stage,
  per-agent_type HLL (`archimedes:funnel:total:<stage>:<agent_type>` /
  the per-day equivalent) — the existing stage-only aggregate keys are
  untouched, so every current reader sees identical numbers.
- `record_funnel()` reads `request.state.agent_type` and passes it
  through. All four call sites (`generate_routes`, `vaults_routes`,
  `auth_siwe`, the metrics beacon) already pass `request` in, so none of
  them needed to change.
- `GET /api/metrics/funnel` surfaces the breakdown as a new `by_agent_type`
  field per stage, alongside the unchanged `distinct_visitors` /
  `pct_of_landed` / `step_conversion`.
- Graceful degradation: a request whose `agent_type` was never classified
  (attribute missing on `request.state`) still records under the
  aggregate, unchanged from today's behavior.

Only one acceptance criterion of #788 (not the whole issue) — leaving #788
open.

## Test plan

- [x] `backend/tests/test_funnel_store.py` — 33 tests (9 new): per-agent_type
      write/read, unrecognized-agent_type no-op, `_build_funnel` threading
      the breakdown map (including a stage missing from it), and the
      `record_funnel` backward-compat case (no `agent_type` on
      `request.state`).
- [x] `backend/tests/test_metrics_routes.py` — updated the `GET
      /api/metrics/funnel` test to mock the new store call and assert
      `by_agent_type` rides alongside the unchanged aggregate.
- [x] Hermetic gate on all three touched test files: `env -i HOME=$HOME
      PATH=$PATH PYTHONPATH=backend python -m pytest
      backend/tests/test_funnel_store.py backend/tests/test_metrics_routes.py
      backend/tests/test_visitor_insights.py -q` → 53 passed, 0 failed.
- [x] `ruff format --check` + `ruff check` clean on all six touched files.
- [x] Coverage on the three touched production modules: 89% combined
      (funnel_store 90%, funnel_middleware 85%, metrics_routes 89%) — the
      few uncovered lines are pre-existing (`_get_redis` lazy-init,
      `close()`), untouched by this change.