### PR TITLE
Fix the frozen leaderboard refresh: artifact dir is read-only on Fargate

### DIFF
--- a/backend/archimedes/scripts/run_backtests.py
+++ b/backend/archimedes/scripts/run_backtests.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import sys
+import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -72,8 +73,51 @@ def _analytics_strategy_dir(repo_root: Path) -> Path:
     return repo_root / "analytics-engine" / "strategies"
 
 
+def _dir_writable(d: Path) -> bool:
+    """Probe by actually creating a file — ``os.access`` lies in containers."""
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+        probe = d / f".write-probe-{os.getpid()}"
+        probe.write_text("")
+        probe.unlink()
+        return True
+    except OSError:
+        return False
+
+
 def _artifact_dir(repo_root: Path) -> Path:
-    return repo_root / "analytics-engine" / "artifacts"
+    """Where run artifacts get written. Must be writable, which the packaged
+    default is NOT on Fargate: the image ships read-only for the nonroot user,
+    so every backtest in the scheduled refresh died with
+    ``PermissionError: /app/analytics-engine/artifacts/<run>.json`` — at the
+    artifact write, BEFORE the DB insert — and the leaderboard silently froze
+    at its last pre-cutover rows (2026-08-18 diagnosis of the stale-refresh
+    incident; newest row was 2026-07-01).
+
+    Resolution order:
+      1. ``ARCHIMEDES_ARTIFACT_DIR`` env — the deployment's explicit choice
+         (ecs.tf sets it to task-local scratch; the artifact JSON is also
+         persisted into ``backtest_results.artifact_json``, which is the
+         durable record, so ephemeral task storage is honest here).
+      2. The repo-local ``analytics-engine/artifacts`` when writable — the
+         dev/EC2 behaviour, unchanged.
+      3. A stable path under the system temp dir, logged at WARNING — loud,
+         because a silent location change is how artifacts "disappear".
+    """
+    env = os.getenv("ARCHIMEDES_ARTIFACT_DIR")
+    if env:
+        return Path(env)
+    default = repo_root / "analytics-engine" / "artifacts"
+    if _dir_writable(default):
+        return default
+    fallback = Path(tempfile.gettempdir()) / "archimedes-artifacts"
+    logger.warning(
+        "artifact dir %s is not writable (read-only container image?); writing run artifacts to %s instead. "
+        "Set ARCHIMEDES_ARTIFACT_DIR to choose explicitly. The DB row's artifact_json remains the durable record.",
+        default,
+        fallback,
+    )
+    return fallback
 
 
 def _ensure_analytics_import(repo_root: Path) -> None:

--- a/backend/tests/scripts/test_run_backtests_artifact_dir.py
+++ b/backend/tests/scripts/test_run_backtests_artifact_dir.py
@@ -1,0 +1,56 @@
+"""_artifact_dir resolution (stale-leaderboard incident, 2026-08-18).
+
+The scheduled refresh on Fargate died on EVERY strategy with
+``PermissionError: /app/analytics-engine/artifacts/<run>.json`` — the packaged
+default is read-only for the nonroot task user, and the write happens before
+the DB insert, so no rows ever landed and the leaderboard froze at 2026-07-01.
+These pin the three resolution branches; the read-only case is reproduced with
+a genuinely unwritable directory, not a mock.
+"""
+
+from __future__ import annotations
+
+import stat
+import tempfile
+from pathlib import Path
+
+from archimedes.scripts.run_backtests import _artifact_dir, _dir_writable
+
+
+def test_env_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("ARCHIMEDES_ARTIFACT_DIR", str(tmp_path / "chosen"))
+    assert _artifact_dir(tmp_path / "repo") == tmp_path / "chosen"
+
+
+def test_writable_repo_default_unchanged(monkeypatch, tmp_path):
+    monkeypatch.delenv("ARCHIMEDES_ARTIFACT_DIR", raising=False)
+    repo = tmp_path / "repo"
+    (repo / "analytics-engine").mkdir(parents=True)
+    assert _artifact_dir(repo) == repo / "analytics-engine" / "artifacts"
+
+
+def test_read_only_default_falls_back_loudly(monkeypatch, tmp_path, caplog):
+    """The prod incident's exact shape: parent exists, is not writable."""
+    monkeypatch.delenv("ARCHIMEDES_ARTIFACT_DIR", raising=False)
+    repo = tmp_path / "repo"
+    locked = repo / "analytics-engine"
+    locked.mkdir(parents=True)
+    locked.chmod(stat.S_IRUSR | stat.S_IXUSR)  # r-x: mkdir/writes inside fail
+    try:
+        if _dir_writable(locked / "artifacts"):  # e.g. running as root: cannot reproduce
+            import pytest
+
+            pytest.skip("cannot create a read-only dir under this user")
+        with caplog.at_level("WARNING"):
+            result = _artifact_dir(repo)
+        assert result == Path(tempfile.gettempdir()) / "archimedes-artifacts"
+        assert any("not writable" in r.message for r in caplog.records), (
+            "the fallback must be LOUD — a silent location change is how artifacts disappear"
+        )
+    finally:
+        locked.chmod(stat.S_IRWXU)
+
+
+def test_dir_writable_probe_leaves_no_droppings(tmp_path):
+    assert _dir_writable(tmp_path / "fresh") is True
+    assert list((tmp_path / "fresh").iterdir()) == []

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -512,6 +512,13 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "ARCHIMEDES_STRATEGIES_DIR", value = "/app/analytics-engine/strategies" },
         { name = "ARCHIMEDES_CORPUS_MANIFEST", value = "/app/data/corpus/manifest.jsonl" },
         { name = "KB_ARTIFACT_DIR", value = "/app/data/corpus-artifact" },
+        # Backtest run artifacts (scripts/run_backtests.py). The packaged
+        # analytics-engine/artifacts dir is NOT writable by the nonroot task
+        # user, which killed every scheduled backtest refresh at the artifact
+        # write and froze the leaderboard at its 2026-07-01 rows. Task-local
+        # scratch is the deliberate choice: the durable record is the DB row's
+        # artifact_json, not the file.
+        { name = "ARCHIMEDES_ARTIFACT_DIR", value = "/tmp/archimedes-artifacts" },
         # Deployed Arc testnet contract addresses — T3.2 redeploy 2026-07-09
         # (deployer 0x03AaB3C91873f0Ec606c1Ed7528FE4CDCD6a4092, chain 5042002).
         # One authoritative set; converges the prior FE/BE split-brain. Not secrets.


### PR DESCRIPTION
**Root cause of the stale leaderboard (newest row 2026-07-01), from prod logs — not guessed:** the scheduled refresh runs on cadence and every strategy dies at the artifact write (`PermissionError: /app/analytics-engine/artifacts/…`), which happens **before** the DB insert. Computed backtests are thrown away; the refresh then mis-diagnoses itself ("9 strategies still have no rows … backing off"). Worked on EC2 because the dir was a writable bind mount; broke silently at the Fargate cutover.

Fix: `ARCHIMEDES_ARTIFACT_DIR` env (set in ecs.tf to task-local scratch — the durable record is `backtest_results.artifact_json`, so ephemeral is honest) → writable repo dir (dev unchanged) → loud WARNING fallback. Writability probed by real file creation, not `os.access`.

Tests reproduce the incident with a genuinely read-only dir and **assert the fallback logs** — a quiet fallback is worse than a crash (the zombie-oracle lesson).

**Sequencing:** with this + #1256 deployed, the scheduled refresh self-heals the leaderboard with momentum-honest rows — the re-run happens on the box, no manual prod surgery. Needs a `terraform apply` for the env var (Dan) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7