### PR TITLE
[infra] Refuse --apply when AGENT_DRY_RUN is unset and unseeded (Copilot follow-up to #1173)

### DIFF
--- a/infra/scripts/setup-ssm-secrets.sh
+++ b/infra/scripts/setup-ssm-secrets.sh
@@ -73,6 +73,37 @@ APPLY=false; for a in "$@"; do case "$a" in
 $APPLY && echo ">>> APPLY MODE — writing SecureString params under ${PREFIX}/" \
         || echo ">>> DRY RUN — re-run with --apply to write. Values are read from env; names only are shown."
 
+# ── Fail-closed guard for funds-behaviour parameters ────────────────────────
+# Everything else in this script is intentionally skip-if-unset, so partial runs
+# work. That default is WRONG for AGENT_DRY_RUN: agent_runner.py resolves an
+# unset AGENT_DRY_RUN to "false" (= LIVE on-chain signing), so "operator ran
+# --apply and didn't notice one skip line among twenty" silently arms the
+# funds-adjacent agent. Enforce the invariant in the tool instead of relying on
+# the caller reading output (Copilot review, PR #1173).
+#
+# Deliberately narrow so partial runs keep working:
+#   - only in --apply mode (a dry run writes nothing and stays advisory)
+#   - only for AGENT_DRY_RUN
+#   - satisfied by EITHER an exported value OR the parameter already existing in
+#     SSM (re-seeding one unrelated secret must not require re-passing it)
+#   - checked BEFORE any put, so a failure writes nothing at all
+if $APPLY && [ -z "${AGENT_DRY_RUN:-}" ]; then
+  if ! aws ssm get-parameter --name "${PREFIX}/AGENT_DRY_RUN" >/dev/null 2>&1; then
+    cat >&2 <<EOM
+ERROR: refusing to --apply. AGENT_DRY_RUN is not set and ${PREFIX}/AGENT_DRY_RUN
+       does not exist yet.
+
+       agent_runner.py treats an UNSET AGENT_DRY_RUN as "false" — i.e. the
+       relocated agent runner would boot into LIVE on-chain signing.
+
+       Seed it explicitly, dry-run first:
+           export AGENT_DRY_RUN=true    # flip to false only after a smoke pass
+       then re-run with --apply.
+EOM
+    exit 3
+  fi
+fi
+
 put=0; skip=0
 for name in "${PARAMS[@]}"; do
   val="${!name:-}"

--- a/infra/scripts/setup-ssm-secrets.sh
+++ b/infra/scripts/setup-ssm-secrets.sh
@@ -87,9 +87,10 @@ $APPLY && echo ">>> APPLY MODE — writing SecureString params under ${PREFIX}/"
 #   - satisfied by EITHER an exported value OR the parameter already existing in
 #     SSM (re-seeding one unrelated secret must not require re-passing it)
 #   - checked BEFORE any put, so a failure writes nothing at all
-if $APPLY && [ -z "${AGENT_DRY_RUN:-}" ]; then
-  if ! aws ssm get-parameter --name "${PREFIX}/AGENT_DRY_RUN" >/dev/null 2>&1; then
-    cat >&2 <<EOM
+if $APPLY; then
+  if [ -z "${AGENT_DRY_RUN:-}" ]; then
+    if ! aws ssm get-parameter --name "${PREFIX}/AGENT_DRY_RUN" >/dev/null 2>&1; then
+      cat >&2 <<EOM
 ERROR: refusing to --apply. AGENT_DRY_RUN is not set and ${PREFIX}/AGENT_DRY_RUN
        does not exist yet.
 
@@ -100,7 +101,33 @@ ERROR: refusing to --apply. AGENT_DRY_RUN is not set and ${PREFIX}/AGENT_DRY_RUN
            export AGENT_DRY_RUN=true    # flip to false only after a smoke pass
        then re-run with --apply.
 EOM
-    exit 3
+      exit 3
+    fi
+  else
+    # VALUE validation, not just presence (Copilot review, PR #1174).
+    # agent_runner.py parses this as:  os.getenv("AGENT_DRY_RUN","false").lower() == "true"
+    # so ONLY the literal "true" (any case) enables dry-run and EVERYTHING else —
+    # including the intuitive-looking "1", "yes", "on", "True " with whitespace —
+    # silently resolves to LIVE signing. An operator typing `AGENT_DRY_RUN=1`
+    # reasonably believes they armed dry-run; they armed the opposite. Accept only
+    # the two values that mean what they look like.
+    case "$(printf '%s' "$AGENT_DRY_RUN" | tr 'A-Z' 'a-z')" in
+      true|false) ;;
+      *)
+        cat >&2 <<EOM
+ERROR: refusing to --apply. AGENT_DRY_RUN="${AGENT_DRY_RUN}" is not a recognised value.
+
+       agent_runner.py evaluates:  AGENT_DRY_RUN.lower() == "true"
+       so ONLY "true" enables dry-run. Values like "1", "yes" or "on" look like
+       they enable it but resolve to LIVE on-chain signing.
+
+       Use exactly one of:
+           export AGENT_DRY_RUN=true     # agent computes trades, signs nothing
+           export AGENT_DRY_RUN=false    # LIVE signing (only after a smoke pass)
+EOM
+        exit 3
+        ;;
+    esac
   fi
 fi
 


### PR DESCRIPTION
## Why
Actions the Copilot review comment on **#1173**, which merged before the comment was addressed.

#1173 moved `AGENT_DRY_RUN` out of a `docker run -e` flag into the SSM-sourced `--env-file` and **documented** that an unset value means live trading. Copilot's point: *documenting it is not enforcing it.*

`setup-ssm-secrets.sh` skips unset env vars **even in `--apply` mode**. So an operator can run `--apply`, miss one `skip` line among twenty, and leave `/archimedes/prod/AGENT_DRY_RUN` absent — which `agent_runner.py` resolves to `"false"`, arming the funds-adjacent agent for **live on-chain signing**.

> Verified on the live account: `/archimedes/prod/AGENT_DRY_RUN` is **currently ABSENT** — this is not hypothetical, it is today's state.

## What
A fail-fast guard, deliberately **narrow** so the documented partial-run workflow still works:

- only in `--apply` mode (dry run stays advisory)
- only for `AGENT_DRY_RUN` — not a blanket require-everything
- satisfied by **either** an exported value **or** the param already existing in SSM, so re-seeding one unrelated secret doesn't require re-passing it
- evaluated **before any put**, so a refusal writes nothing at all

## Verification

| Path | Expected | Result |
|---|---|---|
| dry run, unset | unchanged, advisory | ✅ exit 0 |
| `--apply`, unset + absent in SSM | refuse, write nothing | ✅ **exit 3** |
| `--apply`, `AGENT_DRY_RUN=true` | proceed + seed | ✅ `put /archimedes/prod/AGENT_DRY_RUN` |
| `-h` | unchanged | ✅ exit 0 |

`bash -n` clean. No Terraform touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)