### PR TITLE
[backend] Resolve latest-backtest-per-strategy in SQL instead of loading the whole table

### DIFF
--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -11,6 +11,7 @@ import os
 from collections.abc import Iterable
 from datetime import UTC, datetime
 
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from archimedes.models.backtest import BacktestResult
@@ -251,19 +252,38 @@ def latest_backtests_by_strategy(
     if not ids:
         return {}
 
-    rows = (
-        session.query(BacktestResultRecord)
-        .filter(BacktestResultRecord.strategy_id.in_(ids))
-        .order_by(
-            BacktestResultRecord.strategy_id.asc(),
-            BacktestResultRecord.created_at.desc(),
-            BacktestResultRecord.id.desc(),
+    # Resolve "latest per strategy" IN THE DATABASE, then hydrate only those
+    # rows. The previous implementation `.all()`-ed every row for every id and
+    # reduced in Python, which meant fetching N_refreshes x N_strategies rows to
+    # return N_strategies. Each row carries a ~489 KB artifact_json plus a
+    # ~108 KB equity_curve_json, and nothing dedupes them (canonical_artifact_hash
+    # includes run_id, a timestamp, so content_hash is unique per run by
+    # construction), so the table grows ~30 rows per refresh cycle forever.
+    # Measured cost of the old path: 0.58 MB of peak RSS per persisted row,
+    # perfectly linear — 21 MB at 34 rows, 395 MB at 680 rows. That staircase is
+    # what pushed the 2026-08-19 backend past its 3072 MB task budget.
+    #
+    # The inner query deliberately selects ONLY the id column: the window
+    # function must not drag the JSON payloads through the client buffer. Window
+    # functions are available on Postgres and on SQLite >= 3.25 (the test path).
+    ranked = (
+        select(
+            BacktestResultRecord.id.label("id"),
+            func.row_number()
+            .over(
+                partition_by=BacktestResultRecord.strategy_id,
+                order_by=(
+                    BacktestResultRecord.created_at.desc(),
+                    BacktestResultRecord.id.desc(),
+                ),
+            )
+            .label("rank"),
         )
-        .all()
+        .where(BacktestResultRecord.strategy_id.in_(ids))
+        .subquery()
     )
+    latest_ids = select(ranked.c.id).where(ranked.c.rank == 1)
 
-    latest: dict[str, BacktestResultRecord] = {}
-    for row in rows:
-        if row.strategy_id not in latest:
-            latest[row.strategy_id] = row
-    return latest
+    rows = session.query(BacktestResultRecord).filter(BacktestResultRecord.id.in_(latest_ids)).all()
+
+    return {row.strategy_id: row for row in rows}

--- a/backend/tests/test_backtest_repository.py
+++ b/backend/tests/test_backtest_repository.py
@@ -9,7 +9,7 @@ from archimedes.services.backtest_repository import (
     insert_backtest_if_missing,
     latest_backtests_by_strategy,
 )
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 
@@ -192,3 +192,105 @@ def test_replay_script_passes_explicit_none() -> None:
         assert isinstance(kw["source_git_sha"], ast.Constant) and kw["source_git_sha"].value is None, (
             "replay must pass source_git_sha=None (explicit unknown), not the running build's SHA"
         )
+
+
+# ── Bounded reader (2026-08-19 OOM regression guard) ─────────────────────────
+#
+# `latest_backtests_by_strategy` used to `.all()` every row for every strategy
+# and reduce in Python. Because `canonical_artifact_hash` includes `run_id` (a
+# timestamp), `insert_backtest_if_missing` never dedupes, so the table grows by
+# ~30 rows on every refresh cycle forever. Each row carries a ~489 KB
+# artifact_json, and the old read cost a measured 0.58 MB of peak RSS per
+# persisted row — the staircase that pushed the backend past its 3072 MB task
+# budget on 2026-08-19. These tests pin the "resolve in SQL, hydrate only the
+# winners" contract.
+
+
+def _seeded_session(n_strategies: int, n_cycles: int):
+    """A session over a DB holding n_strategies x n_cycles rows."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    ids = [f"strat_{i:03d}" for i in range(n_strategies)]
+    for cycle in range(n_cycles):
+        for sid in ids:
+            # sharpe encodes the cycle so we can assert WHICH row came back.
+            insert_backtest_if_missing(
+                session,
+                strategy_id=sid,
+                content_hash=f"{sid}-cycle-{cycle}",
+                result=_sample_result(sid, float(cycle)),
+                source_pipeline="run_backtests",
+                run_id=f"run-{cycle}",
+            )
+    session.commit()
+    return session, ids
+
+
+def test_latest_backtests_returns_the_newest_row_per_strategy() -> None:
+    session, ids = _seeded_session(n_strategies=5, n_cycles=8)
+    try:
+        latest = latest_backtests_by_strategy(session, ids)
+        assert set(latest) == set(ids)
+        # Cycle 7 was inserted last, so it must be the one returned for each id.
+        for sid in ids:
+            assert latest[sid].sharpe_ratio == 7.0, sid
+    finally:
+        session.close()
+
+
+def test_latest_backtests_hydrates_only_one_row_per_strategy() -> None:
+    """THE GUARD: 34 strategies x 20 cycles = 680 rows on disk must still
+    hydrate exactly 34 ORM objects. The old `.all()` implementation loaded all
+    680 — this assertion is what makes that regression impossible to reintroduce.
+    """
+    n_strategies, n_cycles = 34, 20
+    session, ids = _seeded_session(n_strategies=n_strategies, n_cycles=n_cycles)
+    try:
+        total_rows = session.query(BacktestResultRecord).count()
+        assert total_rows == n_strategies * n_cycles, "seed did not produce duplicates"
+
+        session.expunge_all()
+
+        # Count hydration via the mapper "load" event, which fires once per row
+        # the ORM materialises from the DB. Counting session.identity_map instead
+        # does NOT work: the identity map holds WEAK references, so rows the old
+        # implementation loaded and then discarded are garbage-collected before
+        # the assertion runs and the test passes against the unfixed code.
+        loaded: list[str] = []
+
+        def _count(target, _context) -> None:
+            loaded.append(target.strategy_id)
+
+        event.listen(BacktestResultRecord, "load", _count)
+        try:
+            latest = latest_backtests_by_strategy(session, ids)
+        finally:
+            event.remove(BacktestResultRecord, "load", _count)
+
+        assert len(latest) == n_strategies
+        assert len(loaded) == n_strategies, (
+            f"hydrated {len(loaded)} BacktestResultRecord rows to return {n_strategies}; "
+            f"the reader is loading the whole table ({total_rows} rows on disk)"
+        )
+    finally:
+        session.close()
+
+
+def test_latest_backtests_ignores_unrequested_strategies() -> None:
+    session, ids = _seeded_session(n_strategies=6, n_cycles=3)
+    try:
+        subset = ids[:2]
+        latest = latest_backtests_by_strategy(session, subset)
+        assert set(latest) == set(subset)
+    finally:
+        session.close()
+
+
+def test_latest_backtests_empty_ids_short_circuits() -> None:
+    session, _ = _seeded_session(n_strategies=2, n_cycles=2)
+    try:
+        assert latest_backtests_by_strategy(session, []) == {}
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary

`latest_backtests_by_strategy()` fetched **every** row for every requested strategy and reduced in Python, keeping one row per strategy and throwing the rest away. It loaded `N_refresh_cycles × N_strategies` rows in order to return `N_strategies`.

That would be merely wasteful if the table were bounded. It is not:

- `canonical_artifact_hash()` ([`backtest_mapper.py:119-127`](backend/archimedes/services/backtest_mapper.py#L119-L127)) hashes the **whole payload**, which includes `run_id` — a UTC timestamp minted per run ([`cli.py:160`](analytics-engine/src/archimedes_analytics_engine/cli.py#L160)) — and `timestamp_utc`.
- So `content_hash` is unique per run **by construction**, and `insert_backtest_if_missing` can never match an existing row.
- The scheduler runs a refresh on **every container start** (`_last_unresolved_missing` is a module global reset each process), so the table grows by ~30 rows per cycle, forever.
- Every row carries a **~489 KB `artifact_json`** plus a **~108 KB `equity_curve_json`**.

**Measured cost of the old read path: 0.58 MB of peak RSS per persisted row, perfectly linear** — 21 MB at 34 rows, 201 MB at 340, 395 MB at 680.

That staircase is what walked the 2026-08-19 backend from a flat 842 MB plateau to 2.6 GB against a **3,072 MB task budget shared with `auth` and `nginx`**, until the T+180s refresh spike crossed the limit and the OOM killer took the container — repeatedly, with `desiredCount=1`, so every kill was a full site outage.

## What changed

A `row_number()` window partitioned by `strategy_id` resolves the winners **in the database**; only those rows are hydrated.

The inner query deliberately selects **only `id`** — the window must not drag the 489 KB payload columns through the client buffer. Ordering semantics are unchanged (`created_at DESC`, then `id DESC`).

Window functions are available on Postgres (prod) and SQLite ≥ 3.25 (the hermetic test path; this machine has 3.53.1).

## Verification

```
pytest backend/tests/test_backtest_repository.py \
       backend/tests/test_backtest_scheduler.py \
       backend/tests/test_backtest_mapper.py -q      → 25 passed
ruff format --check + ruff check (changed files)     → clean
```

All five production callers exercised: `_generated_strategy_rigor`, `get_strategy_returns`, `needs_refresh`, `_remember_unresolved_missing`, `_load_backtests`.

### The guard, and the first version of it that was worthless

Per `CLAUDE.md` § "A guard must be shown to reject something", I mutation-checked by restoring the old `.all()` reader.

**My first attempt passed against the unfixed code.** It counted `session.identity_map` after the call — but the identity map holds **weak references**, so the 646 rows the old implementation loaded and discarded were garbage-collected before the assertion ran. It would have guarded nothing while looking like coverage. This is exactly rule 3 in that section, and I nearly shipped it.

The guard now counts hydration through the SQLAlchemy mapper `load` event, which fires once per row materialised from the DB regardless of what survives GC. Re-running the mutation:

```
AssertionError: hydrated 680 BacktestResultRecord rows to return 34;
                the reader is loading the whole table (680 rows on disk)
FAILED test_latest_backtests_hydrates_only_one_row_per_strategy
```

Restored → `9 passed`.

## Scope — what this does NOT fix

This bounds the **read**. It does **not** stop the table growing, and it does not reclaim the rows already accumulated in production. Two follow-ups, filed separately so they can be reviewed on their own merits:

1. **`canonical_artifact_hash` must exclude `run_id`/`timestamp_utc`** so `insert_backtest_if_missing` can actually dedupe. This changes hash semantics for existing rows and deserves its own review.
2. **The accumulated duplicate rows need a one-off cleanup**, and nobody has yet read the real row count in production — `SELECT strategy_id, count(*) FROM backtest_results GROUP BY 1 ORDER BY 2 DESC;` should be the first thing run.

Also unaddressed here, deliberately: whether a full 34-strategy backtrader re-run belongs inside the request-serving container at all (its own module docstring says re-triggering "burns the box's 2 vCPUs for ~15 min").

## Anti-goals honoured

- No change to write-path behaviour, to `insert_backtest_if_missing`, or to the hash.
- No change to ordering semantics or to the function's signature/return type.
- No new dependency; no raw SQL string (stays in the SQLAlchemy expression layer so SQLite and Postgres both work).

## Related

- Companion to #1328 (`/health` no longer loads the embedding model — 521 MB). Together these take the backend from a 2,956 MB peak toward roughly 800 MB inside the existing 3,072 MB budget, with **no memory bump and no cost increase**.
- Root cause traced to #1263, which fixed a real artifact-write `PermissionError` and thereby unmasked these two latent unbounded defects — before it, rows never persisted at all.
