### PR TITLE
chore(lint): clear Python quality findings

### DIFF
--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -44,7 +44,7 @@ def _load_address_defaults() -> tuple[dict[str, str], dict[str, str]]:
         tokens = {s: v["token"] for s, v in raw.items() if isinstance(v, dict) and v.get("token")}
         oracles = {s: v["oracle"] for s, v in raw.items() if isinstance(v, dict) and v.get("oracle")}
         return tokens, oracles
-    except Exception as exc:  # noqa: BLE001 — never let an address-file issue crash import
+    except Exception as exc:  # Never let an address-file issue crash import.
         logger.error("client: could not load %s (%s) — synth addresses resolve from env only", _ADDRESS_SSOT_PATH, exc)
         return {}, {}
 

--- a/backend/tests/marketplace/test_settlement_idempotency.py
+++ b/backend/tests/marketplace/test_settlement_idempotency.py
@@ -56,7 +56,7 @@ def test_claim_settlement_intent_lifecycle():
     svc = _svc()
     # Unique tick_id per test — assertions are scoped to this logical charge so
     # they never depend on cross-test DB isolation.
-    key = dict(strategy_id="strat_a", tick_id="lifecycle:1", sub_id="0x" + "cc" * 32, step="rebalance")
+    key = {"strategy_id": "strat_a", "tick_id": "lifecycle:1", "sub_id": "0x" + "cc" * 32, "step": "rebalance"}
 
     assert svc._claim_settlement_intent(**key) == "claimed"
     # A second claim for the same logical charge is blocked (pending in-flight).

--- a/backend/tests/test_unify_curated_generated.py
+++ b/backend/tests/test_unify_curated_generated.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 
 import time
 
-import pytest
 import archimedes.db as db
+import pytest
 from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
 from httpx import ASGITransport, AsyncClient
 

--- a/backend/tests/test_vault_rigor_gate.py
+++ b/backend/tests/test_vault_rigor_gate.py
@@ -297,9 +297,11 @@ def test_strategy_record_visible_fails_closed_on_db_error():
     'no record — fall through to the ownership-blind badge', i.e. fail-open
     for private strategies exactly when the DB is down). It must raise a 503
     so the deploy is blocked loudly and recoverably."""
-    with patch("archimedes.db.get_session", side_effect=RuntimeError("db down")):
-        with pytest.raises(HTTPException) as exc_info:
-            _strategy_record_visible("any-id", _FakeRequest(_OWNER))
+    with (
+        patch("archimedes.db.get_session", side_effect=RuntimeError("db down")),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        _strategy_record_visible("any-id", _FakeRequest(_OWNER))
     assert exc_info.value.status_code == 503
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -89,4 +89,4 @@ ignore = [
 # AgentStateStore._get_redis (spec-mandated, see D-BYTES32/D-FANOUT) — both are
 # intentional private-member accesses.
 "backend/archimedes/marketplace/**" = ["SLF"]
-"backend/archimedes/api/marketplace_routes.py" = ["SLF"]
+"backend/archimedes/api/marketplace_routes.py" = ["SLF", "ARG001"]


### PR DESCRIPTION
## Summary
- make repository-wide Ruff lint pass with behavior-preserving fixes
- preserve SlowAPI-required `response` parameters through scoped `ARG001` config
- normalize affected tests to enabled lint rules

## Validation
- [x] `ruff check .`
- [x] `ruff format --check .` — 483 files
- [x] backend suite — 2939 passed, 2 skipped, 2 deselected
- [x] focused affected tests — 39 passed, 2 skipped
- [x] fresh read-only review — no material findings

## Coordination
Open PRs #1172 and #1099 touch two affected test files in separate hunks. Rebase may be needed depending on merge order.
