### PR TITLE
[strategy] Instrument the true marginal cost of one generation

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -46,6 +46,7 @@ from archimedes.agents.generation_pipeline import (
     _CandidateResult,
     _society_num_trials,
 )
+from archimedes.services import cost_meter
 from archimedes.services._fusion_helpers import equity_curve_to_daily_returns
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -696,8 +697,13 @@ async def _run_debate_leaderboard(
         args_summary=f"steers={len(_STEERS)}, asset_classes={brief.asset_classes or '(any)'}",
     )
 
-    corpus = await asyncio.to_thread(load_corpus)
-    pool = await _propose_pool(brief, model, corpus)
+    # Cost instrumentation (#1217): the society's own phases are timed here so the
+    # per-phase breakdown answers "which phase dominates" — corpus retrieval vs.
+    # the LLM debate vs. the backtests — rather than collapsing into one number.
+    with cost_meter.stage("corpus_load"):
+        corpus = await asyncio.to_thread(load_corpus)
+    with cost_meter.stage("debate_propose"):
+        pool = await _propose_pool(brief, model, corpus)
     pool_size = len(pool)
     if pool_size == 0:
         raise DebateUnavailable("debate produced no actionable, DSL-conformant candidate (empty pool)")
@@ -710,7 +716,8 @@ async def _run_debate_leaderboard(
     )
 
     # Step 2 — best-effort adversarial transcript (never gates).
-    await _debate_round(pool, model, emit, candidate_id)
+    with cost_meter.stage("debate_transcript"):
+        await _debate_round(pool, model, emit, candidate_id)
 
     # Step 3a — C-prov (non-votable, Xia 1/2/4): cull candidates citing outside the
     # embargo+decay surface. Does NOT change pool_size (the DSR denominator counts
@@ -739,7 +746,8 @@ async def _run_debate_leaderboard(
         tool_name="evaluate_fusion_spec",
         args_summary=f"backtest ×{len(prov_clean)}, num_trials={num_trials} (own pool, decouple #2)",
     )
-    rigor_results = await _critic_rigor(prov_clean, num_trials)
+    with cost_meter.stage("debate_backtest"):
+        rigor_results = await _critic_rigor(prov_clean, num_trials)
     if not rigor_results:
         raise DebateUnavailable("debate: no candidate produced a successful backtest")
 

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1065,9 +1065,10 @@ async def run_generation(
             ownership["owner_user_id"] = owner_user_id
         with meter.stage("persist_winner"):
             sid, thash = await _persist_candidate(best, brief, **ownership)
-        # K=1: exactly one strategy_store row + its strategy_passports mirror.
+        # K=1: one strategy_store row. The strategy_passports mirror counts
+        # itself inside _persist_candidate's success branch, because its
+        # persist is deliberately non-blocking and can fail without raising.
         meter.record_write("strategy_store")
-        meter.record_write("strategy_passports")
         strategy_ids[best.candidate_id] = sid
         await emit.emit(
             "trace_hashed",
@@ -1359,6 +1360,11 @@ async def _persist_candidate(
                         owner_user_id=owner_user_id,
                     )
                     sess2.commit()
+                # Counted HERE, inside the success branch: the passport mirror
+                # is a swallowed-failure write, and the outer caller cannot see
+                # whether it landed — counting there overcounts on the logged
+                # non-blocking failure path (#1314 review).
+                cost_meter.record_write("strategy_passports")
             except Exception as exc:
                 logger.warning("unified passport persist failed (non-blocking): %s", exc)
 

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -33,6 +33,7 @@ See ``docs/specs/generation-streaming-spec.md`` for the full SSE contract.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import hashlib
 import json
@@ -45,6 +46,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from archimedes.api.generate_schemas import GenerateBrief
+from archimedes.services import cost_meter
 from archimedes.services.identity_events import emit_identity_event
 from archimedes.services.job_queue import JobStore, get_job_store
 
@@ -743,22 +745,34 @@ async def run_generation(
     store = store or get_job_store()
     emit = _Emitter(job_id, store)
 
+    # Cost instrumentation (#1217). Bound for the whole job so every LLM call
+    # made anywhere beneath this frame — including inside `asyncio.to_thread`
+    # workers, which copy the context — lands in one per-job record. The
+    # snapshot is persisted in the `finally` below, so it exists for the
+    # rigor-FAILED and errored runs too; those spend the same backtest compute
+    # and are the common case, which is exactly what this measurement is for.
+    meter = cost_meter.CostMeter(job_id=job_id)
+    meter_token = cost_meter.bind(meter)
+    meter.set_meta("n_candidates_requested", n_candidates)
+    meter.set_meta("model_requested", model)
+
     await store.update_status(job_id, "running")
     await emit.emit("job_queued", brief=brief.model_dump())
 
     try:
         # Real LLM validation step (live path only). The fixture path skips
         # the validator so tests stay hermetic.
-        if _llm_available():
-            validated = await _validate_brief(brief)
-        else:
-            validated = {
-                "is_valid": True,
-                "intent_summary": brief.intent[:140],
-                "asset_classes_inferred": brief.asset_classes or [],
-                "time_horizon_inferred": "unknown",
-                "risk_appetite_adjusted": brief.risk_appetite,
-            }
+        with meter.stage("brief_validation"):
+            if _llm_available():
+                validated = await _validate_brief(brief)
+            else:
+                validated = {
+                    "is_valid": True,
+                    "intent_summary": brief.intent[:140],
+                    "asset_classes_inferred": brief.asset_classes or [],
+                    "time_horizon_inferred": "unknown",
+                    "risk_appetite_adjusted": brief.risk_appetite,
+                }
 
         if not validated.get("is_valid", True):
             # Brief failed validation — emit a recoverable error and stop.
@@ -771,6 +785,7 @@ async def run_generation(
                 recoverable=True,
                 code="BRIEF_INVALID",
             )
+            meter.set_meta("outcome", "brief_invalid")
             await store.update_status(job_id, "error", error="brief invalid")
             return
 
@@ -829,7 +844,9 @@ async def run_generation(
         fixture_mode = os.getenv("GENERATION_PIPELINE_FIXTURE", "").lower() in ("1", "true") or (
             not use_live and os.getenv("TESTING")
         )
-        if use_live and await asyncio.to_thread(_debate_can_run, brief):
+        with meter.stage("pipeline_select"):
+            debate_can_run = use_live and await asyncio.to_thread(_debate_can_run, brief)
+        if debate_can_run:
             runner: Callable[..., Awaitable[Any]] = functools.partial(_run_debate_leaderboard, model=model)
         elif fixture_mode:
             pipeline_name = "fixture"
@@ -847,6 +864,7 @@ async def run_generation(
                 recoverable=True,
                 code="GENERATION_UNAVAILABLE",
             )
+            meter.set_meta("outcome", "generation_unavailable")
             await store.update_status(job_id, "error", error=f"generation unavailable: {reason}")
             return
 
@@ -900,14 +918,18 @@ async def run_generation(
         for i, regime in enumerate(regimes):
             candidate_id = f"cand_{regime}" if dual_regime else f"cand_{i + 1}"
             try:
-                cand = await runner(
-                    candidate_id=candidate_id,
-                    brief=brief,
-                    emit=emit,
-                    regime=regime,
-                    agent=job_agent,
-                    selection_pool_size=n_candidates,  # #770: DSR deflates for the N-candidate search
-                )
+                # The society's own sub-phases (corpus load, proposal fan-out,
+                # adversarial transcript, per-proposal backtests) are timed
+                # separately inside debate_engine; this outer stage is the total.
+                with meter.stage("candidate_generation"):
+                    cand = await runner(
+                        candidate_id=candidate_id,
+                        brief=brief,
+                        emit=emit,
+                        regime=regime,
+                        agent=job_agent,
+                        selection_pool_size=n_candidates,  # #770: DSR deflates for the N-candidate search
+                    )
             except FusionUnavailable as exc:
                 # T1.1 Phase-3: the society declined at runtime (empty pool /
                 # nothing conformant). There is NO fallback pipeline anymore —
@@ -972,6 +994,7 @@ async def run_generation(
                 recoverable=True,
                 code="NO_CANDIDATES",
             )
+            meter.set_meta("outcome", "no_candidates")
             await store.update_status(job_id, "error", error="no candidates generated")
             return
 
@@ -979,14 +1002,15 @@ async def run_generation(
         # et al. CSCV needs N≥2 to be meaningful; the helper handles N<2
         # gracefully by setting PBO=0.0). After this, every candidate's
         # rigor_verdict has all four fields (DSR, PBO, OOS Sharpe, lookahead).
-        _patch_pbo(candidates)
-        # Re-deflate DSR using the REAL candidate-pool correlation (#822, approach B
-        # for #770/#811). Runs after PBO so it can re-derive `passing`'s PBO leg from
-        # the already-patched value. Falls back to the untouched ρ̄=0 verdicts (approach
-        # A) whenever fewer than two buy-and-hold return series are available.
-        _patch_dsr_with_pool_correlation(candidates)
-        for c in candidates:
-            c.passes_rigor = c.rigor_verdict.get("passing", False)
+        with meter.stage("rigor_gate"):
+            _patch_pbo(candidates)
+            # Re-deflate DSR using the REAL candidate-pool correlation (#822, approach B
+            # for #770/#811). Runs after PBO so it can re-derive `passing`'s PBO leg from
+            # the already-patched value. Falls back to the untouched ρ̄=0 verdicts (approach
+            # A) whenever fewer than two buy-and-hold return series are available.
+            _patch_dsr_with_pool_correlation(candidates)
+            for c in candidates:
+                c.passes_rigor = c.rigor_verdict.get("passing", False)
 
         # Selection: prefer rigor-passing candidates; fall back to the full set only to
         # still surface a "considered best" for the alternatives panel. Whether that best
@@ -994,6 +1018,11 @@ async def run_generation(
         # gate is persisted with passes_rigor_gate=False and the server-side vault gate
         # refuses to deploy it — we must not imply it is validated.
         validated = [c for c in candidates if c.passes_rigor]
+        # The rejected path is the common case and costs the same compute — record
+        # which one this run was, so a stored snapshot can be read as pass or fail
+        # rather than assumed to be the happy path (#1217 anti-goal 2).
+        meter.set_meta("candidates_considered", len(candidates))
+        meter.set_meta("candidates_passing_rigor", len(validated))
         pool = validated or candidates
         if pipeline_name == "debate":
             # The society's deterministic synthesizer already ranked the board
@@ -1034,7 +1063,11 @@ async def run_generation(
         ownership = {"owner_wallet": owner_wallet}
         if owner_user_id is not None:
             ownership["owner_user_id"] = owner_user_id
-        sid, thash = await _persist_candidate(best, brief, **ownership)
+        with meter.stage("persist_winner"):
+            sid, thash = await _persist_candidate(best, brief, **ownership)
+        # K=1: exactly one strategy_store row + its strategy_passports mirror.
+        meter.record_write("strategy_store")
+        meter.record_write("strategy_passports")
         strategy_ids[best.candidate_id] = sid
         await emit.emit(
             "trace_hashed",
@@ -1074,28 +1107,29 @@ async def run_generation(
         # emit a DSL spec (weights={}) scored by evaluate_fusion_spec, or are a
         # populated ABSTAIN — so they skip the static backtester too (T1.1).
         _static_skip = ("fusion", "debate", "debate_abstain")
-        await asyncio.gather(
-            *[
-                # num_trials = the strategy's OWN candidate pool (N), never the library
-                # size — a strategy's rigor depends only on itself (decouple #2).
-                _backtest_and_persist(c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates))
-                for c in candidates
-                if c.generation_method not in _static_skip and c.candidate_id in strategy_ids
-            ]
-        )
+        with meter.stage("backtest_persist"):
+            await asyncio.gather(
+                *[
+                    # num_trials = the strategy's OWN candidate pool (N), never the library
+                    # size — a strategy's rigor depends only on itself (decouple #2).
+                    _backtest_and_persist(c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates))
+                    for c in candidates
+                    if c.generation_method not in _static_skip and c.candidate_id in strategy_ids
+                ]
+            )
 
-        # Fusion (and debate) candidates skipped the static backtester above but carry
-        # a REAL DSL backtest — persist its returns so live_rigor_gate reads pass/fail
-        # (not "pending") and the strategy is deployable (#788/#818). Without this, a
-        # fusion winner with a genuine backtest forever reads rigor_gate_status=pending
-        # and the server-side create_vault gate (#829) refuses to deploy it.
-        await asyncio.gather(
-            *[
-                _persist_real_returns(c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates))
-                for c in candidates
-                if c.has_real_rigor and c.return_series and c.candidate_id in strategy_ids
-            ]
-        )
+            # Fusion (and debate) candidates skipped the static backtester above but carry
+            # a REAL DSL backtest — persist its returns so live_rigor_gate reads pass/fail
+            # (not "pending") and the strategy is deployable (#788/#818). Without this, a
+            # fusion winner with a genuine backtest forever reads rigor_gate_status=pending
+            # and the server-side create_vault gate (#829) refuses to deploy it.
+            await asyncio.gather(
+                *[
+                    _persist_real_returns(c, strategy_ids[c.candidate_id], emit, _society_num_trials(n_candidates))
+                    for c in candidates
+                    if c.has_real_rigor and c.return_series and c.candidate_id in strategy_ids
+                ]
+            )
 
         # ── Persist all candidates to episodic memory (T-PE.8) ──
         try:
@@ -1141,6 +1175,7 @@ async def run_generation(
                     owner_wallet=owner_wallet,
                     owner_user_id=owner_user_id,
                 )
+                meter.record_write("strategy_proposals")
         except Exception:
             pass  # Non-blocking per spec
 
@@ -1171,6 +1206,9 @@ async def run_generation(
         # the post-call value when available (e.g. response.model), else the
         # configured id; falls back to the fixture marker on the non-live path.
         served_model = _served_model_for(job_agent, use_live)
+        meter.set_meta("served_model", served_model)
+        meter.set_meta("pipeline", pipeline_name)
+        meter.set_meta("outcome", "done")
         await emit.emit(
             "done",
             strategy_id=strategy_id,
@@ -1194,13 +1232,25 @@ async def run_generation(
         )
 
     except asyncio.CancelledError:
+        meter.set_meta("outcome", "cancelled")
         await emit.emit("error", message="job cancelled", recoverable=False, code="CANCELLED")
         await store.update_status(job_id, "cancelled", error="cancelled by client")
         raise
     except Exception as exc:
+        meter.set_meta("outcome", "pipeline_crash")
         logger.exception("generation pipeline crashed: %s", exc)
         await emit.emit("error", message=str(exc), recoverable=False, code="PIPELINE_CRASH")
         await store.update_status(job_id, "error", error=str(exc))
+    finally:
+        # Persist the measurement on EVERY terminal path — done, rigor-failed,
+        # errored, cancelled. Merged into the job's result rather than written
+        # with it, because most of those paths never write a result at all.
+        # Instrumentation is not allowed to change the outcome of a generation,
+        # so a failure here is swallowed (CancelledError included: this runs
+        # while a cancellation is already propagating).
+        cost_meter.unbind(meter_token)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await store.merge_result(job_id, {"cost": meter.snapshot()})
 
 
 async def _persist_candidate(
@@ -1509,6 +1559,8 @@ async def _persist_real_returns(c: _CandidateResult, strategy_id: str, emit: _Em
 
     try:
         await asyncio.to_thread(_do)
+        cost_meter.record_write("backtest_results")
+        cost_meter.record_write("strategy_passports")
         await emit.emit(
             "backtest_done", candidate_id=c.candidate_id, strategy_id=strategy_id, source=c.generation_method
         )
@@ -1694,6 +1746,8 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         metrics = await asyncio.to_thread(_do_backtest_and_persist)
         if metrics is None:
             return
+        cost_meter.record_write("backtest_results")
+        cost_meter.record_write("strategy_passports")
         await emit.emit(
             "backtest_done",
             strategy_id=strategy_id,

--- a/backend/archimedes/agents/portfolio_agent.py
+++ b/backend/archimedes/agents/portfolio_agent.py
@@ -367,8 +367,21 @@ class PortfolioAgent:
 
             # Cost instrumentation (#1217). This tool-use loop calls the raw SDK
             # directly, bypassing LLMBackend.complete() where every other call is
-            # metered — so without this line these turns would be invisible in the
-            # per-job token count, and the snapshot would under-report.
+            # metered — so a metered job running through here would under-report
+            # without this line.
+            #
+            # INERT TODAY, deliberately. record_llm_call is a no-op when no meter
+            # is bound to the context, and nothing binds one on this path:
+            # propose_portfolio_with_tools() is not on the generation pipeline's
+            # call graph. Its only caller is GET /api/strategies/advisor, which
+            # never opens a cost_meter.measure() scope; the pipeline's two runners
+            # (_run_debate_leaderboard, _run_fixture_candidate) both accept an
+            # `agent` argument purely for signature parity and ignore it. So this
+            # call cannot contribute to any job's snapshot as the code stands.
+            #
+            # It is kept because it is correct the moment that changes: whoever
+            # wires this loop into a metered job gets the coverage already in
+            # place rather than discovering a silent under-report afterwards.
             record_llm_call(model=final_response_model, response=resp)
 
             # Capture the assistant turn for the next iteration

--- a/backend/archimedes/agents/portfolio_agent.py
+++ b/backend/archimedes/agents/portfolio_agent.py
@@ -21,6 +21,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from archimedes.services.cost_meter import record_llm_call
 from archimedes.services.llm_backend import LLMBackend, make_llm_backend
 from archimedes.services.strategy_signal_evaluator import (
     GLOBAL_ASSETS,
@@ -363,6 +364,12 @@ class PortfolioAgent:
             served = getattr(resp, "model", None)
             if served:
                 final_response_model = str(served)
+
+            # Cost instrumentation (#1217). This tool-use loop calls the raw SDK
+            # directly, bypassing LLMBackend.complete() where every other call is
+            # metered — so without this line these turns would be invisible in the
+            # per-job token count, and the snapshot would under-report.
+            record_llm_call(model=final_response_model, response=resp)
 
             # Capture the assistant turn for the next iteration
             messages.append({"role": "assistant", "content": resp.content})

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -33,6 +33,7 @@ from archimedes.api.generate_schemas import (
     GenerateBrief,
     GenerateStartRequest,
     GenerateStartResponse,
+    JobCostResponse,
     JobsListResponse,
     JobSummary,
 )
@@ -426,6 +427,10 @@ def _job_summary(job: dict, job_id: str | None = None) -> JobSummary:
         updated_at=job.get("updated_at", ""),
         n_candidates=int(payload.get("n_candidates") or 1),
         best_strategy_id=result.get("best_strategy_id"),
+        # Raw measurement for this job (#1217): token counts, per-stage
+        # seconds, write tallies. None until the job reaches a terminal
+        # state, and None for jobs generated before the meter existed.
+        cost=result.get("cost"),
     )
 
 
@@ -471,6 +476,39 @@ async def get_job(
         raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
     _require_job_access(job, user.id, job_id, get_linked_wallet_address(request))
     return _job_summary(job, job_id)
+
+
+@generate_router.get("/jobs/{job_id}/cost", response_model=JobCostResponse)
+async def get_job_cost(
+    job_id: str,
+    request: Request,
+    user: CurrentUser = Depends(require_current_user),
+) -> JobCostResponse:
+    """What this generation actually consumed (#1217).
+
+    Raw measurement only — Bedrock input/output token counts taken from the
+    provider's own ``usage`` block, wall + CPU seconds per pipeline stage, peak
+    RSS, and the rows the pipeline wrote. **No prices**: the paywall quote seam
+    (``GET /api/generate/quote``) stays ``flat_v1`` and is untouched by this
+    endpoint; converting these counts into dollars is done off-server, and this
+    is the input that lets it stop being an estimate.
+
+    Owner-scoped exactly like ``/candidates`` — a job you do not own 404s rather
+    than leaking its existence. ``cost`` is ``null`` for a job that has not
+    reached a terminal state yet, and for jobs older than the instrumentation.
+    """
+    store = get_job_store()
+    job = await store.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
+    _require_job_access(job, user.id, job_id, get_linked_wallet_address(request))
+    result = job.get("result") or {}
+    cost = result.get("cost") if isinstance(result, dict) else None
+    return JobCostResponse(
+        job_id=job_id,
+        state=_normalize_state(job.get("status") or "queued"),
+        cost=cost if isinstance(cost, dict) else None,
+    )
 
 
 @generate_router.get("/jobs/{job_id}/candidates", response_model=CandidatesListResponse)

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -8,6 +8,7 @@ Endpoints (per ``docs/specs/generation-streaming-spec.md``):
   GET  /api/generate/jobs                     — list recent jobs (status table)
   GET  /api/generate/jobs/{job_id}            — one job's status (poll fallback)
   GET  /api/generate/jobs/{job_id}/candidates — N candidates incl. rejected
+  GET  /api/generate/jobs/{job_id}/cost       — raw measurement, no prices (#1217)
 
 This router lives in its own file per the Spine+ v2 plan's cross-cutting
 principle #2 — no new endpoints go into ``api/routes.py``.

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -131,6 +131,16 @@ class GenerateEvent(BaseModel):
 # ── Job listing + candidates list ─────────────────────────────────────────
 
 
+#: What the cost meter measured for one job. Free-form on purpose: the payload
+#: carries its own ``schema`` version (``cost_v1``), so the measurement record
+#: can gain fields without a lockstep API-model change. It is RAW MEASUREMENT
+#: ONLY — token counts, seconds, byte counts, write tallies. No prices, and no
+#: money is derivable from it without the pricing table, which lives outside the
+#: server. The paywall quote seam (``generation_payment.quote()``) is unaffected
+#: and still reports ``pricing_model: "flat_v1"`` (#1217).
+JobCost = dict[str, Any]
+
+
 class JobSummary(BaseModel):
     job_id: str
     state: Literal["queued", "running", "done", "error", "cancelled"]
@@ -139,10 +149,24 @@ class JobSummary(BaseModel):
     updated_at: str
     n_candidates: int
     best_strategy_id: str | None = None
+    cost: JobCost | None = None
 
 
 class JobsListResponse(BaseModel):
     jobs: list[JobSummary]
+
+
+class JobCostResponse(BaseModel):
+    """One job's measured resource consumption.
+
+    ``cost`` is ``None`` while the job is still running (the snapshot is written
+    once, on the terminal path) and stays ``None`` for a job that predates the
+    instrumentation — an honest absence, not a zeroed record.
+    """
+
+    job_id: str
+    state: Literal["queued", "running", "done", "error", "cancelled"]
+    cost: JobCost | None = None
 
 
 class CandidateSummary(BaseModel):

--- a/backend/archimedes/services/cost_meter.py
+++ b/backend/archimedes/services/cost_meter.py
@@ -28,19 +28,33 @@ Three properties are enforced in code rather than asserted in prose:
 2. **An implausible count is refused, not accumulated.** Negative, non-finite,
    non-integral, stringly-typed, or absurd (> :data:`MAX_PLAUSIBLE_TOKENS`)
    counts are treated as missing.
-3. **No pricing math lives here.** Stage names, write-counter names, and meta
-   keys are screened against :data:`_PRICING_TOKENS` and a match raises
-   :class:`PricingLeakError`. The quote seam
+3. **No pricing math lives here.** Every caller-chosen label — stage name,
+   write-counter name, meta key — is screened against :data:`_PRICING_TOKENS` at
+   write time, and a match raises :class:`PricingLeakError`. That screening is
+   what generalizes: the rest of a snapshot's keys are this module's own fixed
+   literals (see :meth:`CostMeter.snapshot`), so a caller label is the only route
+   by which a pricing-shaped key could enter one at all. The quote seam
    (``generation_payment.quote()``) stays ``flat_v1``; this module feeds the
    flat-to-measured evolution with numbers, and the conversion from numbers to
    dollars happens outside the server.
 
 The meter is bound to a :mod:`contextvars` context for the duration of one job,
 so the LLM boundary can record usage without threading a parameter through the
-debate engine, the fusion proposer, and the portfolio agent. ``asyncio.to_thread``
-and ``asyncio.create_task`` both copy the current context, so worker threads and
+debate engine and the fusion proposer. ``asyncio.to_thread`` and
+``asyncio.create_task`` both copy the current context, so worker threads and
 child tasks see the same meter object; mutations are lock-guarded because the
 society proposes and backtests in parallel threads.
+
+**What the context binding does and does not reach.** A recorder is a no-op when
+no meter is bound, which is the correct behaviour outside a job — but it also
+means instrumenting a code path proves nothing on its own about whether that path
+is measured. Only ``run_generation`` binds a meter today. In particular the
+:mod:`archimedes.agents.portfolio_agent` tool-use loop carries a
+:func:`record_llm_call` that is **inert**: its only caller is
+``GET /api/strategies/advisor``, which never opens a :func:`measure` scope, and
+the generation pipeline's runners ignore the ``agent`` argument they are handed.
+The call is correct-if-reached rather than a gap it closes today. See
+``docs/generation-cost-instrumentation.md`` for the full coverage boundary.
 """
 
 from __future__ import annotations

--- a/backend/archimedes/services/cost_meter.py
+++ b/backend/archimedes/services/cost_meter.py
@@ -1,0 +1,419 @@
+"""Per-generation cost instrumentation — raw measurement only, never pricing.
+
+Issue #1217: *"we do not know what a generation costs."* The only figure anyone
+has quoted for a generation is a Bedrock inference estimate, which is the
+language-model term alone — it excludes the debate society's per-proposal
+backtests and the rigor gate, which are plausibly the dominant term. Until the
+raw numbers exist, every pricing decision downstream rests on an assumption.
+
+This module is the measurement layer, and *only* the measurement layer:
+
+* **Token counts** come from the provider's own ``usage`` block, recorded at the
+  :mod:`archimedes.services.llm_backend` boundary — the one place every provider
+  response passes through.
+* **Wall time and CPU time** are recorded per named stage, so the per-phase
+  breakdown (corpus retrieval / debate / backtest / rigor gate / persistence) is
+  visible rather than assumed.
+* **Write counts** are the pipeline's own tally of the rows it issued.
+
+Three properties are enforced in code rather than asserted in prose:
+
+1. **A missing measurement is never a zero.** A provider response that carries no
+   usable ``usage`` block increments ``calls_missing_usage`` and flips
+   ``usage_complete`` to ``False``; it does not add ``0`` tokens and quietly look
+   like a cheap call. Same for a *partial* block — a call whose input count is
+   readable but whose output count is not is not a measurement, and neither half
+   is banked. (``CLAUDE.md`` § fail-soft: the correct degraded state is a loud,
+   visible absence, never a plausible substitute.)
+2. **An implausible count is refused, not accumulated.** Negative, non-finite,
+   non-integral, stringly-typed, or absurd (> :data:`MAX_PLAUSIBLE_TOKENS`)
+   counts are treated as missing.
+3. **No pricing math lives here.** Stage names, write-counter names, and meta
+   keys are screened against :data:`_PRICING_TOKENS` and a match raises
+   :class:`PricingLeakError`. The quote seam
+   (``generation_payment.quote()``) stays ``flat_v1``; this module feeds the
+   flat-to-measured evolution with numbers, and the conversion from numbers to
+   dollars happens outside the server.
+
+The meter is bound to a :mod:`contextvars` context for the duration of one job,
+so the LLM boundary can record usage without threading a parameter through the
+debate engine, the fusion proposer, and the portfolio agent. ``asyncio.to_thread``
+and ``asyncio.create_task`` both copy the current context, so worker threads and
+child tasks see the same meter object; mutations are lock-guarded because the
+society proposes and backtests in parallel threads.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import math
+import resource
+import sys
+import threading
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Bumped whenever the snapshot shape changes, so a stored snapshot is
+#: self-describing to whatever reads it later.
+SCHEMA = "cost_v1"
+
+#: A single completion cannot plausibly report more tokens than this (the
+#: largest production context windows are ~2M). Anything above it is a
+#: corrupted/misread field, not a measurement.
+MAX_PLAUSIBLE_TOKENS = 10_000_000
+
+#: ``time.process_time()`` is process-wide, so a stage delta also captures CPU
+#: burned by anything else running in the same worker. Recorded honestly under
+#: this label rather than presented as isolated per-job CPU.
+CPU_ATTRIBUTION = "process_wide_delta"
+
+#: ``ru_maxrss`` is a process high-water mark that never falls, so this is
+#: "the peak this worker has ever reached", not "the peak this job caused".
+RSS_ATTRIBUTION = "process_high_water"
+
+# Substrings that mark a label as pricing rather than measurement. Screened on
+# every caller-chosen label (stage / write-counter / meta key). Deliberately a
+# deny-list of whole meaningful fragments — "cents" not "cent" (percent,
+# recent), "billing" not "bill" (billion).
+_PRICING_TOKENS = (
+    "usd",
+    "dollar",
+    "cents",
+    "price",
+    "pricing",
+    "cost",
+    "fee",
+    "charge",
+    "spend",
+    "billing",
+    "invoice",
+    "revenue",
+)
+
+# Provider-specific names for the same two numbers. Anthropic SDK →
+# ``input_tokens``/``output_tokens``; Bedrock Converse → ``inputTokens``/
+# ``outputTokens``; OpenAI-compatible → ``prompt_tokens``/``completion_tokens``;
+# Ollama → ``prompt_eval_count``/``eval_count`` (top level, no usage block).
+_INPUT_TOKEN_KEYS = ("input_tokens", "inputTokens", "prompt_tokens", "promptTokens", "prompt_eval_count")
+_OUTPUT_TOKEN_KEYS = ("output_tokens", "outputTokens", "completion_tokens", "completionTokens", "eval_count")
+
+
+class PricingLeakError(ValueError):
+    """A label was supplied that would put pricing math in the measurement layer.
+
+    Raised eagerly at the call site so the violation surfaces as a hard failure
+    in the first test run that exercises it, never as a silently-priced field in
+    a persisted job record.
+    """
+
+
+def _assert_no_pricing(label: str, kind: str) -> str:
+    """Screen a caller-chosen label; return it unchanged when clean."""
+    text = str(label)
+    lowered = text.lower()
+    for token in _PRICING_TOKENS:
+        if token in lowered:
+            raise PricingLeakError(
+                f"{kind} name {text!r} contains {token!r}: the cost meter records raw counts only. "
+                "Pricing math belongs outside the server (the quote seam stays flat_v1)."
+            )
+    return text
+
+
+def _peak_rss_bytes() -> int | None:
+    """Process peak resident set size in bytes, or ``None`` if unavailable.
+
+    ``ru_maxrss`` is bytes on macOS/Darwin and kilobytes on Linux — getrusage(2).
+    Getting this unit wrong is a 1024× error in a number someone will size an
+    ECS task from, so it is branched explicitly.
+    """
+    try:
+        raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except Exception:  # pragma: no cover — platform without getrusage
+        return None
+    return int(raw) if sys.platform == "darwin" else int(raw) * 1024
+
+
+def _coerce_count(value: Any) -> int | None:
+    """Return ``value`` as a plausible non-negative count, or ``None`` if it is not one.
+
+    Used for token counts and write tallies alike. ``None`` means *not measured*
+    — the caller must record that as missing, never as zero. ``bool`` is
+    rejected explicitly (``True`` is an ``int`` in Python and would otherwise
+    bank as one token).
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        count = value
+    elif isinstance(value, float):
+        if not math.isfinite(value) or value != int(value):
+            return None
+        count = int(value)
+    else:
+        # Strings and everything else: a stringly-typed count is a parse we did
+        # not do, so it is not a measurement we are entitled to report.
+        return None
+    if count < 0 or count > MAX_PLAUSIBLE_TOKENS:
+        return None
+    return count
+
+
+def _get_field(container: Any, key: str) -> Any:
+    if isinstance(container, Mapping):
+        return container.get(key)
+    return getattr(container, key, None)
+
+
+def _usage_containers(response: Any) -> Iterator[Any]:
+    """Yield the places a provider might have put its usage block."""
+    usage = _get_field(response, "usage")
+    if usage is not None:
+        yield usage
+    if response is not None:
+        yield response
+
+
+def _lookup(container: Any, keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        count = _coerce_count(_get_field(container, key))
+        if count is not None:
+            return count
+    return None
+
+
+def extract_token_usage(response: Any) -> tuple[int | None, int | None]:
+    """Pull ``(input_tokens, output_tokens)`` out of any provider response shape.
+
+    Returns ``(None, None)`` when nothing usable is present. A half-readable
+    block returns the readable half and ``None`` for the other; the recorder
+    treats that as a missing measurement rather than banking half a call.
+    """
+    for container in _usage_containers(response):
+        input_tokens = _lookup(container, _INPUT_TOKEN_KEYS)
+        output_tokens = _lookup(container, _OUTPUT_TOKEN_KEYS)
+        if input_tokens is not None or output_tokens is not None:
+            return input_tokens, output_tokens
+    return None, None
+
+
+class CostMeter:
+    """Accumulates the raw measurements for one generation job."""
+
+    def __init__(self, job_id: str = "") -> None:
+        self.job_id = job_id
+        self._lock = threading.Lock()
+        self._wall_start = time.monotonic()
+        self._cpu_start = time.process_time()
+        self._stages: dict[str, dict[str, Any]] = {}
+        self._writes: dict[str, int] = {}
+        self._meta: dict[str, Any] = {}
+        self._calls = 0
+        self._calls_missing_usage = 0
+        self._input_tokens = 0
+        self._output_tokens = 0
+        self._by_model: dict[str, dict[str, int]] = {}
+
+    # ── LLM usage ────────────────────────────────────────────────────────
+
+    def record_usage(self, *, model: str, input_tokens: int | None, output_tokens: int | None) -> None:
+        """Bank one LLM call's token counts.
+
+        Both counts must be present and plausible for the call to be banked.
+        Anything else increments ``calls_missing_usage`` and flips
+        ``usage_complete`` — the call still happened and still cost money, and
+        saying so is the point.
+        """
+        clean_in = _coerce_count(input_tokens)
+        clean_out = _coerce_count(output_tokens)
+        model_id = str(model or "unknown")
+        with self._lock:
+            self._calls += 1
+            per_model = self._by_model.setdefault(
+                model_id,
+                {"calls": 0, "calls_missing_usage": 0, "input_tokens": 0, "output_tokens": 0},
+            )
+            per_model["calls"] += 1
+            if clean_in is None or clean_out is None:
+                self._calls_missing_usage += 1
+                per_model["calls_missing_usage"] += 1
+                return
+            self._input_tokens += clean_in
+            self._output_tokens += clean_out
+            per_model["input_tokens"] += clean_in
+            per_model["output_tokens"] += clean_out
+
+    def record_response(self, *, model: str, response: Any) -> None:
+        """Bank one LLM call from the raw provider response object/dict."""
+        input_tokens, output_tokens = extract_token_usage(response)
+        self.record_usage(model=model, input_tokens=input_tokens, output_tokens=output_tokens)
+
+    # ── Stage timing ─────────────────────────────────────────────────────
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        """Accumulate wall + CPU seconds for a named phase.
+
+        Re-entering the same name accumulates rather than overwriting, so a
+        stage run once per candidate reports the total and its ``runs`` count.
+        """
+        clean = _assert_no_pricing(name, "stage")
+        wall0 = time.monotonic()
+        cpu0 = time.process_time()
+        try:
+            yield
+        finally:
+            wall = time.monotonic() - wall0
+            cpu = time.process_time() - cpu0
+            with self._lock:
+                bucket = self._stages.setdefault(clean, {"wall_seconds": 0.0, "cpu_seconds": 0.0, "runs": 0})
+                bucket["wall_seconds"] += wall
+                bucket["cpu_seconds"] += cpu
+                bucket["runs"] += 1
+
+    # ── Write counts + metadata ──────────────────────────────────────────
+
+    def record_write(self, table: str, count: int = 1) -> None:
+        """Tally rows the pipeline wrote (upserts count as one write each)."""
+        clean = _assert_no_pricing(table, "write-counter")
+        n = _coerce_count(count)
+        if n is None:
+            logger.debug("cost meter: ignoring implausible write count %r for %s", count, clean)
+            return
+        with self._lock:
+            self._writes[clean] = self._writes.get(clean, 0) + n
+
+    def set_meta(self, key: str, value: Any) -> None:
+        """Attach a descriptive scalar (pipeline name, outcome, candidate count).
+
+        Meta exists so a stored snapshot can be interpreted later — in
+        particular whether the run passed or failed the rigor gate, since the
+        rejected path burns the same backtest compute and is the common case.
+        """
+        clean = _assert_no_pricing(key, "meta")
+        with self._lock:
+            self._meta[clean] = value
+
+    # ── Readout ──────────────────────────────────────────────────────────
+
+    def snapshot(self) -> dict[str, Any]:
+        """The raw measurement record. Contains counts and seconds; no money."""
+        with self._lock:
+            wall = time.monotonic() - self._wall_start
+            cpu = time.process_time() - self._cpu_start
+            return {
+                "schema": SCHEMA,
+                "job_id": self.job_id,
+                "wall_seconds": round(wall, 4),
+                "cpu_seconds": round(cpu, 4),
+                "cpu_attribution": CPU_ATTRIBUTION,
+                "peak_rss_bytes": _peak_rss_bytes(),
+                "rss_attribution": RSS_ATTRIBUTION,
+                "llm": {
+                    "calls": self._calls,
+                    "calls_missing_usage": self._calls_missing_usage,
+                    "usage_complete": self._calls_missing_usage == 0,
+                    "input_tokens": self._input_tokens,
+                    "output_tokens": self._output_tokens,
+                    "total_tokens": self._input_tokens + self._output_tokens,
+                    "by_model": {k: dict(v) for k, v in self._by_model.items()},
+                },
+                "stages": {
+                    name: {
+                        "wall_seconds": round(float(bucket["wall_seconds"]), 4),
+                        "cpu_seconds": round(float(bucket["cpu_seconds"]), 4),
+                        "runs": int(bucket["runs"]),
+                    }
+                    for name, bucket in self._stages.items()
+                },
+                "writes": dict(self._writes),
+                "meta": dict(self._meta),
+            }
+
+
+# ── Context binding ──────────────────────────────────────────────────────
+
+_CURRENT: contextvars.ContextVar[CostMeter | None] = contextvars.ContextVar("archimedes_cost_meter", default=None)
+
+
+def current_meter() -> CostMeter | None:
+    """The meter bound to this context, or ``None`` outside a measured job."""
+    return _CURRENT.get()
+
+
+def bind(meter: CostMeter) -> contextvars.Token:
+    """Bind ``meter`` to the current context; pass the token back to :func:`unbind`."""
+    return _CURRENT.set(meter)
+
+
+def unbind(token: contextvars.Token) -> None:
+    try:
+        _CURRENT.reset(token)
+    except ValueError:  # pragma: no cover — token from a different context
+        logger.debug("cost meter: token reset out of context", exc_info=True)
+
+
+@contextmanager
+def measure(job_id: str = "") -> Iterator[CostMeter]:
+    """Bind a fresh meter for the duration of the block."""
+    meter = CostMeter(job_id=job_id)
+    token = bind(meter)
+    try:
+        yield meter
+    finally:
+        unbind(token)
+
+
+# ── Module-level recorders (no-ops outside a measured job) ───────────────
+
+
+def record_llm_call(*, model: str, response: Any) -> None:
+    """Record one LLM call from the provider boundary. Never raises.
+
+    Called from inside every backend's ``complete()``. Instrumentation must not
+    be able to fail a real generation, so unexpected errors are logged and
+    swallowed — the honest consequence of a swallow here is a snapshot with
+    fewer calls in it, which the reader can see.
+    """
+    meter = _CURRENT.get()
+    if meter is None:
+        return
+    try:
+        meter.record_response(model=model, response=response)
+    except Exception:  # pragma: no cover — defensive
+        logger.debug("cost meter: failed to record LLM usage", exc_info=True)
+
+
+def record_write(table: str, count: int = 1) -> None:
+    """Tally a persisted write. :class:`PricingLeakError` propagates by design."""
+    meter = _CURRENT.get()
+    if meter is None:
+        _assert_no_pricing(table, "write-counter")
+        return
+    meter.record_write(table, count)
+
+
+def set_meta(key: str, value: Any) -> None:
+    """Attach descriptive metadata. :class:`PricingLeakError` propagates by design."""
+    meter = _CURRENT.get()
+    if meter is None:
+        _assert_no_pricing(key, "meta")
+        return
+    meter.set_meta(key, value)
+
+
+@contextmanager
+def stage(name: str) -> Iterator[None]:
+    """Time a named phase against the bound meter (no-op when unbound)."""
+    meter = _CURRENT.get()
+    if meter is None:
+        _assert_no_pricing(name, "stage")
+        yield
+        return
+    with meter.stage(name):
+        yield

--- a/backend/archimedes/services/job_queue.py
+++ b/backend/archimedes/services/job_queue.py
@@ -120,6 +120,40 @@ class JobStore:
         await r.hset(key, mapping=updates)
         logger.info("job: %s → %s", sanitize_log_value(job_id), status)
 
+    async def merge_result(self, job_id: str, patch: dict[str, Any]) -> bool:
+        """Merge top-level keys into an EXISTING job's persisted ``result``.
+
+        Used by the cost meter (#1217) to attach the per-job measurement record
+        after the terminal ``update_status`` has already written the result —
+        including on the error / cancelled paths, where there is no result write
+        at all but the compute was still spent.
+
+        Returns ``True`` when the patch landed. **Never creates a job.** A bare
+        ``hset`` on a missing key would materialise a TTL-less phantom hash that
+        then shows up in ``list_recent_jobs`` as a statusless job, so existence
+        is checked before the write and re-checked after it (the key can expire
+        in between); a hash the write resurrected is deleted again.
+        """
+        r = await self._get_redis()
+        key = f"{KEY_PREFIX}{job_id}"
+        if not await r.exists(key):
+            logger.debug("job: merge_result skipped — %s not found", sanitize_log_value(job_id))
+            return False
+        current = _safe_json(await r.hget(key, "result"), {}, context=f"job:{job_id}:result")
+        if not isinstance(current, dict):
+            # A non-dict result (legacy / tampered) is left intact rather than
+            # clobbered — the measurement is not worth destroying a payload for.
+            logger.warning("job: merge_result skipped — %s has a non-dict result", sanitize_log_value(job_id))
+            return False
+        current.update(patch)
+        await r.hset(key, "result", json.dumps(current, default=str))
+        if not await r.hexists(key, "id"):
+            # The key expired between the check and the write; the hset above
+            # recreated it as a fragment. Undo rather than leave a phantom.
+            await r.delete(key)
+            return False
+        return True
+
     # ── Event log (for streaming jobs) ────────────────────────────────────
 
     async def push_event(self, job_id: str, event_payload: dict[str, Any]) -> int:

--- a/backend/archimedes/services/llm_backend.py
+++ b/backend/archimedes/services/llm_backend.py
@@ -15,6 +15,8 @@ import logging
 import os
 from typing import Protocol
 
+from archimedes.services.cost_meter import record_llm_call
+
 logger = logging.getLogger(__name__)
 
 # ── Protocol ─────────────────────────────────────────────────────────
@@ -142,6 +144,9 @@ class AnthropicBackend:
         served = getattr(resp, "model", None)
         if served:
             self._served = str(served)
+        # Cost instrumentation (#1217): the provider's own usage block, banked
+        # against whatever job meter is bound to this context. No-op when none is.
+        record_llm_call(model=self._served, response=resp)
         return _first_text_block(resp.content)
 
 
@@ -193,6 +198,9 @@ class AnthropicCompatibleBackend:
         served = getattr(resp, "model", None)
         if served:
             self._served = str(served)
+        # Cost instrumentation (#1217): the provider's own usage block, banked
+        # against whatever job meter is bound to this context. No-op when none is.
+        record_llm_call(model=self._served, response=resp)
         return _first_text_block(resp.content)
 
 
@@ -259,6 +267,9 @@ class BedrockBackend:
         served = getattr(resp, "model", None)
         if served:
             self._served = str(served)
+        # Cost instrumentation (#1217): the provider's own usage block, banked
+        # against whatever job meter is bound to this context. No-op when none is.
+        record_llm_call(model=self._served, response=resp)
         return _first_text_block(resp.content)
 
 
@@ -327,6 +338,9 @@ class BedrockConverseBackend:
                 resp = self._client.converse(**kwargs)
             else:
                 raise
+        # Cost instrumentation (#1217). Converse reports usage as
+        # {"usage": {"inputTokens": n, "outputTokens": n, "totalTokens": n}}.
+        record_llm_call(model=self._served, response=resp)
         blocks = resp.get("output", {}).get("message", {}).get("content", []) or []
         # Reasoning models may emit a reasoningContent block before the text — return
         # the first block that actually carries text.
@@ -379,6 +393,8 @@ class OpenAIBackend:
         resp.raise_for_status()
         data = resp.json()
         self._served = data.get("model", self._model)
+        # Cost instrumentation (#1217): {"usage": {"prompt_tokens", "completion_tokens"}}.
+        record_llm_call(model=self._served, response=data)
         # Defensive: OpenAI-style APIs can legitimately return empty `choices`
         # (content filtering, tool-only responses, etc.). Mirror OllamaBackend's
         # `.get()`-chain pattern so we never IndexError mid-request.
@@ -449,6 +465,9 @@ class OllamaBackend:
         resp.raise_for_status()
         data = resp.json()
         self._served = data.get("model", self._model)
+        # Cost instrumentation (#1217): Ollama reports counts at the top level
+        # as prompt_eval_count / eval_count, with no usage block.
+        record_llm_call(model=self._served, response=data)
         return data.get("message", {}).get("content", "").strip()
 
 

--- a/backend/tests/test_generation_cost_meter.py
+++ b/backend/tests/test_generation_cost_meter.py
@@ -545,3 +545,35 @@ class TestCostEndpoint:
             resp = client.get("/api/generate/jobs", cookies=_cookies(_OWNER))
         assert resp.status_code == 200, resp.text
         assert resp.json()["jobs"][0]["cost"]["llm"]["calls"] == 9
+
+
+def test_passport_write_is_counted_inside_the_success_branch_not_at_the_caller():
+    """The strategy_passports persist is deliberately non-blocking: it can fail
+    with only a warning while _persist_candidate still succeeds, so a caller
+    cannot know whether the write landed. The counter must therefore live
+    INSIDE the swallowing try, after sess2.commit() (#1314 review — counting
+    at the caller overcounts on the logged failure path). Source-invariant in
+    the house slowapi-AST style; mutation-proven: restoring the caller-side
+    record_write("strategy_passports") fails this test."""
+    import re
+    from pathlib import Path
+
+    src = Path("backend/archimedes/agents/generation_pipeline.py").read_text()
+
+    # (a) The persist-winner path's strategy_passports count sits between the
+    # passport commit and the except that swallows its failure. (The two
+    # backtest-refresh sites count after their un-swallowed awaits inside
+    # their own trys — conditioned on success by construction.)
+    guarded = re.search(
+        r"sess2\.commit\(\)[\s\S]{0,400}?record_write\(\s*\"strategy_passports\"[\s\S]{0,400}?except Exception",
+        src,
+    )
+    assert guarded, "the passport counter must sit after sess2.commit() and before the swallowing except"
+
+    # (b) The caller block counts ONLY strategy_store — the K=1 comment block
+    # must not regain a passports count it cannot verify.
+    caller = re.search(r"K=1[\s\S]{0,400}?strategy_ids\[best\.candidate_id\]", src)
+    assert caller, "caller block not found"
+    assert not re.search(r'record_write\(\s*"strategy_passports"', caller.group(0)), (
+        "caller must not count the passport mirror (prose may mention it; the call may not)"
+    )

--- a/backend/tests/test_generation_cost_meter.py
+++ b/backend/tests/test_generation_cost_meter.py
@@ -1,0 +1,547 @@
+"""Per-generation cost instrumentation (#1217) — the measurement must be honest.
+
+The point of the meter is to replace an assumption ("near-zero marginal cost")
+with numbers. A measurement layer that reports a plausible-looking zero when it
+failed to measure is worse than no measurement at all, so the guards below are
+the substance of this file, not a formality. Each one is exercised with the
+input that SHOULD fail it:
+
+* **G1** — a provider response with no ``usage`` block must not bank as a 0-token
+  call. ``usage_complete`` flips to ``False``.
+* **G2** — an implausible count (negative, non-finite, stringly-typed, absurd) is
+  refused, not accumulated; the call is recorded as missing instead.
+* **G3** — a pricing-shaped label (``cost_usd``, ``price_per_call``, …) is
+  rejected with :class:`PricingLeakError`. No pricing math lives server-side and
+  the quote seam stays ``flat_v1``.
+* **G4** — ``JobStore.merge_result`` on a job that does not exist must not create
+  a phantom, TTL-less job hash.
+
+Hermetic: fakeredis for the job store (``test_runner_lease`` precedent), the
+provider SDK clients mocked at the boundary (``test_api_routes`` precedent), and
+real signed SIWE cookies for the endpoint scoping (``test_user_routes``
+precedent). No live LLM, no Postgres, no network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import fakeredis
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from archimedes.services import cost_meter
+from archimedes.services.cost_meter import CostMeter, PricingLeakError, extract_token_usage
+from archimedes.services.job_queue import JOB_TTL, JobStore
+from fastapi.testclient import TestClient
+
+
+# ── Token extraction, per provider response shape ─────────────────────────
+
+
+class TestTokenExtraction:
+    """Every provider spells the same two numbers differently."""
+
+    def test_bedrock_converse_shape(self):
+        # boto3 bedrock-runtime `converse` — the live provider (bedrock_converse).
+        resp = {"usage": {"inputTokens": 812, "outputTokens": 143, "totalTokens": 955}}
+        assert extract_token_usage(resp) == (812, 143)
+
+    def test_anthropic_sdk_shape(self):
+        resp = MagicMock()
+        resp.usage.input_tokens = 400
+        resp.usage.output_tokens = 91
+        assert extract_token_usage(resp) == (400, 91)
+
+    def test_openai_compatible_shape(self):
+        resp = {"usage": {"prompt_tokens": 33, "completion_tokens": 7}}
+        assert extract_token_usage(resp) == (33, 7)
+
+    def test_ollama_top_level_shape(self):
+        # Ollama reports counts at the top level with no usage block at all.
+        assert extract_token_usage({"prompt_eval_count": 12, "eval_count": 4}) == (12, 4)
+
+    def test_no_usage_anywhere_is_none_not_zero(self):
+        assert extract_token_usage({"output": {"message": {}}}) == (None, None)
+        assert extract_token_usage(None) == (None, None)
+
+
+# ── G1: a missing measurement is never a zero ─────────────────────────────
+
+
+class TestMissingUsageIsNotZero:
+    """The input that SHOULD fail the guard: a response with no usage block.
+
+    A meter that banked it as 0/0 would report ``usage_complete: true`` with
+    plausible-looking totals, which is exactly the fail-soft substitution
+    CLAUDE.md forbids — the run would look free.
+    """
+
+    def test_response_without_usage_marks_the_snapshot_incomplete(self):
+        meter = CostMeter("job-g1")
+        meter.record_response(model="amazon.nova-micro-v1:0", response={"output": {"message": {}}})
+        llm = meter.snapshot()["llm"]
+
+        assert llm["calls"] == 1, "the call happened and must be counted"
+        assert llm["calls_missing_usage"] == 1
+        assert llm["usage_complete"] is False, "a snapshot with an unmeasured call must not claim completeness"
+        assert llm["input_tokens"] == 0
+        assert llm["output_tokens"] == 0
+
+    def test_a_measured_call_alongside_an_unmeasured_one_still_flags_incomplete(self):
+        meter = CostMeter("job-g1b")
+        meter.record_response(model="m", response={"usage": {"inputTokens": 100, "outputTokens": 10}})
+        meter.record_response(model="m", response={"no": "usage"})
+        llm = meter.snapshot()["llm"]
+
+        assert llm["input_tokens"] == 100, "the measured call is still banked"
+        assert llm["calls"] == 2
+        assert llm["calls_missing_usage"] == 1
+        assert llm["usage_complete"] is False
+        assert llm["by_model"]["m"]["calls_missing_usage"] == 1
+
+    def test_half_readable_usage_banks_neither_half(self):
+        # Input side readable, output side absent. Banking 812/0 would understate
+        # the run while reporting itself complete.
+        meter = CostMeter("job-g1c")
+        meter.record_response(model="m", response={"usage": {"inputTokens": 812}})
+        llm = meter.snapshot()["llm"]
+
+        assert llm["input_tokens"] == 0
+        assert llm["usage_complete"] is False
+        assert llm["calls_missing_usage"] == 1
+
+    def test_all_measured_reports_complete(self):
+        meter = CostMeter("job-g1d")
+        meter.record_response(model="m", response={"usage": {"inputTokens": 5, "outputTokens": 6}})
+        llm = meter.snapshot()["llm"]
+        assert llm["usage_complete"] is True
+        assert llm["total_tokens"] == 11
+
+
+# ── G2: implausible counts are refused, not accumulated ───────────────────
+
+
+class TestImplausibleCountsRefused:
+    """The inputs that SHOULD fail the guard, each demonstrated to fail it."""
+
+    @pytest.mark.parametrize(
+        ("bad_usage", "why"),
+        [
+            ({"inputTokens": -5, "outputTokens": 12}, "negative token count"),
+            ({"inputTokens": float("nan"), "outputTokens": 12}, "NaN token count"),
+            ({"inputTokens": float("inf"), "outputTokens": 12}, "infinite token count"),
+            ({"inputTokens": "812", "outputTokens": 12}, "stringly-typed count"),
+            ({"inputTokens": 10**12, "outputTokens": 12}, "absurd count (> MAX_PLAUSIBLE_TOKENS)"),
+            ({"inputTokens": True, "outputTokens": 12}, "bool masquerading as an int"),
+            ({"inputTokens": 1.5, "outputTokens": 12}, "non-integral count"),
+        ],
+    )
+    def test_bad_count_is_recorded_as_missing_not_added(self, bad_usage, why):
+        meter = CostMeter("job-g2")
+        meter.record_response(model="m", response={"usage": bad_usage})
+        llm = meter.snapshot()["llm"]
+
+        assert llm["input_tokens"] == 0, f"{why} must not be accumulated"
+        assert llm["output_tokens"] == 0, f"{why} must not bank its partner half either"
+        assert llm["calls_missing_usage"] == 1, f"{why} must be recorded as an unmeasured call"
+        assert llm["usage_complete"] is False
+
+    def test_zero_is_a_legitimate_measurement(self):
+        # 0 is only wrong when it stands in for "unknown". A provider that
+        # genuinely reports 0 output tokens is measured, not missing.
+        meter = CostMeter("job-g2b")
+        meter.record_response(model="m", response={"usage": {"inputTokens": 40, "outputTokens": 0}})
+        llm = meter.snapshot()["llm"]
+        assert llm["usage_complete"] is True
+        assert llm["calls_missing_usage"] == 0
+        assert llm["total_tokens"] == 40
+
+    def test_implausible_write_count_is_ignored(self):
+        meter = CostMeter("job-g2c")
+        meter.record_write("backtest_results", -3)
+        assert meter.snapshot()["writes"] == {}
+
+
+# ── G3: no pricing math in the measurement layer ──────────────────────────
+
+
+class TestNoPricingInMeasurementLayer:
+    """The inputs that SHOULD fail the guard: pricing-shaped labels.
+
+    #1217 is explicit that the server records raw counts and nothing more; the
+    quote seam stays ``flat_v1`` until a human converts these numbers into a
+    price off-server.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_label",
+        ["cost_usd", "price_per_call", "bedrock_spend", "usd_total", "token_pricing", "settlement_fee"],
+    )
+    def test_pricing_shaped_write_counter_is_rejected(self, bad_label):
+        meter = CostMeter("job-g3")
+        with pytest.raises(PricingLeakError):
+            meter.record_write(bad_label)
+        assert meter.snapshot()["writes"] == {}
+
+    @pytest.mark.parametrize("bad_label", ["cost_usd", "price_per_call", "invoice_build"])
+    def test_pricing_shaped_stage_name_is_rejected(self, bad_label):
+        meter = CostMeter("job-g3b")
+        with pytest.raises(PricingLeakError):
+            with meter.stage(bad_label):
+                pass
+        assert meter.snapshot()["stages"] == {}
+
+    @pytest.mark.parametrize("bad_label", ["dollars_burned", "revenue_attributed", "unit_cost"])
+    def test_pricing_shaped_meta_key_is_rejected(self, bad_label):
+        meter = CostMeter("job-g3c")
+        with pytest.raises(PricingLeakError):
+            meter.set_meta(bad_label, 1)
+        assert meter.snapshot()["meta"] == {}
+
+    def test_module_level_recorders_reject_even_with_no_meter_bound(self):
+        # Unbound is the common case in tests/scripts; the guard must not be
+        # bypassable by simply not having started a job.
+        assert cost_meter.current_meter() is None
+        with pytest.raises(PricingLeakError):
+            cost_meter.record_write("cost_usd")
+        with pytest.raises(PricingLeakError):
+            cost_meter.set_meta("price_hint", 1)
+        with pytest.raises(PricingLeakError):
+            with cost_meter.stage("usd_conversion"):
+                pass
+
+    def test_legitimate_labels_are_accepted(self):
+        meter = CostMeter("job-g3d")
+        meter.record_write("backtest_results")
+        with meter.stage("debate_backtest"):
+            pass
+        meter.set_meta("outcome", "done")
+        snap = meter.snapshot()
+        assert snap["writes"] == {"backtest_results": 1}
+        assert snap["stages"]["debate_backtest"]["runs"] == 1
+        assert snap["meta"]["outcome"] == "done"
+
+    def test_snapshot_carries_no_pricing_shaped_key(self):
+        meter = CostMeter("job-g3e")
+        meter.record_response(model="m", response={"usage": {"inputTokens": 1, "outputTokens": 2}})
+        with meter.stage("rigor_gate"):
+            pass
+        meter.record_write("strategy_store")
+
+        def _keys(node, prefix=""):
+            if isinstance(node, dict):
+                for k, v in node.items():
+                    yield f"{prefix}{k}"
+                    yield from _keys(v, f"{prefix}{k}.")
+
+        banned = ("usd", "dollar", "price", "cost", "fee", "revenue")
+        offenders = [k for k in _keys(meter.snapshot()) if any(b in k.lower() for b in banned)]
+        assert offenders == [], f"measurement snapshot must carry no pricing fields: {offenders}"
+
+    def test_quote_seam_is_untouched_and_still_flat(self):
+        from archimedes.services.generation_payment import quote
+
+        assert quote()["pricing_model"] == "flat_v1"
+
+
+# ── The LLM boundary actually records (production code path) ──────────────
+
+
+class TestLLMBackendBoundaryRecords:
+    """``complete()`` is where every provider response passes; mock the SDK
+    client, not the meter, so the wiring under test is the real one."""
+
+    def test_bedrock_converse_complete_banks_usage(self):
+        from archimedes.services.llm_backend import BedrockConverseBackend
+
+        fake_client = MagicMock()
+        fake_client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "hello"}]}},
+            "usage": {"inputTokens": 1200, "outputTokens": 260, "totalTokens": 1460},
+        }
+        with patch("boto3.Session") as session, patch("boto3.client", return_value=fake_client):
+            session.return_value.get_credentials.return_value = object()
+            backend = BedrockConverseBackend(model="amazon.nova-micro-v1:0")
+            with cost_meter.measure("job-live") as meter:
+                assert backend.complete("sys", "user") == "hello"
+
+        llm = meter.snapshot()["llm"]
+        assert llm["calls"] == 1
+        assert llm["usage_complete"] is True
+        assert llm["input_tokens"] == 1200
+        assert llm["output_tokens"] == 260
+        assert llm["by_model"]["amazon.nova-micro-v1:0"]["calls"] == 1
+
+    def test_bedrock_converse_without_usage_is_flagged_not_zeroed(self):
+        from archimedes.services.llm_backend import BedrockConverseBackend
+
+        fake_client = MagicMock()
+        fake_client.converse.return_value = {"output": {"message": {"content": [{"text": "hi"}]}}}
+        with patch("boto3.Session") as session, patch("boto3.client", return_value=fake_client):
+            session.return_value.get_credentials.return_value = object()
+            backend = BedrockConverseBackend(model="amazon.nova-micro-v1:0")
+            with cost_meter.measure("job-live-2") as meter:
+                backend.complete("sys", "user")
+
+        llm = meter.snapshot()["llm"]
+        assert llm["calls"] == 1
+        assert llm["usage_complete"] is False
+
+    def test_anthropic_backend_complete_banks_usage(self):
+        import anthropic
+
+        from archimedes.services.llm_backend import AnthropicBackend
+
+        block = MagicMock()
+        block.text = "answer"
+        resp = MagicMock()
+        resp.content = [block]
+        resp.model = "claude-haiku-4-5"
+        resp.usage.input_tokens = 77
+        resp.usage.output_tokens = 21
+
+        client = MagicMock()
+        client.messages.create.return_value = resp
+        with patch.object(anthropic, "Anthropic", return_value=client):
+            backend = AnthropicBackend(model="claude-haiku-4-5", api_key="test-key")
+            with cost_meter.measure("job-live-3") as meter:
+                assert backend.complete("sys", "user") == "answer"
+
+        llm = meter.snapshot()["llm"]
+        assert llm["input_tokens"] == 77
+        assert llm["output_tokens"] == 21
+        assert llm["by_model"]["claude-haiku-4-5"]["calls"] == 1
+
+    def test_recording_is_a_noop_with_no_meter_bound(self):
+        # An LLM call outside a measured job must not raise; the shared agent
+        # singleton is used by chat and the KB runner too.
+        assert cost_meter.current_meter() is None
+        cost_meter.record_llm_call(model="m", response={"usage": {"inputTokens": 1, "outputTokens": 1}})
+
+
+# ── Context propagation into worker threads ───────────────────────────────
+
+
+class TestContextPropagation:
+    """The society proposes and backtests in ``asyncio.to_thread`` workers, so
+    usage recorded there has to reach the job's meter."""
+
+    def test_usage_recorded_in_a_worker_thread_reaches_the_job_meter(self):
+        async def _run() -> dict:
+            with cost_meter.measure("job-threads") as meter:
+
+                def _call(n: int) -> None:
+                    cost_meter.record_llm_call(
+                        model="amazon.nova-micro-v1:0",
+                        response={"usage": {"inputTokens": n, "outputTokens": 1}},
+                    )
+
+                await asyncio.gather(*(asyncio.to_thread(_call, i) for i in range(1, 6)))
+                return meter.snapshot()
+
+        llm = asyncio.run(_run())["llm"]
+        assert llm["calls"] == 5
+        assert llm["input_tokens"] == 1 + 2 + 3 + 4 + 5
+        assert llm["usage_complete"] is True
+
+    def test_stages_accumulate_across_repeat_entries(self):
+        meter = CostMeter("job-stages")
+        for _ in range(3):
+            with meter.stage("candidate_generation"):
+                time.sleep(0.001)
+        stage = meter.snapshot()["stages"]["candidate_generation"]
+        assert stage["runs"] == 3
+        assert stage["wall_seconds"] > 0
+
+
+# ── G4: merge_result must never conjure a job ─────────────────────────────
+
+
+def _fake_store() -> JobStore:
+    store = JobStore(url="redis://unused")
+    store._redis = fakeredis.FakeAsyncRedis(decode_responses=True)
+    return store
+
+
+class TestJobStoreMergeResult:
+    async def test_merges_into_an_existing_job_result(self):
+        store = _fake_store()
+        job_id = await store.enqueue(job_type="generate", payload={"brief": {"intent": "x"}})
+        await store.update_status(job_id, "done", result={"best_strategy_id": "s1"})
+
+        assert await store.merge_result(job_id, {"cost": {"schema": "cost_v1"}}) is True
+        job = await store.get(job_id)
+        assert job["result"]["best_strategy_id"] == "s1", "the existing result must survive the merge"
+        assert job["result"]["cost"] == {"schema": "cost_v1"}
+
+    async def test_merges_onto_an_errored_job_that_never_wrote_a_result(self):
+        # The rejected path is the common case (#1217 anti-goal 2) and it spends
+        # the same compute, so it must still carry a measurement.
+        store = _fake_store()
+        job_id = await store.enqueue(job_type="generate", payload={})
+        await store.update_status(job_id, "error", error="no candidates generated")
+
+        assert await store.merge_result(job_id, {"cost": {"schema": "cost_v1"}}) is True
+        job = await store.get(job_id)
+        assert job["status"] == "error"
+        assert job["result"]["cost"]["schema"] == "cost_v1"
+
+    async def test_unknown_job_is_not_conjured_into_existence(self):
+        """The input that SHOULD fail the guard: a merge for a job id that does
+        not exist. A bare HSET would materialise a TTL-less hash that then shows
+        up in ``list_recent_jobs`` as a statusless phantom job."""
+        store = _fake_store()
+        redis = store._redis
+
+        assert await store.merge_result("does-not-exist", {"cost": {"schema": "cost_v1"}}) is False
+        assert await redis.exists("archimedes:job:does-not-exist") == 0
+        assert await store.get("does-not-exist") is None
+        assert await store.list_recent_jobs() == []
+
+    async def test_merge_preserves_the_job_ttl(self):
+        store = _fake_store()
+        job_id = await store.enqueue(job_type="generate", payload={})
+        await store.merge_result(job_id, {"cost": {"schema": "cost_v1"}})
+        ttl = await store._redis.ttl(f"archimedes:job:{job_id}")
+        assert 0 < ttl <= JOB_TTL, "merging a measurement must not clear or extend the job's expiry"
+
+    async def test_non_dict_result_is_left_intact(self):
+        store = _fake_store()
+        job_id = await store.enqueue(job_type="generate", payload={})
+        await store._redis.hset(f"archimedes:job:{job_id}", "result", '["legacy", "list"]')
+
+        assert await store.merge_result(job_id, {"cost": {"schema": "cost_v1"}}) is False
+        job = await store.get(job_id)
+        assert job["result"] == ["legacy", "list"]
+
+
+# ── The pipeline persists a snapshot on the FAILED path too ───────────────
+
+
+class TestPipelinePersistsSnapshot:
+    """A generation that fails still consumed the compute. #1217's anti-goal 2 is
+    explicit that the rejected path is the common case and is not cheaper, so the
+    measurement has to survive the error paths, not just ``done``."""
+
+    async def _run_brief_invalid(self) -> MagicMock:
+        from archimedes.agents import generation_pipeline
+
+        store = MagicMock()
+        store.update_status = AsyncMock()
+        store.push_event = AsyncMock(return_value=1)
+        store.merge_result = AsyncMock(return_value=True)
+
+        with (
+            patch.object(generation_pipeline, "_llm_available", return_value=True),
+            patch.object(
+                generation_pipeline,
+                "_validate_brief",
+                new=AsyncMock(return_value={"is_valid": False, "reason": "too vague", "hint": "name an asset class"}),
+            ),
+        ):
+            await generation_pipeline.run_generation(
+                job_id="job-fail",
+                brief=generation_pipeline.GenerateBrief(intent="uh"),
+                store=store,
+            )
+        return store
+
+    async def test_error_path_still_persists_a_measurement(self):
+        store = await self._run_brief_invalid()
+
+        store.merge_result.assert_awaited_once()
+        job_id, patch_payload = store.merge_result.await_args.args
+        assert job_id == "job-fail"
+        snapshot = patch_payload["cost"]
+        assert snapshot["schema"] == "cost_v1"
+        assert snapshot["job_id"] == "job-fail"
+        assert snapshot["meta"]["outcome"] == "brief_invalid"
+        assert "brief_validation" in snapshot["stages"], "the stage that ran must appear in the breakdown"
+        assert snapshot["wall_seconds"] >= 0
+        assert snapshot["cpu_attribution"] == "process_wide_delta"
+
+    async def test_meter_is_unbound_after_the_job_finishes(self):
+        # A leaked binding would attribute the NEXT job's tokens to this one.
+        await self._run_brief_invalid()
+        assert cost_meter.current_meter() is None
+
+
+# ── The measurement is readable, and only by its owner ────────────────────
+
+_OWNER = "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+_ATTACKER = "0x9999999999999999999999999999999999999999"
+_JOB_ID = "job-cost-1"
+_SNAPSHOT = {
+    "schema": "cost_v1",
+    "job_id": _JOB_ID,
+    "llm": {"calls": 9, "input_tokens": 41234, "output_tokens": 5120, "usage_complete": True},
+    "stages": {"debate_backtest": {"wall_seconds": 31.2, "cpu_seconds": 28.9, "runs": 1}},
+    "writes": {"strategy_store": 1},
+}
+
+
+def _cookies(wallet: str) -> dict[str, str]:
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _cost_job(owner_wallet: str | None, *, cost: dict | None) -> dict:
+    return {
+        "id": _JOB_ID,
+        "type": "generate",
+        "status": "done",
+        "created_at": "2026-08-01T00:00:00+00:00",
+        "updated_at": "2026-08-01T00:00:30+00:00",
+        "payload": {"owner_wallet": owner_wallet, "brief": {"intent": "x"}, "n_candidates": 1},
+        "result": {"best_strategy_id": "s1", "candidates": [], **({"cost": cost} if cost is not None else {})},
+    }
+
+
+def _client_with(job: dict | None) -> tuple[TestClient, object]:
+    from archimedes.main import app
+
+    store = MagicMock()
+    store.get = AsyncMock(return_value=job)
+    store.list_recent_jobs = AsyncMock(return_value=[job] if job else [])
+    return TestClient(app), patch("archimedes.api.generate_routes.get_job_store", return_value=store)
+
+
+class TestCostEndpoint:
+    def test_owner_reads_the_measurement(self):
+        client, patched = _client_with(_cost_job(_OWNER.lower(), cost=_SNAPSHOT))
+        with patched:
+            resp = client.get(f"/api/generate/jobs/{_JOB_ID}/cost", cookies=_cookies(_OWNER))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["state"] == "done"
+        assert body["cost"]["llm"]["input_tokens"] == 41234
+        assert body["cost"]["stages"]["debate_backtest"]["cpu_seconds"] == 28.9
+
+    def test_missing_measurement_is_null_not_zero(self):
+        """A job that predates the meter (or has not finished) reports ``null`` —
+        an honest absence, never a fabricated zero-token record."""
+        client, patched = _client_with(_cost_job(_OWNER.lower(), cost=None))
+        with patched:
+            resp = client.get(f"/api/generate/jobs/{_JOB_ID}/cost", cookies=_cookies(_OWNER))
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["cost"] is None
+
+    def test_another_users_job_404s(self):
+        client, patched = _client_with(_cost_job(_OWNER.lower(), cost=_SNAPSHOT))
+        with patched:
+            resp = client.get(f"/api/generate/jobs/{_JOB_ID}/cost", cookies=_cookies(_ATTACKER))
+        assert resp.status_code == 404, resp.text
+
+    def test_anonymous_401(self):
+        client, patched = _client_with(_cost_job(_OWNER.lower(), cost=_SNAPSHOT))
+        with patched:
+            resp = client.get(f"/api/generate/jobs/{_JOB_ID}/cost")
+        assert resp.status_code == 401, resp.text
+
+    def test_jobs_listing_carries_the_measurement(self):
+        client, patched = _client_with(_cost_job(_OWNER.lower(), cost=_SNAPSHOT))
+        with patched:
+            resp = client.get("/api/generate/jobs", cookies=_cookies(_OWNER))
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["jobs"][0]["cost"]["llm"]["calls"] == 9

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`diagrams/strategy-passport-architecture.md`](diagrams/strategy-passport-architecture.md) | reference | Dan Browne | — | Passport architecture diagram + reference. |
 | [`bedrock-model-cost-comparison.md`](bedrock-model-cost-comparison.md) | reference | Dan Browne | — | Bedrock model costs, us-east-1 on-demand. LLM is `bedrock_converse` / `amazon.nova-micro-v1:0`. |
 | [`cost-estimates/generate-llm-costs.md`](cost-estimates/generate-llm-costs.md) | reference | Dan Browne | — | Per-generation LLM cost estimate. |
+| [`generation-cost-instrumentation.md`](generation-cost-instrumentation.md) | current | Dan Browne | 2026-08-20 | What one generation actually consumes: per-job token counts, per-stage wall/CPU seconds, peak RSS, row writes. Raw measurement only — the quote seam stays `flat_v1`. |
 
 ## On-chain and Arc
 

--- a/docs/generation-cost-instrumentation.md
+++ b/docs/generation-cost-instrumentation.md
@@ -27,7 +27,7 @@ a guess.
 | Piece | File |
 |---|---|
 | The meter — accumulation, guards, snapshot shape | [`backend/archimedes/services/cost_meter.py`](../backend/archimedes/services/cost_meter.py) |
-| Token capture at the provider boundary | [`backend/archimedes/services/llm_backend.py`](../backend/archimedes/services/llm_backend.py) (every `complete()`), [`backend/archimedes/agents/portfolio_agent.py`](../backend/archimedes/agents/portfolio_agent.py) (raw-SDK tool-use loop) |
+| Token capture at the provider boundary | [`backend/archimedes/services/llm_backend.py`](../backend/archimedes/services/llm_backend.py) (every `complete()`) — plus an inert call in [`backend/archimedes/agents/portfolio_agent.py`](../backend/archimedes/agents/portfolio_agent.py), see "What is not measured" below |
 | Stage timing + write tallies | [`backend/archimedes/agents/generation_pipeline.py`](../backend/archimedes/agents/generation_pipeline.py), [`backend/archimedes/agents/debate_engine.py`](../backend/archimedes/agents/debate_engine.py) |
 | Persistence onto the job | `JobStore.merge_result` in [`backend/archimedes/services/job_queue.py`](../backend/archimedes/services/job_queue.py) |
 | Read surfaces | `GET /api/generate/jobs/{job_id}/cost`, and the `cost` field on `GET /api/generate/jobs` |
@@ -35,10 +35,31 @@ a guess.
 
 The meter is bound to a `contextvars` context for the duration of one job, so
 the LLM boundary records usage without threading a parameter through the debate
-engine, the fusion proposer, and the portfolio agent. `asyncio.to_thread` and
-`asyncio.create_task` both copy the current context, so the society's parallel
-proposal and backtest workers write into the same meter; mutations are
-lock-guarded.
+engine and the fusion proposer. `asyncio.to_thread` and `asyncio.create_task`
+both copy the current context, so the society's parallel proposal and backtest
+workers write into the same meter; mutations are lock-guarded.
+
+### What is not measured
+
+A recorder is a no-op when no meter is bound to the context. That is the right
+behaviour outside a job, but it has a consequence worth stating plainly:
+**instrumenting a code path does not by itself put that path in a job's
+snapshot.** `run_generation` is the only thing that binds a meter.
+
+One instrumented call is therefore **inert today**:
+`propose_portfolio_with_tools()` in `portfolio_agent.py` carries a
+`record_llm_call`, and its raw-SDK tool-use loop genuinely does bypass
+`LLMBackend.complete()` — but that method is not on the generation pipeline's
+call graph. Its only caller is `GET /api/strategies/advisor`, which never opens
+a `cost_meter.measure()` scope, and the pipeline's two runners
+(`_run_debate_leaderboard`, `_run_fixture_candidate`) both accept an `agent`
+argument for signature parity and ignore it. So no generation reaches this loop,
+and the call cannot contribute to any job's cost snapshot as the code stands.
+
+It is kept rather than removed because it is correct the moment that changes: if
+this loop is ever joined to a metered job, the coverage is already in place
+instead of being discovered missing after the fact. It closes no gap today, and
+the snapshots in this document do not include anything from it.
 
 ## Snapshot shape (`cost_v1`)
 
@@ -122,11 +143,17 @@ lock-guarded.
 2. **An implausible count is refused, not accumulated.** Negative, `NaN`,
    infinite, stringly-typed, boolean, non-integral, or absurd (`>` 10M) counts
    are recorded as missing.
-3. **No pricing math server-side.** Stage names, write-counter names, and meta
-   keys are screened; a pricing-shaped label (`cost_usd`, `price_per_call`,
-   `bedrock_spend`, …) raises `PricingLeakError`. The snapshot carries no
-   pricing-shaped key at any depth, and `quote()["pricing_model"]` stays
-   `flat_v1`.
+3. **No pricing math server-side.** Every caller-chosen label — stage name,
+   write-counter name, meta key — is screened at write time, and a pricing-shaped
+   one (`cost_usd`, `price_per_call`, `bedrock_spend`, …) raises
+   `PricingLeakError`, whether or not a meter is bound. That write-time screening
+   is the enforcement: the remaining keys in a snapshot are the meter's own fixed
+   literals, so a caller label is the only route a pricing-shaped key could take
+   into one. The test complements it from the other side by walking a
+   representative snapshot's keys at every depth and asserting none contains
+   `usd` / `dollar` / `price` / `cost` / `fee` / `revenue` — a check on one
+   instance, not a proof over all of them; the screening is what makes it
+   general. `quote()["pricing_model"]` stays `flat_v1`.
 4. **The measurement never conjures a job.** `merge_result` refuses to write to a
    job id that does not exist, and undoes a write that raced an expiry —
    otherwise a bare `HSET` would materialise a TTL-less phantom hash that then

--- a/docs/generation-cost-instrumentation.md
+++ b/docs/generation-cost-instrumentation.md
@@ -1,0 +1,185 @@
+# Generation cost instrumentation
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+Every generation now carries a measurement record: how many tokens the debate
+society actually consumed, how long each pipeline phase took in wall and CPU
+seconds, the process peak RSS, and how many rows the run wrote. The record is
+persisted on the job and readable over the API.
+
+This exists because the only figure ever quoted for a generation was a Bedrock
+inference estimate — the language-model term alone, excluding the walk-forward
+and CSCV backtests the debate society runs across every candidate. Issue #1217:
+*"until this number exists, 'near-zero marginal cost' is an assumption wearing
+the clothes of a finding."*
+
+**This layer records counts and seconds. It does not price anything.** The
+paywall quote seam (`generation_payment.quote()`, `GET /api/generate/quote`)
+remains `pricing_model: "flat_v1"` and is untouched. Converting the counts into
+dollars happens off-server against the current Bedrock and Fargate rate cards;
+the point of the instrumentation is that the conversion stops being applied to
+a guess.
+
+## Where it lives
+
+| Piece | File |
+|---|---|
+| The meter — accumulation, guards, snapshot shape | [`backend/archimedes/services/cost_meter.py`](../backend/archimedes/services/cost_meter.py) |
+| Token capture at the provider boundary | [`backend/archimedes/services/llm_backend.py`](../backend/archimedes/services/llm_backend.py) (every `complete()`), [`backend/archimedes/agents/portfolio_agent.py`](../backend/archimedes/agents/portfolio_agent.py) (raw-SDK tool-use loop) |
+| Stage timing + write tallies | [`backend/archimedes/agents/generation_pipeline.py`](../backend/archimedes/agents/generation_pipeline.py), [`backend/archimedes/agents/debate_engine.py`](../backend/archimedes/agents/debate_engine.py) |
+| Persistence onto the job | `JobStore.merge_result` in [`backend/archimedes/services/job_queue.py`](../backend/archimedes/services/job_queue.py) |
+| Read surfaces | `GET /api/generate/jobs/{job_id}/cost`, and the `cost` field on `GET /api/generate/jobs` |
+| Tests | [`backend/tests/test_generation_cost_meter.py`](../backend/tests/test_generation_cost_meter.py) |
+
+The meter is bound to a `contextvars` context for the duration of one job, so
+the LLM boundary records usage without threading a parameter through the debate
+engine, the fusion proposer, and the portfolio agent. `asyncio.to_thread` and
+`asyncio.create_task` both copy the current context, so the society's parallel
+proposal and backtest workers write into the same meter; mutations are
+lock-guarded.
+
+## Snapshot shape (`cost_v1`)
+
+```json
+{
+  "schema": "cost_v1",
+  "job_id": "9f2c…",
+  "wall_seconds": 47.9312,
+  "cpu_seconds": 31.4407,
+  "cpu_attribution": "process_wide_delta",
+  "peak_rss_bytes": 812939264,
+  "rss_attribution": "process_high_water",
+  "llm": {
+    "calls": 17,
+    "calls_missing_usage": 0,
+    "usage_complete": true,
+    "input_tokens": 41234,
+    "output_tokens": 5120,
+    "total_tokens": 46354,
+    "by_model": {
+      "amazon.nova-micro-v1:0": {
+        "calls": 17, "calls_missing_usage": 0,
+        "input_tokens": 41234, "output_tokens": 5120
+      }
+    }
+  },
+  "stages": {
+    "brief_validation":      {"wall_seconds": 1.02,  "cpu_seconds": 0.01, "runs": 1},
+    "pipeline_select":       {"wall_seconds": 0.31,  "cpu_seconds": 0.28, "runs": 1},
+    "corpus_load":           {"wall_seconds": 2.44,  "cpu_seconds": 2.31, "runs": 1},
+    "debate_propose":        {"wall_seconds": 12.80, "cpu_seconds": 1.10, "runs": 1},
+    "debate_transcript":     {"wall_seconds": 6.02,  "cpu_seconds": 0.40, "runs": 1},
+    "debate_backtest":       {"wall_seconds": 21.55, "cpu_seconds": 20.90,"runs": 1},
+    "candidate_generation":  {"wall_seconds": 43.10, "cpu_seconds": 24.9, "runs": 1},
+    "rigor_gate":            {"wall_seconds": 0.90,  "cpu_seconds": 0.88, "runs": 1},
+    "persist_winner":        {"wall_seconds": 0.42,  "cpu_seconds": 0.05, "runs": 1},
+    "backtest_persist":      {"wall_seconds": 2.10,  "cpu_seconds": 1.90, "runs": 1}
+  },
+  "writes": {
+    "strategy_store": 1, "strategy_passports": 2,
+    "backtest_results": 1, "strategy_proposals": 4
+  },
+  "meta": {
+    "n_candidates_requested": 1, "model_requested": null,
+    "candidates_considered": 4, "candidates_passing_rigor": 0,
+    "pipeline": "debate", "served_model": "amazon.nova-micro-v1:0",
+    "outcome": "done"
+  }
+}
+```
+
+### Reading it honestly
+
+* **`candidate_generation` is the outer stage; `corpus_load` / `debate_propose` /
+  `debate_transcript` / `debate_backtest` are its sub-phases.** They overlap by
+  construction — do not sum all stages and expect `wall_seconds`.
+* **`cpu_seconds` is a `time.process_time()` delta, which is process-wide.**
+  Under concurrent traffic a stage's CPU figure includes work other requests did
+  in the same worker. Labelled `cpu_attribution: "process_wide_delta"` rather
+  than presented as isolated per-job CPU. For an isolated figure, measure a
+  single generation on a quiet task.
+* **`peak_rss_bytes` is a process high-water mark** (`ru_maxrss`, unit-corrected
+  per platform), so it says what the worker has ever reached, not what this job
+  caused. It is the number to size an ECS task from, not to attribute.
+* **`writes` counts write operations the pipeline issued**, upserts counting
+  once — not a measured row delta in Aurora.
+* **`usage_complete: false` means at least one call's tokens were not readable.**
+  Do not treat the totals as the run's full token consumption when this is false.
+* **`meta.candidates_passing_rigor: 0` is the common case, not a failure to
+  measure.** A run that fails the gate spends the same backtest compute; the
+  snapshot is written on the error and cancelled paths too, so the rejected path
+  is measurable rather than assumed to be cheaper.
+
+## Guarantees the code enforces
+
+1. **A missing measurement is never a zero.** A provider response with no usable
+   `usage` block increments `calls_missing_usage` and sets `usage_complete:
+   false`; it does not bank a 0-token call. A half-readable block banks neither
+   half. (`CLAUDE.md` § fail-soft — the correct degraded state is a loud, visible
+   absence, never a plausible substitute.)
+2. **An implausible count is refused, not accumulated.** Negative, `NaN`,
+   infinite, stringly-typed, boolean, non-integral, or absurd (`>` 10M) counts
+   are recorded as missing.
+3. **No pricing math server-side.** Stage names, write-counter names, and meta
+   keys are screened; a pricing-shaped label (`cost_usd`, `price_per_call`,
+   `bedrock_spend`, …) raises `PricingLeakError`. The snapshot carries no
+   pricing-shaped key at any depth, and `quote()["pricing_model"]` stays
+   `flat_v1`.
+4. **The measurement never conjures a job.** `merge_result` refuses to write to a
+   job id that does not exist, and undoes a write that raced an expiry —
+   otherwise a bare `HSET` would materialise a TTL-less phantom hash that then
+   lists forever as a statusless job.
+5. **Instrumentation cannot fail a generation.** `record_llm_call` swallows
+   unexpected errors, and the snapshot persist is suppressed on failure. A
+   deliberate pricing-label violation is the one exception: it raises, because it
+   is a code bug with a fixed literal label, not a data-dependent condition.
+
+## Measurement procedure
+
+Both runs below are `n_candidates=1` and `n_candidates>1`, so the scaling in N is
+observed rather than assumed. Run against a live LLM path — the fixture runner
+makes no LLM calls and reports `llm.calls: 0`, which is honest and useless for
+this purpose.
+
+```bash
+# 1. Start a generation (session cookie required; paywall per environment).
+curl -s -X POST https://archimedes-arc.com/api/generate/start \
+  -H 'content-type: application/json' -b "$COOKIES" \
+  -d '{"brief":{"intent":"momentum on liquid majors","risk_appetite":"moderate"},"n_candidates":1}'
+# → {"job_id": "...", "stream_url": "...", "ttl_seconds": 900}
+
+# 2. Wait for a terminal state on the SSE stream (or poll /api/generate/jobs).
+curl -s -N -b "$COOKIES" https://archimedes-arc.com/api/generate/stream/$JOB_ID
+
+# 3. Read the measurement.
+curl -s -b "$COOKIES" https://archimedes-arc.com/api/generate/jobs/$JOB_ID/cost | jq .
+
+# 4. Repeat with "n_candidates": 5 and compare llm.total_tokens,
+#    stages.debate_backtest.cpu_seconds, and writes.strategy_proposals.
+```
+
+Record at minimum: one `outcome: "done"` run that passed the gate, one that
+failed it (`meta.candidates_passing_rigor: 0`), and one multi-candidate run. The
+`meta` block makes each snapshot self-describing, so the three are comparable
+after the fact.
+
+### Task sizing, and what this does not measure
+
+`peak_rss_bytes` and `cpu_seconds` come from inside the worker process. The
+allocated task size — what Fargate actually bills — is the ECS task definition's
+`cpu`/`memory`, and per-task utilisation is CloudWatch's `CpuUtilized` /
+`MemoryUtilized`:
+
+```bash
+aws ecs describe-tasks --cluster <cluster> --tasks <task> \
+  --query 'tasks[0].{cpu:cpu,memory:memory}'
+```
+
+Turning `cpu_seconds` + task size into a per-generation Fargate figure, and
+`llm.total_tokens` + the model's rate card into a per-generation inference
+figure, is deliberately left outside the server. Related:
+[`bedrock-model-cost-comparison.md`](bedrock-model-cost-comparison.md) for the
+rate card, and [`cost-estimates/generate-llm-costs.md`](cost-estimates/generate-llm-costs.md)
+for the estimate this instrumentation exists to replace.


### PR DESCRIPTION
Refs #1217

## Summary

We did not know what a generation costs. This lands the measurement layer: every generation now records **Bedrock input/output token counts** (from the provider's own `usage` block), **wall + CPU seconds per pipeline stage**, **process peak RSS**, and **the rows the run wrote** — persisted onto the job record and exposed in the job payload.

This is the decidable, in-repo subset of #1217, hence `Refs` rather than `Closes` — see **What #1217 still needs** at the bottom.

**No pricing math server-side.** The paywall quote seam (`generation_payment.quote()`, `GET /api/generate/quote`) is untouched and still reports `pricing_model: "flat_v1"`. Converting counts into dollars happens off-server against the current rate cards; the point of this PR is that the conversion stops being applied to a guess. Quota, payment, auth, and rigor-gate semantics are unchanged — no threshold, gate, or enforcement path is touched.

The snapshot is written on **every** terminal path — `done`, rigor-failed, errored, cancelled — because #1217's second anti-goal is explicit that the rejected path burns the same backtest compute and is the common case. `meta.candidates_passing_rigor` makes each stored snapshot self-describing as a pass or a fail.

## What changed, file by file

**`backend/archimedes/services/cost_meter.py`** (new)
The meter: token accumulation with per-model breakdown, per-stage wall/CPU timing, write tallies, descriptive `meta`, and the `cost_v1` snapshot. `extract_token_usage` normalises four provider shapes — Bedrock Converse (`inputTokens`/`outputTokens`), Anthropic SDK (`input_tokens`/`output_tokens`), OpenAI-compatible (`prompt_tokens`/`completion_tokens`), Ollama (`prompt_eval_count`/`eval_count`, top level, no usage block). Bound to a `contextvars` context for the duration of one job, so the LLM boundary records without threading a parameter through the debate engine and the fusion proposer; `asyncio.to_thread` and `asyncio.create_task` copy the context, so the society's parallel proposal and backtest workers write into the same meter, and mutations are lock-guarded.

**`backend/archimedes/services/llm_backend.py`**
`record_llm_call(...)` in all six concrete backends' `complete()` — `AnthropicBackend`, `AnthropicCompatibleBackend`, `BedrockBackend`, `BedrockConverseBackend`, `OpenAIBackend`, `OllamaBackend` — the one place every provider response passes through. (`LLMBackend` is a Protocol; `CannedBackend` is the test double and is deliberately not instrumented.) Placed after the existing `served_model` resolution so usage is attributed to the model that actually served.

**`backend/archimedes/agents/portfolio_agent.py`** — instrumented but **inert today**
The tool-use loop in `propose_portfolio_with_tools()` does call the raw SDK directly and does bypass `complete()`, so a *metered* job running through it would under-report without this line. But no job runs through it: **`propose_portfolio_with_tools()` is not on the generation pipeline's call graph**, so this `record_llm_call` cannot contribute to any job's cost snapshot as the code stands. Three facts, each checkable:

- its only caller is `strategies_routes.py:775`, inside `GET /api/strategies/advisor`;
- that endpoint never opens a `cost_meter.measure()` scope — the only meter binding in the tree is `generation_pipeline.py:754`;
- the pipeline's two runners, `_run_debate_leaderboard` and `_run_fixture_candidate`, both accept an `agent` argument marked `# noqa: ARG001 — signature parity` and ignore it.

`record_llm_call` returns immediately when no meter is bound, so the call is a no-op on this path rather than a wrong number.

**It is kept, not removed**, because it is correct the moment that changes: if this loop is ever joined to a metered job, the coverage is already in place instead of being discovered missing afterwards. **It closes no under-reporting gap today**, and none of the snapshots in this PR or in `docs/generation-cost-instrumentation.md` contain anything from it. The in-code comment, the `cost_meter` module docstring, and the doc's new "What is not measured" section all say exactly this.

**`backend/archimedes/agents/generation_pipeline.py`**
Binds the meter for the whole job; stages `brief_validation`, `pipeline_select`, `candidate_generation`, `rigor_gate`, `persist_winner`, `backtest_persist`; write tallies for `strategy_store` / `strategy_passports` / `backtest_results` / `strategy_proposals`; `meta` (requested N, requested/served model, candidates considered, candidates passing rigor, pipeline, outcome). A `finally` clause unbinds the meter and merges the snapshot onto the job. Instrumentation cannot change a generation's outcome — the persist is suppressed on failure, `CancelledError` included, since it runs while a cancellation is already propagating.

**`backend/archimedes/agents/debate_engine.py`**
Sub-stages `corpus_load`, `debate_propose`, `debate_transcript`, `debate_backtest`. This is the split that answers #1217's actual question — which phase dominates — instead of collapsing the society into one number.

**`backend/archimedes/services/job_queue.py`**
`JobStore.merge_result(job_id, patch)` — merges top-level keys into an existing job's `result`. Needed because most terminal paths (error, cancelled) never write a result at all.

**`backend/archimedes/api/generate_routes.py`, `generate_schemas.py`**
New `GET /api/generate/jobs/{job_id}/cost`, owner-scoped exactly like `/candidates` (404, no existence oracle), plus a `cost` field on `GET /api/generate/jobs`. Absent measurement reports `null`, never a fabricated zero.

Rebased onto `main` after #1292 landed, which moved the job listing onto a shared `_job_summary()` helper. Both sides are preserved: the `cost` field now lives in that helper rather than in an inline construction, so `GET /jobs` and `GET /jobs/{job_id}` (#1292) report it identically, and `GET /jobs/{job_id}` and `GET /jobs/{job_id}/cost` both survive. The module docstring's endpoint list gains the `/cost` line it had been missing.

**`backend/tests/test_generation_cost_meter.py`** (new, 52 tests)
Hermetic: fakeredis for the job store, provider SDK clients mocked at the boundary, real signed session cookies for endpoint scoping. No live LLM, no Postgres, no network.

**`docs/generation-cost-instrumentation.md`** (new) + `docs/README.md` row
Snapshot shape, how to read it honestly, the enforced guarantees, the reproducible measurement procedure (single-candidate and N>1, so the scaling in N is observed rather than assumed), and a **"What is not measured"** section recording the inert `portfolio_agent` call and the general point behind it: instrumenting a code path does not by itself put that path in a job's snapshot, because a recorder is a no-op when no meter is bound.

## Reading the numbers honestly

Three attributions are labelled in the payload rather than presented as cleaner than they are:

- `candidate_generation` is the **outer** stage; `corpus_load` / `debate_propose` / `debate_transcript` / `debate_backtest` are its sub-phases. They overlap by construction — do not sum all stages.
- `cpu_seconds` is a `time.process_time()` delta, which is **process-wide**: under concurrent traffic a stage's CPU includes other requests' work in the same worker. Carried as `cpu_attribution: "process_wide_delta"`. For an isolated figure, measure on a quiet task.
- `peak_rss_bytes` is `ru_maxrss`, a **process high-water mark** (unit-corrected: bytes on Darwin, KiB on Linux). It is the number to size a task from, not to attribute to one job. Carried as `rss_attribution: "process_high_water"`.
- `writes` counts write operations the pipeline **issued** (upserts count once), not a measured Aurora row delta.

## Guard demonstrations

House rule: a guard must be shown to reject something. Each guard below was disabled, the tests re-run to confirm they fail, then the guard restored and the tests re-run to confirm they pass.

### G1 + G2 — a missing measurement is never a zero; an implausible count is refused

The failure this prevents: a response whose `usage` block is absent or corrupt gets banked as a 0-token call, the snapshot reports `usage_complete: true`, and the run looks free.

Guard replaced with the naive version (`clean_in = clean_in or 0; clean_out = clean_out or 0`):

```
$ pytest backend/tests/test_generation_cost_meter.py -q -k "MissingUsage or Implausible"
FAILED ...::TestImplausibleCountsRefused::test_bad_count_is_recorded_as_missing_not_added[bad_usage2-infinite token count]
  - AssertionError: infinite token count must not bank its partner half either
FAILED ...::TestImplausibleCountsRefused::test_bad_count_is_recorded_as_missing_not_added[bad_usage3-stringly-typed count]
  - AssertionError: stringly-typed count must not bank its partner half either
FAILED ...::TestImplausibleCountsRefused::test_bad_count_is_recorded_as_missing_not_added[bad_usage4-absurd count (> MAX_PLAUSIBLE_TOKENS)]
FAILED ...::TestImplausibleCountsRefused::test_bad_count_is_recorded_as_missing_not_added[bad_usage5-bool masquerading as an int]
FAILED ...::TestImplausibleCountsRefused::test_bad_count_is_recorded_as_missing_not_added[bad_usage6-non-integral count]
=========== 10 failed, 3 passed, 39 deselected, 2 warnings in 2.70s ============

# guard restored
=================== 13 passed, 39 deselected, 2 warnings in 2.37s ===================
```

Rejected inputs, each demonstrated: `{"inputTokens": -5}`, `NaN`, `inf`, `"812"` (stringly-typed), `10**12` (> `MAX_PLAUSIBLE_TOKENS`), `True` (bool is an `int` in Python and would bank as one token), `1.5` (non-integral), and a half-readable block (`{"inputTokens": 812}` with no output count — banks neither half). A genuine `0` is still a measurement and is banked.

### G3 — no pricing math in the measurement layer

The failure this prevents: pricing creeps server-side one field at a time and the "raw counts only" claim becomes prose the code does not enforce.

`_assert_no_pricing` screening loop replaced with `for token in ():`:

```
$ pytest backend/tests/test_generation_cost_meter.py -q -k "NoPricing"
FAILED ...::test_pricing_shaped_stage_name_is_rejected[cost_usd]      - DID NOT RAISE PricingLeakError
FAILED ...::test_pricing_shaped_stage_name_is_rejected[price_per_call] - DID NOT RAISE PricingLeakError
FAILED ...::test_pricing_shaped_stage_name_is_rejected[invoice_build]  - DID NOT RAISE PricingLeakError
FAILED ...::test_pricing_shaped_meta_key_is_rejected[dollars_burned]   - DID NOT RAISE PricingLeakError
FAILED ...::test_pricing_shaped_meta_key_is_rejected[revenue_attributed] - DID NOT RAISE PricingLeakError
FAILED ...::test_pricing_shaped_meta_key_is_rejected[unit_cost]        - DID NOT RAISE PricingLeakError
FAILED ...::test_module_level_recorders_reject_even_with_no_meter_bound - DID NOT RAISE PricingLeakError
=========== 13 failed, 3 passed, 36 deselected, 2 warnings in 2.15s ============

# guard restored
=================== 16 passed, 36 deselected, 2 warnings in 1.76s ===================
```

Rejected labels: `cost_usd`, `price_per_call`, `bedrock_spend`, `usd_total`, `token_pricing`, `settlement_fee`, `dollars_burned`, `revenue_attributed`, `unit_cost`, `invoice_build`. The guard also fires with **no meter bound**, so it cannot be bypassed by simply not starting a job. The write-time screening is what makes the property general: every other key in a snapshot is one of the meter's own fixed literals, so a caller-chosen label is the only route a pricing-shaped key could take into one.

A separate test complements it from the other side — it builds **one** snapshot from legitimate labels, walks its keys recursively to every depth, and asserts none contains `usd`/`dollar`/`price`/`cost`/`fee`/`revenue`. That is a check on an instance, not a proof over all possible snapshots; stating it as "the snapshot carries no pricing-shaped key at any depth" overclaimed what it establishes, and the doc's guarantee 3 has been reworded to lead with the screening. A third test asserts `quote()["pricing_model"] == "flat_v1"`.

### G4 — the measurement must never conjure a job

The failure this prevents: a bare `HSET` on a missing key materialises a TTL-less phantom hash that then lists forever as a statusless job.

Both the pre-write `exists` check and the post-write `hexists("id")` undo removed, then the same call made against fakeredis:

```
UNGUARDED  key exists: 1  ttl: -1  listed as job: ['does-not-exist']
GUARDED    key exists: 0  ttl: -2  listed as job: []
```

`ttl: -1` is Redis for "key exists, no expiry" — the phantom never goes away. Under test:

```
$ pytest backend/tests/test_generation_cost_meter.py -q -k "MergeResult"
FAILED ...::TestJobStoreMergeResult::test_unknown_job_is_not_conjured_into_existence - assert True is False
============ 1 failed, 4 passed, 47 deselected, 2 warnings in 1.93s ============

# guard restored
================= 5 passed, 47 deselected, 2 warnings in 1.25s =================
```

### G5 — the failed path must still be measured

The failure this prevents: only successful generations carry a snapshot, so the measurement describes the rare case and the 89%-of-runs rejected path stays unmeasured — the exact thing #1217's anti-goal 2 forbids.

Persist gated on `outcome == "done"`:

```
$ pytest backend/tests/test_generation_cost_meter.py -q -k "PipelinePersists"
FAILED ...::TestPipelinePersistsSnapshot::test_error_path_still_persists_a_measurement
  - AssertionError: Expected merge_result to have been awaited once. Awaited 0 times.
============ 1 failed, 1 passed, 50 deselected, 2 warnings in 1.73s ============

# guard restored
================= 2 passed, 50 deselected, 2 warnings in 1.55s =================
```

### G6 — the boundary instrumentation is real, not asserted

`record_llm_call` removed from `BedrockConverseBackend.complete()` (the live provider path):

```
$ pytest backend/tests/test_generation_cost_meter.py -q -k "LLMBackendBoundary"
FAILED ...::test_bedrock_converse_complete_banks_usage            - assert 0 == 1
FAILED ...::test_bedrock_converse_without_usage_is_flagged_not_zeroed - assert 0 == 1
============ 2 failed, 2 passed, 48 deselected, 2 warnings in 2.72s ============

# guard restored
================= 4 passed, 48 deselected, 2 warnings in 2.04s =================
```

These exercise the production code path with the boto3 / Anthropic client mocked at the boundary, not the meter mocked.

### G7 — owner scoping on the new read surface

`_require_job_access` removed from the cost endpoint:

```
$ pytest backend/tests/test_generation_cost_meter.py -q -k "CostEndpoint"
FAILED ...::TestCostEndpoint::test_another_users_job_404s
  - AssertionError: {"job_id":"job-cost-1","state":"done","cost":{"schema":"cos...
============ 1 failed, 4 passed, 47 deselected, 6 warnings in 2.80s ============

# guard restored
================= 5 passed, 47 deselected, 6 warnings in 2.38s =================
```

## Verification

New tests:

```
$ pytest backend/tests/test_generation_cost_meter.py -q
52 passed, 6 warnings in 5.07s
```

Full unit suite, from the repo root, the exact command CI runs:

```
$ pytest -m "not integration" -q
3269 passed, 2 skipped, 2 deselected, 191 warnings in 270.11s (0:04:30)
```

Lint:

```
$ ruff format --check .
547 files already formatted

$ ruff check --select E9,F63,F7,F40 .
All checks passed!
```

Hermetic gate (no `.env`, no services), per the testing conventions:

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_generation_cost_meter.py -q
52 passed, 6 warnings in 2.79s

$ grep -r "asyncio.get_event_loop" backend/tests/
(no output)
```

Docs gate:

```
$ make docs-check
links: scanned 1222 in 144 markdown files; broken 0 (0.0%)
index: 140 docs under docs/; 140 indexed, 0 orphaned.
```

## Sample payload

```json
GET /api/generate/jobs/{job_id}/cost
{
  "job_id": "9f2c…",
  "state": "done",
  "cost": {
    "schema": "cost_v1",
    "wall_seconds": 47.9312,
    "cpu_seconds": 31.4407,
    "cpu_attribution": "process_wide_delta",
    "peak_rss_bytes": 812939264,
    "rss_attribution": "process_high_water",
    "llm": {
      "calls": 17, "calls_missing_usage": 0, "usage_complete": true,
      "input_tokens": 41234, "output_tokens": 5120, "total_tokens": 46354,
      "by_model": {"amazon.nova-micro-v1:0": {"calls": 17, "calls_missing_usage": 0,
                                              "input_tokens": 41234, "output_tokens": 5120}}
    },
    "stages": {
      "corpus_load":      {"wall_seconds": 2.44,  "cpu_seconds": 2.31,  "runs": 1},
      "debate_propose":   {"wall_seconds": 12.80, "cpu_seconds": 1.10,  "runs": 1},
      "debate_backtest":  {"wall_seconds": 21.55, "cpu_seconds": 20.90, "runs": 1},
      "rigor_gate":       {"wall_seconds": 0.90,  "cpu_seconds": 0.88,  "runs": 1}
    },
    "writes": {"strategy_store": 1, "strategy_passports": 2,
               "backtest_results": 1, "strategy_proposals": 4},
    "meta": {"pipeline": "debate", "candidates_considered": 4,
             "candidates_passing_rigor": 0, "outcome": "done"}
  }
}
```

## Anti-goals honoured

- **No estimates.** Every number here is read from a provider response, a clock, `getrusage`, or a write the pipeline performed. Where a figure cannot be isolated (process-wide CPU, high-water RSS), it carries an attribution label rather than being presented as cleaner than it is.
- **Only the happy path is not measured.** The snapshot is written on error and cancellation too, and `meta.candidates_passing_rigor` records which case the run was.
- **Generation behaviour is unchanged.** Nothing was made cheaper. The only control-flow edits are `with` wrappers and one hoist of `use_live and await asyncio.to_thread(_debate_can_run, brief)` into a named variable (short-circuit preserved).

## What #1217 still needs

Acceptance criteria this PR does **not** close, all of which need work outside this repo:

1. **`$/generation` at current ECS pricing, LLM and compute stated separately.** Deliberately not computed server-side — this PR's scope is raw counts and the quote seam stays `flat_v1`. Needs the Bedrock and Fargate rate cards applied to `llm.total_tokens` and `cpu_seconds` + task size.
2. **A measured run of each shape recorded.** Needs live runs against prod (single-candidate, multi-candidate, one that fails the gate). The procedure is in `docs/generation-cost-instrumentation.md`; the instrumentation has to be deployed first.
3. **Per-task CloudWatch `CpuUtilized` / `MemoryUtilized` correlation.** In-process figures are here; the billed task-level figures need an AWS read alongside a live run.
4. **Result recorded in the private docs repo's business-model doc.** By policy that material is not in this repo.

