### PR TITLE
Generation payment gate: x402 paywall + public quote + wallet precondition (flag-gated)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,6 +215,16 @@ MARKETPLACE_SPEND_CAP_USDC=50
 GENERATION_DAILY_CAP_PER_USER=10
 GENERATION_DAILY_CAP_PER_IP=20
 
+# ── Generation payment gate (x402; Dan's directive 2026-08-19) ────────────
+# Generation requires wallet connection + payment when the flag is "true"
+# (paper trading stays free). Flag-gated for a deliberate flip — see the #834
+# flip-list. Recipient MUST be set before the flag (flag-on without a
+# recipient is a 503 outage, never a free pass). Flat price is the #1217 seam:
+# the measured per-generation budget replaces it later.
+GENERATION_PAYMENT_REQUIRED=false
+GENERATION_PRICE_USD=0.15
+GENERATION_PAYMENT_RECIPIENT=
+
 # ── Email encryption at rest ──────────────────────────────────────────────
 # REQUIRED when PUBLIC_DOMAIN is set (production). Generate with:
 #   python -c "import secrets; print(secrets.token_urlsafe(32))"

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -37,6 +37,7 @@ from archimedes.api.generate_schemas import (
 )
 from archimedes.api.limiter import limiter
 from archimedes.api.wallet_routes import get_linked_wallet_address
+from archimedes.services import generation_payment
 from archimedes.services.generation_quota import enforce_generation_quota
 from archimedes.services.identity_events import emit_identity_event
 from archimedes.services.job_queue import EVENT_LOG_TTL, get_job_store
@@ -47,6 +48,12 @@ from archimedes.services.model_gate import enforce_model_entitlement
 logger = logging.getLogger(__name__)
 
 generate_router = APIRouter(prefix="/api/generate", tags=["generate"])
+
+# Public sibling: main.py mounts generate_router behind require_current_user
+# wholesale, but the price quote must be readable BEFORE sign-in — a human
+# comparing cost, or an agent planning its approval flow (#1293), needs the
+# number first. Only /quote lives here; everything stateful stays gated.
+generate_public_router = APIRouter(prefix="/api/generate", tags=["generate"])
 
 _TERMINAL_EVENTS = {"done", "error"}
 _POLL_INTERVAL_SECONDS = 0.4
@@ -85,12 +92,23 @@ def _require_job_access(job: dict, user_id: str, job_id: str, linked_wallet: str
         raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
 
 
+@generate_public_router.get("/quote")
+async def get_generation_quote():
+    """The upfront generation cost estimate — public, so a human can see the
+    price before signing in and an agent can plan before paying (#1293's
+    discoverability point). The SAME quote rides inside every 402 from
+    /start, so the two surfaces can never disagree: both call
+    ``generation_payment.quote()``, whose flat price is the seam #1217's
+    measured budget later replaces."""
+    return generation_payment.quote()
+
+
 @generate_router.post("/start", response_model=GenerateStartResponse, status_code=202)
 @limiter.limit("5/minute")
 async def start_generation(
     req: GenerateStartRequest,
     request: Request,  # used for slowapi rate-limit keying AND funnel attribution (#787)
-    response: Response,  # noqa: ARG001
+    response: Response,  # slowapi header injection (#1182) + PAYMENT-RESPONSE receipt
     user: CurrentUser = Depends(require_current_user),
 ) -> GenerateStartResponse:
     """Create account-owned generation job and start pipeline in background."""
@@ -104,6 +122,36 @@ async def start_generation(
     # test_generation_quota.py.
     if not os.getenv("TESTING"):
         await enforce_generation_quota(request, user.id)
+
+    # Payment gate (flag: GENERATION_PAYMENT_REQUIRED — Dan flips deliberately,
+    # see the #834 flip-list). Order is deliberate: AFTER the quota (a
+    # quota-blocked caller is refused 429 before ever being asked to pay) and
+    # BEFORE entitlement/enqueue (no work is burned for an unpaid request).
+    # The 402 carries the full x402 requirements — that response IS the
+    # quote-approval flow for humans and agents alike. Paper trading stays free.
+    if generation_payment.payment_required():
+        if not linked_wallet:
+            # The wallet-connection precondition. 409 (not 402): the blocker is
+            # account state, not a missing payment. NOTE the faucet is the one
+            # human-only step (#1294) — an agent hitting this must have its
+            # wallet funded by a human before payment can succeed.
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "reason": "wallet_link_required",
+                    "message": (
+                        "Generation requires a linked, funded wallet. Link a wallet to your account "
+                        "(POST /api/wallets/challenge → /api/wallets/verify), fund it with testnet USDC "
+                        "(the faucet currently requires a human), then retry. "
+                        "See GET /api/generate/quote for the price."
+                    ),
+                },
+            )
+        payment = await generation_payment.enforce_generation_payment(request, linked_wallet)
+        if payment is not None:
+            # Surface the settlement receipt (PAYMENT-RESPONSE) to the payer.
+            for name, value in (payment.response_headers or {}).items():
+                response.headers[name] = value
 
     # Paid-tier gating (T1.8): a premium (Anthropic) model requires a
     # wallet-connected entitlement. Enforced BEFORE the job is enqueued so a

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -44,7 +44,7 @@ from archimedes.api.chat_routes import chat_router
 from archimedes.api.corpus_routes import corpus_router
 from archimedes.api.explore_routes import explore_router
 from archimedes.api.features_routes import features_router
-from archimedes.api.generate_routes import generate_router
+from archimedes.api.generate_routes import generate_public_router, generate_router
 from archimedes.api.leaderboard_routes import leaderboard_router
 from archimedes.api.limiter import limiter
 from archimedes.api.paper_routes import paper_router
@@ -502,6 +502,7 @@ app.include_router(corpus_router)
 app.include_router(paper_router)
 app.include_router(explore_router)
 app.include_router(generate_router, dependencies=[Depends(require_current_user)])
+app.include_router(generate_public_router)  # /quote only — public by design
 if marketplace_router is not None:
     app.include_router(marketplace_router)
 app.include_router(risk_router)

--- a/backend/archimedes/services/generation_payment.py
+++ b/backend/archimedes/services/generation_payment.py
@@ -1,0 +1,203 @@
+"""x402 paywall for strategy generation (Dan's directive, 2026-08-19).
+
+Generation REQUIRES wallet connection + payment — for humans and agents alike,
+no free path — while paper trading stays free. The 402 response *is* the
+quote-approval flow: it carries the full payment requirements in the
+``PAYMENT-REQUIRED`` header (and a human-readable quote in the JSON body), the
+client signs and retries with a ``Payment-Signature`` header, and the server
+verifies + settles via Circle's facilitator (the same
+``marketplace.payments``/circlekit machinery the tick-charging rail uses —
+this module reuses ``get_gateway_middleware``; circlekit stays imported in one
+place).
+
+FLAG-GATED: ``GENERATION_PAYMENT_REQUIRED`` (only the literal ``"true"``
+enables — Dan flips it deliberately; see the flip-list, issue #834). While the
+flag is off every function here is inert and /api/generate behaves exactly as
+before. The account+IP daily quota stays stacked UNDERNEATH the paywall as
+anti-abuse — and runs BEFORE it, so a quota-blocked caller is refused with 429
+before ever being asked to pay.
+
+``PAYMENTS_DRY_RUN`` semantics (mirrors ``main.py``): in dry-run the paywall
+still quotes (402 without a payment header — so the approval UX is exercised
+end to end) but accepts a presented payment WITHOUT verify/settle, loudly.
+No real value can move while the custody migration (#975) is pending.
+
+Pricing is flat (``GENERATION_PRICE_USD``, default $0.15 testnet USDC) behind
+``quote()`` — the single seam #1217's measured per-generation budget replaces
+later without touching the paywall flow.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from decimal import Decimal, InvalidOperation
+
+from fastapi import HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PRICE_USD = "0.15"
+
+# The logical resource identifier bound into the 402 requirements. One flat
+# resource for now — per-job binding is unnecessary while the price is flat
+# (replay of a settled payment is prevented by the facilitator consuming the
+# signed authorization at settle time, not by path uniqueness).
+_RESOURCE_PATH = "/api/generate/start"
+
+
+def payment_required() -> bool:
+    """Only the literal "true" enables — mirrors EMAIL_VERIFICATION_ENFORCED."""
+    return os.getenv("GENERATION_PAYMENT_REQUIRED") == "true"
+
+
+def _payments_dry_run() -> bool:
+    """EXACT mirror of main.py's parse — the two must never disagree."""
+    return os.getenv("PAYMENTS_DRY_RUN", "true").lower() in ("1", "true", "yes")
+
+
+def _recipient() -> str:
+    return os.getenv("GENERATION_PAYMENT_RECIPIENT", "").strip()
+
+
+def _price() -> str:
+    """The circlekit "$X.XXXXXX" price string. Fails SAFE to the default on a
+    malformed env value (a typo must not turn the paywall free or absurd)."""
+    raw = os.getenv("GENERATION_PRICE_USD", DEFAULT_PRICE_USD).strip() or DEFAULT_PRICE_USD
+    try:
+        value = Decimal(raw)
+        if value < 0:
+            raise InvalidOperation
+    except InvalidOperation:
+        logger.warning("invalid GENERATION_PRICE_USD=%r — using default %s", raw, DEFAULT_PRICE_USD)
+        value = Decimal(DEFAULT_PRICE_USD)
+    return f"${value:.6f}"
+
+
+def quote() -> dict:
+    """The generation price quote — public, also embedded in every 402 body.
+
+    ``pricing_model: "flat_v1"`` names the current scheme; #1217's measured
+    per-generation budget replaces the internals of this function (and bumps
+    the model name) without changing the paywall flow around it.
+    """
+    from archimedes.marketplace.config import DEFAULT_GATEWAY_CHAIN
+
+    return {
+        "payment_required": payment_required(),
+        "pricing_model": "flat_v1",
+        "price": _price(),
+        "asset": "USDC",
+        "chain": os.getenv("GATEWAY_CHAIN", DEFAULT_GATEWAY_CHAIN).strip(),
+        "recipient": _recipient() or None,
+        "dry_run": _payments_dry_run(),
+        "how": (
+            "POST /api/generate/start without a Payment-Signature header returns 402 "
+            "with these requirements in the PAYMENT-REQUIRED header; sign them "
+            "(x402 / Circle Gateway) and retry with Payment-Signature."
+        ),
+    }
+
+
+def _quote_402(detail_reason: str, message: str) -> HTTPException:
+    """A 402 carrying BOTH the machine quote (PAYMENT-REQUIRED header, built by
+    the same circlekit middleware the settle path uses) and a human/agent
+    readable body. Raising-site helper so every 402 is shaped identically."""
+    from archimedes.marketplace.payments import get_gateway_middleware
+
+    headers = {}
+    try:
+        required = get_gateway_middleware(_recipient()).require(_price(), _RESOURCE_PATH)
+        headers = required.get("headers") or {}
+    except Exception:
+        # Requirements are computed locally; a failure here is a config bug.
+        # Still 402 (honest: payment IS required) with the JSON quote only.
+        logger.exception("could not build PAYMENT-REQUIRED header")
+    return HTTPException(
+        status_code=402,
+        detail={"reason": detail_reason, "message": message, "quote": quote()},
+        headers=headers,
+    )
+
+
+async def enforce_generation_payment(request: Request, linked_wallet: str):
+    """The paywall. Returns a settled ``PaymentInfo`` (or ``None`` when the
+    flag is off / dry-run accepted). Raises HTTPException 402/503 otherwise.
+
+    Fail-closed configuration: flag ON with no recipient configured is an
+    OUTAGE (503), never a free pass — the flip-list documents that
+    ``GENERATION_PAYMENT_RECIPIENT`` must be set before the flag.
+    """
+    if not payment_required():
+        return None
+
+    if not _recipient():
+        logger.error("GENERATION_PAYMENT_REQUIRED=true but GENERATION_PAYMENT_RECIPIENT is unset — refusing (503)")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "reason": "payment_config_missing",
+                "message": "Generation payments are enabled but not fully configured. Please try again later.",
+            },
+        )
+
+    header = request.headers.get("Payment-Signature")
+    if not header:
+        raise _quote_402(
+            "payment_required",
+            "Generation requires payment. Sign the PAYMENT-REQUIRED requirements with your linked wallet "
+            "and retry with a Payment-Signature header.",
+        )
+
+    if _payments_dry_run():
+        # No real value may move while PAYMENTS_DRY_RUN holds (#975 custody
+        # migration pending). Accept the presented payment WITHOUT verify or
+        # settle — loudly, so a log reader can never mistake this for revenue.
+        logger.warning(
+            "PAYMENTS_DRY_RUN — generation payment header accepted UNVERIFIED and UNSETTLED (no value moved)"
+        )
+        return None
+
+    from circlekit.x402 import decode_payment_header
+
+    from archimedes.marketplace.payments import get_gateway_middleware
+
+    # Bind the payment to the caller's PROVEN wallet before spending a
+    # facilitator round-trip: the payer inside the signed authorization must be
+    # the wallet this account linked (the wallet-connection precondition and
+    # the payment are one identity, not two).
+    try:
+        payload = decode_payment_header(header)
+        payer = str(((payload.get("payload") or {}).get("authorization") or {}).get("from", ""))
+    except Exception:
+        raise _quote_402("payment_malformed", "The Payment-Signature header could not be decoded.") from None
+    if not payer or payer.lower() != linked_wallet.lower():
+        raise _quote_402(
+            "payer_mismatch",
+            "The payment must be signed by your linked wallet "
+            f"({linked_wallet[:10]}…). Link that wallet or sign with it and retry.",
+        )
+
+    middleware = get_gateway_middleware(_recipient())
+    price = _price()
+    try:
+        verify_result = await middleware.verify(header, price)
+    except ValueError as exc:
+        raise _quote_402("payment_invalid", f"Payment could not be verified: {exc}") from exc
+    if not verify_result.is_valid:
+        reason = getattr(verify_result, "invalid_reason", None) or "verification failed"
+        raise _quote_402("payment_invalid", f"Payment verification failed: {reason}")
+
+    try:
+        payment = await middleware.settle(header, price)
+    except ValueError as exc:
+        # Verified but not settled — the caller keeps their funds; honest 402.
+        raise _quote_402("payment_settle_failed", f"Payment could not be settled: {exc}") from exc
+
+    logger.info(
+        "generation payment settled: payer=%s amount=%s tx=%s",
+        payment.payer,
+        payment.amount,
+        payment.transaction,
+    )
+    return payment

--- a/backend/tests/services/test_generation_payment.py
+++ b/backend/tests/services/test_generation_payment.py
@@ -1,0 +1,209 @@
+"""The generation paywall's laws (Dan's directive 2026-08-19).
+
+Hermetic — the facilitator boundary (``middleware.verify``/``settle``) is
+mocked; ``require()`` and header decoding run REAL circlekit code (both are
+local computation). Payment-Signature headers are crafted as base64 JSON,
+which is exactly circlekit's wire encoding.
+
+Pinned laws:
+  1. Flag off → inert (returns None, no exception) — today's behavior.
+  2. Flag on + no recipient → 503 outage, NEVER a free pass.
+  3. No payment header → 402 whose PAYMENT-REQUIRED header and JSON quote both
+     carry the price — the quote endpoint and the 402 can never disagree.
+  4. PAYMENTS_DRY_RUN → header accepted WITHOUT verify/settle, loudly.
+  5. The payer inside the signed authorization must BE the linked wallet.
+  6. verify-invalid and settle-failure are honest 402s, not 500s.
+  7. Price parsing fails safe to the default.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.services import generation_payment as gp
+
+RECIPIENT = "0x00000000000000000000000000000000000000a1"
+WALLET = "0xAbCd000000000000000000000000000000000001"
+
+
+def _payment_header(payer: str = WALLET) -> str:
+    payload = {
+        "accepted": {"network": "eip155:5042002"},
+        "payload": {"authorization": {"from": payer, "value": "150000"}},
+    }
+    return base64.b64encode(json.dumps(payload).encode()).decode()
+
+
+def _request_with(header: str | None):
+    request = MagicMock()
+    request.headers = {"Payment-Signature": header} if header else {}
+    return request
+
+
+def _arm(monkeypatch, *, dry_run: bool = False, recipient: str = RECIPIENT):
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", recipient)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "true" if dry_run else "false")
+    monkeypatch.delenv("GENERATION_PRICE_USD", raising=False)
+
+
+class TestFlagAndConfig:
+    @pytest.mark.asyncio
+    async def test_flag_off_is_inert(self, monkeypatch):
+        monkeypatch.delenv("GENERATION_PAYMENT_REQUIRED", raising=False)
+        assert await gp.enforce_generation_payment(_request_with(None), WALLET) is None
+        # Strict parse: near-misses stay off.
+        for value in ("1", "TRUE", "yes"):
+            monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", value)
+            assert gp.payment_required() is False
+
+    @pytest.mark.asyncio
+    async def test_flag_on_without_recipient_is_an_outage_not_a_free_pass(self, monkeypatch):
+        _arm(monkeypatch, recipient="")
+        with pytest.raises(Exception) as excinfo:
+            await gp.enforce_generation_payment(_request_with(_payment_header()), WALLET)
+        assert excinfo.value.status_code == 503
+        assert excinfo.value.detail["reason"] == "payment_config_missing"
+
+
+class TestQuoteAnd402:
+    @pytest.mark.asyncio
+    async def test_missing_header_402_carries_requirements_and_matching_quote(self, monkeypatch):
+        _arm(monkeypatch)
+        with pytest.raises(Exception) as excinfo:
+            await gp.enforce_generation_payment(_request_with(None), WALLET)
+        exc = excinfo.value
+        assert exc.status_code == 402
+        assert exc.detail["reason"] == "payment_required"
+        # The machine path: real circlekit requirements in the header.
+        assert "PAYMENT-REQUIRED" in exc.headers
+        decoded = json.loads(base64.b64decode(exc.headers["PAYMENT-REQUIRED"]))
+        assert decoded  # non-empty requirements document
+        # The human/agent path: the same quote the public endpoint serves.
+        assert exc.detail["quote"]["price"] == "$0.150000"
+        assert exc.detail["quote"] == gp.quote()
+
+    def test_price_env_overrides_and_fails_safe(self, monkeypatch):
+        monkeypatch.setenv("GENERATION_PRICE_USD", "0.42")
+        assert gp.quote()["price"] == "$0.420000"
+        monkeypatch.setenv("GENERATION_PRICE_USD", "not-a-number")
+        assert gp.quote()["price"] == "$0.150000"  # default, never free/absurd
+        monkeypatch.setenv("GENERATION_PRICE_USD", "-3")
+        assert gp.quote()["price"] == "$0.150000"
+
+
+class TestDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_accepts_header_without_verify_or_settle(self, monkeypatch, caplog):
+        _arm(monkeypatch, dry_run=True)
+        middleware = MagicMock()
+        middleware.require = MagicMock(return_value={"headers": {"PAYMENT-REQUIRED": "req"}, "body": {}})
+        middleware.verify = AsyncMock(side_effect=AssertionError("verify must not run in dry-run"))
+        middleware.settle = AsyncMock(side_effect=AssertionError("settle must not run in dry-run"))
+        with (
+            patch("archimedes.marketplace.payments.get_gateway_middleware", return_value=middleware),
+            caplog.at_level("WARNING"),
+        ):
+            result = await gp.enforce_generation_payment(_request_with(_payment_header()), WALLET)
+        assert result is None
+        assert "UNVERIFIED" in caplog.text  # loud, never mistakable for revenue
+        middleware.verify.assert_not_called()
+        middleware.settle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_still_quotes_when_no_header(self, monkeypatch):
+        """The approval UX is exercised end to end even in dry-run."""
+        _arm(monkeypatch, dry_run=True)
+        with pytest.raises(Exception) as excinfo:
+            await gp.enforce_generation_payment(_request_with(None), WALLET)
+        assert excinfo.value.status_code == 402
+
+
+class TestLivePayment:
+    def _middleware(self, *, valid: bool = True, settle_error: str | None = None):
+        middleware = MagicMock()
+        middleware.require = MagicMock(return_value={"headers": {"PAYMENT-REQUIRED": "req"}, "body": {}})
+        verify_result = MagicMock()
+        verify_result.is_valid = valid
+        verify_result.invalid_reason = None if valid else "insufficient balance"
+        middleware.verify = AsyncMock(return_value=verify_result)
+        if settle_error:
+            middleware.settle = AsyncMock(side_effect=ValueError(settle_error))
+        else:
+            payment = MagicMock()
+            payment.payer = WALLET
+            payment.amount = "150000"
+            payment.transaction = "0xsettled"
+            payment.response_headers = {"PAYMENT-RESPONSE": "receipt"}
+            middleware.settle = AsyncMock(return_value=payment)
+        return middleware
+
+    @pytest.mark.asyncio
+    async def test_payer_must_be_the_linked_wallet(self, monkeypatch):
+        _arm(monkeypatch)
+        middleware = self._middleware()
+        with (
+            patch("archimedes.marketplace.payments.get_gateway_middleware", return_value=middleware),
+            pytest.raises(Exception) as excinfo,
+        ):
+            await gp.enforce_generation_payment(
+                _request_with(_payment_header(payer="0x9999999999999999999999999999999999999999")),
+                WALLET,
+            )
+        assert excinfo.value.status_code == 402
+        assert excinfo.value.detail["reason"] == "payer_mismatch"
+        middleware.verify.assert_not_called()  # rejected before any facilitator spend
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_payer_match_settles_and_returns_receipt(self, monkeypatch):
+        _arm(monkeypatch)
+        middleware = self._middleware()
+        with patch("archimedes.marketplace.payments.get_gateway_middleware", return_value=middleware):
+            result = await gp.enforce_generation_payment(
+                _request_with(_payment_header(payer=WALLET.upper().replace("0X", "0x"))),
+                WALLET.lower(),
+            )
+        assert result is not None
+        assert result.transaction == "0xsettled"
+        middleware.verify.assert_awaited_once()
+        middleware.settle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_verify_invalid_is_an_honest_402(self, monkeypatch):
+        _arm(monkeypatch)
+        with (
+            patch(
+                "archimedes.marketplace.payments.get_gateway_middleware",
+                return_value=self._middleware(valid=False),
+            ),
+            pytest.raises(Exception) as excinfo,
+        ):
+            await gp.enforce_generation_payment(_request_with(_payment_header()), WALLET)
+        assert excinfo.value.status_code == 402
+        assert excinfo.value.detail["reason"] == "payment_invalid"
+        assert "insufficient balance" in excinfo.value.detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_settle_failure_is_an_honest_402_not_a_500(self, monkeypatch):
+        _arm(monkeypatch)
+        with (
+            patch(
+                "archimedes.marketplace.payments.get_gateway_middleware",
+                return_value=self._middleware(settle_error="facilitator timeout"),
+            ),
+            pytest.raises(Exception) as excinfo,
+        ):
+            await gp.enforce_generation_payment(_request_with(_payment_header()), WALLET)
+        assert excinfo.value.status_code == 402
+        assert excinfo.value.detail["reason"] == "payment_settle_failed"
+
+    @pytest.mark.asyncio
+    async def test_malformed_header_is_a_402_not_a_500(self, monkeypatch):
+        _arm(monkeypatch)
+        with pytest.raises(Exception) as excinfo:
+            await gp.enforce_generation_payment(_request_with("not-base64!!"), WALLET)
+        assert excinfo.value.status_code == 402
+        assert excinfo.value.detail["reason"] == "payment_malformed"

--- a/backend/tests/test_generate_payment_gate.py
+++ b/backend/tests/test_generate_payment_gate.py
@@ -1,0 +1,161 @@
+"""Route-level contract of the generation payment gate (Dan's directive).
+
+Hermetic — same harness as test_generate_model_gating.py (mocked job store,
+pipeline task patched out, signed auth cookies). The paywall module's own laws
+live in services/test_generation_payment.py; THIS file pins the route wiring:
+
+  * flag off (the shipped default) → /start behaves exactly as before;
+  * flag on + no linked wallet → 409 wallet_link_required (with the faucet
+    guidance — #1294's human-only step now bites agents here);
+  * flag on + wallet + no payment → 402 quoting via PAYMENT-REQUIRED;
+  * dry-run + payment header → 202, the request proceeds to enqueue;
+  * the QUOTA runs BEFORE the paywall — a quota-blocked caller is 429'd
+    without ever being asked to pay;
+  * GET /api/generate/quote is public and matches the 402's quote.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from tests.auth_helpers import auth_cookies
+
+RECIPIENT = "0x00000000000000000000000000000000000000a1"
+
+_BODY = {"brief": {"intent": "low-vol treasury alternative", "risk_appetite": "moderate"}}
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _mock_store() -> MagicMock:
+    store = MagicMock()
+    store.enqueue = AsyncMock(return_value="job-pay")
+    return store
+
+
+def _close_background_coroutine(coro):
+    coro.close()
+    return MagicMock()
+
+
+def _harness(store):
+    return (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        patch("archimedes.api.generate_routes.asyncio.create_task", side_effect=_close_background_coroutine),
+    )
+
+
+def _payment_header(payer: str) -> str:
+    payload = {"payload": {"authorization": {"from": payer, "value": "150000"}}}
+    return base64.b64encode(json.dumps(payload).encode()).decode()
+
+
+def test_flag_off_start_behaves_exactly_as_before(monkeypatch) -> None:
+    monkeypatch.delenv("GENERATION_PAYMENT_REQUIRED", raising=False)
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+    assert resp.status_code == 202
+    store.enqueue.assert_awaited_once()
+
+
+def test_flag_on_without_linked_wallet_is_409_with_faucet_guidance(monkeypatch) -> None:
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    with (
+        p1,
+        p2,
+        patch("archimedes.api.generate_routes.get_linked_wallet_address", return_value=None),
+    ):
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["reason"] == "wallet_link_required"
+    assert "faucet" in detail["message"].lower()
+    store.enqueue.assert_not_called()
+
+
+def test_flag_on_without_payment_is_402_with_requirements(monkeypatch) -> None:
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+    assert resp.status_code == 402
+    assert "PAYMENT-REQUIRED" in resp.headers
+    detail = resp.json()["detail"]
+    assert detail["reason"] == "payment_required"
+    # The 402's quote and the public quote endpoint can never disagree.
+    quote = _client().get("/api/generate/quote").json()
+    assert detail["quote"]["price"] == quote["price"]
+    store.enqueue.assert_not_called()
+
+
+def test_dry_run_payment_header_proceeds_to_enqueue(monkeypatch) -> None:
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "true")
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    cookies = auth_cookies()
+    with p1, p2:
+        # The conftest legacy adapter links the cookie's wallet; any payer works
+        # in dry-run because verify/settle are skipped (module tests pin that).
+        resp = _client().post(
+            "/api/generate/start",
+            json=_BODY,
+            cookies=cookies,
+            headers={"Payment-Signature": _payment_header("0x" + "ab" * 20)},
+        )
+    assert resp.status_code == 202
+    store.enqueue.assert_awaited_once()
+
+
+def test_quota_runs_before_the_paywall(monkeypatch) -> None:
+    """A quota-blocked caller must be refused 429 BEFORE being asked to pay —
+    never pay-then-blocked. TESTING is unset so the quota branch runs; the
+    quota itself is stubbed to raise, and the paywall is spied."""
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+
+    async def _blocked(request, user_id):
+        raise HTTPException(status_code=429, detail="daily cap reached")
+
+    paywall_spy = AsyncMock(side_effect=AssertionError("paywall must not run after a quota block"))
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    with (
+        p1,
+        p2,
+        patch("archimedes.api.generate_routes.enforce_generation_quota", _blocked),
+        patch("archimedes.api.generate_routes.generation_payment.enforce_generation_payment", paywall_spy),
+    ):
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+    assert resp.status_code == 429
+    paywall_spy.assert_not_called()
+    store.enqueue.assert_not_called()
+
+
+def test_quote_endpoint_is_public_and_reports_the_flag(monkeypatch) -> None:
+    monkeypatch.delenv("GENERATION_PAYMENT_REQUIRED", raising=False)
+    resp = _client().get("/api/generate/quote")  # no cookies — public by design
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["payment_required"] is False
+    assert body["price"] == "$0.150000"
+    assert body["pricing_model"] == "flat_v1"

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -536,6 +536,13 @@ resource "aws_ecs_task_definition" "backend" {
         # Not secrets. Both layers must pass; <= 0 disables a layer.
         { name = "GENERATION_DAILY_CAP_PER_USER", value = "10" },
         { name = "GENERATION_DAILY_CAP_PER_IP", value = "20" },
+        # Generation payment gate (flip-list #834): flag stays "false" until
+        # Dan flips it deliberately — and GENERATION_PAYMENT_RECIPIENT (the
+        # platform wallet that receives x402 settlements) MUST be set first;
+        # flag-on with no recipient is a deliberate 503, never a free pass.
+        { name = "GENERATION_PAYMENT_REQUIRED", value = "false" },
+        { name = "GENERATION_PRICE_USD", value = "0.15" },
+        { name = "GENERATION_PAYMENT_RECIPIENT", value = "" },
         # KNOWN GAP #2 (see file header): these three paths have no Fargate
         # equivalent of the docker-compose host bind mount yet.
         { name = "ARCHIMEDES_STRATEGIES_DIR", value = "/app/analytics-engine/strategies" },


### PR DESCRIPTION
## What

Dan's directive (2026-08-19, post-dogfood): **generation requires wallet connection + payment** — for humans and agents alike, no free path — with an upfront cost quote the caller approves before paying. **Paper trading stays free.** Flag-gated (`GENERATION_PAYMENT_REQUIRED`, default `false` everywhere) so the flip is a deliberate act, not a side effect of merging.

### The flow

1. **`GET /api/generate/quote`** — public (new `generate_public_router`; the auth-gated mount covers everything else). A human sees the price before signing in; an agent plans before paying (#1293). Flat `GENERATION_PRICE_USD` (default **$0.15** testnet USDC) behind `quote()` — the single seam #1217's measured per-generation budget replaces later, tagged `pricing_model: "flat_v1"`.
2. **`POST /api/generate/start` without payment → 402** carrying real circlekit x402 requirements in `PAYMENT-REQUIRED` (built by the same middleware that settles) plus the JSON quote in the body. **The 402 IS the approval flow**: the client signs the requirements with their wallet and retries with `Payment-Signature`.
3. **Verify + settle** via the Circle facilitator through `marketplace.payments` (circlekit stays imported in exactly one module). The settlement receipt (`PAYMENT-RESPONSE`) is returned to the payer. Recipient: `GENERATION_PAYMENT_RECIPIENT` (the platform wallet).
4. **Payer binding**: the payer inside the signed authorization must **be the caller's linked wallet** — checked before any facilitator round-trip. The wallet-connection precondition and the payment are one identity.

### Gate ordering in `/start` (each earlier gate protects the caller's money)

`quota` (429 before ever being asked to pay) → `wallet precondition` (409 `wallet_link_required` with link + faucet guidance — #1294's human-only faucet now bites agents exactly here) → `paywall` (402/settle) → `entitlement` → enqueue. The account+IP daily quota stays stacked underneath as anti-abuse.

### Safety posture

- **Fail-closed config**: flag on without a recipient is a **503 outage, never a free pass**.
- **`PAYMENTS_DRY_RUN`** (parse mirrors `main.py` exactly): still quotes 402 without a header — the approval UX is exercisable end to end — but accepts a presented payment **without** verify/settle, loudly logged as `UNVERIFIED`, so no value can move while the #975 custody migration is pending.
- **Price parse fails safe** to the default — a typo'd env can't make generation free or absurd.

## Verification

17 tests (module laws + route wiring), each side mutation-checked:

| Mutation / adversarial probe | Result |
|---|---|
| Free-path mutant: missing header falls through in live mode | 3 tests FAIL (402 contract + dry-run quote) |
| Dry-run accidentally verifying/settling | blocked by `AssertionError` stubs on both calls |
| Paywall runs after a quota block (pay-then-blocked) | order pinned: quota 429 + paywall spy asserts never called |
| Wrong payer signs the payment | 402 `payer_mismatch` before any facilitator spend |
| settle/verify failures | honest 402s (`payment_invalid` / `payment_settle_failed`), never 500s |

Env contracts updated in the same PR (`.env.example` + `ecs.tf`, flag `false`, recipient empty with the must-set-first comment). Flip-list #834 entry added on merge. Full suite result posted below.

## Not in this PR

- The quote-approval **UI** (strategy session, via workflow).
- #1217's measured pricing (the `quote()` seam is its landing pad).
- The platform recipient wallet's provisioning — `GENERATION_PAYMENT_RECIPIENT` is empty until Dan designates it; the flag physically cannot be flipped before that (503 by design).

## Full suite

`python -m pytest -m "not integration" -q`: **3153 passed, 3 skipped (pre-existing), 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
