### PR TITLE
Paper-trading UI: /app/paper page + passport CTA !minor

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -84,6 +84,7 @@ export default function App() {
       account: 'Account · Archimedes',
       'vault-detail': 'Vault · Archimedes',
       strategy: 'Strategy · Archimedes',
+      paper: 'Paper Trading · Archimedes',
       'sign-in': 'Sign in · Archimedes',
       'sign-up': 'Create account · Archimedes',
     }

--- a/ui/src/AuthenticatedApp.jsx
+++ b/ui/src/AuthenticatedApp.jsx
@@ -14,6 +14,7 @@ import MarketplacePage from "./components/MarketplacePage";
 import OnboardingTour, {
 	hasCompletedOnboarding,
 } from "./components/OnboardingTour";
+import PaperTrading from "./components/PaperTrading";
 import Portfolio from "./components/Portfolio";
 import PublishPage from "./components/PublishPage";
 import QuantLab from "./components/QuantLab";
@@ -137,12 +138,15 @@ export default function AuthenticatedApp({
 						onNavigate={navigateToPage}
 					/>
 				);
+			case "paper":
+				return <PaperTrading onNavigate={navigateToPage} />;
 			case "strategy":
 				return (
 					<StrategyPassport
 						strategyId={route.strategyId}
 						onNavigate={navigateToPage}
 						walletAddr={walletAddr}
+						user={user}
 					/>
 				);
 			case "corpus":

--- a/ui/src/components/Breadcrumbs.jsx
+++ b/ui/src/components/Breadcrumbs.jsx
@@ -28,6 +28,7 @@ export const CRUMB_MAP = {
   // Strategy — wallet-gated, owns the primary generation path
   generate:     { group: null, groupPage: null },
   library:      { group: 'Strategy', groupPage: 'generate' },
+  paper:        { group: 'Strategy', groupPage: 'generate' },
   leaderboard:  { group: 'Strategy', groupPage: 'generate' },
   // Position — wallet-gated deployed-state surfaces
   portfolio:    { group: null, groupPage: null },

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -35,6 +35,9 @@ const NAV = [
 		items: [
 			{ id: "generate", label: "Generate", icon: "i-lucide-sparkles" },
 			{ id: "library", label: "Library", icon: "i-lucide-line-chart" },
+			// Paper Trading lives in STRATEGY: it is the act-on step of the MVP
+			// spine (generate → verdict → paper) — simulated, account-owned, free.
+			{ id: "paper", label: "Paper Trading", icon: "i-lucide-trending-up" },
 			// Leaderboard lives in STRATEGY (#1077): it ranks the strategy library —
 			// discovery-friendly but strategy-native. (Quant Lab moved to Position.)
 			{ id: "leaderboard", label: "Leaderboard", icon: "i-lucide-trophy" },
@@ -88,6 +91,7 @@ export const PAGE_LABELS = {
 	architecture: "Architecture",
 	library: "Library",
 	strategy: "Strategy Passport",
+	paper: "Paper Trading",
 	corpus: "Corpus",
 	quant: "Quant Lab",
 	portfolio: "Portfolio",

--- a/ui/src/components/PaperTrading.jsx
+++ b/ui/src/components/PaperTrading.jsx
@@ -104,14 +104,18 @@ export default function PaperTrading({ onNavigate }) {
     }
     // Name join is best-effort decoration — the list renders with ids if the
     // library calls fail, so these settle independently of the load above.
+    // limit=200 is /generated's max (default 50 could miss names for older
+    // strategies; a deployment beyond even 200 falls back to its id honestly).
     const [seed, generated] = await Promise.allSettled([
       apiGet('/api/strategies/'),
-      apiGet('/api/strategies/generated'),
+      apiGet('/api/strategies/generated?limit=200'),
     ])
     const map = {}
     for (const res of [seed, generated]) {
       if (res.status !== 'fulfilled') continue
       for (const row of res.value.strategies || []) {
+        // id-before-strategy_id matches both list shapes today; keep this
+        // order if a third list source is ever added (contract review, #1302).
         const id = row.id ?? row.strategy_id
         const label = nameOf(row)
         if (id && label) map[id] = label

--- a/ui/src/components/PaperTrading.jsx
+++ b/ui/src/components/PaperTrading.jsx
@@ -104,10 +104,11 @@ export default function PaperTrading({ onNavigate }) {
     }
     // Name join is best-effort decoration — the list renders with ids if the
     // library calls fail, so these settle independently of the load above.
-    // limit=200 is /generated's max (default 50 could miss names for older
-    // strategies; a deployment beyond even 200 falls back to its id honestly).
+    // Each list is fetched at its endpoint's max (curated 100, generated 200 —
+    // the defaults, 20/50, could miss names for older rows; anything beyond
+    // the max falls back to its id honestly).
     const [seed, generated] = await Promise.allSettled([
-      apiGet('/api/strategies/'),
+      apiGet('/api/strategies/?limit=100'),
       apiGet('/api/strategies/generated?limit=200'),
     ])
     const map = {}

--- a/ui/src/components/PaperTrading.jsx
+++ b/ui/src/components/PaperTrading.jsx
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useState } from 'react'
+import { apiGet, apiPost } from '../api'
+
+// /app/paper — the act-on step of the MVP spine (generate → verdict → paper).
+// Lists the signed-in account's paper deployments from GET /api/paper/deployments
+// (deployment_summary shape: deployment_id, strategy_id, deployed_at, status,
+// days, total_return, drift_detected_at, series[{date, daily_return,
+// equity_index}]). Deployments are SIMULATED — account-owned, no wallet, no
+// funds — and free by design (Dan's call: paper stays free even after the
+// generation paywall flips). Strategy display names come from a client-side
+// join against the library lists; the paper API deliberately returns ids only.
+
+function nameOf(row) {
+  return row?.strategy_name || row?.name || row?.paper_title || null
+}
+
+function pct(x) {
+  if (x == null || Number.isNaN(x)) return '—'
+  return `${x >= 0 ? '+' : ''}${(x * 100).toFixed(2)}%`
+}
+
+function StatusChip({ status, driftAt }) {
+  const active = status === 'active'
+  return (
+    <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+      <span
+        style={{
+          padding: '2px 10px',
+          borderRadius: 999,
+          fontSize: 12,
+          fontFamily: 'var(--mono, monospace)',
+          background: active ? 'var(--accent-muted)' : 'var(--surface-3)',
+          color: active ? 'var(--accent)' : 'var(--text-3)',
+          border: `1px solid ${active ? 'var(--accent)' : 'var(--border, var(--surface-3))'}`,
+        }}
+      >
+        {active ? 'ACTIVE' : 'STOPPED'}
+      </span>
+      {driftAt && (
+        <span
+          title={`A fresh replay disagreed with the recorded ledger on ${driftAt}. The track record is frozen pending investigation — honest ledgers do not silently rewrite.`}
+          style={{
+            padding: '2px 10px',
+            borderRadius: 999,
+            fontSize: 12,
+            fontFamily: 'var(--mono, monospace)',
+            background: 'var(--surface-3)',
+            color: 'var(--warning, #b45309)',
+            border: '1px solid var(--warning, #b45309)',
+          }}
+        >
+          DRIFT
+        </span>
+      )}
+    </span>
+  )
+}
+
+// Minimal equity sparkline over series[].equity_index. Starts the path at the
+// 1.0 baseline so day-1 deployments still draw a meaningful segment.
+function Sparkline({ series }) {
+  if (!series || series.length === 0) return null
+  const values = [1.0, ...series.map((p) => p.equity_index)]
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const span = max - min || 1
+  const W = 220
+  const H = 48
+  const pts = values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * (W - 4) + 2
+      const y = H - 6 - ((v - min) / span) * (H - 12)
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+  const up = values[values.length - 1] >= values[0]
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width={W} height={H} aria-hidden="true">
+      <polyline
+        points={pts}
+        fill="none"
+        stroke={up ? 'var(--accent)' : 'var(--danger, #b91c1c)'}
+        strokeWidth="1.5"
+      />
+    </svg>
+  )
+}
+
+export default function PaperTrading({ onNavigate }) {
+  const [deployments, setDeployments] = useState(null)
+  const [names, setNames] = useState({})
+  const [error, setError] = useState('')
+  const [stopping, setStopping] = useState(null)
+
+  const load = useCallback(async () => {
+    setError('')
+    try {
+      const res = await apiGet('/api/paper/deployments')
+      setDeployments(res.deployments || [])
+    } catch (e) {
+      setError(e.message || 'Failed to load paper deployments')
+      setDeployments([])
+      return
+    }
+    // Name join is best-effort decoration — the list renders with ids if the
+    // library calls fail, so these settle independently of the load above.
+    const [seed, generated] = await Promise.allSettled([
+      apiGet('/api/strategies/'),
+      apiGet('/api/strategies/generated'),
+    ])
+    const map = {}
+    for (const res of [seed, generated]) {
+      if (res.status !== 'fulfilled') continue
+      for (const row of res.value.strategies || []) {
+        const id = row.id ?? row.strategy_id
+        const label = nameOf(row)
+        if (id && label) map[id] = label
+      }
+    }
+    setNames(map)
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const stop = async (dep) => {
+    const label = names[dep.strategy_id] || dep.strategy_id
+    if (!window.confirm(`Stop paper trading "${label}"? The track record freezes where it is; this cannot be restarted in place.`)) return
+    setStopping(dep.deployment_id)
+    try {
+      await apiPost(`/api/paper/deployments/${encodeURIComponent(dep.deployment_id)}/stop`, {})
+      await load()
+    } catch (e) {
+      setError(e.message || 'Failed to stop deployment')
+    } finally {
+      setStopping(null)
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 1100 }}>
+      <div style={{ marginBottom: 18 }}>
+        <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 8 }}>
+          Paper Trading
+        </h2>
+        <p className="body" style={{ maxWidth: 760 }}>
+          Simulated deployments of your strategies — <strong>no funds move</strong>. Each one
+          snapshots the strategy spec at deploy time and appends one real-data return per trading
+          day; later regeneration of the strategy never rewrites a running ledger. This is the
+          track record that carries to mainnet.
+        </p>
+      </div>
+
+      {error && (
+        <div role="alert" className="card" style={{ padding: 14, marginBottom: 14, color: 'var(--danger, #b91c1c)' }}>
+          {error}
+        </div>
+      )}
+
+      {deployments === null && <p className="caption">Loading deployments…</p>}
+
+      {deployments !== null && deployments.length === 0 && !error && (
+        <div className="card" style={{ padding: 24, textAlign: 'center' }}>
+          <p className="body" style={{ marginBottom: 12 }}>
+            No paper deployments yet. Open a strategy in your Library and choose{' '}
+            <strong>Start paper trading</strong> on its passport.
+          </p>
+          <button className="btn-primary" onClick={() => onNavigate('library')}>
+            Open Library →
+          </button>
+        </div>
+      )}
+
+      {deployments !== null && deployments.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {deployments.map((dep) => (
+            <div
+              key={dep.deployment_id}
+              className="card"
+              style={{ padding: 16, display: 'flex', flexWrap: 'wrap', gap: 16, alignItems: 'center' }}
+            >
+              <div style={{ flex: '1 1 240px', minWidth: 0 }}>
+                <button
+                  className="btn-link"
+                  style={{
+                    fontWeight: 600,
+                    fontSize: '1.05rem',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    color: 'var(--text-1)',
+                    textAlign: 'left',
+                  }}
+                  title="Open the strategy passport"
+                  onClick={() => onNavigate('strategy', { strategyId: dep.strategy_id })}
+                >
+                  {names[dep.strategy_id] || dep.strategy_id}
+                </button>
+                <div className="caption" style={{ marginTop: 4 }}>
+                  deployed {dep.deployed_at} ·{' '}
+                  {dep.days === 0
+                    ? 'day 0 — first return lands with the next daily advance'
+                    : `${dep.days} trading day${dep.days === 1 ? '' : 's'}`}
+                </div>
+                <div style={{ marginTop: 8 }}>
+                  <StatusChip status={dep.status} driftAt={dep.drift_detected_at} />
+                </div>
+              </div>
+
+              <div style={{ flex: '0 0 auto' }}>
+                <Sparkline series={dep.series} />
+              </div>
+
+              <div style={{ flex: '0 0 auto', textAlign: 'right', minWidth: 110 }}>
+                <div
+                  style={{
+                    fontFamily: 'var(--mono, monospace)',
+                    fontSize: '1.3rem',
+                    fontVariantNumeric: 'tabular-nums',
+                    color:
+                      dep.total_return > 0
+                        ? 'var(--accent)'
+                        : dep.total_return < 0
+                          ? 'var(--danger, #b91c1c)'
+                          : 'var(--text-2)',
+                  }}
+                >
+                  {pct(dep.total_return)}
+                </div>
+                <div className="caption">total return</div>
+                {dep.status === 'active' && (
+                  <button
+                    className="btn btn-outline btn-sm"
+                    style={{ marginTop: 8 }}
+                    disabled={stopping === dep.deployment_id}
+                    onClick={() => stop(dep)}
+                  >
+                    {stopping === dep.deployment_id ? 'Stopping…' : 'Stop'}
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import CreateVaultModal from "./CreateVaultModal";
 import { ROADMAP_SURFACES_ENABLED } from "../featureFlags.js";
 import RigorStrictnessControl, { levelLabel } from "./RigorStrictnessControl";
+import { apiGet, apiPostWithMeta } from "../api";
 import { useRigorStrictness, BADGE_LEVEL } from "../hooks/useRigorStrictness";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "";
@@ -101,6 +102,7 @@ export default function StrategyPassport({
 	strategyId,
 	onNavigate,
 	walletAddr,
+	user = null,
 }) {
 	const [strategy, setStrategy] = useState(null);
 	const [loading, setLoading] = useState(true);
@@ -363,6 +365,16 @@ export default function StrategyPassport({
 					<div className="passport-strictness fade-up fade-up-2">
 						<RigorStrictnessControl level={level} onChange={setLevel} />
 					</div>
+
+					{/* Paper trading — the MVP act-on step. Account-owned and simulated
+					    (POST /api/paper/deployments): no wallet, no rigor precondition,
+					    free by design. The server allows duplicate deployments, so the
+					    already-running state below is client-side dedupe UX. */}
+					<PaperDeployCard
+						strategyId={strategyId}
+						user={user}
+						onNavigate={onNavigate}
+					/>
 				</aside>
 
 				<div className="passport-evidence">
@@ -762,6 +774,102 @@ function Metric({ label, value, hint }) {
 			<div className="caption text-[var(--text-4)]">{label}</div>
 			<div className="text-[1.1rem] font-semibold tabular-nums">{value}</div>
 			{hint && <div className="caption text-[var(--text-4)]">{hint}</div>}
+		</div>
+	);
+}
+
+// Paper-trading CTA — the free, account-owned act-on step (MVP spine). Kept
+// separate from the vault Deploy card above: no wallet, no strictness gate,
+// nothing moves. The server permits duplicate deployments for one strategy,
+// so the "already running" state is client-side dedupe UX only.
+function PaperDeployCard({ strategyId, user, onNavigate }) {
+	const [existing, setExisting] = useState(null); // active deployment for THIS strategy
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState("");
+
+	useEffect(() => {
+		if (!user || !strategyId) return;
+		let cancelled = false;
+		apiGet("/api/paper/deployments")
+			.then((res) => {
+				if (cancelled) return;
+				const hit = (res.deployments || []).find(
+					(d) => d.strategy_id === strategyId && d.status === "active",
+				);
+				setExisting(hit || null);
+			})
+			.catch(() => {}); // decoration only — the CTA still works without it
+		return () => {
+			cancelled = true;
+		};
+	}, [user, strategyId]);
+
+	const start = async () => {
+		setBusy(true);
+		setError("");
+		try {
+			await apiPostWithMeta("/api/paper/deployments", {
+				strategy_id: strategyId,
+			});
+			onNavigate("paper");
+		} catch (e) {
+			if (e.status === 401) {
+				setError("Your session expired — sign in again to paper trade.");
+			} else if (e.detail?.reason === "no_strategy_spec") {
+				setError(
+					"This strategy has no machine-readable spec, so it cannot be paper-traded.",
+				);
+			} else if (e.detail?.reason === "invalid_strategy_spec") {
+				setError(
+					"This strategy's stored spec fails validation — it cannot be paper-traded.",
+				);
+			} else {
+				setError(e.detail?.message || e.message || "Paper deploy failed.");
+			}
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<div className="card fade-up fade-up-2" style={{ marginTop: 12 }}>
+			<div className="label mb-1">Paper trading</div>
+			<p className="caption leading-relaxed">
+				Simulated deployment — <strong>free, no funds move</strong>. Snapshots
+				this strategy's spec and appends one real-data return per trading day,
+				building the track record that carries to mainnet.
+			</p>
+			{error && (
+				<p className="caption" role="alert" style={{ color: "var(--danger, #b91c1c)", marginTop: 6 }}>
+					{error}
+				</p>
+			)}
+			<div style={{ marginTop: 10 }}>
+				{!user ? (
+					<a
+						className="btn btn-outline btn-sm"
+						href={`/sign-in?next=${encodeURIComponent(`/app/strategy/${strategyId}`)}`}
+					>
+						Sign in to paper trade →
+					</a>
+				) : existing ? (
+					<button
+						className="btn btn-outline btn-sm"
+						onClick={() => onNavigate("paper")}
+						title={`Active since ${existing.deployed_at}`}
+					>
+						Paper trading — day {existing.days} · view →
+					</button>
+				) : (
+					<button
+						className="btn btn-primary btn-sm"
+						disabled={busy}
+						onClick={start}
+					>
+						{busy ? "Deploying…" : "Start paper trading (free) →"}
+					</button>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -17,6 +17,7 @@ const APP_PATHS = {
   '/app/leaderboard': 'leaderboard',
   '/app/generate': 'generate',
   '/app/library': 'library',
+  '/app/paper': 'paper',
   '/app/corpus': 'corpus',
   '/app/quant': 'quant',
   '/app/portfolio': 'portfolio',

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -134,6 +134,7 @@ test("auth-required pages stay auth-required", () => {
 	for (const path of [
 		"/app/generate",
 		"/app/library",
+		"/app/paper",
 		"/app/account",
 	]) {
 		const route = resolveRoute(path);


### PR DESCRIPTION
## Summary

The paper-trading backend (#1268) was API-only — the MVP spine's final step (deploy a passing strategy to paper trading) worked for an agent with curl and not at all for a human in the browser. This adds the UI half.

### `/app/paper` — Paper Trading page

New page in the **Strategy** nav group (generate → library → **paper** → leaderboard), auth-required (not in `ANON_APP_PAGES`). Renders `GET /api/paper/deployments`:

- **ACTIVE / STOPPED** chip, plus a **DRIFT** chip when `drift_detected_at` is set (tooltip explains the frozen-ledger semantics).
- Day count (`days`), with an honest day-0 line ("first return lands with the next daily advance").
- `total_return` and an equity **sparkline** drawn from the summary's own `series[].equity_index` — no extra endpoints.
- **Stop** via `POST /api/paper/deployments/{id}/stop` with a confirm dialog (freeze-in-place wording — there is no restart).
- Strategy display names come from a best-effort client-side join against `/api/strategies/` + `/api/strategies/generated` (the paper API deliberately returns ids only); the list renders with raw ids if the join fails.
- Empty state routes to the Library.

### StrategyPassport — "Start paper trading (free)" card

Separate from the vault Deploy card: account-only, **no wallet, no strictness gate, nothing moves** — matching the server contract exactly (`paper_routes.py` requires only a Better Auth session + spec presence + visibility). Handles:

- **Already running** → "Paper trading — day N · view →" (client-side dedupe; the server permits duplicate deployments by design, there is no 409).
- **422** `no_strategy_spec` / `invalid_strategy_spec` → specific messages (real for some curated rows).
- **Anonymous reader** (the passport is a public page) → "Sign in to paper trade" with a `next=` return path.
- Success (201) → navigates to `/app/paper`.

The card is placed after the strictness slider and imports are non-adjacent, so this PR's hunks do not overlap #1266's edits to the same file — clean auto-merge in either merge order.

## Deliberately not in scope

- No rigor precondition on the CTA — deliberate mirror of the backend's contract (paper is the free act-on step; the gate verdict is displayed two cards up).
- No paper metrics beyond the summary payload; richer analytics belong with #63/#1217-era instrumentation.
- Onboarding-tour card for paper: follow-up, after #1266 lands (the tour's card list is edited by that PR).

## Verification

```
ui: node --test        0 fail (adds /app/paper to the auth-required route pin)
ui: npm run lint       clean
ui: npm run build      clean
backend: pytest backend/tests/test_breadcrumbs.py   5/5 (CRUMB_MAP sync holds)
```

Cross-review requested from the contracts session (backend-contract fit; its agent_journey paper step exercises the same POST + readback).
