### PR TITLE
Fix #1182: four rate-limited routes 500 on every successful call

### DIFF
--- a/backend/archimedes/api/portfolio_routes.py
+++ b/backend/archimedes/api/portfolio_routes.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel, Field
 
 from archimedes.api.limiter import limiter
@@ -137,7 +137,7 @@ class ScenarioAnalysisRequest(BaseModel):
 
 @portfolio_router.post("/optimize")
 @limiter.limit("5/minute")
-async def optimize_portfolio(req: OptimizeRequest, request: Request) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def optimize_portfolio(req: OptimizeRequest, request: Request, response: Response) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Compute optimal synth-asset weights with the requested optimizer.
 
     Returns {method, optimizer, risk_profile, usdc_weight, weights, symbols_used,
@@ -210,7 +210,7 @@ async def optimize_portfolio(req: OptimizeRequest, request: Request) -> dict:  #
 
 @portfolio_router.post("/parameter-sweep")
 @limiter.limit("5/minute")
-async def parameter_sweep(req: ParameterSweepRequest, request: Request) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def parameter_sweep(req: ParameterSweepRequest, request: Request, response: Response) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Run a 2D sensitivity sweep over two backtest parameters.
 
     Returns a heatmap-ready grid_2d with rows=param1 values, cols=param2 values,
@@ -290,7 +290,7 @@ async def parameter_sweep(req: ParameterSweepRequest, request: Request) -> dict:
 
 @portfolio_router.post("/scenario-analysis")
 @limiter.limit("10/minute")
-async def scenario_analysis(req: ScenarioAnalysisRequest, request: Request) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+async def scenario_analysis(req: ScenarioAnalysisRequest, request: Request, response: Response) -> dict:  # noqa: ARG001 — slowapi @limiter.limit inspects param name
     """Apply mark-to-model stress shocks to a portfolio and return per-scenario P&L.
 
     Uses predefined scenarios when none are supplied. Applies a 1.2x stress beta

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -679,6 +679,7 @@ def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: in
 @limiter.limit("10/minute")
 async def evaluate_strategy_rigor(
     request: Request,
+    response: Response,  # noqa: ARG001 — slowapi injects rate-limit headers into it; omitting it 500s every SUCCESSFUL call (#1182)
     strategy_id: str,
     strictness: int = Query(DEFAULT_LEVEL, ge=STRICTEST_LEVEL, le=LOOSEST_LEVEL),
 ):

--- a/backend/tests/test_slowapi_response_param.py
+++ b/backend/tests/test_slowapi_response_param.py
@@ -1,0 +1,96 @@
+"""Every @limiter.limit route must give slowapi a Response to inject into (#1182).
+
+The failure this pins: slowapi's ``_inject_headers`` needs a
+``starlette.responses.Response`` to attach rate-limit headers to. A decorated
+handler that returns a plain dict/pydantic model and does NOT declare a
+``response: Response`` parameter raises
+``Exception: parameter `response` must be an instance of starlette.responses.Response``
+— **after** the handler has done all its work, converting every SUCCESSFUL
+call into a 500. That is precisely how ``GET /api/selection-bias/gate/{id}``
+(the passport's "verify this yourself" endpoint) and all three quant-lab
+portfolio endpoints were fully down in production while ~3,000 tests stayed
+green: the suite runs with the limiter disabled (TESTING), so the decorator's
+header-injection path never executes in CI.
+
+Because the runtime path is untestable under TESTING, the invariant is
+enforced structurally: an AST walk over every route module, requiring each
+``@limiter.limit``-decorated function to either declare a ``response``
+parameter or visibly return a Response object. The walk is proven
+discriminating by test_the_invariant_catches_a_missing_response_param below.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+API_DIR = Path(__file__).resolve().parents[2] / "backend" / "archimedes" / "api"
+
+
+def _limited_functions(tree: ast.Module):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if any(
+                isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "limit"
+                for d in node.decorator_list
+            ):
+                yield node
+
+
+def _satisfies_slowapi_contract(func: ast.AST) -> bool:
+    params = {a.arg for a in func.args.args + func.args.kwonlyargs}
+    if "response" in params:
+        return True
+    # Returning a Response object directly also satisfies slowapi — it injects
+    # into the returned instance. Detect `return XxxResponse(...)` shapes.
+    return any(
+        isinstance(n, ast.Return)
+        and isinstance(n.value, ast.Call)
+        and (
+            (isinstance(n.value.func, ast.Name) and n.value.func.id.endswith("Response"))
+            or (isinstance(n.value.func, ast.Attribute) and n.value.func.attr.endswith("Response"))
+        )
+        for n in ast.walk(func)
+    )
+
+
+def test_every_rate_limited_route_satisfies_the_slowapi_contract():
+    offenders = []
+    for path in sorted(API_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for func in _limited_functions(tree):
+            if not _satisfies_slowapi_contract(func):
+                offenders.append(f"{path.name}:{func.lineno} {func.name}")
+    assert not offenders, (
+        "@limiter.limit routes without a `response: Response` param (or a direct "
+        f"Response return): {offenders}. slowapi raises AFTER the handler succeeds, "
+        "so each of these 500s on every successful production call while the "
+        "TESTING-disabled limiter keeps CI green. Add `response: Response  # noqa: ARG001`."
+    )
+
+
+def test_the_invariant_catches_a_missing_response_param():
+    """Adversarial pass on the guard itself: the exact pre-fix signature of
+    evaluate_strategy_rigor (#1182) must be flagged, and the fixed shape must
+    not be."""
+    broken = ast.parse(
+        "@limiter.limit('10/minute')\n"
+        "async def gate(request: Request, strategy_id: str):\n"
+        "    return {'ok': True}\n"
+    )
+    assert [f.name for f in _limited_functions(broken)] == ["gate"]
+    assert not _satisfies_slowapi_contract(next(_limited_functions(broken)))
+
+    fixed = ast.parse(
+        "@limiter.limit('10/minute')\n"
+        "async def gate(request: Request, response: Response, strategy_id: str):\n"
+        "    return {'ok': True}\n"
+    )
+    assert _satisfies_slowapi_contract(next(_limited_functions(fixed)))
+
+    returns_response = ast.parse(
+        "@limiter.limit('10/minute')\n"
+        "async def stream(request: Request):\n"
+        "    return StreamingResponse(gen())\n"
+    )
+    assert _satisfies_slowapi_contract(next(_limited_functions(returns_response)))

--- a/backend/tests/test_slowapi_response_param.py
+++ b/backend/tests/test_slowapi_response_param.py
@@ -29,12 +29,11 @@ API_DIR = Path(__file__).resolve().parents[2] / "backend" / "archimedes" / "api"
 
 def _limited_functions(tree: ast.Module):
     for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if any(
-                isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "limit"
-                for d in node.decorator_list
-            ):
-                yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+            isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "limit"
+            for d in node.decorator_list
+        ):
+            yield node
 
 
 def _satisfies_slowapi_contract(func: ast.AST) -> bool:
@@ -74,9 +73,7 @@ def test_the_invariant_catches_a_missing_response_param():
     evaluate_strategy_rigor (#1182) must be flagged, and the fixed shape must
     not be."""
     broken = ast.parse(
-        "@limiter.limit('10/minute')\n"
-        "async def gate(request: Request, strategy_id: str):\n"
-        "    return {'ok': True}\n"
+        "@limiter.limit('10/minute')\nasync def gate(request: Request, strategy_id: str):\n    return {'ok': True}\n"
     )
     assert [f.name for f in _limited_functions(broken)] == ["gate"]
     assert not _satisfies_slowapi_contract(next(_limited_functions(broken)))
@@ -89,8 +86,6 @@ def test_the_invariant_catches_a_missing_response_param():
     assert _satisfies_slowapi_contract(next(_limited_functions(fixed)))
 
     returns_response = ast.parse(
-        "@limiter.limit('10/minute')\n"
-        "async def stream(request: Request):\n"
-        "    return StreamingResponse(gen())\n"
+        "@limiter.limit('10/minute')\nasync def stream(request: Request):\n    return StreamingResponse(gen())\n"
     )
     assert _satisfies_slowapi_contract(next(_limited_functions(returns_response)))


### PR DESCRIPTION
Closes #1182 — root-caused from the production traceback rather than guessed.

**The gate endpoint did all its work (8.5s of real rigor computation) and then slowapi killed the response**: the handler lacked the `response: Response` parameter the decorator injects rate-limit headers into. An AST survey found the identical defect on **three more routes** — the entire quant-lab portfolio surface (`optimize`, `parameter-sweep`, `scenario-analysis`) has been 500ing on success in prod.

**Why CI never saw it:** the limiter is disabled under TESTING, so the injection path never runs in the suite. Hence the regression guard is a structural AST invariant over every route module — proven discriminating with the exact pre-fix signature *and* a mutation run.

Verification: prod reproduced before the fix (`gate/{id}` → 500 in 8.5s; batch → 200; unknown id → 404), 78 tests green across touched files, mutation flips the invariant red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7