### PR TITLE
[test] Fix three test files that only passed on suite ordering (#1243)

### DIFF
--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from archimedes.db import get_session, init_db
+from archimedes.db import get_session
 from archimedes.models.backtest_fixtures_store import FIXTURE_FIELDS, StrategyBacktestFixture
 from archimedes.services.backtest_mapper import (
     AnalyticsArtifactModel,
@@ -21,6 +21,8 @@ from archimedes.services.backtest_mapper import (
 )
 from archimedes.services.backtest_repository import insert_backtest_if_missing
 from fastapi.testclient import TestClient
+
+from tests.db_isolation import redirect_to_tmp_sqlite
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "analytics_artifact_buy_hold.json"
 
@@ -41,38 +43,42 @@ def _utcnow():
 
 
 @pytest.fixture(autouse=True)
-def _use_tmp_db(tmp_path, monkeypatch):
-    """Point the DB at a temp SQLite so we don't pollute the real one."""
-    db_path = tmp_path / "test_archimedes.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-    init_db()
+def _use_tmp_db(tmp_path):
+    """Point the DB at a genuinely fresh temp SQLite for every test (#1243).
 
-    # engine/SessionLocal in archimedes.db are constructed once at import
-    # time from the FIRST DATABASE_URL seen in this process — the
-    # monkeypatch above does not migrate an already-bound engine onto a new
-    # file. In practice that means this "tmp DB" can be shared across tests
-    # in the same run, so the seed below merges by primary key (upsert)
-    # rather than add()-ing, matching the if-missing convention
-    # insert_backtest_if_missing already uses for the same reason.
-    snapshot = json.loads(BACKTEST_FIXTURES_SNAPSHOT_PATH.read_text(encoding="utf-8"))
-    with get_session() as session:
-        for stem, rec in snapshot.items():
-            session.merge(StrategyBacktestFixture(stem=stem, **{field: rec[field] for field in FIXTURE_FIELDS}))
-        session.commit()
+    This used to monkeypatch DATABASE_URL and call init_db(), which the comment
+    here correctly described as not working: archimedes.db builds engine and
+    SessionLocal once at import time, so setting the env var afterwards rebinds
+    nothing and every get_session() call kept resolving the original engine.
+    The "tmp DB" was never written to. What the tests actually read was whatever
+    that first engine pointed at, which is why this file passed under the full
+    suite (an earlier file left a usable engine behind) and failed standalone
+    against a stale on-disk schema.
 
-    # The strategy_provider() accessor in _route_helpers is @lru_cache'd and
-    # is built once per pytest process from the DB state at first call.  If any
-    # earlier test (in another file) triggered that first call before this
-    # fixture had a chance to seed strategy_backtest_fixtures, the cached
-    # provider has real_sharpe=None for every strategy — causing the advisor
-    # and list endpoints to report "no strategies with real backtest data".
-    # Clearing the cache after each seed forces the next call to re-read the
-    # now-seeded DB so every test in this file sees real fixture data.
-    from archimedes.api._route_helpers import strategy_provider
+    redirect_to_tmp_sqlite reassigns the module attributes for real and restores
+    them in a finally, so nothing leaks into a later file either.
+    """
+    for _ in redirect_to_tmp_sqlite(tmp_path):
+        # The DB is genuinely per-test now, so a plain add() would be correct.
+        # merge() is kept because it is also correct and costs nothing — it just
+        # no longer papers over shared state that is no longer there.
+        snapshot = json.loads(BACKTEST_FIXTURES_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        with get_session() as session:
+            for stem, rec in snapshot.items():
+                session.merge(StrategyBacktestFixture(stem=stem, **{field: rec[field] for field in FIXTURE_FIELDS}))
+            session.commit()
 
-    strategy_provider.cache_clear()
+        # strategy_provider() in _route_helpers is @lru_cache'd and built once
+        # per pytest process from the DB state at first call. If an earlier test
+        # triggered that call before this seed ran, the cached provider has
+        # real_sharpe=None for every strategy and the advisor/list endpoints
+        # report "no strategies with real backtest data". Clearing after each
+        # seed forces the next call to re-read the freshly seeded DB.
+        from archimedes.api._route_helpers import strategy_provider
 
-    yield
+        strategy_provider.cache_clear()
+
+        yield
 
 
 @pytest.fixture()

--- a/backend/tests/test_passport_honesty.py
+++ b/backend/tests/test_passport_honesty.py
@@ -24,18 +24,23 @@ import uuid
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from tests.db_isolation import redirect_to_tmp_sqlite
+
 # ── DB isolation fixture ────────────────────────────────────────────────────
 
 
 @pytest.fixture(autouse=True)
-def _use_tmp_db(tmp_path, monkeypatch):
-    """Per-test SQLite DB so each test starts empty."""
-    from archimedes.db import init_db
+def _use_tmp_db(tmp_path):
+    """Per-test SQLite DB so each test starts empty.
 
-    db_path = tmp_path / "passport_honesty.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-    init_db()
-    yield
+    Setting DATABASE_URL and calling init_db() did not give one (#1243):
+    archimedes.db builds engine/SessionLocal once at import, so the env var
+    rebinds nothing and get_session() kept resolving the original engine — the
+    tmp file was never written to. This file passed under the full suite only
+    because an earlier file left a usable engine bound, and failed standalone
+    against a stale on-disk schema.
+    """
+    yield from redirect_to_tmp_sqlite(tmp_path)
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -31,25 +31,26 @@ from archimedes.api.selection_bias_routes import (
 from archimedes.services.rigor_evaluator import run_rigor_gate
 from httpx import ASGITransport, AsyncClient
 
+from tests.db_isolation import redirect_to_tmp_sqlite
+
 # ── Hermetic DB fixture ────────────────────────────────────────────────
 
 
 @pytest.fixture(autouse=True)
-def _use_tmp_db(tmp_path, monkeypatch):
-    """Redirect DATABASE_URL to a per-test temp SQLite file.
+def _use_tmp_db(tmp_path):
+    """Bind archimedes.db to a per-test temp SQLite file.
 
-    The evaluate_rigor_gate endpoint calls init_db() before querying
-    persisted backtest data.  Without this fixture, init_db() falls back
-    to sqlite:///./archimedes_chat.db (CWD-relative), which accumulates
-    state across test runs and across parallel workers.  The fixture
-    isolates every test and satisfies the hermetic-test mandate.
+    The evaluate_rigor_gate endpoint queries persisted backtest data, so
+    without isolation it reads sqlite:///./archimedes_chat.db (CWD-relative),
+    which accumulates state across runs and across parallel workers.
+
+    Setting DATABASE_URL and calling init_db() did not achieve that (#1243):
+    archimedes.db builds engine/SessionLocal once at import, so the env var
+    rebinds nothing and get_session() kept resolving the original engine. This
+    file passed under the full suite only because an earlier file left a usable
+    engine bound, and failed standalone against a stale on-disk schema.
     """
-    from archimedes.db import init_db
-
-    db_path = tmp_path / "test_selection_bias.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-    init_db()
-    yield
+    yield from redirect_to_tmp_sqlite(tmp_path)
 
 
 # ── CPCV honest not-run reporting (#771) ───────────────────────────────


### PR DESCRIPTION
Fixes #1243.

## The problem

Three files fail standalone on `main` and pass in the full suite:

| File | Standalone before | After |
|---|---|---|
| `test_passport_honesty.py` | 6 failed, 8 passed | 14 passed |
| `test_selection_bias_routes.py` | 2 failed, 55 passed | 57 passed |
| `test_api_routes.py` | 3 failed, 30 passed | 33 passed |

They were passing on ordering luck — an earlier file left a usable engine bound
and these three inherited it. CI has been green the whole time.

## Cause

All three isolated with `monkeypatch.setenv("DATABASE_URL", ...)` plus
`init_db()`. `archimedes.db` builds `engine`/`SessionLocal` **once at import**,
so setting the env var afterwards rebinds nothing, and every `get_session()`
call kept resolving the original engine. The tmp file was never written to.

Standalone, that original engine points at a stale on-disk SQLite, which is why
the failure is `no such column: strategy_store.strategy_spec` — a column added
by migration `3f643d292e04`.

`test_api_routes.py`'s fixture already described this accurately in its own
comment and worked around it by `merge()`-ing its seed rows rather than
`add()`-ing. That workaround stays (still correct) but is no longer
load-bearing.

## Fix

All three now use `tests/db_isolation.redirect_to_tmp_sqlite` — the helper
written for the same class of bug in #1100, which reassigns the module
attributes and restores them in a `finally` so nothing leaks into a later file.

## Verification

```
each file standalone            0 failed
trio forward and reversed       104 passed both ways
full suite                      3065 passed
ruff format --check backend/    407 files clean
```

## Not in this PR

14 other files still pair `setenv("DATABASE_URL")` with `init_db()`:

```bash
for f in $(grep -rln 'setenv("DATABASE_URL"' backend/tests/); do
  grep -q "redirect_to_tmp_sqlite" "$f" || echo "$f"
done
```

None of them fails today, but they pass for the same reason these three did —
any change to which file touches the DB first can flip them. Left as a
follow-up so this change stays reviewable; noted on the issue.