### PR TITLE
[auth] Password reset + resend-verification (#1323)

### DIFF
--- a/auth/auth.js
+++ b/auth/auth.js
@@ -78,6 +78,29 @@ export function createAuth({ database, env = process.env, mailer = createMailer(
       maxPasswordLength: 128,
       revokeSessionsOnPasswordReset: true,
       requireEmailVerification: emailVerificationEnforced(env),
+      sendResetPassword: async ({ user, url }) => {
+        try {
+          await mailer.send({
+            to: user.email,
+            subject: 'Reset your Archimedes password',
+            text:
+              'A password reset was requested for your Archimedes account:\n\n'
+              + `${url}\n\n`
+              + 'If you did not request this, ignore this message — your password will not change.',
+          })
+        } catch (error) {
+          // Fail-soft ON PURPOSE, same reasoning as sendVerificationEmail
+          // below: an undeliverable reset mail must not 500 the request.
+          // It matters MORE here than for verification mail — Better Auth
+          // already returns the identical response body/status for a known
+          // vs. unknown email (see requestPasswordReset in
+          // better-auth/dist/api/routes/password.mjs) precisely to prevent
+          // account-enumeration; a 500 that only known accounts can trigger
+          // (unknown emails never reach this callback) would reopen that
+          // same enumeration channel via status code. Loud single line.
+          console.error('reset password email send failed:', error instanceof Error ? error.name : 'UnknownError')
+        }
+      },
     },
     emailVerification: {
       sendOnSignUp: true,

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -79,27 +79,37 @@ export function createAuth({ database, env = process.env, mailer = createMailer(
       revokeSessionsOnPasswordReset: true,
       requireEmailVerification: emailVerificationEnforced(env),
       sendResetPassword: async ({ user, url }) => {
-        try {
-          await mailer.send({
-            to: user.email,
-            subject: 'Reset your Archimedes password',
-            text:
-              'A password reset was requested for your Archimedes account:\n\n'
-              + `${url}\n\n`
-              + 'If you did not request this, ignore this message — your password will not change.',
-          })
-        } catch (error) {
-          // Fail-soft ON PURPOSE, same reasoning as sendVerificationEmail
-          // below: an undeliverable reset mail must not 500 the request.
-          // It matters MORE here than for verification mail — Better Auth
-          // already returns the identical response body/status for a known
-          // vs. unknown email (see requestPasswordReset in
-          // better-auth/dist/api/routes/password.mjs) precisely to prevent
-          // account-enumeration; a 500 that only known accounts can trigger
-          // (unknown emails never reach this callback) would reopen that
-          // same enumeration channel via status code. Loud single line.
+        // Fire-and-forget ON PURPOSE — do not `await` the send. Better Auth
+        // already returns an identical response body/status for a known vs.
+        // unknown email (requestPasswordReset in
+        // better-auth/dist/api/routes/password.mjs: an unknown address
+        // never reaches this callback at all, it takes a dummy-lookup
+        // early-return instead), which is the anti-enumeration design. But
+        // without `advanced.backgroundTasks.handler` configured, Better
+        // Auth's own dispatcher (`runInBackgroundOrAwait` in
+        // better-auth/dist/context/create-context.mjs) does `await promise`
+        // on whatever this callback returns — so an awaited mailer.send()
+        // here would make a known-address request measurably slower than an
+        // unknown-address one (the real SES round trip vs. an immediate
+        // early return), reopening the same enumeration channel through
+        // response TIMING instead of status code. Not awaiting the send
+        // makes this callback's own duration independent of mailer latency
+        // regardless. The `.catch` below is what keeps a mailer failure
+        // fail-soft (same reasoning as sendVerificationEmail below, and
+        // load-bearing here for the same anti-enumeration reason: a 500
+        // that only known accounts could trigger would leak account
+        // existence via status code) — loud single line, logged
+        // asynchronously after the response has already gone out.
+        mailer.send({
+          to: user.email,
+          subject: 'Reset your Archimedes password',
+          text:
+            'A password reset was requested for your Archimedes account:\n\n'
+            + `${url}\n\n`
+            + 'If you did not request this, ignore this message — your password will not change.',
+        }).catch(error => {
           console.error('reset password email send failed:', error instanceof Error ? error.name : 'UnknownError')
-        }
+        })
       },
     },
     emailVerification: {

--- a/auth/test/auth.test.js
+++ b/auth/test/auth.test.js
@@ -211,15 +211,101 @@ test('password reset gives an unknown address the identical response, and sends 
   assert.deepEqual(knownBody, unknownBody)
 })
 
-test('a failing reset mailer never 500s the request (fail-soft, and preserves anti-enumeration)', async () => {
+test('a failing reset mailer never 500s the request, and the failure is actually logged (fail-soft)', async () => {
   const mailer = { kind: 'test', sender: 'x', send: async () => { throw new Error('SES sandbox: address not verified') } }
   const auth = createAuth({ database: new DatabaseSync(':memory:'), env, mailer })
   await (await getMigrations(auth.options)).runMigrations()
   const credentials = { email: 'sandboxed-reset@example.com', password: 'correct horse battery staple' }
   await auth.api.signUpEmail({ body: { ...credentials, name: 'S' }, asResponse: true })
 
-  const response = await auth.api.requestPasswordReset({ body: { email: credentials.email }, asResponse: true })
+  // Better Auth's own runInBackgroundOrAwait no longer touches this failure
+  // at all — sendResetPassword is fire-and-forget (see auth.js), so the
+  // ONLY thing standing between a mailer throw and an unhandled rejection
+  // is the local .catch(). Spy on console.error to prove that catch is
+  // doing real work, not merely restating a status-code assertion that
+  // Better Auth's own wrapper would already satisfy on its own.
+  const originalError = console.error
+  const logged = []
+  console.error = (...args) => logged.push(args)
+  let response
+  try {
+    response = await auth.api.requestPasswordReset({ body: { email: credentials.email }, asResponse: true })
+    // The send is fire-and-forget, so its rejection settles on a later
+    // microtask/macrotask than the response itself — give it one tick.
+    await new Promise(resolve => setImmediate(resolve))
+  } finally {
+    console.error = originalError
+  }
+
   assert.equal(response.status, 200)
+  assert.ok(
+    logged.some(args => args[0] === 'reset password email send failed:'),
+    `expected the fail-soft log line; saw: ${JSON.stringify(logged)}`,
+  )
+})
+
+test('reset-request timing does not leak account existence (fire-and-forget send, not an awaited one)', async () => {
+  // A mailer slow enough that an accidentally-awaited send is unmistakable.
+  const SLOW_MS = 200
+  const mailer = {
+    kind: 'test',
+    sender: 'x',
+    send: async () => { await new Promise(resolve => setTimeout(resolve, SLOW_MS)) },
+  }
+  const auth = createAuth({ database: new DatabaseSync(':memory:'), env, mailer })
+  await (await getMigrations(auth.options)).runMigrations()
+  const credentials = { email: 'timing-known@example.com', password: 'correct horse battery staple' }
+  await auth.api.signUpEmail({ body: { ...credentials, name: 'T' }, asResponse: true })
+
+  const start = performance.now()
+  const response = await auth.api.requestPasswordReset({ body: { email: credentials.email }, asResponse: true })
+  const elapsedMs = performance.now() - start
+
+  assert.equal(response.status, 200)
+  // If sendResetPassword awaited the send (the pre-fix shape), this request
+  // could not return in under SLOW_MS — it would block on the mailer round
+  // trip that an unknown address's early-return never pays, distinguishing
+  // known from unknown addresses by response time. Budget well under
+  // SLOW_MS so the assertion is unambiguous against normal jitter.
+  assert.ok(
+    elapsedMs < SLOW_MS / 2,
+    `known-address reset request took ${elapsedMs}ms against a ${SLOW_MS}ms mailer — ` +
+    'looks like the send is being awaited, which leaks account existence via timing',
+  )
+})
+
+// ── HTTP-layer coverage: origin-check middleware ─────────────────────────
+// auth.api.* calls the endpoint's handler function directly, with no
+// Request object — Better Auth's originCheck middleware
+// (better-auth/dist/api/middlewares/origin-check.mjs) starts with
+// `if (!ctx.request) return`, so calling auth.api.* alone never exercises
+// it. auth.handler(request) is the real dispatcher (what toNodeHandler /
+// the compose stack / production actually serve through) and does apply it.
+
+test('the HTTP handler rejects an untrusted redirectTo; auth.api.* alone does not exercise that check', async () => {
+  const { auth } = await testAuthWithMailer()
+  const credentials = { email: 'origin-check@example.com', password: 'correct horse battery staple' }
+  await auth.api.signUpEmail({ body: { ...credentials, name: 'O' }, asResponse: true })
+
+  const untrustedBody = { email: credentials.email, redirectTo: 'https://evil.example.com/reset-password' }
+
+  // Direct auth.api.* call: no Request, so originCheck bails out early and
+  // an untrusted redirectTo sails through — this is NOT a stand-in for the
+  // real HTTP path, which is exactly finding #3's point.
+  const direct = await auth.api.requestPasswordReset({ body: untrustedBody, asResponse: true })
+  assert.equal(direct.status, 200)
+
+  const post = body => auth.handler(new Request('http://localhost:3000/api/auth/request-password-reset', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }))
+
+  const rejected = await post(untrustedBody)
+  assert.equal(rejected.status, 403)
+
+  const accepted = await post({ email: credentials.email, redirectTo: 'http://localhost:3000/reset-password' })
+  assert.equal(accepted.status, 200)
 })
 
 test('enforcement flag parses strictly', async () => {

--- a/auth/test/auth.test.js
+++ b/auth/test/auth.test.js
@@ -143,6 +143,85 @@ test('a failing mailer never breaks signup (fail-soft while SES is sandboxed)', 
   assert.equal(registration.status, 200)
 })
 
+// ── Password reset (SES wiring, mirrors email verification above) ──────
+
+test('password reset dispatches reset mail for a known address and lets the old password go, revoking sessions', async () => {
+  const { auth, mailer } = await testAuthWithMailer()
+  const credentials = { email: 'resetme@example.com', password: 'correct horse battery staple' }
+
+  const registration = await auth.api.signUpEmail({ body: { ...credentials, name: 'R' }, asResponse: true })
+  assert.equal(registration.status, 200)
+
+  const login = await auth.api.signInEmail({ body: credentials, asResponse: true })
+  const cookie = cookieHeader(login)
+  assert.ok(await auth.api.getSession({ headers: new Headers({ cookie }) }))
+
+  const request = await auth.api.requestPasswordReset({
+    body: { email: credentials.email, redirectTo: 'http://localhost:3000/reset-password' },
+    asResponse: true,
+  })
+  assert.equal(request.status, 200)
+
+  // signUpEmail already sent one verification mail (sendOnSignUp); the reset
+  // request must add exactly one more, distinguishable by subject.
+  const resetMail = mailer.sent.find(m => m.subject === 'Reset your Archimedes password')
+  assert.ok(resetMail, `no reset mail among: ${JSON.stringify(mailer.sent.map(m => m.subject))}`)
+  assert.equal(resetMail.to, credentials.email)
+  const url = resetMail.text.match(/https?:\/\/\S+/)?.[0]
+  assert.ok(url, `reset mail carried no url: ${resetMail.text}`)
+  const token = new URL(url).searchParams.get('token') ?? url.match(/\/reset-password\/([^/?]+)/)?.[1]
+  assert.ok(token, `reset url carried no token: ${url}`)
+
+  const reset = await auth.api.resetPassword({ body: { token, newPassword: 'new correct horse battery' }, asResponse: true })
+  assert.equal(reset.status, 200)
+
+  // Old password is rejected now.
+  const oldLogin = await auth.api.signInEmail({ body: credentials, asResponse: true })
+  assert.equal(oldLogin.status, 401)
+
+  // New password works.
+  const newLogin = await auth.api.signInEmail({
+    body: { email: credentials.email, password: 'new correct horse battery' },
+    asResponse: true,
+  })
+  assert.equal(newLogin.status, 200)
+
+  // The session that predated the reset was revoked (revokeSessionsOnPasswordReset).
+  assert.equal(await auth.api.getSession({ headers: new Headers({ cookie }) }), null)
+})
+
+test('password reset gives an unknown address the identical response, and sends no mail (no account enumeration)', async () => {
+  const { auth, mailer } = await testAuthWithMailer()
+  const credentials = { email: 'realaccount@example.com', password: 'correct horse battery staple' }
+  await auth.api.signUpEmail({ body: { ...credentials, name: 'K' }, asResponse: true })
+
+  const known = await auth.api.requestPasswordReset({ body: { email: credentials.email }, asResponse: true })
+  const knownBody = await known.json()
+  // One verification mail (signup) + one reset mail for the known address.
+  assert.equal(mailer.sent.length, 2)
+  assert.ok(mailer.sent.some(m => m.subject === 'Reset your Archimedes password'))
+
+  const unknown = await auth.api.requestPasswordReset({ body: { email: 'nobody-here@example.com' }, asResponse: true })
+  const unknownBody = await unknown.json()
+  // Still exactly two mails sent — the unknown address triggered no dispatch.
+  assert.equal(mailer.sent.length, 2)
+
+  // Status and body are indistinguishable between the two cases.
+  assert.equal(known.status, unknown.status)
+  assert.deepEqual(knownBody, unknownBody)
+})
+
+test('a failing reset mailer never 500s the request (fail-soft, and preserves anti-enumeration)', async () => {
+  const mailer = { kind: 'test', sender: 'x', send: async () => { throw new Error('SES sandbox: address not verified') } }
+  const auth = createAuth({ database: new DatabaseSync(':memory:'), env, mailer })
+  await (await getMigrations(auth.options)).runMigrations()
+  const credentials = { email: 'sandboxed-reset@example.com', password: 'correct horse battery staple' }
+  await auth.api.signUpEmail({ body: { ...credentials, name: 'S' }, asResponse: true })
+
+  const response = await auth.api.requestPasswordReset({ body: { email: credentials.email }, asResponse: true })
+  assert.equal(response.status, 200)
+})
+
 test('enforcement flag parses strictly', async () => {
   const { emailVerificationEnforced } = await import('../auth.js')
   assert.equal(emailVerificationEnforced({}), false)

--- a/docs/account-authentication.md
+++ b/docs/account-authentication.md
@@ -13,7 +13,7 @@ passkey authorizes Circle smart wallet only; it is not Archimedes login credenti
 
 Routes:
 
-- `/`, `/architecture`, `/sign-in`, and `/sign-up`: public SPA routes.
+- `/`, `/architecture`, `/sign-in`, `/sign-up`, and `/reset-password`: public SPA routes.
 - `/app/*`: Better Auth session required by nginx `auth_request` and client router.
 - private FastAPI routes: repeat session checks through `require_current_user`.
 - on-chain wallet actions: additionally require wallet present in `linked_wallets` for
@@ -84,6 +84,26 @@ Independently of enforcement, disposable accounts are bounded by three layers:
    (`backend/archimedes/services/generation_quota.py`). Generation is the
    endpoint that spends money, and its IP bucket does not reset when a new
    account is minted — so a signup farm gains nothing where it matters.
+
+### Password reset (#1323)
+
+Forgotten-password recovery is wired end to end — before this, a lost password
+permanently destroyed the account that owns the user's strategies. `auth/auth.js`
+`emailAndPassword.sendResetPassword` mirrors `sendVerificationEmail`: same mailer
+(`auth/mailer.js`), same fail-soft-on-send-failure handling. Better Auth's built-in
+`POST /api/auth/request-password-reset` returns the identical response body/status for
+a known and an unknown email — `sendResetPassword` is only ever invoked for a real
+account, so the fail-soft catch matters doubly here: a 500 that only real accounts could
+trigger would itself leak account existence via status code. `POST
+/api/auth/reset-password` consumes the mailed token, sets the new password, and (via
+`revokeSessionsOnPasswordReset: true`) signs out every existing session.
+
+UI: `ui/src/components/AuthPage.jsx` — "Forgot password?" on the sign-in view opens an
+inline request form (`ui/src/auth-client.js` `requestPasswordReset`); the mailed link
+points at the public `/reset-password` route, which reads `?token=` and calls
+`resetPassword`. A sign-in refused with 403 (unverified email) surfaces a "Resend
+verification email" action calling the existing `send-verification-email` endpoint
+(`resendVerificationEmail`) — closing the matching lockout for a lost verification mail.
 
 ## Wallet linking
 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -87,6 +87,7 @@ export default function App() {
       paper: 'Paper Trading · Archimedes',
       'sign-in': 'Sign in · Archimedes',
       'sign-up': 'Create account · Archimedes',
+      'reset-password': 'Reset password · Archimedes',
       // resolveRoute() returns page === null for not-found, so this branch used
       // to fall through to the bare 'Archimedes' title — byte-identical to the
       // landing page, leaving a screen-reader or many-tabs user unable to tell

--- a/ui/src/auth-client.js
+++ b/ui/src/auth-client.js
@@ -1,4 +1,6 @@
-const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+// import.meta.env?. (not .env.), so this module loads under plain node in
+// ui/test/ too — see featureFlags.js's header comment for the same pattern.
+const API_BASE = import.meta.env?.VITE_API_BASE ?? ''
 
 async function authRequest(path, options = {}) {
   const response = await fetch(`${API_BASE}${path}`, {
@@ -38,3 +40,21 @@ export async function signInSocial(provider, callbackURL) {
 }
 
 export const signOut = () => authRequest('/api/auth/sign-out', { method: 'POST' })
+
+// Same user-visible outcome whether or not the address has an account
+// (Better Auth's own anti-enumeration behavior — see auth/auth.js
+// sendResetPassword) — callers must not branch UI copy on the result.
+export const requestPasswordReset = (email, redirectTo) => authRequest('/api/auth/request-password-reset', {
+  method: 'POST',
+  body: JSON.stringify({ email, redirectTo }),
+})
+
+export const resetPassword = (newPassword, token) => authRequest('/api/auth/reset-password', {
+  method: 'POST',
+  body: JSON.stringify({ newPassword, token }),
+})
+
+export const resendVerificationEmail = (email, callbackURL) => authRequest('/api/auth/send-verification-email', {
+  method: 'POST',
+  body: JSON.stringify({ email, callbackURL }),
+})

--- a/ui/src/components/AuthPage.jsx
+++ b/ui/src/components/AuthPage.jsx
@@ -1,7 +1,15 @@
 import { useEffect, useState } from 'react'
 
 import { useAuth } from '../AuthContext'
-import { getProviders, signInEmail, signInSocial, signUpEmail } from '../auth-client'
+import {
+  getProviders,
+  requestPasswordReset,
+  resendVerificationEmail,
+  resetPassword,
+  signInEmail,
+  signInSocial,
+  signUpEmail,
+} from '../auth-client'
 import {
   PASSWORD_MAX,
   PASSWORD_MIN,
@@ -14,23 +22,203 @@ import { postAuthPath } from '../routes'
 
 const STRENGTH_COLORS = ['var(--text-4)', 'var(--text-4)', 'var(--warning, #b08a3e)', 'var(--accent)', 'var(--accent)']
 
+// Better Auth returns this identical response whether or not the address has
+// an account (auth/auth.js sendResetPassword sits behind that check) — the UI
+// shows the same copy in both cases and must never branch on the result.
+const RESET_REQUESTED_MESSAGE = 'If that email has an Archimedes account, a reset link is on its way.'
+const VERIFICATION_RESENT_MESSAGE = 'Verification email sent — check your inbox.'
+
+/** Live checklist + guidance strength meter, shared by sign-up and reset-password. */
+function PasswordChecklist({ password, confirm, showMismatch }) {
+  const rules = passwordRules(password)
+  const match = passwordsMatch(password, confirm)
+  const strength = passwordStrength(password)
+  return (
+    <div aria-live="polite" className="flex flex-col gap-1.5">
+      <div className="flex gap-1" aria-hidden="true">
+        {[1, 2, 3, 4].map((step) => (
+          <span
+            key={step}
+            className="h-1 flex-1 rounded"
+            style={{ background: step <= strength.score ? STRENGTH_COLORS[strength.score] : 'var(--glass-border)' }}
+          />
+        ))}
+      </div>
+      {password.length > 0 && (
+        <span className="caption">
+          Strength: {strength.label} — guidance only; the length rule below is the requirement.
+        </span>
+      )}
+      <ul className="caption flex flex-col gap-0.5" id="password-rules" aria-label="Password requirements">
+        {rules.map((rule) => (
+          <li key={rule.id} className={rule.met ? 'text-[var(--accent)]' : undefined}>
+            {rule.met ? '✓' : '○'} {rule.label}
+          </li>
+        ))}
+        <li className={match ? 'text-[var(--accent)]' : undefined}>
+          {match ? '✓' : '○'} Passwords match
+        </li>
+      </ul>
+      {showMismatch && (
+        <div className="status" role="alert" id="confirm-mismatch">
+          Passwords do not match.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ForgotPasswordForm({ email, onBack, callbackOrigin }) {
+  const [address, setAddress] = useState(email)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const [sent, setSent] = useState(false)
+
+  const submit = async (event) => {
+    event.preventDefault()
+    setBusy(true)
+    setError('')
+    try {
+      await requestPasswordReset(address, `${callbackOrigin}/reset-password`)
+      setSent(true)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="body">{RESET_REQUESTED_MESSAGE}</p>
+        <button className="btn-secondary" type="button" onClick={onBack}>Back to sign in</button>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1.5">
+        <span className="caption">Email</span>
+        <input
+          required
+          type="email"
+          autoComplete="email"
+          value={address}
+          onChange={(event) => setAddress(event.target.value)}
+        />
+      </label>
+      {error && <div className="status" role="alert">{error}</div>}
+      <button className="btn-primary" type="submit" disabled={busy}>
+        {busy ? 'Working…' : 'Send reset link'}
+      </button>
+      <button className="btn-secondary" type="button" onClick={onBack} disabled={busy}>Back to sign in</button>
+    </form>
+  )
+}
+
+function ResetPasswordForm({ token, callbackOrigin }) {
+  const [form, setForm] = useState({ password: '', confirm: '' })
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const [done, setDone] = useState(false)
+
+  const rulesMet = passwordRulesMet(form.password)
+  const match = passwordsMatch(form.password, form.confirm)
+  const showMismatch = form.confirm.length > 0 && !match
+
+  if (!token) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="body">This reset link is invalid or has expired.</p>
+        <a className="btn-primary text-center" href={`${callbackOrigin}/sign-in`}>Request a new one</a>
+      </div>
+    )
+  }
+
+  if (done) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="body">Password updated. Every prior session was signed out.</p>
+        <a className="btn-primary text-center" href={`${callbackOrigin}/sign-in`}>Sign in</a>
+      </div>
+    )
+  }
+
+  const submit = async (event) => {
+    event.preventDefault()
+    setBusy(true)
+    setError('')
+    try {
+      await resetPassword(form.password, token)
+      setDone(true)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1.5">
+        <span className="caption">New password</span>
+        <input
+          required
+          type="password"
+          minLength={PASSWORD_MIN}
+          maxLength={PASSWORD_MAX}
+          autoComplete="new-password"
+          aria-describedby="password-rules"
+          value={form.password}
+          onChange={(event) => setForm({ ...form, password: event.target.value })}
+        />
+      </label>
+      <label className="flex flex-col gap-1.5">
+        <span className="caption">Confirm new password</span>
+        <input
+          required
+          type="password"
+          maxLength={PASSWORD_MAX}
+          autoComplete="new-password"
+          aria-invalid={showMismatch}
+          aria-describedby={showMismatch ? 'password-rules confirm-mismatch' : 'password-rules'}
+          value={form.confirm}
+          onChange={(event) => setForm({ ...form, confirm: event.target.value })}
+        />
+      </label>
+      <PasswordChecklist password={form.password} confirm={form.confirm} showMismatch={showMismatch} />
+      {error && <div className="status" role="alert">{error}</div>}
+      <button className="btn-primary" type="submit" disabled={busy || !rulesMet || !match}>
+        {busy ? 'Working…' : 'Set new password'}
+      </button>
+    </form>
+  )
+}
+
 export default function AuthPage({ mode }) {
   const creating = mode === 'sign-up'
+  const resetting = mode === 'reset-password'
   const next = postAuthPath(window.location.search)
   const callbackURL = `${window.location.origin}${next}`
+  const callbackOrigin = window.location.origin
+  const resetToken = resetting ? new URLSearchParams(window.location.search).get('token') : null
   const { user, refresh } = useAuth()
   const [providers, setProviders] = useState({ emailPassword: true, google: false, github: false })
   const [form, setForm] = useState({ name: '', email: '', password: '', confirm: '' })
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [needsVerification, setNeedsVerification] = useState(false)
+  const [screen, setScreen] = useState('credentials') // 'credentials' | 'forgot'
 
   // Sign-up validity mirrors the SERVER's rules exactly (length only — see
-  // password-rules.js). The strength meter is guidance and never gates.
-  const rules = passwordRules(form.password)
+  // password-rules.js). The strength meter (PasswordChecklist) is guidance
+  // and never gates.
   const rulesMet = passwordRulesMet(form.password)
   const match = passwordsMatch(form.password, form.confirm)
   const showMismatch = creating && form.confirm.length > 0 && !match
-  const strength = passwordStrength(form.password)
   const canSubmit = !creating || (rulesMet && match)
 
   useEffect(() => {
@@ -38,13 +226,15 @@ export default function AuthPage({ mode }) {
   }, [])
 
   useEffect(() => {
-    if (user) window.location.replace(next)
-  }, [user, next])
+    if (user && !resetting) window.location.replace(next)
+  }, [user, next, resetting])
 
   const submit = async (event) => {
     event.preventDefault()
     setBusy(true)
     setError('')
+    setNotice('')
+    setNeedsVerification(false)
     try {
       if (creating) {
         await signUpEmail(form.name, form.email, form.password, callbackURL)
@@ -54,6 +244,24 @@ export default function AuthPage({ mode }) {
       }
       await refresh()
       window.location.assign(next)
+    } catch (err) {
+      setError(err.message)
+      // Better Auth answers an unverified sign-in with 403 (BASE_ERROR_CODES
+      // .EMAIL_NOT_VERIFIED) — give that specific lockout an escape hatch
+      // instead of leaving the user stuck on a bare error string.
+      if (err.status === 403) setNeedsVerification(true)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const resendVerification = async () => {
+    setBusy(true)
+    setError('')
+    try {
+      await resendVerificationEmail(form.email, callbackURL)
+      setNotice(VERIFICATION_RESENT_MESSAGE)
+      setNeedsVerification(false)
     } catch (err) {
       setError(err.message)
     } finally {
@@ -72,138 +280,147 @@ export default function AuthPage({ mode }) {
     }
   }
 
+  const title = resetting ? 'Reset your password' : creating ? 'Create your account' : screen === 'forgot' ? 'Reset your password' : 'Sign in'
+
   return (
     <main className="min-h-screen flex items-center justify-center px-4 py-12 bg-[var(--canvas)]">
       <section className="card-flat w-full max-w-[430px] p-7" aria-labelledby="auth-title">
         <a href="/" className="caption text-[var(--accent)]">← Archimedes</a>
-        <h1 id="auth-title" className="serif text-[2rem] mt-4 mb-2">
-          {creating ? 'Create your account' : 'Sign in'}
-        </h1>
-        <p className="body mb-6">
-          Account owns your strategies and settings. Wallets stay optional and link only after signature proof.
-        </p>
+        <h1 id="auth-title" className="serif text-[2rem] mt-4 mb-2">{title}</h1>
 
-        <form onSubmit={submit} className="flex flex-col gap-4">
-          {creating && (
-            <label className="flex flex-col gap-1.5">
-              <span className="caption">Name</span>
-              <input
-                required
-                autoComplete="name"
-                value={form.name}
-                onChange={(event) => setForm({ ...form, name: event.target.value })}
-              />
-            </label>
-          )}
-          <label className="flex flex-col gap-1.5">
-            <span className="caption">Email</span>
-            <input
-              required
-              type="email"
-              autoComplete="email"
-              value={form.email}
-              onChange={(event) => setForm({ ...form, email: event.target.value })}
+        {resetting ? (
+          <>
+            <p className="body mb-6">Choose a new password for your Archimedes account.</p>
+            <ResetPasswordForm token={resetToken} callbackOrigin={callbackOrigin} />
+          </>
+        ) : screen === 'forgot' ? (
+          <>
+            <p className="body mb-6">Enter your account email and we&rsquo;ll send a reset link.</p>
+            <ForgotPasswordForm
+              email={form.email}
+              callbackOrigin={callbackOrigin}
+              onBack={() => setScreen('credentials')}
             />
-          </label>
-          <label className="flex flex-col gap-1.5">
-            <span className="caption">Password</span>
-            <input
-              required
-              type="password"
-              minLength={PASSWORD_MIN}
-              maxLength={PASSWORD_MAX}
-              autoComplete={creating ? 'new-password' : 'current-password'}
-              aria-describedby={creating ? 'password-rules' : undefined}
-              value={form.password}
-              onChange={(event) => setForm({ ...form, password: event.target.value })}
-            />
-          </label>
-          {creating && (
-            <>
+          </>
+        ) : (
+          <>
+            <p className="body mb-6">
+              Account owns your strategies and settings. Wallets stay optional and link only after signature proof.
+            </p>
+
+            <form onSubmit={submit} className="flex flex-col gap-4">
+              {creating && (
+                <label className="flex flex-col gap-1.5">
+                  <span className="caption">Name</span>
+                  <input
+                    required
+                    autoComplete="name"
+                    value={form.name}
+                    onChange={(event) => setForm({ ...form, name: event.target.value })}
+                  />
+                </label>
+              )}
               <label className="flex flex-col gap-1.5">
-                <span className="caption">Confirm password</span>
-                {/* aria-invalid alone said "invalid entry" with no statement of
-                    what was wrong: the mismatch alert fires once while the user
-                    is still typing and is unreachable afterwards, and the rules
-                    list was never associated with the field (3.3.1). */}
+                <span className="caption">Email</span>
+                <input
+                  required
+                  type="email"
+                  autoComplete="email"
+                  value={form.email}
+                  onChange={(event) => setForm({ ...form, email: event.target.value })}
+                />
+              </label>
+              <label className="flex flex-col gap-1.5">
+                <span className="caption">Password</span>
                 <input
                   required
                   type="password"
+                  minLength={PASSWORD_MIN}
                   maxLength={PASSWORD_MAX}
-                  autoComplete="new-password"
-                  aria-invalid={showMismatch}
-                  aria-describedby={showMismatch ? 'password-rules confirm-mismatch' : 'password-rules'}
-                  value={form.confirm}
-                  onChange={(event) => setForm({ ...form, confirm: event.target.value })}
+                  autoComplete={creating ? 'new-password' : 'current-password'}
+                  aria-describedby={creating ? 'password-rules' : undefined}
+                  value={form.password}
+                  onChange={(event) => setForm({ ...form, password: event.target.value })}
                 />
               </label>
-              <div aria-live="polite" className="flex flex-col gap-1.5">
-                <div className="flex gap-1" aria-hidden="true">
-                  {[1, 2, 3, 4].map((step) => (
-                    <span
-                      key={step}
-                      className="h-1 flex-1 rounded"
-                      style={{
-                        background: step <= strength.score ? STRENGTH_COLORS[strength.score] : 'var(--glass-border)',
-                      }}
+              {!creating && (
+                <button
+                  type="button"
+                  className="caption text-[var(--accent)] text-left"
+                  onClick={() => { setScreen('forgot'); setError(''); setNotice(''); setNeedsVerification(false) }}
+                >
+                  Forgot password?
+                </button>
+              )}
+              {creating && (
+                <>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="caption">Confirm password</span>
+                    {/* aria-invalid alone said "invalid entry" with no statement of
+                        what was wrong: the mismatch alert fires once while the user
+                        is still typing and is unreachable afterwards, and the rules
+                        list was never associated with the field (3.3.1). */}
+                    <input
+                      required
+                      type="password"
+                      maxLength={PASSWORD_MAX}
+                      autoComplete="new-password"
+                      aria-invalid={showMismatch}
+                      aria-describedby={showMismatch ? 'password-rules confirm-mismatch' : 'password-rules'}
+                      value={form.confirm}
+                      onChange={(event) => setForm({ ...form, confirm: event.target.value })}
                     />
-                  ))}
-                </div>
-                {form.password.length > 0 && (
-                  <span className="caption">
-                    Strength: {strength.label} — guidance only; the length rule below is the requirement.
-                  </span>
-                )}
-                {/* Unmet rules inherit .caption's --text-3 rather than --text-4:
-                    on the base palette --text-4 is #3f3f46, i.e. 1.73:1 on the
-                    card — the rule text a user needs precisely when their
-                    password was rejected was the least readable text here.
-                    The ✓/○ glyph stays the state signal (1.4.1). */}
-                <ul className="caption flex flex-col gap-0.5" id="password-rules" aria-label="Password requirements">
-                  {rules.map((rule) => (
-                    <li key={rule.id} className={rule.met ? 'text-[var(--accent)]' : undefined}>
-                      {rule.met ? '✓' : '○'} {rule.label}
-                    </li>
-                  ))}
-                  <li className={match ? 'text-[var(--accent)]' : undefined}>
-                    {match ? '✓' : '○'} Passwords match
-                  </li>
-                </ul>
-              </div>
-              {showMismatch && (
-                <div className="status" role="alert" id="confirm-mismatch">
-                  Passwords do not match.
+                  </label>
+                  {/* Unmet rules inherit .caption's --text-3 rather than --text-4:
+                      on the base palette --text-4 is #3f3f46, i.e. 1.73:1 on the
+                      card — the rule text a user needs precisely when their
+                      password was rejected was the least readable text here.
+                      The ✓/○ glyph stays the state signal (1.4.1). */}
+                  <PasswordChecklist password={form.password} confirm={form.confirm} showMismatch={showMismatch} />
+                </>
+              )}
+              {notice && <div className="status" role="status">{notice}</div>}
+              {error && (
+                <div className="status" role="alert">
+                  {error}
+                  {needsVerification && (
+                    <>
+                      {' '}
+                      <button type="button" className="text-[var(--accent)]" onClick={resendVerification} disabled={busy}>
+                        Resend verification email
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
-            </>
-          )}
-          {error && <div className="status" role="alert">{error}</div>}
-          <button
-            className="btn-primary"
-            type="submit"
-            disabled={busy || !canSubmit}
-            aria-describedby={creating && !canSubmit ? 'password-rules' : undefined}
-          >
-            {busy ? 'Working…' : creating ? 'Create account' : 'Sign in'}
-          </button>
-        </form>
+              <button
+                className="btn-primary"
+                type="submit"
+                disabled={busy || !canSubmit}
+                aria-describedby={creating && !canSubmit ? 'password-rules' : undefined}
+              >
+                {busy ? 'Working…' : creating ? 'Create account' : 'Sign in'}
+              </button>
+            </form>
 
-        {(providers.google || providers.github) && (
-          <div className="mt-5 flex flex-col gap-2 border-t border-[var(--glass-border)] pt-5">
-            {providers.google && <button className="btn-secondary" onClick={() => social('google')} disabled={busy}>Continue with Google</button>}
-            {providers.github && <button className="btn-secondary" onClick={() => social('github')} disabled={busy}>Continue with GitHub</button>}
-          </div>
+            {(providers.google || providers.github) && (
+              <div className="mt-5 flex flex-col gap-2 border-t border-[var(--glass-border)] pt-5">
+                {providers.google && <button className="btn-secondary" onClick={() => social('google')} disabled={busy}>Continue with Google</button>}
+                {providers.github && <button className="btn-secondary" onClick={() => social('github')} disabled={busy}>Continue with GitHub</button>}
+              </div>
+            )}
+
+            <p className="caption mt-5 text-center">
+              {creating ? 'Already registered?' : 'New to Archimedes?'}{' '}
+              <a href={`${creating ? '/sign-in' : '/sign-up'}?next=${encodeURIComponent(next)}`}>
+                {creating ? 'Sign in' : 'Create account'}
+              </a>
+            </p>
+            <p className="caption mt-5">
+              Circle wallet passkeys authorize Circle smart wallets. They do not sign in to Archimedes.
+            </p>
+          </>
         )}
-
-        <p className="caption mt-5 text-center">
-          {creating ? 'Already registered?' : 'New to Archimedes?'}{' '}
-          <a href={`${creating ? '/sign-in' : '/sign-up'}?next=${encodeURIComponent(next)}`}>
-            {creating ? 'Sign in' : 'Create account'}
-          </a>
-        </p>
-        <p className="caption mt-5">
-          Circle wallet passkeys authorize Circle smart wallets. They do not sign in to Archimedes.
-        </p>
       </section>
     </main>
   )

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -8,6 +8,7 @@ const PUBLIC_PATHS = {
 const AUTH_PATHS = {
   '/sign-in': 'sign-in',
   '/sign-up': 'sign-up',
+  '/reset-password': 'reset-password',
 }
 
 const APP_PATHS = {

--- a/ui/test/auth-client.test.js
+++ b/ui/test/auth-client.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	requestPasswordReset,
+	resendVerificationEmail,
+	resetPassword,
+} from "../src/auth-client.js";
+
+// ── #1323: password reset + resend-verification wiring ──────────────────
+// authRequest() itself (session/sign-in/sign-up/sign-out) is exercised
+// end-to-end via the live auth service elsewhere; these three are new and
+// get direct fetch-boundary coverage here (mock at the boundary — fetch —
+// not at authRequest's internals, per CLAUDE.md's testing conventions).
+
+function jsonResponse(status, body) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function mockFetch(t, handler) {
+	t.mock.method(globalThis, "fetch", handler);
+}
+
+test("requestPasswordReset POSTs email + redirectTo to /api/auth/request-password-reset, credentials included", async (t) => {
+	let seen;
+	mockFetch(t, async (url, options) => {
+		seen = { url, method: options.method, credentials: options.credentials, body: JSON.parse(options.body) };
+		return jsonResponse(200, { status: true, message: "If this email exists in our system, check your email for the reset link" });
+	});
+
+	const result = await requestPasswordReset("a@example.com", "https://app.test/reset-password");
+
+	assert.equal(seen.url, "/api/auth/request-password-reset");
+	assert.equal(seen.method, "POST");
+	assert.equal(seen.credentials, "include");
+	assert.deepEqual(seen.body, { email: "a@example.com", redirectTo: "https://app.test/reset-password" });
+	assert.equal(result.status, true);
+});
+
+test("resetPassword POSTs newPassword + token to /api/auth/reset-password", async (t) => {
+	let seen;
+	mockFetch(t, async (url, options) => {
+		seen = { url, body: JSON.parse(options.body) };
+		return jsonResponse(200, { status: true });
+	});
+
+	await resetPassword("a new correct horse battery", "the-reset-token");
+
+	assert.equal(seen.url, "/api/auth/reset-password");
+	assert.deepEqual(seen.body, { newPassword: "a new correct horse battery", token: "the-reset-token" });
+});
+
+test("resendVerificationEmail POSTs email + callbackURL to /api/auth/send-verification-email", async (t) => {
+	let seen;
+	mockFetch(t, async (url, options) => {
+		seen = { url, body: JSON.parse(options.body) };
+		return jsonResponse(200, { status: true });
+	});
+
+	await resendVerificationEmail("a@example.com", "https://app.test/app");
+
+	assert.equal(seen.url, "/api/auth/send-verification-email");
+	assert.deepEqual(seen.body, { email: "a@example.com", callbackURL: "https://app.test/app" });
+});
+
+test("a non-ok response throws using the server's message, for all three", async (t) => {
+	mockFetch(t, async () => jsonResponse(400, { message: "Reset password isn't enabled" }));
+
+	await assert.rejects(() => requestPasswordReset("a@example.com"), /Reset password isn't enabled/);
+	await assert.rejects(() => resetPassword("x", "tok"), /Reset password isn't enabled/);
+	await assert.rejects(() => resendVerificationEmail("a@example.com"), /Reset password isn't enabled/);
+});

--- a/ui/test/password-rules.test.js
+++ b/ui/test/password-rules.test.js
@@ -97,10 +97,18 @@ test("sign-up form wires the shared rules module, confirm field, and gate", () =
 test("sign-in view offers a Forgot password control wired to the reset request", () => {
 	assert.match(authPage, /Forgot password\?/);
 	assert.match(authPage, /requestPasswordReset/);
+	assert.match(authPage, /RESET_REQUESTED_MESSAGE/);
 	// No account-enumeration: the same confirmation copy must be shown
 	// regardless of whether the address has an account (mirrors the server's
-	// identical response — auth/auth.js sendResetPassword).
-	assert.match(authPage, /RESET_REQUESTED_MESSAGE/);
+	// identical response — auth/auth.js sendResetPassword). A grep for the
+	// constant's name alone can't detect a branch — it stays green even if a
+	// future edit does `setSent(result.userExists ? A : RESET_REQUESTED_MESSAGE)`.
+	// The actual invariant this call site must hold is that the server's
+	// response is never even looked at: requestPasswordReset's return value
+	// is discarded outright, and confirmation always follows a bare
+	// `setSent(true)` with no conditional between them.
+	assert.doesNotMatch(authPage, /=\s*await requestPasswordReset/);
+	assert.match(authPage, /await requestPasswordReset\([^)]*\)\s*\n\s*setSent\(true\)/);
 });
 
 test("an unverified sign-in (403) offers Resend verification email, wired to the resend endpoint", () => {

--- a/ui/test/password-rules.test.js
+++ b/ui/test/password-rules.test.js
@@ -91,3 +91,28 @@ test("sign-up form wires the shared rules module, confirm field, and gate", () =
 	// confirm/rules machinery.
 	assert.match(authPage, /const canSubmit = !creating \|\|/);
 });
+
+// ── #1323: forgot-password + resend-verification wiring ─────────────────
+
+test("sign-in view offers a Forgot password control wired to the reset request", () => {
+	assert.match(authPage, /Forgot password\?/);
+	assert.match(authPage, /requestPasswordReset/);
+	// No account-enumeration: the same confirmation copy must be shown
+	// regardless of whether the address has an account (mirrors the server's
+	// identical response — auth/auth.js sendResetPassword).
+	assert.match(authPage, /RESET_REQUESTED_MESSAGE/);
+});
+
+test("an unverified sign-in (403) offers Resend verification email, wired to the resend endpoint", () => {
+	assert.match(authPage, /err\.status === 403/);
+	assert.match(authPage, /Resend verification email/);
+	assert.match(authPage, /resendVerificationEmail/);
+});
+
+test("reset-password mode reads the token from the URL and gates submit on the shared rules", () => {
+	assert.match(authPage, /mode === 'reset-password'/);
+	assert.match(authPage, /URLSearchParams\(window\.location\.search\)\.get\('token'\)/);
+	assert.match(authPage, /disabled=\{busy \|\| !rulesMet \|\| !match\}/);
+	// A missing/expired token must not silently render a submittable form.
+	assert.match(authPage, /invalid or has expired/);
+});

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -26,6 +26,12 @@ test("account routes remain public", () => {
 	assert.equal(resolveRoute("/sign-up").kind, "auth");
 });
 
+test("reset-password is a public auth route (#1323)", () => {
+	const route = resolveRoute("/reset-password");
+	assert.equal(route.kind, "auth");
+	assert.equal(route.page, "reset-password");
+});
+
 test("application routes use /app boundary", () => {
 	const route = resolveRoute("/app/library", "?tab=examples");
 	assert.equal(route.kind, "app");


### PR DESCRIPTION
## Summary

There was no password reset anywhere in the product — `sendResetPassword` was never
configured on Better Auth's `emailAndPassword` block, so `POST /api/auth/request-password-reset`
400'd (`RESET_PASSWORD_DISABLED`) for every address, and `AuthPage.jsx` had no entry
point to it. Since account ownership of a user's strategies landed, a forgotten
password meant permanent, unrecoverable loss. This closes that hole, and the
related resend-verification lockout named in the issue.

## What changed

**`auth/auth.js`** — `emailAndPassword.sendResetPassword` wired to the existing mailer
(`auth/mailer.js`), mirroring `sendVerificationEmail`'s fail-soft-on-send-failure
handling. Unlike `sendVerificationEmail`, the send is **fire-and-forget** — see
"Round 2" below for why an awaited send here specifically leaked account existence
through response timing.

**`ui/src/components/AuthPage.jsx`** (+ `auth-client.js`, `routes.js`, `App.jsx`) —
three entry points, all previously absent:
- **"Forgot password?"** on the sign-in view → inline request form → identical
  confirmation copy regardless of whether the account exists (never branches UI
  text on the server's anti-enumeration result).
- **`/reset-password`** (new public route) reads `?token=` from the mailed link and
  submits the new password through the same strength/rules checklist sign-up uses.
- **"Resend verification email"** appears when sign-in is refused with 403
  (`EMAIL_NOT_VERIFIED`) — the matching lockout the issue's "related" section calls
  out (no code change needed on the auth side; `send-verification-email` was already
  live, just never surfaced in the UI).

Fixed `auth-client.js`'s `import.meta.env.VITE_API_BASE` (no optional chaining) to
`import.meta.env?.` — the project's existing pattern (`featureFlags.js`) for modules
that load under plain `node` in `ui/test/`. This module had never been imported by a
test before, so the gap was latent; it crashed the new test file's import until fixed.

**`docs/account-authentication.md`** — documents the new route and reset flow.

## Anti-goals honored

- No new mail provider/dependency — reused `auth/mailer.js` as-is.
- No account-existence leak in response **or timing** — see "Round 2" below for the
  timing leak that was present through the first review pass and is now fixed and
  covered by a dedicated test.
- `minPasswordLength`, `requireEmailVerification`, `revokeSessionsOnPasswordReset`
  unchanged.
- OAuth (#1289) untouched.

## Acceptance criteria — verified against this branch

```
$ grep -n "sendResetPassword" auth/auth.js
81:      sendResetPassword: async ({ user, url }) => {

$ cd auth && npm test
ℹ tests 19
ℹ pass 19
ℹ fail 0

$ grep -n "Forgot password" ui/src/components/AuthPage.jsx
352:                  Forgot password?

$ cd ui && npm run lint && node --test
(lint: clean)
ℹ tests 98
ℹ pass 98
ℹ fail 0

$ cd ui && npm run build
✓ built in 1.82s
```

**AC #4 (end-to-end: request → email → complete → old password rejected → sessions
revoked)** — the core flow (real token generation, real password hashing, real
session revocation) is covered by a hermetic integration test calling `auth.api.*`
directly, asserting against the `console` mailer transcript:

```
✔ password reset dispatches reset mail for a known address and lets the old
  password go, revoking sessions
```

This does **not** exercise Better Auth's HTTP middleware layer (`originCheck` on
`redirectTo`, applied via `auth.handler`/`toNodeHandler`) — `auth.api.*` never
constructs a `Request`, and that middleware bails out immediately without one. A
separate test now drives that leg through `auth.handler(new Request(...))` instead
(see "Round 2" below). I still did not run this against `docker compose up` — this
host already has another compose stack (`compose-1194-*`) running against the same
Docker daemon and port 8080, and starting a second full stack risked colliding with
it. Between the hermetic `auth.api.*` test and the `auth.handler` test, both the
core reset flow and the HTTP-layer origin check are exercised; a live compose run is
still the more literal reading of AC #4 and remains unverified as written.

## Guard demonstrations (stash the fix, rerun, confirm red; restore, confirm green)

**Backend** — swap `auth/auth.js` back to the pre-#1323 version
(`git show f64b864c:auth/auth.js > auth/auth.js`, leaving only the new tests), then:
```
✖ password reset dispatches reset mail for a known address …
✖ password reset gives an unknown address the identical response …
✖ a failing reset mailer never 500s the request, and the failure is actually logged …
✖ reset-request timing does not leak account existence …
✖ the HTTP handler rejects an untrusted redirectTo …
ℹ pass 14, fail 5
```
(All five reset-specific tests fail with `RESET_PASSWORD_DISABLED` once
`sendResetPassword` doesn't exist at all — expected, since these tests didn't exist
before this PR either.) Restored: `19/19 pass`.

**Frontend** — `git stash push -- ui/src/App.jsx ui/src/auth-client.js
ui/src/components/AuthPage.jsx ui/src/routes.js`, then `node --test
test/auth-client.test.js test/password-rules.test.js test/routes.test.js`:
```
✖ test/auth-client.test.js                                    (suite fails to load —
                                                                 the import.meta.env
                                                                 crash pre-fix)
✖ sign-in view offers a Forgot password control …
✖ an unverified sign-in (403) offers Resend verification email …
✖ reset-password mode reads the token from the URL …
✖ reset-password is a public auth route (#1323)
ℹ pass 22, fail 5
```
That tally is the subset command's, not the full suite: `node --test
test/auth-client.test.js test/password-rules.test.js test/routes.test.js` →
22 pass, 5 fail (full `node --test` under the same revert: 90 pass / 5 fail
of 95). Restored (`git stash pop`): `98/98 pass`.

## Round 2 — adversarial review findings addressed

An adversarial review of the first version of this PR found five issues; all were
verified against the code (not taken on faith) before fixing. Commit `535a87b4`.
Each guard below was demonstrated failing against the pre-fix code before this was
pushed:

1. **(blocker) Timing leak.** `sendResetPassword` `await`ed `mailer.send()`. Better
   Auth's `requestPasswordReset` returns early for an unknown address without ever
   calling this callback, but for a *known* address, Better Auth's own
   `runInBackgroundOrAwait` does `await promise` on it (no
   `advanced.backgroundTasks.handler` is configured) — so a known-address request
   paid the full SES round trip while an unknown one returned instantly. Status code
   and body were identical (as claimed), but response **time** was not — the exact
   thing the anti-goal above says not to leak, and the thing this PR previously
   (wrongly) claimed was "verified by test." Fixed: the send is now
   fire-and-forget (`mailer.send({...}).catch(...)`), so this callback's own
   duration no longer depends on mailer latency. New test
   `reset-request timing does not leak account existence` measures a known-address
   request against a 200ms mock mailer and asserts it returns in <100ms.
   Guard demo — swap `auth.js` back to the pre-Round-2 version (`git show
   faea6a6d:auth/auth.js`), rerun `auth/test/auth.test.js`:
   ```
   ✖ reset-request timing does not leak account existence … 492ms, not < 100ms
   ℹ pass 18, fail 1
   ```
   Restored: `19/19 pass`.

2. **(major) Weak fail-soft guard.** The original
   `a failing reset mailer never 500s the request` test passed even with the local
   `try/catch` deleted, because Better Auth's own wrapper was silently swallowing
   the rejection — it wasn't testing what it claimed to guard. Now that the send is
   fire-and-forget, Better Auth's wrapper never sees the rejection at all, so the
   local `.catch` is the only thing standing between a mailer failure and an
   unhandled rejection. Tightened to spy on `console.error` and require the
   `'reset password email send failed:'` line while asserting status 200.
   Guard demo — delete just the trailing `.catch(error => { console.error(...) })`
   from `sendResetPassword` (send stays fire-and-forget, otherwise unchanged), rerun:
   ```
   ✖ a failing reset mailer never 500s the request, and the failure is actually
     logged (fail-soft) … expected log line, saw: []
   ℹ pass 12, fail 1   (auth/test/auth.test.js alone)
   ```
   Restored: full suite `19/19 pass`.

3. **(major) AC #4 substitute didn't exercise the HTTP middleware layer.**
   `auth.api.requestPasswordReset()` never builds a `Request`, so Better Auth's
   `originCheck` middleware (`if (!ctx.request) return`) never ran — an untrusted
   `redirectTo` sailed through with 200 in the original test suite, meaning a
   misconfigured `BETTER_AUTH_TRUSTED_ORIGINS` in production (the one deployment
   failure mode that turns every reset into a 403) had zero coverage. Added
   `the HTTP handler rejects an untrusted redirectTo`, driving the request through
   `auth.handler(new Request(...))` — the same dispatcher `toNodeHandler`/production
   use — asserting 403 for an untrusted `redirectTo` and 200 for a trusted one, with
   the direct `auth.api.*` call on the same untrusted body shown returning 200
   alongside it (in the same test) to make the gap explicit — this test is
   self-demonstrating: it fails outright if the untrusted `redirectTo` doesn't come
   back 403.

4. **(minor) Grep-only anti-enumeration guard.**
   `ui/test/password-rules.test.js` asserted only
   `assert.match(authPage, /RESET_REQUESTED_MESSAGE/)` — satisfied by the identifier
   appearing anywhere in the file, so a future
   `setSent(result.userExists ? A : RESET_REQUESTED_MESSAGE)` would keep it green.
   Replaced with an assertion on the actual invariant: the response is discarded
   outright (`assert.doesNotMatch` on `= await requestPasswordReset`) and
   confirmation always follows a bare `setSent(true)` with nothing conditional in
   between.
   Guard demo — change the call site to `const result = await
   requestPasswordReset(...); setSent(result.userExists ? true : true)`, rerun
   `ui/test/password-rules.test.js`:
   ```
   ✖ sign-in view offers a Forgot password control wired to the reset request
   ℹ pass 10, fail 1
   ```
   Reverted after confirming: `11/11 pass`.

5. **(minor) Trailer/close-keyword inconsistency.** `2f9b0baa` and `f4a86533` said
   `Refs #1323`; `59c300a5` said `Closes #1323` while this body also said
   `Closes #1323` at the bottom — with AC #4 admittedly not run as written and
   (until finding #1, above) the timing anti-goal unmet, merging would have
   auto-closed #1323 on an unverified claim. `59c300a5`'s trailer-only change
   (`Closes` → `Refs`, identical tree otherwise) required rebuilding it and every
   commit after it, so the branch's tip commits are now `2f9b0baa` (unchanged) →
   `781fc047` (was `59c300a5`, trailer fixed) → `faea6a6d` (was `f4a86533`, content
   unchanged) → `535a87b4` (this fix). This body's closing keyword below is now
   `Refs` too. #1323 will be closed manually once AC #4 is run against a live
   compose stack, per CLAUDE.md's pre-close verification gate.

Test tallies after Round 2: `cd auth && npm test` → **19 passed, 0 failed** (was 17);
`cd ui && node --test` → **98 passed, 0 failed**; `cd ui && npm run lint` → clean;
`cd ui && npm run build` → succeeds.

## Test tallies (this branch, both suites, both green)

- `cd auth && npm test` → **19 passed, 0 failed**
- `cd ui && node --test` → **98 passed, 0 failed**
- `cd ui && npm run lint` → clean
- `cd ui && npm run build` → succeeds
- `make docs-check` → 0 broken links, 0 orphaned docs

Refs #1323

