### PR TITLE
fix: backtest single-feed strategies on their declared ASSET_UNIVERSE, not BACKTEST_OPERATIONS

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/cli.py
+++ b/analytics-engine/src/archimedes_analytics_engine/cli.py
@@ -13,7 +13,15 @@ import backtrader as bt
 import pandas as pd
 
 from .data import fetch_ohlcv
-from .engine import BACKTEST_ENGINE_TAG, FeedArityError, required_feeds, run_backtest, run_pairs_backtest
+from .engine import (
+    BACKTEST_ENGINE_TAG,
+    BacktestResult,
+    FeedArityError,
+    combine_universe_results,
+    required_feeds,
+    run_backtest,
+    run_pairs_backtest,
+)
 from .instruments import OPERATION_TO_SYMBOL, resolve_operations
 from .strategy_loader import load_strategy
 
@@ -156,7 +164,26 @@ def run_command(
             }
         )
     else:
-        ops = resolve_operations(operations)
+        # Single-feed strategies must be backtested on the instruments they
+        # were actually designed for. A strategy's ASSET_UNIVERSE (module-
+        # level, read off `metadata` exactly like `_pair_legs` reads it above)
+        # is the strategy's OWN declared contract — the same status the pairs
+        # branch already gives it. `operations` (BACKTEST_OPERATIONS) is a
+        # benchmark/default selector for strategies that decline to declare a
+        # universe of their own; it must never override a declared one, or
+        # the engine silently substitutes the wrong return series. That
+        # silent substitution was the defect: every single-feed strategy —
+        # regardless of its own ASSET_UNIVERSE — was unconditionally
+        # backtested on BACKTEST_OPERATIONS (default ["SPY"]), so e.g.
+        # capital_preservation_tbill (declares ["BIL"], ~0.2% real vol) was
+        # graded on pure S&P-500 returns instead.
+        declared_universe = metadata.get("asset_universe")
+        if declared_universe:
+            ops = resolve_operations([str(o) for o in declared_universe])
+        else:
+            ops = resolve_operations(operations)
+
+        per_asset: list[tuple[str, BacktestResult]] = []
         for op in ops:
             symbol = OPERATION_TO_SYMBOL[op]
             prices = fetcher(symbol, start, end)
@@ -169,12 +196,35 @@ def run_command(
                 transaction_cost_bps=tx_cost_bps,
                 slippage_bps=slippage_bps,
             )
+            per_asset.append((op, bt_result))
 
             results.append(
                 {
                     "operation": op,
                     "symbol": symbol,
                     "metrics": asdict(bt_result),
+                }
+            )
+
+        # The rigor gate (backend get_daily_returns) grades ONE daily_returns
+        # series per strategy. With a declared multi-asset universe the loop
+        # above now produces N per-asset results, and grading only the first
+        # would be arbitrary — so emit an additional composite result
+        # representing the strategy applied across its whole declared
+        # universe (equal-weighted, date-intersection-aligned — see
+        # combine_universe_results), and let the backend select IT for
+        # persistence/grading (backtest_mapper.select_operation_result).
+        # Only meaningful when the ops actually came from a declared
+        # universe: a fallback run on the passed-in benchmark `operations`
+        # has no "declared universe" to composite over.
+        if declared_universe:
+            composite = combine_universe_results(per_asset, initial_cash=initial_cash)
+            results.append(
+                {
+                    "operation": "UNIVERSE",
+                    "symbol": "/".join(op for op, _ in per_asset),
+                    "constituent_operations": [op for op, _ in per_asset],
+                    "metrics": asdict(composite),
                 }
             )
 

--- a/analytics-engine/src/archimedes_analytics_engine/cli.py
+++ b/analytics-engine/src/archimedes_analytics_engine/cli.py
@@ -15,12 +15,16 @@ import pandas as pd
 from .data import fetch_ohlcv
 from .engine import (
     BACKTEST_ENGINE_TAG,
+    REQUIRED_FEEDS_UNIVERSE,
     BacktestResult,
     FeedArityError,
     combine_universe_results,
+    coverage_summary,
     required_feeds,
     run_backtest,
+    run_multi_backtest,
     run_pairs_backtest,
+    universe_date_coverage,
 )
 from .instruments import OPERATION_TO_SYMBOL, resolve_operations
 from .strategy_loader import load_strategy
@@ -88,6 +92,49 @@ def _pair_legs(
     return resolve_operations(legs[:2])
 
 
+def _multi_feed_legs(
+    strategy_cls: type[bt.Strategy],
+    metadata: dict[str, Any],
+    strategy_path: Path,
+    feeds_needed: int | str,
+) -> list[str]:
+    """Resolve the aligned N-feed universe for a cross-sectional / portfolio
+    strategy (``REQUIRED_FEEDS`` is the :data:`REQUIRED_FEEDS_UNIVERSE`
+    sentinel, or an explicit int > 2) from its declared ``ASSET_UNIVERSE``, in
+    DECLARED ORDER — order matters: strategies such as
+    ``frazzini_pedersen_2014_bab`` and ``ang_hodrick_2006_low_idiovol`` treat
+    ``self.datas[0]`` as the market benchmark and everything after it as the
+    investable universe. Mirrors :func:`_pair_legs`'s fail-closed contract
+    (dedupe case-insensitively, never silently accept too few legs) but for
+    N >= 2 feeds instead of exactly two, and additionally cross-checks an
+    EXPLICIT integer ``REQUIRED_FEEDS`` against what the universe actually
+    resolves to — the contract and the universe must never be allowed to
+    silently drift apart.
+    """
+    universe = metadata.get("asset_universe") or []
+    legs: list[str] = []
+    for symbol in universe:
+        normalized = str(symbol).upper()
+        if normalized and normalized not in legs:
+            legs.append(normalized)
+
+    if len(legs) < 2:
+        raise FeedArityError(
+            f"cross-sectional strategy {strategy_cls.__name__} ({strategy_path.name}) needs "
+            f">= 2 distinct instruments, but its declared ASSET_UNIVERSE {universe!r} resolves "
+            f"to {len(legs)} — failing closed rather than silently downgrading to a "
+            "single-feed run that would produce a plausible-looking but wrong number"
+        )
+    if isinstance(feeds_needed, int) and len(legs) != feeds_needed:
+        raise FeedArityError(
+            f"strategy {strategy_cls.__name__} ({strategy_path.name}) declares "
+            f"REQUIRED_FEEDS={feeds_needed}, but its declared ASSET_UNIVERSE {universe!r} "
+            f"resolves to {len(legs)} distinct instruments — the feed-count contract and the "
+            "universe have drifted out of sync; fix one or the other rather than guessing"
+        )
+    return resolve_operations(legs)
+
+
 def run_command(
     *,
     operations: list[str],
@@ -127,12 +174,18 @@ def run_command(
     results: list[dict] = []
     data_hashes: list[str] = []
 
+    # Route on the strategy's declared feed-count contract (engine.required_feeds):
+    #   1 feed              -> per-asset loop over the declared universe + UNIVERSE composite
+    #   2 feeds             -> run_pairs_backtest on the declared two-leg universe
+    #   N feeds (>= 2,       -> run_multi_backtest on the declared universe, in
+    #     REQUIRED_FEEDS_       declared order — the strategy ranks/weights across
+    #     UNIVERSE sentinel      its whole universe in one cerebro run, so that
+    #     or an explicit int)   single N-asset result IS the strategy result (no
+    #                           per-asset loop, no averaged composite over it).
+    # Every branch fails LOUD (FeedArityError) rather than silently downgrading
+    # a multi-feed strategy to a single-feed run — a plausible-looking wrong
+    # number is exactly the defect class this router exists to eliminate.
     feeds_needed = required_feeds(bundle.cls)
-    if feeds_needed > 2:
-        raise FeedArityError(
-            f"strategy {bundle.cls.__name__} declares REQUIRED_FEEDS={feeds_needed}, "
-            "but this runner supports 1 (single-feed) or 2 (pairs) feeds today"
-        )
 
     if feeds_needed == 2:
         # Pairs strategies trade their declared two-leg universe, not the
@@ -163,7 +216,7 @@ def run_command(
                 "metrics": asdict(bt_result),
             }
         )
-    else:
+    elif feeds_needed == 1:
         # Single-feed strategies must be backtested on the instruments they
         # were actually designed for. A strategy's ASSET_UNIVERSE (module-
         # level, read off `metadata` exactly like `_pair_legs` reads it above)
@@ -224,9 +277,75 @@ def run_command(
                     "operation": "UNIVERSE",
                     "symbol": "/".join(op for op, _ in per_asset),
                     "constituent_operations": [op for op, _ in per_asset],
+                    "date_coverage": universe_date_coverage(per_asset),
                     "metrics": asdict(composite),
                 }
             )
+    else:
+        # Cross-sectional / portfolio strategies (REQUIRED_FEEDS is the
+        # REQUIRED_FEEDS_UNIVERSE sentinel, or an explicit int > 2): the
+        # strategy ranks, weights, or otherwise reads every self.datas[i]
+        # together each bar (Jegadeesh-Titman momentum, Maillard risk parity,
+        # Frazzini-Pedersen BAB, the PCA stat-arb, ...). Running it once per
+        # asset and averaging the results — the single-feed branch above — is
+        # NOT the strategy: it silently replaces the cross-sectional signal
+        # with N independent single-asset runs, which is exactly the defect
+        # class this whole module exists to eliminate. Feed the strategy's
+        # DECLARED ASSET_UNIVERSE through run_multi_backtest in declared
+        # order instead — order matters (e.g. frazzini_pedersen_2014_bab
+        # treats self.datas[0] as the benchmark) — and feed-name each leg by
+        # its resolved SYMBOL (ticker), not its operation code: at least one
+        # strategy (antonacci_2014_dual_momentum) identifies its defensive
+        # leg by matching `self.data._name` against a hardcoded ticker
+        # ("TLT"), which only works if the feed is named by symbol.
+        #
+        # Belt-and-suspenders: required_feeds() only ever returns an int >= 1
+        # or the REQUIRED_FEEDS_UNIVERSE sentinel, so by construction this
+        # branch is only reached for the sentinel or an int >= 3 — but assert
+        # it explicitly rather than silently mis-routing if that contract
+        # ever changes without this router being updated to match.
+        if not (feeds_needed == REQUIRED_FEEDS_UNIVERSE or (isinstance(feeds_needed, int) and feeds_needed >= 3)):
+            raise FeedArityError(
+                f"strategy {bundle.cls.__name__} declares REQUIRED_FEEDS={feeds_needed!r}, which "
+                f"this router does not know how to serve (expected 1, 2, an int >= 3, or the "
+                f"{REQUIRED_FEEDS_UNIVERSE!r} sentinel) — failing closed rather than guessing"
+            )
+        ops = _multi_feed_legs(bundle.cls, metadata, strategy_path, feeds_needed)
+        symbols = [OPERATION_TO_SYMBOL[op] for op in ops]
+
+        prices_list: list[pd.DataFrame] = []
+        for symbol in symbols:
+            prices = fetcher(symbol, start, end)
+            prices_list.append(prices)
+            data_hashes.append(_hash_frame(prices))
+
+        bt_result = run_multi_backtest(
+            prices_list,
+            strategy_cls=bundle.cls,
+            initial_cash=initial_cash,
+            names=symbols,
+            transaction_cost_bps=tx_cost_bps,
+            slippage_bps=slippage_bps,
+        )
+
+        # The single N-asset result IS the strategy result — no per-asset rows,
+        # no equal-weighted composite averaged on top of an already-joint
+        # portfolio series (see combine_universe_results's own docstring on
+        # why that would be double-averaging). select_operation_result
+        # (backend/.../backtest_mapper.py) picks this the same way it already
+        # picks a pairs result: it isn't named "UNIVERSE" or "SPY", so it
+        # falls through to "the only row" — the same fallback pairs results
+        # already rely on.
+        per_constituent_bars = {op: len(df) for op, df in zip(ops, prices_list, strict=True)}
+        results.append(
+            {
+                "operation": "/".join(ops),
+                "symbol": "/".join(symbols),
+                "constituent_operations": ops,
+                "date_coverage": coverage_summary(per_constituent_bars, bt_result.bars),
+                "metrics": asdict(bt_result),
+            }
+        )
 
     # NOTE: look_ahead_audit_passed is a broker-execution-timing check only (no
     # cheat-on-close/cheat-on-open) — it is NOT a source-level audit of the

--- a/analytics-engine/src/archimedes_analytics_engine/data/instruments.json
+++ b/analytics-engine/src/archimedes_analytics_engine/data/instruments.json
@@ -29,6 +29,8 @@
     "XLP": "XLP",
     "XLU": "XLU",
     "XLV": "XLV",
-    "XLY": "XLY"
+    "XLY": "XLY",
+    "BIL": "BIL",
+    "TLT": "TLT"
   }
 }

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 import statistics
 from dataclasses import dataclass, field
@@ -10,32 +11,64 @@ import pandas as pd
 
 from archimedes_analytics_engine.costs import CostModel, TurnoverAnalyzer
 
+logger = logging.getLogger(__name__)
+
 ANNUALIZATION = 252
 RF_ANNUAL = 0.05  # 5% annual risk-free rate
 RF_DAILY = RF_ANNUAL / ANNUALIZATION
 BACKTEST_ENGINE_TAG = "backtrader"
 
+# Sentinel REQUIRED_FEEDS value: "as many aligned feeds as my own declared
+# ASSET_UNIVERSE lists", rather than one fixed integer. Cross-sectional /
+# portfolio strategies (Jegadeesh-Titman momentum, Maillard risk parity,
+# Frazzini-Pedersen BAB, ...) rank or weight across their WHOLE declared
+# universe, so hardcoding a literal count on the class would silently drift
+# out of sync the moment ASSET_UNIVERSE is edited — the sentinel keeps the
+# feed-count contract derived from the universe itself, always.
+REQUIRED_FEEDS_UNIVERSE = "UNIVERSE"
+
 
 class FeedArityError(ValueError):
-    """A strategy that hard-requires N aligned data feeds was given fewer.
+    """A strategy that hard-requires N aligned data feeds was given fewer (or
+    a mismatched/malformed feed-count contract).
 
     Raised fail-closed at the runner boundary (issue #887) instead of letting
-    a pairs strategy crash mid-run with a bare ``IndexError`` on
-    ``self.datas[1]``. The message is passport-grade: it says what the
-    strategy needs ("pairs needs >= 2 instruments") rather than where a list
-    index went out of range.
+    a pairs/cross-sectional strategy crash mid-run with a bare ``IndexError``
+    on ``self.datas[i]``, or letting the runner silently downgrade it to a
+    single-feed run that produces a plausible-looking but wrong number. The
+    message is passport-grade: it says what the strategy needs (e.g. "pairs
+    needs >= 2 instruments") rather than where a list index went out of range.
     """
 
 
-def required_feeds(strategy_cls: type[bt.Strategy]) -> int:
+def required_feeds(strategy_cls: type[bt.Strategy]) -> int | str:
     """How many aligned data feeds ``strategy_cls`` declares it hard-requires.
 
-    Strategies that index ``self.datas[1]`` (the pairs family) declare
-    ``REQUIRED_FEEDS = 2`` as a class attribute; anything undeclared or
-    malformed is treated as the single-feed default of 1.
+    Returns either a positive ``int`` (an exact feed count — ``1`` for
+    ordinary single-asset strategies, ``2`` for the pairs family) or the
+    :data:`REQUIRED_FEEDS_UNIVERSE` sentinel string for cross-sectional /
+    portfolio strategies that trade their whole declared ``ASSET_UNIVERSE``
+    at once (see ``cli.run_command``'s N-feed routing branch).
+
+    Strategies declare this via a ``REQUIRED_FEEDS`` class attribute;
+    anything undeclared is treated as the single-feed default of 1. A string
+    value that is NOT exactly ``REQUIRED_FEEDS_UNIVERSE`` is almost certainly
+    a typo (e.g. ``"Universe"`` or ``"univers"``) and raises loudly rather
+    than silently collapsing to 1 — the whole point of this contract is that
+    the router must never guess.
     """
+    raw = getattr(strategy_cls, "REQUIRED_FEEDS", 1)
+    if isinstance(raw, str):
+        if raw.strip().upper() == REQUIRED_FEEDS_UNIVERSE:
+            return REQUIRED_FEEDS_UNIVERSE
+        raise FeedArityError(
+            f"{strategy_cls.__name__} declares REQUIRED_FEEDS={raw!r} — a string value must be "
+            f"exactly {REQUIRED_FEEDS_UNIVERSE!r} (meaning 'match my ASSET_UNIVERSE'); anything "
+            "else is most likely a typo, so this fails closed instead of silently defaulting to "
+            "a single-feed run"
+        )
     try:
-        return max(1, int(getattr(strategy_cls, "REQUIRED_FEEDS", 1) or 1))
+        return max(1, int(raw or 1))
     except (TypeError, ValueError):
         return 1
 
@@ -177,6 +210,16 @@ def _max_drawdown_from_curve(equity_curve: list[float]) -> tuple[float | None, i
     peak * 100``), reimplemented here because :func:`combine_universe_results`
     combines already-extracted per-asset results and has no cerebro run of its
     own to attach an analyzer to.
+
+    Duration counting matches backtrader's own ``DrawDown.next()`` exactly:
+    ``r.len = r.len + 1 if drawdown else 0`` — the streak resets whenever the
+    CURRENT bar sits exactly AT the running peak (``drawdown == 0``), not only
+    on a strictly NEW all-time high. Resetting on ``value > peak`` alone (the
+    previous implementation here) leaves a bar that merely equals the prior
+    peak still counted as "in drawdown", which both starts the counter
+    incrementing from bar 0 (``peak`` is seeded from ``equity_curve[0]``, so
+    the first comparison is against itself) and inflates every recovery that
+    round-trips back to a prior high before falling again.
     """
     if not equity_curve:
         return None, None
@@ -187,15 +230,12 @@ def _max_drawdown_from_curve(equity_curve: list[float]) -> tuple[float | None, i
     for value in equity_curve:
         if value > peak:
             peak = value
-            cur_len = 0
-        else:
-            cur_len += 1
-            if cur_len > max_len:
-                max_len = cur_len
-        if peak > 0:
-            dd = (peak - value) / peak * 100.0
-            if dd > max_dd:
-                max_dd = dd
+        dd = (peak - value) / peak * 100.0 if peak > 0 else 0.0
+        cur_len = cur_len + 1 if dd else 0
+        if cur_len > max_len:
+            max_len = cur_len
+        if dd > max_dd:
+            max_dd = dd
     return max_dd, max_len
 
 
@@ -406,12 +446,12 @@ def run_backtest(
         :func:`run_pairs_backtest` or :func:`run_multi_backtest`.
     """
     required = required_feeds(strategy_cls)
-    if required > 1:
+    if required != 1:
         raise FeedArityError(
             f"strategy {strategy_cls.__name__} requires {required} aligned data feeds "
-            "but the single-feed runner provides 1 — a pairs strategy needs >= 2 "
-            "instruments; run it via run_pairs_backtest/run_multi_backtest with its "
-            "declared asset universe"
+            "but the single-feed runner provides 1 — a pairs/cross-sectional strategy "
+            "needs >= 2 instruments; run it via run_pairs_backtest/run_multi_backtest "
+            "with its declared asset universe"
         )
 
     cerebro = bt.Cerebro(stdstats=False)
@@ -530,6 +570,73 @@ def _extract_result(
     )
 
 
+# Below this retained-fraction, a date/index intersection has lost enough of
+# the longest constituent's history that it needs a human's eyes. 90% is a
+# deliberately loose floor: ordinary calendar noise between liquid, actively
+# traded feeds (different market holidays, the odd half-day) costs
+# low-single-digit percent of trading days, not double digits. Losing more
+# than 10% of the longest constituent's bars usually means one feed's
+# AVAILABLE HISTORY is materially shorter than the others' — a late listing,
+# a yfinance gap, or a wrong date range — which is exactly the "truncated or
+# data-quality-broken" case this warning exists to surface rather than
+# silently averaging/aligning over.
+_COVERAGE_WARN_RATIO = 0.90
+
+
+def coverage_summary(per_constituent_bars: dict[str, int], intersection_bars: int) -> dict[str, Any]:
+    """Build the retained-date-coverage record attached to composite/multi-feed
+    artifacts: how many bars each constituent had available, how many survived
+    the intersection, and the ratio — so "this universe legitimately has
+    limited overlap" is distinguishable from "one feed is truncated or
+    data-quality-broken" (see :func:`combine_universe_results` and
+    :func:`run_multi_backtest`).
+    """
+    longest = max(per_constituent_bars.values()) if per_constituent_bars else 0
+    return {
+        "per_constituent_bars": dict(per_constituent_bars),
+        "intersection_bars": intersection_bars,
+        "longest_constituent_bars": longest,
+        "intersection_ratio": (intersection_bars / longest) if longest else None,
+    }
+
+
+def warn_on_truncated_coverage(context: str, coverage: dict[str, Any]) -> None:
+    """Log loudly when ``coverage`` (from :func:`coverage_summary`) shows a
+    materially-shorter-than-expected intersection. No-op (and safe on
+    zero-length input) otherwise.
+    """
+    longest = coverage.get("longest_constituent_bars") or 0
+    ratio = coverage.get("intersection_ratio")
+    if longest <= 0 or ratio is None:
+        return
+    if ratio < _COVERAGE_WARN_RATIO:
+        logger.warning(
+            "%s: retained %d bars, only %.1f%% of the longest constituent's %d bars "
+            "(per-constituent bar counts: %s) — investigate whether this is genuine "
+            "limited overlap or a truncated/data-quality-broken feed before trusting "
+            "this result",
+            context,
+            coverage.get("intersection_bars", 0),
+            ratio * 100.0,
+            longest,
+            coverage.get("per_constituent_bars", {}),
+        )
+
+
+def universe_date_coverage(op_results: list[tuple[str, BacktestResult]]) -> dict[str, Any]:
+    """:func:`coverage_summary` derived from a list of ``(name, BacktestResult)``
+    pairs — the shape :func:`combine_universe_results` and ``cli.run_command``'s
+    single-feed composite branch both work with.
+    """
+    per_constituent_bars = {name: len(result.daily_return_dates) for name, result in op_results}
+    if not op_results:
+        return coverage_summary(per_constituent_bars, 0)
+    common_dates = set(op_results[0][1].daily_return_dates)
+    for _, result in op_results[1:]:
+        common_dates &= set(result.daily_return_dates)
+    return coverage_summary(per_constituent_bars, len(common_dates))
+
+
 def combine_universe_results(
     op_results: list[tuple[str, BacktestResult]],
     *,
@@ -581,6 +688,11 @@ def combine_universe_results(
         names = ", ".join(name for name, _ in op_results)
         raise ValueError(f"universe constituents [{names}] share no common trading dates; cannot build composite")
     sorted_dates = sorted(common_dates)
+
+    per_constituent_bars = {name: len(result.daily_return_dates) for name, result in op_results}
+    coverage = coverage_summary(per_constituent_bars, len(sorted_dates))
+    names = ", ".join(name for name, _ in op_results)
+    warn_on_truncated_coverage(f"combine_universe_results([{names}])", coverage)
 
     daily_returns = [statistics.fmean(by_date[d] for by_date in per_op_by_date) for d in sorted_dates]
 
@@ -732,6 +844,10 @@ def run_multi_backtest(
         common_index = common_index.intersection(prices.index)
     if len(common_index) == 0:
         raise ValueError("price frames share no common dates; cannot align feeds")
+
+    per_constituent_bars = {name: len(prices.index) for name, prices in zip(feed_names, prices_list, strict=True)}
+    coverage = coverage_summary(per_constituent_bars, len(common_index))
+    warn_on_truncated_coverage(f"run_multi_backtest([{', '.join(feed_names)}])", coverage)
 
     cerebro = bt.Cerebro(stdstats=False)
     transaction_cost_bps, slippage_bps = _configure_broker(

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -169,6 +169,36 @@ def _build_equity_curve(initial_cash: float, daily_pairs: list[tuple]) -> list[f
     return curve
 
 
+def _max_drawdown_from_curve(equity_curve: list[float]) -> tuple[float | None, int | None]:
+    """Peak-to-trough max drawdown (percent) and its duration (bars) from a
+    plain equity curve.
+
+    Same definition as backtrader's ``DrawDown`` analyzer (``(peak - value) /
+    peak * 100``), reimplemented here because :func:`combine_universe_results`
+    combines already-extracted per-asset results and has no cerebro run of its
+    own to attach an analyzer to.
+    """
+    if not equity_curve:
+        return None, None
+    peak = equity_curve[0]
+    max_dd = 0.0
+    max_len = 0
+    cur_len = 0
+    for value in equity_curve:
+        if value > peak:
+            peak = value
+            cur_len = 0
+        else:
+            cur_len += 1
+            if cur_len > max_len:
+                max_len = cur_len
+        if peak > 0:
+            dd = (peak - value) / peak * 100.0
+            if dd > max_dd:
+                max_dd = dd
+    return max_dd, max_len
+
+
 def _compute_sortino(daily_returns: list[float]) -> float | None:
     if not daily_returns:
         return None
@@ -497,6 +527,103 @@ def _extract_result(
         bars=bars,
         backtest_start=backtest_start,
         backtest_end=backtest_end,
+    )
+
+
+def combine_universe_results(
+    op_results: list[tuple[str, BacktestResult]],
+    *,
+    initial_cash: float,
+) -> BacktestResult:
+    """Equal-weighted composite of a strategy's per-declared-asset backtests
+    into ONE daily-return series, aligned on the INTERSECTION of trading dates.
+
+    A strategy with an N-asset ``ASSET_UNIVERSE`` is now backtested once per
+    declared asset (see ``cli.run_command``), but the rigor gate — and every
+    other downstream consumer of ``backend/.../get_daily_returns`` — needs a
+    single series to grade. Averaging the per-asset returns POSITIONALLY (by
+    index) would silently misalign calendars that genuinely differ (``^N225``
+    trades on the Tokyo calendar, ``CL=F`` is a futures contract with its own
+    session) and produce a plausible-looking but WRONG series — exactly the
+    bug class this module exists to fix. Aligning by DATE instead means only
+    bars present in *every* constituent's own series are averaged.
+
+    For a single-asset universe (``len(op_results) == 1``) the result is
+    numerically identical to that one run: an intersection of one date set is
+    just that series' own dates, and the equal-weighted mean of one value is
+    that value.
+
+    Trade-level stats (``total_trades``, ``win_rate``, ``profit_factor``,
+    ``avg_holding_period_days``) and cost-realism fields
+    (``turnover_annualized``, ``traded_notional``, ``total_commission_paid``,
+    ``cost_drag_annual_pct``, ``break_even_cost_bps``, ``gross_sharpe_ratio``)
+    have no well-defined meaning for a synthetic blended series — no single
+    backtrader run produced them — and are left at their dataclass defaults
+    rather than fabricated by summing/averaging across independent runs.
+
+    Raises
+    ------
+    ValueError
+        If ``op_results`` is empty, or if the constituent series share no
+        common trading dates at all.
+    """
+    if not op_results:
+        raise ValueError("combine_universe_results requires at least one operation result")
+
+    per_op_by_date: list[dict[str, float]] = [
+        dict(zip(result.daily_return_dates, result.daily_returns, strict=True)) for _, result in op_results
+    ]
+
+    common_dates = set(per_op_by_date[0])
+    for by_date in per_op_by_date[1:]:
+        common_dates &= set(by_date)
+    if not common_dates:
+        names = ", ".join(name for name, _ in op_results)
+        raise ValueError(f"universe constituents [{names}] share no common trading dates; cannot build composite")
+    sorted_dates = sorted(common_dates)
+
+    daily_returns = [statistics.fmean(by_date[d] for by_date in per_op_by_date) for d in sorted_dates]
+
+    equity_curve = _build_equity_curve(initial_cash, list(zip(sorted_dates, daily_returns, strict=True)))
+    bars = len(sorted_dates)
+    final_value = equity_curve[-1]
+    total_return_pct = ((final_value / initial_cash) - 1.0) * 100.0 if initial_cash else 0.0
+
+    sharpe = _sharpe_bt_convention(daily_returns)
+    sortino = _compute_sortino(daily_returns)
+    cagr = _compute_cagr(initial_cash, final_value, bars)
+
+    max_dd_pct, max_dd_len = _max_drawdown_from_curve(equity_curve)
+    calmar: float | None = None
+    if cagr is not None and max_dd_pct is not None and max_dd_pct > 0:
+        calmar = cagr / (max_dd_pct / 100.0)
+
+    look_ahead_passed = all(result.look_ahead_audit_passed for _, result in op_results)
+    # All constituent legs are run with the same tx-cost/slippage settings
+    # (cli.run_command applies one flat config to every per-asset call), so
+    # carrying the first leg's values forward is exact, not an approximation.
+    transaction_cost_bps = op_results[0][1].transaction_cost_bps
+    slippage_bps = op_results[0][1].slippage_bps
+
+    return BacktestResult(
+        final_value=final_value,
+        total_return_pct=total_return_pct,
+        equity_curve=equity_curve,
+        sharpe_ratio=sharpe,
+        sortino_ratio=sortino,
+        calmar_ratio=calmar,
+        max_drawdown_pct=max_dd_pct,
+        max_drawdown_duration_bars=max_dd_len,
+        cagr=cagr,
+        daily_returns=daily_returns,
+        daily_return_dates=sorted_dates,
+        transaction_cost_bps=transaction_cost_bps,
+        slippage_bps=slippage_bps,
+        look_ahead_audit_passed=look_ahead_passed,
+        backtest_engine=BACKTEST_ENGINE_TAG,
+        bars=bars,
+        backtest_start=sorted_dates[0] if sorted_dates else None,
+        backtest_end=sorted_dates[-1] if sorted_dates else None,
     )
 
 

--- a/analytics-engine/src/archimedes_analytics_engine/instruments.py
+++ b/analytics-engine/src/archimedes_analytics_engine/instruments.py
@@ -20,6 +20,10 @@ Universe notes (kept here for readers; the authoritative values live in
   ``VNQ``), and the nine SPDR sector ETFs (``XLB``…``XLY``). See
   ``docs/specs/second-wave-universe-experiment.md`` for which composition suits
   which strategy.
+* Declared-universe backfill (backtest-vol audit): ``BIL`` (SPDR 1-3 Month
+  T-Bill ETF) and ``TLT`` (iShares 20+ Year Treasury Bond ETF) as direct
+  operation keys, so every curated strategy's ``ASSET_UNIVERSE`` resolves
+  through ``resolve_operations`` — see ``cli.run_command``.
 
 If the JSON SSOT cannot be read (e.g. a stripped install that dropped package
 data), the module falls back to an in-module copy so the package never fails to
@@ -69,6 +73,15 @@ _FALLBACK_OPERATION_TO_SYMBOL: dict[str, str] = {
     "XLU": "XLU",
     "XLV": "XLV",
     "XLY": "XLY",
+    # Declared-universe backfill (backtest-vol audit): the two ASSET_UNIVERSE
+    # tickers among the 34 curated strategies that were not yet operation keys
+    # — capital_preservation_tbill declares BIL (SPDR 1-3 Month T-Bill ETF),
+    # gatev_2006_portfolio_of_pairs declares TLT (iShares 20+ Year Treasury
+    # Bond ETF) alongside its other direct-ticker entries. Added so
+    # cli.run_command can resolve every declared universe; TREASURY -> TLT
+    # (above) is a separate legacy alias and is kept unchanged.
+    "BIL": "BIL",
+    "TLT": "TLT",
 }
 
 

--- a/analytics-engine/strategies/ang_hodrick_2006_low_idiovol.py
+++ b/analytics-engine/strategies/ang_hodrick_2006_low_idiovol.py
@@ -119,6 +119,10 @@ class AngHodrickLowIdioVol(bt.Strategy):
     ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("vol_window", 22),  # bars for residual-vol estimation
         ("beta_window", 63),  # bars for rolling OLS beta estimation (~quarter)

--- a/analytics-engine/strategies/antonacci_2014_dual_momentum.py
+++ b/analytics-engine/strategies/antonacci_2014_dual_momentum.py
@@ -101,6 +101,10 @@ class DualMomentum(bt.Strategy):
     cash. Driven by ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks/rotates across its whole declared
+    # universe (engine.required_feeds() / cli.run_command's N-feed branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 252),  # trailing-return window (bars)
         ("rebalance_every", 21),  # ~monthly

--- a/analytics-engine/strategies/arnott_2019_defensive_quality.py
+++ b/analytics-engine/strategies/arnott_2019_defensive_quality.py
@@ -107,6 +107,10 @@ class ArnottDefensiveQuality(bt.Strategy):
     ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("vol_window", 63),  # realized-vol / drift window (bars)
         ("beta_window", 63),  # beta-vs-benchmark window (bars)

--- a/analytics-engine/strategies/asness_moskowitz_2013_value.py
+++ b/analytics-engine/strategies/asness_moskowitz_2013_value.py
@@ -91,6 +91,10 @@ class AsnessMoskowitzValue(bt.Strategy):
     Expects N>=2 data feeds. Driven by ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("value_window", 252),  # rolling mean window for cheapness proxy
         ("rebalance_every", 21),

--- a/analytics-engine/strategies/avellaneda_lee_2010_pca_statarb.py
+++ b/analytics-engine/strategies/avellaneda_lee_2010_pca_statarb.py
@@ -116,6 +116,11 @@ class PCAStatArb(bt.Strategy):
     ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class trades across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    # ASSET_UNIVERSE above has 5 entries, comfortably above the N>=3 PCA needs.
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 60),  # return-matrix / PCA estimation window (bars)
         ("n_components", 2),  # number of leading principal components (factors)

--- a/analytics-engine/strategies/blitz_hanauer_2010_rmom.py
+++ b/analytics-engine/strategies/blitz_hanauer_2010_rmom.py
@@ -105,6 +105,10 @@ class BlitzHanauerRMOM(bt.Strategy):
     market benchmark (SPY). Driven by ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 252),  # formation window start (bars back)
         ("skip", 21),  # skip most-recent bars (short-term reversal control)

--- a/analytics-engine/strategies/frazzini_pedersen_2014_bab.py
+++ b/analytics-engine/strategies/frazzini_pedersen_2014_bab.py
@@ -96,6 +96,10 @@ class FrazziniPedersenBAB(bt.Strategy):
     market benchmark (SPY). Driven by ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 63),  # rolling window for beta estimation (bars)
         ("rebalance_every", 21),  # ~monthly rebalance

--- a/analytics-engine/strategies/gatev_2006_portfolio_of_pairs.py
+++ b/analytics-engine/strategies/gatev_2006_portfolio_of_pairs.py
@@ -187,6 +187,10 @@ class GatevPortfolioOfPairs(bt.Strategy):
     ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class trades across its whole declared 26-ETF
+    # universe (engine.required_feeds() / cli.run_command's N-feed branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("formation", 252),  # 12-month formation window (bars)
         ("trading", 126),  # 6-month trading window (bars)

--- a/analytics-engine/strategies/jegadeesh_titman_1993_cross_sectional_momentum.py
+++ b/analytics-engine/strategies/jegadeesh_titman_1993_cross_sectional_momentum.py
@@ -94,6 +94,10 @@ class CrossSectionalMomentum(bt.Strategy):
     ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 252),  # formation window (bars)
         ("skip", 21),  # skip most-recent bars (short-term reversal control)

--- a/analytics-engine/strategies/low_tan_wermers_2004_dividend_yield.py
+++ b/analytics-engine/strategies/low_tan_wermers_2004_dividend_yield.py
@@ -102,6 +102,10 @@ class FamaFrenchDividendYield(bt.Strategy):
     market benchmark (SPY). Driven by ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 252),  # trailing window (bars) for the proxy score
         ("rebalance_every", 21),  # ~monthly

--- a/analytics-engine/strategies/maillard_2010_risk_parity.py
+++ b/analytics-engine/strategies/maillard_2010_risk_parity.py
@@ -92,6 +92,10 @@ class RiskParityInverseVol(bt.Strategy):
     ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class weights across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 63),  # volatility-estimation window (~3 months)
         ("rebalance_every", 21),  # ~monthly

--- a/analytics-engine/strategies/novy_marx_2012_quality_momentum.py
+++ b/analytics-engine/strategies/novy_marx_2012_quality_momentum.py
@@ -95,6 +95,10 @@ class NovyMarxQualityMomentum(bt.Strategy):
     Expects N>=2 data feeds. Driven by ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 252),  # formation window for momentum
         ("skip", 21),  # skip most-recent bars (short-term reversal control)

--- a/analytics-engine/strategies/novy_marx_2013_qmj.py
+++ b/analytics-engine/strategies/novy_marx_2013_qmj.py
@@ -109,6 +109,10 @@ class NoVyMarxQMJ(bt.Strategy):
     ``engine.run_multi_backtest``.
     """
 
+    # Runner contract: this class ranks across its whole declared universe
+    # (engine.required_feeds() / cli.run_command's N-feed routing branch).
+    REQUIRED_FEEDS = "UNIVERSE"
+
     params = (
         ("lookback", 252),  # window for IR computation (bars)
         ("rebalance_every", 21),  # ~monthly rebalance

--- a/analytics-engine/tests/test_cli.py
+++ b/analytics-engine/tests/test_cli.py
@@ -442,6 +442,165 @@ def test_universe_composite_aligns_on_date_intersection(tmp_path: Path) -> None:
     assert len(universe_dates) < len(by_op["OIL"]["metrics"]["daily_return_dates"])
 
 
+# ── Cross-sectional / N-feed routing (backtest-vol audit item 1) ───────────
+#
+# A strategy that ranks/weights across self.datas[i] for i beyond 0 must be
+# routed through run_multi_backtest on its declared ASSET_UNIVERSE, in
+# declared order, feed-named by resolved SYMBOL — never run once per asset
+# and averaged (that "single-feed-loop" path silently replaces the
+# cross-sectional signal with N independent single-asset runs).
+
+
+def _write_multi_feed_strategy(path: Path, universe: str = "['SPY', 'GOLD', 'OIL']") -> None:
+    path.write_text(
+        "import backtrader as bt\n\n"
+        f"ASSET_UNIVERSE = {universe}\n\n"
+        "class MultiFeedProbe(bt.Strategy):\n"
+        "    REQUIRED_FEEDS = 'UNIVERSE'\n\n"
+        "    def next(self):\n"
+        "        for d in self.datas:\n"
+        "            float(d.close[0])  # hard N-feed dependency: touches every feed\n"
+    )
+
+
+def test_run_command_routes_cross_sectional_strategy_through_multi_feed_runner(tmp_path: Path) -> None:
+    strategy_file = tmp_path / "multi_feed_probe.py"
+    _write_multi_feed_strategy(strategy_file)
+
+    fetcher = _make_fetcher(
+        {
+            "SPY": _symbol_series("SPY", "2024-01-01", [100.0, 101.0, 102.0, 103.0, 104.0]),
+            "GC=F": _symbol_series("GC=F", "2024-01-01", [1800.0, 1801.0, 1802.0, 1803.0, 1804.0]),
+            "CL=F": _symbol_series("CL=F", "2024-01-01", [50.0, 51.0, 52.0, 53.0, 54.0]),
+        }
+    )
+
+    output = run_command(
+        operations=["SPY"],  # benchmark ops are ignored — the declared universe wins
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=fetcher,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    assert payload["operations"] == ["SPY", "GOLD", "OIL"]  # declared order preserved
+    assert set(fetcher.requested) == {"SPY", "GC=F", "CL=F"}
+
+    # Exactly ONE result row — no per-asset rows, no averaged UNIVERSE composite
+    # on top of the already-joint N-asset portfolio series.
+    assert len(payload["results"]) == 1
+    result = payload["results"][0]
+    assert result["operation"] == "SPY/GOLD/OIL"
+    assert result["symbol"] == "SPY/GC=F/CL=F"
+    assert result["constituent_operations"] == ["SPY", "GOLD", "OIL"]
+    assert result["metrics"]["bars"] == 5
+    assert result["metrics"]["look_ahead_audit_passed"] is True
+
+    # date_coverage is recorded (item 3): per-constituent + intersection sizes.
+    coverage = result["date_coverage"]
+    assert coverage["per_constituent_bars"] == {"SPY": 5, "GOLD": 5, "OIL": 5}
+    assert coverage["intersection_bars"] == 5
+    assert coverage["longest_constituent_bars"] == 5
+    assert coverage["intersection_ratio"] == pytest.approx(1.0)
+
+    assert len(payload["data_hashes"]) == 3  # one per declared-universe leg
+
+
+def test_run_command_names_multi_feeds_by_resolved_symbol_not_operation_code(tmp_path: Path) -> None:
+    """Regression: at least one real cross-sectional strategy
+    (antonacci_2014_dual_momentum) identifies a feed by matching
+    ``self.data._name`` against a hardcoded TICKER ("TLT"). Naming feeds by
+    their OPERATION code ("TREASURY") instead would silently break that
+    lookup — the strategy would never find its defensive leg and nothing
+    would raise, which is exactly the kind of silent wrong-number defect this
+    whole module exists to eliminate. This probe fails LOUDLY if the feeds
+    are misnamed, rather than silently."""
+    strategy_file = tmp_path / "name_probe.py"
+    strategy_file.write_text(
+        "import backtrader as bt\n\n"
+        "ASSET_UNIVERSE = ['SPY', 'TREASURY']\n\n"
+        "class NameProbe(bt.Strategy):\n"
+        "    REQUIRED_FEEDS = 'UNIVERSE'\n\n"
+        "    def next(self):\n"
+        "        names = {d._name for d in self.datas}\n"
+        "        if names != {'SPY', 'TLT'}:\n"
+        "            raise AssertionError(f'expected feeds named by SYMBOL, got {names!r}')\n"
+    )
+    fetcher = _make_fetcher(
+        {
+            "SPY": _symbol_series("SPY", "2024-01-01", [100.0] * 5),
+            "TLT": _symbol_series("TLT", "2024-01-01", [90.0] * 5),
+        }
+    )
+
+    output = run_command(
+        operations=["SPY"],
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=fetcher,
+    )
+    # No exception means the assertion inside next() never fired — feeds were
+    # correctly named "SPY"/"TLT", not "SPY"/"TREASURY".
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    assert payload["results"][0]["metrics"]["bars"] == 5
+
+
+def test_run_command_fails_closed_on_single_symbol_cross_sectional_universe(tmp_path: Path) -> None:
+    strategy_file = tmp_path / "degenerate_multi_feed.py"
+    _write_multi_feed_strategy(strategy_file, universe="['SPY', 'SPY']")  # dedupes to 1 distinct instrument
+
+    with pytest.raises(FeedArityError, match="needs >= 2 distinct instruments"):
+        run_command(
+            operations=["SPY"],
+            start="2024-01-01",
+            end="2024-01-10",
+            initial_cash=10000.0,
+            tx_cost_bps=10,
+            slippage_bps=5,
+            artifact_dir=tmp_path,
+            strategy_path=strategy_file,
+            fetcher=_fake_fetch,
+        )
+
+
+def test_run_command_fails_closed_on_explicit_required_feeds_universe_drift(tmp_path: Path) -> None:
+    """A strategy declaring an EXPLICIT int REQUIRED_FEEDS that no longer
+    matches its own ASSET_UNIVERSE length must fail loud rather than silently
+    running on however many legs happen to resolve."""
+    strategy_file = tmp_path / "drifted_contract.py"
+    strategy_file.write_text(
+        "import backtrader as bt\n\n"
+        "ASSET_UNIVERSE = ['SPY', 'GOLD', 'OIL']\n\n"
+        "class DriftedProbe(bt.Strategy):\n"
+        "    REQUIRED_FEEDS = 5\n\n"
+        "    def next(self):\n"
+        "        pass\n"
+    )
+
+    with pytest.raises(FeedArityError, match="drifted out of sync"):
+        run_command(
+            operations=["SPY"],
+            start="2024-01-01",
+            end="2024-01-10",
+            initial_cash=10000.0,
+            tx_cost_bps=10,
+            slippage_bps=5,
+            artifact_dir=tmp_path,
+            strategy_path=strategy_file,
+            fetcher=_fake_fetch,
+        )
+
+
 def test_pairs_strategy_has_no_universe_composite(tmp_path: Path) -> None:
     """Pairs strategies are unaffected by the declared-universe routing/composite
     change — they already resolve their two legs via _pair_legs."""

--- a/analytics-engine/tests/test_cli.py
+++ b/analytics-engine/tests/test_cli.py
@@ -243,3 +243,225 @@ def test_run_command_fails_closed_on_single_symbol_pairs_universe(tmp_path: Path
             strategy_path=strategy_file,
             fetcher=_fake_fetch,
         )
+
+
+# ── Declared-universe routing (backtest-vol audit) ──────────────────────────
+#
+# Regression coverage for: every single-feed strategy — regardless of its own
+# ASSET_UNIVERSE — was unconditionally backtested on BACKTEST_OPERATIONS
+# (default ["SPY"]), because run_command's single-feed branch never consulted
+# the strategy's own declared universe. capital_preservation_tbill (declares
+# ["BIL"]) and maillard_2010_risk_parity (declares 5 non-SPY-only assets)
+# were both graded on pure SPY returns as a result.
+
+
+def _write_single_feed_strategy(path: Path, universe: str) -> None:
+    path.write_text(
+        "import backtrader as bt\n\n"
+        f"ASSET_UNIVERSE = {universe}\n\n"
+        "class SingleFeedProbe(bt.Strategy):\n"
+        "    def next(self):\n"
+        "        if not self.position:\n"
+        "            self.buy(size=1)\n"
+    )
+
+
+def _symbol_series(symbol: str, start_date: str, closes: list[float]) -> pd.DataFrame:
+    idx = pd.date_range(start_date, periods=len(closes), freq="D")
+    return pd.DataFrame(
+        {
+            "Open": closes,
+            "High": [c + 1 for c in closes],
+            "Low": [c - 1 for c in closes],
+            "Close": closes,
+            "Volume": [1000] * len(closes),
+        },
+        index=idx,
+    )
+
+
+def _make_fetcher(by_symbol: dict[str, pd.DataFrame]):
+    requested: list[str] = []
+
+    def fetch(symbol: str, start: str, end: str) -> pd.DataFrame:
+        requested.append(symbol)
+        if symbol not in by_symbol:
+            raise AssertionError(f"unexpected symbol fetched: {symbol!r} (declared universe was overridden)")
+        return by_symbol[symbol]
+
+    fetch.requested = requested  # type: ignore[attr-defined]
+    return fetch
+
+
+def test_declared_universe_is_backtested_not_the_benchmark_default(tmp_path: Path) -> None:
+    """The core regression guard: a strategy declaring a non-SPY universe must
+    be backtested on THAT universe. Must FAIL without the fix (the old code
+    always used `operations`, here simulating BACKTEST_OPERATIONS=["SPY"])."""
+    strategy_file = tmp_path / "tbill_probe.py"
+    _write_single_feed_strategy(strategy_file, universe="['BIL']")
+
+    fetcher = _make_fetcher({"BIL": _symbol_series("BIL", "2024-01-01", [100.0] * 5)})
+
+    output = run_command(
+        operations=["SPY"],  # BACKTEST_OPERATIONS default — must NOT win
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=fetcher,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    assert payload["operations"] == ["BIL"]
+    assert fetcher.requested == ["BIL"]
+    op_names = {r["operation"] for r in payload["results"]}
+    assert "SPY" not in op_names
+    assert "BIL" in op_names
+
+
+def test_backtest_operations_does_not_override_a_declared_universe(tmp_path: Path) -> None:
+    """Even a multi-symbol BACKTEST_OPERATIONS benchmark list must never leak
+    into a strategy that declares its own universe."""
+    strategy_file = tmp_path / "oil_gold_probe.py"
+    _write_single_feed_strategy(strategy_file, universe="['OIL', 'GOLD']")
+
+    fetcher = _make_fetcher(
+        {
+            "CL=F": _symbol_series("CL=F", "2024-01-01", [50.0] * 5),
+            "GC=F": _symbol_series("GC=F", "2024-01-01", [1800.0] * 5),
+        }
+    )
+
+    output = run_command(
+        operations=["SPY", "TREASURY", "NIKKEI"],  # a differently-shaped benchmark list
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=fetcher,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    assert payload["operations"] == ["OIL", "GOLD"]
+    assert set(fetcher.requested) == {"CL=F", "GC=F"}
+    op_names = {r["operation"] for r in payload["results"]}
+    assert op_names == {"OIL", "GOLD", "UNIVERSE"}
+
+
+def test_no_declared_universe_still_falls_back_to_passed_operations(tmp_path: Path) -> None:
+    """A strategy with no ASSET_UNIVERSE at all keeps today's behavior exactly:
+    no UNIVERSE composite is fabricated when there is no declared universe to
+    composite over."""
+    strategy_file = tmp_path / "no_universe_probe.py"
+    _write_minimal_strategy(strategy_file)
+
+    output = run_command(
+        operations=["SPY", "OIL"],
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=_fake_fetch,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    op_names = {r["operation"] for r in payload["results"]}
+    assert op_names == {"SPY", "OIL"}
+    assert "UNIVERSE" not in op_names
+
+
+def test_universe_composite_equals_single_run_for_one_asset_universe(tmp_path: Path) -> None:
+    strategy_file = tmp_path / "single_asset_universe.py"
+    _write_single_feed_strategy(strategy_file, universe="['OIL']")
+
+    fetcher = _make_fetcher({"CL=F": _symbol_series("CL=F", "2024-01-01", [50.0, 51.0, 49.5, 52.0, 53.0])})
+
+    output = run_command(
+        operations=["SPY"],
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=fetcher,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    by_op = {r["operation"]: r for r in payload["results"]}
+    assert set(by_op) == {"OIL", "UNIVERSE"}
+    assert by_op["UNIVERSE"]["constituent_operations"] == ["OIL"]
+    assert by_op["UNIVERSE"]["metrics"]["daily_returns"] == pytest.approx(by_op["OIL"]["metrics"]["daily_returns"])
+    assert by_op["UNIVERSE"]["metrics"]["daily_return_dates"] == by_op["OIL"]["metrics"]["daily_return_dates"]
+    assert by_op["UNIVERSE"]["metrics"]["equity_curve"] == pytest.approx(by_op["OIL"]["metrics"]["equity_curve"])
+
+
+def test_universe_composite_aligns_on_date_intersection(tmp_path: Path) -> None:
+    """Two declared legs with deliberately different calendars (mirrors
+    ^N225 vs CL=F): the composite must use only the OVERLAPPING dates, not a
+    naive positional zip."""
+    strategy_file = tmp_path / "misaligned_calendars.py"
+    _write_single_feed_strategy(strategy_file, universe="['NIKKEI', 'OIL']")
+
+    # NIKKEI trades 01-01..01-04; OIL trades 01-02..01-05 — a 3-day overlap.
+    nikkei = _symbol_series("^N225", "2024-01-01", [100.0, 110.0, 121.0, 133.1])
+    oil = _symbol_series("CL=F", "2024-01-02", [50.0, 55.0, 60.5, 66.55])
+    fetcher = _make_fetcher({"^N225": nikkei, "CL=F": oil})
+
+    output = run_command(
+        operations=["SPY"],
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=0,
+        slippage_bps=0,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=fetcher,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    by_op = {r["operation"]: r for r in payload["results"]}
+    universe_dates = by_op["UNIVERSE"]["metrics"]["daily_return_dates"]
+    nikkei_dates = set(by_op["NIKKEI"]["metrics"]["daily_return_dates"])
+    oil_dates = set(by_op["OIL"]["metrics"]["daily_return_dates"])
+    expected_dates = sorted(nikkei_dates & oil_dates)
+
+    assert universe_dates == expected_dates
+    assert len(universe_dates) < len(by_op["NIKKEI"]["metrics"]["daily_return_dates"])
+    assert len(universe_dates) < len(by_op["OIL"]["metrics"]["daily_return_dates"])
+
+
+def test_pairs_strategy_has_no_universe_composite(tmp_path: Path) -> None:
+    """Pairs strategies are unaffected by the declared-universe routing/composite
+    change — they already resolve their two legs via _pair_legs."""
+    strategy_file = tmp_path / "pairs_unaffected.py"
+    _write_pairs_strategy(strategy_file)
+
+    output = run_command(
+        operations=["SPY"],
+        start="2024-01-01",
+        end="2024-01-10",
+        initial_cash=10000.0,
+        tx_cost_bps=10,
+        slippage_bps=5,
+        artifact_dir=tmp_path,
+        strategy_path=strategy_file,
+        fetcher=_fake_fetch,
+    )
+
+    payload = json.loads(Path(output["artifact_path"]).read_text())
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["operation"] == "GLD/GDX"
+    op_names = {r["operation"] for r in payload["results"]}
+    assert "UNIVERSE" not in op_names

--- a/analytics-engine/tests/test_engine_coverage.py
+++ b/analytics-engine/tests/test_engine_coverage.py
@@ -19,12 +19,15 @@ from archimedes_analytics_engine.engine import (
     RF_ANNUAL,
     RF_DAILY,
     BacktestResult,
+    BuyAndHoldStrategy,
     _build_equity_curve,
     _compute_cagr,
     _compute_sortino,
+    _max_drawdown_from_curve,
     _safe_get,
     _sharpe_bt_convention,
     _trade_stats,
+    combine_universe_results,
     run_backtest,
     run_buy_and_hold,
 )
@@ -279,3 +282,71 @@ def test_buy_and_hold_deploys_capital_on_rising_feed() -> None:
     assert result.total_return_pct > 0
     assert result.traded_notional > 0.0
     assert len(result.equity_curve) == result.bars + 1
+
+
+# ── _max_drawdown_from_curve duration semantics ─────────────────────────────
+#
+# Regression coverage: the duration counter must reset whenever the CURRENT
+# bar sits exactly AT the running peak (drawdown == 0), matching backtrader's
+# own DrawDown analyzer (`r.len = r.len + 1 if drawdown else 0`) — not only on
+# a STRICTLY NEW all-time high. The old `value > peak` reset condition left a
+# bar that merely equals the prior peak still counted as "in drawdown".
+
+
+def test_max_drawdown_from_curve_duration_resets_when_curve_retouches_peak() -> None:
+    """Hand-verified against backtrader's own reset rule. The curve dips from
+    its opening peak (100), partially recovers, RETOUCHES that same peak
+    (100) without ever exceeding it, dips again, retouches it a second time,
+    then finally breaks to a genuine new high (110).
+
+    Correct (backtrader) semantics: the counter resets to 0 every time the
+    curve is back at 100 (drawdown == 0), so the longest streak is the
+    3-bar stretch [90, 80, 90] before the first retouch — max_len == 3.
+
+    The pre-fix implementation only reset on a STRICTLY new high
+    (`value > peak`), so retouching a prior peak without exceeding it did NOT
+    reset the counter: it kept incrementing through both retouches and every
+    down-day in between, hand-computed to max_len == 8 on this exact curve —
+    proving this test fails without the fix.
+    """
+    curve = [100, 90, 80, 90, 100, 95, 90, 100, 110, 100, 95]
+
+    max_dd, max_len = _max_drawdown_from_curve(curve)
+
+    assert max_dd == pytest.approx(20.0)  # peak-to-trough 100 -> 80, unaffected by the duration bug
+    assert max_len == 3
+    # The bug this pins: the old `value > peak`-only reset would have produced 8 here.
+    assert max_len != 8
+
+
+def test_max_drawdown_from_curve_duration_matches_backtrader_dd_analyzer() -> None:
+    """Cross-validate the reimplementation against a REAL cerebro run's own
+    ``bt.analyzers.DrawDown`` output (the ground truth _max_drawdown_from_curve
+    is standing in for, per its own docstring) via the single-asset composite
+    identity: ``combine_universe_results`` on a ONE-constituent list must
+    reproduce ``max_drawdown_duration_bars`` exactly, not just the equity
+    curve and daily returns the pre-existing composite test already pins.
+    """
+    idx = pd.date_range("2022-01-01", periods=11, freq="D")
+    # Same shape as the hand-verified curve above (dip, partial recovery
+    # retouching the open, dip again, retouch again, then a genuine new high)
+    # expressed as a price series so a REAL BuyAndHold cerebro run exercises
+    # backtrader's own DrawDown analyzer on it.
+    closes = [100.0, 100.0, 90.0, 80.0, 90.0, 100.0, 95.0, 90.0, 100.0, 110.0, 100.0]
+    prices = pd.DataFrame(
+        {
+            "Open": closes,
+            "High": [c + 1 for c in closes],
+            "Low": [c - 1 for c in closes],
+            "Close": closes,
+            "Volume": [1_000] * len(closes),
+        },
+        index=idx,
+    )
+
+    solo = run_backtest(prices, strategy_cls=BuyAndHoldStrategy, initial_cash=10_000.0, transaction_cost_bps=0)
+    assert solo.max_drawdown_duration_bars is not None  # the curve does draw down; guard against a vacuous pass
+
+    composite = combine_universe_results([("SOLO", solo)], initial_cash=10_000.0)
+
+    assert composite.max_drawdown_duration_bars == solo.max_drawdown_duration_bars

--- a/analytics-engine/tests/test_instruments.py
+++ b/analytics-engine/tests/test_instruments.py
@@ -1,11 +1,15 @@
 import json
 from importlib import resources
+from pathlib import Path
 
 import archimedes_analytics_engine.instruments as instruments_mod
 from archimedes_analytics_engine.instruments import (
     OPERATION_TO_SYMBOL,
     resolve_operations,
 )
+from archimedes_analytics_engine.strategy_loader import load_strategy
+
+_STRATEGIES_DIR = Path(__file__).parent.parent / "strategies"
 
 
 def test_operations_include_required_assets() -> None:
@@ -69,3 +73,41 @@ def test_load_falls_back_when_resource_missing(monkeypatch) -> None:
     monkeypatch.setattr(instruments_mod, "_SSOT_RESOURCE", "data/does_not_exist.json")
     loaded = instruments_mod._load_operation_to_symbol()
     assert loaded == instruments_mod._FALLBACK_OPERATION_TO_SYMBOL
+
+
+# ─── Declared-universe backfill (backtest-vol audit) ──────────────────────
+#
+# BIL (capital_preservation_tbill) and TLT (gatev_2006_portfolio_of_pairs)
+# were the two ASSET_UNIVERSE tickers among the 34 curated strategies that
+# were not yet operation keys — cli.run_command's declared-universe routing
+# needs resolve_operations to succeed for every strategy's own universe.
+
+
+def test_all_curated_strategies_declared_universe_resolves() -> None:
+    strategy_files = sorted(_STRATEGIES_DIR.glob("*.py"))
+    assert len(strategy_files) == 34, (
+        f"expected 34 curated strategy files, found {len(strategy_files)} — "
+        "update this test if the curated library size changed intentionally"
+    )
+
+    unresolved: dict[str, list[str]] = {}
+    resolved_count = 0
+    for path in strategy_files:
+        bundle = load_strategy(path)
+        universe = bundle.metadata.get("asset_universe") or []
+        try:
+            resolve_operations(universe)
+            resolved_count += 1
+        except ValueError:
+            bad = [op for op in universe if op.upper() not in OPERATION_TO_SYMBOL]
+            unresolved[path.name] = bad
+
+    assert not unresolved, f"strategies with unresolved ASSET_UNIVERSE entries: {unresolved}"
+    assert resolved_count == 34
+
+
+def test_bil_and_tlt_are_operation_keys() -> None:
+    # BIL: SPDR Bloomberg 1-3 Month T-Bill ETF (capital_preservation_tbill's cash leg).
+    # TLT: iShares 20+ Year Treasury Bond ETF (gatev_2006_portfolio_of_pairs universe entry).
+    assert OPERATION_TO_SYMBOL["BIL"] == "BIL"
+    assert OPERATION_TO_SYMBOL["TLT"] == "TLT"

--- a/analytics-engine/tests/test_multi_engine.py
+++ b/analytics-engine/tests/test_multi_engine.py
@@ -8,6 +8,7 @@ two-asset runners. Mirrors test_pairs_engine.py.
 
 from __future__ import annotations
 
+import logging
 import math
 
 import backtrader as bt
@@ -103,6 +104,33 @@ def test_run_multi_backtest_honors_named_feeds() -> None:
     result = run_multi_backtest(frames, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0, names=["SPY", "GLD"])
     assert isinstance(result, BacktestResult)
     assert result.bars == 30
+
+
+def test_run_multi_backtest_warns_loudly_on_material_truncation(caplog: pytest.LogCaptureFixture) -> None:
+    """One feed with much shorter available history than the others (a late
+    listing, a yfinance gap, ...) must produce a WARNING, not a silent N-way
+    intersection down to that feed's short window (item 3, extended to the
+    N-feed runner for the same reason combine_universe_results needs it)."""
+    long_feed = _synthetic_prices(50, start="2020-01-01", base=100.0)
+    short_feed = _synthetic_prices(5, start="2020-01-01", base=50.0)  # only 5 of 50 bars
+
+    with caplog.at_level(logging.WARNING, logger="archimedes_analytics_engine.engine"):
+        result = run_multi_backtest(
+            [long_feed, short_feed], strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0, names=["LONG", "SHORT"]
+        )
+
+    assert result.bars == 5
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "retained 5 bars" in warnings[0].getMessage()
+    assert "50 bars" in warnings[0].getMessage()
+
+
+def test_run_multi_backtest_stays_quiet_on_full_overlap(caplog: pytest.LogCaptureFixture) -> None:
+    frames = [_synthetic_prices(40, base=100.0), _synthetic_prices(40, base=50.0)]
+    with caplog.at_level(logging.WARNING, logger="archimedes_analytics_engine.engine"):
+        run_multi_backtest(frames, strategy_cls=_EqualWeightStrategy, initial_cash=100_000.0)
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
 
 
 def test_run_multi_backtest_matches_pairs_for_two_feeds() -> None:

--- a/analytics-engine/tests/test_required_feeds.py
+++ b/analytics-engine/tests/test_required_feeds.py
@@ -1,0 +1,114 @@
+"""Tests for engine.required_feeds() and the REQUIRED_FEEDS_UNIVERSE sentinel.
+
+Hermetic: hand-built bt.Strategy subclasses, no network. Covers the feed-count
+contract cli.run_command's router depends on (backtest-vol audit item 1b): a
+plain int (1 default, 2 for pairs), the "UNIVERSE" sentinel for cross-sectional
+strategies, and the fail-loud behavior for a malformed declaration — the whole
+point being that the router must never silently downgrade a multi-feed
+strategy to a single-feed run.
+"""
+
+from __future__ import annotations
+
+import backtrader as bt
+import pytest
+from archimedes_analytics_engine.engine import (
+    REQUIRED_FEEDS_UNIVERSE,
+    FeedArityError,
+    required_feeds,
+)
+
+
+class _NoDeclaration(bt.Strategy):
+    def next(self) -> None:
+        pass
+
+
+class _ExplicitOne(bt.Strategy):
+    REQUIRED_FEEDS = 1
+
+    def next(self) -> None:
+        pass
+
+
+class _PairsTwo(bt.Strategy):
+    REQUIRED_FEEDS = 2
+
+    def next(self) -> None:
+        pass
+
+
+class _CrossSectional(bt.Strategy):
+    REQUIRED_FEEDS = "UNIVERSE"
+
+    def next(self) -> None:
+        pass
+
+
+class _CrossSectionalLowercase(bt.Strategy):
+    # Case-insensitive: "universe" (lowercase) must still resolve to the sentinel.
+    REQUIRED_FEEDS = "universe"
+
+    def next(self) -> None:
+        pass
+
+
+class _Typo(bt.Strategy):
+    REQUIRED_FEEDS = "Univers"  # plausible typo — must fail loud, not silently become 1
+
+    def next(self) -> None:
+        pass
+
+
+class _MalformedNone(bt.Strategy):
+    REQUIRED_FEEDS = None
+
+    def next(self) -> None:
+        pass
+
+
+class _ExplicitFive(bt.Strategy):
+    # A hypothetical strategy declaring an exact N > 2 rather than the sentinel.
+    REQUIRED_FEEDS = 5
+
+    def next(self) -> None:
+        pass
+
+
+def test_undeclared_defaults_to_one() -> None:
+    assert required_feeds(_NoDeclaration) == 1
+
+
+def test_explicit_one_is_one() -> None:
+    assert required_feeds(_ExplicitOne) == 1
+
+
+def test_pairs_two_is_two() -> None:
+    assert required_feeds(_PairsTwo) == 2
+
+
+def test_universe_sentinel_returns_sentinel() -> None:
+    assert required_feeds(_CrossSectional) == REQUIRED_FEEDS_UNIVERSE
+
+
+def test_universe_sentinel_is_case_insensitive() -> None:
+    assert required_feeds(_CrossSectionalLowercase) == REQUIRED_FEEDS_UNIVERSE
+
+
+def test_explicit_int_greater_than_two_passes_through() -> None:
+    assert required_feeds(_ExplicitFive) == 5
+
+
+def test_malformed_none_falls_back_to_one() -> None:
+    # `REQUIRED_FEEDS = None` predates this contract's typed-string handling;
+    # preserve the pre-existing graceful fallback for non-string garbage.
+    assert required_feeds(_MalformedNone) == 1
+
+
+def test_typo_string_fails_loud_instead_of_silently_downgrading() -> None:
+    """The whole point of the sentinel: a near-miss string must never
+    silently collapse to the single-feed default of 1 — that would be
+    exactly the "plausible-looking but wrong" defect this module exists to
+    eliminate."""
+    with pytest.raises(FeedArityError, match="REQUIRED_FEEDS='Univers'"):
+        required_feeds(_Typo)

--- a/analytics-engine/tests/test_strategy_loader.py
+++ b/analytics-engine/tests/test_strategy_loader.py
@@ -135,6 +135,45 @@ def test_pairs_family_declares_required_feeds() -> None:
         assert bundle.metadata.get("required_feeds") == 2, f"{filename} missing REQUIRED_FEEDS=2"
 
 
+# The definitive cross-sectional / portfolio family (backtest-vol audit item
+# 1a): every strategy class whose next() reads self.datas beyond index 0 —
+# established by direct code inspection, not docstring grepping — and so
+# must route through engine.run_multi_backtest rather than the single-feed
+# per-asset loop. 13 strategies, not the 11 an initial docstring-only sweep
+# found: novy_marx_2012_quality_momentum and asness_moskowitz_2013_value are
+# genuinely cross-sectional (`for d in self.datas`) but were not covered by
+# any existing run_multi_backtest test file either.
+_CROSS_SECTIONAL_STRATEGY_FILES = [
+    "ang_hodrick_2006_low_idiovol.py",
+    "antonacci_2014_dual_momentum.py",
+    "arnott_2019_defensive_quality.py",
+    "asness_moskowitz_2013_value.py",
+    "avellaneda_lee_2010_pca_statarb.py",
+    "blitz_hanauer_2010_rmom.py",
+    "frazzini_pedersen_2014_bab.py",
+    "gatev_2006_portfolio_of_pairs.py",
+    "jegadeesh_titman_1993_cross_sectional_momentum.py",
+    "low_tan_wermers_2004_dividend_yield.py",
+    "maillard_2010_risk_parity.py",
+    "novy_marx_2012_quality_momentum.py",
+    "novy_marx_2013_qmj.py",
+]
+
+
+def test_cross_sectional_family_declares_required_feeds_universe() -> None:
+    """Every cross-sectional / portfolio strategy must carry the
+    REQUIRED_FEEDS="UNIVERSE" runner contract so cli.run_command routes it
+    through run_multi_backtest on its own declared universe instead of
+    silently averaging N independent single-asset runs (backtest-vol audit)."""
+    for filename in _CROSS_SECTIONAL_STRATEGY_FILES:
+        bundle = load_strategy(_STRATEGIES_DIR / filename)
+        assert bundle.metadata.get("required_feeds") == "UNIVERSE", f"{filename} missing REQUIRED_FEEDS='UNIVERSE'"
+        # Every one of these must also declare a >=2-asset universe for the
+        # sentinel to mean anything — a 1-asset "cross-sectional" strategy is
+        # a contradiction in terms.
+        assert len(bundle.metadata.get("asset_universe") or []) >= 2, f"{filename} declares too small a universe"
+
+
 def test_pairs_strategy_declares_two_asset_universe() -> None:
     """The Gatev pairs strategy must declare exactly two assets (it is multi-asset)."""
     import importlib.util

--- a/analytics-engine/tests/test_universe_composite.py
+++ b/analytics-engine/tests/test_universe_composite.py
@@ -10,8 +10,16 @@ test_multi_engine.py.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
-from archimedes_analytics_engine.engine import BacktestResult, combine_universe_results
+from archimedes_analytics_engine.engine import (
+    BacktestResult,
+    combine_universe_results,
+    coverage_summary,
+    universe_date_coverage,
+    warn_on_truncated_coverage,
+)
 
 
 def _result(dates: list[str], returns: list[float], *, tx_bps: int = 10, slip_bps: int = 5) -> BacktestResult:
@@ -115,3 +123,85 @@ def test_look_ahead_audit_passed_is_and_of_constituents() -> None:
 
     both_clean = combine_universe_results([("A", clean), ("B", clean)], initial_cash=100_000.0)
     assert both_clean.look_ahead_audit_passed is True
+
+
+# ── Date-coverage recording + loud-truncation warning (item 3) ──────────────
+
+
+def test_coverage_summary_shape() -> None:
+    summary = coverage_summary({"A": 100, "B": 80}, 75)
+    assert summary == {
+        "per_constituent_bars": {"A": 100, "B": 80},
+        "intersection_bars": 75,
+        "longest_constituent_bars": 100,
+        "intersection_ratio": pytest.approx(0.75),
+    }
+
+
+def test_coverage_summary_empty_constituents_has_no_ratio() -> None:
+    summary = coverage_summary({}, 0)
+    assert summary["longest_constituent_bars"] == 0
+    assert summary["intersection_ratio"] is None
+
+
+def test_universe_date_coverage_matches_combine_universe_results_intersection() -> None:
+    a = _result(["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"], [0.01, 0.02, 0.01, 0.0])
+    b = _result(["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"], [0.01, 0.02, 0.01, 0.0])
+
+    coverage = universe_date_coverage([("A", a), ("B", b)])
+
+    assert coverage["per_constituent_bars"] == {"A": 4, "B": 4}
+    assert coverage["intersection_bars"] == 3  # 01-02, 01-03, 01-04 overlap
+    assert coverage["longest_constituent_bars"] == 4
+    assert coverage["intersection_ratio"] == pytest.approx(0.75)
+
+
+def test_combine_universe_results_warns_loudly_on_material_truncation(caplog: pytest.LogCaptureFixture) -> None:
+    """A constituent with much shorter available history than the others must
+    produce a WARNING naming the retained/longest bar counts — distinguishing
+    "legitimate limited overlap" from "one feed is truncated or
+    data-quality-broken" (item 3)."""
+    long_dates = [f"2024-{m:02d}-01" for m in range(1, 11)]  # 10 dates
+    short_dates = long_dates[:2]  # only the first 2 overlap — 20% retained
+    long_run = _result(long_dates, [0.01] * len(long_dates))
+    short_run = _result(short_dates, [0.02] * len(short_dates))
+
+    with caplog.at_level(logging.WARNING, logger="archimedes_analytics_engine.engine"):
+        composite = combine_universe_results([("LONG", long_run), ("SHORT", short_run)], initial_cash=100_000.0)
+
+    assert composite.bars == 2
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "retained 2 bars" in message
+    assert "10 bars" in message
+    assert "20.0%" in message
+
+
+def test_combine_universe_results_stays_quiet_on_ordinary_calendar_noise(caplog: pytest.LogCaptureFixture) -> None:
+    """Losing a small, ordinary fraction of bars (different market holidays
+    between two liquid feeds) must NOT trigger the loud-truncation warning —
+    only material loss should."""
+    dates_a = [f"2024-01-{d:02d}" for d in range(1, 21)]  # 20 dates
+    dates_b = [f"2024-01-{d:02d}" for d in range(1, 19)]  # 18 dates — 90% overlap
+    a = _result(dates_a, [0.01] * len(dates_a))
+    b = _result(dates_b, [0.01] * len(dates_b))
+
+    with caplog.at_level(logging.WARNING, logger="archimedes_analytics_engine.engine"):
+        combine_universe_results([("A", a), ("B", b)], initial_cash=100_000.0)
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_warn_on_truncated_coverage_is_a_noop_below_threshold(caplog: pytest.LogCaptureFixture) -> None:
+    coverage = coverage_summary({"A": 100, "B": 95}, 95)  # 95% retained
+    with caplog.at_level(logging.WARNING, logger="archimedes_analytics_engine.engine"):
+        warn_on_truncated_coverage("test-context", coverage)
+    assert not caplog.records
+
+
+def test_warn_on_truncated_coverage_handles_zero_longest_without_error(caplog: pytest.LogCaptureFixture) -> None:
+    coverage = coverage_summary({}, 0)
+    with caplog.at_level(logging.WARNING, logger="archimedes_analytics_engine.engine"):
+        warn_on_truncated_coverage("test-context", coverage)
+    assert not caplog.records

--- a/analytics-engine/tests/test_universe_composite.py
+++ b/analytics-engine/tests/test_universe_composite.py
@@ -1,0 +1,117 @@
+"""Tests for engine.combine_universe_results — the equal-weighted,
+date-intersection-aligned composite across a strategy's declared
+ASSET_UNIVERSE (backtest-vol audit).
+
+Hermetic: operates directly on hand-built BacktestResult objects, no
+backtrader/network involved — isolates the aggregation math from the
+per-asset backtest runners already covered by test_engine.py /
+test_multi_engine.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes_analytics_engine.engine import BacktestResult, combine_universe_results
+
+
+def _result(dates: list[str], returns: list[float], *, tx_bps: int = 10, slip_bps: int = 5) -> BacktestResult:
+    equity = [100_000.0]
+    for r in returns:
+        equity.append(equity[-1] * (1.0 + r))
+    return BacktestResult(
+        final_value=equity[-1],
+        total_return_pct=((equity[-1] / equity[0]) - 1.0) * 100.0,
+        equity_curve=equity,
+        daily_returns=list(returns),
+        daily_return_dates=list(dates),
+        transaction_cost_bps=tx_bps,
+        slippage_bps=slip_bps,
+        look_ahead_audit_passed=True,
+        bars=len(returns),
+        backtest_start=dates[0] if dates else None,
+        backtest_end=dates[-1] if dates else None,
+    )
+
+
+def test_single_asset_universe_is_numerically_identical_to_the_single_run() -> None:
+    dates = ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"]
+    returns = [0.01, -0.02, 0.015, 0.0]
+    solo = _result(dates, returns)
+
+    composite = combine_universe_results([("BIL", solo)], initial_cash=100_000.0)
+
+    assert composite.daily_return_dates == solo.daily_return_dates
+    assert composite.daily_returns == pytest.approx(solo.daily_returns)
+    assert composite.equity_curve == pytest.approx(solo.equity_curve)
+    assert composite.final_value == pytest.approx(solo.final_value)
+    assert composite.bars == solo.bars
+    assert composite.backtest_start == solo.backtest_start
+    assert composite.backtest_end == solo.backtest_end
+
+
+def test_two_asset_composite_is_equal_weighted_mean_on_full_overlap() -> None:
+    dates = ["2024-01-02", "2024-01-03", "2024-01-04"]
+    a = _result(dates, [0.02, 0.00, -0.01])
+    b = _result(dates, [0.00, 0.04, 0.03])
+
+    composite = combine_universe_results([("A", a), ("B", b)], initial_cash=100_000.0)
+
+    assert composite.daily_return_dates == dates
+    assert composite.daily_returns == pytest.approx([0.01, 0.02, 0.01])
+    assert composite.bars == 3
+
+
+def test_composite_aligns_on_date_intersection_not_position() -> None:
+    """The exact regression this composite exists to prevent: two feeds whose
+    calendars genuinely differ (e.g. ^N225 vs CL=F) must be aligned by DATE,
+    never by list position — a positional zip would silently splice unrelated
+    trading days together and produce a plausible-but-wrong series."""
+    # Asset A (e.g. a Tokyo-calendar feed): trades Mon/Tue/Wed/Thu.
+    dates_a = ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]
+    returns_a = [0.10, 0.20, 0.30, 0.40]
+    # Asset B (e.g. a futures feed): trades Tue/Wed/Thu/Fri — offset by one day,
+    # same LENGTH as A, so a positional zip would "align" but be wrong.
+    dates_b = ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"]
+    returns_b = [1.0, 2.0, 3.0, 4.0]
+
+    a = _result(dates_a, returns_a)
+    b = _result(dates_b, returns_b)
+
+    composite = combine_universe_results([("A", a), ("B", b)], initial_cash=100_000.0)
+
+    # Only the overlapping dates (01-02, 01-03, 01-04) survive.
+    assert composite.daily_return_dates == ["2024-01-02", "2024-01-03", "2024-01-04"]
+    assert composite.bars == 3
+    # Correct (date-aligned) means: (0.20+1.0)/2, (0.30+2.0)/2, (0.40+3.0)/2.
+    assert composite.daily_returns == pytest.approx([0.6, 1.15, 1.7])
+    # A naive positional zip (index 0 of A with index 0 of B, etc.) would
+    # instead produce (0.10+1.0)/2, (0.20+2.0)/2, (0.30+3.0)/2, ... — assert
+    # the composite is NOT that wrong series.
+    wrong_positional = [(0.10 + 1.0) / 2, (0.20 + 2.0) / 2, (0.30 + 3.0) / 2]
+    assert composite.daily_returns != pytest.approx(wrong_positional)
+
+
+def test_no_common_dates_raises() -> None:
+    a = _result(["2024-01-02"], [0.01])
+    b = _result(["2024-06-01"], [0.02])
+
+    with pytest.raises(ValueError, match="no common trading dates"):
+        combine_universe_results([("A", a), ("B", b)], initial_cash=100_000.0)
+
+
+def test_combine_universe_results_requires_at_least_one_result() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        combine_universe_results([], initial_cash=100_000.0)
+
+
+def test_look_ahead_audit_passed_is_and_of_constituents() -> None:
+    dates = ["2024-01-02", "2024-01-03"]
+    clean = _result(dates, [0.01, 0.02])
+    dirty = _result(dates, [0.01, 0.02])
+    dirty.look_ahead_audit_passed = False
+
+    composite = combine_universe_results([("A", clean), ("B", dirty)], initial_cash=100_000.0)
+    assert composite.look_ahead_audit_passed is False
+
+    both_clean = combine_universe_results([("A", clean), ("B", clean)], initial_cash=100_000.0)
+    assert both_clean.look_ahead_audit_passed is True

--- a/backend/archimedes/services/backtest_mapper.py
+++ b/backend/archimedes/services/backtest_mapper.py
@@ -67,6 +67,10 @@ class OperationResultModel(BaseModel):
     operation: str
     symbol: str
     metrics: EngineMetricsModel
+    # Present only on the "UNIVERSE" composite row (analytics-engine
+    # cli.run_command's declared-universe path) — the per-asset operations it
+    # was averaged from. Absent/empty on every ordinary per-asset row.
+    constituent_operations: list[str] = Field(default_factory=list)
 
 
 class StrategyBlockModel(BaseModel):
@@ -128,6 +132,16 @@ def select_operation_result(
         for row in artifact.results:
             if row.operation.upper() == wanted:
                 return row
+
+    # The "UNIVERSE" composite (cli.run_command's declared-universe path —
+    # equal-weighted, date-aligned across every asset the strategy declares)
+    # represents the strategy applied across its own declared universe, not
+    # just one leg of it. Grade that ahead of "SPY", which is just one of
+    # potentially several declared assets and is no longer special once a
+    # genuine composite exists (backtest-vol audit; see cli.py).
+    for row in artifact.results:
+        if row.operation.upper() == "UNIVERSE":
+            return row
 
     for row in artifact.results:
         if row.operation.upper() == "SPY":

--- a/backend/tests/test_backtest_mapper.py
+++ b/backend/tests/test_backtest_mapper.py
@@ -7,6 +7,7 @@ import pytest
 from archimedes.services.backtest_mapper import (
     AnalyticsArtifactModel,
     map_artifact_to_backtest_result,
+    select_operation_result,
 )
 
 
@@ -38,3 +39,82 @@ def test_mapper_preserves_buy_hold_sharpe() -> None:
     assert result.sharpe_ratio == pytest.approx(0.7135863248834242)
     assert result.max_drawdown == pytest.approx(0.3407931346227104)
     assert result.backtest_code_hash == artifact.strategy.backtest_code_hash
+
+
+def _minimal_metrics(sharpe: float) -> dict:
+    return {
+        "sharpe_ratio": sharpe,
+        "sortino_ratio": None,
+        "calmar_ratio": None,
+        "max_drawdown_pct": None,
+        "cagr": None,
+        "win_rate": None,
+        "profit_factor": None,
+        "total_trades": 0,
+        "avg_holding_period_days": None,
+        "correlation_to_spy": None,
+        "correlation_to_btc": None,
+        "equity_curve": [100000.0, 101000.0],
+        "monthly_returns": [],
+        "backtest_start": "2018-01-01",
+        "backtest_end": "2026-01-01",
+        "look_ahead_audit_passed": True,
+        "backtest_engine": "backtrader",
+        "transaction_cost_bps": 10,
+    }
+
+
+def _universe_artifact(*, universe_present: bool) -> dict:
+    results = [
+        {"operation": "SPY", "symbol": "SPY", "metrics": _minimal_metrics(0.7)},
+        {"operation": "NIKKEI", "symbol": "^N225", "metrics": _minimal_metrics(0.3)},
+    ]
+    if universe_present:
+        results.append(
+            {
+                "operation": "UNIVERSE",
+                "symbol": "SPY/NIKKEI",
+                "constituent_operations": ["SPY", "NIKKEI"],
+                "metrics": _minimal_metrics(0.5),
+            }
+        )
+    return {
+        "run_id": "r1",
+        "strategy": {"backtest_code_hash": "a" * 64, "paper_claimed_sharpe": None},
+        "assumptions": {"transaction_cost_bps": 10},
+        "integrity_flags": {"lookahead_audit_passed": True},
+        "results": results,
+    }
+
+
+def test_select_operation_result_prefers_universe_composite_over_spy() -> None:
+    """The regression this exists for: once a strategy declares a real,
+    non-trivial universe, "SPY" is just one of N declared assets — the
+    UNIVERSE composite (representing the whole declared universe) must be
+    selected ahead of it, not the other way around. Must FAIL without the fix
+    (old code always picked "SPY" first)."""
+    artifact = AnalyticsArtifactModel.model_validate(_universe_artifact(universe_present=True))
+
+    chosen = select_operation_result(artifact)
+
+    assert chosen.operation == "UNIVERSE"
+    assert chosen.metrics.sharpe_ratio == pytest.approx(0.5)
+    assert chosen.constituent_operations == ["SPY", "NIKKEI"]
+
+
+def test_select_operation_result_falls_back_to_spy_when_no_universe_row() -> None:
+    """Legacy/no-composite artifacts (e.g. the ad-hoc CLI fallback path) keep
+    today's SPY-first behavior unchanged."""
+    artifact = AnalyticsArtifactModel.model_validate(_universe_artifact(universe_present=False))
+
+    chosen = select_operation_result(artifact)
+
+    assert chosen.operation == "SPY"
+
+
+def test_select_operation_result_explicit_operation_still_wins_over_universe() -> None:
+    artifact = AnalyticsArtifactModel.model_validate(_universe_artifact(universe_present=True))
+
+    chosen = select_operation_result(artifact, operation="NIKKEI")
+
+    assert chosen.operation == "NIKKEI"

--- a/backend/tests/test_backtest_mapper.py
+++ b/backend/tests/test_backtest_mapper.py
@@ -118,3 +118,47 @@ def test_select_operation_result_explicit_operation_still_wins_over_universe() -
     chosen = select_operation_result(artifact, operation="NIKKEI")
 
     assert chosen.operation == "NIKKEI"
+
+
+def _multi_feed_artifact() -> dict:
+    """Shape cli.run_command's N-feed (cross-sectional) branch produces: a
+    SINGLE result row whose operation is the "/"-joined declared universe —
+    not "UNIVERSE" and not "SPY" — because the joint N-asset run IS the
+    strategy result, with no per-asset rows or averaged composite on top."""
+    return {
+        "run_id": "r2",
+        "strategy": {"backtest_code_hash": "b" * 64, "paper_claimed_sharpe": None},
+        "assumptions": {"transaction_cost_bps": 10},
+        "integrity_flags": {"lookahead_audit_passed": True},
+        "results": [
+            {
+                "operation": "SPY/NIKKEI/GOLD/TREASURY/OIL",
+                "symbol": "SPY/^N225/GC=F/TLT/CL=F",
+                "constituent_operations": ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"],
+                "metrics": _minimal_metrics(0.42),
+            }
+        ],
+    }
+
+
+def test_select_operation_result_picks_the_sole_multi_feed_row() -> None:
+    """Regression for backtest-vol-audit item 1d: a cross-sectional strategy's
+    single run_multi_backtest result — named by its whole joined universe,
+    never "UNIVERSE" or "SPY" — must still be selected via the same "only row"
+    fallback pairs results already rely on, with no special-casing needed."""
+    artifact = AnalyticsArtifactModel.model_validate(_multi_feed_artifact())
+
+    chosen = select_operation_result(artifact)
+
+    assert chosen.operation == "SPY/NIKKEI/GOLD/TREASURY/OIL"
+    assert chosen.metrics.sharpe_ratio == pytest.approx(0.42)
+    assert chosen.constituent_operations == ["SPY", "NIKKEI", "GOLD", "TREASURY", "OIL"]
+
+
+def test_map_artifact_to_backtest_result_returns_multi_feed_operation_label() -> None:
+    artifact = AnalyticsArtifactModel.model_validate(_multi_feed_artifact())
+
+    mapped, operation = map_artifact_to_backtest_result(artifact, strategy_id="strat")
+
+    assert operation == "SPY/NIKKEI/GOLD/TREASURY/OIL"
+    assert mapped.sharpe_ratio == pytest.approx(0.42)


### PR DESCRIPTION
## The defect

`cli.run_command` has two routing paths:

- `feeds_needed == 2` (pairs): `ops = _pair_legs(...)` — the strategy's **declared** legs. Correct.
- `feeds_needed != 2` (every single-feed strategy): `ops = resolve_operations(operations)`, where `operations` comes from the `BACKTEST_OPERATIONS` env var (default `["SPY"]`, `backend/archimedes/scripts/run_backtests.py`). **The strategy's own `ASSET_UNIVERSE` was never consulted in this branch.**

So every single-feed strategy — regardless of what it declares — was backtested on `BACKTEST_OPERATIONS`, not on the assets it was designed for.

### Measured blast radius (34 curated strategies, computed programmatically, not by grepping file text)

| group | count | routing |
|---|---|---|
| pairs (`REQUIRED_FEEDS == 2`) | 6 | already correct — 3 declare `REQUIRED_FEEDS = 2` directly, 3 more (`gatev_2006_pairs_ewa_ewc/gld_slv/ko_pep`) import and reuse `PairsDistanceTrading`, which carries `REQUIRED_FEEDS = 2` as a class attribute, so `required_feeds()` already routes them through `_pair_legs` |
| single-feed, declares exactly `["SPY"]` | 4 | correct *by coincidence* |
| single-feed, declares anything else | 24 | **backtested on SPY regardless of its declared universe** |

(Earlier framing of this issue said "3 pairs / 27 broken" — that undercounted the pairs group by 3, because those 3 files inherit `REQUIRED_FEEDS` from an imported class rather than declaring it in their own file text. Functionally they were never affected; the real broken count is 24, confirmed by actually calling `required_feeds()` on all 34 loaded strategy classes.)

This is why `capital_preservation_tbill` (declares `["BIL"]`) and `maillard_2010_risk_parity` (declares a 5-asset universe) both showed ~17–19% annualized vol in prod artifacts — statistically indistinguishable from pure S&P-500 returns, because that's literally what they were backtested on.

**⚠️ Of the "24 broken, now fixed" above, 13 turned out to still be wrong after this PR's original fix — see "SCOPE UPDATE" below.** The per-asset routing fixed here was necessary but not sufficient for strategies that trade their whole universe *simultaneously*, not one asset at a time.

## The fix (original scope: per-asset routing)

**1. Instruments SSOT** (`data/instruments.json` + the in-module fallback, kept in sync): added `BIL` and `TLT` as operation keys (identity-mapped yfinance tickers). These were the only two `ASSET_UNIVERSE` entries among the 34 strategies that weren't yet resolvable operation names (`capital_preservation_tbill` declares `BIL`; `gatev_2006_portfolio_of_pairs` declares `TLT` among its many direct-ticker entries). Added `test_all_curated_strategies_declared_universe_resolves`, which programmatically asserts every one of the 34 files' `ASSET_UNIVERSE` fully resolves.

**2. Route on the declared universe.** In the single-feed branch, `ops` is now derived from the strategy's own `ASSET_UNIVERSE` (read off `metadata` — the exact same mechanism `_pair_legs` already uses) when the strategy declares one, falling back to the passed-in `operations` only when it doesn't. The pairs branch is untouched.

**3. The universe composite.** The rigor gate (`backend/.../get_daily_returns`) grades **one** `daily_returns` series per strategy. With an N-asset declared universe, the engine now produces N per-asset results — grading only the first would be arbitrary. `run_command` emits one more result, labelled `"UNIVERSE"`, with `constituent_operations` recorded:

   - equal-weighted mean of the per-asset daily returns,
   - computed on the **intersection** of trading dates — not a positional zip. `^N225` trades the Tokyo calendar, `CL=F` is a futures contract with its own session; a naive index-aligned zip would silently splice unrelated trading days together into a plausible-looking but wrong series. Tests construct two feeds with deliberately offset calendars and assert only the overlap is used (and assert the result is *not* what the wrong positional-zip version would produce).
   - for a single-asset universe, numerically identical to that one run (verified in tests: same `daily_returns`, `daily_return_dates`, `equity_curve`).

   `backtest_mapper.select_operation_result` now prefers `"UNIVERSE"` over `"SPY"` (which is no longer special once a real composite exists) when no explicit operation is requested — so the persisted/selected result is the composite, grading the strategy across its declared universe. The existing "selected operation persisted first" invariant (`_payload_with_selected_operation_first` in `run_backtests.py`) is untouched and still applies to whatever operation gets selected.

   Trade-level stats (`total_trades`, `win_rate`, `profit_factor`, `avg_holding_period_days`) and cost-realism fields aren't well-defined for a synthetic blended series (no single backtrader run produced them) and are left at their dataclass defaults rather than fabricated. **This equal-weighted-average composite remains correct and unchanged for the 15 genuinely single-feed strategies below — the scope update does not touch it.** It was, however, being WRONGLY applied to 13 strategies that needed simultaneous multi-feed treatment instead; see below.

---

## SCOPE UPDATE (this session): per-asset routing was necessary but not sufficient

An independent skeptic review of this PR found a gap the description above did not disclose, confirmed by direct code read: **strategies that read `self.datas[i]` for `i` beyond 0** — ranking, weighting, or trading their whole declared universe *simultaneously* in one cerebro run — were being run through the per-asset loop above: once per asset, then equal-weight-averaged. That is not the strategy. It silently replaces the cross-sectional signal with N independent single-asset runs — a plausible-but-wrong number, exactly the defect class this PR exists to eliminate.

### The corrected count — 13, not 11 (verified by direct code inspection, not docstring grepping)

Re-derived from scratch: for every one of the 34 curated strategy files, checked whether its `next()` method actually reads `self.datas[i]` for `i` beyond 0 (iteration, indexing beyond `[0]`, or both) — not "mentions `run_multi_backtest` in a docstring," and not "is covered by an existing multi-feed test file" (both would have undercounted, and did: the skeptic's initial count of 11 matched exactly the union of `test_factor_strategies.py` + `test_dividend_defensive_strategies.py` + `test_cross_sectional_strategies.py` + `test_pca_statarb.py` + `test_portfolio_of_pairs.py`'s existing coverage — which itself missed 2 strategies no test file had ever exercised as multi-feed).

| file | class | benchmark treatment |
|---|---|---|
| `ang_hodrick_2006_low_idiovol` | `AngHodrickLowIdioVol` | `datas[0]` = benchmark, excluded from ranking |
| `antonacci_2014_dual_momentum` | `DualMomentum` | identifies its defensive leg by feed `_name` (`"TLT"`) |
| `arnott_2019_defensive_quality` | `ArnottDefensiveQuality` | `datas[0]` = benchmark, included as beta reference |
| `asness_moskowitz_2013_value` | `AsnessMoskowitzValue` | no benchmark exclusion — **not in the original 11** |
| `avellaneda_lee_2010_pca_statarb` | `PCAStatArb` | N>=3 required (PCA); no benchmark exclusion |
| `blitz_hanauer_2010_rmom` | `BlitzHanauerRMOM` | `datas[0]` = benchmark, excluded from ranking |
| `frazzini_pedersen_2014_bab` | `FrazziniPedersenBAB` | `datas[0]` = benchmark, excluded from ranking |
| `gatev_2006_portfolio_of_pairs` | `GatevPortfolioOfPairs` | N>=3 (26-ETF universe), index-addressed pairs |
| `jegadeesh_titman_1993_cross_sectional_momentum` | `CrossSectionalMomentum` | no benchmark exclusion |
| `low_tan_wermers_2004_dividend_yield` | `FamaFrenchDividendYield` | no benchmark exclusion (despite its docstring mentioning `datas[0]`) |
| `maillard_2010_risk_parity` | `RiskParityInverseVol` | no benchmark exclusion — whole universe weighted together |
| `novy_marx_2012_quality_momentum` | `NovyMarxQualityMomentum` | no benchmark exclusion — **not in the original 11** |
| `novy_marx_2013_qmj` | `NoVyMarxQMJ` | no benchmark exclusion, `datas[0]` included in ranking |

New test `test_cross_sectional_family_declares_required_feeds_universe` (`test_strategy_loader.py`) pins this exact 13-file list.

### The fix

1. **Explicit contract**, not docstring-only (`engine.REQUIRED_FEEDS_UNIVERSE`, the sentinel string `"UNIVERSE"`): all 13 strategies above now declare `REQUIRED_FEEDS = "UNIVERSE"` as a class attribute — the same status the pairs family's `REQUIRED_FEEDS = 2` already had. `engine.required_feeds()` returns either a positive `int` or this sentinel. A near-miss string (e.g. a typo'd `"Univers"`) raises `FeedArityError` instead of silently defaulting to 1 — the whole point of a typed contract is that the router must never guess (adversarially verified: reverting this raise makes the typo silently collapse to a single-feed run — see Verification).

2. **Routing** (`cli.run_command`): a third branch, alongside the untouched 1-feed and 2-feed (pairs) branches, resolves the strategy's *declared* `ASSET_UNIVERSE` in declared order (order matters — e.g. `frazzini_pedersen_2014_bab` treats `datas[0]` as the benchmark) and feeds it through the pre-existing `engine.run_multi_backtest` — which already existed, was already engine-tested (`test_multi_engine.py`) and exercised directly by 5 strategy-level test files, but **was never called from `cli.py`, ever, before this session.** The capability was built; the router just never reached it. Feeds are named by resolved **symbol** (ticker), not operation code: `antonacci_2014_dual_momentum` identifies its defensive leg by matching `self.data._name == "TLT"`, which only works if the feed is actually named `"TLT"`, not `"TREASURY"` — naming by op code would have silently broken that lookup with nothing raising (verified with a dedicated adversarial test, `test_run_command_names_multi_feeds_by_resolved_symbol_not_operation_code`).

3. **No double-averaging**: for a strategy routed here, the single N-asset `run_multi_backtest` result *is* the strategy result — no per-asset rows, no `"UNIVERSE"` composite averaged on top of an already-joint portfolio series (that would double-average). `select_operation_result` picks it via the exact same "falls through to the only row" mechanism pairs results already rely on (new backend test: `test_select_operation_result_picks_the_sole_multi_feed_row`).

4. **Fail loud, never silently downgrade**: an explicit `REQUIRED_FEEDS` int that no longer matches the strategy's own `ASSET_UNIVERSE` length raises `FeedArityError` naming the drift; a universe collapsing to fewer than 2 distinct instruments fails the same way `_pair_legs` already does. Never, under any resolvable path, does a cross-sectional strategy fall back to running on 1 feed.

### Two more confirmed-and-fixed bugs found while wiring this up

- **`max_drawdown_duration_bars` was wrong for every strategy, single- *or* multi-feed** (`engine._max_drawdown_from_curve`, used by `combine_universe_results`): the length counter reset only on a *strictly new* all-time high (`value > peak`) instead of whenever drawdown is exactly zero (`value == peak` too counts as "at the peak") — the reset rule backtrader's own `DrawDown` analyzer actually uses (`r.len = r.len + 1 if drawdown else 0`). Because `peak` seeds from `equity_curve[0]` and the first comparison is against itself, the counter started incrementing from bar 0 on every composite, and any bar that merely revisited a prior peak without exceeding it stayed miscounted as "still in drawdown." Fixed to match backtrader exactly; pinned with two new tests — one hand-verified against a curve that retouches its own peak twice (buggy code: `max_len == 8`; fixed code: `max_len == 3`), one cross-validated against a REAL cerebro `bt.analyzers.DrawDown` run via the single-asset composite identity (`composite.max_drawdown_duration_bars == solo.max_drawdown_duration_bars`, using the actual backtrader-computed value as ground truth, not a hand-derived one). Both confirmed to fail on the pre-fix code (verbatim: hand-computed test asserted `8 == 3` and failed; the cross-validation test asserted `10 == 3` and failed — backtrader's real answer for that curve is 3; the old code's recomputation gave 10).

- **Silent composite/intersection truncation** (`combine_universe_results` *and*, for the identical reason, `run_multi_backtest`): both silently shrink to the shortest constituent's date range with no signal — "this universe legitimately has limited overlap" and "one feed's history is truncated or data-quality-broken" look identical from the outside. Added `coverage_summary()` / `universe_date_coverage()` (recorded per result row in the artifact's new `date_coverage` field: per-constituent bar counts, intersection size, ratio) and `warn_on_truncated_coverage()` — a loud `WARNING` log when the intersection retains less than 90% of the longest constituent's available history. 90% is a deliberately loose floor: ordinary calendar noise between liquid, actively-traded feeds (different market holidays, the odd half-day) costs low-single-digit percent of trading days, not double digits; losing more than 10% usually means a feed's AVAILABLE HISTORY is materially shorter than the others' (a late listing, a yfinance gap, a wrong date range). Wired into both `combine_universe_results` (as scoped) and `run_multi_backtest` (not explicitly scoped, but the identical silent-truncation risk exists there — real data below shows a genuine, sub-threshold case: the `jegadeesh_titman`/`maillard` 5-asset universe's date-coverage record shows `per_constituent_bars={SPY:1761, NIKKEI:1709, GOLD:1760, TREASURY:1761, OIL:1761}`, `intersection_bars=1649`, i.e. a 93.6% retained-vs-longest ratio — correctly NOT flagged, since 93.6% is above the 90% floor and this is ordinary Tokyo-vs-NYSE calendar noise, not a data-quality problem). Nine new tests cover this (7 for `combine_universe_results`/`coverage_summary`/`universe_date_coverage`, 2 for `run_multi_backtest`), confirming the warning fires exactly when material and stays silent on ordinary noise / full overlap; the two production-path warning tests (one for each function) were confirmed to fail without the wiring (verbatim: `assert 0 == 1` for the expected-warning count, both times).

### Real-data verification (yfinance, 2018-01-01 → 2025-01-01, LOCAL ONLY — no prod DB writes, no prod re-run)

| strategy | declared universe | route | vol (ann.) | CAGR |
|---|---|---|---|---|
| `jegadeesh_titman_1993_cross_sectional_momentum` | SPY, NIKKEI, GOLD, TREASURY, OIL | **NEW**: `run_multi_backtest` (5 feeds, 28 trades) | 32.07% | -3.21% |
| `jegadeesh_titman_1993_cross_sectional_momentum` | *(same)* | OLD (this PR's original per-asset loop) | every leg: 0 trades, flat 0.0%; `UNIVERSE` composite also flat 0.0% | 0.0% |
| `maillard_2010_risk_parity` | SPY, NIKKEI, GOLD, TREASURY, OIL | **NEW**: `run_multi_backtest` (5 feeds) | **16.19%** | **+7.78%** |
| `maillard_2010_risk_parity` | *(same)* | OLD (this PR's original per-asset loop) | 28.85% composite (OIL leg alone: 132.8% vol) | -8.98% |
| `capital_preservation_tbill` | BIL | 1-feed loop (unchanged) | 0.25% | +2.18% |
| `pipeline_buy_hold` | SPY | 1-feed loop (unchanged) | 19.45% | +13.33% |
| `gatev_2006_pairs_distance` | GLD, GDX | pairs (unchanged, byte-identical) | 8.67% | +4.10% |

**The OLD-routing `jegadeesh_titman` number is the sharpest illustration of the defect.** `CrossSectionalMomentum.next()` requires `len(scored) >= 2` to form both a long and a short bucket. Under the per-asset loop, each run only ever sees ONE feed, so `n < 2` on every single bar and the strategy **never places a single trade** — 0 trades, a flat 0.0% return, on all 5 legs and the composite. That isn't a plausible-but-wrong number; it's a strategy that silently never traded, dressed up as a valid, passing, zero-return backtest (look-ahead audit: pass; non-empty `daily_returns`: technically true, just all zeros). Reproduced verbatim by literally re-running the pre-session code against the strategy file.

**Verified the fix needs BOTH the explicit contract and the routing — neither alone is sufficient.** Running the CURRENT (this-session) `cli.py`/`engine.py` against the OLD strategy file (same code, `REQUIRED_FEEDS = "UNIVERSE"` removed) reproduces the identical 0-trades / flat-0.0% defect: `required_feeds()` defaults an undeclared class to 1, so it falls straight back into the 1-feed branch. Only with the declaration present does the new router see it and dispatch through `run_multi_backtest` — restoring the declaration alone (with the OLD router) instead makes `cli.py`'s old blanket `if feeds_needed > 2: raise` guard `TypeError` on comparing the sentinel string to `2`. Routing capability without a machine-readable contract, or a contract without a router that honours it, both reproduce failure — only both together produce the 28-trade, real result above.

**`maillard_2010_risk_parity` — the economic-sanity check this session was asked to run.** The "before this session" table further up in this PR body reported 23.58% vol for maillard and called it `clean`; **that number was itself a symptom of this scope gap**, not evidence the original fix was complete. `RiskParityInverseVol.next()` computes `deployed = (1/sigma) / total * exposure`; under a single-feed collapse, `total == 1/sigma` for that one asset, so this simplifies to `deployed == exposure` (~0.99) **regardless of that asset's own volatility** — every "leg" just becomes a ~99%-invested buy-and-hold of whichever single asset it happened to run on; the risk-parity math never actually engages. That is why the OIL leg alone (raw `CL=F` continuous futures — which went briefly negative on 2020-04-20) showed 132.8% annualized vol on its own, dragging the naive 5-leg average to 28.85% / -8.98% CAGR: an economically absurd result for something called risk parity, that nonetheless passed every existing test and, per the original PR body, the vol-plausibility guard. Correctly routed through `run_multi_backtest`, all 5 feeds are weighted simultaneously by their OWN inverse volatility in one cerebro run: **16.19% vol, materially below pure SPY (19.45%)** — exactly what a genuine inverse-vol-weighted, mostly-long-only, multi-asset book should show — with a positive Sharpe (0.24) instead of a large negative CAGR. This is the "does it still look like 23.58%?" check the task asked for: it does not, and the reason it does not is understood and disclosed, not just observed.

### #1191 vol-plausibility guard, re-run on the corrected numbers

| strategy | status |
|---|---|
| `jegadeesh_titman_1993_cross_sectional_momentum` | `clean` |
| `maillard_2010_risk_parity` | `clean` |
| `capital_preservation_tbill` | `clean` |
| `pipeline_buy_hold` | `clean` |
| `gatev_2006_pairs_distance` | `clean` |

### The honest final scope tally (34 curated strategies)

- **15** genuinely single-feed strategies — routed on their declared universe via the per-asset loop, unchanged this session, re-verified this session by direct `self.datas` usage inspection (not docstring).
- **6** pairs strategies (`REQUIRED_FEEDS == 2`) — routed via `run_pairs_backtest`, byte-identical and untouched this session.
- **13** cross-sectional / portfolio strategies — now routed via `run_multi_backtest` on their whole declared universe (this session's fix).
- 15 + 6 + 13 = 34. **Every curated strategy is now routed to a runner that reflects its own declared feed contract. Zero strategies are structurally unable to be correctly backtested after this change.**
- Correct ROUTING is a different claim from "passes the rigor/vol-plausibility gate." `avellaneda_lee_2010_pca_statarb`'s own `CURATOR_NOTE` already discloses that a 5-asset universe is too small for PCA-residual stat-arb to be genuinely market-neutral (the factor hedge doesn't diversify idiosyncratic risk at N=5) and that it may legitimately fail the rigor gate on economic grounds even once correctly routed — that would be the gate doing its job on a now-correctly-routed backtest, not a remaining routing defect. This PR does not claim every one of the 13 will pass every downstream gate; it claims every one is now honestly backtested on the universe it declares.

---

## Tests

- `analytics-engine/tests/test_cli.py` — declared-universe routing (the core regression guard; verified to **fail without the fix**), `BACKTEST_OPERATIONS` never overrides a declared universe, no-declared-universe fallback preserved exactly, composite ≡ single run for a 1-asset universe, composite date-intersection alignment through the full `run_command`/JSON path, pairs strategies unaffected, plus (this session) 4 new tests for the N-feed branch: routes through `run_multi_backtest`, symbol-not-op-code feed naming, fails closed on a degenerate <2-instrument universe, fails closed on an explicit-`REQUIRED_FEEDS`/universe-length drift.
- `analytics-engine/tests/test_universe_composite.py` — `combine_universe_results` unit tests: 1-asset identity, 2-asset equal-weighted mean, date-intersection alignment (adversarially verified against a buggy positional-zip implementation), no-common-dates raises, empty-input raises, look-ahead-audit AND-of-constituents, plus (this session) `coverage_summary`/`universe_date_coverage` shape tests and loud-vs-silent truncation-warning tests.
- `analytics-engine/tests/test_multi_engine.py` (this session) — `run_multi_backtest`'s own loud-truncation-warning tests (material truncation warns; full overlap stays silent).
- `analytics-engine/tests/test_instruments.py` — all 34 strategies resolve (adversarially verified to fail pre-fix), `BIL`/`TLT` are operation keys.
- `analytics-engine/tests/test_required_feeds.py` (new, this session) — `engine.required_feeds()`/`REQUIRED_FEEDS_UNIVERSE` sentinel: undeclared/explicit-1/pairs-2/sentinel/case-insensitive-sentinel/explicit->2/malformed-None/typo-fails-loud.
- `analytics-engine/tests/test_strategy_loader.py` (this session) — `test_cross_sectional_family_declares_required_feeds_universe` pins the 13-file list.
- `analytics-engine/tests/test_engine_coverage.py` (this session) — `_max_drawdown_from_curve` duration-reset semantics, hand-verified and cross-validated against a real backtrader `DrawDown` run.
- `backend/tests/test_backtest_mapper.py` — `select_operation_result` prefers `UNIVERSE` over `SPY` (adversarially verified to fail without the fix), falls back to `SPY` when no `UNIVERSE` row exists, explicit `operation=` still wins, plus (this session) 2 new tests confirming it correctly selects the sole multi-feed row (not `UNIVERSE`, not `SPY`) via the same "only row" fallback pairs already use.

Every new/changed assertion in this PR — original scope and this session's scope update alike — was verified to fail without its corresponding fix before being confirmed passing with it. This session's adversarial passes (drawdown-duration hand-check, drawdown-duration cross-validation, both truncation-warning wiring points, all 4 new cli.py routing tests, the `required_feeds` typo-detection test) were each re-run against a temporarily-reverted copy of the fix, observed to fail with the exact output quoted above, then restored — not left in the tree.

## Verification

- `PYTHONPATH=analytics-engine/src pytest analytics-engine/tests -q` → **227 passed** (was 203; +24 this session)
- `PYTHONPATH=backend pytest backend/tests -q` (full suite) → **3018 passed, 5 skipped** (was 3016 passed; +2 this session; skips unrelated: no local Postgres / PR #1129 not merged yet)
- `ruff format --check .` → clean
- `ruff check --select E9,F63,F7,F40,F82 .` → clean
- Full (non-CI-restricted) `ruff check` on the changed trees → also clean

## Out of scope / not done here

- **Not merged.** Not run against production. No production DB writes.
- The actual production re-run (`backend/archimedes/scripts/run_backtests.py` against the real DB, so all 34 strategies' persisted backtests get regraded) is intentionally left for a human to trigger after reviewing this PR — this is now doubly true, since the 13 cross-sectional strategies' persisted numbers (computed under the ORIGINAL per-asset-loop scope of this PR) are now known to be wrong in some cases (see `jegadeesh_titman`/`maillard` above) and should be regraded, not left as-is.
- Did not touch `backend/archimedes/services/vol_plausibility.py` (the guard itself) — it already does exactly the right thing once fed the correct series, per both before/after tables above.
- Did not add an explicit `MIN_FEEDS` enforcement for strategies whose own docstring states a minimum above 2 (`avellaneda_lee_2010_pca_statarb`: N>=3 for PCA; `gatev_2006_portfolio_of_pairs`: N>=3). Both currently declare `ASSET_UNIVERSE`s comfortably above their stated minimum (5 and 26 assets respectively), so this is a latent gap, not a live one — a future universe edit that shrinks either below its true minimum would not be caught by anything beyond the generic ">=2 distinct instruments" guard.
