### PR TITLE
[frontend] HOTFIX: match react-dom to react 19.2.8 — production renders a blank page

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@circle-fin/modular-wallets-core": "^1.0.15",
         "react": "^19.2.8",
-        "react-dom": "^19.2.7",
+        "react-dom": "^19.2.8",
         "react-force-graph-2d": "^1.29.1",
         "viem": "^2.55.8"
       },
@@ -5475,15 +5475,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-force-graph-2d": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@circle-fin/modular-wallets-core": "^1.0.15",
     "react": "^19.2.8",
-    "react-dom": "^19.2.7",
+    "react-dom": "^19.2.8",
     "react-force-graph-2d": "^1.29.1",
     "viem": "^2.55.8"
   },


### PR DESCRIPTION
## 🔴 Production is down

`https://archimedes-arc.com` serves HTTP 200 and every hashed asset returns 200 — but the page is **blank**. The app throws before React mounts.

## Root cause

Dependabot commit `5a969476` bumped `react` 19.2.6 → **19.2.8** (plus `@types/react`) but left `react-dom` at `^19.2.7`. `react-dom` asserts an **exact** version match at module init:

```js
var Bp = r.version;
if (Bp !== `19.2.7`) throw Error(a(527, Bp, `19.2.7`));   // React error #527
```

Resolved on `main` today: `react@19.2.8` vs `react-dom@19.2.7` → **throws** → nothing mounts.

> The `secp256k1` frame in the console stack is a **red herring** — it is just the shared CJS-interop chunk that lazily requires react-dom.

## Fix

One line: `react-dom: ^19.2.8` (+ regenerated lockfile). Both now resolve to 19.2.8.

## Verification

| Check | Result |
|---|---|
| `npm ci` | ✅ exit 0 |
| `npm run build` | ✅ exit 0 |
| Built bundle guard | ✅ expects `19.2.8` vs bundled react `19.2.8` (was 19.2.7 vs 19.2.8) |
| Serve `dist/` + load in browser | ✅ **full app renders** (nav, hero, onboarding modal) — prod renders nothing |

## Follow-up (separate PR)

`.github/workflows/` contains **no CloudFront invalidation**, so this fix propagates only on cache TTL, and index.html/asset skew can recur on any deploy. An infra PR will add invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)