### PR TITLE
[chain] Fix raw-tx serialization, pending-nonce omissions, idempotency keys, bootstrap crash

### DIFF
--- a/backend/archimedes/chain/circle_signer.py
+++ b/backend/archimedes/chain/circle_signer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import os
 import uuid
@@ -118,8 +119,28 @@ class CircleSigner:
 
             ciphertext = _encrypt_entity_secret(self._entity_secret, public_key)
 
+            # Deterministic idempotency key (#F5): derived from the stable
+            # identifying content of this exact call (wallet + contract +
+            # function + args), not a fresh random UUID per call. A retry of
+            # THIS SAME logical call now produces the same key, so Circle's
+            # dedup can actually recognize it as a retry, while a genuinely
+            # different call (different contract/function/args) still
+            # produces a different key. uuid5 is used so the result is a
+            # validly-formatted UUID per Circle's IdempotencyKey schema.
+            idempotency_source = json.dumps(
+                {
+                    "walletId": self._wallet_id,
+                    "contractAddress": contract_address,
+                    "abiFunctionSignature": abi_function,
+                    "abiParameters": abi_params,
+                },
+                sort_keys=True,
+                default=str,
+            )
+            idempotency_key = str(uuid.uuid5(uuid.NAMESPACE_URL, idempotency_source))
+
             payload = {
-                "idempotencyKey": str(uuid.uuid4()),
+                "idempotencyKey": idempotency_key,
                 "walletId": self._wallet_id,
                 "contractAddress": contract_address,
                 "abiFunctionSignature": abi_function,
@@ -170,7 +191,15 @@ class CircleSigner:
         async with aiohttp.ClientSession() as session:
             payload = {
                 "walletId": self._wallet_id,
-                "transaction": tx_object if isinstance(tx_object, str) else str(tx_object),
+                # Circle's SignTransaction endpoint documents `transaction` as
+                # a JSON-encoded string of the tx object (see
+                # developer-controlled-wallets.yaml TransactionObject schema).
+                # Python's str() produces a single-quoted repr
+                # ("{'nonce': '0x5', ...}") which is not valid JSON and is
+                # rejected by Circle's parser — json.dumps() is the correct
+                # encoding. A caller that already passes a pre-serialized
+                # string (e.g. a raw RLP hex string) is passed through as-is.
+                "transaction": tx_object if isinstance(tx_object, str) else json.dumps(tx_object),
             }
 
             # Sign

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -482,7 +482,7 @@ class ChainExecutor:
         if not account:
             raise RuntimeError("No agent account configured — set CIRCLE_API_KEY or ARC_AGENT_PRIVATE_KEY")
 
-        nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+        nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
 
         tx = await factory.functions.createVault(
             name, symbol, management_fee_bps, performance_fee_bps, agent_assisted

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import os
 import uuid
@@ -298,8 +299,29 @@ class OracleUpdater:
                 try:
                     ciphertext = _encrypt_entity_secret(self._entity_secret, public_key)
 
+                    # Deterministic idempotency key (#F5): derived from the
+                    # stable identifying content of this exact call (wallet +
+                    # oracle contract + function + price), not a fresh random
+                    # UUID per call. A retry of THIS SAME push (same symbol,
+                    # same price) now produces the same key, so Circle's
+                    # dedup can actually recognize it as a retry, while a
+                    # genuinely different push (different oracle or price)
+                    # still produces a different key. uuid5 is used so the
+                    # result is a validly-formatted UUID per Circle's
+                    # IdempotencyKey schema.
+                    idempotency_source = json.dumps(
+                        {
+                            "walletId": self._wallet_id,
+                            "contractAddress": oracle_addr,
+                            "abiFunctionSignature": "setPrice(uint256)",
+                            "abiParameters": [str(price_int)],
+                        },
+                        sort_keys=True,
+                    )
+                    idempotency_key = str(uuid.uuid5(uuid.NAMESPACE_URL, idempotency_source))
+
                     payload = {
-                        "idempotencyKey": str(uuid.uuid4()),
+                        "idempotencyKey": idempotency_key,
                         "walletId": self._wallet_id,
                         "contractAddress": oracle_addr,
                         "abiFunctionSignature": "setPrice(uint256)",

--- a/backend/archimedes/chain/strategy_publisher.py
+++ b/backend/archimedes/chain/strategy_publisher.py
@@ -108,7 +108,7 @@ class StrategyPublisher:
             return None
 
         registry = self.loader.strategy_registry
-        nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+        nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
 
         try:
             tx = await registry.functions.registerStrategy(

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -98,7 +98,7 @@ class TracePublisher:
             return None
 
         registry = self.loader.trace_registry
-        nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+        nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
 
         try:
             tx = await registry.functions.publishTrace(vault_addr, trace_hash_bytes, metadata).build_transaction(
@@ -201,7 +201,7 @@ class TracePublisher:
 
         registry = self.loader.trace_registry
         try:
-            nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+            nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
             tx = await registry.functions.commit(
                 vault_addr, content_hash_bytes, claimed_execution_time, trade_id, trade_intent_summary
             ).build_transaction(
@@ -306,7 +306,7 @@ class TracePublisher:
 
         registry = self.loader.trace_registry
         try:
-            nonce = await chain_client.w3.eth.get_transaction_count(account.address)
+            nonce = await chain_client.w3.eth.get_transaction_count(account.address, "pending")
             tx = await registry.functions.reveal(trace_id, storage_pointer, full_content).build_transaction(
                 {
                     "from": account.address,

--- a/backend/archimedes/scripts/bootstrap_vaults.py
+++ b/backend/archimedes/scripts/bootstrap_vaults.py
@@ -181,6 +181,14 @@ async def mint_synthetic_tokens() -> dict[str, float]:
     minted: dict[str, float] = {}
 
     for symbol, usdc_amount in MINT_BUDGET.items():
+        if symbol not in synth_addresses:
+            # sTSLA/sNVDA (and any other MINT_BUDGET entry not in the live
+            # SSOT) are compliance-held single-stock synths removed from
+            # chain_client.settings.synth_addresses — see client.py. Skip
+            # rather than crash on the first KeyError, so the remaining
+            # valid symbols still get minted.
+            print(f"  ⏭️  {symbol}: not in current synth_addresses SSOT — skipping")
+            continue
         vault_addr = synth_vault_addresses[symbol]
         token_addr = synth_addresses[symbol]
         usdc_int = int(usdc_amount * 1e6)  # USDC has 6 decimals

--- a/backend/archimedes/scripts/deploy_contracts.py
+++ b/backend/archimedes/scripts/deploy_contracts.py
@@ -97,7 +97,9 @@ async def deploy_contract(bytecode_hex: str, gas: int = 5_000_000) -> str:
         "value": "0x0",
         "data": f"0x{bytecode_hex}" if not bytecode_hex.startswith("0x") else bytecode_hex,
         "chainId": hex(5042002),
-        "to": "0x",  # contract creation
+        # No "to" field: contract creation is signaled by omitting `to`
+        # entirely (a literal "0x" is not a valid 20-byte address and would
+        # be rejected once this dict is JSON-encoded and sent to Circle).
     }
 
     print(f"  ⏳ Submitting deploy tx (nonce={nonce}, gas={gas})...")

--- a/backend/tests/chain/test_circle_signer.py
+++ b/backend/tests/chain/test_circle_signer.py
@@ -13,6 +13,7 @@ where a real key would otherwise be needed. No network, no Circle, no Arc RPC.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -235,6 +236,39 @@ class TestSignAndBroadcast:
             pytest.raises(RuntimeError, match="sign failed"),
         ):
             await configured.sign_and_broadcast({"to": "0xabc", "value": 0})
+
+    async def test_dict_transaction_is_json_encoded_not_python_repr(self, configured):
+        """A dict tx_object must be sent as valid JSON (Circle's documented
+        TransactionObject format — see developer-controlled-wallets.yaml),
+        not Python's str() repr. A repr like "{'nonce': '0x5', ...}" (single
+        quotes) is not valid JSON and is not a format Circle's sign endpoint
+        accepts."""
+        session = _mock_session()
+        sign_resp = _resp(201, {"data": {"signedTransaction": "0xabcd", "txHash": ""}})
+        session.post = MagicMock(return_value=session._cm(sign_resp))
+
+        mock_chain = MagicMock()
+        sent_hash = MagicMock()
+        sent_hash.hex = MagicMock(return_value="0xBROADCAST")
+        mock_chain.w3.eth.send_raw_transaction = AsyncMock(return_value=sent_hash)
+
+        tx = {"nonce": "0x5", "to": "0xabc", "value": "0x0", "gas": "0x5208", "chainId": "0x4cef52"}
+
+        with (
+            patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)),
+            patch("archimedes.chain.client.chain_client", mock_chain),
+        ):
+            await configured.sign_and_broadcast(tx)
+
+        sent_payload = session.post.call_args.kwargs["json"]
+        sent_transaction = sent_payload["transaction"]
+
+        # Must be valid JSON (json.loads must not raise) round-tripping to
+        # the original dict — the old str(tx_object) repr fails this.
+        assert json.loads(sent_transaction) == tx
+        # Guard against a Python-repr regression directly: repr() uses
+        # single-quoted keys/values, which is never valid JSON syntax.
+        assert "'" not in sent_transaction
 
 
 # ── _encrypt_entity_secret ────────────────────────────────────


### PR DESCRIPTION
Closes #1134

## Summary
- `circle_signer.py` `sign_and_broadcast`: serialized a dict transaction via Python's `str()` (dict repr) instead of a valid encoding. Reachable via `scripts/deploy_contracts.py`'s `deploy_contract()`, so every contract deployment through the Circle signer path hit this. Switched to `json.dumps()`; also dropped `deploy_contract()`'s `"to": "0x"` key for contract creation (not a valid 20-byte address once JSON-encoded).
- `executor.py` `create_vault()` + 4 call sites across `trace_publisher.py` (publish/commit/reveal) and `strategy_publisher.py` (anchor) fetched the raw-key nonce without `"pending"`, inconsistent with every other raw-key call site in `executor.py`. For the commit/reveal pair specifically, this risked silently dropping one half of the causal-ordering guarantee the commit-reveal scheme provides.
- `bootstrap_vaults.py` `mint_synthetic_tokens()`: `MINT_BUDGET`'s first two keys (`sTSLA`, `sNVDA`) are compliance-held single-stocks removed from the live synth-address SSOT, so the loop crashed with an uncaught `KeyError` on its first iteration. Now skips symbols absent from the current SSOT.
- `circle_signer.py` `execute_contract()` and `oracle_updater.py` generated a fresh random `idempotencyKey` per call, defeating Circle's retry-dedup safety net. Switched to a deterministic key derived from the call's stable identifying fields.

Added a regression test asserting the outgoing `"transaction"` field is valid JSON, not a repr string.

Found in an internal bug-hunt pass, 2026-07-14.

## Test plan
- [x] `pytest backend/tests/chain/ backend/tests/scripts/` → all pass (excluding a pre-existing, unrelated local sqlite-schema failure in `test_vault_rigor_gate.py` confirmed present on a clean `main` checkout too)
- [x] `ruff format --check` + `ruff check --select E9,F63,F7,F40` clean
