### PR TITLE
Papers-consulted honesty: claim citations per candidate, never the depth knob

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -883,21 +883,16 @@ async def run_generation(
             except Exception as exc:
                 logger.warning("could not build per-job agent for model %r (%s); using default", model, exc)
                 job_agent = None
-        # Library = the candidate pool the agent reasons over; surface it so the UI
-        # can show "agent is considering N papers". The DSR multiple-testing count is
-        # the strategy's OWN candidate pool (computed per-candidate below), NOT the
-        # library size — a strategy's rigor depends only on itself (decouple #2).
-        try:
-            from archimedes.services.strategy_provider import default_provider
-
-            lib = default_provider().list_strategies()
-            arxiv_ids = [s.paper_arxiv_id for s in lib if getattr(s, "paper_arxiv_id", None)]
-        except Exception:
-            arxiv_ids = []
+        # No papers claim here — deliberately. This event fires BEFORE any
+        # corpus retrieval happens (paper selection runs inside each
+        # candidate's debate), so no honest papers count exists yet. The old
+        # payload sliced the CURATED LIBRARY's arxiv ids to max_papers, which
+        # made the stream claim a constant "N papers" from the wrong
+        # population at the wrong time. The real, provenance-checked citations
+        # ride each candidate_drafted event below instead.
         await emit.emit(
             "candidates_selected",
             candidate_count=len(regimes),
-            source_arxiv_ids=arxiv_ids[: brief.max_papers],
             regimes=regimes,
         )
 
@@ -950,6 +945,11 @@ async def run_generation(
                     strategy_name=entry.strategy_name,
                     weights_preview=entry.weights,
                     regime=regime,
+                    # The papers this accepted proposal actually cites —
+                    # provenance-checked against the corpus surface by the
+                    # debate critics (_critic_prov), never the depth knob.
+                    source_arxiv_ids=[aid for p in entry.source_papers if (aid := p.get("arxiv_id", ""))]
+                    or list(entry.source_arxiv_ids),
                 )
                 await emit.emit(
                     "candidate_evaluated",

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -1349,3 +1349,38 @@ async def test_no_llm_prod_shape_emits_generation_unavailable(monkeypatch):
     )
     statuses = [s[0] for s in store.status]
     assert "error" in statuses
+
+
+@pytest.mark.asyncio
+async def test_papers_claim_lives_on_candidate_drafted_not_candidates_selected():
+    """The stream's papers claim must come from each candidate's ACTUAL
+    citations, never the depth knob (task #54, claims-must-be-true):
+
+    - ``candidates_selected`` fires BEFORE any retrieval, so it must carry NO
+      papers field at all — the removed field sliced the curated library to
+      ``max_papers``, a constant count from the wrong population;
+    - every ``candidate_drafted`` carries ``source_arxiv_ids`` — the accepted
+      proposal's own citations (provenance-checked by the debate critics on
+      the live path; the fixture path threads its fixture citations through
+      the same emit).
+    """
+    store = _FakeStore()
+    brief = GenerateBrief(intent="13-week treasury alternative", risk_appetite="conservative")
+
+    with patch(
+        "archimedes.agents.generation_pipeline._persist_candidate",
+        new=AsyncMock(return_value=("strat_fixture_002", "0xdeadbeef")),
+    ):
+        await run_generation(job_id="job_papers_001", brief=brief, n_candidates=1, store=store)
+
+    selected = [e for e in store.events if e["event"] == "candidates_selected"]
+    assert len(selected) == 1
+    assert "source_arxiv_ids" not in selected[0]["data"], (
+        "candidates_selected must not claim papers — no retrieval has happened yet"
+    )
+
+    drafted = [e for e in store.events if e["event"] == "candidate_drafted"]
+    assert drafted
+    for e in drafted:
+        assert "source_arxiv_ids" in e["data"], "each drafted candidate must carry its own citations"
+        assert isinstance(e["data"]["source_arxiv_ids"], list)

--- a/docs/specs/generation-streaming-spec.md
+++ b/docs/specs/generation-streaming-spec.md
@@ -80,11 +80,11 @@ Each SSE event is `id: <monotonic_int>\nevent: <name>\ndata: <json>\n\n`.
 |---|---|---|
 | `job_queued` | `{ job_id, brief, ts }` | Immediately after `POST /api/generate/jobs`. |
 | `brief_validated` | `{ job_id, asset_classes, risk_appetite, time_horizon, ts }` | After LLM extracts structured intent from free-text brief. |
-| `candidates_selected` | `{ job_id, candidate_count, source_arxiv_ids: [...], ts }` | After agent selects candidate papers from corpus (typically 3-5). |
+| `candidates_selected` | `{ job_id, candidate_count, regimes, ts }` | Before per-candidate work begins. Carries **no papers claim** — paper selection happens inside each candidate's debate run, so no honest count exists at this point (the field previously here sliced the curated library to `max_papers`, a constant from the wrong population). |
 | `agent_iteration` | `{ job_id, iteration_n, max_iterations, ts }` | At the top of every `PortfolioAgent.recommend()` loop iteration. |
 | `tool_called` | `{ job_id, tool_name, args_summary, ts }` | When the agent invokes a tool (`get_asset_stats`, `get_correlation`, `stress_test`). |
 | `tool_result` | `{ job_id, tool_name, result_summary, ts }` | After the tool returns. `result_summary` is a 1-line human-readable summary, not the full payload. |
-| `candidate_drafted` | `{ job_id, candidate_id, strategy_name, weights_preview, ts }` | When the agent produces a candidate portfolio. Multiple may fire per job (per the locked decision, agent considers N internally). |
+| `candidate_drafted` | `{ job_id, candidate_id, strategy_name, weights_preview, regime, source_arxiv_ids: [...], ts }` | When the agent produces a candidate portfolio. Multiple may fire per job (per the locked decision, agent considers N internally). `source_arxiv_ids` are the papers the accepted proposal **actually cites**, provenance-checked against the corpus surface by the debate critics — never the `max_papers` depth knob. |
 | `candidate_evaluated` | `{ job_id, candidate_id, rigor_verdict: { dsr, pbo, oos_sharpe, lookahead_audit_passed, passes }, ts }` | After rigor gate runs on each candidate. |
 | `best_selected` | `{ job_id, best_candidate_id, considered_count, ts }` | When the agent picks the surfaced candidate from the considered set. |
 | `trace_hashed` | `{ job_id, trace_hash, ts }` | After the reasoning trace is committed to `AgentStateStore` and its keccak256 computed. |

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -49,19 +49,28 @@ function summarizeEvent(name, data) {
     case 'pipeline_selected':
       return `${data?.pipeline || '?'} — ${data?.reason || ''}`
     case 'candidates_selected':
-      return `Considering ${data?.candidate_count || '?'} candidates; ${(data?.source_arxiv_ids?.length || 0)} papers`
+      // No papers count here — paper retrieval happens inside each candidate's
+      // debate run, so no honest count exists yet. The real citations arrive
+      // per candidate on candidate_drafted below.
+      return `Considering ${data?.candidate_count || '?'} candidates`
     case 'agent_iteration':
       return `Iteration ${data?.iteration_n}/${data?.max_iterations} (${data?.candidate_id || ''})`
     case 'tool_called':
       return `${data?.tool_name}(${data?.args_summary || ''})`
     case 'tool_result':
       return `${data?.tool_name} → ${data?.result_summary || 'ok'}`
-    case 'candidate_drafted':
+    case 'candidate_drafted': {
+      // Papers count comes from the candidate's ACTUAL, provenance-checked
+      // citations (source_arxiv_ids on the event) — omitted when absent,
+      // never invented.
+      const nPapers = data?.source_arxiv_ids?.length || 0
       return (
         <>
           <RegimeIcon regime={data?.regime} /> {data?.strategy_name || '?'} ({data?.candidate_id})
+          {nPapers > 0 ? ` — grounded in ${nPapers} paper${nPapers === 1 ? '' : 's'}` : ''}
         </>
       )
+    }
     case 'candidate_evaluated': {
       const v = data?.rigor_verdict || {}
       const bits = []

--- a/ui/test/app-visuals.test.js
+++ b/ui/test/app-visuals.test.js
@@ -122,3 +122,18 @@ test("app motion and core workspaces respect narrow or reduced-motion contexts",
 		/@media \(max-width: 900px\)[^{]*\{[\s\S]*?\.generate-workbench,[\s\S]*?\.passport-workspace,[\s\S]*?\.portfolio-workspace\s*\{[^}]*grid-template-columns:\s*1fr;/s,
 	);
 });
+
+const generationStream = readFileSync(
+	new URL("../src/components/GenerationStream.jsx", import.meta.url),
+	"utf8",
+);
+
+test("generation stream claims papers only from real per-candidate citations (task #54)", () => {
+	// The old candidates_selected line rendered a papers COUNT sliced from the
+	// curated library (a constant from the wrong population) — it must not return.
+	assert.doesNotMatch(generationStream, /candidates;.*papers/);
+	// The honest claim: candidate_drafted's own provenance-checked citations,
+	// omitted when absent.
+	assert.match(generationStream, /case 'candidate_drafted'[\s\S]{0,400}source_arxiv_ids/);
+	assert.match(generationStream, /grounded in \$\{nPapers\}/);
+});


### PR DESCRIPTION
## The defect (task from the UI-lane session's audit queue)

`candidates_selected` emitted `source_arxiv_ids` sliced from the **curated library** to `max_papers` — before any retrieval, from the wrong population, effectively a constant — and `GenerationStream` rendered its length as "Considering X candidates; **N papers**". The streaming spec always described this field as papers selected from the corpus; the implementation never was. (The per-candidate provenance itself was already honest: the debate critics' `_critic_prov` drops any proposal citing papers outside the corpus surface.)

## The fix

- `candidates_selected` carries **no papers claim** — none honestly exists at that point.
- `candidate_drafted` now carries `source_arxiv_ids` — on the LIVE path, the accepted proposal's **actual citations, provenance-checked by the debate critics**; the fixture path threads its (unverified, demo-labeled) fixture citations through the same emit. The stream renders "grounded in K papers" per candidate from that real list, omitted when absent, never invented.
- `docs/specs/generation-streaming-spec.md` updated on both event rows.
- Non-zero-when-retrieval-returned-rows holds structurally for accepted live candidates: fusion validity requires `len(source_arxiv_ids) >= MIN_PAPERS`.

## Guards (mutations built, run, reverted)

- Backend: re-adding `source_arxiv_ids` to `candidates_selected` → `test_papers_claim_lives_on_candidate_drafted_not_candidates_selected` **fails** (1 failed).
- UI: restoring the old count template → the new static-source test in `app-visuals.test.js` **fails** (55 pass, 1 fail).

Backend 29/29 (pipeline suite), UI 56/56, ruff + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7