### PR TITLE
archimedes-cli 0.1.0: login, meter, verify + usage & rigor-verify endpoints + skill !minor

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -134,6 +134,13 @@ jobs:
           pip install --quiet -r /tmp/req-ci.txt "pytest>=8.3" "pytest-asyncio>=0.24" "pytest-cov>=5.0" "fakeredis[lua]>=2.26.0"
       - name: Test
         run: pytest -m "not integration" --tb=short -q
+      - name: CLI tests
+        # archimedes-cli has its own small suite (click + httpx, mocked at the
+        # boundary, no network) — running it here makes the CLI's test claims
+        # CI-backed instead of author-attested (#1307 review finding).
+        run: |
+          pip install --quiet -e ./cli
+          python -m pytest cli/tests --tb=short -q
 
   frontend-and-auth:
     name: Frontend + Better Auth

--- a/backend/archimedes/api/account_usage_routes.py
+++ b/backend/archimedes/api/account_usage_routes.py
@@ -1,0 +1,82 @@
+"""``GET /api/account/usage`` — the CLI's ``meter`` command backend (#1305).
+
+Reports the caller's daily generation-quota usage against the SAME two Redis
+buckets ``services/generation_quota.py`` enforces (``GenerationQuota.peek`` —
+a read, never a write — added there for exactly this route; enforcement in
+``enforce_generation_quota`` is untouched), plus the current price quote from
+``generation_payment.quote()``. Both the enforcement path
+(``POST /api/generate/start``) and this display path read the price from the
+same ``quote()`` call, so the CLI's number and the API's number can never
+drift apart.
+
+Account-session-gated (Better Auth, ``require_current_user``) — mirrors
+``paper_routes.py``'s per-route ``Depends`` style, not the router-level
+``dependencies=[...]`` style some other routers use in ``main.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from archimedes.api.account_auth import CurrentUser, require_current_user
+from archimedes.services import generation_payment
+from archimedes.services.generation_quota import (
+    GenerationQuota,
+    client_ip,
+    ip_daily_cap,
+    user_daily_cap,
+)
+
+account_usage_router = APIRouter(prefix="/api/account", tags=["account"])
+
+
+class DailyCapUsage(BaseModel):
+    """One bucket's usage today. ``used`` is honestly ``None`` — never a
+    fabricated ``0`` — when the quota backend could not be reached."""
+
+    used: int | None = None
+    cap: int
+    unlimited: bool
+    remaining: int | None = None
+    error: str | None = None
+
+
+class AccountUsageResponse(BaseModel):
+    date: str  # UTC day, YYYY-MM-DD — the same day-bucket key generation_quota uses
+    user_id: str
+    user: DailyCapUsage
+    ip: DailyCapUsage
+    quote: dict
+
+
+def _bucket(used: int | None, cap: int) -> DailyCapUsage:
+    unlimited = cap <= 0
+    if used is None:
+        return DailyCapUsage(used=None, cap=cap, unlimited=unlimited, remaining=None, error="quota_backend_unavailable")
+    remaining = None if unlimited else max(0, cap - used)
+    return DailyCapUsage(used=used, cap=cap, unlimited=unlimited, remaining=remaining, error=None)
+
+
+@account_usage_router.get("/usage", response_model=AccountUsageResponse)
+async def get_account_usage(
+    request: Request,
+    user: CurrentUser = Depends(require_current_user),
+):
+    """Today's generation usage vs both daily caps, plus the live price quote."""
+    quota = GenerationQuota()
+    try:
+        user_used = await quota.peek("user", user.id)
+        ip_used = await quota.peek("ip", client_ip(request))
+    finally:
+        await quota.close()
+
+    return AccountUsageResponse(
+        date=datetime.now(UTC).strftime("%Y-%m-%d"),
+        user_id=user.id,
+        user=_bucket(user_used, user_daily_cap()),
+        ip=_bucket(ip_used, ip_daily_cap()),
+        quote=generation_payment.quote(),
+    )

--- a/backend/archimedes/api/rigor_verify_routes.py
+++ b/backend/archimedes/api/rigor_verify_routes.py
@@ -1,0 +1,215 @@
+"""``POST /api/rigor/verify`` — the CLI's ``verify`` command backend (#1305).
+
+Runs the rigor gate's admission checks over a BARE returns series (no
+strategy code, no trial matrix) submitted directly by a caller — the CLI's
+``archimedes verify RETURNS_CSV``. Reuses the exact same computational
+functions the strategy-passport verdict uses
+(``archimedes.services.rigor_evaluator`` / ``_rigor_helpers`` via it, and the
+SAME threshold constants from ``rigor_profiles``) — no reimplementation, no
+new thresholds, per the issue spec.
+
+**Honesty contract (load-bearing).** The gate is four checks. A single
+returns series can only ever support two of them:
+
+  * **DSR** — evaluable. Deflated by the *declared* (self-attested) ``trials``
+    count via ``compute_dsr_hac_and_iid`` (the identical function
+    ``run_rigor_gate`` calls), gated against ``DSR_P_FLOOR`` — the always-on,
+    strictness-independent correctness floor (``rigor_profiles.DSR_P_FLOOR``),
+    not a strictness-adjustable per-level threshold, since this endpoint takes
+    no strictness parameter.
+  * **walk-forward OOS consistency** — evaluable. ``compute_oos_sharpe``
+    (single chronological 70/30 holdout, the same function the gate uses)
+    gated against ``OOS_ABS_FLOOR`` — the identical always-on floor
+    ``RigorGateResult.blocked_by_floor`` enforces.
+  * **PBO** — ALWAYS ``not_evaluable``. Probability of backtest overfitting
+    (Bailey et al. 2014 CSCV) is a property of a *selection set* — it needs a
+    trial matrix of multiple candidate strategies' returns over the same
+    window. A bare series has no selection set to measure overfitting
+    probability against, so this is reported honestly rather than silently
+    passed, defaulted, or graded as a FAIL it was never evaluated for.
+  * **look-ahead audit** — ALWAYS ``not_evaluable``. The audit is AST-based
+    static analysis of strategy source code; a returns series carries no code.
+    Archimedes never executes or uploads strategy code server-side (the
+    README's hard boundary) — this endpoint accepts only numbers, on purpose.
+
+``passes`` is ``True`` iff no EVALUABLE check failed AND at least one check
+was evaluable — a request where every check is ``not_evaluable`` (e.g. a
+too-short series) must not report ``passes=True`` by vacuous truth.
+
+Account-session-gated (Better Auth) + rate-limited ``5/minute`` per the issue
+spec, mirroring ``paper_routes.py`` / ``selection_bias_routes.py`` style.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import BaseModel, Field
+
+from archimedes.api.account_auth import CurrentUser, require_current_user
+from archimedes.api.limiter import limiter
+from archimedes.services.rigor_evaluator import (
+    compute_dsr_hac_and_iid,
+    compute_in_sample_sharpe,
+    compute_oos_sharpe,
+)
+from archimedes.services.rigor_profiles import DSR_P_FLOOR, OOS_ABS_FLOOR
+
+rigor_verify_router = APIRouter(prefix="/api/rigor", tags=["rigor"])
+
+CheckStatus = Literal["pass", "fail", "not_evaluable"]
+
+_PBO_NOT_EVALUABLE_REASON = (
+    "PBO (probability of backtest overfitting, Bailey et al. 2014 CSCV) is a property "
+    "of a SELECTION SET, not one series — it requires a trial matrix of multiple "
+    "candidate strategies' returns over the same window. A single returns series has "
+    "no selection set to measure overfitting probability against. "
+    "See POST /api/selection-bias/pbo for the trial-matrix form."
+)
+_LOOK_AHEAD_NOT_EVALUABLE_REASON = (
+    "The look-ahead audit is AST-based static analysis of strategy SOURCE CODE; a "
+    "bare returns series carries no code to inspect. Archimedes never executes or "
+    "uploads strategy code server-side, so this check can only ever run locally "
+    "(see `archimedes verify --local`)."
+)
+
+
+# ── Schemas ──────────────────────────────────────────────────
+
+
+class ReturnPoint(BaseModel):
+    date: str
+    daily_return: float
+
+
+class RigorVerifyRequest(BaseModel):
+    returns: list[ReturnPoint] = Field(min_length=1)
+    trials: int = Field(default=1, ge=1, description="Self-attested trial count for the DSR deflation.")
+
+
+class RigorCheck(BaseModel):
+    status: CheckStatus
+    reason: str | None = None
+
+
+class DsrCheckResult(RigorCheck):
+    deflated_sharpe: float | None = None
+    dsr_p_value: float | None = None
+
+
+class OosConsistencyResult(RigorCheck):
+    oos_sharpe: float | None = None
+    in_sample_sharpe: float | None = None
+
+
+class RigorVerifyResponse(BaseModel):
+    passes: bool
+    trials: int
+    self_attested: bool = True
+    n_bars: int
+    dsr: DsrCheckResult
+    pbo: RigorCheck
+    oos_consistency: OosConsistencyResult
+    look_ahead: RigorCheck
+
+
+# ── Check evaluators (thin wrappers over the SAME gate functions) ──────
+
+
+def _evaluate_dsr(daily_returns: list[float], trials: int) -> DsrCheckResult:
+    """DSR, deflated by the declared (self-attested) trial count.
+
+    Calls the identical ``compute_dsr_hac_and_iid`` the passport gate calls
+    (Newey-West HAC standard error, ``average_correlation=0.0`` — a bare
+    series carries no cohort/variant-pool correlation context to supply, the
+    same conservative default ``run_rigor_gate`` falls back to). Gated against
+    ``DSR_P_FLOOR`` — the always-on floor, not a strictness-level threshold,
+    since this endpoint takes no strictness parameter.
+    """
+    deflated_sharpe, p_value, _dsr_iid, _p_iid = compute_dsr_hac_and_iid(
+        daily_returns, trials, average_correlation=0.0, hac_lags="auto"
+    )
+    if deflated_sharpe is None or p_value is None or not math.isfinite(deflated_sharpe) or not math.isfinite(p_value):
+        return DsrCheckResult(
+            status="not_evaluable",
+            reason="return series too short or degenerate for DSR (need >= 4 bars with nonzero variance)",
+        )
+    passed = p_value >= DSR_P_FLOOR
+    reason = (
+        f"self-attested trials={trials}: DSR p-value {p_value:.4f} "
+        f"{'>=' if passed else '<'} floor {DSR_P_FLOOR:.2f} (Newey-West HAC standard error)"
+    )
+    return DsrCheckResult(
+        status="pass" if passed else "fail",
+        reason=reason,
+        deflated_sharpe=deflated_sharpe,
+        dsr_p_value=p_value,
+    )
+
+
+def _evaluate_oos_consistency(daily_returns: list[float]) -> OosConsistencyResult:
+    """Walk-forward OOS consistency — the same chronological 70/30 holdout the
+    passport gate uses (``compute_oos_sharpe``), gated against
+    ``OOS_ABS_FLOOR`` — the identical always-on floor
+    ``RigorGateResult.blocked_by_floor`` enforces (a strategy that loses money
+    out-of-sample is broken, not merely riskier)."""
+    oos_sharpe = compute_oos_sharpe(daily_returns)
+    if oos_sharpe is None or not math.isfinite(oos_sharpe):
+        return OosConsistencyResult(
+            status="not_evaluable",
+            reason=(
+                "insufficient data for a walk-forward OOS split "
+                "(need >= 10 bars total and >= 21 OOS bars, or a degenerate slice)"
+            ),
+        )
+    in_sample_sharpe = compute_in_sample_sharpe(daily_returns)
+    passed = oos_sharpe > OOS_ABS_FLOOR
+    if passed:
+        reason = f"walk-forward OOS Sharpe {oos_sharpe:.4f} > floor {OOS_ABS_FLOOR:.2f} (chronological 70/30 holdout)"
+    else:
+        reason = (
+            f"walk-forward OOS Sharpe {oos_sharpe:.4f} <= floor {OOS_ABS_FLOOR:.2f} "
+            "— strategy loses money out-of-sample"
+        )
+    return OosConsistencyResult(
+        status="pass" if passed else "fail",
+        reason=reason,
+        oos_sharpe=oos_sharpe,
+        in_sample_sharpe=in_sample_sharpe,
+    )
+
+
+# ── Endpoint ─────────────────────────────────────────────────
+
+
+@rigor_verify_router.post("/verify", response_model=RigorVerifyResponse)
+@limiter.limit("5/minute")
+async def verify_rigor(
+    request: Request,  # noqa: ARG001 — slowapi @limiter.limit inspects param name
+    response: Response,  # noqa: ARG001 — slowapi injects rate-limit headers into it; omitting it 500s every SUCCESSFUL call (#1182)
+    body: RigorVerifyRequest,
+    user: CurrentUser = Depends(require_current_user),  # noqa: ARG001 — auth gate only; verdict is per-request
+):
+    daily_returns = [pt.daily_return for pt in body.returns]
+
+    dsr_check = _evaluate_dsr(daily_returns, body.trials)
+    oos_check = _evaluate_oos_consistency(daily_returns)
+    pbo_check = RigorCheck(status="not_evaluable", reason=_PBO_NOT_EVALUABLE_REASON)
+    look_ahead_check = RigorCheck(status="not_evaluable", reason=_LOOK_AHEAD_NOT_EVALUABLE_REASON)
+
+    statuses = [dsr_check.status, pbo_check.status, oos_check.status, look_ahead_check.status]
+    evaluable = [s for s in statuses if s != "not_evaluable"]
+    passes = bool(evaluable) and all(s == "pass" for s in evaluable)
+
+    return RigorVerifyResponse(
+        passes=passes,
+        trials=body.trials,
+        self_attested=True,
+        n_bars=len(daily_returns),
+        dsr=dsr_check,
+        pbo=pbo_check,
+        oos_consistency=oos_check,
+        look_ahead=look_ahead_check,
+    )

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -39,6 +39,7 @@ if os.getenv("PUBLIC_DOMAIN"):
 # Shared rate limiter (Redis-backed, falls back to in-memory).
 # Defined in a separate module to avoid circular imports with route modules.
 from archimedes.api.account_auth import better_auth_session_middleware, require_current_user
+from archimedes.api.account_usage_routes import account_usage_router
 from archimedes.api.agent_manifest_routes import agent_manifest_router
 from archimedes.api.chat_routes import chat_router
 from archimedes.api.corpus_routes import corpus_router
@@ -69,6 +70,7 @@ from archimedes.api.metrics_private_routes import metrics_private_router
 from archimedes.api.metrics_routes import metrics_router
 from archimedes.api.portfolio_routes import portfolio_router
 from archimedes.api.proposals_routes import proposals_router
+from archimedes.api.rigor_verify_routes import rigor_verify_router
 from archimedes.api.risk_routes import risk_router
 from archimedes.api.routes import (
     agent_router,
@@ -508,6 +510,8 @@ if marketplace_router is not None:
 app.include_router(risk_router)
 app.include_router(portfolio_router, dependencies=[Depends(require_current_user)])
 app.include_router(selection_bias_router)
+app.include_router(rigor_verify_router)
+app.include_router(account_usage_router)
 app.include_router(papers_router)
 app.include_router(user_router, dependencies=[Depends(require_current_user)])
 app.include_router(wallet_router)

--- a/backend/archimedes/services/generation_quota.py
+++ b/backend/archimedes/services/generation_quota.py
@@ -190,10 +190,13 @@ class GenerationQuota:
             day = datetime.now(UTC).strftime("%Y-%m-%d")
             key = f"archimedes:genquota:{scope}:{day}:{identity}"
             val = await r.get(key)
+            # int() stays INSIDE the try: a corrupt/non-numeric stored value is
+            # the same "unknown" as an unreachable Redis — the promised None,
+            # never a raised ValueError surfacing as a 500 on a display read.
+            return int(val) if val is not None else 0
         except Exception as exc:
             logger.warning("generation quota peek failed for %s=%s: %s", scope, identity, exc)
             return None
-        return int(val) if val is not None else 0
 
     async def close(self) -> None:
         if self._redis:

--- a/backend/archimedes/services/generation_quota.py
+++ b/backend/archimedes/services/generation_quota.py
@@ -167,6 +167,34 @@ class GenerationQuota:
 
         return (count <= cap, int(count))
 
+    async def peek(self, scope: str, identity: str) -> int | None:
+        """Read (never increment) today's count for ``scope:identity``.
+
+        Companion to :meth:`check_and_increment` for DISPLAY-only reads (e.g.
+        ``GET /api/account/usage``) — it never touches enforcement and never
+        writes. Uses the exact same key format and UTC-day bucketing as the
+        enforcement path, so a peek always reads the same counter a concurrent
+        ``check_and_increment`` would be incrementing.
+
+        Returns the current count (``0`` when the key has never been written
+        today), or ``None`` on a Redis error. ``None`` is a DIFFERENT signal
+        than ``check_and_increment``'s fail-closed ``(False, 0)`` — this method
+        backs a read-only display, not a gate, so the honest degraded state is
+        "unknown" (``None``), never a fabricated ``0`` that would tell a caller
+        they have used nothing when the truth is merely unreachable (the
+        repo's fail-soft rule: an outage renders as a loud absence, not a
+        plausible substitute).
+        """
+        try:
+            r = await self._get_redis()
+            day = datetime.now(UTC).strftime("%Y-%m-%d")
+            key = f"archimedes:genquota:{scope}:{day}:{identity}"
+            val = await r.get(key)
+        except Exception as exc:
+            logger.warning("generation quota peek failed for %s=%s: %s", scope, identity, exc)
+            return None
+        return int(val) if val is not None else 0
+
     async def close(self) -> None:
         if self._redis:
             try:

--- a/backend/tests/test_account_usage_routes.py
+++ b/backend/tests/test_account_usage_routes.py
@@ -1,0 +1,193 @@
+"""``GET /api/account/usage`` — the CLI ``meter`` command backend (#1305).
+
+Covers:
+
+  1. the route 401s without a Better Auth session (mirrors
+     ``test_paper_routes_auth.py``'s auth-swap contract);
+  2. usage reads the SAME Redis buckets ``enforce_generation_quota`` writes —
+     ``GenerationQuota.peek`` reads the identical
+     ``archimedes:genquota:{scope}:{day}:{identity}`` key format, proven here
+     by driving a real (mocked-at-the-Redis-boundary) ``GenerationQuota``
+     instance through both a peek and a real increment and checking they see
+     the same counter, not two independently-behaving code paths;
+  3. the price quote embedded in the response is the literal
+     ``generation_payment.quote()`` dict — never a re-derived number;
+  4. a Redis outage renders as an honest ``used: null`` +
+     ``error: "quota_backend_unavailable"``, never a fabricated ``0`` (the
+     repo's fail-soft rule) — the ADVERSARIAL case: an outage that a naive
+     implementation would silently report as "0 used, plenty of room left".
+
+Hermetic: mocks the Better Auth session fetch and the Redis client at
+``GenerationQuota._get_redis`` (the same boundary
+``test_generation_quota.py`` mocks) — no live Redis, no live DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from archimedes.api import account_auth, account_usage_routes
+from archimedes.services.generation_quota import GenerationQuota
+from fastapi import FastAPI
+
+
+@pytest.fixture()
+def app():
+    application = FastAPI()
+    application.middleware("http")(account_auth.better_auth_session_middleware)
+    application.include_router(account_usage_routes.account_usage_router)
+    return application
+
+
+def _session_for(user_id: str):
+    async def fetch(_request):
+        return {
+            "user": {"id": user_id, "name": user_id, "email": f"{user_id}@example.com", "emailVerified": True},
+            "session": {"id": f"s-{user_id}", "expiresAt": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+        }
+
+    return fetch
+
+
+def _sign_in(monkeypatch, user_id: str = "user-1"):
+    monkeypatch.setattr(account_auth, "_fetch_session", _session_for(user_id))
+
+
+def _client(app):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"cookie": "better-auth.session_token=opaque", "host": "archimedes-arc.com"},
+    )
+
+
+def _mock_redis(get_returns: dict[str, str | None] | None = None):
+    """A MagicMock redis client whose GET reads from a plain dict, so a peek
+    and a subsequent real check_and_increment (via .incr) can be composed in
+    the same test to prove they touch the same key space."""
+    store: dict[str, str] = dict(get_returns or {})
+    r = MagicMock()
+
+    async def _get(key):
+        return store.get(key)
+
+    async def _incr(key):
+        store[key] = str(int(store.get(key, "0")) + 1)
+        return int(store[key])
+
+    r.get = AsyncMock(side_effect=_get)
+    r.incr = AsyncMock(side_effect=_incr)
+    r.expire = AsyncMock(return_value=True)
+    return r, store
+
+
+# ── 1. Auth gate ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_usage_requires_a_better_auth_session(app, monkeypatch):
+    monkeypatch.setattr(account_auth, "_fetch_session", AsyncMock(return_value=None))
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/account/usage")
+    assert resp.status_code == 401
+
+
+# ── 2. Reads the SAME buckets enforcement writes ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_usage_reads_the_same_bucket_enforcement_increments(app, monkeypatch):
+    _sign_in(monkeypatch, "user-abc")
+    redis_mock, _store = _mock_redis()
+    monkeypatch.setattr(GenerationQuota, "_get_redis", AsyncMock(return_value=redis_mock))
+    monkeypatch.setattr(account_usage_routes, "client_ip", lambda _r: "203.0.113.9")
+    monkeypatch.setattr(account_usage_routes, "user_daily_cap", lambda: 10)
+    monkeypatch.setattr(account_usage_routes, "ip_daily_cap", lambda: 20)
+
+    # Simulate 3 prior generations via the REAL enforcement key format.
+    quota = GenerationQuota()
+    for _ in range(3):
+        await quota.check_and_increment("user", "user-abc", 10)
+
+    async with _client(app) as client:
+        resp = await client.get("/api/account/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["user_id"] == "user-abc"
+    assert body["user"]["used"] == 3
+    assert body["user"]["cap"] == 10
+    assert body["user"]["remaining"] == 7
+    assert body["user"]["unlimited"] is False
+    assert body["user"]["error"] is None
+    assert body["ip"]["used"] == 0
+    assert body["ip"]["cap"] == 20
+    assert body["ip"]["remaining"] == 20
+    # UTC day bucket, sanity-shaped.
+    assert body["date"] == datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+@pytest.mark.asyncio
+async def test_usage_unlimited_cap_reports_no_remaining_ceiling(app, monkeypatch):
+    _sign_in(monkeypatch, "user-unlimited")
+    redis_mock, _store = _mock_redis()
+    monkeypatch.setattr(GenerationQuota, "_get_redis", AsyncMock(return_value=redis_mock))
+    monkeypatch.setattr(account_usage_routes, "client_ip", lambda _r: "203.0.113.9")
+    monkeypatch.setattr(account_usage_routes, "user_daily_cap", lambda: 0)  # <=0 disables the layer
+    monkeypatch.setattr(account_usage_routes, "ip_daily_cap", lambda: 20)
+
+    async with _client(app) as client:
+        resp = await client.get("/api/account/usage")
+    body = resp.json()
+    assert body["user"]["unlimited"] is True
+    assert body["user"]["remaining"] is None
+
+
+# ── 3. quote() is the single source of the price ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_usage_embeds_the_literal_generation_payment_quote(app, monkeypatch):
+    _sign_in(monkeypatch)
+    redis_mock, _store = _mock_redis()
+    monkeypatch.setattr(GenerationQuota, "_get_redis", AsyncMock(return_value=redis_mock))
+    monkeypatch.setattr(account_usage_routes, "client_ip", lambda _r: "203.0.113.9")
+
+    sentinel_quote = {"price": "$0.42", "asset": "USDC", "pricing_model": "flat_v1", "dry_run": True}
+    monkeypatch.setattr(account_usage_routes.generation_payment, "quote", lambda: dict(sentinel_quote))
+
+    async with _client(app) as client:
+        resp = await client.get("/api/account/usage")
+    assert resp.json()["quote"] == sentinel_quote
+
+
+# ── 4. Adversarial: Redis outage must render as an honest absence ──────
+
+
+@pytest.mark.asyncio
+async def test_redis_outage_renders_null_used_not_a_fabricated_zero(app, monkeypatch):
+    """The guard-review adversarial demonstration: a naive read (``GET`` that
+    swallows the exception and returns 0) would report "0 used, plenty of
+    room" during an outage — indistinguishable from a genuinely idle account.
+    This must instead surface ``used: null`` + an explicit error marker."""
+    _sign_in(monkeypatch)
+
+    r = MagicMock()
+    r.get = AsyncMock(side_effect=ConnectionError("redis unreachable"))
+    monkeypatch.setattr(GenerationQuota, "_get_redis", AsyncMock(return_value=r))
+    monkeypatch.setattr(account_usage_routes, "client_ip", lambda _r: "203.0.113.9")
+
+    async with _client(app) as client:
+        resp = await client.get("/api/account/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["user"]["used"] is None
+    assert body["user"]["error"] == "quota_backend_unavailable"
+    assert body["ip"]["used"] is None
+    assert body["ip"]["error"] == "quota_backend_unavailable"
+    # The would-be-naive failure mode this guards against:
+    assert body["user"]["used"] != 0

--- a/backend/tests/test_account_usage_routes.py
+++ b/backend/tests/test_account_usage_routes.py
@@ -191,3 +191,24 @@ async def test_redis_outage_renders_null_used_not_a_fabricated_zero(app, monkeyp
     assert body["ip"]["error"] == "quota_backend_unavailable"
     # The would-be-naive failure mode this guards against:
     assert body["user"]["used"] != 0
+
+
+@pytest.mark.asyncio
+async def test_corrupt_stored_value_reads_as_unknown_not_500(app, monkeypatch):
+    """A non-numeric value in the quota key is the same "unknown" as an
+    unreachable Redis: peek() must return None (rendered used: null), never
+    let int() raise into a 500 on a display read (#1307 review finding —
+    pre-fix, int(val) sat outside the try and this request 500s)."""
+    _sign_in(monkeypatch)
+
+    r = MagicMock()
+    r.get = AsyncMock(return_value=b"not-a-number")
+    monkeypatch.setattr(GenerationQuota, "_get_redis", AsyncMock(return_value=r))
+    monkeypatch.setattr(account_usage_routes, "client_ip", lambda _r: "203.0.113.9")
+
+    async with _client(app) as client:
+        resp = await client.get("/api/account/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user"]["used"] is None
+    assert body["ip"]["used"] is None

--- a/backend/tests/test_rigor_verify_routes.py
+++ b/backend/tests/test_rigor_verify_routes.py
@@ -1,0 +1,224 @@
+"""``POST /api/rigor/verify`` — the CLI ``verify`` command backend (#1305).
+
+Covers the honesty contract this endpoint exists to enforce:
+
+  1. every route 401s without a Better Auth session;
+  2. DSR and walk-forward OOS consistency are EVALUABLE and reuse the exact
+     same gate functions/thresholds the passport verdict uses
+     (``compute_dsr_hac_and_iid`` gated on ``DSR_P_FLOOR``,
+     ``compute_oos_sharpe`` gated on ``OOS_ABS_FLOOR``) — never new thresholds;
+  3. PBO and look-ahead are ALWAYS ``not_evaluable`` for a bare returns series
+     — never silently passed, never defaulted, never reported as a FAIL they
+     were never evaluated for;
+  4. ``passes`` is true only when no evaluable check failed AND at least one
+     check was evaluable (a request where nothing was evaluable must not read
+     as passing by vacuous truth);
+  5. ``trials`` is self-attested, `>= 1` enforced at the schema (0 is a 422,
+     not a silently-accepted degenerate deflation);
+  6. the ADVERSARIAL demonstration the repo's guard-review rule requires: a
+     synthetic series constructed to FAIL both evaluable checks is shown
+     failing both, not merely "not passing" for an unrelated reason.
+
+Hermetic: mocks only the Better Auth session fetch (the account-session
+boundary); the rigor math runs for real against synthetic numpy series with a
+fixed seed, so the DSR/OOS numbers below are reproducible, not fixtures.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import httpx
+import numpy as np
+import pytest
+from archimedes.api import account_auth, rigor_verify_routes
+from fastapi import FastAPI
+
+# ── Synthetic, reproducible fixture series ──────────────────────────────
+# Deterministic (fixed seed) so CI and local runs see byte-identical DSR/OOS
+# numbers — not tuned by hand to "happen" to pass/fail.
+
+_STRONG_SERIES = np.random.default_rng(7).normal(0.0015, 0.004, 300).tolist()  # DSR PASS, OOS PASS
+_WEAK_SERIES = np.random.default_rng(11).normal(-0.002, 0.01, 300).tolist()  # DSR FAIL, OOS FAIL
+_SHORT_SERIES = [0.01, -0.02, 0.015]  # T=3: DSR needs T>=4, OOS needs T>=10 -> both not_evaluable
+
+
+def _returns_body(series: list[float], trials: int = 1) -> dict:
+    base = datetime(2024, 1, 1)
+    return {
+        "returns": [
+            {"date": (base + timedelta(days=i)).date().isoformat(), "daily_return": r} for i, r in enumerate(series)
+        ],
+        "trials": trials,
+    }
+
+
+@pytest.fixture()
+def app():
+    application = FastAPI()
+    application.middleware("http")(account_auth.better_auth_session_middleware)
+    application.include_router(rigor_verify_routes.rigor_verify_router)
+    return application
+
+
+def _session_for(user_id: str):
+    async def fetch(_request):
+        return {
+            "user": {"id": user_id, "name": user_id, "email": f"{user_id}@example.com", "emailVerified": True},
+            "session": {"id": f"s-{user_id}", "expiresAt": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+        }
+
+    return fetch
+
+
+def _sign_in(monkeypatch, user_id: str = "user-1"):
+    monkeypatch.setattr(account_auth, "_fetch_session", _session_for(user_id))
+
+
+def _client(app):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"cookie": "better-auth.session_token=opaque", "host": "archimedes-arc.com"},
+    )
+
+
+# ── 1. Auth gate ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_requires_a_better_auth_session(app, monkeypatch):
+    monkeypatch.setattr(account_auth, "_fetch_session", AsyncMock(return_value=None))
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_STRONG_SERIES))
+    assert resp.status_code == 401
+
+
+# ── 2/3/4. The honesty contract ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_strong_lookahead_free_series_passes_both_evaluable_checks(app, monkeypatch):
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_STRONG_SERIES))
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["dsr"]["status"] == "pass"
+    assert body["dsr"]["dsr_p_value"] >= 0.50  # DSR_P_FLOOR, reused not reinvented
+    assert body["oos_consistency"]["status"] == "pass"
+    assert body["oos_consistency"]["oos_sharpe"] > 0.0
+
+    # PBO and look-ahead are structurally not_evaluable for a bare series —
+    # even on a strong, clean series, never silently passed.
+    assert body["pbo"]["status"] == "not_evaluable"
+    assert body["pbo"]["reason"]
+    assert body["look_ahead"]["status"] == "not_evaluable"
+    assert body["look_ahead"]["reason"]
+
+    assert body["passes"] is True
+    assert body["trials"] == 1
+    assert body["self_attested"] is True
+
+
+@pytest.mark.asyncio
+async def test_weak_series_fails_dsr_and_oos_the_adversarial_demonstration(app, monkeypatch):
+    """The guard-review rule (CLAUDE.md): show the input that SHOULD fail the
+    guard actually failing it — not merely absent from the passing case."""
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_WEAK_SERIES))
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["dsr"]["status"] == "fail"
+    assert body["dsr"]["dsr_p_value"] < 0.50
+    assert body["oos_consistency"]["status"] == "fail"
+    assert body["oos_consistency"]["oos_sharpe"] <= 0.0
+
+    assert body["pbo"]["status"] == "not_evaluable"
+    assert body["look_ahead"]["status"] == "not_evaluable"
+
+    assert body["passes"] is False
+
+
+@pytest.mark.asyncio
+async def test_synthetic_failing_series_pbo_is_not_evaluable_never_a_default_pass_or_fail(app, monkeypatch):
+    """Mirrors the issue's stated acceptance check: on a failing series,
+    pbo.status == "not_evaluable" — never silently passed, never a FAIL for a
+    check that was structurally never run."""
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_WEAK_SERIES))
+    body = resp.json()
+    assert body["passes"] is False
+    assert body["pbo"]["status"] == "not_evaluable"
+
+
+@pytest.mark.asyncio
+async def test_too_short_series_neither_evaluable_check_runs_and_passes_is_false(app, monkeypatch):
+    """No evaluable check at all — passes must be False by construction
+    (vacuous truth is not honesty), not True because nothing failed."""
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_SHORT_SERIES))
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["dsr"]["status"] == "not_evaluable"
+    assert body["oos_consistency"]["status"] == "not_evaluable"
+    assert body["pbo"]["status"] == "not_evaluable"
+    assert body["look_ahead"]["status"] == "not_evaluable"
+    assert body["passes"] is False  # nothing evaluable -> never vacuously "passes"
+
+
+# ── 5. trials validation ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_trials_zero_is_rejected_422(app, monkeypatch):
+    """trials is self-attested but must be >= 1 — a degenerate/absent trial
+    count must not silently pass schema validation and reach the DSR math."""
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_STRONG_SERIES, trials=0))
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_trials_default_is_one_and_is_echoed_self_attested(app, monkeypatch):
+    _sign_in(monkeypatch)
+    body = _returns_body(_STRONG_SERIES)
+    del body["trials"]  # omit -> default
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["trials"] == 1
+
+
+@pytest.mark.asyncio
+async def test_higher_declared_trials_deflates_dsr_p_value(app, monkeypatch):
+    """The DSR must actually respond to the declared trial count (deflation is
+    real, not decorative) — more trials -> harder to clear the same floor."""
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        p1 = (await client.post("/api/rigor/verify", json=_returns_body(_STRONG_SERIES, trials=1))).json()["dsr"][
+            "dsr_p_value"
+        ]
+        p50 = (await client.post("/api/rigor/verify", json=_returns_body(_STRONG_SERIES, trials=50))).json()["dsr"][
+            "dsr_p_value"
+        ]
+    assert p50 < p1
+
+
+# ── empty returns rejected ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_returns_rejected_422(app, monkeypatch):
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json={"returns": [], "trials": 1})
+    assert resp.status_code == 422

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,13 +11,12 @@ four the series survives.
 
 ## Status
 
-**0.0.1 is a name reservation.** The command tree is in place and the flags are settled,
-but every subcommand exits 3 with a message saying so. Nothing here opens a network
-connection.
+**0.1.0** — `login`, `meter`, and `verify` work against the hosted API. `verify --local`
+and `backtest` still exit 3 (`NOT_IMPLEMENTED`); both need the local execution engine,
+which is published separately and isn't out yet.
 
-The first working release is 0.1.0, with `login`, `meter`, and `verify` against the hosted
-API. `verify --local` and `backtest` follow once the local execution engine is published
-separately.
+0.0.1 was a name reservation: the command tree and flags were fixed, but every subcommand
+exited 3.
 
 ## Install
 
@@ -31,11 +30,15 @@ rather than a compiler-and-a-coffee one.
 ## Commands
 
 ```
-archimedes login                      authenticate with a wallet signature
-archimedes meter                      show calls used and USDC spent this period
+archimedes login                      sign in (Better Auth email + password) and cache the session
+archimedes meter                      show today's generation usage and the live price
 archimedes verify RETURNS_CSV         run the gate over a returns series
 archimedes backtest --strategy-path   run a strategy locally and print its returns
 ```
+
+`login` prompts for email and password (or reads `ARCHIMEDES_EMAIL` / `ARCHIMEDES_PASSWORD`
+for CI) and caches the session cookie at `~/.config/archimedes/session.json`, mode 600.
+`meter` and `verify` read that cache; run `login` first.
 
 `RETURNS_CSV` is two columns, date and daily return, or `-` to read from stdin. So the
 whole loop is one line:
@@ -44,10 +47,17 @@ whole loop is one line:
 archimedes backtest --strategy-path mine.py --strategy-class Mine | archimedes verify -
 ```
 
+`verify` sends the returns series to `POST /api/rigor/verify`, which computes DSR and a
+walk-forward out-of-sample check for real against those numbers, using the exact functions
+and thresholds the strategy-passport verdict uses. PBO and the look-ahead audit can't run
+over a bare series (PBO needs a trial matrix, look-ahead needs strategy source), so both
+always render `not_evaluable` — never a silent pass.
+
 Every command takes `--json` and prints a single object on stdout, including on its error
 paths. A script never has to parse prose to find out what happened.
 
-`verify --local` runs the gate on your machine with no network, no account, and no charge.
+`verify --local` runs the gate on your machine with no network, no account, and no charge
+— not implemented yet.
 
 ## Exit codes
 
@@ -55,15 +65,15 @@ These are stable from 0.0.1 onward.
 
 | Code | Meaning |
 | --- | --- |
-| 0 | The gate passed |
+| 0 | The command completed; for `verify`, the gate passed |
 | 1 | The gate ran and returned a failing verdict |
-| 2 | Bad arguments or a missing file |
+| 2 | Bad arguments, a missing file, or no valid session (`login` first) |
 | 3 | Subcommand not implemented in this release |
 
 The line worth drawing is 1 against everything else. Exit 1 is a real answer about the
 strategy. Any other non-zero code means no verdict was produced at all, so a CI job that
-treats every failure as "strategy rejected" would report a network timeout as a research
-finding. Branch on 1 specifically:
+treats every failure as "strategy rejected" would report a network timeout — or an expired
+session — as a research finding. Branch on 1 specifically:
 
 ```bash
 archimedes verify returns.csv

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archimedes-cli"
-version = "0.0.1"
+version = "0.1.0"
 description = "Run the Archimedes rigor gate over your own strategies and returns, from the command line."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ license-files = ["LICENSE"]
 authors = [{ name = "Archimedes" }]
 keywords = ["quantitative-finance", "backtesting", "deflated-sharpe", "overfitting", "rigor"]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Environment :: Console",
   "Intended Audience :: Financial and Insurance Industry",
   "Intended Audience :: Science/Research",
@@ -20,14 +20,14 @@ classifiers = [
   "Topic :: Office/Business :: Financial :: Investment",
 ]
 
-# Deliberately small. `login` / `meter` / `verify` need an HTTP client and an
-# argument parser and nothing else, so `pip install archimedes-cli` stays a
-# seconds-long install. Two dependencies are not yet listed because the commands
-# that need them are not written:
-#   eth-account  -> `login` (SIWE signing), lands in 0.1.0
+# Deliberately small. `login` / `meter` / `verify` (0.1.0) need only an HTTP client and
+# an argument parser, so `pip install archimedes-cli` stays a seconds-long install.
+# Login is Better Auth email + password (POST /api/auth/sign-in/email), not a wallet
+# signature, so no eth-account/SIWE dependency was ever needed for it. One dependency
+# is not yet listed because the commands that need it are not written:
 #   archimedes-analytics-engine -> the `[local]` extra behind `verify --local`
 #                                  and `backtest`, once that package is on PyPI
-# Listing either one now would be metadata describing code that does not exist.
+# Listing it now would be metadata describing code that does not exist.
 dependencies = [
   "click>=8.1",
   "httpx>=0.27",

--- a/cli/src/archimedes_cli/__init__.py
+++ b/cli/src/archimedes_cli/__init__.py
@@ -5,6 +5,6 @@ matches ``pyproject.toml`` so a release cannot ship a binary that reports one
 number while PyPI shows another.
 """
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 __all__ = ["__version__"]

--- a/cli/src/archimedes_cli/__main__.py
+++ b/cli/src/archimedes_cli/__main__.py
@@ -1,0 +1,5 @@
+"""``python -m archimedes_cli`` — same entry point as the ``archimedes`` script."""
+
+from .cli import main
+
+main()

--- a/cli/src/archimedes_cli/cli.py
+++ b/cli/src/archimedes_cli/cli.py
@@ -1,25 +1,30 @@
 """The ``archimedes`` entry point.
 
-0.0.1 is a name-reservation release. The command tree below is the shape the tool
-will have and the flags are the ones it will accept, but no subcommand does any
-work yet: each one explains itself and exits ``NOT_IMPLEMENTED``. Nothing here
-opens a socket or reads a credential.
+0.0.1 was a name-reservation release: the command tree and flags were fixed, but no
+subcommand did any work. 0.1.0 fills in three of them against the hosted API —
+``login`` (Better Auth email + password, ``POST /api/auth/sign-in/email``), ``meter``
+(``GET /api/account/usage`` — today's generation usage and the live price quote), and
+``verify`` (``POST /api/rigor/verify`` — the rigor gate over a returns series).
+``backtest`` and ``verify --local`` still exit ``NOT_IMPLEMENTED``: both need the local
+execution engine, which is not published yet.
 
-The tree is committed now rather than grown later because the flags are a
-contract. ``--json`` on every command and a stable exit code for a failing gate
-are what make the tool usable from a CI job, and both are much cheaper to get
-right before anyone has scripted against them.
+``--json`` on every command, including every error path, and a stable exit code for a
+failing gate are what make the tool usable from a CI job — see ``exits.py``.
 """
 
 from __future__ import annotations
 
+import csv
+import io
 import json
+import os
 import sys
 
 import click
+import httpx
 
-from . import __version__
-from .exits import NOT_IMPLEMENTED
+from . import __version__, exits
+from .session import SESSION_COOKIE_NAME, load_session, save_session
 
 DEFAULT_API_URL = "https://archimedes-arc.com"
 
@@ -40,14 +45,34 @@ _api_url_option = click.option(
 )
 
 
-def _unavailable(command: str, *, as_json: bool, lands_in: str = "0.1.0") -> None:
+def _http_client(api_url: str, *, cookies: dict[str, str] | None = None) -> httpx.Client:
+    """The one place an ``httpx.Client`` gets constructed.
+
+    Keeping construction behind a single function is what lets tests mock HTTP at the
+    boundary: they monkeypatch this factory to return a client wired to an
+    ``httpx.MockTransport`` instead of a real socket, rather than patching internals of
+    each command.
+    """
+    return httpx.Client(base_url=api_url, cookies=cookies, timeout=10.0, follow_redirects=True)
+
+
+def _unavailable(command: str, *, as_json: bool, lands_in: str = "unscheduled") -> None:
     """Report that ``command`` has no implementation yet, then exit.
+
+    ``lands_in`` defaults to ``"unscheduled"`` rather than guessing a version number —
+    ``backtest`` and ``verify --local`` both need the not-yet-published local execution
+    engine, and no target release for that exists yet. Fabricating one (e.g. hardcoding
+    the CURRENT version, which 0.0.1 did — a bug once 0.1.0 became the running version
+    and made this same message claim a feature "lands in" the release it's running in)
+    would be exactly the kind of false claim this repo's conventions forbid.
 
     Structured output is honoured even here. A caller that asked for ``--json``
     gets JSON on every code path, so a script never has to parse prose to find
     out what happened.
     """
-    message = f"'archimedes {command}' is not implemented in {__version__}. It lands in {lands_in}."
+    message = f"'archimedes {command}' is not implemented in {__version__}."
+    if lands_in != "unscheduled":
+        message += f" It lands in {lands_in}."
     if as_json:
         payload = {
             "ok": False,
@@ -61,7 +86,64 @@ def _unavailable(command: str, *, as_json: bool, lands_in: str = "0.1.0") -> Non
     else:
         click.echo(message, err=True)
         click.echo("See https://github.com/a-apin/archimedes for progress.", err=True)
-    sys.exit(NOT_IMPLEMENTED)
+    sys.exit(exits.NOT_IMPLEMENTED)
+
+
+def _fail(command: str, *, as_json: bool, exit_code: int, error: str, message: str) -> None:
+    """Report a command-produced failure (bad input, no session, a rejected request)
+    and exit. Same ``--json``-on-every-path contract as :func:`_unavailable`."""
+    if as_json:
+        payload = {"ok": False, "command": command, "error": error, "message": message}
+        click.echo(json.dumps(payload))
+    else:
+        click.echo(message, err=True)
+    sys.exit(exit_code)
+
+
+def _response_detail(response: httpx.Response) -> str:
+    """Best-effort human string for a non-2xx API response body."""
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text[:200] if response.text else f"HTTP {response.status_code}"
+    if isinstance(body, dict) and "detail" in body:
+        return str(body["detail"])
+    return str(body)
+
+
+def _handle_api_error(command: str, *, as_json: bool, response: httpx.Response) -> None:
+    """Turn a non-2xx API response into a :func:`_fail` call. Never returns."""
+    if response.status_code == 401:
+        _fail(
+            command,
+            as_json=as_json,
+            exit_code=exits.AUTH,
+            error="session_expired",
+            message="session expired or was revoked. Run `archimedes login` again.",
+        )
+    if response.status_code == 429:
+        _fail(
+            command,
+            as_json=as_json,
+            exit_code=exits.USAGE,
+            error="rate_limited",
+            message="rate limited by the API. Wait a moment and try again.",
+        )
+    if response.status_code == 422:
+        _fail(
+            command,
+            as_json=as_json,
+            exit_code=exits.USAGE,
+            error="invalid_request",
+            message=f"the API rejected the request: {_response_detail(response)}",
+        )
+    _fail(
+        command,
+        as_json=as_json,
+        exit_code=exits.USAGE,
+        error="http_error",
+        message=f"{command} failed: HTTP {response.status_code}: {_response_detail(response)}",
+    )
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -75,6 +157,10 @@ def main() -> None:
     is worth deploying capital behind; one that clears none of them is a curve
     fit that happens to have a pretty equity chart.
 
+    A bare returns series (what ``verify`` takes) cannot support all four: PBO
+    needs a trial matrix and the look-ahead audit needs strategy source, so those
+    two always render ``not_evaluable`` rather than being silently passed.
+
     Your strategy code is never uploaded or executed on an Archimedes server.
     See the README for exactly where that boundary sits.
     """
@@ -84,26 +170,201 @@ def main() -> None:
 @_api_url_option
 @_json_option
 def login(api_url: str, as_json: bool) -> None:
-    """Authenticate with a wallet signature and cache the session.
+    """Sign in and cache the session.
 
-    Signs a Sign-In With Ethereum message locally and exchanges it for a session
-    cookie. The private key is read once, used to sign, and never sent anywhere.
+    Archimedes accounts are Better Auth (email + password) — there is no wallet
+    signature involved in signing in. Reads ``ARCHIMEDES_EMAIL`` / ``ARCHIMEDES_PASSWORD``
+    from the environment when both are set (the CI path, so a pipeline never has to
+    answer an interactive prompt); otherwise prompts for them, with the password hidden.
+
+    The password is sent once, over this one request (``POST /api/auth/sign-in/email``),
+    and is never stored. What gets cached at ``~/.config/archimedes/session.json``
+    (mode 600) is the session cookie Better Auth issues back, after confirming it round
+    trips against ``GET /api/auth/get-session``. Linking a crypto wallet is a separate,
+    optional, later step (for on-chain vault actions) — it does not authenticate you and
+    is not part of this command.
     """
-    del api_url
-    _unavailable("login", as_json=as_json)
+    email = os.environ.get("ARCHIMEDES_EMAIL", "").strip()
+    password = os.environ.get("ARCHIMEDES_PASSWORD", "")
+    if not email:
+        email = click.prompt("Email")
+    if not password:
+        password = click.prompt("Password", hide_input=True)
+
+    try:
+        with _http_client(api_url) as client:
+            response = client.post("/api/auth/sign-in/email", json={"email": email, "password": password})
+    except httpx.HTTPError as exc:
+        _fail(
+            "login",
+            as_json=as_json,
+            exit_code=exits.AUTH,
+            error="network_error",
+            message=f"could not reach {api_url}: {exc}",
+        )
+
+    if not response.is_success:
+        _fail(
+            "login",
+            as_json=as_json,
+            exit_code=exits.AUTH,
+            error="invalid_credentials",
+            message=f"sign-in failed: HTTP {response.status_code}: {_response_detail(response)}",
+        )
+
+    token = response.cookies.get(SESSION_COOKIE_NAME)
+    if not token:
+        _fail(
+            "login",
+            as_json=as_json,
+            exit_code=exits.AUTH,
+            error="no_session_cookie",
+            message="sign-in succeeded but the server did not return a session cookie",
+        )
+
+    # Confirm the cookie actually round-trips, and read back the canonical account email,
+    # before trusting it — mirrors scripts/agent_journey.py's step_auth.
+    try:
+        with _http_client(api_url, cookies={SESSION_COOKIE_NAME: token}) as client:
+            session_response = client.get("/api/auth/get-session")
+        session_payload = session_response.json() if session_response.is_success else None
+    except (httpx.HTTPError, ValueError):
+        # ValueError covers json.JSONDecodeError from a 200 with a non-JSON or empty
+        # body — treated the same as "the round trip didn't confirm a session", not a
+        # crash.
+        session_payload = None
+
+    user = session_payload.get("user") if isinstance(session_payload, dict) else None
+    confirmed_email = user.get("email") if isinstance(user, dict) else None
+    if not confirmed_email:
+        _fail(
+            "login",
+            as_json=as_json,
+            exit_code=exits.AUTH,
+            error="session_not_confirmed",
+            message="signed in, but the session cookie did not round-trip on GET /api/auth/get-session",
+        )
+
+    path = save_session(api_url=api_url, cookies={SESSION_COOKIE_NAME: token}, email=confirmed_email)
+
+    if as_json:
+        click.echo(json.dumps({"ok": True, "email": confirmed_email}))
+    else:
+        click.echo(f"Logged in as {confirmed_email}. Session cached at {path}.")
+    sys.exit(exits.OK)
+
+
+def _render_usage(usage: dict) -> None:
+    click.echo(f"Usage for {usage.get('date', '?')} (user {usage.get('user_id', '?')})")
+    for label, bucket in (("Per-user", usage.get("user") or {}), ("Per-IP", usage.get("ip") or {})):
+        error = bucket.get("error")
+        used = bucket.get("used")
+        if error:
+            click.echo(f"  {label}: unavailable ({error})")
+        elif bucket.get("unlimited"):
+            click.echo(f"  {label}: {used if used is not None else '?'} used (no cap)")
+        else:
+            click.echo(f"  {label}: {used}/{bucket.get('cap')} used, {bucket.get('remaining')} remaining")
+    quote = usage.get("quote") or {}
+    price = quote.get("price")
+    if price is not None:
+        suffix = " (dry run)" if quote.get("dry_run") else ""
+        click.echo(f"  Price per generation: {price} {quote.get('asset', '')}{suffix}".rstrip())
 
 
 @main.command()
 @_api_url_option
 @_json_option
 def meter(api_url: str, as_json: bool) -> None:
-    """Show what you have used and what it cost.
+    """Show what you have used today and what it costs.
 
-    Prints the current billing period's call count and USDC spend, so the number
-    the CLI reports and the number the invoice reports come from one place.
+    ``GET /api/account/usage`` — today's generation count against both the per-user and
+    per-IP daily caps, plus the live price quote (the same ``generation_payment.quote()``
+    call the paywall itself reads, so this number and the invoice can never drift apart).
+    Requires a cached session; run ``archimedes login`` first.
     """
-    del api_url
-    _unavailable("meter", as_json=as_json)
+    session = load_session()
+    if session is None:
+        _fail(
+            "meter",
+            as_json=as_json,
+            exit_code=exits.AUTH,
+            error="no_session",
+            message="not logged in. Run `archimedes login` first.",
+        )
+
+    try:
+        with _http_client(api_url, cookies=session["cookies"]) as client:
+            response = client.get("/api/account/usage")
+    except httpx.HTTPError as exc:
+        _fail(
+            "meter",
+            as_json=as_json,
+            exit_code=exits.USAGE,
+            error="network_error",
+            message=f"could not reach {api_url}: {exc}",
+        )
+
+    if not response.is_success:
+        _handle_api_error("meter", as_json=as_json, response=response)
+
+    usage = response.json()
+    if as_json:
+        click.echo(json.dumps({"ok": True, **usage}))
+    else:
+        _render_usage(usage)
+    sys.exit(exits.OK)
+
+
+def _parse_returns_csv(source: str) -> list[dict]:
+    """Parse ``RETURNS_CSV`` into ``[{"date": ..., "daily_return": ...}, ...]``.
+
+    Two columns: date, then daily return. A header row (or any row whose second column
+    does not parse as a float — a blank line, a comment) is skipped rather than rejected,
+    so both a ``date,daily_return`` header and a bare headerless file work.
+    """
+    if source == "-":
+        text = click.get_text_stream("stdin").read()
+    else:
+        with open(source, newline="", encoding="utf-8") as handle:
+            text = handle.read()
+
+    rows: list[dict] = []
+    for row in csv.reader(io.StringIO(text)):
+        if len(row) < 2:
+            continue
+        date_str = row[0].strip()
+        if not date_str:
+            continue
+        try:
+            value = float(row[1].strip())
+        except ValueError:
+            continue
+        rows.append({"date": date_str, "daily_return": value})
+    return rows
+
+
+_CHECK_LABELS = (
+    ("DSR", "dsr"),
+    ("PBO", "pbo"),
+    ("OOS consistency", "oos_consistency"),
+    ("Look-ahead", "look_ahead"),
+)
+_STATUS_TAG = {"pass": "PASS", "fail": "FAIL", "not_evaluable": "N/A"}
+
+
+def _render_verify(body: dict) -> None:
+    click.echo(f"n_bars={body.get('n_bars')}  trials={body.get('trials')} (self-attested)")
+    for name, key in _CHECK_LABELS:
+        check = body.get(key) or {}
+        status = check.get("status", "?")
+        tag = _STATUS_TAG.get(status, status.upper())
+        line = f"  [{tag}] {name}"
+        reason = check.get("reason")
+        if reason:
+            line += f" — {reason}"
+        click.echo(line)
+    click.echo("PASSES" if body.get("passes") else "FAILS")
 
 
 @main.command()
@@ -118,19 +379,88 @@ def meter(api_url: str, as_json: bool) -> None:
     is_flag=True,
     help="Run the gate on this machine. No network, no account, no charge.",
 )
+@click.option(
+    "--trials",
+    type=int,
+    default=1,
+    show_default=True,
+    metavar="N",
+    help="Self-attested trial/variant count the DSR deflation is computed against (>= 1).",
+)
 @_api_url_option
 @_json_option
-def verify(returns_csv: str, run_local: bool, api_url: str, as_json: bool) -> None:
+def verify(returns_csv: str, run_local: bool, trials: int, api_url: str, as_json: bool) -> None:
     """Run the rigor gate over a returns series.
 
-    RETURNS_CSV is a two-column CSV of date and daily return, or ``-`` to read
-    the series from stdin.
+    RETURNS_CSV is a two-column CSV of date and daily return (a header row, if present,
+    is skipped automatically), or ``-`` to read the series from stdin.
 
-    Exits 0 when the gate passes and 1 when it fails, which is what makes
-    ``archimedes verify returns.csv`` usable as a CI check before a deploy.
+    Runs against the hosted API: ``POST /api/rigor/verify`` computes the deflated Sharpe
+    ratio (DSR, deflated by ``--trials``) and a walk-forward out-of-sample consistency
+    check against your real returns — the exact same functions and thresholds the
+    strategy-passport verdict uses. A bare returns series cannot support the other two
+    gate checks: PBO needs a trial matrix of candidate strategies and the look-ahead audit
+    needs strategy source, so both always render ``not_evaluable`` with a reason rather
+    than being silently scored as a pass. ``--local`` (this machine, no network, no
+    account) is not implemented yet.
+
+    Requires a cached session; run ``archimedes login`` first. Exits 0 when the gate
+    passes and 1 when it fails, which is what makes ``archimedes verify returns.csv``
+    usable as a CI check before a deploy.
     """
-    del returns_csv, run_local, api_url
-    _unavailable("verify", as_json=as_json)
+    if run_local:
+        _unavailable("verify", as_json=as_json)
+
+    if trials < 1:
+        _fail(
+            "verify",
+            as_json=as_json,
+            exit_code=exits.USAGE,
+            error="invalid_trials",
+            message="--trials must be >= 1",
+        )
+
+    returns = _parse_returns_csv(returns_csv)
+    if not returns:
+        _fail(
+            "verify",
+            as_json=as_json,
+            exit_code=exits.USAGE,
+            error="empty_returns",
+            message=f"no (date, daily_return) rows parsed from {returns_csv!r}",
+        )
+
+    session = load_session()
+    if session is None:
+        _fail(
+            "verify",
+            as_json=as_json,
+            exit_code=exits.AUTH,
+            error="no_session",
+            message="not logged in. Run `archimedes login` first.",
+        )
+
+    try:
+        with _http_client(api_url, cookies=session["cookies"]) as client:
+            response = client.post("/api/rigor/verify", json={"returns": returns, "trials": trials})
+    except httpx.HTTPError as exc:
+        _fail(
+            "verify",
+            as_json=as_json,
+            exit_code=exits.USAGE,
+            error="network_error",
+            message=f"could not reach {api_url}: {exc}",
+        )
+
+    if not response.is_success:
+        _handle_api_error("verify", as_json=as_json, response=response)
+
+    body = response.json()
+    if as_json:
+        click.echo(json.dumps({"ok": True, **body}))
+    else:
+        _render_verify(body)
+    sys.exit(exits.OK if body.get("passes") else exits.GATE_FAILED)
 
 
 @main.command()

--- a/cli/src/archimedes_cli/cli.py
+++ b/cli/src/archimedes_cli/cli.py
@@ -493,5 +493,21 @@ def backtest(strategy_path: str, strategy_class: str, as_json: bool) -> None:
     _unavailable("backtest", as_json=as_json)
 
 
+@main.command()
+def manifest() -> None:
+    """Emit this CLI's machine-readable contract and exit 0.
+
+    Agentic connectivity is the interface: an agent should discover what this
+    tool accepts, returns, costs, and exits with from a declarative contract —
+    not by parsing --help prose. Always JSON, no network, no session. A test
+    walks the real click command tree and asserts this contract matches it,
+    so the promise cannot silently drift from the truth.
+    """
+    from .manifest import MANIFEST
+
+    click.echo(json.dumps(MANIFEST, indent=2))
+    sys.exit(exits.OK)
+
+
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/cli/src/archimedes_cli/cli.py
+++ b/cli/src/archimedes_cli/cli.py
@@ -45,6 +45,24 @@ _api_url_option = click.option(
 )
 
 
+# Session-aware variant for commands that RUN AGAINST an existing session
+# (meter/verify): when --api-url/ARCHIMEDES_API_URL is absent, the URL the
+# session was logged into wins over the global default — otherwise a session
+# cached against a non-default server would silently send its cookie to the
+# wrong host and surface as a confusing 401.
+_api_url_session_option = click.option(
+    "--api-url",
+    envvar="ARCHIMEDES_API_URL",
+    default=None,
+    metavar="URL",
+    help=f"Base URL of the Archimedes API. Defaults to the cached session's URL, else {DEFAULT_API_URL}.",
+)
+
+
+def _resolve_api_url(explicit: str | None, session: dict | None) -> str:
+    return explicit or (session or {}).get("api_url") or DEFAULT_API_URL
+
+
 def _http_client(api_url: str, *, cookies: dict[str, str] | None = None) -> httpx.Client:
     """The one place an ``httpx.Client`` gets constructed.
 
@@ -53,7 +71,10 @@ def _http_client(api_url: str, *, cookies: dict[str, str] | None = None) -> http
     ``httpx.MockTransport`` instead of a real socket, rather than patching internals of
     each command.
     """
-    return httpx.Client(base_url=api_url, cookies=cookies, timeout=10.0, follow_redirects=True)
+    # follow_redirects=False, deliberately: the API never redirects, and a
+    # compromised/misconfigured endpoint must not be able to bounce a request
+    # carrying credentials (login body, session cookie) to another host.
+    return httpx.Client(base_url=api_url, cookies=cookies, timeout=10.0, follow_redirects=False)
 
 
 def _unavailable(command: str, *, as_json: bool, lands_in: str = "unscheduled") -> None:
@@ -273,9 +294,9 @@ def _render_usage(usage: dict) -> None:
 
 
 @main.command()
-@_api_url_option
+@_api_url_session_option
 @_json_option
-def meter(api_url: str, as_json: bool) -> None:
+def meter(api_url: str | None, as_json: bool) -> None:
     """Show what you have used today and what it costs.
 
     ``GET /api/account/usage`` — today's generation count against both the per-user and
@@ -292,6 +313,7 @@ def meter(api_url: str, as_json: bool) -> None:
             error="no_session",
             message="not logged in. Run `archimedes login` first.",
         )
+    api_url = _resolve_api_url(api_url, session)
 
     try:
         with _http_client(api_url, cookies=session["cookies"]) as client:
@@ -387,9 +409,9 @@ def _render_verify(body: dict) -> None:
     metavar="N",
     help="Self-attested trial/variant count the DSR deflation is computed against (>= 1).",
 )
-@_api_url_option
+@_api_url_session_option
 @_json_option
-def verify(returns_csv: str, run_local: bool, trials: int, api_url: str, as_json: bool) -> None:
+def verify(returns_csv: str, run_local: bool, trials: int, api_url: str | None, as_json: bool) -> None:
     """Run the rigor gate over a returns series.
 
     RETURNS_CSV is a two-column CSV of date and daily return (a header row, if present,
@@ -440,6 +462,7 @@ def verify(returns_csv: str, run_local: bool, trials: int, api_url: str, as_json
             message="not logged in. Run `archimedes login` first.",
         )
 
+    api_url = _resolve_api_url(api_url, session)
     try:
         with _http_client(api_url, cookies=session["cookies"]) as client:
             response = client.post("/api/rigor/verify", json={"returns": returns, "trials": trials})

--- a/cli/src/archimedes_cli/exits.py
+++ b/cli/src/archimedes_cli/exits.py
@@ -22,8 +22,17 @@ USAGE = 2
 """Bad arguments or a missing file. Click exits with this on its own; it is named here
 so the full set is documented in one place."""
 
+AUTH = 2
+"""No valid cached session (run ``archimedes login`` first), or the server rejected it.
+Deliberately the SAME value as ``USAGE``, not a new code: a missing/expired session means
+the command could not run to a verdict at all, exactly like a bad argument — it is not a
+real answer about a strategy the way ``GATE_FAILED`` is. Kept as a separate name (rather
+than spelling ``USAGE`` at every auth call site) purely so the reason is legible in the
+code that raises it."""
+
 NOT_IMPLEMENTED = 3
 """The subcommand exists in the command tree but has no implementation in this
-release. Every subcommand returns this in 0.0.1."""
+release. 0.0.1 returned this for every subcommand; 0.1.0 narrows it to ``backtest``
+and ``verify --local``, which still need the not-yet-published local execution engine."""
 
-__all__ = ["GATE_FAILED", "NOT_IMPLEMENTED", "OK", "USAGE"]
+__all__ = ["AUTH", "GATE_FAILED", "NOT_IMPLEMENTED", "OK", "USAGE"]

--- a/cli/src/archimedes_cli/manifest.py
+++ b/cli/src/archimedes_cli/manifest.py
@@ -49,7 +49,10 @@ MANIFEST: dict = {
             "implemented": True,
             "description": "Today's generation usage vs both daily caps, plus the live price quote.",
             "inputs": {
-                "--api-url": {"env": "ARCHIMEDES_API_URL", "default": "https://archimedes-arc.com"},
+                "--api-url": {
+                    "env": "ARCHIMEDES_API_URL",
+                    "default": "the cached session's URL, else https://archimedes-arc.com",
+                },
                 "--json": {"flag": True},
             },
             "output": {
@@ -67,7 +70,10 @@ MANIFEST: dict = {
                 "RETURNS_CSV": {"positional": True, "format": "two columns: date, daily_return; '-' reads stdin"},
                 "--trials": {"default": 1, "min": 1, "meaning": "self-attested trial count deflating the DSR"},
                 "--local": {"flag": True, "implemented": False},
-                "--api-url": {"env": "ARCHIMEDES_API_URL", "default": "https://archimedes-arc.com"},
+                "--api-url": {
+                    "env": "ARCHIMEDES_API_URL",
+                    "default": "the cached session's URL, else https://archimedes-arc.com",
+                },
                 "--json": {"flag": True},
             },
             "output": {

--- a/cli/src/archimedes_cli/manifest.py
+++ b/cli/src/archimedes_cli/manifest.py
@@ -1,0 +1,101 @@
+"""The CLI's machine-readable contract — ``archimedes manifest``.
+
+Agentic connectivity is the interface (Ricardo's skill-store brief, applied):
+an agent can only invoke what it can understand, and it should understand this
+tool through a declarative contract, not by parsing ``--help`` prose. Every
+command declares its inputs, output contract, exit codes, cost class, and
+whether it is implemented at all.
+
+This dict is hand-written but it is NOT allowed to drift: a test walks the
+real click command tree and asserts every command and every flag here matches
+it (``cli/tests/test_cli.py``, the manifest-sync tests) — the promise is
+checked against the truth by CI, per house convention.
+"""
+
+from __future__ import annotations
+
+from . import __version__
+
+EXIT_CODES = {
+    "0": "OK — command succeeded (for `verify`: the gate PASSED)",
+    "1": "GATE_FAILED — `verify` produced a verdict and it fails the gate",
+    "2": "USAGE/AUTH — bad invocation, or no/expired session (run `archimedes login`)",
+    "3": "NOT_IMPLEMENTED — the subcommand has no implementation in this version",
+}
+
+MANIFEST: dict = {
+    "tool": "archimedes",
+    "version": __version__,
+    "json_contract": (
+        "--json makes every code path, including errors, emit exactly one JSON "
+        "object on stdout; a script never parses prose."
+    ),
+    "exit_codes": EXIT_CODES,
+    "commands": {
+        "login": {
+            "implemented": True,
+            "description": "Authenticate with an Archimedes account and cache the session cookie.",
+            "inputs": {
+                "--api-url": {"env": "ARCHIMEDES_API_URL", "default": "https://archimedes-arc.com"},
+                "--json": {"flag": True},
+                "email": {"env": "ARCHIMEDES_EMAIL", "prompted_if_absent": True},
+                "password": {"env": "ARCHIMEDES_PASSWORD", "prompted_if_absent": True, "hidden": True},
+            },
+            "output": {"ok": "bool", "email": "str"},
+            "cost_class": "network: 2 HTTP calls (sign-in + session round-trip); no funds, no chain",
+            "side_effects": "writes ~/.config/archimedes/session.json (mode 600)",
+        },
+        "meter": {
+            "implemented": True,
+            "description": "Today's generation usage vs both daily caps, plus the live price quote.",
+            "inputs": {
+                "--api-url": {"env": "ARCHIMEDES_API_URL", "default": "https://archimedes-arc.com"},
+                "--json": {"flag": True},
+            },
+            "output": {
+                "user": "{used: int|null, cap: int} — null used means the quota backend was unavailable, never a fabricated 0",
+                "ip": "{used: int|null, cap: int}",
+                "quote": "the literal GET /api/generate/quote payload",
+            },
+            "cost_class": "network: 1 HTTP call; requires session; no funds, no chain",
+            "side_effects": "none",
+        },
+        "verify": {
+            "implemented": True,
+            "description": "Run the rigor gate's evaluable checks over a returns CSV (or '-' for stdin).",
+            "inputs": {
+                "RETURNS_CSV": {"positional": True, "format": "two columns: date, daily_return; '-' reads stdin"},
+                "--trials": {"default": 1, "min": 1, "meaning": "self-attested trial count deflating the DSR"},
+                "--local": {"flag": True, "implemented": False},
+                "--api-url": {"env": "ARCHIMEDES_API_URL", "default": "https://archimedes-arc.com"},
+                "--json": {"flag": True},
+            },
+            "output": {
+                "passes": "bool — no evaluable check failed AND at least one was evaluable",
+                "dsr": "{status: pass|fail|not_evaluable, deflated_sharpe, dsr_p_value, reason}",
+                "oos_consistency": "{status, oos_sharpe, in_sample_sharpe, reason}",
+                "pbo": "{status: always not_evaluable for a bare series — needs a trial matrix, reason names the decisive gap}",
+                "look_ahead": "{status: always not_evaluable — needs strategy source; never uploaded}",
+            },
+            "cost_class": "network: 1 HTTP call; requires session; rate-limited 5/minute; free",
+            "side_effects": "none",
+            "honesty": (
+                "checks the endpoint cannot honestly compute are reported not_evaluable "
+                "with the decisive reason — never silently passed, failed, or defaulted"
+            ),
+        },
+        "backtest": {
+            "implemented": False,
+            "lands_in": "unscheduled",
+            "description": "Local-only backtest of a strategy file (never uploaded).",
+        },
+        "manifest": {
+            "implemented": True,
+            "description": "This contract. Always JSON, always exit 0.",
+            "inputs": {},
+            "output": "this document",
+            "cost_class": "local, no network",
+            "side_effects": "none",
+        },
+    },
+}

--- a/cli/src/archimedes_cli/manifest.py
+++ b/cli/src/archimedes_cli/manifest.py
@@ -94,6 +94,11 @@ MANIFEST: dict = {
             "implemented": False,
             "lands_in": "unscheduled",
             "description": "Local-only backtest of a strategy file (never uploaded).",
+            "inputs": {
+                "--strategy-path": {"required": True},
+                "--strategy-class": {"required": True},
+                "--json": {"flag": True},
+            },
         },
         "manifest": {
             "implemented": True,

--- a/cli/src/archimedes_cli/session.py
+++ b/cli/src/archimedes_cli/session.py
@@ -1,0 +1,79 @@
+"""Session cache for the Better Auth cookie ``archimedes login`` obtains.
+
+Stored at ``~/.config/archimedes/session.json``, mode ``600`` — this file holds a live
+session credential, so it gets the same treatment any other credential store in this repo
+does (compare ``.env`` staying gitignored, ``~/.arc-canteen/`` team credentials). The value
+cached here is opaque to the CLI: it is whatever cookie(s) ``POST /api/auth/sign-in/email``
+sets, forwarded verbatim on later requests. The CLI never parses or validates the cookie
+itself — same division of responsibility as the server side, which also never parses it and
+just forwards it to Better Auth's ``/api/auth/get-session``
+(``backend/archimedes/api/account_auth.py``, ``_fetch_session``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+SESSION_COOKIE_NAME = "better-auth.session_token"
+"""The cookie Better Auth issues on sign-in, matching the fragment
+``backend/archimedes/api/account_auth.py``'s ``_SESSION_COOKIE_FRAGMENT`` looks for
+(``"better-auth.session_token="``)."""
+
+
+def session_path() -> Path:
+    """Where the session cache lives.
+
+    Built from ``Path.home()`` rather than hardcoded, so tests can point it at a tmp
+    directory by setting ``HOME`` (``Path.home()`` reads that on POSIX) instead of
+    monkeypatching this function.
+    """
+    return Path.home() / ".config" / "archimedes" / "session.json"
+
+
+def load_session() -> dict | None:
+    """The cached session, or ``None`` if there isn't a usable one.
+
+    Never raises. A missing file, a permissions error, a corrupt JSON body, or a body
+    missing its cookie jar are all just "not logged in" from the caller's point of view —
+    the CLI can always fall back to telling the user to run ``archimedes login``.
+    """
+    path = session_path()
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    cookies = data.get("cookies")
+    if not isinstance(cookies, dict) or not cookies:
+        return None
+    return data
+
+
+def save_session(*, api_url: str, cookies: dict[str, str], email: str) -> Path:
+    """Cache the session cookie(s) at :func:`session_path`, mode 600.
+
+    Uses ``os.open`` with an explicit mode rather than ``Path.write_text`` so the file is
+    never briefly world- or group-readable between creation and a follow-up ``chmod`` — and
+    still ``chmod``s afterward, in case the path already existed with looser permissions
+    from an older version (``O_TRUNC`` reuses an existing file's mode, it does not reset it).
+    """
+    path = session_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"api_url": api_url, "cookies": cookies, "email": email}, indent=2) + "\n"
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, payload.encode("utf-8"))
+    finally:
+        os.close(fd)
+    path.chmod(0o600)
+    return path
+
+
+__all__ = ["SESSION_COOKIE_NAME", "load_session", "save_session", "session_path"]

--- a/cli/tests/test_api_url_resolution.py
+++ b/cli/tests/test_api_url_resolution.py
@@ -1,0 +1,50 @@
+"""A cached session's api_url must win over the global default (review finding:
+it was write-only — a staging login silently sent its cookie to prod)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from click.testing import CliRunner
+
+from archimedes_cli import cli as cli_mod
+from archimedes_cli.cli import DEFAULT_API_URL, _resolve_api_url, main
+from archimedes_cli.session import save_session
+
+STAGING = "https://staging.archimedes.invalid"
+
+
+def test_resolution_order_explicit_then_session_then_default():
+    assert _resolve_api_url("https://x", {"api_url": STAGING}) == "https://x"
+    assert _resolve_api_url(None, {"api_url": STAGING}) == STAGING
+    assert _resolve_api_url(None, {}) == DEFAULT_API_URL
+    assert _resolve_api_url(None, None) == DEFAULT_API_URL
+
+
+def test_meter_uses_the_session_url_not_the_default(monkeypatch, tmp_path):
+    """The regression the finding describes: login against a non-default URL,
+    then run plain `meter` — the request must go to the session's host.
+    Pre-fix, seen_base_urls captured DEFAULT_API_URL and this test fails."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("ARCHIMEDES_API_URL", raising=False)
+    save_session(api_url=STAGING, cookies={"better-auth.session_token": "t"}, email="a@b.co")
+
+    seen_base_urls: list[str] = []
+    real_factory = cli_mod._http_client
+
+    def capturing_factory(api_url, *, cookies=None):
+        seen_base_urls.append(api_url)
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200, json={"user": {"used": 1, "cap": 10}, "ip": {"used": 1, "cap": 20}, "quote": {}}
+            )
+        )
+        return httpx.Client(base_url=api_url, cookies=cookies, transport=transport)
+
+    monkeypatch.setattr(cli_mod, "_http_client", capturing_factory)
+    result = CliRunner().invoke(main, ["meter", "--json"])
+    assert result.exit_code == 0, result.output
+    assert seen_base_urls == [STAGING]
+    assert json.loads(result.stdout)["user"]["used"] == 1
+    del real_factory

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,8 +1,12 @@
-"""Smoke tests for the 0.0.1 command tree.
+"""Tests for the 0.1.0 command tree.
 
-There is no behaviour to test yet, so these cover the things that are already a
-contract with users: the exit codes, the shape of ``--json`` output, the version
-the binary reports, and the claim that no command touches the network.
+0.0.1 shipped a stub with nothing to test but shape (exit codes, `--json`, no sockets).
+0.1.0 makes `login`, `meter`, and `verify` real against the hosted API, so this file adds:
+real HTTP interactions mocked at the transport boundary (`httpx.MockTransport`, patched in
+via the CLI's own `_http_client` factory — never internals), exit-code coverage for the new
+`AUTH` family, the `not_evaluable` rendering the honesty contract requires, and the
+session-file's 600 permission. `backtest` and `verify --local` are unchanged stubs and keep
+their original no-network guarantee.
 """
 
 from __future__ import annotations
@@ -10,78 +14,197 @@ from __future__ import annotations
 import json
 import re
 import socket
+import stat
 from pathlib import Path
 from unittest import mock
 
+import archimedes_cli.cli as cli_module
+import httpx
 import pytest
 from archimedes_cli import __version__
 from archimedes_cli.cli import main
-from archimedes_cli.exits import GATE_FAILED, NOT_IMPLEMENTED, OK, USAGE
+from archimedes_cli.exits import AUTH, GATE_FAILED, NOT_IMPLEMENTED, OK, USAGE
+from archimedes_cli.session import SESSION_COOKIE_NAME, save_session, session_path
 from click.testing import CliRunner
 
-SUBCOMMANDS = ["login", "meter", "verify", "backtest"]
-
-# Argument lists that satisfy each command's required options, so the command
-# reaches its body instead of being rejected by click.
-INVOCATIONS = {
-    "login": ["login"],
-    "meter": ["meter"],
-    "verify": ["verify", "returns.csv"],
-    "backtest": ["backtest", "--strategy-path", "s.py", "--strategy-class", "S"],
-}
+# ── Fixtures & test-only helpers ────────────────────────────────────────
 
 
 @pytest.fixture
 def runner(tmp_path, monkeypatch):
-    """A CliRunner in a tmp dir holding the files the commands expect to exist."""
+    """A CliRunner in a tmp dir, with an isolated $HOME (so the session cache never
+    touches a real `~/.config/archimedes`) and no ambient CI credentials leaking in
+    from the real environment."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "returns.csv").write_text("date,ret\n2026-01-02,0.001\n")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("ARCHIMEDES_EMAIL", raising=False)
+    monkeypatch.delenv("ARCHIMEDES_PASSWORD", raising=False)
+    monkeypatch.delenv("ARCHIMEDES_API_URL", raising=False)
+    (tmp_path / "returns.csv").write_text(
+        "date,daily_return\n2026-01-02,0.0021\n2026-01-03,-0.0009\n2026-01-04,0.0014\n"
+    )
     (tmp_path / "s.py").write_text("class S:\n    pass\n")
     return CliRunner()
+
+
+def _route(routes: dict[tuple[str, str], object]):
+    """Build an ``httpx.MockTransport`` handler from a ``{(method, path): response}``
+    map. ``response`` may be an ``httpx.Response`` or a callable taking the request and
+    returning one (for handlers that need to inspect the request body/headers)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        key = (request.method, request.url.path)
+        target = routes.get(key)
+        if target is None:
+            raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+        return target(request) if callable(target) else target
+
+    return handler
+
+
+def _install_transport(monkeypatch, handler):
+    """Mock HTTP at the boundary: patch the CLI's one client-construction function so
+    every client it builds talks to ``handler`` via ``httpx.MockTransport`` instead of a
+    real socket. Nothing inside `cli.py`'s command bodies is touched."""
+
+    def factory(api_url, *, cookies=None):
+        return httpx.Client(base_url=api_url, cookies=cookies, transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(cli_module, "_http_client", factory)
+
+
+def _forbid_network(monkeypatch):
+    """Install a transport factory that blows up if the CLI ever tries to build an HTTP
+    client — proves a client-side guard short-circuited BEFORE any request, not merely
+    that the eventual response happened to look like a failure."""
+
+    def factory(api_url, *, cookies=None):  # noqa: ARG001 — signature must match `_http_client`'s
+        raise AssertionError("a guard should have stopped this before any HTTP client was built")
+
+    monkeypatch.setattr(cli_module, "_http_client", factory)
+
+
+def _seed_session(cookie_value: str = "opaque-token", email: str = "dan@example.com") -> Path:
+    return save_session(
+        api_url="https://archimedes-arc.com",
+        cookies={SESSION_COOKIE_NAME: cookie_value},
+        email=email,
+    )
+
+
+_USAGE_BODY = {
+    "date": "2026-08-19",
+    "user_id": "user-abc",
+    "user": {"used": 3, "cap": 10, "unlimited": False, "remaining": 7, "error": None},
+    "ip": {"used": 0, "cap": 20, "unlimited": False, "remaining": 20, "error": None},
+    "quote": {
+        "payment_required": True,
+        "pricing_model": "flat_v1",
+        "price": "$0.05",
+        "asset": "USDC",
+        "chain": "arc-testnet",
+        "recipient": "0xabc",
+        "dry_run": True,
+        "how": "POST /api/generate/start without a Payment-Signature header returns 402 ...",
+    },
+}
+
+_USAGE_BODY_QUOTA_DOWN = {
+    "date": "2026-08-19",
+    "user_id": "user-abc",
+    "user": {"used": None, "cap": 10, "unlimited": False, "remaining": None, "error": "quota_backend_unavailable"},
+    "ip": {"used": None, "cap": 20, "unlimited": False, "remaining": None, "error": "quota_backend_unavailable"},
+    "quote": {"price": "$0.05", "asset": "USDC", "dry_run": True, "pricing_model": "flat_v1"},
+}
+
+_VERIFY_PASS_BODY = {
+    "passes": True,
+    "trials": 1,
+    "self_attested": True,
+    "n_bars": 300,
+    "dsr": {
+        "status": "pass",
+        "reason": "self-attested trials=1: DSR p-value 0.9997 >= floor 0.50 (Newey-West HAC standard error)",
+        "deflated_sharpe": 1.9,
+        "dsr_p_value": 0.9997,
+    },
+    "pbo": {
+        "status": "not_evaluable",
+        "reason": "PBO requires a trial matrix of multiple candidate strategies' returns.",
+    },
+    "oos_consistency": {
+        "status": "pass",
+        "reason": "walk-forward OOS Sharpe 2.6300 > floor 0.00 (chronological 70/30 holdout)",
+        "oos_sharpe": 2.63,
+        "in_sample_sharpe": 2.1,
+    },
+    "look_ahead": {
+        "status": "not_evaluable",
+        "reason": "The look-ahead audit is AST-based static analysis of strategy source code.",
+    },
+}
+
+_VERIFY_FAIL_BODY = {
+    "passes": False,
+    "trials": 1,
+    "self_attested": True,
+    "n_bars": 300,
+    "dsr": {
+        "status": "fail",
+        "reason": "self-attested trials=1: DSR p-value 0.0002 < floor 0.50 (Newey-West HAC standard error)",
+        "deflated_sharpe": -1.2,
+        "dsr_p_value": 0.000165,
+    },
+    "pbo": {"status": "not_evaluable", "reason": "PBO requires a trial matrix."},
+    "oos_consistency": {
+        "status": "fail",
+        "reason": "walk-forward OOS Sharpe -3.6200 <= floor 0.00 — strategy loses money out-of-sample",
+        "oos_sharpe": -3.62,
+        "in_sample_sharpe": -0.4,
+    },
+    "look_ahead": {"status": "not_evaluable", "reason": "The look-ahead audit needs strategy source."},
+}
+
+_VERIFY_NOT_EVALUABLE_BODY = {
+    "passes": False,
+    "trials": 1,
+    "self_attested": True,
+    "n_bars": 3,
+    "dsr": {"status": "not_evaluable", "reason": "return series too short or degenerate for DSR (need >= 4 bars)"},
+    "pbo": {"status": "not_evaluable", "reason": "PBO requires a trial matrix."},
+    "oos_consistency": {"status": "not_evaluable", "reason": "insufficient data for a walk-forward OOS split"},
+    "look_ahead": {"status": "not_evaluable", "reason": "The look-ahead audit needs strategy source."},
+}
+
+
+def _login_ok_route(*, cookie: str = "tok123", email: str = "dan@example.com"):
+    return {
+        ("POST", "/api/auth/sign-in/email"): httpx.Response(
+            200,
+            json={"redirect": False},
+            headers=[("set-cookie", f"{SESSION_COOKIE_NAME}={cookie}; Path=/; HttpOnly")],
+        ),
+        ("GET", "/api/auth/get-session"): httpx.Response(
+            200,
+            json={"user": {"id": "u1", "email": email, "name": "Dan"}, "session": {"id": "s1"}},
+        ),
+    }
+
+
+# ── Exit codes, version, help (kept from 0.0.1; extended for AUTH) ─────
 
 
 class TestExitCodesAreAContract:
     """These numbers ship in CI jobs. Changing one silently breaks a user's pipeline."""
 
     def test_codes_have_their_documented_values(self):
-        assert (OK, GATE_FAILED, USAGE, NOT_IMPLEMENTED) == (0, 1, 2, 3)
-
-    @pytest.mark.parametrize("command", SUBCOMMANDS)
-    def test_every_subcommand_is_not_implemented(self, runner, command):
-        result = runner.invoke(main, INVOCATIONS[command])
-        assert result.exit_code == NOT_IMPLEMENTED
+        assert (OK, GATE_FAILED, USAGE, AUTH, NOT_IMPLEMENTED) == (0, 1, 2, 2, 3)
 
     def test_a_missing_file_is_usage_not_not_implemented(self, runner):
-        """Click validates before the body runs, so a bad path is 2 and not 3.
-
-        This is the distinction the README asks people to branch on: 3 means the
-        command exists but does nothing yet, 2 means they typed something wrong.
-        """
+        """Click validates before the body runs, so a bad path is 2 and not 3 — still
+        true in 0.1.0: `verify`'s RETURNS_CSV argument keeps `exists=True`."""
         result = runner.invoke(main, ["verify", "no-such-file.csv"])
         assert result.exit_code == USAGE
-
-    def test_stdin_is_an_accepted_returns_source(self, runner):
-        """`archimedes backtest ... | archimedes verify -` is the headline usage,
-        so `-` has to get past argument validation even in the stub."""
-        result = runner.invoke(main, ["verify", "-"])
-        assert result.exit_code == NOT_IMPLEMENTED
-
-
-class TestJsonOutput:
-    @pytest.mark.parametrize("command", SUBCOMMANDS)
-    def test_json_flag_produces_one_parseable_object(self, runner, command):
-        result = runner.invoke(main, [*INVOCATIONS[command], "--json"])
-        payload = json.loads(result.stdout)
-        assert payload["ok"] is False
-        assert payload["error"] == "not_implemented"
-        assert payload["command"] == command
-        assert payload["version"] == __version__
-
-    @pytest.mark.parametrize("command", SUBCOMMANDS)
-    def test_without_json_nothing_lands_on_stdout(self, runner, command):
-        """The human path writes to stderr, so piping stdout stays clean."""
-        result = runner.invoke(main, INVOCATIONS[command])
-        assert result.stdout == ""
 
 
 class TestVersionReporting:
@@ -103,15 +226,402 @@ class TestHelp:
     def test_help_lists_every_subcommand(self, runner):
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == OK
-        for command in SUBCOMMANDS:
+        for command in ("login", "meter", "verify", "backtest"):
             assert command in result.stdout
 
 
-class TestNothingTouchesTheNetwork:
-    """The README says 0.0.1 opens no sockets. This is what backs that sentence."""
+# ── backtest + verify --local: still stubs, still no network ───────────
 
-    @pytest.mark.parametrize("command", SUBCOMMANDS)
-    def test_no_socket_is_opened(self, runner, command):
-        with mock.patch.object(socket, "socket", side_effect=AssertionError("opened a socket")):
-            result = runner.invoke(main, INVOCATIONS[command], catch_exceptions=False)
+
+class TestStubsStillNotImplemented:
+    """`backtest` and `verify --local` are explicitly out of scope for 0.1.0 (need the
+    unpublished local execution engine) and must keep 0.0.1's guarantees exactly."""
+
+    @pytest.mark.parametrize(
+        ("invocation", "command"),
+        [
+            (["backtest", "--strategy-path", "s.py", "--strategy-class", "S"], "backtest"),
+            (["verify", "--local", "returns.csv"], "verify"),
+        ],
+    )
+    def test_not_implemented_json_shape(self, runner, invocation, command):
+        result = runner.invoke(main, [*invocation, "--json"])
         assert result.exit_code == NOT_IMPLEMENTED
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "ok": False,
+            "command": command,
+            "error": "not_implemented",
+            "version": __version__,
+            "lands_in": "unscheduled",
+            "message": payload["message"],
+        }
+        # The self-contradictory claim this guards against: 0.0.1 hardcoded
+        # `lands_in="0.1.0"`, which became false the moment 0.1.0 itself became the
+        # running version (a feature can't "land in" the release it's already in).
+        assert __version__ not in payload["lands_in"]
+
+    @pytest.mark.parametrize(
+        "invocation",
+        [
+            ["backtest", "--strategy-path", "s.py", "--strategy-class", "S"],
+            ["verify", "--local", "returns.csv"],
+        ],
+    )
+    def test_no_socket_is_opened(self, runner, invocation):
+        with mock.patch.object(socket, "socket", side_effect=AssertionError("opened a socket")):
+            result = runner.invoke(main, invocation, catch_exceptions=False)
+        assert result.exit_code == NOT_IMPLEMENTED
+
+
+# ── login ────────────────────────────────────────────────────────────
+
+
+class TestLogin:
+    def test_success_via_env_credentials_reports_ok_and_caches_session(self, runner, monkeypatch):
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "correct horse battery staple")
+        _install_transport(monkeypatch, _route(_login_ok_route(cookie="tok123", email="dan@example.com")))
+
+        result = runner.invoke(main, ["login", "--json"])
+
+        assert result.exit_code == OK
+        assert json.loads(result.stdout) == {"ok": True, "email": "dan@example.com"}
+
+        cached = json.loads(session_path().read_text())
+        assert cached["email"] == "dan@example.com"
+        assert cached["cookies"][SESSION_COOKIE_NAME] == "tok123"
+
+    def test_session_file_is_written_mode_600(self, runner, monkeypatch):
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "hunter2-but-longer")
+        _install_transport(monkeypatch, _route(_login_ok_route()))
+
+        result = runner.invoke(main, ["login", "--json"])
+
+        assert result.exit_code == OK
+        mode = stat.S_IMODE(session_path().stat().st_mode)
+        assert mode == 0o600, f"session.json is {oct(mode)}, must be 0o600"
+
+    def test_prompts_for_credentials_when_env_vars_absent(self, runner, monkeypatch):
+        _install_transport(monkeypatch, _route(_login_ok_route(email="prompted@example.com")))
+        result = runner.invoke(main, ["login"], input="prompted@example.com\ns3cret\n")
+        assert result.exit_code == OK
+        assert "Logged in as prompted@example.com" in result.stdout
+
+    def test_invalid_credentials_exits_auth(self, runner, monkeypatch):
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "wrong")
+        _install_transport(
+            monkeypatch,
+            _route({("POST", "/api/auth/sign-in/email"): httpx.Response(401, json={"error": "invalid credentials"})}),
+        )
+        result = runner.invoke(main, ["login", "--json"])
+        assert result.exit_code == AUTH
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        assert payload["error"] == "invalid_credentials"
+        assert not session_path().exists()
+
+    def test_adversarial_missing_session_cookie_is_not_trusted(self, runner, monkeypatch):
+        """A 200 with no Set-Cookie header must not be treated as a successful login —
+        this is the input that should fail the 'a session actually exists' guard."""
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "whatever")
+        _install_transport(
+            monkeypatch,
+            _route({("POST", "/api/auth/sign-in/email"): httpx.Response(200, json={"redirect": False})}),
+        )
+        result = runner.invoke(main, ["login", "--json"])
+        assert result.exit_code == AUTH
+        assert json.loads(result.stdout)["error"] == "no_session_cookie"
+        assert not session_path().exists()
+
+    def test_adversarial_cookie_that_does_not_round_trip_is_not_trusted(self, runner, monkeypatch):
+        """The other adversarial case: sign-in returns a cookie, but GET
+        /api/auth/get-session with that exact cookie says nobody's signed in (Better
+        Auth's actual empty-session shape — see `_user_from_payload` in
+        `backend/archimedes/api/account_auth.py`). A naive implementation would cache
+        the cookie anyway because sign-in "succeeded"."""
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "whatever")
+        _install_transport(
+            monkeypatch,
+            _route(
+                {
+                    ("POST", "/api/auth/sign-in/email"): httpx.Response(
+                        200,
+                        json={"redirect": False},
+                        headers=[("set-cookie", f"{SESSION_COOKIE_NAME}=stale; Path=/")],
+                    ),
+                    ("GET", "/api/auth/get-session"): httpx.Response(200, json={"user": None, "session": None}),
+                }
+            ),
+        )
+        result = runner.invoke(main, ["login", "--json"])
+        assert result.exit_code == AUTH
+        assert json.loads(result.stdout)["error"] == "session_not_confirmed"
+        assert not session_path().exists()
+
+    def test_adversarial_non_json_round_trip_response_does_not_crash(self, runner, monkeypatch):
+        """A 200 with a non-JSON body from get-session (proxy hiccup, HTML error page)
+        must fail the same clean way as a confirmed-empty session, not raise an
+        uncaught exception out of the command."""
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "whatever")
+        _install_transport(
+            monkeypatch,
+            _route(
+                {
+                    ("POST", "/api/auth/sign-in/email"): httpx.Response(
+                        200,
+                        json={"redirect": False},
+                        headers=[("set-cookie", f"{SESSION_COOKIE_NAME}=stale; Path=/")],
+                    ),
+                    ("GET", "/api/auth/get-session"): httpx.Response(200, content=b"<html>not json</html>"),
+                }
+            ),
+        )
+        result = runner.invoke(main, ["login", "--json"], catch_exceptions=False)
+        assert result.exit_code == AUTH
+        assert json.loads(result.stdout)["error"] == "session_not_confirmed"
+
+    def test_network_error_is_reported_not_raised(self, runner, monkeypatch):
+        def factory(api_url, *, cookies=None):
+            def blow_up(_request):
+                raise httpx.ConnectError("connection refused")
+
+            return httpx.Client(base_url=api_url, cookies=cookies, transport=httpx.MockTransport(blow_up))
+
+        monkeypatch.setattr(cli_module, "_http_client", factory)
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "whatever")
+
+        result = runner.invoke(main, ["login", "--json"], catch_exceptions=False)
+        assert result.exit_code == AUTH
+        assert json.loads(result.stdout)["error"] == "network_error"
+
+
+# ── meter ────────────────────────────────────────────────────────────
+
+
+class TestMeter:
+    def test_no_session_exits_auth_without_touching_the_network(self, runner, monkeypatch):
+        _forbid_network(monkeypatch)
+        result = runner.invoke(main, ["meter", "--json"])
+        assert result.exit_code == AUTH
+        assert isinstance(result.exception, SystemExit)  # not the network-guard AssertionError
+        payload = json.loads(result.stdout)
+        assert payload == {"ok": False, "command": "meter", "error": "no_session", "message": payload["message"]}
+
+    def test_json_passthrough_on_success(self, runner, monkeypatch):
+        _seed_session(cookie_value="tok-xyz")
+        _install_transport(monkeypatch, _route({("GET", "/api/account/usage"): httpx.Response(200, json=_USAGE_BODY)}))
+        result = runner.invoke(main, ["meter", "--json"])
+        assert result.exit_code == OK
+        assert json.loads(result.stdout) == {"ok": True, **_USAGE_BODY}
+
+    def test_sends_the_cached_session_cookie(self, runner, monkeypatch):
+        _seed_session(cookie_value="tok-xyz")
+        seen = {}
+
+        def handler(request):
+            seen["cookie"] = request.headers.get("cookie", "")
+            return httpx.Response(200, json=_USAGE_BODY)
+
+        _install_transport(monkeypatch, handler)
+        result = runner.invoke(main, ["meter", "--json"])
+        assert result.exit_code == OK
+        assert f"{SESSION_COOKIE_NAME}=tok-xyz" in seen["cookie"]
+
+    def test_human_table_renders_caps_and_price(self, runner, monkeypatch):
+        _seed_session()
+        _install_transport(monkeypatch, _route({("GET", "/api/account/usage"): httpx.Response(200, json=_USAGE_BODY)}))
+        result = runner.invoke(main, ["meter"])
+        assert result.exit_code == OK
+        assert "3/10 used" in result.stdout
+        assert "0/20 used" in result.stdout
+        assert "$0.05" in result.stdout
+
+    def test_quota_backend_unavailable_renders_honestly_not_as_zero(self, runner, monkeypatch):
+        """The repo's fail-soft rule, at the CLI layer: an outage must read as
+        "unavailable", never as a plausible-looking 0/cap."""
+        _seed_session()
+        _install_transport(
+            monkeypatch, _route({("GET", "/api/account/usage"): httpx.Response(200, json=_USAGE_BODY_QUOTA_DOWN)})
+        )
+        result = runner.invoke(main, ["meter"])
+        assert result.exit_code == OK
+        assert "unavailable (quota_backend_unavailable)" in result.stdout
+        assert "None/10" not in result.stdout
+        assert "0/10 used" not in result.stdout  # would misreport the outage as "idle"
+
+    def test_expired_session_exits_auth(self, runner, monkeypatch):
+        _seed_session()
+        _install_transport(
+            monkeypatch,
+            _route({("GET", "/api/account/usage"): httpx.Response(401, json={"detail": "Authentication required"})}),
+        )
+        result = runner.invoke(main, ["meter", "--json"])
+        assert result.exit_code == AUTH
+        assert json.loads(result.stdout)["error"] == "session_expired"
+
+
+# ── verify ───────────────────────────────────────────────────────────
+
+
+class TestVerify:
+    def test_passing_series_exits_0_and_renders_all_four_checks(self, runner, monkeypatch):
+        _seed_session()
+        _install_transport(
+            monkeypatch, _route({("POST", "/api/rigor/verify"): httpx.Response(200, json=_VERIFY_PASS_BODY)})
+        )
+        result = runner.invoke(main, ["verify", "returns.csv"])
+        assert result.exit_code == OK
+        assert "[PASS] DSR" in result.stdout
+        assert "[PASS] OOS consistency" in result.stdout
+        assert "[N/A] PBO" in result.stdout
+        assert "[N/A] Look-ahead" in result.stdout
+        assert "PASSES" in result.stdout
+
+    def test_json_on_a_lookahead_free_strong_oos_series_exits_0(self, runner, monkeypatch):
+        """The issue's literal acceptance check, second half: `--json` on a series with
+        look-ahead-free strong OOS exits 0."""
+        _seed_session()
+        _install_transport(
+            monkeypatch, _route({("POST", "/api/rigor/verify"): httpx.Response(200, json=_VERIFY_PASS_BODY)})
+        )
+        result = runner.invoke(main, ["verify", "returns.csv", "--json"])
+        assert result.exit_code == OK
+        payload = json.loads(result.stdout)
+        assert payload["passes"] is True
+        assert payload["oos_consistency"]["status"] == "pass"
+        assert payload["oos_consistency"]["oos_sharpe"] > 0.0
+
+    def test_failing_series_exits_1(self, runner, monkeypatch):
+        _seed_session()
+        _install_transport(
+            monkeypatch, _route({("POST", "/api/rigor/verify"): httpx.Response(200, json=_VERIFY_FAIL_BODY)})
+        )
+        result = runner.invoke(main, ["verify", "returns.csv", "--json"])
+        assert result.exit_code == GATE_FAILED
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True  # the REQUEST succeeded; the verdict is what failed
+        assert payload["passes"] is False
+        assert payload["pbo"]["status"] == "not_evaluable"  # issue's literal acceptance check
+
+    def test_not_evaluable_rendering_when_nothing_could_run(self, runner, monkeypatch):
+        """The honesty-contract case from the issue's acceptance criteria: every check
+        not_evaluable must render as such (never a silent pass) and still exit 1."""
+        _seed_session()
+        _install_transport(
+            monkeypatch, _route({("POST", "/api/rigor/verify"): httpx.Response(200, json=_VERIFY_NOT_EVALUABLE_BODY)})
+        )
+        result = runner.invoke(main, ["verify", "returns.csv"])
+        assert result.exit_code == GATE_FAILED
+        assert result.stdout.count("[N/A]") == 4
+        assert "[PASS]" not in result.stdout
+        assert "[FAIL]" not in result.stdout
+        assert "FAILS" in result.stdout
+
+    def test_trials_option_is_sent_to_the_api(self, runner, monkeypatch):
+        _seed_session()
+        seen = {}
+
+        def handler(request):
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_VERIFY_PASS_BODY)
+
+        _install_transport(monkeypatch, handler)
+        result = runner.invoke(main, ["verify", "returns.csv", "--trials", "50"])
+        assert result.exit_code == OK
+        assert seen["body"]["trials"] == 50
+        assert len(seen["body"]["returns"]) == 3  # the 3 data rows in the runner fixture's CSV
+
+    def test_header_row_is_skipped_not_sent_as_a_data_point(self, runner, monkeypatch):
+        seen = {}
+
+        def handler(request):
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_VERIFY_PASS_BODY)
+
+        _seed_session()
+        _install_transport(monkeypatch, handler)
+        result = runner.invoke(main, ["verify", "returns.csv"])
+        assert result.exit_code == OK
+        dates = [row["date"] for row in seen["body"]["returns"]]
+        assert "date" not in dates
+        assert dates == ["2026-01-02", "2026-01-03", "2026-01-04"]
+
+    def test_stdin_source_is_parsed_and_sent(self, runner, monkeypatch):
+        seen = {}
+
+        def handler(request):
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_VERIFY_PASS_BODY)
+
+        _seed_session()
+        _install_transport(monkeypatch, handler)
+        result = runner.invoke(main, ["verify", "-"], input="2026-02-01,0.01\n2026-02-02,-0.004\n")
+        assert result.exit_code == OK
+        assert len(seen["body"]["returns"]) == 2
+
+    def test_adversarial_trials_zero_rejected_before_any_network_call(self, runner, monkeypatch):
+        """The guard: --trials must be >= 1 (a self-attested trial count of 0 makes no
+        sense for a deflation). Demonstrated failing, and failing WITHOUT spending a
+        rate-limited API call."""
+        _seed_session()
+        _forbid_network(monkeypatch)
+        result = runner.invoke(main, ["verify", "returns.csv", "--trials", "0", "--json"])
+        assert result.exit_code == USAGE
+        assert isinstance(result.exception, SystemExit)
+        payload = json.loads(result.stdout)
+        assert payload["error"] == "invalid_trials"
+
+    def test_adversarial_empty_returns_rejected_before_any_network_call(self, runner, monkeypatch, tmp_path):
+        """A CSV with a header and nothing else parses to zero rows — must be caught
+        client-side (the API also 422s on this, but the guard should fire first)."""
+        (tmp_path / "header_only.csv").write_text("date,daily_return\n")
+        _seed_session()
+        _forbid_network(monkeypatch)
+        result = runner.invoke(main, ["verify", "header_only.csv", "--json"])
+        assert result.exit_code == USAGE
+        assert isinstance(result.exception, SystemExit)
+        assert json.loads(result.stdout)["error"] == "empty_returns"
+
+    def test_no_session_exits_auth_without_touching_the_network(self, runner, monkeypatch):
+        _forbid_network(monkeypatch)
+        result = runner.invoke(main, ["verify", "returns.csv", "--json"])
+        assert result.exit_code == AUTH
+        assert isinstance(result.exception, SystemExit)
+        assert json.loads(result.stdout)["error"] == "no_session"
+
+    def test_rate_limited_exits_usage_not_gate_failed(self, runner, monkeypatch):
+        """A 429 is not a verdict about the strategy — it must not be conflated with
+        exit 1 (GATE_FAILED)."""
+        _seed_session()
+        _install_transport(
+            monkeypatch,
+            _route({("POST", "/api/rigor/verify"): httpx.Response(429, json={"detail": "rate limited"})}),
+        )
+        result = runner.invoke(main, ["verify", "returns.csv", "--json"])
+        assert result.exit_code == USAGE
+        assert result.exit_code != GATE_FAILED
+        assert json.loads(result.stdout)["error"] == "rate_limited"
+
+    def test_expired_session_exits_auth(self, runner, monkeypatch):
+        _seed_session()
+        _install_transport(
+            monkeypatch,
+            _route({("POST", "/api/rigor/verify"): httpx.Response(401, json={"detail": "Authentication required"})}),
+        )
+        result = runner.invoke(main, ["verify", "returns.csv", "--json"])
+        assert result.exit_code == AUTH
+        assert json.loads(result.stdout)["error"] == "session_expired"
+
+    def test_local_flag_is_still_not_implemented_even_with_a_session(self, runner, monkeypatch):
+        _seed_session()
+        _forbid_network(monkeypatch)
+        result = runner.invoke(main, ["verify", "--local", "returns.csv", "--json"])
+        assert result.exit_code == NOT_IMPLEMENTED
+        assert json.loads(result.stdout)["error"] == "not_implemented"

--- a/cli/tests/test_manifest.py
+++ b/cli/tests/test_manifest.py
@@ -37,16 +37,23 @@ def test_implemented_flags_match_reality():
     assert payload["tool"] == "archimedes"
 
 
-def test_manifest_flags_exist_on_the_real_commands():
-    """Every --flag the manifest declares for a command must exist on that
-    command's actual click params (positional/env-only entries excluded)."""
+def test_manifest_flags_match_the_real_commands_both_directions():
+    """Flag parity is BIDIRECTIONAL (the drift-proofing promise): every --flag
+    the manifest declares must exist on the command, AND every real click
+    --option must appear in the manifest — a new flag added to a command
+    without updating manifest.py must fail this test (review finding: the
+    original one-directional check let that drift through silently)."""
     for name, spec in MANIFEST["commands"].items():
         inputs = spec.get("inputs") or {}
+        declared_flags = {k for k in inputs if k.startswith("--")}
         cmd = main.commands[name]
-        real_flags = {opt for p in cmd.params if isinstance(p, click.Option) for opt in p.opts}
-        for input_name in inputs:
-            if input_name.startswith("--"):
-                assert input_name in real_flags, f"{name}: manifest declares {input_name} but the command lacks it"
+        real_flags = {opt for p in cmd.params if isinstance(p, click.Option) for opt in p.opts if opt.startswith("--")}
+        assert declared_flags <= real_flags, (
+            f"{name}: manifest declares {declared_flags - real_flags} but the command lacks them"
+        )
+        assert real_flags <= declared_flags, (
+            f"{name}: command has {real_flags - declared_flags} undeclared in the manifest"
+        )
 
 
 def test_manifest_exit_codes_match_exits_module():

--- a/cli/tests/test_manifest.py
+++ b/cli/tests/test_manifest.py
@@ -1,0 +1,60 @@
+"""The manifest is a promise; these tests check it against the truth.
+
+House pattern (compare CRUMB_MAP⊂PAGE_TO_PATH, the slowapi AST invariant):
+the hand-written contract in ``manifest.py`` must track the real click
+command tree, so an agent reading ``archimedes manifest`` can trust it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+from click.testing import CliRunner
+
+from archimedes_cli import exits
+from archimedes_cli.cli import main
+from archimedes_cli.manifest import MANIFEST
+
+
+def test_every_click_command_appears_in_the_manifest():
+    assert set(MANIFEST["commands"].keys()) == set(main.commands.keys())
+
+
+def test_implemented_flags_match_reality():
+    """A command marked implemented must not be the NOT_IMPLEMENTED stub, and
+    vice versa — checked by actually invoking the two unimplemented paths."""
+    runner = CliRunner()
+    # backtest is declared unimplemented → must exit NOT_IMPLEMENTED.
+    assert MANIFEST["commands"]["backtest"]["implemented"] is False
+    result = runner.invoke(main, ["backtest", "--strategy-path", __file__, "--strategy-class", "X"])
+    assert result.exit_code == exits.NOT_IMPLEMENTED
+    # manifest is declared implemented → exits OK with parseable JSON.
+    assert MANIFEST["commands"]["manifest"]["implemented"] is True
+    result = runner.invoke(main, ["manifest"])
+    assert result.exit_code == exits.OK
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "archimedes"
+
+
+def test_manifest_flags_exist_on_the_real_commands():
+    """Every --flag the manifest declares for a command must exist on that
+    command's actual click params (positional/env-only entries excluded)."""
+    for name, spec in MANIFEST["commands"].items():
+        inputs = spec.get("inputs") or {}
+        cmd = main.commands[name]
+        real_flags = {opt for p in cmd.params if isinstance(p, click.Option) for opt in p.opts}
+        for input_name in inputs:
+            if input_name.startswith("--"):
+                assert input_name in real_flags, f"{name}: manifest declares {input_name} but the command lacks it"
+
+
+def test_manifest_exit_codes_match_exits_module():
+    assert MANIFEST["exit_codes"].keys() == {"0", "1", "2", "3"}
+    assert exits.OK == 0 and exits.GATE_FAILED == 1 and exits.AUTH == 2 and exits.NOT_IMPLEMENTED == 3
+
+
+def test_manifest_version_matches_package():
+    from archimedes_cli import __version__
+
+    assert MANIFEST["version"] == __version__

--- a/skills/archimedes-cli/SKILL.md
+++ b/skills/archimedes-cli/SKILL.md
@@ -178,7 +178,7 @@ Both are reported with an explicit `status: "not_evaluable"` + `reason` string
 (`_PBO_NOT_EVALUABLE_REASON` / `_LOOK_AHEAD_NOT_EVALUABLE_REASON`,
 rigor_verify_routes.py:64-76) — never silently passed, never defaulted, never
 scored as a `fail` for something that was structurally never run. This mirrors
-the CPCV-honesty pattern documented in `skills/verdict-api/SKILL.md` ("CPCV is
+the CPCV-honesty pattern documented in `skills/verdict-api/SKILL.md` (lands with PR #1260; "CPCV is
 honestly reported as `NOT_RUN`, not silently absent") — same principle, applied
 here to PBO and look-ahead.
 
@@ -200,7 +200,7 @@ verdict uses — no reimplementation, no new thresholds
 submitting a trial matrix to `POST /api/selection-bias/pbo` instead (the
 `_PBO_NOT_EVALUABLE_REASON` string points there directly) — out of scope for
 this CLI's `verify`, and out of scope for this skill; see
-`skills/verdict-api/SKILL.md` for that endpoint family.
+`skills/verdict-api/SKILL.md` (lands with PR #1260) for that endpoint family.
 
 ## Exit codes
 
@@ -266,17 +266,24 @@ cli.py:92-100) — a script never has to parse prose to learn what happened.
 
 - The `POST /api/rigor/verify` / `GET /api/account/usage` endpoints as raw HTTP
   surfaces for a *non-CLI* client (curl, another agent) — that's
-  `skills/verdict-api/SKILL.md`'s territory (it covers the sibling
+  `skills/verdict-api/SKILL.md`'s territory (lands with PR #1260; it covers the sibling
   `/api/generate/*` family in that style; a bare-series `/api/rigor/verify`
   entry could be added there or here later, but isn't duplicated in both).
 - Reading a full strategy passport's DSR/PBO/OOS fields once a strategy has
   gone through real generation with a trial matrix — see
-  `skills/strategy-passport/SKILL.md`. `verify`'s `not_evaluable` PBO is not
+  `skills/strategy-passport/SKILL.md` (lands with PR #1260). `verify`'s `not_evaluable` PBO is not
   the same code path as a passport's real (evaluable) PBO.
 - Wallet linking, on-chain vault actions, or anything payment-related — the
   CLI's `meter` only *reads* the price quote; it never pays.
 
 ## Verify (re-run these before trusting this document)
+
+```bash
+# The sibling skills this document points to exist (they land with PR #1260 —
+# if this grep fails, that PR has not merged yet and those pointers dangle):
+ls skills/verdict-api/SKILL.md skills/strategy-passport/SKILL.md
+```
+
 
 ```bash
 # The three working commands are still exactly these three:

--- a/skills/archimedes-cli/SKILL.md
+++ b/skills/archimedes-cli/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: archimedes-cli
+description: How to install and drive the `archimedes` command-line tool — `login`, `meter`, and `verify` against the hosted API — including the exact `--json` shape on every path, the stable exit-code contract, and why `verify` can only ever evaluate two of the gate's four checks over a bare returns series.
+triggers:
+  - "how do I use the archimedes CLI"
+  - installing or scripting `archimedes-cli` (`pip install archimedes-cli`)
+  - "archimedes login" / "archimedes meter" / "archimedes verify"
+  - wiring `archimedes verify` into a CI job and branching on its exit code
+  - reading a `not_evaluable` PBO or look-ahead status from `verify`'s output
+  - "what does archimedes verify actually check" / "why is PBO not_evaluable"
+  - asking what the CLI does NOT do yet (`backtest`, `verify --local`)
+---
+
+# Driving Archimedes from the command line
+
+This skill grounds every claim in the working tree. File:line citations refer to
+`cli/src/archimedes_cli/` and `backend/archimedes/api/` at the commit this skill
+shipped with (`cli/` commit `c834f41d`, backend commit `9f8fe258`, issue #1305) —
+re-run the greps in "Verify" if the code has moved.
+
+**Version status: 0.1.0.** 0.0.1 was a name-reservation stub — every subcommand
+exited `NOT_IMPLEMENTED`. 0.1.0 fills in exactly three: `login`, `meter`, `verify`.
+`backtest` and `verify --local` still exit `NOT_IMPLEMENTED` (3) — see "What's
+still not implemented" below. Don't imply otherwise.
+
+## Install
+
+```bash
+pip install archimedes-cli
+```
+
+Python ≥3.10, two dependencies (`click`, `httpx`) —
+[`cli/pyproject.toml`](../../cli/pyproject.toml):31-34. No `eth-account`/SIWE
+dependency: login is Better Auth email+password, not a wallet signature
+(pyproject.toml:23-30 explains why in a comment, not just a diff).
+
+## The three commands that work
+
+### `archimedes login`
+
+[`cli/src/archimedes_cli/cli.py`](../../cli/src/archimedes_cli/cli.py):172-254.
+
+```bash
+archimedes login
+# Email: you@example.com
+# Password: ********
+# Logged in as you@example.com. Session cached at /Users/you/.config/archimedes/session.json.
+
+# CI path — no prompt:
+ARCHIMEDES_EMAIL=you@example.com ARCHIMEDES_PASSWORD=hunter2 archimedes login --json
+# {"ok": true, "email": "you@example.com"}
+```
+
+What actually happens, in order (cli.py:187-253):
+
+1. Reads `ARCHIMEDES_EMAIL` / `ARCHIMEDES_PASSWORD` from the environment if both
+   are set; otherwise prompts (`click.prompt`, password hidden) — cli.py:187-192.
+2. `POST /api/auth/sign-in/email` with `{email, password}` — cli.py:196.
+3. Reads the `better-auth.session_token` cookie off the response
+   ([`session.py`](../../cli/src/archimedes_cli/session.py):19-22 —
+   `SESSION_COOKIE_NAME`, matching the fragment
+   `backend/archimedes/api/account_auth.py`'s `_SESSION_COOKIE_FRAGMENT` looks
+   for). No cookie → fails as `no_session_cookie`, does not cache anything
+   (cli.py:215-223).
+4. **Confirms the cookie round-trips** against `GET /api/auth/get-session`
+   before trusting it (cli.py:227-246) — mirrors `scripts/agent_journey.py`'s
+   `step_auth`. A non-JSON or empty 200 body is treated as "not confirmed," not
+   a crash (cli.py:231-235, the `ValueError` branch). No `user.email` in the
+   response → fails as `session_not_confirmed` (cli.py:239-246) and, again,
+   nothing is cached.
+5. Only then: `save_session(...)` writes
+   `~/.config/archimedes/session.json` — [`session.py`](../../cli/src/archimedes_cli/session.py):59-76,
+   opened via `os.open(..., 0o600)` (never briefly world-readable) and
+   `chmod(0o600)` again afterward in case the path pre-existed with looser
+   permissions (session.py:62-65 comment explains why the second chmod isn't
+   redundant).
+
+The password is sent once, on that one request, and is never written to disk
+(cli.py docstring, lines 180-182). Linking a crypto wallet is a separate, later,
+optional step for on-chain vault actions — it is not part of `login` and does
+not authenticate you (cli.py:183-185).
+
+### `archimedes meter`
+
+cli.py:275-316. Requires a cached session (`archimedes login` first).
+
+```bash
+archimedes meter
+# Usage for 2026-08-19 (user usr_01H...)
+#   Per-user: 3/10 used, 7 remaining
+#   Per-IP: 3/20 used, 17 remaining
+#   Price per generation: 0.5 USDC (dry run)
+
+archimedes meter --json
+# {"ok": true, "date": "2026-08-19", "user_id": "usr_01H...",
+#  "user": {"used": 3, "cap": 10, "unlimited": false, "remaining": 7, "error": null},
+#  "ip": {...}, "quote": {"price": 0.5, "asset": "USDC", "dry_run": true}}
+```
+
+`GET /api/account/usage` (cli.py:298) reads the SAME two Redis buckets
+`enforce_generation_quota` enforces, via a new read-only
+`GenerationQuota.peek()` — [`backend/archimedes/services/generation_quota.py`](../../backend/archimedes/services/generation_quota.py):170,
+added for this route without touching enforcement — plus
+`generation_payment.quote()` (`backend/archimedes/services/generation_payment.py`:77),
+the identical call the paywall itself reads. The CLI's number and the paywall's
+invoice can never drift apart because they're one function call, not two
+implementations of the same math
+([`backend/archimedes/api/account_usage_routes.py`](../../backend/archimedes/api/account_usage_routes.py):1-14).
+
+**Honesty point:** a Redis outage renders as `"used": null, "error":
+"quota_backend_unavailable"` (account_usage_routes.py:55-60,
+`DailyCapUsage.error`), which the CLI renders as `unavailable
+(quota_backend_unavailable)` (cli.py:262-263) — never a fabricated `0/cap`. This
+is the same fail-loud-not-fail-soft convention the repo's `CLAUDE.md` names as
+a hard rule for anything a claim depends on.
+
+No session → exits `AUTH` (2) before any network call (cli.py:286-294).
+Expired/revoked session → the API 401s, mapped to `AUTH` with
+`error: "session_expired"` (cli.py:116-123, `_handle_api_error`).
+
+### `archimedes verify RETURNS_CSV`
+
+cli.py:392-463. Requires a cached session.
+
+```bash
+archimedes verify returns.csv
+# n_bars=252  trials=1 (self-attested)
+#   [PASS] DSR — self-attested trials=1: DSR p-value 0.6123 >= floor 0.50 (Newey-West HAC standard error)
+#   [N/A] PBO — PBO (probability of backtest overfitting, ...) requires a trial matrix ...
+#   [PASS] OOS consistency — walk-forward OOS Sharpe 0.7331 > floor 0.00 (chronological 70/30 holdout)
+#   [N/A] Look-ahead — The look-ahead audit is AST-based static analysis of strategy SOURCE CODE; ...
+# PASSES
+
+echo $?   # 0
+
+archimedes verify returns.csv --trials 40 --json
+# {"ok": true, "passes": true, "trials": 40, "self_attested": true, "n_bars": 252,
+#  "dsr": {"status": "pass", "reason": "...", "deflated_sharpe": ..., "dsr_p_value": ...},
+#  "pbo": {"status": "not_evaluable", "reason": "..."},
+#  "oos_consistency": {"status": "pass", "reason": "...", "oos_sharpe": ..., "in_sample_sharpe": ...},
+#  "look_ahead": {"status": "not_evaluable", "reason": "..."}}
+```
+
+`RETURNS_CSV` is two columns (`date,daily_return`); a header row, or any row
+whose second column doesn't parse as a float, is skipped automatically
+(cli.py:319-344, `_parse_returns_csv`). `-` reads from stdin, so this pipes:
+
+```bash
+archimedes backtest --strategy-path mine.py --strategy-class Mine | archimedes verify -
+```
+
+(`backtest` itself is not implemented yet — see below — but the pipe shape is
+already wired and tested, cli.py:466-493.)
+
+`--trials N` (default 1) is a **self-attested** trial/variant count fed into the
+DSR deflation — client-side guarded `>= 1` (cli.py:414-421) with **no HTTP call
+attempted** on violation (`test_adversarial_trials_zero_rejected_before_any_network_call`,
+[`cli/tests/test_cli.py`](../../cli/tests/test_cli.py):569-579). An empty parse
+(e.g. a header-only CSV) is rejected the same way, same guarantee
+(cli.py:424-431; `test_adversarial_empty_returns_rejected_before_any_network_call`,
+test_cli.py:581-590).
+
+## The honesty rule: why two of the four checks are `not_evaluable`
+
+The rigor gate is four checks. `POST /api/rigor/verify`
+([`backend/archimedes/api/rigor_verify_routes.py`](../../backend/archimedes/api/rigor_verify_routes.py):1-41)
+takes a **bare returns series** — no strategy code, no trial matrix — and that
+input shape can only ever support two of them:
+
+| Check | Status for a bare series | Why | Source |
+| --- | --- | --- | --- |
+| **DSR** (deflated Sharpe ratio) | evaluable (`pass`/`fail`) | Needs only the series + a declared trial count | `compute_dsr_hac_and_iid`, gated on `DSR_P_FLOOR` — rigor_verify_routes.py:121-149 |
+| **Walk-forward OOS consistency** | evaluable (`pass`/`fail`) | A chronological 70/30 holdout only needs the series | `compute_oos_sharpe`, gated on `OOS_ABS_FLOOR` — rigor_verify_routes.py:152-181 |
+| **PBO** (probability of backtest overfitting) | always `not_evaluable` | PBO (Bailey et al. 2014 CSCV) is a property of a *selection set* — it measures how much of your winning candidate's edge came from having tried many variants and picking the best. A single series has no sibling candidates to compare against, so there is no selection set to measure overfitting probability against. | rigor_verify_routes.py:24-29, 64-70, 199 |
+| **Look-ahead audit** | always `not_evaluable` | It is AST-based static analysis of strategy *source code*. A returns series carries no code — and Archimedes never executes or uploads strategy code server-side (the CLI README's hard boundary), so this endpoint deliberately accepts only numbers. | rigor_verify_routes.py:30-33, 71-76, 200 |
+
+Both are reported with an explicit `status: "not_evaluable"` + `reason` string
+(`_PBO_NOT_EVALUABLE_REASON` / `_LOOK_AHEAD_NOT_EVALUABLE_REASON`,
+rigor_verify_routes.py:64-76) — never silently passed, never defaulted, never
+scored as a `fail` for something that was structurally never run. This mirrors
+the CPCV-honesty pattern documented in `skills/verdict-api/SKILL.md` ("CPCV is
+honestly reported as `NOT_RUN`, not silently absent") — same principle, applied
+here to PBO and look-ahead.
+
+**The pass rule accounts for this:** `passes` is `True` **iff no evaluable
+check failed AND at least one check was evaluable**
+(rigor_verify_routes.py:202-204). A request where every check comes back
+`not_evaluable` (e.g. a series too short for either DSR or OOS to run) must
+**not** read as passing by vacuous truth — it renders 4×`[N/A]`, zero
+`[PASS]`/`[FAIL]`, and `FAILS`/exit 1
+(`test_not_evaluable_rendering_when_nothing_could_run`, test_cli.py:513-525;
+backend-side: `test_too_short_series_neither_evaluable_check_runs_and_passes_is_false`,
+[`backend/tests/test_rigor_verify_routes.py`](../../backend/tests/test_rigor_verify_routes.py):161).
+
+DSR and OOS reuse the **exact same functions and threshold constants**
+(`compute_dsr_hac_and_iid`, `compute_oos_sharpe`, `DSR_P_FLOOR`,
+`OOS_ABS_FLOOR` from `services/rigor_profiles.py`) that the strategy-passport
+verdict uses — no reimplementation, no new thresholds
+(rigor_verify_routes.py:6-9, 51-58). If you need PBO for real, that means
+submitting a trial matrix to `POST /api/selection-bias/pbo` instead (the
+`_PBO_NOT_EVALUABLE_REASON` string points there directly) — out of scope for
+this CLI's `verify`, and out of scope for this skill; see
+`skills/verdict-api/SKILL.md` for that endpoint family.
+
+## Exit codes
+
+[`cli/src/archimedes_cli/exits.py`](../../cli/src/archimedes_cli/exits.py):15-38 —
+stable from 0.0.1 onward; this is treated as an API a CI job can branch on.
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| 0 | `OK` | Command completed; for `verify`, the gate passed. |
+| 1 | `GATE_FAILED` | The gate ran to completion and returned a failing verdict — a real answer about the strategy, not an error. |
+| 2 | `USAGE` / `AUTH` | Bad arguments, a missing file, **or** no valid session / a rejected one. `AUTH` is a documented alias of `USAGE` (same value, `2`) — kept as a separate name in code so a no-session exit is legible at the call site, but deliberately not a new number (exits.py:25-31): a missing session means no verdict was produced, exactly like a bad argument, not a real answer the way `GATE_FAILED` is. |
+| 3 | `NOT_IMPLEMENTED` | The subcommand exists in the tree but has no implementation this release. |
+
+The split that matters is **1 vs. everything else**. A CI job that treats every
+non-zero exit as "strategy rejected" would report a network timeout or an
+expired session as a research finding — branch on `1` specifically:
+
+```bash
+archimedes verify returns.csv
+case $? in
+  0) echo "gate passed" ;;
+  1) echo "gate failed, not deploying"; exit 1 ;;
+  *) echo "verify did not run"; exit 2 ;;
+esac
+```
+
+## The `--json` contract
+
+Every command honors `--json` on **every** code path, including errors
+(cli.py docstring lines 11-12; `_unavailable`, cli.py:69-89; `_fail`,
+cli.py:92-100) — a script never has to parse prose to learn what happened.
+
+- **Success:** `{"ok": true, ...command-specific fields...}` — `login`:
+  `{ok, email}` (cli.py:251); `meter`: `{ok, **usage}` (cli.py:313); `verify`:
+  `{ok, **body}`, where `body` is the full `RigorVerifyResponse` (cli.py:460).
+- **A produced-but-failing `verify` verdict is still `ok: true`** — the
+  *request* succeeded; the verdict is what failed
+  (`test_failing_series_exits_1` asserts `payload["ok"] is True` alongside
+  `payload["passes"] is False`, test_cli.py:509).
+- **Any error path:** `{"ok": false, "command": ..., "error": <machine-readable slug>, "message": <human string>}`
+  (cli.py:96, `_fail`) — e.g. `"invalid_trials"`, `"empty_returns"`,
+  `"no_session"`, `"session_expired"`, `"rate_limited"`, `"network_error"`.
+- **`NOT_IMPLEMENTED`'s JSON body** additionally carries `"version"` and
+  `"lands_in"` (cli.py:76-85) — see the version-string note below.
+
+## What's still NOT implemented
+
+- **`archimedes backtest`** — always exits `NOT_IMPLEMENTED` (3), regardless of
+  arguments (cli.py:481-493). Running a strategy file means importing and
+  executing arbitrary Python, which is why it's local-only by design, not a
+  performance choice — and that engine isn't published yet.
+- **`archimedes verify --local`** — same exit, same reason: needs the same
+  not-yet-published local execution engine (cli.py:411-412).
+- Both report `lands_in: "unscheduled"` in `--json` mode by default
+  (cli.py:59, `_unavailable`'s default parameter) rather than guessing a
+  version number. This is a **deliberate fix during this same 0.1.0 work**:
+  0.0.1 hardcoded `lands_in="0.1.0"`, which became a false, self-contradictory
+  claim ("lands in 0.1.0") the instant `0.1.0` became the *running* version —
+  exactly the kind of fabricated-future-value claim this repo's conventions
+  forbid. Don't reintroduce a hardcoded target version here.
+
+## Not covered by this skill
+
+- The `POST /api/rigor/verify` / `GET /api/account/usage` endpoints as raw HTTP
+  surfaces for a *non-CLI* client (curl, another agent) — that's
+  `skills/verdict-api/SKILL.md`'s territory (it covers the sibling
+  `/api/generate/*` family in that style; a bare-series `/api/rigor/verify`
+  entry could be added there or here later, but isn't duplicated in both).
+- Reading a full strategy passport's DSR/PBO/OOS fields once a strategy has
+  gone through real generation with a trial matrix — see
+  `skills/strategy-passport/SKILL.md`. `verify`'s `not_evaluable` PBO is not
+  the same code path as a passport's real (evaluable) PBO.
+- Wallet linking, on-chain vault actions, or anything payment-related — the
+  CLI's `meter` only *reads* the price quote; it never pays.
+
+## Verify (re-run these before trusting this document)
+
+```bash
+# The three working commands are still exactly these three:
+grep -n "^@main.command" cli/src/archimedes_cli/cli.py
+
+# Exit codes unchanged:
+grep -n "^OK\|^GATE_FAILED\|^USAGE\|^AUTH\|^NOT_IMPLEMENTED" cli/src/archimedes_cli/exits.py
+
+# The honesty rule is still enforced exactly this way:
+grep -n "not_evaluable" backend/archimedes/api/rigor_verify_routes.py
+grep -n "passes = bool(evaluable)" backend/archimedes/api/rigor_verify_routes.py
+
+# Session cookie name still matches the backend's fragment:
+grep -n "SESSION_COOKIE_NAME" cli/src/archimedes_cli/session.py
+grep -n "_SESSION_COOKIE_FRAGMENT" backend/archimedes/api/account_auth.py
+
+# Session file is still written mode 600:
+grep -n "0o600" cli/src/archimedes_cli/session.py
+
+# backtest / verify --local are still NOT_IMPLEMENTED, not silently shipped:
+grep -n "_unavailable" cli/src/archimedes_cli/cli.py
+
+# lands_in still defaults honestly rather than hardcoding a version:
+grep -n 'lands_in: str = ' cli/src/archimedes_cli/cli.py
+
+# No SIWE/wallet-signature residue in the CLI source (Better Auth replaced it):
+grep -rn "SIWE" cli/src/    # expect: no output
+
+# Full test suites this skill's claims are backed by:
+cd cli && python -m pytest tests/ -q
+cd .. && python -m pytest backend/tests/test_rigor_verify_routes.py backend/tests/test_account_usage_routes.py -q
+```

--- a/skills/archimedes-cli/SKILL.md
+++ b/skills/archimedes-cli/SKILL.md
@@ -38,7 +38,7 @@ dependency: login is Better Auth email+password, not a wallet signature
 
 ### `archimedes login`
 
-[`cli/src/archimedes_cli/cli.py`](../../cli/src/archimedes_cli/cli.py):172-254.
+[`cli/src/archimedes_cli/cli.py`](../../cli/src/archimedes_cli/cli.py):190-275.
 
 ```bash
 archimedes login
@@ -82,7 +82,7 @@ not authenticate you (cli.py:183-185).
 
 ### `archimedes meter`
 
-cli.py:275-316. Requires a cached session (`archimedes login` first).
+cli.py:296-338. Requires a cached session (`archimedes login` first).
 
 ```bash
 archimedes meter
@@ -275,6 +275,19 @@ cli.py:92-100) — a script never has to parse prose to learn what happened.
   the same code path as a passport's real (evaluable) PBO.
 - Wallet linking, on-chain vault actions, or anything payment-related — the
   CLI's `meter` only *reads* the price quote; it never pays.
+
+## `archimedes manifest` — the machine-readable contract
+
+Everything this document says in prose, an agent can get declaratively:
+`archimedes manifest` emits one JSON object — every command's inputs
+(flags, env vars, defaults including the session-aware `--api-url`
+resolution), output shapes, cost class, side effects, exit codes, and
+`implemented` status — always exit 0, no network, no session
+(`cli/src/archimedes_cli/manifest.py`; command at cli.py:519). The
+contract cannot silently drift: `cli/tests/test_manifest.py` walks the real
+click command tree and asserts every command, flag, and exit code in the
+manifest matches it. Prefer the manifest over parsing `--help` when
+integrating programmatically.
 
 ## Verify (re-run these before trusting this document)
 

--- a/skills/archimedes-cli/SKILL.md
+++ b/skills/archimedes-cli/SKILL.md
@@ -116,11 +116,11 @@ a hard rule for anything a claim depends on.
 
 No session → exits `AUTH` (2) before any network call (cli.py:286-294).
 Expired/revoked session → the API 401s, mapped to `AUTH` with
-`error: "session_expired"` (cli.py:116-123, `_handle_api_error`).
+`error: "session_expired"` (cli.py:135-167, `_handle_api_error`).
 
 ### `archimedes verify RETURNS_CSV`
 
-cli.py:392-463. Requires a cached session.
+cli.py:392-486. Requires a cached session.
 
 ```bash
 archimedes verify returns.csv
@@ -143,7 +143,7 @@ archimedes verify returns.csv --trials 40 --json
 
 `RETURNS_CSV` is two columns (`date,daily_return`); a header row, or any row
 whose second column doesn't parse as a float, is skipped automatically
-(cli.py:319-344, `_parse_returns_csv`). `-` reads from stdin, so this pipes:
+(cli.py:341-364, `_parse_returns_csv`). `-` reads from stdin, so this pipes:
 
 ```bash
 archimedes backtest --strategy-path mine.py --strategy-class Mine | archimedes verify -
@@ -230,8 +230,8 @@ esac
 ## The `--json` contract
 
 Every command honors `--json` on **every** code path, including errors
-(cli.py docstring lines 11-12; `_unavailable`, cli.py:69-89; `_fail`,
-cli.py:92-100) — a script never has to parse prose to learn what happened.
+(cli.py docstring lines 11-12; `_unavailable`, cli.py:80-110; `_fail`,
+cli.py:113-121) — a script never has to parse prose to learn what happened.
 
 - **Success:** `{"ok": true, ...command-specific fields...}` — `login`:
   `{ok, email}` (cli.py:251); `meter`: `{ok, **usage}` (cli.py:313); `verify`:
@@ -249,7 +249,7 @@ cli.py:92-100) — a script never has to parse prose to learn what happened.
 ## What's still NOT implemented
 
 - **`archimedes backtest`** — always exits `NOT_IMPLEMENTED` (3), regardless of
-  arguments (cli.py:481-493). Running a strategy file means importing and
+  arguments (cli.py:489-516). Running a strategy file means importing and
   executing arbitrary Python, which is why it's local-only by design, not a
   performance choice — and that engine isn't published yet.
 - **`archimedes verify --local`** — same exit, same reason: needs the same


### PR DESCRIPTION
## Summary

archimedes-cli **0.1.0** — the 0.0.1 name-reservation's own promised first working release: `login`, `meter`, and `verify` against the hosted API, plus the two backend endpoints they need and the first-party skill. Built workflow-first, then personally inspected and re-tested end to end.

Closes #1305

### Backend (two endpoints, account-session-gated)

- **`GET /api/account/usage`** — today's generation count vs both daily caps + the live `generation_payment.quote()` payload, via a new read-only `GenerationQuota.peek()` (enforcement paths untouched — proven by a test driving `peek` and `check_and_increment` against the same store). Redis outage → `used: null` + explicit error, never a fabricated 0.
- **`POST /api/rigor/verify`** — the gate's checks over a bare returns series, reusing the exact passport-gate functions (`compute_dsr_hac_and_iid`, `compute_oos_sharpe`) and the always-on floors (`DSR_P_FLOOR`, `OOS_ABS_FLOOR`) — no reimplementation, no new thresholds. **Honesty contract:** DSR (deflated by the self-attested `trials`) and OOS-consistency are evaluable; **PBO and the look-ahead audit report `not_evaluable` with the decisive reason** (no trial matrix / no source code — which is never uploaded). `passes` requires ≥1 evaluable check and no evaluable failure — no vacuous-truth pass.

### CLI

- `login` — Better Auth email+password (env vars for CI), session-cookie round-trip verified before caching at `~/.config/archimedes/session.json` (mode 600, never briefly world-readable).
- `meter` / `verify RETURNS_CSV [--trials N]` — exit 0 pass / 1 fail / 2 auth / 3 not-implemented; `--json` on every path including errors.
- **`manifest`** — the machine-readable contract (inputs, output shapes, exit codes, cost class, implemented-status per command): agents discover the tool declaratively, not by parsing help prose. Drift-proof: tests walk the real click tree and assert the contract matches it.
- `backtest` / `verify --local` stay `NOT_IMPLEMENTED` (the honest `lands_in` is now "unscheduled", fixing 0.0.1's self-contradicting "lands in 0.1.0").

### Skill

`skills/archimedes-cli/SKILL.md` — grounded file:line in this branch's shipped code, including the not_evaluable honesty rule and the manifest surface.

## Guard demonstrations (house rule 4, executed)

- Synthetic failing series → exit 1, `dsr fail (p=0.000165)`, `oos fail (-3.62)`, `pbo.status=not_evaluable`.
- `trials=0` → 422 before any math; empty returns → 422; unauthenticated → 401; T=3 series → everything not_evaluable and `passes=false` (vacuous-truth guard shown rejecting).
- Redis-down usage → `used: null` with an assertion pinning `used != 0`.

## Verification

```
pytest -m "not integration"   (repo root)   3203 passed  (run twice: builder + verifier)
cli: python -m pytest tests/                41 passed
backend new-route files                     15 passed (re-verified independently; count as of the review-fix commit)
ruff format --check / ruff-gate subset      clean
grep -rn "SIWE" cli/src/                    empty
```


**Depends on #1260** (the sibling skills this skill references — merge #1260 first; the skill's own Verify block checks their existence). **CI note:** this PR adds the cli/tests suite to the blocking quality-gate job so the test claims above are CI-backed.

