### PR TITLE
[frontend] Mark the leaderboard provisional while backtests are re-computed

### DIFF
--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -96,6 +96,35 @@ export default function Leaderboard() {
           real rigor-gate and backtest results — the ugly numbers included. Build your track record now;
           it carries to mainnet.
         </p>
+        {/* PROVISIONAL-DATA BANNER — remove this whole block once the backtest
+            re-run completes and the figures below are trustworthy again.
+            A routing defect (fixed in #1203) meant most library strategies were
+            backtested against a hardcoded SPY default instead of their own
+            declared ASSET_UNIVERSE. Cross-sectional strategies fared worst:
+            given a single feed they had nothing to rank, so they emitted zero
+            trades and a flat 0% return, which the rigor gate then graded as
+            though it were a result.
+            Saying so out loud is the only option consistent with the product's
+            own thesis: taking the page down would hide the demonstration, and
+            leaving it silently wrong is the exact failure this product exists
+            to oppose. */}
+        <div
+          role="status"
+          style={{
+            marginTop: 10,
+            padding: '10px 14px',
+            borderLeft: '3px solid var(--warning, #b45309)',
+            background: 'var(--warning-muted, rgba(180,83,9,0.10))',
+            borderRadius: 4,
+            fontSize: 13,
+            color: 'var(--text-2)',
+          }}
+        >
+          <strong style={{ color: 'var(--warning, #b45309)' }}>Provisional — figures are being re-computed.</strong>{' '}
+          Backtest data is being re-computed following a routing defect; figures shown are known to be
+          incorrect and will change.
+        </div>
+
         {engine?.disclaimer && (
           <div style={{ marginTop: 10, padding: '8px 12px', borderLeft: '3px solid var(--accent)', background: 'var(--accent-muted)', borderRadius: 4, fontSize: 13, color: 'var(--text-2)' }}>
             <strong style={{ color: 'var(--accent)' }}>Testnet — paper/simulated.</strong> {engine.disclaimer}

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -121,8 +121,10 @@ export default function Leaderboard() {
           }}
         >
           <strong style={{ color: 'var(--warning, #b45309)' }}>Provisional — figures are being re-computed.</strong>{' '}
-          Backtest data is being re-computed following a routing defect; figures shown are known to be
-          incorrect and will change.
+          Two defects are being corrected. A routing defect meant most strategies were backtested against the
+          wrong asset universe. Separately, the backtest and live-trading engines were found to interpret the
+          same strategy differently — so for some strategies these figures describe behaviour that differs
+          from what the strategy would actually do. Figures shown are known to be incorrect and will change.
         </div>
 
         {engine?.disclaimer && (

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -114,7 +114,7 @@ export default function Leaderboard() {
             marginTop: 10,
             padding: '10px 14px',
             borderLeft: '3px solid var(--warning, #b45309)',
-            background: 'var(--warning-muted, rgba(180,83,9,0.10))',
+            background: 'var(--warning-bg, rgba(180,83,9,0.10))',
             borderRadius: 4,
             fontSize: 13,
             color: 'var(--text-2)',


### PR DESCRIPTION
Reinstates the banner from #1216, which was closed when the decision was to fix the figures rather than label them. Re-opened under a revised call: **hold the re-run, label the page now.**

> **Provisional — figures are being re-computed.** Backtest data is being re-computed following a routing defect; figures shown are known to be incorrect and will change.

### Why the numbers are wrong

#1203 fixed a routing defect: most library strategies were backtested against a hardcoded `SPY` default instead of their own declared `ASSET_UNIVERSE`. Cross-sectional strategies fared worst — given a single feed they had nothing to rank, so they emitted **zero trades and a flat 0% return**, which the rigor gate then graded as though it were a result. The persisted backtests have not been re-computed yet, so the page is still serving those figures.

### Why the re-run is being held rather than rushed

A second problem surfaced while preparing the re-run, and re-running before resolving it would publish a *fresh* set of biased numbers with more authority attached:

`run_dsl_backtest` (`backend/archimedes/services/fusion_evaluator.py:181-190`) accepts **no slippage parameter at all**. The only two `set_slippage_perc` call sites in the tree are `analytics-engine/.../engine.py:399` and `costs.py:78`. So dsl-fusion strategies structurally cannot pay slippage, while curated strategies do — and the rigor gate and leaderboard are engine-blind, with no branch on which engine produced a row. A differential experiment is measuring the magnitude now.

### Why a banner rather than taking the page down

Taking the page down hides the demonstration. Leaving it silently wrong is the precise failure this product exists to oppose. Saying so out loud is the only option consistent with the thesis — and it is the strongest thing a skeptical reader could click on.

### Removal

The block is self-contained and carries its own removal condition in a comment, so retiring it after the re-run is one deletion, not an archaeology exercise.

### Verification

`npm run build` and `npm run lint` clean. The banner string is present in the **shipped bundle** (`dist/assets/index-DsW_knRF.js`), not just in source — and the check is discriminating: the same grep against a build of the unmodified tree returns **0** occurrences, versus 1 with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
