### PR TITLE
[test] Unbreak main — spend-cap tests used a pre-validator placeholder address

### DIFF
--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -246,7 +246,7 @@ def test_subscribe_rejects_over_spend_cap(client):
     be reached when the check refuses."""
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("c1")},
     )
     assert resp.status_code == 200, resp.text
 
@@ -274,7 +274,7 @@ def test_subscribe_under_spend_cap_still_succeeds(client):
     against an accidentally-inverted cap check silently 429-ing everything."""
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("c2")},
     )
     assert resp.status_code == 200, resp.text
 


### PR DESCRIPTION
**main is red** on `Backend — unit tests`:

```
{"detail":"vault_address must be a 0x-prefixed 20-byte hex address"}
assert 400 == 200
```

`test_subscribe_rejects_over_spend_cap` and `test_subscribe_under_spend_cap_still_succeeds`, both from #1099.

### Cause — a process failure, not a code one

#1099 was **180 commits behind main**. It was written before `marketplace_routes.py` grew an `_EVM_ADDRESS_RE` check on the user-supplied vault path (landed in `8cb5ebc4`, *"Wallet gate Marketplace and migrate to non-custodial"*), so its two new tests post the placeholder `"0xvault"` — today a 400.

**Its CI was green, and that green meant nothing.** GitHub freezes the test-merge ref at the PR's last push, so #1099 was tested against a base predating the validator. This is the **same failure mode diagnosed on #1155 earlier this week** — a stale merge ref producing a meaningless green check — and I merged straight past my own diagnosis of it.

### Fix

Use the file's own `_vaddr()` helper, as every other publish test already does, with previously-unused suffixes. Line 126's `"0xvault"` is deliberately left alone — that is a `create_vault` mock return on the auto-create path, which never reaches the validator.

### Verification

Run with the **exact** command CI uses, from the repo root rather than my usual `PYTHONPATH=backend` invocation — that difference is part of why this escaped locally:

```
python -m pytest -m "not integration" --tb=short -q
→ 3062 passed, 3 skipped, 2 deselected
```

`ruff format --check` and the critical rule set both clean.

### The durable lesson

**A PR far behind main has a green check that describes a base that no longer exists.** Two of these in one week. The disposition rule should be: *N commits behind → re-run CI against current main before merging, regardless of what the checkmark says.* Worth encoding in the branch-protection script or the merge checklist rather than relying on someone remembering.