### PR TITLE
[api][agent] Add a headless wallet-link provider; link the real journey from agent discovery

### DIFF
--- a/backend/archimedes/api/agent_manifest_routes.py
+++ b/backend/archimedes/api/agent_manifest_routes.py
@@ -13,16 +13,23 @@ user. Same URL prefix (``/api/agent``), different concept — kept in separate m
 neither docstring has to disambiguate the other's meaning inline.
 
 Honesty note (mirrors docs/agent-api.md): READ / AUTH / GENERATE — including the rigor
-readback surfaced under the generate group (there is no separate ``rigor`` group) — are live today.
+readback surfaced under the generate group (there is no separate ``rigor`` group) — and
+PAPER (simulated deployments, no chain, no funds) are live today.
 DEPLOY, and the marketplace PUBLISH/SUBSCRIBE + MONITOR endpoints that depend on a
 deployed vault, are real routes but not yet wired for agent-driven end-to-end use --
 they land with the T3.2 contract redeploy (issue #588). Never advertise these as
 complete; the ``status`` field on each group says so explicitly.
+
+Every route string here is asserted to resolve against the running app's OpenAPI in
+``backend/tests/test_agent_discovery.py`` — a manifest that advertises a 404 is worse
+than one that omits the endpoint, so the drift is caught in CI rather than by the agent.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter
+
+from archimedes.api.wallet_routes import WALLET_PROVIDERS
 
 agent_manifest_router = APIRouter(prefix="/api/agent", tags=["agent"])
 
@@ -58,6 +65,12 @@ async def get_agent_manifest():
                 "separate optional link under /api/wallets/* and never creates a session."
             ),
             "wallet_link_spec": "EIP-4361",
+            # Read straight off the request model's Literal so the advertised set can
+            # never drift from the set the endpoint actually accepts (#1293). A
+            # non-browser client should send "headless": the other three name browser
+            # wallet software an API caller does not have.
+            "wallet_link_providers": list(WALLET_PROVIDERS),
+            "wallet_link_provider_default_for_agents": "headless",
             "chain_id": 5042002,
         },
         "endpoints": {
@@ -81,15 +94,34 @@ async def get_agent_manifest():
                     "sign_out": "POST /api/auth/sign-out",
                     "wallet_challenge": "POST /api/wallets/challenge",
                     "wallet_verify": "POST /api/wallets/verify",
+                    "wallet_list": "GET /api/wallets",
                 },
             },
             "generate": {
                 "status": "live",
                 "auth_required": True,
                 "routes": {
+                    # Public and unauthenticated, unlike its siblings: an agent can
+                    # price the run before holding a session (#1293).
+                    "quote": "GET /api/generate/quote",
                     "start": "POST /api/generate/start",
                     "stream": "GET /api/generate/stream/{job_id}",
                     "candidates": "GET /api/generate/jobs/{job_id}/candidates",
+                    "strategy": "GET /api/strategies/{strategy_id}",
+                },
+            },
+            # Paper trading is the one deployment path that is live TODAY — it is
+            # simulated, so it does not wait on the T3.2 contract redeploy the way
+            # the `deploy` group below does. An agent that wants an end-to-end
+            # journey now ends it here, not at POST /api/vaults/create.
+            "paper": {
+                "status": "live",
+                "auth_required": True,
+                "routes": {
+                    "deploy": "POST /api/paper/deployments",
+                    "list": "GET /api/paper/deployments",
+                    "read": "GET /api/paper/deployments/{deployment_id}",
+                    "stop": "POST /api/paper/deployments/{deployment_id}/stop",
                 },
             },
             "deploy": {

--- a/backend/archimedes/api/agent_manifest_routes.py
+++ b/backend/archimedes/api/agent_manifest_routes.py
@@ -12,17 +12,29 @@ system health). This file's "agent" is an external AI agent consuming the produc
 user. Same URL prefix (``/api/agent``), different concept — kept in separate modules so
 neither docstring has to disambiguate the other's meaning inline.
 
-Honesty note (mirrors docs/agent-api.md): READ / AUTH / GENERATE — including the rigor
-readback surfaced under the generate group (there is no separate ``rigor`` group) — and
-PAPER (simulated deployments, no chain, no funds) are live today.
+Honesty note (mirrors docs/agent-api.md): READ — including the rigor readback
+``GET /api/strategies/{strategy_id}``, which is a PUBLIC read like its siblings — plus
+AUTH, WALLETLINK, GENERATE, ACCOUNT, RIGOR, and PAPER (simulated deployments, no chain,
+no funds) are live today.
 DEPLOY, and the marketplace PUBLISH/SUBSCRIBE + MONITOR endpoints that depend on a
 deployed vault, are real routes but not yet wired for agent-driven end-to-end use --
 they land with the T3.2 contract redeploy (issue #588). Never advertise these as
 complete; the ``status`` field on each group says so explicitly.
 
+``auth_required`` is a per-GROUP flag, so a route belongs to the group whose gating it
+actually shares — the three ``/api/wallets/*`` routes all sit behind
+``require_current_user`` and therefore live in ``walletLink`` (auth_required True), NOT
+alongside the anonymous sign-up/sign-in routes in ``auth``. The one deliberate exception
+is ``generate.quote``, which is public inside an otherwise-gated group and is called out
+inline there.
+
 Every route string here is asserted to resolve against the running app's OpenAPI in
 ``backend/tests/test_agent_discovery.py`` — a manifest that advertises a 404 is worse
 than one that omits the endpoint, so the drift is caught in CI rather than by the agent.
+That file also asserts that every route shared with the static
+``ui/public/.well-known/agent.json`` card carries the SAME auth flag on both surfaces:
+two discovery documents that disagree about whether a call needs a session send the
+agent into a retry loop it cannot diagnose.
 """
 
 from __future__ import annotations
@@ -79,6 +91,11 @@ async def get_agent_manifest():
                 "auth_required": False,
                 "routes": {
                     "strategies": "GET /api/strategies/",
+                    # The rigor readback. Anonymous-OK like its siblings here: the
+                    # route takes no auth dependency, and visibility is enforced
+                    # per-row (a private strategy 404s rather than 401s), so an
+                    # agent can read a public strategy's verdict before signing in.
+                    "strategy": "GET /api/strategies/{strategy_id}",
                     "assets": "GET /api/explore/assets",
                     "health": "GET /api/health",
                 },
@@ -92,9 +109,21 @@ async def get_agent_manifest():
                     "sign_in": "POST /api/auth/sign-in/email",
                     "session": "GET /api/auth/get-session",
                     "sign_out": "POST /api/auth/sign-out",
-                    "wallet_challenge": "POST /api/wallets/challenge",
-                    "wallet_verify": "POST /api/wallets/verify",
-                    "wallet_list": "GET /api/wallets",
+                },
+            },
+            # Separate from `auth` because the gating is the opposite: linking a
+            # wallet PROVES an address for an account that already holds a session,
+            # so all three routes sit behind require_current_user and 401 without
+            # one. Grouping them under the anonymous `auth` block told an agent it
+            # could start here, which it cannot.
+            "walletLink": {
+                "status": "live",
+                "auth_required": True,
+                "spec": "EIP-4361",
+                "routes": {
+                    "challenge": "POST /api/wallets/challenge",
+                    "verify": "POST /api/wallets/verify",
+                    "list": "GET /api/wallets",
                 },
             },
             "generate": {
@@ -107,7 +136,27 @@ async def get_agent_manifest():
                     "start": "POST /api/generate/start",
                     "stream": "GET /api/generate/stream/{job_id}",
                     "candidates": "GET /api/generate/jobs/{job_id}/candidates",
-                    "strategy": "GET /api/strategies/{strategy_id}",
+                },
+            },
+            # Backs the CLI's `archimedes meter` (#1305): today's generation usage
+            # against both daily caps, plus the live price quote.
+            "account": {
+                "status": "live",
+                "auth_required": True,
+                "routes": {
+                    "usage": "GET /api/account/usage",
+                },
+            },
+            # Backs the CLI's `archimedes verify` (#1305). Distinct from the rigor
+            # READBACK under `read.strategy`: this one runs the gate's admission
+            # checks over a bare returns series the caller submits. Only DSR and
+            # walk-forward OOS are evaluable from a bare series — PBO and the
+            # look-ahead audit report `not_evaluable`, never a silent pass.
+            "rigor": {
+                "status": "live",
+                "auth_required": True,
+                "routes": {
+                    "verify": "POST /api/rigor/verify",
                 },
             },
             # Paper trading is the one deployment path that is live TODAY — it is

--- a/backend/archimedes/api/wallet_routes.py
+++ b/backend/archimedes/api/wallet_routes.py
@@ -7,7 +7,7 @@ import os
 import re
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import Literal
+from typing import Literal, get_args
 from urllib.parse import urlsplit
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -23,11 +23,22 @@ _CHALLENGE_TTL = timedelta(minutes=5)
 _SUPPORTED_CHAIN_ID = int(os.getenv("ARC_CHAIN_ID", "5042002"))
 _NONCE_RE = re.compile(r"^[A-Za-z0-9]{8,}$")
 
+# How the caller's key is held, recorded as PROVENANCE only — it never widens or
+# narrows what a linked wallet may do (that is `is_primary` + the proof itself).
+#
+# ``headless`` exists because the first three are browser-UI concepts and an
+# autonomous API client is none of them (#1293): a script holding a raw key has
+# no MetaMask, no injected EIP-1193 provider, and no Circle passkey. Before it
+# existed the reference journey sent ``browser``, which recorded a fact that was
+# simply untrue. Callers outside the browser should send ``headless``.
+WalletProvider = Literal["metamask", "browser", "circle", "headless"]
+WALLET_PROVIDERS: tuple[str, ...] = get_args(WalletProvider)
+
 
 class WalletChallengeRequest(BaseModel):
     address: str = Field(pattern=r"^0x[a-fA-F0-9]{40}$")
     chain_id: int = Field(gt=0)
-    provider: Literal["metamask", "browser", "circle"]
+    provider: WalletProvider
     circle_wallet_id: str | None = Field(default=None, max_length=128)
 
     @model_validator(mode="after")

--- a/backend/tests/test_agent_discovery.py
+++ b/backend/tests/test_agent_discovery.py
@@ -13,6 +13,14 @@ The ``/api/auth/*`` prefix is the one documented exemption: those routes belong 
 Better Auth Node service (``auth/server.js``), proxied onto the same origin by nginx,
 so they are genuinely absent from the FastAPI route table. The exemption is asserted to
 stay exactly that narrow — widening it would quietly turn this guard off.
+
+A route resolving is necessary but not sufficient. The second guard here is
+**cross-surface consistency**: for every route BOTH surfaces advertise, the auth flag
+must agree. A real 200 that the manifest calls anonymous and the card calls gated is a
+route an agent cannot plan around — it reads one document, omits the session, gets a
+401, and cannot tell a wrong flag from a broken endpoint. That is the #1293 finding this
+file grew for: the manifest filed all three ``/api/wallets/*`` routes under the anonymous
+``auth`` group while every one of them sits behind ``require_current_user``.
 """
 
 from __future__ import annotations
@@ -59,6 +67,40 @@ def unresolved_routes(routes: list[str], index: dict[str, set[str]]) -> list[str
         if method not in index.get(path, set()):
             missing.append(route)
     return missing
+
+
+def auth_flag_by_route(endpoints: dict, flag_key: str) -> dict[str, bool]:
+    """``{"METHOD /path" -> auth flag}`` for one discovery surface.
+
+    ``auth_required`` / ``authRequired`` is a per-GROUP flag on both surfaces, so a
+    route inherits the flag of the group it was filed under — which is exactly how
+    the three ``/api/wallets/*`` routes came to be advertised as anonymous while the
+    app 401s them (#1293). Non-dict members (the card's ``_note``) are skipped.
+
+    A route advertised twice within ONE surface under conflicting flags is itself a
+    contradiction, so it raises here rather than silently resolving last-wins.
+    """
+    flags: dict[str, bool] = {}
+    for name, group in endpoints.items():
+        if not isinstance(group, dict):
+            continue
+        required = group[flag_key]
+        for route in group.get("routes", {}).values():
+            if flags.setdefault(route, required) != required:
+                raise AssertionError(f"{route} carries conflicting {flag_key} values (group {name!r})")
+    return flags
+
+
+def auth_flag_disagreements(manifest_endpoints: dict, card_endpoints: dict) -> dict[str, tuple[bool, bool]]:
+    """``{route -> (manifest flag, card flag)}`` for every route both surfaces
+    advertise and disagree about. Empty dict ⇒ the two surfaces are consistent."""
+    manifest_flags = auth_flag_by_route(manifest_endpoints, "auth_required")
+    card_flags = auth_flag_by_route(card_endpoints, "authRequired")
+    return {
+        route: (manifest_flags[route], card_flags[route])
+        for route in sorted(manifest_flags.keys() & card_flags.keys())
+        if manifest_flags[route] != card_flags[route]
+    }
 
 
 def _card() -> dict:
@@ -141,7 +183,15 @@ async def test_manifest_wallet_providers_match_the_accepted_literal_exactly():
 def test_agent_card_is_valid_json_with_an_endpoints_block():
     card = _card()
     assert card["name"] == "Archimedes"
-    assert set(card["endpoints"]) >= {"read", "auth", "walletLink", "generate", "paper"}
+    assert set(card["endpoints"]) >= {
+        "read",
+        "auth",
+        "walletLink",
+        "generate",
+        "account",
+        "rigor",
+        "paper",
+    }
 
 
 def test_agent_card_routes_all_resolve_against_the_live_openapi():
@@ -178,6 +228,77 @@ def test_agent_card_wallet_providers_match_the_accepted_literal_exactly():
     assert _card()["endpoints"]["walletLink"]["challengeBody"]["provider"] == "headless"
 
 
+# ── the two surfaces must not contradict each other ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shared_routes_carry_the_same_auth_flag_on_both_surfaces():
+    """Cross-surface consistency: whether a call needs a session cannot depend on
+    which discovery document the agent happened to read.
+
+    An agent that reads "anonymous" on one surface and 401s at the call has no way
+    to tell a broken endpoint from a wrong flag — it just retries. This is the
+    guard for the manifest's original ``auth`` group, which advertised the three
+    ``/api/wallets/*`` routes as unauthenticated while the card (correctly) had
+    them behind ``walletLink: authRequired true``.
+    """
+    manifest = await _manifest()
+    disagreements = auth_flag_disagreements(manifest["endpoints"], _card()["endpoints"])
+    assert disagreements == {}, (
+        f"manifest and agent card disagree on auth for {{route: (manifest, card)}}: {disagreements}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_two_surfaces_actually_share_routes():
+    """Anti-vacuity for the check above: a comparison over an empty intersection
+    passes for free, so an accidental rename of every route on one surface must
+    not read as agreement."""
+    manifest = await _manifest()
+    manifest_flags = auth_flag_by_route(manifest["endpoints"], "auth_required")
+    card_flags = auth_flag_by_route(_card()["endpoints"], "authRequired")
+    shared = manifest_flags.keys() & card_flags.keys()
+    assert len(shared) >= 10, f"only {len(shared)} shared routes — the consistency guard is near-vacuous"
+
+
+@pytest.mark.asyncio
+async def test_wallet_link_routes_are_advertised_as_authenticated_on_both_surfaces():
+    """The specific #1293 finding, pinned. All three ``/api/wallets/*`` routes sit
+    behind ``require_current_user``; neither surface may say otherwise."""
+    manifest = await _manifest()
+    manifest_flags = auth_flag_by_route(manifest["endpoints"], "auth_required")
+    card_flags = auth_flag_by_route(_card()["endpoints"], "authRequired")
+    for route in ("POST /api/wallets/challenge", "POST /api/wallets/verify", "GET /api/wallets"):
+        assert manifest_flags[route] is True, f"manifest advertises {route} as anonymous"
+        assert card_flags[route] is True, f"agent card advertises {route} as anonymous"
+
+
+@pytest.mark.asyncio
+async def test_public_strategy_readback_is_not_advertised_as_authenticated():
+    """``GET /api/strategies/{strategy_id}`` takes no auth dependency — visibility is
+    enforced per-row (private ⇒ 404, not 401), so an agent can read a public
+    strategy's rigor verdict before it holds a session."""
+    manifest = await _manifest()
+    manifest_flags = auth_flag_by_route(manifest["endpoints"], "auth_required")
+    assert manifest_flags["GET /api/strategies/{strategy_id}"] is False
+    assert "strategy" in manifest["endpoints"]["read"]["routes"]
+
+
+@pytest.mark.asyncio
+async def test_cli_backing_endpoints_are_discoverable_and_gated():
+    """``meter`` and ``verify`` (#1305) are live agent-relevant endpoints; an agent
+    that cannot find them cannot check its own quota or pre-screen a returns series."""
+    manifest = await _manifest()
+    assert manifest["endpoints"]["account"]["routes"]["usage"] == "GET /api/account/usage"
+    assert manifest["endpoints"]["account"]["auth_required"] is True
+    assert manifest["endpoints"]["rigor"]["routes"]["verify"] == "POST /api/rigor/verify"
+    assert manifest["endpoints"]["rigor"]["auth_required"] is True
+
+    card_routes = set(_card_routes(_card()))
+    assert "GET /api/account/usage" in card_routes
+    assert "POST /api/rigor/verify" in card_routes
+
+
 # ── guard demonstrations: the inputs that MUST be rejected ───────────────────
 
 
@@ -206,6 +327,47 @@ def test_agent_card_with_a_fabricated_endpoint_fails_the_same_check():
     card = _card()
     card["endpoints"]["paper"]["routes"]["bogus"] = "POST /api/paper/does-not-exist"
     assert unresolved_routes(_card_routes(card), _openapi_index()) == ["POST /api/paper/does-not-exist"]
+
+
+@pytest.mark.asyncio
+async def test_cross_surface_check_catches_a_flipped_auth_flag():
+    """The failing input for the consistency guard: flip ONE flag on the real card
+    and every route in that group must be reported. This is the regression the
+    manifest actually shipped, reproduced against the live shapes."""
+    manifest = await _manifest()
+    card = _card()
+    card["endpoints"]["walletLink"]["authRequired"] = False
+
+    disagreements = auth_flag_disagreements(manifest["endpoints"], card["endpoints"])
+    assert disagreements == {
+        "GET /api/wallets": (True, False),
+        "POST /api/wallets/challenge": (True, False),
+        "POST /api/wallets/verify": (True, False),
+    }
+
+
+@pytest.mark.asyncio
+async def test_cross_surface_check_catches_the_flip_in_the_other_direction():
+    """Symmetry: a gated route mis-advertised as public is the dangerous direction,
+    but a public route mis-advertised as gated wastes a sign-in too."""
+    manifest = await _manifest()
+    card = _card()
+    card["endpoints"]["read"]["authRequired"] = True
+
+    disagreements = auth_flag_disagreements(manifest["endpoints"], card["endpoints"])
+    assert disagreements["GET /api/strategies/{strategy_id}"] == (False, True)
+    assert disagreements["GET /api/health"] == (False, True)
+
+
+def test_auth_flag_map_rejects_a_route_filed_under_two_conflicting_groups():
+    """A surface that contradicts ITSELF must not resolve to whichever group was
+    serialized last."""
+    endpoints = {
+        "auth": {"authRequired": False, "routes": {"list": "GET /api/wallets"}},
+        "walletLink": {"authRequired": True, "routes": {"list": "GET /api/wallets"}},
+    }
+    with pytest.raises(AssertionError, match="conflicting authRequired"):
+        auth_flag_by_route(endpoints, "authRequired")
 
 
 def test_exemption_does_not_swallow_a_lookalike_prefix():

--- a/backend/tests/test_agent_discovery.py
+++ b/backend/tests/test_agent_discovery.py
@@ -1,0 +1,213 @@
+"""The two machine-readable discovery surfaces must describe the API that exists.
+
+``GET /api/agent/manifest`` and the static ``ui/public/.well-known/agent.json`` both
+hand an autonomous client a list of routes to call. A stale entry there is worse than
+an omission: the agent spends a request, gets a 404, and has no way to tell "wrong path"
+from "endpoint down". #1293 was filed after exactly that class of dogfood friction.
+
+So both surfaces are checked against the app's own OpenAPI document — the same source
+FastAPI serves at ``/openapi.json`` — rather than against a hand-kept list that would
+drift in lockstep with the thing it is supposed to guard.
+
+The ``/api/auth/*`` prefix is the one documented exemption: those routes belong to the
+Better Auth Node service (``auth/server.js``), proxied onto the same origin by nginx,
+so they are genuinely absent from the FastAPI route table. The exemption is asserted to
+stay exactly that narrow — widening it would quietly turn this guard off.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Routes served by the separate Better Auth Node service, not by FastAPI.
+_EXTERNALLY_SERVED_PREFIXES = ("/api/auth/",)
+
+_ROUTE_RE = re.compile(r"^(GET|POST|PUT|PATCH|DELETE) (/\S*)$")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_AGENT_CARD = _REPO_ROOT / "ui" / "public" / ".well-known" / "agent.json"
+
+
+def _openapi_index() -> dict[str, set[str]]:
+    """{path -> {METHOD, ...}} straight off the live app, no hand-kept mirror."""
+    from archimedes.main import app
+
+    return {path: {m.upper() for m in ops} for path, ops in app.openapi()["paths"].items()}
+
+
+def unresolved_routes(routes: list[str], index: dict[str, set[str]]) -> list[str]:
+    """Which of these ``"METHOD /path"`` strings do NOT exist on the app?
+
+    Malformed strings count as unresolved: a route an agent cannot parse is as
+    useless as one that 404s, and silently ignoring them would let a typo'd
+    method sail through.
+    """
+    missing = []
+    for route in routes:
+        match = _ROUTE_RE.match(route.strip())
+        if match is None:
+            missing.append(route)
+            continue
+        method, path = match.group(1), match.group(2)
+        if path.startswith(_EXTERNALLY_SERVED_PREFIXES):
+            continue
+        if method not in index.get(path, set()):
+            missing.append(route)
+    return missing
+
+
+def _card() -> dict:
+    return json.loads(_AGENT_CARD.read_text())
+
+
+def _card_routes(card: dict) -> list[str]:
+    return [
+        route
+        for group in card["endpoints"].values()
+        if isinstance(group, dict)
+        for route in group.get("routes", {}).values()
+    ]
+
+
+async def _manifest() -> dict:
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ── the exemption is narrow, and stays narrow ────────────────────────────────
+
+
+def test_only_better_auth_is_exempt_from_route_resolution():
+    """One exemption, spelled out. Widening this list disables the guard below."""
+    assert _EXTERNALLY_SERVED_PREFIXES == ("/api/auth/",)
+
+
+# ── manifest ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_manifest_routes_all_resolve_against_the_live_openapi():
+    manifest = await _manifest()
+    routes = [route for group in manifest["endpoints"].values() for route in group["routes"].values()]
+    assert routes, "manifest advertised no routes at all"
+    assert unresolved_routes(routes, _openapi_index()) == []
+
+
+@pytest.mark.asyncio
+async def test_manifest_advertises_the_live_paper_trading_group():
+    """Paper trading is the deployment path that works TODAY — an agent that cannot
+    find it concludes the journey dead-ends at the T3.2-pending vault create."""
+    manifest = await _manifest()
+    paper = manifest["endpoints"]["paper"]
+    assert paper["status"] == "live"
+    assert paper["auth_required"] is True
+    assert paper["routes"]["deploy"] == "POST /api/paper/deployments"
+    assert paper["routes"]["stop"] == "POST /api/paper/deployments/{deployment_id}/stop"
+
+
+@pytest.mark.asyncio
+async def test_manifest_advertises_the_public_generation_quote():
+    manifest = await _manifest()
+    assert manifest["endpoints"]["generate"]["routes"]["quote"] == "GET /api/generate/quote"
+
+
+@pytest.mark.asyncio
+async def test_manifest_wallet_providers_match_the_accepted_literal_exactly():
+    """Drift guard: the advertised set IS the set the endpoint accepts.
+
+    Read off ``WalletChallengeRequest``'s Literal rather than restated, so a value
+    added to one side and not the other fails here instead of in an agent's retry loop.
+    """
+    from archimedes.api.wallet_routes import WALLET_PROVIDERS
+
+    manifest = await _manifest()
+    assert manifest["auth"]["wallet_link_providers"] == list(WALLET_PROVIDERS)
+    assert "headless" in WALLET_PROVIDERS
+    assert manifest["auth"]["wallet_link_provider_default_for_agents"] == "headless"
+
+
+# ── static agent card ────────────────────────────────────────────────────────
+
+
+def test_agent_card_is_valid_json_with_an_endpoints_block():
+    card = _card()
+    assert card["name"] == "Archimedes"
+    assert set(card["endpoints"]) >= {"read", "auth", "walletLink", "generate", "paper"}
+
+
+def test_agent_card_routes_all_resolve_against_the_live_openapi():
+    """The card is a static file with no CI-visible link to the API — which is
+    precisely why it went stale (#1293 dogfood finding #6)."""
+    routes = _card_routes(_card())
+    assert routes, "agent card advertised no routes at all"
+    assert unresolved_routes(routes, _openapi_index()) == []
+
+
+def test_agent_card_covers_the_full_agent_journey():
+    """auth -> wallet link -> quote -> generate -> paper deployment, end to end."""
+    routes = set(_card_routes(_card()))
+    for required in (
+        "POST /api/auth/sign-in/email",
+        "POST /api/wallets/challenge",
+        "POST /api/wallets/verify",
+        "GET /api/generate/quote",
+        "POST /api/generate/start",
+        "GET /api/generate/jobs/{job_id}/candidates",
+        "POST /api/paper/deployments",
+        "GET /api/paper/deployments/{deployment_id}",
+    ):
+        assert required in routes, f"agent card omits {required}"
+
+
+def test_agent_card_wallet_providers_match_the_accepted_literal_exactly():
+    from archimedes.api.wallet_routes import WALLET_PROVIDERS
+
+    auth = _card()["authentication"]
+    assert auth["walletLinkProviders"] == list(WALLET_PROVIDERS)
+    assert auth["walletLinkProviderForAgents"] == "headless"
+    # The worked example an agent will copy verbatim must use the honest value.
+    assert _card()["endpoints"]["walletLink"]["challengeBody"]["provider"] == "headless"
+
+
+# ── guard demonstrations: the inputs that MUST be rejected ───────────────────
+
+
+def test_route_checker_rejects_a_path_the_app_does_not_serve():
+    """The failing input for the resolution guard: a plausible-looking 404."""
+    index = _openapi_index()
+    assert unresolved_routes(["POST /api/paper/deploy"], index) == ["POST /api/paper/deploy"]
+    assert unresolved_routes(["GET /api/wallets/providers"], index) == ["GET /api/wallets/providers"]
+
+
+def test_route_checker_rejects_a_real_path_under_the_wrong_method():
+    """Right path, wrong verb — the failure mode a path-only check would miss."""
+    index = _openapi_index()
+    assert "/api/wallets/challenge" in index
+    assert unresolved_routes(["GET /api/wallets/challenge"], index) == ["GET /api/wallets/challenge"]
+
+
+def test_route_checker_rejects_a_malformed_route_string():
+    index = _openapi_index()
+    assert unresolved_routes(["/api/generate/quote"], index) == ["/api/generate/quote"]
+    assert unresolved_routes(["FETCH /api/generate/quote"], index) == ["FETCH /api/generate/quote"]
+
+
+def test_agent_card_with_a_fabricated_endpoint_fails_the_same_check():
+    """Prove the card guard bites: inject a dead route into the real card shape."""
+    card = _card()
+    card["endpoints"]["paper"]["routes"]["bogus"] = "POST /api/paper/does-not-exist"
+    assert unresolved_routes(_card_routes(card), _openapi_index()) == ["POST /api/paper/does-not-exist"]
+
+
+def test_exemption_does_not_swallow_a_lookalike_prefix():
+    """``/api/authz/...`` is not ``/api/auth/...`` — a prefix check must not slip."""
+    assert unresolved_routes(["GET /api/authz/whoami"], _openapi_index()) == ["GET /api/authz/whoami"]

--- a/backend/tests/test_agent_manifest.py
+++ b/backend/tests/test_agent_manifest.py
@@ -44,7 +44,7 @@ async def test_agent_manifest_endpoint_groups_present():
         resp = await client.get("/api/agent/manifest")
 
     endpoints = resp.json()["endpoints"]
-    expected_groups = {"read", "auth", "generate", "deploy", "marketplace", "monitor"}
+    expected_groups = {"read", "auth", "generate", "paper", "deploy", "marketplace", "monitor"}
     assert set(endpoints.keys()) == expected_groups
     for group in expected_groups:
         assert "status" in endpoints[group]
@@ -64,8 +64,9 @@ async def test_agent_manifest_deploy_and_marketplace_marked_pending():
     for group in ("deploy", "marketplace", "monitor"):
         assert "#588" in endpoints[group]["status"]
 
-    # READ / AUTH / GENERATE are live, not pending.
-    for group in ("read", "auth", "generate"):
+    # READ / AUTH / GENERATE / PAPER are live, not pending. Paper deployments are
+    # simulated, so they do not wait on the contract redeploy.
+    for group in ("read", "auth", "generate", "paper"):
         assert endpoints[group]["status"] == "live"
 
 

--- a/backend/tests/test_agent_manifest.py
+++ b/backend/tests/test_agent_manifest.py
@@ -44,11 +44,23 @@ async def test_agent_manifest_endpoint_groups_present():
         resp = await client.get("/api/agent/manifest")
 
     endpoints = resp.json()["endpoints"]
-    expected_groups = {"read", "auth", "generate", "paper", "deploy", "marketplace", "monitor"}
+    expected_groups = {
+        "read",
+        "auth",
+        "walletLink",
+        "generate",
+        "account",
+        "rigor",
+        "paper",
+        "deploy",
+        "marketplace",
+        "monitor",
+    }
     assert set(endpoints.keys()) == expected_groups
     for group in expected_groups:
         assert "status" in endpoints[group]
         assert "routes" in endpoints[group]
+        assert "auth_required" in endpoints[group], f"{group} must state whether a session is needed"
         assert endpoints[group]["routes"], f"{group} routes must be non-empty"
 
 
@@ -64,9 +76,9 @@ async def test_agent_manifest_deploy_and_marketplace_marked_pending():
     for group in ("deploy", "marketplace", "monitor"):
         assert "#588" in endpoints[group]["status"]
 
-    # READ / AUTH / GENERATE / PAPER are live, not pending. Paper deployments are
-    # simulated, so they do not wait on the contract redeploy.
-    for group in ("read", "auth", "generate", "paper"):
+    # READ / AUTH / WALLETLINK / GENERATE / ACCOUNT / RIGOR / PAPER are live, not
+    # pending. Paper deployments are simulated, so they do not wait on the redeploy.
+    for group in ("read", "auth", "walletLink", "generate", "account", "rigor", "paper"):
         assert endpoints[group]["status"] == "live"
 
 

--- a/backend/tests/test_wallet_linking.py
+++ b/backend/tests/test_wallet_linking.py
@@ -14,7 +14,7 @@ from archimedes.api.wallet_routes import (
     unlink_wallet,
     verify_wallet_challenge,
 )
-from archimedes.models.account import AuthUser, LinkedWallet
+from archimedes.models.account import AuthUser, LinkedWallet, WalletLinkChallenge
 from archimedes.models.chat import Base
 from archimedes.models.identity import ControlledWallet, WalletIdentity
 from archimedes.models.strategy_passport_record import StrategyPassportRecord
@@ -22,6 +22,7 @@ from archimedes.models.strategy_proposal import StrategyProposal
 from archimedes.models.strategy_store import upsert_strategy
 from archimedes.models.user_profile import UserProfile
 from fastapi import HTTPException
+from pydantic import ValidationError
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -388,3 +389,63 @@ def test_legacy_profile_only_counts_when_account_has_no_profile():
         # user-1 now HAS a profile: the claim loop would skip the legacy one,
         # so the prompt must not fire on profile evidence alone.
         assert _wallet_has_unclaimed_legacy_data(session, "user-1", ADDRESS) is False
+
+
+# ── provider provenance (#1293) ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_headless_provider_links_and_is_stored_verbatim():
+    """An API client is not MetaMask, a browser, or a Circle passkey.
+
+    The value must survive challenge -> verify -> LinkedWallet unaltered: it is
+    the provenance a later reader (account settings, support) sees, and silently
+    normalising it back to a browser value would re-introduce the untruth.
+    """
+    with _session() as session:
+        challenge = issue_wallet_challenge(
+            session,
+            _user("user-1"),
+            _challenge(provider="headless"),
+            site_url="https://archimedes-arc.com",
+            now=NOW,
+        )
+        stored = session.query(WalletLinkChallenge).one()
+        assert stored.provider == "headless"
+
+        linked = await verify_wallet_challenge(
+            session,
+            _user("user-1"),
+            _verify(challenge.message),
+            verifier=AsyncMock(return_value=True),
+            now=NOW,
+        )
+        assert linked.provider == "headless"
+        assert linked.address == ADDRESS
+
+
+def test_headless_is_the_only_value_added_to_the_accepted_set():
+    """Pin the enum: the manifest and the agent card both mirror this tuple."""
+    from archimedes.api.wallet_routes import WALLET_PROVIDERS
+
+    assert WALLET_PROVIDERS == ("metamask", "browser", "circle", "headless")
+
+
+@pytest.mark.parametrize("provider", ["agent", "external", "headless-agent", "Headless", "", "browser "])
+def test_unlisted_provider_values_are_rejected(provider):
+    """Guard demonstration: widening the enum by one value must not turn it into
+    a free-text field. Case and whitespace variants are rejected too -- a stored
+    "Headless" would not match the label map the UI renders from."""
+    with pytest.raises(ValidationError):
+        WalletChallengeRequest(address=ADDRESS, chain_id=5042002, provider=provider)
+
+
+def test_circle_wallet_id_still_requires_the_circle_provider():
+    """The new value must not become a side door around the circle_wallet_id rule."""
+    with pytest.raises(ValidationError):
+        WalletChallengeRequest(
+            address=ADDRESS,
+            chain_id=5042002,
+            provider="headless",
+            circle_wallet_id="circle-wallet-1",
+        )

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -135,6 +135,50 @@ GET /api/strategies/{strategy_id}
 > fusion/debate winner reads `pass`/`fail` like any other strategy. **Never weaken
 > the gate to force a `pass` — `pending`/`fail` are honest, deployable-only-on-`pass`.**
 
+### 5. METER + VERIFY — quota readback and standalone rigor (account session required)
+
+Two utility endpoints an agent can call outside the generation journey. Both are
+`require_current_user`-gated and both are advertised at `GET /api/agent/manifest`
+(groups `account` and `rigor`) and in `/.well-known/agent.json`.
+
+```http
+GET /api/account/usage
+```
+```json
+{
+  "date": "2026-08-20",
+  "user_id": "…",
+  "user": { "used": 3, "cap": 10, "unlimited": false, "remaining": 7, "error": null },
+  "ip":   { "used": 3, "cap": 25, "unlimited": false, "remaining": 22, "error": null },
+  "quote": { "…": "the SAME generation_payment.quote() the enforcement path reads" }
+}
+```
+Read this before `POST /api/generate/start` to avoid spending a request on a 429. It
+reads the same two Redis buckets `enforce_generation_quota` enforces (a peek, never a
+write), and the same `quote()` the enforcement path prices from, so the displayed number
+and the enforced number cannot drift. `used` is honestly `null` — never a fabricated
+`0` — when the quota backend is unreachable.
+
+```http
+POST /api/rigor/verify        # rate limited 5/minute
+{ "returns": [{ "date": "2026-01-02", "daily_return": 0.0012 }, …], "trials": 40 }
+```
+Runs the gate's admission checks over a **bare returns series** you submit — no strategy
+code, no trial matrix — reusing the identical functions and threshold constants the
+strategy-passport verdict uses. A bare series can only support two of the four checks:
+
+| Check | From a bare series |
+| --- | --- |
+| DSR | evaluable — deflated by the **self-attested** `trials` count, gated on `DSR_P_FLOOR` |
+| walk-forward OOS | evaluable — single chronological 70/30 holdout, gated on `OOS_ABS_FLOOR` |
+| PBO | always `not_evaluable` — overfitting probability is a property of a *selection set* |
+| look-ahead audit | always `not_evaluable` — AST analysis of code, and this endpoint takes only numbers |
+
+`passes` is `true` **iff** no evaluable check failed *and* at least one check was
+evaluable: an all-`not_evaluable` request (e.g. a too-short series) must never report
+`passes: true` by vacuous truth. `self_attested: true` is returned to keep the caller's
+declared `trials` count visible as the unverified input it is.
+
 ## Account authentication and optional wallet proof
 
 ### Better Auth recipe

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -159,10 +159,17 @@ account for smoke testing.
 Wallet is needed only for wallet/on-chain operations. Account session must exist first.
 
 1. `POST /api/wallets/challenge` with
-   `{ "address": "0x...", "chain_id": 5042002, "provider": "browser" }`.
+   `{ "address": "0x...", "chain_id": 5042002, "provider": "headless" }`.
 2. Sign exact returned `message`; do not reconstruct it.
 3. `POST /api/wallets/verify` with returned message and signature.
 4. `GET /api/wallets` confirms link.
+
+`provider` is provenance only — it never widens or narrows what the link may do. Accepted
+values are `metamask`, `browser`, `circle`, and `headless`. **An API client sends
+`headless`**: the other three name browser wallet software a script does not have, and
+recording one of them logs a fact that is not true. `circle_wallet_id` may accompany
+`circle` only. The live set is advertised at `GET /api/agent/manifest` under
+`auth.wallet_link_providers`.
 
 Challenge is bound to account, normalized address, chain, domain, URI, issue time, and
 five-minute expiry. It is consumed atomically and cannot replay. A wallet already linked

--- a/scripts/agent_journey.py
+++ b/scripts/agent_journey.py
@@ -108,7 +108,9 @@ def step_wallet_link(client: httpx.Client, *, ephemeral: bool) -> str | None:
     try:
         challenge = client.post(
             "/api/wallets/challenge",
-            json={"address": account.address, "chain_id": ARC_CHAIN_ID, "provider": "browser"},
+            # "headless", not "browser": this client holds a raw key and has no
+            # MetaMask, no injected provider, and no Circle passkey (#1293).
+            json={"address": account.address, "chain_id": ARC_CHAIN_ID, "provider": "headless"},
         )
     except httpx.HTTPError as exc:
         print(f"  ✗ wallet challenge transport error: {exc}")

--- a/ui/public/.well-known/agent.json
+++ b/ui/public/.well-known/agent.json
@@ -22,13 +22,105 @@
     "schemes": ["Better Auth session"],
     "methods": ["emailPassword", "google", "github"],
     "description": "Use /api/auth/* and retain session cookie. Optional EIP-4361 wallet proof uses /api/wallets/* and never creates a session.",
-    "walletLinkChainId": 5042002
+    "walletLinkChainId": 5042002,
+    "walletLinkProviders": ["metamask", "browser", "circle", "headless"],
+    "walletLinkProviderForAgents": "headless"
+  },
+  "endpoints": {
+    "_note": "Paths are relative to service.endpoint's origin. The /api/auth/* group is served by the Better Auth service behind the same origin, not by the REST API, so it does not appear in /openapi.json. Every other path here is asserted against the API's OpenAPI document in CI.",
+    "read": {
+      "status": "live",
+      "authRequired": false,
+      "routes": {
+        "strategies": "GET /api/strategies/",
+        "strategy": "GET /api/strategies/{strategy_id}",
+        "assets": "GET /api/explore/assets",
+        "health": "GET /api/health",
+        "manifest": "GET /api/agent/manifest"
+      }
+    },
+    "auth": {
+      "status": "live",
+      "authRequired": false,
+      "routes": {
+        "providers": "GET /api/auth/providers",
+        "signUp": "POST /api/auth/sign-up/email",
+        "signIn": "POST /api/auth/sign-in/email",
+        "session": "GET /api/auth/get-session",
+        "signOut": "POST /api/auth/sign-out"
+      }
+    },
+    "walletLink": {
+      "status": "live",
+      "authRequired": true,
+      "spec": "EIP-4361",
+      "routes": {
+        "challenge": "POST /api/wallets/challenge",
+        "verify": "POST /api/wallets/verify",
+        "list": "GET /api/wallets"
+      },
+      "challengeBody": {
+        "address": "0x...",
+        "chain_id": 5042002,
+        "provider": "headless"
+      }
+    },
+    "generate": {
+      "status": "live",
+      "authRequired": true,
+      "routes": {
+        "quote": "GET /api/generate/quote",
+        "start": "POST /api/generate/start",
+        "stream": "GET /api/generate/stream/{job_id}",
+        "candidates": "GET /api/generate/jobs/{job_id}/candidates"
+      },
+      "note": "quote is public — price the run before holding a session."
+    },
+    "paper": {
+      "status": "live",
+      "authRequired": true,
+      "routes": {
+        "deploy": "POST /api/paper/deployments",
+        "list": "GET /api/paper/deployments",
+        "read": "GET /api/paper/deployments/{deployment_id}",
+        "stop": "POST /api/paper/deployments/{deployment_id}/stop"
+      },
+      "note": "Simulated: no chain, no funds. The only deployment path that is live today."
+    },
+    "deploy": {
+      "status": "landing with the T3.2 redeploy (#588)",
+      "authRequired": true,
+      "routes": {
+        "createVault": "POST /api/vaults/create"
+      }
+    },
+    "marketplace": {
+      "status": "landing with the T3.2 redeploy (#588)",
+      "authRequired": true,
+      "routes": {
+        "publish": "POST /api/marketplace/publish",
+        "subscribe": "POST /api/marketplace/subscribe"
+      }
+    },
+    "monitor": {
+      "status": "landing with the T3.2 redeploy (#588)",
+      "authRequired": false,
+      "routes": {
+        "vaultHealth": "GET /api/vaults/{address}/health"
+      }
+    }
   },
   "skills": [
     {
       "id": "generate-strategy",
       "name": "Generate strategy",
       "description": "Turn a natural-language investment intent into a rigor-gated portfolio strategy (DSR / PBO / walk-forward OOS), grounded in the quantitative-finance research corpus.",
+      "status": "live"
+    },
+    {
+      "id": "paper-trade",
+      "name": "Paper trade",
+      "description": "Deploy a rigor-passing strategy to a simulated paper portfolio and read its running performance. No chain, no funds.",
       "status": "live"
     },
     {

--- a/ui/public/.well-known/agent.json
+++ b/ui/public/.well-known/agent.json
@@ -76,6 +76,22 @@
       },
       "note": "quote is public — price the run before holding a session."
     },
+    "account": {
+      "status": "live",
+      "authRequired": true,
+      "routes": {
+        "usage": "GET /api/account/usage"
+      },
+      "note": "Today's generation usage against both daily caps, plus the live price quote. Backs the CLI's `meter`."
+    },
+    "rigor": {
+      "status": "live",
+      "authRequired": true,
+      "routes": {
+        "verify": "POST /api/rigor/verify"
+      },
+      "note": "Runs the gate's admission checks over a bare returns series you submit. DSR and walk-forward OOS are evaluable; PBO and the look-ahead audit report not_evaluable rather than a silent pass. Backs the CLI's `verify`. Rate limited 5/minute."
+    },
     "paper": {
       "status": "live",
       "authRequired": true,

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -22,12 +22,17 @@ operations. Circle wallet passkeys control Circle wallets; they do not log in to
    - new account: `POST /api/auth/sign-up/email` with
      `{ "name": "...", "email": "...", "password": "..." }`, then sign in
    - confirm: `GET /api/auth/get-session`
-3. **Generate** — `POST /api/generate/start` with `brief.intent` and
+3. **Generate** — price it first with public `GET /api/generate/quote`, then
+   `POST /api/generate/start` with `brief.intent` and
    `brief.risk_appetite`; tail `GET /api/generate/stream/{job_id}` as SSE.
 4. **Rigor** — `GET /api/generate/jobs/{job_id}/candidates`, then
    `GET /api/strategies/{strategy_id}`. `rigor_gate_status` is `pass`, `fail`, or
    `pending`; never infer admission from headline Sharpe alone.
-5. **Wallet operations** — first link wallet using proof flow below. Deploy/publish/
+5. **Paper trade** — live today, simulated (no chain, no funds):
+   `POST /api/paper/deployments` with `{ "strategy_id": "..." }`, then
+   `GET /api/paper/deployments/{deployment_id}` to read performance and
+   `POST /api/paper/deployments/{deployment_id}/stop` to end it.
+6. **Wallet operations** — first link wallet using proof flow below. Deploy/publish/
    subscribe remain subject to live contract status advertised by agent manifest.
 
 ## Optional wallet link (EIP-4361)
@@ -35,7 +40,9 @@ operations. Circle wallet passkeys control Circle wallets; they do not log in to
 Account session must already exist.
 
 1. `POST /api/wallets/challenge` with
-   `{ "address": "0x...", "chain_id": 5042002, "provider": "browser" }`.
+   `{ "address": "0x...", "chain_id": 5042002, "provider": "headless" }`.
+   `provider` is provenance only: `metamask` | `browser` | `circle` | `headless`. An API
+   client sends `headless` — the other three name browser wallet software it lacks.
 2. Sign exact returned `message` with wallet. Do not rebuild it client-side.
 3. `POST /api/wallets/verify` with returned message and signature.
 4. `GET /api/wallets` confirms verified link.

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -35,6 +35,17 @@ operations. Circle wallet passkeys control Circle wallets; they do not log in to
 6. **Wallet operations** — first link wallet using proof flow below. Deploy/publish/
    subscribe remain subject to live contract status advertised by agent manifest.
 
+## Account + rigor utilities (account session required)
+
+- `GET /api/account/usage` — today's generation usage against both daily caps (`user`
+  and `ip`) plus live `quote`. `used` is `null`, never a fabricated `0`, when quota
+  backend is unreachable. Read it before `POST /api/generate/start` to avoid a 429.
+- `POST /api/rigor/verify` — run gate's admission checks over bare returns series you
+  submit: `{ "returns": [{ "date": "...", "daily_return": ... }], "trials": N }`. Rate
+  limited `5/minute`. DSR and walk-forward OOS are evaluable; PBO and look-ahead audit
+  always report `not_evaluable` — bare series carries no selection set and no code.
+  `passes` is true only when at least one check was evaluable and none failed.
+
 ## Optional wallet link (EIP-4361)
 
 Account session must already exist.

--- a/ui/src/components/AccountSettings.jsx
+++ b/ui/src/components/AccountSettings.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { useAuth } from '../AuthContext'
 import { listLinkedWallets, makePrimaryWallet, removeLinkedWallet } from '../linked-wallets'
+import { providerLabel } from '../wallet-providers'
 
 export default function AccountSettings({ walletAddr, onDisconnect }) {
   const { user, signOut } = useAuth()
@@ -74,7 +75,7 @@ export default function AccountSettings({ walletAddr, onDisconnect }) {
               <li key={wallet.id} className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--glass-border)] pt-3">
                 <div>
                   <div className="mono text-sm">{wallet.display_address}</div>
-                  <div className="caption">{wallet.provider} · chain {wallet.chain_id}{wallet.is_primary ? ' · primary' : ''}</div>
+                  <div className="caption">{providerLabel(wallet.provider)} · chain {wallet.chain_id}{wallet.is_primary ? ' · primary' : ''}</div>
                 </div>
                 <div className="flex gap-2">
                   {!wallet.is_primary && (

--- a/ui/src/wallet-providers.js
+++ b/ui/src/wallet-providers.js
@@ -1,0 +1,21 @@
+// Display labels for the `provider` a wallet link was recorded with.
+//
+// Deliberately dependency-free (no ./config, no viem): this is pure data +
+// one lookup, and keeping it importable outside a browser is what lets the
+// node test exercise it directly.
+//
+// The browser can only ever SEND 'metamask' | 'browser' | 'circle' —
+// providerName() in linked-wallets.js emits nothing else. It can READ back
+// 'headless', because an API client links wallets against the same account
+// and has none of those three (#1293).
+export const PROVIDER_LABELS = {
+  metamask: 'MetaMask',
+  browser: 'Browser wallet',
+  circle: 'Circle passkey',
+  headless: 'Headless (API)',
+}
+
+// Anything unrecognised renders as-is rather than being coerced to a
+// wrong-but-familiar label: showing a scripted link as "Browser wallet" is the
+// display half of the same untruth the enum change fixed.
+export const providerLabel = (provider) => PROVIDER_LABELS[provider] ?? (provider || 'unknown')

--- a/ui/test/wallet-providers.test.js
+++ b/ui/test/wallet-providers.test.js
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { PROVIDER_LABELS, providerLabel } from "../src/wallet-providers.js";
+
+// ── provider provenance (#1293) ─────────────────────────────────────────────
+// The browser can only ever SEND metamask | browser | circle, but it READS
+// back whatever the account's other clients linked with — including
+// "headless", which an API client sends because it has none of the three
+// browser wallets. Account settings renders this string, so an unknown value
+// must degrade to itself rather than to a familiar-but-wrong label.
+
+test("every provider the API accepts has a label", () => {
+	const card = JSON.parse(
+		readFileSync(new URL("../public/.well-known/agent.json", import.meta.url)),
+	);
+	const accepted = card.authentication.walletLinkProviders;
+	assert.deepEqual(accepted, ["metamask", "browser", "circle", "headless"]);
+	for (const provider of accepted) {
+		assert.ok(
+			PROVIDER_LABELS[provider],
+			`no display label for provider "${provider}"`,
+		);
+	}
+});
+
+test("headless renders as an API link, not as a browser wallet", () => {
+	assert.equal(providerLabel("headless"), "Headless (API)");
+	assert.notEqual(providerLabel("headless"), providerLabel("browser"));
+});
+
+test("known providers render their own label", () => {
+	assert.equal(providerLabel("metamask"), "MetaMask");
+	assert.equal(providerLabel("browser"), "Browser wallet");
+	assert.equal(providerLabel("circle"), "Circle passkey");
+});
+
+// Guard demonstration: the inputs that must NOT be coerced to a wrong label.
+test("an unrecognised provider is shown verbatim, never as a browser wallet", () => {
+	for (const unknown of ["ledger", "walletconnect", "Headless", ""]) {
+		assert.notEqual(
+			providerLabel(unknown),
+			"Browser wallet",
+			`"${unknown}" was mislabelled as a browser wallet`,
+		);
+	}
+	assert.equal(providerLabel("ledger"), "ledger");
+});
+
+test("a missing provider degrades to unknown rather than crashing", () => {
+	assert.equal(providerLabel(undefined), "unknown");
+	assert.equal(providerLabel(null), "unknown");
+	assert.equal(providerLabel(""), "unknown");
+});


### PR DESCRIPTION
Closes #1293

## Summary

Three findings, one root cause: the discoverability surfaces described a product an autonomous client could not actually drive.

1. **`POST /api/wallets/challenge` accepted only `metamask | browser | circle`.** All three name browser wallet software. A script holding a raw key has none of them, so the reference journey (`scripts/agent_journey.py`) picked `browser` arbitrarily and wrote a `provider` value that was simply false — and `provider` is provenance the account-settings page renders back to the user. The enum gains **`headless`**, and the advertised set is now read off the request model's `Literal` rather than restated, so the endpoint / manifest / agent-card can no longer disagree.

2. **`/.well-known/agent.json` linked no endpoints.** It carried a name, a blurb, skills, and a pointer to `/api/agent/manifest` — an agent still had to guess the journey. The card now spells out auth → wallet link → quote → generate → paper deployment, and `GET /api/agent/manifest` gains the public generation quote plus a `paper` group (the one deployment path that is live today; the vault-create path is still pending the T3.2 redeploy).

3. **The surfaces disagreed about which calls need a session, and omitted two live ones.** The manifest filed all three `/api/wallets/*` routes under the anonymous `auth` group while every one of them sits behind `require_current_user`; it flagged the public `GET /api/strategies/{strategy_id}` readback as gated; and `GET /api/account/usage` + `POST /api/rigor/verify` (the CLI's `meter` / `verify` backends, #1305) appeared on no surface at all. All four are corrected, and a cross-surface consistency guard now keeps the manifest and the agent card from contradicting each other.

Both surfaces are now checked against the app's own OpenAPI document in CI, so a route that 404s cannot ship as advice — and against each other, so a route that 401s cannot ship advertised as anonymous.

**Semantics unchanged.** `provider` is provenance and has never been an authorization input; adding a value does not widen any gate. `circle_wallet_id` still requires `provider == "circle"`. The `LinkedWallet.provider` column is `String(64)` with no DB-level constraint, so there is no migration. No change to the rigor gate, quota, payment, or auth paths.

## What changed, file by file

**Backend**

- `backend/archimedes/api/wallet_routes.py` — `WalletProvider = Literal["metamask", "browser", "circle", "headless"]`, exported alongside `WALLET_PROVIDERS = get_args(WalletProvider)`. `WalletChallengeRequest.provider` now uses the alias. The comment states why `headless` exists and what `provider` is (and is not) for.
- `backend/archimedes/api/agent_manifest_routes.py` — `auth.wallet_link_providers` is `list(WALLET_PROVIDERS)` (imported, not restated) plus `auth.wallet_link_provider_default_for_agents = "headless"`. `endpoints.generate` gains `quote` (`GET /api/generate/quote`, public); new `endpoints.paper` group (status `live`, 4 routes). Auth grouping corrected to match the gating the app actually enforces:

  - New `walletLink` group (`auth_required: True`, `spec: EIP-4361`) holding `challenge` / `verify` / `list`. They were under `auth` at `auth_required: False`, which told an agent it could start there; all three `Depends(require_current_user)` and 401 without a session. `wallet_list` arrived on this branch, `wallet_challenge` / `wallet_verify` were mis-grouped on `main` already — both halves are fixed here rather than leaving a known-false flag in place.
  - `strategy` (`GET /api/strategies/{strategy_id}`) moved from `generate` (`True`) to `read` (`False`). Checked against the route: it takes no auth dependency. `get_current_user` is consulted only for per-row visibility, and a non-visible row 404s rather than 401s, so a public strategy's rigor verdict is readable anonymously. `agent.json` already had it under `read`.
  - New `account` group (`GET /api/account/usage`) and `rigor` group (`POST /api/rigor/verify`), both `auth_required: True`.

  Module docstring updated: PAPER joins the live list, the honesty note now names the rigor readback as a public read, `auth_required` is documented as a per-GROUP flag (with `generate.quote` called out as the one deliberate public-inside-gated exception), and it points at both tests that keep the surface honest.

**Static discovery**

- `ui/public/.well-known/agent.json` — new `endpoints` block: `read`, `auth`, `walletLink` (with a `challengeBody` example that uses `provider: "headless"`), `generate`, `account`, `rigor`, `paper`, `deploy`, `marketplace`, `monitor`, each with `status` + `authRequired`. `account` and `rigor` carry `usage` and `verify` respectively, both `authRequired: true`. `authentication` gains `walletLinkProviders` and `walletLinkProviderForAgents`. New `paper-trade` skill, status `live`. The `_note` records that `/api/auth/*` is served by the Better Auth service and therefore absent from `/openapi.json`.
- `ui/public/llms.txt` — journey step 3 mentions the public quote; new step 5 covers paper deployments; the wallet-link body uses `headless` and lists the accepted values. New "Account + rigor utilities" section for `GET /api/account/usage` and `POST /api/rigor/verify`, with the request shape and the `not_evaluable` honesty contract.
- `docs/agent-api.md` — wallet-link recipe uses `headless`; new paragraph on what `provider` means, the four accepted values, the `circle_wallet_id` pairing rule, and where the live set is advertised. New journey section 5 (METER + VERIFY) documenting both CLI-backing endpoints: response shapes read off `AccountUsageResponse` / `RigorVerifyRequest` rather than restated, why `used` is `null` and not `0` when the quota backend is down, and a table of which of the four rigor checks a bare returns series can and cannot support.

**Clients**

- `scripts/agent_journey.py` — sends `provider: "headless"` instead of `"browser"`.
- `ui/src/wallet-providers.js` (new) — `PROVIDER_LABELS` + `providerLabel()`. Dependency-free on purpose (no `./config`, no viem) so it is importable under plain `node --test`. Unknown values render verbatim; empty/absent renders `unknown`.
- `ui/src/components/AccountSettings.jsx` — the linked-wallet caption renders `providerLabel(wallet.provider)` instead of the raw string, so a headless link reads "Headless (API)" rather than a bare token. The browser never *sends* `headless` (`providerName()` in `linked-wallets.js` can only emit the three browser values) but it does *read* one back from `GET /api/wallets`.

**Tests**

- `backend/tests/test_agent_discovery.py` (new, 22 cases) — two guards.

  *Resolution:* `unresolved_routes()` parses each `"METHOD /path"` string and checks it against `app.openapi()["paths"]`. Applied to every route in the manifest and every route in the shipped agent card. `/api/auth/*` is the single exemption (Better Auth Node service, proxied onto the same origin), and the exemption tuple is itself asserted so widening it fails loudly.

  *Cross-surface consistency:* `auth_flag_by_route()` + `auth_flag_disagreements()` compare, for every route BOTH surfaces advertise, the auth flag each one claims. Resolution alone never catches this class — the wallet routes resolve fine, they just 401. The comparison is anti-vacuity-checked (a shared-route floor, so an accidental rename on one side cannot read as agreement), and `auth_flag_by_route` raises rather than resolving last-wins if one surface files a route under two conflicting groups. Plus the provider drift guards on both surfaces and pinned assertions for the specific routes involved.
- `backend/tests/test_wallet_linking.py` — `headless` survives challenge → verify → `LinkedWallet` unaltered; `WALLET_PROVIDERS` pinned; parametrised rejection of unlisted values; `circle_wallet_id` + `headless` still rejected.
- `backend/tests/test_agent_manifest.py` — expected group set gains `paper`, `walletLink`, `account`, `rigor`; the same four added to the live-status loop; every group is now asserted to carry an `auth_required` flag at all.
- `ui/test/wallet-providers.test.js` (new, 5 cases) — every provider the card advertises has a label; `headless` does not render as a browser wallet; unknown values are not coerced.

## Guard demonstrations

Every guard was run against the input that should fail it, before pushing.

**1. Revert the enum** — `WalletProvider = Literal["metamask", "browser", "circle"]`:

```
$ python -m pytest backend/tests/test_wallet_linking.py -q -k "headless"
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for WalletChallengeRequest
E   AssertionError: assert ('metamask', ...er', 'circle') == ('metamask', ...', 'headless')
FAILED backend/tests/test_wallet_linking.py::test_headless_provider_links_and_is_stored_verbatim
FAILED backend/tests/test_wallet_linking.py::test_headless_is_the_only_value_added_to_the_accepted_set
2 failed, 2 passed, 16 deselected, 1 warning in 2.76s

$ python -m pytest backend/tests/test_agent_discovery.py -q
FAILED backend/tests/test_agent_discovery.py::test_manifest_wallet_providers_match_the_accepted_literal_exactly - AssertionError: assert 'headless' in ('metamask', 'browser', 'circle')
FAILED backend/tests/test_agent_discovery.py::test_agent_card_wallet_providers_match_the_accepted_literal_exactly - AssertionError: assert ['metamask', ...', 'headless'] == ['metamask', ...er...
2 failed, 20 passed, 1 warning in 4.59s
```

**2. Ship a dead route in the agent card** — injected `"bogus": "POST /api/paper/deploy"` into the real `ui/public/.well-known/agent.json`:

```
$ python -m pytest backend/tests/test_agent_discovery.py -q -k "card_routes_all_resolve"
E   AssertionError: assert ['POST /api/paper/deploy'] == []
FAILED backend/tests/test_agent_discovery.py::test_agent_card_routes_all_resolve_against_the_live_openapi
1 failed, 21 deselected, 1 warning in 5.16s
```

**3. Restate the provider list in the manifest instead of importing it** — `"wallet_link_providers": ["metamask", "browser", "circle"]` (i.e. a stale hand-kept copy, the exact drift the import exists to prevent):

```
$ python -m pytest backend/tests/test_agent_discovery.py -q -k "manifest_wallet_providers"
E   AssertionError: assert ['metamask', ...er', 'circle'] == ['metamask', ...', 'headless']
FAILED backend/tests/test_agent_discovery.py::test_manifest_wallet_providers_match_the_accepted_literal_exactly
1 failed, 21 deselected, 1 warning in 4.43s
```

**4. Widen the exemption to disable the route check** — `_EXTERNALLY_SERVED_PREFIXES = ("/api/",)`:

```
$ python -m pytest backend/tests/test_agent_discovery.py -q
FAILED backend/tests/test_agent_discovery.py::test_only_better_auth_is_exempt_from_route_resolution - AssertionError: assert ('/api/',) == ('/api/auth/',)
FAILED backend/tests/test_agent_discovery.py::test_route_checker_rejects_a_path_the_app_does_not_serve - AssertionError: assert [] == ['POST /api/paper/deploy']
FAILED backend/tests/test_agent_discovery.py::test_route_checker_rejects_a_real_path_under_the_wrong_method - AssertionError: assert [] == ['GET /api/wallets/challenge']
FAILED backend/tests/test_agent_discovery.py::test_agent_card_with_a_fabricated_endpoint_fails_the_same_check - AssertionError: assert [] == ['POST /api/p...es-not-exist']
FAILED backend/tests/test_agent_discovery.py::test_exemption_does_not_swallow_a_lookalike_prefix - AssertionError: assert [] == ['GET /api/authz/whoami']
5 failed, 17 passed, 1 warning in 4.04s
```

**5. Coerce an unknown provider to a familiar label** — `providerLabel = (provider) => PROVIDER_LABELS[provider] ?? 'Browser wallet'`:

```
$ node --test test/wallet-providers.test.js
✖ an unrecognised provider is shown verbatim, never as a browser wallet (1.609584ms)
✖ a missing provider degrades to unknown rather than crashing (1.218708ms)
ℹ pass 3
ℹ fail 2
```

**6. Flip one auth flag** — the guard added for finding 3, run in both directions against the real, committed shapes.

Card side, `walletLink.authRequired: true -> false`:

```
$ python -m pytest backend/tests/test_agent_discovery.py -q -k "shared_routes or wallet_link_routes"
E   AssertionError: manifest and agent card disagree on auth for {route: (manifest, card)}: {'GET /api/wallets': (True, False), 'POST /api/wallets/challenge': (True, False), 'POST /api/wallets/verify': (True, False)}
E   AssertionError: agent card advertises POST /api/wallets/challenge as anonymous
FAILED backend/tests/test_agent_discovery.py::test_shared_routes_carry_the_same_auth_flag_on_both_surfaces
FAILED backend/tests/test_agent_discovery.py::test_wallet_link_routes_are_advertised_as_authenticated_on_both_surfaces
2 failed, 20 deselected, 1 warning in 3.88s
```

Manifest side, `walletLink.auth_required: True -> False` (i.e. the exact regression this PR is fixing, re-introduced):

```
$ python -m pytest backend/tests/test_agent_discovery.py -q -k "shared_routes or wallet_link_routes"
E   AssertionError: manifest and agent card disagree on auth for {route: (manifest, card)}: {'GET /api/wallets': (False, True), 'POST /api/wallets/challenge': (False, True), 'POST /api/wallets/verify': (False, True)}
E   AssertionError: manifest advertises POST /api/wallets/challenge as anonymous
FAILED backend/tests/test_agent_discovery.py::test_shared_routes_carry_the_same_auth_flag_on_both_surfaces
FAILED backend/tests/test_agent_discovery.py::test_wallet_link_routes_are_advertised_as_authenticated_on_both_surfaces
2 failed, 20 deselected, 1 warning in 3.15s
```

Both mutations were reverted and the file re-run clean before pushing. The same two flips are also pinned as committed guard-demonstration tests (`test_cross_surface_check_catches_a_flipped_auth_flag`, `test_cross_surface_check_catches_the_flip_in_the_other_direction`), so the guard carries its own failing input rather than relying on this transcript.

Guards that already reject in the committed tree (no revert needed — they carry their own failing input): `test_route_checker_rejects_a_path_the_app_does_not_serve`, `test_route_checker_rejects_a_real_path_under_the_wrong_method` (right path, wrong verb — the case a path-only check would miss), `test_route_checker_rejects_a_malformed_route_string`, `test_agent_card_with_a_fabricated_endpoint_fails_the_same_check`, `test_exemption_does_not_swallow_a_lookalike_prefix` (`/api/authz/…` must not slip through the `/api/auth/` exemption), `test_unlisted_provider_values_are_rejected` (`agent`, `external`, `headless-agent`, `Headless`, `""`, `"browser "` — case and whitespace variants included, because a stored `"Headless"` would miss the UI label map), `test_circle_wallet_id_still_requires_the_circle_provider`, and `test_auth_flag_map_rejects_a_route_filed_under_two_conflicting_groups` (one surface filing `GET /api/wallets` under both an anonymous and a gated group must raise, not silently pick the last one).

## Verification

Full unit suite, from the repo root, the command CI runs:

```
$ python -m pytest -m "not integration" -q
3235 passed, 2 skipped, 2 deselected, 174 warnings in 272.08s (0:04:32)
```

Touched + new backend tests:

```
$ python -m pytest backend/tests/test_agent_discovery.py backend/tests/test_agent_manifest.py backend/tests/test_wallet_linking.py -q
47 passed, 1 warning in 4.49s
```

Hermetic gate (no `.env`, no services):

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_agent_discovery.py backend/tests/test_wallet_linking.py -q
42 passed, 1 warning in 3.62s
```

Ruff:

```
$ ruff format --check .
555 files already formatted

$ ruff check --select E9,F63,F7,F40 .
All checks passed!
```

Frontend (`npm ci && npm test && npm run lint && npm run build`):

```
ℹ tests 66
ℹ pass 66
ℹ fail 0

> eslint .
(no output)

✓ built in 2.59s
```

Docs gate:

```
$ make docs-check
links: scanned 1068 in 133 markdown files; broken 0 (0.0%)
index: 129 docs under docs/; 129 indexed, 0 orphaned.
```

