### PR TITLE
[frontend] Gate Library's Published tab behind ROADMAP_SURFACES_ENABLED

### DIFF
--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -5,6 +5,7 @@ import RigorExplainer from './RigorExplainer'
 import RigorStrictnessControl, { levelLabel } from './RigorStrictnessControl'
 import { useRigorStrictness, BADGE_LEVEL } from '../hooks/useRigorStrictness'
 import useDialogFocus from '../hooks/useDialogFocus'
+import { ROADMAP_SURFACES_ENABLED } from '../featureFlags.js'
 
 import { apiGet, apiPost, apiDelete } from '../api'
 
@@ -634,8 +635,13 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
   // to their badge boolean (no chip).
   const [deployMap, setDeployMap] = useState({})
   // 'generated' is the first-class tab per product feedback — pushes user
-  // toward Generate when empty.
-  const [activeTab, setActiveTab] = useState(() => defaultTab || 'generated')
+  // toward Generate when empty. Published is a hidden roadmap surface
+  // (#1266/#1324) — a ?tab=published deep link must not land there with the
+  // flag off, since the tab button that would normally set this is gone too.
+  const [activeTab, setActiveTab] = useState(() => {
+    if (defaultTab === 'published' && !ROADMAP_SURFACES_ENABLED) return 'generated'
+    return defaultTab || 'generated'
+  })
   // Page-level rigor explainer modal, opened from any row expansion's "?"
   // affordance. Single modal instance per page keeps state simple.
   const [rigorModalOpen, setRigorModalOpen] = useState(false)
@@ -662,11 +668,13 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
     setLoading(true)
     setLoadError('')
     try {
+      // Published is a hidden roadmap surface (#1266/#1324) — its fetch must
+      // not fire with the flag off, not just its tab stay unclickable.
       const [seedRes, genRes, gateRes, publishedRes] = await Promise.allSettled([
         apiGet('/api/strategies/'),
         apiGet('/api/strategies/generated'),
         apiGet('/api/selection-bias/gate'),
-        apiGet('/api/marketplace/my-published'),
+        ROADMAP_SURFACES_ENABLED ? apiGet('/api/marketplace/my-published') : Promise.resolve([]),
       ])
       if (seedRes.status === 'fulfilled') {
         const sorted = [...(seedRes.value.strategies || [])].sort(
@@ -733,14 +741,19 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
         >
           Examples ({examples.length})
         </button>
-        <button
-          type="button"
-          className={`tag ${activeTab === 'published' ? 'tag-accent' : 'tag-muted'}`}
-          aria-pressed={activeTab === 'published'}
-          onClick={() => setActiveTab('published')}
-        >
-          Published ({published.length})
-        </button>
+        {/* Published leads into the marketplace surface #1266 hid — hides
+            with it (#1324). Anti-goal: gating render alone without gating
+            the fetch above would still hit the hidden API every load. */}
+        {ROADMAP_SURFACES_ENABLED && (
+          <button
+            type="button"
+            className={`tag ${activeTab === 'published' ? 'tag-accent' : 'tag-muted'}`}
+            aria-pressed={activeTab === 'published'}
+            onClick={() => setActiveTab('published')}
+          >
+            Published ({published.length})
+          </button>
+        )}
       </div>
 
       {loadError && (
@@ -862,7 +875,7 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
         </>
       )}
 
-      {activeTab === 'published' && (
+      {activeTab === 'published' && ROADMAP_SURFACES_ENABLED && (
         <>
           <div className="caption mb-3 text-[var(--text-3)] leading-relaxed">
             Strategies you have published to the on-chain marketplace. Subscribers

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -188,6 +188,40 @@ test("roadmap surfaces are hidden by default: flat routes, deep links, nav (#126
 	assert.equal(visibleNavigation(nav, ROADMAP_ON, { id: "u1" }).length, 6);
 });
 
+test("Library's in-page Published tab hides with the marketplace surface it leads into (#1324)", () => {
+	// #1266's dead-door audit only checked route/nav call sites
+	// (onNavigate/setPage/navigateToPage); it couldn't see a tab that
+	// renders and fetches inline with no route of its own. Strategies.jsx
+	// (the Library page, itself NOT a hidden route) must gate its Published
+	// tab the same way routes.js gates a hidden page: import the one flag
+	// and use it, not a second bespoke check.
+	const strategiesSrc = readFileSync(
+		new URL("../src/components/Strategies.jsx", import.meta.url),
+		"utf8",
+	);
+	assert.match(
+		strategiesSrc,
+		/import \{ ROADMAP_SURFACES_ENABLED \} from '\.\.\/featureFlags\.js'/,
+	);
+	// 1. The fetch must not fire unconditionally — a hidden tab that still
+	// calls the hidden API on every Library load is the exact bug filed.
+	assert.match(
+		strategiesSrc,
+		/ROADMAP_SURFACES_ENABLED \? apiGet\('\/api\/marketplace\/my-published'\) : Promise\.resolve\(\[\]\)/,
+	);
+	// 2. The tab button must not render unconditionally.
+	assert.match(
+		strategiesSrc,
+		/\{ROADMAP_SURFACES_ENABLED && \(\s*<button[\s\S]*?Published \(\{published\.length\}\)/,
+	);
+	// 3. The tab panel must not render either — belt-and-suspenders against
+	// a stale ?tab=published deep link coercing activeTab directly.
+	assert.match(
+		strategiesSrc,
+		/activeTab === 'published' && ROADMAP_SURFACES_ENABLED && \(/,
+	);
+});
+
 test("anonymous nav shows browse + the Generate conversion path, nothing stateful", () => {
 	const nav = [
 		{ id: "explore" },

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -232,7 +232,7 @@ test("Library's in-page Published tab hides with the marketplace surface it lead
 	// evaluate false and Library would render an empty content area.
 	assert.match(
 		strategiesSrc,
-		/defaultTab === 'published' && !ROADMAP_SURFACES_ENABLED/,
+		/defaultTab === 'published' && !ROADMAP_SURFACES_ENABLED\) return 'generated'/,
 	);
 });
 

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -209,16 +209,30 @@ test("Library's in-page Published tab hides with the marketplace surface it lead
 		strategiesSrc,
 		/ROADMAP_SURFACES_ENABLED \? apiGet\('\/api\/marketplace\/my-published'\) : Promise\.resolve\(\[\]\)/,
 	);
-	// 2. The tab button must not render unconditionally.
+	// 2. The tab button must not render unconditionally. Anchored directly to
+	// the Published button's own attributes (no `[\s\S]*?` gap) — a lazy gap
+	// here previously let an unrelated gated button elsewhere in the file
+	// satisfy the assertion while the real Published tab stayed ungated.
+	// Demonstrated: inserting `{ROADMAP_SURFACES_ENABLED && (<button ...>Publish
+	// to marketplace</button>)}` above the tab row while removing the Published
+	// tab's own gate passed the old regex and fails this one.
 	assert.match(
 		strategiesSrc,
-		/\{ROADMAP_SURFACES_ENABLED && \(\s*<button[\s\S]*?Published \(\{published\.length\}\)/,
+		/\{ROADMAP_SURFACES_ENABLED && \(\s*<button\s+type="button"\s+className=\{`tag \$\{activeTab === 'published'/,
 	);
 	// 3. The tab panel must not render either — belt-and-suspenders against
 	// a stale ?tab=published deep link coercing activeTab directly.
 	assert.match(
 		strategiesSrc,
 		/activeTab === 'published' && ROADMAP_SURFACES_ENABLED && \(/,
+	);
+	// 4. The activeTab deep-link fallback: with the flag off, a stale
+	// ?tab=published link must not leave activeTab pinned to 'published' —
+	// every panel (generated/examples/now-gated published) would then
+	// evaluate false and Library would render an empty content area.
+	assert.match(
+		strategiesSrc,
+		/defaultTab === 'published' && !ROADMAP_SURFACES_ENABLED/,
 	);
 });
 


### PR DESCRIPTION
## Summary

PR #1266 hid Marketplace, Publish, Subscriptions, Portfolio/vaults and Learnings behind `ROADMAP_SURFACES_ENABLED`, but its dead-door audit only checked route/nav call sites (`onNavigate`/`setPage`/`navigateToPage`) — it couldn't see a tab that renders and fetches **inline**, with no route of its own. `Strategies.jsx` (the Library page, itself not a hidden route) shipped a live "Published" tab that fetched `/api/marketplace/my-published` unconditionally on every Library load and rendered a panel for a feature with no publish flow or marketplace page left to reach it from.

Closes #1324

## Fix

Imported the existing `ROADMAP_SURFACES_ENABLED` flag from `featureFlags.js` into `Strategies.jsx` — same import shape `StrategyPassport.jsx` already uses for its deploy-CTA gate — and applied it at all three call sites:

1. The `/api/marketplace/my-published` fetch in `load()`: `ROADMAP_SURFACES_ENABLED ? apiGet(...) : Promise.resolve([])` — the request no longer fires with the flag off.
2. The Published tab `<button>`: wrapped in `{ROADMAP_SURFACES_ENABLED && (...)}`.
3. The Published tab panel: `activeTab === 'published' && ROADMAP_SURFACES_ENABLED && (...)` — belt-and-suspenders in case a stale `?tab=published` deep link coerces `activeTab` directly (the initial `useState` also falls back to `'generated'` in that case).

No routing, `featureFlags.js`, or `ROADMAP_PAGES` semantics changed — reuses the single existing gate, per the issue's anti-goals. No component code deleted (Published tab logic stays in the tree).

## Acceptance criteria — verified

**1. Fetch is gated, not unconditional:**
```
$ grep -n "my-published" ui/src/components/Strategies.jsx
677:        ROADMAP_SURFACES_ENABLED ? apiGet('/api/marketplace/my-published') : Promise.resolve([]),
```

**2. Extended `ui/test/routes.test.js`'s #1266 handoff test to cover in-page surfaces** — new test `"Library's in-page Published tab hides with the marketplace surface it leads into (#1324)"` pins the import, all three gate sites, and the `activeTab` deep-link fallback via source-regex assertions (same shape as `test/a11y.test.js`'s established pattern — this codebase has no DOM/React-render test harness, so component gating is pinned on source, not rendered output). **Honest scope note (issue #1324 acceptance criterion 2):** these are static source-text assertions against a single checkout; `ROADMAP_SURFACES_ENABLED` is a Vite build-time constant they never toggle, so they cannot and do not exercise the flag-on render path ("the tab DOES render with `roadmapSurfaces: true`"). That half of the criterion is verified only manually, via the two `npm run build` invocations below (confirmed: `my-published` is absent from every `dist/assets/*` file with the flag off, and present in `AuthenticatedApp-*.js` with it on) — not by anything that runs in CI. `Closes #1324` should be read against that: the flag-off path is regression-tested; the flag-on path is not, today.

Full suite, post-fix:
```
$ cd ui && node --test
ℹ tests 91
ℹ pass 91
ℹ fail 0

$ npm run lint        # clean
$ npm run build        # clean, VITE_ROADMAP_SURFACES unset (default off); my-published absent from dist/assets/*
$ VITE_ROADMAP_SURFACES=true npm run build   # clean, flag on; my-published present in dist/assets/AuthenticatedApp-*.js
```

**Mutation check (CLAUDE.md "a guard must be shown to reject something"):** reverted only `Strategies.jsx` to pre-fix (`git checkout HEAD~1 -- ui/src/components/Strategies.jsx`, keeping the new test), reran `node --test test/routes.test.js`:
```
ℹ tests 15
ℹ pass 14
ℹ fail 1
AssertionError: The input did not match /import \{ ROADMAP_SURFACES_ENABLED \} from '\.\.\/featureFlags\.js'/
```
The new guard fails against fully-unfixed code. Re-applied the fix, reran — 15/15 pass.

Two further targeted mutations, added after an adversarial review pass found the original button-gate assertion used a lazy `[\s\S]*?` that let an unrelated gated button anywhere earlier in the file satisfy it while the Published tab itself stayed ungated:
- Inserted `{ROADMAP_SURFACES_ENABLED && (<button ...>Publish to marketplace</button>)}` above the tab row **and** removed the Published tab's own gate → passed the old lazy regex, **fails** the tightened one (`/\{ROADMAP_SURFACES_ENABLED && \(\s*<button\s+type="button"\s+className=\{`tag \$\{activeTab === 'published'/`, anchored directly to the Published button's own attributes, no crossing).
- Reverted only the `activeTab` deep-link-fallback `useState` initializer to its pre-fix form (`() => defaultTab || 'generated'`) → the new fourth assertion (`/defaultTab === 'published' && !ROADMAP_SURFACES_ENABLED/`) catches it; previously nothing did.

**3. Re-ran #1266's dead-door audit across component internals** (not just routes/nav):
```
grep -rn "api/marketplace\|api/subscriptions\|api/vault" ui/src
```
Every call site to these prefixes **outside `Strategies.jsx`** lives inside a component that is itself only reachable through a route already gated by `featureEnabled()`/`ROADMAP_PAGES` in `routes.js` — `MarketplacePage.jsx`, `PublishPage.jsx`, `SubscriptionsPage.jsx`, `StrategyDetailPage.jsx` (`market-strategy`), `VaultDetail.jsx`/`VaultChat.jsx`/`CreateVaultModal.jsx` (`vault-detail`/`portfolio`) — i.e. "backstopped by the routing layer," matching #1266's original conclusion. `Breadcrumbs.jsx` and `OnboardingTour.jsx` already use `roadmapSurfaceHidden()`; `StrategyPassport.jsx`'s deploy CTA already uses the raw `ROADMAP_SURFACES_ENABLED` import (the precedent this fix copies).

**Correction (caught in review, not accurate as originally written):** `Strategies.jsx` itself is *not* fully covered by that "backstopped by routing" story — it has two marketplace call sites of its own, `apiPost(`/api/marketplace/publish/${row.strategy_id}/withdraw`, ...)` and `apiDelete(`/api/marketplace/publish/${row.strategy_id}`)`, both inside the Published panel (the `activeTab === 'published' && ROADMAP_SURFACES_ENABLED` block this PR adds). `Strategies.jsx`/Library is **not** a hidden route — `/app/library` is reachable with the flag off. Those two call sites are unreachable today only because of *this PR's* panel gate, not because of `routes.js`. `Strategies.jsx`'s Published tab (fetch + button + panel + its two action calls) was the one component genuinely missed by #1266 — now fixed, but by a component-local gate, not by the routing backstop the rest of the audit describes.

One adjacent-but-out-of-scope observation, noted for visibility rather than fixed here: `QuantLab.jsx` (`/app/quant`, gated by a separate `features.quant` runtime flag, not `ROADMAP_SURFACES_ENABLED`) reads `/api/vaults/` for allocation-drift display. `quant` was never in `ROADMAP_PAGES` and Quant wasn't part of #1266's or this issue's hidden-surface list, so left as-is — flagging in case that's an intentional gap worth its own issue.

## Anti-goals honored

- Published tab component code untouched/undeleted — only the gate added.
- Gated the fetch, not just the render (issue's explicit anti-goal).
- No changes to `routes.js` or `featureFlags.js` — the single gate is reused as-is.

