### PR TITLE
Test-mode payer: linked-wallet-first with a no-payer guard (#1298 prep)

### DIFF
--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -16,6 +16,7 @@ import {
 	describePayerMismatch,
 	extractReceipt,
 	paymentErrorMessage,
+	primaryLinkedWallet,
 } from "../generateQuote";
 
 const shortAddr = (addr) => (addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : "");
@@ -236,13 +237,23 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// The PAYMENTS_DRY_RUN continuation: any non-empty Payment-Signature is
 	// accepted UNVERIFIED, so this actually completes the job — honestly
 	// labeled, never dressed up as a real settlement. The payer named is the
-	// caller's OWN active wallet, which — by having reached a 402 at all —
-	// is already proven to be a wallet linked to this account (the 409 gate
-	// runs first and would have fired otherwise).
+	// LINKED wallet (server truth — what #1296's payer binding will require
+	// when signing becomes real, #1298), falling back to the active browser
+	// wallet. Reaching a 402 proves the SERVER-side link exists (the 409 gate
+	// ran first), but NOT that the browser wallet is connected or that the
+	// linked-wallets fetch succeeded — so the none-available case is handled
+	// here as UX, never shipped as an empty payer.
 	const continueInTestMode = async () => {
+		const payer = primaryLinkedWallet(linkedWallets) || walletAddr;
+		if (!payer) {
+			setPaymentMessage(
+				"Could not resolve your linked wallet (reconnect your wallet or reload). No payment was attempted.",
+			);
+			return;
+		}
 		setContinuingTestMode(true);
 		try {
-			await submitStart({ "Payment-Signature": buildDryRunPaymentHeader(walletAddr) });
+			await submitStart({ "Payment-Signature": buildDryRunPaymentHeader(payer) });
 			setPaymentStatus(PAYMENT_STATUS.NONE);
 			setPaymentMessage("");
 			setTestModeNotice(true);

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -16,7 +16,7 @@ import {
 	describePayerMismatch,
 	extractReceipt,
 	paymentErrorMessage,
-	primaryLinkedWallet,
+	resolveDryRunPayer,
 } from "../generateQuote";
 
 const shortAddr = (addr) => (addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : "");
@@ -244,7 +244,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// linked-wallets fetch succeeded — so the none-available case is handled
 	// here as UX, never shipped as an empty payer.
 	const continueInTestMode = async () => {
-		const payer = primaryLinkedWallet(linkedWallets) || walletAddr;
+		const payer = resolveDryRunPayer(linkedWallets, walletAddr);
 		if (!payer) {
 			setPaymentMessage(
 				"Could not resolve your linked wallet (reconnect your wallet or reload). No payment was attempted.",

--- a/ui/src/generateQuote.js
+++ b/ui/src/generateQuote.js
@@ -169,8 +169,16 @@ function toBase64(str) {
  * wallet-link precondition to reach this state), never fabricated.
  */
 export function buildDryRunPaymentHeader(payerAddress) {
-	const from = payerAddress || "";
-	return toBase64(JSON.stringify({ payload: { authorization: { from } } }));
+	// Loud contract for #1298's implementer: a payment header with no payer is
+	// never meaningful — dry-run happens not to read it today, but real x402
+	// signing will, and the server's payer binding (#1296) requires the LINKED
+	// wallet. Callers must resolve a payer first (linked wallet preferred,
+	// active browser wallet as fallback) and handle the none-available case in
+	// the UI rather than shipping an empty `from` here.
+	if (!payerAddress) {
+		throw new Error("buildDryRunPaymentHeader requires a payer address (the caller's linked wallet)");
+	}
+	return toBase64(JSON.stringify({ payload: { authorization: { from: payerAddress } } }));
 }
 
 /**

--- a/ui/src/generateQuote.js
+++ b/ui/src/generateQuote.js
@@ -182,6 +182,20 @@ export function buildDryRunPaymentHeader(payerAddress) {
 }
 
 /**
+ * Resolve the dry-run payer ADDRESS: the account's primary linked wallet's
+ * address first (the server-side truth that already cleared the 409 wallet
+ * precondition), the browser-connected wallet second, null when neither
+ * exists. Always a string or null — NEVER the LinkedWalletResponse object
+ * (#1299 review: the call site passed `primaryLinkedWallet(...)` — the whole
+ * object — into buildDryRunPaymentHeader, so the header's `from` carried an
+ * object whenever a linked wallet existed; the object is truthy, so neither
+ * the caller's no-payer bail nor the header's falsy-payer throw caught it).
+ */
+export function resolveDryRunPayer(linkedWallets, walletAddr) {
+	return primaryLinkedWallet(linkedWallets)?.address || walletAddr || null;
+}
+
+/**
  * The settlement receipt (PAYMENT-RESPONSE header, #1296) from a
  * successful /start response, if present — surfaced subtly, never
  * fabricated. Accepts either a Fetch `Headers` object or a plain object

--- a/ui/test/generate-quote.test.js
+++ b/ui/test/generate-quote.test.js
@@ -184,10 +184,24 @@ test("buildDryRunPaymentHeader: base64-JSON carrying the REAL payer, decodable t
 	assert.equal(decoded.payload.authorization.from, "0xPayerAddress");
 });
 
-test("buildDryRunPaymentHeader: never silently fabricates a payer for a falsy address", () => {
-	const header = buildDryRunPaymentHeader(null);
-	const decoded = JSON.parse(globalThis.Buffer.from(header, "base64").toString("utf8"));
-	assert.equal(decoded.payload.authorization.from, "");
+test("buildDryRunPaymentHeader: REFUSES a falsy payer (loud contract for #1298)", () => {
+	// A payment header with no payer is never meaningful. Strengthened from
+	// the original "encode an empty from honestly" (#1295 review nit): the
+	// server's payer binding (#1296) requires the linked wallet, so an
+	// empty payer at this seam is a caller bug — throw, don't encode.
+	assert.throws(() => buildDryRunPaymentHeader(null), /requires a payer address/);
+	assert.throws(() => buildDryRunPaymentHeader(""), /requires a payer address/);
+});
+
+test("Generate.jsx resolves the test-mode payer linked-wallet-first with a no-payer guard", () => {
+	// Reaching a 402 proves the SERVER-side link, not that the browser wallet
+	// is connected or the linked-wallets fetch succeeded — the component must
+	// resolve linked-first, fall back to the active wallet, and bail with a
+	// message (no submit) when neither resolves.
+	const generateSrc = readFileSync(new URL("../src/components/Generate.jsx", import.meta.url), "utf8");
+	assert.match(generateSrc, /primaryLinkedWallet\(linkedWallets\) \|\| walletAddr/);
+	assert.match(generateSrc, /No payment was attempted/);
+	assert.match(generateSrc, /buildDryRunPaymentHeader\(payer\)/);
 });
 
 // ── extractReceipt: the PAYMENT-RESPONSE settlement receipt ───────────────

--- a/ui/test/generate-quote.test.js
+++ b/ui/test/generate-quote.test.js
@@ -13,6 +13,7 @@ import {
 	isWalletLinkRequiredError,
 	paymentErrorMessage,
 	primaryLinkedWallet,
+	resolveDryRunPayer,
 } from "../src/generateQuote.js";
 
 // ── deriveQuoteView: shapes the ratified GET /api/generate/quote response
@@ -193,13 +194,37 @@ test("buildDryRunPaymentHeader: REFUSES a falsy payer (loud contract for #1298)"
 	assert.throws(() => buildDryRunPaymentHeader(""), /requires a payer address/);
 });
 
-test("Generate.jsx resolves the test-mode payer linked-wallet-first with a no-payer guard", () => {
+test("resolveDryRunPayer: the header carries the linked wallet's ADDRESS STRING, never the object", () => {
+	// #1299 review: the old call site passed primaryLinkedWallet(...) — the
+	// whole LinkedWalletResponse object — into buildDryRunPaymentHeader. The
+	// object is truthy, so neither the no-payer bail nor the falsy-payer
+	// throw caught it. This test EXECUTES the resolution end to end and pins
+	// the decoded payer as the address string.
+	const wallets = [
+		{ address: "0xAAA", is_primary: false },
+		{ address: "0xBBB", is_primary: true },
+	];
+	const payer = resolveDryRunPayer(wallets, "0xBrowserWallet");
+	assert.equal(payer, "0xBBB"); // linked-first, and the ADDRESS, not the object
+	const header = buildDryRunPaymentHeader(payer);
+	const decoded = JSON.parse(globalThis.Buffer.from(header, "base64").toString("utf8"));
+	assert.equal(decoded.payload.authorization.from, "0xBBB");
+	assert.equal(typeof decoded.payload.authorization.from, "string");
+});
+
+test("resolveDryRunPayer: browser-wallet fallback, then null (the bail case)", () => {
 	// Reaching a 402 proves the SERVER-side link, not that the browser wallet
-	// is connected or the linked-wallets fetch succeeded — the component must
-	// resolve linked-first, fall back to the active wallet, and bail with a
-	// message (no submit) when neither resolves.
+	// is connected or the linked-wallets fetch succeeded.
+	assert.equal(resolveDryRunPayer([], "0xBrowserWallet"), "0xBrowserWallet");
+	assert.equal(resolveDryRunPayer(null, ""), null);
+	assert.equal(resolveDryRunPayer(undefined, undefined), null);
+});
+
+test("Generate.jsx wires the shared resolver, the bail message, and the header call", () => {
+	// Wiring pin only — the LOGIC is executed by the two tests above (a
+	// source regex can't catch a type bug; #1299 review).
 	const generateSrc = readFileSync(new URL("../src/components/Generate.jsx", import.meta.url), "utf8");
-	assert.match(generateSrc, /primaryLinkedWallet\(linkedWallets\) \|\| walletAddr/);
+	assert.match(generateSrc, /resolveDryRunPayer\(linkedWallets, walletAddr\)/);
 	assert.match(generateSrc, /No payment was attempted/);
 	assert.match(generateSrc, /buildDryRunPaymentHeader\(payer\)/);
 });


### PR DESCRIPTION
The #1295 consumption-pass nit, taken by the contract owner — and it ran deeper than cosmetic.

**The bug shape**: the test-mode path passed `walletAddr` (the **browser's** active wallet) as the payer. Reaching a 402 proves the **server-side** wallet link (the 409 gate ran first) — it does not prove the browser wallet is connected or that the linked-wallets fetch succeeded, so an empty payer was genuinely reachable, and the call-site comment claimed otherwise.

**Now**: payer resolves **linked-wallet-first** (server truth — exactly what #1296's payer binding requires once signing becomes real, #1298), falls back to the active wallet, and bails with an honest "no payment was attempted" message when neither resolves. `buildDryRunPaymentHeader` **throws** on a falsy payer — a loud contract for #1298's implementer instead of a silently-encoded empty `from`.

58/58 UI tests (count as of 9d361483) (the old encode-empty test is strengthened into the refusal assertion + a source-level guard pin), lint and build clean. One file each in src/components/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7

---

**Review fix (9d361483):** the call site passed the full LinkedWalletResponse OBJECT into the payment header (truthy, so no guard caught it). New `resolveDryRunPayer()` returns the address string or null; the source-regex guard test — which pinned the buggy line verbatim — is replaced by tests that EXECUTE the resolution and decode the header (mutation-proven: an object-returning resolver fails them).
