### PR TITLE
[contracts] Add PythAdapter & Consolidate IAggregatorV3 (#794, #827)

### DIFF
--- a/contracts/abis/PythAdapter.json
+++ b/contracts/abis/PythAdapter.json
@@ -1,0 +1,111 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_pyth",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_feedId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "feedId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pyth",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IPyth"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "PriceExponentOutOfRange",
+    "inputs": [
+      {
+        "name": "expo",
+        "type": "int32",
+        "internalType": "int32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeedId",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPyth",
+    "inputs": []
+  }
+]

--- a/contracts/abis/StorkAggregatorV3Adapter.json
+++ b/contracts/abis/StorkAggregatorV3Adapter.json
@@ -1,0 +1,113 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_stork",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_priceId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "STORK_DECIMALS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "latestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "priceId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stork",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IStorkTemporalNumericValueUnsafeGetter"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "ZeroPriceId",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroStork",
+    "inputs": []
+  }
+]

--- a/contracts/script/DeployPythAdapter.s.sol
+++ b/contracts/script/DeployPythAdapter.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/adapters/PythAdapter.sol";
+
+/// @notice Deploy one PythAdapter, binding a Pyth price-feed id to the
+///         AggregatorV3 interface PriceOracle (#724) consumes. One adapter per asset.
+///         Mirrors DeployStorkAdapter.s.sol (#1153 review parity).
+///
+///         Env:
+///           PYTH_CONTRACT — the Pyth contract on the target chain. REQUIRED: unlike
+///                           Stork (verified on Arc testnet on-chain, #794), no Pyth
+///                           deployment on Arc has been verified yet, so there is no
+///                           default to bake in — never guess a funds-adjacent address.
+///           PYTH_PRICE_ID — the bytes32 Pyth price-feed id for this asset
+///
+///         Usage:
+///           PYTH_CONTRACT=0x<pyth> PYTH_PRICE_ID=0x<feedId> \
+///           forge script contracts/script/DeployPythAdapter.s.sol \
+///             --rpc-url https://rpc.testnet.arc.network --broadcast
+///
+///         After deploy: PriceOracle(asset).setPriceFeed(adapter) — owner-only (Dan).
+///         The #724 oracle keeps the admin-fed value as the degrade target behind it.
+contract DeployPythAdapter is Script {
+    function run() external {
+        address pythContract = vm.envAddress("PYTH_CONTRACT");
+        bytes32 priceId = vm.envBytes32("PYTH_PRICE_ID");
+
+        vm.startBroadcast();
+        PythAdapter adapter = new PythAdapter(pythContract, priceId);
+        vm.stopBroadcast();
+
+        console.log("=== Pyth AggregatorV3 adapter deployed ===");
+        console.log("Pyth contract:", pythContract);
+        console.logBytes32(priceId);
+        console.log("Adapter:", address(adapter));
+        console.log("Next: call PriceOracle(asset).setPriceFeed(adapter) as owner");
+    }
+}

--- a/contracts/script/DeployStorkAdapter.s.sol
+++ b/contracts/script/DeployStorkAdapter.s.sol
@@ -35,6 +35,8 @@ contract DeployStorkAdapter is Script {
         console.log("Stork contract:", storkContract);
         console.logBytes32(priceId);
         console.log("Adapter:", address(adapter));
-        console.log("Next: PriceOracle(asset).setPriceFeed(", address(adapter), ") as owner");
+        // The adapter address is logged above; forge-std has no console.log(string,address,string)
+        // overload, so keep this a plain-string hint rather than interpolating the address inline.
+        console.log("Next: call PriceOracle(asset).setPriceFeed(adapter) as owner");
     }
 }

--- a/contracts/script/DeployStorkAdapter.s.sol
+++ b/contracts/script/DeployStorkAdapter.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/StorkAggregatorV3Adapter.sol";
+
+/// @notice Deploy one StorkAggregatorV3Adapter, binding a Stork feed id to the
+///         AggregatorV3 interface PriceOracle (#724) consumes. One adapter per asset.
+///
+///         Env:
+///           STORK_CONTRACT  — Stork on-chain contract (Arc testnet default below)
+///           STORK_PRICE_ID  — the bytes32 Stork feed id for this asset
+///
+///         Usage:
+///           STORK_CONTRACT=0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62 \
+///           STORK_PRICE_ID=0x<feedId> \
+///           forge script contracts/script/DeployStorkAdapter.s.sol \
+///             --rpc-url https://rpc.testnet.arc.network --broadcast
+///
+///         After deploy: PriceOracle(asset).setPriceFeed(adapter) — owner-only (Dan).
+///         The #724 oracle keeps the admin-fed value as the degrade target behind it.
+contract DeployStorkAdapter is Script {
+    /// @dev Stork's verified Arc-testnet deployment (#794).
+    address constant ARC_STORK_DEFAULT = 0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62;
+
+    function run() external {
+        address storkContract = vm.envOr("STORK_CONTRACT", ARC_STORK_DEFAULT);
+        bytes32 priceId = vm.envBytes32("STORK_PRICE_ID");
+
+        vm.startBroadcast();
+        StorkAggregatorV3Adapter adapter = new StorkAggregatorV3Adapter(storkContract, priceId);
+        vm.stopBroadcast();
+
+        console.log("=== Stork AggregatorV3 adapter deployed ===");
+        console.log("Stork contract:", storkContract);
+        console.logBytes32(priceId);
+        console.log("Adapter:", address(adapter));
+        console.log("Next: PriceOracle(asset).setPriceFeed(", address(adapter), ") as owner");
+    }
+}

--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "./interfaces/IAggregatorV3.sol";
+import "./interfaces/AggregatorV3Interface.sol";
 
 /// @title PriceOracle
 /// @notice Per-asset price oracle for any asset on Arc testnet. Prefers a Chainlink

--- a/contracts/src/PriceOracle.sol
+++ b/contracts/src/PriceOracle.sol
@@ -2,30 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-
-/// @notice Minimal Chainlink price-feed interface (T1.3 — Chainlink-first read path).
-///         Declared locally rather than pulling in the chainlink/contracts package
-///         so we add no new submodule dependency for one interface. This is the canonical
-///         AggregatorV3Interface signature — Chainlink feeds (and Arc-native /
-///         Chainlink-compatible aggregators) implement it verbatim.
-///         Reference: https://docs.chain.link/data-feeds/api-reference
-interface AggregatorV3Interface {
-    /// @return The number of decimals the feed answer is reported in (USD feeds: 8).
-    function decimals() external view returns (uint8);
-
-    /// @notice Latest completed round of price data.
-    /// @return roundId         The round ID the answer was computed in.
-    /// @return answer          The price (signed; non-negative for a healthy feed).
-    /// @return startedAt       Timestamp the round started.
-    /// @return updatedAt       Timestamp the answer was last updated (staleness key).
-    /// @return answeredInRound The round in which the answer was computed (legacy
-    ///                         carry-over detector; answeredInRound < roundId means
-    ///                         the answer is stale carried from a prior round).
-    function latestRoundData()
-        external
-        view
-        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
-}
+import "./interfaces/IAggregatorV3.sol";
 
 /// @title PriceOracle
 /// @notice Per-asset price oracle for any asset on Arc testnet. Prefers a Chainlink

--- a/contracts/src/StorkAggregatorV3Adapter.sol
+++ b/contracts/src/StorkAggregatorV3Adapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./interfaces/IAggregatorV3.sol";
+import "./interfaces/AggregatorV3Interface.sol";
 
 /// @notice Minimal read interface for the Stork on-chain price contract (live on Arc
 ///         testnet at 0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62, verified #794). Stork

--- a/contracts/src/StorkAggregatorV3Adapter.sol
+++ b/contracts/src/StorkAggregatorV3Adapter.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Minimal read interface for the Stork on-chain price contract (live on Arc
+///         testnet at 0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62, verified #794). Stork
+///         stores a per-asset temporal numeric value keyed by a bytes32 feed id; the
+///         "Unsafe" getter returns the stored value WITHOUT reverting on staleness —
+///         staleness is enforced downstream by the consuming PriceOracle, which degrades
+///         to the admin-fed price on a stale/invalid feed (#724 design).
+interface IStorkTemporalNumericValueUnsafeGetter {
+    struct TemporalNumericValue {
+        uint64 timestampNs; // observation time, NANOSECONDS
+        int192 quantizedValue; // value scaled to 18 decimals (Stork convention)
+    }
+
+    function getTemporalNumericValueUnsafeV1(bytes32 id) external view returns (TemporalNumericValue memory value);
+}
+
+/// @notice Chainlink AggregatorV3 signature — function selectors are byte-identical to the
+///         `AggregatorV3Interface` PriceOracle.sol declares locally, so this adapter is a
+///         drop-in `setPriceFeed` target. Named `IAggregatorV3` (not `AggregatorV3Interface`)
+///         only to avoid an identifier clash when a consumer imports both files.
+/// @dev    ⚠️ DUPLICATE (tracked): this restates PriceOracle.sol's local `AggregatorV3Interface`.
+///         The clean fix is one shared `src/interfaces/IAggregatorV3.sol` imported by BOTH —
+///         deferred to the #588 redeploy because it edits the deployed PriceOracle.sol
+///         (bytecode-neutral, but contract-review-grade). See the consolidation follow-up issue.
+interface IAggregatorV3 {
+    function decimals() external view returns (uint8);
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+/// @title StorkAggregatorV3Adapter
+/// @notice Adapts ONE Stork price feed to Chainlink's AggregatorV3Interface so the existing
+///         #724 PriceOracle (Chainlink-first, degrade-to-admin) can consume Stork on Arc —
+///         where Chainlink has no Data Feeds (#794). One adapter instance per asset (one
+///         Stork feed id), pointed at by `PriceOracle.setPriceFeed(adapter)`.
+/// @dev    Thin, view-only, holds no funds. Stork quantizes to 18 decimals; the adapter
+///         reports `decimals() = 18` and PriceOracle rescales to its 6-decimal convention.
+///         The adapter does NOT enforce staleness itself (it uses the Unsafe getter) —
+///         PriceOracle owns staleness / round-completeness / sanity-band validation and
+///         degrades to the admin price on ANY feed failure, so a frozen or garbled Stork
+///         feed can never brick a vault read. It is a real decentralized primary sitting in
+///         front of the admin safety net, not a replacement for it.
+///
+///         ⚠️ Funds-adjacent (feeds vault collateral math via PriceOracle). Contract work →
+///         Dan owns + deploys; Bogdan reviews (#794).
+contract StorkAggregatorV3Adapter is IAggregatorV3 {
+    /// @notice The Stork on-chain contract this adapter reads from.
+    IStorkTemporalNumericValueUnsafeGetter public immutable stork;
+
+    /// @notice The Stork feed id (asset) this adapter exposes.
+    bytes32 public immutable priceId;
+
+    /// @notice Stork quantizes values to 18 decimals; PriceOracle rescales to 6.
+    uint8 public constant STORK_DECIMALS = 18;
+
+    error ZeroStork();
+    error ZeroPriceId();
+
+    constructor(address _stork, bytes32 _priceId) {
+        if (_stork == address(0)) revert ZeroStork();
+        if (_priceId == bytes32(0)) revert ZeroPriceId();
+        stork = IStorkTemporalNumericValueUnsafeGetter(_stork);
+        priceId = _priceId;
+    }
+
+    /// @inheritdoc IAggregatorV3
+    function decimals() external pure returns (uint8) {
+        return STORK_DECIMALS;
+    }
+
+    /// @inheritdoc IAggregatorV3
+    /// @dev Maps Stork's (timestampNs, quantizedValue) → Chainlink round data:
+    ///        answer              = quantizedValue (18-dec; PriceOracle rescales to 6)
+    ///        updatedAt/startedAt = timestampNs / 1e9 (ns → s; PriceOracle's staleness key)
+    ///        roundId = answeredInRound = the second-resolution timestamp. Stork has no round
+    ///          concept, so a monotonic-by-time id keeps PriceOracle's carry-over guard
+    ///          (`answeredInRound >= roundId`) satisfied while advancing on each update.
+    ///      An uninitialized feed (timestampNs == 0) yields updatedAt == 0, which PriceOracle
+    ///      reads as an incomplete round and degrades to admin — the intended fail-soft.
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        IStorkTemporalNumericValueUnsafeGetter.TemporalNumericValue memory v =
+            stork.getTemporalNumericValueUnsafeV1(priceId);
+        uint256 tsSeconds = uint256(v.timestampNs) / 1e9;
+        answer = int256(v.quantizedValue);
+        startedAt = tsSeconds;
+        updatedAt = tsSeconds;
+        roundId = uint80(tsSeconds);
+        answeredInRound = uint80(tsSeconds);
+    }
+}

--- a/contracts/src/StorkAggregatorV3Adapter.sol
+++ b/contracts/src/StorkAggregatorV3Adapter.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import "./interfaces/IAggregatorV3.sol";
+
 /// @notice Minimal read interface for the Stork on-chain price contract (live on Arc
 ///         testnet at 0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62, verified #794). Stork
 ///         stores a per-asset temporal numeric value keyed by a bytes32 feed id; the
@@ -14,23 +16,6 @@ interface IStorkTemporalNumericValueUnsafeGetter {
     }
 
     function getTemporalNumericValueUnsafeV1(bytes32 id) external view returns (TemporalNumericValue memory value);
-}
-
-/// @notice Chainlink AggregatorV3 signature — function selectors are byte-identical to the
-///         `AggregatorV3Interface` PriceOracle.sol declares locally, so this adapter is a
-///         drop-in `setPriceFeed` target. Named `IAggregatorV3` (not `AggregatorV3Interface`)
-///         only to avoid an identifier clash when a consumer imports both files.
-/// @dev    ⚠️ DUPLICATE (tracked): this restates PriceOracle.sol's local `AggregatorV3Interface`.
-///         The clean fix is one shared `src/interfaces/IAggregatorV3.sol` imported by BOTH —
-///         deferred to the #588 redeploy because it edits the deployed PriceOracle.sol
-///         (bytecode-neutral, but contract-review-grade). See the consolidation follow-up issue.
-interface IAggregatorV3 {
-    function decimals() external view returns (uint8);
-
-    function latestRoundData()
-        external
-        view
-        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
 }
 
 /// @title StorkAggregatorV3Adapter
@@ -48,7 +33,7 @@ interface IAggregatorV3 {
 ///
 ///         ⚠️ Funds-adjacent (feeds vault collateral math via PriceOracle). Contract work →
 ///         Dan owns + deploys; Bogdan reviews (#794).
-contract StorkAggregatorV3Adapter is IAggregatorV3 {
+contract StorkAggregatorV3Adapter is AggregatorV3Interface {
     /// @notice The Stork on-chain contract this adapter reads from.
     IStorkTemporalNumericValueUnsafeGetter public immutable stork;
 
@@ -68,12 +53,12 @@ contract StorkAggregatorV3Adapter is IAggregatorV3 {
         priceId = _priceId;
     }
 
-    /// @inheritdoc IAggregatorV3
+    /// @inheritdoc AggregatorV3Interface
     function decimals() external pure returns (uint8) {
         return STORK_DECIMALS;
     }
 
-    /// @inheritdoc IAggregatorV3
+    /// @inheritdoc AggregatorV3Interface
     /// @dev Maps Stork's (timestampNs, quantizedValue) → Chainlink round data:
     ///        answer              = quantizedValue (18-dec; PriceOracle rescales to 6)
     ///        updatedAt/startedAt = timestampNs / 1e9 (ns → s; PriceOracle's staleness key)

--- a/contracts/src/adapters/PythAdapter.sol
+++ b/contracts/src/adapters/PythAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "../interfaces/IAggregatorV3.sol";
+import "../interfaces/AggregatorV3Interface.sol";
 
 interface IPyth {
     struct Price {

--- a/contracts/src/adapters/PythAdapter.sol
+++ b/contracts/src/adapters/PythAdapter.sol
@@ -20,6 +20,32 @@ contract PythAdapter is AggregatorV3Interface {
     IPyth public immutable pyth;
     bytes32 public immutable feedId;
 
+    /// @notice The feed reported an exponent outside the provably-safe scaling
+    ///         window. Real Pyth feeds publish expo near -8; anything outside
+    ///         [-77, 49] cannot be scaled here without either a silent int256
+    ///         sign reinterpretation or a checked-arithmetic panic, so the
+    ///         adapter refuses loudly instead.
+    error PriceExponentOutOfRange(int32 expo);
+
+    /// @dev Bounds for the scaling arithmetic below, derived — not vibes:
+    ///      UPPER (49): the multiply path computes price * 10**(8+expo).
+    ///        |price| <= int64.max ≈ 9.22e18, and int256.max ≈ 5.78e76, so the
+    ///        product provably fits iff 10**(8+expo) <= 5.78e76 / 9.22e18
+    ///        ≈ 6.27e57, i.e. 8+expo <= 57 → expo <= 49. The previously
+    ///        unguarded landmine sat at exactly expo = 69: 10**77 FITS uint256
+    ///        (max ≈ 1.16e77) but exceeds int256.max, so int256(multiplier)
+    ///        silently reinterpreted NEGATIVE — and (price = -1, expo = 69)
+    ///        produced large POSITIVE garbage that defeats PriceOracle's
+    ///        answer <= 0 guard in the documented setMaxFeedDeviationBps(0)
+    ///        config. Every exponent above 69 merely panicked; 69 lied.
+    ///      LOWER (-77): the divide path computes 10**(-expo-8), which must
+    ///        itself fit int256: -expo-8 <= 76 → expo >= -84; -77 adds margin
+    ///        and division then only truncates toward zero (a vanishingly
+    ///        small price reads 0, which the downstream answer <= 0 guard
+    ///        rejects honestly).
+    int32 internal constant MIN_EXPO = -77;
+    int32 internal constant MAX_EXPO = 49;
+
     constructor(address _pyth, bytes32 _feedId) {
         pyth = IPyth(_pyth);
         feedId = _feedId;
@@ -36,6 +62,9 @@ contract PythAdapter is AggregatorV3Interface {
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         IPyth.Price memory p = pyth.getPriceUnsafe(feedId);
+        if (p.expo < MIN_EXPO || p.expo > MAX_EXPO) {
+            revert PriceExponentOutOfRange(p.expo);
+        }
         int256 scaledPrice;
         if (p.expo < -8) {
             uint256 divisor = 10 ** uint256(int256(-p.expo) - 8);

--- a/contracts/src/adapters/PythAdapter.sol
+++ b/contracts/src/adapters/PythAdapter.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../interfaces/IAggregatorV3.sol";
+
+interface IPyth {
+    struct Price {
+        int64 price;
+        uint64 conf;
+        int32 expo;
+        uint256 publishTime;
+    }
+
+    function getPriceUnsafe(bytes32 id) external view returns (Price memory price);
+}
+
+/// @title PythAdapter
+/// @notice AggregatorV3Interface adapter for Pyth Network price feeds on Arc testnet (#794).
+contract PythAdapter is AggregatorV3Interface {
+    IPyth public immutable pyth;
+    bytes32 public immutable feedId;
+
+    constructor(address _pyth, bytes32 _feedId) {
+        pyth = IPyth(_pyth);
+        feedId = _feedId;
+    }
+
+    function decimals() external pure override returns (uint8) {
+        return 8;
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        IPyth.Price memory p = pyth.getPriceUnsafe(feedId);
+        int256 scaledPrice;
+        if (p.expo < -8) {
+            uint256 divisor = 10 ** uint256(int256(-p.expo) - 8);
+            scaledPrice = int256(p.price) / int256(divisor);
+        } else {
+            uint256 multiplier = 10 ** uint256(int256(8 + p.expo));
+            scaledPrice = int256(p.price) * int256(multiplier);
+        }
+        return (1, scaledPrice, p.publishTime, p.publishTime, 1);
+    }
+}

--- a/contracts/src/adapters/PythAdapter.sol
+++ b/contracts/src/adapters/PythAdapter.sol
@@ -46,7 +46,12 @@ contract PythAdapter is AggregatorV3Interface {
     int32 internal constant MIN_EXPO = -77;
     int32 internal constant MAX_EXPO = 49;
 
+    error ZeroPyth();
+    error ZeroFeedId();
+
     constructor(address _pyth, bytes32 _feedId) {
+        if (_pyth == address(0)) revert ZeroPyth();
+        if (_feedId == bytes32(0)) revert ZeroFeedId();
         pyth = IPyth(_pyth);
         feedId = _feedId;
     }

--- a/contracts/src/interfaces/AggregatorV3Interface.sol
+++ b/contracts/src/interfaces/AggregatorV3Interface.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-/// @notice Minimal Chainlink price-feed interface (consolidated per issue #827).
+/// @notice Minimal Chainlink price-feed interface (consolidated per issue #827; file named for the canonical Chainlink symbol it declares).
 interface AggregatorV3Interface {
     function decimals() external view returns (uint8);
 

--- a/contracts/src/interfaces/IAggregatorV3.sol
+++ b/contracts/src/interfaces/IAggregatorV3.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Minimal Chainlink price-feed interface (consolidated per issue #827).
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}

--- a/contracts/test/PythAdapter.t.sol
+++ b/contracts/test/PythAdapter.t.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/adapters/PythAdapter.sol";
+
+contract MockPyth is IPyth {
+    int64 internal _price;
+    int32 internal _expo;
+    uint256 internal _publishTime;
+
+    constructor(int64 price_, int32 expo_, uint256 publishTime_) {
+        _price = price_;
+        _expo = expo_;
+        _publishTime = publishTime_;
+    }
+
+    function setPrice(int64 price_, int32 expo_, uint256 publishTime_) external {
+        _price = price_;
+        _expo = expo_;
+        _publishTime = publishTime_;
+    }
+
+    function getPriceUnsafe(bytes32) external view override returns (Price memory) {
+        return Price({
+            price: _price,
+            conf: 100,
+            expo: _expo,
+            publishTime: _publishTime
+        });
+    }
+}
+
+contract PythAdapterTest is Test {
+    MockPyth public pyth;
+    PythAdapter public adapter;
+    bytes32 public constant FEED_ID = bytes32(uint256(1));
+
+    function setUp() public {
+        pyth = new MockPyth(50000000000, -8, block.timestamp); // $500.00 at -8 decimals
+        adapter = new PythAdapter(address(pyth), FEED_ID);
+    }
+
+    function test_decimals() public view {
+        assertEq(adapter.decimals(), 8);
+    }
+
+    function test_latestRoundData_exponent_minus_8() public view {
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = adapter.latestRoundData();
+        assertEq(roundId, 1);
+        assertEq(answer, 50000000000); // 500 * 1e8 = 50,000,000,000
+        assertEq(startedAt, block.timestamp);
+        assertEq(updatedAt, block.timestamp);
+        assertEq(answeredInRound, 1);
+    }
+
+    function test_latestRoundData_exponent_minus_5() public {
+        pyth.setPrice(500000, -5, block.timestamp); // 5.00000 at -5 decimals
+        (, int256 answer, , , ) = adapter.latestRoundData();
+        assertEq(answer, 500000000); // 5 * 1e8 = 500,000,000
+    }
+
+    function test_latestRoundData_exponent_minus_10() public {
+        pyth.setPrice(5000000000000, -10, block.timestamp); // 500.0000000000
+        (, int256 answer, , , ) = adapter.latestRoundData();
+        assertEq(answer, 50000000000); // 500 * 1e8
+    }
+
+    function test_latestRoundData_exponent_positive() public {
+        pyth.setPrice(500, 2, block.timestamp); // 500 * 10^2 = 50,000
+        (, int256 answer, , , ) = adapter.latestRoundData();
+        assertEq(answer, 5000000000000); // 50,000 * 1e8 = 5,000,000,000,000
+    }
+
+    function test_latestRoundData_negative_price() public {
+        pyth.setPrice(-500, 2, block.timestamp); // -500 * 10^2 = -50,000
+        (, int256 answer, , , ) = adapter.latestRoundData();
+        assertEq(answer, -5000000000000); // -50,000 * 1e8 = -5,000,000,000,000
+    }
+}

--- a/contracts/test/PythAdapter.t.sol
+++ b/contracts/test/PythAdapter.t.sol
@@ -45,6 +45,19 @@ contract PythAdapterTest is Test {
         assertEq(adapter.decimals(), 8);
     }
 
+    // Constructor zero-guards — parity with the sibling StorkAggregatorV3Adapter
+    // (#1153 review): a zero pyth address or feed id can only ever be a
+    // deploy-script bug; revert at construction, not at first read.
+    function test_revert_zero_pyth_address() public {
+        vm.expectRevert(PythAdapter.ZeroPyth.selector);
+        new PythAdapter(address(0), FEED_ID);
+    }
+
+    function test_revert_zero_feed_id() public {
+        vm.expectRevert(PythAdapter.ZeroFeedId.selector);
+        new PythAdapter(address(pyth), bytes32(0));
+    }
+
     function test_latestRoundData_exponent_minus_8() public view {
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = adapter.latestRoundData();
         assertEq(roundId, 1);

--- a/contracts/test/PythAdapter.t.sol
+++ b/contracts/test/PythAdapter.t.sol
@@ -77,4 +77,45 @@ contract PythAdapterTest is Test {
         (, int256 answer, , , ) = adapter.latestRoundData();
         assertEq(answer, -5000000000000); // -50,000 * 1e8 = -5,000,000,000,000
     }
+
+    /// @notice THE regression case (#1153 review): expo = 69 was the one SILENT
+    ///         failure. 10**77 fits uint256 but exceeds int256.max, so the cast
+    ///         reinterpreted the multiplier negative and (price=-1, expo=69)
+    ///         returned large POSITIVE garbage — defeating PriceOracle's
+    ///         answer <= 0 guard in the setMaxFeedDeviationBps(0) config.
+    ///         Every larger exponent merely panicked; 69 lied. It must revert
+    ///         with the typed error, never return.
+    function test_revert_expo69_negative_price_no_positive_garbage() public {
+        pyth.setPrice(-1, 69, block.timestamp);
+        vm.expectRevert(abi.encodeWithSelector(PythAdapter.PriceExponentOutOfRange.selector, int32(69)));
+        adapter.latestRoundData();
+    }
+
+    function test_expo_at_upper_bound_scales_and_preserves_sign() public {
+        // expo = 49 is the provably-safe maximum: |int64| * 10**57 < int256.max.
+        pyth.setPrice(-3, 49, block.timestamp);
+        (, int256 answer,,,) = adapter.latestRoundData();
+        assertEq(answer, int256(-3) * int256(10 ** 57));
+        assertLt(answer, 0); // a negative price must never come out positive
+    }
+
+    function test_revert_just_above_upper_bound() public {
+        pyth.setPrice(1, 50, block.timestamp);
+        vm.expectRevert(abi.encodeWithSelector(PythAdapter.PriceExponentOutOfRange.selector, int32(50)));
+        adapter.latestRoundData();
+    }
+
+    function test_expo_at_lower_bound_truncates_toward_zero() public {
+        // expo = -77: divisor 10**69 dwarfs any int64 price — truncates to 0,
+        // which downstream answer <= 0 guards reject HONESTLY (no fabrication).
+        pyth.setPrice(type(int64).max, -77, block.timestamp);
+        (, int256 answer,,,) = adapter.latestRoundData();
+        assertEq(answer, 0);
+    }
+
+    function test_revert_just_below_lower_bound() public {
+        pyth.setPrice(1, -78, block.timestamp);
+        vm.expectRevert(abi.encodeWithSelector(PythAdapter.PriceExponentOutOfRange.selector, int32(-78)));
+        adapter.latestRoundData();
+    }
 }

--- a/contracts/test/StorkAggregatorV3Adapter.t.sol
+++ b/contracts/test/StorkAggregatorV3Adapter.t.sol
@@ -28,7 +28,6 @@ contract StorkAggregatorV3AdapterTest is Test {
     uint256 constant EXPECTED_6DEC = 392_600_000;
 
     address constant OWNER = address(0x1);
-    address constant ALICE = address(0x2);
 
     function setUp() public {
         vm.warp(1_000_000);

--- a/contracts/test/StorkAggregatorV3Adapter.t.sol
+++ b/contracts/test/StorkAggregatorV3Adapter.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/StorkAggregatorV3Adapter.sol";
+import "../src/PriceOracle.sol";
+
+/// @dev Minimal mock of the Stork on-chain getter — settable per-id value + timestamp.
+contract MockStork is IStorkTemporalNumericValueUnsafeGetter {
+    mapping(bytes32 => TemporalNumericValue) internal _values;
+
+    function set(bytes32 id, uint64 timestampNs, int192 quantizedValue) external {
+        _values[id] = TemporalNumericValue(timestampNs, quantizedValue);
+    }
+
+    function getTemporalNumericValueUnsafeV1(bytes32 id) external view returns (TemporalNumericValue memory) {
+        return _values[id];
+    }
+}
+
+contract StorkAggregatorV3AdapterTest is Test {
+    MockStork internal stork;
+    StorkAggregatorV3Adapter internal adapter;
+
+    bytes32 constant FEED_ID = keccak256("SPY/USD");
+    // $392.60 at Stork's 18-decimal quantization (3.926e20) and PriceOracle's 6 (392_600_000).
+    int192 constant STORK_392_60 = 392_600_000_000_000_000_000;
+    uint256 constant EXPECTED_6DEC = 392_600_000;
+
+    address constant OWNER = address(0x1);
+    address constant ALICE = address(0x2);
+
+    function setUp() public {
+        vm.warp(1_000_000);
+        stork = new MockStork();
+        adapter = new StorkAggregatorV3Adapter(address(stork), FEED_ID);
+    }
+
+    function _setFresh(int192 value) internal {
+        stork.set(FEED_ID, uint64(block.timestamp * 1e9), value);
+    }
+
+    // ── Adapter unit ──────────────────────────────────────────────
+
+    function test_decimals_is_18() public view {
+        assertEq(adapter.decimals(), 18);
+    }
+
+    function test_immutables() public view {
+        assertEq(address(adapter.stork()), address(stork));
+        assertEq(adapter.priceId(), FEED_ID);
+    }
+
+    function test_constructor_reverts_on_zero_stork() public {
+        vm.expectRevert(StorkAggregatorV3Adapter.ZeroStork.selector);
+        new StorkAggregatorV3Adapter(address(0), FEED_ID);
+    }
+
+    function test_constructor_reverts_on_zero_id() public {
+        vm.expectRevert(StorkAggregatorV3Adapter.ZeroPriceId.selector);
+        new StorkAggregatorV3Adapter(address(stork), bytes32(0));
+    }
+
+    function test_latestRoundData_maps_stork_value() public {
+        uint64 tsNs = uint64(block.timestamp * 1e9);
+        stork.set(FEED_ID, tsNs, STORK_392_60);
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            adapter.latestRoundData();
+        assertEq(answer, int256(STORK_392_60));
+        assertEq(updatedAt, block.timestamp); // ns / 1e9
+        assertEq(startedAt, block.timestamp);
+        assertEq(roundId, uint80(block.timestamp));
+        assertEq(answeredInRound, roundId); // carry-over guard always satisfied
+    }
+
+    function test_latestRoundData_uninitialized_feed_is_incomplete_round() public view {
+        // No value set → timestampNs 0 → updatedAt 0 (PriceOracle reads as incomplete round).
+        (, int256 answer,, uint256 updatedAt,) = adapter.latestRoundData();
+        assertEq(answer, 0);
+        assertEq(updatedAt, 0);
+    }
+
+    // ── Integration with PriceOracle (#724 read path) ─────────────
+
+    function _oracle(uint256 adminPrice) internal returns (PriceOracle o) {
+        vm.prank(OWNER);
+        o = new PriceOracle("SPY", adminPrice, OWNER);
+        vm.prank(OWNER);
+        o.setPriceFeed(address(adapter));
+    }
+
+    function test_setPriceFeed_caches_18_decimals() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        assertEq(o.feedDecimals(), 18);
+        assertEq(address(o.priceFeed()), address(adapter));
+    }
+
+    function test_oracle_reads_stork_via_adapter_scaled_to_6dec() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(STORK_392_60);
+        // 18-dec Stork $392.60 → 6-dec 392_600_000 through the adapter + PriceOracle.
+        assertEq(o.getPrice(), EXPECTED_6DEC);
+        assertTrue(o.isFresh());
+    }
+
+    function test_oracle_feed_precedence_in_band() public {
+        // Admin $392.60; Stork reads $450 (in the 50% band) → feed wins.
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(450_000_000_000_000_000_000); // $450 @ 18 dec
+        assertEq(o.getPrice(), 450_000_000);
+    }
+
+    function test_oracle_degrades_to_admin_on_stale_stork() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        // Stork value observed now, then time advances past the feed heartbeat while the
+        // admin reference stays fresh → PriceOracle degrades to admin (fail-soft).
+        _setFresh(450_000_000_000_000_000_000);
+        vm.warp(block.timestamp + o.feedStaleness() + 1);
+        assertEq(o.getPrice(), EXPECTED_6DEC); // admin, not the stale feed
+        assertTrue(o.isFresh());
+    }
+
+    function test_oracle_degrades_to_admin_on_negative_stork() public {
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(-1);
+        assertEq(o.getPrice(), EXPECTED_6DEC);
+    }
+
+    function test_oracle_out_of_band_stork_degrades_to_admin() public {
+        // Stork $5000 vs admin $392.60 — way outside the 50% band → degrade to admin.
+        PriceOracle o = _oracle(EXPECTED_6DEC);
+        _setFresh(5_000_000_000_000_000_000_000); // $5000 @ 18 dec
+        assertEq(o.getPrice(), EXPECTED_6DEC);
+    }
+}


### PR DESCRIPTION
Adds two AggregatorV3 adapters so the #724 PriceOracle (Chainlink-first, degrade-to-admin) can consume a real decentralized feed on Arc testnet, where Chainlink has no Data Feeds — and consolidates the duplicated AggregatorV3 interface into one shared file.

**Closes #794** — StorkAggregatorV3Adapter (Stork is live on Arc testnet, verified on-chain) + PythAdapter (with exponent bounds; `expo = 69` was the one exponent that defeated the int256 negative-price guard). Both are thin, view-only, undeployed until pointed at by `setPriceFeed`; PriceOracle keeps staleness/sanity enforcement and admin degrade.

**Closes #827** — one canonical `src/interfaces/AggregatorV3Interface.sol`; `PriceOracle.sol`, `StorkAggregatorV3Adapter.sol`, and `PythAdapter.sol` all import it; both local declarations deleted.

## #827 acceptance evidence

1. `grep -rE "interface (AggregatorV3Interface|IAggregatorV3)" contracts/src` → exactly one hit (`src/interfaces/AggregatorV3Interface.sol` — file renamed per review to match the canonical Chainlink symbol it declares; deviates from #827's proposed filename deliberately, the substance — one canonical declaration imported everywhere — holds).
2. `forge test` → 310 passed, 0 failed (post-rebase onto current main; includes the PythAdapter constructor zero-guard reverts added per review — parity with the Stork sibling).
3. PriceOracle bytecode-neutrality: `FOUNDRY_BYTECODE_HASH=none FOUNDRY_CBOR_METADATA=false forge inspect src/PriceOracle.sol:PriceOracle deployedBytecode | shasum -a 256` → `81838b2dd1e234fa1c9a9b8ae689773f…` on **both** main and this branch (identical). Raw `deployedBytecode` differs only in the solc CBOR metadata tail, which hashes source content — the executable code section is bit-identical, as an interface-declaration move must be.

Branch is rebased to 0-behind main. Contract change — Dan approves as contract owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
**Review parity additions (292362a5):** `DeployPythAdapter.s.sol` mirroring the Stork deploy script (`PYTH_CONTRACT` required from env — no on-chain-verified Arc Pyth deployment exists to bake in as a default) and `contracts/abis/PythAdapter.json` cached from forge output. Rebased 0-behind current main; forge 310/310 post-rebase.
