### PR TITLE
[infra] Pin ruff==0.15.13 across all CI workflows

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -34,7 +34,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install guards
-        run: pip install --quiet ruff deptry
+        # ruff pinned to match quality-gate.yml + main-format-guard.yml +
+        # .pre-commit-config.yaml — unpinned installs drift to whatever ruff
+        # just released. Bump all four together when intentionally upgrading.
+        run: pip install --quiet ruff==0.15.13 deptry
       - name: Undefined names (F821) — catches aliased-import NameErrors
         run: ruff check backend/archimedes --select F821 --no-cache
       - name: Byte-compile (no syntax / obvious import-time breakage)

--- a/.github/workflows/main-format-guard.yml
+++ b/.github/workflows/main-format-guard.yml
@@ -41,7 +41,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: pip install --quiet ruff
+      # Pinned to match quality-gate.yml's ruff-gate + .pre-commit-config.yaml's
+      # ruff-pre-commit rev — an unpinned install here silently drifts to
+      # whatever ruff just released, which can change what "formatted" means
+      # (e.g. a version that starts reformatting Markdown) and make this
+      # self-heal job fight every open PR for a reason unrelated to their
+      # diffs. Bump alongside quality-gate.yml + .pre-commit-config.yaml when
+      # intentionally upgrading ruff.
+      - run: pip install --quiet ruff==0.15.13
 
       - name: ruff format --check (surface the violation)
         id: check

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -60,7 +60,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install --quiet ruff
+      # Pinned to match .pre-commit-config.yaml's ruff-pre-commit rev — an
+      # unpinned install here silently drifts to whatever ruff just released,
+      # which can reformat files differently than the last commit that ran
+      # `ruff format .` and fail every open PR for a reason unrelated to its
+      # diff. Bump both together when intentionally upgrading ruff.
+      - run: pip install --quiet ruff==0.15.13
       - name: ruff format --check
         run: ruff format --check .
       - name: ruff check (critical rules only)
@@ -75,7 +80,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install --quiet ruff
+      # Pinned to match ruff-gate + .pre-commit-config.yaml (see comment there).
+      - run: pip install --quiet ruff==0.15.13
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Summary
`quality-gate.yml`'s ruff-gate jobs were already pinned to `ruff==0.15.13`, but `main-format-guard.yml` and `import-guard.yml` still did an unpinned `pip install --quiet ruff`. A newer ruff release started reformatting Markdown-embedded Python by default, which made the ruff-gate step fail on every open PR *and* on direct pushes to `main` since 2026-07-23, for reasons unrelated to each PR's actual diff.

This pins the remaining two workflows to the same `0.15.13` that `.pre-commit-config.yaml` and `quality-gate.yml` already use, so all four ruff install sites move in lockstep.

## Verify
- `ruff==0.15.13 format --check .` → `483 files already formatted` (reproduced locally against this branch)
- CI on this PR should show ruff-gate green again

## Anti-goals
- Not touching lint rule selection or `ruff.toml` — this is a version-pin fix only.