### PR TITLE
[infra] Grant ssm:GetParametersByPath on the PATH, not just its children — unblocks the runner AND fixes silent backend secret loading

### DIFF
--- a/infra/ec2_iam.tf
+++ b/infra/ec2_iam.tf
@@ -42,10 +42,19 @@ resource "aws_iam_role_policy" "ec2_ssm_params" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "ReadAppSecrets"
-        Effect   = "Allow"
-        Action   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
-        Resource = "arn:aws:ssm:*:*:parameter/archimedes/prod/*"
+        Sid    = "ReadAppSecrets"
+        Effect = "Allow"
+        Action = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+        # BOTH ARNs are required. ssm:GetParametersByPath authorizes against the PATH
+        # itself (".../parameter/archimedes/prod"), which the "/*" child pattern does
+        # NOT match — granting only the child pattern yields:
+        #   AccessDeniedException ... not authorized to perform: ssm:GetParametersByPath
+        #   on resource: arn:aws:ssm:us-east-1:<acct>:parameter/archimedes/prod
+        # The child ARN is still needed for GetParameter/GetParameters on individual keys.
+        Resource = [
+          "arn:aws:ssm:*:*:parameter/archimedes/prod",
+          "arn:aws:ssm:*:*:parameter/archimedes/prod/*",
+        ]
       },
       {
         Sid      = "DecryptSecureStringViaSSM"

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -246,10 +246,19 @@ resource "aws_iam_role_policy" "ecs_task_ssm_params" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "ReadAppSecrets"
-        Effect   = "Allow"
-        Action   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
-        Resource = "arn:aws:ssm:*:*:parameter/archimedes/prod/*"
+        Sid    = "ReadAppSecrets"
+        Effect = "Allow"
+        Action = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+        # BOTH ARNs are required. ssm:GetParametersByPath authorizes against the PATH
+        # itself (".../parameter/archimedes/prod"), which the "/*" child pattern does
+        # NOT match — granting only the child pattern yields:
+        #   AccessDeniedException ... not authorized to perform: ssm:GetParametersByPath
+        #   on resource: arn:aws:ssm:us-east-1:<acct>:parameter/archimedes/prod
+        # The child ARN is still needed for GetParameter/GetParameters on individual keys.
+        Resource = [
+          "arn:aws:ssm:*:*:parameter/archimedes/prod",
+          "arn:aws:ssm:*:*:parameter/archimedes/prod/*",
+        ]
       },
       {
         Sid      = "DecryptSecureStringViaSSM"

--- a/infra/runner_ec2.tf
+++ b/infra/runner_ec2.tf
@@ -98,10 +98,19 @@ resource "aws_iam_role_policy" "runner_ssm_params" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "ReadAppSecrets"
-        Effect   = "Allow"
-        Action   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
-        Resource = "arn:aws:ssm:*:*:parameter/archimedes/prod/*"
+        Sid    = "ReadAppSecrets"
+        Effect = "Allow"
+        Action = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+        # BOTH ARNs are required. ssm:GetParametersByPath authorizes against the PATH
+        # itself (".../parameter/archimedes/prod"), which the "/*" child pattern does
+        # NOT match — granting only the child pattern yields:
+        #   AccessDeniedException ... not authorized to perform: ssm:GetParametersByPath
+        #   on resource: arn:aws:ssm:us-east-1:<acct>:parameter/archimedes/prod
+        # The child ARN is still needed for GetParameter/GetParameters on individual keys.
+        Resource = [
+          "arn:aws:ssm:*:*:parameter/archimedes/prod",
+          "arn:aws:ssm:*:*:parameter/archimedes/prod/*",
+        ]
       },
       {
         Sid      = "DecryptSecureStringViaSSM"


### PR DESCRIPTION
## Two symptoms, one root cause

**The runner EC2 cannot start**, and **the backend has been silently booting without its SSM secrets**. Both are the same IAM defect.

`ssm:GetParametersByPath` authorizes against the **path resource itself** — `…:parameter/archimedes/prod` — which the child pattern `…/prod/*` does **not** match. All three SSM-read policies granted only the child pattern.

## Evidence

Live on the new runner (`i-0423fd0800b026c64`):
```
AccessDeniedException … not authorized to perform: ssm:GetParametersByPath
on resource: arn:aws:ssm:us-east-1:037613907429:parameter/archimedes/prod
```

Independently confirmed with `iam simulate-principal-policy`:

| Role | on `…/prod` (path) | on `…/prod/CIRCLE_API_KEY` |
|---|---|---|
| `archimedes-ecs-task-role` | **implicitDeny** | allowed |
| `archimedes-runner-ec2-role` | **implicitDeny** | allowed |

## Impact

| File | Effect |
|---|---|
| `runner_ec2.tf` | `fetch-secrets.sh` exits 254, `runner.env` empty, both systemd units stuck in `activating (auto-restart)`. **No oracle price pushes → all 281 oracles stale → `getPrice()` reverts `StalePrice()`.** |
| `ecs.tf` | `load_ssm_secrets()` catches the `ClientError` and boots **degraded by design** — so this failed **silently**. `CIRCLE_API_KEY`/`CIRCLE_ENTITY_SECRET`/`WALLET_ID`/`INTERNAL_AGENT_API_KEY` have **never reached the backend process** despite being correctly seeded. A concrete cause of the **publish 502s** (#1065 Step 1b). |
| `ec2_iam.tf` | Same defect on the legacy box; fixed for consistency. |

**Not affected:** `DATABASE_URL`/`REDIS_URL`/`AURORA_MASTER_PASSWORD`/`EMAIL_ENCRYPTION_KEY` arrive via the ECS `secrets` block, resolved by the **execution** role with `GetParameters` against per-parameter ARNs (`ecs.tf:206`) — those child ARNs match fine. That is why the DB works while Circle does not.

## Fix
List **both** the path ARN and the child ARN in each policy, with a comment explaining why both are required so it isn't "simplified" back later.

`terraform fmt` + `terraform validate` → **Success**.

## After apply
```bash
aws iam simulate-principal-policy --policy-source-arn <role> \
  --action-names ssm:GetParametersByPath \
  --resource-arns arn:aws:ssm:us-east-1:037613907429:parameter/archimedes/prod   # expect: allowed
sudo systemctl restart archimedes-oracle archimedes-agent   # on the runner
```
Then the oracle should push and `getPrice()` should stop reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)