### PR TITLE
[live] RSI uses Wilder smoothing, matching the backtested RSI (F5)

### DIFF
--- a/backend/archimedes/services/strategy_signal_evaluator.py
+++ b/backend/archimedes/services/strategy_signal_evaluator.py
@@ -993,25 +993,46 @@ def _indicator_periods(spec: StrategySpec) -> dict[str, tuple[str, int]]:
 def _compute_indicator_value(name: str, period: int, prices: pd.Series) -> float:
     """Compute the latest value of one indicator from a price Series.
 
-    Uses the SAME numpy/pandas primitives the 5 hardcoded evaluators use, so the
-    live spec path produces values consistent with both them and the backtrader
-    interpreter's indicators:
+    Same numpy/pandas primitives as the 5 hardcoded evaluators, aligned with
+    the backtrader interpreter's indicators (the backtest is what gets graded,
+    so the live value must be computed the way the graded value was):
       - sma           → rolling(N).mean().iloc[-1]
-      - ema           → ewm(span=N).mean().iloc[-1]
-      - rsi           → standard Wilder-style RSI over N
+      - ema           → ewm(span=N).mean().iloc[-1]  (first-value seeded; bt
+                        seeds with an SMA — converges, known-benign F10)
+      - rsi           → Wilder SMMA smoothing, seeded with the first-N SMA —
+                        the algorithm behind bt.indicators.RSI's default
+                        MovAv.Smoothed. NOT a plain rolling mean: that is
+                        Cutler's RSI, a different indicator (7+ points apart
+                        on short windows), and shipping it here while the
+                        backtest used Wilder meant a threshold like rsi > 65
+                        could pass in the graded backtest and fail live on
+                        identical data (divergence audit F5).
       - momentum      → prices.iloc[-1] / prices.iloc[-N-1] - 1   (matches _tsmom_signal)
-      - realized_vol  → pct_change().tail(N).std() * sqrt(252)    (matches _vol_managed_signal)
+      - realized_vol  → pct_change().tail(N).std() * sqrt(252)    (matches _vol_managed_signal;
+                        NO backtest counterpart yet — interpret_spec raises
+                        DSLError for it, divergence audit F6)
     """
     if name == "sma":
         return float(prices.rolling(period).mean().iloc[-1])
     if name == "ema":
         return float(prices.ewm(span=period, adjust=False).mean().iloc[-1])
     if name == "rsi":
-        delta = prices.diff()
+        delta = prices.diff().dropna()
+        if len(delta) < period:
+            return float("nan")
         gain = delta.clip(lower=0.0)
         loss = -delta.clip(upper=0.0)
-        avg_gain = gain.rolling(period).mean().iloc[-1]
-        avg_loss = loss.rolling(period).mean().iloc[-1]
+        # Wilder smoothing: seed with the plain mean of the first `period`
+        # moves, then recurse avg = (avg*(period-1) + current) / period.
+        # This is exactly backtrader's MovAv.Smoothed (SMA seed + recursive
+        # exponential with alpha = 1/period), so the live RSI now equals the
+        # backtested RSI to float precision on the same series — pinned by
+        # the bt-parity test in test_dsl_rsi_parity.py.
+        avg_gain = float(gain.iloc[:period].mean())
+        avg_loss = float(loss.iloc[:period].mean())
+        for g, lo in zip(gain.iloc[period:], loss.iloc[period:], strict=True):
+            avg_gain = (avg_gain * (period - 1) + float(g)) / period
+            avg_loss = (avg_loss * (period - 1) + float(lo)) / period
         if avg_loss == 0:
             return 100.0
         rs = avg_gain / avg_loss

--- a/backend/tests/services/test_dsl_rsi_parity.py
+++ b/backend/tests/services/test_dsl_rsi_parity.py
@@ -1,0 +1,93 @@
+"""F5 regression guard: live RSI equals backtrader's RSI on the same series.
+
+The defect (interpreter-divergence audit, 2026-08-03, F5): the live signal
+evaluator computed RSI with a plain ``rolling(period).mean()`` of gains and
+losses — Cutler's RSI — while the backtest's ``bt.indicators.RSI`` uses
+Wilder's recursive SMMA (SMA seed, then ``avg = (avg*(N-1)+cur)/N``).
+Backtrader ships the rolling-mean variant as a *separate* indicator
+(``RSI_SMA``/"Cutler") precisely because they are different indicators: on
+short windows they sit several points apart, so a graded backtest could pass
+``rsi > 65`` where the live path fails it on identical data.
+
+The parity oracle here is deliberately NOT a hand-written Wilder formula (a
+reimplementation could share a bug with the code under test — the
+same-literal-both-sides trap). It is ``bt.indicators.RSI`` itself, run over
+the same series: the actual other side of the divergence.
+"""
+
+from __future__ import annotations
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes.services.strategy_signal_evaluator import _compute_indicator_value
+
+# Mixed gains and losses so neither average is zero and the two smoothing
+# conventions measurably disagree (this exact series is the audit's worked
+# example, extended so the recursion has bars to differentiate on).
+_SERIES = [100.0, 102.0, 101.0, 105.0, 103.0, 108.0, 107.0, 110.0, 109.0, 113.0, 111.0, 116.0]
+_PERIOD = 3
+
+
+def _bt_rsi(values: list[float], period: int) -> float:
+    """Final RSI value from backtrader's own indicator over ``values``."""
+    idx = pd.bdate_range("2024-01-01", periods=len(values))
+    close = pd.Series(values, index=idx)
+    df = pd.DataFrame(
+        {"Open": close, "High": close, "Low": close, "Close": close, "Volume": 0.0},
+        index=idx,
+    )
+
+    captured: list[float] = []
+
+    class Probe(bt.Strategy):
+        def __init__(self) -> None:
+            self.rsi = bt.indicators.RSI(self.data.close, period=period)
+
+        def next(self) -> None:
+            captured.append(float(self.rsi[0]))
+
+    cerebro = bt.Cerebro()
+    cerebro.adddata(bt.feeds.PandasData(dataname=df))
+    cerebro.addstrategy(Probe)
+    cerebro.run()
+    return captured[-1]
+
+
+def test_live_rsi_matches_backtrader_rsi_to_float_precision():
+    """The parity contract itself: same series, same period, same number —
+    because the backtest is what gets graded, and the live value must be
+    computed the way the graded value was."""
+    live = _compute_indicator_value("rsi", _PERIOD, pd.Series(_SERIES))
+    reference = _bt_rsi(_SERIES, _PERIOD)
+    assert live == pytest.approx(reference, rel=1e-9)
+
+
+def test_the_parity_oracle_discriminates_against_cutler():
+    """Guard on the guard: prove the backtrader reference actually rejects the
+    OLD implementation. If Wilder and Cutler happened to coincide on this
+    series, the parity test above would pass against the pre-fix code too and
+    assert nothing — so pin that they measurably disagree here."""
+    prices = pd.Series(_SERIES)
+    delta = prices.diff()
+    gain = delta.clip(lower=0.0)
+    loss = -delta.clip(upper=0.0)
+    avg_gain = gain.rolling(_PERIOD).mean().iloc[-1]
+    avg_loss = loss.rolling(_PERIOD).mean().iloc[-1]
+    cutler = float(100.0 - 100.0 / (1.0 + avg_gain / avg_loss))
+    assert _bt_rsi(_SERIES, _PERIOD) != pytest.approx(cutler, abs=1.0)
+
+
+def test_rsi_all_gains_saturates_at_100():
+    """Degenerate branch kept from the old implementation: with no losses in
+    the window, avg_loss is 0 and RSI reads 100 rather than dividing by zero."""
+    rising = [100.0 + i for i in range(10)]
+    assert _compute_indicator_value("rsi", _PERIOD, pd.Series(rising)) == 100.0
+
+
+def test_rsi_insufficient_history_is_nan_not_a_number():
+    """Fewer moves than the period → NaN (matches the old rolling-mean
+    behaviour of having no defined value), never a fabricated reading."""
+    import math
+
+    assert math.isnan(_compute_indicator_value("rsi", 5, pd.Series([100.0, 101.0, 102.0])))


### PR DESCRIPTION
## What this fixes

**F5 from the interpreter-divergence audit.** The live signal evaluator computed RSI as a plain rolling mean of gains/losses — **Cutler's RSI** — while the backtest's `bt.indicators.RSI` uses **Wilder's recursive smoothing**. Backtrader ships the rolling-mean variant as a *separate* indicator precisely because they're different indicators.

Measured on this PR's fixture series: **81.82 (Cutler) vs 80.75 (Wilder)** — and on shorter windows the audit measured a 7.7-point gap. Gaps like that straddle real thresholds, so a graded backtest could pass `rsi > 65` while the live path fails it on identical data.

The sharpest part: the function's own docstring claimed *"standard Wilder-style RSI"* above the Cutler code — a load-bearing false comment, and plausibly why nobody re-checked. The docstring now says what each indicator actually computes, including the two asymmetries deliberately left **out** of this PR: EMA seeding (F10 — benign, converges) and `realized_vol` having no backtest counterpart (F6 — owned by the codegen work).

## Verification

- The parity oracle is **`bt.indicators.RSI` itself** run over the same series — not a hand-written Wilder formula that could share a bug with the code under test (the same-literal-both-sides trap).
- **Proven discriminating:** against the old code, the parity test fails with `81.818… != 80.750…`. A second test pins that Wilder and Cutler measurably *disagree* on the fixture series, so a passing parity test can never be vacuous coincidence.
- Degenerate branches kept and pinned: all-gains saturates at 100; insufficient history reads NaN, never a fabricated value.
- Full backend suite: **3069 passed, 0 failed.**

## ⚠️ For merge approval (Dan)

This **changes live signal behaviour** for any deployed spec with an RSI condition. The direction of change is the honest one — live now agrees with what the published backtest graded — but per the sprint brief, `AGENT_DRY_RUN` state should be confirmed at merge time. Not self-merging.

Sequencing: F1 is #1256 (blocks the re-run). F2/F3 remain **prepare-and-hold** for Dan's explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
