### PR TITLE
[backend][frontend] Persist per-generation cost and surface it: passport card, library column, quote-vs-measured

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -710,6 +710,85 @@ def _served_model_for(job_agent: Any, use_live: bool) -> str:
         return "unknown"
 
 
+def _quote_in_force() -> dict[str, Any] | None:
+    """The literal ``generation_payment.quote()`` payload, or ``None``.
+
+    Read-only use of the quote seam (#1326 anti-goal: don't touch it). The
+    payload is recorded verbatim next to the measurement so the passport can
+    show "quoted X / measured Y" as two facts we wrote down, rather than as a
+    conversion — no token count is ever turned into money server-side.
+
+    ``None`` when the seam cannot be read. That is an honest "we did not record
+    what was quoted", and it renders as unknown; it is never a zero price.
+    """
+    try:
+        from archimedes.services import generation_payment
+
+        return dict(generation_payment.quote())
+    except Exception:
+        logger.warning("cost record: could not read the generation quote — recording it as unknown", exc_info=True)
+        return None
+
+
+async def _persist_generation_cost(
+    *,
+    job_id: str,
+    strategy_ids: dict[str, str],
+    measurement: dict[str, Any],
+    quote: dict[str, Any] | None,
+) -> None:
+    """Write the durable ``generation_costs`` row(s) for this job (#1326).
+
+    No strategy row ⇒ nothing to key a durable record to, so nothing is written
+    and the job record (with its TTL) remains the only copy. That is the issue's
+    own boundary: persist "on rigor-failed/errored terminal paths **where a
+    strategy row exists**".
+
+    Two deliberate omissions:
+
+    * The write is **not** tallied through ``cost_meter.record_write``. The
+      snapshot being written is already sealed — a tally could not appear inside
+      the document it is counting — and ``record_write("generation_costs")``
+      raises :class:`~archimedes.services.cost_meter.PricingLeakError` anyway,
+      because "cost" is pricing vocabulary inside a measurement record. The
+      table's *name* is fine; a counter label inside a ``cost_v1`` snapshot is
+      not, and that screen is working as designed.
+    * Failure is logged, never raised. Instrumentation is not allowed to change
+      the outcome of a generation (``docs/generation-cost-instrumentation.md``
+      § guarantee 5), and this runs in a ``finally`` that may already be
+      unwinding a cancellation.
+    """
+    if not strategy_ids:
+        logger.debug("cost record: job %s produced no strategy row — durable cost not written", job_id)
+        return
+
+    def _write() -> int:
+        from archimedes.db import get_session
+        from archimedes.models.generation_cost import record_generation_cost
+
+        written = 0
+        with get_session() as session:
+            for strategy_id in dict.fromkeys(strategy_ids.values()):
+                if not strategy_id:
+                    continue
+                record_generation_cost(
+                    session,
+                    job_id=job_id,
+                    strategy_id=strategy_id,
+                    measurement=measurement,
+                    quote=quote,
+                )
+                written += 1
+            session.commit()
+        return written
+
+    try:
+        count = await asyncio.to_thread(_write)
+        logger.info("cost record: persisted %d durable generation cost row(s) for job %s", count, job_id)
+    except (Exception, asyncio.CancelledError):
+        logger.warning("cost record: durable persist failed for job %s (non-blocking)", job_id, exc_info=True)
+
+
 async def run_generation(
     *,
     job_id: str,
@@ -755,6 +834,19 @@ async def run_generation(
     meter_token = cost_meter.bind(meter)
     meter.set_meta("n_candidates_requested", n_candidates)
     meter.set_meta("model_requested", model)
+
+    # The price quote in force as this job starts (#1326). Read once, here,
+    # because that is the quote the caller was actually charged against — a
+    # quote re-read at the end would be a different fact wearing this run's
+    # name. Stored in its OWN column beside the measurement so quote-vs-measured
+    # is a pairing of two recorded facts, never a conversion. Read-only: the
+    # quote seam itself is untouched.
+    quote_in_force = _quote_in_force()
+
+    # Populated by the persist step inside the try. Declared out here so the
+    # `finally` can write the durable cost row on the rigor-FAILED, errored and
+    # cancelled paths too — every path where a strategy row already exists.
+    strategy_ids: dict[str, str] = {}  # candidate_id → strategy_id
 
     await store.update_status(job_id, "running")
     await emit.emit("job_queued", brief=brief.model_dump())
@@ -1059,7 +1151,7 @@ async def run_generation(
         # rigor verdicts) and surfaced via the job's candidates payload — they
         # must NOT accumulate as rejected StrategyRecords (the orphan pattern
         # the ownership purge removed).
-        strategy_ids: dict[str, str] = {}  # candidate_id → strategy_id
+        # (`strategy_ids` is declared before the try — the `finally` reads it.)
         ownership = {"owner_wallet": owner_wallet}
         if owner_user_id is not None:
             ownership["owner_user_id"] = owner_user_id
@@ -1250,8 +1342,21 @@ async def run_generation(
         # so a failure here is swallowed (CancelledError included: this runs
         # while a cancellation is already propagating).
         cost_meter.unbind(meter_token)
+        snapshot: dict[str, Any] | None = None
         with contextlib.suppress(Exception, asyncio.CancelledError):
-            await store.merge_result(job_id, {"cost": meter.snapshot()})
+            snapshot = meter.snapshot()
+            await store.merge_result(job_id, {"cost": snapshot})
+        # …and durably, keyed to the strategy the run produced (#1326). The job
+        # record above expires with JOB_TTL; this one is what the passport card
+        # and the library column read an hour, a week or a year later. Same
+        # snapshot object as the job record gets, so the two can never disagree.
+        if snapshot is not None:
+            await _persist_generation_cost(
+                job_id=job_id,
+                strategy_ids=strategy_ids,
+                measurement=snapshot,
+                quote=quote_in_force,
+            )
 
 
 async def _persist_candidate(

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -13,7 +13,7 @@ Convention:
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, model_validator
 
@@ -253,6 +253,20 @@ class StrategyResponse(BaseModel):
     # deterministic heuristic in services/return_source_classifier.py.
     return_source: str = "noise"  # "risk_premium" | "mispricing" | "productive_growth" | "noise"
     return_source_note: str = ""
+
+    # ── Generation cost (#1326) ─────────────────────────────────────────────
+    # What the generation run that produced this strategy actually consumed,
+    # read from the durable ``generation_costs`` row rather than the Redis job
+    # record (which expires after an hour). Shape:
+    #   {"schema": "cost_v1", "job_id", "recorded_at",
+    #    "measurement": {…the cost_v1 snapshot…},
+    #    "quote": {…the literal generation_payment.quote() payload…} | null}
+    # RAW MEASUREMENT beside a RECORDED PRICE, never a conversion of one into
+    # the other: no server-side $-conversion of token counts (#1217's remaining
+    # pricing work). ``None`` = nothing measured this strategy — every curated
+    # strategy, and every generated one from before the meter — which the UI
+    # renders as "not measured", never as zero.
+    generation_cost: dict[str, Any] | None = None
 
     # Whether the caller's wallet is permitted to publish this strategy.
     # Always False for anonymous requests; True only when the caller is the

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -576,12 +576,20 @@ async def list_generated_strategies(
                 )
             query = query.filter(StrategyRecord.is_published.is_(True) | or_(*owner_filters))
             records = query.order_by(StrategyRecord.created_at.desc()).limit(limit).all()
+            # One query for the whole page's generation-cost records (#1326) —
+            # the library's cost column reads this. Strategies with nothing
+            # measured are simply absent from the map and stay absent from the
+            # row, which the table renders as an em-dash, never as zero.
+            from archimedes.models.generation_cost import generation_costs_for_strategies
+
+            costs = generation_costs_for_strategies(session, [r.id for r in records])
             rows = []
             for r in records:
                 d = r.to_dict()
                 d["can_publish"] = bool(caller) and wallet_can_publish(
                     session, strategy_id=r.id, wallet_address=caller, is_example=False
                 )
+                d["generation_cost"] = costs.get(r.id)
                 rows.append(_redact_owner_wallet(d, caller))
     except Exception as exc:
         import logging as _logging
@@ -1663,6 +1671,32 @@ def _enrich_paper_titles_from_corpus(
         return {}
 
 
+def _generation_cost_for(strategy_id: str, session) -> dict | None:
+    """The durable generation-cost record for one strategy, or ``None`` (#1326).
+
+    ``None`` covers three genuinely different situations — no session on this
+    call path, no record for this strategy, and a record whose measurement will
+    not decode — and every one of them is the same claim to a reader: *nothing
+    measured this*. That is deliberate. The alternative, distinguishing them in
+    the payload, would invite a caller to treat "we didn't look" as "measured
+    zero". The corrupt-record case is logged loudly by the model layer.
+
+    A lookup failure must never take down a strategy read: the cost card is
+    decoration on a page whose subject is the strategy.
+    """
+    if session is None or not strategy_id:
+        return None
+    try:
+        from archimedes.models.generation_cost import generation_cost_for_strategy
+
+        return generation_cost_for_strategy(session, strategy_id)
+    except Exception as exc:  # pragma: no cover — defensive; DB-level failure
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning("generation cost lookup failed for %s: %s", strategy_id, exc)
+        return None
+
+
 def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
     """Reshape a StrategyPassportRecord (fusion/architect output) into the
     StrategyResponse schema that StrategyPassport.jsx expects. Curated
@@ -1680,6 +1714,12 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
         StrategyView,
         classify_return_source,
     )
+
+    # What the generation run that produced this strategy consumed (#1326).
+    # Needs the session, so it is None on the session-less call path — and None
+    # is also the answer for every strategy generated before the meter existed.
+    # Either way the UI renders "not measured"; nothing is zeroed or invented.
+    generation_cost = _generation_cost_for(record.id, session)
 
     refs = list(record.paper_refs or [])
     first = refs[0] if refs else None
@@ -1778,6 +1818,7 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
         regime_tag=record.regime_tag,
         return_source=return_source_enum.value,
         return_source_note=return_source_note,
+        generation_cost=generation_cost,
     )
 
 

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -27,6 +27,7 @@ from archimedes.models.backtest_store import BacktestResultRecord
 from archimedes.models.chat import Base
 from archimedes.models.corpus_store import CorpusMetaRecord, PaperRecord
 from archimedes.models.daily_returns_store import StrategyDailyReturn
+from archimedes.models.generation_cost import GenerationCostRecord
 from archimedes.models.identity import ControlledWallet, IdentityEvent, WalletIdentity
 from archimedes.models.marketplace import (
     MarketplaceAgent,
@@ -56,6 +57,7 @@ __all__ = [
     "Base",
     "ControlledWallet",
     "CorpusMetaRecord",
+    "GenerationCostRecord",
     "IdentityEvent",
     "LinkedWallet",
     "MarketplaceAgent",

--- a/backend/archimedes/models/generation_cost.py
+++ b/backend/archimedes/models/generation_cost.py
@@ -1,0 +1,225 @@
+"""Durable per-generation cost record — the measurement, and the quote beside it.
+
+Issue #1326, following the #1314 cost meter. The meter's ``cost_v1`` snapshot
+lived only on the Redis job record, whose ``JOB_TTL`` is 3600s: an hour after a
+generation finished, the only measurement anyone had of what it consumed was
+gone, and no surface ever showed it. This table is where it survives.
+
+Two columns, deliberately two:
+
+* ``measurement_json`` — the literal ``cost_v1`` snapshot
+  (:meth:`archimedes.services.cost_meter.CostMeter.snapshot`). Counts and
+  seconds. No money, and :func:`archimedes.services.cost_meter.assert_measurement_only`
+  is run over it on the way in, so a future edit that merges a price into the
+  measurement raises instead of shipping a priced ``cost_v1`` record.
+* ``quote_json`` — the literal ``generation_payment.quote()`` payload that was
+  in force when the job started. A *recorded fact* about what we charged, which
+  is why it is displayable; it is not derived from the measurement and nothing
+  here converts one into the other. Turning measured tokens into dollars is
+  #1217's remaining pricing work and happens off-server.
+
+Keeping them in separate columns is the whole design: quote-vs-measured is an
+honest pairing of two independently recorded facts, never a conversion.
+
+**The row is keyed to a (job, strategy) pair, and the measurement is the JOB's.**
+Generation is K=1 today (one ``strategy_store`` row per job — see
+``generation_pipeline`` § "K=1 persistence"), so the pairing is one-to-one in
+practice. If a job ever persists more than one strategy again, each gets a row
+carrying the *same* job-level measurement: that is the honest record (the run
+cost what it cost), and summing across rows would double-count. Read a row as
+"the generation run that produced this strategy consumed this", not as "this
+strategy's private share".
+
+No backfill: strategies generated before #1314 have no measurement, and
+inventing one would be the exact failure this instrumentation exists to end.
+They render as *not measured*.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from archimedes.models.chat import Base
+
+logger = logging.getLogger(__name__)
+
+#: Used when a stored snapshot carries no ``schema`` of its own. Never guessed
+#: to be ``cost_v1`` — a record whose shape we cannot name is not a record whose
+#: shape we may assert.
+UNKNOWN_SCHEMA = "unknown"
+
+
+class GenerationCostRecord(Base):
+    """One generation run's measurement, durably keyed to the strategy it produced.
+
+    ``strategy_id`` carries no foreign key, mirroring ``paper_deployments``
+    (the sibling table that also references ``strategy_store.id``): a purge of
+    the strategy row must not delete the record of what the run consumed —
+    the run still happened and still cost what it cost.
+    """
+
+    __tablename__ = "generation_costs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    strategy_id: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # The ``schema`` field of the stored snapshot, lifted out so a reader can
+    # tell ``cost_v1`` rows from a future ``cost_v2`` without parsing the blob.
+    schema_version: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    measurement_json: Mapped[str] = mapped_column(Text, nullable=False)
+    # NULL when the quote seam could not be read at job start. An honest
+    # absence: it means "we did not record what was quoted", not "$0.00".
+    quote_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    recorded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("job_id", "strategy_id", name="uq_generation_costs_job_strategy"),
+        Index("ix_generation_costs_strategy", "strategy_id"),
+    )
+
+    # ── Readout ──────────────────────────────────────────────────────────
+
+    def to_payload(self) -> dict[str, Any] | None:
+        """The API shape, or ``None`` when the measurement cannot be read.
+
+        A corrupt ``measurement_json`` yields ``None`` rather than an empty
+        measurement: the row exists to carry a measurement, so one we cannot
+        decode is an absence, and an absence renders as *not measured*. The
+        warning is the loud half of that (``CLAUDE.md`` § fail-soft).
+
+        A corrupt ``quote_json`` degrades on its own — the measurement is still
+        a measurement without the price beside it.
+        """
+        measurement = _decode(self.measurement_json, what="measurement", strategy_id=self.strategy_id)
+        if not isinstance(measurement, Mapping):
+            return None
+        quote = _decode(self.quote_json, what="quote", strategy_id=self.strategy_id)
+        return {
+            "schema": self.schema_version,
+            "job_id": self.job_id,
+            "recorded_at": self.recorded_at.isoformat() if self.recorded_at else None,
+            "measurement": dict(measurement),
+            "quote": dict(quote) if isinstance(quote, Mapping) else None,
+        }
+
+
+def _decode(raw: str | None, *, what: str, strategy_id: str) -> Any:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("generation_costs: corrupt %s JSON for strategy %s — treating as absent", what, strategy_id)
+        return None
+
+
+def record_generation_cost(
+    session: Session,
+    *,
+    job_id: str,
+    strategy_id: str,
+    measurement: Mapping[str, Any],
+    quote: Mapping[str, Any] | None = None,
+) -> GenerationCostRecord:
+    """Upsert one (job, strategy) measurement. Idempotent on re-run.
+
+    ``measurement`` is screened by
+    :func:`archimedes.services.cost_meter.assert_measurement_only` before it is
+    serialized, so a pricing-shaped key at any depth raises
+    :class:`~archimedes.services.cost_meter.PricingLeakError` at this boundary
+    instead of landing in the column. ``quote`` is NOT screened — it is a price
+    by definition and that is why it lives in its own column.
+
+    Raises ``ValueError`` on a missing key or a non-mapping measurement: writing
+    a measurement with no job or no strategy would produce a row nothing can
+    ever read back.
+    """
+    from archimedes.services.cost_meter import assert_measurement_only
+
+    if not job_id:
+        raise ValueError("record_generation_cost requires a job_id")
+    if not strategy_id:
+        raise ValueError("record_generation_cost requires a strategy_id")
+    if not isinstance(measurement, Mapping):
+        raise ValueError(f"record_generation_cost requires a measurement mapping, got {type(measurement).__name__}")
+
+    assert_measurement_only(measurement, where="generation_costs.measurement_json")
+
+    schema_version = str(measurement.get("schema") or UNKNOWN_SCHEMA)[:32]
+    measurement_json = json.dumps(measurement, sort_keys=True, ensure_ascii=False)
+    quote_json = json.dumps(dict(quote), sort_keys=True, ensure_ascii=False) if isinstance(quote, Mapping) else None
+    now = datetime.now(UTC)
+
+    existing = session.query(GenerationCostRecord).filter_by(job_id=job_id, strategy_id=strategy_id).first()
+    if existing is not None:
+        existing.schema_version = schema_version
+        existing.measurement_json = measurement_json
+        existing.quote_json = quote_json
+        existing.recorded_at = now
+        session.flush()
+        return existing
+
+    record = GenerationCostRecord(
+        job_id=job_id,
+        strategy_id=strategy_id,
+        schema_version=schema_version,
+        measurement_json=measurement_json,
+        quote_json=quote_json,
+        recorded_at=now,
+    )
+    session.add(record)
+    session.flush()
+    return record
+
+
+def generation_cost_for_strategy(session: Session, strategy_id: str) -> dict[str, Any] | None:
+    """The most recently recorded measurement for one strategy, or ``None``.
+
+    ``None`` is the honest answer for every strategy generated before #1326 (and
+    for every curated one): nothing measured it, so nothing is claimed about it.
+    """
+    if not strategy_id:
+        return None
+    record = (
+        session.query(GenerationCostRecord)
+        .filter_by(strategy_id=strategy_id)
+        .order_by(GenerationCostRecord.recorded_at.desc(), GenerationCostRecord.id.desc())
+        .first()
+    )
+    return record.to_payload() if record is not None else None
+
+
+def generation_costs_for_strategies(session: Session, strategy_ids: Iterable[str]) -> dict[str, dict[str, Any]]:
+    """Batch form of :func:`generation_cost_for_strategy` — one query for a page.
+
+    Strategies with no record are simply absent from the mapping; the caller
+    renders that absence, it does not get a zeroed placeholder. Rows whose
+    measurement will not decode are absent too (see :meth:`to_payload`).
+    """
+    ids = [s for s in dict.fromkeys(strategy_ids) if s]
+    if not ids:
+        return {}
+    records = (
+        session.query(GenerationCostRecord)
+        .filter(GenerationCostRecord.strategy_id.in_(ids))
+        .order_by(GenerationCostRecord.recorded_at.asc(), GenerationCostRecord.id.asc())
+        .all()
+    )
+    # Ascending order + overwrite ⇒ the newest row per strategy wins, matching
+    # the single-strategy reader's "most recently recorded" rule.
+    out: dict[str, dict[str, Any]] = {}
+    for record in records:
+        payload = record.to_payload()
+        if payload is not None:
+            out[record.strategy_id] = payload
+    return out

--- a/backend/archimedes/models/generation_cost.py
+++ b/backend/archimedes/models/generation_cost.py
@@ -156,8 +156,14 @@ def record_generation_cost(
     assert_measurement_only(measurement, where="generation_costs.measurement_json")
 
     schema_version = str(measurement.get("schema") or UNKNOWN_SCHEMA)[:32]
-    measurement_json = json.dumps(measurement, sort_keys=True, ensure_ascii=False)
-    quote_json = json.dumps(dict(quote), sort_keys=True, ensure_ascii=False) if isinstance(quote, Mapping) else None
+    # ``default=str`` mirrors ``JobStore.update_status``/``merge_result``: the
+    # same snapshot is written to both stores, so a value one of them can encode
+    # and the other cannot would silently give the two copies different fates —
+    # the durable row failing while the (expiring) job record succeeds.
+    measurement_json = json.dumps(measurement, sort_keys=True, ensure_ascii=False, default=str)
+    quote_json = (
+        json.dumps(dict(quote), sort_keys=True, ensure_ascii=False, default=str) if isinstance(quote, Mapping) else None
+    )
     now = datetime.now(UTC)
 
     existing = session.query(GenerationCostRecord).filter_by(job_id=job_id, strategy_id=strategy_id).first()

--- a/backend/archimedes/models/generation_cost.py
+++ b/backend/archimedes/models/generation_cost.py
@@ -209,8 +209,17 @@ def generation_costs_for_strategies(session: Session, strategy_ids: Iterable[str
     """Batch form of :func:`generation_cost_for_strategy` — one query for a page.
 
     Strategies with no record are simply absent from the mapping; the caller
-    renders that absence, it does not get a zeroed placeholder. Rows whose
-    measurement will not decode are absent too (see :meth:`to_payload`).
+    renders that absence, it does not get a zeroed placeholder. A strategy whose
+    NEWEST record will not decode is absent too — the same answer the
+    single-strategy reader gives, which is the point.
+
+    That equivalence is why this orders DESC and keeps a ``seen`` set rather
+    than ordering ASC and letting later rows overwrite earlier ones. The
+    overwrite form silently fell back to an older, stale row when only the
+    newest was corrupt, so the batch and single readers disagreed about the same
+    strategy: one served a superseded measurement, the other honestly served
+    nothing. Skipping every row after the first per strategy makes "newest wins,
+    and if the newest is unreadable we have nothing" true in both readers.
     """
     ids = [s for s in dict.fromkeys(strategy_ids) if s]
     if not ids:
@@ -218,13 +227,18 @@ def generation_costs_for_strategies(session: Session, strategy_ids: Iterable[str
     records = (
         session.query(GenerationCostRecord)
         .filter(GenerationCostRecord.strategy_id.in_(ids))
-        .order_by(GenerationCostRecord.recorded_at.asc(), GenerationCostRecord.id.asc())
+        .order_by(GenerationCostRecord.recorded_at.desc(), GenerationCostRecord.id.desc())
         .all()
     )
-    # Ascending order + overwrite ⇒ the newest row per strategy wins, matching
-    # the single-strategy reader's "most recently recorded" rule.
     out: dict[str, dict[str, Any]] = {}
+    seen: set[str] = set()
     for record in records:
+        # First row per strategy IS the newest (DESC). Once seen, older rows are
+        # skipped whether or not the newest decoded — an older row is never a
+        # stand-in for a newer one we could not read.
+        if record.strategy_id in seen:
+            continue
+        seen.add(record.strategy_id)
         payload = record.to_payload()
         if payload is not None:
             out[record.strategy_id] = payload

--- a/backend/archimedes/services/cost_meter.py
+++ b/backend/archimedes/services/cost_meter.py
@@ -139,6 +139,25 @@ def _assert_no_pricing(label: str, kind: str) -> str:
     return text
 
 
+#: Dotted paths inside a snapshot whose IMMEDIATE keys are runtime **data**
+#: rather than caller-authored labels, and are therefore exempt from
+#: :func:`assert_measurement_only`'s key screen.
+#:
+#: Only ``llm.by_model`` qualifies today: its keys are provider model
+#: identifiers copied verbatim off a response (``response.model``), never
+#: something this codebase chose. Screening them would let a vendor's naming
+#: decide whether a generation's measurement gets persisted at all — a model id
+#: as ordinary as ``llama-3-feedback-tuned`` contains ``fee``, and one marketed
+#: as cost- or price-optimized contains the words outright. The write would then
+#: raise inside the pipeline's ``finally``, be swallowed, and drop the durable
+#: row: the exact silent-loss failure this instrumentation exists to end.
+#:
+#: The exemption is one level deep. Values beneath an exempt key are still
+#: walked, so ``llm.by_model["some-model"]["cost_usd"]`` still raises — the model
+#: id is data, the counters hanging off it are ours.
+DATA_KEYED_PATHS = frozenset({"llm.by_model"})
+
+
 def assert_measurement_only(payload: Any, *, where: str = "snapshot") -> None:
     """Refuse a payload whose KEYS carry pricing vocabulary, at any depth.
 
@@ -157,17 +176,28 @@ def assert_measurement_only(payload: Any, *, where: str = "snapshot") -> None:
 
     Values are deliberately not screened: a *quote* is a legitimately priced
     document and stores fine in its own column, and a measurement's values are
-    numbers, not labels. Keys are the namespace; keys are what is policed.
+    numbers, not labels. Keys are the namespace; keys are what is policed —
+    except where the keys are themselves data, which is what
+    :data:`DATA_KEYED_PATHS` records and why.
 
-    Raises :class:`PricingLeakError` on the first offending key. ``where`` names
-    the boundary for the error message.
+    Each key is screened on its own, with the dotted path carried only for the
+    error message. Screening the concatenated path would be equivalent for
+    ordinary keys (no deny-listed token contains a ``.``, and every ancestor
+    segment is screened when it is visited), but it would leak an exempt key's
+    text into its children's screens and re-raise on exactly the model ids the
+    exemption exists to allow.
+
+    Raises :class:`PricingLeakError` on the first offending key.
     """
 
     def _walk(node: Any, path: str) -> None:
         if isinstance(node, Mapping):
+            keys_are_data = path in DATA_KEYED_PATHS
             for key, value in node.items():
-                _assert_no_pricing(f"{path}.{key}" if path else str(key), f"{where} key")
-                _walk(value, f"{path}.{key}" if path else str(key))
+                child = f"{path}.{key}" if path else str(key)
+                if not keys_are_data:
+                    _assert_no_pricing(str(key), f"{where} key at {child}")
+                _walk(value, child)
         elif isinstance(node, (list, tuple)):
             for index, value in enumerate(node):
                 _walk(value, f"{path}[{index}]")

--- a/backend/archimedes/services/cost_meter.py
+++ b/backend/archimedes/services/cost_meter.py
@@ -139,6 +139,42 @@ def _assert_no_pricing(label: str, kind: str) -> str:
     return text
 
 
+def assert_measurement_only(payload: Any, *, where: str = "snapshot") -> None:
+    """Refuse a payload whose KEYS carry pricing vocabulary, at any depth.
+
+    :func:`_assert_no_pricing` screens one caller-chosen label at write time,
+    which is what keeps a live meter's snapshot clean. This is the same screen
+    applied to a *whole assembled payload* — the check a persistence boundary
+    needs, because by the time a snapshot reaches storage the labels that built
+    it are long gone and the only thing left to inspect is the document.
+
+    It exists for the durable ``generation_costs`` row (#1326): that row stores
+    the measurement and the price quote in **two separate columns** precisely so
+    the two never share a namespace, and this is the guard that makes "separate"
+    enforced rather than merely intended. Merging the quote into the measurement
+    — the obvious future shortcut — raises here instead of silently shipping a
+    priced ``cost_v1`` record.
+
+    Values are deliberately not screened: a *quote* is a legitimately priced
+    document and stores fine in its own column, and a measurement's values are
+    numbers, not labels. Keys are the namespace; keys are what is policed.
+
+    Raises :class:`PricingLeakError` on the first offending key. ``where`` names
+    the boundary for the error message.
+    """
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, Mapping):
+            for key, value in node.items():
+                _assert_no_pricing(f"{path}.{key}" if path else str(key), f"{where} key")
+                _walk(value, f"{path}.{key}" if path else str(key))
+        elif isinstance(node, (list, tuple)):
+            for index, value in enumerate(node):
+                _walk(value, f"{path}[{index}]")
+
+    _walk(payload, "")
+
+
 def _peak_rss_bytes() -> int | None:
     """Process peak resident set size in bytes, or ``None`` if unavailable.
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -53,6 +53,7 @@ from archimedes.models.backtest_store import BacktestResultRecord  # noqa: E402
 from archimedes.models.chat import Base  # noqa: E402
 from archimedes.models.corpus_store import CorpusMetaRecord, PaperRecord  # noqa: E402
 from archimedes.models.daily_returns_store import StrategyDailyReturn  # noqa: E402
+from archimedes.models.generation_cost import GenerationCostRecord  # noqa: E402
 from archimedes.models.identity import ControlledWallet, IdentityEvent, WalletIdentity  # noqa: E402
 from archimedes.models.kg import KGEntity, KGRelation  # noqa: E402
 from archimedes.models.marketplace import (  # noqa: E402
@@ -88,6 +89,7 @@ __all__ = [
     "Base",
     "ControlledWallet",
     "CorpusMetaRecord",
+    "GenerationCostRecord",
     "IdentityEvent",
     "KGEntity",
     "KGRelation",

--- a/backend/migrations/versions/e2b7f4c81d93_add_generation_costs.py
+++ b/backend/migrations/versions/e2b7f4c81d93_add_generation_costs.py
@@ -1,0 +1,87 @@
+"""add generation_costs — durable per-generation measurement + the quote beside it
+
+Issue #1326, following the #1314 cost meter. The ``cost_v1`` snapshot lived only
+on the Redis job record (``JOB_TTL`` 3600s), so an hour after a generation ended
+the only measurement of what it consumed was gone. This table is where it
+survives, and what the passport card and the library column read.
+
+Two payload columns, deliberately two:
+
+  - ``measurement_json`` — the literal ``cost_v1`` snapshot. Counts and seconds.
+    Screened by ``cost_meter.assert_measurement_only`` on the way in, so a
+    pricing-shaped key at any depth raises rather than landing here.
+  - ``quote_json`` — the literal ``generation_payment.quote()`` payload in force
+    when the job started. A recorded fact about what we charged; NULL when the
+    quote seam could not be read, which means "not recorded", never "$0.00".
+
+Separate columns are the design, not an accident of normalization:
+quote-vs-measured must be a pairing of two independently recorded facts, never a
+server-side conversion of tokens into dollars (that is #1217's remaining pricing
+work and it happens off-server).
+
+``strategy_id`` carries no foreign key, matching ``paper_deployments`` — the
+sibling table that also references ``strategy_store.id``. Purging a strategy row
+must not delete the record of what its run consumed: the run still happened.
+
+BACKFILL (migrations-ship-with-their-data rule): **none, and none is possible.**
+The table is new and every pre-#1314 generation was never measured — there is no
+recoverable figure for those runs, and fabricating one is precisely the failure
+this instrumentation exists to end. Historical strategies therefore render as
+"not measured" on the passport and as an em-dash in the library, which is the
+honest state. The issue's own anti-goal says the same: don't backfill.
+
+Revision ID: e2b7f4c81d93
+Revises: c9396e0d95d4
+Create Date: 2026-08-20 00:00:00.000000
+
+SEQUENCING: chained onto ``c9396e0d95d4`` (asset_daily_bars), the chain head at
+authoring time. If another migration lands on main first, re-point
+``down_revision`` at the new head — the chain stays serial (the two-heads fork
+has bitten this repo three times; ``.github/scripts/migration_chain_guard.py``
+is the check that catches it).
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e2b7f4c81d93"
+down_revision: str | Sequence[str] | None = "c9396e0d95d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "generation_costs",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("job_id", sa.String(length=64), nullable=False),
+        sa.Column("strategy_id", sa.String(length=64), nullable=False),
+        sa.Column("schema_version", sa.String(length=32), nullable=False),
+        sa.Column("measurement_json", sa.Text(), nullable=False),
+        sa.Column("quote_json", sa.Text(), nullable=True),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("job_id", "strategy_id", name="uq_generation_costs_job_strategy"),
+    )
+    op.create_index("ix_generation_costs_strategy", "generation_costs", ["strategy_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Dropping the table discards the measurements recorded while this revision
+    was live. There is nowhere else to put them — the Redis job record they used
+    to live on has an hour's TTL, which is the gap this revision closes — so a
+    downgrade is a deliberate loss of measurement, not a reversible move.
+    """
+    op.drop_index("ix_generation_costs_strategy", table_name="generation_costs")
+    op.drop_table("generation_costs")

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -95,6 +95,7 @@ def test_alembic_upgrade_head_from_empty_db(tmp_path):
         "marketplace_agents",
         "user_profiles",
         "request_count_snapshots",
+        "generation_costs",
     ):
         assert expected in tables, f"table {expected!r} missing after upgrade head; got {sorted(tables)}"
 
@@ -181,6 +182,95 @@ def test_alembic_strategy_spec_column_added_and_removed(tmp_path):
     reupgrade_again = _run_alembic("upgrade", "head", database_url=database_url)
     assert reupgrade_again.returncode == 0, reupgrade_again.stderr
     assert _has_strategy_spec_column()
+
+
+def test_alembic_generation_costs_table_added_and_removed(tmp_path):
+    """Durable generation cost (#1326): ``generation_costs`` lands on upgrade, is
+    gone on downgrade, and comes back on re-upgrade — the per-migration
+    up/down/idempotent contract exercised directly.
+
+    Same derived-target discipline as the ``strategy_spec`` test above: the
+    downgrade target is looked up as this revision's OWN ``down_revision``, never
+    a hardcoded hash or a relative ``-1``, so it keeps testing this migration
+    however many revisions later land on top of it.
+    """
+    db_path = tmp_path / "generation_costs.db"
+    database_url = f"sqlite:///{db_path}"
+
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(Config(str(_BACKEND_DIR / "alembic.ini")))
+    target = script.get_revision("e2b7f4c81d93").down_revision
+
+    upgrade = _run_alembic("upgrade", "head", database_url=database_url)
+    assert upgrade.returncode == 0, upgrade.stderr
+    assert "generation_costs" in _table_names(db_path)
+
+    downgrade = _run_alembic("downgrade", target, database_url=database_url)
+    assert downgrade.returncode == 0, downgrade.stderr
+    assert "generation_costs" not in _table_names(db_path)
+
+    reupgrade = _run_alembic("upgrade", "head", database_url=database_url)
+    assert reupgrade.returncode == 0, reupgrade.stderr
+    assert "generation_costs" in _table_names(db_path)
+
+    again = _run_alembic("upgrade", "head", database_url=database_url)
+    assert again.returncode == 0, again.stderr
+    assert "generation_costs" in _table_names(db_path)
+
+
+def test_alembic_generation_costs_matches_a_fresh_create_all_schema(tmp_path):
+    """Column parity for ``generation_costs`` between the two schema-management
+    paths — the ORM's ``GenerationCostRecord`` (create_all, every hermetic test
+    and local dev) and this migration's ``create_table`` (Alembic, CI/prod).
+
+    Divergence here is not cosmetic: the cost card reads
+    ``measurement_json`` / ``quote_json`` by name, so a column that exists on one
+    path and not the other means the passport renders "not measured" in exactly
+    one environment — the hardest kind of gap to notice.
+    """
+    create_all_db = tmp_path / "create_all_generation_costs.db"
+    script = (
+        "import sqlalchemy as sa\n"
+        "from archimedes.models.account import AuthUser\n"
+        "from archimedes.models.chat import Base\n"
+        # vault_metadata.creator_address FKs wallet_identities; register it or
+        # create_all() cannot resolve the whole metadata graph.
+        "from archimedes.models.identity import WalletIdentity\n"
+        "from archimedes.models.generation_cost import GenerationCostRecord\n"
+        f"engine = sa.create_engine('sqlite:///{create_all_db}')\n"
+        "Base.metadata.create_all(bind=engine)\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(_BACKEND_DIR),
+        env={"PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", "")},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    alembic_db = tmp_path / "alembic_built_generation_costs.db"
+    upgrade = _run_alembic("upgrade", "head", database_url=f"sqlite:///{alembic_db}")
+    assert upgrade.returncode == 0, upgrade.stderr
+
+    def _columns(db_path: Path, table: str) -> set[str]:
+        con = sqlite3.connect(str(db_path))
+        try:
+            cur = con.cursor()
+            cur.execute(f"PRAGMA table_info({table})")
+            return {row[1] for row in cur.fetchall()}
+        finally:
+            con.close()
+
+    create_all_cols = _columns(create_all_db, "generation_costs")
+    alembic_cols = _columns(alembic_db, "generation_costs")
+    assert {"job_id", "strategy_id", "schema_version", "measurement_json", "quote_json", "recorded_at"} <= (
+        create_all_cols
+    )
+    assert create_all_cols == alembic_cols
 
 
 def test_alembic_upgrade_head_matches_a_fresh_create_all_schema(tmp_path):

--- a/backend/tests/test_generation_cost_persistence.py
+++ b/backend/tests/test_generation_cost_persistence.py
@@ -40,7 +40,12 @@ from archimedes.models.generation_cost import (
     generation_costs_for_strategies,
     record_generation_cost,
 )
-from archimedes.services.cost_meter import CostMeter, PricingLeakError, assert_measurement_only
+from archimedes.services.cost_meter import (
+    DATA_KEYED_PATHS,
+    CostMeter,
+    PricingLeakError,
+    assert_measurement_only,
+)
 from archimedes.services.job_queue import KEY_PREFIX, JobStore
 
 from tests.db_isolation import redirect_to_tmp_sqlite
@@ -139,6 +144,76 @@ class TestMeasurementOnlyGuard:
         assert payload["quote"]["pricing_model"] == "flat_v1"
         # …and the measurement half is still money-free.
         assert_measurement_only(payload["measurement"], where="test")
+
+
+# ── G2b: model ids are DATA, and screening data drops measurements ────────
+
+
+class TestModelIdsAreNotScreened:
+    """``llm.by_model``'s keys are provider identifiers copied off a response,
+    not labels this codebase chose. Screening them would let a vendor's naming
+    decide whether a generation's measurement survives at all — and it would
+    fail SILENTLY, because the persist runs inside a swallowing ``finally``."""
+
+    def test_the_exemption_is_exactly_one_path_and_it_is_by_model(self):
+        assert DATA_KEYED_PATHS == frozenset({"llm.by_model"})
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "price-aware-model-x",  # marketed on price
+            "llama-3-feedback-tuned",  # "fee" inside "feedback" — the ordinary case
+            "vendor/cost-optimized-v2",
+            "acme-spend-lite",
+        ],
+    )
+    def test_a_model_id_carrying_pricing_words_still_persists(self, model_id):
+        """The input that SHOULD NOT fail the guard. Against the unexempted walk
+        every one of these raises ``PricingLeakError`` and the durable row is
+        dropped, which is the loss this instrumentation exists to prevent."""
+        snapshot = {
+            **_SNAPSHOT,
+            "llm": {
+                **_SNAPSHOT["llm"],
+                "by_model": {model_id: {"calls": 3, "input_tokens": 10, "output_tokens": 2}},
+            },
+        }
+        assert_measurement_only(snapshot, where="test")
+
+        with get_session() as session:
+            record_generation_cost(session, job_id="j-model", strategy_id="s-model", measurement=snapshot)
+            session.commit()
+            payload = generation_cost_for_strategy(session, "s-model")
+
+        assert payload is not None, "a vendor's model name must never cost us the measurement"
+        assert payload["measurement"]["llm"]["by_model"][model_id]["calls"] == 3
+
+    def test_the_exemption_is_one_level_deep_counters_under_a_model_id_are_still_screened(self):
+        """The model id is data; the counters hanging off it are ours, and a
+        pricing-shaped one there still raises."""
+        snapshot = {
+            **_SNAPSHOT,
+            "llm": {**_SNAPSHOT["llm"], "by_model": {"price-aware-model-x": {"calls": 1, "cost_usd": 0.14}}},
+        }
+        with pytest.raises(PricingLeakError):
+            assert_measurement_only(snapshot, where="test")
+
+    @pytest.mark.parametrize(
+        ("payload", "why"),
+        [
+            ({"stages": {"usd_conversion": {"wall_seconds": 1.0}}}, "stage name"),
+            ({"writes": {"settlement_fee": 1}}, "write-counter name"),
+            ({"meta": {"unit_price": 1}}, "meta key"),
+            ({"llm": {"by_model_pricing": {"m": {}}}}, "a near-miss key that is NOT the exempt path"),
+            ({"by_model": {"price-aware-model-x": {}}}, "by_model at the WRONG path is not exempt"),
+        ],
+    )
+    def test_authored_labels_are_still_rejected(self, payload, why):
+        """The exemption must not have opened a hole: every caller-authored label
+        is screened exactly as before, including a key that merely resembles the
+        exempt path and a ``by_model`` that is not under ``llm``."""
+        with pytest.raises(PricingLeakError):
+            assert_measurement_only(payload, where="test")
 
 
 # ── G3: why the persistence write is not tallied ──────────────────────────

--- a/backend/tests/test_generation_cost_persistence.py
+++ b/backend/tests/test_generation_cost_persistence.py
@@ -1,0 +1,553 @@
+"""Durable per-generation cost (#1326) — the measurement has to outlive the job.
+
+#1314 built the meter; its snapshot lived only on the Redis job record, whose
+``JOB_TTL`` is 3600s. An hour after a generation finished, the only record of
+what it consumed was gone and no surface ever showed it. This file covers the
+persistence and the read surfaces that close that gap, and each guard is
+exercised with the input that SHOULD fail it:
+
+* **G1 — unknown is never zero.** A strategy nothing measured reads ``None``, a
+  record whose measurement will not decode reads ``None``, and neither ever
+  becomes an empty measurement or a zero-token record. The other half of the
+  same rule is checked too: a genuinely measured zero survives as zero.
+* **G2 — the measurement and the price stay in separate columns.** The obvious
+  future shortcut is to merge the quote into the snapshot; that raises
+  :class:`PricingLeakError` at the write boundary rather than shipping a priced
+  ``cost_v1`` record. Demonstrated with the exact merged payload.
+* **G3 — the persistence write is deliberately untallied**, because
+  ``record_write("generation_costs")`` is itself a pricing-shaped label and the
+  meter refuses it. Demonstrated, so the omission reads as the design it is.
+* **G4 — instrumentation cannot fail a generation.** A DB that refuses the write
+  produces a log line, not a failed run.
+
+Hermetic: tmp-file SQLite via ``redirect_to_tmp_sqlite`` (the ``#1243``
+precedent), ``fakeredis`` for the job store (the ``test_generation_cost_meter``
+precedent), the fixture generation path (``GENERATION_PIPELINE_FIXTURE=1``). No
+Postgres, no Redis, no LLM, no network.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import fakeredis
+import pytest
+from archimedes.db import get_session
+from archimedes.models.generation_cost import (
+    GenerationCostRecord,
+    generation_cost_for_strategy,
+    generation_costs_for_strategies,
+    record_generation_cost,
+)
+from archimedes.services.cost_meter import CostMeter, PricingLeakError, assert_measurement_only
+from archimedes.services.job_queue import KEY_PREFIX, JobStore
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+_SNAPSHOT = {
+    "schema": "cost_v1",
+    "job_id": "job-1326",
+    "wall_seconds": 47.9312,
+    "cpu_seconds": 31.4407,
+    "cpu_attribution": "process_wide_delta",
+    "peak_rss_bytes": 812939264,
+    "rss_attribution": "process_high_water",
+    "llm": {
+        "calls": 17,
+        "calls_missing_usage": 0,
+        "usage_complete": True,
+        "input_tokens": 41234,
+        "output_tokens": 5120,
+        "total_tokens": 46354,
+        "by_model": {"amazon.nova-micro-v1:0": {"calls": 17, "input_tokens": 41234, "output_tokens": 5120}},
+    },
+    "stages": {
+        "candidate_generation": {"wall_seconds": 43.1, "cpu_seconds": 24.9, "runs": 1},
+        "debate_backtest": {"wall_seconds": 21.55, "cpu_seconds": 20.9, "runs": 1},
+    },
+    "writes": {"strategy_store": 1, "strategy_passports": 2},
+    "meta": {"pipeline": "debate", "outcome": "done", "candidates_passing_rigor": 0},
+}
+
+_QUOTE = {
+    "payment_required": True,
+    "pricing_model": "flat_v1",
+    "price": "$0.150000",
+    "asset": "USDC",
+    "chain": "eip155:5042002",
+    "recipient": "0xRecipient",
+    "dry_run": True,
+    "how": "POST /api/generate/start ...",
+}
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+# ── G2: the measurement and the price never share a namespace ─────────────
+
+
+class TestMeasurementOnlyGuard:
+    """``assert_measurement_only`` is the persistence-boundary form of the
+    meter's write-time label screen: by the time a snapshot reaches storage the
+    labels that built it are gone, and the document is the only thing left to
+    inspect."""
+
+    def test_a_real_snapshot_passes(self):
+        assert_measurement_only(_SNAPSHOT, where="test")
+        assert_measurement_only(CostMeter("job-x").snapshot(), where="test")
+
+    @pytest.mark.parametrize(
+        ("payload", "why"),
+        [
+            ({"cost_usd": 0.14}, "top-level pricing key"),
+            ({"llm": {"price_per_1k": 0.0002}}, "nested pricing key"),
+            ({"stages": {"debate": {"bedrock_spend": 1}}}, "pricing key two levels down"),
+            ({"meta": [{"invoice_id": "x"}]}, "pricing key inside a list"),
+            ({"writes": {"settlement_fee": 1}}, "pricing-shaped write counter name"),
+        ],
+    )
+    def test_a_pricing_shaped_key_at_any_depth_is_refused(self, payload, why):
+        with pytest.raises(PricingLeakError):
+            assert_measurement_only(payload, where="test")
+
+    def test_merging_the_quote_into_the_measurement_is_refused_at_the_write(self):
+        """The input that SHOULD fail the guard: the obvious future shortcut of
+        folding the recorded quote into the snapshot instead of keeping it in its
+        own column. It carries ``pricing_model`` and ``price``, so it raises."""
+        merged = {**_SNAPSHOT, "quote": _QUOTE}
+        with pytest.raises(PricingLeakError):
+            assert_measurement_only(merged, where="generation_costs.measurement_json")
+
+        with get_session() as session:
+            with pytest.raises(PricingLeakError):
+                record_generation_cost(session, job_id="j", strategy_id="s", measurement=merged)
+            # Nothing landed — the refusal is at the boundary, not after it.
+            assert session.query(GenerationCostRecord).count() == 0
+
+    def test_the_quote_itself_is_NOT_screened_it_is_a_price_by_definition(self):
+        """The quote is the recorded price; screening it would make the column
+        unwritable. It is kept apart, not sanitized."""
+        with get_session() as session:
+            record_generation_cost(session, job_id="j-q", strategy_id="s-q", measurement=_SNAPSHOT, quote=_QUOTE)
+            session.commit()
+            payload = generation_cost_for_strategy(session, "s-q")
+        assert payload["quote"]["price"] == "$0.150000"
+        assert payload["quote"]["pricing_model"] == "flat_v1"
+        # …and the measurement half is still money-free.
+        assert_measurement_only(payload["measurement"], where="test")
+
+
+# ── G3: why the persistence write is not tallied ──────────────────────────
+
+
+def test_record_write_generation_costs_is_refused_by_the_meter():
+    """The pipeline does NOT tally its own ``generation_costs`` write, and this
+    is why: "cost" is pricing vocabulary inside a measurement record, so the
+    meter refuses the label. (The snapshot is also already sealed by then — a
+    tally cannot appear inside the document it counts.)"""
+    meter = CostMeter("job-g3")
+    with pytest.raises(PricingLeakError):
+        meter.record_write("generation_costs")
+    assert meter.snapshot()["writes"] == {}
+
+
+def test_the_pipeline_does_not_tally_the_durable_write():
+    """Source-invariant companion to the test above: if someone "fixes" the
+    missing tally, the meter raises inside a ``finally`` on every generation.
+
+    AST, not substring: the docstring beside the write *explains* the omission
+    by quoting the forbidden call, and a grep cannot tell prose from code —
+    exactly the confusion the house slowapi-AST checks exist to avoid. Only a
+    real ``record_write("generation_costs")`` **call** fails this.
+    """
+    import ast
+    from pathlib import Path
+
+    tree = ast.parse(Path("backend/archimedes/agents/generation_pipeline.py").read_text())
+    offenders = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "attr", getattr(node.func, "id", None)) == "record_write"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == "generation_costs"
+    ]
+    assert offenders == [], f"the durable write must not be tallied through the meter (lines {offenders})"
+
+
+# ── The model: upsert, refusals, round-trip ───────────────────────────────
+
+
+class TestRecordGenerationCost:
+    def test_round_trips_the_measurement_and_the_quote(self):
+        with get_session() as session:
+            record_generation_cost(
+                session, job_id="job-1326", strategy_id="strat-a", measurement=_SNAPSHOT, quote=_QUOTE
+            )
+            session.commit()
+            payload = generation_cost_for_strategy(session, "strat-a")
+
+        assert payload["schema"] == "cost_v1"
+        assert payload["job_id"] == "job-1326"
+        assert payload["recorded_at"]
+        assert payload["measurement"]["llm"]["total_tokens"] == 46354
+        assert payload["measurement"]["stages"]["debate_backtest"]["wall_seconds"] == 21.55
+        assert payload["quote"]["price"] == "$0.150000"
+
+    def test_is_idempotent_on_the_job_strategy_pair(self):
+        with get_session() as session:
+            record_generation_cost(session, job_id="j", strategy_id="s", measurement=_SNAPSHOT)
+            record_generation_cost(
+                session,
+                job_id="j",
+                strategy_id="s",
+                measurement={**_SNAPSHOT, "wall_seconds": 99.0},
+                quote=_QUOTE,
+            )
+            session.commit()
+            assert session.query(GenerationCostRecord).count() == 1
+            payload = generation_cost_for_strategy(session, "s")
+        assert payload["measurement"]["wall_seconds"] == 99.0
+        assert payload["quote"] is not None
+
+    def test_a_missing_key_is_refused_rather_than_written_unreadable(self):
+        with get_session() as session:
+            with pytest.raises(ValueError, match="job_id"):
+                record_generation_cost(session, job_id="", strategy_id="s", measurement=_SNAPSHOT)
+            with pytest.raises(ValueError, match="strategy_id"):
+                record_generation_cost(session, job_id="j", strategy_id="", measurement=_SNAPSHOT)
+            with pytest.raises(ValueError, match="measurement mapping"):
+                record_generation_cost(session, job_id="j", strategy_id="s", measurement=None)
+            assert session.query(GenerationCostRecord).count() == 0
+
+    def test_a_schemaless_snapshot_is_labelled_unknown_not_assumed_to_be_cost_v1(self):
+        with get_session() as session:
+            record_generation_cost(session, job_id="j", strategy_id="s", measurement={"wall_seconds": 1.0})
+            session.commit()
+            payload = generation_cost_for_strategy(session, "s")
+        assert payload["schema"] == "unknown"
+
+    def test_a_missing_quote_is_null_not_a_zero_price(self):
+        with get_session() as session:
+            record_generation_cost(session, job_id="j", strategy_id="s", measurement=_SNAPSHOT, quote=None)
+            session.commit()
+            payload = generation_cost_for_strategy(session, "s")
+        assert payload["quote"] is None
+        assert "price" not in json.dumps(payload["measurement"])
+
+
+# ── G1: unknown is never zero at the read boundary ────────────────────────
+
+
+class TestUnknownIsNeverZero:
+    def test_a_strategy_with_no_record_reads_none(self):
+        with get_session() as session:
+            assert generation_cost_for_strategy(session, "never-generated") is None
+            assert generation_cost_for_strategy(session, "") is None
+            assert generation_costs_for_strategies(session, ["never-generated"]) == {}
+            assert generation_costs_for_strategies(session, []) == {}
+
+    def test_a_corrupt_measurement_reads_as_absent_not_as_an_empty_measurement(self):
+        """The input that SHOULD fail the guard: a row whose measurement column
+        is not JSON. Returning ``{}`` would render a cost card full of zeros for
+        a run we cannot actually read."""
+        with get_session() as session:
+            record_generation_cost(session, job_id="j", strategy_id="s", measurement=_SNAPSHOT)
+            session.query(GenerationCostRecord).filter_by(strategy_id="s").first().measurement_json = "{not json"
+            session.commit()
+
+            assert generation_cost_for_strategy(session, "s") is None
+            assert generation_costs_for_strategies(session, ["s"]) == {}
+
+    def test_a_corrupt_quote_degrades_alone_the_measurement_still_stands(self):
+        with get_session() as session:
+            record_generation_cost(session, job_id="j", strategy_id="s", measurement=_SNAPSHOT, quote=_QUOTE)
+            session.query(GenerationCostRecord).filter_by(strategy_id="s").first().quote_json = "{not json"
+            session.commit()
+            payload = generation_cost_for_strategy(session, "s")
+
+        assert payload is not None
+        assert payload["quote"] is None
+        assert payload["measurement"]["llm"]["total_tokens"] == 46354
+
+    def test_a_measured_zero_survives_as_zero(self):
+        """The other half of the same rule. The fixture path makes no LLM calls
+        and honestly reports zeros; those must round-trip as zeros, or "unknown"
+        and "measured zero" have collapsed into one another."""
+        zeroed = {
+            **_SNAPSHOT,
+            "llm": {
+                "calls": 0,
+                "calls_missing_usage": 0,
+                "usage_complete": True,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "by_model": {},
+            },
+        }
+        with get_session() as session:
+            record_generation_cost(session, job_id="j0", strategy_id="s0", measurement=zeroed)
+            session.commit()
+            payload = generation_cost_for_strategy(session, "s0")
+        assert payload["measurement"]["llm"]["total_tokens"] == 0
+        assert payload["measurement"]["llm"]["usage_complete"] is True
+
+    def test_the_batch_reader_returns_the_newest_row_per_strategy(self):
+        with get_session() as session:
+            record_generation_cost(session, job_id="job-old", strategy_id="s", measurement=_SNAPSHOT)
+            record_generation_cost(
+                session, job_id="job-new", strategy_id="s", measurement={**_SNAPSHOT, "wall_seconds": 5.0}
+            )
+            session.commit()
+            batch = generation_costs_for_strategies(session, ["s", "missing"])
+
+        assert set(batch) == {"s"}
+        assert batch["s"]["job_id"] == "job-new"
+        assert batch["s"]["measurement"]["wall_seconds"] == 5.0
+
+
+# ── The pipeline writes it, on the real production path ───────────────────
+
+
+class _FakeStore:
+    """Mirrors ``tests/services/test_generation_pipeline._FakeStore``."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.status: list[tuple] = []
+
+    async def push_event(self, job_id, payload):
+        self.events.append(payload)
+        return len(self.events)
+
+    async def update_status(self, job_id, status, *, result=None, error=""):
+        self.status.append((status, result, error))
+
+    async def merge_result(self, job_id, patch):
+        return True
+
+
+@pytest.fixture
+def _fixture_path(monkeypatch):
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+
+@pytest.mark.usefixtures("_fixture_path")
+class TestPipelinePersistsDurably:
+    async def test_a_completed_generation_writes_the_durable_row(self):
+        from archimedes.agents.generation_pipeline import GenerateBrief, run_generation
+
+        with patch(
+            "archimedes.agents.generation_pipeline._persist_candidate",
+            new=AsyncMock(return_value=("strat_cost_001", "0xabc")),
+        ):
+            await run_generation(
+                job_id="job_cost_e2e",
+                brief=GenerateBrief(intent="balanced macro", risk_appetite="moderate"),
+                n_candidates=1,
+                store=_FakeStore(),
+            )
+
+        with get_session() as session:
+            payload = generation_cost_for_strategy(session, "strat_cost_001")
+
+        assert payload is not None, "a completed generation must leave a durable measurement"
+        assert payload["job_id"] == "job_cost_e2e"
+        assert payload["schema"] == "cost_v1"
+        assert payload["measurement"]["meta"]["outcome"] == "done"
+        assert "persist_winner" in payload["measurement"]["stages"]
+        # This run's candidates FAILED the gate, and it still carries a full
+        # measurement — the issue's "rigor-failed terminal path where a strategy
+        # row exists", which is also the common case and costs the same compute.
+        assert payload["measurement"]["meta"]["candidates_passing_rigor"] == 0
+        # The fixture runner makes no LLM calls, so zero tokens here is a real
+        # measurement, not a missing one — and it reports itself complete.
+        assert payload["measurement"]["llm"]["total_tokens"] == 0
+        assert payload["measurement"]["llm"]["usage_complete"] is True
+        # The quote in force at generation time is recorded beside it.
+        assert payload["quote"] is not None
+        assert payload["quote"]["pricing_model"] == "flat_v1"
+
+    async def test_the_record_survives_the_job_records_expiry(self):
+        """The acceptance criterion, exercised: delete the Redis job hash — the
+        TTL's end state — and the measurement is still readable."""
+        from archimedes.agents.generation_pipeline import GenerateBrief, run_generation
+
+        store = JobStore(url="redis://unused")
+        store._redis = fakeredis.FakeAsyncRedis(decode_responses=True)
+        job_id = await store.enqueue(job_type="generate", payload={"brief": {"intent": "x"}})
+
+        with patch(
+            "archimedes.agents.generation_pipeline._persist_candidate",
+            new=AsyncMock(return_value=("strat_ttl_001", "0xabc")),
+        ):
+            await run_generation(
+                job_id=job_id,
+                brief=GenerateBrief(intent="balanced macro", risk_appetite="moderate"),
+                n_candidates=1,
+                store=store,
+            )
+
+        # Before: both copies exist.
+        job = await store.get(job_id)
+        assert job["result"]["cost"]["schema"] == "cost_v1"
+
+        # Simulate JOB_TTL elapsing.
+        await store._redis.delete(f"{KEY_PREFIX}{job_id}")
+        assert await store.get(job_id) is None
+
+        with get_session() as session:
+            payload = generation_cost_for_strategy(session, "strat_ttl_001")
+        assert payload is not None, "the durable record must not depend on the job hash"
+        assert payload["measurement"]["llm"]["calls"] == job["result"]["cost"]["llm"]["calls"], (
+            "the durable row and the job record must carry the SAME snapshot, not two readings"
+        )
+
+    async def test_a_run_that_produced_no_strategy_writes_no_durable_row(self):
+        """The issue's own boundary: persist "where a strategy row exists". An
+        invalid brief bails before any persist, so there is nothing to key a
+        record to — and inventing a strategy id to hang it on would be worse
+        than the gap."""
+        from archimedes.agents import generation_pipeline
+
+        with (
+            patch.object(generation_pipeline, "_llm_available", return_value=True),
+            patch.object(
+                generation_pipeline,
+                "_validate_brief",
+                new=AsyncMock(return_value={"is_valid": False, "reason": "too vague", "hint": "name an asset"}),
+            ),
+        ):
+            await generation_pipeline.run_generation(
+                job_id="job_no_strategy",
+                brief=generation_pipeline.GenerateBrief(intent="uh"),
+                store=_FakeStore(),
+            )
+
+        with get_session() as session:
+            assert session.query(GenerationCostRecord).count() == 0
+
+    async def test_a_persist_failure_does_not_fail_the_generation(self):
+        """G4. The input that SHOULD break a naive implementation: a write that
+        raises inside the ``finally``. Instrumentation is not allowed to change
+        the outcome of a generation."""
+        from archimedes.agents.generation_pipeline import GenerateBrief, run_generation
+
+        store = _FakeStore()
+        with (
+            patch(
+                "archimedes.agents.generation_pipeline._persist_candidate",
+                new=AsyncMock(return_value=("strat_boom", "0xabc")),
+            ),
+            patch(
+                "archimedes.models.generation_cost.record_generation_cost",
+                side_effect=RuntimeError("database is on fire"),
+            ),
+        ):
+            await run_generation(
+                job_id="job_boom",
+                brief=GenerateBrief(intent="balanced macro", risk_appetite="moderate"),
+                n_candidates=1,
+                store=store,
+            )
+
+        assert [s[0] for s in store.status] == ["running", "done"], (
+            "a failed cost persist must not change the job's terminal state"
+        )
+        with get_session() as session:
+            assert session.query(GenerationCostRecord).count() == 0
+
+
+class TestQuoteInForce:
+    def test_reads_the_quote_seam_verbatim(self):
+        from archimedes.agents.generation_pipeline import _quote_in_force
+        from archimedes.services.generation_payment import quote
+
+        assert _quote_in_force() == quote()
+
+    def test_an_unreadable_quote_seam_records_unknown_not_a_free_generation(self):
+        from archimedes.agents import generation_pipeline
+        from archimedes.services import generation_payment
+
+        with patch.object(generation_payment, "quote", side_effect=RuntimeError("seam down")):
+            assert generation_pipeline._quote_in_force() is None
+
+    def test_the_quote_seam_is_still_flat_v1_and_untouched(self):
+        from archimedes.services.generation_payment import quote
+
+        assert quote()["pricing_model"] == "flat_v1"
+
+
+# ── The read surfaces ─────────────────────────────────────────────────────
+
+
+def _make_passport(session, strategy_id: str):
+    from archimedes.models.strategy_passport_record import PassportPaperRef, StrategyPassportRecord
+
+    session.add(
+        StrategyPassportRecord(
+            id=strategy_id,
+            generation_method="debate",
+            methodology_summary="For brief 'momentum': a test methodology",
+            asset_universe="[]",
+            position_sizing="equal_weight",
+            rebalance_frequency="weekly",
+            status="candidate",
+            regime_tag="regime_neutral",
+            passes_rigor_gate=False,
+        )
+    )
+    session.add(PassportPaperRef(passport_id=strategy_id, arxiv_id="2301.00001", title="A Paper", authors="[]"))
+    session.flush()
+
+
+class TestPassportReadSurface:
+    def test_the_passport_response_carries_the_durable_record(self):
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        with get_session() as session:
+            _make_passport(session, "pp-with-cost")
+            record_generation_cost(
+                session, job_id="job-pp", strategy_id="pp-with-cost", measurement=_SNAPSHOT, quote=_QUOTE
+            )
+            session.commit()
+            resp = _passport_to_strategy_response(get_passport(session, "pp-with-cost"), session=session)
+
+        assert resp.generation_cost["job_id"] == "job-pp"
+        assert resp.generation_cost["measurement"]["llm"]["total_tokens"] == 46354
+        assert resp.generation_cost["quote"]["price"] == "$0.150000"
+
+    def test_a_strategy_nothing_measured_reports_none_not_a_zeroed_record(self):
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+        from archimedes.services.passport_loader import get_passport
+
+        with get_session() as session:
+            _make_passport(session, "pp-no-cost")
+            session.commit()
+            resp = _passport_to_strategy_response(get_passport(session, "pp-no-cost"), session=session)
+
+        assert resp.generation_cost is None
+
+    def test_a_curated_strategy_reports_none(self):
+        """Curated strategies were never generated by a metered run, so there is
+        nothing to measure and nothing is claimed."""
+        from archimedes.api.schemas import StrategyResponse
+
+        assert (
+            StrategyResponse(
+                id="x",
+                methodology_summary="",
+                asset_universe=[],
+                position_sizing="equal_weight",
+                rebalance_frequency="weekly",
+                status="live",
+            ).generation_cost
+            is None
+        )

--- a/backend/tests/test_generation_cost_persistence.py
+++ b/backend/tests/test_generation_cost_persistence.py
@@ -313,6 +313,35 @@ class TestUnknownIsNeverZero:
         assert payload["measurement"]["llm"]["total_tokens"] == 0
         assert payload["measurement"]["llm"]["usage_complete"] is True
 
+    def test_the_batch_reader_does_not_fall_back_to_an_older_row_when_the_NEWEST_is_corrupt(self):
+        """The input that SHOULD fail the guard: two rows for one strategy where
+        only the NEWEST will not decode.
+
+        The ASC + overwrite form silently kept the older row, so the batch reader
+        served a superseded measurement while the single-strategy reader served
+        ``None`` for the same strategy — two surfaces disagreeing about what was
+        measured, with the stale one looking perfectly healthy. Both readers must
+        answer "the newest is unreadable, so we have nothing"."""
+        with get_session() as session:
+            record_generation_cost(
+                session, job_id="job-old", strategy_id="s", measurement={**_SNAPSHOT, "wall_seconds": 1.0}
+            )
+            record_generation_cost(
+                session, job_id="job-new", strategy_id="s", measurement={**_SNAPSHOT, "wall_seconds": 2.0}
+            )
+            session.commit()
+
+            newest = session.query(GenerationCostRecord).filter_by(strategy_id="s", job_id="job-new").first()
+            newest.measurement_json = "{not json"
+            session.commit()
+
+            batch = generation_costs_for_strategies(session, ["s"])
+            single = generation_cost_for_strategy(session, "s")
+
+        assert single is None, "the single reader already answers honestly"
+        assert "s" not in batch, "the batch reader must not substitute the older, superseded row"
+        assert batch == {}
+
     def test_the_batch_reader_returns_the_newest_row_per_strategy(self):
         with get_session() as session:
             record_generation_cost(session, job_id="job-old", strategy_id="s", measurement=_SNAPSHOT)

--- a/backend/tests/test_generation_cost_persistence.py
+++ b/backend/tests/test_generation_cost_persistence.py
@@ -215,6 +215,21 @@ class TestRecordGenerationCost:
         assert payload["measurement"]["wall_seconds"] == 99.0
         assert payload["quote"] is not None
 
+    def test_a_value_json_cannot_encode_is_stringified_like_the_job_record_does(self):
+        """The two stores must not disagree about whether a snapshot is
+        writable. ``JobStore`` encodes with ``default=str``; if this one did not,
+        a stray non-JSON meta value would land on the expiring copy and be lost
+        from the durable one — the failure mode hardest to notice, because it
+        looks fine for an hour."""
+        from datetime import datetime as _dt
+
+        exotic = {**_SNAPSHOT, "meta": {"outcome": "done", "stamped_at": _dt(2026, 8, 20, 9, 16)}}
+        with get_session() as session:
+            record_generation_cost(session, job_id="j", strategy_id="s", measurement=exotic)
+            session.commit()
+            payload = generation_cost_for_strategy(session, "s")
+        assert payload["measurement"]["meta"]["stamped_at"] == "2026-08-20 09:16:00"
+
     def test_a_missing_key_is_refused_rather_than_written_unreadable(self):
         with get_session() as session:
             with pytest.raises(ValueError, match="job_id"):

--- a/docs/generation-cost-instrumentation.md
+++ b/docs/generation-cost-instrumentation.md
@@ -7,7 +7,8 @@
 Every generation now carries a measurement record: how many tokens the debate
 society actually consumed, how long each pipeline phase took in wall and CPU
 seconds, the process peak RSS, and how many rows the run wrote. The record is
-persisted on the job and readable over the API.
+persisted on the job, **written durably to the database keyed to the strategy the
+run produced**, and readable over the API and on the strategy passport.
 
 This exists because the only figure ever quoted for a generation was a Bedrock
 inference estimate — the language-model term alone, excluding the walk-forward
@@ -29,9 +30,11 @@ a guess.
 | The meter — accumulation, guards, snapshot shape | [`backend/archimedes/services/cost_meter.py`](../backend/archimedes/services/cost_meter.py) |
 | Token capture at the provider boundary | [`backend/archimedes/services/llm_backend.py`](../backend/archimedes/services/llm_backend.py) (every `complete()`) — plus an inert call in [`backend/archimedes/agents/portfolio_agent.py`](../backend/archimedes/agents/portfolio_agent.py), see "What is not measured" below |
 | Stage timing + write tallies | [`backend/archimedes/agents/generation_pipeline.py`](../backend/archimedes/agents/generation_pipeline.py), [`backend/archimedes/agents/debate_engine.py`](../backend/archimedes/agents/debate_engine.py) |
-| Persistence onto the job | `JobStore.merge_result` in [`backend/archimedes/services/job_queue.py`](../backend/archimedes/services/job_queue.py) |
-| Read surfaces | `GET /api/generate/jobs/{job_id}/cost`, and the `cost` field on `GET /api/generate/jobs` |
-| Tests | [`backend/tests/test_generation_cost_meter.py`](../backend/tests/test_generation_cost_meter.py) |
+| Persistence onto the job (expires with `JOB_TTL`) | `JobStore.merge_result` in [`backend/archimedes/services/job_queue.py`](../backend/archimedes/services/job_queue.py) |
+| Durable persistence (`generation_costs`) | [`backend/archimedes/models/generation_cost.py`](../backend/archimedes/models/generation_cost.py) + migration `e2b7f4c81d93`, written from `run_generation`'s `finally` |
+| Read surfaces | `GET /api/generate/jobs/{job_id}/cost`, the `cost` field on `GET /api/generate/jobs`, `generation_cost` on `GET /api/strategies/{id}` and `GET /api/strategies/generated` |
+| UI | passport card + library column via [`ui/src/generationCost.js`](../ui/src/generationCost.js) |
+| Tests | [`backend/tests/test_generation_cost_meter.py`](../backend/tests/test_generation_cost_meter.py), [`backend/tests/test_generation_cost_persistence.py`](../backend/tests/test_generation_cost_persistence.py), [`ui/test/generation-cost.test.js`](../ui/test/generation-cost.test.js) |
 
 The meter is bound to a `contextvars` context for the duration of one job, so
 the LLM boundary records usage without threading a parameter through the debate
@@ -133,6 +136,71 @@ the snapshots in this document do not include anything from it.
   snapshot is written on the error and cancelled paths too, so the rejected path
   is measurable rather than assumed to be cheaper.
 
+## Where it is stored, and for how long (#1326)
+
+The snapshot is written **twice, from the same object**, in `run_generation`'s
+`finally` — so the two copies can never be two different readings:
+
+1. **Onto the Redis job record** via `merge_result`. Expires with `JOB_TTL`
+   (3600s). This is what `GET /api/generate/jobs/{job_id}/cost` serves.
+2. **Into the `generation_costs` table**, keyed to the strategy the run
+   produced. This is what the passport card and the library column read, an
+   hour or a year later.
+
+One row per `(job_id, strategy_id)` pair, with two payload columns:
+
+| Column | What it holds |
+|---|---|
+| `measurement_json` | The literal `cost_v1` snapshot. Screened by `cost_meter.assert_measurement_only` on the way in — a pricing-shaped key at any depth raises `PricingLeakError` rather than landing in the column. |
+| `quote_json` | The literal `generation_payment.quote()` payload in force when the job **started**. NULL when the seam could not be read, which means "not recorded", never "$0.00". |
+
+**Two columns is the design, not normalization.** Quote-vs-measured has to be a
+pairing of two independently recorded facts. Merging the quote into the snapshot
+— the obvious shortcut — would produce a priced `cost_v1` record, and the screen
+above exists to make that raise instead.
+
+**The measurement is the JOB's.** Generation is K=1 (one `strategy_store` row per
+job), so the pairing is one-to-one today. If a job ever persists more than one
+strategy again, each gets a row carrying the *same* job-level measurement: read a
+row as "the run that produced this strategy consumed this", never as "this
+strategy's private share", and never sum across rows.
+
+**Nothing is written when no strategy row exists.** A run that bails before
+persistence — an invalid brief, an early crash — leaves the job record as the
+only copy. There is nothing to key a durable record to, and inventing an id to
+hang one on would be worse than the gap.
+
+**No backfill, and none is possible.** Every generation before the meter was
+never measured. Those strategies render as *not measured* on the passport and as
+an em-dash in the library. That is the honest state, and manufacturing a figure
+for them is precisely the failure this instrumentation exists to end.
+
+### Reading the surfaced record honestly
+
+`GET /api/strategies/{id}` serves `generation_cost` as
+`{schema, job_id, recorded_at, measurement, quote}`, or `null`. The UI's rules
+(all in `ui/src/generationCost.js`, all covered by `ui/test/generation-cost.test.js`):
+
+* **`null` renders as "not measured", never as zero.** A count that arrives as a
+  string, a boolean, `NaN`, `Infinity` or a negative is *not measured* either —
+  the same refusal `_coerce_count` makes server-side.
+* **A genuinely measured zero stays zero.** The fixture path makes no LLM calls
+  and honestly reports `total_tokens: 0`; that must remain distinguishable from
+  "we don't know".
+* **`usage_complete: false` renders the totals with a `≥`.** They are a floor,
+  not a total, and the card says how many calls were unreadable. An *absent*
+  `usage_complete` fails closed to the same treatment — completeness is claimed
+  only when the record literally says `true`.
+* **The dominant stage excludes `candidate_generation`.** It is the umbrella that
+  contains `corpus_load` / `debate_propose` / `debate_transcript` /
+  `debate_backtest`, so a plain maximum names it every time and says nothing.
+* **The library column shows total tokens.** Design call: it is the term that
+  scales with the model and the one #1217 exists to pin down, while wall time is
+  dominated by backtests and moves with whatever else the worker is doing. Wall
+  time and the dominant stage ride in the cell's tooltip.
+* **No `$`-conversion anywhere client-side.** The only money on the card is the
+  price string the server recorded from the quote seam.
+
 ## Guarantees the code enforces
 
 1. **A missing measurement is never a zero.** A provider response with no usable
@@ -159,9 +227,16 @@ the snapshots in this document do not include anything from it.
    otherwise a bare `HSET` would materialise a TTL-less phantom hash that then
    lists forever as a statusless job.
 5. **Instrumentation cannot fail a generation.** `record_llm_call` swallows
-   unexpected errors, and the snapshot persist is suppressed on failure. A
-   deliberate pricing-label violation is the one exception: it raises, because it
-   is a code bug with a fixed literal label, not a data-dependent condition.
+   unexpected errors, and both snapshot persists — the job record and the durable
+   row — are suppressed-and-logged on failure. A deliberate pricing-label
+   violation is the one exception: it raises, because it is a code bug with a
+   fixed literal label, not a data-dependent condition.
+6. **The durable write is deliberately untallied.** The pipeline does not call
+   `cost_meter.record_write` for its own `generation_costs` row. The snapshot is
+   already sealed by then — a tally cannot appear inside the document it counts —
+   and the label is pricing vocabulary inside a measurement record, so the meter
+   would refuse it anyway. The table's *name* is fine; a counter label inside a
+   `cost_v1` snapshot is not.
 
 ## Measurement procedure
 

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -7,6 +7,7 @@ import { useRigorStrictness, BADGE_LEVEL } from '../hooks/useRigorStrictness'
 import useDialogFocus from '../hooks/useDialogFocus'
 
 import { apiGet, apiPost, apiDelete } from '../api'
+import { compactCostCell } from '../generationCost.js'
 
 // A compact "deployable at your level" chip for a library row, driven by the
 // strategy's min_passing_level (from the live gate) and the user's strictness.
@@ -157,6 +158,9 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
   const sharpeCI = s.sharpe_ci_95 != null ? s.sharpe_ci_95 : null
   const driftFlag = s.drift_detected === true
   const detailId = `lib-detail-${s.id}`
+  // Absence is the point: a strategy nothing measured gets an em-dash and a
+  // tooltip that says so, never a zero (#1326).
+  const genCost = compactCostCell(s.generation_cost)
 
   useEffect(() => {
     if (isHighlighted && rowRef.current) {
@@ -259,10 +263,15 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
         </td>
         <td className="mono" style={{ textAlign: 'right', color: 'var(--positive)' }}>{fmtUsd(endValue)}</td>
         <td className="caption" style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>{years != null ? `${years.toFixed(1)} yrs` : '—'}</td>
+        <td
+          className={genCost.measured ? 'mono' : 'caption'}
+          style={{ textAlign: 'right', whiteSpace: 'nowrap', color: genCost.measured ? undefined : 'var(--text-4)' }}
+          title={genCost.title}
+        >{genCost.label}</td>
       </tr>
       {open && (
         <tr className="lib-row-detail" id={detailId}>
-          <td colSpan={8} style={{ padding: '12px 18px', background: 'var(--glass)' }}>
+          <td colSpan={9} style={{ padding: '12px 18px', background: 'var(--glass)' }}>
             <StrategyDetailContent
               s={s}
               onOpenRigorExplainer={onOpenRigorExplainer}
@@ -440,6 +449,7 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
   const startStr = (s.backtest_start || '').slice(0, 10)
   const endStr = (s.backtest_end || '').slice(0, 10)
   const driftFlag = s.drift_detected === true
+  const genCost = compactCostCell(s.generation_cost)
 
   useEffect(() => {
     if (isHighlighted && cardRef.current) {
@@ -488,6 +498,7 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
         <div><div className="caption">Sharpe</div><div className="mono">{fmt(s.sharpe_ratio)}</div></div>
         <div><div className="caption">CAGR</div><div className="mono positive">{fmtPct(s.cagr)}</div></div>
         <div><div className="caption">Max DD</div><div className="mono negative">{s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}</div></div>
+        <div title={genCost.title}><div className="caption">Gen tokens</div><div className={genCost.measured ? 'mono' : 'caption'}>{genCost.label}</div></div>
       </div>
       {open && (
         <div className="lib-card-detail" onClick={(e) => e.stopPropagation()}>
@@ -528,6 +539,15 @@ function StrategyTable({ strategies, emptyState, highlightStrategyId, onOpenRigo
               <th style={{ padding: '10px 14px', textAlign: 'right' }}>Max DD</th>
               <th style={{ padding: '10px 14px', textAlign: 'right' }}>$1k →</th>
               <th style={{ padding: '10px 14px', textAlign: 'right' }}>Period</th>
+              {/* Generation cost (#1326) — total tokens is the design call: it's
+                  the term that scales with the model and the one #1217 exists to
+                  pin down, while wall time is dominated by backtests and moves
+                  with whatever else the worker is doing. Wall time + dominant
+                  stage ride in the cell's tooltip. */}
+              <th
+                style={{ padding: '10px 14px', textAlign: 'right' }}
+                title="Tokens consumed by the generation run that produced this strategy. A raw measurement — never converted to dollars."
+              >Gen tokens</th>
             </tr>
           </thead>
           <tbody>
@@ -617,6 +637,10 @@ function coerceGenerated(row) {
     dsr_p_value: verdict?.dsr_p_value ?? null,
     sharpe_ci_95: null,
     drift_detected: null,
+    // Durable generation-cost record (#1326) served by /api/strategies/generated.
+    // Absent for anything generated before the meter — passed through as null so
+    // the cost column renders "not measured" rather than a fabricated zero.
+    generation_cost: row.generation_cost ?? null,
   }
 }
 

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -4,6 +4,18 @@ import { ROADMAP_SURFACES_ENABLED } from "../featureFlags.js";
 import RigorStrictnessControl, { levelLabel } from "./RigorStrictnessControl";
 import { apiGet, apiPostWithMeta } from "../api";
 import { useRigorStrictness, BADGE_LEVEL } from "../hooks/useRigorStrictness";
+import {
+	NOT_MEASURED,
+	NOT_MEASURED_HINT,
+	deriveGenerationCostView,
+	formatDuration,
+	formatTokenCount,
+	quoteLabel,
+	quoteNote,
+	stageLabel,
+	tokensLabel,
+	usageNote,
+} from "../generationCost.js";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "";
 
@@ -375,6 +387,11 @@ export default function StrategyPassport({
 						user={user}
 						onNavigate={onNavigate}
 					/>
+
+					{/* What the generation run that produced this strategy actually
+					    consumed (#1326). Durable — read from the DB, not from the
+					    job record, which expires an hour after the run ends. */}
+					<GenerationCostCard record={s.generation_cost} />
 				</aside>
 
 				<div className="passport-evidence">
@@ -774,6 +791,80 @@ function Metric({ label, value, hint }) {
 			<div className="caption text-[var(--text-4)]">{label}</div>
 			<div className="text-[1.1rem] font-semibold tabular-nums">{value}</div>
 			{hint && <div className="caption text-[var(--text-4)]">{hint}</div>}
+		</div>
+	);
+}
+
+// Generation cost (#1326) — the measurement of the run that produced this
+// strategy, beside the price that was quoted for it.
+//
+// Two facts, two sources, never a conversion: the tokens/seconds come from the
+// cost meter, the price comes from the recorded `generation_payment.quote()`
+// payload. Nothing here turns one into the other — converting measured tokens
+// into dollars is #1217's remaining pricing work and it happens off-server.
+//
+// Absence is the honest default. No record at all (every curated strategy, and
+// every generated one from before the meter) renders as "not measured", never
+// as zero; a run whose token usage was only partly readable renders its totals
+// with a `≥` so a floor is never read as a total.
+function GenerationCostCard({ record }) {
+	const view = deriveGenerationCostView(record);
+	return (
+		<div className="card fade-up fade-up-2" style={{ marginTop: 12 }}>
+			<div className="label mb-1">Generation cost</div>
+			{!view ? (
+				<p className="caption leading-relaxed">{NOT_MEASURED_HINT}</p>
+			) : (
+				<>
+					<p className="caption leading-relaxed">
+						What this generation run consumed — a raw measurement, recorded when
+						the run finished. Token counts are <strong>not</strong> converted to
+						dollars.
+					</p>
+					<div className="mt-3 grid grid-cols-2 gap-3">
+						<Metric
+							label="Tokens"
+							value={tokensLabel(view)}
+							hint={`in ${formatTokenCount(view.tokens.input)} / out ${formatTokenCount(view.tokens.output)}`}
+						/>
+						<Metric
+							label="Wall time"
+							value={formatDuration(view.wallSeconds)}
+							hint={
+								view.tokens.calls != null
+									? `${view.tokens.calls} LLM calls`
+									: "LLM calls not measured"
+							}
+						/>
+					</div>
+					<div className="mt-3">
+						<div className="caption text-[var(--text-4)]">Dominant stage</div>
+						<div className="body">
+							{view.dominantStage
+								? `${stageLabel(view.dominantStage.name)} · ${formatDuration(view.dominantStage.wallSeconds)}`
+								: NOT_MEASURED}
+						</div>
+					</div>
+					<p
+						className="caption mt-2 leading-relaxed"
+						style={{
+							color: view.usageComplete ? "var(--text-3)" : "var(--warning)",
+						}}
+					>
+						{usageNote(view)}
+					</p>
+					<div
+						className="mt-3 pt-3"
+						style={{ borderTop: "1px solid var(--glass-border)" }}
+					>
+						<div className="caption text-[var(--text-4)]">Quoted price</div>
+						<div className="body">{quoteLabel(view) || NOT_MEASURED}</div>
+						<p className="caption leading-relaxed text-[var(--text-3)]">
+							{quoteNote(view)}
+						</p>
+					</div>
+				</>
+			)}
 		</div>
 	);
 }

--- a/ui/src/generationCost.js
+++ b/ui/src/generationCost.js
@@ -1,0 +1,236 @@
+// Generation cost (#1326) — reading the durable `cost_v1` record honestly.
+//
+// The backend serves `generation_cost` on a strategy as
+//   { schema, job_id, recorded_at, measurement: {…cost_v1…}, quote: {…} | null }
+// where `measurement` is raw counts and seconds, and `quote` is the literal
+// `generation_payment.quote()` payload that was in force when the run started.
+// The two are separate columns in the database and stay separate here: nothing
+// in this file converts a token count into money. Quote-vs-measured is two
+// recorded facts side by side, never a derivation.
+//
+// The rule this file exists to enforce, from #1314 and restated by #1326:
+// **a missing measurement is never a zero.** Every reader below returns `null`
+// for "not measured" and the formatters render `null` as an em-dash. A genuine
+// measured zero — the fixture path makes no LLM calls and honestly reports
+// `total_tokens: 0` — still renders as `0`, and the two must never collapse
+// into each other.
+
+/** What every formatter renders for a value nothing measured. */
+export const NOT_MEASURED = "—";
+
+export const NOT_MEASURED_HINT =
+	"Not measured — this strategy predates generation-cost instrumentation, or its run recorded no measurement.";
+
+// `candidate_generation` is the OUTER stage; `corpus_load` / `debate_propose` /
+// `debate_transcript` / `debate_backtest` run inside it and overlap it by
+// construction (docs/generation-cost-instrumentation.md § "Reading it
+// honestly"). Picking the plain maximum would therefore name the umbrella every
+// single time and tell the reader nothing about where the run's time actually
+// went, so umbrellas are excluded from the "dominant stage" answer.
+export const UMBRELLA_STAGES = new Set(["candidate_generation"]);
+
+const STAGE_LABELS = {
+	brief_validation: "Brief validation",
+	pipeline_select: "Pipeline select",
+	corpus_load: "Corpus retrieval",
+	debate_propose: "Debate — propose",
+	debate_transcript: "Debate — transcript",
+	debate_backtest: "Debate — backtest",
+	candidate_generation: "Candidate generation",
+	rigor_gate: "Rigor gate",
+	persist_winner: "Persist winner",
+	backtest_persist: "Backtest persist",
+};
+
+/** A human label for a stage name; unknown names pass through verbatim. */
+export function stageLabel(name) {
+	if (!name) return NOT_MEASURED;
+	return STAGE_LABELS[name] || name;
+}
+
+// A count is a measurement only when it arrived as a finite, non-negative
+// number. A string ("1234"), a boolean, null, undefined, NaN and Infinity are
+// all "not measured" — mirroring the server-side `_coerce_count` in
+// cost_meter.py, which refuses the same shapes rather than banking them.
+function countOrNull(value) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+	return value;
+}
+
+function secondsOrNull(value) {
+	return countOrNull(value);
+}
+
+/**
+ * The stage that consumed the most wall time, excluding umbrella stages.
+ * `null` when no non-umbrella stage carries a readable wall time.
+ */
+export function dominantStage(measurement) {
+	const stages = measurement?.stages;
+	if (!stages || typeof stages !== "object") return null;
+	let best = null;
+	for (const [name, bucket] of Object.entries(stages)) {
+		if (UMBRELLA_STAGES.has(name)) continue;
+		const wallSeconds = secondsOrNull(bucket?.wall_seconds);
+		if (wallSeconds == null) continue;
+		if (best == null || wallSeconds > best.wallSeconds) best = { name, wallSeconds };
+	}
+	return best;
+}
+
+/**
+ * Shape the raw `generation_cost` payload for display.
+ * Returns `null` when there is no record at all — the caller renders the
+ * "not measured" state rather than an empty card full of em-dashes.
+ */
+export function deriveGenerationCostView(record) {
+	if (!record || typeof record !== "object") return null;
+	const measurement = record.measurement;
+	if (!measurement || typeof measurement !== "object") return null;
+
+	const llm = measurement.llm && typeof measurement.llm === "object" ? measurement.llm : {};
+	// Fail closed: completeness is claimed only when the record literally says
+	// `true`. A missing or non-boolean flag means we do not know whether every
+	// call reported usage, and "we do not know" may not be shown as "complete".
+	const usageKnown = typeof llm.usage_complete === "boolean";
+	const usageComplete = llm.usage_complete === true;
+
+	return {
+		schema: typeof record.schema === "string" ? record.schema : null,
+		jobId: typeof record.job_id === "string" ? record.job_id : null,
+		recordedAt: typeof record.recorded_at === "string" ? record.recorded_at : null,
+		wallSeconds: secondsOrNull(measurement.wall_seconds),
+		cpuSeconds: secondsOrNull(measurement.cpu_seconds),
+		tokens: {
+			input: countOrNull(llm.input_tokens),
+			output: countOrNull(llm.output_tokens),
+			total: countOrNull(llm.total_tokens),
+			calls: countOrNull(llm.calls),
+			callsMissingUsage: countOrNull(llm.calls_missing_usage),
+		},
+		usageComplete,
+		usageKnown,
+		dominantStage: dominantStage(measurement),
+		quote: deriveRecordedQuote(record.quote),
+	};
+}
+
+/**
+ * The recorded quote, verbatim. `null` when the run recorded no quote — which
+ * means "we did not write down what was quoted", never "it was free".
+ */
+export function deriveRecordedQuote(quote) {
+	if (!quote || typeof quote !== "object") return null;
+	return {
+		price: typeof quote.price === "string" ? quote.price : null,
+		pricingModel: typeof quote.pricing_model === "string" ? quote.pricing_model : null,
+		asset: typeof quote.asset === "string" ? quote.asset : null,
+		chain: typeof quote.chain === "string" ? quote.chain : null,
+		paymentRequired: quote.payment_required === true,
+		dryRun: quote.dry_run === true,
+	};
+}
+
+/** Group digits for display. `null` → em-dash; a measured `0` stays `0`. */
+export function formatTokenCount(value) {
+	const n = countOrNull(value);
+	if (n == null) return NOT_MEASURED;
+	return n.toLocaleString("en-US");
+}
+
+/** Seconds → a readable duration. `null` → em-dash. */
+export function formatDuration(value) {
+	const s = secondsOrNull(value);
+	if (s == null) return NOT_MEASURED;
+	if (s < 1) return `${s.toFixed(2)} s`;
+	if (s < 60) return `${s.toFixed(1)} s`;
+	const minutes = Math.floor(s / 60);
+	const rest = Math.round(s - minutes * 60);
+	return `${minutes} m ${rest} s`;
+}
+
+/**
+ * The headline token figure. When the run could not read every call's usage,
+ * the totals are a FLOOR — rendered with a `≥` so nobody reads a partial tally
+ * as the run's full consumption.
+ */
+export function tokensLabel(view) {
+	const total = view?.tokens?.total;
+	if (total == null) return NOT_MEASURED;
+	const formatted = formatTokenCount(total);
+	return view.usageComplete ? formatted : `≥ ${formatted}`;
+}
+
+/** One sentence on how much of the token measurement is trustworthy. */
+export function usageNote(view) {
+	if (!view) return NOT_MEASURED_HINT;
+	if (view.usageComplete) return "Complete — every LLM call reported its token usage.";
+	const { callsMissingUsage, calls } = view.tokens;
+	if (!view.usageKnown) {
+		return "Incomplete — this run did not record whether every LLM call reported its token usage, so the totals are a floor.";
+	}
+	if (callsMissingUsage != null && calls != null) {
+		return `Incomplete — ${callsMissingUsage} of ${calls} LLM calls reported no usable token usage, so the totals are a floor, not the total.`;
+	}
+	return "Incomplete — at least one LLM call reported no usable token usage, so the totals are a floor, not the total.";
+}
+
+/**
+ * Trim a recorded price string's trailing zeros for display ("$0.150000" →
+ * "$0.15"). A pure display trim of a recorded string: it never rounds, never
+ * drops a significant digit, and anything not shaped like a decimal price is
+ * returned exactly as recorded rather than reformatted into a guess.
+ */
+export function quotePriceLabel(price) {
+	if (typeof price !== "string" || !price) return NOT_MEASURED;
+	const match = price.match(/^(\D*)(\d+)\.(\d+)$/);
+	if (!match) return price;
+	const [, prefix, whole, fraction] = match;
+	// Trailing zeros only, and never below two decimals — a price reads as a
+	// price. "$1.000000" → "$1.00", "$0.150000" → "$0.15", "$0.000001" stays.
+	const trimmed = fraction.replace(/0+$/, "");
+	return `${prefix}${whole}.${trimmed.length >= 2 ? trimmed : trimmed.padEnd(2, "0")}`;
+}
+
+/**
+ * The quote line: what we charged, as recorded. Never derived from the tokens.
+ * `null` when no quote was recorded, so the card can say so explicitly.
+ */
+export function quoteLabel(view) {
+	const quote = view?.quote;
+	if (!quote || !quote.price) return null;
+	const parts = [quotePriceLabel(quote.price)];
+	if (quote.asset) parts.push(quote.asset);
+	return parts.join(" ");
+}
+
+/** The caveats that belong next to a recorded quote, as recorded facts. */
+export function quoteNote(view) {
+	const quote = view?.quote;
+	if (!quote) return "No quote was recorded for this run.";
+	const notes = [];
+	if (quote.pricingModel) notes.push(`pricing model ${quote.pricingModel}`);
+	if (!quote.paymentRequired) notes.push("the paywall was off, so nothing was charged");
+	else if (quote.dryRun) notes.push("dry run — no value moved");
+	return notes.length ? `Quoted at generation time (${notes.join("; ")}).` : "Quoted at generation time.";
+}
+
+/**
+ * The library table's compact cell. Total tokens is the design call: it is the
+ * term that scales with the model and the one #1217 exists to pin down, whereas
+ * wall time is dominated by backtests and moves with whatever else the worker
+ * is doing. Wall time and the dominant stage ride along in the tooltip.
+ */
+export function compactCostCell(record) {
+	const view = deriveGenerationCostView(record);
+	if (!view) return { label: NOT_MEASURED, title: NOT_MEASURED_HINT, measured: false };
+	const title = [
+		`${tokensLabel(view)} tokens (in ${formatTokenCount(view.tokens.input)} / out ${formatTokenCount(view.tokens.output)})`,
+		`wall ${formatDuration(view.wallSeconds)}`,
+		view.dominantStage
+			? `dominant stage ${stageLabel(view.dominantStage.name)} (${formatDuration(view.dominantStage.wallSeconds)})`
+			: "dominant stage not measured",
+		usageNote(view),
+	].join(" · ");
+	return { label: tokensLabel(view), title, measured: true };
+}

--- a/ui/src/generationCost.js
+++ b/ui/src/generationCost.js
@@ -224,8 +224,15 @@ export function quoteNote(view) {
 export function compactCostCell(record) {
 	const view = deriveGenerationCostView(record);
 	if (!view) return { label: NOT_MEASURED, title: NOT_MEASURED_HINT, measured: false };
+	// A record can exist while its token count is unreadable. Say that in words
+	// rather than rendering "— tokens (in — / out —)", which reads like a
+	// formatting bug instead of the honest statement it is.
+	const tokensPhrase =
+		view.tokens.total == null
+			? "Token count not measured for this run"
+			: `${tokensLabel(view)} tokens (in ${formatTokenCount(view.tokens.input)} / out ${formatTokenCount(view.tokens.output)})`;
 	const title = [
-		`${tokensLabel(view)} tokens (in ${formatTokenCount(view.tokens.input)} / out ${formatTokenCount(view.tokens.output)})`,
+		tokensPhrase,
 		`wall ${formatDuration(view.wallSeconds)}`,
 		view.dominantStage
 			? `dominant stage ${stageLabel(view.dominantStage.name)} (${formatDuration(view.dominantStage.wallSeconds)})`

--- a/ui/test/generation-cost.test.js
+++ b/ui/test/generation-cost.test.js
@@ -1,0 +1,361 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+	NOT_MEASURED,
+	NOT_MEASURED_HINT,
+	UMBRELLA_STAGES,
+	compactCostCell,
+	deriveGenerationCostView,
+	deriveRecordedQuote,
+	dominantStage,
+	formatDuration,
+	formatTokenCount,
+	quoteLabel,
+	quoteNote,
+	quotePriceLabel,
+	stageLabel,
+	tokensLabel,
+	usageNote,
+} from "../src/generationCost.js";
+
+// A representative durable record, matching what the backend serves on
+// `strategy.generation_cost` (#1326): the cost_v1 measurement in one field, the
+// literal generation_payment.quote() payload in another.
+const RECORD = {
+	schema: "cost_v1",
+	job_id: "9f2c8a1b4d5e6f70",
+	recorded_at: "2026-08-20T09:16:04.228106+00:00",
+	measurement: {
+		schema: "cost_v1",
+		job_id: "9f2c8a1b4d5e6f70",
+		wall_seconds: 47.9312,
+		cpu_seconds: 31.4407,
+		llm: {
+			calls: 17,
+			calls_missing_usage: 0,
+			usage_complete: true,
+			input_tokens: 41234,
+			output_tokens: 5120,
+			total_tokens: 46354,
+		},
+		stages: {
+			candidate_generation: { wall_seconds: 43.1, cpu_seconds: 24.9, runs: 1 },
+			debate_backtest: { wall_seconds: 21.55, cpu_seconds: 20.9, runs: 1 },
+			debate_propose: { wall_seconds: 12.8, cpu_seconds: 1.1, runs: 1 },
+			rigor_gate: { wall_seconds: 0.9, cpu_seconds: 0.88, runs: 1 },
+		},
+		writes: { strategy_store: 1, strategy_passports: 2 },
+		meta: { pipeline: "debate", outcome: "done", candidates_passing_rigor: 0 },
+	},
+	quote: {
+		payment_required: true,
+		pricing_model: "flat_v1",
+		price: "$0.150000",
+		asset: "USDC",
+		chain: "eip155:5042002",
+		recipient: "0xRecipient",
+		dry_run: true,
+		how: "POST /api/generate/start ...",
+	},
+};
+
+// ── The record shapes into a view ─────────────────────────────────────────
+
+test("deriveGenerationCostView shapes the measurement and the quote as two separate facts", () => {
+	const view = deriveGenerationCostView(RECORD);
+	assert.equal(view.schema, "cost_v1");
+	assert.equal(view.jobId, "9f2c8a1b4d5e6f70");
+	assert.equal(view.wallSeconds, 47.9312);
+	assert.equal(view.cpuSeconds, 31.4407);
+	assert.equal(view.tokens.input, 41234);
+	assert.equal(view.tokens.output, 5120);
+	assert.equal(view.tokens.total, 46354);
+	assert.equal(view.tokens.calls, 17);
+	assert.equal(view.usageComplete, true);
+	assert.equal(view.quote.price, "$0.150000");
+	assert.equal(view.quote.pricingModel, "flat_v1");
+	// No $-figure is ever derived FROM the tokens — the only money on the view
+	// is the string the server recorded from the quote seam.
+	assert.equal("usd" in view, false);
+	assert.equal("priceFromTokens" in view, false);
+});
+
+test("deriveGenerationCostView returns null when there is no record and when the record carries no measurement", () => {
+	assert.equal(deriveGenerationCostView(null), null);
+	assert.equal(deriveGenerationCostView(undefined), null);
+	assert.equal(deriveGenerationCostView({}), null);
+	assert.equal(deriveGenerationCostView({ measurement: null, quote: RECORD.quote }), null);
+	// A record carrying only a QUOTE is not a measurement. Rendering it as a
+	// cost card would put a price where a measurement belongs.
+	assert.equal(deriveGenerationCostView({ schema: "cost_v1", quote: RECORD.quote }), null);
+});
+
+// ── GUARD: unknown is never zero ──────────────────────────────────────────
+
+test("GUARD: a missing token total renders as unknown, never as 0", () => {
+	const record = {
+		...RECORD,
+		measurement: {
+			...RECORD.measurement,
+			llm: { calls: 4, calls_missing_usage: 4, usage_complete: false },
+		},
+	};
+	const view = deriveGenerationCostView(record);
+	assert.equal(view.tokens.total, null);
+	assert.equal(view.tokens.input, null);
+	assert.equal(view.tokens.output, null);
+	assert.equal(tokensLabel(view), NOT_MEASURED);
+	assert.notEqual(tokensLabel(view), "0");
+	assert.equal(formatTokenCount(undefined), NOT_MEASURED);
+	assert.equal(formatTokenCount(null), NOT_MEASURED);
+});
+
+test("GUARD: an unusable token count is unknown, not banked — strings, booleans, NaN, Infinity, negatives", () => {
+	// Mirrors cost_meter._coerce_count server-side: a stringly-typed count is a
+	// parse we did not do, so it is not a measurement we may report.
+	for (const bad of ["46354", true, false, NaN, Infinity, -1, {}, []]) {
+		const view = deriveGenerationCostView({
+			...RECORD,
+			measurement: { ...RECORD.measurement, llm: { ...RECORD.measurement.llm, total_tokens: bad } },
+		});
+		assert.equal(view.tokens.total, null, `expected ${String(bad)} to read as unknown`);
+		assert.equal(tokensLabel(view), NOT_MEASURED);
+	}
+});
+
+test("GUARD: a genuinely measured zero still renders as 0 — the fixture path makes no LLM calls", () => {
+	// The other half of the same rule. If unknown collapsed onto zero, this case
+	// would be indistinguishable from the one above; it must not be.
+	const view = deriveGenerationCostView({
+		...RECORD,
+		measurement: {
+			...RECORD.measurement,
+			llm: {
+				calls: 0,
+				calls_missing_usage: 0,
+				usage_complete: true,
+				input_tokens: 0,
+				output_tokens: 0,
+				total_tokens: 0,
+			},
+		},
+	});
+	assert.equal(view.tokens.total, 0);
+	assert.equal(tokensLabel(view), "0");
+	assert.equal(formatTokenCount(0), "0");
+});
+
+// ── GUARD: a floor is never presented as a total ──────────────────────────
+
+test("GUARD: usage_complete=false renders the totals as a floor (≥) and says how many calls were unreadable", () => {
+	const view = deriveGenerationCostView({
+		...RECORD,
+		measurement: {
+			...RECORD.measurement,
+			llm: {
+				calls: 17,
+				calls_missing_usage: 3,
+				usage_complete: false,
+				input_tokens: 30000,
+				output_tokens: 4000,
+				total_tokens: 34000,
+			},
+		},
+	});
+	assert.equal(view.usageComplete, false);
+	assert.equal(tokensLabel(view), "≥ 34,000");
+	assert.match(usageNote(view), /3 of 17/);
+	assert.match(usageNote(view), /floor, not the total/);
+});
+
+test("GUARD: an absent usage_complete flag fails CLOSED — never claimed complete", () => {
+	const view = deriveGenerationCostView({
+		...RECORD,
+		measurement: {
+			...RECORD.measurement,
+			llm: { calls: 5, input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+		},
+	});
+	assert.equal(view.usageKnown, false);
+	assert.equal(view.usageComplete, false);
+	assert.equal(tokensLabel(view), "≥ 15");
+	assert.match(usageNote(view), /did not record whether/);
+});
+
+test("a complete measurement says so plainly", () => {
+	const view = deriveGenerationCostView(RECORD);
+	assert.equal(tokensLabel(view), "46,354");
+	assert.match(usageNote(view), /^Complete/);
+});
+
+// ── GUARD: the dominant stage is not the umbrella ─────────────────────────
+
+test("GUARD: dominantStage excludes candidate_generation, the umbrella that contains the sub-phases", () => {
+	// candidate_generation has the LARGEST wall_seconds in the fixture (43.1 vs
+	// 21.55) because the sub-phases run inside it. A plain max would name it
+	// every time and say nothing about where the run's time went.
+	assert.ok(UMBRELLA_STAGES.has("candidate_generation"));
+	const best = dominantStage(RECORD.measurement);
+	assert.equal(best.name, "debate_backtest");
+	assert.equal(best.wallSeconds, 21.55);
+	assert.notEqual(best.name, "candidate_generation");
+});
+
+test("dominantStage is unknown when only umbrella stages, no stages, or unreadable stages are present", () => {
+	assert.equal(dominantStage({ stages: { candidate_generation: { wall_seconds: 43.1 } } }), null);
+	assert.equal(dominantStage({ stages: {} }), null);
+	assert.equal(dominantStage({}), null);
+	assert.equal(dominantStage(null), null);
+	assert.equal(dominantStage({ stages: { rigor_gate: { wall_seconds: "0.9" } } }), null);
+});
+
+test("stageLabel humanizes known stages and passes unknown ones through verbatim", () => {
+	assert.equal(stageLabel("debate_backtest"), "Debate — backtest");
+	assert.equal(stageLabel("some_future_stage"), "some_future_stage");
+	assert.equal(stageLabel(null), NOT_MEASURED);
+});
+
+// ── Duration formatting ───────────────────────────────────────────────────
+
+test("formatDuration: unknown is an em-dash; sub-second, seconds and minutes each read naturally", () => {
+	assert.equal(formatDuration(null), NOT_MEASURED);
+	assert.equal(formatDuration("47.9"), NOT_MEASURED);
+	assert.equal(formatDuration(NaN), NOT_MEASURED);
+	assert.equal(formatDuration(0.42), "0.42 s");
+	assert.equal(formatDuration(0), "0.00 s");
+	assert.equal(formatDuration(47.9312), "47.9 s");
+	assert.equal(formatDuration(192), "3 m 12 s");
+});
+
+// ── The quote is a recorded fact, shown as recorded ───────────────────────
+
+test("quotePriceLabel trims trailing zeros without rounding, and passes anything unexpected through unchanged", () => {
+	assert.equal(quotePriceLabel("$0.150000"), "$0.15");
+	assert.equal(quotePriceLabel("$1.000000"), "$1.00");
+	assert.equal(quotePriceLabel("$0.000001"), "$0.000001");
+	assert.equal(quotePriceLabel("$0.123456"), "$0.123456");
+	// Not a decimal price → returned exactly as recorded, never reformatted
+	// into a guess.
+	assert.equal(quotePriceLabel("free"), "free");
+	assert.equal(quotePriceLabel(""), NOT_MEASURED);
+	assert.equal(quotePriceLabel(null), NOT_MEASURED);
+});
+
+test("quoteLabel and quoteNote carry the recorded quote, and say so when none was recorded", () => {
+	const view = deriveGenerationCostView(RECORD);
+	assert.equal(quoteLabel(view), "$0.15 USDC");
+	assert.match(quoteNote(view), /flat_v1/);
+	assert.match(quoteNote(view), /dry run/);
+
+	const noQuote = deriveGenerationCostView({ ...RECORD, quote: null });
+	assert.equal(noQuote.quote, null);
+	assert.equal(quoteLabel(noQuote), null);
+	assert.equal(quoteNote(noQuote), "No quote was recorded for this run.");
+});
+
+test("a quote recorded while the paywall was OFF says nothing was charged, rather than implying a payment", () => {
+	const view = deriveGenerationCostView({
+		...RECORD,
+		quote: { ...RECORD.quote, payment_required: false, dry_run: false },
+	});
+	assert.equal(view.quote.paymentRequired, false);
+	assert.match(quoteNote(view), /paywall was off/);
+});
+
+test("deriveRecordedQuote reads only the ratified quote fields and never invents a price", () => {
+	assert.equal(deriveRecordedQuote(null), null);
+	assert.equal(deriveRecordedQuote("$0.15"), null);
+	const q = deriveRecordedQuote({ price: 0.15, pricing_model: "flat_v1" });
+	// A numeric price is not the recorded string shape — not read, not guessed.
+	assert.equal(q.price, null);
+	assert.equal(q.pricingModel, "flat_v1");
+	assert.equal(q.paymentRequired, false);
+});
+
+// ── The library cell ──────────────────────────────────────────────────────
+
+test("compactCostCell: no record renders the em-dash plus an explicit not-measured tooltip", () => {
+	const cell = compactCostCell(null);
+	assert.equal(cell.label, NOT_MEASURED);
+	assert.equal(cell.measured, false);
+	assert.equal(cell.title, NOT_MEASURED_HINT);
+	assert.match(cell.title, /Not measured/);
+	// Never a zero, and never an empty string that reads as "nothing to say".
+	assert.notEqual(cell.label, "0");
+	assert.notEqual(cell.label, "");
+});
+
+test("compactCostCell: a measured record shows tokens, with wall time and the dominant stage in the tooltip", () => {
+	const cell = compactCostCell(RECORD);
+	assert.equal(cell.label, "46,354");
+	assert.equal(cell.measured, true);
+	assert.match(cell.title, /in 41,234 \/ out 5,120/);
+	assert.match(cell.title, /wall 47\.9 s/);
+	assert.match(cell.title, /dominant stage Debate — backtest/);
+	assert.doesNotMatch(cell.title, /candidate generation/i);
+});
+
+test("compactCostCell: an incomplete measurement carries the ≥ into the library cell too", () => {
+	const cell = compactCostCell({
+		...RECORD,
+		measurement: {
+			...RECORD.measurement,
+			llm: { ...RECORD.measurement.llm, usage_complete: false, calls_missing_usage: 2 },
+		},
+	});
+	assert.equal(cell.label, "≥ 46,354");
+	assert.match(cell.title, /floor, not the total/);
+});
+
+// ── Wiring: the components read the shared helpers rather than forking the
+// honesty rules inline. Static-source pins, matching the pattern established
+// in ui/test/generate-quote.test.js. ──────────────────────────────────────
+
+const passport = readFileSync(
+	new URL("../src/components/StrategyPassport.jsx", import.meta.url),
+	"utf8",
+);
+const library = readFileSync(
+	new URL("../src/components/Strategies.jsx", import.meta.url),
+	"utf8",
+);
+
+test("StrategyPassport.jsx renders the generation-cost card from the shared helpers", () => {
+	assert.match(passport, /from ["']\.\.\/generationCost\.js["']/);
+	assert.match(passport, /<GenerationCostCard record=\{s\.generation_cost\}/);
+	assert.match(passport, /deriveGenerationCostView\(record\)/);
+	assert.match(passport, /tokensLabel\(view\)/);
+	assert.match(passport, /usageNote\(view\)/);
+	assert.match(passport, /quoteLabel\(view\)/);
+	assert.match(passport, /NOT_MEASURED_HINT/);
+});
+
+test("StrategyPassport.jsx does no $-conversion of token counts", () => {
+	// The card may only show the price the SERVER recorded from the quote seam.
+	// Any arithmetic between a token count and a rate would be a pricing model
+	// living in the frontend.
+	assert.doesNotMatch(passport, /tokens?\s*[*/]\s*[\d.]/i);
+	assert.doesNotMatch(passport, /per_?(1k|thousand|million|token)/i);
+	assert.doesNotMatch(passport, /RATE_CARD|PRICE_PER/i);
+});
+
+test("Strategies.jsx renders the library cost column through compactCostCell, in both layouts", () => {
+	assert.match(library, /from ["']\.\.\/generationCost\.js["']/);
+	assert.match(library, /compactCostCell\(s\.generation_cost\)/);
+	assert.match(library, />Gen tokens<\/th>/);
+	// The table and the mobile card list must not drift apart — the card list
+	// IS the ≤768px layout, so a table-only column is invisible on mobile.
+	assert.match(library, /<div className="caption">Gen tokens<\/div>/);
+	// The row's detail panel spans every column; adding one without widening
+	// the span silently misaligns the expanded row.
+	assert.match(library, /colSpan=\{9\}/);
+	assert.doesNotMatch(library, /colSpan=\{8\}/);
+});
+
+test("Strategies.jsx passes the generation_cost record through the generated-row coercion", () => {
+	// coerceGenerated builds the row object the table renders; a field it drops
+	// can never reach the cell, however well the cell is written.
+	assert.match(library, /generation_cost: row\.generation_cost \?\? null/);
+});

--- a/ui/test/generation-cost.test.js
+++ b/ui/test/generation-cost.test.js
@@ -297,6 +297,22 @@ test("compactCostCell: a measured record shows tokens, with wall time and the do
 	assert.doesNotMatch(cell.title, /candidate generation/i);
 });
 
+test("compactCostCell: a record whose token count is unreadable says so in words, in the cell and the tooltip", () => {
+	const cell = compactCostCell({
+		...RECORD,
+		measurement: {
+			...RECORD.measurement,
+			llm: { calls: 4, calls_missing_usage: 4, usage_complete: false },
+		},
+	});
+	assert.equal(cell.label, NOT_MEASURED);
+	assert.match(cell.title, /Token count not measured for this run/);
+	// Never the formatting-bug rendering of the same fact.
+	assert.doesNotMatch(cell.title, /— tokens \(in — \/ out —\)/);
+	// The rest of the record is still readable and still shown.
+	assert.match(cell.title, /wall 47\.9 s/);
+});
+
 test("compactCostCell: an incomplete measurement carries the ≥ into the library cell too", () => {
 	const cell = compactCostCell({
 		...RECORD,


### PR DESCRIPTION
Closes #1326

## What this does

The #1314 cost meter measures every generation, but its `cost_v1` snapshot lived
only on the Redis job record, whose `JOB_TTL` is 3600s. An hour after a run
finished the only measurement of what it consumed was gone, and no surface ever
showed it. This makes it durable and puts it on the two pages that should carry
it.

**Persist.** `run_generation`'s `finally` now writes the *same snapshot object*
twice — onto the job record as before, and into a new `generation_costs` table
keyed to the strategy the run produced. Two copies of one reading, so they
cannot disagree. `strategy_ids` moved above the `try` so the write also happens
on the rigor-failed and errored terminal paths, which is where it matters most:
those runs spend the same backtest compute and are the common case.

The row has two payload columns, deliberately:

| Column | Holds |
|---|---|
| `measurement_json` | the literal `cost_v1` snapshot |
| `quote_json` | the literal `generation_payment.quote()` payload in force when the job **started** |

Keeping them apart is the design, not normalization. Quote-vs-measured has to be
a pairing of two independently recorded facts. Merging the quote into the
snapshot — the obvious future shortcut — would ship a priced `cost_v1` record,
so a new `cost_meter.assert_measurement_only` screens the measurement's keys at
every depth on the way in and raises `PricingLeakError` instead. **No token count
is converted into dollars anywhere server-side or client-side.** The quote seam
itself is read-only here and still reports `pricing_model: "flat_v1"`.

**Surface.** `GET /api/strategies/{id}` and `GET /api/strategies/generated` gain
`generation_cost`. The passport's authority aside gets a Generation cost card
(tokens in/out with the `usage_complete` honesty flag, wall time, dominant
stage, and the recorded quote beside them); the library table — and the mobile
card list that replaces it below 768px — gets a compact **Gen tokens** column.

### Design calls made here

- **Library column shows total tokens**, not wall time. Tokens are the term that
  scales with the model and the one #1217 exists to pin down; wall time is
  dominated by backtests and moves with whatever else the worker is doing. Wall
  time and the dominant stage ride in the cell's tooltip.
- **The measurement is the JOB's, not the strategy's share.** Generation is K=1
  (one `strategy_store` row per job), so the pairing is one-to-one today. If a
  job ever persists more than one strategy again, each gets a row carrying the
  same job-level measurement — read a row as "the run that produced this
  strategy consumed this", never as a private share, and never sum across rows.
  Documented in the model, the migration and the doc.
- **No backfill, and none is possible.** Pre-meter generations were never
  measured; they render as *not measured*. Matches the issue's anti-goal.
- **Nothing is written when no strategy row exists** (invalid brief, early
  crash). There is nothing to key a record to, and inventing an id would be
  worse than the gap. The job record stays the only copy for those runs.
- **The durable write is not tallied through the meter.** The snapshot is sealed
  by then — a tally cannot appear inside the document it counts — and
  `record_write("generation_costs")` raises `PricingLeakError` anyway. The
  table's *name* is fine; a counter label inside a `cost_v1` snapshot is not.

Not touched: quota/payment enforcement, and the quote seam (read-only).

## Unknown vs zero

The rule from #1314, restated by this issue, is enforced on both sides:

| Situation | Renders as |
|---|---|
| No record (curated strategy, or generated before the meter) | `—` + "Not measured — this strategy predates generation-cost instrumentation…" |
| Record whose `measurement_json` will not decode | `—` (logged loudly server-side; treated as absent, never as `{}`) |
| Count arriving as a string / bool / `NaN` / `Infinity` / negative | `—` (the same refusal `_coerce_count` makes server-side) |
| `usage_complete: false`, or the flag absent entirely | `≥ 34,000` + "Incomplete — 3 of 17 LLM calls reported no usable token usage, so the totals are a floor, not the total." |
| Genuinely measured zero (fixture path makes no LLM calls) | `0` |

The last two rows are why this is a real distinction rather than a slogan: a
measured zero and an unknown must stay visibly different, and a partial tally
must never be presented as a total.

## A real recorded snapshot

`generation_cost_for_strategy()` read back out of the durable row after a real
fixture-pipeline run, printed verbatim (`json.dumps(..., indent=2,
sort_keys=True)`) — this is the exact payload the API serves as
`strategy.generation_cost`:

```json
{
  "job_id": "j1",
  "measurement": {
    "cpu_attribution": "process_wide_delta",
    "cpu_seconds": 0.422,
    "job_id": "j1",
    "llm": {
      "by_model": {},
      "calls": 0,
      "calls_missing_usage": 0,
      "input_tokens": 0,
      "output_tokens": 0,
      "total_tokens": 0,
      "usage_complete": true
    },
    "meta": {
      "candidates_considered": 2,
      "candidates_passing_rigor": 0,
      "model_requested": null,
      "n_candidates_requested": 1,
      "outcome": "done",
      "pipeline": "fixture",
      "served_model": "fixture"
    },
    "peak_rss_bytes": 185106432,
    "rss_attribution": "process_high_water",
    "schema": "cost_v1",
    "stages": {
      "backtest_persist": {
        "cpu_seconds": 0.0001,
        "runs": 1,
        "wall_seconds": 0.0002
      },
      "brief_validation": {
        "cpu_seconds": 0.0,
        "runs": 1,
        "wall_seconds": 0.0
      },
      "candidate_generation": {
        "cpu_seconds": 0.1375,
        "runs": 2,
        "wall_seconds": 0.5874
      },
      "persist_winner": {
        "cpu_seconds": 0.0,
        "runs": 1,
        "wall_seconds": 0.0
      },
      "pipeline_select": {
        "cpu_seconds": 0.0,
        "runs": 1,
        "wall_seconds": 0.0
      },
      "rigor_gate": {
        "cpu_seconds": 0.0,
        "runs": 1,
        "wall_seconds": 0.0
      }
    },
    "wall_seconds": 1.6569,
    "writes": {
      "strategy_proposals": 2,
      "strategy_store": 1
    }
  },
  "quote": {
    "asset": "USDC",
    "chain": "arcTestnet",
    "dry_run": true,
    "how": "POST /api/generate/start without a Payment-Signature header returns 402 with these requirements in the PAYMENT-REQUIRED header; sign them (x402 / Circle Gateway) and retry with Payment-Signature.",
    "payment_required": false,
    "price": "$0.150000",
    "pricing_model": "flat_v1",
    "recipient": null
  },
  "recorded_at": "2026-08-20T10:32:19.075774",
  "schema": "cost_v1"
}
```

Reading it: `candidates_passing_rigor: 0` is the rigor-failed path carrying a
full measurement. `total_tokens: 0` is a *real* measurement — the fixture runner
makes no LLM calls — and it reports itself complete, which is exactly the case
that must not collapse onto "unknown". `candidate_generation` has `runs: 2`
(both regime candidates) and the largest wall time of any stage, which is why
the dominant-stage reader excludes it. `payment_required: false` is why the card
says the paywall was off rather than implying a charge.

One environment note: `recorded_at` here has no UTC offset because this read-back
ran against SQLite, which drops `tzinfo`. The column is `DateTime(timezone=True)`,
so on Aurora the same field carries the offset.

## Guard demonstrations

Every guard was built, then broken, then confirmed to reject the broken input,
before this was pushed. Transcripts verbatim.

### B1 — remove the pricing screen from the write

```
$ # deleted assert_measurement_only(...) from record_generation_cost
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "merging_the_quote"
    with pytest.raises(PricingLeakError):
E   Failed: DID NOT RAISE <class 'archimedes.services.cost_meter.PricingLeakError'>
FAILED backend/tests/test_generation_cost_persistence.py::TestMeasurementOnlyGuard::test_merging_the_quote_into_the_measurement_is_refused_at_the_write
================= 1 failed, 29 deselected, 1 warning in 2.32s ==================
--- restored ---
================= 1 passed, 29 deselected, 1 warning in 1.92s ==================
```

### B2 — corrupt measurement returns `{}` instead of `None` (the fail-soft substitution)

```
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "corrupt_measurement"
    assert generation_cost_for_strategy(session, "s") is None
E   AssertionError: assert {'job_id': 'j', 'measurement': {}, 'quote': None, 'recorded_at': '2026-08-20T07:09:33.391166', ...} is None
FAILED backend/tests/test_generation_cost_persistence.py::TestUnknownIsNeverZero::test_a_corrupt_measurement_reads_as_absent_not_as_an_empty_measurement
================= 1 failed, 29 deselected, 1 warning in 2.27s ==================
--- restored ---
================= 1 passed, 29 deselected, 1 warning in 1.56s ==================
```

### B3 — drop the durable persist from the `finally` (the pre-#1326 state)

```
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "survives_the_job_records_expiry or completed_generation_writes"
E   AssertionError: a completed generation must leave a durable measurement
E   AssertionError: the durable record must not depend on the job hash
FAILED ...::TestPipelinePersistsDurably::test_a_completed_generation_writes_the_durable_row
FAILED ...::TestPipelinePersistsDurably::test_the_record_survives_the_job_records_expiry
================= 2 failed, 28 deselected, 1 warning in 4.00s ==================
--- restored ---
================= 2 passed, 28 deselected, 1 warning in 4.09s ==================
```

### B4 — let a persist failure escape (no swallow)

```
$ # replaced the logging except with a bare `raise`
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "persist_failure_does_not_fail"
E   RuntimeError: database is on fire
FAILED ...::TestPipelinePersistsDurably::test_a_persist_failure_does_not_fail_the_generation
================= 1 failed, 29 deselected, 1 warning in 2.61s ==================
```

### B5 — tally the durable write through the meter

```
$ # added cost_meter.record_write("generation_costs", count) after the write
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "does_not_tally_the_durable_write"
    assert offenders == [], f"the durable write must not be tallied through the meter (lines {offenders})"
E   assert [787] == []
FAILED ...::test_the_pipeline_does_not_tally_the_durable_write
================= 1 failed, 29 deselected, 1 warning in 1.62s ==================
```

(The companion unit test proves *why*: `meter.record_write("generation_costs")`
raises `PricingLeakError`.)

### B6 — the durable write drops `default=str`, diverging from the job store

The same snapshot goes to both stores. Without matching encoders, a stray
non-JSON-encodable `meta` value lands on the expiring copy and is lost from the
permanent one — which looks fine for an hour and then isn't.

```
$ # removed default=str from the measurement_json dumps
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "json_cannot_encode"
E   TypeError: Object of type datetime is not JSON serializable
FAILED ...::TestRecordGenerationCost::test_a_value_json_cannot_encode_is_stringified_like_the_job_record_does
================= 1 failed, 30 deselected, 1 warning in 6.97s ==================
--- restored ---
================= 1 passed, 30 deselected, 1 warning in 5.11s ==================
```

### R1 — batch reader falls back to a stale row (review fix)

The batch reader ordered ASC and overwrote, so a strategy whose NEWEST row was
corrupt silently kept the older one — while the single-strategy reader honestly
returned `None` for the same strategy.

```
$ # reverted generation_costs_for_strategies to ASC + overwrite
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "NEWEST_is_corrupt"
    assert "s" not in batch, "the batch reader must not substitute the older, superseded row"
E   assert 's' not in {'s': {'job_id': 'job-old', 'measurement': {...}, 'quote': None, 'recorded_at': '2026-08-20T10:30:32.805678', ...}}
FAILED ...::TestUnknownIsNeverZero::test_the_batch_reader_does_not_fall_back_to_an_older_row_when_the_NEWEST_is_corrupt
================= 1 failed, 42 deselected, 1 warning in 2.52s ==================
--- restored ---
================= 2 passed, 41 deselected, 1 warning in 3.38s ==================
```

### R2 — screening provider model ids drops the measurement (review fix)

`llm.by_model`'s keys are provider identifiers copied off a response, not labels
this codebase chose. Screening them let a vendor's naming decide whether a
measurement got persisted — **silently**, because the write runs inside the
pipeline's swallowing `finally`.

```
$ # removed the DATA_KEYED_PATHS exemption from assert_measurement_only
$ pytest backend/tests/test_generation_cost_persistence.py -q -k "model_id_carrying_pricing_words"
E   PricingLeakError: test key at llm.by_model.price-aware-model-x name 'price-aware-model-x' contains 'price': ...
E   PricingLeakError: test key at llm.by_model.llama-3-feedback-tuned name 'llama-3-feedback-tuned' contains 'fee': ...
E   PricingLeakError: test key at llm.by_model.vendor/cost-optimized-v2 name 'vendor/cost-optimized-v2' contains 'cost': ...
E   PricingLeakError: test key at llm.by_model.acme-spend-lite name 'acme-spend-lite' contains 'spend': ...
================= 4 failed, 39 deselected, 1 warning in 1.76s ==================
--- restored ---
================= 19 passed, 24 deselected, 1 warning in 2.17s =================
```

`llama-3-feedback-tuned` is the one that makes this not a hypothetical: `fee`
inside `feedback`. And the exemption opened no hole — stage / write-counter /
meta labels, a near-miss `by_model_pricing` key, a `by_model` at the wrong path,
and a `cost_usd` counter *underneath* a model id all still raise:

```
$ pytest backend/tests/test_generation_cost_persistence.py -q \
    -k "authored_labels_are_still_rejected or one_level_deep or exemption_is_exactly_one_path"
================= 7 passed, 36 deselected, 1 warning in 2.59s ==================
```

### M1 — ORM gains a column the migration does not create

```
$ pytest backend/tests/test_alembic_migrations.py -q -k "generation_costs"
    assert create_all_cols == alembic_cols
E   AssertionError: assert {'drifted_col...rded_at', ...} == {'id', 'job_i...version', ...}
FAILED backend/tests/test_alembic_migrations.py::test_alembic_generation_costs_matches_a_fresh_create_all_schema
============ 1 failed, 1 passed, 6 deselected, 1 warning in 10.65s =============
```

### M2 — migration downgrade forgets to drop the table

```
$ pytest backend/tests/test_alembic_migrations.py -q -k "generation_costs_table_added"
    assert "generation_costs" not in _table_names(db_path)
E   AssertionError: assert 'generation_costs' not in {'alembic_version', 'asset_daily_bars', 'auth_accounts', 'auth_rate_limits', 'auth_sessions', 'auth_users', ...}
FAILED backend/tests/test_alembic_migrations.py::test_alembic_generation_costs_table_added_and_removed
================== 1 failed, 7 deselected, 1 warning in 5.46s ==================
--- restored ---
================= 2 passed, 6 deselected, 1 warning in 12.48s ==================
```

### M3 — migration chain guard, re-pointed at a stale parent

```
$ python .github/scripts/migration_chain_guard.py --base-ref origin/main
FAIL: backend/migrations/versions/e2b7f4c81d93_add_generation_costs.py has down_revision='b41c7d9e2a05', but origin/main's migration chain head is 'c9396e0d95d4'.
Someone else's migration merged to main after you branched — re-serialize:
  1. git fetch origin main
  2. edit down_revision in backend/migrations/versions/e2b7f4c81d93_add_generation_costs.py to "c9396e0d95d4"
  3. from backend/: `alembic history` should show one unbroken chain, one head.
exit=1
--- restored ---
migration_chain_guard: OK — ['backend/migrations/versions/e2b7f4c81d93_add_generation_costs.py'] extend origin/main's head (c9396e0d95d4) cleanly.
exit=0
```

### U1 — unknown coerced to zero (`Number(value) || 0`)

```
$ node --test test/generation-cost.test.js
✖ GUARD: a missing token total renders as unknown, never as 0
    actual: 0
    expected: null
✖ GUARD: an unusable token count is unknown, not banked — strings, booleans, NaN, Infinity, negatives
    actual: 46354
    expected: null
✖ dominantStage is unknown when only umbrella stages, no stages, or unreadable stages are present
    actual: { name: 'rigor_gate', wallSeconds: 0.9 }
    expected: null
✖ formatDuration: unknown is an em-dash; sub-second, seconds and minutes each read naturally
    actual: '0.00 s'
    expected: '—'
ℹ fail 4
--- restored ---
ℹ pass 23
ℹ fail 0
```

### U2 — dominant stage stops excluding the umbrella

```
✖ GUARD: dominantStage excludes candidate_generation, the umbrella that contains the sub-phases
    actual: 'candidate_generation'
    expected: 'debate_backtest'
✖ compactCostCell: a measured record shows tokens, with wall time and the dominant stage in the tooltip
    actual: '46,354 tokens (in 41,234 / out 5,120) · wall 47.9 s · dominant stage Candidate generation (43.1 s) · Complete — every LLM call reported its token usage.'
    expected: /dominant stage Debate — backtest/
ℹ fail 3
```

### U3 — `usage_complete` fails open (`!== false`)

```
✖ GUARD: an absent usage_complete flag fails CLOSED — never claimed complete
    actual: true
    expected: false
ℹ fail 1
```

### U4 — new column added without widening the detail row's `colSpan`

```
✖ Strategies.jsx renders the library cost column through compactCostCell, in both layouts
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression /colSpan=\{9\}/
ℹ fail 1
```

### U5 — the row coercion drops the record

```
✖ Strategies.jsx passes the generation_cost record through the generated-row coercion
ℹ fail 1
```

### U6 — an unreadable token count rendered as an em-dash sentence

A record can exist while its token count is unreadable. Rendering that as
"— tokens (in — / out —)" reads like a formatting bug rather than the honest
statement it is.

```
✖ compactCostCell: a record whose token count is unreadable says so in words, in the cell and the tooltip
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression /Token count not measured for this run/
ℹ fail 1
--- restored ---
ℹ pass 24
ℹ fail 0
```

## Acceptance criterion, exercised rather than asserted

`test_the_record_survives_the_job_records_expiry` runs the real fixture pipeline
against a fakeredis job store, asserts both copies exist, then **deletes the
Redis job hash** — the TTL's end state — confirms `store.get(job_id) is None`,
and reads the measurement back out of the database. It also asserts the two
copies carry the *same* snapshot, not two readings.

## Verification

All run from the repo root on the rebased branch. `main` advanced four times while
this was in flight (#1310, #1239, #1201, #1200), so the pass-count delta is not a
clean subtraction against the original branch point — the per-file tallies below are
the exact accounting of what this branch adds.

| Gate | Result |
|---|---|
| `pytest -m "not integration"` (this branch, rebased on `c0e6400f`) | `3422 passed, 2 skipped, 2 deselected` |
| `pytest -m "not integration"` (baseline at the original branch point `c4f64387`) | `3352 passed, 2 skipped, 2 deselected` |
| `backend/tests/test_generation_cost_persistence.py` (new) | `43 passed` |
| `backend/tests/test_generation_cost_persistence.py` hermetic gate (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend`) | `43 passed` |
| `backend/tests/test_alembic_migrations.py` | `8 passed` (was 6) |
| `cd ui && node --test` | `114 passed, 0 failed` (was 90) |
| `ui/test/generation-cost.test.js` (new) | `24 passed, 0 failed` |
| `cd ui && npm run lint` | clean |
| `cd ui && npm run build` | `✓ built` |
| `ruff format --check .` | `565 files already formatted` |
| `ruff check --select E9,F63,F7,F40 .` | `All checks passed!` |
| `python .github/scripts/migration_chain_guard.py --base-ref origin/main` | `OK — extends origin/main's head (c9396e0d95d4) cleanly` |
| `make docs-check` | `broken 0 (0.0%)`, `131 indexed, 0 orphaned` |
| `grep -r "asyncio.get_event_loop" backend/tests/` | no matches |

## Files

- `backend/archimedes/services/cost_meter.py` — `assert_measurement_only`
- `backend/archimedes/models/generation_cost.py` — the table, its upsert and its readers
- `backend/migrations/versions/e2b7f4c81d93_add_generation_costs.py`
- `backend/archimedes/agents/generation_pipeline.py` — `_quote_in_force`, `_persist_generation_cost`, the `finally`
- `backend/archimedes/api/schemas.py`, `backend/archimedes/api/strategies_routes.py` — the read surfaces
- `ui/src/generationCost.js` — every honesty rule, in one tested place
- `ui/src/components/StrategyPassport.jsx`, `ui/src/components/Strategies.jsx`
- `docs/generation-cost-instrumentation.md`
