### PR TITLE
[backend][tests] Fix cross-file DB isolation leak in marketplace tests

### DIFF
--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -7,19 +7,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.marketplace_routes import marketplace_router
-from archimedes.db import Base, engine
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from tests.db_isolation import redirect_to_tmp_sqlite
 
 TEST_WALLET = "0x0000000000000000000000000000000000000001"
 
 
 @pytest.fixture(autouse=True)
-def _setup_db():
-    """Create all tables before each test, drop after."""
-    Base.metadata.create_all(bind=engine)
-    yield
-    Base.metadata.drop_all(bind=engine)
+def _setup_db(tmp_path):
+    """Point archimedes.db at a fresh, isolated tmp SQLite file for each test.
+
+    See tests/db_isolation.py — archimedes.db's engine/SessionLocal/DATABASE_URL
+    are process-global singletons bound once at import time, so real isolation
+    means swapping and restoring them, not create_all/drop_all on whichever
+    engine object happens to still be bound to them (issue #1100).
+    """
+    yield from redirect_to_tmp_sqlite(tmp_path)
 
 
 @pytest.fixture(autouse=True)
@@ -405,9 +409,9 @@ def test_unsubscribe_triggers_refund_and_returns_tx(client, app):
 
 
 # ─── Identity ledger (issue #1028, D1a/D2/D3) ──────────────────────────────
-# _setup_db creates+drops all tables around EACH test in this file, so these
-# assertions can be absolute (not delta-based) — no shared-process residue
-# from other tests, unlike files that use the process-wide default engine.
+# _setup_db redirects to a fresh isolated tmp DB around EACH test in this
+# file, so these assertions can be absolute (not delta-based) — no
+# shared-process residue from other tests.
 
 
 def test_publish_registers_dcw_and_ledgers_strategy_published(client):

--- a/backend/tests/db_isolation.py
+++ b/backend/tests/db_isolation.py
@@ -37,23 +37,30 @@ def redirect_to_tmp_sqlite(tmp_path: Path) -> Iterator[None]:
     orig_session_local = archimedes_db.SessionLocal
     orig_database_url = archimedes_db.DATABASE_URL
 
-    db_path = tmp_path / "test_archimedes.db"
-    archimedes_db.DATABASE_URL = f"sqlite:///{db_path}"
-    archimedes_db.engine = create_engine(
-        archimedes_db.DATABASE_URL,
-        connect_args={"check_same_thread": False},
-    )
-    archimedes_db.SessionLocal = sessionmaker(
-        bind=archimedes_db.engine,
-        autocommit=False,
-        autoflush=False,
-    )
-    archimedes_db.Base.metadata.create_all(bind=archimedes_db.engine)
-
+    tmp_engine = None
     try:
+        # Setup happens INSIDE the try: if create_engine/sessionmaker/create_all
+        # raises after some module attributes were already reassigned, the
+        # finally below still restores the originals — otherwise a setup-time
+        # failure would leak the half-redirected globals into every later test
+        # in the process, the exact #1100 failure mode this helper exists to fix.
+        db_path = tmp_path / "test_archimedes.db"
+        archimedes_db.DATABASE_URL = f"sqlite:///{db_path}"
+        tmp_engine = create_engine(
+            archimedes_db.DATABASE_URL,
+            connect_args={"check_same_thread": False},
+        )
+        archimedes_db.engine = tmp_engine
+        archimedes_db.SessionLocal = sessionmaker(
+            bind=tmp_engine,
+            autocommit=False,
+            autoflush=False,
+        )
+        archimedes_db.Base.metadata.create_all(bind=tmp_engine)
         yield
     finally:
-        archimedes_db.engine.dispose()
+        if tmp_engine is not None:
+            tmp_engine.dispose()
         archimedes_db.engine = orig_engine
         archimedes_db.SessionLocal = orig_session_local
         archimedes_db.DATABASE_URL = orig_database_url

--- a/backend/tests/db_isolation.py
+++ b/backend/tests/db_isolation.py
@@ -44,6 +44,18 @@ def redirect_to_tmp_sqlite(tmp_path: Path) -> Iterator[None]:
         # finally below still restores the originals — otherwise a setup-time
         # failure would leak the half-redirected globals into every later test
         # in the process, the exact #1100 failure mode this helper exists to fix.
+        #
+        # Same side-effect imports init_db() does before ITS create_all: ORM
+        # models must register with Base.metadata or their tables (kg_*,
+        # strategy_passports) silently won't exist on the tmp DB — whether
+        # they do would otherwise depend on which other test file imported
+        # those models first, the exact import-order roulette this helper
+        # exists to eliminate (review follow-up).
+        from archimedes.models import (  # noqa: F401
+            kg,
+            strategy_passport_record,
+        )
+
         db_path = tmp_path / "test_archimedes.db"
         archimedes_db.DATABASE_URL = f"sqlite:///{db_path}"
         tmp_engine = create_engine(

--- a/backend/tests/db_isolation.py
+++ b/backend/tests/db_isolation.py
@@ -1,0 +1,59 @@
+"""Shared per-test isolation for archimedes.db's process-global engine.
+
+``archimedes.db`` builds ``engine`` / ``SessionLocal`` once at import time from
+whatever ``DATABASE_URL`` is set at that moment. Monkeypatching the
+``DATABASE_URL`` env var afterward does not rebind an already-constructed
+engine, and every runtime code path that resolves a session via
+``get_session()`` looks up ``archimedes.db.SessionLocal`` dynamically at call
+time — so the only way to give a test a genuinely fresh, isolated database is
+to reassign the ``archimedes.db`` module attributes directly, and the only way
+to do that safely when many test files share one pytest process is to restore
+the originals afterward. Without the restore step, one test file's tmp-db
+redirect silently outlives it and leaks into every test that runs later in
+the same process (see issue #1100).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from archimedes import db as archimedes_db
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def redirect_to_tmp_sqlite(tmp_path: Path) -> Iterator[None]:
+    """Point archimedes.db at a fresh tmp-file SQLite DB, then restore.
+
+    Use from an autouse fixture: ``yield from redirect_to_tmp_sqlite(tmp_path)``.
+    Saves the current engine/SessionLocal/DATABASE_URL, builds a new engine
+    bound to a tmp_path-scoped file, creates every Base-registered table on
+    it, yields to the test, then disposes the tmp engine and restores the
+    originals — so no later test, in this file or any other, can inherit a
+    dangling redirected engine.
+    """
+    orig_engine = archimedes_db.engine
+    orig_session_local = archimedes_db.SessionLocal
+    orig_database_url = archimedes_db.DATABASE_URL
+
+    db_path = tmp_path / "test_archimedes.db"
+    archimedes_db.DATABASE_URL = f"sqlite:///{db_path}"
+    archimedes_db.engine = create_engine(
+        archimedes_db.DATABASE_URL,
+        connect_args={"check_same_thread": False},
+    )
+    archimedes_db.SessionLocal = sessionmaker(
+        bind=archimedes_db.engine,
+        autocommit=False,
+        autoflush=False,
+    )
+    archimedes_db.Base.metadata.create_all(bind=archimedes_db.engine)
+
+    try:
+        yield
+    finally:
+        archimedes_db.engine.dispose()
+        archimedes_db.engine = orig_engine
+        archimedes_db.SessionLocal = orig_session_local
+        archimedes_db.DATABASE_URL = orig_database_url

--- a/backend/tests/marketplace/conftest.py
+++ b/backend/tests/marketplace/conftest.py
@@ -1,0 +1,19 @@
+"""Autouse DB isolation for every test under backend/tests/marketplace/.
+
+See ``tests/db_isolation.py`` for why this can't be a plain
+``Base.metadata.create_all`` / ``drop_all`` on the module-level engine —
+``archimedes.db.engine`` is a process-global singleton, and a test elsewhere
+in this directory reassigning it without restoring breaks that pattern for
+every other test in the same pytest process (issue #1100).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+
+@pytest.fixture(autouse=True)
+def _isolated_marketplace_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)

--- a/backend/tests/marketplace/test_remove_subscriber.py
+++ b/backend/tests/marketplace/test_remove_subscriber.py
@@ -10,37 +10,16 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from archimedes import db as archimedes_db
 from archimedes.db import get_session
 from archimedes.marketplace.service import MarketService, Publisher, Subscriber
-from archimedes.models.chat import Base
 from archimedes.models.marketplace import MarketplaceAgent
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-
-@pytest.fixture(autouse=True)
-def _use_tmp_db(tmp_path):
-    """Replace engine with a temp SQLite DB so tests never touch the default
-    archimedes_chat.db (which may have stale rows from other test runs).
-
-    We must mutate the module-level engine directly because DATABASE_URL is
-    evaluated at import time (before this fixture runs), so monkeypatch is
-    ineffective here.
-    """
-    db_path = tmp_path / "test_archimedes.db"
-    archimedes_db.DATABASE_URL = f"sqlite:///{db_path}"
-    archimedes_db.engine = create_engine(
-        archimedes_db.DATABASE_URL,
-        connect_args={"check_same_thread": False},
-    )
-    archimedes_db.SessionLocal = sessionmaker(
-        bind=archimedes_db.engine,
-        autocommit=False,
-        autoflush=False,
-    )
-    Base.metadata.create_all(bind=archimedes_db.engine)
-    yield
+# DB isolation for this file's tests comes from the autouse fixture in
+# backend/tests/marketplace/conftest.py (see tests/db_isolation.py) — it
+# replaces the ad hoc redirect-without-restore fixture that used to live
+# here, which left archimedes.db.engine/SessionLocal permanently pointed at
+# this file's last tmp DB for every test that ran later in the same pytest
+# process (issue #1100).
 
 
 @pytest.fixture

--- a/backend/tests/marketplace/test_settlement_idempotency.py
+++ b/backend/tests/marketplace/test_settlement_idempotency.py
@@ -11,19 +11,17 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
-from archimedes.db import Base, engine, get_session
+from archimedes.db import get_session
 from archimedes.marketplace.service import MarketService, Publisher, Subscriber
 from archimedes.marketplace.tick_registry import TickStep
 from archimedes.models.marketplace import SettlementIntent
 
-
-@pytest.fixture(autouse=True)
-def _db():
-    Base.metadata.create_all(bind=engine)
-    yield
-    Base.metadata.drop_all(bind=engine)
+# DB isolation for this file's tests comes from the autouse fixture in
+# backend/tests/marketplace/conftest.py (see tests/db_isolation.py) — it
+# replaces a create_all/drop_all pair that operated on `engine` captured at
+# import time, which silently stopped matching what get_session() resolved
+# to once another file in this directory redirected archimedes.db.engine
+# without restoring it (issue #1100).
 
 
 def _svc(dry_run: bool = False) -> MarketService:


### PR DESCRIPTION
## Summary

Fixes #1100.

Three files in the marketplace test suite touched `archimedes.db`'s process-global `engine` / `SessionLocal` in two incompatible ways:

- `test_remove_subscriber.py` redirected the module attributes to a fresh tmp-file SQLite engine per test, but never restored them afterward.
- `test_settlement_idempotency.py` and `test_marketplace_routes.py` instead ran `Base.metadata.create_all(bind=engine)` / `drop_all(bind=engine)` against `engine` captured once at *import* time.

Once `test_remove_subscriber.py` ran first in a pytest process, it left `archimedes.db.engine` / `SessionLocal` pointed at its last test's abandoned tmp file. Every later `get_session()` call — including the ones inside the real route handlers under test — silently resolved through that dangling engine, while the other two files' own create_all/drop_all fixture kept managing a completely different, untouched `engine` object. Their per-test isolation became a no-op relative to what the code under test actually read and wrote, so rows (e.g. a `test_strat` publisher row) survived across tests in the same run.

## Fix

Added `backend/tests/db_isolation.py::redirect_to_tmp_sqlite()` — a small generator that saves the current `engine` / `SessionLocal` / `DATABASE_URL`, points them at a fresh `tmp_path`-scoped SQLite file, creates every table, yields, then disposes the tmp engine and restores the originals in a `finally` block. This combines a genuinely fresh isolated engine (only possible via direct attribute reassignment, since `get_session()` resolves `SessionLocal` dynamically at call time — see the existing comment in `test_api_routes.py`'s `_use_tmp_db`) with restoring afterward, so no test can leak into anything that runs later in the same process.

- `backend/tests/marketplace/conftest.py` (new) — one autouse fixture applying the helper to every test under `backend/tests/marketplace/`, replacing the two different ad hoc fixtures that used to live in `test_remove_subscriber.py` and `test_settlement_idempotency.py`.
- `backend/tests/api/test_marketplace_routes.py` — `_setup_db` now uses the same helper (this directory isn't covered by the `marketplace/` conftest, so it keeps its own fixture).

No production code under `backend/archimedes/` changed.

## Verify

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python3 -m pytest backend/tests/marketplace/ backend/tests/api/test_marketplace_routes.py -q
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python3 -m pytest backend/tests/api/test_marketplace_routes.py backend/tests/marketplace/ -q
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python3 -m pytest backend/tests/marketplace/test_remove_subscriber.py -q
```

All three pass 0 failed (96 / 96 / 2 passed respectively, both orderings). Ran hermetically in a scratch venv with the `circle-titanoboa-sdk` pinned commit + `pytest-asyncio` + `fakeredis[lua]` installed (this environment's conda env wasn't available, so I rebuilt the equivalent test deps from `environment.yml` in a throwaway venv).

Also ran the full hermetic suite as a broader regression check:

```bash
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python3 -m pytest backend/tests/ -q
# → 2868 passed, 4 skipped (all 4 pre-existing Postgres-only/no-op skips, unrelated to this change)
```

## Anti-goals honored

- No changes under `backend/archimedes/`.
- No assertions weakened, no tests skip-marked — all 6 previously-flaky tests now pass because the DB state is actually clean, not because an assertion got looser.
