### PR TITLE
[infra] Escape $${ARCH} so templatefile() stops breaking terraform plan

### DIFF
--- a/infra/runner-user-data.sh
+++ b/infra/runner-user-data.sh
@@ -65,8 +65,14 @@ systemctl start docker
 # directly from AWS, same as infra/scripts/bake-backend-ami.sh does.
 # Arch-aware: hardcoding x86_64 would break bootstrap (and with it ECR login
 # + secret fetch) the day runner_instance_type moves to Graviton (review).
+# NOTE: Terraform renders this file through `templatefile()`, so a bare
+# dollar-brace sequence is TERRAFORM interpolation, not shell — including inside
+# comments, which the template engine does not treat as comments. Shell variables
+# must be doubled (`$${ARCH}`) so Terraform emits a single dollar-brace for bash
+# to expand at boot; same convention as the REGION line further down. Leaving it
+# undoubled fails `terraform plan` with: vars map does not contain key "ARCH".
 ARCH="$(uname -m)"   # x86_64 | aarch64 — matches AWS's installer naming
-curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o /tmp/awscliv2.zip
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$${ARCH}.zip" -o /tmp/awscliv2.zip
 unzip -q /tmp/awscliv2.zip -d /tmp
 /tmp/aws/install
 rm -rf /tmp/awscliv2.zip /tmp/aws


### PR DESCRIPTION
## Summary

`terraform plan` and `terraform validate` have been **hard-failing for the entire `infra/` directory** — not just the runner resource. Dan hit this today trying to inspect infrastructure drift:

```
Error: Invalid function argument
  on runner_ec2.tf line 220, in resource "aws_instance" "runner":
  Invalid value for "vars" parameter: vars map does not contain key "ARCH",
  referenced at ./runner-user-data.sh:69,61-65.
```

## Root cause

`infra/runner-user-data.sh` is rendered by Terraform's `templatefile()`, where a bare dollar-brace is **Terraform interpolation**, not shell.

Commit `5d88fa58` ("Wave-2 review: arch-aware awscli install") correctly introduced a **shell** variable so the bootstrap survives a move to Graviton:

```bash
ARCH="$(uname -m)"
curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" ...
```

…but referenced it undoubled, so Terraform tried to resolve `ARCH` from the vars map and failed. The other four references in the file (`aws_region`, `ecr_registry`, `ecr_registry_host`, `log_group_name`) are legitimate template vars and were fine.

## Fix

Double the sequence to `$${ARCH}` so Terraform emits a single dollar-brace and bash expands it at boot. This is **the convention the file already used** for the REGION line further down — which is exactly why that one never broke.

The added explanatory comment is doubled for the same reason: `templatefile()` does **not** treat `#` lines as comments, so an unescaped dollar-brace inside a comment fails the render identically. (Found the hard way while writing this fix — worth the comment so the next person doesn't repeat it.)

## Verification

```
$ terraform validate
Success! The configuration is valid.     # previously: Error in function call
```

Runtime behavior is **unchanged** — the rendered user-data is byte-identical to what `5d88fa58` intended. This is purely un-breaking the render.

## Blast radius

Zero at runtime. `aws_instance.runner` carries `lifecycle { ignore_changes = [ami, user_data] }`, so this does not replace or reboot the funds-adjacent runner singleton even once applied.

## Why this matters now

This is on the critical path for #1065 (runner relocation `terraform apply`) — the runners have been stranded since the Fargate cutover, and the apply could not even be *planned* while this was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M