### PR TITLE
[backend] Fix Redis snapshot lookup, StockBench param typo, vault-bootstrap idempotency, trace-route Redis degradation, marketplace JSON guard

### DIFF
--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -254,7 +254,21 @@ async def publish_trace(req: TracePublishRequest, _: None = Depends(require_inte
     try:
         await state.save_trace(off_chain_data)
     except Exception:
+        # WRITE path: unlike the read endpoints' graceful degradation above,
+        # a failed off-chain persist must NOT return 200 — the caller would
+        # get is_anchored=True for a trace whose full reasoning body was never
+        # stored, i.e. an on-chain anchor that can never be re-verified against
+        # its off-chain content (claim-integrity). Fail loudly and retryably;
+        # include the anchor tx so the caller knows the on-chain half landed.
         logger.error("publish_trace: failed to persist off-chain trace data (Redis unavailable?)", exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Trace anchored on-chain"
+                + (f" (tx {arc_tx_hash})" if arc_tx_hash else "")
+                + " but off-chain persistence failed — retry publish."
+            ),
+        ) from None
     finally:
         await state.close()
 

--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -35,12 +35,16 @@ async def list_traces(
 
     state = AgentStateStore()
     try:
-        off_chain_traces, total = await state.list_traces(
-            vault_address=vault_address,
-            decision_type=decision_type,
-            limit=limit,
-            offset=offset,
-        )
+        try:
+            off_chain_traces, total = await state.list_traces(
+                vault_address=vault_address,
+                decision_type=decision_type,
+                limit=limit,
+                offset=offset,
+            )
+        except Exception:
+            logger.warning("list_traces: Redis unavailable — falling back to on-chain-only listing", exc_info=True)
+            off_chain_traces, total = [], 0
 
         if off_chain_traces:
             traces = []
@@ -125,7 +129,11 @@ async def get_trace(trace_id: str):
 
     state = AgentStateStore()
     try:
-        off_chain = await state.get_trace(trace_id)
+        try:
+            off_chain = await state.get_trace(trace_id)
+        except Exception:
+            logger.warning("get_trace: Redis unavailable — falling back to on-chain-only lookup", exc_info=True)
+            off_chain = None
         if off_chain:
             return TraceResponse(
                 id=off_chain.get("id", trace_id),
@@ -245,6 +253,8 @@ async def publish_trace(req: TracePublishRequest, _: None = Depends(require_inte
     state = AgentStateStore()
     try:
         await state.save_trace(off_chain_data)
+    except Exception:
+        logger.error("publish_trace: failed to persist off-chain trace data (Redis unavailable?)", exc_info=True)
     finally:
         await state.close()
 
@@ -270,7 +280,13 @@ async def verify_trace(trace_id: str, request: Request):  # noqa: ARG001 — slo
 
     state = AgentStateStore()
     try:
-        off_chain = await state.get_trace(trace_id)
+        try:
+            off_chain = await state.get_trace(trace_id)
+        except Exception:
+            logger.warning(
+                "verify_trace: Redis unavailable — falling back to on-chain-only verification", exc_info=True
+            )
+            off_chain = None
         if not off_chain:
             try:
                 int_id = int(trace_id)
@@ -354,7 +370,11 @@ async def get_trace_canonical(trace_id: str):
 
     state = AgentStateStore()
     try:
-        off_chain = await state.get_trace(trace_id)
+        try:
+            off_chain = await state.get_trace(trace_id)
+        except Exception:
+            logger.warning("get_trace_canonical: Redis unavailable", exc_info=True)
+            off_chain = None
         if not off_chain:
             raise HTTPException(status_code=404, detail="Trace not found")
 

--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -264,9 +264,9 @@ async def publish_trace(req: TracePublishRequest, _: None = Depends(require_inte
         raise HTTPException(
             status_code=503,
             detail=(
-                "Trace anchored on-chain"
-                + (f" (tx {arc_tx_hash})" if arc_tx_hash else "")
-                + " but off-chain persistence failed — retry publish."
+                f"Trace anchored on-chain (tx {arc_tx_hash}) but off-chain persistence failed — retry publish."
+                if arc_tx_hash
+                else "Off-chain trace persistence failed (no on-chain anchor was recorded either) — retry publish."
             ),
         ) from None
     finally:
@@ -387,8 +387,11 @@ async def get_trace_canonical(trace_id: str):
         try:
             off_chain = await state.get_trace(trace_id)
         except Exception:
+            # 503, not 404: "store unavailable" must stay distinguishable from
+            # "trace doesn't exist" — a canonical-JSON consumer (hash
+            # re-verification) should retry, not conclude the trace is gone.
             logger.warning("get_trace_canonical: Redis unavailable", exc_info=True)
-            off_chain = None
+            raise HTTPException(status_code=503, detail="Trace store temporarily unavailable — retry.") from None
         if not off_chain:
             raise HTTPException(status_code=404, detail="Trace not found")
 

--- a/backend/archimedes/evaluation/stockbench/adapter.py
+++ b/backend/archimedes/evaluation/stockbench/adapter.py
@@ -436,7 +436,7 @@ class ArchimedesStockBenchAdapter:
                 synth_budget=0.75,
                 market_ranking=market_ranking,
                 strategies=strategies,
-                scan_universe={f"s{a['ticker']}" for a in analysis},
+                scan_universe_synths={f"s{a['ticker']}" for a in analysis},
             )
 
             if portfolio is None or not portfolio.picks:

--- a/backend/archimedes/marketplace/state.py
+++ b/backend/archimedes/marketplace/state.py
@@ -12,7 +12,7 @@ import uuid
 # NOTE: import avoids literal text that triggers the M0 verify heuristic.
 # AgentStateStore wraps an actual Redis connection via _get_redis().
 # Never access the underlying client directly.
-from archimedes.services.redis_state import AgentStateStore, _safe_json_loads
+from archimedes.services.redis_state import AgentStateStore, safe_json_loads
 
 _EVENTS_PREFIX = "archimedes:market:events:"  # + strategy_id  (capped list)
 _SUBS_PREFIX = "archimedes:market:subs:"  # + strategy_id  (JSON dict cache)
@@ -59,7 +59,7 @@ class MarketState:
     async def get_events(self, strategy_id: str, count: int = 50) -> list[dict]:
         r = await self.store._get_redis()
         raw = await r.lrange(f"{_EVENTS_PREFIX}{strategy_id}", 0, count - 1)
-        events = [_safe_json_loads(e, context="market_event") for e in raw]  # already str
+        events = [safe_json_loads(e, context="market_event") for e in raw]  # already str
         return [e for e in events if e is not None]
 
     async def save_subscribers(self, strategy_id: str, subs: dict) -> None:
@@ -71,7 +71,7 @@ class MarketState:
         raw = await r.get(f"{_SUBS_PREFIX}{strategy_id}")
         if not raw:  # raw is str|None
             return {}
-        return _safe_json_loads(raw, context="market_subscribers") or {}
+        return safe_json_loads(raw, context="market_subscribers") or {}
 
     async def try_acquire_leader(self, strategy_id: str, ttl_seconds: int = LEADER_LOCK_TTL_SECONDS) -> str | None:
         """Attempt to acquire the per-strategy leader lock.
@@ -130,7 +130,7 @@ class MarketState:
     async def get_subscriber_ticks(self, sub_id: str, count: int = 50) -> list[dict]:
         r = await self.store._get_redis()
         raw = await r.lrange(f"{_SUBTICK_PREFIX}{sub_id}", 0, count - 1)
-        ticks = [_safe_json_loads(e, context="subscriber_tick") for e in raw]  # already str
+        ticks = [safe_json_loads(e, context="subscriber_tick") for e in raw]  # already str
         return [t for t in ticks if t is not None]
 
     # ---- x402 payment record ------------------------------------------------
@@ -148,7 +148,7 @@ class MarketState:
         """Return the most recent payment record for *sub_id*, or None."""
         r = await self.store._get_redis()
         raw = await r.get(f"{_PAYMENT_PREFIX}{sub_id}")
-        return _safe_json_loads(raw, context="market_payment") if raw else None
+        return safe_json_loads(raw, context="market_payment") if raw else None
 
     async def has_active_payment(self, sub_id: str) -> bool:
         """Return True iff a payment record exists and its ``paid`` field is True."""

--- a/backend/archimedes/marketplace/state.py
+++ b/backend/archimedes/marketplace/state.py
@@ -12,7 +12,7 @@ import uuid
 # NOTE: import avoids literal text that triggers the M0 verify heuristic.
 # AgentStateStore wraps an actual Redis connection via _get_redis().
 # Never access the underlying client directly.
-from archimedes.services.redis_state import AgentStateStore
+from archimedes.services.redis_state import AgentStateStore, _safe_json_loads
 
 _EVENTS_PREFIX = "archimedes:market:events:"  # + strategy_id  (capped list)
 _SUBS_PREFIX = "archimedes:market:subs:"  # + strategy_id  (JSON dict cache)
@@ -59,7 +59,8 @@ class MarketState:
     async def get_events(self, strategy_id: str, count: int = 50) -> list[dict]:
         r = await self.store._get_redis()
         raw = await r.lrange(f"{_EVENTS_PREFIX}{strategy_id}", 0, count - 1)
-        return [json.loads(e) for e in raw]  # already str
+        events = [_safe_json_loads(e, context="market_event") for e in raw]  # already str
+        return [e for e in events if e is not None]
 
     async def save_subscribers(self, strategy_id: str, subs: dict) -> None:
         r = await self.store._get_redis()
@@ -68,7 +69,9 @@ class MarketState:
     async def load_subscribers(self, strategy_id: str) -> dict:
         r = await self.store._get_redis()
         raw = await r.get(f"{_SUBS_PREFIX}{strategy_id}")
-        return json.loads(raw) if raw else {}  # raw is str|None
+        if not raw:  # raw is str|None
+            return {}
+        return _safe_json_loads(raw, context="market_subscribers") or {}
 
     async def try_acquire_leader(self, strategy_id: str, ttl_seconds: int = LEADER_LOCK_TTL_SECONDS) -> str | None:
         """Attempt to acquire the per-strategy leader lock.
@@ -127,7 +130,8 @@ class MarketState:
     async def get_subscriber_ticks(self, sub_id: str, count: int = 50) -> list[dict]:
         r = await self.store._get_redis()
         raw = await r.lrange(f"{_SUBTICK_PREFIX}{sub_id}", 0, count - 1)
-        return [json.loads(e) for e in raw]  # already str
+        ticks = [_safe_json_loads(e, context="subscriber_tick") for e in raw]  # already str
+        return [t for t in ticks if t is not None]
 
     # ---- x402 payment record ------------------------------------------------
 
@@ -144,7 +148,7 @@ class MarketState:
         """Return the most recent payment record for *sub_id*, or None."""
         r = await self.store._get_redis()
         raw = await r.get(f"{_PAYMENT_PREFIX}{sub_id}")
-        return json.loads(raw) if raw else None
+        return _safe_json_loads(raw, context="market_payment") if raw else None
 
     async def has_active_payment(self, sub_id: str) -> bool:
         """Return True iff a payment record exists and its ``paid`` field is True."""

--- a/backend/archimedes/scripts/bootstrap_vaults.py
+++ b/backend/archimedes/scripts/bootstrap_vaults.py
@@ -232,7 +232,29 @@ async def create_vaults(minted: dict[str, float]) -> list[dict]:
     loader = get_contract_loader()
     vaults: list[dict] = []
 
+    # Idempotency check: a rerun of this script mints fresh collateral-backed
+    # synth tokens (fund_and_allocate_vaults transfers them all out of the
+    # wallet immediately) and would otherwise create duplicate vaults with
+    # identical names/symbols on every rerun. Skip any profile that already
+    # exists on-chain.
+    existing_names: set[str] = set()
+    existing_symbols: set[str] = set()
+    try:
+        existing_addresses = await loader.vault_factory.functions.getVaults().call()
+        for existing_addr in existing_addresses:
+            try:
+                existing_vault = loader.vault(existing_addr)
+                existing_names.add(await existing_vault.functions.name().call())
+                existing_symbols.add(await existing_vault.functions.symbol().call())
+            except Exception:
+                logger.debug("existing vault name/symbol check failed for %s", existing_addr, exc_info=True)
+    except Exception:
+        logger.debug("getVaults() check failed", exc_info=True)
+
     for profile in VAULT_PROFILES:
+        if profile["name"] in existing_names or profile["symbol"] in existing_symbols:
+            print(f"  ⏭️  {profile['name']} ({profile['symbol']}): already exists on-chain — skipping")
+            continue
         try:
             # Create vault via VaultFactory
             tx_hash = await circle_signer.execute_contract(

--- a/backend/archimedes/services/redis_state.py
+++ b/backend/archimedes/services/redis_state.py
@@ -101,8 +101,12 @@ end
 """
 
 
-def _safe_json_loads(raw, *, context: str):
+def safe_json_loads(raw, *, context: str):
     """``json.loads`` that degrades gracefully on malformed data (#919).
+
+    Public helper (promoted from ``_safe_json_loads`` in the #1107 review so
+    cross-module consumers — e.g. ``marketplace/state.py`` — depend on a
+    stable name rather than a private internal).
 
     A truncated, partial, or externally-tampered Redis value must not crash a
     read path with a 500. Logs the decode failure and returns ``None`` so the
@@ -203,7 +207,7 @@ class AgentStateStore:
         r = await self._get_redis()
         raw = await r.get(KEY_REGIME)
         if raw:
-            return _safe_json_loads(raw, context=KEY_REGIME)
+            return safe_json_loads(raw, context=KEY_REGIME)
         return None
 
     async def load_ensemble_consensus(self) -> dict | None:
@@ -211,7 +215,7 @@ class AgentStateStore:
         r = await self._get_redis()
         raw = await r.get(KEY_ENSEMBLE_CONSENSUS)
         if raw:
-            return _safe_json_loads(raw, context=KEY_ENSEMBLE_CONSENSUS)
+            return safe_json_loads(raw, context=KEY_ENSEMBLE_CONSENSUS)
         return None
 
     # ─── Heartbeat ────────────────────────────────────────────────
@@ -326,7 +330,7 @@ class AgentStateStore:
     async def get_events(self, count: int = 20) -> list[dict]:
         r = await self._get_redis()
         raw = await r.lrange("archimedes:agent:events", 0, count - 1)
-        return [d for e in raw if (d := _safe_json_loads(e, context="agent:events")) is not None]
+        return [d for e in raw if (d := safe_json_loads(e, context="agent:events")) is not None]
 
     # ─── Vault Monitoring ─────────────────────────────────────────
 
@@ -347,7 +351,7 @@ class AgentStateStore:
         r = await self._get_redis()
         key = f"archimedes:vault:snapshots:{vault_address.lower()}"
         raw = await r.lrange(key, 0, count - 1)
-        return [d for e in raw if (d := _safe_json_loads(e, context="vault:snapshots")) is not None]
+        return [d for e in raw if (d := safe_json_loads(e, context="vault:snapshots")) is not None]
 
     # ─── Reasoning Trace Persistence ────────────────────────────
 
@@ -393,7 +397,7 @@ class AgentStateStore:
         # Try direct hash lookup
         raw = await r.get(f"{KEY_TRACE_PREFIX}{trace_id_or_hash}")
         if raw:
-            parsed = _safe_json_loads(raw, context="trace:hash")
+            parsed = safe_json_loads(raw, context="trace:hash")
             if parsed is not None:
                 return parsed
 
@@ -402,7 +406,7 @@ class AgentStateStore:
         if hash_val:
             raw = await r.get(f"{KEY_TRACE_PREFIX}{hash_val}")
             if raw:
-                parsed = _safe_json_loads(raw, context="trace:uuid")
+                parsed = safe_json_loads(raw, context="trace:uuid")
                 if parsed is not None:
                     return parsed
 
@@ -481,3 +485,7 @@ class AgentStateStore:
         if self._redis:
             await self._redis.aclose()
             self._redis = None
+
+
+# Backwards-compat alias — prefer safe_json_loads (public) going forward.
+_safe_json_loads = safe_json_loads

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -264,9 +264,8 @@ class VaultService:
         # (every concurrent request on the worker stalls) if Redis is slow.
         r = None
         try:
-            r = _aioredis.Redis(
-                host=os.getenv("REDIS_HOST", "localhost"),
-                port=int(os.getenv("REDIS_PORT", "6379")),
+            r = _aioredis.from_url(
+                os.getenv("REDIS_URL", "redis://localhost:6379/0"),
                 decode_responses=True,
             )
             await r.ping()

--- a/backend/tests/api/test_traces_routes.py
+++ b/backend/tests/api/test_traces_routes.py
@@ -1,0 +1,91 @@
+"""Redis-degradation coverage for /api/traces/* (#1107 review follow-up).
+
+The audit PR added graceful-degradation branches to the trace routes; none had
+tests. These pin the two load-bearing behaviors:
+
+- READ path (list_traces): Redis down → 200 with an empty listing, never a 500
+  (the PR's intent — the on-chain anchors still exist, the page still renders).
+- WRITE path (publish_trace): a failed off-chain persist must NOT return a
+  200/is_anchored=True success — the anchor would be unverifiable against an
+  off-chain body that was never stored. It must fail loudly (503) so the
+  internal-agent caller retries.
+
+Hermetic: AgentStateStore and the chain trace_publisher are mocked at the
+boundary; the internal-agent key guard is dependency-overridden.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _publish_body() -> dict:
+    return {
+        "vault_address": "0xVault",
+        "decision_type": "rebalance",
+        "trigger": "drift",
+        "market_context": {},
+        "portfolio_before": {},
+        "portfolio_after": {},
+        "reasoning": "test reasoning",
+        "confidence": 0.9,
+        "trades_executed": [],
+        "strategies_referenced": [],
+    }
+
+
+async def test_list_traces_degrades_to_empty_when_redis_down():
+    from archimedes.main import app
+    from archimedes.services.redis_state import AgentStateStore
+
+    with (
+        patch.object(AgentStateStore, "list_traces", AsyncMock(side_effect=ConnectionError("redis down"))),
+        patch.object(AgentStateStore, "close", AsyncMock()),
+        patch("archimedes.chain.trace_publisher.trace_publisher") as mock_pub,
+    ):
+        mock_pub.list_onchain_trace_ids = AsyncMock(return_value=[])
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/traces/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["traces"] == []
+
+
+async def test_publish_trace_returns_503_when_offchain_persist_fails():
+    """WRITE path: never a silent 200 for a trace whose body was not stored."""
+    from archimedes.api.auth_guard import require_internal_agent_key
+    from archimedes.main import app
+    from archimedes.services.redis_state import AgentStateStore
+
+    prev = app.dependency_overrides.get(require_internal_agent_key)
+    app.dependency_overrides[require_internal_agent_key] = lambda: None
+    try:
+        with (
+            patch.object(AgentStateStore, "save_trace", AsyncMock(side_effect=ConnectionError("redis down"))),
+            patch.object(AgentStateStore, "close", AsyncMock()),
+            patch("archimedes.chain.trace_publisher.trace_publisher") as mock_pub,
+        ):
+            # On-chain half succeeds — the failure mode under test is precisely
+            # "anchored on-chain, but the off-chain body never persisted".
+            mock_pub.publish = AsyncMock(return_value="0xAnchorTx")
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.post("/api/traces/publish", json=_publish_body())
+    finally:
+        if prev is None:
+            app.dependency_overrides.pop(require_internal_agent_key, None)
+        else:
+            app.dependency_overrides[require_internal_agent_key] = prev
+
+    assert resp.status_code == 503
+    assert "off-chain persistence failed" in resp.json()["detail"]

--- a/backend/tests/api/test_traces_routes.py
+++ b/backend/tests/api/test_traces_routes.py
@@ -53,7 +53,12 @@ async def test_list_traces_degrades_to_empty_when_redis_down():
         patch.object(AgentStateStore, "close", AsyncMock()),
         patch("archimedes.chain.trace_publisher.trace_publisher") as mock_pub,
     ):
-        mock_pub.list_onchain_trace_ids = AsyncMock(return_value=[])
+        # The route's on-chain fallback calls get_total_trace_count() +
+        # get_trace_by_id() — mock THOSE (review follow-up: an earlier version
+        # mocked a method the route never calls, so the fallback's swallowed
+        # exception made the test pass vacuously).
+        mock_pub.get_total_trace_count = AsyncMock(return_value=0)
+        mock_pub.get_trace_by_id = AsyncMock(return_value=None)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get("/api/traces/")
 

--- a/backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
+++ b/backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
@@ -33,7 +33,7 @@ class TestCreateVaults:
     def test_happy_path_returns_parsed_vault_address(self):
         """status=1 + VaultCreated event found → vault appended with the
         address parsed from the event (not the getVaults()-idempotency-check
-        fallback, which is called once upfront per #1103 but returns no
+        fallback, which is called once upfront per #1102 but returns no
         existing vaults here)."""
         factory = MagicMock()
         factory.events.VaultCreated.return_value.process_log.return_value = {"args": {"vault": "0xNewVault"}}

--- a/backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
+++ b/backend/tests/scripts/test_bootstrap_vaults_create_vaults.py
@@ -32,9 +32,12 @@ class TestCreateVaults:
 
     def test_happy_path_returns_parsed_vault_address(self):
         """status=1 + VaultCreated event found → vault appended with the
-        parsed address, without ever calling getVaults()."""
+        address parsed from the event (not the getVaults()-idempotency-check
+        fallback, which is called once upfront per #1103 but returns no
+        existing vaults here)."""
         factory = MagicMock()
         factory.events.VaultCreated.return_value.process_log.return_value = {"args": {"vault": "0xNewVault"}}
+        factory.functions.getVaults.return_value.call = AsyncMock(return_value=[])
         loader = MagicMock()
         loader.vault_factory = factory
         receipt = AttributeDict({"status": 1, "logs": [MagicMock()]})
@@ -58,13 +61,13 @@ class TestCreateVaults:
                 "allocations": {"USDC": 10000},
             }
         ]
-        factory.functions.getVaults.assert_not_called()
 
     def test_revert_skips_profile_and_prints_error(self, capsys):
         """status=0 → VaultCreationRevertedError is raised, caught by the
         per-profile try/except, and the profile is NOT appended to vaults
         (the bug #655 guards against: silently returning all_vaults[-1])."""
         factory = MagicMock()
+        factory.functions.getVaults.return_value.call = AsyncMock(return_value=[])
         loader = MagicMock()
         loader.vault_factory = factory
         receipt = AttributeDict({"status": 0, "logs": []})
@@ -81,7 +84,6 @@ class TestCreateVaults:
             vaults = asyncio.run(create_vaults({}))
 
         assert vaults == []
-        factory.functions.getVaults.assert_not_called()
         captured = capsys.readouterr()
         assert "Test Vault: creation failed" in captured.out
         assert "reverted on-chain" in captured.out

--- a/backend/tests/services/test_vault_service.py
+++ b/backend/tests/services/test_vault_service.py
@@ -216,10 +216,12 @@ class TestComputeReturnsAsyncRedis:
     async def test_uses_async_redis_and_awaits_snapshot(self) -> None:
         """Regression for #914: the Redis snapshot path must use the asyncio
         client and await ping/get so it never blocks the event loop. We mock
-        redis.asyncio.Redis with a valid snapshot plus a mocked oracle; the
-        returns must come from the Redis price path (not the deterministic
-        fallback), which only happens if the awaits land. A revert to the sync
-        redis.Redis would miss this patch and fall through to the fallback."""
+        redis.asyncio.from_url (the REDIS_URL-based connection convention used
+        everywhere else in the codebase — see services/redis_state.py) with a
+        valid snapshot plus a mocked oracle; the returns must come from the
+        Redis price path (not the deterministic fallback), which only happens
+        if the awaits land. A revert to the sync redis.Redis would miss this
+        patch and fall through to the fallback."""
         import json
 
         alloc = VaultHolding(symbol="sSPY", token_address="0xT", amount=1.0, value_usdc=1.0, weight_pct=100.0)
@@ -238,7 +240,7 @@ class TestComputeReturnsAsyncRedis:
 
         svc = VaultService()
         with (
-            patch("redis.asyncio.Redis", return_value=fake_redis),
+            patch("redis.asyncio.from_url", return_value=fake_redis),
             patch("archimedes.chain.contracts.get_contract_loader", return_value=loader),
         ):
             result = await svc._compute_returns("0xVault", [alloc])


### PR DESCRIPTION
## Summary

Batch of backend fixes from a code-review sweep, most severe first:

- **`vault_service.py` `_compute_returns()`**: connected to Redis via `REDIS_HOST`/`REDIS_PORT` env vars, which are set nowhere in `.env.example`/docker-compose/infra — every other Redis consumer in the repo uses `REDIS_URL`. Switched to `redis.asyncio.from_url(os.getenv("REDIS_URL", ...))` matching the rest of the codebase. Note: this makes the real-returns code path reachable, it does not fully fix the feature — nothing writes the `vault:prices:{address}` snapshot key it reads, so returns still fall through to the synthetic fallback. That deeper gap is tracked in #1103 (needs an oracle price-writer, Dan's on-chain lane).
- **`evaluation/stockbench/adapter.py`**: `_call_real_agent` called `PortfolioAgent.propose_portfolio(..., scan_universe=...)`, but the real parameter (verified at `portfolio_agent.py:453`) is `scan_universe_synths`. Every call raised `TypeError`, silently caught and downgraded to a momentum fallback — meaning the StockBench benchmark harness never actually exercised the real agent it claims to benchmark. Fixed the kwarg name.
- **`scripts/bootstrap_vaults.py` `create_vaults()`**: no idempotency check before calling `createVault()` per profile — a rerun mints fresh collateral and creates duplicate vaults with identical names. Added an upfront `getVaults()` + name/symbol check, mirroring the existing balance-check pattern in `mint_synthetic_tokens`. Did not touch the hardcoded `synth_vault_addresses` dict (tracked separately in #1102 — needs Dan's input on the current SSOT).
- **`api/traces_routes.py`**: all 5 endpoints wrapped `AgentStateStore` calls in `try/finally` with no `except`, so a Redis outage 500'd instead of degrading gracefully (unlike `agent_routes.py`/`regime_routes.py`). Added explicit exception handling per endpoint, falling through to the existing on-chain-only path where one exists.
- **`marketplace/state.py`**: 4 functions (`get_events`, `load_subscribers`, `get_subscriber_ticks`, `get_payment`) did raw `json.loads()` with no malformed-data guard, unlike `redis_state.py`'s `_safe_json_loads` (added for #919 specifically for this class of bug). Now reuse that helper.

**Collateral test updates** (required by the production changes, not scope creep): `test_vault_service.py` now patches `redis.asyncio.from_url` instead of `redis.asyncio.Redis`; `test_bootstrap_vaults_create_vaults.py`'s two tests asserting `getVaults.assert_not_called()` were updated since the idempotency check now legitimately calls `getVaults()` once upfront (mocked to return `[]` in both tests, preserving their original intent).

## Test plan

- [x] `ruff format --check` + `ruff check --select E9,F63,F7,F40` on all touched files — clean
- [x] `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_vault_service.py backend/tests/scripts/test_bootstrap_vaults_create_vaults.py backend/tests/services/test_stockbench_adapter.py -q` → **62 passed, 0 failed** (hermetic gate)
- [x] Verified `scan_universe_synths` against `PortfolioAgent.propose_portfolio`'s real signature in `portfolio_agent.py:444-453`
- [x] Verified `vault_address` filter and `_safe_json_loads` signature against `traces_routes.py`/`redis_state.py` before applying the fix
- [ ] No dedicated test file exists for `traces_routes.py` — pre-existing coverage gap, not introduced or fixed here

Related: #1102, #1103 (filed separately for the two findings needing Dan's architectural input rather than a guessed fix).