### PR TITLE
fix(explore): stale-while-revalidate for /api/explore/assets cache

### DIFF
--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -415,9 +415,12 @@ class AssetMarketService:
         The old shape awaited the full oracle+yfinance rebuild inline on
         every cache miss: whichever request landed just after the 30s TTL
         expired paid that cost synchronously. Measured in prod (2026-08-02):
-        12.7s-42.9s per rebuild (12s is the oracle-read budget alone, spent
-        even when the oracle path yields zero live prices — see
-        _read_oracle_prices' docstring on current on-chain oracle health).
+        12.7s-42.9s per rebuild. The oracle read alone accounts for up to
+        ``_ORACLE_TOTAL_BUDGET_SECONDS`` of that, and it is spent whether or
+        not any price comes back: ``_read_oracle_prices`` runs its reads
+        sequentially under that budget and simply OMITS symbols that fail or
+        run past the deadline, so a fully unresponsive oracle costs the entire
+        budget and returns nothing.
         That is the whole "Explore takes a long time to load" symptom for
         an unlucky visitor.
 
@@ -451,7 +454,13 @@ class AssetMarketService:
                 return
             exc = task.exception()
             if exc is not None:
-                logger.warning("explore: background refresh failed: %s", exc)
+                # exc_info so the traceback survives. This path swallows a
+                # failure by design -- a stale cache is still served -- which
+                # makes the log the ONLY evidence the refresh is broken. A
+                # bare "%s" would reduce an rpc/yfinance/oracle stack trace to
+                # one uninformative line and leave the failure looking like a
+                # transient blip rather than a broken dependency.
+                logger.warning("explore: background refresh failed: %s", exc, exc_info=exc)
 
         self._refresh_task.add_done_callback(_log_if_failed)
 

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -259,6 +259,10 @@ class AssetMarketService:
         # Keyed by (symbol, range) — different ranges have different lookbacks.
         self._cache_history: dict[tuple[str, str], tuple[float, ExploreHistoryResponse]] = {}
         self._history_cache_ttl = 60.0  # seconds
+        # Guards the background refresh (see list_assets): at most one
+        # in-flight refresh at a time, so N requests landing in the same
+        # stale window don't each spawn their own oracle+yfinance rebuild.
+        self._refresh_task: asyncio.Task | None = None
 
     # ── On-chain oracle reads ────────────────────────────────────────────
 
@@ -406,9 +410,60 @@ class AssetMarketService:
     # ── Main list ─────────────────────────────────────────────────────────
 
     async def list_assets(self) -> ExploreAssetsResponse:
+        """Serve the asset list, stale-while-revalidate (#explore-latency).
+
+        The old shape awaited the full oracle+yfinance rebuild inline on
+        every cache miss: whichever request landed just after the 30s TTL
+        expired paid that cost synchronously. Measured in prod (2026-08-02):
+        12.7s-42.9s per rebuild (12s is the oracle-read budget alone, spent
+        even when the oracle path yields zero live prices — see
+        _read_oracle_prices' docstring on current on-chain oracle health).
+        That is the whole "Explore takes a long time to load" symptom for
+        an unlucky visitor.
+
+        Fix: once a cache exists at all, NEVER block a request behind a
+        rebuild. A stale cache is served immediately and a rebuild is
+        kicked off in the background (deduplicated via ``_refresh_task`` so
+        concurrent requests in the same stale window don't each start their
+        own rebuild); the NEXT request picks up the fresh result. Only the
+        very first request after cold start (no cache yet at all) pays the
+        synchronous cost — unavoidable, and no worse than today.
+        """
         now = time.time()
-        if self._cache and (now - self._cache_ts) < _CACHE_TTL_SECONDS:
+        if self._cache is not None:
+            if (now - self._cache_ts) < _CACHE_TTL_SECONDS:
+                return self._cache
+            self._kick_background_refresh()
             return self._cache
+
+        # Cold start — no cache yet. This request pays the one-time cost;
+        # every request after it hits the branches above.
+        return await self._refresh()
+
+    def _kick_background_refresh(self) -> None:
+        """Start a background rebuild if one isn't already in flight."""
+        if self._refresh_task is not None and not self._refresh_task.done():
+            return
+        self._refresh_task = asyncio.create_task(self._refresh(), name="explore-assets-refresh")
+
+        def _log_if_failed(task: asyncio.Task) -> None:
+            if task.cancelled():
+                return
+            exc = task.exception()
+            if exc is not None:
+                logger.warning("explore: background refresh failed: %s", exc)
+
+        self._refresh_task.add_done_callback(_log_if_failed)
+
+    async def _refresh(self) -> ExploreAssetsResponse:
+        """Rebuild the asset list from oracle + yfinance and populate the cache.
+
+        This is the full-cost path (was the entire body of ``list_assets``
+        before the stale-while-revalidate wrapper above). Callers should go
+        through ``list_assets()``; this is called directly only for the
+        cold-start (no cache yet) case and from the background refresh task.
+        """
+        now = time.time()
 
         # The deploy-eligible SSOT universe — same set as the Generate picker.
         # See _explore_universe() for the source rationale.

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -312,8 +312,11 @@ class TestListAssets:
 
         # Seed a cache directly — skip the cold-start path entirely.
         stale_resp = ExploreAssetsResponse(
-            assets=[], cache_ttl_seconds=_CACHE_TTL_SECONDS, generated_at="t0",
-            universe_size=0, priced_count=0,
+            assets=[],
+            cache_ttl_seconds=_CACHE_TTL_SECONDS,
+            generated_at="t0",
+            universe_size=0,
+            priced_count=0,
         )
         service._cache = stale_resp
         service._cache_ts = time.time() - (_CACHE_TTL_SECONDS + 1)  # already expired
@@ -326,8 +329,11 @@ class TestListAssets:
             rebuild_started.set()
             await rebuild_may_finish.wait()
             return ExploreAssetsResponse(
-                assets=[], cache_ttl_seconds=_CACHE_TTL_SECONDS, generated_at="t1",
-                universe_size=0, priced_count=0,
+                assets=[],
+                cache_ttl_seconds=_CACHE_TTL_SECONDS,
+                generated_at="t1",
+                universe_size=0,
+                priced_count=0,
             )
 
         with patch.object(service, "_refresh", side_effect=slow_refresh):
@@ -349,8 +355,11 @@ class TestListAssets:
         service = AssetMarketService()
 
         stale_resp = ExploreAssetsResponse(
-            assets=[], cache_ttl_seconds=_CACHE_TTL_SECONDS, generated_at="t0",
-            universe_size=0, priced_count=0,
+            assets=[],
+            cache_ttl_seconds=_CACHE_TTL_SECONDS,
+            generated_at="t0",
+            universe_size=0,
+            priced_count=0,
         )
         service._cache = stale_resp
         service._cache_ts = time.time() - (_CACHE_TTL_SECONDS + 1)
@@ -368,7 +377,12 @@ class TestListAssets:
             results = await asyncio.gather(*(service.list_assets() for _ in range(5)))
             assert all(r is stale_resp for r in results)
             finish.set()
-            await service._refresh_task
+            # Bind the result rather than awaiting for the side effect alone:
+            # a bare ``await task`` reads to a linter as a statement with no
+            # effect, and asserting on what the background refresh actually
+            # returned is a strictly stronger check than merely draining it.
+            refreshed = await service._refresh_task
+            assert refreshed is stale_resp
 
         assert call_count == 1  # deduplicated, not 5 separate rebuilds
 

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -15,11 +15,14 @@ timeout. All tests are hermetic — yfinance / chain boundaries are mocked.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from archimedes.api.explore_schemas import ExploreAssetsResponse
 from archimedes.services.asset_market_service import (
+    _CACHE_TTL_SECONDS,
     AssetMarketService,
     _explore_universe,
     _pct_change,
@@ -295,6 +298,79 @@ class TestListAssets:
             resp2 = await service.list_assets()
 
         assert resp1 is resp2  # Same object (cached)
+
+    @pytest.mark.asyncio
+    async def test_stale_cache_served_immediately_not_blocked_on_rebuild(self):
+        """Stale-while-revalidate (explore-latency fix): once ANY cache exists,
+        a request past the TTL must never await the rebuild inline — it gets
+        the last-good (stale) response immediately, and a background task
+        does the rebuild. This is what turns the measured 12.7s-42.9s prod
+        stall (cache-miss request pays the full oracle+yfinance cost) into a
+        sub-millisecond cache read for every request except the very first.
+        """
+        service = AssetMarketService()
+
+        # Seed a cache directly — skip the cold-start path entirely.
+        stale_resp = ExploreAssetsResponse(
+            assets=[], cache_ttl_seconds=_CACHE_TTL_SECONDS, generated_at="t0",
+            universe_size=0, priced_count=0,
+        )
+        service._cache = stale_resp
+        service._cache_ts = time.time() - (_CACHE_TTL_SECONDS + 1)  # already expired
+
+        # A rebuild that would hang forever if this test ever awaited it inline.
+        rebuild_started = asyncio.Event()
+        rebuild_may_finish = asyncio.Event()
+
+        async def slow_refresh():
+            rebuild_started.set()
+            await rebuild_may_finish.wait()
+            return ExploreAssetsResponse(
+                assets=[], cache_ttl_seconds=_CACHE_TTL_SECONDS, generated_at="t1",
+                universe_size=0, priced_count=0,
+            )
+
+        with patch.object(service, "_refresh", side_effect=slow_refresh):
+            t0 = time.monotonic()
+            resp = await asyncio.wait_for(service.list_assets(), timeout=1.0)
+            elapsed = time.monotonic() - t0
+
+            assert resp is stale_resp  # served the stale cache, not the rebuild
+            assert elapsed < 0.5  # never blocked on the (hung) rebuild
+            await asyncio.wait_for(rebuild_started.wait(), timeout=1.0)  # rebuild WAS kicked off
+
+            rebuild_may_finish.set()
+            await service._refresh_task  # let the background task finish cleanly
+
+    @pytest.mark.asyncio
+    async def test_stale_cache_concurrent_requests_dedupe_background_refresh(self):
+        """N requests landing in the same stale window must not each start
+        their own oracle+yfinance rebuild — only one refresh in flight."""
+        service = AssetMarketService()
+
+        stale_resp = ExploreAssetsResponse(
+            assets=[], cache_ttl_seconds=_CACHE_TTL_SECONDS, generated_at="t0",
+            universe_size=0, priced_count=0,
+        )
+        service._cache = stale_resp
+        service._cache_ts = time.time() - (_CACHE_TTL_SECONDS + 1)
+
+        call_count = 0
+        finish = asyncio.Event()
+
+        async def counting_refresh():
+            nonlocal call_count
+            call_count += 1
+            await finish.wait()
+            return stale_resp
+
+        with patch.object(service, "_refresh", side_effect=counting_refresh):
+            results = await asyncio.gather(*(service.list_assets() for _ in range(5)))
+            assert all(r is stale_resp for r in results)
+            finish.set()
+            await service._refresh_task
+
+        assert call_count == 1  # deduplicated, not 5 separate rebuilds
 
 
 # ── Universe alignment (#759 follow-up to #842) ────────────────────────────


### PR DESCRIPTION
## Why

Dan (2026-08-02): "Pricing information is poorly cached; the Explore page takes a long time to load." This PR fixes the specific mechanism, with prod measurements.

## Measured against archimedes-arc.com

| call | time |
|---|---|
| `/api/explore/assets` fully cold (both the 30s response cache and the evaluator's 600s yfinance price cache empty) | **42.9s** |
| same endpoint, warm (inside 30s TTL) | 0.19-0.20s |
| request landing right after the 30s TTL expires (yfinance cache still warm, only the oracle-read budget paid) | **12.7s** |

```
curl -s -o /dev/null -w "%{time_total}s %{http_code}\n" https://archimedes-arc.com/api/explore/assets
run1: 42.890877s 200   (cold)
run2: 0.203832s 200    (warm)
run3: 0.190738s 200    (warm)
... wait 35s ...
expired-run: 12.728061s 200   (TTL just expired)
immediate-followup: 0.185735s 200
```

## Root cause

`AssetMarketService.list_assets()` had a 30s TTL cache but rebuilt it **inline** on every miss — the unlucky request that lands right after expiry pays the full rebuild cost synchronously, on the request-serving path.

The floor of that cost is `_ORACLE_TOTAL_BUDGET_SECONDS` = 12s, a sequential (not concurrent) loop of on-chain `PriceOracle.getPrice()` reads, one per universe symbol (up to 281), each with its own timeout, capped at a 12s total budget.

That budget currently buys **zero** live prices. Verified directly against the deployed contracts:

```
$ cast call --rpc-url https://rpc.testnet.arc.network <sSPY-oracle> "getPrice()(uint256)"
Error: execution reverted, data: "0x19abf40e"
$ cast sig "StalePrice()"
0x19abf40e
$ cast call --rpc-url https://rpc.testnet.arc.network <sSPY-oracle> "lastUpdated()(uint256)"
1783584493   # → 2026-07-09 08:08 UTC — the T3.2 deploy date. Never updated since.
$ cast call --rpc-url https://rpc.testnet.arc.network <sSPY-oracle> "isFresh()(bool)"
false
```

In prod, `price_source == "oracle"` for **0 of 281** listed assets right now (checked via the live `/api/explore/assets` response) — including sSPY and sBTC, the only two symbols `OracleUpdater.YFINANCE_MAP` / `CRYPTO_MAP` are supposed to keep pushed. So every 30s the endpoint burns ~12s of synchronous latency on a read path that currently returns nothing.

Separately (not fixed here — flagging since pricing/oracle is now Tier 1): the ABI the backend calls (`contracts/abis/IPriceOracle.json`, `getPrice(address token) → (price, updatedAt)`) does not match the deployed `PriceOracle.sol`, whose real signature is the no-arg `getPrice() → uint256` (see the doc-comment at `contracts/src/PriceOracle.sol:349` — "Signature unchanged (no-arg)..."). `cast call ... "getPrice(address)(...)"` against 3 different deployed oracles (including sSPY, sBTC) reverts outright — wrong selector. Even calling the *correct* no-arg signature reverts too, with `StalePrice()`, because the admin-fed price hasn't been updated since deploy — i.e. the `OracleUpdater` push job also isn't landing writes. Both need fixing (ABI + get the updater running) before the oracle path can ever contribute a single live price; that's a contract/ops call, out of scope for this PR.

I also benchmarked whether just parallelizing the 281 sequential oracle reads was a safe quick fix. It is not: at bounded concurrency 5/8/10 against the shared Arc testnet RPC, wall-clock got *worse* (57-85s) with `TimeoutError` / rate-limit-shaped `ClientResponseError` failures showing up. Blindly adding concurrency here risks a 429 storm against a shared resource other services (agent runner, oracle updater) also depend on. Not touching that in this PR.

## Fix

Stale-while-revalidate, scoped to `asset_market_service.py` only — no change to what gets called, how often, or in what order:

- Once a cache exists at all, a request past the TTL gets the last-good (stale) cache **immediately**.
- A rebuild is kicked off in the background (`asyncio.create_task`, deduplicated via `_refresh_task` so N requests landing in the same stale window share one rebuild instead of starting N).
- The *next* request after the background rebuild finishes gets the fresh result.
- Only the very first request after cold start (no cache yet) still pays the synchronous cost — same as today, unavoidable, and it's one request per process lifetime, not one every 30s.

## Tests

`backend/tests/services/test_asset_market_service.py` — 2 new tests, 24/24 passing in the file, 41/41 passing across the touched + adjacent universe-parity suites:

- `test_stale_cache_served_immediately_not_blocked_on_rebuild` — patches `_refresh` to hang on an `asyncio.Event`, asserts `list_assets()` still returns in <0.5s with the stale value, and that the rebuild was in fact kicked off in the background.
- `test_stale_cache_concurrent_requests_dedupe_background_refresh` — 5 concurrent `list_assets()` calls in the stale window trigger exactly 1 `_refresh()` call, not 5.

```
env -i HOME="$HOME" PATH="$PATH" PYTHONPATH=backend python -m pytest backend/tests/services/test_asset_market_service.py backend/tests/test_universe_parity.py backend/tests/test_ui_asset_universe.py -q
41 passed
```

## Also found, not fixed here (describing per investigation scope)

- **`AssetGroupModal.jsx` N+1**: opening an asset-group detail modal fires one `/api/explore/assets/{symbol}/history` request per member (up to `MAX_AGGREGATE_MEMBERS` = 20), and each hits `yf.download()` individually — unlike the main `/assets` list endpoint, which correctly batches yfinance calls via `_fetch_price_histories`. Measured: 20 concurrent cold history fetches for a real group completed in ~1.2s wall-clock in practice (FastAPI's thread-pool concurrency absorbs it today), so this is not currently the dominant contributor to page-load pain, but it's a real inefficiency and a yfinance-rate-limit risk under load. Fixing it cleanly needs a new batched history endpoint (`/api/explore/history_batch?symbols=...`) — a bigger surface change than "low risk," so describing rather than doing.
- **Process-local cache**: both the 30s response cache and the evaluator's 600s yfinance price cache (`_PRICE_CACHE`) are plain in-process dicts on singletons, not Redis. Confirmed prod is currently `desired_count=1` / `running_count=1` on ECS, so this isn't hurting today, but it's a latent multiplier: if the service is ever scaled to N tasks, each gets its own independent caches, so N tasks pay the full oracle+yfinance rebuild cost independently and simultaneously. Redis (ElastiCache) is already live in this stack; migrating both caches there is the natural fix whenever task count > 1 is on the table, but it's a real wiring change (client, key design, TTL semantics for the partial/budgeted fetch) — out of scope here.
- **On-chain oracle read path is fully non-functional** (see root-cause section above) — ABI mismatch + stale admin price / dead `OracleUpdater` push job. Given pricing/oracle is now explicit Tier-1 MVP scope, this needs its own issue; I did not attempt a fix since it requires a judgment call on which interface is authoritative and whether/how to get the updater running again.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7