### PR TITLE
[infra] Close supply-chain audit blind spots: wallet-setup/ + ui/ devDeps

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -9,8 +9,9 @@
 #   ruff linter    — full `ruff check` (broader rule set; not blocking yet)
 #   eslint         — npm run lint
 #   coverage       — unit coverage vs 60% floor (agent PRs only)
-#   supply-chain   — pip-audit + npm audit + detect-secrets (non-blocking; see
-#                    the supply-chain job below for the promote-to-hard-block note)
+#   supply-chain   — pip-audit + npm audit (ui prod, ui dev, wallet-setup) +
+#                    detect-secrets (non-blocking; see the supply-chain job
+#                    below for the promote-to-hard-block note)
 
 name: Quality Gate
 
@@ -315,9 +316,17 @@ jobs:
 
   supply-chain:
     # INFORMATIONAL ONLY — every step runs with continue-on-error and the job
-    # never blocks merge. It surfaces dependency CVEs (pip-audit + npm audit)
-    # and leaked-secret regressions (detect-secrets) as a PR-comment table so
-    # the signal is visible without gating the build.
+    # never blocks merge. It surfaces dependency CVEs (pip-audit + npm audit
+    # across BOTH npm projects, ui/ and wallet-setup/) and leaked-secret
+    # regressions (detect-secrets) as a PR-comment table so the signal is
+    # visible without gating the build.
+    #
+    # Coverage note (#1198): this job used to be blind to wallet-setup/'s
+    # dependencies entirely, and to ui/'s devDependencies (--omit=dev on the
+    # only npm audit step). Both are now separate rows in the report table —
+    # a reader should never infer "clean" for a scope this job doesn't
+    # actually measure. wallet-setup/ has no devDependencies today, so one
+    # audit covers it; ui/ gets a prod row and a dev-only-delta row.
     #
     # Informational first; promote dependency audits to hard-block once known
     # CVE backlog is cleared. Until then, a red row is a triage nudge, not a wall.
@@ -336,7 +345,9 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: ui/package-lock.json
+          cache-dependency-path: |
+            ui/package-lock.json
+            wallet-setup/package-lock.json
 
       - name: pip-audit
         id: pip_audit
@@ -359,18 +370,61 @@ jobs:
           out.write(f"count={count}\n")
           EOF
 
-      - name: npm audit
-        id: npm_audit
+      - name: npm audit (ui, prod)
+        id: npm_audit_ui_prod
         continue-on-error: true
         run: |
           cd ui
           # --omit=dev mirrors the prod-only audit we run locally (see CLAUDE.md
           # supply-chain conventions). --json emits the structured report.
-          npm audit --omit=dev --json > /tmp/npm_audit.json 2>/dev/null || true
+          npm audit --omit=dev --json > /tmp/npm_audit_ui_prod.json 2>/dev/null || true
           python3 - <<'EOF'
           import json, os
           # npm audit --json shape: {"metadata": {"vulnerabilities": {"total": N, ...}}}.
-          data = json.load(open("/tmp/npm_audit.json"))
+          data = json.load(open("/tmp/npm_audit_ui_prod.json"))
+          count = data.get("metadata", {}).get("vulnerabilities", {}).get("total", 0)
+          out = open(os.environ["GITHUB_OUTPUT"], "a")
+          out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
+          out.write(f"count={count}\n")
+          EOF
+
+      - name: npm audit (ui, dev)
+        id: npm_audit_ui_dev
+        continue-on-error: true
+        # #1198: --omit=dev on the step above structurally excludes
+        # devDependencies (4 of the 14 alerts that accumulated silently pre-
+        # #1155 were exactly this). Run the unrestricted audit and report the
+        # dev-only delta as its own row, rather than folding it into "prod"
+        # silently or dropping --omit=dev and losing the prod-only signal.
+        run: |
+          cd ui
+          npm audit --json > /tmp/npm_audit_ui_full.json 2>/dev/null || true
+          python3 - <<'EOF'
+          import json, os
+          full = json.load(open("/tmp/npm_audit_ui_full.json"))
+          full_count = full.get("metadata", {}).get("vulnerabilities", {}).get("total", 0)
+          prod_count = int("${{ steps.npm_audit_ui_prod.outputs.count }}" or "0")
+          count = max(full_count - prod_count, 0)
+          out = open(os.environ["GITHUB_OUTPUT"], "a")
+          out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
+          out.write(f"count={count}\n")
+          EOF
+
+      - name: npm audit (wallet-setup)
+        id: npm_audit_wallet
+        continue-on-error: true
+        # #1198: wallet-setup/ was never audited by any CI job. It is a real
+        # npm project with runtime (not dev) deps used by ops scripts
+        # (create-wallet.mjs, deploy.mjs, rotate-secret.mjs, setvault.mjs) —
+        # production-risk surface, not tooling noise. No --omit=dev: the
+        # project has no devDependencies today, so the unrestricted audit is
+        # already the runtime-only scope.
+        run: |
+          cd wallet-setup
+          npm audit --json > /tmp/npm_audit_wallet.json 2>/dev/null || true
+          python3 - <<'EOF'
+          import json, os
+          data = json.load(open("/tmp/npm_audit_wallet.json"))
           count = data.get("metadata", {}).get("vulnerabilities", {}).get("total", 0)
           out = open(os.environ["GITHUB_OUTPUT"], "a")
           out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
@@ -416,25 +470,33 @@ jobs:
         with:
           script: |
             const fmt = r => r === 'passed' ? '✅ passed' : '❌ not passed';
-            const pipResult   = fmt('${{ steps.pip_audit.outputs.result }}');
-            const pipCount    = '${{ steps.pip_audit.outputs.count }}' || '0';
-            const npmResult   = fmt('${{ steps.npm_audit.outputs.result }}');
-            const npmCount    = '${{ steps.npm_audit.outputs.count }}' || '0';
+            const pipResult      = fmt('${{ steps.pip_audit.outputs.result }}');
+            const pipCount       = '${{ steps.pip_audit.outputs.count }}' || '0';
+            const npmUiProdResult = fmt('${{ steps.npm_audit_ui_prod.outputs.result }}');
+            const npmUiProdCount  = '${{ steps.npm_audit_ui_prod.outputs.count }}' || '0';
+            const npmUiDevResult  = fmt('${{ steps.npm_audit_ui_dev.outputs.result }}');
+            const npmUiDevCount   = '${{ steps.npm_audit_ui_dev.outputs.count }}' || '0';
+            const npmWalletResult = fmt('${{ steps.npm_audit_wallet.outputs.result }}');
+            const npmWalletCount  = '${{ steps.npm_audit_wallet.outputs.count }}' || '0';
             const secResult   = fmt('${{ steps.detect_secrets.outputs.result }}');
             const secCount    = '${{ steps.detect_secrets.outputs.count }}' || '0';
 
-            const marker = '<!-- supply-chain-v1 -->';
+            const marker = '<!-- supply-chain-v2 -->';
             const body = [
               marker,
               '## Supply Chain (informational)',
               '',
               'Non-blocking. Promote dependency audits to hard-block once known',
-              'CVE backlog is cleared.',
+              'CVE backlog is cleared. Scope per row is explicit — a row not',
+              'listed here is not covered by this job (see GitHub\'s native',
+              'Dependabot tab for the full picture).',
               '',
               '| Check | Status | Count |',
               '|---|---|---|',
-              `| pip-audit (python deps) | ${pipResult} | ${pipCount} |`,
-              `| npm audit (frontend prod deps) | ${npmResult} | ${npmCount} |`,
+              `| pip-audit (backend, python deps) | ${pipResult} | ${pipCount} |`,
+              `| npm audit (ui, **prod-only**) | ${npmUiProdResult} | ${npmUiProdCount} |`,
+              `| npm audit (ui, **dev-only**) | ${npmUiDevResult} | ${npmUiDevCount} |`,
+              `| npm audit (wallet-setup, runtime deps) | ${npmWalletResult} | ${npmWalletCount} |`,
               `| detect-secrets (changed files) | ${secResult} | ${secCount} |`,
             ].join('\n');
 

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -381,11 +381,24 @@ jobs:
           python3 - <<'EOF'
           import json, os
           # npm audit --json shape: {"metadata": {"vulnerabilities": {"total": N, ...}}}.
-          data = json.load(open("/tmp/npm_audit_ui_prod.json"))
-          count = data.get("metadata", {}).get("vulnerabilities", {}).get("total", 0)
+          # On failure (no lockfile, registry/network error) npm still emits
+          # valid JSON, but as {"error": {"code": ..., ...}} with no "metadata"
+          # key. #1198 was filed because a scope this job never measured still
+          # rendered green; falling through .get("metadata", {}) to count=0
+          # reintroduces that exact defect for the audit's own error path. Treat
+          # a missing report as a distinct, visibly-not-clean outcome instead.
+          try:
+              data = json.load(open("/tmp/npm_audit_ui_prod.json"))
+          except Exception:
+              data = {}
           out = open(os.environ["GITHUB_OUTPUT"], "a")
-          out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
-          out.write(f"count={count}\n")
+          if "metadata" not in data:
+              out.write("result=error\n")
+              out.write(f"count={data.get('error', {}).get('code', 'unknown')}\n")
+          else:
+              count = data["metadata"].get("vulnerabilities", {}).get("total", 0)
+              out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
+              out.write(f"count={count}\n")
           EOF
 
       - name: npm audit (ui, dev)
@@ -401,13 +414,30 @@ jobs:
           npm audit --json > /tmp/npm_audit_ui_full.json 2>/dev/null || true
           python3 - <<'EOF'
           import json, os
-          full = json.load(open("/tmp/npm_audit_ui_full.json"))
-          full_count = full.get("metadata", {}).get("vulnerabilities", {}).get("total", 0)
-          prod_count = int("${{ steps.npm_audit_ui_prod.outputs.count }}" or "0")
-          count = max(full_count - prod_count, 0)
+          # Same missing-report guard as the prod step above. Also: the delta
+          # below is only meaningful if the prod baseline is itself trustworthy
+          # — if that step's report was unparsable, "full - prod" would quietly
+          # compute a wrong delta against an implied prod count of 0. Propagate
+          # the upstream error instead of manufacturing a number from it.
+          try:
+              full = json.load(open("/tmp/npm_audit_ui_full.json"))
+          except Exception:
+              full = {}
+          prod_result = "${{ steps.npm_audit_ui_prod.outputs.result }}"
+          prod_count_raw = "${{ steps.npm_audit_ui_prod.outputs.count }}"
           out = open(os.environ["GITHUB_OUTPUT"], "a")
-          out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
-          out.write(f"count={count}\n")
+          if "metadata" not in full:
+              out.write("result=error\n")
+              out.write(f"count={full.get('error', {}).get('code', 'unknown')}\n")
+          elif prod_result == "error":
+              out.write("result=error\n")
+              out.write(f"count=prod-audit-{prod_count_raw or 'unknown'}\n")
+          else:
+              full_count = full["metadata"].get("vulnerabilities", {}).get("total", 0)
+              prod_count = int(prod_count_raw or "0")
+              count = max(full_count - prod_count, 0)
+              out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
+              out.write(f"count={count}\n")
           EOF
 
       - name: npm audit (wallet-setup)
@@ -424,11 +454,21 @@ jobs:
           npm audit --json > /tmp/npm_audit_wallet.json 2>/dev/null || true
           python3 - <<'EOF'
           import json, os
-          data = json.load(open("/tmp/npm_audit_wallet.json"))
-          count = data.get("metadata", {}).get("vulnerabilities", {}).get("total", 0)
+          # Same missing-report guard as the ui audit steps above — see the
+          # comment there for why a missing "metadata" key must not read as
+          # count=0.
+          try:
+              data = json.load(open("/tmp/npm_audit_wallet.json"))
+          except Exception:
+              data = {}
           out = open(os.environ["GITHUB_OUTPUT"], "a")
-          out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
-          out.write(f"count={count}\n")
+          if "metadata" not in data:
+              out.write("result=error\n")
+              out.write(f"count={data.get('error', {}).get('code', 'unknown')}\n")
+          else:
+              count = data["metadata"].get("vulnerabilities", {}).get("total", 0)
+              out.write(f"result={'passed' if count == 0 else 'not passed'}\n")
+              out.write(f"count={count}\n")
           EOF
 
       - name: detect-secrets
@@ -469,7 +509,11 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const fmt = r => r === 'passed' ? '✅ passed' : '❌ not passed';
+            // 'error' is a distinct third outcome (audit didn't run — no
+            // lockfile, registry failure, etc.) and must render as neither
+            // ✅ nor ❌: a reader should never infer "clean" OR "vulnerable"
+            // for a scope this job structurally failed to measure.
+            const fmt = r => r === 'passed' ? '✅ passed' : r === 'error' ? '⚠️ audit did not run' : '❌ not passed';
             const pipResult      = fmt('${{ steps.pip_audit.outputs.result }}');
             const pipCount       = '${{ steps.pip_audit.outputs.count }}' || '0';
             const npmUiProdResult = fmt('${{ steps.npm_audit_ui_prod.outputs.result }}');
@@ -481,6 +525,12 @@ jobs:
             const secResult   = fmt('${{ steps.detect_secrets.outputs.result }}');
             const secCount    = '${{ steps.detect_secrets.outputs.count }}' || '0';
 
+            // Match on the version-agnostic prefix, not the exact v2 string, so
+            // bumping the marker updates an existing v1 comment in place rather
+            // than orphaning it — leaving both the stale, scope-silent v1 table
+            // AND the new v2 table visible on every PR that had a v1 comment
+            // before this change (verified live on #1095 and #1271).
+            const markerPrefix = '<!-- supply-chain-v';
             const marker = '<!-- supply-chain-v2 -->';
             const body = [
               marker,
@@ -506,7 +556,7 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const existing = comments.find(c => c.body.includes(marker));
+            const existing = comments.find(c => c.body.includes(markerPrefix));
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,9 @@ informational. `pip install pre-commit && pre-commit install` mirrors the CI gat
 so pre-commit can't pass while CI fails. `--unsafe-fixes` needs line-by-line human review
 and is never auto-applied.
 
-Dependency hygiene — `pip-audit` / `cd ui && npm audit --omit=dev` before any dep bump;
+Dependency hygiene — `pip-audit` / `cd ui && npm audit --omit=dev` (prod-only view; drop
+the flag to also see dev-tooling CVEs) / `cd wallet-setup && npm audit` (a second, separate
+npm project — runtime deps only, no `--omit=dev` needed) before any dep bump;
 triage Dependabot promptly. Three rules:
 
 - **Pin transitively-vulnerable deps directly when CVEs warrant it** — e.g. `starlette>=1.0.1` is pinned in both `environment.yml` and `backend/requirements.txt` to close PYSEC-2026-161 even though it would otherwise arrive transitively via FastAPI. Pin to the closest `Fix Versions` so a fresh resolution can't regress.


### PR DESCRIPTION
## Summary

`quality-gate.yml`'s `supply-chain` job audited only `ui/`'s **prod** dependencies
(`npm audit --omit=dev`). Two real dependency-risk surfaces were structurally
unmeasured — `wallet-setup/` (a second npm project with runtime deps, never
referenced by any workflow) and `ui/`'s `devDependencies` — so a green "0
vulnerabilities" PR comment could not be distinguished from "never checked" in
either scope. This is not hypothetical: 14 alerts (10 `wallet-setup` runtime, 4
`ui/` dev, all HIGH/MEDIUM) accumulated silently in exactly those two blind
spots until caught manually and cleared by #1155, without the workflow itself
changing.

Closes #1198.

## Fix

Two new report rows, each with its scope stated explicitly in the table so no
row implies coverage it doesn't have:

- **`npm audit (wallet-setup, runtime deps)`** — new step, `cd wallet-setup &&
  npm audit`. No `--omit=dev` needed: the project has no `devDependencies`.
- **`npm audit (ui, dev-only)`** — new step: full `ui/` audit minus the
  existing prod-only audit's count, isolating the devDependency-only delta.
  The existing prod row is kept and relabeled `**prod-only**` for clarity.

Job stays **non-blocking** (`continue-on-error: true` on every step,
unchanged) — this is a coverage fix, not a policy change, per the issue's own
proposed-fix item 3.

## Verification

**Before (origin/main) — confirms the blind spots as filed:**

```
$ git show origin/main:.github/workflows/quality-gate.yml | grep -c wallet-setup
0   # wallet-setup/ referenced nowhere in the pre-fix workflow

$ cd ui && npm audit --omit=dev --json | jq .metadata.vulnerabilities.total
0   # the only audit the old job ran — reports clean
```

**Live proof the gap was still real today, not just historical** — a fresh
`npm audit` (no `--omit=dev`) on current `ui/` turns up a HIGH-severity dev
dependency CVE that `--omit=dev` was hiding from the report *right now*:

```
$ cd ui && npm audit --json | jq '.vulnerabilities.brace-expansion.via[0]'
{
  "title": "brace-expansion: DoS via unbounded intermediate arrays, bypassing
             the CVE-2026-14257 mitigation",
  "url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
  "severity": "high",
  "range": ">=4.0.0 <5.0.9"
}
```

**After fix — new rows surface exactly what the old table hid**, run against
the same live repo state:

| Row | Result | Count |
|---|---|---|
| npm audit (ui, prod-only) | ✅ passed | 0 |
| npm audit (ui, dev-only) | ❌ not passed | **1** (the brace-expansion HIGH above) |
| npm audit (wallet-setup, runtime deps) | ✅ passed | 0 |

Full transcript (real `npm audit` output, real subtraction logic from the new
step, not synthetic data):

```
--- npm audit (ui, prod) ---
result: passed | count: 0
--- npm audit (ui, dev) — the new row that catches the blind spot ---
full_count: 1 | prod_count: 0 | dev-only delta: 1
result: NOT PASSED | count: 1
--- npm audit (wallet-setup) — the new project that was never audited ---
result: passed | count: 0
```

Also verified:
- `yaml.safe_load` on the full workflow file — parses clean.
- Every embedded `python3` heredoc block (7 total, incl. the 2 new ones)
  extracted and `compile()`-checked, with GHA `${{ }}` expressions substituted
  as they'd resolve at runtime — all syntax-OK.
- The `Post or update PR comment` step's embedded JS extracted and
  `node --check`'d — syntax-OK.
- `make docs-check` (CLAUDE.md was touched to document the two-project audit
  convention): `links: scanned 1082 in 134 markdown files; broken 0` / `index:
  130 docs, 0 orphaned` — clean.

No backend/Python or `ui/` source files were touched (only the workflow YAML
and `CLAUDE.md`), so `pytest`, `ruff`, and `npm run lint`/`build` are out of
scope for this change per the repo's own touched-files convention.

## Anti-goals honored

- Job stays informational/non-blocking — not promoted to hard-block.
- No change to what already passes (`pip-audit`, `detect-secrets`,
  `ui` prod audit) — same commands, same thresholds, only additive rows.
- No new top-level dependency.


## Review follow-up (2026-08-20)

An adversarial review pass caught two defects in the rows/prose this PR itself
adds — both fixed and re-verified before push (commit c2b8ac24):

**1. Major — the new audit rows failed *soft*, reintroducing #1198's own defect
class inside the fix for it.** `npm audit --json` emits valid JSON with no
`metadata` key on failure (no lockfile, registry/network error) —
`{"error":{"code":"ENOLOCK",...}}` — and all three npm-audit parsers
(ui-prod, ui-dev, wallet-setup) read that as `count=0` / `result=passed` via
`.get("metadata", {})`. A never-ran audit rendered a green row, which made
this job's own "a reader should never infer 'clean' for a scope this job
doesn't actually measure" prose untrue for the audit's own failure path.

Fixed: a missing `metadata` key now reports a distinct `result=error`,
rendered `⚠️ audit did not run` (not folded into ✅/❌). The ui-dev delta step
additionally refuses to compute a dev-only count against an untrustworthy
prod baseline — if the prod step itself errored, the delta step propagates
`result=error` rather than silently subtracting against an implied 0.

Guard-rejection evidence (adversarial — built the input that should fail,
confirmed it does, before pushing):

```
$ cd /tmp/npmauditrepro && npm audit --json 2>/dev/null   # dir w/ package.json, no lockfile
{"error":{"code":"ENOLOCK","summary":"This command requires an existing lockfile.",...}}

$ python3 - <<'PY'   # new parser logic against that exact output
import json
data = json.load(open("out.json"))
if "metadata" not in data:
    print("result=error"); print(f"count={data.get('error', {}).get('code', 'unknown')}")
PY
result=error
count=ENOLOCK
```

Positive control (clean `{"metadata":{"vulnerabilities":{"total":0}}}`) still
yields `result=passed` / `count=0` — the guard rejects the bad input without
breaking the good one.

**2. Minor — the `supply-chain-v1` → `-v2` marker bump would have stranded
every open PR's existing comment.** The updater matched on the exact marker
string, so a body containing `<!-- supply-chain-v1 -->` would never match
`<!-- supply-chain-v2 -->`, leaving the old scope-silent 2-row table visible
forever and adding a second v2 comment beside it. Verified live before
fixing: PRs #1095 and #1271 both currently carry the v1 comment with the old
`npm audit (frontend prod deps) | ✅ passed | 0` row — precisely the
"green comment indistinguishable from never checked" #1198 describes.

Fixed: match on the version-agnostic `<!-- supply-chain-v` prefix so an
existing v1 comment gets updated in place (to the v2 body) instead of
orphaned; the comment itself still writes the v2 marker.

**Verification re-run after the fix:**
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses clean.
- All 7 embedded `python3` heredocs (incl. the 3 rewritten ones) extracted
  and `compile()`-checked — syntax OK.
- Both embedded JS blocks (`lint-report` + `supply-chain` comment steps)
  extracted and `node --check`'d — syntax OK.
- `make docs-check` — unaffected (workflow YAML only, no docs touched):
  `links: scanned 1082 in 134 markdown files; broken 0` / `index: 130 docs,
  0 orphaned`.
- No backend/Python or `ui/` source touched — `pytest`/`ruff`/`npm
  lint`/`build` remain out of scope per this PR's own touched-files
  convention (unchanged from the original verification above).
