### PR TITLE
Correct corpus retrieval claims on every public surface and guard them

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Foundry, Circle wallet, and oracle targets (`compile`, `test`, `wallet`, `feed`,
 - **Honest rigor gate** — every generated strategy runs four admission controls before it is deployable: Deflated Sharpe (dsr_p ≥ 0.90 at the badge level, HAC standard errors, library-size multiple-testing deflation), PBO (CSCV), positive OOS Sharpe with no in-sample/OOS cliff, and a static look-ahead AST audit. Most briefs honestly FAIL the gate — that is the product working. **What actually gates at the current library size:** the "Archimedes Verified" badge is enforced by DSR + OOS + the look-ahead audit (plus the always-on correctness floors). PBO is computed and disclosed on every passport but does **not** block the badge while the library has fewer than 10 graded strategies — below that N, CSCV lacks the statistical power to gate honestly (it reports `NOT_RUN` with the reason instead). It starts gating automatically once the library reaches N = 10. The 0.90 DSR bar is a deliberate calibration (PR #901): a one-sided ~10% test — evidence, not proof.
 - **Real multi-asset market data** — fusion backtests pull real daily OHLCV via yfinance, resolved through the Chainlink-only universe SSOT, strictly inner-joined across assets (missing data = fail-closed, never synthetic unless the real fetch fails).
 - **Automated backtest refresh** — `backtest_scheduler.py` checks staleness on startup and on a 24h cadence, refreshing any curated strategy that has no persisted backtest or whose latest run is older than 7 days. No operator ritual required.
-- **Paper corpus + MiniLM semantic retrieval** — a ~10,000-paper quant-finance corpus (file-sourced, embedded at ingest) backs `paper_rag.py`, which runs `all-MiniLM-L6-v2` semantic reranking as a second pass over the keyword-pre-filtered candidate set. Scoring is embedding cosine similarity (TF-IDF fallback when the model is unavailable). `FUSION_SEMANTIC_RETRIEVAL=true` default; `/health` reports `paper_rag: live | degraded | disabled`.
+- **Paper corpus + query-time rerank** — a 10,000-paper quant-finance corpus (arXiv metadata + abstracts, seeded from a JSONL manifest into Postgres) backs `paper_rag.py`, which reranks the keyword-pre-filtered candidate set against the brief. **Seeding writes metadata and abstracts, and stops there** — the `papers` schema carries no vector column and no KB artifact exists, so ranking is computed at request time over title + abstract: `all-MiniLM-L6-v2` sentence embeddings when that model loads in-process, lexical TF-IDF cosine otherwise. **Production serves the lexical path today** (verified against prod 2026-08-19: no embedding column, `corpus_meta` = 0 rows, `kg_entities`/`kg_relations` = 0/0). `FUSION_SEMANTIC_RETRIEVAL=true` default; `/health` reports the live state as `paper_rag: live | degraded | disabled` — read that field rather than this line, which is a snapshot. Tracked in [#778](https://github.com/a-apin/archimedes/issues/778).
 - **Canonical Better Auth accounts** — email/password login is always available; Google/GitHub appear only when configured. `/app/*` and generation require account session. Wallets are optional EIP-4361 proof-linked accounts used only for wallet/on-chain actions.
 - **Multi-wallet UX** with EIP-6963 wallet discovery — MetaMask, Coinbase, and Circle Modular Wallets passkey paths all working.
 - **Unified `strategy_passports` store on Postgres** — both curated and generated strategies live in one typed table; the Considered-Alternatives panel reads from `strategy_proposals` so visitors see what was rejected and why.
@@ -89,7 +89,8 @@ Debate society — the sole generation pipeline (T1.1 Phase-3)
   │
   ├─ Proposer pool: fans over regime × mechanism steer grid (up to 10 steers
   │   from 18 possible: 3 regimes × 6 mechanisms). Each proposer call:
-  │     • selects corpus candidates via keyword filter → MiniLM semantic rerank
+  │     • selects corpus candidates via keyword filter → query-time rerank
+  │       (MiniLM when the model is loaded; lexical TF-IDF in prod today)
   │     • StrategyFusion(model=…) proposes a DSL strategy spec
   │     • non-actionable or non-conformant specs are dropped immediately
   │
@@ -229,7 +230,7 @@ archimedes/
 | LLM               | Provider-agnostic (`LLM_*` env): GLM via z.ai, Anthropic, OpenAI, Ollama                  |
 | Backtesting       | [backtrader](https://github.com/mementum/backtrader) ([ADR](docs/adr/backtrader-backtest-engine.md)) |
 | Generation        | Multi-agent debate society (regime × mechanism steer grid, deterministic critics, K=1)    |
-| Semantic retrieval | `all-MiniLM-L6-v2` (sentence-transformers) — paper RAG reranker for corpus selection    |
+| Corpus retrieval  | Keyword filter → query-time rerank over title + abstract (`paper_rag.py`), scored per request with no vector index behind it: `all-MiniLM-L6-v2` when the model loads, lexical TF-IDF otherwise (prod today) |
 | Smart contracts   | Solidity targeting Arc (EVM-compatible) + [Foundry](https://book.getfoundry.sh/)          |
 | On-chain          | Circle SDK (Wallets, Gateway, CCTP) + viem on the UI side                                 |
 | Auth              | Better Auth accounts/sessions; EIP-4361 only for optional wallet linking                  |
@@ -278,8 +279,8 @@ audit our claims.
 ## Known Limitations (testnet)
 
 - **AMM liquidity:** Only the sTSLA/USDC pool has reserves ($3.97 USDC). The 4 remaining pools (sNVDA, sSPY, sBTC, sGOLD) are deployed but empty — the synthetic token mint authority (`0x0546…`) is a separate Foundry deployer wallet not accessible to the bootstrap script's Circle signer. The autonomous agent's liquidity guard honestly skips swaps into empty pools and logs the reason on-chain. This is the rigor system working as designed: capital is never exposed to doomed trades.
-- **Knowledge graph not yet built:** The corpus graph (`corpus_kg_built=false` in `/health`) is planned — citation-link extraction over the 10k-paper corpus is roadmap, not current. The semantic retrieval layer (MiniLM rerank) is live and does not depend on the KG.
-- **Corpus population in progress:** The ~10,000-paper seed target is the production goal; ingestion is incremental. Generation requires ≥ 2 papers for any given steer to pass the corpus viability precheck.
+- **Metadata only — no vector index, no knowledge graph:** The production corpus is title + abstract rows and nothing else. The `papers` schema carries no vector column, `corpus_meta` holds 0 rows, and `kg_entities`/`kg_relations` are 0/0 — the KB pipeline (SPECTER2 embeddings, HDBSCAN clusters, REBEL/SciSpacy triples) has never produced a production artifact. `/api/corpus/graph` therefore returns **503 with `kb_artifact_not_found`** rather than a synthesized graph, `/api/corpus/kg/*` returns **empty entity and relation sets**, and `/health` reports `corpus_kg_built=false`. Corpus retrieval in production is consequently **lexical** (TF-IDF cosine over title + abstract), not semantic. Tracked in [#778](https://github.com/a-apin/archimedes/issues/778).
+- **Corpus is seeded; full text is not:** All 10,000 manifest rows are in Postgres with title + abstract — which is the whole of what retrieval reads. Full-text (PDF body) hydration is incomplete, and is a prerequisite for the KB pipeline producing a real artifact ([#1091](https://github.com/a-apin/archimedes/issues/1091)). Generation requires ≥ 2 papers for any given steer to pass the corpus viability precheck.
 
 ## License
 

--- a/backend/tests/test_corpus_claim_integrity.py
+++ b/backend/tests/test_corpus_claim_integrity.py
@@ -31,6 +31,17 @@ to be conditional (artifacts present ⇒ 200) and to reject a synthesising route
 possible over-claim. Prose that describes the mechanism without asserting its state — "a
 semantic rerank with MiniLM sentence embeddings" — passes this guard and still needs a
 human read. The patterns are the floor, not the ceiling.
+
+**Point-in-time documents are deliberately NOT in ``PUBLIC_SURFACES``.** ``docs/audits/``,
+``docs/handovers/``, and ``docs/archive/`` are dated records of what was believed on a given
+day; a historical document that contains a claim later found false is not a defect, it is
+the evidence of how the error propagated. Scanning them would force a rewrite of history to
+make a test pass, which is the wrong repair. They are corrected by **annotation** instead —
+a dated claim-integrity banner at the top naming what was adjudicated false and pointing at
+the live authority, as done on ``docs/handovers/2026-07-14-architecture-review.md`` (whose
+corpus-panel and memory-layer-E bullets asserted a live stored-embedding layer) and on
+``docs/corpus-architecture.md``. If a point-in-time doc is ever rewritten into a live
+reference, it belongs in ``PUBLIC_SURFACES`` at that point and not before.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_corpus_claim_integrity.py
+++ b/backend/tests/test_corpus_claim_integrity.py
@@ -1,0 +1,358 @@
+"""Claim-integrity guards for the corpus surface (issue #778).
+
+Adjudicated against production on 2026-08-19: the ``papers`` table holds 10,000 rows
+with title + abstract, **no embedding column exists anywhere in the schema**,
+``corpus_meta`` is 0 rows, and ``kg_entities``/``kg_relations`` are 0/0. Retrieval is
+therefore lexical (TF-IDF cosine computed at request time over title + abstract), and no
+knowledge graph exists. ``paper_rag.py`` itself is honest — it reports a runtime tri-state
+(``live | degraded | disabled``) — but the prose around it had drifted into asserting
+embedded-at-ingest storage and live semantic retrieval as standing facts.
+
+Two guards, both hermetic (no network, no DB, no Redis, no ``.env``):
+
+1. **Prose guard** — the public surfaces listed in ``PUBLIC_SURFACES`` must not contain the
+   claim-shapes in ``OVERCLAIM_PATTERNS``: that the corpus is embedded, that retrieval is
+   semantically live, that a knowledge graph exists. The guard is negation-blind on purpose
+   (see ``find_overclaims``), so the way to describe the gap is to name what runs — the UI
+   now quotes ``/health``'s ``paper_rag`` field and lets it say which scorer is active.
+
+2. **Honest-endpoint guard** — with no KB artifact, ``GET /api/corpus/graph`` must fail with
+   a 503 naming ``kb_artifact_not_found`` rather than synthesising a graph, and
+   ``GET /api/corpus/kg/entities`` must return empty entity/relation sets (it does *not*
+   503 — overstating that would be the same defect pointing the other way). The README and
+   ``docs/architecture.md`` now assert both behaviours in prose, so both are pinned here
+   instead of trusted.
+
+Each guard carries its own anti-vacuity coverage: every prose pattern must reject a
+canonical example, every declared surface file must exist, and the 503 assertion is shown
+to be conditional (artifacts present ⇒ 200) and to reject a synthesising route.
+
+**Scope limit, stated plainly.** ``OVERCLAIM_PATTERNS`` catches claim *shapes*, not every
+possible over-claim. Prose that describes the mechanism without asserting its state — "a
+semantic rerank with MiniLM sentence embeddings" — passes this guard and still needs a
+human read. The patterns are the floor, not the ceiling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+# ---------------------------------------------------------------------------
+# Repo layout
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    import archimedes  # backend/archimedes/__init__.py → parents: archimedes, backend, <repo>
+
+    return Path(archimedes.__file__).resolve().parents[2]
+
+
+#: Public, reader-facing surfaces that describe corpus retrieval. A file listed here is
+#: scanned in full. Renaming one without updating this tuple is caught by
+#: ``test_every_declared_surface_exists`` — otherwise the scan would silently shrink to
+#: nothing and the guard would pass vacuously.
+PUBLIC_SURFACES: tuple[str, ...] = (
+    "README.md",
+    "docs/README.md",
+    "docs/architecture.md",
+    "docs/corpus-architecture.md",
+    "docs/specs/architecture-page-design.md",
+    "ui/src/components/Architecture.jsx",
+    "ui/src/components/CorpusGraph.jsx",
+    "ui/src/components/CorpusKG.jsx",
+)
+
+# ---------------------------------------------------------------------------
+# Prose guard
+# ---------------------------------------------------------------------------
+
+#: ``(name, regex, canonical_example)``. The example is the shortest string that must trip
+#: the pattern — ``test_every_pattern_rejects_its_canonical_example`` runs it, so a pattern
+#: that stops matching anything (a typo, an over-eager edit) fails loudly instead of
+#: silently guarding nothing.
+OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    (
+        "embed_at_ingest",
+        re.compile(r"\bembed(?:ded|ding)?[ \-]at[ \-]ingest\b", re.IGNORECASE),
+        "the corpus is embedded at ingest",
+    ),
+    (
+        "embeddings_are_live",
+        re.compile(r"\blive\s+(?:\w+\s+){0,2}embeddings\b|\bembeddings?\s+(?:are|is)\s+live\b", re.IGNORECASE),
+        "paper retrieval already uses live semantic embeddings (MiniLM)",
+    ),
+    (
+        "semantic_retrieval_is_live",
+        re.compile(
+            r"\bsemantic\s+(?:retrieval|rerank(?:ing)?|search)\b[^.\n;]{0,40}?\b(?:is|are)\s+live\b", re.IGNORECASE
+        ),
+        "the semantic retrieval layer (MiniLM rerank) is live",
+    ),
+    (
+        "minilm_rerank_is_live",
+        re.compile(r"\bMiniLM\b[^.\n;]{0,25}?\brerank(?:ing|er)?\s+(?:is\s+)?live\b", re.IGNORECASE),
+        "MiniLM rerank live; knowledge graph not built.",
+    ),
+    (
+        "corpus_holds_embeddings",
+        re.compile(
+            r"\bcorpus\b[^.\n;]{0,60}?\b(?:is\s+embedded\b|(?:has|have|holds?|contains?|carries|stores?)"
+            r"\s+(?:\w+\s+){0,3}embeddings\b)",
+            re.IGNORECASE,
+        ),
+        "the corpus stores SPECTER2 embeddings",
+    ),
+    (
+        "knowledge_graph_exists",
+        re.compile(
+            r"\bknowledge[ \-]graph\b[^.\n;]{0,40}?\b(?:is|has\s+been|was)\s+(?:built|live|populated)\b",
+            re.IGNORECASE,
+        ),
+        "the knowledge graph is built over the corpus",
+    ),
+    (
+        "semantic_search_over_the_corpus",
+        re.compile(
+            r"\b(?:semantic|vector|embedding|RAG)\b[ \-]?(?:\w+\s+){0,2}?\bover\s+(?:the\s+)?(?:10,?000|10k)\b",
+            re.IGNORECASE,
+        ),
+        "RAG over 10,000 papers",
+    ),
+)
+
+
+def find_overclaims(text: str) -> list[tuple[str, str]]:
+    """Return ``(pattern_name, matched_text)`` for every banned claim-shape in ``text``.
+
+    Deliberately **negation-blind**: "nothing is embedded at ingest" is rejected exactly
+    like "embedded at ingest". Two reasons. (1) A negation window is the wrong primitive
+    here — the pre-fix sentence *"The semantic retrieval layer (MiniLM rerank) is live and
+    does not depend on the KG"* carries a negator inside the same clause as the over-claim,
+    so any proximity or clause-scoped negation check silently waves it through, which is
+    precisely the drift this guard exists to stop. (2) A reader skimming a page keeps the
+    claim-shape, not the negation. Honest copy must therefore state what *is* true rather
+    than restate the false sentence in order to deny it.
+    """
+    hits: list[tuple[str, str]] = []
+    for name, pattern, _example in OVERCLAIM_PATTERNS:
+        hits.extend((name, match.group(0)) for match in pattern.finditer(text))
+    return hits
+
+
+def test_every_declared_surface_exists():
+    """A renamed/removed surface must fail loudly, not shrink the scan to nothing."""
+    missing = [rel for rel in PUBLIC_SURFACES if not (_repo_root() / rel).is_file()]
+    assert not missing, f"PUBLIC_SURFACES lists files that do not exist: {missing}"
+
+
+def test_every_pattern_rejects_its_canonical_example():
+    """No dead patterns: each one must still reject the claim it was written for."""
+    for name, _pattern, example in OVERCLAIM_PATTERNS:
+        hits = find_overclaims(example)
+        assert any(hit_name == name for hit_name, _ in hits), (
+            f"pattern {name!r} no longer rejects its canonical example {example!r} — "
+            f"it is guarding nothing (hits: {hits})"
+        )
+
+
+def test_guard_is_negation_blind_by_design():
+    """A denial of the claim is rejected too — see ``find_overclaims`` for why.
+
+    The load-bearing case is the second one: the pre-fix README limitation sentence pairs
+    the over-claim with a negator *inside the same clause*, so a negation-aware guard would
+    have permitted the exact prose this issue was filed about.
+    """
+    assert find_overclaims("Nothing is embedded at ingest."), "guard must reject the claim-shape even when denied"
+
+    denied_in_the_same_clause = "The semantic retrieval layer (MiniLM rerank) is live and does not depend on the KG."
+    names = {name for name, _ in find_overclaims(denied_in_the_same_clause)}
+    assert "semantic_retrieval_is_live" in names, f"a same-clause negator disarmed the guard (hits: {names})"
+
+    honest = "Candidates are ranked at request time over title and abstract; /health names the scorer."
+    assert find_overclaims(honest) == [], "honest, health-gated copy must not trip the guard"
+
+
+@pytest.mark.parametrize("rel_path", PUBLIC_SURFACES)
+def test_public_surface_carries_no_corpus_overclaim(rel_path: str):
+    text = (_repo_root() / rel_path).read_text(encoding="utf-8")
+    hits = find_overclaims(text)
+    assert not hits, (
+        f"{rel_path} asserts corpus capability that production does not have (#778): {hits}. "
+        "Prod retrieval is lexical, the papers schema carries text only, and the KB pipeline "
+        "has produced no artifact — name what /health.paper_rag reports instead of asserting "
+        "a capability. Note the guard is negation-blind: denying the claim still trips it."
+    )
+
+
+# --- Adversarial demonstrations: the exact prose this PR removed must be rejected ------
+#
+# Verbatim pre-fix text. Each of these lived on a public surface and each must trip the
+# guard, otherwise the guard would have permitted the very drift it was written to stop.
+
+PRE_FIX_README_STATUS_LINE = (
+    "- **Paper corpus + MiniLM semantic retrieval** — a ~10,000-paper quant-finance corpus "
+    "(file-sourced, embedded at ingest) backs `paper_rag.py`, which runs `all-MiniLM-L6-v2` "
+    "semantic reranking as a second pass over the keyword-pre-filtered candidate set."
+)
+
+PRE_FIX_README_LIMITATION_LINE = (
+    "- **Knowledge graph not yet built:** The corpus graph (`corpus_kg_built=false` in `/health`) "
+    "is planned — citation-link extraction over the 10k-paper corpus is roadmap, not current. "
+    "The semantic retrieval layer (MiniLM rerank) is live and does not depend on the KG."
+)
+
+PRE_FIX_ARCHITECTURE_DOC_LINE = (
+    "2. **Embed at ingest**: title+abstract embeddings are the query-time lookup key "
+    "([`docs/corpus-architecture.md`](corpus-architecture.md))."
+)
+
+PRE_FIX_DOCS_INDEX_CELL = "10,000 arXiv preprints (not peer-reviewed). MiniLM rerank live; knowledge graph not built."
+
+PRE_FIX_CORPUS_GRAPH_UI_STRING = (
+    "Knowledge-graph pipeline hasn't run yet (SPECTER2 clustering + entity extraction) — paper "
+    "retrieval already uses live semantic embeddings (MiniLM); this similarity graph will populate "
+    "once the KB pipeline produces its first artifact."
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "prose", "expected_pattern"),
+    [
+        ("README § Status", PRE_FIX_README_STATUS_LINE, "embed_at_ingest"),
+        ("README § Known Limitations", PRE_FIX_README_LIMITATION_LINE, "semantic_retrieval_is_live"),
+        ("docs/architecture.md § corpus flow", PRE_FIX_ARCHITECTURE_DOC_LINE, "embed_at_ingest"),
+        ("docs/README.md doc index", PRE_FIX_DOCS_INDEX_CELL, "minilm_rerank_is_live"),
+        ("CorpusGraph.jsx empty state", PRE_FIX_CORPUS_GRAPH_UI_STRING, "embeddings_are_live"),
+    ],
+)
+def test_guard_rejects_the_prose_it_replaced(label: str, prose: str, expected_pattern: str):
+    hits = find_overclaims(prose)
+    names = {name for name, _ in hits}
+    assert expected_pattern in names, f"{label}: guard failed to reject the pre-fix prose (hits: {hits})"
+
+
+# ---------------------------------------------------------------------------
+# Honest-503 guard
+# ---------------------------------------------------------------------------
+
+
+def _assert_503_on_missing_artifact(route) -> None:
+    """The guard body: ``route`` must refuse with a structured 503, not invent a graph."""
+    try:
+        result = asyncio.run(route())
+    except HTTPException as exc:
+        assert exc.status_code == 503, f"expected 503, got {exc.status_code}"
+        assert isinstance(exc.detail, dict), f"503 detail should be structured, got {exc.detail!r}"
+        assert exc.detail.get("error") == "kb_artifact_not_found", f"unexpected 503 detail: {exc.detail!r}"
+        return
+    raise AssertionError(f"route returned a graph instead of 503 with no artifact present: {result!r}")
+
+
+def _patch_artifacts_absent(monkeypatch) -> None:
+    from archimedes.services import kb_artifacts
+
+    def _raise_missing():
+        raise kb_artifacts.ArtifactNotFound("embeddings.npy")
+
+    monkeypatch.setattr(kb_artifacts, "load_umap_projection", lambda: None)
+    monkeypatch.setattr(kb_artifacts, "load_embeddings", _raise_missing)
+
+
+def test_corpus_graph_503s_when_no_kb_artifact_exists(monkeypatch):
+    """No artifact ⇒ an explicit 503, never a synthesised graph.
+
+    Mocked at the artifact-store boundary (``kb_artifacts``), which is the seam that talks
+    to S3 / the mounted volume — the route's own logic runs for real.
+    """
+    from archimedes.api.corpus_routes import corpus_graph
+
+    _patch_artifacts_absent(monkeypatch)
+    _assert_503_on_missing_artifact(corpus_graph)
+
+
+def test_the_503_guard_rejects_a_graph_synthesised_from_nothing(monkeypatch):
+    """Adversarial: hand the guard the implementation it exists to catch.
+
+    A route that quietly fabricates points when the artifact is missing is the exact defect
+    ("no fake fallbacks", ``kb_artifacts`` module docstring) — it must fail the assertion
+    above, otherwise that assertion is decoration.
+    """
+    _patch_artifacts_absent(monkeypatch)
+
+    async def synthesising_graph() -> dict:
+        points = [{"arxiv_id": "0000.00000", "x": 0.0, "y": 0.0, "cluster_id": 1}]
+        return {"points": points, "topics": {}, "cluster_count": 1, "point_count": len(points)}
+
+    with pytest.raises(AssertionError, match="returned a graph instead of 503"):
+        _assert_503_on_missing_artifact(synthesising_graph)
+
+
+def test_corpus_graph_503_is_conditional_not_unconditional(monkeypatch):
+    """Anti-vacuity: with an artifact present the same route returns 200 with its points.
+
+    Without this, the assertion above would also pass against a route hard-wired to 503,
+    which would prove nothing about artifact detection.
+    """
+    from archimedes.api.corpus_routes import corpus_graph
+    from archimedes.services import kb_artifacts
+
+    points = [{"arxiv_id": "2501.00001", "x": 0.1, "y": 0.2, "cluster_id": 3}]
+    monkeypatch.setattr(kb_artifacts, "load_umap_projection", lambda: points)
+    monkeypatch.setattr(kb_artifacts, "load_topics", lambda: {"3": "momentum"})
+
+    result = asyncio.run(corpus_graph())
+
+    assert result["point_count"] == 1
+    assert result["points"] == points
+    assert result["cluster_count"] == 1
+
+
+def test_kg_search_returns_empty_sets_not_synthesised_entities(monkeypatch):
+    """The other half of the endpoint claim the README now makes.
+
+    ``/api/corpus/kg/*`` does **not** 503 on an un-built graph — it returns empty entity and
+    relation sets. Stating "503" for these routes would be the same defect in the opposite
+    direction, so the honest wording is pinned here. Mocked at the DB-session boundary with
+    an in-memory SQLite carrying the real KG tables and no rows (the prod shape: 0/0).
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from archimedes import db as db_module
+    from archimedes.api.corpus_routes import kg_search_entities
+    from archimedes.models.chat import Base
+    from archimedes.models.kg import KGEntity, KGRelation  # noqa: F401 — KGRelation registers its table on Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    class _CtxSession:
+        def __enter__(self):
+            return session
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(db_module, "get_session", lambda: _CtxSession())
+    try:
+        empty = asyncio.run(kg_search_entities(q="momentum"))
+
+        # Anti-vacuity: the route swallows SQLAlchemy errors into the *same* empty shape, so
+        # an empty result alone would also be produced by a query that never ran. Seed one
+        # row and confirm it comes back — that proves the query path is live and the 0/0
+        # answer above is the data speaking, not an exception.
+        session.add(KGEntity(canonical_name="momentum factor", entity_type="method", paper_count=7))
+        session.commit()
+        populated = asyncio.run(kg_search_entities(q="momentum"))
+    finally:
+        session.close()
+
+    assert empty == {"query": "momentum", "entities": [], "relations": []}
+    assert [e["canonical_name"] for e in populated["entities"]] == ["momentum factor"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 
 | Doc | Status | Owner | Last verified | What it is |
 |---|---|---|---|---|
-| [`corpus-architecture.md`](corpus-architecture.md) | current | Dan Browne | 2026-07-28 | 10,000 arXiv preprints (not peer-reviewed). MiniLM rerank live; knowledge graph not built. |
+| [`corpus-architecture.md`](corpus-architecture.md) | target-state | Dan Browne | 2026-08-19 | 10,000 arXiv preprints (not peer-reviewed), metadata + abstracts only. Describes embeddings/clusters/KG as built; in prod none of the three exist — retrieval is lexical and the graph/KG endpoints 503 (#778). |
 | [`specs/multi-agent-debate-spec.md`](specs/multi-agent-debate-spec.md) | shipped | Dan Browne | 2026-07-28 | The debate society — the sole generation pipeline. |
 | [`specs/strategy-fusion-spec.md`](specs/strategy-fusion-spec.md) | shipped | Dan Browne | 2026-07-28 | Multi-paper synthesis feeding the debate proposals. |
 | [`specs/strategy-passport-spec.md`](specs/strategy-passport-spec.md) | shipped | Dan Browne | — | Paper-grounding contract carried by every strategy. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ the machine-readable claim-integrity surface the new page should read from.
 | Concern | Path | Role |
 |---|---|---|
 | LLM seam | [`services/llm_backend.py`](../backend/archimedes/services/llm_backend.py) | Multi-provider **Converse** backend: AWS Bedrock **Amazon Nova Micro** default; BYOK; local-Ollama single-user path. `response.model` is provenance-of-record |
-| Corpus retrieval | [`services/paper_rag.py`](../backend/archimedes/services/paper_rag.py) | Stage-2 **MiniLM** (`all-MiniLM-L6-v2`) semantic rerank over the keyword-filtered candidates; 150-candidate cap, bounded embedding cache, `torch.set_num_threads(1)` (the #885 outage guardrails); TF-IDF fallback reported as `paper_rag: degraded` |
+| Corpus retrieval | [`services/paper_rag.py`](../backend/archimedes/services/paper_rag.py) | Stage-2 **query-time** rerank over the keyword-filtered candidates — nothing is read from a stored embedding index (none exists). `all-MiniLM-L6-v2` when the model loads in-process (`paper_rag: live`), lexical TF-IDF cosine otherwise (`paper_rag: degraded` — the prod state, #778). 150-candidate cap, bounded embedding cache, `torch.set_num_threads(1)` (the #885 outage guardrails) |
 | Corpus ingest | [`services/corpus_service.py`](../backend/archimedes/services/corpus_service.py), [`services/arxiv_corpus.py`](../backend/archimedes/services/arxiv_corpus.py), [`services/arxiv_pipeline.py`](../backend/archimedes/services/arxiv_pipeline.py) | 10,000-paper JSONL manifest seed into Postgres |
 | KB pipeline | [`services/kb_runner.py`](../backend/archimedes/services/kb_runner.py), [`services/kb_artifacts.py`](../backend/archimedes/services/kb_artifacts.py) | Scheduled runner triggering SPECTER2 embeddings / HDBSCAN clusters / REBEL+SciSpacy KG builds (the "KB pipeline"); artifacts served by `corpus_routes` |
 | Rigor gate | [`services/live_rigor_gate.py`](../backend/archimedes/services/live_rigor_gate.py) | **Single source of truth** for `passes_rigor_gate`: tri-state pass/fail/**pending**, computed live from persisted real returns — never a cached boolean (issue #821, the #1 rule) |
@@ -197,7 +197,7 @@ Runbook: [`infra/runbooks/ecs-fargate-cutover.md`](../infra/runbooks/ecs-fargate
 
 1. **Auth**: Better Auth account session (email/password or OAuth) → canonical user id; a wallet may be LINKED later via a single-use EIP-4361 proof ([`api/wallet_routes.py`](../backend/archimedes/api/wallet_routes.py)) but never logs in. Passkey users get a Circle smart account ([`ui/src/circle-wallet.js`](../ui/src/circle-wallet.js)); headless agents use the same endpoints ([`docs/agent-api.md`](agent-api.md), [`scripts/agent_journey.py`](../scripts/agent_journey.py)).
 2. **Brief** → `POST /api/generate` ([`api/generate_routes.py`](../backend/archimedes/api/generate_routes.py)) → SSE job ([`agents/generation_pipeline.py`](../backend/archimedes/agents/generation_pipeline.py)), events persisted per-job in Redis.
-3. **Retrieval**: keyword/asset-class pre-filter (`agents/strategy_fusion.py::select_candidates`) → MiniLM cosine rerank ([`services/paper_rag.py`](../backend/archimedes/services/paper_rag.py)) → top-N papers, embargo-filtered ([`services/embargo_filter.py`](../backend/archimedes/services/embargo_filter.py)) and age-decayed ([`services/time_aware_retrieval.py`](../backend/archimedes/services/time_aware_retrieval.py)). **Precheck: ≥2 corpus papers or `GENERATION_UNAVAILABLE`** — prod corpus hydration is the honest gap (issue #778).
+3. **Retrieval**: keyword/asset-class pre-filter (`agents/strategy_fusion.py::select_candidates`) → query-time cosine rerank ([`services/paper_rag.py`](../backend/archimedes/services/paper_rag.py); MiniLM when the model loads, lexical TF-IDF in prod today) → top-N papers, embargo-filtered ([`services/embargo_filter.py`](../backend/archimedes/services/embargo_filter.py)) and age-decayed ([`services/time_aware_retrieval.py`](../backend/archimedes/services/time_aware_retrieval.py)). **Precheck: ≥2 corpus papers or `GENERATION_UNAVAILABLE`** — the absence of stored embeddings and of any KB artifact is the honest gap (issue #778).
 4. **Debate society** ([`agents/debate_engine.py`](../backend/archimedes/agents/debate_engine.py)): proposer pool fans LLM fusion calls (model = user's cost-picker choice via [`services/llm_backend.py`](../backend/archimedes/services/llm_backend.py)) across regime-biased evidence sets → dedup by canonical spec hash → adversarial bull/bear transcript (surface, non-gating) → **C-rigor** deterministic backtest of every survivor → **C-null** vs buy-and-hold → **K=1 winner + considered-rejects**, or first-class ABSTAIN.
 5. **Persist + hash**: winner and rejects content-hashed into `strategy_proposals` ([`models/strategy_proposal.py`](../backend/archimedes/models/strategy_proposal.py)); trace hashed; strategy record created ([`models/strategy_store.py`](../backend/archimedes/models/strategy_store.py)).
 6. **External rigor gate**: the badge the user sees is computed live from persisted real returns ([`services/live_rigor_gate.py`](../backend/archimedes/services/live_rigor_gate.py) — tri-state pass/fail/pending) and served by [`api/selection_bias_routes.py`](../backend/archimedes/api/selection_bias_routes.py); the Deploy button gates on it. The gate runs **outside** the generator (architectural primitive 5, `CLAUDE.md:1015`).
@@ -228,10 +228,10 @@ Runbook: [`infra/runbooks/ecs-fargate-cutover.md`](../infra/runbooks/ecs-fargate
 ## 5. Flow — Corpus (papers → retrievable knowledge)
 
 1. **Seed**: 10,000-paper JSONL manifest → Postgres (`services/corpus_service.py::seed_from_manifest`, boot-time in `main.py:139`).
-2. **Embed at ingest**: title+abstract embeddings are the query-time lookup key ([`docs/corpus-architecture.md`](corpus-architecture.md)).
-3. **KB pipeline** ([`services/kb_runner.py`](../backend/archimedes/services/kb_runner.py), own compose service / scheduled-Fargate target (PR #1071, merged; apply pending)): SPECTER2 embeddings, HDBSCAN clusters, REBEL+SciSpacy knowledge graph → artifacts → [`api/corpus_routes.py`](../backend/archimedes/api/corpus_routes.py) (503 until real artifacts exist; `corpus_kg_built` flag in `/health`).
-4. **Retrieval at generate time**: keyword filter → MiniLM rerank (§2.3).
-5. **Honest state**: prod corpus is **sparsely hydrated** — the 10k number is manifest-scale, not fully-ingested-paper count (issue #778). Build decision: **HYBRID** — custom KB spine (Postgres + MiniLM, live now) + optional Bedrock-KB retrieval bridge; Neptune ruled out; a MiniLM-only no-AWS local option exists.
+2. **Seed writes text, and stops there**: metadata + abstracts land in Postgres; the `papers` schema carries no vector column, so there is nothing stored for a query to look up. Ranking is computed per request instead (§2.3). The ingest-time vectorisation described in [`docs/corpus-architecture.md`](corpus-architecture.md) is the target design, not the deployed one.
+3. **KB pipeline** ([`services/kb_runner.py`](../backend/archimedes/services/kb_runner.py), own compose service / scheduled-Fargate target (PR #1071, merged; apply pending)): SPECTER2 embeddings, HDBSCAN clusters, REBEL+SciSpacy knowledge graph → artifacts → [`api/corpus_routes.py`](../backend/archimedes/api/corpus_routes.py). With no artifact, `/graph` raises **503 `kb_artifact_not_found`** and `/kg/*` returns **empty entity/relation sets** — neither synthesises from arXiv metadata (#201). `corpus_kg_built` flag in `/health`; both behaviours pinned by `backend/tests/test_corpus_claim_integrity.py`.
+4. **Retrieval at generate time**: keyword filter → query-time rerank (§2.3).
+5. **Honest state** (verified against prod 2026-08-19): all 10,000 rows are present with title + abstract, but there are **no embeddings** (no embedding column anywhere in the schema), `corpus_meta` = 0 rows, and `kg_entities`/`kg_relations` = 0/0 — so retrieval is **lexical**, and the KG/graph endpoints 503. What is missing is the artifact layer, not the papers (issue #778). Build decision: **HYBRID** — custom KB spine (Postgres + MiniLM) + optional Bedrock-KB retrieval bridge; Neptune ruled out; a MiniLM-only no-AWS local option exists.
 
 ## 6. Flow — Identity / accounts + linked wallets
 
@@ -291,7 +291,7 @@ kb → scheduled Fargate task; EFS for corpus artifacts.
 6. **[`docs/specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md)** — `StrategyRegistry → AssetRegistry` replacement; in code both coexist intentionally (noted in `CLAUDE.md:404-406`).
 7. **`.env.example`** — `LLM_PROVIDER=anthropic_compatible` default vs live `bedrock_converse` (tracked as roadmap T3.10).
 8. **[`agents/strategy_fusion.py`](../backend/archimedes/agents/strategy_fusion.py) module docstring** — still describes fusion as "feature-flagged beside strategy_architect, default OFF" and GLM-backed; fusion proposals are now the heart of the sole (debate) pipeline and the architect was deleted (PR #1074, merged 2026-07-14). Docstring predates the pivot.
-9. **[`docs/corpus-architecture.md`](corpus-architecture.md)** — Day-9 fusion-path framing; retrieval reality is keyword → MiniLM ([`services/paper_rag.py`](../backend/archimedes/services/paper_rag.py)) with the KB pipeline as the artifact layer.
+9. **[`docs/corpus-architecture.md`](corpus-architecture.md)** — Day-9 fusion-path framing, and it describes embeddings/clusters/KG as if built; retrieval reality is keyword → query-time rerank ([`services/paper_rag.py`](../backend/archimedes/services/paper_rag.py), lexical in prod) with the KB pipeline as an artifact layer that has not yet run (#778).
 10. **[`ui/src/components/Architecture.jsx`](../ui/src/components/Architecture.jsx)** — the page being replaced; full staleness list in §10 and [`docs/handovers/2026-07-14-architecture-review.md`](handovers/2026-07-14-architecture-review.md).
 
 ## 10. What the pre-#1192 Architecture page got wrong (headline items)
@@ -305,7 +305,14 @@ Itemized with evidence in [`docs/handovers/2026-07-14-architecture-review.md`](h
 model (now: debate society + external rigor gate), "10 smart contracts" (now 12 Solidity
 sources compiling into 570 live protocol instances on the fresh chain-5042002
 deploy, per §1.7 and `GET /api/config/contracts`), "keyword/TF-IDF today"
-(MiniLM rerank is live), "60s tick" (default 300 s), "4 wallet signatures" (2+3 client-signed
+(see the note below — that entry was over-corrected), "60s tick" (default 300 s), "4 wallet signatures" (2+3 client-signed
 steps), publish-after trace anchoring (now commit-before-trade, contract-enforced), no
 marketplace/x402, no SIWE/agent-native story, no leaderboard, and stat-card numbers hardcoded
 in JSX where live endpoints exist (`/health`, `/api/config/contracts`, `/api/explore/assets`).
+
+One item on that staleness list was corrected in the *wrong direction*. The "keyword/TF-IDF
+today" entry was rewritten to present MiniLM reranking as a standing property of the corpus,
+on the strength of `/health`'s `corpus_embedded` field. That field describes the process, not
+the corpus: it is `paper_rag == "live"`, i.e. whether sentence-transformers loaded in *this*
+worker. The stored corpus is text either way, and prod serves the lexical path. #778 carries
+the correction; `backend/tests/test_corpus_claim_integrity.py` pins it.

--- a/docs/corpus-architecture.md
+++ b/docs/corpus-architecture.md
@@ -10,6 +10,16 @@
 > #95 (engine v2), #97 (10k corpus), #105 + #108 (rigor wedge), #106 (DB-backed
 > corpus), and #93 (Corpus Explorer UI).
 
+> **Claim-integrity note (verified against production 2026-08-19, issue #778).** Layer 1
+> is real: 10,000 rows with title + abstract are in Postgres. Layers 2 and 3 are **not**:
+> there is no embedding column anywhere in the schema, `corpus_meta` holds 0 rows, and
+> `kg_entities`/`kg_relations` are 0/0. Where this document describes embeddings, clusters,
+> or a knowledge graph as part of the substrate, read that as the **target design**, not the
+> deployed state — the "Scaffolded but not running yet" section below is the accurate part.
+> Retrieval in production ranks candidates at request time over title + abstract, using the
+> lexical TF-IDF path; `/health`'s `paper_rag` field is the authority on which scorer is
+> running in any given process.
+
 ## The substrate (3 layers)
 
 ```

--- a/docs/handovers/2026-07-14-architecture-review.md
+++ b/docs/handovers/2026-07-14-architecture-review.md
@@ -16,6 +16,24 @@
 > [`../specs/architecture-page-design.md`](../specs/architecture-page-design.md) (the
 > design, now implemented) and [`../architecture.md`](../architecture.md) (the system map).
 
+> **Claim-integrity note (added 2026-08-20, issue #778).** Two corpus-retrieval claims in
+> the *"What's stale on the current page"* list below — the corpus-panel bullet and the
+> memory-pillar-layer-E bullet — were **adjudicated false on #778** and are corrected here
+> rather than in place. Verified against production 2026-08-19: **no embedding column
+> exists anywhere in the schema**, `corpus_meta` holds 0 rows, and
+> `kg_entities`/`kg_relations` are 0/0. Corpus retrieval ranks candidates at request time
+> over title + abstract via the lexical TF-IDF path. The two bullets asserted the opposite —
+> that the page's "keyword/TF-IDF today" copy was the stale claim and that a stored
+> sentence-embedding layer was the live one — which inverted the truth and became one
+> upstream of the over-claims #778 was filed about.
+>
+> **The body below is left as written, on purpose.** This is a dated point-in-time record of
+> what was believed on 2026-07-14; rewriting its findings would destroy the evidence of how
+> the misreading propagated. Read those two bullets as superseded, not as current state.
+> `/health`'s `paper_rag` field is the authority on which scorer is running in any given
+> process, and [`../corpus-architecture.md`](../corpus-architecture.md) carries the same
+> note over the target-design description of the substrate.
+
 ## What was produced (this directory)
 
 | File | What it is |

--- a/docs/specs/architecture-page-design.md
+++ b/docs/specs/architecture-page-design.md
@@ -225,8 +225,11 @@ unaffected — they are non-custodial today.
 
 **Body:** Generation starts from a corpus of quantitative-finance research — a 10,000-paper
 manifest spanning statistical finance, portfolio math, market microstructure, and agentic AI.
-At generate time, retrieval runs in two stages: a keyword/asset-class filter, then a semantic
-rerank with MiniLM sentence embeddings against your brief. Retrieved papers are
+At generate time, retrieval runs in two stages: a keyword/asset-class filter, then a relevance
+rerank against your brief, computed at request time over each candidate's title and abstract,
+with no vector index behind it. `/health`'s `paper_rag` field says which scorer is running:
+`live` means MiniLM sentence embeddings, `degraded` means the lexical TF-IDF fallback (the
+production state today). Retrieved papers are
 embargo-filtered — nothing published after a decision point can inform it — and every citation
 carries its arXiv ID and content hash.
 
@@ -265,8 +268,9 @@ current state, kept current from the system's own health surface:
 | Commit → trade → reveal provenance | **Live** — contract-enforced ordering |
 | Autonomous rebalance loop | **Live path** — runs on a schedule; infrastructure relocation in progress *(driven by health flag)* |
 | Marketplace publish / subscribe | **Live, settlement in dry-run** — real x402 pipeline, simulated final settlement |
-| Corpus retrieval | **Live** — keyword + MiniLM; hydration in progress *(live count)* |
-| Knowledge graph | **Not yet** — pipeline built, first artifact pending |
+| Corpus retrieval | **Live** — keyword + query-time rerank; scorer named from `/health.paper_rag` (`live` = MiniLM, `degraded` = lexical TF-IDF) *(live value)* |
+| Stored embeddings | **Not yet** — no embedding column; ranking is computed per request |
+| Knowledge graph | **Not yet** — pipeline built, first artifact pending; graph/KG endpoints 503 |
 | Mainnet, real funds | **Roadmap** — Arc mainnet is upcoming; settlement architecture is an explicit deferred decision |
 
 **Close:** If a row here ever disagrees with what you see in the product, that's a bug —

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -859,9 +859,14 @@ function MarketplaceSection() {
 }
 
 // ── §9 — The research corpus ───────────────────────────────────────────
-// Corrects the stale keyword/TF-IDF claim: MiniLM semantic retrieval IS
-// live (/health: paper_rag "live", corpus_embedded true). The honest gap is
-// the knowledge graph, which has not been built (corpus_kg_built false).
+// Every retrieval claim on this panel is driven off /health, never asserted
+// statically — see #778. Two things this panel must NOT imply. (1) That a
+// vector index sits behind the corpus: the papers schema carries text only,
+// and /health's corpus_embedded reports something narrower than its name
+// suggests — whether the MiniLM model loaded in *this* worker process.
+// (2) That a knowledge graph exists: corpus_kg_built is false and the
+// graph/KG endpoints 503. backend/tests/test_corpus_claim_integrity.py
+// scans this file for both claim-shapes.
 
 function CorpusSection({ health, healthError }) {
 	const loading = !health && !healthError;
@@ -885,11 +890,12 @@ function CorpusSection({ health, healthError }) {
 					{fmtNum(health.corpus_papers)}-paper arXiv manifest spanning
 					statistical finance, portfolio math, market microstructure, and
 					agentic AI. At generate time, retrieval runs in two stages: a
-					keyword/asset-class filter, then a semantic rerank with MiniLM
-					sentence embeddings against your brief (
+					keyword/asset-class filter, then a relevance rerank against your brief,
+					scored at request time over each candidate's title and abstract, with no
+					vector index behind it (
 					{health.paper_rag === "live"
-						? "semantic retrieval is live today"
-						: "semantic retrieval is currently degraded to a keyword-only fallback"}
+						? "/health reports paper_rag: live — the rerank is running MiniLM sentence embeddings right now"
+						: "/health reports paper_rag: degraded — the rerank is running the lexical TF-IDF fallback right now"}
 					). Retrieved papers are embargo-filtered — nothing published after a
 					decision point can inform it — and every citation carries its arXiv ID
 					and content hash.
@@ -928,8 +934,8 @@ function CorpusSection({ health, healthError }) {
 }
 
 // ── §10 — Reasoning protocols (Xia et al.) ─────────────────────────────
-// Kept panel shape; reworded the retrieval-mechanism line (MiniLM is the
-// live mechanism, not a "build target" caveat).
+// Kept panel shape. The retrieval-mechanism line must name the scorer from
+// /health.paper_rag rather than asserting one (#778).
 const PROTOCOLS = [
 	{
 		name: "Outcome Embargo",
@@ -1066,13 +1072,14 @@ function HonestyLedger({ health, healthError }) {
 								) : health.paper_rag === "live" ? (
 									<>
 										<LedgerStatus tone="live">Live</LedgerStatus> — keyword +
-										MiniLM; {fmtNum(health.corpus_db_count)} of{" "}
+										MiniLM rerank, scored per request;{" "}
+										{fmtNum(health.corpus_db_count)} of{" "}
 										{fmtNum(health.corpus_papers)} papers hydrated
 									</>
 								) : (
 									<>
 										<LedgerStatus tone="pending">Degraded</LedgerStatus> —
-										keyword-only fallback active
+										lexical TF-IDF fallback active
 									</>
 								)}
 							</td>

--- a/ui/src/components/CorpusGraph.jsx
+++ b/ui/src/components/CorpusGraph.jsx
@@ -187,7 +187,7 @@ export default function CorpusGraph() {
       <div className="corpus-graph-error" style={{ padding: 24 }}>
         <div className="info-box warning">
           {error.includes('503') || error.includes('KB pipeline')
-            ? "Knowledge-graph pipeline hasn't run yet (SPECTER2 clustering + entity extraction) — paper retrieval already uses live semantic embeddings (MiniLM); this similarity graph will populate once the KB pipeline produces its first artifact."
+            ? "Knowledge-graph pipeline hasn't run yet (SPECTER2 clustering + entity extraction), so there are no stored embeddings to project — this similarity graph will populate once the KB pipeline produces its first artifact. Paper retrieval does not depend on it: candidates are ranked at request time over title + abstract (see /health's paper_rag field for the scorer in use)."
             : `Graph unavailable: ${error}`}
         </div>
       </div>


### PR DESCRIPTION
## Summary

The public surfaces described the corpus as embedded at ingest and semantic retrieval as live. Verified against production on 2026-08-19, neither is true: the `papers` table holds 10,000 rows with title + abstract, **no embedding column exists anywhere in the schema**, `corpus_meta` is 0 rows, and `kg_entities`/`kg_relations` are 0/0. Corpus retrieval is lexical — TF-IDF cosine computed at request time over title + abstract.

This PR corrects the prose everywhere that asserted otherwise, and adds a hermetic guard so the drift cannot recur silently.

**Two treatments, because two kinds of document are involved.** "Every public surface" is not one operation:

- **Live documents** — `README.md`, `docs/architecture.md`, `docs/README.md`, `docs/specs/architecture-page-design.md`, and the two UI components — describe how the system works *today*, so the false claims are **rewritten out** of them. These are the eight files the new guard scans in full.
- **Point-in-time documents** — dated records of what was believed on a given day — are **annotated, not rewritten**. A historical document that contains a claim later found false is not a defect; it is the evidence of how the error propagated, and editing it away would destroy that. Each gets a dated claim-integrity banner naming what was adjudicated false and pointing at `/health.paper_rag` as the live authority. This treatment is applied to `docs/corpus-architecture.md` and to `docs/handovers/2026-07-14-architecture-review.md`.

Consequently `docs/audits/`, `docs/handovers/`, and `docs/archive/` are deliberately **absent** from the guard's `PUBLIC_SURFACES` — scanning them would force rewriting history to make a test pass. The guard's module docstring states that exclusion and its reason, so the omission reads as a decision rather than an oversight.

**No production code changed.** `backend/archimedes/services/paper_rag.py` was already honest: it reports a runtime tri-state (`live | degraded | disabled`) and never claims a stored index. The defect was entirely in the prose wrapped around it. The confusion has a specific root: `/health`'s `corpus_embedded` field is defined as `paper_rag_status == "live"` (`backend/archimedes/main.py:668`) — it reports whether sentence-transformers loaded in *this worker process*, not anything about what the corpus stores. Reading it as a statement about the corpus is what produced the over-claim.

Refs #778

**Refs, not Closes — reasoning.** #778's own acceptance criteria are two: *"honest surface verified"* and *"build path decided + scoped into follow-up issues"*, and its Part B checklist ("stand up S3 corpus/artifact buckets … wire the honest endpoints to real output") is unchecked with the RAG/KG build named in the issue title. This PR delivers Part A only; the build half is real, open work tracked in #1090 / #1091 / #1092 / #1093 (all currently open), so letting this merge auto-close #778 would mark those Part-B boxes done by side effect. The issue's owner can close it deliberately once Part B lands or is formally re-scoped — that call belongs to a human, not to a merge.

## What changed, file by file

**`README.md`**
- § Status bullet — was "Paper corpus + MiniLM semantic retrieval … (file-sourced, embedded at ingest) … Scoring is embedding cosine similarity". Now names the seed contents (metadata + abstracts), states that the schema carries no vector column, describes ranking as computed at request time, records the prod state as the lexical path with the verification date, and points the reader at `/health.paper_rag` as the live authority rather than the line itself.
- Generation flow diagram — `keyword filter → MiniLM semantic rerank` became `keyword filter → query-time rerank (MiniLM when the model is loaded; lexical TF-IDF in prod today)`.
- Tech-stack table — the `Semantic retrieval` row is now `Corpus retrieval`, describing the two-stage mechanism and both scorers.
- § Known Limitations — the "Knowledge graph not yet built" bullet ended with "The semantic retrieval layer (MiniLM rerank) is live", which is the claim this issue disputes. Replaced with a bullet naming all four measured facts (no vector column, `corpus_meta` = 0, KG 0/0, no KB artifact) and the endpoint behaviour that follows. The adjacent "Corpus population in progress" bullet understated the opposite way — it implied ingestion was partial; all 10,000 rows are present with abstracts, and the incomplete part is full-text (PDF body) hydration, which is what the KB pipeline needs (#1091).

**`docs/architecture.md`**
- §2.3 component table, corpus-retrieval row — reframed from "Stage-2 MiniLM semantic rerank … TF-IDF fallback" to a query-time rerank with no stored index behind it, naming which scorer maps to which `paper_rag` state and which one prod serves.
- §5 flow step 3 — "MiniLM cosine rerank" → query-time rerank naming both scorers; the honest-gap sentence now points at the missing artifact layer rather than at row count.
- §5 corpus flow step 2 — was **"Embed at ingest: title+abstract embeddings are the query-time lookup key."** This was the origin of the README claim and is simply false; there is no such column. Replaced with what seeding actually writes, and marked the ingest-time vectorisation in `corpus-architecture.md` as target design.
- §5 step 3 — endpoint behaviour made precise (see the correction note below).
- §5 step 5 "Honest state" — said the prod corpus is "sparsely hydrated" and that "the 10k number is manifest-scale, not fully-ingested-paper count". Both are wrong per the adjudication; corrected to the measured state.
- §10 staleness list — the entry reading `"keyword/TF-IDF today" (MiniLM rerank is live)` was a correction applied in the wrong direction. Replaced, with a short note explaining the `corpus_embedded` misreading that produced it.

**`docs/README.md`** — the doc-index row for `corpus-architecture.md` claimed "MiniLM rerank live; knowledge graph not built"; restated to the measured position and demoted the doc's status to `target-state`.

**`docs/corpus-architecture.md`** — the document describes embeddings, clusters, and a KG as part of the shipped substrate. Rather than rewrite a dated Day-9 record, added a claim-integrity banner under the header: Layer 1 is real, Layers 2 and 3 are not, and the "Scaffolded but not running yet" section further down is the accurate part.

**`docs/handovers/2026-07-14-architecture-review.md`** — same banner treatment, and the reason this PR's "every public surface" claim needed qualifying. Its *"what's stale on the current page"* list contains two bullets that assert the **opposite** of the adjudication: the corpus-panel bullet says a stored sentence-embedding rerank IS live and that TF-IDF is "only the degraded fallback", and the memory-pillar layer-E bullet calls the layer "half-stale (embeddings live at retrieval)". Both marked the page's *honest* "keyword/TF-IDF today" copy as the stale claim, inverting the truth — one upstream source of the over-claims removed elsewhere in this PR. The doc is indexed and non-archived, so it was reachable, but it is a **dated record**, so the body is left as written and a claim-integrity banner is added above it.

**`docs/specs/architecture-page-design.md`** — the §9 body copy and the honesty-ledger table specified the page text that ships in `Architecture.jsx`, so it had to move with it. Retrieval row now names the scorer from `/health.paper_rag`; added a "Stored embeddings — Not yet" row; the KG row notes the endpoint behaviour.

**`ui/src/components/Architecture.jsx`**
- §9 header comment asserted `corpus_embedded true` as fact. Replaced with the two things the panel must not imply and why.
- §9 body copy led with "a semantic rerank with MiniLM sentence embeddings" before its runtime gate. Now leads with the mechanism (relevance rerank, scored at request time, no vector index) and lets the gated branch quote `/health` directly: `/health reports paper_rag: live — …` / `/health reports paper_rag: degraded — …`.
- Honesty-ledger corpus row — the degraded branch said "keyword-only fallback active"; TF-IDF is lexical scoring, not a keyword filter, so it now says "lexical TF-IDF fallback active". The live branch notes the rerank is scored per request.
- §10 comment updated to match.

**`ui/src/components/CorpusGraph.jsx`** — the KB-pipeline-absent empty state told users "paper retrieval already uses live semantic embeddings (MiniLM)" as an unconditional fact. Rewritten to say why the graph is empty (no stored embeddings to project) and to point at `/health.paper_rag` for the scorer.

**`backend/tests/test_corpus_claim_integrity.py`** (new, 20 tests, hermetic) — two guards, described below.

## Guard 1 — public surfaces must not carry the banned claim-shapes

`OVERCLAIM_PATTERNS` holds seven regexes for claim-shapes that production cannot back; `PUBLIC_SURFACES` lists the eight **live** files scanned in full. Point-in-time documents are excluded on purpose, for the reason given above; the module docstring records that exclusion so a later reader does not read it as a gap and "fix" it by scanning history.

The guard is **negation-blind by design**, which is a deliberate choice and the most important detail in the file. The obvious implementation — allow a match when a negator sits nearby — was built first and discarded, because the pre-fix README sentence is:

> The semantic retrieval layer (MiniLM rerank) is live and does not depend on the KG.

The negator (`not`) sits inside the same clause as the over-claim, so every proximity and clause-scoped negation check waved through the exact prose this issue was filed about. Banning the shape outright also matches how a page is read: a skimming reader keeps the claim-shape, not the denial. The cost is that honest copy must state what *is* true rather than restate the false sentence to deny it, which is why the rewrites above say "the schema carries no vector column" instead of "nothing is embedded at ingest".

### Demonstration: the guard rejects the prose this PR removed

Reverted the prose changes (`git stash push -- README.md docs/ ui/`), leaving the new test in place, and re-ran it. Verbatim:

```
E   AssertionError: README.md asserts corpus capability that production does not have (#778): [('embed_at_ingest', 'embedded at ingest'), ('semantic_retrieval_is_live', 'semantic retrieval layer (MiniLM rerank) is live')]
E   AssertionError: docs/README.md asserts corpus capability that production does not have (#778): [('minilm_rerank_is_live', 'MiniLM rerank live')]
E   AssertionError: docs/architecture.md asserts corpus capability that production does not have (#778): [('embed_at_ingest', 'Embed at ingest'), ('minilm_rerank_is_live', 'MiniLM rerank is live')]
E   AssertionError: ui/src/components/Architecture.jsx asserts corpus capability that production does not have (#778): [('semantic_retrieval_is_live', 'semantic retrieval is live')]
E   AssertionError: ui/src/components/CorpusGraph.jsx asserts corpus capability that production does not have (#778): [('embeddings_are_live', 'live semantic embeddings')]

=================== 5 failed, 15 passed, 1 warning in 2.15s ====================
```

Five of the eight surfaces fail against the pre-fix tree; all 20 pass after. The prose fix and the guard were each verified to be load-bearing without the other.

`docs/corpus-architecture.md` and `docs/specs/architecture-page-design.md` did **not** trip the guard pre-fix — they described the mechanism without asserting its state. Those two edits are accuracy corrections a human made, not guard-driven ones, and the module docstring states that scope limit explicitly rather than implying the pattern list is exhaustive.

### Demonstration: negation-blindness, exercised directly

```
negation-blind check: [('embed_at_ingest', 'embedded at ingest')]     # input: "Nothing is embedded at ingest."
honest copy       : []                                                 # input: "Candidates are ranked at request time over title and abstract; /health names the scorer."
```

Committed as `test_guard_is_negation_blind_by_design`, which also asserts the same-clause case above is caught.

### Anti-vacuity coverage

- `test_every_declared_surface_exists` — a renamed or deleted surface fails loudly instead of silently shrinking the scan to nothing.
- `test_every_pattern_rejects_its_canonical_example` — each pattern carries the shortest string that must trip it, so a pattern that stops matching anything (typo, over-eager edit) fails rather than passing as dead weight.
- `test_guard_rejects_the_prose_it_replaced` — five parametrised cases holding the verbatim pre-fix text from each surface, each asserting the specific pattern that must catch it.

## Guard 2 — the corpus endpoints must stay honest when no artifact exists

The README now asserts specific endpoint behaviour, so that behaviour is pinned by test rather than trusted. Mocked at the artifact-store and DB-session boundaries; the route logic runs for real.

- `GET /api/corpus/graph` with no artifact → `HTTPException(503)` whose structured detail carries `error: "kb_artifact_not_found"`.
- `GET /api/corpus/kg/entities` with an empty KG → empty entity and relation sets. It does **not** 503, and an earlier draft of this PR's README said it did. That was the same defect pointing the other way, caught by writing the test; both the prose and the test now say what the route does.

### Demonstration: the guard rejects a synthesising route

Handed the guard body the implementation it exists to catch — a route that fabricates points when the artifact is missing, which is precisely the "no fake fallbacks" rule in `kb_artifacts`' own docstring and the #201 anti-goal:

```
AssertionError: route returned a graph instead of 503 with no artifact present: {'points': [{'arxiv_id': '0000.00000', 'x': 0.0, 'y': 0.0, 'cluster_id': 1}], 'topics': {}, 'cluster_count': 1, 'point_count': 1}
```

Committed as `test_the_503_guard_rejects_a_graph_synthesised_from_nothing`.

### Anti-vacuity coverage

- `test_corpus_graph_503_is_conditional_not_unconditional` — with an artifact present the same route returns 200 with those points, so the 503 assertion is conditioned on artifact detection rather than on a hard-wired refusal.
- The KG test seeds one matching entity after asserting the empty case and confirms it comes back. The route swallows SQLAlchemy errors into the *same* empty shape, so an empty result on its own would also be produced by a query that never ran; the seeded round-trip proves the query path is live and the 0/0 answer is the data speaking.

## Verification

All from the worktree root, toolchain from the `archimedes` conda env.

New tests, hermetic gate (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_corpus_claim_integrity.py -q`):

```
======================== 20 passed, 1 warning in 1.63s =========================
```

Full unit suite (`pytest -m "not integration" -q`):

```
=== 3237 passed, 2 skipped, 2 deselected, 187 warnings in 233.07s (0:03:53) ====
```

`ruff format --check .`:

```
556 files already formatted
```

`ruff check --select E9,F63,F7,F40 .`:

```
All checks passed!
```

ESLint on both edited components (`./node_modules/.bin/eslint src/components/Architecture.jsx src/components/CorpusGraph.jsx`) — exit 0, no output.

`make docs-check`:

```
links: scanned 1072 in 133 markdown files; broken 0 (0.0%)
index: 129 docs under docs/; 129 indexed, 0 orphaned.
```

`grep -r "asyncio.get_event_loop" backend/tests/` — no matches.

## Scope

This is the honest-surface half of #778 (Part A) — hence `Refs #778` rather than `Closes`, per the reasoning at the top. Part B — building the KB pipeline artifact so embeddings and the KG become real — is unaffected and remains tracked in #1090 / #1091 / #1092 / #1093, all open. Nothing here weakens the rigor gate, quota, payment, or auth semantics; the only executable code added is test code.

