### PR TITLE
[deps] Fix arxiv floor drift between environment.yml and requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -85,7 +85,7 @@ dependencies:
       - boto3>=1.43.46                 # S3 artifact reads for KB pipeline output (embeddings, KG). Aligned with backend/requirements.txt (dependabot batch 2026-07-13).
 
       # --- Paper ingestion (Q-fin corpus) ---
-      - arxiv>=2.1                    # arxiv API client
+      - arxiv>=4.0.0                  # arxiv API client. Floor aligned with backend/requirements.txt (was still pinned at 2.1, a pre-existing drift with no open Dependabot PR to attach the fix to).
       - pypdf>=6.14.2                 # PDF text extraction. Floor 6.13.3 closed 8 CVEs incl GHSA-jm82-fx9c-mx94 (CVE bump 2026-06-25). Aligned with backend/requirements.txt (dependabot batch 2026-07-13).
 
       # --- Semantic retrieval (paper_rag MiniLM embeddings, issue #874) ---


### PR DESCRIPTION
## Summary
environment.yml pins `arxiv>=2.1`; `backend/requirements.txt` has been at `arxiv>=4.0.0` for a while (see the comment above that line about the `requests<2.34` pin arxiv forces). No open Dependabot PR touches this dep, so the drift needed a manual fix rather than riding along on a bump.

Found this while reviewing the current backend Dependabot PR batch (#1162/#1163/#1165/#1166/#1167) and checking whether `environment.yml` and `backend/requirements.txt` still agree per the dependency-hygiene convention in CLAUDE.md.

## Scope
`environment.yml` only, one line.

## Verify
```
grep -n "arxiv>=" environment.yml backend/requirements.txt
```
Both should read `arxiv>=4.0.0`.

Local: `pip install -r backend/requirements.txt` resolves `arxiv-4.0.0` cleanly; full non-integration suite still 2933 passed / 6 pre-existing unrelated failures (missing local `alembic` binary, not this repo's tests).

## Anti-goals
Not touching any other environment.yml line here — the other backend Dependabot PRs each carry their own alignment fix.