### PR TITLE
[infra] Fix fresh-stack postgres crash: mount /var/lib/postgresql for 18-alpine (#1119)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,21 +54,24 @@ services:
   # runs the app tier against managed stores. See docs/deployment.md.
   postgres:
     # Bumped 16-alpine -> 18-alpine (#777) to match prod Aurora's 18.3 major version.
-    # BREAKING for existing local envs: Postgres refuses to start on a data directory
-    # that a previous major version initialized. If your local `pgdata` volume was
-    # created under the old 16-alpine image, remove it before starting this image:
-    #   docker compose down -v          # drops the pgdata volume (loses local-only data)
-    #   docker compose --profile localdb up -d --build
     #
     # Mount moved to the PARENT dir, `pgdata18:/var/lib/postgresql` (#1119):
     # postgres:18-alpine image revisions since ~2026-07 store data in a
     # major-version-suffixed subdirectory (/var/lib/postgresql/18/docker, for
     # `pg_upgrade --link` support — docker-library/postgres#1259) and HARD-ERROR
     # on a mount at the legacy /var/lib/postgresql/data path, which broke every
-    # fresh `docker compose up`. BREAKING again for existing local envs: data in
-    # the old `pgdata` volume (legacy path) is orphaned by this change — for a
-    # disposable local dev DB, `docker compose down -v` and start fresh; to keep
-    # data, copy it into the version-suffixed layout before switching.
+    # fresh `docker compose up`.
+    #
+    # BREAKING for pre-#1119 local envs: the old `pgdata` volume is no longer
+    # declared here, so `docker compose down -v` will NOT remove it and your
+    # old data is simply orphaned (a fresh, empty `pgdata18` is created on next
+    # up). For the usual disposable local dev DB, no action needed — migrations
+    # re-run on the empty DB. To reclaim disk: `docker volume rm archimedes_pgdata`.
+    # To KEEP old local data: before switching, copy the old volume's contents
+    # into the new layout, e.g.
+    #   docker run --rm -v archimedes_pgdata:/old -v archimedes_pgdata18:/new \
+    #     alpine sh -c 'mkdir -p /new/18/docker && cp -a /old/. /new/18/docker/'
+    # (then verify with a throwaway `docker compose up postgres`).
     image: postgres:18-alpine
     profiles: ["localdb"]
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,16 @@ services:
     # created under the old 16-alpine image, remove it before starting this image:
     #   docker compose down -v          # drops the pgdata volume (loses local-only data)
     #   docker compose --profile localdb up -d --build
+    #
+    # Mount moved to the PARENT dir, `pgdata18:/var/lib/postgresql` (#1119):
+    # postgres:18-alpine image revisions since ~2026-07 store data in a
+    # major-version-suffixed subdirectory (/var/lib/postgresql/18/docker, for
+    # `pg_upgrade --link` support — docker-library/postgres#1259) and HARD-ERROR
+    # on a mount at the legacy /var/lib/postgresql/data path, which broke every
+    # fresh `docker compose up`. BREAKING again for existing local envs: data in
+    # the old `pgdata` volume (legacy path) is orphaned by this change — for a
+    # disposable local dev DB, `docker compose down -v` and start fresh; to keep
+    # data, copy it into the version-suffixed layout before switching.
     image: postgres:18-alpine
     profiles: ["localdb"]
     restart: unless-stopped
@@ -67,7 +77,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env — no default for security}
       POSTGRES_DB: ${POSTGRES_DB:-archimedes}
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata18:/var/lib/postgresql
     # NO host port binding — Postgres is only reachable by other containers
     # on the Docker bridge network. Never expose DB ports to the host/internet.
     healthcheck:
@@ -296,5 +306,7 @@ services:
         required: false
 
 volumes:
-  pgdata:
+  # pgdata (legacy /var/lib/postgresql/data mount) replaced by pgdata18 in
+  # #1119 — see the comment on the postgres service for the migration note.
+  pgdata18:
   archimedes-corpus-artifact:


### PR DESCRIPTION
## Summary

Fixes #1119: `postgres:18-alpine` image revisions since ~2026-07 hard-error on a data mount at the legacy `/var/lib/postgresql/data` path (docker-library/postgres#1259 — 18+ stores data in major-version-suffixed subdirectories for `pg_upgrade --link`). Every fresh `docker compose up` on `main` crash-loops at postgres startup. Found during the 2026-07-13 dependabot full-stack validation on a fresh worktree + fresh volume; `docker-compose.yml` was byte-identical to `main`, so no open PR causes this.

## Change

- Mount moved to the parent dir per the image's own guidance: `pgdata18:/var/lib/postgresql`.
- Volume renamed `pgdata` → `pgdata18`, deliberately: existing local envs get a LOUD, comprehensible break (fresh empty volume, service comment explains why + how to migrate) instead of a confusing in-place crash loop on next recreate.
- Service comment block extended with the migration note (same pattern as the #777 16→18 note above it).

## Validated

- Fresh volume + freshly-pulled image (2026-07-07 revision): stack comes up, postgres **healthy**, backend healthy, endpoint smoke battery green (`/api/health`, `/api/leaderboard`, `/api/regime/current`, `/docs`, UI via nginx).
- `docker compose config -q` clean.

## Heads-up for existing local stacks

Your running stack survives until its postgres container is *recreated*. On first `up` after this merge you'll get a fresh, empty local DB (migrations re-run). To keep old local data, copy it into the version-suffixed layout before switching — see the service comment. **Prod unaffected** (Aurora; `localdb` profile off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6Kusi4wPvwmZSJcd5QeP
