### PR TITLE
Hide non-MVP surfaces (vaults, marketplace, publish, subscriptions, learnings) behind one flag

### DIFF
--- a/ui/.env.example
+++ b/ui/.env.example
@@ -34,7 +34,7 @@ VITE_CIRCLE_CLIENT_URL=https://modular-sdk.circle.com/v1/rpc/w3s/buidl
 VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW=1000000
 
 # Roadmap surfaces (#1266): vaults (Portfolio + vault-detail), Marketplace
-# (+ market-strategy), Publish, Subscriptions. Off (default) hides them
+# (+ market-strategy), Publish, Subscriptions, Learnings. Off (default) hides them
 # completely — no nav items, and their routes (deep links included) resolve
 # to not-found. Set true to preview the full app. All component code stays
 # in the tree either way.

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -33,6 +33,13 @@ VITE_CIRCLE_CLIENT_URL=https://modular-sdk.circle.com/v1/rpc/w3s/buidl
 # MARKETPLACE_MIN_VAULT_FUNDS_RAW. 1000000 = 1 USDC.
 VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW=1000000
 
+# Roadmap surfaces (#1266): vaults (Portfolio + vault-detail), Marketplace
+# (+ market-strategy), Publish, Subscriptions. Off (default) hides them
+# completely — no nav items, and their routes (deep links included) resolve
+# to not-found. Set true to preview the full app. All component code stays
+# in the tree either way.
+VITE_ROADMAP_SURFACES=false
+
 # Upfront cost-quote + x402 paywall step on the Generate page (RATIFIED —
 # docs/specs/generation-quote-contract.md, #1296). Off by default: Generate
 # submits directly, no quote step. Set true to try the quote card + 402/409

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -5,14 +5,13 @@
   anonymous visitor with no wallet connected and no selected entity.
 
   Excluded on purpose:
-    - portfolio, marketplace, publish, subscriptions — hidden roadmap
-      surfaces (#1266): their routes resolve to not-found unless the app is
-      built with VITE_ROADMAP_SURFACES=true. A static sitemap can't read a
-      build flag, so it matches the default-off production build.
-    - generate, library, quant, reasoning, learnings — each renders only a
-      generic sign-in/"Connect your wallet" prompt for a cold/anonymous
-      visitor. No unique indexable content exists at these URLs without a
-      session.
+    - portfolio, marketplace, publish, subscriptions, learnings — hidden
+      roadmap surfaces (#1266): their routes resolve to not-found unless the
+      app is built with VITE_ROADMAP_SURFACES=true. A static sitemap can't
+      read a build flag, so it matches the default-off production build.
+    - generate, library, quant, reasoning — each renders only a generic
+      sign-in/"Connect your wallet" prompt for a cold/anonymous visitor. No
+      unique indexable content exists at these URLs without a session.
     - strategy, vault-detail, market-strategy — dynamic routes that require
       an id/address in the path; there is no single canonical URL to list.
 

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -5,11 +5,14 @@
   anonymous visitor with no wallet connected and no selected entity.
 
   Excluded on purpose:
-    - generate, library, quant, portfolio, reasoning, learnings, publish,
-      subscriptions — each renders only a generic "Connect your wallet"
-      prompt for a cold/anonymous visitor (see ui/src/components/WalletGate.jsx
-      and the equivalent inline gates in PublishPage.jsx / SubscriptionsPage.jsx).
-      No unique indexable content exists at these URLs without a session.
+    - portfolio, marketplace, publish, subscriptions — hidden roadmap
+      surfaces (#1266): their routes resolve to not-found unless the app is
+      built with VITE_ROADMAP_SURFACES=true. A static sitemap can't read a
+      build flag, so it matches the default-off production build.
+    - generate, library, quant, reasoning, learnings — each renders only a
+      generic sign-in/"Connect your wallet" prompt for a cold/anonymous
+      visitor. No unique indexable content exists at these URLs without a
+      session.
     - strategy, vault-detail, market-strategy — dynamic routes that require
       an id/address in the path; there is no single canonical URL to list.
 
@@ -30,11 +33,6 @@
   <url>
     <loc>https://archimedes-arc.com/explore</loc>
     <priority>0.9</priority>
-    <changefreq>daily</changefreq>
-  </url>
-  <url>
-    <loc>https://archimedes-arc.com/marketplace</loc>
-    <priority>0.8</priority>
     <changefreq>daily</changefreq>
   </url>
   <url>

--- a/ui/src/components/Breadcrumbs.jsx
+++ b/ui/src/components/Breadcrumbs.jsx
@@ -47,8 +47,9 @@ export default function Breadcrumbs({ page, setPage }) {
   if (!info) return null
 
   // When the group's landing page is a hidden roadmap surface (#1266 —
-  // quant/reasoning/learnings point at Portfolio), the mid-crumb would be a
-  // link into a not-found route: fall back to a flat Home / <page> crumb.
+  // quant/reasoning point at Portfolio; learnings is itself hidden), the
+  // mid-crumb would link into a not-found route: fall back to a flat
+  // Home / <page> crumb.
   const crumbs = [
     { label: 'Home', page: 'explore' },
     ...(info.group && !roadmapSurfaceHidden(info.groupPage)

--- a/ui/src/components/Breadcrumbs.jsx
+++ b/ui/src/components/Breadcrumbs.jsx
@@ -7,6 +7,7 @@
  */
 
 import { PAGE_LABELS } from './Layout'
+import { roadmapSurfaceHidden } from '../featureFlags.js'
 
 // `group: null` means "no intermediate label" — breadcrumb reads "Home / <page>".
 // Mirrors Layout.jsx NAV groups: Discover, Strategy, Position, Market, Ops.
@@ -45,9 +46,14 @@ export default function Breadcrumbs({ page, setPage }) {
   const info = CRUMB_MAP[page]
   if (!info) return null
 
+  // When the group's landing page is a hidden roadmap surface (#1266 —
+  // quant/reasoning/learnings point at Portfolio), the mid-crumb would be a
+  // link into a not-found route: fall back to a flat Home / <page> crumb.
   const crumbs = [
     { label: 'Home', page: 'explore' },
-    ...(info.group ? [{ label: info.group, page: info.groupPage }] : []),
+    ...(info.group && !roadmapSurfaceHidden(info.groupPage)
+      ? [{ label: info.group, page: info.groupPage }]
+      : []),
     { label: PAGE_LABELS[page] ?? page, page: null },
   ]
 

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useLayoutEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
+import { roadmapSurfaceHidden } from '../featureFlags.js'
 
 const STORAGE_KEY = 'archimedes.onboarding.v1'
 
@@ -9,7 +10,10 @@ const STORAGE_KEY = 'archimedes.onboarding.v1'
 //
 // `anchor` is a nav id (see Layout.jsx `data-tour`). When set, the step
 // spotlights that real nav button; when null the step is a centered card.
-const CARDS = [
+// Steps anchored to a hidden roadmap surface (#1266: the 'deploy' step's
+// anchor-navigation effect calls setPage('portfolio') on mount — a dead door
+// for every first-time visitor) are filtered out below.
+const ALL_CARDS = [
   {
     id: 'what',
     title: 'What is Archimedes?',
@@ -75,6 +79,8 @@ const CARDS = [
     illustration: 'reasoning',
   },
 ]
+
+const CARDS = ALL_CARDS.filter((card) => !roadmapSurfaceHidden(card.anchor))
 
 function Illustration({ name }) {
   // Simple geometric SVGs — no external dependencies, theme-aware via

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import CreateVaultModal from "./CreateVaultModal";
+import { ROADMAP_SURFACES_ENABLED } from "../featureFlags.js";
 import RigorStrictnessControl, { levelLabel } from "./RigorStrictnessControl";
 import { useRigorStrictness, BADGE_LEVEL } from "../hooks/useRigorStrictness";
 
@@ -281,7 +282,9 @@ export default function StrategyPassport({
 
 			<div className="passport-workspace">
 				<aside className="passport-authority">
-					{/* Deploy CTA — top, gated on rigor-at-your-level + wallet */}
+					{/* Deploy CTA — top, gated on rigor-at-your-level + wallet. The card
+					    leads into the vault surface, so it hides with it (#1266). */}
+					{ROADMAP_SURFACES_ENABLED && (
 					<div className="card passport-deploy fade-up fade-up-2">
 						<div className="flex-1 min-w-[240px]">
 							<div className="label mb-1">Deploy as a vault</div>
@@ -354,6 +357,7 @@ export default function StrategyPassport({
 							)}
 						</div>
 					</div>
+					)}
 
 					{/* Per-user strictness slider — the deploy gate above reads from this. */}
 					<div className="passport-strictness fade-up fade-up-2">
@@ -734,7 +738,7 @@ export default function StrategyPassport({
 				</div>
 			</div>
 
-			{deployOpen && (
+			{ROADMAP_SURFACES_ENABLED && deployOpen && (
 				<CreateVaultModal
 					strategy={s}
 					walletAddr={walletAddr}

--- a/ui/src/featureFlags.js
+++ b/ui/src/featureFlags.js
@@ -19,11 +19,11 @@ export const GENERATION_QUOTE_ENABLED =
 
 // Single flag gating the UI surfaces that are out of scope for the MVP
 // (#1266): vaults (Portfolio + the vault-detail deep link), the strategy
-// Marketplace (+ market-strategy deep link), Publish, and Subscriptions.
-// All the code for these stays in the tree — this flag just keeps them out
-// of the shipped nav/routes/CTAs until they're back in scope. Set
-// VITE_ROADMAP_SURFACES=true at build time (see ui/.env.example) to
-// preview the full app.
+// Marketplace (+ market-strategy deep link), Publish, Subscriptions, and
+// Learnings. All the code for these stays in the tree — this flag just
+// keeps them out of the shipped nav/routes/CTAs until they're back in
+// scope. Set VITE_ROADMAP_SURFACES=true at build time (see
+// ui/.env.example) to preview the full app.
 export const ROADMAP_SURFACES_ENABLED =
 	import.meta.env?.VITE_ROADMAP_SURFACES === "true";
 
@@ -38,6 +38,7 @@ export const ROADMAP_PAGES = new Set([
 	"market-strategy",
 	"publish",
 	"subscriptions",
+	"learnings",
 ]);
 
 export function roadmapSurfaceHidden(page) {

--- a/ui/src/featureFlags.js
+++ b/ui/src/featureFlags.js
@@ -1,10 +1,9 @@
 // Build-time feature flags (Vite env-gated).
 //
 // Pattern: one flag per Vite env var, exported as a plain boolean, all in
-// this one file. Established by #1266 (ui/src/featureFlags.js,
-// ROADMAP_SURFACES_ENABLED) — that PR is open, not yet on main, but this
-// file's path/shape matches it deliberately so the two flags land in the
-// same file without conflict once it merges.
+// this one file. Env access uses `import.meta.env?.` (the features.js
+// pattern) — this module is imported by routes.js and therefore loads under
+// plain node in ui/test/, where import.meta.env is undefined.
 
 // Gates the upfront cost-quote + x402 paywall step on the Generate page
 // (docs/specs/generation-quote-contract.md — RATIFIED, #1296). Off by
@@ -16,4 +15,31 @@
 // off, since GET /api/generate/quote always reports payment_required
 // honestly either way.
 export const GENERATION_QUOTE_ENABLED =
-	import.meta.env.VITE_GENERATION_QUOTE_ENABLED === "true";
+	import.meta.env?.VITE_GENERATION_QUOTE_ENABLED === "true";
+
+// Single flag gating the UI surfaces that are out of scope for the MVP
+// (#1266): vaults (Portfolio + the vault-detail deep link), the strategy
+// Marketplace (+ market-strategy deep link), Publish, and Subscriptions.
+// All the code for these stays in the tree — this flag just keeps them out
+// of the shipped nav/routes/CTAs until they're back in scope. Set
+// VITE_ROADMAP_SURFACES=true at build time (see ui/.env.example) to
+// preview the full app.
+export const ROADMAP_SURFACES_ENABLED =
+	import.meta.env?.VITE_ROADMAP_SURFACES === "true";
+
+// Page ids the flag hides. Consumed by routes.js featureEnabled() — the
+// single gate for nav visibility, flat routes, and deep links alike — plus
+// the two spots routing can't reach: the Breadcrumbs mid-crumb and in-page
+// CTAs (StrategyPassport deploy card, onboarding tour).
+export const ROADMAP_PAGES = new Set([
+	"portfolio",
+	"vault-detail",
+	"marketplace",
+	"market-strategy",
+	"publish",
+	"subscriptions",
+]);
+
+export function roadmapSurfaceHidden(page) {
+	return !ROADMAP_SURFACES_ENABLED && ROADMAP_PAGES.has(page);
+}

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -1,3 +1,5 @@
+import { ROADMAP_PAGES, ROADMAP_SURFACES_ENABLED } from './featureFlags.js'
+
 const PUBLIC_PATHS = {
   '/': 'landing',
   '/architecture': 'architecture',
@@ -62,6 +64,12 @@ const route = (kind, page, extras = {}) => ({
 })
 
 export function featureEnabled(page, features = { quant: true }) {
+  // Roadmap surfaces (#1266): hidden at BUILD time (VITE_ROADMAP_SURFACES,
+  // default off), deliberately separate from the runtime features fetch —
+  // parseFeatures() never emits `roadmapSurfaces`, so the override below is
+  // reachable only from tests, never from the server.
+  const roadmapOn = features.roadmapSurfaces ?? ROADMAP_SURFACES_ENABLED
+  if (!roadmapOn && ROADMAP_PAGES.has(page)) return false
   return page !== 'quant' || features.quant === true
 }
 

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -11,6 +11,11 @@ import {
 	visibleNavigation,
 } from "../src/routes.js";
 
+// Test-only override restoring the hidden roadmap surfaces (#1266): the
+// build-time VITE_ROADMAP_SURFACES flag is off under node, and
+// parseFeatures() never emits this key, so app code can't pass it.
+const ROADMAP_ON = { quant: true, roadmapSurfaces: true };
+
 test("landing and architecture remain public", () => {
 	assert.deepEqual(resolveRoute("/").kind, "public");
 	assert.deepEqual(resolveRoute("/architecture").kind, "public");
@@ -33,8 +38,10 @@ test("application routes use /app boundary", () => {
 });
 
 test("deep application routes retain identifiers", () => {
+	// vault-detail is a hidden roadmap surface (#1266) — its identifier
+	// extraction is pinned under the flag-on override.
 	assert.equal(
-		resolveRoute("/app/portfolio/vaults/0x123").vaultAddress,
+		resolveRoute("/app/portfolio/vaults/0x123", "", ROADMAP_ON).vaultAddress,
 		"0x123",
 	);
 	assert.equal(resolveRoute("/app/strategy/alpha").strategyId, "alpha");
@@ -127,14 +134,55 @@ test("auth-required pages stay auth-required", () => {
 	for (const path of [
 		"/app/generate",
 		"/app/library",
-		"/app/portfolio",
 		"/app/account",
-		"/app/portfolio/vaults/0x123",
 	]) {
 		const route = resolveRoute(path);
 		assert.equal(route.kind, "app", path);
 		assert.equal(route.anonymousOk, false, path);
 	}
+	// The hidden surfaces stay auth-required in flag-on builds too.
+	for (const path of ["/app/portfolio", "/app/portfolio/vaults/0x123"]) {
+		const route = resolveRoute(path, "", ROADMAP_ON);
+		assert.equal(route.kind, "app", path);
+		assert.equal(route.anonymousOk, false, path);
+	}
+});
+
+test("roadmap surfaces are hidden by default: flat routes, deep links, nav (#1266)", () => {
+	for (const path of [
+		"/app/portfolio",
+		"/app/marketplace",
+		"/app/publish",
+		"/app/subscriptions",
+	]) {
+		assert.equal(resolveRoute(path).kind, "not-found", path);
+	}
+	// The #1194 handoff case: a feature-disabled page must NOT stay reachable
+	// via its deep link — deepRoutes shares the same featureEnabled() gate.
+	assert.equal(
+		resolveRoute("/app/marketplace/strategy/alpha").kind,
+		"not-found",
+	);
+	assert.equal(resolveRoute("/app/portfolio/vaults/0x123").kind, "not-found");
+	// Nav: Portfolio drops and the Market group empties even for a signed-in
+	// user (Layout skips emptied groups, so no bare "Market" header remains).
+	const nav = [
+		{ id: "portfolio" },
+		{ id: "marketplace" },
+		{ id: "publish" },
+		{ id: "subscriptions" },
+		{ id: "library" },
+	];
+	assert.deepEqual(visibleNavigation(nav, { quant: true }, { id: "u1" }), [
+		{ id: "library" },
+	]);
+	// And the flag-on build restores all of it unchanged.
+	assert.equal(resolveRoute("/app/marketplace", "", ROADMAP_ON).page, "marketplace");
+	assert.equal(
+		resolveRoute("/app/marketplace/strategy/alpha", "", ROADMAP_ON).strategyId,
+		"alpha",
+	);
+	assert.equal(visibleNavigation(nav, ROADMAP_ON, { id: "u1" }).length, 5);
 });
 
 test("anonymous nav shows browse + the Generate conversion path, nothing stateful", () => {

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -154,6 +154,7 @@ test("roadmap surfaces are hidden by default: flat routes, deep links, nav (#126
 		"/app/marketplace",
 		"/app/publish",
 		"/app/subscriptions",
+		"/app/learnings",
 	]) {
 		assert.equal(resolveRoute(path).kind, "not-found", path);
 	}
@@ -171,6 +172,7 @@ test("roadmap surfaces are hidden by default: flat routes, deep links, nav (#126
 		{ id: "marketplace" },
 		{ id: "publish" },
 		{ id: "subscriptions" },
+		{ id: "learnings" },
 		{ id: "library" },
 	];
 	assert.deepEqual(visibleNavigation(nav, { quant: true }, { id: "u1" }), [
@@ -182,7 +184,7 @@ test("roadmap surfaces are hidden by default: flat routes, deep links, nav (#126
 		resolveRoute("/app/marketplace/strategy/alpha", "", ROADMAP_ON).strategyId,
 		"alpha",
 	);
-	assert.equal(visibleNavigation(nav, ROADMAP_ON, { id: "u1" }).length, 5);
+	assert.equal(visibleNavigation(nav, ROADMAP_ON, { id: "u1" }).length, 6);
 });
 
 test("anonymous nav shows browse + the Generate conversion path, nothing stateful", () => {


### PR DESCRIPTION
## Summary

Hides the four non-MVP UI surfaces — **vaults** (Portfolio + vault-detail), **Marketplace** (+ market-strategy), **Publish**, and **Subscriptions** — behind one build-time flag:

```js
// ui/src/featureFlags.js
export const ROADMAP_SURFACES_ENABLED =
  import.meta.env?.VITE_ROADMAP_SURFACES === "true";
```

Default (unset/`false`): the four surfaces are unreachable — not in the nav, not in breadcrumbs, not routable by flat URL or deep link, and no CTA leads to them. `VITE_ROADMAP_SURFACES=true` at build time restores the full app unchanged. **All component code stays in the tree.**

This is the rebuild on post-#1194 main that the original PR's reconciliation note promised — the note's items are now implemented rather than predicted:

- **`routes.js` `featureEnabled()`** is the single gate (item 2): a `ROADMAP_PAGES` set short-circuits it, with `features.roadmapSurfaces` as a tests-only override (`parseFeatures()` never emits the key, so the server can't flip it). Main's `deepRoutes` loop already routes through `featureEnabled()` (item 3 landed with #1194's revisions), so deep links `/app/portfolio/vaults/:addr` and `/app/marketplace/strategy/:id` are covered by the same check — no separate gating.
- **Nav needs no hand-edits** (item 4): `visibleNavigation()` drops the Portfolio item and empties the Market group via the extended `featureEnabled()`; `Layout.jsx` already skips emptied groups. `NAV` is untouched.
- **`App.jsx` render-switch guards dropped** (item 7): `navigateToPage()` on main re-derives the route via `resolveRoute()` after every push, so a stray programmatic nav to a hidden page resolves to not-found at the routing layer.
- **Breadcrumbs** (item 5): `CRUMB_MAP` untouched (keeps `test_breadcrumbs.py`'s sync invariant intact, 5/5 both flag states); the component flattens the mid-crumb when its group page is hidden, so quant/reasoning/learnings read `Home / <page>` instead of linking into a 404.
- **Re-applied by hand onto current shapes** (item 6): StrategyPassport's "Deploy as a vault" card + `CreateVaultModal`; OnboardingTour drops cards anchored to hidden surfaces (the `deploy` step's mount effect called `setPage('portfolio')` for every first-time visitor).
- **`featureFlags.js` merged, not added**: #1295 pre-created the file for `GENERATION_QUOTE_ENABLED` with a shape matching this PR; both flags now live there, env access via the node-safe `import.meta.env?.` pattern (the module is imported by `routes.js`, which loads under plain node in `ui/test/`).
- **`sitemap.xml`**: `/marketplace` dropped; the exclusion comment now records the roadmap-surface reason vs the sign-in-gated reason separately.

## Tests

`ui/test/routes.test.js` gains the handoff test: the four flat routes and both deep links resolve `not-found` by default, nav drops them for a signed-in user, and the `roadmapSurfaces: true` override restores all of it (which also keeps vault-detail's identifier-extraction coverage alive). **Mutation-verified**: deleting the `featureEnabled()` roadmap clause fails the test.

Dead-door audit re-run on current main: every remaining `onNavigate`/`setPage`/`navigateToPage` call site targeting a hidden page is either inside an already-hidden component or backstopped by the routing layer above.

## Verification

```
ui: node --test            56/56 (incl. new handoff test; mutation pass: gate removed → fail)
ui: npm run lint           clean
ui: npm run build          clean, both flag states
backend: pytest backend/tests/test_breadcrumbs.py   5/5
```


## Addendum: Learnings is hidden too

Per product direction, **Learnings** joins the hidden set (`ROADMAP_PAGES`). No CTA in the tree navigates to it (verified by grep — only the routes map and NAV item reference it), so the existing single gate covers every path; quant/reasoning keep the Position group non-empty. Tests updated (56/56, both flag-state builds clean).

Hiding supersedes #1122's wallet-gating ask — an unreachable route is strictly stronger than a gated one — and settles its Learnings-placement question.

Closes #1122
