### PR TITLE
[docs] CLAUDE.md: pre-merge review conventions — the green check may not mean what you think

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,47 @@ For a 5-person hackathon team operating async across 5 timezones, **one approvin
 is enough for non-contract changes. Contract changes get two. Reviewers should respond
 within ~12 hours during the hackathon so the contributor isn't blocked overnight.
 
+### Before you approve a merge — the green check may not mean what you think
+
+Applies to every reviewer, every session, and **every review subagent**. All four rules
+below come from defects that shipped past a full row of green checks in a single week.
+The common shape: **a signal was trusted for something it does not actually measure.**
+
+**1. A stale PR's green check describes a base that no longer exists.**
+GitHub freezes a PR's test-merge ref at its last push. A PR far behind `main` was tested
+against a base that may lack validators, columns, or behaviour that exist today — and
+"re-run failed jobs" replays the same frozen snapshot, so it can never pick up the fix.
+→ **If a PR is materially behind `main`, re-verify against current `main` before merging,
+whatever the checkmark says.** Push to the branch (or merge `main` in) to regenerate the
+ref, then read the *new* result.
+*Cost of learning it:* #1155 failed for exactly this reason; days later #1099 merged green
+and broke `main`, because its tests predated a `vault_address` validator.
+
+**2. Verify the merged result, not each PR.**
+Every PR being green does not make their union green. Semantic conflicts are textually
+clean and CI-invisible.
+→ **After merging anything non-trivial, re-run the suite on the merged `main`** — with the
+*exact* command CI uses, from the repo root. A local `pytest backend/tests` collects a
+different set than `pytest -m "not integration"` from the root, and the gap is where this
+hides.
+
+**3. A test that passes against the unfixed code proves nothing.**
+The specific trap: **passing the same literal to both sides of the boundary the bug lives
+on.** A Redis-key casing test that lower-cased the input before handing it to the reader
+made fixed and unfixed code produce identical keys — it passed either way and guarded
+nothing.
+→ **Before pushing a regression test, revert the fix and confirm the test fails.** If it
+passes both ways, it is not a regression guard; say so rather than counting it as coverage.
+
+**4. A guard must be shown to reject something.**
+Guards are where this repo's defects cluster: one checked presence but not value
+(`AGENT_DRY_RUN=1` silently meant LIVE), one measured the wrong compression state, one
+claimed "no network" and "installed package import path" while enforcing neither.
+→ **Build the input that *should* fail the guard, run it, confirm it fails — before
+pushing** — and put that demonstration in the PR body. This applies to claims made in
+**prose** too: a PR description asserting a property the code does not enforce is the same
+defect, just harder to grep for.
+
 ### Commit style
 
 Imperative mood ("Add strategy passport schema" not "Added strategy passport schema").

--- a/backend/tests/api/test_marketplace_routes.py
+++ b/backend/tests/api/test_marketplace_routes.py
@@ -246,7 +246,7 @@ def test_subscribe_rejects_over_spend_cap(client):
     be reached when the check refuses."""
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("c1")},
     )
     assert resp.status_code == 200, resp.text
 
@@ -274,7 +274,7 @@ def test_subscribe_under_spend_cap_still_succeeds(client):
     against an accidentally-inverted cap check silently 429-ing everything."""
     resp = client.post(
         "/api/marketplace/publish",
-        json={"strategy_id": "test_strat", "vault_address": "0xvault"},
+        json={"strategy_id": "test_strat", "vault_address": _vaddr("c2")},
     )
     assert resp.status_code == 200, resp.text
 


### PR DESCRIPTION
Four pre-merge rules for CLAUDE.md. All four come from defects that shipped **past a full row of green checks** in a single week, and they share one shape: **a signal was trusted for something it does not actually measure.**

| # | Rule | What it cost to learn |
|---|---|---|
| 1 | A stale PR's green check describes a base that no longer exists | #1155 failed for exactly this; days later **#1099 merged green and broke `main`** because its tests predated a `vault_address` validator that landed 180 commits earlier |
| 2 | Verify the merged result, not each PR | Every PR green ≠ their union green. Also names the local-vs-CI invocation gap that hid it |
| 3 | A test that passes against the unfixed code proves nothing | The specific trap: passing the **same literal to both sides of the boundary the bug lives on** |
| 4 | A guard must be shown to reject something — including claims made in prose | `AGENT_DRY_RUN=1` silently meant LIVE; a size guard measured the wrong compression state; a CI job advertised "no network" and enforced nothing |

Written for reviewers, sessions **and review subagents** — the failure mode is identical regardless of who is reading the diff, and subagents are where most diffs now get read first.

### Placement

Deliberately adjacent to `### CI / quality gates`, which **survives the pending docs restructure** (`origin/dbrowneup/docs-restructure` cuts CLAUDE.md 1066 → 229 lines). Placing it beside a section that is being deleted would have guaranteed a conflict. This should rebase cleanly, or at worst need a one-hunk re-application.

### Note for the docs series

If the restructure prefers this content as an ADR under `## Architectural decisions` — where the fail-soft principle already landed as *"Fail-soft is correct for optional configuration and wrong for anything a claim depends on"* — that is a reasonable home too, and these four are the same family. Happy to move it; flagging rather than assuming, since `docs/` is Cowork's lane.