### PR TITLE
Add first-party agent skills (skills/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ Script retains Better Auth cookie, streams generation, and prints rigor verdict.
 
 See [`scripts/agent_journey.py`](scripts/agent_journey.py) for the full implementation.
 
+Reaching for the API surface directly (not via the script)? See
+[`skills/`](skills/README.md) for grounded, file:line-cited agent skills on the
+generate/verdict flow, reading a strategy passport honestly, and the x402
+marketplace payment flow.
+
 ## Why Archimedes
 
 | Category                  | Examples                                  | What's missing                                            |

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,50 @@
+# Archimedes skills
+
+First-party agent skills for working with and on Archimedes — for ourselves
+(Claude Code sessions, the agentic issue pipeline) and for external agents/humans
+integrating against the live API. Each skill is a self-contained directory with a
+`SKILL.md` that uses frontmatter (`name`, `description`, `triggers`) in the style
+of manifest-driven skills, so a skill-aware agent can discover and load the right
+one by matching its `triggers` against the task at hand.
+
+Note the location: this is `skills/`, tracked in git at the repo root — distinct
+from `.agents/`, which is gitignored and never the place for anything meant to
+ship with the repo.
+
+## What's here
+
+| Skill | Use it when |
+|---|---|
+| [`verdict-api/`](verdict-api/SKILL.md) | Calling `/api/generate/*` over HTTP — starting a generation job, reading its SSE event stream, understanding auth/rate-limit requirements as they actually are on `main`, and interpreting DSR/PBO/holdout numbers without over-claiming. |
+| [`x402-payment/`](x402-payment/SKILL.md) | Understanding or touching the x402/Circle Gateway copy-trading fee flow (`marketplace/payments.py`) — the in-process 402→sign→verify→settle protocol, testnet posture, and `PAYMENTS_DRY_RUN` semantics. |
+| [`strategy-passport/`](strategy-passport/SKILL.md) | Reading or summarizing a strategy passport — every `strategy_passports` field, what `passes_rigor_gate` does and does not mean, why `status="live"` is not a rigor claim, and the five claims never to make about a strategy's rigor. |
+| [`repo-dev/`](repo-dev/SKILL.md) | Doing general development work in this repo — the conda env (Python + Node), hermetic pytest conventions, merge-commit-only branch policy, CI gates, and where things live. |
+
+## Ground rules for every skill in this directory
+
+- **Every factual claim traces to a `file:line` citation in the working tree.**
+  A skill that asserts an endpoint, a field, or a default without pointing at
+  the line that proves it is a liability, not a shortcut — re-run the greps in
+  each skill's "Verify" section before trusting a claim that's gone stale.
+  Endpoints and behavior described here were verified against `main` as of the
+  skill's last update; if the code has since moved, the skill is wrong until
+  someone re-verifies and updates it.
+- **State what's deliberately NOT covered.** Every skill ends with a short list
+  of adjacent things it intentionally leaves to a different skill, so an agent
+  doesn't infer coverage that isn't there.
+- **No skill here claims more rigor, security, or capability than the code
+  currently has.** If a behavior is a stub, a dry-run default, or an
+  interim/custodial arrangement, the skill says so — see `strategy-passport/`'s
+  "five forbidden phrasings" and `x402-payment/`'s custody-model note for the
+  house style on this.
+- **The CLI is deliberately not covered.** `cli/` is a `0.0.1`
+  name-reservation stub — every subcommand exits `NOT_IMPLEMENTED`
+  (`cli/src/archimedes_cli/cli.py`). There is no `skills/cli/` here on purpose;
+  add one only once the CLI actually does something.
+
+## Adding a new skill
+
+Copy the shape of an existing `SKILL.md`: YAML frontmatter with `name`,
+`description`, and `triggers`, then grounded prose with file:line citations and
+a "Verify" section a reader can re-run. Keep each skill scoped to one coherent
+surface — cross-link to a sibling skill rather than duplicating its content.

--- a/skills/repo-dev/SKILL.md
+++ b/skills/repo-dev/SKILL.md
@@ -50,14 +50,14 @@ collide (`ImportPathMismatch`) if scooped up here. `-m "not integration"` is
 the exact filter the CI unit-test gate uses (needs no DB/Redis); the
 `integration` marker is defined in `pytest.ini`:25.
 
-`make pytest` (repo root `Makefile`:105-107) runs the same suite with two
+`make pytest` (repo root `Makefile`:108-110) runs the same suite with two
 Redis-dependent tests deselected for a bare-metal local run without Redis —
 useful when you don't have the docker-compose stack up.
 
 ### Hermetic-test discipline (codified 2026-05-27) — read before writing any new test
 
 "CI green ≠ local green" is itself treated as a bug here. The rules
-(`CLAUDE.md`:580-641, "Testing conventions"):
+(`CLAUDE.md`:229-291, "Testing conventions"):
 
 - **No `.env` dependence, no live Redis/Postgres/Anthropic/Arc RPC.** A test
   that only passes with `.env` loaded, or only fails without it, is a real bug
@@ -76,33 +76,33 @@ useful when you don't have the docker-compose stack up.
   inheriting `os.environ` leaks the developer's `.env` (e.g. a
   docker-compose-only `DATABASE_URL` hostname) into the subprocess. Reference
   pattern: `backend/tests/test_security_hardening.py`
-  (`_clean_subprocess_env` at line 38, `_DOTENV_NEUTRALIZE` at line 29).
+  (`_clean_subprocess_env` at line 40, `_DOTENV_NEUTRALIZE` at line 31).
 - **Mock at boundaries, not internals** — the HTTP client, DB session, Redis
   client, chain client, Circle signer; never internal dict/helper calls.
-  Concrete precedents named in `CLAUDE.md`:606-628: `AgentStateStore` mock for
+  Concrete precedents named in `CLAUDE.md`:255-273: `AgentStateStore` mock for
   Redis-down (`backend/tests/test_api_routes.py`), the SIWE signed-cookie
   helper `_siwe_cookies()` (`backend/tests/test_user_routes.py`),
   `httpx.ASGITransport` for endpoint tests (`backend/tests/test_risk_routes.py`).
 - **Coverage:** per-module ≥85% line coverage is the standard for new test
   work; the repo-level `--cov-fail-under=60` gate fires only on agent (`t2o2`)
-  PRs and is informational for everything else (`CLAUDE.md`:632-635).
+  PRs and is informational for everything else (`CLAUDE.md`:281-285).
 - **No skip-marks on flaky tests.** Flakiness is almost always a missing
   boundary mock or hidden environment state — fix it. A skip-mark should be
   rare and load-bearing (a documented architectural limitation), not a way to
-  avoid diagnosing (`CLAUDE.md`:636-641).
+  avoid diagnosing (`CLAUDE.md`:286-290).
 
 ## Linting + formatting (ruff)
 
 `ruff.toml` (repo root): `line-length = 120`, `target-version = "py312"`, ruff
-defaults plus `I,UP,B,SIM,RUF`. Two checks block every Python PR
-(`quality-gate.yml` per `CLAUDE.md`'s CI table); broader `ruff check` and
-`npm run lint` in `ui/` are informational only (`continue-on-error`, posted as
-a PR comment table):
+defaults plus `I,UP,B,SIM,RUF,ARG,C4,PIE,RET,SLF` (`[lint] extend-select`). Two
+checks block every Python PR (`quality-gate.yml` per `CLAUDE.md`'s CI table);
+broader `ruff check` and `npm run lint` in `ui/` are informational only
+(`continue-on-error`, posted as a PR comment table):
 
 ```bash
-ruff format --check .                       # hard block
-ruff check --select E9,F63,F7,F40 .          # hard block (syntax + undefined-module only, deliberately narrow)
-ruff check .                                 # informational (broader rule set)
+ruff format --check .                            # hard block
+ruff check --select E9,F63,F7,F40,F82 .          # hard block (syntax + undefined-name only, deliberately narrow)
+ruff check .                                      # informational (broader rule set)
 ```
 
 Local cleanup before committing:
@@ -121,24 +121,25 @@ Pre-commit is **opt-in**; without it you get the same feedback from CI on push.
 
 ## Merge-commit-only — the branch model
 
-(`CLAUDE.md`:458-478, "Branch model")
+(`CLAUDE.md`:140-163, "Branch model")
 
 - **`main` is the only long-lived branch, and it is the deploy branch.** Every
   merge triggers a CI build + deploy. There is no `develop` branch.
 - **Merge commits only.** Squash-merge and rebase-merge are **disabled in repo
   settings** — use `gh pr merge <n> --merge`, not the squash/rebase buttons.
-  Rationale stated in `CLAUDE.md`:474-478: merge commits keep
+  Rationale stated in `CLAUDE.md`:150-154: merge commits keep
   `git log --merges` / `git log --graph` showing unit-of-work boundaries, and
   rebase-merge breaks `git branch --merged` (rewritten commits are no longer
   ancestors of `main`).
 - **Never force-push `main`.** Force-pushing your own unmerged feature branch
-  is fine and expected (rebase-before-merge, `CLAUDE.md`:471-472).
+  is fine and expected (rebase-before-merge, `CLAUDE.md`:155-157 — now folded
+  into the "few hard rules" bullet rather than stated standalone).
 - **One logical change per PR; atomic commits; imperative-mood commit
   messages** ("Add X" not "Added X"), optional scope tags
   (`[strategy]`, `[backtest]`, `[contracts]`, `[frontend]`, `[infra]`, `[docs]`)
-  — `CLAUDE.md`:481-484.
+  — `CLAUDE.md`:161-162.
 - **Branch naming:** `<discord-handle>/<short-name>` → PR → merge to `main`;
-  delete the branch after merge (`CLAUDE.md`:467-468, 900-908).
+  delete the branch after merge (`CLAUDE.md`:149 — one line covers both today).
 - **Contract/on-chain changes need the contract owner's review** — currently
   Dan, with a second reviewer preferred; see `CLAUDE.md`'s "Team" section for
   who that is at any given time. Don't merge a Solidity change on your own
@@ -154,12 +155,18 @@ Fargate roll); `main-format-guard.yml` self-heals unformatted pushes to `main`;
 `release-tag.yml` tags merged PRs by title marker (`!minor`/`!version-release`/
 none — default to none when unsure).
 
-**No repo-wide markdown/docs-link gate exists today.** This repo does not
-currently have a `.github/scripts/docs_links.py` or any equivalent
-link-checking script or workflow — verified by `find .github -iname
-"*docs*"` and `grep -rl docs_links .github` both returning nothing on this
-tree. If one is added later, re-check whether it scans `skills/` before
-assuming these files are covered by it.
+**A docs-link gate exists now (`docs-gate.yml`), but it does not cover
+`skills/`.** `.github/workflows/docs-gate.yml` runs
+`.github/scripts/docs_links.py` (link resolution, blocking-when-triggered) +
+`docs_index.py` (index completeness) + a staleness check (informational) —
+but its default scan scope (`markdown_files()` in `docs_links.py`, `--scope
+gate`) is `docs/**/*.md` plus **root-level** `*.md` only; `skills/*/SKILL.md`
+is neither. The workflow's own `on.pull_request.paths` trigger (`docs/**`,
+`*.md`, the two `docs_*.py`/workflow files) also won't fire on a PR that
+touches only `skills/`. It's also path-filtered and therefore must not be a
+required check (boxed warning at the top of the workflow) — see
+`CLAUDE.md`'s CI table. Don't assume `skills/` content is covered by it; if
+the scope is widened later, re-check before assuming these files are covered.
 
 ## Where things live (top-level map)
 
@@ -196,8 +203,9 @@ grep -n "PYTHONPATH=backend" CLAUDE.md
 # Merge-commit-only is still the repo policy:
 grep -n "Merge commits only" CLAUDE.md
 
-# No docs-link gate exists yet:
-find .github -iname "*docs*"; grep -rl "docs_links" .github 2>/dev/null; echo "(empty output above = confirmed absent)"
+# A docs-link gate exists but its scope + trigger both exclude skills/:
+grep -n "paths:" -A5 .github/workflows/docs-gate.yml
+python3 .github/scripts/docs_links.py --root . 2>&1 | grep -i "skills/"; echo "(empty output above = skills/ not in the gate's default scan scope)"
 
 # CLI is still an unimplemented stub:
 grep -n "NOT_IMPLEMENTED" cli/src/archimedes_cli/cli.py
@@ -208,5 +216,6 @@ grep -n "NOT_IMPLEMENTED" cli/src/archimedes_cli/cli.py
 - API-level detail for the generate/verdict flow — see `skills/verdict-api/SKILL.md`.
 - Passport field semantics — see `skills/strategy-passport/SKILL.md`.
 - The marketplace payment protocol — see `skills/x402-payment/SKILL.md`.
-- AWS/infra operations (SSM, Terraform, deploy) — see `CLAUDE.md`'s "AWS account
-  access" section and `OPERATIONS.md`; out of scope for a dev-workflow skill.
+- AWS/infra operations (SSM, Terraform, deploy) — see the AWS paragraph in
+  `CLAUDE.md`'s "Setup" section and `docs/runbooks/operations.md` (the doc
+  formerly at root-level `OPERATIONS.md`); out of scope for a dev-workflow skill.

--- a/skills/repo-dev/SKILL.md
+++ b/skills/repo-dev/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: repo-dev
+description: Working on the Archimedes codebase — the conda env that carries both Python and Node, hermetic pytest conventions, merge-commit-only branch policy, CI quality gates, and where things live in the repo. Grounded in CLAUDE.md and the working tree; read this before writing or running code here.
+triggers:
+  - starting work in the archimedes repo
+  - "how do I run the tests, and why does pytest pass in CI but fail locally"
+  - "which branch strategy does this repo use, and how do I open a PR here"
+  - "node/npm not found, in this repo's shell"
+  - looking for where a piece of functionality lives in the tree
+---
+
+# Working on this codebase
+
+This is the operational complement to `CLAUDE.md` (repo root) — read `CLAUDE.md`
+for the full narrative; this skill is the load-bearing subset an agent needs
+before touching code, condensed and re-verified against the working tree.
+
+## The conda env carries Node too — a common trap
+
+**`python`/`pytest`/`ruff` AND `node`/`npm`/the `ui/` ESLint all come from the
+single `archimedes` conda env; none of them are on the base shell PATH.**
+A bare `command -v node` returning nothing does **not** mean Node is missing —
+it means the env isn't activated (`CLAUDE.md`, "Setup" section). For a
+non-interactive shell (CI runner, or an agent's Bash tool), prepend the env's
+bin directory instead of trying to `conda activate`:
+
+```bash
+export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
+node --version            # v26.x ; npm 11.x
+cd ui && npm run lint     # or scoped: ./node_modules/.bin/eslint src/<file>
+```
+
+`environment.yml` (repo root) is the single source of truth for the env. It is
+also a file you should **ask before editing** — every team member rebuilds
+their env on a change (`CLAUDE.md`, "When to ask before acting").
+
+## Running the tests
+
+```bash
+pytest                     # from repo root, in the archimedes env — pytest.ini
+                            #   sets pythonpath=backend, testpaths=backend/tests
+pytest --cov=archimedes --cov-report=term-missing
+cd analytics-engine && uv run pytest   # separate suite, separate toolchain (uv)
+```
+
+`pytest.ini` (repo root) explicitly excludes submodules/analytics-engine/cli/
+node_modules/ui/contracts/infra/wallet-setup from collection
+(`norecursedirs`, pytest.ini:14) — they have their own toolchains and would
+collide (`ImportPathMismatch`) if scooped up here. `-m "not integration"` is
+the exact filter the CI unit-test gate uses (needs no DB/Redis); the
+`integration` marker is defined in `pytest.ini`:25.
+
+`make pytest` (repo root `Makefile`:105-107) runs the same suite with two
+Redis-dependent tests deselected for a bare-metal local run without Redis —
+useful when you don't have the docker-compose stack up.
+
+### Hermetic-test discipline (codified 2026-05-27) — read before writing any new test
+
+"CI green ≠ local green" is itself treated as a bug here. The rules
+(`CLAUDE.md`:580-641, "Testing conventions"):
+
+- **No `.env` dependence, no live Redis/Postgres/Anthropic/Arc RPC.** A test
+  that only passes with `.env` loaded, or only fails without it, is a real bug
+  to fix — never skip-mark it. The literal gate a reviewer runs:
+  ```bash
+  env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
+    python -m pytest backend/tests/test_<module>.py -q
+  # must end: N passed, 0 failed
+  ```
+- **`asyncio.get_event_loop().run_until_complete(...)` is forbidden** — Python
+  3.12 raises `RuntimeError` for it outside a running loop. Use `asyncio.run(coro)`
+  for a sync test calling async code, or a plain `async def test_...` (asyncio
+  mode is `auto` in `pytest.ini`:8). CI check: `grep -r "asyncio.get_event_loop" backend/tests/`
+  must return nothing.
+- **Subprocess tests need `_clean_subprocess_env()` + `_DOTENV_NEUTRALIZE`** —
+  inheriting `os.environ` leaks the developer's `.env` (e.g. a
+  docker-compose-only `DATABASE_URL` hostname) into the subprocess. Reference
+  pattern: `backend/tests/test_security_hardening.py`
+  (`_clean_subprocess_env` at line 38, `_DOTENV_NEUTRALIZE` at line 29).
+- **Mock at boundaries, not internals** — the HTTP client, DB session, Redis
+  client, chain client, Circle signer; never internal dict/helper calls.
+  Concrete precedents named in `CLAUDE.md`:606-628: `AgentStateStore` mock for
+  Redis-down (`backend/tests/test_api_routes.py`), the SIWE signed-cookie
+  helper `_siwe_cookies()` (`backend/tests/test_user_routes.py`),
+  `httpx.ASGITransport` for endpoint tests (`backend/tests/test_risk_routes.py`).
+- **Coverage:** per-module ≥85% line coverage is the standard for new test
+  work; the repo-level `--cov-fail-under=60` gate fires only on agent (`t2o2`)
+  PRs and is informational for everything else (`CLAUDE.md`:632-635).
+- **No skip-marks on flaky tests.** Flakiness is almost always a missing
+  boundary mock or hidden environment state — fix it. A skip-mark should be
+  rare and load-bearing (a documented architectural limitation), not a way to
+  avoid diagnosing (`CLAUDE.md`:636-641).
+
+## Linting + formatting (ruff)
+
+`ruff.toml` (repo root): `line-length = 120`, `target-version = "py312"`, ruff
+defaults plus `I,UP,B,SIM,RUF`. Two checks block every Python PR
+(`quality-gate.yml` per `CLAUDE.md`'s CI table); broader `ruff check` and
+`npm run lint` in `ui/` are informational only (`continue-on-error`, posted as
+a PR comment table):
+
+```bash
+ruff format --check .                       # hard block
+ruff check --select E9,F63,F7,F40 .          # hard block (syntax + undefined-module only, deliberately narrow)
+ruff check .                                 # informational (broader rule set)
+```
+
+Local cleanup before committing:
+
+```bash
+ruff check --select I --fix .      # import organization (safe, mechanical)
+ruff check --fix .                 # other safe auto-fixes
+ruff format .                      # apply formatting
+```
+
+`pip install pre-commit && pre-commit install` wires the same checks
+(`.pre-commit-config.yaml`, repo root — its ruff hook args are commented as
+"MIRRORS the CI ruff-gate blocking subset") plus `detect-secrets` (secret
+scanning against `.secrets.baseline`) and basic YAML/JSON/whitespace hygiene.
+Pre-commit is **opt-in**; without it you get the same feedback from CI on push.
+
+## Merge-commit-only — the branch model
+
+(`CLAUDE.md`:458-478, "Branch model")
+
+- **`main` is the only long-lived branch, and it is the deploy branch.** Every
+  merge triggers a CI build + deploy. There is no `develop` branch.
+- **Merge commits only.** Squash-merge and rebase-merge are **disabled in repo
+  settings** — use `gh pr merge <n> --merge`, not the squash/rebase buttons.
+  Rationale stated in `CLAUDE.md`:474-478: merge commits keep
+  `git log --merges` / `git log --graph` showing unit-of-work boundaries, and
+  rebase-merge breaks `git branch --merged` (rewritten commits are no longer
+  ancestors of `main`).
+- **Never force-push `main`.** Force-pushing your own unmerged feature branch
+  is fine and expected (rebase-before-merge, `CLAUDE.md`:471-472).
+- **One logical change per PR; atomic commits; imperative-mood commit
+  messages** ("Add X" not "Added X"), optional scope tags
+  (`[strategy]`, `[backtest]`, `[contracts]`, `[frontend]`, `[infra]`, `[docs]`)
+  — `CLAUDE.md`:481-484.
+- **Branch naming:** `<discord-handle>/<short-name>` → PR → merge to `main`;
+  delete the branch after merge (`CLAUDE.md`:467-468, 900-908).
+- **Contract/on-chain changes need the contract owner's review** — currently
+  Dan, with a second reviewer preferred; see `CLAUDE.md`'s "Team" section for
+  who that is at any given time. Don't merge a Solidity change on your own
+  judgment alone.
+
+## CI quality gates (what actually blocks a PR)
+
+Full table + exact commands in `CLAUDE.md`'s "CI / quality gates" section.
+Headline: `quality-gate.yml` hard-blocks on `pytest -m "not integration"` +
+the ruff-gate subset above; `complexity-gate.yml` is **informational only,
+never blocks merge**; `deploy.yml` fires on push to `main` (build → ECR →
+Fargate roll); `main-format-guard.yml` self-heals unformatted pushes to `main`;
+`release-tag.yml` tags merged PRs by title marker (`!minor`/`!version-release`/
+none — default to none when unsure).
+
+**No repo-wide markdown/docs-link gate exists today.** This repo does not
+currently have a `.github/scripts/docs_links.py` or any equivalent
+link-checking script or workflow — verified by `find .github -iname
+"*docs*"` and `grep -rl docs_links .github` both returning nothing on this
+tree. If one is added later, re-check whether it scans `skills/` before
+assuming these files are covered by it.
+
+## Where things live (top-level map)
+
+Full annotated tree in `README.md`'s "Repository structure" section; the
+parts most relevant to backend/API work:
+
+```
+backend/archimedes/
+├── api/            ← FastAPI routers (generate_routes.py, strategies_routes.py, …)
+├── agents/          ← generation pipeline, debate engine
+├── chain/           ← on-chain integration + oracle runner
+├── interfaces/       ← frozen Protocol classes
+├── models/           ← SQLAlchemy ORM (StrategyPassportRecord, StrategyRecord, …)
+├── services/         ← business logic (rigor_evaluator, model_gate, generation_quota, …)
+└── marketplace/       ← x402/Circle Gateway copy-trading money seam
+
+analytics-engine/    ← backtrader-based backtest engine (own uv project, own pytest)
+contracts/           ← Solidity, Foundry layout
+ui/                  ← React 19 + Vite 8 + viem
+scripts/              ← operational scripts, incl. agent_journey.py (reference SIWE + generate client)
+cli/                  ← archimedes CLI — 0.0.1 stub, every subcommand exits NOT_IMPLEMENTED (see skills/verdict-api)
+docs/                 ← specs, ADRs, design docs; docs/README.md is its own map
+```
+
+## Verify (re-run these before trusting this document)
+
+```bash
+# Env carries both Python and Node:
+grep -n "nodejs" environment.yml
+
+# Hermetic gate command still matches CLAUDE.md:
+grep -n "PYTHONPATH=backend" CLAUDE.md
+
+# Merge-commit-only is still the repo policy:
+grep -n "Merge commits only" CLAUDE.md
+
+# No docs-link gate exists yet:
+find .github -iname "*docs*"; grep -rl "docs_links" .github 2>/dev/null; echo "(empty output above = confirmed absent)"
+
+# CLI is still an unimplemented stub:
+grep -n "NOT_IMPLEMENTED" cli/src/archimedes_cli/cli.py
+```
+
+## What this skill deliberately does not cover
+
+- API-level detail for the generate/verdict flow — see `skills/verdict-api/SKILL.md`.
+- Passport field semantics — see `skills/strategy-passport/SKILL.md`.
+- The marketplace payment protocol — see `skills/x402-payment/SKILL.md`.
+- AWS/infra operations (SSM, Terraform, deploy) — see `CLAUDE.md`'s "AWS account
+  access" section and `OPERATIONS.md`; out of scope for a dev-workflow skill.

--- a/skills/repo-dev/SKILL.md
+++ b/skills/repo-dev/SKILL.md
@@ -179,7 +179,7 @@ backend/archimedes/
 analytics-engine/    ← backtrader-based backtest engine (own uv project, own pytest)
 contracts/           ← Solidity, Foundry layout
 ui/                  ← React 19 + Vite 8 + viem
-scripts/              ← operational scripts, incl. agent_journey.py (reference SIWE + generate client)
+scripts/              ← operational scripts, incl. agent_journey.py (reference account-auth + generate client)
 cli/                  ← archimedes CLI — 0.0.1 stub, every subcommand exits NOT_IMPLEMENTED (see skills/verdict-api)
 docs/                 ← specs, ADRs, design docs; docs/README.md is its own map
 ```

--- a/skills/strategy-passport/SKILL.md
+++ b/skills/strategy-passport/SKILL.md
@@ -12,7 +12,7 @@ triggers:
 # Reading a strategy passport
 
 A passport is one row in the `strategy_passports` table
-(`StrategyPassportRecord`, [`backend/archimedes/models/strategy_passport_record.py`](../../backend/archimedes/models/strategy_passport_record.py):44-139)
+(`StrategyPassportRecord`, [`backend/archimedes/models/strategy_passport_record.py`](../../backend/archimedes/models/strategy_passport_record.py):44-144)
 — the unified store for curated, fusion, and architect-generated strategies
 alike (record.py:1-11 module docstring). Read that table's columns as ground
 truth; anything summarized from it must trace back to a named field, never to
@@ -20,7 +20,7 @@ vibes.
 
 ## Every field, grouped as the model groups them
 
-Line numbers below are the `Column(...)` declarations in `strategy_passport_record.py`.
+Line numbers below are the `Column(...)` (or, for `owner_wallet`/`owner_user_id`, `mapped_column(...)`) declarations in `strategy_passport_record.py`.
 
 **Identity / provenance**
 | Field | Line | Meaning |
@@ -50,50 +50,51 @@ Line numbers below are the `Column(...)` declarations in `strategy_passport_reco
 **Ownership**
 | Field | Line | Meaning |
 |---|---|---|
-| `owner_wallet` (FK → `wallet_identities`) | 87 | SIWE-derived generating wallet, server-bound; `NULL` for curated/legacy rows |
+| `owner_user_id` (FK → `auth_users.id`) | 90-92 | **Canonical account ownership** (post-#1194 Better Auth cutover) — the account id that owns this strategy. This is the field that gates visibility/access, not `owner_wallet`. |
+| `owner_wallet` (FK → `wallet_identities`) | 87-89 | Wallet **provenance** only — the SIWE-derived generating wallet, server-bound; `NULL` for curated/legacy rows. Mirrors `strategy_store.owner_wallet`. Do not use this for ownership/access checks — that's `owner_user_id`. |
 
 **Code binding**
 | Field | Line |
 |---|---|
-| `strategy_code_path`, `strategy_code_hash` | 90-91 |
+| `strategy_code_path`, `strategy_code_hash` | 95-96 |
 
 **On-chain anchor**
 | Field | Line |
 |---|---|
-| `on_chain_registration_tx`, `on_chain_registration_block` | 94-95 |
+| `on_chain_registration_tx`, `on_chain_registration_block` | 99-100 |
 
 **Paper claims** (what the *source paper* reported — not what Archimedes measured)
 | Field | Line |
 |---|---|
-| `paper_claimed_sharpe`, `paper_claimed_cagr`, `paper_claimed_max_dd` | 98-100 |
-| `paper_claim_blended_sharpe` | 101 |
+| `paper_claimed_sharpe`, `paper_claimed_cagr`, `paper_claimed_max_dd` | 103-105 |
+| `paper_claim_blended_sharpe` | 106 |
 
 **Backtest results** (what Archimedes actually measured, denormalized for query speed)
 | Field | Line |
 |---|---|
-| `sharpe_ratio`, `sortino_ratio`, `max_drawdown`, `cagr`, `win_rate`, `total_trades`, `calmar_ratio`, `correlation_to_spy` | 104-111 |
-| `backtest_start`, `backtest_end` | 112-113 |
+| `sharpe_ratio`, `sortino_ratio`, `max_drawdown`, `cagr`, `win_rate`, `total_trades`, `calmar_ratio`, `correlation_to_spy` | 109-116 |
+| `backtest_start`, `backtest_end` | 117-118 |
 
 **Rigor gate results** — the four-primitive admission gate (DSR / PBO / OOS / look-ahead audit, per `docs/specs/selection-bias-corrections-spec.md`)
 | Field | Line | Meaning |
 |---|---|---|
-| `deflated_sharpe_ratio`, `dsr_p_value` | 116-117 | Deflated Sharpe Ratio + its p-value (Bailey & López de Prado 2014) |
-| `pbo_score` | 118 | Probability of Backtest Overfitting |
-| `out_of_sample_sharpe` | 119 | Walk-forward holdout Sharpe |
-| `passes_rigor_gate` | 120 | **The badge boolean — read the whole next section before quoting this** |
-| `kelly_fraction` | 121 | Position-sizing primitive |
-| `sharpe_ci_lower`, `sharpe_ci_upper` | 122-123 | Confidence interval on Sharpe |
-| `n_obs_daily` | 124 | Sample size the above were computed over |
+| `deflated_sharpe_ratio`, `dsr_p_value` | 121-122 | Deflated Sharpe Ratio + its p-value (Bailey & López de Prado 2014) |
+| `pbo_score` | 123 | Probability of Backtest Overfitting |
+| `out_of_sample_sharpe` | 124 | Walk-forward holdout Sharpe |
+| `passes_rigor_gate` | 125 | **The badge boolean — read the whole next section before quoting this** |
+| `kelly_fraction` | 126 | Position-sizing primitive |
+| `sharpe_ci_lower`, `sharpe_ci_upper` | 127-128 | Confidence interval on Sharpe |
+| `n_obs_daily` | 129 | Sample size the above were computed over |
 
-Timestamps (`created_at`/`updated_at`) at 127-128.
+Timestamps (`created_at`/`updated_at`) at 132-133.
 
-`StrategyPassportRecord.to_dict()` (record.py:200-217) is the compact API
-serialization; `to_strategy_passport()` (record.py:141-198) is the fuller
+`StrategyPassportRecord.to_dict()` (record.py:205-222) is the compact API
+serialization; `to_strategy_passport()` (record.py:146-203) is the fuller
 dataclass conversion including everything above. The live HTTP surface is
 `GET /api/strategies/passports/{strategy_id}`
-([`api/strategies_routes.py`](../../backend/archimedes/api/strategies_routes.py):1592-1609)
+([`api/strategies_routes.py`](../../backend/archimedes/api/strategies_routes.py):1622-1640)
 — 404s (never 403) for a non-owner on an unpublished non-example passport, so a
-mismatched caller can't confirm the id exists (strategies_routes.py:1596-1598).
+mismatched caller can't confirm the id exists (strategies_routes.py:1638-1639).
 
 ## `passes_rigor_gate` — what it means and what it does NOT mean
 
@@ -104,12 +105,12 @@ computed
 (`services/rigor_profiles.py` docstring line 22: "The badge (`passes_rigor_gate`)
 is always evaluated at `STRICTEST_LEVEL`"). For a **generated** (fusion/architect)
 strategy it is a real, persisted **live**-gate verdict —
-`strategies_routes.py`:1733-1741 is explicit that this is "a stored *live*
+`strategies_routes.py`:1764-1767 is explicit that this is "a stored *live*
 verdict, not a fixture boolean," legitimate per issue #821 ("read a persisted
 live-gate verdict"). The same route also derives a tri-state
 `rigor_gate_status`: `"pending"` when there's no real backtest yet
 (`sharpe_ratio is None`), else `"pass"`/`"fail"` from the boolean
-(strategies_routes.py:1739-1741) — **prefer `rigor_gate_status` over the bare
+(strategies_routes.py:1770-1772) — **prefer `rigor_gate_status` over the bare
 boolean when a "pending" state matters**, since a bare `False` can't
 distinguish "failed" from "never backtested."
 
@@ -126,7 +127,7 @@ distinguish "failed" from "never backtested."
   the loosest one a UI might be showing under a relaxed filter.
 - **For a curated strategy, it was graded at `num_trials=1`** — its own return
   series only, not deflated against the rest of the library
-  (`selection_bias_routes.py`:313-320; full mechanics in `skills/verdict-api/SKILL.md`
+  (`selection_bias_routes.py`:313-321; full mechanics in `skills/verdict-api/SKILL.md`
   point 2). Say that scope out loud if you're explaining *why* a curated
   strategy's DSR looks strong.
 
@@ -150,7 +151,7 @@ decoupling concrete:
   (strategy_provider.py:321-328). A curator can mark a strategy `live` by hand.
 - **Generated strategies (`StrategyRecord`, a *different* table from the
   passport):** `status` transitions to `"live"` purely as a function of the
-  rigor verdict at write time (`models/strategy_store.py`:269-278, 307) — but
+  rigor verdict at write time (`models/strategy_store.py`:281-289, 317) — but
   that's a one-time transition at persist time, not a live-recomputed value; a
   strategy whose returns later degrade doesn't automatically flip back.
 
@@ -185,29 +186,29 @@ contradicts every one of them on the curated path (`_rigor_helpers.py` sets
 
 Separately, the team-wide pitch-rigor anti-claims —
 [`docs/anti-features.md`](../../docs/anti-features.md), "Pitch-rigor anti-claims"
-section, lines 197–249 — also apply when summarizing a passport:
+section, lines 204–255 — also apply when summarizing a passport:
 
-1. **"Blockchain as memory" as the load-bearing claim.** (anti-features.md:203-214)
+1. **"Blockchain as memory" as the load-bearing claim.** (anti-features.md:210-221)
    The defensible framing is narrower: the on-chain registry is "the agent's
    externalized memory for the specific financial-decision artifacts no party —
    including Archimedes — can later rewrite," not "blockchain as universal
    computational substrate."
-2. **Predicted alpha or future-return guarantees.** (anti-features.md:216-222)
+2. **Predicted alpha or future-return guarantees.** (anti-features.md:223-229)
    McLean & Pontiff (2016): published cross-sectional predictors lose 26%
    out-of-sample and 58% post-publication. Bailey & López de Prado (2014):
    backtest-optimized strategies often do not exceed the median out-of-sample
    result. Never say a strategy "delivers" or "will achieve" a Sharpe/CAGR —
    only that it was backtested to one, over a stated window.
 3. **That an on-chain trace hash proves the agent *used* that trace.**
-   (anti-features.md:224-230) A hash anchored at time T proves the reasoning
+   (anti-features.md:231-237) A hash anchored at time T proves the reasoning
    *existed* at T. It does not prove the trade was *caused* by it — that needs
    the commit-reveal upgrade (`docs/specs/commit-reveal-trace-spec.md`, v1.5,
    not yet the default path). Say "verifiable record of the reasoning at the
    moment of the trade," never "proof the trade followed from the reasoning."
-4. **Regulatory clarity or production-readiness.** (anti-features.md:232-240)
+4. **Regulatory clarity or production-readiness.** (anti-features.md:239-247)
    Frame every passport as describing a research-prototype strategy on Arc
    testnet, not a launchable investment product.
-5. **That the rigor gate makes a strategy "right."** (anti-features.md:242-249)
+5. **That the rigor gate makes a strategy "right."** (anti-features.md:249-255)
    DSR/PBO/OOS *reduce* the false-positive rate of a backtest-selected
    strategy; they do not make any specific strategy a confirmed true positive.
    The honest claim is "we apply the corrections and surface the numbers" —
@@ -216,8 +217,12 @@ section, lines 197–249 — also apply when summarizing a passport:
 ## Verify (re-run these before trusting this document)
 
 ```bash
-# Column list still matches:
-grep -n '= Column(' backend/archimedes/models/strategy_passport_record.py
+# Column list still matches (Column(...) AND Mapped/mapped_column(...) fields —
+# owner_wallet/owner_user_id use the latter, so a bare '= Column(' grep misses them):
+grep -nE '= (Column|mapped_column)\(' backend/archimedes/models/strategy_passport_record.py
+
+# owner_user_id is the canonical ownership column (post-#1194):
+grep -n "owner_user_id" backend/archimedes/models/strategy_passport_record.py
 
 # passes_rigor_gate is always graded at the strictest level:
 grep -n "STRICTEST_LEVEL" backend/archimedes/services/rigor_profiles.py
@@ -228,7 +233,7 @@ grep -n "CANDIDATE .. VALIDATED.*fixture boolean\|hand-declare" backend/archimed
 
 # The five anti-claims are still all present under the Pitch-rigor section (expect 5):
 grep -n "^## Pitch-rigor" docs/anti-features.md
-awk 'NR>=197 && NR<=249 && /^### NOT/' docs/anti-features.md
+awk 'NR>=204 && NR<=255 && /^### NOT/' docs/anti-features.md
 ```
 
 ## What this skill deliberately does not cover

--- a/skills/strategy-passport/SKILL.md
+++ b/skills/strategy-passport/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: strategy-passport
+description: How to read a strategy passport honestly — every field on strategy_passports (backend/archimedes/models/strategy_passport_record.py), what passes_rigor_gate does and does NOT mean, why status="live" is not a rigor claim, and the five specific claims this skill (and anyone summarizing a passport) must never make.
+triggers:
+  - reading /api/strategies/passports/{id} or a StrategyPassportRecord row
+  - "does this strategy pass the rigor gate"
+  - summarizing a strategy's DSR / PBO / Sharpe / backtest numbers for a user
+  - "is status=live the same as passing the gate"
+  - writing copy that describes Archimedes' strategy rigor
+---
+
+# Reading a strategy passport
+
+A passport is one row in the `strategy_passports` table
+(`StrategyPassportRecord`, [`backend/archimedes/models/strategy_passport_record.py`](../../backend/archimedes/models/strategy_passport_record.py):44-139)
+— the unified store for curated, fusion, and architect-generated strategies
+alike (record.py:1-11 module docstring). Read that table's columns as ground
+truth; anything summarized from it must trace back to a named field, never to
+vibes.
+
+## Every field, grouped as the model groups them
+
+Line numbers below are the `Column(...)` declarations in `strategy_passport_record.py`.
+
+**Identity / provenance**
+| Field | Line | Meaning |
+|---|---|---|
+| `id` | 49 | Primary key |
+| `methodology_hash` | 50 | Hash of the methodology text — the provenance anchor also written on-chain via `ReasoningTraceRegistry` |
+| `content_hash` | 51 | keccak256 for dedup (unique) |
+| `generation_method` | 54 | `curated \| fusion \| architect` |
+| `methodology_summary` / `methodology_text` | 55-56 | Human-readable + full text |
+| `asset_universe` | 57 | JSON list |
+| `universe_source` | 58-61 | `"user" \| "model" \| "full" \| NULL` — provenance of the asset picks (#857); a model-picked universe is a mild look-ahead channel (the model may pick names it "knows" did well in training data), surfaced here for audit, **not gated**. `NULL` for rows predating this column — never backfilled with a guess. |
+| `position_sizing` / `rebalance_frequency` | 62-63 | Strategy mechanics |
+| `risk_constraints` / `risk_profiles` | 64-65 | JSON |
+
+**Lifecycle**
+| Field | Line | Meaning |
+|---|---|---|
+| `status` | 68 | `candidate \| validated \| live \| retired \| rejected` — see "status ≠ gate" below |
+| `regime_tag` | 69 | e.g. `regime_neutral` |
+
+**Curation trail**
+| Field | Line |
+|---|---|
+| `extraction_llm`, `extraction_prompt_hash` | 72-73 |
+| `curator_wallet` (FK → `wallet_identities`), `curator_note` | 77-78 |
+
+**Ownership**
+| Field | Line | Meaning |
+|---|---|---|
+| `owner_wallet` (FK → `wallet_identities`) | 87 | SIWE-derived generating wallet, server-bound; `NULL` for curated/legacy rows |
+
+**Code binding**
+| Field | Line |
+|---|---|
+| `strategy_code_path`, `strategy_code_hash` | 90-91 |
+
+**On-chain anchor**
+| Field | Line |
+|---|---|
+| `on_chain_registration_tx`, `on_chain_registration_block` | 94-95 |
+
+**Paper claims** (what the *source paper* reported — not what Archimedes measured)
+| Field | Line |
+|---|---|
+| `paper_claimed_sharpe`, `paper_claimed_cagr`, `paper_claimed_max_dd` | 98-100 |
+| `paper_claim_blended_sharpe` | 101 |
+
+**Backtest results** (what Archimedes actually measured, denormalized for query speed)
+| Field | Line |
+|---|---|
+| `sharpe_ratio`, `sortino_ratio`, `max_drawdown`, `cagr`, `win_rate`, `total_trades`, `calmar_ratio`, `correlation_to_spy` | 104-111 |
+| `backtest_start`, `backtest_end` | 112-113 |
+
+**Rigor gate results** — the four-primitive admission gate (DSR / PBO / OOS / look-ahead audit, per `docs/specs/selection-bias-corrections-spec.md`)
+| Field | Line | Meaning |
+|---|---|---|
+| `deflated_sharpe_ratio`, `dsr_p_value` | 116-117 | Deflated Sharpe Ratio + its p-value (Bailey & López de Prado 2014) |
+| `pbo_score` | 118 | Probability of Backtest Overfitting |
+| `out_of_sample_sharpe` | 119 | Walk-forward holdout Sharpe |
+| `passes_rigor_gate` | 120 | **The badge boolean — read the whole next section before quoting this** |
+| `kelly_fraction` | 121 | Position-sizing primitive |
+| `sharpe_ci_lower`, `sharpe_ci_upper` | 122-123 | Confidence interval on Sharpe |
+| `n_obs_daily` | 124 | Sample size the above were computed over |
+
+Timestamps (`created_at`/`updated_at`) at 127-128.
+
+`StrategyPassportRecord.to_dict()` (record.py:200-217) is the compact API
+serialization; `to_strategy_passport()` (record.py:141-198) is the fuller
+dataclass conversion including everything above. The live HTTP surface is
+`GET /api/strategies/passports/{strategy_id}`
+([`api/strategies_routes.py`](../../backend/archimedes/api/strategies_routes.py):1592-1609)
+— 404s (never 403) for a non-owner on an unpublished non-example passport, so a
+mismatched caller can't confirm the id exists (strategies_routes.py:1596-1598).
+
+## `passes_rigor_gate` — what it means and what it does NOT mean
+
+**What it means:** a stored boolean, written by the generation pipeline (or the
+live rigor-gate recompute), reflecting whether the strategy passed DSR + PBO +
+OOS + look-ahead **at the strictest strictness level** at the time it was
+computed
+(`services/rigor_profiles.py` docstring line 22: "The badge (`passes_rigor_gate`)
+is always evaluated at `STRICTEST_LEVEL`"). For a **generated** (fusion/architect)
+strategy it is a real, persisted **live**-gate verdict —
+`strategies_routes.py`:1733-1741 is explicit that this is "a stored *live*
+verdict, not a fixture boolean," legitimate per issue #821 ("read a persisted
+live-gate verdict"). The same route also derives a tri-state
+`rigor_gate_status`: `"pending"` when there's no real backtest yet
+(`sharpe_ratio is None`), else `"pass"`/`"fail"` from the boolean
+(strategies_routes.py:1739-1741) — **prefer `rigor_gate_status` over the bare
+boolean when a "pending" state matters**, since a bare `False` can't
+distinguish "failed" from "never backtested."
+
+**What it does NOT mean:**
+
+- **It does not mean "will make money."** DSR and PBO *reduce* the false-positive
+  rate of backtest-driven selection; they do not eliminate it, and they say
+  nothing about future returns. See "The five forbidden phrasings" below.
+- **It is not the only strictness level that exists.** `/api/selection-bias/gate`
+  computes a full 1–5 strictness ladder per strategy
+  (`selection_bias_routes.py`:186-200) and returns `min_passing_level` — the
+  loosest level the strategy *would* clear. `passes_rigor_gate` on the passport
+  is always the level-1 (strictest, "Archimedes Verified" badge) verdict, never
+  the loosest one a UI might be showing under a relaxed filter.
+- **For a curated strategy, it was graded at `num_trials=1`** — its own return
+  series only, not deflated against the rest of the library
+  (`selection_bias_routes.py`:313-320; full mechanics in `skills/verdict-api/SKILL.md`
+  point 2). Say that scope out loud if you're explaining *why* a curated
+  strategy's DSR looks strong.
+
+## `status` ≠ gate result — say this explicitly, every time
+
+This is the single easiest honesty mistake to make reading a passport, because
+`status: "live"` *sounds* like "verified and running well." It is not that.
+
+`StrategyStatus.LIVE` is defined as **"Active in at least one portfolio"**
+([`models/strategy.py`](../../backend/archimedes/models/strategy.py):40) — a
+*usage* fact, not a *rigor* fact. Two independent code paths make the
+decoupling concrete:
+
+- **Curated strategies:** `status` comes straight from a curator-declared
+  `STATUS` field in the strategy file's metadata
+  (`services/strategy_provider.py`:314-319), and the surrounding comment is
+  explicit: "`CANDIDATE → VALIDATED` promotion is **not** driven by the fixture
+  boolean... the served status is overlaid [from the live gate] elsewhere; here
+  we keep only the file's declared STATUS **so a curator can still hand-declare
+  live/retired**; the fixture boolean no longer promotes anything"
+  (strategy_provider.py:321-328). A curator can mark a strategy `live` by hand.
+- **Generated strategies (`StrategyRecord`, a *different* table from the
+  passport):** `status` transitions to `"live"` purely as a function of the
+  rigor verdict at write time (`models/strategy_store.py`:269-278, 307) — but
+  that's a one-time transition at persist time, not a live-recomputed value; a
+  strategy whose returns later degrade doesn't automatically flip back.
+
+**The honest framing:** `status` tells you whether a strategy is deployed /
+in a portfolio / curator-declared active. `passes_rigor_gate` /
+`rigor_gate_status` tell you whether it currently clears the statistical
+admission bar. **Never present one as evidence for the other.** A strategy can
+be `status="live"` and `rigor_gate_status="fail"` simultaneously, and the
+passport should be read (and summarized) that way.
+
+## The five forbidden phrasings
+
+These are documented team-wide pitch-rigor anti-claims —
+[`docs/anti-features.md`](../../docs/anti-features.md), "Pitch-rigor anti-claims"
+section, lines 197–249 — restated here because a passport-summarizing skill is
+exactly where they get violated by accident. **Never claim any of the following
+when describing a passport, regardless of how good its numbers look:**
+
+1. **"Blockchain as memory" as the load-bearing claim.** (anti-features.md:203-214)
+   The defensible framing is narrower: the on-chain registry is "the agent's
+   externalized memory for the specific financial-decision artifacts no party —
+   including Archimedes — can later rewrite," not "blockchain as universal
+   computational substrate."
+2. **Predicted alpha or future-return guarantees.** (anti-features.md:216-222)
+   McLean & Pontiff (2016): published cross-sectional predictors lose 26%
+   out-of-sample and 58% post-publication. Bailey & López de Prado (2014):
+   backtest-optimized strategies often do not exceed the median out-of-sample
+   result. Never say a strategy "delivers" or "will achieve" a Sharpe/CAGR —
+   only that it was backtested to one, over a stated window.
+3. **That an on-chain trace hash proves the agent *used* that trace.**
+   (anti-features.md:224-230) A hash anchored at time T proves the reasoning
+   *existed* at T. It does not prove the trade was *caused* by it — that needs
+   the commit-reveal upgrade (`docs/specs/commit-reveal-trace-spec.md`, v1.5,
+   not yet the default path). Say "verifiable record of the reasoning at the
+   moment of the trade," never "proof the trade followed from the reasoning."
+4. **Regulatory clarity or production-readiness.** (anti-features.md:232-240)
+   Frame every passport as describing a research-prototype strategy on Arc
+   testnet, not a launchable investment product.
+5. **That the rigor gate makes a strategy "right."** (anti-features.md:242-249)
+   DSR/PBO/OOS *reduce* the false-positive rate of a backtest-selected
+   strategy; they do not make any specific strategy a confirmed true positive.
+   The honest claim is "we apply the corrections and surface the numbers" —
+   never "so this strategy is correct/validated as profitable."
+
+## Verify (re-run these before trusting this document)
+
+```bash
+# Column list still matches:
+grep -n '= Column(' backend/archimedes/models/strategy_passport_record.py
+
+# passes_rigor_gate is always graded at the strictest level:
+grep -n "STRICTEST_LEVEL" backend/archimedes/services/rigor_profiles.py
+
+# status=live means "active in a portfolio", not a rigor verdict:
+grep -n 'LIVE = "live"' backend/archimedes/models/strategy.py
+grep -n "CANDIDATE .. VALIDATED.*fixture boolean\|hand-declare" backend/archimedes/services/strategy_provider.py
+
+# The five anti-claims are still all present under the Pitch-rigor section (expect 5):
+grep -n "^## Pitch-rigor" docs/anti-features.md
+awk 'NR>=197 && NR<=249 && /^### NOT/' docs/anti-features.md
+```
+
+## What this skill deliberately does not cover
+
+- How to *request* a generation and get a job's SSE stream to the point a
+  passport exists — see `skills/verdict-api/SKILL.md`.
+- The marketplace fee-charging flow — unrelated to passport truthfulness; see
+  `skills/x402-payment/SKILL.md`.

--- a/skills/strategy-passport/SKILL.md
+++ b/skills/strategy-passport/SKILL.md
@@ -163,11 +163,29 @@ passport should be read (and summarized) that way.
 
 ## The five forbidden phrasings
 
-These are documented team-wide pitch-rigor anti-claims —
+These five are the claim-integrity rules for the rigor gate itself. The code
+contradicts every one of them on the curated path (`_rigor_helpers.py` sets
+`E_max_N = 0.0` when `N == 1`; `rigor_evaluator.py` logs verbatim
+"num_trials=1 — DSR runs UNDEFLATED (no multiple-testing correction)").
+**Never write, about a passport or the gate:**
+
+1. **"corrects for multiple testing"** — the curated path applies no
+   multiple-testing correction; only the generated path deflates, and only
+   against that strategy's own candidate pool.
+2. **"deflated for multiple testing"** — same reason; say *"deflated against
+   its own candidate pool"* for generated strategies only.
+3. **"corrects selection bias"** — board-level selection bias is *disclosed*,
+   not corrected (Benjamini–Hochberg helpers exist with zero non-test callers).
+4. **"statistically proven"** — nothing here is proven; the gate reduces the
+   false-positive rate under stated assumptions.
+5. **"95% confidence"** — the live gate is **90% one-sided** (0.90 since #901);
+   the 0.95 figure is a fossil from retired thresholds.
+
+## The pitch anti-claims (related, broader)
+
+Separately, the team-wide pitch-rigor anti-claims —
 [`docs/anti-features.md`](../../docs/anti-features.md), "Pitch-rigor anti-claims"
-section, lines 197–249 — restated here because a passport-summarizing skill is
-exactly where they get violated by accident. **Never claim any of the following
-when describing a passport, regardless of how good its numbers look:**
+section, lines 197–249 — also apply when summarizing a passport:
 
 1. **"Blockchain as memory" as the load-bearing claim.** (anti-features.md:203-214)
    The defensible framing is narrower: the on-chain registry is "the agent's

--- a/skills/verdict-api/SKILL.md
+++ b/skills/verdict-api/SKILL.md
@@ -7,17 +7,8 @@ triggers:
   - "what does the SSE stream from Archimedes send"
   - reading a strategy's passes_rigor_gate / DSR / PBO / out_of_sample_sharpe fields
   - integrating an external agent against Archimedes' generation endpoint
-  - "is REQUIRE_SIWE_FOR_GENERATION on, and generation auth questions in general"
+  - "what auth does generation need — account session, wallet, or both"
 ---
-
-> **⚠️ Auth model transition in flight (2026-08):** this skill documents `main`
-> as of 2026-08-19, where generation auth is SIWE-based
-> (`REQUIRE_SIWE_FOR_GENERATION`, secure-by-default). **PR #1194 replaces this
-> with Better Auth accounts as canonical identity** (`require_current_user` +
-> per-account/per-IP generation caps). When #1194 merges, update this skill's
-> auth section before trusting it — the endpoints stay, the identity model
-> changes.
-
 
 # Requesting a strategy verdict over HTTP
 
@@ -135,58 +126,60 @@ full passport field list).
 
 ## Auth requirements — as they actually are on `main` today
 
-There is **no API key**. Authentication is a SIWE (EIP-4361) wallet-signature
-session cookie, and whether it's *required* is a runtime flag:
+There is **no API key** and **no wallet requirement to generate**. Canonical
+identity is a **Better Auth account session** (#1194): every generation
+endpoint takes `user: CurrentUser = Depends(require_current_user)`
+(generate_routes.py:27, 112) and returns **401** with no session. Wallets
+are *linked to* an account, never a login by themselves.
 
-- `_generation_auth_required()` in
-  [`api/auth_siwe.py`](../../backend/archimedes/api/auth_siwe.py):189-210 — **secure
-  by default**: unless `REQUIRE_SIWE_FOR_GENERATION` is explicitly set to a falsy
-  value (`0|false|no|off`), generation requires a verified session. Set it to a
-  truthy value to force the gate on explicitly; leave it unset for the default-on
-  behavior. Under `TESTING=1` with the var unset, the gate is off (the hermetic
-  suite exercises the open path) — an explicit true/false always overrides that
-  carve-out.
-- `gate_generation` (auth_siwe.py:213-225) is the FastAPI dependency actually
-  wired onto `POST /api/generate/start` (generate_routes.py:120). When the gate is
-  on it behaves like `require_verified_wallet` — **401** with no session. When
-  explicitly off, it's best-effort: returns whatever wallet the session cookie
-  carries (possibly `None`) without enforcing.
-- The **stream/cancel/jobs/candidates** endpoints use a *different*, narrower
-  dependency: `get_verified_wallet` (never raises on its own) plus an explicit
-  `_require_job_auth` / `_require_job_access` check
-  (generate_routes.py:76-111). When gating is on: an anonymous caller gets **401
-  before any job lookup** (existence-oracle avoidance, generate_routes.py:81-83);
-  a caller whose wallet doesn't own the job gets **404, not 403** — a mismatched
-  caller must not be able to tell the job exists (generate_routes.py:94-98).
-  Ownerless jobs (created while gating was off) stay readable by any
-  *authenticated* caller.
+**Getting a session, in short:** `POST /api/auth/sign-up/email
+{name, email, password}` (password minimum 12 chars) → `POST
+/api/auth/sign-in/email` → the response sets the session cookie; send it on
+every subsequent call (`credentials: include` / curl `-b`). Verify with
+`GET /api/auth/get-session`. `scripts/agent_journey.py` at the repo root is
+the reference implementation of the full account → wallet-link → generate →
+paper-deploy flow for an external agent — read it before hand-rolling your
+own client.
 
-**Getting a session, in short:** `GET /api/auth/nonce` → sign the returned SIWE
-message with your key → `POST /api/auth/verify {message, signature}` → the
-response sets an `httponly`+`secure`+`samesite=strict` cookie
-(`api/auth_siwe.py`:231-464). A production `PUBLIC_DOMAIN`/chain-id mismatch fails
-closed with 401/503 (auth_siwe.py:96-113, 320-333) — the message must be signed
-for *this* domain and Arc chain id, not replayed from elsewhere. `scripts/agent_journey.py`
-at the repo root is the reference implementation of this exact flow for an
-external agent — read it before hand-rolling your own signer.
+**Job access is account-scoped.** The stream/jobs/candidates endpoints
+resolve the session first, then check `_require_job_access(job, user.id,
+job_id, linked_wallet)` (generate_routes.py:84, 261, 354): a job you don't
+own returns **404, not 403** — a mismatched caller must not learn the job
+exists.
 
-**Rate limiting**, independent of the auth gate:
+**Where a wallet still matters** — two places, both *optional* until they
+aren't:
+
+- **Payment.** `GET /api/generate/quote` is public and always tells the
+  truth about whether payment is required (generate_routes.py:96-103;
+  contract spec: [`docs/specs/generation-quote-contract.md`](../../docs/specs/generation-quote-contract.md)).
+  When the backend's payment flag is on, `POST /start` without a
+  `Payment-Signature` returns **402 with the quote in `detail`**, and the
+  signed payer must equal the account's **linked wallet**
+  (generate_routes.py:132-153). Link a wallet via `POST
+  /api/wallets/challenge` → sign the EIP-4361 message with your key → `POST
+  /api/wallets/verify` — one round-trip, `cast`-signable.
+- **Premium models.** See "Model gating" below — entitlement is checked
+  against the linked wallet.
+
+**Rate limiting and quotas**, stacked and fail-closed:
 
 - `POST /api/generate/start` is capped at `5/minute` via slowapi
-  (`@limiter.limit("5/minute")`, generate_routes.py:115).
-- A **wallet-less** caller (gate off, or gate on but genuinely anonymous — only
-  possible when the gate is off) is additionally capped at a small **daily**
-  quota per IP by `enforce_generation_quota`
-  (`services/generation_quota.py`:1-40, called at generate_routes.py:131-132);
-  a SIWE-authenticated caller bypasses this cap entirely. Hitting it returns 429
-  with a "connect a wallet" steering payload — it's deliberately also a
-  conversion prompt, not just a rate limit.
+  (`@limiter.limit("5/minute")`, generate_routes.py:107).
+- `enforce_generation_quota(request, user.id)` (generate_routes.py:124,
+  [`services/generation_quota.py`](../../backend/archimedes/services/generation_quota.py):212)
+  enforces **two stacked daily caps**: per-account
+  (`GENERATION_DAILY_CAP_PER_USER`, default 10) and per-IP
+  (`GENERATION_DAILY_CAP_PER_IP`, default 20), user bucket checked first,
+  `<= 0` disables either (generation_quota.py:63-86). Hitting one returns
+  **429**. Quota runs **before** the payment check — you cannot pay your
+  way past the cap.
 
 ## Model gating (`model` field on the start request)
 
-Passing a **premium** (Anthropic-on-Bedrock) model id requires wallet-connected
-entitlement, checked *before* the job is enqueued
-(`enforce_model_entitlement`, generate_routes.py:139,
+Passing a **premium** (Anthropic-on-Bedrock) model id requires entitlement on
+the account's **linked wallet**, checked *before* the job is enqueued
+(`enforce_model_entitlement`, generate_routes.py:156-162,
 [`services/model_gate.py`](../../backend/archimedes/services/model_gate.py)):
 a non-entitled caller gets **HTTP 402**, never a silent downgrade
 (model_gate.py:18-20). A **free** model id is always allowed. Anything that
@@ -251,8 +244,8 @@ number from this response to a user). The headline honesty traps specific to
 # Endpoint list + line numbers still match:
 grep -n "@generate_router\.\(post\|get\)" backend/archimedes/api/generate_routes.py
 
-# Auth gate default is still secure-by-default:
-grep -n "_generation_auth_required\|REQUIRE_SIWE_FOR_GENERATION" backend/archimedes/api/auth_siwe.py
+# Generation is still account-session-gated with stacked daily caps:
+grep -n "require_current_user\|enforce_generation_quota" backend/archimedes/api/generate_routes.py
 
 # EVENT_LOG_TTL:
 grep -n "EVENT_LOG_TTL = " backend/archimedes/services/job_queue.py
@@ -261,7 +254,7 @@ grep -n "EVENT_LOG_TTL = " backend/archimedes/services/job_queue.py
 grep -n "num_trials = 1" backend/archimedes/api/selection_bias_routes.py
 grep -n "num_trials.*!= 1" backend/archimedes/services/_rigor_helpers.py
 
-# Reference client for the full SIWE + stream flow:
+# Reference client for the full account + wallet-link + stream flow:
 sed -n '1,40p' scripts/agent_journey.py
 ```
 

--- a/skills/verdict-api/SKILL.md
+++ b/skills/verdict-api/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: verdict-api
+description: How an agent (or a human, via curl/HTTPie) requests a strategy generation and reads its rigor verdict over Archimedes' HTTP API — the /api/generate/* endpoints, the SSE event shape, real auth requirements on main today, and how to read DSR/PBO/OOS numbers without over-claiming.
+triggers:
+  - calling POST /api/generate/start or GET /api/generate/stream
+  - "how do I generate a strategy from the API"
+  - "what does the SSE stream from Archimedes send"
+  - reading a strategy's passes_rigor_gate / DSR / PBO / out_of_sample_sharpe fields
+  - integrating an external agent against Archimedes' generation endpoint
+  - "is REQUIRE_SIWE_FOR_GENERATION on, and generation auth questions in general"
+---
+
+# Requesting a strategy verdict over HTTP
+
+This skill grounds every claim in the working tree. File:line citations refer to
+`backend/archimedes/` at the commit this skill shipped with — re-run the greps in
+"Verify" if the code has moved.
+
+## The endpoint family
+
+Defined in [`backend/archimedes/api/generate_routes.py`](../../backend/archimedes/api/generate_routes.py)
+(module docstring, lines 1–13) and mounted at prefix `/api/generate`:
+
+| Method | Path | Line | What it does |
+|---|---|---|---|
+| POST | `/api/generate/start` | 114 | Create a generation job; returns `job_id` + `stream_url` immediately (202) and runs the pipeline in the background |
+| GET | `/api/generate/stream/{job_id}` | 227 | Server-Sent Events (SSE) stream of the job's progress and final verdict |
+| POST | `/api/generate/jobs/{job_id}/cancel` | 315 | Best-effort cancel of a running job |
+| GET | `/api/generate/jobs` | 371 | List recent jobs (status table) |
+| GET | `/api/generate/jobs/{job_id}/candidates` | 418 | N candidates considered, including rejected ones, once the job is `done` |
+
+This router deliberately lives outside `api/routes.py` — "no new endpoints go into
+`api/routes.py`" (generate_routes.py:11-12) — so don't look there for these.
+
+## Step 1 — start a job
+
+```bash
+curl -sX POST http://localhost:8000/api/generate/start \
+  -H 'Content-Type: application/json' \
+  --cookie-jar /tmp/cj.txt --cookie /tmp/cj.txt \
+  -d '{
+        "brief": {
+          "intent": "momentum tilt on large-cap tech, moderate risk",
+          "risk_appetite": "moderate",
+          "max_papers": 5
+        },
+        "n_candidates": 1
+      }'
+```
+
+Request/response schema: `GenerateStartRequest` / `GenerateStartResponse` in
+[`generate_schemas.py`](../../backend/archimedes/api/generate_schemas.py) (lines 27–86).
+Notable fields:
+
+- `brief.intent` — free text, required.
+- `brief.risk_appetite` — one of `fixed_income | conservative | moderate | aggressive | hyper_risky` (generate_schemas.py:31).
+- `brief.max_papers` — 1–20, default 5 (generate_schemas.py:34).
+- `n_candidates` — 1–5, default 1 (generate_schemas.py:63). This is **not** the DSR
+  multiple-testing count — see "Reading DSR/PBO honestly" below.
+- `mode` — accepted for API compatibility but **ignored**: "the debate society is
+  the sole generation pipeline" (generate_schemas.py:66-69, generate_routes.py's
+  `_run_with_cleanup` never branches on it besides passing it through unused by
+  the active pipeline).
+- `model` — optional model id; gated server-side, see "Model gating" below.
+
+Response is `202` with `{job_id, stream_url, ttl_seconds}` (generate_routes.py:197-201).
+`ttl_seconds` is `EVENT_LOG_TTL = 900` (15 minutes) from
+[`services/job_queue.py`](../../backend/archimedes/services/job_queue.py):26 — the
+event log a reconnecting client can replay from expires that long after the job
+reaches a terminal state.
+
+## Step 2 — stream the verdict
+
+```bash
+curl -N http://localhost:8000/api/generate/stream/<job_id> \
+  --cookie /tmp/cj.txt
+```
+
+This is a real `text/event-stream` response (`StreamingResponse`,
+generate_routes.py:296-304), not a polling endpoint. Behavior worth knowing before
+you write a client:
+
+- **First byte is a comment**, not an event: `: stream opened\n\n` (generate_routes.py:255),
+  sent immediately so `EventSource.onopen` fires fast. A spec-compliant SSE parser
+  ignores `:`-prefixed lines; a hand-rolled line-splitter must not choke on them.
+- **Heartbeats.** If no real event fires for 15s (`_HEARTBEAT_INTERVAL_SECONDS`,
+  generate_routes.py:63), the server emits `: heartbeat\n\n` so intermediaries with
+  a shorter idle-read timeout (CloudFront, corporate proxies) don't drop the
+  connection while a long debate/backtest step is still computing
+  (generate_routes.py:53-63, 280-289). Also invisible to a spec-compliant parser.
+- **Resume with `Last-Event-ID`.** Each real event carries a numeric `id:` field;
+  send it back as the `Last-Event-ID` header on reconnect and the server resumes
+  after that cursor (generate_routes.py:248-250, 257).
+- **Hard timeout.** One connection is capped at 300s (`_STREAM_TIMEOUT_SECONDS`,
+  generate_routes.py:52); past that it sends `: stream timeout\n\n` and closes —
+  reconnect with `Last-Event-ID` to keep tailing a still-running job.
+- **Terminal events** are `done` and `error` (`_TERMINAL_EVENTS`, generate_routes.py:50);
+  the stream closes right after either.
+
+### Event names on the wire
+
+The full `EventName` literal (generate_schemas.py:92-107):
+
+```
+job_queued, brief_validated, pipeline_selected, candidates_selected,
+agent_iteration, tool_called, tool_result, candidate_drafted,
+candidate_evaluated, best_selected, trace_hashed, persisted, done, error
+```
+
+Each SSE frame is built by `_format_sse` (generate_routes.py:307-312) as:
+
+```
+id: <int>
+event: <one of the names above>
+data: <json>
+
+```
+
+`data` is an arbitrary JSON object (`GenerateEvent.data: dict[str, Any]`,
+generate_schemas.py:114-128) — the event name tells you how to interpret it; there
+is no single fixed schema across all fourteen event types. The verdict itself
+arrives inside the `done` event's payload (and via the separate
+`/api/generate/jobs/{job_id}/candidates` and `/api/strategies/passports/{id}`
+endpoints once the job is `done` — see `skills/strategy-passport/SKILL.md` for the
+full passport field list).
+
+## Auth requirements — as they actually are on `main` today
+
+There is **no API key**. Authentication is a SIWE (EIP-4361) wallet-signature
+session cookie, and whether it's *required* is a runtime flag:
+
+- `_generation_auth_required()` in
+  [`api/auth_siwe.py`](../../backend/archimedes/api/auth_siwe.py):189-210 — **secure
+  by default**: unless `REQUIRE_SIWE_FOR_GENERATION` is explicitly set to a falsy
+  value (`0|false|no|off`), generation requires a verified session. Set it to a
+  truthy value to force the gate on explicitly; leave it unset for the default-on
+  behavior. Under `TESTING=1` with the var unset, the gate is off (the hermetic
+  suite exercises the open path) — an explicit true/false always overrides that
+  carve-out.
+- `gate_generation` (auth_siwe.py:213-225) is the FastAPI dependency actually
+  wired onto `POST /api/generate/start` (generate_routes.py:120). When the gate is
+  on it behaves like `require_verified_wallet` — **401** with no session. When
+  explicitly off, it's best-effort: returns whatever wallet the session cookie
+  carries (possibly `None`) without enforcing.
+- The **stream/cancel/jobs/candidates** endpoints use a *different*, narrower
+  dependency: `get_verified_wallet` (never raises on its own) plus an explicit
+  `_require_job_auth` / `_require_job_access` check
+  (generate_routes.py:76-111). When gating is on: an anonymous caller gets **401
+  before any job lookup** (existence-oracle avoidance, generate_routes.py:81-83);
+  a caller whose wallet doesn't own the job gets **404, not 403** — a mismatched
+  caller must not be able to tell the job exists (generate_routes.py:94-98).
+  Ownerless jobs (created while gating was off) stay readable by any
+  *authenticated* caller.
+
+**Getting a session, in short:** `GET /api/auth/nonce` → sign the returned SIWE
+message with your key → `POST /api/auth/verify {message, signature}` → the
+response sets an `httponly`+`secure`+`samesite=strict` cookie
+(`api/auth_siwe.py`:231-464). A production `PUBLIC_DOMAIN`/chain-id mismatch fails
+closed with 401/503 (auth_siwe.py:96-113, 320-333) — the message must be signed
+for *this* domain and Arc chain id, not replayed from elsewhere. `scripts/agent_journey.py`
+at the repo root is the reference implementation of this exact flow for an
+external agent — read it before hand-rolling your own signer.
+
+**Rate limiting**, independent of the auth gate:
+
+- `POST /api/generate/start` is capped at `5/minute` via slowapi
+  (`@limiter.limit("5/minute")`, generate_routes.py:115).
+- A **wallet-less** caller (gate off, or gate on but genuinely anonymous — only
+  possible when the gate is off) is additionally capped at a small **daily**
+  quota per IP by `enforce_generation_quota`
+  (`services/generation_quota.py`:1-40, called at generate_routes.py:131-132);
+  a SIWE-authenticated caller bypasses this cap entirely. Hitting it returns 429
+  with a "connect a wallet" steering payload — it's deliberately also a
+  conversion prompt, not just a rate limit.
+
+## Model gating (`model` field on the start request)
+
+Passing a **premium** (Anthropic-on-Bedrock) model id requires wallet-connected
+entitlement, checked *before* the job is enqueued
+(`enforce_model_entitlement`, generate_routes.py:139,
+[`services/model_gate.py`](../../backend/archimedes/services/model_gate.py)):
+a non-entitled caller gets **HTTP 402**, never a silent downgrade
+(model_gate.py:18-20). A **free** model id is always allowed. Anything that
+isn't on the free allowlist and wasn't entitled falls back to the env default
+(generate_routes.py:142-151) — check `is_allowed_model` in
+`services/llm_backend.py` for the current free-tier list.
+
+## Reading DSR/PBO/holdout numbers honestly
+
+Once a job is `done`, the winning strategy's verdict fields live on its passport
+(`StrategyPassportRecord` / `/api/strategies/passports/{id}` — full field-by-field
+guide in `skills/strategy-passport/SKILL.md`, read that skill before quoting a
+number from this response to a user). The headline honesty traps specific to
+*this* endpoint family:
+
+1. **`n_candidates` on the request is not the DSR `num_trials`.** The Deflated
+   Sharpe Ratio's multiple-testing correction uses `_society_num_trials(pool_size)`
+   — the *search pool the winning candidate was actually selected from* —
+   computed independently in
+   [`agents/generation_pipeline.py`](../../backend/archimedes/agents/generation_pipeline.py):645
+   and threaded through `_backtest_and_persist` (generation_pipeline.py:1511,
+   1582-1590). It is deliberately **never** the size of the curated strategy
+   library (generation_pipeline.py:334-335, "NEVER the curated library's count").
+2. **Curated strategies are graded at `num_trials=1` — always.** For a
+   hand-curated single-paper strategy (no generation search of ours produced
+   it), the self-contained trial count is 1: it's judged purely on its own return
+   series, not deflated by how many *other* strategies sit in the library
+   ([`api/selection_bias_routes.py`](../../backend/archimedes/api/selection_bias_routes.py):313-320,
+   the hardcoded `num_trials = 1` at line 320). This is a deliberate 2026-07-09
+   decision (decouple #2) that **reverses** an earlier library-size-deflation
+   scheme and needed Önder's sign-off precisely because it raises curated pass
+   rates by removing a cross-strategy penalty (selection_bias_routes.py:314-319).
+   A guard (`assert_self_contained_cohort_correlation`,
+   `services/_rigor_helpers.py`:615) raises loudly if a future edit ever
+   re-couples curated DSR to the library's cross-strategy correlation — so this
+   invariant is enforced, not just documented. **When you report a curated
+   strategy's DSR p-value, say "graded at num_trials=1 against its own series" —
+   do not imply it was tested against the whole library.**
+3. **`passes_rigor_gate` is strictness-level-dependent for the ladder, but the
+   badge is always the strictest level.** `/api/selection-bias/gate` accepts a
+   `strictness` query param (1 = strictest/badge … 5 = loosest,
+   selection_bias_routes.py:186-200); the badge shown as `passes_rigor_gate` on a
+   strategy object is *always* evaluated at the strictest level regardless of
+   what a caller queries for (see `services/rigor_profiles.py` docstring, line 22).
+   `min_passing_level` on `StrategyRigorResult` tells you the loosest level the
+   strategy *would* pass at, if you need that nuance.
+4. **`status: "live"` is not a rigor claim.** See `skills/strategy-passport/SKILL.md`
+   ("passes_rigor_gate vs status") — this trap is common enough on this endpoint's
+   output that it's worth flagging here too: a strategy's lifecycle `status`
+   field means "active in at least one portfolio" (`models/strategy.py`:40), not
+   "currently passes the gate." Read `passes_rigor_gate` /
+   `rigor_gate_status` for the actual verdict, never `status`.
+5. **CPCV is honestly reported as `NOT_RUN`, not silently absent.** The
+   combinatorial-purged-CV criterion needs a rolling multi-split re-backtest
+   pipeline that isn't wired into this route yet; rather than omit the field
+   (which would look like a passing/neutral result), every strategy gets an
+   explicit `NOT_RUN` status with a reason (selection_bias_routes.py:207-213).
+
+## Verify (re-run these before trusting this document)
+
+```bash
+# Endpoint list + line numbers still match:
+grep -n "@generate_router\.\(post\|get\)" backend/archimedes/api/generate_routes.py
+
+# Auth gate default is still secure-by-default:
+grep -n "_generation_auth_required\|REQUIRE_SIWE_FOR_GENERATION" backend/archimedes/api/auth_siwe.py
+
+# EVENT_LOG_TTL:
+grep -n "EVENT_LOG_TTL = " backend/archimedes/services/job_queue.py
+
+# The curated num_trials=1 caveat is still live and still guarded:
+grep -n "num_trials = 1" backend/archimedes/api/selection_bias_routes.py
+grep -n "num_trials.*!= 1" backend/archimedes/services/_rigor_helpers.py
+
+# Reference client for the full SIWE + stream flow:
+sed -n '1,40p' scripts/agent_journey.py
+```
+
+## What this skill deliberately does not cover
+
+- The `archimedes` CLI (`cli/`) does **not** wrap this API — it's a `0.0.1`
+  name-reservation stub whose subcommands all exit `NOT_IMPLEMENTED`
+  (`cli/src/archimedes_cli/cli.py`:3-5, 50). Don't reach for it; use `curl`/HTTPie
+  or `scripts/agent_journey.py` directly against `/api/*`.
+- Full passport field semantics — see `skills/strategy-passport/SKILL.md`.
+- The x402 marketplace payment flow (a *separate* money seam, unrelated to
+  generation) — see `skills/x402-payment/SKILL.md`.

--- a/skills/verdict-api/SKILL.md
+++ b/skills/verdict-api/SKILL.md
@@ -23,11 +23,11 @@ Defined in [`backend/archimedes/api/generate_routes.py`](../../backend/archimede
 
 | Method | Path | Line | What it does |
 |---|---|---|---|
-| POST | `/api/generate/start` | 114 | Create a generation job; returns `job_id` + `stream_url` immediately (202) and runs the pipeline in the background |
-| GET | `/api/generate/stream/{job_id}` | 227 | Server-Sent Events (SSE) stream of the job's progress and final verdict |
-| POST | `/api/generate/jobs/{job_id}/cancel` | 315 | Best-effort cancel of a running job |
-| GET | `/api/generate/jobs` | 371 | List recent jobs (status table) |
-| GET | `/api/generate/jobs/{job_id}/candidates` | 418 | N candidates considered, including rejected ones, once the job is `done` |
+| POST | `/api/generate/start` | 106 | Create a generation job; returns `job_id` + `stream_url` immediately (202) and runs the pipeline in the background |
+| GET | `/api/generate/stream/{job_id}` | 250 | Server-Sent Events (SSE) stream of the job's progress and final verdict |
+| POST | `/api/generate/jobs/{job_id}/cancel` | 331 | Best-effort cancel of a running job |
+| GET | `/api/generate/jobs` | 381 | List recent jobs (status table) |
+| GET | `/api/generate/jobs/{job_id}/candidates` | 428 | N candidates considered, including rejected ones, once the job is `done` |
 
 This router deliberately lives outside `api/routes.py` — "no new endpoints go into
 `api/routes.py`" (generate_routes.py:11-12) — so don't look there for these.
@@ -63,7 +63,7 @@ Notable fields:
   the active pipeline).
 - `model` — optional model id; gated server-side, see "Model gating" below.
 
-Response is `202` with `{job_id, stream_url, ttl_seconds}` (generate_routes.py:197-201).
+Response is `202` with `{job_id, stream_url, ttl_seconds}` (generate_routes.py:218-222).
 `ttl_seconds` is `EVENT_LOG_TTL = 900` (15 minutes) from
 [`services/job_queue.py`](../../backend/archimedes/services/job_queue.py):26 — the
 event log a reconnecting client can replay from expires that long after the job
@@ -77,24 +77,24 @@ curl -N http://localhost:8000/api/generate/stream/<job_id> \
 ```
 
 This is a real `text/event-stream` response (`StreamingResponse`,
-generate_routes.py:296-304), not a polling endpoint. Behavior worth knowing before
+generate_routes.py:312-320), not a polling endpoint. Behavior worth knowing before
 you write a client:
 
-- **First byte is a comment**, not an event: `: stream opened\n\n` (generate_routes.py:255),
+- **First byte is a comment**, not an event: `: stream opened\n\n` (generate_routes.py:271),
   sent immediately so `EventSource.onopen` fires fast. A spec-compliant SSE parser
   ignores `:`-prefixed lines; a hand-rolled line-splitter must not choke on them.
 - **Heartbeats.** If no real event fires for 15s (`_HEARTBEAT_INTERVAL_SECONDS`,
-  generate_routes.py:63), the server emits `: heartbeat\n\n` so intermediaries with
+  generate_routes.py:71), the server emits `: heartbeat\n\n` so intermediaries with
   a shorter idle-read timeout (CloudFront, corporate proxies) don't drop the
   connection while a long debate/backtest step is still computing
-  (generate_routes.py:53-63, 280-289). Also invisible to a spec-compliant parser.
+  (generate_routes.py:61-71, 302-305). Also invisible to a spec-compliant parser.
 - **Resume with `Last-Event-ID`.** Each real event carries a numeric `id:` field;
   send it back as the `Last-Event-ID` header on reconnect and the server resumes
-  after that cursor (generate_routes.py:248-250, 257).
+  after that cursor (generate_routes.py:264-266, 273).
 - **Hard timeout.** One connection is capped at 300s (`_STREAM_TIMEOUT_SECONDS`,
-  generate_routes.py:52); past that it sends `: stream timeout\n\n` and closes —
+  generate_routes.py:60); past that it sends `: stream timeout\n\n` and closes —
   reconnect with `Last-Event-ID` to keep tailing a still-running job.
-- **Terminal events** are `done` and `error` (`_TERMINAL_EVENTS`, generate_routes.py:50);
+- **Terminal events** are `done` and `error` (`_TERMINAL_EVENTS`, generate_routes.py:58);
   the stream closes right after either.
 
 ### Event names on the wire
@@ -107,7 +107,7 @@ agent_iteration, tool_called, tool_result, candidate_drafted,
 candidate_evaluated, best_selected, trace_hashed, persisted, done, error
 ```
 
-Each SSE frame is built by `_format_sse` (generate_routes.py:307-312) as:
+Each SSE frame is built by `_format_sse` (generate_routes.py:323-328) as:
 
 ```
 id: <int>
@@ -156,7 +156,7 @@ aren't:
   When the backend's payment flag is on, `POST /start` without a
   `Payment-Signature` returns **402 with the quote in `detail`**, and the
   signed payer must equal the account's **linked wallet**
-  (generate_routes.py:132-153). Link a wallet via `POST
+  (generate_routes.py:132-154). Link a wallet via `POST
   /api/wallets/challenge` → sign the EIP-4361 message with your key → `POST
   /api/wallets/verify` — one round-trip, `cast`-signable.
 - **Premium models.** See "Model gating" below — entitlement is checked
@@ -184,7 +184,7 @@ the account's **linked wallet**, checked *before* the job is enqueued
 a non-entitled caller gets **HTTP 402**, never a silent downgrade
 (model_gate.py:18-20). A **free** model id is always allowed. Anything that
 isn't on the free allowlist and wasn't entitled falls back to the env default
-(generate_routes.py:142-151) — check `is_allowed_model` in
+(generate_routes.py:164-174) — check `is_allowed_model` in
 `services/llm_backend.py` for the current free-tier list.
 
 ## Reading DSR/PBO/holdout numbers honestly
@@ -200,20 +200,20 @@ number from this response to a user). The headline honesty traps specific to
    — the *search pool the winning candidate was actually selected from* —
    computed independently in
    [`agents/generation_pipeline.py`](../../backend/archimedes/agents/generation_pipeline.py):645
-   and threaded through `_backtest_and_persist` (generation_pipeline.py:1511,
-   1582-1590). It is deliberately **never** the size of the curated strategy
+   and threaded through `_backtest_and_persist` (generation_pipeline.py:1520,
+   1591-1599). It is deliberately **never** the size of the curated strategy
    library (generation_pipeline.py:334-335, "NEVER the curated library's count").
 2. **Curated strategies are graded at `num_trials=1` — always.** For a
    hand-curated single-paper strategy (no generation search of ours produced
    it), the self-contained trial count is 1: it's judged purely on its own return
    series, not deflated by how many *other* strategies sit in the library
-   ([`api/selection_bias_routes.py`](../../backend/archimedes/api/selection_bias_routes.py):313-320,
-   the hardcoded `num_trials = 1` at line 320). This is a deliberate 2026-07-09
+   ([`api/selection_bias_routes.py`](../../backend/archimedes/api/selection_bias_routes.py):313-321,
+   the hardcoded `num_trials = 1` at line 321). This is a deliberate 2026-07-09
    decision (decouple #2) that **reverses** an earlier library-size-deflation
    scheme and needed Önder's sign-off precisely because it raises curated pass
-   rates by removing a cross-strategy penalty (selection_bias_routes.py:314-319).
+   rates by removing a cross-strategy penalty (selection_bias_routes.py:319-320).
    A guard (`assert_self_contained_cohort_correlation`,
-   `services/_rigor_helpers.py`:615) raises loudly if a future edit ever
+   `services/_rigor_helpers.py`:577) raises loudly if a future edit ever
    re-couples curated DSR to the library's cross-strategy correlation — so this
    invariant is enforced, not just documented. **When you report a curated
    strategy's DSR p-value, say "graded at num_trials=1 against its own series" —

--- a/skills/verdict-api/SKILL.md
+++ b/skills/verdict-api/SKILL.md
@@ -153,12 +153,17 @@ aren't:
 - **Payment.** `GET /api/generate/quote` is public and always tells the
   truth about whether payment is required (generate_routes.py:96-103;
   contract spec: [`docs/specs/generation-quote-contract.md`](../../docs/specs/generation-quote-contract.md)).
-  When the backend's payment flag is on, `POST /start` without a
-  `Payment-Signature` returns **402 with the quote in `detail`**, and the
-  signed payer must equal the account's **linked wallet**
-  (generate_routes.py:132-154). Link a wallet via `POST
-  /api/wallets/challenge` → sign the EIP-4361 message with your key → `POST
-  /api/wallets/verify` — one round-trip, `cast`-signable.
+  When the backend's payment flag is on, the error ladder on `POST /start`
+  is, in order: **409** `{reason: "wallet_link_required"}` when the account
+  has **no linked wallet** — the blocker is account state, not a missing
+  payment, and it fires before any 402 is possible
+  (generate_routes.py:132-149) — then **402 with the quote in `detail`**
+  when a wallet is linked but no valid `Payment-Signature` accompanies the
+  request, with the signed payer required to equal the account's linked
+  wallet (generate_routes.py:150-154); then **202** on success. Handle all
+  three. Link a wallet via `POST /api/wallets/challenge` → sign the
+  EIP-4361 message with your key → `POST /api/wallets/verify` — one
+  round-trip, `cast`-signable.
 - **Premium models.** See "Model gating" below — entitlement is checked
   against the linked wallet.
 

--- a/skills/verdict-api/SKILL.md
+++ b/skills/verdict-api/SKILL.md
@@ -10,6 +10,15 @@ triggers:
   - "is REQUIRE_SIWE_FOR_GENERATION on, and generation auth questions in general"
 ---
 
+> **⚠️ Auth model transition in flight (2026-08):** this skill documents `main`
+> as of 2026-08-19, where generation auth is SIWE-based
+> (`REQUIRE_SIWE_FOR_GENERATION`, secure-by-default). **PR #1194 replaces this
+> with Better Auth accounts as canonical identity** (`require_current_user` +
+> per-account/per-IP generation caps). When #1194 merges, update this skill's
+> auth section before trusting it — the endpoints stay, the identity model
+> changes.
+
+
 # Requesting a strategy verdict over HTTP
 
 This skill grounds every claim in the working tree. File:line citations refer to

--- a/skills/x402-payment/SKILL.md
+++ b/skills/x402-payment/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: x402-payment
+description: The x402 / Circle Gateway micropayment flow Archimedes actually implements for copy-trading fee charges — an in-process 402-requirements → sign → verify → settle protocol over Circle Developer-Controlled Wallets, not a public HTTP payment endpoint. Covers PAYMENTS_DRY_RUN semantics and testnet posture, grounded in backend/archimedes/marketplace/payments.py.
+triggers:
+  - "how does Archimedes charge subscribers for copy-trading"
+  - working on backend/archimedes/marketplace/payments.py or settlement.py
+  - "what does PAYMENTS_DRY_RUN do"
+  - x402 / Circle Gateway / circlekit integration questions
+  - "is this on mainnet or testnet, for the marketplace money path"
+---
+
+# x402 / Circle Gateway payment flow
+
+**Read this first — the shape is not what "x402" usually means.** In the canonical
+x402 pattern, a client hits an HTTP endpoint, gets back a real `402 Payment
+Required` response, and retries with a payment header. Archimedes' implementation
+is the *same three-step protocol* (requirements → signed header → verify/settle)
+but run **entirely in-process, with no HTTP round-trip between the two parties**:
+
+> "Flow per charge (all in-process, no HTTP between publisher/subscriber): 1.
+> `middleware.require(price, path)` -> 402 requirements (publisher side) 2.
+> `create_payment_header(signer, reqs)` -> EIP-712 signature with the subscriber's
+> ephemeral key (subscriber side, same process) 3. `middleware.settle(header,
+> price)` -> Circle facilitator verifies and records the micropayment."
+> — [`marketplace/payments.py`](../../backend/archimedes/marketplace/payments.py):7-13
+
+This exists to charge a copy-trading **subscriber's** Circle wallet a flat fee
+per pipeline step, on the **publisher's** behalf, once per tick of the in-process
+marketplace engine — not to gate a public API route. If you came here looking for
+"how do I pay to call an Archimedes endpoint," that's not what this is; there is
+no paid public endpoint today.
+
+## Who calls what
+
+```
+MarketService (backend/archimedes/marketplace/service.py)
+  └─ per tick, per subscriber, per pipeline step:
+       _charge_one()  ──────────────────────────────  service.py:824-905
+         ├─ dry-run short-circuit                       service.py:833-834
+         ├─ idempotency claim (SettlementIntent row)     service.py:864-877
+         ├─ spend-cap reservation                        service.py:879-889
+         └─ payments.charge(...)  ─────────────────────  payments.py:85-155
+              ├─ 1. middleware.require()  → 402 reqs      payments.py:118-126
+              ├─ 2. create_payment_header() (EIP-712)     payments.py:128-136
+              └─ 3. middleware.verify() + middleware.settle()  payments.py:138-151
+```
+
+`payments.py` is the **only** file that imports `circlekit`
+(payments.py:1-5 module docstring: "This module is the ONLY place circlekit is
+imported... keeping the import surface here gives API drift a one-file blast
+radius") — if you need to touch the Circle SDK surface, this is the file.
+
+## The three steps, with line numbers
+
+1. **Requirements (`402`).** `get_gateway_middleware(seller_address)`
+   (payments.py:52-72) returns a cached `GatewayMiddleware` per **creator's**
+   Circle wallet address — the zero address is unconditionally refused
+   (payments.py:62-63). `middleware.require(price, path)` (payments.py:118)
+   builds the 402 payment-requirements object; `path` here is a **logical**
+   resource id (`/charge/{strategy_id}/{tick_id}/{sub_id}[/{step}]`,
+   payments.py:116-117) — no real HTTP route exists at that path, it's purely an
+   identifier the requirements object carries.
+2. **Sign.** The **subscriber's** side signs an EIP-712 payment header with
+   their Circle-managed wallet key via `create_payment_header`
+   (payments.py:128-136), run through `asyncio.to_thread` because the signer
+   and the header call both make blocking HTTPS calls to Circle
+   (payments.py:129-131 comment). `_get_signer` caches one `CircleWalletSigner`
+   per `wallet_id` (payments.py:42-49) so constructing a signer — which
+   re-initializes the Circle client — doesn't happen on every tick.
+3. **Verify + settle.** `middleware.verify(header, price)` (payments.py:139)
+   checks the signed header against Circle's facilitator; on failure the charge
+   returns `False` with the `invalid_reason` logged (payments.py:140-147).
+   `middleware.settle(header, price)` (payments.py:149) then **records** the
+   micropayment — Circle batches and settles the underlying value on-chain
+   later; **this module does not run any settlement logic of its own** (that's
+   `settlement.py`, see below).
+
+`charge()` (payments.py:85-155) **never raises** — every failure path is caught,
+logged, and returned as `False` (payments.py:153-155 + the docstring at
+85-99), so the caller's existing "unpaid subscriber → halt" path is the single
+place that has to reason about payment failure.
+
+**Zero-amount ticks are free, not zero-charged**: if `fee_to_price(...)` computes
+`"$0.000000"`, `charge()` returns `True` immediately without touching the
+middleware at all (payments.py:110-112) — nothing to verify/settle when nothing
+is owed.
+
+## `fee_to_price` — the money math
+
+```python
+def fee_to_price(action_count: int, flat_fee_raw: int) -> str:
+    ...
+```
+(payments.py:75-82). Converts `action_count × flat_fee_raw` (raw 6-decimal USDC
+units) into the `"$X.XXXXXX"` string `circlekit` expects, using `Decimal` —
+**never floats** (payments.py:77 docstring). Rejects negative inputs
+(payments.py:78-79). `flat_fee_raw` itself is `FLAT_FEE_PER_ACTION`, env-tunable,
+default `100` raw units = **$0.0001 per action**
+([`marketplace/service.py`](../../backend/archimedes/marketplace/service.py):53).
+
+## What actually gets charged, and when
+
+The charge granularity is one flat fee per named pipeline step
+(`TickStep` enum, [`marketplace/tick_registry.py`](../../backend/archimedes/marketplace/tick_registry.py):13-30)
+— `load_strategy`, `evaluate_signals`, `aggregate_weights`, … through the
+publisher-pipeline boundaries, plus a per-subscriber `rebalance` step whose
+`action_count` scales with the number of trades actually generated
+(tick_registry.py:28-29). `_charge_one` in `service.py` wraps `payments.charge`
+with three things `payments.py` itself does **not** do:
+
+- **Idempotency.** x402 payment headers are **not** crash-retry-idempotent — a
+  retry signs a fresh EIP-3009 nonce and settles as a *second* payment. A
+  `SettlementIntent` row is claimed before calling `payments.charge`
+  (service.py:864-877) so a crash/retry short-circuits to "already settled"
+  instead of double-charging.
+- **Per-wallet 24h spend cap**, reserved atomically immediately before the
+  charge call to avoid a check-then-record TOCTOU race across concurrent ticks
+  (service.py:879-889, referencing issue #1099).
+- **Treating an unexpected raise as a failed charge anyway** (service.py:886-905)
+  — `payments.charge`'s "never raises" contract is documented, not blindly
+  trusted; a raise still releases the spend-cap reservation.
+
+## Testnet posture
+
+- Default chain: `DEFAULT_GATEWAY_CHAIN = "arcTestnet"`
+  ([`marketplace/config.py`](../../backend/archimedes/marketplace/config.py):7),
+  overridable via the `GATEWAY_CHAIN` env var (payments.py:65, settlement.py:34).
+- `.env.example`:178 sets `CIRCLE_BLOCKCHAIN=ARC-TESTNET` for the
+  subscriber/publisher wallet-provisioning path — this whole seam is wired for
+  Arc **testnet**, not mainnet, on `main` today.
+- On-chain settlement of the *aggregated* fee pool is a separate, three-stage
+  sweep in [`marketplace/settlement.py`](../../backend/archimedes/marketplace/settlement.py):
+  Stage A (Gateway balance → agent wallet, threshold `SWEEP_WITHDRAW_THRESHOLD_USDC`,
+  default 10 USDC, settlement.py:29-36, 92-126), Stage B (wallet USDC →
+  `PaymentSplitter.depositToPool`, min 1 USDC, settlement.py:130-189), Stage C
+  (`PaymentSplitter.withdraw` — creator/platform payout on demand,
+  settlement.py:193-222). None of the three stages ever raises out of
+  `sweep_publisher` (settlement.py:12-13) — same fail-soft posture as `charge()`.
+
+## `PAYMENTS_DRY_RUN` — semantics
+
+**Default is dry (safe).** `main.py`:203 —
+`payments_dry_run = os.getenv("PAYMENTS_DRY_RUN", "true").lower() in ("1", "true", "yes")`
+— an out-of-the-box deploy does not move real money. `.env.example`:179-182 labels
+it explicitly: "FAIL-SAFE money switch. Defaults to true (no real charges)."
+
+Two independent money switches must be turned on **together and deliberately**
+(`main.py`:196-202 comment): `PAYMENTS_DRY_RUN=false` *and* whatever gates real
+trade mirroring (`PAPER_TRADING`, also defaulting to `true`). The comment is
+explicit about why: the two used to default asymmetrically (`PAYMENTS_DRY_RUN`
+defaulting false while `PAPER_TRADING` defaulted true), so an out-of-the-box
+deploy mirrored *no* real trades yet still charged *real* USDC — "the worst
+possible asymmetry." Both now default to the safe side.
+
+**Where the flag is enforced — read the actual gates, not `payments.py`:**
+`payments.py`'s `charge()` function has **no dry-run branch of its own** — it
+always runs the full sign/verify/settle sequence if called. The gate lives one
+layer up, at every call site:
+
+- `MarketService._charge_one`: `if self.payments_dry_run: return True, None`
+  **before** `payments.charge` is ever invoked (service.py:833-834) — dry-run
+  ticks are treated as "paid" without touching Circle at all.
+- `SettlementSweeper.sweep_publisher` / `withdraw_publisher` /
+  `withdraw_subscriber`: each independently short-circuits on
+  `self._payments_dry_run` at the **top** of the method
+  (settlement.py:75-79, 199-205, 240-242) — the constructor comment explains
+  why the check is duplicated at every fund-moving method rather than checked
+  once by a caller: "Gating lives HERE (not only at call sites) so a future
+  caller can't forget it — the manual withdraw endpoint (M1') did exactly that,
+  bypassing PAYMENTS_DRY_RUN on a real on-chain path" (settlement.py:48-51).
+- `/api/marketplace/*` manual-withdraw route: also fails soft when dry-run is on
+  (`api/marketplace_routes.py`:727-732, returning
+  `{"status": "dry_run_noop", ...}` rather than attempting a real settlement).
+
+**Practical implication for anyone testing this flow:** with `PAYMENTS_DRY_RUN`
+unset (or `true`), every subscriber charge in the marketplace tick loop reports
+success without a single call into `circlekit`, and every sweep/withdraw is a
+logged no-op. To exercise the real Circle Gateway path — even on testnet — you
+must explicitly set `PAYMENTS_DRY_RUN=false` and have real `CIRCLE_API_KEY` /
+`CIRCLE_ENTITY_SECRET` configured (`.env.example`:123-131, 176-183).
+
+## Custody model (read before assuming "non-custodial")
+
+The copy-trading fee flow runs through **Circle Developer-Controlled Wallets**
+(DCWs) that the platform, not the subscriber, controls the entity secret for —
+this fee seam is **custodial, interim**, by explicit team decision (2026-07,
+"DCW fees = custodial-INTERIM"), separate from the non-custodial ERC-4626 vault
+architecture that holds actual portfolio funds. `withdraw_subscriber`
+(settlement.py:224-267) is the subscriber's exit path — it sweeps any remaining
+prepaid-fee balance out of the custodial DCW back to the subscriber's own SIWE
+wallet on unsubscribe. Don't describe this fee mechanism as non-custodial; it
+isn't, today.
+
+## Verify (re-run these before trusting this document)
+
+```bash
+# circlekit is imported nowhere else:
+grep -rln "^from circlekit\|^import circlekit" backend/archimedes/
+
+# PAYMENTS_DRY_RUN defaults to true, and where each fund-moving method gates on it:
+grep -n 'PAYMENTS_DRY_RUN' backend/archimedes/main.py
+grep -n 'self\._payments_dry_run\|self\.payments_dry_run' \
+  backend/archimedes/marketplace/settlement.py backend/archimedes/marketplace/service.py
+
+# Testnet chain default:
+grep -n 'DEFAULT_GATEWAY_CHAIN' backend/archimedes/marketplace/config.py
+
+# charge() never raises:
+sed -n '85,155p' backend/archimedes/marketplace/payments.py
+```
+
+## What this skill deliberately does not cover
+
+- The vault/portfolio contracts (non-custodial by design) — a different money
+  seam entirely; see `docs/specs/ecosystem-design-spec.md` § 3.2.
+- Strategy verdict fields (DSR/PBO/passport) — see `skills/strategy-passport/SKILL.md`.
+- The public `/api/marketplace/*` HTTP routes (publish/subscribe/withdraw) in
+  `api/marketplace_routes.py` — those are the human-facing onboarding surface
+  around this engine, not the charge protocol itself; skim them separately if
+  you need the subscribe/publish request shapes.

--- a/skills/x402-payment/SKILL.md
+++ b/skills/x402-payment/SKILL.md
@@ -35,20 +35,24 @@ no paid public endpoint today.
 ```
 MarketService (backend/archimedes/marketplace/service.py)
   └─ per tick, per subscriber, per pipeline step:
-       _charge_one()  ──────────────────────────────  service.py:824-905
+       _charge_one()  ──────────────────────────────  service.py:825-909
          ├─ dry-run short-circuit                       service.py:833-834
-         ├─ idempotency claim (SettlementIntent row)     service.py:864-877
-         ├─ spend-cap reservation                        service.py:879-889
+         ├─ idempotency claim (SettlementIntent row)     service.py:842-859
+         ├─ spend-cap reservation                        service.py:861-885
          └─ payments.charge(...)  ─────────────────────  payments.py:85-155
               ├─ 1. middleware.require()  → 402 reqs      payments.py:118-126
               ├─ 2. create_payment_header() (EIP-712)     payments.py:128-136
               └─ 3. middleware.verify() + middleware.settle()  payments.py:138-151
 ```
 
-`payments.py` is the **only** file that imports `circlekit`
-(payments.py:1-5 module docstring: "This module is the ONLY place circlekit is
+`payments.py`'s module docstring claims it is the **only** file that imports
+`circlekit` (payments.py:1-5: "This module is the ONLY place circlekit is
 imported... keeping the import surface here gives API drift a one-file blast
-radius") — if you need to touch the Circle SDK surface, this is the file.
+radius") — **that claim is now stale**: `settlement.py` also imports directly
+from `circlekit` (`circlekit.client.GatewayClient`,
+`circlekit.wallets.CircleTxExecutor`/`CircleWalletSigner`, settlement.py:21-22)
+for its own sweep signers/executors. If you need to touch the Circle SDK
+surface, check both files, not just this one.
 
 ## The three steps, with line numbers
 
@@ -64,7 +68,7 @@ radius") — if you need to touch the Circle SDK surface, this is the file.
    their Circle-managed wallet key via `create_payment_header`
    (payments.py:128-136), run through `asyncio.to_thread` because the signer
    and the header call both make blocking HTTPS calls to Circle
-   (payments.py:129-131 comment). `_get_signer` caches one `CircleWalletSigner`
+   (payments.py:129-130 comment). `_get_signer` caches one `CircleWalletSigner`
    per `wallet_id` (payments.py:42-49) so constructing a signer — which
    re-initializes the Circle client — doesn't happen on every tick.
 3. **Verify + settle.** `middleware.verify(header, price)` (payments.py:139)
@@ -111,12 +115,12 @@ with three things `payments.py` itself does **not** do:
 - **Idempotency.** x402 payment headers are **not** crash-retry-idempotent — a
   retry signs a fresh EIP-3009 nonce and settles as a *second* payment. A
   `SettlementIntent` row is claimed before calling `payments.charge`
-  (service.py:864-877) so a crash/retry short-circuits to "already settled"
+  (service.py:842-859) so a crash/retry short-circuits to "already settled"
   instead of double-charging.
 - **Per-wallet 24h spend cap**, reserved atomically immediately before the
   charge call to avoid a check-then-record TOCTOU race across concurrent ticks
-  (service.py:879-889, referencing issue #1099).
-- **Treating an unexpected raise as a failed charge anyway** (service.py:886-905)
+  (service.py:861-885, referencing issue #1099).
+- **Treating an unexpected raise as a failed charge anyway** (service.py:887-908)
   — `payments.charge`'s "never raises" contract is documented, not blindly
   trusted; a raise still releases the spend-cap reservation.
 
@@ -125,7 +129,7 @@ with three things `payments.py` itself does **not** do:
 - Default chain: `DEFAULT_GATEWAY_CHAIN = "arcTestnet"`
   ([`marketplace/config.py`](../../backend/archimedes/marketplace/config.py):7),
   overridable via the `GATEWAY_CHAIN` env var (payments.py:65, settlement.py:34).
-- `.env.example`:178 sets `CIRCLE_BLOCKCHAIN=ARC-TESTNET` for the
+- `.env.example`:194 sets `CIRCLE_BLOCKCHAIN=ARC-TESTNET` for the
   subscriber/publisher wallet-provisioning path — this whole seam is wired for
   Arc **testnet**, not mainnet, on `main` today.
 - On-chain settlement of the *aggregated* fee pool is a separate, three-stage
@@ -139,13 +143,13 @@ with three things `payments.py` itself does **not** do:
 
 ## `PAYMENTS_DRY_RUN` — semantics
 
-**Default is dry (safe).** `main.py`:203 —
+**Default is dry (safe).** `main.py`:212 —
 `payments_dry_run = os.getenv("PAYMENTS_DRY_RUN", "true").lower() in ("1", "true", "yes")`
-— an out-of-the-box deploy does not move real money. `.env.example`:179-182 labels
+— an out-of-the-box deploy does not move real money. `.env.example`:195-198 labels
 it explicitly: "FAIL-SAFE money switch. Defaults to true (no real charges)."
 
 Two independent money switches must be turned on **together and deliberately**
-(`main.py`:196-202 comment): `PAYMENTS_DRY_RUN=false` *and* whatever gates real
+(`main.py`:206-211 comment): `PAYMENTS_DRY_RUN=false` *and* whatever gates real
 trade mirroring (`PAPER_TRADING`, also defaulting to `true`). The comment is
 explicit about why: the two used to default asymmetrically (`PAYMENTS_DRY_RUN`
 defaulting false while `PAPER_TRADING` defaulted true), so an out-of-the-box
@@ -169,7 +173,7 @@ layer up, at every call site:
   caller can't forget it — the manual withdraw endpoint (M1') did exactly that,
   bypassing PAYMENTS_DRY_RUN on a real on-chain path" (settlement.py:48-51).
 - `/api/marketplace/*` manual-withdraw route: also fails soft when dry-run is on
-  (`api/marketplace_routes.py`:727-732, returning
+  (`api/marketplace_routes.py`:724-729, returning
   `{"status": "dry_run_noop", ...}` rather than attempting a real settlement).
 
 **Practical implication for anyone testing this flow:** with `PAYMENTS_DRY_RUN`
@@ -177,7 +181,7 @@ unset (or `true`), every subscriber charge in the marketplace tick loop reports
 success without a single call into `circlekit`, and every sweep/withdraw is a
 logged no-op. To exercise the real Circle Gateway path — even on testnet — you
 must explicitly set `PAYMENTS_DRY_RUN=false` and have real `CIRCLE_API_KEY` /
-`CIRCLE_ENTITY_SECRET` configured (`.env.example`:123-131, 176-183).
+`CIRCLE_ENTITY_SECRET` configured (`.env.example`:137-147, 192-198).
 
 ## Custody model (read before assuming "non-custodial")
 
@@ -194,7 +198,8 @@ isn't, today.
 ## Verify (re-run these before trusting this document)
 
 ```bash
-# circlekit is imported nowhere else:
+# circlekit's import surface — expect payments.py AND settlement.py (the
+# module docstring's "ONLY place" claim is stale; see the note above):
 grep -rln "^from circlekit\|^import circlekit" backend/archimedes/
 
 # PAYMENTS_DRY_RUN defaults to true, and where each fund-moving method gates on it:


### PR DESCRIPTION
## Summary

- Adds a tracked top-level `skills/` directory (not `.agents/`, which is gitignored) per Dan's directive (via Aadi): "add high-quality skills in strategic and useful places, for ourselves and for customers or users."
- Four skills, each `<name>/SKILL.md` with `name`/`description`/`triggers` YAML frontmatter in the manifest-driven-skill style, plus `skills/README.md` explaining the directory:
  - `skills/verdict-api/` — how an agent or human requests a strategy generation and reads its rigor verdict over `/api/generate/*`: real endpoints, the SSE event shape, auth requirements as they actually are on `main` (SIWE, secure-by-default, rate limits), and how to read DSR/PBO/holdout numbers honestly (including the curated `num_trials=1` caveat).
  - `skills/x402-payment/` — the x402/Circle Gateway copy-trading fee flow in `backend/archimedes/marketplace/payments.py`: an **in-process** 402→sign→verify→settle protocol (not a public HTTP payment endpoint), testnet posture, and `PAYMENTS_DRY_RUN` semantics (default-safe, gated independently at every fund-moving call site).
  - `skills/strategy-passport/` — every `strategy_passports` field, what `passes_rigor_gate` means and does **not** mean, why `status="live"` is not a rigor claim (say it explicitly), and the five forbidden phrasings sourced from `docs/anti-features.md`'s "Pitch-rigor anti-claims" section.
  - `skills/repo-dev/` — conda env (Python + Node from one env), hermetic pytest conventions, merge-commit-only branch policy, CI gates, where things live.
- One-line pointer to `skills/` added under README.md's "Dogfooding as an agent" section.

## Deliberate omissions

- **No CLI skill.** `cli/` is a `0.0.1` name-reservation stub — every subcommand exits `NOT_IMPLEMENTED` (`cli/src/archimedes_cli/cli.py`). Noted explicitly in `skills/README.md` and in `skills/verdict-api/SKILL.md`'s "does not cover" section, rather than silently skipped.
- **No docs-link gate found to worry about.** The task asked me to check whether `.github/scripts/docs_links.py` scans this path. That file (and any equivalent link-checking script/workflow) does not exist anywhere in this repo today — verified with `find .github -iname "*docs*"` and `grep -rl docs_links .github`, both empty. Noted in `skills/repo-dev/SKILL.md` so a future skill author knows to re-check if one is ever added.

## Verify

Every skill ends with its own "Verify" section (runnable greps reproducing every file:line claim). I re-ran all of them against the working tree. Headline commands:

```bash
grep -n "@generate_router\.\(post\|get\)" backend/archimedes/api/generate_routes.py
grep -n "num_trials = 1" backend/archimedes/api/selection_bias_routes.py
grep -n 'LIVE = "live"' backend/archimedes/models/strategy.py
grep -n "^## Pitch-rigor" docs/anti-features.md
grep -n 'self\._payments_dry_run\|self\.payments_dry_run' backend/archimedes/marketplace/settlement.py backend/archimedes/marketplace/service.py
find .github -iname "*docs*"   # confirms no docs-link gate exists
```

Also validated all four `SKILL.md` frontmatter blocks parse as valid YAML with `name`/`description`/`triggers` (list) present, and that every relative markdown link across the five new files + the README.md addition resolves to a real file in the tree.

## Anti-goals honored

- No `.agents/` usage (gitignored, explicitly excluded per task).
- No CLI skill written (explicit instruction).
- Nothing outside `skills/` touched except the one-line README.md pointer.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
