### PR TITLE
F2/F3: live interpreter gets position-state semantics + rebalance cadence, parity-pinned !minor

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -84,7 +84,35 @@ RUNNER_NAME = "agent_runner"
 LEASE_TTL_MS = int(os.getenv("AGENT_LEASE_TTL_MS", "180000"))  # 3 min
 LEASE_RENEW_INTERVAL_S = int(os.getenv("AGENT_LEASE_RENEW_S", "50"))  # ~ttl/3
 
-# Drift threshold for rebalance trigger
+# Drift threshold for rebalance trigger.
+#
+# CADENCE GATE FIRST, DRIFT THRESHOLD WITHIN THE OPEN WINDOW (divergence audit
+# F3). These are two different gates on two different objects and they compose
+# in this order:
+#
+#   1. CADENCE, per strategy, upstream of here. A DSL strategy declares
+#      ``rebalance_frequency`` (daily / weekly / monthly). The live evaluator
+#      now honours it — strategy_signal_evaluator._replay_position_state only
+#      re-decides entry/exit on cadence-eligible bars and HOLDS the position
+#      through the rest, mirroring DSLStrategy._should_rebalance in the
+#      backtest. A monthly strategy therefore emits the SAME per-asset weight on
+#      every one of the ~288 ticks a day between its decision bars, so it
+#      contributes no new drift here. Before that fix the live path never read
+#      ``rebalance_frequency`` at all and a monthly spec was effectively re-run
+#      every tick, with _DRIFT_THRESHOLD as the only thing standing between it
+#      and a trade.
+#
+#      Note the gate holds the strategy's VOTE rather than skipping it:
+#      aggregate_signals averages every bound strategy's weight, so a strategy
+#      that simply stopped emitting on off-cadence ticks would silently change
+#      every OTHER co-bound strategy's effective allocation in the vault.
+#
+#   2. DRIFT, per vault, below. Once the vault's aggregated target weights are
+#      built, a leg only trades when it has drifted at least this far from the
+#      target. This is a cost/no-op filter on an ALREADY cadence-gated target —
+#      it does not, and must not, decide WHEN a strategy is allowed to change
+#      its mind. A vault binding a daily strategy alongside a monthly one still
+#      rebalances daily, because the daily strategy is due; that is correct.
 _DRIFT_THRESHOLD = 0.15
 
 # The exogenous market regime is detected each tick by VixRegimeDetector
@@ -1183,7 +1211,13 @@ class StrategyRunner:
         portfolio: Portfolio,
         targets: list[TargetAllocation],
     ) -> list[TradeOrder]:
-        """Diff current portfolio vs target weights → trade list."""
+        """Diff current portfolio vs target weights → trade list.
+
+        Second of the two gates described at ``_DRIFT_THRESHOLD``: the targets
+        arriving here are already cadence-gated per strategy by the evaluator, so
+        this is purely a cost filter on how far the vault has drifted — never the
+        thing that decides when a strategy may change its mind.
+        """
         current_weights = portfolio.weights_dict
         target_map = {t.symbol: t for t in targets}
 

--- a/backend/archimedes/services/dsl_to_backtrader.py
+++ b/backend/archimedes/services/dsl_to_backtrader.py
@@ -88,6 +88,26 @@ def _make_indicator(
     raise DSLError(f"unsupported indicator: {name}")
 
 
+# ── Rebalance cadence ─────────────────────────────────────────────────
+
+# Trading-day proxy for each cadence in strategy_dsl.REBALANCE_FREQUENCIES.
+# Deliberately module-level rather than a closure method: the LIVE evaluator
+# replays this exact gate (strategy_signal_evaluator._replay_position_state,
+# divergence audit F3), so cadence has ONE definition and the two interpreters
+# of the DSL cannot drift apart on it the way they drifted on momentum (F1) and
+# RSI (F5). test_interpreter_parity.py pins the pair per-bar.
+_REBALANCE_PERIOD_BARS: dict[str, int] = {"daily": 1, "weekly": 5, "monthly": 21}
+
+
+def rebalance_period_bars(frequency: str) -> int:
+    """Bars between rebalances for a declared cadence.
+
+    Unknown/daily → 1 (every bar). Trading-day proxies, NOT calendar months:
+    weekly = 5 bars, monthly = 21 bars.
+    """
+    return _REBALANCE_PERIOD_BARS.get(frequency, 1)
+
+
 # ── Strategy factory ──────────────────────────────────────────────────
 
 
@@ -150,12 +170,12 @@ def interpret_spec(spec: StrategySpec) -> type[bt.Strategy]:
 
         @staticmethod
         def _rebalance_period() -> int:
-            """Bars between rebalances for the spec's rebalance frequency."""
-            if spec.rebalance_frequency == "weekly":
-                return 5
-            if spec.rebalance_frequency == "monthly":
-                return 21
-            return 1
+            """Bars between rebalances for the spec's rebalance frequency.
+
+            Delegates to the module-level ``rebalance_period_bars`` so the live
+            evaluator's cadence replay reads the SAME table (audit F3).
+            """
+            return rebalance_period_bars(spec.rebalance_frequency)
 
         def _should_rebalance(self) -> bool:
             if spec.rebalance_frequency == "daily":

--- a/backend/archimedes/services/strategy_signal_evaluator.py
+++ b/backend/archimedes/services/strategy_signal_evaluator.py
@@ -1007,6 +1007,211 @@ def _compute_indicator_value(name: str, period: int, prices: pd.Series) -> float
     raise DSLError(f"unsupported indicator: {name}")
 
 
+def _rsi_wilder_series(prices: pd.Series, period: int) -> pd.Series:
+    """Per-bar Wilder RSI — the whole-series twin of ``_compute_indicator_value``.
+
+    Same seed (plain mean of the first ``period`` moves) and same recursion
+    (``avg = (avg*(period-1) + current) / period``), just carried forward once
+    instead of re-derived per prefix, so value[i] == the scalar the prefix
+    ``prices.iloc[:i+1]`` would produce. NaN before the seed is complete.
+    """
+    n = len(prices)
+    out = np.full(n, np.nan, dtype=float)
+    if period < 1 or n < 2:
+        return pd.Series(out, index=prices.index)
+
+    raw = prices.to_numpy(dtype=float)
+    diff = np.diff(raw)  # diff[k] is the move INTO price position k + 1
+    # ``_compute_indicator_value`` drops NaN moves before seeding; mirror that
+    # by carrying the kept moves' positions so a gap in the series shifts both
+    # implementations identically instead of only one of them.
+    kept = np.flatnonzero(~np.isnan(diff))
+    if len(kept) < period:
+        return pd.Series(out, index=prices.index)
+
+    gains = np.where(diff > 0, diff, 0.0)[kept]
+    losses = np.where(diff < 0, -diff, 0.0)[kept]
+    avg_gain = float(gains[:period].mean())
+    avg_loss = float(losses[:period].mean())
+
+    def _rsi(ag: float, al: float) -> float:
+        if al == 0:
+            return 100.0
+        return float(100.0 - (100.0 / (1.0 + ag / al)))
+
+    out[kept[period - 1] + 1] = _rsi(avg_gain, avg_loss)
+    for j in range(period, len(kept)):
+        avg_gain = (avg_gain * (period - 1) + gains[j]) / period
+        avg_loss = (avg_loss * (period - 1) + losses[j]) / period
+        out[kept[j] + 1] = _rsi(avg_gain, avg_loss)
+    return pd.Series(out, index=prices.index)
+
+
+def _compute_indicator_series(name: str, period: int, prices: pd.Series) -> pd.Series:
+    """Per-bar values of one indicator over the WHOLE series.
+
+    The vectorised twin of ``_compute_indicator_value``: element *i* equals
+    ``_compute_indicator_value(name, period, prices.iloc[: i + 1])`` for every
+    bar the scalar form can compute, pinned per-bar by
+    ``test_interpreter_parity.test_indicator_series_matches_per_prefix_value``.
+    Existing to make the position-state replay (audit F2) O(bars) instead of
+    O(bars²) — a per-prefix rescan of Wilder RSI on a 2-year window is ~125k
+    Python iterations per (strategy, asset) per tick.
+
+    NaN in the warm-up region is deliberate and load-bearing: the backtest reads
+    an unready indicator as NaN too (``DSLStrategy._bar_values``'s IndexError
+    guard), and NaN comparisons are False in ``_eval_condition`` — so a warm-up
+    bar decides "no entry / no exit" on BOTH sides rather than diverging.
+    """
+    if name == "sma":
+        return prices.rolling(period).mean().astype(float)
+    if name == "ema":
+        return prices.ewm(span=period, adjust=False).mean().astype(float)
+    if name == "rsi":
+        return _rsi_wilder_series(prices, period)
+    if name == "momentum":
+        return (prices / prices.shift(period) - 1.0).astype(float)
+    if name == "realized_vol":
+        # rolling().std() is NaN until a full window of returns exists, where the
+        # scalar form's .tail(period).std() silently computes on a short window.
+        # The replay only ever reads bars at/after max_period, so the two agree
+        # everywhere the replay looks; the difference is confined to the warm-up
+        # region the insufficient-data guard already refuses to trade on.
+        return (prices.pct_change().rolling(period).std() * np.sqrt(252)).astype(float)
+    raise DSLError(f"unsupported indicator: {name}")
+
+
+# ─── Position-state replay — the live FSM (audit F2 + F3) ─────────
+#
+# THE DIVERGENCE THIS EXISTS FOR. The backtest is a position FSM
+# (dsl_to_backtrader.DSLStrategy.next): entry is only tested while FLAT, exit is
+# only tested while IN POSITION, and a bar where neither branch fires is an
+# implicit HOLD. The live evaluator used to be stateless — ``entry AND NOT
+# exit``, recomputed from scratch each tick with no memory — so an RSI 30/70
+# band strategy was long in the backtest and in cash live on the very same bar
+# (audit F2): the whole dead zone between the bands (30 <= rsi <= 70), where
+# entry is false AND exit is false, collapsed to FLAT live.
+#
+# On top of that the live path never read ``rebalance_frequency`` at all (audit
+# F3), so a spec declaring monthly cadence was re-decided on every one of the
+# ~288 ticks a day, gated only by the runner's flat 15% drift threshold.
+#
+# STATE APPROACH: REPLAY-DERIVED, not persisted. The position is recomputed by
+# replaying the spec's own FSM over the same price window the signal is computed
+# from, every tick. Rationale:
+#   * Deterministic and restart-safe — a redeploy, a crash, a Redis flush or a
+#     second runner process all derive the SAME state from the same prices.
+#     Persisted per-strategy state would silently reset to "flat" on restart,
+#     which the FSM cannot tell from a genuine first entry.
+#   * Exactly-once by construction. Signals are produced ONCE per tick per
+#     (strategy, asset) but consumed by N vaults; a mutable persisted state
+#     advanced in the per-vault loop would tick 2+ times per tick for a strategy
+#     bound to 2+ vaults and corrupt its transitions. A pure function of the
+#     price window cannot be double-advanced.
+#   * No new persistence, no migration, no backfill, and nothing to reconcile
+#     when a strategy is re-bound to a different vault.
+#   * A missing-bars tick degrades honestly: the replay simply runs over the
+#     bars that exist and the insufficient-data guard still refuses to trade —
+#     it can never mistake a vendor gap for an exit, because there is no stored
+#     "last position" for a gap to contradict.
+# It matches how paper trading already derives position state (paper_trading.
+# replay_spec re-runs the full backtest on every advance rather than
+# checkpointing), so all three surfaces now agree by construction.
+#
+# KNOWN LIMIT, stated plainly: the cadence grid is anchored to the first
+# post-warm-up bar of the window handed to the evaluator, exactly as the
+# backtest anchors it (``_rebal_counter = period - 1``). Live, that window is a
+# rolling 2-year fetch, so the grid's phase shifts by one bar per new trading
+# day — a monthly strategy re-decides roughly every 21 bars, but not on a fixed
+# calendar date. Intraday (the ~288-ticks-a-day case F3 is about) the daily bars
+# are identical, so the position is provably constant within a day. A stable
+# epoch anchor would fix the phase but would no longer match the backtest, and
+# the backtest FSM is the semantic contract.
+
+
+@dataclass(frozen=True)
+class PositionReplay:
+    """Position state derived by replaying a spec's FSM over a price window."""
+
+    in_market: bool
+    decision_index: int | None  # 0-based bar of the LAST cadence-eligible decision
+    decision_count: int  # cadence-eligible bars the FSM actually evaluated
+    entered_index: int | None  # bar the currently-open position was entered on
+
+
+def _replay_position_state(
+    spec: StrategySpec,
+    prices: pd.Series,
+    max_period: int,
+) -> PositionReplay:
+    """Replay the spec's position FSM over ``prices`` → state at the last bar.
+
+    Bar-for-bar equivalent of ``DSLStrategy.next()``:
+      * bars at index < ``max_period`` are warm-up and never decide anything
+        (backtrader's ``len(self) <= self._warmup`` gate — the first bar the
+        backtest can act on is 0-based index ``max_period``, for every
+        indicator this DSL supports);
+      * the cadence gate runs BEFORE the entry/exit branches, so an off-cadence
+        bar is never even exit-tested (a held position stays held through it);
+      * entry is only evaluated while flat, exit only while in position, and a
+        bar where the active branch is false is a HOLD.
+
+    Raises DSLError if the spec references an indicator this module cannot
+    compute — the caller turns that into a loud FLAT, never a silent long.
+    """
+    from archimedes.services.dsl_to_backtrader import _eval_condition, rebalance_period_bars
+
+    period_bars = rebalance_period_bars(spec.rebalance_frequency)
+    closes = prices.to_numpy(dtype=float)
+    n = len(closes)
+
+    indicator_cols: dict[str, np.ndarray] = {
+        alias: _compute_indicator_series(name, period, prices).to_numpy(dtype=float)
+        for alias, (name, period) in _indicator_periods(spec).items()
+    }
+
+    in_market = False
+    entered_index: int | None = None
+    decision_index: int | None = None
+    decision_count = 0
+
+    for t in range(max_period, n):
+        # Cadence gate FIRST — mirrors DSLStrategy._should_rebalance, whose
+        # counter is seeded to period-1 so the first post-warm-up bar always
+        # rebalances (offsets 0, period, 2*period, … from that bar).
+        if period_bars > 1 and (t - max_period) % period_bars != 0:
+            continue
+
+        px = float(closes[t])
+        bar_values: dict[str, float] = {
+            "close": px,
+            "open": px,
+            "high": px,
+            "low": px,
+            "volume": 0.0,
+        }
+        for alias, col in indicator_cols.items():
+            bar_values[alias] = float(col[t])
+
+        decision_index = t
+        decision_count += 1
+
+        if not in_market:
+            if _eval_condition(spec.entry, bar_values):
+                in_market = True
+                entered_index = t
+        elif _eval_condition(spec.exit, bar_values):
+            in_market = False
+            entered_index = None
+
+    return PositionReplay(
+        in_market=in_market,
+        decision_index=decision_index,
+        decision_count=decision_count,
+        entered_index=entered_index,
+    )
+
+
 def _spec_signal(
     strategy_id: str,
     asset: str,
@@ -1016,10 +1221,18 @@ def _spec_signal(
     """Evaluate a validated DSL spec against live prices → AssetSignal.
 
     Pure Python — NO backtrader.Strategy / Cerebro / full backtest in the tick
-    path. Validates the spec (cached), guards insufficient data, computes each
-    referenced indicator from the price Series, evaluates the entry/exit
-    condition tree via the shared ``_eval_condition``, and sizes the position by
+    path. Validates the spec (cached), guards insufficient data, then REPLAYS the
+    spec's position FSM over the price window (``_replay_position_state``) to get
+    the state at the current bar, and sizes the position by
     ``position_sizing.type``.
+
+    The replay is what makes this agree with the backtest (audit F2/F3): the
+    position is HELD through the dead zone where entry and exit are both false,
+    and entry/exit are only re-decided on bars the declared
+    ``rebalance_frequency`` makes eligible. Sizing is evaluated as of that last
+    decision bar, not the current one — otherwise an off-cadence bar could still
+    move the target weight and re-open the hole F3 is about (for daily specs the
+    two are the same bar, so daily behaviour is unchanged).
 
     On a DSLError (invalid spec) it logs loudly and returns a FLAT signal with an
     explicit reason — it NEVER silently buys-and-holds.
@@ -1058,18 +1271,12 @@ def _spec_signal(
             reason=f"insufficient data ({len(prices)} bars, need {max_period + 1})",
         )
 
-    # Compute bar_values for the condition tree: raw price operands + each
-    # indicator alias the spec references.
-    bar_values: dict[str, float] = {
-        "close": float(prices.iloc[-1]),
-        "open": float(prices.iloc[-1]),
-        "high": float(prices.iloc[-1]),
-        "low": float(prices.iloc[-1]),
-        "volume": 0.0,
-    }
+    # Replay the spec's position FSM over the window (audit F2 + F3). The
+    # condition tree is evaluated inside the replay via the SAME
+    # ``_eval_condition`` the backtest uses; ``_replay_position_state`` imports it
+    # lazily so backtrader stays out of the API/runner module-load chain.
     try:
-        for alias, (name, period) in periods.items():
-            bar_values[alias] = _compute_indicator_value(name, period, prices)
+        replay = _replay_position_state(spec, prices, max_period)
     except DSLError as exc:
         logger.error(
             "DSL indicator compute failed for strategy %s asset %s: %s — returning FLAT",
@@ -1086,34 +1293,46 @@ def _spec_signal(
             reason=f"spec invalid: {exc}",
         )
 
-    # Evaluate entry/exit via the SAME condition tree the backtest uses. Lazy
-    # import keeps backtrader out of the module-load import chain (dsl_to_backtrader
-    # imports backtrader at top level; _eval_condition itself is pure Python).
-    from archimedes.services.dsl_to_backtrader import _eval_condition
+    close = float(prices.iloc[-1])
+    cadence = spec.rebalance_frequency
 
-    # The runner is stateless across ticks here (no position memory), so we treat
-    # "in market" as: entry true AND NOT exit. This is the live snapshot of the
-    # spec's market-membership predicate.
-    in_market = _eval_condition(spec.entry, bar_values) and not _eval_condition(spec.exit, bar_values)
-
-    if not in_market:
+    if replay.decision_index is None:
+        # Unreachable given the insufficient-data guard above (bar max_period is
+        # always cadence-eligible), but never imply a position that was never
+        # derived — say so instead of falling through to a weight.
         return AssetSignal(
             strategy_id=strategy_id,
             strategy_name=strategy_name,
             asset=asset,
             signal=Signal.FLAT,
             weight=0.0,
-            reason=f"entry/exit conditions → out of market (close={bar_values['close']:.2f})",
+            reason=f"no {cadence} decision bar in window ({len(prices)} bars)",
         )
 
-    # Position sizing → weight.
+    decision_index = replay.decision_index
+    held_bars = len(prices) - 1 - decision_index
+    cadence_note = f"{cadence} cadence, {replay.decision_count} decision bar(s), held {held_bars} bar(s) since"
+
+    if not replay.in_market:
+        return AssetSignal(
+            strategy_id=strategy_id,
+            strategy_name=strategy_name,
+            asset=asset,
+            signal=Signal.FLAT,
+            weight=0.0,
+            reason=f"position FSM → out of market ({cadence_note}; close={close:.2f})",
+        )
+
+    # Position sizing → weight, evaluated AS OF the last decision bar so an
+    # off-cadence bar cannot move the target weight (see the docstring).
+    decision_prices = prices.iloc[: decision_index + 1]
     ps = spec.position_sizing or {}
     ps_type = ps.get("type", "full_invested_when_in_market")
 
     if ps_type == "volatility_target":
         annual_pct = ps.get("annual_pct")
         # 22-day realized-vol window matches _vol_managed_signal's vol_window.
-        realized_vol = _compute_indicator_value("realized_vol", 22, prices)
+        realized_vol = _compute_indicator_value("realized_vol", 22, decision_prices)
         weight = 1.0 if not annual_pct or realized_vol <= 0 else min(float(annual_pct) / realized_vol, 1.0)
         signal_type = Signal.LONG if weight >= 0.95 else Signal.SCALED
         return AssetSignal(
@@ -1122,7 +1341,10 @@ def _spec_signal(
             asset=asset,
             signal=signal_type,
             weight=round(weight, 4),
-            reason=(f"in market; vol-target {annual_pct} / realized {realized_vol:.1%} → weight {weight:.0%}"),
+            reason=(
+                f"in market since bar {replay.entered_index}; vol-target {annual_pct} / "
+                f"realized {realized_vol:.1%} → weight {weight:.0%} ({cadence_note})"
+            ),
         )
 
     # full_invested_when_in_market / equal_weight / inverse_vol → full exposure
@@ -1133,7 +1355,7 @@ def _spec_signal(
         asset=asset,
         signal=Signal.LONG,
         weight=1.0,
-        reason=f"in market (close={bar_values['close']:.2f}) → long",
+        reason=f"in market since bar {replay.entered_index} ({cadence_note}; close={close:.2f}) → long",
     )
 
 
@@ -1266,8 +1488,9 @@ class StrategySignalEvaluator:
 
             if use_spec:
                 logger.info(
-                    "Strategy '%s' → DSL-spec path (interpreting validated spec)",
+                    "Strategy '%s' → DSL-spec path (interpreting validated spec, %s cadence)",
                     strategy.paper_title,
+                    spec_dict.get("rebalance_frequency", "unknown"),
                 )
                 evaluator = lambda sid, asset, prices, _spec=spec_dict: _spec_signal(sid, asset, prices, _spec)  # noqa: E731
             else:

--- a/backend/archimedes/services/strategy_signal_evaluator.py
+++ b/backend/archimedes/services/strategy_signal_evaluator.py
@@ -1127,6 +1127,17 @@ def _compute_indicator_series(name: str, period: int, prices: pd.Series) -> pd.S
 # are identical, so the position is provably constant within a day. A stable
 # epoch anchor would fix the phase but would no longer match the backtest, and
 # the backtest FSM is the semantic contract.
+#
+# SECOND KNOWN LIMIT — position MEMBERSHIP, not just phase (adversarial review
+# of this change): the replay can only see entries inside the visible window.
+# A position whose true entry bar has aged out of the rolling fetch's left
+# edge (or sits inside the warm-up region) derives as FLAT here while the
+# backtest, which saw the true entry, says LONG. Unreachable today — every
+# live strategy is years younger than the fetch window — so the failure mode
+# is guarded LOUDLY instead of redesigned: ``evaluate_strategies`` warns when
+# a strategy's ``created_at`` predates its price window (see the guard there).
+# Before any strategy approaches the window's age, the fetch must be anchored
+# at strategy inception rather than rolling.
 
 
 @dataclass(frozen=True)
@@ -1492,6 +1503,39 @@ class StrategySignalEvaluator:
                     strategy.paper_title,
                     spec_dict.get("rebalance_frequency", "unknown"),
                 )
+                # F2 known-limit guard (see the SECOND KNOWN LIMIT note above
+                # _replay_position_state): a strategy older than its price
+                # window can hold a position whose entry bar the replay cannot
+                # see — it would read flat while the backtest reads long. No
+                # strategy is near the window's age today; if this ever fires,
+                # the fetch must be re-anchored at strategy inception before
+                # this strategy's live signals are trusted. (Warm-up adds a
+                # small extra blind margin beyond this comparison.)
+                created_at = getattr(strategy, "created_at", None)
+                window_start = min(
+                    (price_histories[s].index[0] for s in strategy_synths if len(price_histories[s]) > 0),
+                    default=None,
+                )
+                if created_at is not None and window_start is not None:
+                    try:
+                        created_ts = pd.Timestamp(created_at)
+                        if created_ts.tzinfo is not None:
+                            created_ts = created_ts.tz_localize(None)
+                        window_ts = pd.Timestamp(window_start)
+                        if window_ts.tzinfo is not None:
+                            window_ts = window_ts.tz_localize(None)
+                        if created_ts <= window_ts:
+                            logger.warning(
+                                "Strategy '%s' predates its price window (created %s <= window start %s): "
+                                "a position entered before the window is INVISIBLE to the position replay "
+                                "(F2 known limit) — re-anchor the price fetch at strategy inception before "
+                                "trusting this strategy's live signals",
+                                strategy.paper_title,
+                                created_ts.date(),
+                                window_ts.date(),
+                            )
+                    except (ValueError, TypeError):
+                        logger.debug("could not compare created_at %r to window start", created_at)
                 evaluator = lambda sid, asset, prices, _spec=spec_dict: _spec_signal(sid, asset, prices, _spec)  # noqa: E731
             else:
                 evaluator = _get_evaluator(strategy.paper_title, strategy.strategy_code_path)

--- a/backend/tests/test_agent_runner_tick.py
+++ b/backend/tests/test_agent_runner_tick.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pandas as pd
 import pytest
 from archimedes.models.portfolio import Portfolio, PortfolioHolding, TargetAllocation
 from archimedes.models.regime import ConsensusLabel, EnsembleConsensus, Regime, RegimeClassification
@@ -819,3 +820,151 @@ class TestRunLoop:
         lease.install_sigterm_release.assert_called_once()
         assert runner.lease is lease
         runner.tick.assert_awaited_once()
+
+
+# ── Cadence gate upstream of the drift threshold (divergence audit F3) ────
+
+
+def _band_price_series() -> pd.Series:
+    """20-bar-down / 20-bar-up sawtooth. Deterministic; RSI(14) sweeps 0–83 so
+    an RSI 30/70 band spec genuinely flips both ways."""
+    vals = [100.0]
+    for i in range(1, 320):
+        step = 0.010 if (i // 20) % 2 else -0.010
+        zig = 0.002 if (i * 7919) % 7 < 3 else -0.001
+        vals.append(round(vals[-1] * (1.0 + step + zig), 10))
+    return pd.Series(vals, name="sSPY")
+
+
+def _band_spec(rebalance_frequency: str) -> dict:
+    return {
+        "name": f"RSI band ({rebalance_frequency})",
+        "asset_universe": ["SPY"],
+        "rebalance_frequency": rebalance_frequency,
+        "entry": {"lt": ["rsi_14", 30]},
+        "exit": {"gt": ["rsi_14", 70]},
+        "position_sizing": {"type": "full_invested_when_in_market"},
+        "source_arxiv_ids": ["0000.0000"],
+        "look_ahead_safe": True,
+    }
+
+
+def _spec_strategy(spec: dict):
+    from archimedes.models.paper_ref import PaperRef
+    from archimedes.models.strategy import Strategy
+
+    return Strategy(
+        id="band_001",
+        papers=[PaperRef(title=spec["name"])],
+        asset_universe=["SPY"],
+        strategy_spec=spec,
+    )
+
+
+def _portfolio_at(weights: dict[str, float], total: float = 1000.0) -> Portfolio:
+    return Portfolio(
+        vault_address="0xVault",
+        total_value_usdc=total,
+        holdings=[
+            PortfolioHolding(
+                symbol=sym,
+                token_address=f"0x{sym.lower()}",
+                amount=w * total,
+                weight=w,
+                value_usdc=w * total,
+            )
+            for sym, w in weights.items()
+        ],
+        risk_profile="moderate",
+    )
+
+
+class TestCadenceGateRunsBeforeDriftThreshold:
+    """F3, at the runner boundary: the per-strategy cadence gate decides WHEN a
+    strategy may change its target; _DRIFT_THRESHOLD only decides whether an
+    already-cadence-gated change is worth trading. Same vault, same bar, same
+    drift gate — only the spec's declared ``rebalance_frequency`` differs.
+
+    Hermetic: a real StrategySignalEvaluator over an injected in-memory price
+    Series (no yfinance), and _compute_trades called directly (no chain).
+    """
+
+    @staticmethod
+    def _targets(evaluator, spec: dict, prices, upto: int) -> list[TargetAllocation]:
+        signals = evaluator.evaluate_strategies(
+            [_spec_strategy(spec)],
+            ["sSPY"],
+            price_histories={"sSPY": prices.iloc[: upto + 1]},
+        )
+        weights = evaluator.aggregate_signals(signals, usdc_floor=0.20)
+        return [
+            TargetAllocation(symbol=s, token_address=f"0x{s.lower()}", weight=w, strategy_ids=["band_001"])
+            for s, w in weights.items()
+        ]
+
+    def test_monthly_spec_holds_target_where_a_daily_spec_would_trade(self, runner_env):
+        from archimedes.chain.agent_runner import _DRIFT_THRESHOLD
+        from archimedes.services.strategy_signal_evaluator import StrategySignalEvaluator
+
+        runner, _ = runner_env
+        evaluator = StrategySignalEvaluator()
+        prices = _band_price_series()
+        monthly, daily = _band_spec("monthly"), _band_spec("daily")
+        warmup = 14  # max indicator period → first bar the FSM can act on
+
+        def weight_of(targets, sym):
+            return next((t.weight for t in targets if t.symbol == sym), 0.0)
+
+        # An OFF-cadence bar on which the daily version of the same spec wants a
+        # different sSPY weight than the monthly version is holding.
+        bar = next(
+            (
+                t
+                for t in range(warmup + 1, 200)
+                if (t - warmup) % 21 != 0
+                and abs(
+                    weight_of(self._targets(evaluator, daily, prices, t), "sSPY")
+                    - weight_of(self._targets(evaluator, monthly, prices, t), "sSPY")
+                )
+                > _DRIFT_THRESHOLD
+            ),
+            None,
+        )
+        assert bar is not None, (
+            "no off-cadence bar where the daily and monthly versions of one spec disagree — "
+            "either the fixture stopped exercising cadence, or the live path is ignoring "
+            "rebalance_frequency again (audit F3)"
+        )
+
+        # The vault sits exactly on the monthly strategy's target from the
+        # previous bar.
+        prev_targets = self._targets(evaluator, monthly, prices, bar - 1)
+        portfolio = _portfolio_at({t.symbol: t.weight for t in prev_targets})
+
+        # Cadence gate holds the target → nothing for the drift gate to fire on.
+        held_trades = runner._compute_trades(portfolio, self._targets(evaluator, monthly, prices, bar))
+        assert held_trades == [], f"monthly spec produced trades on off-cadence bar {bar}: {held_trades}"
+
+        # Same vault, same bar, same 15% threshold — the DAILY spec is due, so it
+        # moves and the drift gate lets it through. This is the contrast that
+        # makes the assertion above mean something rather than "nothing ever
+        # trades on this fixture".
+        due_trades = runner._compute_trades(portfolio, self._targets(evaluator, daily, prices, bar))
+        assert due_trades, f"daily spec produced no trades on bar {bar} — contrast case is vacuous"
+        assert any(t.symbol == "sSPY" for t in due_trades)
+
+    def test_repeated_intraday_ticks_never_accumulate_drift(self, runner_env):
+        """The literal ~288-ticks-a-day case: re-evaluating the same daily-bar
+        window over and over must keep producing the identical target, so the
+        vault never drifts into a trade between decision bars."""
+        from archimedes.services.strategy_signal_evaluator import StrategySignalEvaluator
+
+        runner, _ = runner_env
+        evaluator = StrategySignalEvaluator()
+        prices = _band_price_series()
+        monthly = _band_spec("monthly")
+
+        targets = self._targets(evaluator, monthly, prices, 150)
+        portfolio = _portfolio_at({t.symbol: t.weight for t in targets})
+        for _ in range(24):
+            assert runner._compute_trades(portfolio, self._targets(evaluator, monthly, prices, 150)) == []

--- a/backend/tests/test_interpreter_parity.py
+++ b/backend/tests/test_interpreter_parity.py
@@ -39,6 +39,13 @@ SCOPE, stated exactly (the honest part):
     stdev capped at 1.0x. Both sides now agree on WHEN a vol-targeted strategy
     is in the market (the cases below cover that); how much they buy once in is
     a separate, still-open divergence and is not asserted here.
+  * DELIBERATELY OUT: window-age position membership — the live replay derives
+    position from the visible rolling window, so an entry older than the
+    window's left edge is invisible (backtest long, live flat). Unreachable
+    until a strategy approaches the fetch window's age; guarded LOUDLY by the
+    created_at-vs-window warning in evaluate_strategies (pinned in
+    test_live_position_fsm.py::TestWindowAgeGuard), and the fetch must be
+    re-anchored at strategy inception before it ever becomes reachable.
 
 Mechanics: the backtrader side runs a probe strategy that records each
 indicator's value at every bar; the live side recomputes on the price prefix

--- a/backend/tests/test_interpreter_parity.py
+++ b/backend/tests/test_interpreter_parity.py
@@ -11,7 +11,14 @@ next convention drift fails CI instead of shipping into published numbers.
 
 SCOPE, stated exactly (the honest part):
   * PINNED EQUAL, per-bar: sma, rsi (post-F5 Wilder), momentum (post-F1
-    trailing return), and flat-state daily entry decisions.
+    trailing return), flat-state daily entry decisions, the STATEFUL position
+    path (post-F2 — the live evaluator replays the spec's FSM instead of
+    recomputing "entry AND NOT exit", so a band strategy holds through the dead
+    zone on both sides), and REBALANCE CADENCE (post-F3 — the live replay runs
+    the same cadence gate the backtest does, so a monthly spec re-decides on the
+    same bars in both interpreters). Each indicator's whole-series form is also
+    pinned against its per-prefix scalar form, because the position replay reads
+    the series and a live tick reads the scalar.
   * PINNED CONVERGENT: ema — backtrader seeds with an SMA, the live evaluator
     seeds ewm from the first value (audit F10). The seeds differ; the decay
     factor (1 - 2/(N+1))^k drives them together, so parity is asserted after
@@ -21,11 +28,17 @@ SCOPE, stated exactly (the honest part):
     (audit F6). The asymmetry itself is asserted, so both the silent arrival
     of a backtest implementation (must then be promoted to PINNED EQUAL) and
     a live-side removal are caught.
-  * DELIBERATELY OUT: stateful entry/exit parity (audit F2 — the live path is
-    stateless entry-AND-NOT-exit, the backtest is a position FSM) and
-    rebalance cadence (F3 — the live path never reads it). Both are
-    live-money behaviour changes prepared and HELD for Dan's explicit
-    go-ahead; when those land, their parity cases belong here.
+  * PINNED WITH A ONE-BAR EXECUTION OFFSET: the stateful/cadence cases compare
+    DECISIONS, not fills. backtrader submits the order on the decision bar and
+    the broker fills it at the next bar's open, so the backtest's observable
+    position at bar t+1 is the state its FSM decided at bar t. That offset is an
+    execution convention, not an interpreter divergence, and the helpers below
+    state it explicitly rather than hiding it in a fudge factor.
+  * DELIBERATELY OUT: volatility_target SIZING parity — the backtest sizes off a
+    20-bar RMS of returns capped at 2.0x, the live path off a 22-bar sample
+    stdev capped at 1.0x. Both sides now agree on WHEN a vol-targeted strategy
+    is in the market (the cases below cover that); how much they buy once in is
+    a separate, still-open divergence and is not asserted here.
 
 Mechanics: the backtrader side runs a probe strategy that records each
 indicator's value at every bar; the live side recomputes on the price prefix
@@ -39,9 +52,14 @@ import math
 import backtrader as bt
 import pandas as pd
 import pytest
-from archimedes.services.dsl_to_backtrader import _make_indicator
-from archimedes.services.strategy_dsl import DSLError
-from archimedes.services.strategy_signal_evaluator import _compute_indicator_value
+from archimedes.services.dsl_to_backtrader import _eval_condition, _make_indicator, interpret_spec
+from archimedes.services.strategy_dsl import DSLError, validate_strategy_spec
+from archimedes.services.strategy_signal_evaluator import (
+    Signal,
+    _compute_indicator_series,
+    _compute_indicator_value,
+    _spec_signal,
+)
 
 # Deterministic two-regime series: a drift-up half then a drift-down half,
 # with bar-level zig-zag inside each. Two regimes are load-bearing, not
@@ -147,8 +165,6 @@ def test_flat_state_daily_entry_decision_parity():
     stateful exit/cadence halves are audit F2/F3, held for Dan). Evaluated
     through the SHARED _eval_condition on both sides' own indicator values, so
     a divergent indicator value flips a decision here, not just a number."""
-    from archimedes.services.dsl_to_backtrader import _eval_condition
-
     period = 20
     entry = {"gt": [f"momentum_{period}", 0]}
     bt_vals = _bt_indicator_series("momentum", period)
@@ -167,6 +183,216 @@ def test_flat_state_daily_entry_decision_parity():
     assert decisions > 100
     # Anti-vacuity: the series must actually exercise BOTH decision branches.
     assert 0 < entered_bt < decisions, "series never flips the entry decision — test asserts nothing"
+
+
+@pytest.mark.parametrize(
+    ("name", "period"),
+    [("sma", 50), ("ema", 12), ("rsi", 14), ("momentum", 20), ("realized_vol", 20)],
+)
+def test_indicator_series_matches_per_prefix_value(name, period):
+    """The whole-series indicator form equals the per-prefix scalar form, bar
+    for bar. Load-bearing, not bookkeeping: the position replay (F2/F3) reads
+    ``_compute_indicator_series`` while a plain live tick reads
+    ``_compute_indicator_value``, so a drift between the two would put the
+    replayed position and the value the same tick reports on different numbers —
+    the exact failure mode this whole file exists to prevent, reintroduced
+    inside one module."""
+    series = _compute_indicator_series(name, period, pd.Series(_SERIES))
+    assert len(series) == _N_BARS
+    compared = 0
+    for t in range(period + 2, _N_BARS):
+        vec = float(series.iloc[t])
+        scalar = float(_compute_indicator_value(name, period, pd.Series(_SERIES[: t + 1])))
+        if math.isnan(vec) and math.isnan(scalar):
+            continue
+        assert vec == pytest.approx(scalar, rel=1e-12), (
+            f"{name}_{period} series/scalar disagree at bar {t}: series={vec!r} scalar={scalar!r}"
+        )
+        compared += 1
+    assert compared >= (_N_BARS - period - 2) * 0.8, f"only {compared} bars compared for {name}_{period}"
+
+
+# ── Pinned EQUAL: stateful position path (F2) + cadence (F3) ────────────────
+#
+# A second deterministic series, purpose-built for the band case. `_SERIES`
+# above keeps RSI(14) inside a narrow 65–83 corridor, which never crosses a
+# 30/70 band and would make every band assertion below vacuous. This one is a
+# 20-bar-down / 20-bar-up sawtooth with a bar-level zig, so RSI(14) sweeps the
+# full 0–83 range: ~67 bars below 30, ~70 above 70, and ~169 bars in the DEAD
+# ZONE between them where entry and exit are BOTH false — which is precisely
+# where the pre-F2 stateless live rule and the backtest FSM disagreed.
+_BAND_N_BARS = 320
+_BAND_SERIES = [100.0]
+for _i in range(1, _BAND_N_BARS):
+    _leg = (_i // 20) % 2  # 0 = 20-bar down leg, 1 = 20-bar up leg
+    _step = 0.010 if _leg else -0.010
+    _zig = 0.002 if (_i * 7919) % 7 < 3 else -0.001
+    _BAND_SERIES.append(round(_BAND_SERIES[-1] * (1.0 + _step + _zig), 10))
+
+_RSI_PERIOD = 14
+_ENTRY = {"lt": [f"rsi_{_RSI_PERIOD}", 30]}
+_EXIT = {"gt": [f"rsi_{_RSI_PERIOD}", 70]}
+
+
+def _band_spec(rebalance_frequency: str) -> dict:
+    """RSI 30/70 band spec — the canonical F2 case: long below 30, out above 70,
+    HOLD in between."""
+    return {
+        "name": f"RSI band ({rebalance_frequency})",
+        "asset_universe": ["SPY"],
+        "rebalance_frequency": rebalance_frequency,
+        "entry": dict(_ENTRY),
+        "exit": dict(_EXIT),
+        "position_sizing": {"type": "full_invested_when_in_market"},
+        "source_arxiv_ids": ["0000.0000"],
+        "look_ahead_safe": True,
+    }
+
+
+def _bt_position_path(spec_dict: dict) -> dict[int, bool]:
+    """Per-bar in-market state of the REAL backtest FSM.
+
+    Runs the generated ``DSLStrategy`` unmodified and records
+    ``self.position.size > 0`` at the top of each ``next()`` — the state the FSM
+    reads BEFORE deciding on that bar. backtrader submits the order on the
+    decision bar and the broker fills it at the NEXT bar's open, so the state
+    the FSM decided at bar t is what shows up at bar t+1; callers compare
+    ``path[t + 1]`` against the live decision at bar t.
+
+    ``exposure_fraction`` is dialled down from the 0.99 default on purpose: at
+    99% notional an entry order sized on bar t's close can be MARGIN-REJECTED
+    when bar t+1's open gaps up, and the FSM then silently stays flat. That is
+    an execution-layer artifact of this fixture's 1%/bar sawtooth, not an
+    interpreter divergence, and letting it into the comparison would have this
+    test failing for a reason it does not claim to be about.
+    """
+    idx = pd.bdate_range("2024-01-02", periods=_BAND_N_BARS)
+    close = pd.Series(_BAND_SERIES, index=idx)
+    df = pd.DataFrame({"Open": close, "High": close, "Low": close, "Close": close, "Volume": 0.0}, index=idx)
+
+    captured: dict[int, bool] = {}
+    strategy_cls = interpret_spec(validate_strategy_spec(spec_dict))
+
+    class Probe(strategy_cls):
+        def next(self) -> None:
+            captured[len(self) - 1] = self.position.size > 0
+            super().next()
+
+    cerebro = bt.Cerebro()
+    cerebro.broker.setcash(1_000_000.0)
+    cerebro.adddata(bt.feeds.PandasData(dataname=df))
+    cerebro.addstrategy(Probe, exposure_fraction=0.5)
+    cerebro.run()
+    return captured
+
+
+def _live_position_path(spec_dict: dict) -> dict[int, bool]:
+    """Per-bar in-market decision of the LIVE evaluator — ``_spec_signal`` on
+    each growing price prefix, exactly the history a live tick sees."""
+    close = pd.Series(_BAND_SERIES)
+    out: dict[int, bool] = {}
+    for t in range(_RSI_PERIOD, _BAND_N_BARS):
+        sig = _spec_signal("parity", "sSPY", close.iloc[: t + 1], dict(spec_dict))
+        out[t] = sig.signal is not Signal.FLAT
+    return out
+
+
+def _stateless_in_market(t: int) -> bool:
+    """The PRE-F2 live rule: ``entry(bar) and not exit(bar)``, no memory."""
+    rsi = _compute_indicator_value("rsi", _RSI_PERIOD, pd.Series(_BAND_SERIES[: t + 1]))
+    bar = {f"rsi_{_RSI_PERIOD}": rsi}
+    return _eval_condition(_ENTRY, bar) and not _eval_condition(_EXIT, bar)
+
+
+def test_stateful_dead_zone_position_parity():
+    """F2: an RSI 30/70 band strategy holds its position through the dead zone
+    in BOTH interpreters, per bar.
+
+    Entry is only tested while flat and exit only while in position, so the
+    ~169 bars where 30 <= rsi <= 70 are a HOLD — the backtest stays long there
+    and, post-fix, so does the live evaluator. The anti-vacuity block at the end
+    is also the regression demonstration: it asserts the dead zone is actually
+    exercised AND that the pre-F2 stateless rule (`entry and not exit`) gives a
+    different answer on those bars, which is what made this strategy long in the
+    backtest and in cash live on the same bar."""
+    spec = _band_spec("daily")
+    bt_path = _bt_position_path(spec)
+    live_path = _live_position_path(spec)
+
+    compared = 0
+    live_long = 0
+    for t in range(_RSI_PERIOD, _BAND_N_BARS - 1):
+        expected = bt_path.get(t + 1)  # +1: broker fills the decision at the next bar
+        if expected is None:
+            continue
+        assert live_path[t] == expected, (
+            f"position state diverges at bar {t}: backtest={expected} live={live_path[t]} — "
+            "the live evaluator and the backtest FSM disagree about whether this strategy "
+            "holds its position; see the divergence-audit scope note in this file's docstring."
+        )
+        compared += 1
+        live_long += live_path[t]
+
+    assert compared > 250, f"only {compared} bars compared — fixture stopped exercising the FSM"
+    assert 0 < live_long < compared, "series never flips the position — test asserts nothing"
+
+    # Anti-vacuity + regression demonstration: bars where BOTH conditions are
+    # false and the FSM is long. These are exactly the bars the stateless rule
+    # got wrong, so this count must be non-trivial or the test proves nothing.
+    dead_zone_holds = 0
+    for t in range(_RSI_PERIOD, _BAND_N_BARS - 1):
+        if bt_path.get(t + 1) and live_path[t] and not _stateless_in_market(t):
+            dead_zone_holds += 1
+    assert dead_zone_holds > 50, (
+        f"only {dead_zone_holds} dead-zone hold bars — the fixture no longer separates the "
+        "position FSM from the pre-F2 stateless rule, so this test would pass on the old code"
+    )
+
+
+def test_monthly_cadence_decision_parity():
+    """F3: a monthly spec re-decides on the SAME bars in both interpreters, and
+    holds its position in between.
+
+    Cadence is a 21-trading-bar modulus anchored on the first post-warm-up bar
+    (``DSLStrategy._rebalance_period`` / ``_rebal_counter = period - 1``), and
+    the gate runs BEFORE both branches — an off-cadence bar is not even
+    exit-tested. The last block is the regression demonstration: the identical
+    spec on daily cadence must change state on bars the monthly one holds
+    through, so a live path that ignored ``rebalance_frequency`` (as it did
+    pre-F3) cannot pass this."""
+    spec = _band_spec("monthly")
+    bt_path = _bt_position_path(spec)
+    live_path = _live_position_path(spec)
+
+    compared = 0
+    for t in range(_RSI_PERIOD, _BAND_N_BARS - 1):
+        expected = bt_path.get(t + 1)
+        if expected is None:
+            continue
+        assert live_path[t] == expected, (
+            f"monthly-cadence position diverges at bar {t}: backtest={expected} live={live_path[t]}"
+        )
+        compared += 1
+    assert compared > 250, f"only {compared} bars compared — fixture stopped exercising the FSM"
+
+    # The live side changes state ONLY on cadence-eligible bars, and there are
+    # several of them (a single flip would not distinguish cadence from luck).
+    changes = [t for t in range(_RSI_PERIOD + 1, _BAND_N_BARS) if live_path[t] != live_path[t - 1]]
+    assert len(changes) >= 3, f"only {len(changes)} state changes — cadence spacing is not exercised"
+    for t in changes:
+        assert (t - _RSI_PERIOD) % 21 == 0, (
+            f"live position changed at bar {t}, which is not a monthly cadence boundary "
+            f"(offset {(t - _RSI_PERIOD) % 21} from the 21-bar grid)"
+        )
+
+    # Anti-vacuity: the cadence gate must actually suppress decisions the same
+    # spec would take on daily cadence.
+    daily_path = _live_position_path(_band_spec("daily"))
+    suppressed = sum(1 for t in range(_RSI_PERIOD, _BAND_N_BARS) if daily_path[t] != live_path[t])
+    assert suppressed > 20, (
+        f"monthly and daily cadence differ on only {suppressed} bars — the fixture no longer "
+        "distinguishes a cadence-gated live path from one that ignores rebalance_frequency"
+    )
 
 
 # ── Pinned CONVERGENT (F10) ─────────────────────────────────────────────────

--- a/backend/tests/test_live_position_fsm.py
+++ b/backend/tests/test_live_position_fsm.py
@@ -356,3 +356,54 @@ def test_replay_decision_bars_match_the_declared_cadence(frequency):
     expected = ((_N - _WARMUP) + period - 1) // period
     assert replay.decision_count == expected
     assert replay.decision_index == _WARMUP + (expected - 1) * period
+
+
+class TestWindowAgeGuard:
+    """F2 SECOND KNOWN LIMIT (adversarial review): position MEMBERSHIP is
+    derived from the visible window only — an entry older than the rolling
+    fetch's left edge is invisible to the replay. Unreachable today (every
+    strategy is years younger than the window), so the contract is a LOUD
+    warning when a strategy's created_at predates its price window, never a
+    silent flat-vs-long divergence."""
+
+    @staticmethod
+    def _stub_strategy(created_at):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            id="window-age-probe",
+            paper_title="window-age probe",
+            paper_arxiv_id="0000.00000",
+            asset_universe=["SPY"],
+            strategy_spec=_band_spec("daily"),
+            strategy_code_path=None,
+            created_at=created_at,
+        )
+
+    # The prod window is a DatetimeIndex (yfinance); the module fixture is
+    # int-indexed, so re-index it onto fixed business days for this class.
+    _DATED = pd.Series(_PRICES.to_numpy(), index=pd.bdate_range(end="2026-08-03", periods=len(_PRICES)))
+
+    def _run(self, created_at, caplog):
+        import logging
+
+        from archimedes.services.strategy_signal_evaluator import StrategySignalEvaluator
+
+        with caplog.at_level(logging.WARNING, logger="archimedes.services.strategy_signal_evaluator"):
+            StrategySignalEvaluator().evaluate_strategies(
+                [self._stub_strategy(created_at)],
+                ["sSPY"],
+                price_histories={"sSPY": self._DATED},
+            )
+        return [r for r in caplog.records if "INVISIBLE to the position replay" in r.getMessage()]
+
+    def test_strategy_older_than_window_warns_loudly(self, caplog):
+        older_than_window = self._DATED.index[0] - pd.Timedelta(days=30)
+        assert len(self._run(older_than_window, caplog)) == 1
+
+    def test_young_strategy_does_not_warn(self, caplog):
+        younger_than_window = self._DATED.index[-1] - pd.Timedelta(days=5)
+        assert self._run(younger_than_window, caplog) == []
+
+    def test_missing_created_at_does_not_warn_or_crash(self, caplog):
+        assert self._run(None, caplog) == []

--- a/backend/tests/test_live_position_fsm.py
+++ b/backend/tests/test_live_position_fsm.py
@@ -1,0 +1,358 @@
+"""Live position-state FSM + rebalance cadence (divergence audit F2 and F3).
+
+Target: ``archimedes.services.strategy_signal_evaluator._spec_signal`` and the
+``_replay_position_state`` it now runs.
+
+WHAT BROKE. The live evaluator was stateless — ``in_market = entry(bar) and not
+exit(bar)``, recomputed from scratch on every tick with no memory of the
+previous one. The backtest is a position FSM: entry is only tested while flat,
+exit only while in position, and a bar where neither fires is a HOLD. On an RSI
+30/70 band strategy the whole dead zone (30 <= rsi <= 70) is a hold, so the same
+bar had the strategy long in the backtest and in cash live (F2). Separately, the
+live path never read ``rebalance_frequency`` at all, so a spec declaring monthly
+cadence was re-decided on every one of the ~288 ticks a day (F3).
+
+WHAT THE FIX IS. Position state is REPLAY-DERIVED: every tick recomputes the
+position by replaying the spec's own FSM — cadence gate included — over the same
+price window the signals are computed from. No persistence, so nothing to reset
+on restart, nothing to double-advance when one strategy is bound to several
+vaults, and nothing a vendor data gap can contradict. These tests pin both the
+FSM semantics and the property that makes the approach safe (no memory between
+calls).
+
+Bar-for-bar agreement with the REAL backtrader FSM is pinned separately, in
+test_interpreter_parity.py; this file pins the live side's semantics on their
+own, in cases small enough to read.
+
+Hermetic: pure functions over in-memory price Series. No network, no Redis, no
+DB, no yfinance.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from archimedes.services.dsl_to_backtrader import _eval_condition, rebalance_period_bars
+from archimedes.services.strategy_dsl import validate_strategy_spec
+from archimedes.services.strategy_signal_evaluator import (
+    Signal,
+    _compute_indicator_value,
+    _replay_position_state,
+    _spec_signal,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+#
+# A 20-bar-down / 20-bar-up sawtooth with a bar-level zig. Deterministic (seeded
+# drift is how these go flaky) and shaped so RSI(14) sweeps the full 0–83 range:
+# it spends long stretches below 30, long stretches above 70, and the majority of
+# its bars in the DEAD ZONE between them, which is the region F2 is about.
+
+_N = 320
+_RSI_PERIOD = 14
+_WARMUP = _RSI_PERIOD  # first bar the FSM can act on == max indicator period
+
+
+def _band_prices(n: int = _N) -> pd.Series:
+    vals = [100.0]
+    for i in range(1, n):
+        leg = (i // 20) % 2  # 0 = down leg, 1 = up leg
+        step = 0.010 if leg else -0.010
+        zig = 0.002 if (i * 7919) % 7 < 3 else -0.001
+        vals.append(round(vals[-1] * (1.0 + step + zig), 10))
+    return pd.Series(vals, name="sSPY")
+
+
+_PRICES = _band_prices()
+
+_ENTRY = {"lt": [f"rsi_{_RSI_PERIOD}", 30]}
+_EXIT = {"gt": [f"rsi_{_RSI_PERIOD}", 70]}
+
+
+def _band_spec(rebalance_frequency: str = "daily", **overrides) -> dict:
+    """RSI 30/70 band: long below 30, out above 70, HOLD in between."""
+    spec = {
+        "name": f"RSI band ({rebalance_frequency})",
+        "asset_universe": ["SPY"],
+        "rebalance_frequency": rebalance_frequency,
+        "entry": dict(_ENTRY),
+        "exit": dict(_EXIT),
+        "position_sizing": {"type": "full_invested_when_in_market"},
+        "source_arxiv_ids": ["0000.0000"],
+        "look_ahead_safe": True,
+    }
+    spec.update(overrides)
+    return spec
+
+
+def _in_market(spec: dict, upto: int) -> bool:
+    """The live decision at bar ``upto`` — a tick whose history ends there."""
+    return _spec_signal("s1", "sSPY", _PRICES.iloc[: upto + 1], dict(spec)).signal is not Signal.FLAT
+
+
+def _stateless_in_market(upto: int) -> bool:
+    """The PRE-F2 rule: ``entry(bar) and not exit(bar)``, no position memory."""
+    rsi = _compute_indicator_value("rsi", _RSI_PERIOD, _PRICES.iloc[: upto + 1])
+    bar = {f"rsi_{_RSI_PERIOD}": rsi}
+    return _eval_condition(_ENTRY, bar) and not _eval_condition(_EXIT, bar)
+
+
+def _dead_zone_hold_bars(spec: dict) -> list[int]:
+    """Bars where the FSM is long but the stateless rule said flat."""
+    return [t for t in range(_WARMUP, _N) if _in_market(spec, t) and not _stateless_in_market(t)]
+
+
+# ── F2: position-state semantics ──────────────────────────────────────────
+
+
+class TestPositionStateSemantics:
+    def test_holds_position_through_the_dead_zone(self):
+        """The core F2 case. On these bars entry is false AND exit is false, so
+        the FSM holds — while the old stateless rule reported FLAT and put the
+        vault in cash on a bar the published backtest was long."""
+        holds = _dead_zone_hold_bars(_band_spec("daily"))
+        assert len(holds) > 50, f"only {len(holds)} dead-zone hold bars — fixture no longer exercises F2"
+
+        for t in holds[:25]:
+            rsi = _compute_indicator_value("rsi", _RSI_PERIOD, _PRICES.iloc[: t + 1])
+            # These really are dead-zone bars: neither condition fires.
+            assert 30 <= rsi <= 70, f"bar {t} is not in the dead zone (rsi={rsi})"
+            sig = _spec_signal("s1", "sSPY", _PRICES.iloc[: t + 1], _band_spec("daily"))
+            assert sig.signal is Signal.LONG and sig.weight == 1.0
+
+    def test_stays_flat_in_the_dead_zone_when_it_never_entered(self):
+        """Holding is not the same as inventing a position: a window whose FSM
+        never saw an entry is FLAT in the dead zone, not long."""
+        spec = _band_spec("daily")
+        # First dead-zone bar reached without any prior entry.
+        candidates = [
+            t
+            for t in range(_WARMUP, 60)
+            if 30 <= _compute_indicator_value("rsi", _RSI_PERIOD, _PRICES.iloc[: t + 1]) <= 70
+            and not _replay_position_state(validate_strategy_spec(spec), _PRICES.iloc[: t + 1], _WARMUP).entered_index
+        ]
+        assert candidates, "fixture no longer has a never-entered dead-zone bar"
+        t = candidates[0]
+        sig = _spec_signal("s1", "sSPY", _PRICES.iloc[: t + 1], spec)
+        assert sig.signal is Signal.FLAT and sig.weight == 0.0
+
+    def test_exit_condition_still_closes_the_position(self):
+        """Hold-through-the-dead-zone must not become never-exit."""
+        spec = _band_spec("daily")
+        exits = [
+            t for t in range(_WARMUP, _N) if _compute_indicator_value("rsi", _RSI_PERIOD, _PRICES.iloc[: t + 1]) > 70
+        ]
+        assert exits, "fixture never crosses the exit band"
+        for t in exits[:10]:
+            sig = _spec_signal("s1", "sSPY", _PRICES.iloc[: t + 1], spec)
+            assert sig.signal is Signal.FLAT, f"bar {t}: exit condition true but signal is {sig.signal}"
+
+    def test_entry_branch_wins_when_both_conditions_are_true_on_the_same_bar(self):
+        """The FSM's branches are mutually exclusive on the position flag: while
+        flat, only entry is evaluated. The stateless rule ANDed the two, so a
+        spec whose exit is true on the entry bar could never be long at all."""
+        spec = {
+            "name": "both-true",
+            "asset_universe": ["SPY"],
+            "rebalance_frequency": "daily",
+            "entry": {"gt": ["close", "sma_5"]},
+            "exit": {"gt": ["close", 0]},  # always true
+            "position_sizing": {"type": "full_invested_when_in_market"},
+            "source_arxiv_ids": ["0000.0000"],
+            "look_ahead_safe": True,
+        }
+        # Exactly one decision bar (index == max_period == 5), rising → entry true.
+        prices = pd.Series([100.0, 101.0, 102.0, 103.0, 104.0, 105.0], name="sSPY")
+        sig = _spec_signal("s1", "sSPY", prices, spec)
+        assert sig.signal is Signal.LONG
+        # The pre-fix rule on the same bar: entry AND NOT exit → False.
+        bar = {"close": 105.0, "sma_5": float(prices.iloc[1:].mean())}
+        assert _eval_condition(spec["entry"], bar) and _eval_condition(spec["exit"], bar)
+
+    def test_two_bar_minimum_for_a_round_trip(self):
+        """A round trip needs two decision bars: entry fires on one, exit can
+        only be tested on the next. Same convention as the backtest."""
+        spec = {
+            "name": "round-trip",
+            "asset_universe": ["SPY"],
+            "rebalance_frequency": "daily",
+            "entry": {"gt": ["close", "sma_5"]},
+            "exit": {"gt": ["close", 0]},
+            "position_sizing": {"type": "full_invested_when_in_market"},
+            "source_arxiv_ids": ["0000.0000"],
+            "look_ahead_safe": True,
+        }
+        prices = pd.Series([100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0], name="sSPY")
+        one_bar = _spec_signal("s1", "sSPY", prices.iloc[:6], spec)
+        two_bars = _spec_signal("s1", "sSPY", prices, spec)
+        assert one_bar.signal is Signal.LONG  # decision bar 1: entered
+        assert two_bars.signal is Signal.FLAT  # decision bar 2: exit tested, closed
+
+
+class TestReplayDerivedStateIsRestartSafe:
+    """The property that made replay the right choice over persisted state: the
+    answer is a pure function of the price window, so a restart, a redeploy or a
+    second reader can never see a different position than the first."""
+
+    def test_repeated_evaluation_is_identical(self):
+        spec = _band_spec("daily")
+        holds = _dead_zone_hold_bars(spec)
+        assert holds, "fixture no longer produces a dead-zone hold — see F2 note above"
+        t = holds[len(holds) // 2]
+        first = _spec_signal("s1", "sSPY", _PRICES.iloc[: t + 1], spec)
+        second = _spec_signal("s1", "sSPY", _PRICES.iloc[: t + 1], spec)
+        assert (first.signal, first.weight) == (second.signal, second.weight)
+
+    def test_evaluation_order_does_not_change_any_answer(self):
+        """Evaluating a longer window first must not colour the shorter one —
+        the failure mode a per-strategy cached/persisted position would have."""
+        spec = _band_spec("daily")
+        short_first = _spec_signal("s1", "sSPY", _PRICES.iloc[:120], spec).signal
+        _spec_signal("s1", "sSPY", _PRICES, spec)
+        short_after = _spec_signal("s1", "sSPY", _PRICES.iloc[:120], spec).signal
+        assert short_first is short_after
+
+    def test_state_does_not_leak_across_assets_of_one_strategy(self):
+        """Signals are produced once per (strategy, asset) but read by N vaults;
+        a shared mutable position would cross-contaminate assets here."""
+        spec = _band_spec("daily")
+        holds = _dead_zone_hold_bars(spec)
+        assert holds, "fixture no longer produces a dead-zone hold — see F2 note above"
+        t = holds[len(holds) // 2]
+        long_window = _PRICES.iloc[: t + 1]
+        # A monotonically rising window can never satisfy rsi < 30 → never enters.
+        never_enters = pd.Series([100.0 + i for i in range(t + 1)], name="sQQQ")
+        assert _spec_signal("s1", "sSPY", long_window, spec).signal is Signal.LONG
+        assert _spec_signal("s1", "sQQQ", never_enters, spec).signal is Signal.FLAT
+        assert _spec_signal("s1", "sSPY", long_window, spec).signal is Signal.LONG
+
+
+# ── F3: rebalance cadence ─────────────────────────────────────────────────
+
+
+class TestRebalanceCadenceGate:
+    def test_cadence_table_is_shared_with_the_backtest(self):
+        """One definition of the cadence vocabulary, imported by both
+        interpreters — the anti-drift discipline this whole area exists for."""
+        assert rebalance_period_bars("daily") == 1
+        assert rebalance_period_bars("weekly") == 5
+        assert rebalance_period_bars("monthly") == 21
+        assert rebalance_period_bars("hourly") == 1  # unknown degrades to every bar
+
+    def test_monthly_holds_its_signal_between_cadence_boundaries(self):
+        """The literal F3 case: a monthly spec must not re-decide on a bar the
+        backtest would have skipped."""
+        monthly = _band_spec("monthly")
+        daily = _band_spec("daily")
+        changed_off_cadence = 0
+        differs_from_daily = 0
+        for t in range(_WARMUP + 1, _N):
+            monthly_now = _in_market(monthly, t)
+            if monthly_now != _in_market(monthly, t - 1) and (t - _WARMUP) % 21 != 0:
+                changed_off_cadence += 1
+            if monthly_now != _in_market(daily, t):
+                differs_from_daily += 1
+        assert changed_off_cadence == 0, f"monthly spec changed state on {changed_off_cadence} off-cadence bars"
+        # Anti-vacuity: the gate must actually be suppressing decisions.
+        assert differs_from_daily > 20, (
+            f"monthly and daily agree on all but {differs_from_daily} bars — the fixture no longer "
+            "distinguishes a cadence-gated path from one that ignores rebalance_frequency"
+        )
+
+    def test_weekly_boundaries_are_five_bars_apart(self):
+        weekly = _band_spec("weekly")
+        changes = [t for t in range(_WARMUP + 1, _N) if _in_market(weekly, t) != _in_market(weekly, t - 1)]
+        assert len(changes) >= 3, f"only {len(changes)} state changes — spacing is not exercised"
+        for t in changes:
+            assert (t - _WARMUP) % 5 == 0, f"weekly spec changed at bar {t}, off the 5-bar grid"
+
+    def test_daily_cadence_still_decides_every_bar(self):
+        """Control: the gate must not throttle a spec that declared daily."""
+        daily = _band_spec("daily")
+        changes = [t for t in range(_WARMUP + 1, _N) if _in_market(daily, t) != _in_market(daily, t - 1)]
+        assert len(changes) >= 10
+        assert any((t - _WARMUP) % 21 != 0 for t in changes), "daily spec is behaving as if gated"
+
+    def test_repeated_intraday_ticks_report_one_stable_weight(self):
+        """A 300s tick loop evaluates a daily-bar window ~288 times a day. Every
+        one of those must report the SAME weight, or the drift threshold
+        downstream is the only thing between a monthly spec and a trade."""
+        monthly = _band_spec("monthly")
+        holds = _dead_zone_hold_bars(monthly)
+        assert holds, "fixture no longer produces a held monthly position"
+        window = _PRICES.iloc[: holds[len(holds) // 2] + 1]
+        results = {(s.signal, s.weight) for s in (_spec_signal("s1", "sSPY", window, monthly) for _ in range(288))}
+        assert len(results) == 1, f"288 ticks on one window produced {len(results)} distinct weights"
+
+    def test_vol_target_weight_is_frozen_between_boundaries(self):
+        """Sizing is evaluated as of the last decision bar too — otherwise an
+        off-cadence bar moves the target weight and re-opens the F3 hole through
+        the sizing term instead of the signal term."""
+        spec = _band_spec("monthly", position_sizing={"type": "volatility_target", "annual_pct": 0.15})
+        # Find a boundary bar where the position is open, then walk the bars after it.
+        boundaries = [t for t in range(_WARMUP, _N - 5) if (t - _WARMUP) % 21 == 0]
+        held = [b for b in boundaries if _in_market(spec, b)]
+        assert held, "fixture no longer opens a vol-targeted position on a boundary"
+        b = held[len(held) // 2]
+        base = _spec_signal("s1", "sSPY", _PRICES.iloc[: b + 1], spec)
+        for t in range(b + 1, min(b + 21, _N)):
+            off = _spec_signal("s1", "sSPY", _PRICES.iloc[: t + 1], spec)
+            assert off.weight == base.weight, f"vol-target weight moved on off-cadence bar {t}"
+        assert 0.0 < base.weight <= 1.0
+
+    def test_reason_states_the_cadence_and_the_hold(self):
+        """Claim integrity: the published reasoning must say WHY the position is
+        what it is, not imply a fresh decision on every tick."""
+        monthly = _band_spec("monthly")
+        holds = _dead_zone_hold_bars(monthly)
+        assert holds, "fixture no longer produces a dead-zone hold — see F2 note above"
+        t = holds[len(holds) // 2]
+        sig = _spec_signal("s1", "sSPY", _PRICES.iloc[: t + 1], monthly)
+        assert "monthly cadence" in sig.reason
+        assert "held" in sig.reason
+        assert "in market since bar" in sig.reason
+
+
+# ── Degradation: data gaps must not look like exits ───────────────────────
+
+
+class TestDegradesHonestly:
+    def test_short_window_is_insufficient_data_not_an_exit(self):
+        spec = _band_spec("daily")
+        sig = _spec_signal("s1", "sSPY", _PRICES.iloc[:10], spec)
+        assert sig.signal is Signal.FLAT
+        assert "insufficient data" in sig.reason
+
+    def test_exactly_one_decision_bar_of_history_is_evaluable(self):
+        """The warm-up boundary: max_period + 1 bars gives exactly one decision
+        bar. It must decide, not raise and not silently buy-and-hold."""
+        spec = _band_spec("daily")
+        sig = _spec_signal("s1", "sSPY", _PRICES.iloc[: _WARMUP + 1], spec)
+        assert sig.signal in (Signal.LONG, Signal.FLAT)
+        assert "insufficient data" not in sig.reason
+        replay = _replay_position_state(validate_strategy_spec(spec), _PRICES.iloc[: _WARMUP + 1], _WARMUP)
+        assert replay.decision_count == 1 and replay.decision_index == _WARMUP
+
+    def test_unsupported_indicator_is_a_loud_flat(self):
+        spec = _band_spec("daily")
+        spec["entry"] = {"gt": ["close", "bogus_10"]}
+        sig = _spec_signal("s1", "sSPY", _PRICES, spec)
+        assert sig.signal is Signal.FLAT
+        assert sig.weight == 0.0
+
+    def test_invalid_spec_is_still_a_loud_flat_not_buy_and_hold(self):
+        sig = _spec_signal("s1", "sSPY", _PRICES, {"name": "broken"})
+        assert sig.signal is Signal.FLAT
+        assert sig.reason.startswith("spec invalid:")
+
+
+@pytest.mark.parametrize("frequency", ["daily", "weekly", "monthly"])
+def test_replay_decision_bars_match_the_declared_cadence(frequency):
+    """Structural pin on the replay itself: the number of bars it evaluates is
+    the post-warm-up bar count divided by the declared cadence period."""
+    spec = validate_strategy_spec(_band_spec(frequency))
+    replay = _replay_position_state(spec, _PRICES, _WARMUP)
+    period = rebalance_period_bars(frequency)
+    expected = ((_N - _WARMUP) + period - 1) // period
+    assert replay.decision_count == expected
+    assert replay.decision_index == _WARMUP + (expected - 1) * period


### PR DESCRIPTION
Lands the two held backtest/live interpreter divergences on Dan's go-ahead (`AGENT_DRY_RUN=true` re-confirmed via SSM at launch — no live money moves; paper/testnet behavior only). The backtest FSM is the semantic contract; both fixes are live-side only.

## F2 — position state, replay-derived

`_spec_signal` no longer computes stateless `entry AND NOT exit`. A new `_replay_position_state` replays the spec's own FSM bar-by-bar over the same price window the signals come from: warm-up decides nothing, entry is only evaluated while flat, exit only while in position, dead-zone bars are HOLDs. **Replay over persisted state** because it is restart-safe and deterministic (a crash/redeploy/Redis flush derives the same state from the same prices), exactly-once by construction (signals are computed once per strategy but read by N vaults — a pure function can't double-advance), immune to data-gap corruption, needs no migration, and matches how paper trading already derives positions.

## F3 — rebalance cadence

The replay runs the backtest's cadence gate BEFORE both branches on the same 21/5/1-bar grid, anchored exactly as `DSLStrategy._should_rebalance` anchors it — and `rebalance_period_bars()` is extracted to module level in `dsl_to_backtrader.py` so both interpreters read ONE cadence table (the F1/F5 drift mechanism can't recur for cadence). Sizing is evaluated as of the last decision bar, so an off-cadence bar can't move the target weight through the sizing term either. The gate HOLDS the strategy's vote rather than skipping it — a runner-level skip would silently reweight co-bound strategies in `aggregate_signals`. Cadence (upstream, per strategy) decides WHEN a target may change; the 15% drift threshold (downstream, per vault) decides whether the change is worth trading — documented at both sites; `agent_runner.py`'s diff is comments-only.

## Verification (three independent adversarial lenses + full suite)

- **F3 lens — unrefuted**: frequency coverage proven exhaustive via `REBALANCE_FREQUENCIES` validation; first-tick/restart/multi-strategy/drift-interplay probes all held; hand-verified algebraic equivalence of the two cadence anchors; adversarial revert (`period_bars = 1` unconditionally) → exactly the 7 cadence tests fail.
- **Regression lens — unrefuted**: diff-scope verified (`agent_runner.py` comments-only, extraction behavior-preserving); full suite + hermeticity checks green. Non-blocking notes carried into the code: cadence grid phase shifts one bar/day with the rolling window (documented; provably constant intraday); vol-target SIZING parity remains the named pre-existing exclusion; the O(bars) per-tick replay is a deliberate, documented cost.
- **F2 lens — REFUTED the draft, now fixed**: position MEMBERSHIP is derived from the visible window only, so an entry that ages out of the rolling fetch's left edge would read flat live while the backtest reads long. Unreachable today (every strategy is years younger than the 2y window), so the honest fix is loud, not structural: a SECOND KNOWN LIMIT note at the replay, a `created_at`-vs-window-start **warning** in `evaluate_strategies` naming the re-anchor-at-inception fix, three `TestWindowAgeGuard` tests on a prod-faithful DatetimeIndex window (aged warns once; young doesn't; missing `created_at` neither warns nor crashes), and the parity docstring names it as a deliberate exclusion. Mutation-proven: deleting the guard fails the aged-strategy test.
- **Pre-fix failure demonstrations** (in the draft commit): F2 reverted in place → 6 failures incl. per-bar divergence at bar 24; F3 reverted → 7 cadence failures.
- **Parity cases** compare the live decision against a REAL generated backtrader `DSLStrategy` run: >250 bars, >50 dead-zone bars, cadence grid pinned, plus per-indicator series-vs-scalar pins.
- **Full CI-exact suite on the branch: 3238 passed, 0 failed.**

On merge + deploy: the own-scope leaderboard banner's divergence clause retires per #1306's wording (the pre-correction-rows clause stays until those refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7