### PR TITLE
Discriminate num_trials by provenance, not column presence (V1-V4, W3)

### DIFF
--- a/analytics-engine/scripts/consolidation_candidate1_verify.py
+++ b/analytics-engine/scripts/consolidation_candidate1_verify.py
@@ -408,11 +408,26 @@ def main() -> None:
     # ---------------------------------------------------------------------
     from archimedes.services.rigor_evaluator import run_rigor_gate
 
-    # num_trials: current (unmodified) library-count convention — the doc's
-    # own Part A #2 flags this convention as a known issue for a SEPARATE PR;
-    # this script does not change it, only uses it as every curated strategy
-    # is graded today.
-    NUM_CURATED_FILES = len(list(STRATEGIES_DIR.glob("*.py")))
+    # num_trials = 1 (audit 2026-08-03, V2): candidate #1 is a hand-fused blend
+    # of THREE hand-implemented published papers (Antonacci/Maillard/T-bill),
+    # combined with a fixed, untuned 1/3 weight — there is no search of ours
+    # here, so its selection-set size is 1, exactly like any other curated
+    # strategy (Dan's decision, 2026-07-27: "For a hand-curated implementation
+    # of one published paper there is no search of ours, so num_trials = 1").
+    # The PREVIOUS convention (`len(STRATEGIES_DIR.glob("*.py"))` == the
+    # curated library's file count, 34 as of this fix) deflated this candidate
+    # by the WHOLE library's size, which is exactly the cohort-deflation
+    # pattern the decision retires (mirrors V1's regen_fixtures.py bug, and
+    # decouple #2 for the live selection-bias routes) — it was never this
+    # candidate's own trial count. Restated at num_trials=1 the verdict is
+    # STILL a FAIL at the badge/strictest level (dsr_p_value rises from 0.0198
+    # to 0.5997 — the far more lenient number — but the badge threshold is
+    # 0.90; min_passing_level moves from None to 5, i.e. it only clears the
+    # loosest/Speculative rung, never the strictest one) — the corrected
+    # number changes, the conclusion does not. See
+    # docs/CURATED-STRATEGY-DECOUPLE-AND-CONSOLIDATE-2026-07-08.md and the
+    # 2026-08-03 num_trials-provenance audit for the full restatement.
+    CANDIDATE1_NUM_TRIALS = 1
     look_ahead_ok = (
         all(results[s].look_ahead_audit_passed for s in ("antonacci_2014_dual_momentum", "maillard_2010_risk_parity"))
         and tbill_result.look_ahead_audit_passed
@@ -421,7 +436,7 @@ def main() -> None:
     verdict = run_rigor_gate(
         strategy_id="candidate1_fused_tactical_riskparity_cashfloor",
         daily_returns=fused_returns,
-        num_trials=NUM_CURATED_FILES,
+        num_trials=CANDIDATE1_NUM_TRIALS,
         look_ahead_audit_passed=look_ahead_ok,
         library_pbo=fused_pbo,
         pbo_library_size=len(cohort_returns),
@@ -433,7 +448,7 @@ def main() -> None:
     _log(f"n_obs (fused, date-aligned)   = {len(fused_returns)}")
     _log(f"date range                    = {fused_dates[0]} .. {fused_dates[-1]}")
     _log(f"look_ahead_audit_passed       = {look_ahead_ok}")
-    _log(f"num_trials (library count)    = {NUM_CURATED_FILES}")
+    _log(f"num_trials (self-contained)   = {CANDIDATE1_NUM_TRIALS}")
     _log(f"deflated_sharpe               = {verdict.deflated_sharpe}")
     _log(f"dsr_p_value (HAC)             = {verdict.dsr_p_value}")
     _log(f"dsr_p_value (IID, advisory)   = {verdict.dsr_p_value_iid}")
@@ -487,7 +502,7 @@ def main() -> None:
         v = run_rigor_gate(
             strategy_id=label,
             daily_returns=returns,
-            num_trials=NUM_CURATED_FILES,
+            num_trials=CANDIDATE1_NUM_TRIALS,
             look_ahead_audit_passed=look_ahead_passed,
             library_pbo=fused_pbo,
             pbo_library_size=len(cohort_returns),
@@ -553,7 +568,7 @@ def main() -> None:
         "in_sample_sharpe": verdict.in_sample_sharpe,
         "pbo_score": verdict.pbo_score,
         "pbo_library_size": verdict.pbo_library_size,
-        "num_trials": NUM_CURATED_FILES,
+        "num_trials": CANDIDATE1_NUM_TRIALS,
         "passes_all": verdict.passes_all,
         "min_passing_level": verdict.min_passing_level,
         "blocked_by_floor": verdict.blocked_by_floor,

--- a/analytics-engine/scripts/regen_buy_hold_fixture.py
+++ b/analytics-engine/scripts/regen_buy_hold_fixture.py
@@ -230,6 +230,21 @@ def _compute_passes_rigor_gate(
     return not (full_sharpe is not None and full_sharpe > 0 and oos_sharpe / full_sharpe < 0.5)
 
 
+def curated_num_trials(existing_fixture_count: int) -> int:
+    """``num_trials_in_selection`` for the ``pipeline_buy_hold`` fixture entry
+    (V1 sibling fix, num_trials-provenance audit 2026-08-03).
+
+    ALWAYS 1: a buy-and-hold benchmark is hand-implemented, not the output of
+    a search of ours, so there is no candidate pool to deflate against — never
+    the curated library's size (Dan's decision, 2026-07-27). ``existing_fixture_count``
+    exists only so this function's contract is independently unit-testable
+    against the PREVIOUS (buggy) formula it replaces — ``len(fixtures)`` (the
+    library size) — without needing to run the whole fetch-and-backtest
+    pipeline; the fix is that this now ignores it.
+    """
+    return 1
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 
@@ -248,7 +263,7 @@ def main(write: bool = False) -> None:
             "snapshot first: conda run -n archimedes python "
             "backend/scripts/export_backtest_fixtures.py"
         ) from exc
-    num_trials = len(fixtures)
+    num_trials = curated_num_trials(len(fixtures))
     existing = fixtures.get("pipeline_buy_hold", {})
 
     print(f"Fetching SPY {BACKTEST_START} → {BACKTEST_END}…")

--- a/analytics-engine/scripts/regen_fixtures.py
+++ b/analytics-engine/scripts/regen_fixtures.py
@@ -21,8 +21,16 @@ PBO caveat:
     strategy's daily-return series simultaneously. Since we cannot faithfully
     reproduce the legacy return series, PBO here is computed over the NEW
     cohort only and is reported as such. It is a cohort-overfit signal, not the
-    full-library value. ``num_trials_in_selection`` IS set to the full library
-    size (legacy + new) so the DSR multiple-testing penalty is conservative.
+    full-library value.
+
+    ``num_trials_in_selection`` is set to 1 for every entry (V1 fix,
+    num_trials-provenance audit 2026-08-03): each strategy here is a
+    hand-implemented published paper, not the output of a search of ours, so
+    there is no candidate pool to deflate against — never the curated
+    library's size (Dan's decision, 2026-07-27). A PREVIOUS version of this
+    script stamped the post-add library size into every new entry instead;
+    that was the cross-strategy coupling the decision forbids outside
+    Leaderboard/Marketplace, not a genuine per-strategy trial count.
 
 DSR math (compute_dsr / compute_oos_sharpe / compute_kelly) is imported from
 ``regen_buy_hold_fixture`` so there is a single source for the rigor formulas
@@ -257,6 +265,24 @@ def _build_entry(result, *, metadata: dict, num_trials: int, corr_spy: float | N
     }
 
 
+def curated_num_trials(existing_fixture_count: int, new_entry_count: int) -> int:
+    """``num_trials_in_selection`` for every curated fixture entry this script
+    writes (V1 fix, num_trials-provenance audit 2026-08-03).
+
+    ALWAYS 1: every strategy backtested here is a hand-implemented published
+    paper, not the output of a search of ours, so there is no candidate pool
+    to deflate against — never the curated library's size (Dan's decision,
+    2026-07-27: "For a hand-curated implementation of one published paper
+    there is no search of ours, so num_trials = 1"). The arguments exist only
+    so this function's contract is independently unit-testable against the
+    PREVIOUS (buggy) formula it replaces — ``existing_fixture_count +
+    new_entry_count`` (the post-add library size) — without needing to run
+    the whole fetch-and-backtest pipeline; the fix is that this now ignores
+    both.
+    """
+    return 1
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 
@@ -285,10 +311,29 @@ def main(write: bool = False) -> None:
         print("Nothing to add — all catalog specs are already in the fixture file.")
         return
 
-    # num_trials_in_selection = full library size *after* this add (conservative DSR
-    # multiple-testing penalty). Counts existing fixtures + the genuinely-new specs.
-    num_trials = len(fixtures) + len(pending_single) + len(pending_pair) + len(pending_multi)
-    print(f"Library size after add: {num_trials} strategies (num_trials_in_selection)")
+    # num_trials_in_selection = 1 for every curated fixture entry this script
+    # writes (V1 fix, num_trials-provenance audit 2026-08-03). Every strategy
+    # backtested here is a hand-implemented published paper — the fixture
+    # generation process is not itself a search, so there is nothing to deflate
+    # against (Dan's decision, 2026-07-27: "For a hand-curated implementation
+    # of one published paper there is no search of ours, so num_trials = 1").
+    #
+    # The PREVIOUS convention below stamped the count of every curated fixture
+    # in the file (existing + newly-added) into EACH new entry's
+    # num_trials_in_selection, deflating each individually-authored strategy by
+    # how many OTHER strategies happen to sit in the library — exactly the
+    # cross-strategy coupling the decision forbids outside Leaderboard/
+    # Marketplace, and the same library-size-into-num_trials shape as the
+    # num_trials ∈ {25, 4} buckets observed live in production
+    # `backtest_results` rows tagged backtest_engine='backtrader' (this script
+    # writes to a separate table, `strategy_backtest_fixtures`, not
+    # `backtest_results` — the two were never mechanically linked — but it is
+    # the same anti-pattern, and fixing it here closes off the one remaining
+    # place in the codebase that still manufactures a library-size num_trials
+    # value for a curated entry):
+    #   num_trials = len(fixtures) + len(pending_single) + len(pending_pair) + len(pending_multi)
+    num_trials = curated_num_trials(len(fixtures), len(pending_single) + len(pending_pair) + len(pending_multi))
+    print(f"num_trials_in_selection for every new entry: {num_trials} (curated = no search of ours)")
 
     print(f"Fetching SPY benchmark {BACKTEST_START} → {BACKTEST_END}…")
     spy = fetch_ohlcv("SPY", BACKTEST_START, BACKTEST_END)

--- a/analytics-engine/tests/test_curated_num_trials.py
+++ b/analytics-engine/tests/test_curated_num_trials.py
@@ -1,0 +1,123 @@
+"""Regression guard for V1 (num_trials-provenance audit, 2026-08-03).
+
+``regen_fixtures.py`` and its sibling ``regen_buy_hold_fixture.py`` generate
+fixture entries for CURATED strategies — hand-implemented published papers,
+never the output of a search of ours. Per Dan's decision (2026-07-27): "For a
+hand-curated implementation of one published paper there is no search of
+ours, so num_trials = 1." A curated strategy's DSR multiple-testing
+correction must therefore be self-contained (num_trials=1), never deflated by
+how many OTHER strategies happen to sit in the library.
+
+BEFORE the fix, both scripts computed ``num_trials`` as a function of the
+current library size (``len(fixtures)`` [+ pending new entries]) and stamped
+that library-size count into every new entry's ``num_trials_in_selection`` —
+exactly the cross-strategy coupling the decision forbids outside
+Leaderboard/Marketplace, and the confirmed shape of the anomalous
+``num_trials`` values this audit traced in production.
+
+These tests call the extracted, directly-testable ``curated_num_trials()``
+helpers with library sizes that are DELIBERATELY LARGE (25, 34) and NONZERO
+pending-entry counts — i.e. exactly the inputs that would have produced a
+large, wrong ``num_trials`` under the old library-size formula. Asserting the
+result is always ``1`` regardless of those inputs is what makes this a
+regression guard, not a same-literal-both-sides tautology: the old formula
+and the new one are given the SAME inputs and diverge sharply (25/34/59 vs 1).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from regen_buy_hold_fixture import curated_num_trials as buy_hold_num_trials  # noqa: E402
+from regen_fixtures import curated_num_trials as fixtures_num_trials  # noqa: E402
+
+
+def _old_buggy_fixtures_formula(existing_fixture_count: int, new_entry_count: int) -> int:
+    """The PRE-fix formula regen_fixtures.py used to compute num_trials —
+    kept here only so the tests below can demonstrate they fail against it."""
+    return existing_fixture_count + new_entry_count
+
+
+def _old_buggy_buy_hold_formula(existing_fixture_count: int) -> int:
+    """The PRE-fix formula regen_buy_hold_fixture.py used to compute
+    num_trials — kept here only so the tests below can demonstrate they fail
+    against it."""
+    return existing_fixture_count
+
+
+def test_regen_fixtures_curated_num_trials_is_always_one():
+    """A curated fixture entry's num_trials is 1 no matter how large the
+    library is or how many new entries are being added in this run."""
+    # Library already has 25 entries (matches the production N=25 bucket this
+    # audit traced), and this run is adding 9 more (matches NEW_SINGLE_SPECS'
+    # actual length) — the exact shape of a real regen_fixtures.py --write run.
+    assert fixtures_num_trials(existing_fixture_count=25, new_entry_count=9) == 1
+    # A from-scratch library (0 existing) adding a handful of new entries.
+    assert fixtures_num_trials(existing_fixture_count=0, new_entry_count=6) == 1
+    # A much larger, more mature library — the result must still be 1.
+    assert fixtures_num_trials(existing_fixture_count=34, new_entry_count=1) == 1
+
+
+def test_regen_fixtures_diverges_from_the_old_buggy_formula():
+    """Adversarial: the SAME inputs that produced the wrong answer under the
+    old code must produce a DIFFERENT (correct) answer under the fix — proof
+    this isn't a test that would pass against unfixed code too."""
+    existing, new = 25, 9
+    old_wrong = _old_buggy_fixtures_formula(existing, new)
+    fixed = fixtures_num_trials(existing, new)
+    assert old_wrong == 34  # the old formula really did produce library-size N
+    assert fixed == 1
+    assert fixed != old_wrong
+
+
+def test_buy_hold_curated_num_trials_is_always_one():
+    assert buy_hold_num_trials(existing_fixture_count=25) == 1
+    assert buy_hold_num_trials(existing_fixture_count=0) == 1
+    assert buy_hold_num_trials(existing_fixture_count=34) == 1
+
+
+def test_buy_hold_diverges_from_the_old_buggy_formula():
+    existing = 25
+    old_wrong = _old_buggy_buy_hold_formula(existing)
+    fixed = buy_hold_num_trials(existing)
+    assert old_wrong == 25  # the old formula really did produce the library size
+    assert fixed == 1
+    assert fixed != old_wrong
+
+
+def test_every_entry_this_run_would_produce_gets_num_trials_one():
+    """Simulates the loop shape in regen_fixtures.py: several new entries
+    from ONE run must all receive num_trials=1, not the (larger) post-add
+    library size that a per-entry misuse of `len(fixtures)` after each write
+    could otherwise produce."""
+    existing = 25
+    pending_stems = ["a", "b", "c"]  # 3 new entries added in this run
+    for _ in pending_stems:
+        n = fixtures_num_trials(existing, len(pending_stems))
+        assert n == 1
+
+
+def test_main_wires_through_curated_num_trials_not_an_inline_formula():
+    """Wiring guard: the unit tests above only prove ``curated_num_trials()``
+    itself is correct — they would NOT catch a future refactor that reverts
+    ``main()`` to an inline library-size formula while leaving the (now
+    unused) helper untouched. Assert ``main()``'s source actually calls the
+    helper, so that regression is caught too."""
+    import inspect
+
+    import regen_fixtures as rf
+
+    src = inspect.getsource(rf.main)
+    assert "curated_num_trials(" in src
+
+
+def test_buy_hold_main_wires_through_curated_num_trials_not_an_inline_formula():
+    import inspect
+
+    import regen_buy_hold_fixture as rbh
+
+    src = inspect.getsource(rbh.main)
+    assert "curated_num_trials(" in src

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -533,7 +533,13 @@ def _num_trials_for_generated_row(backtest_engine: str | None, stored_num_trials
     ``backtest_engine``), not on whether ``stored_num_trials`` happens to be
     populated (V3). See the module comment above for the full rationale.
     """
-    if backtest_engine in _SEARCH_TRACKED_ENGINES and stored_num_trials:
+    # ``> 0``, not truthiness. A stored 0 or a negative is not a smaller search
+    # pool, it is a corrupt row: num_trials is a COUNT of candidates evaluated,
+    # so the only values with meaning are >= 1. Truthiness would reject 0 and
+    # silently ACCEPT -5, which then flows into the DSR deflation term and makes
+    # the correction weaker than no correction at all -- a bad row would grade
+    # more favourably than an honest one. Fail closed to 1 instead.
+    if backtest_engine in _SEARCH_TRACKED_ENGINES and (stored_num_trials or 0) > 0:
         return int(stored_num_trials), _SCOPE_GENERATED_SEARCH_POOL
     return 1, _SCOPE_GENERATED_UNTRACKED_DEFAULT
 

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Query, Request, Response
 
 from archimedes.api.limiter import limiter
 from archimedes.services.rigor_evaluator import (
+    assert_self_contained_cohort_correlation,
     compute_average_pairwise_correlation,
     compute_library_pbo,
     compute_pbo,
@@ -114,6 +115,15 @@ class StrategyRigorResult(BaseModel):
     strictness_level: int = 1
     min_passing_level: int | None = None
     blocked_by_floor: bool = False
+    # PROVENANCE of the num_trials this verdict was graded at (num_trials-
+    # provenance audit, 2026-08-03 — the "central item"): num_trials is the
+    # number of candidates the selection process that produced THIS result
+    # actually evaluated, never borrowed from a neighbour or a cohort. See
+    # ``_num_trials_for_generated_row`` for the values this takes and why.
+    # "unspecified" is the safe default for shapes (pending/no-data) that never
+    # got far enough to compute a num_trials at all — never silently implies a
+    # trustworthy value.
+    num_trials_scope: str = "unspecified"
 
 
 class RigorGateResponse(BaseModel):
@@ -313,7 +323,17 @@ async def evaluate_rigor_gate(
         # The strategy library is the multiple-testing selection set; correlated
         # strategies (overlapping assets/signals) carry fewer independent trials, so
         # the DSR effective-N correction relaxes the penalty via N_eff = N/(1+(N-1)ρ̄).
+        #
+        # NOTE: this cohort-wide correlation is INERT today because num_trials=1
+        # above (see _dsr_from_stats: E[max_N]=0 when N==1) — it is computed and
+        # threaded through for whichever criteria might use it, but cannot move
+        # the DSR verdict at num_trials=1. The guard below (V4, num_trials-
+        # provenance audit 2026-08-03) makes that invariant IMPOSSIBLE to
+        # silently break: if a future edit ever reintroduces num_trials>1 here,
+        # this raises loudly instead of quietly re-coupling every curated
+        # strategy's DSR to the library's correlation structure again.
         avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+        assert_self_contained_cohort_correlation(num_trials, avg_correlation)
 
         # Run rigor gate for each strategy
         computed: list[StrategyRigorResult] = []
@@ -405,6 +425,7 @@ async def evaluate_rigor_gate(
                     strictness_level=strictness,
                     min_passing_level=gate_result.min_passing_level,
                     blocked_by_floor=gate_result.blocked_by_floor,
+                    num_trials_scope=_SCOPE_CURATED_SELF_CONTAINED,
                 )
             )
         return computed
@@ -438,6 +459,83 @@ async def evaluate_rigor_gate(
         library_pbo=library_pbo,
         strictness_level=strictness,
     )
+
+
+# ── num_trials provenance discriminator (W3, the central item) ──────────────
+#
+# The rule (Dan, 2026-07-27): num_trials is the number of candidates the
+# selection process that produced THIS result actually evaluated.
+#   curated  (a hand-implemented published paper — no search of ours) -> 1
+#   generated (the candidate pool IS the search)                      -> selection_pool_size
+#
+# For curated strategies (`evaluate_rigor_gate` above) that's unconditional —
+# num_trials=1 is hardcoded regardless of any stored value (see the comment at
+# `num_trials = 1` above). For GENERATED strategies (this function, DB-
+# persisted `strategy_store` rows) num_trials has to come from a STORED
+# column, and V3 is exactly the bug that read it bare: ANY populated
+# ``num_trials_in_selection`` was trusted, regardless of which pipeline wrote
+# it. That conflates two different things a positive integer in that column
+# could mean — "a real generation search evaluated N candidates" vs. "some
+# writer's default/forgotten argument happened to be N" — which the stored
+# value alone cannot distinguish (traced concretely: debate_engine.py's
+# dsl-fusion path and generation_pipeline.py's portfolio-simulator-v1 path
+# both funnel through `_society_num_trials(pool_size)` at their one live call
+# site today, but `_backtest_and_persist`'s own signature defaults
+# `num_trials: int = 1` — a FUTURE caller that forgets to pass the real pool
+# size would silently write the same num_trials=1 a genuinely self-contained
+# strategy writes, with nothing in the column to tell them apart).
+#
+# The fix: discriminate on PROVENANCE — which pipeline actually computed and
+# persisted this row — not on whether the column happens to be populated.
+# `backtest_engine` (NOT NULL-reliable for the three pipelines that exist
+# today: 'backtrader' | 'dsl-fusion' | 'portfolio-simulator-v1' — confirmed by
+# repo-wide grep, num_trials-provenance audit 2026-08-03) is the only
+# currently-persisted signal that says which pipeline wrote a row, so it is
+# the discriminator used here. Only 'dsl-fusion' and 'portfolio-simulator-v1'
+# are pipelines whose live writer stamps a genuine, tracked selection-pool
+# size (both call `_society_num_trials(n_candidates)` — generation_pipeline.py
+# passes it to both `_persist_real_returns` and `_backtest_and_persist`
+# identically) — a row tagged with one of those AND carrying a truthy stored
+# value can be trusted. Anything else reaching this DB-persisted (generated)
+# code path — an unknown/missing engine tag, or a search-tracked engine whose
+# writer left num_trials unset/zero — has NOT proven it tracks its own search
+# count, so per the rule it must record num_trials=1 and say so explicitly
+# via ``num_trials_scope``, rather than silently borrowing whatever number
+# happens to be sitting in the column.
+#
+# Deliberately NOT a new persisted DB column (the task's "decide whether a
+# dedicated deflation_scope field is warranted" question): (1) `backtest_engine`
+# is already a reliable, live discriminator for every pipeline that exists
+# today — there is nothing this needs that isn't already on the row; (2) a
+# separate provenance-column migration (source_pipeline/computed_at/
+# provenance_inferred) already exists as its own open, unreviewed PR
+# (branch `provenance-backtest-results-work`) — landing an overlapping schema
+# change here would fork that review and create an avoidable merge conflict
+# instead of building on it later; (3) this scope label is a DERIVED,
+# request-time classification of already-persisted, reliable data, not new
+# ground truth — computing it at read time keeps ONE source of truth
+# (`backtest_engine`) instead of two independently-writable columns that could
+# drift apart. ``num_trials_scope`` on the response is the "carry an explicit
+# scope marker" the task asks for — visible to callers/tests without a schema
+# change.
+_SEARCH_TRACKED_ENGINES = frozenset({"dsl-fusion", "portfolio-simulator-v1"})
+
+# Scope labels for StrategyRigorResult.num_trials_scope.
+_SCOPE_CURATED_SELF_CONTAINED = "curated_self_contained"  # hand-implemented paper, no search of ours -> 1
+_SCOPE_GENERATED_SEARCH_POOL = "generated_search_pool"  # trusted: engine's own tracked selection-pool size
+_SCOPE_GENERATED_UNTRACKED_DEFAULT = "generated_untracked_default"  # untrusted/absent -> forced to 1, explicitly
+
+
+def _num_trials_for_generated_row(backtest_engine: str | None, stored_num_trials: int | None) -> tuple[int, str]:
+    """``(num_trials, scope)`` for a DB-persisted (generated) strategy row.
+
+    Discriminates on PROVENANCE (which pipeline wrote the row via
+    ``backtest_engine``), not on whether ``stored_num_trials`` happens to be
+    populated (V3). See the module comment above for the full rationale.
+    """
+    if backtest_engine in _SEARCH_TRACKED_ENGINES and stored_num_trials:
+        return int(stored_num_trials), _SCOPE_GENERATED_SEARCH_POOL
+    return 1, _SCOPE_GENERATED_UNTRACKED_DEFAULT
 
 
 def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: int) -> StrategyRigorResult | None:
@@ -503,9 +601,14 @@ def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: in
             )
 
         # Persisted context from the latest backtest row — never recomputed
-        # against any cohort (curated or otherwise). A missing num_trials
-        # defaults to 1 (run_rigor_gate's own documented "genuinely single-trial"
-        # fallback, logged loudly there); a missing pbo_score stays None, which
+        # against any cohort (curated or otherwise). num_trials is resolved by
+        # PROVENANCE, not a bare column read (V3 — see
+        # ``_num_trials_for_generated_row`` above for the full rationale): only
+        # a row from a pipeline whose live writer tracks its own selection-pool
+        # size ('dsl-fusion' | 'portfolio-simulator-v1') is trusted to carry a
+        # real N; anything else is forced to num_trials=1 with an explicit
+        # ``num_trials_scope`` marker rather than silently trusting whatever
+        # happens to be in the column. A missing pbo_score stays None, which
         # run_rigor_gate treats fail-closed (criterion 4 FAILs rather than
         # silently passing) — exactly the same fail-closed contract the curated
         # path relies on.
@@ -520,7 +623,10 @@ def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: in
         # judged on its face, never softened by a library-size argument it doesn't
         # have) — consistent with "never weaken the gate", not an oversight.
         latest = latest_backtests_by_strategy(session, [strategy_id]).get(strategy_id)
-        num_trials = latest.num_trials_in_selection if latest and latest.num_trials_in_selection else 1
+        num_trials, num_trials_scope = _num_trials_for_generated_row(
+            latest.backtest_engine if latest else None,
+            latest.num_trials_in_selection if latest else None,
+        )
         persisted_pbo = latest.pbo_score if latest else None
         persisted_look_ahead = bool(latest.look_ahead_audit_passed) if latest else False
 
@@ -559,6 +665,7 @@ def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: in
         strictness_level=strictness,
         min_passing_level=gate_result.min_passing_level,
         blocked_by_floor=gate_result.blocked_by_floor,
+        num_trials_scope=num_trials_scope,
     )
 
 

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -339,6 +339,7 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
 
     def _compute() -> dict[str, RigorGateResult]:
         from archimedes.services.rigor_evaluator import (
+            assert_self_contained_cohort_correlation,
             compute_average_pairwise_correlation,
             compute_pbo,
             run_rigor_gate,
@@ -361,6 +362,13 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
             # #2). PBO/avg_correlation stay cohort-wide (out of scope here).
             num_trials = 1
             avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+            # V4 guard (num_trials-provenance audit 2026-08-03): cohort-wide
+            # avg_correlation is INERT at num_trials=1 (E[max_N]=0 when N==1) —
+            # this makes it IMPOSSIBLE for a future edit to silently reintroduce
+            # num_trials>1 here without re-coupling every strategy's DSR to the
+            # library's correlation structure; it raises instead (caught below,
+            # same fail-closed contract as the rest of this cohort-context block).
+            assert_self_contained_cohort_correlation(num_trials, avg_correlation)
         except Exception as exc:
             logger.warning("live rigor result batch: cohort-context compute failed (all → stale fallback): %s", exc)
             return {}

--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -575,6 +575,53 @@ def compute_average_pairwise_correlation(
     return max(0.0, min(1.0, float(np.mean(upper))))
 
 
+def assert_self_contained_cohort_correlation(num_trials: int, average_correlation: float) -> None:
+    """Guard against the num_trials / cohort-correlation re-coupling trap
+    (num_trials-provenance audit 2026-08-03, V4).
+
+    Three call sites (``selection_bias_routes.evaluate_rigor_gate``,
+    ``strategies_routes._live_rigor_results_for_strategies``,
+    ``live_rigor_gate.verdicts_for_strategies``) each compute a COHORT-WIDE
+    ``average_correlation`` across every strategy in the curated library with
+    enough persisted returns, then grade each individual strategy at
+    ``num_trials=1`` (Dan's decouple #2 principle, 2026-07-09 / restated
+    2026-07-27: a curated strategy's rigor depends only on itself, never on
+    its neighbours). At ``num_trials=1`` that cohort-wide correlation is INERT
+    by construction — ``_dsr_from_stats``'s ``E[max_N]`` term is unconditionally
+    ``0.0`` when ``N == 1``, so ``average_correlation`` cannot move the DSR
+    verdict no matter what value it holds.
+
+    That inertness is exactly what makes ``num_trials=1`` + a cohort-wide
+    correlation SAFE today — and exactly what would make a future edit that
+    reintroduces ``num_trials > 1`` at one of those call sites DANGEROUS: the
+    cohort-wide correlation would silently start relaxing the multiple-testing
+    penalty using OTHER strategies' correlation structure, re-coupling the
+    library the decision retired. Nothing else flags it — the code would just
+    silently compute a different, wrong DSR for every strategy in the cohort.
+
+    Call this immediately after computing a cohort-wide ``average_correlation``
+    and before it is used, at any call site that holds ``num_trials=1`` by
+    contract. Raises ``RuntimeError`` (never a bare ``assert``, which ``-O``
+    can strip) so the violation is IMPOSSIBLE to silently pass through, not
+    merely unlikely. Does nothing when ``average_correlation == 0.0`` — an
+    N>1 caller with its OWN, non-cohort correlation context (a strategy's own
+    generation search pool or parameter-variant grid) is legitimate and
+    unaffected; only the COMBINATION of num_trials>1 with a nonzero
+    correlation reaching this specific guard is disallowed.
+    """
+    if num_trials != 1 and average_correlation != 0.0:
+        raise RuntimeError(
+            f"cohort-wide average_correlation={average_correlation!r} combined with "
+            f"num_trials={num_trials!r} != 1 — this re-couples a curated/self-contained "
+            "strategy's DSR to a cohort's correlation structure, exactly what the "
+            "decouple #2 decision (2026-07-09, restated 2026-07-27) forbids outside "
+            "Leaderboard/Marketplace. If this call site legitimately needs num_trials>1 "
+            "(e.g. a strategy's own generation search pool or parameter-variant grid), "
+            "compute average_correlation from THAT search's own candidates — never from "
+            "the curated cohort."
+        )
+
+
 # ─── 3b. Combinatorial Purged Cross-Validation OOS Sharpe ────────────
 
 

--- a/backend/archimedes/services/live_rigor_gate.py
+++ b/backend/archimedes/services/live_rigor_gate.py
@@ -216,6 +216,7 @@ def verdicts_for_strategies(strategies: list) -> dict[str, RigorGateVerdict]:
         from archimedes.db import get_session, init_db
         from archimedes.services.backtest_repository import get_all_daily_returns
         from archimedes.services.rigor_evaluator import (
+            assert_self_contained_cohort_correlation,
             compute_average_pairwise_correlation,
             compute_pbo,
         )
@@ -243,6 +244,13 @@ def verdicts_for_strategies(strategies: list) -> dict[str, RigorGateVerdict]:
         pbo_scores = compute_pbo(valid_returns) if len(valid_returns) >= 2 else {}
         num_trials = 1
         avg_correlation = compute_average_pairwise_correlation(valid_returns) if len(valid_returns) >= 2 else 0.0
+        # V4 guard (num_trials-provenance audit 2026-08-03): cohort-wide
+        # avg_correlation is INERT at num_trials=1 — makes it IMPOSSIBLE for a
+        # future edit to silently reintroduce num_trials>1 here without
+        # re-coupling every strategy's badge DSR to the library's correlation
+        # structure; it raises instead (caught below, same fail-closed
+        # contract — a pending badge, never a wrong PASS).
+        assert_self_contained_cohort_correlation(num_trials, avg_correlation)
     except Exception as exc:
         logger.warning("live rigor gate batch: cohort-context compute failed (all → pending): %s", exc)
         return {sid: RigorGateVerdict.pending() for sid in strategy_ids}

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import Session
 from archimedes.services._rigor_helpers import (
     _ANNUALIZATION,
     _RF_DAILY,
+    assert_self_contained_cohort_correlation,  # noqa: F401 - re-exported for the 3 cohort call sites (V4 guard)
     benjamini_hochberg_fdr,  # noqa: F401 - re-exported for test_rigor_evaluator
     bonferroni_correction,  # noqa: F401 - re-exported for test_rigor_evaluator
     classify_regimes,  # used by run_rigor_gate (regime-robustness) + re-exported for test_rigor_regime

--- a/backend/tests/test_num_trials_correlation_guard.py
+++ b/backend/tests/test_num_trials_correlation_guard.py
@@ -28,7 +28,9 @@ IMPOSSIBLE (raises ``RuntimeError``) rather than merely unlikely. These tests:
 
 from __future__ import annotations
 
+import ast
 import inspect
+import textwrap
 
 import pytest
 from archimedes.services.rigor_evaluator import assert_self_contained_cohort_correlation
@@ -67,23 +69,58 @@ def test_guard_allows_genuinely_self_contained_multi_trial_with_zero_correlation
 
 # ── 3. Wiring: all three call sites actually invoke the guard ──────────────
 
+_GUARD = "assert_self_contained_cohort_correlation"
+
+
+def _invokes(func: object, target: str = _GUARD) -> bool:
+    """True only if ``func``'s own AST contains a real invocation of ``target``.
+
+    Deliberately NOT ``target in inspect.getsource(func)``. A substring check
+    passes on any occurrence of the name — including the one left behind in a
+    comment or docstring after the actual call was deleted. That is precisely
+    how a wiring guard stops guarding while still reporting green, so the guard
+    on the guard has to inspect structure, not text. Matches both ``guard(...)``
+    and ``mod.guard(...)`` forms.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    return any(
+        isinstance(node, ast.Call)
+        and (getattr(node.func, "id", None) == target or getattr(node.func, "attr", None) == target)
+        for node in ast.walk(tree)
+    )
+
+
+def test_the_wiring_check_itself_discriminates():
+    """Adversarial pass on our own guard-checker, per the pre-merge conventions:
+    a check is only worth trusting once it has been shown to REJECT something.
+    A function that merely mentions the guard's name in a comment and a string
+    -- but never calls it -- must NOT be reported as wired."""
+
+    def _mentions_but_never_calls():
+        # assert_self_contained_cohort_correlation(num_trials, corr)
+        return "assert_self_contained_cohort_correlation("
+
+    assert _invokes(_mentions_but_never_calls) is False
+
+    def _actually_calls():
+        return assert_self_contained_cohort_correlation(1, 0.0)
+
+    assert _invokes(_actually_calls) is True
+
 
 def test_selection_bias_routes_evaluate_rigor_gate_calls_the_guard():
     from archimedes.api.selection_bias_routes import evaluate_rigor_gate
 
-    src = inspect.getsource(evaluate_rigor_gate)
-    assert "assert_self_contained_cohort_correlation(" in src
+    assert _invokes(evaluate_rigor_gate)
 
 
 def test_strategies_routes_live_rigor_results_calls_the_guard():
     from archimedes.api.strategies_routes import _live_rigor_results_for_strategies
 
-    src = inspect.getsource(_live_rigor_results_for_strategies)
-    assert "assert_self_contained_cohort_correlation(" in src
+    assert _invokes(_live_rigor_results_for_strategies)
 
 
 def test_live_rigor_gate_verdicts_for_strategies_calls_the_guard():
     from archimedes.services.live_rigor_gate import verdicts_for_strategies
 
-    src = inspect.getsource(verdicts_for_strategies)
-    assert "assert_self_contained_cohort_correlation(" in src
+    assert _invokes(verdicts_for_strategies)

--- a/backend/tests/test_num_trials_correlation_guard.py
+++ b/backend/tests/test_num_trials_correlation_guard.py
@@ -1,0 +1,89 @@
+"""V4 regression guard: num_trials-provenance audit, 2026-08-03.
+
+Three cohort-computing call sites — ``selection_bias_routes.evaluate_rigor_gate``,
+``strategies_routes._live_rigor_results_for_strategies``, and
+``live_rigor_gate.verdicts_for_strategies`` — each compute a COHORT-WIDE
+``average_correlation`` across every curated strategy with enough persisted
+returns, then grade each strategy at ``num_trials=1`` (Dan's decouple #2
+principle). At ``num_trials=1`` that correlation is INERT by construction
+(``_dsr_from_stats``: ``E[max_N] == 0`` when ``N == 1``), so today it changes
+nothing. The risk is a FUTURE edit at one of those three sites reintroducing
+``num_trials > 1`` while leaving the cohort-wide correlation wired in —
+silently re-coupling every curated strategy's DSR to the library's
+correlation structure again, exactly what the decision forbids outside
+Leaderboard/Marketplace.
+
+``assert_self_contained_cohort_correlation`` makes that combination
+IMPOSSIBLE (raises ``RuntimeError``) rather than merely unlikely. These tests:
+  1. Prove the guard actually rejects the forbidden input (adversarial pass).
+  2. Prove it does NOT fire on the legitimate ``num_trials=1`` case (today's
+     real usage) or on a genuinely self-contained ``num_trials>1`` case with
+     its OWN (non-cohort) correlation of 0.0 (e.g. an uncorrelated
+     parameter-variant grid — the documented legitimate exception).
+  3. Prove all three call sites are actually WIRED to call the guard, not
+     just that the guard itself is correct in isolation (the same
+     same-literal-both-sides risk V1's fix guarded against: a helper being
+     correct doesn't prove its caller still uses it).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from archimedes.services.rigor_evaluator import assert_self_contained_cohort_correlation
+
+
+# ── 1 & 2. The guard itself ──────────────────────────────────────────────────
+
+
+def test_guard_rejects_num_trials_above_one_with_nonzero_cohort_correlation():
+    """Adversarial: this is EXACTLY the shape a reintroduced library-size bug
+    would produce at one of the three cohort call sites — num_trials pulled
+    from cohort size (>1) alongside that same cohort's average_correlation.
+    Before this guard existed, this combination would silently compute a
+    materially different (wrong) DSR with nothing to catch it."""
+    with pytest.raises(RuntimeError, match="re-couples"):
+        assert_self_contained_cohort_correlation(25, 0.31)
+
+    with pytest.raises(RuntimeError):
+        assert_self_contained_cohort_correlation(2, 1e-9)  # any nonzero correlation trips it
+
+
+def test_guard_allows_the_real_num_trials_one_cohort_case():
+    """Today's actual usage at all three call sites: num_trials=1 with a
+    real, nonzero cohort-wide correlation. Must never raise — this is the
+    documented-safe combination (E[max_N]=0 makes the correlation inert)."""
+    assert_self_contained_cohort_correlation(1, 0.73) is None
+    assert_self_contained_cohort_correlation(1, 0.0) is None
+
+
+def test_guard_allows_genuinely_self_contained_multi_trial_with_zero_correlation():
+    """A strategy's OWN N-candidate generation pool or parameter-variant grid
+    legitimately passes num_trials>1 — the guard must not block that, only
+    the COMBINATION with a nonzero (cohort) correlation."""
+    assert_self_contained_cohort_correlation(35, 0.0) is None
+
+
+# ── 3. Wiring: all three call sites actually invoke the guard ──────────────
+
+
+def test_selection_bias_routes_evaluate_rigor_gate_calls_the_guard():
+    from archimedes.api.selection_bias_routes import evaluate_rigor_gate
+
+    src = inspect.getsource(evaluate_rigor_gate)
+    assert "assert_self_contained_cohort_correlation(" in src
+
+
+def test_strategies_routes_live_rigor_results_calls_the_guard():
+    from archimedes.api.strategies_routes import _live_rigor_results_for_strategies
+
+    src = inspect.getsource(_live_rigor_results_for_strategies)
+    assert "assert_self_contained_cohort_correlation(" in src
+
+
+def test_live_rigor_gate_verdicts_for_strategies_calls_the_guard():
+    from archimedes.services.live_rigor_gate import verdicts_for_strategies
+
+    src = inspect.getsource(verdicts_for_strategies)
+    assert "assert_self_contained_cohort_correlation(" in src

--- a/backend/tests/test_selection_bias_generated_gate.py
+++ b/backend/tests/test_selection_bias_generated_gate.py
@@ -111,10 +111,16 @@ def _mk_backtest(
     num_trials: int | None = 1,
     pbo: float | None = 0.05,
     look_ahead: bool = True,
+    backtest_engine: str | None = None,
 ):
     """Persist a BacktestResultRecord whose artifact_json carries daily_returns
     (mirrors how the real pipeline / analytics-engine writes them — see
-    backend/archimedes/services/backtest_repository.get_daily_returns)."""
+    backend/archimedes/services/backtest_repository.get_daily_returns).
+
+    ``backtest_engine`` defaults to None (matches every pre-existing caller in
+    this file — legacy/untagged row shape) — tests exercising the num_trials
+    PROVENANCE discriminator (V3) pass it explicitly.
+    """
     from archimedes.models.backtest_store import BacktestResultRecord
 
     artifact_json = None
@@ -131,6 +137,7 @@ def _mk_backtest(
                 pbo_score=pbo,
                 look_ahead_audit_passed=look_ahead,
                 source_pipeline="test",
+                backtest_engine=backtest_engine,
             )
         )
         session.commit()
@@ -269,3 +276,105 @@ def test_look_ahead_override_flips_blocked_verdict_to_pass():
     assert with_override.status == "pass"
     assert with_override.passes is True
     assert with_override.blocked_by_floor is False
+
+
+# ── 6. num_trials PROVENANCE discriminator (V3 / W3, num_trials-provenance audit 2026-08-03) ──
+#
+# `_generated_strategy_rigor` used to do a bare read of the persisted
+# `num_trials_in_selection` column — ANY populated value was trusted,
+# regardless of which pipeline wrote it. These tests prove the replacement
+# (`_num_trials_for_generated_row`) discriminates on `backtest_engine`
+# PROVENANCE instead, using a return series (seed=3, mu=0.0006, sigma=0.008,
+# n=300) deliberately chosen so num_trials=1 vs num_trials=25 flips the
+# DSR-gate verdict (PASS at N=1, FAIL at N=25) — an end-to-end, observable
+# consequence, not just an internal label.
+
+
+def _flip_sensitive_returns() -> list[float]:
+    """PASSES the DSR gate at num_trials=1 (p≈0.964 ≥ 0.90) and FAILS it at
+    num_trials=25 (p≈0.377 < 0.90) — verified directly against
+    rigor_evaluator.run_rigor_gate with these exact parameters."""
+    return np.random.default_rng(3).normal(0.0006, 0.008, 300).tolist()
+
+
+def test_num_trials_for_generated_row_discriminates_on_provenance():
+    """Unit-level: the discriminator trusts a stored value ONLY for engines
+    whose live writer tracks its own selection-pool size; everything else
+    (unknown/missing engine, or a search-tracked engine with no real value
+    stored) is forced to num_trials=1 with an explicit, honest scope label —
+    never a bare 'is the column populated' check."""
+    from archimedes.api.selection_bias_routes import (
+        _SCOPE_GENERATED_SEARCH_POOL,
+        _SCOPE_GENERATED_UNTRACKED_DEFAULT,
+        _num_trials_for_generated_row,
+    )
+
+    # Trusted: a search-tracking engine with a real stored pool size.
+    assert _num_trials_for_generated_row("dsl-fusion", 35) == (35, _SCOPE_GENERATED_SEARCH_POOL)
+    assert _num_trials_for_generated_row("portfolio-simulator-v1", 12) == (12, _SCOPE_GENERATED_SEARCH_POOL)
+
+    # Adversarial: an UNKNOWN/missing engine tag with a large stored value that
+    # LOOKS like a real search pool (exactly the shape a stale/borrowed
+    # library-size write would produce, e.g. the V1 bug) must NOT be trusted —
+    # this is the case the bare-read code got wrong.
+    assert _num_trials_for_generated_row(None, 25) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
+    assert _num_trials_for_generated_row("backtrader", 25) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
+    assert _num_trials_for_generated_row("some-future-engine", 999) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
+
+    # A search-tracked engine with no real value stored (falsy) still forces 1.
+    assert _num_trials_for_generated_row("dsl-fusion", None) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
+    assert _num_trials_for_generated_row("dsl-fusion", 0) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
+
+
+async def test_dsl_fusion_engine_trusts_stored_search_pool_end_to_end():
+    """A row tagged 'dsl-fusion' with a stored num_trials is graded at THAT
+    N (trusted, real search-pool size) — verdict FAILS because num_trials=25
+    applies the full multiple-testing penalty to this return series."""
+    sid = "gen0000000000006"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_backtest(sid, returns=_flip_sensitive_returns(), num_trials=25, backtest_engine="dsl-fusion")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/selection-bias/gate/{sid}", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["num_trials_scope"] == "generated_search_pool"
+    assert body["dsr_p_value"] < 0.90
+    assert body["passes_all"] is False
+
+
+async def test_untracked_engine_num_trials_forced_to_one_not_bare_column_read():
+    """THE adversarial case (V3): a row with NO recognized search-tracking
+    engine (backtest_engine=None — the untagged/legacy shape) but a stored
+    num_trials_in_selection=25 that LOOKS like a real cohort/search size.
+
+    Before the fix, `_generated_strategy_rigor` did a bare read of the
+    column: ``latest.num_trials_in_selection if latest and
+    latest.num_trials_in_selection else 1`` — this would have trusted 25 and
+    FAILED the gate (dsr_p≈0.377 < 0.90) on a return series that is
+    genuinely fine at its true (self-contained) trial count. The fix
+    discriminates on provenance: an untracked engine cannot prove it ran a
+    real 25-candidate search, so num_trials is forced to 1 and the gate
+    PASSES (dsr_p≈0.964 ≥ 0.90) — the honest verdict for this strategy.
+    """
+    sid = "gen0000000000007"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_backtest(sid, returns=_flip_sensitive_returns(), num_trials=25, backtest_engine=None)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/selection-bias/gate/{sid}", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["num_trials_scope"] == "generated_untracked_default"
+    assert body["dsr_p_value"] >= 0.90, (
+        f"num_trials was not forced to 1 — the bare-column-read bug is back "
+        f"(dsr_p_value={body['dsr_p_value']} suggests the untrusted stored "
+        f"num_trials=25 was used instead)"
+    )
+    assert body["passes_all"] is True

--- a/backend/tests/test_selection_bias_generated_gate.py
+++ b/backend/tests/test_selection_bias_generated_gate.py
@@ -325,6 +325,19 @@ def test_num_trials_for_generated_row_discriminates_on_provenance():
     assert _num_trials_for_generated_row("dsl-fusion", None) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
     assert _num_trials_for_generated_row("dsl-fusion", 0) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
 
+    # NEGATIVES. This is the case a truthiness test cannot catch and the two
+    # above do not discriminate: 0 and None are already falsy, so they pass
+    # against a buggy ``and stored_num_trials`` implementation too. -5 is
+    # TRUTHY, so only a ``> 0`` check rejects it.
+    #
+    # Why it matters beyond hygiene: num_trials is a COUNT of candidates
+    # evaluated, and it feeds the DSR multiple-testing deflation. A negative
+    # would not merely be ignored -- it would make the correction weaker than
+    # applying no correction at all, so a corrupt row would grade MORE
+    # favourably than an honest one. Fail closed to 1.
+    assert _num_trials_for_generated_row("dsl-fusion", -5) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
+    assert _num_trials_for_generated_row("portfolio-simulator-v1", -1) == (1, _SCOPE_GENERATED_UNTRACKED_DEFAULT)
+
 
 async def test_dsl_fusion_engine_trusts_stored_search_pool_end_to_end():
     """A row tagged 'dsl-fusion' with a stored num_trials is graded at THAT


### PR DESCRIPTION
## Summary

Lands the **agent-safe** items from the 2026-08-03 num_trials-provenance audit, implementing Dan's 2026-07-27 decision:

> Strategies are deflated WITHIN THE DEBATE SOCIETY, as part of generation, where num_trials = the candidate pool the search actually considered. They are NOT deflated against each other in the curated library or anywhere outside generation.
> - curated (a hand-implemented published paper — no search of ours) → num_trials = 1
> - generated (the candidate pool IS the search) → num_trials = selection_pool_size

**Does not** touch `docs/`, does not merge/close anything, does not write to the production DB, does not retire any curated strategy, does not touch `MIN_LIBRARY_N_FOR_PBO_GATING` or cohort PBO. All out-of-scope items (W0/W5/W8/W10) are explicitly **not** implemented — see below.

## What landed

### V1 — `regen_fixtures.py` / `regen_buy_hold_fixture.py` (curated fixture generators)
Both scripts stamped a **library-size** count into every new fixture entry's `num_trials_in_selection` (`regen_fixtures.py`: `len(fixtures) + len(pending_*)`; `regen_buy_hold_fixture.py`: `len(fixtures)`). Every entry either script writes is tagged `backtest_engine="backtrader"` — i.e. always curated, always a hand-implemented paper, never a search. Fixed: both now call an extracted `curated_num_trials(...)` helper that unconditionally returns `1`, with the old formula left in a comment for context. The helper is independently unit-tested (not just inline) so a future revert of the *call site* — leaving the helper itself untouched — is also caught (a "wiring guard", same pattern as the V4 tests below).

### V2 — `consolidation_candidate1_verify.py` (one-off curated-consolidation verification script)
Used `NUM_CURATED_FILES = len(list(STRATEGIES_DIR.glob("*.py")))` (**34**) as `num_trials` for a hand-fused, untuned 1/3 blend of three curated papers (Antonacci + Maillard + T-bill). No search of ours produced this candidate, so `num_trials` must be `1`. Fixed the constant and **restated the verdict against real yfinance data** (same fetch, same fused return series, only `num_trials` changed):

| | num_trials=34 (buggy) | num_trials=1 (corrected) |
|---|---|---|
| `deflated_sharpe` | -0.4495 | **+0.0551** |
| `dsr_p_value` (HAC) | 0.0198 | **0.5997** |
| `blocked_by_floor` | True | False |
| `min_passing_level` | None | **5** (loosest rung only) |
| `passes_all` @ badge/strictest level | False | **False (unchanged)** |

The number was wrong; the conclusion wasn't — candidate #1 still fails at the badge level even under the maximally lenient `num_trials=1` (no multiple-testing penalty at all). Full run log + raw JSON kept for reproducibility, not committed (matches the script's existing "kept locally, not committed" convention for its own output).

### V3 — `selection_bias_routes.py` (THE item with deploy-gate blast radius)
`_generated_strategy_rigor` (the rigor path for DB-persisted / generated strategies — reached both by the passport `GET /gate/{id}` and by `vaults_routes._deployable_levels`, i.e. the **deploy gate**) did a bare read:
```python
num_trials = latest.num_trials_in_selection if latest and latest.num_trials_in_selection else 1
```
Any populated value was trusted regardless of *which pipeline wrote it*. Replaced with `_num_trials_for_generated_row(backtest_engine, stored_num_trials)`, which discriminates on **provenance**:
- `backtest_engine` ∈ `{"dsl-fusion", "portfolio-simulator-v1"}` **and** a truthy stored value → trusted (both pipelines' one live writer, `generation_pipeline.py`, funnels through `_society_num_trials(pool_size)` identically — verified by reading the call sites, not assumed).
- anything else (unknown/missing engine tag, or a search-tracked engine with no real value stored) → forced to `num_trials=1`, with an explicit `num_trials_scope` marker (`"generated_search_pool"` vs. `"generated_untracked_default"` vs. `"curated_self_contained"`) added to the `StrategyRigorResult` response so the discrimination is visible, not just internal.

**Why no new DB column** (the task's "decide whether a dedicated `deflation_scope` field is warranted" question): `backtest_engine` is already a reliable, live, NOT-borrowed discriminator for every pipeline that exists today. A separate provenance-column migration (`source_pipeline`/`computed_at`/`provenance_inferred`) already exists as its own **open, unreviewed** PR (#1220, branch `provenance-backtest-results-work`) — landing an overlapping schema change here would fork that review and risk a needless merge conflict. `num_trials_scope` is a *derived*, request-time classification of already-persisted data, not new ground truth, so computing it at read time off the one existing signal (`backtest_engine`) keeps a single source of truth instead of forking into two independently-writable columns that could drift apart. Full rationale is in the code comment above `_num_trials_for_generated_row`.

### V4 — the three cohort-wide `average_correlation` sites
`live_rigor_gate.py`, `selection_bias_routes.py`, `strategies_routes.py` each compute a cohort-wide `average_correlation` and pair it with a hardcoded `num_trials=1`. Today that's inert by construction (`_dsr_from_stats`: `E[max_N]=0` when `N==1`), but nothing stopped a future edit from reintroducing `num_trials>1` at one of these sites while leaving the cohort correlation wired in — silently re-coupling every curated strategy's DSR to the library's correlation structure again. Added `assert_self_contained_cohort_correlation(num_trials, average_correlation)` (in `_rigor_helpers.py`, re-exported from `rigor_evaluator.py`) — raises `RuntimeError` on `num_trials != 1 and average_correlation != 0.0`, wired into all three call sites immediately after they compute the correlation. **No behavior change today** (verified: full backend suite green, all three sites still produce identical results) — this is a trip-wire, not a fix to a live bug.

## Deliberately NOT implemented (human-gated, per task brief)

- **W0** — retroactive portfolio-math sign-off (Onder, blocking).
- **W5** — replace cohort PBO with per-strategy criterion 4 + delete `MIN_LIBRARY_N_FOR_PBO_GATING` (Onder).
- **W8** — de-sqrt(T) the leaderboard DSR component (Onder — re-ranks the public board).
- **W10** — execute the retire/keep split (Dan — not agent-safe). Nothing here touches `MIN_LIBRARY_N_FOR_PBO_GATING`, the leaderboard DSR component, or any curated-strategy file.

Also **not** attempted: hardening `generation_pipeline._backtest_and_persist`'s `num_trials: int = 1` default signature (a landmine noted in the audit — a *future* caller that forgets to pass the real pool size would silently look identical to a genuinely self-contained write) — that's a generation-pipeline change, out of this PR's file set, and the one live caller today (`generation_pipeline.py:1079`) already passes the real value correctly.

## Verification

- `env -i HOME="$HOME" PATH="$PATH" PYTHONPATH=backend python -m pytest backend/tests -q` → **3069 passed, 5 skipped, 2 failed**. The 2 failures (`test_marketplace_routes.py::test_subscribe_rejects_over_spend_cap`, `test_subscribe_under_spend_cap_still_succeeds`) are **pre-existing on `origin/main`** — reproduced identically with this branch's changes fully `git stash`ed, unrelated to spend-cap/vault_address validation, not touched by this PR.
- `PYTHONPATH=analytics-engine/src python -m pytest analytics-engine/tests -q` → **234 passed** (baseline 227 + 7 new).
- `ruff format --check .` and `ruff check --select E9,F63,F7,F40,F82 .` → clean, repo-wide.
- Every new test was run against the **unfixed** code first and confirmed to fail (adversarial pass), then the fix was restored and re-verified green — done for V1 (both scripts), V3 (the bare-column-read case), and V4 (guard rejection + wiring at all 3 call sites). None of the new tests pass the same literal to both sides of the boundary being tested (the specific failure mode flagged in the task brief) — each adversarial test constructs an input the OLD code demonstrably handles wrong and the NEW code handles right, verified by literally reverting and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
