### PR TITLE
Add the free paper-trading leg to the agent journey harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ ARCHIMEDES_EMAIL=agent@example.test ARCHIMEDES_PASSWORD='<secret>' \
   python scripts/agent_journey.py --base https://archimedes-arc.com
 ```
 
-Script retains Better Auth cookie, streams generation, and prints rigor verdict. `--deploy` additionally links wallet from `AGENT_WALLET_KEY` (or disposable wallet with `--ephemeral`) through EIP-4361. Explicit agent `User-Agent` keeps telemetry classification. Exit code is nonzero on hard failure.
+Script retains Better Auth cookie, streams generation, and prints rigor verdict. After generation the winner is deployed to **free paper trading** by default (`--no-paper` to skip) — note this creates a **persistent paper deployment** on whatever `--base` points at. On `--ephemeral` runs the script stops the deployment at the end (the disposable account is unreachable afterwards); on real-account runs it is left ACTIVE deliberately — that running ledger is the point — stop it later via `POST /api/paper/deployments/{id}/stop`. `--deploy` additionally links wallet from `AGENT_WALLET_KEY` (or disposable wallet with `--ephemeral`) through EIP-4361. Explicit agent `User-Agent` keeps telemetry classification. Exit code is nonzero on hard failure.
 
 See [`scripts/agent_journey.py`](scripts/agent_journey.py) for the full implementation.
 

--- a/backend/tests/scripts/test_agent_journey_paper.py
+++ b/backend/tests/scripts/test_agent_journey_paper.py
@@ -171,3 +171,15 @@ def test_malformed_201_body_fails_cleanly():
     client.post.return_value = _response(201, {"unexpected": "shape"})
     assert aj.step_paper(client, dict(_WINNER)) is None
     client.get.assert_not_called()
+
+
+def test_200_is_not_success_the_contract_is_201_only():
+    """The route's success is 201 Created, and the harness pins EXACTLY that:
+    a 200 carrying an otherwise valid summary body must still fail the leg —
+    a relaxed any-2xx check would mask a route/proxy behavior change the
+    harness exists to surface. (Review: the 422 test alone cannot prove this;
+    this test fails against a `status_code not in (200, 201)` relaxation.)"""
+    client = MagicMock()
+    client.post.return_value = _response(200, _summary())
+    assert aj.step_paper(client, dict(_WINNER)) is None
+    client.get.assert_not_called()

--- a/backend/tests/scripts/test_agent_journey_paper.py
+++ b/backend/tests/scripts/test_agent_journey_paper.py
@@ -1,0 +1,173 @@
+"""PAPER-leg coverage for the agent journey harness (#1268 spine step).
+
+Target: scripts/agent_journey.py (repo root — loaded via importlib, it isn't a
+package). Mirrors test_agent_journey_deploy.py's loader pattern. Three
+surfaces:
+
+  1. ``build_paper_deploy_payload`` + ``PAPER_SUMMARY_FIELDS`` — cross-checked
+     against the REAL ``deployment_summary()`` service output (built on a tmp
+     sqlite via ``create_deployment``), so a field rename on the service side
+     fails THIS test, not a live readback while dogfooding. This is the
+     promise-checked-against-the-truth pattern (see test_agent_journey_deploy's
+     VaultCreateRequest pin).
+  2. ``step_paper`` skip semantics — no winner / no persisted strategy_id
+     means the endpoint is never called.
+  3. ``step_paper`` request + failure handling — the exact body posted, the
+     201-only success contract, and created-but-unreadable failing the leg.
+
+Hermetic: the httpx client is a MagicMock for the step tests; the truth-side
+pin uses tmp sqlite only (no network, no Redis, no live server).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_agent_journey():
+    """Import scripts/agent_journey.py from the repo root by file path."""
+    path = _REPO_ROOT / "scripts" / "agent_journey.py"
+    spec = importlib.util.spec_from_file_location("agent_journey_paper", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["agent_journey_paper"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+aj = _load_agent_journey()
+
+_WINNER = {
+    "strategy_id": "strat-paper-1",
+    "strategy_name": "Momentum Fusion",
+    "rigor_gate_status": "pending",  # paper deliberately has no gate precondition
+    "deployable": False,
+}
+
+# A valid DSL spec (test_paper_routes_auth precedent) for the truth-side pin.
+_SPEC = {
+    "name": "journey paper pin",
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "daily",
+    "entry": {"gt": ["momentum_20", 0]},
+    "exit": {"lt": ["momentum_20", -0.99]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "source_arxiv_ids": ["0706.1497"],
+    "look_ahead_safe": True,
+}
+
+
+def _summary(deployment_id: str = "pd-1") -> dict:
+    """A response shaped like the real deployment_summary() output."""
+    return {
+        "deployment_id": deployment_id,
+        "strategy_id": _WINNER["strategy_id"],
+        "deployed_at": "2026-08-19T00:00:00+00:00",
+        "status": "active",
+        "days": 0,
+        "total_return": 0.0,
+        "drift_detected_at": None,
+        "series": [],
+    }
+
+
+def _response(status_code: int, payload: dict | None = None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    if payload is not None:
+        resp.json.return_value = payload
+    else:
+        resp.json.side_effect = ValueError("no json")
+    return resp
+
+
+# ── 1. The promise, checked against the truth ────────────────────────────────
+
+
+@pytest.fixture()
+def _tmp_db(tmp_path):
+    from tests.db_isolation import redirect_to_tmp_sqlite
+
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+def test_summary_fields_exist_in_the_real_service_output(_tmp_db):
+    """Every field the harness prints must exist in what deployment_summary()
+    actually returns — built through the real create path, not a fixture."""
+    from archimedes.db import get_session, init_db
+    from archimedes.services.paper_trading import create_deployment, deployment_summary
+
+    init_db()
+    with get_session() as session:
+        dep = create_deployment(
+            session,
+            strategy_id=_WINNER["strategy_id"],
+            spec_dict=dict(_SPEC),
+            owner_wallet=None,
+            owner_user_id="user-journey-pin",
+        )
+        summary = deployment_summary(session, dep)
+    missing = [f for f in aj.PAPER_SUMMARY_FIELDS if f not in summary]
+    assert not missing, f"harness prints fields the service no longer returns: {missing}"
+
+
+def test_payload_shape_is_the_single_required_field():
+    assert aj.build_paper_deploy_payload("s-1") == {"strategy_id": "s-1"}
+
+
+# ── 2. Skip semantics: never call the endpoint without a persisted winner ────
+
+
+def test_no_winner_skips_without_calling():
+    client = MagicMock()
+    assert aj.step_paper(client, None) is None
+    client.post.assert_not_called()
+    client.get.assert_not_called()
+
+
+def test_winner_without_strategy_id_skips_without_calling():
+    client = MagicMock()
+    assert aj.step_paper(client, {"strategy_name": "unpersisted", "strategy_id": None}) is None
+    client.post.assert_not_called()
+
+
+# ── 3. Request contract + failure handling ───────────────────────────────────
+
+
+def test_success_posts_exact_body_and_reads_back():
+    client = MagicMock()
+    client.post.return_value = _response(201, _summary())
+    client.get.return_value = _response(200, _summary())
+    assert aj.step_paper(client, dict(_WINNER)) == "pd-1"
+    client.post.assert_called_once_with("/api/paper/deployments", json={"strategy_id": _WINNER["strategy_id"]})
+    client.get.assert_called_once_with("/api/paper/deployments/pd-1")
+
+
+def test_non_201_fails_the_leg():
+    client = MagicMock()
+    client.post.return_value = _response(422, text='{"detail": "no spec"}')
+    assert aj.step_paper(client, dict(_WINNER)) is None
+    client.get.assert_not_called()
+
+
+def test_created_but_unreadable_fails_the_leg():
+    """The readback is part of the leg: a deployment the owner cannot GET back
+    is a failure, not a footnote."""
+    client = MagicMock()
+    client.post.return_value = _response(201, _summary())
+    client.get.return_value = _response(404, text="not found")
+    assert aj.step_paper(client, dict(_WINNER)) is None
+
+
+def test_malformed_201_body_fails_cleanly():
+    client = MagicMock()
+    client.post.return_value = _response(201, {"unexpected": "shape"})
+    assert aj.step_paper(client, dict(_WINNER)) is None
+    client.get.assert_not_called()

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -650,6 +650,18 @@ def main() -> int:
         print(f"\nRESULT: journey {'completed' if ok else 'partial (no verdict read)'} — job_id={job_id}")
 
         paper_id = step_paper(client, readback.get("winner")) if args.paper else None
+        if paper_id and args.ephemeral:
+            # A disposable account is unreachable after this run, so its paper
+            # deployment would accumulate as an orphan on --base forever. Stop
+            # it (freezes the ledger honestly); real-account runs deliberately
+            # leave the deployment ACTIVE — the running ledger is the point.
+            try:
+                stop = client.post(f"/api/paper/deployments/{paper_id}/stop")
+                print(
+                    f"  · ephemeral run: paper deployment {'stopped' if stop.is_success else f'stop failed (HTTP {stop.status_code})'}"
+                )
+            except httpx.HTTPError as exc:
+                print(f"  · ephemeral run: paper deployment stop failed ({exc})")
 
         vault_address = step_deploy(
             client,

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -663,8 +663,12 @@ def main() -> int:
         )
         # Requested hard steps must move the exit code (review): a --deploy
         # run that deployed nothing, or a failed monitor read, is not success.
-        # Same for the paper leg: skipped-for-no-winner is soft (readback
-        # already degraded `ok`), but a failed POST/readback is a failure.
+        # Same for the paper leg, but only when it was actually ATTEMPTED:
+        # no persisted winner means there was nothing to deploy — the journey
+        # RESULT line above already reports how the generation went (note
+        # `ok` covers verdict readability, not winner existence, so a
+        # winnerless-but-readable run legitimately exits 0 with paper
+        # skipped). A failed POST/readback on a real attempt is a failure.
         paper_ok = True
         if args.paper and (readback.get("winner") or {}).get("strategy_id"):
             if paper_id:

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -3,6 +3,8 @@
 
 Better Auth account session owns generation and application data. Optional EIP-4361
 wallet link is created only for ``--deploy``; wallet connection never authenticates.
+After generation the winner is deployed to FREE paper trading by default
+(``--no-paper`` to skip) — account session only, no wallet, no rigor precondition.
 Credentials and private keys come from environment only and are never printed.
 
 Usage:
@@ -338,6 +340,72 @@ def step_readback(client: httpx.Client, job_id: str) -> dict:
     return {"read_ok": True, "winner": winner}
 
 
+# ── PAPER — the free spine leg (#1268) ─────────────────────────────────────
+
+# The summary fields this harness prints; pinned against the REAL
+# deployment_summary() output by backend/tests/scripts/test_agent_journey_paper.py
+# so a rename on the service side fails that test, not a live readback.
+PAPER_SUMMARY_FIELDS = ("deployment_id", "status", "days", "total_return")
+
+
+def build_paper_deploy_payload(strategy_id: str) -> dict:
+    """The exact JSON body ``POST /api/paper/deployments`` reads. Factored out
+    of ``step_paper`` so the hermetic test can pin this shape (and
+    ``PAPER_SUMMARY_FIELDS``) against the real route/service —
+    ``backend/tests/scripts/test_agent_journey_paper.py``."""
+    return {"strategy_id": strategy_id}
+
+
+def step_paper(client: httpx.Client, winner: dict | None) -> str | None:
+    """Deploy the winning strategy to PAPER trading and read it back.
+
+    ``POST /api/paper/deployments`` needs only the account session — no
+    wallet, no gas, free by design (#1268), and deliberately NO rigor
+    precondition on the server: paper trading is where a pending strategy can
+    prove itself honestly. So unlike ``step_deploy`` this step does not
+    refuse a non-deployable winner; it prints the live-gate status and lets
+    the server decide (404 for invisible strategies, 422 for spec-less ones).
+
+    Returns the deployment_id; None when skipped (no persisted winner) or
+    failed — ``main`` turns a failure into a nonzero exit the same way
+    ``--deploy`` does. The post-create readback is part of the leg: a
+    deployment the owner cannot immediately GET back is a failure, not a
+    footnote.
+    """
+    _hr("PAPER — free paper-trading deployment (account session only)")
+    if not winner or not winner.get("strategy_id"):
+        print("  · no winning candidate with a persisted strategy — skipping paper deploy")
+        return None
+    sid = winner["strategy_id"]
+    print(
+        f"  · {winner.get('strategy_name')!r}  live_gate={winner.get('rigor_gate_status')!r} "
+        "(paper has no gate precondition)"
+    )
+    try:
+        r = client.post("/api/paper/deployments", json=build_paper_deploy_payload(sid))
+    except httpx.HTTPError as exc:
+        print(f"  ✗ POST /api/paper/deployments — transport error: {exc}")
+        return None
+    if r.status_code != 201:
+        print(f"  ✗ POST /api/paper/deployments — HTTP {r.status_code}: {r.text[:300]}")
+        return None
+    try:
+        dep = r.json()
+        deployment_id = dep["deployment_id"]
+    except (ValueError, KeyError, TypeError) as exc:
+        print(f"  ✗ POST /api/paper/deployments — unexpected response shape ({exc}): {r.text[:200]}")
+        return None
+    print(f"  ✓ paper deployment created: {deployment_id}")
+
+    summary = _get(client, f"/api/paper/deployments/{deployment_id}")
+    if not isinstance(summary, dict):
+        print("  ✗ created but could not read the deployment back — failing the leg")
+        return None
+    fields = "  ".join(f"{k}={summary.get(k)!r}" for k in PAPER_SUMMARY_FIELDS)
+    print(f"  ✓ readback: {fields}")
+    return deployment_id
+
+
 # ── DEPLOY + MONITOR (slice 2 continued) ───────────────────────────────────
 
 
@@ -531,6 +599,14 @@ def main() -> int:
         "the always-on correctness floors)",
     )
     ap.add_argument(
+        "--paper",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="after generation, deploy the winner to FREE paper trading (POST /api/paper/deployments; "
+        "account session only — no wallet, no gas, no rigor precondition). --no-paper skips. "
+        "Stop later via POST /api/paper/deployments/{id}/stop.",
+    )
+    ap.add_argument(
         "--monitor-address",
         default=None,
         help="GET /api/vaults/{address}/health for an existing vault, independent of deploying one this run "
@@ -573,6 +649,8 @@ def main() -> int:
         ok = readback["read_ok"]
         print(f"\nRESULT: journey {'completed' if ok else 'partial (no verdict read)'} — job_id={job_id}")
 
+        paper_id = step_paper(client, readback.get("winner")) if args.paper else None
+
         vault_address = step_deploy(
             client,
             readback.get("winner"),
@@ -585,6 +663,17 @@ def main() -> int:
         )
         # Requested hard steps must move the exit code (review): a --deploy
         # run that deployed nothing, or a failed monitor read, is not success.
+        # Same for the paper leg: skipped-for-no-winner is soft (readback
+        # already degraded `ok`), but a failed POST/readback is a failure.
+        paper_ok = True
+        if args.paper and (readback.get("winner") or {}).get("strategy_id"):
+            if paper_id:
+                print(
+                    f"RESULT: paper deployment {paper_id} created (free; stop via POST /api/paper/deployments/{paper_id}/stop)"
+                )
+            else:
+                paper_ok = False
+                print("RESULT: paper deployment failed — see above.")
         deploy_ok = True
         if args.deploy and not vault_address:
             deploy_ok = False
@@ -596,7 +685,7 @@ def main() -> int:
         if vault_address:
             print(f"RESULT: vault deployed — {vault_address}")
 
-        return 0 if (ok and deploy_ok and monitor_ok) else 1
+        return 0 if (ok and paper_ok and deploy_ok and monitor_ok) else 1
     finally:
         client.close()
 


### PR DESCRIPTION
## What

After generation, the winner is deployed to paper trading by default (`--no-paper` to skip): `POST /api/paper/deployments {strategy_id}` with the account session only — no wallet, no gas, and deliberately no client-side rigor refusal (paper has no gate precondition on the server; #1268). The post-create `GET` readback is part of the leg — created-but-unreadable fails the run, and a failed paper leg moves the exit code the same way `--deploy` does.

Closes the reproducibility gap from the 2026-08-19 dogfood, whose paper step was performed outside the script. The script and the upcoming paper UI CTA now exercise the same contract.

## Tests

`backend/tests/scripts/test_agent_journey_paper.py` (loader pattern from `test_agent_journey_deploy.py`):
- **Truth-side pin**: the fields the harness prints (`PAPER_SUMMARY_FIELDS`) are checked against the REAL `deployment_summary()` output, built through `create_deployment` on tmp sqlite — a service-side rename fails this test, not a live readback.
- Skip semantics (no winner / no persisted strategy_id → endpoint never called), the exact request body, 201-only success, malformed-body and unreadable-readback failure paths.

## Guard demonstrations (mutations built, run, reverted)

- `PAPER_SUMMARY_FIELDS` mutated to include `net_pnl` → `test_summary_fields_exist_in_the_real_service_output` **fails** (1 failed, 7 passed).
- Payload key mutated to `strategyId` → `test_payload_shape...` **and** `test_success_posts_exact_body_and_reads_back` **fail** (2 failed, 6 passed).

31/31 green across both journey test files (count as of f6ee7755); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7

---

**Review fix (f6ee7755):** added the executing 201-only pin — a 200 with a valid summary body fails the leg (mutation-proven: a `status_code not in (200, 201)` relaxation fails it, 1 failed / 8 passed) — and corrected the paper_ok comment (readback `ok` covers verdict readability, not winner existence).
