### PR TITLE
Leaderboard goes single-user for MVP

### DIFF
--- a/backend/archimedes/api/leaderboard_routes.py
+++ b/backend/archimedes/api/leaderboard_routes.py
@@ -1,16 +1,28 @@
-"""Leaderboard endpoint — /api/leaderboard (public, no wallet).
+"""Leaderboard endpoint — /api/leaderboard (public, no wallet required — never
+auth-gated, even though most of it is now per-user).
 
-The testnet engagement engine (North Star §5): a public, gamified ranking of the
-strategy library by the transparent conviction score (real rigor gate + backtest),
-paired with an honest, pending StockBench / live-P&L forward axis.
+MVP single-user pivot (Dan's directive): the board used to rank a global
+cohort (curated ∪ everyone's published-generated strategies), but no publish
+mechanism exists yet, so a global ranking was incoherent — nobody had opted
+into competing. The board is now SINGLE-USER by default: a signed-in caller
+ranks THEIR OWN strategies against each other (``scope=own``); an anonymous
+visitor — or a signed-in caller who asks for it — sees the curated seed
+library instead, CLEARLY as a reference set, never as "your competition"
+(``scope=curated``). The global-cohort machinery (curated ∪ published-
+generated) is left intact server-side as the 'curated' scope's implementation
+rather than deleted — see ``_curated_cohort_responses`` — so nothing here
+forecloses a future real "public leaderboard" once publish ships (tracked:
+#1185 board-level selection-bias is largely moot for a single-user MVP board,
+but is NOT closed — it matters again the moment a global cohort returns).
 
-Ranks the curated/validated library (``strategy_provider``) ALONGSIDE PUBLISHED
-generated strategies (curated ∪ generated — the "unify source" decouple in
-docs/CURATED-STRATEGY-DECOUPLE-AND-CONSOLIDATE-2026-07-08.md Part A). Publish is
-the ONLY generated-side criterion: rigor promotion ("live" status) deliberately
-does NOT qualify, or a private strategy would leak onto the public board the
-moment it passed rigor (#850 privacy principle — publish is the consent signal).
-A generated strategy earns a spot the same way a curated one does: real,
+Ranks the curated/validated library (``strategy_provider``) alongside
+published generated strategies for ``scope=curated`` (unchanged from the
+pre-single-user board), or the caller's own generated strategies — published
+or not — for ``scope=own``. Publish is the ONLY generated-side criterion for
+the *curated* scope: rigor promotion ("live" status) deliberately does NOT
+qualify, or a private strategy would leak onto a shared board the moment it
+passed rigor (#850 privacy principle — publish is the consent signal). A
+generated strategy earns a spot the same way a curated one does: real,
 rigor-gated backtest numbers score it via ``compute_conviction`` — a strategy
 missing a metric scores 0 on that axis and sinks honestly, never fabricated.
 """
@@ -19,10 +31,12 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 
 from archimedes.api._route_helpers import strategy_provider
+from archimedes.api.account_auth import get_current_user
 from archimedes.api.leaderboard_schemas import LeaderboardResponse
+from archimedes.api.wallet_routes import get_linked_wallet_address
 from archimedes.services.leaderboard import build_leaderboard
 
 logger = logging.getLogger(__name__)
@@ -35,19 +49,13 @@ _SORT_FIELDS = (
 )
 
 
-@leaderboard_router.get("", response_model=LeaderboardResponse)
-async def get_leaderboard(
-    sort_by: str = Query("conviction_score", pattern=f"^({_SORT_FIELDS})$"),
-    order: str = Query("desc", pattern="^(asc|desc)$"),
-    regime_tag: str | None = Query(None, pattern="^(bull|bear|regime_neutral)$"),
-    min_rigor: bool = Query(False),
-    limit: int = Query(50, ge=1, le=200),
-) -> LeaderboardResponse:
-    """Public, gamified strategy leaderboard.
+def _curated_cohort_responses() -> list:
+    """Curated library ∪ published-generated strategies — the pre-single-user
+    board's exact cohort, unchanged, now served under ``scope=curated``.
 
-    Fail-safe: if the strategy provider is unavailable, returns an empty board
-    (with the scoring-engine metadata intact) rather than erroring — the public
-    page must never hard-fail.
+    Fail-safe: if the strategy provider is unavailable, returns an empty
+    board (with the scoring-engine metadata intact) rather than erroring —
+    this endpoint must never hard-fail.
     """
     # Imported lazily to avoid import-time coupling with the heavy strategies
     # module (and any future cycle).
@@ -76,9 +84,8 @@ async def get_leaderboard(
     # Unify: add GENERATED strategies alongside curated (low-pri decouple).
     # Public/no-wallet criterion — is_published ONLY (never status: rigor
     # promotion sets "live" on unpublished strategies too, and keying off it
-    # would leak a private candidate onto the public board; publish is the
-    # consent signal — #850). Best-effort: a failure here degrades to
-    # curated-only, exactly today's behavior.
+    # would leak a private candidate onto a shared board the moment it passed
+    # rigor — #850). Best-effort: a failure here degrades to curated-only.
     try:
         from archimedes.api.strategies_routes import _public_generated_strategy_responses
         from archimedes.db import get_session
@@ -88,6 +95,71 @@ async def get_leaderboard(
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("leaderboard: generated strategies unavailable: %s", exc)
 
+    return responses
+
+
+def _own_cohort_responses(caller_wallet: str | None, caller_user_id: str | None) -> list:
+    """GENERATED strategies owned by the signed-in caller — ``scope=own``.
+
+    Never includes curated rows (nobody owns the curated library) and never
+    includes another user's strategies, published or not — see
+    ``_owned_generated_strategy_responses``'s docstring for the ownership-only
+    predicate. Fail-safe, same contract as ``_curated_cohort_responses``.
+    """
+    try:
+        from archimedes.api.strategies_routes import _owned_generated_strategy_responses
+        from archimedes.db import get_session
+
+        with get_session() as session:
+            return _owned_generated_strategy_responses(session, caller_wallet, caller_user_id)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("leaderboard: owned strategies unavailable: %s", exc)
+        return []
+
+
+@leaderboard_router.get("", response_model=LeaderboardResponse)
+async def get_leaderboard(
+    request: Request,
+    scope: str | None = Query(
+        None,
+        pattern="^(own|curated)$",
+        description=(
+            "'own': the signed-in caller's own strategies, ranked against each "
+            "other (single-user MVP default when signed in). 'curated': the "
+            "curated seed library, shown as reference — never a competing "
+            "cohort (default when anonymous). An anonymous request for 'own' "
+            "is transparently served 'curated' instead — this endpoint never "
+            "401s; check the response's own `scope` field for what was "
+            "actually served."
+        ),
+    ),
+    sort_by: str = Query("conviction_score", pattern=f"^({_SORT_FIELDS})$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
+    regime_tag: str | None = Query(None, pattern="^(bull|bear|regime_neutral)$"),
+    min_rigor: bool = Query(False),
+    limit: int = Query(50, ge=1, le=200),
+) -> LeaderboardResponse:
+    """Single-user (signed in) or curated-reference (anonymous) leaderboard.
+
+    Fail-safe: if the underlying data source is unavailable, returns an empty
+    board (with the scoring-engine metadata intact) rather than erroring — the
+    page must never hard-fail, for either scope.
+    """
+    user = get_current_user(request)
+    caller_wallet = get_linked_wallet_address(request)
+
+    effective_scope = scope or ("own" if user is not None else "curated")
+    if effective_scope == "own" and user is None:
+        # Public, no-wallet endpoint (module docstring) — never 401. An
+        # anonymous caller explicitly asking for "own" gets the only scope
+        # that means anything without a session, not an error.
+        effective_scope = "curated"
+
+    if effective_scope == "own":
+        responses = _own_cohort_responses(caller_wallet, user.id if user is not None else None)
+    else:
+        responses = _curated_cohort_responses()
+
     return build_leaderboard(
         responses,
         sort_by=sort_by,
@@ -95,4 +167,5 @@ async def get_leaderboard(
         regime_tag=regime_tag,
         min_rigor=min_rigor,
         limit=limit,
+        scope=effective_scope,
     )

--- a/backend/archimedes/api/leaderboard_schemas.py
+++ b/backend/archimedes/api/leaderboard_schemas.py
@@ -136,4 +136,15 @@ class LeaderboardResponse(BaseModel):
     total: int
     sort_by: str
     order: str
+    scope: str = Field(
+        "curated",
+        description=(
+            "The cohort actually served: 'own' (the signed-in caller's own "
+            "strategies, ranked against each other) or 'curated' (the curated "
+            "seed library, shown as reference — never a competing cohort). May "
+            "differ from a requested ?scope= — an anonymous caller requesting "
+            "'own' is served 'curated' instead, and this field reports what was "
+            "actually served, not what was asked for."
+        ),
+    )
     scoring_engine: LeaderboardScoringEngine

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1845,6 +1845,48 @@ def _public_generated_strategy_responses(session) -> list[StrategyResponse]:
     return [_passport_to_strategy_response(r, session) for r in visible]
 
 
+def _owned_generated_strategy_responses(
+    session, caller_wallet: str | None, caller_user_id: str | None
+) -> list[StrategyResponse]:
+    """GENERATED strategies OWNED by *caller* — the single-user leaderboard's
+    "own" scope (leaderboard-goes-single-user MVP: with no publish mechanism
+    live, ranking against a global cohort was incoherent, so a signed-in
+    caller instead ranks THEIR OWN strategies against each other).
+
+    Deliberately narrower than ``_generated_strategy_responses`` (published-
+    by-anyone ∪ owned-by-caller): here the question is "is this MINE", not
+    "am I allowed to see this", so another user's published strategy must
+    NOT appear just because it is public. Reuses ``is_strategy_visible`` (the
+    single #850 predicate — never re-implement ownership matching at a call
+    site) for the two-tier owner_user_id/owner_wallet check, but pins
+    ``is_published`` False in the row_view fed to it so a stranger's
+    published row can never ride that predicate's publish-visibility clause
+    onto this caller's board. Curated (``is_example``) rows have no owner and
+    are never returned here — they are the separate "curated" scope.
+    """
+    from archimedes.services.passport_loader import list_passports
+    from archimedes.services.strategy_visibility import is_strategy_visible
+
+    if not caller_user_id and not caller_wallet:
+        return []
+
+    records = [r for r in list_passports(session) if (r.generation_method or "").lower() != "curated"]
+    if not records:
+        return []
+
+    owned = []
+    for r in records:
+        row_view = {
+            "is_example": False,
+            "is_published": False,  # ownership only — publish state is irrelevant to "own"
+            "owner_user_id": r.owner_user_id,
+            "owner_wallet": r.owner_wallet,
+        }
+        if is_strategy_visible(row_view, caller_wallet, caller_user_id=caller_user_id):
+            owned.append(r)
+    return [_passport_to_strategy_response(r, session) for r in owned]
+
+
 @strategies_router.get("/{strategy_id}/returns", response_model=StrategyReturnsResponse)
 async def get_strategy_returns(strategy_id: str, request: Request):
     """Return persisted real daily returns for a strategy.

--- a/backend/archimedes/services/leaderboard.py
+++ b/backend/archimedes/services/leaderboard.py
@@ -179,8 +179,16 @@ def build_leaderboard(
     regime_tag: str | None = None,
     min_rigor: bool = False,
     limit: int = 50,
+    scope: str = "curated",
 ) -> LeaderboardResponse:
-    """Rank strategies into a leaderboard. Pure — no I/O."""
+    """Rank strategies into a leaderboard. Pure — no I/O.
+
+    ``scope`` is echoed back verbatim (never derived here) — it is the caller's
+    statement of what cohort ``responses`` actually is ('own': the signed-in
+    caller's own strategies; 'curated': the curated seed library), so the UI
+    can label the board honestly even when the caller's requested scope was
+    silently coerced (e.g. an anonymous request for 'own').
+    """
     if sort_by not in _SORTABLE:
         sort_by = "conviction_score"
     order = "asc" if order == "asc" else "desc"
@@ -225,5 +233,6 @@ def build_leaderboard(
         total=total,
         sort_by=sort_by,
         order=order,
+        scope=scope,
         scoring_engine=engine,
     )

--- a/backend/tests/test_leaderboard_single_user_scope.py
+++ b/backend/tests/test_leaderboard_single_user_scope.py
@@ -1,0 +1,262 @@
+"""Hermetic tests for the leaderboard's single-user MVP pivot (Dan's
+directive: no publish mechanism exists yet, so ranking a global cohort was
+incoherent — the board goes single-user by default).
+
+Pins the contract:
+  1. POISON TEST — a signed-in user A never sees user B's strategies under
+     ``scope=own``, published or not. This is the load-bearing guarantee:
+     "own" must be ownership-only, never "anyone who opted in".
+  2. Anonymous callers are served ``scope=curated`` only — the curated seed
+     library, never a stranger's generated strategy, even explicitly asking
+     for ``scope=own``.
+  3. Default scope is contextual: 'own' when signed in, 'curated' when
+     anonymous — without the caller having to pass ?scope= at all.
+  4. The response's own ``scope`` field always reports what was actually
+     served (never blindly the query param), so the UI can label the board
+     honestly even after a silent coercion.
+  5. A signed-in user with zero generated strategies gets an honest EMPTY
+     "own" board (not a fallback to curated, not an error) — the single-user
+     board must never quietly show someone else's strategies as filler.
+
+Uses the same two patterns already established in this test suite:
+  - tmp-sqlite DB isolation + StrategyRecord/StrategyPassportRecord fixture
+    builders (test_unify_curated_generated.py's ``_mk_strategy``/``_mk_passport``).
+  - Better Auth session simulation via monkeypatching
+    ``account_auth._fetch_session`` + the session cookie header
+    (test_paper_routes_auth.py's ``_sign_in``/``_client`` pattern).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import archimedes.db as db
+import httpx
+import pytest
+from archimedes.api import account_auth
+from archimedes.main import app
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Point the DB at a FRESH temp sqlite (rebinds db.engine + db.SessionLocal),
+    same pattern as test_strategy_ownership.py / test_unify_curated_generated.py.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'leaderboard_scope.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _mk_strategy(
+    sid: str,
+    *,
+    owner_user_id: str | None = None,
+    published: bool = False,
+    status: str = "candidate",
+    name: str = "Test Strategy",
+) -> None:
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with db.get_session() as session:
+        session.add(
+            StrategyRecord(
+                id=sid,
+                content_hash=("0x" + sid).ljust(66, "0"),
+                generation_method="fusion",
+                source_papers="[]",
+                strategy_name=name,
+                thesis="test thesis",
+                asset_universe="[]",
+                risk_profile="moderate",
+                status=status,
+                is_example=False,
+                owner_user_id=owner_user_id,
+                is_published=published,
+            )
+        )
+        session.commit()
+
+
+def _mk_passport(
+    sid: str,
+    *,
+    owner_user_id: str | None = None,
+    status: str = "candidate",
+    passes: bool = True,
+    sharpe: float | None = 1.1,
+    dsr: float | None = 0.95,
+    oos: float | None = 1.0,
+    pbo: float | None = 0.1,
+    title: str = "Gen Strat",
+) -> None:
+    from archimedes.models.strategy_passport_record import PassportPaperRef, StrategyPassportRecord
+
+    with db.get_session() as session:
+        record = StrategyPassportRecord(
+            id=sid,
+            content_hash=("0x" + sid).ljust(66, "0"),
+            generation_method="fusion",
+            methodology_summary="test methodology",
+            asset_universe='["SPY", "GLD"]',
+            status=status,
+            owner_user_id=owner_user_id,
+            sharpe_ratio=sharpe,
+            cagr=0.12,
+            max_drawdown=-0.10,
+            win_rate=0.55,
+            calmar_ratio=1.2,
+            correlation_to_spy=0.2,
+            deflated_sharpe_ratio=dsr,
+            dsr_p_value=dsr,
+            pbo_score=pbo,
+            out_of_sample_sharpe=oos,
+            passes_rigor_gate=passes,
+        )
+        record.paper_refs = [PassportPaperRef(passport_id=sid, arxiv_id="2401.00001", title=title)]
+        session.add(record)
+        session.commit()
+
+
+def _own(sid: str, user_id: str, **kw) -> None:
+    """Create a strategy + passport pair owned by *user_id*."""
+    _mk_strategy(sid, owner_user_id=user_id, **{k: v for k, v in kw.items() if k in {"published", "status", "name"}})
+    _mk_passport(sid, owner_user_id=user_id, **{k: v for k, v in kw.items() if k not in {"published", "name"}})
+
+
+def _session_for(user_id: str):
+    async def fetch(_request):
+        return {
+            "user": {"id": user_id, "name": user_id, "email": f"{user_id}@example.com", "emailVerified": True},
+            "session": {"id": f"s-{user_id}", "expiresAt": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+        }
+
+    return fetch
+
+
+def _sign_in(monkeypatch, user_id: str) -> None:
+    monkeypatch.setattr(account_auth, "_fetch_session", _session_for(user_id))
+
+
+def _client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"cookie": "better-auth.session_token=opaque", "host": "test"},
+    )
+
+
+# ── 1. Poison test: user A never sees user B's rows under scope=own ────────
+
+
+@pytest.mark.asyncio
+async def test_own_scope_never_leaks_another_users_strategy(monkeypatch):
+    _own("a-strat-1", "user-a", published=False, status="live", sharpe=1.9, dsr=0.97, oos=1.4, pbo=0.05)
+    _own("b-strat-1", "user-b", published=True, status="live", sharpe=2.5, dsr=0.99, oos=1.8, pbo=0.02)
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        resp = await client.get("/api/leaderboard?scope=own")
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = [e["id"] for e in body["entries"]]
+    assert "a-strat-1" in ids
+    # The poison case: user B's strategy is PUBLISHED (would appear on the old
+    # global-cohort board) and scores strictly higher, so if ownership scoping
+    # were broken it would not just leak — it would leak to the TOP of A's board.
+    assert "b-strat-1" not in ids
+    assert body["scope"] == "own"
+
+
+@pytest.mark.asyncio
+async def test_own_scope_symmetric_for_both_users(monkeypatch):
+    """Same fixtures, from B's side: B sees only B's row, never A's — the
+    leak must not be one-directional (e.g. an accidental owner_user_id-is-None
+    fallback that only fires for one of the two users)."""
+    _own("a-strat-2", "user-a", published=True, status="live")
+    _own("b-strat-2", "user-b", published=False, status="live")
+
+    _sign_in(monkeypatch, "user-b")
+    async with _client() as client:
+        resp = await client.get("/api/leaderboard?scope=own")
+    ids = [e["id"] for e in resp.json()["entries"]]
+    assert ids == ["b-strat-2"]
+
+
+# ── 2. Anonymous is coerced to curated, even if it asks for "own" ──────────
+
+
+@pytest.mark.asyncio
+async def test_anonymous_requesting_own_scope_gets_curated_not_error_not_leak():
+    _own("anon-poison-1", "user-a", published=False, status="live", sharpe=3.0, dsr=0.99, oos=2.0, pbo=0.01)
+
+    async with _client() as client:
+        # No cookie sent — genuinely anonymous, not just an unsigned-in client.
+        client.headers.pop("cookie", None)
+        resp = await client.get("/api/leaderboard?scope=own")
+    assert resp.status_code == 200  # never 401 — public, no-wallet endpoint
+    body = resp.json()
+    assert body["scope"] == "curated"
+    assert "anon-poison-1" not in [e["id"] for e in body["entries"]]
+
+
+@pytest.mark.asyncio
+async def test_anonymous_default_scope_is_curated():
+    async with _client() as client:
+        client.headers.pop("cookie", None)
+        resp = await client.get("/api/leaderboard")
+    assert resp.status_code == 200
+    assert resp.json()["scope"] == "curated"
+
+
+# ── 3 & 4. Signed-in default is "own"; response always reports served scope ─
+
+
+@pytest.mark.asyncio
+async def test_signed_in_default_scope_is_own_without_query_param(monkeypatch):
+    _own("default-own-1", "user-a", published=False, status="live")
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        resp = await client.get("/api/leaderboard")  # no ?scope= at all
+    body = resp.json()
+    assert body["scope"] == "own"
+    assert [e["id"] for e in body["entries"]] == ["default-own-1"]
+
+
+@pytest.mark.asyncio
+async def test_signed_in_user_explicit_curated_scope_excludes_own_private_row(monkeypatch):
+    """A signed-in user can explicitly ask for the curated reference view; it
+    must not include their own private (unpublished) strategy — curated means
+    curated, not 'curated plus my stuff'."""
+    _own("mine-not-curated", "user-a", published=False, status="live")
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        resp = await client.get("/api/leaderboard?scope=curated")
+    body = resp.json()
+    assert body["scope"] == "curated"
+    assert "mine-not-curated" not in [e["id"] for e in body["entries"]]
+
+
+# ── 5. Zero-strategy signed-in user gets an honest empty board, not curated ─
+
+
+@pytest.mark.asyncio
+async def test_own_scope_empty_for_user_with_no_generated_strategies(monkeypatch):
+    _sign_in(monkeypatch, "user-nobody")
+    async with _client() as client:
+        resp = await client.get("/api/leaderboard?scope=own")
+    body = resp.json()
+    assert body["scope"] == "own"
+    assert body["entries"] == []
+    assert body["total"] == 0
+    # Scoring-engine metadata stays intact even for an empty board (existing
+    # fail-safe contract — must survive the new scope branch too).
+    assert abs(sum(body["scoring_engine"]["weights"].values()) - 1.0) < 1e-9

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -33,7 +33,12 @@ function useArchStats() {
 		apiGet("/health")
 			.then(setHealth)
 			.catch(() => setHealthError(true));
-		apiGet("/api/leaderboard")
+		// scope=curated pinned deliberately: this stat is labeled "the public
+		// leaderboard" / a library-wide count below, and the endpoint now
+		// defaults to scope=own for a signed-in caller (leaderboard-goes-
+		// single-user MVP) — an unpinned call would silently turn this into
+		// the viewer's own strategy count for anyone signed in.
+		apiGet("/api/leaderboard?scope=curated")
 			.then(setLeaderboard)
 			.catch(() => setLeaderboardError(true));
 	}, []);

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -1,12 +1,17 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useAuth } from '../AuthContext'
 import { apiGet } from '../api'
 
-// The public, gamified strategy leaderboard (North Star §5 — the testnet
-// engagement engine). Ranks the library by the backend's transparent conviction
-// score (real rigor gate + backtest), and pairs an honest, pending StockBench /
-// live-P&L "forward axis". Nothing here is fabricated: validation metrics are
-// real passport fields; the forward axis renders as "pending" until that data
-// flows. Public — no wallet required.
+// Single-user leaderboard (MVP pivot — no publish mechanism exists yet, so
+// ranking a global cohort was incoherent; nobody had opted into competing).
+// Signed in: ranks YOUR OWN strategies against each other by the backend's
+// transparent conviction score (real rigor gate + backtest). Signed out (or
+// explicitly toggled): shows the curated seed library as an honestly-labeled
+// REFERENCE set, never framed as competition. Nothing here is fabricated:
+// validation metrics are real passport fields; the forward axis renders as
+// "pending" until that data flows. Never auth-gated — public browse stays;
+// see backend's `scope` field (own|curated), which reports what was actually
+// served, not just what was requested.
 
 const SORT_OPTIONS = [
   { id: 'conviction_score', label: 'Conviction' },
@@ -63,6 +68,7 @@ function ScoreBar({ components, weights }) {
 }
 
 export default function Leaderboard() {
+  const { user } = useAuth()
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -70,32 +76,100 @@ export default function Leaderboard() {
   const [order, setOrder] = useState('desc')
   const [minRigor, setMinRigor] = useState(false)
   const [regime, setRegime] = useState('')
+  // null = let the backend pick the default (own if signed in, else curated).
+  // Explicit only when the caller toggles — see the scope switch below.
+  const [scopeParam, setScopeParam] = useState(null)
+
+  // If auth resolves (or the user signs in/out) while this page is open, drop
+  // back to the server default rather than keep stale explicit scope — e.g. a
+  // visitor who toggled to "Curated" pre-login should not stay stuck there
+  // post-login for no reason.
+  useEffect(() => { setScopeParam(null) }, [user?.id])
 
   const load = useCallback(() => {
     setLoading(true)
     const params = new URLSearchParams({ sort_by: sortBy, order, limit: '100' })
     if (minRigor) params.set('min_rigor', 'true')
     if (regime) params.set('regime_tag', regime)
+    if (scopeParam) params.set('scope', scopeParam)
     apiGet(`/api/leaderboard?${params.toString()}`)
       .then(d => { setData(d); setError(null) })
       .catch(e => setError(e.message || 'Failed to load leaderboard'))
       .finally(() => setLoading(false))
-  }, [sortBy, order, minRigor, regime])
+  }, [sortBy, order, minRigor, regime, scopeParam])
 
   useEffect(() => { load() }, [load])
 
   const engine = data?.scoring_engine
   const sb = engine?.stockbench_global
+  // The scope actually served (may differ from scopeParam — an anonymous
+  // request for "own" is transparently served "curated"). This, not the
+  // request param, is the source of truth for labeling the page.
+  const servedScope = data?.scope ?? (user ? 'own' : 'curated')
+  const isOwn = servedScope === 'own'
 
   return (
     <div className="leaderboard-page" style={{ maxWidth: 1100 }}>
       <div style={{ marginBottom: 18 }}>
-        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 8 }}>Strategy Leaderboard</h2>
+        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 8 }}>
+          {isOwn ? 'Your Strategy Leaderboard' : 'Strategy Leaderboard'}
+        </h2>
         <p className="body" style={{ maxWidth: 760 }}>
-          Every library strategy, ranked by a transparent <strong>conviction score</strong> built from
-          real rigor-gate and backtest results — the ugly numbers included. Build your track record now;
-          it carries to mainnet.
+          {isOwn
+            ? <>Your strategies, ranked against each other by a transparent <strong>conviction score</strong> built
+                from real rigor-gate and backtest results — the ugly numbers included. Build your track record now;
+                it carries to mainnet.</>
+            : <>The curated seed library, ranked by a transparent <strong>conviction score</strong> built from real
+                rigor-gate and backtest results — the ugly numbers included. A reference set, not a competition.</>}
         </p>
+
+        {!user && (
+          <div
+            role="status"
+            style={{
+              marginTop: 10,
+              padding: '10px 14px',
+              borderLeft: '3px solid var(--accent)',
+              background: 'var(--accent-muted)',
+              borderRadius: 4,
+              fontSize: 13,
+              color: 'var(--text-2)',
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 8,
+              alignItems: 'center',
+            }}
+          >
+            <span>
+              <strong style={{ color: 'var(--accent)' }}>Sign in to rank your strategies.</strong>{' '}
+              What you're seeing below is the curated library — reference rows, not strategies you're
+              competing against.
+            </span>
+            <a
+              className="btn-primary"
+              style={{ marginLeft: 'auto', flexShrink: 0 }}
+              href={`/sign-in?next=${encodeURIComponent(`${window.location.pathname}${window.location.search}`)}`}
+            >
+              Sign in
+            </a>
+          </div>
+        )}
+
+        {user && (
+          <div style={{ marginTop: 10, display: 'flex', gap: 6, alignItems: 'center' }}>
+            <button type="button" onClick={() => setScopeParam('own')}
+              className={`tag-tab ${isOwn ? 'tag-accent' : 'tag-muted'}`}
+              style={{ cursor: 'pointer', border: 'none', borderRadius: 14, fontSize: 12 }}>
+              My strategies
+            </button>
+            <button type="button" onClick={() => setScopeParam('curated')}
+              className={`tag-tab ${!isOwn ? 'tag-accent' : 'tag-muted'}`}
+              style={{ cursor: 'pointer', border: 'none', borderRadius: 14, fontSize: 12 }}
+              title="The curated seed library — reference rows, not strategies you're competing against">
+              Curated library (reference)
+            </button>
+          </div>
+        )}
         {/* PROVISIONAL-DATA BANNER — remove this whole block once the backtest
             re-run completes and the figures below are trustworthy again.
             A routing defect (fixed in #1203) meant most library strategies were
@@ -181,7 +255,18 @@ export default function Leaderboard() {
       {loading && <div className="body" style={{ color: 'var(--text-3)' }}>Loading the board…</div>}
       {error && <div className="tag-warning" style={{ display: 'inline-block', padding: '6px 10px' }}>Couldn’t load the leaderboard: {error}</div>}
 
-      {!loading && !error && data && data.entries.length === 0 && (
+      {!loading && !error && data && data.entries.length === 0 && isOwn && (
+        <div className="body" style={{ color: 'var(--text-3)', padding: 20, textAlign: 'center', border: '1px dashed var(--glass-border)', borderRadius: 8 }}>
+          You haven't generated any strategies yet.{' '}
+          <a href="/app/generate" style={{ color: 'var(--accent)' }}>Generate one</a>, or{' '}
+          <button type="button" onClick={() => setScopeParam('curated')}
+            style={{ background: 'none', border: 'none', padding: 0, color: 'var(--accent)', cursor: 'pointer', textDecoration: 'underline', font: 'inherit' }}>
+            browse the curated library
+          </button> for reference.
+        </div>
+      )}
+
+      {!loading && !error && data && data.entries.length === 0 && !isOwn && (
         <div className="body" style={{ color: 'var(--text-3)', padding: 20, textAlign: 'center', border: '1px dashed var(--glass-border)', borderRadius: 8 }}>
           No strategies match these filters yet.
         </div>
@@ -211,7 +296,12 @@ export default function Leaderboard() {
                   <td style={{ padding: '10px', maxWidth: 280 }}>
                     <div style={{ color: 'var(--text-1)', fontWeight: 500 }}>{e.name}</div>
                     <div style={{ fontSize: 11, color: 'var(--text-3)' }}>
-                      {e.creator === 'Archimedes' ? 'Archimedes (curated)' : `by ${e.creator.slice(0, 6)}…${e.creator.slice(-4)}`}
+                      {isOwn
+                        // Every row here is the caller's own by construction (server-scoped) —
+                        // `creator` is curator_wallet provenance, not ownership, and is often
+                        // unset for generated strategies, so it's redundant/misleading here.
+                        ? 'Your strategy'
+                        : (e.creator === 'Archimedes' ? 'Archimedes (curated)' : `by ${e.creator.slice(0, 6)}…${e.creator.slice(-4)}`)}
                       {e.regime_tag && e.regime_tag !== 'regime_neutral' ? ` · ${e.regime_tag}` : ''}
                     </div>
                   </td>


### PR DESCRIPTION
## What

The leaderboard ranked a global cohort, but there's no publish mechanism, so that ranking was incoherent (nobody had opted into competing). It now defaults to **single-user**:

- **Signed in** → `scope=own`: your own generated strategies, ranked against each other. Ownership-only — never another user's row, published or not.
- **Anonymous, or explicitly toggled** → `scope=curated`: the curated seed library, labeled as a **reference set**, never framed as competition. This is the endpoint's pre-existing global-cohort behavior (curated ∪ published-generated), left intact as `curated`'s implementation rather than deleted.

The endpoint stays public — never auth-gated. `GET /api/leaderboard?scope=own` from an anonymous caller is transparently served `curated` (never a 401/error). The response's own `scope` field always reports what was **actually served**, since a request can be silently coerced — the UI trusts that field, not the query param it sent.

## Backend

- `api/leaderboard_routes.py`: `scope` query param (`own|curated`), default contextual (own if signed in, curated if anon). Owner resolved via the Better Auth session (`get_current_user`) + linked wallet — optional, so anonymous never 401s.
- `api/strategies_routes.py`: new `_owned_generated_strategy_responses()` — reuses the single `#850` visibility predicate (`is_strategy_visible`) for the two-tier owner_user_id/owner_wallet match, but pins `is_published=False` in the row it feeds that predicate so a stranger's published strategy can never ride the publish-visibility clause onto your board. Ownership only, never re-implemented ad hoc.
- `services/leaderboard.py` / `leaderboard_schemas.py`: `build_leaderboard()` and `LeaderboardResponse` now carry `scope` through, pure passthrough.

## UI

`Leaderboard.jsx`: renders the scoped view (own vs curated), an honest anonymous state ("Sign in to rank your strategies" + curated reference rows, clearly labeled), a scope toggle for signed-in users, and an empty-state for a signed-in user with zero strategies. The #1226 provisional-data banner is untouched. Also fixed `Architecture.jsx`'s `/api/leaderboard` stat call (labeled "the public leaderboard") to pin `scope=curated` — it would otherwise have silently become the viewer's own count for anyone signed in.

## #1185 interaction (NOT closed)

#1185 (board-level selection-bias correction, BH-FDR) is about search-over-a-shared-board risk. A single-user `own` board isn't a shared board — that risk is largely moot for MVP. It still applies to `curated` (a real shared board anyone can browse) and returns in full once a global cohort exists again post-publish. Leaving #1185 open.

## Tests

New `backend/tests/test_leaderboard_single_user_scope.py` (7 tests):
- **Poison test** (both directions): user A signed in never sees user B's strategy under `scope=own`, even when B's is published and scores higher than A's. Verified adversarially — reverting the `is_published` pin to reuse the row's real publish state (the realistic regression) makes the poison assertion fail, confirming the test is discriminating.
- Anonymous `scope=own` → served `curated`, no leak, 200 not 401.
- Default scope: curated when anonymous, own when signed in, without `?scope=`.
- Signed-in explicit `scope=curated` excludes their own private row.
- Signed-in user with zero strategies gets an honest empty `own` board (not a curated fallback).

Full suite: `3143 passed, 5 skipped` (skips pre-existing/unrelated — no Postgres/forge in this env). `ruff check` + `ruff format --check` clean; `eslint` + `vite build` clean.

## Omissions

- No UI change to `list_generated_strategies`/Library — out of scope, this ticket is leaderboard-only.
- `curator_wallet` provenance labeling on generated strategies is a pre-existing rough edge (unrelated to ownership) — `own`-scope rows just show "Your strategy" in the UI rather than surface it.