### PR TITLE
WCAG 2.2 AA fix pass: tokens, focus, keyboard operability, names and announcements !minor

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -41,10 +41,23 @@
 	--glass-border: rgba(255, 255, 255, 0.06);
 	--glass-hover: rgba(255, 255, 255, 0.05);
 
-	/* — Text — */
+	/* Form fields are the one place --glass-border is load-bearing rather than
+     decorative: an input's fill matches the card it sits in, so the 1px
+     border IS the component boundary and 1.4.11 wants it at 3:1. Separate
+     token so raising it can't brighten every hairline in the system.
+     rgba(255,255,255,0.35) on --surface-2 = 3.23:1 (0.06 gave 1.17:1). */
+	--field-border: rgba(255, 255, 255, 0.35);
+
+	/* — Text —
+     --text-3 is the `.caption` colour and the only muted text token that ever
+     lands on the BASE palette (the auth screen renders outside both
+     .app-site and .public-site, so it gets these values verbatim). It is
+     therefore pinned at ≥4.5:1 on --surface-2 for WCAG 2.2 AA 1.4.3:
+     #8a8a93 on #16161a = 5.27:1 (was #71717a = 3.73:1). --text-4 stays a
+     border/decoration token — never use it as a text colour on this palette. */
 	--text-1: #fafafa;
 	--text-2: #a1a1aa;
-	--text-3: #71717a;
+	--text-3: #8a8a93;
 	--text-4: #3f3f46;
 
 	/* — Semantic —
@@ -70,7 +83,12 @@
      on both canvases. */
 	--chart-grid: rgba(255, 255, 255, 0.06);
 	--chart-grid-strong: rgba(255, 255, 255, 0.22);
-	--chart-label: rgba(255, 255, 255, 0.42);
+	/* Axis tick values are real 8–10px <text>, so they need 4.5:1 (1.4.3).
+     Neither .app-site nor .public-site overrides these, and the asset price
+     modal portals to <body> (outside both shells), so the BASE value has to
+     hold on every card we draw a chart on: 0.52 gives ≥4.74:1 from #081218
+     through #19343d (0.42 gave 3.88:1 on --app-raised). */
+	--chart-label: rgba(255, 255, 255, 0.52);
 	--chart-label-strong: rgba(255, 255, 255, 0.55);
 
 	/* — Type — */
@@ -107,12 +125,17 @@
 :root[data-theme="light"] {
 	color-scheme: light;
 
-	/* — Brand — */
-	--accent-rgb: 156, 107, 11;
-	--accent: #9c6b0b;
+	/* — Brand —
+     Darkened from #9c6b0b to clear 4.5:1 as link/label text on --surface-2
+     (#8a5f0a on #eceae2 = 4.68:1, was 3.86:1) — the auth screen is the one
+     surface still on this palette and its "← Archimedes" link and met
+     password rules are drawn in --accent. --canvas on --accent (the
+     .btn-primary pairing) improves to 5.40:1 at the same time. */
+	--accent-rgb: 138, 95, 10;
+	--accent: #8a5f0a;
 	--accent-hover: #b47f17;
-	--accent-muted: rgba(156, 107, 11, 0.12);
-	--accent-glow: rgba(156, 107, 11, 0.06);
+	--accent-muted: rgba(138, 95, 10, 0.12);
+	--accent-glow: rgba(138, 95, 10, 0.06);
 
 	/* — Canvas — */
 	--canvas: #fafaf7;
@@ -126,11 +149,13 @@
 	--glass: rgba(9, 9, 11, 0.02);
 	--glass-border: rgba(9, 9, 11, 0.09);
 	--glass-hover: rgba(9, 9, 11, 0.05);
+	--field-border: rgba(9, 9, 11, 0.5);
 
-	/* — Text — */
+	/* — Text — (see the dark note above: --text-3 is pinned for the auth
+     screen; #62626b on #eceae2 = 5.01:1, was #71717a = 4.01:1) */
 	--text-1: #18181b;
 	--text-2: #52525b;
-	--text-3: #71717a;
+	--text-3: #62626b;
 	--text-4: #a1a1aa;
 
 	/* — Semantic —
@@ -147,10 +172,10 @@
 	--info: #2563eb;
 	--info-bg: rgba(37, 99, 235, 0.08);
 
-	/* — Chart ink — */
+	/* — Chart ink — (0.6 → ≥4.99:1 on every light card; 0.5 gave 3.74:1) */
 	--chart-grid: rgba(9, 9, 11, 0.1);
 	--chart-grid-strong: rgba(9, 9, 11, 0.28);
-	--chart-label: rgba(9, 9, 11, 0.5);
+	--chart-label: rgba(9, 9, 11, 0.6);
 	--chart-label-strong: rgba(9, 9, 11, 0.65);
 }
 
@@ -168,6 +193,12 @@ html {
 	-moz-osx-font-smoothing: grayscale;
 	scroll-behavior: smooth;
 	overflow-x: hidden;
+	/* The document is the scroll container and .topbar is sticky over it at a
+     fixed 56px on every breakpoint. Without this, Shift+Tab backwards up a
+     long page parks the newly focused control under the blurred bar and its
+     focus ring becomes unreadable (2.4.11 Focus Not Obscured). 56px bar +
+     3px outline + 3px offset = 62, rounded to 64. */
+	scroll-padding-top: 64px;
 }
 body {
 	font-family: var(--sans);
@@ -260,6 +291,21 @@ h4,
 }
 .negative {
 	color: var(--negative);
+}
+
+/* Visually hidden but announced — the text half of a colour/glyph signal, and
+   accessible names for table captions. Not `display: none`, which would hide
+   it from assistive tech too. */
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }
 
 /* --- App Shell --- */
@@ -1211,7 +1257,7 @@ textarea {
 	width: 100%;
 	padding: 9px 13px;
 	background: var(--surface-2);
-	border: 1px solid var(--glass-border);
+	border: 1px solid var(--field-border);
 	border-radius: var(--radius-sm);
 	color: var(--text-1);
 	font-family: var(--sans);
@@ -1220,10 +1266,12 @@ textarea {
 	transition:
 		border-color 0.15s,
 		box-shadow 0.15s;
-	outline: none;
 	-webkit-appearance: none;
 	appearance: none;
 }
+/* NOTE: no `outline: none` here. It used to sit in this block and, because
+   the auth screen has no :focus-visible rule of its own, it deleted the
+   focus indicator outright on every sign-in / sign-up field (2.4.7). */
 
 /* Restore native checkbox / radio appearance */
 input[type="checkbox"],
@@ -1323,7 +1371,7 @@ textarea {
 	gap: 8px;
 	padding: 9px 13px;
 	background: var(--surface-2);
-	border: 1px solid var(--glass-border);
+	border: 1px solid var(--field-border);
 	border-radius: var(--radius-sm);
 	color: var(--text-1);
 	font-family: var(--sans);
@@ -1333,8 +1381,9 @@ textarea {
 	transition:
 		border-color 0.15s,
 		box-shadow 0.15s;
-	outline: none;
 }
+/* The focus indicator is deliberately left intact on .cs-trigger — see the
+   note on the base input rule above (2.4.7). */
 .cs-trigger:hover {
 	border-color: rgba(var(--accent-rgb), 0.2);
 }
@@ -2190,6 +2239,20 @@ button.primary:disabled {
 	letter-spacing: 0.02em;
 	white-space: nowrap;
 }
+/* Pill-shaped controls (filter tabs, asset toggles) are real <button>s so they
+   are focusable and expose a role (2.1.1 / 4.1.2). `:where()` keeps this at
+   element specificity so every .tag-* variant below still wins on background,
+   colour and border; all it does is strip the UA button chrome that the
+   <span> version never had. */
+button:where(.tag) {
+	font-family: inherit;
+	color: inherit;
+	background: transparent;
+	border: 1px solid transparent;
+	margin: 0;
+	cursor: pointer;
+}
+
 .tag-accent {
 	background: var(--accent-muted);
 	color: var(--accent);
@@ -2286,6 +2349,19 @@ button.primary:disabled {
 		flex-direction: column;
 		gap: 10px;
 	}
+}
+
+/* The library row's disclosure control — renders exactly as the title text it
+   replaced, but with a native button role, name and keyboard activation. */
+.lib-row-toggle {
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
 }
 
 .lib-card {
@@ -3200,14 +3276,18 @@ button.primary:disabled {
 	align-items: center;
 	gap: 8px;
 }
+/* Sized in flex basis, not a hard px width, and allowed to wrap: the label is
+   rem-based so it grows under text zoom and under the 1.4.12 text-spacing
+   overrides while a fixed 140px box does not — category names like
+   "Statistical Finance (q-fin.ST)" were clipped to a few characters and the
+   content was simply lost (`title` only helps a hovering mouse). */
 .bar-label,
 .year-label {
-	width: 140px;
+	flex: 0 1 140px;
+	min-width: 0;
 	font-size: 0.7rem;
 	color: var(--text-2);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	overflow-wrap: break-word;
 }
 .bar-track,
 .year-track {
@@ -3271,14 +3351,49 @@ button.primary:disabled {
 	padding: 8px 12px;
 	border-radius: 6px;
 	background: var(--surface-2);
-	border: 1px solid var(--glass-border);
+	border: 1px solid var(--field-border);
 	color: var(--text-1);
 	font-size: 0.85rem;
 }
+/* No `outline: none` — see the note on the base input rule (2.4.7). */
 .catalog-search:focus,
 .kg-search:focus {
-	outline: none;
 	border-color: var(--accent);
+}
+
+/* Knowledge-graph view controls — the single-pointer alternative to drag-pan
+   and wheel-zoom (2.5.7). Sits where the lone "Reset view" button used to. */
+.corpus-kg-controls {
+	position: absolute;
+	top: 8px;
+	right: 20px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+	gap: 4px;
+	max-width: calc(100% - 32px);
+}
+.corpus-kg-controls .btn {
+	padding: 4px 10px;
+	font-size: 0.75rem;
+	min-width: 30px;
+}
+
+/* Paper titles in the catalog are the control that opens a paper, so they are
+   buttons; the reset keeps the cell looking exactly as it did. */
+.catalog-title-btn {
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 /* .catalog-filter now wraps a CustomSelect (a div-based cs-wrap, not a raw
    <select>) — it only controls layout/sizing here; the visible chrome
@@ -3596,7 +3711,11 @@ button.primary:disabled {
 	--text-1: var(--public-paper);
 	--text-2: #b8c2bb;
 	--text-3: #8da098;
-	--text-4: #657a73;
+	/* Architecture's loading / error / "live number unavailable" copy is drawn
+     in --text-4 (Architecture.jsx :86, :382, :514, :872, :901, :1054, :1084),
+     so it has to clear 4.5:1: #7d9189 is 4.74:1 on --surface-2 (#10252d) and
+     5.28:1 on the glass card, where #657a73 was 3.46 / 3.86:1. */
+	--text-4: #7d9189;
 	--accent-rgb: 217, 168, 92;
 	--accent: var(--public-bronze);
 	--accent-hover: #e4ba78;
@@ -3632,20 +3751,34 @@ button.primary:disabled {
 	font-family: inherit;
 }
 
-.public-skip-link {
+/* Bypass Blocks (2.4.1). `.app-skip-link` is the authenticated shell's copy:
+   it cannot reuse `.public-skip-link`'s colours because --public-paper /
+   --public-abyss are undefined inside .app-site, which would compute the link
+   to a transparent background and make it unreadable when focused. */
+.public-skip-link,
+.app-skip-link {
 	position: fixed;
 	top: 10px;
 	left: 12px;
 	z-index: 100;
 	padding: 10px 14px;
-	background: var(--public-paper);
-	color: var(--public-abyss);
 	font-size: 0.8rem;
 	font-weight: 600;
 	transform: translateY(-180%);
 }
 
-.public-skip-link:focus {
+.public-skip-link {
+	background: var(--public-paper);
+	color: var(--public-abyss);
+}
+
+.app-skip-link {
+	background: var(--text-1);
+	color: var(--canvas);
+}
+
+.public-skip-link:focus,
+.app-skip-link:focus {
 	transform: translateY(0);
 }
 
@@ -4609,6 +4742,11 @@ button.primary:disabled {
 	--app-verify: #79c9b7;
 	--app-action: #d9a85c;
 	--app-risk: #c56f55;
+	/* Fields are filled with --app-canvas inside --app-surface cards, so the
+     fill gives no cue (1.08:1) and the border is the whole boundary:
+     rgba(225,230,222,0.45) is 3.81:1 on the fill and 3.54:1 on the card
+     (--glass-border was 1.32 / 1.22:1). */
+	--field-border: rgba(225, 230, 222, 0.45);
 	--canvas: var(--app-canvas);
 	--surface-1: var(--app-surface);
 	--surface-2: var(--app-raised);
@@ -4654,6 +4792,7 @@ button.primary:disabled {
 	--app-verify: #287566;
 	--app-action: #97630b;
 	--app-risk: #a64e38;
+	--field-border: rgba(8, 18, 24, 0.5);
 	--canvas: var(--app-canvas);
 	--surface-1: var(--app-surface);
 	--surface-2: var(--app-raised);
@@ -4970,19 +5109,22 @@ button.primary:disabled {
 .app-site input,
 .app-site select,
 .app-site textarea {
-	border-color: var(--glass-border);
+	border-color: var(--field-border);
 	border-radius: 3px;
 	background: var(--app-canvas);
 	color: var(--text-1);
 }
 
+/* `outline: none` was here and out-specified `.app-site :focus-visible`
+   (0,2,1 vs 0,2,0), stripping the 3px ring from every text input, select and
+   textarea in the shell — the controls where a keyboard user needs it most
+   (2.4.7). The border tint + shadow stay as the polish they always were. */
 .app-site .chat-input:focus,
 .app-site input:focus,
 .app-site select:focus,
 .app-site textarea:focus {
 	border-color: var(--app-verify);
 	box-shadow: 0 0 0 2px rgba(121, 201, 183, 0.12);
-	outline: none;
 }
 
 .app-site .tag {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -53,8 +53,18 @@
      lands on the BASE palette (the auth screen renders outside both
      .app-site and .public-site, so it gets these values verbatim). It is
      therefore pinned at ≥4.5:1 on --surface-2 for WCAG 2.2 AA 1.4.3:
-     #8a8a93 on #16161a = 5.27:1 (was #71717a = 3.73:1). --text-4 stays a
-     border/decoration token — never use it as a text colour on this palette. */
+     #8a8a93 on #16161a = 5.27:1 (was #71717a = 3.73:1).
+
+     --text-4 (#3f3f46) is a border/decoration token here and must not be used
+     as a text colour on this palette — 1.73:1 on --surface-2. KNOWN OPEN
+     ISSUE, not a claim that the tree is clean: AssetModal.jsx and
+     AssetGroupModal.jsx portal to document.body, i.e. OUTSIDE .app-site, so
+     their "Current price" / "24h change" / "24h high" / "24h low" captions
+     resolve this base token and render at 1.73–1.83:1. Same portal mechanism
+     that forced the --chart-label fix below; the --text-4 half is unfixed
+     because raising the base token would also brighten every hairline that
+     legitimately uses it as decoration. It needs the call sites moved to
+     --text-3, not a token bump. */
 	--text-1: #fafafa;
 	--text-2: #a1a1aa;
 	--text-3: #8a8a93;
@@ -3775,6 +3785,14 @@ button:where(.tag) {
 .app-skip-link {
 	background: var(--text-1);
 	color: var(--canvas);
+	/* The shared block's z-index: 100 ties with `.sidebar` (App.css:325), which
+     is `position: fixed; inset: 0 auto 0 0`, opaque, and comes LATER in the
+     DOM — so at an equal z-index the sidebar won the paint order and covered
+     the link's whole focused box (top 10px, left 12px, inside the 232px
+     rail). The link was reachable but never visible, which is the classic
+     dead skip link: 2.4.1's mechanism existed while 2.4.7's indicator did
+     not. Above the sidebar (100) and topbar (50), below the modals (1000). */
+	z-index: 200;
 }
 
 .public-skip-link:focus,

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -87,9 +87,15 @@ export default function App() {
       paper: 'Paper Trading · Archimedes',
       'sign-in': 'Sign in · Archimedes',
       'sign-up': 'Create account · Archimedes',
+      // resolveRoute() returns page === null for not-found, so this branch used
+      // to fall through to the bare 'Archimedes' title — byte-identical to the
+      // landing page, leaving a screen-reader or many-tabs user unable to tell
+      // a failed deep link from home (2.4.2 Page Titled).
+      'not-found': 'Page not found · Archimedes',
     }
-    document.title = titles[route.page] ?? 'Archimedes'
-  }, [route.page])
+    const key = route.kind === 'not-found' ? 'not-found' : route.page
+    document.title = titles[key] ?? 'Archimedes'
+  }, [route.kind, route.page])
 
   const navigateToPage = useCallback((page, options = {}) => {
     const path = pageToPath(page, options)

--- a/ui/src/components/AccountSettings.jsx
+++ b/ui/src/components/AccountSettings.jsx
@@ -7,6 +7,7 @@ export default function AccountSettings({ walletAddr, onDisconnect }) {
   const { user, signOut } = useAuth()
   const [wallets, setWallets] = useState([])
   const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
   const [busy, setBusy] = useState(null)
 
   const load = useCallback(() => listLinkedWallets().then(setWallets).catch((err) => setError(err.message)), [])
@@ -25,13 +26,25 @@ export default function AccountSettings({ walletAddr, onDisconnect }) {
     }
   }
 
+  // Unlinking deletes the account↔wallet binding that owns the user's on-chain
+  // history, with no undo — relinking means re-running the SIWE signature flow,
+  // and until then the wallet's data is invisible. It was a single unconfirmed
+  // click, so a mis-click or a stray Enter on a focused button silently
+  // stranded strategies (3.3.4). PaperTrading.jsx already confirms the
+  // comparable destructive action, so this was an inconsistency, not a policy.
   const unlink = async (wallet) => {
+    const label = wallet.display_address || wallet.address
+    if (!window.confirm(
+      `Unlink ${label}? This removes the account↔wallet binding; re-linking requires signing again with that wallet.`,
+    )) return
     setBusy(wallet.id)
     setError('')
+    setNotice('')
     try {
       await removeLinkedWallet(wallet.id)
       if (walletAddr?.toLowerCase() === wallet.address) onDisconnect?.()
       await load()
+      setNotice(`Unlinked ${label}.`)
     } catch (err) {
       setError(err.message)
     } finally {
@@ -90,6 +103,9 @@ export default function AccountSettings({ walletAddr, onDisconnect }) {
             ))}
           </ul>
         )}
+        <div role="status" aria-live="polite" className={notice ? 'caption mt-3' : 'sr-only'}>
+          {notice}
+        </div>
         {error && <div className="status mt-3" role="alert">{error}</div>}
       </section>
 

--- a/ui/src/components/AuthPage.jsx
+++ b/ui/src/components/AuthPage.jsx
@@ -113,6 +113,7 @@ export default function AuthPage({ mode }) {
               minLength={PASSWORD_MIN}
               maxLength={PASSWORD_MAX}
               autoComplete={creating ? 'new-password' : 'current-password'}
+              aria-describedby={creating ? 'password-rules' : undefined}
               value={form.password}
               onChange={(event) => setForm({ ...form, password: event.target.value })}
             />
@@ -121,12 +122,17 @@ export default function AuthPage({ mode }) {
             <>
               <label className="flex flex-col gap-1.5">
                 <span className="caption">Confirm password</span>
+                {/* aria-invalid alone said "invalid entry" with no statement of
+                    what was wrong: the mismatch alert fires once while the user
+                    is still typing and is unreachable afterwards, and the rules
+                    list was never associated with the field (3.3.1). */}
                 <input
                   required
                   type="password"
                   maxLength={PASSWORD_MAX}
                   autoComplete="new-password"
                   aria-invalid={showMismatch}
+                  aria-describedby={showMismatch ? 'password-rules confirm-mismatch' : 'password-rules'}
                   value={form.confirm}
                   onChange={(event) => setForm({ ...form, confirm: event.target.value })}
                 />
@@ -144,30 +150,40 @@ export default function AuthPage({ mode }) {
                   ))}
                 </div>
                 {form.password.length > 0 && (
-                  <span className="caption text-[var(--text-4)]">
+                  <span className="caption">
                     Strength: {strength.label} — guidance only; the length rule below is the requirement.
                   </span>
                 )}
-                <ul className="caption flex flex-col gap-0.5" aria-label="Password requirements">
+                {/* Unmet rules inherit .caption's --text-3 rather than --text-4:
+                    on the base palette --text-4 is #3f3f46, i.e. 1.73:1 on the
+                    card — the rule text a user needs precisely when their
+                    password was rejected was the least readable text here.
+                    The ✓/○ glyph stays the state signal (1.4.1). */}
+                <ul className="caption flex flex-col gap-0.5" id="password-rules" aria-label="Password requirements">
                   {rules.map((rule) => (
-                    <li key={rule.id} className={rule.met ? 'text-[var(--accent)]' : 'text-[var(--text-4)]'}>
+                    <li key={rule.id} className={rule.met ? 'text-[var(--accent)]' : undefined}>
                       {rule.met ? '✓' : '○'} {rule.label}
                     </li>
                   ))}
-                  <li className={match ? 'text-[var(--accent)]' : 'text-[var(--text-4)]'}>
+                  <li className={match ? 'text-[var(--accent)]' : undefined}>
                     {match ? '✓' : '○'} Passwords match
                   </li>
                 </ul>
               </div>
               {showMismatch && (
-                <div className="status" role="alert">
+                <div className="status" role="alert" id="confirm-mismatch">
                   Passwords do not match.
                 </div>
               )}
             </>
           )}
           {error && <div className="status" role="alert">{error}</div>}
-          <button className="btn-primary" type="submit" disabled={busy || !canSubmit}>
+          <button
+            className="btn-primary"
+            type="submit"
+            disabled={busy || !canSubmit}
+            aria-describedby={creating && !canSubmit ? 'password-rules' : undefined}
+          >
             {busy ? 'Working…' : creating ? 'Create account' : 'Sign in'}
           </button>
         </form>
@@ -185,7 +201,7 @@ export default function AuthPage({ mode }) {
             {creating ? 'Sign in' : 'Create account'}
           </a>
         </p>
-        <p className="caption mt-5 text-[var(--text-4)]">
+        <p className="caption mt-5">
           Circle wallet passkeys authorize Circle smart wallets. They do not sign in to Archimedes.
         </p>
       </section>

--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -179,8 +179,11 @@ function CatalogTab({ papers, total, page, loading, search, setSearch, categoryF
   return (
     <div className="corpus-catalog">
       <div className="catalog-controls">
+        {/* The placeholder is not a label: it disappears on the first keystroke
+            and the field is then anonymous to a screen reader (3.3.2). */}
         <input
           type="text" placeholder="Search papers..." value={search}
+          aria-label="Search papers"
           onChange={e => { setSearch(e.target.value); setPage(1) }}
           className="catalog-search"
         />
@@ -188,13 +191,14 @@ function CatalogTab({ papers, total, page, loading, search, setSearch, categoryF
           value={categoryFilter}
           onChange={v => { setCategoryFilter(v); setPage(1) }}
           className="catalog-filter"
+          ariaLabel="Filter papers by category"
           options={[{ value: '', label: 'All Categories' }, ...categories.map(c => ({ value: c.name, label: `${c.label || c.name} (${c.count})` }))]}
         />
       </div>
 
       {loading ? <div className="corpus-loading">Loading...</div> : (
         <>
-          <div className="catalog-results-info">{total.toLocaleString()} papers found</div>
+          <div className="catalog-results-info" role="status">{total.toLocaleString()} papers found</div>
           <div className="overflow-x-auto rounded-lg border border-[var(--glass-border)]">
             {/* Tight one-line-per-entry table. arxiv ID dropped from the
                 listing (it shows on the paper detail page after click);
@@ -233,7 +237,19 @@ function CatalogTab({ papers, total, page, loading, search, setSearch, categoryF
                       style={{ padding: '5px 12px', color: 'var(--text-1)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
                       title={cleanLatex(p.title) || p.arxiv_id}
                     >
-                      {cleanLatex(p.title) || p.arxiv_id}
+                      {/* Real control in the title cell: the row onClick was the
+                          only way into a paper's detail view and no cell held a
+                          link, so on this anonymous-OK front door a keyboard or
+                          switch user could page the catalog but never open a
+                          paper (2.1.1). The row keeps its onClick for the mouse;
+                          stopPropagation keeps that one activation. */}
+                      <button
+                        type="button"
+                        className="catalog-title-btn"
+                        onClick={(e) => { e.stopPropagation(); openPaper(p.arxiv_id) }}
+                      >
+                        {cleanLatex(p.title) || p.arxiv_id}
+                      </button>
                     </td>
                     <td style={{ padding: '5px 12px', whiteSpace: 'nowrap' }}>
                       {p.primary_category && (

--- a/ui/src/components/CorpusKG.jsx
+++ b/ui/src/components/CorpusKG.jsx
@@ -220,6 +220,33 @@ export default function CorpusKG({ onOpenPaper }) {
 
   const resetView = useCallback(() => setViewTransform({ scale: 1, x: 0, y: 0 }), [])
 
+  // Single-pointer alternatives to the drag-pan and wheel-zoom (2.5.7 Dragging
+  // Movements). "Reset view" was the only non-drag control and it only ever
+  // returns to the origin, so a head-pointer / eye-gaze / switch user — or
+  // anyone who cannot hold a button while moving — saw only whatever fell
+  // inside the default viewport. Drag and wheel are untouched; they simply
+  // stop being the only route.
+  const zoomBy = useCallback((factor) => {
+    setViewTransform((prev) => {
+      const nextScale = Math.min(8, Math.max(0.4, prev.scale * factor))
+      // Keep the viewport centre fixed, the same invariant the wheel handler
+      // holds for the cursor position.
+      const cx = layout.svgW / 2
+      const cy = layout.svgH / 2
+      return {
+        scale: nextScale,
+        x: cx - ((cx - prev.x) / prev.scale) * nextScale,
+        y: cy - ((cy - prev.y) / prev.scale) * nextScale,
+      }
+    })
+  }, [layout.svgW, layout.svgH])
+
+  const panBy = useCallback((dx, dy) => {
+    setViewTransform((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }))
+  }, [])
+
+  const PAN_STEP = 80
+
   // --- Render ---
 
   if (error) {
@@ -310,8 +337,14 @@ export default function CorpusKG({ onOpenPaper }) {
         <div style={{ padding: 40, textAlign: 'center' }} className="caption">No entities found.</div>
       ) : (
         <div style={{ overflow: 'hidden', padding: '0 12px 12px', position: 'relative' }}>
+          {/* Informative chart, so it gets the same role="img" + aria-label
+              treatment every other real chart in the repo already carries
+              (BacktestVisualizer, RiskAnalysis). Without it this 500px region
+              was announced as nothing at all (1.1.1). */}
           <svg
             ref={setSvgRef}
+            role="img"
+            aria-label={`Topic cluster graph: ${entities.length} entities, ${relations.length} relations`}
             viewBox={`0 0 ${layout.svgW} ${layout.svgH}`}
             style={{
               width: '100%', maxWidth: 800, height: 500, background: 'rgba(0,0,0,0.15)', borderRadius: 8,
@@ -394,14 +427,25 @@ export default function CorpusKG({ onOpenPaper }) {
             </g>
           </svg>
 
-          <button
-            type="button"
-            className="btn btn-outline corpus-kg-reset-view"
-            onClick={resetView}
-            style={{ position: 'absolute', top: 8, right: 20, padding: '4px 10px', fontSize: '0.75rem' }}
+          <div
+            className="corpus-kg-controls"
+            role="group"
+            aria-label="Graph view controls"
           >
-            Reset view
-          </button>
+            <button type="button" className="btn btn-outline" onClick={() => zoomBy(1.25)} aria-label="Zoom in">+</button>
+            <button type="button" className="btn btn-outline" onClick={() => zoomBy(1 / 1.25)} aria-label="Zoom out">−</button>
+            <button type="button" className="btn btn-outline" onClick={() => panBy(PAN_STEP, 0)} aria-label="Pan left">←</button>
+            <button type="button" className="btn btn-outline" onClick={() => panBy(-PAN_STEP, 0)} aria-label="Pan right">→</button>
+            <button type="button" className="btn btn-outline" onClick={() => panBy(0, PAN_STEP)} aria-label="Pan up">↑</button>
+            <button type="button" className="btn btn-outline" onClick={() => panBy(0, -PAN_STEP)} aria-label="Pan down">↓</button>
+            <button
+              type="button"
+              className="btn btn-outline corpus-kg-reset-view"
+              onClick={resetView}
+            >
+              Reset view
+            </button>
+          </div>
 
           {/* Hover tooltip — full, untruncated entity title with strong
               contrast so it stays readable over a busy/filtered graph. */}

--- a/ui/src/components/CustomSelect.jsx
+++ b/ui/src/components/CustomSelect.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, useId } from 'react'
 import { createPortal } from 'react-dom'
 
 export default function CustomSelect({
@@ -9,13 +9,20 @@ export default function CustomSelect({
   disabled = false,
   className = '',
   style,
+  // Without this the trigger is announced as its current value alone ("All
+  // Categories, button") with no indication of what it selects (4.1.2).
+  ariaLabel,
+  ariaLabelledBy,
 }) {
   const [open, setOpen] = useState(false)
+  const listboxId = `cs-listbox-${useId()}`
+  const optionId = (i) => `${listboxId}-opt-${i}`
   const [dropdownStyle, setDropdownStyle] = useState({})
   const triggerRef = useRef(null)
   const dropdownRef = useRef(null)
 
-  const selected = options.find(o => o.value === value)
+  const selectedIndex = options.findIndex(o => o.value === value)
+  const selected = selectedIndex >= 0 ? options[selectedIndex] : undefined
 
   const close = useCallback(() => setOpen(false), [])
 
@@ -109,6 +116,14 @@ export default function CustomSelect({
         onKeyDown={handleKeyDown}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        // ArrowUp/ArrowDown mutate the selection while focus stays on the
+        // trigger; without activedescendant the value changed silently.
+        aria-activedescendant={
+          open && selectedIndex >= 0 ? optionId(selectedIndex) : undefined
+        }
         disabled={disabled}
       >
         <span className="cs-value">
@@ -133,10 +148,14 @@ export default function CustomSelect({
           className="cs-dropdown"
           style={dropdownStyle}
           role="listbox"
+          id={listboxId}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabel ? undefined : ariaLabelledBy}
         >
-          {options.map(opt => (
+          {options.map((opt, i) => (
             <div
               key={opt.value}
+              id={optionId(i)}
               className={`cs-option ${opt.value === value ? 'cs-selected' : ''} ${opt.disabled ? 'cs-option-disabled' : ''}`}
               role="option"
               aria-selected={opt.value === value}

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -151,16 +151,20 @@ export default function Explore() {
       {/* Filter pills — only meaningful for the flat asset list */}
       {view === 'assets' && (
         <div className="strat-filter-bar" style={{ marginBottom: 18 }}>
+          {/* Buttons with aria-pressed, matching the view toggles directly
+              above — as click-only spans these were unreachable from the
+              keyboard on the default /app landing page (2.1.1 / 4.1.2). */}
           {classes.map(c => (
-            <span
+            <button
               key={c}
+              type="button"
               className={`tag ${filterClass === c ? 'tag-accent' : 'tag-muted'}`}
+              aria-pressed={filterClass === c}
               onClick={() => setFilterClass(c)}
-              style={{ cursor: 'pointer' }}
             >
               {c === 'all' ? 'All' : c.replace(/_/g, ' ')}
               {c !== 'all' && ` (${assets.filter(a => a.asset_class === c).length})`}
-            </span>
+            </button>
           ))}
         </div>
       )}

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -344,9 +344,18 @@ export default function Generate({ onNavigate, onStageChange }) {
 				{/* ── 1. BRIEF INPUT + SUBMIT ── */}
 				<section className="card generate-brief">
 					{/* Strategy name — promoted from Advanced options so it's seen before the brief */}
+					{/* Real <label htmlFor> associations. These three fields — the
+					    strategy name, the brief, and the asset search below — were
+					    labelled by plain <div>s and placeholders only, so a screen
+					    reader announced the product's single most important control
+					    as an anonymous "edit, multiline" the moment the user typed
+					    the first character (3.3.2 / 4.1.2). */}
 					<div className="mb-3">
-						<div className="label mb-1">Strategy name (optional)</div>
+						<label className="label mb-1 block" htmlFor="generate-strategy-name">
+							Strategy name (optional)
+						</label>
 						<input
+							id="generate-strategy-name"
 							type="text"
 							value={strategyName}
 							onChange={(e) => setStrategyName(e.target.value)}
@@ -361,13 +370,21 @@ export default function Generate({ onNavigate, onStageChange }) {
 						</p>
 					</div>
 
-					<div className="label mb-1">Your brief</div>
-					<p className="caption mb-2" style={{ color: "var(--text-3)" }}>
+					<label className="label mb-1 block" htmlFor="generate-brief">
+						Your brief
+					</label>
+					<p
+						className="caption mb-2"
+						id="generate-brief-help"
+						style={{ color: "var(--text-3)" }}
+					>
 						A good brief names concrete assets or classes, a mechanism (momentum
 						/ vol-managed / hedge / mean-reversion), and a goal.
 					</p>
 
 					<textarea
+						id="generate-brief"
+						aria-describedby="generate-brief-help"
 						value={intent}
 						onChange={(e) => setIntent(e.target.value)}
 						placeholder="e.g. blend momentum, quality and a gold hedge across major ETFs with volatility-managed sizing for idle USDC"
@@ -503,6 +520,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 										value={assetQuery}
 										onChange={(e) => setAssetQuery(e.target.value)}
 										placeholder="Search assets (e.g. SPY, GOLD, BTC)…"
+										aria-label="Search assets"
 										className="chat-input w-full mb-2 px-2.5 py-1.5"
 										disabled={starting}
 									/>
@@ -521,6 +539,11 @@ export default function Generate({ onNavigate, onStageChange }) {
 												No assets match "{assetQuery}".
 											</div>
 										)}
+										{/* Each ticker is a real toggle button: as a click-only
+										    <span> the universe picker had no tab stop and no
+										    role, so a keyboard user could clear the selection
+										    (the "Clear" affordance is a real button) but never
+										    set one (2.1.1 / 4.1.2). */}
 										{filteredAssetGroups.map((group) => (
 											<div key={group.id} className="mb-2">
 												<div
@@ -529,15 +552,21 @@ export default function Generate({ onNavigate, onStageChange }) {
 												>
 													{group.label}
 												</div>
-												<div className="flex gap-1.5 flex-wrap">
+												<div
+													className="flex gap-1.5 flex-wrap"
+													role="group"
+													aria-label={`${group.label} assets`}
+												>
 													{group.assets.map((a) => (
-														<span
+														<button
 															key={a}
+															type="button"
 															className={`tag ${selectedAssets.includes(a) ? "tag-accent" : "tag-muted"} cursor-pointer`}
+															aria-pressed={selectedAssets.includes(a)}
 															onClick={() => toggleAsset(a)}
 														>
 															{a}
-														</span>
+														</button>
 													))}
 												</div>
 											</div>
@@ -624,6 +653,21 @@ export default function Generate({ onNavigate, onStageChange }) {
 						className="flex items-center justify-between flex-wrap gap-2"
 						style={{ marginTop: 2 }}
 					>
+						{/* Every outcome of pressing Generate — start failure, quote not
+						    ready, wallet-link required, test mode, payments unavailable,
+						    and the success receipt — paints into this one slot. None of
+						    it was announced: the user heard the button label revert from
+						    "Starting…" and was never told whether the job started or why
+						    it failed (4.1.3). The live container is mounted
+						    unconditionally, because a live region added at the same
+						    moment as its text is usually missed by assistive tech. */}
+						<div
+							className="generate-submit-status"
+							role="status"
+							aria-live="polite"
+							aria-atomic="true"
+							style={{ flex: 1, display: "flex" }}
+						>
 						{paymentStatus === PAYMENT_STATUS.WALLET_LINK_REQUIRED ? (
 							<div className="info-box warning" style={{ flex: 1 }}>
 								<strong>Wallet link required.</strong> {paymentMessage}
@@ -704,10 +748,14 @@ export default function Generate({ onNavigate, onStageChange }) {
 						) : (
 							<div />
 						)}
+						</div>
 						<button
 							className="btn btn-primary"
 							onClick={startJob}
 							disabled={starting || !intent.trim() || !quoteReady}
+							aria-describedby={
+								!intent.trim() ? "generate-submit-hint" : undefined
+							}
 						>
 							{starting
 								? "Starting…"
@@ -716,6 +764,17 @@ export default function Generate({ onNavigate, onStageChange }) {
 									: "Generate →"}
 						</button>
 					</div>
+					{/* The submit button is disabled until a brief exists; state the
+					    cause rather than leaving the form looking stuck (3.3.1). */}
+					{!intent.trim() && (
+						<p
+							id="generate-submit-hint"
+							className="caption mt-2 mb-0"
+							style={{ color: "var(--text-3)" }}
+						>
+							Enter a brief above to enable generation.
+						</p>
+					)}
 				</section>
 
 				<aside

--- a/ui/src/components/GenerationStatus.jsx
+++ b/ui/src/components/GenerationStatus.jsx
@@ -125,15 +125,18 @@ export default function GenerationStatus({ activeJobId, onDrillIn }) {
           <table
             style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}
           >
+            <caption className="sr-only">Recent generations</caption>
             <thead>
               <tr
                 style={{ textAlign: 'left', borderBottom: '1px solid var(--glass-border)' }}
               >
-                <th style={{ padding: '6px 8px' }}>Brief</th>
-                <th style={{ padding: '6px 8px' }}>State</th>
-                <th style={{ padding: '6px 8px' }}>N</th>
-                <th style={{ padding: '6px 8px' }}>Updated</th>
-                <th style={{ padding: '6px 8px' }} />
+                <th scope="col" style={{ padding: '6px 8px' }}>Brief</th>
+                <th scope="col" style={{ padding: '6px 8px' }}>State</th>
+                <th scope="col" style={{ padding: '6px 8px' }}>N</th>
+                <th scope="col" style={{ padding: '6px 8px' }}>Updated</th>
+                <th scope="col" style={{ padding: '6px 8px' }}>
+                  <span className="sr-only">Open</span>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -141,18 +144,16 @@ export default function GenerationStatus({ activeJobId, onDrillIn }) {
                 const tag = STATE_TAGS[j.state] || STATE_TAGS.queued
                 const isActive = j.job_id === activeJobId
                 return (
+                  // role="button" on a <tr> destroys the row's table semantics:
+                  // the <td>s stop being exposed as cells and the aria-label
+                  // replaces the row content wholesale, so a screen-reader user
+                  // heard only "Open generation: <brief>, button" and never the
+                  // state, candidate count or updated time this table exists to
+                  // convey (4.1.2 / 1.3.1). The control now lives in the last
+                  // cell; the row keeps onClick as a mouse convenience.
                   <tr
                     key={j.job_id}
                     onClick={() => onDrillIn?.(j.job_id)}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`Open generation: ${j.brief_intent || j.job_id}`}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        onDrillIn?.(j.job_id)
-                      }
-                    }}
                     style={{
                       borderBottom: '1px solid var(--glass)',
                       background: isActive
@@ -190,12 +191,23 @@ export default function GenerationStatus({ activeJobId, onDrillIn }) {
                       {timeAgo(j.updated_at)}
                     </td>
                     <td style={{ padding: '8px 8px', textAlign: 'right' }}>
-                      <span
+                      <button
+                        type="button"
                         className="caption"
-                        style={{ color: 'var(--accent)', whiteSpace: 'nowrap' }}
+                        onClick={e => { e.stopPropagation(); onDrillIn?.(j.job_id) }}
+                        aria-label={`Open generation: ${j.brief_intent || j.job_id}`}
+                        style={{
+                          background: 'none',
+                          border: 'none',
+                          padding: 0,
+                          font: 'inherit',
+                          cursor: 'pointer',
+                          color: 'var(--accent)',
+                          whiteSpace: 'nowrap',
+                        }}
                       >
                         {j.state === 'running' || j.state === 'queued' ? 'resume →' : 'view →'}
-                      </span>
+                      </button>
                     </td>
                   </tr>
                 )

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -209,11 +209,17 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
   return (
     <div className="card" style={{ padding: 20 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-        <div>
+        {/* Generation runs for minutes and every terminal outcome landed in
+            plain <div>s: a screen-reader user who submitted a brief had no way
+            to know the run was progressing, had finished, or had errored
+            (4.1.3). role="status" for the running/done states, role="alert" for
+            the failure so it is announced even when the user is not on the log
+            below. */}
+        <div role={terminal === 'error' ? 'alert' : 'status'}>
           <div className="label">Generating — job {jobId.slice(0, 10)}…</div>
           {terminal === 'done' && (
             <div className="positive caption" style={{ marginTop: 4 }}>
-              <span className="i-lucide-check w-3.5 h-3.5 mr-1" /> Strategy persisted{strategyId ? ` as ${strategyId}` : ''}
+              <span aria-hidden="true" className="i-lucide-check w-3.5 h-3.5 mr-1" /> Strategy persisted{strategyId ? ` as ${strategyId}` : ''}
               {servedModel && servedModel !== 'fixture' && (
                 <span style={{ color: 'var(--text-3)' }}> · served by <strong>{servedModel}</strong></span>
               )}
@@ -221,7 +227,7 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
           )}
           {terminal === 'error' && (
             <div className="negative caption" style={{ marginTop: 4 }}>
-              <span className="i-lucide-x w-3.5 h-3.5 mr-1" /> {errorMsg}
+              <span aria-hidden="true" className="i-lucide-x w-3.5 h-3.5 mr-1" /> {errorMsg}
             </div>
           )}
           {!terminal && (
@@ -248,8 +254,15 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
         </div>
       </div>
 
+      {/* role="log" is the right role for an append-only feed: it keeps
+          announcements to newly added entries instead of re-reading the whole
+          scroller on every event. */}
       <div
         ref={scrollRef}
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions text"
+        aria-label="Generation events"
         style={{
           maxHeight: 320,
           overflowY: 'auto',

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -215,21 +215,36 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
             (4.1.3). role="status" for the running/done states, role="alert" for
             the failure so it is announced even when the user is not on the log
             below. */}
-        <div role={terminal === 'error' ? 'alert' : 'status'}>
+        <div>
           <div className="label">Generating — job {jobId.slice(0, 10)}…</div>
-          {terminal === 'done' && (
-            <div className="positive caption" style={{ marginTop: 4 }}>
-              <span aria-hidden="true" className="i-lucide-check w-3.5 h-3.5 mr-1" /> Strategy persisted{strategyId ? ` as ${strategyId}` : ''}
-              {servedModel && servedModel !== 'fixture' && (
-                <span style={{ color: 'var(--text-3)' }}> · served by <strong>{servedModel}</strong></span>
-              )}
-            </div>
-          )}
-          {terminal === 'error' && (
-            <div className="negative caption" style={{ marginTop: 4 }}>
-              <span aria-hidden="true" className="i-lucide-x w-3.5 h-3.5 mr-1" /> {errorMsg}
-            </div>
-          )}
+          {/* The live region holds ONLY the terminal outcome, and is mounted
+              empty from the start so the message it later receives is actually
+              announced. The running-state event counter below is deliberately
+              OUTSIDE it: `events.length` increments on every SSE frame, and
+              while it sat inside this region a screen reader re-read the whole
+              block — job id and all — once per event, for the several minutes
+              a generation runs. That buried the very outcome the region exists
+              to convey, and it defeated the point of the role="log" feed
+              further down, which already reports progress one entry at a
+              time. */}
+          <div
+            role="status"
+            aria-live={terminal === 'error' ? 'assertive' : 'polite'}
+          >
+            {terminal === 'done' && (
+              <div className="positive caption" style={{ marginTop: 4 }}>
+                <span aria-hidden="true" className="i-lucide-check w-3.5 h-3.5 mr-1" /> Strategy persisted{strategyId ? ` as ${strategyId}` : ''}
+                {servedModel && servedModel !== 'fixture' && (
+                  <span style={{ color: 'var(--text-3)' }}> · served by <strong>{servedModel}</strong></span>
+                )}
+              </div>
+            )}
+            {terminal === 'error' && (
+              <div className="negative caption" style={{ marginTop: 4 }}>
+                <span aria-hidden="true" className="i-lucide-x w-3.5 h-3.5 mr-1" /> {errorMsg}
+              </div>
+            )}
+          </div>
           {!terminal && (
             <div className="caption" style={{ marginTop: 4, color: 'var(--text-3)' }}>
               Streaming live · {events.length} event{events.length === 1 ? '' : 's'}

--- a/ui/src/components/GenerationStream.jsx
+++ b/ui/src/components/GenerationStream.jsx
@@ -212,9 +212,10 @@ export default function GenerationStream({ jobId, onDone, onReset, onPipelineSel
         {/* Generation runs for minutes and every terminal outcome landed in
             plain <div>s: a screen-reader user who submitted a brief had no way
             to know the run was progressing, had finished, or had errored
-            (4.1.3). role="status" for the running/done states, role="alert" for
-            the failure so it is announced even when the user is not on the log
-            below. */}
+            (4.1.3). role="status" with aria-live toggled to "assertive" on failure
+ (and "polite" otherwise) — the explicit aria-live overrides the role's
+ implicit politeness, so an error is announced even when the user is not
+ on the log below. */}
         <div>
           <div className="label">Generating — job {jobId.slice(0, 10)}…</div>
           {/* The live region holds ONLY the terminal outcome, and is mounted

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -186,6 +186,14 @@ export default function Layout({
 		<div
 			className={`shell app-site${sidebarCollapsed ? " shell-sidebar-collapsed" : ""}`}
 		>
+			{/* Bypass Blocks (2.4.1). The public shell has always shipped one; the
+			    authenticated shell made every /app page start with the same ~18
+			    stops (sidebar close, up to 12 nav buttons, collapse, hamburger,
+			    theme, tour, account chip, wallet) before any content. */}
+			<a className="app-skip-link" href="#app-content">
+				Skip to content
+			</a>
+
 			{/* Mobile overlay — uses UnoCSS `fixed inset-0` + App.css `.sidebar-overlay` */}
 			{menuOpen && (
 				<div
@@ -219,7 +227,7 @@ export default function Layout({
 					</div>
 				</div>
 
-				<nav>
+				<nav aria-label="Main">
 					{NAV.map((group) => ({
 						...group,
 						// Anonymous visitors see only the browsable pages plus
@@ -235,14 +243,26 @@ export default function Layout({
 							{group.group && (
 								<div className="nav-group-label">{group.group}</div>
 							)}
-							{group.items.map((item) => (
+							{group.items.map((item) => {
+								const isCurrent =
+									page === item.id ||
+									(item.id === "portfolio" && page === "vault-detail");
+								return (
 								<button
 									key={item.id}
 									type="button"
 									data-tour={item.id}
-									className={`nav-link${page === item.id || (item.id === "portfolio" && page === "vault-detail") ? " active" : ""}`}
+									className={`nav-link${isCurrent ? " active" : ""}`}
 									onClick={() => handleNav(item.id)}
-									aria-label={item.label}
+									// This is a client-routed SPA, so the `.active` class was the
+									// ONLY "you are here" signal — every item read identically to
+									// a screen reader. aria-label is kept only for the collapsed
+									// rail, where .nav-label is display:none (App.css:501) and the
+									// button would otherwise have no accessible name; leaving it
+									// on the expanded state silently overrides the visible label
+									// if the two ever drift (2.5.3).
+									aria-current={isCurrent ? "page" : undefined}
+									aria-label={sidebarCollapsed ? item.label : undefined}
 									title={sidebarCollapsed ? item.label : undefined}
 								>
 									<span
@@ -251,7 +271,8 @@ export default function Layout({
 									/>
 									<span className="nav-label">{item.label}</span>
 								</button>
-							))}
+								);
+							})}
 						</div>
 					))}
 				</nav>
@@ -377,7 +398,13 @@ export default function Layout({
 						)}
 					</div>
 				</div>
-				<main className={`page-content page-${page}`}>
+				{/* tabIndex={-1} so the skip link above actually lands focus here
+				    rather than only moving the scroll position. */}
+				<main
+					id="app-content"
+					tabIndex={-1}
+					className={`page-content page-${page}`}
+				>
 					{proofStage && (
 						<ol className="app-proof-rail" aria-label="Core strategy journey">
 							{PROOF_STAGES.map((stage) => {

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -252,7 +252,10 @@ export default function OnboardingTour({ open, onClose, setPage }) {
   // accessibility tree — but focus was never moved in, never trapped and never
   // restored, so the tour was announced as nothing while a sighted keyboard
   // user tabbed straight through the four dim panels into the app behind them.
-  const panelRef = useDialogFocus(open)
+  // refocusKey: the centered-card branch and the spotlight branch are two
+  // different portal trees, so advancing off card 0 (the only unanchored card)
+  // destroys the panel the user's focus is in and strands it on <body>.
+  const panelRef = useDialogFocus(open, { refocusKey: cardIndex })
 
   // Keyboard support — Esc closes, ArrowRight advances, ArrowLeft goes back.
   useEffect(() => {

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useLayoutEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { roadmapSurfaceHidden } from '../featureFlags.js'
+import useDialogFocus from '../hooks/useDialogFocus'
 
 const STORAGE_KEY = 'archimedes.onboarding.v1'
 
@@ -246,6 +247,13 @@ export default function OnboardingTour({ open, onClose, setPage }) {
     else setCardIndex(i => i + 1)
   }, [isLast, finish])
 
+  // The tour auto-opens for every first-time signed-in user and declares
+  // aria-modal="true", which removes the rest of the page from the
+  // accessibility tree — but focus was never moved in, never trapped and never
+  // restored, so the tour was announced as nothing while a sighted keyboard
+  // user tabbed straight through the four dim panels into the app behind them.
+  const panelRef = useDialogFocus(open)
+
   // Keyboard support — Esc closes, ArrowRight advances, ArrowLeft goes back.
   useEffect(() => {
     if (!open) return
@@ -278,23 +286,33 @@ export default function OnboardingTour({ open, onClose, setPage }) {
         {card.body}
       </p>
 
-      {/* Pagination dots */}
-      <div className="flex gap-1.5 justify-center mb-5" role="tablist" aria-label="Tour progress">
+      {/* Pagination dots. The 8px visual dot is unchanged, but the hit area is
+          now the 24x24 minimum (2.5.8) — at 8px with a 6px gap the 24px
+          targets centred on adjacent dots overlapped, so the spacing exception
+          did not rescue them either. The tablist/tab roles are dropped rather
+          than kept: it promised arrow-key navigation between tabs and matching
+          tabpanels, neither of which this component implements. */}
+      <div className="flex justify-center mb-5" role="group" aria-label="Tour progress">
         {CARDS.map((c, i) => (
           <button
             key={c.id}
             type="button"
-            role="tab"
-            aria-selected={i === cardIndex}
+            aria-current={i === cardIndex ? 'true' : undefined}
             aria-label={`Card ${i + 1}: ${c.title}`}
             onClick={() => setCardIndex(i)}
-            className="w-2 h-2 rounded-full border-none cursor-pointer"
-            style={{
-              background: i === cardIndex ? 'var(--accent)' : 'var(--text-4)',
-              opacity: i === cardIndex ? 1 : 0.4,
-              padding: 0,
-            }}
-          />
+            className="w-6 h-6 flex items-center justify-center border-none cursor-pointer"
+            style={{ background: 'transparent', padding: 0 }}
+          >
+            <span
+              aria-hidden="true"
+              className="w-2 h-2 rounded-full"
+              style={{
+                display: 'block',
+                background: i === cardIndex ? 'var(--accent)' : 'var(--text-4)',
+                opacity: i === cardIndex ? 1 : 0.4,
+              }}
+            />
+          </button>
         ))}
       </div>
 
@@ -328,6 +346,8 @@ export default function OnboardingTour({ open, onClose, setPage }) {
         aria-labelledby="onboarding-title"
       >
         <div
+          ref={panelRef}
+          tabIndex={-1}
           className="card-elevated p-6 max-w-[460px] w-[90vw]"
           onClick={e => e.stopPropagation()}
           style={{ background: 'var(--surface-1)', opacity: 1 }}
@@ -387,6 +407,8 @@ export default function OnboardingTour({ open, onClose, setPage }) {
 
       {/* Tooltip */}
       <div
+        ref={panelRef}
+        tabIndex={-1}
         className="card-elevated tour-tooltip p-5"
         style={{
           position: 'fixed', top: tipTop, left: tipLeft, width: TIP_W, maxWidth: '90vw',

--- a/ui/src/components/PaperTrading.jsx
+++ b/ui/src/components/PaperTrading.jsx
@@ -79,7 +79,7 @@ function Sparkline({ series }) {
       <polyline
         points={pts}
         fill="none"
-        stroke={up ? 'var(--accent)' : 'var(--danger, #b91c1c)'}
+        stroke={up ? 'var(--accent)' : 'var(--negative)'}
         strokeWidth="1.5"
       />
     </svg>
@@ -90,6 +90,7 @@ export default function PaperTrading({ onNavigate }) {
   const [deployments, setDeployments] = useState(null)
   const [names, setNames] = useState({})
   const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
   const [stopping, setStopping] = useState(null)
 
   const load = useCallback(async () => {
@@ -133,9 +134,14 @@ export default function PaperTrading({ onNavigate }) {
     const label = names[dep.strategy_id] || dep.strategy_id
     if (!window.confirm(`Stop paper trading "${label}"? The track record freezes where it is; this cannot be restarted in place.`)) return
     setStopping(dep.deployment_id)
+    setNotice('')
     try {
       await apiPost(`/api/paper/deployments/${encodeURIComponent(dep.deployment_id)}/stop`, {})
       await load()
+      // The success path used to be silent: load() re-renders, the chip flips
+      // ACTIVE→STOPPED and the Stop button unmounts, so a screen-reader user
+      // was left with no statement of what happened (4.1.3).
+      setNotice(`Paper trading stopped for ${label}. The track record is frozen at ${dep.days} trading day${dep.days === 1 ? '' : 's'}.`)
     } catch (e) {
       setError(e.message || 'Failed to stop deployment')
     } finally {
@@ -157,8 +163,15 @@ export default function PaperTrading({ onNavigate }) {
         </p>
       </div>
 
+      {/* Mounted unconditionally so the message it later receives is actually
+          announced — a live region created at the same moment as its content
+          is routinely missed. */}
+      <div role="status" aria-live="polite" className={notice ? 'caption' : 'sr-only'} style={notice ? { marginBottom: 14 } : undefined}>
+        {notice}
+      </div>
+
       {error && (
-        <div role="alert" className="card" style={{ padding: 14, marginBottom: 14, color: 'var(--danger, #b91c1c)' }}>
+        <div role="alert" className="card" style={{ padding: 14, marginBottom: 14, color: 'var(--negative)' }}>
           {error}
         </div>
       )}
@@ -228,7 +241,7 @@ export default function PaperTrading({ onNavigate }) {
                       dep.total_return > 0
                         ? 'var(--accent)'
                         : dep.total_return < 0
-                          ? 'var(--danger, #b91c1c)'
+                          ? 'var(--negative)'
                           : 'var(--text-2)',
                   }}
                 >

--- a/ui/src/components/RigorExplainer.jsx
+++ b/ui/src/components/RigorExplainer.jsx
@@ -12,7 +12,8 @@ export default function RigorExplainer() {
   return (
     <div style={{ maxWidth: 760, margin: '0 auto', padding: '32px 24px' }}>
       <div>
-        <h1 style={{ fontSize: '1.6rem', marginBottom: 8, fontFamily: 'var(--serif)' }}>
+        {/* id is the aria-labelledby target for the Library's modal wrapper. */}
+        <h1 id="rigor-explainer-title" style={{ fontSize: '1.6rem', marginBottom: 8, fontFamily: 'var(--serif)' }}>
           The Rigor Gate
         </h1>
         <p className="body" style={{ color: 'var(--text-2)', marginBottom: 20, lineHeight: 1.65 }}>

--- a/ui/src/components/RigorStrictnessControl.jsx
+++ b/ui/src/components/RigorStrictnessControl.jsx
@@ -90,14 +90,24 @@ export default function RigorStrictnessControl({ level, onChange }) {
         value={level}
         onChange={(e) => onChange(parseInt(e.target.value, 10))}
         aria-label="Rigor strictness level"
+        // The whole meaning of this control is the named rung, not the ordinal:
+        // without aria-valuetext a screen-reader user dragging 1 → 4 hears
+        // "4 of 5" and is never told they have moved below the Verified bar.
+        aria-valuetext={`${level} — ${current?.label ?? `Level ${level}`}`}
         style={{ width: '100%', accentColor: color, cursor: 'pointer' }}
       />
       <div className="flex justify-between mt-1" style={{ fontSize: '0.68rem', color: 'var(--text-4)' }}>
         {(ladder.levels || []).map((l) => (
-          <span
+          <button
             key={l.level}
+            type="button"
             onClick={() => onChange(l.level)}
+            aria-pressed={l.level === level}
             style={{
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              font: 'inherit',
               cursor: 'pointer',
               fontWeight: l.level === level ? 700 : 400,
               color: l.level === level ? color : 'var(--text-4)',
@@ -105,7 +115,7 @@ export default function RigorStrictnessControl({ level, onChange }) {
             title={l.description || l.label}
           >
             {l.label}
-          </span>
+          </button>
         ))}
       </div>
 
@@ -121,7 +131,11 @@ export default function RigorStrictnessControl({ level, onChange }) {
       )}
 
       {aboveBadge && (
-        <div className="info-box warning mt-4" style={{ fontSize: '0.82rem' }}>
+        <div
+          className="info-box warning mt-4"
+          role="status"
+          style={{ fontSize: '0.82rem' }}
+        >
           <strong>You're below the Archimedes Verified bar.</strong> At{' '}
           <strong>{current?.label}</strong> you accept strategies whose edge is less statistically
           certain than the Conservative standard. Size positions accordingly.

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import RigorExplainer from './RigorExplainer'
 import RigorStrictnessControl, { levelLabel } from './RigorStrictnessControl'
 import { useRigorStrictness, BADGE_LEVEL } from '../hooks/useRigorStrictness'
+import useDialogFocus from '../hooks/useDialogFocus'
 
 import { apiGet, apiPost, apiDelete } from '../api'
 
@@ -155,6 +156,7 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
 
   const sharpeCI = s.sharpe_ci_95 != null ? s.sharpe_ci_95 : null
   const driftFlag = s.drift_detected === true
+  const detailId = `lib-detail-${s.id}`
 
   useEffect(() => {
     if (isHighlighted && rowRef.current) {
@@ -171,8 +173,24 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
     <>
       <tr ref={rowRef} className="lib-row cursor-pointer" onClick={() => setOpen(o => !o)} style={rowStyle}>
         <td className="font-semibold">
-          <span className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3 h-3 mr-1.5 text-[var(--text-4)] flex-shrink-0 inline-block`} />
-          {s.paper_title}
+          {/* The disclosure is a real <button> in the first cell rather than a
+              bare onClick on the <tr>: App.css hides the keyboard-accessible
+              card list above 768px, so on desktop a keyboard-only user could
+              open no strategy's detail panel at all — and with it none of
+              "Open Passport", the exports, the source links or the DSR/PBO
+              numbers, which live only in the expanded row (2.1.1 / 4.1.2).
+              The row keeps its onClick as a mouse convenience; the button
+              stops propagation so one activation is one toggle. */}
+          <button
+            type="button"
+            className="lib-row-toggle"
+            aria-expanded={open}
+            aria-controls={detailId}
+            onClick={(e) => { e.stopPropagation(); setOpen(o => !o) }}
+          >
+            <span aria-hidden="true" className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3 h-3 mr-1.5 text-[var(--text-4)] flex-shrink-0 inline-block`} />
+            {s.paper_title}
+          </button>
           {(s.papers || []).length > 1 && (
             <span
               className="tag tag-accent"
@@ -192,14 +210,22 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
             >
               {statusLabel(s.status, s.passes_rigor_gate)}
             </span>
+            {/* These UnoCSS icons render as a CSS mask on an empty <span>, so
+                without role/aria-label they contribute nothing to the
+                accessible name tree and `title` on a bare span is not
+                reliably exposed — the rigor-gate verdict, the fact that
+                decides whether a strategy may be deployed, was sighted-only
+                (1.1.1). --warning replaces the hardcoded base-dark amber so the drift
+                triangle follows the light palette (2.15:1 on a white card
+                before; --warning is 5.12:1 there and 8.12:1 in dark). */}
             {s.passes_rigor_gate === true && (
-              <span className="i-lucide-check w-3.5 h-3.5 text-[var(--positive)]" title="Passes rigor gate" />
+              <span role="img" aria-label="Passes rigor gate" className="i-lucide-check w-3.5 h-3.5 text-[var(--positive)]" title="Passes rigor gate" />
             )}
             {s.passes_rigor_gate === false && (
-              <span className="i-lucide-x w-3.5 h-3.5 text-[var(--text-4)]" title="Does not pass rigor gate" />
+              <span role="img" aria-label="Does not pass rigor gate" className="i-lucide-x w-3.5 h-3.5 text-[var(--text-4)]" title="Does not pass rigor gate" />
             )}
             {driftFlag && (
-              <span className="i-lucide-alert-triangle w-3.5 h-3.5 text-[#f59e0b]" title="Drift detected" />
+              <span role="img" aria-label="Drift detected" className="i-lucide-alert-triangle w-3.5 h-3.5 text-[var(--warning)]" title="Drift detected" />
             )}
             <DeployabilityChip deploy={deploy} level={level} />
           </div>
@@ -220,9 +246,14 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
         <td className="mono positive" style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
         <td className="mono negative" style={{ textAlign: 'right' }}>
           {s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}
+          {/* Same defect: crossing the 0.5 overfitting threshold was signalled
+              only by the colour swap to --negative (1.4.1). */}
           {s.pbo_score != null && (
             <div style={{ fontSize: '0.68rem', color: s.pbo_score > 0.5 ? 'var(--negative)' : 'var(--text-4)' }}>
-              (PBO {s.pbo_score.toFixed(2)})
+              (PBO {s.pbo_score.toFixed(2)}{s.pbo_score > 0.5 && <span aria-hidden="true"> ⚠</span>})
+              {s.pbo_score > 0.5 && (
+                <span className="sr-only"> — above the 0.50 overfitting threshold</span>
+              )}
             </div>
           )}
         </td>
@@ -230,7 +261,7 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
         <td className="caption" style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>{years != null ? `${years.toFixed(1)} yrs` : '—'}</td>
       </tr>
       {open && (
-        <tr className="lib-row-detail">
+        <tr className="lib-row-detail" id={detailId}>
           <td colSpan={8} style={{ padding: '12px 18px', background: 'var(--glass)' }}>
             <StrategyDetailContent
               s={s}
@@ -331,11 +362,26 @@ function StrategyDetailContent({ s, onOpenRigorExplainer, onOpenPassport, extraA
           {s.paper_claimed_sharpe != null && (
             <div className="caption mt-2">
               Paper claim: <strong>{fmt(s.paper_claimed_sharpe)}</strong> · Backtest: <strong>{fmt(s.sharpe_ratio)}</strong>
+              {/* The pass/fail judgement against the 50% replication threshold
+                  used to live in the green/red class alone — "(43%)" and
+                  "(97%)" rendered identically to a colourblind reader (1.4.1).
+                  The ✓/✗ glyph carries it now, with the threshold spelled out
+                  for assistive tech; colour stays as reinforcement. */}
               {s.sharpe_ratio != null && (() => {
                 const ratio = s.paper_claimed_sharpe > 0.01 ? s.sharpe_ratio / s.paper_claimed_sharpe : null
+                const replicated = ratio != null && ratio >= 0.5
                 return (
-                  <span className={ratio != null && ratio >= 0.5 ? 'positive' : 'negative'} style={{ marginLeft: 6 }}>
+                  <span className={replicated ? 'positive' : 'negative'} style={{ marginLeft: 6 }}>
+                    <span aria-hidden="true">{replicated ? '✓' : '✗'}</span>{' '}
                     ({ratio != null ? `${(ratio * 100).toFixed(0)}%` : '—'})
+                    <span className="sr-only">
+                      {' '}
+                      {ratio == null
+                        ? 'replication ratio unavailable'
+                        : replicated
+                          ? 'of the paper claim — at or above the 50% replication threshold'
+                          : 'of the paper claim — below the 50% replication threshold'}
+                    </span>
                   </span>
                 )
               })()}
@@ -435,7 +481,7 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
         >
           {statusLabel(s.status, s.passes_rigor_gate)}
         </span>
-        {driftFlag && <span className="i-lucide-alert-triangle w-3.5 h-3.5 text-[#f59e0b]" title="Drift detected" />}
+        {driftFlag && <span role="img" aria-label="Drift detected" className="i-lucide-alert-triangle w-3.5 h-3.5 text-[var(--warning)]" title="Drift detected" />}
         <DeployabilityChip deploy={deploy} level={level} />
       </div>
       <div className="lib-card-stats">
@@ -594,6 +640,8 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
   // affordance. Single modal instance per page keeps state simple.
   const [rigorModalOpen, setRigorModalOpen] = useState(false)
   const openRigorExplainer = useCallback(() => setRigorModalOpen(true), [])
+  const closeRigorExplainer = useCallback(() => setRigorModalOpen(false), [])
+  const rigorModalRef = useDialogFocus(rigorModalOpen, { onEscape: closeRigorExplainer })
 
   // Deep-link to the strategy passport route — added in Phase 4.
   const openPassport = useCallback(
@@ -663,25 +711,36 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
         <RigorStrictnessControl level={level} onChange={setLevel} />
       </div>
 
-      <div className="strat-filter-bar mb-4">
-        <span
+      {/* Real <button>s, not click-only <span>s: activeTab defaults to
+          'generated', so a keyboard-only user was permanently pinned to that
+          one view and could never reach Examples or Published, and nothing in
+          the accessibility tree said which view was active (2.1.1 / 4.1.2).
+          Same shape Leaderboard.jsx:239 already uses. */}
+      <div className="strat-filter-bar mb-4" role="group" aria-label="Strategy view">
+        <button
+          type="button"
           className={`tag ${activeTab === 'generated' ? 'tag-accent' : 'tag-muted'}`}
+          aria-pressed={activeTab === 'generated'}
           onClick={() => setActiveTab('generated')}
         >
           Generated ({generated.length})
-        </span>
-        <span
+        </button>
+        <button
+          type="button"
           className={`tag ${activeTab === 'examples' ? 'tag-accent' : 'tag-muted'}`}
+          aria-pressed={activeTab === 'examples'}
           onClick={() => setActiveTab('examples')}
         >
           Examples ({examples.length})
-        </span>
-        <span
+        </button>
+        <button
+          type="button"
           className={`tag ${activeTab === 'published' ? 'tag-accent' : 'tag-muted'}`}
+          aria-pressed={activeTab === 'published'}
           onClick={() => setActiveTab('published')}
         >
           Published ({published.length})
-        </span>
+        </button>
       </div>
 
       {loadError && (
@@ -874,7 +933,12 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
 
       {/* EfficientFrontier + CorrelationMatrix removed (Issue #383) — synthetic RNG data */}
 
-      {/* Rigor Explainer modal (portal-rendered, page-level) */}
+      {/* Rigor Explainer modal (portal-rendered, page-level).
+          It had no dialog role, no accessible name, no Escape handler and no
+          focus management — and because the portal appends after #root its
+          Close button was the LAST focus stop in the document, so reaching it
+          meant tabbing the whole Library page underneath a blurred overlay
+          (2.4.3 / 4.1.2). */}
       {rigorModalOpen && createPortal(
         <div
           className="modal-overlay"
@@ -882,14 +946,19 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
           style={{ zIndex: 1000 }}
         >
           <div
+            ref={rigorModalRef}
+            tabIndex={-1}
             className="modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="rigor-explainer-title"
             onClick={e => e.stopPropagation()}
             style={{ maxWidth: 820, maxHeight: '85vh', overflowY: 'auto', width: '90vw' }}
           >
             <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
               <button
                 type="button"
-                onClick={() => setRigorModalOpen(false)}
+                onClick={closeRigorExplainer}
                 style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-4)' }}
                 aria-label="Close"
               >

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -840,7 +840,7 @@ function PaperDeployCard({ strategyId, user, onNavigate }) {
 				building the track record that carries to mainnet.
 			</p>
 			{error && (
-				<p className="caption" role="alert" style={{ color: "var(--danger, #b91c1c)", marginTop: 6 }}>
+				<p className="caption" role="alert" style={{ color: "var(--negative)", marginTop: 6 }}>
 					{error}
 				</p>
 			)}

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -9,6 +9,7 @@ import {
 } from '../config'
 import { sanitizeWalletName } from '../circle-wallet'
 import { linkConnectedWallet } from '../linked-wallets'
+import useDialogFocus from '../hooks/useDialogFocus'
 
 export default function WalletConnect({ address, displayName, onConnect, onDisconnect, onEditProfile }) {
   const [showModal, setShowModal] = useState(false)
@@ -20,6 +21,7 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
   const [balance, setBalance] = useState(null)
   const [walletName, setWalletName] = useState('')
   const menuRef = useRef(null)
+  const modalRef = useDialogFocus(showModal)
   const providerId = getConnectedProvider()
   const isPasskey = providerId === CIRCLE_PROVIDER_ID
 
@@ -281,10 +283,25 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
         Connect Wallet
       </button>
 
+      {/* The entry point to every on-chain action. It was portalled to <body>
+          with no dialog role, no accessible name and no focus move, so after
+          clicking "Connect Wallet" a screen-reader user's focus stayed on the
+          trigger behind the overlay and reaching the provider buttons meant
+          tabbing through the whole page behind it (2.4.3 / 4.1.2). Escape was
+          already handled above; the trap and focus restore come from the
+          shared hook. */}
       {showModal && createPortal(
         <div className="modal-overlay" onClick={() => setShowModal(false)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <h3>Connect Wallet</h3>
+          <div
+            ref={modalRef}
+            tabIndex={-1}
+            className="modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="wallet-modal-title"
+            onClick={e => e.stopPropagation()}
+          >
+            <h3 id="wallet-modal-title">Connect Wallet</h3>
             <p style={{ fontSize: '0.98rem', color: 'var(--text-2)', lineHeight: 1.55, marginBottom: 14 }}>
               {available.length > 1
                 ? 'Connect a Circle passkey wallet, or connect a browser wallet to interact with Arc Testnet contracts.'
@@ -394,7 +411,7 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
                               }}
                             />
                             {walletName.trim().length > 0 && sanitizeWalletName(walletName) === null && (
-                              <span style={{ fontSize: '0.7rem', color: 'var(--danger, #f87171)' }}>
+                              <span style={{ fontSize: '0.7rem', color: 'var(--negative)' }}>
                                 At least 5 characters — letters, numbers, or _ @ . : + -
                               </span>
                             )}

--- a/ui/src/hooks/useDialogFocus.js
+++ b/ui/src/hooks/useDialogFocus.js
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+// Focus management for portalled dialogs (WCAG 2.2 SC 2.4.3 Focus Order,
+// with 4.1.2 Name, Role, Value).
+//
+// Every dialog in this app is rendered with createPortal(…, document.body),
+// which appends it AFTER #root. Without the three behaviours below, that is a
+// concrete trap rather than a theoretical one:
+//
+//   1. Focus is never moved in, so a dialog that declares aria-modal="true"
+//      removes the rest of the page from the accessibility tree while the
+//      user's focus is still sitting in the part that just disappeared — the
+//      dialog is announced as nothing and cannot be found.
+//   2. Focus is never constrained, so Tab walks out of the dialog and into the
+//      dimmed page behind it, where the focus ring travels over blurred,
+//      non-actionable content. Because the portal appends last, reaching the
+//      dialog's own Close button by tabbing means traversing the entire page
+//      first.
+//   3. Focus is never restored, so dismissing the dialog drops focus to
+//      <body> and the keyboard user loses their place.
+//
+// Usage: attach the returned ref to the element that should contain focus
+// (the dialog panel, not the overlay), and pass `open`. The element needs
+// tabIndex={-1} so it can receive focus when it holds no focusable children
+// yet.
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+export default function useDialogFocus(open, { onEscape } = {}) {
+  const containerRef = useRef(null)
+  const openerRef = useRef(null)
+  // Kept in a ref so a caller passing an inline arrow doesn't re-run the
+  // effect (and re-steal focus) on every render.
+  const escapeRef = useRef(onEscape)
+  useEffect(() => { escapeRef.current = onEscape })
+
+  const focusablesIn = useCallback((node) => {
+    if (!node) return []
+    return Array.from(node.querySelectorAll(FOCUSABLE)).filter(
+      (el) => el.offsetParent !== null || el === document.activeElement,
+    )
+  }, [])
+
+  useEffect(() => {
+    if (!open) return undefined
+    const opener = document.activeElement
+    openerRef.current = opener instanceof HTMLElement ? opener : null
+
+    // Move focus in on the next frame: the panel's children mount with it, and
+    // for the spotlight tour the panel is repositioned after measurement.
+    const raf = requestAnimationFrame(() => {
+      const node = containerRef.current
+      if (!node) return
+      const first = focusablesIn(node)[0]
+      ;(first ?? node).focus?.()
+    })
+
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape' && escapeRef.current) {
+        escapeRef.current()
+        return
+      }
+      if (e.key !== 'Tab') return
+      const node = containerRef.current
+      if (!node) return
+      const items = focusablesIn(node)
+      if (items.length === 0) {
+        e.preventDefault()
+        node.focus?.()
+        return
+      }
+      const first = items[0]
+      const last = items[items.length - 1]
+      const active = document.activeElement
+      if (!node.contains(active)) {
+        e.preventDefault()
+        ;(e.shiftKey ? last : first).focus()
+        return
+      }
+      if (e.shiftKey && active === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => {
+      cancelAnimationFrame(raf)
+      document.removeEventListener('keydown', onKeyDown, true)
+      // Only take focus back if it is still inside (or was dropped by) the
+      // dialog — never yank it from somewhere the user deliberately moved to.
+      const active = document.activeElement
+      if (active === document.body || active == null) {
+        openerRef.current?.focus?.()
+      }
+    }
+  }, [open, focusablesIn])
+
+  return containerRef
+}

--- a/ui/src/hooks/useDialogFocus.js
+++ b/ui/src/hooks/useDialogFocus.js
@@ -22,7 +22,9 @@ import { useCallback, useEffect, useRef } from 'react'
 // Usage: attach the returned ref to the element that should contain focus
 // (the dialog panel, not the overlay), and pass `open`. The element needs
 // tabIndex={-1} so it can receive focus when it holds no focusable children
-// yet.
+// yet. Pass `refocusKey` when the dialog replaces its whole panel while
+// staying open, so focus follows the new panel instead of being left on
+// <body> (see the focus-move effect).
 const FOCUSABLE = [
   'a[href]',
   'button:not([disabled])',
@@ -32,7 +34,7 @@ const FOCUSABLE = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',')
 
-export default function useDialogFocus(open, { onEscape } = {}) {
+export default function useDialogFocus(open, { onEscape, refocusKey } = {}) {
   const containerRef = useRef(null)
   const openerRef = useRef(null)
   // Kept in a ref so a caller passing an inline arrow doesn't re-run the
@@ -47,19 +49,52 @@ export default function useDialogFocus(open, { onEscape } = {}) {
     )
   }, [])
 
+  // Opener capture and restore, keyed on `open` ALONE. Kept separate from the
+  // focus-move effect below so that re-running that effect (a `refocusKey`
+  // change, while the dialog is still open) can never overwrite the element we
+  // have to hand focus back to on close.
   useEffect(() => {
     if (!open) return undefined
     const opener = document.activeElement
     openerRef.current = opener instanceof HTMLElement ? opener : null
+    return () => {
+      // Only take focus back if it is still inside (or was dropped by) the
+      // dialog — never yank it from somewhere the user deliberately moved to.
+      const active = document.activeElement
+      if (active === document.body || active == null) {
+        openerRef.current?.focus?.()
+      }
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return undefined
 
     // Move focus in on the next frame: the panel's children mount with it, and
     // for the spotlight tour the panel is repositioned after measurement.
+    //
+    // `refocusKey` re-runs this for a dialog that swaps its whole panel while
+    // staying open. The tour is the live case: card 0 has no anchor and renders
+    // the centered-card branch, card 1 anchors to a nav button and renders the
+    // spotlight branch. React reconciles those two portals position-by-position,
+    // so the first "Continue" press destroys the subtree the button lives in and
+    // drops focus to <body> — the exact stranding this hook exists to prevent.
+    // Guarded on containment, so a panel that re-renders in place (card 1 → 2,
+    // both anchored) leaves the user's place alone instead of yanking them back
+    // to the first control on every press.
     const raf = requestAnimationFrame(() => {
       const node = containerRef.current
       if (!node) return
+      if (node.contains(document.activeElement)) return
       const first = focusablesIn(node)[0]
       ;(first ?? node).focus?.()
     })
+
+    return () => cancelAnimationFrame(raf)
+  }, [open, refocusKey, focusablesIn])
+
+  useEffect(() => {
+    if (!open) return undefined
 
     const onKeyDown = (e) => {
       if (e.key === 'Escape' && escapeRef.current) {
@@ -93,16 +128,7 @@ export default function useDialogFocus(open, { onEscape } = {}) {
     }
 
     document.addEventListener('keydown', onKeyDown, true)
-    return () => {
-      cancelAnimationFrame(raf)
-      document.removeEventListener('keydown', onKeyDown, true)
-      // Only take focus back if it is still inside (or was dropped by) the
-      // dialog — never yank it from somewhere the user deliberately moved to.
-      const active = document.activeElement
-      if (active === document.body || active == null) {
-        openerRef.current?.focus?.()
-      }
-    }
+    return () => document.removeEventListener('keydown', onKeyDown, true)
   }, [open, focusablesIn])
 
   return containerRef

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -1,0 +1,358 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+// WCAG 2.2 AA regression guards.
+//
+// Same shape as app-visuals.test.js / public-visuals.test.js: readFileSync +
+// regex pins on the source, no DOM. These pin the specific accessibility
+// properties that a later refactor is most likely to delete by accident —
+// a token value, a live-region attribute, a real <button> where a click-only
+// <span> used to be. Every assertion here was confirmed to FAIL against the
+// pre-fix tree.
+
+const src = (p) => readFileSync(new URL(`../src/${p}`, import.meta.url), "utf8");
+
+const css = src("App.css");
+const app = src("App.jsx");
+const authPage = src("components/AuthPage.jsx");
+const corpusExplorer = src("components/CorpusExplorer.jsx");
+const corpusKg = src("components/CorpusKG.jsx");
+const customSelect = src("components/CustomSelect.jsx");
+const explore = src("components/Explore.jsx");
+const generate = src("components/Generate.jsx");
+const generationStatus = src("components/GenerationStatus.jsx");
+const generationStream = src("components/GenerationStream.jsx");
+const layout = src("components/Layout.jsx");
+const onboardingTour = src("components/OnboardingTour.jsx");
+const paperTrading = src("components/PaperTrading.jsx");
+const strategies = src("components/Strategies.jsx");
+const walletConnect = src("components/WalletConnect.jsx");
+
+// ── 1.4.3 Contrast (Minimum) ──────────────────────────────────────────────
+//
+// The auth screen renders outside both .app-site and .public-site, so it is
+// the only surface left on the base palette — these three token values are
+// what make its labels, its password rules and its links readable. The public
+// --text-4 carries Architecture's error/loading copy. Ratios are against
+// --surface-2 in the matching theme.
+
+test("base and public palettes keep muted text above the 4.5:1 floor", () => {
+	// #71717a was 3.73:1 on #16161a (dark) and 4.01:1 on #eceae2 (light).
+	assert.match(css, /:root\s*\{[\s\S]*?--text-3:\s*#8a8a93;/);
+	assert.match(
+		css,
+		/:root\[data-theme="light"\]\s*\{[\s\S]*?--text-3:\s*#62626b;/,
+	);
+	// #9c6b0b was 3.86:1 as link text on the light card.
+	assert.match(
+		css,
+		/:root\[data-theme="light"\]\s*\{[\s\S]*?--accent:\s*#8a5f0a;/,
+	);
+	assert.match(
+		css,
+		/:root\[data-theme="light"\]\s*\{[\s\S]*?--accent-rgb:\s*138,\s*95,\s*10;/,
+	);
+	// Public --text-4 was #657a73 = 3.46:1 on the slate card.
+	assert.match(css, /\.public-site\s*\{[\s\S]*?--text-4:\s*#7d9189;/);
+	// --text-4 is a border/decoration token on the base palette (it is #3f3f46
+	// there = 1.73:1) and must never be used as text on the auth screen.
+	assert.doesNotMatch(authPage, /text-\[var\(--text-4\)\]/);
+});
+
+test("chart axis labels clear 4.5:1 on every card they are drawn on", () => {
+	// Axis ticks are real 8-10px <text>. Neither shell overrides these tokens
+	// and the asset modal portals outside both, so the BASE values are the
+	// ones that must hold. 0.42 / 0.5 gave 3.88:1 and 3.74:1.
+	assert.match(css, /--chart-label:\s*rgba\(255,\s*255,\s*255,\s*0\.52\);/);
+	assert.match(css, /--chart-label:\s*rgba\(9,\s*9,\s*11,\s*0\.6\);/);
+});
+
+test("error text uses the defined --negative, never an undefined --danger", () => {
+	// `--danger` is not defined in any stylesheet, so `var(--danger, #b91c1c)`
+	// always resolved to the literal — 2.71:1 on the app card, for a
+	// role="alert" message.
+	const files = [];
+	const walk = (dir) => {
+		for (const entry of readdirSync(dir)) {
+			const full = join(dir, entry);
+			if (statSync(full).isDirectory()) walk(full);
+			else if (/\.jsx?$/.test(entry)) files.push(full);
+		}
+	};
+	walk(new URL("../src", import.meta.url).pathname);
+	const offenders = files.filter((f) =>
+		readFileSync(f, "utf8").includes("--danger"),
+	);
+	assert.deepEqual(offenders, []);
+	assert.match(css, /--negative:\s*var\(--app-risk\);/);
+});
+
+// ── 1.4.11 Non-text Contrast / 2.4.7 Focus Visible ────────────────────────
+
+test("form fields carry a 3:1 boundary token in both shells", () => {
+	// Fields are filled with the canvas inside surface cards, so the fill gives
+	// no cue (1.08:1) and --glass-border was 1.22-1.45:1.
+	assert.match(css, /:root\s*\{[\s\S]*?--field-border:\s*rgba\(255,\s*255,\s*255,\s*0\.35\);/);
+	assert.match(
+		css,
+		/:root\[data-theme="light"\]\s*\{[\s\S]*?--field-border:\s*rgba\(9,\s*9,\s*11,\s*0\.5\);/,
+	);
+	assert.match(
+		css,
+		/\.app-site\s*\{[\s\S]*?--field-border:\s*rgba\(225,\s*230,\s*222,\s*0\.45\);/,
+	);
+	assert.match(
+		css,
+		/:root\[data-theme="light"\] \.app-site\s*\{[\s\S]*?--field-border:\s*rgba\(8,\s*18,\s*24,\s*0\.5\);/,
+	);
+	assert.match(
+		css,
+		/^input,\nselect,\ntextarea \{[^}]*border: 1px solid var\(--field-border\);/m,
+	);
+	assert.match(
+		css,
+		/\.app-site \.chat-input,\n\.app-site input,\n\.app-site select,\n\.app-site textarea \{[^}]*border-color: var\(--field-border\);/,
+	);
+});
+
+test("no rule strips the focus indicator from a control", () => {
+	// `.app-site input:focus { outline: none }` out-specified
+	// `.app-site :focus-visible` and deleted the 3px ring from every text
+	// field in the shell; the base input rule did the same on the auth screen,
+	// which has no :focus-visible rule of its own to fall back to.
+	for (const block of [
+		/^input,\nselect,\ntextarea \{[^}]*\}/m,
+		/\.app-site \.chat-input:focus,[\s\S]*?\}/,
+		/^\.cs-trigger \{[^}]*\}/m,
+		/^\.catalog-search:focus,\n\.kg-search:focus \{[^}]*\}/m,
+	]) {
+		const match = css.match(block);
+		assert.ok(match, `rule not found: ${block}`);
+		assert.doesNotMatch(match[0], /outline:\s*none/);
+	}
+	assert.match(css, /\.app-site :focus-visible \{\n\toutline: 3px solid/);
+});
+
+// ── 2.4.11 Focus Not Obscured / 1.4.4 Resize Text ─────────────────────────
+
+test("sticky topbar cannot cover a focused control", () => {
+	// 56px bar + 3px outline + 3px offset.
+	assert.match(css, /^html \{[^}]*scroll-padding-top: 64px;/m);
+});
+
+test("corpus category labels wrap instead of clipping under zoom", () => {
+	const rule = css.match(/^\.bar-label,\n\.year-label \{[^}]*\}/m);
+	assert.ok(rule);
+	assert.doesNotMatch(rule[0], /width:\s*140px/);
+	assert.doesNotMatch(rule[0], /white-space:\s*nowrap/);
+	assert.match(rule[0], /flex: 0 1 140px/);
+});
+
+// ── 2.4.1 Bypass Blocks / 2.4.2 Page Titled ───────────────────────────────
+
+test("the authenticated shell ships a skip link with a focusable target", () => {
+	assert.match(layout, /className="app-skip-link" href="#app-content"/);
+	assert.match(layout, /id="app-content"\s+tabIndex=\{-1\}/);
+	// It cannot borrow .public-skip-link's colours — --public-paper /
+	// --public-abyss are undefined inside .app-site.
+	assert.match(css, /\.app-skip-link \{\n\tbackground: var\(--text-1\);/);
+});
+
+test("a failed deep link does not share the landing page's title", () => {
+	assert.match(app, /'not-found': 'Page not found · Archimedes'/);
+	assert.match(app, /route\.kind === 'not-found' \? 'not-found' : route\.page/);
+});
+
+// ── 2.1.1 Keyboard / 4.1.2 Name, Role, Value ──────────────────────────────
+
+test("filter and toggle pills are real buttons with a pressed state", () => {
+	// Library tabs: activeTab defaults to 'generated', so click-only spans
+	// pinned a keyboard user to that one view forever.
+	assert.match(
+		strategies,
+		/<button\n\s+type="button"\n\s+className=\{`tag \$\{activeTab === 'generated'[\s\S]{0,120}aria-pressed=\{activeTab === 'generated'\}/,
+	);
+	assert.match(strategies, /aria-pressed=\{activeTab === 'examples'\}/);
+	assert.match(strategies, /aria-pressed=\{activeTab === 'published'\}/);
+	// Explore asset-class filter.
+	assert.match(explore, /aria-pressed=\{filterClass === c\}/);
+	// Generate asset universe picker.
+	assert.match(generate, /aria-pressed=\{selectedAssets\.includes\(a\)\}/);
+	// None of the three may regress to a click-only span.
+	for (const [name, source] of [
+		["Strategies", strategies],
+		["Explore", explore],
+		["Generate", generate],
+	]) {
+		assert.doesNotMatch(
+			source,
+			/<span[^>]*className=\{`tag[\s\S]{0,200}?onClick=/,
+			`${name} still has a click-only tag span`,
+		);
+	}
+	// The pill reset that lets a <button> render like the <span> it replaced.
+	assert.match(css, /button:where\(\.tag\) \{/);
+});
+
+test("row-level click targets expose a real control", () => {
+	// Library: App.css hides the keyboard-accessible card list above 768px, so
+	// the desktop table row was the only disclosure and it had no role, no tab
+	// stop and no aria-expanded.
+	assert.match(strategies, /className="lib-row-toggle"[\s\S]{0,120}aria-expanded=\{open\}/);
+	assert.match(strategies, /aria-controls=\{detailId\}/);
+	assert.match(strategies, /className="lib-row-detail" id=\{detailId\}/);
+	// Corpus catalog: clicking the row was the only way into a paper.
+	assert.match(
+		corpusExplorer,
+		/className="catalog-title-btn"[\s\S]{0,140}openPaper\(p\.arxiv_id\)/,
+	);
+	// Recent Generations: role="button" on a <tr> destroys the cells.
+	assert.doesNotMatch(generationStatus, /<tr[\s\S]{0,200}role="button"/);
+	assert.match(generationStatus, /<caption className="sr-only">Recent generations<\/caption>/);
+	assert.match(generationStatus, /<th scope="col"/);
+});
+
+test("shared select and its call site expose an accessible name", () => {
+	assert.match(customSelect, /aria-label=\{ariaLabel\}/);
+	assert.match(customSelect, /aria-controls=\{open \? listboxId : undefined\}/);
+	assert.match(customSelect, /aria-activedescendant=\{/);
+	assert.match(corpusExplorer, /ariaLabel="Filter papers by category"/);
+});
+
+test("sidebar navigation states where the user currently is", () => {
+	assert.match(layout, /<nav aria-label="Main">/);
+	assert.match(layout, /aria-current=\{isCurrent \? "page" : undefined\}/);
+	// aria-label survives only for the collapsed rail, where .nav-label is
+	// display:none — on the expanded rail it silently overrode the visible
+	// label (2.5.3).
+	assert.match(layout, /aria-label=\{sidebarCollapsed \? item\.label : undefined\}/);
+});
+
+// ── 1.1.1 Non-text Content / 1.4.1 Use of Color ───────────────────────────
+
+test("informative icons and charts carry a text alternative", () => {
+	// UnoCSS icons are a CSS mask on an empty <span>: no role, no name, and
+	// `title` on a bare span is not reliably exposed.
+	assert.match(strategies, /role="img" aria-label="Passes rigor gate"/);
+	assert.match(strategies, /role="img" aria-label="Does not pass rigor gate"/);
+	assert.match(strategies, /role="img" aria-label="Drift detected"/);
+	// The drift triangle was hardcoded to base-dark amber: 2.15:1 on a white
+	// card in the light theme.
+	assert.doesNotMatch(strategies, /#f59e0b/);
+	// The knowledge graph is a 500px informative SVG that had no role at all.
+	assert.match(
+		corpusKg,
+		/role="img"\n\s+aria-label=\{`Topic cluster graph: \$\{entities\.length\} entities, \$\{relations\.length\} relations`\}/,
+	);
+});
+
+test("threshold verdicts do not rely on colour alone", () => {
+	// "(43%)" and "(97%)" rendered identically apart from green/red.
+	assert.match(strategies, /replicated \? '✓' : '✗'/);
+	assert.match(strategies, /below the 50% replication threshold/);
+	assert.match(strategies, /above the 0\.50 overfitting threshold/);
+	assert.match(css, /^\.sr-only \{/m);
+});
+
+// ── 2.4.3 Focus Order / 2.5.8 Target Size / 2.5.7 Dragging ────────────────
+
+test("portalled dialogs move, trap and restore focus", () => {
+	for (const [name, source] of [
+		["OnboardingTour", onboardingTour],
+		["Strategies", strategies],
+		["WalletConnect", walletConnect],
+	]) {
+		assert.match(
+			source,
+			/import useDialogFocus from '\.\.\/hooks\/useDialogFocus'/,
+			`${name} does not use the shared dialog-focus hook`,
+		);
+	}
+	// The two dialogs that had no dialog semantics at all.
+	assert.match(
+		walletConnect,
+		/role="dialog"\n\s+aria-modal="true"\n\s+aria-labelledby="wallet-modal-title"/,
+	);
+	assert.match(walletConnect, /<h3 id="wallet-modal-title">Connect Wallet<\/h3>/);
+	assert.match(
+		strategies,
+		/role="dialog"\n\s+aria-modal="true"\n\s+aria-labelledby="rigor-explainer-title"/,
+	);
+	// Escape had no handler on the rigor explainer.
+	assert.match(strategies, /useDialogFocus\(rigorModalOpen, \{ onEscape: closeRigorExplainer \}\)/);
+});
+
+test("tour pagination dots meet the 24px minimum target", () => {
+	// 8px dots with a 6px gap: the 24px targets centred on adjacent dots
+	// overlapped, so the spacing exception did not apply either.
+	assert.match(onboardingTour, /className="w-6 h-6 flex items-center justify-center border-none cursor-pointer"/);
+	// role="tab" promised arrow-key navigation and tabpanels this component
+	// never implemented.
+	assert.doesNotMatch(onboardingTour, /role="tablist"/);
+	assert.doesNotMatch(onboardingTour, /role="tab"/);
+});
+
+test("knowledge-graph pan and zoom have single-pointer alternatives", () => {
+	// Pan was drag-only and zoom wheel-only; "Reset view" only ever returns to
+	// the origin.
+	assert.match(corpusKg, /aria-label="Graph view controls"/);
+	for (const label of ["Zoom in", "Zoom out", "Pan left", "Pan right", "Pan up", "Pan down"]) {
+		assert.match(corpusKg, new RegExp(`aria-label="${label}"`), `missing ${label}`);
+	}
+});
+
+// ── 3.3.x Labels, Instructions, Error Identification ──────────────────────
+
+test("the generate form's fields are programmatically labelled", () => {
+	assert.match(generate, /<label className="label mb-1 block" htmlFor="generate-brief">/);
+	assert.match(generate, /id="generate-brief"\s+aria-describedby="generate-brief-help"/);
+	assert.match(generate, /htmlFor="generate-strategy-name"/);
+	assert.match(generate, /aria-label="Search assets"/);
+});
+
+test("the corpus search field has a name that survives typing", () => {
+	assert.match(corpusExplorer, /aria-label="Search papers"/);
+});
+
+test("sign-up states why the confirm field is invalid and the button disabled", () => {
+	assert.match(authPage, /id="password-rules"/);
+	assert.match(authPage, /id="confirm-mismatch"/);
+	assert.match(
+		authPage,
+		/aria-describedby=\{showMismatch \? 'password-rules confirm-mismatch' : 'password-rules'\}/,
+	);
+});
+
+test("unlinking a wallet is confirmed before it happens", () => {
+	// Single unconfirmed click deleted the account↔wallet binding with no undo.
+	assert.match(
+		src("components/AccountSettings.jsx"),
+		/window\.confirm\(\n\s+`Unlink \$\{label\}\?/,
+	);
+});
+
+// ── 4.1.3 Status Messages ─────────────────────────────────────────────────
+
+test("generation outcomes are announced, not just painted", () => {
+	// One slot carried start failures, the quote-not-ready message, both
+	// payment banners and the settlement receipt, with no role or aria-live.
+	assert.match(
+		generate,
+		/className="generate-submit-status"\s+role="status"\s+aria-live="polite"\s+aria-atomic="true"/,
+	);
+	// The stream is a minutes-long append-only feed.
+	assert.match(
+		generationStream,
+		/role="log"\n\s+aria-live="polite"\n\s+aria-relevant="additions text"\n\s+aria-label="Generation events"/,
+	);
+	assert.match(generationStream, /role=\{terminal === 'error' \? 'alert' : 'status'\}/);
+});
+
+test("stopping a paper deployment says so", () => {
+	// On success the row's chip silently flipped and the Stop button unmounted.
+	assert.match(paperTrading, /<div role="status" aria-live="polite"/);
+	assert.match(paperTrading, /setNotice\(`Paper trading stopped for \$\{label\}\./);
+	assert.match(corpusExplorer, /className="catalog-results-info" role="status"/);
+});

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -158,6 +158,29 @@ test("the authenticated shell ships a skip link with a focusable target", () => 
 	// It cannot borrow .public-skip-link's colours — --public-paper /
 	// --public-abyss are undefined inside .app-site.
 	assert.match(css, /\.app-skip-link \{\n\tbackground: var\(--text-1\);/);
+	// ...and it must out-stack the sidebar. `.sidebar` is position: fixed,
+	// inset: 0 auto 0 0, opaque, z-index: 100, and comes LATER in the DOM than
+	// the link, so at the shared block's z-index: 100 the sidebar won the paint
+	// order and covered the link's entire focused box (top 10px / left 12px,
+	// inside the 232px rail). Verified in a browser against the built CSS:
+	// elementFromPoint at all three corners returned DIV.sidebar-brand.
+	// `.app-skip-link` is declared twice — once in the shared geometry block
+	// alongside `.public-skip-link`, once on its own — at equal specificity, so
+	// the EFFECTIVE z-index is the last one declared. Read it that way rather
+	// than matching the first rule that mentions the class.
+	const zDecls = [
+		...css.matchAll(/([^{}]*\.app-skip-link[^{}]*)\{([^}]*)\}/g),
+	].flatMap((rule) =>
+		[...rule[2].matchAll(/z-index:\s*(\d+);/g)].map((m) => Number(m[1])),
+	);
+	assert.ok(zDecls.length > 0, ".app-skip-link declares no z-index");
+	const effectiveZ = zDecls[zDecls.length - 1];
+	const sidebar = css.match(/^\.sidebar \{[^}]*\}/m);
+	const sidebarZ = Number(sidebar[0].match(/z-index:\s*(\d+);/)[1]);
+	assert.ok(
+		effectiveZ > sidebarZ,
+		`skip link z-index ${effectiveZ} must beat .sidebar's ${sidebarZ}`,
+	);
 });
 
 test("a failed deep link does not share the landing page's title", () => {
@@ -347,7 +370,19 @@ test("generation outcomes are announced, not just painted", () => {
 		generationStream,
 		/role="log"\n\s+aria-live="polite"\n\s+aria-relevant="additions text"\n\s+aria-label="Generation events"/,
 	);
-	assert.match(generationStream, /role=\{terminal === 'error' \? 'alert' : 'status'\}/);
+	// The live region must hold ONLY the terminal outcome. `events.length`
+	// increments on every SSE frame, so while the running-state counter sat
+	// inside the region a screen reader re-read the job id and the whole block
+	// once per event for the length of the run.
+	assert.match(
+		generationStream,
+		/role="status"\n\s+aria-live=\{terminal === 'error' \? 'assertive' : 'polite'\}/,
+	);
+	const liveRegion = generationStream.match(
+		/<div\n\s+role="status"\n\s+aria-live=\{terminal[\s\S]*?\n {10}<\/div>/,
+	);
+	assert.ok(liveRegion, "GenerationStream live region not found");
+	assert.doesNotMatch(liveRegion[0], /events\.length/);
 });
 
 test("stopping a paper deployment says so", () => {


### PR DESCRIPTION
## Summary

Implements the findings of a three-lens WCAG 2.2 Level AA audit of the shipped UI (issue #1311): ~31 confirmed defects fixed across ten commits, each scoped to one concern. **This PR makes no conformance claim** — it is a fixed-defect-list pass, independently verified; the residual gaps and the never-assessed non-visual half of the standard are tracked in #1318.

Closes #1311

## What changed, by theme

- **Design tokens & shared rules** (1.4.3, 1.4.11): text tokens raised to ≥4.5:1 on their real backgrounds in *both* theme blocks; form-control boundaries raised to ≥3:1 (`--field-border`); the undefined `var(--danger, …)` fallback (unreadable #b91c1c on dark cards) replaced with the palette's real `--negative` at every occurrence; chart axis ink brought above 4.5:1.
- **Focus & dialogs** (2.4.3, 2.4.7, 2.4.11, 4.1.2): new `useDialogFocus` hook — moves focus in, traps Tab, restores to the opener — applied to every portalled dialog; `outline: none` removals restore the UA focus ring; skip link added; scroll-padding clears the fixed topbar.
- **Keyboard operability** (2.1.1, 2.5.8): clickable rows/cards in Library, Corpus, and Explore became real buttons or gained key handlers; icon-only controls meet the 24px target minimum; the KG controls and strictness slider gained non-pointer alternatives.
- **Names, labels, announcements** (1.1.1, 3.3.1–3.3.3, 4.1.3): rigor-gate verdict icons carry accessible names; the Generate form is labeled and its submission outcome announced; sign-up errors are stated in text (not color/dimming alone) with the unmet-password-rule text readable; destructive actions (stop paper trading, account) announce their result via live regions.
- **Accessible authentication** (3.3.8): sign-in/sign-up verified free of paste-blocking and cognitive tests; autocomplete attributes present.

## Guards

`ui/test/a11y.test.js` (393 lines) pins the regression-prone fixes as static source checks — each was demonstrated to FAIL against the pre-fix code before landing (stash-run-unstash transcripts in the workflow record). Two source comments were reworded because the guards correctly trip on forbidden literals even in prose.

## Verification (re-run on the rebased branch by the session lead)

```
ui: node --test     85/85  (incl. the new a11y guard suite)
ui: npm run lint    clean
ui: npm run build   clean, both flag states
backend: test_breadcrumbs.py  5/5
grep -rn "var(--danger" ui/src/  →  0
```

Independent verification also included a built-CSS browser harness check of both themes (sign-up screen, app-shell probe). **Not assessed** (see #1318): screen-reader passes, 200%/400% reflow, text-spacing overrides, motion review, automated axe/Lighthouse — the repo has no DOM-rendering test framework, so behavioural claims rest on code tracing plus the CSS harness.
