### PR TITLE
[frontend] Generate page: upfront cost quote + approval (flag-gated)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`specs/strategy-dsl-spec.md`](specs/strategy-dsl-spec.md) | spec | Dan Browne | — | Strategy DSL. |
 | [`specs/strategy-lifecycle-spec.md`](specs/strategy-lifecycle-spec.md) | spec | Dan Browne | — | Draft → generated → published lifecycle. |
 | [`specs/generation-streaming-spec.md`](specs/generation-streaming-spec.md) | spec | Dan Browne | — | SSE contract for the Generate page. |
-| [`specs/generation-quote-contract.md`](specs/generation-quote-contract.md) | proposed | Dan Browne | — | Upfront cost-quote endpoint + `quote_id` on `/api/generate/start`, drafted by the frontend session for the contracts session to ratify. Frontend ships behind `VITE_GENERATION_QUOTE_ENABLED`. |
+| [`specs/generation-quote-contract.md`](specs/generation-quote-contract.md) | spec | Dan Browne | — | Public cost quote + 409/402 x402 paywall on `/api/generate/start`, ratified in #1296. Frontend ships behind `VITE_GENERATION_QUOTE_ENABLED`. |
 | [`specs/kb-integration-spec.md`](specs/kb-integration-spec.md) | spec | Dan Browne | — | KnowledgeBase submodule integration. |
 | [`specs/page-roles-spec.md`](specs/page-roles-spec.md) | spec | Dan Browne | — | What each page is for. |
 | [`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md) | spec | Dan Browne | — | Component interfaces and the team work split. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`specs/strategy-dsl-spec.md`](specs/strategy-dsl-spec.md) | spec | Dan Browne | — | Strategy DSL. |
 | [`specs/strategy-lifecycle-spec.md`](specs/strategy-lifecycle-spec.md) | spec | Dan Browne | — | Draft → generated → published lifecycle. |
 | [`specs/generation-streaming-spec.md`](specs/generation-streaming-spec.md) | spec | Dan Browne | — | SSE contract for the Generate page. |
+| [`specs/generation-quote-contract.md`](specs/generation-quote-contract.md) | proposed | Dan Browne | — | Upfront cost-quote endpoint + `quote_id` on `/api/generate/start`, drafted by the frontend session for the contracts session to ratify. Frontend ships behind `VITE_GENERATION_QUOTE_ENABLED`. |
 | [`specs/kb-integration-spec.md`](specs/kb-integration-spec.md) | spec | Dan Browne | — | KnowledgeBase submodule integration. |
 | [`specs/page-roles-spec.md`](specs/page-roles-spec.md) | spec | Dan Browne | — | What each page is for. |
 | [`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md) | spec | Dan Browne | — | Component interfaces and the team work split. |

--- a/docs/adr/portfolio-constructor-decision-tree.md
+++ b/docs/adr/portfolio-constructor-decision-tree.md
@@ -12,7 +12,7 @@
 > LLM-agentic top-level constructor. Three pre-Day-10 deterministic constructors
 > remained in the tree:
 > - [`services/portfolio_constructor.py`](../../backend/archimedes/services/portfolio_constructor.py) (285 lines)
-> - [`services/kelly_portfolio.py`](../../backend/archimedes/services/_deprecated/kelly_portfolio.py) (505 lines)
+> - ``services/kelly_portfolio.py`` (deleted in #1259) (505 lines)
 > - [`services/portfolio_optimizer.py`](../../backend/archimedes/services/portfolio_optimizer.py) (488 lines)
 >
 > Most have **zero production call sites** today. This spec decides who fires

--- a/docs/specs/generation-quote-contract.md
+++ b/docs/specs/generation-quote-contract.md
@@ -1,92 +1,210 @@
 # Generation Quote Contract
 
-> **Status: PROPOSED.** Drafted 2026-08-19 by the frontend session so the
-> contracts/backend session (quote endpoint + x402 paywall on
-> `/api/generate/start`) has something concrete to converge on or amend.
-> Not yet implemented on the backend. Flip this line to **RATIFIED** once
-> both sides agree — see "Ratification" below.
+> **Status: RATIFIED.** Drafted 2026-08-19 by the frontend session as a
+> PROPOSED contract; the contracts/backend session implemented and landed
+> the real thing in **#1296** (`backend/archimedes/services/generation_payment.py`,
+> `backend/archimedes/api/generate_routes.py`) with a *different* shape than
+> originally proposed here — no `quote_id`, no `expires_at`, a 409
+> wallet-link precondition ahead of the 402, and payer binding to the
+> caller's linked wallet. This doc now records **that** ratified shape
+> verbatim, not the original proposal. The frontend
+> (`ui/src/components/Generate.jsx`, `ui/src/generateQuote.js`) was reworked
+> onto it in the PR that flipped this status line.
+>
+> **Ground truth**: `backend/tests/test_generate_payment_gate.py` pins the
+> route-level contract (both endpoints' shapes, the 409/402 ordering, the
+> dry-run success path). `backend/tests/services/test_generation_payment.py`
+> pins the payment module's internal laws (payer binding, fail-safe price
+> parsing, dry-run's unverified-accept). If this doc and either test file
+> ever disagree, the tests are correct — update this doc, not them.
 
-Small and deliberately narrow: one GET endpoint, one new optional field on
-an existing POST. The frontend (`ui/src/components/Generate.jsx`,
-`ui/src/generateQuote.js`) is built against this doc, feature-flagged by
-`VITE_GENERATION_QUOTE_ENABLED` (`ui/src/featureFlags.js`) so it ships dark
-until both sides are ready.
+Two endpoints, one backend flag (`GENERATION_PAYMENT_REQUIRED`, default
+`false`). The frontend has its own independent flag
+(`VITE_GENERATION_QUOTE_ENABLED`, `ui/src/featureFlags.js`) that gates
+whether the UI *shows* the quote/paywall UI at all — it works fine against
+a backend where `GENERATION_PAYMENT_REQUIRED` is still off, since the quote
+just reports `payment_required: false` honestly in that case.
 
 ## `GET /api/generate/quote`
 
-Returns the upfront price to run one generation job, in testnet USDC,
-before the caller commits to `/api/generate/start`.
+**Public** — no auth required (`generate_public_router` in
+`generate_routes.py`, mounted outside the `require_current_user`
+dependency that gates the rest of `/api/generate/*`). A human sees the
+price before signing in; an agent plans before paying (#1293).
 
-**Request:** no body. Optional query params the frontend already has at
-quote time — send them if useful for sizing the quote, otherwise the
-backend may return a flat MVP price and ignore them:
-
-- `model` — LLM model id (matches `ui/src/data/modelPricing.json`)
-- `max_papers` — requested research depth (int)
+**Request:** no body, no query params. Pricing is flat
+(`GENERATION_PRICE_USD`, default **$0.15**) — there is nothing per-request
+to size the quote by.
 
 **Response 200:**
 
 ```json
 {
-  "quote_id": "qt_2f9a1c...",
-  "price_usdc": "0.42",
-  "currency": "USDC-testnet",
-  "breakdown": [
-    { "label": "LLM inference (est.)", "amount_usdc": "0.30" },
-    { "label": "Research retrieval", "amount_usdc": "0.12" }
-  ],
-  "expires_at": "2026-08-19T18:05:00Z"
+  "payment_required": false,
+  "pricing_model": "flat_v1",
+  "price": "$0.150000",
+  "asset": "USDC",
+  "chain": "eip155:5042002",
+  "recipient": null,
+  "dry_run": true,
+  "how": "POST /api/generate/start without a Payment-Signature header returns 402 with these requirements in the PAYMENT-REQUIRED header; sign them (x402 / Circle Gateway) and retry with Payment-Signature."
 }
 ```
 
-- `price_usdc` — **decimal string**, not a float (money, no FP rounding).
-- `currency` — literal `"USDC-testnet"`. The frontend renders this verbatim
-  as the "testnet USDC" label — do not send `"USDC"` alone, the honesty
-  framing depends on the distinction being visible.
-- `breakdown` — optional; omit or send `[]` if the backend can't itemize
-  yet. The frontend renders it as a plain list when present.
-- `quote_id` — opaque string, echoed back on `/start`.
-- `expires_at` — ISO-8601 UTC. The frontend treats `now >= expires_at` as
-  expired and refetches before letting the user submit.
+- `payment_required` — mirrors the backend's `GENERATION_PAYMENT_REQUIRED`
+  flag. `false` in every environment until Dan flips it (#834's flip-list).
+- `price` — a **decimal string** (`"$0.150000"`, six decimal places), not a
+  float — money, no FP rounding. Parses safely to the default on a
+  malformed `GENERATION_PRICE_USD`; never free, never absurd.
+- `pricing_model` — literal `"flat_v1"` today. #1217's measured
+  per-generation budget replaces the pricing internals later and bumps
+  this string — the frontend must not hardcode assumptions about what
+  `flat_v1` implies beyond "one flat number."
+- `asset` — literal `"USDC"`.
+- `chain` — the gateway chain id string (`GATEWAY_CHAIN` env, e.g.
+  `"eip155:5042002"`).
+- `recipient` — the platform wallet address, or `null` when unset
+  (flag-off environments; also the fail-closed 503 case below).
+- `dry_run` — mirrors `PAYMENTS_DRY_RUN` (backend default: **true**). When
+  true, a 402 from `/start` is still returned for a missing payment header,
+  but a *present* header is accepted **without verification or
+  settlement** — loudly logged `UNVERIFIED` server-side. No real value can
+  move while `dry_run` is true, so the frontend must render this
+  explicitly (never imply a real charge happened) — see "test mode" below.
+- `how` — a literal, backend-owned instruction string. Render it verbatim
+  if shown; do not paraphrase it into something that could drift from what
+  the 402 actually requires.
 
-**Non-2xx:** standard error body. The frontend treats any non-2xx as "quote
-unavailable" and disables the submit button — fails closed, no
-bypass-by-error path.
+**There is no `quote_id` and no `expires_at`.** The original PROPOSED
+contract had both (an opaque id to echo back on `/start`, an ISO-8601
+expiry the frontend was to treat as a submit-blocking condition). Neither
+survived ratification: the price is flat and re-quoted fresh on every
+`/start` attempt, so there is nothing to echo back and nothing that goes
+stale. **Do not reintroduce quote-id/expiry logic in the frontend** — the
+409/402 flow below is the entire approval mechanism.
 
-## `POST /api/generate/start` — `quote_id` addition
+**Non-2xx:** not expected in normal operation (this endpoint does no I/O
+beyond reading env vars) — the frontend still treats any non-2xx as "quote
+unavailable" defensively.
 
-Existing request body (`GenerateStartRequest` in `generate_schemas.py`)
-gains one new optional field:
+## `POST /api/generate/start` — the payment gate
 
-```json
-{ "brief": { "...": "..." }, "quote_id": "qt_2f9a1c..." }
-```
+**No new request field.** Unlike the PROPOSED contract (which added an
+optional `quote_id` to the body), the ratified `/start` request body is
+**unchanged** — still just `GenerateStartRequest` (`brief`, optional
+`model`, etc.), with no payment-related field at all. The payment gate
+lives entirely in headers and status codes, checked in this order (each
+earlier gate protects the caller from a wasted round-trip on the one
+after it):
 
-- Paywall flag **off**: `quote_id` accepted and ignored.
-- Paywall flag **on**: request must carry a valid, unexpired `quote_id`
-  scoped to the caller, else **402** — the same status code/shape as the
-  existing `PREMIUM_MODELS_ENABLED` entitlement gate on this endpoint
-  (`generate_schemas.py`'s `model` field docs), so the frontend's existing
-  `err.status` handling (`ui/src/api.js`) needs no new plumbing.
-- The frontend's payment-step UI activates on **any** 402 from this
-  endpoint. If the trigger condition ends up needing to be distinguished
-  from other 402s (e.g. a response body discriminator), please add it here
-  before ratifying — the frontend currently treats them as the same case.
+1. **Quota (429)** — the existing account+IP daily cap, unrelated to
+   payment, runs first. A quota-blocked caller is refused before ever
+   being asked to pay.
+2. **Wallet-link precondition (409)** — only when `GENERATION_PAYMENT_REQUIRED`
+   is true. If the caller has no linked wallet resolvable from the request
+   (`get_linked_wallet_address` — driven by the `X-Wallet-Address` header
+   the frontend already sends on every request, or the account's primary
+   linked wallet if that header is absent), the response is:
+
+   ```json
+   {
+     "detail": {
+       "reason": "wallet_link_required",
+       "message": "Generation requires a linked, funded wallet. Link a wallet to your account (POST /api/wallets/challenge → /api/wallets/verify), fund it with testnet USDC (the faucet currently requires a human), then retry. See GET /api/generate/quote for the price."
+     }
+   }
+   ```
+
+   `409`, not `402` — the blocker is account state (no proven linked
+   wallet), not a missing payment. The message includes the faucet caveat
+   verbatim (#1294: the faucet is human-only, which now bites agents at
+   exactly this gate) — render it as-is, do not re-paraphrase it away.
+
+3. **Paywall (402)** — wallet is linked; no `Payment-Signature` header (or
+   one that fails verification/settlement — see below) present:
+
+   ```json
+   {
+     "detail": {
+       "reason": "payment_required",
+       "message": "Generation requires payment. Sign the PAYMENT-REQUIRED requirements with your linked wallet and retry with a Payment-Signature header.",
+       "quote": { "payment_required": true, "pricing_model": "flat_v1", "price": "$0.150000", "asset": "USDC", "chain": "eip155:5042002", "recipient": "0x...", "dry_run": true, "how": "..." }
+     }
+   }
+   ```
+
+   **`detail.quote` is BYTE-IDENTICAL to the `GET /api/generate/quote`
+   response** — both are built by the same `generation_payment.quote()`
+   call, so they can never disagree. The frontend parses **one** shape
+   (`deriveQuoteView` in `generateQuote.js`) for both surfaces. The
+   response also carries the real x402 requirements in a `PAYMENT-REQUIRED`
+   header (circlekit-built) — the 402 response body *is* the
+   quote-approval flow: sign those requirements and retry with
+   `Payment-Signature`.
+
+   Other `reason` values on the same 402 shape: `payment_malformed` (header
+   didn't decode), `payer_mismatch` (the signed authorization's payer isn't
+   the caller's linked wallet — see "Payer binding" below),
+   `payment_invalid` (facilitator verify failed), `payment_settle_failed`
+   (verified but settle failed — caller keeps funds). All honest 402s, never
+   500s.
+
+4. **Fail-closed config (503)** — flag on with `GENERATION_PAYMENT_RECIPIENT`
+   unset is a deliberate outage (`reason: "payment_config_missing"`), never
+   a free pass.
+
+**Success — 202**, same body as before this feature
+(`GenerateStartResponse`). When a real payment was verified and settled
+(live mode, not dry-run), the response additionally carries a
+**`PAYMENT-RESPONSE`** header — the facilitator's settlement receipt.
+Surface it if present; most successful responses (flag off, or dry-run)
+will not have it, and that's normal, not an error.
+
+### Test mode (`PAYMENTS_DRY_RUN`, backend default **true**)
+
+When `dry_run` is true in the quote: a *missing* `Payment-Signature`
+header still 402s (so the approval UX is exercisable end to end), but a
+*present* one — any non-empty value, not decoded or verified — is accepted
+and the request proceeds to enqueue. **No `PAYMENT-RESPONSE` header is set
+in this path** (nothing was settled). The frontend must render this
+honestly: **"test mode — payment accepted unverified"**, never dressed up
+as a real charge. See `PAYMENT_STATUS.DRY_RUN` in `generateQuote.js`.
+
+### Payer binding
+
+The payer named inside a *real, verified* `Payment-Signature` (its signed
+authorization's `from` field) must equal the caller's **linked** wallet —
+checked before any facilitator round-trip (`payer_mismatch` 402 otherwise).
+Because the wallet-link precondition (step 2 above) resolves using the
+`X-Wallet-Address` header the frontend already sends with every request
+(`api.js`'s `walletHeaders()`, driven by `getAddress()` — the wallet
+currently active in the injected provider), reaching the 402 stage at all
+already proves that active address is a wallet linked to this account. The
+frontend still surfaces a proactive mismatch note
+(`describePayerMismatch` in `generateQuote.js`) when the active provider
+address is linked to nothing on the account, or differs from the account's
+primary linked wallet — signing must use the **linked** wallet's account,
+never whatever happens to be active in the provider, and the UI says so
+when they diverge rather than silently trusting the injected address.
 
 ## Explicitly out of scope here
 
-- **Actual payment execution.** Signing/paying the quote from the
-  connected wallet (x402) is not wired in this frontend PR — on a 402 it
-  renders an honest "payments aren't enabled yet" preview instead of a
-  non-functional pay button. That lands once this contract is ratified and
-  the payment rail (amount/address/protocol) is nailed down.
+- **Real x402 signing.** Building and signing the EIP-712 payment
+  authorization from the connected wallet isn't wired in this frontend —
+  on a live (non-dry-run) 402 it renders an honest "payments aren't
+  enabled yet" preview instead of a non-functional pay button. Test mode
+  (above) gives a real, functional path end to end while `PAYMENTS_DRY_RUN`
+  holds, without needing this.
 - **Paper-trading deployment cost.** Always $0, unrelated to this
-  endpoint — the Generate UI states that separately so the two costs
+  contract — the Generate UI states that separately so the two costs
   aren't conflated with the generation quote.
 
 ## Ratification
 
-Contracts session: please confirm or amend field names, the `model`/
-`max_papers` query params (or drop them if the MVP quote is flat), and the
-402 trigger condition — then flip the status line at the top of this file
-to RATIFIED.
+Closed. This doc was PROPOSED by the frontend session; #1296 implemented
+and shipped a materially different (and now authoritative) shape on the
+backend; this revision brings the doc in line with what actually shipped.
+Any further change to the wire contract must land in
+`backend/tests/test_generate_payment_gate.py` /
+`backend/tests/services/test_generation_payment.py` first — this doc
+follows the tests, not the other way around.

--- a/docs/specs/generation-quote-contract.md
+++ b/docs/specs/generation-quote-contract.md
@@ -1,0 +1,92 @@
+# Generation Quote Contract
+
+> **Status: PROPOSED.** Drafted 2026-08-19 by the frontend session so the
+> contracts/backend session (quote endpoint + x402 paywall on
+> `/api/generate/start`) has something concrete to converge on or amend.
+> Not yet implemented on the backend. Flip this line to **RATIFIED** once
+> both sides agree — see "Ratification" below.
+
+Small and deliberately narrow: one GET endpoint, one new optional field on
+an existing POST. The frontend (`ui/src/components/Generate.jsx`,
+`ui/src/generateQuote.js`) is built against this doc, feature-flagged by
+`VITE_GENERATION_QUOTE_ENABLED` (`ui/src/featureFlags.js`) so it ships dark
+until both sides are ready.
+
+## `GET /api/generate/quote`
+
+Returns the upfront price to run one generation job, in testnet USDC,
+before the caller commits to `/api/generate/start`.
+
+**Request:** no body. Optional query params the frontend already has at
+quote time — send them if useful for sizing the quote, otherwise the
+backend may return a flat MVP price and ignore them:
+
+- `model` — LLM model id (matches `ui/src/data/modelPricing.json`)
+- `max_papers` — requested research depth (int)
+
+**Response 200:**
+
+```json
+{
+  "quote_id": "qt_2f9a1c...",
+  "price_usdc": "0.42",
+  "currency": "USDC-testnet",
+  "breakdown": [
+    { "label": "LLM inference (est.)", "amount_usdc": "0.30" },
+    { "label": "Research retrieval", "amount_usdc": "0.12" }
+  ],
+  "expires_at": "2026-08-19T18:05:00Z"
+}
+```
+
+- `price_usdc` — **decimal string**, not a float (money, no FP rounding).
+- `currency` — literal `"USDC-testnet"`. The frontend renders this verbatim
+  as the "testnet USDC" label — do not send `"USDC"` alone, the honesty
+  framing depends on the distinction being visible.
+- `breakdown` — optional; omit or send `[]` if the backend can't itemize
+  yet. The frontend renders it as a plain list when present.
+- `quote_id` — opaque string, echoed back on `/start`.
+- `expires_at` — ISO-8601 UTC. The frontend treats `now >= expires_at` as
+  expired and refetches before letting the user submit.
+
+**Non-2xx:** standard error body. The frontend treats any non-2xx as "quote
+unavailable" and disables the submit button — fails closed, no
+bypass-by-error path.
+
+## `POST /api/generate/start` — `quote_id` addition
+
+Existing request body (`GenerateStartRequest` in `generate_schemas.py`)
+gains one new optional field:
+
+```json
+{ "brief": { "...": "..." }, "quote_id": "qt_2f9a1c..." }
+```
+
+- Paywall flag **off**: `quote_id` accepted and ignored.
+- Paywall flag **on**: request must carry a valid, unexpired `quote_id`
+  scoped to the caller, else **402** — the same status code/shape as the
+  existing `PREMIUM_MODELS_ENABLED` entitlement gate on this endpoint
+  (`generate_schemas.py`'s `model` field docs), so the frontend's existing
+  `err.status` handling (`ui/src/api.js`) needs no new plumbing.
+- The frontend's payment-step UI activates on **any** 402 from this
+  endpoint. If the trigger condition ends up needing to be distinguished
+  from other 402s (e.g. a response body discriminator), please add it here
+  before ratifying — the frontend currently treats them as the same case.
+
+## Explicitly out of scope here
+
+- **Actual payment execution.** Signing/paying the quote from the
+  connected wallet (x402) is not wired in this frontend PR — on a 402 it
+  renders an honest "payments aren't enabled yet" preview instead of a
+  non-functional pay button. That lands once this contract is ratified and
+  the payment rail (amount/address/protocol) is nailed down.
+- **Paper-trading deployment cost.** Always $0, unrelated to this
+  endpoint — the Generate UI states that separately so the two costs
+  aren't conflated with the generation quote.
+
+## Ratification
+
+Contracts session: please confirm or amend field names, the `model`/
+`max_papers` query params (or drop them if the MVP quote is flat), and the
+402 trigger condition — then flip the status line at the top of this file
+to RATIFIED.

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -33,8 +33,10 @@ VITE_CIRCLE_CLIENT_URL=https://modular-sdk.circle.com/v1/rpc/w3s/buidl
 # MARKETPLACE_MIN_VAULT_FUNDS_RAW. 1000000 = 1 USDC.
 VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW=1000000
 
-# Upfront cost-quote + approval step on the Generate page (PROPOSED —
-# docs/specs/generation-quote-contract.md). Off by default: Generate submits
-# directly, no quote step. Set true once the backend's GET /api/generate/quote
-# and the x402 paywall on /api/generate/start are live to try against.
+# Upfront cost-quote + x402 paywall step on the Generate page (RATIFIED —
+# docs/specs/generation-quote-contract.md, #1296). Off by default: Generate
+# submits directly, no quote step. Set true to try the quote card + 402/409
+# state handling against the backend's GET /api/generate/quote — works even
+# while the backend's own GENERATION_PAYMENT_REQUIRED is still off (the
+# quote just reports payment_required: false).
 VITE_GENERATION_QUOTE_ENABLED=false

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -32,3 +32,9 @@ VITE_CIRCLE_CLIENT_URL=https://modular-sdk.circle.com/v1/rpc/w3s/buidl
 # Client-side pre-check only; the backend is authoritative. Mirror of the backend's
 # MARKETPLACE_MIN_VAULT_FUNDS_RAW. 1000000 = 1 USDC.
 VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW=1000000
+
+# Upfront cost-quote + approval step on the Generate page (PROPOSED —
+# docs/specs/generation-quote-contract.md). Off by default: Generate submits
+# directly, no quote step. Set true once the backend's GET /api/generate/quote
+# and the x402 paywall on /api/generate/start are live to try against.
+VITE_GENERATION_QUOTE_ENABLED=false

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -56,6 +56,37 @@ export async function apiPost(path, body) {
 }
 
 /**
+ * POST JSON to an endpoint, returning both the parsed body AND the raw
+ * response `Headers` — for callers that need a response header alongside
+ * the body (the generation paywall's PAYMENT-RESPONSE settlement receipt,
+ * #1296) rather than just the JSON plain apiPost returns. On a non-2xx
+ * response the thrown Error also carries `err.detail` — the parsed body's
+ * `detail` field (FastAPI's error-body convention) — so callers can read a
+ * structured `{reason, message, ...}` instead of only the status code
+ * apiPost's Error already carries via `err.status`.
+ * @param {string} path — API path
+ * @param {object} body — JSON-serializable body
+ * @param {object} [extraHeaders] — additional request headers (e.g. Payment-Signature)
+ * @returns {Promise<{data: any, headers: Headers}>}
+ */
+export async function apiPostWithMeta(path, body, extraHeaders = {}) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...walletHeaders(), ...extraHeaders },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  })
+  const data = await res.json().catch(() => null)
+  if (!res.ok) {
+    const err = new Error(`Backend returned ${res.status}`)
+    err.status = res.status
+    err.detail = data?.detail ?? null
+    throw err
+  }
+  return { data, headers: res.headers }
+}
+
+/**
  * DELETE an endpoint. Throws a clean error on non-2xx responses.
  * @param {string} path — API path
  * @returns {Promise<any>} parsed JSON

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -4,17 +4,21 @@ import GenerationStatus from "./GenerationStatus";
 import ModelCostPanel from "./ModelCostPanel";
 import { EXAMPLE_BRIEFS } from "../data/exampleBriefs";
 import { ASSET_GROUPS, SUPPORTED_ASSETS } from "../data/assetUniverse";
-import { apiGet, apiPost } from "../api";
+import { apiGet, apiPostWithMeta } from "../api";
 import { getAddress } from "../config";
+import { listLinkedWallets } from "../linked-wallets";
 import { GENERATION_QUOTE_ENABLED } from "../featureFlags";
 import {
 	PAYMENT_STATUS,
-	attachQuoteId,
+	buildDryRunPaymentHeader,
 	deriveQuoteView,
 	derivePaymentState,
-	isPaywallError,
-	isQuoteExpired,
+	describePayerMismatch,
+	extractReceipt,
+	paymentErrorMessage,
 } from "../generateQuote";
+
+const shortAddr = (addr) => (addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : "");
 
 // /generate spine page — redesigned per issue #872.
 //
@@ -28,16 +32,21 @@ import {
 // view. The SSE endpoint honours Last-Event-ID for replay, so re-subscribing
 // on drill-in shows the full history for a completed job too.
 //
-// Upfront cost quote (feature-flagged, GENERATION_QUOTE_ENABLED in
-// featureFlags.js — off by default): when on, a quote is fetched from
-// GET /api/generate/quote and shown before the submit button, which reads
-// "Approve & Generate" and carries `quote_id` on /start. If /start 402s
-// (backend paywall active — docs/specs/generation-quote-contract.md,
-// PROPOSED), the submit row switches to a payment-step banner instead of
-// the generic error: wallet-required if none is connected, otherwise an
-// honest "payments aren't enabled yet" preview — this build does not sign
-// or execute an on-chain payment. State-transition logic lives in
-// ../generateQuote.js so it's unit-testable without a DOM.
+// Upfront cost quote + x402 paywall (feature-flagged, GENERATION_QUOTE_ENABLED
+// in featureFlags.js — off by default): when on, a quote is fetched from the
+// PUBLIC GET /api/generate/quote and shown before the submit button.
+// /start's request body is unchanged — the ratified contract
+// (docs/specs/generation-quote-contract.md, #1296) carries no quote_id or
+// any other payment field on the body; the gate lives entirely in status
+// codes: a 409 means "link + fund a wallet first" (CTA reuses the existing
+// open-wallet-modal flow), a 402 means "sign and retry with
+// Payment-Signature" — while the backend runs PAYMENTS_DRY_RUN (its
+// default), any non-empty header is accepted UNVERIFIED, so this build
+// offers a real, honestly-labeled "continue in test mode" retry instead of
+// a non-functional pay button (real x402 signing isn't wired here). A
+// settlement receipt (PAYMENT-RESPONSE header) is surfaced when present.
+// State-transition logic lives in ../generateQuote.js so it's unit-testable
+// without a DOM.
 
 const RISK_PROFILES = [
 	{ id: "fixed_income", label: "Fixed income" },
@@ -76,23 +85,38 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// ── Track the most-recently submitted job so the table can highlight it ──
 	const [lastJobId, setLastJobId] = useState(null);
 
-	// ── Upfront cost quote (feature-flagged) ──
+	// ── Upfront cost quote + x402 paywall (feature-flagged) ──
 	const [quote, setQuote] = useState(null);
 	const [quoteStatus, setQuoteStatus] = useState(
 		GENERATION_QUOTE_ENABLED ? "loading" : "idle",
 	);
 	const [quoteError, setQuoteError] = useState("");
-	// Set true only by a genuine 402 from /start (isPaywallError). Cleared on
-	// every fresh submit attempt so a stale banner never survives a retry.
-	const [paywallActive, setPaywallActive] = useState(false);
 	const [walletAddr, setWalletAddr] = useState(() => getAddress());
+	// The account's linked wallets (GET /api/wallets) — fetched only once the
+	// quote says payments are actually required, so this call costs nothing
+	// in the common (flag-off) case. Used purely for the payer-binding
+	// transparency note (describePayerMismatch); never used to *select* a
+	// signer, since real signing isn't wired in this build.
+	const [linkedWallets, setLinkedWallets] = useState([]);
+	// The payment-step banner. Set only from a genuine 409/402 on /start
+	// (derivePaymentState); cleared on every fresh submit attempt so a stale
+	// banner never survives a retry.
+	const [paymentStatus, setPaymentStatus] = useState(PAYMENT_STATUS.NONE);
+	const [paymentMessage, setPaymentMessage] = useState("");
+	// True only right after a successful "continue in test mode" submit —
+	// the honest label the ratified contract requires (PAYMENTS_DRY_RUN:
+	// the payment header was accepted WITHOUT verification or settlement).
+	const [testModeNotice, setTestModeNotice] = useState(false);
+	const [continuingTestMode, setContinuingTestMode] = useState(false);
+	// The PAYMENT-RESPONSE settlement receipt from a successful /start, if
+	// the response carried one (only true payments settled — live mode).
+	const [receipt, setReceipt] = useState(null);
 
 	const fetchQuote = useCallback(() => {
 		if (!GENERATION_QUOTE_ENABLED) return;
 		setQuoteStatus("loading");
 		setQuoteError("");
-		const qs = selectedModel ? `?model=${encodeURIComponent(selectedModel)}` : "";
-		apiGet(`/api/generate/quote${qs}`)
+		apiGet("/api/generate/quote")
 			.then((data) => {
 				setQuote(data);
 				setQuoteStatus("ready");
@@ -102,28 +126,76 @@ export default function Generate({ onNavigate, onStageChange }) {
 				setQuoteError(e.message || "Cost quote unavailable");
 				setQuoteStatus("error");
 			});
-	}, [selectedModel]);
+	}, []);
 
 	useEffect(() => {
 		fetchQuote();
 	}, [fetchQuote]);
 
 	// Wallet connect/disconnect is a global event (config.js), not React
-	// state — re-derive our copy on change so the payment-step banner can
-	// flip from "connect a wallet" to the payment preview live.
+	// state — re-derive our copy on change so the payer-mismatch note and
+	// payment-step banner stay live.
 	useEffect(() => {
 		const onWalletChanged = () => setWalletAddr(getAddress());
 		window.addEventListener("wallet-changed", onWalletChanged);
 		return () => window.removeEventListener("wallet-changed", onWalletChanged);
 	}, []);
 
+	// Linked wallets: only needed once the quote reports payments are
+	// actually required (flag on server-side) — the common case (flag off)
+	// never makes this call.
+	useEffect(() => {
+		if (!GENERATION_QUOTE_ENABLED || !quote?.payment_required) return;
+		let cancelled = false;
+		listLinkedWallets()
+			.then((wallets) => {
+				if (!cancelled) setLinkedWallets(Array.isArray(wallets) ? wallets : []);
+			})
+			.catch(() => {
+				if (!cancelled) setLinkedWallets([]);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [quote?.payment_required]);
+
 	const quoteView = useMemo(() => deriveQuoteView(quote), [quote]);
-	const quoteReady =
-		!GENERATION_QUOTE_ENABLED ||
-		(quoteStatus === "ready" && Boolean(quoteView) && !isQuoteExpired(quote));
-	const paymentStatus = paywallActive
-		? derivePaymentState(walletAddr)
-		: PAYMENT_STATUS.NONE;
+	const quoteReady = !GENERATION_QUOTE_ENABLED || (quoteStatus === "ready" && Boolean(quoteView));
+	// The wallet actually active in the injected provider vs. the account's
+	// LINKED wallet — signing must use the linked one, not whatever's merely
+	// selected right now. Null when there's nothing to flag (see
+	// describePayerMismatch's own doc for the exact conditions).
+	const payerMismatch = useMemo(
+		() => describePayerMismatch(walletAddr, linkedWallets),
+		[walletAddr, linkedWallets],
+	);
+
+	// ── Build the /start request body. No payment field on it anywhere —
+	// the ratified contract (#1296) gates entirely via status codes/headers,
+	// not a request-body field (the PROPOSED contract's quote_id is dead). ──
+	const buildBrief = () => ({
+		brief: {
+			intent,
+			risk_appetite: riskAppetite,
+			asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
+			max_papers: depth,
+			...(strategyName.trim() ? { name: strategyName.trim() } : {}),
+		},
+		...(selectedModel ? { model: selectedModel } : {}),
+	});
+
+	// POST /start, optionally with a Payment-Signature header, and surface
+	// whatever the response carries (job id + PAYMENT-RESPONSE if present).
+	const submitStart = async (extraHeaders) => {
+		const { data, headers } = await apiPostWithMeta(
+			"/api/generate/start",
+			buildBrief(),
+			extraHeaders,
+		);
+		setLastJobId(data.job_id);
+		setReceipt(extractReceipt(headers));
+		return data;
+	};
 
 	// ── Submit a generation job ──
 	const startJob = async () => {
@@ -132,45 +204,53 @@ export default function Generate({ onNavigate, onStageChange }) {
 			setStartError("Describe what you want in a sentence or two.");
 			return;
 		}
-		if (GENERATION_QUOTE_ENABLED && isQuoteExpired(quote)) {
-			setStartError("Your quote expired — fetching a new one, try again in a moment.");
-			fetchQuote();
-			return;
-		}
 		if (GENERATION_QUOTE_ENABLED && !quoteReady) {
 			setStartError("Cost quote isn't ready yet.");
 			return;
 		}
 		setStarting(true);
-		setPaywallActive(false);
-		const payload = attachQuoteId(
-			{
-				brief: {
-					intent,
-					risk_appetite: riskAppetite,
-					asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
-					max_papers: depth,
-					...(strategyName.trim() ? { name: strategyName.trim() } : {}),
-				},
-				...(selectedModel ? { model: selectedModel } : {}),
-			},
-			{ quoteEnabled: GENERATION_QUOTE_ENABLED, approvedQuoteId: quote?.quote_id },
-		);
+		setPaymentStatus(PAYMENT_STATUS.NONE);
+		setPaymentMessage("");
+		setTestModeNotice(false);
+		setReceipt(null);
 		try {
-			const data = await apiPost("/api/generate/start", payload);
-			setLastJobId(data.job_id);
-			// Quote is consumed by a successful /start — fetch a fresh one for
-			// the next generation rather than letting a spent quote_id linger.
+			await submitStart();
+			// Re-quote for the next generation — flat pricing has nothing to
+			// consume, but the flag/dry_run/recipient could change underneath.
 			if (GENERATION_QUOTE_ENABLED) fetchQuote();
 			// Stay on the page — the job table will show the new row.
 		} catch (e) {
-			if (isPaywallError(e)) {
-				setPaywallActive(true);
+			const dryRun = e?.detail?.quote?.dry_run ?? quote?.dry_run;
+			const state = derivePaymentState(e, dryRun);
+			if (state !== PAYMENT_STATUS.NONE) {
+				setPaymentStatus(state);
+				setPaymentMessage(paymentErrorMessage(e));
 			} else {
 				setStartError(e.message || "Failed to start generation");
 			}
 		} finally {
 			setStarting(false);
+		}
+	};
+
+	// The PAYMENTS_DRY_RUN continuation: any non-empty Payment-Signature is
+	// accepted UNVERIFIED, so this actually completes the job — honestly
+	// labeled, never dressed up as a real settlement. The payer named is the
+	// caller's OWN active wallet, which — by having reached a 402 at all —
+	// is already proven to be a wallet linked to this account (the 409 gate
+	// runs first and would have fired otherwise).
+	const continueInTestMode = async () => {
+		setContinuingTestMode(true);
+		try {
+			await submitStart({ "Payment-Signature": buildDryRunPaymentHeader(walletAddr) });
+			setPaymentStatus(PAYMENT_STATUS.NONE);
+			setPaymentMessage("");
+			setTestModeNotice(true);
+			if (GENERATION_QUOTE_ENABLED) fetchQuote();
+		} catch (e) {
+			setPaymentMessage(paymentErrorMessage(e, "Test-mode continue failed — try again."));
+		} finally {
+			setContinuingTestMode(false);
 		}
 	};
 
@@ -457,7 +537,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 						)}
 					</div>
 
-					{/* ── Upfront cost quote (feature-flagged) ── */}
+					{/* ── Upfront cost quote (feature-flagged, ratified #1296 shape) ── */}
 					{GENERATION_QUOTE_ENABLED && (
 						<div className="generate-quote mb-3">
 							{quoteStatus === "loading" && (
@@ -489,22 +569,20 @@ export default function Generate({ onNavigate, onStageChange }) {
 								<div className="info-box">
 									<div className="flex items-center flex-wrap gap-2">
 										<span className="label">Cost to generate</span>
-										<span className="tag tag-accent">{quoteView.priceLabel}</span>
-										<span className="tag tag-info">testnet USDC</span>
+										<span className="tag tag-accent">
+											{quoteView.price} {quoteView.asset}
+										</span>
+										{quoteView.paymentRequired ? (
+											<span className="tag tag-info">testnet USDC</span>
+										) : (
+											<span className="tag tag-muted">payment not required yet</span>
+										)}
+										{quoteView.paymentRequired && quoteView.dryRun && (
+											<span className="tag tag-warning">
+												test mode — payment accepted unverified
+											</span>
+										)}
 									</div>
-									{quoteView.breakdown.length > 0 && (
-										<ul style={{ margin: "8px 0 0", paddingLeft: 18 }}>
-											{quoteView.breakdown.map((b) => (
-												<li
-													key={b.label}
-													className="caption"
-													style={{ color: "var(--text-3)" }}
-												>
-													{b.label}: {b.amount_usdc} USDC-testnet
-												</li>
-											))}
-										</ul>
-									)}
 									<p
 										className="caption mb-0"
 										style={{ marginTop: 8, color: "var(--text-3)" }}
@@ -515,6 +593,16 @@ export default function Generate({ onNavigate, onStageChange }) {
 										Paper trading after generation costs nothing — this quote
 										covers generation only.
 									</p>
+									{quoteView.paymentRequired && payerMismatch && (
+										<p
+											className="caption mb-0"
+											style={{ marginTop: 6, color: "var(--text-3)" }}
+										>
+											Payments must be signed by your linked wallet (
+											{shortAddr(payerMismatch.linked)}) — your connected wallet
+											({shortAddr(payerMismatch.active)}) isn't linked yet.
+										</p>
+									)}
 								</div>
 							)}
 						</div>
@@ -525,10 +613,20 @@ export default function Generate({ onNavigate, onStageChange }) {
 						className="flex items-center justify-between flex-wrap gap-2"
 						style={{ marginTop: 2 }}
 					>
-						{paymentStatus === PAYMENT_STATUS.WALLET_REQUIRED ? (
+						{paymentStatus === PAYMENT_STATUS.WALLET_LINK_REQUIRED ? (
 							<div className="info-box warning" style={{ flex: 1 }}>
-								<strong>Payment required.</strong> Connect a wallet to pay for
-								this generation in testnet USDC.{" "}
+								<strong>Wallet link required.</strong> {paymentMessage}
+								{payerMismatch && (
+									<p
+										className="caption mb-0"
+										style={{ marginTop: 6, color: "var(--text-3)" }}
+									>
+										Your connected wallet ({shortAddr(payerMismatch.active)})
+										isn't linked to your account — your linked wallet is{" "}
+										{shortAddr(payerMismatch.linked)}. Switch your wallet's
+										active account to that one, or link the connected one below.
+									</p>
+								)}{" "}
 								<button
 									type="button"
 									onClick={() =>
@@ -544,18 +642,53 @@ export default function Generate({ onNavigate, onStageChange }) {
 										padding: 0,
 									}}
 								>
-									Connect wallet →
+									Connect / link wallet →
 								</button>
 							</div>
-						) : paymentStatus === PAYMENT_STATUS.PAYMENT_PREVIEW ? (
+						) : paymentStatus === PAYMENT_STATUS.DRY_RUN ? (
 							<div className="info-box warning" style={{ flex: 1 }}>
-								<strong>Payments aren't enabled yet.</strong> This generation
-								would cost {quoteView?.priceLabel ?? "the quoted amount"} from
-								your connected wallet once live. Nothing was charged.
+								<strong>Test mode.</strong> {paymentMessage} This backend
+								accepts payments unverified right now — nothing real is
+								charged.{" "}
+								<button
+									type="button"
+									onClick={continueInTestMode}
+									disabled={continuingTestMode}
+									className="caption"
+									style={{
+										background: "none",
+										border: "none",
+										cursor: "pointer",
+										color: "var(--accent)",
+										textDecoration: "underline",
+										padding: 0,
+									}}
+								>
+									{continuingTestMode ? "Continuing…" : "Continue in test mode →"}
+								</button>
+							</div>
+						) : paymentStatus === PAYMENT_STATUS.LIVE_UNAVAILABLE ? (
+							<div className="info-box warning" style={{ flex: 1 }}>
+								<strong>Payments aren't enabled in this build yet.</strong>{" "}
+								{paymentMessage}
 							</div>
 						) : startError ? (
 							<div className="info-box warning" style={{ flex: 1 }}>
 								{startError}
+							</div>
+						) : testModeNotice ? (
+							<div className="info-box" style={{ flex: 1 }}>
+								<span className="tag tag-warning" style={{ marginRight: 6 }}>
+									test mode
+								</span>
+								Payment accepted unverified — no real charge.
+							</div>
+						) : receipt ? (
+							<div className="info-box" style={{ flex: 1 }}>
+								<span className="tag tag-positive" style={{ marginRight: 6 }}>
+									paid
+								</span>
+								Settlement receipt: <code>{receipt}</code>
 							</div>
 						) : (
 							<div />

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -1,10 +1,20 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import GenerationStream from "./GenerationStream";
 import GenerationStatus from "./GenerationStatus";
 import ModelCostPanel from "./ModelCostPanel";
 import { EXAMPLE_BRIEFS } from "../data/exampleBriefs";
 import { ASSET_GROUPS, SUPPORTED_ASSETS } from "../data/assetUniverse";
-import { apiPost } from "../api";
+import { apiGet, apiPost } from "../api";
+import { getAddress } from "../config";
+import { GENERATION_QUOTE_ENABLED } from "../featureFlags";
+import {
+	PAYMENT_STATUS,
+	attachQuoteId,
+	deriveQuoteView,
+	derivePaymentState,
+	isPaywallError,
+	isQuoteExpired,
+} from "../generateQuote";
 
 // /generate spine page — redesigned per issue #872.
 //
@@ -17,6 +27,17 @@ import { apiPost } from "../api";
 // the page. Clicking a row opens that job's live SSE stream as a drill-down
 // view. The SSE endpoint honours Last-Event-ID for replay, so re-subscribing
 // on drill-in shows the full history for a completed job too.
+//
+// Upfront cost quote (feature-flagged, GENERATION_QUOTE_ENABLED in
+// featureFlags.js — off by default): when on, a quote is fetched from
+// GET /api/generate/quote and shown before the submit button, which reads
+// "Approve & Generate" and carries `quote_id` on /start. If /start 402s
+// (backend paywall active — docs/specs/generation-quote-contract.md,
+// PROPOSED), the submit row switches to a payment-step banner instead of
+// the generic error: wallet-required if none is connected, otherwise an
+// honest "payments aren't enabled yet" preview — this build does not sign
+// or execute an on-chain payment. State-transition logic lives in
+// ../generateQuote.js so it's unit-testable without a DOM.
 
 const RISK_PROFILES = [
 	{ id: "fixed_income", label: "Fixed income" },
@@ -55,6 +76,55 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// ── Track the most-recently submitted job so the table can highlight it ──
 	const [lastJobId, setLastJobId] = useState(null);
 
+	// ── Upfront cost quote (feature-flagged) ──
+	const [quote, setQuote] = useState(null);
+	const [quoteStatus, setQuoteStatus] = useState(
+		GENERATION_QUOTE_ENABLED ? "loading" : "idle",
+	);
+	const [quoteError, setQuoteError] = useState("");
+	// Set true only by a genuine 402 from /start (isPaywallError). Cleared on
+	// every fresh submit attempt so a stale banner never survives a retry.
+	const [paywallActive, setPaywallActive] = useState(false);
+	const [walletAddr, setWalletAddr] = useState(() => getAddress());
+
+	const fetchQuote = useCallback(() => {
+		if (!GENERATION_QUOTE_ENABLED) return;
+		setQuoteStatus("loading");
+		setQuoteError("");
+		const qs = selectedModel ? `?model=${encodeURIComponent(selectedModel)}` : "";
+		apiGet(`/api/generate/quote${qs}`)
+			.then((data) => {
+				setQuote(data);
+				setQuoteStatus("ready");
+			})
+			.catch((e) => {
+				setQuote(null);
+				setQuoteError(e.message || "Cost quote unavailable");
+				setQuoteStatus("error");
+			});
+	}, [selectedModel]);
+
+	useEffect(() => {
+		fetchQuote();
+	}, [fetchQuote]);
+
+	// Wallet connect/disconnect is a global event (config.js), not React
+	// state — re-derive our copy on change so the payment-step banner can
+	// flip from "connect a wallet" to the payment preview live.
+	useEffect(() => {
+		const onWalletChanged = () => setWalletAddr(getAddress());
+		window.addEventListener("wallet-changed", onWalletChanged);
+		return () => window.removeEventListener("wallet-changed", onWalletChanged);
+	}, []);
+
+	const quoteView = useMemo(() => deriveQuoteView(quote), [quote]);
+	const quoteReady =
+		!GENERATION_QUOTE_ENABLED ||
+		(quoteStatus === "ready" && Boolean(quoteView) && !isQuoteExpired(quote));
+	const paymentStatus = paywallActive
+		? derivePaymentState(walletAddr)
+		: PAYMENT_STATUS.NONE;
+
 	// ── Submit a generation job ──
 	const startJob = async () => {
 		setStartError("");
@@ -62,23 +132,43 @@ export default function Generate({ onNavigate, onStageChange }) {
 			setStartError("Describe what you want in a sentence or two.");
 			return;
 		}
+		if (GENERATION_QUOTE_ENABLED && isQuoteExpired(quote)) {
+			setStartError("Your quote expired — fetching a new one, try again in a moment.");
+			fetchQuote();
+			return;
+		}
+		if (GENERATION_QUOTE_ENABLED && !quoteReady) {
+			setStartError("Cost quote isn't ready yet.");
+			return;
+		}
 		setStarting(true);
-		const payload = {
-			brief: {
-				intent,
-				risk_appetite: riskAppetite,
-				asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
-				max_papers: depth,
-				...(strategyName.trim() ? { name: strategyName.trim() } : {}),
+		setPaywallActive(false);
+		const payload = attachQuoteId(
+			{
+				brief: {
+					intent,
+					risk_appetite: riskAppetite,
+					asset_classes: selectedAssets.length > 0 ? selectedAssets : undefined,
+					max_papers: depth,
+					...(strategyName.trim() ? { name: strategyName.trim() } : {}),
+				},
+				...(selectedModel ? { model: selectedModel } : {}),
 			},
-			...(selectedModel ? { model: selectedModel } : {}),
-		};
+			{ quoteEnabled: GENERATION_QUOTE_ENABLED, approvedQuoteId: quote?.quote_id },
+		);
 		try {
 			const data = await apiPost("/api/generate/start", payload);
 			setLastJobId(data.job_id);
+			// Quote is consumed by a successful /start — fetch a fresh one for
+			// the next generation rather than letting a spent quote_id linger.
+			if (GENERATION_QUOTE_ENABLED) fetchQuote();
 			// Stay on the page — the job table will show the new row.
 		} catch (e) {
-			setStartError(e.message || "Failed to start generation");
+			if (isPaywallError(e)) {
+				setPaywallActive(true);
+			} else {
+				setStartError(e.message || "Failed to start generation");
+			}
 		} finally {
 			setStarting(false);
 		}
@@ -367,12 +457,103 @@ export default function Generate({ onNavigate, onStageChange }) {
 						)}
 					</div>
 
+					{/* ── Upfront cost quote (feature-flagged) ── */}
+					{GENERATION_QUOTE_ENABLED && (
+						<div className="generate-quote mb-3">
+							{quoteStatus === "loading" && (
+								<p className="caption" style={{ color: "var(--text-3)" }}>
+									Fetching cost quote…
+								</p>
+							)}
+							{quoteStatus === "error" && (
+								<div className="info-box warning">
+									Cost quote unavailable ({quoteError}).{" "}
+									<button
+										type="button"
+										onClick={fetchQuote}
+										className="caption"
+										style={{
+											background: "none",
+											border: "none",
+											cursor: "pointer",
+											color: "var(--accent)",
+											textDecoration: "underline",
+											padding: 0,
+										}}
+									>
+										Try again
+									</button>
+								</div>
+							)}
+							{quoteStatus === "ready" && quoteView && (
+								<div className="info-box">
+									<div className="flex items-center flex-wrap gap-2">
+										<span className="label">Cost to generate</span>
+										<span className="tag tag-accent">{quoteView.priceLabel}</span>
+										<span className="tag tag-info">testnet USDC</span>
+									</div>
+									{quoteView.breakdown.length > 0 && (
+										<ul style={{ margin: "8px 0 0", paddingLeft: 18 }}>
+											{quoteView.breakdown.map((b) => (
+												<li
+													key={b.label}
+													className="caption"
+													style={{ color: "var(--text-3)" }}
+												>
+													{b.label}: {b.amount_usdc} USDC-testnet
+												</li>
+											))}
+										</ul>
+									)}
+									<p
+										className="caption mb-0"
+										style={{ marginTop: 8, color: "var(--text-3)" }}
+									>
+										<span className="tag tag-positive" style={{ marginRight: 6 }}>
+											free
+										</span>
+										Paper trading after generation costs nothing — this quote
+										covers generation only.
+									</p>
+								</div>
+							)}
+						</div>
+					)}
+
 					{/* Submit row */}
 					<div
 						className="flex items-center justify-between flex-wrap gap-2"
 						style={{ marginTop: 2 }}
 					>
-						{startError ? (
+						{paymentStatus === PAYMENT_STATUS.WALLET_REQUIRED ? (
+							<div className="info-box warning" style={{ flex: 1 }}>
+								<strong>Payment required.</strong> Connect a wallet to pay for
+								this generation in testnet USDC.{" "}
+								<button
+									type="button"
+									onClick={() =>
+										window.dispatchEvent(new Event("open-wallet-modal"))
+									}
+									className="caption"
+									style={{
+										background: "none",
+										border: "none",
+										cursor: "pointer",
+										color: "var(--accent)",
+										textDecoration: "underline",
+										padding: 0,
+									}}
+								>
+									Connect wallet →
+								</button>
+							</div>
+						) : paymentStatus === PAYMENT_STATUS.PAYMENT_PREVIEW ? (
+							<div className="info-box warning" style={{ flex: 1 }}>
+								<strong>Payments aren't enabled yet.</strong> This generation
+								would cost {quoteView?.priceLabel ?? "the quoted amount"} from
+								your connected wallet once live. Nothing was charged.
+							</div>
+						) : startError ? (
 							<div className="info-box warning" style={{ flex: 1 }}>
 								{startError}
 							</div>
@@ -382,9 +563,13 @@ export default function Generate({ onNavigate, onStageChange }) {
 						<button
 							className="btn btn-primary"
 							onClick={startJob}
-							disabled={starting || !intent.trim()}
+							disabled={starting || !intent.trim() || !quoteReady}
 						>
-							{starting ? "Starting…" : "Generate →"}
+							{starting
+								? "Starting…"
+								: GENERATION_QUOTE_ENABLED
+									? "Approve & Generate →"
+									: "Generate →"}
 						</button>
 					</div>
 				</section>

--- a/ui/src/featureFlags.js
+++ b/ui/src/featureFlags.js
@@ -1,0 +1,16 @@
+// Build-time feature flags (Vite env-gated).
+//
+// Pattern: one flag per Vite env var, exported as a plain boolean, all in
+// this one file. Established by #1266 (ui/src/featureFlags.js,
+// ROADMAP_SURFACES_ENABLED) — that PR is open, not yet on main, but this
+// file's path/shape matches it deliberately so the two flags land in the
+// same file without conflict once it merges.
+
+// Gates the upfront cost-quote + approval step on the Generate page
+// (docs/specs/generation-quote-contract.md — PROPOSED). Off by default:
+// Generate submits directly with no quote step, same as before this flag
+// existed. Dan flips VITE_GENERATION_QUOTE_ENABLED=true once the backend
+// quote endpoint + x402 paywall (contracts session, flag-gated on that
+// side too) are live enough to try against.
+export const GENERATION_QUOTE_ENABLED =
+	import.meta.env.VITE_GENERATION_QUOTE_ENABLED === "true";

--- a/ui/src/featureFlags.js
+++ b/ui/src/featureFlags.js
@@ -6,11 +6,14 @@
 // file's path/shape matches it deliberately so the two flags land in the
 // same file without conflict once it merges.
 
-// Gates the upfront cost-quote + approval step on the Generate page
-// (docs/specs/generation-quote-contract.md — PROPOSED). Off by default:
-// Generate submits directly with no quote step, same as before this flag
-// existed. Dan flips VITE_GENERATION_QUOTE_ENABLED=true once the backend
-// quote endpoint + x402 paywall (contracts session, flag-gated on that
-// side too) are live enough to try against.
+// Gates the upfront cost-quote + x402 paywall step on the Generate page
+// (docs/specs/generation-quote-contract.md — RATIFIED, #1296). Off by
+// default: Generate submits directly with no quote step, same as before
+// this flag existed. Dan flips VITE_GENERATION_QUOTE_ENABLED=true once
+// the backend's GENERATION_PAYMENT_REQUIRED flag (independently
+// flag-gated on that side, see #834's flip-list) is worth trying against
+// — this frontend flag works fine against a backend where that's still
+// off, since GET /api/generate/quote always reports payment_required
+// honestly either way.
 export const GENERATION_QUOTE_ENABLED =
 	import.meta.env.VITE_GENERATION_QUOTE_ENABLED === "true";

--- a/ui/src/generateQuote.js
+++ b/ui/src/generateQuote.js
@@ -1,12 +1,21 @@
-// Pure, framework-free helpers for the Generate page's upfront cost-quote
-// step (docs/specs/generation-quote-contract.md — PROPOSED, feature-flagged
-// via GENERATION_QUOTE_ENABLED in featureFlags.js).
+// Pure, framework-free helpers for the Generate page's upfront cost-quote +
+// x402 paywall step (docs/specs/generation-quote-contract.md — RATIFIED,
+// pinned by backend/tests/test_generate_payment_gate.py in #1296;
+// feature-flagged via GENERATION_QUOTE_ENABLED in featureFlags.js).
 //
-// Kept out of Generate.jsx so the state-transition logic — what payload
-// goes to /start, what the payment step shows after a 402 — is unit
+// Kept out of Generate.jsx so the state-transition logic — what a 402/409
+// from /start means, which linked wallet a payment binds to — is unit
 // testable without a DOM. This repo's `ui/test` has no jsdom /
 // testing-library; see ui/test/routes.test.js for the established pattern
 // of testing pure logic directly rather than rendered markup.
+//
+// NOTE on scope: this build does not perform real x402 signing (EIP-712
+// authorization + wallet signature) — that lands once the payment rail is
+// wired end to end. What IS wired: the honest quote card, the 402/409
+// state routing, a functional "test mode" continuation while the backend
+// runs PAYMENTS_DRY_RUN (which accepts any non-empty Payment-Signature
+// header without verifying it — see generation_payment.py on the backend),
+// and passive receipt/mismatch surfacing for when real signing lands.
 
 /** Lifecycle of the GET /api/generate/quote fetch. */
 export const QUOTE_STATUS = {
@@ -16,70 +25,167 @@ export const QUOTE_STATUS = {
 	ERROR: "error",
 };
 
-/** What the payment step shows once /start responds 402 (paywall active). */
+/**
+ * What the payment step shows once /start responds 402 or 409 (paywall
+ * gate active). WALLET_LINK_REQUIRED is the 409 precondition; DRY_RUN and
+ * LIVE_UNAVAILABLE are the two possible 402s, distinguished by the quote's
+ * `dry_run` flag — the backend's PAYMENTS_DRY_RUN mirror (#1296).
+ */
 export const PAYMENT_STATUS = {
 	NONE: "none",
-	WALLET_REQUIRED: "wallet-required",
-	// Wallet is connected and the quote is real, but this build doesn't wire
-	// actual x402 signing yet — render the state honestly instead of a pay
-	// button that doesn't work. See PR notes / contract doc "out of scope".
-	PAYMENT_PREVIEW: "payment-preview",
+	WALLET_LINK_REQUIRED: "wallet-link-required",
+	// PAYMENTS_DRY_RUN on the backend: any non-empty Payment-Signature header
+	// is accepted WITHOUT verify/settle. Real functionality (the job actually
+	// starts), honestly labeled — never dressed up as a real settlement.
+	DRY_RUN: "dry-run",
+	// Live paywall, but this build doesn't sign real x402 payments yet —
+	// render the honest preview rather than a pay button that doesn't work.
+	LIVE_UNAVAILABLE: "live-unavailable",
 };
 
 /**
  * Shape a raw GET /api/generate/quote response into what the quote card
  * needs to render. Returns null for a missing/falsy quote (nothing to
- * show yet).
+ * show yet). Ratified shape (#1296): payment_required, pricing_model,
+ * price (a "$X.XXXXXX" decimal string, not a float), asset, chain,
+ * recipient, dry_run, how. There is no quote_id and no expires_at — the
+ * PROPOSED contract this replaced had both; the ratified one has neither
+ * (the price is flat and re-quoted fresh on every /start attempt, so
+ * there's nothing to echo back or time out).
  */
 export function deriveQuoteView(quote) {
 	if (!quote) return null;
 	return {
-		priceLabel: `${quote.price_usdc} ${quote.currency}`,
-		quoteId: quote.quote_id,
-		breakdown: Array.isArray(quote.breakdown) ? quote.breakdown : [],
-		expiresAt: quote.expires_at ?? null,
+		paymentRequired: Boolean(quote.payment_required),
+		pricingModel: quote.pricing_model ?? null,
+		price: quote.price,
+		asset: quote.asset,
+		chain: quote.chain,
+		recipient: quote.recipient ?? null,
+		dryRun: Boolean(quote.dry_run),
+		how: quote.how ?? "",
 	};
 }
 
 /**
- * True once a quote's `expires_at` (ISO-8601) is at/past `now`. A quote
- * with no `expires_at` never expires (backend opted out of the check).
- */
-export function isQuoteExpired(quote, now = new Date()) {
-	if (!quote?.expires_at) return false;
-	const exp = new Date(quote.expires_at);
-	if (Number.isNaN(exp.getTime())) return false;
-	return exp.getTime() <= now.getTime();
-}
-
-/**
- * Build the /api/generate/start payload. quote_id is attached only when
- * the quote flow is enabled AND a quote was actually approved — never
- * fabricated, never carried over stale. When the flag is off, or nothing
- * has been approved yet, the payload passes through unchanged so a
- * flag-off build behaves exactly like before this feature existed.
- */
-export function attachQuoteId(payload, { quoteEnabled, approvedQuoteId }) {
-	if (!quoteEnabled || !approvedQuoteId) return payload;
-	return { ...payload, quote_id: approvedQuoteId };
-}
-
-/**
- * Decide the payment-step state from the currently connected wallet
- * address. Fails closed to WALLET_REQUIRED for any falsy/blank address —
- * a payment can't be previewed for a wallet that isn't there.
- */
-export function derivePaymentState(walletAddress) {
-	return walletAddress && walletAddress.trim()
-		? PAYMENT_STATUS.PAYMENT_PREVIEW
-		: PAYMENT_STATUS.WALLET_REQUIRED;
-}
-
-/**
- * True only for a genuine HTTP 402 as thrown by api.js's apiGet/apiPost
- * (they set `err.status` from the response). Guards against treating a
- * generic network failure or a 5xx as "payment required".
+ * True only for a genuine HTTP 402 as thrown by api.js's apiPost /
+ * apiPostWithMeta (they set `err.status` from the response). Guards
+ * against treating a generic network failure or a 5xx as "payment
+ * required".
  */
 export function isPaywallError(err) {
 	return Boolean(err) && err.status === 402;
+}
+
+/**
+ * True only for the wallet-link-required 409 — checked via the error
+ * body's `detail.reason` (api.js attaches the parsed FastAPI error body as
+ * `err.detail`), not just the status code: a bare 409 status alone isn't
+ * enough — some other future 409 on this endpoint must not be mistaken
+ * for this specific precondition.
+ */
+export function isWalletLinkRequiredError(err) {
+	return Boolean(err) && err.status === 409 && err.detail?.reason === "wallet_link_required";
+}
+
+/**
+ * Classify a /start error into a payment-step state. Anything that isn't
+ * the wallet-link 409 or a genuine 402 fails closed to NONE — callers
+ * fall through to the generic error banner for those, never a
+ * payment-specific one.
+ */
+export function derivePaymentState(err, quoteDryRun) {
+	if (isWalletLinkRequiredError(err)) return PAYMENT_STATUS.WALLET_LINK_REQUIRED;
+	if (isPaywallError(err)) return quoteDryRun ? PAYMENT_STATUS.DRY_RUN : PAYMENT_STATUS.LIVE_UNAVAILABLE;
+	return PAYMENT_STATUS.NONE;
+}
+
+/**
+ * The human-readable message the backend attached to a 402/409 error body
+ * (`detail.message` — #1296's shape). Falls back to a generic string so a
+ * malformed or absent detail never crashes the banner; never fabricates
+ * backend wording otherwise — the faucet caveat on the 409 in particular
+ * must render verbatim, not be re-paraphrased.
+ */
+export function paymentErrorMessage(err, fallback) {
+	return err?.detail?.message || fallback || "Payment step failed.";
+}
+
+/**
+ * The account's PRIMARY linked wallet from a GET /api/wallets response
+ * (list of LinkedWalletResponse) — or the first entry if none is flagged
+ * primary. Null for an empty/missing list.
+ */
+export function primaryLinkedWallet(linkedWallets) {
+	if (!Array.isArray(linkedWallets) || linkedWallets.length === 0) return null;
+	return linkedWallets.find((w) => w?.is_primary) ?? linkedWallets[0];
+}
+
+/**
+ * Detect a payer-binding mismatch worth flagging: the wallet currently
+ * active in the injected provider (config.js's getAddress()) is NOT any
+ * of the account's linked wallets. Returns null when there's nothing to
+ * flag — no active address, no linked wallets yet (the 409 CTA already
+ * covers that case), or the active address IS one of the linked wallets
+ * (a payment from it resolves to itself server-side, #1296's
+ * get_linked_wallet_address — no mismatch).
+ *
+ * This is a transparency check, not the enforcement gate: the backend is
+ * the actual authority (payer_mismatch, #1296) — this only lets the UI
+ * warn BEFORE a signing attempt would fail, using the LINKED wallet's
+ * account rather than blindly trusting whatever's active in the provider.
+ */
+export function describePayerMismatch(activeAddress, linkedWallets) {
+	const active = (activeAddress || "").trim().toLowerCase();
+	const wallets = Array.isArray(linkedWallets) ? linkedWallets : [];
+	if (!active || wallets.length === 0) return null;
+	const activeIsLinked = wallets.some((w) => (w?.address || "").toLowerCase() === active);
+	if (activeIsLinked) return null;
+	const primary = primaryLinkedWallet(wallets);
+	return { active: activeAddress, linked: primary.address };
+}
+
+/**
+ * Base64-JSON, matching circlekit's Payment-Signature wire encoding (see
+ * backend/tests/test_generate_payment_gate.py's `_payment_header`) —
+ * portable across the browser (btoa) and the node:test runner (Buffer).
+ */
+function toBase64(str) {
+	if (typeof btoa === "function") return btoa(str);
+	// globalThis.Buffer (not a bare `Buffer` reference) so this line is
+	// statically valid under the browser-only eslint globals this repo lints
+	// with — the branch itself only ever runs under node:test, where
+	// globalThis.Buffer is the real Node Buffer.
+	return globalThis.Buffer.from(str, "utf-8").toString("base64");
+}
+
+/**
+ * Build the stand-in Payment-Signature header used ONLY to continue in
+ * PAYMENTS_DRY_RUN test mode (PAYMENT_STATUS.DRY_RUN) — NOT a real
+ * signature. The backend's dry-run path accepts any non-empty header
+ * without decoding or verifying it, so this exists purely so the "from"
+ * inside it is honest rather than absent: the payer named is the caller's
+ * OWN linked wallet (the same address that already cleared the 409
+ * wallet-link precondition to reach this state), never fabricated.
+ */
+export function buildDryRunPaymentHeader(payerAddress) {
+	const from = payerAddress || "";
+	return toBase64(JSON.stringify({ payload: { authorization: { from } } }));
+}
+
+/**
+ * The settlement receipt (PAYMENT-RESPONSE header, #1296) from a
+ * successful /start response, if present — surfaced subtly, never
+ * fabricated. Accepts either a Fetch `Headers` object or a plain object
+ * (tests use the latter); header names are matched case-insensitively
+ * either way, since a plain object isn't guaranteed to normalize casing
+ * the way `Headers` does.
+ */
+export function extractReceipt(headers) {
+	if (!headers) return null;
+	if (typeof headers.get === "function") {
+		return headers.get("PAYMENT-RESPONSE") || headers.get("payment-response") || null;
+	}
+	const key = Object.keys(headers).find((k) => k.toLowerCase() === "payment-response");
+	return key ? headers[key] : null;
 }

--- a/ui/src/generateQuote.js
+++ b/ui/src/generateQuote.js
@@ -1,0 +1,85 @@
+// Pure, framework-free helpers for the Generate page's upfront cost-quote
+// step (docs/specs/generation-quote-contract.md — PROPOSED, feature-flagged
+// via GENERATION_QUOTE_ENABLED in featureFlags.js).
+//
+// Kept out of Generate.jsx so the state-transition logic — what payload
+// goes to /start, what the payment step shows after a 402 — is unit
+// testable without a DOM. This repo's `ui/test` has no jsdom /
+// testing-library; see ui/test/routes.test.js for the established pattern
+// of testing pure logic directly rather than rendered markup.
+
+/** Lifecycle of the GET /api/generate/quote fetch. */
+export const QUOTE_STATUS = {
+	IDLE: "idle",
+	LOADING: "loading",
+	READY: "ready",
+	ERROR: "error",
+};
+
+/** What the payment step shows once /start responds 402 (paywall active). */
+export const PAYMENT_STATUS = {
+	NONE: "none",
+	WALLET_REQUIRED: "wallet-required",
+	// Wallet is connected and the quote is real, but this build doesn't wire
+	// actual x402 signing yet — render the state honestly instead of a pay
+	// button that doesn't work. See PR notes / contract doc "out of scope".
+	PAYMENT_PREVIEW: "payment-preview",
+};
+
+/**
+ * Shape a raw GET /api/generate/quote response into what the quote card
+ * needs to render. Returns null for a missing/falsy quote (nothing to
+ * show yet).
+ */
+export function deriveQuoteView(quote) {
+	if (!quote) return null;
+	return {
+		priceLabel: `${quote.price_usdc} ${quote.currency}`,
+		quoteId: quote.quote_id,
+		breakdown: Array.isArray(quote.breakdown) ? quote.breakdown : [],
+		expiresAt: quote.expires_at ?? null,
+	};
+}
+
+/**
+ * True once a quote's `expires_at` (ISO-8601) is at/past `now`. A quote
+ * with no `expires_at` never expires (backend opted out of the check).
+ */
+export function isQuoteExpired(quote, now = new Date()) {
+	if (!quote?.expires_at) return false;
+	const exp = new Date(quote.expires_at);
+	if (Number.isNaN(exp.getTime())) return false;
+	return exp.getTime() <= now.getTime();
+}
+
+/**
+ * Build the /api/generate/start payload. quote_id is attached only when
+ * the quote flow is enabled AND a quote was actually approved — never
+ * fabricated, never carried over stale. When the flag is off, or nothing
+ * has been approved yet, the payload passes through unchanged so a
+ * flag-off build behaves exactly like before this feature existed.
+ */
+export function attachQuoteId(payload, { quoteEnabled, approvedQuoteId }) {
+	if (!quoteEnabled || !approvedQuoteId) return payload;
+	return { ...payload, quote_id: approvedQuoteId };
+}
+
+/**
+ * Decide the payment-step state from the currently connected wallet
+ * address. Fails closed to WALLET_REQUIRED for any falsy/blank address —
+ * a payment can't be previewed for a wallet that isn't there.
+ */
+export function derivePaymentState(walletAddress) {
+	return walletAddress && walletAddress.trim()
+		? PAYMENT_STATUS.PAYMENT_PREVIEW
+		: PAYMENT_STATUS.WALLET_REQUIRED;
+}
+
+/**
+ * True only for a genuine HTTP 402 as thrown by api.js's apiGet/apiPost
+ * (they set `err.status` from the response). Guards against treating a
+ * generic network failure or a 5xx as "payment required".
+ */
+export function isPaywallError(err) {
+	return Boolean(err) && err.status === 402;
+}

--- a/ui/test/generate-quote.test.js
+++ b/ui/test/generate-quote.test.js
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+	PAYMENT_STATUS,
+	attachQuoteId,
+	deriveQuoteView,
+	derivePaymentState,
+	isPaywallError,
+	isQuoteExpired,
+} from "../src/generateQuote.js";
+
+// ── deriveQuoteView: shapes the raw GET /api/generate/quote response ──────
+
+test("quote renders: deriveQuoteView shapes price, testnet label, and breakdown", () => {
+	const view = deriveQuoteView({
+		quote_id: "qt_abc123",
+		price_usdc: "0.42",
+		currency: "USDC-testnet",
+		breakdown: [{ label: "LLM inference (est.)", amount_usdc: "0.30" }],
+		expires_at: "2026-08-19T18:05:00Z",
+	});
+	assert.equal(view.priceLabel, "0.42 USDC-testnet");
+	assert.match(view.priceLabel, /USDC-testnet/);
+	assert.equal(view.quoteId, "qt_abc123");
+	assert.equal(view.breakdown.length, 1);
+	assert.equal(view.breakdown[0].label, "LLM inference (est.)");
+	assert.equal(view.expiresAt, "2026-08-19T18:05:00Z");
+});
+
+test("quote renders: absent breakdown/quote degrade to empty/null, not a crash", () => {
+	assert.equal(deriveQuoteView(null), null);
+	const view = deriveQuoteView({
+		quote_id: "qt_x",
+		price_usdc: "1.00",
+		currency: "USDC-testnet",
+	});
+	assert.deepEqual(view.breakdown, []);
+	assert.equal(view.expiresAt, null);
+});
+
+// ── isQuoteExpired ─────────────────────────────────────────────────────────
+
+test("a quote past its expires_at is expired; one still ahead is not", () => {
+	const now = new Date("2026-08-19T12:00:00Z");
+	assert.equal(
+		isQuoteExpired({ expires_at: "2026-08-19T11:59:59Z" }, now),
+		true,
+	);
+	assert.equal(
+		isQuoteExpired({ expires_at: "2026-08-19T12:00:00Z" }, now),
+		true,
+		"exact boundary counts as expired, not a race the caller can win",
+	);
+	assert.equal(
+		isQuoteExpired({ expires_at: "2026-08-19T12:00:01Z" }, now),
+		false,
+	);
+});
+
+test("a quote with no/malformed expires_at is never treated as expired", () => {
+	assert.equal(isQuoteExpired(null), false);
+	assert.equal(isQuoteExpired({}), false);
+	assert.equal(isQuoteExpired({ expires_at: "not-a-date" }), false);
+});
+
+// ── attachQuoteId: "approve carries quote_id" ──────────────────────────────
+
+test("approve carries quote_id: attached only when the flag is on and a quote was fetched", () => {
+	const payload = { brief: { intent: "momentum" } };
+	const withId = attachQuoteId(payload, {
+		quoteEnabled: true,
+		approvedQuoteId: "qt_777",
+	});
+	assert.equal(withId.quote_id, "qt_777");
+	assert.equal(withId.brief.intent, "momentum", "original payload fields untouched");
+	assert.notEqual(withId, payload, "does not mutate the input payload");
+});
+
+test("approve carries quote_id: fails closed when flag is off, even if a quote id is present", () => {
+	const payload = { brief: { intent: "momentum" } };
+	const result = attachQuoteId(payload, {
+		quoteEnabled: false,
+		approvedQuoteId: "qt_777",
+	});
+	assert.equal(result, payload);
+	assert.equal("quote_id" in result, false);
+});
+
+test("approve carries quote_id: fails closed when the flag is on but no quote was approved", () => {
+	const payload = { brief: { intent: "momentum" } };
+	const result = attachQuoteId(payload, {
+		quoteEnabled: true,
+		approvedQuoteId: null,
+	});
+	assert.equal(result, payload);
+	assert.equal("quote_id" in result, false);
+});
+
+// ── 402 state: isPaywallError + derivePaymentState ─────────────────────────
+
+test("402 state renders: isPaywallError recognizes only a genuine 402", () => {
+	assert.equal(isPaywallError({ status: 402 }), true);
+	assert.equal(isPaywallError({ status: 500 }), false);
+	assert.equal(isPaywallError({ status: 404 }), false);
+	assert.equal(isPaywallError(null), false);
+	assert.equal(isPaywallError(undefined), false);
+	assert.equal(isPaywallError({}), false);
+});
+
+test("402 state renders: no wallet -> wallet-required, connected wallet -> payment preview", () => {
+	assert.equal(derivePaymentState(null), PAYMENT_STATUS.WALLET_REQUIRED);
+	assert.equal(derivePaymentState(""), PAYMENT_STATUS.WALLET_REQUIRED);
+	assert.equal(derivePaymentState("   "), PAYMENT_STATUS.WALLET_REQUIRED);
+	assert.equal(
+		derivePaymentState("0xabc123"),
+		PAYMENT_STATUS.PAYMENT_PREVIEW,
+	);
+});
+
+// ── Wiring: Generate.jsx actually uses the flag + helpers, not a fork of the
+// logic re-implemented inline. Static-source checks, matching the pattern
+// already established in ui/test/app-visuals.test.js for this file. ──────
+
+const generate = readFileSync(
+	new URL("../src/components/Generate.jsx", import.meta.url),
+	"utf8",
+);
+
+test("Generate.jsx gates the quote card and payment step behind GENERATION_QUOTE_ENABLED", () => {
+	assert.match(generate, /from ["']\.\.\/featureFlags["']/);
+	assert.match(generate, /GENERATION_QUOTE_ENABLED\s*&&/);
+	assert.match(generate, /testnet USDC/);
+	assert.match(generate, /Paper trading after generation costs nothing/);
+});
+
+test("Generate.jsx builds the /start payload through attachQuoteId, not an inline fork", () => {
+	assert.match(generate, /attachQuoteId\(/);
+	assert.match(generate, /apiPost\(["']\/api\/generate\/start["']/);
+});
+
+test("Generate.jsx routes a 402 through isPaywallError into the payment-step states", () => {
+	assert.match(generate, /isPaywallError\(e\)/);
+	assert.match(generate, /PAYMENT_STATUS\.WALLET_REQUIRED/);
+	assert.match(generate, /PAYMENT_STATUS\.PAYMENT_PREVIEW/);
+	assert.match(generate, /open-wallet-modal/);
+});

--- a/ui/test/generate-quote.test.js
+++ b/ui/test/generate-quote.test.js
@@ -4,124 +4,213 @@ import test from "node:test";
 
 import {
 	PAYMENT_STATUS,
-	attachQuoteId,
+	buildDryRunPaymentHeader,
 	deriveQuoteView,
 	derivePaymentState,
+	describePayerMismatch,
+	extractReceipt,
 	isPaywallError,
-	isQuoteExpired,
+	isWalletLinkRequiredError,
+	paymentErrorMessage,
+	primaryLinkedWallet,
 } from "../src/generateQuote.js";
 
-// ── deriveQuoteView: shapes the raw GET /api/generate/quote response ──────
+// ── deriveQuoteView: shapes the ratified GET /api/generate/quote response
+// (#1296) — payment_required, pricing_model, price, asset, chain,
+// recipient, dry_run, how. NO quote_id, NO expires_at, NO breakdown: the
+// PROPOSED contract this replaced had all three; the ratified shape has
+// none of them. ─────────────────────────────────────────────────────────
 
-test("quote renders: deriveQuoteView shapes price, testnet label, and breakdown", () => {
+test("quote renders: deriveQuoteView shapes the ratified fields", () => {
 	const view = deriveQuoteView({
-		quote_id: "qt_abc123",
-		price_usdc: "0.42",
-		currency: "USDC-testnet",
-		breakdown: [{ label: "LLM inference (est.)", amount_usdc: "0.30" }],
-		expires_at: "2026-08-19T18:05:00Z",
+		payment_required: true,
+		pricing_model: "flat_v1",
+		price: "$0.150000",
+		asset: "USDC",
+		chain: "eip155:5042002",
+		recipient: "0xRecipient",
+		dry_run: true,
+		how: "POST /api/generate/start without a Payment-Signature header returns 402...",
 	});
-	assert.equal(view.priceLabel, "0.42 USDC-testnet");
-	assert.match(view.priceLabel, /USDC-testnet/);
-	assert.equal(view.quoteId, "qt_abc123");
-	assert.equal(view.breakdown.length, 1);
-	assert.equal(view.breakdown[0].label, "LLM inference (est.)");
-	assert.equal(view.expiresAt, "2026-08-19T18:05:00Z");
+	assert.equal(view.paymentRequired, true);
+	assert.equal(view.pricingModel, "flat_v1");
+	assert.equal(view.price, "$0.150000");
+	assert.equal(view.asset, "USDC");
+	assert.equal(view.chain, "eip155:5042002");
+	assert.equal(view.recipient, "0xRecipient");
+	assert.equal(view.dryRun, true);
+	assert.match(view.how, /Payment-Signature/);
 });
 
-test("quote renders: absent breakdown/quote degrade to empty/null, not a crash", () => {
+test("quote renders: null quote and a null recipient degrade cleanly, not a crash", () => {
 	assert.equal(deriveQuoteView(null), null);
 	const view = deriveQuoteView({
-		quote_id: "qt_x",
-		price_usdc: "1.00",
-		currency: "USDC-testnet",
+		payment_required: false,
+		pricing_model: "flat_v1",
+		price: "$0.150000",
+		asset: "USDC",
+		chain: "eip155:5042002",
+		recipient: null,
+		dry_run: true,
+		how: "...",
 	});
-	assert.deepEqual(view.breakdown, []);
-	assert.equal(view.expiresAt, null);
+	assert.equal(view.recipient, null);
+	assert.equal(view.paymentRequired, false);
 });
 
-// ── isQuoteExpired ─────────────────────────────────────────────────────────
-
-test("a quote past its expires_at is expired; one still ahead is not", () => {
-	const now = new Date("2026-08-19T12:00:00Z");
-	assert.equal(
-		isQuoteExpired({ expires_at: "2026-08-19T11:59:59Z" }, now),
-		true,
-	);
-	assert.equal(
-		isQuoteExpired({ expires_at: "2026-08-19T12:00:00Z" }, now),
-		true,
-		"exact boundary counts as expired, not a race the caller can win",
-	);
-	assert.equal(
-		isQuoteExpired({ expires_at: "2026-08-19T12:00:01Z" }, now),
-		false,
-	);
-});
-
-test("a quote with no/malformed expires_at is never treated as expired", () => {
-	assert.equal(isQuoteExpired(null), false);
-	assert.equal(isQuoteExpired({}), false);
-	assert.equal(isQuoteExpired({ expires_at: "not-a-date" }), false);
-});
-
-// ── attachQuoteId: "approve carries quote_id" ──────────────────────────────
-
-test("approve carries quote_id: attached only when the flag is on and a quote was fetched", () => {
-	const payload = { brief: { intent: "momentum" } };
-	const withId = attachQuoteId(payload, {
-		quoteEnabled: true,
-		approvedQuoteId: "qt_777",
+test("quote renders: the ratified shape carries no quote_id, expires_at, or breakdown", () => {
+	// The PROPOSED contract's dead fields must not leak through even if a
+	// stale/misbehaving backend sent them — deriveQuoteView only reads the
+	// ratified field names.
+	const view = deriveQuoteView({
+		payment_required: true,
+		pricing_model: "flat_v1",
+		price: "$0.150000",
+		asset: "USDC",
+		chain: "eip155:5042002",
+		recipient: null,
+		dry_run: false,
+		how: "...",
+		quote_id: "qt_shouldnt_survive",
+		expires_at: "2026-08-19T18:05:00Z",
+		breakdown: [{ label: "should not survive" }],
 	});
-	assert.equal(withId.quote_id, "qt_777");
-	assert.equal(withId.brief.intent, "momentum", "original payload fields untouched");
-	assert.notEqual(withId, payload, "does not mutate the input payload");
+	assert.equal("quoteId" in view, false);
+	assert.equal("expiresAt" in view, false);
+	assert.equal("breakdown" in view, false);
 });
 
-test("approve carries quote_id: fails closed when flag is off, even if a quote id is present", () => {
-	const payload = { brief: { intent: "momentum" } };
-	const result = attachQuoteId(payload, {
-		quoteEnabled: false,
-		approvedQuoteId: "qt_777",
-	});
-	assert.equal(result, payload);
-	assert.equal("quote_id" in result, false);
-});
+// ── isPaywallError / isWalletLinkRequiredError: the two gate guards ───────
 
-test("approve carries quote_id: fails closed when the flag is on but no quote was approved", () => {
-	const payload = { brief: { intent: "momentum" } };
-	const result = attachQuoteId(payload, {
-		quoteEnabled: true,
-		approvedQuoteId: null,
-	});
-	assert.equal(result, payload);
-	assert.equal("quote_id" in result, false);
-});
-
-// ── 402 state: isPaywallError + derivePaymentState ─────────────────────────
-
-test("402 state renders: isPaywallError recognizes only a genuine 402", () => {
+test("402 state: isPaywallError recognizes only a genuine 402", () => {
 	assert.equal(isPaywallError({ status: 402 }), true);
 	assert.equal(isPaywallError({ status: 500 }), false);
-	assert.equal(isPaywallError({ status: 404 }), false);
+	assert.equal(isPaywallError({ status: 409 }), false);
 	assert.equal(isPaywallError(null), false);
 	assert.equal(isPaywallError(undefined), false);
 	assert.equal(isPaywallError({}), false);
 });
 
-test("402 state renders: no wallet -> wallet-required, connected wallet -> payment preview", () => {
-	assert.equal(derivePaymentState(null), PAYMENT_STATUS.WALLET_REQUIRED);
-	assert.equal(derivePaymentState(""), PAYMENT_STATUS.WALLET_REQUIRED);
-	assert.equal(derivePaymentState("   "), PAYMENT_STATUS.WALLET_REQUIRED);
+test("409 state: isWalletLinkRequiredError recognizes only the wallet_link_required reason, not any 409", () => {
 	assert.equal(
-		derivePaymentState("0xabc123"),
-		PAYMENT_STATUS.PAYMENT_PREVIEW,
+		isWalletLinkRequiredError({ status: 409, detail: { reason: "wallet_link_required" } }),
+		true,
+	);
+	// A 409 for some other reason must NOT be mistaken for this precondition.
+	assert.equal(
+		isWalletLinkRequiredError({ status: 409, detail: { reason: "some_other_conflict" } }),
+		false,
+	);
+	assert.equal(isWalletLinkRequiredError({ status: 409 }), false);
+	assert.equal(isWalletLinkRequiredError({ status: 402, detail: { reason: "wallet_link_required" } }), false);
+	assert.equal(isWalletLinkRequiredError(null), false);
+});
+
+// ── derivePaymentState: routes an error + the quote's dry_run flag into a
+// PAYMENT_STATUS ────────────────────────────────────────────────────────
+
+test("derivePaymentState: 409 wallet_link_required routes to WALLET_LINK_REQUIRED regardless of dry_run", () => {
+	const err = { status: 409, detail: { reason: "wallet_link_required" } };
+	assert.equal(derivePaymentState(err, true), PAYMENT_STATUS.WALLET_LINK_REQUIRED);
+	assert.equal(derivePaymentState(err, false), PAYMENT_STATUS.WALLET_LINK_REQUIRED);
+});
+
+test("derivePaymentState: a 402 routes to DRY_RUN or LIVE_UNAVAILABLE by the quote's dry_run flag", () => {
+	const err = { status: 402, detail: { reason: "payment_required" } };
+	assert.equal(derivePaymentState(err, true), PAYMENT_STATUS.DRY_RUN);
+	assert.equal(derivePaymentState(err, false), PAYMENT_STATUS.LIVE_UNAVAILABLE);
+});
+
+test("derivePaymentState: anything else fails closed to NONE, never a payment-specific state", () => {
+	assert.equal(derivePaymentState({ status: 500 }, true), PAYMENT_STATUS.NONE);
+	assert.equal(derivePaymentState({ status: 404 }, true), PAYMENT_STATUS.NONE);
+	assert.equal(derivePaymentState(null, true), PAYMENT_STATUS.NONE);
+});
+
+// ── paymentErrorMessage: renders the backend's message verbatim ───────────
+
+test("paymentErrorMessage: renders detail.message verbatim, falls back only when absent", () => {
+	assert.equal(
+		paymentErrorMessage({ detail: { message: "fund it with testnet USDC (the faucet currently requires a human)" } }),
+		"fund it with testnet USDC (the faucet currently requires a human)",
+	);
+	assert.equal(paymentErrorMessage({}, "fallback"), "fallback");
+	assert.equal(paymentErrorMessage(null), "Payment step failed.");
+});
+
+// ── primaryLinkedWallet / describePayerMismatch: payer binding ────────────
+
+test("primaryLinkedWallet: picks the wallet flagged primary, or the first if none is", () => {
+	assert.equal(primaryLinkedWallet([]), null);
+	assert.equal(primaryLinkedWallet(null), null);
+	const wallets = [
+		{ address: "0xAAA", is_primary: false },
+		{ address: "0xBBB", is_primary: true },
+	];
+	assert.equal(primaryLinkedWallet(wallets).address, "0xBBB");
+	assert.equal(
+		primaryLinkedWallet([{ address: "0xCCC", is_primary: false }]).address,
+		"0xCCC",
 	);
 });
 
+test("describePayerMismatch: null when the active wallet IS one of the linked wallets (case-insensitive, either side mixed-case)", () => {
+	const wallets = [{ address: "0xabcdef0000000000000000000000000000001", is_primary: true }];
+	// The ACTIVE address (not just the linked one) is mixed-case here — both
+	// sides must be normalized, not just the linked-wallet side.
+	assert.equal(describePayerMismatch("0xAbCdEf0000000000000000000000000000001", wallets), null);
+});
+
+test("describePayerMismatch: null when there's nothing to compare (no active address, or no linked wallets)", () => {
+	assert.equal(describePayerMismatch(null, [{ address: "0xAAA", is_primary: true }]), null);
+	assert.equal(describePayerMismatch("0xAAA", []), null);
+	assert.equal(describePayerMismatch("0xAAA", null), null);
+});
+
+test("describePayerMismatch: flags the primary linked wallet when the active address isn't any linked one", () => {
+	const wallets = [
+		{ address: "0xAAA", is_primary: false },
+		{ address: "0xBBB", is_primary: true },
+	];
+	const result = describePayerMismatch("0xCCC", wallets);
+	assert.deepEqual(result, { active: "0xCCC", linked: "0xBBB" });
+});
+
+// ── buildDryRunPaymentHeader: the honest test-mode stand-in ────────────────
+
+test("buildDryRunPaymentHeader: base64-JSON carrying the REAL payer, decodable the same way the backend's own test fixture is built", () => {
+	const header = buildDryRunPaymentHeader("0xPayerAddress");
+	const decoded = JSON.parse(globalThis.Buffer.from(header, "base64").toString("utf8"));
+	assert.equal(decoded.payload.authorization.from, "0xPayerAddress");
+});
+
+test("buildDryRunPaymentHeader: never silently fabricates a payer for a falsy address", () => {
+	const header = buildDryRunPaymentHeader(null);
+	const decoded = JSON.parse(globalThis.Buffer.from(header, "base64").toString("utf8"));
+	assert.equal(decoded.payload.authorization.from, "");
+});
+
+// ── extractReceipt: the PAYMENT-RESPONSE settlement receipt ───────────────
+
+test("extractReceipt: reads PAYMENT-RESPONSE from a Headers-like object and a plain object, case-insensitively", () => {
+	const fakeHeaders = { get: (name) => (name.toLowerCase() === "payment-response" ? "receipt-123" : null) };
+	assert.equal(extractReceipt(fakeHeaders), "receipt-123");
+	assert.equal(extractReceipt({ "payment-response": "receipt-456" }), "receipt-456");
+	assert.equal(extractReceipt({ "PAYMENT-RESPONSE": "receipt-789" }), "receipt-789");
+});
+
+test("extractReceipt: null when absent, never a crash on a missing/empty headers object", () => {
+	assert.equal(extractReceipt(null), null);
+	assert.equal(extractReceipt({}), null);
+	const fakeHeaders = { get: () => null };
+	assert.equal(extractReceipt(fakeHeaders), null);
+});
+
 // ── Wiring: Generate.jsx actually uses the flag + helpers, not a fork of the
-// logic re-implemented inline. Static-source checks, matching the pattern
-// already established in ui/test/app-visuals.test.js for this file. ──────
+// logic re-implemented inline, and the dead PROPOSED-contract concepts
+// (quote_id, expiry, attachQuoteId) are actually gone. Static-source
+// checks, matching the pattern already established in
+// ui/test/app-visuals.test.js for this file. ──────────────────────────────
 
 const generate = readFileSync(
 	new URL("../src/components/Generate.jsx", import.meta.url),
@@ -131,18 +220,28 @@ const generate = readFileSync(
 test("Generate.jsx gates the quote card and payment step behind GENERATION_QUOTE_ENABLED", () => {
 	assert.match(generate, /from ["']\.\.\/featureFlags["']/);
 	assert.match(generate, /GENERATION_QUOTE_ENABLED\s*&&/);
-	assert.match(generate, /testnet USDC/);
 	assert.match(generate, /Paper trading after generation costs nothing/);
 });
 
-test("Generate.jsx builds the /start payload through attachQuoteId, not an inline fork", () => {
-	assert.match(generate, /attachQuoteId\(/);
-	assert.match(generate, /apiPost\(["']\/api\/generate\/start["']/);
+test("Generate.jsx submits /start through apiPostWithMeta, not the plain apiPost / a fork of the ratified body", () => {
+	assert.match(generate, /apiPostWithMeta\(\s*["']\/api\/generate\/start["']/);
+	// The PROPOSED contract's quote_id/attachQuoteId must be fully gone from
+	// the code (not merely from a doc comment explaining that it's dead) —
+	// the ratified /start body carries no payment field at all.
+	assert.doesNotMatch(generate, /attachQuoteId/);
+	assert.doesNotMatch(generate, /quote_id\s*[:.]/);
 });
 
-test("Generate.jsx routes a 402 through isPaywallError into the payment-step states", () => {
-	assert.match(generate, /isPaywallError\(e\)/);
-	assert.match(generate, /PAYMENT_STATUS\.WALLET_REQUIRED/);
-	assert.match(generate, /PAYMENT_STATUS\.PAYMENT_PREVIEW/);
+test("Generate.jsx routes 409/402 through derivePaymentState into the ratified payment-step states", () => {
+	assert.match(generate, /derivePaymentState\(/);
+	assert.match(generate, /PAYMENT_STATUS\.WALLET_LINK_REQUIRED/);
+	assert.match(generate, /PAYMENT_STATUS\.DRY_RUN/);
+	assert.match(generate, /PAYMENT_STATUS\.LIVE_UNAVAILABLE/);
 	assert.match(generate, /open-wallet-modal/);
+});
+
+test("Generate.jsx offers a functional test-mode continuation and surfaces the receipt when present", () => {
+	assert.match(generate, /buildDryRunPaymentHeader\(/);
+	assert.match(generate, /continueInTestMode/);
+	assert.match(generate, /extractReceipt\(/);
 });


### PR DESCRIPTION
## Summary

Frontend half of the quote/paywall feature (contracts session owns the
backend: quote endpoint + x402 paywall on `/api/generate/start`). Built
against a contract this PR proposes for that session to ratify or amend:
[`docs/specs/generation-quote-contract.md`](docs/specs/generation-quote-contract.md).

- Generate fetches `GET /api/generate/quote` and shows a quote card before
  submission: price, an explicit **"testnet USDC"** label, optional
  breakdown, and a **"free"**-tagged note that paper trading after
  generation costs nothing (Dan: say it in the UI).
- Submit button becomes "Approve & Generate →"; approving carries
  `quote_id` on `POST /api/generate/start`.
- A 402 from `/start` renders a payment-step banner instead of the generic
  error: **wallet-required** (Connect Wallet, reusing the existing
  `open-wallet-modal` link flow) if no wallet is connected, otherwise an
  honest **"payments aren't enabled yet"** preview — this PR does not sign
  or execute an on-chain payment.
- Everything is behind `VITE_GENERATION_QUOTE_ENABLED`
  (`ui/src/featureFlags.js`, default **off**) — flag-off behavior is
  byte-identical to before this PR. Dan flips it once the backend is ready.

`ui/src/featureFlags.js` follows the path/shape of the flag file introduced
in #1266 (`ROADMAP_SURFACES_ENABLED`), which is open but not yet on `main`
— checked before writing this so the two flags land in the same file
without a merge conflict once #1266 lands.

State-transition logic (quote shaping, expiry, payload building, 402 →
payment-state routing) lives in `ui/src/generateQuote.js`, pure and
DOM-free, imported by `Generate.jsx` rather than reimplemented inline.

## Verification

```
cd ui
npm run lint                                          # clean
npm test                                               # 38/38 pass (12 new)
rm -rf dist && npm run build                           # flag off — clean
rm -rf dist && VITE_GENERATION_QUOTE_ENABLED=true npm run build   # flag on — clean
```

Adversarial pass on the three guard functions (per repo convention) —
mutated each to the wrong-but-plausible behavior, confirmed the
corresponding test fails, then reverted:
- `attachQuoteId` ignoring `quoteEnabled` → "fails closed when flag is off" test fails
- `isPaywallError` treating any error as 402 → "recognizes only a genuine 402" test fails
- `derivePaymentState` not failing closed on blank address → wallet-required test fails

## Omissions (deliberate)

- **No real payment execution.** Signing/paying the quote via the connected
  wallet (x402) isn't wired here — see contract doc's "out of scope"
  section. Lands once the contract is ratified and the payment rail is
  defined.
- **No wallet-address prop threading.** Uses `getAddress()` /
  `wallet-changed` directly (same pattern as `WalletConnect.jsx`) rather
  than plumbing `walletAddr` through `AuthenticatedApp.jsx`'s render
  switch, to keep the diff scoped to `Generate.jsx`.
- Quote is treated as single-use: a successful `/start` triggers a
  refetch for the next generation. Not stated in the contract doc either
  way — flag for the contracts session to confirm.