### PR TITLE
[frontend][infra] Fix the rejected-candidates 401 and pin the money switches explicitly

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -529,6 +529,16 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "LLM_PROVIDER", value = "bedrock_converse" },
         { name = "LLM_BEDROCK_MODEL", value = "amazon.nova-micro-v1:0" },
         { name = "PRICE_SOURCE", value = "cascade" },
+        # Money switches — pinned explicitly (2026-08-16). Both were unset here,
+        # in both compose files, and in setup-ssm-secrets.sh, so prod's values
+        # were an accident of main.py:203-204's defaults rather than a decision.
+        # An unset money switch is the bug regardless of which way it points.
+        # These values change ONLY alongside the written mainnet scope decision
+        # (payment-rail-only; PAYMENTS_DRY_RUN=false is scoped to the
+        # caller-signed metered-API path, never the DCW browser subscribe flow,
+        # which stays blocked on #975). Do not flip either one in a drive-by PR.
+        { name = "PAYMENTS_DRY_RUN", value = "true" },
+        { name = "PAPER_TRADING", value = "true" },
         # Daily generation caps (services/generation_quota.py, #1194 rev a).
         # Plumbed here EXPLICITLY: a cap that silently falls back to its
         # code default because it was never added to the task definition is a

--- a/ui/src/components/RejectedCandidates.jsx
+++ b/ui/src/components/RejectedCandidates.jsx
@@ -70,7 +70,10 @@ export default function RejectedCandidates({ jobId, onClose, onNavigate }) {
 
   useEffect(() => {
     let cancelled = false
-    fetch(`${API_BASE}/api/generate/jobs/${encodeURIComponent(jobId)}/candidates`)
+    // credentials:'include' sends the SIWE session cookie. The job endpoints are
+    // owner-scoped and REQUIRE_SIWE_FOR_GENERATION defaults on, so without it
+    // this 401s and the considered-alternatives panel renders empty.
+    fetch(`${API_BASE}/api/generate/jobs/${encodeURIComponent(jobId)}/candidates`, { credentials: 'include' })
       .then(r => r.ok ? r.json() : Promise.reject(new Error(`Backend returned ${r.status}`)))
       .then(d => { if (!cancelled) setData(d) })
       .catch(e => { if (!cancelled) setError(e.message || 'Failed to load candidates') })

--- a/ui/src/components/RejectedCandidates.jsx
+++ b/ui/src/components/RejectedCandidates.jsx
@@ -70,9 +70,9 @@ export default function RejectedCandidates({ jobId, onClose, onNavigate }) {
 
   useEffect(() => {
     let cancelled = false
-    // credentials:'include' sends the SIWE session cookie. The job endpoints are
-    // owner-scoped and REQUIRE_SIWE_FOR_GENERATION defaults on, so without it
-    // this 401s and the considered-alternatives panel renders empty.
+    // credentials:'include' sends the account session cookie. The job endpoints
+    // are account-owned (#1194: require_current_user + _require_job_access), so
+    // without it this 401s and the considered-alternatives panel renders empty.
     fetch(`${API_BASE}/api/generate/jobs/${encodeURIComponent(jobId)}/candidates`, { credentials: 'include' })
       .then(r => r.ok ? r.json() : Promise.reject(new Error(`Backend returned ${r.status}`)))
       .then(d => { if (!cancelled) setData(d) })


### PR DESCRIPTION
Two small, independent day-0 fixes, one commit each. Both were found while
measuring the live system ahead of the Arc mainnet window.

## 1. Considered-alternatives panel 401s in production

`RejectedCandidates.jsx` was the only bare `fetch()` in the UI. `api.js` and
seven other components all pass `credentials: 'include'`. The job endpoints are
owner-scoped and `REQUIRE_SIWE_FOR_GENERATION` defaults on, so the request goes
out with no SIWE cookie, comes back 401, and the panel renders its error state.

That panel is the visible evidence of the K=1-plus-rejects design — the thing
that shows a user what the debate society considered and rejected. It sits on
the Generate page, which is the only surface in the funnel that converts.

One line, plus a comment saying why the option is there so the next person
doesn't drop it again.

## 2. `PAYMENTS_DRY_RUN` and `PAPER_TRADING` were unset everywhere

Neither appears in `infra/ecs.tf`, either compose file, or
`setup-ssm-secrets.sh`. Production's values were therefore an accident of the
defaults at `backend/archimedes/main.py:203-204` rather than a decision anyone
recorded.

Both are pinned here to their **current effective value** (`true`), so this
changes no runtime behaviour — it makes two money switches reviewable in a diff
instead of implicit in a default. The comment states that changing either one
belongs with the written mainnet scope decision, not a drive-by PR.

## Verification

- `eslint src/components/RejectedCandidates.jsx` — clean
- `tofu fmt -check infra/ecs.tf` — clean
- No behaviour change from the Terraform edit; values match what the task is
  already running with

## Review note

The `infra/ecs.tf` change is in Dan's lane as infra owner. It is deliberately
behaviour-neutral, but it is a task-definition edit, so it should have his eyes
before merge.


**Review corrections (2026-08-20):** earlier body text claimed RejectedCandidates.jsx was the only bare fetch() in the UI and attributed the 401 to REQUIRE_SIWE_FOR_GENERATION — both stale. Other bare fetch() calls remain elsewhere in the UI (largely on anonymous-OK or roadmap-hidden surfaces; not audited here), and the gate that 401s is the shipped account model (#1194: require_current_user + _require_job_access) — the SIWE flag no longer exists. This PR's change stands on its own: the considered-alternatives fetch now sends the session cookie, and the ecs.tf money switches are pinned explicitly.