### PR TITLE
[frontend] Fix rigor-verdict field mapping, weighted-metric renormalization, and stale-response/NaN guards

### DIFF
--- a/ui/src/components/BacktestVisualizer.jsx
+++ b/ui/src/components/BacktestVisualizer.jsx
@@ -389,7 +389,15 @@ export default function BacktestVisualizer({ result, strategyId, weights } = {})
         return res.json()
       })
       .then((data) => {
-        if (!cancelled && data?.daily_returns) setRealReturns(data.daily_returns)
+        if (cancelled) return
+        if (Array.isArray(data?.daily_returns) && data.daily_returns.length > 0) {
+          setRealReturns(data.daily_returns)
+        } else if (data) {
+          // Persisted-but-empty returns are the same honest "no data" state
+          // as a 404 — an empty equity curve is a flat line (NaN in
+          // EquityDrawdownChart's toYeq), not a real backtest.
+          setReturnsNoData(true)
+        }
       })
       .catch((err) => {
         // Abort is not an error state; network/unexpected errors read as no data
@@ -547,11 +555,22 @@ export default function BacktestVisualizer({ result, strategyId, weights } = {})
                 <div className="bv-sweep-head mono" style={{ textAlign: 'right', paddingRight: 8 }}>{r}</div>
                 {sweepForHeatmap.cols.map((c, j) => {
                   const v = sweepForHeatmap.grid[i][j]
-                  const t = (v - sweepForHeatmap.min) / range
-                  const bg = `rgba(192,132,252,${(0.08 + 0.82 * t).toFixed(3)})`
                   const metricName = sweepForHeatmap.metric ?? 'metric'
                   const p1 = sweepForHeatmap.param1Name ?? 'param1'
                   const p2 = sweepForHeatmap.param2Name ?? 'param2'
+                  if (!Number.isFinite(v)) {
+                    return (
+                      <div
+                        key={`${r}-${c}`}
+                        className="bv-sweep-cell mono"
+                        title={`${p1}=${r}, ${p2}=${c} → ${metricName} unavailable`}
+                      >
+                        —
+                      </div>
+                    )
+                  }
+                  const t = (v - sweepForHeatmap.min) / range
+                  const bg = `rgba(192,132,252,${(0.08 + 0.82 * t).toFixed(3)})`
                   return (
                     <div
                       key={`${r}-${c}`}

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -266,7 +266,7 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
       </div>
 
       {/* ── Dual regime result cards (Issue #163) ── */}
-      {terminal === 'done' && draftedCandidates.length >= 2 && (
+      {terminal === 'done' && (draftedCandidates.length >= 1 || failedRegimes.length >= 1) && (
         <div style={{ marginTop: 16 }}>
           <div className="label" style={{ marginBottom: 8 }}>Strategy Candidates</div>
           <div style={{

--- a/ui/src/components/PortfolioAdvisor.jsx
+++ b/ui/src/components/PortfolioAdvisor.jsx
@@ -23,7 +23,7 @@ function fmt(v, d = 2) {
 }
 
 function AllocationBar({ label, weight, isUsdc, kelly, rigorPassed, isCandidate }) {
-  const pct = (weight * 100).toFixed(1)
+  const pct = (Number.isFinite(weight) ? weight * 100 : 0).toFixed(1)
   return (
     <div style={{ marginBottom: 16 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 5 }}>
@@ -81,11 +81,13 @@ export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {
   const [error, setError] = useState('')
 
   useEffect(() => {
+    let cancelled = false
     setLoading(true)
     setError('')
     setData(null)
     apiGet(`/api/strategies/advisor?risk_profile=${selectedProfile}`)
       .then(d => {
+        if (cancelled) return
         // Backend may return 200 with an `error` body (e.g. when no
         // strategies are available) — surface that as a user-facing error
         // rather than rendering a half-empty card.
@@ -95,8 +97,9 @@ export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {
           setData(d)
         }
       })
-      .catch(e => setError(e.message || 'Failed to load advisor'))
-      .finally(() => setLoading(false))
+      .catch(e => { if (!cancelled) setError(e.message || 'Failed to load advisor') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
   }, [selectedProfile])
 
   const regime = data?.regime ?? 'unknown'
@@ -365,8 +368,8 @@ export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {
                       {data.correlation_pairs.map((p, i) => (
                         <tr key={i}>
                           <td className="mono" style={{ fontSize: '0.72rem' }}>{p.a} ⟷ {p.b}</td>
-                          <td className="text-right mono" style={{ color: Math.abs(p.corr) > 0.6 ? 'var(--warning)' : 'inherit' }}>
-                            {p.corr > 0 ? '+' : ''}{p.corr.toFixed(2)}
+                          <td className="text-right mono" style={{ color: Number.isFinite(p.corr) && Math.abs(p.corr) > 0.6 ? 'var(--warning)' : 'inherit' }}>
+                            {Number.isFinite(p.corr) ? `${p.corr > 0 ? '+' : ''}${fmt(p.corr)}` : '—'}
                           </td>
                         </tr>
                       ))}

--- a/ui/src/components/PortfolioAdvisorPanels.jsx
+++ b/ui/src/components/PortfolioAdvisorPanels.jsx
@@ -117,6 +117,7 @@ function EfficientFrontier({ points }) {
   const PAD_B = 36
 
   const { plot, frontierPath, optimal, xTicks, yTicks } = useMemo(() => {
+    if (!points.length) return { plot: [], frontierPath: '', optimal: null, xTicks: [], yTicks: [] }
     const xs = points.map((p) => p.risk)
     const ys = points.map((p) => p.ret)
     const xlo = Math.min(...xs) * 0.9
@@ -142,6 +143,15 @@ function EfficientFrontier({ points }) {
     const yt = [ylo, (ylo + yhi) / 2, yhi].map((v) => ({ y: toY(v), label: fmtPct(v) }))
     return { plot: mapped, frontierPath: path, optimal: opt, xTicks: xt, yTicks: yt }
   }, [points])
+
+  if (!optimal) {
+    return (
+      <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>
+        <div className="label mb-2">Efficient Frontier</div>
+        <p className="caption" style={{ color: 'var(--text-4)' }}>No candidate allocations to plot yet.</p>
+      </div>
+    )
+  }
 
   return (
     <div className="card-flat" style={{ padding: 20, marginBottom: 20 }}>

--- a/ui/src/components/RegimePanel.jsx
+++ b/ui/src/components/RegimePanel.jsx
@@ -90,22 +90,25 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
   const [failed, setFailed] = useState(false)
 
   const fetchRegime = useCallback(() => {
+    let cancelled = false
     setLoading(true)
     setFailed(false)
     const timeout = setTimeout(() => {
+      if (cancelled) return
       setLoading(false)
       setFailed(true)
       console.error('Regime fetch timed out after', FETCH_TIMEOUT_MS, 'ms')
     }, FETCH_TIMEOUT_MS)
     apiGet('/api/regime/current')
-      .then(data => { clearTimeout(timeout); setFetchedRegime(data); setFailed(false) })
-      .catch(err => { clearTimeout(timeout); setFailed(true); console.error('Regime fetch failed:', err) })
-      .finally(() => setLoading(false))
+      .then(data => { clearTimeout(timeout); if (!cancelled) { setFetchedRegime(data); setFailed(false) } })
+      .catch(err => { clearTimeout(timeout); if (!cancelled) setFailed(true); console.error('Regime fetch failed:', err) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
   }, [])
 
   useEffect(() => {
     if (regimeProp != null) return
-    fetchRegime()
+    return fetchRegime()
   }, [regimeProp, fetchRegime])
 
   const regime = regimeProp ?? fetchedRegime

--- a/ui/src/components/RegimePanel.jsx
+++ b/ui/src/components/RegimePanel.jsx
@@ -92,17 +92,23 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
   // (e.g. an in-flight auto-fetch that loses a race with a manual Retry
   // click) can't overwrite state after a newer one has already resolved.
   const requestIdRef = useRef(0)
+  // The pending watchdog timer, so a superseding fetch or an unmount can
+  // clear it — otherwise a superseded request's timer stays pending for up
+  // to FETCH_TIMEOUT_MS doing nothing (review).
+  const timeoutRef = useRef(null)
 
   const fetchRegime = useCallback(() => {
     const requestId = ++requestIdRef.current
     setLoading(true)
     setFailed(false)
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
     const timeout = setTimeout(() => {
       if (requestIdRef.current !== requestId) return
       setLoading(false)
       setFailed(true)
       console.error('Regime fetch timed out after', FETCH_TIMEOUT_MS, 'ms')
     }, FETCH_TIMEOUT_MS)
+    timeoutRef.current = timeout
     apiGet('/api/regime/current')
       .then(data => {
         clearTimeout(timeout)
@@ -121,6 +127,17 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
     if (regimeProp != null) return
     return fetchRegime()
   }, [regimeProp, fetchRegime])
+
+  // Unmount: invalidate ANY in-flight request — including one started by the
+  // manual Retry onClick, which has no effect-cleanup path — and kill the
+  // pending watchdog so neither can setState after unmount (review).
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    },
+    []
+  )
 
   const regime = regimeProp ?? fetchedRegime
 

--- a/ui/src/components/RegimePanel.jsx
+++ b/ui/src/components/RegimePanel.jsx
@@ -1,5 +1,5 @@
 import { apiGet } from '../api'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { regimeMeta, regimeLabel, REGIME_ORDER } from '../regime'
 
 
@@ -88,22 +88,33 @@ export default function RegimePanel({ regime: regimeProp = null, compact = false
   const [fetchedRegime, setFetchedRegime] = useState(null)
   const [loading, setLoading] = useState(regimeProp == null)
   const [failed, setFailed] = useState(false)
+  // Tracks the most recently *started* request so a slow, superseded call
+  // (e.g. an in-flight auto-fetch that loses a race with a manual Retry
+  // click) can't overwrite state after a newer one has already resolved.
+  const requestIdRef = useRef(0)
 
   const fetchRegime = useCallback(() => {
-    let cancelled = false
+    const requestId = ++requestIdRef.current
     setLoading(true)
     setFailed(false)
     const timeout = setTimeout(() => {
-      if (cancelled) return
+      if (requestIdRef.current !== requestId) return
       setLoading(false)
       setFailed(true)
       console.error('Regime fetch timed out after', FETCH_TIMEOUT_MS, 'ms')
     }, FETCH_TIMEOUT_MS)
     apiGet('/api/regime/current')
-      .then(data => { clearTimeout(timeout); if (!cancelled) { setFetchedRegime(data); setFailed(false) } })
-      .catch(err => { clearTimeout(timeout); if (!cancelled) setFailed(true); console.error('Regime fetch failed:', err) })
-      .finally(() => { if (!cancelled) setLoading(false) })
-    return () => { cancelled = true }
+      .then(data => {
+        clearTimeout(timeout)
+        if (requestIdRef.current === requestId) { setFetchedRegime(data); setFailed(false) }
+      })
+      .catch(err => {
+        clearTimeout(timeout)
+        if (requestIdRef.current === requestId) setFailed(true)
+        console.error('Regime fetch failed:', err)
+      })
+      .finally(() => { if (requestIdRef.current === requestId) setLoading(false) })
+    return () => { if (requestIdRef.current === requestId) requestIdRef.current += 1 }
   }, [])
 
   useEffect(() => {

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -154,15 +154,18 @@ export function BacktestHorizon({ s, principal = 1000 }) {
 
 // ── Strategy Architect form ───────────────────────────────────
 
-// Weighted-sum of per-strategy backtest metrics across the architect's
-// selected portfolio. Honest about partial coverage — if any selected
-// strategy is missing a metric, we return null for that metric rather
-// than silently undercounting.
+// Weighted-average of per-strategy backtest metrics across the architect's
+// selected portfolio. Honest about partial coverage — if a selected strategy
+// is missing a metric, its weight is excluded from that metric's average
+// (renormalized by the weight of strategies that actually contributed)
+// rather than silently treated as a zero contribution, which would deflate
+// the blended result.
 function aggregateMetrics(selected, strategies) {
   if (!selected?.length || !strategies?.length) return null
   const byId = Object.fromEntries(strategies.map(s => [s.id, s]))
   const metrics = ['sharpe_ratio', 'cagr', 'max_drawdown']
   const out = {}
+  const metricWeight = Object.fromEntries(metrics.map(m => [m, 0]))
   let totalWeight = 0
   let anyMissing = false
   for (const sel of selected) {
@@ -172,13 +175,14 @@ function aggregateMetrics(selected, strategies) {
     for (const m of metrics) {
       if (row[m] == null) { anyMissing = true; continue }
       out[m] = (out[m] || 0) + row[m] * sel.weight
+      metricWeight[m] += sel.weight
     }
   }
   if (totalWeight === 0) return null
   return {
-    sharpe_ratio: out.sharpe_ratio ?? null,
-    cagr: out.cagr ?? null,
-    max_drawdown: out.max_drawdown ?? null,
+    sharpe_ratio: metricWeight.sharpe_ratio > 0 ? out.sharpe_ratio / metricWeight.sharpe_ratio : null,
+    cagr: metricWeight.cagr > 0 ? out.cagr / metricWeight.cagr : null,
+    max_drawdown: metricWeight.max_drawdown > 0 ? out.max_drawdown / metricWeight.max_drawdown : null,
     coverage_weight: totalWeight,
     partial: anyMissing,
   }
@@ -779,6 +783,13 @@ function coerceGenerated(row) {
   const sourcePapers = Array.isArray(row.source_papers) ? row.source_papers : []
   const firstPaper = sourcePapers[0]?.arxiv_id || ''
   const year = row.created_at ? new Date(row.created_at).getFullYear() : null
+  // rigor_verdict is the real shape the backend persists (see
+  // StrategyRecord.to_dict() in backend/archimedes/models/strategy_store.py
+  // and generation_pipeline.py ~line 1272): {dsr, dsr_p_value, pbo,
+  // oos_sharpe, passing}. Read from there rather than nonexistent top-level
+  // fields — fall back to null only when rigor_verdict itself is absent.
+  const verdict = row.rigor_verdict || null
+  const hasRealMetrics = verdict?.dsr != null || row.sharpe_ratio != null
   // Honest status mapping: the generation pipeline persists status="rejected"
   // when its synthesis-time signal didn't pass, but for these rows no real
   // backtest has run yet (every metric column is null). Calling that
@@ -786,7 +797,6 @@ function coerceGenerated(row) {
   // know what's actually happening: candidate generated, real metrics not
   // computed yet. The rigor gate verdict + DSR/PBO numbers still render
   // honestly on the strategy passport.
-  const hasRealMetrics = row.dsr_value != null || row.sharpe_ratio != null
   const honestStatus = (!hasRealMetrics && row.status === 'rejected')
     ? 'pending_backtest'
     : (row.status || 'candidate')
@@ -804,15 +814,15 @@ function coerceGenerated(row) {
     cagr: null,
     max_drawdown: null,
     correlation_to_spy: null,
-    deflated_sharpe_ratio: null,
-    pbo_score: null,
-    out_of_sample_sharpe: null,
+    deflated_sharpe_ratio: verdict?.dsr ?? null,
+    pbo_score: verdict?.pbo ?? null,
+    out_of_sample_sharpe: verdict?.oos_sharpe ?? null,
     paper_claimed_sharpe: null,
     backtest_start: null,
     backtest_end: null,
     is_backtest_placeholder: true,
-    passes_rigor_gate: null,
-    dsr_p_value: null,
+    passes_rigor_gate: verdict ? Boolean(verdict.passing) : null,
+    dsr_p_value: verdict?.dsr_p_value ?? null,
     sharpe_ci_95: null,
     drift_detected: null,
   }


### PR DESCRIPTION
## Summary

Batch of frontend fixes from a code-review sweep over the strategy generation / rigor UI, most severe first:

- **`Strategies.jsx` `coerceGenerated()`**: was reading nonexistent top-level fields (`row.dsr_value`, `row.sharpe_ratio`) and hardcoding `passes_rigor_gate`/`deflated_sharpe_ratio`/`pbo_score`/`out_of_sample_sharpe` to `null`, discarding the real `rigor_verdict.{dsr, dsr_p_value, pbo, oos_sharpe, passing}` object the backend actually persists (verified against `StrategyRecord.to_dict()` and `generation_pipeline.py`). Every rigor metric on the Generate page rendered "—" and rejected candidates never showed why.
- **`Strategies.jsx` `aggregateMetrics()`**: the function's own comment claimed missing-metric strategies are excluded honestly, but the code summed `row[m] * weight` over contributing strategies without renormalizing by their contributed weight — silently deflating the blended metric (treating a missing value as a zero contribution). Now tracks per-metric contributed weight and renormalizes.
- **`PortfolioAdvisor.jsx`**: added a cancellation guard on the advisor fetch (fast profile switches could let a stale response overwrite a fresher one), guarded `p.corr.toFixed(2)` against non-finite values, and guarded `AllocationBar`'s `pct` against `NaN`.
- **`GenerationStream.jsx`**: the dual-regime result card section was gated on `draftedCandidates.length >= 2`, hiding the entire section (including a real success + failure explanation) whenever only one regime succeeded and the other failed.
- **`BacktestVisualizer.jsx`**: an empty (but present) `daily_returns` array was treated as real data instead of the "no data" state, producing a NaN equity/drawdown chart; the parameter-sweep heatmap had no finite guard despite the surrounding min/max calc already filtering for it.
- **`PortfolioAdvisorPanels.jsx`**: `EfficientFrontier` crashed on an explicit empty `points` array (only guarded `null`/`undefined`).
- **`RegimePanel.jsx`**: added a staleness guard using a request-id ref (not just a cancelled-flag closure) so both the auto-fetch effect and the manual Retry click are covered by the same race protection.

## Test plan

- [x] `./node_modules/.bin/eslint` on all touched files — clean
- [x] Manually cross-checked `coerceGenerated`'s field mapping against `backend/archimedes/models/strategy_store.py` and `backend/archimedes/agents/generation_pipeline.py` (~line 1272) to confirm the real `rigor_verdict` shape
- [ ] Not run against a live backend in this pass — worth a smoke test on the Generate/Architect pages before merge