### PR TITLE
[backtest] momentum_N is a trailing return, not a price ratio (F1)

### DIFF
--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -788,7 +788,10 @@ tickers the mechanism trades from the user's selected assets (in user_steer); th
 platform overrides this with the user's chosen universe, so do not default to a \
 single broad-market proxy. Valid rebalance_frequency values: \
 daily, weekly, monthly. Valid indicators: sma_N, ema_N, rsi_N, momentum_N (replace \
-N with an integer period). Entry/exit conditions use comparison ops (gt, lt, gte, lte) \
+N with an integer period). momentum_N is the trailing N-bar RETURN, centred on 0 \
+(+0.05 means +5%); write momentum thresholds on that scale — e.g. \
+{"gt": ["momentum_20", 0]} means "trailing 20-bar return is positive". \
+Entry/exit conditions use comparison ops (gt, lt, gte, lte) \
 or logic ops (and, or, not). Position sizing types: full_invested_when_in_market, \
 equal_weight, volatility_target (needs annual_pct). look_ahead_safe MUST be true. \
 parameter_variants is OPTIONAL: a dict mapping indicator aliases to 2-8 numeric \

--- a/backend/archimedes/services/dsl_to_backtrader.py
+++ b/backend/archimedes/services/dsl_to_backtrader.py
@@ -74,7 +74,17 @@ def _make_indicator(
     if name == "rsi":
         return bt.indicators.RSI(data_line, period=period)
     if name == "momentum":
-        return data_line / data_line(-period)
+        # TRAILING RETURN (centred on 0.0), not a price ratio (centred on 1.0).
+        # The distinction decides whether momentum conditions mean anything:
+        # every hand-authored momentum condition in this repo is written as
+        # {"gt": ["momentum_N", 0]}, and close prices are always positive, so
+        # under the ratio convention that entry filter is a tautology — the
+        # backtest enters long on a 10% DECLINE (ratio 0.9 > 0). The live
+        # signal path (strategy_signal_evaluator._compute_indicator_value),
+        # _tsmom_signal, and rank_market all already subtract 1.0; this was
+        # the lone ratio-convention outlier, and it is the backtest — i.e.
+        # the side whose numbers get published.
+        return data_line / data_line(-period) - 1.0
     raise DSLError(f"unsupported indicator: {name}")
 
 

--- a/backend/tests/services/test_dsl_momentum_convention.py
+++ b/backend/tests/services/test_dsl_momentum_convention.py
@@ -1,0 +1,118 @@
+"""F1 regression guard: DSL ``momentum_N`` is a trailing RETURN, not a price ratio.
+
+The defect this pins down (interpreter-divergence audit, 2026-08-03): the
+backtest interpreter computed ``momentum_N = close[0] / close[-N]`` — a ratio
+centred on 1.0 — while the live signal evaluator, ``_tsmom_signal`` and
+``rank_market`` all compute ``close[0] / close[-N] - 1.0``, a trailing return
+centred on 0.0. Every hand-authored momentum condition in the repo is written
+as ``{"gt": ["momentum_N", 0]}``, i.e. for the return convention. Close prices
+are always positive, so under the ratio convention that entry filter was a
+TAUTOLOGY: the backtest entered long on a 10% decline (ratio 0.9 > 0), and
+every published momentum backtest described a strategy whose entry filter
+never filtered anything.
+
+These tests are behavioural, run through the real ``run_dsl_backtest`` path on
+controlled synthetic feeds, and are DISCRIMINATING by construction: each
+"stays flat" case was verified to FAIL against the pre-fix ratio convention
+(the old code enters and the equity curve moves) before being trusted — per
+the pre-merge conventions, a guard is only worth trusting once it has been
+shown to reject something.
+"""
+
+from __future__ import annotations
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes.services.fusion_evaluator import run_dsl_backtest
+from archimedes.services.strategy_dsl import validate_strategy_spec
+
+_CASH = 100_000.0
+
+
+def _feed(daily_factor: float, bars: int = 300) -> bt.feeds.PandasData:
+    """Synthetic OHLCV feed: price compounds by ``daily_factor`` each bar."""
+    idx = pd.bdate_range("2020-01-01", periods=bars)
+    close = pd.Series([100.0 * (daily_factor**i) for i in range(bars)], index=idx)
+    df = pd.DataFrame(
+        {
+            "Open": close,
+            "High": close * 1.001,
+            "Low": close * 0.999,
+            "Close": close,
+            "Volume": 1_000_000.0,
+        },
+        index=idx,
+    )
+    return bt.feeds.PandasData(dataname=df)
+
+
+def _spec(entry: dict, exit_: dict) -> object:
+    return validate_strategy_spec(
+        {
+            "name": "momentum convention probe",
+            "asset_universe": ["SPY"],
+            "rebalance_frequency": "daily",
+            "entry": entry,
+            "exit": exit_,
+            "position_sizing": {"type": "full_invested_when_in_market"},
+            "source_arxiv_ids": ["0706.1497"],
+            "look_ahead_safe": True,
+        }
+    )
+
+
+def _run(spec: object, feed: bt.feeds.PandasData):
+    return run_dsl_backtest(
+        spec,
+        data_feed=feed,
+        data_source_label="synthetic-momentum-probe",
+        initial_cash=_CASH,
+        tx_cost_bps=0,
+    )
+
+
+def test_momentum_gt_zero_does_not_enter_a_declining_market():
+    """THE tautology case. Price declines 0.15%/bar, so the trailing 20-bar
+    return is ~-3% every bar: ``momentum_20 > 0`` must never fire and the
+    account must stay in cash for the whole run.
+
+    Under the old ratio convention this exact setup ENTERED (ratio ~0.97 > 0)
+    and rode the decline — verified: the pre-fix code fails this test with a
+    final value materially below initial cash.
+    """
+    metrics = _run(
+        _spec(entry={"gt": ["momentum_20", 0]}, exit_={"lt": ["momentum_20", -0.99]}),
+        _feed(0.9985),
+    )
+    assert metrics.total_trades == 0
+    assert metrics.equity_curve[-1] == pytest.approx(_CASH)
+
+
+def test_momentum_threshold_is_on_the_return_scale_not_the_ratio_scale():
+    """A threshold of 0.5 means "+50% trailing return", not "ratio above 0.5"
+    (which any positive price series satisfies). Price rises 0.1%/bar, so the
+    trailing 20-bar return is ~+2% — far below 0.5: no entry.
+
+    Under the old ratio convention (~1.02 > 0.5) this entered immediately —
+    verified failing pre-fix.
+    """
+    metrics = _run(
+        _spec(entry={"gt": ["momentum_20", 0.5]}, exit_={"lt": ["momentum_20", -0.99]}),
+        _feed(1.001),
+    )
+    assert metrics.total_trades == 0
+    assert metrics.equity_curve[-1] == pytest.approx(_CASH)
+
+
+def test_momentum_gt_zero_still_enters_a_rising_market():
+    """The fix must not make momentum entries unreachable: on a rising series
+    the trailing return is genuinely positive, so the strategy enters and the
+    long position gains. Guards the direction of the fix (subtracting 1.0),
+    not just its presence — an over-correction (e.g. subtracting 2.0) would
+    fail here while passing the two flat cases."""
+    metrics = _run(
+        _spec(entry={"gt": ["momentum_20", 0]}, exit_={"lt": ["momentum_20", -0.99]}),
+        _feed(1.001),
+    )
+    assert metrics.equity_curve[-1] > _CASH


### PR DESCRIPTION
## What this fixes

**F1 from the interpreter-divergence audit (21 confirmed divergences, 0 refuted): the most damaging one, and the one that blocks the re-run.**

The backtest computed `momentum_N` as a **price ratio** (`close[0] / close[-N]`, centred on 1.0). The live signal evaluator, `_tsmom_signal`, and `rank_market` all compute a **trailing return** (`… − 1.0`, centred on 0.0). Every hand-authored momentum condition in the repo — `{"gt": ["momentum_N", 0]}` — is written for the return convention.

Prices are always positive, so under the ratio convention that entry filter was a **tautology**. Measured in this PR's own tests:

| Scenario | Old (ratio) | New (return) | Live path |
|---|---|---|---|
| Market declining 0.15%/bar, entry `momentum_20 > 0` | **enters long**, $100,000 → **$66,279** | stays flat, $100,000 | stays flat ✓ |
| +2% trailing return, entry threshold `0.5` | **enters**, → $131,728 | stays flat | stays flat ✓ |
| Rising market, entry `> 0` | enters | enters ✓ | enters ✓ |

Same spec, opposite positions between the published backtest and the deployed strategy.

## The fix

One term: subtract 1.0 (`dsl_to_backtrader.py`, `_make_indicator`). Plus one sentence in the LLM spec contract (`_SPEC_CONTRACT`) defining `momentum_N`'s scale — it previously offered the indicator with **no defined semantics**, so generated thresholds were a coin flip.

## Verification

- Tests are behavioural (through the real `run_dsl_backtest` path) and **proven discriminating before being trusted**: against the pre-fix code the two stay-flat cases fail with the $66,279 / $131,728 values above; against the fix all three pass with flat cases at exactly $100,000.
- The rising-market case guards the *direction* of the fix — an over-correction (e.g. −2.0) would fail it while passing the flat cases.
- Full backend suite: **3068 passed, 0 failed.** No existing test broke — which is itself the finding: nothing pinned this convention, which is how a tautology survived in every published momentum backtest.

## Sequencing

⛔ **This blocks the curated/library re-run** (queue item 3). Re-running before this lands would re-publish numbers built on the tautological filter with fresh authority. It also blocks the paper-trading backend, which Dan has specified as running on backtest-engine semantics *post-F1*.

F5 (RSI smoothing) is next and separate. F2/F3 are live-money changes: prepared but held for Dan's explicit go-ahead per the strategy-session brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
