### PR TITLE
Sign-up password UX: confirm field, guidance meter, server-mirrored requirements (#1290)

### DIFF
--- a/ui/src/components/AuthPage.jsx
+++ b/ui/src/components/AuthPage.jsx
@@ -2,7 +2,17 @@ import { useEffect, useState } from 'react'
 
 import { useAuth } from '../AuthContext'
 import { getProviders, signInEmail, signInSocial, signUpEmail } from '../auth-client'
+import {
+  PASSWORD_MAX,
+  PASSWORD_MIN,
+  passwordRules,
+  passwordRulesMet,
+  passwordsMatch,
+  passwordStrength,
+} from '../password-rules'
 import { postAuthPath } from '../routes'
+
+const STRENGTH_COLORS = ['var(--text-4)', 'var(--text-4)', 'var(--warning, #b08a3e)', 'var(--accent)', 'var(--accent)']
 
 export default function AuthPage({ mode }) {
   const creating = mode === 'sign-up'
@@ -10,9 +20,18 @@ export default function AuthPage({ mode }) {
   const callbackURL = `${window.location.origin}${next}`
   const { user, refresh } = useAuth()
   const [providers, setProviders] = useState({ emailPassword: true, google: false, github: false })
-  const [form, setForm] = useState({ name: '', email: '', password: '' })
+  const [form, setForm] = useState({ name: '', email: '', password: '', confirm: '' })
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
+
+  // Sign-up validity mirrors the SERVER's rules exactly (length only — see
+  // password-rules.js). The strength meter is guidance and never gates.
+  const rules = passwordRules(form.password)
+  const rulesMet = passwordRulesMet(form.password)
+  const match = passwordsMatch(form.password, form.confirm)
+  const showMismatch = creating && form.confirm.length > 0 && !match
+  const strength = passwordStrength(form.password)
+  const canSubmit = !creating || (rulesMet && match)
 
   useEffect(() => {
     getProviders().then(setProviders).catch(() => {})
@@ -91,14 +110,64 @@ export default function AuthPage({ mode }) {
             <input
               required
               type="password"
-              minLength={12}
+              minLength={PASSWORD_MIN}
+              maxLength={PASSWORD_MAX}
               autoComplete={creating ? 'new-password' : 'current-password'}
               value={form.password}
               onChange={(event) => setForm({ ...form, password: event.target.value })}
             />
           </label>
+          {creating && (
+            <>
+              <label className="flex flex-col gap-1.5">
+                <span className="caption">Confirm password</span>
+                <input
+                  required
+                  type="password"
+                  maxLength={PASSWORD_MAX}
+                  autoComplete="new-password"
+                  aria-invalid={showMismatch}
+                  value={form.confirm}
+                  onChange={(event) => setForm({ ...form, confirm: event.target.value })}
+                />
+              </label>
+              <div aria-live="polite" className="flex flex-col gap-1.5">
+                <div className="flex gap-1" aria-hidden="true">
+                  {[1, 2, 3, 4].map((step) => (
+                    <span
+                      key={step}
+                      className="h-1 flex-1 rounded"
+                      style={{
+                        background: step <= strength.score ? STRENGTH_COLORS[strength.score] : 'var(--glass-border)',
+                      }}
+                    />
+                  ))}
+                </div>
+                {form.password.length > 0 && (
+                  <span className="caption text-[var(--text-4)]">
+                    Strength: {strength.label} — guidance only; the length rule below is the requirement.
+                  </span>
+                )}
+                <ul className="caption flex flex-col gap-0.5" aria-label="Password requirements">
+                  {rules.map((rule) => (
+                    <li key={rule.id} className={rule.met ? 'text-[var(--accent)]' : 'text-[var(--text-4)]'}>
+                      {rule.met ? '✓' : '○'} {rule.label}
+                    </li>
+                  ))}
+                  <li className={match ? 'text-[var(--accent)]' : 'text-[var(--text-4)]'}>
+                    {match ? '✓' : '○'} Passwords match
+                  </li>
+                </ul>
+              </div>
+              {showMismatch && (
+                <div className="status" role="alert">
+                  Passwords do not match.
+                </div>
+              )}
+            </>
+          )}
           {error && <div className="status" role="alert">{error}</div>}
-          <button className="btn-primary" type="submit" disabled={busy}>
+          <button className="btn-primary" type="submit" disabled={busy || !canSubmit}>
             {busy ? 'Working…' : creating ? 'Create account' : 'Sign in'}
           </button>
         </form>

--- a/ui/src/password-rules.js
+++ b/ui/src/password-rules.js
@@ -1,0 +1,53 @@
+// Client-side mirror of the SERVER's password policy — auth/auth.js
+// (`emailAndPassword`: minPasswordLength 12, maxPasswordLength 128).
+//
+// The server enforces LENGTH ONLY. This module deliberately lists no
+// composition rules (uppercase/digits/symbols), so the UI never promises —
+// or demands — anything the server doesn't enforce (#1290). The strength
+// meter below is guidance, never a gate.
+//
+// Drift guard: ui/test/password-rules.test.js parses auth/auth.js and fails
+// the suite if these literals stop matching the server config.
+
+export const PASSWORD_MIN = 12
+export const PASSWORD_MAX = 128
+
+/** The enforced requirements, each with a live `met` flag for the checklist. */
+export function passwordRules(password) {
+  const length = (password ?? '').length
+  return [
+    {
+      id: 'length',
+      label: `${PASSWORD_MIN}–${PASSWORD_MAX} characters`,
+      met: length >= PASSWORD_MIN && length <= PASSWORD_MAX,
+    },
+  ]
+}
+
+export function passwordRulesMet(password) {
+  return passwordRules(password).every((rule) => rule.met)
+}
+
+export function passwordsMatch(password, confirm) {
+  return (password ?? '').length > 0 && password === confirm
+}
+
+/**
+ * Guidance-only strength score, 0–4. Length does most of the work (matching
+ * the server's own philosophy — length is the only enforced rule); character
+ * variety adds one step. Never used to block submission.
+ */
+export function passwordStrength(password) {
+  const value = password ?? ''
+  if (value.length === 0) return { score: 0, label: 'empty' }
+  if (value.length < PASSWORD_MIN) return { score: 0, label: 'too short' }
+  let variety = 0
+  if (/[a-z]/.test(value)) variety += 1
+  if (/[A-Z]/.test(value)) variety += 1
+  if (/[0-9]/.test(value)) variety += 1
+  if (/[^A-Za-z0-9]/.test(value)) variety += 1
+  const lengthTier = value.length >= 20 ? 2 : value.length >= 16 ? 1 : 0
+  const score = Math.max(1, Math.min(4, 1 + lengthTier + (variety >= 3 ? 1 : 0)))
+  const label = ['empty', 'weak', 'fair', 'good', 'strong'][score]
+  return { score, label }
+}

--- a/ui/test/password-rules.test.js
+++ b/ui/test/password-rules.test.js
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+	PASSWORD_MAX,
+	PASSWORD_MIN,
+	passwordRules,
+	passwordRulesMet,
+	passwordsMatch,
+	passwordStrength,
+} from "../src/password-rules.js";
+
+// ── The server-mirror drift guard (#1290's core requirement) ────────────
+// The UI's rules must equal what auth/auth.js ACTUALLY enforces. Parse the
+// server config's literals and compare — if either side changes alone, this
+// fails and the UI can never promise what the server rejects.
+
+test("UI password bounds mirror the server's Better Auth config exactly", () => {
+	const serverConfig = readFileSync(new URL("../../auth/auth.js", import.meta.url), "utf8");
+	const min = serverConfig.match(/minPasswordLength:\s*(\d+)/);
+	const max = serverConfig.match(/maxPasswordLength:\s*(\d+)/);
+	assert.ok(min && max, "auth/auth.js no longer declares password length bounds — update this guard AND the UI");
+	assert.equal(PASSWORD_MIN, Number(min[1]));
+	assert.equal(PASSWORD_MAX, Number(max[1]));
+});
+
+test("the only listed requirement is length — no invented composition rules", () => {
+	// The server enforces length only; a UI that demands uppercase/digits would
+	// reject passwords the server accepts (claim-integrity in miniature).
+	const rules = passwordRules("x".repeat(PASSWORD_MIN));
+	assert.equal(rules.length, 1);
+	assert.equal(rules[0].id, "length");
+	assert.ok(rules[0].met);
+});
+
+// ── Length boundaries ───────────────────────────────────────────────────
+
+test("length rule boundaries: min-1 fails, min passes, max passes, max+1 fails", () => {
+	assert.equal(passwordRulesMet("x".repeat(PASSWORD_MIN - 1)), false);
+	assert.equal(passwordRulesMet("x".repeat(PASSWORD_MIN)), true);
+	assert.equal(passwordRulesMet("x".repeat(PASSWORD_MAX)), true);
+	assert.equal(passwordRulesMet("x".repeat(PASSWORD_MAX + 1)), false);
+});
+
+// ── Match / mismatch ────────────────────────────────────────────────────
+
+test("match requires identical non-empty passwords", () => {
+	assert.equal(passwordsMatch("correct horse battery", "correct horse battery"), true);
+	assert.equal(passwordsMatch("correct horse battery", "correct horse batterX"), false);
+	assert.equal(passwordsMatch("", ""), false); // empty never counts as matched
+});
+
+// ── Strength (guidance only) ────────────────────────────────────────────
+
+test("strength: below the minimum is 'too short' with score 0", () => {
+	assert.deepEqual(passwordStrength("short"), { score: 0, label: "too short" });
+	assert.deepEqual(passwordStrength(""), { score: 0, label: "empty" });
+});
+
+test("strength grows with length and variety but never gates the rules", () => {
+	const weak = passwordStrength("aaaaaaaaaaaa"); // 12 chars, one class
+	const strong = passwordStrength("Correct-Horse-Battery-42!"); // long + varied
+	assert.equal(weak.label, "weak");
+	assert.equal(strong.label, "strong");
+	assert.ok(weak.score < strong.score);
+	// The weak-but-legal password still MEETS the requirements — the meter is
+	// guidance; length is the only rule (mirrors the server).
+	assert.equal(passwordRulesMet("aaaaaaaaaaaa"), true);
+});
+
+test("strength is monotone across the tiers used by the meter", () => {
+	const s12 = passwordStrength("aaaaaaaaaaaa").score;
+	const s16 = passwordStrength("aaaaaaaaaaaaaaaa").score;
+	const s20 = passwordStrength("a".repeat(20)).score;
+	assert.ok(s12 <= s16 && s16 <= s20);
+});
+
+// ── AuthPage wiring (source assertions, matching this suite's idiom) ────
+
+const authPage = readFileSync(new URL("../src/components/AuthPage.jsx", import.meta.url), "utf8");
+
+test("sign-up form wires the shared rules module, confirm field, and gate", () => {
+	assert.match(authPage, /from '\.\.\/password-rules'/);
+	assert.match(authPage, /Confirm password/);
+	assert.match(authPage, /passwordsMatch\(form\.password, form\.confirm\)/);
+	assert.match(authPage, /disabled=\{busy \|\| !canSubmit\}/);
+	assert.match(authPage, /minLength=\{PASSWORD_MIN\}/); // no re-hardcoded literal
+	assert.match(authPage, /Passwords do not match\./);
+	// The gate applies to sign-up only — sign-in must not be blocked by the
+	// confirm/rules machinery.
+	assert.match(authPage, /const canSubmit = !creating \|\|/);
+});


### PR DESCRIPTION
Closes #1290.

Sign-up only: enter-twice with live match state and a blocking mismatch alert; a 4-segment strength meter (aria-live, explicitly labeled guidance-only); and the visible requirements checklist.

**The requirements mirror the server exactly.** `auth/auth.js` enforces length only (min 12 / max 128), so the UI lists exactly one rule and deliberately invents no composition rules — a UI demanding uppercase/digits would reject passwords the server accepts. Shared literals live in `ui/src/password-rules.js`; a **drift-guard test parses `auth/auth.js`** and fails if either side moves alone (mutation-verified: `PASSWORD_MIN` 12→8 fails exactly that guard). Sign-in is untouched.

34/34 UI tests, lint and build clean. No password-change surface exists in `ui/` today; when one ships it should consume this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7