### PR TITLE
[frontend] Mark the leaderboard provisional while backtests are re-computed

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -43,6 +43,38 @@ jobs:
       - name: EC2 user-data stays under the 16 KB limit
         run: bash ./infra/scripts/check-user-data-size.sh
 
+  # The analytics engine had NO CI coverage at all until now. pytest.ini sets
+  # `testpaths = backend/tests` and lists analytics-engine under
+  # `norecursedirs`, and no workflow ran its suite — so its 227 tests never
+  # executed on a PR. That is how #1203 (which re-routed EVERY backtest to its
+  # declared ASSET_UNIVERSE, and therefore determines every number the product
+  # publishes) merged with a full row of green checks and zero automated
+  # verification of the code it changed. The engine sits on the MVP critical
+  # path; it gets its own gate.
+  #
+  # Deliberately NOT path-filtered, for the same reason as infra-guards above:
+  # a path-filtered job marked as a required check never reports on PRs that
+  # miss its paths, so the check sits in "Expected" forever and the PR can
+  # never merge.
+  engine-tests:
+    name: Analytics engine — unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install
+        # The engine declares its own deps in analytics-engine/pyproject.toml
+        # (backtrader/pandas/yfinance). Installed as a package so the suite
+        # exercises the same import path production uses.
+        run: pip install --quiet ./analytics-engine "pytest>=8.2"
+      - name: Test
+        # No network: the suite must stay hermetic. A test that reaches
+        # yfinance would make this gate flaky and, worse, make a data-provider
+        # outage look like a code failure.
+        run: python -m pytest analytics-engine/tests -q
+
   backend-tests:
     name: Backend — unit tests
     runs-on: ubuntu-latest

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -96,6 +96,33 @@ export default function Leaderboard() {
           real rigor-gate and backtest results — the ugly numbers included. Build your track record now;
           it carries to mainnet.
         </p>
+        {/* PROVISIONAL-DATA BANNER — remove this whole block when the backtest
+            re-run completes and the figures below are trustworthy again.
+            A routing defect (fixed in #1203) meant most library strategies were
+            backtested against a hardcoded SPY default instead of their own
+            declared ASSET_UNIVERSE, so the numbers on this page are known to be
+            wrong until every strategy is re-computed.
+            Saying so out loud is the only option consistent with the product's
+            own thesis: taking the page down would hide the demonstration, and
+            leaving it silently wrong is the exact failure this product exists
+            to oppose. */}
+        <div
+          role="status"
+          style={{
+            marginTop: 10,
+            padding: '10px 14px',
+            borderLeft: '3px solid var(--warning, #b45309)',
+            background: 'var(--warning-muted, rgba(180,83,9,0.10))',
+            borderRadius: 4,
+            fontSize: 13,
+            color: 'var(--text-2)',
+          }}
+        >
+          <strong style={{ color: 'var(--warning, #b45309)' }}>Provisional — figures are being re-computed.</strong>{' '}
+          Backtest data is being re-computed following a routing defect; figures shown are known to be
+          incorrect and will change.
+        </div>
+
         {engine?.disclaimer && (
           <div style={{ marginTop: 10, padding: '8px 12px', borderLeft: '3px solid var(--accent)', background: 'var(--accent-muted)', borderRadius: 4, fontSize: 13, color: 'var(--text-2)' }}>
             <strong style={{ color: 'var(--accent)' }}>Testnet — paper/simulated.</strong> {engine.disclaimer}


### PR DESCRIPTION
Adds a visible banner to the leaderboard for the duration of the backtest re-run:

> **Provisional — figures are being re-computed.** Backtest data is being re-computed following a routing defect; figures shown are known to be incorrect and will change.

### Why the numbers are wrong

PR #1203 fixed a routing defect: most library strategies were backtested against a hardcoded `SPY` default instead of their own declared `ASSET_UNIVERSE`. Cross-sectional strategies fared worse — given a single feed they had nothing to rank, so they emitted **zero trades and a flat 0% return**, which the rigor gate then graded as though it were a result.

Every figure on this page is therefore known to be wrong until the persisted backtests are re-computed.

### Why a banner rather than taking the page down

Dan's call, and the reasoning is worth recording: taking the page down loses the demonstration, and leaving it **silently** wrong is the precise failure this product exists to oppose. Saying so out loud is the only option consistent with the thesis — and it is the strongest thing a skeptical reader could click on.

### Removal

The block is self-contained and carries its own removal condition in a comment, so retiring it after the re-run is one deletion, not an archaeology exercise.

### Verification

`npm ci` + `npm run build` + `npm run lint` all clean, and the banner string is present in the **shipped bundle** (`dist/assets/index-*.js`) — verified in the build output, not just in source.