### PR TITLE
[infra] deploy-runners: re-exec the SSM remote script under bash

### DIFF
--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -140,6 +140,16 @@ jobs:
           # inline through shell quoting is a reliable source of "parse error
           # near ')'" failures.
           cat > /tmp/remote.sh <<EOS
+          # AWS-RunShellScript executes this with /bin/sh (dash on Ubuntu),
+          # which rejects 'set -o pipefail' at line 1 and can't do the
+          # 'exec 200>' fd redirection below — this script had NEVER run
+          # (first real dispatch 2026-08-20 failed exactly there; the
+          # first-execution-is-post-merge class). Re-exec under bash before
+          # anything else. The \${...} escapes are load-bearing: this heredoc
+          # is unquoted so the WORKFLOW shell interpolates \$-vars at
+          # authoring time — BASH_VERSION must be tested on the BOX, not on
+          # the GitHub runner (where it is always set).
+          [ -z "\${BASH_VERSION:-}" ] && exec /bin/bash "\$0" "\$@"
           set -euo pipefail
           # Instance-local mutex: GitHub's concurrency.cancel-in-progress only
           # cancels the Actions JOB — an already-dispatched SSM command keeps


### PR DESCRIPTION
The oracle+agent SSM remote script had **never successfully run**: AWS-RunShellScript executes with `/bin/sh` (dash), which rejects `set -o pipefail` at line 1. First real dispatch tonight (run 32344678279, after the runner EC2's SSM agent was revived) failed exactly there — the first-execution-is-post-merge class.

**Fix**: the standard bash re-exec guard as the script's first line. Forcing bash (rather than downgrading to `set -eu`) is required anyway: the script uses `exec 200>` flock fd redirection (bash-only) and a `get-login-password | docker login` pipe that genuinely wants pipefail. The `\${...}` escapes are load-bearing — the heredoc is unquoted for workflow-side env interpolation, so `BASH_VERSION` must survive to be tested on the box, not on the GitHub runner.

**Guard demonstrations**:
- Pre-fix failing execution is prod itself: run 32344678279 → `set: Illegal option -o pipefail`, exit 2 — reproduced locally under dash byte-for-byte.
- Post-fix rendered script under dash → re-execs into bash (`reached-past-shell-gate under: 3.2.57(1)-release`); under bash the guard is a no-op; heredoc rendering verified to keep the guard literal.

Needs merge to main before `workflow_dispatch` picks it up; I re-dispatch deploy-runners immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7