### PR TITLE
[frontend] Chain-status pill derives from /health, not a static object literal

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -635,6 +635,18 @@ h4,
 	flex-shrink: 0;
 }
 
+/* Tri-state chain-status pill (#1321) — "unknown" must read as visibly
+   distinct from "connected", never fall back to the same green as live. */
+.live-dot-connected {
+	background: var(--positive);
+}
+.live-dot-disconnected {
+	background: var(--negative);
+}
+.live-dot-unknown {
+	background: var(--warning);
+}
+
 /* --- Breadcrumbs --- */
 .breadcrumbs {
 	display: flex;
@@ -4947,6 +4959,19 @@ button:where(.tag) {
 .app-site .live-dot {
 	background: var(--app-verify);
 	box-shadow: 0 0 8px rgba(121, 201, 183, 0.5);
+}
+
+/* Tri-state overrides (#1321) — same specificity as `.app-site .live-dot`
+   above, declared after it so the tone-specific rule wins per element. The
+   "connected" case intentionally reproduces the prior always-on glow;
+   "disconnected"/"unknown" must not, or an outage still LOOKS alive. */
+.app-site .live-dot-disconnected {
+	background: var(--negative);
+	box-shadow: 0 0 8px rgba(239, 68, 68, 0.45);
+}
+.app-site .live-dot-unknown {
+	background: var(--warning);
+	box-shadow: none;
 }
 
 .app-site .topbar {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -4961,21 +4961,22 @@ button:where(.tag) {
    base `.live-dot` / `.live-dot-*` rules above — decides which wins; a tone
    class always co-occurs with `.live-dot` (Layout.jsx: `live-dot
    live-dot-${tone}`), so scoping under `.app-site` is what makes these
-   reachable at all. `--positive` is aliased to `--app-verify` inside
-   `.app-site` (both themes, above), so "connected" keeps the exact glow this
-   pill has always had. `--negative`/`--warning` are aliased the same way, so
-   using them (rather than the raw `--app-risk`/`--app-action` tokens) keeps
-   this block theme-aware without hard-coding either palette. */
+   reachable at all. `--positive`/`--negative`/`--warning` are aliased to
+   `--app-verify`/`--app-risk`/`--app-action` inside `.app-site` (both
+   themes, above), so using them (rather than the raw `--app-*` tokens
+   directly) keeps this block theme-aware without hard-coding either
+   palette. `connected` and `disconnected` both glow via `color-mix` against
+   the aliased token rather than a literal rgba — a hard-coded color drawn
+   from one theme's hex would stay that exact color for the other theme too,
+   mismatching the token there (`--positive`/`--negative` resolve to a
+   different hex per theme). `unknown` alone drops the glow entirely, so an
+   outage or a not-yet-resolved state doesn't still *look* alive. */
 .app-site .live-dot-connected {
 	background: var(--positive);
-	box-shadow: 0 0 8px rgba(121, 201, 183, 0.5);
+	box-shadow: 0 0 8px color-mix(in srgb, var(--positive) 50%, transparent);
 }
 .app-site .live-dot-disconnected {
 	background: var(--negative);
-	/* color-mix instead of a literal rgba: a hard-coded red glow drawn from
-	   the base (non-.app-site) dark-theme --negative would stay that exact
-	   red for the app-site light theme too, mismatching --negative there
-	   (which resolves to --app-risk, a different hex per theme). */
 	box-shadow: 0 0 8px color-mix(in srgb, var(--negative) 45%, transparent);
 }
 .app-site .live-dot-unknown {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -636,16 +636,16 @@ h4,
 }
 
 /* Tri-state chain-status pill (#1321) — "unknown" must read as visibly
-   distinct from "connected", never fall back to the same green as live. */
-.live-dot-connected {
-	background: var(--positive);
-}
-.live-dot-disconnected {
-	background: var(--negative);
-}
-.live-dot-unknown {
-	background: var(--warning);
-}
+   distinct from "connected", never fall back to the same green as live.
+   The three `.live-dot-connected`/`-disconnected`/`-unknown` tone rules are
+   declared under `.app-site .live-dot-*` below, not as bare classes here:
+   the only `.live-dot` element in the app is the sidebar footer pill
+   (Layout.jsx), and it always renders inside `.app-site`. A bare rule at
+   this scope is (0,1,0) — lower specificity than any `.app-site`-scoped
+   rule targeting the same element — so it would sit dead in the sheet.
+   (#1333 review caught an earlier version of exactly that: three unreachable
+   base-scope tone rules shipped alongside a PR whose point was deleting
+   dead code.) */
 
 /* --- Breadcrumbs --- */
 .breadcrumbs {
@@ -4956,18 +4956,27 @@ button:where(.tag) {
 	font-size: 0.58rem;
 }
 
-.app-site .live-dot {
-	background: var(--app-verify);
+/* Tri-state chain-status pill (#1321), all three tones stated here at equal
+   (0,2,0) specificity so source order — not a specificity fight with the
+   base `.live-dot` / `.live-dot-*` rules above — decides which wins; a tone
+   class always co-occurs with `.live-dot` (Layout.jsx: `live-dot
+   live-dot-${tone}`), so scoping under `.app-site` is what makes these
+   reachable at all. `--positive` is aliased to `--app-verify` inside
+   `.app-site` (both themes, above), so "connected" keeps the exact glow this
+   pill has always had. `--negative`/`--warning` are aliased the same way, so
+   using them (rather than the raw `--app-risk`/`--app-action` tokens) keeps
+   this block theme-aware without hard-coding either palette. */
+.app-site .live-dot-connected {
+	background: var(--positive);
 	box-shadow: 0 0 8px rgba(121, 201, 183, 0.5);
 }
-
-/* Tri-state overrides (#1321) — same specificity as `.app-site .live-dot`
-   above, declared after it so the tone-specific rule wins per element. The
-   "connected" case intentionally reproduces the prior always-on glow;
-   "disconnected"/"unknown" must not, or an outage still LOOKS alive. */
 .app-site .live-dot-disconnected {
 	background: var(--negative);
-	box-shadow: 0 0 8px rgba(239, 68, 68, 0.45);
+	/* color-mix instead of a literal rgba: a hard-coded red glow drawn from
+	   the base (non-.app-site) dark-theme --negative would stay that exact
+	   red for the app-site light theme too, mismatching --negative there
+	   (which resolves to --app-risk, a different hex per theme). */
+	box-shadow: 0 0 8px color-mix(in srgb, var(--negative) 45%, transparent);
 }
 .app-site .live-dot-unknown {
 	background: var(--warning);

--- a/ui/src/chainStatus.js
+++ b/ui/src/chainStatus.js
@@ -1,0 +1,46 @@
+// Tri-state chain-status derivation for the app-shell footer pill (#1321).
+//
+// Previously the pill's label was `Object.keys(NEW_CONTRACTS).length ? "Arc
+// · Testnet live" : "Arc · Connecting"` — NEW_CONTRACTS is a static object
+// literal (ui/src/config.js) with seven hard-coded addresses, so that count
+// is the constant 7 and the "problem" branch was unreachable dead code. The
+// pill said "live" through the 2026-08-19/20 backend OOM crash loop while
+// the site was serving 502/503.
+//
+// This module derives the label from the REAL `/health` response's
+// `chain_connected` boolean instead (backend/archimedes/main.py), with an
+// explicit third "unknown" state for the loading window and for a failed
+// `/health` fetch. Per docs/architectural-principles.md § fail-soft: the
+// correct degraded state is a loud, visible "unknown" — never a plausible
+// substitute rendered as healthy.
+
+export const CHAIN_STATUS = {
+	CONNECTED: "connected",
+	DISCONNECTED: "disconnected",
+	UNKNOWN: "unknown",
+};
+
+const LABEL = {
+	[CHAIN_STATUS.CONNECTED]: "Arc · Testnet live",
+	[CHAIN_STATUS.DISCONNECTED]: "Arc · Chain disconnected",
+	[CHAIN_STATUS.UNKNOWN]: "Arc · Status unknown",
+};
+
+/**
+ * Derive the tri-state chain-connection status shown in the shell footer.
+ *
+ * @param {{chain_connected?: unknown} | null | undefined} health - parsed
+ *   `/health` body, or null/undefined before the fetch resolves.
+ * @param {boolean} healthError - true if the `/health` fetch itself failed
+ *   (network error or non-2xx status).
+ * @returns {{tone: "connected"|"disconnected"|"unknown", label: string}}
+ */
+export function deriveChainStatus(health, healthError) {
+	if (healthError || !health || typeof health.chain_connected !== "boolean") {
+		return { tone: CHAIN_STATUS.UNKNOWN, label: LABEL[CHAIN_STATUS.UNKNOWN] };
+	}
+	const tone = health.chain_connected
+		? CHAIN_STATUS.CONNECTED
+		: CHAIN_STATUS.DISCONNECTED;
+	return { tone, label: LABEL[tone] };
+}

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useState } from "react";
 import { apiGet } from "../api";
+import { fetchHealth } from "../health";
 import flowDiagramSrc from "../assets/flow-diagram.svg";
 
 function fmtNum(n) {
@@ -30,7 +31,11 @@ function useArchStats() {
 		apiGet("/api/config/contracts")
 			.then(setContracts)
 			.catch(() => setContractsError(true));
-		apiGet("/health")
+		// Shared TTL-cached call (#1333 review) — Layout.jsx's footer pill and
+		// ModelCostPanel.jsx also read /health; fetchHealth() (../health.js)
+		// lets a nav that lands here reuse Layout's just-fetched response
+		// instead of firing a second Arc RPC round-trip + DB reads.
+		fetchHealth()
 			.then(setHealth)
 			.catch(() => setHealthError(true));
 		// scope=curated pinned deliberately: this stat is labeled "the public

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 import WalletConnect from "./WalletConnect";
 import Breadcrumbs from "./Breadcrumbs";
-import { NEW_CONTRACTS, getStoredWalletName } from "../config";
+import { apiGet } from "../api";
+import { getStoredWalletName } from "../config";
+import { deriveChainStatus } from "../chainStatus";
 import { getStoredTheme, applyTheme } from "../theme";
 import { visibleNavigation } from "../routes";
 import { lockBodyScroll, unlockBodyScroll } from "../utils/scrollLock";
@@ -136,12 +138,31 @@ export default function Layout({
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 	const [theme, setTheme] = useState(getStoredTheme);
+	const [health, setHealth] = useState(null);
+	const [healthError, setHealthError] = useState(false);
 	const hamburgerRef = useRef(null);
-	const blockLabel = Object.keys(NEW_CONTRACTS).length
-		? "Arc · Testnet live"
-		: "Arc · Connecting";
+	const chainStatus = deriveChainStatus(health, healthError);
 	const proofStage =
 		(page === "generate" ? journeyStage : null) ?? CORE_PAGE_STAGE[page];
+
+	// Chain-status pill (#1321): a single fetch on mount, not a polling loop —
+	// the shell doesn't need a live-updating dot, it needs an HONEST one. The
+	// "unknown" tone (deriveChainStatus, ../chainStatus.js) covers both the
+	// pre-resolution window and a failed fetch, so a backend outage can never
+	// silently render as "Arc · Testnet live".
+	useEffect(() => {
+		let cancelled = false;
+		apiGet("/health")
+			.then((d) => {
+				if (!cancelled) setHealth(d);
+			})
+			.catch(() => {
+				if (!cancelled) setHealthError(true);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	// Lock body scroll while the mobile nav drawer is open — otherwise the
 	// page content underneath can still scroll behind the fixed overlay/drawer,
@@ -278,8 +299,11 @@ export default function Layout({
 				</nav>
 
 				<div className="sidebar-footer">
-					<span className="live-dot" />
-					<span className="sidebar-footer-label">{blockLabel}</span>
+					<span
+						className={`live-dot live-dot-${chainStatus.tone}`}
+						aria-hidden="true"
+					/>
+					<span className="sidebar-footer-label">{chainStatus.label}</span>
 					<button
 						type="button"
 						className="sidebar-collapse-btn"

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 import WalletConnect from "./WalletConnect";
 import Breadcrumbs from "./Breadcrumbs";
-import { apiGet } from "../api";
 import { getStoredWalletName } from "../config";
 import { deriveChainStatus } from "../chainStatus";
+import { fetchHealth } from "../health";
 import { getStoredTheme, applyTheme } from "../theme";
 import { visibleNavigation } from "../routes";
 import { lockBodyScroll, unlockBodyScroll } from "../utils/scrollLock";
@@ -145,7 +145,7 @@ export default function Layout({
 	const proofStage =
 		(page === "generate" ? journeyStage : null) ?? CORE_PAGE_STAGE[page];
 
-	// Chain-status pill (#1321): re-fetches /health on mount and on every
+	// Chain-status pill (#1321): re-derives from /health on mount and on every
 	// in-app navigation (dep: `page`) — not a polling loop, a bounded
 	// re-derivation. Layout sits at a stable position in the tree
 	// (AuthenticatedApp.jsx renders it with no `key`, so React reconciles
@@ -160,9 +160,17 @@ export default function Layout({
 	// the user navigates — that gap is accepted, not solved, by design: it
 	// stays bounded by the next click rather than growing unbounded, without
 	// adding the polling loop this issue explicitly ruled out.
+	//
+	// The actual network call goes through fetchHealth() (../health.js), a
+	// short-TTL-cached wrapper, not a direct call to the raw fetch helper
+	// here: Layout isn't the only /health caller (Architecture.jsx,
+	// ModelCostPanel.jsx), so re-fetching straight from this effect on every
+	// navigation would fire a fresh Arc RPC round-trip + DB reads even on a
+	// nav that lands on a page with its own /health read. fetchHealth() lets
+	// those callers share one response instead (#1333 review).
 	useEffect(() => {
 		let cancelled = false;
-		apiGet("/health")
+		fetchHealth()
 			.then((d) => {
 				if (!cancelled) {
 					setHealth(d);

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -145,16 +145,34 @@ export default function Layout({
 	const proofStage =
 		(page === "generate" ? journeyStage : null) ?? CORE_PAGE_STAGE[page];
 
-	// Chain-status pill (#1321): a single fetch on mount, not a polling loop —
-	// the shell doesn't need a live-updating dot, it needs an HONEST one. The
-	// "unknown" tone (deriveChainStatus, ../chainStatus.js) covers both the
-	// pre-resolution window and a failed fetch, so a backend outage can never
-	// silently render as "Arc · Testnet live".
+	// Chain-status pill (#1321): re-fetches /health on mount and on every
+	// in-app navigation (dep: `page`) — not a polling loop, a bounded
+	// re-derivation. Layout sits at a stable position in the tree
+	// (AuthenticatedApp.jsx renders it with no `key`, so React reconciles
+	// rather than remounts across route changes), so an empty dep array here
+	// would mean an outage that begins mid-session stays invisible until the
+	// tab is reloaded — the same fail-soft failure #1321 was filed for, just
+	// time-bounded instead of permanent. The "unknown" tone (deriveChainStatus,
+	// ../chainStatus.js) covers both the pre-resolution window and a failed
+	// fetch, so a backend outage in progress at mount OR surfaced by the next
+	// navigation never silently renders as "Arc · Testnet live". A tab left
+	// idle on a single page for the whole session still won't repaint until
+	// the user navigates — that gap is accepted, not solved, by design: it
+	// stays bounded by the next click rather than growing unbounded, without
+	// adding the polling loop this issue explicitly ruled out.
 	useEffect(() => {
 		let cancelled = false;
 		apiGet("/health")
 			.then((d) => {
-				if (!cancelled) setHealth(d);
+				if (!cancelled) {
+					setHealth(d);
+					// Clear a prior failure so a fetch on a later navigation can
+					// report recovery — without this, one failed /health call
+					// pins the pill on "unknown" for the rest of the session even
+					// after the backend comes back, defeating the re-fetch this
+					// effect now does on every `page` change.
+					setHealthError(false);
+				}
 			})
 			.catch(() => {
 				if (!cancelled) setHealthError(true);
@@ -162,7 +180,7 @@ export default function Layout({
 		return () => {
 			cancelled = true;
 		};
-	}, []);
+	}, [page]);
 
 	// Lock body scroll while the mobile nav drawer is open — otherwise the
 	// page content underneath can still scroll behind the fixed overlay/drawer,

--- a/ui/src/components/ModelCostPanel.jsx
+++ b/ui/src/components/ModelCostPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { apiGet } from '../api'
+import { fetchHealth } from '../health'
 import pricing from '../data/modelPricing.json'
 
 // Cost-comparison + model picker for the Generate page. Surfaces the Bedrock
@@ -25,7 +25,11 @@ export default function ModelCostPanel({ selectedModel = null, onSelectModel }) 
 
   useEffect(() => {
     let cancelled = false
-    apiGet('/health')
+    // Shared TTL-cached call (#1333 review) — Layout.jsx's footer pill and
+    // Architecture.jsx also read /health; fetchHealth() (../health.js) lets
+    // this reuse whichever of those just fetched it instead of firing a
+    // third independent Arc RPC round-trip + DB reads.
+    fetchHealth()
       .then((d) => { if (!cancelled) setActiveModel(d?.llm_model || null) })
       .catch(() => {})
     return () => { cancelled = true }

--- a/ui/src/health.js
+++ b/ui/src/health.js
@@ -1,0 +1,11 @@
+// Shared /health fetch, TTL-cached (#1333 review follow-up). See
+// ./healthCache.js for the caching logic and the full rationale; this is
+// the thin production wrapper the real UI components call — it binds the
+// real `apiGet` so Layout.jsx, Architecture.jsx, and ModelCostPanel.jsx can
+// all call `fetchHealth()` with no arguments and share one response.
+import { apiGet } from "./api";
+import { getCachedHealth } from "./healthCache.js";
+
+export function fetchHealth() {
+	return getCachedHealth(apiGet);
+}

--- a/ui/src/healthCache.js
+++ b/ui/src/healthCache.js
@@ -1,0 +1,60 @@
+// Pure TTL-cache primitive backing fetchHealth() (./health.js, #1333 review
+// follow-up). Deliberately zero imports — like ./chainStatus.js — so it can
+// be unit-tested directly with node:test. health.js's own import graph
+// (api.js → config.js → circle-wallet.js → wallet/passkey browser SDKs) is
+// browser-oriented and not safe to load under a bare `node --test` run, so
+// the cache logic lives here, decoupled from that chain, and health.js is a
+// thin wrapper around it.
+//
+// The bug this exists to fix: Layout.jsx (footer chain-status pill, #1321),
+// Architecture.jsx, and ModelCostPanel.jsx each called `apiGet("/health")`
+// independently, on their own effect. #1321's anti-goal said "/health is
+// already fetched by the shell; reuse that response" — but no shell-level
+// fetch existed for them to reuse, so once Layout started re-fetching on
+// every in-app navigation, landing on /architecture fired /health twice in
+// the same render pass: Layout's per-navigation re-fetch plus Architecture's
+// own mount fetch. /health is rate-limit-exempt but not free — it does an
+// Arc RPC round-trip (`chain_client.is_connected()`) plus several DB reads
+// (`backend/archimedes/main.py`).
+//
+// getCachedHealth() makes the "reuse that response" anti-goal real: a call
+// within HEALTH_TTL_MS of the last *resolved* fetch returns that same
+// promise instead of invoking `fetcher` again. A failed fetch is not
+// cached — cachedAt/cachedPromise are cleared immediately on rejection, so
+// the very next call (e.g. Layout's next navigation) gets a fresh retry
+// rather than being stuck reusing a rejected promise for the rest of the
+// TTL window, which would otherwise pin the chain-status pill on "unknown"
+// for up to HEALTH_TTL_MS after a real recovery.
+
+export const HEALTH_TTL_MS = 30_000;
+
+let cachedPromise = null;
+let cachedAt = 0;
+
+/**
+ * @param {(path: string) => Promise<any>} fetcher — performs the actual
+ *   `/health` request; injected so this stays a pure, dependency-free
+ *   module (production code passes the real `apiGet`, tests pass a fake).
+ * @param {number} [now] — injectable clock for tests; defaults to
+ *   `Date.now()`.
+ * @returns {Promise<any>} the `/health` response, shared across callers
+ *   within the TTL window.
+ */
+export function getCachedHealth(fetcher, now = Date.now()) {
+	if (cachedPromise && now - cachedAt < HEALTH_TTL_MS) {
+		return cachedPromise;
+	}
+	cachedAt = now;
+	cachedPromise = fetcher("/health").catch((err) => {
+		cachedAt = 0;
+		cachedPromise = null;
+		throw err;
+	});
+	return cachedPromise;
+}
+
+// Test-only: force the next getCachedHealth() call to bypass the cache.
+export function _resetHealthCache() {
+	cachedPromise = null;
+	cachedAt = 0;
+}

--- a/ui/test/chain-status.test.js
+++ b/ui/test/chain-status.test.js
@@ -3,6 +3,11 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { CHAIN_STATUS, deriveChainStatus } from "../src/chainStatus.js";
+import {
+	_resetHealthCache,
+	getCachedHealth,
+	HEALTH_TTL_MS,
+} from "../src/healthCache.js";
 
 // ── deriveChainStatus: the tri-state pill logic (#1321) ────────────────────
 // The bug: the footer pill's label was `Object.keys(NEW_CONTRACTS).length ?
@@ -61,6 +66,63 @@ test("chain status: a malformed /health body (missing or non-boolean chain_conne
 	assert.equal(deriveChainStatus(undefined, false).tone, CHAIN_STATUS.UNKNOWN);
 });
 
+// ── getCachedHealth: shared TTL cache backing fetchHealth (#1333 review) ───
+// The bug: Layout.jsx, Architecture.jsx, and ModelCostPanel.jsx each called
+// apiGet("/health") independently. Once Layout's effect re-fetches on every
+// in-app navigation (above), landing on /architecture fired /health twice
+// in the same render pass, against an endpoint that does an Arc RPC
+// round-trip plus several DB reads. fetchHealth() (../src/health.js) wraps
+// this cache with the real apiGet; the cache logic itself lives in
+// ../src/healthCache.js (zero imports, so it's real-imported and exercised
+// directly here rather than only wiring-checked via readFileSync).
+
+test("getCachedHealth: a second call within the TTL window reuses the first call's promise instead of fetching again", async () => {
+	_resetHealthCache();
+	let calls = 0;
+	const fetcher = async () => {
+		calls += 1;
+		return { chain_connected: true };
+	};
+	const p1 = getCachedHealth(fetcher, 1_000);
+	const p2 = getCachedHealth(fetcher, 1_000 + HEALTH_TTL_MS - 1);
+	assert.equal(p1, p2, "the second call should return the exact same promise, not a new fetch");
+	await p1;
+	assert.equal(calls, 1, "fetcher should have been invoked exactly once");
+});
+
+test("getCachedHealth: a call at/after the TTL window fetches again", async () => {
+	_resetHealthCache();
+	let calls = 0;
+	const fetcher = async () => {
+		calls += 1;
+		return { chain_connected: true };
+	};
+	await getCachedHealth(fetcher, 1_000);
+	await getCachedHealth(fetcher, 1_000 + HEALTH_TTL_MS);
+	assert.equal(calls, 2, "the TTL boundary must not extend the cache indefinitely");
+});
+
+test("getCachedHealth: a failed fetch is not cached — the very next call retries rather than reusing the rejection", async () => {
+	// Mutation-check target: if the .catch() didn't clear cachedPromise/
+	// cachedAt, this second call would return the same rejected promise and
+	// `calls` would stay at 1 — an outage would pin every caller (including
+	// Layout's next navigation) on the same failure for the rest of the TTL
+	// window instead of getting a fresh attempt.
+	_resetHealthCache();
+	let calls = 0;
+	const failingFetcher = async () => {
+		calls += 1;
+		throw new Error("network down");
+	};
+	await assert.rejects(getCachedHealth(failingFetcher, 1_000));
+	const okFetcher = async () => {
+		calls += 1;
+		return { chain_connected: true };
+	};
+	await getCachedHealth(okFetcher, 1_001);
+	assert.equal(calls, 2, "the call after a failure must re-invoke the fetcher, not reuse the rejection");
+});
+
 // ── Wiring: Layout.jsx reads the real /health signal, not NEW_CONTRACTS ────
 
 const layout = readFileSync(
@@ -77,7 +139,7 @@ test("Layout.jsx: the footer pill no longer derives from NEW_CONTRACTS (acceptan
 test("Layout.jsx: the pill is driven by deriveChainStatus off a bounded /health re-fetch, not a new polling loop", () => {
 	assert.match(layout, /from ["']\.\.\/chainStatus["']/);
 	assert.match(layout, /deriveChainStatus\(health, healthError\)/);
-	assert.match(layout, /apiGet\(["']\/health["']\)/);
+	assert.match(layout, /fetchHealth\(\)/);
 	// Anti-goal: no new polling loop — the effect only re-runs on an actual
 	// in-app navigation (dep: `page`), never on a timer.
 	assert.doesNotMatch(layout, /setInterval/);
@@ -95,9 +157,9 @@ test("Layout.jsx: a successful re-fetch clears a prior healthError, so recovery 
 	// session — deriveChainStatus treats healthError as sticky-unknown
 	// regardless of what a later successful fetch reports.
 	const successBlock = layout.match(
-		/apiGet\(["']\/health["']\)\s*\.then\(\(d\) => \{([\s\S]*?)\}\)\s*\.catch/,
+		/fetchHealth\(\)\s*\.then\(\(d\) => \{([\s\S]*?)\}\)\s*\.catch/,
 	);
-	assert.ok(successBlock, "apiGet('/health').then(...) block not found");
+	assert.ok(successBlock, "fetchHealth().then(...) block not found");
 	assert.match(successBlock[1], /setHealth\(d\)/);
 	assert.match(successBlock[1], /setHealthError\(false\)/);
 });
@@ -120,4 +182,87 @@ test("config.js: NEW_CONTRACTS still has its 7 hard-coded addresses — this iss
 	assert.ok(match, "NEW_CONTRACTS block not found");
 	const keyCount = (match[1].match(/^\s*\w+:/gm) || []).length;
 	assert.equal(keyCount, 7);
+});
+
+// ── Wiring: every /health caller shares fetchHealth's cache (#1333 review) ─
+// Layout.jsx's per-navigation re-fetch (above) turned /health into a
+// per-navigation call from the always-mounted shell. Architecture.jsx and
+// ModelCostPanel.jsx also read /health, each on their own mount effect — if
+// either called apiGet("/health") directly instead of the shared
+// fetchHealth(), landing on their page would fire a second/third
+// independent Arc RPC round-trip + DB read in the same render pass that
+// Layout's effect just triggered.
+
+const architecture = readFileSync(
+	new URL("../src/components/Architecture.jsx", import.meta.url),
+	"utf8",
+);
+const modelCostPanel = readFileSync(
+	new URL("../src/components/ModelCostPanel.jsx", import.meta.url),
+	"utf8",
+);
+
+const health = readFileSync(
+	new URL("../src/health.js", import.meta.url),
+	"utf8",
+);
+
+test("health.js: fetchHealth() delegates to the shared getCachedHealth cache with the real apiGet, not its own logic", () => {
+	assert.match(health, /from ["']\.\/api["']/);
+	assert.match(health, /from ["']\.\/healthCache\.js["']/);
+	assert.match(health, /getCachedHealth\(apiGet\)/);
+});
+
+test("Layout.jsx / Architecture.jsx / ModelCostPanel.jsx: /health is read through the shared fetchHealth cache, not independent apiGet('/health') calls", () => {
+	for (const [name, src] of [
+		["Layout.jsx", layout],
+		["Architecture.jsx", architecture],
+		["ModelCostPanel.jsx", modelCostPanel],
+	]) {
+		assert.doesNotMatch(
+			src,
+			/apiGet\(["']\/health["']\)/,
+			`${name} calls apiGet("/health") directly instead of the shared fetchHealth() — this reintroduces a duplicate /health fetch`,
+		);
+		assert.match(
+			src,
+			/from ["']\.\.\/health["']/,
+			`${name} does not import from ../health`,
+		);
+		assert.match(
+			src,
+			/fetchHealth\(\)/,
+			`${name} does not call the shared fetchHealth()`,
+		);
+	}
+});
+
+// ── App.css: the tone rules must stay reachable (#1333 review) ─────────────
+// The CSS half of the original fix had no guard: the review that landed
+// alongside this test caught three tone rules shipping as unreachable
+// bare `.live-dot-*` selectors (0,1,0) — lower specificity than the
+// existing `.app-site .live-dot { ... }` base rule, so they sat dead in the
+// sheet regardless of source order (see the "Tri-state chain-status pill"
+// comment in App.css). A future edit to that block could silently
+// reintroduce the same defect with nothing here to catch it.
+
+const css = readFileSync(new URL("../src/App.css", import.meta.url), "utf8");
+
+test("App.css: all three chain-status tone rules are scoped under .app-site, not bare base-scope rules", () => {
+	for (const tone of ["connected", "disconnected", "unknown"]) {
+		assert.match(
+			css,
+			new RegExp(`\\.app-site \\.live-dot-${tone}\\s*\\{`),
+			`.app-site .live-dot-${tone} rule not found`,
+		);
+	}
+	// Mutation-check target: a bare rule at the start of a line is the exact
+	// unreachable shape the #1333 review caught — (0,1,0) specificity, always
+	// beaten by the `.app-site .live-dot { ... }` base rule above, so it
+	// would sit dead in the sheet however it's added back.
+	assert.doesNotMatch(
+		css,
+		/^\.live-dot-(connected|disconnected|unknown)\s*\{/m,
+		"a bare, unscoped .live-dot-* rule is unreachable — lower specificity than the .app-site base rule",
+	);
 });

--- a/ui/test/chain-status.test.js
+++ b/ui/test/chain-status.test.js
@@ -74,13 +74,32 @@ test("Layout.jsx: the footer pill no longer derives from NEW_CONTRACTS (acceptan
 	assert.doesNotMatch(layout, /NEW_CONTRACTS/);
 });
 
-test("Layout.jsx: the pill is driven by deriveChainStatus off a single /health fetch, not a new polling loop", () => {
+test("Layout.jsx: the pill is driven by deriveChainStatus off a bounded /health re-fetch, not a new polling loop", () => {
 	assert.match(layout, /from ["']\.\.\/chainStatus["']/);
 	assert.match(layout, /deriveChainStatus\(health, healthError\)/);
 	assert.match(layout, /apiGet\(["']\/health["']\)/);
-	// Anti-goal: no new polling loop — a single effect-on-mount fetch only.
+	// Anti-goal: no new polling loop — the effect only re-runs on an actual
+	// in-app navigation (dep: `page`), never on a timer.
 	assert.doesNotMatch(layout, /setInterval/);
-	assert.match(layout, /\}, \[\]\);/); // the health-fetch effect has an empty dep array
+	// #1333 review: an empty dep array here meant Layout — reconciled, not
+	// remounted, across route changes (AuthenticatedApp.jsx renders it with
+	// no `key`) — fetched /health exactly once per session, so an outage
+	// beginning after mount stayed invisible for the rest of the session.
+	// The effect must re-run per navigation instead.
+	assert.match(layout, /\}, \[page\]\);/);
+});
+
+test("Layout.jsx: a successful re-fetch clears a prior healthError, so recovery after an outage is reachable", () => {
+	// #1333 review follow-up: re-fetching on navigation is pointless if a
+	// single earlier failure pins healthError=true for the rest of the
+	// session — deriveChainStatus treats healthError as sticky-unknown
+	// regardless of what a later successful fetch reports.
+	const successBlock = layout.match(
+		/apiGet\(["']\/health["']\)\s*\.then\(\(d\) => \{([\s\S]*?)\}\)\s*\.catch/,
+	);
+	assert.ok(successBlock, "apiGet('/health').then(...) block not found");
+	assert.match(successBlock[1], /setHealth\(d\)/);
+	assert.match(successBlock[1], /setHealthError\(false\)/);
 });
 
 test("Layout.jsx: the dot and label both carry the derived tone, so unknown/disconnected are visually distinct from live", () => {

--- a/ui/test/chain-status.test.js
+++ b/ui/test/chain-status.test.js
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { CHAIN_STATUS, deriveChainStatus } from "../src/chainStatus.js";
+
+// ── deriveChainStatus: the tri-state pill logic (#1321) ────────────────────
+// The bug: the footer pill's label was `Object.keys(NEW_CONTRACTS).length ?
+// "Arc · Testnet live" : "Arc · Connecting"` — NEW_CONTRACTS is a static
+// object literal with 7 hard-coded addresses, so the count is the constant
+// 7 and the "problem" branch was unreachable dead code. During the
+// 2026-08-19/20 backend OOM crash loop the pill said "live" the entire
+// time the site served 502/503.
+//
+// These tests render (i.e. compute the derived view for) each of the three
+// states off the REAL runtime signal (/health's `chain_connected`), not a
+// build-time constant, and assert the label text for each.
+
+test("chain status: connected renders the live label", () => {
+	const result = deriveChainStatus({ chain_connected: true }, false);
+	assert.equal(result.tone, CHAIN_STATUS.CONNECTED);
+	assert.equal(result.label, "Arc · Testnet live");
+});
+
+test("chain status: disconnected renders a distinct, non-live label — THE regression this issue is about", () => {
+	// This is the case that was structurally unreachable before the fix:
+	// chain_connected: false must NOT fall through to the "live" label.
+	const result = deriveChainStatus({ chain_connected: false }, false);
+	assert.equal(result.tone, CHAIN_STATUS.DISCONNECTED);
+	assert.equal(result.label, "Arc · Chain disconnected");
+	assert.notEqual(result.label, "Arc · Testnet live");
+});
+
+test("chain status: a failed /health fetch renders unknown, never live — mutation-check target", () => {
+	// Mutation-check (CLAUDE.md § "Before you approve a merge", rule 4): force
+	// the health fetch to fail (healthError=true, health=null, exactly what
+	// Layout.jsx's apiGet(...).catch(() => setHealthError(true)) produces) and
+	// confirm the assertion that would have read "live" now FAILS instead.
+	// Verified manually against pre-fix Layout.jsx (blockLabel derived from
+	// NEW_CONTRACTS, ignoring /health entirely) by stashing this fix and
+	// re-running — see PR body for the transcript.
+	const result = deriveChainStatus(null, true);
+	assert.equal(result.tone, CHAIN_STATUS.UNKNOWN);
+	assert.equal(result.label, "Arc · Status unknown");
+	assert.notEqual(result.tone, CHAIN_STATUS.CONNECTED);
+	assert.notEqual(result.label, "Arc · Testnet live");
+});
+
+test("chain status: the pre-resolution window (health not yet loaded, no error yet) is unknown, not live", () => {
+	const result = deriveChainStatus(null, false);
+	assert.equal(result.tone, CHAIN_STATUS.UNKNOWN);
+	assert.equal(result.label, "Arc · Status unknown");
+});
+
+test("chain status: a malformed /health body (missing or non-boolean chain_connected) is unknown, not trusted as live", () => {
+	assert.equal(deriveChainStatus({}, false).tone, CHAIN_STATUS.UNKNOWN);
+	assert.equal(
+		deriveChainStatus({ chain_connected: "true" }, false).tone,
+		CHAIN_STATUS.UNKNOWN,
+	);
+	assert.equal(deriveChainStatus(undefined, false).tone, CHAIN_STATUS.UNKNOWN);
+});
+
+// ── Wiring: Layout.jsx reads the real /health signal, not NEW_CONTRACTS ────
+
+const layout = readFileSync(
+	new URL("../src/components/Layout.jsx", import.meta.url),
+	"utf8",
+);
+
+test("Layout.jsx: the footer pill no longer derives from NEW_CONTRACTS (acceptance criterion #1)", () => {
+	// The exact grep from the issue: no match at all, since NEW_CONTRACTS had
+	// no other use in this file besides the dead-code blockLabel assignment.
+	assert.doesNotMatch(layout, /NEW_CONTRACTS/);
+});
+
+test("Layout.jsx: the pill is driven by deriveChainStatus off a single /health fetch, not a new polling loop", () => {
+	assert.match(layout, /from ["']\.\.\/chainStatus["']/);
+	assert.match(layout, /deriveChainStatus\(health, healthError\)/);
+	assert.match(layout, /apiGet\(["']\/health["']\)/);
+	// Anti-goal: no new polling loop — a single effect-on-mount fetch only.
+	assert.doesNotMatch(layout, /setInterval/);
+	assert.match(layout, /\}, \[\]\);/); // the health-fetch effect has an empty dep array
+});
+
+test("Layout.jsx: the dot and label both carry the derived tone, so unknown/disconnected are visually distinct from live", () => {
+	assert.match(layout, /live-dot live-dot-\$\{chainStatus\.tone\}/);
+	assert.match(layout, /\{chainStatus\.label\}/);
+});
+
+// ── config.js: NEW_CONTRACTS itself is untouched (acceptance criterion #3) ─
+
+const config = readFileSync(
+	new URL("../src/config.js", import.meta.url),
+	"utf8",
+);
+
+test("config.js: NEW_CONTRACTS still has its 7 hard-coded addresses — this issue is about the label, not the address book", () => {
+	assert.match(config, /export const NEW_CONTRACTS = \{/);
+	const match = config.match(/export const NEW_CONTRACTS = \{([^}]*)\}/s);
+	assert.ok(match, "NEW_CONTRACTS block not found");
+	const keyCount = (match[1].match(/^\s*\w+:/gm) || []).length;
+	assert.equal(keyCount, 7);
+});


### PR DESCRIPTION
Closes #1321

## The bug

The app-shell footer status pill read `Object.keys(NEW_CONTRACTS).length ? "Arc · Testnet live" : "Arc · Connecting"`. `NEW_CONTRACTS` (`ui/src/config.js`) is a static object literal with 7 hard-coded addresses, so the count is the constant `7` — always truthy. `"Arc · Connecting"` was structurally unreachable dead code. It is the only chain-status affordance in the app shell, and during the 2026-08-19/20 backend OOM crash loop it said **"Arc · Testnet live"** the entire time the site served 502/503.

## The fix

- `ui/src/chainStatus.js` (new): pure function `deriveChainStatus(health, healthError)` that derives a tri-state `{ tone, label }` from the **real** `/health` response's `chain_connected` boolean (`backend/archimedes/main.py`) — `connected` / `disconnected` / `unknown`. `unknown` covers both the pre-resolution window and a failed fetch, and a malformed/non-boolean `chain_connected` also falls to `unknown` rather than being trusted as live.
- `ui/src/components/Layout.jsx`: fetches `/health` on mount **and on every in-app navigation** (cancelled-guard pattern, effect keyed on `page`) — no `setInterval`, no new polling loop, but also not a single fetch frozen at mount. (Revised post-review — see "Review follow-up" below.) The footer dot's class and the label text are both driven by the derived tone. `NEW_CONTRACTS` import removed — it had no other use in this file.
- `ui/src/App.css`: three tone classes (`live-dot-connected` / `-disconnected` / `-unknown`), scoped `.app-site .live-dot-*`, mapped to the existing `--positive` / `--negative` / `--warning` tokens — which resolve to `--app-verify`/`--app-risk`/`--app-action` inside `.app-site` for both themes, same palette the rigor-gate tri-state pattern already uses. `connected` and `disconnected` both glow, via `color-mix` against the theme-aliased token rather than a hard-coded literal color (see "Review follow-up" #2 below); only `unknown` drops the glow entirely, so an outage or a not-yet-resolved state doesn't still *look* alive.
- `ui/src/health.js` / `ui/src/healthCache.js` (new — added in review follow-up #4 below): a shared, short-TTL-cached `fetchHealth()` that Layout, Architecture, and ModelCostPanel all call, so a navigation that lands on a page with its own `/health` read reuses whichever of them just fetched it instead of firing an independent Arc RPC round-trip + DB reads.
- `ui/src/config.js` is untouched — it stays a legitimate address book, used elsewhere in the shell (Portfolio, Reasoning, CreateVaultModal).

## Acceptance criteria (issue's exact commands)

**AC#1** — no match on the `blockLabel` assignment:
```
$ grep -n "NEW_CONTRACTS" ui/src/components/Layout.jsx
(no output, exit 1)
```

**AC#2** — tri-state rendered, disconnected/unknown reachable, `node --test` all green:
```
$ cd ui && node --test
ℹ tests 106
ℹ pass 106
ℹ fail 0
```
16 of those are `ui/test/chain-status.test.js`: 5 direct `deriveChainStatus` state assertions (connected / disconnected / fetch-failed-unknown / pending-unknown / malformed-unknown), 3 `getCachedHealth` TTL-cache behavior assertions (reuse-within-TTL / refetch-after-TTL / failure-not-cached), 4 static-source wiring checks on `Layout.jsx`, 1 on `health.js`, 1 on `config.js`, 1 covering the shared-fetchHealth wiring across `Layout.jsx`/`Architecture.jsx`/`ModelCostPanel.jsx`, and 1 on `App.css`'s tone-rule reachability.

**AC#3** — `NEW_CONTRACTS` untouched: confirmed via `git diff --stat` on this branch — `ui/src/config.js` does not appear.

## Guard transcript — mutation-check (CLAUDE.md "Before you approve a merge" rule 4)

Per-guard mutation checks, each applied in isolation against the current branch, full `chain-status.test.js` suite re-run, then reverted before the next (`git diff --stat` clean between each):

```
$ # 1. `}, [page]);` → `}, []);` — the "pill only honest until first navigation" defect
ℹ tests 16 / pass 15 / fail 1
✖ Layout.jsx: the pill is driven by deriveChainStatus off a bounded /health re-fetch, not a new polling loop

$ # 2. delete `setHealthError(false)` from the success branch — a stale healthError sticks forever
ℹ tests 16 / pass 15 / fail 1
✖ Layout.jsx: a successful re-fetch clears a prior healthError, so recovery after an outage is reachable

$ # 3. reintroduce a bare (unscoped) `.live-dot-connected { ... }` rule in App.css
ℹ tests 16 / pass 15 / fail 1
✖ App.css: all three chain-status tone rules are scoped under .app-site, not bare base-scope rules

$ # 4. revert Architecture.jsx to a direct apiGet("/health") call, bypassing the shared cache
ℹ tests 16 / pass 15 / fail 1
✖ Layout.jsx / Architecture.jsx / ModelCostPanel.jsx: /health is read through the shared fetchHealth cache, not independent apiGet('/health') calls
```

Each of the four fails against the unfixed mutation and passes once reverted — confirming they reject the real defect rather than passing unconditionally.

One gap, disclosed rather than hidden: the `connected` tone's glow color has no dedicated regression guard. Reverting `box-shadow: 0 0 8px color-mix(in srgb, var(--positive) 50%, transparent)` back to the original hard-coded `rgba(121, 201, 183, 0.5)` still passes the full suite 16/16 — the sibling `disconnected` rule has the same gap. Both are visual/theme-correctness properties verified by inspection against the `--positive`→`--app-verify` alias chain in App.css, not by an automated color assertion; closing this would need a computed-style or screenshot-diff test, not attempted here.

Restored the fix after each mutation; re-ran the full suite green (see AC#2 transcript above).

## Verification tallies

- `cd ui && node --test` → **106 passed, 0 failed** (full suite, not just the new file)
- `cd ui && npm run lint` → clean, no output
- `cd ui && npm run build` → succeeds (`vite build`, pre-existing >500kB chunk-size warning only, unrelated to this change)
- `git diff --stat origin/main...HEAD -- ui/` on this branch → `ui/src/App.css`, `ui/src/chainStatus.js` (new), `ui/src/components/Architecture.jsx`, `ui/src/components/Layout.jsx`, `ui/src/components/ModelCostPanel.jsx`, `ui/src/health.js` (new), `ui/src/healthCache.js` (new), `ui/test/chain-status.test.js` — nothing else touched

## Anti-goals honored

- No new polling loop — `/health` re-fetches only on mount and on an actual in-app navigation, cancelled-guard pattern, never on a timer. The issue's anti-goal also said "`/health` is already fetched by the shell; reuse that response" — that premise didn't hold as originally shipped: no shell-level fetch existed for Layout, Architecture, or ModelCostPanel to reuse, each called `apiGet("/health")` independently (see "Review follow-up" #4 below). `ui/src/health.js`'s shared, TTL-cached `fetchHealth()` makes that reuse real: a navigation that lands on a page with its own `/health` read now shares whichever caller just fetched it instead of firing a second or third independent round-trip.
- No always-neutral label — the pill still says "Arc · Testnet live" when it's true; only the false/uncertain cases changed.
- `ui/src/config.js` `NEW_CONTRACTS` untouched.
- Did not touch the landing page's separate "Arc census live" badge.

## Review follow-up (2026-08-20)

An adversarial review of this PR found four confirmed issues, fixed on this branch:

1. **Major — the pill was honest only until the first navigation.** The `/health` effect originally ran with an empty dep array (`}, []);`). `AuthenticatedApp.jsx` renders `<Layout>` at a stable tree position with no `key`, so React reconciles rather than remounts it across in-app route changes — meaning the effect fired exactly once per session. A tab left open across a backend outage that started *after* load kept showing "Arc · Testnet live" for the rest of the session: the same fail-soft failure #1321 was filed for, just time-bounded instead of permanent. This directly contradicted the "can never silently render as live" claim above (and the matching code comment). Fixed: the effect now depends on `page` and re-fetches on every in-app navigation — still not a polling loop, honoring the issue's explicit anti-goal. Fixing this also surfaced a second bug it would otherwise have masked: `healthError` was set on failure but never cleared on a later success, so one failed fetch would have pinned the pill on "unknown" forever even after the backend recovered — the success branch now resets it. `ui/test/chain-status.test.js` gained a wiring check for the `[page]` dep (mutation-checked: reverting to `[]` fails it) and a check that the success path clears `healthError`.
2. **Minor — the "mapped to `--positive`/`--negative`/`--warning`" claim was true for the tokens but not for the CSS.** The three tone classes were declared as bare `.live-dot-connected`/`-disconnected`/`-unknown` rules at (0,1,0) specificity. The pill's only element is always inside `.app-site`, which already carried a same-element `.app-site .live-dot { background: var(--app-verify); ... }` rule at (0,2,0) — higher specificity always wins regardless of source order, so the bare `connected` rule was dead CSS from the moment it shipped (the `disconnected`/`unknown` overrides worked only because App.css *also* had `.app-site`-scoped versions of those two declared after the base rule, at matching specificity). Net effect: `var(--positive)` never painted; the connected dot rendered `--app-verify` the whole time (visually the same color by coincidence — `--positive` is itself aliased to `--app-verify` inside `.app-site` — but the stated mechanism was wrong, and a bug for any future theme where that alias diverges). Separately, the disconnected glow hard-coded `rgba(239, 68, 68, 0.45)`, the *base* (non-`.app-site`) dark-theme `--negative`, rather than tracking the theme-scoped token. Fixed at the time: all three tones declared directly under `.app-site .live-dot-*`, and the disconnected glow switched to `color-mix(in srgb, var(--negative) 45%, transparent)`.
3. **Minor — a follow-up review caught the same defect surviving one tone over.** The `connected` rule's glow was left as `box-shadow: 0 0 8px rgba(121, 201, 183, 0.5)` — a hard-coded dark-theme `--app-verify` hex, the exact defect class item 2 above just fixed for `disconnected`. In the light `.app-site` theme, `--positive` resolves to `#287566`, not `#79c9b7`, so the glow painted a dark-theme mint halo around a differently-colored dot. Fixed: `connected` now uses `color-mix(in srgb, var(--positive) 50%, transparent)`, matching `disconnected`'s treatment (same 50%/0.5 alpha the original rgba carried). The App.css comment above the three rules was rewritten to describe this consistently instead of claiming `connected` "keeps the exact glow this pill has always had" via the token alias alone. No dedicated regression test guards this specific color choice — see the disclosed gap in the Guard transcript above.
4. **Minor — the `[page]` fix turned `/health` into a per-navigation call with no reuse across the three components that read it.** `/health` is rate-limit-exempt but not free: it does an Arc RPC round-trip (`chain_client.is_connected()`) plus several DB reads (`backend/archimedes/main.py`). Once Layout started re-fetching on every navigation, landing on `/architecture` fired `/health` twice in the same render pass — Layout's per-navigation re-fetch plus Architecture's own mount-time fetch (`ModelCostPanel.jsx` is a third independent caller, reachable from the Generate page). No shell-level fetch existed for any of them to "reuse," despite issue #1321's anti-goal saying one did. Fixed: `ui/src/healthCache.js` is a small, dependency-free TTL cache (`getCachedHealth(fetcher, now)`, 30s window, a failed fetch is not cached so the next call retries immediately rather than being stuck reusing a rejection); `ui/src/health.js` is the thin production wrapper (`fetchHealth()`) that binds it to the real `apiGet`. All three components now call `fetchHealth()` instead of `apiGet("/health")` directly.

Re-verified after all four fixes: `cd ui && node --test` → **106 passed, 0 failed**; `npm run lint` clean; `npm run build` succeeds (same pre-existing chunk-size warning only). See the Guard transcript section above for the mutation-check evidence.

