### PR TITLE
[docs] Add sprint session cards for the Arc mainnet build window

### DIFF
--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -1,0 +1,64 @@
+# Arc mainnet sprint — session cards
+
+Working cards sharded from `arc-goes-mainnet-sleepy-marble.md` (2026-08-10 measurement).
+Purpose: **one card per session, ~50 lines instead of a 45k-token plan re-read.**
+
+> Not committed by default. `git status` will show this directory untracked — commit it or
+> add to `.gitignore`, your call. New subdirectory, so collision risk with #1225's docs
+> restructure is low.
+
+## State — 2026-08-16
+
+Zero sprint work has landed. `origin/main` since Aug 8 = 20 commits, all dependabot (10 PRs
+merged as a batch, including #1229/#1233/#1234 which the plan told us to hold). #1224, #1226,
+#1201, #1095 — all marked "merge now" — still open.
+
+**All doc anchors re-verified 6/6 fresh on 2026-08-16.** Trust them.
+
+Path corrections vs the source doc:
+- `spend_cap.py` → `backend/archimedes/marketplace/spend_cap.py` (not `services/`)
+- `Architecture.jsx` → `ui/src/components/Architecture.jsx` (not `pages/`)
+
+~20 working days remain to Sept 16 against a 24-day estimate. See the re-cut at the bottom.
+
+## Session rules — apply to every card
+
+1. **Anchor-trust.** Re-anchor with `grep -n "<symbol>" <file>` (~200 tok), then `Read` with
+   `offset`/`limit` for a ±40-line window. Never `Read` a file whole to "get oriented."
+2. **Never read whole** — ~8,400 lines ≈ 105k tokens:
+   `strategies_routes.py` (2357) · `_rigor_helpers.py` (1328) · `portfolio_backtester.py` (1180)
+   · `rigor_evaluator.py` (956) · `Architecture.jsx` (896) · `fusion_evaluator.py` (864)
+   · `main.py` (821)
+3. **One cluster per session.** Do not drift into an adjacent item because it is nearby.
+4. **Test narrow:** `pytest backend/tests/test_<module>.py -q`. Full suite once, pre-merge.
+5. **No subagents, no workflows.** No discovery left to parallelize.
+6. **Universal anti-goals** (from the source doc's "Explicitly not doing"): no vitest/playwright
+   · no `React.lazy` · no `python-multipart` · no server-side user Python · no DSL-JSON upload
+   · don't delete `_run_fusion_job` · don't repair QuantLab's mocks · no KB pipeline · no
+   distributed meter reaper · don't un-pin `circlekit` · no vectorbt · don't rewrite
+   `Architecture.jsx`. **Never weaken a rigor threshold.**
+7. **Merge discipline is a token rule too.** Max 2 merges/day, ≥40 min apart, never during a
+   deploy, verify `/health` version matches the SHA before the next. A killed deploy costs a
+   ~50k-token diagnosis session.
+
+## Order — by value-per-token, not workstream letter
+
+| Session | Card | Doc items | Est. |
+|---|---|---|---|
+| 1 | [cluster-0-unblock](cluster-0-unblock.md) | D1 asks · merges · B0 checks · A6 diagnostic | 0.5d, ~0 code tokens |
+| 2 | [cluster-1-cost-ssot](cluster-1-cost-ssot.md) + [cluster-3-backtest-models](cluster-3-backtest-models.md) | A1 · A7-surgical · A2-lite · A3/A4 mapper | 1.5d — **best ratio in the sprint** |
+| 3 | [cluster-2-fusion-engine](cluster-2-fusion-engine.md) | A1c · A4 · A8 label | 0.75d |
+| 4 | [cluster-4-strategies-route](cluster-4-strategies-route.md) | A3 fixture kill · DEGENERATE | 1.5d |
+| 5 | [a6-rerun](a6-rerun.md) | A5 memo · A6 re-run + before/after table | 1.25d |
+| 6–8 | [cluster-5-meter](cluster-5-meter.md), [cluster-6-boot-paywall](cluster-6-boot-paywall.md) | B2 · B5 · B0-boot · B3 | 4.0d |
+| 9 | [cluster-8-returns-csv](cluster-8-returns-csv.md) | B4 | 1.5d |
+| 10 | [cluster-7-ui-surface](cluster-7-ui-surface.md) | B1 (re-cut) | 0.4d sprint / 0.85d buffer |
+
+## Re-cut vs the source doc
+
+- **B1 splits.** Claim-honesty subset in-sprint (~0.4d); the `routes.js` 6-way consolidation +
+  3 check scripts to buffer. #1237 already fixes CRUMB_MAP #1219 — coordinate, don't collide.
+- **A2 stays lite.** `backtest_engine` surfaced + `cost_model_id` only. The 9-column migration
+  to buffer.
+- **A7 surgical only.** Full unification (`cohort_results`, golden vectors) to buffer.
+- Everything already on the doc's cut list stays cut.

--- a/docs/sprint/a6-rerun.md
+++ b/docs/sprint/a6-rerun.md
@@ -1,0 +1,97 @@
+# A5 + A6 — the fetch memo and the re-run
+
+**The re-run is the deliverable of Sprint 1.** Everything in clusters 1–4 exists to make its
+output honest.
+
+Read [README](README.md) session rules first.
+
+## Hard abort gate — read this first
+
+The re-run is authorised **only** by a passing cost-parity test
+([cluster-1](cluster-1-cost-ssot.md)): both engines charge identical slippage + commission for
+the same trade list. **If that test does not exist and pass, skip the re-run entirely**, leave
+#1226's banner up, and move it to the Sept 16 gate. Do not run it anyway.
+
+Run against a **production snapshot first** and diff the pass count before touching prod. If the
+pass count comes back **zero**, hold publication, keep the banner, escalate as a gate item — a
+leaderboard with no passing rows is not shippable.
+
+## A5 — the 15-line fetch memo (0.25d)
+
+Measured across all 34 curated strategies: universe sizes are `{1:5, 2:6, 5:22, 26:1}` — **153
+`(strategy, asset)` fetch pairs over only 31 distinct tickers.**
+
+`run_command` already exposes a `fetcher: Callable = fetch_ohlcv` injection seam (`cli.py:156`)
+and `run_backtests.py:277` **does not pass it**. Build a per-symbol memo dict once in
+`run_backtests()` and thread it in: **153 → 31 downloads**, which is also what makes the daily
+scheduler viable.
+
+No new file, no schema, no eviction policy — the seam already exists. The persisted Parquet
+cache is **cut**.
+
+Also: cache raw pulls to disk *before* the re-run so retries replay from cache and Yahoo leaves
+the critical path. Throttle; run overnight. (Blast radius is narrower than it looks —
+`PRICE_SOURCE=cascade` already routes *live* prices through Pyth; only historical is Yahoo.)
+
+## A6 — diagnose first
+
+The diagnostic belongs in [cluster-0](cluster-0-unblock.md), but restate the finding here before
+running. #1203 merged 2026-08-03 and the newest row on the board is `backtest_end 2026-07-01`.
+The scheduler is armed (`main.py:330-338`), `BACKTEST_REFRESH_ENABLED` defaults on,
+`BACKTEST_MAX_AGE_HOURS` = 168h, and `content_hash` hashes the *result artifact*
+(`backtest_mapper.py:111`) — so a corrected run produces a new hash and **would** insert.
+Something is stopping it. Know which of the three hypotheses is true before you run.
+
+## A4 read-path fix — do it in this session, it is the one moment
+
+`backtest_repository.py:95-100 get_daily_returns` — honour the `operation` column (`row.operation`
+is right there), then **delete** `run_backtests.py:209 _payload_with_selected_operation_first`.
+Its own comment says it is a band-aid awaiting exactly this. The standing objection — "changing a
+shared reader re-grades persisted rows" — is **void during a full re-run**. This is the one
+moment in the year to do it.
+
+## Execute
+
+Run `run_backtests()` over all 34 with the `CostModel`. Then extend
+`backend/archimedes/scripts/audit_backtest_universe.py` (already read-only, already reports the
+cross-store delta) to emit the per-strategy **before/after** table:
+
+> Sharpe · DSR p · PBO · OOS · turnover · cost drag · break-even bps · engine · `cost_model_id` ·
+> status transition
+
+**That table is the deliverable.** Publish it with the re-run.
+
+**Run detached. Do not stream the run's output into context** — write to a log file, tail the
+last 40 lines when it finishes.
+
+## Set the expectation before you publish
+
+`docs/specs/second-wave-universe-experiment.md` already tested whether a bigger universe rescues
+failing strategies. **The answer is no** — no verdict flips, several get worse, 7 of 9 had
+negative Sharpe after costs. `docs/specs/quant-roadmap.md` concludes strategy count is a vanity
+metric.
+
+**Fixing the backtests will make more strategies fail, not fewer.** Today 3 of 34 pass, and the
+three are a T-bill proxy, buy-and-hold, and risk parity. Correct routing plus real slippage on
+Engine C will very likely push that down. **That is the gate working, and it is the product: we
+sell the verdict, not the alpha.**
+
+Have the copy ready **before** the run, not after. Reframe the headline from scoreboard to
+**rejection rate** — "34 candidates, 3 clear the bar" *is* the thesis; a board that passes
+everything is marketing.
+
+## No threshold moves. A `FeedArityError` is a loud honest failure, not a regression.
+
+Rollback is free — the store is add-only with content-hash dedup, so old rows survive and the
+gate can be pinned to a `run_id`.
+
+## Verify
+
+```bash
+# no row may predate 2026-08-03 (#1203's merge); today the newest is 2026-07-01
+curl -s https://archimedes-arc.com/api/leaderboard \
+| python3 -c "import sys,json;print(sum(1 for e in json.load(sys.stdin)['entries'] if e.get('sharpe_ratio')==0.0))"
+# expect 0 — no zero-trade artifact presented as a completed backtest
+```
+
+Then **re-scope #1226's banner** to "engine-attributed, cost-parity floor" rather than removing it.

--- a/docs/sprint/cluster-0-unblock.md
+++ b/docs/sprint/cluster-0-unblock.md
@@ -1,0 +1,81 @@
+# Cluster 0 — human unblocking + day-0 checks
+
+**Zero code. Bash and `gh` only.** Every item has multi-day human lead time and is already
+5 days late. Do this before writing a line.
+
+Read [README](README.md) session rules first.
+
+## Asks to Dan — send all in one message
+
+1. **Contract review, prioritised: #1129 > #1200 > #1153.** One-paragraph exploit statement
+   each, explicit Sept-16-gate deadline. Tell him the order rather than leaving him to choose.
+   None of the three blocks the payment rail — say that too.
+2. **Three decisions needed in writing:**
+   - identity key (#1194) — **deadline EOD Aug 17**; default if unsettled: opaque `principal_id`
+     derived from wallet today, Better Auth later. Document in an ADR either way.
+   - narrow `PAYMENTS_DRY_RUN=false` scope (caller-signed metered-API path only; DCW browser
+     subscribe stays dry-run, stays blocked on #975). **Bogdan acknowledges the custody side.**
+   - mainnet `PaymentSplitter` owner address (multisig).
+3. **Kick off Bedrock Anthropic use-case activation** — multi-day approval. No approval by
+   **Aug 24** ⇒ assume it misses, B5 ships against the free model path.
+4. **Circle mainnet credentials into SSM** + into the ECS `secrets` block, not just the
+   best-effort boot fetch.
+5. **`terraform apply` for #1071** (runner relocation). If he can't get to it, **stop the
+   runners on the detached EC2 box** — a clean stop beats stale funds-adjacent code running
+   unmanaged. Frame as a decision, not a complaint.
+
+## Merges — max 2/day, ≥40 min apart, verify `/health` between
+
+Order: **#1224** (mine, money path) → **#1226** (leaderboard provisional banner — makes the
+leaderboard claim honest *today*, highest claim-value-per-token in the sprint) → **#1201**
+(stop fabricating vault returns; honesty cover for the re-run window) → **#1095** (commit-reveal
+stale-trace; narrows the "anchored on-chain" retraction, so sequence it *before* the claims copy).
+
+Then #1202 (low risk, spare slot). #1096 merge-as-docs or close if #1225 supersedes.
+**#1225 lands D1–D2 or after Aug 24 — never mid-sprint.** #1223 lands before or after the
+re-run, never during (collides with A7 and B4's `num_trials_source`).
+
+## Day-0 checks (B0)
+
+1. **[BLOCKING] Does the pinned `circlekit` know an Arc *mainnet* chain?** Read the installed
+   SDK's chain table. `marketplace/config.py:6` hardcodes `"arcTestnet"`; `payments.py:69`
+   passes `GATEWAY_CHAIN` into `create_gateway_middleware(chain=…)`. If there is no mainnet
+   entry, **the payment rail cannot reach Arc mainnet and the decision changes.**
+2. Arc mainnet chain ID + RPC published? `contracts/foundry.toml` has only `arc-testnet`;
+   `ui/src/siwe.js:15` hardcodes `5042002`.
+3. **Reserve `archimedes-cli` on PyPI** — 10 minutes, irreversible if lost.
+4. Measure real generations/wallet/day from prod before choosing a meter ceiling.
+5. Confirm the considered-alternatives modal is broken in prod.
+
+## Two live bug fixes — same PR, ~3 lines total
+
+- [`ui/src/components/RejectedCandidates.jsx:73`](../../ui/src/components/RejectedCandidates.jsx:73)
+  — bare `fetch()` with no `credentials: 'include'`. **Verified still broken 2026-08-16.** Sole
+  outlier against a universal convention (`api.js` + seven components). With
+  `REQUIRE_SIWE_FOR_GENERATION` on this 401/404s, so the visible proof of the K=1-plus-rejects
+  architecture is dead on the one surface that converts.
+- **`PAYMENTS_DRY_RUN` is unset** in `infra/ecs.tf`, both compose files, and
+  `setup-ssm-secrets.sh`. Its prod value is an accident of
+  [`main.py:203`](../../backend/archimedes/main.py:203)'s default. Set it explicitly — even to
+  `true`. An unset money switch is the bug regardless of which way it points.
+
+## A6 diagnostic — one command, do it here
+
+```bash
+aws logs tail /ecs/archimedes-backend --since 7d \
+  --filter-pattern '"backtest refresh"' | tail -40
+```
+
+- `backtest refresh: skipped (…)` → staleness/backoff (`_last_unresolved_missing`)
+- `backtest refresh: cycle failed (…)` → runner raises (likely yfinance egress from Fargate)
+- `REFUSING to persist … VolPlausibilityError` (`run_backtests.py:386`) → corrected results
+  tripping the vol guard, rejected per-strategy, fail-closed, stale rows left in place
+
+## File two tracking issues
+
+Mainnet gate checklist (16 items + the 8 visibly-deferred, tagged out of scope) · claims ledger.
+
+## Done when
+
+Asks sent · 2 merges landed with `/health` verified · circlekit mainnet answer known · PyPI name
+held · both bug fixes in one PR · A6 hypothesis identified by log line.

--- a/docs/sprint/cluster-0-unblock.md
+++ b/docs/sprint/cluster-0-unblock.md
@@ -75,6 +75,57 @@ aws logs tail /ecs/archimedes-backend --since 7d \
 
 Mainnet gate checklist (16 items + the 8 visibly-deferred, tagged out of scope) · claims ledger.
 
+## Results — executed 2026-08-16
+
+Recorded here so no later session re-derives any of it.
+
+**Check 1 (BLOCKING) — answered: NO.** `circlekit/constants.py` at pinned SHA `09828f3999` has
+23 `CHAIN_CONFIGS` entries. Arc appears once, `arcTestnet` / chain 5042002, in the testnet block.
+The 11 mainnet entries are ethereum, base, arbitrum, polygon, optimism, avalanche, sonic,
+unichain, worldChain, hyperEvm, sei. **Upstream HEAD is the same commit** (2026-03-24), so
+bumping the pin does not help.
+
+Two follow-on facts:
+- `CHAIN_ALIASES` maps `"mainnet"` → `"ethereum"`. `GATEWAY_CHAIN=mainnet` resolves to a **valid**
+  config and would settle real USDC on Ethereum rather than erroring. This is why
+  [cluster-6](cluster-6-boot-paywall.md)'s startup assertion #1 is load-bearing, not hygiene.
+- Mitigation without forking: `CHAIN_CONFIGS` is a plain module-level dict and `get_chain_config`
+  reads it at call time, so an Arc mainnet `ChainConfig` can be registered at runtime. 8 of 9
+  fields are available or derivable (`MAINNET_GATEWAY_WALLET` / `MAINNET_GATEWAY_MINTER` are
+  already SDK constants; USDC is likely the same `0x3600…` native sentinel). **The one field we
+  cannot invent is `gateway_domain`** — Circle's internal domain ID, `arcTestnet` is `26`.
+  → Tracked as the top item on the mainnet-gate issue.
+
+**Check 2 — no.** `contracts/foundry.toml` still has only `arc-testnet`;
+`ui/src/siwe.js:15` is `VITE_ARC_CHAIN_ID ?? '5042002'`.
+
+**Check 4 — meter ceiling.** Funnel on 2026-08-16: landed 301, wallet_connected 35,
+generation_started 22, vault_deployed 0. Versus 2026-08-10 (282/35/22/0): **+19 landings, zero
+new wallet connections, zero new generations in six days.** `/api/marketplace/published` still
+`[]`. Any ceiling is invisible at this volume — set it from observed p99 after
+`METER_ENFORCE=false` ships, per [cluster-5](cluster-5-meter.md).
+
+**Check 5 — confirmed** by code inspection; fixed in PR #1239.
+
+**A6 diagnostic — BLOCKED, reassigned.** No AWS credentials on Önder's machine and none
+available (Dan holds the account). The `aws logs tail` command is now an ask to Dan, not a
+local step. **Do not retry it locally.**
+
+**Environment facts** (each cost a round-trip to discover):
+- conda base is `/opt/homebrew/Caskroom/miniconda/base`; env at `.../envs/archimedes`,
+  Python 3.12.13, circlekit installed. `conda info --base` returns **empty** non-interactively —
+  it is shell-function-initialized in `.zshrc`. **Use the absolute path.**
+- `node` is **not** in the conda env despite CLAUDE.md; `/opt/homebrew/bin/node` is what exists.
+  `ui/node_modules` is present, so `./node_modules/.bin/eslint` works.
+- `tofu` (OpenTofu) is installed; `terraform` is not.
+- `aws` CLI is not installed.
+
+**Artifacts:** PR #1238 (sprint cards, CI green) · PR #1239 (both day-0 bug fixes) ·
+issue #1240 (mainnet gate) · issue #1241 (claims ledger).
+
+**Still open:** Dan message unsent · PyPI `archimedes-cli` unreserved (needs an account) ·
+merges held.
+
 ## Done when
 
 Asks sent · 2 merges landed with `/health` verified · circlekit mainnet answer known · PyPI name

--- a/docs/sprint/cluster-1-cost-ssot.md
+++ b/docs/sprint/cluster-1-cost-ssot.md
@@ -1,0 +1,64 @@
+# Cluster 1 — cost SSOT (A1)
+
+**Pair with [cluster-3](cluster-3-backtest-models.md) in one session.** Both are small files;
+together they are the best value-per-token in the sprint.
+
+Read [README](README.md) session rules first.
+
+## Why
+
+Three engines write to one `backtest_results` table, graded by one gate that cannot tell them
+apart. `grep -rn "set_slippage" --include="*.py" .` returns **exactly two hits, both Engine A**
+— re-verified 2026-08-16. Engine C, the engine that grades the *generated* strategies we want
+to sell, charges commission only and systematically flatters its own output against the curated
+library it is ranked beside. **This blocks the re-run**: re-running before closing it publishes
+a fresh set of biased numbers with more authority attached.
+
+Literal cost parity is not reachable in two weeks (Almgren impact needs ADV inside a custom
+`bt.CommInfoBase`). The target is an **identical cost floor** everywhere — per-side linear bps +
+proportional slippage from one SSOT — with Engine B's Almgren term retained as an additional
+*disclosed* haircut, which makes B stricter and never looser.
+
+## Files (all small — read whole)
+
+| File | Lines | Edit |
+|---|---|---|
+| `analytics-engine/src/archimedes_analytics_engine/costs.py` | 155 | add `DEFAULT_COST_MODEL` + `cost_model_fingerprint()` |
+| `analytics-engine/.../cli.py` | — | `run_command`: build a `CostModel`, pass `cost_model=` to all three runners |
+| `backend/archimedes/services/portfolio_backtester.py` | 1180 | **window-read only** — `_simulate_portfolio` + `:509` |
+
+Engine C's two sites live in [cluster-2](cluster-2-fusion-engine.md) — same file, one open.
+
+## Edits
+
+1. **`costs.py`** — `CostModel.apply_to_broker` (`:65-78`) *already* does commission **and**
+   `set_slippage_perc`. Add `DEFAULT_COST_MODEL` as the single source and
+   `cost_model_fingerprint()` returning a stable id that gets stamped on every row.
+2. **`cli.py run_command`** — build a `CostModel`, pass `cost_model=` to all three runners.
+   This also revives the dead per-symbol override path; `_configure_broker` already honours it.
+3. **`portfolio_backtester._simulate_portfolio`** — add an explicit slippage term on
+   `sum(|Δw|)` so the floor matches. Fix the misleading `"slippage_bps": tx_cost_bps` at
+   `portfolio_backtester.py:509`.
+
+## Test — `test_cost_parity.py`, both suites
+
+- Same buy-and-hold-equivalent run on a **deterministic ramp** through all three engines lands
+  within tolerance and **strictly below** the zero-cost run.
+- A spy asserts `set_slippage_perc` is called on the Engine C cerebro.
+- A regression pins that `tx=0, slip=0` reproduces Engine C's pre-change numbers **exactly**.
+
+```bash
+pytest backend/tests/test_cost_parity.py -q
+cd analytics-engine && uv run pytest tests/test_cost_parity.py -q
+```
+
+## Anti-goals
+
+- Do **not** attempt Almgren impact inside backtrader. Not this sprint.
+- Do **not** change any rigor threshold.
+- Do not touch `engine.py:399` — Engine A is already correct; it is the reference.
+
+## Gate
+
+**This test passing is what authorises the re-run** ([a6-rerun](a6-rerun.md)). If it does not
+exist and pass, skip the re-run entirely and leave #1226's banner up. Do not run it anyway.

--- a/docs/sprint/cluster-2-fusion-engine.md
+++ b/docs/sprint/cluster-2-fusion-engine.md
@@ -1,0 +1,78 @@
+# Cluster 2 — fusion_evaluator.py (A1c · A4 · A8-label · A7-adapter)
+
+**Four doc items, one file open.** `fusion_evaluator.py` is 864 lines — **never read whole**
+(~10k tokens). Grep to each anchor, window-read ±40 lines, edit, move on.
+
+Read [README](README.md) session rules first.
+
+```bash
+grep -n "setcommission\|adddata\|data_feed\|apply_rigor_gate\|run_dsl_backtest_portfolio" \
+  backend/archimedes/services/fusion_evaluator.py
+```
+
+## 1. A1c — Engine C slippage (depends on [cluster-1](cluster-1-cost-ssot.md))
+
+`:222-223` and `:379-380` — replace the bare `setcommission` with
+`CostModel.apply_to_broker(cerebro)` using cluster-1's `DEFAULT_COST_MODEL`. One line per site.
+`apply_to_broker` (`costs.py:65-78`) already does commission **and** `set_slippage_perc`.
+
+Stamp `cost_model_id` on the result so the row carries its fingerprint.
+
+## 2. A4 — the dead condition that nulls every DSL start date
+
+`:285` — the condition is **dead**: `data_feed` is assigned at `:216-219` so it is never `None`.
+That is why DSL rows always get `backtest_start=None`, while `_run_variant_backtest:438` uses a
+*different* condition for the same job. Thread the real panel dates through both.
+
+This one matters for the re-run: a null `backtest_start` makes a row un-auditable.
+
+## 3. A8-label — stop the sleeve fiction being silent
+
+`run_dsl_backtest_portfolio` (`:516`) runs the **same single-asset spec** once per asset with
+`initial_cash/N` sleeves and averages the results — precisely the pattern #1203 ripped out of
+Engine A as wrong. `run_dsl_backtest` does exactly one `cerebro.adddata(...)` (`:221`, same at
+`:378`). An "inverse-vol 5-asset" generated strategy is really **five independent 100%-long
+single-asset backtests, equal-weighted**.
+
+The full multi-feed interpreter is ~3.75d and is **cut**. What ships is the label:
+
+- Stamp `backtest_engine="dsl-fusion-sleeves"` and
+  `portfolio_construction="n_independent_sleeves_equal_weight"` on rows from
+  `run_dsl_backtest_portfolio`.
+- Surface both on the passport and leaderboard (rides cluster-3's A2-lite plumbing).
+
+That converts a silent lie into a disclosed limitation. It is a real improvement over today and
+it is the truth-first answer.
+
+## 4. A7-adapter — re-point thresholds only
+
+`:609 apply_rigor_gate` — **keep it as an adapter**, re-point its thresholds at
+`rigor_profiles.py`'s ladder. Do not delete it: it owns the variant-grid → `num_trials` / CSCV-
+matrix assembly, which is genuinely fusion-specific and is exactly what `run_rigor_gate` wants
+as input.
+
+If #1223 (num_trials by provenance) is in flight, **coordinate before touching this** — it
+collides here.
+
+## Also in this file, do NOT fix now
+
+`fusion_market_data.py:53 _MAX_ASSETS = 6` caps the fan-out. Leave it — but the Generate-page
+copy must state the cap (see [cluster-7](cluster-7-ui-surface.md)): the picker offers 281 assets,
+Engine C caps at 6 per spec and grades them as independent sleeves.
+
+## Test
+
+```bash
+pytest backend/tests/test_fusion_evaluator.py -q
+```
+
+Add: a spy asserting `set_slippage_perc` is called on the Engine C cerebro (shared with
+cluster-1's parity test); a case asserting a DSL row now carries non-null `backtest_start`; a
+case asserting sleeve rows carry the `portfolio_construction` label.
+
+## Anti-goals
+
+- **Do not build the multi-asset interpreter.** Cut. Next sprint's design is in the source doc.
+- Do not touch `strategy_dsl.py` validation or `debate_engine.py:151 _dsl_conformance_ok` —
+  that is A8-contract-tests, buffer work.
+- Do not raise `_MAX_ASSETS`.

--- a/docs/sprint/cluster-3-backtest-models.md
+++ b/docs/sprint/cluster-3-backtest-models.md
@@ -1,0 +1,85 @@
+# Cluster 3 — backtest models + mapper (A7-surgical · A2-lite · A3/A4 mapper)
+
+**Highest value-per-token in the sprint.** Four doc items, three small files, ~25 lines for the
+headline fix. Pair with [cluster-1](cluster-1-cost-ssot.md) in one session.
+
+Read [README](README.md) session rules first.
+
+## Files — all small, read whole
+
+| File | Lines |
+|---|---|
+| `backend/archimedes/models/backtest.py` | 202 |
+| `backend/archimedes/services/backtest_mapper.py` | 202 |
+| `backend/archimedes/models/backtest_store.py` | — |
+
+## 1. A7-surgical — delete the second gate ⭐
+
+> *"The highest-value single action in this workstream, and it is surgical."*
+
+`BacktestResult.passes_rigor_gate` uses **entirely different thresholds** from the canonical
+gate (`sharpe>0.5`, `dsr_p>0.95`, `pbo<0.5`, `oos/is>=0.5`, `sharpe_vs_paper>=0.5`,
+`max_dd<0.5`) — and it is the one `generation_pipeline.py:1573` uses. **So generated and curated
+strategies are graded by different gates today.** The comment above that call claims parity with
+`_to_strategy_response`; verified false — that route uses `verdict.passes` from `live_rigor_gate`.
+
+Verified present 2026-08-16:
+- [`models/backtest.py:126`](../../backend/archimedes/models/backtest.py:126) `passes_validation`
+- [`models/backtest.py:144`](../../backend/archimedes/models/backtest.py:144) `passes_rigor_gate`
+- `:159` `if not self.passes_validation` — internal caller inside `passes_rigor_gate`, so the
+  two delete together cleanly.
+
+**Do:** delete both properties → re-point `generation_pipeline.py:1573` at `live_rigor_gate`'s
+`verdict.passes` → **retract the false comment above it in the same diff.**
+
+**Targeted equivalence test** (not the full golden-vector harness — that is buffer work): freeze
+the return series for the 3 passing strategies + 2 zero-Sharpe + 1 degenerate, assert the
+generated and curated paths now produce identical verdicts.
+
+```bash
+grep -rn "passes_rigor_gate" backend/archimedes/models/backtest.py   # must return nothing
+pytest backend/tests/test_gate_equivalence.py -q
+```
+
+## 2. A2-lite — provenance
+
+`backtest_engine` is **already a column** (`models/backtest.py:91`, `backtest_store.py:70`) and
+all three engines already write their tag — it just appears in **zero API schemas and zero UI
+files**. This is plumbing, not new capability.
+
+- Add `cost_model_id` (from cluster-1's `cost_model_fingerprint()`).
+- Declare `backtest_engine` + `cost_model_id` on `backtest_mapper.py:35 EngineMetricsModel` —
+  its `extra="ignore"` is what silently eats them at the boundary.
+- Carry through `models/backtest.py`, `backtest_store.py`, `api/schemas.py`,
+  `leaderboard_schemas.py`.
+- **Fail closed:** `insert_backtest_if_missing` **raises** on `backtest_engine is None`. No
+  unattributed row can ever be written again.
+
+**Deferred to buffer** (A2-full): `slippage_bps`, `turnover_annualized`, `traded_notional`,
+`total_commission_paid`, `cost_drag_annual_pct`, `break_even_cost_bps`, `gross_sharpe_ratio`,
+`portfolio_construction`, `daily_return_dates`.
+
+## 3. A3-part — the look-ahead OR
+
+`backtest_mapper.py:165-167` — `look_ahead_audit_passed` is the **OR** of a real AST audit and a
+broker-config check whose own docstring admits it is *"unconditionally True for every run"*
+(`engine.py:103-114`). An OR with an always-true operand is always true. Drop the broker-config
+leg from the OR; keep the AST audit as the only signal.
+
+## 4. A4-part — stop coercing correlations
+
+`backtest_mapper.py:180` — stop coercing `correlation_to_spy` / `correlation_to_btc` to `0.0`;
+serve `null`. Populating them needs a benchmark feed in every run: **not this sprint.** A null
+is honest; a fabricated `0.0` is not.
+
+## Anti-goals
+
+- Do **not** build `cohort_results` or the 7-way golden-vector harness — buffer.
+- Do **not** delete the persisted rigor columns yet (A3/cluster-4 switches the *read* path;
+  column drop is next sprint).
+- Never weaken a threshold.
+
+## Done when
+
+`grep passes_rigor_gate models/backtest.py` is empty · every new row carries a non-null
+`backtest_engine` + `cost_model_id` or the insert raises · equivalence test green.

--- a/docs/sprint/cluster-4-strategies-route.md
+++ b/docs/sprint/cluster-4-strategies-route.md
@@ -1,0 +1,88 @@
+# Cluster 4 — strategies_routes.py + live_rigor_gate (A3 · A7-cohort · meter hole)
+
+`strategies_routes.py` is **2357 lines ≈ 30k tokens. Never read whole.** Three anchors, three
+windows.
+
+```bash
+grep -n "metrics_source\|_live_rigor_results_for_strategies\|_run_fusion_job\|pbo_score" \
+  backend/archimedes/api/strategies_routes.py
+```
+
+Read [README](README.md) session rules first.
+
+## 1. A3 — kill the fixture fallback (#1187) ⭐ re-run prerequisite
+
+Live contamination is measurable. Bucketing `pbo_score` on the production leaderboard:
+
+```
+pbo=0.112821  n=14   <- live-computed cohort value
+pbo=None      n=14
+pbo=0.299456  n=3    <- fixture constant
+pbo=0.065113  n=2    <- fixture constant
+pbo=0.083838  n=1    <- fixture constant
+```
+
+`strategies_routes.py` ~154-179 falls back to DB columns migrated from
+`backend/tests/fixtures/backtest_fixtures_snapshot.json`. If the live cohort compute fails for
+any strategy post-re-run, this serves **fixture constants next to fresh live numbers** — exactly
+"publishing biased numbers with more authority."
+
+**Do:** replace every `s.<field> ?? bt.<field>` rigor fallback with `None` plus an explicit
+`metrics_source: "live_gate" | "persisted_backtest" | "unavailable"`. Keep the columns for now;
+drop them next sprint.
+
+## 2. A3 — `DEGENERATE` status
+
+Add a fourth status to `live_rigor_gate` (285 lines — readable whole), gated on the **same test**
+`_rigor_helpers.py:130` uses — `float(np.ptp(arr)) == 0.0` — so the two agree by construction.
+
+Five strategies have a mathematically constant 5,659-point return series reported as "pending"
+(#1184); eight rows show Sharpe of exactly 0.0 (zero-trade cross-sectional artifacts). **These
+are almost certainly the same population** — a zero-trade run yields a flat curve, which is both.
+The before/after report must show that overlap explicitly.
+
+## 3. A7-cohort — note the divergence, fix in buffer
+
+The badge and the numbers beside it are computed on **different cohorts today**:
+`_live_rigor_results_for_strategies` (`:270`) filters zero-variance series;
+`verdicts_for_strategies` (`live_rigor_gate.py:232`) filters only `len >= 10`. So
+`avg_correlation` and `pbo_scores` differ between the badge and the figures next to it.
+
+One `cohort_results(strategies) -> dict[str, RigorGateResult]`, from which both derive, deletes
+~120 lines and this divergence together. **Buffer work** — but leave a `# TODO(A7)` at both
+sites naming the divergence so the next session doesn't rediscover it.
+
+## 4. The unmetered budget hole — 2 lines
+
+`:1962 POST /api/strategies/generate` → `_run_fusion_job` is a **second live, SIWE-gated,
+LLM-spending generation endpoint with no UI consumer**, rate-limited at 20/minute vs 5/minute on
+the real one. Once [cluster-5](cluster-5-meter.md)'s meter lands it must go through the same
+meter or it is an unmetered budget hole. **Route it through the meter; defer deletion.**
+
+If cluster-5 hasn't landed yet, leave a `# TODO(B2)` at the site and do it there instead.
+
+## Test
+
+```bash
+pytest backend/tests/test_strategies_routes.py backend/tests/test_live_rigor_gate.py -q
+```
+
+Add: a test asserting no response field ever falls back to a persisted column silently — every
+value carries a `metrics_source`; a test asserting a zero-variance series returns `DEGENERATE`,
+not `pending` and not a 0.0 Sharpe.
+
+## Verify on prod after deploy
+
+```bash
+curl -s https://archimedes-arc.com/api/leaderboard | python3 -c "
+import sys,json,collections
+e=json.load(sys.stdin)['entries']
+print(collections.Counter(round(x['pbo_score'],6) if x.get('pbo_score') is not None else None for x in e))"
+# 0.299456 / 0.065113 / 0.083838 must be absent
+```
+
+## Anti-goals
+
+- Do **not** drop the persisted columns this sprint — switch the read path only.
+- Do not build `cohort_results` here.
+- Never weaken a threshold.

--- a/docs/sprint/cluster-5-meter.md
+++ b/docs/sprint/cluster-5-meter.md
@@ -1,0 +1,114 @@
+# Cluster 5 — metering + premium tier (B2 · B5)
+
+**Metering is the prerequisite for selling anything.** Two doc items, one file open
+(`generate_routes.py`, 439 lines — readable whole) plus one new module.
+
+Read [README](README.md) session rules first.
+
+## The bug, precisely
+
+`enforce_generation_quota()` opens with `if wallet: return`. `REQUIRE_SIWE_FOR_GENERATION` is
+secure-by-default **on**, so every live caller has a wallet, so **the cap never applies to
+anyone** and `WALLET_LESS_GENERATION_DAILY_CAP=5` is dead config (#1199).
+
+## The load-bearing technical call
+
+**Build `services/metering.py` on `marketplace/spend_cap.py`'s Lua, not `generation_quota.py`'s
+INCR.** *(Path corrected — the doc says `services/spend_cap.py`; it is at
+`backend/archimedes/marketplace/spend_cap.py`.)*
+
+`check_and_increment` is a one-way `INCR` — the wrong primitive for something you charge for,
+because a failed generation can never be un-charged. `spend_cap.py:82 _CHECK_AND_RESERVE_LUA`
+already does atomic check-and-reserve in one EVAL over a rolling sorted-set window, dedupes on
+repeated member, closes the N-concurrent TOCTOU, **and is already tested.**
+
+Generalize it from raw USDC to units-of-SKU and add `release` (a single `ZREM`, ~15 lines).
+
+## The `Principal` seam — build it here, the paid API needs it
+
+`{kind: wallet|api_key|anon, wallet, key_id, meter_key, tier}` where `meter_key` is
+`wallet:0x…` | `key:<key_id>` | `ip:<x-real-ip>`. **Reuse `generation_quota.client_ip()`
+verbatim** — it already correctly refuses `X-Forwarded-For`.
+
+**The lowercased-wallet constraint is satisfied by construction:** for an API key,
+`Principal.wallet` is the resolved *owner* wallet and resolution happens **inside**
+`get_verified_wallet` / `gate_generation`, which keep returning a lowercased `0x` string. So
+`owner_wallet` columns, `wallet_can_publish`, `is_strategy_visible`, `derive_pool_id`, and
+`spend_cap._key` all keep working **untouched**.
+
+## Three SKUs
+
+`generation` (one completed job, 5/day free) · `generation_premium` (20/day — **this is #1197's
+ceiling, free from this mechanism**) · `rigor_verdict` (20/day).
+
+Price the **job**, not the candidate (server-influenced `n_candidates` invites disputes) and not
+the token (unpredictable for the buyer). Absorb the `max_papers` variance at the p90.
+
+## Wiring — `generate_routes.py`
+
+- `:118` resolve principal → `reserve(...)` **before** `store.enqueue` and **before any LLM
+  spend**, replacing the `:130` quota call
+- carry `meter_reservation` in the job payload
+- `commit` on the terminal `done` event
+- `release` in `_run_with_cleanup`'s `except`, on `error`, and in `cancel_job` (`:296`)
+
+**TTL is the correctness backstop; release is the optimization.** `_RUNNING_TASKS` is an
+in-process dict and Fargate can run more than one task, so a crash between reserve and commit
+leaks a reservation — the rolling window ages it out within 24h. **Say that in the module
+docstring. Do not build a distributed reaper.**
+
+## Ship observe-first
+
+`METER_ENFORCE=false` on the first deploy: reserve, record, log, return `X-Meter-Used` /
+`X-Meter-Remaining`, **never 402/429**. Read the real distribution for 2–3 days, set the ceiling
+above the observed p99, then flip. One env var is the difference between launching a paywall and
+rate-limiting your only 15 users.
+
+- Keep `WALLET_LESS_GENERATION_DAILY_CAP` as a **deprecated alias** so deploying changes no
+  behaviour.
+- Keep the fail-closed-on-Redis stance (#929).
+- **Map free-wallet-exhausted to 402, not 429** — 429 says "wait", 402 says "pay" and can carry a
+  payment option. Keep 429 for the anonymous-IP case with its existing connect-wallet steering.
+
+## The proof test
+
+With a valid SIWE cookie (`_siwe_cookies(wallet)` from `test_user_routes.py`),
+`POST /api/generate/start` N+1 times → **the last returns 402.** On today's code that test
+asserts unlimited — which is exactly what makes it the #1199 regression proof.
+
+```bash
+env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_metering.py -q
+grep -r "asyncio.get_event_loop" backend/tests/   # must return nothing
+```
+
+## B5 — premium tier: the silent downgrade (same file, ~5 lines)
+
+**Verified bug.** `generate_routes.py:151` is
+`selected_model = req.model if is_allowed_model(req.model) else None`, and `is_allowed_model`
+checks membership in `FREE_TIER_MODELS` — which deliberately **excludes** the premium ids. So an
+**entitled** premium request resolves to `None` and silently runs the env default (Nova Micro).
+Today nobody is charged, so it is documented rather than dishonest — **the instant you charge for
+the tier it becomes charging for a downgrade.**
+
+- Add `PREMIUM_TIER_MODELS` and `is_servable_model(model, *, premium_entitled)`; keep
+  `is_allowed_model` as the free-only predicate (tests reference it); call the new one after
+  `enforce_model_entitlement`.
+- **Fail loud, never fall back**: if Bedrock rejects the premium id at runtime the job errors
+  **and releases the meter reservation**.
+- Surface `response.model` (already the provenance of record) on the job result and passport.
+- Un-grey `ModelCostPanel` rows from a **server** field, not a build flag — Bedrock activation is
+  an AWS fact that changes without a deploy.
+- Regenerate `ui/src/data/modelPricing.json` (stamped `2026-06-24`) with a test asserting every
+  `model_id` in it is in `FREE_TIER_MODELS ∪ PREMIUM_TIER_MODELS`.
+
+**If Bedrock activation misses:** ship the tier anyway against `mistral.mistral-small-2402-v1:0`
+or `moonshotai.kimi-k2.5`, relabel the row "Premium tier · frontier-class" naming the actual
+model, keep the `us.anthropic.*` rows greyed with the honest tooltip. **The one variant that must
+not ship is a premium tier that resolves to the same model as the free tier at a higher price.**
+
+## Anti-goals
+
+- Do not build on `generation_quota.py`'s INCR.
+- Do not build a distributed reservation reaper.
+- Do not rekey the meter on anything but `principal_id` (see #1194 default in cluster-0).
+- Release marker: **this PR is `!minor`.**

--- a/docs/sprint/cluster-6-boot-paywall.md
+++ b/docs/sprint/cluster-6-boot-paywall.md
@@ -1,0 +1,126 @@
+# Cluster 6 — boot assertions + the x402 paywall (B0-boot · B3)
+
+**The critical path and the biggest new-code item in the sprint.** `main.py` is 821 lines —
+**never read whole.** Four anchors, four windows.
+
+```bash
+grep -n "circlekit\|PAYMENTS_DRY_RUN\|_MAX_BODY_BYTES\|GATEWAY_CHAIN" backend/archimedes/main.py
+```
+
+Read [README](README.md) session rules first.
+
+## Scope correction — this is new code, not a config flip
+
+`grep -rni "PAYMENT-REQUIRED"` across `backend/` and `ui/src` returns **exactly one hit** —
+`marketplace/payments.py:120`, where the platform *consumes* a requirement it generated itself
+and signs it with a Circle Developer-Controlled Wallet it controls (`charge()` takes the
+subscriber's `wallet_id`). **Re-verified 2026-08-16.**
+
+**No route anywhere emits a 402 an external caller can satisfy.** The two real 402s in the tree
+(model entitlement, vault funding) are bare. So there is no cheap "challenge-only" version to
+ship first — the challenge and the settlement are the same PR.
+
+## Why this unlocks #975
+
+#975's acceptance criterion is that the platform never holds caller funds. **If the caller signs
+the x402 payment from their own key, the platform never holds their funds.** So scope the flip
+narrowly: `PAYMENTS_DRY_RUN=false` **only** for the caller-signed metered-API path; the DCW
+browser subscribe flow stays in dry-run and stays blocked on #975.
+
+**This needs Dan's explicit sign-off and Bogdan's acknowledgment on the custody side. It must not
+be inferred.** See [cluster-0](cluster-0-unblock.md).
+
+## Two startup assertions — ship in this PR
+
+Both convert a silent-degradation path into a refusal to boot.
+
+1. **`GATEWAY_CHAIN` must be explicit and verified.** Never `marketplace/config.py:6`'s
+   `arcTestnet` default. Assert the configured chain matches what the RPC actually reports, and
+   **refuse to boot when `PAYMENTS_DRY_RUN=false` on an unknown or mismatched chain** — otherwise
+   a mainnet deploy silently falls back to testnet or fails settlement.
+2. **`circlekit` import failure must be fatal when payments are live.** `main.py:51-57` wraps the
+   import in try/except so a broken install degrades to *marketplace absent* rather than failing
+   loudly. If circlekit did not import and `PAYMENTS_DRY_RUN=false`, **the process must not serve
+   traffic.**
+
+Plus B0's carry-over: set `PAYMENTS_DRY_RUN` **explicitly** in `infra/ecs.tf` — even to `true`.
+
+## The paywall — one tight PR, two at most
+
+Request-path middleware that catches an over-quota call and returns 402 with a real
+`PAYMENT-REQUIRED` header → caller retries with `X-PAYMENT` → server verifies, settles, proceeds.
+**Payer is the caller's own key; seller is the platform address.**
+
+- **The `accepts` block and the `PAYMENT-REQUIRED` header must come from the existing
+  `marketplace/payments.py` middleware. Do not hand-roll an x402 body.**
+- **402 body:** `{error, reason, sku, unit_price_usdc, meter:{used,ceiling,resets_at}, accepts:[…]}`
+- **Until pay-and-retry is wired, `accepts` must be `[]` with
+  `"payment_rail": "not_yet_available"`.** Advertising a payment option you cannot honour violates
+  the repo's own honesty convention as badly as advertising an endpoint that 404s.
+- When wired, **`Idempotency-Key` is required** — x402 is not crash-retry-idempotent, as
+  `service.py:768/805` already learned the hard way.
+
+## Prove it — one real cent, three pieces of evidence
+
+**A log line saying "charged" is not proof:** `_charge_one` returns `(True, None)` in dry-run at
+`service.py:834` and logs the same shape. Require all three, recorded in `docs/runbooks/`:
+
+1. a Circle facilitator settlement id from `middleware.settle`
+2. an on-chain `PaymentSplitter` transfer tx hash with **non-zero USDC value**
+3. publisher balance delta == subscriber balance delta, reconciled to the raw unit
+
+**Prove it end-to-end on testnet with real testnet USDC in non-dry-run mode before this PR
+merges.** Only then flip the manifest's `paid` group to `status: "live"`.
+
+## The `/api/v1/` surface
+
+New prefix, new router `backend/archimedes/api/v1_routes.py`. **Do not retrofit `/v1` onto the 24
+existing routers** — a breaking change for the SPA with no benefit. Write the policy in
+`docs/agent-api.md`: `/api/*` is SPA-internal and may change; `/api/v1/*` is paid, versioned,
+additive-only.
+
+In scope this sprint: `POST /api/v1/rigor/verdict` (see
+[cluster-8](cluster-8-returns-csv.md)).
+
+**Deferred to buffer, ahead of the CLI** (~1.0d): `GET /api/v1/meter` and
+`POST/GET/DELETE /api/v1/keys`. **Consequence to state out loud: the metered API has a paywall
+but no key management and no balance endpoint, so the only usable principal in the sprint is a
+SIWE session.** That is a coherent launch — browser and `agent_journey.py` both authenticate by
+SIWE today — but it is **not** the sellable machine API. The CLI's `login`/`meter` subcommands
+depend on keys, so keys come first in the buffer.
+
+When keys land: `Authorization: Bearer ark_live_<key_id>_<secret>`, prefixed so leaked-secret
+scanners catch it, compared with `hmac.compare_digest` (the `auth_guard.py:38` precedent), secret
+shown once, stored as sha256, SIWE-session-only to mint (a key must never mint another key).
+**Leave `INTERNAL_AGENT_API_KEY` completely alone** and say why in the docstring — a shared secret
+with no identity is a different concept that must not be conflated.
+
+**x402 is a top-up rail for the meter, not an auth rail.** An x402 header proves only that *a
+payer settled*; the payer need not equal the login wallet. Making it the auth rail forces either
+treating the payer as `owner_wallet` (breaking `is_strategy_visible`) or forking every check.
+The one exception is `POST /api/v1/rigor/verdict` — stateless, no ownership, no persistence — so
+bare `402 → pay → retry` with **no account at all** is correct there, and it is the best demo you
+have.
+
+## Manifest honesty
+
+`agent_manifest_routes.py` + `.well-known/agent.json` + `llms.txt`:
+
+- add `"APIKey"` and `"x402"` to `auth.schemes`; add a `pricing` block
+- **replace the flat `chain_id: 5042002`** with
+  `chains: {payments: {…}, execution: {name: "Arc testnet", chain_id: 5042002}}` in all three —
+  that is the honest disclosure of the split
+- **rewrite `_PENDING_T32`**, whose text still says deploy/marketplace/monitor are "landing with
+  the T3.2 contract redeploy (#588)" when T3.2 shipped 2026-07-09
+- **delete "Arc has no mainnet yet" from `llms.txt`** — false from Sept 16
+
+Extend `backend/tests/test_agent_manifest.py`: every route string in a group marked `live` must
+resolve against `app.routes`, and `chain_id` must appear **nowhere as a bare scalar**.
+
+## Anti-goals
+
+- No OAuth/JWT/npm SDK. No un-pinning `circlekit`.
+- Do not retrofit `/v1` onto existing routers.
+- Do not advertise an `accepts` option you cannot honour.
+- Release marker: **`!minor`** (shared with cluster-5 if they land together). Save
+  `!version-release` for the Sept 16 cutover PR.

--- a/docs/sprint/cluster-7-ui-surface.md
+++ b/docs/sprint/cluster-7-ui-surface.md
@@ -1,0 +1,107 @@
+# Cluster 7 — UI surface shrink (B1, re-cut)
+
+**Re-cut vs the source doc.** The full 6-way consolidation is 1.25d and touches more files than
+any other item; the claim-honesty subset is ~0.4d and captures most of the value. Ship the subset
+in-sprint, consolidation in the buffer.
+
+Read [README](README.md) session rules first.
+
+## Correction to the original premise — carried from the source doc
+
+A `VITE_*` flag will not tree-shake anything: `App.jsx` statically imports all 20 page components
+(25 imports, zero `React.lazy`). **Bundle size isn't the problem; claim-honesty and
+discoverability are.** The flag is a *policy selector*, not a code-elimination device.
+
+## Coordinate first
+
+**#1237 (danielscoffee) already fixes `Breadcrumbs.jsx` CRUMB_MAP #1219** — which the full B1 was
+going to kill as a side effect. Check its state before touching `Breadcrumbs.jsx`. Let it land;
+build on it.
+
+## Sprint subset (~0.4d) — claim-honesty only
+
+| Do | Why |
+|---|---|
+| `/corpus` — **hide the Graph + KG tabs** | They 503 (`corpus_kg_built: false`). A live 503 inside the product is worse than an absent tab. Component-level, not route-level — `/corpus` stays live |
+| `/quant` — wip-stub, drop from nav | Nine `mockReturns`/`seededRng` sites: **the single biggest claim-integrity liability in the UI**. Stub it; do not repair the mocks |
+| `/reasoning` — wip-banner, drop from nav | Real but empty until traces exist; traces need vaults; vaults are testnet. **Keep reachable** for the provenance claim |
+| `/learnings` — wip-stub, drop from nav | — |
+| `/portfolio`, `/portfolio/vaults/:address` — wip-banner, **stay in nav** | — |
+| `/marketplace`, `/marketplace/strategy/:id`, `/publish`, `/subscriptions` — live + wip-banner | The meter + spend-cap UI lands on `/subscriptions` |
+| **Delete** (zero importers, verified) | `FusionResult.jsx` · `PortfolioAdvisor.jsx` (477L, last caller of `/api/strategies/advisor`) · `data/promptLibrary.js` · `assets/hero.png` · `assets/logo_old.svg` |
+| `sitemap.xml` | Currently lists `/marketplace`, which is `WalletGate`d — **violating the file's own documented exclusion rule.** Post-shrink public set: `/`, `/explore`, `/leaderboard`, `/architecture`, `/corpus`, `/insights` |
+| Generate page copy | State the cap: the picker offers 281 assets; Engine C caps at 6 per spec and grades them as **independent sleeves** |
+
+**`Architecture.jsx` is 896 lines — surgical edit at `:627` only. Do not rewrite it.** (Path
+correction: it is at `ui/src/components/Architecture.jsx`, not `pages/`.)
+
+## Four coupling traps — each with its fix
+
+1. `GenerationStream.jsx:286 → onNavigate('library', …)` and `RejectedCandidates → 'strategy'` —
+   **both targets must stay `live`.**
+2. `App.jsx:158`'s funnel beacon keeps firing **unconditionally** — it is the only measured
+   evidence in the system. Add `"paid"` as a fifth **server-recorded** stage in
+   `services/funnel_store.py:55 STAGES`; keep `vault_deployed` separate as a testnet counter.
+   **Do not conflate them.**
+3. `sitemap.xml` — see table above.
+4. **`OnboardingTour` has a live trap.** `OnboardingTour.jsx:195` queries
+   `[data-tour="reasoning"]`; with reasoning out of nav the anchor is null, the effect at `:221`
+   calls `setPage('reasoning')` to drive it into view, the anchor still doesn't exist, and the
+   step is **permanently dead.** Drop that step and add a guard skipping any step whose anchor
+   isn't `live`.
+
+## Buffer (~0.85d) — the consolidation
+
+The same fact — route X exists, is called Y, sits in group Z, is wallet-gated, is publicly
+indexable — is asserted independently in **six places**: `App.jsx:31 PAGE_TO_PATH`,
+`App.jsx:198 titles`, `App.jsx:225-355 renderPage`, `Layout.jsx:22 NAV`,
+`Layout.jsx:59 PAGE_LABELS`, `Breadcrumbs.jsx:14 CRUMB_MAP`, plus `sitemap.xml`. **A shrink that
+edits some-but-not-all of these is the failure mode.**
+
+Create `ui/src/routes.js` — one manifest of
+`{id, path, label, icon, group, status, gate, gateCopy, title, indexable}` where `status` is
+`live | wip-banner | wip-stub | hidden`. `App.jsx`, `Layout.jsx`, `Breadcrumbs.jsx` all derive
+from it. Extract `ui/src/components/WorkInProgress.jsx` **verbatim** from `Learnings.jsx:15-40`'s
+existing "Roadmap · post-hackathon" treatment, then rewrite `Learnings.jsx` as a ~20-line consumer
+— **that rewrite is the proof the extraction is faithful.** One env var `VITE_SURFACE_PROFILE`
+(default `mainnet`, dev sets `full`) selects between two status overlays; statuses stay hardcoded
+in source so they are reviewable in a diff.
+
+## Tests — do NOT stand up vitest
+
+Three Node check scripts wired as `npm run check:routes` catch the actual regression class at ~5%
+of the cost:
+
+- `check-routes.mjs` — every `onNavigate('X'` / `setPage('X'` literal resolves to a `live` id.
+  **This is what catches traps 1 and 4 mechanically.**
+- `check-sitemap.mjs` — sitemap ≡ the derived public set. **Assert, don't generate.**
+- `check-orphans.mjs` — every component reachable from `main.jsx`, catching the next
+  `FusionResult.jsx`.
+
+## Verify — the artifact, not the source
+
+```bash
+cd ui && npm run build && grep -c "mockReturns" dist/assets/*.js   # expect 0
+npm run check:routes                                              # all three pass
+```
+
+**Grep the artifact from the actual nginx image that deploys, not a local build.** Note that
+#1229 (vite 8.2.1) and #1233 (cssnano) already merged ahead of this check existing — the bundler
+changed before the integrity check was written, so establish the baseline fresh.
+
+## Backend routers — leave every one registered, unchanged
+
+`swap_routes.py` exposes only `GET /quote` and `GET /pools` — no signer, no executor. **Nothing
+orphaned can move funds, spend LLM budget, or write state.** Instead add
+`docs/api-surface-status.md` (one row per router: prefix, UI consumer, status, plan) plus a test
+asserting every router registered in `main.py:471-495` appears in it — **documentation with teeth
+rather than prose that drifts.**
+
+One exception, handled in [cluster-4](cluster-4-strategies-route.md): `strategies_routes.py:1962`
+is a second live LLM-spending generation endpoint with no UI consumer. **Route it through the
+meter; do not delete it.**
+
+## Anti-goals
+
+No vitest/playwright · no `React.lazy` · don't rewrite `Architecture.jsx` · don't repair
+QuantLab's nine mock sites (stub it) · don't unregister any backend router.

--- a/docs/sprint/cluster-8-returns-csv.md
+++ b/docs/sprint/cluster-8-returns-csv.md
@@ -1,0 +1,103 @@
+# Cluster 8 — returns-CSV → rigor verdict (B4)
+
+The strategy-import surface. Mostly a new pure module — cheap to write, cheap to test, no big
+file reads.
+
+Read [README](README.md) session rules first.
+
+## Transport — zero new deps
+
+**Do not add `python-multipart`.** It is absent from `requirements.txt`, and per CLAUDE.md a new
+pip dep must land in both that and `environment.yml`.
+
+`POST /api/v1/rigor/verdict` accepts either `Content-Type: text/csv` with the raw body, or
+`application/json` `{returns, dates, num_trials, units, meta}`. The browser does
+`<input type="file">` → `FileReader.readAsText` → POST as `text/csv`. **One endpoint serves
+browser, CLI, and agents.**
+
+**Size is already bounded:** `main.py:426 _MAX_BODY_BYTES = 1 MB` and nginx has no override —
+1 MB is ~40k daily rows ≈ 160 years. **Verify and document rather than change.**
+
+## `services/returns_import.py` — pure, therefore testable
+
+- **Units are the highest-risk validation.** Someone will submit `1.2` meaning 1.2%.
+  `max(|r|) > 1.0` → **reject** with "looks like percent; pass `units=percent` or divide by 100."
+  **Never auto-guess.** Silently-wrong units is exactly where a fake Sharpe comes from.
+- **Two length floors.** Reuse `live_rigor_gate._MIN_RETURNS_FOR_GATE = 10` as the hard floor —
+  **do not invent a second constant.** DSR/PBO on 10 points is meaningless, so add an advisory
+  `_MIN_RETURNS_FOR_MEANINGFUL = 252` below which the verdict carries `confidence: "low"` with a
+  named reason. **Never silently return `pass` on 30 observations.**
+- **Do not interpolate gaps** — interpolation manufactures autocorrelation and would poison
+  `return_diagnostics.ljung_box_test`. Flag >5 consecutive missing days and >10% total.
+- ISO-8601 dates only, strictly increasing. Reject `MM/DD` vs `DD/MM` ambiguity outright. Reject
+  non-finite values (with row numbers), zero-variance series, >20,000 observations.
+- **`num_trials` is user-disclosed and adversarial.** Default to `1` matching
+  `_default_num_trials()`, and add `num_trials_source: user_disclosed | undisclosed_default_1 |
+  engine_measured` **now** — with `undisclosed_default_1` the response must state that DSR runs
+  **undeflated** and the verdict is an *upper bound* on rigor. Because #1223 reworks `num_trials`
+  by provenance, making this a field today means **#1223 lands as a value change rather than a
+  schema change.** Coordinate with Dan.
+
+## Reuse — do not rebuild
+
+`verdict_from_returns` (`live_rigor_gate.py:117` — bare list of floats → tri-state plus
+`min_passing_level` / `blocked_by_floor`) · `vol_plausibility` (`compute_vol_stats`,
+`assess_strategy`) · `return_diagnostics.diagnose` · `rigor_cache` (600s TTL + single-flight, so a
+resubmitted identical CSV is free).
+
+Return a shape **byte-compatible with what `StrategyPassport.jsx` already renders.**
+
+**`data_quality.verify_universe` does NOT apply** — it needs tickers and a yfinance call, and the
+user chose "no market data." Say so in the docstring rather than implying reuse.
+
+## The look-ahead decision — make it explicitly
+
+An imported return series has no code, so the AST look-ahead audit cannot run. Passing
+`strategy_code=None` and `look_ahead_audit_passed=None` forces the always-on look-ahead floor to
+fail at every strictness level.
+
+**The honest answer is not to accept a self-attestation the way the DSL path does.** Report the
+look-ahead leg as `NOT_RUN` and **cap the verdict accordingly**, stating that no code was supplied.
+
+## Persistence — default to not persisting
+
+Compute, return, forget. Smallest correct thing, and it dodges the storage/abuse/PII surface
+entirely. Optional `?save=true` (auth required) writes a `StrategyRecord` with
+`owner_wallet=<principal.wallet>` and a new `source='imported_returns'` — and `is_strategy_visible:10`
+then gives owner-only visibility with **zero new code**.
+
+## Hard rule — enforced in code, not docs ⭐
+
+`docs/anti-features.md` already says allowing arbitrary third-party strategies into Tier 1
+"dilutes the badge to meaninglessness."
+
+An imported series can **never** carry Archimedes Verified, appear on `/leaderboard`, be published
+to the marketplace, or be deployed. **Enforce it in the publish path and the leaderboard query,
+and test both.** The badge is what the product's credibility rests on.
+
+## Run the gate in `asyncio.to_thread`
+
+CSCV PBO over 20k points is seconds of numpy. On the event loop it would stall
+`/api/generate/stream`'s 15-second heartbeat and break SSE for every concurrent user. **This is a
+real availability bug if skipped.**
+
+## UI — a card on `/library`, not a new route
+
+Drop zone plus the existing `RigorExplainer.jsx`. **No `routes.js` / sitemap / nav /
+OnboardingTour churn.** (UI card may slip to buffer; the endpoint is the deliverable.)
+
+## Test
+
+```bash
+env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_returns_import.py -q
+```
+
+Cases: percent-units rejection · <10 rejected · 10–251 returns `confidence: "low"` · gap flagging
+without interpolation · DD/MM ambiguity rejected · non-finite with row numbers · zero-variance →
+`DEGENERATE` · `num_trials_source` present on every response · **imported series cannot reach the
+leaderboard or the publish path** (two separate tests).
+
+## Anti-goals
+
+No `python-multipart` · no server-side user Python · no DSL-JSON upload · no second minimum-length
+constant · never auto-guess units.


### PR DESCRIPTION
Docs only. No code paths touched, no test or CI behaviour changes.

## What this is

The Arc mainnet sprint plan is a single ~1000-line document. Loading it at the
start of every working session is most of a context window before any work
starts. This shards it into per-cluster cards under `docs/sprint/`, so a session
reads one ~50-line card instead.

## Why the cards are organised by file rather than by workstream

The plan is written by workstream (A1, A2, A3, B1…), but several items land in
the same file:

- `fusion_evaluator.py` carries four (slippage at `:222`/`:379`, the dead
  `data_feed` condition at `:285`, the rigor adapter at `:609`, sleeve labelling
  at `:516`)
- `models/backtest.py` + `backtest_mapper.py` carry four
- `strategies_routes.py` carries three
- `generate_routes.py` and `main.py` carry two and three

Working by workstream reopens each of those files once per item. Working by file
opens each one once. That reordering is the only substantive change from the
plan's own sequencing; the content of each item is unchanged.

## Contents

`README.md` is the index — ordering, shared session rules, and the
never-read-whole list (seven files totalling ~8,400 lines that should always be
window-read). Each cluster card carries its verified anchors, the exact edits,
the acceptance command, and its anti-goals.

## Anchors were re-verified before writing

Six spot checks against the tree, all still accurate: `passes_rigor_gate` at
`models/backtest.py:144`, exactly two `set_slippage` hits (both Engine A),
`PAYMENTS_DRY_RUN` defaulting true at `main.py:203`, the bare `fetch()` at
`RejectedCandidates.jsx:73`, and exactly one `PAYMENT-REQUIRED` hit at
`marketplace/payments.py:120`.

Two path corrections vs the plan: `spend_cap.py` is under
`backend/archimedes/marketplace/`, not `services/`; `Architecture.jsx` is under
`ui/src/components/`, not `ui/src/pages/`.