### PR TITLE
[ui] Fix Breadcrumbs CRUMB_MAP stale navigation scheme (#1219)

### DIFF
--- a/backend/tests/test_breadcrumbs.py
+++ b/backend/tests/test_breadcrumbs.py
@@ -1,0 +1,139 @@
+"""Regression: Breadcrumbs CRUMB_MAP must stay in sync with App.jsx PAGE_TO_PATH (#1219).
+
+Fourth surface carrying the retired navigation scheme — the first three were
+fixed in #1192. A dead key fails silently (Breadcrumbs returns null), so the
+invariant must be enforced by a test, not by eyeballing.
+
+Hermetic: reads the committed source files, no DB / Redis / RPC / .env.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BREADCRUMBS = REPO_ROOT / "ui" / "src" / "components" / "Breadcrumbs.jsx"
+APP = REPO_ROOT / "ui" / "src" / "App.jsx"
+
+
+def _extract_crumb_keys(text: str) -> set[str]:
+    m = re.search(r"const\s+CRUMB_MAP\s*=\s*\{(.*?)\n\}", text, re.DOTALL)
+    assert m, "CRUMB_MAP block not found in Breadcrumbs.jsx"
+    block = m.group(1)
+    # keys are: explore: or 'create-vault': or "create-vault":
+    keys = re.findall(r"""^\s*['\"]?([a-z0-9_-]+)['\"]?\s*:""", block, re.MULTILINE | re.IGNORECASE)
+    # fallback: unquoted without colon quote
+    if not keys:
+        keys = re.findall(r"^\s*['\"]?([a-zA-Z0-9_-]+)['\"]?\s*:", block, re.MULTILINE)
+    return set(keys)
+
+
+def _extract_page_to_path_keys(text: str) -> set[str]:
+    m = re.search(r"const\s+PAGE_TO_PATH\s*=\s*\{(.*?)\n\}", text, re.DOTALL)
+    assert m, "PAGE_TO_PATH block not found in App.jsx"
+    block = m.group(1)
+    keys = re.findall(r"^\s*['\"]?([a-z0-9_-]+)['\"]?\s*:", block, re.MULTILINE | re.IGNORECASE)
+    return set(keys)
+
+
+def _extract_crumb_groups(text: str) -> list[str | None]:
+    m = re.search(r"const\s+CRUMB_MAP\s*=\s*\{(.*?)\n\}", text, re.DOTALL)
+    assert m
+    block = m.group(1)
+    # group: 'Discover' or group: null
+    raw = re.findall(r"group\s*:\s*(?:'([^']+)'|\"([^\"]+)\"|null)", block)
+    groups: list[str | None] = []
+    for a, b in raw:
+        if a:
+            groups.append(a)
+        elif b:
+            groups.append(b)
+        else:
+            groups.append(None)
+    return groups
+
+
+def _extract_crumb_group_pages(text: str) -> list[str | None]:
+    m = re.search(r"const\s+CRUMB_MAP\s*=\s*\{(.*?)\n\}", text, re.DOTALL)
+    assert m
+    block = m.group(1)
+    raw = re.findall(r"groupPage\s*:\s*(?:'([^']+)'|\"([^\"]+)\"|null)", block)
+    pages: list[str | None] = []
+    for a, b in raw:
+        if a:
+            pages.append(a)
+        elif b:
+            pages.append(b)
+        else:
+            pages.append(None)
+    return pages
+
+
+def test_crumb_map_keys_subset_of_page_to_path() -> None:
+    crumbs = _extract_crumb_keys(BREADCRUMBS.read_text(encoding="utf-8"))
+    pages = _extract_page_to_path_keys(APP.read_text(encoding="utf-8"))
+    extra = crumbs - pages
+    assert not extra, (
+        f"CRUMB_MAP contains keys not in PAGE_TO_PATH: {sorted(extra)}. "
+        f"CRUMB_MAP={sorted(crumbs)} PAGE_TO_PATH={sorted(pages)}. "
+        "Remove stale keys or add the page to App.jsx PAGE_TO_PATH (latter is wrong per #1219 anti-goals)."
+    )
+
+
+def test_crumb_map_has_no_retired_group_labels() -> None:
+    text = BREADCRUMBS.read_text(encoding="utf-8")
+    # only inspect the CRUMB_MAP block, not comments
+    m = re.search(r"const\s+CRUMB_MAP\s*=\s*\{(.*?)\n\}", text, re.DOTALL)
+    assert m
+    block = m.group(1)
+    assert "Markets" not in block, "retired group label 'Markets' still in CRUMB_MAP — use Discover/Strategy/etc."
+    assert "Portfolio" not in block, "retired group label 'Portfolio' still in CRUMB_MAP — use Position/Market/etc."
+    # also ensure the retired dead keys are gone (subset test would catch them, but give a clearer message)
+    crumbs = _extract_crumb_keys(text)
+    dead = {
+        "strategies",
+        "trade",
+        "dashboard",
+        "mint",
+        "liquidity",
+        "vaults",
+        "create-vault",
+        "financial",
+        "vault-detail",
+        "risk",
+        "rigor-explainer",
+    }
+    leaked = crumbs & dead
+    assert not leaked, f"CRUMB_MAP still contains retired keys: {sorted(leaked)}"
+
+
+def test_crumb_map_group_labels_are_current_nav() -> None:
+    allowed = {None, "Discover", "Strategy", "Position", "Market", "Ops"}
+    groups = _extract_crumb_groups(BREADCRUMBS.read_text(encoding="utf-8"))
+    bad = [g for g in groups if g not in allowed]
+    assert not bad, f"CRUMB_MAP uses unknown group labels {bad} — allowed {sorted(a for a in allowed if a)} plus null"
+
+
+def test_crumb_map_group_pages_are_valid() -> None:
+    pages = _extract_page_to_path_keys(APP.read_text(encoding="utf-8"))
+    group_pages = _extract_crumb_group_pages(BREADCRUMBS.read_text(encoding="utf-8"))
+    bad = [p for p in group_pages if p is not None and p not in pages]
+    assert not bad, f"CRUMB_MAP groupPage values not in PAGE_TO_PATH: {bad} — must be a valid page or null"
+
+
+def test_crumb_map_covers_primary_path() -> None:
+    crumbs = _extract_crumb_keys(BREADCRUMBS.read_text(encoding="utf-8"))
+    primary = {"generate", "leaderboard", "library", "corpus", "architecture"}
+    missing = primary - crumbs
+    # primary pages may be deliberately excluded, but then a comment must explain why
+    if missing:
+        text = BREADCRUMBS.read_text(encoding="utf-8")
+        # require a comment mentioning the missing page and "deliberately" or "intentionally" or "excluded"
+        for page in missing:
+            assert page in text.lower() and (
+                "deliberat" in text.lower() or "intentional" in text.lower() or "exclud" in text.lower()
+            ), (
+                f"primary page '{page}' missing from CRUMB_MAP without a deliberate-exclusion comment. "
+                "Either add it with a correct group, or leave a comment explaining the exclusion per #1219."
+            )

--- a/ui/src/components/Breadcrumbs.jsx
+++ b/ui/src/components/Breadcrumbs.jsx
@@ -9,23 +9,36 @@
 import { PAGE_LABELS } from './Layout'
 
 // `group: null` means "no intermediate label" — breadcrumb reads "Home / <page>".
-// Dropped the "Intelligence" grouping (M5): users don't know what the internal
-// grouping means, so the corpus/reasoning/risk pages now render a flat trail.
-const CRUMB_MAP = {
-  explore:      { group: 'Markets', groupPage: 'explore' },
-  strategies:   { group: 'Markets', groupPage: 'explore' },
-  trade:        { group: 'Markets', groupPage: 'explore' },
-  dashboard:    { group: 'Portfolio', groupPage: 'dashboard' },
-  mint:         { group: 'Portfolio', groupPage: 'dashboard' },
-  liquidity:    { group: 'Portfolio', groupPage: 'dashboard' },
-  vaults:       { group: 'Portfolio', groupPage: 'vaults' },
-  'create-vault': { group: 'Portfolio', groupPage: 'vaults' },
-  financial:    { group: 'Portfolio', groupPage: 'dashboard' },
-  'vault-detail': { group: 'Portfolio', groupPage: 'vaults' },
-  reasoning:       { group: null, groupPage: null },
-  risk:            { group: null, groupPage: null },
-  corpus:          { group: null, groupPage: null },
-  'rigor-explainer': { group: null, groupPage: null },
+// Mirrors Layout.jsx NAV groups: Discover, Strategy, Position, Market, Ops.
+// Every key must exist in App.jsx PAGE_TO_PATH — subset invariant enforced by
+// backend/tests/test_breadcrumbs.py (prevents a fifth stale-map occurrence).
+//
+// Deliberately excluded:
+//   - landing — it *is* Home; breadcrumb would be circular.
+//   - vault-detail, strategy, market-strategy — dynamic routes with an id/address
+//     param, not entries in PAGE_TO_PATH; reached via deep-link only.
+// Primary path (generate, leaderboard, library, corpus, architecture) all have
+// entries below; if one is intentionally omitted a comment must explain why.
+export const CRUMB_MAP = {
+  // Discover — open to anonymous visitors
+  explore:      { group: null, groupPage: null },
+  corpus:       { group: 'Discover', groupPage: 'explore' },
+  architecture: { group: 'Discover', groupPage: 'explore' },
+  // Strategy — wallet-gated, owns the primary generation path
+  generate:     { group: null, groupPage: null },
+  library:      { group: 'Strategy', groupPage: 'generate' },
+  leaderboard:  { group: 'Strategy', groupPage: 'generate' },
+  // Position — wallet-gated deployed-state surfaces
+  portfolio:    { group: null, groupPage: null },
+  quant:        { group: 'Position', groupPage: 'portfolio' },
+  reasoning:    { group: 'Position', groupPage: 'portfolio' },
+  learnings:    { group: 'Position', groupPage: 'portfolio' },
+  // Market — strategy marketplace
+  marketplace:  { group: null, groupPage: null },
+  publish:      { group: 'Market', groupPage: 'marketplace' },
+  subscriptions:{ group: 'Market', groupPage: 'marketplace' },
+  // Ops
+  insights:     { group: null, groupPage: null },
 }
 
 export default function Breadcrumbs({ page, setPage }) {


### PR DESCRIPTION
Fixes #1219.

## Summary
`ui/src/components/Breadcrumbs.jsx`'s `CRUMB_MAP` referenced 10 pages that no longer exist (`strategies`, `trade`, `dashboard`, `mint`, `liquidity`, `vaults`, `create-vault`, `financial`, `vault-detail`, `risk` plus `rigor-explainer`) with retired group labels `Markets`/`Portfolio`. Because `Breadcrumbs` returns `null` for unknown pages the failure is silent — breadcrumbs never rendered on the actual pages (`generate`, `leaderboard`, `library`, `corpus`, `architecture`).

This is the fourth surface carrying the retired scheme (first three fixed in #1192).

## Changes
- **ui/src/components/Breadcrumbs.jsx**: Replace dead keys with keys that are a subset of `App.jsx:PAGE_TO_PATH`. Group labels now mirror `Layout.jsx:NAV` — `Discover`, `Strategy`, `Position`, `Market`, `Ops` (or flat `Home / Page` for entry pages). Primary path pages all have entries; deliberately excluded pages (`landing` is `Home`; `vault-detail`/`strategy`/`market-strategy` are dynamic deep-links) are documented in the header comment. Export `CRUMB_MAP` for testability.
- **backend/tests/test_breadcrumbs.py**: Regression asserting the subset invariant, no retired labels, valid groups/pages, and primary-path coverage. Hermetic — reads committed source, no DB.

## Acceptance criteria
- [x] `CRUMB_MAP` keys are a subset of `PAGE_TO_PATH` keys — enforced by `backend/tests/test_breadcrumbs.py::test_crumb_map_keys_subset_of_page_to_path`
- [x] Group labels reflect current navigation, not retired `Markets`/`Portfolio` — `test_crumb_map_has_no_retired_group_labels` + `test_crumb_map_group_labels_are_current_nav`
- [x] Primary path (`generate`, `leaderboard`, `library`, `corpus`, `architecture`) all have entries (or deliberate exclusion with comment) — `test_crumb_map_covers_primary_path`
- [x] `npm run lint` clean in `ui/` and `npm run build` succeeds; `ruff check` clean for new test

## Verify
```bash
grep -n "CRUMB_MAP" -A20 ui/src/components/Breadcrumbs.jsx
grep -n "PAGE_TO_PATH" -A20 ui/src/App.jsx
npm --prefix ui run lint
npm --prefix ui run build
# python headless check (or pytest if env has deps):
# pytest backend/tests/test_breadcrumbs.py -v
```

## Anti-goals
- No routes added to `PAGE_TO_PATH`.
- No changes to `resolveRoute()`.