### PR TITLE
[infra] Remove decommissioned EC2 server (aws_instance.archimedes) from terraform

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -243,18 +243,10 @@ resource "aws_lb_target_group" "backend" {
   }
 }
 
-# ── Phase 4 cutover (issue #1039): EC2 detached from the target group ──
-# Fargate (the ECS service's own target registrations) is now the sole web tier.
-# The EC2 instance stays RUNNING (attached to nothing) as a one-deploy-cycle
-# rollback window per the runbook — to roll back, uncomment this block and
-# `terraform apply` to re-register the box alongside Fargate. This block is
-# deleted for good at Phase 8 (EC2 decommission), along with aws_instance.archimedes.
-# resource "aws_lb_target_group_attachment" "backend" {
-#   target_group_arn  = aws_lb_target_group.backend.arn
-#   target_id         = aws_instance.archimedes.private_ip # IP target, not instance ID
-#   port              = 80
-#   availability_zone = "all" # Cross-VPC IP target
-# }
+# ── Phase 4 cutover (issue #1039) rollback window: CLOSED at Phase 8 ──────
+# The commented-out aws_lb_target_group_attachment that re-registered the EC2
+# box (aws_instance.archimedes) alongside Fargate as a one-deploy-cycle
+# rollback path was removed 2026-08-19 with the EC2 decommission (main.tf).
 
 # ── Listeners ────────────────────────────────────────────────
 

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -37,40 +37,10 @@ resource "aws_sns_topic_subscription" "alerts_email" {
 }
 
 # ── EC2 (application host) ───────────────────────────────────────────────────
-
-resource "aws_cloudwatch_metric_alarm" "ec2_cpu_high" {
-  alarm_name          = "${var.project_name}-ec2-cpu-high"
-  alarm_description   = "EC2 host CPU > 85% for 10 min — app host saturated."
-  namespace           = "AWS/EC2"
-  metric_name         = "CPUUtilization"
-  statistic           = "Average"
-  comparison_operator = "GreaterThanThreshold"
-  threshold           = 85
-  period              = 300
-  evaluation_periods  = 2
-  dimensions          = { InstanceId = aws_instance.archimedes.id }
-  alarm_actions       = [aws_sns_topic.alerts.arn]
-  ok_actions          = [aws_sns_topic.alerts.arn]
-  treat_missing_data  = "missing"
-  tags                = { Project = var.project_name }
-}
-
-resource "aws_cloudwatch_metric_alarm" "ec2_status_check_failed" {
-  alarm_name          = "${var.project_name}-ec2-status-check-failed"
-  alarm_description   = "EC2 instance/system status check failed — host unhealthy."
-  namespace           = "AWS/EC2"
-  metric_name         = "StatusCheckFailed"
-  statistic           = "Maximum"
-  comparison_operator = "GreaterThanThreshold"
-  threshold           = 0
-  period              = 60
-  evaluation_periods  = 3
-  dimensions          = { InstanceId = aws_instance.archimedes.id }
-  alarm_actions       = [aws_sns_topic.alerts.arn]
-  ok_actions          = [aws_sns_topic.alerts.arn]
-  treat_missing_data  = "breaching"
-  tags                = { Project = var.project_name }
-}
+# ec2_cpu_high / ec2_status_check_failed (both dimensioned on
+# aws_instance.archimedes) were removed 2026-08-19 with the EC2 decommission
+# (main.tf). The runner box has its own equivalent status-check alarm
+# (runner_ec2.tf's runner_ec2_status_check_failed).
 
 # ── ALB (edge) ───────────────────────────────────────────────────────────────
 
@@ -194,18 +164,12 @@ resource "aws_cloudwatch_metric_alarm" "aurora_connections_high" {
 resource "aws_cloudwatch_dashboard" "ops" {
   dashboard_name = "${var.project_name}-ops"
   dashboard_body = jsonencode({
+    # The "EC2 CPU" widget (aws_instance.archimedes) was removed 2026-08-19
+    # with the EC2 decommission (main.tf); the remaining three widgets were
+    # reflowed to fill the freed x=0,y=0 slot rather than leaving a gap.
     widgets = [
       {
         type = "metric", x = 0, y = 0, width = 12, height = 6,
-        properties = {
-          title   = "EC2 CPU",
-          region  = var.aws_region,
-          view    = "timeSeries",
-          metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.archimedes.id]]
-        }
-      },
-      {
-        type = "metric", x = 12, y = 0, width = 12, height = 6,
         properties = {
           title  = "ALB requests / 5xx",
           region = var.aws_region,
@@ -217,7 +181,7 @@ resource "aws_cloudwatch_dashboard" "ops" {
         }
       },
       {
-        type = "metric", x = 0, y = 6, width = 12, height = 6,
+        type = "metric", x = 12, y = 0, width = 12, height = 6,
         properties = {
           title   = "ALB target latency (p95)",
           region  = var.aws_region,
@@ -227,7 +191,7 @@ resource "aws_cloudwatch_dashboard" "ops" {
         }
       },
       {
-        type = "metric", x = 12, y = 6, width = 12, height = 6,
+        type = "metric", x = 0, y = 6, width = 12, height = 6,
         properties = {
           title  = "Aurora CPU / connections",
           region = var.aws_region,
@@ -300,9 +264,10 @@ resource "aws_cloudwatch_metric_alarm" "nat_egress_anomaly" {
   tags                = { Project = var.project_name }
 }
 
-# NAT health + auto-recovery (issue #1039 N1). Mirrors the app box's own
-# `ec2_status_check_failed` alarm above (same alarm-name suffix pattern,
-# SNS action, tags), with two deliberate deltas from an exact mirror:
+# NAT health + auto-recovery (issue #1039 N1). Mirrors the former app box's
+# `ec2_status_check_failed` alarm (removed 2026-08-19 with the EC2
+# decommission, main.tf) — same alarm-name suffix pattern, SNS action,
+# tags — with two deliberate deltas from an exact mirror:
 #
 # 1. Metric is `StatusCheckFailed_System`, NOT the combined `StatusCheckFailed`
 #    the app box alarm uses. This isn't stylistic — it's an AWS hard
@@ -718,92 +683,12 @@ resource "aws_cloudwatch_dashboard" "vpc_nat" {
   })
 }
 
-# ── EC2 backend dashboard ────────────────────────────────────────────────────
-# Memory/disk are NOT default EC2 metrics — they require the CloudWatch agent on
-# the host emitting to the CWAgent namespace. The widgets reference CWAgent so
-# they light up once the agent is installed (separate infra task); until then
-# they render empty, which is the honest state.
-
-resource "aws_cloudwatch_dashboard" "ec2_backend" {
-  dashboard_name = "${var.project_name}-ec2-backend"
-  dashboard_body = jsonencode({
-    widgets = [
-      {
-        type = "metric", x = 0, y = 0, width = 12, height = 6,
-        properties = {
-          title  = "CPU utilization (%)",
-          region = var.aws_region,
-          view   = "timeSeries",
-          metrics = [
-            ["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.archimedes.id]
-          ]
-        }
-      },
-      {
-        type = "metric", x = 12, y = 0, width = 12, height = 6,
-        properties = {
-          title  = "Network in / out (bytes / 5 min)",
-          region = var.aws_region,
-          view   = "timeSeries",
-          stat   = "Sum",
-          metrics = [
-            ["AWS/EC2", "NetworkIn", "InstanceId", aws_instance.archimedes.id],
-            ["AWS/EC2", "NetworkOut", "InstanceId", aws_instance.archimedes.id]
-          ]
-        }
-      },
-      {
-        type = "metric", x = 0, y = 6, width = 12, height = 6,
-        properties = {
-          title  = "Memory used (%) — requires CloudWatch agent (CWAgent)",
-          region = var.aws_region,
-          view   = "timeSeries",
-          metrics = [
-            ["CWAgent", "mem_used_percent", "InstanceId", aws_instance.archimedes.id]
-          ]
-        }
-      },
-      {
-        type = "metric", x = 12, y = 6, width = 12, height = 6,
-        properties = {
-          title  = "Disk used (%) root volume — requires CloudWatch agent (CWAgent)",
-          region = var.aws_region,
-          view   = "timeSeries",
-          metrics = [
-            ["CWAgent", "disk_used_percent", "InstanceId", aws_instance.archimedes.id, "path", "/"]
-          ]
-        }
-      },
-      {
-        type = "metric", x = 0, y = 12, width = 12, height = 6,
-        properties = {
-          title  = "EBS read/write bytes (container/Docker IO proxy)",
-          region = var.aws_region,
-          view   = "timeSeries",
-          stat   = "Sum",
-          metrics = [
-            ["AWS/EC2", "EBSReadBytes", "InstanceId", aws_instance.archimedes.id],
-            ["AWS/EC2", "EBSWriteBytes", "InstanceId", aws_instance.archimedes.id]
-          ]
-        }
-      },
-      {
-        type = "metric", x = 12, y = 12, width = 12, height = 6,
-        properties = {
-          title  = "Status check failed (host health — container-restart proxy)",
-          region = var.aws_region,
-          view   = "timeSeries",
-          stat   = "Maximum",
-          metrics = [
-            ["AWS/EC2", "StatusCheckFailed", "InstanceId", aws_instance.archimedes.id],
-            ["AWS/EC2", "StatusCheckFailed_Instance", "InstanceId", aws_instance.archimedes.id],
-            ["AWS/EC2", "StatusCheckFailed_System", "InstanceId", aws_instance.archimedes.id]
-          ]
-        }
-      }
-    ]
-  })
-}
+# ── EC2 backend dashboard: REMOVED 2026-08-19 ───────────────────────────────
+# aws_cloudwatch_dashboard.ec2_backend was 100% dimensioned on
+# aws_instance.archimedes (CPU/network/memory/disk/EBS/status-check, all
+# InstanceId = the old box) and had no content left once that instance was
+# decommissioned (main.tf), so the whole dashboard resource was deleted
+# rather than emptied.
 
 # ── ALB dashboard ────────────────────────────────────────────────────────────
 
@@ -1022,8 +907,9 @@ output "ops_dashboard_name" {
 }
 
 # All CloudWatch dashboard names (issue #418 acceptance — `terraform output
-# cloudwatch_dashboard_names`). Includes the pre-existing ops dashboard plus the
-# six per-subsystem dashboards added for Layer 1.
+# cloudwatch_dashboard_names`). Includes the pre-existing ops dashboard plus
+# the per-subsystem dashboards added for Layer 1 (originally six; ec2_backend
+# was removed 2026-08-19 with the EC2 decommission, leaving five).
 output "cloudwatch_dashboard_names" {
   description = "Names of every CloudWatch dashboard managed by Terraform."
   value = [
@@ -1031,7 +917,6 @@ output "cloudwatch_dashboard_names" {
     aws_cloudwatch_dashboard.aurora.dashboard_name,
     aws_cloudwatch_dashboard.elasticache.dashboard_name,
     aws_cloudwatch_dashboard.vpc_nat.dashboard_name,
-    aws_cloudwatch_dashboard.ec2_backend.dashboard_name,
     aws_cloudwatch_dashboard.alb.dashboard_name,
     aws_cloudwatch_dashboard.waf.dashboard_name,
   ]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -143,57 +143,19 @@ resource "aws_security_group" "archimedes" {
 }
 
 # ---------------------------------------------------------------------------
-# EC2 instance
+# EC2 instance — DECOMMISSIONED 2026-08-19.
+#
+# aws_instance.archimedes (i-01803d3abc271d39b) and its aws_eip.archimedes
+# were the original single-EC2 Docker-Compose host. Superseded by the ECS
+# Fargate backend service (ecs.tf, issue #1039) at the Phase 4 cutover — the
+# ALB stopped forwarding to it (see alb.tf's Phase 4 note) and it sat RUNNING
+# but unreferenced as a one-deploy-cycle rollback window. Both the box's
+# rollback usefulness and the relocated runners (runner_ec2.tf, #1065/#1043)
+# have since been proven out; the instance was stopped and snapshotted
+# (snap-02edf9e4a9ac7f201) ahead of this removal. Dan-authorized teardown.
+#
+# `aws_security_group.archimedes` (above) is NOT removed here: aurora.tf and
+# elasticache.tf still carry live "transitional" ingress rules keyed off its
+# SG id, and this PR deliberately does not touch those other-lane files (see
+# the PR body) — so the SG stays as an orphaned-but-harmless ingress source.
 # ---------------------------------------------------------------------------
-
-resource "aws_instance" "archimedes" {
-  ami                    = data.aws_ami.ubuntu.id
-  instance_type          = var.instance_type
-  key_name               = aws_key_pair.deploy.key_name
-  vpc_security_group_ids = [aws_security_group.archimedes.id]
-  iam_instance_profile   = aws_iam_instance_profile.ec2.name # SSM SendCommand target + /archimedes/prod/* secret reads
-
-  # 20 GB gp3 root volume (enough for Docker images + data)
-  root_block_device {
-    volume_size           = 20
-    volume_type           = "gp3"
-    delete_on_termination = true
-    # Encrypt at rest (audit 2026-06-14): the root volume holds /opt/archimedes/.env
-    # (Postgres password, DATABASE_URL), SSM-pulled secrets in process/tmp, and
-    # Docker layers. Aurora + ElastiCache were already encrypted; this closes the
-    # last unencrypted store on the funds-hosting box.
-    # NOTE: applying this forces EC2 instance REPLACEMENT — coordinate with a
-    # human-credentialed `terraform plan` (or set account-level EBS default
-    # encryption to avoid replacement). Merge alone changes nothing (no CI apply).
-    encrypted = true
-  }
-
-  user_data = templatefile("${path.module}/user-data.sh", {
-    repo_url = var.repo_url
-  })
-
-  tags = {
-    Name    = "${var.project_name}-server"
-    Project = var.project_name
-  }
-
-  lifecycle {
-    ignore_changes = [ami, user_data] # AMI updates + user_data (bootstrap-only, runs at first boot) must not reboot the live box
-  }
-}
-
-# ---------------------------------------------------------------------------
-# Elastic IP — ensures DNS stays valid through EC2 replacements
-# ---------------------------------------------------------------------------
-
-resource "aws_eip" "archimedes" {
-  instance = aws_instance.archimedes.id
-  domain   = "vpc"
-
-  tags = {
-    Name    = "${var.project_name}-eip"
-    Project = var.project_name
-  }
-
-  depends_on = [aws_instance.archimedes]
-}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,27 +1,6 @@
-output "instance_id" {
-  description = "EC2 instance ID"
-  value       = aws_instance.archimedes.id
-}
-
-output "public_ip" {
-  description = "Public IP address of the EC2 instance"
-  value       = aws_instance.archimedes.public_ip
-}
-
-output "public_dns" {
-  description = "Public DNS name of the EC2 instance"
-  value       = aws_instance.archimedes.public_dns
-}
-
-output "ssh_command" {
-  description = "SSH command to connect"
-  value       = "ssh -i infra/${var.key_name}.pem ubuntu@${aws_instance.archimedes.public_ip}"
-}
-
-output "api_url" {
-  description = "Backend API URL"
-  value       = "http://${aws_instance.archimedes.public_ip}:8000"
-}
+# instance_id / public_ip / public_dns / ssh_command / api_url were removed
+# 2026-08-19 with aws_instance.archimedes (main.tf) — the single-EC2 Docker
+# host decommission. See main.tf's decommission note for the full rationale.
 
 output "private_key_path" {
   description = "Path to the SSH private key"

--- a/infra/runner_ec2.tf
+++ b/infra/runner_ec2.tf
@@ -217,7 +217,7 @@ resource "aws_instance" "runner" {
     volume_size           = 20
     volume_type           = "gp3"
     delete_on_termination = true
-    encrypted             = true # same posture as main.tf's aws_instance.archimedes
+    encrypted             = true # same posture the decommissioned app box's root volume carried (main.tf, removed 2026-08-19)
   }
 
   metadata_options {
@@ -251,10 +251,10 @@ resource "aws_instance" "runner" {
   }
 
   lifecycle {
-    # Same rationale as main.tf's aws_instance.archimedes: an unrelated
-    # `terraform apply` picking up a newer Ubuntu AMI, or a user-data.sh edit
-    # that's bootstrap-only (runs once at first boot), must not silently
-    # replace/reboot this live funds-adjacent singleton.
+    # Same rationale as aws_instance.nat's own ignore_changes = [ami]
+    # (vpc.tf): an unrelated `terraform apply` picking up a newer Ubuntu AMI,
+    # or a user-data.sh edit that's bootstrap-only (runs once at first boot),
+    # must not silently replace/reboot this live funds-adjacent singleton.
     ignore_changes = [ami, user_data, user_data_base64]
   }
 }

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -207,8 +207,9 @@ resource "aws_instance" "nat" {
   }
 
   lifecycle {
-    # Same rationale as aws_instance.archimedes (main.tf): data.aws_ami.fck_nat
-    # is `most_recent = true`, so an unrelated `terraform apply` picking up a
+    # Same rationale as aws_instance.runner's own ignore_changes = [ami]
+    # (runner_ec2.tf): data.aws_ami.fck_nat is `most_recent = true`, so an
+    # unrelated `terraform apply` picking up a
     # newly-published fck-nat AMI would otherwise destroy-recreate a LIVE NAT
     # instance — taking down both private subnets' egress (ECR pulls, Bedrock,
     # Arc RPC, Aurora/ElastiCache client traffic) for the recreate window, on


### PR DESCRIPTION
## Summary

Removes the decommissioned EC2 server (`aws_instance.archimedes`, `i-01803d3abc271d39b`) and its Elastic IP from Terraform so `terraform apply` tears down what AWS still shows as live config. The instance is **STOPPED** and snapshotted (`snap-02edf9e4a9ac7f201`); teardown is Dan-authorized. Fargate (ecs.tf, #1039) has been the sole web tier since the Phase 4 cutover, and the relocated oracle/agent runner (runner_ec2.tf, #1065/#1043) has since been proven out — this box has had zero traffic and zero purpose since.

## ⚠️ Authorization gate — read before running `terraform apply`

**`terraform plan` must show ONLY:**
- **destroys** of `aws_instance.archimedes`, `aws_eip.archimedes`, `aws_cloudwatch_metric_alarm.ec2_cpu_high`, `aws_cloudwatch_metric_alarm.ec2_status_check_failed`, and `aws_cloudwatch_dashboard.ec2_backend`
- **one in-place update** to `aws_cloudwatch_dashboard.ops` (its `dashboard_body`, dropping the dead "EC2 CPU" widget and reflowing the other three)
- **output changes** removing `instance_id`, `public_ip`, `public_dns`, `ssh_command`, `api_url`, and the `ec2_backend` entry from `cloudwatch_dashboard_names`

**If the plan shows anything else — any create, replace, or update touching NAT, the runner instance, ECS, Aurora, ElastiCache, the ALB/target groups, or WAF — DO NOT APPLY.**

## What changed (exactly the 6 files / ~25 references from the task)

- **infra/main.tf** — deleted `aws_instance.archimedes` and `aws_eip.archimedes`, replaced with a decommission note (snapshot id, dates, rationale).
  **`aws_security_group.archimedes` is deliberately KEPT** — `aurora.tf` and `elasticache.tf` still carry live "Postgres/Redis from current EC2 (transitional)" ingress rules keyed off its SG id, and this PR does not touch those other-lane files. Deleting the SG would break `terraform validate` for those two files.
- **infra/outputs.tf** — deleted the 5 outputs that named the instance (`instance_id`, `public_ip`, `public_dns`, `ssh_command`, `api_url`).
- **infra/cloudwatch.tf**:
  - deleted the two dedicated alarms (`ec2_cpu_high`, `ec2_status_check_failed`)
  - deleted the entire `aws_cloudwatch_dashboard.ec2_backend` resource — 100% of its 6 widgets were dimensioned on the old instance, nothing was left to keep
  - removed the "EC2 CPU" widget from `aws_cloudwatch_dashboard.ops` and reflowed the remaining 3 widgets into the freed grid slot
  - dropped `ec2_backend` from the `cloudwatch_dashboard_names` output list
  - fixed two stale comments that described alarms/dashboards "above"/mirroring the old box
- **infra/alb.tf** — deleted the dead, already-commented-out Phase-4-rollback block (`# resource "aws_lb_target_group_attachment" "backend"`) that referenced `aws_instance.archimedes.private_ip`. It was inert (pure comment) either way, but its own text said it should be "deleted for good at Phase 8 (EC2 decommission)" — this is that.
- **infra/vpc.tf**, **infra/runner_ec2.tf** — repointed stale `ignore_changes = [ami]` rationale comments that cited `main.tf`'s `aws_instance.archimedes` at still-live analogues (`aws_instance.nat`, `aws_instance.runner`), so nothing in the codebase cites a resource that no longer exists.

## Deliberate omissions (flagged, not fixed here)

1. **`infra/scripts/aws-idle-discovery.sh` does not exist on `main`.** It only exists on an unmerged, never-PR'd branch `dbrowneup/aws-idle-discovery` (commit `0a8aff69`, 2026-07-28), whose own commit message says *"DO NOT tear down the detached EC2 (i-01803d3abc271d39b) while it remains the Fargate rollback window."* I did not cherry-pick that branch in — pulling an unrelated, unreviewed branch into this focused removal PR felt like scope creep. If you want it on `main`, it needs its own PR; once there, its DO-NOT-TERMINATE guard should flip to a "decommissioned 2026-08-19" note per the task.
2. **`aws_security_group.alb`'s "To EC2 backend" egress rule** (port 80 → `aws_security_group.archimedes`, alb.tf line ~168) is now dead traffic policy — nothing targets that SG anymore since the Phase 4 target-group detach — but it's left in place. Since `aws_security_group.archimedes` isn't being destroyed, this rule doesn't dangle; removing it would only produce an SG-rule UPDATE on `aws_security_group.alb`, which would break the "plan shows ONLY destroys + one dashboard update" guarantee above. Flagging as an optional follow-up cleanup.
3. **The SSH key-pair resources** (`tls_private_key.deploy`, `aws_key_pair.deploy`, `local_sensitive_file.private_key` in main.tf) and their outputs (`private_key_path`, `ssh_private_key`) existed only to give the old instance a `key_name`. They compile fine standing alone — no dangling refs — and weren't part of the named ~25-reference scope, so left as-is. They're now orphaned. Note `local_sensitive_file.private_key` also manages a local `infra/${var.key_name}.pem` file on disk; destroying that resource deletes the file, which felt like your call, not mine.
4. **Docs/CI stragglers outside `infra/`**, found by the repo-wide grep, left untouched (none block `terraform apply`):
   - `docs/deployment-runbook.md` (5 hits) — SSM-based runbook still targets `i-01803d3abc271d39b`.
   - `.github/workflows/deploy.yml` (2 hits) — `EC2_INSTANCE_ID` env var for a legacy SSM deploy job, gated behind the `DEPLOY_ENABLED` repo variable; presumably superseded by the ECS/Fargate deploy path.
   - `infra/scripts/bake-backend-ami.sh` — auto-discovers a *running* instance tagged `Name=archimedes-server` for the optional ASG AMI bake. Already fails gracefully ("could not find a running instance... pass SOURCE_INSTANCE_ID=i-... explicitly") once the box is stopped/gone, so no code change is needed there.
   - `docs/aws-architecture.md` — references a *different* instance id (`i-0987f70a131ed3ab1`) under the same `archimedes-server` Name tag; looks like it pre-dates an earlier instance replacement and is unrelated to today's target id.

## Verification

Run from `infra/` (this session has no AWS credentials — plan/apply were not run):

```
$ terraform fmt -check -diff .
# exit 0, no output

$ terraform init -backend=false -input=false
# Terraform has been successfully initialized!

$ terraform validate
# Success! The configuration is valid.
```

`terraform validate` confirms zero remaining functional references anywhere in `infra/*.tf` to `aws_instance.archimedes` or `aws_eip.archimedes` — every one of the original ~25 grep hits (`aws_instance.archimedes` literal) is now either a deleted resource or a historical comment.

```
$ grep -rn "aws_instance\.archimedes\|aws_eip\.archimedes" infra/*.tf
# only comment lines remain (decommission notes), no live code references
```

**Dan: please run `terraform plan` yourself from `infra/` and confirm it matches the shape described in the authorization gate above before applying.**
