### PR TITLE
Scope the leaderboard caveat banner: curated verified clean, own view keeps both residuals

### DIFF
--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -180,10 +180,13 @@ export default function Leaderboard() {
             the backtest's position FSM) and F3 (rebalance cadence never read
             live) are prepared and HELD for the live-money go-ahead — and
             exit + rebalance_frequency are REQUIRED DSL fields, so every
-            generated strategy carries them. Hence the narrower banner below,
-            scoped to the own view (generated strategies someone may actually
-            run live); curated rows are reference-only backtests, where the
-            remaining divergence makes no claim. */}
+            generated strategy carries them. The own view ALSO still holds
+            July-era rows for older generated strategies (21 ids at the time
+            of verification) that predate the corrections and refresh on
+            their next cycle. Hence the narrower banner below, scoped to the
+            own view and carrying BOTH residuals; curated rows are
+            reference-only backtests, all verified fresh, where neither
+            residual makes a claim. */}
         {isOwn && (
           <div
             role="status"
@@ -197,11 +200,12 @@ export default function Leaderboard() {
               color: 'var(--text-2)',
             }}
           >
-            <strong style={{ color: 'var(--warning, #b45309)' }}>Backtest figures — live behaviour can differ.</strong>{' '}
-            These numbers are computed correctly by the backtest engine, but live execution currently
-            interprets entry/exit state and rebalance cadence differently than the backtest does — so a
-            strategy run live may not behave exactly as these figures describe. A fix is prepared and
-            awaiting live-trading sign-off.
+            <strong style={{ color: 'var(--warning, #b45309)' }}>Two caveats on your figures.</strong>{' '}
+            Older strategies may still show numbers computed before the August engine corrections —
+            they refresh on their next backtest cycle. And live execution currently interprets
+            entry/exit state and rebalance cadence differently than the backtest does, so a strategy
+            run live may not behave exactly as its figures describe; a fix is prepared and awaiting
+            live-trading sign-off.
           </div>
         )}
         {engine?.disclaimer && (

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -170,37 +170,11 @@ export default function Leaderboard() {
             </button>
           </div>
         )}
-        {/* PROVISIONAL-DATA BANNER — remove this whole block once the backtest
-            re-run completes and the figures below are trustworthy again.
-            A routing defect (fixed in #1203) meant most library strategies were
-            backtested against a hardcoded SPY default instead of their own
-            declared ASSET_UNIVERSE. Cross-sectional strategies fared worst:
-            given a single feed they had nothing to rank, so they emitted zero
-            trades and a flat 0% return, which the rigor gate then graded as
-            though it were a result.
-            Saying so out loud is the only option consistent with the product's
-            own thesis: taking the page down would hide the demonstration, and
-            leaving it silently wrong is the exact failure this product exists
-            to oppose. */}
-        <div
-          role="status"
-          style={{
-            marginTop: 10,
-            padding: '10px 14px',
-            borderLeft: '3px solid var(--warning, #b45309)',
-            background: 'var(--warning-bg, rgba(180,83,9,0.10))',
-            borderRadius: 4,
-            fontSize: 13,
-            color: 'var(--text-2)',
-          }}
-        >
-          <strong style={{ color: 'var(--warning, #b45309)' }}>Provisional — figures are being re-computed.</strong>{' '}
-          Two defects are being corrected. A routing defect meant most strategies were backtested against the
-          wrong asset universe. Separately, the backtest and live-trading engines were found to interpret the
-          same strategy differently — so for some strategies these figures describe behaviour that differs
-          from what the strategy would actually do. Figures shown are known to be incorrect and will change.
-        </div>
-
+        {/* The provisional-data banner that lived here (routing defect #1203 +
+            backtest/live interpreter divergences) was removed 2026-08-19 after
+            its stated condition was verified against prod: the post-fix re-run
+            landed fresh rows for every curated strategy (backtest_results max
+            created_at 2026-08-20 03:28 UTC; zero curated strategies stale). */}
         {engine?.disclaimer && (
           <div style={{ marginTop: 10, padding: '8px 12px', borderLeft: '3px solid var(--accent)', background: 'var(--accent-muted)', borderRadius: 4, fontSize: 13, color: 'var(--text-2)' }}>
             <strong style={{ color: 'var(--accent)' }}>Testnet — paper/simulated.</strong> {engine.disclaimer}

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -170,11 +170,40 @@ export default function Leaderboard() {
             </button>
           </div>
         )}
-        {/* The provisional-data banner that lived here (routing defect #1203 +
-            backtest/live interpreter divergences) was removed 2026-08-19 after
-            its stated condition was verified against prod: the post-fix re-run
-            landed fresh rows for every curated strategy (backtest_results max
-            created_at 2026-08-20 03:28 UTC; zero curated strategies stale). */}
+        {/* The broad provisional-data banner that lived here named TWO defects.
+            The routing defect (#1203) is retired everywhere: the post-fix
+            re-run landed fresh rows for every curated strategy (verified
+            against prod 2026-08-19 — backtest_results max created_at
+            2026-08-20 03:28 UTC; zero curated strategies stale). The
+            backtest/live interpreter divergence is retired only in part:
+            F1/F4–F10 are fixed, but F2 (stateless entry-AND-NOT-exit live vs
+            the backtest's position FSM) and F3 (rebalance cadence never read
+            live) are prepared and HELD for the live-money go-ahead — and
+            exit + rebalance_frequency are REQUIRED DSL fields, so every
+            generated strategy carries them. Hence the narrower banner below,
+            scoped to the own view (generated strategies someone may actually
+            run live); curated rows are reference-only backtests, where the
+            remaining divergence makes no claim. */}
+        {isOwn && (
+          <div
+            role="status"
+            style={{
+              marginTop: 10,
+              padding: '10px 14px',
+              borderLeft: '3px solid var(--warning, #b45309)',
+              background: 'var(--warning-bg, rgba(180,83,9,0.10))',
+              borderRadius: 4,
+              fontSize: 13,
+              color: 'var(--text-2)',
+            }}
+          >
+            <strong style={{ color: 'var(--warning, #b45309)' }}>Backtest figures — live behaviour can differ.</strong>{' '}
+            These numbers are computed correctly by the backtest engine, but live execution currently
+            interprets entry/exit state and rebalance cadence differently than the backtest does — so a
+            strategy run live may not behave exactly as these figures describe. A fix is prepared and
+            awaiting live-trading sign-off.
+          </div>
+        )}
         {engine?.disclaimer && (
           <div style={{ marginTop: 10, padding: '8px 12px', borderLeft: '3px solid var(--accent)', background: 'var(--accent-muted)', borderRadius: 4, fontSize: 13, color: 'var(--text-2)' }}>
             <strong style={{ color: 'var(--accent)' }}>Testnet — paper/simulated.</strong> {engine.disclaimer}

--- a/ui/test/app-visuals.test.js
+++ b/ui/test/app-visuals.test.js
@@ -137,3 +137,22 @@ test("generation stream claims papers only from real per-candidate citations (ta
 	assert.match(generationStream, /case 'candidate_drafted'[\s\S]{0,400}source_arxiv_ids/);
 	assert.match(generationStream, /grounded in \$\{nPapers\}/);
 });
+
+const leaderboard = readFileSync(
+	new URL("../src/components/Leaderboard.jsx", import.meta.url),
+	"utf8",
+);
+
+test("leaderboard caveat banner is own-scope-gated and carries both residuals (#1306)", () => {
+	// The broad unconditional banner ("known to be incorrect") is retired for
+	// the curated view, whose freshness was verified against prod.
+	assert.doesNotMatch(leaderboard, /known to be incorrect/);
+	// The remaining banner renders ONLY under isOwn — the gate expression must
+	// immediately precede the banner's status div.
+	assert.match(leaderboard, /\{isOwn && \(\s*<div\s*\n?\s*role="status"/);
+	// Both residuals, by their load-bearing phrases: pre-correction rows that
+	// refresh later, and the held backtest/live interpreter divergence.
+	assert.match(leaderboard, /before the August engine corrections/);
+	assert.match(leaderboard, /entry\/exit state and rebalance cadence/);
+	assert.match(leaderboard, /awaiting\s*\n?\s*live-trading sign-off/);
+});


### PR DESCRIPTION
Splits the old provisional banner by scope — the banner named TWO defects; verification supports retiring it only where both are actually resolved.

**Curated view — banner removed.** Routing-defect (#1203) re-run verified against prod via ECS exec: `backtest_results` max `created_at` = **2026-08-20 03:28 UTC**, 540/614 rows since Aug 18, **zero curated strategies stale**. Curated rows are reference-only backtests; neither residual below makes a claim about them.

**Own view — a narrower banner naming BOTH residuals** (round-3 review correction — the first rewrite claimed all figures were computed correctly, which was false for the July-era rows this PR's own evidence identified):
1. Older generated strategies (21 ids at verification) may still show pre-correction numbers until their next refresh cycle.
2. Live execution interprets entry/exit state and rebalance cadence differently than the backtest (F2/F3 — prepared, held for live-trading sign-off; `exit` + `rebalance_frequency` are required DSL fields so this touches every generated strategy).

**Test**: a static-source test pins the `isOwn` gating (mutation-proven — ungating the banner fails it), the retirement of the unconditional "known to be incorrect" banner, and both residual phrases. UI 61/61 post-rebase onto current main (both same-anchor test blocks — #1304's generationStream pin and this PR's leaderboard pin — verified present after the conflict resolution), eslint clean. Branch 0-behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7