### PR TITLE
Paper trading: forward-run the graded engine, append-only ledger

### DIFF
--- a/backend/archimedes/api/paper_routes.py
+++ b/backend/archimedes/api/paper_routes.py
@@ -1,0 +1,120 @@
+"""Paper-trading endpoints — /api/paper/* (MVP: verdict → paper-trade).
+
+Ownership follows the SIWE model live on main today (verified wallet), with
+the Better Auth user id column already carried for the #1194 transition —
+this router only needs its auth dependency swapped when that lands.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request, Response
+
+from archimedes.api.auth_siwe import get_verified_wallet
+from archimedes.api.limiter import limiter
+from archimedes.db import get_session, init_db
+from archimedes.models.paper_store import STATUS_STOPPED, PaperDeployment
+from archimedes.services.paper_trading import advance_deployment, create_deployment, deployment_summary
+from archimedes.services.strategy_dsl import DSLError
+
+logger = logging.getLogger(__name__)
+
+paper_router = APIRouter(prefix="/api/paper", tags=["paper"])
+
+
+def _spec_for_strategy(session, strategy_id: str, caller: str | None) -> dict:
+    """The spec to snapshot, honoring strategy visibility (#850 rules)."""
+    from archimedes.models.strategy_store import StrategyRecord
+    from archimedes.services.strategy_visibility import is_strategy_visible
+
+    row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+    if row is None or not is_strategy_visible(row, caller):
+        raise HTTPException(status_code=404, detail="Strategy not found")
+    spec = (row.to_dict() or {}).get("strategy_spec")
+    if not spec:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "This strategy has no machine-readable spec to paper-trade.",
+                "reason": "no_strategy_spec",
+            },
+        )
+    return spec
+
+
+@paper_router.post("/deployments", status_code=201)
+@limiter.limit("10/minute")
+async def deploy_paper(
+    request: Request,
+    response: Response,  # noqa: ARG001 — slowapi header injection (#1182 invariant)
+    body: dict,
+):
+    wallet = get_verified_wallet(request)
+    if not wallet:
+        raise HTTPException(status_code=401, detail="Connect a wallet to paper-trade")
+    strategy_id = str(body.get("strategy_id") or "").strip()
+    if not strategy_id:
+        raise HTTPException(status_code=422, detail="strategy_id is required")
+
+    init_db()
+    with get_session() as session:
+        spec = _spec_for_strategy(session, strategy_id, wallet)
+        try:
+            dep = create_deployment(session, strategy_id=strategy_id, spec_dict=spec, owner_wallet=wallet)
+        except DSLError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail={"message": f"Stored spec fails validation: {exc}", "reason": "invalid_strategy_spec"},
+            ) from exc
+        # First advance is best-effort and SYNCHRONOUS-failure-soft: the
+        # deployment exists even if data is momentarily unavailable — the
+        # scheduler's daily pass will backfill from deployed_at.
+        try:
+            advance_deployment(session, dep)
+        except Exception as exc:
+            logger.warning("paper: initial advance for %s deferred to the scheduler: %s", dep.id, exc)
+        summary = deployment_summary(session, dep)
+        session.commit()
+    return summary
+
+
+@paper_router.get("/deployments")
+async def list_paper_deployments(request: Request):
+    wallet = get_verified_wallet(request)
+    if not wallet:
+        raise HTTPException(status_code=401, detail="Connect a wallet to view paper trades")
+    init_db()
+    with get_session() as session:
+        deps = (
+            session.query(PaperDeployment)
+            .filter(PaperDeployment.owner_wallet == wallet.lower())
+            .order_by(PaperDeployment.created_at.desc())
+            .all()
+        )
+        return {"deployments": [deployment_summary(session, d) for d in deps]}
+
+
+@paper_router.get("/deployments/{deployment_id}")
+async def get_paper_deployment(request: Request, deployment_id: str):
+    wallet = get_verified_wallet(request)
+    init_db()
+    with get_session() as session:
+        dep = session.query(PaperDeployment).filter_by(id=deployment_id).first()
+        # 404 for missing AND for not-yours: existence is private (#850 idiom).
+        if dep is None or not wallet or dep.owner_wallet != wallet.lower():
+            raise HTTPException(status_code=404, detail="Paper deployment not found")
+        return deployment_summary(session, dep)
+
+
+@paper_router.post("/deployments/{deployment_id}/stop")
+async def stop_paper_deployment(request: Request, deployment_id: str):
+    wallet = get_verified_wallet(request)
+    init_db()
+    with get_session() as session:
+        dep = session.query(PaperDeployment).filter_by(id=deployment_id).first()
+        if dep is None or not wallet or dep.owner_wallet != wallet.lower():
+            raise HTTPException(status_code=404, detail="Paper deployment not found")
+        dep.status = STATUS_STOPPED
+        session.commit()
+        return {"deployment_id": dep.id, "status": dep.status}

--- a/backend/archimedes/api/paper_routes.py
+++ b/backend/archimedes/api/paper_routes.py
@@ -1,18 +1,28 @@
 """Paper-trading endpoints — /api/paper/* (MVP: verdict → paper-trade).
 
-Ownership follows the SIWE model live on main today (verified wallet), with
-the Better Auth user id column already carried for the #1194 transition —
-this router only needs its auth dependency swapped when that lands.
+Ownership is CANONICAL account identity (#1194): every route requires a Better
+Auth session and every deployment is owned by ``owner_user_id``. Account-first
+users never hold a SIWE session post-#1194, so a wallet-session gate here
+would 401 exactly the users the product creates. Paper deploys are SIMULATED —
+no funds move — so an account session is the correct strength of proof (the
+relaxed-lookup boundary in ``wallet_routes.get_linked_wallet_address`` applies:
+no fresh wallet signature is required for a non-money-moving action; the day a
+paper→real promotion exists, THAT action takes the fresh-signature gate).
+
+``owner_wallet`` is recorded as provenance only (the caller's linked wallet at
+deploy time, when one exists) — it never grants access. The table shipped with
+this feature, so there are no legacy wallet-owned rows and no fallback tier.
 """
 
 from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
-from archimedes.api.auth_siwe import get_verified_wallet
+from archimedes.api.account_auth import CurrentUser, require_current_user
 from archimedes.api.limiter import limiter
+from archimedes.api.wallet_routes import get_linked_wallet_address
 from archimedes.db import get_session, init_db
 from archimedes.models.paper_store import STATUS_STOPPED, PaperDeployment
 from archimedes.services.paper_trading import advance_deployment, create_deployment, deployment_summary
@@ -23,13 +33,13 @@ logger = logging.getLogger(__name__)
 paper_router = APIRouter(prefix="/api/paper", tags=["paper"])
 
 
-def _spec_for_strategy(session, strategy_id: str, caller: str | None) -> dict:
+def _spec_for_strategy(session, strategy_id: str, caller_wallet: str | None, caller_user_id: str | None) -> dict:
     """The spec to snapshot, honoring strategy visibility (#850 rules)."""
     from archimedes.models.strategy_store import StrategyRecord
     from archimedes.services.strategy_visibility import is_strategy_visible
 
     row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
-    if row is None or not is_strategy_visible(row, caller):
+    if row is None or not is_strategy_visible(row, caller_wallet, caller_user_id=caller_user_id):
         raise HTTPException(status_code=404, detail="Strategy not found")
     spec = (row.to_dict() or {}).get("strategy_spec")
     if not spec:
@@ -43,25 +53,41 @@ def _spec_for_strategy(session, strategy_id: str, caller: str | None) -> dict:
     return spec
 
 
+def _owned_deployment(session, deployment_id: str, user_id: str) -> PaperDeployment:
+    """Fetch a deployment the caller owns — 404 for missing AND for not-yours:
+    existence is private (#850 idiom). Ownership is owner_user_id only."""
+    dep = session.query(PaperDeployment).filter_by(id=deployment_id).first()
+    if dep is None or dep.owner_user_id != user_id:
+        raise HTTPException(status_code=404, detail="Paper deployment not found")
+    return dep
+
+
 @paper_router.post("/deployments", status_code=201)
 @limiter.limit("10/minute")
 async def deploy_paper(
     request: Request,
     response: Response,  # noqa: ARG001 — slowapi header injection (#1182 invariant)
     body: dict,
+    user: CurrentUser = Depends(require_current_user),
 ):
-    wallet = get_verified_wallet(request)
-    if not wallet:
-        raise HTTPException(status_code=401, detail="Connect a wallet to paper-trade")
     strategy_id = str(body.get("strategy_id") or "").strip()
     if not strategy_id:
         raise HTTPException(status_code=422, detail="strategy_id is required")
 
+    # Provenance only — never an access grant, may be None (account-only user).
+    linked_wallet = get_linked_wallet_address(request)
+
     init_db()
     with get_session() as session:
-        spec = _spec_for_strategy(session, strategy_id, wallet)
+        spec = _spec_for_strategy(session, strategy_id, linked_wallet, user.id)
         try:
-            dep = create_deployment(session, strategy_id=strategy_id, spec_dict=spec, owner_wallet=wallet)
+            dep = create_deployment(
+                session,
+                strategy_id=strategy_id,
+                spec_dict=spec,
+                owner_wallet=linked_wallet,
+                owner_user_id=user.id,
+            )
         except DSLError as exc:
             raise HTTPException(
                 status_code=422,
@@ -80,15 +106,12 @@ async def deploy_paper(
 
 
 @paper_router.get("/deployments")
-async def list_paper_deployments(request: Request):
-    wallet = get_verified_wallet(request)
-    if not wallet:
-        raise HTTPException(status_code=401, detail="Connect a wallet to view paper trades")
+async def list_paper_deployments(request: Request, user: CurrentUser = Depends(require_current_user)):  # noqa: ARG001
     init_db()
     with get_session() as session:
         deps = (
             session.query(PaperDeployment)
-            .filter(PaperDeployment.owner_wallet == wallet.lower())
+            .filter(PaperDeployment.owner_user_id == user.id)
             .order_by(PaperDeployment.created_at.desc())
             .all()
         )
@@ -96,25 +119,26 @@ async def list_paper_deployments(request: Request):
 
 
 @paper_router.get("/deployments/{deployment_id}")
-async def get_paper_deployment(request: Request, deployment_id: str):
-    wallet = get_verified_wallet(request)
+async def get_paper_deployment(
+    request: Request,  # noqa: ARG001 — route signature parity
+    deployment_id: str,
+    user: CurrentUser = Depends(require_current_user),
+):
     init_db()
     with get_session() as session:
-        dep = session.query(PaperDeployment).filter_by(id=deployment_id).first()
-        # 404 for missing AND for not-yours: existence is private (#850 idiom).
-        if dep is None or not wallet or dep.owner_wallet != wallet.lower():
-            raise HTTPException(status_code=404, detail="Paper deployment not found")
+        dep = _owned_deployment(session, deployment_id, user.id)
         return deployment_summary(session, dep)
 
 
 @paper_router.post("/deployments/{deployment_id}/stop")
-async def stop_paper_deployment(request: Request, deployment_id: str):
-    wallet = get_verified_wallet(request)
+async def stop_paper_deployment(
+    request: Request,  # noqa: ARG001 — route signature parity
+    deployment_id: str,
+    user: CurrentUser = Depends(require_current_user),
+):
     init_db()
     with get_session() as session:
-        dep = session.query(PaperDeployment).filter_by(id=deployment_id).first()
-        if dep is None or not wallet or dep.owner_wallet != wallet.lower():
-            raise HTTPException(status_code=404, detail="Paper deployment not found")
+        dep = _owned_deployment(session, deployment_id, user.id)
         dep.status = STATUS_STOPPED
         session.commit()
         return {"deployment_id": dep.id, "status": dep.status}

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -41,6 +41,7 @@ from archimedes.api.features_routes import features_router
 from archimedes.api.generate_routes import generate_router
 from archimedes.api.leaderboard_routes import leaderboard_router
 from archimedes.api.limiter import limiter
+from archimedes.api.paper_routes import paper_router
 
 # FAIL-SOFT import: marketplace_routes → service → payments imports circlekit
 # (the circle-titanoboa-sdk VCS dependency). If that dependency fails to IMPORT
@@ -338,6 +339,13 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             # lifetime instead of being reaped once this function returns.
             _app.state.backtest_refresh_task = asyncio.create_task(backtest_refresh_loop())
             _logger.info("startup: backtest refresh scheduler armed")
+            # Paper-trading ledgers advance on the same cadence family: one
+            # appended bar per deployment per day, replayed on the graded
+            # engine (services/paper_trading.py). Same RUF006 reference rule.
+            from archimedes.services.paper_trading import paper_advance_loop
+
+            _app.state.paper_advance_task = asyncio.create_task(paper_advance_loop())
+            _logger.info("startup: paper-trading advance scheduler armed")
         else:
             _logger.info("startup: backtest refresh scheduler disabled")
     except Exception as exc:
@@ -485,6 +493,7 @@ app.include_router(config_router)
 app.include_router(agent_router)
 app.include_router(chat_router)
 app.include_router(corpus_router)
+app.include_router(paper_router)
 app.include_router(explore_router)
 app.include_router(generate_router, dependencies=[Depends(require_current_user)])
 if marketplace_router is not None:

--- a/backend/archimedes/models/paper_store.py
+++ b/backend/archimedes/models/paper_store.py
@@ -1,0 +1,84 @@
+"""Paper-trading deployments and their forward return ledgers (MVP: verdict → paper-trade).
+
+Design (Dan, 2026-08-18, validated with one amendment): a paper deployment is
+an incremental forward run of the BACKTEST engine's semantics — the engine
+that graded the verdict the user paid for — one bar per day from the deploy
+date. NOT the live signal evaluator: the divergence audit (F2/F3) established
+it grades a different strategy.
+
+The amendment: this is deliberately a SIBLING of the daily-returns machinery,
+not a tenant of it. ``strategy_daily_returns``' own documented law is
+"re-measuring a stem replaces that stem's rows wholesale" — a measurement
+store. A paper ledger obeys the OPPOSITE law: append-only per deployment,
+never rewritten, because it is a user-facing track record. Same row shape, so
+every metric function that eats (date, daily_return) series works unchanged.
+
+Provenance: ``spec_json`` snapshots the strategy spec AT DEPLOY TIME. The
+strategy row's spec can be regenerated later; the ledger must keep grading
+the spec the user actually deployed — the same lesson as backtest provenance
+(#1220): a row must not silently change what it asserts about the past.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, date, datetime
+
+from sqlalchemy import Date, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from archimedes.models.chat import Base
+
+STATUS_ACTIVE = "active"
+STATUS_STOPPED = "stopped"
+
+
+def _new_id() -> str:
+    return secrets.token_hex(16)
+
+
+class PaperDeployment(Base):
+    """One user's paper-trade of one strategy, from one start date."""
+
+    __tablename__ = "paper_deployments"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_new_id)
+    strategy_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Ownership carries BOTH identity columns during the canonical-identity
+    # transition (#1194): wallet for the SIWE model live today, user id for
+    # Better Auth once it lands. Same pattern as strategy_store.
+    owner_wallet: Mapped[str | None] = mapped_column(String(42), nullable=True)
+    owner_user_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # The deploy-time snapshot of the validated spec — the thing being graded.
+    spec_json: Mapped[str] = mapped_column(Text, nullable=False)
+    deployed_at: Mapped[date] = mapped_column(Date, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default=STATUS_ACTIVE)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    # Set when a replay disagrees with already-written ledger rows (upstream
+    # data restatement). The ledger is never rewritten; this flags that a
+    # fresh replay would tell a different story — surfaced, not hidden.
+    drift_detected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index("ix_paper_deployments_owner_wallet", "owner_wallet"),
+        Index("ix_paper_deployments_strategy", "strategy_id"),
+    )
+
+
+class PaperDailyReturn(Base):
+    """One appended daily observation of one deployment. Append-only by law."""
+
+    __tablename__ = "paper_daily_returns"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    deployment_id: Mapped[str] = mapped_column(
+        String(32), ForeignKey("paper_deployments.id", ondelete="CASCADE"), nullable=False
+    )
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    daily_return: Mapped[float] = mapped_column(Float, nullable=False)
+    appended_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+    __table_args__ = (
+        UniqueConstraint("deployment_id", "date", name="uq_paper_daily_returns_dep_date"),
+        Index("ix_paper_daily_returns_dep", "deployment_id"),
+    )

--- a/backend/archimedes/services/paper_trading.py
+++ b/backend/archimedes/services/paper_trading.py
@@ -1,0 +1,242 @@
+"""Paper trading: forward-run the GRADED engine, one appended bar per day.
+
+Why replay-then-append rather than a persisted position state machine: the
+backtest engine is a position FSM, so "today's" paper bar depends on every
+bar since deploy. Re-running the full replay daily is cheap (one strategy,
+daily bars), needs no serialized broker state, and is deterministic given the
+data. The LEDGER is still append-only — the replay only ever contributes
+dates the ledger has not seen. When a replay DISAGREES with rows already
+written (an upstream data restatement — yfinance revises history), the ledger
+is NOT rewritten: the drift is counted, logged loudly, and stamped on the
+deployment. A track record that silently rewrites itself is the exact failure
+this product exists to oppose.
+
+Replay = the same calls the grading path uses (``fetch_real_panel`` →
+``feed_factory`` → per-sleeve ``run_dsl_backtest`` with fusion's
+dollar-sleeve aggregation), so paper semantics track graded semantics by
+construction — including F1's momentum convention and whatever lands next,
+with the interpreter-parity harness holding the other side.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, date, datetime
+
+from archimedes.models.paper_store import STATUS_ACTIVE, PaperDailyReturn, PaperDeployment
+from archimedes.services.strategy_dsl import DSLError, validate_strategy_spec
+
+logger = logging.getLogger(__name__)
+
+# |replayed - ledgered| beyond this is a restatement, not float noise.
+_DRIFT_EPS = 1e-9
+
+
+class PaperReplayError(RuntimeError):
+    """Replay could not produce a trustworthy dated series (fail closed)."""
+
+
+def _sleeve_dated_returns(spec, sym: str, factory, frame) -> dict[date, float]:
+    """Dated per-bar returns for one sleeve of the deployment's universe.
+
+    backtrader starts ``next()`` (and therefore the TimeReturn series feeding
+    ``equity_curve``) only after the largest indicator warmup, so the returns
+    list is END-aligned with the feed's bar index. The tail-alignment below is
+    guarded by a hard length check — misalignment must fail loudly, because a
+    misdated ledger row is worse than no row.
+    """
+    from archimedes.services.fusion_evaluator import run_dsl_backtest
+
+    metrics = run_dsl_backtest(spec, data_feed_factory=factory, data_source_label=f"paper:{sym}")
+    curve = list(metrics.equity_curve or [])
+    if len(curve) < 2:
+        raise PaperReplayError(f"sleeve {sym}: replay produced no equity path")
+    rets = [(curve[i] - curve[i - 1]) / curve[i - 1] for i in range(1, len(curve)) if curve[i - 1] > 0]
+    idx = [d.date() if hasattr(d, "date") else d for d in frame.index]
+    if len(rets) > len(idx):
+        raise PaperReplayError(f"sleeve {sym}: {len(rets)} returns for {len(idx)} bars — alignment broken")
+    return dict(zip(idx[-len(rets) :], rets, strict=True))
+
+
+def replay_spec(spec_dict: dict, deployed_at: date) -> dict[date, float]:
+    """Full-history replay of a deployment's spec; returns {date: portfolio_return}
+    for dates >= ``deployed_at``.
+
+    Dollar-sleeve aggregation, faithful to the graded path: each symbol runs
+    as an independently-capitalized sleeve; the portfolio return on a date is
+    the equity-weighted combination of that date's sleeve returns.
+    """
+    from archimedes.services import fusion_market_data
+
+    spec = validate_strategy_spec(spec_dict)
+    panel = fusion_market_data.fetch_real_panel(spec.asset_universe)
+    if panel is None:
+        raise PaperReplayError(f"real data unavailable for universe {spec.asset_universe}")
+
+    sleeves: dict[str, dict[date, float]] = {}
+    for sym, frame in panel.frames.items():
+        factory = fusion_market_data.feed_factory(frame)
+        sleeves[sym] = _sleeve_dated_returns(spec, sym, factory, frame)
+    if not sleeves:
+        raise PaperReplayError("no sleeves replayed")
+
+    common = sorted(set.intersection(*(set(s.keys()) for s in sleeves.values())))
+    if not common:
+        raise PaperReplayError("sleeves share no dates")
+
+    # Equity-weighted dollar sleeves: each sleeve compounds independently from
+    # equal initial capital; the portfolio return is total-equity ratio.
+    equities = dict.fromkeys(sleeves, 1.0)
+    out: dict[date, float] = {}
+    for d in common:
+        total_before = sum(equities.values())
+        for sym in sleeves:
+            equities[sym] *= 1.0 + sleeves[sym][d]
+        total_after = sum(equities.values())
+        if d >= deployed_at and total_before > 0:
+            out[d] = total_after / total_before - 1.0
+    return out
+
+
+def create_deployment(
+    session,
+    *,
+    strategy_id: str,
+    spec_dict: dict,
+    owner_wallet: str | None,
+    owner_user_id: str | None = None,
+    deployed_at: date | None = None,
+) -> PaperDeployment:
+    """Snapshot the spec and open a deployment. The snapshot is the contract:
+    later regeneration of the strategy must not change what this ledger grades."""
+    spec = validate_strategy_spec(spec_dict)  # raises DSLError on junk
+    dep = PaperDeployment(
+        strategy_id=strategy_id,
+        owner_wallet=owner_wallet.lower() if owner_wallet else None,
+        owner_user_id=owner_user_id,
+        spec_json=json.dumps(spec_dict, sort_keys=True),
+        deployed_at=deployed_at or datetime.now(UTC).date(),
+        status=STATUS_ACTIVE,
+    )
+    session.add(dep)
+    session.flush()
+    logger.info("paper: deployed %s for strategy %s (spec=%s)", dep.id, strategy_id, spec.name)
+    return dep
+
+
+def advance_deployment(session, dep: PaperDeployment, *, replay=None) -> dict:
+    """Append the replay's NEW dates to the ledger; detect (never repair) drift.
+
+    Returns {"appended": n, "drift": n} — drift is overlapping dates where the
+    fresh replay disagrees with what the ledger already recorded.
+
+    ``replay`` resolves at CALL time (module attribute), not in the signature:
+    a def-time default freezes the original function and silently defeats any
+    monkeypatch — which in a hermetic test means the "stub" quietly hits the
+    real network path. Found by this module's own isolation test.
+    """
+    spec_dict = json.loads(dep.spec_json)
+    replayed = (replay or replay_spec)(spec_dict, dep.deployed_at)
+
+    existing = {
+        row.date: row.daily_return
+        for row in session.query(PaperDailyReturn).filter(PaperDailyReturn.deployment_id == dep.id)
+    }
+
+    drift = 0
+    appended = 0
+    for d, r in sorted(replayed.items()):
+        if d in existing:
+            if abs(existing[d] - r) > _DRIFT_EPS:
+                drift += 1
+        else:
+            session.add(PaperDailyReturn(deployment_id=dep.id, date=d, daily_return=r))
+            appended += 1
+
+    if drift:
+        dep.drift_detected_at = datetime.now(UTC)
+        logger.warning(
+            "paper: deployment %s — fresh replay disagrees with %d already-written ledger row(s) "
+            "(upstream data restatement). The ledger is append-only and was NOT rewritten; the "
+            "deployment is stamped drift_detected_at so the discrepancy is surfaced, not hidden.",
+            dep.id,
+            drift,
+        )
+    session.flush()
+    return {"appended": appended, "drift": drift}
+
+
+def advance_all(session) -> dict:
+    """Advance every active deployment. Per-deployment failures are isolated
+    and counted — one bad universe must not stall everyone else's ledger."""
+    deps = session.query(PaperDeployment).filter(PaperDeployment.status == STATUS_ACTIVE).all()
+    ok = failed = appended = 0
+    for dep in deps:
+        try:
+            result = advance_deployment(session, dep)
+            appended += result["appended"]
+            ok += 1
+        except (PaperReplayError, DSLError) as exc:
+            failed += 1
+            logger.warning("paper: advance failed for %s: %s", dep.id, exc)
+        except Exception:
+            failed += 1
+            logger.exception("paper: advance crashed for %s", dep.id)
+    return {"deployments": len(deps), "ok": ok, "failed": failed, "appended": appended}
+
+
+def deployment_summary(session, dep: PaperDeployment) -> dict:
+    rows = (
+        session.query(PaperDailyReturn)
+        .filter(PaperDailyReturn.deployment_id == dep.id)
+        .order_by(PaperDailyReturn.date.asc())
+        .all()
+    )
+    equity = 1.0
+    series = []
+    for row in rows:
+        equity *= 1.0 + row.daily_return
+        series.append({"date": row.date.isoformat(), "daily_return": row.daily_return, "equity_index": equity})
+    return {
+        "deployment_id": dep.id,
+        "strategy_id": dep.strategy_id,
+        "deployed_at": dep.deployed_at.isoformat(),
+        "status": dep.status,
+        "days": len(rows),
+        "total_return": equity - 1.0,
+        "drift_detected_at": dep.drift_detected_at.isoformat() if dep.drift_detected_at else None,
+        "series": series,
+    }
+
+
+async def paper_advance_loop() -> None:
+    """Long-lived task: advance every active ledger once per interval.
+
+    Same fail-soft contract as backtest_refresh_loop: a bad cycle logs and
+    retries next tick; it must never take the app down. Interval defaults to
+    daily — the ledger law makes extra runs harmless (idempotent appends).
+    """
+    import asyncio
+    import os
+
+    from archimedes.db import get_session, init_db
+
+    delay = float(os.getenv("PAPER_ADVANCE_STARTUP_DELAY_S", "240"))
+    interval_s = float(os.getenv("PAPER_ADVANCE_INTERVAL_HOURS", "24")) * 3600.0
+    await asyncio.sleep(delay)
+    while True:
+        try:
+            init_db()
+
+            def _run() -> dict:
+                with get_session() as session:
+                    summary = advance_all(session)
+                    session.commit()
+                    return summary
+
+            summary = await asyncio.to_thread(_run)
+            logger.info("paper advance: %s", summary)
+        except Exception as exc:
+            logger.warning("paper advance: cycle failed (%s: %s) — will retry next tick", type(exc).__name__, exc)
+        await asyncio.sleep(interval_s)

--- a/backend/migrations/versions/c9f2e8d4a1b7_add_paper_trading_tables.py
+++ b/backend/migrations/versions/c9f2e8d4a1b7_add_paper_trading_tables.py
@@ -7,16 +7,14 @@ strategy_daily_returns, whose own law (wholesale replace per re-measurement)
 is the opposite of what a user-facing track record may do.
 
 Revision ID: c9f2e8d4a1b7
-Revises: b41c7d9e2a05
+Revises: b7e3f1a2c9d4
 Create Date: 2026-08-18 12:00:00.000000
 
-SEQUENCING NOTE: authored against main's head b41c7d9e2a05 while PR #1194
-(Better Auth) carries 9ad1c4e2b7f0 -> b7e3f1a2c9d4 against the same parent.
-Whichever lands second must re-point onto the other's head — the two-heads
-fork has now bitten this repo twice (2026-08-03 deploy outage; #1194's CI on
-2026-08-18), so this note exists to make the third time a conscious step
-instead of a surprise. The tables are disjoint from #1194's (new paper_*
-tables only).
+SEQUENCING NOTE (resolved 2026-08-19): authored against b41c7d9e2a05 while
+PR #1194 carried 9ad1c4e2b7f0 -> b7e3f1a2c9d4 against the same parent. #1194
+merged first, so this revision re-pointed onto its head b7e3f1a2c9d4 — the
+planned step, keeping the chain serial (the two-heads fork has bitten this
+repo twice). The tables are disjoint from #1194's (new paper_* tables only).
 """
 
 from __future__ import annotations
@@ -27,7 +25,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "c9f2e8d4a1b7"
-down_revision: str | Sequence[str] | None = "b41c7d9e2a05"
+down_revision: str | Sequence[str] | None = "b7e3f1a2c9d4"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/migrations/versions/c9f2e8d4a1b7_add_paper_trading_tables.py
+++ b/backend/migrations/versions/c9f2e8d4a1b7_add_paper_trading_tables.py
@@ -1,0 +1,72 @@
+"""add paper-trading deployments and append-only daily-return ledgers
+
+MVP paper trading (Dan's design, 2026-08-18): a deployment snapshots the spec
+at deploy time and forward-runs the GRADED backtest engine one bar per day.
+The ledger table is append-only by law — deliberately a sibling of
+strategy_daily_returns, whose own law (wholesale replace per re-measurement)
+is the opposite of what a user-facing track record may do.
+
+Revision ID: c9f2e8d4a1b7
+Revises: b41c7d9e2a05
+Create Date: 2026-08-18 12:00:00.000000
+
+SEQUENCING NOTE: authored against main's head b41c7d9e2a05 while PR #1194
+(Better Auth) carries 9ad1c4e2b7f0 -> b7e3f1a2c9d4 against the same parent.
+Whichever lands second must re-point onto the other's head — the two-heads
+fork has now bitten this repo twice (2026-08-03 deploy outage; #1194's CI on
+2026-08-18), so this note exists to make the third time a conscious step
+instead of a surprise. The tables are disjoint from #1194's (new paper_*
+tables only).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c9f2e8d4a1b7"
+down_revision: str | Sequence[str] | None = "b41c7d9e2a05"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "paper_deployments",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("strategy_id", sa.String(length=64), nullable=False),
+        sa.Column("owner_wallet", sa.String(length=42), nullable=True),
+        sa.Column("owner_user_id", sa.String(length=64), nullable=True),
+        sa.Column("spec_json", sa.Text(), nullable=False),
+        sa.Column("deployed_at", sa.Date(), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("drift_detected_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_paper_deployments_owner_wallet", "paper_deployments", ["owner_wallet"])
+    op.create_index("ix_paper_deployments_strategy", "paper_deployments", ["strategy_id"])
+    op.create_table(
+        "paper_daily_returns",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("deployment_id", sa.String(length=32), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("daily_return", sa.Float(), nullable=False),
+        sa.Column("appended_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["deployment_id"], ["paper_deployments.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("deployment_id", "date", name="uq_paper_daily_returns_dep_date"),
+    )
+    op.create_index("ix_paper_daily_returns_dep", "paper_daily_returns", ["deployment_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_paper_daily_returns_dep", table_name="paper_daily_returns")
+    op.drop_table("paper_daily_returns")
+    op.drop_index("ix_paper_deployments_strategy", table_name="paper_deployments")
+    op.drop_index("ix_paper_deployments_owner_wallet", table_name="paper_deployments")
+    op.drop_table("paper_deployments")

--- a/backend/tests/services/test_paper_trading.py
+++ b/backend/tests/services/test_paper_trading.py
@@ -1,0 +1,167 @@
+"""The paper-trading laws (MVP: verdict → paper-trade).
+
+Hermetic: an in-memory SQLite session and a stubbed replay. What is pinned is
+the part that must never regress silently:
+
+  1. APPEND-ONLY: advancing twice appends nothing new the second time; a
+     replay can only ever contribute unseen dates.
+  2. DRIFT IS SURFACED, NEVER REPAIRED: when a fresh replay disagrees with
+     rows already written (upstream restatement), the ledger keeps the
+     original numbers, the deployment is stamped, and the event is logged —
+     mutation-verified: a variant that "repairs" the ledger fails these.
+  3. THE SNAPSHOT IS THE CONTRACT: mutating the strategy's spec after deploy
+     must not change what the ledger grades.
+  4. THE DEPLOY DATE SLICES THE REPLAY: history before deployed_at never
+     enters the ledger.
+  5. ONE BAD DEPLOYMENT CANNOT STALL THE REST of advance_all.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+from archimedes.models.chat import Base
+from archimedes.models.paper_store import PaperDailyReturn
+from archimedes.services.paper_trading import (
+    advance_all,
+    advance_deployment,
+    create_deployment,
+    deployment_summary,
+)
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+_SPEC = {
+    "name": "paper probe",
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "daily",
+    "entry": {"gt": ["momentum_20", 0]},
+    "exit": {"lt": ["momentum_20", -0.99]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "source_arxiv_ids": ["0706.1497"],
+    "look_ahead_safe": True,
+}
+
+_DEPLOY = date(2026, 8, 1)
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _replay_v1(spec_dict, deployed_at):
+    # A stub replay honouring the real contract: dates >= deployed_at only.
+    series = {
+        date(2026, 7, 30): 0.9,  # pre-deploy history — must never be ledgered
+        date(2026, 8, 1): 0.01,
+        date(2026, 8, 4): -0.02,
+        date(2026, 8, 5): 0.005,
+    }
+    return {d: r for d, r in series.items() if d >= deployed_at}
+
+
+def test_advance_appends_only_from_the_deploy_date():
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        out = advance_deployment(s, dep, replay=_replay_v1)
+        assert out == {"appended": 3, "drift": 0}
+        dates = [r.date for r in s.query(PaperDailyReturn).order_by(PaperDailyReturn.date)]
+        assert dates == [date(2026, 8, 1), date(2026, 8, 4), date(2026, 8, 5)]
+        assert date(2026, 7, 30) not in dates  # law 4
+
+
+def test_second_advance_is_idempotent_and_new_days_append():
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        advance_deployment(s, dep, replay=_replay_v1)
+        assert advance_deployment(s, dep, replay=_replay_v1) == {"appended": 0, "drift": 0}  # law 1
+
+        def replay_v2(spec_dict, deployed_at):
+            out = _replay_v1(spec_dict, deployed_at)
+            out[date(2026, 8, 6)] = 0.003  # the next trading day arrives
+            return out
+
+        assert advance_deployment(s, dep, replay=replay_v2) == {"appended": 1, "drift": 0}
+        assert s.query(PaperDailyReturn).count() == 4
+
+
+def test_restatement_is_surfaced_never_repaired(caplog):
+    """Law 2 — the load-bearing one. Mutation-verified: an implementation that
+    overwrites the drifted row makes BOTH assertions here fail (the stored
+    value changes, and drift reports 0 on the second pass)."""
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        advance_deployment(s, dep, replay=_replay_v1)
+
+        def restated(spec_dict, deployed_at):
+            out = _replay_v1(spec_dict, deployed_at)
+            out[date(2026, 8, 4)] = -0.5  # upstream rewrote history
+            return out
+
+        with caplog.at_level("WARNING"):
+            out = advance_deployment(s, dep, replay=restated)
+        assert out["drift"] == 1
+        row = s.query(PaperDailyReturn).filter_by(date=date(2026, 8, 4)).one()
+        assert row.daily_return == pytest.approx(-0.02)  # original stands
+        assert dep.drift_detected_at is not None
+        assert any("NOT rewritten" in r.message for r in caplog.records)
+
+
+def test_spec_snapshot_survives_strategy_mutation():
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        seen_specs = []
+
+        def spy_replay(spec_dict, deployed_at):
+            seen_specs.append(spec_dict)
+            return _replay_v1(spec_dict, deployed_at)
+
+        advance_deployment(s, dep, replay=spy_replay)
+        # The strategy gets regenerated with a different spec afterwards —
+        # the deployment must keep replaying its snapshot.
+        advance_deployment(s, dep, replay=spy_replay)
+        assert all(spec["entry"] == _SPEC["entry"] for spec in seen_specs)
+        assert json.loads(dep.spec_json)["name"] == "paper probe"
+
+
+def test_advance_all_isolates_failures():
+    from archimedes.services import paper_trading
+
+    with _session() as s:
+        good = create_deployment(s, strategy_id="ok", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        bad = create_deployment(s, strategy_id="bad", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        bad.spec_json = json.dumps({**_SPEC, "entry": {"gt": ["nonsense_metric", 0]}})
+
+        calls = {}
+
+        def selective(spec_dict, deployed_at):
+            if spec_dict["entry"] == _SPEC["entry"]:
+                calls["good"] = True
+                return _replay_v1(spec_dict, deployed_at)
+            raise paper_trading.PaperReplayError("boom")
+
+        original = paper_trading.replay_spec
+        paper_trading.replay_spec = selective
+        try:
+            out = advance_all(s)
+        finally:
+            paper_trading.replay_spec = original
+        assert out["deployments"] == 2
+        assert out["ok"] == 1 and out["failed"] == 1
+        assert calls.get("good") is True
+        assert s.query(PaperDailyReturn).filter_by(deployment_id=good.id).count() == 3
+
+
+def test_summary_compounds_the_ledger():
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        advance_deployment(s, dep, replay=_replay_v1)
+        summary = deployment_summary(s, dep)
+        assert summary["days"] == 3
+        expected = (1.01 * 0.98 * 1.005) - 1.0
+        assert summary["total_return"] == pytest.approx(expected)
+        assert summary["series"][-1]["equity_index"] == pytest.approx(1.0 + expected)

--- a/backend/tests/test_paper_routes_auth.py
+++ b/backend/tests/test_paper_routes_auth.py
@@ -1,0 +1,151 @@
+"""Paper routes are account-owned (#1194 cutover): the auth-swap contract.
+
+Post-#1194, account-first users never hold a SIWE session, so these routes
+gate on the Better Auth session and own rows by ``owner_user_id``. The linked
+wallet is provenance only. Pinned here:
+
+  1. every route 401s without a session;
+  2. deploy works for an account with NO linked wallet — the exact user the
+     swap exists for;
+  3. ownership is user-scoped: another signed-in user gets 404 (existence is
+     private) and an empty list;
+  4. owner_user_id is stamped and the linked wallet, when present, is recorded
+     as provenance.
+
+Hermetic: tmp sqlite via redirect_to_tmp_sqlite; Better Auth's session fetch
+and the spec/advance machinery are stubbed at their boundaries.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from archimedes.api import account_auth, paper_routes
+from fastapi import FastAPI
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+_SPEC = {
+    "name": "route probe",
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "daily",
+    "entry": {"gt": ["momentum_20", 0]},
+    "exit": {"lt": ["momentum_20", -0.99]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "source_arxiv_ids": ["0706.1497"],
+    "look_ahead_safe": True,
+}
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    application = FastAPI()
+    application.middleware("http")(account_auth.better_auth_session_middleware)
+    application.include_router(paper_routes.paper_router)
+    # Boundary stubs: strategy lookup/visibility and the panel-driven first
+    # advance are their own tested machinery — not this file's subject.
+    monkeypatch.setattr(paper_routes, "_spec_for_strategy", lambda *_a, **_k: dict(_SPEC))
+    monkeypatch.setattr(paper_routes, "advance_deployment", lambda *_a, **_k: {"appended": 0, "drift": 0})
+    return application
+
+
+def _session_for(user_id: str):
+    async def fetch(_request):
+        return {
+            "user": {"id": user_id, "name": user_id, "email": f"{user_id}@example.com", "emailVerified": True},
+            "session": {"id": f"s-{user_id}", "expiresAt": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+        }
+
+    return fetch
+
+
+def _client(app):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"cookie": "better-auth.session_token=opaque", "host": "archimedes-arc.com"},
+    )
+
+
+def _sign_in(monkeypatch, user_id: str):
+    monkeypatch.setattr(account_auth, "_fetch_session", _session_for(user_id))
+
+
+@pytest.mark.asyncio
+async def test_every_route_requires_a_better_auth_session(app, monkeypatch):
+    monkeypatch.setattr(account_auth, "_fetch_session", AsyncMock(return_value=None))
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        assert (await client.post("/api/paper/deployments", json={"strategy_id": "s1"})).status_code == 401
+        assert (await client.get("/api/paper/deployments")).status_code == 401
+        assert (await client.get("/api/paper/deployments/anything")).status_code == 401
+        assert (await client.post("/api/paper/deployments/anything/stop")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_account_only_user_with_no_linked_wallet_can_deploy(app, monkeypatch):
+    """The motivating case: a signed-in user who never linked a wallet. A
+    SIWE-gated implementation 401s here; the account-owned one succeeds."""
+    _sign_in(monkeypatch, "user-nowallet")
+    monkeypatch.setattr(paper_routes, "get_linked_wallet_address", lambda _r: None)
+
+    async with _client(app) as client:
+        created = await client.post("/api/paper/deployments", json={"strategy_id": "s1"})
+        assert created.status_code == 201
+        listed = await client.get("/api/paper/deployments")
+        assert listed.status_code == 200
+        assert len(listed.json()["deployments"]) == 1
+
+    from archimedes.db import get_session
+    from archimedes.models.paper_store import PaperDeployment
+
+    with get_session() as session:
+        dep = session.query(PaperDeployment).one()
+        assert dep.owner_user_id == "user-nowallet"
+        assert dep.owner_wallet is None  # provenance honestly absent
+
+
+@pytest.mark.asyncio
+async def test_ownership_is_user_scoped_and_existence_is_private(app, monkeypatch):
+    _sign_in(monkeypatch, "user-a")
+    monkeypatch.setattr(
+        paper_routes, "get_linked_wallet_address", lambda _r: "0xAbCd000000000000000000000000000000000001"
+    )
+
+    async with _client(app) as client:
+        created = await client.post("/api/paper/deployments", json={"strategy_id": "s1"})
+        assert created.status_code == 201
+        dep_id = created.json()["deployment_id"]
+
+        # Owner sees and can stop it.
+        assert (await client.get(f"/api/paper/deployments/{dep_id}")).status_code == 200
+
+    # A DIFFERENT signed-in user: 404 on get/stop (never 403 — existence is
+    # private), and an empty list. A wallet match could not help them even if
+    # they linked the same address — ownership is owner_user_id only.
+    _sign_in(monkeypatch, "user-b")
+    async with _client(app) as client:
+        assert (await client.get(f"/api/paper/deployments/{dep_id}")).status_code == 404
+        assert (await client.post(f"/api/paper/deployments/{dep_id}/stop")).status_code == 404
+        assert (await client.get("/api/paper/deployments")).json()["deployments"] == []
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client(app) as client:
+        stopped = await client.post(f"/api/paper/deployments/{dep_id}/stop")
+        assert stopped.status_code == 200
+        assert stopped.json()["status"] == "stopped"
+
+    from archimedes.db import get_session
+    from archimedes.models.paper_store import PaperDeployment
+
+    with get_session() as session:
+        dep = session.query(PaperDeployment).one()
+        assert dep.owner_user_id == "user-a"
+        assert dep.owner_wallet == "0xabcd000000000000000000000000000000000001"  # provenance, lowercased


### PR DESCRIPTION
MVP queue item 6, built to Dan's design with the validation he asked for — **verdict confirmed with one amendment** (full reasoning in the commit message):

- ✅ *Forward-run the backtest engine, not the live evaluator* — correct, and now structurally safe: the replay goes through the exact calls the grading path uses, so F1's fix (and every future one) applies to paper automatically, with #1267's parity harness holding the other interpreter.
- 🔧 *"Persisted to the existing daily-returns machinery"* — amended to a **sibling** of it: `strategy_daily_returns`' own documented law is wholesale-replace per re-measurement; a user's track record needs the opposite law (append-only, per-deployment, spec snapshotted at deploy). Same row shape, so every metric consumer works unchanged.

Three laws, each mutation-verified or adversarially pinned: **append-only** (idempotent advances), **drift surfaced never repaired** (upstream restatements stamp the deployment and log loudly — the ledger keeps its numbers), **the snapshot is the contract** (regenerating the strategy can't rewrite what the ledger grades).

**DRAFT because of migration sequencing:** `c9f2e8d4a1b7` chains on main's head; #1194 chains its two migrations on the same parent. Whichever merges second re-points — #1194 is the critical path, so this waits for it, then I re-point and mark ready. Tables are disjoint; nothing else blocks.

Full suite: **3,123 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7