### PR TITLE
[backend] Make the rigor verdict identical across list, passport, and deploy gate

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -481,23 +481,40 @@ async def list_strategies(
     from archimedes.models.strategy_generators import wallet_can_publish
 
     status_filter = StrategyStatus(status) if status else None
-    strats = strategy_provider().list_strategies(status=status_filter)
-    total = len(strats)
-    # Grade over the FULL library, not the paginated window (#1173). The detail
-    # route grades via _library_cohort_including() — i.e. the whole library — so
-    # scoring the list over `window` made the same strategy's badge depend on
-    # which page it happened to land on: a short window can fall under
-    # MIN_LIBRARY_N_FOR_PBO_GATING (criterion 4 skipped) and the CSCV/PBO value
-    # itself shifts with the cohort. Verified live before this fix: strategy
-    # d90b357a…4bbd graded False in a 5-item window but True in the full-library
-    # view and True on its own detail/passport route — the exact list-vs-detail
-    # contradiction dfa8fc1 was written to prevent, and which the docstring
-    # above still asserts cannot happen.
+
+    # Grade over the FULL library — never a filtered or paginated subset (#1173).
+    # The detail route grades via _library_cohort_including(), which calls
+    # list_strategies() with NO status filter, so the cohort here must match it
+    # exactly or the same strategy's badge changes depending on how it was
+    # requested. Two distinct ways that broke:
+    #
+    #   1. Pagination. Scoring over `window` made the badge depend on which page
+    #      a strategy landed on: a short window can fall under
+    #      MIN_LIBRARY_N_FOR_PBO_GATING (criterion 4 skipped) and the CSCV/PBO
+    #      value itself shifts with the cohort. Verified live: strategy
+    #      d90b357a…4bbd graded False in a 5-item window but True in the
+    #      full-library view and True on its own detail/passport route.
+    #   2. The `status` filter. Grading `list_strategies(status=...)` graded a
+    #      SUBSET, so `?status=candidate` and `?status=validated` could return
+    #      different verdicts for the same strategy, and both could disagree with
+    #      the passport. Same class of bug as (1), same fix — the filter is a
+    #      display concern and must not reach the cohort.
+    #
+    # Both are the list-vs-detail contradiction dfa8fc1 was written to prevent,
+    # and which this route's docstring asserts cannot happen.
     #
     # Bonus: the cache key (see cohort_key) is derived from the cohort's ids, so
-    # grading the full library also collapses the previous one-cohort-computation
-    # -per-offset (~6s each) into a single shared entry.
-    rigor_results = _live_rigor_results_for_strategies(strats)
+    # grading the full library collapses the previous one-cohort-computation-per
+    # -offset AND per-status-filter (~6s each) into a single shared entry.
+    library = strategy_provider().list_strategies()
+    rigor_results = _live_rigor_results_for_strategies(library)
+
+    # Filter/paginate only AFTER grading. Delegated to the provider rather than
+    # filtered in-process so the `status` semantics stay byte-identical to the
+    # previous behaviour (file-declared status, before the live-gate promotion
+    # overlay — see the docstring note above).
+    strats = strategy_provider().list_strategies(status=status_filter) if status_filter else library
+    total = len(strats)
     window = strats[offset : offset + limit]
     caller = get_verified_wallet(request)
     responses: list[StrategyResponse] = []

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -483,8 +483,22 @@ async def list_strategies(
     status_filter = StrategyStatus(status) if status else None
     strats = strategy_provider().list_strategies(status=status_filter)
     total = len(strats)
+    # Grade over the FULL library, not the paginated window (#1173). The detail
+    # route grades via _library_cohort_including() — i.e. the whole library — so
+    # scoring the list over `window` made the same strategy's badge depend on
+    # which page it happened to land on: a short window can fall under
+    # MIN_LIBRARY_N_FOR_PBO_GATING (criterion 4 skipped) and the CSCV/PBO value
+    # itself shifts with the cohort. Verified live before this fix: strategy
+    # d90b357a…4bbd graded False in a 5-item window but True in the full-library
+    # view and True on its own detail/passport route — the exact list-vs-detail
+    # contradiction dfa8fc1 was written to prevent, and which the docstring
+    # above still asserts cannot happen.
+    #
+    # Bonus: the cache key (see cohort_key) is derived from the cohort's ids, so
+    # grading the full library also collapses the previous one-cohort-computation
+    # -per-offset (~6s each) into a single shared entry.
+    rigor_results = _live_rigor_results_for_strategies(strats)
     window = strats[offset : offset + limit]
-    rigor_results = _live_rigor_results_for_strategies(window)
     caller = get_verified_wallet(request)
     responses: list[StrategyResponse] = []
     with get_session() as session:

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -79,7 +79,32 @@ def _strategy_rigor_status(strategy_id: str) -> tuple[bool, bool]:
     """
     strat = strategy_provider().get_strategy(strategy_id)
     if strat is not None:
-        return True, bool(getattr(strat, "passes_rigor_gate", False))
+        # Use the LIVE verdict, not the provider object's attribute (#1173).
+        # LocalStrategyProvider sets passes_rigor_gate = False unconditionally on
+        # every curated Strategy (fail-closed by construction, 56cc9bde); the real
+        # verdict is overlaid downstream in _to_strategy_response. Reading the raw
+        # attribute here therefore made EVERY curated strategy undeployable at the
+        # default strictness with the message "has not passed the rigor gate —
+        # server-side rigor enforcement", which is simply false. Perverse symptom:
+        # deploying at strictness >= 2 worked, because that path takes the
+        # _deployable_levels branch below, which already consults the live gate.
+        #
+        # Graded against the FULL library cohort — same cohort the list badge and
+        # the passport use — because the verdict is cohort-dependent (cohort-scoped
+        # PBO/CSCV; a cohort under MIN_LIBRARY_N_FOR_PBO_GATING skips criterion 4).
+        # Grading `strat` alone would let the deploy gate disagree with the badge.
+        from archimedes.services.live_rigor_gate import RigorGateVerdict, verdicts_for_strategies
+
+        try:
+            cohort = list(strategy_provider().list_strategies())
+            if not any(getattr(x, "id", None) == strategy_id for x in cohort):
+                cohort.append(strat)
+            verdict = verdicts_for_strategies(cohort).get(strategy_id, RigorGateVerdict.pending())
+        except Exception:
+            # Fail closed, consistent with this function's contract.
+            logger.exception("live rigor verdict failed for %s — failing closed", sanitize_log_value(strategy_id))
+            return True, False
+        return True, bool(verdict.passes)
 
     from archimedes.db import get_session
     from archimedes.services.passport_loader import get_passport

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -67,7 +67,7 @@ async def _anchor_strategies_async(strategy_ids: list[str]) -> None:
             logger.warning("anchor failed for strategy %s (non-fatal): %s", sanitize_log_value(sid), exc)
 
 
-def _strategy_rigor_status(strategy_id: str) -> tuple[bool, bool]:
+def _strategy_rigor_status(strategy_id: str, cohort_cache: dict | None = None) -> tuple[bool, bool]:
     """``(found, passes_rigor_gate)`` for a strategy id, resolved across the curated
     provider AND the generated ``strategy_passports`` table — the same two sources
     ``GET /api/strategies/{id}`` uses. Server-side source of truth for the deploy
@@ -76,6 +76,13 @@ def _strategy_rigor_status(strategy_id: str) -> tuple[bool, bool]:
     Fail-closed: if the DB lookup raises (cannot verify a generated strategy), the
     strategy is reported as not-found so the caller refuses the deploy rather than
     waving through an unverifiable one.
+
+    ``cohort_cache`` (optional) is a caller-owned dict used to compute the curated
+    full-library verdict map at most ONCE per request. ``verdicts_for_strategies``
+    is uncached and does a fresh ``get_all_daily_returns`` read plus a full cohort
+    CSCV/PBO pass on every call (~6s), so a vault bound to k curated strategies
+    otherwise paid that k times inside a single deploy request. Only the canonical
+    full-library map is ever cached — see the in-cohort guard below.
     """
     strat = strategy_provider().get_strategy(strategy_id)
     if strat is not None:
@@ -97,9 +104,21 @@ def _strategy_rigor_status(strategy_id: str) -> tuple[bool, bool]:
 
         try:
             cohort = list(strategy_provider().list_strategies())
-            if not any(getattr(x, "id", None) == strategy_id for x in cohort):
-                cohort.append(strat)
-            verdict = verdicts_for_strategies(cohort).get(strategy_id, RigorGateVerdict.pending())
+            in_cohort = any(getattr(x, "id", None) == strategy_id for x in cohort)
+            # Reuse the cached map ONLY for a strategy that is genuinely in the
+            # library list. A strategy missing from it needs `strat` appended,
+            # which yields a different (one-off) cohort — caching that map would
+            # let a later missing strategy miss the dict and silently degrade to
+            # `pending` → fail-closed → a spurious "not passed the rigor gate".
+            if in_cohort and cohort_cache is not None and "verdicts" in cohort_cache:
+                verdicts = cohort_cache["verdicts"]
+            else:
+                if not in_cohort:
+                    cohort.append(strat)
+                verdicts = verdicts_for_strategies(cohort)
+                if in_cohort and cohort_cache is not None:
+                    cohort_cache["verdicts"] = verdicts
+            verdict = verdicts.get(strategy_id, RigorGateVerdict.pending())
         except Exception:
             # Fail closed, consistent with this function's contract.
             logger.exception("live rigor verdict failed for %s — failing closed", sanitize_log_value(strategy_id))
@@ -283,6 +302,9 @@ def _assert_strategies_pass_rigor(
     # level 1, so no live per-level ladder computation is needed. This also keeps
     # the default deploy path unchanged for callers that don't opt into strictness.
     if level <= STRICTEST_LEVEL:
+        # Request-scoped: the curated full-library verdict map is computed at most
+        # once for this deploy, not once per strategy_id (see _strategy_rigor_status).
+        cohort_cache: dict = {}
         for sid in strategy_ids:
             # Ownership gate (#1073): `_strategy_rigor_status` below resolves the
             # passport badge without regard to ownership, so a private/unpublished
@@ -296,7 +318,7 @@ def _assert_strategies_pass_rigor(
                 if visible is False:
                     raise HTTPException(status_code=422, detail=f"Strategy '{sid}' not found — cannot deploy.")
 
-            found, passes = _strategy_rigor_status(sid)
+            found, passes = _strategy_rigor_status(sid, cohort_cache=cohort_cache)
             if not found:
                 raise HTTPException(status_code=422, detail=f"Strategy '{sid}' not found — cannot deploy.")
             if not passes:

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -242,6 +242,50 @@ class TestSingleStrategyCohortContext:
         assert strategies_routes._live_rigor_result_for_one(lib[1]) is sentinel
         assert captured["cohort_ids"] == ["s0", "s1"]
 
+    @pytest.mark.asyncio
+    async def test_list_route_grades_full_library_not_the_page(self, monkeypatch):
+        """REGRESSION (#1173): the LIST badge must be graded over the whole library,
+        never the paginated window.
+
+        The detail route grades via ``_library_cohort_including`` (the test above
+        pins that), so grading the list over ``strats[offset:offset+limit]`` made
+        the same strategy's badge depend on which page it landed on — a short window
+        can fall under ``MIN_LIBRARY_N_FOR_PBO_GATING`` (criterion 4 skipped) and the
+        cohort-scoped PBO/CSCV value itself shifts with membership. Verified against
+        production before the fix: strategy ``d90b357a…4bbd`` graded False in a
+        5-item window but True in the full-library view and True on its own
+        detail/passport route — the exact list-vs-detail contradiction dfa8fc1 was
+        written to prevent.
+        """
+        from archimedes.api import strategies_routes
+        from archimedes.main import app
+
+        lib = [MagicMock(id=f"s{i}", status=None) for i in range(30)]
+        provider = MagicMock()
+        provider.list_strategies.return_value = lib
+        monkeypatch.setattr(strategies_routes, "strategy_provider", lambda: provider)
+
+        captured = {}
+
+        def _fake_batch(strategies):
+            captured["cohort_ids"] = [s.id for s in strategies]
+            return {}
+
+        monkeypatch.setattr(strategies_routes, "_live_rigor_results_for_strategies", _fake_batch)
+
+        # The cohort is handed to the gate BEFORE any response serialization, so we
+        # assert on it regardless of whether serializing these MagicMock strategies
+        # succeeds. raise_app_exceptions=False keeps a serialization 500 from
+        # masking the assertion we actually care about.
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.get("/api/strategies/?limit=5&offset=25")
+
+        assert captured.get("cohort_ids") == [s.id for s in lib], (
+            "list route must grade the FULL library cohort; got a "
+            f"{len(captured.get('cohort_ids', []))}-item cohort for a 5-item page"
+        )
+
 
 class TestRigorGateVerdict:
     def test_passes_only_truthy_for_pass(self):

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -740,3 +740,73 @@ async def test_single_strategy_endpoint_numeric_fields_equal_live_gate(monkeypat
     assert served["out_of_sample_sharpe"] == pytest.approx(expected.oos_sharpe, rel=1e-9)
     assert served["deflated_sharpe_ratio"] == pytest.approx(expected.deflated_sharpe, rel=1e-9)
     assert served["passes_rigor_gate"] == expected.passes_all
+
+
+# ── Cohort invariance under the ?status= filter (#1172 review follow-up) ────
+#
+# Fixing the PAGINATION dependence alone left a second way for the same badge to
+# change with how it was requested: the route graded
+# `list_strategies(status=...)`, a SUBSET, while the detail/passport path grades
+# `_library_cohort_including()` — which calls `list_strategies()` with NO filter.
+# So `?status=candidate` and `?status=validated` could disagree with each other
+# and with the passport for one strategy. The cohort must be the full library;
+# `status` is a display concern only.
+
+
+@pytest.mark.asyncio
+async def test_list_route_grades_full_library_regardless_of_status_filter(monkeypatch):
+    """The graded cohort is byte-identical with and without ?status=, and equals
+    the unfiltered library — the same cohort _library_cohort_including() builds."""
+    import archimedes.api.strategies_routes as sr
+    from archimedes.main import app
+
+    seen_cohorts: list[list[str]] = []
+
+    def _spy(strategies):
+        seen_cohorts.append([s.id for s in strategies])
+        return {}
+
+    monkeypatch.setattr(sr, "_live_rigor_results_for_strategies", _spy)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r_all = await client.get("/api/strategies/?limit=3")
+        r_candidate = await client.get("/api/strategies/?limit=3&status=candidate")
+        r_validated = await client.get("/api/strategies/?limit=3&status=validated")
+
+    assert r_all.status_code == 200
+    assert r_candidate.status_code == 200
+    assert r_validated.status_code == 200
+
+    full_library = [s.id for s in sr.strategy_provider().list_strategies()]
+    assert len(seen_cohorts) == 3, "each request must grade exactly one cohort"
+    for cohort in seen_cohorts:
+        assert cohort == full_library
+
+    # And the filter still actually filters the RESPONSE — the fix must not have
+    # turned ?status= into a no-op.
+    assert r_candidate.json()["total"] <= r_all.json()["total"]
+
+
+@pytest.mark.asyncio
+async def test_list_route_grades_full_library_regardless_of_pagination(monkeypatch):
+    """Companion to the above: the cohort is also independent of offset/limit,
+    which is the original #1173 defect. Pinned so neither can regress alone."""
+    import archimedes.api.strategies_routes as sr
+    from archimedes.main import app
+
+    seen_cohorts: list[list[str]] = []
+    monkeypatch.setattr(
+        sr,
+        "_live_rigor_results_for_strategies",
+        lambda strategies: (seen_cohorts.append([s.id for s in strategies]), {})[1],
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.get("/api/strategies/?limit=2&offset=0")
+        await client.get("/api/strategies/?limit=2&offset=4")
+        await client.get("/api/strategies/?limit=100&offset=0")
+
+    full_library = [s.id for s in sr.strategy_provider().list_strategies()]
+    assert len(seen_cohorts) == 3
+    for cohort in seen_cohorts:
+        assert cohort == full_library

--- a/backend/tests/test_vault_metadata_anchor.py
+++ b/backend/tests/test_vault_metadata_anchor.py
@@ -8,6 +8,7 @@ survives anchor failures without breaking the DB write.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -37,10 +38,26 @@ def _make_passport(sid: str, methodology_hash: str | None = "abcd1234" * 8):
     return mock
 
 
+@contextlib.contextmanager
+def _rigor_passes():
+    """Stub the deploy gate to "this strategy is deployable".
+
+    These tests exercise metadata anchoring, not the rigor gate. They previously
+    passed only incidentally: the curated branch of ``_strategy_rigor_status`` read
+    ``getattr(strat, "passes_rigor_gate", False)`` off a ``MagicMock`` passport,
+    which is truthy for ANY attribute. Since #1173 that branch consults the live
+    gate (a MagicMock passport has no persisted returns → ``pending`` → 422), so the
+    intent has to be stated explicitly rather than ridden in on mock truthiness.
+    """
+    with patch("archimedes.api.vaults_routes._strategy_rigor_status", return_value=(True, True)):
+        yield
+
+
 class TestVaultMetadataAnchor:
     @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
+    @_rigor_passes()
     def test_metadata_post_calls_anchor_once_per_strategy_id(self, mock_provider, mock_publisher, mock_owner):
         # strategy_provider is now a lazily-cached accessor (strategy_provider()),
         # so the mocked callable's return_value stands in for the provider instance.
@@ -68,6 +85,7 @@ class TestVaultMetadataAnchor:
     @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
+    @_rigor_passes()
     def test_metadata_post_skips_passports_without_methodology_hash(self, mock_provider, mock_publisher, mock_owner):
         def get_strat(sid):
             if sid == "s2":
@@ -97,6 +115,7 @@ class TestVaultMetadataAnchor:
     @patch("archimedes.api.vaults_routes.chain_executor.get_vault_owner", new_callable=AsyncMock)
     @patch("archimedes.api.vaults_routes.strategy_publisher")
     @patch("archimedes.api.vaults_routes.strategy_provider")
+    @_rigor_passes()
     def test_metadata_post_succeeds_when_anchor_raises(self, mock_provider, mock_publisher, mock_owner):
         mock_provider.return_value.get_strategy.side_effect = _make_passport
         mock_publisher.anchor = AsyncMock(side_effect=RuntimeError("simulated chain failure"))

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -470,9 +470,7 @@ def test_deploy_gate_computes_cohort_verdicts_once_for_many_strategies():
         patch(f"{LRG}.verdicts_for_strategies", side_effect=_verdicts),
     ):
         provider.return_value.list_strategies.return_value = cohort
-        provider.return_value.get_strategy.side_effect = lambda sid: next(
-            (s for s in cohort if s.id == sid), None
-        )
+        provider.return_value.get_strategy.side_effect = lambda sid: next((s for s in cohort if s.id == sid), None)
         _assert_strategies_pass_rigor(ids)  # must not raise
 
     assert len(calls) == 1, f"expected 1 cohort computation, got {len(calls)}"

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -180,7 +180,7 @@ def test_assert_empty_list_is_noop():
 
 def test_assert_blocks_if_any_one_fails():
     # All must pass; one failing id blocks the whole deploy.
-    def _status(sid):
+    def _status(sid, cohort_cache=None):
         return (True, sid != "bad")
 
     with patch(f"{V}._strategy_rigor_status", side_effect=_status), pytest.raises(HTTPException) as exc:
@@ -444,3 +444,64 @@ async def test_create_vault_allows_owner_to_deploy_private_strategy():
     body = resp.json()
     assert body["vault_address"] == "0xOwnerDeployedAddress"
     mock_create.assert_awaited_once()  # owner → gate lets it through
+
+
+# ── Cohort map computed once per deploy (#1172 review follow-up) ───────────
+#
+# `verdicts_for_strategies` is UNCACHED: every call re-reads
+# get_all_daily_returns and re-runs a full cohort CSCV/PBO pass (~6s by the
+# route's own measurement). Grading the deploy against the full library — the
+# correctness fix — therefore made a vault bound to k curated strategies pay
+# that k times inside one request. The map must be built at most once.
+
+
+def test_deploy_gate_computes_cohort_verdicts_once_for_many_strategies():
+    """A 3-strategy deploy triggers exactly ONE verdicts_for_strategies call."""
+    ids = ["s1", "s2", "s3"]
+    cohort = [_Strat(True, sid=i) for i in ids]
+    calls: list[int] = []
+
+    def _verdicts(strategies):
+        calls.append(len(strategies))
+        return {s.id: RigorGateVerdict.passed() for s in strategies}
+
+    with (
+        patch(f"{V}.strategy_provider") as provider,
+        patch(f"{LRG}.verdicts_for_strategies", side_effect=_verdicts),
+    ):
+        provider.return_value.list_strategies.return_value = cohort
+        provider.return_value.get_strategy.side_effect = lambda sid: next(
+            (s for s in cohort if s.id == sid), None
+        )
+        _assert_strategies_pass_rigor(ids)  # must not raise
+
+    assert len(calls) == 1, f"expected 1 cohort computation, got {len(calls)}"
+    assert calls[0] == len(cohort), "and it must be graded over the FULL library"
+
+
+def test_deploy_gate_does_not_cache_a_one_off_cohort():
+    """A strategy MISSING from list_strategies() is graded on a one-off cohort
+    (itself appended). That map must NOT be cached and reused, or a second such
+    strategy would miss the dict, degrade to `pending`, and be wrongly refused."""
+    listed = [_Strat(True, sid="listed")]
+    missing_a = _Strat(True, sid="missing-a")
+    missing_b = _Strat(True, sid="missing-b")
+    by_id = {s.id: s for s in (listed[0], missing_a, missing_b)}
+    seen: list[list[str]] = []
+
+    def _verdicts(strategies):
+        seen.append([s.id for s in strategies])
+        return {s.id: RigorGateVerdict.passed() for s in strategies}
+
+    with (
+        patch(f"{V}.strategy_provider") as provider,
+        patch(f"{LRG}.verdicts_for_strategies", side_effect=_verdicts),
+    ):
+        provider.return_value.list_strategies.return_value = listed
+        provider.return_value.get_strategy.side_effect = by_id.get
+        # Neither unlisted strategy may be refused.
+        _assert_strategies_pass_rigor(["missing-a", "missing-b"])
+
+    assert len(seen) == 2, "each unlisted strategy needs its own cohort"
+    assert seen[0] == ["listed", "missing-a"]
+    assert seen[1] == ["listed", "missing-b"]

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -19,9 +19,13 @@ from archimedes.api.vaults_routes import (
     _strategy_record_visible,
     _strategy_rigor_status,
 )
+from archimedes.services.live_rigor_gate import RigorGateVerdict
 from fastapi import HTTPException
 
 V = "archimedes.api.vaults_routes"
+# The curated deploy-gate branch imports the live gate lazily (inside the function)
+# to avoid a route<->service import cycle, so patch the SOURCE module here.
+LRG = "archimedes.services.live_rigor_gate"
 
 
 @contextlib.contextmanager
@@ -45,8 +49,10 @@ def _override_verified_wallet(app, wallet: str = "0x0000000000000000000000000000
 
 
 class _Strat:
-    def __init__(self, passes):
+    def __init__(self, passes, sid="s1"):
         self.passes_rigor_gate = passes
+        # The cohort build dedupes on .id, so the stub needs one.
+        self.id = sid
 
 
 # ── _strategy_rigor_status ────────────────────────────────────────────────
@@ -55,14 +61,83 @@ class _Strat:
 def test_status_curated_passing():
     # strategy_provider is now a lazily-cached accessor (strategy_provider());
     # patch the name wholesale and configure the mocked callable's return_value.
-    with patch(f"{V}.strategy_provider") as mock_provider:
+    # The curated branch reads the LIVE gate (#1173), so stub that too.
+    with (
+        patch(f"{V}.strategy_provider") as mock_provider,
+        patch(f"{LRG}.verdicts_for_strategies", return_value={"s1": RigorGateVerdict.passed()}),
+    ):
         mock_provider.return_value.get_strategy.return_value = _Strat(True)
         assert _strategy_rigor_status("s1") == (True, True)
 
 
 def test_status_curated_failing():
-    with patch(f"{V}.strategy_provider") as mock_provider:
+    with (
+        patch(f"{V}.strategy_provider") as mock_provider,
+        patch(f"{LRG}.verdicts_for_strategies", return_value={"s1": RigorGateVerdict.failed()}),
+    ):
         mock_provider.return_value.get_strategy.return_value = _Strat(False)
+        assert _strategy_rigor_status("s1") == (True, False)
+
+
+def test_status_curated_uses_live_verdict_not_provider_attribute():
+    """REGRESSION (#1173): a curated strategy must be deployable when the LIVE gate
+    passes it, even though the provider object always carries
+    ``passes_rigor_gate = False``.
+
+    ``LocalStrategyProvider`` sets that attribute to False unconditionally
+    (fail-closed by construction, 56cc9bde) and the real verdict is overlaid
+    downstream. Reading the raw attribute here made EVERY curated strategy
+    undeployable at the default strictness with a message asserting it "has not
+    passed the rigor gate" — a false statement — while deploying at strictness >= 2
+    worked, because that path consults the live gate. This test pins the live
+    verdict as the source of truth.
+    """
+    with (
+        patch(f"{V}.strategy_provider") as mock_provider,
+        patch(f"{LRG}.verdicts_for_strategies", return_value={"s1": RigorGateVerdict.passed()}),
+    ):
+        # Provider says False — the historical bug source.
+        mock_provider.return_value.get_strategy.return_value = _Strat(False)
+        assert _strategy_rigor_status("s1") == (True, True)
+
+
+def test_status_curated_grades_against_full_library_cohort():
+    """REGRESSION (#1173): the deploy gate must grade against the shared FULL-library
+    cohort, never a 1-item list.
+
+    The verdict is cohort-dependent (cohort-scoped PBO/CSCV; a cohort under
+    MIN_LIBRARY_N_FOR_PBO_GATING skips criterion 4), so grading a strategy alone
+    would let the deploy gate disagree with the list badge and the passport.
+    """
+    strat = _Strat(False, sid="s1")
+    library = [_Strat(False, sid=f"other{i}") for i in range(12)] + [strat]
+    seen: dict = {}
+
+    def _capture(strategies):
+        seen["ids"] = [s.id for s in strategies]
+        return {"s1": RigorGateVerdict.passed()}
+
+    with (
+        patch(f"{V}.strategy_provider") as mock_provider,
+        patch(f"{LRG}.verdicts_for_strategies", side_effect=_capture),
+    ):
+        mock_provider.return_value.get_strategy.return_value = strat
+        mock_provider.return_value.list_strategies.return_value = library
+        assert _strategy_rigor_status("s1") == (True, True)
+
+    assert seen["ids"] == [s.id for s in library], (
+        "deploy gate must grade against the full library cohort, not the strategy alone; "
+        f"got a {len(seen.get('ids', []))}-item cohort"
+    )
+
+
+def test_status_curated_fails_closed_when_live_gate_raises():
+    """A live-gate failure must not wave a deploy through."""
+    with (
+        patch(f"{V}.strategy_provider") as mock_provider,
+        patch(f"{LRG}.verdicts_for_strategies", side_effect=RuntimeError("boom")),
+    ):
+        mock_provider.return_value.get_strategy.return_value = _Strat(True)
         assert _strategy_rigor_status("s1") == (True, False)
 
 


### PR DESCRIPTION
## Summary
Two defects made the **same strategy report different rigor verdicts depending on which surface asked**. This class of bug has recurred three times (`fede979`, `dfa8fc1`, `c8e0436`) with nothing pinning the invariant — so this PR fixes both and adds the regression tests.

## Bug A — the list badge depended on the pagination window
`strategies_routes` graded the list over `strats[offset:offset+limit]`, while the detail/passport route grades over the **full library**. The verdict is cohort-dependent (cohort-scoped PBO/CSCV shifts with membership; a short cohort falls under `MIN_LIBRARY_N_FOR_PBO_GATING` and skips criterion 4).

**Verified against production before the fix:**

| View | `passes_rigor_gate` for `d90b357a…4bbd` |
|---|---|
| 5-item window (offset 31) | **False** |
| Full library (34) | **True** |
| Detail / passport | **True** |

Fix: grade the full library, then slice the window. Bonus: the cache key is derived from cohort ids, so this collapses one ~6s cohort computation *per pagination offset* into a single shared entry.

## Bug B — no curated strategy was deployable at the default strictness
`vaults_routes._strategy_rigor_status` read `getattr(strat, "passes_rigor_gate")` off the provider object, but `LocalStrategyProvider` sets that `False` **unconditionally** (fail-closed by construction, `56cc9bde`); the real verdict is overlaid downstream. Every curated deploy was refused with *"has not passed the rigor gate — server-side rigor enforcement"* — a false statement — while **strictness ≥ 2 worked**, because that path already consults the live gate.

Fix: use the live verdict, graded against the same full-library cohort so the deploy gate cannot disagree with the badge.

## Tests
Three new regression tests pin the invariant: live verdict beats the provider attribute; the deploy gate grades the full cohort (not a 1-item list); the list route grades the full library, not the page. Plus fail-closed on gate error.

Two pre-existing tests asserted the *buggy* behaviour and are corrected. Three tests in `test_vault_metadata_anchor.py` passed only via `MagicMock` attribute truthiness — they now state their intent explicitly.

| Gate | Result |
|---|---|
| Full unit suite | ✅ **2943 passed**, 0 failed |
| `ruff format --check` | ✅ clean |
| `ruff check --select E9,F63,F7,F40,F82` | ✅ clean |

## ⚠️ Note for the rigor-audit thread
This changes **which cohort the list is graded over**, so some served list badges will change on deploy — they become consistent with the passport. Relevant to any number quoted externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)