### PR TITLE
[backend] Detect + guard against strategies backtesting the wrong asset

### DIFF
--- a/backend/archimedes/scripts/audit_backtest_universe.py
+++ b/backend/archimedes/scripts/audit_backtest_universe.py
@@ -1,0 +1,317 @@
+"""Audit: does every strategy's PERSISTED backtest actually trade its declared universe?
+
+Mechanical detector for the "backtesting the wrong asset" defect class (audit
+2026-07-27) — see ``services/vol_plausibility.py`` for the full rule design and its
+honest reasoning/limits. Confirmed on production data: ``capital_preservation_tbill``
+declares ``ASSET_UNIVERSE = ["BIL"]`` (a T-bill ETF, real-world vol ~0.2%) but its
+persisted backtest has annualized vol 18.65% — that is the S&P, not BIL.
+``maillard_2010_risk_parity`` declares a 5-asset risk-parity book (which by
+construction should have LOWER vol than pure equity) but persists 18.46% vol —
+also pure equity. Both PASS the rigor gate on returns that are not theirs.
+
+DATA SOURCE (read the code, not guessed): the live rigor gate reads persisted daily
+returns via ``services/backtest_repository.py::get_daily_returns(session,
+strategy_id)`` — the LATEST ``BacktestResultRecord`` row's ``artifact_json ->
+results[0].metrics.daily_returns``, falling back to deriving from the equity curve.
+This script reads the SAME store, keyed the SAME way (``strategy_id``), so what it
+reports is exactly what the gate sees — not a parallel, possibly-stale view.
+
+There is a SECOND, independent store: the ``strategy_daily_returns`` table, keyed by
+file ``stem`` rather than ``strategy_id`` (feeds the library-level PBO cross-section
+via ``services/rigor_evaluator.py::load_daily_returns_store``). The two stores
+disagree for at least one strategy (maillard: ~10.93% vol in ``strategy_daily_returns``
+vs 18.46% in ``backtest_results``) — that disagreement is itself a defect signal, so
+this script reports the cross-store delta wherever both exist, in addition to (never
+instead of) grading against the primary gate-facing store.
+
+Usage (run from the repo root; ``PYTHONPATH=backend`` makes ``archimedes`` importable
+since the package lives under ``backend/`` with no top-level ``archimedes/``)::
+
+    PYTHONPATH=backend python -m archimedes.scripts.audit_backtest_universe
+    PYTHONPATH=backend python -m archimedes.scripts.audit_backtest_universe --json
+    PYTHONPATH=backend python -m archimedes.scripts.audit_backtest_universe --margin 2.0
+
+Exit code: 0 when every strategy is "clean", "skipped" (no persisted backtest yet), or
+"insufficient_data"; 1 when ANY strategy is "flagged", "degenerate", "unclassified"
+(an audit gap — an honest "needs human review" beats a fabricated verdict, per the
+module design), or shows a large cross-store delta. This script never re-runs or
+regenerates a backtest — it only reads what is already persisted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from archimedes.db import get_session, init_db
+from archimedes.services.backtest_repository import get_daily_returns
+from archimedes.services.rigor_evaluator import load_daily_returns_store
+from archimedes.services.strategy_provider import default_provider
+from archimedes.services.vol_plausibility import (
+    BAND_MARGIN,
+    PlausibilityVerdict,
+    assess_strategy,
+    compute_vol_stats,
+)
+
+logger = logging.getLogger(__name__)
+
+_BASELINE_STRATEGY_STEM = "pipeline_buy_hold"
+
+# Cross-store delta reporting thresholds (informational + attention-worthy, not a
+# precision claim): flag a "large" disagreement between backtest_results and
+# strategy_daily_returns when it is BOTH a meaningful relative gap AND not just
+# noise from a tiny baseline.
+_CROSS_STORE_ABS_TOL = 0.02
+_CROSS_STORE_REL_TOL = 0.25
+
+
+def _repo_root() -> Path:
+    """Nearest ancestor that contains ``analytics-engine`` — mirrors
+    ``scripts/run_backtests.py::_repo_root`` (layout-robust across host/container)."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "analytics-engine").is_dir():
+            return parent
+    return here.parents[3]
+
+
+class StrategyAuditRow:
+    """One printable row: a strategy's declared universe vs. its persisted reality."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        strategy_id: str,
+        stem: str,
+        asset_universe: list[str],
+        verdict: PlausibilityVerdict | None,
+        cross_store_vol: float | None,
+    ) -> None:
+        self.name = name
+        self.strategy_id = strategy_id
+        self.stem = stem
+        self.asset_universe = asset_universe
+        self.verdict = verdict  # None means "skipped: no persisted backtest_results row"
+        self.cross_store_vol = cross_store_vol
+
+    @property
+    def status(self) -> str:
+        if self.verdict is None:
+            return "skipped"
+        return self.verdict.status
+
+    @property
+    def cross_store_delta(self) -> float | None:
+        if self.verdict is None or self.cross_store_vol is None:
+            return None
+        primary_vol = self.verdict.vol_stats.annualized_vol
+        if primary_vol is None:
+            return None
+        return primary_vol - self.cross_store_vol
+
+    @property
+    def cross_store_large_delta(self) -> bool:
+        delta = self.cross_store_delta
+        if delta is None:
+            return False
+        primary_vol = self.verdict.vol_stats.annualized_vol if self.verdict else None
+        if primary_vol is None:
+            return False
+        tol = max(_CROSS_STORE_ABS_TOL, _CROSS_STORE_REL_TOL * max(primary_vol, self.cross_store_vol or 0.0))
+        return abs(delta) > tol
+
+    @property
+    def needs_attention(self) -> bool:
+        """Drives the script's exit code — see the module docstring's exit-code contract."""
+        if self.verdict is not None and self.verdict.needs_attention:
+            return True
+        return self.cross_store_large_delta
+
+    def to_dict(self) -> dict:
+        v = self.verdict
+        return {
+            "name": self.name,
+            "strategy_id": self.strategy_id,
+            "stem": self.stem,
+            "asset_universe": self.asset_universe,
+            "status": self.status,
+            "n_obs": v.vol_stats.n_obs if v else None,
+            "annualized_vol": v.vol_stats.annualized_vol if v else None,
+            "annualized_return": v.vol_stats.annualized_return if v else None,
+            "buckets": list(v.universe.buckets) if v else [],
+            "band": list(v.universe.band) if (v and v.universe.band) else None,
+            "baseline_vol": v.baseline_vol if v else None,
+            "baseline_delta": v.baseline_delta if v else None,
+            "cross_store_vol": self.cross_store_vol,
+            "cross_store_delta": self.cross_store_delta,
+            "cross_store_large_delta": self.cross_store_large_delta,
+            "reasons": list(v.reasons) if v else [],
+            "needs_attention": self.needs_attention,
+        }
+
+
+def run_audit(*, repo_root: Path | None = None, margin: float = BAND_MARGIN) -> list[StrategyAuditRow]:
+    """Read-only pass over every strategy with a persisted backtest. Never writes."""
+    repo_root = repo_root or _repo_root()
+    init_db()
+
+    provider = default_provider(repo_root=repo_root)
+    strategies = [s for s in provider.list_strategies() if s.strategy_code_path]
+
+    with get_session() as session:
+        daily_by_strategy_id = {s.id: get_daily_returns(session, s.id) for s in strategies}
+        cross_store, cross_store_vintage = load_daily_returns_store(session)
+
+    if cross_store_vintage:
+        logger.info("strategy_daily_returns cross-store vintage: %s", cross_store_vintage)
+
+    baseline_vol: float | None = None
+    baseline = next((s for s in strategies if Path(s.strategy_code_path).stem == _BASELINE_STRATEGY_STEM), None)
+    if baseline is not None:
+        baseline_returns = daily_by_strategy_id.get(baseline.id) or []
+        if baseline_returns:
+            stats = compute_vol_stats(baseline_returns)
+            baseline_vol = stats.annualized_vol
+    if baseline_vol is None:
+        logger.warning(
+            "no usable persisted backtest for %r — Rule B (equity-baseline match) skipped for this whole run; "
+            "only the self-contained asset-class-band rule (Rule A) will apply",
+            _BASELINE_STRATEGY_STEM,
+        )
+
+    rows: list[StrategyAuditRow] = []
+    for strategy in sorted(strategies, key=lambda s: Path(s.strategy_code_path).stem):
+        stem = Path(strategy.strategy_code_path).stem
+        daily_returns = daily_by_strategy_id.get(strategy.id) or []
+
+        cross_entry = cross_store.get(stem)
+        cross_store_vol: float | None = None
+        if cross_entry and cross_entry.get("daily_returns"):
+            cross_stats = compute_vol_stats(cross_entry["daily_returns"])
+            cross_store_vol = cross_stats.annualized_vol
+
+        if not daily_returns:
+            # No persisted backtest_results row for this strategy — skipped, not
+            # crashed, and not counted as a failure (nothing to grade yet).
+            rows.append(
+                StrategyAuditRow(
+                    name=strategy.paper_title,
+                    strategy_id=strategy.id,
+                    stem=stem,
+                    asset_universe=list(strategy.asset_universe),
+                    verdict=None,
+                    cross_store_vol=cross_store_vol,
+                )
+            )
+            continue
+
+        verdict = assess_strategy(strategy.asset_universe, daily_returns, baseline_vol=baseline_vol, margin=margin)
+        rows.append(
+            StrategyAuditRow(
+                name=strategy.paper_title,
+                strategy_id=strategy.id,
+                stem=stem,
+                asset_universe=list(strategy.asset_universe),
+                verdict=verdict,
+                cross_store_vol=cross_store_vol,
+            )
+        )
+
+    return rows
+
+
+def _fmt_pct(value: float | None) -> str:
+    return f"{value * 100:.2f}%" if value is not None else "—"
+
+
+def render_table(rows: list[StrategyAuditRow]) -> str:
+    headers = ["strategy", "universe", "status", "n", "vol", "return", "baseline_Δ", "cross_Δ", "reason"]
+    out_rows: list[list[str]] = []
+    for row in rows:
+        v = row.verdict
+        universe_str = ",".join(row.asset_universe) or "—"
+        if len(universe_str) > 28:
+            universe_str = universe_str[:25] + "..."
+        n_obs = str(v.vol_stats.n_obs) if v else "—"
+        vol = _fmt_pct(v.vol_stats.annualized_vol) if v else "—"
+        ret = _fmt_pct(v.vol_stats.annualized_return) if v else "—"
+        baseline_delta = _fmt_pct(v.baseline_delta) if (v and v.baseline_delta is not None) else "—"
+        cross_delta = _fmt_pct(row.cross_store_delta) if row.cross_store_delta is not None else "—"
+        cross_flag = "!" if row.cross_store_large_delta else ""
+        reason = "; ".join(v.reasons) if v and v.reasons else ""
+        if len(reason) > 60:
+            reason = reason[:57] + "..."
+        marker = "*" if row.needs_attention else " "
+        out_rows.append(
+            [
+                f"{marker}{row.stem}",
+                universe_str,
+                row.status,
+                n_obs,
+                vol,
+                ret,
+                baseline_delta,
+                f"{cross_delta}{cross_flag}",
+                reason,
+            ]
+        )
+
+    widths = [max(len(h), *(len(r[i]) for r in out_rows)) if out_rows else len(h) for i, h in enumerate(headers)]
+    lines = [
+        "  ".join(h.ljust(w) for h, w in zip(headers, widths, strict=True)),
+        "  ".join("-" * w for w in widths),
+    ]
+    for r in out_rows:
+        lines.append("  ".join(c.ljust(w) for c, w in zip(r, widths, strict=True)))
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit persisted backtests against each strategy's declared ASSET_UNIVERSE."
+    )
+    parser.add_argument(
+        "--margin",
+        type=float,
+        default=BAND_MARGIN,
+        help=f"Safety margin over each asset-class vol band before flagging (default {BAND_MARGIN}).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of a text table.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repo root containing analytics-engine/ (default: auto-detected from this file's location).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    args = build_parser().parse_args(argv)
+
+    rows = run_audit(repo_root=args.repo_root, margin=args.margin)
+    flagged = [r for r in rows if r.needs_attention]
+
+    if args.json:
+        print(json.dumps({"strategies": [r.to_dict() for r in rows], "flagged_count": len(flagged)}, indent=2))
+    else:
+        print(render_table(rows))
+        print()
+        print(f"{len(rows)} strategies audited, {len(flagged)} need attention (marked '*').")
+        if flagged:
+            print("Statuses: flagged=implausible vol for declared universe; degenerate=zero-variance series;")
+            print(
+                "unclassified=unrecognized ticker(s), needs human review; cross_Δ '!'=large cross-store disagreement."
+            )
+
+    return 1 if flagged else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -206,6 +206,36 @@ def _daily_returns_for_operation(artifact_payload: dict, operation: str | None) 
     return None
 
 
+def _payload_with_selected_operation_first(artifact_payload: dict, operation: str | None) -> dict:
+    """``artifact_payload`` with the chosen operation's row moved to the front of
+    ``results`` — everything else preserved, order of the remaining rows intact.
+
+    Exists so that ``backtest_repository.get_daily_returns()``, which returns the
+    first non-empty ``daily_returns`` and ignores the ``operation`` column, reads
+    back the SAME series the write-time vol guard validated. Returns the payload
+    unchanged when there is nothing to do (no operation, single/zero result, or
+    the chosen row is already first), so the common single-operation case is
+    byte-identical and does not perturb ``canonical_artifact_hash``.
+    """
+    if not operation:
+        return artifact_payload
+    results = artifact_payload.get("results")
+    if not isinstance(results, list) or len(results) < 2:
+        return artifact_payload
+
+    wanted = operation.upper()
+    idx = next(
+        (i for i, row in enumerate(results) if str(row.get("operation", "")).upper() == wanted),
+        None,
+    )
+    if idx is None or idx == 0:
+        return artifact_payload
+
+    reordered = dict(artifact_payload)
+    reordered["results"] = [results[idx], *results[:idx], *results[idx + 1 :]]
+    return reordered
+
+
 def run_backtests() -> dict:
     repo_root = _repo_root()
     strategy_dir = _analytics_strategy_dir(repo_root)
@@ -263,6 +293,33 @@ def run_backtests() -> dict:
                 artifact,
                 strategy_id=strategy.id,
             )
+
+            # Persist the SELECTED operation first, and hash what we persist.
+            #
+            # Making the guard read the chosen operation's series (above) only
+            # closed half the gap: backtest_repository.get_daily_returns() —
+            # what the rigor gate and the audit script actually read back —
+            # ignores the `operation` column and returns the FIRST non-empty
+            # daily_returns in artifact_json["results"]. So with
+            # BACKTEST_OPERATIONS="NIKKEI,SPY" the guard would validate SPY
+            # while every downstream consumer graded NIKKEI. The divergence
+            # would just have moved rather than closed, and a guard that
+            # validates a different series than the gate reads is worse than
+            # no guard: it certifies the wrong thing.
+            #
+            # Reordering at write time makes "first entry" and "selected
+            # operation" the same row by construction, so the naive reader is
+            # correct without changing it. Fixing get_daily_returns() to honour
+            # the operation column is the better long-term shape, but it is a
+            # shared reader whose behaviour change would re-grade already
+            # persisted rows — that belongs in its own PR, not this guard's.
+            #
+            # No-op under the current default (BACKTEST_OPERATIONS="SPY" ⇒ one
+            # result), so no content_hash churn and no duplicate re-inserts for
+            # existing rows; it only starts mattering the moment a second
+            # operation is configured, which is exactly when it must be right.
+            artifact_payload = _payload_with_selected_operation_first(artifact_payload, selected_operation)
+            artifact_json = json.dumps(artifact_payload)
             content_hash = canonical_artifact_hash(artifact_payload)
 
             # Deliverable-2 permanent guard (audit 2026-07-27): refuse to persist

--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -21,10 +21,21 @@ from archimedes.services.backtest_mapper import (
     canonical_artifact_hash,
     map_artifact_to_backtest_result,
 )
-from archimedes.services.backtest_repository import insert_backtest_if_missing
+from archimedes.services.backtest_repository import get_daily_returns, insert_backtest_if_missing
 from archimedes.services.strategy_provider import default_provider
+from archimedes.services.vol_plausibility import (
+    VolPlausibilityError,
+    assess_strategy,
+    compute_vol_stats,
+    daily_returns_from_equity_curve,
+)
 
 logger = logging.getLogger(__name__)
+
+# The confirmed-correct reference strategy for the Rule-B equity-baseline-match
+# check (see services/vol_plausibility.py module docstring) — a stem match
+# against analytics-engine/strategies/pipeline_buy_hold.py.
+_BASELINE_STRATEGY_STEM = "pipeline_buy_hold"
 
 
 @dataclass(frozen=True)
@@ -113,6 +124,59 @@ def _read_config() -> RunConfig:
     )
 
 
+def _load_baseline_vol(strategy_by_path: dict) -> float | None:
+    """Best-effort fetch of the pipeline_buy_hold realized vol for Rule B.
+
+    Deliverable-2 permanent guard (audit 2026-07-27, services/vol_plausibility.py):
+    every strategy's freshly-computed backtest is checked against BOTH the
+    self-contained asset-class-band rule (Rule A) AND, when available, this
+    pre-existing equity baseline (Rule B) — the check that specifically catches a
+    diversified/non-equity strategy whose realized vol is suspiciously close to
+    pure S&P equity (the exact signature of the confirmed single-feed-default
+    fallback). Reads whatever ``pipeline_buy_hold`` last persisted BEFORE this
+    run started — one query, done once, not per strategy.
+
+    Returns ``None`` (never raises) when the reference strategy file is missing,
+    has no persisted backtest yet (e.g. a brand new clone before the first ever
+    run), or its own persisted series is degenerate/too short — every case logs
+    a clear warning so the "Rule B skipped this run" gap is visible, not silent.
+    """
+    baseline = next(
+        (s for s in strategy_by_path.values() if Path(s.strategy_code_path or "").stem == _BASELINE_STRATEGY_STEM),
+        None,
+    )
+    if baseline is None:
+        logger.warning(
+            "vol-plausibility guard: no strategy file matching stem %r found — "
+            "Rule B (equity-baseline match) skipped this run; only Rule A runs",
+            _BASELINE_STRATEGY_STEM,
+        )
+        return None
+
+    with get_session() as session:
+        baseline_returns = get_daily_returns(session, baseline.id)
+
+    if not baseline_returns:
+        logger.warning(
+            "vol-plausibility guard: %s has no persisted backtest yet — "
+            "Rule B (equity-baseline match) skipped this run; only Rule A runs",
+            _BASELINE_STRATEGY_STEM,
+        )
+        return None
+
+    stats = compute_vol_stats(baseline_returns)
+    if stats.annualized_vol is None:
+        logger.warning(
+            "vol-plausibility guard: %s's persisted series is degenerate/too short "
+            "(n_obs=%d) — Rule B (equity-baseline match) skipped this run; only Rule A runs",
+            _BASELINE_STRATEGY_STEM,
+            stats.n_obs,
+        )
+        return None
+
+    return stats.annualized_vol
+
+
 def run_backtests() -> dict:
     repo_root = _repo_root()
     strategy_dir = _analytics_strategy_dir(repo_root)
@@ -128,6 +192,12 @@ def run_backtests() -> dict:
     }
 
     init_db()
+
+    # Deliverable-2 permanent guard: fetch the pre-existing equity baseline ONCE
+    # (not per strategy) so every freshly-computed artifact below can be checked
+    # against both plausibility rules before it is persisted. See
+    # services/vol_plausibility.py's module docstring for Rule A / Rule B.
+    baseline_vol = _load_baseline_vol(strategy_by_path)
 
     inserted = 0
     skipped = 0
@@ -166,6 +236,22 @@ def run_backtests() -> dict:
             )
             content_hash = canonical_artifact_hash(artifact_payload)
 
+            # Deliverable-2 permanent guard (audit 2026-07-27): refuse to persist
+            # a backtest whose realized vol is wildly inconsistent with the
+            # strategy's own declared ASSET_UNIVERSE — this is exactly the
+            # confirmed "backtesting the wrong asset" defect class (e.g.
+            # capital_preservation_tbill declaring BIL but reading pure equity
+            # vol). Checked BEFORE insert_backtest_if_missing so a flagged
+            # artifact is never written, loudly, fail-closed.
+            candidate_returns = daily_returns_from_equity_curve(mapped.equity_curve)
+            verdict = assess_strategy(strategy.asset_universe, candidate_returns, baseline_vol=baseline_vol)
+            if verdict.status in ("flagged", "degenerate"):
+                raise VolPlausibilityError(
+                    f"strategy {strategy.id} ({strategy.paper_title}) declares ASSET_UNIVERSE="
+                    f"{strategy.asset_universe!r}; realized vol/return check status={verdict.status!r}: "
+                    f"{'; '.join(verdict.reasons)}"
+                )
+
             with get_session() as session:
                 _, was_inserted = insert_backtest_if_missing(
                     session,
@@ -185,6 +271,15 @@ def run_backtests() -> dict:
                 skipped += 1
                 logger.info("skip duplicate content hash: %s (%s)", strategy.paper_title, strategy.id)
 
+        except VolPlausibilityError as exc:
+            # Loud + fail-closed by construction: this exception is only ever
+            # raised AFTER the artifact was computed but BEFORE
+            # insert_backtest_if_missing — so nothing was written. ERROR (not
+            # WARNING) because this is the exact defect class the whole guard
+            # exists to catch, not a routine engine limitation.
+            failed += 1
+            errors[strategy.id] = f"VolPlausibilityError: {exc}"
+            logger.error("REFUSING to persist backtest for %s: %s", strategy_file.name, exc)
         except Exception as exc:
             failed += 1
             if typed_errors and isinstance(exc, typed_errors):

--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -177,6 +177,35 @@ def _load_baseline_vol(strategy_by_path: dict) -> float | None:
     return stats.annualized_vol
 
 
+def _daily_returns_for_operation(artifact_payload: dict, operation: str | None) -> list[float] | None:
+    """Raw ``daily_returns`` for one named operation, read directly off the
+    parsed artifact payload — ``None`` if not found/empty.
+
+    ``AnalyticsArtifactModel``/``EngineMetricsModel`` (``backtest_mapper.py``)
+    declare ``extra="ignore"`` and never define a ``daily_returns`` field, so
+    the raw per-bar returns array the analytics engine actually wrote
+    (``archimedes_analytics_engine.cli.run_command``'s ``asdict(bt_result)``,
+    which includes ``daily_returns``) only survives in the plain-dict
+    ``artifact_payload`` from ``json.loads`` — not in the pydantic-validated
+    ``artifact`` object. Matches by operation name (case-insensitive), the same
+    identity ``select_operation_result`` (``backtest_mapper.py``) used to pick
+    the row ``map_artifact_to_backtest_result`` mapped from — so this reads the
+    CHOSEN operation's own series, never whichever entry happens to sit first
+    in ``results`` (see ``get_daily_returns`` in ``backtest_repository.py``,
+    which — unlike ``select_operation_result`` — does exactly that and is the
+    reason this guard cannot just reuse it).
+    """
+    if not operation:
+        return None
+    wanted = operation.upper()
+    for row in artifact_payload.get("results", []):
+        if str(row.get("operation", "")).upper() != wanted:
+            continue
+        raw = row.get("metrics", {}).get("daily_returns")
+        return [float(v) for v in raw] if raw else None
+    return None
+
+
 def run_backtests() -> dict:
     repo_root = _repo_root()
     strategy_dir = _analytics_strategy_dir(repo_root)
@@ -243,7 +272,25 @@ def run_backtests() -> dict:
             # capital_preservation_tbill declaring BIL but reading pure equity
             # vol). Checked BEFORE insert_backtest_if_missing so a flagged
             # artifact is never written, loudly, fail-closed.
-            candidate_returns = daily_returns_from_equity_curve(mapped.equity_curve)
+            #
+            # Pull the CHOSEN operation's raw daily_returns straight off the
+            # artifact payload rather than re-deriving them from
+            # mapped.equity_curve via pct-change: select_operation_result()
+            # (backtest_mapper.py) picks the row by NAME (searches for "SPY"
+            # regardless of position), but this file's own _load_baseline_vol()
+            # — and every other downstream reader, via
+            # backtest_repository.get_daily_returns() — reads artifact
+            # results[0], which is not guaranteed to be the same row once
+            # BACKTEST_OPERATIONS lists more than one op (e.g.
+            # "NIKKEI,SPY" puts SPY, the chosen op, at index 1). Deriving from
+            # mapped.equity_curve happened to coincide with the chosen op
+            # today, but named lookup is what actually keeps this guard
+            # checking the row that gets persisted and later re-read — falling
+            # back to the equity-curve derivation only if the raw field is
+            # absent (e.g. an older artifact schema).
+            candidate_returns = _daily_returns_for_operation(artifact_payload, selected_operation)
+            if not candidate_returns:
+                candidate_returns = daily_returns_from_equity_curve(mapped.equity_curve)
             verdict = assess_strategy(strategy.asset_universe, candidate_returns, baseline_vol=baseline_vol)
             if verdict.status in ("flagged", "degenerate"):
                 raise VolPlausibilityError(

--- a/backend/archimedes/services/vol_plausibility.py
+++ b/backend/archimedes/services/vol_plausibility.py
@@ -68,7 +68,10 @@ have a persisted backtest (callers degrade gracefully — see ``assess_strategy`
 strategy that is legitimately, coincidentally close to the equity baseline (e.g. a
 genuinely fully-invested-in-SPY strategy with a near-no-op timing signal) will also
 trip this rule; that is still an actionable finding worth a human's eyes, not a false
-alarm to be tuned away.
+alarm to be tuned away. Like Rule A, Rule B is gated on
+``universe.is_fully_classified`` — a PARTIALLY-unclassified universe (some tickers
+resolve, others don't) never gets a baseline-match verdict, fabricated or otherwise;
+it always reports ``unclassified`` instead, same as a fully-unclassified one.
 
 This module itself stays pure and hermetic (no DB, no network — everything below
 takes plain lists/tuples of tickers and returns). Both callers do their own I/O
@@ -341,7 +344,12 @@ def compute_vol_stats(daily_returns: list[float] | np.ndarray) -> VolStats:
     Return: geometric CAGR over a synthetic equity curve built by compounding the
     daily returns from 1.0 — ``(curve[-1] / curve[0]) ** (252 / T) - 1`` — the same
     formula ``_annualized_metrics`` uses. Returns ``None`` if the series ever
-    drives the synthetic curve to <= 0 (a >= -100% day makes CAGR undefined).
+    drives the synthetic curve to <= 0 AT ANY POINT along the path (a >= -100%
+    day makes CAGR undefined) — checked over the whole curve, not just its last
+    value, because an EVEN number of sub-(-100%) days flips ``cumprod``'s sign
+    back positive: the curve can go negative mid-series and still end up
+    positive, which would otherwise produce a plausible-looking CAGR from an
+    economically impossible path.
 
     Degenerate check: ``np.ptp(arr) == 0.0`` — IDENTICAL to the guard
     ``services/_rigor_helpers.py::_sharpe_dsr_inputs`` uses to bail ``compute_dsr``
@@ -362,7 +370,11 @@ def compute_vol_stats(daily_returns: list[float] | np.ndarray) -> VolStats:
     ann_vol = sigma * math.sqrt(_ANNUALIZATION)
 
     curve = np.cumprod(1.0 + arr)
-    ann_return: float | None = None if curve[-1] <= 0 else float(curve[-1] ** (_ANNUALIZATION / n) - 1.0)
+    # Check the WHOLE curve, not just its last point: an even number of
+    # sub-(-100%) days flips cumprod's sign back positive, so the curve can go
+    # negative (or zero) mid-series — an economically impossible path — and
+    # still end up positive, producing a plausible-looking CAGR from garbage.
+    ann_return: float | None = None if bool((curve <= 0).any()) else float(curve[-1] ** (_ANNUALIZATION / n) - 1.0)
 
     return VolStats(
         n_obs=n, annualized_vol=ann_vol, annualized_return=ann_return, degenerate=False, insufficient_data=False
@@ -523,7 +535,16 @@ def assess_strategy(
     reasons.extend(_evaluate_class_band(universe, realized_vol, margin=margin))
 
     baseline_delta: float | None = None
-    if baseline_vol is not None:
+    # Gate Rule B on full classification too, same as Rule A (which returns []
+    # when universe.band is None). Without this, a PARTIALLY-unclassified
+    # universe whose vol happens to sit near the equity baseline would get a
+    # fabricated "matches the pipeline_buy_hold equity baseline" reason instead
+    # of the honest "unclassified" verdict — and since `if reasons:` below is
+    # checked before the `not universe.is_fully_classified` branch, that
+    # fabricated reason would win, contradicting this module's whole design
+    # goal (see module docstring: unclassifiable tickers get `unclassified`
+    # rather than a fabricated verdict).
+    if baseline_vol is not None and universe.is_fully_classified:
         baseline_delta = realized_vol - baseline_vol
         reasons.extend(
             _evaluate_baseline_match(

--- a/backend/archimedes/services/vol_plausibility.py
+++ b/backend/archimedes/services/vol_plausibility.py
@@ -1,0 +1,552 @@
+"""Universe/vol plausibility checks — the mechanical detector for "backtesting the
+wrong asset" (audit 2026-07-27).
+
+Confirmed defect class: a strategy declares ``ASSET_UNIVERSE`` (e.g. ``["BIL"]``, the
+SPDR 1-3 Month T-Bill ETF) but its persisted daily returns are statistically
+indistinguishable from pure S&P 500 equity — i.e. the backtest silently ran against
+the wrong price series. Root cause (read in ``analytics_engine.cli.run_command``,
+2026-07-27): a strategy is only routed through the declared-universe-aware multi-feed
+path when its class declares ``REQUIRED_FEEDS == 2`` (pairs). Every other strategy —
+single-asset AND multi-asset alike — is backtested against
+``RunConfig.operations`` (``BACKTEST_OPERATIONS`` env var, default ``"SPY"``),
+**regardless of its own declared ``ASSET_UNIVERSE``**. A strategy that is fully
+invested with no real timing signal on that default feed (e.g.
+``capital_preservation_tbill``, or ``maillard_2010_risk_parity`` once its
+``self.datas`` collapses to the single default feed) therefore reproduces the pure
+buy-and-hold S&P return series almost exactly.
+
+This module is deliberately split into two complementary, independently-defensible
+rules rather than one "precise" model — see ``assess_strategy`` for how they combine:
+
+Rule A — asset-class plausibility band (self-contained, no cross-strategy state)
+----------------------------------------------------------------------------
+Every ticker that appears in any strategy's ``ASSET_UNIVERSE`` is resolved to a
+*broad* asset-class bucket (cash/T-bill, short/mid/long government bond, broad
+equity, sector/thematic equity, single-name equity, REIT, commodity, FX, crypto,
+volatility) via the SAME curated classification the live on-chain universe uses —
+``archimedes.universe.SYNTHETIC_UNIVERSE`` (``asset_class`` per
+``yfinance_ticker``) — plus a small, explicit supplemental table for the handful of
+legacy analytics-engine "operation" aliases (``NIKKEI``, ``GOLD``, ``TREASURY``,
+``OIL``) and single-name pairs legs (``KO``, ``PEP``) that predate the on-chain SSOT
+and are not present in it. Each bucket carries a WIDE, generously-bounded annualized
+realized-vol band drawn from well-known multi-decade historical ranges for that asset
+class (not per-ticker precision — see ``_BUCKET_VOL_BANDS`` for the numbers and their
+honest provenance).
+
+For a strategy whose *entire* declared universe sits in ONE bucket, the realized vol
+must fall within ``[lo / margin, hi * margin]``. For a strategy spanning MULTIPLE
+buckets (a genuinely diversified book), only the upper bound is enforced — the
+portfolio-variance inequality ``sigma_portfolio <= sum_i(w_i * sigma_i) <=
+max_i(sigma_i)`` for non-negative, fully-invested weights and correlations <= 1 means
+a long-only diversified book can never be MORE volatile than its most volatile single
+leg's band, but it can legitimately be far LESS volatile (e.g. a risk-parity book
+dominated by its T-bill leg) — so no lower bound is meaningful there.
+
+**Honest limits of Rule A:** these bands are a sanity check, not an oracle. They will
+not catch a diversified multi-asset strategy whose realized vol happens to land
+inside the (deliberately wide) union of its components' bands — which is exactly why
+Rule B exists. They can also be wrong for leveraged/inverse instruments, or for
+periods where multi-decade "normal" ranges are a poor guide.
+
+Rule B — equity-baseline match (cross-strategy, targets the exact root cause)
+----------------------------------------------------------------------------
+``pipeline_buy_hold`` (``ASSET_UNIVERSE = ["SPY"]``, unconditionally fully invested)
+is the confirmed-correct reference: its persisted vol IS the real S&P annualized vol.
+Because the confirmed root cause is "the backtest silently fell back to the SPY-only
+default feed," any OTHER strategy whose declared universe is not that same trivial
+single-broad-equity book, but whose realized annualized vol lands within a tight
+tolerance of the ``pipeline_buy_hold`` baseline, is exhibiting the exact statistical
+signature of that fallback — regardless of whether Rule A's wide bands would also
+catch it. This is what catches ``maillard_2010_risk_parity`` (18.46% vs the 18.65%
+baseline): its declared 5-asset, risk-parity-weighted universe should structurally
+produce a MATERIALLY lower vol than pure single-name equity; landing within ~1% of
+the baseline is not a coincidence, it is the single-feed collapse.
+
+**Honest limits of Rule B:** it needs the ``pipeline_buy_hold`` reference to itself
+have a persisted backtest (callers degrade gracefully — see ``assess_strategy``'s
+``baseline_vol=None`` path — logging the gap rather than silently skipping it). A
+strategy that is legitimately, coincidentally close to the equity baseline (e.g. a
+genuinely fully-invested-in-SPY strategy with a near-no-op timing signal) will also
+trip this rule; that is still an actionable finding worth a human's eyes, not a false
+alarm to be tuned away.
+
+This module itself stays pure and hermetic (no DB, no network — everything below
+takes plain lists/tuples of tickers and returns). Both callers do their own I/O
+first: ``scripts/audit_backtest_universe.py`` (Deliverable 1) reads every
+strategy's persisted returns plus the ``pipeline_buy_hold`` baseline once per run
+and applies both rules to every strategy; ``scripts/run_backtests.py``'s
+write-time guard (Deliverable 2) fetches that same pre-existing baseline ONCE
+before its per-strategy loop (not per strategy — one extra query per run) and
+applies Rule A + Rule B to each freshly-computed artifact before persisting it,
+degrading to Rule-A-only (self-contained, no baseline needed) the first time ever
+run — before ``pipeline_buy_hold`` itself has a persisted backtest to compare
+against.
+
+Degenerate series
+------------------
+A constant (zero-range) daily-return series makes ``numpy.std`` numerically
+meaningless and is exactly the check ``services/_rigor_helpers.py::compute_dsr``
+already uses (``np.ptp(arr) == 0.0``) to bail out to ``None`` rather than emit a
+Sharpe/DSR built on division-adjacent noise. This module uses the identical check and
+reports it as its own ``degenerate`` status — never silently "clean", never a crash.
+
+Owner: Dan (backtest universe audit, 2026-07-27)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = [
+    "BAND_MARGIN",
+    "BASELINE_ABS_TOL",
+    "BASELINE_REL_TOL",
+    "MIN_OBS_FOR_ASSESSMENT",
+    "PlausibilityVerdict",
+    "UniverseClassification",
+    "VolPlausibilityError",
+    "VolStats",
+    "assess_strategy",
+    "classify_ticker",
+    "classify_universe",
+    "compute_vol_stats",
+    "daily_returns_from_equity_curve",
+]
+
+_ANNUALIZATION = 252  # trading days/year — matches portfolio_backtester.ANNUALIZATION
+# and _rigor_helpers._ANNUALIZATION so numbers agree repo-wide.
+
+# Generous safety margin applied to each bucket's historical vol band before
+# flagging (Rule A). 1.5x is deliberately loose: the goal is to catch GROSS
+# universe mismatches (an order-of-magnitude-off T-bill, a 5-asset risk-parity
+# book reading as pure equity) without tripping on ordinary regime variation
+# (e.g. equity vol was ~12% in 2017 and ~35%+ in the 2020 COVID crash — both
+# comfortably inside the un-margined band already).
+BAND_MARGIN = 1.5
+
+# Rule B tolerance: how close realized vol must be to the pipeline_buy_hold
+# baseline to count as a "matches equity baseline" flag. Absolute floor of 75bp
+# (so tiny baselines don't produce a vanishingly tight window) OR 3% relative,
+# whichever is LARGER. Calibrated against the two confirmed cases: BIL's 18.65%
+# is an exact match (0bp delta); maillard's 18.46% is a ~1% relative delta —
+# both comfortably inside; a genuine market-timing strategy that spends a
+# meaningful fraction of its days out of the market moves vol by double-digit
+# percent (vol scales roughly with sqrt(time-invested-fraction)), safely outside.
+BASELINE_ABS_TOL = 0.0075
+BASELINE_REL_TOL = 0.03
+
+# Below this many observations, vol/return estimates are too noisy to assess —
+# report "insufficient_data" rather than a confident verdict either way.
+MIN_OBS_FOR_ASSESSMENT = 5
+
+# ─── Fine asset_class (archimedes.universe SSOT) → broad plausibility bucket ──
+#
+# The SSOT (`backend/archimedes/data/synthetic_universe.json`, loaded via
+# `archimedes.universe.SYNTHETIC_UNIVERSE`) already curates ~281 real,
+# yfinance-backed instruments into ~30 FINE asset classes for the on-chain
+# universe. We fold those fine classes into a small set of BROAD vol buckets —
+# reusing an existing, reviewed SSOT rather than hand-rolling a second ticker
+# taxonomy. Any fine class not listed here maps to `None` (unclassified) rather
+# than guessing.
+_FINE_CLASS_TO_BUCKET: dict[str, str] = {
+    "us_bond_tbill": "cash_tbill",
+    "us_bond_short": "short_bond",
+    "us_muni": "short_bond",
+    "us_bond_mid": "mid_bond",
+    "us_bond_tips": "mid_bond",
+    "credit_ig": "mid_bond",
+    "us_bond_long": "long_bond",
+    "us_bond_agg": "long_bond",
+    "intl_bond": "long_bond",
+    "em_bond": "long_bond",
+    "credit_hy": "long_bond",
+    "us_equity_etf": "broad_equity",
+    "intl_equity_etf": "broad_equity",
+    "eu_equity_etf": "broad_equity",
+    "eu_index": "broad_equity",
+    "asia_equity_etf": "broad_equity",
+    "asia_index": "broad_equity",
+    "em_equity_etf": "broad_equity",
+    "latam_equity_etf": "broad_equity",
+    "tr_equity_etf": "broad_equity",
+    "tr_index": "broad_equity",
+    "factor_etf": "broad_equity",
+    "us_sector_etf": "sector_thematic_equity",
+    "us_thematic_etf": "sector_thematic_equity",
+    "reit_etf": "reit",
+    "metal_etf": "commodity",
+    "metal_eq_etf": "commodity",
+    "metal_spot": "commodity",
+    "metal_fut": "commodity",
+    "energy_etf": "commodity",
+    "energy_fut": "commodity",
+    "commodity_etf": "commodity",
+    "agri_etf": "commodity",
+    "agri_fut": "commodity",
+    "fx": "fx",
+    "crypto": "crypto",
+    "volatility_etf": "volatility",
+}
+
+# Supplemental map for tickers that are NOT in the on-chain synthetic-universe
+# SSOT: legacy analytics-engine "operation" aliases (the original 5-operation
+# universe predates the SSOT — see
+# analytics-engine/src/archimedes_analytics_engine/instruments.py) and the two
+# single-name Gatev-pairs legs. Kept intentionally tiny and explicit — every
+# entry here is a documented, named exception, not a fallback heuristic.
+_SUPPLEMENTAL_TICKER_BUCKET: dict[str, str] = {
+    "NIKKEI": "broad_equity",  # operation alias for ^N225 — broad Japanese equity index
+    "GOLD": "commodity",  # operation alias for GC=F — gold futures
+    "TREASURY": "long_bond",  # operation alias for TLT — long-duration UST proxy
+    "OIL": "commodity",  # operation alias for CL=F — crude oil futures
+    "KO": "single_name_equity",  # Coca-Cola — Gatev 2006 pairs leg
+    "PEP": "single_name_equity",  # PepsiCo — Gatev 2006 pairs leg
+}
+
+# Broad-bucket → (lo, hi) plausible annualized-vol band, un-margined. Wide,
+# multi-decade, order-of-magnitude-honest ranges — NOT a precise per-ticker
+# oracle. Sourced from well-known asset-class realized-vol characteristics
+# (e.g. Ilmanen "Expected Returns" asset-class vol tables; standard practitioner
+# ranges). Deliberately erring toward under-flagging: the goal is to catch
+# strategies trading a fundamentally different RISK CLASS than declared, not to
+# certify precise correctness.
+_BUCKET_VOL_BANDS: dict[str, tuple[float, float]] = {
+    "cash_tbill": (0.0, 0.03),
+    "short_bond": (0.0, 0.07),
+    "mid_bond": (0.0, 0.11),
+    "long_bond": (0.02, 0.20),
+    "broad_equity": (0.08, 0.35),
+    "sector_thematic_equity": (0.10, 0.45),
+    "single_name_equity": (0.12, 0.55),
+    "reit": (0.10, 0.40),
+    "commodity": (0.10, 0.55),
+    "fx": (0.03, 0.18),
+    "crypto": (0.25, 1.50),
+    "volatility": (0.30, 2.00),
+}
+
+
+def _ticker_asset_class_map() -> dict[str, str]:
+    """``{yfinance_ticker.upper(): asset_class}`` from the on-chain universe SSOT.
+
+    Lazy + re-derived per call (cheap — ``SYNTHETIC_UNIVERSE`` is already a
+    module-level dict loaded once by ``archimedes.universe`` at import time; this
+    just re-indexes it) so a test can monkeypatch ``archimedes.universe.SYNTHETIC_UNIVERSE``
+    without needing to reload this module.
+    """
+    from archimedes.universe import SYNTHETIC_UNIVERSE
+
+    out: dict[str, str] = {}
+    for spec in SYNTHETIC_UNIVERSE.values():
+        ticker = (spec.yfinance_ticker or "").upper()
+        if ticker:
+            out[ticker] = spec.asset_class
+    return out
+
+
+def classify_ticker(ticker: str) -> str | None:
+    """Resolve one declared-universe ticker to a broad vol bucket, or ``None``.
+
+    Resolution order: (1) the on-chain synthetic-universe SSOT
+    (``archimedes.universe.SYNTHETIC_UNIVERSE``, keyed by ``yfinance_ticker``),
+    (2) the small explicit supplemental table for legacy operation aliases /
+    single-name pairs legs. Anything else is honestly reported as unclassified —
+    see the module docstring: "needs human review" beats a fabricated verdict.
+    """
+    t = ticker.strip().upper()
+    if not t:
+        return None
+    fine = _ticker_asset_class_map().get(t)
+    if fine is not None:
+        return _FINE_CLASS_TO_BUCKET.get(fine)
+    return _SUPPLEMENTAL_TICKER_BUCKET.get(t)
+
+
+@dataclass(frozen=True)
+class UniverseClassification:
+    """Bucket classification of one strategy's declared ``ASSET_UNIVERSE``."""
+
+    tickers: tuple[str, ...]
+    buckets: tuple[str, ...]  # sorted distinct buckets actually resolved
+    unclassified: tuple[str, ...]  # tickers with no known bucket, sorted
+    band: tuple[float, float] | None  # combined (lo, hi); None if any ticker unclassified
+
+    @property
+    def is_diversified(self) -> bool:
+        """True when the declared universe spans more than one broad bucket."""
+        return len(self.buckets) > 1
+
+    @property
+    def is_fully_classified(self) -> bool:
+        return not self.unclassified
+
+
+def classify_universe(tickers: list[str] | tuple[str, ...]) -> UniverseClassification:
+    """Classify every declared ticker and combine into a plausibility band.
+
+    Combination rule (see module docstring for the portfolio-variance
+    justification): the band's upper bound is the MAX across all resolved
+    buckets' upper bounds (a long-only diversified book cannot be more volatile
+    than its most volatile leg); the lower bound is only meaningful — and only
+    applied by ``assess_strategy`` — when the universe resolves to a SINGLE
+    bucket. ``band`` is ``None`` whenever any declared ticker fails to resolve,
+    so callers never silently apply a partial/wrong band.
+    """
+    resolved: dict[str, str] = {}
+    unclassified: list[str] = []
+    for t in tickers:
+        bucket = classify_ticker(t)
+        if bucket is None:
+            unclassified.append(t.strip().upper())
+        else:
+            resolved[t.strip().upper()] = bucket
+
+    buckets = sorted(set(resolved.values()))
+    band: tuple[float, float] | None = None
+    if buckets and not unclassified:
+        los = [_BUCKET_VOL_BANDS[b][0] for b in buckets]
+        his = [_BUCKET_VOL_BANDS[b][1] for b in buckets]
+        band = (min(los), max(his))
+
+    return UniverseClassification(
+        tickers=tuple(t.strip().upper() for t in tickers),
+        buckets=tuple(buckets),
+        unclassified=tuple(sorted(set(unclassified))),
+        band=band,
+    )
+
+
+@dataclass(frozen=True)
+class VolStats:
+    """Realized annualized vol/return computed from a persisted daily-return series."""
+
+    n_obs: int
+    annualized_vol: float | None
+    annualized_return: float | None
+    degenerate: bool
+    insufficient_data: bool
+
+
+def compute_vol_stats(daily_returns: list[float] | np.ndarray) -> VolStats:
+    """Annualized vol + return from a daily-return series.
+
+    Vol: ``std(ddof=1) * sqrt(252)`` — matches
+    ``services/portfolio_backtester.py::_annualized_metrics`` and
+    ``services/_rigor_helpers.py`` exactly, so the numbers this tool prints agree
+    with every other rigor-gate computation in the repo.
+
+    Return: geometric CAGR over a synthetic equity curve built by compounding the
+    daily returns from 1.0 — ``(curve[-1] / curve[0]) ** (252 / T) - 1`` — the same
+    formula ``_annualized_metrics`` uses. Returns ``None`` if the series ever
+    drives the synthetic curve to <= 0 (a >= -100% day makes CAGR undefined).
+
+    Degenerate check: ``np.ptp(arr) == 0.0`` — IDENTICAL to the guard
+    ``services/_rigor_helpers.py::_sharpe_dsr_inputs`` uses to bail ``compute_dsr``
+    out to ``(None, None)`` on a constant series (checking range rather than
+    ``std(ddof=1) == 0`` because floating-point cancellation can leave a tiny
+    non-zero std for an actually-constant series).
+    """
+    arr = np.asarray(daily_returns, dtype=float)
+    n = int(arr.size)
+
+    if n < MIN_OBS_FOR_ASSESSMENT:
+        return VolStats(n_obs=n, annualized_vol=None, annualized_return=None, degenerate=False, insufficient_data=True)
+
+    if float(np.ptp(arr)) == 0.0:
+        return VolStats(n_obs=n, annualized_vol=None, annualized_return=None, degenerate=True, insufficient_data=False)
+
+    sigma = float(arr.std(ddof=1))
+    ann_vol = sigma * math.sqrt(_ANNUALIZATION)
+
+    curve = np.cumprod(1.0 + arr)
+    ann_return: float | None = None if curve[-1] <= 0 else float(curve[-1] ** (_ANNUALIZATION / n) - 1.0)
+
+    return VolStats(
+        n_obs=n, annualized_vol=ann_vol, annualized_return=ann_return, degenerate=False, insufficient_data=False
+    )
+
+
+def daily_returns_from_equity_curve(equity_curve: list[float] | np.ndarray) -> list[float]:
+    """Derive a daily-return series from an equity curve via pct-change.
+
+    Shared by the write-time guard (``scripts/run_backtests.py``), which has a
+    freshly-mapped ``BacktestResult.equity_curve`` available before the artifact
+    is persisted but not yet a DB row to re-read ``daily_returns`` from. This is
+    the SAME fallback formula ``services/backtest_repository.py::get_daily_returns``
+    uses when a persisted row's ``artifact_json`` has no raw ``daily_returns``
+    array — so a strategy checked at write time and re-checked later by the audit
+    script (Deliverable 1) sees numerically consistent vol figures either way.
+    """
+    arr = np.asarray(equity_curve, dtype=float)
+    if arr.size < 2:
+        return []
+    return ((arr[1:] - arr[:-1]) / arr[:-1]).tolist()
+
+
+class VolPlausibilityError(Exception):
+    """Raised by the write-time guard when a freshly-computed backtest's realized
+    vol is wildly inconsistent with its strategy's declared ``ASSET_UNIVERSE``.
+
+    Callers (e.g. ``scripts/run_backtests.py``) should catch this alongside their
+    other typed engine errors and REFUSE to persist the row rather than silently
+    writing a backtest that reads as the wrong asset — this is the deliverable-2
+    permanent guard for the confirmed "backtesting the wrong asset" defect class
+    (see the module docstring for the Rule A / Rule B split it applies).
+    """
+
+
+@dataclass(frozen=True)
+class PlausibilityVerdict:
+    """Combined verdict from ``assess_strategy``."""
+
+    status: str  # "clean" | "flagged" | "unclassified" | "degenerate" | "insufficient_data"
+    reasons: tuple[str, ...]
+    universe: UniverseClassification
+    vol_stats: VolStats
+    baseline_vol: float | None
+    baseline_delta: float | None
+
+    @property
+    def is_clean(self) -> bool:
+        return self.status == "clean"
+
+    @property
+    def needs_attention(self) -> bool:
+        """True for every status a human should look at — everything except a
+        confirmed-clean read and a "too little data yet" read."""
+        return self.status in ("flagged", "unclassified", "degenerate")
+
+
+def _evaluate_class_band(
+    universe: UniverseClassification,
+    realized_vol: float,
+    *,
+    margin: float,
+) -> list[str]:
+    """Rule A. Returns a list of human-readable violation reasons (empty = passes)."""
+    if universe.band is None:
+        return []  # unclassified — handled separately, not a Rule-A verdict
+    lo, hi = universe.band
+    reasons: list[str] = []
+    hi_bound = hi * margin
+    if realized_vol > hi_bound:
+        reasons.append(
+            f"realized vol {realized_vol:.4f} exceeds the declared-universe plausible band "
+            f"upper bound {hi_bound:.4f} ({margin}x margin over bucket(s) {', '.join(universe.buckets)})"
+        )
+    # Lower bound only meaningful (and only enforced) for a single-bucket
+    # universe — see module docstring: diversification can legitimately push a
+    # multi-bucket book's vol far below any single component's floor.
+    if len(universe.buckets) == 1 and lo > 0:
+        lo_bound = lo / margin
+        if realized_vol < lo_bound:
+            reasons.append(
+                f"realized vol {realized_vol:.4f} is below the declared-universe plausible band "
+                f"lower bound {lo_bound:.4f} (bucket {universe.buckets[0]!r})"
+            )
+    return reasons
+
+
+def _evaluate_baseline_match(
+    universe: UniverseClassification,
+    realized_vol: float,
+    baseline_vol: float,
+    *,
+    abs_tol: float,
+    rel_tol: float,
+) -> list[str]:
+    """Rule B. Returns violation reasons (empty = no suspicious match)."""
+    # The reference strategy's own trivial single-broad-equity universe
+    # legitimately matches itself — nothing to flag there. Any other universe
+    # that lands this close to the pure-equity baseline is suspicious.
+    if universe.buckets == ("broad_equity",) and len(universe.tickers) == 1:
+        return []
+    tol = max(abs_tol, rel_tol * baseline_vol)
+    delta = abs(realized_vol - baseline_vol)
+    if delta <= tol:
+        return [
+            f"realized vol {realized_vol:.4f} matches the pipeline_buy_hold equity baseline "
+            f"{baseline_vol:.4f} within tolerance {tol:.4f} despite a non-equity-only declared "
+            f"universe {list(universe.tickers)!r} — statistical signature of the confirmed "
+            "single-feed-default fallback (see module docstring)"
+        ]
+    return []
+
+
+def assess_strategy(
+    tickers: list[str] | tuple[str, ...],
+    daily_returns: list[float] | np.ndarray,
+    *,
+    baseline_vol: float | None = None,
+    margin: float = BAND_MARGIN,
+    baseline_abs_tol: float = BASELINE_ABS_TOL,
+    baseline_rel_tol: float = BASELINE_REL_TOL,
+) -> PlausibilityVerdict:
+    """Single entry point combining degenerate/insufficient-data/Rule-A/Rule-B.
+
+    ``baseline_vol=None`` skips Rule B entirely — the caller degrades to the
+    self-contained Rule A when no ``pipeline_buy_hold`` baseline is available yet
+    (see the module docstring). Both the audit script and the write-time guard
+    normally pass the ``pipeline_buy_hold`` realized vol here to get the full
+    two-rule check.
+    """
+    universe = classify_universe(list(tickers))
+    vol_stats = compute_vol_stats(daily_returns)
+
+    if vol_stats.insufficient_data:
+        return PlausibilityVerdict(
+            status="insufficient_data",
+            reasons=(f"only {vol_stats.n_obs} observations (< {MIN_OBS_FOR_ASSESSMENT})",),
+            universe=universe,
+            vol_stats=vol_stats,
+            baseline_vol=baseline_vol,
+            baseline_delta=None,
+        )
+
+    if vol_stats.degenerate:
+        return PlausibilityVerdict(
+            status="degenerate",
+            reasons=(f"constant daily-return series across {vol_stats.n_obs} observations (zero range)",),
+            universe=universe,
+            vol_stats=vol_stats,
+            baseline_vol=baseline_vol,
+            baseline_delta=None,
+        )
+
+    assert vol_stats.annualized_vol is not None  # guaranteed by the two branches above
+    realized_vol = vol_stats.annualized_vol
+
+    reasons: list[str] = []
+    reasons.extend(_evaluate_class_band(universe, realized_vol, margin=margin))
+
+    baseline_delta: float | None = None
+    if baseline_vol is not None:
+        baseline_delta = realized_vol - baseline_vol
+        reasons.extend(
+            _evaluate_baseline_match(
+                universe, realized_vol, baseline_vol, abs_tol=baseline_abs_tol, rel_tol=baseline_rel_tol
+            )
+        )
+
+    if reasons:
+        status = "flagged"
+    elif not universe.tickers:
+        status = "unclassified"
+        reasons = ["strategy declares no ASSET_UNIVERSE — cannot assess plausibility"]
+    elif not universe.is_fully_classified:
+        status = "unclassified"
+        reasons = [f"unrecognized ticker(s), cannot assess plausibility: {list(universe.unclassified)!r}"]
+    else:
+        status = "clean"
+
+    return PlausibilityVerdict(
+        status=status,
+        reasons=tuple(reasons),
+        universe=universe,
+        vol_stats=vol_stats,
+        baseline_vol=baseline_vol,
+        baseline_delta=baseline_delta,
+    )

--- a/backend/tests/test_audit_backtest_universe.py
+++ b/backend/tests/test_audit_backtest_universe.py
@@ -1,0 +1,337 @@
+"""Hermetic integration tests for scripts/audit_backtest_universe.py (Deliverable 1).
+
+sqlite-in-memory DB + a temp analytics-engine/strategies/ tree, mirroring the
+pattern in test_run_backtests_script.py. Mocks at the boundary — the DB session
+factory and the strategies directory — never internals.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from archimedes.models.backtest import BacktestResult
+from archimedes.models.chat import Base
+from archimedes.scripts import audit_backtest_universe as audit_mod
+from archimedes.services.backtest_repository import insert_backtest_if_missing
+from archimedes.services.strategy_provider import default_provider
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def _write_strategy(path: Path, *, asset_universe: list[str], regime_tag: str = "regime_neutral") -> None:
+    universe_literal = json.dumps(asset_universe)
+    path.write_text(
+        "import backtrader as bt\n\n"
+        f"PAPER_TITLE = {path.stem!r}\n"
+        "PAPER_AUTHORS = ['Test']\n"
+        "METHODOLOGY_SUMMARY = 'Test summary'\n"
+        f"ASSET_UNIVERSE = {universe_literal}\n"
+        "STATUS = 'candidate'\n"
+        f"REGIME_TAG = {regime_tag!r}\n\n"
+        "class TestStrategy(bt.Strategy):\n"
+        "    def next(self):\n"
+        "        if not self.position:\n"
+        "            self.buy(size=1)\n"
+    )
+
+
+def _sample_result(strategy_id: str, equity_curve: list[float]) -> BacktestResult:
+    return BacktestResult(
+        strategy_id=strategy_id,
+        sharpe_ratio=0.5,
+        sortino_ratio=0.5,
+        max_drawdown=0.2,
+        cagr=0.1,
+        calmar_ratio=0.5,
+        win_rate=0.5,
+        profit_factor=1.2,
+        total_trades=10,
+        avg_holding_period_days=5.0,
+        correlation_to_spy=0.3,
+        correlation_to_btc=0.1,
+        equity_curve=equity_curve,
+        monthly_returns=[0.01],
+    )
+
+
+def _equity_curve_from_returns(daily_returns: list[float], start: float = 100_000.0) -> list[float]:
+    curve = [start]
+    for r in daily_returns:
+        curve.append(curve[-1] * (1.0 + r))
+    return curve
+
+
+def _artifact_json_with_daily_returns(daily_returns: list[float]) -> str:
+    """A minimal artifact payload shaped like get_daily_returns expects:
+    results[0].metrics.daily_returns."""
+    return json.dumps({"results": [{"operation": "SPY", "metrics": {"daily_returns": daily_returns}}]})
+
+
+def _spy_like_returns(n: int = 5659, seed: int = 20260727) -> list[float]:
+    rng = np.random.default_rng(seed)
+    return rng.normal(loc=0.00045, scale=0.01175, size=n).tolist()
+
+
+def _near_zero_returns(n: int = 5659, seed: int = 7) -> list[float]:
+    rng = np.random.default_rng(seed)
+    return rng.normal(loc=0.00007, scale=0.0006, size=n).tolist()
+
+
+@pytest.fixture
+def _db(monkeypatch):
+    """In-memory sqlite wired into every module that touches the DB, matching
+    the mock-at-the-boundary convention (never internals)."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def fake_init_db() -> None:
+        Base.metadata.create_all(bind=engine)
+
+    def fake_get_session():
+        return SessionLocal()
+
+    monkeypatch.setattr(audit_mod, "get_session", fake_get_session)
+    monkeypatch.setattr(audit_mod, "init_db", fake_init_db)
+
+    # strategy_provider.py does its own `from archimedes.db import get_session`
+    # import (a separately-bound reference) for fixture/backtest-stub loading —
+    # patch it too so the provider degrades cleanly against the SAME fake DB
+    # instead of a real one that doesn't exist in this test process.
+    from archimedes.services import strategy_provider as strategy_provider_mod
+
+    monkeypatch.setattr(strategy_provider_mod, "get_session", fake_get_session)
+
+    return SessionLocal
+
+
+def test_clean_strategy_passes(_db, tmp_path) -> None:
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "pipeline_buy_hold.py", asset_universe=["SPY"], regime_tag="bull")
+
+    returns = _spy_like_returns()
+    SessionLocal = _db
+    provider = default_provider(repo_root=tmp_path)
+    (strategy,) = provider.list_strategies()
+
+    with SessionLocal() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategy.id,
+            content_hash="h1",
+            result=_sample_result(strategy.id, _equity_curve_from_returns(returns)),
+            artifact_json=_artifact_json_with_daily_returns(returns),
+        )
+        session.commit()
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].status == "clean"
+    assert rows[0].needs_attention is False
+
+
+def test_bil_declared_strategy_with_equity_vol_is_flagged(_db, tmp_path) -> None:
+    """The confirmed defect, end to end through the audit script: a BIL-declared
+    strategy whose persisted returns are actually ~18-19% (equity) vol."""
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "pipeline_buy_hold.py", asset_universe=["SPY"], regime_tag="bull")
+    _write_strategy(strategies_dir / "capital_preservation_tbill.py", asset_universe=["BIL"])
+
+    equity_returns = _spy_like_returns()
+    SessionLocal = _db
+    provider = default_provider(repo_root=tmp_path)
+    strategies = {Path(s.strategy_code_path).stem: s for s in provider.list_strategies()}
+
+    with SessionLocal() as session:
+        for stem, strategy in strategies.items():
+            insert_backtest_if_missing(
+                session,
+                strategy_id=strategy.id,
+                content_hash=f"h-{stem}",
+                result=_sample_result(strategy.id, _equity_curve_from_returns(equity_returns)),
+                artifact_json=_artifact_json_with_daily_returns(equity_returns),
+            )
+        session.commit()
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+    by_stem = {r.stem: r for r in rows}
+
+    assert by_stem["pipeline_buy_hold"].status == "clean"
+    tbill_row = by_stem["capital_preservation_tbill"]
+    assert tbill_row.status == "flagged"
+    assert tbill_row.needs_attention is True
+    assert any("plausible band" in r for r in tbill_row.verdict.reasons)
+    assert any("equity baseline" in r for r in tbill_row.verdict.reasons)
+
+    # Table rendering + exit-code plumbing both surface the flag.
+    table = audit_mod.render_table(rows)
+    assert "capital_preservation_tbill" in table
+    assert "flagged" in table
+
+    exit_code = audit_mod.main(["--json", "--repo-root", str(tmp_path)])
+    assert exit_code == 1
+
+
+def test_strategy_with_no_persisted_returns_is_skipped_not_crashed(_db, tmp_path) -> None:
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "brand_new_strategy.py", asset_universe=["SPY"])
+
+    # No insert_backtest_if_missing call at all — nothing persisted yet.
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].status == "skipped"
+    assert rows[0].verdict is None
+    assert rows[0].needs_attention is False
+
+    # Must not raise, and must not count as a failure.
+    exit_code = audit_mod.main(["--repo-root", str(tmp_path)])
+    assert exit_code == 0
+
+
+def test_degenerate_all_zero_series_is_reported_not_passed_or_crashed(_db, tmp_path) -> None:
+    """5 real strategies persist an exact-zero, 5,659-observation constant
+    series (per the audit) — compute_dsr returns None for these; the audit
+    tool must report them as a distinct 'degenerate' category."""
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "flatlined_strategy.py", asset_universe=["SPY"])
+
+    zero_returns = [0.0] * 5659
+    SessionLocal = _db
+    provider = default_provider(repo_root=tmp_path)
+    (strategy,) = provider.list_strategies()
+
+    with SessionLocal() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategy.id,
+            content_hash="h1",
+            result=_sample_result(strategy.id, _equity_curve_from_returns(zero_returns)),
+            artifact_json=_artifact_json_with_daily_returns(zero_returns),
+        )
+        session.commit()
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].status == "degenerate"
+    assert rows[0].needs_attention is True
+
+    exit_code = audit_mod.main(["--repo-root", str(tmp_path)])
+    assert exit_code == 1
+
+
+def test_maillard_style_diversified_strategy_matching_baseline_is_flagged(_db, tmp_path) -> None:
+    """The second confirmed defect: a 5-asset declared universe whose realized
+    vol lands within tolerance of the pipeline_buy_hold equity baseline."""
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "pipeline_buy_hold.py", asset_universe=["SPY"], regime_tag="bull")
+    _write_strategy(
+        strategies_dir / "maillard_2010_risk_parity.py",
+        asset_universe=["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"],
+    )
+
+    baseline_returns = _spy_like_returns(seed=1)
+    near_match_returns = _spy_like_returns(seed=2)
+
+    SessionLocal = _db
+    provider = default_provider(repo_root=tmp_path)
+    strategies = {Path(s.strategy_code_path).stem: s for s in provider.list_strategies()}
+
+    with SessionLocal() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategies["pipeline_buy_hold"].id,
+            content_hash="h-baseline",
+            result=_sample_result(strategies["pipeline_buy_hold"].id, _equity_curve_from_returns(baseline_returns)),
+            artifact_json=_artifact_json_with_daily_returns(baseline_returns),
+        )
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategies["maillard_2010_risk_parity"].id,
+            content_hash="h-maillard",
+            result=_sample_result(
+                strategies["maillard_2010_risk_parity"].id, _equity_curve_from_returns(near_match_returns)
+            ),
+            artifact_json=_artifact_json_with_daily_returns(near_match_returns),
+        )
+        session.commit()
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+    by_stem = {r.stem: r for r in rows}
+
+    maillard_row = by_stem["maillard_2010_risk_parity"]
+    assert maillard_row.status == "flagged"
+    assert any("equity baseline" in r for r in maillard_row.verdict.reasons)
+
+
+def test_cross_store_delta_is_reported_when_stores_disagree(_db, tmp_path) -> None:
+    """strategy_daily_returns (keyed by stem) disagreeing with backtest_results
+    (keyed by strategy_id) is itself a defect signal — must be surfaced, not
+    silently ignored, without being the thing that drives the primary verdict."""
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "disagreeing_strategy.py", asset_universe=["SPY"])
+
+    primary_returns = _spy_like_returns(seed=3)
+    other_store_returns = _near_zero_returns(seed=4)  # wildly different vol in the other store
+
+    SessionLocal = _db
+    provider = default_provider(repo_root=tmp_path)
+    (strategy,) = provider.list_strategies()
+
+    with SessionLocal() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategy.id,
+            content_hash="h1",
+            result=_sample_result(strategy.id, _equity_curve_from_returns(primary_returns)),
+            artifact_json=_artifact_json_with_daily_returns(primary_returns),
+        )
+        session.commit()
+
+        from datetime import date, timedelta
+
+        from archimedes.models.daily_returns_store import StrategyDailyReturn
+
+        base_date = date(2004, 1, 2)
+        for i, r in enumerate(other_store_returns):
+            session.add(
+                StrategyDailyReturn(
+                    stem="disagreeing_strategy",
+                    date=base_date + timedelta(days=i),
+                    daily_return=r,
+                    data_vintage="2026-07-27",
+                )
+            )
+        session.commit()
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.cross_store_vol is not None
+    assert row.cross_store_delta is not None
+    assert abs(row.cross_store_delta) > 0.05  # near-zero vs equity vol — a large, real gap
+    assert row.cross_store_large_delta is True
+    assert row.needs_attention is True
+
+
+def test_render_table_does_not_crash_on_empty_or_mixed_rows(_db, tmp_path) -> None:
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "only_strategy.py", asset_universe=["SPY"])
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+    table = audit_mod.render_table(rows)
+    assert "only_strategy" in table
+    assert "skipped" in table

--- a/backend/tests/test_run_backtests_vol_guard.py
+++ b/backend/tests/test_run_backtests_vol_guard.py
@@ -99,6 +99,60 @@ def _artifact_payload(equity_curve: list[float], daily_returns: list[float], *, 
     }
 
 
+def _multi_op_artifact_payload(entries: list[tuple[str, list[float], list[float]]]) -> dict:
+    """Like ``_artifact_payload`` but with N result entries — one per
+    ``(operation, equity_curve, daily_returns)`` tuple, in the given order.
+    Lets a test put the CHOSEN operation somewhere other than ``results[0]``
+    (e.g. a ``BACKTEST_OPERATIONS=NIKKEI,SPY`` run where select_operation_result
+    finds "SPY" at index 1, not index 0)."""
+    return {
+        "run_id": "20260727T000000Z",
+        "strategy": {
+            "backtest_code_hash": "a" * 64,
+            "paper_claimed_sharpe": None,
+            "paper_claimed_cagr": None,
+            "paper_claimed_max_dd": None,
+        },
+        "assumptions": {
+            "transaction_cost_bps": 10,
+            "walk_forward_split": None,
+            "backtest_engine": "backtrader",
+        },
+        "integrity_flags": {
+            "lookahead_audit_passed": True,
+        },
+        "results": [
+            {
+                "operation": operation,
+                "symbol": operation,
+                "metrics": {
+                    "sharpe_ratio": 0.5,
+                    "sortino_ratio": 0.5,
+                    "calmar_ratio": 0.3,
+                    "max_drawdown_pct": 20.0,
+                    "cagr": 0.08,
+                    "total_trades": 0,
+                    "win_rate": None,
+                    "profit_factor": None,
+                    "avg_holding_period_days": None,
+                    "correlation_to_spy": None,
+                    "correlation_to_btc": None,
+                    "equity_curve": equity_curve,
+                    "monthly_returns": [0.01],
+                    "daily_returns": daily_returns,
+                    "transaction_cost_bps": 10,
+                    "slippage_bps": 5,
+                    "look_ahead_audit_passed": True,
+                    "backtest_engine": "backtrader",
+                    "backtest_start": "2004-01-02T00:00:00",
+                    "backtest_end": "2026-07-27T00:00:00",
+                },
+            }
+            for operation, equity_curve, daily_returns in entries
+        ],
+    }
+
+
 def _wire_hermetic_db(monkeypatch):
     engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
     SessionLocal = sessionmaker(bind=engine)
@@ -273,3 +327,65 @@ def test_baseline_missing_degrades_to_rule_a_only_without_crashing(monkeypatch, 
 
     with SessionLocal() as session:
         assert session.query(BacktestResultRecord).count() == 1
+
+
+def test_guard_validates_chosen_operations_raw_series_not_results_zero_or_curve(monkeypatch, tmp_path) -> None:
+    """Regression for the write-time guard validating a different series than
+    downstream reads (audit 2026-07-27 follow-up): with a multi-operation
+    artifact (e.g. BACKTEST_OPERATIONS=NIKKEI,SPY), select_operation_result
+    picks the row by NAME — it finds "SPY" at index 1, not index 0 — so the
+    CHOSEN operation is NOT results[0].
+
+    results[0] ("NIKKEI") is a degenerate all-zero series that is never the
+    chosen operation and must be ignored entirely. results[1] ("SPY", the
+    chosen operation) deliberately carries an equity_curve that pct-changes to
+    a CLEAN low-vol series but a raw daily_returns field that is wildly
+    high-vol (annualized ~190%, far outside even the 1.5x-margined
+    broad_equity band of 8-35%) — an artificial split that isolates exactly
+    one thing: does the guard read the chosen operation's raw daily_returns
+    (correct — must flag) or silently re-derive a different, clean-looking
+    series from its equity_curve (the bug — would wrongly pass)?
+    """
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    _write_strategy(strategies_dir / "multi_op_strategy.py", asset_universe=["SPY"])
+
+    SessionLocal = _wire_hermetic_db(monkeypatch)
+
+    nikkei_returns = [0.0] * 20  # degenerate — must never be read (not chosen)
+    nikkei_curve = _equity_curve_from_returns(nikkei_returns)
+
+    spy_clean_returns = _spy_like_returns(n=300, seed=123)  # ~18% vol — passes Rule A
+    spy_clean_curve = _equity_curve_from_returns(spy_clean_returns)
+
+    rng = np.random.default_rng(456)
+    spy_raw_extreme_returns = rng.normal(loc=0.0, scale=0.12, size=300).tolist()  # ~190% vol — fails Rule A
+
+    def fake_run_command(**kwargs):
+        artifact_path = kwargs["artifact_dir"] / "20260727T000000Z.json"
+        payload = _multi_op_artifact_payload(
+            [
+                ("NIKKEI", nikkei_curve, nikkei_returns),
+                ("SPY", spy_clean_curve, spy_raw_extreme_returns),
+            ]
+        )
+        artifact_path.write_text(json.dumps(payload), encoding="utf-8")
+        return {"run_id": "20260727T000000Z", "artifact_path": str(artifact_path)}
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+
+    summary = run_backtests_mod.run_backtests()
+
+    assert summary["inserted"] == 0
+    assert summary["failed"] == 1
+    message = next(iter(summary["errors"].values()))
+    assert "VolPlausibilityError" in message
+    assert "plausible band" in message  # Rule A upper-bound violation, not "degenerate"
+
+    with SessionLocal() as session:
+        assert session.query(BacktestResultRecord).count() == 0

--- a/backend/tests/test_run_backtests_vol_guard.py
+++ b/backend/tests/test_run_backtests_vol_guard.py
@@ -389,3 +389,54 @@ def test_guard_validates_chosen_operations_raw_series_not_results_zero_or_curve(
 
     with SessionLocal() as session:
         assert session.query(BacktestResultRecord).count() == 0
+
+
+# ── The guard must validate the SAME series downstream reads back ──────────
+#
+# Making the guard read the chosen operation closed only half the gap:
+# backtest_repository.get_daily_returns() ignores the `operation` column and
+# returns the FIRST non-empty daily_returns in artifact_json["results"]. With
+# BACKTEST_OPERATIONS="NIKKEI,SPY" the guard validated SPY while the rigor gate
+# graded NIKKEI. A guard that certifies a different series than the gate reads
+# is worse than none. Write-time reordering makes them the same row.
+
+
+def test_persisted_payload_puts_selected_operation_first():
+    from archimedes.scripts.run_backtests import _payload_with_selected_operation_first
+
+    payload = {
+        "run_id": "r1",
+        "results": [
+            {"operation": "NIKKEI", "metrics": {"daily_returns": [0.9, -0.9]}},
+            {"operation": "SPY", "metrics": {"daily_returns": [0.01, -0.01]}},
+        ],
+    }
+    out = _payload_with_selected_operation_first(payload, "SPY")
+
+    assert [r["operation"] for r in out["results"]] == ["SPY", "NIKKEI"]
+    # What get_daily_returns() would return (first non-empty) is now the
+    # chosen operation's series, not NIKKEI's.
+    assert out["results"][0]["metrics"]["daily_returns"] == [0.01, -0.01]
+    # Non-results keys survive untouched.
+    assert out["run_id"] == "r1"
+    # Original is not mutated.
+    assert [r["operation"] for r in payload["results"]] == ["NIKKEI", "SPY"]
+
+
+def test_persisted_payload_is_untouched_in_the_single_operation_case():
+    """No content_hash churn for the current default (BACKTEST_OPERATIONS=SPY)."""
+    from archimedes.scripts.run_backtests import _payload_with_selected_operation_first
+
+    payload = {"results": [{"operation": "SPY", "metrics": {"daily_returns": [0.01]}}]}
+    assert _payload_with_selected_operation_first(payload, "SPY") is payload
+    # Already-first, multi-result case is also a pass-through.
+    two = {
+        "results": [
+            {"operation": "SPY", "metrics": {"daily_returns": [0.01]}},
+            {"operation": "NIKKEI", "metrics": {"daily_returns": [0.9]}},
+        ]
+    }
+    assert _payload_with_selected_operation_first(two, "SPY") is two
+    # Unknown/absent operation must not reorder or raise.
+    assert _payload_with_selected_operation_first(two, "GOLD") is two
+    assert _payload_with_selected_operation_first(two, None) is two

--- a/backend/tests/test_run_backtests_vol_guard.py
+++ b/backend/tests/test_run_backtests_vol_guard.py
@@ -1,0 +1,275 @@
+"""Hermetic tests for the Deliverable-2 permanent guard wired into
+scripts/run_backtests.py (audit 2026-07-27): a regenerated artifact whose
+realized vol is wildly inconsistent with its strategy's declared
+``ASSET_UNIVERSE`` must FAIL rather than be silently persisted.
+
+Same sqlite-in-memory + monkeypatch pattern as test_run_backtests_script.py
+(mocks at the boundary: ``_repo_root``, ``_load_run_command``, ``init_db``,
+``get_session`` — never internals).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+from archimedes.models.backtest_store import BacktestResultRecord
+from archimedes.models.chat import Base
+from archimedes.scripts import run_backtests as run_backtests_mod
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def _write_strategy(path: Path, *, asset_universe: list[str], regime_tag: str = "regime_neutral") -> None:
+    universe_literal = json.dumps(asset_universe)
+    path.write_text(
+        "import backtrader as bt\n\n"
+        f"PAPER_TITLE = {path.stem!r}\n"
+        "PAPER_AUTHORS = ['Test']\n"
+        "METHODOLOGY_SUMMARY = 'Test summary'\n"
+        f"ASSET_UNIVERSE = {universe_literal}\n"
+        "STATUS = 'candidate'\n"
+        f"REGIME_TAG = {regime_tag!r}\n\n"
+        "class TestStrategy(bt.Strategy):\n"
+        "    def next(self):\n"
+        "        if not self.position:\n"
+        "            self.buy(size=1)\n"
+    )
+
+
+def _equity_curve_from_returns(daily_returns: list[float], start: float = 100_000.0) -> list[float]:
+    curve = [start]
+    for r in daily_returns:
+        curve.append(curve[-1] * (1.0 + r))
+    return curve
+
+
+def _spy_like_returns(n: int = 5659, seed: int = 20260727) -> list[float]:
+    rng = np.random.default_rng(seed)
+    return rng.normal(loc=0.00045, scale=0.01175, size=n).tolist()
+
+
+def _artifact_payload(equity_curve: list[float], daily_returns: list[float], *, operation: str = "SPY") -> dict:
+    return {
+        "run_id": "20260727T000000Z",
+        "strategy": {
+            "backtest_code_hash": "a" * 64,
+            "paper_claimed_sharpe": None,
+            "paper_claimed_cagr": None,
+            "paper_claimed_max_dd": None,
+        },
+        "assumptions": {
+            "transaction_cost_bps": 10,
+            "walk_forward_split": None,
+            "backtest_engine": "backtrader",
+        },
+        "integrity_flags": {
+            "lookahead_audit_passed": True,
+        },
+        "results": [
+            {
+                "operation": operation,
+                "symbol": operation,
+                "metrics": {
+                    "sharpe_ratio": 0.5,
+                    "sortino_ratio": 0.5,
+                    "calmar_ratio": 0.3,
+                    "max_drawdown_pct": 20.0,
+                    "cagr": 0.08,
+                    "total_trades": 0,
+                    "win_rate": None,
+                    "profit_factor": None,
+                    "avg_holding_period_days": None,
+                    "correlation_to_spy": None,
+                    "correlation_to_btc": None,
+                    "equity_curve": equity_curve,
+                    "monthly_returns": [0.01],
+                    "daily_returns": daily_returns,
+                    "transaction_cost_bps": 10,
+                    "slippage_bps": 5,
+                    "look_ahead_audit_passed": True,
+                    "backtest_engine": "backtrader",
+                    "backtest_start": "2004-01-02T00:00:00",
+                    "backtest_end": "2026-07-27T00:00:00",
+                },
+            }
+        ],
+    }
+
+
+def _wire_hermetic_db(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    monkeypatch.setattr(run_backtests_mod, "init_db", lambda: Base.metadata.create_all(bind=engine))
+    monkeypatch.setattr(run_backtests_mod, "get_session", lambda: SessionLocal())
+
+    from archimedes.services import strategy_provider as strategy_provider_mod
+
+    monkeypatch.setattr(strategy_provider_mod, "get_session", lambda: SessionLocal())
+
+    return SessionLocal
+
+
+def test_wildly_inconsistent_artifact_is_refused_not_persisted(monkeypatch, tmp_path) -> None:
+    """The confirmed defect, at the exact write path: a BIL-declared strategy
+    whose freshly-computed artifact reads ~18-19% (equity) vol must be REFUSED
+    — no row written — rather than silently persisted."""
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    _write_strategy(strategies_dir / "capital_preservation_tbill.py", asset_universe=["BIL"])
+
+    SessionLocal = _wire_hermetic_db(monkeypatch)
+    equity_returns = _spy_like_returns()
+
+    def fake_run_command(**kwargs):
+        artifact_path = kwargs["artifact_dir"] / "20260727T000000Z.json"
+        curve = _equity_curve_from_returns(equity_returns)
+        artifact_path.write_text(json.dumps(_artifact_payload(curve, equity_returns)), encoding="utf-8")
+        return {"run_id": "20260727T000000Z", "artifact_path": str(artifact_path)}
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+
+    summary = run_backtests_mod.run_backtests()
+
+    assert summary["inserted"] == 0
+    assert summary["failed"] == 1
+    assert "VolPlausibilityError" in next(iter(summary["errors"].values()))
+
+    with SessionLocal() as session:
+        assert session.query(BacktestResultRecord).count() == 0
+
+
+def test_wildly_inconsistent_artifact_logs_loudly_no_traceback(monkeypatch, tmp_path, caplog) -> None:
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    _write_strategy(strategies_dir / "capital_preservation_tbill.py", asset_universe=["BIL"])
+
+    _wire_hermetic_db(monkeypatch)
+    equity_returns = _spy_like_returns()
+
+    def fake_run_command(**kwargs):
+        artifact_path = kwargs["artifact_dir"] / "20260727T000000Z.json"
+        curve = _equity_curve_from_returns(equity_returns)
+        artifact_path.write_text(json.dumps(_artifact_payload(curve, equity_returns)), encoding="utf-8")
+        return {"run_id": "20260727T000000Z", "artifact_path": str(artifact_path)}
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+
+    with caplog.at_level(logging.INFO, logger=run_backtests_mod.logger.name):
+        run_backtests_mod.run_backtests()
+
+    records = [r for r in caplog.records if r.name == run_backtests_mod.logger.name]
+    error_records = [r for r in records if r.levelno == logging.ERROR]
+    assert any("REFUSING to persist" in r.getMessage() for r in error_records)
+    assert not any(r.exc_info for r in records)  # explanatory error, no dumped traceback
+
+
+def test_plausible_artifact_is_persisted_normally(monkeypatch, tmp_path) -> None:
+    """A strategy whose declared universe and realized vol agree must NOT be
+    touched by the guard — no false positives on the happy path."""
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    _write_strategy(strategies_dir / "pipeline_buy_hold.py", asset_universe=["SPY"], regime_tag="bull")
+
+    SessionLocal = _wire_hermetic_db(monkeypatch)
+    equity_returns = _spy_like_returns()
+
+    def fake_run_command(**kwargs):
+        artifact_path = kwargs["artifact_dir"] / "20260727T000000Z.json"
+        curve = _equity_curve_from_returns(equity_returns)
+        artifact_path.write_text(json.dumps(_artifact_payload(curve, equity_returns)), encoding="utf-8")
+        return {"run_id": "20260727T000000Z", "artifact_path": str(artifact_path)}
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+
+    summary = run_backtests_mod.run_backtests()
+
+    assert summary["inserted"] == 1
+    assert summary["failed"] == 0
+
+    with SessionLocal() as session:
+        assert session.query(BacktestResultRecord).count() == 1
+
+
+def test_degenerate_artifact_is_refused_not_persisted(monkeypatch, tmp_path) -> None:
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    _write_strategy(strategies_dir / "flatlined_strategy.py", asset_universe=["SPY"])
+
+    SessionLocal = _wire_hermetic_db(monkeypatch)
+    zero_returns = [0.0] * 5659
+
+    def fake_run_command(**kwargs):
+        artifact_path = kwargs["artifact_dir"] / "20260727T000000Z.json"
+        curve = _equity_curve_from_returns(zero_returns)
+        artifact_path.write_text(json.dumps(_artifact_payload(curve, zero_returns)), encoding="utf-8")
+        return {"run_id": "20260727T000000Z", "artifact_path": str(artifact_path)}
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+
+    summary = run_backtests_mod.run_backtests()
+
+    assert summary["inserted"] == 0
+    assert summary["failed"] == 1
+    assert "degenerate" in next(iter(summary["errors"].values()))
+
+    with SessionLocal() as session:
+        assert session.query(BacktestResultRecord).count() == 0
+
+
+def test_baseline_missing_degrades_to_rule_a_only_without_crashing(monkeypatch, tmp_path) -> None:
+    """Before pipeline_buy_hold itself has ANY persisted backtest (e.g. a brand
+    new clone's first ever run), the guard must degrade gracefully to Rule A
+    rather than raising or blocking every other strategy's insert."""
+    repo_root = tmp_path
+    strategies_dir = repo_root / "analytics-engine" / "strategies"
+    artifacts_dir = repo_root / "analytics-engine" / "artifacts"
+    strategies_dir.mkdir(parents=True)
+    artifacts_dir.mkdir(parents=True)
+
+    # No pipeline_buy_hold.py at all in this tree.
+    _write_strategy(strategies_dir / "some_equity_strategy.py", asset_universe=["SPY"])
+
+    SessionLocal = _wire_hermetic_db(monkeypatch)
+    equity_returns = _spy_like_returns()
+
+    def fake_run_command(**kwargs):
+        artifact_path = kwargs["artifact_dir"] / "20260727T000000Z.json"
+        curve = _equity_curve_from_returns(equity_returns)
+        artifact_path.write_text(json.dumps(_artifact_payload(curve, equity_returns)), encoding="utf-8")
+        return {"run_id": "20260727T000000Z", "artifact_path": str(artifact_path)}
+
+    monkeypatch.setattr(run_backtests_mod, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(run_backtests_mod, "_load_run_command", lambda _repo: fake_run_command)
+
+    summary = run_backtests_mod.run_backtests()
+
+    assert summary["inserted"] == 1
+    assert summary["failed"] == 0
+
+    with SessionLocal() as session:
+        assert session.query(BacktestResultRecord).count() == 1

--- a/backend/tests/test_vol_plausibility.py
+++ b/backend/tests/test_vol_plausibility.py
@@ -146,6 +146,19 @@ def test_compute_vol_stats_pathological_wipeout_return_is_none_not_a_crash() -> 
     assert stats.annualized_vol is not None  # vol is still well-defined
 
 
+def test_compute_vol_stats_curve_goes_negative_mid_series_then_recovers_is_none() -> None:
+    """Regression: the docstring promises None if the synthetic curve EVER goes
+    <= 0, but checking only curve[-1] misses a curve that dips negative
+    mid-series and then flips back positive. Two sub-(-100%) days in a row
+    compound to a POSITIVE factor (-0.5 * -0.5 = +0.25) via cumprod, even
+    though the curve was actually negative for one step in between — an
+    economically impossible path (you cannot lose more than 100% and then
+    recover). Must be None, not a fabricated ~-100% CAGR."""
+    returns = [-1.5, -1.5] + [0.0] * 10
+    stats = vp.compute_vol_stats(returns)
+    assert stats.annualized_return is None
+
+
 def test_daily_returns_from_equity_curve_matches_pct_change() -> None:
     curve = [100.0, 101.0, 99.99]
     out = vp.daily_returns_from_equity_curve(curve)
@@ -255,6 +268,30 @@ def test_assess_strategy_unclassified_universe_flags_for_human_review() -> None:
     assert verdict.status == "unclassified"
     assert verdict.needs_attention is True
     assert "NOT_A_REAL_TICKER" in verdict.reasons[0]
+
+
+def test_assess_strategy_partially_unclassified_universe_near_baseline_is_unclassified_not_flagged() -> None:
+    """Regression: Rule A correctly returns [] when universe.band is None (any
+    unclassified ticker blanks the band), but Rule B had no equivalent guard —
+    only skipping the trivial pipeline_buy_hold self-match case. A PARTIALLY
+    unclassified universe (SPY resolves, the other ticker doesn't) whose vol
+    happens to sit near the equity baseline must come back 'unclassified' with
+    an honest 'unrecognized ticker(s)' reason — never a fabricated 'matches the
+    pipeline_buy_hold equity baseline' verdict just because it also happens to
+    contain SPY."""
+    baseline_returns = _spy_like_returns(seed=1)
+    baseline_vol = vp.compute_vol_stats(baseline_returns).annualized_vol
+
+    # Same distribution as the baseline (different seed) — realized vol lands
+    # well within Rule B's tolerance of baseline_vol, which is exactly the
+    # scenario that used to produce a fabricated baseline-match flag.
+    near_match_returns = _spy_like_returns(seed=2)
+
+    verdict = vp.assess_strategy(["SPY", "TOTALLY_MADE_UP_TICKER_XYZ"], near_match_returns, baseline_vol=baseline_vol)
+
+    assert verdict.status == "unclassified"
+    assert not any("equity baseline" in r for r in verdict.reasons)
+    assert any("TOTALLY_MADE_UP_TICKER_XYZ" in r for r in verdict.reasons)
 
 
 def test_assess_strategy_no_baseline_available_degrades_to_rule_a_only() -> None:

--- a/backend/tests/test_vol_plausibility.py
+++ b/backend/tests/test_vol_plausibility.py
@@ -1,0 +1,283 @@
+"""Hermetic unit tests for services/vol_plausibility.py — the mechanical detector
+for the confirmed "backtesting the wrong asset" defect class (audit 2026-07-27).
+
+No DB, no network. ``classify_ticker``/``classify_universe`` read
+``archimedes.universe.SYNTHETIC_UNIVERSE``, which is itself a pure JSON-file read at
+import time (no DB/network) — see backend/archimedes/universe.py.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from archimedes.services import vol_plausibility as vp
+
+# Deterministic synthetic daily-return series standing in for real persisted
+# data. Seeded so the exact numeric assertions below are reproducible.
+
+
+def _spy_like_returns(n: int = 5659, seed: int = 20260727) -> list[float]:
+    """~18-19% annualized vol, positive drift — stands in for the real,
+    confirmed-correct pipeline_buy_hold series (18.65% vol per the audit)."""
+    rng = np.random.default_rng(seed)
+    return rng.normal(loc=0.00045, scale=0.01175, size=n).tolist()
+
+
+def _near_zero_vol_returns(n: int = 5659, seed: int = 7) -> list[float]:
+    """~0.2-0.4% annualized vol — stands in for a real T-bill-proxy series."""
+    rng = np.random.default_rng(seed)
+    return rng.normal(loc=0.00007, scale=0.0006, size=n).tolist()
+
+
+# ─── classify_ticker / classify_universe ──────────────────────────────────
+
+
+def test_classify_ticker_resolves_via_onchain_ssot() -> None:
+    assert vp.classify_ticker("SPY") == "broad_equity"
+    assert vp.classify_ticker("BIL") == "cash_tbill"
+    assert vp.classify_ticker("TLT") == "long_bond"
+    assert vp.classify_ticker("GLD") == "commodity"
+
+
+def test_classify_ticker_is_case_insensitive_and_strips_whitespace() -> None:
+    assert vp.classify_ticker("  spy ") == "broad_equity"
+    assert vp.classify_ticker("bil") == "cash_tbill"
+
+
+def test_classify_ticker_resolves_supplemental_legacy_aliases() -> None:
+    # NIKKEI/GOLD/TREASURY/OIL predate the on-chain SSOT (analytics-engine
+    # "operation" aliases); KO/PEP are single-name Gatev-pairs legs. All five
+    # strategy files in the repo that declare these must resolve, not silently
+    # fall through to "unclassified".
+    assert vp.classify_ticker("NIKKEI") == "broad_equity"
+    assert vp.classify_ticker("GOLD") == "commodity"
+    assert vp.classify_ticker("TREASURY") == "long_bond"
+    assert vp.classify_ticker("OIL") == "commodity"
+    assert vp.classify_ticker("KO") == "single_name_equity"
+    assert vp.classify_ticker("PEP") == "single_name_equity"
+
+
+def test_classify_ticker_unknown_ticker_is_unclassified_not_guessed() -> None:
+    assert vp.classify_ticker("ZZZNOTATICKER") is None
+
+
+def test_classify_universe_single_bucket_gets_a_tight_band() -> None:
+    result = vp.classify_universe(["BIL"])
+    assert result.buckets == ("cash_tbill",)
+    assert result.band == (0.0, 0.03)
+    assert result.is_diversified is False
+    assert result.is_fully_classified is True
+
+
+def test_classify_universe_multi_bucket_combines_to_widest_band() -> None:
+    result = vp.classify_universe(["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"])
+    assert set(result.buckets) == {"broad_equity", "commodity", "long_bond"}
+    assert result.is_diversified is True
+    lo, hi = result.band
+    assert lo == min(0.08, 0.10, 0.02)  # broad_equity.lo, commodity.lo, long_bond.lo
+    assert hi == max(0.35, 0.55, 0.20)  # commodity.hi is the widest leg
+
+
+def test_classify_universe_any_unclassified_ticker_blanks_the_band() -> None:
+    result = vp.classify_universe(["SPY", "NOT_A_REAL_TICKER"])
+    assert result.band is None
+    assert result.unclassified == ("NOT_A_REAL_TICKER",)
+    assert not result.is_fully_classified
+
+
+# ─── compute_vol_stats ─────────────────────────────────────────────────────
+
+
+def test_compute_vol_stats_matches_portfolio_backtester_convention() -> None:
+    """252 trading days, ddof=1 — same formula as
+    services/portfolio_backtester.py::_annualized_metrics, so numbers agree
+    repo-wide."""
+    returns = _spy_like_returns()
+    stats = vp.compute_vol_stats(returns)
+
+    arr = np.asarray(returns)
+    expected_vol = float(arr.std(ddof=1)) * (252**0.5)
+
+    assert stats.n_obs == len(returns)
+    assert stats.degenerate is False
+    assert stats.insufficient_data is False
+    assert stats.annualized_vol == expected_vol
+    assert stats.annualized_return is not None
+
+
+def test_compute_vol_stats_degenerate_all_zero_series() -> None:
+    """The exact defect noted in the audit: 5 strategies have realized vol
+    EXACTLY 0.00000 across thousands of observations — a constant series. Must
+    be reported as its own category, not a crash and not a silent 'pass'."""
+    stats = vp.compute_vol_stats([0.0] * 5659)
+    assert stats.degenerate is True
+    assert stats.annualized_vol is None
+    assert stats.annualized_return is None
+    assert stats.n_obs == 5659
+
+
+def test_compute_vol_stats_degenerate_constant_nonzero_series() -> None:
+    """np.ptp-based check (matching _rigor_helpers.compute_dsr) catches ANY
+    constant series, not just all-zero — floating-point std(ddof=1) can be a
+    tiny nonzero float for identical values, which is exactly why range (ptp),
+    not std, is the check."""
+    stats = vp.compute_vol_stats([0.001] * 100)
+    assert stats.degenerate is True
+
+
+def test_compute_vol_stats_insufficient_data_short_series() -> None:
+    stats = vp.compute_vol_stats([0.01, -0.02, 0.005])
+    assert stats.insufficient_data is True
+    assert stats.degenerate is False
+    assert stats.annualized_vol is None
+
+
+def test_compute_vol_stats_empty_series_is_insufficient_not_a_crash() -> None:
+    stats = vp.compute_vol_stats([])
+    assert stats.insufficient_data is True
+    assert stats.n_obs == 0
+
+
+def test_compute_vol_stats_pathological_wipeout_return_is_none_not_a_crash() -> None:
+    """A >= -100% day drives the synthetic equity curve to <= 0 — CAGR is
+    undefined there. Must degrade to None, never raise/NaN silently."""
+    returns = [0.01] * 20 + [-1.5] + [0.01] * 20
+    stats = vp.compute_vol_stats(returns)
+    assert stats.annualized_return is None
+    assert stats.annualized_vol is not None  # vol is still well-defined
+
+
+def test_daily_returns_from_equity_curve_matches_pct_change() -> None:
+    curve = [100.0, 101.0, 99.99]
+    out = vp.daily_returns_from_equity_curve(curve)
+    assert out == [0.01, (99.99 - 101.0) / 101.0]
+
+
+def test_daily_returns_from_equity_curve_too_short_returns_empty() -> None:
+    assert vp.daily_returns_from_equity_curve([100.0]) == []
+    assert vp.daily_returns_from_equity_curve([]) == []
+
+
+# ─── assess_strategy — the combined verdict ───────────────────────────────
+
+
+def test_assess_strategy_clean_strategy_passes() -> None:
+    """pipeline_buy_hold itself: single-ticker SPY, matches the baseline by
+    construction (it IS the baseline) — must be 'clean', not flagged, even
+    though Rule B's whole purpose is to catch equity-baseline matches."""
+    returns = _spy_like_returns()
+    baseline_vol = vp.compute_vol_stats(returns).annualized_vol
+
+    verdict = vp.assess_strategy(["SPY"], returns, baseline_vol=baseline_vol)
+
+    assert verdict.status == "clean"
+    assert verdict.reasons == ()
+    assert verdict.is_clean is True
+    assert verdict.needs_attention is False
+
+
+def test_assess_strategy_flags_bil_declared_strategy_with_equity_vol() -> None:
+    """The confirmed defect: capital_preservation_tbill declares ASSET_UNIVERSE
+    = ["BIL"] but its persisted series reads ~18-19% vol — pure equity, not a
+    T-bill ETF (real-world T-bill vol ~0.2%). Must be flagged by Rule A alone
+    (self-contained — no baseline needed) AND, when a baseline is supplied, by
+    Rule B too."""
+    equity_returns = _spy_like_returns()
+
+    # Rule A alone (no cross-strategy baseline — the write-time-guard shape).
+    verdict_rule_a_only = vp.assess_strategy(["BIL"], equity_returns)
+    assert verdict_rule_a_only.status == "flagged"
+    assert any("plausible band" in r for r in verdict_rule_a_only.reasons)
+
+    # Rule A + Rule B (the full audit-script shape).
+    baseline_vol = vp.compute_vol_stats(equity_returns).annualized_vol
+    verdict_full = vp.assess_strategy(["BIL"], equity_returns, baseline_vol=baseline_vol)
+    assert verdict_full.status == "flagged"
+    assert any("equity baseline" in r for r in verdict_full.reasons)
+    assert verdict_full.needs_attention is True
+
+
+def test_assess_strategy_does_not_flag_a_genuine_low_vol_tbill_series() -> None:
+    """A BIL-declared strategy whose persisted vol IS actually near-zero (the
+    correct, non-defective case) must come back clean — the detector should
+    not cry wolf on the strategy it exists to vindicate."""
+    real_bil_returns = _near_zero_vol_returns()
+    verdict = vp.assess_strategy(["BIL"], real_bil_returns)
+    assert verdict.status == "clean"
+
+
+def test_assess_strategy_flags_diversified_universe_matching_equity_baseline() -> None:
+    """The second confirmed defect: maillard_2010_risk_parity declares a
+    5-asset, risk-parity-weighted universe (which by construction should have
+    LOWER vol than pure equity) but persists ~18.46% vol — statistically
+    indistinguishable from the pure-SPY baseline (18.65%). Rule A's wide
+    multi-bucket band alone does NOT catch this (by design — see module
+    docstring); Rule B does."""
+    baseline_returns = _spy_like_returns(seed=1)
+    baseline_vol = vp.compute_vol_stats(baseline_returns).annualized_vol
+
+    # A slightly different, still near-identical-vol series for the "risk
+    # parity" strategy — the real-world maillard delta was ~1% relative.
+    near_match_returns = _spy_like_returns(seed=2)
+
+    universe = ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+
+    verdict_rule_a_only = vp.assess_strategy(universe, near_match_returns)
+    assert verdict_rule_a_only.status == "clean", (
+        "Rule A's wide multi-bucket band should NOT catch this on its own — "
+        "documented limitation, exactly why Rule B exists"
+    )
+
+    verdict_full = vp.assess_strategy(universe, near_match_returns, baseline_vol=baseline_vol)
+    assert verdict_full.status == "flagged"
+    assert any("equity baseline" in r for r in verdict_full.reasons)
+
+
+def test_assess_strategy_degenerate_series_is_its_own_category() -> None:
+    """Not a pass, not a crash — a distinct 'degenerate' status."""
+    verdict = vp.assess_strategy(["BIL"], [0.0] * 5659)
+    assert verdict.status == "degenerate"
+    assert verdict.needs_attention is True
+    assert verdict.vol_stats.annualized_vol is None
+
+
+def test_assess_strategy_no_returns_is_insufficient_data_not_a_crash() -> None:
+    """The module-level contract for an empty series (the script layer maps
+    this to its own 'skipped' status for a strategy with no persisted backtest
+    at all — see test_audit_backtest_universe.py)."""
+    verdict = vp.assess_strategy(["BIL"], [])
+    assert verdict.status == "insufficient_data"
+    assert verdict.needs_attention is False
+
+
+def test_assess_strategy_unclassified_universe_flags_for_human_review() -> None:
+    equity_returns = _spy_like_returns()
+    verdict = vp.assess_strategy(["NOT_A_REAL_TICKER"], equity_returns)
+    assert verdict.status == "unclassified"
+    assert verdict.needs_attention is True
+    assert "NOT_A_REAL_TICKER" in verdict.reasons[0]
+
+
+def test_assess_strategy_no_baseline_available_degrades_to_rule_a_only() -> None:
+    """baseline_vol=None must never raise — degrade gracefully to Rule A."""
+    equity_returns = _spy_like_returns()
+    verdict = vp.assess_strategy(["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"], equity_returns, baseline_vol=None)
+    assert verdict.baseline_vol is None
+    assert verdict.baseline_delta is None
+    # Clean because Rule A's wide band doesn't trip and Rule B was skipped.
+    assert verdict.status == "clean"
+
+
+def test_margin_override_changes_rule_a_sensitivity() -> None:
+    """A caller-supplied stricter margin should be able to flag a strategy the
+    default margin would pass, and vice versa — proves margin is a real,
+    load-bearing parameter, not decorative."""
+    # Vol just barely inside the default-margin band for a single broad_equity
+    # ticker (0.35 * 1.5 = 0.525) but outside a tight 1.0x margin (0.35).
+    rng = np.random.default_rng(99)
+    returns = rng.normal(loc=0.0004, scale=0.40 / (252**0.5), size=200).tolist()
+
+    default_verdict = vp.assess_strategy(["SPY"], returns, margin=1.5)
+    strict_verdict = vp.assess_strategy(["SPY"], returns, margin=1.0)
+
+    assert default_verdict.status == "clean"
+    assert strict_verdict.status == "flagged"


### PR DESCRIPTION
## Defect

Confirmed on production data 2026-07-27: strategies silently backtest against the
**wrong price series**.

- `capital_preservation_tbill` declares `ASSET_UNIVERSE = ["BIL"]` (SPDR 1-3 Month
  T-Bill ETF, real-world annualised vol ~0.2%). Its persisted backtest has
  annualised vol **18.65%** and annualised return **10.17%** — that is the S&P, not
  BIL.
- `maillard_2010_risk_parity` declares a 5-asset equal-risk-contribution book
  (`SPY, NIKKEI, GOLD, TREASURY, OIL`), which by construction should have LOWER vol
  than pure equity. Its persisted backtest has vol **18.46%** — also pure equity.
- `pipeline_buy_hold` is 18.65% and that IS correct (it really is SPY).
- Both defective strategies **pass the rigor gate** on returns that are not theirs.

**Root cause** (read in `analytics-engine/src/archimedes_analytics_engine/cli.py::run_command`,
not guessed): a strategy only gets its declared universe fed to it when its class
declares `REQUIRED_FEEDS == 2` (pairs). Every other strategy — single-asset AND
multi-asset alike — is backtested against `RunConfig.operations`
(`BACKTEST_OPERATIONS` env var, default `"SPY"`), **regardless of its own declared
`ASSET_UNIVERSE`**. A strategy with no real timing signal on that default feed
(capital_preservation_tbill), or one whose `self.datas` collapses to the single
default feed (maillard, which needs `engine.run_multi_backtest`), reproduces the
pure buy-and-hold S&P series almost exactly. This also explains why
`analytics-engine/scripts/regen_fixtures.py`'s own docstring says
"capital_preservation_tbill models a T-bill yield, not a TLT buy-hold" — that belief
is itself stale/wrong, corroborating the audit finding.

## What this PR does NOT do (anti-goals, honored)

- Does **not** re-run or regenerate any backtest.
- Does **not** modify any strategy file (`analytics-engine/strategies/**` untouched).
- Does **not** touch the rigor gate or `num_trials`.
- Does **not** touch `strategies_routes.py`, `vaults_routes.py`, `contracts/**`, or
  any of the listed `infra/*` files.

## Deliverable 1 — re-runnable detector: `backend/archimedes/scripts/audit_backtest_universe.py`

Reads the exact store the live rigor gate reads
(`services/backtest_repository.py::get_daily_returns`, keyed by `strategy_id`), and
also reports the delta against the second, independent `strategy_daily_returns`
store (keyed by file `stem`) wherever both exist — that disagreement is itself a
defect signal per the task spec.

Threshold design (documented in full in `services/vol_plausibility.py`'s module
docstring — this is the "defensible rule, honest about its limits" the task asked
for), two complementary rules:

- **Rule A — asset-class plausibility band.** Every declared ticker is resolved to
  a broad vol bucket via the SAME curated classification the on-chain universe
  already uses (`archimedes.universe.SYNTHETIC_UNIVERSE`, `asset_class` per
  `yfinance_ticker`) plus a tiny, explicit supplemental table for the handful of
  legacy `NIKKEI`/`GOLD`/`TREASURY`/`OIL` operation aliases and the `KO`/`PEP`
  pairs legs that predate that SSOT. Each bucket has a wide, generous historical
  vol band (a sanity check, not an oracle — deliberately erring toward
  under-flagging). Catches `capital_preservation_tbill` on its own.
- **Rule B — equity-baseline match.** `pipeline_buy_hold`'s persisted vol is the
  confirmed-correct S&P reference. Any OTHER strategy whose declared universe isn't
  that trivial single-broad-equity book, but whose realized vol lands within a
  tight tolerance of that baseline, is exhibiting the exact statistical signature
  of the single-feed-default fallback — this is what catches
  `maillard_2010_risk_parity` (Rule A's wide multi-asset band alone does **not**
  catch it, by design — verified by a dedicated test asserting Rule-A-only comes
  back clean on that case).

Degenerate (zero-variance) series get their own `degenerate` status — matching
`services/_rigor_helpers.py::compute_dsr`'s exact `np.ptp(arr) == 0.0` check — never
a silent pass, never a crash. Unclassifiable tickers get `unclassified` ("needs
human review" per the task's own guidance, rather than a fabricated verdict).

```
PYTHONPATH=backend python -m archimedes.scripts.audit_backtest_universe
PYTHONPATH=backend python -m archimedes.scripts.audit_backtest_universe --json
```
Exits non-zero if any strategy is `flagged` / `degenerate` / `unclassified`, or
shows a large cross-store delta.

## Deliverable 2 — permanent guard: `backend/archimedes/scripts/run_backtests.py`

`run_backtests.py` is the writer into `backtest_results` (the primary store the
gate reads) that the task's own hint list names, and per
`insert_backtest_if_missing`'s docstring it's one of exactly three writers into
that table. Before persisting each freshly-computed artifact, the script now:

1. Fetches the pre-existing `pipeline_buy_hold` baseline **once per run** (not per
   strategy — one extra query).
2. Runs the SAME Rule A (+ Rule B when the baseline is available) against the
   candidate's own freshly-computed equity curve.
3. On `flagged` / `degenerate`, raises `VolPlausibilityError` **before**
   `insert_backtest_if_missing` is ever called — nothing is written — logs loudly
   at ERROR (no traceback, an explanatory error like the existing `FeedArityError`
   pattern), and the strategy is counted in `failed` with the reason in
   `summary["errors"]`.
4. Degrades gracefully to Rule-A-only the first time ever run (before
   `pipeline_buy_hold` itself has a persisted backtest) — never crashes, never
   blocks the whole batch.

I considered hooking this into `insert_backtest_if_missing` directly (the single
funnel point for all 3 writers) instead, but `strategy_provider.py` already imports
`backtest_repository.py` — adding a provider/universe lookup there would create a
circular import. `run_backtests.py` is the scheduled/cron regeneration entrypoint
and was the only one of the three writers the task named as a candidate location,
so that's where the guard lives. **Deliberately not wired into
`seed_backtests_from_artifacts.py`** (a secondary, artifact-loading-only path for
container-deploy contexts without the analytics-engine installed) or
`analytics-engine/scripts/regen_fixtures.py` (writes to the legacy
`backtest_fixtures.json` bundle, not the `backtest_results` table the gate reads,
per its own docstring — a different store than the one this task specifies) — noting
this honestly rather than silently expanding scope.

## Deliverable 3 — tests (hermetic, no DB/network)

- `backend/tests/test_vol_plausibility.py` (24 tests) — pure unit tests of the
  classification + statistics + two-rule verdict logic, including the
  Rule-A-alone-does-NOT-catch-maillard case, margin-override sensitivity, and the
  exact degenerate/insufficient-data/pathological-return edge cases.
- `backend/tests/test_audit_backtest_universe.py` (7 tests) — sqlite-in-memory +
  temp strategy tree, mocking at the boundary (DB session factory, strategies
  dir), covering: clean strategy passes; BIL-declared 18%-vol strategy flagged
  end-to-end through the CLI (`main()` exit code 1); strategy with no persisted
  returns is skipped, not crashed; degenerate all-zero series reported as its own
  category; maillard-style multi-asset match; cross-store delta reporting.
- `backend/tests/test_run_backtests_vol_guard.py` (5 tests) — same sqlite pattern
  as the existing `test_run_backtests_script.py`: wildly-inconsistent artifact
  refused + zero rows written; loud ERROR log with no traceback; plausible
  artifact persisted normally (no false positive); degenerate artifact refused;
  missing-baseline degrades gracefully.

## Verification

```
$ export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"

$ ruff format --check .
488 files already formatted

$ ruff check --select E9,F63,F7,F40,F82 .
All checks passed!

$ PYTHONPATH=backend python -m pytest backend/tests/test_vol_plausibility.py \
    backend/tests/test_audit_backtest_universe.py \
    backend/tests/test_run_backtests_vol_guard.py \
    backend/tests/test_run_backtests_script.py backend/tests/test_backtest_repository.py -q
40 passed, 1 warning in 2.12s

$ python -m pytest -m "not integration" -q
2975 passed, 2 skipped, 2 deselected, 111 warnings in 190.54s (0:03:10)
```

Full existing suite is green — no regressions from the `run_backtests.py` change
(verified `test_run_backtests_is_idempotent` and
`test_run_backtests_surfaces_typed_errors_without_traceback` still pass unmodified).

## What I deliberately did NOT do

- Did not re-run/regenerate any backtest against real data (no DB access in this
  environment; all verification is against hermetic sqlite fixtures + synthetic
  return series calibrated to the confirmed real numbers).
- Did not wire the guard into `seed_backtests_from_artifacts.py` or
  `analytics-engine/scripts/regen_fixtures.py` — see Deliverable 2 above for why.
- Did not touch `analytics-engine/scripts/regen_fixtures.py`'s stale
  "capital_preservation_tbill models a T-bill yield" comment, even though it
  appears to reflect the same incorrect belief the audit disproves — flagging it
  here for Dan/Önder rather than editing a file outside this task's scope.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
