### PR TITLE
fix(local-mode): honest Ollama probe + prod-only SSM secret load (#1044 eval)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,9 +89,16 @@ REDIS_URL=redis://redis:6379/0
 #        LLM_API_KEY=<key>
 #        LLM_BASE_URL=https://api.openai.com/v1
 #
-#  (D) Local Ollama:
+#  (D) Local Ollama — no key, no cloud creds. Run `ollama pull llama3.1` on
+#      the HOST first (`available` now probes GET {base_url}/api/tags and
+#      falls back to canned output if the model isn't pulled — issue #1044).
+#      From INSIDE the docker-compose stack, "localhost" is the container
+#      itself, not your host — use host.docker.internal (mapped for the
+#      `backend`/`oracle`/`agent`/`kb-runner` services below via extra_hosts).
+#      Running the backend bare (not in compose) can use localhost instead.
 #        LLM_PROVIDER=ollama
-#        LLM_BASE_URL=http://localhost:11434
+#        LLM_MODEL=llama3.1
+#        LLM_BASE_URL=http://host.docker.internal:11434
 #
 # Default matches production: AWS Bedrock Converse + Amazon Nova Micro.
 LLM_PROVIDER=bedrock_converse
@@ -392,9 +399,12 @@ KB_ARTIFACT_DIR=/srv/corpus-artifact
 
 # ── AWS SSM Parameter Store — production secrets surface ──────────────────
 # Set by TS.2 (issue #176). Backend reads all params under this prefix at
-# startup via boto3.client("ssm").get_parameters_by_path(...). Leave blank
-# for local dev (uses .env values directly).
-AWS_SSM_PATH_PREFIX=/archimedes/prod/
+# startup via boto3.client("ssm").get_parameters_by_path(...) — but ONLY when
+# running in production mode (PUBLIC_DOMAIN set; see main.py), so a local run
+# can never pull real prod secrets even with ambient AWS creds (issue #1044).
+# Leave blank for local dev (uses .env values directly). Production sets this
+# explicitly in its own deploy config (infra/ecs.tf), not from this file.
+AWS_SSM_PATH_PREFIX=
 
 # ── x402 payment gateway webhook secret ──────────────────────────────────
 # HMAC-SHA256 shared secret for authenticating x402 gateway callbacks to

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -23,12 +23,18 @@ from slowapi.errors import RateLimitExceeded
 load_dotenv("../.env", override=True)  # Project root .env first (has real secrets)
 load_dotenv(".env", override=False)  # Backend-local .env fills in any missing (no override)
 
-# Load secrets from AWS SSM Parameter Store (production).
-# No-op when AWS_SSM_PATH_PREFIX is unset (local dev). Must run BEFORE
-# any service imports that read os.environ for API keys / secrets.
+# Load secrets from AWS SSM Parameter Store — PRODUCTION ONLY. Gated on
+# PUBLIC_DOMAIN (same "is this production" signal used below for the docs gate
+# and the EMAIL_ENCRYPTION_KEY fail-close) so a local run can never pull real
+# prod secrets from SSM, even with ambient AWS creds and AWS_SSM_PATH_PREFIX
+# resolving to a real path — issue #1044. Belt-and-suspenders with
+# AWS_SSM_PATH_PREFIX defaulting blank in .env.example: this gate is what
+# actually stops the fetch regardless of what that var resolves to. Must run
+# BEFORE any service imports that read os.environ for API keys / secrets.
 from archimedes.services.secrets_service import load_ssm_secrets
 
-load_ssm_secrets()
+if os.getenv("PUBLIC_DOMAIN"):
+    load_ssm_secrets()
 
 # Shared rate limiter (Redis-backed, falls back to in-memory).
 # Defined in a separate module to avoid circular imports with route modules.

--- a/backend/archimedes/services/llm_backend.py
+++ b/backend/archimedes/services/llm_backend.py
@@ -408,7 +408,28 @@ class OllamaBackend:
 
     @property
     def available(self) -> bool:
-        return True
+        """Probe the Ollama server for reachability AND that ``LLM_MODEL`` is
+        actually pulled there.
+
+        Unlike every other backend, Ollama has no credential to check
+        statically — so ``available`` used to be hardcoded ``True``, which made
+        ``make_llm_backend()`` treat a misconfigured/unreachable ollama as
+        live and ``/health`` report ``llm_available: true`` right up until the
+        first real request errored (issue #1044). A real (short-timeout) probe
+        against ``GET {base_url}/api/tags`` makes an unreachable server or an
+        unpulled model correctly fall back to ``CannedBackend``.
+        """
+        import httpx
+
+        try:
+            resp = httpx.get(f"{self._base_url}/api/tags", timeout=3.0)
+            resp.raise_for_status()
+            tags = {m.get("name", "") for m in resp.json().get("models", [])}
+        except Exception:
+            return False
+        # Ollama tags carry a ":variant" suffix (e.g. "llama3.1:latest"); match
+        # the bare name too so LLM_MODEL=llama3.1 matches a pulled default tag.
+        return any(tag == self._model or tag.partition(":")[0] == self._model for tag in tags)
 
     def complete(self, system: str, user: str) -> str:
         import httpx

--- a/backend/tests/services/test_ollama_backend_health.py
+++ b/backend/tests/services/test_ollama_backend_health.py
@@ -1,0 +1,95 @@
+"""Guard tests for issue #1044 leak 1 — OllamaBackend must probe honestly.
+
+Before this fix, ``OllamaBackend.available`` was hardcoded ``True`` (unlike
+every other backend), so a misconfigured or unreachable local Ollama was
+reported live by ``make_llm_backend()`` and ``/health`` right up until the
+first real request errored. These tests are hermetic — no real Ollama server,
+no network — via a fake ``httpx.get``/``httpx.Response``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _fake_response(*, status_ok: bool = True, models: list[str] | None = None):
+    resp = MagicMock()
+    if status_ok:
+        resp.raise_for_status.return_value = None
+    else:
+        resp.raise_for_status.side_effect = Exception("boom")
+    resp.json.return_value = {"models": [{"name": name} for name in (models or [])]}
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _isolate_llm_env(monkeypatch):
+    # These tests construct OllamaBackend directly and don't exercise
+    # LLM_PROVIDER routing, but keep the env clean so a stray LLM_MODEL/
+    # LLM_BASE_URL from the developer's shell can't change the assertions.
+    for var in ("LLM_MODEL", "LLM_BASE_URL", "LLM_PROVIDER"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_available_false_when_server_unreachable():
+    from archimedes.services.llm_backend import OllamaBackend
+
+    backend = OllamaBackend(model="llama3.1")
+    with patch("httpx.get", side_effect=OSError("connection refused")):
+        assert backend.available is False
+
+
+def test_available_false_when_model_not_pulled():
+    from archimedes.services.llm_backend import OllamaBackend
+
+    backend = OllamaBackend(model="llama3.1")
+    with patch("httpx.get", return_value=_fake_response(models=["mistral:latest"])):
+        assert backend.available is False
+
+
+def test_available_true_when_exact_tag_pulled():
+    from archimedes.services.llm_backend import OllamaBackend
+
+    backend = OllamaBackend(model="llama3.1:latest")
+    with patch("httpx.get", return_value=_fake_response(models=["llama3.1:latest"])):
+        assert backend.available is True
+
+
+def test_available_true_when_bare_name_matches_tagged_pull():
+    """LLM_MODEL=llama3.1 (no variant) must match a pulled "llama3.1:latest"."""
+    from archimedes.services.llm_backend import OllamaBackend
+
+    backend = OllamaBackend(model="llama3.1")
+    with patch("httpx.get", return_value=_fake_response(models=["llama3.1:latest"])):
+        assert backend.available is True
+
+
+def test_make_llm_backend_returns_live_ollama_when_reachable_and_pulled(monkeypatch):
+    """Adversarial-pass counterpart: a correctly configured, reachable server
+    with the model pulled must NOT be downgraded to CannedBackend — the fix
+    must not overcorrect into always-unavailable.
+    """
+    from archimedes.services.llm_backend import OllamaBackend, make_llm_backend
+
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MODEL", "llama3.1")
+    monkeypatch.setenv("LLM_BASE_URL", "http://host.docker.internal:11434")
+    with patch("httpx.get", return_value=_fake_response(models=["llama3.1:latest"])):
+        backend = make_llm_backend()
+    assert isinstance(backend, OllamaBackend)
+
+
+def test_make_llm_backend_falls_back_to_canned_when_ollama_unreachable(monkeypatch):
+    """Integration: the /health honesty contract — an unreachable ollama must
+    resolve to CannedBackend, not silently report live.
+    """
+    from archimedes.services.llm_backend import CannedBackend, make_llm_backend
+
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MODEL", "llama3.1")
+    monkeypatch.setenv("LLM_BASE_URL", "http://127.0.0.1:1")  # nothing listens here
+    with patch("httpx.get", side_effect=OSError("connection refused")):
+        backend = make_llm_backend()
+    assert isinstance(backend, CannedBackend)

--- a/backend/tests/test_main_ssm_prod_gate.py
+++ b/backend/tests/test_main_ssm_prod_gate.py
@@ -1,0 +1,129 @@
+"""Guard test for issue #1044 leak 2 — SSM secrets must never load locally.
+
+Before this fix, ``load_ssm_secrets()`` ran unconditionally at
+``archimedes/main.py`` import time, and ``.env.example`` defaulted
+``AWS_SSM_PATH_PREFIX`` to the real prod path with a comment (not enforced by
+any code) saying "leave blank for local dev". On any dev machine with ambient
+AWS creds, a plain ``docker compose up`` could silently pull real prod
+secrets into the local process.
+
+This test runs ``archimedes.main`` import in a **subprocess**, with a fake
+``boto3``/``botocore`` shimmed into ``sys.modules`` so ``secrets_service``'s
+lazy ``import boto3`` binds to a spy instead of ever touching real AWS or
+requiring credentials. It counts ``boto3.client("ssm", ...)`` calls — the
+observable point at which ``load_ssm_secrets()`` would actually try to talk
+to SSM — to prove the gate directly, rather than inferring it from whether
+an exception was raised. Runs
+out-of-process (not a plain function call/monkeypatch) because the gate lives
+in top-level module code that only executes once per interpreter; every other
+test file in this suite already imports ``archimedes.main``, so re-exercising
+that import path in-process would depend on cache/reload ordering across the
+whole test session instead of being hermetic.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+
+_HARNESS = dedent(
+    """
+    import os
+    import sys
+    import types
+
+    # Spy boto3/botocore BEFORE archimedes.main (and its secrets_service
+    # import) ever runs — secrets_service does a lazy `import boto3` inside
+    # load_ssm_secrets(), so shadowing sys.modules here intercepts it without
+    # touching the real AWS SDK or needing real credentials.
+    ssm_client_calls = []
+
+    class _FakeSsmClient:
+        def get_parameters_by_path(self, **kwargs):
+            return {"Parameters": []}
+
+    def _fake_client(service, region_name=None):
+        ssm_client_calls.append((service, region_name))
+        return _FakeSsmClient()
+
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = _fake_client
+    sys.modules["boto3"] = fake_boto3
+
+    fake_botocore = types.ModuleType("botocore")
+    fake_botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+    class BotoCoreError(Exception):
+        pass
+
+    class ClientError(Exception):
+        pass
+
+    class NoCredentialsError(Exception):
+        pass
+
+    fake_botocore_exceptions.BotoCoreError = BotoCoreError
+    fake_botocore_exceptions.ClientError = ClientError
+    fake_botocore_exceptions.NoCredentialsError = NoCredentialsError
+    sys.modules["botocore"] = fake_botocore
+    sys.modules["botocore.exceptions"] = fake_botocore_exceptions
+
+    import archimedes.main  # noqa: F401  (import-time side effect under test)
+
+    print(len(ssm_client_calls))
+    """
+)
+
+
+def _run(env: dict[str, str]) -> int:
+    result = subprocess.run(
+        [sys.executable, "-c", _HARNESS],
+        cwd=_BACKEND_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return int(result.stdout.strip().splitlines()[-1])
+
+
+def _base_env() -> dict[str, str]:
+    import os
+
+    env = dict(os.environ)
+    # Ambient AWS creds must not matter either way — the gate is on
+    # PUBLIC_DOMAIN, not credential presence. Scrub them so a developer's
+    # real AWS env can't accidentally make this test pass for the wrong
+    # reason (or fail if it somehow did reach real SSM).
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE"):
+        env.pop(var, None)
+    return env
+
+
+def test_local_mode_never_calls_ssm_even_with_prod_shaped_prefix():
+    """PUBLIC_DOMAIN unset (local mode) — boto3 SSM client must never be built,
+    even when AWS_SSM_PATH_PREFIX resolves to the real prod path (e.g. via the
+    compose file's legacy default) — the #1044 leak scenario exactly."""
+    env = _base_env()
+    env.pop("PUBLIC_DOMAIN", None)
+    env["AWS_SSM_PATH_PREFIX"] = "/archimedes/prod/"
+    assert _run(env) == 0
+
+
+def test_production_mode_does_call_ssm():
+    """PUBLIC_DOMAIN set (production mode) — the SSM load path still runs.
+    Guards against the fix over-correcting into never loading secrets in prod."""
+    env = _base_env()
+    env["PUBLIC_DOMAIN"] = "https://example.com"
+    env["AWS_SSM_PATH_PREFIX"] = "/archimedes/prod/"
+    # Avoid tripping the unrelated fail-closed EMAIL_ENCRYPTION_KEY check
+    # (main.py) so the process reaches a clean, observable exit.
+    env["EMAIL_ENCRYPTION_KEY"] = "test-only-not-a-real-key"
+    assert _run(env) == 1

--- a/backend/tests/test_main_ssm_prod_gate.py
+++ b/backend/tests/test_main_ssm_prod_gate.py
@@ -72,6 +72,15 @@ _HARNESS = dedent(
     sys.modules["botocore"] = fake_botocore
     sys.modules["botocore.exceptions"] = fake_botocore_exceptions
 
+    # Neutralize load_dotenv BEFORE archimedes.main runs its own
+    # load_dotenv("../.env", override=True) — otherwise a populated repo-root
+    # .env (e.g. PUBLIC_DOMAIN set for local prod-mimicry, as .env.example's
+    # comment suggests) overrides this test's carefully-constructed env and
+    # flips the local-mode assertion: local-red/CI-green, the class the
+    # testing conventions ban (pattern: test_security_hardening.py).
+    import dotenv as _dotenv
+    _dotenv.load_dotenv = lambda *_a, **_kw: False
+
     import archimedes.main  # noqa: F401  (import-time side effect under test)
 
     print(len(ssm_client_calls))
@@ -95,16 +104,21 @@ def _run(env: dict[str, str]) -> int:
 
 
 def _base_env() -> dict[str, str]:
+    """Whitelist-only env (testing conventions; pattern:
+    test_security_hardening._clean_subprocess_env). Inheriting os.environ
+    leaks the developer's .env — loaded into the parent pytest process by
+    earlier imports — into the subprocess: ambient AWS creds, a real
+    DATABASE_URL pointing at compose's postgres hostname, or a locally-set
+    PUBLIC_DOMAIN would all change what this test measures. The gate is on
+    PUBLIC_DOMAIN, not credential presence, so nothing ambient may vary."""
     import os
 
-    env = dict(os.environ)
-    # Ambient AWS creds must not matter either way — the gate is on
-    # PUBLIC_DOMAIN, not credential presence. Scrub them so a developer's
-    # real AWS env can't accidentally make this test pass for the wrong
-    # reason (or fail if it somehow did reach real SSM).
-    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE"):
-        env.pop(var, None)
-    return env
+    return {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "PYTHONPATH": str(_BACKEND_DIR),
+        "DATABASE_URL": "sqlite:////tmp/archimedes-ssm-gate-subprocess.db",
+    }
 
 
 def test_local_mode_never_calls_ssm_even_with_prod_shaped_prefix():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,11 @@ services:
     # locally", not a substitute for the Redis lease.
     profiles: ["runners"]
     restart: unless-stopped
+    # Lets LLM_BASE_URL=http://host.docker.internal:11434 (local Ollama, #1044)
+    # reach the host from inside the container on Linux too — Docker Desktop
+    # (macOS/Windows) already resolves this name; harmless no-op in prod.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command: ["python", "-m", "archimedes.chain.oracle_runner"]
     environment:
       DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL in .env}
@@ -233,6 +238,9 @@ services:
     # #1043 — gated behind the `runners` profile; see the file-header note.
     profiles: ["runners"]
     restart: unless-stopped
+    # See the oracle service's comment above (host.docker.internal, #1044).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command: ["python", "-m", "archimedes.chain.agent_runner"]
     environment:
       DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL in .env}
@@ -275,6 +283,10 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     restart: unless-stopped
+    # See the oracle service's comment above (host.docker.internal, #1044) —
+    # this is the service Generate/chat/rigor actually call through.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # NO host port binding — backend is only reachable via nginx reverse proxy.
     # This ensures all rate limits, CORS, security headers, and the docs gate
     # cannot be bypassed by hitting port 8000 directly.


### PR DESCRIPTION
Evaluation pass on #1044 (issue's own instruction: "sequencing deliberately deferred... come back and rebuild local mode to this contract"). Per Dan's ask, this evaluates rather than big-bangs: audited what actually breaks a fresh `docker compose up`, fixed what's cheap, left the rest as a gap list.

## Gap list (file:line)

| # | Gap | Status |
|---|---|---|
| 1 | `OllamaBackend.available` hardcoded `True` — `backend/archimedes/services/llm_backend.py:410` (pre-fix). Unreachable/misconfigured ollama reported live via `/health` (`main.py:695`) until the first real request errored. | **Fixed this PR** — real `GET {base_url}/api/tags` probe, checks the configured model is pulled. |
| 2 | `.env.example` Option (D) ollama recipe had no `LLM_MODEL` (falls back to `DEFAULT_MODEL="claude-sonnet-4-…"`, not a real ollama tag) and pointed `LLM_BASE_URL` at `localhost:11434`, which is the *container* from inside the compose network, not the host running ollama. | **Fixed this PR** — documents `LLM_MODEL=llama3.1` + `host.docker.internal`; `docker-compose.yml` maps `host.docker.internal:host-gateway` on `backend`/`oracle`/`agent` (the services that call `make_llm_backend()`). |
| 3 | `load_ssm_secrets()` ran unconditionally at `main.py:31` import, before any production check exists. `.env.example:383` defaulted `AWS_SSM_PATH_PREFIX=/archimedes/prod/` with an unenforced "leave blank for local dev" comment. On a dev box with ambient AWS creds, local `docker compose up` could pull real prod secrets (Circle keys, encryption key, LLM tokens) into the local process. | **Fixed this PR** — gated behind `PUBLIC_DOMAIN` (same signal already used for the docs gate + `EMAIL_ENCRYPTION_KEY` fail-close); `.env.example` default now blank. Belt-and-suspenders: the gate closes the leak regardless of what `AWS_SSM_PATH_PREFIX` resolves to (left `docker-compose.yml`'s own `${AWS_SSM_PATH_PREFIX:-/archimedes/prod/}` default alone — current prod is ECS/Fargate and sets this explicitly via `infra/ecs.tf:487`, bypassing the compose default entirely; touching it risked an unverifiable side effect on whatever the legacy EC2 box still does). |
| 4 | Image-pull footgun (`docker-compose.yml`'s `image:` + `build:` on the app-tier services): confirmed empirically (throwaway compose file, bogus registry) that a bare `docker compose up` with no local image tries to **pull first**, falling back to build only on failure — so an ECR-authenticated dev on a fresh clone risks running the last-pushed prod image against local code. | **Not fixed** — already substantially mitigated: `make up`, README.md:27/33/44, and SETUP.md:3/47/171/174/179 all document `docker compose up -d --build` as the canonical entry point. Residual risk is only a dev bypassing the documented entrypoints with ECR read access. A real guard (e.g. a self-healing `pull_policy` toggle mirroring how `deploy.yml` self-heals `COMPOSE_PROFILES`) touches the same file that *is* the box's live prod deploy target for the `runners`-profile fix (#1039/#1001's OOM-on-serving-host lineage) — riskier than this PR's scope without a way to verify against the real ECR-authenticated path. Left as a documented residual, not silently dropped. |
| 5 | Runners not gated behind a profile | **Already fixed** — `#1043` landed; `docker-compose.yml` already has `profiles: ["runners"]` on `oracle`/`agent`/`kb-runner`. |
| 6 | Identity ledger "prod-only" framing | **Clarification only, no bug** (per issue's own item 4) — vault creation is unconditionally SIWE-gated in both modes; fail-soft. No action taken. |
| 7 | `docker-compose.production.yml` adopt-or-delete | **Still undecided**, per the issue's own 2026-07-08 comment thread. Out of scope here — not touched. |
| 8 | Better Auth sidecar on `origin/feat/account-auth-app-boundary` (checked per task instructions) | **New finding, not fixed** (different branch/PR, not mergeable into this one). That branch adds an `auth` service + `docker-compose.local.yml` (`COMPOSE_FILE=docker-compose.yml:docker-compose.local.yml`) for strict local migration ordering, and requires `BETTER_AUTH_SECRET` with no default (`:?Set BETTER_AUTH_SECRET in .env`) even for local `docker compose up` — consistent with this repo's existing "required secret, no default" pattern (`POSTGRES_PASSWORD`, `DATABASE_URL`), but it's a new local-setup step (`python -c "import secrets; print(secrets.token_urlsafe(48))"`) that whoever picks up that branch should fold into the local-mode contract once it merges. `REQUIRE_SIWE_FOR_GENERATION` / `WALLET_LESS_GENERATION_DAILY_CAP` are removed on that branch in favor of an unconditional Better Auth session requirement — i.e. local dev loses the current open, wallet-less Generate flow. Flagging for whoever owns that merge, not resolving here. |
| SQLite/`DATABASE_URL` fail-loud (issue's 2nd comment) | **Not evaluated this pass** — out of scope for the cheap-fixes bar; needs its own look at `db.py`'s fallback path + the `nonroot`-writable-path fix already noted as done in #1050. |

## What's in this PR
- `backend/archimedes/services/llm_backend.py` — `OllamaBackend.available` real probe.
- `backend/archimedes/main.py` — `load_ssm_secrets()` gated on `PUBLIC_DOMAIN`.
- `.env.example` — ollama recipe (`LLM_MODEL`, `host.docker.internal`); `AWS_SSM_PATH_PREFIX` blank default.
- `docker-compose.yml` — `extra_hosts: host.docker.internal:host-gateway` on `backend`/`oracle`/`agent`.
- Two new hermetic test files: `backend/tests/services/test_ollama_backend_health.py` (probe honesty, both directions — unreachable/unpulled → canned, reachable/pulled → live) and `backend/tests/test_main_ssm_prod_gate.py` (subprocess test with a spied `boto3`, proving SSM is never touched locally even with a prod-shaped prefix, and still fires in production mode).

## Verification
- Full backend suite: `pytest` — 3127 passed, 5 skipped (pre-existing, DB/contract-dependent), 0 failed.
- `ruff check` + `ruff format --check` on all changed files: clean.
- `docker compose -f docker-compose.yml --profile localdb --profile runners config` parses cleanly with the new `extra_hosts` entries.
- Adversarial pass on the new guard: confirmed `available` is `False` for both an unreachable server AND a reachable server missing the configured model tag, and `True` only when both hold (exact tag and bare-name-vs-`:variant` match).

## Omissions (explicit, not silent)
- No local-vs-prod one-page doc (issue's acceptance criteria item 3) — out of scope for "small fixes."
- No fix for the image-pull-without-`--build` footgun (see gap #4) — documented residual, judged higher-risk than the fix bar for this pass.
- `docker-compose.production.yml` adopt-or-delete and the Better Auth sidecar branch are flagged, not resolved.

Related: #1043 (merged), #1039, #1041, #1028, #1042.
