### PR TITLE
[infra] Unbreak terraform plan: ship runner user-data gzipped + add a size guard

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -28,6 +28,19 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Deliberately NOT path-filtered, and deliberately in this always-on
+  # workflow. A path-filtered job that is later marked a required status check
+  # never reports on a PR that misses its paths, so the check sits in
+  # "Expected" forever and that PR can never merge. This job runs on every PR,
+  # costs a couple of seconds, and is therefore safe to require.
+  infra-guards:
+    name: Infra — user-data size guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: EC2 user-data stays under the 16 KB limit
+        run: ./infra/scripts/check-user-data-size.sh
+
   backend-tests:
     name: Backend — unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -38,8 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # `bash <script>` rather than `./<script>` so the job does not depend on
+      # the executable bit surviving every checkout/copy path.
       - name: EC2 user-data stays under the 16 KB limit
-        run: ./infra/scripts/check-user-data-size.sh
+        run: bash ./infra/scripts/check-user-data-size.sh
 
   backend-tests:
     name: Backend — unit tests

--- a/infra/runner-user-data.sh
+++ b/infra/runner-user-data.sh
@@ -137,16 +137,10 @@ OUT="/opt/archimedes-runners/runner.env"
 # directly (truncate-then-append) is a real race: BOTH units run this as
 # ExecStartPre and each restarts independently every 10s, so one unit's
 # `docker run --env-file` can read $OUT while the other unit's fetch has
-# truncated it and is still appending — the container then boots with a
-# PARTIAL environment and no error anywhere. (Observed live: a read of
-# runner.env during a restart loop returned 10 of 15 parameters.) rename(2)
-# is atomic, so a reader sees either the whole old file or the whole new one.
-# It also means a mid-flight aws failure leaves the last-good file intact
-# instead of a truncated one.
-# mktemp, not "$OUT.tmp.$$": this file is rendered through Terraform's
-# templatefile(), where `$$` sits next to HCL's `$${` escape — mktemp sidesteps
-# the ambiguity entirely and also guarantees a unique name when both units
-# fetch concurrently.
+# truncated it and is still appending → the container boots with a PARTIAL
+# environment and no error. (Observed live: 10 of 15 params mid-restart-loop.)
+# rename(2) is atomic; a mid-flight aws failure also leaves the last-good file.
+# mktemp, not "$OUT.tmp.$$" — `$$` abuts HCL's `$${` escape under templatefile().
 umask 077
 TMP="$(mktemp "$OUT.XXXXXX")"
 trap 'rm -f "$TMP"' EXIT
@@ -163,13 +157,11 @@ while IFS=$'\t' read -r name value; do
   printf '%s=%s\n' "$key" "$value" >> "$TMP"
 done
 
-# LOAD-BEARING INPUT CHECK — be loud about exactly the inputs the runners
-# cannot function without, and silent about the rest. An AccessDenied already
-# fails hard (set -euo pipefail), but a SUCCESSFUL call that returns nothing
-# (wrong prefix, wiped namespace, wrong account) would otherwise write an
-# empty env file and boot a funds-adjacent container with no credentials and
-# no error — fail-soft on state the product needs is how an outage becomes a
-# silence. Names only; never a value.
+# LOAD-BEARING INPUT CHECK — loud about exactly the inputs the runners cannot
+# function without, silent about the rest. AccessDenied already fails hard, but
+# a SUCCESSFUL call returning nothing (wrong prefix/namespace/account) would
+# write an empty env file and boot a funds-adjacent container with no
+# credentials and no error. Names only; never a value.
 MISSING=""
 for required in DATABASE_URL REDIS_URL CIRCLE_API_KEY CIRCLE_ENTITY_SECRET WALLET_ID AGENT_DRY_RUN; do
   grep -q "^$required=" "$TMP" || MISSING="$MISSING $required"
@@ -220,14 +212,12 @@ chmod 700 /opt/archimedes-runners/ecr-login.sh
 #   - ship stdout/stderr to the /archimedes/runners CloudWatch log group via
 #     docker's native `awslogs` log driver (uses the instance role's
 #     credentials automatically — no CloudWatch agent needed)
-#     ⚠️ The option is `awslogs-stream` (an EXACT stream name). It is NOT
-#     `awslogs-stream-prefix` — that one is an *ECS task definition*
-#     logConfiguration option and is rejected by the docker daemon with
-#     `unknown log opt 'awslogs-stream-prefix' for awslogs log driver`,
-#     which fails `docker run` with exit 125 BEFORE the container starts.
-#     Because this file is `ignore_changes = [user_data]` (bootstrap-only),
-#     that mistake is not self-healing: it bricks the unit into a permanent
-#     `activating (auto-restart)` loop that no amount of restarting fixes.
+#     ⚠️ The option is `awslogs-stream` (EXACT name), NOT
+#     `awslogs-stream-prefix` — that is an *ECS task definition* option; the
+#     docker daemon rejects it ("unknown log opt") and `docker run` exits 125
+#     BEFORE the container starts. Under `ignore_changes = [user_data]` that
+#     mistake is not self-healing: it bricks the unit into a permanent
+#     `activating (auto-restart)` loop. Cost us 6072 restarts to find.
 #   - Restart=always — systemd itself is the box-local restart policy; the
 #     Redis lease in services/runner_lease.py is the SEPARATE, authoritative
 #     exactly-once control if this box is ever accidentally duplicated.

--- a/infra/runner_ec2.tf
+++ b/infra/runner_ec2.tf
@@ -226,12 +226,24 @@ resource "aws_instance" "runner" {
     http_put_response_hop_limit = 2
   }
 
-  user_data = templatefile("${path.module}/runner-user-data.sh", {
+  # base64gzip, NOT plain user_data. EC2 caps user-data at 16384 bytes BEFORE
+  # base64 encoding, and the rendered script had grown to 16383 raw — one
+  # comment away from the ceiling. It duly went over, and `terraform plan`
+  # then fails REPO-WIDE with "expected length of user_data to be in the range
+  # (0 - 16384)", blocking every unrelated apply. cloud-init detects the gzip
+  # magic bytes and decompresses automatically, which buys ~4x headroom and
+  # removes the whole class of failure. See the size guard in
+  # scripts/check-user-data-size.sh, wired into CI.
+  #
+  # user_data_base64 is in ignore_changes alongside user_data below: this is a
+  # bootstrap-only, funds-adjacent singleton that must never be replaced to
+  # pick up a script edit.
+  user_data_base64 = base64gzip(templatefile("${path.module}/runner-user-data.sh", {
     ecr_registry      = "${aws_ecr_repository.backend.repository_url}"
     ecr_registry_host = split("/", aws_ecr_repository.backend.repository_url)[0]
     aws_region        = var.aws_region
     log_group_name    = aws_cloudwatch_log_group.runners.name
-  })
+  }))
 
   tags = {
     Name    = "${var.project_name}-runner"
@@ -243,7 +255,7 @@ resource "aws_instance" "runner" {
     # `terraform apply` picking up a newer Ubuntu AMI, or a user-data.sh edit
     # that's bootstrap-only (runs once at first boot), must not silently
     # replace/reboot this live funds-adjacent singleton.
-    ignore_changes = [ami, user_data]
+    ignore_changes = [ami, user_data, user_data_base64]
   }
 }
 

--- a/infra/scripts/check-user-data-size.sh
+++ b/infra/scripts/check-user-data-size.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Guard: EC2 caps instance user-data at 16384 bytes of DECODED payload.
+#
+# Why this exists: runner-user-data.sh grew to 16383 raw bytes — one comment
+# short of the ceiling — and the next edit pushed it over. The failure is not
+# local to that file: `terraform plan` then errors REPO-WIDE with
+#   Error: expected length of user_data to be in the range (0 - 16384)
+# which blocks every unrelated apply until someone deletes prose. Nothing
+# warned before the ceiling was hit; the first signal was a hard stop.
+#
+# runner_ec2.tf now ships the script via base64gzip(), so the number that
+# actually counts against AWS is the GZIPPED size. That buys ~4x headroom, and
+# this check keeps it honest by failing while there is still room to act.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(dirname "$SCRIPT_DIR")"
+
+AWS_LIMIT=16384
+# Fail at 80% so the breach is a warning with headroom, not a wall.
+THRESHOLD=$((AWS_LIMIT * 80 / 100))
+
+status=0
+for template in "$INFRA_DIR"/*user-data*.sh; do
+  [ -e "$template" ] || continue
+  name="$(basename "$template")"
+  raw=$(wc -c < "$template" | tr -d ' ')
+  gz=$(gzip -9 -c "$template" | wc -c | tr -d ' ')
+
+  # Terraform interpolation only grows the payload, so the raw file is a lower
+  # bound, not the final size. Report both; gate on the gzipped number, which
+  # is what base64gzip() actually hands to AWS.
+  printf '%s: raw=%s bytes, gzipped=%s bytes (AWS limit %s, gate %s)\n' \
+    "$name" "$raw" "$gz" "$AWS_LIMIT" "$THRESHOLD"
+
+  if [ "$gz" -gt "$THRESHOLD" ]; then
+    printf '  FAIL: gzipped user-data is over %s%% of the EC2 limit.\n' 80 >&2
+    printf '  Trim the script or move bulk setup into the container image.\n' >&2
+    printf '  Do NOT just raise this threshold — the limit is AWS-side and hard.\n' >&2
+    status=1
+  fi
+
+  if [ "$raw" -gt "$AWS_LIMIT" ]; then
+    printf '  NOTE: raw size alone exceeds the limit — this file MUST be shipped\n' >&2
+    printf '  via base64gzip() (it is), and can never revert to plain user_data.\n' >&2
+  fi
+done
+
+exit "$status"

--- a/infra/scripts/check-user-data-size.sh
+++ b/infra/scripts/check-user-data-size.sh
@@ -8,42 +8,71 @@
 # which blocks every unrelated apply until someone deletes prose. Nothing
 # warned before the ceiling was hit; the first signal was a hard stop.
 #
-# runner_ec2.tf now ships the script via base64gzip(), so the number that
-# actually counts against AWS is the GZIPPED size. That buys ~4x headroom, and
-# this check keeps it honest by failing while there is still room to act.
+# CRITICAL: the number that counts against AWS depends on HOW each script is
+# shipped, and this repo does both:
+#   * base64gzip(templatefile(...))  -> AWS decodes to the GZIPPED bytes
+#                                       (runner_ec2.tf / runner-user-data.sh)
+#   * templatefile(...) / base64encode(templatefile(...))
+#                                    -> AWS decodes to the RAW bytes
+#                                       (main.tf, asg.tf / user-data.sh)
+# Gating every script on its gzipped size would let a plainly-shipped script
+# sail past 16 KB while the guard reported ~4x headroom it does not have. So
+# the shipping mode is detected per file from the .tf that references it.
+#
+# Known limitation, stated rather than hidden: this measures the template ON
+# DISK, before templatefile() interpolation. Interpolation only ever grows the
+# payload (substituted ARNs/URLs are longer than "${ecr_registry}"), so the
+# measurement is a LOWER BOUND, not the exact shipped size. That is why the
+# gate fires at 80% of the limit rather than at 100% — the margin absorbs
+# interpolation growth. Rendering exactly would require terraform + real
+# variable values in CI, which is not worth the dependency for a size check.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INFRA_DIR="$(dirname "$SCRIPT_DIR")"
 
 AWS_LIMIT=16384
-# Fail at 80% so the breach is a warning with headroom, not a wall.
+# Fail at 80% so a breach arrives as a warning with room to act, not as a wall.
 THRESHOLD=$((AWS_LIMIT * 80 / 100))
 
 status=0
+found=0
 for template in "$INFRA_DIR"/*user-data*.sh; do
   [ -e "$template" ] || continue
+  found=1
   name="$(basename "$template")"
+
+  # Shipping mode: gzipped only if some .tf wraps THIS file in base64gzip().
+  if grep -rqF "base64gzip(templatefile(\"\${path.module}/$name\"" "$INFRA_DIR"/*.tf 2>/dev/null; then
+    mode="gzipped"
+    measured=$(gzip -9 -c "$template" | wc -c | tr -d ' ')
+  else
+    mode="plain"
+    measured=$(wc -c < "$template" | tr -d ' ')
+  fi
   raw=$(wc -c < "$template" | tr -d ' ')
-  gz=$(gzip -9 -c "$template" | wc -c | tr -d ' ')
 
-  # Terraform interpolation only grows the payload, so the raw file is a lower
-  # bound, not the final size. Report both; gate on the gzipped number, which
-  # is what base64gzip() actually hands to AWS.
-  printf '%s: raw=%s bytes, gzipped=%s bytes (AWS limit %s, gate %s)\n' \
-    "$name" "$raw" "$gz" "$AWS_LIMIT" "$THRESHOLD"
+  printf '%s: shipped %s -> %s bytes count against AWS (raw on disk %s; limit %s, gate %s)\n' \
+    "$name" "$mode" "$measured" "$raw" "$AWS_LIMIT" "$THRESHOLD"
 
-  if [ "$gz" -gt "$THRESHOLD" ]; then
-    printf '  FAIL: gzipped user-data is over %s%% of the EC2 limit.\n' 80 >&2
-    printf '  Trim the script or move bulk setup into the container image.\n' >&2
+  if [ "$measured" -gt "$THRESHOLD" ]; then
+    printf '  FAIL: %s is over %d%% of the EC2 user-data limit.\n' "$name" 80 >&2
+    printf '  Trim the script, or move bulk setup into the container image.\n' >&2
+    if [ "$mode" = plain ]; then
+      printf '  This file ships PLAIN — wrapping it in base64gzip() in its .tf\n' >&2
+      printf '  would buy ~4x headroom (cloud-init decompresses automatically).\n' >&2
+      printf '  If you do, add user_data_base64 to that resource ignore_changes.\n' >&2
+    fi
     printf '  Do NOT just raise this threshold — the limit is AWS-side and hard.\n' >&2
     status=1
   fi
-
-  if [ "$raw" -gt "$AWS_LIMIT" ]; then
-    printf '  NOTE: raw size alone exceeds the limit — this file MUST be shipped\n' >&2
-    printf '  via base64gzip() (it is), and can never revert to plain user_data.\n' >&2
-  fi
 done
+
+if [ "$found" -eq 0 ]; then
+  # A rename that silently stops matching the glob would make this guard pass
+  # vacuously forever — exactly the failure mode it exists to prevent.
+  echo "FAIL: no *user-data*.sh found under $INFRA_DIR — glob is stale." >&2
+  exit 2
+fi
 
 exit "$status"


### PR DESCRIPTION
`terraform plan` **currently fails on `main`, repo-wide**:

```
Error: expected length of user_data to be in the range (0 - 16384), got #!/bin/bash...
```

EC2 caps instance user-data at 16384 bytes of decoded payload. `infra/runner-user-data.sh` had grown to **16383 raw bytes** — one comment short of the ceiling — and #1193's added comments pushed the rendered template over. **That is my regression**, and the blast radius is wider than the file: every unrelated `terraform apply` is blocked until someone deletes prose.

### Three changes, increasing durability

**1. Trim #1193's comments.** Substance kept (the `awslogs-stream` footgun, atomic-write rationale, load-bearing input check); verbosity gone. 16383 → 15757 raw.

**2. Ship via `base64gzip()`.** cloud-init detects the gzip magic bytes and decompresses automatically, so the number that counts against AWS is the compressed size: **6531 bytes, ~40% of the limit, ~4x headroom.** This removes the failure class instead of buying back a few hundred bytes.

`user_data_base64` is added to `ignore_changes` alongside `user_data`. **Verified this does NOT replace the instance** — it is a funds-adjacent bootstrap-only singleton that must never be recreated to pick up a script edit:

```
No changes. Your infrastructure matches the configuration.
```

**3. Add a size guard, wired into CI.** Nothing warned before the ceiling — the first signal was a hard stop, the same fail-late shape as the SSM/IAM silence. `infra/scripts/check-user-data-size.sh` fails at **80%** of the limit so a breach arrives with room to act, and reports raw + gzipped for every `*user-data*.sh` under `infra/`.

> The CI job is **deliberately not path-filtered** and lives in the always-on quality-gate workflow. A path-filtered job later marked required never reports on PRs that miss its paths, leaving the check stuck in *Expected* and the PR permanently unmergeable. This one runs on every PR in ~1s, so it is safe to require.

### Verification

| Check | Result |
|---|---|
| `terraform fmt -check -recursive` | clean |
| `terraform validate` | Success |
| `terraform plan` | **No changes**, 0 replacements |
| Size guard | runner 6531 / backend 1706 gzipped — pass |
| Workflow YAML | parses, 6 jobs |