### PR TITLE
[backend] Remove the startup rigor-gate backfill — it pinned ~1 GB for the process lifetime

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -113,37 +113,35 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     _logger = logging.getLogger("archimedes.startup")
 
     # ── STARTUP ──────────────────────────────────────────────────────────
-    # 1. Populate selection-bias rigor gate fields (idempotent). Only runs
-    # the full computation when some backtest row is missing DSR/PBO, and
-    # refreshes the provider cache afterwards so /api/strategies serves the
-    # new values immediately (mirrors the pre-lifespan startup handler).
-    try:
-        from archimedes.db import get_session
-        from archimedes.models.backtest_store import BacktestResultRecord
-        from archimedes.services.strategy_provider import default_provider
-
-        provider = default_provider()
-        strategies = provider.list_strategies()
-        if strategies:
-            strategy_ids = [s.id for s in strategies]
-            with get_session() as session:
-                rows = (
-                    session.query(BacktestResultRecord).filter(BacktestResultRecord.strategy_id.in_(strategy_ids)).all()
-                )
-                needs_rigor = [r for r in rows if r.deflated_sharpe_ratio is None]
-            if needs_rigor:
-                _logger.info("startup: computing rigor gate for %d strategies...", len(needs_rigor))
-                from archimedes.api.selection_bias_routes import evaluate_rigor_gate
-
-                result = await evaluate_rigor_gate()
-                _logger.info("startup: rigor gate computed — %d/%d passing", result.passing, result.total)
-                # Refresh provider's backtest cache so /api/strategies serves
-                # the new DSR/PBO values without waiting for a cache cycle.
-                provider.refresh()
-            else:
-                _logger.info("startup: all %d backtest rows have rigor gate fields", len(rows))
-    except Exception as exc:
-        _logger.warning("startup: rigor gate population failed (non-fatal): %s", exc)
+    # 1. (removed) Rigor-gate backfill.
+    #
+    # This used to load every backtest_results row for every curated strategy
+    # and then call evaluate_rigor_gate() to backfill DSR/PBO. Both halves were
+    # wrong, and it was a primary cause of the 2026-08-19 OOM crash loop:
+    #
+    #   * The query was `.all()` over full rows. artifact_json and
+    #     equity_curve_json are plain Text columns with no deferred loading
+    #     (models/backtest_store.py), so every row's JSON blob was materialised
+    #     — measured +1079 MB of RSS at 408 rows, strictly linear at ~2.6 MB
+    #     per row, and rising daily because nothing dedupes that table.
+    #   * Worse, `rows` was a local of THIS function, and lifespan() is an
+    #     @asynccontextmanager that suspends at the `yield` below for the entire
+    #     process lifetime. Python pins the frame, so those blobs were never
+    #     collected — retained garbage for the life of the container, not a
+    #     transient spike. `del rows; gc.collect()` in a probe returned 100% of it.
+    #   * evaluate_rigor_gate() is a FastAPI route handler whose `strictness`
+    #     parameter defaults to Query(DEFAULT_LEVEL). Called directly it stays a
+    #     Query object, the whole cohort DSR/PBO computation runs (~14-20 s of
+    #     one vCPU), and then StrategyRigorResult validation raises. It had
+    #     therefore NEVER once succeeded since 2026-07-05 (commit 4cf8d59b) —
+    #     46 days of burning that computation on every boot and discarding it.
+    #
+    # Nothing is lost by removing it. The rigor gate already runs where it
+    # belongs: in the generation pipeline for generated strategies
+    # (agents/generation_pipeline.py, via live_rigor_gate.verdict_from_returns),
+    # and on demand for the curated library via GET /api/selection-bias/gate —
+    # whose _compute() is the only production caller of update_rigor_gate_fields(),
+    # i.e. the only thing that ever persisted these columns anyway.
 
     # 2. Seed papers table from manifest.jsonl (idempotent)
     try:
@@ -163,7 +161,9 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         import hashlib
         import json
 
+        from archimedes.db import get_session
         from archimedes.models.strategy_store import StrategyRecord
+        from archimedes.services.strategy_provider import default_provider
 
         provider = default_provider()
         with get_session() as session:

--- a/backend/tests/test_lifespan_no_rigor_backfill.py
+++ b/backend/tests/test_lifespan_no_rigor_backfill.py
@@ -1,0 +1,78 @@
+"""The FastAPI lifespan must not read backtest_results (2026-08-19 OOM guard).
+
+The startup handler used to `.all()` every backtest_results row for every
+curated strategy and then call ``evaluate_rigor_gate()``.
+
+Two things made that a container-killer rather than a slow boot:
+
+* ``artifact_json`` and ``equity_curve_json`` are plain ``Text`` columns with no
+  deferred loading, so every row's JSON blob was materialised. Measured in the
+  production image: +1079 MB of RSS at 408 rows, strictly linear at ~2.6 MB/row,
+  and growing daily because nothing dedupes that table.
+* ``lifespan`` is an ``@asynccontextmanager`` that suspends at its ``yield`` for
+  the entire process lifetime, so Python pins the frame and every local in it.
+  The blobs were retained garbage for the life of the container, not a spike.
+
+``evaluate_rigor_gate()`` was also being called as a plain function despite
+being a FastAPI route handler with a ``Query(...)`` default, so it burned the
+full cohort DSR/PBO computation and then raised on response validation — it had
+never once succeeded.
+
+This is a source-level guard on purpose: booting the whole app to observe the
+absence of a query is far more fragile than asserting the code is not there, and
+the property we care about ("the lifespan does not touch this table") is exactly
+a property of the source.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import archimedes.main as main_module
+
+
+def _lifespan_source() -> str:
+    # __wrapped__: lifespan is decorated with @asynccontextmanager, so the
+    # decorated object is not the function whose body we want to inspect.
+    fn = getattr(main_module.lifespan, "__wrapped__", main_module.lifespan)
+    return inspect.getsource(fn)
+
+
+def _code_lines(source: str) -> list[str]:
+    """Source lines with comments and docstring-ish content stripped."""
+    out = []
+    for raw in source.splitlines():
+        line = raw.split("#", 1)[0]
+        if line.strip():
+            out.append(line)
+    return out
+
+
+def test_lifespan_does_not_query_backtest_results() -> None:
+    code = "\n".join(_code_lines(_lifespan_source()))
+    assert "BacktestResultRecord" not in code, (
+        "lifespan references BacktestResultRecord again. Reading that table at "
+        "startup retains every artifact_json/equity_curve_json blob for the life "
+        "of the process (measured +1079 MB at 408 rows) because the lifespan "
+        "frame is pinned at its yield."
+    )
+
+
+def test_lifespan_does_not_call_the_rigor_gate_route() -> None:
+    code = "\n".join(_code_lines(_lifespan_source()))
+    assert "evaluate_rigor_gate" not in code, (
+        "lifespan calls evaluate_rigor_gate() again. It is a FastAPI route "
+        "handler whose `strictness` parameter defaults to Query(...); called "
+        "directly it runs the whole cohort DSR/PBO computation and then raises "
+        "on response validation. The rigor gate belongs in the generation "
+        "pipeline and in GET /api/selection-bias/gate, not at boot."
+    )
+
+
+# NOTE: deliberately NOT asserting "no .all() anywhere in lifespan". The
+# marketplace rehydration block (main.py:269,279) legitimately `.all()`s
+# MarketplaceAgent rows filtered to status == "running" — small metadata rows
+# with no blob columns. A blanket rule would fail on that pre-existing query and
+# force unrelated restructuring without guarding anything real. The two
+# assertions above name the actual defect: the blob-carrying table, and the
+# route handler that was called as a function.


### PR DESCRIPTION
## Summary

This is the **largest single item** in the 2026-08-19 OOM crash loop, and it is bigger than either #1328 or #1329.

The lifespan loaded every `backtest_results` row for every curated strategy, then called `evaluate_rigor_gate()` to backfill DSR/PBO. Both halves were wrong.

### The query materialised every JSON blob

`artifact_json` and `equity_curve_json` are plain `Text` columns with no deferred loading, so `.all()` pulled every blob. Measured in the **production image against a real Postgres**, with artifact payloads sized to the observed distribution:

| rows | RSS delta | per row |
|---|---|---|
| 34 | +54.2 MB | 1.59 MB |
| 102 | +238.6 MB | 2.34 MB |
| 204 | +518.6 MB | 2.54 MB |
| 408 | **+1078.7 MB** | 2.64 MB |

Strictly linear — and rising daily, because nothing dedupes that table (`canonical_artifact_hash` includes `run_id`, a timestamp).

### The retention is what made it fatal

`rows` was a local of `lifespan()`, an `@asynccontextmanager` that **suspends at its `yield` for the entire process lifetime**. Python pins that frame and every local in it. These were not a transient spike — they were retained garbage for the life of the container.

A probe confirms 100% retention and 0% fragmentation: `del rows, needs_rigor; gc.collect()` returned RSS from 1266.6 MB → 185.2 MB, giving back **1081 of 1081 MB**.

Production matches exactly. Successive tasks on Aug 19 plateaued at **1553 → 1824 → 1842 → 2049 → 2163 → 2288 MB** as the table grew — each restart's startup query costing more than the last, until the T+180s refresh spike crossed the 3,072 MB task limit. Container Insights on the final task: `20:49 233 MB → 20:50 1287 MB`, a **+1054 MB step** across startup, correlated to the second with `uvicorn start 20:49:26` → `startup complete 20:49:54`.

### The call had never once succeeded

`evaluate_rigor_gate()` is a FastAPI route handler whose `strictness` parameter defaults to `Query(DEFAULT_LEVEL)`. Called directly it stays a `Query` object, the **whole cohort DSR/PBO computation runs** (~14–20s of one vCPU), and then `StrategyRigorResult` validation raises. Swallowed as a non-fatal warning since **2026-07-05** (commit `4cf8d59b`) — 46 days of computing and discarding that work on every boot.

## Why removing it is correct, not just cheaper

Nothing is lost. The rigor gate already runs where it belongs:

- **Generated strategies** — `live_rigor_gate.verdict_from_returns`, called from `agents/generation_pipeline.py:1477` and `:1630`, i.e. the post-generation validation step.
- **Curated library** — on demand via `GET /api/selection-bias/gate`, whose `_compute()` is the **only production caller of `update_rigor_gate_fields()`** — the only thing that ever persisted these columns at all.

So the startup block was a cache warmer for a cache that on-demand traffic fills anyway, and it has been failing silently for 46 days with no visible consequence — which is itself the evidence it was not load-bearing.

`get_session` / `default_provider` imports move into the provider-seeding block that still uses them (they were being imported by the deleted block).

## Verification

```
pytest backend/tests/test_lifespan_no_rigor_backfill.py
       backend/tests/test_api_routes.py
       backend/tests/test_selection_bias_routes.py -q     → 94 passed
ruff format --check + ruff check                          → clean
app imports, 40 routes registered, lifespan_context present
```

**Mutation check** — restoring the block from `main`:

```
FAILED test_lifespan_does_not_query_backtest_results
       - AssertionError: lifespan references BacktestResultRecord again…
FAILED test_lifespan_does_not_call_the_rigor_gate_route
       - AssertionError: lifespan calls evaluate_rigor_gate() again…
```

Restored → `2 passed`.

### A note on the guards, and one I deliberately removed

The guards are **source-level on purpose**: booting the whole app to observe the *absence* of a query is far more fragile than asserting the code is gone, and "the lifespan does not touch this table" is a property of the source.

I also wrote a third assertion — "no `.all()` anywhere in the lifespan" — and **deleted it**. It failed on the pre-existing marketplace rehydration block (`main.py:269,279`), which `.all()`s `MarketplaceAgent` rows filtered to `status == "running"` — small metadata rows with no blob columns. Keeping it would have forced unrelated restructuring while guarding nothing real. The two remaining assertions name the actual defect.

## Expected effect

Measured end-to-end in the prod image on a 408-row database:

| build | steady RSS | peak |
|---|---|---|
| as-shipped | 1230.7 MB | 1460.7 MB |
| + startup query scoped/removed | 957–962 MB | ~1188 MB |
| + no MiniLM on `/health` (#1328) | 686.8 MB | 892.8 MB |

Together with #1328 and #1329 this should bring the container comfortably inside the existing 3,072 MB budget **with no memory bump and no cost increase**. The measurement actually argues for *lowering* the task to 2048 MB later, once we have stability data.

## Follow-ups (not here)

- `canonical_artifact_hash` must exclude `run_id`/`timestamp_utc` so `insert_backtest_if_missing` can dedupe.
- A one-off cleanup of the rows already accumulated. Nobody has yet read the real production row count: `SELECT strategy_id, count(*) FROM backtest_results GROUP BY 1 ORDER BY 2 DESC;`
- Whether a 34-strategy backtrader re-run belongs in the request-serving container at all — its own module docstring says re-triggering "burns the box's 2 vCPUs for ~15 min", and it retains ~741 MB in-process that a standalone run gives back.
