### PR TITLE
CI: guard against the recurring alembic migration-chain fork

### DIFF
--- a/.github/scripts/migration_chain_guard.py
+++ b/.github/scripts/migration_chain_guard.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Alembic migration-chain fork guard (CI).
+
+The recurring failure this exists to catch: two branches each add a new
+migration whose `down_revision` points at the SAME parent — the chain head
+each branch saw when it forked from main. Whichever merges first becomes the
+new head; the other branch's migration is now parented on a revision that is
+no longer the head, which `alembic upgrade head` cannot resolve on its own —
+a silent fork. This has bitten three times already (the Aug 3 deploy, and
+twice on #1194) before this guard existed.
+
+Two different reference points are used deliberately, not interchangeably:
+  - `--base-ref`'s merge-base with HEAD scopes step (a): "which migration
+    files did THIS PR add or change" (the standard three-dot-diff idiom used
+    elsewhere in this repo, e.g. import-guard.yml).
+  - `--base-ref` itself (its CURRENT tip, freshly fetched) is the chain those
+    new migrations must extend — the actual thing "re-serialize onto main"
+    means. Using the historical merge-base for this instead would silently
+    pass a migration that forked against a revision another PR has since
+    made obsolete, which is exactly the bug class this guard exists to catch.
+
+Usage: python .github/scripts/migration_chain_guard.py [--base-ref REF]
+Exit 0 = pass (including "nothing to check"). Exit 1 = fork / stale parent
+detected, or main's own chain isn't a clean single-head chain to begin with.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+VERSIONS = "backend/migrations/versions"
+
+# Matches the shape script.py.mako generates:
+#   revision: str = "07e9c1489199"
+#   down_revision: str | Sequence[str] | None = "af9c6a9376e4"  (or None)
+REV_RE = re.compile(r'^revision(?:\s*:[^=\n]+)?\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+DOWN_RE = re.compile(r'^down_revision(?:\s*:[^=\n]+)?\s*=\s*(None|["\']([^"\']+)["\'])', re.MULTILINE)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"FAIL: `git {' '.join(args)}` failed:\n{result.stderr}")
+    return result.stdout
+
+
+def _parse(text: str, where: str) -> tuple[str, str | None]:
+    rev_m, down_m = REV_RE.search(text), DOWN_RE.search(text)
+    if not rev_m or not down_m:
+        sys.exit(
+            f"FAIL: could not find `revision =` / `down_revision =` in {where}.\n"
+            "This guard only understands a bare string or None (the standard "
+            "script.py.mako shape). A tuple down_revision (merge migration) needs "
+            "manual review — teach migration_chain_guard.py that shape if it's intentional."
+        )
+    return rev_m.group(1), (None if down_m.group(1) == "None" else down_m.group(2))
+
+
+def _chain_at(repo: Path, ref: str) -> dict[str, str | None]:
+    """revision -> down_revision for every migration file as of git ref `ref`."""
+    listing = _git(repo, "ls-tree", "-r", "--name-only", ref, "--", VERSIONS)
+    chain: dict[str, str | None] = {}
+    for path in listing.splitlines():
+        if path.endswith(".py"):
+            rev, down = _parse(_git(repo, "show", f"{ref}:{path}"), f"{path} @ {ref}")
+            chain[rev] = down
+    return chain
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-ref", default="origin/main")
+    args = ap.parse_args()
+
+    repo = Path(_git(Path("."), "rev-parse", "--show-toplevel").strip())
+    diff_base = _git(repo, "merge-base", "HEAD", args.base_ref).strip()
+
+    changed = [
+        p
+        for p in _git(repo, "diff", "--name-only", "--diff-filter=ACMR", diff_base, "HEAD", "--", VERSIONS).splitlines()
+        if p.endswith(".py")
+    ]
+    if not changed:
+        print(f"migration_chain_guard: no migration files changed vs {diff_base[:12]} — nothing to check.")
+        return 0
+
+    main_chain = _chain_at(repo, args.base_ref)
+    if main_chain:
+        heads = [r for r in main_chain if r not in main_chain.values()]
+        if len(heads) != 1:
+            print(
+                f"FAIL: {args.base_ref}'s migration chain doesn't have exactly one head "
+                f"(found {heads}) — this guard can't tell which one your migration should "
+                "extend. Fix main's chain before this guard can validate new migrations."
+            )
+            return 1
+        main_head = heads[0]
+    else:
+        main_head = None  # no migrations exist yet on base-ref
+
+    new_revs: dict[str, str | None] = {}
+    paths: dict[str, str] = {}
+    for p in changed:
+        rev, down = _parse((repo / p).read_text(), p)
+        if rev not in main_chain:  # skip edits to migrations that already exist on base-ref
+            new_revs[rev], paths[rev] = down, p
+
+    if not new_revs:
+        print("migration_chain_guard: changed migration files are all edits to existing revisions — nothing to check.")
+        return 0
+
+    roots = [rev for rev, down in new_revs.items() if down not in new_revs]
+    if not roots:
+        print(
+            f"FAIL: new migrations {list(paths.values())} form a cycle — no revision roots outside this PR's own set."
+        )
+        return 1
+    if len(roots) > 1:
+        print(
+            f"FAIL: {len(roots)} new migrations each extend from OUTSIDE this PR's own chain "
+            f"({[paths[r] for r in roots]}) instead of one linear line — only one new migration "
+            "may graft onto main; chain the rest after it."
+        )
+        return 1
+
+    root = roots[0]
+    down = new_revs[root]
+    if down != main_head:
+        print(
+            f"FAIL: {paths[root]} has down_revision={down!r}, but {args.base_ref}'s migration "
+            f"chain head is {main_head!r}.\n"
+            "Someone else's migration merged to main after you branched — re-serialize:\n"
+            "  1. git fetch origin main\n"
+            f'  2. edit down_revision in {paths[root]} to "{main_head}"\n'
+            "  3. from backend/: `alembic history` should show one unbroken chain, one head."
+        )
+        return 1
+
+    print(f"migration_chain_guard: OK — {list(paths.values())} extend {args.base_ref}'s head ({main_head}) cleanly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -56,6 +56,34 @@ jobs:
   # a path-filtered job marked as a required check never reports on PRs that
   # miss its paths, so the check sits in "Expected" forever and the PR can
   # never merge.
+  # Guards the alembic chain against the recurring fork bug: two PRs each add
+  # a migration whose down_revision points at the SAME parent (the head each
+  # saw when it branched). Whichever merges first becomes the new head; the
+  # other's migration is now parented on a stale revision — `alembic upgrade
+  # head` can't resolve that on its own. Bit three times already (the Aug 3
+  # deploy, and twice on #1194).
+  #
+  # Deliberately NOT path-filtered at the trigger level, for the same reason
+  # as infra-guards above: a path-filtered required check never reports on a
+  # PR that misses its paths, so it sits in "Expected" forever and blocks
+  # merge permanently. The script itself early-exits the moment it finds no
+  # changed migration files vs the merge-base — checkout + one git diff, no
+  # pip install — so a non-migration PR pays only a few seconds for this job.
+  migration-chain-guard:
+    name: Migrations — chain fork guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      # actions/checkout on a pull_request event does not otherwise leave a
+      # resolvable `origin/main` ref lying around — it fetches only the ref
+      # it checks out. The guard needs `origin/main` to name main's CURRENT
+      # tip, not a stale snapshot, so fetch it explicitly.
+      - run: git fetch origin main:refs/remotes/origin/main
+      - name: New migrations must extend main's current chain head, not fork it
+        run: python3 .github/scripts/migration_chain_guard.py
+
   engine-tests:
     name: Analytics engine — unit tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The alembic migration chain has forked three times already: two branches
each add a migration whose `down_revision` points at the same parent — the
chain head each branch saw when it forked from main. Whichever merges first
becomes the new head; the other's migration is now parented on a revision
that's no longer the head, which `alembic upgrade head` can't resolve on its
own. Hit on the Aug 3 deploy, and twice on #1194.

## What

- `.github/scripts/migration_chain_guard.py` — rebuilds the migration chain
  from `backend/migrations/versions/` (found via
  `find backend -path '*versions*.py'`) and fails fast, with a re-serialize
  instruction, if a newly-added migration's `down_revision` isn't the
  current head of `--base-ref`'s chain (default `origin/main`, fetched fresh
  in CI — deliberately the ref's *current* tip, not a historical merge-base
  snapshot, so a migration that's gone stale because another PR merged
  first is still caught; see the module docstring for the reasoning). A
  separate merge-base diff (`git diff --diff-filter=ACMR <merge-base>..HEAD`)
  scopes which migration files this PR actually touched, mirroring the
  three-dot idiom `import-guard.yml` already uses in this repo.
- Wired into `quality-gate.yml` as a new `migration-chain-guard` job.
  Deliberately **not** path-filtered at the trigger level — this repo has
  already hit the failure mode where a path-filtered required check never
  reports on PRs outside its paths and sits in "Expected" forever (see the
  `infra-guards`/`engine-tests`/`import-guard.yml` comments). Instead the
  script itself early-exits in a few seconds (checkout + one git diff, no
  pip install) the moment no migration files changed vs the merge-base.

## Proof it discriminates (local runs, transcript below)

Built three synthetic scenarios as throwaway branches off this repo's real
migration chain (current real head `b41c7d9e2a05`), plus a bonus fourth:

**1. Forked migration (down_revision stale relative to the base ref) → FAIL**
```
$ python3 .github/scripts/migration_chain_guard.py --base-ref test/fake-main-with-y
FAIL: backend/migrations/versions/bbbb33334444_test_pr_migration.py has down_revision='b41c7d9e2a05', but test/fake-main-with-y's migration chain head is 'aaaa11112222'.
Someone else's migration merged to main after you branched — re-serialize:
  1. git fetch origin main
  2. edit down_revision in backend/migrations/versions/bbbb33334444_test_pr_migration.py to "aaaa11112222"
  3. from backend/: `alembic history` should show one unbroken chain, one head.
exit=1
```

**2. Correctly-chained new migration → PASS**
```
$ python3 .github/scripts/migration_chain_guard.py --base-ref origin/main
migration_chain_guard: OK — ['backend/migrations/versions/cccc55556666_test_correct_migration.py'] extend origin/main's head (b41c7d9e2a05) cleanly.
exit=0
```

**3. PR touching no migration files → untouched (fast no-op)**
```
$ python3 .github/scripts/migration_chain_guard.py --base-ref origin/main
migration_chain_guard: no migration files changed vs 7aabe5d50c6b — nothing to check.
exit=0
```

**Bonus 4. Two new migrations in the same PR both grafting off the same parent → FAIL**
```
FAIL: 2 new migrations each extend from OUTSIDE this PR's own chain (['backend/migrations/versions/dddd77778888_test_intra_a.py', 'backend/migrations/versions/eeee99990000_test_intra_b.py']) instead of one linear line — only one new migration may graft onto main; chain the rest after it.
exit=1
```

Also confirmed: `ruff format --check` and `ruff check --select E9,F63,F7,F40,F82`
both pass on the new script; the edited `quality-gate.yml` parses cleanly
(`yaml.safe_load`) with the new job present alongside the existing seven.

## Scope / omissions

- Only understands a bare-string-or-`None` `down_revision` (the standard
  `script.py.mako` shape every current migration uses). A tuple
  `down_revision` (an actual alembic *merge* migration, joining two heads on
  purpose) isn't supported — the script fails loudly with a manual-review
  message rather than silently passing, since this repo has never used one
  and the "small script" brief didn't ask for it.
- Only validates newly-added revisions (by revision id, not by file diff
  status) — editing an already-existing migration's docstring/body without
  changing its `down_revision` is correctly left alone.
- Not tested against an actual GitHub Actions run (no CI trigger available
  from this environment) — verified via direct local invocation against
  real throwaway git branches instead, as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)