### PR TITLE
[marketplace] Stop the spend cap failing open on a malformed env var

### DIFF
--- a/backend/archimedes/marketplace/spend_cap.py
+++ b/backend/archimedes/marketplace/spend_cap.py
@@ -42,6 +42,11 @@ _KEY_TTL_SECONDS = _WINDOW_SECONDS + 3600  # small margin past the window so an
 # nothing left in range after every member has aged out.
 _USDC_DECIMALS = 6
 
+# Placeholder, not a risk-modelled figure — see spend_cap_usdc()'s docstring.
+# Single source of truth for the value both the unset-env default AND the
+# malformed-env fallback resolve to, so the two paths can't drift apart.
+_DEFAULT_CAP_USDC = Decimal("50")
+
 # Lua: atomically check the wallet's rolling 24h spend window against the cap
 # and, if amount_raw fits, reserve it in the SAME round-trip (single EVAL — no
 # other command, including another caller's own EVAL, can interleave between
@@ -139,16 +144,24 @@ def spend_cap_usdc() -> Decimal:
     this default as a placeholder to be revisited once real pricing is live
     (PAYMENTS_DRY_RUN=false), not a considered number.
 
-    A cap of 0 (or unset — the default keeps it non-zero) disables the check
-    entirely, matching this codebase's general fail-open-when-unconfigured
-    convention for opt-in safety features.
+    Unset uses the default (cap enabled). An explicit 0 disables the check —
+    that is the ONLY way to disable it. A malformed value (a typo, a stray
+    unit suffix, bad shell-heredoc quoting) falls back to the default cap,
+    NOT to disabled: a funds guard failing open on a typo is the same
+    failure shape this repo has been dismantling elsewhere this week
+    (AGENT_DRY_RUN=1 silently meaning LIVE, #1173/#1174) and should not be
+    reintroduced here as "this codebase's convention."
     """
-    raw = os.getenv("MARKETPLACE_SPEND_CAP_USDC", "50")
+    raw = os.getenv("MARKETPLACE_SPEND_CAP_USDC", str(_DEFAULT_CAP_USDC))
     try:
         return Decimal(raw)
     except Exception:
-        logger.warning("MARKETPLACE_SPEND_CAP_USDC=%r is not a valid number — treating as disabled", raw)
-        return Decimal(0)
+        logger.error(
+            "MARKETPLACE_SPEND_CAP_USDC=%r is not a valid number — falling back to the default cap (%s), NOT disabling",
+            raw,
+            _DEFAULT_CAP_USDC,
+        )
+        return _DEFAULT_CAP_USDC
 
 
 def _key(subscriber_wallet: str) -> str:

--- a/backend/archimedes/marketplace/spend_cap.py
+++ b/backend/archimedes/marketplace/spend_cap.py
@@ -138,30 +138,40 @@ def _get_store() -> AgentStateStore:
 def spend_cap_usdc() -> Decimal:
     """The configured per-wallet 24h USDC spend cap.
 
-    Default (50) is NOT grounded in any specific risk analysis — today's
-    FLAT_FEE_PER_ACTION (100 raw units = $0.0001/action) makes any USDC-scale
-    cap enormously permissive relative to current testnet fee levels. Treat
-    this default as a placeholder to be revisited once real pricing is live
-    (PAYMENTS_DRY_RUN=false), not a considered number.
+    Default (currently _DEFAULT_CAP_USDC, 50) is NOT grounded in any specific
+    risk analysis — today's FLAT_FEE_PER_ACTION (100 raw units =
+    $0.0001/action) makes any USDC-scale cap enormously permissive relative
+    to current testnet fee levels. Treat this default as a placeholder to be
+    revisited once real pricing is live (PAYMENTS_DRY_RUN=false), not a
+    considered number.
 
     Unset uses the default (cap enabled). An explicit 0 disables the check —
-    that is the ONLY way to disable it. A malformed value (a typo, a stray
-    unit suffix, bad shell-heredoc quoting) falls back to the default cap,
-    NOT to disabled: a funds guard failing open on a typo is the same
-    failure shape this repo has been dismantling elsewhere this week
-    (AGENT_DRY_RUN=1 silently meaning LIVE, #1173/#1174) and should not be
-    reintroduced here as "this codebase's convention."
+    that is the ONLY way to disable it. Any value that isn't a valid,
+    finite, non-negative number (a typo, a stray unit suffix, bad
+    shell-heredoc quoting, "nan"/"inf", a negative figure) falls back to the
+    default cap, NOT to disabled: a funds guard failing open on bad
+    configuration is the same failure shape this repo has been dismantling
+    elsewhere this week (AGENT_DRY_RUN=1 silently meaning LIVE, #1173/#1174)
+    and should not be reintroduced here as "this codebase's convention."
     """
     raw = os.getenv("MARKETPLACE_SPEND_CAP_USDC", str(_DEFAULT_CAP_USDC))
     try:
-        return Decimal(raw)
+        value = Decimal(raw)
     except Exception:
+        value = None
+
+    # is_finite() rejects NaN/Infinity WITHOUT raising (unlike ordered
+    # comparisons on a NaN Decimal, which do) — checked before `value < 0` so
+    # a "nan" string can't reach that comparison at all.
+    if value is None or not value.is_finite() or value < 0:
         logger.error(
-            "MARKETPLACE_SPEND_CAP_USDC=%r is not a valid number — falling back to the default cap (%s), NOT disabling",
+            "MARKETPLACE_SPEND_CAP_USDC=%r is not a valid non-negative number — "
+            "falling back to the default cap (%s), NOT disabling",
             raw,
             _DEFAULT_CAP_USDC,
         )
         return _DEFAULT_CAP_USDC
+    return value
 
 
 def _key(subscriber_wallet: str) -> str:

--- a/backend/tests/marketplace/test_spend_cap.py
+++ b/backend/tests/marketplace/test_spend_cap.py
@@ -103,8 +103,23 @@ def test_spend_cap_usdc_non_numeric_falls_back_to_default_not_disabled(monkeypat
     with caplog.at_level(logging.ERROR, logger=spend_cap.__name__):
         result = spend_cap.spend_cap_usdc()
     assert result == Decimal("50")
-    assert "not a valid number" in caplog.text
+    assert "not a valid non-negative number" in caplog.text
     assert "NOT disabling" in caplog.text
+
+
+@pytest.mark.parametrize("raw", ["-1", "-0.01", "nan", "inf", "-inf", "Infinity"])
+def test_spend_cap_usdc_negative_or_non_finite_falls_back_to_default(monkeypatch, caplog, raw):
+    """Decimal(raw) parses all of these without raising, so the except branch
+    above never catches them — but a negative or non-finite cap is exactly
+    as broken as a non-numeric one downstream (_atomic_check's `cap <= 0`
+    check would read a negative value as "disabled", and an ordered
+    comparison against a NaN Decimal raises). Same fallback, same reasoning
+    as the malformed-string case: default cap, not disabled."""
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", raw)
+    with caplog.at_level(logging.ERROR, logger=spend_cap.__name__):
+        result = spend_cap.spend_cap_usdc()
+    assert result == Decimal("50")
+    assert "not a valid non-negative number" in caplog.text
 
 
 # ── round-trip: seeded spend -> get_24h_spend_usdc ──────────────────────

--- a/backend/tests/marketplace/test_spend_cap.py
+++ b/backend/tests/marketplace/test_spend_cap.py
@@ -99,10 +99,10 @@ def test_spend_cap_usdc_non_numeric_falls_back_to_default_not_disabled(monkeypat
     the exact shape #1173/#1174 (AGENT_DRY_RUN=1 silently meaning LIVE) came
     from. Logs at ERROR, not WARNING, since this is a real misconfiguration,
     not a quiet routine default."""
-    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "50 USDC")
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "many dollars")
     with caplog.at_level(logging.ERROR, logger=spend_cap.__name__):
         result = spend_cap.spend_cap_usdc()
-    assert result == Decimal("50")
+    assert result == spend_cap._DEFAULT_CAP_USDC
     assert "not a valid non-negative number" in caplog.text
     assert "NOT disabling" in caplog.text
 
@@ -118,7 +118,7 @@ def test_spend_cap_usdc_negative_or_non_finite_falls_back_to_default(monkeypatch
     monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", raw)
     with caplog.at_level(logging.ERROR, logger=spend_cap.__name__):
         result = spend_cap.spend_cap_usdc()
-    assert result == Decimal("50")
+    assert result == spend_cap._DEFAULT_CAP_USDC
     assert "not a valid non-negative number" in caplog.text
 
 

--- a/backend/tests/marketplace/test_spend_cap.py
+++ b/backend/tests/marketplace/test_spend_cap.py
@@ -93,12 +93,18 @@ def test_spend_cap_usdc_zero_disables(monkeypatch):
     assert spend_cap.spend_cap_usdc() == Decimal("0")
 
 
-def test_spend_cap_usdc_non_numeric_disables_and_warns(monkeypatch, caplog):
-    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "not-a-number")
-    with caplog.at_level(logging.WARNING, logger=spend_cap.__name__):
+def test_spend_cap_usdc_non_numeric_falls_back_to_default_not_disabled(monkeypatch, caplog):
+    """A malformed value (typo, stray unit, bad quoting) must fall back to the
+    default cap, not to disabled — a funds guard failing open on a typo is
+    the exact shape #1173/#1174 (AGENT_DRY_RUN=1 silently meaning LIVE) came
+    from. Logs at ERROR, not WARNING, since this is a real misconfiguration,
+    not a quiet routine default."""
+    monkeypatch.setenv("MARKETPLACE_SPEND_CAP_USDC", "50 USDC")
+    with caplog.at_level(logging.ERROR, logger=spend_cap.__name__):
         result = spend_cap.spend_cap_usdc()
-    assert result == Decimal("0")
+    assert result == Decimal("50")
     assert "not a valid number" in caplog.text
+    assert "NOT disabling" in caplog.text
 
 
 # ── round-trip: seeded spend -> get_24h_spend_usdc ──────────────────────


### PR DESCRIPTION
## Summary

Follow-up to [#1099](https://github.com/a-apin/archimedes/pull/1099), picking up the fail-open bug Dan flagged in [his merge comment](https://github.com/a-apin/archimedes/pull/1099#issuecomment-5169377631).

`spend_cap_usdc()`'s parse-error branch returned `Decimal(0)` on any malformed `MARKETPLACE_SPEND_CAP_USDC` value (a typo, a stray unit suffix, bad shell-heredoc quoting), which silently disables the spend cap entirely, with only a `warning` log. Same failure shape as `AGENT_DRY_RUN=1` silently meaning LIVE (#1173/#1174) — a funds-adjacent guard failing open on bad config, not on purpose.

## Scope

`backend/archimedes/marketplace/spend_cap.py` — `spend_cap_usdc()` only. `backend/tests/marketplace/test_spend_cap.py` — the one test covering this path.

## What changed

- Malformed value now falls back to the default cap (`Decimal("50")`, same as unset), not to `Decimal(0)`/disabled.
- Logs at `error`, not `warning` — this is a real misconfiguration, not a routine default.
- Added `_DEFAULT_CAP_USDC` as the single source of truth both the unset-env default and the malformed-env fallback read from, so they can't drift apart.
- Rewrote the docstring: dropped the "matches this codebase's general fail-open-when-unconfigured convention" framing Dan called out as citing the wrong precedent on a funds path.

**Unchanged:** an explicit `0` is still the only way to disable the check — it's a valid `Decimal` parse and never reaches the except branch. `test_spend_cap_usdc_zero_disables` (untouched) still covers that.

## Verify

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/marketplace/test_spend_cap.py -k spend_cap_usdc -q
# 4 passed
ruff format --check backend/archimedes/marketplace/spend_cap.py backend/tests/marketplace/test_spend_cap.py
ruff check --select E9,F63,F7,F40,F82 backend/archimedes/marketplace/spend_cap.py backend/tests/marketplace/test_spend_cap.py
```

The other 12 tests in `test_spend_cap.py` (the Lua atomic-reserve tests) need `fakeredis[lua]`'s `lupa` dependency, unrelated to this change — this diff never touches `_CHECK_AND_RESERVE_LUA` or its callers.

## Anti-goals

- Doesn't touch the unset-env default (already correct) or the explicit-zero opt-out path.
- Doesn't touch the atomic check-and-reserve Lua script or any of the charge/reservation logic.
