### PR TITLE
[backend] Refuse to list or interact with vaults whose fee bps exceed the #1129 caps

### DIFF
--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -15,7 +16,7 @@ from sqlalchemy.exc import IntegrityError
 
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
-from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
+from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 from archimedes.db import get_session
 from archimedes.marketplace.encoding import derive_pool_id, to_bytes32
 from archimedes.marketplace.service import MarketService, Subscriber
@@ -27,6 +28,11 @@ from archimedes.services.identity_events import emit_identity_event, register_co
 logger = logging.getLogger(__name__)
 
 marketplace_router = APIRouter(prefix="/api/marketplace", tags=["marketplace"])
+
+# 20-byte 0x-prefixed hex address. vault_address arrives via an untyped body
+# dict, so validate before any chain read — a malformed address must be a 400
+# (client error), not a 502 from the fee guard's fail-closed path.
+_EVM_ADDRESS_RE = re.compile(r"^0x[a-fA-F0-9]{40}$")
 
 
 def _get_market(request: Request) -> MarketService:
@@ -164,6 +170,11 @@ async def publish_strategy(
             owner_wallet=wallet,
         )
     else:
+        if not _EVM_ADDRESS_RE.fullmatch(vault_address):
+            raise HTTPException(
+                status_code=400,
+                detail="vault_address must be a 0x-prefixed 20-byte hex address",
+            )
         # Fee-cap guard (issue #1138) — only the user-supplied path needs it:
         # a reused vault may have been minted by the pre-cap factory with
         # hostile immutable fees, while the create path above hardcodes 0/0.

--- a/backend/archimedes/api/marketplace_routes.py
+++ b/backend/archimedes/api/marketplace_routes.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError
 
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.limiter import limiter
+from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 from archimedes.db import get_session
 from archimedes.marketplace.encoding import derive_pool_id, to_bytes32
 from archimedes.marketplace.service import MarketService, Subscriber
@@ -33,6 +34,45 @@ def _get_market(request: Request) -> MarketService:
     if market is None:
         raise HTTPException(status_code=503, detail="Marketplace engine not available")
     return market
+
+
+async def _require_vault_fees_within_caps(market: MarketService, vault_address: str) -> None:
+    """Refuse any vault whose on-chain fees exceed the #1129 caps (issue #1138).
+
+    The live VaultFactory predates the constructor caps and fee bps are
+    immutable with no setter, so a vault created with hostile fees before the
+    factory redeploy stays hostile forever. The only protection for users is
+    off-chain: read the fees and refuse to interact.
+
+    Fail-CLOSED on read failure: this guard is fund-adjacent — waving through
+    a vault whose fees we couldn't verify exposes depositors to the C1
+    fee-drain, so an unreadable vault is refused with a 502. (Contrast with
+    the #713 spend cap, which fails open for availability: the worst case
+    there is a bounded overcharge, not principal loss.)
+    """
+    try:
+        mgmt_fee_bps, perf_fee_bps = await market.executor.get_vault_fee_bps(vault_address)
+    except Exception as exc:
+        logger.warning("Fee-cap guard: could not read fees for vault %s: %s", vault_address, exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Could not verify on-chain fees for vault {vault_address}; refusing (fail-closed)",
+        ) from exc
+    if mgmt_fee_bps > MAX_MANAGEMENT_FEE_BPS or perf_fee_bps > MAX_PERFORMANCE_FEE_BPS:
+        logger.warning(
+            "Fee-cap guard: refusing vault %s (managementFeeBps=%d, performanceFeeBps=%d)",
+            vault_address,
+            mgmt_fee_bps,
+            perf_fee_bps,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Vault {vault_address} fees exceed caps: "
+                f"managementFeeBps={mgmt_fee_bps} (cap {MAX_MANAGEMENT_FEE_BPS}), "
+                f"performanceFeeBps={perf_fee_bps} (cap {MAX_PERFORMANCE_FEE_BPS})"
+            ),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +163,11 @@ async def publish_strategy(
             agent_assisted=True,
             owner_wallet=wallet,
         )
+    else:
+        # Fee-cap guard (issue #1138) — only the user-supplied path needs it:
+        # a reused vault may have been minted by the pre-cap factory with
+        # hostile immutable fees, while the create path above hardcodes 0/0.
+        await _require_vault_fees_within_caps(market, vault_address)
 
     # 3a. Publish funding gate (D7) — vault MUST hold at least
     #     MARKETPLACE_MIN_VAULT_FUNDS_RAW idle USDC (raw 6-dec).
@@ -303,6 +348,12 @@ async def subscribe_strategy(
         )
     if pub_row is None:
         raise HTTPException(status_code=404, detail=f"No running publisher for strategy '{strategy_id}'")
+
+    # 1a. Fee-cap guard (issue #1138): the publisher's vault is where the
+    # subscription's economics live — a vault published before the guard
+    # existed (or minted by the pre-cap factory) may carry hostile immutable
+    # fees. Refuse before provisioning any wallet for a doomed subscribe.
+    await _require_vault_fees_within_caps(market, pub_row.vault_address)
 
     # 2. Reject if this wallet is already subscribed
     with get_session() as session:

--- a/backend/archimedes/api/vault_schemas.py
+++ b/backend/archimedes/api/vault_schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS
+from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS
 
 
 class VaultCreateRequest(BaseModel):

--- a/backend/archimedes/api/vault_schemas.py
+++ b/backend/archimedes/api/vault_schemas.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS
+
 
 class VaultCreateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=64)
     symbol: str = Field(..., min_length=1, max_length=16)
-    management_fee_bps: int = Field(0, ge=0, le=1000)
+    # Aligned with the Vault.sol constructor caps (PR #1129 / issue #1138) —
+    # the old le=1000 admitted requests the capped contract reverts. The
+    # performance cap stays at 3000 (30%): deliberately stricter than the
+    # on-chain hard ceiling of MAX_PERFORMANCE_FEE_BPS (5000), matching the
+    # ~10-20% industry norm with headroom.
+    management_fee_bps: int = Field(0, ge=0, le=MAX_MANAGEMENT_FEE_BPS)
     performance_fee_bps: int = Field(0, ge=0, le=3000)
     agent_assisted: bool = True
     # Off-chain metadata only — not passed to the contract.

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -403,7 +403,15 @@ async def get_vault_detail(address: str):
     """Get full vault detail including holdings, performance, traces."""
     from fastapi import HTTPException
 
-    detail = await vault_svc.get_vault_detail(address)
+    from archimedes.services.vault_service import VaultFeeGuardRefusal
+
+    try:
+        detail = await vault_svc.get_vault_detail(address)
+    except VaultFeeGuardRefusal as exc:
+        # Issue #1138: the vault exists but the fee guard refuses it — answer
+        # 400 (over-cap, reason names the values) or 502 (fees unverifiable,
+        # fail-closed) instead of conflating it with an unknown address.
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     if detail is None:
         raise HTTPException(status_code=404, detail="Vault not found")
     return detail

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -39,6 +39,7 @@ import uuid
 from datetime import UTC, datetime
 
 from archimedes.chain.client import chain_client
+from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 from archimedes.chain.executor import InsufficientLiquidityError, chain_executor, compute_trade_id
 from archimedes.chain.oracle_updater import OracleUpdater
 from archimedes.chain.provenance_publisher import pin_public_provenance
@@ -608,6 +609,64 @@ class StrategyRunner:
 
         return strategy_evaluator.evaluate_strategies(gen_strategies, synth_assets)
 
+    async def _vault_fee_cap_refusal(self, vault_address: str) -> str | None:
+        """Fail-closed fee-cap gate for the agent's OWN state-changing call.
+
+        Issue #1138 follow-up (flagged by Dan on PR #1139's review): the
+        marketplace guard in ``marketplace_routes.py``/``vault_service.py``
+        only covers the surfaces a human reaches (publish/subscribe/list/
+        detail) — it never touched this loop, so an over-cap vault stayed
+        fully tradeable by the agent, which is the actual state-changing
+        path that triggers ``_accrueFees()`` in ``Vault.sol`` (rebalance()).
+        Read once here, right before Phase 2 TRADE (not earlier in
+        ``_process_vault``, since a no-drift tick never reaches this point
+        anyway — no extra RPC cost on the common path).
+
+        Returns a SKIP reason string when the vault must be refused, else
+        None. Mirrors ``_lease_ok``'s fail-closed shape: unreadable fees
+        refuse the same as over-cap fees, never silently proceed.
+        """
+        try:
+            mgmt_fee_bps, perf_fee_bps = await chain_executor.get_vault_fee_bps(vault_address)
+        except Exception as exc:
+            return f"Could not verify on-chain fees for vault {vault_address[:10]}: {exc} — refusing (fail-closed)"
+        if mgmt_fee_bps > MAX_MANAGEMENT_FEE_BPS or perf_fee_bps > MAX_PERFORMANCE_FEE_BPS:
+            return (
+                f"Vault {vault_address[:10]} fees exceed caps: "
+                f"managementFeeBps={mgmt_fee_bps} (cap {MAX_MANAGEMENT_FEE_BPS}), "
+                f"performanceFeeBps={perf_fee_bps} (cap {MAX_PERFORMANCE_FEE_BPS})"
+            )
+        return None
+
+    async def _vault_fee_cap_refusal(self, vault_address: str) -> str | None:
+        """Fail-closed fee-cap gate for the agent's OWN state-changing call.
+
+        Issue #1138 follow-up (flagged by Dan on PR #1139's review): the
+        marketplace guard in ``marketplace_routes.py``/``vault_service.py``
+        only covers the surfaces a human reaches (publish/subscribe/list/
+        detail) — it never touched this loop, so an over-cap vault stayed
+        fully tradeable by the agent, which is the actual state-changing
+        path that triggers ``_accrueFees()`` in ``Vault.sol`` (rebalance()).
+        Read once here, right before Phase 2 TRADE (not earlier in
+        ``_process_vault``, since a no-drift tick never reaches this point
+        anyway — no extra RPC cost on the common path).
+
+        Returns a SKIP reason string when the vault must be refused, else
+        None. Mirrors ``_lease_ok``'s fail-closed shape: unreadable fees
+        refuse the same as over-cap fees, never silently proceed.
+        """
+        try:
+            mgmt_fee_bps, perf_fee_bps = await chain_executor.get_vault_fee_bps(vault_address)
+        except Exception as exc:
+            return f"Could not verify on-chain fees for vault {vault_address[:10]}: {exc} — refusing (fail-closed)"
+        if mgmt_fee_bps > MAX_MANAGEMENT_FEE_BPS or perf_fee_bps > MAX_PERFORMANCE_FEE_BPS:
+            return (
+                f"Vault {vault_address[:10]} fees exceed caps: "
+                f"managementFeeBps={mgmt_fee_bps} (cap {MAX_MANAGEMENT_FEE_BPS}), "
+                f"performanceFeeBps={perf_fee_bps} (cap {MAX_PERFORMANCE_FEE_BPS})"
+            )
+        return None
+
     async def _process_vault(
         self,
         vault_address: str,
@@ -977,6 +1036,60 @@ class StrategyRunner:
                 commit_block=commit_block,
             )
             return
+
+        # Fee-cap guard (issue #1138 follow-up): refuse to submit the trade if
+        # this vault's immutable on-chain fees exceed the #1129 caps, or if
+        # they can't be read. rebalance() is what triggers Vault.sol's
+        # _accrueFees() — gating it here closes the gap the marketplace-only
+        # guard left open (see _vault_fee_cap_refusal docstring). Skipped
+        # under DRY_RUN, matching the _lease_ok check right below: no real
+        # write happens either way.
+        if not DRY_RUN:
+            fee_skip_reason = await self._vault_fee_cap_refusal(vault_address)
+            if fee_skip_reason is not None:
+                logger.error("[tick %s] %s", tick_id, fee_skip_reason)
+                await self._publish_trace(
+                    vault_address,
+                    DecisionType.SKIP,
+                    "fee_cap_exceeded",
+                    portfolio,
+                    [],
+                    all_signals,
+                    market_regime,
+                    consensus,
+                    tick_id,
+                    fee_skip_reason,
+                    commit_tx=commit_tx,
+                    commit_block=commit_block,
+                )
+                return
+
+        # Fee-cap guard (issue #1138 follow-up): refuse to submit the trade if
+        # this vault's immutable on-chain fees exceed the #1129 caps, or if
+        # they can't be read. rebalance() is what triggers Vault.sol's
+        # _accrueFees() — gating it here closes the gap the marketplace-only
+        # guard left open (see _vault_fee_cap_refusal docstring). Skipped
+        # under DRY_RUN, matching the _lease_ok check right below: no real
+        # write happens either way.
+        if not DRY_RUN:
+            fee_skip_reason = await self._vault_fee_cap_refusal(vault_address)
+            if fee_skip_reason is not None:
+                logger.error("[tick %s] %s", tick_id, fee_skip_reason)
+                await self._publish_trace(
+                    vault_address,
+                    DecisionType.SKIP,
+                    "fee_cap_exceeded",
+                    portfolio,
+                    [],
+                    all_signals,
+                    market_regime,
+                    consensus,
+                    tick_id,
+                    fee_skip_reason,
+                    commit_tx=commit_tx,
+                    commit_block=commit_block,
+                )
+                return
 
         # Phase 2: TRADE — execute the rebalance, submitting the SAME arrays
         # (trade_arrays) the tradeId above was derived from — never recomputed.

--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -638,35 +638,6 @@ class StrategyRunner:
             )
         return None
 
-    async def _vault_fee_cap_refusal(self, vault_address: str) -> str | None:
-        """Fail-closed fee-cap gate for the agent's OWN state-changing call.
-
-        Issue #1138 follow-up (flagged by Dan on PR #1139's review): the
-        marketplace guard in ``marketplace_routes.py``/``vault_service.py``
-        only covers the surfaces a human reaches (publish/subscribe/list/
-        detail) — it never touched this loop, so an over-cap vault stayed
-        fully tradeable by the agent, which is the actual state-changing
-        path that triggers ``_accrueFees()`` in ``Vault.sol`` (rebalance()).
-        Read once here, right before Phase 2 TRADE (not earlier in
-        ``_process_vault``, since a no-drift tick never reaches this point
-        anyway — no extra RPC cost on the common path).
-
-        Returns a SKIP reason string when the vault must be refused, else
-        None. Mirrors ``_lease_ok``'s fail-closed shape: unreadable fees
-        refuse the same as over-cap fees, never silently proceed.
-        """
-        try:
-            mgmt_fee_bps, perf_fee_bps = await chain_executor.get_vault_fee_bps(vault_address)
-        except Exception as exc:
-            return f"Could not verify on-chain fees for vault {vault_address[:10]}: {exc} — refusing (fail-closed)"
-        if mgmt_fee_bps > MAX_MANAGEMENT_FEE_BPS or perf_fee_bps > MAX_PERFORMANCE_FEE_BPS:
-            return (
-                f"Vault {vault_address[:10]} fees exceed caps: "
-                f"managementFeeBps={mgmt_fee_bps} (cap {MAX_MANAGEMENT_FEE_BPS}), "
-                f"performanceFeeBps={perf_fee_bps} (cap {MAX_PERFORMANCE_FEE_BPS})"
-            )
-        return None
-
     async def _process_vault(
         self,
         vault_address: str,
@@ -1036,33 +1007,6 @@ class StrategyRunner:
                 commit_block=commit_block,
             )
             return
-
-        # Fee-cap guard (issue #1138 follow-up): refuse to submit the trade if
-        # this vault's immutable on-chain fees exceed the #1129 caps, or if
-        # they can't be read. rebalance() is what triggers Vault.sol's
-        # _accrueFees() — gating it here closes the gap the marketplace-only
-        # guard left open (see _vault_fee_cap_refusal docstring). Skipped
-        # under DRY_RUN, matching the _lease_ok check right below: no real
-        # write happens either way.
-        if not DRY_RUN:
-            fee_skip_reason = await self._vault_fee_cap_refusal(vault_address)
-            if fee_skip_reason is not None:
-                logger.error("[tick %s] %s", tick_id, fee_skip_reason)
-                await self._publish_trace(
-                    vault_address,
-                    DecisionType.SKIP,
-                    "fee_cap_exceeded",
-                    portfolio,
-                    [],
-                    all_signals,
-                    market_regime,
-                    consensus,
-                    tick_id,
-                    fee_skip_reason,
-                    commit_tx=commit_tx,
-                    commit_block=commit_block,
-                )
-                return
 
         # Fee-cap guard (issue #1138 follow-up): refuse to submit the trade if
         # this vault's immutable on-chain fees exceed the #1129 caps, or if

--- a/backend/archimedes/chain/constants.py
+++ b/backend/archimedes/chain/constants.py
@@ -1,0 +1,16 @@
+"""Chain-layer constants with no import side effects.
+
+Kept separate from executor.py (which instantiates the chain_executor
+singleton at import time) so lightweight consumers — pydantic schemas,
+OpenAPI generation, tooling — can import the fee caps without pulling in
+Web3/chain configuration.
+"""
+
+# Off-chain mirror of the Vault constructor fee caps (PR #1129 —
+# MAX_MANAGEMENT_FEE_BPS / MAX_PERFORMANCE_FEE_BPS in Vault.sol). The live
+# VaultFactory predates those caps and fee bps are immutable once a vault is
+# constructed, so a pre-cap vault with hostile fees can never be fixed
+# on-chain. These constants bound what the backend will list or interact
+# with (issue #1138) and MUST stay in lockstep with the Solidity values.
+MAX_MANAGEMENT_FEE_BPS = 500  # 5%
+MAX_PERFORMANCE_FEE_BPS = 5000  # 50%

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -31,6 +31,15 @@ logger = logging.getLogger(__name__)
 # Production would raise this to $1000+.
 MIN_HEALTHY_LIQUIDITY_USDC = 5.0
 
+# Off-chain mirror of the Vault constructor fee caps (PR #1129 —
+# MAX_MANAGEMENT_FEE_BPS / MAX_PERFORMANCE_FEE_BPS in Vault.sol). The live
+# VaultFactory predates those caps and fee bps are immutable once a vault is
+# constructed, so a pre-cap vault with hostile fees can never be fixed
+# on-chain. These constants bound what the backend will list or interact
+# with (issue #1138) and MUST stay in lockstep with the Solidity values.
+MAX_MANAGEMENT_FEE_BPS = 500  # 5%
+MAX_PERFORMANCE_FEE_BPS = 5000  # 50%
+
 # Solidity types of Vault.rebalance()'s params, in order — MUST match
 # Vault.sol's `rebalance(address[] tokensIn, uint256[] amountsIn,
 # address[] tokensOut, uint256[] amountsOut)` exactly, since
@@ -707,14 +716,17 @@ class ChainExecutor:
             tier = await vault.functions.tier().call()
         except Exception:
             tier = 2
+        # Fee reads degrade to None (unknown), NOT 0 — rendering an unreadable
+        # vault as "0% fees" on a trust surface is a lie, and the #1138 guard
+        # needs to distinguish "free" from "couldn't verify" to fail closed.
         try:
             mgmt_fee_bps = await vault.functions.managementFeeBps().call()
         except Exception:
-            mgmt_fee_bps = 0
+            mgmt_fee_bps = None
         try:
             perf_fee_bps = await vault.functions.performanceFeeBps().call()
         except Exception:
-            perf_fee_bps = 0
+            perf_fee_bps = None
         try:
             is_agent = await vault.functions.isAgentAssisted().call()
         except Exception:
@@ -756,6 +768,19 @@ class ChainExecutor:
         except Exception as exc:
             logger.warning("Could not read on-chain owner for vault %s: %s", vault_address, exc)
             return None
+
+    async def get_vault_fee_bps(self, vault_address: str) -> tuple[int, int]:
+        """Read (managementFeeBps, performanceFeeBps) from the vault contract.
+
+        Raises on any read failure — this is the read behind the #1138 fee
+        guard, and its callers must fail CLOSED (refuse the vault) when the
+        fees can't be verified. No silent zero-default here; contrast with
+        get_vault_metrics, whose display path degrades to None instead.
+        """
+        vault = self.loader.vault(vault_address)
+        mgmt_fee_bps = await vault.functions.managementFeeBps().call()
+        perf_fee_bps = await vault.functions.performanceFeeBps().call()
+        return int(mgmt_fee_bps), int(perf_fee_bps)
 
     async def get_all_vaults(self) -> list[str]:
         """Get all vault addresses from VaultFactory."""

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -31,14 +31,9 @@ logger = logging.getLogger(__name__)
 # Production would raise this to $1000+.
 MIN_HEALTHY_LIQUIDITY_USDC = 5.0
 
-# Off-chain mirror of the Vault constructor fee caps (PR #1129 —
-# MAX_MANAGEMENT_FEE_BPS / MAX_PERFORMANCE_FEE_BPS in Vault.sol). The live
-# VaultFactory predates those caps and fee bps are immutable once a vault is
-# constructed, so a pre-cap vault with hostile fees can never be fixed
-# on-chain. These constants bound what the backend will list or interact
-# with (issue #1138) and MUST stay in lockstep with the Solidity values.
-MAX_MANAGEMENT_FEE_BPS = 500  # 5%
-MAX_PERFORMANCE_FEE_BPS = 5000  # 50%
+# The #1138 fee-cap constants live in archimedes.chain.constants (a module
+# with no import side effects) so schemas and tooling can use them without
+# instantiating the chain_executor singleton below.
 
 # Solidity types of Vault.rebalance()'s params, in order — MUST match
 # Vault.sol's `rebalance(address[] tokensIn, uint256[] amountsIn,

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -16,37 +16,55 @@ from archimedes.api.schemas import (
     VaultListResponse,
     VaultSummaryResponse,
 )
-from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS, chain_executor
+from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
+from archimedes.chain.executor import chain_executor
 from archimedes.chain.trace_publisher import trace_publisher
 from archimedes.services.log_scrubber import sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
 
-def _fees_pass_caps(metrics: dict) -> bool:
+class VaultFeeGuardRefusal(Exception):
+    """A vault exists but the #1138 fee guard refuses to surface it.
+
+    Raised by get_vault_detail so the route can distinguish "refused" from
+    "unknown address" (404): over-cap → status_code 400 with the actual fee
+    values, unreadable fees → 502 (verification failed, fail-closed).
+    """
+
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(detail)
+
+
+def _fee_refusal(metrics: dict) -> tuple[int, str] | None:
     """The #1138 fee-cap gate for display surfaces.
 
-    False for vaults whose immutable fee bps exceed the #1129 caps (hostile —
-    the pre-cap factory could mint them and no setter can ever fix them) AND
-    for vaults whose fees could not be read (None from get_vault_metrics) —
-    fail-closed: never render a vault we couldn't verify as investable.
+    Returns (status_code, reason) for vaults whose immutable fee bps exceed
+    the #1129 caps (hostile — the pre-cap factory could mint them and no
+    setter can ever fix them) and for vaults whose fees could not be read
+    (None from get_vault_metrics) — fail-closed: never render a vault we
+    couldn't verify as investable. Returns None when the vault passes.
     """
+    address = metrics.get("vault_address", "?")
     mgmt, perf = metrics.get("management_fee_bps"), metrics.get("performance_fee_bps")
     if mgmt is None or perf is None:
-        logger.warning(
-            "Refusing to surface vault %s: fee bps unreadable (fail-closed)",
-            sanitize_log_value(metrics.get("vault_address", "?")),
-        )
-        return False
+        logger.warning("Refusing to surface vault %s: fee bps unreadable (fail-closed)", sanitize_log_value(address))
+        return 502, f"Could not verify on-chain fees for vault {address}; refusing (fail-closed)"
     if mgmt > MAX_MANAGEMENT_FEE_BPS or perf > MAX_PERFORMANCE_FEE_BPS:
         logger.warning(
             "Refusing to surface vault %s: fees exceed caps (managementFeeBps=%d, performanceFeeBps=%d)",
-            sanitize_log_value(metrics.get("vault_address", "?")),
+            sanitize_log_value(address),
             mgmt,
             perf,
         )
-        return False
-    return True
+        return 400, (
+            f"Vault {address} fees exceed caps: "
+            f"managementFeeBps={mgmt} (cap {MAX_MANAGEMENT_FEE_BPS}), "
+            f"performanceFeeBps={perf} (cap {MAX_PERFORMANCE_FEE_BPS})"
+        )
+    return None
 
 
 class VaultService:
@@ -128,7 +146,7 @@ class VaultService:
         for addr in vault_addresses:
             try:
                 metrics = await chain_executor.get_vault_metrics(addr)
-                if not _fees_pass_caps(metrics):  # issue #1138 — refuse to list
+                if _fee_refusal(metrics) is not None:  # issue #1138 — refuse to list
                     continue
                 summary = self._metrics_to_summary(metrics, meta=metadata_by_address.get(addr.lower()))
                 if tier is not None and summary.tier != tier:
@@ -163,9 +181,12 @@ class VaultService:
             metrics = await chain_executor.get_vault_metrics(address)
             # Issue #1138 — refuse to surface hostile or unverifiable vaults on
             # the detail view too: it's the page that renders the deposit CTA,
-            # so a direct link must not bypass the listing filter.
-            if not _fees_pass_caps(metrics):
-                return None
+            # so a direct link must not bypass the listing filter. Raises (not
+            # returns None) so the route can answer 400/502 with the reason
+            # instead of conflating a refused vault with an unknown address.
+            refusal = _fee_refusal(metrics)
+            if refusal is not None:
+                raise VaultFeeGuardRefusal(*refusal)
             portfolio = await chain_executor.read_portfolio(address)
 
             # Build holdings
@@ -233,6 +254,8 @@ class VaultService:
                 strategy_ids=strategy_ids,
                 current_regime=current_regime,
             )
+        except VaultFeeGuardRefusal:
+            raise  # deliberate refusal, not a read failure — let the route map it
         except Exception:
             logging.getLogger(__name__).exception("Failed to get vault detail for %s", sanitize_log_value(address))
             return None

--- a/backend/archimedes/services/vault_service.py
+++ b/backend/archimedes/services/vault_service.py
@@ -16,11 +16,37 @@ from archimedes.api.schemas import (
     VaultListResponse,
     VaultSummaryResponse,
 )
-from archimedes.chain.executor import chain_executor
+from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS, chain_executor
 from archimedes.chain.trace_publisher import trace_publisher
 from archimedes.services.log_scrubber import sanitize_log_value
 
 logger = logging.getLogger(__name__)
+
+
+def _fees_pass_caps(metrics: dict) -> bool:
+    """The #1138 fee-cap gate for display surfaces.
+
+    False for vaults whose immutable fee bps exceed the #1129 caps (hostile —
+    the pre-cap factory could mint them and no setter can ever fix them) AND
+    for vaults whose fees could not be read (None from get_vault_metrics) —
+    fail-closed: never render a vault we couldn't verify as investable.
+    """
+    mgmt, perf = metrics.get("management_fee_bps"), metrics.get("performance_fee_bps")
+    if mgmt is None or perf is None:
+        logger.warning(
+            "Refusing to surface vault %s: fee bps unreadable (fail-closed)",
+            sanitize_log_value(metrics.get("vault_address", "?")),
+        )
+        return False
+    if mgmt > MAX_MANAGEMENT_FEE_BPS or perf > MAX_PERFORMANCE_FEE_BPS:
+        logger.warning(
+            "Refusing to surface vault %s: fees exceed caps (managementFeeBps=%d, performanceFeeBps=%d)",
+            sanitize_log_value(metrics.get("vault_address", "?")),
+            mgmt,
+            perf,
+        )
+        return False
+    return True
 
 
 class VaultService:
@@ -102,6 +128,8 @@ class VaultService:
         for addr in vault_addresses:
             try:
                 metrics = await chain_executor.get_vault_metrics(addr)
+                if not _fees_pass_caps(metrics):  # issue #1138 — refuse to list
+                    continue
                 summary = self._metrics_to_summary(metrics, meta=metadata_by_address.get(addr.lower()))
                 if tier is not None and summary.tier != tier:
                     continue
@@ -133,6 +161,11 @@ class VaultService:
         """Get full vault detail."""
         try:
             metrics = await chain_executor.get_vault_metrics(address)
+            # Issue #1138 — refuse to surface hostile or unverifiable vaults on
+            # the detail view too: it's the page that renders the deposit CTA,
+            # so a direct link must not bypass the listing filter.
+            if not _fees_pass_caps(metrics):
+                return None
             portfolio = await chain_executor.read_portfolio(address)
 
             # Build holdings

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.marketplace_routes import marketplace_router
+from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from tests.db_isolation import redirect_to_tmp_sqlite
@@ -104,6 +105,11 @@ def app():
     market.signer.execute_contract = AsyncMock()
     market.executor = MagicMock()
     market.executor.create_vault = AsyncMock(return_value="0xvault")
+    # Fee-cap guard (issue #1138): publish with a user-supplied vault_address and
+    # subscribe both read the vault's on-chain fee bps and refuse over-cap or
+    # unreadable vaults. Default the mock to a compliant (0, 0) vault; the guard
+    # tests override per-case.
+    market.executor.get_vault_fee_bps = AsyncMock(return_value=(0, 0))
     # Funding gate (D7): the publish route rejects (402) when the vault holds less
     # than MARKETPLACE_MIN_VAULT_FUNDS_RAW. Mock the vault as well-funded so the
     # publish-path tests exercise publishing rather than the funding gate; the
@@ -406,6 +412,121 @@ def test_unsubscribe_triggers_refund_and_returns_tx(client, app):
     # The subscriber's own SIWE wallet is the withdrawal recipient.
     kwargs = app.state.market.refund_subscriber.await_args.kwargs
     assert kwargs["to_wallet"] == TEST_WALLET
+
+
+# ─── Fee-cap guard (issue #1138) ────────────────────────────────────────────
+# The live VaultFactory predates the #1129 constructor caps and fee bps are
+# immutable, so a pre-cap vault with hostile fees can never be fixed on-chain.
+# publish (user-supplied vault_address) and subscribe (the publisher's vault)
+# must refuse over-cap vaults with a 4xx naming the actual values, and must
+# fail CLOSED (502) when the fees can't be read.
+
+
+def _set_fees(app, mgmt: int, perf: int) -> None:
+    app.state.market.executor.get_vault_fee_bps = AsyncMock(return_value=(mgmt, perf))
+
+
+def test_publish_rejects_over_cap_management_fee(client, app):
+    _set_fees(app, MAX_MANAGEMENT_FEE_BPS + 100, 0)
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xhostile"},
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    # The reason names the actual on-chain values and the caps.
+    assert f"managementFeeBps={MAX_MANAGEMENT_FEE_BPS + 100}" in detail
+    assert f"cap {MAX_MANAGEMENT_FEE_BPS}" in detail
+
+
+def test_publish_rejects_over_cap_performance_fee(client, app):
+    _set_fees(app, 0, MAX_PERFORMANCE_FEE_BPS + 1)
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xhostile"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert f"performanceFeeBps={MAX_PERFORMANCE_FEE_BPS + 1}" in resp.json()["detail"]
+
+
+def test_publish_allows_fees_exactly_at_caps(client, app):
+    """A vault at exactly the caps is allowed — the contract allows it too."""
+    _set_fees(app, MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS)
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xatcap"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_publish_fee_read_failure_fails_closed(client, app):
+    """Unreadable fees → refuse (502), never wave the vault through.
+
+    Fail-closed is deliberate: this guard is fund-adjacent — passing a vault
+    whose fees we couldn't verify exposes depositors to the C1 fee-drain.
+    """
+    app.state.market.executor.get_vault_fee_bps = AsyncMock(side_effect=RuntimeError("rpc down"))
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xunknown"},
+    )
+    assert resp.status_code == 502, resp.text
+    assert "fail-closed" in resp.json()["detail"]
+
+
+def test_publish_created_vault_skips_fee_read(client, app):
+    """No user-supplied vault_address → backend creates the vault with 0/0 fees;
+    the guard must NOT run (a fee-read blip must not block the create path)."""
+    app.state.market.executor.get_vault_fee_bps = AsyncMock(side_effect=RuntimeError("rpc down"))
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat"},
+    )
+    assert resp.status_code == 200, resp.text
+    app.state.market.executor.get_vault_fee_bps.assert_not_awaited()
+
+
+def test_subscribe_rejects_over_cap_publisher_vault(client, app):
+    """A vault published before the guard existed stays reachable in the DB —
+    subscribe must re-check its fees on-chain and refuse, same as publish."""
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xpre_guard"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The vault's immutable on-chain fees are hostile; the publish-time check
+    # is history. Subscribe reads them fresh.
+    _set_fees(app, 0, MAX_PERFORMANCE_FEE_BPS + 1000)
+    with patch(
+        "archimedes.marketplace.wallet_provisioner.provision_subscriber_wallet",
+        new=AsyncMock(return_value=("w-fee", "0x0000000000000000000000000000000000000fe1")),
+    ):
+        r = client.post(
+            "/api/marketplace/subscribe",
+            json={"strategy_id": "test_strat", "sub_id": "0x" + "fe" * 32, "ephemeral_wallet": "0xeph"},
+        )
+    assert r.status_code == 400, r.text
+    assert f"performanceFeeBps={MAX_PERFORMANCE_FEE_BPS + 1000}" in r.json()["detail"]
+
+
+def test_subscribe_fee_read_failure_fails_closed(client, app):
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    app.state.market.executor.get_vault_fee_bps = AsyncMock(side_effect=RuntimeError("rpc down"))
+    with patch(
+        "archimedes.marketplace.wallet_provisioner.provision_subscriber_wallet",
+        new=AsyncMock(return_value=("w-fee", "0x0000000000000000000000000000000000000fe2")),
+    ):
+        r = client.post(
+            "/api/marketplace/subscribe",
+            json={"strategy_id": "test_strat", "sub_id": "0x" + "fd" * 32, "ephemeral_wallet": "0xeph"},
+        )
+    assert r.status_code == 502, r.text
 
 
 # ─── Identity ledger (issue #1028, D1a/D2/D3) ──────────────────────────────

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -7,12 +7,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from archimedes.api.auth_siwe import require_verified_wallet
 from archimedes.api.marketplace_routes import marketplace_router
-from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
+from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from tests.db_isolation import redirect_to_tmp_sqlite
 
 TEST_WALLET = "0x0000000000000000000000000000000000000001"
+
+
+def _vaddr(byte: str) -> str:
+    """A valid 20-byte hex vault address built from one repeated byte.
+
+    Publish validates user-supplied vault_address format before the #1138
+    fee guard runs, so test addresses must be real-shaped."""
+    return "0x" + byte * 20
 
 
 @pytest.fixture(autouse=True)
@@ -150,7 +158,7 @@ def test_publish_rejects_unknown_strategy(client):
     """
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "nonexistent", "vault_address": "0xvault"},
+        json={"strategy_id": "nonexistent", "vault_address": _vaddr("aa")},
     )
     assert resp.status_code == 404, resp.text
 
@@ -172,7 +180,7 @@ def test_publish_generated_strategy_not_in_curated_provider(client):
 
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "gen_strat", "vault_address": "0xvault_gen"},
+        json={"strategy_id": "gen_strat", "vault_address": _vaddr("a1")},
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["strategy_id"] == "gen_strat"
@@ -183,7 +191,7 @@ def test_publish_creates_publisher_row(client):
     """Publish creates a MarketplaceAgent row with a derived pool_id."""
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault_pre"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("a2")},
     )
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -199,7 +207,7 @@ def test_publish_underfunded_vault_returns_402(client):
     client.app.state.market._usdc_balance_of = AsyncMock(return_value=0)
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault_pre"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("a2")},
     )
     assert resp.status_code == 402, resp.text
     assert "below minimum" in resp.json()["detail"]
@@ -224,13 +232,13 @@ def test_publish_duplicate_returns_409(client):
     """Publishing the same strategy twice returns 409."""
     resp1 = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "dup_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "dup_strat", "vault_address": _vaddr("aa")},
     )
     assert resp1.status_code == 200
 
     resp2 = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "dup_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "dup_strat", "vault_address": _vaddr("aa")},
     )
     assert resp2.status_code == 409, resp2.text
 
@@ -240,7 +248,7 @@ def test_publish_pool_id_is_derived_not_accepted(client):
     # Validate that pool_id is non-zero, 66 chars, and starts with 0x
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "check_pool", "vault_address": "0xvault_a"},
+        json={"strategy_id": "check_pool", "vault_address": _vaddr("a3")},
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["pool_id"].startswith("0x")
@@ -260,7 +268,7 @@ def test_subscribe_succeeds_live_mode_no_chain_calls(client, app):
     # Create publisher first
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("aa")},
     )
     assert resp.status_code == 200
 
@@ -308,7 +316,7 @@ def test_subscribe_rejects_duplicate_sub_id_from_other_wallet(client, app):
     """
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "dup_sid_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "dup_sid_strat", "vault_address": _vaddr("aa")},
     )
     assert resp.status_code == 200
 
@@ -350,7 +358,7 @@ def test_published_detail_public_surface_count_only(client, app):
     """
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "redact_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "redact_strat", "vault_address": _vaddr("aa")},
     )
     assert resp.status_code == 200
 
@@ -389,7 +397,7 @@ def test_published_detail_public_surface_count_only(client, app):
 def test_unsubscribe_triggers_refund_and_returns_tx(client, app):
     """Unsubscribe auto-withdraws the subscriber's remaining DCW balance back to
     their wallet (issue #975 exit) and surfaces the tx in the response."""
-    resp = client.post("/api/marketplace/publish", json={"strategy_id": "refund_strat", "vault_address": "0xv"})
+    resp = client.post("/api/marketplace/publish", json={"strategy_id": "refund_strat", "vault_address": _vaddr("a5")})
     assert resp.status_code == 200
 
     with patch(
@@ -430,7 +438,7 @@ def test_publish_rejects_over_cap_management_fee(client, app):
     _set_fees(app, MAX_MANAGEMENT_FEE_BPS + 100, 0)
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xhostile"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("bb")},
     )
     assert resp.status_code == 400, resp.text
     detail = resp.json()["detail"]
@@ -443,7 +451,7 @@ def test_publish_rejects_over_cap_performance_fee(client, app):
     _set_fees(app, 0, MAX_PERFORMANCE_FEE_BPS + 1)
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xhostile"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("bb")},
     )
     assert resp.status_code == 400, resp.text
     assert f"performanceFeeBps={MAX_PERFORMANCE_FEE_BPS + 1}" in resp.json()["detail"]
@@ -454,7 +462,7 @@ def test_publish_allows_fees_exactly_at_caps(client, app):
     _set_fees(app, MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS)
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xatcap"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("cc")},
     )
     assert resp.status_code == 200, resp.text
 
@@ -468,10 +476,22 @@ def test_publish_fee_read_failure_fails_closed(client, app):
     app.state.market.executor.get_vault_fee_bps = AsyncMock(side_effect=RuntimeError("rpc down"))
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xunknown"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("dd")},
     )
     assert resp.status_code == 502, resp.text
     assert "fail-closed" in resp.json()["detail"]
+
+
+def test_publish_rejects_malformed_vault_address(client, app):
+    """A malformed vault_address is a client error (400) caught BEFORE any
+    chain read — not a 502 from the fee guard's fail-closed path."""
+    resp = client.post(
+        "/api/marketplace/publish",
+        json={"strategy_id": "test_strat", "vault_address": "0xnot-an-address"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "vault_address" in resp.json()["detail"]
+    app.state.market.executor.get_vault_fee_bps.assert_not_awaited()
 
 
 def test_publish_created_vault_skips_fee_read(client, app):
@@ -491,7 +511,7 @@ def test_subscribe_rejects_over_cap_publisher_vault(client, app):
     subscribe must re-check its fees on-chain and refuse, same as publish."""
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xpre_guard"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("ee")},
     )
     assert resp.status_code == 200, resp.text
 
@@ -513,7 +533,7 @@ def test_subscribe_rejects_over_cap_publisher_vault(client, app):
 def test_subscribe_fee_read_failure_fails_closed(client, app):
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("aa")},
     )
     assert resp.status_code == 200, resp.text
 
@@ -545,7 +565,7 @@ def test_publish_registers_dcw_and_ledgers_strategy_published(client):
 
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault_ledger"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("a4")},
     )
     assert resp.status_code == 200, resp.text
 
@@ -570,7 +590,7 @@ def test_subscribe_registers_dcw_and_ledgers_marketplace_subscribed(client):
     from archimedes.db import get_session
     from archimedes.models.identity import ControlledWallet, IdentityEvent
 
-    pub = client.post("/api/marketplace/publish", json={"strategy_id": "test_strat", "vault_address": "0xvault"})
+    pub = client.post("/api/marketplace/publish", json={"strategy_id": "test_strat", "vault_address": _vaddr("aa")})
     assert pub.status_code == 200, pub.text
 
     dcw_address = "0x0000000000000000000000000000000000000eee"
@@ -604,7 +624,7 @@ def test_unsubscribe_ledgers_marketplace_unsubscribed(client, app):
     from archimedes.db import get_session
     from archimedes.models.identity import IdentityEvent
 
-    pub = client.post("/api/marketplace/publish", json={"strategy_id": "refund_strat", "vault_address": "0xv"})
+    pub = client.post("/api/marketplace/publish", json={"strategy_id": "refund_strat", "vault_address": _vaddr("a5")})
     assert pub.status_code == 200
 
     with patch(

--- a/backend/tests/chain/test_executor_reads.py
+++ b/backend/tests/chain/test_executor_reads.py
@@ -225,6 +225,30 @@ class TestGetVaultMetrics:
         assert m["creator"] == "0x0000000000000000000000000000000000000000"
         assert m["tier"] == 2  # default
         assert m["is_agent_assisted"] is False
+        # Fees degrade to None (unknown), NOT 0 — "0% fees" on a trust surface
+        # would be a lie, and the #1138 guard fails closed on None (issue #1138).
+        assert m["management_fee_bps"] is None
+        assert m["performance_fee_bps"] is None
+
+
+# ── get_vault_fee_bps (issue #1138 fee guard) ─────────────────
+
+
+class TestGetVaultFeeBps:
+    def test_returns_both_fee_bps_as_ints(self, executor, mock_loader):
+        vault = mock_loader.vault.return_value
+        _vault_fn(vault, "managementFeeBps", return_value=500)
+        _vault_fn(vault, "performanceFeeBps", return_value=5000)
+        assert asyncio.run(executor.get_vault_fee_bps("0xVault")) == (500, 5000)
+
+    def test_raises_on_read_failure_so_callers_fail_closed(self, executor, mock_loader):
+        """No silent zero-default: the #1138 guard must refuse a vault whose
+        fees can't be verified, so the read raises instead of degrading."""
+        vault = mock_loader.vault.return_value
+        _vault_fn(vault, "managementFeeBps", side_effect=RuntimeError("revert"))
+        _vault_fn(vault, "performanceFeeBps", return_value=0)
+        with pytest.raises(RuntimeError):
+            asyncio.run(executor.get_vault_fee_bps("0xVault"))
 
 
 # ── get_all_vaults / get_vault_count ──────────────────────────

--- a/backend/tests/chain/test_fee_cap_constants_parity.py
+++ b/backend/tests/chain/test_fee_cap_constants_parity.py
@@ -1,0 +1,49 @@
+"""Parity check: the Python fee-cap constants must never drift from Solidity.
+
+Dan's review on PR #1139 (issue #1138 follow-up): archimedes/chain/constants.py
+mirrors Vault.sol's MAX_MANAGEMENT_FEE_BPS/MAX_PERFORMANCE_FEE_BPS by comment
+convention only — nothing ties them together, so if PR #1129 changes the caps
+during contract review, the off-chain guard silently starts enforcing a
+different bound than the chain does.
+
+Ordering note: #1129 (the Solidity caps) has not merged to main as of this
+PR — the constants don't exist in contracts/src/Vault.sol yet. This test
+skips (not fails) until they land, so #1139 isn't blocked on #1129's merge
+order; once the constants are present, a mismatch fails loudly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
+
+_MGMT_RE = re.compile(r"MAX_MANAGEMENT_FEE_BPS\s*=\s*(\d+)\s*;")
+_PERF_RE = re.compile(r"MAX_PERFORMANCE_FEE_BPS\s*=\s*(\d+)\s*;")
+
+
+def test_python_caps_match_vault_sol(repo_root: Path) -> None:
+    vault_sol = repo_root / "contracts" / "src" / "Vault.sol"
+    source = vault_sol.read_text()
+
+    mgmt_match = _MGMT_RE.search(source)
+    perf_match = _PERF_RE.search(source)
+    if mgmt_match is None or perf_match is None:
+        import pytest
+
+        pytest.skip(
+            "Vault.sol does not yet define MAX_MANAGEMENT_FEE_BPS/MAX_PERFORMANCE_FEE_BPS "
+            "(PR #1129 not merged) — nothing to compare against yet."
+        )
+
+    assert int(mgmt_match.group(1)) == MAX_MANAGEMENT_FEE_BPS, (
+        f"Vault.sol MAX_MANAGEMENT_FEE_BPS={mgmt_match.group(1)} != "
+        f"archimedes.chain.constants.MAX_MANAGEMENT_FEE_BPS={MAX_MANAGEMENT_FEE_BPS} — "
+        "update both together (issue #1138)."
+    )
+    assert int(perf_match.group(1)) == MAX_PERFORMANCE_FEE_BPS, (
+        f"Vault.sol MAX_PERFORMANCE_FEE_BPS={perf_match.group(1)} != "
+        f"archimedes.chain.constants.MAX_PERFORMANCE_FEE_BPS={MAX_PERFORMANCE_FEE_BPS} — "
+        "update both together (issue #1138)."
+    )

--- a/backend/tests/services/test_vault_service.py
+++ b/backend/tests/services/test_vault_service.py
@@ -166,6 +166,72 @@ class TestListVaults:
             assert [v.address for v in resp.vaults] == ["0xA", "0xB", "0xC"]
 
     @pytest.mark.asyncio
+    async def test_over_cap_fee_vault_refused_from_listing(self) -> None:
+        """Issue #1138: a vault whose immutable fee bps exceed the #1129 caps
+        (mintable by the pre-cap factory, unfixable on-chain) must not be
+        listed as investable."""
+        from archimedes.chain.executor import MAX_PERFORMANCE_FEE_BPS
+
+        with patch("archimedes.services.vault_service.chain_executor") as ce:
+            ce.get_all_vaults = AsyncMock(return_value=["0xGOOD", "0xHOSTILE"])
+
+            def metrics_side_effect(addr):
+                m = _metrics(address=addr)
+                if addr == "0xHOSTILE":
+                    m["performance_fee_bps"] = MAX_PERFORMANCE_FEE_BPS + 10_000  # >100%, the C1 drain shape
+                return m
+
+            ce.get_vault_metrics = AsyncMock(side_effect=metrics_side_effect)
+            resp = await VaultService().list_vaults()
+            assert [v.address for v in resp.vaults] == ["0xGOOD"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_fee_vault_refused_from_listing(self) -> None:
+        """Fail-closed: fee reads degrade to None in get_vault_metrics; a vault
+        we couldn't verify must not be rendered as investable (issue #1138)."""
+        with patch("archimedes.services.vault_service.chain_executor") as ce:
+            ce.get_all_vaults = AsyncMock(return_value=["0xGOOD", "0xUNKNOWN"])
+
+            def metrics_side_effect(addr):
+                m = _metrics(address=addr)
+                if addr == "0xUNKNOWN":
+                    m["management_fee_bps"] = None
+                return m
+
+            ce.get_vault_metrics = AsyncMock(side_effect=metrics_side_effect)
+            resp = await VaultService().list_vaults()
+            assert [v.address for v in resp.vaults] == ["0xGOOD"]
+
+    @pytest.mark.asyncio
+    async def test_at_cap_fee_vault_stays_listed(self) -> None:
+        """A vault at exactly the caps is allowed — the contract allows it too."""
+        from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
+
+        with patch("archimedes.services.vault_service.chain_executor") as ce:
+            ce.get_all_vaults = AsyncMock(return_value=["0xATCAP"])
+            m = _metrics(address="0xATCAP")
+            m["management_fee_bps"] = MAX_MANAGEMENT_FEE_BPS
+            m["performance_fee_bps"] = MAX_PERFORMANCE_FEE_BPS
+            ce.get_vault_metrics = AsyncMock(return_value=m)
+            resp = await VaultService().list_vaults()
+            assert [v.address for v in resp.vaults] == ["0xATCAP"]
+
+    @pytest.mark.asyncio
+    async def test_detail_refuses_over_cap_vault(self) -> None:
+        """The detail view renders the deposit CTA — a direct link to a hostile
+        vault must not bypass the listing filter (issue #1138)."""
+        from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS
+
+        with patch("archimedes.services.vault_service.chain_executor") as ce:
+            m = _metrics(address="0xHOSTILE")
+            m["management_fee_bps"] = MAX_MANAGEMENT_FEE_BPS + 1
+            ce.get_vault_metrics = AsyncMock(return_value=m)
+            detail = await VaultService().get_vault_detail("0xHOSTILE")
+            assert detail is None
+            # Refused before any further chain reads.
+            ce.read_portfolio.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_pagination_respects_limit_and_offset(self) -> None:
         addrs = ["0x" + chr(0x41 + i) for i in range(5)]  # 0xA..0xE
         with patch("archimedes.services.vault_service.chain_executor") as ce:

--- a/backend/tests/services/test_vault_service.py
+++ b/backend/tests/services/test_vault_service.py
@@ -170,7 +170,7 @@ class TestListVaults:
         """Issue #1138: a vault whose immutable fee bps exceed the #1129 caps
         (mintable by the pre-cap factory, unfixable on-chain) must not be
         listed as investable."""
-        from archimedes.chain.executor import MAX_PERFORMANCE_FEE_BPS
+        from archimedes.chain.constants import MAX_PERFORMANCE_FEE_BPS
 
         with patch("archimedes.services.vault_service.chain_executor") as ce:
             ce.get_all_vaults = AsyncMock(return_value=["0xGOOD", "0xHOSTILE"])
@@ -205,7 +205,7 @@ class TestListVaults:
     @pytest.mark.asyncio
     async def test_at_cap_fee_vault_stays_listed(self) -> None:
         """A vault at exactly the caps is allowed — the contract allows it too."""
-        from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
+        from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
 
         with patch("archimedes.services.vault_service.chain_executor") as ce:
             ce.get_all_vaults = AsyncMock(return_value=["0xATCAP"])
@@ -217,19 +217,38 @@ class TestListVaults:
             assert [v.address for v in resp.vaults] == ["0xATCAP"]
 
     @pytest.mark.asyncio
-    async def test_detail_refuses_over_cap_vault(self) -> None:
+    async def test_detail_refuses_over_cap_vault_with_400(self) -> None:
         """The detail view renders the deposit CTA — a direct link to a hostile
-        vault must not bypass the listing filter (issue #1138)."""
-        from archimedes.chain.executor import MAX_MANAGEMENT_FEE_BPS
+        vault must not bypass the listing filter (issue #1138). The refusal is
+        a typed raise (not None → 404) so the route can answer 400 with the
+        actual fee values instead of pretending the vault doesn't exist."""
+        from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS
+        from archimedes.services.vault_service import VaultFeeGuardRefusal
 
         with patch("archimedes.services.vault_service.chain_executor") as ce:
             m = _metrics(address="0xHOSTILE")
             m["management_fee_bps"] = MAX_MANAGEMENT_FEE_BPS + 1
             ce.get_vault_metrics = AsyncMock(return_value=m)
-            detail = await VaultService().get_vault_detail("0xHOSTILE")
-            assert detail is None
+            with pytest.raises(VaultFeeGuardRefusal) as exc_info:
+                await VaultService().get_vault_detail("0xHOSTILE")
+            assert exc_info.value.status_code == 400
+            assert f"managementFeeBps={MAX_MANAGEMENT_FEE_BPS + 1}" in exc_info.value.detail
             # Refused before any further chain reads.
             ce.read_portfolio.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_detail_refuses_unreadable_fee_vault_with_502(self) -> None:
+        """Unverifiable fees on detail → 502 (fail-closed), distinguishable
+        from both a hostile vault (400) and an unknown address (404)."""
+        from archimedes.services.vault_service import VaultFeeGuardRefusal
+
+        with patch("archimedes.services.vault_service.chain_executor") as ce:
+            m = _metrics(address="0xUNKNOWN")
+            m["performance_fee_bps"] = None
+            ce.get_vault_metrics = AsyncMock(return_value=m)
+            with pytest.raises(VaultFeeGuardRefusal) as exc_info:
+                await VaultService().get_vault_detail("0xUNKNOWN")
+            assert exc_info.value.status_code == 502
 
     @pytest.mark.asyncio
     async def test_pagination_respects_limit_and_offset(self) -> None:

--- a/backend/tests/test_agent_runner_tick.py
+++ b/backend/tests/test_agent_runner_tick.py
@@ -91,6 +91,11 @@ def runner_env(monkeypatch):
         patch("archimedes.chain.agent_runner.AgentStateStore") as mock_state_cls,
         patch("archimedes.chain.agent_runner.strategy_evaluator") as mock_eval,
     ):
+        # Fee-cap guard (issue #1138 follow-up) default: compliant (0, 0) fees so
+        # existing live-mode (DRY_RUN=False) tests that don't care about fees
+        # keep reaching Phase 2 TRADE unmodified. TestFeeCapGuardBlocksTradeOnHostileVault
+        # overrides this per-case to exercise the guard itself.
+        mock_executor.get_vault_fee_bps = AsyncMock(return_value=(0, 0))
         mock_client.settings = MagicMock(
             synth_addresses={"sSPY": "0xsspy", "sGOLD": "0xsgold"},
             usdc_address="0xusdc",
@@ -651,6 +656,104 @@ class TestCommitRevealGuardBlocksTradeOnFailedCommit:
         # Trade proceeds exactly as before commit-reveal existed — the guard
         # does not fire because supports_commit_reveal() is False.
         m["executor"].execute_trades.assert_awaited_once()
+
+
+class TestFeeCapGuardBlocksTradeOnHostileVault:
+    """Issue #1138 follow-up (Dan's PR #1139 review): the marketplace-only
+    fee guard never reached the agent's own rebalance() call — the actual
+    state-changing path that triggers Vault.sol's _accrueFees(). These cover
+    the gap: over-cap and unreadable fees must both refuse Phase 2 TRADE,
+    fail-closed, while an at-cap vault must still trade normally."""
+
+    async def test_over_cap_fees_skip_trade(self, runner_env, monkeypatch):
+        runner, m = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.DRY_RUN", False)
+
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        m["executor"].build_trade_arrays = AsyncMock(return_value=(["0x" + "11" * 20], [600_000000], [], []))
+        m["executor"].execute_trades = AsyncMock(side_effect=AssertionError("execute_trades must not be called"))
+        from archimedes.chain.constants import MAX_PERFORMANCE_FEE_BPS
+
+        m["executor"].get_vault_fee_bps = AsyncMock(return_value=(0, MAX_PERFORMANCE_FEE_BPS + 1))
+
+        m["publisher"].supports_commit_reveal = MagicMock(return_value=False)
+        m["publisher"].publish = AsyncMock(return_value=None)
+        runner._get_vault_strategy_ids = MagicMock(return_value=None)
+
+        await runner.tick()
+
+        m["executor"].execute_trades.assert_not_called()
+        m["state"].save_trace.assert_awaited()
+        saved = m["state"].save_trace.await_args.args[0]
+        assert saved["decision_type"] == "skip"
+        assert saved["trigger"] == "fee_cap_exceeded"
+
+    async def test_unreadable_fees_skip_trade_fail_closed(self, runner_env, monkeypatch):
+        """Unreadable fees refuse the same as over-cap — never silently proceed."""
+        runner, m = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.DRY_RUN", False)
+
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        m["executor"].build_trade_arrays = AsyncMock(return_value=(["0x" + "11" * 20], [600_000000], [], []))
+        m["executor"].execute_trades = AsyncMock(side_effect=AssertionError("execute_trades must not be called"))
+        m["executor"].get_vault_fee_bps = AsyncMock(side_effect=RuntimeError("rpc down"))
+
+        m["publisher"].supports_commit_reveal = MagicMock(return_value=False)
+        m["publisher"].publish = AsyncMock(return_value=None)
+        runner._get_vault_strategy_ids = MagicMock(return_value=None)
+
+        await runner.tick()
+
+        m["executor"].execute_trades.assert_not_called()
+        saved = m["state"].save_trace.await_args.args[0]
+        assert saved["decision_type"] == "skip"
+        assert saved["trigger"] == "fee_cap_exceeded"
+        assert "rpc down" in saved["reasoning"]
+
+    async def test_at_cap_fees_trade_proceeds(self, runner_env, monkeypatch):
+        """A vault at exactly the caps is allowed — the contract allows it too."""
+        runner, m = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.DRY_RUN", False)
+        from archimedes.chain.constants import MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS
+
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        m["executor"].build_trade_arrays = AsyncMock(return_value=(["0x" + "11" * 20], [600_000000], [], []))
+        m["executor"].execute_trades = AsyncMock(return_value=["0xtradetx"])
+        m["executor"].get_vault_fee_bps = AsyncMock(return_value=(MAX_MANAGEMENT_FEE_BPS, MAX_PERFORMANCE_FEE_BPS))
+
+        m["publisher"].supports_commit_reveal = MagicMock(return_value=False)
+        m["publisher"].publish = AsyncMock(return_value=None)
+        runner._get_vault_strategy_ids = MagicMock(return_value=None)
+
+        await runner.tick()
+
+        m["executor"].execute_trades.assert_awaited_once()
+
+    async def test_dry_run_unaffected_by_fee_guard(self, runner_env):
+        """DRY_RUN never submits a real trade — the fee-cap read must not run
+        (and must not block the simulate path) under DRY_RUN."""
+        runner, m = runner_env  # runner_env fixture forces DRY_RUN=True
+        m["executor"].get_all_vaults = AsyncMock(return_value=["0xVault"])
+        m["executor"].read_portfolio = AsyncMock(return_value=_portfolio())
+        m["executor"].set_token_oracles = AsyncMock()
+        m["executor"].set_target_allocations = AsyncMock()
+        m["executor"].get_vault_fee_bps = AsyncMock(side_effect=AssertionError("must not be read under DRY_RUN"))
+        runner._get_vault_strategy_ids = MagicMock(return_value=None)
+
+        await runner.tick()
+
+        m["executor"].get_vault_fee_bps.assert_not_called()
+        saved = m["state"].save_trace.await_args.args[0]
+        assert saved["decision_type"] == "rebalance"
 
 
 # ── run() loop body ───────────────────────────────────────────


### PR DESCRIPTION
Closes #1138

## Summary

#1129 caps fee bps in the Vault constructor, but that only protects vaults created after the factory redeploy. Fee bps are immutable with no setter, so any vault the pre-cap factory already minted with hostile fees stays hostile forever. This adds the off-chain guard: read `managementFeeBps()` / `performanceFeeBps()` from chain and refuse to surface or interact with any vault over the caps. Works today, independent of the redeploy timeline.

## What it does

- `chain/executor.py`: `MAX_MANAGEMENT_FEE_BPS = 500` / `MAX_PERFORMANCE_FEE_BPS = 5000`, defined once, mirroring the #1129 Solidity values. New `get_vault_fee_bps()` that raises on read failure instead of defaulting.
- Marketplace publish: a user-supplied `vault_address` gets its fees checked before anything else runs. Over-cap → 400 with the actual values in the detail. The backend-created path skips the check since it hardcodes 0/0.
- Marketplace subscribe: re-checks the publisher's vault on every subscribe, so a vault published before this guard existed still gets caught. Refused before any Circle wallet is provisioned.
- Vault list + detail: `get_vault_metrics` fee reads now degrade to `None` instead of a fake 0 (an unreadable vault rendering as "0% fees" was a lie on a trust surface). The list filters out over-cap and unverifiable vaults; the detail view refuses them too, since that's the page with the deposit CTA and a direct link shouldn't bypass the list filter.
- `vault_schemas.py`: `VaultCreateRequest.management_fee_bps` was `le=1000`, which admits requests the capped contract will revert post-redeploy. Now tied to the shared constant (500). The performance cap stays at 3000, deliberately stricter than the on-chain 5000.

## Fail-open vs fail-closed

Fail-closed, per the issue: if the fee read fails, the vault is refused with a 502. This guard is fund-adjacent — waving through a vault we couldn't verify exposes depositors to the C1 fee-drain. Different call than the #713 spend cap (fail-open), where the worst case is a bounded overcharge rather than principal loss.

## Test plan

- [x] Publish against an over-cap vault → 400 naming the actual fee values
- [x] Subscribe against an over-cap publisher vault → 400 the same way
- [x] Fees exactly at the caps → allowed (contract allows it too)
- [x] Fee read failure → 502 on publish and subscribe, and over-cap/unreadable vaults dropped from list + detail
- [x] Chain client mocked at the boundary throughout (`get_vault_fee_bps` AsyncMock in route tests, `.functions.X().call()` AsyncMocks in executor tests)
- [x] `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/ -q -k "not integration"` → 2928 passed, 0 failed
- [x] `ruff format --check` clean; `ruff check --select E9,F63,F7,F40` clean (the 6 ARG001 hits in marketplace_routes are the pre-existing slowapi `response` params, unchanged)

## Anti-goals honored

- No contract changes (#1129 owns the on-chain side)
- No hardcoded bad-vault addresses — fees always read from chain
- Caps defined once and imported everywhere; the one pre-existing divergent cap (`le=1000` in vault_schemas) is now aligned rather than duplicated

Touches `chain/executor.py` (read-only additions, no tx paths) — flagging for Dan since that's his lane; the rest is backend/API.
