### PR TITLE
[frontend] Fix CorpusGraph resize/sample-cap bugs, KG search 422 messaging, and stale stat counts

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -245,7 +245,7 @@ export default function App() {
         <WalletGate
           walletAddr={walletAddr}
           pageName="Generate"
-          description="Generate uses an LLM-powered multi-agent pipeline against a 1,014-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
+          description="Generate uses an LLM-powered multi-agent pipeline against a 10,000-paper q-fin corpus. Connect a wallet — sign in with a passkey, no extension needed — to run the agent and persist your generated strategies in your library."
           onConnect={openConnectModal}
         >
           <Generate onNavigate={navigateToPage} walletAddr={walletAddr} />

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -118,7 +118,7 @@ function HeroStrip() {
     { n: '3', l: 'Top-level agents', s: 'Generation · Construction · Execution' },
     { n: '6', l: 'Memory layers', s: 'KV cache → on-chain ground truth' },
     { n: '10,000', l: 'q-fin metadata records', s: 'embeddings + clusters + KG: build target' },
-    { n: '10', l: 'Smart contracts', s: 'Deployed on Arc testnet' },
+    { n: '11', l: 'Smart contracts', s: 'Deployed on Arc testnet' },
   ]
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-7">

--- a/ui/src/components/CorpusGraph.jsx
+++ b/ui/src/components/CorpusGraph.jsx
@@ -196,7 +196,16 @@ export default function CorpusGraph() {
       )}
 
       <div className="corpus-graph-stats flex gap-2 flex-wrap mb-2" style={{ padding: '0 12px' }}>
-        <span className="tag tag-muted">{data.point_count || data.points?.length || data.nodes?.length || 0} points</span>
+        {/* Count what is actually RENDERED (the MAX_GRAPH_POINTS slice), and
+            disclose truncation explicitly — the backend's point_count is
+            uncapped, so once the corpus exceeds the cap the badge would
+            otherwise claim more points than the canvas draws. */}
+        <span className="tag tag-muted">
+          {graphData.nodes.length} points
+          {(data.point_count || data.points?.length || data.nodes?.length || 0) > graphData.nodes.length
+            ? ` (of ${(data.point_count || data.points?.length || data.nodes?.length || 0).toLocaleString()} total)`
+            : ''}
+        </span>
         <span className="tag tag-muted">{data.cluster_count || 0} clusters</span>
         <span className="tag tag-muted">{data.total_papers?.toLocaleString() || ''} total papers</span>
       </div>

--- a/ui/src/components/CorpusGraph.jsx
+++ b/ui/src/components/CorpusGraph.jsx
@@ -10,6 +10,11 @@ const CLUSTER_PALETTE = [
   '#e879f9', '#22d3ee', '#fb923c', '#a3e635', '#f472b6',
 ]
 
+// Client-side safety net: the backend doesn't currently enforce the
+// `sample` query param, so a future full-corpus response can't overwhelm
+// the force-graph render. Mirrors CorpusKG.jsx's MAX_ENTITIES cap.
+const MAX_GRAPH_POINTS = 1000
+
 /**
  * SPECTER2 similarity force-directed graph.
  *
@@ -26,15 +31,20 @@ export default function CorpusGraph() {
   const [error, setError] = useState('')
   const [hoverNode, setHoverNode] = useState(null)
   const [containerWidth, setContainerWidth] = useState(800)
-  const containerRef = useRef(null)
+  // The wrapper div only mounts once data has loaded (the loading/error/empty
+  // states render before it), so a plain useRef + useEffect(..., []) would see
+  // containerRef.current as null on the one time the effect runs and never
+  // retry. A callback ref fires exactly when the node attaches (including
+  // after that later render), which is what we need here.
+  const [containerNode, setContainerNode] = useState(null)
+  const containerRef = useCallback(node => setContainerNode(node), [])
   const fgRef = useRef(null)
 
   // Track the container's actual width so the canvas always matches it —
-  // both on first paint (in case the ref attaches after the first data-ready
-  // render) and on resize/rotation, instead of locking in a stale/fallback
-  // width forever.
+  // both on mount and on resize/rotation, instead of locking in a stale/
+  // fallback width forever.
   useEffect(() => {
-    const el = containerRef.current
+    const el = containerNode
     if (!el) return
     // ResizeObserver isn't available everywhere (older browsers, some test
     // runners/jsdom) — fall back to a one-time width read from the
@@ -50,7 +60,7 @@ export default function CorpusGraph() {
     ro.observe(el)
     setContainerWidth(el.offsetWidth || 800)
     return () => ro.disconnect()
-  }, [])
+  }, [containerNode])
 
   useEffect(() => {
     let cancelled = false
@@ -83,8 +93,9 @@ export default function CorpusGraph() {
   const graphData = useMemo(() => {
     if (data?.points) {
       // New API: points with pre-computed UMAP x,y
+      const points = data.points.slice(0, MAX_GRAPH_POINTS)
       return {
-        nodes: data.points.map(p => ({
+        nodes: points.map(p => ({
           id: p.arxiv_id,
           label: p.arxiv_id,
           cluster: p.cluster_id || 'default',
@@ -98,19 +109,23 @@ export default function CorpusGraph() {
     }
     // Legacy fallback
     if (!data?.nodes) return { nodes: [], links: [] }
+    const nodes = data.nodes.slice(0, MAX_GRAPH_POINTS)
+    const nodeIds = new Set(nodes.map(n => n.id))
     return {
-      nodes: data.nodes.map(n => ({
+      nodes: nodes.map(n => ({
         id: n.id,
         label: n.title || n.id,
         cluster: n.cluster || 'default',
         val: 2,
         color: clusterColorMap[n.cluster || 'default'] || CLUSTER_PALETTE[0],
       })),
-      links: (data.edges || []).map(e => ({
-        source: e.source,
-        target: e.target,
-        value: e.weight || 1,
-      })),
+      links: (data.edges || [])
+        .filter(e => nodeIds.has(e.source) && nodeIds.has(e.target))
+        .map(e => ({
+          source: e.source,
+          target: e.target,
+          value: e.weight || 1,
+        })),
     }
   }, [data, clusterColorMap])
 

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -46,7 +46,10 @@ export default function CorpusKG({ onOpenPaper }) {
     setLoading(true)
     setError('')
     try {
-      const searchTerm = q || 'topic'
+      // Trim before the default-fallback check: whitespace-only input must
+      // fall back to 'topic' (not become the literal query and 422), and
+      // stray leading/trailing spaces shouldn't reach the backend (review).
+      const searchTerm = (q || '').trim() || 'topic'
       const res = await fetch(`${API_BASE}/api/corpus/kg/entities?q=${encodeURIComponent(searchTerm)}`)
       if (res.status === 503) throw new Error('KB pipeline still running — first artifact pending')
       if (res.status === 422) throw new Error(`422: search term must be at least ${MIN_QUERY_LENGTH} characters`)
@@ -82,7 +85,9 @@ export default function CorpusKG({ onOpenPaper }) {
       return
     }
     setValidationError('')
-    fetchKG(query)
+    // Pass the TRIMMED value — validation ran on `trimmed`, so the request
+    // must use the same string or validation and request can disagree (review).
+    fetchKG(trimmed)
   }
 
   // Layout: arrange entities in a radial layout by type

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -19,6 +19,11 @@ const TYPE_ICONS = {
   method: 'i-lucide-settings',
 }
 
+// Matches the backend's `Query(..., min_length=2)` on /api/corpus/kg/entities —
+// checked client-side so a too-short search shows validation feedback instead
+// of firing a request that 422s.
+const MIN_QUERY_LENGTH = 2
+
 /**
  * Topic Clusters viewer. (Currently renders BERTopic-derived topic clusters
  * across the KB-processed paper subset. Promoted to a real Knowledge Graph
@@ -33,6 +38,7 @@ export default function CorpusKG({ onOpenPaper }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [query, setQuery] = useState('')
+  const [validationError, setValidationError] = useState('')
   const [hoverEntity, setHoverEntity] = useState(null)
   const svgRef = useRef(null)
 
@@ -43,6 +49,7 @@ export default function CorpusKG({ onOpenPaper }) {
       const searchTerm = q || 'topic'
       const res = await fetch(`${API_BASE}/api/corpus/kg/entities?q=${encodeURIComponent(searchTerm)}`)
       if (res.status === 503) throw new Error('KB pipeline still running — first artifact pending')
+      if (res.status === 422) throw new Error(`422: search term must be at least ${MIN_QUERY_LENGTH} characters`)
       if (!res.ok) throw new Error(res.statusText)
       const raw = await res.json()
       // Normalize backend field names to frontend conventions (Issue #345)
@@ -69,6 +76,12 @@ export default function CorpusKG({ onOpenPaper }) {
 
   const handleSearch = (e) => {
     e.preventDefault()
+    const trimmed = query.trim()
+    if (trimmed.length > 0 && trimmed.length < MIN_QUERY_LENGTH) {
+      setValidationError(`Enter at least ${MIN_QUERY_LENGTH} characters`)
+      return
+    }
+    setValidationError('')
     fetchKG(query)
   }
 
@@ -109,15 +122,20 @@ export default function CorpusKG({ onOpenPaper }) {
         <form onSubmit={handleSearch} className="flex gap-2 mb-4">
           <input
             type="text" placeholder="Search entities (author, topic, method)…"
-            value={query} onChange={e => setQuery(e.target.value)}
+            value={query} onChange={e => { setQuery(e.target.value); setValidationError('') }}
             className="chat-input flex-1 p-2.5"
           />
           <button type="submit" className="btn btn-primary">Search</button>
         </form>
+        {validationError && (
+          <div className="caption mb-2" style={{ color: 'var(--text-3)' }}>{validationError}</div>
+        )}
         <div className="info-box warning">
           {error.includes('503') || error.includes('KB pipeline')
             ? 'KB pipeline still running — first artifact pending. The topic clusters will populate once the KG is built.'
-            : `Knowledge graph unavailable: ${error}`}
+            : error.startsWith('422')
+              ? `Search term too short — enter at least ${MIN_QUERY_LENGTH} characters.`
+              : `Knowledge graph unavailable: ${error}`}
         </div>
       </div>
     )
@@ -149,13 +167,17 @@ export default function CorpusKG({ onOpenPaper }) {
       <form onSubmit={handleSearch} className="flex gap-2 mb-4" style={{ padding: '0 12px' }}>
         <input
           type="text" placeholder="Filter by entity (author, topic, category)…"
-          value={query} onChange={e => setQuery(e.target.value)}
+          value={query} onChange={e => { setQuery(e.target.value); setValidationError('') }}
           className="chat-input flex-1 p-2.5"
         />
         <button type="submit" className="btn btn-primary" disabled={loading}>
           {loading ? 'Searching…' : 'Search'}
         </button>
       </form>
+
+      {validationError && (
+        <div className="caption mb-2" style={{ padding: '0 12px', color: 'var(--text-3)' }}>{validationError}</div>
+      )}
 
       {data?.note && (
         <div className="caption" style={{ padding: '4px 12px', color: 'var(--text-4)', fontSize: '0.8rem' }}>

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -100,7 +100,7 @@ function Illustration({ name }) {
           {[0, 1, 2, 3].map(i => (
             <rect key={i} x={20 + i * 30} y={20 + (i % 2) * 6} width="22" height="40" rx="2" fill={i === 2 ? accent : muted} opacity={i === 2 ? 1 : 0.5} />
           ))}
-          <text x="80" y="73" textAnchor="middle" fontFamily="monospace" fontSize="8" fill={muted}>1,014 papers</text>
+          <text x="80" y="73" textAnchor="middle" fontFamily="monospace" fontSize="8" fill={muted}>10,000 papers</text>
         </svg>
       )
     case 'generate':


### PR DESCRIPTION
## Summary

Batch of frontend fixes from a code-review sweep over marketplace/corpus/misc chrome, most severe first:

- **High — `CorpusGraph.jsx` ResizeObserver never activates**: the container div only mounts after data loads (loading/empty states render first), so the mount-only `useEffect(..., [])` always saw `containerRef.current === null` and never retried — `containerWidth` stayed at the 800px fallback forever, overflowing the canvas on any narrower viewport. Replaced the plain ref with a callback ref (`containerNode` state) so the ResizeObserver setup effect re-runs the moment the div actually attaches.
- **Medium — `CorpusGraph.jsx` sample cap not enforced**: the frontend requested `sample=1000` but neither side enforced it (backend ignores the param; frontend had no client-side cap, unlike `CorpusKG.jsx`'s `MAX_ENTITIES`). Added a `MAX_GRAPH_POINTS = 1000` client-side slice (both the new points-API and legacy nodes/edges paths), with edges filtered down to the retained node set. Currently dormant (endpoint 503s pending the KB pipeline's first artifact) but now safe once it isn't.
- **Medium — `CorpusKG.jsx` 422 vs 503 messaging**: a 1-character search triggers the backend's `min_length=2` validation (422), but the frontend lumped any non-ok response into a generic "Knowledge graph unavailable" message. Added a client-side length check with an inline validation hint, plus a 422-specific error branch as a backstop.
- **Low — `Architecture.jsx` stale contract count**: hero stat said "10" smart contracts vs. `Landing.jsx`'s (and CLAUDE.md's canonical) "11". Fixed to match.
- **Low — `OnboardingTour.jsx` stale paper count**: onboarding illustration hardcoded "1,014 papers" vs. the "10,000" figure used elsewhere in the app. Fixed to match.

## Test plan

- [x] `./node_modules/.bin/eslint` on all touched files — clean
- [x] Verified the backend's `min_length=2` against `backend/archimedes/api/corpus_routes.py` and confirmed `corpus_graph()` takes no query params before choosing a client-side-only fix for the sample cap
- [ ] Not run against a live backend in this pass — the Corpus Graph/KG tabs currently 503 until the KB pipeline produces its first artifact, so full visual verification is blocked on that (unrelated, pre-existing)