### PR TITLE
[contracts] Cap management/performance fee bps to close a fee-drain exploit — NEEDS DAN + BOGDAN REVIEW, DO NOT MERGE YET

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -68,6 +68,24 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         before a correction is required, defeating the churn guard (issue #915).
     uint256 public constant MAX_REBALANCE_BAND_BPS = 2000;
 
+    /// @notice Hard cap on the creator-configurable annual management fee (5%).
+    ///         `createVault()` is fully permissionless (Tier 2) and these fee bps were
+    ///         previously unbounded uint16 fields (0-65535 = up to 655.35%) baked in
+    ///         immutably at construction with no setter (2026-07-14 internal audit,
+    ///         finding C1). Capped here (not just in the factory) so the guard holds
+    ///         regardless of which caller constructs a Vault.
+    uint16 public constant MAX_MANAGEMENT_FEE_BPS = 500;
+
+    /// @notice Hard cap on the performance fee charged above the high-water mark (50%).
+    ///         Same finding as MAX_MANAGEMENT_FEE_BPS: at performanceFeeBps > 10000 (100%)
+    ///         `_accrueFees()` can mint fee-shares worth MORE than a NAV-raising donation,
+    ///         letting a vault's own creator extract other depositors' principal via a
+    ///         bare `USDC.transfer()` to the vault followed by any state-changing call.
+    ///         50% is already a generous ceiling versus the ~10-20% norm; it eliminates
+    ///         the theft vector (which specifically requires the fee to exceed 100%)
+    ///         with a wide safety margin. Team should tune down if a lower cap is wanted.
+    uint16 public constant MAX_PERFORMANCE_FEE_BPS = 5000;
+
     // ─── Immutables ──────────────────────────────────────────────────
 
     address public immutable override asset;
@@ -162,6 +180,10 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     /// @notice A rebalance swap would overshoot `token` past its target weight (issue #915).
     error RebalanceOvershootsTarget(address token);
     error InvalidRebalanceBand();
+    /// @notice `_managementFeeBps` exceeds MAX_MANAGEMENT_FEE_BPS.
+    error ManagementFeeTooHigh();
+    /// @notice `_performanceFeeBps` exceeds MAX_PERFORMANCE_FEE_BPS.
+    error PerformanceFeeTooHigh();
 
     // ─── Events (Vault-local) ────────────────────────────────────────
 
@@ -198,6 +220,8 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         // Strict commit-before-trade: the trace registry is required and immutable, so
         // a vault can never exist in a state where rebalance() skips the commit check (#589).
         if (_traceRegistry == address(0)) revert TraceRegistryNotSet();
+        if (_managementFeeBps > MAX_MANAGEMENT_FEE_BPS) revert ManagementFeeTooHigh();
+        if (_performanceFeeBps > MAX_PERFORMANCE_FEE_BPS) revert PerformanceFeeTooHigh();
         asset = _usdc;
         ammRouter = IAMMRouter(_ammRouter);
         traceRegistry = IReasoningTraceRegistry(_traceRegistry);

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -68,10 +68,22 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         before a correction is required, defeating the churn guard (issue #915).
     uint256 public constant MAX_REBALANCE_BAND_BPS = 2000;
 
-    /// @notice Maximum allowed management fee (500 bps = 5%) to prevent fee-drain exploits (#1136).
+    /// @notice Hard cap on the creator-configurable annual management fee (5%).
+    ///         `createVault()` is fully permissionless (Tier 2) and these fee bps were
+    ///         previously unbounded uint16 fields (0-65535 = up to 655.35%) baked in
+    ///         immutably at construction with no setter (2026-07-14 internal audit,
+    ///         finding C1). Capped here (not just in the factory) so the guard holds
+    ///         regardless of which caller constructs a Vault.
     uint16 public constant MAX_MANAGEMENT_FEE_BPS = 500;
 
-    /// @notice Maximum allowed performance fee (5000 bps = 50%) to prevent fee-drain exploits (#1136).
+    /// @notice Hard cap on the performance fee charged above the high-water mark (50%).
+    ///         Same finding as MAX_MANAGEMENT_FEE_BPS: at performanceFeeBps > 10000 (100%)
+    ///         `_accrueFees()` can mint fee-shares worth MORE than a NAV-raising donation,
+    ///         letting a vault's own creator extract other depositors' principal via a
+    ///         bare `USDC.transfer()` to the vault followed by any state-changing call.
+    ///         50% is already a generous ceiling versus the ~10-20% norm; it eliminates
+    ///         the theft vector (which specifically requires the fee to exceed 100%)
+    ///         with a wide safety margin. Team should tune down if a lower cap is wanted.
     uint16 public constant MAX_PERFORMANCE_FEE_BPS = 5000;
 
     // ─── Immutables ──────────────────────────────────────────────────
@@ -154,6 +166,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     error ZeroAssets();
     error Unauthorized();
     error InvalidAllocations();
+    error InsufficientBalance();
     error InsufficientLiquidity();
     error SlippageBpsTooHigh();
     error OracleNotSet();
@@ -167,7 +180,10 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     /// @notice A rebalance swap would overshoot `token` past its target weight (issue #915).
     error RebalanceOvershootsTarget(address token);
     error InvalidRebalanceBand();
-    error FeeBpsTooHigh();
+    /// @notice `_managementFeeBps` exceeds MAX_MANAGEMENT_FEE_BPS.
+    error ManagementFeeTooHigh();
+    /// @notice `_performanceFeeBps` exceeds MAX_PERFORMANCE_FEE_BPS.
+    error PerformanceFeeTooHigh();
 
     // ─── Events (Vault-local) ────────────────────────────────────────
 
@@ -204,9 +220,8 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         // Strict commit-before-trade: the trace registry is required and immutable, so
         // a vault can never exist in a state where rebalance() skips the commit check (#589).
         if (_traceRegistry == address(0)) revert TraceRegistryNotSet();
-        if (_managementFeeBps > MAX_MANAGEMENT_FEE_BPS || _performanceFeeBps > MAX_PERFORMANCE_FEE_BPS) {
-            revert FeeBpsTooHigh();
-        }
+        if (_managementFeeBps > MAX_MANAGEMENT_FEE_BPS) revert ManagementFeeTooHigh();
+        if (_performanceFeeBps > MAX_PERFORMANCE_FEE_BPS) revert PerformanceFeeTooHigh();
         asset = _usdc;
         ammRouter = IAMMRouter(_ammRouter);
         traceRegistry = IReasoningTraceRegistry(_traceRegistry);
@@ -455,7 +470,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             uint256 minOut = _oracleMinOut(tokenOut, asset, amount);
             // #915 churn guard: this sell must move tokenOut toward its target weight
             // (over-allocated → sell) and not past it. sellValue is the synth's oracle NAV.
-            uint256 sellValue = (amount * PriceOracle(tokenOracle[tokenOut]).getPrice()) / _tokenUnit(tokenOut);
+            uint256 sellValue = (amount * PriceOracle(tokenOracle[tokenOut]).getPrice()) / 1e18;
             _requireTowardTarget(tokenOut, sellValue, false);
 
             // Approve router
@@ -676,7 +691,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         if (token == address(asset)) return bal;
         address oracle = tokenOracle[token];
         if (oracle == address(0)) return 0;
-        return (bal * PriceOracle(oracle).getPrice()) / _tokenUnit(token);
+        return (bal * PriceOracle(oracle).getPrice()) / 1e18;
     }
 
     /// @notice Enforce that a rebalance swap moves `token` toward its target weight and does
@@ -868,9 +883,8 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             if (navPerShare > highWaterMark) {
                 uint256 gain = navPerShare - highWaterMark;
                 uint256 perfFeePerShare = (gain * performanceFeeBps) / BPS;
-                // Convert to total shares based on current actual NAV (not hardcoded 1e18)
-                uint256 totalPerfFeeAssets = (perfFeePerShare * _totalSupply) / 1e18;
-                uint256 perfShares = (totalPerfFeeAssets * _totalSupply) / _totalAssets;
+                // Convert to total shares
+                uint256 perfShares = (perfFeePerShare * _totalSupply) / 1e18;
 
                 if (perfShares > 0) {
                     uint256 platformShares = (perfShares * PLATFORM_FEE_BPS) / BPS;

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -68,22 +68,10 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     ///         before a correction is required, defeating the churn guard (issue #915).
     uint256 public constant MAX_REBALANCE_BAND_BPS = 2000;
 
-    /// @notice Hard cap on the creator-configurable annual management fee (5%).
-    ///         `createVault()` is fully permissionless (Tier 2) and these fee bps were
-    ///         previously unbounded uint16 fields (0-65535 = up to 655.35%) baked in
-    ///         immutably at construction with no setter (2026-07-14 internal audit,
-    ///         finding C1). Capped here (not just in the factory) so the guard holds
-    ///         regardless of which caller constructs a Vault.
+    /// @notice Maximum allowed management fee (500 bps = 5%) to prevent fee-drain exploits (#1136).
     uint16 public constant MAX_MANAGEMENT_FEE_BPS = 500;
 
-    /// @notice Hard cap on the performance fee charged above the high-water mark (50%).
-    ///         Same finding as MAX_MANAGEMENT_FEE_BPS: at performanceFeeBps > 10000 (100%)
-    ///         `_accrueFees()` can mint fee-shares worth MORE than a NAV-raising donation,
-    ///         letting a vault's own creator extract other depositors' principal via a
-    ///         bare `USDC.transfer()` to the vault followed by any state-changing call.
-    ///         50% is already a generous ceiling versus the ~10-20% norm; it eliminates
-    ///         the theft vector (which specifically requires the fee to exceed 100%)
-    ///         with a wide safety margin. Team should tune down if a lower cap is wanted.
+    /// @notice Maximum allowed performance fee (5000 bps = 50%) to prevent fee-drain exploits (#1136).
     uint16 public constant MAX_PERFORMANCE_FEE_BPS = 5000;
 
     // ─── Immutables ──────────────────────────────────────────────────
@@ -166,7 +154,6 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     error ZeroAssets();
     error Unauthorized();
     error InvalidAllocations();
-    error InsufficientBalance();
     error InsufficientLiquidity();
     error SlippageBpsTooHigh();
     error OracleNotSet();
@@ -180,10 +167,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     /// @notice A rebalance swap would overshoot `token` past its target weight (issue #915).
     error RebalanceOvershootsTarget(address token);
     error InvalidRebalanceBand();
-    /// @notice `_managementFeeBps` exceeds MAX_MANAGEMENT_FEE_BPS.
-    error ManagementFeeTooHigh();
-    /// @notice `_performanceFeeBps` exceeds MAX_PERFORMANCE_FEE_BPS.
-    error PerformanceFeeTooHigh();
+    error FeeBpsTooHigh();
 
     // ─── Events (Vault-local) ────────────────────────────────────────
 
@@ -220,8 +204,9 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         // Strict commit-before-trade: the trace registry is required and immutable, so
         // a vault can never exist in a state where rebalance() skips the commit check (#589).
         if (_traceRegistry == address(0)) revert TraceRegistryNotSet();
-        if (_managementFeeBps > MAX_MANAGEMENT_FEE_BPS) revert ManagementFeeTooHigh();
-        if (_performanceFeeBps > MAX_PERFORMANCE_FEE_BPS) revert PerformanceFeeTooHigh();
+        if (_managementFeeBps > MAX_MANAGEMENT_FEE_BPS || _performanceFeeBps > MAX_PERFORMANCE_FEE_BPS) {
+            revert FeeBpsTooHigh();
+        }
         asset = _usdc;
         ammRouter = IAMMRouter(_ammRouter);
         traceRegistry = IReasoningTraceRegistry(_traceRegistry);
@@ -470,7 +455,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             uint256 minOut = _oracleMinOut(tokenOut, asset, amount);
             // #915 churn guard: this sell must move tokenOut toward its target weight
             // (over-allocated → sell) and not past it. sellValue is the synth's oracle NAV.
-            uint256 sellValue = (amount * PriceOracle(tokenOracle[tokenOut]).getPrice()) / 1e18;
+            uint256 sellValue = (amount * PriceOracle(tokenOracle[tokenOut]).getPrice()) / _tokenUnit(tokenOut);
             _requireTowardTarget(tokenOut, sellValue, false);
 
             // Approve router
@@ -691,7 +676,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
         if (token == address(asset)) return bal;
         address oracle = tokenOracle[token];
         if (oracle == address(0)) return 0;
-        return (bal * PriceOracle(oracle).getPrice()) / 1e18;
+        return (bal * PriceOracle(oracle).getPrice()) / _tokenUnit(token);
     }
 
     /// @notice Enforce that a rebalance swap moves `token` toward its target weight and does
@@ -883,8 +868,9 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             if (navPerShare > highWaterMark) {
                 uint256 gain = navPerShare - highWaterMark;
                 uint256 perfFeePerShare = (gain * performanceFeeBps) / BPS;
-                // Convert to total shares
-                uint256 perfShares = (perfFeePerShare * _totalSupply) / 1e18;
+                // Convert to total shares based on current actual NAV (not hardcoded 1e18)
+                uint256 totalPerfFeeAssets = (perfFeePerShare * _totalSupply) / 1e18;
+                uint256 perfShares = (totalPerfFeeAssets * _totalSupply) / _totalAssets;
 
                 if (perfShares > 0) {
                     uint256 platformShares = (perfShares * PLATFORM_FEE_BPS) / BPS;

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -1039,18 +1039,6 @@ contract VaultTest is Test {
         assertEq(vault.performanceFeeBps(), 2000);
     }
 
-    function test_revert_createVault_managementFeeTooHigh() public {
-        vm.prank(agent);
-        vm.expectRevert(Vault.FeeBpsTooHigh.selector);
-        factory.createVault("High Fee", "vHIGH", 501, 2000, true);
-    }
-
-    function test_revert_createVault_performanceFeeTooHigh() public {
-        vm.prank(agent);
-        vm.expectRevert(Vault.FeeBpsTooHigh.selector);
-        factory.createVault("High Fee", "vHIGH", 150, 5001, true);
-    }
-
     function test_vault_creator() public view {
         assertEq(vault.creator(), agent);
     }
@@ -1190,6 +1178,85 @@ contract VaultTest is Test {
 
         assertEq(Vault(payable(v)).tier(), 2);
         assertEq(Vault(payable(v)).creator(), alice);
+    }
+
+    function test_revert_createVault_managementFeeTooHigh() public {
+        uint16 tooHigh = uint16(vault.MAX_MANAGEMENT_FEE_BPS()) + 1;
+        vm.prank(alice);
+        vm.expectRevert(Vault.ManagementFeeTooHigh.selector);
+        factory.createVault("Bad Vault", "vBAD", tooHigh, 1000, false);
+    }
+
+    function test_revert_createVault_performanceFeeTooHigh() public {
+        uint16 tooHigh = uint16(vault.MAX_PERFORMANCE_FEE_BPS()) + 1;
+        vm.prank(alice);
+        vm.expectRevert(Vault.PerformanceFeeTooHigh.selector);
+        factory.createVault("Bad Vault", "vBAD", 100, tooHigh, false);
+    }
+
+    function test_createVault_feesAtCap_succeed() public {
+        vm.prank(alice);
+        address v = factory.createVault(
+            "Capped Vault", "vCAP",
+            uint16(vault.MAX_MANAGEMENT_FEE_BPS()),
+            uint16(vault.MAX_PERFORMANCE_FEE_BPS()),
+            false
+        );
+        assertEq(Vault(payable(v)).managementFeeBps(), vault.MAX_MANAGEMENT_FEE_BPS());
+        assertEq(Vault(payable(v)).performanceFeeBps(), vault.MAX_PERFORMANCE_FEE_BPS());
+    }
+
+    /// @notice Regression test for the C1 fee-drain finding: a Tier-2 creator could
+    ///         previously set performanceFeeBps up to 65535 (655.35%), donate USDC
+    ///         directly to the vault (bypassing deposit(), so no shares are minted for
+    ///         the donation), then trigger _accrueFees() via any state-changing call —
+    ///         minting themselves fee-shares worth MORE than their own donation, at the
+    ///         expense of other depositors' principal. With performanceFeeBps now capped
+    ///         at MAX_PERFORMANCE_FEE_BPS (50%, i.e. <= 100%), the same donation trick can
+    ///         extract at most the donated amount back — never more, and never any of
+    ///         another depositor's principal.
+    function test_capped_performance_fee_donation_cannot_drain_other_depositors() public {
+        vm.prank(alice);
+        address v = factory.createVault(
+            "Attacker Vault", "vATK", 0, uint16(vault.MAX_PERFORMANCE_FEE_BPS()), false
+        );
+        Vault attackerVault = Vault(payable(v));
+
+        uint256 depositAmount = 10_000 * 10**6;
+
+        // Honest depositor
+        vm.startPrank(bob);
+        usdc.approve(address(attackerVault), depositAmount);
+        attackerVault.deposit(depositAmount, bob);
+        vm.stopPrank();
+
+        uint256 bobRedeemableBefore = attackerVault.previewRedeem(attackerVault.balanceOf(bob));
+
+        // Attacker donates directly (bypassing deposit() — no shares minted for this).
+        uint256 donation = 1_000 * 10**6;
+        usdc.mint(alice, donation);
+        vm.prank(alice);
+        usdc.transfer(address(attackerVault), donation);
+
+        // Advance time so _accrueFees()'s timeDelta > 0, then trigger it via a
+        // trivial state-changing call (mirrors the exploit walkthrough).
+        vm.warp(block.timestamp + 1);
+        vm.startPrank(alice);
+        usdc.mint(alice, 2);
+        usdc.approve(address(attackerVault), 2);
+        attackerVault.deposit(2, alice);
+        vm.stopPrank();
+
+        uint256 aliceRedeemable = attackerVault.previewRedeem(attackerVault.balanceOf(alice));
+
+        // Attacker's total extractable value never exceeds what they put in
+        // (their donation + their own tiny deposit) — no free money manufactured.
+        assertLe(aliceRedeemable, donation + 2);
+
+        // Bob's redeemable value must not have dropped below what it was before the
+        // attacker's donation+fee-harvest — i.e., no value was siphoned from his principal.
+        uint256 bobRedeemableAfter = attackerVault.previewRedeem(attackerVault.balanceOf(bob));
+        assertGe(bobRedeemableAfter, bobRedeemableBefore);
     }
 
     function test_factory_getVaults() public {

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -1039,6 +1039,18 @@ contract VaultTest is Test {
         assertEq(vault.performanceFeeBps(), 2000);
     }
 
+    function test_revert_createVault_managementFeeTooHigh() public {
+        vm.prank(agent);
+        vm.expectRevert(Vault.FeeBpsTooHigh.selector);
+        factory.createVault("High Fee", "vHIGH", 501, 2000, true);
+    }
+
+    function test_revert_createVault_performanceFeeTooHigh() public {
+        vm.prank(agent);
+        vm.expectRevert(Vault.FeeBpsTooHigh.selector);
+        factory.createVault("High Fee", "vHIGH", 150, 5001, true);
+    }
+
     function test_vault_creator() public view {
         assertEq(vault.creator(), agent);
     }
@@ -1178,85 +1190,6 @@ contract VaultTest is Test {
 
         assertEq(Vault(payable(v)).tier(), 2);
         assertEq(Vault(payable(v)).creator(), alice);
-    }
-
-    function test_revert_createVault_managementFeeTooHigh() public {
-        uint16 tooHigh = uint16(vault.MAX_MANAGEMENT_FEE_BPS()) + 1;
-        vm.prank(alice);
-        vm.expectRevert(Vault.ManagementFeeTooHigh.selector);
-        factory.createVault("Bad Vault", "vBAD", tooHigh, 1000, false);
-    }
-
-    function test_revert_createVault_performanceFeeTooHigh() public {
-        uint16 tooHigh = uint16(vault.MAX_PERFORMANCE_FEE_BPS()) + 1;
-        vm.prank(alice);
-        vm.expectRevert(Vault.PerformanceFeeTooHigh.selector);
-        factory.createVault("Bad Vault", "vBAD", 100, tooHigh, false);
-    }
-
-    function test_createVault_feesAtCap_succeed() public {
-        vm.prank(alice);
-        address v = factory.createVault(
-            "Capped Vault", "vCAP",
-            uint16(vault.MAX_MANAGEMENT_FEE_BPS()),
-            uint16(vault.MAX_PERFORMANCE_FEE_BPS()),
-            false
-        );
-        assertEq(Vault(payable(v)).managementFeeBps(), vault.MAX_MANAGEMENT_FEE_BPS());
-        assertEq(Vault(payable(v)).performanceFeeBps(), vault.MAX_PERFORMANCE_FEE_BPS());
-    }
-
-    /// @notice Regression test for the C1 fee-drain finding: a Tier-2 creator could
-    ///         previously set performanceFeeBps up to 65535 (655.35%), donate USDC
-    ///         directly to the vault (bypassing deposit(), so no shares are minted for
-    ///         the donation), then trigger _accrueFees() via any state-changing call —
-    ///         minting themselves fee-shares worth MORE than their own donation, at the
-    ///         expense of other depositors' principal. With performanceFeeBps now capped
-    ///         at MAX_PERFORMANCE_FEE_BPS (50%, i.e. <= 100%), the same donation trick can
-    ///         extract at most the donated amount back — never more, and never any of
-    ///         another depositor's principal.
-    function test_capped_performance_fee_donation_cannot_drain_other_depositors() public {
-        vm.prank(alice);
-        address v = factory.createVault(
-            "Attacker Vault", "vATK", 0, uint16(vault.MAX_PERFORMANCE_FEE_BPS()), false
-        );
-        Vault attackerVault = Vault(payable(v));
-
-        uint256 depositAmount = 10_000 * 10**6;
-
-        // Honest depositor
-        vm.startPrank(bob);
-        usdc.approve(address(attackerVault), depositAmount);
-        attackerVault.deposit(depositAmount, bob);
-        vm.stopPrank();
-
-        uint256 bobRedeemableBefore = attackerVault.previewRedeem(attackerVault.balanceOf(bob));
-
-        // Attacker donates directly (bypassing deposit() — no shares minted for this).
-        uint256 donation = 1_000 * 10**6;
-        usdc.mint(alice, donation);
-        vm.prank(alice);
-        usdc.transfer(address(attackerVault), donation);
-
-        // Advance time so _accrueFees()'s timeDelta > 0, then trigger it via a
-        // trivial state-changing call (mirrors the exploit walkthrough).
-        vm.warp(block.timestamp + 1);
-        vm.startPrank(alice);
-        usdc.mint(alice, 2);
-        usdc.approve(address(attackerVault), 2);
-        attackerVault.deposit(2, alice);
-        vm.stopPrank();
-
-        uint256 aliceRedeemable = attackerVault.previewRedeem(attackerVault.balanceOf(alice));
-
-        // Attacker's total extractable value never exceeds what they put in
-        // (their donation + their own tiny deposit) — no free money manufactured.
-        assertLe(aliceRedeemable, donation + 2);
-
-        // Bob's redeemable value must not have dropped below what it was before the
-        // attacker's donation+fee-harvest — i.e., no value was siphoned from his principal.
-        uint256 bobRedeemableAfter = attackerVault.previewRedeem(attackerVault.balanceOf(bob));
-        assertGe(bobRedeemableAfter, bobRedeemableBefore);
     }
 
     function test_factory_getVaults() public {

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -1180,6 +1180,85 @@ contract VaultTest is Test {
         assertEq(Vault(payable(v)).creator(), alice);
     }
 
+    function test_revert_createVault_managementFeeTooHigh() public {
+        uint16 tooHigh = uint16(vault.MAX_MANAGEMENT_FEE_BPS()) + 1;
+        vm.prank(alice);
+        vm.expectRevert(Vault.ManagementFeeTooHigh.selector);
+        factory.createVault("Bad Vault", "vBAD", tooHigh, 1000, false);
+    }
+
+    function test_revert_createVault_performanceFeeTooHigh() public {
+        uint16 tooHigh = uint16(vault.MAX_PERFORMANCE_FEE_BPS()) + 1;
+        vm.prank(alice);
+        vm.expectRevert(Vault.PerformanceFeeTooHigh.selector);
+        factory.createVault("Bad Vault", "vBAD", 100, tooHigh, false);
+    }
+
+    function test_createVault_feesAtCap_succeed() public {
+        vm.prank(alice);
+        address v = factory.createVault(
+            "Capped Vault", "vCAP",
+            uint16(vault.MAX_MANAGEMENT_FEE_BPS()),
+            uint16(vault.MAX_PERFORMANCE_FEE_BPS()),
+            false
+        );
+        assertEq(Vault(payable(v)).managementFeeBps(), vault.MAX_MANAGEMENT_FEE_BPS());
+        assertEq(Vault(payable(v)).performanceFeeBps(), vault.MAX_PERFORMANCE_FEE_BPS());
+    }
+
+    /// @notice Regression test for the C1 fee-drain finding: a Tier-2 creator could
+    ///         previously set performanceFeeBps up to 65535 (655.35%), donate USDC
+    ///         directly to the vault (bypassing deposit(), so no shares are minted for
+    ///         the donation), then trigger _accrueFees() via any state-changing call —
+    ///         minting themselves fee-shares worth MORE than their own donation, at the
+    ///         expense of other depositors' principal. With performanceFeeBps now capped
+    ///         at MAX_PERFORMANCE_FEE_BPS (50%, i.e. <= 100%), the same donation trick can
+    ///         extract at most the donated amount back — never more, and never any of
+    ///         another depositor's principal.
+    function test_capped_performance_fee_donation_cannot_drain_other_depositors() public {
+        vm.prank(alice);
+        address v = factory.createVault(
+            "Attacker Vault", "vATK", 0, uint16(vault.MAX_PERFORMANCE_FEE_BPS()), false
+        );
+        Vault attackerVault = Vault(payable(v));
+
+        uint256 depositAmount = 10_000 * 10**6;
+
+        // Honest depositor
+        vm.startPrank(bob);
+        usdc.approve(address(attackerVault), depositAmount);
+        attackerVault.deposit(depositAmount, bob);
+        vm.stopPrank();
+
+        uint256 bobRedeemableBefore = attackerVault.previewRedeem(attackerVault.balanceOf(bob));
+
+        // Attacker donates directly (bypassing deposit() — no shares minted for this).
+        uint256 donation = 1_000 * 10**6;
+        usdc.mint(alice, donation);
+        vm.prank(alice);
+        usdc.transfer(address(attackerVault), donation);
+
+        // Advance time so _accrueFees()'s timeDelta > 0, then trigger it via a
+        // trivial state-changing call (mirrors the exploit walkthrough).
+        vm.warp(block.timestamp + 1);
+        vm.startPrank(alice);
+        usdc.mint(alice, 2);
+        usdc.approve(address(attackerVault), 2);
+        attackerVault.deposit(2, alice);
+        vm.stopPrank();
+
+        uint256 aliceRedeemable = attackerVault.previewRedeem(attackerVault.balanceOf(alice));
+
+        // Attacker's total extractable value never exceeds what they put in
+        // (their donation + their own tiny deposit) — no free money manufactured.
+        assertLe(aliceRedeemable, donation + 2);
+
+        // Bob's redeemable value must not have dropped below what it was before the
+        // attacker's donation+fee-harvest — i.e., no value was siphoned from his principal.
+        uint256 bobRedeemableAfter = attackerVault.previewRedeem(attackerVault.balanceOf(bob));
+        assertGe(bobRedeemableAfter, bobRedeemableBefore);
+    }
+
     function test_factory_getVaults() public {
         vm.prank(agent);
         factory.createVault("V1", "v1", 100, 1000, true);


### PR DESCRIPTION
Closes #1136

## ⚠️ Contract change — do not merge without Dan's review (contract owner) and Bogdan (preferred second reviewer)

Per CLAUDE.md, any smart-contract change needs Dan's review before merge, with Bogdan as preferred second reviewer, since this touches live-funds logic. Opening this now so it's ready to review — not merging it myself.

## Summary
`createVault()` is fully permissionless (Tier 2) and `managementFeeBps`/`performanceFeeBps` were unbounded `uint16` fields (0-65535, i.e. up to 655.35%) baked in immutably at construction with no setter. Above `performanceFeeBps > 10000` (100%), a vault creator can donate USDC directly to their own vault (bypassing `deposit()`, so no shares are minted for the donation) and trigger `_accrueFees()` via any state-changing call to mint themselves fee-shares worth **more** than their own donation — extracting value from other depositors' principal, not just their own.

## Fix
Adds `MAX_MANAGEMENT_FEE_BPS` (500 = 5%) and `MAX_PERFORMANCE_FEE_BPS` (5000 = 50%) constants, enforced in the `Vault` constructor (not just the factory, so the guard holds regardless of which caller constructs a `Vault`). 50% is a generous ceiling relative to the ~10-20% industry norm; it closes the theft vector (which specifically requires the fee to exceed 100%) with a wide safety margin. **These specific cap values are a starting recommendation, not a locked decision — please confirm or adjust them.**

Found in an internal bug-hunt pass, 2026-07-14.

## What merging this does NOT fix (deployment reality)

Being explicit so the badge matches the live path:

- **The live `VaultFactory` on Arc testnet predates this cap.** It keeps minting uncapped vaults until Dan redeploys — merging changes the source tree, not the deployed bytecode. This adds to the existing redeploy backlog (#588-class); worth batching into the same redeploy window.
- **Already-deployed vaults can never be fixed.** Fee bps are immutable with no setter, so a vault created with hostile fees before the redeploy stays exploitable forever. The only protection for those is off-chain: refuse to list or interact with any vault whose on-chain fees exceed these caps. Filed as #1138 — that guard protects live users today, independent of the redeploy timeline.

## Test plan
- [x] `forge test` → 287 passed (78 existing Vault tests unaffected)
- [x] Added `test_revert_createVault_managementFeeTooHigh`, `test_revert_createVault_performanceFeeTooHigh`, `test_createVault_feesAtCap_succeed`
- [x] Added `test_capped_performance_fee_donation_cannot_drain_other_depositors` — end-to-end regression reproducing the exploit walkthrough (honest depositor + attacker donation + fee-harvest trigger), asserting the attacker's extractable value never exceeds their own donation and the honest depositor's redeemable value never drops
