### PR TITLE
[backend] Stop /health loading the embedding model — 521 MB on the ALB probe path

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -662,7 +662,12 @@ async def health():
     # as "embedded / knowledge-graphed". Each is driven from actual state, never a
     # constant:
     #   corpus_embedded         — live sentence-transformer embeddings active
-    #                             (paper_rag == "live"; "degraded" => TF-IDF, NOT embedded)
+    #                             (paper_rag == "live"; "degraded" => TF-IDF, NOT embedded).
+    #                             NOTE: "ready" (weights on disk, model not yet
+    #                             loaded because nothing has retrieved yet) is
+    #                             deliberately NOT embedded — presence on disk is
+    #                             not proof, and this field must not overstate.
+    #                             It flips to true on the first real retrieval.
     #   corpus_kg_built         — at least one KG entity exists (REBEL/SciSpacy output)
     #   corpus_artifact_present — a real KB-pipeline artifact (S3/local manifest) exists
     corpus_embedded = paper_rag_status == "live"
@@ -746,7 +751,10 @@ async def health_paper_rag():
     """Dedicated paper-rag health endpoint."""
     from archimedes.services.paper_rag import paper_rag_health
 
-    diag = paper_rag_health()
+    # probe=True: this endpoint exists to PROVE the model loads, so it is the
+    # one place allowed to pay the ~521 MB load cost. The ALB-polled /health
+    # deliberately does not (see paper_rag_health's docstring).
+    diag = paper_rag_health(probe=True)
     return {
         "paper_rag": diag.status,
         "reason": diag.reason,

--- a/backend/archimedes/services/paper_rag.py
+++ b/backend/archimedes/services/paper_rag.py
@@ -40,6 +40,7 @@ import re
 import threading
 from collections import Counter
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -66,25 +67,84 @@ def _model_name() -> str:
 class PaperRAGHealth:
     """Health diagnostic for the paper RAG subsystem."""
 
-    status: str  # live | degraded | disabled
+    status: str  # live | ready | degraded | disabled
     reason: str = ""
 
 
-def paper_rag_health() -> PaperRAGHealth:
+def paper_rag_health(probe: bool = False) -> PaperRAGHealth:
     """Report the current health of the paper RAG subsystem.
 
-    - ``live``: semantic retrieval enabled, model loaded successfully.
-    - ``degraded``: enabled but sentence-transformers import failed or model
-      could not be loaded (falls back to TF-IDF).
+    - ``live``: semantic retrieval enabled and the model is loaded in THIS
+      process right now.
+    - ``ready``: enabled and the weights are present on disk, but nothing has
+      needed the model yet so it has not been loaded. Distinct from ``live``
+      on purpose — this reports what is true, not what is likely.
+    - ``degraded``: enabled but a load was attempted and failed (TF-IDF fallback).
     - ``disabled``: ``FUSION_SEMANTIC_RETRIEVAL`` is off.
+
+    ``probe`` controls whether this is allowed to LOAD the model to answer.
+    Default ``False``, because this function is on the ``/health`` path that the
+    ALB polls every 30s: loading ``all-MiniLM-L6-v2`` costs a measured **521 MB
+    of RSS** (torch 207 MB + sentence_transformers 109 MB + the model itself
+    ~205 MB), which more than doubled the API container and was a direct
+    contributor to the 2026-08-19 OOM crash loop. A liveness probe must not
+    allocate half a gigabyte to answer a question about itself.
+
+    Pass ``probe=True`` (the dedicated ``/health/paper-rag`` endpoint does) to
+    force the load and get a proven ``live``/``degraded`` verdict.
     """
     if not _semantic_enabled():
         return PaperRAGHealth(status="disabled", reason="FUSION_SEMANTIC_RETRIEVAL not set")
+
+    # Already loaded (something used retrieval) — free to report, no allocation.
+    if _embedding_model is not None:
+        return PaperRAGHealth(status="live", reason=f"model={_model_name()}")
+
+    # A load was tried and failed — that verdict is cached and also free.
+    if _embedding_load_attempted:
+        return PaperRAGHealth(status="degraded", reason="embedding model unavailable, TF-IDF fallback")
+
+    if not probe:
+        if _weights_present():
+            return PaperRAGHealth(
+                status="ready",
+                reason=f"model={_model_name()} present, not loaded (no retrieval yet)",
+            )
+        return PaperRAGHealth(
+            status="degraded",
+            reason=f"model={_model_name()} weights not found in {os.getenv('HF_HOME', '<unset HF_HOME>')}",
+        )
 
     model = _get_embedding_model()
     if model is not None:
         return PaperRAGHealth(status="live", reason=f"model={_model_name()}")
     return PaperRAGHealth(status="degraded", reason="embedding model unavailable, TF-IDF fallback")
+
+
+def _weights_present() -> bool:
+    """Cheap on-disk check that the baked model cache holds our model.
+
+    The Docker image bakes the weights into ``HF_HOME`` at build time
+    (backend/Dockerfile:70) and runs with ``HF_HUB_OFFLINE=1``, so "the
+    directory for this model exists and is non-empty" is the strongest claim
+    available without importing torch. It is deliberately NOT reported as
+    ``live`` — presence on disk is not proof the model loads.
+    """
+    hf_home = os.getenv("HF_HOME")
+    if not hf_home:
+        return False
+    slug = _model_name().replace("/", "--")
+    root = Path(hf_home)
+    try:
+        for candidate in root.iterdir():
+            if not candidate.is_dir():
+                continue
+            name = candidate.name
+            if slug in name or name in (slug, f"models--sentence-transformers--{slug}"):
+                return any(candidate.rglob("*.safetensors")) or any(candidate.rglob("*.bin"))
+    except OSError:
+        return False
+    return False
 
 
 def _semantic_enabled() -> bool:

--- a/backend/tests/test_paper_rag.py
+++ b/backend/tests/test_paper_rag.py
@@ -84,7 +84,7 @@ class TestPaperRAGHealth:
         monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
         _reset_model_cache()
         with patch.object(rag_module, "_get_embedding_model", return_value=_fake_model()):
-            h = paper_rag_health()
+            h = paper_rag_health(probe=True)
         assert h.status == "live"
         assert "model=" in h.reason
 
@@ -93,7 +93,7 @@ class TestPaperRAGHealth:
         monkeypatch.setenv("MINILM_MODEL", "all-MiniLM-L6-v2")
         _reset_model_cache()
         with patch.object(rag_module, "_get_embedding_model", return_value=_fake_model()):
-            h = paper_rag_health()
+            h = paper_rag_health(probe=True)
         assert h.status == "live"
         assert "all-MiniLM-L6-v2" in h.reason
 
@@ -101,7 +101,7 @@ class TestPaperRAGHealth:
         monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
         _reset_model_cache()
         with patch.object(rag_module, "_get_embedding_model", return_value=None):
-            h = paper_rag_health()
+            h = paper_rag_health(probe=True)
         assert h.status == "degraded"
         assert "TF-IDF" in h.reason
 
@@ -113,7 +113,7 @@ class TestPaperRAGHealth:
         # Simulate ImportError by making _get_embedding_model return None
         # (which is what happens when sentence-transformers isn't installed).
         with patch.object(rag_module, "_get_embedding_model", return_value=None):
-            h = paper_rag_health()
+            h = paper_rag_health(probe=True)
         assert h.status == "degraded"
 
     def test_model_load_exception_leads_to_degraded(self, monkeypatch):
@@ -127,10 +127,83 @@ class TestPaperRAGHealth:
 
             st_mod = sys.modules["sentence_transformers"]
             st_mod.SentenceTransformer = MagicMock(side_effect=OSError("corrupted model files"))
-            h = paper_rag_health()
+            h = paper_rag_health(probe=True)
         # Reset after test
         _reset_model_cache()
         assert h.status == "degraded"
+
+
+# ── /health must never load the model (2026-08-19 OOM regression guard) ──────
+
+
+class TestHealthDoesNotLoadModel:
+    """The ALB polls /health every 30s. Loading all-MiniLM-L6-v2 there costs a
+    measured 521 MB of RSS and was a direct contributor to the 2026-08-19 OOM
+    crash loop. These tests exist to make that regression impossible to
+    reintroduce silently.
+    """
+
+    def setup_method(self):
+        _reset_model_cache()
+
+    def test_default_call_never_loads_the_model(self, monkeypatch):
+        """THE GUARD: probe=False must not call _get_embedding_model at all."""
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
+        _reset_model_cache()
+        loader = MagicMock(return_value=_fake_model())
+        with patch.object(rag_module, "_get_embedding_model", loader):
+            paper_rag_health()
+        loader.assert_not_called()
+
+    def test_probe_true_does_load_the_model(self, monkeypatch):
+        """The dedicated /health/paper-rag endpoint still proves the load."""
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
+        _reset_model_cache()
+        loader = MagicMock(return_value=_fake_model())
+        with patch.object(rag_module, "_get_embedding_model", loader):
+            h = paper_rag_health(probe=True)
+        loader.assert_called_once()
+        assert h.status == "live"
+
+    def test_ready_when_weights_present_but_unloaded(self, monkeypatch):
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
+        _reset_model_cache()
+        with patch.object(rag_module, "_weights_present", return_value=True):
+            h = paper_rag_health()
+        assert h.status == "ready"
+        assert "not loaded" in h.reason
+
+    def test_degraded_when_weights_missing(self, monkeypatch):
+        """No weights on disk is a real problem and must not read as 'ready'."""
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
+        _reset_model_cache()
+        with patch.object(rag_module, "_weights_present", return_value=False):
+            h = paper_rag_health()
+        assert h.status == "degraded"
+
+    def test_live_reported_free_once_already_loaded(self, monkeypatch):
+        """After a real retrieval loaded the model, /health reports live with
+        no further allocation and without calling the loader again."""
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
+        _reset_model_cache()
+        rag_module._embedding_model = _fake_model()
+        loader = MagicMock()
+        try:
+            with patch.object(rag_module, "_get_embedding_model", loader):
+                h = paper_rag_health()
+        finally:
+            _reset_model_cache()
+        loader.assert_not_called()
+        assert h.status == "live"
+
+    def test_disabled_short_circuits_before_any_disk_check(self, monkeypatch):
+        monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "false")
+        _reset_model_cache()
+        probe = MagicMock(return_value=True)
+        with patch.object(rag_module, "_weights_present", probe):
+            h = paper_rag_health()
+        probe.assert_not_called()
+        assert h.status == "disabled"
 
 
 # ── _get_embedding_model caching ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`/health` was loading a machine-learning model to answer a liveness probe.

`main.py:580` calls `paper_rag_health()`, which called `_get_embedding_model()`, which constructs `SentenceTransformer('all-MiniLM-L6-v2')` — importing torch and sentence-transformers into the API process. The ALB health-checks `/health` **every 30 seconds** (`infra/alb.tf`, and `backend/Dockerfile:91` does the same), so this fired unconditionally ~30s after every boot and the memory was never released. That is the `Loading weights: 0/103` line in every production boot log.

**Measured cost in the production image: 521 MB** — torch 207 MB, sentence_transformers 109 MB, the model itself ~205 MB. The backend container's import floor is 374 MB, so this single call *more than doubled* the process, on a task whose entire budget is 3072 MB shared by backend + auth + nginx.

This is one half of the 2026-08-19 OOM crash-loop remediation. It is not the trigger (that is the backtest refresh's row accumulation, handled separately) but it is the largest single reducible allocation and it costs nothing to remove.

## What changed

`paper_rag_health(probe: bool = False)` — the default no longer loads anything:

| state | condition | cost |
|---|---|---|
| `live` | model already loaded in this process | free |
| `degraded` | a load was attempted and failed | free (cached verdict) |
| `ready` | **new** — enabled, weights present on disk, nothing has needed the model yet | free (one `iterdir`) |
| `degraded` | enabled but weights absent from `HF_HOME` | free |

Only `probe=True` loads, and only `/health/paper-rag` passes it — that endpoint exists precisely to *prove* the model loads, so it is the right place to pay 521 MB.

### Why `ready` is a new state rather than reported as `live`

Weights on disk is not proof the model loads. Reporting `live` off a filesystem check would be substituting a plausible proxy for a measurement — the exact pattern [`docs/architectural-principles.md`](docs/architectural-principles.md) § fail-soft forbids. So `ready` is explicit, and `corpus_embedded` stays strictly `paper_rag_status == "live"`.

**Reviewer note — a real behaviour change:** on a fresh container `/health` now reports `paper_rag: "ready"` and `corpus_embedded: false` until the first genuine retrieval loads the model, where previously the health check itself forced it true. I believe this is *more* honest (the field's own comment says "live sentence-transformer embeddings **active**"), but it is a visible change on a claim-bearing field and it touches the same surface as open PR #1315 (corpus retrieval claims), so please sanity-check the interaction before merging.

## Verification

```
pytest backend/tests/test_paper_rag.py \
       backend/tests/test_paper_rag_guardrails.py \
       backend/tests/test_corpus_claim_integrity.py -q      → 55 passed
ruff format --check + ruff check (changed files)            → clean
```

**Direct measurement** (conda env, `HF_HOME` pointed at a nonexistent path so no model is available):

```
AFTER /health path : status=degraded  rss=137.5 MB  delta=  0.0 MB
  torch imported?  : False
  sentence_transformers imported? : False
AFTER probe=True   : status=degraded  rss=430.9 MB  delta=293.5 MB
  torch imported?  : True
```

Zero delta and torch never imported on the ALB path. (293 MB here rather than 521 MB because the model could not be fetched; the 521 MB figure is measured inside the prod image.)

**Mutation check** — per `CLAUDE.md` § "A guard must be shown to reject something", I reverted the fix (forced `probe=False` to fall through to the load) and re-ran the new guard class:

```
FAILED TestHealthDoesNotLoadModel::test_default_call_never_loads_the_model
        - AssertionError: Expected 'mock' to not have been called. Called 1 times.
FAILED TestHealthDoesNotLoadModel::test_ready_when_weights_present_but_unloaded
        - AssertionError: assert 'live' == 'ready'
FAILED TestHealthDoesNotLoadModel::test_degraded_when_weights_missing
        - AssertionError: assert 'live' == 'degraded'
3 failed, 3 passed
```

Restored → `6 passed`. The guard rejects the thing it exists to reject. (The mutated run also took 15.5s for a single test, because it really did load the model.)

## Anti-goals honoured

- No change to `_get_embedding_model()` itself — the lazy-load, the `torch.set_num_threads(1)` CPU guardrail from the 2026-07-04 starvation incident, and the TF-IDF fallback are all untouched.
- No new dependency, no new endpoint, no new polling.
- `corpus_embedded` semantics deliberately **not** loosened to absorb `ready`.

## Related

- Part of the 2026-08-19 prod OOM incident. The trigger itself — unbounded `backtest_results` row growth plus an unbounded reader, unmasked by #1263 — is a separate PR.
- Interacts with #1315 (corpus retrieval claims) as noted above.
