### PR TITLE
Fix M1/M2: serve LIVE rigor verdicts to the advisor, the portfolio LLM, and vault chat

### DIFF
--- a/backend/archimedes/agents/portfolio_agent.py
+++ b/backend/archimedes/agents/portfolio_agent.py
@@ -140,8 +140,19 @@ def _format_market_scan(market_ranking: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _format_strategies(strategies: list[Any]) -> str:
-    """Render paper strategies with their backtest stats + signal rules."""
+def _format_strategies(strategies: list[Any], rigor_statuses: dict[str, str] | None = None) -> str:
+    """Render paper strategies with their backtest stats + signal rules.
+
+    ``rigor_statuses`` maps strategy id → LIVE tri-state gate status
+    ("pass" | "fail" | "pending"), computed by the caller (the advisor route
+    runs the same memoized live-gate batch that serves the library badge).
+    ``Strategy.passes_rigor_gate`` on the in-memory object is a fail-closed
+    sentinel (always ``False``, #821) and must never be presented to the LLM
+    as a verdict — before this parameter existed, every curated strategy was
+    labeled ``candidate``, so the model was systematically told the whole
+    library had failed rigor. A missing map or id renders ``pending``:
+    "verdict not computed" is honest; "candidate"/"fail" from a sentinel is not.
+    """
     rule_summary = {
         "faber": "long when price > 200-day SMA, else flat",
         "moreira": "scale exposure by target_vol / realized_vol (vol-managed)",
@@ -159,14 +170,18 @@ def _format_strategies(strategies: list[Any]) -> str:
                 return rule
         return "see paper"
 
+    _RIGOR_LABELS = {"pass": "PASS (live gate)", "fail": "FAIL (live gate)", "pending": "pending (no live verdict)"}
+
     lines: list[str] = []
     for s in strategies:
         sr = s.real_sharpe if s.real_sharpe is not None else float("nan")
         cagr = (s.real_cagr or 0.0) * 100
         rule = _summarize_rule(s)
+        status = (rigor_statuses or {}).get(s.id, "pending")
+        rigor_label = _RIGOR_LABELS.get(status, "pending (no live verdict)")
         lines.append(
             f"  - id={s.id[:8]}  title={s.paper_title}\n"
-            f"      sharpe={sr:.2f}  cagr={cagr:+.1f}%  rigor={'PASS' if s.passes_rigor_gate else 'candidate'}\n"
+            f"      sharpe={sr:.2f}  cagr={cagr:+.1f}%  rigor={rigor_label}\n"
             f"      signal rule: {rule}"
         )
     return "\n".join(lines)
@@ -181,6 +196,7 @@ def _build_user_prompt(
     market_ranking: list[dict],
     strategies: list[Any],
     scan_universe_synths: set[str],
+    rigor_statuses: dict[str, str] | None = None,
 ) -> str:
     return (
         f"## CONTEXT\n"
@@ -191,7 +207,7 @@ def _build_user_prompt(
         f"## TOP MARKET OPPORTUNITIES (live 90-day risk-adjusted ranking)\n"
         f"{_format_market_scan(market_ranking)}\n\n"
         f"## PAPER STRATEGIES (you must anchor every pick to one of these ids)\n"
-        f"{_format_strategies(strategies)}\n\n"
+        f"{_format_strategies(strategies, rigor_statuses)}\n\n"
         f"## AVAILABLE UNIVERSE (pick any of these tickers; * = appeared in top scan)\n"
         f"{_format_universe(scan_universe_synths)}\n\n"
         f"## YOUR TASK\n"
@@ -290,6 +306,7 @@ class PortfolioAgent:
         strategies: list,
         scan_universe_synths: set[str],
         price_histories: dict,
+        rigor_statuses: dict[str, str] | None = None,
     ) -> AgentPortfolio | None:
         """Multi-turn tool-use portfolio construction.
 
@@ -322,6 +339,7 @@ class PortfolioAgent:
             market_ranking,
             strategies,
             scan_universe_synths,
+            rigor_statuses,
         )
 
         messages: list[dict] = [{"role": "user", "content": user}]
@@ -451,6 +469,7 @@ class PortfolioAgent:
         market_ranking: list[dict],
         strategies: list[Any],
         scan_universe_synths: set[str],
+        rigor_statuses: dict[str, str] | None = None,
     ) -> AgentPortfolio | None:
         if not self.available:
             logger.info("PortfolioAgent unavailable — no LLM backend configured")
@@ -472,6 +491,7 @@ class PortfolioAgent:
             market_ranking,
             strategies,
             scan_universe_synths,
+            rigor_statuses,
         )
 
         try:
@@ -825,6 +845,7 @@ def _build_tool_user_prompt(
     market_ranking: list[dict],
     strategies: list,
     scan_universe_synths: set[str],
+    rigor_statuses: dict[str, str] | None = None,
 ) -> str:
     """Same context as single-turn, but framed for an investigative agent."""
     return (
@@ -836,7 +857,7 @@ def _build_tool_user_prompt(
         f"## TOP MARKET OPPORTUNITIES (live 90-day risk-adjusted ranking)\n"
         f"{_format_market_scan(market_ranking)}\n\n"
         f"## PAPER STRATEGIES (anchor every pick to one of these ids)\n"
-        f"{_format_strategies(strategies)}\n\n"
+        f"{_format_strategies(strategies, rigor_statuses)}\n\n"
         f"## AVAILABLE UNIVERSE (pick from here; * = appeared in top market scan)\n"
         f"{_format_universe(scan_universe_synths)}\n\n"
         f"## YOUR PROCESS\n"

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -750,6 +750,22 @@ async def get_portfolio_advisor(
     except Exception:
         market_ranking = []
 
+    # Live rigor gate (#821/#868) — computed BEFORE the portfolio LLM runs, as
+    # ONE memoized batch (the same machinery + cache entry the library list
+    # uses), serving three consumers from a single computation:
+    #   * the LLM prompt's per-strategy rigor label — the in-memory
+    #     Strategy.passes_rigor_gate is a fail-closed sentinel (always False),
+    #     and presenting it to the model as a verdict told it every curated
+    #     strategy had failed the gate;
+    #   * the per-pick badge in the response (_rigor_fields);
+    #   * the five numeric rigor statistics in the response, previously served
+    #     from the frozen fixture fields on the in-memory objects.
+    # Both layers fail closed without raising: an empty batch result maps every
+    # id to a "pending" verdict, never a fabricated pass.
+    advisor_results = await asyncio.to_thread(_live_rigor_results_for_strategies, strategies)
+    advisor_verdicts = {s.id: _verdict_from_result(advisor_results.get(s.id)) for s in strategies}
+    rigor_statuses = {sid: v.status for sid, v in advisor_verdicts.items()}
+
     agent = get_portfolio_agent()
     agent_portfolio = None
     if agent.available and market_ranking:
@@ -766,6 +782,7 @@ async def get_portfolio_advisor(
                     strategies,
                     set(DEFAULT_SCAN_UNIVERSE),
                     price_histories,
+                    rigor_statuses,
                 ),
                 timeout=120.0,
             )
@@ -784,6 +801,7 @@ async def get_portfolio_advisor(
                         market_ranking,
                         strategies,
                         set(DEFAULT_SCAN_UNIVERSE),
+                        rigor_statuses,
                     ),
                     timeout=60.0,
                 )
@@ -808,13 +826,8 @@ async def get_portfolio_advisor(
 
     strat_by_id = {s.id: s for s in strategies}
 
-    # Live rigor verdicts (#821): the advisor's per-pick badge must come from the
-    # LIVE gate on real persisted returns, NOT the in-memory Strategy.passes_rigor_gate
-    # (which strategy_provider initialises to False/fail-closed so no fixture leaks).
-    # Computed once here and reused by _rigor_fields so this surface matches the
-    # library list. verdicts_for_strategies is itself fail-closed (→ all "pending"),
-    # so it never raises into this route.
-    advisor_verdicts = verdicts_for_strategies(strategies)
+    # advisor_verdicts / advisor_results were computed above, BEFORE the
+    # portfolio LLM call, so the prompt and this response share one live-gate run.
 
     from archimedes.services.stress_engine import stress_all as _stress_all
 
@@ -924,14 +937,22 @@ async def get_portfolio_advisor(
         # the in-memory object). Fail-closed to "pending" if the strategy isn't in the
         # verdict map (it always should be, but never claim an unearned pass).
         _verdict = advisor_verdicts.get(st.id)
+        # Numeric rigor stats from the SAME live gate run that produced the badge
+        # (#868 contract, mirrored from _to_strategy_response): the fixture fields
+        # on the in-memory object are frozen values the live gate never wrote, so
+        # serving them next to a live badge let the advisor's numbers disagree
+        # with GET /api/selection-bias/gate. Fall back to the stored fixture value
+        # only when the live gate could not run for this strategy — the fallback
+        # is the documented #868 behavior, only the preferred source changes.
+        _live = advisor_results.get(st.id)
         return {
             "passes_rigor_gate": _verdict.passes if _verdict else False,
             "rigor_gate_status": _verdict.status if _verdict else "pending",
-            "deflated_sharpe_ratio": st.deflated_sharpe_ratio,
-            "dsr_p_value": st.dsr_p_value,
-            "num_trials_in_selection": st.num_trials_in_selection,
-            "pbo_score": st.pbo_score,
-            "out_of_sample_sharpe": st.out_of_sample_sharpe,
+            "deflated_sharpe_ratio": _live.deflated_sharpe if _live else st.deflated_sharpe_ratio,
+            "dsr_p_value": _live.dsr_p_value if _live else st.dsr_p_value,
+            "num_trials_in_selection": _live.num_trials if _live else st.num_trials_in_selection,
+            "pbo_score": _live.pbo_score if _live else st.pbo_score,
+            "out_of_sample_sharpe": _live.oos_sharpe if _live else st.out_of_sample_sharpe,
             "paper_claimed_sharpe": st.paper_claimed_sharpe,
             "paper_claimed_cagr": st.paper_claimed_cagr,
             "paper_claimed_max_dd": st.paper_claimed_max_dd,

--- a/backend/archimedes/services/chat_service.py
+++ b/backend/archimedes/services/chat_service.py
@@ -49,6 +49,40 @@ AI_WALLET_ADDRESS = os.getenv(
 CHAT_MODEL = os.getenv("CHAT_MODEL", "").strip() or None
 
 
+def _curated_rigor_statuses(strategies: list) -> dict[str, str]:
+    """LIVE tri-state rigor statuses ("pass"|"fail"|"pending") for chat context.
+
+    ``Strategy.passes_rigor_gate`` on the in-memory provider object is a
+    fail-closed sentinel (always ``False``, #821) — presenting it as a verdict
+    told the vault-chat LLM that every curated strategy had failed the gate.
+    This reuses the library list's memoized live-gate batch over the full
+    library cohort (same cohort context, same cache entry, so a warm library
+    page makes this free) and reduces each requested strategy to its tri-state
+    status. Any failure returns ``{}`` and the caller omits the rigor line
+    entirely — this context builder's law is "missing data is omitted, never
+    invented".
+    """
+    if not strategies:
+        return {}
+    try:
+        # Service→api import mirrors the existing precedent in
+        # live_rigor_gate._load_strategy_code_safe; local so module import stays light.
+        from archimedes.api.strategies_routes import (
+            _live_rigor_results_for_strategies,
+            _verdict_from_result,
+        )
+        from archimedes.services.strategy_provider import default_provider
+
+        cohort = list(default_provider().list_strategies())
+        cohort_ids = {c.id for c in cohort}
+        cohort.extend(s for s in strategies if s.id not in cohort_ids)
+        results = _live_rigor_results_for_strategies(cohort)
+        return {s.id: _verdict_from_result(results.get(s.id)).status for s in strategies}
+    except Exception:
+        logger.debug("live rigor statuses for chat context failed (line omitted)", exc_info=True)
+        return {}
+
+
 def _generated_context_lines(strategy_id: str) -> list[str]:
     """Curated-provider miss → look up a GENERATED strategy directly from the
     unified strategy_passports store, so a generated-strategy vault's chat gets
@@ -342,16 +376,29 @@ class ChatService:
                         from archimedes.services.strategy_provider import default_provider
 
                         provider = default_provider()
-                        for sid in strategy_ids[:3]:
-                            s = provider.get_strategy(sid)
+                        found = [(sid, provider.get_strategy(sid)) for sid in strategy_ids[:3]]
+                        # LIVE tri-state verdicts, batched once (M2 fix). The
+                        # in-memory passes_rigor_gate is a fail-closed sentinel,
+                        # not a verdict — the old line told the LLM every curated
+                        # strategy was "not passed".
+                        rigor_statuses = _curated_rigor_statuses([s for _, s in found if s])
+                        rigor_labels = {
+                            "pass": "passed (live gate)",
+                            "fail": "failed (live gate)",
+                            "pending": "pending — no live backtest verdict yet",
+                        }
+                        for sid, s in found:
                             if s:
                                 parts.append(f"Strategy: {s.paper_title}")
                                 if s.methodology_summary:
                                     parts.append(f"Methodology: {s.methodology_summary[:400]}")
                                 if s.asset_universe:
                                     parts.append(f"Assets: {', '.join(s.asset_universe)}")
-                                rigor = "passed" if s.passes_rigor_gate else "not passed"
-                                parts.append(f"Rigor gate: {rigor}")
+                                label = rigor_labels.get(rigor_statuses.get(s.id, ""))
+                                if label:
+                                    parts.append(f"Rigor gate: {label}")
+                                # No live status (batch failed) → the rigor line is
+                                # omitted, never invented from the sentinel.
                             else:
                                 # Curated provider miss — GENERATED strategy vault
                                 # (unify-source decouple): fall back to the unified

--- a/backend/tests/services/test_chat_service.py
+++ b/backend/tests/services/test_chat_service.py
@@ -334,3 +334,111 @@ class TestGenerateAiResponse:
         finally:
             monkeypatch.delenv("CHAT_MODEL", raising=False)
             importlib.reload(mod)
+
+
+class TestVaultContextLiveRigor:
+    """The vault-chat context's rigor line must be a LIVE verdict or absent.
+
+    ``Strategy.passes_rigor_gate`` on the in-memory provider object is a
+    fail-closed sentinel (always ``False``, #821). Pre-fix,
+    ``_build_vault_context`` rendered it as "Rigor gate: not passed" for every
+    curated strategy — the vault chat LLM was told the whole library had
+    failed. The builder's own law is "missing data is omitted, never
+    invented": when no live status is available the rigor line must be
+    OMITTED, not fabricated from the sentinel. Every stub strategy here is
+    poisoned so a sentinel-reading mutant renders the wrong text and fails.
+    """
+
+    def _context_with(self, statuses: dict[str, str]) -> str:
+        from archimedes.services.chat_service import ChatService
+
+        meta = MagicMock()
+        meta.name = "Test Vault"
+        meta.get_strategy_ids.return_value = ["sid1"]
+        session, _ = _make_session([meta])
+
+        strat = MagicMock()
+        strat.id = "sid1"
+        strat.paper_title = "Faber TAA"
+        strat.methodology_summary = "10-month SMA timing"
+        strat.asset_universe = ["SPY"]
+        strat.passes_rigor_gate = False  # POISON: sentinel-reader renders "not passed"
+
+        provider = MagicMock()
+        provider.get_strategy.return_value = strat
+
+        with (
+            patch("archimedes.db.get_session", return_value=session),
+            patch("archimedes.services.strategy_provider.default_provider", return_value=provider),
+            patch("archimedes.services.chat_service._curated_rigor_statuses", return_value=statuses),
+        ):
+            return ChatService()._build_vault_context("0xVault")
+
+    def test_live_pass_renders_passed_never_the_sentinel(self) -> None:
+        ctx = self._context_with({"sid1": "pass"})
+        assert "Rigor gate: passed (live gate)" in ctx
+        assert "not passed" not in ctx
+
+    def test_live_fail_renders_failed(self) -> None:
+        ctx = self._context_with({"sid1": "fail"})
+        assert "Rigor gate: failed (live gate)" in ctx
+
+    def test_pending_is_stated_honestly(self) -> None:
+        ctx = self._context_with({"sid1": "pending"})
+        assert "Rigor gate: pending — no live backtest verdict yet" in ctx
+
+    def test_no_live_status_omits_the_line_never_invents_it(self) -> None:
+        # Batch failure → {}: pre-fix code invented "Rigor gate: not passed"
+        # from the poisoned sentinel; the fixed builder omits the line.
+        ctx = self._context_with({})
+        assert "Rigor gate" not in ctx
+        assert "Faber TAA" in ctx  # the rest of the context still renders
+
+
+class TestCuratedRigorStatuses:
+    """_curated_rigor_statuses reduces the memoized live-gate batch to tri-states."""
+
+    def _statuses(self, batch_results, batch_raises=False):
+        from archimedes.services.chat_service import _curated_rigor_statuses
+
+        strat = MagicMock()
+        strat.id = "sid1"
+
+        provider = MagicMock()
+        provider.list_strategies.return_value = []
+
+        if batch_raises:
+
+            def batch(_cohort):
+                raise RuntimeError("db down")
+        else:
+
+            def batch(_cohort):
+                return batch_results
+
+        with (
+            patch("archimedes.services.strategy_provider.default_provider", return_value=provider),
+            patch("archimedes.api.strategies_routes._live_rigor_results_for_strategies", side_effect=batch),
+        ):
+            return _curated_rigor_statuses([strat])
+
+    def test_passing_result_maps_to_pass(self) -> None:
+        result = MagicMock()
+        result.passes_all = True
+        assert self._statuses({"sid1": result}) == {"sid1": "pass"}
+
+    def test_failing_result_maps_to_fail(self) -> None:
+        result = MagicMock()
+        result.passes_all = False
+        assert self._statuses({"sid1": result}) == {"sid1": "fail"}
+
+    def test_absent_result_maps_to_pending(self) -> None:
+        assert self._statuses({}) == {"sid1": "pending"}
+
+    def test_batch_failure_returns_empty_so_caller_omits(self) -> None:
+        assert self._statuses(None, batch_raises=True) == {}
+
+    def test_empty_input_short_circuits(self) -> None:
+        from archimedes.services.chat_service import _curated_rigor_statuses
+
+        assert _curated_rigor_statuses([]) == {}

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -759,6 +759,92 @@ class TestAdvisorRoutes:
         # Without Redis the regime defaults to "transition"
         assert data["regime"] == "transition"
 
+    def test_advisor_serves_live_rigor_numbers_not_fixture(self, client, seeded_db):
+        """M1: the five numeric rigor stats must come from the SAME live-gate
+        batch that produces the badge, not the frozen fixture fields on the
+        in-memory Strategy objects. The sentinel values below exist in no
+        fixture; against the pre-fix route (which served ``st.<field>``)
+        every assertion here fails."""
+        from archimedes.api import strategies_routes as sr
+        from archimedes.services.rigor_evaluator import RigorGateResult
+
+        def fake_batch(strategies):
+            return {
+                s.id: RigorGateResult(
+                    strategy_id=s.id,
+                    deflated_sharpe=1.2468,
+                    dsr_p_value=0.97531,
+                    num_trials=1,
+                    pbo_score=0.13579,
+                    oos_sharpe=0.86421,
+                    look_ahead_passed=True,
+                )
+                for s in strategies
+            }
+
+        with patch.object(sr, "_live_rigor_results_for_strategies", side_effect=fake_batch):
+            resp = client.get("/api/strategies/advisor?risk_profile=moderate")
+        assert resp.status_code == 200
+        allocations = resp.json()["allocations"]
+        assert allocations, "advisor returned no allocations to check"
+        for alloc in allocations:
+            assert alloc["deflated_sharpe_ratio"] == pytest.approx(1.2468)
+            assert alloc["dsr_p_value"] == pytest.approx(0.97531)
+            assert alloc["num_trials_in_selection"] == 1
+            assert alloc["pbo_score"] == pytest.approx(0.13579)
+            assert alloc["out_of_sample_sharpe"] == pytest.approx(0.86421)
+
+    def test_advisor_passes_live_rigor_statuses_to_portfolio_llm(self, client, seeded_db):
+        """M2: the portfolio LLM must receive the LIVE tri-state statuses,
+        computed BEFORE the agent call. The in-memory ``passes_rigor_gate``
+        sentinel (always False) told the model every curated strategy had
+        failed the gate; pre-fix the route passed no status map at all, so
+        the captured final positional arg here is not a status dict and the
+        assertions fail."""
+        from archimedes.services.strategy_signal_evaluator import strategy_evaluator
+
+        captured = {}
+
+        class _StubAgent:
+            available = True
+            model_id = "stub"
+
+            def propose_portfolio_with_tools(self, *args):
+                captured["with_tools"] = args
+                return None
+
+            def propose_portfolio(self, *args):
+                captured["plain"] = args
+                return None
+
+        fake_ranking = [
+            {
+                "synth": "sSPY",
+                "display": "SPY",
+                "asset_class": "equity_us",
+                "score": 1.0,
+                "momentum_90d": 0.1,
+                "vol_ann": 0.2,
+                "exchange": "US",
+            }
+        ]
+
+        with (
+            # get_portfolio_agent is imported inside the route function, so it
+            # must be patched at its source module.
+            patch("archimedes.agents.portfolio_agent.get_portfolio_agent", return_value=_StubAgent()),
+            patch.object(strategy_evaluator, "rank_market", return_value=fake_ranking),
+        ):
+            resp = client.get("/api/strategies/advisor?risk_profile=moderate")
+        assert resp.status_code == 200
+        assert "with_tools" in captured, "portfolio agent was never invoked"
+        statuses = captured["with_tools"][-1]
+        assert isinstance(statuses, dict) and statuses, "final arg must be the rigor-status map"
+        assert all(isinstance(k, str) and v in {"pass", "fail", "pending"} for k, v in statuses.items())
+        # The plain (non-tool) fallback call must carry the same map.
+        assert "plain" in captured
+        assert captured["plain"][-1] == statuses
+
 
 class TestFusionEvaluatorIntegration:
     """Tests for fusion_evaluator wiring in _run_fusion_job.

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -811,11 +811,9 @@ class TestAdvisorRoutes:
 
             def propose_portfolio_with_tools(self, *args):
                 captured["with_tools"] = args
-                return None
 
             def propose_portfolio(self, *args):
                 captured["plain"] = args
-                return None
 
         fake_ranking = [
             {

--- a/backend/tests/test_portfolio_agent_prompt.py
+++ b/backend/tests/test_portfolio_agent_prompt.py
@@ -66,16 +66,16 @@ def test_format_strategies_without_statuses_says_pending_never_candidate():
 def test_both_prompt_builders_thread_the_status_map():
     strategies = [_Strategy("dddd4444", poisoned_gate=True)]
     statuses = {"dddd4444": "fail"}
-    common = dict(
-        regime="risk_on",
-        regime_confidence=0.8,
-        risk_profile="moderate",
-        usdc_floor=0.2,
-        synth_budget=0.8,
-        market_ranking=[],
-        strategies=strategies,
-        scan_universe_synths=set(),
-    )
+    common = {
+        "regime": "risk_on",
+        "regime_confidence": 0.8,
+        "risk_profile": "moderate",
+        "usdc_floor": 0.2,
+        "synth_budget": 0.8,
+        "market_ranking": [],
+        "strategies": strategies,
+        "scan_universe_synths": set(),
+    }
     for builder in (_build_user_prompt, _build_tool_user_prompt):
         prompt = builder(**common, rigor_statuses=statuses)
         assert "rigor=FAIL (live gate)" in prompt

--- a/backend/tests/test_portfolio_agent_prompt.py
+++ b/backend/tests/test_portfolio_agent_prompt.py
@@ -1,0 +1,84 @@
+"""The portfolio LLM prompt must carry LIVE rigor verdicts, never the sentinel.
+
+``Strategy.passes_rigor_gate`` on in-memory provider objects is a fail-closed
+sentinel (always ``False``, #821). Before the M2 fix, ``_format_strategies``
+rendered it as a verdict — ``rigor=candidate`` for every curated strategy — so
+the portfolio-construction model was systematically told the whole library had
+failed the gate.
+
+Adversarial construction: every stub strategy here carries a POISONED
+``passes_rigor_gate`` attribute that CONTRADICTS the live status passed in. A
+mutant that reads the attribute (the pre-fix behavior) renders the wrong label
+and fails these tests; the pre-fix code itself fails them on the ``candidate``
+string it can't stop emitting.
+"""
+
+from __future__ import annotations
+
+from archimedes.agents.portfolio_agent import (
+    _build_tool_user_prompt,
+    _build_user_prompt,
+    _format_strategies,
+)
+
+
+class _Strategy:
+    def __init__(self, sid: str, poisoned_gate: bool):
+        self.id = sid
+        self.paper_title = f"Paper {sid}"
+        self.real_sharpe = 1.1
+        self.real_cagr = 0.12
+        self.strategy_code_path = "strategies/faber_taa.py"
+        # POISON: contradicts the live status the test passes in. Reading this
+        # attribute (instead of the status map) flips the rendered label.
+        self.passes_rigor_gate = poisoned_gate
+
+
+def _block_for(out: str, sid: str) -> str:
+    """The 3-line block rendered for one strategy id."""
+    blocks = out.split("  - id=")
+    for block in blocks:
+        if block.startswith(sid[:8]):
+            return block
+    raise AssertionError(f"no block rendered for {sid}: {out!r}")
+
+
+def test_format_strategies_renders_live_statuses_not_the_attribute():
+    # aaa: live says PASS but the attribute is poisoned False (attribute-reader → candidate).
+    # bbb: live says FAIL but the attribute is poisoned True (attribute-reader → PASS).
+    strategies = [_Strategy("aaaa1111", poisoned_gate=False), _Strategy("bbbb2222", poisoned_gate=True)]
+    out = _format_strategies(strategies, {"aaaa1111": "pass", "bbbb2222": "fail"})
+
+    assert "rigor=PASS (live gate)" in _block_for(out, "aaaa1111")
+    assert "rigor=FAIL (live gate)" in _block_for(out, "bbbb2222")
+    assert "candidate" not in out
+
+
+def test_format_strategies_without_statuses_says_pending_never_candidate():
+    # Poisoned True: the pre-fix code renders "rigor=PASS" from the attribute —
+    # an unearned pass — and "candidate" for a False one. Both are forbidden.
+    out = _format_strategies([_Strategy("cccc3333", poisoned_gate=True)])
+    assert "rigor=pending (no live verdict)" in out
+    assert "candidate" not in out
+    assert "PASS" not in out
+
+
+def test_both_prompt_builders_thread_the_status_map():
+    strategies = [_Strategy("dddd4444", poisoned_gate=True)]
+    statuses = {"dddd4444": "fail"}
+    common = dict(
+        regime="risk_on",
+        regime_confidence=0.8,
+        risk_profile="moderate",
+        usdc_floor=0.2,
+        synth_budget=0.8,
+        market_ranking=[],
+        strategies=strategies,
+        scan_universe_synths=set(),
+    )
+    for builder in (_build_user_prompt, _build_tool_user_prompt):
+        prompt = builder(**common, rigor_statuses=statuses)
+        assert "rigor=FAIL (live gate)" in prompt
+        # The exact pre-fix label ("candidate" alone also appears as legitimate
+        # prose in the tool prompt's process steps).
+        assert "rigor=candidate" not in prompt


### PR DESCRIPTION
## What

Fixes the two remaining **M-class audit findings** from the 22-agent test-suite/chaff audit (2026-08-17): every LLM surface and the `/advisor` response now serve **live rigor-gate verdicts** — never the frozen fixture statistics and never the fail-closed sentinel presented as a verdict.

**M1 — `/advisor` served five frozen rigor statistics.** The route live-corrected only the badge; `deflated_sharpe_ratio`, `dsr_p_value`, `num_trials_in_selection`, `pbo_score`, and `out_of_sample_sharpe` came from the fixture fields on the in-memory `Strategy` objects — values the live gate never wrote, which could disagree with `GET /api/selection-bias/gate` for the same strategy at the same moment. The route now runs the **same memoized live-gate batch the library list uses** (`_live_rigor_results_for_strategies`, the #868 machinery — same cohort context, same cache entry) and serves badge + numbers from that **single computation**. Fixture values remain only as the documented #868 fallback when the live gate cannot run (no/insufficient persisted returns).

**M2 — the portfolio LLM and vault chat were told every curated strategy fails rigor.** `Strategy.passes_rigor_gate` on in-memory provider objects is a fail-closed sentinel (**always `False`**, #821 — correct at that layer, so no fixture boolean can leak). Two downstream readers presented the sentinel as a verdict:

- `portfolio_agent._format_strategies` rendered `rigor=candidate` for every strategy in the portfolio-construction prompt (both the single-turn and tool-use paths, `/advisor`'s agent calls);
- `chat_service._build_vault_context` rendered `Rigor gate: not passed` for every curated strategy in the vault-chat context.

The prompt builders now take a live tri-state status map (`pass`/`fail`/`pending`) computed by the route **before** the LLM call. Vault chat batches the same memoized live gate and, when no live status is available, **omits the rigor line entirely** — per that builder's own documented law, "missing data is omitted, never invented."

## Why it matters

The #1 rule: claims must be true on the live path. An LLM constructing portfolios while told the entire curated library failed the gate is reasoning from a fabricated premise; an advisor response whose numbers disagree with the gate route undermines the rigor wedge that is the product's core claim.

## Verification (adversarial pass)

Every stub strategy in the new tests carries a **poisoned `passes_rigor_gate` that contradicts the live status**, so a sentinel-reading mutant renders the wrong label and fails. Mutation-verified by reverting each source file to `main` and re-running its tests:

| Reverted file | Result |
|---|---|
| `strategies_routes.py` | both advisor tests FAIL — the numbers test caught the route serving `0.545957` (the actual fixture DSR) instead of the live sentinel value; the statuses test caught `price_histories` arriving where the status map belongs |
| `portfolio_agent.py` | all 3 prompt tests FAIL (`rigor=candidate` / unearned `rigor=PASS` from the poisoned attribute) |
| `chat_service.py` | all 9 chat tests FAIL (invented `Rigor gate: not passed`; helper missing) |

**Local suite**: `python -m pytest -m "not integration" -q` from repo root — **3133 passed, 3 skipped (pre-existing: chain-settings defaults ×2, fee-cap parity awaiting #1129), 0 failed** in 3m33s.

## Notes for review

- **Latency**: the advisor previously ran `verdicts_for_strategies` (unmemoized) per request; it now shares the library list's `rigor_cache` entry, so a warm cache makes this *faster*, and the batch runs in a thread (`asyncio.to_thread`) instead of blocking the event loop as before.
- **Consistency**: the advisor badge now comes from the exact batch the library list serves, so the two surfaces can no longer disagree on a verdict (previously they used different cohort filtering).
- **`num_trials_in_selection` now serves `1`** for live-graded curated strategies — self-contained per the num-trials decouple (curated = 1 trial), replacing whatever the fixture froze. This is the correct convention, not a regression.
- **stockbench eval adapter** calls `propose_portfolio` without a status map → its prompts now say `rigor=pending (no live verdict)` instead of `rigor=candidate`. Honest for an eval harness; flagging for awareness.
- **Scope**: the audit finding named the five gate statistics. Other fixture-sourced display fields (`sharpe_ci_*`, `n_obs_daily`, `real_*` metrics) are unchanged — separate surface, separate decision.
- **Service→api import** in `chat_service._curated_rigor_statuses` follows the existing precedent (`live_rigor_gate._load_strategy_code_safe`); local import, fail-safe to `{}`.
- No migration, no contract changes, no UI changes. No overlap with #1194's hunks in these files (verified against its diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
