### PR TITLE
[docs] ADR amendments: fixture-leak class (num-trials) + honest engine census and #1242 provenance (backtrader)

### DIFF
--- a/docs/adr/backtrader-backtest-engine.md
+++ b/docs/adr/backtrader-backtest-engine.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Archimedes team
 > **Status:** Accepted
-> **Date:** 2026-05-13 (recommended); ratified in the Day-3 sync — exact ratification date not recorded in git [unestablished — needs Dan]; closed as Accepted 2026-07-28
+> **Date:** 2026-05-13 (recommended); ratified in the Day-3 sync — exact ratification date not recorded in git [unestablished — needs Dan]; closed as Accepted 2026-07-28; amended 2026-08-19 (engine census + provenance columns)
 > **Owner:** Dan Browne
 > **Supersedes:** —
 > **Superseded-by:** —
@@ -268,3 +268,42 @@ rewrite.
 
 *(The three items above were the memo's "open questions". They are not open decisions —
 they are known properties of the chosen engine, recorded here as costs.)*
+
+## Amendment (2026-08-19): the engine census as it actually stands, and extended provenance
+
+This ADR chose backtrader as "the" engine. Two and a half months on, the honest census —
+per the `backtest_results.backtest_engine` discriminator this ADR mandated (the
+`_SEARCH_TRACKED_ENGINES` handling in
+[`selection_bias_routes.py`](../../backend/archimedes/api/selection_bias_routes.py)) —
+is **three engine tags, each with a distinct role**, and this amendment records them so
+the record matches reality:
+
+- **`backtrader`** — the per-strategy grading engine, exactly as decided above. The
+  rigor gate's substrate; unchanged.
+- **`dsl-fusion`** — the DSL generation path's evaluator
+  (`dsl_to_backtrader`; backtrader under the hood, tagged separately because its
+  `num_trials` carries the generation pool — see
+  [`num-trials-self-containment.md`](num-trials-self-containment.md)).
+- **`portfolio-simulator-v1`** — a numpy dollar-sleeve **portfolio** simulator in
+  [`portfolio_backtester.py`](../../backend/archimedes/services/portfolio_backtester.py),
+  serving portfolio-level questions (`backtest_portfolio`, `sensitivity_sweep`) that a
+  per-strategy Cerebro run does not answer (the "no native multi-strategy run" cost
+  above). It is a *companion* surface, not a rival grading engine.
+
+**Disposition after the 2026-08 chaff/test-suite audit:** much of
+`portfolio_backtester.py` was found structurally dead on the production pipeline —
+"bypassed, never decommissioned" (its Phase-2.2 rigor-overlay helpers and the
+`capacity_decay` loop had no live callers). [PR #1259](https://github.com/a-apin/archimedes/pull/1259)
+(in review at the time of this amendment) deletes the dead clusters with their tests;
+the surviving `portfolio-simulator-v1` surface is exactly `backtest_portfolio` +
+`sensitivity_sweep`. Historical `backtest_results` rows tagged
+`portfolio-simulator-v1` remain valid provenance — the tag did its job.
+
+**Provenance extended beyond the engine tag** ([PR #1242](https://github.com/a-apin/archimedes/pull/1242),
+merged, migration `b41c7d9e2a05`): `backtest_results` now also carries
+`cost_model_id` (which cost floor priced the run) and `look_ahead_audit_source`
+(AST audit vs. closed-DSL self-attestation — the distinction matters for generated
+strategies). The "engine provenance is recorded per result" consequence above now
+covers *how* a result was costed and audited, not just which engine produced it.
+Per-engine row counts are a live-DB question (`GROUP BY source_pipeline,
+backtest_engine`); no number is stated here by design.

--- a/docs/adr/num-trials-self-containment.md
+++ b/docs/adr/num-trials-self-containment.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Archimedes team
 > **Status:** **Accepted, pending quant sign-off** (Önder Akkaya, portfolio math — see "Ratification" below)
-> **Date:** 2026-07-09 (reversal shipped); spec addendum 2026-07-14
+> **Date:** 2026-07-09 (reversal shipped); spec addendum 2026-07-14; amended 2026-08-19 (fixture-leak class)
 > **Owner:** Dan Browne (quant reviewer of record: Önder Akkaya)
 > **Supersedes:** the `N + library_size` DSR convention from [#770](https://github.com/a-apin/archimedes/issues/770) / #811 / [#820](https://github.com/a-apin/archimedes/issues/820)
 > **Superseded-by:** —
@@ -153,3 +153,32 @@ rests on.
   honest floor; the residual author-side selection bias is a known, unmodelled term.
 - **Keep a portfolio-level correction inside the gate — rejected** as answering the wrong
   question at the wrong surface; see the open gap above.
+
+## Amendment (2026-08-19): the fixture-leak class
+
+The convention marker (Decision #4) protects verdicts computed *by the gate*. The
+2026-08 test-suite/chaff audit found a failure class it does not protect against:
+**surfaces that serve rigor values from the frozen strategy fixtures instead of a live
+gate run.** The fixture fields (`Strategy.dsr_p_value`, `num_trials_in_selection`,
+`pbo_score`, `deflated_sharpe_ratio`, `out_of_sample_sharpe`, and the
+`passes_rigor_gate` boolean) are stored values the live gate never rewrites — most
+predate the 2026-07-09 reversal, so a surface serving them next to a live badge
+**silently mixes conventions**, exactly what the marker exists to prevent, without ever
+touching the marker.
+
+Live instance (audit finding M1, fixed in
+[PR #1272](https://github.com/a-apin/archimedes/pull/1272)): `/api/strategies/advisor`
+served five fixture statistics — including a fixture-era `num_trials_in_selection` —
+with only the badge live-corrected, so its numbers could disagree with
+`GET /api/selection-bias/gate` for the same strategy at the same moment. The sibling
+finding (M2, same PR) was the *sentinel* variant: readers presenting the fail-closed
+in-memory `passes_rigor_gate = False` (#821) to LLM prompts as if it were a verdict.
+
+**Rule this amendment records:** a served rigor statistic or verdict must come from a
+live `run_rigor_gate` computation (directly or via the honest memoized batch in
+`rigor_cache` — a cache hit serves exactly what the miss would have computed). Fixture
+fields may appear only as the explicitly-documented fallback when the live gate cannot
+run for a strategy (#868 contract), and the fail-closed sentinel is never a verdict —
+downstream consumers render "pending"/omission, not "fail". The leaderboard (#868), the
+library badge (#821), the advisor, the portfolio LLM prompt, and vault chat (#1272) now
+all comply; any new consumer of these fields starts from this rule.


### PR DESCRIPTION
## What

The two ADR amendments left for this session, unblocked by the docs restructure (#1225).

**`num-trials-self-containment.md`** — records the **fixture-leak class**: the `num_trials_convention` marker protects verdicts computed by the gate, but not surfaces that serve rigor values from the frozen strategy fixtures — most of which predate the 2026-07-09 reversal, so serving them beside a live badge silently mixes conventions without touching the marker. The live instance was audit finding M1 (`/advisor`'s five fixture statistics, fixed in #1272), with M2 as the sentinel variant. The amendment states the rule: served rigor values come from a live `run_rigor_gate` computation (or its honest memoized batch); fixture fields only as the documented #868 fallback; the fail-closed sentinel is never a verdict.

**`backtrader-backtest-engine.md`** — records the engine census as it actually stands (`backtrader` | `dsl-fusion` | `portfolio-simulator-v1`, each with its distinct role — verified against the code sites that write each tag), `portfolio-simulator-v1`'s post-audit disposition (dead clusters deleted by #1259, in review; surviving surface is exactly `backtest_portfolio` + `sensitivity_sweep`), and the #1242 provenance columns (`cost_model_id`, `look_ahead_audit_source`) extending per-result provenance beyond the engine tag.

## Notes

- Doc-only; no code. `make docs-check` passes (staleness warnings pre-existing).
- Deliberately **no pass counts or row counts** anywhere — per the no-numbers-in-docs rule, live-DB questions stay live-DB questions.
- Amendments are additive sections with dated front-matter updates — no rewriting of the decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7