### PR TITLE
Tranche 5: the 22 funds-adjacent tests the deletions fund (G1/G2/G3)

### DIFF
--- a/backend/tests/marketplace/test_fee_unit_scale.py
+++ b/backend/tests/marketplace/test_fee_unit_scale.py
@@ -1,0 +1,128 @@
+"""G3: pin the fee's UNIT SCALE with literals, and let the real ``_charge_one`` run.
+
+Audit finding (2026-08-18): every existing charge test re-derived its
+expectation from the live ``FLAT_FEE_PER_ACTION`` symbol and every ``tick()``
+test monkeypatched the charge away — so a 10⁶ unit-scale regression would have
+kept the whole suite green at 100% file coverage. The literals below are the
+only assertions in the repo that break when the SCALE (not the logic) moves.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from archimedes.marketplace.service import FLAT_FEE_PER_ACTION, MarketService, Publisher, Subscriber
+from archimedes.marketplace.tick_registry import TickStep
+
+
+def test_flat_fee_per_action_is_100_raw_microusdc():
+    # 100 raw 6-decimal USDC units = $0.000100 per action. If this fails,
+    # either the price changed on purpose (update this literal AND the
+    # fee_to_price literals below together) or a unit-scale regression is
+    # trying to ship. Deliberately a literal — never re-derive from the
+    # constant under test.
+    assert FLAT_FEE_PER_ACTION == 100
+
+
+def test_fee_to_price_pins_the_six_decimal_dollar_scale():
+    from archimedes.marketplace.payments import fee_to_price
+
+    assert fee_to_price(1, 100) == "$0.000100"  # one action at the shipped fee
+    assert fee_to_price(3, 100) == "$0.000300"
+    assert fee_to_price(0, 100) == "$0.000000"  # zero-action tick is free
+    assert fee_to_price(1, 1_000_000) == "$1.000000"  # 10^6 raw = exactly one dollar
+
+
+def _live_service_with_one_sub():
+    svc = MarketService(interval_seconds=9999, payments_dry_run=False, paper_trading=True)
+    svc._claim_settlement_intent = MagicMock(return_value="claimed")
+    svc._finalize_settlement_intent = MagicMock()
+    pub = Publisher(
+        strategy_id="strat_fee",
+        pool_id="0x" + "aa" * 32,
+        vault_address="0xpub_vault",
+        creator_wallet="0xpublisher",
+        gateway_seller_address="0xgateway_seller",
+    )
+    sub = Subscriber(
+        sub_id="0x" + "cd" * 32,
+        pool_id="0x" + "bb" * 32,
+        vault_address="0xsub_vault",
+        ephemeral_wallet="0xephemeral",
+        subscriber_wallet="0xsubscriber",
+        active=True,
+        circle_wallet_id="wallet_circle_id",
+    )
+    return svc, pub, sub
+
+
+@pytest.mark.asyncio
+async def test_real_charge_one_debits_the_literal_fee_from_the_right_wallets():
+    """The REAL ``_charge_one`` runs (payments_dry_run=False) against a stubbed
+    payment client: the debited flat fee is the literal 100 raw, the spend-cap
+    reservation matches it exactly, and the charge is billed from the
+    subscriber's Circle wallet to the publisher's seller address."""
+    svc, pub, sub = _live_service_with_one_sub()
+
+    charged: dict = {}
+    reserved: dict = {}
+
+    async def fake_charge(**kwargs):
+        charged.update(kwargs)
+        return True
+
+    async def fake_reserve(wallet, amount, charge_id):
+        reserved.update(wallet=wallet, amount=amount, charge_id=charge_id)
+        return True
+
+    with (
+        patch("archimedes.marketplace.service.payments.charge", fake_charge),
+        patch("archimedes.marketplace.service.spend_cap.try_reserve_usdc", fake_reserve),
+    ):
+        paid, override = await svc._charge_one(pub, sub, "strat_fee", "tick-1", TickStep.LOAD_STRATEGY, action_count=1)
+
+    assert paid is True and override is None
+    assert charged["flat_fee_raw"] == 100  # the literal — not a re-derivation
+    assert reserved["amount"] == 100  # reservation and charge must agree on scale
+    assert reserved["wallet"] == "0xsubscriber"  # cap is per SIWE wallet, not per sub
+    assert charged["wallet_id"] == "wallet_circle_id"
+    assert charged["wallet_address"] == "0xephemeral"
+    assert charged["seller_address"] == "0xgateway_seller"
+    assert charged["action_count"] == 1
+    svc._finalize_settlement_intent.assert_called_once_with(
+        "strat_fee", "tick-1", sub.sub_id, TickStep.LOAD_STRATEGY.value, settled=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_charge_releases_the_exact_reserved_amount():
+    """A refused charge must hand back precisely what it reserved — same
+    wallet, same charge id, same raw amount — or the 24h cap silently leaks."""
+    svc, pub, sub = _live_service_with_one_sub()
+
+    released: dict = {}
+
+    async def fake_charge(**kwargs):
+        return False
+
+    async def fake_reserve(wallet, amount, charge_id):
+        return True
+
+    async def fake_release(wallet, charge_id, amount):
+        released.update(wallet=wallet, charge_id=charge_id, amount=amount)
+
+    with (
+        patch("archimedes.marketplace.service.payments.charge", fake_charge),
+        patch("archimedes.marketplace.service.spend_cap.try_reserve_usdc", fake_reserve),
+        patch("archimedes.marketplace.service.spend_cap.release_reservation", fake_release),
+    ):
+        paid, _ = await svc._charge_one(pub, sub, "strat_fee", "tick-2", TickStep.LOAD_STRATEGY, action_count=1)
+
+    assert paid is False
+    assert released["amount"] == 100
+    assert released["wallet"] == "0xsubscriber"
+    assert released["charge_id"] == f"tick-2:{sub.sub_id}:{TickStep.LOAD_STRATEGY.value}"
+    svc._finalize_settlement_intent.assert_called_once_with(
+        "strat_fee", "tick-2", sub.sub_id, TickStep.LOAD_STRATEGY.value, settled=False
+    )

--- a/backend/tests/marketplace/test_settlement.py
+++ b/backend/tests/marketplace/test_settlement.py
@@ -268,3 +268,122 @@ async def test_sweep_skips_missing_wallet_info(sweeper, pub):
         await sweeper.sweep_publisher(pub)
         mock_a.assert_not_called()
         mock_b.assert_not_called()
+
+
+# ── G1: the live money-out paths (audit 2026-08-18: withdraw_subscriber was
+# 4/18 statements covered, withdraw_publisher 4/16 — only dry-run and guard
+# clauses executed; the balance read, executor construction, and ERC-20
+# transfer had never run under test). Everything below exercises the LIVE
+# path with a stubbed executor at the module boundary.
+
+
+@pytest.mark.asyncio
+async def test_withdraw_publisher_live_calls_splitter_withdraw(sweeper, pub, splitter_addr):
+    """Stage C live: the exact PaymentSplitter.withdraw calldata, from the
+    publisher's own executor, and the tx hash surfaced to the caller."""
+    executor = MagicMock()
+    executor._submit_and_wait = MagicMock(return_value="0xtxStageC")
+    sweeper._get_executor = MagicMock(return_value=executor)
+
+    tx = await sweeper.withdraw_publisher(pub, 5_000_000)
+
+    assert tx == "0xtxStageC"
+    executor._submit_and_wait.assert_called_once_with(
+        splitter_addr, "withdraw(bytes32,uint256)", [pub.pool_id, "5000000"]
+    )
+    sweeper._get_executor.assert_called_once_with(pub.agent_wallet_id, pub.gateway_seller_address)
+
+
+@pytest.mark.asyncio
+async def test_withdraw_publisher_without_splitter_never_reaches_chain(settings, pub):
+    settings.payment_splitter_address = ""
+    sweeper = SettlementSweeper(settings)
+    executor = MagicMock()
+    executor._submit_and_wait = MagicMock(side_effect=AssertionError("no splitter configured — must not reach chain"))
+    sweeper._get_executor = MagicMock(return_value=executor)
+
+    assert await sweeper.withdraw_publisher(pub, 1_000_000) is None
+    executor._submit_and_wait.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_withdraw_publisher_chain_failure_returns_none_never_raises(sweeper, pub):
+    executor = MagicMock()
+    executor._submit_and_wait = MagicMock(side_effect=RuntimeError("chain down"))
+    sweeper._get_executor = MagicMock(return_value=executor)
+
+    assert await sweeper.withdraw_publisher(pub, 1_000_000) is None
+
+
+@pytest.mark.asyncio
+async def test_withdraw_subscriber_returns_exact_balance_to_the_siwe_wallet(sweeper, settings):
+    """The three claims the docstring makes and nothing checked (G1):
+    the transfer amount EQUALS the balance read (not a caller-supplied
+    number), the token is the configured USDC contract, and the destination
+    is the subscriber's own SIWE wallet — not the DCW. Executed FROM the
+    DCW: the executor is bound to (circle_wallet_id, dcw_address). A mutant
+    that swaps destination and DCW, or invents an amount, fails here."""
+    sweeper._usdc_balance_of = MagicMock(return_value=7_250_000)
+    executor = MagicMock()
+    executor._submit_and_wait = MagicMock(return_value="0xtxReturn")
+    sweeper._get_executor = MagicMock(return_value=executor)
+
+    tx = await sweeper.withdraw_subscriber(
+        circle_wallet_id="w-dcw-1",
+        dcw_address="0xDCW0000000000000000000000000000000000001",
+        to_wallet="0xS1WE0000000000000000000000000000000000001",
+        sub_id="sub-9",
+    )
+
+    assert tx == "0xtxReturn"
+    sweeper._usdc_balance_of.assert_called_once_with("0xDCW0000000000000000000000000000000000001")
+    executor._submit_and_wait.assert_called_once_with(
+        settings.usdc_address,
+        "transfer(address,uint256)",
+        ["0xS1WE0000000000000000000000000000000000001", "7250000"],
+    )
+    sweeper._get_executor.assert_called_once_with("w-dcw-1", "0xDCW0000000000000000000000000000000000001")
+
+
+@pytest.mark.asyncio
+async def test_withdraw_subscriber_empty_dcw_transfers_nothing(sweeper):
+    sweeper._usdc_balance_of = MagicMock(return_value=0)
+    sweeper._get_executor = MagicMock(side_effect=AssertionError("empty DCW — executor must not be built"))
+
+    tx = await sweeper.withdraw_subscriber(circle_wallet_id="w-1", dcw_address="0xdcw", to_wallet="0xto", sub_id="s")
+
+    assert tx is None
+    sweeper._get_executor.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", ["circle_wallet_id", "dcw_address", "to_wallet"])
+async def test_withdraw_subscriber_missing_identifier_short_circuits(sweeper, missing):
+    kwargs = {"circle_wallet_id": "w-1", "dcw_address": "0xdcw", "to_wallet": "0xto", "sub_id": "s"}
+    kwargs[missing] = ""
+    sweeper._usdc_balance_of = MagicMock(side_effect=AssertionError("must not read balance with missing ids"))
+
+    assert await sweeper.withdraw_subscriber(**kwargs) is None
+    sweeper._usdc_balance_of.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_withdraw_subscriber_failed_sweep_is_recoverable_by_retry(sweeper):
+    """The docstring's promise, previously unchecked: 'a failed sweep leaves
+    the balance recoverable by a later retry.' Nothing may mark the sweep
+    done on failure — the retry must re-read the balance and transfer the
+    full amount. A mutant that records the attempt as settled fails here."""
+    sweeper._usdc_balance_of = MagicMock(return_value=3_000_000)
+    executor = MagicMock()
+    executor._submit_and_wait = MagicMock(side_effect=[RuntimeError("circle 502"), "0xretryTx"])
+    sweeper._get_executor = MagicMock(return_value=executor)
+
+    first = await sweeper.withdraw_subscriber(circle_wallet_id="w-1", dcw_address="0xdcw", to_wallet="0xto", sub_id="s")
+    second = await sweeper.withdraw_subscriber(
+        circle_wallet_id="w-1", dcw_address="0xdcw", to_wallet="0xto", sub_id="s"
+    )
+
+    assert first is None  # failure surfaced softly, never raised
+    assert second == "0xretryTx"
+    assert sweeper._usdc_balance_of.call_count == 2  # retry re-reads, no sticky state
+    assert executor._submit_and_wait.call_args[0][2] == ["0xto", "3000000"]  # full balance again

--- a/backend/tests/marketplace/test_wallet_provisioner.py
+++ b/backend/tests/marketplace/test_wallet_provisioner.py
@@ -1,0 +1,251 @@
+"""Hermetic tests for Circle DCW provisioning (audit gap G2).
+
+Before these, ``_create_circle_wallet`` measured 1/28 statements covered,
+``_find_wallet_by_ref`` 1/12, ``_encrypt_entity_secret`` 1/7 — every
+subscriber's custodial wallet is minted in code that had effectively never
+run under test, including the double-provision guard.
+
+No network: the module's ``aiohttp`` reference is swapped for a URL-routing
+fake session that records every POST. The entity-secret encryption is
+exercised for REAL — a test RSA keypair decrypts the posted ciphertext back
+to the entity secret, so the OAEP/SHA-256 path is proven, not mocked away.
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+
+import pytest
+from archimedes.marketplace import wallet_provisioner as wp
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+ENTITY_SECRET_HEX = "ab" * 32  # 32 bytes, valid hex — shape of a real entity secret
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return key, pem
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeSession:
+    """Routes requests by (method, URL fragment); records every POST payload."""
+
+    def __init__(self, routes: dict):
+        self.routes = routes
+        self.posts: list[dict] = []
+
+    def get(self, url, **kwargs):
+        return self._route("GET", url)
+
+    def post(self, url, json=None, **kwargs):
+        self.posts.append(json)
+        return self._route("POST", url)
+
+    def _route(self, method: str, url: str):
+        for (m, frag), resp in self.routes.items():
+            if m == method and frag in url:
+                return resp
+        raise AssertionError(f"unrouted request: {method} {url}")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _install(monkeypatch, session: _FakeSession, pem: str | None = None):
+    """Point the module's aiohttp at the fake and seed Circle creds."""
+    monkeypatch.setattr(wp, "aiohttp", SimpleNamespace(ClientSession=lambda: session))
+    monkeypatch.setenv("CIRCLE_API_KEY", "test-api-key")
+    monkeypatch.setenv("CIRCLE_ENTITY_SECRET", ENTITY_SECRET_HEX)
+
+
+def _pubkey_route(pem: str):
+    return ("GET", "config/entity/publicKey"), _FakeResp(200, {"data": {"publicKey": pem}})
+
+
+def _created_route(wallet_id="w-created-1", address="0xWa11e70000000000000000000000000000000001"):
+    return (
+        ("POST", "developer/wallets"),
+        _FakeResp(201, {"data": {"wallet": {"id": wallet_id, "address": address}}}),
+    )
+
+
+class TestCreateCircleWallet:
+    @pytest.mark.asyncio
+    async def test_happy_path_creates_wallet_and_really_encrypts_the_entity_secret(self, monkeypatch, rsa_keypair):
+        key, pem = rsa_keypair
+        session = _FakeSession(dict([_pubkey_route(pem), _created_route()]))
+        _install(monkeypatch, session)
+
+        wallet_id, address = await wp.provision_subscriber_wallet("0xsubid")
+
+        assert (wallet_id, address) == ("w-created-1", "0xWa11e70000000000000000000000000000000001")
+        assert len(session.posts) == 1
+        payload = session.posts[0]
+        assert payload["blockchain"] == wp.CIRCLE_BLOCKCHAIN
+        assert {"name": "ref", "value": "sub:0xsubid"} in payload["metadata"]
+        # THE load-bearing assertion: decrypt the posted ciphertext with the
+        # test private key and require the original entity secret back. A
+        # mutant that skips encryption, encrypts the wrong bytes, or uses the
+        # wrong padding cannot produce this plaintext.
+        plaintext = key.decrypt(
+            base64.b64decode(payload["entitySecretCiphertext"]),
+            padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None),
+        )
+        assert plaintext == bytes.fromhex(ENTITY_SECRET_HEX)
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_is_deterministic_per_ref(self, monkeypatch, rsa_keypair):
+        """The docstring's idempotency claim: a retry for the SAME ref must
+        reuse the SAME key (so Circle returns the existing wallet), and a
+        different ref must get a different key (so wallets never collide)."""
+        _, pem = rsa_keypair
+        session = _FakeSession(dict([_pubkey_route(pem), _created_route()]))
+        _install(monkeypatch, session)
+
+        await wp.provision_subscriber_wallet("0xsame")
+        await wp.provision_subscriber_wallet("0xsame")
+        await wp.provision_publisher_wallet("0xsame")  # different ref namespace: pub: vs sub:
+
+        keys = [p["idempotencyKey"] for p in session.posts]
+        assert keys[0] == keys[1], "same ref must reuse the same idempotency key"
+        assert keys[2] != keys[0], "a different ref must never share an idempotency key"
+
+    @pytest.mark.asyncio
+    async def test_conflict_returns_the_existing_wallet_instead_of_a_duplicate(self, monkeypatch, rsa_keypair):
+        """409 = the idempotency key already minted a wallet. The guard must
+        surface THAT wallet (found by metadata ref), not raise and not mint."""
+        _, pem = rsa_keypair
+        listing = _FakeResp(
+            200,
+            {
+                "data": {
+                    "wallets": [
+                        {"id": "w-other", "address": "0xother", "metadata": [{"name": "ref", "value": "sub:zzz"}]},
+                        {
+                            "id": "w-existing",
+                            "address": "0xExisting",
+                            "metadata": [{"name": "ref", "value": "sub:0xdup"}],
+                        },
+                    ]
+                }
+            },
+        )
+        session = _FakeSession(
+            {
+                ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("POST", "developer/wallets"): _FakeResp(409, {"code": "conflict"}),
+                ("GET", "developer/wallets"): listing,
+            }
+        )
+        _install(monkeypatch, session)
+
+        wallet_id, address = await wp.provision_subscriber_wallet("0xdup")
+
+        assert (wallet_id, address) == ("w-existing", "0xExisting")
+        assert len(session.posts) == 1  # exactly one creation attempt — no duplicate mint
+
+    @pytest.mark.asyncio
+    async def test_conflict_with_no_findable_wallet_raises(self, monkeypatch, rsa_keypair):
+        _, pem = rsa_keypair
+        session = _FakeSession(
+            {
+                ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("POST", "developer/wallets"): _FakeResp(409, {"code": "conflict"}),
+                ("GET", "developer/wallets"): _FakeResp(200, {"data": {"wallets": []}}),
+            }
+        )
+        _install(monkeypatch, session)
+
+        with pytest.raises(RuntimeError, match="conflict but could not find"):
+            await wp.provision_subscriber_wallet("0xghost")
+
+    @pytest.mark.asyncio
+    async def test_api_error_raises_with_status(self, monkeypatch, rsa_keypair):
+        _, pem = rsa_keypair
+        session = _FakeSession(
+            {
+                ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("POST", "developer/wallets"): _FakeResp(500, {"error": "boom"}),
+            }
+        )
+        _install(monkeypatch, session)
+
+        with pytest.raises(RuntimeError, match="500"):
+            await wp.provision_subscriber_wallet("0xerr")
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_fail_before_any_network(self, monkeypatch):
+        def _no_session():
+            raise AssertionError("no credentials — must not open a session")
+
+        monkeypatch.setattr(wp, "aiohttp", SimpleNamespace(ClientSession=_no_session))
+        monkeypatch.delenv("CIRCLE_API_KEY", raising=False)
+        monkeypatch.delenv("CIRCLE_ENTITY_SECRET", raising=False)
+
+        with pytest.raises(RuntimeError, match="credentials not configured"):
+            await wp.provision_subscriber_wallet("0xnocreds")
+
+
+class TestFindWalletByRef:
+    @pytest.mark.asyncio
+    async def test_matches_on_metadata_ref(self):
+        listing = _FakeResp(
+            200,
+            {
+                "data": {
+                    "wallets": [
+                        {"id": "w-1", "address": "0xA", "metadata": [{"name": "ref", "value": "sub:target"}]},
+                    ]
+                }
+            },
+        )
+        session = _FakeSession({("GET", "developer/wallets"): listing})
+
+        found = await wp._find_wallet_by_ref(session, "key", "sub:target")
+
+        assert found == {"id": "w-1", "address": "0xA"}
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_none(self):
+        listing = _FakeResp(
+            200,
+            {"data": {"wallets": [{"id": "w-1", "address": "0xA", "metadata": [{"name": "ref", "value": "other"}]}]}},
+        )
+        session = _FakeSession({("GET", "developer/wallets"): listing})
+
+        assert await wp._find_wallet_by_ref(session, "key", "sub:missing") is None
+
+    @pytest.mark.asyncio
+    async def test_non_200_listing_returns_none(self):
+        session = _FakeSession({("GET", "developer/wallets"): _FakeResp(503, {})})
+
+        assert await wp._find_wallet_by_ref(session, "key", "sub:x") is None


### PR DESCRIPTION
## What

**Test-audit Tranche 5** — the +22 funds-adjacent gap-fill tests that the Tranche-1 deletions (#1259) were meant to fund. Purely additive: no source changes, three test surfaces. The audit's headline was *"the suite is thickest where nothing ships, and thinnest where money leaves"* — this PR is the thin part getting its first real tests, ahead of the Sept 16 real-USDC cutover.

### G1 — the live money-out paths (9 tests, `test_settlement.py`)

`withdraw_subscriber` measured **4/18 statements** covered, `withdraw_publisher` **4/16** — only the `PAYMENTS_DRY_RUN` early-returns and guard clauses had ever executed. The balance read, executor construction, and ERC-20 transfer had never run under test. New:

- Stage C live: the exact `PaymentSplitter.withdraw(bytes32,uint256)` calldata from the publisher's own executor; refusal without a configured splitter; soft-fail on chain error (never raises).
- The subscriber DCW return-transfer proven on the three claims its docstring makes: the amount **equals the balance read** (never caller-supplied), the token is the configured USDC contract, the destination is the subscriber's **SIWE wallet — not the DCW** — and the executor is bound to `(circle_wallet_id, dcw_address)`.
- Empty-DCW and missing-identifier short-circuits (no executor is ever built).
- **The recoverable-by-retry promise**: a failed sweep leaves no sticky state — the retry re-reads the balance and transfers the full amount again.

### G2 — Circle DCW provisioning (9 tests, new `test_wallet_provisioner.py`)

`_create_circle_wallet` measured **1/28**, `_find_wallet_by_ref` 1/12, `_encrypt_entity_secret` 1/7 — every subscriber's custodial wallet is minted in code that had effectively never run under test. New hermetic suite (URL-routing fake session, no network):

- **The entity-secret encryption is proven, not mocked**: a test RSA keypair decrypts the posted `entitySecretCiphertext` and requires the original secret bytes back — a mutant that skips encryption, encrypts the wrong bytes, or uses the wrong padding cannot pass.
- Idempotency keys are deterministic per ref and distinct across refs (the property that makes retries mint zero duplicates).
- The 409 double-provision guard surfaces the **existing** wallet via metadata-ref lookup — one creation attempt, no duplicate mint; 409-with-no-findable-wallet raises.
- Credential absence fails **before** any network I/O; non-201/409 statuses raise with the status code.

### G3 — the fee's unit scale (4 tests, new `test_fee_unit_scale.py`)

Every existing charge test re-derived its expectation from the live `FLAT_FEE_PER_ACTION` symbol, and every `tick()` test monkeypatched the charge away — a 10⁶ unit-scale regression would have shipped through a fully green suite at 100% file coverage. New:

- The literal pin: `FLAT_FEE_PER_ACTION == 100` (raw 6-dec µUSDC = $0.000100/action) and `fee_to_price` dollar-string literals including the `10⁶ raw = $1.000000` anchor.
- The **real `_charge_one`** running with `payments_dry_run=False` against a stubbed payment client: asserts the debited `flat_fee_raw` is the literal 100, the spend-cap **reservation and release amounts match it exactly** (same wallet, same charge id — a mismatch silently leaks the 24h cap), and the charge bills the subscriber's Circle wallet pair to the publisher's seller address.

## Verification

**Mutation pass** (each mutation applied to source, tests run, source restored):

| Mutation | Result |
|---|---|
| Refund destination `to_wallet` → `dcw_address` (money returned to the custodial wallet) | `test_withdraw_subscriber_returns_exact_balance_to_the_siwe_wallet` FAILS |
| `_encrypt_entity_secret` encrypts `b"\x00"*32` instead of the secret | the real-decrypt test FAILS on plaintext mismatch |
| `FLAT_FEE_PER_ACTION` default `"100"` → `"100000000"` (10⁶ scale slip) | 3 tests FAIL (`100000000 == 100`); the `fee_to_price` literal test correctly still passes |

**Coverage on the target modules** (marketplace test dir): `settlement.py` → **91%**, `wallet_provisioner.py` → **98%** (from 23%). Full unit suite result posted below.

## Notes for review

- Additive only — no source files touched, no collisions with any open PR (verified against the diffs of #1194/#1258/#1259/#1263/#1266/#1267/#1268/#1270/#1271).
- Remaining audit gaps deliberately NOT here: G8 is Tranche 4 (HELD for #1194 — file collision), G10's skip→FAIL conversion waits for #1129's merge, G5/G6/G7/G9/G11–G14 are the next tranche of this series.
- The `FLAT_FEE_PER_ACTION == 100` literal pins the shipped default; an env override in a dev shell will fail it loudly — that is the point (CI is hermetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7

## Full suite

`python -m pytest -m "not integration" -q`: **3141 passed, 3 skipped (pre-existing), 0 failed** in 3m26s.
