### PR TITLE
[contracts] Fix Vault NAV decimals for 6-dec synths + performance-fee share-mint dilution (split from #1129)

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -470,7 +470,7 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             uint256 minOut = _oracleMinOut(tokenOut, asset, amount);
             // #915 churn guard: this sell must move tokenOut toward its target weight
             // (over-allocated → sell) and not past it. sellValue is the synth's oracle NAV.
-            uint256 sellValue = (amount * PriceOracle(tokenOracle[tokenOut]).getPrice()) / 1e18;
+            uint256 sellValue = (amount * PriceOracle(tokenOracle[tokenOut]).getPrice()) / _tokenUnit(tokenOut);
             _requireTowardTarget(tokenOut, sellValue, false);
 
             // Approve router
@@ -683,15 +683,15 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
     // ─── Internal ────────────────────────────────────────────────────
 
     /// @notice A token's current value in USDC (6-decimal) terms, matching totalAssets()'s
-    ///         convention: USDC at face value, synths at balance(18) * price(6) / 1e18.
-    ///         Unpriced tokens contribute 0 (they can't be weighted); a rebalance touching
-    ///         such a token reverts earlier in _oracleMinOut anyway.
+    ///         convention: USDC at face value, synths at balance(decimals) * price(6) /
+    ///         10**decimals. Unpriced tokens contribute 0 (they can't be weighted); a
+    ///         rebalance touching such a token reverts earlier in _oracleMinOut anyway.
     function _tokenValueUsdc(address token) internal view returns (uint256) {
         uint256 bal = IERC20(token).balanceOf(address(this));
         if (token == address(asset)) return bal;
         address oracle = tokenOracle[token];
         if (oracle == address(0)) return 0;
-        return (bal * PriceOracle(oracle).getPrice()) / 1e18;
+        return (bal * PriceOracle(oracle).getPrice()) / _tokenUnit(token);
     }
 
     /// @notice Enforce that a rebalance swap moves `token` toward its target weight and does
@@ -883,8 +883,16 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
             if (navPerShare > highWaterMark) {
                 uint256 gain = navPerShare - highWaterMark;
                 uint256 perfFeePerShare = (gain * performanceFeeBps) / BPS;
-                // Convert to total shares
-                uint256 perfShares = (perfFeePerShare * _totalSupply) / 1e18;
+                // perfFeePerShare is USDC-per-share (1e18-scaled); multiplying by
+                // _totalSupply and dividing by 1e18 converts it to a USDC fee amount —
+                // NOT a share count. Minting that amount 1:1 as shares (the old bug)
+                // only breaks even when navPerShare == 1e18 exactly; once NAV/share has
+                // grown past $1, each share is worth more than $1 of assets, so minting
+                // $-amount-many shares hands the fee recipient more value than the fee.
+                // Standard dilution-mint conversion instead: shares = feeAssets *
+                // totalSupply / totalAssets (mirrors Yearn's report() fee-share calc).
+                uint256 totalPerfFeeAssets = (perfFeePerShare * _totalSupply) / 1e18;
+                uint256 perfShares = (totalPerfFeeAssets * _totalSupply) / _totalAssets;
 
                 if (perfShares > 0) {
                     uint256 platformShares = (perfShares * PLATFORM_FEE_BPS) / BPS;

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -891,6 +891,12 @@ contract Vault is IVault, ERC20, Ownable, ReentrancyGuard, Pausable {
                 // $-amount-many shares hands the fee recipient more value than the fee.
                 // Standard dilution-mint conversion instead: shares = feeAssets *
                 // totalSupply / totalAssets (mirrors Yearn's report() fee-share calc).
+                // The minted shares are themselves diluted by the mint, so the
+                // recipient's realized value lands slightly BELOW feeAssets —
+                // deliberate: the error is in the depositors' favor, never the fee
+                // recipient's (the exact-value form divides by totalAssets minus
+                // feeAssets; we keep the Yearn form). HWM math is unaffected — the
+                // dead-shares 1:1 scale note at the top of this contract still holds.
                 uint256 totalPerfFeeAssets = (perfFeePerShare * _totalSupply) / 1e18;
                 uint256 perfShares = (totalPerfFeeAssets * _totalSupply) / _totalAssets;
 

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -49,6 +49,22 @@ contract MockToken8 is ERC20 {
     }
 }
 
+/// @dev A 6-decimal token — matches production synths (per Dan's #1129 review) — for
+///      the _tokenValueUsdc / churn-guard sellValue decimals regression.
+contract MockToken6 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+        _mint(msg.sender, 1_000_000 * 10**6);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+}
+
 contract VaultTest is Test {
     MockUSDC public usdc;
     AMMRouter public router;
@@ -1131,6 +1147,75 @@ contract VaultTest is Test {
         assertGt(vault.totalAssets(), 20_000 * 10**6);
     }
 
+    /// @dev Regression for Dan's #1129 review: #942 fixed totalAssets()'s decimal scaling
+    ///      but missed two other call sites — _tokenValueUsdc() and the churn guard's
+    ///      sellValue in rebalance() — which kept dividing by a hardcoded 1e18. Production
+    ///      synths are 6-decimal, so for a 6-decimal holding the old code crushed the
+    ///      computed value by 10**12 (e.g. a $20k position priced as ~$0.00002).
+    ///      _requireTowardTarget() derives currentWeight from _tokenValueUsdc(), so under
+    ///      the bug a 6-decimal synth always looked like ~0% of NAV — meaning "currentWeight
+    ///      <= target + band" was always true and EVERY sell of an over-target 6-decimal
+    ///      synth reverted with RebalanceNotTowardTarget, no matter how overweight the vault
+    ///      actually was. Fixed by routing both sites through _tokenUnit(token) like
+    ///      totalAssets() already does.
+    function test_rebalance_sell_toward_target_succeeds_for_6_decimal_synth() public {
+        MockToken6 s6 = new MockToken6("Synthetic6", "S6");
+        PriceOracle o6 = new PriceOracle("S6", TSLA_PRICE, owner);
+
+        router.createPool(address(usdc), address(s6));
+        uint256 poolUsdc = 10_000_000 * 10**6;
+        uint256 poolS6 = 5_000_000 * 10**6; // 6-decimal reserves, same value ratio as TSLA_PRICE
+        usdc.mint(address(this), poolUsdc);
+        s6.mint(address(this), poolS6);
+        usdc.approve(address(router), poolUsdc);
+        s6.approve(address(router), poolS6);
+        router.addLiquidity(address(usdc), address(s6), poolUsdc, poolS6, 0);
+
+        address[] memory oracleTokens = new address[](1);
+        oracleTokens[0] = address(s6);
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(o6);
+        vm.prank(agent);
+        vault.setTokenOracles(oracleTokens, oracles);
+
+        _depositAsAlice(50_000 * 10**6);
+
+        // Buy ~98% into the 6-decimal synth — no target set yet, so unconstrained.
+        address[] memory buyIn = _singleton(address(s6));
+        uint256[] memory buyAmt = _singletonUint(49_000 * 10**6);
+        address[] memory buyOutT = new address[](0);
+        uint256[] memory buyOutA = new uint256[](0);
+        _commitFor(buyIn, buyAmt, buyOutT, buyOutA);
+        vm.prank(agent);
+        vault.rebalance(buyIn, buyAmt, buyOutT, buyOutA);
+
+        // Arm a 50/50 USDC/s6 target — the vault is now deep over-target on s6.
+        address[] memory tgtTokens = new address[](2);
+        tgtTokens[0] = address(usdc);
+        tgtTokens[1] = address(s6);
+        uint256[] memory tgtWeights = new uint256[](2);
+        tgtWeights[0] = 5000;
+        tgtWeights[1] = 5000;
+        vm.prank(agent);
+        vault.setTargetAllocations(tgtTokens, tgtWeights);
+
+        // Selling toward target must succeed. Under the pre-fix /1e18 divisor this
+        // reverts with RebalanceNotTowardTarget, since _tokenValueUsdc(s6) collapses
+        // to ~0 for a 6-decimal balance and the guard never sees "over target".
+        address[] memory sellInT = new address[](0);
+        uint256[] memory sellInA = new uint256[](0);
+        address[] memory sellOutT = _singleton(address(s6));
+        uint256[] memory sellOutA = _singletonUint(10_000 * 10**6); // ~20k USDC of s6
+        _commitFor(sellInT, sellInA, sellOutT, sellOutA);
+        vm.prank(agent);
+        vault.rebalance(sellInT, sellInA, sellOutT, sellOutA);
+
+        uint256 s6Value = (s6.balanceOf(address(vault)) * o6.getPrice()) / 10**6;
+        uint256 weightAfter = (s6Value * 10000) / vault.totalAssets();
+        assertGt(weightAfter, 5000, "still over target after a partial toward-target sell");
+        assertLt(weightAfter, 9800, "sell actually moved weight down");
+    }
+
     // ─── Fee Tests ───────────────────────────────────────────────────
 
     function test_management_fee_accrues() public {
@@ -1160,6 +1245,57 @@ contract VaultTest is Test {
 
     function test_highWaterMark_initial() public view {
         assertEq(vault.highWaterMark(), 1e18);
+    }
+
+    /// @dev Regression for Dan's #1129 review: the old performance-fee mint treated a
+    ///      USDC-denominated fee amount as a 1:1 share count (`perfShares =
+    ///      perfFeePerShare * totalSupply / 1e18`), which only breaks even when
+    ///      navPerShare == 1e18. Once NAV/share has grown past $1 — exactly the
+    ///      condition required for a performance fee to be owed at all — each share is
+    ///      worth more than $1, so minting that many shares hands the fee recipients
+    ///      more value than the fee. Fixed to the same dilution-mint formula the
+    ///      management-fee branch two lines above already uses: shares = feeAssets *
+    ///      totalSupply / totalAssets.
+    ///
+    ///      Bob deposits 10,000 USDC (navPerShare = 1e18, matches the initial HWM).
+    ///      A 10,000 USDC donation (bypassing deposit(), so no shares are minted for
+    ///      it) doubles totalAssets without moving totalSupply, so navPerShare = 2e18
+    ///      when fees next accrue. At the 50% (cap) performance fee this is a $5,000
+    ///      fee on a $10,000 gain — the exact numbers below are what the fixed
+    ///      dilution formula mints; the old formula would have minted double
+    ///      (5,000e6 total / platform 500e6 / creator 4,500e6).
+    function test_performanceFee_shareMint_uses_dilution_formula_not_raw_assets() public {
+        // 50% performance fee. (Note: main doesn't carry the #1129 fee-bps cap yet —
+        // that PR is still open — so this uses a literal rather than
+        // Vault.MAX_PERFORMANCE_FEE_BPS(), which doesn't exist on this branch.)
+        vm.prank(alice);
+        address v = factory.createVault("Perf Fee Vault", "vPERF", 0, 5000, false);
+        Vault perfVault = Vault(payable(v));
+
+        uint256 deposit = 10_000 * 10**6;
+        vm.startPrank(bob);
+        usdc.approve(address(perfVault), deposit);
+        perfVault.deposit(deposit, bob);
+        vm.stopPrank();
+
+        assertEq(perfVault.totalSupply(), deposit, "1:1 mint on first deposit");
+
+        // Donate — doubles totalAssets, mints no shares, so navPerShare doubles too.
+        uint256 donation = 10_000 * 10**6;
+        usdc.mint(address(this), donation);
+        usdc.transfer(address(perfVault), donation);
+
+        // Trigger _accrueFees() via a trivial state-changing call; timeDelta must be > 0.
+        vm.warp(block.timestamp + 1);
+        usdc.mint(address(this), 2);
+        usdc.approve(address(perfVault), 2);
+        perfVault.deposit(2, address(this));
+
+        // Fixed dilution formula: totalPerfFeeAssets = 5,000e6 ("$5,000", 50% of the
+        // $10,000 gain); perfShares = 5,000e6 * 10,000e6 / 20,000e6 = 2,500e6 — split
+        // 10% platform / 90% creator (PLATFORM_FEE_BPS).
+        assertEq(perfVault.balanceOf(platformRecipient), 250 * 10**6, "platform perf-fee shares");
+        assertEq(perfVault.balanceOf(alice), 2_250 * 10**6, "creator perf-fee shares");
     }
 
     // ─── VaultFactory Tests ──────────────────────────────────────────

--- a/contracts/test/Vault.t.sol
+++ b/contracts/test/Vault.t.sol
@@ -1265,11 +1265,14 @@ contract VaultTest is Test {
     ///      dilution formula mints; the old formula would have minted double
     ///      (5,000e6 total / platform 500e6 / creator 4,500e6).
     function test_performanceFee_shareMint_uses_dilution_formula_not_raw_assets() public {
-        // 50% performance fee. (Note: main doesn't carry the #1129 fee-bps cap yet —
-        // that PR is still open — so this uses a literal rather than
-        // Vault.MAX_PERFORMANCE_FEE_BPS(), which doesn't exist on this branch.)
+        // Performance fee at MAX_PERFORMANCE_FEE_BPS (50%, the #1129 cap — merged):
+        // the worst fee the constructor allows, so the donation-gain numbers below
+        // are the largest any vault can mint. Read the constant BEFORE the prank —
+        // the getter is an external call, and evaluating it as a createVault
+        // argument would consume vm.prank(alice) and mis-assign the creator.
+        uint16 perfCap = uint16(vault.MAX_PERFORMANCE_FEE_BPS());
         vm.prank(alice);
-        address v = factory.createVault("Perf Fee Vault", "vPERF", 0, 5000, false);
+        address v = factory.createVault("Perf Fee Vault", "vPERF", 0, perfCap, false);
         Vault perfVault = Vault(payable(v));
 
         uint256 deposit = 10_000 * 10**6;


### PR DESCRIPTION
## Summary

Splits two unrelated fixes out of #1129 (the fee-bps cap PR) per [Dan's review](https://github.com/a-apin/archimedes/pull/1129#pullrequestreview) — they got bundled into `64fdea43` along with the fee cap, but are higher-blast-radius correctness fixes that should be reviewed and land on their own timeline rather than riding inside a PR titled "cap fee bps."

**NEEDS DAN + BOGDAN REVIEW** — same reasoning as #1129: live-funds NAV/share-mint math.

## What's actually broken

**1. NAV valuation for 6-decimal synths (`_tokenValueUsdc` + churn-guard `sellValue`)**

`#942` fixed `totalAssets()` to scale by a token's real decimals via `_tokenUnit(token)`, but missed two other call sites that still divide by a hardcoded `1e18`:
- `_tokenValueUsdc()` (`Vault.sol:665`)
- the `#915` churn guard's `sellValue` in `rebalance()`'s sell branch (`Vault.sol:449`)

Production synths are 6-decimal. For a 6-decimal balance, dividing by `1e18` instead of `1e6` crushes the computed value by `10**12` — a $20k position prices out at ~$0.00002. Since `_requireTowardTarget()` derives `currentWeight` from `_tokenValueUsdc()`, every 6-decimal synth looked like ~0% of NAV to the churn guard, so `currentWeight <= target + band` was always true on the sell branch — **every rebalance-sell of an over-target 6-decimal synth reverted with `RebalanceNotTowardTarget`, no matter how overweight the vault actually was.**

Fixed by routing both sites through the existing `_tokenUnit(token)` helper.

**2. Performance-fee share-mint formula**

The old formula converted a USDC-denominated fee amount to shares 1:1:
```solidity
uint256 perfShares = (perfFeePerShare * _totalSupply) / 1e18;
```
`perfFeePerShare` is USDC-per-share; multiplying by `totalSupply` and dividing by `1e18` yields a **dollar amount**, not a share count. Minting that amount 1:1 as shares only breaks even when `navPerShare == 1e18` exactly — but a performance fee is only ever owed once NAV/share has grown *past* $1, which is exactly when this breaks: at `navPerShare = $2`, a $5,000 intended fee minted shares worth ~$6,667.

Fixed to the same dilution-mint formula the **management-fee branch two lines above already uses** (so this isn't a novel formula — it's making performance-fee accrual consistent with management-fee accrual, which was already correct):
```solidity
uint256 totalPerfFeeAssets = (perfFeePerShare * _totalSupply) / 1e18;
uint256 perfShares = (totalPerfFeeAssets * _totalSupply) / _totalAssets;
```

## Test plan

Two new regression tests, both **verified to fail on the pre-fix source** (reverted `Vault.sol` locally, confirmed both fail with the exact predicted numbers, then restored the fix):

- `test_rebalance_sell_toward_target_succeeds_for_6_decimal_synth` — fails with `RebalanceNotTowardTarget` on unfixed code, passes on fixed
- `test_performanceFee_shareMint_uses_dilution_formula_not_raw_assets` — asserts exact minted-share amounts (`250e6` platform / `2_250e6` creator); unfixed code mints exactly double (`500e6` / `4_500e6`)

```
forge test        # 287 passed, 0 failed (full contracts suite)
```

## Anti-goals

- Does not touch the fee-bps cap itself — that's #1129, unchanged.
- Does not touch the management-fee formula — it was already correct; only referenced as the pattern to match.

---

**2026-08-20 re-verification (rebased to 0-behind current main, clean):** forge 316/316 on the rebased head. Mutation check: reverting the dilution fix in place to the old 1:1 mint → `test_performanceFee_shareMint_uses_dilution_formula_not_raw_assets` fails with `500000000 != 250000000` (at $2 NAV/share the pre-fix mint hands the fee recipient exactly 2× the fee) — restored clean. The dilution form (`feeAssets * totalSupply / totalAssets`) is the conservative direction: it slightly under-pays the recipient rather than ever over-paying, matching the cited Yearn precedent.

**Review minors addressed:** the perf-fee test now runs at the merged #1129 cap constant (read before the prank — the getter is an external call and would otherwise consume it); the dilution comment documents the value direction (minted shares self-dilute, recipient lands slightly below feeAssets — depositor-favoring by design; the dead-shares 1:1 HWM note is unaffected). Re-rebased 0-behind at push time.
