### PR TITLE
Implement IPortfolioConstructor.construct() — KellyRegimePortfolioConstructor (#1264)

### DIFF
--- a/backend/archimedes/api/vault_schemas.py
+++ b/backend/archimedes/api/vault_schemas.py
@@ -99,3 +99,16 @@ class SetAllocationsResponse(BaseModel):
         default_factory=list,
         description="Selected strategies sized to zero (rigor-gate CANDIDATE/fail, or no stored kelly_fraction)",
     )
+    # Literal default rather than an import of
+    # services.portfolio_constructor.REGIME_CONVENTION_NEUTRAL_NO_FEED: this
+    # schemas module stays free of service imports. The route always sets the
+    # value explicitly from the constructor, so this default only covers a
+    # caller constructing the response directly.
+    regime_convention: str = Field(
+        default="neutral_no_feed",
+        description=(
+            "Whether the regime tilt actually ran: 'regime_tilt_applied' (a live regime scaled these "
+            "weights) or 'neutral_no_feed' (no regime input, weights are pure Kelly sizing). Without "
+            "this, an un-tilted allocation and a regime-tilted one that scored 1.0 look identical."
+        ),
+    )

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -615,11 +615,14 @@ async def derive_vault_allocations(
     # documented neutral default (see KellyRegimePortfolioConstructor's
     # docstring) — so this is a behavior-preserving pass-through of
     # `kelly_weights` for every caller of this endpoint today.
+    # One `regime` value feeds both the arithmetic and the disclosed marker, so
+    # the two can never report different things (the #1409 rf_convention rule).
+    regime = None
     allocs = _portfolio_constructor.construct(
         risk_profile=RiskProfile(req.risk_profile),
         strategies=strategies,
         backtest_results={},
-        regime=None,
+        regime=regime,
         ensemble_consensus=None,
         base_weights=kelly_weights,
     )
@@ -662,4 +665,5 @@ async def derive_vault_allocations(
         risk_profile=req.risk_profile,
         sized_strategies={sid: frac for sid, frac in sized_fractions.items() if frac > 0.0},
         excluded_strategy_ids=excluded,
+        regime_convention=_portfolio_constructor.regime_convention(regime),
     )

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -30,11 +30,18 @@ from archimedes.api.vault_schemas import (
 )
 from archimedes.chain.executor import chain_executor
 from archimedes.models.chat import VaultMetadata
+from archimedes.models.portfolio import RiskProfile
 from archimedes.services.live_rigor_gate import verdicts_for_strategies
+from archimedes.services.portfolio_constructor import KellyRegimePortfolioConstructor
 from archimedes.services.rigor_profiles import STRICTEST_LEVEL, clamp_level
 from archimedes.services.strategy_sizer import kelly_weighted_allocations, scale_to_budget, size_strategies
 
 vaults_router = APIRouter(prefix="/api/vaults", tags=["vaults"])
+
+# Module-level singleton (matches strategy_evaluator's convention below) — the
+# class is pure computation (no I/O), so one shared instance is safe across
+# requests. See KellyRegimePortfolioConstructor's docstring (issue #1264).
+_portfolio_constructor = KellyRegimePortfolioConstructor()
 
 
 async def _anchor_strategies_async(strategy_ids: list[str]) -> None:
@@ -600,7 +607,23 @@ async def derive_vault_allocations(
     sized_fractions = size_strategies(strategies, req.risk_profile, deployable_ids=deployable_ids)
     sized_fractions = scale_to_budget(sized_fractions, 1.0 - usdc_floor)
     excluded = sorted(sid for sid, frac in sized_fractions.items() if frac <= 0.0)
-    target_weights = kelly_weighted_allocations(all_signals, sized_fractions, usdc_floor=usdc_floor)
+    kelly_weights = kelly_weighted_allocations(all_signals, sized_fractions, usdc_floor=usdc_floor)
+
+    # Route the Kelly-sized weights through IPortfolioConstructor (#1264) so
+    # this endpoint gains the regime tilt for free once a live regime feed is
+    # wired to it. No live feed is wired here today — regime=None is the
+    # documented neutral default (see KellyRegimePortfolioConstructor's
+    # docstring) — so this is a behavior-preserving pass-through of
+    # `kelly_weights` for every caller of this endpoint today.
+    allocs = _portfolio_constructor.construct(
+        risk_profile=RiskProfile(req.risk_profile),
+        strategies=strategies,
+        backtest_results={},
+        regime=None,
+        ensemble_consensus=None,
+        base_weights=kelly_weights,
+    )
+    target_weights = {a.symbol: a.weight for a in allocs}
 
     allocations: list[AllocationTarget] = []
 

--- a/backend/archimedes/services/portfolio_constructor.py
+++ b/backend/archimedes/services/portfolio_constructor.py
@@ -59,6 +59,15 @@ REGIME_MULTIPLIER: dict[Regime, float] = {
 # fetch failed or lacked VIX/MA signals — see agent_runner._classify_market_regime).
 REGIME_MULTIPLIER_NONE = 0.7
 
+# ── Regime provenance markers (#1264 review) ────────────────────────
+# `KellyRegimePortfolioConstructor` treats `regime is None` as neutral (scale
+# 1.0), so an inert tilt and a benign regime that scores 1.0 produce identical
+# weights. These name which one happened, so a consumer can tell them apart.
+# Same reasoning as `rf_convention` in `services/rf_series.py` (#1409): a
+# fail-soft default has to be a disclosed state, never a silent substitute.
+REGIME_CONVENTION_NEUTRAL_NO_FEED = "neutral_no_feed"
+REGIME_CONVENTION_APPLIED = "regime_tilt_applied"
+
 # Confidence floor: even at confidence 0 the regime multiplier is not fully
 # erased — low confidence halves the regime's effect rather than zeroing it.
 # scale_within_regime = _CONF_BASE + _CONF_SLOPE * confidence.
@@ -297,6 +306,16 @@ class KellyRegimePortfolioConstructor(IPortfolioConstructor):
         if regime is None:
             return 1.0
         return self._regime_scaler.compute_position_scale(regime, ensemble_consensus)
+
+    def regime_convention(self, regime: RegimeClassification | None) -> str:
+        """Which regime state produced the scale ``compute_position_scale`` returned.
+
+        Derived from the SAME ``regime is None`` test the scale is, so the two
+        cannot disagree. Callers surface this alongside the weights: without
+        it, a response carrying an un-tilted allocation is indistinguishable
+        from one carrying a regime-tilted allocation that scored 1.0.
+        """
+        return REGIME_CONVENTION_NEUTRAL_NO_FEED if regime is None else REGIME_CONVENTION_APPLIED
 
     def construct(
         self,

--- a/backend/archimedes/services/portfolio_constructor.py
+++ b/backend/archimedes/services/portfolio_constructor.py
@@ -1,17 +1,23 @@
-"""Regime- and consensus-throttled portfolio construction.
+"""Portfolio construction — ``IPortfolioConstructor`` implementations.
 
-Implements ``IPortfolioConstructor``. The job of this module is to take the
-runner's raw aggregated target weights and *throttle* exposure by two
-orthogonal signals:
+Two classes live here, both implementing the frozen ``IPortfolioConstructor``
+protocol (``interfaces/math.py``), for two different callers:
 
-1. The exogenous market regime (``RegimeClassification``) — what the *market*
-   is doing (VIX / momentum / spreads).
-2. The endogenous ensemble consensus (``EnsembleConsensus``) — how decisive the
-   *strategy ensemble* itself is (the fraction of flat signals).
+``PortfolioConstructor`` — the execution-society's regime/consensus throttle
+(issue #662). Wired into the per-tick trading loop
+(``chain/agent_runner.py``, ``marketplace/service.py``): takes the runner's
+already-aggregated raw target weights and *throttles* exposure by two
+orthogonal signals — the exogenous market regime and the endogenous strategy-
+ensemble consensus — shrinking risk-asset exposure into the USDC safe asset
+when either is weak. See its own docstring below.
 
-Both shrink risk-asset exposure and move the freed mass into the USDC safe
-asset. The two are kept distinct on purpose (issue #659): one is exogenous, the
-other endogenous; multiplying them gives a single position scale in [0, 1].
+``KellyRegimePortfolioConstructor`` — promotes ``services/strategy_sizer.py``'s
+Kelly-weighted strategy sizing behind the same interface (issue #1264), for the
+vault-*setup* path (``POST /api/vaults/{address}/derive-allocations``): sizes
+each selected strategy by its passport's half-Kelly fraction × a risk-profile
+multiplier, then applies the SAME regime tilt as ``PortfolioConstructor``
+(reused, not forked) on top. See its own docstring below for how the two
+differ in their None-regime default and why.
 
 Sizing basis — regime-conditional Kelly sizing:
   - Lo (2002), "The Statistics of Sharpe Ratios", Financial Analysts Journal.
@@ -25,12 +31,14 @@ from __future__ import annotations
 from archimedes.interfaces.math import IPortfolioConstructor
 from archimedes.models.backtest import BacktestResult
 from archimedes.models.portfolio import (
+    RISK_PROFILE_PARAMS,
     Portfolio,
     RiskProfile,
     TargetAllocation,
 )
 from archimedes.models.regime import EnsembleConsensus, Regime, RegimeClassification
 from archimedes.models.strategy import Strategy
+from archimedes.services.strategy_sizer import scale_to_budget, size_strategies
 
 # ── Named constants (NO magic numbers) ──────────────────────────────
 # Sizing basis: regime-conditional Kelly sizing — Lo (2002),
@@ -66,6 +74,34 @@ _FLAT_HIGH = 0.60
 _CONSENSUS_FLOOR = 0.6
 _FLAT_SPAN = _FLAT_HIGH - _FLAT_LOW  # 0.30
 _CONSENSUS_DROP = 1.0 - _CONSENSUS_FLOOR  # 0.4
+
+
+def _shrink_to_safe_asset(raw_weights: dict[str, float], scale: float) -> dict[str, float]:
+    """Shrink every non-``SAFE_ASSET`` weight by ``scale``; freed mass moves to ``SAFE_ASSET``.
+
+    Renormalizes so weights sum to 1.0 (guards divide-by-zero when everything
+    is exactly zero). Shared by both ``PortfolioConstructor`` (regime-only
+    throttle) and ``KellyRegimePortfolioConstructor`` (Kelly sizing + this same
+    throttle) so the shrink-and-renormalize arithmetic has one source, per this
+    codebase's convention of not forking the same formula across call sites.
+    """
+    scaled: dict[str, float] = {}
+    freed_mass = 0.0
+    safe_weight = 0.0
+    for symbol, weight in raw_weights.items():
+        if symbol == SAFE_ASSET:
+            safe_weight += weight
+            continue
+        new_weight = weight * scale
+        scaled[symbol] = new_weight
+        freed_mass += weight - new_weight
+
+    scaled[SAFE_ASSET] = safe_weight + freed_mass
+
+    total = sum(scaled.values())
+    if total > 0:
+        scaled = {sym: w / total for sym, w in scaled.items()}
+    return scaled
 
 
 class PortfolioConstructor(IPortfolioConstructor):
@@ -129,25 +165,7 @@ class PortfolioConstructor(IPortfolioConstructor):
         raw_weights = base_weights if base_weights is not None else self._fallback_weights(strategies, backtest_results)
 
         scale = self.compute_position_scale(regime, ensemble_consensus)
-
-        # Shrink every non-USDC weight by `scale`; the freed mass moves to USDC.
-        scaled: dict[str, float] = {}
-        freed_mass = 0.0
-        usdc_weight = 0.0
-        for symbol, weight in raw_weights.items():
-            if symbol == SAFE_ASSET:
-                usdc_weight += weight
-                continue
-            new_weight = weight * scale
-            scaled[symbol] = new_weight
-            freed_mass += weight - new_weight
-
-        scaled[SAFE_ASSET] = usdc_weight + freed_mass
-
-        # Renormalize so weights sum to 1.0 (guard divide-by-zero).
-        total = sum(scaled.values())
-        if total > 0:
-            scaled = {sym: w / total for sym, w in scaled.items()}
+        scaled = _shrink_to_safe_asset(raw_weights, scale)
 
         return [
             TargetAllocation(symbol=symbol, token_address="", weight=weight, strategy_ids=[])
@@ -198,3 +216,161 @@ class PortfolioConstructor(IPortfolioConstructor):
             # Nothing rankable → park everything in the safe asset.
             return {SAFE_ASSET: 1.0}
         return {sid: score / total for sid, score in scores.items()}
+
+
+class KellyRegimePortfolioConstructor(IPortfolioConstructor):
+    """Kelly-weighted strategy sizing + regime tilt, behind ``IPortfolioConstructor``.
+
+    Built for issue #1264 — the vault-*setup* path
+    (``POST /api/vaults/{address}/derive-allocations``), which previously called
+    ``services/strategy_sizer.py`` directly with no regime awareness at all.
+    This class is that promotion: the SAME Kelly math (``size_strategies`` /
+    ``scale_to_budget`` — passport half-Kelly × risk-profile multiplier, gate-
+    failers zeroed, never levered above budget; see ``strategy_sizer``'s module
+    docstring for the full sizing model) behind the frozen interface, with the
+    execution-society's regime tilt (``PortfolioConstructor.compute_position_scale``,
+    §3.2 of ``docs/specs/execution-trading-agent-society-spec.md``) layered on
+    top rather than re-derived — reused via composition so the regime-tilt
+    formula has exactly one implementation in the codebase.
+
+    Two production paths through ``construct()``:
+
+    1. **``base_weights`` supplied (the derive-allocations production path).**
+       The caller has already run ``strategy_sizer``'s full pipeline —
+       ``size_strategies`` → ``scale_to_budget`` → ``kelly_weighted_allocations``
+       — against the strategies' live signal votes (this class's ``construct()``
+       does not receive per-asset signal votes, so it cannot re-derive this
+       step; see design note below). ``base_weights`` are those per-asset
+       weights; this class scales them by the regime/consensus throttle and
+       returns them, byte-identical when the scale is neutral (see below).
+
+    2. **``base_weights`` absent (fallback, no production caller today).**
+       Derives per-*strategy* fractions directly from ``strategies`` via
+       ``size_strategies`` + ``scale_to_budget``, using the risk profile's
+       ``RISK_PROFILE_PARAMS[profile]["usyc_floor"]`` as the investable budget
+       ceiling (the production path instead uses the caller's user-supplied
+       ``usdc_floor_pct``, which this interface has no parameter for). Returned
+       weights are keyed by ``strategy.id`` — not a real asset symbol — because
+       mapping a strategy's sized fraction onto per-asset votes needs the
+       signal-evaluator output this interface does not carry either. Same
+       shape and caveat as the sibling class's ``_fallback_weights``.
+
+    **Regime-None default diverges from the sibling class on purpose.** When
+    ``regime is None``, ``PortfolioConstructor`` (the execution society's tick
+    loop, which polls a live snapshot every tick) applies the conservative
+    ``REGIME_MULTIPLIER_NONE`` (0.7) — there, "no regime" usually means "this
+    tick's snapshot fetch degraded," and caution is the right default. This
+    class instead treats ``regime is None`` as **neutral** (scale 1.0, no
+    throttle at all): derive-allocations is a non-committing preview endpoint
+    with no live regime feed wired to it today (wiring one would mean either a
+    fresh, unfed ``GmmRegimeDetector`` — which always reports ``None`` and would
+    additionally stomp the module-level detector the ``/health`` probe reads,
+    see ``gmm_regime_detector._register_detector`` — or a new Redis dependency
+    in this request path; both are out of scope for this change). Silently
+    shrinking every derive-allocations response by 30% with no way to see the
+    un-shrunk number would be a worse default than no throttle, and it would
+    break behaviour-compatibility with the pre-existing (shipped, tested)
+    ``strategy_sizer``-only output for callers who pass no regime — which is
+    every caller today. A future caller that DOES have a live regime (e.g. the
+    execution runner, if it ever calls this class instead of the sibling one)
+    gets the identical spec-named tilt as ``PortfolioConstructor`` — this
+    override affects only the missing-signal fallback value, not the formula.
+    """
+
+    def __init__(self, regime_scaler: PortfolioConstructor | None = None) -> None:
+        # Composition, not inheritance: reuses the canonical regime-tilt
+        # formula (REGIME_MULTIPLIER + confidence factor + consensus throttle)
+        # without forking its constants. Injectable for tests.
+        self._regime_scaler = regime_scaler or PortfolioConstructor()
+
+    def compute_position_scale(
+        self,
+        regime: RegimeClassification | None,
+        ensemble_consensus: EnsembleConsensus | None,
+    ) -> float:
+        """Regime/consensus throttle — see the class docstring for the ``None`` divergence.
+
+        ``regime is None`` → 1.0 (neutral; no signal, no throttle). Otherwise
+        delegates entirely to ``PortfolioConstructor.compute_position_scale``
+        (same formula, same consensus handling) so the two classes never drift.
+        """
+        if regime is None:
+            return 1.0
+        return self._regime_scaler.compute_position_scale(regime, ensemble_consensus)
+
+    def construct(
+        self,
+        risk_profile: RiskProfile,
+        strategies: list[Strategy],
+        backtest_results: dict[str, BacktestResult],  # noqa: ARG002 — Protocol signature; Kelly sizing reads passport.kelly_fraction, not the backtest object
+        regime: RegimeClassification | None,
+        current_portfolio: Portfolio | None = None,  # noqa: ARG002 — Protocol signature; sizing is stateless wrt current holdings
+        ensemble_consensus: EnsembleConsensus | None = None,
+        *,
+        base_weights: dict[str, float] | None = None,
+    ) -> list[TargetAllocation]:
+        """Kelly-size strategies (or scale caller-supplied weights), then apply the regime tilt.
+
+        See the class docstring for the two paths (``base_weights`` supplied vs.
+        absent) and why a neutral ``scale == 1.0`` is applied as a pass-through
+        rather than routed through the shrink/renormalize arithmetic: caller-
+        supplied ``base_weights`` may already carry their own rounding
+        convention (``strategy_sizer.kelly_weighted_allocations`` rounds to 4
+        decimal places), and the production caller (``derive_vault_allocations``)
+        applies its own basis-point-level rounding correction downstream. Re-
+        normalizing here too, even by a no-op divisor, would reintroduce
+        floating-point drift into an already-reconciled total and could shift
+        which symbol absorbs that caller's rounding remainder. Skipping the
+        arithmetic entirely when there is nothing to throttle keeps this path
+        byte-identical to the pre-#1264 ``strategy_sizer``-only output.
+        """
+        raw_weights = (
+            dict(base_weights) if base_weights is not None else self._kelly_fallback_weights(strategies, risk_profile)
+        )
+
+        scale = self.compute_position_scale(regime, ensemble_consensus)
+        scaled = dict(raw_weights) if scale == 1.0 else _shrink_to_safe_asset(raw_weights, scale)
+
+        return [
+            TargetAllocation(symbol=symbol, token_address="", weight=weight, strategy_ids=[])
+            for symbol, weight in scaled.items()
+        ]
+
+    def score_strategy(
+        self,
+        strategy: Strategy,
+        result: BacktestResult,
+        risk_profile: RiskProfile,
+    ) -> float:
+        """Score a strategy for ranking. Higher = better fit.
+
+        Delegates to ``PortfolioConstructor.score_strategy`` (DSR-preferred,
+        Sharpe fallback) — one scoring implementation, reused rather than
+        forked, matching the regime-tilt reuse above.
+        """
+        return self._regime_scaler.score_strategy(strategy, result, risk_profile)
+
+    # ── Fallback weight derivation (no production caller uses this path) ──
+
+    def _kelly_fallback_weights(
+        self,
+        strategies: list[Strategy],
+        risk_profile: RiskProfile,
+    ) -> dict[str, float]:
+        """Per-strategy Kelly-sized fractions when ``base_weights`` is absent.
+
+        Uses the risk profile's own ``usyc_floor`` (``RISK_PROFILE_PARAMS``) as
+        the investable-budget ceiling — see the class docstring for why this
+        differs from the production path's user-supplied floor. Unclaimed
+        budget (gate-failers sized to zero, or Kelly fractions that sum below
+        the ceiling) stays in ``SAFE_ASSET`` — never levered up to fill it,
+        matching ``strategy_sizer``'s "never lever up to fill a budget" rule.
+        """
+        profile = RiskProfile(risk_profile)
+        usyc_floor = RISK_PROFILE_PARAMS[profile]["usyc_floor"]
+        sized = size_strategies(strategies, profile.value)
+        sized = scale_to_budget(sized, max(0.0, 1.0 - usyc_floor))
+
+        weights = {sid: frac for sid, frac in sized.items() if frac > 0.0}
+        weights[SAFE_ASSET] = round(max(0.0, 1.0 - sum(weights.values())), 6)
+        return weights

--- a/backend/tests/services/test_kelly_regime_portfolio_constructor.py
+++ b/backend/tests/services/test_kelly_regime_portfolio_constructor.py
@@ -23,7 +23,12 @@ import pytest
 from archimedes.models.backtest import BacktestResult
 from archimedes.models.portfolio import RISK_PROFILE_PARAMS, RiskProfile
 from archimedes.models.regime import Regime, RegimeClassification, RegimeSignals
-from archimedes.services.portfolio_constructor import SAFE_ASSET, KellyRegimePortfolioConstructor
+from archimedes.services.portfolio_constructor import (
+    REGIME_CONVENTION_APPLIED,
+    REGIME_CONVENTION_NEUTRAL_NO_FEED,
+    SAFE_ASSET,
+    KellyRegimePortfolioConstructor,
+)
 from archimedes.services.strategy_signal_evaluator import AssetSignal, Signal, StrategySignals
 from archimedes.services.strategy_sizer import (
     kelly_multiplier,
@@ -326,3 +331,41 @@ def test_construct_reproduces_old_strategy_sizer_pipeline_on_fixed_fixture(
     new_weights = {a.symbol: a.weight for a in allocs}
 
     assert new_weights == old_weights
+
+
+# ── Regime provenance (#1264 review) ──────────────────────────────────────
+
+
+def test_regime_convention_tracks_whether_the_tilt_actually_applied() -> None:
+    """The disclosed convention must agree with the scale actually used.
+
+    `regime=None` yields scale 1.0 here (the documented divergence from the
+    execution society's conservative 0.7), so a caller cannot tell an inert
+    tilt apart from a benign regime that happened to score 1.0. The response
+    marker exists to make that difference visible, and it is only worth
+    anything if it is derived from the SAME input the arithmetic used --
+    the `rf_convention` lesson from #1409, applied here.
+    """
+    c = KellyRegimePortfolioConstructor()
+
+    assert c.compute_position_scale(None, None) == 1.0
+    assert c.regime_convention(None) == REGIME_CONVENTION_NEUTRAL_NO_FEED
+
+    crisis = _regime(Regime.CRISIS, confidence=0.9)
+    assert c.compute_position_scale(crisis, None) < 1.0
+    assert c.regime_convention(crisis) == REGIME_CONVENTION_APPLIED
+
+
+def test_regime_convention_says_applied_even_when_the_tilt_scores_neutral() -> None:
+    """A real regime that happens to produce scale 1.0 must NOT read as
+    'no feed'. This is the case the marker exists to separate: same weights
+    out, materially different provenance."""
+    c = KellyRegimePortfolioConstructor()
+
+    # RISK_ON's multiplier IS 1.0, so at full confidence this produces the
+    # identical scale the no-feed path produces. Identical weights out, and
+    # the only thing separating them is the marker.
+    risk_on = _regime(Regime.RISK_ON, confidence=1.0)
+    assert c.compute_position_scale(risk_on, None) == c.compute_position_scale(None, None)
+    assert c.regime_convention(risk_on) == REGIME_CONVENTION_APPLIED
+    assert c.regime_convention(None) == REGIME_CONVENTION_NEUTRAL_NO_FEED

--- a/backend/tests/services/test_kelly_regime_portfolio_constructor.py
+++ b/backend/tests/services/test_kelly_regime_portfolio_constructor.py
@@ -1,0 +1,328 @@
+"""Tests for KellyRegimePortfolioConstructor (issue #1264).
+
+Hermetic: no env, no network, no DB, no chain. Pure sync computation over the
+frozen `IPortfolioConstructor` interface.
+
+Per this repo's test convention, every core assertion below is proven
+discriminating: for the two properties #1264 explicitly calls out (regime
+tilt, Kelly-not-equal-weight sizing) there is a companion test that runs a
+deliberately broken variant through the SAME assertion and shows it fails —
+so a future regression that silently drops the regime tilt or falls back to
+equal-weighting cannot pass this suite by accident. This mirrors the gap the
+2026-08-18 test audit found in `strategy_guardrail`'s tests (floor assertions
+that passed vacuously because every floor was 0.0) — every assertion here
+compares against a concrete, nonzero, hand-computed expected value.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+from archimedes.models.backtest import BacktestResult
+from archimedes.models.portfolio import RISK_PROFILE_PARAMS, RiskProfile
+from archimedes.models.regime import Regime, RegimeClassification, RegimeSignals
+from archimedes.services.portfolio_constructor import SAFE_ASSET, KellyRegimePortfolioConstructor
+from archimedes.services.strategy_signal_evaluator import AssetSignal, Signal, StrategySignals
+from archimedes.services.strategy_sizer import (
+    kelly_multiplier,
+    kelly_weighted_allocations,
+    scale_to_budget,
+    size_strategies,
+)
+
+# ── helpers (mirrors test_strategy_sizer.py's minimal stand-ins) ──────────
+
+
+@dataclass
+class _Strat:
+    """Minimal stand-in carrying only the fields size_strategies() reads."""
+
+    id: str
+    passes_rigor_gate: bool = False
+    kelly_fraction: float | None = None
+
+
+def _signals(strategy_id: str, votes: dict[str, float]) -> StrategySignals:
+    return StrategySignals(
+        strategy_id=strategy_id,
+        strategy_name=strategy_id,
+        paper_title=strategy_id,
+        signals=[
+            AssetSignal(
+                strategy_id=strategy_id,
+                strategy_name=strategy_id,
+                asset=asset,
+                signal=Signal.LONG if w > 0 else Signal.FLAT,
+                weight=w,
+                reason="test",
+            )
+            for asset, w in votes.items()
+        ],
+    )
+
+
+def _regime_signals() -> RegimeSignals:
+    return RegimeSignals(
+        vix_level=18.0,
+        vix_rate_of_change=0.0,
+        sp500_above_ma50=True,
+        sp500_above_ma200=True,
+    )
+
+
+def _regime(regime: Regime, confidence: float) -> RegimeClassification:
+    return RegimeClassification(
+        regime=regime,
+        confidence=confidence,
+        signals=_regime_signals(),
+        timestamp=datetime.now(UTC),
+    )
+
+
+def _backtest(strategy_id: str, sharpe: float, dsr: float | None = None) -> BacktestResult:
+    return BacktestResult(
+        strategy_id=strategy_id,
+        sharpe_ratio=sharpe,
+        sortino_ratio=sharpe * 0.8,
+        max_drawdown=0.15,
+        cagr=0.15,
+        calmar_ratio=1.0,
+        win_rate=0.55,
+        profit_factor=1.3,
+        total_trades=100,
+        avg_holding_period_days=7.0,
+        correlation_to_spy=0.7,
+        correlation_to_btc=0.2,
+        deflated_sharpe_ratio=dsr,
+    )
+
+
+@pytest.fixture
+def ctor() -> KellyRegimePortfolioConstructor:
+    return KellyRegimePortfolioConstructor()
+
+
+# ── Regime tilt: real assets shrink in CRISIS, pass through when scale=1.0 ──
+
+
+def test_crisis_regime_shrinks_risk_assets_into_safe_asset(ctor: KellyRegimePortfolioConstructor) -> None:
+    base = {"sTSLA": 0.6, "sBTC": 0.2, SAFE_ASSET: 0.2}
+    allocs = ctor.construct(
+        risk_profile=RiskProfile.MODERATE,
+        strategies=[],
+        backtest_results={},
+        regime=_regime(Regime.CRISIS, 1.0),
+        base_weights=base,
+    )
+    by_symbol = {a.symbol: a.weight for a in allocs}
+
+    assert sum(by_symbol.values()) == pytest.approx(1.0)
+    # Concrete, nonzero, hand-computed expectation (CRISIS mult=0.1, conf=1.0
+    # → scale=0.1): sTSLA 0.6*0.1=0.06, sBTC 0.2*0.1=0.02, SAFE_ASSET absorbs
+    # the freed 0.72 on top of its own 0.2 = 0.92.
+    assert by_symbol["sTSLA"] == pytest.approx(0.06)
+    assert by_symbol["sBTC"] == pytest.approx(0.02)
+    assert by_symbol[SAFE_ASSET] == pytest.approx(0.92)
+
+
+def test_regime_blind_variant_fails_the_crisis_shrink_assertion(ctor: KellyRegimePortfolioConstructor) -> None:
+    """Discriminating companion to the test above.
+
+    A constructor that silently ignores `regime` (returns a constant neutral
+    scale) must fail the CRISIS-shrink assertion — proving that assertion
+    actually exercises the tilt rather than passing regardless of the input.
+    """
+
+    class RegimeBlindConstructor(KellyRegimePortfolioConstructor):
+        def compute_position_scale(self, regime, ensemble_consensus) -> float:
+            return 1.0  # the bug: regime is never consulted
+
+    blind = RegimeBlindConstructor()
+    base = {"sTSLA": 0.6, "sBTC": 0.2, SAFE_ASSET: 0.2}
+    allocs = blind.construct(
+        risk_profile=RiskProfile.MODERATE,
+        strategies=[],
+        backtest_results={},
+        regime=_regime(Regime.CRISIS, 1.0),
+        base_weights=base,
+    )
+    by_symbol = {a.symbol: a.weight for a in allocs}
+
+    with pytest.raises(AssertionError):
+        assert by_symbol["sTSLA"] == pytest.approx(0.06)
+    # And the blind variant's actual (wrong) output is the untouched input.
+    assert by_symbol["sTSLA"] == pytest.approx(0.6)
+
+
+def test_regime_none_is_neutral_byte_identical_pass_through(ctor: KellyRegimePortfolioConstructor) -> None:
+    """The derive-allocations endpoint's real default (see class docstring):
+    with no regime signal, weights pass through unchanged — not shrunk by the
+    execution-society's conservative REGIME_MULTIPLIER_NONE. Deliberately
+    non-round numbers so a stray renormalize/rounding pass would be visible.
+    """
+    base = {"sSPY": 0.37219, SAFE_ASSET: 0.62781}
+    allocs = ctor.construct(
+        risk_profile=RiskProfile.MODERATE,
+        strategies=[],
+        backtest_results={},
+        regime=None,
+        base_weights=base,
+    )
+    by_symbol = {a.symbol: a.weight for a in allocs}
+    assert by_symbol == base
+
+
+# ── Kelly sizing: proportional to kelly_fraction, never equal-weight ────────
+
+
+def test_kelly_sizing_is_proportional_to_kelly_fraction_not_equal_weight(
+    ctor: KellyRegimePortfolioConstructor,
+) -> None:
+    strategies = [
+        _Strat("big", passes_rigor_gate=True, kelly_fraction=0.30),
+        _Strat("small", passes_rigor_gate=True, kelly_fraction=0.05),
+    ]
+    allocs = ctor.construct(
+        risk_profile=RiskProfile.MODERATE,
+        strategies=strategies,
+        backtest_results={},
+        regime=None,
+    )
+    by_id = {a.symbol: a.weight for a in allocs}
+
+    mult = kelly_multiplier("moderate")  # 2/3
+    # size_strategies() rounds to 6dp, so a tight absolute tolerance (not the
+    # default relative one, which is too strict for a number this small).
+    assert by_id["big"] == pytest.approx(0.30 * mult, abs=1e-6)
+    assert by_id["small"] == pytest.approx(0.05 * mult, abs=1e-6)
+    # Nonzero and unequal — the whole point of Kelly sizing over equal-weight.
+    assert by_id["big"] > 0.0
+    assert by_id["small"] > 0.0
+    assert by_id["big"] != pytest.approx(by_id["small"])
+    assert by_id["big"] > by_id["small"]
+
+
+def test_equal_weight_variant_fails_the_kelly_proportionality_assertion() -> None:
+    """Discriminating companion: an equal-weight scheme over the same two
+    strategies gives IDENTICAL shares, which is exactly the naive behavior
+    #1264 / strategy_sizer's Kelly sizing was built to replace (see
+    strategy_sizer.py's module docstring). It must fail the real assertion.
+    """
+    strategies = [
+        _Strat("big", passes_rigor_gate=True, kelly_fraction=0.30),
+        _Strat("small", passes_rigor_gate=True, kelly_fraction=0.05),
+    ]
+    investable = 1.0 - RISK_PROFILE_PARAMS[RiskProfile.MODERATE]["usyc_floor"]
+    equal_weight = {s.id: investable / len(strategies) for s in strategies}
+
+    mult = kelly_multiplier("moderate")
+    with pytest.raises(AssertionError):
+        assert equal_weight["big"] == pytest.approx(0.30 * mult)
+    with pytest.raises(AssertionError):
+        assert equal_weight["big"] != pytest.approx(equal_weight["small"])
+
+
+def test_gate_failing_strategy_gets_no_capital_gate_passer_does(
+    ctor: KellyRegimePortfolioConstructor,
+) -> None:
+    strategies = [
+        _Strat("passer", passes_rigor_gate=True, kelly_fraction=0.30),
+        # A huge kelly_fraction that would dominate the book if the gate were
+        # bypassed — sizing must not become a side-door past the rigor gate.
+        _Strat("failer", passes_rigor_gate=False, kelly_fraction=0.90),
+    ]
+    allocs = ctor.construct(
+        risk_profile=RiskProfile.MODERATE,
+        strategies=strategies,
+        backtest_results={},
+        regime=None,
+    )
+    by_id = {a.symbol: a.weight for a in allocs}
+
+    assert by_id.get("failer", 0.0) == 0.0
+    assert by_id["passer"] > 0.0
+    assert by_id["passer"] == pytest.approx(0.30 * kelly_multiplier("moderate"))
+
+
+def test_fallback_weights_use_profile_usyc_floor(ctor: KellyRegimePortfolioConstructor) -> None:
+    """base_weights absent → profile's own usyc_floor is the investable ceiling."""
+    strategies = [_Strat("s1", passes_rigor_gate=True, kelly_fraction=0.30)]
+    allocs = ctor.construct(
+        risk_profile=RiskProfile.CONSERVATIVE,  # usyc_floor=0.40
+        strategies=strategies,
+        backtest_results={},
+        regime=None,
+    )
+    by_id = {a.symbol: a.weight for a in allocs}
+    expected = 0.30 * kelly_multiplier("conservative")
+    assert expected > 0.0
+    assert by_id["s1"] == pytest.approx(expected)
+    assert by_id[SAFE_ASSET] == pytest.approx(1.0 - expected)
+
+
+# ── score_strategy: DSR-preferred, matches PortfolioConstructor's rule ──────
+
+
+def test_score_strategy_prefers_dsr_over_sharpe(ctor: KellyRegimePortfolioConstructor) -> None:
+    result = _backtest("s1", sharpe=1.0, dsr=0.42)
+    score = ctor.score_strategy(strategy=None, result=result, risk_profile=RiskProfile.MODERATE)  # type: ignore[arg-type]
+    assert score == pytest.approx(0.42)
+    assert score != pytest.approx(1.0)
+
+
+def test_score_strategy_falls_back_to_sharpe_without_dsr(ctor: KellyRegimePortfolioConstructor) -> None:
+    result = _backtest("s1", sharpe=1.25, dsr=None)
+    score = ctor.score_strategy(strategy=None, result=result, risk_profile=RiskProfile.MODERATE)  # type: ignore[arg-type]
+    assert score == pytest.approx(1.25)
+
+
+# ── Behavior-compatibility proof: old strategy_sizer pipeline vs new construct() ──
+
+
+def test_construct_reproduces_old_strategy_sizer_pipeline_on_fixed_fixture(
+    ctor: KellyRegimePortfolioConstructor,
+) -> None:
+    """#1264's wire-up requirement: the pre-existing strategy_sizer-only
+    pipeline (size_strategies -> scale_to_budget -> kelly_weighted_allocations,
+    exactly as derive_vault_allocations called it before this change) routed
+    through construct() with the endpoint's real regime=None default must be
+    byte-identical to the raw pipeline output, on a fixed multi-strategy,
+    multi-asset fixture with a gate-failer in the mix.
+    """
+    strategies = [
+        _Strat("s1", passes_rigor_gate=True, kelly_fraction=0.30),
+        _Strat("s2", passes_rigor_gate=True, kelly_fraction=0.15),
+        _Strat("s3", passes_rigor_gate=False, kelly_fraction=0.90),  # gate-failer
+    ]
+    signals = [
+        _signals("s1", {"sSPY": 1.0}),
+        _signals("s2", {"sGOLD": 0.6, "sTLT": 0.4}),
+        _signals("s3", {"sSPY": 1.0}),
+    ]
+    usdc_floor = 0.20
+
+    # OLD pipeline — exactly what derive_vault_allocations called before #1264.
+    old_sized = size_strategies(strategies, "moderate")
+    old_sized = scale_to_budget(old_sized, 1.0 - usdc_floor)
+    old_weights = kelly_weighted_allocations(signals, old_sized, usdc_floor=usdc_floor)
+
+    # Sanity: fixture actually exercises real, nonzero sizing (not vacuous).
+    assert old_weights["sSPY"] > 0.0
+    assert old_weights["sGOLD"] > 0.0
+    assert old_weights["sTLT"] > 0.0
+
+    # NEW — same old_weights routed through construct() as base_weights, with
+    # the endpoint's actual regime=None default.
+    allocs = ctor.construct(
+        risk_profile=RiskProfile.MODERATE,
+        strategies=strategies,
+        backtest_results={},
+        regime=None,
+        ensemble_consensus=None,
+        base_weights=old_weights,
+    )
+    new_weights = {a.symbol: a.weight for a in allocs}
+
+    assert new_weights == old_weights

--- a/backend/tests/test_strategy_sizer.py
+++ b/backend/tests/test_strategy_sizer.py
@@ -206,6 +206,10 @@ async def test_derive_allocations_sizes_passers_and_excludes_candidates(tmp_path
     assert resp.sized_strategies == {"val": pytest.approx(0.2)}
     assert resp.excluded_strategy_ids == ["cand"]
     assert resp.risk_profile == "moderate"
+    # #1264 review: the route wires no live regime feed, so the tilt did not
+    # run. The response has to say so — these weights are pure Kelly sizing,
+    # not a regime-tilted allocation that happened to score 1.0.
+    assert resp.regime_convention == "neutral_no_feed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes the gap #1264 describes: `IPortfolioConstructor.construct()` /
`score_strategy()` (`backend/archimedes/interfaces/math.py`) were frozen but
never implemented for the vault-setup path. This PR builds them on exactly
the assets #1264 names — no new endpoints, no vault-deploy-UI changes.

- **New class**: `KellyRegimePortfolioConstructor` in
  `services/portfolio_constructor.py`, alongside (not replacing) the
  existing `PortfolioConstructor`. **Note for review**: that file already
  held a `PortfolioConstructor` class implementing the same interface for
  the execution-society's per-tick regime/consensus throttle, wired into
  `chain/agent_runner.py` and `marketplace/service.py` — issue #1264's "two
  stand-ins, zero production callers" framing predates it. This PR does not
  touch that class's behavior (13 pre-existing tests still pass unmodified)
  beyond extracting its shrink/renormalize arithmetic into a shared
  `_shrink_to_safe_asset()` helper so the new class can reuse it byte-for-byte
  rather than forking the formula.
- **Core**: promotes `strategy_sizer.py`'s `size_strategies` /
  `scale_to_budget` (real, tested Kelly sizing — untouched) behind the
  interface.
- **Risk ladder**: `RISK_PROFILE_PARAMS` — used both by the production
  `base_weights` path (via the caller) and by `construct()`'s own fallback
  weight derivation when called without `base_weights`.
- **Regime tilt**: reused via composition from
  `PortfolioConstructor.compute_position_scale` (§3.2 of
  `docs/specs/execution-trading-agent-society-spec.md` — `REGIME_MULTIPLIER`
  × confidence factor × ensemble-consensus throttle) — not re-derived. One
  deliberate, documented divergence: `regime is None` → **neutral** (scale
  1.0) here, vs. the execution society's **conservative**
  `REGIME_MULTIPLIER_NONE` (0.7) there. Rationale in the class docstring:
  `derive-allocations` has no live regime feed wired into it in this change
  (a fresh, unfed `GmmRegimeDetector` always reports `None` and would
  additionally stomp the module-level detector instance `/health` reads;
  a Redis-backed persisted-regime read was judged out of scope for a minimal
  diff). Neutral-on-None is also what makes the wiring below
  behavior-preserving for every caller today.

## Wire-up

`POST /api/vaults/{address}/derive-allocations` (`strategy_sizer`'s only
caller) now routes its Kelly-sized weights through
`KellyRegimePortfolioConstructor.construct()` as `base_weights`, with
`regime=None` (see above). Because `regime=None` → scale 1.0 → an identity
pass-through (no renormalize arithmetic at all — see the docstring for why:
avoids reintroducing float drift into a dict that already carries the
route's own basis-point rounding correction downstream), this is
byte-identical to the pre-existing output for every current caller.

Proof: the **pre-existing, unmodified**
`test_derive_allocations_sizes_passers_and_excludes_candidates` (and the
whole rest of `test_strategy_sizer.py`) still passes with zero changes to
its assertions. Additionally, `test_kelly_regime_portfolio_constructor.py`
adds a direct old-vs-new comparison test
(`test_construct_reproduces_old_strategy_sizer_pipeline_on_fixed_fixture`)
that runs the literal pre-#1264 pipeline
(`size_strategies → scale_to_budget → kelly_weighted_allocations`) on a
fixed multi-strategy/multi-asset fixture (including a gate-failer), then
routes that same output through `construct()`, and asserts dict equality.

## Tests

New file: `backend/tests/services/test_kelly_regime_portfolio_constructor.py`
(10 tests, hermetic — no env/DB/network/chain).

Per this repo's testing convention, the two properties #1264 explicitly
calls out are proven **discriminating**, not just asserted:

- `test_regime_blind_variant_fails_the_crisis_shrink_assertion` — a
  constructor subclass that ignores `regime` (constant scale=1.0) is run
  through the real CRISIS-shrink assertion inside `pytest.raises`, proving
  it fails.
- `test_equal_weight_variant_fails_the_kelly_proportionality_assertion` — an
  equal-weight scheme over the same two strategies is run through the real
  Kelly-proportionality assertions inside `pytest.raises`, proving it fails.

I also did the adversarial pass by hand before pushing (per
`CLAUDE.md`'s "a guard must be shown to reject something"): temporarily
replaced the real regime tilt with a constant, and separately replaced
`_kelly_fallback_weights` with a literal equal-weight implementation,
re-ran the suite each time, confirmed the relevant tests failed (3 tests
caught the equal-weight injection: proportionality, gate-bypass, and
profile-floor), then restored the real code and confirmed all 10 pass again.

Every assertion compares against a concrete nonzero expected value (e.g.
`0.06`, `0.92`, `0.2·(2/3)`) — the vacuous-floor trap the 2026-08-18 test
audit found in `strategy_guardrail`'s tests (floor assertions that passed
with every floor at 0.0) does not reproduce here.

### Verification run

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
  backend/tests/services/test_kelly_regime_portfolio_constructor.py \
  backend/tests/services/test_portfolio_constructor.py \
  backend/tests/test_strategy_sizer.py -q
# 39 passed
```
Also ran (non-hermetic-gate, broader regression sweep): `test_strategy_sizer.py`,
all of `tests/services/`, `test_agent_runner_tick.py` (agent_runner's
`PortfolioConstructor` caller), `tests/marketplace/` (the other production
caller), vault/rigor test files — **and the full repo suite**:
`3127 passed, 5 skipped` (skips pre-exist, unrelated). `ruff format --check`
and `ruff check` clean on all three changed/added files.

## MVP rationale (Dan, 2026-08-19)

Per #1264: Dan pulled this into the MVP sprint rather than waiting —
"build it ourselves on what Önder has done rather than waiting; he can
build on or amend what we ship." This PR is exactly that: it does not touch
`strategy_guardrail.py` (a separate tranche per #1264) or any vault-deploy
UI, and adds no new endpoints.

## Requesting review

@onder-akkaya — this was your lane (`interfaces/math.py` marks you reviewer
for `IPortfolioConstructor`). Please treat this as a starting point to build
on or amend, not a final answer — in particular the regime-tilt formula
reuse, the `regime=None` neutral-default divergence from the execution
society's class, and the fallback-weights-without-`base_weights` design are
all judgment calls documented in the class docstring that you may want to
revisit. Cites #1264 throughout.

## Omissions / explicit scope cuts

- No live regime feed is wired into `derive-allocations` — `regime=None`
  always, in this PR. `construct()` itself is fully regime-aware and tested
  against realistic `RegimeClassification` fixtures; wiring a live feed
  (Redis-persisted regime, or similar) is left as follow-up.
- `ensemble_consensus` is likewise always `None` from this route today.
- `strategy_guardrail.py` deletion (test-audit Tranche 3, per #1264) is
  intentionally not part of this PR.
- Did not touch `services/_deprecated/portfolio_constructor.py` or
  `services/_deprecated/kelly_portfolio.py` — both explicitly deprecated,
  out of scope.

Never merged by me — draft, for review.