### PR TITLE
[infra] Make a verbatim .env.example bootstrap the local stack; refuse the placeholder in prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -295,7 +295,11 @@ PRICE_ORACLE_ADDRESS=0xe1c9f2b11be97097223a66a188fca541e07873a6
 SYNTHETIC_FACTORY_ADDRESS=
 AMM_ROUTER_ADDRESS=0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4
 VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32
-REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6
+# v1.5 registry — the one production runs (confirmed via GET /api/config/contracts).
+# The previous value here, 0x42d8a23e…, is the superseded v1 anchor-only deployment:
+# an on-chain selector scan shows commit/executeTrade/reveal/getCommitment ABSENT on
+# it, so a local stack pointed at it silently cannot do commit-before-trade.
+REASONING_TRACE_REGISTRY_ADDRESS=0x9d81bfbfadb683cf77acda480e94e64088012847
 ASSET_REGISTRY_ADDRESS=0x2d44550711137916df6175587d17886281a0fbc7
 STRATEGY_REGISTRY_ADDRESS=0x728C264d0681b71c4Cc1D26a4fb14Ec29D9a90e4
 
@@ -317,7 +321,7 @@ STRATEGY_REGISTRY_ADDRESS=0x728C264d0681b71c4Cc1D26a4fb14Ec29D9a90e4
 # ARC_AMM_ROUTER_ADDRESS=0xd5b829f9d364a8bbe1caf6c8b19cb05371b178f4
 # ARC_SYNTHETIC_FACTORY_ADDRESS=
 # ARC_VAULT_FACTORY_ADDRESS=0xca873414070844aeb98b0bf1051f81969c79cc32
-# ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x42d8a23edb897cbee203e9fa197eb05ab5106ca6
+# ARC_REASONING_TRACE_REGISTRY_ADDRESS=0x9d81bfbfadb683cf77acda480e94e64088012847
 # ARC_ASSET_REGISTRY_ADDRESS=0x2d44550711137916df6175587d17886281a0fbc7
 # ARC_STRATEGY_REGISTRY_ADDRESS=0x728C264d0681b71c4Cc1D26a4fb14Ec29D9a90e4
 #
@@ -358,7 +362,14 @@ PUBLIC_DOMAIN=
 # REQUIRED: generate locally, then paste value after `=`. Production value
 # belongs in SSM /archimedes/prod/BETTER_AUTH_SECRET.
 #   python -c "import secrets; print(secrets.token_urlsafe(48))"
-BETTER_AUTH_SECRET=
+#
+# The value below is a PUBLIC PLACEHOLDER so that a verbatim `cp .env.example .env`
+# gives a working local stack. Leaving it empty broke EVERY docker compose command
+# — including `down` — because compose resolves ${BETTER_AUTH_SECRET:?...} before
+# it runs any action. It signs session cookies, so createAuth() REFUSES to boot
+# with this exact value when NODE_ENV=production (auth/auth.js). Replace it for
+# anything you deploy.
+BETTER_AUTH_SECRET=insecure-local-dev-placeholder-change-me-before-any-deploy
 BETTER_AUTH_URL=http://localhost:8080
 BETTER_AUTH_INTERNAL_URL=http://auth:3000
 BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:8080,http://localhost:5173

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -17,6 +17,10 @@ function csv(value) {
 // unverified account is REFUSED sign-in. Explicit opt-in ("true") because
 // SES starts in sandbox — enforcement flips on via env once production
 // sending access is granted, with no code change.
+// The literal shipped in .env.example. Public by design, refused in production
+// by createAuth() — keep these two in lockstep; auth/test/auth.test.js pins it.
+export const PLACEHOLDER_SECRET = 'insecure-local-dev-placeholder-change-me-before-any-deploy'
+
 export function emailVerificationEnforced(env = process.env) {
   return env.EMAIL_VERIFICATION_ENFORCED === 'true'
 }
@@ -42,6 +46,19 @@ export function createAuth({ database, env = process.env, mailer = createMailer(
 
   if (!secret || secret.length < 32) {
     throw new Error('BETTER_AUTH_SECRET must contain at least 32 characters')
+  }
+
+  // .env.example ships PLACEHOLDER_SECRET so that `cp .env.example .env` gives a
+  // working LOCAL stack — without it every docker compose command, including
+  // `down`, dies during interpolation on `${BETTER_AUTH_SECRET:?}`. The value is
+  // public by construction, so it must never boot a deployed environment: it
+  // signs session cookies, and anyone reading the repo could forge them.
+  if (production && secret === PLACEHOLDER_SECRET) {
+    throw new Error(
+      'BETTER_AUTH_SECRET is still the public .env.example placeholder. '
+      + 'Set a real secret (production reads SSM /archimedes/prod/BETTER_AUTH_SECRET). '
+      + 'Generate one with: python -c "import secrets; print(secrets.token_urlsafe(48))"',
+    )
   }
 
   // node-postgres does NOT honor libpq's `sslmode` query parameter — it must

--- a/auth/test/auth.test.js
+++ b/auth/test/auth.test.js
@@ -4,7 +4,7 @@ import test from 'node:test'
 
 import { getMigrations } from 'better-auth/db/migration'
 
-import { createAuth, enabledProviders } from '../auth.js'
+import { createAuth, enabledProviders, PLACEHOLDER_SECRET } from '../auth.js'
 
 const env = {
   NODE_ENV: 'test',
@@ -149,4 +149,48 @@ test('enforcement flag parses strictly', async () => {
   assert.equal(emailVerificationEnforced({ EMAIL_VERIFICATION_ENFORCED: 'false' }), false)
   assert.equal(emailVerificationEnforced({ EMAIL_VERIFICATION_ENFORCED: '1' }), false)
   assert.equal(emailVerificationEnforced({ EMAIL_VERIFICATION_ENFORCED: 'true' }), true)
+})
+
+
+// ── .env.example placeholder must never boot production ─────────────────────
+//
+// .env.example ships PLACEHOLDER_SECRET so `cp .env.example .env` gives a
+// working local stack (an empty value broke every docker compose command,
+// including `down`, during ${BETTER_AUTH_SECRET:?} interpolation). The value is
+// public, and it signs session cookies — anyone reading the repo could forge
+// them — so production must refuse it.
+
+test('the public .env.example placeholder is refused in production', () => {
+  assert.throws(
+    () => createAuth({
+      database: new DatabaseSync(':memory:'),
+      env: { ...env, NODE_ENV: 'production', BETTER_AUTH_SECRET: PLACEHOLDER_SECRET },
+    }),
+    /still the public \.env\.example placeholder/,
+  )
+})
+
+test('the placeholder is accepted outside production so local dev works', () => {
+  assert.doesNotThrow(() => createAuth({
+    database: new DatabaseSync(':memory:'),
+    env: { ...env, NODE_ENV: 'development', BETTER_AUTH_SECRET: PLACEHOLDER_SECRET },
+  }))
+})
+
+test('a real secret still boots in production', () => {
+  assert.doesNotThrow(() => createAuth({
+    database: new DatabaseSync(':memory:'),
+    env: { ...env, NODE_ENV: 'production', BETTER_AUTH_SECRET: 'a-genuinely-random-production-secret-value-x7f2' },
+  }))
+})
+
+test('PLACEHOLDER_SECRET is exactly what .env.example ships', async () => {
+  const { readFileSync } = await import('node:fs')
+  const envExample = readFileSync(new URL('../../.env.example', import.meta.url), 'utf8')
+  const line = envExample.split('\n').find(l => l.startsWith('BETTER_AUTH_SECRET='))
+  assert.equal(line, `BETTER_AUTH_SECRET=${PLACEHOLDER_SECRET}`)
+})
+
+test('the shipped placeholder still satisfies the 32-char floor', () => {
+  assert.ok(PLACEHOLDER_SECRET.length >= 32)
 })

--- a/backend/tests/test_local_setup_contract.py
+++ b/backend/tests/test_local_setup_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 import unittest
@@ -26,7 +27,15 @@ def _template_env() -> dict[str, str]:
 
 def _compose_config(*, local: bool) -> dict:
     template = (ROOT / ".env.example").read_text()
-    template = template.replace("BETTER_AUTH_SECRET=", f"BETTER_AUTH_SECRET={TEST_AUTH_SECRET}", 1)
+    # Full-line substitution, not a prefix replace: .env.example now ships a
+    # non-empty placeholder value (PLACEHOLDER_SECRET in auth/auth.js), so a
+    # bare `.replace("BETTER_AUTH_SECRET=", "BETTER_AUTH_SECRET=<value>", 1)`
+    # would only prepend TEST_AUTH_SECRET onto that placeholder instead of
+    # overriding it — the resulting line would end up concatenated, not equal
+    # to TEST_AUTH_SECRET. re.sub with MULTILINE replaces the whole line.
+    template = re.sub(
+        r"^BETTER_AUTH_SECRET=.*$", f"BETTER_AUTH_SECRET={TEST_AUTH_SECRET}", template, count=1, flags=re.MULTILINE
+    )
     command = ["docker", "compose"]
     if local:
         template = template.replace("\nCOMPOSE_PROFILES=localdb\n", "\nCOMPOSE_PROFILES=localdb,runners\n", 1)
@@ -73,6 +82,20 @@ class TestLocalSetupContract(unittest.TestCase):
         self.assertEqual(
             self.config["services"]["nginx"]["ports"],
             [{"mode": "ingress", "target": 8080, "published": str(host_port), "protocol": "tcp"}],
+        )
+
+    def test_composed_auth_secret_equals_the_test_override_exactly(self) -> None:
+        """_compose_config's TEST_AUTH_SECRET substitution must fully REPLACE
+        whatever .env.example ships for BETTER_AUTH_SECRET, not concatenate
+        onto it. .env.example now ships a non-empty public placeholder
+        (auth/auth.js PLACEHOLDER_SECRET) for a verbatim `cp .env.example .env`
+        to work, so a naive prefix-replace of "BETTER_AUTH_SECRET=" would
+        prepend TEST_AUTH_SECRET onto that placeholder instead of overriding
+        it. The composed value reaching the auth service must be exactly
+        TEST_AUTH_SECRET — nothing appended, nothing left over."""
+        self.assertEqual(
+            self.config["services"]["auth"]["environment"]["BETTER_AUTH_SECRET"],
+            TEST_AUTH_SECRET,
         )
 
     def test_local_apps_wait_for_successful_schema_migration(self) -> None:


### PR DESCRIPTION
## Summary

`cp .env.example .env` — the exact command the file's own header tells you to run — produced a `.env` that broke **every** `docker compose` command:

```
error while interpolating services.auth.environment.BETTER_AUTH_SECRET:
required variable BETTER_AUTH_SECRET is missing a value: Set BETTER_AUTH_SECRET in .env
```

`BETTER_AUTH_SECRET` shipped empty (`.env.example:361`) while [`docker-compose.yml:167`](docker-compose.yml#L167) requires it via `${BETTER_AUTH_SECRET:?…}`. It was the **only** compose-required variable shipped empty — `DATABASE_URL` and `POSTGRES_PASSWORD` both have working values.

Worse than a failed `up`: compose resolves interpolation **before it runs any action**, so this also broke `docker compose down`. You could not tear down a stack you had already started, and the error text points at a variable you may never have needed to think about.

The file header promises the opposite: *"Most defaults work out of the box for local development."*

## What changed

**1. `.env.example` ships a public placeholder** so a verbatim copy bootstraps the stack.

**2. That placeholder is refused in production.** It signs session cookies and is readable by anyone with the repo, so `createAuth()` throws when it sees exactly that value with `NODE_ENV=production`:

```js
if (production && secret === PLACEHOLDER_SECRET) {
  throw new Error('BETTER_AUTH_SECRET is still the public .env.example placeholder. …')
}
```

The literal lives in `auth/auth.js` as `PLACEHOLDER_SECRET`, and a test asserts `.env.example` still ships exactly that string — so the two cannot silently drift apart. The existing 32-character floor is untouched (the placeholder satisfies it).

**3. Corrected `REASONING_TRACE_REGISTRY_ADDRESS`** (both the bare and the `ARC_`-prefixed commented variant). It pointed at `0x42d8a23e…`, the **superseded v1 anchor-only registry**. An on-chain selector scan against Arc testnet:

| selector | `0x42d8a23e…` (was in .env.example) | `0x9d81bfbf…` (production) |
|---|---|---|
| `commit(address,bytes32,uint64,bytes32,bytes)` | **ABSENT** | PRESENT |
| `executeTrade(bytes32)` | **ABSENT** | PRESENT |
| `reveal(uint256,string,bytes)` | **ABSENT** | PRESENT |
| `getCommitment(uint256)` | **ABSENT** | PRESENT |
| `publishTrace(address,bytes32,bytes)` | PRESENT | PRESENT |

Production serves `0x9d81bfbf…` from `GET /api/config/contracts`. A local stack pointed at the old address silently **cannot do commit-before-trade** — it would fall back to bare anchoring while the UI claims ordering is contract-enforced.

## Verification

```
docker compose --env-file <verbatim copy of .env.example> config   → OK
same, with BETTER_AUTH_SECRET emptied                              → reproduces the original error verbatim
cd auth && npm ci && npm test                                      → 19 passed
```

**Mutation check** (`CLAUDE.md` § "A guard must be shown to reject something") — disabling the production guard:

```
✖ the public .env.example placeholder is refused in production
  AssertionError [ERR_ASSERTION]: Missing expected exception.
```

Restored → all pass.

Note: `auth/node_modules` was absent on a fresh clone, so `npm test` failed with `Cannot find package 'better-auth'` before `npm ci`. That is not introduced here, but it means `auth/`'s tests are easy to skip accidentally — see the follow-up note below.

## Anti-goals honoured

- **No real secret is committed.** The placeholder is deliberately non-secret and is rejected in production.
- `docker-compose.yml` and `docker-compose.production.yml` are **not** modified — the `${VAR:?…}` guards stay exactly as they are.
- The 32-char minimum, `revokeSessionsOnPasswordReset`, and `requireEmailVerification` are untouched.
- No change to any real contract address used by production.

## Follow-ups (not in this PR)

- ~~`auth/` has no CI job running `npm test`~~ — **retracted, this was wrong.** `.github/workflows/quality-gate.yml:158` runs `cd auth && npm ci --quiet && npm test` in the "Frontend + Better Auth" job, and it passed on this PR. The only real point was local: `auth/node_modules` is absent on a fresh clone, so `npm test` fails locally until you `npm ci`. CI is fine.
- The stale address also raises a live defect I filed separately: `supports_commit_reveal()` ([`trace_publisher.py:36-48`](backend/archimedes/chain/trace_publisher.py#L36-L48)) checks `hasattr()` against the **locally cached ABI**, not the chain. `contracts/abis/ReasoningTraceRegistry.json` contains `commit`/`reveal`, so that guard **always returns `True`** and its documented `publishTrace` fallback can never fire. `verifyTrace` is in that ABI but on neither deployed contract.
