### PR TITLE
[frontend] Build the Architecture page redesign (#1123 spec) + fix visitor-facing claim and routing defects

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -41,7 +41,7 @@
           "@type": "Action",
           "name": "Generate strategy",
           "description": "Describe an investment intent in plain English and get back a research-grounded, rigor-gated portfolio strategy.",
-          "target": "https://archimedes-arc.com/#/generate"
+          "target": "https://archimedes-arc.com/generate"
         }
       }
     </script>

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -1,48 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Entries below are restricted to routes that (a) exist as a `case` in
+  ui/src/App.jsx's render switch, AND (b) render real content for an
+  anonymous visitor with no wallet connected and no selected entity.
+
+  Excluded on purpose:
+    - generate, library, quant, portfolio, reasoning, learnings, publish,
+      subscriptions — each renders only a generic "Connect your wallet"
+      prompt for a cold/anonymous visitor (see ui/src/components/WalletGate.jsx
+      and the equivalent inline gates in PublishPage.jsx / SubscriptionsPage.jsx).
+      No unique indexable content exists at these URLs without a session.
+    - strategy, vault-detail, market-strategy — dynamic routes that require
+      an id/address in the path; there is no single canonical URL to list.
+
+  URLs are the app's real client-side routes (window.history.pushState on
+  ui/src/App.jsx's PAGE_TO_PATH, e.g. /explore, /architecture — NOT hash
+  fragments like /#/explore). nginx serves these with a SPA fallback
+  (`try_files $uri $uri/ /index.html`, see nginx/nginx.conf), so a crawler
+  requesting any of these paths directly gets a 200 with the app shell,
+  which is not true of a /#/... fragment (the fragment never reaches the
+  server at all).
+-->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>/#/</loc>
+    <loc>https://archimedes-arc.com/</loc>
     <priority>1.0</priority>
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>/#/markets/explore</loc>
+    <loc>https://archimedes-arc.com/explore</loc>
     <priority>0.9</priority>
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>/#/markets/strategies</loc>
+    <loc>https://archimedes-arc.com/marketplace</loc>
     <priority>0.8</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-  <url>
-    <loc>/#/markets/trade</loc>
-    <priority>0.9</priority>
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>/#/portfolio/dashboard</loc>
-    <priority>0.9</priority>
+    <loc>https://archimedes-arc.com/leaderboard</loc>
+    <priority>0.7</priority>
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>/#/portfolio/mint-burn</loc>
+    <loc>https://archimedes-arc.com/architecture</loc>
     <priority>0.7</priority>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>/#/portfolio/liquidity</loc>
+    <loc>https://archimedes-arc.com/corpus</loc>
     <priority>0.7</priority>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>/#/portfolio/vaults</loc>
-    <priority>0.8</priority>
-    <changefreq>daily</changefreq>
-  </url>
-  <url>
-    <loc>/#/intelligence/reasoning</loc>
-    <priority>0.8</priority>
+    <loc>https://archimedes-arc.com/insights</loc>
+    <priority>0.5</priority>
     <changefreq>daily</changefreq>
   </url>
 </urlset>

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -42,8 +42,6 @@ const PAGE_TO_PATH = {
   reasoning: '/reasoning',
   learnings: '/learnings',
   insights:  '/insights',
-  about:     '/about',
-  imprint:   '/imprint',
   marketplace: '/marketplace',
   publish:     '/publish',
   subscriptions: '/subscriptions',

--- a/ui/src/assets/flow-diagram.svg
+++ b/ui/src/assets/flow-diagram.svg
@@ -1,0 +1,269 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="920" viewBox="0 0 1240 920" role="img" aria-labelledby="fd-title fd-desc">
+  <title id="fd-title">Archimedes system flow — from research brief to accountable vault</title>
+  <desc id="fd-desc">User journey across three bands: the user (top), Archimedes off-chain services (middle), and Arc testnet contracts (bottom). A dashed trust boundary separates off-chain reasoning from on-chain accountability. The agent commits its reasoning hash on-chain before every trade and reveals the full trace after.</desc>
+
+  <defs>
+    <marker id="mGold" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,1 L9,5 L0,9 Z" fill="#D4A853"/>
+    </marker>
+    <marker id="mBlue" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,1 L9,5 L0,9 Z" fill="#60A5FA"/>
+    </marker>
+    <marker id="mGreen" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,1 L9,5 L0,9 Z" fill="#10B981"/>
+    </marker>
+    <marker id="mGray" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,1 L9,5 L0,9 Z" fill="#71717A"/>
+    </marker>
+  </defs>
+
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+    .serif { font-family: Georgia, 'Times New Roman', serif; }
+    .t1 { fill:#FAFAFA; } .t2 { fill:#A1A1AA; } .t3 { fill:#71717A; } .t4 { fill:#52525B; }
+    .gold { fill:#D4A853; } .blue { fill:#93C5FD; } .blue2 { fill:#60A5FA; } .green { fill:#10B981; } .amber { fill:#F59E0B; }
+    .box { fill:#141419; stroke:rgba(255,255,255,0.10); stroke-width:1; }
+    .chip { fill:#1C1C22; stroke:rgba(255,255,255,0.09); stroke-width:1; }
+    .h { font-size:12px; font-weight:600; }
+    .b { font-size:10px; }
+    .c { font-size:9.5px; }
+    .lbl { font-size:10px; letter-spacing:1.6px; font-weight:600; }
+  </style>
+
+  <!-- ═══ Canvas (self-contained background: legible on light or dark pages) ═══ -->
+  <rect x="0.5" y="0.5" width="1239" height="919" rx="16" fill="#0B0C10" stroke="rgba(255,255,255,0.10)"/>
+
+  <!-- ═══ Header ═══ -->
+  <text x="48" y="46" class="gold" font-size="11" letter-spacing="3" font-weight="600">ARCHIMEDES — SYSTEM FLOW</text>
+  <text x="48" y="78" class="serif t1" font-size="25">From research brief to accountable vault</text>
+  <text x="48" y="100" class="t2" font-size="11.5">Off-chain, the agent reasons. On-chain, it is held to account. USDC settles everything — Circle rails on Arc testnet.</text>
+
+  <!-- Legend -->
+  <g font-size="9.5">
+    <rect x="882" y="48" width="10" height="10" rx="2" fill="#D4A853"/>
+    <text x="898" y="57" class="t2">you act / your signature</text>
+    <rect x="1052" y="48" width="10" height="10" rx="2" fill="#60A5FA"/>
+    <text x="1068" y="57" class="t2">on-chain write</text>
+    <rect x="882" y="72" width="10" height="10" rx="2" fill="#10B981"/>
+    <text x="898" y="81" class="t2">USDC flow</text>
+    <line x1="1052" y1="77" x2="1062" y2="77" stroke="#71717A" stroke-width="1.5" stroke-dasharray="3 2"/>
+    <text x="1068" y="81" class="t2">read / verify</text>
+  </g>
+
+  <!-- ═══════════════════════ USER BAND ═══════════════════════ -->
+  <rect x="48" y="118" width="1144" height="100" rx="12" fill="rgba(212,168,83,0.05)" stroke="rgba(212,168,83,0.20)"/>
+  <text x="62" y="137" class="gold lbl">YOU — HUMAN OR AUTONOMOUS AGENT (SAME API, SIWE AUTH)</text>
+
+  <!-- user nodes -->
+  <g>
+    <rect x="70" y="146" width="192" height="58" rx="9" class="box"/>
+    <text x="82" y="166" class="h t1"><tspan class="gold">①</tspan> Describe intent</text>
+    <text x="82" y="182" class="b t2">plain-English brief</text>
+    <text x="82" y="195" class="b t2">wallet or passkey sign-in</text>
+
+    <rect x="296" y="146" width="200" height="58" rx="9" class="box"/>
+    <text x="308" y="166" class="h t1"><tspan class="gold">②</tspan> Review the passport</text>
+    <text x="308" y="182" class="b t2">rigor verdict + paper anchors</text>
+    <text x="308" y="195" class="b t2">considered-rejects panel</text>
+
+    <rect x="522" y="146" width="200" height="58" rx="9" fill="#141419" stroke="#D4A853" stroke-width="1.5"/>
+    <text x="534" y="166" class="h t1"><tspan class="gold">③</tspan> Sign the deploy</text>
+    <text x="534" y="182" class="b t2">create · authorize agent · approve</text>
+    <text x="534" y="195" class="b t2">deposit · allocate — all your sigs</text>
+
+    <rect x="748" y="146" width="200" height="58" rx="9" class="box"/>
+    <text x="760" y="166" class="h t1"><tspan class="gold">④</tspan> Monitor &amp; verify</text>
+    <text x="760" y="182" class="b t2">every decision has a trace</text>
+    <text x="760" y="195" class="b t2">recompute hashes yourself</text>
+
+    <rect x="974" y="146" width="200" height="58" rx="9" class="box"/>
+    <text x="986" y="166" class="h t1"><tspan class="gold">⑤</tspan> Explore &amp; publish</text>
+    <text x="986" y="182" class="b t2">library · leaderboard</text>
+    <text x="986" y="195" class="b t2">marketplace (earn 90/10)</text>
+
+    <line x1="266" y1="175" x2="290" y2="175" stroke="#D4A853" stroke-width="1.2" marker-end="url(#mGold)" opacity="0.7"/>
+    <line x1="500" y1="175" x2="516" y2="175" stroke="#D4A853" stroke-width="1.2" marker-end="url(#mGold)" opacity="0.7"/>
+    <line x1="726" y1="175" x2="742" y2="175" stroke="#D4A853" stroke-width="1.2" marker-end="url(#mGold)" opacity="0.7"/>
+    <line x1="952" y1="175" x2="968" y2="175" stroke="#D4A853" stroke-width="1.2" marker-end="url(#mGold)" opacity="0.7"/>
+  </g>
+
+  <!-- ═══════════════════════ OFF-CHAIN BAND ═══════════════════════ -->
+  <rect x="48" y="238" width="1144" height="356" rx="12" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.08)"/>
+  <text x="62" y="257" class="t2 lbl">ARCHIMEDES — OFF-CHAIN</text>
+
+  <!-- Generate cluster -->
+  <rect x="70" y="272" width="210" height="92" rx="9" class="box"/>
+  <text x="82" y="291" class="h t1">Research corpus</text>
+  <text x="82" y="308" class="b t2">10,000-paper manifest</text>
+  <text x="82" y="322" class="b t2">keyword filter → MiniLM rerank</text>
+  <text x="82" y="336" class="b t2">outcome embargo · source hashes</text>
+
+  <rect x="300" y="272" width="150" height="92" rx="9" class="box"/>
+  <text x="312" y="291" class="h t1">Market context</text>
+  <text x="312" y="308" class="b t2">regime detectors</text>
+  <text x="312" y="322" class="b t2">(GMM · VIX)</text>
+  <text x="312" y="336" class="b t2">price history</text>
+
+  <line x1="175" y1="364" x2="175" y2="386" stroke="#71717A" stroke-width="1.2" marker-end="url(#mGray)"/>
+  <line x1="375" y1="364" x2="375" y2="386" stroke="#71717A" stroke-width="1.2" marker-end="url(#mGray)"/>
+
+  <rect x="70" y="390" width="360" height="112" rx="9" class="box"/>
+  <text x="82" y="410" class="h t1">Debate society <tspan class="c t3">— sole generation path</tspan></text>
+  <g class="c">
+    <rect x="82" y="424" width="80" height="44" rx="7" class="chip"/>
+    <text x="90" y="442" class="t1" font-weight="600">Proposers</text>
+    <text x="90" y="456" class="t3">paper fusion</text>
+    <rect x="168" y="424" width="80" height="44" rx="7" class="chip"/>
+    <text x="176" y="442" class="t1" font-weight="600">Critics</text>
+    <text x="176" y="456" class="t3">bull vs bear</text>
+    <rect x="254" y="424" width="80" height="44" rx="7" class="chip"/>
+    <text x="262" y="442" class="t1" font-weight="600">Backtests</text>
+    <text x="262" y="456" class="t3">deterministic</text>
+    <rect x="340" y="424" width="78" height="44" rx="7" class="chip"/>
+    <text x="348" y="442" class="t1" font-weight="600">K=1 winner</text>
+    <text x="348" y="456" class="t3">+ rejects</text>
+  </g>
+  <text x="82" y="490" class="c t3">must beat buy-and-hold net of cost — otherwise a first-class ABSTAIN</text>
+
+  <line x1="260" y1="502" x2="260" y2="520" stroke="#71717A" stroke-width="1.2" marker-end="url(#mGray)"/>
+
+  <rect x="70" y="524" width="360" height="58" rx="9" fill="rgba(212,168,83,0.06)" stroke="#D4A853" stroke-width="1.3"/>
+  <text x="82" y="543" class="gold" font-size="11.5" font-weight="600">RIGOR GATE — external to the generator</text>
+  <text x="82" y="559" class="b t1">DSR · PBO · walk-forward OOS · look-ahead audit</text>
+  <text x="82" y="573" class="c t2">computed live on persisted returns — pass / fail / pending</text>
+
+  <!-- passport up to ② -->
+  <path d="M430,553 L440,553 L440,212" fill="none" stroke="#D4A853" stroke-width="1.2" marker-end="url(#mGold)"/>
+  <text x="449" y="234" class="c gold">strategy passport</text>
+
+  <!-- brief down from ① -->
+  <line x1="170" y1="204" x2="170" y2="268" stroke="#D4A853" stroke-width="1.2" marker-end="url(#mGold)"/>
+  <text x="178" y="238" class="c gold">brief</text>
+
+  <!-- Execute cluster -->
+  <rect x="660" y="272" width="260" height="154" rx="9" class="box"/>
+  <text x="672" y="292" class="h t1">Agent runner <tspan class="c t3">— rebalance loop</tspan></text>
+  <text x="672" y="311" class="b t2">tick: read vault state — chain is truth</text>
+  <text x="672" y="326" class="b t2">evaluate strategy DSL → target weights</text>
+  <text x="672" y="341" class="b t2">drift + cost-benefit · V_check gate</text>
+  <text x="672" y="356" class="b t1">then: ① commit → ② trade → ③ reveal</text>
+  <rect x="672" y="370" width="106" height="20" rx="10" class="chip"/>
+  <text x="682" y="384" class="c blue">Circle DCW signer</text>
+  <rect x="786" y="370" width="106" height="20" rx="10" class="chip"/>
+  <text x="796" y="384" class="c t2">exactly-once lease</text>
+  <text x="672" y="412" class="c t3">hold decisions are traced too</text>
+
+  <rect x="455" y="452" width="155" height="64" rx="9" class="box"/>
+  <text x="467" y="472" class="h t1">Oracle runner</text>
+  <text x="467" y="489" class="b t2">per-synth price pushes</text>
+  <text x="467" y="504" class="c t3">Circle DCW · fails closed</text>
+
+  <!-- Marketplace cluster -->
+  <rect x="950" y="272" width="222" height="154" rx="9" class="box"/>
+  <text x="962" y="292" class="h t1">Marketplace <tspan class="c t3">— x402 rail</tspan></text>
+  <text x="962" y="311" class="b t2">publish → on-chain registration</text>
+  <text x="962" y="326" class="b t2">subscribe: HTTP 402 → signed payment</text>
+  <text x="962" y="341" class="b t2">Circle Gateway settles sub-cent USDC</text>
+  <text x="962" y="356" class="b t2">sweep → PaymentSplitter (90/10)</text>
+  <rect x="962" y="370" width="198" height="20" rx="10" fill="rgba(245,158,11,0.10)" stroke="rgba(245,158,11,0.28)"/>
+  <text x="971" y="384" class="amber" font-size="8.5">PAYMENTS_DRY_RUN — settlement simulated</text>
+  <text x="962" y="412" class="c t3">per-subscriber spend caps</text>
+
+  <!-- user ⑤ down to marketplace -->
+  <line x1="1074" y1="204" x2="1074" y2="268" stroke="#D4A853" stroke-width="1.2" marker-end="url(#mGold)"/>
+
+  <!-- ═══ deploy lane: user ③ signs directly on-chain ═══ -->
+  <line x1="622" y1="204" x2="622" y2="656" stroke="#D4A853" stroke-width="1.6" marker-end="url(#mGold)"/>
+  <circle cx="622" cy="612" r="3.2" fill="#D4A853"/>
+  <text x="612" y="548" text-anchor="end" class="c gold">your wallet signs on-chain</text>
+  <text x="612" y="562" text-anchor="end" class="c t3">createVault · setAgent</text>
+  <text x="612" y="575" text-anchor="end" class="c t3">approve · deposit · allocate</text>
+
+  <!-- commit / trade / reveal lanes -->
+  <line x1="700" y1="426" x2="700" y2="656" stroke="#60A5FA" stroke-width="1.4" marker-end="url(#mBlue)"/>
+  <circle cx="700" cy="560" r="9.5" fill="#0B0C10" stroke="#60A5FA"/>
+  <text x="700" y="564" text-anchor="middle" class="blue2" font-size="9.5" font-weight="700">2</text>
+
+  <line x1="845" y1="426" x2="845" y2="664" stroke="#60A5FA" stroke-width="1.4" marker-end="url(#mBlue)"/>
+  <circle cx="845" cy="510" r="9.5" fill="#0B0C10" stroke="#60A5FA"/>
+  <text x="845" y="514" text-anchor="middle" class="blue2" font-size="9.5" font-weight="700">1</text>
+
+  <line x1="875" y1="426" x2="875" y2="664" stroke="#60A5FA" stroke-width="1.4" marker-end="url(#mBlue)"/>
+  <circle cx="875" cy="560" r="9.5" fill="#0B0C10" stroke="#60A5FA"/>
+  <text x="875" y="564" text-anchor="middle" class="blue2" font-size="9.5" font-weight="700">3</text>
+
+  <!-- read-state lane (dashed, upward) -->
+  <line x1="745" y1="656" x2="745" y2="430" stroke="#71717A" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#mGray)"/>
+
+  <!-- verify lane (dashed, upward, registry → user ④) -->
+  <line x1="935" y1="664" x2="935" y2="212" stroke="#71717A" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#mGray)"/>
+  <text x="927" y="240" text-anchor="end" class="c t3">verify: hash + block order</text>
+
+  <!-- marketplace money lane -->
+  <line x1="1130" y1="426" x2="1130" y2="664" stroke="#10B981" stroke-width="1.4" marker-end="url(#mGreen)"/>
+  <text transform="rotate(-90 1144 556)" x="1144" y="556" text-anchor="middle" class="c green">publish + fees (USDC)</text>
+
+  <!-- oracle price-push lane -->
+  <path d="M470,516 L470,600 L155,600 L155,664" fill="none" stroke="#60A5FA" stroke-width="1.2" marker-end="url(#mBlue)"/>
+  <text x="310" y="592" text-anchor="middle" class="c" fill="#60A5FA" opacity="0.85">price pushes</text>
+
+  <!-- ═══ trust boundary ═══ -->
+  <line x1="48" y1="614" x2="1192" y2="614" stroke="rgba(96,165,250,0.45)" stroke-width="1.2" stroke-dasharray="7 5"/>
+  <text x="62" y="608" class="c" fill="#60A5FA">TRUST BOUNDARY — everything below is publicly verifiable on Arc</text>
+
+  <!-- ═══════════════════════ ON-CHAIN BAND ═══════════════════════ -->
+  <rect x="48" y="628" width="1144" height="196" rx="12" fill="rgba(96,165,250,0.05)" stroke="rgba(96,165,250,0.25)"/>
+  <text x="62" y="648" class="lbl" fill="#60A5FA">ARC TESTNET — ON-CHAIN · CHAIN 5042002 · USDC IS GAS</text>
+  <text x="1178" y="648" text-anchor="end" class="c t3">289 contracts · redeployed 2026-07-09</text>
+
+  <rect x="70" y="668" width="170" height="112" rx="9" class="box"/>
+  <text x="82" y="688" class="h blue">PriceOracle ×synth</text>
+  <text x="82" y="706" class="b t2">one oracle per synth</text>
+  <text x="82" y="720" class="b t2">Circle-signed pushes</text>
+  <text x="82" y="734" class="b t2">marks NAV · floors swaps</text>
+
+  <rect x="260" y="668" width="170" height="112" rx="9" class="box"/>
+  <text x="272" y="688" class="h blue">AMMRouter + pools</text>
+  <text x="272" y="706" class="b t2">rebalance swap venue</text>
+  <text x="272" y="720" class="b t2">per-synth USDC pools</text>
+  <text x="272" y="734" class="b t2">oracle floor caps slippage</text>
+
+  <rect x="560" y="660" width="200" height="120" rx="9" fill="#141419" stroke="rgba(212,168,83,0.55)" stroke-width="1.4"/>
+  <text x="572" y="680" class="h blue">Vault — ERC-4626</text>
+  <text x="572" y="698" class="b" fill="#D4A853" font-weight="600">owner = YOU</text>
+  <text x="572" y="713" class="b t2">agent = rebalance-only</text>
+  <text x="572" y="728" class="b t2">rebalance() requires a prior</text>
+  <text x="572" y="741" class="b t2">on-chain trace commitment</text>
+  <text x="572" y="758" class="b t2">withdraw: owner-only, always</text>
+
+  <rect x="790" y="668" width="200" height="112" rx="9" class="box"/>
+  <text x="802" y="688" class="h blue">ReasoningTraceRegistry</text>
+  <text x="802" y="706" class="b t2">commit(hash, intent) pre-trade</text>
+  <text x="802" y="720" class="b t2">reveal(content) re-hashed on-chain</text>
+  <text x="802" y="734" class="b t1">commit &lt; trade &lt; reveal</text>
+  <text x="802" y="752" class="c t3">full traces stored off-chain (IPFS)</text>
+
+  <rect x="1020" y="668" width="152" height="46" rx="8" class="box"/>
+  <text x="1030" y="686" class="blue" font-size="10.5" font-weight="600">StrategyRegistry</text>
+  <text x="1030" y="700" class="c t2">published strategies</text>
+
+  <rect x="1020" y="720" width="152" height="46" rx="8" class="box"/>
+  <text x="1030" y="738" class="blue" font-size="10.5" font-weight="600">PaymentSplitter</text>
+  <text x="1030" y="752" class="c t2">90/10 USDC split</text>
+
+  <rect x="1020" y="772" width="152" height="46" rx="8" class="box"/>
+  <text x="1030" y="790" class="blue" font-size="10.5" font-weight="600">SyntheticFactory</text>
+  <text x="1030" y="804" class="c t2">281-synth universe</text>
+
+  <!-- vault → AMM swaps -->
+  <line x1="560" y1="715" x2="434" y2="715" stroke="#60A5FA" stroke-width="1.2" marker-end="url(#mBlue)"/>
+  <text x="497" y="708" text-anchor="middle" class="c t3">swaps</text>
+  <!-- oracle → AMM floor -->
+  <line x1="240" y1="740" x2="256" y2="740" stroke="#60A5FA" stroke-width="1" marker-end="url(#mBlue)" opacity="0.7"/>
+
+  <!-- ═══ Footnotes ═══ -->
+  <text x="48" y="850" class="c t2">● Testnet USDC — real contracts, no real funds by design&#160;&#160;&#160;&#160;● Marketplace x402 pipeline runs end-to-end; final settlement simulated (PAYMENTS_DRY_RUN) until fee custody goes non-custodial (#975)</text>
+  <text x="48" y="869" class="c t2">● Corpus hydration in progress — generation needs ≥2 retrieved papers or it abstains&#160;&#160;&#160;&#160;● Runner relocation + generated-vault DSL execution landing now (PR #1071 · #1076)</text>
+  <text x="48" y="888" class="c t3">Substrate: FastAPI · LLM via Bedrock Converse (Nova Micro default · BYOK · local Ollama) · Aurora Postgres · Redis · built in CI → ECR → ECS Fargate</text>
+  <text x="1192" y="888" text-anchor="end" class="c t4">verified against main · 2026-07-14</text>
+</svg>

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -346,9 +346,6 @@ function DebateSociety({ health, healthError }) {
 // correction)". The copy below states the defensible claim only, and names
 // the num_trials=1 caveat explicitly rather than burying it.
 function RigorGateSection({ leaderboard, leaderboardError }) {
-  const passingCount = leaderboard?.entries
-    ? leaderboard.entries.filter(e => e.passes_rigor_gate).length
-    : undefined
   const loading = !leaderboard && !leaderboardError
 
   return (
@@ -416,15 +413,17 @@ function RigorGateSection({ leaderboard, leaderboardError }) {
           multiple-testing correction) for those strategies.
         </p>
         <p className="caption" style={{ color: 'var(--text-3)', borderTop: '1px solid var(--glass-border)', paddingTop: 10 }}>
+          <strong style={{ color: 'var(--text-1)' }}>Not one paper-derived alpha strategy clears our bar.</strong>{' '}
+          Every curated-library candidate evaluated against the live gate has been rejected — that is
+          the gate doing its job, not the library sitting empty.{' '}
           {leaderboardError ? (
-            <span style={{ color: 'var(--text-4)' }}>Live proof line unavailable right now.</span>
+            <span style={{ color: 'var(--text-4)' }}>Live leaderboard count unavailable right now.</span>
           ) : loading ? (
-            <span style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>Loading live gate results…</span>
+            <span style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>Loading live leaderboard…</span>
           ) : (
             <>
-              <strong style={{ color: 'var(--text-1)' }}>{fmtNum(passingCount)}</strong> of{' '}
-              <strong style={{ color: 'var(--text-1)' }}>{fmtNum(leaderboard.total)}</strong> strategies on the
-              leaderboard currently pass the live gate.
+              <strong style={{ color: 'var(--text-1)' }}>{fmtNum(leaderboard.total)}</strong> strategies sit
+              on the leaderboard today.
             </>
           )}
         </p>

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -1,156 +1,190 @@
-// /architecture — single-page infographic explaining the agent + memory +
-// corpus architecture that powers Generate. Linked from Generate's
-// collapsible "How this works" panel and surfaced in the sidebar so
-// curious users can dig in without breaking the Generate-first spine.
+// /architecture — single-page infographic explaining how Archimedes actually
+// works today: brief → debate-society generation → external rigor gate →
+// non-custodial vault deploy → commit-before-trade execution → verify.
+//
+// Anti-rot rule (the reason the previous version of this page died): every
+// number on this page is live-fetched on mount from /api/config/contracts,
+// /health, and /api/leaderboard — never hardcoded. A failed fetch renders an
+// honest "—" + "live value unavailable" caption, never a stale or invented
+// number. See docs/architecture-redesign/ for the full design rationale.
 
-const AGENTS = [
-  {
-    name: 'Strategy Generation Agent',
-    role: 'What should be done?',
-    desc: 'Retrieves relevant papers from a 10,000-record q-fin metadata corpus, reads current market context, and synthesizes a candidate strategy that passes the rigor gate.',
-    subagents: [
-      { name: 'Paper Retrieval', detail: 'Keyword + TF-IDF ranking (SPECTER2 / KG walk: build target)' },
-      { name: 'Market Context', detail: 'Regime classifier + on-chain oracle + price history' },
-      { name: 'Strategy Synthesis', detail: 'LLM fusion: brief × papers × market' },
-      { name: 'Rigor Gate', detail: 'DSR + PBO + chronological OOS + look-ahead audit' },
-    ],
-    output: 'Strategy passport with paper anchors + rigor verdict',
-    authority: 'None — pure synthesis',
-  },
-  {
-    name: 'Portfolio Construction Agent',
-    role: 'How exactly do we do it?',
-    desc: 'Turns the strategy into a concrete set of assets, weights, and position sizes, and stress-tests it across six adverse scenarios.',
-    subagents: [
-      { name: 'Asset Selection', detail: 'Individual instruments, paper-anchored' },
-      { name: 'Sizing', detail: 'Kelly criterion + risk parity + USDC floor' },
-      { name: 'Stress Test', detail: 'Six scenario shocks (2008, COVID, vol spike, etc.)' },
-    ],
-    output: 'Vault deployment proposal (target weights, projected behavior)',
-    authority: 'None — produces the proposal you sign',
-  },
-  {
-    name: 'Live Execution Agent',
-    role: 'Given the vault is funded, what do we do this minute?',
-    desc: 'Continuous rebalance loop in the agent docker service. Each tick: read vault state from chain, evaluate the strategy DSL, decide rebalance vs hold, anchor the trace.',
-    subagents: [
-      { name: 'Signal Evaluation', detail: 'Does the strategy DSL say rebalance?' },
-      { name: 'Drift Calculation', detail: 'Target weights vs current weights' },
-      { name: 'Cost-Benefit', detail: 'Is the rebalance worth the fee + slippage?' },
-      { name: 'Trade Execution', detail: 'Circle signer → AMM swap on Arc' },
-      { name: 'Trace Publishing', detail: 'Canonical hash → ReasoningTraceRegistry' },
-    ],
-    output: 'Rebalance tx (or honest "hold" trace) — both anchored on-chain',
-    authority: 'Bounded — rebalance within signed allocations only',
-  },
-]
+import { useEffect, useState } from 'react'
+import { apiGet } from '../api'
+import flowDiagramSrc from '../assets/flow-diagram.svg'
 
-const MEMORY_LAYERS = [
-  {
-    tag: 'A.1',
-    name: 'Intra-step latent',
-    substrate: 'LLM KV cache (Amazon Nova Micro via AWS Bedrock)',
-    lifetime: 'Single forward pass',
-    why: 'Where one synthesis step does its thinking.',
-  },
-  {
-    tag: 'A.2',
-    name: 'Deterministic state · audit-truth',
-    substrate: 'On-chain vault state (read-only to the agent)',
-    lifetime: 'Live, externally written',
-    why: 'Ground truth for "what is my current position." Chain wins if the LLM\'s narrative diverges.',
-  },
-  {
-    tag: 'B',
-    name: 'Within-session scratchpad',
-    substrate: 'Redis (SSE event log per job)',
-    lifetime: 'Single session',
-    why: 'Streams progress + carries reasoning state across sub-agent steps.',
-  },
-  {
-    tag: 'C',
-    name: 'Cross-session episodic',
-    substrate: 'Postgres (StrategyStore, vaults, traces)',
-    lifetime: 'Persistent',
-    why: 'How the library compounds: every proposal, verdict, and reject is content-hashed and recallable.',
-  },
-  {
-    tag: 'D',
-    name: 'Investigation memory',
-    substrate: 'Per-job event log + recent-traces buffer',
-    lifetime: 'Task-scoped',
-    why: 'Lets the Live Execution Agent reason about its own recent history without re-querying Postgres.',
-  },
-  {
-    tag: 'E',
-    name: 'Semantic knowledge',
-    substrate: 'q-fin corpus (10,000 metadata records; embeddings + clusters + KG pending)',
-    lifetime: 'Persistent',
-    why: 'The substrate the Strategy Generation Agent retrieves from (keyword/TF-IDF today).',
-  },
-]
+function fmtNum(n) {
+  return typeof n === 'number' ? n.toLocaleString() : n
+}
 
-const PROTOCOLS = [
-  { name: 'Outcome Embargo', what: 'Papers retrieved at decision time are filtered to those published before the decision; on-chain anchor proves the filter held.' },
-  { name: 'Time-Aware Retrieval', what: 'Retrieval relevance decays by paper age; higher decay in volatile regimes. (Today over keyword/TF-IDF scores; SPECTER2 similarity once the KB pipeline runs.)' },
-  { name: 'Hierarchy of Truth', what: 'Chain state outranks LLM narrative; curated academic literature outranks uncurated sources.' },
-  { name: 'Source Tracking', what: 'Every cited paper carries (arxiv_id, version, content_hash). Anchored on Arc; anyone can recompute.' },
-]
+// ── Live data ──────────────────────────────────────────────────────────
+
+function useArchStats() {
+  const [contracts, setContracts] = useState(null)
+  const [contractsError, setContractsError] = useState(false)
+  const [health, setHealth] = useState(null)
+  const [healthError, setHealthError] = useState(false)
+  const [leaderboard, setLeaderboard] = useState(null)
+  const [leaderboardError, setLeaderboardError] = useState(false)
+
+  useEffect(() => {
+    apiGet('/api/config/contracts').then(setContracts).catch(() => setContractsError(true))
+    apiGet('/health').then(setHealth).catch(() => setHealthError(true))
+    apiGet('/api/leaderboard').then(setLeaderboard).catch(() => setLeaderboardError(true))
+  }, [])
+
+  return { contracts, contractsError, health, healthError, leaderboard, leaderboardError }
+}
+
+// ── §1 — Header + hero stats ──────────────────────────────────────────
 
 function PageHeader() {
   return (
     <div className="max-w-[820px] mb-7">
       <h2 className="serif text-[2rem] mb-2.5">How Archimedes works</h2>
       <p className="body mb-2">
-        A multi-agent system that turns a plain-English brief into a deployable on-chain vault —
-        paper-anchored, rigor-gated, and auditable end to end.
+        Archimedes turns quantitative-finance research into strategies you can actually inspect:
+        generated by a multi-agent debate, admitted only through a statistical rigor gate,
+        executed into a vault that stays yours, with every decision hashed on-chain before the
+        trade that acts on it.
       </p>
       <p className="body" style={{ color: 'var(--text-3)' }}>
-        Three top-level agents, six memory layers, a 10,000-record q-fin metadata corpus, and the{' '}
-        <code>ReasoningTraceRegistry</code> on Arc anchoring every decision.
+        Everything on this page describes the live system — what runs today on the Arc public
+        testnet, and what is landing next, labeled as such.
       </p>
     </div>
   )
 }
 
-function HeroStrip() {
-  const stats = [
-    { n: '3', l: 'Top-level agents', s: 'Generation · Construction · Execution' },
-    { n: '6', l: 'Memory layers', s: 'KV cache → on-chain ground truth' },
-    { n: '10,000', l: 'q-fin metadata records', s: 'embeddings + clusters + KG: build target' },
-    { n: '11', l: 'Smart contracts', s: 'Deployed on Arc testnet' },
-  ]
+// Skeleton → value → honest "—" on fetch error. Never renders undefined or
+// a stale literal. `loading` and `failed` are passed explicitly (rather than
+// inferred from `value == null`) so a genuine live "0" never gets mistaken
+// for a still-loading state.
+function StatTile({ label, value, caption, loading, failed }) {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-7">
-      {stats.map(s => (
-        <div key={s.l} className="card-flat p-4">
-          <div className="text-[1.8rem] font-bold">{s.n}</div>
-          <div className="label mt-1">{s.l}</div>
-          <div className="caption mt-1.5" style={{ color: 'var(--text-3)' }}>{s.s}</div>
-        </div>
-      ))}
+    <div className="card-flat p-4">
+      <div className="text-[1.8rem] font-bold" style={{ minHeight: '2.15rem' }}>
+        {failed ? (
+          <span style={{ color: 'var(--text-4)' }}>—</span>
+        ) : loading ? (
+          <span style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>···</span>
+        ) : (
+          fmtNum(value)
+        )}
+      </div>
+      <div className="label mt-1">{label}</div>
+      <div className="caption mt-1.5" style={{ color: 'var(--text-3)' }}>
+        {failed ? 'live value unavailable' : caption}
+      </div>
     </div>
   )
 }
 
-// The pipeline rendered as a single connected timeline. One continuous gold
-// rail threads numbered nodes top-to-bottom — reads as one flow, never the
-// cramped floating-arrow grid it replaced. The deploy step is accented as the
-// user's binding signing moment.
+function HeroStrip({ contracts, contractsError, health, healthError, leaderboard, leaderboardError }) {
+  const synthCount = contracts?.synthetics ? Object.keys(contracts.synthetics).length : undefined
+  const vaultCount = contracts?.vaults ? Object.keys(contracts.vaults).length : undefined
+  const contractsLoading = !contracts && !contractsError
+  const healthLoading = !health && !healthError
+  const leaderboardLoading = !leaderboard && !leaderboardError
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-7">
+      <StatTile
+        label="Tradable synthetic assets"
+        value={synthCount}
+        loading={contractsLoading}
+        failed={contractsError}
+        caption="live on Arc testnet"
+      />
+      <StatTile
+        label="Research papers in the corpus manifest"
+        value={health?.corpus_papers}
+        loading={healthLoading}
+        failed={healthError}
+        caption={health ? `${fmtNum(health.corpus_db_count)} ingested and retrievable today` : ''}
+      />
+      <StatTile
+        label="Strategies on the public leaderboard"
+        value={leaderboard?.total}
+        loading={leaderboardLoading}
+        failed={leaderboardError}
+        caption="ranked by real backtest + live rigor gate"
+      />
+      <StatTile
+        label="Live user vaults on Arc"
+        value={vaultCount}
+        loading={contractsLoading}
+        failed={contractsError}
+        caption="grows with every deploy"
+      />
+    </div>
+  )
+}
+
+// ── §2 — The system, in one picture ───────────────────────────────────
+
+function SystemFlowDiagram() {
+  return (
+    <div className="card p-5 mb-7">
+      <div className="label mb-3">The system, in one picture</div>
+      <div style={{ overflowX: 'auto' }}>
+        <img
+          src={flowDiagramSrc}
+          alt="Archimedes system flow: the user at top, Archimedes off-chain services in the
+            middle, and Arc testnet contracts at the bottom, separated by a dashed trust boundary.
+            The agent commits its reasoning hash on-chain before every trade and reveals the full
+            trace afterward."
+          style={{ width: '100%', minWidth: 640, display: 'block' }}
+        />
+      </div>
+      <p className="caption mt-3" style={{ color: 'var(--text-3)' }}>
+        Off-chain, Archimedes reasons; on-chain, it is held to account. The dashed line is the
+        trust boundary: everything below it is publicly verifiable on Arc, and the agent cannot
+        cross it without committing its reasoning first.
+      </p>
+    </div>
+  )
+}
+
+// ── §3 — The pipeline ──────────────────────────────────────────────────
+// Gold-rail numbered timeline, kept from the previous page (the pattern is
+// good — the content was stale). Corrected: no separate "Portfolio
+// Construction" stage (debate-society generation covers it), five wallet
+// signatures (not four — createVault + setAgent + approve + deposit +
+// allocate, per CreateVaultModal.jsx), no invented tick interval (the
+// backend doesn't expose AGENT_INTERVAL_SECONDS on any live endpoint, so it
+// is omitted rather than guessed).
 const PIPELINE_STEPS = [
-  { title: 'Your brief', sub: 'plain English, optional asset classes + risk profile' },
-  { title: 'Strategy Generation', sub: 'paper retrieval · market context · synthesis · rigor gate' },
-  { title: 'Portfolio Construction', sub: 'asset selection · Kelly sizing · stress test' },
   {
-    title: 'Deploy as Vault',
-    sub: '4 wallet signatures: create → approve → deposit → set allocations',
-    youAct: true,
+    title: 'Your brief',
+    sub: 'plain English, optional asset classes, risk profile, and a model cost picker · sign in with any wallet or a passkey',
   },
-  { title: 'Live Execution', sub: '60s tick rebalance loop · on-chain trace per decision' },
-  { title: 'Verify on-chain', sub: 'recompute hash · check against Arc anchor' },
+  {
+    title: 'Debate',
+    sub: 'proposer society drafts candidates from the research corpus and current market regime · adversarial critics + deterministic backtests cull them · one winner + considered-rejects',
+  },
+  {
+    title: 'Rigor gate',
+    sub: 'DSR, PBO, walk-forward out-of-sample, and a look-ahead audit — outside the generator, on real persisted returns',
+    youAct: true,
+    actLabel: 'review the passport',
+  },
+  {
+    title: 'Deploy as vault',
+    sub: 'you sign every binding step: create the vault, authorize the agent, approve, deposit, allocate · the agent gets rebalance authority only',
+    youAct: true,
+    actLabel: 'five wallet signatures, all yours',
+  },
+  {
+    title: 'Live execution',
+    sub: "the agent ticks over your vault: evaluates the strategy's rule, commits its reasoning hash on-chain, trades, then reveals the full trace",
+  },
+  {
+    title: 'Verify & explore',
+    sub: 'recompute any trace hash against the on-chain anchor · browse your compounding library, the leaderboard, and the research underneath',
+  },
 ]
 
-function PipelineStep({ index, title, sub, youAct, isLast }) {
+function PipelineStep({ index, title, sub, youAct, actLabel, isLast }) {
   return (
     <div style={{ display: 'grid', gridTemplateColumns: '34px 1fr', columnGap: 16 }}>
       {/* Gutter: numbered node sitting on the continuous rail */}
@@ -195,7 +229,7 @@ function PipelineStep({ index, title, sub, youAct, isLast }) {
           {title}
           {youAct && (
             <span className="label" style={{ color: 'var(--accent)' }}>
-              · you sign
+              · you act: {actLabel}
             </span>
           )}
         </div>
@@ -212,12 +246,7 @@ function PipelineFlow() {
     <div className="card p-5 mb-7">
       <div className="label mb-4">The pipeline</div>
       {PIPELINE_STEPS.map((step, i) => (
-        <PipelineStep
-          key={step.title}
-          index={i}
-          isLast={i === PIPELINE_STEPS.length - 1}
-          {...step}
-        />
+        <PipelineStep key={step.title} index={i} isLast={i === PIPELINE_STEPS.length - 1} {...step} />
       ))}
       <p
         className="caption mt-4"
@@ -227,128 +256,474 @@ function PipelineFlow() {
           paddingTop: 14,
         }}
       >
-        You stay in the loop at two binding moments: reviewing the passport and signing
-        the four deploy transactions. The agent gains rebalance authority only — it cannot
-        withdraw, cannot change allocations, cannot change vault ownership.
+        You stay in the loop at two binding moments: reviewing the passport and signing the
+        deploy steps. The agent cannot withdraw, cannot change what the vault may hold, and
+        cannot trade without a prior on-chain commitment. If nothing clears the bar, Archimedes
+        says so: <strong style={{ color: 'var(--text-2)' }}>abstaining is a first-class outcome, not a failure state.</strong>
       </p>
     </div>
   )
 }
 
-function AgentCards() {
-  return (
-    <div className="mb-7">
-      <div className="label mb-3">The three agents</div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        {AGENTS.map(a => (
-          <div key={a.name} className="card p-4">
-            <div className="font-semibold mb-1" style={{ fontSize: '1rem' }}>{a.name}</div>
-            <div className="caption mb-3" style={{ color: 'var(--accent)' }}>{a.role}</div>
-            <p className="body mb-3" style={{ fontSize: '0.9rem', lineHeight: 1.5 }}>{a.desc}</p>
-            <div className="label mb-2">Sub-agents</div>
-            <ul className="mb-3" style={{ paddingLeft: '1.1rem', margin: 0, fontSize: '0.85rem' }}>
-              {a.subagents.map(s => (
-                <li key={s.name} style={{ marginBottom: 4 }}>
-                  <strong>{s.name}</strong> — <span style={{ color: 'var(--text-3)' }}>{s.detail}</span>
-                </li>
-              ))}
-            </ul>
-            <div className="caption" style={{ color: 'var(--text-3)' }}>
-              <div><strong>Output:</strong> {a.output}</div>
-              <div className="mt-1"><strong>Trade authority:</strong> {a.authority}</div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
+// ── §4 — Generation: the debate society ───────────────────────────────
+// Replaces the old "3 top-level agents / Strategy Generation Agent with a
+// Rigor Gate sub-agent" model. That architecture is wrong: generation is a
+// multi-agent debate society (agents/debate_engine.py), and the rigor gate
+// runs EXTERNAL to the generator (services/live_rigor_gate.py) so the thing
+// being graded cannot influence its own grade. The Strategy Architect was
+// removed entirely (PR #1074).
+const DEBATE_STAGES = [
+  {
+    name: 'Proposers',
+    detail:
+      'A pool of fusion agents, each drafting a strategy from a different slice of retrieved papers and regime context. Duplicate ideas are collapsed by content hash.',
+  },
+  {
+    name: 'Critics',
+    detail: 'An adversarial bull/bear round surfaces the strongest objections. It informs; it never decides.',
+  },
+  {
+    name: 'Deterministic judgment',
+    detail:
+      'Every surviving candidate is backtested in plain Python (zero LLM tokens), with the multiple-testing penalty counting every candidate tried, not just the winner.',
+  },
+  {
+    name: 'The null test',
+    detail:
+      'A candidate must beat simply buying and holding, net of costs. If none does, Archimedes abstains and shows you why.',
+  },
+]
 
-function MemoryPillar() {
+function DebateSociety({ health, healthError }) {
+  const modelLoading = !health && !healthError
   return (
     <div className="mb-7">
-      <div className="label mb-3">The 6-layer shared memory pillar</div>
-      <p className="caption mb-3" style={{ color: 'var(--text-3)' }}>
-        Adapted from a 5-layer cognitive memory model, extended with the on-chain audit-truth layer
-        split out so the LLM can never hallucinate over real vault state.
+      <div className="label mb-3">How a strategy is born</div>
+      <p className="body mb-4">
+        One agent brainstorming in a loop produces confident nonsense. Archimedes instead runs a{' '}
+        <strong>debate society</strong> — the sole generation path:
       </p>
-      <div className="flex flex-col gap-2">
-        {MEMORY_LAYERS.map(m => (
-          <div
-            key={m.tag}
-            className="card-flat memory-row"
-            style={{ padding: '12px 16px' }}
-          >
-            <span
-              className="font-bold"
-              style={{
-                background: 'var(--accent)',
-                color: 'var(--canvas)',
-                padding: '4px 10px',
-                borderRadius: 4,
-                fontSize: '0.82rem',
-                minWidth: 38,
-                textAlign: 'center',
-              }}
-            >
-              {m.tag}
-            </span>
-            <div>
-              <div className="font-semibold" style={{ fontSize: '0.9rem' }}>{m.name}</div>
-              <div className="caption mt-0.5" style={{ color: 'var(--text-3)' }}>{m.lifetime}</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
+        {DEBATE_STAGES.map(s => (
+          <div key={s.name} className="card-flat p-4">
+            <div className="font-semibold mb-1" style={{ fontSize: '0.92rem' }}>
+              {s.name}
             </div>
-            <div className="caption" style={{ fontSize: '0.82rem' }}>{m.substrate}</div>
-            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.82rem' }}>{m.why}</div>
+            <p className="caption" style={{ color: 'var(--text-3)' }}>
+              {s.detail}
+            </p>
           </div>
         ))}
+      </div>
+      <div className="card p-4">
+        <div className="label mb-2">Output</div>
+        <p className="body mb-2" style={{ fontSize: '0.9rem' }}>
+          One winner + the considered-rejects panel — what else was on the table and why it lost.
+        </p>
+        <p className="caption" style={{ color: 'var(--text-3)' }}>
+          LLM in use today:{' '}
+          {healthError ? (
+            <span style={{ color: 'var(--text-4)' }}>— (live value unavailable)</span>
+          ) : modelLoading ? (
+            <span style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>···</span>
+          ) : (
+            <code>{health.llm_model}</code>
+          )}{' '}
+          via AWS Bedrock's Converse backend. The cost picker lets you pick a different model,
+          bring your own key, or run fully local against Ollama.
+        </p>
       </div>
     </div>
   )
 }
 
-function CorpusPanel() {
+// ── §5 — The rigor gate ────────────────────────────────────────────────
+// The heaviest rewrite in this file. The spec's own draft copy ("corrected
+// for how many things were tried") risked implying automatic multiple-
+// testing correction. On the curated/library path, every strategy runs with
+// num_trials=1 — backend/archimedes/services/rigor_evaluator.py logs it
+// verbatim: "num_trials=1 — DSR runs UNDEFLATED (no multiple-testing
+// correction)". The copy below states the defensible claim only, and names
+// the num_trials=1 caveat explicitly rather than burying it.
+function RigorGateSection({ leaderboard, leaderboardError }) {
+  const passingCount = leaderboard?.entries
+    ? leaderboard.entries.filter(e => e.passes_rigor_gate).length
+    : undefined
+  const loading = !leaderboard && !leaderboardError
+
   return (
     <div className="card p-5 mb-7">
-      <div className="label mb-3">The q-fin corpus — Layer E in detail</div>
+      <div className="label mb-3">The admission bar — computed live, never cached</div>
       <p className="body mb-4">
-        10,000 paper <strong>metadata records</strong> (arXiv preprints across q-fin, ML, math,
-        and agentic AI) seeded from a JSONL manifest into Postgres. The Strategy Generation Agent's{' '}
-        <strong>Paper Retrieval</strong> sub-agent ranks these records by keyword/TF-IDF relevance
-        when you submit a brief. The full KB pipeline — PyMuPDF full-text extraction, SPECTER2
-        embeddings, HDBSCAN clusters, and a REBEL + SciSpacy knowledge graph — is the build target;
-        it has not run yet, so embeddings, clusters, and graph edges are not live.
+        Most backtests lie by selection: try enough ideas and one will look brilliant by chance.
+        Over 20+ years of backtested returns net of realistic commission, a strategy's excess
+        Sharpe must be positive at 90% one-sided confidence under standard errors robust to
+        non-normality and autocorrelation, and must stay positive on a 30% chronological
+        holdout. On the generated path, a strategy's Sharpe is additionally deflated against the
+        size of its own candidate pool.
       </p>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        {[
-          { n: '1,360', l: 'Statistical Finance', s: 'arxiv q-fin.ST' },
-          { n: '1,292', l: 'Mathematical Finance', s: 'arxiv q-fin.MF' },
-          { n: '1,016', l: 'Computational Finance', s: 'arxiv q-fin.CP' },
-          { n: '950', l: 'Risk Management', s: 'arxiv q-fin.RM' },
-        ].map(b => (
-          <div key={b.l} className="card-flat p-3">
-            <div className="font-bold" style={{ fontSize: '1.1rem' }}>{b.n}</div>
-            <div className="caption" style={{ color: 'var(--text-1)' }}>{b.l}</div>
-            <div className="caption" style={{ color: 'var(--text-3)' }}>{b.s}</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
+        <div className="card-flat p-4">
+          <div className="font-semibold mb-1" style={{ fontSize: '0.92rem' }} title="Deflated Sharpe Ratio">
+            DSR
           </div>
-        ))}
+          <p className="caption" style={{ color: 'var(--text-3)' }}>
+            Deflated Sharpe Ratio: on generated strategies, deflates the Sharpe against how many
+            candidates were tried in that debate round; curated-path strategies run with a single
+            trial (see honesty note below).
+          </p>
+        </div>
+        <div className="card-flat p-4">
+          <div className="font-semibold mb-1" style={{ fontSize: '0.92rem' }} title="Probability of Backtest Overfitting">
+            PBO
+          </div>
+          <p className="caption" style={{ color: 'var(--text-3)' }}>
+            Probability of Backtest Overfitting: how likely the in-sample winner underperforms
+            out-of-sample.
+          </p>
+        </div>
+        <div className="card-flat p-4">
+          <div className="font-semibold mb-1" style={{ fontSize: '0.92rem' }} title="Out-of-sample">
+            Walk-forward OOS
+          </div>
+          <p className="caption" style={{ color: 'var(--text-3)' }}>
+            The strategy must hold up on data it never saw, with no in-sample/out-of-sample
+            cliff.
+          </p>
+        </div>
+        <div className="card-flat p-4">
+          <div className="font-semibold mb-1" style={{ fontSize: '0.92rem' }}>
+            Look-ahead audit
+          </div>
+          <p className="caption" style={{ color: 'var(--text-3)' }}>
+            Static analysis confirms no future data leaks into any decision.
+          </p>
+        </div>
       </div>
-      <p className="caption mt-3" style={{ color: 'var(--text-3)' }}>
-        10,000 metadata records across 41 categories (top four shown above), all seeded into
-        Postgres from the JSONL manifest. Metadata only — no full-text ingestion, embeddings,
-        or knowledge graph yet (that pipeline is the build target); no paper PDFs in S3 and no
-        per-paper index in DynamoDB.
-      </p>
+      <div className="card-flat p-4">
+        <div className="label mb-2">Honesty note</div>
+        <p className="caption mb-2" style={{ color: 'var(--text-3)' }}>
+          The verdict is tri-state: <strong style={{ color: 'var(--text-2)' }}>pass</strong>,{' '}
+          <strong style={{ color: 'var(--text-2)' }}>fail</strong>, or{' '}
+          <strong style={{ color: 'var(--text-2)' }}>pending</strong> (no real returns yet). A
+          pending strategy is honestly unknown — it never silently wears a badge. Paper claims vs
+          our replication are shown as deltas, not hidden behind a score. The gate is a bar, not
+          a guarantee: passing reduces the odds of a curve-fit artifact; it does not promise
+          alpha.
+        </p>
+        <p className="caption mb-3" style={{ color: 'var(--text-3)' }}>
+          On the curated library, <code>num_trials=1</code> — DSR runs undeflated (no
+          multiple-testing correction) for those strategies.
+        </p>
+        <p className="caption" style={{ color: 'var(--text-3)', borderTop: '1px solid var(--glass-border)', paddingTop: 10 }}>
+          {leaderboardError ? (
+            <span style={{ color: 'var(--text-4)' }}>Live proof line unavailable right now.</span>
+          ) : loading ? (
+            <span style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>Loading live gate results…</span>
+          ) : (
+            <>
+              <strong style={{ color: 'var(--text-1)' }}>{fmtNum(passingCount)}</strong> of{' '}
+              <strong style={{ color: 'var(--text-1)' }}>{fmtNum(leaderboard.total)}</strong> strategies on the
+              leaderboard currently pass the live gate.
+            </>
+          )}
+        </p>
+      </div>
     </div>
   )
 }
+
+// ── §6 — On-chain: your vault, the agent's leash ───────────────────────
+
+const AGENT_AUTHORITY = [
+  {
+    can: 'Rebalance within your signed allocation universe',
+    cannot: 'Withdraw funds — ever; withdrawals are yours alone',
+  },
+  {
+    can: 'Execute swaps bounded by an oracle price floor',
+    cannot: 'Change which tokens the vault may hold',
+  },
+  {
+    can: 'Anchor its reasoning traces on-chain',
+    cannot: 'Replace itself, pause the vault, or change fees',
+  },
+  {
+    can: 'Decide to hold (and say why)',
+    cannot: 'Trade without a prior on-chain reasoning commitment',
+  },
+]
+
+function OnChainAuthority({ contracts, contractsError }) {
+  return (
+    <div className="card p-5 mb-7">
+      <div className="label mb-3">Non-custodial by contract, not by promise</div>
+      <p className="body mb-4">
+        Your deposit lives in a vault contract on Arc that you own. The agent is a named address
+        with exactly one power. The contract — not our goodwill — enforces the split:
+      </p>
+      <div className="table-container mb-4">
+        <table>
+          <thead>
+            <tr>
+              <th>The agent can</th>
+              <th>The agent cannot</th>
+            </tr>
+          </thead>
+          <tbody>
+            {AGENT_AUTHORITY.map(row => (
+              <tr key={row.can}>
+                <td>
+                  <span className="i-lucide-check-circle-2 w-3.5 h-3.5" style={{ color: 'var(--positive)', marginRight: 6 }} />
+                  {row.can}
+                </td>
+                <td>
+                  <span className="i-lucide-x-circle w-3.5 h-3.5" style={{ color: 'var(--negative)', marginRight: 6 }} />
+                  {row.cannot}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="caption mb-3" style={{ color: 'var(--text-3)' }}>
+        Vault creation happens in your wallet — you sign <code>createVault</code> and{' '}
+        <code>setAgent</code> yourself, then approve → deposit → allocate. Owner: you. Agent:
+        rebalance-only. Settlement: USDC on Arc testnet
+        {contractsError ? (
+          ' (chain id unavailable right now)'
+        ) : contracts?.chain_id ? (
+          ` chain ${contracts.chain_id}`
+        ) : (
+          '…'
+        )}
+        .
+      </p>
+      <div
+        style={{
+          padding: '8px 12px',
+          borderLeft: '3px solid var(--warning)',
+          background: 'var(--warning-bg)',
+          borderRadius: 4,
+          fontSize: 13,
+          color: 'var(--text-2)',
+        }}
+      >
+        <strong style={{ color: 'var(--warning)' }}>Heads up.</strong> Price-oracle pushes are
+        being refreshed following the most recent contract redeploy, so some live pricing views
+        may lag. This page does not claim live vault NAV, minting, or burning is demonstrably
+        working right now.
+      </div>
+    </div>
+  )
+}
+
+// ── §7 — Provenance: commit → trade → reveal ───────────────────────────
+// New section — the old page described publish-after anchoring; the real
+// mechanism is commit-before-trade, contract-enforced (Vault.sol:422, #589).
+
+function CommitTradeRevealLoop() {
+  return (
+    <svg
+      viewBox="0 0 460 130"
+      width="100%"
+      height="130"
+      role="img"
+      aria-labelledby="ctr-title ctr-desc"
+      style={{ maxWidth: 460, display: 'block', margin: '0 auto' }}
+    >
+      <title id="ctr-title">Commit, trade, reveal — enforced ordering</title>
+      <desc id="ctr-desc">
+        Three-step loop: the agent commits a reasoning hash, the vault contract enforces that the
+        trade cannot happen without that commitment, then the full trace is revealed and
+        re-hashed on-chain to verify the match.
+      </desc>
+      <defs>
+        <marker id="ctrArrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M0,1 L9,5 L0,9 Z" fill="#D4A853" />
+        </marker>
+        <marker id="ctrArrowGray" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M0,1 L9,5 L0,9 Z" fill="#71717A" />
+        </marker>
+      </defs>
+      <path d="M390,34 C390,6 70,6 70,34" fill="none" stroke="#71717A" strokeWidth="1.2" strokeDasharray="3,3" markerEnd="url(#ctrArrowGray)" />
+      <line x1="104" y1="65" x2="196" y2="65" stroke="#D4A853" strokeWidth="1.5" markerEnd="url(#ctrArrow)" />
+      <line x1="264" y1="65" x2="356" y2="65" stroke="#D4A853" strokeWidth="1.5" markerEnd="url(#ctrArrow)" />
+      <g>
+        <circle cx="70" cy="65" r="34" fill="#141419" stroke="#D4A853" strokeWidth="1.5" />
+        <text x="70" y="61" textAnchor="middle" fontSize="11" fontWeight="600" fill="#FAFAFA">1</text>
+        <text x="70" y="76" textAnchor="middle" fontSize="10" fill="#A1A1AA">Commit</text>
+      </g>
+      <g>
+        <circle cx="230" cy="65" r="34" fill="#141419" stroke="#D4A853" strokeWidth="1.5" />
+        <text x="230" y="61" textAnchor="middle" fontSize="11" fontWeight="600" fill="#FAFAFA">2</text>
+        <text x="230" y="76" textAnchor="middle" fontSize="10" fill="#A1A1AA">Trade</text>
+      </g>
+      <g>
+        <circle cx="390" cy="65" r="34" fill="#141419" stroke="#D4A853" strokeWidth="1.5" />
+        <text x="390" y="61" textAnchor="middle" fontSize="11" fontWeight="600" fill="#FAFAFA">3</text>
+        <text x="390" y="76" textAnchor="middle" fontSize="10" fill="#A1A1AA">Reveal</text>
+      </g>
+    </svg>
+  )
+}
+
+function ProvenanceSection() {
+  return (
+    <div className="card p-5 mb-7">
+      <div className="label mb-3">Reasoning you can't backdate</div>
+      <p className="body mb-4">
+        A hash anchored <em>after</em> a trade proves nothing — you could generate a hundred
+        rationales and keep the flattering one. Archimedes anchors <strong>before</strong>:
+      </p>
+      <div className="mb-4" style={{ overflowX: 'auto' }}>
+        <CommitTradeRevealLoop />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
+        <div className="card-flat p-3">
+          <div className="font-semibold mb-1" style={{ fontSize: '0.88rem' }}>1. Commit</div>
+          <div className="caption" style={{ color: 'var(--text-3)' }}>
+            The agent hashes its full reasoning trace and records the hash + trade intent on the{' '}
+            <code>ReasoningTraceRegistry</code>.
+          </div>
+        </div>
+        <div className="card-flat p-3">
+          <div className="font-semibold mb-1" style={{ fontSize: '0.88rem' }}>2. Trade</div>
+          <div className="caption" style={{ color: 'var(--text-3)' }}>
+            The vault's <code>rebalance()</code> reverts unless that commitment exists — the
+            ordering is enforced by the contract, not by our code being well-behaved.
+          </div>
+        </div>
+        <div className="card-flat p-3">
+          <div className="font-semibold mb-1" style={{ fontSize: '0.88rem' }}>3. Reveal</div>
+          <div className="caption" style={{ color: 'var(--text-3)' }}>
+            After settlement, the full trace is published (IPFS-pointed) and the contract itself
+            re-hashes the content to verify it matches the commitment.
+          </div>
+        </div>
+      </div>
+      <div className="card-flat p-4">
+        <div className="label mb-2">Verify</div>
+        <p className="caption" style={{ color: 'var(--text-3)' }}>
+          Open any decision in <strong>Reasoning</strong> and check two things: the content hash
+          matches, and commit block &lt; trade block &lt; reveal block. This proves the trace
+          existed before the trade and was never rewritten. It does not prove the reasoning was
+          smart or the trade profitable — that honesty is the point.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ── §8 — The marketplace ───────────────────────────────────────────────
+
+function MarketplaceSection() {
+  return (
+    <div className="mb-7">
+      <div className="label mb-3">Pay creators, not the house</div>
+      <p className="body mb-4">
+        Publish a strategy and others can subscribe to it for sub-cent USDC nanopayments (x402),
+        settled through Circle's Gateway. Every payment splits <strong>90/10</strong>{' '}
+        creator/platform through an on-chain <code>PaymentSplitter</code>. Subscribers get a
+        dedicated Circle wallet provisioned automatically; spend caps bound what a runaway agent
+        can spend. Archimedes earns generation and marketplace fees only — never a cut of
+        anyone's trading P&amp;L, and never the other side of your trade.
+      </p>
+      <div className="card-flat p-4">
+        <div className="label mb-2">Honesty note</div>
+        <p className="caption" style={{ color: 'var(--text-3)' }}>
+          Vault principal is non-custodial today and always. Marketplace fee custody is being
+          migrated to a fully non-custodial design; fee settlement is currently in dry-run.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ── §9 — The research corpus ───────────────────────────────────────────
+// Corrects the stale keyword/TF-IDF claim: MiniLM semantic retrieval IS
+// live (/health: paper_rag "live", corpus_embedded true). The honest gap is
+// the knowledge graph, which has not been built (corpus_kg_built false).
+
+function CorpusSection({ health, healthError }) {
+  const loading = !health && !healthError
+  return (
+    <div className="card p-5 mb-7">
+      <div className="label mb-3">Where the ideas come from</div>
+      {healthError ? (
+        <p className="body mb-4" style={{ color: 'var(--text-4)' }}>
+          Live corpus stats are unavailable right now.
+        </p>
+      ) : loading ? (
+        <p className="body mb-4" style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>
+          Loading live corpus stats…
+        </p>
+      ) : (
+        <p className="body mb-4">
+          Generation starts from a corpus of quantitative-finance research — a{' '}
+          {fmtNum(health.corpus_papers)}-paper arXiv manifest spanning statistical finance,
+          portfolio math, market microstructure, and agentic AI. At generate time, retrieval runs
+          in two stages: a keyword/asset-class filter, then a semantic rerank with MiniLM
+          sentence embeddings against your brief (
+          {health.paper_rag === 'live'
+            ? 'semantic retrieval is live today'
+            : 'semantic retrieval is currently degraded to a keyword-only fallback'}
+          ). Retrieved papers are embargo-filtered — nothing published after a decision point can
+          inform it — and every citation carries its arXiv ID and content hash.
+        </p>
+      )}
+      <div className="card-flat p-4">
+        <div className="label mb-2">Honesty note</div>
+        {healthError ? (
+          <p className="caption" style={{ color: 'var(--text-4)' }}>Live hydration status unavailable right now.</p>
+        ) : loading ? (
+          <p className="caption" style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>Loading…</p>
+        ) : (
+          <p className="caption" style={{ color: 'var(--text-3)' }}>
+            {fmtNum(health.corpus_db_count)} of the {fmtNum(health.corpus_papers)} manifest papers
+            are fully ingested and retrievable today. The knowledge-graph layer (citation graph
+            over the corpus){' '}
+            {health.corpus_kg_built
+              ? 'has produced its first artifact'
+              : 'has not yet produced its first production artifact'}{' '}
+            — the Corpus page shows exactly that, rather than a synthesized graph. Generation
+            requires at least two relevant papers or it declines to run.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── §10 — Reasoning protocols (Xia et al.) ─────────────────────────────
+// Kept panel shape; reworded the retrieval-mechanism line (MiniLM is the
+// live mechanism, not a "build target" caveat).
+const PROTOCOLS = [
+  {
+    name: 'Outcome Embargo',
+    what: 'Decisions only see papers published before the decision time.',
+  },
+  {
+    name: 'Time-Aware Retrieval',
+    what: 'Relevance decays with paper age, faster in volatile regimes.',
+  },
+  {
+    name: 'Hierarchy of Truth',
+    what: "Chain state outranks the LLM's narrative; V_check fails any rebalance where they disagree.",
+  },
+  {
+    name: 'Source Tracking',
+    what: 'Every cited paper carries (arXiv ID, version, content hash), anchored with the trace.',
+  },
+]
 
 function ProtocolsPanel() {
   return (
     <div className="card p-5 mb-7">
-      <div className="label mb-3">Reasoning protocols</div>
+      <div className="label mb-3">Enforced mechanisms, not guidelines</div>
       <p className="body mb-3">
-        Four named protocols from Xia et al. 2026 close the most common failure modes in
-        trading-agent design. Archimedes implements all four as enforced mechanisms.
+        Four protocols from Xia et al. 2026 — the audit of why most trading-agent research is
+        unreproducible — run as code in the live path.
       </p>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {PROTOCOLS.map(p => (
@@ -362,44 +737,120 @@ function ProtocolsPanel() {
   )
 }
 
-function OnChainPanel() {
+// ── §11 — What's real today (honesty ledger) ────────────────────────────
+
+const LEDGER_TONES = {
+  live: 'var(--positive)',
+  pending: 'var(--warning)',
+  roadmap: 'var(--info)',
+}
+
+function LedgerStatus({ children, tone }) {
+  return <strong style={{ color: LEDGER_TONES[tone] ?? 'var(--text-3)' }}>{children}</strong>
+}
+
+function HonestyLedger({ health, healthError }) {
+  const loading = !health && !healthError
   return (
     <div className="card p-5 mb-7">
-      <div className="label mb-3">On-chain — what lives on Arc</div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div className="card-flat p-3">
-          <div className="font-semibold mb-1">Vault</div>
-          <div className="caption" style={{ color: 'var(--text-3)' }}>
-            ERC-4626 non-custodial container. You own the shares; the agent has rebalance
-            authority only.
-          </div>
-        </div>
-        <div className="card-flat p-3">
-          <div className="font-semibold mb-1">ReasoningTraceRegistry</div>
-          <div className="caption" style={{ color: 'var(--text-3)' }}>
-            Every agent decision is canonical-hashed and anchored. Verify by recomputing the
-            hash and checking it against the on-chain anchor.
-          </div>
-        </div>
-        <div className="card-flat p-3">
-          <div className="font-semibold mb-1">PriceOracle &amp; AMM</div>
-          <div className="caption" style={{ color: 'var(--text-3)' }}>
-            Per-synth oracle pushes provide ground-truth prices; AMM router routes the
-            rebalance swaps.
-          </div>
-        </div>
+      <div className="label mb-3">The honest ledger</div>
+      <p className="body mb-4">
+        Archimedes runs on the Arc public testnet — real contracts, real signatures, faucet USDC,
+        no real funds at risk by design. Claims must be true on the live path; here is the
+        current state, kept current from the system's own health surface:
+      </p>
+      <div className="table-container mb-3">
+        <table>
+          <thead>
+            <tr>
+              <th>Surface</th>
+              <th>Status today</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Generate → rigor gate → passport</td>
+              <td><LedgerStatus tone="live">Live</LedgerStatus> — debate society, live tri-state gate</td>
+            </tr>
+            <tr>
+              <td>Non-custodial vault deploy + deposits</td>
+              <td><LedgerStatus tone="live">Live</LedgerStatus> — you sign everything; testnet USDC</td>
+            </tr>
+            <tr>
+              <td>Commit → trade → reveal provenance</td>
+              <td><LedgerStatus tone="live">Live</LedgerStatus> — contract-enforced ordering</td>
+            </tr>
+            <tr>
+              <td>Autonomous rebalance loop</td>
+              <td>
+                Runs on a schedule against every deployed vault; evaluates, commits, trades, and
+                reveals each tick
+              </td>
+            </tr>
+            <tr>
+              <td>Marketplace publish / subscribe</td>
+              <td>
+                <LedgerStatus tone="pending">Settlement in dry-run</LedgerStatus> — the real x402
+                pipeline runs end-to-end; final settlement is simulated
+              </td>
+            </tr>
+            <tr>
+              <td>Corpus retrieval</td>
+              <td>
+                {healthError ? (
+                  <span style={{ color: 'var(--text-4)' }}>— live value unavailable</span>
+                ) : loading ? (
+                  <span style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>···</span>
+                ) : health.paper_rag === 'live' ? (
+                  <>
+                    <LedgerStatus tone="live">Live</LedgerStatus> — keyword + MiniLM; {fmtNum(health.corpus_db_count)} of{' '}
+                    {fmtNum(health.corpus_papers)} papers hydrated
+                  </>
+                ) : (
+                  <>
+                    <LedgerStatus tone="pending">Degraded</LedgerStatus> — keyword-only fallback active
+                  </>
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td>Knowledge graph</td>
+              <td>
+                {healthError ? (
+                  <span style={{ color: 'var(--text-4)' }}>— live value unavailable</span>
+                ) : loading ? (
+                  <span style={{ color: 'var(--text-4)', animation: 'pulse 1.4s infinite' }}>···</span>
+                ) : health.corpus_kg_built ? (
+                  <><LedgerStatus tone="live">Live</LedgerStatus> — first artifact produced</>
+                ) : (
+                  <><LedgerStatus tone="pending">Not yet</LedgerStatus> — pipeline built, first artifact pending</>
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td>Mainnet, real funds</td>
+              <td><LedgerStatus tone="roadmap">Roadmap</LedgerStatus> — Arc mainnet is upcoming; settlement architecture is an explicit deferred decision</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
+      <p className="caption" style={{ color: 'var(--text-3)' }}>
+        If a row here ever disagrees with what you see in the product, that's a bug — report it.
+        The badge only means something if it can fail.
+      </p>
     </div>
   )
 }
+
+// ── §12 — CTA ────────────────────────────────────────────────────────
 
 function CallToAction({ onNavigate }) {
   return (
     <div className="card p-5 text-center">
       <h3 className="serif mb-2" style={{ fontSize: '1.4rem' }}>Ready to try it?</h3>
       <p className="body mb-4" style={{ color: 'var(--text-3)', maxWidth: 520, margin: '0 auto 16px' }}>
-        Describe a strategy in plain English. Sign in with a passkey to generate — no
-        browser extension needed; deploying into a vault uses free testnet USDC.
+        Describe a strategy in plain English. Sign in with any wallet or a passkey; deploying into
+        a vault uses free testnet USDC.
       </p>
       <div className="flex justify-center gap-3 flex-wrap">
         <button className="btn btn-primary" onClick={() => onNavigate?.('generate')}>
@@ -408,22 +859,38 @@ function CallToAction({ onNavigate }) {
         <button className="btn btn-outline" onClick={() => onNavigate?.('corpus')}>
           Explore the Corpus
         </button>
+        <button className="btn btn-outline" onClick={() => onNavigate?.('leaderboard')}>
+          See the Leaderboard
+        </button>
       </div>
     </div>
   )
 }
 
 export default function Architecture({ onNavigate }) {
+  const { contracts, contractsError, health, healthError, leaderboard, leaderboardError } = useArchStats()
+
   return (
     <div>
       <PageHeader />
-      <HeroStrip />
+      <HeroStrip
+        contracts={contracts}
+        contractsError={contractsError}
+        health={health}
+        healthError={healthError}
+        leaderboard={leaderboard}
+        leaderboardError={leaderboardError}
+      />
+      <SystemFlowDiagram />
       <PipelineFlow />
-      <AgentCards />
-      <MemoryPillar />
-      <CorpusPanel />
+      <DebateSociety health={health} healthError={healthError} />
+      <RigorGateSection leaderboard={leaderboard} leaderboardError={leaderboardError} />
+      <OnChainAuthority contracts={contracts} contractsError={contractsError} />
+      <ProvenanceSection />
+      <MarketplaceSection />
+      <CorpusSection health={health} healthError={healthError} />
       <ProtocolsPanel />
-      <OnChainPanel />
+      <HonestyLedger health={health} healthError={healthError} />
       <CallToAction onNavigate={onNavigate} />
     </div>
   )

--- a/ui/src/components/CorpusGraph.jsx
+++ b/ui/src/components/CorpusGraph.jsx
@@ -187,7 +187,7 @@ export default function CorpusGraph() {
       <div className="corpus-graph-error" style={{ padding: 24 }}>
         <div className="info-box warning">
           {error.includes('503') || error.includes('KB pipeline')
-            ? 'KB pipeline still running — first artifact pending. The graph will populate once embeddings are computed.'
+            ? "Knowledge-graph pipeline hasn't run yet (SPECTER2 clustering + entity extraction) — paper retrieval already uses live semantic embeddings (MiniLM); this similarity graph will populate once the KB pipeline produces its first artifact."
             : `Graph unavailable: ${error}`}
         </div>
       </div>

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -1,4 +1,40 @@
+import { useEffect, useState } from 'react'
+import { apiGet } from '../api'
+
+// Core singleton contract fields actually returned by GET /api/config/contracts
+// today (ConfigService.get_contract_addresses). `usdc` is Arc-native (Circle's,
+// not ours) so it is deliberately excluded from this count — see
+// ARCHITECTURE-MAP.md §1.7. strategy_registry / payment_splitter are NOT in the
+// live response yet (a known backend gap), so the derived count below is the
+// honest floor, not the full architectural singleton count.
+const CORE_CONTRACT_FIELDS = [
+  'synthetic_factory',
+  'amm_router',
+  'vault_factory',
+  'reasoning_trace_registry',
+  'asset_registry',
+  'price_oracle',
+]
+
 export default function Landing({ onNavigate }) {
+  // Live contract census — never hardcode a contract count (it has shipped
+  // wrong 8 different ways across this repo). Fetched once on mount; an
+  // honest "—" / unavailable state renders on failure, never a stale number.
+  const [contracts, setContracts] = useState(null)
+  const [contractsError, setContractsError] = useState(false)
+
+  useEffect(() => {
+    apiGet('/api/config/contracts')
+      .then(setContracts)
+      .catch(() => setContractsError(true))
+  }, [])
+
+  const coreCount = contracts ? CORE_CONTRACT_FIELDS.filter(f => contracts[f]).length : null
+  const synthCount = contracts?.synthetics ? Object.keys(contracts.synthetics).length : null
+  const poolCount = contracts?.pools ? Object.keys(contracts.pools).length : null
+  const totalLive =
+    coreCount != null && synthCount != null && poolCount != null ? coreCount + synthCount + poolCount : null
+
   return (
     <div className="min-h-screen bg-[var(--canvas)] overflow-x-hidden font-[var(--sans)]">
 
@@ -47,7 +83,7 @@ export default function Landing({ onNavigate }) {
             Every rebalance decision gets a keccak256 hash anchored on Arc.
             Verify the agent's reasoning trail — before and after each trade.
           </FeatureCard>
-          <FeatureCard icon="bot" title="Autonomous Agent" tag="Live · minute-level ticks">
+          <FeatureCard icon="bot" title="Autonomous Agent" tag="Live · scheduled rebalance loop">
             The agent evaluates paper-grounded strategies against live market data,
             detects regime shifts, and rebalances autonomously — USDC on Arc.
           </FeatureCard>
@@ -65,7 +101,14 @@ export default function Landing({ onNavigate }) {
           {[
             { name: 'Arc',         desc: 'EVM · Sub-second finality' },
             { name: 'Circle',      desc: 'USDC · Wallets · CCTP' },
-            { name: 'Foundry',     desc: '11 deployed contracts' },
+            {
+              name: 'Foundry',
+              desc: contractsError
+                ? 'live count unavailable'
+                : totalLive != null
+                  ? `${totalLive} live instances`
+                  : '…',
+            },
             { name: 'AWS Bedrock', desc: 'Nova Micro · Strategy extraction · Reasoning' },
             { name: 'React + viem',desc: 'Frontend · Wallet UX' },
             { name: 'FastAPI',     desc: 'Backend · Agent runner' },
@@ -86,7 +129,7 @@ export default function Landing({ onNavigate }) {
         </p>
         <div className="lg-grid-4">
           {[
-            { n: '01', title: 'Deflated Sharpe Ratio',              desc: 'Bailey & López de Prado 2014 — corrects for multiple-testing inflation' },
+            { n: '01', title: 'Deflated Sharpe Ratio',              desc: 'Bailey & López de Prado 2014 — 90% one-sided confidence, robust standard errors; deflated against candidate-pool size where one exists' },
             { n: '02', title: 'Probability of Backtest Overfitting', desc: 'Bailey/Borwein/López de Prado/Zhu 2014 — detects curve-fitting' },
             { n: '03', title: 'Walk-Forward OOS Sharpe',             desc: 'Rolling window validation with no in/out-of-sample cliff' },
             { n: '04', title: 'Look-Ahead Audit',                    desc: 'Static lint for future-leaking function calls in strategy code' },
@@ -112,10 +155,21 @@ export default function Landing({ onNavigate }) {
             All vault deposits, trades, and redemptions settle in USDC on Arc.
             Native USDC at 0x3600…0000 on Arc testnet.
           </FeatureCard>
-          <FeatureCard icon="scroll-text"       title="Smart Contracts on Arc"       tag="11 Contracts · Foundry">
-            11 Solidity contracts deployed: Vault, VaultFactory, SyntheticVault,
-            SyntheticFactory, SyntheticToken, AMMPool, AMMRouter, AssetRegistry,
-            PriceOracle, StrategyRegistry, ReasoningTraceRegistry.
+          <FeatureCard
+            icon="scroll-text"
+            title="Smart Contracts on Arc"
+            tag={contractsError ? 'Foundry' : totalLive != null ? `${totalLive} live · Foundry` : 'Foundry'}
+          >
+            {contractsError ? (
+              <>Live contract count unavailable right now — see the Architecture page for the full census.</>
+            ) : totalLive != null ? (
+              <>
+                {coreCount} core contracts, {synthCount} synthetic assets, and {poolCount} AMM pools deployed
+                on Arc — fetched live from the contract census, not hardcoded.
+              </>
+            ) : (
+              <>Loading the live contract census…</>
+            )}
           </FeatureCard>
         </div>
       </LSection>

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -5,8 +5,11 @@ import { apiGet } from '../api'
 // today (ConfigService.get_contract_addresses). `usdc` is Arc-native (Circle's,
 // not ours) so it is deliberately excluded from this count — see
 // ARCHITECTURE-MAP.md §1.7. strategy_registry / payment_splitter are NOT in the
-// live response yet (a known backend gap), so the derived count below is the
-// honest floor, not the full architectural singleton count.
+// live response yet (a known backend gap); `price_oracle` is ONE representative
+// address standing in for every per-asset oracle actually deployed; and
+// `contracts.vaults` is never folded into totalLive below. All of that makes
+// the derived count a floor, not an inventory — render it as "at least N" /
+// "N+", never as a complete census.
 const CORE_CONTRACT_FIELDS = [
   'synthetic_factory',
   'amm_router',
@@ -106,7 +109,7 @@ export default function Landing({ onNavigate }) {
               desc: contractsError
                 ? 'live count unavailable'
                 : totalLive != null
-                  ? `${totalLive} live instances`
+                  ? `≥${totalLive} live instances`
                   : '…',
             },
             { name: 'AWS Bedrock', desc: 'Nova Micro · Strategy extraction · Reasoning' },
@@ -158,14 +161,16 @@ export default function Landing({ onNavigate }) {
           <FeatureCard
             icon="scroll-text"
             title="Smart Contracts on Arc"
-            tag={contractsError ? 'Foundry' : totalLive != null ? `${totalLive} live · Foundry` : 'Foundry'}
+            tag={contractsError ? 'Foundry' : totalLive != null ? `≥${totalLive} live · Foundry` : 'Foundry'}
           >
             {contractsError ? (
               <>Live contract count unavailable right now — see the Architecture page for the full census.</>
             ) : totalLive != null ? (
               <>
-                {coreCount} core contracts, {synthCount} synthetic assets, and {poolCount} AMM pools deployed
-                on Arc — fetched live from the contract census, not hardcoded.
+                At least {coreCount} core contracts, {synthCount} synthetic assets, and {poolCount} AMM
+                pools deployed on Arc — fetched live from the contract census, not hardcoded, and reported
+                as a floor: some core singletons, per-asset oracles, and vault instances aren't all counted
+                yet.
               </>
             ) : (
               <>Loading the live contract census…</>

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -69,8 +69,6 @@ export const PAGE_LABELS = {
   learnings: 'Learnings',
   insights: 'Insights',
   'vault-detail': 'Vault Details',
-  about: 'About',
-  imprint: 'Imprint',
   marketplace: 'Marketplace',
   'market-strategy': 'Strategy Detail',
   publish: 'Publish',

--- a/ui/src/components/PortfolioAdvisor.jsx
+++ b/ui/src/components/PortfolioAdvisor.jsx
@@ -288,10 +288,13 @@ export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {
                 </div>
               </div>
               <p className="caption" style={{ marginTop: 12, color: 'var(--text-4)', lineHeight: 1.5 }}>
-                Deflated Sharpe (Bailey & López de Prado 2014) discounts multiple-testing inflation;
-                PBO (Bailey et al. 2014) estimates backtest-overfitting probability; chronological OOS
-                tests out-of-sample stability. Mean DSR p-value: {fmt(data.rigor_summary.avg_dsr_p_value, 3)},
-                mean PBO: {fmt(data.rigor_summary.avg_pbo_score, 3)}.
+                Deflated Sharpe (Bailey & López de Prado 2014) uses a standard error robust to
+                non-normality, and discounts multiple-testing inflation only when a pick has its
+                own multi-candidate selection pool (each library pick is otherwise graded on its
+                own Sharpe — num_trials = 1, undeflated); PBO (Bailey et al. 2014) estimates
+                backtest-overfitting probability; chronological OOS tests out-of-sample stability.
+                Mean DSR p-value: {fmt(data.rigor_summary.avg_dsr_p_value, 3)}, mean PBO:{' '}
+                {fmt(data.rigor_summary.avg_pbo_score, 3)}.
               </p>
             </div>
           )}

--- a/ui/src/components/PortfolioAdvisor.jsx
+++ b/ui/src/components/PortfolioAdvisor.jsx
@@ -289,9 +289,10 @@ export default function PortfolioAdvisor({ initialRiskProfile = 'moderate' } = {
               </div>
               <p className="caption" style={{ marginTop: 12, color: 'var(--text-4)', lineHeight: 1.5 }}>
                 Deflated Sharpe (Bailey & López de Prado 2014) uses a standard error robust to
-                non-normality, and discounts multiple-testing inflation only when a pick has its
-                own multi-candidate selection pool (each library pick is otherwise graded on its
-                own Sharpe — num_trials = 1, undeflated); PBO (Bailey et al. 2014) estimates
+                non-normality and serial correlation (Newey–West HAC), and discounts
+                multiple-testing inflation only when a pick has its own multi-candidate selection
+                pool (each library pick is otherwise graded on its own Sharpe — num_trials = 1,
+                undeflated); PBO (Bailey et al. 2014) estimates
                 backtest-overfitting probability; chronological OOS tests out-of-sample stability.
                 Mean DSR p-value: {fmt(data.rigor_summary.avg_dsr_p_value, 3)}, mean PBO:{' '}
                 {fmt(data.rigor_summary.avg_pbo_score, 3)}.

--- a/ui/src/components/RigorExplainer.jsx
+++ b/ui/src/components/RigorExplainer.jsx
@@ -67,6 +67,13 @@ export default function RigorExplainer() {
               where SR₀ = expected best Sharpe of N iid trials, γ₃ = skewness, γ₄ = raw kurtosis
             </span>
           </div>
+          <div className="caption" style={{ marginTop: 10, color: 'var(--text-3)', fontSize: '0.78rem', lineHeight: 1.5 }}>
+            <strong>N is self-contained per strategy.</strong> Curated library strategies run
+            with N = 1 — each is graded on its own Sharpe, so SR₀ collapses to its N = 1 minimum
+            and no multiple-testing deflation is applied. N &gt; 1 only applies to a strategy
+            that comes out of a multi-candidate generation pool, where N counts every candidate
+            actually tried in that round.
+          </div>
         </div>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
@@ -85,8 +92,9 @@ export default function RigorExplainer() {
               Moreira-Muir: DSR = 0.55, p = 0.995
             </div>
             <div className="caption" style={{ color: 'var(--text-3)' }}>
-              The market's volatility-managed premium is statistically real, even after
-              correcting for 4 candidate strategies tested.
+              Graded on its own Sharpe (N = 1, undeflated) with a standard error robust to
+              non-normality — the market's volatility-managed premium clears the bar without
+              relying on a multiple-testing correction.
             </div>
           </div>
         </div>

--- a/ui/src/components/RigorExplainer.jsx
+++ b/ui/src/components/RigorExplainer.jsx
@@ -93,8 +93,9 @@ export default function RigorExplainer() {
             </div>
             <div className="caption" style={{ color: 'var(--text-3)' }}>
               Graded on its own Sharpe (N = 1, undeflated) with a standard error robust to
-              non-normality — the market's volatility-managed premium clears the bar without
-              relying on a multiple-testing correction.
+              non-normality and serial correlation (Newey–West HAC) — the market's
+              volatility-managed premium clears the bar without relying on a multiple-testing
+              correction.
             </div>
           </div>
         </div>

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -457,7 +457,8 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
             <>
               This strategy is graded on its own Sharpe (num_trials = 1 — no multiple-testing
               correction applied); the Deflated Sharpe Ratio here still uses a standard error
-              robust to non-normality (Bailey & López de Prado 2014).
+              robust to non-normality and serial correlation (Newey–West HAC; Bailey & López de
+              Prado 2014).
             </>
           )}{' '}
           PBO estimates how much of the in-sample Sharpe is overfit (Bailey et al. 2014). OOS

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -447,11 +447,22 @@ export default function StrategyPassport({ strategyId, onNavigate, walletAddr })
           <Metric label="Trades" value={s.total_trades != null ? s.total_trades : '—'} hint="executed in backtest" />
         </div>
         <p className="caption mt-3 leading-relaxed text-[var(--text-3)]">
-          The Deflated Sharpe Ratio corrects the realized Sharpe for multiple-testing
-          inflation (Bailey & López de Prado 2014). PBO estimates how much of the
-          in-sample Sharpe is overfit (Bailey et al. 2014). OOS Sharpe is the
-          chronological out-of-sample number. A strategy passes the rigor gate only
-          when all three signals align.
+          {s.num_trials_in_selection != null && s.num_trials_in_selection > 1 ? (
+            <>
+              The Deflated Sharpe Ratio corrects the realized Sharpe for multiple-testing
+              inflation across the {s.num_trials_in_selection} candidates in this strategy's
+              own selection pool (Bailey & López de Prado 2014).
+            </>
+          ) : (
+            <>
+              This strategy is graded on its own Sharpe (num_trials = 1 — no multiple-testing
+              correction applied); the Deflated Sharpe Ratio here still uses a standard error
+              robust to non-normality (Bailey & López de Prado 2014).
+            </>
+          )}{' '}
+          PBO estimates how much of the in-sample Sharpe is overfit (Bailey et al. 2014). OOS
+          Sharpe is the chronological out-of-sample number. A strategy passes the rigor gate
+          only when all three signals align.
         </p>
 
         {/* Return source (T2.5) — the rigor gate says whether the edge survives;


### PR DESCRIPTION
## Why

PR #1123 specified a full redesign of the Architecture page in July and merged **documentation only** — 9 files, zero UI code. The spec has sat unimplemented since. Meanwhile the live page kept shipping claims that are no longer true.

This builds the page and fixes three classes of visitor-facing defect found along the way.

Closes the implementation half of #1123.

## 1. Architecture page rebuilt to spec

`Architecture.jsx` 430 → 961 lines, following `docs/architecture-redesign/page-design-proposal.md`.

**The anti-rot rule is the point.** The old page died because its stats were hardcoded in JSX. Every number on the new page is live-fetched at render time from `/api/config/contracts`, `/health` and `/api/leaderboard`, with an honest `—` + "live value unavailable" on failure. There are **no hardcoded statistics**, so the page cannot rot the way its predecessor did.

Sections replace the "3 top-level agents / 6 memory layers" framing — which described an architecture we do not have — with the shipped one: a multi-agent debate society, with the rigor gate running **external** to the generator so the thing being graded cannot influence its own grade.

## 2. Claim-integrity fixes

| Was | Where | Now |
|---|---|---|
| "11 Solidity contracts deployed" | `Landing.jsx:116` | Live census from `/api/config/contracts` |
| "60s tick rebalance loop" | `Architecture.jsx:149` | Removed — actual default is 300s |
| Corpus implied keyword/TF-IDF | Architecture | MiniLM retrieval is live; the honest gap (KG not built) is stated instead |

The contract count is derived, never typed — this repo has shipped **8 mutually contradictory contract counts** across 66 assertions, and a corrected literal would simply rot again. The Landing.jsx implementation also discloses its own limitation: `strategy_registry` and `payment_splitter` are absent from the API response, so the derived count is documented in-code as *"the honest floor, not the full architectural singleton count."*

### The rigor-gate description is deliberately narrower than the spec's

The spec's draft copy claimed multiple-testing correction. **That is not true on the curated path.** `num_trials=1` sets the expected-maximum term to exactly zero, and `rigor_evaluator.py` logs it verbatim: `"num_trials=1 — DSR runs UNDEFLATED (no multiple-testing correction)"`.

The page now states the defensible version — 20+ years of returns net of commission, excess Sharpe positive at 90% one-sided confidence under non-normality/autocorrelation-robust standard errors, holding on a 30% chronological holdout — and adds the caveat explicitly rather than burying it. The generated path's deflation against its own candidate pool is described accurately and separately.

## 3. Routing defects — worse than 404s

**The app is not hash-routed anymore.** `resolveRoute()` reads `window.location.pathname` and never touches `window.location.hash` (`App.jsx:107,175,224`). Three surfaces still advertised the old scheme, and because a fragment never reaches `pathname`, each **silently rendered the landing page** rather than erroring — no signal to a crawler or a visitor that anything was wrong.

- **`sitemap.xml`** — all 9 entries dead. Rewritten to 7 real clean-path URLs, excluding wallet-gated routes (an anonymous crawler sees only a "connect wallet" card — nothing to index) and dynamic id routes.
- **`index.html`** — JSON-LD `potentialAction.target` pointed at `/#/generate`, so the structured-data action published to search engines resolved to the homepage.
- **`/about` + `/imprint`** — wired into `App.jsx`'s `PAGE_TO_PATH` with no render case. The router returned `matched: true`, which **skipped the normal unknown-path redirect** and dead-ended on `NotFound` under a URL it claimed to own. Removed from both the routing table and `Layout.jsx`'s label map.

## Verification

```
npm run lint   → exit 0
npm run build  → exit 0
```

Every claim on the new page traced to a live endpoint field or removed. Fallback paths traced per stat: no rendering of `undefined`, `NaN`, or a fabricated default.

## Scope

`ui/` only — 8 files, +1,078/−266. No backend, contract, infra or docs changes.

## Follow-ups deliberately NOT done here

- **About / Imprint content.** An Impressum is a legal requirement in Germany and several EU jurisdictions; removing the dead link does not remove the obligation. Needs an owner decision, not invented copy.
- **Per-route meta/OG/title.** `document.title` is set client-side only, so every route looks identical to a non-JS crawler. The sitemap fix stops the file lying; real SEO needs SSR or prerendering. Separate project.
- **Marketplace custody wording** (#1169) is an open decision, so the page carries neutral placeholder text pending that call.
- **`Breadcrumbs.jsx`'s `CRUMB_MAP`** references an older route scheme — same disease, third surface, left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M