### PR TITLE
[backend] Migrate rename_strategy's legacy-wallet fallback onto canonical ownership

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2014,11 +2014,23 @@ async def rename_strategy(
     NOT recomputed — they are provenance of the original generation, not of the
     display name. The strategy_passports table carries no display-name column,
     so only strategy_store is updated.
+
+    Legacy-wallet fallback (#1283): a pre-account row (``owner_user_id`` NULL)
+    matched via the caller's linked wallet is reclaimed onto canonical account
+    ownership in the same transaction as the rename — the identical effect
+    (re-)linking that wallet has via ``claim_legacy_wallet_data`` — rather than
+    re-deriving ownership from the wallet match on every future call. This is
+    the same relaxed, non-fresh-signature lookup already accepted here for the
+    rename itself (metadata mutation, not money-moving; see the boundary rule
+    on ``get_linked_wallet_address``), applied to the identical class of write.
+    It migrates pre-account rows toward zero over time; deleting the fallback
+    branch entirely is a follow-up gated on verifying no unclaimed rows remain.
     """
     from datetime import datetime
 
     from fastapi import HTTPException
 
+    from archimedes.api.wallet_routes import claim_legacy_wallet_data
     from archimedes.db import get_session
     from archimedes.models.strategy_store import StrategyRecord
 
@@ -2035,9 +2047,14 @@ async def rename_strategy(
             # Curated examples are not user-owned — same 404 as a missing row.
             raise HTTPException(status_code=404, detail="Strategy not found")
         caller = get_linked_wallet_address(request)
-        is_owner = row.owner_user_id == user.id or (
-            row.owner_user_id is None and row.owner_wallet and caller == row.owner_wallet.lower()
-        )
+        is_owner = row.owner_user_id == user.id
+        if not is_owner and row.owner_user_id is None and row.owner_wallet and caller == row.owner_wallet.lower():
+            # Proven via linked-wallet match on a still-unclaimed row: reclaim
+            # every pre-account row tied to this wallet (not just this one),
+            # matching what re-verifying the wallet link would do.
+            claim_legacy_wallet_data(session, user.id, caller)
+            row.owner_user_id = user.id
+            is_owner = True
         if not is_owner:
             # Hide unpublished rows from non-owners (404); published rows are
             # visible, so an honest 403 is returned instead.

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2017,14 +2017,26 @@ async def rename_strategy(
 
     Legacy-wallet fallback (#1283): a pre-account row (``owner_user_id`` NULL)
     matched via the caller's linked wallet is reclaimed onto canonical account
-    ownership in the same transaction as the rename — the identical effect
-    (re-)linking that wallet has via ``claim_legacy_wallet_data`` — rather than
-    re-deriving ownership from the wallet match on every future call. This is
-    the same relaxed, non-fresh-signature lookup already accepted here for the
-    rename itself (metadata mutation, not money-moving; see the boundary rule
-    on ``get_linked_wallet_address``), applied to the identical class of write.
-    It migrates pre-account rows toward zero over time; deleting the fallback
-    branch entirely is a follow-up gated on verifying no unclaimed rows remain.
+    ownership in the same transaction as the rename, using the same bulk claim
+    (``claim_legacy_wallet_data``) a verified wallet link performs — but
+    scoped to the strategy-side tables only (``StrategyRecord`` /
+    ``StrategyPassportRecord`` / ``StrategyProposal``), with
+    ``include_profile=False``. The write is irreversible (no un-claim path)
+    and reaches every unclaimed strategy row for this wallet, not just the
+    one being renamed — that is judged acceptable here because it can only
+    ever touch rows already tied to a wallet ``get_linked_wallet_address``
+    resolves for *this* account (a wallet linked elsewhere 409s at link time;
+    see ``_link_verified_wallet``), the same reach a real wallet re-link would
+    have. ``vault_metadata`` and ``user_profiles`` are deliberately excluded:
+    a rename has no business moving vault ownership — that 409-gates on
+    ``owner_user_id`` being ``None`` specifically so a legitimately
+    transferred on-chain owner can still write it, and a stale reclaim here
+    would slam that door shut with no way back — or adopting a PII-bearing
+    profile on a lookup that never asked for a fresh signature. Full
+    reclaim of those two legs stays behind the signature-verified wallet-link
+    flow. This migrates pre-account strategy rows toward zero over time;
+    deleting the fallback branch entirely is a follow-up gated on verifying
+    no unclaimed rows remain.
     """
     from datetime import datetime
 
@@ -2032,6 +2044,8 @@ async def rename_strategy(
 
     from archimedes.api.wallet_routes import claim_legacy_wallet_data
     from archimedes.db import get_session
+    from archimedes.models.strategy_passport_record import StrategyPassportRecord
+    from archimedes.models.strategy_proposal import StrategyProposal
     from archimedes.models.strategy_store import StrategyRecord
 
     name = payload.get("name")
@@ -2050,9 +2064,21 @@ async def rename_strategy(
         is_owner = row.owner_user_id == user.id
         if not is_owner and row.owner_user_id is None and row.owner_wallet and caller == row.owner_wallet.lower():
             # Proven via linked-wallet match on a still-unclaimed row: reclaim
-            # every pre-account row tied to this wallet (not just this one),
-            # matching what re-verifying the wallet link would do.
-            claim_legacy_wallet_data(session, user.id, caller)
+            # every pre-account STRATEGY row tied to this wallet (not just
+            # this one), matching what re-verifying the wallet link would do
+            # for those tables. vault_metadata/user_profiles are excluded —
+            # see the docstring above.
+            claim_legacy_wallet_data(
+                session,
+                user.id,
+                caller,
+                models=(
+                    (StrategyRecord, StrategyRecord.owner_wallet),
+                    (StrategyPassportRecord, StrategyPassportRecord.owner_wallet),
+                    (StrategyProposal, StrategyProposal.owner_wallet),
+                ),
+                include_profile=False,
+            )
             row.owner_user_id = user.id
             is_owner = True
         if not is_owner:

--- a/backend/archimedes/api/wallet_routes.py
+++ b/backend/archimedes/api/wallet_routes.py
@@ -233,7 +233,14 @@ async def _verify_wallet_proof(address: str, message: str, signature: str, chain
     return await verify_smart_wallet_signature(address, message, signature, rpc_url)
 
 
-def _claim_legacy_wallet_data(session, user_id: str, address: str) -> None:
+def claim_legacy_wallet_data(session, user_id: str, address: str) -> None:
+    """Stamp ``owner_user_id`` onto every unclaimed pre-account row for
+    ``address`` — the effect linking (or re-verifying) a wallet has, and the
+    reclaim `rename_strategy`'s legacy-wallet fallback also triggers on write
+    so pre-account rows migrate onto canonical ownership as they're touched
+    (#1283). Public (not `_`-prefixed) because both callers cross the
+    `wallet_routes` module boundary.
+    """
     from archimedes.models.chat import VaultMetadata
     from archimedes.models.strategy_passport_record import StrategyPassportRecord
     from archimedes.models.strategy_proposal import StrategyProposal
@@ -267,7 +274,7 @@ def _link_verified_wallet(session, user: CurrentUser, challenge: WalletLinkChall
     if existing:
         if existing.user_id != user.id:
             raise HTTPException(status_code=409, detail="Wallet is already linked to another account")
-        _claim_legacy_wallet_data(session, user.id, challenge.address)
+        claim_legacy_wallet_data(session, user.id, challenge.address)
         session.commit()
         session.refresh(existing)
         return existing
@@ -301,7 +308,7 @@ def _link_verified_wallet(session, user: CurrentUser, challenge: WalletLinkChall
     )
     session.add(linked)
     session.flush()
-    _claim_legacy_wallet_data(session, user.id, challenge.address)
+    claim_legacy_wallet_data(session, user.id, challenge.address)
     session.commit()
     session.refresh(linked)
     return linked
@@ -405,7 +412,7 @@ def _wallet_has_owned_data(session, address: str) -> bool:
 
 
 def _wallet_has_unclaimed_legacy_data(session, user_id: str, address: str) -> bool:
-    """Would ``_claim_legacy_wallet_data(user_id, address)`` claim anything?
+    """Would ``claim_legacy_wallet_data(user_id, address)`` claim anything?
 
     DELIBERATELY a separate function from ``_wallet_has_owned_data`` above,
     which asks the OPPOSITE question ("does this wallet back any data at all",

--- a/backend/archimedes/api/wallet_routes.py
+++ b/backend/archimedes/api/wallet_routes.py
@@ -245,8 +245,8 @@ def claim_legacy_wallet_data(
     ``address`` — the effect linking (or re-verifying) a wallet has, and the
     reclaim `rename_strategy`'s legacy-wallet fallback also triggers on write
     so pre-account rows migrate onto canonical ownership as they're touched
-    (#1283). Public (not `_`-prefixed) because both callers cross the
-    `wallet_routes` module boundary.
+    (#1283). Public (not `_`-prefixed) because `rename_strategy` calls it
+    from `strategies_routes`; the wallet-link path calls it in-module.
 
     ``models``/``include_profile`` narrow which tables get stamped. The
     default (both None/True) is the full claim a verified wallet link

--- a/backend/archimedes/api/wallet_routes.py
+++ b/backend/archimedes/api/wallet_routes.py
@@ -233,13 +233,31 @@ async def _verify_wallet_proof(address: str, message: str, signature: str, chain
     return await verify_smart_wallet_signature(address, message, signature, rpc_url)
 
 
-def claim_legacy_wallet_data(session, user_id: str, address: str) -> None:
+def claim_legacy_wallet_data(
+    session,
+    user_id: str,
+    address: str,
+    *,
+    models: tuple[tuple[type, object], ...] | None = None,
+    include_profile: bool = True,
+) -> None:
     """Stamp ``owner_user_id`` onto every unclaimed pre-account row for
     ``address`` — the effect linking (or re-verifying) a wallet has, and the
     reclaim `rename_strategy`'s legacy-wallet fallback also triggers on write
     so pre-account rows migrate onto canonical ownership as they're touched
     (#1283). Public (not `_`-prefixed) because both callers cross the
     `wallet_routes` module boundary.
+
+    ``models``/``include_profile`` narrow which tables get stamped. The
+    default (both None/True) is the full claim a verified wallet link
+    performs: strategy tables + ``vault_metadata`` + ``user_profiles``.
+    ``rename_strategy``'s relaxed, non-fresh-signature lookup passes the
+    strategy-only trio and ``include_profile=False`` — it must not move
+    vault ownership (that gates a separate 409 whose ``None`` case exists
+    specifically to admit a legitimately transferred on-chain owner; a
+    stale reclaim from a rename would wrongly slam that door shut with no
+    un-claim path) or adopt a PII-bearing profile on a caller who has only
+    proven a stale wallet link, not fresh signature control.
     """
     from archimedes.models.chat import VaultMetadata
     from archimedes.models.strategy_passport_record import StrategyPassportRecord
@@ -247,23 +265,25 @@ def claim_legacy_wallet_data(session, user_id: str, address: str) -> None:
     from archimedes.models.strategy_store import StrategyRecord
     from archimedes.models.user_profile import UserProfile
 
-    for model, wallet_column in (
+    default_models = (
         (StrategyRecord, StrategyRecord.owner_wallet),
         (StrategyPassportRecord, StrategyPassportRecord.owner_wallet),
         (StrategyProposal, StrategyProposal.owner_wallet),
         (VaultMetadata, VaultMetadata.creator_address),
-    ):
+    )
+    for model, wallet_column in models if models is not None else default_models:
         session.query(model).filter(
             wallet_column == address,
             model.owner_user_id.is_(None),
         ).update({model.owner_user_id: user_id}, synchronize_session=False)
 
-    existing_profile = session.query(UserProfile).filter(UserProfile.owner_user_id == user_id).first()
-    if existing_profile is None:
-        session.query(UserProfile).filter(
-            UserProfile.wallet_address == address,
-            UserProfile.owner_user_id.is_(None),
-        ).update({UserProfile.owner_user_id: user_id}, synchronize_session=False)
+    if include_profile:
+        existing_profile = session.query(UserProfile).filter(UserProfile.owner_user_id == user_id).first()
+        if existing_profile is None:
+            session.query(UserProfile).filter(
+                UserProfile.wallet_address == address,
+                UserProfile.owner_user_id.is_(None),
+            ).update({UserProfile.owner_user_id: user_id}, synchronize_session=False)
 
 
 def _link_verified_wallet(session, user: CurrentUser, challenge: WalletLinkChallenge, now: datetime) -> LinkedWallet:

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -344,6 +344,59 @@ async def test_rename_owner_only():
         assert session.query(StrategyRecord).filter_by(id=sid).first().strategy_name == "After"
 
 
+async def test_rename_legacy_wallet_fallback_reclaims_row_onto_canonical_owner():
+    """#1283: renaming a pre-account row via the legacy-wallet fallback must
+    migrate it onto canonical account ownership in the same request, not just
+    permit the rename and leave ``owner_user_id`` NULL forever."""
+    sid = "ren00000000000004"
+    _mk_strategy(sid, owner=_W_OWNER, published=False, name="Before")  # owner_user_id NULL
+
+    from archimedes.main import app
+    from archimedes.models.strategy_store import StrategyRecord
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.patch(f"/api/strategies/{sid}", json={"name": "After"}, cookies=_siwe_cookies(_W_OWNER))
+    assert resp.status_code == 200
+
+    expected_owner_user_id = f"legacy-test:{_W_OWNER.lower()}"
+    with db.get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=sid).first()
+        assert row.strategy_name == "After"
+        assert row.owner_user_id == expected_owner_user_id  # reclaimed, no longer NULL
+        assert row.owner_wallet == _W_OWNER.lower()  # wallet provenance untouched
+
+
+async def test_rename_legacy_wallet_fallback_reclaims_sibling_rows_but_not_other_wallets():
+    """The reclaim triggered by a legacy-wallet rename is the SAME bulk claim
+    wallet-linking performs (`claim_legacy_wallet_data`): every unclaimed row
+    for that wallet migrates, not just the one row touched by the request —
+    and a different wallet's unclaimed rows must be left alone."""
+    renamed_sid = "sib00000000000001"
+    _mk_strategy(renamed_sid, owner=_W_OWNER, published=False, name="Before")
+    sibling_sid = "sib00000000000002"
+    _mk_strategy(sibling_sid, owner=_W_OWNER, published=False, name="Sibling")  # same wallet, untouched by request
+    other_wallet_sid = "sib00000000000003"
+    _mk_strategy(other_wallet_sid, owner=_W_OTHER, published=False, name="Other")  # different wallet
+
+    from archimedes.main import app
+    from archimedes.models.strategy_store import StrategyRecord
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.patch(
+            f"/api/strategies/{renamed_sid}", json={"name": "After"}, cookies=_siwe_cookies(_W_OWNER)
+        )
+    assert resp.status_code == 200
+
+    expected_owner_user_id = f"legacy-test:{_W_OWNER.lower()}"
+    with db.get_session() as session:
+        renamed = session.query(StrategyRecord).filter_by(id=renamed_sid).first()
+        sibling = session.query(StrategyRecord).filter_by(id=sibling_sid).first()
+        other = session.query(StrategyRecord).filter_by(id=other_wallet_sid).first()
+        assert renamed.owner_user_id == expected_owner_user_id
+        assert sibling.owner_user_id == expected_owner_user_id  # reclaimed as a side effect
+        assert other.owner_user_id is None  # a different wallet's data is never touched
+
+
 async def test_rename_published_non_owner_403():
     sid = "ren00000000000002"
     _mk_strategy(sid, owner=_W_OWNER, published=True)

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -397,6 +397,54 @@ async def test_rename_legacy_wallet_fallback_reclaims_sibling_rows_but_not_other
         assert other.owner_user_id is None  # a different wallet's data is never touched
 
 
+async def test_rename_legacy_wallet_fallback_does_not_touch_vault_metadata_or_profile():
+    """The rename-triggered reclaim is scoped to strategy tables only: it must
+    NOT stamp `vault_metadata.owner_user_id` (that gates a separate 409 whose
+    None case exists so a legitimately transferred on-chain owner can still
+    write it — see vaults_routes.py) and must NOT adopt a PII-bearing
+    `user_profiles` row on a lookup that never proved fresh signature control.
+    Both legs stay behind the signature-verified wallet-link flow."""
+    from archimedes.models.chat import VaultMetadata
+    from archimedes.models.strategy_store import StrategyRecord
+    from archimedes.models.user_profile import UserProfile
+
+    sid = "vmt00000000000001"
+    _mk_strategy(sid, owner=_W_OWNER, published=False, name="Before")  # owner_user_id NULL
+
+    with db.get_session() as session:
+        session.add(
+            VaultMetadata(
+                vault_address="0x" + "9" * 40,
+                creator_address=_W_OWNER.lower(),
+                owner_user_id=None,  # unclaimed, pre-#1028 style
+            )
+        )
+        session.add(
+            UserProfile(
+                wallet_address=_W_OWNER.lower(),
+                display_name="legacy display name",
+                owner_user_id=None,  # unclaimed
+            )
+        )
+        session.commit()
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.patch(f"/api/strategies/{sid}", json={"name": "After"}, cookies=_siwe_cookies(_W_OWNER))
+    assert resp.status_code == 200
+
+    with db.get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=sid).first()
+        assert row.owner_user_id is not None  # the strategy-side reclaim still happens
+
+        meta = session.query(VaultMetadata).filter_by(vault_address="0x" + "9" * 40).first()
+        assert meta.owner_user_id is None  # untouched — vault ownership is not a rename's business
+
+        profile = session.query(UserProfile).filter_by(wallet_address=_W_OWNER.lower()).first()
+        assert profile.owner_user_id is None  # untouched — no PII adoption on a non-fresh-signature lookup
+
+
 async def test_rename_published_non_owner_403():
     sid = "ren00000000000002"
     _mk_strategy(sid, owner=_W_OWNER, published=True)

--- a/backend/tests/test_wallet_linking.py
+++ b/backend/tests/test_wallet_linking.py
@@ -342,7 +342,7 @@ def test_unclaimed_legacy_data_detected_and_claimed_data_is_not():
     after a claim. Collapsing the two functions inverts the unlink guard.
     """
     from archimedes.api.wallet_routes import (
-        _claim_legacy_wallet_data,
+        claim_legacy_wallet_data,
         _wallet_has_owned_data,
         _wallet_has_unclaimed_legacy_data,
     )
@@ -363,7 +363,7 @@ def test_unclaimed_legacy_data_detected_and_claimed_data_is_not():
         assert _wallet_has_unclaimed_legacy_data(session, "user-1", ADDRESS) is True
         assert _wallet_has_unclaimed_legacy_data(session, "user-1", OTHER_ADDRESS) is False
 
-        _claim_legacy_wallet_data(session, "user-1", ADDRESS)
+        claim_legacy_wallet_data(session, "user-1", ADDRESS)
         session.commit()
 
         # Claimed: the prompt goes quiet -- but the unlink guard must still
@@ -373,7 +373,7 @@ def test_unclaimed_legacy_data_detected_and_claimed_data_is_not():
 
 
 def test_legacy_profile_only_counts_when_account_has_no_profile():
-    """Mirrors _claim_legacy_wallet_data's profile condition exactly: a legacy
+    """Mirrors claim_legacy_wallet_data's profile condition exactly: a legacy
     profile is only claimable when the account has none, so the prompt must
     not promise a claim the link would skip."""
     from archimedes.api.wallet_routes import _wallet_has_unclaimed_legacy_data

--- a/backend/tests/test_wallet_linking.py
+++ b/backend/tests/test_wallet_linking.py
@@ -342,9 +342,9 @@ def test_unclaimed_legacy_data_detected_and_claimed_data_is_not():
     after a claim. Collapsing the two functions inverts the unlink guard.
     """
     from archimedes.api.wallet_routes import (
-        claim_legacy_wallet_data,
         _wallet_has_owned_data,
         _wallet_has_unclaimed_legacy_data,
+        claim_legacy_wallet_data,
     )
 
     with _session() as session:


### PR DESCRIPTION
## Refs #1283

Follow-up from the #1194 rename-route merge (3237e3e3): `rename_strategy`'s
legacy-wallet ownership fallback is the single MUTATING call site on the
relaxed `get_linked_wallet_address` lookup. Ruled acceptable to ship as-is
(metadata mutation, not money-moving, so it doesn't breach the fresh-signature
boundary) with this issue as the follow-up: **migrate the fallback to
canonical account ownership**, then **delete the legacy path once pre-account
rows are reclaimed**.

This PR ships the first, decidable half.

### What changed

When `rename_strategy` hits the legacy-wallet fallback branch (row has
`owner_user_id IS NULL`, caller's linked wallet matches `owner_wallet`), it
now reclaims the row onto canonical account ownership in the same
transaction, via the same bulk claim `_link_verified_wallet` already runs at
wallet-link time (`claim_legacy_wallet_data`, made public/cross-module —
was `_claim_legacy_wallet_data`, pure rename, no behavior change). That means:

- Every unclaimed **strategy-side** row tied to that wallet migrates — not
  just the one touched by the request (`strategy_store`,
  `strategy_passports`, `strategy_proposals`).
- A different wallet's unclaimed data is never touched.
- Rows self-heal onto canonical ownership as they're touched instead of
  re-deriving ownership from the wallet match on every future call.
- No change to what's authorized — a row is renamable under exactly the same
  conditions as before; the only new effect is what gets written once it is.

`claim_legacy_wallet_data` now takes optional `models=`/`include_profile=`
params (default: the full claim a verified wallet link performs — strategy
tables + `vault_metadata` + `user_profiles`). `rename_strategy` passes the
strategy-only trio and `include_profile=False` — see "Review fixes" below for
why `vault_metadata`/`user_profiles` are excluded from this call site.

### Review fixes (adversarial pass, post-initial-push)

An adversarial review caught that the first version of this PR called
`claim_legacy_wallet_data` with its full default scope from
`rename_strategy`, which also stamps `chat.vault_metadata.owner_user_id` and
adopts the `user_profiles` row — two legs that have nothing to do with a
display-name rename, are irreversible (no un-claim path exists), and collide
with `vaults_routes.py`'s vault-metadata 409 gate: that gate's `None` case
exists specifically so a legitimately transferred on-chain owner can still
write vault metadata, and a stale reclaim from an unrelated rename could
permanently lock that owner out. Fixed by scoping the reclaim:

- `claim_legacy_wallet_data` gained `models=`/`include_profile=False`
  parameters; `rename_strategy` now passes only
  `(StrategyRecord, StrategyPassportRecord, StrategyProposal)` with
  `include_profile=False`. `vault_metadata`/`user_profiles` reclaim stays
  exclusively behind the signature-verified wallet-link flow
  (`_link_verified_wallet`, unchanged, still uses the full default claim).
- Added `test_rename_legacy_wallet_fallback_does_not_touch_vault_metadata_or_profile`,
  which seeds an unclaimed `VaultMetadata` + `UserProfile` row for the same
  wallet, renames the strategy, and asserts both stay `owner_user_id IS
  NULL` while the strategy row is reclaimed. Verified failing against the
  pre-fix (full-claim) code first — `AssertionError: assert
  'legacy-test:0xabc...' is None` on `VaultMetadata.owner_user_id` — then
  confirmed green after the scoping fix.
- The docstring on `rename_strategy` previously cited the
  `get_linked_wallet_address` boundary rule ("never gate a money-moving or
  otherwise irreversible action") as authorization for the reclaim, while an
  unscoped reclaim is exactly the class of action that rule forbids. Rewrote
  it to state plainly what the (now-scoped) write is — irreversible,
  wallet-scoped to strategy tables only — and why it's judged acceptable:
  it can only ever touch rows already tied to a wallet
  `get_linked_wallet_address` resolves for *this* account (a wallet linked
  elsewhere 409s at link time), the same reach a real wallet re-link would
  have for those tables.
- Fixed a new `ruff` `I001` (import-order) violation in
  `test_wallet_linking.py:344-348` introduced by this PR. The PR's original
  lint evidence below used `--select E9,F63,F7,F40`, narrower than the
  repo's `ruff.toml` (`extend-select` includes `I`), so it didn't catch this
  — corrected the evidence to use `ruff check --config ruff.toml` instead.

### What's still gated on a decision (not shipped here)

Deleting the fallback branch itself. The issue explicitly conditions deletion
on "once pre-account rows are reclaimed" — that's a production-data state I
can't establish or force from this branch:

- Needs verifying prod has zero rows with `owner_user_id IS NULL AND
  owner_wallet IS NOT NULL` across the strategy tables (and, separately, the
  `vault_metadata`/`user_profiles` legs reclaimed only via wallet-link).
- Organic reclaim only fires on a rename or a wallet (re-)link — a
  pre-account row whose wallet was *never* linked to any account can never
  self-heal via this path, so reaching zero may need a one-off backfill
  script and/or a decision on what happens to permanently-orphaned rows.
- That verification + backfill decision belongs to a follow-up once someone
  can check prod state, not to this PR.

### Verification

New-file targeted run (all rename/legacy-wallet-fallback + wallet-linking
tests, including the new scoping regression test):
```
$ pytest backend/tests/test_strategy_ownership.py backend/tests/test_wallet_linking.py -q
40 passed, 19 warnings in ~5-7s
```

Two distinct "pre-fix" states, each guard demonstrated failing against the
state it guards:

1. Pre-#1283 entirely (no reclaim at all, i.e. before commit cebe4914) —
   `test_rename_legacy_wallet_fallback_reclaims_row_onto_canonical_owner` and
   `..._reclaims_sibling_rows_but_not_other_wallets` fail (see this PR's
   original verification section above for that run).
2. Reclaim present but unscoped (i.e. cebe4914 as originally pushed, before
   this review-fix commit) — reverted only the `models=`/`include_profile=`
   scoping in `rename_strategy` (kept the plain
   `claim_legacy_wallet_data(session, user.id, caller)` call), reran the
   full rename test group:
   ```
   $ pytest backend/tests/test_strategy_ownership.py -q -k rename
   ...F..
   FAILED test_rename_legacy_wallet_fallback_does_not_touch_vault_metadata_or_profile
     - AssertionError: assert 'legacy-test:0xabc0000000000000000000000000000000000001' is None
       (VaultMetadata.owner_user_id got stamped by the unscoped call)
   1 failed, 5 passed, 14 deselected
   ```
   Confirms the new test is the only one sensitive to the scoping — the two
   pre-existing reclaim tests only assert on `strategy_store`, so they pass
   whether or not the reclaim also over-reaches into `vault_metadata`.
   Restored the scoping fix and reran green (6/6) before continuing.

Pre-existing rename tests (`test_rename_owner_only`, `test_rename_published_non_owner_403`,
`test_rename_rejects_bad_names_and_examples`) pass in every state above — the
rename itself was never broken, only the reclaim's presence/scope.

Full unit suite (repo root, CI's exact command): CI's own **"Backend — unit
tests"** check on this push (`pytest -m "not integration"`, the same
`quality-gate.yml` job that runs on every PR) — **pass, 6m29s**. All other
checks on this PR pass as well (ruff-gate, import-guard, complexity,
frontend, analytics-engine, CodeQL, supply-chain).

Formatting/lint on touched files, using the **repo's own config** (not a
narrower hand-picked selector):
```
$ ruff format --check backend/archimedes/api/strategies_routes.py backend/archimedes/api/wallet_routes.py backend/tests/test_strategy_ownership.py backend/tests/test_wallet_linking.py
4 files already formatted
$ ruff check --config ruff.toml backend/archimedes/api/strategies_routes.py backend/archimedes/api/wallet_routes.py backend/tests/test_strategy_ownership.py backend/tests/test_wallet_linking.py
All checks passed!
```

No UI or docs touched.
