### PR TITLE
[infra] Fix invalid docker awslogs log opt that has bricked both runner units since first boot

### DIFF
--- a/infra/runner-user-data.sh
+++ b/infra/runner-user-data.sh
@@ -133,8 +133,23 @@ REGION="${aws_region}"
 PREFIX="/archimedes/prod"
 OUT="/opt/archimedes-runners/runner.env"
 
+# Build into a temp file and rename into place ATOMICALLY. Writing $OUT
+# directly (truncate-then-append) is a real race: BOTH units run this as
+# ExecStartPre and each restarts independently every 10s, so one unit's
+# `docker run --env-file` can read $OUT while the other unit's fetch has
+# truncated it and is still appending — the container then boots with a
+# PARTIAL environment and no error anywhere. (Observed live: a read of
+# runner.env during a restart loop returned 10 of 15 parameters.) rename(2)
+# is atomic, so a reader sees either the whole old file or the whole new one.
+# It also means a mid-flight aws failure leaves the last-good file intact
+# instead of a truncated one.
+# mktemp, not "$OUT.tmp.$$": this file is rendered through Terraform's
+# templatefile(), where `$$` sits next to HCL's `$${` escape — mktemp sidesteps
+# the ambiguity entirely and also guarantees a unique name when both units
+# fetch concurrently.
 umask 077
-: > "$OUT"
+TMP="$(mktemp "$OUT.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
 
 aws ssm get-parameters-by-path \
   --path "$PREFIX" \
@@ -145,10 +160,29 @@ aws ssm get-parameters-by-path \
   --output text |
 while IFS=$'\t' read -r name value; do
   key="$(basename "$name")"
-  printf '%s=%s\n' "$key" "$value" >> "$OUT"
+  printf '%s=%s\n' "$key" "$value" >> "$TMP"
 done
 
-chmod 600 "$OUT"
+# LOAD-BEARING INPUT CHECK — be loud about exactly the inputs the runners
+# cannot function without, and silent about the rest. An AccessDenied already
+# fails hard (set -euo pipefail), but a SUCCESSFUL call that returns nothing
+# (wrong prefix, wiped namespace, wrong account) would otherwise write an
+# empty env file and boot a funds-adjacent container with no credentials and
+# no error — fail-soft on state the product needs is how an outage becomes a
+# silence. Names only; never a value.
+MISSING=""
+for required in DATABASE_URL REDIS_URL CIRCLE_API_KEY CIRCLE_ENTITY_SECRET WALLET_ID AGENT_DRY_RUN; do
+  grep -q "^$required=" "$TMP" || MISSING="$MISSING $required"
+done
+if [ -n "$MISSING" ]; then
+  echo "fetch-secrets: FATAL — required parameter(s) absent from $PREFIX:$MISSING" >&2
+  echo "fetch-secrets: refusing to write $OUT; seed them with infra/scripts/setup-ssm-secrets.sh --apply" >&2
+  exit 4
+fi
+
+chmod 600 "$TMP"
+mv -f "$TMP" "$OUT"
+trap - EXIT
 echo "fetch-secrets: wrote $(wc -l < "$OUT") parameter(s) to $OUT (names only, never values, in this log line)"
 FETCHEOF
 chmod 700 /opt/archimedes-runners/fetch-secrets.sh
@@ -186,6 +220,14 @@ chmod 700 /opt/archimedes-runners/ecr-login.sh
 #   - ship stdout/stderr to the /archimedes/runners CloudWatch log group via
 #     docker's native `awslogs` log driver (uses the instance role's
 #     credentials automatically — no CloudWatch agent needed)
+#     ⚠️ The option is `awslogs-stream` (an EXACT stream name). It is NOT
+#     `awslogs-stream-prefix` — that one is an *ECS task definition*
+#     logConfiguration option and is rejected by the docker daemon with
+#     `unknown log opt 'awslogs-stream-prefix' for awslogs log driver`,
+#     which fails `docker run` with exit 125 BEFORE the container starts.
+#     Because this file is `ignore_changes = [user_data]` (bootstrap-only),
+#     that mistake is not self-healing: it bricks the unit into a permanent
+#     `activating (auto-restart)` loop that no amount of restarting fixes.
 #   - Restart=always — systemd itself is the box-local restart policy; the
 #     Redis lease in services/runner_lease.py is the SEPARATE, authoritative
 #     exactly-once control if this box is ever accidentally duplicated.
@@ -217,7 +259,7 @@ ExecStart=/usr/bin/docker run --rm --name archimedes-oracle \
   --log-driver=awslogs \
   --log-opt awslogs-region=${aws_region} \
   --log-opt awslogs-group=${log_group_name} \
-  --log-opt awslogs-stream-prefix=oracle \
+  --log-opt awslogs-stream=oracle \
   ${ecr_registry}:latest \
   python -m archimedes.chain.oracle_runner
 ExecStop=/usr/bin/docker stop archimedes-oracle
@@ -249,7 +291,7 @@ ExecStart=/usr/bin/docker run --rm --name archimedes-agent \
   --log-driver=awslogs \
   --log-opt awslogs-region=${aws_region} \
   --log-opt awslogs-group=${log_group_name} \
-  --log-opt awslogs-stream-prefix=agent \
+  --log-opt awslogs-stream=agent \
   ${ecr_registry}:latest \
   python -m archimedes.chain.agent_runner
 ExecStop=/usr/bin/docker stop archimedes-agent


### PR DESCRIPTION
## What

Both runner systemd units pass an option to `docker run` that **does not exist**:

```
--log-opt awslogs-stream-prefix=oracle
```

`awslogs-stream-prefix` is an **ECS task definition** `logConfiguration` option. Docker's own `awslogs` log driver takes `awslogs-stream` (an exact stream name). The daemon rejects the unknown option and `docker run` exits **125 before the container starts**:

```
docker: Error response from daemon: unknown log opt 'awslogs-stream-prefix' for awslogs log driver
```

Neither runner has ever started. The live restart counter on `i-0423fd0800b026c64` was **6072**.

## Why it surfaced now

It was masked. The units were failing earlier, in `ExecStartPre=fetch-secrets.sh`, on the SSM path IAM bug (#1188). With #1188 merged and applied, `fetch-secrets.sh` and `ecr-login.sh` both exit `0/SUCCESS` and this became the next blocker in the chain.

## ⚠️ This fix does not reach the running instance by itself

`runner_ec2.tf` sets `lifecycle { ignore_changes = [ami, user_data] }`, deliberately — this is a funds-adjacent singleton that must not be silently replaced. So `runner-user-data.sh` is **bootstrap-only**: merging this + `terraform apply` fixes the *next* instance, not the current one. The live units are patched separately, in place. The comment in the file now states this explicitly so the next reader doesn't assume an apply is sufficient.

## Also: two hardening fixes to `fetch-secrets.sh`

This script writes the env file **both** runners consume, so it is worth getting right.

**1. Atomic write.** It truncated `runner.env` in place (`: > "$OUT"`) and appended line by line. Both units run it as `ExecStartPre` and restart independently every 10s, so one unit's `docker run --env-file` can read the file while the other unit's fetch is mid-append — the container then boots with a **partial environment and no error anywhere**. This is not theoretical: a read during the restart loop returned **10 of the 15** parameters, which is what sent me looking. Now builds a `mktemp` file and `rename(2)`s it into place, so a reader sees either the whole old file or the whole new one.

> `mktemp` rather than `"$OUT.tmp.$$"` because this file is rendered through `templatefile()`, where `$$` abuts HCL's `$${` escape. Sidesteps the ambiguity and gives uniqueness under concurrent fetches.

**2. Load-bearing input check.** An `AccessDenied` already failed hard (`set -euo pipefail`). But a **successful** call returning zero parameters — wrong prefix, wiped namespace, wrong account — would have written an *empty* env file and booted a funds-adjacent container with no credentials and no error. The script now refuses to publish unless `DATABASE_URL`, `REDIS_URL`, `CIRCLE_API_KEY`, `CIRCLE_ENTITY_SECRET`, `WALLET_ID` and `AGENT_DRY_RUN` are all present, and the last-good file survives. Names only, never values.

That second one is the [fail-soft principle](../docs/SESSION-HANDOFF-2026-07-28-infra-and-rigor.md) applied concretely: **be loud about exactly the inputs the product cannot function without, and stay silent about the rest.** Not "always crash."

## Verification

- `terraform fmt -check -recursive` and `terraform validate` — clean
- Template rendered with real values → `bash -n` clean, **no unresolved template vars**, `$${}` escapes preserved
- `awslogs-stream` confirmed **accepted by the live daemon** (docker 29.6.2) via a probe container writing to the real `/archimedes/runners` group
- `fetch-secrets.sh` exercised standalone against a stubbed `aws`, all three cases:

| Case | Result |
|---|---|
| Happy path | exit 0, 7 params, mode `600` |
| SSM returns empty | **exit 4**, prior good file intact |
| AccessDenied | **exit 254**, prior good file intact |
| Temp files left behind | **0** |

## Risk

Low. One file, bootstrap-only, no cloud resource changes in the plan beyond the `user_data` attribute that is already `ignore_changes`. It cannot affect the running instance — which is precisely why the live box is being patched by hand as well.
