### PR TITLE
Market-data vendor seam; resolve #775 through it

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/data.py
+++ b/analytics-engine/src/archimedes_analytics_engine/data.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import logging
-import time
 
 import pandas as pd
-import yfinance as yf
 
 logger = logging.getLogger(__name__)
 
@@ -48,31 +46,15 @@ def normalize_ohlcv(data: pd.DataFrame, *, symbol: str) -> pd.DataFrame:
 
 
 def fetch_ohlcv(symbol: str, start: str, end: str) -> pd.DataFrame:
-    last_exc: Exception | None = None
-    for attempt in range(1, _MAX_RETRIES + 1):
-        try:
-            # auto_adjust=True applies yfinance's built-in split/dividend back-adjustment so
-            # corporate actions (e.g. KO's Aug-2012 2-for-1 split) don't show up as spurious
-            # overnight price discontinuities that corrupt pairs-trading signals and PBO.
-            data = yf.download(symbol, start=start, end=end, auto_adjust=True, progress=False)
-        except Exception as exc:  # transient network/yfinance error — retry with backoff
-            last_exc = exc
-            if attempt == _MAX_RETRIES:
-                break
-            logger.warning("fetch_ohlcv(%s) attempt %d failed: %s — retrying", symbol, attempt, exc)
-            time.sleep(_RETRY_DELAY_S * attempt)
-            continue
+    """Fetch + normalize OHLCV for ``symbol`` over [start, end).
 
-        if data.empty:
-            if attempt == _MAX_RETRIES:
-                raise ValueError(f"No data returned for symbol={symbol} in range {start}..{end}")
-            logger.warning("fetch_ohlcv(%s) returned empty — retrying (attempt %d)", symbol, attempt)
-            time.sleep(_RETRY_DELAY_S * attempt)
-            continue
+    A thin façade over the market-data provider seam (#1218:
+    ``archimedes_analytics_engine.market_data``) — default provider is
+    yfinance, and this function's retry/error contract (3 attempts, backoff,
+    raises on a genuinely empty/unfetchable result) is unchanged from before
+    the seam existed; that logic now lives in ``market_data.YFinanceProvider``.
+    Vendor-swappable via the ``MARKET_DATA_PROVIDER`` env var.
+    """
+    from archimedes_analytics_engine.market_data import get_provider
 
-        result = normalize_ohlcv(data, symbol=symbol)
-        if len(result) == 0:
-            raise ValueError(f"All rows dropped after normalization for {symbol} — check date range")
-        return result
-
-    raise RuntimeError(f"yfinance download failed for {symbol} after {_MAX_RETRIES} attempts") from last_exc
+    return get_provider().fetch_ohlcv(symbol, start, end)

--- a/analytics-engine/src/archimedes_analytics_engine/market_data.py
+++ b/analytics-engine/src/archimedes_analytics_engine/market_data.py
@@ -1,0 +1,107 @@
+"""Market-data vendor seam (#1218) — analytics-engine's choke point.
+
+#1218 priced yfinance as an unlicensed commercial dependency that scales with
+strategies x symbols x re-run cadence, and named ``data.fetch_ohlcv`` as (one
+of) the seam(s) to substitute a vendor at. This module IS that seam:
+``data.fetch_ohlcv`` becomes a thin façade over ``get_provider().fetch_ohlcv``
+— identical signature, identical default behavior (yfinance), vendor-swappable
+via the ``MARKET_DATA_PROVIDER`` env var.
+
+analytics-engine is a standalone, DB-less package (no sqlalchemy/psycopg
+dependency — see ``pyproject.toml``) that runs independently of ``backend``'s
+Postgres, so this provider has no cache layer, unlike
+``backend.archimedes.services.market_data_provider``'s
+``asset_daily_bars``-backed one. Both modules read the SAME
+``MARKET_DATA_PROVIDER`` env var and default to the same vendor name
+(``"yfinance"``), so a single env value picks the vendor across both seams —
+but a vendor implementation is registered separately in each (there is no
+shared package to put one implementation in; ``backend`` already depends on
+THIS package for ``fetch_ohlcv``, which is what makes this half of the seam
+"free" for backend's ``fusion_market_data`` / ``portfolio_backtester`` call
+sites — they import ``fetch_ohlcv`` from here and get the swap for free).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from abc import ABC, abstractmethod
+
+import pandas as pd
+import yfinance as yf
+
+from archimedes_analytics_engine.data import _MAX_RETRIES, _RETRY_DELAY_S, normalize_ohlcv
+
+logger = logging.getLogger(__name__)
+
+
+class MarketDataProvider(ABC):
+    """Vendor abstraction for OHLCV history. Default implementation (below) is
+    yfinance, unchanged in behavior from ``data.fetch_ohlcv`` before this seam
+    existed."""
+
+    @abstractmethod
+    def fetch_ohlcv(self, symbol: str, start: str, end: str) -> pd.DataFrame:
+        """Return a normalized OHLCV frame for ``symbol`` over [start, end).
+        Raises on a genuinely unfetchable symbol/range (see
+        ``YFinanceProvider`` for the exact retry/error contract this
+        preserves)."""
+
+
+class YFinanceProvider(MarketDataProvider):
+    """Default provider — the exact retry/normalize logic that used to live
+    directly in ``data.fetch_ohlcv``, moved here unchanged."""
+
+    def fetch_ohlcv(self, symbol: str, start: str, end: str) -> pd.DataFrame:
+        last_exc: Exception | None = None
+        for attempt in range(1, _MAX_RETRIES + 1):
+            try:
+                # auto_adjust=True applies yfinance's built-in split/dividend back-adjustment so
+                # corporate actions (e.g. KO's Aug-2012 2-for-1 split) don't show up as spurious
+                # overnight price discontinuities that corrupt pairs-trading signals and PBO.
+                data = yf.download(symbol, start=start, end=end, auto_adjust=True, progress=False)
+            except Exception as exc:  # transient network/yfinance error — retry with backoff
+                last_exc = exc
+                if attempt == _MAX_RETRIES:
+                    break
+                logger.warning("fetch_ohlcv(%s) attempt %d failed: %s — retrying", symbol, attempt, exc)
+                time.sleep(_RETRY_DELAY_S * attempt)
+                continue
+
+            if data.empty:
+                if attempt == _MAX_RETRIES:
+                    raise ValueError(f"No data returned for symbol={symbol} in range {start}..{end}")
+                logger.warning("fetch_ohlcv(%s) returned empty — retrying (attempt %d)", symbol, attempt)
+                time.sleep(_RETRY_DELAY_S * attempt)
+                continue
+
+            result = normalize_ohlcv(data, symbol=symbol)
+            if len(result) == 0:
+                raise ValueError(f"All rows dropped after normalization for {symbol} — check date range")
+            return result
+
+        raise RuntimeError(f"yfinance download failed for {symbol} after {_MAX_RETRIES} attempts") from last_exc
+
+
+_PROVIDERS: dict[str, type[MarketDataProvider]] = {
+    "yfinance": YFinanceProvider,
+}
+
+
+def provider_name() -> str:
+    """The active vendor name: ``MARKET_DATA_PROVIDER`` env, default
+    ``"yfinance"``. An unrecognized value fails SAFE to the default (logged)
+    rather than crashing a backtest run over a config typo."""
+    raw = os.getenv("MARKET_DATA_PROVIDER", "yfinance").strip().lower()
+    if raw not in _PROVIDERS:
+        logger.warning("unknown MARKET_DATA_PROVIDER=%r — falling back to yfinance", raw)
+        return "yfinance"
+    return raw
+
+
+def get_provider() -> MarketDataProvider:
+    """The active provider. Call sites use this — never ``YFinanceProvider``
+    directly — so a vendor swap via ``MARKET_DATA_PROVIDER`` changes every
+    choke point that goes through it."""
+    return _PROVIDERS[provider_name()]()

--- a/analytics-engine/tests/test_market_data.py
+++ b/analytics-engine/tests/test_market_data.py
@@ -42,9 +42,7 @@ class TestProviderSelection:
 
 def _multiindex_ohlcv(symbol: str, n: int = 3) -> pd.DataFrame:
     idx = pd.date_range("2024-01-01", periods=n, freq="D")
-    columns = pd.MultiIndex.from_tuples(
-        [(field, symbol) for field in ("Open", "High", "Low", "Close", "Volume")]
-    )
+    columns = pd.MultiIndex.from_tuples([(field, symbol) for field in ("Open", "High", "Low", "Close", "Volume")])
     return pd.DataFrame(
         [[100 + i, 101 + i, 99 + i, 100 + i, 1000 + i] for i in range(n)],
         index=idx,

--- a/analytics-engine/tests/test_market_data.py
+++ b/analytics-engine/tests/test_market_data.py
@@ -1,0 +1,110 @@
+"""Hermetic tests for the #1218 market-data vendor seam (analytics-engine side).
+
+Covers provider selection (default + unknown-value fail-safe) and that
+``data.fetch_ohlcv`` is a pure façade over ``get_provider().fetch_ohlcv`` —
+same retry/error contract as before the seam existed. No network: the
+``yfinance`` boundary is mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from archimedes_analytics_engine import data, market_data
+from archimedes_analytics_engine.market_data import (
+    MarketDataProvider,
+    YFinanceProvider,
+    get_provider,
+    provider_name,
+)
+
+
+class TestProviderSelection:
+    def test_default_is_yfinance(self, monkeypatch):
+        monkeypatch.delenv("MARKET_DATA_PROVIDER", raising=False)
+        assert provider_name() == "yfinance"
+
+    def test_unknown_value_falls_back_to_yfinance(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "some_unreleased_vendor")
+        with caplog.at_level(logging.WARNING):
+            assert provider_name() == "yfinance"
+        assert any("some_unreleased_vendor" in rec.message for rec in caplog.records)
+
+    def test_get_provider_returns_yfinance_provider_by_default(self, monkeypatch):
+        monkeypatch.delenv("MARKET_DATA_PROVIDER", raising=False)
+        assert isinstance(get_provider(), YFinanceProvider)
+        assert isinstance(get_provider(), MarketDataProvider)
+
+
+def _multiindex_ohlcv(symbol: str, n: int = 3) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    columns = pd.MultiIndex.from_tuples(
+        [(field, symbol) for field in ("Open", "High", "Low", "Close", "Volume")]
+    )
+    return pd.DataFrame(
+        [[100 + i, 101 + i, 99 + i, 100 + i, 1000 + i] for i in range(n)],
+        index=idx,
+        columns=columns,
+    )
+
+
+class TestYFinanceProviderFetchOhlcv:
+    def test_normal_fetch_normalizes_and_returns(self):
+        provider = YFinanceProvider()
+        raw = _multiindex_ohlcv("SPY")
+        with patch.object(market_data, "yf") as fake_yf:
+            fake_yf.download = MagicMock(return_value=raw)
+            out = provider.fetch_ohlcv("SPY", "2024-01-01", "2024-01-04")
+        assert list(out.columns) == ["Open", "High", "Low", "Close", "Volume"]
+        assert len(out) == 3
+
+    def test_empty_result_retries_then_raises(self):
+        provider = YFinanceProvider()
+        with (
+            patch.object(market_data, "yf") as fake_yf,
+            patch.object(market_data.time, "sleep"),  # no real backoff delay in tests
+        ):
+            fake_yf.download = MagicMock(return_value=pd.DataFrame())
+            with pytest.raises(ValueError, match="No data returned"):
+                provider.fetch_ohlcv("NOPE", "2024-01-01", "2024-01-04")
+        assert fake_yf.download.call_count == market_data._MAX_RETRIES
+
+    def test_download_exception_retries_then_raises(self):
+        provider = YFinanceProvider()
+        with (
+            patch.object(market_data, "yf") as fake_yf,
+            patch.object(market_data.time, "sleep"),
+        ):
+            fake_yf.download = MagicMock(side_effect=RuntimeError("network down"))
+            with pytest.raises(RuntimeError, match="yfinance download failed"):
+                provider.fetch_ohlcv("SPY", "2024-01-01", "2024-01-04")
+        assert fake_yf.download.call_count == market_data._MAX_RETRIES
+
+    def test_transient_failure_then_success_returns_normalized(self):
+        """First attempt raises, second attempt returns real data — the retry
+        loop's success path, not just its two failure paths."""
+        provider = YFinanceProvider()
+        raw = _multiindex_ohlcv("SPY")
+        with (
+            patch.object(market_data, "yf") as fake_yf,
+            patch.object(market_data.time, "sleep"),
+        ):
+            fake_yf.download = MagicMock(side_effect=[RuntimeError("transient"), raw])
+            out = provider.fetch_ohlcv("SPY", "2024-01-01", "2024-01-04")
+        assert len(out) == 3
+        assert fake_yf.download.call_count == 2
+
+
+class TestDataFetchOhlcvFacade:
+    def test_delegates_to_active_provider(self):
+        """data.fetch_ohlcv must be a pure façade: patching the provider
+        module's get_provider changes what data.fetch_ohlcv returns."""
+        fake_provider = MagicMock()
+        fake_provider.fetch_ohlcv = MagicMock(return_value="SENTINEL")
+        with patch.object(market_data, "get_provider", return_value=fake_provider):
+            assert data.fetch_ohlcv("SPY", "2024-01-01", "2024-01-04") == "SENTINEL"
+        fake_provider.fetch_ohlcv.assert_called_once_with("SPY", "2024-01-01", "2024-01-04")

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -1,9 +1,13 @@
 """Oracle updater — fetches real-world prices and pushes them on-chain.
 
 Implements IOracleUpdater from archimedes/interfaces/chain.py.
-Uses yfinance for equity/ETF prices and CoinGecko for crypto.
-Pushes prices via Circle Developer Controlled Wallets API (the oracle owner
-wallet is a Circle-managed wallet — no raw private key available).
+Equity/ETF prices (and the #775 cross-check's secondary reading) come from
+the market-data provider seam (``archimedes.services.market_data_provider``,
+#1218) — default provider yfinance, unchanged behavior; vendor-swappable via
+``MARKET_DATA_PROVIDER``. Crypto still comes straight from CoinGecko
+(unaffected by that seam). Pushes prices via Circle Developer Controlled
+Wallets API (the oracle owner wallet is a Circle-managed wallet — no raw
+private key available).
 """
 
 from __future__ import annotations
@@ -495,21 +499,34 @@ class OracleUpdater:
         return None
 
     async def _cross_check_secondary(self, price: AssetPrice) -> str | None:
-        """Secondary-source cross-check (#775): compare a NON-yfinance primary
-        (Pyth/Stork via the PRICE_SOURCE cascade) against an independent yfinance
-        reading and fail closed when they diverge beyond the band. Returns a
-        rejection reason, or None to proceed.
+        """Secondary-source cross-check (#775): compare a primary that is NOT
+        the active market-data provider (Pyth/Stork via the PRICE_SOURCE
+        cascade) against an independent reading FROM the active provider
+        (``MARKET_DATA_PROVIDER``, #1218 seam — default yfinance, today's
+        behavior) and fail closed when they diverge beyond the band. Returns
+        a rejection reason, or None to proceed.
 
-        **Asymmetric, by design.** A stale / missing / flaky yfinance NEVER blocks
-        a healthy primary — otherwise a yfinance outage (it's known-flaky, #772)
-        would become a trading halt and the guardrail itself the failure. yfinance
-        problems only proceed-and-log; only a *confident* divergence between two
-        healthy sources fails closed.
+        **The #775/#1218 seam tie-in.** The secondary reading is fetched via
+        ``_fetch_yfinance_single`` → ``market_data_provider.get_provider()``,
+        and the "same source, skip" guard below compares against
+        ``provider_name()`` rather than a hardcoded ``"yfinance"``. Swap
+        ``MARKET_DATA_PROVIDER`` to a new vendor and this guardrail's
+        secondary source swaps with it automatically — no separate change
+        needed here. (The variable/log names below keep saying "yfinance"
+        because that is still the only implemented provider; the mechanism is
+        vendor-generic.)
+
+        **Asymmetric, by design.** A stale / missing / flaky secondary NEVER
+        blocks a healthy primary — otherwise a secondary-provider outage
+        (yfinance is known-flaky, #772) would become a trading halt and the
+        guardrail itself the failure. Secondary problems only proceed-and-log;
+        only a *confident* divergence between two healthy sources fails closed.
 
         Honest claim this earns: *"primary cross-checked against an independent
-        yfinance market source, fail-closed on relative-magnitude divergence beyond
-        a band, with the secondary's own bar timestamp checked for staleness first."*
-        NOT "decentralized 2-of-3" (yfinance is centralized + off-chain).
+        market-data-provider reading, fail-closed on relative-magnitude divergence
+        beyond a band, with the secondary's own bar timestamp checked for staleness
+        first."* NOT "decentralized 2-of-3" (yfinance — the default/only provider
+        today — is centralized + off-chain).
 
         **Staleness gate (#775 Phase 2).** Before comparing magnitudes, the
         secondary's bar timestamp is checked against
@@ -517,23 +534,26 @@ class OracleUpdater:
         same as a missing one (fail-open, proceed on primary) — a stale reading was
         never validly comparable, so no divergence verdict is computed or reported,
         only a staleness verdict. This closes the previous magnitude-only gap where a
-        stale-but-numerically-close yfinance value could pass silently, or a
+        stale-but-numerically-close secondary value could pass silently, or a
         stale-and-wildly-different one could in principle trip a false divergence.
 
-        The check is a no-op when the primary is yfinance (same source), an
-        admin pin (operator last-resort override — must not be second-guessed), or
-        when the symbol has no yfinance ticker.
+        The check is a no-op when the primary already IS the active provider
+        (same source, not an independent second opinion), an admin pin (operator
+        last-resort override — must not be second-guessed), or when the symbol
+        has no ticker mapped for the secondary read.
         """
         if self._crosscheck_band_bps <= 0:
             return None  # disabled
-        if price.source in ("yfinance", "admin"):
-            # yfinance: same source, not an independent second opinion.
+        from archimedes.services.market_data_provider import provider_name
+
+        if price.source in (provider_name(), "admin"):
+            # active provider: same source, not an independent second opinion.
             # admin: a last-resort operator pin (ADMIN_PRICES_JSON) — the whole point
             # is to override upstream, so the secondary guardrail must not block it.
             return None
         yf_ticker = YFINANCE_MAP.get(price.symbol)
         if not yf_ticker:
-            return None  # no independent yfinance ticker for this symbol → can't cross-check → proceed
+            return None  # no ticker mapped for this symbol → can't cross-check → proceed
         try:
             result = await self._fetch_yfinance_single(yf_ticker)
         except Exception as exc:
@@ -645,48 +665,22 @@ class OracleUpdater:
         return None
 
     def _fetch_yfinance(self, symbols: dict[str, str], timestamp: datetime) -> list[AssetPrice]:
-        """Fetch prices from yfinance (sync — call via to_thread)."""
-        try:
-            import yfinance as yf
+        """Fetch equity prices via the market-data provider seam (#1218; sync —
+        call via to_thread). Default provider is yfinance — identical
+        behavior to before this seam existed (the fetch logic itself moved to
+        ``YFinanceProvider.get_intraday_quotes_batch``, unchanged). ``source``
+        on the returned prices is the ACTIVE provider name, not a hardcoded
+        ``"yfinance"``, so a vendor swap is visible on every downstream
+        consumer of these prices (including the #775 cross-check).
+        """
+        from archimedes.services.market_data_provider import get_provider, provider_name
 
-            tickers_str = " ".join(symbols.values())
-            data = yf.download(tickers_str, period="1d", interval="1m", progress=False)
-
-            results: list[AssetPrice] = []
-            for synth_symbol, yf_ticker in symbols.items():
-                try:
-                    if data.empty:
-                        continue
-                    if len(symbols) == 1:
-                        close = data["Close"]
-                        # yfinance >=1.0 returns a 1-column DataFrame (MultiIndex
-                        # columns) for single-ticker downloads; squeeze to a Series
-                        # before taking the last value.
-                        if hasattr(close, "columns"):
-                            close = close.iloc[:, 0]
-                        price = float(close.iloc[-1])
-                    else:
-                        close = data["Close"]
-                        if yf_ticker in close.columns:
-                            price = float(close[yf_ticker].dropna().iloc[-1])
-                        else:
-                            continue
-
-                    results.append(
-                        AssetPrice(
-                            symbol=synth_symbol,
-                            price_usd=price,
-                            timestamp=timestamp,
-                            source="yfinance",
-                        )
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to fetch {synth_symbol}: {e}")
-
-            return results
-        except ImportError:
-            logger.warning("yfinance not installed — returning empty prices")
-            return []
+        quotes = get_provider().get_intraday_quotes_batch(symbols)
+        source = provider_name()
+        return [
+            AssetPrice(symbol=synth_symbol, price_usd=price, timestamp=timestamp, source=source)
+            for synth_symbol, price in quotes.items()
+        ]
 
     async def _fetch_crypto(self, timestamp: datetime) -> list[AssetPrice]:
         """Fetch crypto prices from CoinGecko API."""
@@ -715,48 +709,35 @@ class OracleUpdater:
         return results
 
     async def _fetch_yfinance_single(self, symbol: str) -> tuple[float, datetime] | None:
-        """Fetch a single yfinance price + its bar timestamp (e.g. VIX, or the
-        secondary-source cross-check's independent reading, #775).
+        """Fetch a single provider price + its bar timestamp (e.g. VIX, or the
+        secondary-source cross-check's independent reading, #775) via the
+        market-data provider seam (#1218). Default provider is yfinance —
+        identical behavior to before this seam existed (the fetch logic
+        itself moved to ``YFinanceProvider.get_intraday_quote``, unchanged;
+        this method now just runs it in a thread).
 
         Returns ``(price, bar_ts)`` on success with ``bar_ts`` normalized to a
         tz-aware UTC ``datetime``, or ``None`` on any failure (empty data, missing
         column, exception).
         """
-        try:
-            import yfinance as yf
+        from archimedes.services.market_data_provider import get_provider
 
-            data = await asyncio.to_thread(yf.download, symbol, period="1d", interval="1m", progress=False)
-            if not data.empty:
-                close = data["Close"]
-                # yfinance >=1.0 returns a 1-column DataFrame for single-ticker
-                # downloads; squeeze to a Series before taking the last value.
-                if hasattr(close, "columns"):
-                    close = close.iloc[:, 0]
-                bar_ts = data.index[-1]
-                # Normalize to tz-aware UTC. yfinance intraday bars are tz-aware
-                # (exchange-local) in current versions; if a tz-naive Timestamp ever
-                # shows up, assume UTC to match this file's existing convention for
-                # AssetPrice.timestamp (see _validate_for_push / _is_fresh above,
-                # which treat a naive timestamp as already-UTC rather than local).
-                bar_ts = bar_ts.tz_convert("UTC") if bar_ts.tzinfo is not None else bar_ts.tz_localize("UTC")
-                return float(close.iloc[-1]), bar_ts.to_pydatetime()
-        except Exception as e:
-            logger.warning(f"Failed to fetch {symbol}: {e}")
-        return None
+        return await asyncio.to_thread(get_provider().get_intraday_quote, symbol)
 
     def _fetch_sp500_moving_averages(self) -> dict[str, float]:
-        """Fetch S&P 500 50-day and 200-day moving averages."""
+        """Fetch S&P 500 50-day and 200-day moving averages via the
+        market-data provider seam (#1218) — daily bars, so this also benefits
+        from the provider's ``asset_daily_bars`` Postgres cache."""
         try:
-            import yfinance as yf
+            from archimedes.services.market_data_provider import get_provider
 
-            spy = yf.Ticker("^GSPC")
-            hist = spy.history(period="1y")
-            if hist.empty:
+            close = get_provider().get_daily_close_batch({"^GSPC": "^GSPC"}, period="1y").get("^GSPC")
+            if close is None or close.empty:
                 return {}
 
             return {
-                "ma50": float(hist["Close"].rolling(50).mean().iloc[-1]),
-                "ma200": float(hist["Close"].rolling(200).mean().iloc[-1]),
+                "ma50": float(close.rolling(50).mean().iloc[-1]),
+                "ma200": float(close.rolling(200).mean().iloc[-1]),
             }
         except Exception as e:
             logger.warning(f"Failed to fetch S&P MA data: {e}")

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -21,6 +21,7 @@ from archimedes.models.account import (
     LinkedWallet,
     WalletLinkChallenge,
 )
+from archimedes.models.asset_daily_bars import AssetDailyBar
 from archimedes.models.backtest_fixtures_store import StrategyBacktestFixture
 from archimedes.models.backtest_store import BacktestResultRecord
 from archimedes.models.chat import Base
@@ -50,6 +51,7 @@ __all__ = [
     "AuthSession",
     "AuthUser",
     "AuthVerification",
+    "AssetDailyBar",
     "BacktestResultRecord",
     "Base",
     "ControlledWallet",

--- a/backend/archimedes/models/asset_daily_bars.py
+++ b/backend/archimedes/models/asset_daily_bars.py
@@ -1,0 +1,60 @@
+"""Postgres cache of vendor daily close bars (#775 / #1218 vendor seam).
+
+One row per (symbol, trade_date). ``symbol`` is the VENDOR ticker (e.g.
+``"SPY"``, ``"^GSPC"``) rather than our internal synth symbol (e.g. ``"sSPY"``)
+— the cache is keyed on the thing that's actually fetched from the market-data
+provider, so multiple synths that happen to share an underlying ticker share
+one cached row instead of duplicating it.
+
+Populated read-through by ``archimedes.services.market_data_provider``'s
+``CachingMarketDataProvider``: a request for daily bars checks this table
+first; a coverage/freshness miss fetches the full requested window from the
+active ``MarketDataProvider`` (default yfinance) and writes it here. Shape
+modeled on ``daily_returns_store.py``'s ``StrategyDailyReturn`` (add/update by
+natural key, unique + indexed).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, Float, Index, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from archimedes.models.chat import Base
+
+
+class AssetDailyBar(Base):
+    """One daily OHLC(V) bar for one vendor ticker, cached from the active
+    market-data provider (``archimedes.services.market_data_provider``).
+
+    Re-fetching the same (symbol, trade_date) updates the row in place
+    (source + fetched_at move forward) rather than accumulating duplicates —
+    the cache reflects the vendor's latest-known value for that trading day,
+    not a history of revisions.
+    """
+
+    __tablename__ = "asset_daily_bars"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    symbol: Mapped[str] = mapped_column(String(32), nullable=False)
+    trade_date: Mapped[date] = mapped_column(Date, nullable=False)
+
+    open: Mapped[float | None] = mapped_column(Float, nullable=True)
+    high: Mapped[float | None] = mapped_column(Float, nullable=True)
+    low: Mapped[float | None] = mapped_column(Float, nullable=True)
+    close: Mapped[float] = mapped_column(Float, nullable=False)
+    volume: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Which MARKET_DATA_PROVIDER wrote this row (e.g. "yfinance") — provenance
+    # for the vendor seam; lets a future multi-vendor cache tell rows apart.
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    # When this row was (last) written — the cache-freshness clock. Distinct
+    # from trade_date: a bar for a date weeks ago can be freshly re-verified
+    # today, and a bar fetched today is trade_date=today but stamped "just now".
+    fetched_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("symbol", "trade_date", name="uq_asset_daily_bars_symbol_trade_date"),
+        Index("ix_asset_daily_bars_symbol", "symbol"),
+    )

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -152,12 +152,16 @@ def _realized_vol_annual(prices: list[float], window: int = 30) -> float | None:
 
 
 def _fetch_yfinance_series(symbol: str, period: str, interval: str) -> list[ExploreHistoryPoint]:
-    """Fetch a single-asset time series at the requested period+interval.
+    """Fetch a single-asset time series at the requested period+interval, via
+    the market-data provider seam (#1218 — default provider yfinance,
+    unchanged behavior; vendor-swappable via ``MARKET_DATA_PROVIDER``).
 
-    Returns an empty list when the symbol is unknown, yfinance is unavailable,
-    or the upstream feed returned no data. The caller (route handler) turns
-    an empty list into a 404 so the frontend can render an honest empty state
-    instead of a faked flat line.
+    Returns an empty list when the symbol is unknown, the provider is
+    unavailable, or the upstream feed returned no data. The caller (route
+    handler) turns an empty list into a 404 so the frontend can render an
+    honest empty state instead of a faked flat line. Uncached (a per-request,
+    single-symbol drill-down — not the #1218 volume driver; see
+    ``market_data_provider``'s module docstring for the caching scope).
     """
     try:
         from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
@@ -171,32 +175,14 @@ def _fetch_yfinance_series(symbol: str, period: str, interval: str) -> list[Expl
         return []
 
     try:
-        import yfinance as yf
+        from archimedes.services.market_data_provider import get_provider
 
-        data = yf.download(
-            yf_ticker,
-            period=period,
-            interval=interval,
-            progress=False,
-            auto_adjust=True,
-            threads=False,
-        )
+        close = get_provider().get_series(yf_ticker, period, interval)
     except Exception as exc:
-        logger.warning("explore: yfinance history fetch failed for %s (%s/%s): %s", symbol, period, interval, exc)
+        logger.warning("explore: market-data history fetch failed for %s (%s/%s): %s", symbol, period, interval, exc)
         return []
 
-    if data is None or len(data) == 0:
-        return []
-
-    try:
-        close = data["Close"]
-        # When yfinance is called with a single ticker it sometimes still returns
-        # a DataFrame (one column). Squeeze to a Series for uniform handling.
-        if hasattr(close, "columns"):
-            close = close.iloc[:, 0]
-        close = close.dropna()
-    except Exception as exc:
-        logger.warning("explore: yfinance close extract failed for %s: %s", symbol, exc)
+    if close is None or close.empty:
         return []
 
     points: list[ExploreHistoryPoint] = []

--- a/backend/archimedes/services/market_data_provider.py
+++ b/backend/archimedes/services/market_data_provider.py
@@ -47,6 +47,7 @@ from abc import ABC, abstractmethod
 from datetime import UTC, date, datetime, timedelta
 
 import pandas as pd
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 logger = logging.getLogger(__name__)
 
@@ -408,6 +409,9 @@ class CachingMarketDataProvider(MarketDataProvider):
             return result
 
         fetched = self._inner.get_daily_close_batch(missing, period)
+        # Merge BEFORE priming: the fetch succeeded, and the caller gets that
+        # data no matter what happens to the best-effort cache write below.
+        result.update(fetched)
         if fetched:
             session = self._session_factory()
             try:
@@ -417,10 +421,22 @@ class CachingMarketDataProvider(MarketDataProvider):
                         continue
                     _write_cached_series(session, ticker, series, self._source_name)
                 session.commit()
+            except IntegrityError:
+                # Concurrent writers priming the same cold window (two tasks,
+                # or the refresh loop overlapping a request sweep): the loser
+                # trips uq_asset_daily_bars_symbol_trade_date at commit. The
+                # winner's rows are equivalent vendor data, so this is benign —
+                # roll back and serve the fetch; the next read is warm.
+                session.rollback()
+                logger.info("asset_daily_bars prime lost a concurrent-writer race (benign); next read is warm")
+            except SQLAlchemyError:
+                # Any other cache-write failure is still only a cache failure —
+                # loud, but never allowed to discard a successful fetch.
+                session.rollback()
+                logger.warning("asset_daily_bars cache write failed (fetch still served)", exc_info=True)
             finally:
                 session.close()
 
-        result.update(fetched)
         return result
 
     def get_intraday_quote(self, ticker: str) -> tuple[float, datetime] | None:

--- a/backend/archimedes/services/market_data_provider.py
+++ b/backend/archimedes/services/market_data_provider.py
@@ -1,0 +1,443 @@
+"""Market-data vendor seam (#775 / #1218).
+
+#1218 priced yfinance as an unlicensed commercial dependency that scales with
+strategies x symbols x re-run cadence, and named the seam it should be
+substituted at. This module IS that seam for backend's live/request-path call
+sites (analytics-engine's own choke point — ``fetch_ohlcv`` — gets the
+equivalent treatment in ``archimedes_analytics_engine.market_data``; the two
+are separate modules because analytics-engine is a standalone, DB-less
+package, but both read the SAME ``MARKET_DATA_PROVIDER`` env var and default
+to ``"yfinance"``, so a deploy of this change is a no-op until the flag
+flips).
+
+Three call sites route through here (grep-verified):
+  - ``strategy_signal_evaluator._fetch_price_history(ies)`` — daily close
+    series for backtests/Explore's universe sweep (the #1218 volume driver).
+  - ``chain.oracle_updater`` — the live oracle-push equity fetch, the VIX /
+    S&P-MA regime reads, and the #775 secondary-source cross-check's
+    independent reading.
+  - ``services.asset_market_service._fetch_yfinance_series`` — the Explore
+    per-asset history-modal endpoint.
+
+**#775 resolution, in one line:** the cross-check
+(``oracle_updater._cross_check_secondary``) reads its independent secondary
+through ``get_provider()`` and treats ``provider_name()`` (not a hardcoded
+``"yfinance"``) as "same source, skip". Swap ``MARKET_DATA_PROVIDER`` to a
+new vendor and the cross-check's secondary source swaps with it automatically
+— no separate change needed at the guardrail.
+
+**Caching, scoped intentionally.** Only ``get_daily_close_batch`` — the
+DAILY-bar shape that matches ``asset_daily_bars`` — is cache-backed
+(``CachingMarketDataProvider``). ``get_intraday_quote(s)`` (live oracle
+pushes, VIX, the cross-check's secondary) and ``get_series`` (the Explore
+history modal, any interval) pass straight through, uncached, on purpose: a
+stale daily close must never masquerade as a live push/guardrail reading, and
+a single-symbol drill-down isn't the volume driver #1218 identified — the
+280-symbol universe sweep behind ``get_daily_close_batch`` is. Background
+refresh is deliberately NOT built here (#1218 anti-goal: seam, not
+migration) — the cache primes itself on the first miss.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from abc import ABC, abstractmethod
+from datetime import UTC, date, datetime, timedelta
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# yfinance period vocabulary -> approximate calendar days, used to derive a
+# cache coverage window. Approximate on purpose (trading days < calendar
+# days); the +5-day tolerance in _read_cached_series absorbs the slack.
+_PERIOD_DAYS: dict[str, int] = {
+    "1d": 1,
+    "5d": 5,
+    "1mo": 31,
+    "3mo": 93,
+    "6mo": 186,
+    "1y": 366,
+    "2y": 731,
+    "5y": 1827,
+    "10y": 3653,
+    "ytd": 366,
+    "max": 3653 * 4,
+}
+_DEFAULT_PERIOD_DAYS = 731  # ~2y — matches the evaluator's own default period
+
+# How much back-history the cache must already hold, relative to the
+# requested window's start, to count as "covers this request". Trading-day
+# gaps (weekends/holidays) plus vendor listing-date differences mean an exact
+# match is too strict.
+_COVERAGE_TOLERANCE_DAYS = 5
+
+# How long a cached row is trusted before a request re-fetches it live.
+# Configurable because "how often is it OK to be a day stale" is a product
+# call, not a code constant — default errs toward freshness (daily bars
+# genuinely change once a day; the point of the cache is to not re-fetch on
+# every request within that window, not to go stale for a week).
+DEFAULT_CACHE_TTL_HOURS = 12
+
+
+def _int_env(name: str, default: int) -> int:
+    """Parse an integer env var, failing SAFE to ``default`` (mirrors
+    ``chain.oracle_updater._int_env`` — same fail-safe convention)."""
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        logger.warning("invalid %s=%r (not an integer) — falling back to %d", name, raw, default)
+        return default
+
+
+# ─── Provider interface ─────────────────────────────────────────────────
+
+
+class MarketDataProvider(ABC):
+    """Vendor abstraction for market data. Default implementation (below) is
+    yfinance, unchanged in behavior from what each call site did before this
+    seam existed. A new vendor implements this interface and registers in
+    ``_VENDOR_PROVIDERS``; ``MARKET_DATA_PROVIDER`` selects it."""
+
+    @abstractmethod
+    def get_daily_close_batch(self, tickers: dict[str, str], period: str) -> dict[str, pd.Series]:
+        """Batch daily close-price series. ``tickers`` maps caller-chosen keys
+        (our synth symbols) to vendor tickers; the result is keyed the same
+        way. Missing/failed tickers are simply absent from the result."""
+
+    @abstractmethod
+    def get_intraday_quote(self, ticker: str) -> tuple[float, datetime] | None:
+        """Latest intraday (price, bar_timestamp) for one vendor ticker, or
+        None on any failure. Never cached — see module docstring."""
+
+    @abstractmethod
+    def get_intraday_quotes_batch(self, tickers: dict[str, str]) -> dict[str, float]:
+        """Latest intraday price for many tickers in one vendor call. Keyed
+        like ``get_daily_close_batch``. Never cached."""
+
+    @abstractmethod
+    def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
+        """Generic close-price series at an arbitrary (period, interval) —
+        the Explore history-modal shape. Never cached."""
+
+
+class YFinanceProvider(MarketDataProvider):
+    """Default provider — today's yfinance behavior, unchanged. Each method
+    body is a straight move of the logic that used to live inline at its
+    call site (see the docstring in each caller for the #1218 provenance)."""
+
+    def get_daily_close_batch(self, tickers: dict[str, str], period: str) -> dict[str, pd.Series]:
+        if not tickers:
+            return {}
+        try:
+            import yfinance as yf
+        except ImportError:
+            logger.warning("yfinance not installed — returning empty histories")
+            return {}
+
+        yf_tickers = list(tickers.values())
+        try:
+            data = yf.download(
+                tickers=" ".join(yf_tickers),
+                period=period,
+                interval="1d",
+                progress=False,
+                auto_adjust=True,
+                group_by="ticker",
+                threads=True,
+            )
+        except Exception as exc:
+            logger.warning("Batched yfinance fetch failed: %s", exc)
+            return {}
+
+        if data is None or len(data) == 0:
+            return {}
+
+        result: dict[str, pd.Series] = {}
+
+        if len(yf_tickers) == 1:
+            sole_key = next(iter(tickers))
+            try:
+                close = data["Close"]
+                if isinstance(close, pd.DataFrame):
+                    close = close.iloc[:, 0]
+                close = close.dropna()
+                close.name = sole_key
+                if not close.empty:
+                    result[sole_key] = close
+            except Exception as exc:
+                logger.warning("Failed to extract Close for %s: %s", sole_key, exc)
+            return result
+
+        for key, yf_ticker in tickers.items():
+            try:
+                if isinstance(data.columns, pd.MultiIndex):
+                    if yf_ticker not in data.columns.get_level_values(0):
+                        continue
+                    close = data[yf_ticker]["Close"]
+                else:
+                    close = data["Close"]
+                if isinstance(close, pd.DataFrame):
+                    close = close.iloc[:, 0]
+                close = close.dropna()
+                if close.empty:
+                    continue
+                close.name = key
+                result[key] = close
+            except Exception as exc:
+                logger.warning("Failed to extract %s (%s): %s", key, yf_ticker, exc)
+        return result
+
+    def get_intraday_quote(self, ticker: str) -> tuple[float, datetime] | None:
+        try:
+            import yfinance as yf
+
+            data = yf.download(ticker, period="1d", interval="1m", progress=False)
+            if not data.empty:
+                close = data["Close"]
+                if hasattr(close, "columns"):
+                    close = close.iloc[:, 0]
+                bar_ts = data.index[-1]
+                bar_ts = bar_ts.tz_convert("UTC") if bar_ts.tzinfo is not None else bar_ts.tz_localize("UTC")
+                return float(close.iloc[-1]), bar_ts.to_pydatetime()
+        except Exception as exc:
+            logger.warning("Failed to fetch %s: %s", ticker, exc)
+        return None
+
+    def get_intraday_quotes_batch(self, tickers: dict[str, str]) -> dict[str, float]:
+        try:
+            import yfinance as yf
+        except ImportError:
+            logger.warning("yfinance not installed — returning empty prices")
+            return {}
+
+        tickers_str = " ".join(tickers.values())
+        data = yf.download(tickers_str, period="1d", interval="1m", progress=False)
+
+        results: dict[str, float] = {}
+        for key, yf_ticker in tickers.items():
+            try:
+                if data.empty:
+                    continue
+                if len(tickers) == 1:
+                    close = data["Close"]
+                    if hasattr(close, "columns"):
+                        close = close.iloc[:, 0]
+                    price = float(close.iloc[-1])
+                else:
+                    close = data["Close"]
+                    if yf_ticker in close.columns:
+                        price = float(close[yf_ticker].dropna().iloc[-1])
+                    else:
+                        continue
+                results[key] = price
+            except Exception as exc:
+                logger.warning("Failed to fetch %s: %s", key, exc)
+        return results
+
+    def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
+        try:
+            import yfinance as yf
+
+            data = yf.download(
+                ticker,
+                period=period,
+                interval=interval,
+                progress=False,
+                auto_adjust=True,
+                threads=False,
+            )
+        except Exception as exc:
+            logger.warning("Failed to fetch series for %s (%s/%s): %s", ticker, period, interval, exc)
+            return pd.Series(dtype=float)
+
+        if data is None or len(data) == 0:
+            return pd.Series(dtype=float)
+        try:
+            close = data["Close"]
+            if hasattr(close, "columns"):
+                close = close.iloc[:, 0]
+            return close.dropna()
+        except Exception as exc:
+            logger.warning("Failed to extract Close for %s: %s", ticker, exc)
+            return pd.Series(dtype=float)
+
+
+_VENDOR_PROVIDERS: dict[str, type[MarketDataProvider]] = {
+    "yfinance": YFinanceProvider,
+}
+
+
+def provider_name() -> str:
+    """The active vendor name: ``MARKET_DATA_PROVIDER`` env, default
+    ``"yfinance"``. An unrecognized value fails SAFE to the default (logged),
+    matching this codebase's other mode switches (e.g.
+    ``price_source.price_source_mode``, ``oracle_updater._int_env``) rather
+    than crashing a live process over a config typo."""
+    raw = os.getenv("MARKET_DATA_PROVIDER", "yfinance").strip().lower()
+    if raw not in _VENDOR_PROVIDERS:
+        logger.warning("unknown MARKET_DATA_PROVIDER=%r — falling back to yfinance", raw)
+        return "yfinance"
+    return raw
+
+
+# ─── Postgres read-through cache (asset_daily_bars) ────────────────────
+
+
+def _period_to_start_date(period: str, now: datetime) -> date:
+    days = _PERIOD_DAYS.get(period, _DEFAULT_PERIOD_DAYS)
+    return (now - timedelta(days=days)).date()
+
+
+def _default_session_factory():
+    from archimedes.db import get_session
+
+    return get_session()
+
+
+def _read_cached_series(session, ticker: str, start_date: date, ttl: timedelta) -> pd.Series | None:
+    """Return a cached close-price ``Series`` for ``ticker`` if the cache both
+    covers back to (approximately) ``start_date`` and was written within
+    ``ttl``. ``None`` on a coverage or freshness miss (caller re-fetches)."""
+    from archimedes.models.asset_daily_bars import AssetDailyBar
+
+    rows = (
+        session.query(AssetDailyBar)
+        .filter(AssetDailyBar.symbol == ticker, AssetDailyBar.trade_date >= start_date)
+        .order_by(AssetDailyBar.trade_date)
+        .all()
+    )
+    if not rows:
+        return None
+
+    earliest = rows[0].trade_date
+    if earliest > start_date + timedelta(days=_COVERAGE_TOLERANCE_DAYS):
+        return None  # cache doesn't reach back far enough for this request
+
+    newest_fetch = max(r.fetched_at for r in rows)
+    if newest_fetch.tzinfo is None:
+        newest_fetch = newest_fetch.replace(tzinfo=UTC)
+    if datetime.now(UTC) - newest_fetch > ttl:
+        return None  # cache is past its freshness window
+
+    idx = pd.to_datetime([r.trade_date for r in rows])
+    return pd.Series([r.close for r in rows], index=idx, name=ticker)
+
+
+def _write_cached_series(session, ticker: str, series: pd.Series, source: str) -> None:
+    """Upsert ``series`` (close prices indexed by date) into ``asset_daily_bars``
+    for ``ticker``, dialect-agnostic (works on SQLite in tests and Postgres in
+    prod) via select-then-add/update rather than a dialect-specific ON
+    CONFLICT clause."""
+    from archimedes.models.asset_daily_bars import AssetDailyBar
+
+    now = datetime.now(UTC)
+    to_write: list[tuple[date, float]] = []
+    for ts, close in series.items():
+        try:
+            close_f = float(close)
+        except (TypeError, ValueError):
+            continue
+        if math.isnan(close_f):
+            continue
+        trade_date = ts.date() if hasattr(ts, "date") else ts
+        to_write.append((trade_date, close_f))
+    if not to_write:
+        return
+
+    dates = [d for d, _ in to_write]
+    existing = {
+        row.trade_date: row
+        for row in session.query(AssetDailyBar)
+        .filter(AssetDailyBar.symbol == ticker, AssetDailyBar.trade_date.in_(dates))
+        .all()
+    }
+    for trade_date, close_f in to_write:
+        row = existing.get(trade_date)
+        if row is not None:
+            row.close = close_f
+            row.source = source
+            row.fetched_at = now
+        else:
+            session.add(
+                AssetDailyBar(
+                    symbol=ticker,
+                    trade_date=trade_date,
+                    close=close_f,
+                    source=source,
+                    fetched_at=now,
+                )
+            )
+
+
+class CachingMarketDataProvider(MarketDataProvider):
+    """Wraps another provider with the Postgres ``asset_daily_bars``
+    read-through cache for ``get_daily_close_batch`` only. Every other method
+    passes straight through, uncached — see the module docstring for why."""
+
+    def __init__(self, inner: MarketDataProvider, source_name: str, session_factory=None) -> None:
+        self._inner = inner
+        self._source_name = source_name
+        self._session_factory = session_factory or _default_session_factory
+        self._ttl = timedelta(hours=_int_env("MARKET_DATA_CACHE_TTL_HOURS", DEFAULT_CACHE_TTL_HOURS))
+
+    def get_daily_close_batch(self, tickers: dict[str, str], period: str) -> dict[str, pd.Series]:
+        if not tickers:
+            return {}
+        start_date = _period_to_start_date(period, datetime.now(UTC))
+
+        result: dict[str, pd.Series] = {}
+        missing: dict[str, str] = {}
+        session = self._session_factory()
+        try:
+            for key, ticker in tickers.items():
+                series = _read_cached_series(session, ticker, start_date, self._ttl)
+                if series is not None:
+                    result[key] = series
+                else:
+                    missing[key] = ticker
+        finally:
+            session.close()
+
+        if not missing:
+            return result
+
+        fetched = self._inner.get_daily_close_batch(missing, period)
+        if fetched:
+            session = self._session_factory()
+            try:
+                for key, series in fetched.items():
+                    ticker = missing.get(key)
+                    if ticker is None or series is None or series.empty:
+                        continue
+                    _write_cached_series(session, ticker, series, self._source_name)
+                session.commit()
+            finally:
+                session.close()
+
+        result.update(fetched)
+        return result
+
+    def get_intraday_quote(self, ticker: str) -> tuple[float, datetime] | None:
+        return self._inner.get_intraday_quote(ticker)
+
+    def get_intraday_quotes_batch(self, tickers: dict[str, str]) -> dict[str, float]:
+        return self._inner.get_intraday_quotes_batch(tickers)
+
+    def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
+        return self._inner.get_series(ticker, period, interval)
+
+
+def get_provider() -> MarketDataProvider:
+    """The active provider, cache-wrapped. Call sites use this — never
+    ``YFinanceProvider`` (or ``yfinance``) directly — so a vendor swap via
+    ``MARKET_DATA_PROVIDER`` changes every choke point (including the #775
+    cross-check's secondary source) in one place."""
+    name = provider_name()
+    vendor = _VENDOR_PROVIDERS[name]()
+    return CachingMarketDataProvider(vendor, source_name=name)

--- a/backend/archimedes/services/strategy_signal_evaluator.py
+++ b/backend/archimedes/services/strategy_signal_evaluator.py
@@ -585,11 +585,20 @@ def verify_universe_data_quality(
     return verify_universe(tickers, start, end, _downloader=_downloader)
 
 
-def _fetch_price_history(symbol: str, period: str = "2y", interval: str = "1d") -> pd.Series:
+def _fetch_price_history(symbol: str, period: str = "2y") -> pd.Series:
     """Fetch daily closing prices for a single synth symbol (with cache).
 
     Used as a fallback; the batched variant below is preferred for
-    multi-asset scans.
+    multi-asset scans. Always daily — the vendor seam's cache
+    (``asset_daily_bars``) is daily-grained; a prior ``interval`` parameter
+    was dropped since every caller left it at its "1d" default anyway.
+
+    Fetch goes through the market-data provider seam (#1218:
+    ``archimedes.services.market_data_provider``) rather than yfinance
+    directly — vendor-swappable via ``MARKET_DATA_PROVIDER``, and the
+    provider's own Postgres cache means a warm request never re-hits the
+    vendor live. This in-process ``_cache_get``/``_cache_put`` layer is
+    unchanged (hot 600s TTL in front of that).
     """
     cached = _cache_get(symbol)
     if cached is not None:
@@ -601,23 +610,14 @@ def _fetch_price_history(symbol: str, period: str = "2y", interval: str = "1d") 
     yf_ticker = entry[0]
 
     try:
-        import yfinance as yf
+        from archimedes.services.market_data_provider import get_provider
 
-        data = yf.download(
-            yf_ticker,
-            period=period,
-            interval=interval,
-            progress=False,
-            auto_adjust=True,
-            threads=False,
-        )
-        if data.empty:
+        fetched = get_provider().get_daily_close_batch({symbol: yf_ticker}, period=period)
+        close = fetched.get(symbol)
+        if close is None or close.empty:
             return pd.Series(dtype=float)
-        close = data["Close"]
-        if isinstance(close, pd.DataFrame):
-            close = close.iloc[:, 0]
+        close = close.copy()
         close.name = symbol
-        close = close.dropna()
         _cache_put(symbol, close)
         return close
     except Exception as e:
@@ -631,9 +631,12 @@ def _fetch_price_histories(
 ) -> dict[str, pd.Series]:
     """Batch-fetch price histories for many synth symbols.
 
-    Uses a single yfinance.download() call for everything that is not
-    already in cache.  Failed/empty tickers are simply omitted from
-    the result.
+    Uses a single batched call to the market-data provider (#1218 seam) for
+    everything that is not already in the in-process cache. Failed/empty
+    tickers are simply omitted from the result. The provider's own
+    ``asset_daily_bars`` Postgres cache sits underneath this — a cold
+    in-process cache does not necessarily mean a live vendor hit; it may be
+    served from Postgres instead.
     """
     result: dict[str, pd.Series] = {}
     # First pass: serve from cache
@@ -648,7 +651,7 @@ def _fetch_price_histories(
     if not to_fetch_synths:
         return result
 
-    # Build the yfinance ticker list (skip unknown synths)
+    # Build the ticker list (skip unknown synths)
     ticker_for_synth: dict[str, str] = {}
     for sym in to_fetch_synths:
         entry = GLOBAL_ASSETS.get(sym)
@@ -657,21 +660,12 @@ def _fetch_price_histories(
     if not ticker_for_synth:
         return result
 
-    yf_tickers = list(ticker_for_synth.values())
     try:
-        import yfinance as yf
+        from archimedes.services.market_data_provider import get_provider
 
-        data = yf.download(
-            tickers=" ".join(yf_tickers),
-            period=period,
-            interval="1d",
-            progress=False,
-            auto_adjust=True,
-            group_by="ticker",
-            threads=True,
-        )
+        fetched = get_provider().get_daily_close_batch(ticker_for_synth, period=period)
     except Exception as e:
-        logger.warning("Batched yfinance fetch failed: %s", e)
+        logger.warning("Batched market-data fetch failed: %s", e)
         # Fall back to per-symbol fetch for the ones we still need
         for sym in to_fetch_synths:
             series = _fetch_price_history(sym, period=period)
@@ -679,44 +673,13 @@ def _fetch_price_histories(
                 result[sym] = series
         return result
 
-    # Unpack the batched response (yfinance returns a MultiIndex
-    # frame when given >1 ticker; a flat frame when given 1).
-    if data is None or len(data) == 0:
-        return result
-
-    if len(yf_tickers) == 1:
-        sole_synth = next(iter(ticker_for_synth))
-        try:
-            close = data["Close"]
-            if isinstance(close, pd.DataFrame):
-                close = close.iloc[:, 0]
-            close = close.dropna()
-            close.name = sole_synth
-            if not close.empty:
-                _cache_put(sole_synth, close)
-                result[sole_synth] = close
-        except Exception as e:
-            logger.warning("Failed to extract Close for %s: %s", sole_synth, e)
-        return result
-
-    for synth, yf_ticker in ticker_for_synth.items():
-        try:
-            if isinstance(data.columns, pd.MultiIndex):
-                if yf_ticker not in data.columns.get_level_values(0):
-                    continue
-                close = data[yf_ticker]["Close"]
-            else:
-                close = data["Close"]
-            if isinstance(close, pd.DataFrame):
-                close = close.iloc[:, 0]
-            close = close.dropna()
-            if close.empty:
-                continue
-            close.name = synth
-            _cache_put(synth, close)
-            result[synth] = close
-        except Exception as e:
-            logger.warning("Failed to extract %s (%s): %s", synth, yf_ticker, e)
+    for synth, series in fetched.items():
+        if series is None or series.empty:
+            continue
+        series = series.copy()
+        series.name = synth
+        _cache_put(synth, series)
+        result[synth] = series
 
     return result
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -47,6 +47,7 @@ from archimedes.models.account import (  # noqa: E402
     LinkedWallet,
     WalletLinkChallenge,
 )
+from archimedes.models.asset_daily_bars import AssetDailyBar  # noqa: E402
 from archimedes.models.backtest_fixtures_store import StrategyBacktestFixture  # noqa: E402
 from archimedes.models.backtest_store import BacktestResultRecord  # noqa: E402
 from archimedes.models.chat import Base  # noqa: E402
@@ -82,6 +83,7 @@ __all__ = [
     "AuthSession",
     "AuthUser",
     "AuthVerification",
+    "AssetDailyBar",
     "BacktestResultRecord",
     "Base",
     "ControlledWallet",

--- a/backend/migrations/versions/c9396e0d95d4_add_asset_daily_bars_vendor_cache_table.py
+++ b/backend/migrations/versions/c9396e0d95d4_add_asset_daily_bars_vendor_cache_table.py
@@ -1,0 +1,62 @@
+"""add asset_daily_bars vendor cache table
+
+Market-data vendor seam (#775 / #1218): a Postgres read-through cache of
+daily close bars, fronting the swappable ``MarketDataProvider`` (default
+yfinance, see ``archimedes.services.market_data_provider``). Populated on
+miss by the provider's ``CachingMarketDataProvider`` — this migration only
+creates the empty table; no backfill (there is nothing to backfill: the
+table did not exist before, and the cache primes itself from the first live
+read).
+
+Chained onto ``b41c7d9e2a05`` — the actual head of ``origin/main`` at the
+time this migration was written. Note: #1194 (unmerged as of this PR) also
+adds a migration, ``b7e3f1a2c9d4``, off the SAME parent; whichever of the
+two merges second will need a trivial re-serialize (rebase this revision's
+``down_revision`` onto the other's id, or vice versa) — expected, not a bug.
+
+Revision ID: c9396e0d95d4
+Revises: b41c7d9e2a05
+Create Date: 2026-08-19 09:16:04.228106
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9396e0d95d4"
+down_revision: str | Sequence[str] | None = "b41c7d9e2a05"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "asset_daily_bars",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("symbol", sa.String(length=32), nullable=False),
+        sa.Column("trade_date", sa.Date(), nullable=False),
+        sa.Column("open", sa.Float(), nullable=True),
+        sa.Column("high", sa.Float(), nullable=True),
+        sa.Column("low", sa.Float(), nullable=True),
+        sa.Column("close", sa.Float(), nullable=False),
+        sa.Column("volume", sa.Float(), nullable=True),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("symbol", "trade_date", name="uq_asset_daily_bars_symbol_trade_date"),
+    )
+    with op.batch_alter_table("asset_daily_bars", schema=None) as batch_op:
+        batch_op.create_index("ix_asset_daily_bars_symbol", ["symbol"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("asset_daily_bars", schema=None) as batch_op:
+        batch_op.drop_index("ix_asset_daily_bars_symbol")
+    op.drop_table("asset_daily_bars")

--- a/backend/migrations/versions/c9396e0d95d4_add_asset_daily_bars_vendor_cache_table.py
+++ b/backend/migrations/versions/c9396e0d95d4_add_asset_daily_bars_vendor_cache_table.py
@@ -8,14 +8,13 @@ creates the empty table; no backfill (there is nothing to backfill: the
 table did not exist before, and the cache primes itself from the first live
 read).
 
-Chained onto ``b41c7d9e2a05`` — the actual head of ``origin/main`` at the
-time this migration was written. Note: #1194 (unmerged as of this PR) also
-adds a migration, ``b7e3f1a2c9d4``, off the SAME parent; whichever of the
-two merges second will need a trivial re-serialize (rebase this revision's
-``down_revision`` onto the other's id, or vice versa) — expected, not a bug.
+Chained onto ``c9f2e8d4a1b7`` (paper trading) — re-serialized 2026-08-19
+after the merge train landed #1194 (``b7e3f1a2c9d4``) and #1268
+(``c9f2e8d4a1b7``); originally authored against ``b41c7d9e2a05``, with the
+re-point predicted in this docstring from day one. Chain stays serial.
 
 Revision ID: c9396e0d95d4
-Revises: b41c7d9e2a05
+Revises: c9f2e8d4a1b7
 Create Date: 2026-08-19 09:16:04.228106
 
 """
@@ -29,7 +28,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "c9396e0d95d4"
-down_revision: str | Sequence[str] | None = "b41c7d9e2a05"
+down_revision: str | Sequence[str] | None = "c9f2e8d4a1b7"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/tests/chain/test_oracle_crosscheck.py
+++ b/backend/tests/chain/test_oracle_crosscheck.py
@@ -70,6 +70,31 @@ async def test_yfinance_primary_is_noop():
     m.assert_not_called()
 
 
+async def test_vendor_swap_moves_the_same_source_noop_with_it():
+    """#1218/#775 seam tie-in: the "same source, skip" guard reads the ACTIVE
+    provider (``market_data_provider.provider_name()``), not a hardcoded
+    "yfinance" — so swapping ``MARKET_DATA_PROVIDER`` swaps which source the
+    cross-check treats as "not independent" without touching this guardrail's
+    own code.
+    """
+    from archimedes.services import market_data_provider as mdp
+
+    u = _updater()
+    with patch.object(mdp, "provider_name", return_value="acme_vendor"):
+        # A price whose source now MATCHES the (swapped) active provider is a
+        # no-op — same as "yfinance" was under the default provider.
+        with patch.object(u, "_fetch_yfinance_single", AsyncMock()) as m:
+            assert await u._cross_check_secondary(_price(source="acme_vendor")) is None
+        m.assert_not_called()
+
+        # A price sourced "yfinance" is NO LONGER the active provider once
+        # swapped — it must now actually go through the cross-check instead
+        # of being waved through as "same source".
+        with patch.object(u, "_fetch_yfinance_single", AsyncMock(return_value=(510.0, _fresh_ts()))) as m:
+            assert await u._cross_check_secondary(_price(source="yfinance", usd=500.0)) is None
+        m.assert_called_once()  # actually fetched + compared this time
+
+
 async def test_admin_source_is_noop():
     # An admin pin (ADMIN_PRICES_JSON last-resort operator override) must NOT be
     # second-guessed by the secondary guardrail — the whole point is to override

--- a/backend/tests/chain/test_oracle_updater_fetch.py
+++ b/backend/tests/chain/test_oracle_updater_fetch.py
@@ -8,6 +8,17 @@ public-key fetch, and the no-credentials push early-return.
 
 Hermetic: yfinance is replaced with a fake module via sys.modules; the aiohttp
 CoinGecko/Circle boundary is mocked. No network, no Arc RPC, no Circle.
+
+``archimedes.services.market_data_provider`` is imported here at module level
+(not just where it's used below) so it's already in ``sys.modules`` before any
+test's ``patch.dict(sys.modules, {"yfinance": ...})`` runs. That context
+manager restores ``sys.modules`` to its pre-``with`` snapshot on exit — a
+module first imported (by the code under test, via a *lazy* import inside the
+patched block) is wiped along with it, since it isn't in that snapshot. The
+oracle-push / cross-check paths lazily import ``market_data_provider`` inside
+``patch.dict(sys.modules, {"yfinance": ...})`` blocks below (#1218 seam); this
+import guarantees a stable module identity for ``TestSp500MovingAverages``'s
+own ``patch.object(mdp, "get_provider", ...)`` regardless of run order.
 """
 
 from __future__ import annotations
@@ -19,6 +30,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from archimedes.chain.oracle_updater import OracleUpdater
 from archimedes.models.asset import AssetPrice
+from archimedes.services import market_data_provider as mdp  # see module docstring above
 
 
 @pytest.fixture
@@ -186,17 +198,28 @@ class TestFetchYfinanceSingle:
 
 class TestSp500MovingAverages:
     def test_computes_rolling_means(self, updater):
+        # #1218 seam: the fetch now goes through get_provider().get_daily_close_batch
+        # rather than yf.Ticker(...).history() directly — mock at that boundary
+        # (market_data_provider is preloaded at this file's top, see the comment
+        # there — patch.object needs its target module identity stable across
+        # this file's patch.dict(sys.modules, {"yfinance": ...}) tests).
         import pandas as pd
 
-        hist = pd.DataFrame({"Close": list(range(1, 301))})
-        ticker = MagicMock()
-        ticker.history = MagicMock(return_value=hist)
-        fake_yf = MagicMock()
-        fake_yf.Ticker = MagicMock(return_value=ticker)
-        with patch.dict(sys.modules, {"yfinance": fake_yf}):
+        close = pd.Series(range(1, 301), index=pd.date_range("2024-01-01", periods=300), name="^GSPC")
+        fake_provider = MagicMock()
+        fake_provider.get_daily_close_batch = MagicMock(return_value={"^GSPC": close})
+        with patch.object(mdp, "get_provider", return_value=fake_provider):
             mas = updater._fetch_sp500_moving_averages()
         # rolling(50)/(200) means over 1..300 → finite numbers, ma200 < ma50.
         assert mas["ma50"] > mas["ma200"] > 0
+
+    def test_empty_series_returns_empty_dict(self, updater):
+        import pandas as pd
+
+        fake_provider = MagicMock()
+        fake_provider.get_daily_close_batch = MagicMock(return_value={"^GSPC": pd.Series(dtype=float)})
+        with patch.object(mdp, "get_provider", return_value=fake_provider):
+            assert updater._fetch_sp500_moving_averages() == {}
 
     def test_empty_history_returns_empty_dict(self, updater):
         import pandas as pd

--- a/backend/tests/services/test_market_data_provider.py
+++ b/backend/tests/services/test_market_data_provider.py
@@ -1,0 +1,264 @@
+"""Hermetic tests for the #1218 / #775 market-data vendor seam.
+
+Covers: provider selection (default + unknown-value fail-safe), the
+``asset_daily_bars`` Postgres cache's read-through/miss/freshness/coverage
+behavior, and that the intraday methods (live oracle pushes, the #775
+cross-check's secondary reading) are never routed through that cache.
+
+Hermetic: an isolated, fresh SQLite engine (not the module-level
+``archimedes.db`` singleton) is injected via ``session_factory`` — no real DB,
+no network. The vendor boundary (``MarketDataProvider``) is a hand-rolled
+fake, not real yfinance.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from archimedes.services.market_data_provider import (
+    CachingMarketDataProvider,
+    MarketDataProvider,
+    YFinanceProvider,
+    get_provider,
+    provider_name,
+)
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# ─── Provider selection ────────────────────────────────────────────────
+
+
+class TestProviderSelection:
+    def test_default_is_yfinance(self, monkeypatch):
+        monkeypatch.delenv("MARKET_DATA_PROVIDER", raising=False)
+        assert provider_name() == "yfinance"
+
+    def test_explicit_yfinance(self, monkeypatch):
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "yfinance")
+        assert provider_name() == "yfinance"
+
+    def test_unknown_value_falls_back_to_yfinance(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "some_unreleased_vendor")
+        with caplog.at_level(logging.WARNING):
+            assert provider_name() == "yfinance"
+        assert any("some_unreleased_vendor" in rec.message for rec in caplog.records)
+
+    def test_case_and_whitespace_insensitive(self, monkeypatch):
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "  YFinance  ")
+        assert provider_name() == "yfinance"
+
+    def test_get_provider_wraps_vendor_in_caching_provider(self):
+        assert isinstance(get_provider(), CachingMarketDataProvider)
+        # The inner vendor is the default (yfinance) implementation.
+        assert isinstance(get_provider()._inner, YFinanceProvider)
+
+
+# ─── Cache read-through / miss ──────────────────────────────────────────
+
+
+@pytest.fixture()
+def session_factory(tmp_path):
+    """An isolated SQLite engine/session factory with asset_daily_bars
+    created — independent of the app's module-level engine."""
+    from archimedes.db import Base
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'market_data.db'}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)
+
+
+class _FakeVendor(MarketDataProvider):
+    """A hand-rolled fake vendor — records every call it receives so tests
+    can assert whether the cache actually skipped it."""
+
+    def __init__(self, series_by_key: dict[str, pd.Series]) -> None:
+        self.series_by_key = series_by_key
+        self.daily_batch_calls: list[dict[str, str]] = []
+
+    def get_daily_close_batch(self, tickers: dict[str, str], period: str) -> dict[str, pd.Series]:
+        self.daily_batch_calls.append(dict(tickers))
+        return {k: self.series_by_key[k] for k in tickers if k in self.series_by_key}
+
+    def get_intraday_quote(self, ticker: str) -> tuple[float, datetime] | None:
+        raise AssertionError("get_intraday_quote must never be called by the caching wrapper's own logic")
+
+    def get_intraday_quotes_batch(self, tickers: dict[str, str]) -> dict[str, float]:
+        raise AssertionError("get_intraday_quotes_batch must never be called by the caching wrapper's own logic")
+
+    def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
+        raise AssertionError("get_series must never be called by the caching wrapper's own logic")
+
+
+def _series(n_days: int = 30, start_price: float = 100.0) -> pd.Series:
+    idx = pd.date_range(end=pd.Timestamp.now("UTC").normalize(), periods=n_days, freq="D")
+    return pd.Series([start_price + i for i in range(n_days)], index=idx, name="X")
+
+
+class TestDailyCloseBatchCache:
+    def test_cold_cache_is_a_miss_and_primes(self, session_factory):
+        vendor = _FakeVendor({"sSPY": _series(30)})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+
+        result = provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")
+
+        assert vendor.daily_batch_calls == [{"sSPY": "SPY"}]  # vendor WAS hit (cold cache)
+        assert "sSPY" in result
+        assert len(result["sSPY"]) == 30
+
+        # Verify it actually wrote through to the DB.
+        from archimedes.models.asset_daily_bars import AssetDailyBar
+
+        session = session_factory()
+        try:
+            rows = session.query(AssetDailyBar).filter(AssetDailyBar.symbol == "SPY").all()
+            assert len(rows) == 30
+            assert all(r.source == "yfinance" for r in rows)
+        finally:
+            session.close()
+
+    def test_warm_cache_within_ttl_skips_vendor(self, session_factory):
+        vendor = _FakeVendor({"sSPY": _series(30)})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+
+        provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")  # primes the cache
+        vendor.daily_batch_calls.clear()
+
+        result = provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")
+
+        assert vendor.daily_batch_calls == []  # cache hit — vendor NOT called
+        assert len(result["sSPY"]) == 30
+
+    def test_stale_cache_past_ttl_refetches(self, session_factory):
+        vendor = _FakeVendor({"sSPY": _series(30)})
+        provider = CachingMarketDataProvider(
+            vendor, source_name="yfinance", session_factory=session_factory
+        )
+        provider._ttl = timedelta(hours=1)
+        provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")
+
+        # Backdate every row's fetched_at past the TTL.
+        from archimedes.models.asset_daily_bars import AssetDailyBar
+
+        session = session_factory()
+        try:
+            for row in session.query(AssetDailyBar).all():
+                row.fetched_at = datetime.now(UTC) - timedelta(hours=2)
+            session.commit()
+        finally:
+            session.close()
+
+        vendor.daily_batch_calls.clear()
+        provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")
+        assert vendor.daily_batch_calls == [{"sSPY": "SPY"}]  # stale → refetched
+
+    def test_insufficient_back_coverage_refetches(self, session_factory):
+        """A cache primed for a SHORT period ("1mo") does not satisfy a later
+        request for a LONGER period ("2y") over the same symbol — the earliest
+        cached row doesn't reach back far enough."""
+        vendor = _FakeVendor({"sSPY": _series(30)})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")  # only 30 days cached
+
+        vendor.series_by_key["sSPY"] = _series(731)
+        vendor.daily_batch_calls.clear()
+        result = provider.get_daily_close_batch({"sSPY": "SPY"}, period="2y")
+
+        assert vendor.daily_batch_calls == [{"sSPY": "SPY"}]  # coverage gap → refetched
+        assert len(result["sSPY"]) == 731
+
+    def test_partial_miss_only_fetches_missing_symbols(self, session_factory):
+        vendor = _FakeVendor({"sSPY": _series(30), "sAGG": _series(30)})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")  # primes sSPY only
+        vendor.daily_batch_calls.clear()
+
+        result = provider.get_daily_close_batch({"sSPY": "SPY", "sAGG": "AGG"}, period="1mo")
+
+        assert vendor.daily_batch_calls == [{"sAGG": "AGG"}]  # only the miss goes to the vendor
+        assert set(result) == {"sSPY", "sAGG"}
+
+    def test_empty_tickers_is_a_noop(self, session_factory):
+        vendor = _FakeVendor({})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        assert provider.get_daily_close_batch({}, period="1mo") == {}
+        assert vendor.daily_batch_calls == []
+
+    def test_vendor_miss_leaves_symbol_absent_not_erroring(self, session_factory):
+        """A vendor that returns nothing for a requested ticker (delisted,
+        typo) must not raise — the caller (e.g. _fetch_price_histories)
+        expects a silently-omitted key."""
+        vendor = _FakeVendor({})  # returns nothing for anything
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        result = provider.get_daily_close_batch({"sNOPE": "NOPE"}, period="1mo")
+        assert result == {}
+
+
+# ─── Intraday / generic passthrough — never cache-backed ───────────────
+
+
+class TestUncachedPassthrough:
+    def test_intraday_quote_never_touches_the_cache(self, session_factory):
+        vendor = _FakeVendorPassthroughSpy()
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        assert provider.get_intraday_quote("SPY") == (123.0, vendor.ts)
+        assert vendor.quote_calls == ["SPY"]
+
+    def test_intraday_quotes_batch_never_touches_the_cache(self, session_factory):
+        vendor = _FakeVendorPassthroughSpy()
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        assert provider.get_intraday_quotes_batch({"sSPY": "SPY"}) == {"sSPY": 123.0}
+        assert vendor.batch_calls == [{"sSPY": "SPY"}]
+
+    def test_get_series_never_touches_the_cache(self, session_factory):
+        vendor = _FakeVendorPassthroughSpy()
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        out = provider.get_series("SPY", "1y", "1wk")
+        assert list(out) == [1.0, 2.0]
+        assert vendor.series_calls == [("SPY", "1y", "1wk")]
+
+
+class _FakeVendorPassthroughSpy(MarketDataProvider):
+    def __init__(self) -> None:
+        self.ts = datetime(2026, 8, 19, tzinfo=UTC)
+        self.quote_calls: list[str] = []
+        self.batch_calls: list[dict[str, str]] = []
+        self.series_calls: list[tuple[str, str, str]] = []
+
+    def get_daily_close_batch(self, tickers: dict[str, str], period: str) -> dict[str, pd.Series]:
+        raise AssertionError("not exercised in this test class")
+
+    def get_intraday_quote(self, ticker: str) -> tuple[float, datetime] | None:
+        self.quote_calls.append(ticker)
+        return (123.0, self.ts)
+
+    def get_intraday_quotes_batch(self, tickers: dict[str, str]) -> dict[str, float]:
+        self.batch_calls.append(dict(tickers))
+        return dict.fromkeys(tickers, 123.0)
+
+    def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
+        self.series_calls.append((ticker, period, interval))
+        return pd.Series([1.0, 2.0])
+
+
+# ─── YFinanceProvider — the default vendor's own boundary ──────────────
+
+
+class TestYFinanceProviderBoundary:
+    def test_get_daily_close_batch_import_error_returns_empty(self):
+        import sys
+
+        provider = YFinanceProvider()
+        with patch.dict(sys.modules, {"yfinance": None}):
+            assert provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo") == {}
+
+    def test_get_intraday_quotes_batch_import_error_returns_empty(self):
+        import sys
+
+        provider = YFinanceProvider()
+        with patch.dict(sys.modules, {"yfinance": None}):
+            assert provider.get_intraday_quotes_batch({"sSPY": "SPY"}) == {}

--- a/backend/tests/services/test_market_data_provider.py
+++ b/backend/tests/services/test_market_data_provider.py
@@ -135,9 +135,7 @@ class TestDailyCloseBatchCache:
 
     def test_stale_cache_past_ttl_refetches(self, session_factory):
         vendor = _FakeVendor({"sSPY": _series(30)})
-        provider = CachingMarketDataProvider(
-            vendor, source_name="yfinance", session_factory=session_factory
-        )
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
         provider._ttl = timedelta(hours=1)
         provider.get_daily_close_batch({"sSPY": "SPY"}, period="1mo")
 
@@ -262,3 +260,56 @@ class TestYFinanceProviderBoundary:
         provider = YFinanceProvider()
         with patch.dict(sys.modules, {"yfinance": None}):
             assert provider.get_intraday_quotes_batch({"sSPY": "SPY"}) == {}
+
+
+class TestConcurrentPrimeRace:
+    def test_losing_a_concurrent_write_race_still_returns_the_fetched_data(self, session_factory):
+        """Two writers prime a cold cache; the loser's commit hits
+        ``uq_asset_daily_bars_symbol_trade_date``. The fetch SUCCEEDED — the
+        caller must still get its data, nothing may raise, and the winner's
+        rows stand (equivalent vendor data; next read is warm).
+
+        Deterministic re-creation of the select→commit race window: the WRITE
+        session's ``commit`` is intercepted to first land the same
+        (symbol, trade_date) rows through a rival session — exactly what a
+        second Fargate task or the refresh loop does — before the real commit
+        flushes this session's now-conflicting INSERTs."""
+        from archimedes.models.asset_daily_bars import AssetDailyBar
+        from archimedes.services.market_data_provider import _write_cached_series
+
+        series = _series()
+        vendor = _FakeVendor({"X": series})
+
+        sessions_made: list = []
+        state = {"raced": False}
+
+        def racing_factory():
+            session = session_factory()
+            sessions_made.append(session)
+            if len(sessions_made) == 2 and not state["raced"]:
+                real_commit = session.commit
+
+                def commit_with_rival():
+                    if not state["raced"]:
+                        state["raced"] = True
+                        rival = session_factory()
+                        _write_cached_series(rival, "X", series, "rival")
+                        rival.commit()
+                        rival.close()
+                    real_commit()
+
+                session.commit = commit_with_rival
+            return session
+
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=racing_factory)
+        out = provider.get_daily_close_batch({"X": "X"}, period="1mo")
+
+        assert state["raced"] is True, "the rival writer never ran — the race was not exercised"
+        assert "X" in out and len(out["X"]) == len(series)  # fetched data survives the collision
+
+        check = session_factory()
+        try:
+            rows = check.query(AssetDailyBar).filter_by(symbol="X").all()
+        finally:
+            check.close()
+        assert len(rows) == len(series)  # winner's rows stand; no duplicates


### PR DESCRIPTION
## Summary

Builds the vendor seam #1218 asked for (costing/replacement plan, not a migration) and resolves #775's Phase 1 (off-chain cross-check) inside it.

**Provider interface** at the choke points (grep-verified):
- `analytics-engine/src/archimedes_analytics_engine/data.py::fetch_ohlcv` — now a façade over `market_data.get_provider().fetch_ohlcv`. Backend's `fusion_market_data.py` / `portfolio_backtester.py` import `fetch_ohlcv` directly from here, so they get the swap for free.
- `backend/archimedes/services/strategy_signal_evaluator.py` — `_fetch_price_history(ies)`.
- `backend/archimedes/chain/oracle_updater.py` — `_fetch_yfinance`, `_fetch_yfinance_single`, `_fetch_sp500_moving_averages`.
- `backend/archimedes/services/asset_market_service.py` — `_fetch_yfinance_series`.

Default implementation is yfinance with the exact fetch/parse logic moved unchanged into `YFinanceProvider` — every call site's behavior is identical to before. Vendor-swappable via `MARKET_DATA_PROVIDER` (default `"yfinance"`; an unrecognized value fails safe to the default, logged).

analytics-engine and backend are separate deployables (analytics-engine has no DB dependency), so this is two provider modules sharing one interface shape and one env var, not one shared class — documented in `market_data_provider.py`'s module docstring.

**Cache**: `asset_daily_bars` (Postgres, `unique(symbol, trade_date)`, indexed on `symbol` — modeled on `daily_returns_store.py`'s shape) with read-through in the backend provider (`CachingMarketDataProvider`). Scoped to `get_daily_close_batch` only — the daily-bar shape that's the actual #1218 volume driver (`_fetch_price_histories`'s universe-wide sweep). Intraday/live reads (oracle pushes, VIX, the #775 cross-check's secondary, the Explore history modal) pass straight through, uncached, by design: a stale daily close must never masquerade as a live oracle quote. A coverage/freshness miss fetches the full requested window from the vendor and writes through; no background refresh yet (deliberately out of scope — "seam, not migration") — the cache primes itself on the first miss.

**#775 resolution**: the cross-check (`_cross_check_secondary`) now guards "same source, skip" against `provider_name()` instead of a hardcoded `"yfinance"`. Swapping `MARKET_DATA_PROVIDER` swaps the guardrail's independent secondary source automatically — no separate change needed at the guardrail itself. (#775's Phase 1 off-chain guardrail already shipped in #835/#898; this is the seam tie-in, not a re-implementation.)

## Migration

Chains onto `b41c7d9e2a05` — verified via `alembic heads` against `origin/main` as the actual current head. #1194 also adds a migration (`b7e3f1a2c9d4`) off that same parent but is unmerged; whichever lands second will need a trivial re-serialize (expected, not a bug).

## Tests

- `backend/tests/services/test_market_data_provider.py` (new, 17 tests): provider selection + fail-safe fallback, cache cold/warm/stale/coverage-miss/partial-miss, and that intraday/generic methods never touch the cache.
- `backend/tests/chain/test_oracle_crosscheck.py`: added a test proving the vendor-swap tie-in (source-match guard follows `provider_name()`, not a literal).
- `backend/tests/chain/test_oracle_updater_fetch.py`: `_fetch_sp500_moving_averages`'s test updated to mock at the new provider boundary; all other existing tests (yfinance fetch, single-quote, market snapshot) pass unchanged since the sys.modules-level yfinance mocking still intercepts the (moved, not rewritten) fetch logic.
- `analytics-engine/tests/test_market_data.py` (new, 9 tests): provider selection, retry/error contract preserved, `data.fetch_ohlcv` façade delegation.
- Full suites green: backend 3138 passed / 5 skipped (pre-existing, Postgres-only integration tests); analytics-engine 249 passed.

## Omissions

- Background cache refresh — explicitly out of scope per #1218 ("seam, not migration").
- `backend/archimedes/services/data_quality.py` (the #772 harness) still calls yfinance directly — not one of the three named backend choke points, and it's Önder's lane.
- Phase 2 of #775 (on-chain `PriceOracle.sol` enforcement) is untouched — separate, contract-owned, Dan's call.
- No second vendor is implemented — this PR is the seam only, per #1218's anti-goal ("do not migrate the data provider in this issue").