### PR TITLE
[infra] Source AGENT_DRY_RUN from SSM instead of hardcoding it false — blocks the runner apply

### DIFF
--- a/infra/runner-user-data.sh
+++ b/infra/runner-user-data.sh
@@ -167,8 +167,19 @@ chmod 700 /opt/archimedes-runners/ecr-login.sh
 #   - pull the SAME archimedes-backend image (never build on-box)
 #   - refresh secrets from SSM on every (re)start (ExecStartPre)
 #   - pass ONLY static, non-redeploy-variable config as `-e` flags
-#     (AWS_REGION, ORACLE_INTERVAL_SECONDS/AGENT_INTERVAL_SECONDS,
-#     AGENT_DRY_RUN). Every mutable ARC_*_ADDRESS contract address comes from
+#     (AWS_REGION, ORACLE_INTERVAL_SECONDS/AGENT_INTERVAL_SECONDS).
+#     AGENT_DRY_RUN is deliberately NOT an `-e` flag: it is a funds-BEHAVIOUR
+#     switch, and `docker run -e` overrides `--env-file`, so hardcoding it here
+#     would make it unchangeable in practice — `aws_instance.runner` carries
+#     `lifecycle.ignore_changes = [ami, user_data]` (runner_ec2.tf), so whatever
+#     this file says at FIRST BOOT is baked in for the life of the instance.
+#     Sourcing it from SSM instead means Dan flips dry-run -> live with
+#     `setup-ssm-secrets.sh --apply` + `systemctl restart archimedes-agent`,
+#     with no instance replacement. Seed it as "true" and only flip to "false"
+#     after a dry-run smoke pass. If the SSM param is absent the app default
+#     applies (agent_runner.py: AGENT_DRY_RUN defaults to "false"), so ALWAYS
+#     seed it explicitly before the agent has working credentials.
+#     Every mutable ARC_*_ADDRESS contract address comes from
 #     the SSM-sourced --env-file instead — NEVER as an `-e` flag, which would
 #     override the env-file and re-hardcode a soon-to-be-stale address (see
 #     the fetch-secrets.sh preamble above for the full rationale).
@@ -235,7 +246,6 @@ ExecStart=/usr/bin/docker run --rm --name archimedes-agent \
   --env-file /opt/archimedes-runners/runner.env \
   -e AWS_REGION=${aws_region} \
   -e AGENT_INTERVAL_SECONDS=300 \
-  -e AGENT_DRY_RUN=false \
   --log-driver=awslogs \
   --log-opt awslogs-region=${aws_region} \
   --log-opt awslogs-group=${log_group_name} \

--- a/infra/scripts/setup-ssm-secrets.sh
+++ b/infra/scripts/setup-ssm-secrets.sh
@@ -52,6 +52,16 @@ PARAMS=(
   ARC_REASONING_TRACE_REGISTRY_ADDRESS # ReasoningTraceRegistry — oracle + agent runner (fetch-secrets.sh)
   ARC_STRATEGY_REGISTRY_ADDRESS       # StrategyRegistry — changes at every contract redeploy (T3.2), so SSM-sourced, not hardcoded
   ARC_PAYMENT_SPLITTER_ADDRESS        # PaymentSplitter (marketplace payouts) — same rationale
+  # --- Runner behaviour switches (SSM-sourced so they can change without an
+  #     instance replacement — see runner-user-data.sh's systemd-unit preamble) ---
+  AGENT_DRY_RUN                       # "true" = agent computes trades but signs NOTHING on-chain.
+                                      # Funds-behaviour switch for the relocated agent runner. Deliberately
+                                      # NOT a `docker run -e` flag (that would override --env-file and, because
+                                      # aws_instance.runner sets ignore_changes=[user_data], be unchangeable
+                                      # without replacing the box). Seed "true", flip to "false" only after a
+                                      # dry-run smoke pass, then `systemctl restart archimedes-agent`.
+                                      # WARNING: agent_runner.py defaults AGENT_DRY_RUN to "false" when unset,
+                                      # so leaving this unseeded means LIVE trading on first boot.
 )
 # NOTE: VITE_CIRCLE_CLIENT_KEY is a BUILD-TIME secret baked into the UI bundle at
 # `docker compose build` — it lives in the box-local .env (seeded by user-data.sh),


### PR DESCRIPTION
## ⛔ This must land BEFORE `terraform apply` creates `aws_instance.runner`

`runner-user-data.sh` passed `-e AGENT_DRY_RUN=false` to the agent container. Two facts make that a **one-way door**:

1. **`docker run -e` overrides `--env-file`** — so an SSM-sourced value could never win. This is the same failure mode the `ARC_*_ADDRESS` vars were already fixed for in this very file.
2. **`aws_instance.runner` sets `lifecycle.ignore_changes = [ami, user_data]`** (`runner_ec2.tf:237`) — whatever user-data the instance **first boots with is baked in for its lifetime**. Editing this file later does *not* re-render onto the running box.

**Together:** applying as-is permanently boots the funds-adjacent agent straight into **live on-chain signing**, with no way back to dry-run short of destroying and recreating the instance. The Redis lease protects against *double*-trades — it does not make live trading intentional.

## Fix
Drop the `-e` flag so the value flows from `fetch-secrets.sh`'s `--env-file`; register `AGENT_DRY_RUN` in `setup-ssm-secrets.sh`.

New operator flow: seed `"true"` → smoke-test the agent ticks and computes trades without reverting → flip to `"false"` + `systemctl restart archimedes-agent`. **No instance churn.**

## ⚠️ Sharp edge documented in both files
`agent_runner.py` defaults `AGENT_DRY_RUN` to `"false"` when unset — so an **unseeded** param means **live trading**. Seed it explicitly before the agent has working credentials.

## Verification
| Check | Result |
|---|---|
| `terraform validate` | ✅ Success — templatefile still renders |
| `bash -n setup-ssm-secrets.sh` | ✅ |
| dry-run seeds the param | ✅ `put /archimedes/prod/AGENT_DRY_RUN` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)