### PR TITLE
Add row-level provenance to backtest_results

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1397,7 +1397,10 @@ async def _persist_real_returns(c: _CandidateResult, strategy_id: str, emit: _Em
 
         from archimedes.db import get_session
         from archimedes.models.backtest import BacktestResult
-        from archimedes.services.backtest_repository import insert_backtest_if_missing
+        from archimedes.services.backtest_repository import (
+            SOURCE_PIPELINE_DSL_FUSION,
+            insert_backtest_if_missing,
+        )
         from archimedes.services.live_rigor_gate import verdict_from_returns
 
         returns = list(c.return_series)
@@ -1469,6 +1472,7 @@ async def _persist_real_returns(c: _CandidateResult, strategy_id: str, emit: _Em
                 result=result,
                 operation="DSL_FUSION",
                 artifact_json=artifact_json,
+                source_pipeline=SOURCE_PIPELINE_DSL_FUSION,
             )
             _refresh_passport_real_metrics(
                 session, c, strategy_id, result, passes_rigor_gate=live.passes, n_obs=len(returns)
@@ -1549,7 +1553,10 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         from archimedes.models.paper_ref import PaperRef
         from archimedes.models.strategy import StrategyPassport, StrategyStatus
         from archimedes.models.strategy_store import StrategyRecord
-        from archimedes.services.backtest_repository import insert_backtest_if_missing
+        from archimedes.services.backtest_repository import (
+            SOURCE_PIPELINE_PORTFOLIO_BACKTESTER,
+            insert_backtest_if_missing,
+        )
         from archimedes.services.passport_loader import ingest_passport
         from archimedes.services.portfolio_backtester import backtest_portfolio
 
@@ -1582,6 +1589,7 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
                 run_id=artifact.get("run_id"),
                 operation="PORTFOLIO",
                 artifact_json=artifact_json,
+                source_pipeline=SOURCE_PIPELINE_PORTFOLIO_BACKTESTER,
             )
 
             # 2. Refresh the strategy_passports row with real_* metrics.

--- a/backend/archimedes/models/backtest_store.py
+++ b/backend/archimedes/models/backtest_store.py
@@ -79,9 +79,53 @@ class BacktestResultRecord(Base):
         nullable=False,
     )
 
+    # ── Row-level provenance (audit 2026-08-03) ─────────────────────────
+    # PR #1203's routing defect (single-feed strategies graded against a
+    # hardcoded SPY default; cross-sectional strategies run on one feed
+    # instead of their declared ASSET_UNIVERSE) went undetected in part
+    # because two independent pipelines write this table and a row gave no
+    # way to tell which one produced it. `backtest_engine` (above) already
+    # names the COMPUTE engine ('backtrader' | 'dsl-fusion' |
+    # 'portfolio-simulator-v1') and `backtest_code_hash` (above) already
+    # identifies per-row STRATEGY code — neither says which SCRIPT called
+    # `insert_backtest_if_missing`, which two different scripts can share
+    # the same engine tag (run_backtests.py and seed_backtests_from_artifacts.py
+    # both produce 'backtrader'-tagged artifacts through the same mapper).
+    # `source_pipeline` is that missing identity. Required (no default) —
+    # every writer must pass it explicitly; see backtest_repository.py's
+    # SOURCE_PIPELINE_* constants.
+    source_pipeline: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # When the backtest was actually COMPUTED — may predate `created_at`:
+    # seed_backtests_from_artifacts.py loads a pre-existing artifact file a
+    # much earlier run_backtests.py invocation produced and inserts it later.
+    # Defaults to "now" (mirrors created_at) for writers that compute and
+    # persist in the same call; run_backtests.py / seed_backtests_from_artifacts.py
+    # pass the artifact's own `timestamp_utc` when present for an accurate value.
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    # Git SHA of the backend code that computed this row — the SAME
+    # ARCHIMEDES_GIT_SHA build-provenance env var `/health`'s "version" field
+    # already reads (issue #1039), reused rather than inventing a second
+    # mechanism. NULL when unset (local/dev, or a historical row predating
+    # this column) — an honest unknown, never a fabricated value.
+    source_git_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
+
+    # True only for rows whose source_pipeline/computed_at/source_git_sha were
+    # RECONSTRUCTED after the fact by the 2026-08-03 backfill migration rather
+    # than stamped live by the writer at insert time (see that migration for
+    # exactly how each value was inferred). False for every row a
+    # provenance-aware writer stamps live from here on.
+    provenance_inferred: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
     __table_args__ = (
         UniqueConstraint("strategy_id", "content_hash", name="uq_backtest_strategy_content"),
         Index("ix_backtest_strategy_created", "strategy_id", "created_at"),
+        Index("ix_backtest_source_pipeline", "source_pipeline"),
     )
 
     def to_backtest_result(self) -> BacktestResult:
@@ -124,15 +168,24 @@ class BacktestResultRecord(Base):
         strategy_id: str,
         content_hash: str,
         result: BacktestResult,
+        source_pipeline: str,
         run_id: str | None = None,
         operation: str | None = None,
         artifact_json: str | None = None,
+        computed_at: datetime | None = None,
+        source_git_sha: str | None = None,
     ) -> BacktestResultRecord:
+        kwargs: dict[str, object] = {}
+        if computed_at is not None:
+            kwargs["computed_at"] = computed_at
         return cls(
             strategy_id=strategy_id,
             content_hash=content_hash,
             run_id=run_id,
             operation=operation,
+            source_pipeline=source_pipeline,
+            source_git_sha=source_git_sha,
+            **kwargs,
             sharpe_ratio=result.sharpe_ratio,
             sortino_ratio=result.sortino_ratio,
             max_drawdown=result.max_drawdown,

--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -21,7 +21,11 @@ from archimedes.services.backtest_mapper import (
     canonical_artifact_hash,
     map_artifact_to_backtest_result,
 )
-from archimedes.services.backtest_repository import get_daily_returns, insert_backtest_if_missing
+from archimedes.services.backtest_repository import (
+    SOURCE_PIPELINE_RUN_BACKTESTS,
+    get_daily_returns,
+    insert_backtest_if_missing,
+)
 from archimedes.services.strategy_provider import default_provider
 from archimedes.services.vol_plausibility import (
     VolPlausibilityError,
@@ -175,6 +179,26 @@ def _load_baseline_vol(strategy_by_path: dict) -> float | None:
         return None
 
     return stats.annualized_vol
+
+
+def _computed_at_from_payload(artifact_payload: dict) -> datetime | None:
+    """Parse the analytics-engine artifact's own ``timestamp_utc`` (cli.py's
+    ``run_command``) — when the backtest was actually COMPUTED, as opposed to
+    when this row lands in the DB (``created_at``). Usually near-identical for
+    this script (compute and persist in the same call), but this is the exact
+    field that makes ``computed_at`` meaningful for
+    ``seed_backtests_from_artifacts.py``, which loads artifacts written by an
+    earlier run. Returns ``None`` (never raises) on a missing/malformed field
+    — the caller falls back to "now", the same honest default as before this
+    column existed.
+    """
+    raw = artifact_payload.get("timestamp_utc")
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _daily_returns_for_operation(artifact_payload: dict, operation: str | None) -> list[float] | None:
@@ -365,6 +389,8 @@ def run_backtests() -> dict:
                     run_id=artifact.run_id,
                     operation=selected_operation,
                     artifact_json=artifact_json,
+                    source_pipeline=SOURCE_PIPELINE_RUN_BACKTESTS,
+                    computed_at=_computed_at_from_payload(artifact_payload),
                 )
                 session.commit()
 

--- a/backend/archimedes/scripts/seed_backtests_from_artifacts.py
+++ b/backend/archimedes/scripts/seed_backtests_from_artifacts.py
@@ -136,6 +136,14 @@ def seed_from_artifacts(artifact_dir: Path | None = None) -> dict[str, int]:
                         artifact_json=raw,
                         source_pipeline=SOURCE_PIPELINE_SEED_FROM_ARTIFACTS,
                         computed_at=_computed_at_from_payload(payload),
+                        # EXPLICIT None, not omission. This path replays an
+                        # artifact produced by some earlier, unrecorded commit;
+                        # the running build's SHA did NOT produce it. Omitting
+                        # the argument would stamp the current deploy SHA and
+                        # make every replayed row assert a provenance that is
+                        # simply false — in the column added to make provenance
+                        # trustworthy. NULL is the honest answer here.
+                        source_git_sha=None,
                     )
                     session.commit()
 

--- a/backend/archimedes/scripts/seed_backtests_from_artifacts.py
+++ b/backend/archimedes/scripts/seed_backtests_from_artifacts.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 from archimedes.db import get_session, init_db
@@ -23,10 +24,30 @@ from archimedes.services.backtest_mapper import (
     canonical_artifact_hash,
     map_artifact_to_backtest_result,
 )
-from archimedes.services.backtest_repository import insert_backtest_if_missing
+from archimedes.services.backtest_repository import (
+    SOURCE_PIPELINE_SEED_FROM_ARTIFACTS,
+    insert_backtest_if_missing,
+)
 from archimedes.services.strategy_provider import default_provider
 
 logger = logging.getLogger(__name__)
+
+
+def _computed_at_from_payload(payload: dict) -> datetime | None:
+    """Parse the artifact's own ``timestamp_utc`` — this is the field that
+    matters most for THIS script: it seeds artifacts that were computed by an
+    earlier ``run_backtests.py`` invocation, possibly long before this seed
+    run inserts the row, so ``created_at`` alone would misrepresent when the
+    backtest actually ran. Returns ``None`` (never raises) on a missing/
+    malformed field; the caller then falls back to "now".
+    """
+    raw = payload.get("timestamp_utc")
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def seed_from_artifacts(artifact_dir: Path | None = None) -> dict[str, int]:
@@ -113,6 +134,8 @@ def seed_from_artifacts(artifact_dir: Path | None = None) -> dict[str, int]:
                         run_id=artifact.run_id,
                         operation=selected_operation,
                         artifact_json=raw,
+                        source_pipeline=SOURCE_PIPELINE_SEED_FROM_ARTIFACTS,
+                        computed_at=_computed_at_from_payload(payload),
                     )
                     session.commit()
 

--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -7,7 +7,9 @@ daily returns for the selection-bias rigor gate.
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Iterable
+from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
 
@@ -16,6 +18,21 @@ from archimedes.models.backtest_store import BacktestResultRecord
 
 logger = logging.getLogger(__name__)
 
+# Canonical source_pipeline values — every writer through
+# insert_backtest_if_missing must pass one of these (the function has no
+# default; a caller that forgets fails loudly instead of writing an
+# unattributed row). The migration that added the column backfills historical
+# rows using the same vocabulary — see
+# backend/migrations/versions/363d1c6ff0c0_add_backtest_results_provenance.py.
+SOURCE_PIPELINE_RUN_BACKTESTS = "run_backtests"
+SOURCE_PIPELINE_SEED_FROM_ARTIFACTS = "seed_backtests_from_artifacts"
+SOURCE_PIPELINE_DSL_FUSION = "generation_pipeline.dsl_fusion"
+SOURCE_PIPELINE_PORTFOLIO_BACKTESTER = "generation_pipeline.portfolio_backtester"
+# Backfill-only sentinel — never stamped by a live writer. Existing rows whose
+# backtest_engine ('backtrader') is shared by two indistinguishable historical
+# writers land here rather than guessing which one wrote them.
+SOURCE_PIPELINE_UNKNOWN_LEGACY = "unknown_pre_provenance"
+
 
 def insert_backtest_if_missing(
     session: Session,
@@ -23,11 +40,25 @@ def insert_backtest_if_missing(
     strategy_id: str,
     content_hash: str,
     result: BacktestResult,
+    source_pipeline: str,
     run_id: str | None = None,
     operation: str | None = None,
     artifact_json: str | None = None,
+    computed_at: datetime | None = None,
+    source_git_sha: str | None = None,
 ) -> tuple[BacktestResultRecord, bool]:
-    """Insert row if strategy_id+content_hash missing. Returns (row, inserted)."""
+    """Insert row if strategy_id+content_hash missing. Returns (row, inserted).
+
+    ``source_pipeline`` is required (no default) — it is the field the
+    2026-08-03 audit found missing that let two writers (the analytics-engine
+    /backtrader path and the DSL-fusion path) silently share one table with no
+    way to tell a row's origin apart. ``computed_at`` defaults to "now" (the
+    common case: compute and persist in the same call); pass the artifact's
+    own timestamp when replaying an older run (e.g.
+    ``seed_backtests_from_artifacts.py``). ``source_git_sha`` defaults to the
+    same ``ARCHIMEDES_GIT_SHA`` build-provenance env var ``/health`` reads
+    (issue #1039) — None when unset, an honest unknown rather than a guess.
+    """
     existing = (
         session.query(BacktestResultRecord)
         .filter(
@@ -46,6 +77,9 @@ def insert_backtest_if_missing(
         run_id=run_id,
         operation=operation,
         artifact_json=artifact_json,
+        source_pipeline=source_pipeline,
+        computed_at=computed_at or datetime.now(UTC),
+        source_git_sha=source_git_sha if source_git_sha is not None else (os.getenv("ARCHIMEDES_GIT_SHA") or None),
     )
     session.add(row)
     session.flush()

--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -34,6 +34,20 @@ SOURCE_PIPELINE_PORTFOLIO_BACKTESTER = "generation_pipeline.portfolio_backtester
 SOURCE_PIPELINE_UNKNOWN_LEGACY = "unknown_pre_provenance"
 
 
+class _Unset:
+    """Sentinel distinguishing "argument omitted" from an explicit ``None``.
+
+    A plain ``None`` default cannot express both "use the running build's SHA"
+    and "this row's producing commit is unknowable" — and conflating them makes
+    replayed rows claim a commit that did not produce them.
+    """
+
+    __slots__ = ()
+
+
+_UNSET = _Unset()
+
+
 def insert_backtest_if_missing(
     session: Session,
     *,
@@ -45,7 +59,7 @@ def insert_backtest_if_missing(
     operation: str | None = None,
     artifact_json: str | None = None,
     computed_at: datetime | None = None,
-    source_git_sha: str | None = None,
+    source_git_sha: str | None | _Unset = _UNSET,
 ) -> tuple[BacktestResultRecord, bool]:
     """Insert row if strategy_id+content_hash missing. Returns (row, inserted).
 
@@ -55,9 +69,17 @@ def insert_backtest_if_missing(
     way to tell a row's origin apart. ``computed_at`` defaults to "now" (the
     common case: compute and persist in the same call); pass the artifact's
     own timestamp when replaying an older run (e.g.
-    ``seed_backtests_from_artifacts.py``). ``source_git_sha`` defaults to the
-    same ``ARCHIMEDES_GIT_SHA`` build-provenance env var ``/health`` reads
-    (issue #1039) — None when unset, an honest unknown rather than a guess.
+    ``seed_backtests_from_artifacts.py``). ``source_git_sha`` OMITTED means "stamp the
+    running build" and resolves from the same ``ARCHIMEDES_GIT_SHA`` env var
+    ``/health`` reads (issue #1039). Passing an EXPLICIT ``None`` means "the
+    producing commit is genuinely not knowable" and persists NULL.
+
+    Those two must stay distinguishable. ``seed_backtests_from_artifacts.py``
+    replays artifacts produced by some earlier, unrecorded commit; if omission
+    and explicit-unknown collapsed together, every replayed row would be
+    stamped with the CURRENT deploy SHA — a confident, wrong provenance claim
+    in the very column added to make provenance trustworthy. An honest NULL is
+    the whole point; a plausible wrong SHA is worse than no SHA.
     """
     existing = (
         session.query(BacktestResultRecord)
@@ -79,7 +101,9 @@ def insert_backtest_if_missing(
         artifact_json=artifact_json,
         source_pipeline=source_pipeline,
         computed_at=computed_at or datetime.now(UTC),
-        source_git_sha=source_git_sha if source_git_sha is not None else (os.getenv("ARCHIMEDES_GIT_SHA") or None),
+        source_git_sha=(os.getenv("ARCHIMEDES_GIT_SHA") or None)
+        if isinstance(source_git_sha, _Unset)
+        else source_git_sha,
     )
     session.add(row)
     session.flush()

--- a/backend/migrations/versions/363d1c6ff0c0_add_backtest_results_provenance.py
+++ b/backend/migrations/versions/363d1c6ff0c0_add_backtest_results_provenance.py
@@ -1,0 +1,137 @@
+"""add row-level provenance to backtest_results
+
+Audit 2026-08-03. PR #1203 fixed a routing defect: single-feed strategies
+were backtested against a hardcoded SPY default instead of their declared
+``ASSET_UNIVERSE``, and 13 cross-sectional strategies ran on one feed when
+they need the whole universe simultaneously — both producing worthless
+(often zero-trade / flat-return) rows that the rigor gate graded as if they
+were real. Root cause: two independent pipelines
+(``backend/archimedes/scripts/run_backtests.py``'s analytics-engine/backtrader
+path and ``generation_pipeline.py``'s DSL-fusion/portfolio-simulator paths)
+write the same ``backtest_results`` table and were INDISTINGUISHABLE — no
+column said which script/pipeline produced a row, when it was actually
+computed (as opposed to when the DB row was inserted), or what git SHA of the
+code ran it. Re-running the backtests without fixing this just resets the
+clock on the next occurrence of the same defect class.
+
+Three fields were requested; two already existed on the model and are NOT
+duplicated here:
+  - "which engine computed it"      -> ``backtest_engine`` (existing).
+  - "per-row code identity"         -> ``backtest_code_hash`` (existing; NULL
+    for every dsl-fusion row today — that path scores a DSL spec, not a
+    hashable Python file; unchanged by this migration).
+  - "when the DB row landed"        -> ``created_at`` (existing).
+
+Genuinely missing, added here:
+  - ``source_pipeline`` (NOT NULL) — which SCRIPT/call path invoked
+    ``insert_backtest_if_missing``: 'run_backtests' |
+    'seed_backtests_from_artifacts' | 'generation_pipeline.dsl_fusion' |
+    'generation_pipeline.portfolio_backtester'. ``backtest_engine`` names the
+    COMPUTE engine, not the caller — a single engine tag ('backtrader') is
+    shared by two different Python entrypoints that were otherwise
+    indistinguishable in the data. This is the field the whole episode was
+    actually missing.
+  - ``computed_at`` (NOT NULL) — when the backtest was actually COMPUTED,
+    which can predate ``created_at`` (``seed_backtests_from_artifacts.py``
+    loads an artifact file written by an earlier run and inserts it later).
+  - ``source_git_sha`` (nullable) — ``ARCHIMEDES_GIT_SHA``, the same
+    build-provenance env var ``/health``'s "version" field already reads
+    (issue #1039) — reused here rather than inventing a second mechanism.
+    Stays NULL when unset (local/dev, or a historical row) — an honest
+    unknown, never a fabricated value.
+  - ``provenance_inferred`` (NOT NULL, default false) — true only for rows
+    THIS migration's backfill reconstructed after the fact; false for every
+    row a provenance-aware writer stamps live from here on.
+
+Backfill ships WITH this migration (repo convention — not a follow-up): the
+73 rows in prod as of 2026-08-03 are not left with ``source_pipeline`` NULL.
+  - ``backtest_engine = 'dsl-fusion'``             -> source_pipeline =
+    'generation_pipeline.dsl_fusion' (deterministic: only one writer has ever
+    set that engine tag, so this is a reconstruction, not a guess).
+  - ``backtest_engine = 'portfolio-simulator-v1'`` -> source_pipeline =
+    'generation_pipeline.portfolio_backtester' (deterministic, same
+    reasoning).
+  - everything else (``backtest_engine = 'backtrader'`` or NULL)
+    -> source_pipeline = 'unknown_pre_provenance'. Both run_backtests.py and
+    seed_backtests_from_artifacts.py produce identical 'backtrader'-tagged
+    artifacts through the same mapper (``backtest_mapper.py``), so there is
+    no signal in the pre-existing columns to tell them apart for historical
+    rows — an honestly-labelled unknown beats a confident guess.
+  - ``computed_at`` <- ``created_at`` for every existing row (the best
+    available proxy; the true compute time was never captured before this
+    column existed).
+  - ``source_git_sha`` stays NULL for every existing row (no historical
+    record of which commit produced them).
+  - ``provenance_inferred`` <- true for every row this backfill touches.
+
+Revision ID: 363d1c6ff0c0
+Revises: 3f643d292e04
+Create Date: 2026-08-03 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "363d1c6ff0c0"
+down_revision: str | Sequence[str] | None = "3f643d292e04"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_DSL_FUSION_ENGINE = "dsl-fusion"
+_PORTFOLIO_ENGINE = "portfolio-simulator-v1"
+_UNKNOWN_LEGACY = "unknown_pre_provenance"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("backtest_results", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("source_pipeline", sa.String(length=64), nullable=True))
+        batch_op.add_column(sa.Column("computed_at", sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column("source_git_sha", sa.String(length=40), nullable=True))
+        batch_op.add_column(sa.Column("provenance_inferred", sa.Boolean(), nullable=False, server_default=sa.false()))
+
+    # ── Backfill every pre-existing row (ships with this migration) ───────
+    # WHERE source_pipeline IS NULL scopes this to rows that predate the
+    # column entirely — the only rows that can exist at this point in the
+    # upgrade, since the column was just added.
+    op.execute(
+        f"""
+        UPDATE backtest_results
+        SET
+            source_pipeline = CASE
+                WHEN backtest_engine = '{_DSL_FUSION_ENGINE}' THEN 'generation_pipeline.dsl_fusion'
+                WHEN backtest_engine = '{_PORTFOLIO_ENGINE}' THEN 'generation_pipeline.portfolio_backtester'
+                ELSE '{_UNKNOWN_LEGACY}'
+            END,
+            computed_at = created_at,
+            provenance_inferred = true
+        WHERE source_pipeline IS NULL
+        """
+    )
+
+    with op.batch_alter_table("backtest_results", schema=None) as batch_op:
+        batch_op.alter_column("source_pipeline", existing_type=sa.String(length=64), nullable=False)
+        batch_op.alter_column("computed_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+
+    op.create_index("ix_backtest_source_pipeline", "backtest_results", ["source_pipeline"])
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Structural-only — the reconstructed backfill values are not restored
+    (there is nothing to restore them FROM; they did not exist pre-migration,
+    same convention as every other backfill migration in this history).
+    """
+    op.drop_index("ix_backtest_source_pipeline", table_name="backtest_results")
+    with op.batch_alter_table("backtest_results", schema=None) as batch_op:
+        batch_op.drop_column("provenance_inferred")
+        batch_op.drop_column("source_git_sha")
+        batch_op.drop_column("computed_at")
+        batch_op.drop_column("source_pipeline")

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -133,7 +133,14 @@ def test_alembic_strategy_spec_column_added_and_removed(tmp_path):
     """Rebalancer decouple (Part A #1): ``strategy_store.strategy_spec`` lands
     on upgrade, is gone on downgrade, and comes back on re-upgrade — the
     per-migration up/down/idempotent contract, exercised directly (not just
-    implied by the whole-chain tests above)."""
+    implied by the whole-chain tests above).
+
+    Downgrades to the strategy_spec revision's OWN ``down_revision`` (looked
+    up from the script directory, not hardcoded, and not a relative ``-1``)
+    so this test keeps targeting that specific migration's up/down contract
+    regardless of how many further revisions have since landed on top of it —
+    a relative ``-1`` from head silently started downgrading a *different*
+    migration the moment this one stopped being the head."""
     db_path = tmp_path / "spec_column.db"
     database_url = f"sqlite:///{db_path}"
 
@@ -146,11 +153,18 @@ def test_alembic_strategy_spec_column_added_and_removed(tmp_path):
         finally:
             con.close()
 
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(Config(str(_BACKEND_DIR / "alembic.ini")))
+    strategy_spec_revision = script.get_revision("3f643d292e04")
+    target = strategy_spec_revision.down_revision
+
     upgrade = _run_alembic("upgrade", "head", database_url=database_url)
     assert upgrade.returncode == 0, upgrade.stderr
     assert _has_strategy_spec_column()
 
-    downgrade = _run_alembic("downgrade", "-1", database_url=database_url)
+    downgrade = _run_alembic("downgrade", target, database_url=database_url)
     assert downgrade.returncode == 0, downgrade.stderr
     assert not _has_strategy_spec_column()
 

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -201,6 +201,7 @@ def seeded_db():
             run_id=artifact.run_id,
             operation=operation,
             artifact_json=FIXTURE_PATH.read_text(encoding="utf-8"),
+            source_pipeline="test",
         )
         session.commit()
     return buy_hold.id

--- a/backend/tests/test_audit_backtest_universe.py
+++ b/backend/tests/test_audit_backtest_universe.py
@@ -125,6 +125,7 @@ def test_clean_strategy_passes(_db, tmp_path) -> None:
             content_hash="h1",
             result=_sample_result(strategy.id, _equity_curve_from_returns(returns)),
             artifact_json=_artifact_json_with_daily_returns(returns),
+            source_pipeline="test",
         )
         session.commit()
 
@@ -156,6 +157,7 @@ def test_bil_declared_strategy_with_equity_vol_is_flagged(_db, tmp_path) -> None
                 content_hash=f"h-{stem}",
                 result=_sample_result(strategy.id, _equity_curve_from_returns(equity_returns)),
                 artifact_json=_artifact_json_with_daily_returns(equity_returns),
+                source_pipeline="test",
             )
         session.commit()
 
@@ -216,6 +218,7 @@ def test_degenerate_all_zero_series_is_reported_not_passed_or_crashed(_db, tmp_p
             content_hash="h1",
             result=_sample_result(strategy.id, _equity_curve_from_returns(zero_returns)),
             artifact_json=_artifact_json_with_daily_returns(zero_returns),
+            source_pipeline="test",
         )
         session.commit()
 
@@ -254,6 +257,7 @@ def test_maillard_style_diversified_strategy_matching_baseline_is_flagged(_db, t
             content_hash="h-baseline",
             result=_sample_result(strategies["pipeline_buy_hold"].id, _equity_curve_from_returns(baseline_returns)),
             artifact_json=_artifact_json_with_daily_returns(baseline_returns),
+            source_pipeline="test",
         )
         insert_backtest_if_missing(
             session,
@@ -263,6 +267,7 @@ def test_maillard_style_diversified_strategy_matching_baseline_is_flagged(_db, t
                 strategies["maillard_2010_risk_parity"].id, _equity_curve_from_returns(near_match_returns)
             ),
             artifact_json=_artifact_json_with_daily_returns(near_match_returns),
+            source_pipeline="test",
         )
         session.commit()
 
@@ -296,6 +301,7 @@ def test_cross_store_delta_is_reported_when_stores_disagree(_db, tmp_path) -> No
             content_hash="h1",
             result=_sample_result(strategy.id, _equity_curve_from_returns(primary_returns)),
             artifact_json=_artifact_json_with_daily_returns(primary_returns),
+            source_pipeline="test",
         )
         session.commit()
 

--- a/backend/tests/test_backtest_pipeline_integration.py
+++ b/backend/tests/test_backtest_pipeline_integration.py
@@ -62,6 +62,7 @@ def _seed_buy_hold_from_fixture():
             run_id=artifact.run_id,
             operation=operation,
             artifact_json=FIXTURE_PATH.read_text(encoding="utf-8"),
+            source_pipeline="test",
         )
         session.commit()
     return buy_hold.id

--- a/backend/tests/test_backtest_repository.py
+++ b/backend/tests/test_backtest_repository.py
@@ -46,6 +46,7 @@ def test_insert_backtest_is_idempotent_on_content_hash() -> None:
             content_hash="abc123",
             result=_sample_result("s1", sharpe=0.7),
             run_id="run1",
+            source_pipeline="test",
         )
         row1_id = row1.id
         session.commit()
@@ -57,6 +58,7 @@ def test_insert_backtest_is_idempotent_on_content_hash() -> None:
             content_hash="abc123",
             result=_sample_result("s1", sharpe=0.9),
             run_id="run2",
+            source_pipeline="test",
         )
         session.commit()
 
@@ -79,6 +81,7 @@ def test_latest_backtests_by_strategy_picks_newest_row() -> None:
             content_hash="h1",
             result=_sample_result("s1", sharpe=0.5),
             run_id="run1",
+            source_pipeline="test",
         )
         insert_backtest_if_missing(
             session,
@@ -86,6 +89,7 @@ def test_latest_backtests_by_strategy_picks_newest_row() -> None:
             content_hash="h2",
             result=_sample_result("s1", sharpe=0.8),
             run_id="run2",
+            source_pipeline="test",
         )
         insert_backtest_if_missing(
             session,
@@ -93,6 +97,7 @@ def test_latest_backtests_by_strategy_picks_newest_row() -> None:
             content_hash="h3",
             result=_sample_result("s2", sharpe=1.1),
             run_id="run3",
+            source_pipeline="test",
         )
         session.commit()
 

--- a/backend/tests/test_backtest_repository.py
+++ b/backend/tests/test_backtest_repository.py
@@ -105,3 +105,87 @@ def test_latest_backtests_by_strategy_picks_newest_row() -> None:
 
     assert latest["s1"].sharpe_ratio == 0.8
     assert latest["s2"].sharpe_ratio == 1.1
+
+
+def test_omitted_source_git_sha_stamps_the_running_build() -> None:
+    """Omitting the argument means "stamp the running build"."""
+    import os
+    from unittest.mock import patch
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    with patch.dict(os.environ, {"ARCHIMEDES_GIT_SHA": "deadbeefcafe"}), SessionLocal() as session:
+        row, _ = insert_backtest_if_missing(
+            session,
+            strategy_id="s1",
+            content_hash="omitted",
+            result=_sample_result("s1", sharpe=0.7),
+            run_id="run1",
+            source_pipeline="test",
+        )
+        assert row.source_git_sha == "deadbeefcafe"
+
+
+def test_explicit_none_source_git_sha_persists_null_even_with_env_set() -> None:
+    """An EXPLICIT None means "the producing commit is not knowable" and must
+    persist NULL — even when ARCHIMEDES_GIT_SHA is set.
+
+    This is the case that matters: seed_backtests_from_artifacts.py replays
+    artifacts produced by some earlier, unrecorded commit. If explicit-unknown
+    collapsed into omission, every replayed row would claim the CURRENT deploy
+    SHA — a confident, false provenance claim in the very column added to make
+    provenance trustworthy. A plausible wrong SHA is worse than no SHA.
+
+    Note the env var is deliberately SET here. With it unset the test would
+    pass whether or not the sentinel exists, and would prove nothing.
+    """
+    import os
+    from unittest.mock import patch
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    with patch.dict(os.environ, {"ARCHIMEDES_GIT_SHA": "deadbeefcafe"}), SessionLocal() as session:
+        row, _ = insert_backtest_if_missing(
+            session,
+            strategy_id="s2",
+            content_hash="explicit-none",
+            result=_sample_result("s2", sharpe=0.7),
+            run_id="run2",
+            source_pipeline="seed_from_artifacts",
+            source_git_sha=None,
+        )
+        assert row.source_git_sha is None
+
+
+def test_replay_script_passes_explicit_none() -> None:
+    """Wiring guard: the replay script must pass ``source_git_sha=None``.
+
+    Asserted against the parsed AST, not a substring of the source: a raw
+    ``"source_git_sha=None" in inspect.getsource(...)`` check would still pass
+    if the real keyword argument were deleted and the text survived in a
+    comment or docstring. That is the same vacuous-guard shape this repo keeps
+    producing, so the guard itself is written to be unfoolable.
+    """
+    import ast
+    import inspect
+
+    from archimedes.scripts import seed_backtests_from_artifacts as mod
+
+    tree = ast.parse(inspect.getsource(mod))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "insert_backtest_if_missing"
+    ]
+    assert calls, "seed_backtests_from_artifacts no longer calls insert_backtest_if_missing"
+
+    for call in calls:
+        kw = {k.arg: k.value for k in call.keywords}
+        assert "source_git_sha" in kw, "replay must pass source_git_sha explicitly, not omit it"
+        assert isinstance(kw["source_git_sha"], ast.Constant) and kw["source_git_sha"].value is None, (
+            "replay must pass source_git_sha=None (explicit unknown), not the running build's SHA"
+        )

--- a/backend/tests/test_backtest_scheduler.py
+++ b/backend/tests/test_backtest_scheduler.py
@@ -63,6 +63,7 @@ def _insert_backtest(sid: str, created_at: datetime):
                 content_hash=content_hash,
                 artifact_json="{}",
                 created_at=created_at,
+                source_pipeline="test",
             )
         )
         session.commit()

--- a/backend/tests/test_passport_honesty.py
+++ b/backend/tests/test_passport_honesty.py
@@ -600,6 +600,7 @@ class TestStrategyReturnsEndpoint:
                 content_hash=content_hash,
                 result=result,
                 artifact_json=artifact_json,
+                source_pipeline="test",
             )
 
         session.commit()

--- a/backend/tests/test_selection_bias_generated_gate.py
+++ b/backend/tests/test_selection_bias_generated_gate.py
@@ -130,6 +130,7 @@ def _mk_backtest(
                 num_trials_in_selection=num_trials,
                 pbo_score=pbo,
                 look_ahead_audit_passed=look_ahead,
+                source_pipeline="test",
             )
         )
         session.commit()

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -107,7 +107,7 @@ def _mk_backtest(sid: str):
     from archimedes.models.backtest_store import BacktestResultRecord
 
     with db.get_session() as session:
-        session.add(BacktestResultRecord(strategy_id=sid, content_hash=f"bt_{sid}"))
+        session.add(BacktestResultRecord(strategy_id=sid, content_hash=f"bt_{sid}", source_pipeline="test"))
         session.commit()
 
 


### PR DESCRIPTION
## Summary

Root-causes the "which pipeline wrote this row?" gap behind PR #1203's routing
defect: `backtest_results` is written by two independent pipelines
(`run_backtests.py`'s analytics-engine/backtrader path, and
`generation_pipeline.py`'s DSL-fusion / portfolio-simulator paths), and a
persisted row gave no way to tell which one produced it, when it was actually
computed, or what code ran. Re-running the backtests without fixing this
would just reset the clock on the next occurrence of the same defect class.

Dan asked for three fields. Two were already covered by existing columns and
are **not duplicated**:

| Requested | Already covered by | Notes |
|---|---|---|
| which SCRIPT/pipeline wrote the row | *(nothing — genuinely missing)* | → new `source_pipeline` |
| when it was computed | *(nothing — `created_at` is insert time, not compute time)* | → new `computed_at` |
| git SHA of the code that produced it | *(nothing — `backtest_code_hash` is per-row **strategy** code identity, not the repo commit)* | → new `source_git_sha` |

`backtest_engine` (engine name: `backtrader` \| `dsl-fusion` \|
`portfolio-simulator-v1`) and `backtest_code_hash` (NULL for every
dsl-fusion row — unchanged here, that path scores a DSL spec, not a
hashable file) already existed and are untouched. All three requested
fields turned out to be genuinely missing — none of the three had a
usable existing column, so nothing was skipped as "already covered."

## Columns added (migration `363d1c6ff0c0`)

- `source_pipeline VARCHAR(64) NOT NULL` — which script/call path invoked
  `insert_backtest_if_missing`. **Required, no default** — a caller that
  forgets to pass it fails loudly (`TypeError`) instead of writing an
  unattributed row. Canonical values (constants in `backtest_repository.py`):
  `run_backtests`, `seed_backtests_from_artifacts`,
  `generation_pipeline.dsl_fusion`, `generation_pipeline.portfolio_backtester`.
- `computed_at TIMESTAMPTZ NOT NULL` — when the backtest was actually
  computed, which can predate `created_at` (`seed_backtests_from_artifacts.py`
  loads an artifact a much earlier run produced). `run_backtests.py` and
  `seed_backtests_from_artifacts.py` now parse the analytics-engine
  artifact's own `timestamp_utc` for an accurate value; defaults to "now"
  when unavailable.
- `source_git_sha VARCHAR(40) NULL` — reuses `ARCHIMEDES_GIT_SHA`, the exact
  build-provenance env var `/health`'s `"version"` field already reads
  (issue #1039), rather than inventing a second mechanism. NULL when unset
  (local/dev, historical rows) — an honest unknown, never fabricated.
- `provenance_inferred BOOLEAN NOT NULL DEFAULT false` — true only for rows
  the backfill below reconstructed after the fact; false for every row a
  provenance-aware writer stamps live from here on.
- Index `ix_backtest_source_pipeline` on `source_pipeline`.

## Writers stamped

Every code path that calls `insert_backtest_if_missing` (grepped for all
call sites, production and test):

- `backend/archimedes/scripts/run_backtests.py` → `source_pipeline="run_backtests"`
- `backend/archimedes/scripts/seed_backtests_from_artifacts.py` → `source_pipeline="seed_backtests_from_artifacts"`
- `backend/archimedes/agents/generation_pipeline.py::_persist_real_returns` (DSL-fusion writer) → `source_pipeline="generation_pipeline.dsl_fusion"`
- `backend/archimedes/agents/generation_pipeline.py::_backtest_and_persist` (portfolio-simulator writer) → `source_pipeline="generation_pipeline.portfolio_backtester"`

`source_pipeline` has no default at either the ORM column or the
`insert_backtest_if_missing` function signature — a new writer that forgets
to stamp it fails at call time, not silently. `source_git_sha` is centralized
in `insert_backtest_if_missing` (derived from `ARCHIMEDES_GIT_SHA` once) so
individual writers don't need to duplicate that lookup.

## Backfill (ships with this migration, applied to prod)

The 73 pre-existing rows:

- `backtest_engine = 'dsl-fusion'` → `source_pipeline =
  'generation_pipeline.dsl_fusion'` (deterministic — only one writer has
  ever set that engine tag).
- `backtest_engine = 'portfolio-simulator-v1'` → `source_pipeline =
  'generation_pipeline.portfolio_backtester'` (deterministic, same reasoning;
  0 rows matched this in prod today).
- Everything else (`backtest_engine = 'backtrader'` or NULL) →
  `source_pipeline = 'unknown_pre_provenance'`. `run_backtests.py` and
  `seed_backtests_from_artifacts.py` both produce identical
  `'backtrader'`-tagged artifacts through the same mapper, so there is no
  signal in the pre-existing columns to tell them apart historically — an
  honestly-labelled unknown beats a confident guess.
- `computed_at <- created_at` for every existing row (best available proxy;
  true compute time was never captured before this column existed).
- `source_git_sha` stays NULL for every existing row (no historical record
  of which commit produced them).
- `provenance_inferred <- true` for every row this backfill touched.

**Applied to prod** (tunnel already open, table already backed up +
restore-verified per the safety net in place before this change):

```
$ alembic upgrade head
INFO  [alembic.runtime.migration] Running upgrade 3f643d292e04 -> 363d1c6ff0c0,
      add row-level provenance to backtest_results
```

Post-migration verification against prod:
- `alembic_version` = `363d1c6ff0c0` ✓
- row count unchanged: 73 ✓
- `source_pipeline`/`computed_at` both 0 NULLs ✓
- distribution: `generation_pipeline.dsl_fusion` × 19 (all `dsl-fusion`
  engine rows), `unknown_pre_provenance` × 54 (all `backtrader` engine rows)
  ✓ — matches the measured 54/19 split exactly
- `provenance_inferred = true` on all 73 rows, `source_git_sha` NULL on all
  73 — both correctly flagged as backfilled, not fabricated ✓

## num_trials_in_selection convention (Dan's item 1 — investigated, not
changed)

Traced the self-contained-N convention ("decouple #2") through the code to
confirm the re-run precondition holds:

- **Generated strategies** (`generation_pipeline.py`'s two writers):
  `_society_num_trials(n_candidates) = max(1, n_candidates)` — the
  strategy's own generation/debate pool size, never the library size. This
  is already correctly wired for both the DSL-fusion and portfolio-simulator
  writers.
- **Curated strategies** (`run_backtests.py` / `seed_backtests_from_artifacts.py`):
  `map_artifact_to_backtest_result` never sets `num_trials_in_selection` at
  insert time — it's left `NULL` and later filled to `1` (self-contained,
  "the paper's headline config") by `selection_bias_routes.py`'s cohort-gate
  compute, which always passes `num_trials=1` for every curated strategy.
  Confirmed via `analytics-engine/scripts/retest_candidates.py`'s own
  docstring that the walk-forward parameter-grid trial count
  (`n_param_combos`) is a read-only diagnostic script, explicitly never
  written back to any store — it does not feed `run_backtests.py`.

Net: neither writer inherits N=34 (library size) or the cross-strategy
population — both match the decided self-contained convention. The stale
N=25/32/35 values Dan measured in the live table are pre-"decouple #2"
residue (that convention reversed an older library-size-deflation approach,
per the extensive comments already in `rigor_profiles.py` /
`generation_pipeline.py`); a fresh re-run persists new content-hash-keyed
rows under the current convention, and `latest_backtests_by_strategy` reads
the newest row. **No code change made here** — this section is
investigation only, reported per the task brief's request to confirm before
a re-run, not to redesign the semantics (explicitly out of scope, owned by
Dan/Önder). Flagged as a candidate follow-up in Concerns below.

## Verification

- `alembic upgrade head` — clean, both fresh SQLite and prod Postgres
  (tested a scratch backfill scenario on SQLite matching the 4
  `backtest_engine` cases before touching prod).
- `alembic downgrade` / re-`upgrade head` — clean, idempotent (tested).
- Backend suite: 3018 passed, 5 skipped (unchanged from baseline).
- Analytics-engine suite: 227 passed (unchanged from baseline).
- `ruff format --check .` / `ruff check --select E9,F63,F7,F40,F82 .` — clean.
- Also fixed `test_alembic_strategy_spec_column_added_and_removed`, which
  downgraded via a relative `-1` from head — that silently started
  downgrading a *different* migration (this one) the moment this revision
  landed on top. Now resolves the strategy_spec revision's own
  `down_revision` from the script directory instead, so it stays correct
  regardless of how many further revisions land on top in the future.

## Concerns / follow-ups (not done here — out of scope for this PR)

- `run_backtests.py` leaves `num_trials_in_selection` unset at insert time,
  relying on a later `selection_bias_routes.py` GET request to backfill it
  to `1`. The end state matches convention, but a row that never gets that
  GET call stays `NULL` indefinitely. Stamping `num_trials_in_selection=1`
  directly at insert for curated strategies (matching the already-decided
  self-contained convention, not a new one) would close that gap — flagging
  for Dan/Önder rather than making the call unilaterally.
- The re-run itself (making the 9 currently-rowless strategies produce real
  rows, re-grading the 32 zero-trade casualties) is not part of this PR —
  this PR is the provenance substrate the re-run should land on top of.
