### PR TITLE
[frontend] Fix cross-user trace leak, vault AUM overstatement, and sign/staleness bugs

### DIFF
--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -191,7 +191,7 @@ export default function Leaderboard() {
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmt(e.sharpe_ratio)}</td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmtPct(e.cagr)}</td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap', color: 'var(--negative)' }}>
-                    {e.max_drawdown != null ? `−${fmtPct(e.max_drawdown)}` : '—'}
+                    {e.max_drawdown != null ? `−${fmtPct(Math.abs(e.max_drawdown))}` : '—'}
                   </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     {rigorBadge(e)}

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -190,7 +190,9 @@ export default function Leaderboard() {
                   </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmt(e.sharpe_ratio)}</td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmtPct(e.cagr)}</td>
-                  <td style={{ padding: '10px', whiteSpace: 'nowrap', color: 'var(--negative)' }}>{fmtPct(e.max_drawdown)}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap', color: 'var(--negative)' }}>
+                    {e.max_drawdown != null ? `−${fmtPct(e.max_drawdown)}` : '—'}
+                  </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     {rigorBadge(e)}
                     {e.dsr_p_value != null && <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }} title="DSR confidence (0–1, higher is better): probability the Sharpe survives deflation/multiple-testing. Not a classical p-value.">DSR conf={fmt(e.dsr_p_value)}{e.pbo_score != null ? ` · PBO ${fmt(e.pbo_score)}` : ''}</div>}

--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -150,19 +150,38 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace, on
     // Regime is loaded + rendered by <RegimePanel /> above, not duplicated here.
   }, [])
 
+  // Own vaults only — /api/traces/ has no auth, and an unfiltered call
+  // returns the platform's most recent traces across every user's vaults.
+  // Key on the joined address list (not the userVaults array reference)
+  // so loadTraces only gets a new identity when the actual vault set
+  // changes, not on every re-fetch of the same vaults.
+  const vaultAddrKey = userVaults.map(v => v.address).join(',')
+
   const loadTraces = useCallback(async () => {
+    const addrs = vaultAddrKey ? vaultAddrKey.split(',') : []
+    if (addrs.length === 0) { setRecentTraces([]); return }
     setTracesLoading(true)
     try {
-      const r = await fetch(`${API_BASE}/api/traces/?limit=20`)
-      if (r.ok) {
-        const data = await r.json()
-        setRecentTraces(data.traces || [])
-      }
+      // list_traces() (traces_routes.py) only accepts a single vault_address
+      // filter, not a list — one request per owned vault, merged and
+      // re-sorted client-side, rather than inventing a filter shape the
+      // backend doesn't support.
+      const results = await Promise.all(
+        addrs.map(addr =>
+          fetch(`${API_BASE}/api/traces/?limit=20&vault_address=${addr}`)
+            .then(r => (r.ok ? r.json() : { traces: [] }))
+            .catch(() => ({ traces: [] })),
+        ),
+      )
+      const tsMs = (t) => { const d = new Date(t); return Number.isNaN(d.getTime()) ? 0 : d.getTime() }
+      const merged = results.flatMap(d => d.traces || [])
+      merged.sort((a, b) => tsMs(b.timestamp) - tsMs(a.timestamp))
+      setRecentTraces(merged.slice(0, 20))
     } catch {
       // Network blip — leave prior recentTraces intact; next poll retries.
     }
     setTracesLoading(false)
-  }, [])
+  }, [vaultAddrKey])
 
   useEffect(() => { loadVaults(); loadWalletUsdc() }, [loadVaults, loadWalletUsdc])
   useEffect(() => { loadAgentAndRegime(); loadTraces() }, [loadAgentAndRegime, loadTraces])
@@ -173,11 +192,16 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace, on
     return () => clearInterval(t)
   }, [loadAgentAndRegime, loadTraces, loadWalletUsdc, loadVaults])
 
-  // YOUR AUM — sum across vaults the connected wallet created. Placeholder rows
-  // for vaults whose reads reverted contribute 0 (their AUM is unknown), so a
-  // stale-oracle vault doesn't poison the total with NaN.
-  // Wallet-disconnected users see 0; wallet-connected users see real $ at risk.
-  const yourAum = userVaults.reduce((s, v) => s + (v.aum || 0), 0)
+  // YOUR AUM — sum of the connected wallet's OWN share value across vaults it
+  // created, not each vault's totalAssets() (which includes every depositor).
+  // Vault.deposit() has no access-control modifier, so a vault the wallet
+  // created can hold other depositors' USDC too; using totalAssets() here
+  // would overstate the creator's own exposure. userValue (below) is already
+  // scoped to the wallet's own shares — reuse it instead of re-deriving from
+  // aum. Placeholder rows for vaults whose reads reverted contribute 0 (their
+  // value is unknown), so a stale-oracle vault doesn't poison the total with
+  // NaN. Wallet-disconnected users see 0; wallet-connected users see real $ at risk.
+  const yourAum = userVaults.reduce((s, v) => s + (v.userValue || 0), 0)
   const hasVaults = userVaults.length > 0
 
   // Aggregate unrealized PnL across the user's vault positions (positions they
@@ -344,9 +368,9 @@ export default function Portfolio({ walletAddr, onSelectVault, onSelectTrace, on
                 </div>
                 <div className="flex items-baseline gap-2 mt-3 mb-1">
                   <span className="text-[1.5rem] font-bold">
-                    ${v.aum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    ${v.userValue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                   </span>
-                  <span className="caption">AUM</span>
+                  <span className="caption">Your value</span>
                 </div>
                 <div className="flex justify-between items-center mt-2 flex-wrap gap-2">
                   <code className="caption" style={{ color: 'var(--text-3)' }}>{shortAddr(v.address)}</code>

--- a/ui/src/components/PublishPage.jsx
+++ b/ui/src/components/PublishPage.jsx
@@ -57,11 +57,13 @@ export default function PublishPage({ onNavigate }) {
     if (!vaultMode || !selectedStrategy) return
     const addr = vaultMode === 'create' ? createdVault : existingVault.trim()
     if (!addr) { setVaultBalance(null); return }
+    let cancelled = false
     setCheckingBalance(true)
     usdcBalanceOfRaw(addr)
-      .then(b => setVaultBalance(b))
-      .catch(() => setVaultBalance(null))
-      .finally(() => setCheckingBalance(false))
+      .then(b => { if (!cancelled) setVaultBalance(b) })
+      .catch(() => { if (!cancelled) setVaultBalance(null) })
+      .finally(() => { if (!cancelled) setCheckingBalance(false) })
+    return () => { cancelled = true }
   }, [vaultMode, createdVault, existingVault, selectedStrategy, depositDone])
 
   const resetMenu = () => {

--- a/ui/src/components/PublishPage.jsx
+++ b/ui/src/components/PublishPage.jsx
@@ -54,9 +54,13 @@ export default function PublishPage({ onNavigate }) {
 
   // Check vault balance whenever vault address changes
   useEffect(() => {
-    if (!vaultMode || !selectedStrategy) return
+    // Early-return paths must reset checkingBalance too: when deps change
+    // mid-flight, the cleanup cancels the old run (its guarded .finally never
+    // fires) — if the new run then bails here, the UI would stay stuck on
+    // "Checking balance…" forever (review).
+    if (!vaultMode || !selectedStrategy) { setCheckingBalance(false); return }
     const addr = vaultMode === 'create' ? createdVault : existingVault.trim()
-    if (!addr) { setVaultBalance(null); return }
+    if (!addr) { setVaultBalance(null); setCheckingBalance(false); return }
     let cancelled = false
     setCheckingBalance(true)
     usdcBalanceOfRaw(addr)

--- a/ui/src/components/PublishStrategyTable.jsx
+++ b/ui/src/components/PublishStrategyTable.jsx
@@ -86,11 +86,15 @@ function StrategyRow({ s, onSelect }) {
           <span className="tag tag-muted">{statusLabel(s.status)}</span>
         </td>
         <td className="mono" style={{ textAlign: 'right' }}>{fmt(s.sharpe_ratio)}</td>
-        <td className={`mono ${s.cagr == null ? '' : s.cagr >= 0 ? 'positive' : 'negative'}`} style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
+        {/* Color/class checks use Number.isFinite to match what fmtPct/fmtUsd
+            actually render — a NaN/Infinity CAGR renders "—" and must not
+            carry a positive/negative color (review). Math.abs on drawdown
+            avoids a double negative when the backend ships it signed. */}
+        <td className={`mono ${!Number.isFinite(s.cagr) ? '' : s.cagr >= 0 ? 'positive' : 'negative'}`} style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
         <td className="mono negative" style={{ textAlign: 'right' }}>
-          {s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}
+          {s.max_drawdown != null ? `−${fmtPct(Math.abs(s.max_drawdown))}` : '—'}
         </td>
-        <td className="mono" style={{ textAlign: 'right', color: s.cagr == null ? 'var(--text-3)' : s.cagr >= 0 ? 'var(--positive)' : 'var(--negative)' }}>{fmtUsd(endValue)}</td>
+        <td className="mono" style={{ textAlign: 'right', color: !Number.isFinite(s.cagr) ? 'var(--text-3)' : s.cagr >= 0 ? 'var(--positive)' : 'var(--negative)' }}>{fmtUsd(endValue)}</td>
         <td style={{ textAlign: 'right', padding: '6px 10px' }}>
           {s.can_publish ? (
             <button

--- a/ui/src/components/PublishStrategyTable.jsx
+++ b/ui/src/components/PublishStrategyTable.jsx
@@ -86,11 +86,11 @@ function StrategyRow({ s, onSelect }) {
           <span className="tag tag-muted">{statusLabel(s.status)}</span>
         </td>
         <td className="mono" style={{ textAlign: 'right' }}>{fmt(s.sharpe_ratio)}</td>
-        <td className="mono positive" style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
+        <td className={`mono ${s.cagr == null ? '' : s.cagr >= 0 ? 'positive' : 'negative'}`} style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
         <td className="mono negative" style={{ textAlign: 'right' }}>
           {s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}
         </td>
-        <td className="mono" style={{ textAlign: 'right', color: 'var(--positive)' }}>{fmtUsd(endValue)}</td>
+        <td className="mono" style={{ textAlign: 'right', color: s.cagr == null ? 'var(--text-3)' : s.cagr >= 0 ? 'var(--positive)' : 'var(--negative)' }}>{fmtUsd(endValue)}</td>
         <td style={{ textAlign: 'right', padding: '6px 10px' }}>
           {s.can_publish ? (
             <button


### PR DESCRIPTION
## Summary

Batch of frontend fixes from a code-review sweep over wallet/vault components, most severe first:

- **HIGH — `Portfolio.jsx` `loadTraces()` (privacy leak)**: called `GET /api/traces/?limit=20` with no `vault_address` filter, so it returned the platform's most recent 20 traces globally — any connected wallet, including one with zero vaults, saw other users' vault rebalance/skip traces under "Your Traces." Fixed to fetch per-owned-vault (backend's `vault_address` filter is a single string, not a list — verified against `traces_routes.py::list_traces()`), merge, and re-sort client-side.
- **Medium — `Portfolio.jsx` vault AUM overstatement**: the "Vault AUM" tile summed each vault's `totalAssets()` (all depositors), not the connected wallet's own share value, while explicitly labeled "real $ at risk." Since `Vault.deposit()` has no access-control modifier (any address can deposit into any vault, by contract design), a vault the wallet created could hold other depositors' funds too. Now reuses the file's existing correctly-scoped `userValue` calculation; the per-vault card caption changed from "AUM" to "Your value" to match.
- **Low-Medium — `PublishStrategyTable.jsx`**: CAGR cell and "$1k →" projection were hardcoded green regardless of sign — a strategy with negative CAGR (a real, expected case here) rendered its loss in green on the publish-decision page. Now conditional on `s.cagr`'s sign.
- **Low — `Leaderboard.jsx`**: `max_drawdown` rendered unsigned, while `StrategyPassport.jsx`/`PublishStrategyTable.jsx` both prepend "−" for the same field — same number read differently depending on the page. Now consistent.
- **Low-Medium — `PublishPage.jsx`**: added a cancellation guard to the vault-balance-check effect (editing the vault address input quickly could let a stale balance read win a race).

## Test plan

- [x] `./node_modules/.bin/eslint` on all touched files — clean
- [x] Verified `vault_address` filter shape against `backend/archimedes/api/traces_routes.py::list_traces()` before choosing the per-vault-fetch approach
- [ ] Not run against a live backend in this pass — worth a smoke test on the Portfolio and Publish pages before merge, especially with a multi-vault wallet