### PR TITLE
Test-audit Tranche 2: vacuous/name-fraud cleanup — 3 deleted, 3 rewritten honest

### DIFF
--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -53,25 +53,6 @@ class TestDefaultDatabaseUrl:
 
 
 class TestDatabaseUrlEnvOverride:
-    def test_postgres_database_url_env_override_is_untouched(self):
-        """The DATABASE_URL env var (docker-compose's postgres URL) must pass
-        through os.getenv unchanged — the default-path fix must not affect
-        the override path."""
-        postgres_url = "postgresql://user:pass@postgres:5432/archimedes"
-
-        resolved = os.getenv("DATABASE_URL_FOR_TEST_OVERRIDE", db._default_database_url())
-        # Sanity: without the env var, we get the SQLite default.
-        assert resolved.startswith("sqlite:///")
-
-        # With the env var set, os.getenv returns the override verbatim,
-        # never falling through to _default_database_url().
-        os.environ["DATABASE_URL_FOR_TEST_OVERRIDE"] = postgres_url
-        try:
-            resolved = os.getenv("DATABASE_URL_FOR_TEST_OVERRIDE", db._default_database_url())
-            assert resolved == postgres_url
-        finally:
-            del os.environ["DATABASE_URL_FOR_TEST_OVERRIDE"]
-
     def test_get_engine_kwargs_sqlite_vs_postgres(self, monkeypatch):
         """_get_engine_kwargs branches on the DATABASE_URL prefix — verify both
         branches independent of the module-level constant's current value."""

--- a/backend/tests/test_engine_v2.py
+++ b/backend/tests/test_engine_v2.py
@@ -292,32 +292,3 @@ class TestJobStore:
     async def test_close_idempotent(self, job_store):
         await job_store.close()
         await job_store.close()
-
-
-# ── Corpus overview computation ───────────────────────────────────
-
-
-class TestCorpusOverview:
-    def test_overview_from_corpus(self):
-        from archimedes.agents.strategy_fusion import CorpusPaper
-
-        papers = [
-            CorpusPaper("2401.001", "Paper A", "Abstract", "q-fin.PM", ("q-fin.PM",), "2024-01-15"),
-            CorpusPaper("2402.002", "Paper B", "Abstract", "q-fin.TR", ("q-fin.TR", "q-fin.PM"), "2024-02-20"),
-            CorpusPaper("2303.003", "Paper C", "Abstract", "q-fin.CP", ("q-fin.CP",), "2023-03-10"),
-        ]
-        from collections import Counter
-
-        cat_counts: Counter = Counter()
-        year_counts: Counter = Counter()
-        for p in papers:
-            cat_counts[p.primary_category] += 1
-            for c in p.categories:
-                cat_counts[c] += 1
-            year = p.published[:4]
-            year_counts[year] += 1
-
-        assert cat_counts["q-fin.PM"] == 3  # Paper A primary + Paper B primary + Paper B categories
-        assert year_counts["2024"] == 2
-        assert year_counts["2023"] == 1
-        assert sum(year_counts.values()) == 3

--- a/backend/tests/test_model_gating.py
+++ b/backend/tests/test_model_gating.py
@@ -210,14 +210,6 @@ def test_endpoint_premium_without_entitlement_rejected_402():
     store.enqueue.assert_not_called()
 
 
-def test_endpoint_premium_anonymous_rejected_402():
-    """A premium model with no wallet session → 402."""
-    p_store, p_run = _patched_start()
-    with p_store, p_run:
-        resp = _client().post("/api/generate/start", json=_start_payload(_PREMIUM_HAIKU), cookies=_cookies(_WALLET))
-    assert resp.status_code == 402, resp.text
-
-
 def test_endpoint_premium_with_entitlement_allowed(monkeypatch):
     """Premium model + connected wallet + premium enabled → 202."""
     monkeypatch.setenv("PREMIUM_MODELS_ENABLED", "true")

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -16,9 +16,11 @@ subprocess to avoid poisoning the test process's module cache.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
 import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -212,12 +214,37 @@ async def test_chat_post_rate_limited():
         app.state.limiter.enabled = not os.getenv("TESTING")
 
 
+@contextlib.contextmanager
+def _limiter_enabled():
+    """Rate limiting is off under TESTING (limiter.py) — switch it on for one test.
+
+    Yields the app with a freshly reset limiter bucket so a prior test's request
+    count can't leak in, and restores the suite-wide disabled state afterwards.
+    """
+    from archimedes.main import app
+
+    app.state.limiter.enabled = True
+    with contextlib.suppress(Exception):
+        app.state.limiter.reset()
+    try:
+        yield app
+    finally:
+        app.state.limiter.enabled = not os.getenv("TESTING")
+
+
 @pytest.mark.asyncio
 async def test_strategies_stress_run_has_rate_limit():
-    """POST /api/strategies/stress/run has rate limiting decorator."""
-    from archimedes.api.strategies_routes import run_stress_test
-
-    assert run_stress_test is not None
+    """POST /api/strategies/stress/run is rate-limited (returns 429 eventually)."""
+    payload = {"allocations": [{"symbol": "sTSLA", "weight": 1.0}]}
+    with _limiter_enabled() as app:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            hit_429 = False
+            for _ in range(25):  # limit is 20/minute
+                resp = await client.post("/api/strategies/stress/run", json=payload)
+                if resp.status_code == 429:
+                    hit_429 = True
+                    break
+            assert hit_429, "Expected 429 rate limit but never hit it in 25 requests"
 
 
 @pytest.mark.asyncio
@@ -257,18 +284,41 @@ async def test_stress_run_non_dict_allocation_is_422():
 
 @pytest.mark.asyncio
 async def test_swap_quote_has_rate_limit():
-    """GET /api/swap/quote has rate limiting decorator."""
-    from archimedes.api.swap_routes import get_swap_quote
-
-    assert get_swap_quote is not None
+    """GET /api/swap/quote is rate-limited (returns 429 eventually)."""
+    # The contract loader is mocked so each request fails fast at the AMM call
+    # (a generic 400) instead of reaching for an RPC endpoint — the rate limiter
+    # runs before the handler body, so a 400 still counts against the bucket.
+    params = {
+        "token_in": "0x3600000000000000000000000000000000000000",
+        "token_out": "0xd514cd27baf762c650536765cde9b61c876abacd",
+        "amount_in": 1.0,
+    }
+    with _limiter_enabled() as app, patch("archimedes.chain.contracts.get_contract_loader", return_value=MagicMock()):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            hit_429 = False
+            for _ in range(35):  # limit is 30/minute
+                resp = await client.get("/api/swap/quote", params=params)
+                if resp.status_code == 429:
+                    hit_429 = True
+                    break
+            assert hit_429, "Expected 429 rate limit but never hit it in 35 requests"
 
 
 @pytest.mark.asyncio
 async def test_selection_bias_pbo_has_rate_limit():
-    """POST /api/selection-bias/pbo has rate limiting decorator."""
-    from archimedes.api.selection_bias_routes import compute_pbo_endpoint
-
-    assert compute_pbo_endpoint is not None
+    """POST /api/selection-bias/pbo is rate-limited (returns 429 eventually)."""
+    # s_partitions=4 keeps each accepted request ~30ms; the default 16 makes the
+    # combinatorial PBO scan ~0.5s a call, i.e. ~10s to exhaust the bucket.
+    payload = {"returns_matrix": {"s1": [0.001] * 50, "s2": [-0.0005] * 50}, "s_partitions": 4}
+    with _limiter_enabled() as app:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            hit_429 = False
+            for _ in range(25):  # limit is 20/minute
+                resp = await client.post("/api/selection-bias/pbo", json=payload)
+                if resp.status_code == 429:
+                    hit_429 = True
+                    break
+            assert hit_429, "Expected 429 rate limit but never hit it in 25 requests"
 
 
 # ─── 5. CORS explicit allowlists ──────────────────────────────────────


### PR DESCRIPTION
Tranche 2 of the ratified test-suite audit (vacuous / name-fraud / duplicate cleanup), executed as challenge-and-defense: 4 shard auditors applied the audit checklist over all of `backend/tests`, every candidate then faced an independent defender whose job was to rescue it, and only defense-surviving actions were applied. (The original audit's six defender corrections lived in a session-local plan; this run re-derived the corrections by re-running the defense rather than trusting memory.)

## Deleted (3) — each with quoted evidence on the run record

- `test_db.py::test_postgres_database_url_env_override_is_untouched` — asserted on a fabricated env key (`DATABASE_URL_FOR_TEST_OVERRIDE`) that `db.py` never reads; the test exercised `os.getenv` itself.
- `test_model_gating.py::test_endpoint_premium_anonymous_rejected_402` — name says anonymous; the body posts **with** wallet cookies. The behavior it wanted is covered by the surviving entitlement tests and the #1303 paywall×entitlement matrix.
- `test_engine_v2.py::TestCorpusOverview::test_overview_from_corpus` — builds `Counter`s in the test body and asserts on its own arithmetic; no production function is ever called.

## Rewritten honest (3) — `test_security_hardening.py`

The three "has rate limiting" tests asserted `handler is not None` — the archetype name-fraud. Each now enables the limiter, hammers the live ASGI route, and asserts an observed **429** (stress/run, swap/quote, selection-bias/pbo), with fail-fast mocking and a tuned PBO payload keeping net cost ≤0.3s/test.

## Verification

- **Adversarial pass**: `@limiter.limit` stripped from all three production routes → **3 failed, 1 passed** (the pre-existing chat test); restored and re-verified test-only changes before commit. Honest bound: with a decorator gone the limiter's 60/min default applies, and the loops (25/25/35) also catch loosening past those thresholds — a small tightening-side change (e.g. 20→25/min) would not be caught.
- **Full CI-exact suite**: 3201 passed, 0 failed (baseline on main: 3204 — delta exactly the 3 deletions).
- No production source touched; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7

---

**Correction:** commit 13506ac3's message cites `test_start_anonymous_401_when_gated`, a test name #1300 retired; the covering test on main is `test_generate_job_scoping.py::test_start_anonymous_401_and_never_ledgered` (same boundary, stronger assertions — 401 plus no identity-ledger write).