### PR TITLE
[marketplace] Add subscribe-path 429, env var, and tests for the spend cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,12 @@ CIRCLE_BLOCKCHAIN=ARC-TESTNET
 PAYMENTS_DRY_RUN=true
 # CIRCLE_API_KEY / CIRCLE_ENTITY_SECRET (above) also gate DCW provisioning —
 # without them subscribe/publish 502 at wallet-provision time.
+# MARKETPLACE_SPEND_CAP_USDC: per-subscriber-wallet rolling 24h USDC spend cap
+#   (issue #713) — a wallet at/over this cap is refused further charges
+#   (marketplace/spend_cap.py, wired into MarketService._charge_one) and new
+#   subscriptions (429 on POST /api/marketplace/subscribe). Default 50 is a
+#   placeholder, not a risk-modeled number; set to 0 to disable the check.
+MARKETPLACE_SPEND_CAP_USDC=50
 
 # ── Email encryption at rest ──────────────────────────────────────────────
 # REQUIRED when PUBLIC_DOMAIN is set (production). Generate with:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -60,7 +60,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install --quiet ruff
+      # Pinned to match .pre-commit-config.yaml's ruff-pre-commit rev — an
+      # unpinned install here silently drifts to whatever ruff just released,
+      # which can reformat files differently than the last commit that ran
+      # `ruff format .` and fail every open PR for a reason unrelated to its
+      # diff. Bump both together when intentionally upgrading ruff.
+      - run: pip install --quiet ruff==0.15.13
       - name: ruff format --check
         run: ruff format --check .
       - name: ruff check (critical rules only)
@@ -75,7 +80,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install --quiet ruff
+      # Pinned to match ruff-gate + .pre-commit-config.yaml (see comment there).
+      - run: pip install --quiet ruff==0.15.13
 
       - uses: actions/setup-node@v6
         with:

--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -15,8 +16,8 @@ from sqlalchemy.exc import IntegrityError
 
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
+from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 from archimedes.db import get_session
-from archimedes.marketplace import spend_cap
 from archimedes.marketplace.encoding import derive_pool_id, to_bytes32
 from archimedes.marketplace.service import MarketService, Subscriber
 from archimedes.models.marketplace import MarketplaceAgent
@@ -28,12 +29,56 @@ logger = logging.getLogger(__name__)
 
 marketplace_router = APIRouter(prefix="/api/marketplace", tags=["marketplace"])
 
+# 20-byte 0x-prefixed hex address. vault_address arrives via an untyped body
+# dict, so validate before any chain read — a malformed address must be a 400
+# (client error), not a 502 from the fee guard's fail-closed path.
+_EVM_ADDRESS_RE = re.compile(r"^0x[a-fA-F0-9]{40}$")
+
 
 def _get_market(request: Request) -> MarketService:
     market: MarketService | None = getattr(request.app.state, "market", None)
     if market is None:
         raise HTTPException(status_code=503, detail="Marketplace engine not available")
     return market
+
+
+async def _require_vault_fees_within_caps(market: MarketService, vault_address: str) -> None:
+    """Refuse any vault whose on-chain fees exceed the #1129 caps (issue #1138).
+
+    The live VaultFactory predates the constructor caps and fee bps are
+    immutable with no setter, so a vault created with hostile fees before the
+    factory redeploy stays hostile forever. The only protection for users is
+    off-chain: read the fees and refuse to interact.
+
+    Fail-CLOSED on read failure: this guard is fund-adjacent — waving through
+    a vault whose fees we couldn't verify exposes depositors to the C1
+    fee-drain, so an unreadable vault is refused with a 502. (Contrast with
+    the #713 spend cap, which fails open for availability: the worst case
+    there is a bounded overcharge, not principal loss.)
+    """
+    try:
+        mgmt_fee_bps, perf_fee_bps = await market.executor.get_vault_fee_bps(vault_address)
+    except Exception as exc:
+        logger.warning("Fee-cap guard: could not read fees for vault %s: %s", vault_address, exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Could not verify on-chain fees for vault {vault_address}; refusing (fail-closed)",
+        ) from exc
+    if mgmt_fee_bps > MAX_MANAGEMENT_FEE_BPS or perf_fee_bps > MAX_PERFORMANCE_FEE_BPS:
+        logger.warning(
+            "Fee-cap guard: refusing vault %s (managementFeeBps=%d, performanceFeeBps=%d)",
+            vault_address,
+            mgmt_fee_bps,
+            perf_fee_bps,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Vault {vault_address} fees exceed caps: "
+                f"managementFeeBps={mgmt_fee_bps} (cap {MAX_MANAGEMENT_FEE_BPS}), "
+                f"performanceFeeBps={perf_fee_bps} (cap {MAX_PERFORMANCE_FEE_BPS})"
+            ),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +169,16 @@ async def publish_strategy(
             agent_assisted=True,
             owner_wallet=wallet,
         )
+    else:
+        if not _EVM_ADDRESS_RE.fullmatch(vault_address):
+            raise HTTPException(
+                status_code=400,
+                detail="vault_address must be a 0x-prefixed 20-byte hex address",
+            )
+        # Fee-cap guard (issue #1138) — only the user-supplied path needs it:
+        # a reused vault may have been minted by the pre-cap factory with
+        # hostile immutable fees, while the create path above hardcodes 0/0.
+        await _require_vault_fees_within_caps(market, vault_address)
 
     # 3a. Publish funding gate (D7) — vault MUST hold at least
     #     MARKETPLACE_MIN_VAULT_FUNDS_RAW idle USDC (raw 6-dec).
@@ -252,7 +307,7 @@ async def publish_strategy(
 
 
 @marketplace_router.post("/subscribe")
-@limiter.limit("5/minute")
+@limiter.limit(os.getenv("SUBSCRIBE_RATE_LIMIT", "5/minute"))
 async def subscribe_strategy(
     request: Request,
     response: Response,  # required by slowapi header injection (headers_enabled=True) — looks unused, is not
@@ -305,6 +360,12 @@ async def subscribe_strategy(
     if pub_row is None:
         raise HTTPException(status_code=404, detail=f"No running publisher for strategy '{strategy_id}'")
 
+    # 1a. Fee-cap guard (issue #1138): the publisher's vault is where the
+    # subscription's economics live — a vault published before the guard
+    # existed (or minted by the pre-cap factory) may carry hostile immutable
+    # fees. Refuse before provisioning any wallet for a doomed subscribe.
+    await _require_vault_fees_within_caps(market, pub_row.vault_address)
+
     # 2. Reject if this wallet is already subscribed
     with get_session() as session:
         existing = (
@@ -333,25 +394,6 @@ async def subscribe_strategy(
         )
         if sub_id_taken is not None:
             raise HTTPException(status_code=409, detail="sub_id already in use")
-
-    # 2c. Spend-cap guard (#713): refuse a NEW subscription for a wallet
-    # already at/over its rolling 24h marketplace spend cap. This is the one
-    # place in the subscribe path building a synchronous HTTP response for a
-    # specific wallet, so it's the natural spot for a literal 429 — the
-    # charge-time enforcement in MarketService._charge_one is the more
-    # operationally important guard (it stops further charges on EXISTING
-    # subscriptions) but runs in a background tick loop and cannot itself
-    # produce an HTTP response. No additional_amount_raw here — this checks
-    # current standing only, not a specific pending charge.
-    if await spend_cap.is_over_cap(wallet.lower()):
-        raise HTTPException(
-            status_code=429,
-            detail={
-                "message": "This wallet is at its rolling 24h marketplace spend cap — try subscribing again once the window clears.",
-                "reason": "marketplace_spend_cap_reached",
-                "cap_usdc": str(spend_cap.spend_cap_usdc()),
-            },
-        )
 
     # 3. Use the server-derived pool_id for storage (D-POOL)
     pool_id = derive_pool_id(strategy_id, pub_row.creator_wallet)

--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import IntegrityError
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
 from archimedes.db import get_session
+from archimedes.marketplace import spend_cap
 from archimedes.marketplace.encoding import derive_pool_id, to_bytes32
 from archimedes.marketplace.service import MarketService, Subscriber
 from archimedes.models.marketplace import MarketplaceAgent
@@ -332,6 +333,25 @@ async def subscribe_strategy(
         )
         if sub_id_taken is not None:
             raise HTTPException(status_code=409, detail="sub_id already in use")
+
+    # 2c. Spend-cap guard (#713): refuse a NEW subscription for a wallet
+    # already at/over its rolling 24h marketplace spend cap. This is the one
+    # place in the subscribe path building a synchronous HTTP response for a
+    # specific wallet, so it's the natural spot for a literal 429 — the
+    # charge-time enforcement in MarketService._charge_one is the more
+    # operationally important guard (it stops further charges on EXISTING
+    # subscriptions) but runs in a background tick loop and cannot itself
+    # produce an HTTP response. No additional_amount_raw here — this checks
+    # current standing only, not a specific pending charge.
+    if await spend_cap.is_over_cap(wallet.lower()):
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "message": "This wallet is at its rolling 24h marketplace spend cap — try subscribing again once the window clears.",
+                "reason": "marketplace_spend_cap_reached",
+                "cap_usdc": str(spend_cap.spend_cap_usdc()),
+            },
+        )
 
     # 3. Use the server-derived pool_id for storage (D-POOL)
     pool_id = derive_pool_id(strategy_id, pub_row.creator_wallet)

--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -16,8 +15,8 @@ from sqlalchemy.exc import IntegrityError
 
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
-from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 from archimedes.db import get_session
+from archimedes.marketplace import spend_cap
 from archimedes.marketplace.encoding import derive_pool_id, to_bytes32
 from archimedes.marketplace.service import MarketService, Subscriber
 from archimedes.models.marketplace import MarketplaceAgent
@@ -29,56 +28,12 @@ logger = logging.getLogger(__name__)
 
 marketplace_router = APIRouter(prefix="/api/marketplace", tags=["marketplace"])
 
-# 20-byte 0x-prefixed hex address. vault_address arrives via an untyped body
-# dict, so validate before any chain read — a malformed address must be a 400
-# (client error), not a 502 from the fee guard's fail-closed path.
-_EVM_ADDRESS_RE = re.compile(r"^0x[a-fA-F0-9]{40}$")
-
 
 def _get_market(request: Request) -> MarketService:
     market: MarketService | None = getattr(request.app.state, "market", None)
     if market is None:
         raise HTTPException(status_code=503, detail="Marketplace engine not available")
     return market
-
-
-async def _require_vault_fees_within_caps(market: MarketService, vault_address: str) -> None:
-    """Refuse any vault whose on-chain fees exceed the #1129 caps (issue #1138).
-
-    The live VaultFactory predates the constructor caps and fee bps are
-    immutable with no setter, so a vault created with hostile fees before the
-    factory redeploy stays hostile forever. The only protection for users is
-    off-chain: read the fees and refuse to interact.
-
-    Fail-CLOSED on read failure: this guard is fund-adjacent — waving through
-    a vault whose fees we couldn't verify exposes depositors to the C1
-    fee-drain, so an unreadable vault is refused with a 502. (Contrast with
-    the #713 spend cap, which fails open for availability: the worst case
-    there is a bounded overcharge, not principal loss.)
-    """
-    try:
-        mgmt_fee_bps, perf_fee_bps = await market.executor.get_vault_fee_bps(vault_address)
-    except Exception as exc:
-        logger.warning("Fee-cap guard: could not read fees for vault %s: %s", vault_address, exc)
-        raise HTTPException(
-            status_code=502,
-            detail=f"Could not verify on-chain fees for vault {vault_address}; refusing (fail-closed)",
-        ) from exc
-    if mgmt_fee_bps > MAX_MANAGEMENT_FEE_BPS or perf_fee_bps > MAX_PERFORMANCE_FEE_BPS:
-        logger.warning(
-            "Fee-cap guard: refusing vault %s (managementFeeBps=%d, performanceFeeBps=%d)",
-            vault_address,
-            mgmt_fee_bps,
-            perf_fee_bps,
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Vault {vault_address} fees exceed caps: "
-                f"managementFeeBps={mgmt_fee_bps} (cap {MAX_MANAGEMENT_FEE_BPS}), "
-                f"performanceFeeBps={perf_fee_bps} (cap {MAX_PERFORMANCE_FEE_BPS})"
-            ),
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -169,16 +124,6 @@ async def publish_strategy(
             agent_assisted=True,
             owner_wallet=wallet,
         )
-    else:
-        if not _EVM_ADDRESS_RE.fullmatch(vault_address):
-            raise HTTPException(
-                status_code=400,
-                detail="vault_address must be a 0x-prefixed 20-byte hex address",
-            )
-        # Fee-cap guard (issue #1138) — only the user-supplied path needs it:
-        # a reused vault may have been minted by the pre-cap factory with
-        # hostile immutable fees, while the create path above hardcodes 0/0.
-        await _require_vault_fees_within_caps(market, vault_address)
 
     # 3a. Publish funding gate (D7) — vault MUST hold at least
     #     MARKETPLACE_MIN_VAULT_FUNDS_RAW idle USDC (raw 6-dec).
@@ -307,7 +252,7 @@ async def publish_strategy(
 
 
 @marketplace_router.post("/subscribe")
-@limiter.limit(os.getenv("SUBSCRIBE_RATE_LIMIT", "5/minute"))
+@limiter.limit("5/minute")
 async def subscribe_strategy(
     request: Request,
     response: Response,  # required by slowapi header injection (headers_enabled=True) — looks unused, is not
@@ -360,12 +305,6 @@ async def subscribe_strategy(
     if pub_row is None:
         raise HTTPException(status_code=404, detail=f"No running publisher for strategy '{strategy_id}'")
 
-    # 1a. Fee-cap guard (issue #1138): the publisher's vault is where the
-    # subscription's economics live — a vault published before the guard
-    # existed (or minted by the pre-cap factory) may carry hostile immutable
-    # fees. Refuse before provisioning any wallet for a doomed subscribe.
-    await _require_vault_fees_within_caps(market, pub_row.vault_address)
-
     # 2. Reject if this wallet is already subscribed
     with get_session() as session:
         existing = (
@@ -394,6 +333,25 @@ async def subscribe_strategy(
         )
         if sub_id_taken is not None:
             raise HTTPException(status_code=409, detail="sub_id already in use")
+
+    # 2c. Spend-cap guard (#713): refuse a NEW subscription for a wallet
+    # already at/over its rolling 24h marketplace spend cap. This is the one
+    # place in the subscribe path building a synchronous HTTP response for a
+    # specific wallet, so it's the natural spot for a literal 429 — the
+    # charge-time enforcement in MarketService._charge_one is the more
+    # operationally important guard (it stops further charges on EXISTING
+    # subscriptions) but runs in a background tick loop and cannot itself
+    # produce an HTTP response. No additional_amount_raw here — this checks
+    # current standing only, not a specific pending charge.
+    if await spend_cap.is_over_cap(wallet.lower()):
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "message": "This wallet is at its rolling 24h marketplace spend cap — try subscribing again once the window clears.",
+                "reason": "marketplace_spend_cap_reached",
+                "cap_usdc": str(spend_cap.spend_cap_usdc()),
+            },
+        )
 
     # 3. Use the server-derived pool_id for storage (D-POOL)
     pool_id = derive_pool_id(strategy_id, pub_row.creator_wallet)

--- a/backend/archimedes/marketplace/service.py
+++ b/backend/archimedes/marketplace/service.py
@@ -25,7 +25,7 @@ from archimedes.chain.oracle_updater import OracleUpdater
 from archimedes.chain.v_check import VCheck
 from archimedes.db import get_session
 from archimedes.interfaces.math import IRegimeDetector
-from archimedes.marketplace import payments
+from archimedes.marketplace import payments, spend_cap
 from archimedes.marketplace.settlement import SettlementSweeper
 from archimedes.marketplace.state import MarketState
 from archimedes.marketplace.tick_registry import (
@@ -623,7 +623,9 @@ class MarketService:
 
         async def _one(sub):
             async with sem:
-                paid = await self._charge_one(pub, sub, strategy_id, tick_id, TickStep.REBALANCE, action_count)
+                paid, halt_reason_override = await self._charge_one(
+                    pub, sub, strategy_id, tick_id, TickStep.REBALANCE, action_count
+                )
                 if not paid:
                     self._defer_subscriber(pub, sub)
                     await self.record_subscriber_tick(
@@ -635,7 +637,7 @@ class MarketService:
                             step_reached=TickStep.REBALANCE,
                             halted=True,
                             halt_source=HaltSource.PAYMENT,
-                            halt_reason="could not afford rebalance",
+                            halt_reason=halt_reason_override or "could not afford rebalance",
                             charged=False,
                             action_count=action_count,
                         )
@@ -820,22 +822,45 @@ class MarketService:
         except Exception:
             logger.exception("Failed to finalize settlement intent %s / %s / %s", strategy_id, tick_id, sub_id)
 
-    async def _charge_one(self, pub, sub, strategy_id, tick_id, step: TickStep, action_count: int) -> bool:
+    async def _charge_one(
+        self, pub, sub, strategy_id, tick_id, step: TickStep, action_count: int
+    ) -> tuple[bool, str | None]:
+        """Returns (paid, halt_reason_override). halt_reason_override is only set
+        when this method refuses the charge for a reason more specific than the
+        caller's own generic "could not afford X" message (currently: only the
+        #713 spend cap) — callers should prefer it over their default message
+        when it isn't None."""
         if self.payments_dry_run:
-            return True
+            return True, None
         if not pub.gateway_seller_address:
             logger.warning("[%s] no gateway_seller_address for pub %s — unpaid", tick_id, strategy_id)
-            return False
+            return False, None
         if not sub.circle_wallet_id:
             logger.warning("[%s] no circle_wallet_id for sub %s — unpaid", tick_id, sub.sub_id)
-            return False
+            return False, None
+
+        # Spend-cap guard (#713): per subscriber WALLET (not sub_id — one wallet
+        # can run several subscriptions and the cap is meant to bound total
+        # exposure, not let it multiply per subscription). Checked before the
+        # idempotency claim below so an over-cap charge never consumes a
+        # settlement-intent slot for a charge that isn't going to happen.
+        pending_raw = action_count * FLAT_FEE_PER_ACTION
+        if await spend_cap.is_over_cap(sub.subscriber_wallet, pending_raw):
+            logger.info(
+                "[%s] sub %s (wallet %s) at/over 24h spend cap — refusing charge for step %s",
+                tick_id,
+                sub.sub_id,
+                sub.subscriber_wallet[:10],
+                step.value,
+            )
+            return False, "24h spend cap reached"
 
         # Idempotency guard (x402 is NOT crash-retry-idempotent — a retry signs a
         # fresh EIP-3009 nonce that settles as a new payment). Claim the logical
         # charge BEFORE settling so a crash/retry cannot double-charge.
         claim = self._claim_settlement_intent(strategy_id, tick_id, sub.sub_id, step.value)
         if claim == "already_settled":
-            return True  # this exact (strategy, tick, sub, step) already paid
+            return True, None  # this exact (strategy, tick, sub, step) already paid
         if claim == "in_flight":
             logger.warning(
                 "[%s] settlement intent already in-flight for sub %s step %s — skipping to avoid double-charge",
@@ -843,7 +868,7 @@ class MarketService:
                 sub.sub_id,
                 step.value,
             )
-            return False
+            return False, None
 
         paid = await payments.charge(
             sub_id=sub.sub_id,
@@ -857,7 +882,11 @@ class MarketService:
             step=step.value,
         )
         self._finalize_settlement_intent(strategy_id, tick_id, sub.sub_id, step.value, settled=paid)
-        return paid
+        if paid:
+            await spend_cap.record_charge_usdc(
+                sub.subscriber_wallet, charge_id=f"{tick_id}:{step.value}", amount_raw=pending_raw
+            )
+        return paid, None
 
     # F6.6 — charge all active subscribers for one pipeline step
     # Batched into groups of CHARGE_BATCH_SIZE for concurrent Circle signing.
@@ -869,9 +898,11 @@ class MarketService:
                 *[self._charge_one(pub, s, strategy_id, tick_id, step, action_count=1) for s in chunk],
                 return_exceptions=True,
             )
-            for sub, paid in zip(chunk, results, strict=True):  # results == gather(over chunk) → same length
-                if isinstance(paid, Exception):
-                    paid = False
+            for sub, result in zip(chunk, results, strict=True):  # results == gather(over chunk) → same length
+                if isinstance(result, Exception):
+                    paid, halt_reason_override = False, None
+                else:
+                    paid, halt_reason_override = result
                 if paid:
                     await self.record_subscriber_tick(
                         SubscriberTickRecord(
@@ -897,7 +928,7 @@ class MarketService:
                             step_reached=step,
                             halted=True,
                             halt_source=HaltSource.PAYMENT,
-                            halt_reason=f"could not afford {step.value}",
+                            halt_reason=halt_reason_override or f"could not afford {step.value}",
                             charged=False,
                             action_count=1,
                         )
@@ -1112,7 +1143,8 @@ class MarketService:
         action_count: int,
     ) -> bool:
         """Legacy delegate — replaced by _charge_one.  Kept for test compat."""
-        return await self._charge_one(pub, sub, strategy_id, tick_id, TickStep.LOAD_STRATEGY, action_count)
+        paid, _ = await self._charge_one(pub, sub, strategy_id, tick_id, TickStep.LOAD_STRATEGY, action_count)
+        return paid
 
     async def _record_liability(self, sub: Subscriber, strategy_id: str, tick_id: str, action_count: int) -> None:
         """Record a charge-succeeded/mirror-failed liability. Best-effort:

--- a/backend/archimedes/marketplace/service.py
+++ b/backend/archimedes/marketplace/service.py
@@ -839,25 +839,13 @@ class MarketService:
             logger.warning("[%s] no circle_wallet_id for sub %s — unpaid", tick_id, sub.sub_id)
             return False, None
 
-        # Spend-cap guard (#713): per subscriber WALLET (not sub_id — one wallet
-        # can run several subscriptions and the cap is meant to bound total
-        # exposure, not let it multiply per subscription). Checked before the
-        # idempotency claim below so an over-cap charge never consumes a
-        # settlement-intent slot for a charge that isn't going to happen.
-        pending_raw = action_count * FLAT_FEE_PER_ACTION
-        if await spend_cap.is_over_cap(sub.subscriber_wallet, pending_raw):
-            logger.info(
-                "[%s] sub %s (wallet %s) at/over 24h spend cap — refusing charge for step %s",
-                tick_id,
-                sub.sub_id,
-                sub.subscriber_wallet[:10],
-                step.value,
-            )
-            return False, "24h spend cap reached"
-
         # Idempotency guard (x402 is NOT crash-retry-idempotent — a retry signs a
         # fresh EIP-3009 nonce that settles as a new payment). Claim the logical
-        # charge BEFORE settling so a crash/retry cannot double-charge.
+        # charge BEFORE settling so a crash/retry cannot double-charge. This also
+        # gates the spend-cap reservation below: it guarantees we reach that
+        # reservation at most once per logical charge, so a crash-retry of an
+        # already-settled charge short-circuits here first instead of trying to
+        # reserve the same amount twice (see try_reserve_usdc's docstring).
         claim = self._claim_settlement_intent(strategy_id, tick_id, sub.sub_id, step.value)
         if claim == "already_settled":
             return True, None  # this exact (strategy, tick, sub, step) already paid
@@ -869,6 +857,27 @@ class MarketService:
                 step.value,
             )
             return False, None
+
+        # Spend-cap guard (#713): per subscriber WALLET (not sub_id — one wallet
+        # can run several subscriptions and the cap is meant to bound total
+        # exposure, not let it multiply per subscription). Reserved atomically,
+        # immediately before payments.charge() — a separate check-then-record
+        # (the original design) is a TOCTOU race: N concurrent charges near the
+        # cap could all read "under cap" before any of them recorded anything,
+        # so all N would proceed and blow through the cap by up to N times a
+        # single charge (#1099 review). Released below if the charge fails.
+        pending_raw = action_count * FLAT_FEE_PER_ACTION
+        charge_id = f"{tick_id}:{step.value}"
+        if not await spend_cap.try_reserve_usdc(sub.subscriber_wallet, pending_raw, charge_id):
+            logger.info(
+                "[%s] sub %s (wallet %s) at/over 24h spend cap — refusing charge for step %s",
+                tick_id,
+                sub.sub_id,
+                sub.subscriber_wallet[:10],
+                step.value,
+            )
+            self._finalize_settlement_intent(strategy_id, tick_id, sub.sub_id, step.value, settled=False)
+            return False, "24h spend cap reached"
 
         paid = await payments.charge(
             sub_id=sub.sub_id,
@@ -882,10 +891,8 @@ class MarketService:
             step=step.value,
         )
         self._finalize_settlement_intent(strategy_id, tick_id, sub.sub_id, step.value, settled=paid)
-        if paid:
-            await spend_cap.record_charge_usdc(
-                sub.subscriber_wallet, charge_id=f"{tick_id}:{step.value}", amount_raw=pending_raw
-            )
+        if not paid:
+            await spend_cap.release_reservation(sub.subscriber_wallet, charge_id, pending_raw)
         return paid, None
 
     # F6.6 — charge all active subscribers for one pipeline step

--- a/backend/archimedes/marketplace/service.py
+++ b/backend/archimedes/marketplace/service.py
@@ -866,8 +866,13 @@ class MarketService:
         # cap could all read "under cap" before any of them recorded anything,
         # so all N would proceed and blow through the cap by up to N times a
         # single charge (#1099 review). Released below if the charge fails.
+        # charge_id includes sub_id so the Redis member is unique per logical
+        # charge even for two subscriptions charged from the same wallet in the
+        # same tick+step. Today the subscribe route only allows one running sub
+        # per (wallet, strategy) so that can't happen, but the cap must not
+        # silently undercount (or cross-release) if that invariant ever relaxes.
         pending_raw = action_count * FLAT_FEE_PER_ACTION
-        charge_id = f"{tick_id}:{step.value}"
+        charge_id = f"{tick_id}:{sub.sub_id}:{step.value}"
         if not await spend_cap.try_reserve_usdc(sub.subscriber_wallet, pending_raw, charge_id):
             logger.info(
                 "[%s] sub %s (wallet %s) at/over 24h spend cap — refusing charge for step %s",
@@ -879,17 +884,25 @@ class MarketService:
             self._finalize_settlement_intent(strategy_id, tick_id, sub.sub_id, step.value, settled=False)
             return False, "24h spend cap reached"
 
-        paid = await payments.charge(
-            sub_id=sub.sub_id,
-            wallet_id=sub.circle_wallet_id,
-            wallet_address=sub.ephemeral_wallet,
-            seller_address=pub.gateway_seller_address,
-            strategy_id=strategy_id,
-            tick_id=tick_id,
-            action_count=action_count,
-            flat_fee_raw=FLAT_FEE_PER_ACTION,
-            step=step.value,
-        )
+        # payments.charge documents "never raises", but the reservation above
+        # must not depend on that contract holding forever: a raise escaping
+        # here would leave the reserved amount sitting in the wallet's window
+        # for 24h (and the intent pending). Treat a raise as a failed charge.
+        try:
+            paid = await payments.charge(
+                sub_id=sub.sub_id,
+                wallet_id=sub.circle_wallet_id,
+                wallet_address=sub.ephemeral_wallet,
+                seller_address=pub.gateway_seller_address,
+                strategy_id=strategy_id,
+                tick_id=tick_id,
+                action_count=action_count,
+                flat_fee_raw=FLAT_FEE_PER_ACTION,
+                step=step.value,
+            )
+        except Exception:
+            logger.exception("[%s] payments.charge raised for sub %s — treating as unpaid", tick_id, sub.sub_id)
+            paid = False
         self._finalize_settlement_intent(strategy_id, tick_id, sub.sub_id, step.value, settled=paid)
         if not paid:
             await spend_cap.release_reservation(sub.subscriber_wallet, charge_id, pending_raw)

--- a/backend/archimedes/marketplace/spend_cap.py
+++ b/backend/archimedes/marketplace/spend_cap.py
@@ -80,9 +80,11 @@ async def get_24h_spend_usdc(subscriber_wallet: str) -> Decimal:
     """Sum of USDC actually charged to *subscriber_wallet* in the trailing 24h.
 
     Prunes expired entries first (ZREMRANGEBYSCORE), so this is always the
-    live rolling total, not a stale snapshot. Never raises — a Redis failure
-    here should not itself block or corrupt a charge decision; callers treat
-    an exception as "cap unknown" (see is_over_cap).
+    live rolling total, not a stale snapshot. Does NOT itself catch Redis
+    errors — a connection failure propagates to the caller. is_over_cap is
+    the fail-open boundary: it wraps this call in a try/except and treats
+    any exception as "cap unknown", degrading to False (allow the charge)
+    rather than blocking a charge decision on a Redis outage.
     """
     r = await _get_store()._get_redis()
     key = _key(subscriber_wallet)
@@ -145,7 +147,9 @@ async def is_over_cap(subscriber_wallet: str, additional_amount_raw: int = 0) ->
     try:
         current = await get_24h_spend_usdc(subscriber_wallet)
     except Exception:
-        logger.exception("Spend-cap check failed for wallet %s — failing open (allowing the charge)", subscriber_wallet[:10])
+        logger.exception(
+            "Spend-cap check failed for wallet %s — failing open (allowing the charge)", subscriber_wallet[:10]
+        )
         return False
     additional = _raw_to_usdc(additional_amount_raw) if additional_amount_raw else Decimal(0)
     return (current + additional) >= cap

--- a/backend/archimedes/marketplace/spend_cap.py
+++ b/backend/archimedes/marketplace/spend_cap.py
@@ -66,13 +66,14 @@ _USDC_DECIMALS = 6
 #             of the verdict (is_over_cap's mode)
 # Returns 1 if amount_raw fits under the cap, 0 if it would meet/exceed it.
 #
-# Checks whether `member` already exists BEFORE summing, so re-reserving the
-# exact same (charge_id, amount_raw) — e.g. a caller that reserves twice for
-# what is logically one charge — does not double-count its own prior
-# contribution against the cap: the existing entry is already inside `total`,
-# so it is not added a second time. Callers should still avoid reserving the
-# same charge twice (see try_reserve_usdc's docstring on ordering relative to
-# the idempotency claim); this is defense in depth, not license to skip that.
+# The double-count-avoidance check (does `member` already exist?) only runs
+# when do_reserve==1 — i.e. only in the mode where `member` means anything.
+# In read-only mode (do_reserve==0, is_over_cap's mode) member is always the
+# empty string, so checking its existence would be meaningless at best; worse,
+# ZSCORE key "" happening to find a real (corrupted/externally-written) empty
+# member would wrongly skip adding amount_raw to the projection and undercount
+# (#1099 review — Copilot). Gating it behind do_reserve==1 also drops an
+# unnecessary Redis call from every read-only check.
 _CHECK_AND_RESERVE_LUA = """
 local key = KEYS[1]
 local window_start = tonumber(ARGV[1])
@@ -84,7 +85,6 @@ local ttl_seconds = ARGV[6]
 local do_reserve = tonumber(ARGV[7])
 
 redis.call("ZREMRANGEBYSCORE", key, 0, window_start)
-local already_reserved = redis.call("ZSCORE", key, member)
 local members = redis.call("ZRANGE", key, 0, -1)
 local total = 0
 for _, m in ipairs(members) do
@@ -94,9 +94,20 @@ for _, m in ipairs(members) do
     end
 end
 
-local projected = total
-if already_reserved == false then
-    projected = total + amount_raw
+-- Default: amount_raw is new spend, not yet counted in `total`.
+local projected = total + amount_raw
+if do_reserve == 1 then
+    -- Re-reserving the exact same (charge_id, amount_raw) as an existing
+    -- entry (e.g. a caller that reserves twice for what is logically one
+    -- charge) must not double-count it: it is already inside `total`, so
+    -- don't add it again. Callers should still avoid reserving the same
+    -- charge twice (see try_reserve_usdc's docstring on ordering relative
+    -- to the idempotency claim) — this is defense in depth, not a license
+    -- to skip that.
+    local already_reserved = redis.call("ZSCORE", key, member)
+    if already_reserved ~= false then
+        projected = total
+    end
 end
 
 if projected >= cap_raw then

--- a/backend/archimedes/marketplace/spend_cap.py
+++ b/backend/archimedes/marketplace/spend_cap.py
@@ -1,0 +1,151 @@
+"""Per-subscriber-wallet rolling 24h spend cap for marketplace nanopayments (#713).
+
+Tracks USDC actually charged per subscriber wallet (not per sub_id — a wallet can
+run several subscriptions, and the cap is meant to bound one person's total
+exposure, not let it multiply per subscription) in a trailing 24h window, and
+lets callers refuse a charge (or a new subscription) that would push the wallet
+over a configured ceiling.
+
+Kept deliberately separate from payments.py (settlement) and service.py (custody,
+liability, halting): this is a pure "would this push the wallet over its own
+declared limit" check, backed by its own Redis key. Issue #975's non-custodial
+fee-custody migration will rework payments.py/wallet_provisioner.py/marketplace_routes.py
+for custody reasons; this module doesn't touch custody at all, so it shouldn't
+need rework alongside that migration.
+
+Storage: one Redis sorted set per wallet, score = charge unix timestamp, member =
+f"{charge_id}:{amount_raw}" (amount_raw is 6-decimal raw USDC, matching the rest
+of this codebase's convention — see payments.fee_to_price). charge_id only needs
+to make the member unique per entry; it is never read back.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from decimal import Decimal
+
+from archimedes.services.redis_state import AgentStateStore
+
+logger = logging.getLogger(__name__)
+
+_SPEND_PREFIX = "archimedes:market:spend:"  # + subscriber_wallet (lowercased)
+_WINDOW_SECONDS = 24 * 60 * 60
+_KEY_TTL_SECONDS = _WINDOW_SECONDS + 3600  # small margin past the window so an
+# inactive wallet's key disappears on its own instead of living forever with
+# nothing left in range after every member has aged out.
+_USDC_DECIMALS = 6
+
+_store: AgentStateStore | None = None
+
+
+def _get_store() -> AgentStateStore:
+    global _store
+    if _store is None:
+        _store = AgentStateStore()
+    return _store
+
+
+def spend_cap_usdc() -> Decimal:
+    """The configured per-wallet 24h USDC spend cap.
+
+    Default (50) is NOT grounded in any specific risk analysis — today's
+    FLAT_FEE_PER_ACTION (100 raw units = $0.0001/action) makes any USDC-scale
+    cap enormously permissive relative to current testnet fee levels. Treat
+    this default as a placeholder to be revisited once real pricing is live
+    (PAYMENTS_DRY_RUN=false), not a considered number.
+
+    A cap of 0 (or unset — the default keeps it non-zero) disables the check
+    entirely, matching this codebase's general fail-open-when-unconfigured
+    convention for opt-in safety features.
+    """
+    raw = os.getenv("MARKETPLACE_SPEND_CAP_USDC", "50")
+    try:
+        return Decimal(raw)
+    except Exception:
+        logger.warning("MARKETPLACE_SPEND_CAP_USDC=%r is not a valid number — treating as disabled", raw)
+        return Decimal(0)
+
+
+def _key(subscriber_wallet: str) -> str:
+    return f"{_SPEND_PREFIX}{subscriber_wallet.lower()}"
+
+
+def _raw_to_usdc(amount_raw: int | str) -> Decimal:
+    return Decimal(amount_raw) / (Decimal(10) ** _USDC_DECIMALS)
+
+
+async def get_24h_spend_usdc(subscriber_wallet: str) -> Decimal:
+    """Sum of USDC actually charged to *subscriber_wallet* in the trailing 24h.
+
+    Prunes expired entries first (ZREMRANGEBYSCORE), so this is always the
+    live rolling total, not a stale snapshot. Never raises — a Redis failure
+    here should not itself block or corrupt a charge decision; callers treat
+    an exception as "cap unknown" (see is_over_cap).
+    """
+    r = await _get_store()._get_redis()
+    key = _key(subscriber_wallet)
+    now = time.time()
+    await r.zremrangebyscore(key, 0, now - _WINDOW_SECONDS)
+    members = await r.zrange(key, 0, -1)
+    total = Decimal(0)
+    for member in members:
+        try:
+            total += _raw_to_usdc(member.rsplit(":", 1)[-1])
+        except Exception:
+            continue  # malformed member (should not happen) — skip, don't fail the whole read
+    return total
+
+
+async def record_charge_usdc(subscriber_wallet: str, charge_id: str, amount_raw: int) -> None:
+    """Record a SUCCESSFUL charge against the wallet's rolling window.
+
+    Call this only after payments.charge() returns True — this function does
+    not charge anything itself, it only tracks what was already charged.
+    Best-effort: a failure to record must never undo or fail an already-settled
+    charge, so exceptions are logged and swallowed, never raised.
+    """
+    if amount_raw <= 0:
+        return
+    try:
+        r = await _get_store()._get_redis()
+        key = _key(subscriber_wallet)
+        now = time.time()
+        await r.zadd(key, {f"{charge_id}:{amount_raw}": now})
+        await r.expire(key, _KEY_TTL_SECONDS)
+    except Exception:
+        logger.exception(
+            "Failed to record spend-cap charge for wallet %s (charge %s, amount %d raw) — "
+            "the charge itself already succeeded and is unaffected; only this window's "
+            "bookkeeping is stale until the next successful record",
+            subscriber_wallet[:10],
+            charge_id,
+            amount_raw,
+        )
+
+
+async def is_over_cap(subscriber_wallet: str, additional_amount_raw: int = 0) -> bool:
+    """True if the wallet's current 24h spend, plus *additional_amount_raw* (a
+    pending charge not yet recorded), would meet or exceed the configured cap.
+
+    Pass additional_amount_raw=0 to just check current standing (e.g. before
+    allowing a new subscription) without evaluating a specific pending charge.
+
+    Fails OPEN (returns False — allow the charge) on a Redis read failure.
+    This is a considered choice, not an oversight: this is an additive safety
+    guard on top of the existing reactive halt-on-non-payment model
+    (SubscriberLiability / MarketplaceAgent.halted), not the only backstop —
+    a Redis outage should degrade to today's pre-existing behavior, not start
+    blocking every charge in the system.
+    """
+    cap = spend_cap_usdc()
+    if cap <= 0:
+        return False
+    try:
+        current = await get_24h_spend_usdc(subscriber_wallet)
+    except Exception:
+        logger.exception("Spend-cap check failed for wallet %s — failing open (allowing the charge)", subscriber_wallet[:10])
+        return False
+    additional = _raw_to_usdc(additional_amount_raw) if additional_amount_raw else Decimal(0)
+    return (current + additional) >= cap

--- a/backend/archimedes/marketplace/spend_cap.py
+++ b/backend/archimedes/marketplace/spend_cap.py
@@ -17,6 +17,11 @@ Storage: one Redis sorted set per wallet, score = charge unix timestamp, member 
 f"{charge_id}:{amount_raw}" (amount_raw is 6-decimal raw USDC, matching the rest
 of this codebase's convention — see payments.fee_to_price). charge_id only needs
 to make the member unique per entry; it is never read back.
+
+Checking the cap and reserving against it happen in ONE atomic Lua script
+(_CHECK_AND_RESERVE_LUA), not a read followed by a separate write — see that
+script's docstring for why a two-step check-then-record is a real race under
+concurrent charges (#1099 review).
 """
 
 from __future__ import annotations
@@ -36,6 +41,73 @@ _KEY_TTL_SECONDS = _WINDOW_SECONDS + 3600  # small margin past the window so an
 # inactive wallet's key disappears on its own instead of living forever with
 # nothing left in range after every member has aged out.
 _USDC_DECIMALS = 6
+
+# Lua: atomically check the wallet's rolling 24h spend window against the cap
+# and, if amount_raw fits, reserve it in the SAME round-trip (single EVAL — no
+# other command, including another caller's own EVAL, can interleave between
+# the sum and the write). This closes a real race (#1099 review): the original
+# design summed the window in one Redis round-trip (is_over_cap) and recorded
+# a successful charge in a separate, later one (record_charge_usdc), with the
+# async payments.charge() call in between. N concurrent charges near the cap
+# could all read "under cap" before any of them had recorded anything, so all
+# N would proceed and the wallet could blow through the cap by up to N times a
+# single charge. Modeled directly on redis_state.py's _LEASE_ACQUIRE_LUA — same
+# problem shape: check-and-claim must be one atomic primitive, not two Redis
+# round-trips with caller code (here, an async HTTP/chain call) in between.
+#   KEYS[1] = the wallet's sorted-set key
+#   ARGV[1] = window_start (unix seconds) — prune anything at/before this
+#   ARGV[2] = now (unix seconds) — the score a fresh reservation is written at
+#   ARGV[3] = cap_raw (raw USDC units) — callers already checked
+#             spend_cap_usdc() > 0 before invoking this script
+#   ARGV[4] = amount_raw — the pending amount being checked (0 for a pure read)
+#   ARGV[5] = member — f"{charge_id}:{amount_raw}", only written if ARGV[7]==1
+#   ARGV[6] = ttl_seconds — refreshed on every reservation write
+#   ARGV[7] = do_reserve (1/0) — 0 means read-only: never writes, regardless
+#             of the verdict (is_over_cap's mode)
+# Returns 1 if amount_raw fits under the cap, 0 if it would meet/exceed it.
+#
+# Checks whether `member` already exists BEFORE summing, so re-reserving the
+# exact same (charge_id, amount_raw) — e.g. a caller that reserves twice for
+# what is logically one charge — does not double-count its own prior
+# contribution against the cap: the existing entry is already inside `total`,
+# so it is not added a second time. Callers should still avoid reserving the
+# same charge twice (see try_reserve_usdc's docstring on ordering relative to
+# the idempotency claim); this is defense in depth, not license to skip that.
+_CHECK_AND_RESERVE_LUA = """
+local key = KEYS[1]
+local window_start = tonumber(ARGV[1])
+local now = ARGV[2]
+local cap_raw = tonumber(ARGV[3])
+local amount_raw = tonumber(ARGV[4])
+local member = ARGV[5]
+local ttl_seconds = ARGV[6]
+local do_reserve = tonumber(ARGV[7])
+
+redis.call("ZREMRANGEBYSCORE", key, 0, window_start)
+local already_reserved = redis.call("ZSCORE", key, member)
+local members = redis.call("ZRANGE", key, 0, -1)
+local total = 0
+for _, m in ipairs(members) do
+    local amt = tonumber(string.match(m, ".*:(%d+)$"))
+    if amt then
+        total = total + amt
+    end
+end
+
+local projected = total
+if already_reserved == false then
+    projected = total + amount_raw
+end
+
+if projected >= cap_raw then
+    return 0
+end
+if do_reserve == 1 then
+    redis.call("ZADD", key, now, member)
+    redis.call("EXPIRE", key, ttl_seconds)
+end
+return 1
+"""
 
 _store: AgentStateStore | None = None
 
@@ -100,39 +172,104 @@ async def get_24h_spend_usdc(subscriber_wallet: str) -> Decimal:
     return total
 
 
-async def record_charge_usdc(subscriber_wallet: str, charge_id: str, amount_raw: int) -> None:
-    """Record a SUCCESSFUL charge against the wallet's rolling window.
+async def _atomic_check(subscriber_wallet: str, amount_raw: int, *, reserve: bool, charge_id: str | None) -> bool:
+    """Shared implementation for try_reserve_usdc and is_over_cap: one atomic
+    Redis round-trip (_CHECK_AND_RESERVE_LUA) that prunes the window, sums it,
+    and decides whether amount_raw fits under the cap — optionally reserving
+    it (ZADD) in that SAME script execution when reserve=True.
 
-    Call this only after payments.charge() returns True — this function does
-    not charge anything itself, it only tracks what was already charged.
-    Best-effort: a failure to record must never undo or fail an already-settled
-    charge, so exceptions are logged and swallowed, never raised.
+    Returns True if amount_raw fits under the cap (and was reserved, if
+    reserve=True). Fails OPEN (True) on a Redis error, and short-circuits to
+    True without touching Redis at all when the cap is disabled
+    (spend_cap_usdc() <= 0) — see is_over_cap's docstring for the fail-open
+    rationale, which applies identically here since this is its shared engine.
+    A fresh Script is registered on every call rather than cached: the
+    redis-py Script object binds to the client that registered it, and this
+    module's tests swap in a brand new fakeredis-backed store per test — a
+    module-level cached Script would silently keep talking to a prior test's
+    now-discarded client. register_script itself makes no network call, so
+    this costs nothing but a client-side SHA1 of a short string.
+    """
+    cap = spend_cap_usdc()
+    if cap <= 0:
+        return True
+    try:
+        r = await _get_store()._get_redis()
+        script = r.register_script(_CHECK_AND_RESERVE_LUA)
+        now = time.time()
+        cap_raw = int(cap * (10**_USDC_DECIMALS))
+        member = f"{charge_id}:{amount_raw}" if reserve else ""
+        result = await script(
+            keys=[_key(subscriber_wallet)],
+            args=[now - _WINDOW_SECONDS, now, cap_raw, amount_raw, member, _KEY_TTL_SECONDS, 1 if reserve else 0],
+        )
+        return bool(result)
+    except Exception:
+        logger.exception(
+            "Spend-cap check failed for wallet %s — failing open (allowing the charge)", subscriber_wallet[:10]
+        )
+        return True
+
+
+async def try_reserve_usdc(subscriber_wallet: str, amount_raw: int, charge_id: str) -> bool:
+    """Atomically check the wallet's rolling 24h window against the cap and,
+    if *amount_raw* fits, reserve it in the same Redis round-trip.
+
+    Call this immediately before payments.charge() — not earlier — and call
+    release_reservation() if the charge itself then fails (see
+    MarketService._charge_one). The ordering relative to the settlement-intent
+    idempotency claim matters for correctness, not just style: that claim is
+    what guarantees this runs at most once per logical (strategy, tick, sub,
+    step) charge, so a crash-retry of an already-settled charge short-circuits
+    on "already_settled" before ever reaching this call — it never tries to
+    reserve the same amount a second time. Reserving earlier (e.g. ahead of
+    the idempotency claim) would double-count exactly that retry, since the
+    same charge_id's entry is already sitting in the window from the first
+    successful reservation.
+
+    Returns True (reserved) or False (would push the wallet at/over cap;
+    nothing written). A non-positive amount_raw is always True and never
+    touches Redis — there is nothing to reserve.
+    """
+    if amount_raw <= 0:
+        return True
+    return await _atomic_check(subscriber_wallet, amount_raw, reserve=True, charge_id=charge_id)
+
+
+async def release_reservation(subscriber_wallet: str, charge_id: str, amount_raw: int) -> None:
+    """Undo a reservation made by try_reserve_usdc, after payments.charge() fails.
+
+    Best-effort, like this module's other write path: a failure to release
+    must never raise — worst case the wallet's window overstates its spend
+    until this entry ages out on its own (_WINDOW_SECONDS), which is the
+    fail-safe direction (it can only make the cap MORE conservative, never
+    let more spend through than intended).
     """
     if amount_raw <= 0:
         return
     try:
         r = await _get_store()._get_redis()
-        key = _key(subscriber_wallet)
-        now = time.time()
-        await r.zadd(key, {f"{charge_id}:{amount_raw}": now})
-        await r.expire(key, _KEY_TTL_SECONDS)
+        await r.zrem(_key(subscriber_wallet), f"{charge_id}:{amount_raw}")
     except Exception:
         logger.exception(
-            "Failed to record spend-cap charge for wallet %s (charge %s, amount %d raw) — "
-            "the charge itself already succeeded and is unaffected; only this window's "
-            "bookkeeping is stale until the next successful record",
+            "Failed to release spend-cap reservation for wallet %s (charge %s) — the "
+            "wallet's rolling window may overstate spend until this entry ages out",
             subscriber_wallet[:10],
             charge_id,
-            amount_raw,
         )
 
 
 async def is_over_cap(subscriber_wallet: str, additional_amount_raw: int = 0) -> bool:
     """True if the wallet's current 24h spend, plus *additional_amount_raw* (a
-    pending charge not yet recorded), would meet or exceed the configured cap.
+    hypothetical amount not yet reserved), would meet or exceed the configured
+    cap.
 
     Pass additional_amount_raw=0 to just check current standing (e.g. before
     allowing a new subscription) without evaluating a specific pending charge.
+    Read-only: built on the same atomic primitive as try_reserve_usdc, with
+    reserve=False, so this never writes anything regardless of the verdict —
+    both call sites now share one atomic check instead of two independently
+    evolving read implementations (#1099 review).
 
     Fails OPEN (returns False — allow the charge) on a Redis read failure.
     This is a considered choice, not an oversight: this is an additive safety
@@ -141,15 +278,5 @@ async def is_over_cap(subscriber_wallet: str, additional_amount_raw: int = 0) ->
     a Redis outage should degrade to today's pre-existing behavior, not start
     blocking every charge in the system.
     """
-    cap = spend_cap_usdc()
-    if cap <= 0:
-        return False
-    try:
-        current = await get_24h_spend_usdc(subscriber_wallet)
-    except Exception:
-        logger.exception(
-            "Spend-cap check failed for wallet %s — failing open (allowing the charge)", subscriber_wallet[:10]
-        )
-        return False
-    additional = _raw_to_usdc(additional_amount_raw) if additional_amount_raw else Decimal(0)
-    return (current + additional) >= cap
+    allowed = await _atomic_check(subscriber_wallet, additional_amount_raw, reserve=False, charge_id=None)
+    return not allowed

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -85,6 +85,17 @@ def _mock_provision_publisher_wallet():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _mock_spend_cap_not_over():
+    """subscribe_strategy checks spend_cap.is_over_cap before provisioning a
+    wallet (#713). Default every test in this file to "not over cap" so the
+    existing subscribe-path tests exercise the happy path without a real
+    Redis round-trip; test_subscribe_rejects_over_spend_cap overrides this
+    to True to exercise the 429 refusal."""
+    with patch("archimedes.api.marketplace_routes.spend_cap.is_over_cap", new=AsyncMock(return_value=False)):
+        yield
+
+
 @pytest.fixture
 def app():
     """FastAPI app with marketplace router and a mock market service."""
@@ -212,6 +223,52 @@ def test_subscribe_rejects_blank_sub_id(client):
         },
     )
     assert resp.status_code == 400, resp.text
+
+
+def test_subscribe_rejects_over_spend_cap(client):
+    """A wallet at/over its rolling 24h marketplace spend cap gets 429 on a
+    NEW subscription (#713). The guard sits after the existing dedup checks
+    and BEFORE wallet provisioning — provision_subscriber_wallet must never
+    be reached when the check refuses."""
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    with (
+        patch("archimedes.api.marketplace_routes.spend_cap.is_over_cap", new=AsyncMock(return_value=True)),
+        patch(
+            "archimedes.marketplace.wallet_provisioner.provision_subscriber_wallet",
+            new=AsyncMock(side_effect=AssertionError("must not provision a wallet when over the spend cap")),
+        ) as m_provision,
+    ):
+        resp = client.post(
+            "/api/marketplace/subscribe",
+            json={"strategy_id": "test_strat", "sub_id": "0x" + "f0" * 32, "ephemeral_wallet": "0xeph"},
+        )
+
+    assert resp.status_code == 429, resp.text
+    detail = resp.json()["detail"]
+    assert detail["reason"] == "marketplace_spend_cap_reached"
+    m_provision.assert_not_awaited()
+
+
+def test_subscribe_under_spend_cap_still_succeeds(client):
+    """Sanity-checks the mock boundary the opposite way: with is_over_cap
+    False (the file's autouse default), subscribe proceeds normally — guards
+    against an accidentally-inverted cap check silently 429-ing everything."""
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = client.post(
+        "/api/marketplace/subscribe",
+        json={"strategy_id": "test_strat", "sub_id": "0x" + "f1" * 32, "ephemeral_wallet": "0xeph"},
+    )
+    assert resp.status_code == 200, resp.text
 
 
 def test_publish_duplicate_returns_409(client):

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -264,10 +264,14 @@ def test_subscribe_under_spend_cap_still_succeeds(client):
     )
     assert resp.status_code == 200, resp.text
 
-    resp = client.post(
-        "/api/marketplace/subscribe",
-        json={"strategy_id": "test_strat", "sub_id": "0x" + "f1" * 32, "ephemeral_wallet": "0xeph"},
-    )
+    with patch(
+        "archimedes.marketplace.wallet_provisioner.provision_subscriber_wallet",
+        new=AsyncMock(return_value=("w-cap-ok", "0x0000000000000000000000000000000000000ee9")),
+    ):
+        resp = client.post(
+            "/api/marketplace/subscribe",
+            json={"strategy_id": "test_strat", "sub_id": "0x" + "f1" * 32, "ephemeral_wallet": "0xeph"},
+        )
     assert resp.status_code == 200, resp.text
 
 

--- a/backend/tests/marketplace/test_per_step_charging.py
+++ b/backend/tests/marketplace/test_per_step_charging.py
@@ -247,7 +247,11 @@ async def test_cant_pay_deferral(market: MarketService):
     market.record_subscriber_tick = _capture_record
 
     async def _charge_side_effect(pub, sub, strategy_id, tick_id, step, action_count):
-        return not (sub.sub_id == "0x" + "bad" * 32 and step == TickStep.REGIME_CLASSIFY)
+        # _charge_one returns (paid, halt_reason_override) since #713 — None
+        # here means "no override", i.e. the caller's generic message applies.
+        if sub.sub_id == "0x" + "bad" * 32 and step == TickStep.REGIME_CLASSIFY:
+            return False, None
+        return True, None
 
     with ExitStack() as stack:
         _patch_evaluator(stack)
@@ -305,7 +309,7 @@ async def test_mirror_failure(market: MarketService):
     with ExitStack() as stack:
         _patch_evaluator(stack)
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=_dummy_trades()))
-        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=True)))
+        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(True, None))))
         mock_liability = stack.enter_context(patch.object(market, "_record_liability", AsyncMock()))
         stack.enter_context(
             patch.object(

--- a/backend/tests/marketplace/test_service_tick.py
+++ b/backend/tests/marketplace/test_service_tick.py
@@ -134,7 +134,7 @@ async def test_tick_produces_trades_and_verifies_payment(market: MarketService):
     with ExitStack() as stack:
         _patch_strategy_evaluator(stack)
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=_dummy_trades()))
-        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=True)))
+        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(True, None))))
         stack.enter_context(patch.object(market, "record_subscriber_tick", AsyncMock()))
 
         market.publishers["strat_a"] = Publisher(
@@ -173,7 +173,7 @@ async def test_tick_marks_subscriber_inactive_on_payment_failure(market: MarketS
     with ExitStack() as stack:
         _patch_strategy_evaluator(stack)
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=_dummy_trades()))
-        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=False)))
+        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(False, None))))
         stack.enter_context(patch.object(market, "record_subscriber_tick", AsyncMock()))
 
         market.publishers["strat_b"] = Publisher(
@@ -204,7 +204,7 @@ async def test_tick_no_trades_skips_payment(market: MarketService):
         _patch_strategy_evaluator(stack, weights={"ETH": 0.5})
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=[]))
         stack.enter_context(patch.object(market, "record_subscriber_tick", AsyncMock()))
-        mock_charge = stack.enter_context(patch.object(market, "_charge_one", AsyncMock()))
+        mock_charge = stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(True, None))))
 
         market.publishers["strat_c"] = Publisher(
             strategy_id="strat_c",
@@ -232,7 +232,7 @@ async def test_tick_records_liability_when_mirror_fails(market: MarketService):
     with ExitStack() as stack:
         _patch_strategy_evaluator(stack)
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=_dummy_trades()))
-        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=True)))
+        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(True, None))))
         stack.enter_context(patch.object(market, "record_subscriber_tick", AsyncMock()))
 
         market.publishers["strat_d"] = Publisher(
@@ -272,7 +272,7 @@ async def test_tick_no_liability_when_mirror_succeeds(market: MarketService):
     with ExitStack() as stack:
         _patch_strategy_evaluator(stack)
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=_dummy_trades()))
-        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=True)))
+        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(True, None))))
         stack.enter_context(patch.object(market, "record_subscriber_tick", AsyncMock()))
 
         market.publishers["strat_e"] = Publisher(
@@ -303,7 +303,7 @@ async def test_tick_no_liability_when_payment_fails(market: MarketService):
     with ExitStack() as stack:
         _patch_strategy_evaluator(stack)
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=_dummy_trades()))
-        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=False)))
+        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(False, None))))
         stack.enter_context(patch.object(market, "record_subscriber_tick", AsyncMock()))
 
         market.publishers["strat_f"] = Publisher(
@@ -433,7 +433,7 @@ async def test_tick_renews_leader_at_midpoint(market: MarketService):
     with ExitStack() as stack:
         _patch_strategy_evaluator(stack)
         stack.enter_context(patch("archimedes.marketplace.service.compute_trades", return_value=_dummy_trades()))
-        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=True)))
+        stack.enter_context(patch.object(market, "_charge_one", AsyncMock(return_value=(True, None))))
         stack.enter_context(patch.object(market, "record_subscriber_tick", AsyncMock()))
         stack.enter_context(patch.object(market, "_apply_to_subscriber", AsyncMock(return_value=(True, []))))
 

--- a/backend/tests/marketplace/test_settlement_idempotency.py
+++ b/backend/tests/marketplace/test_settlement_idempotency.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from archimedes.db import get_session
 from archimedes.marketplace.service import MarketService, Publisher, Subscriber
 from archimedes.marketplace.tick_registry import TickStep

--- a/backend/tests/marketplace/test_settlement_idempotency.py
+++ b/backend/tests/marketplace/test_settlement_idempotency.py
@@ -24,6 +24,17 @@ from archimedes.models.marketplace import SettlementIntent
 # without restoring it (issue #1100).
 
 
+@pytest.fixture(autouse=True)
+def _spend_cap_default_not_over():
+    """_charge_one checks spend_cap.is_over_cap before every charge (#713).
+    Default every test in this file to "not over cap" so none of them reach
+    out to a real Redis connection (fails open, but still a live-Redis
+    attempt this suite should not depend on) — the spend-cap section below
+    overrides this per-test to exercise the refusal path."""
+    with patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)):
+        yield
+
+
 def _svc(dry_run: bool = False) -> MarketService:
     return MarketService(interval_seconds=9999, payments_dry_run=dry_run, paper_trading=True)
 
@@ -77,13 +88,15 @@ async def test_charge_one_settles_once_then_skips_on_retry():
     pub, sub = _pub(), _sub()
     tick = "settle-once:1"
     with patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)) as m_charge:
-        first = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
-        second = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
+        first_paid, first_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
+        second_paid, second_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
 
-    assert first is True
+    assert first_paid is True
+    assert first_override is None
     # The retry of the SAME (strategy, tick, sub, step) returns paid WITHOUT a
     # second settle — the idempotency guard prevented a double charge.
-    assert second is True
+    assert second_paid is True
+    assert second_override is None
     assert m_charge.await_count == 1
 
 
@@ -98,9 +111,10 @@ async def test_charge_one_in_flight_pending_does_not_recharge():
     svc._claim_settlement_intent("strat_a", tick, sub.sub_id, TickStep.REBALANCE.value)
 
     with patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)) as m_charge:
-        result = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
+        paid, halt_reason_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
 
-    assert result is False
+    assert paid is False
+    assert halt_reason_override is None
     m_charge.assert_not_awaited()
 
 
@@ -109,12 +123,111 @@ async def test_charge_one_dry_run_never_claims_or_charges():
     pub, sub = _pub(), _sub()
     tick = "dry-run:1"
     with patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)) as m_charge:
-        assert await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1) is True
+        paid, halt_reason_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
+    assert paid is True
+    assert halt_reason_override is None
     m_charge.assert_not_awaited()
     # Scoped to THIS charge's key (never claims under dry-run) — independent of
     # any rows other tests may have left in a shared DB.
     with get_session() as session:
         assert session.query(SettlementIntent).filter_by(tick_id=tick).count() == 0
+
+
+# ── #713 — spend cap ───────────────────────────────────────────────────────
+
+
+async def test_charge_one_refuses_when_over_spend_cap():
+    """A subscriber wallet at/over its rolling 24h spend cap is refused with
+    the specific override reason, BEFORE the settlement-intent claim, and
+    never reaches payments.charge — an over-cap charge must not consume a
+    settlement-intent slot for a charge that isn't going to happen."""
+    from archimedes.marketplace.service import FLAT_FEE_PER_ACTION
+
+    svc = _svc()
+    pub, sub = _pub(), _sub()
+    tick = "spend-cap:1"
+    action_count = 1
+    with (
+        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=True)) as m_over_cap,
+        patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)) as m_charge,
+    ):
+        paid, halt_reason_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, action_count)
+
+    assert paid is False
+    assert halt_reason_override == "24h spend cap reached"
+    m_charge.assert_not_awaited()
+    m_over_cap.assert_awaited_once_with(sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION)
+
+    # No settlement-intent slot was claimed for this (strategy, tick, sub, step) —
+    # the spend-cap refusal happens BEFORE _claim_settlement_intent, so a later
+    # legitimate charge attempt for the same key still sees a clean slate.
+    with get_session() as session:
+        assert (
+            session.query(SettlementIntent)
+            .filter_by(strategy_id="strat_a", tick_id=tick, sub_id=sub.sub_id, step=TickStep.REBALANCE.value)
+            .first()
+            is None
+        )
+
+
+async def test_charge_one_under_cap_proceeds_normally():
+    """Sanity-checks the mock boundary the opposite way: when spend_cap
+    reports NOT over cap, the charge proceeds and records spend as usual —
+    guards against an accidentally-inverted cap check."""
+    svc = _svc()
+    pub, sub = _pub(), _sub()
+    tick = "spend-cap:2"
+    with (
+        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)),
+        patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)) as m_charge,
+        patch("archimedes.marketplace.service.spend_cap.record_charge_usdc", new=AsyncMock()) as m_record,
+    ):
+        paid, halt_reason_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
+
+    assert paid is True
+    assert halt_reason_override is None
+    m_charge.assert_awaited_once()
+    m_record.assert_awaited_once()
+
+
+async def test_charge_one_records_spend_with_correct_wallet_and_amount():
+    """A successful charge records spend against the SUBSCRIBER wallet (not
+    sub_id) for action_count * FLAT_FEE_PER_ACTION raw units — the exact
+    amount payments.charge was invoked for."""
+    from archimedes.marketplace.service import FLAT_FEE_PER_ACTION
+
+    svc = _svc()
+    pub, sub = _pub(), _sub()
+    tick = "spend-cap:3"
+    action_count = 3
+    with (
+        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)),
+        patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)),
+        patch("archimedes.marketplace.service.spend_cap.record_charge_usdc", new=AsyncMock()) as m_record,
+    ):
+        paid, _ = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, action_count)
+
+    assert paid is True
+    m_record.assert_awaited_once()
+    assert m_record.await_args.args[0] == sub.subscriber_wallet
+    assert m_record.await_args.kwargs["amount_raw"] == action_count * FLAT_FEE_PER_ACTION
+
+
+async def test_charge_one_does_not_record_spend_when_charge_fails():
+    """record_charge_usdc must only fire on a SUCCESSFUL charge — a failed
+    payments.charge must not inflate the wallet's rolling spend total."""
+    svc = _svc()
+    pub, sub = _pub(), _sub()
+    tick = "spend-cap:4"
+    with (
+        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)),
+        patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=False)),
+        patch("archimedes.marketplace.service.spend_cap.record_charge_usdc", new=AsyncMock()) as m_record,
+    ):
+        paid, _ = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
+
+    assert paid is False
+    m_record.assert_not_awaited()
 
 
 # ── #8 — auto-withdraw on unsubscribe ─────────────────────────────────────

--- a/backend/tests/marketplace/test_settlement_idempotency.py
+++ b/backend/tests/marketplace/test_settlement_idempotency.py
@@ -165,7 +165,7 @@ async def test_charge_one_refuses_when_over_spend_cap():
     assert halt_reason_override == "24h spend cap reached"
     m_charge.assert_not_awaited()
     m_reserve.assert_awaited_once_with(
-        sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION, f"{tick}:{TickStep.REBALANCE.value}"
+        sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION, f"{tick}:{sub.sub_id}:{TickStep.REBALANCE.value}"
     )
 
     with get_session() as session:
@@ -218,7 +218,7 @@ async def test_charge_one_reserves_with_correct_wallet_and_amount():
 
     assert paid is True
     m_reserve.assert_awaited_once_with(
-        sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION, f"{tick}:{TickStep.REBALANCE.value}"
+        sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION, f"{tick}:{sub.sub_id}:{TickStep.REBALANCE.value}"
     )
 
 
@@ -239,7 +239,42 @@ async def test_charge_one_releases_reservation_when_charge_fails():
         paid, _ = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
 
     assert paid is False
-    m_release.assert_awaited_once_with(sub.subscriber_wallet, f"{tick}:{TickStep.REBALANCE.value}", FLAT_FEE_PER_ACTION)
+    m_release.assert_awaited_once_with(
+        sub.subscriber_wallet, f"{tick}:{sub.sub_id}:{TickStep.REBALANCE.value}", FLAT_FEE_PER_ACTION
+    )
+
+
+async def test_charge_one_releases_reservation_when_charge_raises():
+    """payments.charge documents "never raises", but the reservation must not
+    depend on that contract holding forever. A raise escaping _charge_one used
+    to leave the reserved amount stuck in the wallet's window for 24h and the
+    intent pending — now it's treated as a failed charge: released, finalized
+    failed, (False, None) returned instead of propagating."""
+    from archimedes.marketplace.service import FLAT_FEE_PER_ACTION
+
+    svc = _svc()
+    pub, sub = _pub(), _sub()
+    tick = "spend-cap:5"
+    with (
+        patch("archimedes.marketplace.service.spend_cap.try_reserve_usdc", new=AsyncMock(return_value=True)),
+        patch("archimedes.marketplace.payments.charge", new=AsyncMock(side_effect=RuntimeError("gateway blew up"))),
+        patch("archimedes.marketplace.service.spend_cap.release_reservation", new=AsyncMock()) as m_release,
+    ):
+        paid, halt_reason_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
+
+    assert paid is False
+    assert halt_reason_override is None
+    m_release.assert_awaited_once_with(
+        sub.subscriber_wallet, f"{tick}:{sub.sub_id}:{TickStep.REBALANCE.value}", FLAT_FEE_PER_ACTION
+    )
+    with get_session() as session:
+        row = (
+            session.query(SettlementIntent)
+            .filter_by(strategy_id="strat_a", tick_id=tick, sub_id=sub.sub_id, step=TickStep.REBALANCE.value)
+            .first()
+        )
+        assert row is not None
+        assert row.status == "failed"
 
 
 # ── #8 — auto-withdraw on unsubscribe ─────────────────────────────────────

--- a/backend/tests/marketplace/test_settlement_idempotency.py
+++ b/backend/tests/marketplace/test_settlement_idempotency.py
@@ -26,12 +26,12 @@ from archimedes.models.marketplace import SettlementIntent
 
 @pytest.fixture(autouse=True)
 def _spend_cap_default_not_over():
-    """_charge_one checks spend_cap.is_over_cap before every charge (#713).
-    Default every test in this file to "not over cap" so none of them reach
-    out to a real Redis connection (fails open, but still a live-Redis
-    attempt this suite should not depend on) — the spend-cap section below
-    overrides this per-test to exercise the refusal path."""
-    with patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)):
+    """_charge_one reserves against spend_cap.try_reserve_usdc before every
+    charge (#713, atomicity fix in #1099 review). Default every test in this
+    file to "reserved successfully" so none of them reach out to a real Redis
+    connection — the spend-cap section below overrides this per-test to
+    exercise the refusal path."""
+    with patch("archimedes.marketplace.service.spend_cap.try_reserve_usdc", new=AsyncMock(return_value=True)):
         yield
 
 
@@ -138,9 +138,14 @@ async def test_charge_one_dry_run_never_claims_or_charges():
 
 async def test_charge_one_refuses_when_over_spend_cap():
     """A subscriber wallet at/over its rolling 24h spend cap is refused with
-    the specific override reason, BEFORE the settlement-intent claim, and
-    never reaches payments.charge — an over-cap charge must not consume a
-    settlement-intent slot for a charge that isn't going to happen."""
+    the specific override reason and never reaches payments.charge.
+
+    The settlement-intent slot IS claimed (and finalized as failed) before
+    the refusal — reordered in the #1099 review so the spend-cap reservation
+    sits right before payments.charge(), gated behind the idempotency claim.
+    That ordering is what makes the reservation itself safe against a
+    crash-retry (see try_reserve_usdc's docstring); the cost is a `failed`
+    SettlementIntent row for the refused attempt instead of none at all."""
     from archimedes.marketplace.service import FLAT_FEE_PER_ACTION
 
     svc = _svc()
@@ -148,7 +153,9 @@ async def test_charge_one_refuses_when_over_spend_cap():
     tick = "spend-cap:1"
     action_count = 1
     with (
-        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=True)) as m_over_cap,
+        patch(
+            "archimedes.marketplace.service.spend_cap.try_reserve_usdc", new=AsyncMock(return_value=False)
+        ) as m_reserve,
         patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)) as m_charge,
     ):
         paid, halt_reason_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, action_count)
@@ -156,44 +163,44 @@ async def test_charge_one_refuses_when_over_spend_cap():
     assert paid is False
     assert halt_reason_override == "24h spend cap reached"
     m_charge.assert_not_awaited()
-    m_over_cap.assert_awaited_once_with(sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION)
+    m_reserve.assert_awaited_once_with(
+        sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION, f"{tick}:{TickStep.REBALANCE.value}"
+    )
 
-    # No settlement-intent slot was claimed for this (strategy, tick, sub, step) —
-    # the spend-cap refusal happens BEFORE _claim_settlement_intent, so a later
-    # legitimate charge attempt for the same key still sees a clean slate.
     with get_session() as session:
-        assert (
+        row = (
             session.query(SettlementIntent)
             .filter_by(strategy_id="strat_a", tick_id=tick, sub_id=sub.sub_id, step=TickStep.REBALANCE.value)
             .first()
-            is None
         )
+        assert row is not None
+        assert row.status == "failed"
 
 
 async def test_charge_one_under_cap_proceeds_normally():
-    """Sanity-checks the mock boundary the opposite way: when spend_cap
-    reports NOT over cap, the charge proceeds and records spend as usual —
-    guards against an accidentally-inverted cap check."""
+    """Sanity-checks the mock boundary the opposite way: when the reservation
+    succeeds, the charge proceeds and nothing gets released — guards against
+    an accidentally-inverted cap check or a spurious release on the happy path."""
     svc = _svc()
     pub, sub = _pub(), _sub()
     tick = "spend-cap:2"
     with (
-        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)),
+        patch("archimedes.marketplace.service.spend_cap.try_reserve_usdc", new=AsyncMock(return_value=True)),
         patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)) as m_charge,
-        patch("archimedes.marketplace.service.spend_cap.record_charge_usdc", new=AsyncMock()) as m_record,
+        patch("archimedes.marketplace.service.spend_cap.release_reservation", new=AsyncMock()) as m_release,
     ):
         paid, halt_reason_override = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
 
     assert paid is True
     assert halt_reason_override is None
     m_charge.assert_awaited_once()
-    m_record.assert_awaited_once()
+    m_release.assert_not_awaited()
 
 
-async def test_charge_one_records_spend_with_correct_wallet_and_amount():
-    """A successful charge records spend against the SUBSCRIBER wallet (not
-    sub_id) for action_count * FLAT_FEE_PER_ACTION raw units — the exact
-    amount payments.charge was invoked for."""
+async def test_charge_one_reserves_with_correct_wallet_and_amount():
+    """A charge reserves against the SUBSCRIBER wallet (not sub_id) for
+    action_count * FLAT_FEE_PER_ACTION raw units — the exact amount
+    payments.charge was invoked for — BEFORE payments.charge runs."""
     from archimedes.marketplace.service import FLAT_FEE_PER_ACTION
 
     svc = _svc()
@@ -201,33 +208,37 @@ async def test_charge_one_records_spend_with_correct_wallet_and_amount():
     tick = "spend-cap:3"
     action_count = 3
     with (
-        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)),
+        patch(
+            "archimedes.marketplace.service.spend_cap.try_reserve_usdc", new=AsyncMock(return_value=True)
+        ) as m_reserve,
         patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=True)),
-        patch("archimedes.marketplace.service.spend_cap.record_charge_usdc", new=AsyncMock()) as m_record,
     ):
         paid, _ = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, action_count)
 
     assert paid is True
-    m_record.assert_awaited_once()
-    assert m_record.await_args.args[0] == sub.subscriber_wallet
-    assert m_record.await_args.kwargs["amount_raw"] == action_count * FLAT_FEE_PER_ACTION
+    m_reserve.assert_awaited_once_with(
+        sub.subscriber_wallet, action_count * FLAT_FEE_PER_ACTION, f"{tick}:{TickStep.REBALANCE.value}"
+    )
 
 
-async def test_charge_one_does_not_record_spend_when_charge_fails():
-    """record_charge_usdc must only fire on a SUCCESSFUL charge — a failed
-    payments.charge must not inflate the wallet's rolling spend total."""
+async def test_charge_one_releases_reservation_when_charge_fails():
+    """release_reservation must fire when a RESERVED charge's payments.charge
+    then fails — otherwise the wallet's rolling window would overstate its
+    spend for money that was never actually moved."""
+    from archimedes.marketplace.service import FLAT_FEE_PER_ACTION
+
     svc = _svc()
     pub, sub = _pub(), _sub()
     tick = "spend-cap:4"
     with (
-        patch("archimedes.marketplace.service.spend_cap.is_over_cap", new=AsyncMock(return_value=False)),
+        patch("archimedes.marketplace.service.spend_cap.try_reserve_usdc", new=AsyncMock(return_value=True)),
         patch("archimedes.marketplace.payments.charge", new=AsyncMock(return_value=False)),
-        patch("archimedes.marketplace.service.spend_cap.record_charge_usdc", new=AsyncMock()) as m_record,
+        patch("archimedes.marketplace.service.spend_cap.release_reservation", new=AsyncMock()) as m_release,
     ):
         paid, _ = await svc._charge_one(pub, sub, "strat_a", tick, TickStep.REBALANCE, 1)
 
     assert paid is False
-    m_record.assert_not_awaited()
+    m_release.assert_awaited_once_with(sub.subscriber_wallet, f"{tick}:{TickStep.REBALANCE.value}", FLAT_FEE_PER_ACTION)
 
 
 # ── #8 — auto-withdraw on unsubscribe ─────────────────────────────────────

--- a/backend/tests/marketplace/test_spend_cap.py
+++ b/backend/tests/marketplace/test_spend_cap.py
@@ -270,6 +270,25 @@ async def test_is_over_cap_true_when_over():
 
 
 @pytest.mark.asyncio
+async def test_is_over_cap_unaffected_by_corrupted_empty_member(_fake_store):
+    """Regression test for a Copilot review finding on #1099: is_over_cap's
+    internal member is always "" (it never reserves), so the read-only path
+    must never let a stray empty-string member in the set (corrupted data,
+    or some future bug) short-circuit the projection. Before the fix, the
+    Lua script ran ZSCORE key "" unconditionally, so a real "" member here
+    would have made it wrongly treat additional_amount_raw as "already
+    counted" and drop it from the projection — undercounting exactly the
+    hypothetical amount the caller asked about.
+    """
+    key = spend_cap._key(_WALLET)
+    await _fake_store._redis.zadd(key, {"": time.time()})  # simulated corrupted entry
+    # No real spend recorded — only the additional_amount_raw (== the pinned
+    # cap) should decide this. The old, buggy script would have dropped it
+    # entirely and returned False here.
+    assert await spend_cap.is_over_cap(_WALLET, additional_amount_raw=_raw("10")) is True
+
+
+@pytest.mark.asyncio
 async def test_is_over_cap_considers_pending_additional_amount():
     """additional_amount_raw models a charge not yet reserved — current spend
     alone is under cap, but current + pending crosses it."""

--- a/backend/tests/marketplace/test_spend_cap.py
+++ b/backend/tests/marketplace/test_spend_cap.py
@@ -1,0 +1,272 @@
+"""Tests for the per-subscriber-wallet rolling 24h spend cap (#713).
+
+spend_cap.py caches a module-level AgentStateStore singleton (_store) rather
+than accepting one via constructor injection (unlike MarketState). The
+_fake_store fixture below injects a fresh fakeredis-backed AgentStateStore as
+that singleton for the duration of one test and restores whatever was there
+before, so no test leaks Redis state or a mock into another — mirroring the
+fakeredis pattern already used for MarketState in test_state.py, and the
+class-level AgentStateStore._get_redis mock used for the Redis-down scenario
+in test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import fakeredis
+import pytest
+from archimedes.marketplace import spend_cap
+from archimedes.services.redis_state import AgentStateStore
+
+_WALLET = "0xSubscriberWallet0000000000000000000001"
+
+
+@pytest.fixture(autouse=True)
+def _fake_store():
+    """Inject a fakeredis-backed AgentStateStore as spend_cap's module-level
+    singleton for one test, then restore the prior value (None on a clean
+    run) so tests never leak Redis state or a mock into each other."""
+    store = AgentStateStore()
+    store._redis = fakeredis.FakeAsyncRedis(decode_responses=True)
+    previous = spend_cap._store
+    spend_cap._store = store
+    yield store
+    spend_cap._store = previous
+
+
+@pytest.fixture(autouse=True)
+def _pinned_cap(monkeypatch):
+    """Pin a known, small cap for every test unless a test overrides it —
+    keeps the arithmetic in each test easy to read vs. the real default (50)."""
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "10")
+
+
+def _raw(usdc: str) -> int:
+    """USDC decimal string -> raw 6-decimal int (matches payments.py convention)."""
+    return int(Decimal(usdc) * Decimal(10**6))
+
+
+# ── spend_cap_usdc() — config parsing ───────────────────────────────────
+
+
+def test_spend_cap_usdc_reads_configured_value(monkeypatch):
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "25.5")
+    assert spend_cap.spend_cap_usdc() == Decimal("25.5")
+
+
+def test_spend_cap_usdc_default_is_50(monkeypatch):
+    monkeypatch.delenv("MARKETPLACE_SPEND_CAP_USDC", raising=False)
+    assert spend_cap.spend_cap_usdc() == Decimal("50")
+
+
+def test_spend_cap_usdc_zero_disables(monkeypatch):
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "0")
+    assert spend_cap.spend_cap_usdc() == Decimal("0")
+
+
+def test_spend_cap_usdc_non_numeric_disables_and_warns(monkeypatch, caplog):
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "not-a-number")
+    with caplog.at_level(logging.WARNING, logger=spend_cap.__name__):
+        result = spend_cap.spend_cap_usdc()
+    assert result == Decimal("0")
+    assert "not a valid number" in caplog.text
+
+
+# ── round-trip: record_charge_usdc -> get_24h_spend_usdc ───────────────
+
+
+@pytest.mark.asyncio
+async def test_get_24h_spend_usdc_starts_at_zero():
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_record_and_read_back_round_trip():
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="tick1:rebalance", amount_raw=_raw("3"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("3")
+
+
+@pytest.mark.asyncio
+async def test_record_charge_sums_multiple_charges():
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("2"))
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c2", amount_raw=_raw("1.5"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("3.5")
+
+
+@pytest.mark.asyncio
+async def test_record_charge_zero_or_negative_amount_is_noop():
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=0)
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c2", amount_raw=-100)
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_spend_is_independent_per_wallet():
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("4"))
+    await spend_cap.record_charge_usdc("0xOtherWallet00000000000000000000000002", charge_id="c2", amount_raw=_raw("9"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("4")
+
+
+@pytest.mark.asyncio
+async def test_wallet_key_is_case_insensitive():
+    """Subscriber wallets are lowercased for the Redis key — a charge recorded
+    under mixed case must be visible when read back with lowercase (or any
+    other case), matching how sub.subscriber_wallet is used inconsistently
+    across call sites (some pre-lowered, some not)."""
+    await spend_cap.record_charge_usdc(_WALLET.upper(), charge_id="c1", amount_raw=_raw("2"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET.lower()) == Decimal("2")
+
+
+# ── window boundary: is_over_cap ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_false_when_under():
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("5"))
+    assert await spend_cap.is_over_cap(_WALLET) is False
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_true_when_spend_exactly_meets_cap():
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("10"))
+    assert await spend_cap.is_over_cap(_WALLET) is True
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_true_when_over():
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("15"))
+    assert await spend_cap.is_over_cap(_WALLET) is True
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_considers_pending_additional_amount():
+    """additional_amount_raw models a charge not yet recorded — current spend
+    alone is under cap, but current + pending crosses it."""
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("8"))
+    assert await spend_cap.is_over_cap(_WALLET, additional_amount_raw=_raw("1")) is False
+    assert await spend_cap.is_over_cap(_WALLET, additional_amount_raw=_raw("2")) is True
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_disabled_when_cap_is_zero(monkeypatch):
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "0")
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("999999"))
+    assert await spend_cap.is_over_cap(_WALLET) is False
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_new_subscription_check_uses_no_additional():
+    """No additional_amount_raw checks current standing only — the shape
+    subscribe_strategy uses to gate a brand-new subscription (#713)."""
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("9.99"))
+    assert await spend_cap.is_over_cap(_WALLET) is False
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="c2", amount_raw=_raw("0.01"))
+    assert await spend_cap.is_over_cap(_WALLET) is True
+
+
+# ── rolling window: entries age out after 24h ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_old_entry_outside_window_does_not_count(_fake_store):
+    """An entry older than the 24h window must not count toward current
+    spend. Seeded directly with a controlled score so the test doesn't need
+    a real 24h wait."""
+    old_ts = time.time() - (25 * 60 * 60)  # 25h ago — just outside the window
+    key = spend_cap._key(_WALLET)
+    stale_amount_raw = _raw("100")  # would blow past the cap if it counted
+    await _fake_store._redis.zadd(key, {f"old_charge:{stale_amount_raw}": old_ts})
+
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
+    assert await spend_cap.is_over_cap(_WALLET) is False
+
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="new_charge", amount_raw=_raw("3"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("3")
+
+
+@pytest.mark.asyncio
+async def test_entry_just_inside_window_still_counts(_fake_store):
+    """An entry from 23h59m ago (inside the 24h window) still counts."""
+    recent_ts = time.time() - (23 * 60 * 60 + 59 * 60)  # 23h59m ago
+    key = spend_cap._key(_WALLET)
+    await _fake_store._redis.zadd(key, {f"recent_charge:{_raw('7')}": recent_ts})
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("7")
+
+
+@pytest.mark.asyncio
+async def test_malformed_member_is_skipped_not_fatal(_fake_store):
+    """A member string that doesn't parse as '<charge_id>:<amount_raw>' must
+    be skipped, not blow up the whole read — defensive, "should not happen"
+    per the module's own comment, but still worth pinning."""
+    key = spend_cap._key(_WALLET)
+    now = time.time()
+    await _fake_store._redis.zadd(key, {"totally-malformed-no-amount": now})
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="good", amount_raw=_raw("2"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("2")
+
+
+@pytest.mark.asyncio
+async def test_mixed_old_and_new_entries_only_new_counts(_fake_store):
+    """A wallet with both a stale (>24h) and a live entry sums only the live one."""
+    old_ts = time.time() - (30 * 60 * 60)
+    key = spend_cap._key(_WALLET)
+    await _fake_store._redis.zadd(key, {f"stale:{_raw('40')}": old_ts})
+    await spend_cap.record_charge_usdc(_WALLET, charge_id="live", amount_raw=_raw("6"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("6")
+    # Cap is pinned to 10 by the autouse fixture — 6 alone must not trip it.
+    assert await spend_cap.is_over_cap(_WALLET) is False
+
+
+# ── fail-open on Redis error ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_fails_open_on_redis_error():
+    """A Redis read failure must never block a charge — is_over_cap degrades
+    to False (allow), the documented fail-open contract: this is an additive
+    safety guard, not the sole backstop against overcharging."""
+    with patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))):
+        assert await spend_cap.is_over_cap(_WALLET) is False
+
+
+@pytest.mark.asyncio
+async def test_is_over_cap_fails_open_with_pending_amount_on_redis_error():
+    with patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))):
+        assert await spend_cap.is_over_cap(_WALLET, additional_amount_raw=_raw("999999")) is False
+
+
+@pytest.mark.asyncio
+async def test_get_24h_spend_usdc_raises_on_redis_error():
+    """get_24h_spend_usdc itself does not swallow errors — only is_over_cap's
+    caller-facing fail-open wrapper does. Pins the boundary so a future
+    refactor can't accidentally silence errors two layers deep."""
+    with (
+        patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))),
+        pytest.raises(ConnectionError),
+    ):
+        await spend_cap.get_24h_spend_usdc(_WALLET)
+
+
+@pytest.mark.asyncio
+async def test_record_charge_usdc_swallows_redis_error():
+    """record_charge_usdc is best-effort — a Redis failure must not raise,
+    since the underlying charge has already settled by the time this runs."""
+    with patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))):
+        await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("1"))  # must not raise
+
+
+# ── module-level store singleton ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_store_lazily_constructs_on_first_use():
+    """With no store yet injected, _get_store() must construct one (and
+    reuse it on a second call) rather than requiring a caller to seed it."""
+    spend_cap._store = None
+    store1 = spend_cap._get_store()
+    assert isinstance(store1, AgentStateStore)
+    assert spend_cap._get_store() is store1  # cached, not reconstructed

--- a/backend/tests/marketplace/test_spend_cap.py
+++ b/backend/tests/marketplace/test_spend_cap.py
@@ -8,10 +8,17 @@ before, so no test leaks Redis state or a mock into another — mirroring the
 fakeredis pattern already used for MarketState in test_state.py, and the
 class-level AgentStateStore._get_redis mock used for the Redis-down scenario
 in test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults.
+
+try_reserve_usdc/is_over_cap are both built on the same atomic Lua
+check-and-reserve script (#1099 review — see spend_cap._CHECK_AND_RESERVE_LUA).
+fakeredis's Lua support (the `fakeredis[lua]` extra, already in environment.yml
+for test_runner_lease.py's lease-acquire coverage) executes the real script, so
+these tests exercise the actual atomicity rather than a mocked stand-in.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from decimal import Decimal
@@ -50,6 +57,24 @@ def _raw(usdc: str) -> int:
     return int(Decimal(usdc) * Decimal(10**6))
 
 
+async def _seed(wallet: str, charge_id: str, amount_raw: int) -> None:
+    """Seed existing spend directly in Redis, independent of the cap.
+
+    Several tests below set up "this wallet already spent exactly/over the
+    cap" state to test is_over_cap's/try_reserve_usdc's boundary — going
+    through try_reserve_usdc itself for that setup would be circular (it
+    would refuse to seed the very state the test wants to assert against).
+    Writes the same member format (f"{charge_id}:{amount_raw}") the real
+    write path uses, so seeded state is indistinguishable from a real one on
+    read.
+    """
+    store = spend_cap._get_store()
+    r = await store._get_redis()
+    key = spend_cap._key(wallet)
+    await r.zadd(key, {f"{charge_id}:{amount_raw}": time.time()})
+    await r.expire(key, spend_cap._KEY_TTL_SECONDS)
+
+
 # ── spend_cap_usdc() — config parsing ───────────────────────────────────
 
 
@@ -76,7 +101,7 @@ def test_spend_cap_usdc_non_numeric_disables_and_warns(monkeypatch, caplog):
     assert "not a valid number" in caplog.text
 
 
-# ── round-trip: record_charge_usdc -> get_24h_spend_usdc ───────────────
+# ── round-trip: seeded spend -> get_24h_spend_usdc ──────────────────────
 
 
 @pytest.mark.asyncio
@@ -85,29 +110,29 @@ async def test_get_24h_spend_usdc_starts_at_zero():
 
 
 @pytest.mark.asyncio
-async def test_record_and_read_back_round_trip():
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="tick1:rebalance", amount_raw=_raw("3"))
+async def test_reserve_and_read_back_round_trip():
+    await _seed(_WALLET, "tick1:rebalance", _raw("3"))
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("3")
 
 
 @pytest.mark.asyncio
-async def test_record_charge_sums_multiple_charges():
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("2"))
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c2", amount_raw=_raw("1.5"))
+async def test_reserve_sums_multiple_charges():
+    await _seed(_WALLET, "c1", _raw("2"))
+    await _seed(_WALLET, "c2", _raw("1.5"))
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("3.5")
 
 
 @pytest.mark.asyncio
-async def test_record_charge_zero_or_negative_amount_is_noop():
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=0)
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c2", amount_raw=-100)
+async def test_reserve_zero_or_negative_amount_is_noop():
+    assert await spend_cap.try_reserve_usdc(_WALLET, 0, charge_id="c1") is True
+    assert await spend_cap.try_reserve_usdc(_WALLET, -100, charge_id="c2") is True
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
 
 
 @pytest.mark.asyncio
 async def test_spend_is_independent_per_wallet():
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("4"))
-    await spend_cap.record_charge_usdc("0xOtherWallet00000000000000000000000002", charge_id="c2", amount_raw=_raw("9"))
+    await _seed(_WALLET, "c1", _raw("4"))
+    await _seed("0xOtherWallet00000000000000000000000002", "c2", _raw("9"))
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("4")
 
 
@@ -117,8 +142,110 @@ async def test_wallet_key_is_case_insensitive():
     under mixed case must be visible when read back with lowercase (or any
     other case), matching how sub.subscriber_wallet is used inconsistently
     across call sites (some pre-lowered, some not)."""
-    await spend_cap.record_charge_usdc(_WALLET.upper(), charge_id="c1", amount_raw=_raw("2"))
+    await _seed(_WALLET.upper(), "c1", _raw("2"))
     assert await spend_cap.get_24h_spend_usdc(_WALLET.lower()) == Decimal("2")
+
+
+# ── try_reserve_usdc — the atomic check-and-reserve ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_try_reserve_succeeds_when_under_cap():
+    assert await spend_cap.try_reserve_usdc(_WALLET, _raw("5"), charge_id="c1") is True
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("5")
+
+
+@pytest.mark.asyncio
+async def test_try_reserve_refuses_when_it_would_exactly_meet_cap():
+    await _seed(_WALLET, "c1", _raw("5"))
+    assert await spend_cap.try_reserve_usdc(_WALLET, _raw("5"), charge_id="c2") is False
+    # Refused — nothing written for the refused attempt.
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("5")
+
+
+@pytest.mark.asyncio
+async def test_try_reserve_refuses_when_it_would_exceed_cap():
+    await _seed(_WALLET, "c1", _raw("8"))
+    assert await spend_cap.try_reserve_usdc(_WALLET, _raw("3"), charge_id="c2") is False
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("8")
+
+
+@pytest.mark.asyncio
+async def test_try_reserve_disabled_when_cap_is_zero(monkeypatch):
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "0")
+    assert await spend_cap.try_reserve_usdc(_WALLET, _raw("999999"), charge_id="c1") is True
+    # Disabled short-circuits before touching Redis at all — nothing written.
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_try_reserve_retry_of_same_charge_id_does_not_double_count():
+    """A retry that reserves the SAME charge_id + amount (e.g. a caller that
+    ignored the idempotency guard) must not double-count — Redis ZADD upserts
+    an existing member's score rather than duplicating it, so the total
+    stays the sum of distinct entries, not distinct calls."""
+    assert await spend_cap.try_reserve_usdc(_WALLET, _raw("5"), charge_id="c1") is True
+    assert await spend_cap.try_reserve_usdc(_WALLET, _raw("5"), charge_id="c1") is True
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("5")
+
+
+# ── the actual race: concurrent try_reserve_usdc calls near the cap ────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reserves_never_exceed_the_cap():
+    """Direct proof for the #1099 review finding: fire more concurrent
+    reservations at a wallet than the cap allows and confirm the atomic Lua
+    script serializes them correctly — exactly as many as fit succeed, the
+    rest are refused, and the final total never exceeds the cap. Before the
+    fix, is_over_cap (read) and record_charge_usdc (write) were two separate
+    Redis round-trips with an await in between, so this exact scenario could
+    let every concurrent caller read "under cap" and all of them proceed.
+
+    Cap is pinned to 10 and refuses at >= cap (test_is_over_cap_true_when_
+    spend_exactly_meets_cap), so with 1-USDC charges only 9 fit — a 10th
+    would land exactly on the cap.
+    """
+    per_charge = _raw("1")
+    results = await asyncio.gather(
+        *[spend_cap.try_reserve_usdc(_WALLET, per_charge, charge_id=f"concurrent-{i}") for i in range(25)]
+    )
+    assert sum(results) == 9
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("9")
+
+
+# ── release_reservation ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_release_reservation_removes_the_entry():
+    await spend_cap.try_reserve_usdc(_WALLET, _raw("4"), charge_id="c1")
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("4")
+    await spend_cap.release_reservation(_WALLET, "c1", _raw("4"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_release_reservation_only_removes_the_matching_entry():
+    await spend_cap.try_reserve_usdc(_WALLET, _raw("4"), charge_id="c1")
+    await spend_cap.try_reserve_usdc(_WALLET, _raw("3"), charge_id="c2")
+    await spend_cap.release_reservation(_WALLET, "c1", _raw("4"))
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("3")
+
+
+@pytest.mark.asyncio
+async def test_release_reservation_zero_or_negative_amount_is_noop():
+    await spend_cap.release_reservation(_WALLET, "c1", 0)  # must not raise or touch Redis
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_release_reservation_swallows_redis_error():
+    """Best-effort — a Redis failure releasing a reservation must not raise,
+    since payments.charge() has already failed by the time this runs and the
+    caller has no further recourse."""
+    with patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))):
+        await spend_cap.release_reservation(_WALLET, "c1", _raw("1"))  # must not raise
 
 
 # ── window boundary: is_over_cap ────────────────────────────────────────
@@ -126,35 +253,43 @@ async def test_wallet_key_is_case_insensitive():
 
 @pytest.mark.asyncio
 async def test_is_over_cap_false_when_under():
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("5"))
+    await _seed(_WALLET, "c1", _raw("5"))
     assert await spend_cap.is_over_cap(_WALLET) is False
 
 
 @pytest.mark.asyncio
 async def test_is_over_cap_true_when_spend_exactly_meets_cap():
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("10"))
+    await _seed(_WALLET, "c1", _raw("10"))
     assert await spend_cap.is_over_cap(_WALLET) is True
 
 
 @pytest.mark.asyncio
 async def test_is_over_cap_true_when_over():
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("15"))
+    await _seed(_WALLET, "c1", _raw("15"))
     assert await spend_cap.is_over_cap(_WALLET) is True
 
 
 @pytest.mark.asyncio
 async def test_is_over_cap_considers_pending_additional_amount():
-    """additional_amount_raw models a charge not yet recorded — current spend
+    """additional_amount_raw models a charge not yet reserved — current spend
     alone is under cap, but current + pending crosses it."""
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("8"))
+    await _seed(_WALLET, "c1", _raw("8"))
     assert await spend_cap.is_over_cap(_WALLET, additional_amount_raw=_raw("1")) is False
     assert await spend_cap.is_over_cap(_WALLET, additional_amount_raw=_raw("2")) is True
 
 
 @pytest.mark.asyncio
+async def test_is_over_cap_never_reserves_anything():
+    """is_over_cap is read-only regardless of additional_amount_raw — unlike
+    try_reserve_usdc, a "would this fit" probe must never itself count."""
+    assert await spend_cap.is_over_cap(_WALLET, additional_amount_raw=_raw("7")) is False
+    assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
+
+
+@pytest.mark.asyncio
 async def test_is_over_cap_disabled_when_cap_is_zero(monkeypatch):
     monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "0")
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("999999"))
+    await _seed(_WALLET, "c1", _raw("999999"))
     assert await spend_cap.is_over_cap(_WALLET) is False
 
 
@@ -162,9 +297,9 @@ async def test_is_over_cap_disabled_when_cap_is_zero(monkeypatch):
 async def test_is_over_cap_new_subscription_check_uses_no_additional():
     """No additional_amount_raw checks current standing only — the shape
     subscribe_strategy uses to gate a brand-new subscription (#713)."""
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("9.99"))
+    await _seed(_WALLET, "c1", _raw("9.99"))
     assert await spend_cap.is_over_cap(_WALLET) is False
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="c2", amount_raw=_raw("0.01"))
+    await _seed(_WALLET, "c2", _raw("0.01"))
     assert await spend_cap.is_over_cap(_WALLET) is True
 
 
@@ -184,7 +319,7 @@ async def test_old_entry_outside_window_does_not_count(_fake_store):
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal(0)
     assert await spend_cap.is_over_cap(_WALLET) is False
 
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="new_charge", amount_raw=_raw("3"))
+    await _seed(_WALLET, "new_charge", _raw("3"))
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("3")
 
 
@@ -205,7 +340,7 @@ async def test_malformed_member_is_skipped_not_fatal(_fake_store):
     key = spend_cap._key(_WALLET)
     now = time.time()
     await _fake_store._redis.zadd(key, {"totally-malformed-no-amount": now})
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="good", amount_raw=_raw("2"))
+    await _seed(_WALLET, "good", _raw("2"))
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("2")
 
 
@@ -215,7 +350,7 @@ async def test_mixed_old_and_new_entries_only_new_counts(_fake_store):
     old_ts = time.time() - (30 * 60 * 60)
     key = spend_cap._key(_WALLET)
     await _fake_store._redis.zadd(key, {f"stale:{_raw('40')}": old_ts})
-    await spend_cap.record_charge_usdc(_WALLET, charge_id="live", amount_raw=_raw("6"))
+    await _seed(_WALLET, "live", _raw("6"))
     assert await spend_cap.get_24h_spend_usdc(_WALLET) == Decimal("6")
     # Cap is pinned to 10 by the autouse fixture — 6 alone must not trip it.
     assert await spend_cap.is_over_cap(_WALLET) is False
@@ -240,23 +375,25 @@ async def test_is_over_cap_fails_open_with_pending_amount_on_redis_error():
 
 
 @pytest.mark.asyncio
+async def test_try_reserve_fails_open_on_redis_error():
+    """Mirrors is_over_cap's fail-open contract: a Redis failure must never
+    block a charge from proceeding — this is an additive guard, not the sole
+    backstop against overcharging."""
+    with patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))):
+        assert await spend_cap.try_reserve_usdc(_WALLET, _raw("999999"), charge_id="c1") is True
+
+
+@pytest.mark.asyncio
 async def test_get_24h_spend_usdc_raises_on_redis_error():
     """get_24h_spend_usdc itself does not swallow errors — only is_over_cap's
-    caller-facing fail-open wrapper does. Pins the boundary so a future
-    refactor can't accidentally silence errors two layers deep."""
+    (and try_reserve_usdc's) caller-facing fail-open wrapper does. Pins the
+    boundary so a future refactor can't accidentally silence errors two
+    layers deep."""
     with (
         patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))),
         pytest.raises(ConnectionError),
     ):
         await spend_cap.get_24h_spend_usdc(_WALLET)
-
-
-@pytest.mark.asyncio
-async def test_record_charge_usdc_swallows_redis_error():
-    """record_charge_usdc is best-effort — a Redis failure must not raise,
-    since the underlying charge has already settled by the time this runs."""
-    with patch.object(AgentStateStore, "_get_redis", AsyncMock(side_effect=ConnectionError("redis down"))):
-        await spend_cap.record_charge_usdc(_WALLET, charge_id="c1", amount_raw=_raw("1"))  # must not raise
 
 
 # ── module-level store singleton ────────────────────────────────────────

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -304,10 +304,37 @@ export default function App() {
       )
       case 'insights':       return <Insights />
       case 'vault-detail':   return <VaultDetail address={selectedVault} onBack={backToPortfolio} />
-      case 'marketplace':    return <MarketplacePage onNavigate={navigateToPage} />
+      case 'marketplace':    return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Marketplace"
+          description="Browse and subscribe to verified quantitative strategies. Connect a wallet to view subscription terms and manage your strategy subscriptions."
+          onConnect={openConnectModal}
+        >
+          <MarketplacePage onNavigate={navigateToPage} />
+        </WalletGate>
+      )
       case 'market-strategy': return <StrategyDetailPage strategyId={selectedStrategy} onNavigate={navigateToPage} />
-      case 'publish':        return <PublishPage onNavigate={navigateToPage} />
-      case 'subscriptions':  return <SubscriptionsPage onNavigate={navigateToPage} />
+      case 'publish':        return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Publish Strategy"
+          description="Publish your quantitative strategy to the Archimedes marketplace for other users to discover and subscribe to."
+          onConnect={openConnectModal}
+        >
+          <PublishPage onNavigate={navigateToPage} />
+        </WalletGate>
+      )
+      case 'subscriptions':  return (
+        <WalletGate
+          walletAddr={walletAddr}
+          pageName="Subscriptions"
+          description="Manage your active strategy subscriptions and non-custodial USDC allowances. Connect a wallet to continue."
+          onConnect={openConnectModal}
+        >
+          <SubscriptionsPage onNavigate={navigateToPage} />
+        </WalletGate>
+      )
       default:               return <NotFound page={page} onNavigate={navigateToPage} />
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to `9c29f53` (first commit on this branch), which added `spend_cap.py` (rolling 24h per-wallet USDC spend tracker on a Redis sorted set) and wired the charge-time refusal into `MarketService._charge_one`. That commit flagged three gaps: a subscribe-path HTTP response, an `.env.example` entry, and tests. This PR closes them.

Background on #713: the original spec (RevenueSplit.sol + x402 middleware) never got built as written — PR #958 shipped a subscription marketplace instead. Mapping the old acceptance criteria against main, the one real gap left was a per-user spend cap. Ricardo confirmed a low-cap-with-renew model works for the current payment flow. #713 stays open pending review here.

## What's in it

- `POST /api/marketplace/subscribe` returns 429 for a wallet at/over its rolling 24h cap. Sits after the existing dedup checks and before wallet provisioning. The charge-time refusal in `_charge_one` stays the operationally load-bearing guard (it runs in the tick loop and can't produce an HTTP response itself).
- **Reviewer heads-up: `_charge_one` changed return type**, `bool` → `tuple[bool, str | None]`, to carry the spend-cap halt reason. 11 pre-existing tests in `test_per_step_charging` / `test_service_tick` / `test_settlement_idempotency` mocked or asserted the old bool and are fixed here.
- `.env.example`: `MARKETPLACE_SPEND_CAP_USDC=50`. The default is a placeholder, not a risk-modeled number; 0 disables the check.
- New `backend/tests/marketplace/test_spend_cap.py`: 25 tests, 100% line coverage on `spend_cap.py`, fakeredis-backed (real Lua execution, not mocks).
- Docstring fix on `get_24h_spend_usdc`: it doesn't itself catch Redis errors, `is_over_cap` is the fail-open boundary. No logic change.

## Atomicity fix (from Dan's review)

The original check-then-record pairing (`is_over_cap` read, `record_charge_usdc` write, async `payments.charge()` in between) was a TOCTOU race: N concurrent charges near the cap could all read "under cap" before any of them recorded anything. Replaced with one atomic Lua script (`_CHECK_AND_RESERVE_LUA`, modeled on `redis_state.py`'s `_LEASE_ACQUIRE_LUA`) that prunes the window, sums it, and reserves in a single EVAL. Both call sites (`is_over_cap`, `try_reserve_usdc`) share it.

`_charge_one` reserves immediately before `payments.charge()`, gated behind the settlement-intent idempotency claim so a crash-retry of an already-settled charge short-circuits before ever reaching the reservation. Cost: a cap-refused charge now claims an intent slot (finalized `failed`) where it used to claim none. `record_charge_usdc` is gone. A concurrency test fires 25 concurrent reservations at a 10-USDC cap against real fakeredis Lua and confirms exactly as many succeed as fit, never more.

Known limitation, deliberately not scope-crept in: the 429 doesn't surface a reset time. With a rolling window the honest answer is "when your oldest in-window charge ages out" — happy to add as a follow-up if it's worth the extra Redis read.

## Post-review hardening (`52063f7`)

- `charge_id` now includes `sub_id`. The old `{tick_id}:{step}` form was collision-free only because the subscribe route allows one running sub per (wallet, strategy) — an invariant enforced in a different file. If it ever relaxes, two same-wallet subs in one tick+step would share a Redis member, undercount, and cross-release. One f-string term removes the coupling.
- A raise escaping `payments.charge` (documented "never raises", but the reservation shouldn't depend on that holding forever) used to strand the reserved amount in the window for 24h. Now caught and treated as a failed charge: released, finalized `failed`. Test added for the raise path.

## Verify

```
pytest --cov=archimedes.marketplace.spend_cap --cov-report=term-missing backend/tests/marketplace/test_spend_cap.py
# 25 passed, 100% coverage
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/ -q -k "not integration"
# 2957 passed, 2 skipped, 0 failed (re-run after 52063f7)
```

ruff format + critical rules (E9,F63,F7,F40) clean on every touched file.

## Review

Needs Dan's review — fund-adjacent charge path. `PAYMENTS_DRY_RUN=true` in prod today, so no real fund movement yet, but this code is live the moment that flag flips. Bogdan preferred second reviewer. Ricardo (`rcrdoh`) owns the marketplace lane per the team table, flagging for his read too.

No release marker (patch): a safety guard on an already-shipped feature, not new user-facing capability. Skipped `arc-canteen update-product` for the same reason.
