### PR TITLE
[strategy] Fix split-unadjusted OHLCV data, Sortino denominator, claim-integrity gaps

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/cli.py
+++ b/analytics-engine/src/archimedes_analytics_engine/cli.py
@@ -178,6 +178,12 @@ def run_command(
                 }
             )
 
+    # NOTE: look_ahead_audit_passed is a broker-execution-timing check only (no
+    # cheat-on-close/cheat-on-open) — it is NOT a source-level audit of the
+    # strategy's signal logic and is unconditionally True today because this
+    # engine never sets coc/coo. See BacktestResult.look_ahead_audit_passed's
+    # docstring in engine.py. The real AST-based check lives in
+    # backend/archimedes/services/rigor_evaluator.look_ahead_audit.
     lookahead_passed = all(r["metrics"]["look_ahead_audit_passed"] for r in results) if results else False
     paper_claim_applied = metadata.get("paper_claimed_sharpe") is not None
 

--- a/analytics-engine/src/archimedes_analytics_engine/data.py
+++ b/analytics-engine/src/archimedes_analytics_engine/data.py
@@ -51,7 +51,10 @@ def fetch_ohlcv(symbol: str, start: str, end: str) -> pd.DataFrame:
     last_exc: Exception | None = None
     for attempt in range(1, _MAX_RETRIES + 1):
         try:
-            data = yf.download(symbol, start=start, end=end, auto_adjust=False, progress=False)
+            # auto_adjust=True applies yfinance's built-in split/dividend back-adjustment so
+            # corporate actions (e.g. KO's Aug-2012 2-for-1 split) don't show up as spurious
+            # overnight price discontinuities that corrupt pairs-trading signals and PBO.
+            data = yf.download(symbol, start=start, end=end, auto_adjust=True, progress=False)
         except Exception as exc:  # transient network/yfinance error — retry with backoff
             last_exc = exc
             if attempt == _MAX_RETRIES:

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -68,7 +68,17 @@ class BacktestResult:
     gross_sharpe_ratio : float or None
         Sharpe with commissions added back (slippage is not recoverable).
     look_ahead_audit_passed : bool
-        ``True`` when the broker used neither cheat-on-close nor cheat-on-open.
+        ``True`` when the backtrader broker used neither cheat-on-close nor
+        cheat-on-open execution timing. **This is a broker-execution-timing
+        check only** — it is derived solely from ``cerebro.broker.p.coc`` /
+        ``cerebro.broker.p.coo``, which this engine never sets to ``True``,
+        so the field is unconditionally ``True`` for every run regardless of
+        whether the strategy's own signal logic has a look-ahead bug. It does
+        NOT perform any source-level audit of the strategy code. For a real
+        source-level look-ahead audit, see ``look_ahead_audit()`` in
+        ``backend/archimedes/services/rigor_evaluator.py`` (AST-based, checks
+        the strategy's own code for future-data access), which is a separate
+        system from this analytics engine.
 
     See Also
     --------
@@ -166,7 +176,12 @@ def _compute_sortino(daily_returns: list[float]) -> float | None:
     downside = [r for r in daily_returns if r < 0]
     if not downside:
         return None
-    dd_rms = math.sqrt(sum(r * r for r in downside) / len(downside))
+    # Denominator is the TOTAL sample size (not just the count of negative
+    # days) per the standard Sortino/target-semideviation convention (e.g.
+    # empyrical.downside_risk) — non-negative days contribute 0 to the sum but
+    # still count in the denominator. Dividing by len(downside) alone inflates
+    # the ratio for strategies with a skewed win/loss-day ratio.
+    dd_rms = math.sqrt(sum(r * r for r in downside) / len(daily_returns))
     if dd_rms == 0:
         return None
     return ((mean - RF_DAILY) / dd_rms) * math.sqrt(ANNUALIZATION)
@@ -273,6 +288,16 @@ def _cost_metrics(
 
 
 def _lookahead_audit_passed(cerebro: bt.Cerebro) -> bool:
+    """Check the broker's execution-timing config only.
+
+    NOT a source-level look-ahead audit of the strategy's signal logic — this
+    engine never sets ``coc``/``coo`` to ``True`` anywhere, so this always
+    returns ``True``. It only guards against a future misconfiguration that
+    would let the broker cheat-execute on the same bar's close/open. The real
+    AST-based check of strategy code lives in
+    ``backend/archimedes/services/rigor_evaluator.look_ahead_audit`` — a
+    separate system, not invoked from here.
+    """
     coc = getattr(cerebro.broker.p, "coc", False)
     coo = getattr(cerebro.broker.p, "coo", False)
     return not coc and not coo

--- a/analytics-engine/strategies/george_hwang_2004_52w_high.py
+++ b/analytics-engine/strategies/george_hwang_2004_52w_high.py
@@ -96,8 +96,12 @@ class FiftyTwoWeekHighMomentum(bt.Strategy):
         if len(self) <= lookback:
             return
 
-        recent_highs = [float(self.data.high[-i]) for i in range(1, lookback + 1)]
-        annual_high = max(recent_highs)
+        # Disclosed methodology (METHODOLOGY_TEXT) is the trailing 52-week
+        # highest CLOSE, not intraday high — using self.data.high overstates
+        # the denominator (intraday high >= close) and shifts when the
+        # near-52-week-high signal fires relative to the passport's claim.
+        recent_closes = [float(self.data.close[-i]) for i in range(1, lookback + 1)]
+        annual_high = max(recent_closes)
         if annual_high <= 0:
             return
 

--- a/analytics-engine/tests/test_engine_coverage.py
+++ b/analytics-engine/tests/test_engine_coverage.py
@@ -65,10 +65,14 @@ def test_sortino_all_negative_is_finite_and_negative() -> None:
 
 
 def test_sortino_rms_of_negatives_convention() -> None:
-    # Verify the RMS-of-negatives denominator convention explicitly.
+    # Verify the downside-deviation denominator convention explicitly.
+    # Updated for corrected Sortino denominator: divides by the TOTAL sample
+    # size (len(returns)), not just the count of negative days, per the
+    # standard Sortino/target-semideviation convention (e.g.
+    # empyrical.downside_risk) — bug M1 fix.
     returns = [0.05, -0.02, 0.03, -0.04]
     downside = [r for r in returns if r < 0]
-    dd_rms = math.sqrt(sum(r * r for r in downside) / len(downside))
+    dd_rms = math.sqrt(sum(r * r for r in downside) / len(returns))
     mean = statistics.fmean(returns)
     expected = ((mean - RF_DAILY) / dd_rms) * math.sqrt(ANNUALIZATION)
     assert _compute_sortino(returns) == pytest.approx(expected)


### PR DESCRIPTION
Closes #1133

## Summary
- `data.py`: `fetch_ohlcv` used `auto_adjust=False` with no split/dividend adjustment applied downstream. KO's real Aug-2012 2-for-1 split falls inside the 2004-2026 backtest window and shows up as a fake ~50% overnight price collapse in `gatev_2006_pairs_ko_pep`'s price ratio, firing a spurious z-score signal and polluting the library-wide CSCV PBO computation every other strategy's rigor-gate admission depends on. Switched to `auto_adjust=True`.
- `engine.py` `_compute_sortino`: divided downside deviation by the count of negative-return days instead of total days, inflating the reported Sortino ratio for skewed strategies. Fixed to divide by `len(daily_returns)`.
- `engine.py` `look_ahead_audit_passed`: computed solely from backtrader's cheat-on-close/cheat-on-open flags, which are never enabled anywhere in this engine — the field could structurally never read `False` regardless of an actual look-ahead bug in a strategy's signal logic. Docstring now states this only checks broker execution timing and points at the real AST-based `look_ahead_audit()` in the backend.
- `george_hwang_2004_52w_high.py`: implementation used the intraday High line instead of Close, diverging from the strategy's own disclosed methodology text. Fixed to use Close.

Found in an internal bug-hunt pass, 2026-07-14.

## Test plan
- [x] `cd analytics-engine && uv run pytest -q` → 189 passed
