### PR TITLE
[test] Lock in end-to-end model-selection threading (#1049)

### DIFF
--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -950,6 +950,147 @@ async def test_debate_dispatch_end_to_end_persists_debate_strategy(tmp_path, mon
     assert isinstance(verdict["passing"], bool)
 
 
+# ── Test 3b — user's Generate-page model pick reaches the live LLM call sites
+# (issue #1049: selection must thread end-to-end, not just to the API boundary)
+
+
+@pytest.mark.asyncio
+async def test_run_generation_threads_user_model_to_debate_proposer_and_agent(tmp_path, monkeypatch):
+    """``run_generation(model=...)`` on the LIVE debate dispatch path must reach:
+
+      (a) the debate proposer (``_propose_pool`` → ``StrategyFusion(model=...)``
+          → ``make_llm_backend(model=...)``) — the seam that actually drafts the
+          candidate text, and
+      (b) the per-job ``PortfolioAgent``'s backend, built via
+          ``make_llm_backend(model=...)`` — the seam ``_served_model_for`` reads
+          for the ``done`` event's ``served_model`` provenance.
+
+    Route-level tests (test_generate_model_gating.py) stop at the enqueue
+    boundary (the pipeline task is mocked out entirely); the debate-engine unit
+    test (test_debate_engine.py::test_model_pick_threads_into_served_model)
+    covers only the ``StrategyFusion`` layer in isolation. Neither proves the
+    full chain from ``run_generation`` — what the job queue actually invokes —
+    down to the LLM-backend constructors. This closes that gap: a caller that
+    picked an allowlisted free-tier model must get THAT model, not a silent
+    fallback to the env default, anywhere along the live path.
+    """
+    import archimedes.agents.debate_engine as de
+    import archimedes.db as _db
+    import archimedes.services.fusion_evaluator as fe
+    import archimedes.services.llm_backend as llm_backend_mod
+    from archimedes.agents import generation_pipeline as gp
+    from archimedes.agents import strategy_fusion as sf
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    test_engine = create_engine(
+        f"sqlite:///{tmp_path / 'model_select_e2e.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    monkeypatch.setattr(_db, "engine", test_engine)
+    monkeypatch.setattr(_db, "SessionLocal", sessionmaker(bind=test_engine, autocommit=False, autoflush=False))
+    from archimedes.models import kg, strategy_passport_record  # noqa: F401
+
+    _db.Base.metadata.create_all(bind=test_engine)
+
+    monkeypatch.delenv("GENERATION_PIPELINE_FIXTURE", raising=False)
+
+    async def _pv(brief):
+        return await _permissive_validate(brief)
+
+    monkeypatch.setattr(gp, "_validate_brief", _pv)
+
+    picked_model = "zai.glm-4.7-flash"  # an allowlisted free-tier id, never the env default
+
+    # Spy on _propose_pool (the debate proposer's entry point) instead of the
+    # blanket fake used by _setup_debate_hermetic — capture the `model` it
+    # actually receives.
+    proposer_calls: list[str | None] = []
+    fake_proposals = [
+        _make_fake_proposal("Debate A", ["2401.00001", "2402.00001"]),
+        _make_fake_proposal("Debate B", ["2401.00002", "2402.00002"]),
+    ]
+
+    async def _spy_pool(brief, model, corpus):
+        proposer_calls.append(model)
+        return list(fake_proposals)
+
+    monkeypatch.setattr(gp, "_llm_available", lambda: True)
+    monkeypatch.setattr(de, "_debate_can_run", lambda brief: True)
+    monkeypatch.setattr(de, "_propose_pool", _spy_pool)
+    monkeypatch.setattr(sf, "load_corpus", lambda *a, **k: _debate_fake_corpus(4))
+
+    def _fake_eval(spec, *, num_trials=None, use_real_data=False, **kw):
+        return _fake_eval_result(num_trials=num_trials)
+
+    monkeypatch.setattr(fe, "evaluate_fusion_spec", _fake_eval)
+
+    async def _noop_debate_round(*a, **k):
+        return []
+
+    monkeypatch.setattr(de, "_debate_round", _noop_debate_round)
+
+    # Spy on make_llm_backend (the per-job PortfolioAgent construction reads
+    # this module attribute via a local import inside run_generation, so patch
+    # it where it's DEFINED — the same seam the live bedrock_converse path uses).
+    # Returns a tiny fake backend rather than delegating to the real factory —
+    # this test has no AWS credentials to exercise a live BedrockConverseBackend
+    # with, and a credential-less real call would correctly degrade to
+    # CannedBackend (served_model == "canned-fallback" always, by design — see
+    # CannedBackend's docstring), which would make assertion (c) below test
+    # nothing. The fake isolates what we actually want to verify here: that the
+    # WIRING passes the user's model through, independent of live credentials.
+    backend_calls: list[str | None] = []
+
+    class _FakeAgentBackend:
+        def __init__(self, model):
+            self.model_id = model
+            self.served_model = model
+            self.available = True
+
+        def complete(self, system, user):  # pragma: no cover — debate runner ignores `agent`
+            raise AssertionError("PortfolioAgent.complete should not be called by the debate runner")
+
+    def _spy_make_llm_backend(model=None, **kw):
+        backend_calls.append(model)
+        return _FakeAgentBackend(model)
+
+    monkeypatch.setattr(llm_backend_mod, "make_llm_backend", _spy_make_llm_backend)
+
+    store = _FakeStore()
+    brief = GenerateBrief(
+        intent="equity momentum with a volatility overlay",
+        risk_appetite="moderate",
+        asset_classes=["equities"],
+    )
+    await run_generation(
+        job_id="job_model_select_e2e",
+        brief=brief,
+        store=store,
+        dual_regime=False,
+        n_candidates=1,
+        model=picked_model,
+    )
+
+    # (a) the debate proposer received the user's exact pick, not the env default.
+    assert proposer_calls == [picked_model], (
+        f"expected _propose_pool called with {picked_model!r}, got {proposer_calls}"
+    )
+
+    # (b) the per-job PortfolioAgent's backend was built with the same pick.
+    assert picked_model in backend_calls, (
+        f"expected make_llm_backend(model={picked_model!r}) among the per-job agent's calls; got {backend_calls}"
+    )
+
+    # (c) provenance surfaced on the `done` event reflects the user's pick, not
+    # "fixture" and not silently the env default — the whole point of #1049.
+    done_events = [e for e in store.events if e["event"] == "done"]
+    assert done_events, "no done event emitted"
+    assert done_events[-1]["data"]["served_model"] == picked_model, (
+        f"done event served_model={done_events[-1]['data']['served_model']!r}, expected {picked_model!r}"
+    )
+
+
 # ── Test 4 — debate C-rigor threads _society_num_trials(library, pool) ────────
 
 


### PR DESCRIPTION
## Summary

Audited #1049 against current `main`. Its premise — "every request uses [the box .env's] one model" — predates the fix: #723 (T1.8 paid-tier gating) and #748 (functional model selection) landed on 2026-06-25/26, ~2 weeks before this issue was filed, and together already implement what the issue asks for:

- `ModelCostPanel` (Generate page) sends the user's pick as `model` on `POST /api/generate/start`.
- `enforce_model_entitlement` (`model_gate.py`) rejects a non-entitled premium request with 402 — never a silent downgrade — and stays authoritative (unchanged here).
- `is_allowed_model` filters to the free-tier allowlist (`FREE_TIER_MODELS`, kept 1:1 with `ui/src/data/modelPricing.json`).
- `run_generation` threads the picked model into every live LLM call site: the debate proposer pool (`StrategyFusion`), debate rounds, and the per-job `PortfolioAgent`, all via `make_llm_backend(model=...)`.
- `LLM_BEDROCK_MODEL` is now purely the fallback default, not the only option — the issue's core ask.
- Premium (Anthropic) models stay `works_now:false` / gated pending Bedrock activation (T3.8) — an entitled premium pick is accepted by the 402 gate but still can't serve yet, so it correctly falls back to the env default. Left exactly as-is per the task constraint.

**No production code changes.** I could not find a live selection-path bug after tracing the wiring through `generate_routes.py` → `generation_pipeline.py` → `debate_engine.py` → `strategy_fusion.py` / `llm_backend.py`, and the existing 133-test suite across the model-gating/selection files passes clean.

## Gap found + closed

Existing tests stop at two boundaries: `test_generate_model_gating.py` mocks out the pipeline task entirely at the API route, and `test_debate_engine.py::test_model_pick_threads_into_served_model` covers only the `StrategyFusion` layer in isolation. Nothing proved the full chain — what the job queue actually invokes (`run_generation`) — threads a picked model down to the live debate proposer *and* the per-job agent's backend construction, with correct `served_model` provenance on the `done` event.

Added `test_run_generation_threads_user_model_to_debate_proposer_and_agent` (`backend/tests/services/test_generation_pipeline.py`) to close that gap. It's hermetic (spies on `_propose_pool` and `make_llm_backend`, no live LLM/AWS creds needed) and discriminating — verified adversarially by independently breaking each seam (dropping `model=` from the debate-runner partial; dropping it from the per-job agent's backend construction) and confirming the test fails both ways before confirming it passes clean on `main`.

## Test plan
- [x] `pytest backend/tests/services/test_generation_pipeline.py backend/tests/test_generation_pipeline.py backend/tests/test_debate_engine.py backend/tests/test_generate_model_gating.py backend/tests/test_model_gating.py backend/tests/services/test_llm_backend_model_select.py backend/tests/services/test_chat_service.py` — 133 passed
- [x] New test verified to fail when either threading seam is broken (adversarial check), passes clean on `main`
- [x] `ruff check` / `ruff format --check` clean on the changed file

Ref #1049.