### PR TITLE
[cli] Scaffold archimedes-cli with a 0.0.1 name-reservation release

### DIFF
--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,100 @@
+# archimedes-cli
+
+Command-line access to the Archimedes rigor gate.
+
+A backtest with a Sharpe of 2.1 tells you very little on its own. If it was the best of
+four hundred variants you tried, most of that number is selection, not skill. The gate
+here is the standard correction for that: a deflated Sharpe ratio that prices in how many
+variants were tried, a probability of backtest overfitting, a walk-forward out-of-sample
+pass, and a look-ahead audit. Point it at a returns series and it tells you which of those
+four the series survives.
+
+## Status
+
+**0.0.1 is a name reservation.** The command tree is in place and the flags are settled,
+but every subcommand exits 3 with a message saying so. Nothing here opens a network
+connection.
+
+The first working release is 0.1.0, with `login`, `meter`, and `verify` against the hosted
+API. `verify --local` and `backtest` follow once the local execution engine is published
+separately.
+
+## Install
+
+```bash
+pip install archimedes-cli
+```
+
+Python 3.10 or newer. Two dependencies, both small, so this is a seconds-long install
+rather than a compiler-and-a-coffee one.
+
+## Commands
+
+```
+archimedes login                      authenticate with a wallet signature
+archimedes meter                      show calls used and USDC spent this period
+archimedes verify RETURNS_CSV         run the gate over a returns series
+archimedes backtest --strategy-path   run a strategy locally and print its returns
+```
+
+`RETURNS_CSV` is two columns, date and daily return, or `-` to read from stdin. So the
+whole loop is one line:
+
+```bash
+archimedes backtest --strategy-path mine.py --strategy-class Mine | archimedes verify -
+```
+
+Every command takes `--json` and prints a single object on stdout, including on its error
+paths. A script never has to parse prose to find out what happened.
+
+`verify --local` runs the gate on your machine with no network, no account, and no charge.
+
+## Exit codes
+
+These are stable from 0.0.1 onward.
+
+| Code | Meaning |
+| --- | --- |
+| 0 | The gate passed |
+| 1 | The gate ran and returned a failing verdict |
+| 2 | Bad arguments or a missing file |
+| 3 | Subcommand not implemented in this release |
+
+The line worth drawing is 1 against everything else. Exit 1 is a real answer about the
+strategy. Any other non-zero code means no verdict was produced at all, so a CI job that
+treats every failure as "strategy rejected" would report a network timeout as a research
+finding. Branch on 1 specifically:
+
+```bash
+archimedes verify returns.csv
+case $? in
+  0) echo "gate passed" ;;
+  1) echo "gate failed, not deploying"; exit 1 ;;
+  *) echo "verify did not run"; exit 2 ;;
+esac
+```
+
+## Your code stays on your machine
+
+Archimedes never executes strategy code it received over the wire, and `backtest` is local
+for that reason rather than as a performance choice.
+
+Producing returns from a strategy file means importing and running it. Any server that
+offered to do that for you would be running arbitrary code from strangers. So the split is
+drawn at the file boundary: `backtest` runs your Python on your machine and emits a returns
+series, and only that series is ever sent anywhere.
+
+The two places the hosted service touches code at all are read-only. The look-ahead audit
+parses the file to an AST and inspects it. Strategy constants are read with `ast.parse` and
+`literal_eval`. Neither one imports the module or evaluates an expression.
+
+If you would rather nothing leave your machine at all, `verify --local` closes that loop
+too.
+
+## Links
+
+- [Repository](https://github.com/a-apin/archimedes)
+- [Issues](https://github.com/a-apin/archimedes/issues)
+- [archimedes-arc.com](https://archimedes-arc.com)
+
+Released into the public domain under the [Unlicense](https://unlicense.org).

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,63 @@
+[project]
+name = "archimedes-cli"
+version = "0.0.1"
+description = "Run the Archimedes rigor gate over your own strategies and returns, from the command line."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Unlicense"
+license-files = ["LICENSE"]
+authors = [{ name = "Archimedes" }]
+keywords = ["quantitative-finance", "backtesting", "deflated-sharpe", "overfitting", "rigor"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Environment :: Console",
+  "Intended Audience :: Financial and Insurance Industry",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Office/Business :: Financial :: Investment",
+]
+
+# Deliberately small. `login` / `meter` / `verify` need an HTTP client and an
+# argument parser and nothing else, so `pip install archimedes-cli` stays a
+# seconds-long install. Two dependencies are not yet listed because the commands
+# that need them are not written:
+#   eth-account  -> `login` (SIWE signing), lands in 0.1.0
+#   archimedes-analytics-engine -> the `[local]` extra behind `verify --local`
+#                                  and `backtest`, once that package is on PyPI
+# Listing either one now would be metadata describing code that does not exist.
+dependencies = [
+  "click>=8.1",
+  "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://archimedes-arc.com"
+Repository = "https://github.com/a-apin/archimedes"
+Issues = "https://github.com/a-apin/archimedes/issues"
+
+[project.scripts]
+archimedes = "archimedes_cli.cli:main"
+
+[dependency-groups]
+dev = [
+  "pytest>=8.2.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/archimedes_cli"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src", "tests", "README.md", "LICENSE", "pyproject.toml"]
+# Hatchling also ships the repo-root .gitignore in the sdist and does not honour
+# an `exclude` for it (VCS metadata is force-included). Harmless, just noise.
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/cli/src/archimedes_cli/__init__.py
+++ b/cli/src/archimedes_cli/__init__.py
@@ -1,0 +1,10 @@
+"""Archimedes command-line interface.
+
+The version here is the single source of truth. ``tests/test_cli.py`` asserts it
+matches ``pyproject.toml`` so a release cannot ship a binary that reports one
+number while PyPI shows another.
+"""
+
+__version__ = "0.0.1"
+
+__all__ = ["__version__"]

--- a/cli/src/archimedes_cli/cli.py
+++ b/cli/src/archimedes_cli/cli.py
@@ -1,0 +1,167 @@
+"""The ``archimedes`` entry point.
+
+0.0.1 is a name-reservation release. The command tree below is the shape the tool
+will have and the flags are the ones it will accept, but no subcommand does any
+work yet: each one explains itself and exits ``NOT_IMPLEMENTED``. Nothing here
+opens a socket or reads a credential.
+
+The tree is committed now rather than grown later because the flags are a
+contract. ``--json`` on every command and a stable exit code for a failing gate
+are what make the tool usable from a CI job, and both are much cheaper to get
+right before anyone has scripted against them.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+from . import __version__
+from .exits import NOT_IMPLEMENTED
+
+DEFAULT_API_URL = "https://archimedes-arc.com"
+
+_json_option = click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a single JSON object on stdout instead of human-readable text.",
+)
+
+_api_url_option = click.option(
+    "--api-url",
+    envvar="ARCHIMEDES_API_URL",
+    default=DEFAULT_API_URL,
+    show_default=True,
+    metavar="URL",
+    help="Base URL of the Archimedes API.",
+)
+
+
+def _unavailable(command: str, *, as_json: bool, lands_in: str = "0.1.0") -> None:
+    """Report that ``command`` has no implementation yet, then exit.
+
+    Structured output is honoured even here. A caller that asked for ``--json``
+    gets JSON on every code path, so a script never has to parse prose to find
+    out what happened.
+    """
+    message = f"'archimedes {command}' is not implemented in {__version__}. It lands in {lands_in}."
+    if as_json:
+        payload = {
+            "ok": False,
+            "command": command,
+            "error": "not_implemented",
+            "version": __version__,
+            "lands_in": lands_in,
+            "message": message,
+        }
+        click.echo(json.dumps(payload))
+    else:
+        click.echo(message, err=True)
+        click.echo("See https://github.com/a-apin/archimedes for progress.", err=True)
+    sys.exit(NOT_IMPLEMENTED)
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(__version__, "-V", "--version", prog_name="archimedes")
+def main() -> None:
+    """Run the Archimedes rigor gate over your own strategies and returns.
+
+    The gate is four checks: a deflated Sharpe ratio that prices in how many
+    variants were tried, a probability of backtest overfitting, a walk-forward
+    out-of-sample pass, and a look-ahead audit. A strategy that clears all four
+    is worth deploying capital behind; one that clears none of them is a curve
+    fit that happens to have a pretty equity chart.
+
+    Your strategy code is never uploaded or executed on an Archimedes server.
+    See the README for exactly where that boundary sits.
+    """
+
+
+@main.command()
+@_api_url_option
+@_json_option
+def login(api_url: str, as_json: bool) -> None:
+    """Authenticate with a wallet signature and cache the session.
+
+    Signs a Sign-In With Ethereum message locally and exchanges it for a session
+    cookie. The private key is read once, used to sign, and never sent anywhere.
+    """
+    del api_url
+    _unavailable("login", as_json=as_json)
+
+
+@main.command()
+@_api_url_option
+@_json_option
+def meter(api_url: str, as_json: bool) -> None:
+    """Show what you have used and what it cost.
+
+    Prints the current billing period's call count and USDC spend, so the number
+    the CLI reports and the number the invoice reports come from one place.
+    """
+    del api_url
+    _unavailable("meter", as_json=as_json)
+
+
+@main.command()
+@click.argument(
+    "returns_csv",
+    type=click.Path(exists=True, dir_okay=False, allow_dash=True),
+    metavar="RETURNS_CSV",
+)
+@click.option(
+    "--local",
+    "run_local",
+    is_flag=True,
+    help="Run the gate on this machine. No network, no account, no charge.",
+)
+@_api_url_option
+@_json_option
+def verify(returns_csv: str, run_local: bool, api_url: str, as_json: bool) -> None:
+    """Run the rigor gate over a returns series.
+
+    RETURNS_CSV is a two-column CSV of date and daily return, or ``-`` to read
+    the series from stdin.
+
+    Exits 0 when the gate passes and 1 when it fails, which is what makes
+    ``archimedes verify returns.csv`` usable as a CI check before a deploy.
+    """
+    del returns_csv, run_local, api_url
+    _unavailable("verify", as_json=as_json)
+
+
+@main.command()
+@click.option(
+    "--strategy-path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    metavar="PATH",
+    help="Python file holding the strategy class.",
+)
+@click.option(
+    "--strategy-class",
+    required=True,
+    metavar="NAME",
+    help="Name of the strategy class inside that file.",
+)
+@_json_option
+def backtest(strategy_path: str, strategy_class: str, as_json: bool) -> None:
+    """Backtest a strategy file on this machine and print its returns.
+
+    Runs entirely locally, which is the only way it can work: producing returns
+    means importing and executing your Python, and that is not something an
+    Archimedes server will ever do with code it received over the wire.
+
+    Pipe the output straight into the gate:
+
+        archimedes backtest --strategy-path mine.py --strategy-class Mine | archimedes verify -
+    """
+    del strategy_path, strategy_class
+    _unavailable("backtest", as_json=as_json)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/cli/src/archimedes_cli/exits.py
+++ b/cli/src/archimedes_cli/exits.py
@@ -1,0 +1,29 @@
+"""Exit codes.
+
+These are an API. Someone will write ``archimedes verify returns.csv`` into a CI
+job and branch on the result, so the meaning of each number has to stay fixed
+from 0.0.1 onward. New conditions get new codes; existing codes do not get
+redefined.
+
+The split that matters is 1 vs everything else. Exit 1 means the command ran to
+completion and the answer was "this does not pass" — a real verdict about the
+strategy. Any other non-zero code means the command did not produce a verdict at
+all, so a CI job that treats every non-zero as "strategy rejected" would be
+reporting a network timeout as a research finding.
+"""
+
+OK = 0
+"""The command did what it was asked. For ``verify``, the gate passed."""
+
+GATE_FAILED = 1
+"""The gate ran and returned a failing verdict. This is a real answer, not an error."""
+
+USAGE = 2
+"""Bad arguments or a missing file. Click exits with this on its own; it is named here
+so the full set is documented in one place."""
+
+NOT_IMPLEMENTED = 3
+"""The subcommand exists in the command tree but has no implementation in this
+release. Every subcommand returns this in 0.0.1."""
+
+__all__ = ["GATE_FAILED", "NOT_IMPLEMENTED", "OK", "USAGE"]

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,0 +1,117 @@
+"""Smoke tests for the 0.0.1 command tree.
+
+There is no behaviour to test yet, so these cover the things that are already a
+contract with users: the exit codes, the shape of ``--json`` output, the version
+the binary reports, and the claim that no command touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from archimedes_cli import __version__
+from archimedes_cli.cli import main
+from archimedes_cli.exits import GATE_FAILED, NOT_IMPLEMENTED, OK, USAGE
+from click.testing import CliRunner
+
+SUBCOMMANDS = ["login", "meter", "verify", "backtest"]
+
+# Argument lists that satisfy each command's required options, so the command
+# reaches its body instead of being rejected by click.
+INVOCATIONS = {
+    "login": ["login"],
+    "meter": ["meter"],
+    "verify": ["verify", "returns.csv"],
+    "backtest": ["backtest", "--strategy-path", "s.py", "--strategy-class", "S"],
+}
+
+
+@pytest.fixture
+def runner(tmp_path, monkeypatch):
+    """A CliRunner in a tmp dir holding the files the commands expect to exist."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "returns.csv").write_text("date,ret\n2026-01-02,0.001\n")
+    (tmp_path / "s.py").write_text("class S:\n    pass\n")
+    return CliRunner()
+
+
+class TestExitCodesAreAContract:
+    """These numbers ship in CI jobs. Changing one silently breaks a user's pipeline."""
+
+    def test_codes_have_their_documented_values(self):
+        assert (OK, GATE_FAILED, USAGE, NOT_IMPLEMENTED) == (0, 1, 2, 3)
+
+    @pytest.mark.parametrize("command", SUBCOMMANDS)
+    def test_every_subcommand_is_not_implemented(self, runner, command):
+        result = runner.invoke(main, INVOCATIONS[command])
+        assert result.exit_code == NOT_IMPLEMENTED
+
+    def test_a_missing_file_is_usage_not_not_implemented(self, runner):
+        """Click validates before the body runs, so a bad path is 2 and not 3.
+
+        This is the distinction the README asks people to branch on: 3 means the
+        command exists but does nothing yet, 2 means they typed something wrong.
+        """
+        result = runner.invoke(main, ["verify", "no-such-file.csv"])
+        assert result.exit_code == USAGE
+
+    def test_stdin_is_an_accepted_returns_source(self, runner):
+        """`archimedes backtest ... | archimedes verify -` is the headline usage,
+        so `-` has to get past argument validation even in the stub."""
+        result = runner.invoke(main, ["verify", "-"])
+        assert result.exit_code == NOT_IMPLEMENTED
+
+
+class TestJsonOutput:
+    @pytest.mark.parametrize("command", SUBCOMMANDS)
+    def test_json_flag_produces_one_parseable_object(self, runner, command):
+        result = runner.invoke(main, [*INVOCATIONS[command], "--json"])
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        assert payload["error"] == "not_implemented"
+        assert payload["command"] == command
+        assert payload["version"] == __version__
+
+    @pytest.mark.parametrize("command", SUBCOMMANDS)
+    def test_without_json_nothing_lands_on_stdout(self, runner, command):
+        """The human path writes to stderr, so piping stdout stays clean."""
+        result = runner.invoke(main, INVOCATIONS[command])
+        assert result.stdout == ""
+
+
+class TestVersionReporting:
+    def test_version_flag_exits_zero_and_prints_the_version(self, runner):
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == OK
+        assert __version__ in result.stdout
+
+    def test_package_version_matches_pyproject(self):
+        """A release that reports one number while PyPI shows another is a support
+        problem that takes an hour to diagnose and one line to prevent."""
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        match = re.search(r'^version = "([^"]+)"', pyproject.read_text(), re.MULTILINE)
+        assert match is not None, "no version line in pyproject.toml"
+        assert match.group(1) == __version__
+
+
+class TestHelp:
+    def test_help_lists_every_subcommand(self, runner):
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == OK
+        for command in SUBCOMMANDS:
+            assert command in result.stdout
+
+
+class TestNothingTouchesTheNetwork:
+    """The README says 0.0.1 opens no sockets. This is what backs that sentence."""
+
+    @pytest.mark.parametrize("command", SUBCOMMANDS)
+    def test_no_socket_is_opened(self, runner, command):
+        with mock.patch.object(socket, "socket", side_effect=AssertionError("opened a socket")):
+            result = runner.invoke(main, INVOCATIONS[command], catch_exceptions=False)
+        assert result.exit_code == NOT_IMPLEMENTED

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,7 @@ testpaths = backend/tests
 
 # Don't let collection wander into submodules / the analytics-engine / the UI —
 # they have their own toolchains and cause ImportPathMismatch if scooped up here.
-norecursedirs = submodules analytics-engine node_modules .git .venv ui ui-mockups contracts infra wallet-setup
+norecursedirs = submodules analytics-engine cli node_modules .git .venv ui ui-mockups contracts infra wallet-setup
 
 addopts =
     -ra


### PR DESCRIPTION
New top-level `cli/` holding the `archimedes-cli` package and the `archimedes` console script. 0.0.1 does no work: every subcommand prints what it will do and exits 3. The point of it is to claim the name on PyPI and settle the interface before anyone scripts against it.

## Why the monorepo and not a separate repo

`a-apin` is an org so a separate repo was available, but two things make it cost more than it returns right now.

**PyPI rejects direct URL dependencies.** The `--local` and `backtest` paths will import `run_command` from `archimedes-analytics-engine`, which is not published. In a split repo you cannot path-depend on it and you cannot `git+https://` depend on it either, because Warehouse refuses any distribution whose metadata carries a direct reference. `pip install archimedes-cli` would fail for everyone. Splitting forces the analytics-engine publish decision now, as a prerequisite, rather than when we are ready for it.

**The gate math is in `backend/`, which is not a package.** `verify --local` needs `rigor_evaluator.py`, and that sits inside the FastAPI app. Across repos that becomes a copy, and a drifted copy of the rigor gate means the CLI badge and the site badge can disagree with nothing catching it. Same repo, we can pin it with a parity test the way `test_cost_parity.py` pins the cost SSOT.

Splitting later is `git subtree split -P cli` and keeps history. Merging two repos back is the painful direction, so the cheap order is monorepo first, split when there are outside contributors or when CLI issues start crowding the tracker.

## What is here

- `pyproject.toml`, hatchling, matching how `analytics-engine` is set up
- `src/archimedes_cli/cli.py` with `login`, `meter`, `verify`, `backtest` registered and their flags settled
- `src/archimedes_cli/exits.py`, the exit code contract
- `README.md`, which is the PyPI landing page
- 22 tests

Base deps are `click` and `httpx`. `eth-account` and the backtrader stack are deliberately absent until `login` and the local engine land, since listing them now would be metadata describing code that does not exist.

## Exit codes

Fixed from 0.0.1 on, because someone will put `archimedes verify returns.csv` in a CI job and branch on the result.

| Code | Meaning |
| --- | --- |
| 0 | gate passed |
| 1 | gate ran and returned a failing verdict |
| 2 | bad arguments or missing file |
| 3 | not implemented in this release |

1 against everything else is the line that matters. Exit 1 is a real answer about the strategy; any other non-zero means no verdict was produced, so a job treating all failures as "rejected" would report a network timeout as a research finding.

## Verify

```bash
cd cli
uv build
uvx twine check --strict dist/*
PYTHONPATH=src python -m pytest tests -q
```

What I ran:

- `twine check --strict` passes on the wheel and the sdist
- built wheel installs into a clean Python 3.10 venv, which is the declared floor, and `archimedes --version` / `--help` / `verify --json` all behave
- 22 tests pass on 3.10 and 3.12
- `ruff format --check cli/` clean, `ruff check cli/` clean
- root `pytest --collect-only` still collects 3070, so `cli/` is not swept into the backend suite

Two of the tests were checked against the CLAUDE.md rule that a guard has to be shown to reject something:

- `test_package_version_matches_pyproject` fails when `pyproject.toml` is bumped to 0.0.2 and `__init__.py` is not
- `test_no_socket_is_opened` fails when a `socket.socket()` call is injected into the command path

`pytest.ini` gets `cli` added to `norecursedirs`, same treatment `analytics-engine` already has.

## Not in this PR

No publish workflow. Trusted publishing needs a workflow file plus configuration on the PyPI side, and CI wiring is an ask-first change here. The first upload will be manual.

## Next

`0.1.0` with `login`, `meter`, and `verify` against the hosted API. `verify --local` and `backtest` after that, gated on `archimedes-analytics-engine` going to PyPI.