### PR TITLE
[api] Add GET /api/generate/jobs/{job_id} job-status poll

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -6,6 +6,7 @@ Endpoints (per ``docs/specs/generation-streaming-spec.md``):
   GET  /api/generate/stream/{job_id}          — SSE event stream
   POST /api/generate/jobs/{job_id}/cancel     — best-effort cancel
   GET  /api/generate/jobs                     — list recent jobs (status table)
+  GET  /api/generate/jobs/{job_id}            — one job's status (poll fallback)
   GET  /api/generate/jobs/{job_id}/candidates — N candidates incl. rejected
 
 This router lives in its own file per the Spine+ v2 plan's cross-cutting
@@ -403,26 +404,73 @@ async def list_jobs(
             continue
         if not owner_user_id and owner_wallet and owner_wallet.lower() != (linked_wallet or "").lower():
             continue
-        brief = payload.get("brief") or {}
-        result = j.get("result") or {}
-        summaries.append(
-            JobSummary(
-                job_id=j["id"],
-                state=_normalize_state(j.get("status") or "queued"),
-                brief_intent=brief.get("intent", ""),
-                created_at=j.get("created_at", ""),
-                updated_at=j.get("updated_at", ""),
-                n_candidates=int(payload.get("n_candidates") or 1),
-                best_strategy_id=result.get("best_strategy_id"),
-            )
-        )
+        summaries.append(_job_summary(j))
     return JobsListResponse(jobs=summaries)
+
+
+def _job_summary(job: dict, job_id: str | None = None) -> JobSummary:
+    """Project one job-store record onto the wire shape.
+
+    Shared by the listing and the single-job read so the two surfaces can never
+    disagree about a job's state — an agent that switches from ``GET /jobs`` to
+    ``GET /jobs/{job_id}`` reads the identical record.
+    """
+    payload = job.get("payload") or {}
+    brief = payload.get("brief") or {}
+    result = job.get("result") or {}
+    return JobSummary(
+        job_id=job.get("id") or job_id or "",
+        state=_normalize_state(job.get("status") or "queued"),
+        brief_intent=brief.get("intent", ""),
+        created_at=job.get("created_at", ""),
+        updated_at=job.get("updated_at", ""),
+        n_candidates=int(payload.get("n_candidates") or 1),
+        best_strategy_id=result.get("best_strategy_id"),
+    )
 
 
 def _normalize_state(s: str) -> str:
     if s in ("queued", "running", "done", "error", "cancelled"):
         return s
     return "queued"
+
+
+@generate_router.get("/jobs/{job_id}", response_model=JobSummary)
+async def get_job(
+    job_id: str,
+    request: Request,
+    user: CurrentUser = Depends(require_current_user),
+) -> JobSummary:
+    """One job's current state — the poll fallback for a client with no live stream (#1292).
+
+    An agent that never opened the SSE stream, or whose connection dropped past
+    the 15-minute event-log TTL, previously had to pull ``GET /jobs`` and scan
+    the whole listing to learn whether its single job had finished. This returns
+    the same ``JobSummary`` record for one job.
+
+    Three refusals, all rendered as the byte-identical 404 the other per-job
+    reads use, so none of them is an existence oracle:
+
+    * unknown / expired ``job_id``;
+    * a job whose ``type`` is not ``generate`` — this endpoint is the generate
+      surface, not a general job reader. The filter mirrors ``list_jobs`` and is
+      load-bearing rather than cosmetic: sibling job types use states outside
+      this router's vocabulary (``strategies_routes`` writes ``failed``), which
+      ``_normalize_state`` would coerce to ``queued`` — reporting a crashed job
+      as still-waiting;
+    * a job owned by another account, or a legacy wallet-owned job whose owner
+      is not the caller's linked wallet (``_require_job_access``).
+
+    The stored ``error`` string is deliberately not surfaced: the pipeline
+    writes raw ``str(exc)`` into it, which is unscrubbed internal detail. The
+    ``error`` state plus the SSE ``error`` event remain the reporting path.
+    """
+    store = get_job_store()
+    job = await store.get(job_id)
+    if not job or job.get("type") != "generate":
+        raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+    _require_job_access(job, user.id, job_id, get_linked_wallet_address(request))
+    return _job_summary(job, job_id)
 
 
 @generate_router.get("/jobs/{job_id}/candidates", response_model=CandidatesListResponse)

--- a/backend/tests/test_generate_job_status.py
+++ b/backend/tests/test_generate_job_status.py
@@ -1,0 +1,232 @@
+"""``GET /api/generate/jobs/{job_id}`` — the single-job status poll (#1292).
+
+An agent that never opened the SSE stream (or dropped past the event-log TTL)
+needs to read one job's state without pulling the whole listing. The endpoint
+carries the same auth rules as the other per-job reads — account session
+required, owner-scoped, mismatch → **404** rather than 403 so it is not an
+existence oracle — plus a ``type == "generate"`` filter mirroring
+``GET /api/generate/jobs``.
+
+Hermetic, mirroring ``test_generate_job_scoping.py``: the Redis-backed job store
+is boundary-mocked, and sessions are real signed fixture cookies mapped onto
+canonical test users by the autouse adapter in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from fastapi.testclient import TestClient
+
+_OWNER = "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+_ATTACKER = "0x9999999999999999999999999999999999999999"
+_JOB_ID = "job-status-1"
+
+# The conftest legacy-SIWE adapter derives the canonical user id from the
+# verified (lower-cased) wallet, so an account-owned fixture job can be tagged
+# with the same value the route compares against.
+_OWNER_USER_ID = f"legacy-test:{_OWNER.lower()}"
+_ATTACKER_USER_ID = f"legacy-test:{_ATTACKER.lower()}"
+
+
+def _cookies(wallet: str) -> dict[str, str]:
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _job(
+    *,
+    owner_user_id: str | None = None,
+    owner_wallet: str | None = None,
+    status: str = "done",
+    job_type: str = "generate",
+    best_strategy_id: str | None = "strat-77",
+) -> dict:
+    return {
+        "id": _JOB_ID,
+        "type": job_type,
+        "status": status,
+        "created_at": "2026-08-19T00:00:00+00:00",
+        "updated_at": "2026-08-19T00:00:05+00:00",
+        "payload": {
+            "owner_user_id": owner_user_id,
+            "owner_wallet": owner_wallet,
+            "brief": {"intent": "low-vol USDC carry"},
+            "n_candidates": 3,
+        },
+        "result": {"best_strategy_id": best_strategy_id, "best_candidate_id": None, "candidates": []},
+    }
+
+
+def _mock_store(job: dict | None, *, recent: list[dict] | None = None) -> MagicMock:
+    """Boundary-mocked job store — only ``.get`` / ``.list_recent_jobs`` are read
+    by the surfaces under test here."""
+    store = MagicMock()
+    store.get = AsyncMock(return_value=job)
+    store.list_recent_jobs = AsyncMock(return_value=recent if recent is not None else ([job] if job else []))
+    return store
+
+
+def _patched(store: MagicMock):
+    return patch("archimedes.api.generate_routes.get_job_store", return_value=store)
+
+
+# ── Session required, and required BEFORE the store lookup ───────────
+
+
+def test_job_status_anonymous_401():
+    """No session → 401. Auth is unconditional on this surface."""
+    with _patched(_mock_store(_job(owner_user_id=_OWNER_USER_ID))) as _:
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}")
+    assert resp.status_code == 401, resp.text
+
+
+async def test_job_status_anonymous_missing_job_401_not_404():
+    """An anonymous caller must get 401 for a MISSING job too — a
+    404-for-missing / 401-for-existing split would let an unauthenticated caller
+    enumerate live job ids. The dependency has to run before the store lookup."""
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/generate/jobs/nonexistent-job-id")
+    assert resp.status_code == 401, resp.text
+
+
+# ── Happy path: the shape an agent polls for ─────────────────────────
+
+
+def test_job_status_owner_reads_state_updated_at_and_best_strategy():
+    store = _mock_store(_job(owner_user_id=_OWNER_USER_ID))
+    with _patched(store):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["job_id"] == _JOB_ID
+    assert body["state"] == "done"
+    assert body["updated_at"] == "2026-08-19T00:00:05+00:00"
+    assert body["best_strategy_id"] == "strat-77"
+    assert body["brief_intent"] == "low-vol USDC carry"
+    assert body["n_candidates"] == 3
+    store.get.assert_awaited_once_with(_JOB_ID)
+
+
+def test_job_status_running_job_reports_running_with_no_strategy_yet():
+    """The whole point of polling: a job still in flight reads ``running`` and
+    carries no strategy id — not a terminal state, not an error."""
+    store = _mock_store(_job(owner_user_id=_OWNER_USER_ID, status="running", best_strategy_id=None))
+    with _patched(store):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["state"] == "running"
+    assert resp.json()["best_strategy_id"] is None
+
+
+def test_job_status_matches_the_listing_entry_for_the_same_job():
+    """Single-job read and listing entry are the same record — switching from
+    the list to the poll can never change what a client believes about a job."""
+    job = _job(owner_user_id=_OWNER_USER_ID)
+    with _patched(_mock_store(job)):
+        client = _client()
+        single = client.get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_OWNER))
+        listing = client.get("/api/generate/jobs", cookies=_cookies(_OWNER))
+    assert single.status_code == 200 and listing.status_code == 200
+    assert listing.json()["jobs"] == [single.json()]
+
+
+def test_candidates_route_still_reachable_alongside_the_new_path():
+    """``/jobs/{job_id}`` must not shadow ``/jobs/{job_id}/candidates``."""
+    with _patched(_mock_store(_job(owner_user_id=_OWNER_USER_ID))):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}/candidates", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["candidates"] == []
+
+
+# ── Guards: each rejects an input that must not be served ────────────
+
+
+def test_job_status_other_account_404_identical_body_to_a_missing_job():
+    """GUARD — cross-account read. A job owned by another ``owner_user_id`` is
+    refused with a 404 whose body is byte-identical to a truly-missing job, so
+    the caller cannot tell 'exists but not yours' from 'does not exist'."""
+    with _patched(_mock_store(_job(owner_user_id=_OWNER_USER_ID))):
+        mismatch = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    with _patched(_mock_store(None)):
+        missing = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    assert mismatch.status_code == 404, mismatch.text
+    assert missing.status_code == 404, missing.text
+    assert mismatch.json()["detail"] == missing.json()["detail"]
+    # Never 403 — that would confirm the job exists.
+    assert mismatch.status_code != 403
+
+
+def test_job_status_legacy_wallet_owned_job_of_another_wallet_404():
+    """GUARD — legacy wallet-owned job (no ``owner_user_id``) whose
+    ``owner_wallet`` is not the caller's linked wallet is refused."""
+    with _patched(_mock_store(_job(owner_wallet=_OWNER.lower()))):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    assert resp.status_code == 404, resp.text
+
+
+def test_job_status_account_owner_beats_a_foreign_wallet_tag():
+    """A job carrying the caller's ``owner_user_id`` stays readable even when its
+    legacy ``owner_wallet`` names someone else — canonical ownership wins, and
+    the wallet clause must not lock the real owner out."""
+    with _patched(_mock_store(_job(owner_user_id=_OWNER_USER_ID, owner_wallet=_ATTACKER.lower()))):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+
+
+def test_job_status_ownerless_legacy_job_readable_by_any_authenticated_caller():
+    """Pre-flip jobs (no owner at all) stay readable to authenticated callers —
+    migration compatibility, matching the candidates route. Still never anonymous."""
+    with _patched(_mock_store(_job())):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    assert resp.status_code == 200, resp.text
+
+
+def test_job_status_non_generate_job_404_even_when_ownerless():
+    """GUARD — the type filter. A sibling job type (``fusion``, enqueued by
+    ``strategies_routes``) is refused, exactly as ``GET /jobs`` refuses to list
+    it. Without the filter this ownerless record would be served to any
+    authenticated caller — see the companion test below for why that is not
+    merely untidy."""
+    with _patched(_mock_store(_job(job_type="fusion", status="failed"))):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    assert resp.status_code == 404, resp.text
+
+
+def test_type_filter_prevents_reporting_a_failed_sibling_job_as_queued():
+    """GUARD, consequence side. ``strategies_routes`` writes the status
+    ``failed`` for fusion jobs; ``_normalize_state`` has no such member and
+    coerces it to ``queued``. Serving a non-generate job would therefore report
+    a crashed job as still-waiting — an agent would poll it forever. Assert both
+    halves: the coercion is real, and the endpoint never exposes it."""
+    from archimedes.api.generate_routes import _normalize_state
+
+    assert _normalize_state("failed") == "queued"  # the misreport this guard prevents
+
+    with _patched(_mock_store(_job(job_type="fusion", status="failed"))):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_ATTACKER))
+    assert resp.status_code == 404
+    assert "queued" not in resp.text
+
+
+def test_job_status_never_leaks_the_raw_error_string():
+    """GUARD — the pipeline stores ``error=str(exc)``, unscrubbed internal
+    detail. An errored job reports the ``error`` STATE and nothing more."""
+    job = _job(owner_user_id=_OWNER_USER_ID, status="error", best_strategy_id=None)
+    job["error"] = "psycopg2.OperationalError: could not connect to server at 10.0.3.14:5432"
+    with _patched(_mock_store(job)):
+        resp = _client().get(f"/api/generate/jobs/{_JOB_ID}", cookies=_cookies(_OWNER))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["state"] == "error"
+    assert "psycopg2" not in resp.text
+    assert "10.0.3.14" not in resp.text

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -16,7 +16,7 @@ Two reasons this matters:
    `generation_started` is attributed in the conversion funnel ([#787](https://github.com/a-apin/archimedes/issues/787)).
 
 **READ** needs no authentication. **GENERATE requires Better Auth session**:
-anonymous `POST /api/generate/start` returns 401, and per-job stream/jobs/candidates
+anonymous `POST /api/generate/start` returns 401, and per-job stream/status/jobs/candidates
 reads are scoped by canonical user ID. Wallet connection alone never authenticates.
 
 ## Quick start
@@ -78,6 +78,30 @@ Events (`event:` name + `data:` JSON), in rough order:
 `job_queued → brief_validated → pipeline_selected → candidates_selected →
 agent_iteration → tool_called → tool_result → candidate_drafted →
 candidate_evaluated → best_selected → trace_hashed → persisted → done` (or `error`).
+
+**Poll fallback** — for a client that never opened the stream, or whose connection dropped
+past the event-log TTL:
+```http
+GET /api/generate/jobs/{job_id}
+```
+```json
+{
+  "job_id": "…",
+  "state": "queued",            // queued | running | done | error | cancelled
+  "brief_intent": "…",
+  "created_at": "…",             // ISO-8601 UTC
+  "updated_at": "…",
+  "n_candidates": 1,
+  "best_strategy_id": null       // set once a winner is persisted
+}
+```
+Identical record to the matching entry in `GET /api/generate/jobs`, so a client can switch
+between the listing and the single-job read without the two disagreeing. `state == "done"`
+with a non-null `best_strategy_id` is the signal to move on to the candidates read below;
+`error` and `cancelled` are terminal. The stored failure string is not exposed — it holds
+raw unscrubbed exception text; the `error` state and the SSE `error` event (which carries
+`message` / `code` / `recoverable`) are the reporting path. Only `generate` jobs are
+readable here; any other job id returns the same 404 as an unknown one.
 
 ### 3. RIGOR — the externalized verdict + considered alternatives
 
@@ -177,6 +201,7 @@ Jobs are tagged with creator `owner_user_id`:
 | --- | --- |
 | `GET /api/generate/stream/{job_id}` | account required (401); user mismatch → **404** (no existence oracle) |
 | `GET /api/generate/jobs` | account required; listing filtered to caller |
+| `GET /api/generate/jobs/{job_id}` | same owner rule as stream; non-`generate` job types → **404** |
 | `GET /api/generate/jobs/{job_id}/candidates` | same owner rule as stream |
 | `POST /api/generate/jobs/{job_id}/cancel` | same owner rule as stream |
 


### PR DESCRIPTION
Closes #1292

## Summary

There was no way to read one generation job's state. A client had the SSE stream
(`GET /api/generate/stream/{job_id}`) and the listing (`GET /api/generate/jobs`), which
returns the caller's whole recent-job set and has to be scanned. An agent that never
opened the stream — or whose connection dropped past the 15-minute event-log TTL — had to
poll the listing to answer a question about a single job.

This adds `GET /api/generate/jobs/{job_id}`, returning that job's `JobSummary`:

```json
{
  "job_id": "…",
  "state": "running",          // queued | running | done | error | cancelled
  "brief_intent": "…",
  "created_at": "2026-08-19T00:00:00+00:00",
  "updated_at": "2026-08-19T00:00:05+00:00",
  "n_candidates": 1,
  "best_strategy_id": null
}
```

It is the same record the listing emits for the same job — both surfaces now go through one
`_job_summary()` projection, so a client switching between them can never see two different
answers about one job. A test pins that equality (`listing == [single]`).

Auth is unchanged in kind: account session required, `_require_job_access` for owner
scoping, 404-not-403 on mismatch with a body byte-identical to a genuinely missing job.
Nothing about the rigor gate, quota, payment, or auth semantics is relaxed — the new route
adds one refusal (`type != "generate"`) on top of the existing rules and removes none.

## What changed, file by file

**`backend/archimedes/api/generate_routes.py`**
- New `GET /jobs/{job_id}` → `get_job()`, mounted on `generate_router` (the router
  `main.py` includes behind `dependencies=[Depends(require_current_user)]`, so the auth
  check runs *before* the store lookup — an anonymous caller cannot probe which job ids
  exist).
- Extracted `_job_summary(job, job_id=None)` from the body of `list_jobs()`; `list_jobs`
  now calls it. Behaviour of the listing is unchanged — same fields, same defaults, same
  `_normalize_state` — it is the same code moved into a function so the single-job read
  cannot drift from it.
- Module docstring endpoint list updated.
- Three refusals in `get_job`, all raising the same
  `404 {"detail": "job {job_id} not found or expired"}` the sibling routes use:
  unknown/expired id; `type != "generate"`; owner mismatch.
- The stored `error` string is deliberately **not** surfaced. The pipeline writes raw
  `str(exc)` into it (`generation_pipeline.py:1203`), which is unscrubbed internal detail.
  The `error` *state* plus the SSE `error` event (which carries `message`/`code`/
  `recoverable`) remain the reporting path.

**`backend/tests/test_generate_job_status.py`** (new, 13 tests) — mirrors
`test_generate_job_scoping.py`: boundary-mocked job store (`AsyncMock` on `.get` /
`.list_recent_jobs`, no Redis), real signed fixture session cookies via the autouse
`conftest.py` adapter, no `.env` dependence, no network.

**`docs/agent-api.md`** — the poll fallback documented in the GENERATE section with its
response shape and the "same record as the listing" guarantee, plus a row in the job
endpoint scoping table. `make docs-check` → `broken 0`, `0 orphaned`.

## Guard demonstrations

House rule: every guard gets the input that *should* fail it, run, confirmed failing.
Each guard below was removed from the code, the suite re-run, and the output transcribed.
All mutations were reverted; the pushed tree is the unmutated version.

### Guard 1 — job type must be `generate`

Input that must be refused: a `fusion` job (the type `strategies_routes.py:2126` enqueues),
ownerless so nothing else would stop it, in state `failed`.

Why it is load-bearing rather than tidiness: `_normalize_state` has no `failed` member and
coerces it to `queued`. Serving a non-generate job would report a crashed job as
still-waiting, and an agent polling it would never stop.

Mutation — `if not job or job.get("type") != "generate":` → `if not job:`

```
=== MUTATION A: type filter removed ===
FAILED backend/tests/test_generate_job_status.py::test_job_status_non_generate_job_404_even_when_ownerless
FAILED backend/tests/test_generate_job_status.py::test_type_filter_prevents_reporting_a_failed_sibling_job_as_queued - assert 200 == 404
================== 2 failed, 11 passed, 15 warnings in 2.63s ===================
```

The second test asserts both halves of the claim: `_normalize_state("failed") == "queued"`
(the misreport is real, not hypothetical) and `"queued" not in resp.text` (the endpoint
never exposes it).

### Guard 2 — owner scoping, 404 not 403

Inputs that must be refused: (a) a job whose `owner_user_id` is another account, read by
`_ATTACKER`; (b) a legacy wallet-owned job (`owner_user_id` absent, `owner_wallet` set to
another wallet), read by `_ATTACKER`.

Mutation — `_require_job_access(...)` call deleted from `get_job`

```
=== MUTATION B: _require_job_access removed ===
FAILED backend/tests/test_generate_job_status.py::test_job_status_other_account_404_identical_body_to_a_missing_job - AssertionError: {"job_id":"job-status-1","state":"done","brief_intent":"low...
FAILED backend/tests/test_generate_job_status.py::test_job_status_legacy_wallet_owned_job_of_another_wallet_404 - AssertionError: {"job_id":"job-status-1","state":"done","brief_intent":"low...
================== 2 failed, 11 passed, 15 warnings in 2.63s ===================
```

The mismatch test also asserts the refusal body equals the truly-missing-job body and that
the status is not 403, so "exists but not yours" is indistinguishable from "does not
exist". A companion positive test
(`test_job_status_account_owner_beats_a_foreign_wallet_tag`) confirms the wallet clause
does not lock out a caller whose canonical `owner_user_id` matches, and
`test_job_status_ownerless_legacy_job_readable_by_any_authenticated_caller` preserves the
existing migration-compat rule.

### Guard 3 — session required, and required before the store lookup

Input that must be refused: an unauthenticated read, of both an existing job id and a
nonexistent one. If auth ran after the lookup, 404-for-missing vs 401-for-existing would
let an anonymous caller enumerate live job ids.

Mutation — route moved from `generate_router` to `generate_public_router` and
`require_current_user` → `get_current_user`

```
=== MUTATION D: route mounted on the PUBLIC router (auth removed) ===
FAILED backend/tests/test_generate_job_status.py::test_job_status_anonymous_401 - AssertionError: {"detail":"job job-status-1 not found or expired"}
FAILED backend/tests/test_generate_job_status.py::test_job_status_anonymous_missing_job_401_not_404 - redis.exceptions.ConnectionError: Error Multiple exceptions: [Errno 61] Con...
================== 2 failed, 11 passed, 15 warnings in 4.06s ===================
```

The second failure is the oracle itself made visible: with auth removed, the unauthenticated
request reached the real job store (`ConnectionError … connecting to localhost:6379`)
instead of being turned away first.

### Guard 4 — the raw error string is never in the response

Input that must not appear on the wire: a job record carrying
`error = "psycopg2.OperationalError: could not connect to server at 10.0.3.14:5432"`.
The response must report `state == "error"` and nothing about the exception.

Mutation — `error: str = ""` added to `JobSummary` and populated from `job["error"]`

```
=== MUTATION C: raw error surfaced in the response ===
FAILED backend/tests/test_generate_job_status.py::test_job_status_never_leaks_the_raw_error_string - assert 'psycopg2' not in '{"job_id":"....3.14:5432"}'
================== 1 failed, 12 passed, 15 warnings in 4.50s ===================
```

### Routing

`test_candidates_route_still_reachable_alongside_the_new_path` pins that `/jobs/{job_id}`
does not shadow `/jobs/{job_id}/candidates`. Registration order from the live OpenAPI
schema:

```
        POST  /api/generate/start
         GET  /api/generate/stream/{job_id}
        POST  /api/generate/jobs/{job_id}/cancel
         GET  /api/generate/jobs
         GET  /api/generate/jobs/{job_id}
         GET  /api/generate/jobs/{job_id}/candidates
         GET  /api/generate/quote
```

## Verification

New tests:
```
$ python -m pytest backend/tests/test_generate_job_status.py -q
13 passed, 15 warnings in 7.27s
```

Hermetic gate (no `.env`, no Redis/Postgres/network in the environment):
```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_generate_job_status.py -q
13 passed, 15 warnings in 2.99s
```

Full unit suite, the command CI runs, from the repo root:
```
$ python -m pytest -m "not integration" -q
3202 passed, 2 skipped, 2 deselected, 187 warnings in 266.21s (0:04:26)
```

Lint / format:
```
$ ruff format --check .
546 files already formatted

$ ruff check --select E9,F63,F7,F40 .
All checks passed!
```

Testing-convention gates:
```
$ grep -r "asyncio.get_event_loop" backend/tests/
(none)

$ make docs-check
links: scanned 1212 in 143 markdown files; broken 0 (0.0%)
index: 139 docs under docs/; 139 indexed, 0 orphaned.
```
